### PR TITLE
fix: select most specific launcher instead of first match

### DIFF
--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -633,18 +633,6 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		kodi.NewKodiAlbumLauncher(),
 		kodi.NewKodiArtistLauncher(),
 		kodi.NewKodiTVShowLauncher(),
-		platforms.Launcher{
-			ID:            "Generic",
-			Extensions:    []string{".sh"},
-			AllowListOnly: true,
-			Launch: func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
-				err := exec.CommandContext(context.Background(), path).Start()
-				if err != nil {
-					return nil, fmt.Errorf("failed to start command: %w", err)
-				}
-				return nil, nil //nolint:nilnil // Command launches don't return a process handle
-			},
-		},
 	)
 
 	for folder, info := range esde.SystemMap {
@@ -745,6 +733,19 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			},
 		})
 	}
+
+	launchers = append(launchers, platforms.Launcher{
+		ID:            "Generic",
+		Extensions:    []string{".sh"},
+		AllowListOnly: true,
+		Launch: func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+			err := exec.CommandContext(context.Background(), path).Start()
+			if err != nil {
+				return nil, fmt.Errorf("failed to start command: %w", err)
+			}
+			return nil, nil //nolint:nilnil // Command launches don't return a process handle
+		},
+	})
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
 }


### PR DESCRIPTION
## Summary

- Add specificity scoring to `FindLauncher()` so system-specific launchers (Folders, SystemID, Schemes) take precedence over generic ones — fixes Generic `.sh` launcher preempting the Ports `esapi.APILaunch` launcher on Batocera
- Move Batocera's Generic launcher definition after the `esde.SystemMap` loop as defense-in-depth
- Add 8 tests covering specificity scoring, scheme priority, folder+system vs system-only, generic-alone, no-match, allowlist, and tie-breaking

Closes #535