### PR TITLE
fix(batocera): skip hotkeygen exit when no launcher is active

### DIFF
--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -1188,3 +1188,24 @@ func TestRootDirs_DeduplicatesPaths(t *testing.T) {
 
 	assert.Equal(t, 1, count, "/userdata/roms should appear exactly once (deduplicated)")
 }
+
+// TestStopActiveLauncher_NoActiveState_ReturnsEarly tests that StopActiveLauncher
+// returns early without sending hotkeygen exit when nothing is active.
+// No MockESAPIServer is started — any ES API call would fail, proving the early return works.
+func TestStopActiveLauncher_NoActiveState_ReturnsEarly(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+
+	// No active media, no Kodi, no tracked process
+	platform.activeMedia = func() *models.ActiveMedia {
+		return nil
+	}
+	platform.setActiveMedia = func(_ *models.ActiveMedia) {}
+
+	err := platform.StopActiveLauncher(platforms.StopForMenu)
+	require.NoError(t, err, "should return nil when nothing is active")
+
+	err = platform.StopActiveLauncher(platforms.StopForPreemption)
+	require.NoError(t, err, "should return nil for any stop intent when nothing is active")
+}


### PR DESCRIPTION
## Summary

- On Batocera v42, scanning an NFC card when no game was running opened a "manufacturer menu" in EmulationStation instead of launching the game directly, requiring an extra button press or second scan
- Root cause: `StopActiveLauncher` unconditionally sent `hotkeygen --send exit` to ES even when nothing was running, which changed ES's UI state before the launch call
- Added an early return when no active media, Kodi, or tracked process exists — avoids sending the exit signal when idle

Fixes #512