### PR TITLE
ci: harden workflows with pinned SHAs and explicit permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,9 @@ jobs:
           - platform: libreelec
             arch: arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: zaparooapprel
-        uses: pozetroninc/github-action-get-latest-release@v0.8.0
+        uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c # v0.8.0
         with:
           repository: ZaparooProject/zaparoo-app
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -148,22 +148,22 @@ jobs:
           echo "Version: $VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker CLI
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           use: true
           install: true
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -185,7 +185,7 @@ jobs:
         run: APP_VERSION=${VERSION} task ${{matrix.platform}}:build-${{matrix.arch}}
       - name: Upload unsigned Windows exe
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unsigned-windows-exe-${{matrix.arch}}
           path: _build/windows_${{matrix.arch}}/Zaparoo.exe
@@ -197,14 +197,14 @@ jobs:
              "_build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe"
       - name: Upload unsigned Windows installer
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unsigned-windows-installer-${{matrix.arch}}
           path: _build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe
           retention-days: 30
       - name: Upload Windows distribution files
         if: matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-dist-${{matrix.arch}}
           path: |
@@ -247,7 +247,7 @@ jobs:
           gh release upload "$tag" "_build/packages/batocera/zaparoo-core-${PKG_VERSION}-1-${PKG_ARCH}.pkg.tar.zst" --clobber
       - name: Upload Batocera binary as artifact
         if: matrix.platform == 'batocera'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: batocera-binary-${{matrix.arch}}
           path: _build/batocera_${{matrix.arch}}/zaparoo
@@ -263,14 +263,14 @@ jobs:
       contents: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             scripts/
             go.mod
           sparse-checkout-cone-mode: false
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -282,47 +282,47 @@ jobs:
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Download unsigned exe (amd64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-exe-amd64
           path: _unsigned/amd64/
       - name: Download unsigned exe (arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-exe-arm64
           path: _unsigned/arm64/
       - name: Download unsigned exe (386)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-exe-386
           path: _unsigned/386/
       - name: Download unsigned installer (amd64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-installer-amd64
           path: _unsigned/amd64/
       - name: Download unsigned installer (arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-installer-arm64
           path: _unsigned/arm64/
       - name: Download unsigned installer (386)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: unsigned-windows-installer-386
           path: _unsigned/386/
       - name: Download distribution files (amd64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: windows-dist-amd64
           path: _dist/amd64/
       - name: Download distribution files (arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: windows-dist-arm64
           path: _dist/arm64/
       - name: Download distribution files (386)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: windows-dist-386
           path: _dist/386/
@@ -335,13 +335,13 @@ jobs:
           done
       - name: Upload signing bundle
         id: upload-bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: unsigned-windows-bundle
           path: _signing_bundle/
           retention-days: 30
       - name: Sign all Windows binaries
-        uses: signpath/github-action-submit-signing-request@v2
+        uses: signpath/github-action-submit-signing-request@3f9250c56651ff692d6729a2fbb0603a42d7d322 # v2
         with:
           api-token: "${{ secrets.SIGNPATH_API_TOKEN }}"
           organization-id: "${{ secrets.SIGNPATH_ORGANIZATION_ID }}"
@@ -385,7 +385,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             scripts/
@@ -406,22 +406,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zstd
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download Batocera amd64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: batocera-binary-amd64
           path: _build/batocera_amd64/
       - name: Download Batocera arm64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: batocera-binary-arm64
           path: _build/batocera_arm64/
       - name: Download Batocera arm binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: batocera-binary-arm
           path: _build/batocera_arm/

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   contrib-readme-job:
     runs-on: ubuntu-latest
@@ -13,14 +16,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.ZAPAROO_APP_ID }}
           private-key: ${{ secrets.ZAPAROO_APP_PRIVATE_KEY }}
 
       - name: Contribute List
-        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        uses: akhilmhdh/contributors-readme-action@1ff4c56187458b34cd602aee93e897344ce34bfc # v2.3.10
         with:
           auto_detect_branch_protection: false
         env:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -24,8 +24,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
         id: filter
         with:
           filters: |
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -71,7 +71,7 @@ jobs:
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/go/pkg/mod
@@ -82,7 +82,7 @@ jobs:
 
       - name: Restore Go cache (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             D:\go-mod-cache
@@ -96,13 +96,13 @@ jobs:
 
       - name: Cache APT packages (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
           version: 1.1
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: latest
           args: --timeout=5m
@@ -126,10 +126,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -147,7 +147,7 @@ jobs:
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/go/pkg/mod
@@ -158,7 +158,7 @@ jobs:
 
       - name: Restore Go cache (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             D:\go-mod-cache
@@ -172,7 +172,7 @@ jobs:
 
       - name: Cache APT packages (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
           version: 1.1
@@ -184,7 +184,7 @@ jobs:
 
       - name: Cache scoop packages (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~\scoop
           key: ${{ runner.os }}-scoop-pkg-config
@@ -223,10 +223,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -244,7 +244,7 @@ jobs:
 
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/go/pkg/mod
@@ -255,7 +255,7 @@ jobs:
 
       - name: Restore Go cache (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             D:\go-mod-cache
@@ -269,7 +269,7 @@ jobs:
 
       - name: Cache APT packages (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
           version: 1.1
@@ -281,7 +281,7 @@ jobs:
 
       - name: Cache scoop packages (Windows)
         if: matrix.os == 'windows-latest'
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~\scoop
           key: ${{ runner.os }}-scoop-pkg-config
@@ -310,7 +310,7 @@ jobs:
 
       - name: Upload rapid failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rapid-failures-${{ matrix.os }}
           path: '**/testdata/rapid/**/*.fail'
@@ -323,7 +323,7 @@ jobs:
       - name: Upload coverage to Codecov
         # Skip on tag pushes
         if: matrix.os == 'ubuntu-latest' && !startsWith(github.ref, 'refs/tags/')
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
@@ -333,7 +333,7 @@ jobs:
 
       - name: Save Go cache (Unix)
         if: github.ref == 'refs/heads/main' && matrix.os != 'windows-latest'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             ~/go/pkg/mod
@@ -342,7 +342,7 @@ jobs:
 
       - name: Save Go cache (Windows)
         if: github.ref == 'refs/heads/main' && matrix.os == 'windows-latest'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
             D:\go-mod-cache

--- a/.github/workflows/mister.yml
+++ b/.github/workflows/mister.yml
@@ -18,19 +18,19 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
         id: app-token
         with:
           app-id: ${{ vars.ZAPAROO_APP_ID }}
           private-key: ${{ secrets.ZAPAROO_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           token: ${{ steps.app-token.outputs.token }}
       - name: Get release info
         id: zaparooreleaseinfo
-        uses: cardinalby/git-get-release-action@v1
+        uses: cardinalby/git-get-release-action@cf4593dd18e51a1ecfbfb1c68abac9910a8b1e0c # v1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
@@ -42,7 +42,7 @@ jobs:
         run: |
           python3 scripts/mister/repo/generate.py ${{ steps.zaparooreleaseinfo.outputs.tag_name }}
       - name: Commit repo database
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           add: scripts/mister/repo/tapto.json -f -A
           default_author: github_actions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       tag: ${{ steps.generate_tag.outputs.tag }}
       should_build: ${{ steps.check_changes.outputs.should_build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Fetch all history to check for changes
 
@@ -71,10 +71,10 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Delete old nightly releases
-        uses: dev-drprasad/delete-older-releases@v0.3.0
+        uses: dev-drprasad/delete-older-releases@12d87c89d8ed5efac93b4ef043da60acf6746441 # v0.3.0
         with:
           keep_latest: 5
           delete_tags: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     name: Publish stable update manifest to CDN
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             scripts/generate-update-manifest/
@@ -22,7 +22,7 @@ jobs:
             go.sum
           sparse-checkout-cone-mode: false
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -51,7 +51,7 @@ jobs:
             --output _manifest/manifest.yaml
           cp _assets/checksums.txt _manifest/checksums.txt
       - name: Upload manifest to Bunny.net storage
-        uses: R-J-dev/bunny-deploy@v3.0.0
+        uses: R-J-dev/bunny-deploy@ae25fa670b732ffc8dba84c872fb203d2a365229 # v3.0.0
         with:
           storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
           storage-endpoint: "https://storage.bunnycdn.com"
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 10
     name: Publish beta update manifest to CDN
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           sparse-checkout: |
             scripts/generate-update-manifest/
@@ -82,7 +82,7 @@ jobs:
             go.sum
           sparse-checkout-cone-mode: false
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: false
@@ -118,20 +118,20 @@ jobs:
         env:
           RELEASE_NOTES: ${{ github.event.release.body }}
         run: |
-          MERGE_FLAG=""
+          MERGE_FLAG=()
           if [ -f _existing/manifest.yaml ]; then
-            MERGE_FLAG="--merge _existing/manifest.yaml"
+            MERGE_FLAG=(--merge _existing/manifest.yaml)
           fi
           go run scripts/generate-update-manifest/main.go \
             --version "${{ github.event.release.tag_name }}" \
             --assets-dir _assets \
             --release-notes "$RELEASE_NOTES" \
             --prerelease \
-            $MERGE_FLAG \
+            "${MERGE_FLAG[@]}" \
             --output _manifest/manifest.yaml
           cp _assets/checksums.txt _manifest/checksums.txt
       - name: Upload manifest to Bunny.net storage
-        uses: R-J-dev/bunny-deploy@v3.0.0
+        uses: R-J-dev/bunny-deploy@ae25fa670b732ffc8dba84c872fb203d2a365229 # v3.0.0
         with:
           storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
           storage-endpoint: "https://storage.bunnycdn.com"

--- a/.github/workflows/zigcc-build.yml
+++ b/.github/workflows/zigcc-build.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set version
         id: version
@@ -49,7 +49,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,11 +68,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push
         if: steps.check.outputs.exists != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./scripts/zigcc
           push: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ZaparooProject/zaparoo-core/v2
 
-go 1.26.1
+go 1.26.2
 
 require (
 	fyne.io/systray v1.11.0


### PR DESCRIPTION
## Summary

- Pin all third-party GitHub Actions in the 8 workflows to full-length commit SHAs with version comments, so the exact action code running in CI cannot change silently if a tag is force-moved. Dependabot is already configured and will keep these in sync.
- Add a top-level `permissions: contents: read` default to `contributors.yml` (the only workflow lacking one). Job-level widening is preserved where needed.
- Fix an unquoted `$MERGE_FLAG` word-splitting pattern in `publish-update-manifest.yml` by switching to a bash array (SC2086, flagged by actionlint/shellcheck).

Verified with `actionlint v1.7.12` — no warnings.

Workflows touched: `build.yml`, `contributors.yml`, `lint-and-test.yml`, `mister.yml`, `nightly.yml`, `pr-title.yml`, `publish-update-manifest.yml`, `zigcc-build.yml`.

Commented-out legacy job in `build.yml` (lines 440–497, old mac build scaffolding) left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned third‑party GitHub Actions to specific commit SHAs across CI/CD workflows for more consistent, reproducible runs.
  * Tightened workflow permissions to reduce repository access where applicable.
  * Bumped the Go toolchain version directive (minor patch update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->