### PR TITLE
fix: add consistent panic recovery with stack traces across all platforms

### DIFF
--- a/cmd/bazzite/main.go
+++ b/cmd/bazzite/main.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/bazzite"
+	"github.com/rs/zerolog/log"
 )
 
 func main() {
@@ -43,6 +45,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	install := flag.String(
 		"install",
 		"",

--- a/cmd/chimeraos/main.go
+++ b/cmd/chimeraos/main.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/chimeraos"
+	"github.com/rs/zerolog/log"
 )
 
 func main() {
@@ -43,6 +45,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	install := flag.String(
 		"install",
 		"",

--- a/cmd/linux/main.go
+++ b/cmd/linux/main.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/linux"
+	"github.com/rs/zerolog/log"
 )
 
 func main() {
@@ -43,6 +45,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	install := flag.String(
 		"install",
 		"",

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
@@ -87,6 +88,18 @@ WantedBy=multi-user.target
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	flags := cli.SetupFlags()
 	serviceFlag := flag.String(
 		"service",

--- a/cmd/retropie/main.go
+++ b/cmd/retropie/main.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
@@ -48,6 +49,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	sigs := make(chan os.Signal, 1)
 	defer close(sigs)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/steamos/main.go
+++ b/cmd/steamos/main.go
@@ -30,12 +30,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config/migrate"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/steamos"
+	"github.com/rs/zerolog/log"
 )
 
 func main() {
@@ -46,6 +48,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	install := flag.String(
 		"install",
 		"",

--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/cli"
@@ -100,6 +101,18 @@ func main() {
 }
 
 func run() error {
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			_, _ = fmt.Fprintf(os.Stderr, "Panic: %v\n%s\n", r, stack)
+			log.Error().
+				Interface("panic", r).
+				Bytes("stack", stack).
+				Msg("recovered from panic")
+			os.Exit(1)
+		}
+	}()
+
 	pl := &windows.Platform{}
 	flags := cli.SetupFlags()
 
@@ -130,13 +143,6 @@ func run() error {
 		defaults,
 		logWriters,
 	)
-
-	defer func() {
-		if err := recover(); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Panic: %s\n", err)
-			log.Fatal().Msgf("panic: %v", err)
-		}
-	}()
 
 	flags.Post(cfg, pl)
 


### PR DESCRIPTION
## Summary

- Add panic recovery at the start of `run()` for all 12 platforms
- Capture full stack trace with `debug.Stack()` for better debugging
- Log panic details with zerolog before exiting
- Move existing recovery in MiSTer, Batocera, macOS, Windows, LibreELEC to the beginning of `run()` to catch all panics including setup
- Add recovery to Linux, SteamOS, Bazzite, ChimeraOS, MiSTeX, Recalbox, RetroPie which were previously missing it entirely