### PR TITLE
feat(config): add ignore_on_connect option to suppress initial reader scans

### DIFF
--- a/pkg/config/configreaders.go
+++ b/pkg/config/configreaders.go
@@ -40,11 +40,12 @@ type DriverConfig struct {
 }
 
 type ReadersScan struct {
-	Mode         string   `toml:"mode"`
-	OnScan       string   `toml:"on_scan,omitempty"`
-	OnRemove     string   `toml:"on_remove,omitempty"`
-	IgnoreSystem []string `toml:"ignore_system,omitempty"`
-	ExitDelay    float32  `toml:"exit_delay,omitempty"`
+	Mode            string   `toml:"mode"`
+	OnScan          string   `toml:"on_scan,omitempty"`
+	OnRemove        string   `toml:"on_remove,omitempty"`
+	IgnoreSystem    []string `toml:"ignore_system,omitempty"`
+	ExitDelay       float32  `toml:"exit_delay,omitempty"`
+	IgnoreOnConnect bool     `toml:"ignore_on_connect,omitempty"`
 }
 
 type ReadersConnect struct {
@@ -68,6 +69,12 @@ func (c *Instance) ReadersScan() ReadersScan {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.vals.Readers.Scan
+}
+
+func (c *Instance) ScanIgnoreOnConnect() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.vals.Readers.Scan.IgnoreOnConnect
 }
 
 func (c *Instance) IsHoldModeIgnoredSystem(systemID string) bool {
@@ -118,6 +125,12 @@ func (c *Instance) SetScanIgnoreSystem(ignoreSystem []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.vals.Readers.Scan.IgnoreSystem = ignoreSystem
+}
+
+func (c *Instance) SetScanIgnoreOnConnect(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Readers.Scan.IgnoreOnConnect = enabled
 }
 
 func (c *Instance) Readers() Readers {

--- a/pkg/service/reader_manager_test.go
+++ b/pkg/service/reader_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -46,12 +47,16 @@ type readerManagerEnv struct {
 	itq       chan tokens.Token
 }
 
-func setupReaderManager(t *testing.T) *readerManagerEnv {
+func setupReaderManager(t *testing.T, opts ...func(*config.Instance)) *readerManagerEnv {
 	t.Helper()
 
 	fs := testhelpers.NewMemoryFS()
 	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
 	require.NoError(t, err)
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
 	mockPlayer := mocks.NewMockPlayer()
 	mockPlayer.SetupNoOpMock()
@@ -321,4 +326,194 @@ func TestReaderManager_WroteTokenSuppression(t *testing.T) {
 	})
 	tok := env.expectToken(t)
 	assert.Equal(t, "nfc-other-002", tok.UID)
+}
+
+func withIgnoreOnConnect(cfg *config.Instance) {
+	cfg.SetScanIgnoreOnConnect(true)
+}
+
+func TestReaderManager_IgnoreOnConnect_SuppressesFirstScan(t *testing.T) {
+	t.Parallel()
+	env := setupReaderManager(t, withIgnoreOnConnect)
+
+	// First scan from a reader should be suppressed
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "startup-card",
+			Text:     "**launch.system:nes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	env.expectNoToken(t)
+}
+
+func TestReaderManager_IgnoreOnConnect_SecondScanProceeds(t *testing.T) {
+	t.Parallel()
+	env := setupReaderManager(t, withIgnoreOnConnect)
+
+	// First scan suppressed
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "startup-card",
+			Text:     "**launch.system:nes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	env.expectNoToken(t)
+
+	// Remove the card
+	env.sendScan(readers.Scan{Source: "test-reader", Token: nil})
+	env.expectNoToken(t)
+
+	// Second scan from the same reader should proceed
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "real-card",
+			Text:     "**launch.system:snes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	tok := env.expectToken(t)
+	assert.Equal(t, "real-card", tok.UID)
+}
+
+func TestReaderManager_IgnoreOnConnect_Disabled(t *testing.T) {
+	t.Parallel()
+	env := setupReaderManager(t)
+
+	// With ignore_on_connect disabled (default), first scan should proceed
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "first-card",
+			Text:     "**launch.system:nes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	tok := env.expectToken(t)
+	assert.Equal(t, "first-card", tok.UID)
+}
+
+func TestReaderManager_IgnoreOnConnect_MultipleReaders(t *testing.T) {
+	t.Parallel()
+	env := setupReaderManager(t, withIgnoreOnConnect)
+
+	// First scan from reader-1: suppressed
+	env.sendScan(readers.Scan{
+		Source: "test-reader-1",
+		Token: &tokens.Token{
+			UID:      "card-a",
+			Text:     "**launch.system:nes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	env.expectNoToken(t)
+
+	// First scan from reader-2: also suppressed (independent tracking)
+	env.sendScan(readers.Scan{
+		Source: "test-reader-2",
+		Token: &tokens.Token{
+			UID:      "card-b",
+			Text:     "**launch.system:snes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-2",
+		},
+	})
+	env.expectNoToken(t)
+
+	// Remove from reader-1
+	env.sendScan(readers.Scan{Source: "test-reader-1", Token: nil})
+	env.expectNoToken(t)
+
+	// Second scan from reader-1: proceeds
+	env.sendScan(readers.Scan{
+		Source: "test-reader-1",
+		Token: &tokens.Token{
+			UID:      "card-c",
+			Text:     "**launch.system:gb",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	tok := env.expectToken(t)
+	assert.Equal(t, "card-c", tok.UID)
+
+	// Remove from reader-2
+	env.sendScan(readers.Scan{Source: "test-reader-2", Token: nil})
+	env.expectNoToken(t)
+
+	// Second scan from reader-2: also proceeds
+	env.sendScan(readers.Scan{
+		Source: "test-reader-2",
+		Token: &tokens.Token{
+			UID:      "card-d",
+			Text:     "**launch.system:gba",
+			ScanTime: time.Now(),
+			ReaderID: "reader-2",
+		},
+	})
+	tok2 := env.expectToken(t)
+	assert.Equal(t, "card-d", tok2.UID)
+}
+
+func TestReaderManager_IgnoreOnConnect_ReaderReconnection(t *testing.T) {
+	t.Parallel()
+	env := setupReaderManager(t, withIgnoreOnConnect)
+
+	// First scan from reader: suppressed
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "card-a",
+			Text:     "**launch.system:nes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	env.expectNoToken(t)
+
+	// Reader error (USB disconnect) — clears acknowledged state
+	env.sendScan(readers.Scan{
+		Source:      "test-reader",
+		Token:       nil,
+		ReaderError: true,
+	})
+	env.expectNoToken(t)
+
+	// Reader reconnects with a different card — first scan suppressed again
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "card-b",
+			Text:     "**launch.system:snes",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	env.expectNoToken(t)
+
+	// Remove card
+	env.sendScan(readers.Scan{Source: "test-reader", Token: nil})
+	env.expectNoToken(t)
+
+	// Second scan after reconnection: proceeds
+	env.sendScan(readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "card-c",
+			Text:     "**launch.system:gb",
+			ScanTime: time.Now(),
+			ReaderID: "reader-1",
+		},
+	})
+	tok2 := env.expectToken(t)
+	assert.Equal(t, "card-c", tok2.UID)
 }

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -285,6 +285,7 @@ func readerManager(
 	var lastError time.Time
 
 	proc := &scanPreprocessor{}
+	connectScanSeen := make(map[string]bool)
 	var exitTimer clockwork.Timer
 
 	var autoDetector *AutoDetector
@@ -413,6 +414,18 @@ preprocessing:
 			continue preprocessing
 
 		case scanNewToken:
+			// Suppress the first scan from each newly-connected reader when ignore_on_connect is enabled
+			if svc.Config.ScanIgnoreOnConnect() && scan.ReaderID != "" && !connectScanSeen[scan.ReaderID] {
+				connectScanSeen[scan.ReaderID] = true
+				log.Info().
+					Str("readerID", scan.ReaderID).
+					Msg("suppressing initial detection from reader (ignore_on_connect enabled)")
+				continue preprocessing
+			}
+			if svc.Config.ScanIgnoreOnConnect() && scan.ReaderID != "" {
+				connectScanSeen[scan.ReaderID] = true
+			}
+
 			log.Info().Msgf("new token scanned: %v", scan)
 
 			// Run on_scan hook before SetActiveCard so last_scanned refers to previous token
@@ -461,6 +474,10 @@ preprocessing:
 				Str("source", scanSource).
 				Bool("prevTokenSet", proc.PrevToken() != nil).
 				Msg("token removal due to reader error, keeping media running")
+			// Clear acknowledged state so reconnection triggers a fresh suppression
+			if pt := proc.PrevToken(); pt != nil && pt.ReaderID != "" {
+				delete(connectScanSeen, pt.ReaderID)
+			}
 			if exitTimer != nil {
 				if stopped := exitTimer.Stop(); stopped {
 					log.Debug().Msg("cancelled exit timer due to reader error")


### PR DESCRIPTION
## Summary

- Adds `readers.scan.ignore_on_connect` config option that suppresses the first card detection from each newly-connected reader
- Prevents games from relaunching when a card is left on the reader between sessions
- Per-reader-connection tracking (not time-based) so it works for boot, USB hotplug, and sleep/wake
- Clears suppression state on reader error/disconnect so reconnections get a fresh suppression

```toml
[readers.scan]
ignore_on_connect = true
```

Closes #539