### PR TITLE
fix(batocera): correct Windows game launcher file extensions

### DIFF
--- a/pkg/platforms/shared/esde/systemmap.go
+++ b/pkg/platforms/shared/esde/systemmap.go
@@ -1256,12 +1256,12 @@ var SystemMap = map[string]SystemInfo{
 	},
 	"windows": {
 		SystemID:   systemdefs.SystemWindows,
-		Extensions: []string{".wine", ".exe", ".bat"},
+		Extensions: []string{".pc", ".exe", ".wine", ".wsquashfs", ".wtgz"},
 		LauncherID: "Windows",
 	},
 	"windows_installers": {
 		SystemID:   systemdefs.SystemWindows,
-		Extensions: []string{".exe", ".msi"},
+		Extensions: []string{".exe", ".iso", ".msi"},
 		LauncherID: "WindowsInstallers",
 	},
 	"wine": {


### PR DESCRIPTION
## Summary
- Update `windows` extensions to match Batocera's es_systems.yml: `.pc`, `.exe`, `.wine`, `.wsquashfs`, `.wtgz`
- Update `windows_installers` extensions to add missing `.iso`
- Removes `.bat` which isn't in Batocera's config

Fixes #487