### PR TITLE
fix(mediascanner): isolate SkipFilesystemScan scanners to prevent file wipe

### DIFF
--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -139,6 +139,12 @@ func PathIsLauncher(
 		}
 
 		if !inRoot && !isAbs {
+			log.Trace().
+				Str("launcher", l.ID).
+				Str("path", path).
+				Strs("folders", l.Folders).
+				Strs("rootDirs", rootDirs).
+				Msg("path not in any launcher folder (root or absolute)")
 			return false
 		}
 	}
@@ -154,6 +160,11 @@ func PathIsLauncher(
 		if l.Test != nil {
 			return l.Test(cfg, lp)
 		}
+		log.Trace().
+			Str("launcher", l.ID).
+			Str("path", path).
+			Strs("extensions", l.Extensions).
+			Msg("path extension did not match any launcher extension")
 		return false
 	}
 

--- a/pkg/helpers/paths_test.go
+++ b/pkg/helpers/paths_test.go
@@ -527,10 +527,6 @@ func TestGetPathExt(t *testing.T) {
 	}
 }
 
-// Note: PathIsLauncher tests are in the integration tests (pkg/database/mediascanner)
-// to avoid import cycles with the platforms package. The function is thoroughly tested
-// through those integration tests which exercise all code paths.
-
 // TestGetPathInfo_VirtualPathEdgeCases tests edge cases in GetPathInfo with virtual paths
 // that could cause issues with encoding/decoding, parsing, or display
 func TestGetPathInfo_VirtualPathEdgeCases(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Fix**: SkipFilesystemScan scanners (e.g. RetroBat, Kodi) now receive nil input and have their results *appended* to the shared file list, instead of *replacing* it. This prevents independent scanners that ignore their input from wiping files found by other launchers or the filesystem walk.
- **Regression tests**: Added `TestNewNamesIndex_IndependentScannerDoesNotWipeFiles` (filesystem + independent scanner, verifies both contribute files) and updated `TestNewNamesIndex_MixedSkipFilesystemScanAndCustomLauncher` with a Scanner that returns empty (exact RetroBat scenario).
- **Diagnostic logging**: Added trace-level logging to `PathIsLauncher` and `GetSystemPaths` for debugging launcher path resolution.
- **Test coverage**: Added `TestParseCustomLaunchers_AbsolutePathWithSystemID` for custom launcher parsing.

Fixes the bug where RetroBat's scanner wiped custom launcher files during PS2 indexing.

Closes #507 and closes #517