### PR TITLE
fix(publishers): add connection retry to MQTT publisher

### DIFF
--- a/pkg/service/publishers/mqtt_mocks_test.go
+++ b/pkg/service/publishers/mqtt_mocks_test.go
@@ -58,6 +58,8 @@ func (m *mockMQTTClient) getPublishedCount() int {
 }
 
 func (m *mockMQTTClient) IsConnected() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.connected
 }
 
@@ -66,6 +68,9 @@ func (m *mockMQTTClient) IsConnectionOpen() bool {
 }
 
 func (m *mockMQTTClient) Connect() mqtt.Token {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.connectError != nil {
 		return &mockToken{err: m.connectError}
 	}
@@ -74,6 +79,8 @@ func (m *mockMQTTClient) Connect() mqtt.Token {
 }
 
 func (m *mockMQTTClient) Disconnect(_ uint) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.connected = false
 	m.disconnectCall++
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -582,7 +582,7 @@ func startPublishers(
 			log.Info().Msgf("starting MQTT publisher: %s (topic: %s)", mqttCfg.Broker, mqttCfg.Topic)
 
 			publisher := publishers.NewMQTTPublisher(mqttCfg.Broker, mqttCfg.Topic, mqttCfg.Filter)
-			if err := publisher.Start(); err != nil {
+			if err := publisher.Start(st.GetContext()); err != nil {
 				log.Error().Err(err).Msgf("failed to start MQTT publisher for %s", mqttCfg.Broker)
 				continue
 			}

--- a/pkg/testing/helpers/config_test.go
+++ b/pkg/testing/helpers/config_test.go
@@ -20,7 +20,6 @@
 package helpers
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,8 +46,8 @@ func TestNewTestConfig(t *testing.T) {
 	assert.NotNil(t, cfg)
 	assert.Equal(t, config.DefaultAPIPort, cfg.APIPort())
 
-	// Verify the config file exists on the real filesystem
+	// Verify the config file exists on the in-memory filesystem
 	configPath := filepath.Join(configDir, config.CfgFile)
-	_, err = os.Stat(configPath)
+	_, err = fs.Fs.Stat(configPath)
 	assert.NoError(t, err, "config file should exist")
 }


### PR DESCRIPTION
## Summary

- MQTT publisher now retries connection in the background (30s intervals) instead of being permanently discarded on initial connection failure
- Added `config.NewConfigWithFs()` to support afero filesystems, fixing a bug where test config helpers silently ignored the in-memory FS parameter
- Fixed service tests that were passing for the wrong reason (config never actually read from memory FS, wrong TOML key `schema_version` vs `config_schema`)

Closes #503