### PR TITLE
fix(database): add fallback systems for media types

### DIFF
--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -208,6 +208,35 @@ func AllSystems() []System {
 	return systems
 }
 
+// SystemsWithFallbacks returns the input systems plus any fallback systems,
+// with duplicates removed. Original systems appear first, followed by
+// fallback systems in the order they were encountered.
+// Only direct fallbacks are included, not transitive.
+func SystemsWithFallbacks(systems []System) []System {
+	seen := make(map[string]struct{}, len(systems)*2)
+	result := make([]System, 0, len(systems)*2)
+
+	for _, sys := range systems {
+		if _, ok := seen[sys.ID]; ok {
+			continue
+		}
+		seen[sys.ID] = struct{}{}
+		result = append(result, sys)
+
+		for _, fbID := range sys.Fallbacks {
+			if _, ok := seen[fbID]; ok {
+				continue
+			}
+			seen[fbID] = struct{}{}
+			if fbSys, err := GetSystem(fbID); err == nil {
+				result = append(result, *fbSys)
+			}
+		}
+	}
+
+	return result
+}
+
 // Consoles
 const (
 	System3DO               = "3DO"
@@ -1151,33 +1180,39 @@ var Systems = map[string]System{
 		ID:        SystemMovie,
 		Slugs:     []string{"movies", "film", "cinema"},
 		MediaType: MediaTypeMovie,
+		Fallbacks: []string{SystemVideo},
 	},
 	SystemTVEpisode: {
 		ID:        SystemTVEpisode,
 		Aliases:   []string{"TV"},
 		Slugs:     []string{"television", "tvchannel"},
 		MediaType: MediaTypeTVShow,
+		Fallbacks: []string{SystemVideo},
 	},
 	SystemTVShow: {
 		ID:        SystemTVShow,
 		Slugs:     []string{"tvshows", "tvseries"},
 		MediaType: MediaTypeTVShow,
+		Fallbacks: []string{SystemVideo},
 	},
 	SystemMusicTrack: {
 		ID:        SystemMusicTrack,
 		Aliases:   []string{"Music"},
 		Slugs:     []string{"musicfile", "song", "songs"},
 		MediaType: MediaTypeMusic,
+		Fallbacks: []string{SystemAudio},
 	},
 	SystemMusicArtist: {
 		ID:        SystemMusicArtist,
 		Slugs:     []string{"musician", "musicians", "band", "bands"},
 		MediaType: MediaTypeMusic,
+		Fallbacks: []string{SystemAudio},
 	},
 	SystemMusicAlbum: {
 		ID:        SystemMusicAlbum,
 		Slugs:     []string{"lp", "album", "albums"},
 		MediaType: MediaTypeMusic,
+		Fallbacks: []string{SystemAudio},
 	},
 	SystemImage: {
 		ID:        SystemImage,

--- a/pkg/database/systemdefs/systemdefs_test.go
+++ b/pkg/database/systemdefs/systemdefs_test.go
@@ -796,3 +796,122 @@ func TestMediaTypeStringValues(t *testing.T) {
 		})
 	}
 }
+
+// TestMediaSystemFallbacks verifies that media systems have correct fallback definitions
+func TestMediaSystemFallbacks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		systemID      string
+		wantFallbacks []string
+	}{
+		{SystemTVEpisode, []string{SystemVideo}},
+		{SystemMovie, []string{SystemVideo}},
+		{SystemTVShow, []string{SystemVideo}},
+		{SystemMusicTrack, []string{SystemAudio}},
+		{SystemMusicAlbum, []string{SystemAudio}},
+		{SystemMusicArtist, []string{SystemAudio}},
+		{SystemVideo, nil},
+		{SystemAudio, nil},
+		{SystemImage, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.systemID, func(t *testing.T) {
+			t.Parallel()
+
+			system, err := GetSystem(tt.systemID)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFallbacks, system.Fallbacks,
+				"System %s should have correct fallbacks", tt.systemID)
+		})
+	}
+}
+
+// TestSystemsWithFallbacks verifies the fallback expansion helper
+func TestSystemsWithFallbacks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single system with fallback", func(t *testing.T) {
+		t.Parallel()
+
+		tvEpisode, err := GetSystem(SystemTVEpisode)
+		require.NoError(t, err)
+
+		result := SystemsWithFallbacks([]System{*tvEpisode})
+		ids := make([]string, len(result))
+		for i, s := range result {
+			ids[i] = s.ID
+		}
+
+		assert.Equal(t, []string{SystemTVEpisode, SystemVideo}, ids)
+	})
+
+	t.Run("system without fallback", func(t *testing.T) {
+		t.Parallel()
+
+		video, err := GetSystem(SystemVideo)
+		require.NoError(t, err)
+
+		result := SystemsWithFallbacks([]System{*video})
+		assert.Len(t, result, 1)
+		assert.Equal(t, SystemVideo, result[0].ID)
+	})
+
+	t.Run("deduplicates fallbacks", func(t *testing.T) {
+		t.Parallel()
+
+		tvEpisode, err := GetSystem(SystemTVEpisode)
+		require.NoError(t, err)
+		movie, err := GetSystem(SystemMovie)
+		require.NoError(t, err)
+
+		// Both TVEpisode and Movie fall back to Video — should appear only once
+		result := SystemsWithFallbacks([]System{*tvEpisode, *movie})
+		ids := make([]string, len(result))
+		for i, s := range result {
+			ids[i] = s.ID
+		}
+
+		assert.Equal(t, []string{SystemTVEpisode, SystemVideo, SystemMovie}, ids)
+	})
+
+	t.Run("does not duplicate when fallback already in input", func(t *testing.T) {
+		t.Parallel()
+
+		tvEpisode, err := GetSystem(SystemTVEpisode)
+		require.NoError(t, err)
+		video, err := GetSystem(SystemVideo)
+		require.NoError(t, err)
+
+		result := SystemsWithFallbacks([]System{*tvEpisode, *video})
+		ids := make([]string, len(result))
+		for i, s := range result {
+			ids[i] = s.ID
+		}
+
+		assert.Equal(t, []string{SystemTVEpisode, SystemVideo}, ids)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+
+		result := SystemsWithFallbacks([]System{})
+		assert.Empty(t, result)
+	})
+
+	t.Run("game system with fallback", func(t *testing.T) {
+		t.Parallel()
+
+		amigaCD32, err := GetSystem(SystemAmigaCD32)
+		require.NoError(t, err)
+
+		result := SystemsWithFallbacks([]System{*amigaCD32})
+		ids := make([]string, len(result))
+		for i, s := range result {
+			ids[i] = s.ID
+		}
+
+		assert.Equal(t, []string{SystemAmigaCD32, SystemAmiga}, ids)
+	})
+}

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -168,7 +168,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			} else if system == nil {
 				return platforms.CmdResult{}, fmt.Errorf("system not found: %s", systemID)
 			}
-			systems = []systemdefs.System{*system}
+			systems = systemdefs.SystemsWithFallbacks([]systemdefs.System{*system})
 		}
 
 		// Handle the special case of /* pattern - use RandomGameWithQuery
@@ -233,6 +233,8 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 		systems = append(systems, *system)
 	}
+
+	systems = systemdefs.SystemsWithFallbacks(systems)
 
 	systemIDs := make([]string, len(systems))
 	for i, sys := range systems {
@@ -541,7 +543,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, errors.New("no query specified")
 	}
 
-	systems := make([]systemdefs.System, 0)
+	var systems []systemdefs.System
 
 	if strings.EqualFold(systemID, "all") {
 		systems = systemdefs.AllSystems()
@@ -551,7 +553,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("failed to lookup system '%s': %w", systemID, lookupErr)
 		}
 
-		systems = append(systems, *system)
+		systems = systemdefs.SystemsWithFallbacks([]systemdefs.System{*system})
 	}
 
 	searchFilters := database.SearchFilters{


### PR DESCRIPTION
## Summary

- Adds `Fallbacks` to media system definitions: `TVEpisode`/`Movie`/`TVShow` → `Video`, `MusicTrack`/`MusicAlbum`/`MusicArtist` → `Audio`
- Adds `SystemsWithFallbacks()` helper to expand a system list with its fallback systems (deduplicated)
- Uses fallbacks in `launch.random` and `launch.search` so queries for specific media systems also search their generic counterparts

Closes #506