### PR TITLE
fix(ndef): support long NDEF records in tag parsing

### DIFF
--- a/pkg/readers/shared/ndef/ndef_test.go
+++ b/pkg/readers/shared/ndef/ndef_test.go
@@ -23,6 +23,8 @@ package ndef
 
 import (
 	"bytes"
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/hsanjuan/go-ndef"
@@ -403,7 +405,7 @@ func TestValidateNDEFMessage(t *testing.T) {
 	}
 }
 
-func TestValidateNDEFRecordHeader(t *testing.T) {
+func TestParseNDEFRecord(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -421,6 +423,12 @@ func TestValidateNDEFRecordHeader(t *testing.T) {
 			name: "Valid short URI record",
 			// flags=0xD1 (MB=1,ME=1,CF=0,SR=1,IL=0,TNF=1), typeLen=1, payloadLen=4, type='U', payload
 			payload: []byte{0xD1, 0x01, 0x04, 'U', 0x03, 'a', '.', 'b'},
+			wantErr: "",
+		},
+		{
+			name: "Valid long text record",
+			// flags=0xC1 (MB=1,ME=1,CF=0,SR=0,IL=0,TNF=1), typeLen=1, payloadLen=1(4-byte), type='T', payload
+			payload: []byte{0xC1, 0x01, 0x00, 0x00, 0x00, 0x01, 'T', 'x'},
 			wantErr: "",
 		},
 		{
@@ -453,12 +461,6 @@ func TestValidateNDEFRecordHeader(t *testing.T) {
 			wantErr: "chunked records not supported",
 		},
 		{
-			name: "Long record (SR not set)",
-			// flags=0xC1 (MB=1,ME=1,CF=0,SR=0,IL=0,TNF=1)
-			payload: []byte{0xC1, 0x01, 0x00, 0x00, 0x00, 0x01, 'T', 'x'},
-			wantErr: "long records not supported",
-		},
-		{
 			name: "Record with ID (IL set)",
 			// flags=0xD9 (MB=1,ME=1,CF=0,SR=1,IL=1,TNF=1)
 			payload: []byte{0xD9, 0x01, 0x01, 0x02, 'T', 'x', 'i', 'd'},
@@ -475,6 +477,24 @@ func TestValidateNDEFRecordHeader(t *testing.T) {
 			// flags=0xD1, typeLen=1, payloadLen=10, but only 1 payload byte
 			payload: []byte{0xD1, 0x01, 0x0A, 'T', 'x'},
 			wantErr: "truncated payload",
+		},
+		{
+			name: "Truncated long record header",
+			// flags=0xC1 (long), but only 4 bytes total (need at least 6 for payload length)
+			payload: []byte{0xC1, 0x01, 0x00, 0x00},
+			wantErr: "truncated record header",
+		},
+		{
+			name: "Truncated long record payload",
+			// flags=0xC1, typeLen=1, payloadLen=10(4-byte), type='T', but only 1 payload byte
+			payload: []byte{0xC1, 0x01, 0x00, 0x00, 0x00, 0x0A, 'T', 'x'},
+			wantErr: "truncated payload",
+		},
+		{
+			name: "Long record payload length exceeds maximum",
+			// flags=0xC1, typeLen=1, payloadLen=0x00010000 (exceeds 0xFFFF cap)
+			payload: []byte{0xC1, 0x01, 0x00, 0x01, 0x00, 0x00, 'T'},
+			wantErr: "payload length 65536 exceeds maximum",
 		},
 		{
 			name: "Empty record with non-zero type length",
@@ -505,18 +525,108 @@ func TestValidateNDEFRecordHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateNDEFRecordHeader(tt.payload)
+			_, err := parseNDEFRecord(tt.payload)
 
 			if tt.wantErr == "" {
 				if err != nil {
-					t.Errorf("validateNDEFRecordHeader() unexpected error: %v", err)
+					t.Errorf("parseNDEFRecord() unexpected error: %v", err)
 				}
 			} else {
 				if err == nil {
-					t.Errorf("validateNDEFRecordHeader() expected error containing %q but got none", tt.wantErr)
+					t.Errorf("parseNDEFRecord() expected error containing %q but got none", tt.wantErr)
 				} else if !bytes.Contains([]byte(err.Error()), []byte(tt.wantErr)) {
-					t.Errorf("validateNDEFRecordHeader() error = %v, want error containing %q", err, tt.wantErr)
+					t.Errorf("parseNDEFRecord() error = %v, want error containing %q", err, tt.wantErr)
 				}
+			}
+		})
+	}
+}
+
+func TestParseToText_LongRecord(t *testing.T) {
+	t.Parallel()
+
+	// Exact bytes from issue #552 bug report — a long MGL ZapScript on an NTAG
+	issueBytes, err := hex.DecodeString(
+		"03ff0162c1010000015b5402656e2a2a6d69737465722e6d676c3a3c6d6973746572" +
+			"67616d656465736372697074696f6e3e203c7262663e5f436f6d70757465722f5469" +
+			"393934613c2f7262663e203c7365746e616d652073616d655f6469723d2231223e42" +
+			"6c6173746f3c2f7365746e616d653e203c66696c652064656c61793d223022207479" +
+			"70653d22662220696e6465783d22332220706174683d2254492d39395f34412e7a69" +
+			"702f54492d39395f34412f5353535f47616d65732f47524f4d20466f726d61742f42" +
+			"6c6173746f20283139383029284d696c746f6e20427261646c6579292850484d2033" +
+			"303332295f5b475d2e62696e222f3e203c72657365742064656c61793d2231222f3e" +
+			"203c2f6d697374657267616d656465736372697074696f6e3e207c7c2a2a64656c61" +
+			"793a333030307c7c2a2a696e7075742e6b6579626f6172643a7b656e7465727d7c7c" +
+			"2a2a696e7075742e6b6579626f6172643a32fe000000000000000000")
+	if err != nil {
+		t.Fatalf("bad test hex data: %v", err)
+	}
+
+	expectedText := "**mister.mgl:<mistergamedescription> <rbf>_Computer/Ti994a</rbf>" +
+		" <setname same_dir=\"1\">Blasto</setname>" +
+		" <file delay=\"0\" type=\"f\" index=\"3\"" +
+		" path=\"TI-99_4A.zip/TI-99_4A/SSS_Games/GROM Format/" +
+		"Blasto (1980)(Milton Bradley)(PHM 3032)_[G].bin\"/>" +
+		" <reset delay=\"1\"/> </mistergamedescription>" +
+		" ||**delay:3000||**input.keyboard:{enter}||**input.keyboard:2"
+
+	result, err := ParseToText(issueBytes)
+	if err != nil {
+		t.Fatalf("ParseToText() failed on issue #552 bytes: %v", err)
+	}
+
+	if result != expectedText {
+		t.Errorf("ParseToText() = %q, expected %q", result, expectedText)
+	}
+}
+
+func TestBuildTextMessage_RoundTrip_LongRecord(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "300 byte text (long NDEF record)",
+			text: strings.Repeat("A", 300),
+		},
+		{
+			name: "MGL-style ZapScript",
+			text: "**mister.mgl:<mistergamedescription> <rbf>_Computer/Ti994a</rbf>" +
+				" <setname same_dir=\"1\">Blasto</setname>" +
+				" <file delay=\"0\" type=\"f\" index=\"3\"" +
+				" path=\"TI-99_4A.zip/TI-99_4A/SSS_Games/GROM Format/" +
+				"Blasto (1980)(Milton Bradley)(PHM 3032)_[G].bin\"/>" +
+				" <reset delay=\"1\"/> </mistergamedescription>" +
+				" ||**delay:3000||**input.keyboard:{enter}||**input.keyboard:2",
+		},
+		{
+			name: "Boundary - 252 chars (short record limit)",
+			text: strings.Repeat("B", 252),
+		},
+		{
+			name: "Boundary - 253 chars (just over short record limit)",
+			text: strings.Repeat("C", 253),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			built, err := BuildTextMessage(tt.text)
+			if err != nil {
+				t.Fatalf("BuildTextMessage() failed: %v", err)
+			}
+
+			parsed, err := ParseToText(built)
+			if err != nil {
+				t.Fatalf("ParseToText() failed: %v", err)
+			}
+
+			if parsed != tt.text {
+				t.Errorf("Round trip failed: got %d chars, want %d chars", len(parsed), len(tt.text))
 			}
 		})
 	}

--- a/pkg/readers/shared/ndef/parser.go
+++ b/pkg/readers/shared/ndef/parser.go
@@ -25,9 +25,14 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-
-	"github.com/hsanjuan/go-ndef"
 )
+
+// ndefRecord holds the parsed fields of a single NDEF record.
+type ndefRecord struct {
+	recType string
+	payload []byte
+	tnf     byte
+}
 
 // ParseToText parses raw NDEF data and returns the first text or URI record as a string
 func ParseToText(data []byte) (string, error) {
@@ -42,29 +47,27 @@ func ParseToText(data []byte) (string, error) {
 		return "", ErrNoNDEF
 	}
 
-	// Validate NDEF record header before calling go-ndef to avoid
-	// algorithmic complexity issues with malformed input
-	if err := validateNDEFRecordHeader(payload); err != nil {
+	// Parse the NDEF record header and extract type + payload directly,
+	// without relying on go-ndef (which has algorithmic complexity bugs
+	// that can cause hangs with malformed input).
+	rec, err := parseNDEFRecord(payload)
+	if err != nil {
 		return "", fmt.Errorf("invalid NDEF record: %w", err)
 	}
 
-	// Parse using go-ndef
-	msg := &ndef.Message{}
-	_, err := msg.Unmarshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse NDEF message: %w", err)
+	// TNF 0x01 = NFC Forum Well-Known Type
+	if rec.tnf != 1 {
+		return "", ErrNoNDEF
 	}
 
-	// Find first text or URI record
-	for _, rec := range msg.Records {
-		if rec.TNF() == ndef.NFCForumWellKnownType {
-			if result, err := handleWellKnownRecord(rec); err == nil {
-				return result, nil
-			}
-		}
+	switch rec.recType {
+	case "T":
+		return parseTextPayload(rec.payload)
+	case "U":
+		return parseURIPayload(rec.payload)
+	default:
+		return "", ErrNoNDEF
 	}
-
-	return "", ErrNoNDEF
 }
 
 // ValidateNDEFMessage validates basic NDEF message structure
@@ -89,13 +92,13 @@ func ValidateNDEFMessage(data []byte) error {
 	return nil
 }
 
-// validateNDEFRecordHeader performs strict validation of NDEF record structure
-// to reject malformed data before passing to go-ndef library.
-// go-ndef has algorithmic complexity bugs that can cause hangs with malformed input,
-// so we only accept the common case: short records without chunking or IDs.
-func validateNDEFRecordHeader(payload []byte) error {
+// parseNDEFRecord parses a single NDEF record from the payload, supporting
+// both short records (SR=1, 1-byte payload length) and long records (SR=0,
+// 4-byte payload length). Only single-record messages (MB+ME set) without
+// chunking or ID fields are accepted.
+func parseNDEFRecord(payload []byte) (ndefRecord, error) {
 	if len(payload) < 3 {
-		return fmt.Errorf("%w: record too short", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: record too short", ErrInvalidNDEF)
 	}
 
 	// First byte is flags: MB|ME|CF|SR|IL|TNF(3 bits)
@@ -104,59 +107,93 @@ func validateNDEFRecordHeader(payload []byte) error {
 
 	// TNF must be 0-6 (0x00-0x06), value 7 is reserved
 	if tnf > 6 {
-		return fmt.Errorf("%w: invalid TNF value %d", ErrInvalidNDEF, tnf)
+		return ndefRecord{}, fmt.Errorf("%w: invalid TNF value %d", ErrInvalidNDEF, tnf)
 	}
 
 	// MB (Message Begin) must be set for first record
 	if (flags & 0x80) == 0 {
-		return fmt.Errorf("%w: MB flag not set on first record", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: MB flag not set on first record", ErrInvalidNDEF)
 	}
 
-	// ME (Message End) should be set for single-record messages (common case)
-	// We require this to avoid multi-record parsing complexity in go-ndef
+	// ME (Message End) must be set — we only support single-record messages
 	if (flags & 0x40) == 0 {
-		return fmt.Errorf("%w: ME flag not set (multi-record messages not supported)", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: ME flag not set (multi-record messages not supported)", ErrInvalidNDEF)
 	}
 
-	// CF (Chunk Flag) must NOT be set - chunked records trigger go-ndef bugs
+	// CF (Chunk Flag) must NOT be set — chunked records not supported
 	if (flags & 0x20) != 0 {
-		return fmt.Errorf("%w: chunked records not supported", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: chunked records not supported", ErrInvalidNDEF)
 	}
 
-	// SR (Short Record) must be set - long records can trigger go-ndef bugs
-	if (flags & 0x10) == 0 {
-		return fmt.Errorf("%w: long records not supported", ErrInvalidNDEF)
-	}
-
-	// IL (ID Length) must NOT be set - records with IDs can trigger go-ndef bugs
+	// IL (ID Length) must NOT be set — records with IDs not supported
 	if (flags & 0x08) != 0 {
-		return fmt.Errorf("%w: records with ID not supported", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: records with ID not supported", ErrInvalidNDEF)
 	}
 
-	// For short records without ID: header is flags(1) + typeLen(1) + payloadLen(1) + type
+	shortRecord := (flags & 0x10) != 0
 	typeLen := int(payload[1])
-	if len(payload) < 3+typeLen {
-		return fmt.Errorf("%w: truncated record header", ErrInvalidNDEF)
+
+	// Parse payload length depending on SR flag
+	var payloadLen int
+	var headerLen int
+
+	if shortRecord {
+		// Short record: flags(1) + typeLen(1) + payloadLen(1) + type
+		headerLen = 3 + typeLen
+		payloadLen = int(payload[2])
+	} else {
+		// Long record: flags(1) + typeLen(1) + payloadLen(4) + type
+		headerLen = 6 + typeLen
+		if len(payload) < 6 {
+			return ndefRecord{}, fmt.Errorf("%w: truncated record header", ErrInvalidNDEF)
+		}
+		rawLen := binary.BigEndian.Uint32(payload[2:6])
+		if rawLen > 0xFFFF {
+			return ndefRecord{}, fmt.Errorf(
+				"%w: payload length %d exceeds maximum",
+				ErrInvalidNDEF, rawLen,
+			)
+		}
+		payloadLen = int(rawLen)
 	}
 
-	// Get payload length and validate total size
-	payloadLen := int(payload[2])
-	totalLen := 3 + typeLen + payloadLen
+	if len(payload) < headerLen {
+		return ndefRecord{}, fmt.Errorf("%w: truncated record header", ErrInvalidNDEF)
+	}
+
+	totalLen := headerLen + payloadLen
 	if len(payload) < totalLen {
-		return fmt.Errorf("%w: truncated payload (need %d, have %d)", ErrInvalidNDEF, totalLen, len(payload))
+		return ndefRecord{}, fmt.Errorf(
+			"%w: truncated payload (need %d, have %d)",
+			ErrInvalidNDEF, totalLen, len(payload),
+		)
 	}
 
 	// For TNF 0x00 (Empty), type and payload length must be 0
 	if tnf == 0 && (typeLen != 0 || payloadLen != 0) {
-		return fmt.Errorf("%w: empty record must have zero lengths", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: empty record must have zero lengths", ErrInvalidNDEF)
 	}
 
 	// For TNF 0x01 (Well-Known), type must be present
 	if tnf == 1 && typeLen == 0 {
-		return fmt.Errorf("%w: well-known record must have type", ErrInvalidNDEF)
+		return ndefRecord{}, fmt.Errorf("%w: well-known record must have type", ErrInvalidNDEF)
 	}
 
-	return nil
+	// Extract type and payload
+	var recType string
+	if shortRecord {
+		recType = string(payload[3 : 3+typeLen])
+	} else {
+		recType = string(payload[6 : 6+typeLen])
+	}
+
+	recPayload := payload[headerLen : headerLen+payloadLen]
+
+	return ndefRecord{
+		tnf:     tnf,
+		recType: recType,
+		payload: recPayload,
+	}, nil
 }
 
 // extractNDEFPayload extracts the NDEF message from TLV format
@@ -210,33 +247,6 @@ func extractLongFormatPayload(data []byte, offset int) []byte {
 		return data[offset+4 : offset+4+length]
 	}
 	return nil
-}
-
-// handleWellKnownRecord processes NFC Forum well-known types
-func handleWellKnownRecord(rec *ndef.Record) (string, error) {
-	typeStr := rec.Type()
-	payloadBytes, err := extractPayloadBytes(rec)
-	if err != nil {
-		return "", err
-	}
-
-	switch typeStr {
-	case "T": // Text
-		return parseTextPayload(payloadBytes)
-	case "U": // URI
-		return parseURIPayload(payloadBytes)
-	default:
-		return "", fmt.Errorf("unsupported well-known type: %s", typeStr)
-	}
-}
-
-// extractPayloadBytes extracts the payload bytes from an NDEF record
-func extractPayloadBytes(rec *ndef.Record) ([]byte, error) {
-	payload, err := rec.Payload()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get NDEF record payload: %w", err)
-	}
-	return payload.Marshal(), nil
 }
 
 // parseTextPayload parses a text record payload


### PR DESCRIPTION
## Summary

- Replace go-ndef library in the shared NDEF read path with manual record parsing, removing the restriction that rejected long records (SR=0, 4-byte payload length)
- Tags with >255 bytes of ZapScript content (e.g. MGL commands with long file paths) now scan correctly on all readers using the shared NDEF parser: libnfc, acr122pcsc, and legacy pn532uart (the modern pn532 reader uses go-pn532's own parser and was not affected)
- Cap long record payload length at 65535 bytes (matching TLV layer maximum) to prevent integer overflow on 32-bit platforms (MiSTer GOARCH=arm)

Closes #552