### PR TITLE
feat(mister): add Jaguar CD core support

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -56,6 +56,7 @@ var CoreGroups = map[string][]Core{
 	"Atari7800": {Systems["Atari7800"], Systems["Atari2600"]},
 	"Coleco":    {Systems["ColecoVision"], Systems["SG1000"]},
 	"Gameboy":   {Systems["Gameboy"], Systems["GameboyColor"]},
+	"Jaguar":    {Systems["Jaguar"], Systems["JaguarCD"]},
 	"NES":       {Systems["NES"], Systems["NESMusic"], Systems["FDS"]},
 	"SMS": {Systems["MasterSystem"], Systems["GameGear"], Core{
 		ID: "SG1000",
@@ -497,6 +498,22 @@ var Systems = map[string]Core{
 					Delay:      1,
 					Method:     "f",
 					Index:      0,
+					ResetDelay: 1,
+					ResetHold:  1,
+				},
+			},
+		},
+	},
+	"JaguarCD": {
+		ID:  "JaguarCD",
+		RBF: "_Console/Jaguar",
+		Slots: []Slot{
+			{
+				Exts: []string{".cdi"},
+				Mgl: &MGLParams{
+					Delay:      1,
+					Method:     "s",
+					Index:      1,
 					ResetDelay: 1,
 					ResetHold:  1,
 				},

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -841,6 +841,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemJaguar),
 		},
 		{
+			ID:         systemdefs.SystemJaguarCD,
+			SystemID:   systemdefs.SystemJaguarCD,
+			Folders:    []string{"Jaguar"},
+			Extensions: []string{".cdi"},
+			Launch:     launch(pl, systemdefs.SystemJaguarCD),
+		},
+		{
 			ID:         systemdefs.SystemMasterSystem,
 			SystemID:   systemdefs.SystemMasterSystem,
 			Folders:    []string{"SMS"},


### PR DESCRIPTION
## Summary
- Add JaguarCD MiSTer core entry using the existing Jaguar RBF with CD slot parameters (method `s`, index `1`)
- Add JaguarCD launcher scanning the `Jaguar` folder for `.cdi` files
- Add CoreGroup entry so running core detection covers both Jaguar and JaguarCD

The MiSTer Jaguar core supports CD games via `.cdi` files but Zaparoo wasn't detecting them. The existing `SystemJaguarCD` system definition was already in place but had no MiSTer launcher.