### PR TITLE
build(deps): upgrade go-pn532 to v0.14.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	fyne.io/systray v1.11.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/ZaparooProject/go-pn532 v0.13.1
+	github.com/ZaparooProject/go-pn532 v0.14.0
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0
 	github.com/bendahl/uinput v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
-github.com/ZaparooProject/go-pn532 v0.13.1 h1:SxHnTUmt3THaZAVJkTMlJ7uPfnAH5O7L3a2FHFyN1Ko=
-github.com/ZaparooProject/go-pn532 v0.13.1/go.mod h1:7jkSDn6P2cVaYzWgR3lfMv2EG4zUKRcoaCErNf+hxFs=
+github.com/ZaparooProject/go-pn532 v0.14.0 h1:hkCLKeZAF/Sy9tFIwIh1h0Sk5iAphgnU+1n7RPuf0Ck=
+github.com/ZaparooProject/go-pn532 v0.14.0/go.mod h1:7jkSDn6P2cVaYzWgR3lfMv2EG4zUKRcoaCErNf+hxFs=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/andygrunwald/vdf v1.1.0 h1:gmstp0R7DOepIZvWoSJY97ix7QOrsxpGPU6KusKXqvw=


### PR DESCRIPTION
## Summary

- Upgrades go-pn532 from v0.13.1 to v0.14.0
- Improves clone tag compatibility with spec-compliant TLV scanning

See release notes: https://github.com/ZaparooProject/go-pn532/releases/tag/v0.14.0