### PR TITLE
fix(api): various API correctness and screenshot reliability fixes

### DIFF
--- a/pkg/api/methods/mappings.go
+++ b/pkg/api/methods/mappings.go
@@ -52,7 +52,7 @@ func HandleMappings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 	mrs := make([]models.MappingResponse, 0)
 
 	for _, m := range mappings {
-		t := time.Unix(0, m.Added*int64(time.Millisecond))
+		t := time.Unix(m.Added, 0)
 
 		// keep compatibility for v0.1 api
 		switch m.Type {

--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -70,16 +70,12 @@ func HandleRun(env requests.RequestEnv) (any, error) { //nolint:gocritic // sing
 			t.Type = *params.Type
 		}
 
-		hasArg := false
-
 		if params.UID != nil {
 			t.UID = *params.UID
-			hasArg = true
 		}
 
 		if params.Text != nil {
 			t.Text = norm.NFC.String(*params.Text)
-			hasArg = true
 		}
 
 		if params.Data != nil {
@@ -89,11 +85,9 @@ func HandleRun(env requests.RequestEnv) (any, error) { //nolint:gocritic // sing
 			if _, err := hex.DecodeString(t.Data); err != nil {
 				return nil, validation.ErrInvalidParams
 			}
-
-			hasArg = true
 		}
 
-		if !hasArg {
+		if t.UID == "" && t.Text == "" && t.Data == "" {
 			return nil, validation.ErrInvalidParams
 		}
 
@@ -171,6 +165,8 @@ func HandleRunRest(
 
 func HandleStop(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Info().Msg("received stop request")
+	// TODO: return an error when nothing is active, requires StopActiveLauncher
+	// to report whether anything was actually stopped
 	err := env.Platform.StopActiveLauncher(platforms.StopForMenu)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stop active launcher: %w", err)

--- a/pkg/database/mediadb/sql_systems.go
+++ b/pkg/database/mediadb/sql_systems.go
@@ -206,7 +206,7 @@ func sqlIndexedSystems(ctx context.Context, db *sql.DB) ([]string, error) {
 // table (i.e., have indexed content). Preserves input order.
 func sqlFilterIndexedSystems(ctx context.Context, db sqlQueryable, systemIDs []string) ([]string, error) {
 	if len(systemIDs) == 0 {
-		return nil, nil
+		return []string{}, nil
 	}
 
 	args := make([]any, len(systemIDs))

--- a/pkg/database/mediadb/tag_cache.go
+++ b/pkg/database/mediadb/tag_cache.go
@@ -41,11 +41,15 @@ type tagCache struct {
 func (c *tagCache) tagsForSystems(systems []systemdefs.System) []database.TagInfo {
 	if len(systems) == 1 {
 		first := systems[0] //nolint:gosec // G602 false positive: len==1 guarantees valid index
-		return slices.Clone(c.bySystem[first.ID])
+		tags := c.bySystem[first.ID]
+		if tags == nil {
+			return []database.TagInfo{}
+		}
+		return slices.Clone(tags)
 	}
 
 	seen := make(map[database.TagInfo]struct{})
-	var result []database.TagInfo
+	result := []database.TagInfo{}
 	for _, sys := range systems {
 		for _, tag := range c.bySystem[sys.ID] {
 			if _, exists := seen[tag]; !exists {
@@ -72,6 +76,7 @@ func buildTagCache(ctx context.Context, db *sql.DB) (*tagCache, error) {
 
 	cache := &tagCache{
 		bySystem: make(map[string][]database.TagInfo),
+		allTags:  []database.TagInfo{},
 	}
 	seen := make(map[database.TagInfo]struct{})
 
@@ -104,6 +109,9 @@ func (db *MediaDB) RebuildTagCache() error {
 		return fmt.Errorf("failed to build tag cache: %w", err)
 	}
 	db.inMemoryTagCache.Store(cache)
+	if len(cache.allTags) == 0 {
+		log.Warn().Msg("tag cache is empty, media re-index may be required")
+	}
 	log.Info().
 		Int("tags", len(cache.allTags)).
 		Int("systems", len(cache.bySystem)).

--- a/pkg/database/userdb/sql.go
+++ b/pkg/database/userdb/sql.go
@@ -288,21 +288,20 @@ func sqlGetMapping(ctx context.Context, db *sql.DB, id int64) (database.Mapping,
 }
 
 func sqlDeleteMapping(ctx context.Context, db *sql.DB, id int64) error {
-	stmt, err := db.PrepareContext(ctx, `
-		delete from Mappings where DBID = ?;
-	`)
-	if err != nil {
-		return fmt.Errorf("failed to prepare mapping delete statement: %w", err)
-	}
-	defer func() {
-		if closeErr := stmt.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close sql statement")
-		}
-	}()
-	_, err = stmt.ExecContext(ctx, id)
+	result, err := db.ExecContext(ctx, `delete from Mappings where DBID = ?;`, id)
 	if err != nil {
 		return fmt.Errorf("failed to execute mapping delete: %w", err)
 	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("mapping not found: %d", id)
+	}
+
 	return nil
 }
 

--- a/pkg/database/userdb/sql_test.go
+++ b/pkg/database/userdb/sql_test.go
@@ -331,10 +331,9 @@ func TestSqlDeleteMapping_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectPrepare(`delete from Mappings where DBID`).
-		ExpectExec().
+	mock.ExpectExec(`delete from Mappings where DBID`).
 		WithArgs(int64(123)).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = sqlDeleteMapping(context.Background(), db, 123)
 	require.NoError(t, err)
@@ -347,14 +346,13 @@ func TestSqlDeleteMapping_NotFound(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectPrepare(`delete from Mappings where DBID`).
-		ExpectExec().
+	mock.ExpectExec(`delete from Mappings where DBID`).
 		WithArgs(int64(999)).
-		WillReturnError(sqlmock.ErrCancelled)
+		WillReturnResult(sqlmock.NewResult(0, 0))
 
 	err = sqlDeleteMapping(context.Background(), db, 999)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to execute mapping delete")
+	assert.Contains(t, err.Error(), "mapping not found: 999")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/platforms/mister/screenshot.go
+++ b/pkg/platforms/mister/screenshot.go
@@ -22,6 +22,8 @@
 package mister
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -37,6 +39,84 @@ import (
 )
 
 const screenshotTimeout = 3 * time.Second
+
+// pngIENDTail is the fixed 12-byte sequence that ends every valid PNG:
+// 4 bytes data length (0), 4 bytes chunk type "IEND", 4 bytes CRC.
+var pngIENDTail = []byte{0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82}
+
+// screenshotFileComplete checks whether a screenshot file has been fully
+// written using format-specific markers. This avoids reading a partial file
+// when fsnotify fires before the writer has flushed and closed.
+func screenshotFileComplete(path, ext string) (bool, error) {
+	switch ext {
+	case ".png":
+		return pngFileComplete(path)
+	case ".bmp":
+		return bmpFileComplete(path)
+	default:
+		return false, fmt.Errorf("unsupported screenshot format: %s", ext)
+	}
+}
+
+// pngFileComplete returns true when the file ends with the IEND chunk.
+func pngFileComplete(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("stat png: %w", err)
+	}
+	if info.Size() < int64(len(pngIENDTail)) {
+		return false, nil
+	}
+
+	//nolint:gosec // Safe: reads screenshot from controlled application directory
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open png: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	tail := make([]byte, len(pngIENDTail))
+	if _, err := f.ReadAt(tail, info.Size()-int64(len(tail))); err != nil {
+		return false, fmt.Errorf("read png tail: %w", err)
+	}
+
+	return bytes.Equal(tail, pngIENDTail), nil
+}
+
+// bmpFileComplete returns true when the actual file size matches the size
+// declared in the BMP header (little-endian uint32 at bytes 2-5).
+func bmpFileComplete(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, fmt.Errorf("stat bmp: %w", err)
+	}
+	if info.Size() < 6 {
+		return false, nil
+	}
+
+	//nolint:gosec // Safe: reads screenshot from controlled application directory
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open bmp: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	header := make([]byte, 6)
+	if _, err := f.ReadAt(header, 0); err != nil {
+		return false, fmt.Errorf("read bmp header: %w", err)
+	}
+
+	if header[0] != 'B' || header[1] != 'M' {
+		return false, nil
+	}
+
+	declaredSize := int64(binary.LittleEndian.Uint32(header[2:6]))
+	if declaredSize == 0 {
+		return false, nil
+	}
+
+	return info.Size() == declaredSize, nil
+}
 
 // Screenshot triggers a MiSTer screenshot via the command interface and waits
 // for the resulting file to appear in the screenshots directory. The full image
@@ -95,9 +175,27 @@ func (*Platform) Screenshot() (*platforms.ScreenshotResult, error) {
 
 			log.Info().Str("path", event.Name).Msg("screenshot captured")
 
-			// Wait for the file to be fully written. fsnotify fires Create
+			// Poll until the file is fully written. fsnotify fires Create
 			// when the inode appears, before the writer has flushed and closed.
-			time.Sleep(200 * time.Millisecond)
+			// Use format-specific checks to know when the file is complete:
+			//   PNG: must end with a 12-byte IEND chunk
+			//   BMP: header bytes 2-5 declare the total file size
+			pollInterval := 250 * time.Millisecond
+			for {
+				complete, checkErr := screenshotFileComplete(event.Name, ext)
+				if checkErr != nil {
+					return nil, fmt.Errorf("check screenshot file: %w", checkErr)
+				}
+				if complete {
+					break
+				}
+
+				select {
+				case <-timeout.C:
+					return nil, fmt.Errorf("screenshot file incomplete after %s", screenshotTimeout)
+				case <-time.After(pollInterval):
+				}
+			}
 
 			//nolint:gosec // Safe: reads screenshot from controlled application directory
 			data, readErr := os.ReadFile(event.Name)

--- a/pkg/platforms/mister/screenshot_test.go
+++ b/pkg/platforms/mister/screenshot_test.go
@@ -1,0 +1,146 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPngFileComplete_ValidPNG(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.png")
+	// Minimal valid PNG: 8-byte header + IEND chunk
+	data := append([]byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}, pngIENDTail...)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	complete, err := pngFileComplete(path)
+	require.NoError(t, err)
+	assert.True(t, complete)
+}
+
+func TestPngFileComplete_Truncated(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.png")
+	// PNG header only, no IEND
+	data := []byte{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x00}
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	complete, err := pngFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestPngFileComplete_TooSmall(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.png")
+	require.NoError(t, os.WriteFile(path, []byte{0x89, 0x50}, 0o600))
+
+	complete, err := pngFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestPngFileComplete_EmptyFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.png")
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o600))
+
+	complete, err := pngFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func writeBMP(t *testing.T, dir string, magic [2]byte, declaredSize uint32, actualSize int) string {
+	t.Helper()
+	path := filepath.Join(dir, "test.bmp")
+	data := make([]byte, actualSize)
+	data[0] = magic[0]
+	data[1] = magic[1]
+	if actualSize >= 6 {
+		binary.LittleEndian.PutUint32(data[2:6], declaredSize)
+	}
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func TestBmpFileComplete_ValidBMP(t *testing.T) {
+	t.Parallel()
+	path := writeBMP(t, t.TempDir(), [2]byte{'B', 'M'}, 100, 100)
+
+	complete, err := bmpFileComplete(path)
+	require.NoError(t, err)
+	assert.True(t, complete)
+}
+
+func TestBmpFileComplete_PartiallyWritten(t *testing.T) {
+	t.Parallel()
+	// File exists but is smaller than declared size
+	path := writeBMP(t, t.TempDir(), [2]byte{'B', 'M'}, 100, 50)
+
+	complete, err := bmpFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestBmpFileComplete_ZeroDeclaredSize(t *testing.T) {
+	t.Parallel()
+	path := writeBMP(t, t.TempDir(), [2]byte{'B', 'M'}, 0, 10)
+
+	complete, err := bmpFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestBmpFileComplete_InvalidMagic(t *testing.T) {
+	t.Parallel()
+	path := writeBMP(t, t.TempDir(), [2]byte{0x00, 0x00}, 100, 100)
+
+	complete, err := bmpFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestBmpFileComplete_TooSmall(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.bmp")
+	require.NoError(t, os.WriteFile(path, []byte{0x42, 0x4d, 0x00}, 0o600))
+
+	complete, err := bmpFileComplete(path)
+	require.NoError(t, err)
+	assert.False(t, complete)
+}
+
+func TestScreenshotFileComplete_UnsupportedFormat(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "test.jpg")
+	require.NoError(t, os.WriteFile(path, []byte{0xFF, 0xD8}, 0o600))
+
+	_, err := screenshotFileComplete(path, ".jpg")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported screenshot format")
+}


### PR DESCRIPTION
## Summary

- Fix mapping timestamp display interpreting seconds as milliseconds, producing 1970 dates
- Fix `run` endpoint accepting requests where all of UID/Text/Data resolve to empty strings
- Fix `mappings.delete` returning success for nonexistent IDs by checking `RowsAffected`
- Fix nil slice JSON serialization producing `null` instead of `[]` in tag cache and system filter responses
- Add warning log when tag cache is empty after rebuild (suggests re-index needed after upgrade)
- Fix MiSTer screenshot API returning truncated/corrupt PNG data by replacing a fixed 200ms sleep with format-aware completion polling (PNG checks for IEND chunk, BMP validates header-declared file size)
- Add unit tests for screenshot file completion checks