### PR TITLE
refactor: improve nested playlist command handling

### DIFF
--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -997,7 +997,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 }
 
 func (p *Platform) ShowNotice(
-	cfg *config.Instance,
+	_ *config.Instance,
 	args widgetmodels.NoticeArgs,
 ) (func() error, time.Duration, error) {
 	p.platformMu.Lock()
@@ -1007,7 +1007,7 @@ func (p *Platform) ShowNotice(
 		time.Sleep(3 * time.Second)
 	}
 
-	completePath, err := showNotice(cfg, p, args.Text, false)
+	completePath, err := showNotice(p, args.Text, false)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1020,7 +1020,7 @@ func (p *Platform) ShowNotice(
 }
 
 func (p *Platform) ShowLoader(
-	cfg *config.Instance,
+	_ *config.Instance,
 	args widgetmodels.NoticeArgs,
 ) (func() error, error) {
 	p.platformMu.Lock()
@@ -1030,7 +1030,7 @@ func (p *Platform) ShowLoader(
 		time.Sleep(3 * time.Second)
 	}
 
-	completePath, err := showNotice(cfg, p, args.Text, true)
+	completePath, err := showNotice(p, args.Text, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1043,10 +1043,10 @@ func (p *Platform) ShowLoader(
 }
 
 func (p *Platform) ShowPicker(
-	cfg *config.Instance,
+	_ *config.Instance,
 	args widgetmodels.PickerArgs,
 ) error {
-	return showPicker(cfg, p, args)
+	return showPicker(p, args)
 }
 
 func (p *Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -165,6 +165,8 @@ func launchPlaylistMedia(
 	err := runTokenZapScript(platform, cfg, st, t, db, lsq, plsc, nil)
 	if err != nil {
 		log.Error().Err(err).Msgf("error launching token")
+		path, enabled := cfg.FailSoundPath(helpers.DataDir(platform))
+		helpers.PlayConfiguredSound(path, enabled, assets.FailSound, "fail")
 	}
 
 	now := time.Now()

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -118,7 +118,6 @@ var cmdMap = map[string]func(
 }
 
 // IsMediaLaunchingCommand returns true if the command launches media and should be subject to playtime limits.
-// This includes all launch.* commands, most playlist commands (play/next/prev/goto/load/open), and mister.mgl.
 func IsMediaLaunchingCommand(cmdName string) bool {
 	switch cmdName {
 	// Launch commands
@@ -129,13 +128,11 @@ func IsMediaLaunchingCommand(cmdName string) bool {
 		zapscript.ZapScriptCmdLaunchTitle:
 		return true
 
-	// Playlist commands that launch or load media
+	// Playlist commands that actually play media
 	case zapscript.ZapScriptCmdPlaylistPlay,
 		zapscript.ZapScriptCmdPlaylistNext,
 		zapscript.ZapScriptCmdPlaylistPrevious,
-		zapscript.ZapScriptCmdPlaylistGoto,
-		zapscript.ZapScriptCmdPlaylistLoad,
-		zapscript.ZapScriptCmdPlaylistOpen:
+		zapscript.ZapScriptCmdPlaylistGoto:
 		return true
 
 	// MiSTer MGL launches games

--- a/pkg/zapscript/commands_test.go
+++ b/pkg/zapscript/commands_test.go
@@ -86,18 +86,18 @@ func TestIsMediaLaunchingCommand(t *testing.T) {
 			cmdName: zapscript.ZapScriptCmdPlaylistGoto,
 			want:    true,
 		},
-		{
-			name:    "playlist.load command",
-			cmdName: zapscript.ZapScriptCmdPlaylistLoad,
-			want:    true,
-		},
-		{
-			name:    "playlist.open command",
-			cmdName: zapscript.ZapScriptCmdPlaylistOpen,
-			want:    true,
-		},
-
 		// Playlist commands that don't launch media - should NOT be blocked
+		// playlist.load just loads without playing, playlist.open shows picker UI
+		{
+			name:    "playlist.load command - loads without playing",
+			cmdName: zapscript.ZapScriptCmdPlaylistLoad,
+			want:    false,
+		},
+		{
+			name:    "playlist.open command - shows picker UI",
+			cmdName: zapscript.ZapScriptCmdPlaylistOpen,
+			want:    false,
+		},
 		{
 			name:    "playlist.stop command",
 			cmdName: zapscript.ZapScriptCmdPlaylistStop,
@@ -272,8 +272,7 @@ func TestIsMediaLaunchingCommand_ComprehensiveCoverage(t *testing.T) {
 		zapscript.ZapScriptCmdPlaylistNext,
 		zapscript.ZapScriptCmdPlaylistPrevious,
 		zapscript.ZapScriptCmdPlaylistGoto,
-		zapscript.ZapScriptCmdPlaylistLoad,
-		zapscript.ZapScriptCmdPlaylistOpen,
+		// Note: playlist.load and playlist.open are NOT blocked - they don't launch media
 		zapscript.ZapScriptCmdMisterMGL,
 		zapscript.ZapScriptCmdRandom, // deprecated
 		zapscript.ZapScriptCmdSystem, // deprecated
@@ -287,6 +286,8 @@ func TestIsMediaLaunchingCommand_ComprehensiveCoverage(t *testing.T) {
 		zapscript.ZapScriptCmdEcho,
 		zapscript.ZapScriptCmdPlaylistStop,
 		zapscript.ZapScriptCmdPlaylistPause,
+		zapscript.ZapScriptCmdPlaylistLoad, // loads without playing
+		zapscript.ZapScriptCmdPlaylistOpen, // shows picker UI
 		zapscript.ZapScriptCmdMisterINI,
 		zapscript.ZapScriptCmdMisterCore,
 		zapscript.ZapScriptCmdMisterScript,


### PR DESCRIPTION
## Summary

- Remove `playlist.open` and `playlist.load` from `IsMediaLaunchingCommand` since they don't actually launch media (`open` shows picker UI, `load` just loads without playing)
- Add fail sound to `launchPlaylistMedia` for user feedback when playlist entry execution fails
- Call `runScript` directly in MiSTer `showNotice` and `showPicker` fallback paths instead of going through the API