### PR TITLE
feat(mister): add 3DO core support

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -97,6 +97,20 @@ func PathToMGLDef(system *Core, path string) (*MGLParams, error) {
 
 var Systems = map[string]Core{
 	// Consoles
+	"3DO": {
+		ID:  "3DO",
+		RBF: "_Console/3DO",
+		Slots: []Slot{
+			{
+				Exts: []string{".iso", ".cue"},
+				Mgl: &MGLParams{
+					Delay:  1,
+					Method: "s",
+					Index:  1,
+				},
+			},
+		},
+	},
 	"AdventureVision": {
 		ID:  "AdventureVision",
 		RBF: "_Console/AdventureVision",

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -604,6 +604,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 	return []platforms.Launcher{
 		// Consoles
 		{
+			ID:         systemdefs.System3DO,
+			SystemID:   systemdefs.System3DO,
+			Folders:    []string{"3DO"},
+			Extensions: []string{".iso", ".cue"},
+			Launch:     launch(pl, systemdefs.System3DO),
+		},
+		{
 			ID:         systemdefs.SystemAdventureVision,
 			SystemID:   systemdefs.SystemAdventureVision,
 			Folders:    []string{"AVision"},


### PR DESCRIPTION
## Summary
- Add 3DO core definition to MiSTer cores (RBF `_Console/3DO`, type `s`, slot `1`)
- Add 3DO launcher with folder `3DO` and extensions `.iso`, `.cue`
- Tested and working on MiSTer hardware

Closes #574