### PR TITLE
fix: reduce Sentry noise by downgrading non-critical errors

### DIFF
--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -83,7 +83,7 @@ func LocalClient(
 ) (string, error) {
 	localWebsocketURL := url.URL{
 		Scheme: "ws",
-		Host:   "localhost:" + strconv.Itoa(cfg.APIPort()),
+		Host:   "127.0.0.1:" + strconv.Itoa(cfg.APIPort()),
 		Path:   APIPath,
 	}
 
@@ -133,7 +133,11 @@ func LocalClient(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				log.Error().Err(readErr).Msg("error reading message")
+				if ctx.Err() != nil || errors.Is(readErr, net.ErrClosed) {
+					log.Debug().Err(readErr).Msg("connection closed")
+				} else {
+					log.Error().Err(readErr).Msg("error reading message")
+				}
 				return
 			}
 
@@ -212,7 +216,7 @@ func WaitNotification(
 ) (string, error) {
 	u := url.URL{
 		Scheme: "ws",
-		Host:   "localhost:" + strconv.Itoa(cfg.APIPort()),
+		Host:   "127.0.0.1:" + strconv.Itoa(cfg.APIPort()),
 		Path:   APIPath,
 	}
 
@@ -250,7 +254,11 @@ func WaitNotification(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				log.Error().Err(readErr).Msg("error reading message")
+				if ctx.Err() != nil || errors.Is(readErr, net.ErrClosed) {
+					log.Debug().Err(readErr).Msg("connection closed")
+				} else {
+					log.Error().Err(readErr).Msg("error reading message")
+				}
 				return
 			}
 

--- a/pkg/api/methods/readers.go
+++ b/pkg/api/methods/readers.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -86,7 +87,11 @@ func HandleReaderWrite(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	t, err := reader.Write(params.Text)
 	if err != nil {
-		log.Error().Err(err).Msg("error writing to reader")
+		if errors.Is(err, context.Canceled) {
+			log.Debug().Err(err).Msg("tag write cancelled")
+		} else {
+			log.Error().Err(err).Msg("error writing to reader")
+		}
 		return nil, errors.New("error writing to reader")
 	}
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -1104,7 +1104,7 @@ func NewNamesIndex(
 					return handleCancellationWithRollback(ctx, db,
 						"Media indexing cancelled during second round custom scanner")
 				}
-				log.Error().Err(scanErr).Msgf("error running %s scanner for system: %s", l.ID, systemID)
+				log.Warn().Err(scanErr).Msgf("error running %s scanner for system: %s", l.ID, systemID)
 				continue
 			}
 

--- a/pkg/platforms/shared/launchers/lutris.go
+++ b/pkg/platforms/shared/launchers/lutris.go
@@ -51,7 +51,7 @@ func ScanLutrisGames(dbPath string) ([]platforms.ScanResult, error) {
 	// Open the SQLite database
 	db, err := sql.Open("sqlite3", dbPath)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to open Lutris database")
+		log.Warn().Err(err).Msg("failed to open Lutris database")
 		return results, nil
 	}
 	defer func() {
@@ -64,7 +64,7 @@ func ScanLutrisGames(dbPath string) ([]platforms.ScanResult, error) {
 	query := "SELECT name, slug FROM games WHERE installed = 1"
 	rows, err := db.QueryContext(context.Background(), query)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to query Lutris games")
+		log.Warn().Err(err).Msg("failed to query Lutris games")
 		return results, nil
 	}
 	defer func() {
@@ -95,7 +95,7 @@ func ScanLutrisGames(dbPath string) ([]platforms.ScanResult, error) {
 
 	// Check for errors during iteration
 	if err := rows.Err(); err != nil {
-		log.Error().Err(err).Msg("error iterating Lutris game rows")
+		log.Warn().Err(err).Msg("error iterating Lutris game rows")
 		return results, nil
 	}
 

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -304,7 +304,7 @@ func processTokenQueue(
 			reader := parser.NewParser(scriptText)
 			script, parseErr := reader.ParseScript()
 			if parseErr != nil {
-				log.Error().Err(parseErr).Msg("failed to parse script for playtime check")
+				log.Debug().Err(parseErr).Msg("failed to parse script for playtime check")
 				// Continue anyway - the error will be caught in runTokenZapScript
 			}
 

--- a/pkg/ui/tui/searchmedia.go
+++ b/pkg/ui/tui/searchmedia.go
@@ -242,7 +242,7 @@ func BuildSearchMedia(cfg *config.Instance, pages *tview.Pages, app *tview.Appli
 
 			_, err = client.LocalClient(ctx, cfg, models.MethodReadersWrite, string(data))
 			if err != nil {
-				log.Error().Err(err).Msg("error writing tag")
+				log.Warn().Err(err).Msg("error writing tag")
 				errorModal.SetText("Error writing to tag:\n" + err.Error())
 				mediaPages.HidePage("write_modal")
 				mediaPages.ShowPage("error_modal")


### PR DESCRIPTION
## Summary
- Downgrade WebSocket client connection lifecycle errors to debug level
- Downgrade empty script errors to debug level
- Downgrade Kodi scanner connection errors to warn level
- Downgrade PN532 context cancellation errors to debug level
- Downgrade Lutris database errors to warn level
- Add TUI error state page for Core unavailable handling