### PR TITLE
feat(api): add input.keyboard and input.gamepad endpoints

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -482,6 +482,113 @@ An object:
 }
 ```
 
+### media.browse
+
+Browse indexed media content by directory, similar to navigating a file manager. Supports filesystem paths, virtual URI schemes (e.g. `mame-arcade://`), and paginated results.
+
+When called without a `path` parameter (or with an empty path), returns top-level root entries including filesystem roots and virtual scheme roots.
+
+#### Parameters
+
+All parameters are optional. When called with no parameters, returns root entries.
+
+| Key        | Type   | Required | Description                                                                                                |
+| :--------- | :----- | :------- | :--------------------------------------------------------------------------------------------------------- |
+| path       | string | No       | Directory path to browse. Omit or set empty to list root entries. Supports filesystem paths and virtual URI schemes (e.g. `mame-arcade://`). |
+| maxResults | number | No       | Maximum results per page. Default is 100, maximum is 1000.                                                 |
+| cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page.                     |
+| letter     | string | No       | Filter results to entries starting with this letter.                                                       |
+| sort       | string | No       | Sort order. One of: `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. The `filename` variants sort by full file path. |
+
+#### Result
+
+| Key        | Type                                  | Required | Description                                                              |
+| :--------- | :------------------------------------ | :------- | :----------------------------------------------------------------------- |
+| path       | string                                | Yes      | The browsed directory path. Empty string when listing roots.             |
+| entries    | [BrowseEntry](#browse-entry-object)[] | Yes      | Array of entries in the current path.                                    |
+| totalFiles | number                                | Yes      | Total count of media files in the current directory (respects `letter` filter). |
+| pagination | [Pagination](#browse-pagination-object) | No     | Pagination info. Omitted when there are no file results.                 |
+
+##### Browse entry object
+
+| Key          | Type     | Required | Description                                                                                      |
+| :----------- | :------- | :------- | :----------------------------------------------------------------------------------------------- |
+| name         | string   | Yes      | Display name of the entry.                                                                       |
+| path         | string   | Yes      | Full path to the entry.                                                                          |
+| type         | string   | Yes      | Entry type: `root`, `directory`, or `media`.                                                     |
+| fileCount    | number   | No       | Number of files in this directory. Present on `root` and `directory` entries.                     |
+| group        | string   | No       | Launcher group name. Present on virtual scheme `root` entries.                                   |
+| systemId     | string   | No       | System ID for the media (e.g. `snes`). Present on `media` entries.                               |
+| zapScript    | string   | No       | ZapScript command to launch this media. Present on `media` entries.                              |
+| relativePath | string   | No       | Relative path from root directory. Present on `media` entries.                                   |
+| tags         | object[] | No       | Tags attached to the media. Each object has `tag` (string) and `type` (string). Present on `media` entries. |
+
+##### Browse pagination object
+
+| Key         | Type   | Required | Description                                              |
+| :---------- | :----- | :------- | :------------------------------------------------------- |
+| hasNextPage | bool   | Yes      | Whether more results exist beyond the current page.      |
+| pageSize    | number | Yes      | The requested page size.                                 |
+| nextCursor  | string | No       | Opaque cursor for the next page. Absent on the last page. |
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "d4e5f6a7-3456-7890-bcde-f01234567890",
+  "method": "media.browse",
+  "params": {
+    "path": "/media/fat/games/SNES",
+    "maxResults": 3
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "d4e5f6a7-3456-7890-bcde-f01234567890",
+  "result": {
+    "path": "/media/fat/games/SNES",
+    "entries": [
+      {
+        "name": "RPGs",
+        "path": "/media/fat/games/SNES/RPGs",
+        "type": "directory",
+        "fileCount": 42
+      },
+      {
+        "name": "Super Mario World",
+        "path": "/media/fat/games/SNES/Super Mario World.sfc",
+        "type": "media",
+        "systemId": "snes",
+        "zapScript": "**launch:/media/fat/games/SNES/Super Mario World.sfc",
+        "relativePath": "Super Mario World.sfc"
+      },
+      {
+        "name": "The Legend of Zelda - A Link to the Past",
+        "path": "/media/fat/games/SNES/The Legend of Zelda - A Link to the Past.sfc",
+        "type": "media",
+        "systemId": "snes",
+        "zapScript": "**launch:/media/fat/games/SNES/The Legend of Zelda - A Link to the Past.sfc",
+        "relativePath": "The Legend of Zelda - A Link to the Past.sfc"
+      }
+    ],
+    "totalFiles": 150,
+    "pagination": {
+      "hasNextPage": true,
+      "pageSize": 3,
+      "nextCursor": "eyJzb3J0VmFsdWUiOiJUaGUgTGVnZW5kIG9mIFplbGRhIiwibGFzdElkIjo0Mn0="
+    }
+  }
+}
+```
+
 ### media.tags
 
 Query the media database and return available tags for filtering.
@@ -2172,6 +2279,7 @@ Returns `null` on success.
 
 ### inbox.clear
 
+
 Delete all inbox messages.
 
 #### Parameters
@@ -2202,3 +2310,92 @@ Returns `null` on success.
   "id": "0e8b1a8a-7e48-11ef-9b5e-020304050607",
   "result": null
 }
+```
+
+## Input
+
+Direct platform input control for remote control use cases. These methods bypass the token pipeline entirely — no hooks, history, or sound effects are triggered.
+
+The input macro format is identical to what goes after the `:` in a ZapScript `input.keyboard` or `input.gamepad` command on a token. Each character is a separate keypress, `{...}` groups are special keys/combos, and `\` is the escape character.
+
+### input.keyboard
+
+Press keyboard keys using the ZapScript input macro format.
+
+#### Parameters
+
+An object:
+
+| Key  | Type   | Required | Description                                                                                                                                          |
+| :--- | :----- | :------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| keys | string | Yes      | Input macro string. Each character is a keypress, `{...}` for special keys (e.g. `{enter}`, `{f9}`, `{ctrl+q}`). Same format as ZapScript on a token. |
+
+#### Result
+
+Returns `null` on success.
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "a1b2c3d4-1234-5678-9abc-def012345678",
+  "method": "input.keyboard",
+  "params": {
+    "keys": "abc{enter}"
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "a1b2c3d4-1234-5678-9abc-def012345678",
+  "result": null
+}
+```
+
+### input.gamepad
+
+Press gamepad buttons using the ZapScript input macro format.
+
+#### Parameters
+
+An object:
+
+| Key     | Type   | Required | Description                                                                                                                                                  |
+| :------ | :----- | :------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| buttons | string | Yes      | Input macro string. Each character is a button press, `{...}` for named buttons (e.g. `{up}`, `{start}`, `{l1}`). Same format as ZapScript on a token. |
+
+#### Result
+
+Returns `null` on success.
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "b2c3d4e5-2345-6789-abcd-ef0123456789",
+  "method": "input.gamepad",
+  "params": {
+    "buttons": "^^vv<><>BA{start}"
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "b2c3d4e5-2345-6789-abcd-ef0123456789",
+  "result": null
+}
+```

--- a/pkg/api/methods/input.go
+++ b/pkg/api/methods/input.go
@@ -1,0 +1,85 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"errors"
+	"fmt"
+
+	zapscriptlib "github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
+	"github.com/rs/zerolog/log"
+)
+
+func parseInputMacro(cmdName, macro string) ([]string, error) {
+	script, err := zapscriptlib.NewParser("**" + cmdName + ":" + macro).ParseScript()
+	if err != nil {
+		return nil, fmt.Errorf("invalid input macro: %w", err)
+	}
+	if len(script.Cmds) == 0 {
+		return nil, errors.New("invalid input macro: no commands parsed")
+	}
+	return script.Cmds[0].Args, nil
+}
+
+//nolint:gocritic // single-use parameter in API handler
+func HandleInputKeyboard(env requests.RequestEnv) (any, error) {
+	var params models.InputKeyboardParams
+	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
+	args, err := parseInputMacro(zapscriptlib.ZapScriptCmdInputKeyboard, params.Keys)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info().Strs("keys", args).Msg("keyboard input via API")
+
+	if err := zapscript.PressKeyboardSequence(env.Platform, args); err != nil {
+		return nil, fmt.Errorf("keyboard press failed: %w", err)
+	}
+
+	return NoContent{}, nil
+}
+
+//nolint:gocritic // single-use parameter in API handler
+func HandleInputGamepad(env requests.RequestEnv) (any, error) {
+	var params models.InputGamepadParams
+	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+		return nil, fmt.Errorf("invalid params: %w", err)
+	}
+
+	args, err := parseInputMacro(zapscriptlib.ZapScriptCmdInputGamepad, params.Buttons)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info().Strs("buttons", args).Msg("gamepad input via API")
+
+	if err := zapscript.PressGamepadSequence(env.Platform, args); err != nil {
+		return nil, fmt.Errorf("gamepad press failed: %w", err)
+	}
+
+	return NoContent{}, nil
+}

--- a/pkg/api/methods/input_test.go
+++ b/pkg/api/methods/input_test.go
@@ -1,0 +1,223 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleInputKeyboard_SingleKey(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", "a").Return(nil)
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"keys": "a"}`),
+	}
+
+	result, err := HandleInputKeyboard(env)
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+	pl.AssertCalled(t, "KeyboardPress", "a")
+}
+
+func TestHandleInputKeyboard_MultiCharMacro(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", mock.AnythingOfType("string")).Return(nil)
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"keys": "abc{enter}"}`),
+	}
+
+	result, err := HandleInputKeyboard(env)
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+
+	presses := pl.GetKeyboardPresses()
+	assert.Equal(t, []string{"a", "b", "c", "{enter}"}, presses)
+}
+
+func TestHandleInputKeyboard_SpecialKey(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", "{f9}").Return(nil)
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"keys": "{f9}"}`),
+	}
+
+	result, err := HandleInputKeyboard(env)
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+	pl.AssertCalled(t, "KeyboardPress", "{f9}")
+}
+
+func TestHandleInputKeyboard_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	env := requests.RequestEnv{
+		Context: context.Background(),
+		Params:  json.RawMessage(`{}`),
+	}
+
+	_, err := HandleInputKeyboard(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid params")
+}
+
+func TestHandleInputKeyboard_PlatformError(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("KeyboardPress", "a").Return(errors.New("device not available"))
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"keys": "a"}`),
+	}
+
+	_, err := HandleInputKeyboard(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "device not available")
+}
+
+func TestHandleInputGamepad_SingleButton(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("GamepadPress", "A").Return(nil)
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"buttons": "A"}`),
+	}
+
+	result, err := HandleInputGamepad(env)
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+	pl.AssertCalled(t, "GamepadPress", "A")
+}
+
+func TestHandleInputGamepad_MultiButton(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("GamepadPress", mock.AnythingOfType("string")).Return(nil)
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"buttons": "{up}{down}A"}`),
+	}
+
+	result, err := HandleInputGamepad(env)
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+
+	presses := pl.GetGamepadPresses()
+	assert.Equal(t, []string{"{up}", "{down}", "A"}, presses)
+}
+
+func TestHandleInputGamepad_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	env := requests.RequestEnv{
+		Context: context.Background(),
+		Params:  json.RawMessage(`{}`),
+	}
+
+	_, err := HandleInputGamepad(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid params")
+}
+
+func TestHandleInputGamepad_PlatformError(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	pl.On("GamepadPress", "A").Return(errors.New("virtual gamepad is disabled"))
+
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		Params:   json.RawMessage(`{"buttons": "A"}`),
+	}
+
+	_, err := HandleInputGamepad(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "virtual gamepad is disabled")
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -90,6 +90,8 @@ const (
 	MethodSettingsAuthClaim    = "settings.auth.claim"
 	MethodUpdateCheck          = "update.check"
 	MethodUpdateApply          = "update.apply"
+	MethodInputKeyboard        = "input.keyboard"
+	MethodInputGamepad         = "input.gamepad"
 )
 
 // ResponseWithCallback wraps a method result with a function that should be

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -182,3 +182,11 @@ type SettingsAuthClaimParams struct {
 	ClaimURL string `json:"claimUrl" validate:"required,url"`
 	Token    string `json:"token" validate:"required"`
 }
+
+type InputKeyboardParams struct {
+	Keys string `json:"keys" validate:"required,min=1"`
+}
+
+type InputGamepadParams struct {
+	Buttons string `json:"buttons" validate:"required,min=1"`
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -245,6 +245,9 @@ func NewMethodMap() *MethodMap {
 				env.State.ListReaders(),
 			)
 		},
+		// input
+		models.MethodInputKeyboard: methods.HandleInputKeyboard,
+		models.MethodInputGamepad:  methods.HandleInputGamepad,
 		// utils
 		models.MethodVersion:     methods.HandleVersion,
 		models.MethodHealthCheck: methods.HandleHealthCheck,

--- a/pkg/helpers/linuxinput/keymap.go
+++ b/pkg/helpers/linuxinput/keymap.go
@@ -18,7 +18,7 @@ func ToKeyboardCode(name string) (int, bool) {
 var GamepadMap = map[string]int{
 	"^":        uinput.ButtonDpadUp,
 	"{up}":     uinput.ButtonDpadUp,
-	"v":        uinput.ButtonDpadUp,
+	"v":        uinput.ButtonDpadDown,
 	"V":        uinput.ButtonDpadDown,
 	"{down}":   uinput.ButtonDpadDown,
 	"<":        uinput.ButtonDpadLeft,

--- a/pkg/zapscript/input.go
+++ b/pkg/zapscript/input.go
@@ -53,6 +53,30 @@ func cmdKey(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, e
 	return platforms.CmdResult{}, nil
 }
 
+// PressKeyboardSequence presses each key in args sequentially with a delay
+// between each press. Used by both ZapScript commands and API handlers.
+func PressKeyboardSequence(pl platforms.Platform, args []string) error {
+	for _, name := range args {
+		if err := pl.KeyboardPress(name); err != nil {
+			return fmt.Errorf("failed to press keyboard key '%s': %w", name, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil
+}
+
+// PressGamepadSequence presses each button in args sequentially with a delay
+// between each press. Used by both ZapScript commands and API handlers.
+func PressGamepadSequence(pl platforms.Platform, args []string) error {
+	for _, name := range args {
+		if err := pl.GamepadPress(name); err != nil {
+			return fmt.Errorf("failed to press gamepad button '%s': %w", name, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil
+}
+
 //nolint:gocritic // single-use parameter in command handler
 func cmdKeyboard(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 	if env.Unsafe {
@@ -64,11 +88,8 @@ func cmdKeyboard(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResu
 	// TODO: stuff like adjust delay, only press, etc.
 	//	     basically a filled out mini macro language for key presses
 
-	for _, name := range env.Cmd.Args {
-		if err := pl.KeyboardPress(name); err != nil {
-			return platforms.CmdResult{}, fmt.Errorf("failed to press keyboard key '%s': %w", name, err)
-		}
-		time.Sleep(100 * time.Millisecond)
+	if err := PressKeyboardSequence(pl, env.Cmd.Args); err != nil {
+		return platforms.CmdResult{}, err
 	}
 
 	return platforms.CmdResult{}, nil
@@ -82,11 +103,8 @@ func cmdGamepad(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 
 	log.Info().Msgf("gamepad input: %v", env.Cmd.Args)
 
-	for _, name := range env.Cmd.Args {
-		if err := pl.GamepadPress(name); err != nil {
-			return platforms.CmdResult{}, fmt.Errorf("failed to press gamepad button '%s': %w", name, err)
-		}
-		time.Sleep(100 * time.Millisecond)
+	if err := PressGamepadSequence(pl, env.Cmd.Args); err != nil {
+		return platforms.CmdResult{}, err
 	}
 
 	return platforms.CmdResult{}, nil


### PR DESCRIPTION
- Add `input.keyboard` and `input.gamepad` API methods for direct platform input control, bypassing the token pipeline (no hooks, history, or sound effects)
- Accept the same input macro string format as ZapScript tokens (e.g. `abc{enter}`, `^^vv<><>BA{start}`)
- Extract shared `PressKeyboardSequence`/`PressGamepadSequence` functions so both ZapScript commands and API handlers use the same execution path
- Fix gamepad keymap bug: lowercase `v` incorrectly mapped to DpadUp instead of DpadDown
- Add missing `media.browse` API documentation