### PR TITLE
fix(build): redirect update asset downloads to GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
               --title="${TITLE}" \
               --draft \
               ${PRERELEASE} \
-              --generate-notes
+              --notes ""
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -34,23 +34,25 @@ jobs:
           gh release download "${{ github.event.release.tag_name }}" --dir _assets \
             --pattern "zaparoo-*.tar.gz" \
             --pattern "zaparoo-*.zip"
-      - name: Generate checksums and manifest
+      - name: Generate checksums
+        run: cd _assets && sha256sum zaparoo-* > checksums.txt && cd ..
+      - name: Generate manifest
         env:
           RELEASE_NOTES: ${{ github.event.release.body }}
         run: |
-          cd _assets && sha256sum * > checksums.txt && cd ..
           go run scripts/generate-update-manifest/main.go \
             --version "${{ github.event.release.tag_name }}" \
             --assets-dir _assets \
             --release-notes "$RELEASE_NOTES" \
-            --output _assets/manifest.yaml
-      - name: Upload to Bunny.net storage
+            --output _manifest/manifest.yaml
+          cp _assets/checksums.txt _manifest/checksums.txt
+      - name: Upload manifest to Bunny.net storage
         uses: R-J-dev/bunny-deploy@v2.1.1
         with:
           storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
           storage-endpoint: "https://storage.bunnycdn.com"
           storage-zone-name: ${{ secrets.BUNNY_STORAGE_ZONE }}
-          directory-to-upload: "_assets"
+          directory-to-upload: "_manifest"
           target-directory: "ZaparooProject/zaparoo-core"
           concurrency: "10"
           access-key: ${{ secrets.BUNNY_API_KEY }}

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -54,8 +54,9 @@ func makeUpdater(platformID string) (*selfupdate.Updater, selfupdate.Repository,
 	filter := fmt.Sprintf("^zaparoo-%s_%s", platformID, runtime.GOARCH)
 
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source:  source,
-		Filters: []string{filter},
+		Source:    source,
+		Validator: &selfupdate.ChecksumValidator{UniqueFilename: "checksums.txt"},
+		Filters:   []string{filter},
 	})
 	if err != nil {
 		return nil, selfupdate.RepositorySlug{}, fmt.Errorf("creating updater: %w", err)

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -93,12 +93,17 @@ func buildManifest(version, assetsDir, releaseNotes string) (*manifest, error) {
 			return nil, fmt.Errorf("getting file info for %s: %w", name, infoErr)
 		}
 
+		assetURL := version + "/" + name
+		if name == "checksums.txt" {
+			assetURL = name
+		}
+
 		assetID++
 		assets = append(assets, &asset{
 			ID:   assetID,
 			Name: name,
 			Size: info.Size(),
-			URL:  name,
+			URL:  assetURL,
 		})
 	}
 

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -55,14 +55,17 @@ func TestBuildManifest_ValidAssets(t *testing.T) {
 	assert.Equal(t, int64(3), m.LastAssetID)
 	assert.Equal(t, int64(1), m.LastReleaseID)
 
-	// Verify assets have correct sizes
+	// Verify assets have correct sizes and version-prefixed URLs
 	assetsByName := make(map[string]*asset)
 	for _, a := range m.Releases[0].Assets {
 		assetsByName[a.Name] = a
 	}
 	assert.Equal(t, int64(1024), assetsByName["zaparoo-linux_amd64.tar.gz"].Size)
+	assert.Equal(t, "v2.10.0/zaparoo-linux_amd64.tar.gz", assetsByName["zaparoo-linux_amd64.tar.gz"].URL)
 	assert.Equal(t, int64(2048), assetsByName["zaparoo-windows_amd64.zip"].Size)
+	assert.Equal(t, "v2.10.0/zaparoo-windows_amd64.zip", assetsByName["zaparoo-windows_amd64.zip"].URL)
 	assert.Equal(t, int64(256), assetsByName["checksums.txt"].Size)
+	assert.Equal(t, "checksums.txt", assetsByName["checksums.txt"].URL)
 }
 
 func TestBuildManifest_SkipsNonAssetFiles(t *testing.T) {
@@ -138,7 +141,7 @@ func TestBuildManifest_NonexistentDirectory(t *testing.T) {
 	assert.Nil(t, m)
 }
 
-func TestBuildManifest_AssetURLMatchesName(t *testing.T) {
+func TestBuildManifest_AssetURLIncludesVersion(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -147,7 +150,7 @@ func TestBuildManifest_AssetURLMatchesName(t *testing.T) {
 	m, err := buildManifest("v1.0.0", dir, "")
 	require.NoError(t, err)
 
-	assert.Equal(t, "zaparoo-mister_arm.tar.gz", m.Releases[0].Assets[0].URL)
+	assert.Equal(t, "v1.0.0/zaparoo-mister_arm.tar.gz", m.Releases[0].Assets[0].URL)
 }
 
 func TestBuildManifest_ReleaseNotes(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add version prefix to manifest asset URLs so BunnyCDN edge rule redirects asset downloads to GitHub releases instead of serving them from CDN storage
- Only upload `manifest.yaml` and `checksums.txt` to BunnyCDN (not release binaries)
- Enable SHA256 checksum validation in the self-updater via `ChecksumValidator`
- Stop auto-generating release notes (`--generate-notes` → `--notes ""`) so drafts start empty for manual authoring