### PR TITLE
Update platform.go

### DIFF
--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -164,7 +164,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			ID:         "KodiLocal",
 			SystemID:   systemdefs.SystemVideo,
 			Folders:    []string{"videos", "tvshows"},
-			Extensions: []string{".avi", ".mp4", ".mkv"},
+			Extensions: []string{".avi", ".mp4", ".mkv", ".iso", ".bdmv", ".ifo"},
 			Launch:     kodiLaunchFileRequest,
 		},
 		{


### PR DESCRIPTION
Added more extensions to KodiLocal for the CoreElec/LibreElec platform

- ISO (Disc images)
- BDMV (BD-Disc Folder)
- IFO (DVD-Disc Folder)

in case of BDMV and IFO it would be better if it only scanned the exact files (index.bdmv for BD and VIDEO_TS.ifo for DVD) but i don't know how to specify an exact filename.