### PR TITLE
Update go-pn532 to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	fyne.io/systray v1.11.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/TimDeve/valve-vdf-binary v0.0.1
-	github.com/ZaparooProject/go-pn532 v0.8.0
+	github.com/ZaparooProject/go-pn532 v0.8.1
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0
 	github.com/bendahl/uinput v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/ZaparooProject/go-pn532 v0.7.1-0.20250917004052-1cb75dc9edba h1:M9hdc
 github.com/ZaparooProject/go-pn532 v0.7.1-0.20250917004052-1cb75dc9edba/go.mod h1:leyLRF6grVBRfuyo5oI+zRbzsdDvZlgjiOyGE4RhYqQ=
 github.com/ZaparooProject/go-pn532 v0.8.0 h1:HmRcY2VI0gtM6xqJ6LUHaivHO6WxwCiGbhx7UQWIENA=
 github.com/ZaparooProject/go-pn532 v0.8.0/go.mod h1:leyLRF6grVBRfuyo5oI+zRbzsdDvZlgjiOyGE4RhYqQ=
+github.com/ZaparooProject/go-pn532 v0.8.1 h1:Ve0QzWHNjsgnRCU7d4IX+DFHEU7mbDxc1nJSD64iuP0=
+github.com/ZaparooProject/go-pn532 v0.8.1/go.mod h1:leyLRF6grVBRfuyo5oI+zRbzsdDvZlgjiOyGE4RhYqQ=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/andygrunwald/vdf v1.1.0 h1:gmstp0R7DOepIZvWoSJY97ix7QOrsxpGPU6KusKXqvw=


### PR DESCRIPTION
## Summary
- Updates ZaparooProject/go-pn532 dependency from v0.8.0 to v0.8.1

## Test plan
- [x] All tests pass
- [x] No breaking changes detected