### PR TITLE
feat(ci): enable Bazzite and ChimeraOS as published release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,8 @@ jobs:
           - windows
           - mac
           - batocera
+          - bazzite
+          - chimeraos
           - linux
           - libreelec
         arch:


### PR DESCRIPTION
## Summary

- Add Bazzite and ChimeraOS to the CI build matrix for published releases
- Both platforms are complete and production-ready with full test coverage
- Build infrastructure (task files, entry points) already exists

## New Release Artifacts

This adds 4 new release artifacts to each release:
- `zaparoo-bazzite_amd64-{version}.tar.gz`
- `zaparoo-bazzite_arm64-{version}.tar.gz`
- `zaparoo-chimeraos_amd64-{version}.tar.gz`
- `zaparoo-chimeraos_arm64-{version}.tar.gz`