### PR TITLE
feat(pn532): skip re-probing failed serial ports

### DIFF
--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -498,6 +498,11 @@ func (r *Reader) processNewTag(ctx context.Context, detectedTag *pn532.DetectedT
 }
 
 func (r *Reader) Close() error {
+	// Always clear caches so the port can be re-probed on reconnection,
+	// even if session or device close fails.
+	defer detection.ClearDetectionCache()
+	defer ClearFailedProbe(r.deviceInfo.Path)
+
 	r.mutex.Lock()
 
 	r.connected = false
@@ -530,9 +535,6 @@ func (r *Reader) Close() error {
 			return fmt.Errorf("failed to close PN532 device: %w", err)
 		}
 	}
-
-	detection.ClearDetectionCache()
-	ClearFailedProbe(r.deviceInfo.Path)
 
 	return nil
 }

--- a/pkg/readers/pn532/pn532_test.go
+++ b/pkg/readers/pn532/pn532_test.go
@@ -265,8 +265,22 @@ func TestClose_ClearsFailedProbe(t *testing.T) {
 }
 
 // TestClose_SessionError verifies that Close returns an error when the
-// session fails to close. Not parallel because it modifies package-level state.
+// session fails to close, but still clears the failed probe cache.
+// Not parallel because it modifies package-level state.
 func TestClose_SessionError(t *testing.T) {
+	// Save and restore package state
+	probeStateMu.Lock()
+	origFailed := failedProbePaths
+	defer func() {
+		probeStateMu.Lock()
+		failedProbePaths = origFailed
+		probeStateMu.Unlock()
+	}()
+	failedProbePaths = map[string]failedProbeEntry{
+		"/dev/ttyUSB0": {deviceModTime: time.Now()},
+	}
+	probeStateMu.Unlock()
+
 	reader := &Reader{
 		session: &mockPollingSession{
 			closeFunc: func() error {
@@ -283,10 +297,17 @@ func TestClose_SessionError(t *testing.T) {
 	err := reader.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to close PN532 session")
+
+	// Probe cache should still be cleared despite the error
+	probeStateMu.RLock()
+	assert.NotContains(t, failedProbePaths, "/dev/ttyUSB0",
+		"failed probe should be cleared even when session close fails")
+	probeStateMu.RUnlock()
 }
 
 // TestClose_DeviceError verifies that Close returns an error when the
-// device fails to close. Not parallel because it modifies package-level state.
+// device fails to close, but still clears the failed probe cache.
+// Not parallel because it modifies package-level state.
 func TestClose_DeviceError(t *testing.T) {
 	// Save and restore package state
 	probeStateMu.Lock()
@@ -296,6 +317,9 @@ func TestClose_DeviceError(t *testing.T) {
 		failedProbePaths = origFailed
 		probeStateMu.Unlock()
 	}()
+	failedProbePaths = map[string]failedProbeEntry{
+		"/dev/ttyUSB0": {deviceModTime: time.Now()},
+	}
 	probeStateMu.Unlock()
 
 	reader := &Reader{
@@ -310,6 +334,12 @@ func TestClose_DeviceError(t *testing.T) {
 	err := reader.Close()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to close PN532 device")
+
+	// Probe cache should still be cleared despite the error
+	probeStateMu.RLock()
+	assert.NotContains(t, failedProbePaths, "/dev/ttyUSB0",
+		"failed probe should be cleared even when device close fails")
+	probeStateMu.RUnlock()
 }
 
 // TODO: Detect() integration with failed probe tracking is untested because


### PR DESCRIPTION
## Summary

- Track serial ports that fail PN532 hardware probing and exclude them from subsequent detection cycles, avoiding repeated slow probes of non-PN532 devices
- Use device file ModTime fingerprinting to automatically re-probe when a device is unplugged/replugged or swapped at the same path
- Scope probe cache clearing to the disconnecting reader's path only, so other readers' cached results are preserved

Closes #505