### PR TITLE
fix: audio crash resilience, tag matching, and mediadb query performance

### DIFF
--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/gen2brain/malgo"
@@ -54,6 +55,7 @@ type Player interface {
 // MalgoPlayer implements Player using malgo for real audio hardware output.
 type MalgoPlayer struct {
 	currentCancel context.CancelFunc
+	currentDone   <-chan struct{} // closed when current playback goroutine finishes
 	fileCache     map[string][]byte
 	playbackGen   uint64
 	fileCacheMu   syncutil.RWMutex
@@ -79,18 +81,42 @@ func (p *MalgoPlayer) playWAV(r io.ReadCloser) error {
 	// Resample to 48000 Hz for HDMI audio compatibility (MiSTer, etc.)
 	resampled := beep.Resample(4, format.SampleRate, beep.SampleRate(48000), streamer)
 
-	// Cancel any currently playing sound
+	// Cancel any currently playing sound and capture previous done channel.
 	p.playbackMu.Lock()
 	if p.currentCancel != nil {
 		p.currentCancel()
 	}
+	prevDone := p.currentDone
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: stored in p.currentCancel
 	p.currentCancel = cancel
+	done := make(chan struct{})
+	p.currentDone = done
 	p.playbackGen++
 	thisGen := p.playbackGen
 	p.playbackMu.Unlock()
 
+	// Wait for the previous playback goroutine to fully release the audio
+	// device before initializing a new one. Concurrent ALSA device access
+	// from overlapping init/uninit calls crashes miniaudio on MiSTer.
+	if prevDone != nil {
+		select {
+		case <-prevDone:
+		case <-time.After(3 * time.Second):
+			log.Warn().Msg("timeout waiting for previous audio playback cleanup")
+		}
+	}
+
 	go func() {
+		// Outermost: recover from any panic so audio issues never kill the service.
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Error().Any("panic", rec).Msg("recovered panic in audio playback")
+			}
+		}()
+
+		// Signal that this goroutine has finished and the device is released.
+		defer close(done)
+
 		defer func() {
 			if err := streamer.Close(); err != nil {
 				log.Warn().Err(err).Msg("failed to close audio streamer")
@@ -157,17 +183,40 @@ func (p *MalgoPlayer) PlayFile(path string) error {
 	// Resample to 48000 Hz for HDMI audio compatibility (MiSTer, etc.)
 	resampled := beep.Resample(4, format.SampleRate, beep.SampleRate(48000), streamer)
 
+	// Cancel any currently playing sound and capture previous done channel.
 	p.playbackMu.Lock()
 	if p.currentCancel != nil {
 		p.currentCancel()
 	}
+	prevDone := p.currentDone
 	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118: stored in p.currentCancel
 	p.currentCancel = cancel
+	done := make(chan struct{})
+	p.currentDone = done
 	p.playbackGen++
 	thisGen := p.playbackGen
 	p.playbackMu.Unlock()
 
+	// Wait for the previous playback goroutine to fully release the audio
+	// device before initializing a new one. Concurrent ALSA device access
+	// from overlapping init/uninit calls crashes miniaudio on MiSTer.
+	if prevDone != nil {
+		select {
+		case <-prevDone:
+		case <-time.After(3 * time.Second):
+			log.Warn().Msg("timeout waiting for previous audio playback cleanup")
+		}
+	}
+
 	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Error().Any("panic", rec).Msg("recovered panic in audio playback")
+			}
+		}()
+
+		defer close(done)
+
 		defer func() {
 			if err := streamer.Close(); err != nil {
 				log.Warn().Err(err).Msg("failed to close audio streamer")

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -227,6 +227,12 @@ func (db *MediaDB) Open() error {
 		log.Warn().Err(err).Msg("failed to run WAL checkpoint on startup")
 	}
 
+	// Pre-warm in-memory tag cache from the SystemTagsCache table so the
+	// first media.tags request is served from memory instead of hitting SQL.
+	if warmErr := db.RebuildTagCache(); warmErr != nil {
+		log.Warn().Err(warmErr).Msg("failed to warm tag cache on startup")
+	}
+
 	return nil
 }
 
@@ -1092,7 +1098,6 @@ func (db *MediaDB) slugCacheSearch(
 	ctx context.Context,
 	systemID string,
 	input string,
-	tags []zapscript.TagFilter,
 	matchFn func(*SlugSearchCache, []int64, []byte) []int64,
 ) ([]database.SearchResultWithCursor, bool, error) {
 	cache := db.slugSearchCache.Load()
@@ -1115,7 +1120,10 @@ func (db *MediaDB) slugCacheSearch(
 	if len(candidates) == 0 {
 		return []database.SearchResultWithCursor{}, true, nil
 	}
-	results, err := sqlSearchMediaByTitleDBIDs(ctx, db.conn(), candidates, tags, nil, nil, defaultSlugSearchLimit)
+	// Skip SQL-level tag filters for cache path — the Go-side selection
+	// logic handles missing/conflicting tags gracefully, and the INTERSECT
+	// subqueries are the most expensive part of the query on slow storage.
+	results, err := sqlSearchMediaByTitleDBIDs(ctx, db.conn(), candidates, nil, nil, nil, defaultSlugSearchLimit)
 	return results, true, err
 }
 
@@ -1125,10 +1133,13 @@ func (db *MediaDB) SearchMediaBySlug(
 	if db.sql == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, slug, tags,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, slug,
 		(*SlugSearchCache).ExactSlugMatch); ok || err != nil {
 		return results, err
 	}
+	// SQL fallback (cache not ready) still applies tag filters in the query
+	// for performance. The cache path skips SQL tag filters — Go-side
+	// selection handles tag matching in both cases.
 	return sqlSearchMediaBySlug(ctx, db.conn(), systemID, slug, tags)
 }
 
@@ -1138,7 +1149,7 @@ func (db *MediaDB) SearchMediaBySecondarySlug(
 	if db.sql == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, secondarySlug, tags,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, secondarySlug,
 		(*SlugSearchCache).ExactSecondarySlugMatch); ok || err != nil {
 		return results, err
 	}
@@ -1151,7 +1162,7 @@ func (db *MediaDB) SearchMediaBySlugPrefix(
 	if db.sql == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, slugPrefix, tags,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, slugPrefix,
 		(*SlugSearchCache).PrefixSlugMatch); ok || err != nil {
 		return results, err
 	}
@@ -1264,6 +1275,9 @@ func (db *MediaDB) GetSystemTagsCached(ctx context.Context, systems []systemdefs
 	if db.sql == nil {
 		return make([]database.TagInfo, 0), ErrNullSQL
 	}
+	if len(systems) == 0 {
+		return nil, errors.New("no systems provided for cached tag search")
+	}
 
 	// Try in-memory cache first (instant)
 	if cache := db.inMemoryTagCache.Load(); cache != nil {
@@ -1282,16 +1296,25 @@ func (db *MediaDB) GetSystemTagsCached(ctx context.Context, systems []systemdefs
 	if len(tags) == 0 {
 		log.Debug().Int("system_count", len(systems)).Msg("cache miss, populating for requested systems")
 
-		// Self-healing: populate cache for requested systems (best effort)
+		// Self-healing: populate cache for requested systems
 		if populateErr := db.PopulateSystemTagsCacheForSystems(ctx, systems); populateErr != nil {
 			log.Warn().Err(populateErr).Msg("failed to populate cache, using direct query")
-		} else {
-			log.Debug().Int("system_count", len(systems)).Msg("successfully populated cache for systems")
+			return sqlGetTags(ctx, db.sql, systems)
 		}
 
-		// Always fall back to direct SQL query when cache returns no results
-		// This ensures we return data even if cache population fails or systems have no tags
-		return sqlGetTags(ctx, db.sql, systems)
+		// Populate succeeded — re-read from cache table instead of running
+		// another expensive 6-table join query via sqlGetTags
+		tags, err = sqlGetSystemTagsCached(ctx, db.sql, systems)
+		if err != nil || len(tags) == 0 {
+			return sqlGetTags(ctx, db.sql, systems)
+		}
+
+		// Rebuild in-memory cache so subsequent requests are instant
+		go func() {
+			if cacheErr := db.RebuildTagCache(); cacheErr != nil {
+				log.Warn().Err(cacheErr).Msg("failed to rebuild tag cache after self-healing")
+			}
+		}()
 	}
 
 	return tags, nil

--- a/pkg/database/mediadb/multi_variant_search_test.go
+++ b/pkg/database/mediadb/multi_variant_search_test.go
@@ -73,9 +73,9 @@ func TestSearchMediaWithFilters_MultipleSameMediaTypeSystems(t *testing.T) {
 			AddRow("NES", "Super Mario Bros", "/games/mario.nes", int64(1)))
 
 	// Mock tags query
-	mock.ExpectPrepare("SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaWithFilters(
@@ -183,9 +183,9 @@ func TestSearchMediaWithFilters_MultipleWordsMultipleSystems(t *testing.T) {
 			AddRow("SNES", "Super Mario World", "/games/smw.sfc", int64(1)))
 
 	// Mock tags query
-	mock.ExpectPrepare("SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaWithFilters(

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -130,9 +130,9 @@ func TestSqlBrowseFiles_BasicQuery(t *testing.T) {
 		)
 
 	// fetchAndAttachTags uses Prepare + Query
-	mock.ExpectPrepare(`SELECT DISTINCT`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1), int64(2)).
+		WithArgs(int64(1), int64(2), int64(1), int64(2)).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlBrowseFiles(context.Background(), db, &database.BrowseFilesOptions{

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -37,7 +37,7 @@ import (
 
 // fetchAndAttachTags fetches tags for a slice of search results and attaches them to the results.
 // This helper consolidates duplicated tag-fetching logic across multiple search functions.
-// Uses LEFT JOIN to handle tags with missing TypeDBID defensively.
+// Uses UNION of file-level (MediaTags) and title-level (MediaTitleTags) queries for indexable joins.
 // Modifies results in-place.
 func fetchAndAttachTags(
 	ctx context.Context,
@@ -54,26 +54,44 @@ func fetchAndAttachTags(
 		mediaIDs[i] = result.MediaID
 	}
 
-	// Query tags for all media IDs from both MediaTags (file-level) and MediaTitleTags (title-level)
+	// Query tags for all media IDs from both MediaTags (file-level) and
+	// MediaTitleTags (title-level). Uses UNION of two indexed queries
+	// instead of an OR JOIN which SQLite can't optimize.
+	placeholders := prepareVariadic("?", ",", len(mediaIDs))
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
 	tagsQuery := `
-		SELECT DISTINCT
-			Media.DBID as MediaDBID,
-			Tags.Tag,
-			COALESCE(TagTypes.Type, '') as Type
-		FROM Media
-		LEFT JOIN MediaTags ON MediaTags.MediaDBID = Media.DBID
-		LEFT JOIN MediaTitleTags ON MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
-		LEFT JOIN Tags ON (Tags.DBID = MediaTags.TagDBID OR Tags.DBID = MediaTitleTags.TagDBID)
-		LEFT JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-		WHERE Media.DBID IN (` +
-		prepareVariadic("?", ",", len(mediaIDs)) +
-		`) AND Tags.DBID IS NOT NULL
-		ORDER BY Media.DBID, TagTypes.Type, Tags.Tag`
+		SELECT MediaDBID, Tag, Type FROM (
+			SELECT
+				Media.DBID as MediaDBID,
+				Tags.Tag,
+				TagTypes.Type
+			FROM Media
+			JOIN MediaTags ON MediaTags.MediaDBID = Media.DBID
+			JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+			WHERE Media.DBID IN (` + placeholders + `)
 
-	tagsArgs := make([]any, len(mediaIDs))
-	for i, id := range mediaIDs {
-		tagsArgs[i] = id
+			UNION
+
+			SELECT
+				Media.DBID as MediaDBID,
+				Tags.Tag,
+				TagTypes.Type
+			FROM Media
+			JOIN MediaTitleTags ON MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
+			JOIN Tags ON Tags.DBID = MediaTitleTags.TagDBID
+			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+			WHERE Media.DBID IN (` + placeholders + `)
+		)
+		ORDER BY MediaDBID, Type, Tag`
+
+	// UNION needs the media ID list twice (once per leg)
+	tagsArgs := make([]any, 0, len(mediaIDs)*2)
+	for _, id := range mediaIDs {
+		tagsArgs = append(tagsArgs, id)
+	}
+	for _, id := range mediaIDs {
+		tagsArgs = append(tagsArgs, id)
 	}
 
 	tagsStmt, err := db.PrepareContext(ctx, tagsQuery)

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -63,9 +63,9 @@ func TestFetchAndAttachTags_SingleResultNoTags(t *testing.T) {
 	}
 
 	// Mock the tags query - no rows returned
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -96,9 +96,9 @@ func TestFetchAndAttachTags_SingleResultWithTags(t *testing.T) {
 		AddRow(int64(1), "Nintendo", "publisher").
 		AddRow(int64(1), "1985", "year")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -134,9 +134,9 @@ func TestFetchAndAttachTags_YearTagPresent(t *testing.T) {
 		AddRow(int64(1), "1985", "year").
 		AddRow(int64(1), "Nintendo", "publisher")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -197,9 +197,9 @@ func TestFetchAndAttachTags_VariousYearTags(t *testing.T) {
 			tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 				AddRow(int64(1), tt.yearTag, tt.yearType)
 
-			mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+			mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 				ExpectQuery().
-				WithArgs(int64(1)).
+				WithArgs(int64(1), int64(1)).
 				WillReturnRows(tagRows)
 
 			err = fetchAndAttachTags(context.Background(), db, results)
@@ -249,9 +249,9 @@ func TestFetchAndAttachTags_MultipleResults(t *testing.T) {
 		AddRow(int64(3), "Platform", "genre").
 		AddRow(int64(3), "1990", "year")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1), int64(2), int64(3)).
+		WithArgs(int64(1), int64(2), int64(3), int64(1), int64(2), int64(3)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -298,9 +298,9 @@ func TestFetchAndAttachTags_TagsWithMissingTypeDBID(t *testing.T) {
 		AddRow(int64(1), "untyped-tag", "").
 		AddRow(int64(1), "genre-tag", "genre")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -324,7 +324,7 @@ func TestFetchAndAttachTags_PrepareError(t *testing.T) {
 	}
 
 	prepareErr := errors.New("prepare failed")
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		WillReturnError(prepareErr)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -344,9 +344,9 @@ func TestFetchAndAttachTags_QueryError(t *testing.T) {
 	}
 
 	queryErr := errors.New("query execution failed")
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnError(queryErr)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -369,9 +369,9 @@ func TestFetchAndAttachTags_ScanError(t *testing.T) {
 	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 		AddRow("invalid", "tag", "type") // MediaDBID should be int64, not string
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -395,9 +395,9 @@ func TestFetchAndAttachTags_RowsError(t *testing.T) {
 		AddRow(int64(1), "tag1", "type1").
 		RowError(0, rowsErr)
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -428,9 +428,9 @@ func TestFetchAndAttachTags_MultipleYearTags(t *testing.T) {
 		AddRow(int64(1), "1986", "year").
 		AddRow(int64(1), "1987", "year")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	err = fetchAndAttachTags(context.Background(), db, results)
@@ -468,9 +468,9 @@ func TestSqlSearchMediaWithFilters_IntegrationWithTags(t *testing.T) {
 		AddRow(int64(1), "Action", "genre").
 		AddRow(int64(1), "1985", "year")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	results, err := sqlSearchMediaWithFilters(
@@ -505,9 +505,9 @@ func TestSqlSearchMediaBySlug_IntegrationWithTags(t *testing.T) {
 	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 		AddRow(int64(1), "Platform", "genre")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	results, err := sqlSearchMediaBySlug(
@@ -540,9 +540,9 @@ func TestSqlSearchMediaBySecondarySlug_IntegrationWithTags(t *testing.T) {
 	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 		AddRow(int64(1), "Nintendo", "publisher")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1)).
+		WithArgs(int64(1), int64(1)).
 		WillReturnRows(tagRows)
 
 	results, err := sqlSearchMediaBySecondarySlug(
@@ -578,9 +578,9 @@ func TestSqlSearchMediaBySlugPrefix_IntegrationWithTags(t *testing.T) {
 		AddRow(int64(2), "Platform", "genre").
 		AddRow(int64(2), "Sequel", "series")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1), int64(2)).
+		WithArgs(int64(1), int64(2), int64(1), int64(2)).
 		WillReturnRows(tagRows)
 
 	results, err := sqlSearchMediaBySlugPrefix(
@@ -617,9 +617,9 @@ func TestSqlSearchMediaBySlugIn_IntegrationWithTags(t *testing.T) {
 		AddRow(int64(2), "Adventure", "genre").
 		AddRow(int64(2), "RPG", "genre")
 
-	mock.ExpectPrepare(`SELECT DISTINCT.*FROM Media.*WHERE Media.DBID IN`).
+	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
-		WithArgs(int64(1), int64(2)).
+		WithArgs(int64(1), int64(2), int64(1), int64(2)).
 		WillReturnRows(tagRows)
 
 	results, err := sqlSearchMediaBySlugIn(

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -486,9 +486,9 @@ func TestSqlSearchMediaWithFilters_WithTags(t *testing.T) {
 			AddRow("NES", "Mario", "/games/mario.nes", 1))
 
 	// Mock second query: get tags for the media items
-	mock.ExpectPrepare("SELECT.*MediaTags\\.MediaDBID.*Tags\\.Tag.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1).
+		WithArgs(1, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 			AddRow(1, "Action", "genre"))
 
@@ -853,9 +853,9 @@ func TestSqlSearchMediaBySlug_Success(t *testing.T) {
 			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
 
 	// Mock tags query (now always called even when no tag filters)
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1).
+		WithArgs(1, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaBySlug(context.Background(), db, systemID, slug, tags)
@@ -887,9 +887,9 @@ func TestSqlSearchMediaBySlug_WithTags(t *testing.T) {
 			AddRow("snes", "Super Mario World", "/games/super-mario-world-usa.smc", 1))
 
 	// Mock tags query
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1).
+		WithArgs(1, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 			AddRow(1, "usa", "region").
 			AddRow(1, "platform", "genre"))
@@ -930,9 +930,9 @@ func TestSqlSearchMediaBySlug_MultipleResults(t *testing.T) {
 			AddRow("genesis", "Sonic the Hedgehog 2", "/games/sonic2.bin", 2))
 
 	// Mock tags query (now always called even when no tag filters)
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1, 2).
+		WithArgs(1, 2, 1, 2).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaBySlug(context.Background(), db, systemID, slug, tags)
@@ -974,9 +974,9 @@ func TestSqlSearchMediaBySlug_LoadsTagsWithoutFilters(t *testing.T) {
 			AddRow("snes", "Super Mario World (Europe)", "/games/smw-eu.smc", 2))
 
 	// Mock tags query - returns tags for both ROMs
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1, 2).
+		WithArgs(1, 2, 1, 2).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
 			AddRow(1, "en", "lang").
 			AddRow(1, "us", "region").
@@ -1089,9 +1089,9 @@ func TestSqlSearchMediaBySlug_TagsQueryError(t *testing.T) {
 			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
 
 	// Mock tags query error
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1).
+		WithArgs(1, 1).
 		WillReturnError(sql.ErrTxDone)
 
 	results, err := sqlSearchMediaBySlug(context.Background(), db, systemID, slug, tags)
@@ -1152,9 +1152,9 @@ func TestSqlSearchMediaBySlug_TagsScanError(t *testing.T) {
 			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
 
 	// Mock tags query with wrong column count (scan error)
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(1).
+		WithArgs(1, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID"}). // Missing Tag and Type
 									AddRow(1))
 
@@ -1450,9 +1450,9 @@ func TestSqlSearchMediaByTitleDBIDs_BasicLookup(t *testing.T) {
 			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200))
 
 	// Tag query (fetchAndAttachTags uses PrepareContext)
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(100, 200).
+		WithArgs(100, 200, 100, 200).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaByTitleDBIDs(
@@ -1483,9 +1483,9 @@ func TestSqlSearchMediaByTitleDBIDs_WithCursor(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
 			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200))
 
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(200).
+		WithArgs(200, 200).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaByTitleDBIDs(
@@ -1507,9 +1507,9 @@ func TestSqlSearchMediaByTitleDBIDs_WithLetter(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
 			AddRow("NES", "Super Mario Bros", "/games/nes/smb.nes", 100))
 
-	mock.ExpectPrepare("SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*").
+	mock.ExpectPrepare("SELECT MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
-		WithArgs(100).
+		WithArgs(100, 100).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
 
 	results, err := sqlSearchMediaByTitleDBIDs(

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -346,6 +346,12 @@ func processTokenQueue(
 
 			// launch tokens in a separate thread
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Error().Any("panic", r).Msg("recovered panic in token launch")
+					}
+				}()
+
 				plsc := playlists.PlaylistController{
 					Active: svc.State.GetActivePlaylist(),
 					Queue:  svc.PlaylistQueue,

--- a/pkg/zapscript/launch_title_test.go
+++ b/pkg/zapscript/launch_title_test.go
@@ -1297,7 +1297,7 @@ func TestHasAllTags(t *testing.T) {
 				{Type: "region", Value: "us"},
 				{Type: "lang", Value: "en"},
 			},
-			expected: false,
+			expected: true, // missing tag type is neutral, not a conflict
 		},
 		{
 			name: "wrong tag value",

--- a/pkg/zapscript/titles/resolve_test.go
+++ b/pkg/zapscript/titles/resolve_test.go
@@ -729,9 +729,10 @@ func TestResolveTitle_ErrLowConfidence(t *testing.T) {
 
 	setupCacheMiss(mockMediaDB)
 
-	// Strategy 1: Single result with only a region tag.
-	// With 2 AND filters (region:us matches, lang:en absent from result):
-	// matchRatio=0.5, tagConfidence=0.5, confidence = 1.0 * 0.5 = 0.5
+	// Strategy 1: Single result with conflicting tag values.
+	// With 2 AND filters (region:us conflicts with result's region:jp,
+	// lang:en matches): matchRatio=1/2=0.5, conflictPenalty=0.2,
+	// tagConfidence=0.3, confidence = 1.0 * 0.3 = 0.3
 	// This is > 0.0 but < ConfidenceMinimum (0.60) → ErrLowConfidence
 	mockMediaDB.On("SearchMediaBySlug",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -742,7 +743,8 @@ func TestResolveTitle_ErrLowConfidence(t *testing.T) {
 			Name:     "Super Mario Bros",
 			Path:     "/games/nes/smb.nes",
 			Tags: []database.TagInfo{
-				{Type: string(tags.TagTypeRegion), Tag: string(tags.TagRegionUS)},
+				{Type: string(tags.TagTypeRegion), Tag: string(tags.TagRegionJP)},
+				{Type: string(tags.TagTypeLang), Tag: string(tags.TagLangEN)},
 			},
 		},
 	}, nil)
@@ -811,10 +813,9 @@ func TestResolveTitle_BestCandidateCachedAndReturned(t *testing.T) {
 
 	setupCacheMiss(mockMediaDB)
 
-	// Strategy 1: Single result with moderate confidence (above minimum
-	// but below high). 3 AND tag filters where 2 match, 1 missing:
-	// matchRatio=2/3, confidence≈0.667 → above 0.60 but below 0.95
-	// Stored as bestCandidate, continues to strategies 2-6 (all empty).
+	// Strategy 1: Single result where region and lang match, year tag is
+	// missing from the result. Missing tag types are neutral (skipped),
+	// so confidence = 1.0 * 1.0 = 1.0 → high confidence early exit.
 	mockMediaDB.On("SearchMediaBySlug",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return([]database.SearchResultWithCursor{
@@ -829,19 +830,6 @@ func TestResolveTitle_BestCandidateCachedAndReturned(t *testing.T) {
 			},
 		},
 	}, nil)
-
-	mockMediaDB.On("SearchMediaBySecondarySlug",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return([]database.SearchResultWithCursor{}, nil)
-	mockMediaDB.On("SearchMediaBySlugPrefix",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return([]database.SearchResultWithCursor{}, nil)
-	mockMediaDB.On("SearchMediaBySlugIn",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return([]database.SearchResultWithCursor{}, nil)
-	mockMediaDB.On("GetTitlesWithPreFilter",
-		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
-	).Return([]database.MediaTitle{}, nil)
 
 	setupCacheWrite(mockMediaDB)
 
@@ -861,10 +849,54 @@ func TestResolveTitle_BestCandidateCachedAndReturned(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, StrategyExactMatch, result.Strategy)
-	assert.Greater(t, result.Confidence, ConfidenceMinimum)
-	assert.Less(t, result.Confidence, ConfidenceHigh)
+	assert.GreaterOrEqual(t, result.Confidence, ConfidenceHigh)
 	mockMediaDB.AssertCalled(t, "SetCachedSlugResolution",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, int64(1), StrategyExactMatch)
+}
+
+func TestResolveTitle_MissingTagTypeIsNeutral(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg, err := helpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+
+	setupCacheMiss(mockMediaDB)
+
+	// Result has region:us but no lang tag at all. Filters request both
+	// region:us AND lang:en. The missing lang tag type should be neutral
+	// (skipped), so only region is evaluated → matches → high confidence.
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{
+		{
+			MediaID:  1,
+			SystemID: "NES",
+			Name:     "Super Mario Bros",
+			Path:     "/games/nes/smb.nes",
+			Tags: []database.TagInfo{
+				{Type: string(tags.TagTypeRegion), Tag: string(tags.TagRegionUS)},
+			},
+		},
+	}, nil)
+
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "NES",
+		GameName:  "Super Mario Bros",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+		AdditionalTags: []zapscript.TagFilter{
+			{Type: string(tags.TagTypeRegion), Value: string(tags.TagRegionUS), Operator: zapscript.TagOperatorAND},
+			{Type: string(tags.TagTypeLang), Value: string(tags.TagLangEN), Operator: zapscript.TagOperatorAND},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.GreaterOrEqual(t, result.Confidence, ConfidenceHigh)
 }
 
 func TestResolveTitle_FilenameTagExtraction(t *testing.T) {

--- a/pkg/zapscript/titles/selection.go
+++ b/pkg/zapscript/titles/selection.go
@@ -191,7 +191,14 @@ func HasAllTags(result *database.SearchResultWithCursor, tagFilters []zapscript.
 
 	// Check AND filters: must have ALL
 	for _, requiredTag := range andFilters {
-		if value, exists := resultTags[requiredTag.Type]; !exists || value != requiredTag.Value {
+		value, exists := resultTags[requiredTag.Type]
+		if !exists {
+			// Tag type not present on result — can't evaluate.
+			// Missing metadata is not a conflict, so skip rather
+			// than rejecting results that simply lack this tag type.
+			continue
+		}
+		if value != requiredTag.Value {
 			return false
 		}
 	}
@@ -555,11 +562,12 @@ func selectByQualityScore(results []database.SearchResultWithCursor) database.Se
 
 // CalculateTagMatchConfidence calculates a confidence score based on how well
 // a result's tags match the requested tag filters.
+// Only tag types present on the result are evaluated — missing tag types are
+// skipped (neutral), not penalized. Each conflict carries a 0.2 penalty.
 // Returns a value between 0.0 and 1.0, where:
-// - 1.0 = perfect match (all tags match or no tags required)
-// - 0.7-0.9 = good match (most tags match)
-// - 0.5-0.7 = partial match (some tags match or no tags on result)
-// - <0.5 = poor match (few tags match or conflicts exist)
+// - 1.0 = all applicable filters match, or no applicable filters
+// - 0.65 = result has no tags at all (moderate confidence)
+// - <0.5 = tag conflicts exist
 func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFilters []zapscript.TagFilter) float64 {
 	// No tag requirements = perfect match
 	if len(tagFilters) == 0 {
@@ -584,19 +592,20 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 	// Group filters by operator
 	andFilters, notFilters, orFilters := database.GroupTagFiltersByOperator(tagFilters)
 
-	// Check AND filters
-	yearConflicts := 0
+	// Check AND filters — only count filters where the tag type exists
+	// on the result. Missing metadata is not a conflict.
+	applicableAndFilters := 0
 	for _, requiredTag := range andFilters {
-		if value, exists := resultTags[requiredTag.Type]; exists && value == requiredTag.Value {
+		value, exists := resultTags[requiredTag.Type]
+		if !exists {
+			// Tag type not present — can't evaluate, skip.
+			continue
+		}
+		applicableAndFilters++
+		if value == requiredTag.Value {
 			matched++
-		} else if exists {
-			// Has a different value for this tag type (e.g., wants USA, has Japan)
-			if requiredTag.Type == string(tags.TagTypeYear) {
-				// Year tags get a smaller penalty - they're soft preferences
-				yearConflicts++
-			} else {
-				conflicts++
-			}
+		} else {
+			conflicts++
 		}
 	}
 
@@ -626,7 +635,7 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 		}
 	}
 
-	totalFilters := len(andFilters) + len(notFilters)
+	totalFilters := applicableAndFilters + len(notFilters)
 	if len(orFilters) > 0 {
 		totalFilters++ // OR group counts as one requirement
 	}
@@ -636,10 +645,8 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 	}
 
 	// Calculate confidence: matched ratio minus conflict penalty
-	// Year conflicts use a smaller penalty (0.05) than other tags (0.2)
-	// so year acts as a soft preference rather than a hard filter
 	matchRatio := float64(matched) / float64(totalFilters)
-	conflictPenalty := float64(conflicts)*0.2 + float64(yearConflicts)*0.05
+	conflictPenalty := float64(conflicts) * 0.2
 
 	confidence := matchRatio - conflictPenalty
 	if confidence < 0.0 {

--- a/pkg/zapscript/titles/selection_test.go
+++ b/pkg/zapscript/titles/selection_test.go
@@ -197,7 +197,7 @@ func TestHasAllTagsOperators(t *testing.T) {
 				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
 				{Type: "lang", Value: "en", Operator: zapscript.TagOperatorAND},
 			},
-			expected: false,
+			expected: true, // missing tag type is neutral, not a conflict
 		},
 		{
 			name: "NOT operator - excluded tag present",
@@ -1037,21 +1037,19 @@ func TestCalculateTagMatchConfidence_YearSoftPreference(t *testing.T) {
 			description: "exact year match should give full confidence",
 		},
 		{
-			name: "year mismatch has small penalty (not dealbreaker)",
+			name: "year mismatch has same penalty as other tags",
 			result: database.SearchResultWithCursor{
 				Tags: []database.TagInfo{{Type: "year", Tag: "1992"}},
 			},
 			tagFilters: []zapscript.TagFilter{
 				{Type: "year", Value: "1991", Operator: zapscript.TagOperatorAND},
 			},
-			// Year penalty is 0.05 vs normal 0.2 penalty
-			// With 1 filter and 0 matches: matchRatio = 0, penalty = 0.05
-			// confidence = 0 - 0.05 = 0 (clamped)
-			// But wait - there's no match so matchRatio = 0
-			// The key is that it's not as harsh as other tag conflicts
+			// 1 filter, 0 matches, 1 conflict
+			// matchRatio = 0/1 = 0, penalty = 1*0.2 = 0.2
+			// confidence = 0 - 0.2 = -0.2 (clamped to 0)
 			minExpected: 0.0,
-			maxExpected: 0.05, // Should be near 0 but not a hard failure
-			description: "year mismatch should have small penalty",
+			maxExpected: 0.01,
+			description: "year mismatch penalized same as any other tag conflict",
 		},
 		{
 			name: "year missing from result has no penalty",
@@ -1061,11 +1059,11 @@ func TestCalculateTagMatchConfidence_YearSoftPreference(t *testing.T) {
 			tagFilters: []zapscript.TagFilter{
 				{Type: "year", Value: "1991", Operator: zapscript.TagOperatorAND},
 			},
-			// Year not present = no conflict counted
-			// matchRatio = 0/1 = 0, penalty = 0
-			minExpected: 0.0,
-			maxExpected: 0.05,
-			description: "missing year should not penalize",
+			// Year tag type not present on result — filter is skipped entirely.
+			// applicableAndFilters=0, totalFilters=0 → returns 1.0
+			minExpected: 0.95,
+			maxExpected: 1.0,
+			description: "missing tag type should be neutral, not a penalty",
 		},
 		{
 			name: "region mismatch has normal penalty",
@@ -1082,7 +1080,7 @@ func TestCalculateTagMatchConfidence_YearSoftPreference(t *testing.T) {
 			description: "region mismatch should have normal penalty",
 		},
 		{
-			name: "year mismatch with region match still acceptable",
+			name: "year mismatch with region match",
 			result: database.SearchResultWithCursor{
 				Tags: []database.TagInfo{
 					{Type: "year", Tag: "1992"},
@@ -1093,18 +1091,15 @@ func TestCalculateTagMatchConfidence_YearSoftPreference(t *testing.T) {
 				{Type: "year", Value: "1991", Operator: zapscript.TagOperatorAND},
 				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
 			},
-			// 2 filters total
-			// region matches (matched = 1)
-			// year conflicts with small penalty (yearConflicts = 1)
-			// matchRatio = 1/2 = 0.5
-			// penalty = 0*0.2 + 1*0.05 = 0.05
-			// confidence = 0.5 - 0.05 = 0.45
-			minExpected: 0.40,
-			maxExpected: 0.50,
-			description: "year mismatch with good region match should still be acceptable",
+			// 2 filters: region matches (matched=1), year conflicts (conflicts=1)
+			// matchRatio = 1/2 = 0.5, penalty = 1*0.2 = 0.2
+			// confidence = 0.5 - 0.2 = 0.3
+			minExpected: 0.25,
+			maxExpected: 0.35,
+			description: "year mismatch penalized same as other tag conflicts",
 		},
 		{
-			name: "compare year vs region mismatch severity",
+			name: "both year and region mismatch",
 			result: database.SearchResultWithCursor{
 				Tags: []database.TagInfo{
 					{Type: "year", Tag: "wrong"},
@@ -1115,11 +1110,9 @@ func TestCalculateTagMatchConfidence_YearSoftPreference(t *testing.T) {
 				{Type: "year", Value: "1991", Operator: zapscript.TagOperatorAND},
 				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
 			},
-			// 2 filters, 0 matches
-			// 1 year conflict (0.05 penalty) + 1 region conflict (0.2 penalty)
-			// matchRatio = 0/2 = 0
-			// penalty = 0.2 + 0.05 = 0.25
-			// confidence = 0 - 0.25 = -0.25 (clamped to 0)
+			// 2 filters, 0 matches, 2 conflicts
+			// matchRatio = 0/2 = 0, penalty = 2*0.2 = 0.4
+			// confidence = 0 - 0.4 = -0.4 (clamped to 0)
 			minExpected: 0.0,
 			maxExpected: 0.01,
 			description: "both mismatches should result in low confidence",


### PR DESCRIPTION
## Summary

- **Audio crash fix**: Serialize audio playback goroutines with channel-based synchronization to prevent concurrent ALSA device access crashes on MiSTer. Add panic recovery to audio playback and token launch goroutines.
- **Tag matching fix**: Treat missing tag types as neutral in selection (skip) instead of blocking matches. Apply uniform 0.2 conflict penalty across all tag types instead of special-casing year tags.
- **MediaDB query performance**: Rewrite `fetchAndAttachTags` OR JOIN as UNION for efficient SQLite indexing. Remove redundant SQL tag filters from slug cache search path. Warm in-memory tag cache on startup. Fix self-healing double-query in `GetSystemTagsCached`.