### PR TITLE
feat(mister): add FULLPATH-based game tracking for log_file_entry support

### DIFF
--- a/pkg/platforms/mister/config/config.go
+++ b/pkg/platforms/mister/config/config.go
@@ -39,7 +39,6 @@ const (
 	CoreConfigFolder   = SDRootDir + "/config"
 	MenuConfigFile     = CoreConfigFolder + "/MENU.CFG"
 	DefaultIniFilename = "MiSTer.ini"
-	StartPathFile      = "/tmp/STARTPATH"
 )
 
 func MainHasFeature(feature string) bool {

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -534,45 +534,38 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 		return nil, fmt.Errorf("failed to watch core name file (%s): %w", misterconfig.CoreNameFile, err)
 	}
 
-	// Check if STARTPATH exists (indicates MiSTer's log_file_entry=1 is enabled).
-	// STARTPATH contains the core/MRA path (not ROM), but its presence signals
-	// that FULLPATH will be written when games are selected. Watch FULLPATH for
-	// actual game tracking instead of the recents files.
-	useLogFileEntry := false
-	if _, statErr := os.Stat(misterconfig.StartPathFile); statErr == nil {
-		useLogFileEntry = true
-		log.Info().Msg("STARTPATH exists, using FULLPATH for game tracking (log_file_entry mode)")
+	// Watch recents folder for game tracking (standard method).
+	if _, statErr := os.Stat(misterconfig.CoreConfigFolder); os.IsNotExist(statErr) {
+		//nolint:gosec // MiSTer system directory, needs to be accessible by other apps
+		mkdirErr := os.MkdirAll(misterconfig.CoreConfigFolder, 0o755)
+		if mkdirErr != nil {
+			return nil, fmt.Errorf("failed to create core config folder: %w", mkdirErr)
+		}
+		log.Info().Msgf("created core config folder: %s", misterconfig.CoreConfigFolder)
 	}
 
-	if useLogFileEntry {
-		if _, statErr := os.Stat(misterconfig.FullPathFile); os.IsNotExist(statErr) {
-			//nolint:gosec // MiSTer system file, needs to be readable by other apps
-			writeErr := os.WriteFile(misterconfig.FullPathFile, []byte(""), 0o644)
-			if writeErr != nil {
-				return nil, fmt.Errorf("failed to create FULLPATH file: %w", writeErr)
-			}
-		}
+	log.Debug().Msgf("adding watcher for core config folder: %s", misterconfig.CoreConfigFolder)
+	err = watcher.Add(misterconfig.CoreConfigFolder)
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch core config folder (%s): %w", misterconfig.CoreConfigFolder, err)
+	}
 
-		log.Debug().Msgf("adding watcher for FULLPATH file: %s", misterconfig.FullPathFile)
-		err = watcher.Add(misterconfig.FullPathFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to watch FULLPATH file (%s): %w", misterconfig.FullPathFile, err)
+	// Also watch FULLPATH for game tracking (log_file_entry method).
+	// When log_file_entry=1 is set in mister.ini, MiSTer writes the selected
+	// game path to FULLPATH on OSD file selection. Both methods feed into the
+	// same SetActiveGame pipeline — whichever fires, the tracker handles it.
+	if _, statErr := os.Stat(misterconfig.FullPathFile); os.IsNotExist(statErr) {
+		//nolint:gosec // MiSTer system file, needs to be readable by other apps
+		writeErr := os.WriteFile(misterconfig.FullPathFile, []byte(""), 0o644)
+		if writeErr != nil {
+			return nil, fmt.Errorf("failed to create FULLPATH file: %w", writeErr)
 		}
-	} else {
-		if _, statErr := os.Stat(misterconfig.CoreConfigFolder); os.IsNotExist(statErr) {
-			//nolint:gosec // MiSTer system directory, needs to be accessible by other apps
-			mkdirErr := os.MkdirAll(misterconfig.CoreConfigFolder, 0o755)
-			if mkdirErr != nil {
-				return nil, fmt.Errorf("failed to create core config folder: %w", mkdirErr)
-			}
-			log.Info().Msgf("created core config folder: %s", misterconfig.CoreConfigFolder)
-		}
+	}
 
-		log.Debug().Msgf("adding watcher for core config folder: %s", misterconfig.CoreConfigFolder)
-		err = watcher.Add(misterconfig.CoreConfigFolder)
-		if err != nil {
-			return nil, fmt.Errorf("failed to watch core config folder (%s): %w", misterconfig.CoreConfigFolder, err)
-		}
+	log.Debug().Msgf("adding watcher for FULLPATH file: %s", misterconfig.FullPathFile)
+	err = watcher.Add(misterconfig.FullPathFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to watch FULLPATH file (%s): %w", misterconfig.FullPathFile, err)
 	}
 
 	if _, statActiveErr := os.Stat(misterconfig.ActiveGameFile); os.IsNotExist(statActiveErr) {

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -37,7 +37,6 @@ func cleanupTmpFiles(t *testing.T) {
 	files := []string{
 		misterconfig.FullPathFile,
 		misterconfig.ActiveGameFile,
-		misterconfig.StartPathFile,
 	}
 	for _, f := range files {
 		_ = os.Remove(f)
@@ -267,21 +266,4 @@ func TestStopCore(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestStartPathDetectsLogFileEntryMode(t *testing.T) {
-	cleanupTmpFiles(t)
-	t.Cleanup(func() { cleanupTmpFiles(t) })
-
-	// Without STARTPATH, log_file_entry mode should not be detected
-	_, err := os.Stat(misterconfig.StartPathFile)
-	assert.True(t, os.IsNotExist(err))
-
-	// Create STARTPATH to simulate log_file_entry=1
-	//nolint:gosec // test file
-	err = os.WriteFile(misterconfig.StartPathFile, []byte("/media/fat/_Console/SNES.rbf"), 0o644)
-	require.NoError(t, err)
-
-	_, err = os.Stat(misterconfig.StartPathFile)
-	assert.NoError(t, err, "STARTPATH should exist to signal log_file_entry mode")
 }


### PR DESCRIPTION
## Summary

- Watch both FULLPATH and recents files unconditionally for game tracking
- When `log_file_entry=1` is enabled in `mister.ini`, MiSTer writes game paths to `/tmp/FULLPATH` on OSD file selection
- Both sources feed into the same `SetActiveGame` pipeline — whichever fires, the tracker handles it
- No ini parsing needed — works regardless of `log_file_entry` setting
- Fixes game tracking when MiSTer's recents feature is broken or disabled