### PR TITLE
fix(mister): correct alt-core RBF paths and add fuzzy system ID matching

### DIFF
--- a/pkg/config/configsystems.go
+++ b/pkg/config/configsystems.go
@@ -19,7 +19,11 @@
 
 package config
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+)
 
 type Systems struct {
 	Default []SystemsDefault `toml:"default,omitempty"`
@@ -41,7 +45,11 @@ func (c *Instance) LookupSystemDefaults(systemID string) (SystemsDefault, bool) 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	for _, defaultSystem := range c.vals.Systems.Default {
-		if strings.EqualFold(defaultSystem.System, systemID) {
+		configSystem, err := systemdefs.LookupSystem(defaultSystem.System)
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(configSystem.ID, systemID) {
 			return defaultSystem, true
 		}
 	}

--- a/pkg/config/configsystems_test.go
+++ b/pkg/config/configsystems_test.go
@@ -1,0 +1,187 @@
+// Zaparoo Core
+// Copyright (c) 2025 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupSystemDefaultsFuzzyMatching(t *testing.T) {
+	t.Parallel()
+
+	// Create instance with system defaults using aliases
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{
+						System:   "megadrive", // Alias for Genesis
+						Launcher: "retroarch",
+					},
+					{
+						System:   "N64", // Alias for Nintendo64
+						Launcher: "mupen64plus",
+					},
+					{
+						System:     "playstation", // Alias for PSX
+						Launcher:   "duckstation",
+						BeforeExit: "cleanup.sh",
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name             string
+		systemID         string
+		expectedLauncher string
+		expectFound      bool
+	}{
+		{
+			name:             "canonical ID matches alias in config (Genesis via megadrive)",
+			systemID:         "Genesis",
+			expectFound:      true,
+			expectedLauncher: "retroarch",
+		},
+		{
+			name:             "canonical ID matches alias in config (Nintendo64 via N64)",
+			systemID:         "Nintendo64",
+			expectFound:      true,
+			expectedLauncher: "mupen64plus",
+		},
+		{
+			name:             "canonical ID matches alias in config (PSX via playstation)",
+			systemID:         "PSX",
+			expectFound:      true,
+			expectedLauncher: "duckstation",
+		},
+		{
+			name:        "system not in defaults returns false",
+			systemID:    "NES",
+			expectFound: false,
+		},
+		{
+			name:        "unknown system ID returns false",
+			systemID:    "UnknownSystem",
+			expectFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, found := cfg.LookupSystemDefaults(tt.systemID)
+			assert.Equal(t, tt.expectFound, found)
+			if tt.expectFound {
+				assert.Equal(t, tt.expectedLauncher, result.Launcher)
+			}
+		})
+	}
+}
+
+func TestLookupSystemDefaultsWithInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	// Create instance with invalid system IDs in the defaults
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{
+						System:   "InvalidSystemID",
+						Launcher: "should-not-match",
+					},
+					{
+						System:   "AnotherBadID",
+						Launcher: "also-should-not-match",
+					},
+					{
+						System:   "Genesis", // One valid entry
+						Launcher: "valid-launcher",
+					},
+				},
+			},
+		},
+	}
+
+	// Should still match Genesis despite invalid entries
+	result, found := cfg.LookupSystemDefaults("Genesis")
+	assert.True(t, found)
+	assert.Equal(t, "valid-launcher", result.Launcher)
+
+	// Invalid entries should not cause matches
+	_, found = cfg.LookupSystemDefaults("InvalidSystemID")
+	assert.False(t, found)
+}
+
+func TestLookupSystemDefaultsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	// Create instance with mixed case system IDs
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{
+						System:   "GENESIS", // Uppercase canonical ID
+						Launcher: "uppercase-launcher",
+					},
+				},
+			},
+		},
+	}
+
+	// Should match regardless of case in the lookup
+	result, found := cfg.LookupSystemDefaults("Genesis")
+	assert.True(t, found)
+	assert.Equal(t, "uppercase-launcher", result.Launcher)
+
+	result, found = cfg.LookupSystemDefaults("genesis")
+	assert.True(t, found)
+	assert.Equal(t, "uppercase-launcher", result.Launcher)
+}
+
+func TestLookupSystemDefaultsReturnsCorrectFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{
+						System:     "SMS", // Alias for MasterSystem
+						Launcher:   "retroarch",
+						BeforeExit: "echo 'goodbye'",
+					},
+				},
+			},
+		},
+	}
+
+	result, found := cfg.LookupSystemDefaults("MasterSystem")
+	assert.True(t, found)
+	assert.Equal(t, "SMS", result.System) // Original config value preserved
+	assert.Equal(t, "retroarch", result.Launcher)
+	assert.Equal(t, "echo 'goodbye'", result.BeforeExit)
+}

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -939,7 +939,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "80MHzNintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_Console/N64_80MHz"),
+			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_Other/N64_80MHz"),
 		},
 		{
 			ID:       "PWMNintendo64",
@@ -992,7 +992,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "2XPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_Console/PSX2XCPU"),
+			Launch:   launchAltCore(systemdefs.SystemPSX, "_Other/PSX2XCPU"),
 		},
 		{
 			ID:       "PWMPSX",


### PR DESCRIPTION
## Summary

Fixes two issues reported by MiSTer users:

- **Wrong RBF paths**: The `80MHzNintendo64` and `2XPSX` alt-core launchers had incorrect hardcoded paths pointing to `_Console/` instead of `_Other/`
- **Config system ID matching**: The `[[systems.default]]` and `ignore_system` config options now use `systemdefs.LookupSystem` for fuzzy matching, supporting aliases like "megadrive" → Genesis, "N64" → Nintendo64, etc.

## Changes

- Fix `80MHzNintendo64` RBF path: `_Console/N64_80MHz` → `_Other/N64_80MHz`
- Fix `2XPSX` RBF path: `_Console/PSX2XCPU` → `_Other/PSX2XCPU`
- Update `LookupSystemDefaults()` to use `systemdefs.LookupSystem` for alias resolution
- Update `IsHoldModeIgnoredSystem()` to use `systemdefs.LookupSystem` for alias resolution
- Add regression tests for fuzzy system ID matching