### PR TITLE
fix(mister): resolve alt core RBF paths by launcher ID

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -40,6 +40,7 @@ type Slot struct {
 
 type Core struct {
 	ID             string
+	LauncherID     string // Set for alt cores, empty for main cores
 	SetName        string
 	RBF            string
 	Slots          []Slot

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -235,3 +235,283 @@ func TestRBFCacheThreadSafety(t *testing.T) {
 		<-done
 	}
 }
+
+func TestRegisterAltCore(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+
+	// Register an alt core
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	// Verify it was stored
+	cache.mu.RLock()
+	rbfPath, ok := cache.byLauncherID["2XPSX"]
+	cache.mu.RUnlock()
+
+	assert.True(t, ok, "launcher ID should be found")
+	assert.Equal(t, "_Other/PSX2XCPU", rbfPath)
+}
+
+func TestRegisterAltCore_MultipleRegistrations(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+
+	// Register multiple alt cores
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+	cache.RegisterAltCore("PWMPSX", "_ConsolePWM/PSX_PWM")
+	cache.RegisterAltCore("LLAPIPSX", "_LLAPI/PSX_LLAPI")
+
+	cache.mu.RLock()
+	assert.Len(t, cache.byLauncherID, 3, "should have 3 registered launchers")
+	assert.Equal(t, "_Other/PSX2XCPU", cache.byLauncherID["2XPSX"])
+	assert.Equal(t, "_ConsolePWM/PSX_PWM", cache.byLauncherID["PWMPSX"])
+	assert.Equal(t, "_LLAPI/PSX_LLAPI", cache.byLauncherID["LLAPIPSX"])
+	cache.mu.RUnlock()
+}
+
+func TestGetByLauncherID_NotRegistered(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+
+	// Lookup unregistered launcher should fail
+	_, found := cache.GetByLauncherID("UnknownLauncher")
+	assert.False(t, found, "unregistered launcher should not be found")
+}
+
+func TestGetByLauncherID_RegisteredButNotInShortNameCache(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{
+		byShortName: make(map[string]RBFInfo),
+	}
+
+	// Register an alt core
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	// Lookup should fail because PSX2XCPU isn't in byShortName
+	_, found := cache.GetByLauncherID("2XPSX")
+	assert.False(t, found, "should not be found when RBF not in cache")
+}
+
+func TestGetByLauncherID_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{
+		byShortName: map[string]RBFInfo{
+			"psx2xcpu": {
+				Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
+				Filename:  "PSX2XCPU_20240101.rbf",
+				ShortName: "PSX2XCPU",
+				MglName:   "_Other/PSX2XCPU",
+			},
+		},
+	}
+
+	// Register an alt core
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	// Lookup should succeed
+	rbf, found := cache.GetByLauncherID("2XPSX")
+	assert.True(t, found, "registered launcher should be found")
+	assert.Equal(t, "_Other/PSX2XCPU", rbf.MglName)
+	assert.Equal(t, "PSX2XCPU", rbf.ShortName)
+}
+
+func TestGetByLauncherID_ExtractsShortNameFromPath(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{
+		byShortName: map[string]RBFInfo{
+			"n64_80mhz": {
+				Path:      "/media/fat/_Other/N64_80MHz_20240101.rbf",
+				Filename:  "N64_80MHz_20240101.rbf",
+				ShortName: "N64_80MHz",
+				MglName:   "_Other/N64_80MHz",
+			},
+		},
+	}
+
+	// Register with nested path
+	cache.RegisterAltCore("80MHzNintendo64", "_Other/N64_80MHz")
+
+	// Lookup should extract short name from path and find it
+	rbf, found := cache.GetByLauncherID("80MHzNintendo64")
+	assert.True(t, found, "should find RBF by extracted short name")
+	assert.Equal(t, "_Other/N64_80MHz", rbf.MglName)
+}
+
+func TestResolveRBFPathForLauncher_LauncherIDTakesPriority(t *testing.T) {
+	// Save and restore GlobalRBFCache state
+	originalBySystemID := GlobalRBFCache.bySystemID
+	originalByShortName := GlobalRBFCache.byShortName
+	originalByLauncherID := GlobalRBFCache.byLauncherID
+	defer func() {
+		GlobalRBFCache.mu.Lock()
+		GlobalRBFCache.bySystemID = originalBySystemID
+		GlobalRBFCache.byShortName = originalByShortName
+		GlobalRBFCache.byLauncherID = originalByLauncherID
+		GlobalRBFCache.mu.Unlock()
+	}()
+
+	// Setup cache with both system and alt core entries
+	GlobalRBFCache.mu.Lock()
+	GlobalRBFCache.bySystemID = map[string]RBFInfo{
+		"PSX": {
+			Path:      "/media/fat/_Console/PSX_20240101.rbf",
+			Filename:  "PSX_20240101.rbf",
+			ShortName: "PSX",
+			MglName:   "_Console/PSX",
+		},
+	}
+	GlobalRBFCache.byShortName = map[string]RBFInfo{
+		"psx": {
+			Path:      "/media/fat/_Console/PSX_20240101.rbf",
+			Filename:  "PSX_20240101.rbf",
+			ShortName: "PSX",
+			MglName:   "_Console/PSX",
+		},
+		"psx2xcpu": {
+			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
+			Filename:  "PSX2XCPU_20240101.rbf",
+			ShortName: "PSX2XCPU",
+			MglName:   "_Other/PSX2XCPU",
+		},
+	}
+	GlobalRBFCache.byLauncherID = map[string]string{
+		"2XPSX": "_Other/PSX2XCPU",
+	}
+	GlobalRBFCache.mu.Unlock()
+
+	// When launcherID is provided and found, should use alt core path
+	result := ResolveRBFPathForLauncher("2XPSX", "PSX", "_Console/PSX")
+	assert.Equal(t, "_Other/PSX2XCPU", result, "launcherID lookup should take priority over systemID")
+
+	// When launcherID is empty, should fall back to systemID
+	result = ResolveRBFPathForLauncher("", "PSX", "_Console/PSX")
+	assert.Equal(t, "_Console/PSX", result, "should fall back to systemID when launcherID is empty")
+}
+
+func TestResolveRBFPathForLauncher_FallbackChain(t *testing.T) {
+	// Save and restore GlobalRBFCache state
+	originalBySystemID := GlobalRBFCache.bySystemID
+	originalByShortName := GlobalRBFCache.byShortName
+	originalByLauncherID := GlobalRBFCache.byLauncherID
+	defer func() {
+		GlobalRBFCache.mu.Lock()
+		GlobalRBFCache.bySystemID = originalBySystemID
+		GlobalRBFCache.byShortName = originalByShortName
+		GlobalRBFCache.byLauncherID = originalByLauncherID
+		GlobalRBFCache.mu.Unlock()
+	}()
+
+	// Setup empty cache
+	GlobalRBFCache.mu.Lock()
+	GlobalRBFCache.bySystemID = make(map[string]RBFInfo)
+	GlobalRBFCache.byShortName = make(map[string]RBFInfo)
+	GlobalRBFCache.byLauncherID = make(map[string]string)
+	GlobalRBFCache.mu.Unlock()
+
+	// When nothing is cached, should fall back to hardcoded
+	result := ResolveRBFPathForLauncher("UnknownLauncher", "UnknownSystem", "_Console/Fallback")
+	assert.Equal(t, "_Console/Fallback", result, "should fall back to hardcoded path")
+}
+
+func TestResolveRBFPathForLauncher_LauncherNotFoundFallsBackToSystemID(t *testing.T) {
+	// Save and restore GlobalRBFCache state
+	originalBySystemID := GlobalRBFCache.bySystemID
+	originalByShortName := GlobalRBFCache.byShortName
+	originalByLauncherID := GlobalRBFCache.byLauncherID
+	defer func() {
+		GlobalRBFCache.mu.Lock()
+		GlobalRBFCache.bySystemID = originalBySystemID
+		GlobalRBFCache.byShortName = originalByShortName
+		GlobalRBFCache.byLauncherID = originalByLauncherID
+		GlobalRBFCache.mu.Unlock()
+	}()
+
+	// Setup cache with system entry only
+	GlobalRBFCache.mu.Lock()
+	GlobalRBFCache.bySystemID = map[string]RBFInfo{
+		"PSX": {
+			Path:      "/media/fat/_Console/PSX_20240101.rbf",
+			Filename:  "PSX_20240101.rbf",
+			ShortName: "PSX",
+			MglName:   "_Console/PSX",
+		},
+	}
+	GlobalRBFCache.byShortName = make(map[string]RBFInfo)
+	GlobalRBFCache.byLauncherID = make(map[string]string)
+	GlobalRBFCache.mu.Unlock()
+
+	// When launcherID is not found, should fall back to systemID
+	result := ResolveRBFPathForLauncher("UnknownLauncher", "PSX", "_Console/OldPSX")
+	assert.Equal(t, "_Console/PSX", result, "should fall back to systemID when launcherID not found")
+}
+
+// TestRegression_Issue477_AltCoreUsesWrongRBFPath is a regression test for GitHub issue #477.
+// The bug: 2XPSX launcher didn't work correctly because ResolveRBFPath looked up cached RBF
+// paths by systemID only. Alt cores like 2XPSX share the same systemID ("PSX") as the main
+// core, so the cache returned the main core's path instead of the alt core's path.
+func TestRegression_Issue477_AltCoreUsesWrongRBFPath(t *testing.T) {
+	// Save and restore GlobalRBFCache state
+	originalBySystemID := GlobalRBFCache.bySystemID
+	originalByShortName := GlobalRBFCache.byShortName
+	originalByLauncherID := GlobalRBFCache.byLauncherID
+	defer func() {
+		GlobalRBFCache.mu.Lock()
+		GlobalRBFCache.bySystemID = originalBySystemID
+		GlobalRBFCache.byShortName = originalByShortName
+		GlobalRBFCache.byLauncherID = originalByLauncherID
+		GlobalRBFCache.mu.Unlock()
+	}()
+
+	// Setup: Simulate a MiSTer with both standard PSX and 2XPSX cores installed
+	GlobalRBFCache.mu.Lock()
+	GlobalRBFCache.bySystemID = map[string]RBFInfo{
+		"PSX": {
+			Path:      "/media/fat/_Console/PSX_20240101.rbf",
+			Filename:  "PSX_20240101.rbf",
+			ShortName: "PSX",
+			MglName:   "_Console/PSX",
+		},
+	}
+	GlobalRBFCache.byShortName = map[string]RBFInfo{
+		"psx": {
+			Path:      "/media/fat/_Console/PSX_20240101.rbf",
+			Filename:  "PSX_20240101.rbf",
+			ShortName: "PSX",
+			MglName:   "_Console/PSX",
+		},
+		"psx2xcpu": {
+			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
+			Filename:  "PSX2XCPU_20240101.rbf",
+			ShortName: "PSX2XCPU",
+			MglName:   "_Other/PSX2XCPU",
+		},
+	}
+	GlobalRBFCache.byLauncherID = map[string]string{
+		"2XPSX": "_Other/PSX2XCPU",
+	}
+	GlobalRBFCache.mu.Unlock()
+
+	// THE BUG: Before the fix, calling ResolveRBFPath("PSX", "_Other/PSX2XCPU") for the
+	// 2XPSX launcher would return "_Console/PSX" (the main core) instead of "_Other/PSX2XCPU"
+	// because the lookup was done by systemID ("PSX"), not by launcherID.
+
+	// Test 1: Main PSX launcher (no launcherID) should get the standard PSX core
+	mainPSXPath := ResolveRBFPathForLauncher("", "PSX", "_Console/PSX")
+	assert.Equal(t, "_Console/PSX", mainPSXPath,
+		"main PSX launcher should use standard PSX core")
+
+	// Test 2: 2XPSX alt core launcher should get the PSX2XCPU core, NOT the standard PSX core
+	altCorePath := ResolveRBFPathForLauncher("2XPSX", "PSX", "_Other/PSX2XCPU")
+	assert.Equal(t, "_Other/PSX2XCPU", altCorePath,
+		"2XPSX launcher should use PSX2XCPU core, not standard PSX core")
+
+	// Test 3: Verify they are different - this is the core of the bug
+	assert.NotEqual(t, mainPSXPath, altCorePath,
+		"alt core should resolve to different path than main core even though they share systemID")
+}

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -244,9 +244,13 @@ func launchAggGnw(cfg *config.Instance, path string, _ *platforms.LaunchOptions)
 }
 
 func launchAltCore(
+	launcherID string,
 	systemID string,
 	rbfPath string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	// Register alt core during launcher creation
+	cores.GlobalRBFCache.RegisterAltCore(launcherID, rbfPath)
+
 	return func(cfg *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore(systemID)
 		if err != nil {
@@ -255,9 +259,10 @@ func launchAltCore(
 		path = checkInZip(path)
 
 		sn := *s
+		sn.LauncherID = launcherID
 		sn.RBF = rbfPath
 
-		log.Debug().Str("rbf", sn.RBF).Msgf("launching alt core: %v", sn)
+		log.Debug().Str("rbf", sn.RBF).Str("launcher", launcherID).Msgf("launching alt core: %v", sn)
 
 		err = mgls.LaunchGame(cfg, &sn, path)
 		if err != nil {
@@ -649,7 +654,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIAtari2600",
 			SystemID: systemdefs.SystemAtari2600,
-			Launch:   launchAltCore(systemdefs.SystemAtari2600, "_LLAPI/Atari7800_LLAPI"),
+			Launch:   launchAltCore("LLAPIAtari2600", systemdefs.SystemAtari2600, "_LLAPI/Atari7800_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemAtari5200,
@@ -668,7 +673,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIAtari7800",
 			SystemID: systemdefs.SystemAtari7800,
-			Launch:   launchAltCore(systemdefs.SystemAtari7800, "_LLAPI/Atari7800_LLAPI"),
+			Launch:   launchAltCore("LLAPIAtari7800", systemdefs.SystemAtari7800, "_LLAPI/Atari7800_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemAtariLynx,
@@ -736,7 +741,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIGameboy",
 			SystemID: systemdefs.SystemGameboy,
-			Launch:   launchAltCore(systemdefs.SystemGameboy, "_LLAPI/Gameboy_LLAPI"),
+			Launch:   launchAltCore("LLAPIGameboy", systemdefs.SystemGameboy, "_LLAPI/Gameboy_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemGameboyColor,
@@ -783,7 +788,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIGBA",
 			SystemID: systemdefs.SystemGBA,
-			Launch:   launchAltCore(systemdefs.SystemGBA, "_LLAPI/GBA_LLAPI"),
+			Launch:   launchAltCore("LLAPIGBA", systemdefs.SystemGBA, "_LLAPI/GBA_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemGBA2P,
@@ -812,7 +817,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIMegaDrive",
 			SystemID: systemdefs.SystemGenesis,
-			Launch:   launchAltCore(systemdefs.SystemGenesis, "_LLAPI/MegaDrive_LLAPI"),
+			Launch:   launchAltCore("LLAPIMegaDrive", systemdefs.SystemGenesis, "_LLAPI/MegaDrive_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemIntellivision,
@@ -843,7 +848,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPISMS",
 			SystemID: systemdefs.SystemMasterSystem,
-			Launch:   launchAltCore(systemdefs.SystemMasterSystem, "_LLAPI/SMS_LLAPI"),
+			Launch:   launchAltCore("LLAPISMS", systemdefs.SystemMasterSystem, "_LLAPI/SMS_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemMegaCD,
@@ -860,7 +865,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIMegaCD",
 			SystemID: systemdefs.SystemMegaCD,
-			Launch:   launchAltCore(systemdefs.SystemMegaCD, "_LLAPI/MegaCD_LLAPI"),
+			Launch:   launchAltCore("LLAPIMegaCD", systemdefs.SystemMegaCD, "_LLAPI/MegaCD_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemMegaDuck,
@@ -872,7 +877,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPINeoGeo",
 			SystemID: systemdefs.SystemNeoGeo,
-			Launch:   launchAltCore(systemdefs.SystemNeoGeo, "_LLAPI/NeoGeo_LLAPI"),
+			Launch:   launchAltCore("LLAPINeoGeo", systemdefs.SystemNeoGeo, "_LLAPI/NeoGeo_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemNeoGeoCD,
@@ -917,7 +922,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPINES",
 			SystemID: systemdefs.SystemNES,
-			Launch:   launchAltCore(systemdefs.SystemNES, "_LLAPI/NES_LLAPI"),
+			Launch:   launchAltCore("LLAPINES", systemdefs.SystemNES, "_LLAPI/NES_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemNintendo64,
@@ -929,27 +934,29 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPINintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_LLAPI/N64_LLAPI"),
+			Launch:   launchAltCore("LLAPINintendo64", systemdefs.SystemNintendo64, "_LLAPI/N64_LLAPI"),
 		},
 		{
 			ID:       "LLAPI80MHzNintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_LLAPI/N64_80MHz_LLAPI"),
+			Launch:   launchAltCore("LLAPI80MHzNintendo64", systemdefs.SystemNintendo64, "_LLAPI/N64_80MHz_LLAPI"),
 		},
 		{
 			ID:       "80MHzNintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_Other/N64_80MHz"),
+			Launch:   launchAltCore("80MHzNintendo64", systemdefs.SystemNintendo64, "_Other/N64_80MHz"),
 		},
 		{
 			ID:       "PWMNintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_ConsolePWM/N64_PWM"),
+			Launch:   launchAltCore("PWMNintendo64", systemdefs.SystemNintendo64, "_ConsolePWM/N64_PWM"),
 		},
 		{
 			ID:       "PWM80MHzNintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore(systemdefs.SystemNintendo64, "_ConsolePWM/_Turbo/N64_80MHz_PWM"),
+			Launch: launchAltCore(
+				"PWM80MHzNintendo64", systemdefs.SystemNintendo64, "_ConsolePWM/_Turbo/N64_80MHz_PWM",
+			),
 		},
 		{
 			ID:         systemdefs.SystemOdyssey2,
@@ -982,7 +989,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_LLAPI/PSX_LLAPI"),
+			Launch:   launchAltCore("LLAPIPSX", systemdefs.SystemPSX, "_LLAPI/PSX_LLAPI"),
 		},
 		{
 			ID:       "SindenPSX",
@@ -992,17 +999,17 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "2XPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_Other/PSX2XCPU"),
+			Launch:   launchAltCore("2XPSX", systemdefs.SystemPSX, "_Other/PSX2XCPU"),
 		},
 		{
 			ID:       "PWMPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_ConsolePWM/PSX_PWM"),
+			Launch:   launchAltCore("PWMPSX", systemdefs.SystemPSX, "_ConsolePWM/PSX_PWM"),
 		},
 		{
 			ID:       "PWM2XPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_ConsolePWM/_Turbo/PSX2XCPU_PWM"),
+			Launch:   launchAltCore("PWM2XPSX", systemdefs.SystemPSX, "_ConsolePWM/_Turbo/PSX2XCPU_PWM"),
 		},
 		{
 			ID:         systemdefs.SystemSega32X,
@@ -1014,7 +1021,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPIS32X",
 			SystemID: systemdefs.SystemSega32X,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_LLAPI/S32X_LLAPI"),
+			Launch:   launchAltCore("LLAPIS32X", systemdefs.SystemSega32X, "_LLAPI/S32X_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemSG1000,
@@ -1033,7 +1040,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPISuperGameboy",
 			SystemID: systemdefs.SystemSuperGameboy,
-			Launch:   launchAltCore(systemdefs.SystemSuperGameboy, "_LLAPI/SGB_LLAPI"),
+			Launch:   launchAltCore("LLAPISuperGameboy", systemdefs.SystemSuperGameboy, "_LLAPI/SGB_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemSuperVision,
@@ -1052,12 +1059,12 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPISaturn",
 			SystemID: systemdefs.SystemSaturn,
-			Launch:   launchAltCore(systemdefs.SystemSaturn, "_LLAPI/Saturn_LLAPI"),
+			Launch:   launchAltCore("LLAPISaturn", systemdefs.SystemSaturn, "_LLAPI/Saturn_LLAPI"),
 		},
 		{
 			ID:       "PWMSaturn",
-			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore(systemdefs.SystemPSX, "_ConsolePWM/Saturn_PWM"),
+			SystemID: systemdefs.SystemSaturn,
+			Launch:   launchAltCore("PWMSaturn", systemdefs.SystemSaturn, "_ConsolePWM/Saturn_PWM"),
 		},
 		{
 			ID:         systemdefs.SystemSNES,
@@ -1069,7 +1076,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPISNES",
 			SystemID: systemdefs.SystemSNES,
-			Launch:   launchAltCore(systemdefs.SystemSNES, "_LLAPI/SNES_LLAPI"),
+			Launch:   launchAltCore("LLAPISNES", systemdefs.SystemSNES, "_LLAPI/SNES_LLAPI"),
 		},
 		{
 			ID:       "SindenSNES",
@@ -1100,7 +1107,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "LLAPITurboGrafx16",
 			SystemID: systemdefs.SystemTurboGrafx16,
-			Launch:   launchAltCore(systemdefs.SystemTurboGrafx16, "_LLAPI/TurboGrafx16_LLAPI"),
+			Launch:   launchAltCore("LLAPITurboGrafx16", systemdefs.SystemTurboGrafx16, "_LLAPI/TurboGrafx16_LLAPI"),
 		},
 		{
 			ID:         systemdefs.SystemTurboGrafx16CD,

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -75,7 +75,7 @@ func GenerateMgl(core *cores.Core, path, override string) (string, error) {
 		return "", errors.New("no core supplied for MGL generation")
 	}
 
-	rbfPath := cores.ResolveRBFPath(core.ID, core.RBF)
+	rbfPath := cores.ResolveRBFPathForLauncher(core.LauncherID, core.ID, core.RBF)
 	mgl := fmt.Sprintf("<mistergamedescription>\n\t<rbf>%s</rbf>\n", rbfPath)
 
 	if core.SetName != "" {


### PR DESCRIPTION
## Summary

- Fixes alt cores (like 2XPSX) using wrong RBF path due to cache lookup by systemID only
- Alt cores now register their launcherID during launcher creation
- RBF resolution tries launcherID first, then falls back to systemID

Fixes #477