### PR TITLE
ci: fix Windows Go cache paths not being set

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -61,12 +61,14 @@ jobs:
 
       - name: Configure Go paths for Windows
         if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: |
-          {
-            echo "GOCACHE=D:\go-cache"
-            echo "GOMODCACHE=D:\go-mod-cache"
-            echo "GOTMPDIR=D:\go-tmp"
-          } >> "$GITHUB_ENV"
+          New-Item -ItemType Directory -Force -Path "D:\go-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-mod-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-tmp" | Out-Null
+          Add-Content -Path $env:GITHUB_ENV -Value "GOCACHE=D:\go-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'
@@ -135,12 +137,14 @@ jobs:
 
       - name: Configure Go paths for Windows
         if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: |
-          {
-            echo "GOCACHE=D:\go-cache"
-            echo "GOMODCACHE=D:\go-mod-cache"
-            echo "GOTMPDIR=D:\go-tmp"
-          } >> "$GITHUB_ENV"
+          New-Item -ItemType Directory -Force -Path "D:\go-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-mod-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-tmp" | Out-Null
+          Add-Content -Path $env:GITHUB_ENV -Value "GOCACHE=D:\go-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'
@@ -230,12 +234,14 @@ jobs:
 
       - name: Configure Go paths for Windows
         if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: |
-          {
-            echo "GOCACHE=D:\go-cache"
-            echo "GOMODCACHE=D:\go-mod-cache"
-            echo "GOTMPDIR=D:\go-tmp"
-          } >> "$GITHUB_ENV"
+          New-Item -ItemType Directory -Force -Path "D:\go-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-mod-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-tmp" | Out-Null
+          Add-Content -Path $env:GITHUB_ENV -Value "GOCACHE=D:\go-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
## Summary

- Fixes Windows CI taking 8+ minutes due to missing Go module/build cache
- The `$GITHUB_ENV` bash syntax doesn't work in PowerShell - env vars were never set
- Go was using default C:\ paths while cache actions tried to save non-existent D:\ paths
- Now uses proper PowerShell syntax (`Add-Content -Path $env:GITHUB_ENV`)
- Explicitly creates D:\ cache directories before use

After this fix, subsequent Windows CI runs should have cache hits and run much faster.