### PR TITLE
Add expression support in ZapScript

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d // indirect
 	github.com/creack/goselect v0.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/expr-lang/expr v1.17.5 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/ebfe/scard v0.0.0-20230420082256-7db3f9b7c8a7 h1:HYAhfGa9dEemCZgGZWL5AvVsctBCsHxl2CI0HUXzHQE=
 github.com/ebfe/scard v0.0.0-20230420082256-7db3f9b7c8a7/go.mod h1:BkYEeWL6FbT4Ek+TcOBnPzEKnL7kOq2g19tTQXkorHY=
+github.com/expr-lang/expr v1.17.5 h1:i1WrMvcdLF249nSNlpQZN1S6NXuW9WaOfF5tPi3aw3k=
+github.com/expr-lang/expr v1.17.5/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -33,7 +33,7 @@ import (
 
 var JSONRPCErrorParseError = models.ErrorObject{
 	Code:    -32700,
-	Message: "Parse error",
+	Message: "ParseScript error",
 }
 var JSONRPCErrorInvalidRequest = models.ErrorObject{
 	Code:    -32600,

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -34,8 +34,8 @@ func runTokenZapScript(
 		token.Text = mappedValue
 	}
 
-	reader := parser.NewScriptReader(token.Text)
-	script, err := reader.Parse()
+	reader := parser.NewParser(token.Text)
+	script, err := reader.ParseScript()
 	if err != nil {
 		return err
 	}

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -46,17 +46,14 @@ func runTokenZapScript(
 
 	for i, cmd := range script.Cmds {
 		result, err := zapscript.RunCommand(
-			platform,
-			cfg,
+			platform, cfg,
 			playlists.PlaylistController{
 				Active: pls,
 				Queue:  plsc.Queue,
 			},
-			token,
-			cmd,
-			len(script.Cmds),
-			i,
-			db,
+			token, cmd,
+			len(script.Cmds), i,
+			db, st,
 		)
 		if err != nil {
 			return err

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -203,6 +203,13 @@ func RunCommand(
 		cmd.AdvArgs[k] = output
 	}
 
+	if when, ok := cmd.AdvArgs["when"]; ok {
+		if !strings.EqualFold(when, "true") && !strings.EqualFold(when, "yes") {
+			log.Debug().Msgf("skipping command, does not meet when criteria: %s", cmd)
+			return platforms.CmdResult{}, nil
+		}
+	}
+
 	env := platforms.CmdEnv{
 		Cmd:           cmd,
 		Cfg:           cfg,

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -149,8 +149,8 @@ func RunCommand(
 		log.Error().Err(err).Msgf("error checking link, continuing")
 	} else if linkValue != "" {
 		log.Info().Msgf("valid zap link, replacing cmd: %s", linkValue)
-		reader := parser.NewScriptReader(linkValue)
-		script, err := reader.Parse()
+		reader := parser.NewParser(linkValue)
+		script, err := reader.ParseScript()
 		if err != nil {
 			return platforms.CmdResult{}, fmt.Errorf("error parsing zap link: %w", err)
 		} else if len(script.Cmds) == 0 {

--- a/pkg/zapscript/parser/parser.go
+++ b/pkg/zapscript/parser/parser.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/expr-lang/expr"
 	"io"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -23,6 +25,7 @@ var (
 	ErrInvalidJSON            = errors.New("invalid JSON argument")
 	ErrUnmatchedInputMacroExt = errors.New("unmatched input macro extension")
 	ErrUnmatchedExpression    = errors.New("unmatched expression")
+	ErrBadExpressionReturn    = errors.New("expression return type not supported")
 )
 
 const (
@@ -57,6 +60,19 @@ type Script struct {
 	Cmds []Command
 }
 
+type PostArgPartType int
+
+const (
+	ArgPartTypeUnknown PostArgPartType = iota
+	ArgPartTypeString
+	ArgPartTypeExpression
+)
+
+type PostArgPart struct {
+	Type  PostArgPartType
+	Value string
+}
+
 func isCmdName(ch rune) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '.'
 }
@@ -86,9 +102,9 @@ type ScriptReader struct {
 	pos int64
 }
 
-func NewScriptReader(script string) *ScriptReader {
+func NewParser(value string) *ScriptReader {
 	return &ScriptReader{
-		r: bufio.NewReader(bytes.NewReader([]byte(script))),
+		r: bufio.NewReader(bytes.NewReader([]byte(value))),
 	}
 }
 
@@ -179,43 +195,60 @@ func (sr *ScriptReader) parseQuotedArg(start rune) (string, error) {
 	return arg, nil
 }
 
-func (sr *ScriptReader) parseExpression() (string, error) {
-	expr := string(SymExpressionStart)
+func (sr *ScriptReader) parseExpression(outputBrackets bool) (string, error) {
+	rawExpr := ""
+	if outputBrackets {
+		rawExpr = string(SymExpressionStart)
+	}
 
-	next, err := sr.peek()
+	next, err := sr.read()
 	if err != nil {
-		return expr, err
+		return rawExpr, err
 	} else if next != SymExpressionStart {
-		return expr, nil
+		err := sr.unread()
+		if err != nil {
+			return rawExpr, err
+		}
+		return rawExpr, nil
+	}
+
+	if outputBrackets {
+		rawExpr = rawExpr + string(SymExpressionStart)
 	}
 
 	for {
 		ch, err := sr.read()
 		if err != nil {
-			return expr, err
+			return rawExpr, err
 		} else if ch == eof {
-			return expr, ErrUnmatchedExpression
+			return rawExpr, ErrUnmatchedExpression
 		}
 
 		if ch == SymExpressionEnd {
 			next, err := sr.peek()
 			if err != nil {
-				return expr, err
+				return rawExpr, err
 			} else if next == SymExpressionEnd {
-				expr = expr + string(SymExpressionEnd)
-				expr = expr + string(SymExpressionEnd)
+				if outputBrackets {
+					rawExpr = rawExpr + string(SymExpressionEnd)
+					rawExpr = rawExpr + string(SymExpressionEnd)
+				}
 				err := sr.skip()
 				if err != nil {
-					return expr, err
+					return rawExpr, err
 				}
 				break
 			}
 		}
 
-		expr = expr + string(ch)
+		rawExpr = rawExpr + string(ch)
 	}
 
-	return expr, nil
+	if !outputBrackets {
+		rawExpr = strings.TrimSpace(rawExpr)
+	}
+
+	return rawExpr, nil
 }
 
 func (sr *ScriptReader) parseJSONArg() (string, error) {
@@ -423,7 +456,7 @@ func (sr *ScriptReader) parseAdvArgs() (map[string]string, string, error) {
 
 		if inValue {
 			if ch == SymExpressionStart {
-				exprValue, err := sr.parseExpression()
+				exprValue, err := sr.parseExpression(true)
 				if err != nil {
 					return advArgs, string(buf), err
 				}
@@ -522,7 +555,7 @@ func (sr *ScriptReader) parseArgs(
 			// advanced args are always the last part of a command
 			break
 		} else if ch == SymExpressionStart {
-			exprValue, err := sr.parseExpression()
+			exprValue, err := sr.parseExpression(true)
 			if err != nil {
 				return args, advArgs, err
 			}
@@ -622,7 +655,7 @@ func (sr *ScriptReader) parseCommand(onlyOneArg bool) (Command, string, error) {
 	return cmd, string(buf), nil
 }
 
-func (sr *ScriptReader) Parse() (Script, error) {
+func (sr *ScriptReader) ParseScript() (Script, error) {
 	script := Script{}
 
 	parseErr := func(err error) error {
@@ -715,4 +748,72 @@ func (sr *ScriptReader) Parse() (Script, error) {
 	}
 
 	return script, nil
+}
+
+func (sr *ScriptReader) PostProcess(exprEnv map[string]any) (string, error) {
+	parts := make([]PostArgPart, 0)
+	currentPart := PostArgPart{}
+
+	for {
+		ch, err := sr.read()
+		if err != nil {
+			return "", err
+		} else if ch == eof {
+			break
+		}
+
+		if ch == SymExpressionStart {
+			if currentPart.Type != ArgPartTypeUnknown {
+				parts = append(parts, currentPart)
+				currentPart = PostArgPart{}
+			}
+
+			currentPart.Type = ArgPartTypeExpression
+			exprValue, err := sr.parseExpression(false)
+			if err != nil {
+				return "", err
+			}
+			currentPart.Value = exprValue
+
+			parts = append(parts, currentPart)
+			currentPart = PostArgPart{}
+
+			continue
+		} else {
+			currentPart.Type = ArgPartTypeString
+			currentPart.Value = currentPart.Value + string(ch)
+			continue
+		}
+	}
+
+	if currentPart.Type != ArgPartTypeUnknown {
+		parts = append(parts, currentPart)
+	}
+
+	arg := ""
+	for _, part := range parts {
+		if part.Type == ArgPartTypeExpression {
+			output, err := expr.Eval(part.Value, exprEnv)
+			if err != nil {
+				return "", err
+			}
+
+			switch v := output.(type) {
+			case string:
+				arg = arg + v
+			case bool:
+				arg = arg + strconv.FormatBool(v)
+			case int:
+				arg = arg + strconv.Itoa(v)
+			case float64:
+				arg = arg + strconv.FormatFloat(v, 'f', -1, 64)
+			default:
+				return "", fmt.Errorf("%w: %v (%T)", ErrBadExpressionReturn, v, v)
+			}
+		} else {
+			arg = arg + part.Value
+		}
+	}
+
+	return arg, nil
 }


### PR DESCRIPTION
Adds support for processing expression blocks in ZapScript using the Golang expr library. If an expression block (`[[...]]`) is encountered anywhere in a position arg or advanced arg, the expression will be evaluated and contents replaced with the result as a string. Also added a global "when" advanced arg which will only allow a command to run if the expression evaluates to true.