### PR TITLE
feat(ci): re-enable Windows code signing with release certificate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,12 +171,6 @@ jobs:
         env:
           GOFLAGS: "-buildvcs=false"
         run: APP_VERSION=${VERSION} task ${{matrix.platform}}:build-${{matrix.arch}}
-      # ============================================================================
-      # TODO: RE-ENABLE SIGNING WHEN PRODUCTION SIGNING ACCESS IS READY
-      # Uncomment the signing steps below and remove the unsigned upload steps
-      # ============================================================================
-
-      # --- Keep artifacts for when signing is re-enabled ---
       - name: Upload unsigned exe artifact
         if: matrix.platform == 'windows'
         id: upload-unsigned-exe
@@ -193,83 +187,63 @@ jobs:
           name: unsigned-installer-${{matrix.arch}}
           path: _build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe
           retention-days: 30
-
-      # --- TEMPORARILY DISABLED: Code signing steps ---
-      # - name: Copy installer to consistent name for signing
-      #   if: matrix.platform == 'windows'
-      #   run: |
-      #     cp "_build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe" \
-      #        "_build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe"
-      # - name: Sign exe file
-      #   if: matrix.platform == 'windows'
-      #   uses: signpath/github-action-submit-signing-request@v2
-      #   with:
-      #     api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-      #     organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
-      #     project-slug: 'zaparoo-core'
-      #     signing-policy-slug: '${{ inputs.test_build && ''test-signing'' || ''release-signing'' }}'
-      #     artifact-configuration-slug: 'windows-zip'
-      #     github-artifact-id: '${{ steps.upload-unsigned-exe.outputs.artifact-id }}'
-      #     wait-for-completion: true
-      #     output-artifact-directory: '_build/signed/exe_${{matrix.arch}}'
-      # - name: Sign installer EXE
-      #   if: matrix.platform == 'windows'
-      #   uses: signpath/github-action-submit-signing-request@v2
-      #   with:
-      #     api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-      #     organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
-      #     project-slug: 'zaparoo-core'
-      #     signing-policy-slug: '${{ inputs.test_build && ''test-signing'' || ''release-signing'' }}'
-      #     artifact-configuration-slug: 'windows-installer'
-      #     github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
-      #     wait-for-completion: true
-      #     output-artifact-directory: '_build/signed/installer_${{matrix.arch}}'
-      # - name: Rename signed installer back to versioned name
-      #   if: matrix.platform == 'windows'
-      #   run: |
-      #     mv "_build/signed/installer_${{matrix.arch}}/zaparoo-setup.exe" \
-      #        "_build/signed/installer_${{matrix.arch}}/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe"
-      # - name: Repackage distribution ZIP with signed exe
-      #   if: matrix.platform == 'windows'
-      #   run: |
-      #     # Replace unsigned exe with signed exe in build directory
-      #     cp "_build/signed/exe_${{matrix.arch}}/Zaparoo.exe" "_build/${{matrix.platform}}_${{matrix.arch}}/Zaparoo.exe"
-      #     # Recreate the distribution ZIP
-      #     APP_VERSION=${VERSION} go run scripts/tasks/utils/makezip/main.go \
-      #       ${{matrix.platform}} "_build/${{matrix.platform}}_${{matrix.arch}}" Zaparoo.exe \
-      #       "zaparoo-${{matrix.platform}}_${{matrix.arch}}-${VERSION}.zip"
-      # - name: Add signed ZIP to release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     tag: ${{ env.BUILD_TAG }}
-      #   if: matrix.platform == 'windows' && !inputs.test_build
-      #   run: |
-      #     gh release upload "$tag" "_build/${{matrix.platform}}_${{matrix.arch}}/zaparoo-${{matrix.platform}}_${{matrix.arch}}-${VERSION}.zip"
-      # - name: Add signed Windows installer to release
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     tag: ${{ env.BUILD_TAG }}
-      #   if: matrix.platform == 'windows' && !inputs.test_build
-      #   run: |
-      #     gh release upload "$tag" "_build/signed/installer_${{matrix.arch}}/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe"
-      # --- END TEMPORARILY DISABLED ---
-
-      # --- TEMPORARY: Upload unsigned Windows builds (remove when signing is re-enabled) ---
-      - name: Add unsigned ZIP to release (TEMPORARY - unsigned)
+      - name: Copy installer to consistent name for signing
+        if: matrix.platform == 'windows'
+        run: |
+          cp "_build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe" \
+             "_build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe"
+      - name: Sign exe file
+        if: matrix.platform == 'windows'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'zaparoo-core'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'windows-zip'
+          github-artifact-id: '${{ steps.upload-unsigned-exe.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '_build/signed/exe_${{matrix.arch}}'
+      - name: Sign installer EXE
+        if: matrix.platform == 'windows'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ secrets.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'zaparoo-core'
+          signing-policy-slug: 'release-signing'
+          artifact-configuration-slug: 'windows-installer'
+          github-artifact-id: '${{ steps.upload-unsigned-installer.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: '_build/signed/installer_${{matrix.arch}}'
+      - name: Rename signed installer back to versioned name
+        if: matrix.platform == 'windows'
+        run: |
+          mv "_build/signed/installer_${{matrix.arch}}/zaparoo-setup.exe" \
+             "_build/signed/installer_${{matrix.arch}}/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe"
+      - name: Repackage distribution ZIP with signed exe
+        if: matrix.platform == 'windows'
+        run: |
+          # Replace unsigned exe with signed exe in build directory
+          cp "_build/signed/exe_${{matrix.arch}}/Zaparoo.exe" "_build/${{matrix.platform}}_${{matrix.arch}}/Zaparoo.exe"
+          # Recreate the distribution ZIP
+          APP_VERSION=${VERSION} go run scripts/tasks/utils/makezip/main.go \
+            ${{matrix.platform}} "_build/${{matrix.platform}}_${{matrix.arch}}" Zaparoo.exe \
+            "zaparoo-${{matrix.platform}}_${{matrix.arch}}-${VERSION}.zip"
+      - name: Add signed ZIP to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.BUILD_TAG }}
         if: matrix.platform == 'windows' && !inputs.test_build
         run: |
           gh release upload "$tag" "_build/${{matrix.platform}}_${{matrix.arch}}/zaparoo-${{matrix.platform}}_${{matrix.arch}}-${VERSION}.zip" --clobber
-      - name: Add unsigned Windows installer to release (TEMPORARY - unsigned)
+      - name: Add signed Windows installer to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ env.BUILD_TAG }}
         if: matrix.platform == 'windows' && !inputs.test_build
         run: |
-          gh release upload "$tag" "_build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe" --clobber
-      # --- END TEMPORARY ---
+          gh release upload "$tag" "_build/signed/installer_${{matrix.arch}}/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe" --clobber
       - name: Add release (non-Windows)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ See the [Contributors](https://zaparoo.org/docs/community/contributors/) page fo
 </table>
 <!-- readme: contributors -end -->
 
+## Sponsors
+
+Free code signing on Windows provided by [SignPath.io](https://signpath.io), certificate by [SignPath Foundation](https://signpath.org)
+
 ## Trademarks
 
 This repository contains Zaparoo trademarks which are explicitly licensed to the project in this location by the trademark owner. These trademarks must be removed from the project or replaced if you intend to redistribute or adapt the project in any form. See the Zaparoo [Terms of Use](https://zaparoo.org/terms/) for further details.


### PR DESCRIPTION
## Summary

- Re-enable SignPath code signing for Windows builds in CI
- Use `release-signing` policy for production releases
- Add SignPath sponsor attribution to README per their open source terms