### PR TITLE
Add Batocera pacman package support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.5'
+          go-version: "1.24.5"
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -40,7 +40,7 @@ jobs:
               --title="${tag}" \
               --draft \
               --generate-notes
-      
+
   build:
     runs-on: ubuntu-latest
     needs: create-release
@@ -131,6 +131,21 @@ jobs:
         if: matrix.platform == 'windows'
         run: |
           gh release upload "$tag" _build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe
+      - name: Add Batocera package
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        if: matrix.platform == 'batocera'
+        run: |
+          # Map build arch to package arch
+          case "${{matrix.arch}}" in
+            amd64) PKG_ARCH="x86_64" ;;
+            arm64) PKG_ARCH="aarch64" ;;
+            arm) PKG_ARCH="armv7l" ;;
+          esac
+          mkdir -p _build/packages/batocera
+          BUILD_ARCH=${{matrix.arch}} PKG_ARCH=${PKG_ARCH} VERSION=${VERSION} task batocera:package-arch
+          gh release upload "$tag" _build/packages/batocera/zaparoo-core-${VERSION}-${PKG_ARCH}.pkg.tar.zst
 
   publish-release:
     runs-on: ubuntu-latest

--- a/scripts/batocera/template/.BATOEXEC
+++ b/scripts/batocera/template/.BATOEXEC
@@ -1,0 +1,13 @@
+exec = /bin/bash
+.INSTALL_START
+echo "Installing Zaparoo Core service..."
+batocera-services enable zaparoo_service
+batocera-services start zaparoo_service
+echo "Zaparoo Core installed and service enabled."
+.INSTALL_END
+.UNINSTALL_START
+echo "Uninstalling Zaparoo Core service..."
+batocera-services disable zaparoo_service
+batocera-services stop zaparoo_service
+echo "Zaparoo Core service stopped and disabled."
+.UNINSTALL_END

--- a/scripts/batocera/template/.PKGINFO
+++ b/scripts/batocera/template/.PKGINFO
@@ -1,0 +1,7 @@
+pkgname = zaparoo-core
+pkgver = __VERSION__-1
+pkgdesc = Zaparoo Core - Launch media using physical objects like NFC cards
+arch = __ARCH__
+group = sys
+packager = Zaparoo Project
+url = https://github.com/ZaparooProject/zaparoo-core

--- a/scripts/batocera/template/userdata/system/services/zaparoo_service
+++ b/scripts/batocera/template/userdata/system/services/zaparoo_service
@@ -1,0 +1,2 @@
+#!/bin/bash
+/userdata/system/zaparoo -service "$1"

--- a/scripts/tasks/batocera.yml
+++ b/scripts/tasks/batocera.yml
@@ -22,6 +22,69 @@ tasks:
         vars:
           PLATFORM: batocera
 
+  package:
+    desc: Build Batocera pacman packages for all architectures
+    deps: [build-amd64, build-arm64, build-arm]
+    vars:
+      TEMPLATE_DIR: scripts/batocera/template
+      BUILD_DIR: _build/packages/batocera
+    cmds:
+      - rm -rf {{.BUILD_DIR}}
+      - mkdir -p {{.BUILD_DIR}}
+      - task: package-arch
+        vars:
+          BUILD_ARCH: amd64
+          PKG_ARCH: x86_64
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          TEMPLATE_DIR: "{{.TEMPLATE_DIR}}"
+          VERSION: "{{.APP_VERSION}}"
+      - task: package-arch
+        vars:
+          BUILD_ARCH: arm64
+          PKG_ARCH: aarch64
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          TEMPLATE_DIR: "{{.TEMPLATE_DIR}}"
+          VERSION: "{{.APP_VERSION}}"
+      - task: package-arch
+        vars:
+          BUILD_ARCH: arm
+          PKG_ARCH: armv7l
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          TEMPLATE_DIR: "{{.TEMPLATE_DIR}}"
+          VERSION: "{{.APP_VERSION}}"
+      - echo "Packages created in {{.BUILD_DIR}}:"
+      - ls -la {{.BUILD_DIR}}/*.pkg.tar.zst
+
+  package-arch:
+    desc: Build Batocera pacman package for specific architecture
+    vars:
+      BUILD_DIR: '{{.BUILD_DIR | default "_build/packages/batocera"}}'
+      TEMPLATE_DIR: '{{.TEMPLATE_DIR | default "scripts/batocera/template"}}'
+      PACKAGE_NAME: zaparoo-core-{{.VERSION}}-{{.PKG_ARCH}}
+      PACKAGE_DIR: "{{.BUILD_DIR}}/{{.PACKAGE_NAME}}"
+    cmds:
+      - echo "Creating package for {{.PKG_ARCH}}..."
+      - mkdir -p {{.PACKAGE_DIR}}/userdata/system/services
+      - cp -r {{.TEMPLATE_DIR}}/. {{.PACKAGE_DIR}}/
+      - cp _build/batocera_{{.BUILD_ARCH}}/zaparoo {{.PACKAGE_DIR}}/userdata/system/
+      - sed -i "s/__VERSION__/{{.VERSION}}/g" {{.PACKAGE_DIR}}/.PKGINFO
+      - sed -i "s/__ARCH__/{{.PKG_ARCH}}/g" {{.PACKAGE_DIR}}/.PKGINFO
+      - chmod +x {{.PACKAGE_DIR}}/userdata/system/zaparoo
+      - chmod +x {{.PACKAGE_DIR}}/userdata/system/services/zaparoo_service
+      - task: create-package
+        vars:
+          PACKAGE_DIR: "{{.PACKAGE_DIR}}"
+          PACKAGE_NAME: "{{.PACKAGE_NAME}}"
+          BUILD_DIR: "{{.BUILD_DIR}}"
+
+  create-package:
+    internal: true
+    dir: "{{.PACKAGE_DIR}}"
+    cmds:
+      - echo "Creating package manually..."
+      - tar -cf - .PKGINFO .BATOEXEC userdata | zstd -c --rsyncable - -o "../{{.PACKAGE_NAME}}.pkg.tar.zst"
+      - chmod go+r "../{{.PACKAGE_NAME}}.pkg.tar.zst"
+
   deploy:
     cmds:
       - task: build-{{.CLI_ARGS}}


### PR DESCRIPTION
## Summary
- Implement Batocera pacman package generation with multi-architecture support
- Add CI automation to build and distribute packages on GitHub releases
- Package provides one-click installation via Batocera's content downloader

## Changes
- Add package templates (.PKGINFO, .BATOEXEC) with install/uninstall scripts
- Implement `batocera:package` and `batocera:package-arch` tasks
- Update CI workflow to generate packages for x86_64, aarch64, armv7l architectures
- Package installs to /userdata/system/ with proper service integration