### PR TITLE
ZapScript parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/cors v1.2.1
 	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hsanjuan/go-ndef v0.0.1

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -261,7 +261,7 @@ func (p *Platform) KeyboardPress(name string) error {
 }
 
 func (p *Platform) GamepadPress(name string) error {
-	code, ok := linuxinput.GamepadMap[name]
+	code, ok := linuxinput.ToGamepadCode(name)
 	if !ok {
 		return fmt.Errorf("unknown button: %s", name)
 	}

--- a/pkg/platforms/mister/commands.go
+++ b/pkg/platforms/mister/commands.go
@@ -25,7 +25,11 @@ func CmdIni(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, er
 		return platforms.CmdResult{}, fmt.Errorf("no ini files found")
 	}
 
-	id, err := strconv.Atoi(env.Args)
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, fmt.Errorf("no ini specified")
+	}
+
+	id, err := strconv.Atoi(env.Cmd.Args[0])
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}
@@ -51,17 +55,25 @@ func CmdIni(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, er
 }
 
 func CmdLaunchCore(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, fmt.Errorf("no core specified")
+	}
+
 	return platforms.CmdResult{
 		MediaChanged: true,
-	}, mister.LaunchShortCore(env.Args)
+	}, mister.LaunchShortCore(env.Cmd.Args[0])
 }
 
 func cmdMisterScript(plm *Platform) func(platforms.Platform, platforms.CmdEnv) (platforms.CmdResult, error) {
 	return func(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 		// TODO: generic read bool function
-		hidden := env.NamedArgs["hidden"] == "true" || env.NamedArgs["hidden"] == "yes"
+		hidden := env.Cmd.AdvArgs["hidden"] == "true" || env.Cmd.AdvArgs["hidden"] == "yes"
 
-		args := strings.Fields(env.Args)
+		if len(env.Cmd.Args) == 0 {
+			return platforms.CmdResult{}, fmt.Errorf("no script specified")
+		}
+
+		args := strings.Fields(env.Cmd.Args[0])
 
 		if len(args) == 0 {
 			return platforms.CmdResult{}, fmt.Errorf("no script specified")
@@ -112,7 +124,11 @@ func cmdMisterScript(plm *Platform) func(platforms.Platform, platforms.CmdEnv) (
 }
 
 func CmdMisterMgl(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if env.Args == "" {
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, fmt.Errorf("no mgl specified")
+	}
+
+	if env.Cmd.Args[0] == "" {
 		return platforms.CmdResult{}, fmt.Errorf("no mgl specified")
 	}
 
@@ -121,7 +137,7 @@ func CmdMisterMgl(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResu
 		return platforms.CmdResult{}, err
 	}
 
-	_, err = tmpFile.WriteString(env.Args)
+	_, err = tmpFile.WriteString(env.Cmd.Args[0])
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -336,7 +336,7 @@ func (p *Platform) KeyboardPress(name string) error {
 }
 
 func (p *Platform) GamepadPress(name string) error {
-	code, ok := linuxinput.GamepadMap[name]
+	code, ok := linuxinput.ToGamepadCode(name)
 	if !ok {
 		return fmt.Errorf("unknown button: %s", name)
 	}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -344,7 +344,7 @@ func (p *Platform) GamepadPress(name string) error {
 }
 
 func (p *Platform) ForwardCmd(env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if f, ok := p.cmdMappings[env.Cmd]; ok {
+	if f, ok := p.cmdMappings[env.Cmd.Name]; ok {
 		return f(p, env)
 	} else {
 		return platforms.CmdResult{}, fmt.Errorf("command not supported on mister: %s", env.Cmd)

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -277,7 +277,7 @@ func (p *Platform) KeyboardPress(name string) error {
 }
 
 func (p *Platform) GamepadPress(name string) error {
-	code, ok := linuxinput.GamepadMap[name]
+	code, ok := linuxinput.ToGamepadCode(name)
 	if !ok {
 		return fmt.Errorf("unknown button: %s", name)
 	}

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -285,7 +285,7 @@ func (p *Platform) GamepadPress(name string) error {
 }
 
 func (p *Platform) ForwardCmd(env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if f, ok := commandsMappings[env.Cmd]; ok {
+	if f, ok := commandsMappings[env.Cmd.Name]; ok {
 		return f(p, env)
 	} else {
 		return platforms.CmdResult{}, fmt.Errorf("command not supported on mister: %s", env.Cmd)

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -2,6 +2,7 @@ package platforms
 
 import (
 	widgetModels "github.com/ZaparooProject/zaparoo-core/pkg/ui/widgets/models"
+	"github.com/ZaparooProject/zaparoo-core/pkg/zapscript/parser"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/pkg/api/models"
@@ -36,12 +37,9 @@ const (
 // CmdEnv is the local state of a scanned token, as it processes each ZapScript
 // command. Every command run has access to and can modify it.
 type CmdEnv struct {
-	Cmd           string
-	Args          string
-	NamedArgs     map[string]string
+	Cmd           parser.Command
 	Cfg           *config.Instance
 	Playlist      playlists.PlaylistController
-	Text          string
 	TotalCommands int
 	CurrentIndex  int
 	Unsafe        bool

--- a/pkg/utils/linuxinput/keymap.go
+++ b/pkg/utils/linuxinput/keymap.go
@@ -3,16 +3,13 @@
 package linuxinput
 
 import (
+	"github.com/ZaparooProject/zaparoo-core/pkg/utils/linuxinput/keyboardmap"
 	"github.com/bendahl/uinput"
-	"strings"
 )
 
 // ToKeyboardCode converts a single ZapScript key symbol to a uinput code.
 func ToKeyboardCode(name string) (int, bool) {
-	if len(name) > 2 && name[0] == '{' && name[len(name)-1] == '}' {
-		name = strings.ToLower(name)
-	}
-	if v, ok := GamepadMap[name]; ok {
+	if v, ok := keyboardmap.KeyboardMap[name]; ok {
 		return v, ok
 	} else {
 		return 0, false
@@ -56,9 +53,6 @@ var GamepadMap = map[string]int{
 
 // ToGamepadCode converts a single ZapScript button symbol to a uinput code.
 func ToGamepadCode(name string) (int, bool) {
-	if len(name) > 2 && name[0] == '{' && name[len(name)-1] == '}' {
-		name = strings.ToLower(name)
-	}
 	if v, ok := GamepadMap[name]; ok {
 		return v, ok
 	} else {

--- a/pkg/zapscript/http.go
+++ b/pkg/zapscript/http.go
@@ -1,7 +1,6 @@
 package zapscript
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -11,10 +10,18 @@ import (
 )
 
 func cmdHttpGet(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	if len(env.Cmd.Args) != 1 {
+		return platforms.CmdResult{}, ErrArgCount
+	} else if env.Cmd.Args[0] == "" {
+		return platforms.CmdResult{}, ErrRequiredArgs
+	}
+
+	url := env.Cmd.Args[0]
+
 	go func() {
-		resp, err := http.Get(env.Args)
+		resp, err := http.Get(url)
 		if err != nil {
-			log.Error().Err(err).Msgf("getting url: %s", env.Args)
+			log.Error().Err(err).Msgf("getting url: %s", url)
 			return
 		}
 		err = resp.Body.Close()
@@ -27,18 +34,19 @@ func cmdHttpGet(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	return platforms.CmdResult{}, nil
 }
 
-func cmdHttpPost(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	parts := strings.SplitN(env.Args, ",", 3)
-	if len(parts) < 3 {
-		return platforms.CmdResult{}, fmt.Errorf("invalid post format: %s", env.Args)
+func cmdHttpPost(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	if len(env.Cmd.Args) != 3 {
+		return platforms.CmdResult{}, ErrArgCount
 	}
 
-	url, format, data := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])
+	url := env.Cmd.Args[0]
+	mime := env.Cmd.Args[1]
+	payload := env.Cmd.Args[2]
 
 	go func() {
-		resp, err := http.Post(url, format, strings.NewReader(data))
+		resp, err := http.Post(url, mime, strings.NewReader(payload))
 		if err != nil {
-			log.Error().Err(err).Msgf("error posting to url: %s", env.Args)
+			log.Error().Err(err).Msgf("error posting to url: %s", url)
 			return
 		}
 		err = resp.Body.Close()

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -15,9 +15,13 @@ import (
 )
 
 func cmdSystem(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	// TODO: launcher named arg support
+	if len(env.Cmd.Args) != 1 {
+		return platforms.CmdResult{}, ErrArgCount
+	}
 
-	if strings.EqualFold(env.Args, "menu") {
+	systemID := env.Cmd.Args[0]
+
+	if strings.EqualFold(systemID, "menu") {
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, pl.StopActiveLauncher()
@@ -25,12 +29,18 @@ func cmdSystem(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	return platforms.CmdResult{
 		MediaChanged: true,
-	}, pl.LaunchSystem(env.Cfg, env.Args)
+	}, pl.LaunchSystem(env.Cfg, systemID)
 }
 
 func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if env.Args == "" {
-		return platforms.CmdResult{}, fmt.Errorf("no system specified")
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, ErrArgCount
+	}
+
+	query := env.Cmd.Args[0]
+
+	if query == "" {
+		return platforms.CmdResult{}, ErrRequiredArgs
 	}
 
 	launch, err := getAltLauncher(pl, env)
@@ -40,7 +50,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	gamesdb := env.Database.MediaDB
 
-	if env.Args == "all" {
+	if strings.EqualFold(query, "all") {
 		game, err := gamesdb.RandomGame(systemdefs.AllSystems())
 		if err != nil {
 			return platforms.CmdResult{}, err
@@ -54,18 +64,18 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// absolute path, try read dir and pick random file
 	// TODO: won't work for zips, switch to using gamesdb when it indexes paths
 	// TODO: doesn't filter on extensions
-	if filepath.IsAbs(env.Args) {
-		if _, err := os.Stat(env.Args); err != nil {
+	if filepath.IsAbs(query) {
+		if _, err := os.Stat(query); err != nil {
 			return platforms.CmdResult{}, err
 		}
 
-		files, err := filepath.Glob(filepath.Join(env.Args, "*"))
+		files, err := filepath.Glob(filepath.Join(query, "*"))
 		if err != nil {
 			return platforms.CmdResult{}, err
 		}
 
 		if len(files) == 0 {
-			return platforms.CmdResult{}, fmt.Errorf("no files found in: %s", env.Args)
+			return platforms.CmdResult{}, fmt.Errorf("no files found in: %s", query)
 		}
 
 		file, err := utils.RandomElem(files)
@@ -80,7 +90,8 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	// perform a search similar to launch.search and pick randomly
 	// looking for <system>/<query> format
-	ps := strings.SplitN(env.Args, "/", 2)
+	// TODO: use parser for launch command
+	ps := strings.SplitN(query, "/", 2)
 	if len(ps) == 2 {
 		systemId, query := ps[0], ps[1]
 
@@ -118,10 +129,10 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		}, launch(game.Path)
 	}
 
-	systemIds := strings.Split(env.Args, ",")
-	systems := make([]systemdefs.System, 0, len(systemIds))
+	// assume given a list of system ids
+	systems := make([]systemdefs.System, 0, len(env.Cmd.Args))
 
-	for _, id := range systemIds {
+	for _, id := range env.Cmd.Args {
 		system, err := systemdefs.LookupSystem(id)
 		if err != nil {
 			log.Error().Err(err).Msgf("error looking up system: %s", id)
@@ -145,21 +156,21 @@ func getAltLauncher(
 	pl platforms.Platform,
 	env platforms.CmdEnv,
 ) (func(args string) error, error) {
-	if env.NamedArgs["launcher"] != "" {
+	if env.Cmd.AdvArgs["launcher"] != "" {
 		var launcher platforms.Launcher
 
 		for _, l := range pl.Launchers(env.Cfg) {
-			if l.ID == env.NamedArgs["launcher"] {
+			if l.ID == env.Cmd.AdvArgs["launcher"] {
 				launcher = l
 				break
 			}
 		}
 
 		if launcher.Launch == nil {
-			return nil, fmt.Errorf("alt launcher not found: %s", env.NamedArgs["launcher"])
+			return nil, fmt.Errorf("alt launcher not found: %s", env.Cmd.AdvArgs["launcher"])
 		}
 
-		log.Info().Msgf("launching with alt launcher: %s", env.NamedArgs["launcher"])
+		log.Info().Msgf("launching with alt launcher: %s", env.Cmd.AdvArgs["launcher"])
 
 		return func(args string) error {
 			return launcher.Launch(env.Cfg, args)
@@ -174,52 +185,58 @@ func getAltLauncher(
 var reUri = regexp.MustCompile(`^.+://`)
 
 func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, ErrArgCount
+	}
+
+	path := env.Cmd.Args[0]
+
 	launch, err := getAltLauncher(pl, env)
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}
 
 	// if it's an absolute path, just try launch it
-	if filepath.IsAbs(env.Args) {
-		log.Debug().Msgf("launching absolute path: %s", env.Args)
+	if filepath.IsAbs(path) {
+		log.Debug().Msgf("launching absolute path: %s", path)
 		return platforms.CmdResult{
 			MediaChanged: true,
-		}, launch(env.Args)
+		}, launch(path)
 	}
 
 	// match for uri style launch syntax
-	if reUri.MatchString(env.Args) {
-		log.Debug().Msgf("launching uri: %s", env.Args)
+	if reUri.MatchString(path) {
+		log.Debug().Msgf("launching uri: %s", path)
 		return platforms.CmdResult{
 			MediaChanged: true,
-		}, launch(env.Args)
+		}, launch(path)
 	}
 
 	// for relative paths, perform a basic check if the file exists in a games folder
 	// this always takes precedence over the system/path format (but is not totally cross platform)
-	if p, err := findFile(pl, env.Cfg, env.Args); err == nil {
+	if p, err := findFile(pl, env.Cfg, path); err == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(p)
 	} else {
-		log.Debug().Err(err).Msgf("error finding file: %s", env.Args)
+		log.Debug().Err(err).Msgf("error finding file: %s", path)
 	}
 
 	// attempt to parse the <system>/<path> format
-	ps := strings.SplitN(env.Text, "/", 2)
+	ps := strings.SplitN(path, "/", 2)
 	if len(ps) < 2 {
-		return platforms.CmdResult{}, fmt.Errorf("invalid launch format: %s", env.Text)
+		return platforms.CmdResult{}, fmt.Errorf("invalid launch format: %s", path)
 	}
 
-	systemId, path := ps[0], ps[1]
+	systemID, lookupPath := ps[0], ps[1]
 
-	system, err := systemdefs.LookupSystem(systemId)
+	system, err := systemdefs.LookupSystem(systemID)
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}
 
-	log.Info().Msgf("launching system: %s, path: %s", systemId, path)
+	log.Info().Msgf("launching system: %s, path: %s", systemID, lookupPath)
 
 	var launchers []platforms.Launcher
 	for _, l := range pl.Launchers(env.Cfg) {
@@ -238,7 +255,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	}
 
 	for _, f := range folders {
-		systemPath := filepath.Join(f, path)
+		systemPath := filepath.Join(f, lookupPath)
 		log.Debug().Msgf("checking system path: %s", systemPath)
 		if fp, err := findFile(pl, env.Cfg, systemPath); err == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
@@ -246,30 +263,30 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				MediaChanged: true,
 			}, launch(fp)
 		} else {
-			log.Debug().Err(err).Msgf("error finding system file: %s", path)
+			log.Debug().Err(err).Msgf("error finding system file: %s", lookupPath)
 		}
 	}
 
 	gamesdb := env.Database.MediaDB
 
 	// search if the path contains no / or file extensions
-	if !strings.Contains(path, "/") && filepath.Ext(path) == "" {
-		if strings.Contains(path, "*") {
+	if !strings.Contains(lookupPath, "/") && filepath.Ext(lookupPath) == "" {
+		if strings.Contains(lookupPath, "*") {
 			// treat as a search
 			// TODO: passthrough advanced args
 			return cmdSearch(pl, env)
 		} else {
-			log.Info().Msgf("searching in %s: %s", system.ID, path)
+			log.Info().Msgf("searching in %s: %s", system.ID, lookupPath)
 			// treat as a direct title launch
 			res, err := gamesdb.SearchMediaPathExact(
 				[]systemdefs.System{*system},
-				path,
+				lookupPath,
 			)
 
 			if err != nil {
 				return platforms.CmdResult{}, err
 			} else if len(res) == 0 {
-				return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", path)
+				return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", lookupPath)
 			}
 
 			log.Info().Msgf("found result: %s", res[0].Path)
@@ -281,12 +298,18 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		}
 	}
 
-	return platforms.CmdResult{}, fmt.Errorf("file not found: %s", env.Args)
+	return platforms.CmdResult{}, fmt.Errorf("file not found: %s", path)
 }
 
 func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if env.Args == "" {
-		return platforms.CmdResult{}, fmt.Errorf("no query specified")
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, ErrArgCount
+	}
+
+	query := env.Cmd.Args[0]
+
+	if query == "" {
+		return platforms.CmdResult{}, ErrRequiredArgs
 	}
 
 	launch, err := getAltLauncher(pl, env)
@@ -294,12 +317,12 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, err
 	}
 
-	query := strings.ToLower(env.Args)
+	query = strings.ToLower(query)
 	query = strings.TrimSpace(query)
 
 	gamesdb := env.Database.MediaDB
 
-	if !strings.Contains(env.Args, "/") {
+	if !strings.Contains(query, "/") {
 		// search all systems
 		res, err := gamesdb.SearchMediaPathGlob(systemdefs.AllSystems(), query)
 		if err != nil {
@@ -320,7 +343,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("invalid search format: %s", query)
 	}
 
-	systemId, query := ps[0], ps[1]
+	systemID, query := ps[0], ps[1]
 
 	if query == "" {
 		return platforms.CmdResult{}, fmt.Errorf("no query specified")
@@ -328,10 +351,10 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	systems := make([]systemdefs.System, 0)
 
-	if strings.EqualFold(systemId, "all") {
+	if strings.EqualFold(systemID, "all") {
 		systems = systemdefs.AllSystems()
 	} else {
-		system, err := systemdefs.LookupSystem(systemId)
+		system, err := systemdefs.LookupSystem(systemID)
 		if err != nil {
 			return platforms.CmdResult{}, err
 		}

--- a/pkg/zapscript/parser/parser.go
+++ b/pkg/zapscript/parser/parser.go
@@ -1,0 +1,257 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+var (
+	ErrUnexpectedEOF  = errors.New("unexpected end of file")
+	ErrInvalidCmdName = errors.New("invalid characters in command name")
+	ErrEmptyCmdName   = errors.New("command name is empty")
+)
+
+type Command struct {
+	Name    string
+	Args    []string
+	AdvArgs map[string]string
+}
+
+type Script struct {
+	Cmds []Command
+}
+
+func isCmdName(ch rune) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '.'
+}
+
+func isWhitespace(ch rune) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+var eof = rune(0)
+
+type ScriptReader struct {
+	r   *bufio.Reader
+	pos int64
+}
+
+func NewScriptReader(script string) *ScriptReader {
+	return &ScriptReader{
+		r: bufio.NewReader(bytes.NewReader([]byte(script))),
+	}
+}
+
+func (sr *ScriptReader) read() (rune, error) {
+	ch, _, err := sr.r.ReadRune()
+	if errors.Is(err, io.EOF) {
+		return eof, nil
+	} else if err != nil {
+		return eof, err
+	}
+	sr.pos++
+	return ch, nil
+}
+
+func (sr *ScriptReader) unread() error {
+	err := sr.r.UnreadRune()
+	if err != nil {
+		return err
+	}
+	sr.pos--
+	return nil
+}
+
+func (sr *ScriptReader) peek() (rune, error) {
+	for peekBytes := 4; peekBytes > 0; peekBytes-- {
+		b, err := sr.r.Peek(peekBytes)
+		if err == nil {
+			r, _ := utf8.DecodeRune(b)
+			if r == utf8.RuneError {
+				return r, fmt.Errorf("rune error")
+			}
+			return r, nil
+		}
+	}
+	return eof, nil
+}
+
+func (sr *ScriptReader) skip() error {
+	_, err := sr.read()
+	if err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+func (sr *ScriptReader) checkEndOfCmd(ch rune) (bool, error) {
+	if ch != '|' {
+		return false, nil
+	}
+
+	next, err := sr.peek()
+	if err != nil {
+		return false, err
+	}
+
+	if next == eof {
+		return true, nil
+	} else if next == '|' {
+		err := sr.skip()
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (sr *ScriptReader) parseArgs() ([]string, error) {
+	args := make([]string, 0)
+	currentArg := ""
+
+	for {
+		ch, err := sr.read()
+		if err != nil {
+			return args, err
+		} else if ch == eof {
+			// an eof is effectively the same as || here
+			break
+		}
+
+		//if ch == '\\' {
+		//	// escaping next character
+		//	next, _, err := reader.ReadRune()
+		//	if errors.Is(err, io.EOF) {
+		//		break
+		//	} else if err != nil {
+		//		return []string{}, err
+		//	}
+		//}
+
+		eoc, err := sr.checkEndOfCmd(ch)
+		if err != nil {
+			return args, err
+		} else if eoc {
+			break
+		}
+
+		if ch == ',' {
+			// new argument
+			args = append(args, currentArg)
+			currentArg = ""
+			continue
+		} else {
+			currentArg = currentArg + string(ch)
+			continue
+		}
+	}
+
+	if currentArg != "" {
+		args = append(args, currentArg)
+	}
+
+	return args, nil
+}
+
+func (sr *ScriptReader) parseCommand() (Command, error) {
+	cmd := Command{}
+
+	for {
+		ch, err := sr.read()
+		if err != nil {
+			return cmd, err
+		} else if ch == eof {
+			// an eof is effectively the same as || here
+			break
+		}
+
+		eoc, err := sr.checkEndOfCmd(ch)
+		if err != nil {
+			return cmd, err
+		} else if eoc {
+			break
+		}
+
+		if isCmdName(ch) {
+			cmd.Name = cmd.Name + string(ch)
+		} else if ch == ':' {
+			// parse arguments
+			if cmd.Name == "" {
+				break
+			}
+
+			args, err := sr.parseArgs()
+			if err != nil {
+				return cmd, err
+			} else if len(args) > 0 {
+				cmd.Args = args
+			}
+
+			break
+		} else {
+			// might be a launch cmd
+			err := sr.unread()
+			if err != nil {
+				return cmd, err
+			}
+			return cmd, ErrInvalidCmdName
+		}
+	}
+
+	if cmd.Name == "" {
+		return cmd, ErrEmptyCmdName
+	}
+
+	return cmd, nil
+}
+
+func (sr *ScriptReader) Parse() (Script, error) {
+	script := Script{}
+
+	for {
+		ch, err := sr.read()
+		if err != nil {
+			return script, err
+		} else if ch == eof {
+			break
+		}
+
+		// TODO: newlines should count as a end cmd?
+		// TODO: support escaping *
+
+		if isWhitespace(ch) {
+			continue
+		} else if ch == '*' {
+			next, err := sr.peek()
+			if err != nil {
+				return script, err
+			}
+
+			if next == eof {
+				return script, ErrUnexpectedEOF
+			} else if next == '*' {
+				err := sr.skip()
+				if err != nil {
+					return script, err
+				}
+			}
+
+			cmd, err := sr.parseCommand()
+			if err != nil {
+				return script, err
+			} else {
+				script.Cmds = append(script.Cmds, cmd)
+			}
+		} else {
+			// TODO: is a launch command
+		}
+	}
+
+	return script, nil
+}

--- a/pkg/zapscript/parser/parser.go
+++ b/pkg/zapscript/parser/parser.go
@@ -24,16 +24,17 @@ var (
 )
 
 const (
-	SymCmdStart    = '*'
-	SymCmdSep      = '|'
-	SymEscapeSeq   = '%'
-	SymArgStart    = ':'
-	SymArgSep      = ','
-	SymArgQuote    = '"'
-	SymAdvArgStart = '?'
-	SymAdvArgSep   = '&'
-	SymAdvArgEq    = '='
-	SymJSONStart   = '{'
+	SymCmdStart       = '*'
+	SymCmdSep         = '|'
+	SymEscapeSeq      = '%'
+	SymArgStart       = ':'
+	SymArgSep         = ','
+	SymArgDoubleQuote = '"'
+	SymArgSingleQuote = '\''
+	SymAdvArgStart    = '?'
+	SymAdvArgSep      = '&'
+	SymAdvArgEq       = '='
+	SymJSONStart      = '{'
 )
 
 type Command struct {
@@ -137,7 +138,7 @@ func (sr *ScriptReader) checkEndOfCmd(ch rune) (bool, error) {
 	}
 }
 
-func (sr *ScriptReader) parseQuotedArg() (string, error) {
+func (sr *ScriptReader) parseQuotedArg(start rune) (string, error) {
 	arg := ""
 
 	for {
@@ -148,7 +149,7 @@ func (sr *ScriptReader) parseQuotedArg() (string, error) {
 			return arg, ErrUnmatchedQuote
 		}
 
-		if ch == SymArgQuote {
+		if ch == start {
 			break
 		}
 
@@ -241,8 +242,9 @@ func (sr *ScriptReader) parseAdvArgs() (map[string]string, string, error) {
 		buf = append(buf, ch)
 
 		if inValue {
-			if ch == SymArgQuote && valueStart == sr.pos-1 {
-				quotedValue, err := sr.parseQuotedArg()
+			if valueStart == sr.pos-1 &&
+				(ch == SymArgDoubleQuote || ch == SymArgSingleQuote) {
+				quotedValue, err := sr.parseQuotedArg(ch)
 				if err != nil {
 					return advArgs, string(buf), err
 				}
@@ -321,8 +323,9 @@ func (sr *ScriptReader) parseArgs(
 			break
 		}
 
-		if argStart == sr.pos-1 && ch == SymArgQuote {
-			quotedArg, err := sr.parseQuotedArg()
+		if argStart == sr.pos-1 &&
+			(ch == SymArgDoubleQuote || ch == SymArgSingleQuote) {
+			quotedArg, err := sr.parseQuotedArg(ch)
 			if err != nil {
 				return args, advArgs, err
 			}

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -138,7 +138,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 1",
-			input: `**test.escaped:one%,two`,
+			input: `**test.escaped:one^,two`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test.escaped", Args: []string{`one,two`}},
@@ -147,7 +147,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 2",
-			input: `**test.escaped:one%,two,th%|ree%|`,
+			input: `**test.escaped:one^,two,th^|ree^|`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test.escaped", Args: []string{`one,two`, `th|ree|`}},
@@ -156,10 +156,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 3",
-			input: `**test.escaped:one%%,two,a%%%%b`,
+			input: `**test.escaped:one^^,two,a^^^^b`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "test.escaped", Args: []string{`one%`, `two`, `a%%b`}},
+					{Name: "test.escaped", Args: []string{`one^`, `two`, `a^^b`}},
 				},
 			},
 		},
@@ -261,7 +261,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped question mark in arg (not adv arg)",
-			input: `**print:Hello%?World`,
+			input: `**print:Hello^?World`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "print", Args: []string{"Hello?World"}},
@@ -270,7 +270,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped ampersand in adv arg value",
-			input: `**go:main?cmd=build%&run`,
+			input: `**go:main?cmd=build^&run`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "go", Args: []string{"main"}, AdvArgs: map[string]string{"cmd": "build&run"}},
@@ -340,7 +340,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped equals sign in value",
-			input: `**cfg:file.cfg?env=dev%=beta`,
+			input: `**cfg:file.cfg?env=dev^=beta`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "cfg", Args: []string{"file.cfg"}, AdvArgs: map[string]string{
@@ -351,7 +351,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped ampersand in middle of value",
-			input: `**test:yes?data=foo%&bar%&baz`,
+			input: `**test:yes?data=foo^&bar^&baz`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test", Args: []string{"yes"}, AdvArgs: map[string]string{
@@ -362,7 +362,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped backslash before special",
-			input: `**safe:ok?path=c:%\windows%\system32`,
+			input: `**safe:ok?path=c:^\windows^\system32`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "safe", Args: []string{"ok"}, AdvArgs: map[string]string{
@@ -485,7 +485,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped pipe",
-			input: `MegaDrive%|Game.bin`,
+			input: `MegaDrive^|Game.bin`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`MegaDrive|Game.bin`}},
@@ -494,7 +494,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped question mark",
-			input: `launch%?param=value`,
+			input: `launch^?param=value`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`launch?param=value`}},
@@ -503,7 +503,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped backslashes",
-			input: `path%\with%\ending%\`,
+			input: `path^\with^\ending^\`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`path\with\ending\`}},
@@ -524,7 +524,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with url and escaped query params",
-			input: `https://google.com/stuff%?some=args&q=something`,
+			input: `https://google.com/stuff^?some=args&q=something`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`https://google.com/stuff?some=args&q=something`}},
@@ -560,10 +560,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "quoted arg with escaped backslash",
-			input: `**path:"C:%\Games%\Test"`,
+			input: `**path:"C:^\Games^\Test"`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "path", Args: []string{`C:%\Games%\Test`}},
+					{Name: "path", Args: []string{`C:^\Games^\Test`}},
 				},
 			},
 		},
@@ -628,19 +628,19 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped and quoted together",
-			input: `**weird:"hello%, world",foo%|bar`,
+			input: `**weird:"hello^, world",foo^|bar`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "weird", Args: []string{"hello%, world", "foo|bar"}},
+					{Name: "weird", Args: []string{"hello^, world", "foo|bar"}},
 				},
 			},
 		},
 		{
 			name:  "quoted and escaped mix",
-			input: `**mix:"a%,b",c%,d,e%|f,"g%"h"`,
+			input: `**mix:"a^,b",c^,d,e^|f,"g^"h"`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "mix", Args: []string{"a%,b", "c,d", "e|f", `g%h"`}},
+					{Name: "mix", Args: []string{"a^,b", "c,d", "e|f", `g^h"`}},
 				},
 			},
 		},
@@ -655,16 +655,16 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped trailing special chars",
-			input: `**data:end%,%|%?%%`,
+			input: `**data:end^,^|^?^^`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "data", Args: []string{"end,|?%"}},
+					{Name: "data", Args: []string{"end,|?^"}},
 				},
 			},
 		},
 		{
 			name:  "run http.get",
-			input: `**http.get:https://zapa.roo/stuff%?id=5`,
+			input: `**http.get:https://zapa.roo/stuff^?id=5`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "http.get", Args: []string{`https://zapa.roo/stuff?id=5`}},
@@ -682,11 +682,11 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "quoted value with escaped quote and equals",
-			input: `**info?text="he said %"foo=bar%""`,
+			input: `**info?text="he said ^"foo=bar^""`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "info", AdvArgs: map[string]string{
-						"text": `he said %foo=bar""`,
+						"text": `he said ^foo=bar""`,
 					}},
 				},
 			},
@@ -760,7 +760,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escape sequences",
-			input: `**say:hello%|world`,
+			input: `**say:hello^|world`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{
@@ -792,7 +792,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with bad name",
-			input: `C:\some\path\100% completed\file.exe`,
+			input: `C:\some\path\100^ completed\file.exe`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{
@@ -804,28 +804,28 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped bad name",
-			input: `C:\some\path\100%% completed\file.exe`,
+			input: `C:\some\path\100^^ completed\file.exe`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{
 						Name: "launch",
-						Args: []string{"C:\\some\\path\\100% completed\\file.exe"},
+						Args: []string{"C:\\some\\path\\100^ completed\\file.exe"},
 					},
 				},
 			},
 		},
 		{
 			name:  "generic launch with escaped bad name",
-			input: `C:\some\path\200%% completed\file.exe||C:\some 200%%\path\100%% completed\file.exe`,
+			input: `C:\some\path\200^^ completed\file.exe||C:\some 200^^\path\100^^ completed\file.exe`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{
 						Name: "launch",
-						Args: []string{"C:\\some\\path\\200% completed\\file.exe"},
+						Args: []string{"C:\\some\\path\\200^ completed\\file.exe"},
 					},
 					{
 						Name: "launch",
-						Args: []string{"C:\\some 200%\\path\\100% completed\\file.exe"},
+						Args: []string{"C:\\some 200^\\path\\100^ completed\\file.exe"},
 					},
 				},
 			},
@@ -975,7 +975,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "single quotes 3",
-			input: `**stuff:%'C:\some\path\completed?\usa, games/file.exe'?doot=doot`,
+			input: `**stuff:^'C:\some\path\completed?\usa, games/file.exe'?doot=doot`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "stuff", Args: []string{`'C:\some\path\completed?\usa`, `games/file.exe'`}, AdvArgs: map[string]string{
@@ -988,6 +988,174 @@ func TestParse(t *testing.T) {
 			name:    "single quotes 4",
 			input:   `**stuff:'C:\some\path\completed?\usa, games/file.exe?doot=doot`,
 			wantErr: parser.ErrUnmatchedQuote,
+		},
+		{
+			name:  "input.keyboard basic characters",
+			input: `**input.keyboard:abcXYZ123`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"a", "b", "c", "X", "Y", "Z", "1", "2", "3",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard basic characters and auto launch",
+			input: `**input.keyboard:abcXYZ123||/testing/test.bin`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"a", "b", "c", "X", "Y", "Z", "1", "2", "3",
+					}},
+					{Name: "launch", Args: []string{"/testing/test.bin"}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard special characters",
+			input: `**input.keyboard:!@#$%^&*()_+-=`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "-", "=",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard escape sequences 1",
+			input: `**input.keyboard:{enter}{esc}{tab}{backspace}{space}{up}{down}{left}{right}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"{enter}", "{esc}", "{tab}", "{backspace}", "{space}",
+						"{up}", "{down}", "{left}", "{right}",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard escape sequences 2",
+			input: `**input.keyboard:\{enter}{esc}{tab}{backspace}{space}\{up\}{down}{left}{right}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"{", "e", "n", "t", "e", "r", "}",
+						"{esc}", "{tab}", "{backspace}", "{space}",
+						"{", "u", "p", "}",
+						"{down}", "{left}", "{right}",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard mixed content",
+			input: `**input.keyboard:Hello{space}World!{enter}123{backspace}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard", Args: []string{
+						"H", "e", "l", "l", "o",
+						"{space}",
+						"W", "o", "r", "l", "d", "!",
+						"{enter}",
+						"1", "2", "3",
+						"{backspace}",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.gamepad basic directions",
+			input: `**input.gamepad:^^VV<><>`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.gamepad", Args: []string{
+						"^", "^", "V", "V", "<", ">", "<", ">",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.gamepad buttons",
+			input: `**input.gamepad:ABXYRLZC`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.gamepad", Args: []string{
+						"A", "B", "X", "Y", "R", "L", "Z", "C",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.gamepad special buttons",
+			input: `**input.gamepad:{start}{select}{mode}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.gamepad", Args: []string{
+						"{start}", "{select}", "{mode}",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.gamepad complex sequence",
+			input: `**input.gamepad:^^VV<><>BA{start}XY{select}RL`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.gamepad", Args: []string{
+						"^", "^", "V", "V", "<", ">", "<", ">",
+						"B", "A", "{start}", "X", "Y", "{select}", "R", "L",
+					}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard with advanced args",
+			input: `**input.keyboard:Hello{enter}World?delay=100`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard",
+						Args: []string{
+							"H", "e", "l", "l", "o",
+							"{enter}",
+							"W", "o", "r", "l", "d",
+						},
+						AdvArgs: map[string]string{"delay": "100"}},
+				},
+			},
+		},
+		{
+			name:  "input.keyboard with advanced args escaped",
+			input: `**input.keyboard:Hello{enter}World\?delay=1\\00`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.keyboard",
+						Args: []string{
+							"H", "e", "l", "l", "o",
+							"{enter}",
+							"W", "o", "r", "l", "d",
+							"?", "d", "e", "l", "a", "y", "=", "1", "\\", "0", "0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "input.gamepad with advanced args",
+			input: `**input.gamepad:AB{start}XY?repeat=2&interval=500`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "input.gamepad",
+						Args: []string{
+							"A", "B", "{start}", "X", "Y",
+						},
+						AdvArgs: map[string]string{
+							"repeat":   "2",
+							"interval": "500",
+						}},
+				},
+			},
 		},
 		{
 			name:  "ignore 1 star",
@@ -1115,7 +1283,12 @@ func TestParse(t *testing.T) {
 			input: `**input.keyboard:qWeRty{enter}{up}aaa`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "input.keyboard", Args: []string{`qWeRty{enter}{up}aaa`}},
+					{Name: "input.keyboard", Args: []string{
+						"q", "W", "e", "R", "t", "y",
+						"{enter}",
+						"{up}",
+						"a", "a", "a",
+					}},
 				},
 			},
 		},
@@ -1124,7 +1297,11 @@ func TestParse(t *testing.T) {
 			input: `**input.gamepad:^^VV<><>BA{start}{select}`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "input.gamepad", Args: []string{`^^VV<><>BA{start}{select}`}},
+					{Name: "input.gamepad", Args: []string{
+						"^", "^", "V", "V", "<", ">", "<", ">", "B", "A",
+						"{start}",
+						"{select}",
+					}},
 				},
 			},
 		},

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -954,6 +954,42 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name:  "single quotes 1",
+			input: `'C:\some\path\completed?\usa, games/file.exe'`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`C:\some\path\completed?\usa, games/file.exe`}},
+				},
+			},
+		},
+		{
+			name:  "single quotes 2",
+			input: `**stuff:'C:\some\path\completed?\usa, games/file.exe'?doot=doot`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "stuff", Args: []string{`C:\some\path\completed?\usa, games/file.exe`}, AdvArgs: map[string]string{
+						"doot": "doot",
+					}},
+				},
+			},
+		},
+		{
+			name:  "single quotes 3",
+			input: `**stuff:%'C:\some\path\completed?\usa, games/file.exe'?doot=doot`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "stuff", Args: []string{`'C:\some\path\completed?\usa`, `games/file.exe'`}, AdvArgs: map[string]string{
+						"doot": "doot",
+					}},
+				},
+			},
+		},
+		{
+			name:    "single quotes 4",
+			input:   `**stuff:'C:\some\path\completed?\usa, games/file.exe?doot=doot`,
+			wantErr: parser.ErrUnmatchedQuote,
+		},
+		{
 			name:  "ignore 1 star",
 			input: `*testtest/ASFd/sfasafsfd.bin`,
 			want: parser.Script{

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -519,6 +519,119 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "single quoted arg",
+			input: `**say:"hello, world"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "say", Args: []string{"hello, world"}},
+				},
+			},
+		},
+		{
+			name:  "multiple quoted args",
+			input: `**msg:"hello, world","123"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "msg", Args: []string{"hello, world", "123"}},
+				},
+			},
+		},
+		{
+			name:  "quoted with internal escaped quote",
+			input: `**echo:"she said \"hello\""`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "echo", Args: []string{`she said "hello"`}},
+				},
+			},
+		},
+		{
+			name:  "quoted arg with escaped backslash",
+			input: `**path:"C:\\Games\\Test"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "path", Args: []string{`C:\Games\Test`}},
+				},
+			},
+		},
+		{
+			name:  "quoted arg with unescaped backslash",
+			input: `**path:"C:\Games\Test"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "path", Args: []string{`C:\Games\Test`}},
+				},
+			},
+		},
+		{
+			name:  "quoted arg followed by unquoted",
+			input: `**mix:"hello, world",next`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mix", Args: []string{"hello, world", "next"}},
+				},
+			},
+		},
+		{
+			name:    "unmatched quote in arg",
+			input:   `**fail:"unterminated`,
+			wantErr: parser.ErrUnmatchedQuote,
+		},
+		{
+			name:  "quoted arg with adv arg",
+			input: `**cmd:"hello, world"?env=prod`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cmd", Args: []string{"hello, world"}, AdvArgs: map[string]string{"env": "prod"}},
+				},
+			},
+		},
+		{
+			name:  "quoted key in adv args",
+			input: `**cfg?env="prod build"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cfg", AdvArgs: map[string]string{"env": "prod build"}},
+				},
+			},
+		},
+		{
+			name:  "quoted val in adv args with escaped quote",
+			input: `**cfg?note="he said \"hello\""`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cfg", AdvArgs: map[string]string{"note": `he said "hello"`}},
+				},
+			},
+		},
+		{
+			name:  "quoted generic launch path",
+			input: `"MegaDrive/games/abc,def.bin"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`MegaDrive/games/abc,def.bin`}},
+				},
+			},
+		},
+		{
+			name:  "quoted generic launch path with adv args",
+			input: `"DOS/Games/test,123.iso"?lang=en`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`DOS/Games/test,123.iso`}, AdvArgs: map[string]string{"lang": "en"}},
+				},
+			},
+		},
+		{
+			name:  "escaped and quoted together",
+			input: `**weird:"hello\, world",foo\|bar`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "weird", Args: []string{"hello\\, world", "foo|bar"}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -69,9 +69,13 @@ func TestParse(t *testing.T) {
 			wantErr: parser.ErrEmptyCmdName,
 		},
 		{
-			name:    "invalid character in command name",
-			input:   `**he@llo`,
-			wantErr: parser.ErrInvalidCmdName,
+			name:  "invalid character in command name",
+			input: `**he@llo`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`**he@llo`}},
+				},
+			},
 		},
 		{
 			name:    "unexpected EOF after asterisk",

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -174,6 +174,91 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "command with one advanced arg",
+			input: `**example?debug=true`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "example", AdvArgs: map[string]string{"debug": "true"}},
+				},
+			},
+		},
+		{
+			name:  "command with args and one advanced arg",
+			input: `**download:file1.txt?verify=sha256`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "download", Args: []string{"file1.txt"}, AdvArgs: map[string]string{"verify": "sha256"}},
+				},
+			},
+		},
+		{
+			name:  "command with multiple advanced args",
+			input: `**launch:game.exe?platform=win&fullscreen=yes&lang=en`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{"game.exe"}, AdvArgs: map[string]string{
+						"platform":   "win",
+						"fullscreen": "yes",
+						"lang":       "en",
+					}},
+				},
+			},
+		},
+		{
+			name:  "command with args and trailing || after adv args",
+			input: `**start:demo.bin?mode=fast||`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "start", Args: []string{"demo.bin"}, AdvArgs: map[string]string{"mode": "fast"}},
+				},
+			},
+		},
+		{
+			name:  "command with empty adv arg value",
+			input: `**run:foo?trace=`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "run", Args: []string{"foo"}, AdvArgs: map[string]string{"trace": ""}},
+				},
+			},
+		},
+		{
+			name:  "command with arg but no adv args",
+			input: `**build:release`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "build", Args: []string{"release"}, AdvArgs: nil},
+				},
+			},
+		},
+		{
+			name:  "escaped question mark in arg (not adv arg)",
+			input: `**print:Hello\?World`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "print", Args: []string{"Hello?World"}},
+				},
+			},
+		},
+		{
+			name:  "escaped ampersand in adv arg value",
+			input: `**go:main?cmd=build\&run`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "go", Args: []string{"main"}, AdvArgs: map[string]string{"cmd": "build&run"}},
+				},
+			},
+		},
+		{
+			name:  "advanced args only, no standard args",
+			input: `**env?debug=1&trace=0`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "env", AdvArgs: map[string]string{"debug": "1", "trace": "0"}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -105,6 +105,71 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "command with escaped args 1",
+			input: `**test.escaped:one\,two`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "test.escaped", Args: []string{`one,two`}},
+				},
+			},
+		},
+		{
+			name:  "command with escaped args 2",
+			input: `**test.escaped:one\,two,th\|ree\|`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "test.escaped", Args: []string{`one,two`, `th|ree|`}},
+				},
+			},
+		},
+		{
+			name:  "command with escaped args 3",
+			input: `**test.escaped:one\\,two,a\\\\b`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "test.escaped", Args: []string{`one\`, `two`, `a\\b`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch 1",
+			input: `DOS/some/game/to/play.iso`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`DOS/some/game/to/play.iso`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch 2",
+			input: `/media/fat/games/DOS/some/game/to/play.iso`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`/media/fat/games/DOS/some/game/to/play.iso`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch 3",
+			input: `C:\game\to\to\play.iso`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`C:\game\to\to\play.iso`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch multi 1",
+			input: `C:\game\to\to\play.iso||**http.get:https://google.com/||MegaDrive/something.bin`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`C:\game\to\to\play.iso`}},
+					{Name: "http.get", Args: []string{`https://google.com/`}},
+					{Name: "launch", Args: []string{`MegaDrive/something.bin`}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -1522,6 +1522,198 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "mister docs example 1",
+			input: `**mister.ini:1`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mister.ini", Args: []string{`1`}},
+				},
+			},
+		},
+		{
+			name:  "mister docs example 2",
+			input: `**mister.core:_Console/SNES`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mister.core", Args: []string{`_Console/SNES`}},
+				},
+			},
+		},
+		{
+			name:  "mister docs example 3",
+			input: `**mister.core:_Console/PSX_20220518`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mister.core", Args: []string{`_Console/PSX_20220518`}},
+				},
+			},
+		},
+		{
+			name:  "mister docs example 4",
+			input: `**mister.script:update_all.sh`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mister.script", Args: []string{`update_all.sh`}},
+				},
+			},
+		},
+		{
+			name:  "mister docs example 5",
+			input: `**mister.script:update_all.sh?hidden=yes`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mister.script", Args: []string{`update_all.sh`},
+						AdvArgs: map[string]string{"hidden": "yes"}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 1",
+			input: `**playlist.play:/media/fat/games/Genesis`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.play", Args: []string{`/media/fat/games/Genesis`}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 2",
+			input: `**playlist.play:/media/fat/playlist.pls`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.play", Args: []string{`/media/fat/playlist.pls`}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 3",
+			input: `**playlist.load:/media/fat/playlist.pls`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.load", Args: []string{`/media/fat/playlist.pls`}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 4",
+			input: `**playlist.load:/media/fat/playlist.pls?mode=shuffle`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.load", Args: []string{`/media/fat/playlist.pls`}, AdvArgs: map[string]string{"mode": "shuffle"}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 5",
+			input: `**playlist.play:/media/fat/_@Favorites`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.play", Args: []string{`/media/fat/_@Favorites`}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 6",
+			input: `**playlist.play`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.play"},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 7",
+			input: `**playlist.stop`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.stop"},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 8",
+			input: `**playlist.next`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.next"},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 9",
+			input: `**playlist.previous`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.previous"},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 10",
+			input: `**playlist.pause`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.pause"},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 11",
+			input: `**playlist.goto:2`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.goto", Args: []string{`2`}},
+				},
+			},
+		},
+		{
+			name:  "playlist docs example 12",
+			input: `**playlist.open:/media/fat/playlist.pls`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "playlist.open", Args: []string{`/media/fat/playlist.pls`}},
+				},
+			},
+		},
+		{
+			name:  "stop command",
+			input: `**stop`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "stop"},
+				},
+			},
+		},
+		{
+			name:  "execute command",
+			input: `**execute:reboot`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "execute", Args: []string{`reboot`}},
+				},
+			},
+		},
+		{
+			name:  "delay command",
+			input: `**delay:500`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "delay", Args: []string{`500`}},
+				},
+			},
+		},
+		{
+			name:  "delay combined with other commands",
+			input: `_Console/SNES||**delay:10000||**input.key:88`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`_Console/SNES`}},
+					{Name: "delay", Args: []string{`10000`}},
+					{Name: "input.key", Args: []string{`88`}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -632,6 +632,78 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "quoted and escaped mix",
+			input: `**mix:"a\,b",c\,d,e\|f,"g\"h"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "mix", Args: []string{"a\\,b", "c,d", "e|f", `g"h`}},
+				},
+			},
+		},
+		{
+			name:  "json-like but not json",
+			input: `**cfg:map:{key=value}?debug=true`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cfg", Args: []string{"map:{key=value}"}, AdvArgs: map[string]string{"debug": "true"}},
+				},
+			},
+		},
+		{
+			name:  "escaped trailing special chars",
+			input: `**data:end\,\|\?\\`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "data", Args: []string{"end,|?\\"}},
+				},
+			},
+		},
+		{
+			name:  "run http.get",
+			input: `**http.get:https://zapa.roo/stuff\?id=5`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "http.get", Args: []string{`https://zapa.roo/stuff?id=5`}},
+				},
+			},
+		},
+		{
+			name:  "template-ish content",
+			input: `**render:level-[[difficulty]]?fx=true`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "render", Args: []string{"level-[[difficulty]]"}, AdvArgs: map[string]string{"fx": "true"}},
+				},
+			},
+		},
+		{
+			name:  "quoted value with escaped quote and equals",
+			input: `**info?text="he said \"foo=bar\""`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "info", AdvArgs: map[string]string{"text": `he said "foo=bar"`}},
+				},
+			},
+		},
+		{
+			name:  "quoted path with trailing escaped backslash",
+			input: `"C:\\Games\\End\\"`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`C:\Games\End\`}},
+				},
+			},
+		},
+		{
+			name:  "adv args with json-like garbage",
+			input: `**launch:game.exe?{bad}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{"game.exe"}, AdvArgs: map[string]string{"{bad}": ""}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -818,6 +818,120 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "simple json argument",
+			input: `**config:{"key": "value"}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "config", Args: []string{`{"key":"value"}`}},
+				},
+			},
+		},
+		{
+			name:  "json argument with multiple fields",
+			input: `**setup:{"name": "test", "count": 42, "enabled": true}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "setup", Args: []string{`{"count":42,"enabled":true,"name":"test"}`}},
+				},
+			},
+		},
+		{
+			name:  "nested json argument",
+			input: `**deploy:{"config": {"env": "prod", "replicas": 3}, "name": "app"}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "deploy", Args: []string{`{"config":{"env":"prod","replicas":3},"name":"app"}`}},
+				},
+			},
+		},
+		{
+			name:  "json argument with array",
+			input: `**process:{"items": [1, 2, 3], "type": "batch"}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "process", Args: []string{`{"items":[1,2,3],"type":"batch"}`}},
+				},
+			},
+		},
+		{
+			name:  "json argument with escaped quotes",
+			input: `**message:{"text": "he said \"hello\"", "sender": "user"}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "message", Args: []string{`{"sender":"user","text":"he said \"hello\""}`}},
+				},
+			},
+		},
+		{
+			name:  "json argument mixed with regular args",
+			input: `**run:{"port": 8080, "host": "localhost"},normal_arg`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "run", Args: []string{`{"host":"localhost","port":8080}`, "normal_arg"}},
+				},
+			},
+		},
+		{
+			name:  "json argument with advanced args",
+			input: `**api:{"endpoint": "/users", "method": "GET"}?timeout=30`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "api", Args: []string{`{"endpoint":"/users","method":"GET"}`}, AdvArgs: map[string]string{"timeout": "30"}},
+				},
+			},
+		},
+		{
+			name:  "json in advanced arg value",
+			input: `**configure?data={"debug": true, "level": "info"}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "configure", AdvArgs: map[string]string{"data": `{"debug":true,"level":"info"}`}},
+				},
+			},
+		},
+		{
+			name:  "multiple json arguments",
+			input: `**merge:{"a": 1},{"b": 2}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "merge", Args: []string{`{"a":1}`, `{"b":2}`}},
+				},
+			},
+		},
+		{
+			name:    "start script with json argument",
+			input:   `{"game": "chess", "difficulty": "hard"}`,
+			wantErr: parser.ErrInvalidJSON,
+		},
+		{
+			name:    "invalid json argument - missing closing brace",
+			input:   `**config:{"key": "value"`,
+			wantErr: parser.ErrInvalidJSON,
+		},
+		{
+			name:    "invalid json argument - malformed",
+			input:   `**config:{"key": value}`,
+			wantErr: parser.ErrInvalidJSON,
+		},
+		{
+			name:  "empty json object",
+			input: `**init:{}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "init", Args: []string{`{}`}},
+				},
+			},
+		},
+		{
+			name:  "json with complex nested structure",
+			input: `**complex:{"users": [{"id": 1, "meta": {"active": true}}], "total": 1}`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "complex", Args: []string{`{"total":1,"users":[{"id":1,"meta":{"active":true}}]}`}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -376,7 +376,10 @@ func TestParse(t *testing.T) {
 			input: `**opt ? a = b & c = d `,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "launch", Args: []string{"**opt ? a = b & c = d "}},
+					{Name: "launch", Args: []string{"**opt "}, AdvArgs: map[string]string{
+						" a ": "b",
+						" c ": "d",
+					}},
 				},
 			},
 		},
@@ -386,8 +389,8 @@ func TestParse(t *testing.T) {
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "opt", AdvArgs: map[string]string{
-						"a": "b",
-						"c": "d",
+						" a ": "b",
+						" c ": "d",
 					}},
 				},
 			},
@@ -420,6 +423,99 @@ func TestParse(t *testing.T) {
 						"x": "1", "y": "2",
 					}},
 					{Name: "beta", AdvArgs: map[string]string{"z": "9"}},
+				},
+			},
+		},
+		{
+			name:  "arg with dangling backslash at end",
+			input: `**echo:hello\`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "echo", Args: []string{`hello\`}},
+				},
+			},
+		},
+		{
+			name:  "adv arg with invalid escape in key",
+			input: `**cfg?pa\th=/bin`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cfg", AdvArgs: map[string]string{"pa\\th": "/bin"}},
+				},
+			},
+		},
+		{
+			name:  "adv arg with dangling backslash in value",
+			input: `**cfg?path=C:\bin\`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "cfg", AdvArgs: map[string]string{"path": `C:\bin\`}},
+				},
+			},
+		},
+		{
+			name:  "adv arg with final backslash",
+			input: `**log?file=trace\`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "log", AdvArgs: map[string]string{"file": `trace\`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with windows path",
+			input: `C:\games\doom\doom.exe`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`C:\games\doom\doom.exe`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with escaped pipe",
+			input: `MegaDrive\|Game.bin`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`MegaDrive|Game.bin`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with escaped question mark",
+			input: `launch\?param=value`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`launch?param=value`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with escaped backslashes",
+			input: `path\\with\\ending\\`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`path\with\ending\`}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with url and query params",
+			input: `https://google.com/stuff?some=args&q=something`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`https://google.com/stuff`}, AdvArgs: map[string]string{
+						"some": `args`,
+						"q":    `something`,
+					}},
+				},
+			},
+		},
+		{
+			name:  "generic launch with url and escaped query params",
+			input: `https://google.com/stuff\?some=args&q=something`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{Name: "launch", Args: []string{`https://google.com/stuff?some=args&q=something`}},
 				},
 			},
 		},

--- a/pkg/zapscript/parser/parser_test.go
+++ b/pkg/zapscript/parser/parser_test.go
@@ -138,7 +138,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 1",
-			input: `**test.escaped:one\,two`,
+			input: `**test.escaped:one%,two`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test.escaped", Args: []string{`one,two`}},
@@ -147,7 +147,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 2",
-			input: `**test.escaped:one\,two,th\|ree\|`,
+			input: `**test.escaped:one%,two,th%|ree%|`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test.escaped", Args: []string{`one,two`, `th|ree|`}},
@@ -156,10 +156,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "command with escaped args 3",
-			input: `**test.escaped:one\\,two,a\\\\b`,
+			input: `**test.escaped:one%%,two,a%%%%b`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "test.escaped", Args: []string{`one\`, `two`, `a\\b`}},
+					{Name: "test.escaped", Args: []string{`one%`, `two`, `a%%b`}},
 				},
 			},
 		},
@@ -261,7 +261,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped question mark in arg (not adv arg)",
-			input: `**print:Hello\?World`,
+			input: `**print:Hello%?World`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "print", Args: []string{"Hello?World"}},
@@ -270,7 +270,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped ampersand in adv arg value",
-			input: `**go:main?cmd=build\&run`,
+			input: `**go:main?cmd=build%&run`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "go", Args: []string{"main"}, AdvArgs: map[string]string{"cmd": "build&run"}},
@@ -340,7 +340,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped equals sign in value",
-			input: `**cfg:file.cfg?env=dev\=beta`,
+			input: `**cfg:file.cfg?env=dev%=beta`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "cfg", Args: []string{"file.cfg"}, AdvArgs: map[string]string{
@@ -351,7 +351,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped ampersand in middle of value",
-			input: `**test:yes?data=foo\&bar\&baz`,
+			input: `**test:yes?data=foo%&bar%&baz`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "test", Args: []string{"yes"}, AdvArgs: map[string]string{
@@ -362,7 +362,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped backslash before special",
-			input: `**safe:ok?path=c:\\windows\\system32`,
+			input: `**safe:ok?path=c:%\windows%\system32`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "safe", Args: []string{"ok"}, AdvArgs: map[string]string{
@@ -376,7 +376,7 @@ func TestParse(t *testing.T) {
 			input: `**opt ? a = b & c = d `,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "launch", Args: []string{"**opt "}, AdvArgs: map[string]string{
+					{Name: "launch", Args: []string{"**opt"}, AdvArgs: map[string]string{
 						" a ": "b",
 						" c ": "d",
 					}},
@@ -473,7 +473,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped pipe",
-			input: `MegaDrive\|Game.bin`,
+			input: `MegaDrive%|Game.bin`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`MegaDrive|Game.bin`}},
@@ -482,7 +482,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped question mark",
-			input: `launch\?param=value`,
+			input: `launch%?param=value`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`launch?param=value`}},
@@ -491,7 +491,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with escaped backslashes",
-			input: `path\\with\\ending\\`,
+			input: `path%\with%\ending%\`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`path\with\ending\`}},
@@ -512,7 +512,7 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "generic launch with url and escaped query params",
-			input: `https://google.com/stuff\?some=args&q=something`,
+			input: `https://google.com/stuff%?some=args&q=something`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{`https://google.com/stuff?some=args&q=something`}},
@@ -538,29 +538,20 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name:  "quoted with internal escaped quote",
-			input: `**echo:"she said \"hello\""`,
+			name:  "quoted with internal quotes",
+			input: `**echo:"she said "hello""`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "echo", Args: []string{`she said "hello"`}},
+					{Name: "echo", Args: []string{`she said hello""`}},
 				},
 			},
 		},
 		{
 			name:  "quoted arg with escaped backslash",
-			input: `**path:"C:\\Games\\Test"`,
+			input: `**path:"C:%\Games%\Test"`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "path", Args: []string{`C:\Games\Test`}},
-				},
-			},
-		},
-		{
-			name:  "quoted arg with unescaped backslash",
-			input: `**path:"C:\Games\Test"`,
-			want: parser.Script{
-				Cmds: []parser.Command{
-					{Name: "path", Args: []string{`C:\Games\Test`}},
+					{Name: "path", Args: []string{`C:%\Games%\Test`}},
 				},
 			},
 		},
@@ -598,10 +589,10 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "quoted val in adv args with escaped quote",
-			input: `**cfg?note="he said \"hello\""`,
+			input: `**cfg?note="he said "hello""`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "cfg", AdvArgs: map[string]string{"note": `he said "hello"`}},
+					{Name: "cfg", AdvArgs: map[string]string{"note": `he said hello""`}},
 				},
 			},
 		},
@@ -625,19 +616,19 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped and quoted together",
-			input: `**weird:"hello\, world",foo\|bar`,
+			input: `**weird:"hello%, world",foo%|bar`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "weird", Args: []string{"hello\\, world", "foo|bar"}},
+					{Name: "weird", Args: []string{"hello%, world", "foo|bar"}},
 				},
 			},
 		},
 		{
 			name:  "quoted and escaped mix",
-			input: `**mix:"a\,b",c\,d,e\|f,"g\"h"`,
+			input: `**mix:"a%,b",c%,d,e%|f,"g%"h"`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "mix", Args: []string{"a\\,b", "c,d", "e|f", `g"h`}},
+					{Name: "mix", Args: []string{"a%,b", "c,d", "e|f", `g%h"`}},
 				},
 			},
 		},
@@ -652,16 +643,16 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "escaped trailing special chars",
-			input: `**data:end\,\|\?\\`,
+			input: `**data:end%,%|%?%%`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "data", Args: []string{"end,|?\\"}},
+					{Name: "data", Args: []string{"end,|?%"}},
 				},
 			},
 		},
 		{
 			name:  "run http.get",
-			input: `**http.get:https://zapa.roo/stuff\?id=5`,
+			input: `**http.get:https://zapa.roo/stuff%?id=5`,
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "http.get", Args: []string{`https://zapa.roo/stuff?id=5`}},
@@ -679,19 +670,12 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:  "quoted value with escaped quote and equals",
-			input: `**info?text="he said \"foo=bar\""`,
+			input: `**info?text="he said %"foo=bar%""`,
 			want: parser.Script{
 				Cmds: []parser.Command{
-					{Name: "info", AdvArgs: map[string]string{"text": `he said "foo=bar"`}},
-				},
-			},
-		},
-		{
-			name:  "quoted path with trailing escaped backslash",
-			input: `"C:\\Games\\End\\"`,
-			want: parser.Script{
-				Cmds: []parser.Command{
-					{Name: "launch", Args: []string{`C:\Games\End\`}},
+					{Name: "info", AdvArgs: map[string]string{
+						"text": `he said %foo=bar""`,
+					}},
 				},
 			},
 		},
@@ -701,6 +685,136 @@ func TestParse(t *testing.T) {
 			want: parser.Script{
 				Cmds: []parser.Command{
 					{Name: "launch", Args: []string{"game.exe"}, AdvArgs: map[string]string{"{bad}": ""}},
+				},
+			},
+		},
+		{
+			name:    "empty script",
+			input:   "",
+			want:    parser.Script{},
+			wantErr: parser.ErrEmptyZapScript,
+		},
+		{
+			name:    "empty command name",
+			input:   "**",
+			want:    parser.Script{},
+			wantErr: parser.ErrEmptyCmdName,
+		},
+		{
+			name:  "advanced args only",
+			input: `**config?key1=val1&key2=val2`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "config",
+						AdvArgs: map[string]string{
+							"key1": "val1",
+							"key2": "val2",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "mixed args and advanced args",
+			input: `**do:foo,bar?flag=on&mode=test`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name:    "do",
+						Args:    []string{"foo", "bar"},
+						AdvArgs: map[string]string{"flag": "on", "mode": "test"},
+					},
+				},
+			},
+		},
+		{
+			name:  "quoted argument with comma",
+			input: `**echo:"foo,bar",baz`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "echo",
+						Args: []string{`foo,bar`, "baz"},
+					},
+				},
+			},
+		},
+		{
+			name:    "unmatched quote in argument",
+			input:   `**bad:"abc,def`,
+			want:    parser.Script{},
+			wantErr: parser.ErrUnmatchedQuote,
+		},
+		{
+			name:  "command with escape sequences",
+			input: `**say:hello%|world`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "say",
+						Args: []string{"hello|world"},
+					},
+				},
+			},
+		},
+		{
+			name:  "multiple commands with mix of args and adv args",
+			input: `**a:1,2?x=1&y=2||**b?f=ok||**c`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name:    "a",
+						Args:    []string{"1", "2"},
+						AdvArgs: map[string]string{"x": "1", "y": "2"},
+					},
+					{
+						Name:    "b",
+						AdvArgs: map[string]string{"f": "ok"},
+					},
+					{
+						Name: "c",
+					},
+				},
+			},
+		},
+		{
+			name:  "generic launch with bad name",
+			input: `C:\some\path\100% completed\file.exe`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "launch",
+						Args: []string{"C:\\some\\path\\100 completed\\file.exe"},
+					},
+				},
+			},
+		},
+		{
+			name:  "generic launch with escaped bad name",
+			input: `C:\some\path\100%% completed\file.exe`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "launch",
+						Args: []string{"C:\\some\\path\\100% completed\\file.exe"},
+					},
+				},
+			},
+		},
+		{
+			name:  "generic launch with escaped bad name",
+			input: `C:\some\path\200%% completed\file.exe||C:\some 200%%\path\100%% completed\file.exe`,
+			want: parser.Script{
+				Cmds: []parser.Command{
+					{
+						Name: "launch",
+						Args: []string{"C:\\some\\path\\200% completed\\file.exe"},
+					},
+					{
+						Name: "launch",
+						Args: []string{"C:\\some 200%\\path\\100% completed\\file.exe"},
+					},
 				},
 			},
 		},

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -131,6 +131,7 @@ func readPlsFile(path string) ([]playlists.PlaylistMedia, error) {
 			testFile := filepath.Base(entry.file)
 
 			// check name without advanced args if they're there
+			// TODO: use parser
 			if strings.Contains(testFile, "?") {
 				last := strings.LastIndex(testFile, "?")
 				noArgs := testFile[:last]
@@ -205,7 +206,13 @@ func readPlaylistFolder(path string) ([]playlists.PlaylistMedia, error) {
 }
 
 func loadPlaylist(pl platforms.Platform, env platforms.CmdEnv) (*playlists.Playlist, error) {
-	path, err := findFile(pl, env.Cfg, env.Args)
+	if len(env.Cmd.Args) == 0 {
+		return nil, ErrArgCount
+	} else if env.Cmd.Args[0] == "" {
+		return nil, ErrRequiredArgs
+	}
+
+	path, err := findFile(pl, env.Cfg, env.Cmd.Args[0])
 	if err != nil {
 		return nil, err
 	}
@@ -223,8 +230,8 @@ func loadPlaylist(pl platforms.Platform, env platforms.CmdEnv) (*playlists.Playl
 		}
 	}
 
-	if v, ok := env.NamedArgs["mode"]; ok && strings.EqualFold(v, "shuffle") {
-		log.Info().Msgf("shuffling playlist: %s", env.Args)
+	if v, ok := env.Cmd.AdvArgs["mode"]; ok && strings.EqualFold(v, "shuffle") {
+		log.Info().Msgf("shuffling playlist: %s", env.Cmd.Args[0])
 		if len(media) == 0 {
 			log.Warn().Msgf("playlist is empty: %s", path)
 		} else {
@@ -234,11 +241,12 @@ func loadPlaylist(pl platforms.Platform, env platforms.CmdEnv) (*playlists.Playl
 		}
 	}
 
-	return playlists.NewPlaylist(env.Args, media), nil
+	return playlists.NewPlaylist(env.Cmd.Args[0], media), nil
 }
 
 func cmdPlaylistPlay(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
-	if env.Playlist.Active != nil && env.Args == "" {
+	if env.Playlist.Active != nil &&
+		(len(env.Cmd.Args) == 0 || env.Cmd.Args[0] == "") {
 		log.Info().Msg("starting paused playlist")
 		pls := playlists.Play(*env.Playlist.Active)
 		env.Playlist.Queue <- pls
@@ -253,7 +261,7 @@ func cmdPlaylistPlay(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 		return platforms.CmdResult{}, err
 	}
 
-	log.Info().Any("media", pls.Media).Msgf("play playlist: %s", env.Args)
+	log.Info().Any("media", pls.Media).Msgf("play playlist: %v", env.Cmd.Args)
 	pls = playlists.Play(*pls)
 	env.Playlist.Queue <- pls
 
@@ -269,7 +277,7 @@ func cmdPlaylistLoad(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 		return platforms.CmdResult{}, err
 	}
 
-	log.Info().Any("media", pls.Media).Msgf("load playlist: %s", env.Args)
+	log.Info().Any("media", pls.Media).Msgf("load playlist: %s", env.Cmd.Args)
 	env.Playlist.Queue <- pls
 
 	return platforms.CmdResult{
@@ -289,7 +297,7 @@ func cmdPlaylistOpen(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 		pls.Index = env.Playlist.Active.Index
 	}
 
-	log.Info().Any("media", pls.Media).Msgf("open playlist: %s", env.Args)
+	log.Info().Any("media", pls.Media).Msgf("open playlist: %s", env.Cmd.Args)
 	env.Playlist.Queue <- pls
 
 	var items []models.ZapScript
@@ -370,7 +378,11 @@ func cmdPlaylistGoto(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdR
 		return platforms.CmdResult{}, fmt.Errorf("no playlist active")
 	}
 
-	index, err := strconv.Atoi(env.Args)
+	if len(env.Cmd.Args) == 0 {
+		return platforms.CmdResult{}, ErrArgCount
+	}
+
+	index, err := strconv.Atoi(env.Cmd.Args[0])
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}


### PR DESCRIPTION
This is the first revision of an actual ZapScript parser which converts a string of ZapScript into a struct. This will let us test it, convert ZapScript to/from JSON or whatever other formats, plus extend it with new features and syntax.

- [x] Add support for parsing advanced arguments
- [x] Add minor support for escaping argument characters
- [x] Add support for quoting arguments
- [ ] Create Script object with combined args and advanced args (using position metadata on struct)
- [ ] Convert reader and zapscript functions to use the parser
- [ ] Link the run.script api method back to the input queue