### PR TITLE
Automatic release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Add QEMU for cross-compile support
         run: docker run --privileged --rm tonistiigi/binfmt --install all
         if: matrix.arch != 'amd64' && matrix.platform != 'windows' && matrix.platform != 'mac'
+      - name: Set up Docker CLI
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm
+          use: true
+          install: true
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3
       - name: Add cache override

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3
       - name: Add cache override
-        run: echo CACHE_ARGS=\"--load --cache-to type=gha,mode=max,repository=${GITHUB_REPOSITORY} --cache-from type=gha\" > .env
+        run: echo CACHE_ARGS=\"--load --cache-to type=gha,mode=max,repository=${GITHUB_REPOSITORY},scope=${{matrix.platform}}-${{matrix.arch}} --cache-from type=gha,scope=${{matrix.platform}}-${{matrix.arch}}\" > .env
         if: matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Build
         run: task build-${{matrix.platform}}-${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+on: 
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - windows
+          - mac
+        arch:
+          - amd64
+          - arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add QEMU for cross-compile support
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
+      - name: Build
+        run: task build-${{matrix.platform}}-${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,5 +23,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Add QEMU for cross-compile support
         run: docker run --privileged --rm tonistiigi/binfmt --install all
+        if: matrix.arch != 'amd64' && matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Build
         run: task build-${{matrix.platform}}-${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go
-                    env:
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{hashFiles('go.sum')}}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install Task

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,10 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           use: true
           install: true
+        if: matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3
+        if: matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Add cache override
         run: echo CACHE_ARGS=\"--load --cache-to type=gha,mode=max,repository=${GITHUB_REPOSITORY},scope=${{matrix.platform}}-${{matrix.arch}} --cache-from type=gha,scope=${{matrix.platform}}-${{matrix.arch}}\" > .env
         if: matrix.platform != 'windows' && matrix.platform != 'mac'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,25 @@
-on: 
+on:
   push:
-    branches:
-      - '*'
+    tags:
+      - "v*"
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${tag#v}" \
+              --generate-notes
+      
   build:
     runs-on: ubuntu-latest
+    needs: create-release
     strategy:
       fail-fast: false
       matrix:
@@ -61,3 +75,9 @@ jobs:
         if: matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Build
         run: task build-${{matrix.platform}}-${{matrix.arch}}
+      - name: Add release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release upload "$tag" _build/${{matrix.platform}}_${{matrix.arch}}/zaparoo-${{matrix.platform}}_${{matrix.arch}}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,17 @@ jobs:
         platform:
           - windows
           - mac
+          - batocera
         arch:
           - amd64
           - arm64
+        include:
+          - platform: steamos
+            arch: amd64
+          - platform: mister
+            arch: arm
+          - platform: mistex
+            arch: arm64
     steps:
       - uses: actions/checkout@v4
       - name: Install Task

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,20 @@ jobs:
             arch: arm64
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Go packages and build output
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-go
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go
+                    env:
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Install Task
         uses: arduino/setup-task@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,10 @@ jobs:
       - name: Add QEMU for cross-compile support
         run: docker run --privileged --rm tonistiigi/binfmt --install all
         if: matrix.arch != 'amd64' && matrix.platform != 'windows' && matrix.platform != 'mac'
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: Add cache override
+        run: echo CACHE_ARGS=\"--load --cache-to type=gha,mode=max,repository=${GITHUB_REPOSITORY} --cache-from type=gha\" > .env
+        if: matrix.platform != 'windows' && matrix.platform != 'mac'
       - name: Build
         run: task build-${{matrix.platform}}-${{matrix.arch}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
         run: |
           gh release create "$tag" \
               --repo="$GITHUB_REPOSITORY" \
-              --title="${tag#v}" \
+              --title="${tag}" \
+              --draft \
               --generate-notes
       
   build:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -20,7 +20,7 @@ tasks:
   build-docker-image:
     internal: true
     cmds:
-      - docker build --platform linux/{{.ARCH}} --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/{{.ARCH}} --build-arg UID=$UID --build-arg GID=$GID {{default "" .CACHE_ARGS}} -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-image-mister:
     cmds:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -5,6 +5,10 @@ env:
   GOPROXY: https://goproxy.io,direct
   CGO_ENABLED: 1
   CGO_LDFLAGS: -lpcsclite -lnfc -lusb -lcurses
+  UID:
+    sh: id -u
+  GID:
+    sh: id -g
 
 dotenv: [".env"]
 
@@ -18,35 +22,35 @@ tasks:
       IMAGE_NAME: zaparoo/mister-build
       DOCKERFILE: "./scripts/mister/build"
     cmds:
-      - docker build --platform linux/arm/v7 -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/arm/v7 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-image-mistex:
     vars:
       IMAGE_NAME: zaparoo/mistex-build
       DOCKERFILE: "./scripts/linux_arm64/build"
     cmds:
-      - docker build --platform linux/arm/v8 -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/arm/v8 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-image-batocera-arm64:
     vars:
       IMAGE_NAME: zaparoo/batocera-arm64-build
       DOCKERFILE: "./scripts/linux_arm64/build"
     cmds:
-      - docker build --platform linux/arm/v8 -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/arm/v8 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-image-batocera-amd64:
     vars:
       IMAGE_NAME: zaparoo/batocera-amd64-build
       DOCKERFILE: "./scripts/linux_amd64/build"
     cmds:
-      - docker build --platform linux/amd64 -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/amd64 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-image-steamos-amd64:
     vars:
       IMAGE_NAME: zaparoo/steamos-amd64-build
       DOCKERFILE: "./scripts/linux_amd64/build"
     cmds:
-      - docker build --platform linux/amd64 -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/amd64 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
 
   build-mister:
     vars:
@@ -57,7 +61,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} build.sh
+      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} build.sh
       - rm -f {{.BUILD_DIR}}/zaparoo-mister_arm.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-mister_arm.zip {{.BUILD_DIR}}/zaparoo.sh
 
@@ -70,7 +74,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 -ti {{.IMAGE_NAME}} /bin/bash
+      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build -ti {{.IMAGE_NAME}} /bin/bash
 
   build-mistex:
     vars:
@@ -81,7 +85,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} bash -c "PLATFORM=mistex APP_BIN=zaparoo.sh task build"
+      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=mistex APP_BIN=zaparoo.sh task build"
       - rm -f {{.BUILD_DIR}}/zaparoo-mistex_arm64.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-mistex_arm64.zip {{.BUILD_DIR}}/zaparoo.sh
 
@@ -94,7 +98,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
+      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
       - rm -f {{.BUILD_DIR}}/zaparoo-batocera_arm64.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-batocera_arm64.zip {{.BUILD_DIR}}/zaparoo
 
@@ -107,7 +111,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
+      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
       - rm -f {{.BUILD_DIR}}/zaparoo-batocera_amd64.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-batocera_amd64.zip {{.BUILD_DIR}}/zaparoo
 
@@ -120,7 +124,7 @@ tasks:
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build --user 1000:1000 {{.IMAGE_NAME}} bash -c "PLATFORM=steamos APP_BIN=zaparoo task build"
+      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=steamos APP_BIN=zaparoo task build"
       - rm -f {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip {{.BUILD_DIR}}/zaparoo
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -17,116 +17,157 @@ tasks:
     cmds:
       - go build --ldflags "-linkmode external -extldflags -static -s -w" -o _build/${PLATFORM}_{{ARCH}}/${APP_BIN} ./cmd/$PLATFORM
 
-  build-image-mister:
-    vars:
-      IMAGE_NAME: zaparoo/mister-build
-      DOCKERFILE: "./scripts/mister/build"
+  build-docker-image:
+    internal: true
     cmds:
-      - docker build --platform linux/arm/v7 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - docker build --platform linux/{{.ARCH}} --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+
+  build-image-mister:
+    cmds:
+      - task: build-docker-image
+        vars:
+          IMAGE_NAME: zaparoo/mister-build
+          DOCKERFILE: "./scripts/mister/build"
+          ARCH: arm/v7
 
   build-image-mistex:
-    vars:
-      IMAGE_NAME: zaparoo/mistex-build
-      DOCKERFILE: "./scripts/linux_arm64/build"
     cmds:
-      - docker build --platform linux/arm/v8 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - task: build-docker-image
+        vars:
+          IMAGE_NAME: zaparoo/mistex-build
+          DOCKERFILE: "./scripts/linux_arm64/build"
+          ARCH: arm64/v8
 
   build-image-batocera-arm64:
-    vars:
-      IMAGE_NAME: zaparoo/batocera-arm64-build
-      DOCKERFILE: "./scripts/linux_arm64/build"
     cmds:
-      - docker build --platform linux/arm/v8 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - task: build-docker-image
+        vars:
+          IMAGE_NAME: zaparoo/batocera-arm64-build
+          DOCKERFILE: "./scripts/linux_arm64/build"
+          ARCH: arm64/v8
 
   build-image-batocera-amd64:
-    vars:
-      IMAGE_NAME: zaparoo/batocera-amd64-build
-      DOCKERFILE: "./scripts/linux_amd64/build"
     cmds:
-      - docker build --platform linux/amd64 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - task: build-docker-image
+        vars:
+          IMAGE_NAME: zaparoo/batocera-amd64-build
+          DOCKERFILE: "./scripts/linux_amd64/build"
+          ARCH: amd64
 
   build-image-steamos-amd64:
-    vars:
-      IMAGE_NAME: zaparoo/steamos-amd64-build
-      DOCKERFILE: "./scripts/linux_amd64/build"
     cmds:
-      - docker build --platform linux/amd64 --build-arg UID=$UID --build-arg GID=$GID -t {{.IMAGE_NAME}} {{.DOCKERFILE}}
+      - task: build-docker-image
+        vars:
+          IMAGE_NAME: zaparoo/steamos-amd64-build
+          DOCKERFILE: "./scripts/linux_amd64/build"
+          ARCH: amd64
 
-  build-mister:
+  run-docker:
+    internal: true
     vars:
-      BUILD_DIR: "./_build/mister_arm"
-      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
-      GOCACHE: "{{.BUILD_DIR}}/.go-cache"
-      IMAGE_NAME: zaparoo/mister-build
+      BUILDCACHE: "{{.HOME}}/.cache/go-build"
+      GOCACHE: "{{.HOME}}/go"
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} build.sh
-      - rm -f {{.BUILD_DIR}}/zaparoo-mister_arm.zip
-      - zip -j {{.BUILD_DIR}}/zaparoo-mister_arm.zip {{.BUILD_DIR}}/zaparoo.sh
+      - mkdir -p {{.BUILDCACHE}} {{.GOCACHE}}
+      - docker run --rm --platform linux/{{.DOCKER_ARCH}} -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.EXTRA_DOCKER_ARGS}} {{.IMAGE_NAME}} {{.EXEC}}
+
+  build-docker:
+    internal: true
+    vars:
+      BUILD_NAME: "{{.PLATFORM}}{{if .BUILD_ARCH}}_{{.BUILD_ARCH}}{{end}}"
+      BUILD_DIR: "./_build/{{.BUILD_NAME}}"
+      ZIP_FULLPATH: "{{.BUILD_DIR}}/zaparoo-{{.BUILD_NAME}}.zip"
+    cmds:
+      - task: run-docker
+        vars:
+          IMAGE_NAME: "{{.IMAGE_NAME}}"
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          DOCKER_ARCH: "{{.DOCKER_ARCH}}"
+          PLATFORM: "{{.PLATFORM}}"
+          EXEC: '{{default "task build" .EXEC}}'
+          EXTRA_DOCKER_ARGS: '{{default "" .EXTRA_DOCKER_ARGS}}'
+      - rm -f {{.ZIP_FULLPATH}}
+      - zip -j {{.ZIP_FULLPATH}} {{.BUILD_DIR}}/{{.APP_BIN}}
+
+  build-mister-arm:
+    cmds:
+      - task: build-image-mister
+      - task: build-docker
+        vars:
+          PLATFORM: mister
+          BUILD_ARCH: arm
+          DOCKER_ARCH: arm/v7
+          IMAGE_NAME: zaparoo/mister-build
+          APP_BIN: zaparoo.sh
+          EXEC: build.sh
 
   build-mister-shell:
     vars:
-      BUILD_DIR: "./_build/mister_arm"
       BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
       GOCACHE: "{{.BUILD_DIR}}/.go-cache"
       IMAGE_NAME: zaparoo/mister-build
       IMG_BUILDCACHE: /home/build/.cache/go-build
       IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v7 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build -ti {{.IMAGE_NAME}} /bin/bash
+      - task: build-image-mister
+      - task: run-docker
+        vars:
+          BUILD_DIR: "./_build/mister"
+          PLATFORM: mister
+          BUILD_ARCH: arm
+          DOCKER_ARCH: arm/v7
+          IMAGE_NAME: zaparoo/mister-build
+          EXTRA_DOCKER_ARGS: -it
+          EXEC: bash
 
-  build-mistex:
-    vars:
-      BUILD_DIR: "./_build/mistex_arm64"
-      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
-      GOCACHE: "{{.BUILD_DIR}}/.go-cache"
-      IMAGE_NAME: zaparoo/mistex-build
-      IMG_BUILDCACHE: /home/build/.cache/go-build
-      IMG_GOCACHE: /home/build/go
+  build-mistex-arm64:
     cmds:
-      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=mistex APP_BIN=zaparoo.sh task build"
-      - rm -f {{.BUILD_DIR}}/zaparoo-mistex_arm64.zip
-      - zip -j {{.BUILD_DIR}}/zaparoo-mistex_arm64.zip {{.BUILD_DIR}}/zaparoo.sh
+      - task: build-image-mistex
+      - task: build-docker
+        vars:
+          PLATFORM: mistex
+          BUILD_ARCH: arm64
+          DOCKER_ARCH: arm64/v8
+          IMAGE_NAME: zaparoo/mistex-build
+          APP_BIN: zaparoo.sh
 
   build-batocera-arm64:
-    vars:
-      BUILD_DIR: "./_build/batocera_arm64"
-      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
-      GOCACHE: "{{.BUILD_DIR}}/.go-cache"
-      IMAGE_NAME: zaparoo/batocera-arm64-build
-      IMG_BUILDCACHE: /home/build/.cache/go-build
-      IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/arm/v8 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
-      - rm -f {{.BUILD_DIR}}/zaparoo-batocera_arm64.zip
-      - zip -j {{.BUILD_DIR}}/zaparoo-batocera_arm64.zip {{.BUILD_DIR}}/zaparoo
+      - task: build-image-batocera-arm64
+      - task: build-docker
+        vars:
+          PLATFORM: batocera
+          BUILD_ARCH: arm64
+          DOCKER_ARCH: arm64/v8
+          IMAGE_NAME: zaparoo/batocera-arm64-build
+          APP_BIN: zaparoo
+          EXTRA_DOCKER_ARGS: -e PLATFORM=batocera -e APP_BIN=zaparoo
 
   build-batocera-amd64:
-    vars:
-      BUILD_DIR: "./_build/batocera_amd64"
-      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
-      GOCACHE: "{{.BUILD_DIR}}/.go-cache"
-      IMAGE_NAME: zaparoo/batocera-amd64-build
-      IMG_BUILDCACHE: /home/build/.cache/go-build
-      IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=batocera APP_BIN=zaparoo task build"
-      - rm -f {{.BUILD_DIR}}/zaparoo-batocera_amd64.zip
-      - zip -j {{.BUILD_DIR}}/zaparoo-batocera_amd64.zip {{.BUILD_DIR}}/zaparoo
+      - task: build-image-batocera-amd64
+      - task: build-docker
+        vars:
+          PLATFORM: batocera
+          BUILD_ARCH: amd64
+          DOCKER_ARCH: amd64
+          IMAGE_NAME: zaparoo/batocera-amd64-build
+          APP_BIN: zaparoo
+          EXTRA_DOCKER_ARGS: -e PLATFORM=batocera -e APP_BIN=zaparoo
 
   build-steamos-amd64:
-    vars:
-      BUILD_DIR: "./_build/steamos_amd64"
-      BUILDCACHE: "{{.BUILD_DIR}}/.go-buildcache"
-      GOCACHE: "{{.BUILD_DIR}}/.go-cache"
-      IMAGE_NAME: zaparoo/steamos-amd64-build
-      IMG_BUILDCACHE: /home/build/.cache/go-build
-      IMG_GOCACHE: /home/build/go
     cmds:
-      - docker run --rm --platform linux/amd64 -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.IMAGE_NAME}} bash -c "PLATFORM=steamos APP_BIN=zaparoo task build"
-      - rm -f {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip
-      - zip -j {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip {{.BUILD_DIR}}/zaparoo
+      - task: build-image-steamos-amd64
+      - task: build-docker
+        vars:
+          PLATFORM: steamos
+          BUILD_ARCH: amd64
+          DOCKER_ARCH: amd64
+          IMAGE_NAME: zaparoo/steamos-amd64-build
+          APP_BIN: zaparoo
+          EXTRA_DOCKER_ARGS: -e PLATFORM=steamos -e APP_BIN=zaparoo
 
   build-basic:
     internal: true

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -128,27 +128,60 @@ tasks:
       - rm -f {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip
       - zip -j {{.BUILD_DIR}}/zaparoo-steamos_amd64.zip {{.BUILD_DIR}}/zaparoo
 
-  build-windows:
+  build-basic:
+    internal: true
     vars:
-      BUILD_DIR: "./_build/windows_{{.ARCH}}"
+      BUILD_NAME: "{{if .ARCHLESS}}{{.PLATFORM}}{{else}}{{.PLATFORM}}_{{.BUILD_ARCH}}{{end}}"
+      BUILD_DIR: "./_build/{{.BUILD_NAME}}"
     env:
-      GOOS: windows
-      PLATFORM: windows
-      APP_BIN: Zaparoo.exe
-      CGO_ENABLED: 0
+      GOARCH: "{{default .ARCH .BUILD_ARCH}}"
+      GOOS: '{{default "windows" .BUILD_OS}}'
     cmds:
-      - go build -o _build/${PLATFORM}_{{ARCH}}/${APP_BIN} ./cmd/$PLATFORM
+      - go build -o {{.BUILD_DIR}}/{{.APP_BIN}} ./cmd/{{.PLATFORM}}
+      - rm -f {{.BUILD_DIR}}/zaparoo-{{.BUILD_NAME}}.zip
+      - zip -j {{.BUILD_DIR}}/zaparoo-{{.BUILD_NAME}}.zip {{.BUILD_DIR}}/{{.APP_BIN}}
 
-  build-mac:
-    vars:
-      BUILD_DIR: "./_build/mac_{{.ARCH}}"
-    env:
-      GOOS: darwin
-      PLATFORM: mac
-      APP_BIN: zaparoo
-      CGO_ENABLED: 0
+  build-windows-arm64:
     cmds:
-      - go build -o _build/${PLATFORM}_{{ARCH}}/${APP_BIN} ./cmd/$PLATFORM
+      - task: build-basic
+        vars:
+          BUILD_OS: windows
+          BUILD_ARCH: arm64
+          GOOS: windows
+          PLATFORM: windows
+          APP_BIN: Zaparoo.exe
+          CGO_ENABLED: 0
+
+  build-windows-amd64:
+    cmds:
+      - task: build-basic
+        vars:
+          BUILD_OS: windows
+          BUILD_ARCH: amd64
+          GOOS: windows
+          PLATFORM: windows
+          APP_BIN: Zaparoo.exe
+          CGO_ENABLED: 0
+
+  build-mac-arm64:
+    cmds:
+      - task: build-basic
+        vars:
+          BUILD_OS: darwin
+          BUILD_ARCH: arm64
+          PLATFORM: mac
+          APP_BIN: zaparoo
+          CGO_ENABLED: 0
+
+  build-mac-amd64:
+    cmds:
+      - task: build-basic
+        vars:
+          BUILD_OS: darwin
+          BUILD_ARCH: amd64
+          PLATFORM: mac
+          APP_BIN: zaparoo
+          CGO_ENABLED: 0
 
   deploy-mister:
     cmds:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -71,7 +71,7 @@ tasks:
       IMG_GOCACHE: /home/build/go
     cmds:
       - mkdir -p {{.BUILDCACHE}} {{.GOCACHE}}
-      - docker run --rm --platform linux/{{.DOCKER_ARCH}} -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build {{.EXTRA_DOCKER_ARGS}} {{.IMAGE_NAME}} {{.EXEC}}
+      - docker run --rm --platform linux/{{.DOCKER_ARCH}} -v {{.BUILDCACHE}}:{{.IMG_BUILDCACHE}} -v {{.GOCACHE}}:{{.IMG_GOCACHE}} -v ${PWD}:/build -e PLATFORM={{.PLATFORM}} -e APP_BIN={{.APP_BIN}} {{.EXTRA_DOCKER_ARGS}} {{.IMAGE_NAME}} {{.EXEC}}
 
   build-docker:
     internal: true
@@ -86,6 +86,7 @@ tasks:
           BUILD_DIR: "{{.BUILD_DIR}}"
           DOCKER_ARCH: "{{.DOCKER_ARCH}}"
           PLATFORM: "{{.PLATFORM}}"
+          APP_BIN: "{{.APP_BIN}}"
           EXEC: '{{default "task build" .EXEC}}'
           EXTRA_DOCKER_ARGS: '{{default "" .EXTRA_DOCKER_ARGS}}'
       - rm -f {{.ZIP_FULLPATH}}
@@ -143,7 +144,6 @@ tasks:
           DOCKER_ARCH: arm64/v8
           IMAGE_NAME: zaparoo/batocera-arm64-build
           APP_BIN: zaparoo
-          EXTRA_DOCKER_ARGS: -e PLATFORM=batocera -e APP_BIN=zaparoo
 
   build-batocera-amd64:
     cmds:
@@ -155,7 +155,6 @@ tasks:
           DOCKER_ARCH: amd64
           IMAGE_NAME: zaparoo/batocera-amd64-build
           APP_BIN: zaparoo
-          EXTRA_DOCKER_ARGS: -e PLATFORM=batocera -e APP_BIN=zaparoo
 
   build-steamos-amd64:
     cmds:
@@ -167,7 +166,6 @@ tasks:
           DOCKER_ARCH: amd64
           IMAGE_NAME: zaparoo/steamos-amd64-build
           APP_BIN: zaparoo
-          EXTRA_DOCKER_ARGS: -e PLATFORM=steamos -e APP_BIN=zaparoo
 
   build-basic:
     internal: true

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -224,13 +224,13 @@ tasks:
 
   deploy-mister:
     cmds:
-      - task: build-mister
+      - task: build-mister-arm
       - scp _build/mister_arm/zaparoo.sh root@${MISTER_IP}:/media/fat/Scripts/zaparoo.sh
       - ssh root@${MISTER_IP} /media/fat/Scripts/zaparoo.sh -service restart
 
   deploy-mistex:
     cmds:
-      - task: build-mistex
+      - task: build-mistex-arm64
       - scp _build/mistex_arm64/zaparoo.sh root@${MISTEX_IP}:/media/fat/Scripts/zaparoo.sh
       - ssh root@${MISTEX_IP} /media/fat/Scripts/zaparoo.sh -service restart
 

--- a/scripts/linux_amd64/build/Dockerfile
+++ b/scripts/linux_amd64/build/Dockerfile
@@ -57,4 +57,6 @@ USER build
 
 WORKDIR /build
 
+COPY --from=golang:1.23 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN git config --global --add safe.directory /build

--- a/scripts/linux_amd64/build/Dockerfile
+++ b/scripts/linux_amd64/build/Dockerfile
@@ -51,7 +51,8 @@ RUN cd /internal/libnfc && \
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 # drop permissions on output files
-RUN useradd -m -u 1000 build
+ARG UID=1000 GID=1000
+RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build

--- a/scripts/linux_amd64/build/Dockerfile
+++ b/scripts/linux_amd64/build/Dockerfile
@@ -52,7 +52,7 @@ RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/loc
 
 # drop permissions on output files
 ARG UID=1000 GID=1000
-RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
+RUN groupadd -f -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build

--- a/scripts/linux_arm64/build/Dockerfile
+++ b/scripts/linux_arm64/build/Dockerfile
@@ -57,4 +57,6 @@ USER build
 
 WORKDIR /build
 
+COPY --from=golang:1.23 /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN git config --global --add safe.directory /build

--- a/scripts/linux_arm64/build/Dockerfile
+++ b/scripts/linux_arm64/build/Dockerfile
@@ -51,7 +51,8 @@ RUN cd /internal/libnfc && \
 RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin
 
 # drop permissions on output files
-RUN useradd -m -u 1000 build
+ARG UID=1000 GID=1000
+RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build

--- a/scripts/linux_arm64/build/Dockerfile
+++ b/scripts/linux_arm64/build/Dockerfile
@@ -52,7 +52,7 @@ RUN sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/loc
 
 # drop permissions on output files
 ARG UID=1000 GID=1000
-RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
+RUN groupadd -f -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build

--- a/scripts/mister/build/Dockerfile
+++ b/scripts/mister/build/Dockerfile
@@ -54,7 +54,8 @@ COPY build.sh /usr/local/bin/build.sh
 RUN chmod +x /usr/local/bin/build.sh
 
 # drop permissions on output files
-RUN useradd -m -u 1000 build
+ARG UID=1000 GID=1000
+RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build

--- a/scripts/mister/build/Dockerfile
+++ b/scripts/mister/build/Dockerfile
@@ -55,7 +55,7 @@ RUN chmod +x /usr/local/bin/build.sh
 
 # drop permissions on output files
 ARG UID=1000 GID=1000
-RUN groupadd -g $GID build && useradd -m -u $UID -g $GID build
+RUN groupadd -f -g $GID build && useradd -m -u $UID -g $GID build
 USER build
 
 WORKDIR /build


### PR DESCRIPTION
This PR adds automatic GitHub releases apon being tagged in Git. The release with be created as a draft and build artifacts will be uploaded as they are ready. The Docker builds, with the ARM ones being the worst, are slower to run due to needing to build libnfc if the caching fails. ARM builds take far longer due to using QEMU to run, replacing it with a Buildroot based cross-compiling setup would speed it up, but was deemed out of scope. Replacing libnfc with something go native would be another option, but also put of scope.

The taskfile got a fair bit of tweaking and reworking as a consequence of this. Builds for Batocera, Mistex and SteamOS got fixed.  The Dockerfiles got tweaked to accept build arguments for the UID/GID of the running user to avoid permission issues of the user is not 1000:1000.

The workflow does not publish the release automatically, that one is something left to you as you'd probably want to fill in the the release notes more so than just a link to the GitHub diff page. It should be found on the release page for you to edit and publish. No need to wait for all the builds to finish before publishing the release, they will continue to be added even after release, though I expect you might take longer than the builds do once stuff is cached.