### PR TITLE
feat(batocera): add .squashfs and .zcci extensions for 3DS

### DIFF
--- a/pkg/platforms/batocera/systemmap_test.go
+++ b/pkg/platforms/batocera/systemmap_test.go
@@ -175,6 +175,9 @@ func TestBatoceraOfficialExtensions(t *testing.T) {
 			".mod", ".xm", ".stm", ".s3m", ".far", ".it", ".669", ".mtm",
 		},
 
+		// Handheld systems
+		"3ds": {".3ds", ".cci", ".cxi", ".squashfs", ".zcci"},
+
 		// Modern console systems
 		"ps2":     {".iso", ".mdf", ".nrg", ".bin", ".img", ".dump", ".gz", ".cso", ".chd", ".m3u"},
 		"ps3":     {".ps3", ".psn", ".squashfs"},

--- a/pkg/platforms/shared/esde/systemmap.go
+++ b/pkg/platforms/shared/esde/systemmap.go
@@ -55,7 +55,7 @@ var SystemMap = map[string]SystemInfo{
 	},
 	"3ds": {
 		SystemID:   systemdefs.System3DS,
-		Extensions: []string{".3ds", ".cci", ".cxi"},
+		Extensions: []string{".3ds", ".cci", ".cxi", ".squashfs", ".zcci"},
 		LauncherID: "3DS",
 	},
 	"abuse": {


### PR DESCRIPTION
## Summary
- Adds `.squashfs` and `.zcci` file extensions to the 3DS system definition in the shared ESDE system map
- Batocera's Azahar emulator supports these formats for 3DS games

Closes #561