### PR TITLE
Support mappings from TOML files

### DIFF
--- a/pkg/api/methods/mappings.go
+++ b/pkg/api/methods/mappings.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"github.com/ZaparooProject/zaparoo-core/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/pkg/platforms"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
@@ -211,6 +213,19 @@ func HandleUpdateMapping(env requests.RequestEnv) (any, error) {
 	err = env.Database.UpdateMapping(strconv.Itoa(params.Id), newMapping)
 	if err != nil {
 		return nil, err
+	}
+
+	return nil, nil
+}
+
+func HandleReloadMappings(env requests.RequestEnv) (any, error) {
+	log.Info().Msg("received reload mappings request")
+
+	mapDir := filepath.Join(env.Platform.DataDir(), platforms.MappingsDir)
+	err := env.Config.LoadMappings(mapDir)
+	if err != nil {
+		log.Error().Err(err).Msg("error loading mappings")
+		return nil, errors.New("error loading mappings")
 	}
 
 	return nil, nil

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -25,6 +25,7 @@ const (
 	MethodMappingsNew    = "mappings.new"
 	MethodMappingsDelete = "mappings.delete"
 	MethodMappingsUpdate = "mappings.update"
+	MethodMappingsReload = "mappings.reload"
 	MethodReadersWrite   = "readers.write"
 	MethodStatus         = "status"
 	MethodVersion        = "version"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -52,6 +52,7 @@ var methodMap = map[string]func(requests.RequestEnv) (any, error){
 	models.MethodMappingsNew:    methods.HandleAddMapping,
 	models.MethodMappingsDelete: methods.HandleDeleteMapping,
 	models.MethodMappingsUpdate: methods.HandleUpdateMapping,
+	models.MethodMappingsReload: methods.HandleReloadMappings,
 	// readers
 	models.MethodReadersWrite: methods.HandleReaderWrite,
 	// utils

--- a/pkg/service/mappings.go
+++ b/pkg/service/mappings.go
@@ -121,6 +121,8 @@ func mappingsFromConfig(cfg *config.Instance) []database.Mapping {
 			dbm.Match = database.MatchTypeExact
 			dbm.Pattern = m.MatchPattern
 		}
+
+		mappings = append(mappings, dbm)
 	}
 
 	return mappings

--- a/pkg/service/mappings.go
+++ b/pkg/service/mappings.go
@@ -22,6 +22,7 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package service
 
 import (
+	"github.com/ZaparooProject/zaparoo-core/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/pkg/service/tokens"
 	"regexp"
 	"strings"
@@ -87,28 +88,72 @@ func checkMappingData(m database.Mapping, t tokens.Token) bool {
 	return false
 }
 
-func getMapping(db *database.Database, pl platforms.Platform, token tokens.Token) (string, bool) {
+func isCfgRegex(s string) bool {
+	return len(s) > 2 && s[0] == '/' && s[len(s)-1] == '/'
+}
+
+func mappingsFromConfig(cfg *config.Instance) []database.Mapping {
+	var mappings []database.Mapping
+	cfgMappings := cfg.Mappings()
+
+	for _, m := range cfgMappings {
+		var dbm database.Mapping
+		dbm.Enabled = true
+		dbm.Override = m.ZapScript
+
+		if m.TokenKey == "data" {
+			dbm.Type = database.MappingTypeData
+		} else if m.TokenKey == "value" {
+			dbm.Type = database.MappingTypeText
+		} else {
+			dbm.Type = database.MappingTypeUID
+		}
+
+		if isCfgRegex(m.MatchPattern) {
+			dbm.Match = database.MatchTypeRegex
+			dbm.Pattern = m.MatchPattern[1 : len(m.MatchPattern)-1]
+		} else if strings.Contains(m.MatchPattern, "*") {
+			// TODO: this behaviour doesn't actually match "partial"
+			// the old behaviour will need to be migrated to this one
+			dbm.Match = database.MatchTypePartial
+			dbm.Pattern = strings.ReplaceAll(m.MatchPattern, "*", "")
+		} else {
+			dbm.Match = database.MatchTypeExact
+			dbm.Pattern = m.MatchPattern
+		}
+	}
+
+	return mappings
+}
+
+func getMapping(cfg *config.Instance, db *database.Database, pl platforms.Platform, token tokens.Token) (string, bool) {
+	// TODO: need a way to identify the source of a match so it can be
+	// reported and debugged by the user if there's issues
+
 	// check db mappings
 	ms, err := db.GetEnabledMappings()
 	if err != nil {
 		log.Error().Err(err).Msgf("error getting db mappings")
 	}
 
+	// load config mappings after
+	ms = append(ms, mappingsFromConfig(cfg)...)
+
 	for _, m := range ms {
 		switch {
 		case m.Type == database.MappingTypeUID:
 			if checkMappingUid(m, token) {
-				log.Info().Msg("launching with db uid match override")
+				log.Info().Msg("launching with db/cfg uid match override")
 				return m.Override, true
 			}
 		case m.Type == database.MappingTypeText:
 			if checkMappingText(m, token) {
-				log.Info().Msg("launching with db text match override")
+				log.Info().Msg("launching with db/cfg text match override")
 				return m.Override, true
 			}
 		case m.Type == database.MappingTypeData:
 			if checkMappingData(m, token) {
-				log.Info().Msg("launching with db data match override")
+				log.Info().Msg("launching with db/cfg data match override")
 				return m.Override, true
 			}
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/pkg/service/tokens"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -223,7 +224,11 @@ func Start(
 	pl platforms.Platform,
 	cfg *config.Instance,
 ) (func() error, error) {
-	dirs := []string{pl.DataDir(), pl.TempDir()}
+	dirs := []string{
+		pl.DataDir(),
+		pl.TempDir(),
+		filepath.Join(pl.DataDir(), platforms.MappingsDir),
+	}
 	for _, dir := range dirs {
 		err := os.MkdirAll(dir, 0755)
 		if err != nil {
@@ -245,10 +250,17 @@ func Start(
 		return nil, err
 	}
 
-	log.Info().Msg("opening database")
+	log.Info().Msg("opening user database")
 	db, err := database.Open(pl)
 	if err != nil {
-		log.Error().Err(err).Msgf("error opening database")
+		log.Error().Err(err).Msgf("error opening user database")
+		return nil, err
+	}
+
+	log.Info().Msg("loading mapping files")
+	err = cfg.LoadMappings(filepath.Join(pl.DataDir(), platforms.MappingsDir))
+	if err != nil {
+		log.Error().Err(err).Msgf("error loading mapping files")
 		return nil, err
 	}
 
@@ -256,27 +268,27 @@ func Start(
 	go api.Start(pl, cfg, st, itq, db, ns)
 
 	if !pl.LaunchingEnabled() {
-		log.Warn().Msg("launching disabled")
+		log.Warn().Msg("launching disabled by user")
 		st.DisableLauncher()
 	}
 
 	log.Info().Msg("starting reader manager")
 	go readerManager(pl, cfg, st, itq, lsq)
 
-	log.Info().Msg("starting token queue manager")
+	log.Info().Msg("starting input token queue manager")
 	go processTokenQueue(pl, cfg, st, itq, db, lsq, plq)
 
 	log.Info().Msg("running platform post start")
 	err = pl.StartPost(cfg, st.Notifications)
 	if err != nil {
-		log.Error().Err(err).Msg("platform start pre error")
+		log.Error().Err(err).Msg("platform post start error")
 		return nil, err
 	}
 
 	return func() error {
 		err = pl.Stop()
 		if err != nil {
-			log.Warn().Msgf("error stopping pl: %s", err)
+			log.Warn().Msgf("error stopping platform: %s", err)
 		}
 		st.StopService()
 		close(plq)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -59,7 +59,7 @@ func launchToken(
 ) error {
 	text := token.Text
 
-	mappingText, mapped := getMapping(db, platform, token)
+	mappingText, mapped := getMapping(cfg, db, platform, token)
 	if mapped {
 		log.Info().Msgf("found mapping: %s", mappingText)
 		text = mappingText

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -86,28 +86,14 @@ func (s *State) ShouldStopService() bool {
 
 func (s *State) DisableLauncher() {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.disableLauncher = true
-	if err := s.platform.SetLaunching(false); err != nil {
-		log.Error().Msgf("cannot create disable launch file: %s", err)
-	}
-	s.Notifications <- models.Notification{
-		Method: models.TokensLaunching,
-		Params: false,
-	}
-	s.mu.Unlock()
 }
 
 func (s *State) EnableLauncher() {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.disableLauncher = false
-	if err := s.platform.SetLaunching(true); err != nil {
-		log.Error().Msgf("cannot remove disable launch file: %s", err)
-	}
-	s.Notifications <- models.Notification{
-		Method: models.TokensLaunching,
-		Params: true,
-	}
-	s.mu.Unlock()
 }
 
 func (s *State) IsLauncherDisabled() bool {


### PR DESCRIPTION
Documented here: https://wiki.zaparoo.org/Mappings#Mapping_files

Core will now load up "mapping files" from disk which are simple TOML files that match parameters to alternative ZapScript. These work in addition to the user database mappings, which still exist and take precedence if there's a conflict.

A new `mappings.reload` API endpoint is added to allow reloading these files while the service is running.

A new `-read` CLI flag has been added which prints out a scanned token (without actually launching them) for use with this and other CLI tools.