### PR TITLE
fix: convert launcher paths to OS-native format

### DIFF
--- a/pkg/platforms/launch.go
+++ b/pkg/platforms/launch.go
@@ -21,6 +21,7 @@ package platforms
 
 import (
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -83,6 +84,17 @@ func IsActionDetails(action string) bool {
 	return strings.EqualFold(action, zapscript.ActionDetails)
 }
 
+// nativeLaunchPath converts a forward-slash DB path to OS-native separators
+// for passing to launcher executables. URI paths (containing "://") are
+// returned unchanged because filepath.FromSlash would corrupt their scheme.
+// On non-Windows systems filepath.FromSlash is a no-op.
+func nativeLaunchPath(path string) string {
+	if strings.Contains(path, "://") {
+		return path
+	}
+	return filepath.FromSlash(path)
+}
+
 // DoLaunch launches the given path and updates the active media with it if
 // it was successful. The getDisplayName callback extracts a display name from the path.
 func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
@@ -113,9 +125,13 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 		return fmt.Errorf("launcher %q has no launch function configured", params.Launcher.ID)
 	}
 
+	// Convert DB paths (forward slashes) to OS-native format for launcher
+	// executables. URI paths are left unchanged. On Linux this is a no-op.
+	launchPath := nativeLaunchPath(params.Path)
+
 	switch params.Launcher.Lifecycle {
 	case LifecycleTracked:
-		proc, err := params.Launcher.Launch(params.Config, params.Path, params.Options)
+		proc, err := params.Launcher.Launch(params.Config, launchPath, params.Options)
 		if err != nil {
 			return fmt.Errorf("failed to launch: %w", err)
 		}
@@ -126,7 +142,7 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 	case LifecycleBlocking:
 		go func() {
 			log.Debug().Msgf("launching blocking process for: %s", params.Path)
-			proc, err := params.Launcher.Launch(params.Config, params.Path, params.Options)
+			proc, err := params.Launcher.Launch(params.Config, launchPath, params.Options)
 			if err != nil {
 				log.Error().Err(err).Msgf("blocking launcher failed for: %s", params.Path)
 				params.SetActiveMedia(nil)
@@ -148,7 +164,7 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 			}
 		}()
 	case LifecycleFireAndForget:
-		_, err := params.Launcher.Launch(params.Config, params.Path, params.Options)
+		_, err := params.Launcher.Launch(params.Config, launchPath, params.Options)
 		if err != nil {
 			return fmt.Errorf("failed to launch: %w", err)
 		}

--- a/pkg/platforms/launch_internal_test.go
+++ b/pkg/platforms/launch_internal_test.go
@@ -1,0 +1,54 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package platforms
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNativeLaunchPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"forward_slash_windows_path", "C:/Games/SNES/mario.sfc", filepath.FromSlash("C:/Games/SNES/mario.sfc")},
+		{"unix_absolute_path", "/home/user/roms/game.nes", filepath.FromSlash("/home/user/roms/game.nes")},
+		{"relative_path", "snes/mario.sfc", filepath.FromSlash("snes/mario.sfc")},
+		{"steam_uri_unchanged", "steam://run/12345", "steam://run/12345"},
+		{"kodi_uri_unchanged", "kodi://movies/12345", "kodi://movies/12345"},
+		{"http_uri_unchanged", "http://example.com/file.rom", "http://example.com/file.rom"},
+		{"https_uri_unchanged", "https://example.com/file.rom", "https://example.com/file.rom"},
+		{"empty_string", "", ""},
+		{"no_slashes", "game.rom", "game.rom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, nativeLaunchPath(tt.input))
+		})
+	}
+}

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -21,6 +21,7 @@ package platforms_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -523,4 +524,73 @@ func TestDoLaunch_TrackedLauncherError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to launch")
 	mockPlatform.AssertExpectations(t)
+}
+
+func TestDoLaunch_NativeLaunchPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		inputPath         string
+		expectedLaunchArg string
+	}{
+		{
+			name:              "file_path_converted_to_native",
+			inputPath:         "C:/Games/SNES/mario.sfc",
+			expectedLaunchArg: filepath.FromSlash("C:/Games/SNES/mario.sfc"),
+		},
+		{
+			name:              "uri_path_unchanged",
+			inputPath:         "steam://run/12345",
+			expectedLaunchArg: "steam://run/12345",
+		},
+		{
+			name:              "kodi_uri_unchanged",
+			inputPath:         "kodi://movies/12345",
+			expectedLaunchArg: "kodi://movies/12345",
+		},
+		{
+			name:              "unix_style_path_converted_to_native",
+			inputPath:         "/home/user/roms/game.nes",
+			expectedLaunchArg: filepath.FromSlash("/home/user/roms/game.nes"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("StopActiveLauncher", platforms.StopForPreemption).Return(nil).Once()
+
+			var capturedPath string
+			launcher := &platforms.Launcher{
+				ID:        "test-launcher",
+				SystemID:  "test-system",
+				Lifecycle: platforms.LifecycleFireAndForget,
+				Launch: func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+					capturedPath = path
+					var noProcess *os.Process
+					return noProcess, nil
+				},
+			}
+
+			params := &platforms.LaunchParams{
+				Platform:       mockPlatform,
+				Config:         &config.Instance{},
+				SetActiveMedia: func(*models.ActiveMedia) {},
+				Launcher:       launcher,
+				DB:             nil,
+				Path:           tt.inputPath,
+			}
+
+			err := platforms.DoLaunch(params, func(_ string) string { return "game" })
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedLaunchArg, capturedPath,
+				"Launch should receive OS-native path")
+
+			mockPlatform.AssertExpectations(t)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Convert forward-slash DB paths to OS-native separators (`filepath.FromSlash`) in `DoLaunch` before passing to launcher executables
- URI paths (e.g., `steam://`, `kodi://`) are left unchanged to avoid corrupting their scheme
- DB lookups and `ActiveMedia.Path` retain forward slashes for consistency
- No-op on Linux; fixes Windows launchers like PCSX2 that expect backslash paths

Closes #542