### PR TITLE
fix: normalize VDF keys to lowercase for case-insensitive lookups

### DIFF
--- a/internal/vdfbinary/shortcuts.go
+++ b/internal/vdfbinary/shortcuts.go
@@ -51,26 +51,26 @@ func ParseShortcuts(buf io.Reader) ([]Shortcut, error) {
 			return []Shortcut{}, errors.New("could not get key 'appid' for one of the shortcuts")
 		}
 
-		appName, ok := s.GetString("AppName")
+		appName, ok := s.GetString("appname")
 		if !ok {
-			return []Shortcut{}, errors.New("could not get key 'AppName' for one of the shortcuts")
+			return []Shortcut{}, errors.New("could not get key 'appname' for one of the shortcuts")
 		}
 
-		exe, ok := s.GetString("Exe")
+		exe, ok := s.GetString("exe")
 		if !ok {
-			return []Shortcut{}, errors.New("could not get key 'Exe' for one of the shortcuts")
+			return []Shortcut{}, errors.New("could not get key 'exe' for one of the shortcuts")
 		}
 
-		startDir, ok := s.GetString("StartDir")
+		startDir, ok := s.GetString("startdir")
 		if !ok {
-			return []Shortcut{}, errors.New("could not get key 'StartDir' for one of the shortcuts")
+			return []Shortcut{}, errors.New("could not get key 'startdir' for one of the shortcuts")
 		}
 
 		// icon is optional - some shortcuts don't have an icon set
 		icon, _ := s.GetString("icon")
 
-		// IsHidden is optional - defaults to false if not present
-		isHidden, _ := s.GetBool("IsHidden")
+		// ishidden is optional - defaults to false if not present
+		isHidden, _ := s.GetBool("ishidden")
 
 		// tags is optional - shortcuts from EmuDeck/Lutris may not have tags
 		var tags []string

--- a/internal/vdfbinary/vdf.go
+++ b/internal/vdfbinary/vdf.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 )
 
 var (
@@ -75,7 +76,7 @@ func parseMap(buf *bufio.Reader) (vdfValue, error) {
 			return vdfValue{}, err
 		}
 
-		m[key] = value
+		m[strings.ToLower(key)] = value
 	}
 
 	return vdfValue{m}, nil

--- a/pkg/platforms/shared/steam/appinfo.go
+++ b/pkg/platforms/shared/steam/appinfo.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 )
@@ -171,6 +172,7 @@ func (r *binaryVDFReader) readObject() (map[string]any, error) {
 		if err != nil {
 			return nil, err
 		}
+		key = strings.ToLower(key)
 
 		switch typeMarker {
 		case vdfTypeNested:

--- a/pkg/platforms/shared/steam/appmanifest.go
+++ b/pkg/platforms/shared/steam/appmanifest.go
@@ -71,10 +71,11 @@ func ReadAppManifest(steamAppsDir string, appID int) (AppInfo, bool) {
 		log.Warn().Err(err).Int("appID", appID).Msg("failed to parse app manifest")
 		return AppInfo{}, false
 	}
+	m = normalizeVDFKeys(m)
 
-	appState, ok := m["AppState"].(map[string]any)
+	appState, ok := m["appstate"].(map[string]any)
 	if !ok {
-		log.Warn().Int("appID", appID).Msg("AppState not found in manifest")
+		log.Warn().Int("appID", appID).Msg("appstate not found in manifest")
 		return AppInfo{}, false
 	}
 
@@ -144,6 +145,7 @@ func forEachSteamLibrary(mainSteamAppsDir string, appID int, callback func(steam
 		log.Warn().Err(err).Msg("failed to parse libraryfolders.vdf")
 		return
 	}
+	m = normalizeVDFKeys(m)
 
 	lfs, ok := m["libraryfolders"].(map[string]any)
 	if !ok {

--- a/pkg/platforms/shared/steam/appmanifest_test.go
+++ b/pkg/platforms/shared/steam/appmanifest_test.go
@@ -130,6 +130,28 @@ func TestReadAppManifest(t *testing.T) {
 
 		assert.False(t, ok)
 	})
+
+	t.Run("reads_manifest_with_lowercase_appstate", func(t *testing.T) {
+		t.Parallel()
+
+		steamAppsDir := t.TempDir()
+		manifestPath := filepath.Join(steamAppsDir, "appmanifest_54321.acf")
+		content := `"appstate"
+{
+	"appid"		"54321"
+	"name"		"Lowercase Key Game"
+	"installdir"		"LowercaseGame"
+}`
+		//nolint:gosec // G306: test file permissions are fine
+		require.NoError(t, os.WriteFile(manifestPath, []byte(content), 0o644))
+
+		info, ok := ReadAppManifest(steamAppsDir, 54321)
+
+		assert.True(t, ok)
+		assert.Equal(t, 54321, info.AppID)
+		assert.Equal(t, "Lowercase Key Game", info.Name)
+		assert.Equal(t, "LowercaseGame", info.InstallDir)
+	})
 }
 
 func TestFindSteamAppsDir(t *testing.T) {

--- a/pkg/platforms/shared/steam/scanner.go
+++ b/pkg/platforms/shared/steam/scanner.go
@@ -68,6 +68,7 @@ func ScanSteamApps(steamDir string) ([]platforms.ScanResult, error) {
 		log.Error().Err(err).Msg("error parsing libraryfolders.vdf")
 		return results, nil
 	}
+	m = normalizeVDFKeys(m)
 
 	lfs, ok := m["libraryfolders"].(map[string]any)
 	if !ok {
@@ -122,10 +123,11 @@ func ScanSteamApps(steamDir string) ([]platforms.ScanResult, error) {
 			if closeErr := af.Close(); closeErr != nil {
 				log.Warn().Err(closeErr).Msg("error closing manifest file")
 			}
+			am = normalizeVDFKeys(am)
 
-			appState, ok := am["AppState"].(map[string]any)
+			appState, ok := am["appstate"].(map[string]any)
 			if !ok {
-				log.Error().Msgf("AppState is not a map in manifest: %s", mf)
+				log.Error().Msgf("appstate is not a map in manifest: %s", mf)
 				continue
 			}
 

--- a/pkg/platforms/shared/steam/vdfutil.go
+++ b/pkg/platforms/shared/steam/vdfutil.go
@@ -1,0 +1,36 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package steam
+
+import "strings"
+
+// normalizeVDFKeys recursively lowercases all keys in a map[string]any tree.
+// Valve's VDF format is case-insensitive, but Go maps use exact string matching.
+// This normalizes keys at parse time so all lookups can use lowercase consistently.
+func normalizeVDFKeys(m map[string]any) map[string]any {
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			v = normalizeVDFKeys(nested)
+		}
+		result[strings.ToLower(k)] = v
+	}
+	return result
+}

--- a/pkg/platforms/shared/steam/vdfutil_test.go
+++ b/pkg/platforms/shared/steam/vdfutil_test.go
@@ -1,0 +1,99 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package steam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeVDFKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lowercases_top_level_keys", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]any{
+			"AppState": "value1",
+			"Name":     "value2",
+		}
+
+		result := normalizeVDFKeys(m)
+
+		assert.Equal(t, "value1", result["appstate"])
+		assert.Equal(t, "value2", result["name"])
+		_, hasOriginal := result["AppState"]
+		assert.False(t, hasOriginal)
+	})
+
+	t.Run("lowercases_nested_keys", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]any{
+			"AppState": map[string]any{
+				"AppID": "123",
+				"Name":  "Test Game",
+			},
+		}
+
+		result := normalizeVDFKeys(m)
+
+		nested, ok := result["appstate"].(map[string]any)
+		assert.True(t, ok)
+		assert.Equal(t, "123", nested["appid"])
+		assert.Equal(t, "Test Game", nested["name"])
+	})
+
+	t.Run("preserves_values", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]any{
+			"key": "MixedCaseValue",
+		}
+
+		result := normalizeVDFKeys(m)
+
+		assert.Equal(t, "MixedCaseValue", result["key"])
+	})
+
+	t.Run("handles_empty_map", func(t *testing.T) {
+		t.Parallel()
+
+		result := normalizeVDFKeys(map[string]any{})
+
+		assert.Empty(t, result)
+	})
+
+	t.Run("is_idempotent", func(t *testing.T) {
+		t.Parallel()
+
+		m := map[string]any{
+			"AppState": map[string]any{
+				"Name": "Test",
+			},
+		}
+
+		first := normalizeVDFKeys(m)
+		second := normalizeVDFKeys(first)
+
+		assert.Equal(t, first, second)
+	})
+}


### PR DESCRIPTION
## Summary

- Normalize all VDF keys to lowercase at parse time across all three parsers (binary VDF, appinfo binary VDF, text VDF)
- Valve's VDF format is case-insensitive, but Go maps use exact string matching — this caused non-Steam games to go undetected when `shortcuts.vdf` uses `"appname"` instead of `"AppName"`
- Adds `normalizeVDFKeys` helper for the external text VDF parser (`andygrunwald/vdf`)

Fixes #514