### PR TITLE
fix(ci): skip codecov upload on tag pushes

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -321,7 +321,8 @@ jobs:
         run: go test -tags=deadlock -race -count=1 ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' # Only upload coverage once
+        # Skip on tag pushes
+        if: matrix.os == 'ubuntu-latest' && !startsWith(github.ref, 'refs/tags/')
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Skip Codecov coverage upload on tag pushes to avoid failures when Codecov can't determine branch context