### PR TITLE
fix(mister): write CURRENTPATH/FULLPATH for arcade .mra launches

### DIFF
--- a/pkg/platforms/mister/config/config.go
+++ b/pkg/platforms/mister/config/config.go
@@ -34,6 +34,8 @@ const (
 	LastLaunchFile     = SDRootDir + "/.LASTLAUNCH.mgl"
 	CoreNameFile       = "/tmp/CORENAME"
 	CurrentPathFile    = "/tmp/CURRENTPATH"
+	FullPathFile       = "/tmp/FULLPATH"
+	FileSelectFile     = "/tmp/FILESELECT"
 	CoreConfigFolder   = SDRootDir + "/config"
 	MenuConfigFile     = CoreConfigFolder + "/MENU.CFG"
 	DefaultIniFilename = "MiSTer.ini"

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -201,6 +201,44 @@ func LaunchShortCore(path string) error {
 	return launchFile(tmpFile)
 }
 
+// writeCurrentPath writes the CURRENTPATH, FULLPATH, and FILESELECT files
+// to match the format mister_main uses when launching a game from the menu.
+// mister_main doesn't write these files when launching .mra files via
+// load_core, so we do it here to keep external tools (e.g. marquee displays)
+// working correctly.
+func writeCurrentPath(path string) {
+	writeCurrentPathTo(
+		path,
+		misterconfig.CurrentPathFile,
+		misterconfig.FullPathFile,
+		misterconfig.FileSelectFile,
+	)
+}
+
+func writeCurrentPathTo(
+	path, currentPathFile, fullPathFile, fileSelectFile string,
+) {
+	fname := filepath.Base(path)
+	//nolint:gosec // MiSTer system files, need to be readable by other apps
+	if err := os.WriteFile(
+		currentPathFile, []byte(fname), 0o644,
+	); err != nil {
+		log.Error().Err(err).Msg("failed to write CURRENTPATH")
+	}
+	//nolint:gosec // MiSTer system files
+	if err := os.WriteFile(
+		fullPathFile, []byte(path), 0o644,
+	); err != nil {
+		log.Error().Err(err).Msg("failed to write FULLPATH")
+	}
+	//nolint:gosec // MiSTer system files
+	if err := os.WriteFile(
+		fileSelectFile, []byte("selected"), 0o644,
+	); err != nil {
+		log.Error().Err(err).Msg("failed to write FILESELECT")
+	}
+}
+
 func LaunchGame(cfg *config.Instance, system *cores.Core, path string) error {
 	ext := s.ToLower(filepath.Ext(path))
 	log.Info().Str("system", system.ID).Str("path", path).Str("type", ext).Msg("launching game")
@@ -211,6 +249,7 @@ func LaunchGame(cfg *config.Instance, system *cores.Core, path string) error {
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
+		writeCurrentPath(path)
 		log.Debug().Str("path", path).Msg("arcade game launched via MRA")
 	case ".mgl":
 		err := launchFile(path)
@@ -284,6 +323,7 @@ func LaunchBasicFile(path string) error {
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
+		writeCurrentPath(path)
 	case ".mgl":
 		err = launchFile(path)
 		if err != nil {

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -288,6 +288,75 @@ func TestGenerateMgl(t *testing.T) {
 	}
 }
 
+func TestWriteCurrentPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		path            string
+		wantCurrentPath string
+		wantFullPath    string
+	}{
+		{
+			name:            "standard arcade MRA path",
+			path:            "/media/fat/_Arcade/Pac-Man.mra",
+			wantCurrentPath: "Pac-Man.mra",
+			wantFullPath:    "/media/fat/_Arcade/Pac-Man.mra",
+		},
+		{
+			name:            "MRA in subdirectory",
+			path:            "/media/fat/_Arcade/cores/jotego/Street Fighter II.mra",
+			wantCurrentPath: "Street Fighter II.mra",
+			wantFullPath:    "/media/fat/_Arcade/cores/jotego/Street Fighter II.mra",
+		},
+		{
+			name:            "USB path",
+			path:            "/media/usb0/games/_Arcade/Donkey Kong.mra",
+			wantCurrentPath: "Donkey Kong.mra",
+			wantFullPath:    "/media/usb0/games/_Arcade/Donkey Kong.mra",
+		},
+		{
+			name:            "bare filename without directory",
+			path:            "game.mra",
+			wantCurrentPath: "game.mra",
+			wantFullPath:    "game.mra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			currentPathFile := filepath.Join(tmpDir, "CURRENTPATH")
+			fullPathFile := filepath.Join(tmpDir, "FULLPATH")
+			fileSelectFile := filepath.Join(tmpDir, "FILESELECT")
+
+			writeCurrentPathTo(
+				tt.path,
+				currentPathFile,
+				fullPathFile,
+				fileSelectFile,
+			)
+
+			got, err := os.ReadFile(currentPathFile) //nolint:gosec // test file
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCurrentPath, string(got),
+				"CURRENTPATH should be filename only, no trailing newline")
+
+			got, err = os.ReadFile(fullPathFile) //nolint:gosec // test file
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFullPath, string(got),
+				"FULLPATH should be the full path, no trailing newline")
+
+			got, err = os.ReadFile(fileSelectFile) //nolint:gosec // test file
+			require.NoError(t, err)
+			assert.Equal(t, "selected", string(got),
+				"FILESELECT should be exactly 'selected'")
+		})
+	}
+}
+
 func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- When launching arcade .mra files via `load_core`, mister_main doesn't write `/tmp/CURRENTPATH` or `/tmp/FULLPATH` (it only does so when games are selected through the menu's file browser). This leaves CURRENTPATH stale, breaking external tools like marquee displays.
- After sending `load_core` for .mra files, Zaparoo now writes CURRENTPATH (filename only), FULLPATH (full path), and FILESELECT to match the exact format mister_main uses (`MakeFile` — raw bytes, no trailing newline).
- Affects both `LaunchGame` and `LaunchBasicFile` .mra code paths.

Closes #581