### PR TITLE
feat(api): add PAKE pairing and AES-256-GCM WebSocket encryption

### DIFF
--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -8,7 +8,7 @@ The Zaparoo API supports application-layer encryption on the WebSocket transport
 
 - **Pairing**: One-time PAKE2 (P-256) handshake. The user enters a 6-digit PIN displayed on the Zaparoo device into the client app. A shared 32-byte pairing key is derived without ever transmitting the PIN.
 - **Encryption**: AES-256-GCM with implicit counter-derived nonces on every WebSocket frame after the first.
-- **Per-session keys**: On each new WebSocket connection the client generates a random 16-byte session salt; both sides derive ephemeral session keys via HKDF from `pairingKey || salt`. Counters reset to 0 each session.
+- **Per-session keys**: On each new WebSocket connection the client generates a random 16-byte session salt; both sides derive ephemeral session keys via HKDF-SHA256 using the pairing key as IKM and the session salt as the HKDF salt. Counters reset to 0 each session.
 - **Scope**: Encryption applies to **WebSocket only**. Non-WebSocket transports (HTTP POST, SSE, REST GET) are restricted to localhost by default and require an explicit IP allowlist for remote access.
 
 ## Encryption setting
@@ -213,7 +213,7 @@ Two phases with different requirements:
 |---|---|
 | JavaScript | [`@noble/curves`](https://github.com/paulmillr/noble-curves) (audited, zero deps) |
 | Python | `ecdsa` or `cryptography` |
-| Swift | OpenSSL binding or hand-rolled EC math |
+| Swift | [Swift Crypto](https://github.com/apple/swift-crypto) or OpenSSL binding |
 | Kotlin/Android | Bouncy Castle `ECPoint` (ships on Android) |
 | C#/.NET | BouncyCastle NuGet |
 | Rust | `p256` crate |
@@ -308,7 +308,13 @@ async function connectEncrypted(wsUrl, authToken, pairingKey) {
 
     const ws = new WebSocket(wsUrl);
 
+    const opened = new Promise((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = (e) => reject(e);
+    });
+
     async function sendRPC(method, params) {
+        await opened;
         const payload = JSON.stringify({ jsonrpc: "2.0", method, params, id: Date.now() });
         const counter = sendCounter++;
         const nonce = buildNonce(keys.c2sBase, counter);
@@ -341,6 +347,7 @@ async function connectEncrypted(wsUrl, authToken, pairingKey) {
         handleResponse(JSON.parse(new TextDecoder().decode(pt)));
     };
 
+    await opened;
     return { sendRPC };
 }
 ```

--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -1,0 +1,348 @@
+# API Encryption
+
+> **Status**: Available in Zaparoo Core 2.x. Disabled by default.
+
+The Zaparoo API supports application-layer encryption on the WebSocket transport using a PAKE-based pairing flow and AES-256-GCM with per-session HKDF-derived keys. This document describes the wire protocol for client SDK implementors.
+
+## Overview
+
+- **Pairing**: One-time PAKE2 (P-256) handshake. The user enters a 6-digit PIN displayed on the Zaparoo device into the client app. A shared 32-byte pairing key is derived without ever transmitting the PIN.
+- **Encryption**: AES-256-GCM with implicit counter-derived nonces on every WebSocket frame after the first.
+- **Per-session keys**: On each new WebSocket connection the client generates a random 16-byte session salt; both sides derive ephemeral session keys via HKDF from `pairingKey || salt`. Counters reset to 0 each session.
+- **Scope**: Encryption applies to **WebSocket only**. Non-WebSocket transports (HTTP POST, SSE, REST GET) are restricted to localhost by default and require an explicit IP allowlist for remote access.
+
+## Encryption setting
+
+The server has a single boolean setting `encryption` (in the `[service]` section of `config.toml`):
+
+| Value | Behavior |
+|---|---|
+| `false` (default) | No encryption. All WebSocket connections accepted as plaintext; API key authentication applies. |
+| `true` | Remote WebSocket connections must send an encrypted first frame derived from a paired key. Plaintext WebSocket connections from non-loopback addresses are rejected. API key authentication for the WebSocket transport is bypassed (the pairing key proves identity). Localhost is always exempt — local plaintext WebSocket connections continue to work without pairing. |
+
+The `encryption` setting only affects the WebSocket transport. HTTP POST, SSE, and REST GET endpoints always use the IP allowlist + API key auth model and are unaffected.
+
+## Pairing flow
+
+Pairing happens over plain HTTP (the PAKE protocol provides its own security). Two round trips establish a shared 32-byte pairing key.
+
+```
+TUI                     Server                       Client App
+───                     ──────                       ──────────
+User: "Pair device"
+                        Generate 6-digit PIN
+Display PIN             Store PIN (5min expiry)
+
+                                                     User types PIN
+                                                     A = pake.InitCurve(pin, 0, "p256")
+
+                        ← POST /api/pair/start ────────────────
+                          { "pake": base64(A.Bytes()),
+                            "name": "MyApp" }
+
+                        B = pake.InitCurve(pin, 1, "p256")
+                        B.Update(A.Bytes())
+
+                        ── 200 { "session": uuid, ──────────→
+                             "pake": base64(B.Bytes()) }
+
+                                                     A.Update(B.Bytes())
+                                                     sessionKey = A.SessionKey()
+                                                     prk = HKDF-Extract(sessionKey, nil)
+                                                     confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)
+                                                     confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)
+                                                     pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
+
+                        ← POST /api/pair/finish ───────────────
+                          { "session": uuid,
+                            "confirm": base64(HMAC-SHA256(
+                              confirmKeyA,
+                              LP("zaparoo-v1") || LP("p256") ||
+                              LP("client") || LP(name) ||
+                              LP(MsgA) || LP(MsgB))) }
+
+                        Verify client HMAC.
+                        On success: persist client, return:
+
+                        ── 200 { "authToken": uuid, ────────→
+                             "clientId": uuid,
+                             "confirm": base64(HMAC(
+                               confirmKeyB, "server" || ...)) }
+
+                                                     Verify server HMAC.
+                                                     Store authToken + pairingKey securely.
+                                                     (pairingKey was derived locally above —
+                                                      it is NEVER sent over the wire.)
+PIN cleared
+```
+
+### Length-prefixed encoding
+
+The HMAC inputs use length-prefixed encoding to prevent canonicalization attacks: each variable-length field is encoded as a 4-byte big-endian length prefix followed by the bytes.
+
+```
+LP(field) = 4-byte big-endian uint32 length || field bytes
+```
+
+The HMAC transcript is:
+
+```
+LP("zaparoo-v1") || LP("p256") || LP(role) || LP(clientName) || LP(MsgA) || LP(MsgB)
+```
+
+where `role` is the literal string `"client"` or `"server"`, and `MsgA` / `MsgB` are the **raw bytes** sent over the wire at `/pair/start` (NOT the result of calling `pake.Bytes()` again after `Update()`, which would mutate the state and produce different bytes).
+
+### Pairing limits
+
+- **PIN**: 6 decimal digits, generated with `crypto/rand`. ~20 bits of entropy.
+- **Expiry**: 5 minutes from PIN generation.
+- **Attempts**: 3 failed `/pair/finish` HMAC verifications across all sessions for the same PIN before the PIN is invalidated.
+- **Sessions**: A `/pair/start` session expires after 2 minutes if `/pair/finish` is not called.
+- **Client name**: max 128 bytes.
+- **Max paired clients**: 50 per device. The 51st pairing attempt is rejected.
+- **Rate limit**: 1 request/sec per IP on `/api/pair/*` endpoints.
+
+## Encryption — WebSocket message format
+
+After pairing, every WebSocket connection begins with an encrypted first frame that establishes the session.
+
+### First frame (client → server)
+
+```json
+{
+    "v": 1,
+    "e": "<base64(ciphertext)>",
+    "t": "<authToken>",
+    "s": "<base64(sessionSalt)>"
+}
+```
+
+- `v`: Protocol version. Currently `1`. The server returns a plaintext error if unsupported:
+  ```json
+  {"jsonrpc": "2.0", "id": null, "error": {"code": -32001, "message": "unsupported encryption version", "data": {"supported": [1]}}}
+  ```
+- `e`: AES-256-GCM ciphertext of the JSON-RPC request, base64-encoded.
+- `t`: Auth token (UUID) identifying the paired client. Sent in plaintext as a key lookup; not a secret.
+- `s`: 16-byte random session salt, base64-encoded. **Must be exactly 16 bytes.** The server rejects any other size.
+
+### Subsequent frames (both directions)
+
+```json
+{
+    "e": "<base64(ciphertext)>"
+}
+```
+
+The counter is implicit — both sides start at 0 and increment by 1 per frame. WebSocket is TCP (ordered, reliable) so sender and receiver always agree on the next counter value. **If decryption fails the connection is closed** — there is no recovery.
+
+### Inside the encrypted payload
+
+Once decrypted, the payload is standard JSON-RPC 2.0:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "version",
+    "params": {},
+    "id": 1
+}
+```
+
+## Session key derivation
+
+On each new WebSocket connection (NOT once per pairing), the client generates a random session salt and derives ephemeral session keys via HKDF-SHA256.
+
+```
+prk     = HKDF-Extract(SHA-256, ikm=pairingKey, salt=sessionSalt)
+c2sKey  = HKDF-Expand(SHA-256, prk, info="zaparoo-c2s-v1",       length=32)
+s2cKey  = HKDF-Expand(SHA-256, prk, info="zaparoo-s2c-v1",       length=32)
+c2sBase = HKDF-Expand(SHA-256, prk, info="zaparoo-c2s-nonce-v1", length=12)
+s2cBase = HKDF-Expand(SHA-256, prk, info="zaparoo-s2c-nonce-v1", length=12)
+```
+
+Separate keys + nonce bases per direction prevent reflection attacks and eliminate cross-direction nonce collision.
+
+### Counter-derived nonces
+
+The 12-byte AES-GCM nonce for each frame is derived by XORing a 64-bit big-endian counter into the **last 8 bytes** of the 12-byte nonce base. The first 4 bytes of the base are unchanged.
+
+```
+nonce[0:4] = base[0:4]
+nonce[4:12] = base[4:12] XOR (counter as 8 bytes big-endian)
+```
+
+Counters never wrap or reuse — disconnect and reconnect with a fresh salt to start over.
+
+## AAD (Additional Authenticated Data)
+
+Every encrypt/decrypt operation binds the ciphertext to the auth token via AAD:
+
+```
+aad = authToken + ":ws"
+```
+
+This prevents an attacker from substituting ciphertexts across sessions even if they somehow obtained the keys.
+
+## Server-to-client notifications
+
+The server broadcasts notifications (e.g. `media.started`) to all connected clients. For encrypted sessions the server encrypts each notification with the per-session keys before sending. The wire format is the same as a regular outgoing frame:
+
+```json
+{
+    "e": "<base64(ciphertext)>"
+}
+```
+
+## Duplicate session salt rejection
+
+The server maintains a per-client in-memory list of recently seen session salts (sliding window of 200 entries / 10 minutes). If a client reuses a salt, the connection is rejected. This protects against broken client CSPRNGs producing duplicate salts, which would cause catastrophic AES-GCM nonce reuse.
+
+**Always use `crypto/random` (or platform equivalent) to generate session salts.** Never derive them from time, sequence numbers, or other predictable sources.
+
+## Failed-frame rate limiting
+
+The server tracks consecutive failed first-frame decryptions per `(authToken, sourceIP)` pair. After 10 consecutive failures, that combination is blocked for 30 seconds (exponential backoff on repeated blocks, capped at 30 minutes). Successful first frames reset the counter.
+
+## Client crypto dependencies
+
+Two phases with different requirements:
+
+**Pairing (one-time)**: Requires raw P-256 elliptic curve point arithmetic. No platform's built-in crypto API exposes this directly. Client SDKs need:
+
+| Platform | Library |
+|---|---|
+| JavaScript | [`@noble/curves`](https://github.com/paulmillr/noble-curves) (audited, zero deps) |
+| Python | `ecdsa` or `cryptography` |
+| Swift | OpenSSL binding or hand-rolled EC math |
+| Kotlin/Android | Bouncy Castle `ECPoint` (ships on Android) |
+| C#/.NET | BouncyCastle NuGet |
+| Rust | `p256` crate |
+
+**Per-connection encryption (every session)**: Only needs HKDF-SHA256 + AES-256-GCM + HMAC-SHA256, all available in platform stdlib (Web Crypto, CryptoKit, JCE, .NET, RustCrypto).
+
+## Client-side key storage
+
+Recommend platform-appropriate secure storage:
+
+| Platform | Recommended storage |
+|---|---|
+| iOS | Keychain |
+| Android | EncryptedSharedPreferences / Keystore |
+| Web/Electron | OS keychain via `keytar` or similar |
+| CLI tools | File mode `0600` in user config directory |
+
+The pairing key (32 bytes) and auth token (UUID) must both be stored. The auth token is not a secret but is paired with the key — losing one renders the other useless.
+
+## Error handling
+
+| HTTP status | Endpoint | Meaning |
+|---|---|---|
+| 400 | `/pair/*` | Malformed request body or PAKE message |
+| 401 | `/pair/finish` | HMAC mismatch (wrong PIN) |
+| 403 | `/pair/start` | Maximum paired clients reached, or attempts exhausted |
+| 404 | `/pair/finish` | Unknown session ID |
+| 410 | `/pair/*` | Pairing PIN expired |
+| 429 | `/pair/*` | Rate limit exceeded |
+
+WebSocket-level errors (sent as a plaintext JSON-RPC error then connection closed):
+
+| Code | Meaning |
+|---|---|
+| -32001 | Unsupported encryption version |
+| -32002 | Server has encryption enabled and requires an encrypted first frame from this remote client |
+
+## Discovering server requirements
+
+A client that does not yet know whether the server has encryption enabled should:
+
+1. Try connecting plaintext.
+2. If the server returns the `-32002` error, the client must pair before reconnecting.
+3. If the user has not paired yet, prompt them to initiate pairing from the Zaparoo device's TUI.
+4. Run the PAKE handshake (`/pair/start` then `/pair/finish`); locally derive `pairingKey` from the PAKE session key via `HKDF-Expand(prk, "zaparoo-pairing-v1", 32)` (the server never returns it). Store `authToken` and the derived `pairingKey` securely.
+5. On all subsequent WebSocket connections, generate a fresh session salt, derive session keys, and send the encrypted first frame.
+
+## Non-WebSocket transports
+
+HTTP POST, SSE, and REST GET endpoints (`/api`, `/api/events`, `/r/*`, `/run/*`) are restricted to localhost by default. To allow remote access, the server operator must add IPs (or CIDR ranges) to the `allowed_ips` config field. These transports do **not** support encryption — they exist for simple DIY integrations on trusted networks. API key authentication still applies.
+
+## Minimal JavaScript example
+
+```javascript
+// After pairing, the client has stored: authToken (string), pairingKey (Uint8Array, 32 bytes)
+
+async function deriveSessionKeys(pairingKey, sessionSalt) {
+    const ikm = await crypto.subtle.importKey("raw", pairingKey, "HKDF", false, ["deriveBits"]);
+    const expand = async (info, length) => crypto.subtle.deriveBits(
+        { name: "HKDF", hash: "SHA-256", salt: sessionSalt, info: new TextEncoder().encode(info) },
+        ikm,
+        length * 8,
+    );
+    return {
+        c2sKey: new Uint8Array(await expand("zaparoo-c2s-v1", 32)),
+        s2cKey: new Uint8Array(await expand("zaparoo-s2c-v1", 32)),
+        c2sBase: new Uint8Array(await expand("zaparoo-c2s-nonce-v1", 12)),
+        s2cBase: new Uint8Array(await expand("zaparoo-s2c-nonce-v1", 12)),
+    };
+}
+
+function buildNonce(base, counter) {
+    const nonce = new Uint8Array(12);
+    nonce.set(base);
+    const view = new DataView(nonce.buffer);
+    const hi = Number((counter >> 32n) & 0xffffffffn);
+    const lo = Number(counter & 0xffffffffn);
+    view.setUint32(4, view.getUint32(4) ^ hi, false);
+    view.setUint32(8, view.getUint32(8) ^ lo, false);
+    return nonce;
+}
+
+async function connectEncrypted(wsUrl, authToken, pairingKey) {
+    const sessionSalt = crypto.getRandomValues(new Uint8Array(16));
+    const keys = await deriveSessionKeys(pairingKey, sessionSalt);
+    const c2sKey = await crypto.subtle.importKey("raw", keys.c2sKey, "AES-GCM", false, ["encrypt"]);
+    const s2cKey = await crypto.subtle.importKey("raw", keys.s2cKey, "AES-GCM", false, ["decrypt"]);
+    const aad = new TextEncoder().encode(authToken + ":ws");
+
+    let sendCounter = 0n;
+    let recvCounter = 0n;
+
+    const ws = new WebSocket(wsUrl);
+
+    async function sendRPC(method, params) {
+        const payload = JSON.stringify({ jsonrpc: "2.0", method, params, id: Date.now() });
+        const counter = sendCounter++;
+        const nonce = buildNonce(keys.c2sBase, counter);
+        const ct = await crypto.subtle.encrypt(
+            { name: "AES-GCM", iv: nonce, additionalData: aad },
+            c2sKey,
+            new TextEncoder().encode(payload),
+        );
+        const ctB64 = btoa(String.fromCharCode(...new Uint8Array(ct)));
+        const msg = { e: ctB64 };
+        if (counter === 0n) {
+            msg.v = 1;
+            msg.t = authToken;
+            msg.s = btoa(String.fromCharCode(...sessionSalt));
+        }
+        ws.send(JSON.stringify(msg));
+    }
+
+    ws.onmessage = async (ev) => {
+        const frame = JSON.parse(ev.data);
+        if (!frame.e) return;
+        const ct = Uint8Array.from(atob(frame.e), (c) => c.charCodeAt(0));
+        const counter = recvCounter++;
+        const nonce = buildNonce(keys.s2cBase, counter);
+        const pt = await crypto.subtle.decrypt(
+            { name: "AES-GCM", iv: nonce, additionalData: aad },
+            s2cKey,
+            ct,
+        );
+        handleResponse(JSON.parse(new TextDecoder().decode(pt)));
+    };
+
+    return { sendRPC };
+}
+```
+
+This is a minimal working example. Production clients should add reconnection logic, error handling for HMAC mismatches, and secure storage for the pairing key.

--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -26,7 +26,7 @@ The `encryption` setting only affects the WebSocket transport. HTTP POST, SSE, a
 
 Pairing happens over plain HTTP (the PAKE protocol provides its own security). Two round trips establish a shared 32-byte pairing key.
 
-```
+```text
 TUI                     Server                       Client App
 ───                     ──────                       ──────────
 User: "Pair device"
@@ -80,13 +80,13 @@ PIN cleared
 
 The HMAC inputs use length-prefixed encoding to prevent canonicalization attacks: each variable-length field is encoded as a 4-byte big-endian length prefix followed by the bytes.
 
-```
+```text
 LP(field) = 4-byte big-endian uint32 length || field bytes
 ```
 
 The HMAC transcript is:
 
-```
+```text
 LP("zaparoo-v1") || LP("p256") || LP(role) || LP(clientName) || LP(MsgA) || LP(MsgB)
 ```
 
@@ -152,7 +152,7 @@ Once decrypted, the payload is standard JSON-RPC 2.0:
 
 On each new WebSocket connection (NOT once per pairing), the client generates a random session salt and derives ephemeral session keys via HKDF-SHA256.
 
-```
+```text
 prk     = HKDF-Extract(SHA-256, ikm=pairingKey, salt=sessionSalt)
 c2sKey  = HKDF-Expand(SHA-256, prk, info="zaparoo-c2s-v1",       length=32)
 s2cKey  = HKDF-Expand(SHA-256, prk, info="zaparoo-s2c-v1",       length=32)
@@ -166,7 +166,7 @@ Separate keys + nonce bases per direction prevent reflection attacks and elimina
 
 The 12-byte AES-GCM nonce for each frame is derived by XORing a 64-bit big-endian counter into the **last 8 bytes** of the 12-byte nonce base. The first 4 bytes of the base are unchanged.
 
-```
+```text
 nonce[0:4] = base[0:4]
 nonce[4:12] = base[4:12] XOR (counter as 8 bytes big-endian)
 ```
@@ -177,7 +177,7 @@ Counters never wrap or reuse — disconnect and reconnect with a fresh salt to s
 
 Every encrypt/decrypt operation binds the ciphertext to the auth token via AAD:
 
-```
+```text
 aad = authToken + ":ws"
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb
 	github.com/rs/zerolog v1.34.0
 	github.com/sasha-s/go-deadlock v0.3.6
+	github.com/schollz/pake/v3 v3.1.1
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/afero v1.14.0
 	github.com/stretchr/testify v1.11.1
@@ -65,6 +66,7 @@ require (
 
 require (
 	code.gitea.io/sdk/gitea v0.22.1 // indirect
+	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
@@ -118,6 +120,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/tscholl2/siec v0.0.0-20240310163802-c2c6f6198406 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 code.gitea.io/sdk/gitea v0.22.1 h1:7K05KjRORyTcTYULQ/AwvlVS6pawLcWyXZcTr7gHFyA=
 code.gitea.io/sdk/gitea v0.22.1/go.mod h1:yyF5+GhljqvA30sRDreoyHILruNiy4ASufugzYg0VHM=
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
 fyne.io/systray v1.11.0 h1:D9HISlxSkx+jHSniMBR6fCFOUjk1x/OOOJLa9lJYAKg=
 fyne.io/systray v1.11.0/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/42wim/httpsig v1.2.3 h1:xb0YyWhkYj57SPtfSttIobJUPJZB9as1nsfo7KWVcEs=
@@ -232,6 +234,8 @@ github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/sasha-s/go-deadlock v0.3.6 h1:TR7sfOnZ7x00tWPfD397Peodt57KzMDo+9Ae9rMiUmw=
 github.com/sasha-s/go-deadlock v0.3.6/go.mod h1:CUqNyyvMxTyjFqDT7MRg9mb4Dv/btmGTqSR+rky/UXo=
+github.com/schollz/pake/v3 v3.1.1 h1:lyoU5uNQ3thfjEzrahgxWWBm6+pbI1F2KAZ3gs6LIV8=
+github.com/schollz/pake/v3 v3.1.1/go.mod h1:420+m3AakXcS0n7Uwc7eRs2CosQ2YfE/vKcIkilvqZc=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
@@ -253,6 +257,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/tscholl2/siec v0.0.0-20240310163802-c2c6f6198406 h1:sDWDZkwYqX0jvLWstKzFwh+pYhQNaVg65BgSkCP/f7U=
+github.com/tscholl2/siec v0.0.0-20240310163802-c2c6f6198406/go.mod h1:KL9+ubr1JZdaKjgAaHr+tCytEncXBa1pR6FjbTsOJnw=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/pkg/api/crypto/crypto.go
+++ b/pkg/api/crypto/crypto.go
@@ -1,0 +1,170 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package crypto provides AES-256-GCM encryption with HKDF-derived per-session
+// keys for the Zaparoo API WebSocket transport.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// PairingKeySize is the size in bytes of the long-term pairing key derived
+// from the PAKE exchange and stored in the clients table.
+const PairingKeySize = 32
+
+// SessionSaltSize is the required size in bytes of the per-connection session
+// salt sent by the client on the first WebSocket frame.
+const SessionSaltSize = 16
+
+// AESKeySize is the size in bytes of an AES-256 key.
+const AESKeySize = 32
+
+// NonceSize is the size in bytes of an AES-GCM nonce.
+const NonceSize = 12
+
+// HKDF info strings for domain separation (versioned for future changes).
+const (
+	infoC2SKey   = "zaparoo-c2s-v1"
+	infoS2CKey   = "zaparoo-s2c-v1"
+	infoC2SNonce = "zaparoo-c2s-nonce-v1"
+	infoS2CNonce = "zaparoo-s2c-nonce-v1"
+)
+
+// ErrCounterExhausted prevents silent nonce reuse on counter overflow (unreachable in practice).
+var ErrCounterExhausted = errors.New("counter exhausted: rotate session keys")
+
+// ErrInvalidPairingKey is returned when the pairing key is not exactly PairingKeySize bytes.
+var ErrInvalidPairingKey = errors.New("pairing key must be 32 bytes")
+
+// ErrInvalidSessionSalt is returned when the session salt is not exactly SessionSaltSize bytes.
+var ErrInvalidSessionSalt = errors.New("session salt must be 16 bytes")
+
+// SessionKeys holds the four derived values for a single WebSocket session:
+// directional AES-256 keys and directional 12-byte nonce bases.
+type SessionKeys struct {
+	C2SKey   []byte
+	S2CKey   []byte
+	C2SNonce []byte
+	S2CNonce []byte
+}
+
+// DeriveSessionKeys derives directional session keys from a pairing key and
+// per-connection salt. Separate directional keys prevent reflection attacks.
+func DeriveSessionKeys(pairingKey, sessionSalt []byte) (*SessionKeys, error) {
+	if len(pairingKey) != PairingKeySize {
+		return nil, ErrInvalidPairingKey
+	}
+	if len(sessionSalt) != SessionSaltSize {
+		return nil, ErrInvalidSessionSalt
+	}
+
+	prk, err := hkdf.Extract(sha256.New, pairingKey, sessionSalt)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf extract: %w", err)
+	}
+
+	c2sKey, err := hkdf.Expand(sha256.New, prk, infoC2SKey, AESKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf expand c2s key: %w", err)
+	}
+	s2cKey, err := hkdf.Expand(sha256.New, prk, infoS2CKey, AESKeySize)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf expand s2c key: %w", err)
+	}
+	c2sNonce, err := hkdf.Expand(sha256.New, prk, infoC2SNonce, NonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf expand c2s nonce: %w", err)
+	}
+	s2cNonce, err := hkdf.Expand(sha256.New, prk, infoS2CNonce, NonceSize)
+	if err != nil {
+		return nil, fmt.Errorf("hkdf expand s2c nonce: %w", err)
+	}
+
+	return &SessionKeys{
+		C2SKey:   c2sKey,
+		S2CKey:   s2cKey,
+		C2SNonce: c2sNonce,
+		S2CNonce: s2cNonce,
+	}, nil
+}
+
+// NewAEAD creates a cipher.AEAD from a 32-byte AES-256 key.
+func NewAEAD(key []byte) (cipher.AEAD, error) {
+	if len(key) != AESKeySize {
+		return nil, fmt.Errorf("aes key must be %d bytes, got %d", AESKeySize, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("aes new cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("cipher new gcm: %w", err)
+	}
+	return gcm, nil
+}
+
+// Encrypt encrypts plaintext using AES-256-GCM with a counter-derived nonce.
+// The caller must ensure the counter never repeats with the same key.
+func Encrypt(gcm cipher.AEAD, nonceBase []byte, counter uint64, plaintext, aad []byte) ([]byte, error) {
+	if counter == math.MaxUint64 {
+		return nil, ErrCounterExhausted
+	}
+	if len(nonceBase) != NonceSize {
+		return nil, fmt.Errorf("nonce base must be %d bytes, got %d", NonceSize, len(nonceBase))
+	}
+	nonce := buildNonce(nonceBase, counter)
+	return gcm.Seal(nil, nonce, plaintext, aad), nil
+}
+
+// Decrypt decrypts ciphertext using AES-256-GCM with a counter-derived nonce.
+func Decrypt(gcm cipher.AEAD, nonceBase []byte, counter uint64, ciphertext, aad []byte) ([]byte, error) {
+	if counter == math.MaxUint64 {
+		return nil, ErrCounterExhausted
+	}
+	if len(nonceBase) != NonceSize {
+		return nil, fmt.Errorf("nonce base must be %d bytes, got %d", NonceSize, len(nonceBase))
+	}
+	nonce := buildNonce(nonceBase, counter)
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("gcm open: %w", err)
+	}
+	return plaintext, nil
+}
+
+// buildNonce XORs the counter into the last 8 bytes of the nonce base.
+func buildNonce(base []byte, counter uint64) []byte {
+	nonce := make([]byte, NonceSize)
+	copy(nonce, base)
+	var counterBytes [8]byte
+	binary.BigEndian.PutUint64(counterBytes[:], counter)
+	for i := range 8 {
+		nonce[4+i] ^= counterBytes[i]
+	}
+	return nonce
+}

--- a/pkg/api/crypto/crypto_test.go
+++ b/pkg/api/crypto/crypto_test.go
@@ -1,0 +1,404 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package crypto_test
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// randomKey returns a random byte slice of n bytes for tests.
+func randomKey(t *testing.T, n int) []byte {
+	t.Helper()
+	b := make([]byte, n)
+	_, err := cryptorand.Read(b)
+	require.NoError(t, err)
+	return b
+}
+
+func TestDeriveSessionKeys_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := randomKey(t, crypto.PairingKeySize)
+	salt := randomKey(t, crypto.SessionSaltSize)
+
+	a, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+	b, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+
+	assert.Equal(t, a.C2SKey, b.C2SKey)
+	assert.Equal(t, a.S2CKey, b.S2CKey)
+	assert.Equal(t, a.C2SNonce, b.C2SNonce)
+	assert.Equal(t, a.S2CNonce, b.S2CNonce)
+}
+
+func TestDeriveSessionKeys_DifferentSaltsDifferentKeys(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := randomKey(t, crypto.PairingKeySize)
+	salt1 := randomKey(t, crypto.SessionSaltSize)
+	salt2 := randomKey(t, crypto.SessionSaltSize)
+
+	a, err := crypto.DeriveSessionKeys(pairingKey, salt1)
+	require.NoError(t, err)
+	b, err := crypto.DeriveSessionKeys(pairingKey, salt2)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, a.C2SKey, b.C2SKey)
+	assert.NotEqual(t, a.S2CKey, b.S2CKey)
+	assert.NotEqual(t, a.C2SNonce, b.C2SNonce)
+	assert.NotEqual(t, a.S2CNonce, b.S2CNonce)
+}
+
+func TestDeriveSessionKeys_DirectionalKeysDifferent(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := randomKey(t, crypto.PairingKeySize)
+	salt := randomKey(t, crypto.SessionSaltSize)
+
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+
+	// c2s and s2c must never collide — directional separation prevents
+	// reflection attacks and cross-direction nonce collisions.
+	assert.NotEqual(t, keys.C2SKey, keys.S2CKey)
+	assert.NotEqual(t, keys.C2SNonce, keys.S2CNonce)
+}
+
+func TestDeriveSessionKeys_KeySizes(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	assert.Len(t, keys.C2SKey, crypto.AESKeySize)
+	assert.Len(t, keys.S2CKey, crypto.AESKeySize)
+	assert.Len(t, keys.C2SNonce, crypto.NonceSize)
+	assert.Len(t, keys.S2CNonce, crypto.NonceSize)
+}
+
+func TestDeriveSessionKeys_InvalidPairingKey(t *testing.T) {
+	t.Parallel()
+
+	salt := randomKey(t, crypto.SessionSaltSize)
+
+	tests := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "empty", key: []byte{}},
+		{name: "too short", key: make([]byte, 16)},
+		{name: "too long", key: make([]byte, 64)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := crypto.DeriveSessionKeys(tt.key, salt)
+			assert.ErrorIs(t, err, crypto.ErrInvalidPairingKey)
+		})
+	}
+}
+
+func TestDeriveSessionKeys_InvalidSalt(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := randomKey(t, crypto.PairingKeySize)
+
+	tests := []struct {
+		name string
+		salt []byte
+	}{
+		{name: "empty", salt: []byte{}},
+		{name: "too short", salt: make([]byte, 8)},
+		{name: "too long", salt: make([]byte, 32)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := crypto.DeriveSessionKeys(pairingKey, tt.salt)
+			assert.ErrorIs(t, err, crypto.ErrInvalidSessionSalt)
+		})
+	}
+}
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	plaintext := []byte(`{"jsonrpc":"2.0","method":"launch","params":{"uid":"abc"},"id":1}`)
+	aad := []byte("token-1234:ws")
+
+	ciphertext, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, plaintext, aad)
+	require.NoError(t, err)
+	assert.NotEqual(t, plaintext, ciphertext, "ciphertext must differ from plaintext")
+	assert.Greater(t, len(ciphertext), len(plaintext), "ciphertext must include GCM tag")
+
+	decrypted, err := crypto.Decrypt(gcm, keys.C2SNonce, 0, ciphertext, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestEncryptDecrypt_DifferentCountersDifferentCiphertexts(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	plaintext := []byte("identical plaintext")
+	aad := []byte("token:ws")
+
+	ct0, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, plaintext, aad)
+	require.NoError(t, err)
+	ct1, err := crypto.Encrypt(gcm, keys.C2SNonce, 1, plaintext, aad)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, ct0, ct1, "different counters must produce different ciphertexts")
+}
+
+func TestEncryptDecrypt_WrongCounterFails(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	plaintext := []byte("hello")
+	aad := []byte("token:ws")
+
+	ciphertext, err := crypto.Encrypt(gcm, keys.C2SNonce, 5, plaintext, aad)
+	require.NoError(t, err)
+
+	_, err = crypto.Decrypt(gcm, keys.C2SNonce, 6, ciphertext, aad)
+	assert.Error(t, err, "decrypting with wrong counter must fail")
+}
+
+func TestEncryptDecrypt_WrongKeyFails(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := randomKey(t, crypto.PairingKeySize)
+	salt := randomKey(t, crypto.SessionSaltSize)
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+
+	// Use the s2c key to "decrypt" something encrypted with c2s — must fail.
+	c2sGCM, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	s2cGCM, err := crypto.NewAEAD(keys.S2CKey)
+	require.NoError(t, err)
+
+	plaintext := []byte("hello")
+	aad := []byte("token:ws")
+	ciphertext, err := crypto.Encrypt(c2sGCM, keys.C2SNonce, 0, plaintext, aad)
+	require.NoError(t, err)
+
+	_, err = crypto.Decrypt(s2cGCM, keys.C2SNonce, 0, ciphertext, aad)
+	assert.Error(t, err, "decrypting with wrong key must fail")
+}
+
+func TestEncryptDecrypt_WrongAADFails(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	plaintext := []byte("hello")
+	ciphertext, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, plaintext, []byte("token-a:ws"))
+	require.NoError(t, err)
+
+	_, err = crypto.Decrypt(gcm, keys.C2SNonce, 0, ciphertext, []byte("token-b:ws"))
+	assert.Error(t, err, "decrypting with wrong AAD must fail")
+}
+
+func TestEncryptDecrypt_TamperedCiphertextFails(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	plaintext := []byte("hello world")
+	aad := []byte("token:ws")
+	ciphertext, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, plaintext, aad)
+	require.NoError(t, err)
+
+	// Flip a bit in the middle of the ciphertext.
+	tampered := bytes.Clone(ciphertext)
+	tampered[len(tampered)/2] ^= 0x01
+
+	_, err = crypto.Decrypt(gcm, keys.C2SNonce, 0, tampered, aad)
+	assert.Error(t, err, "tampered ciphertext must fail authentication")
+}
+
+func TestEncrypt_CounterExhausted(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	_, err = crypto.Encrypt(gcm, keys.C2SNonce, math.MaxUint64, []byte("x"), nil)
+	assert.ErrorIs(t, err, crypto.ErrCounterExhausted)
+}
+
+func TestDecrypt_CounterExhausted(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	_, err = crypto.Decrypt(gcm, keys.C2SNonce, math.MaxUint64, []byte("x"), nil)
+	assert.ErrorIs(t, err, crypto.ErrCounterExhausted)
+}
+
+func TestNewAEAD_InvalidKeySize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "empty", key: []byte{}},
+		{name: "too short", key: make([]byte, 16)},
+		{name: "too long", key: make([]byte, 64)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := crypto.NewAEAD(tt.key)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestEncrypt_InvalidNonceSize(t *testing.T) {
+	t.Parallel()
+
+	gcm, err := crypto.NewAEAD(randomKey(t, crypto.AESKeySize))
+	require.NoError(t, err)
+
+	_, err = crypto.Encrypt(gcm, make([]byte, 8), 0, []byte("x"), nil)
+	assert.Error(t, err)
+}
+
+func TestDecrypt_InvalidNonceSize(t *testing.T) {
+	t.Parallel()
+
+	gcm, err := crypto.NewAEAD(randomKey(t, crypto.AESKeySize))
+	require.NoError(t, err)
+
+	_, err = crypto.Decrypt(gcm, make([]byte, 8), 0, []byte("x"), nil)
+	assert.Error(t, err)
+}
+
+// TestNonceUniqueness verifies that different counter values produce
+// distinct nonces. AES-GCM nonce reuse is catastrophic, so this is the
+// single most important property of the counter-derived nonce design.
+func TestNonceUniqueness(t *testing.T) {
+	t.Parallel()
+
+	keys, err := crypto.DeriveSessionKeys(
+		randomKey(t, crypto.PairingKeySize),
+		randomKey(t, crypto.SessionSaltSize),
+	)
+	require.NoError(t, err)
+
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+
+	// Encrypt the same plaintext at many counter values; ciphertexts must
+	// all differ. (Same plaintext + same key + same nonce = same ciphertext;
+	// uniqueness here proves nonces are unique.)
+	plaintext := []byte("test")
+	seen := make(map[string]struct{}, 1000)
+	for counter := range uint64(1000) {
+		ct, encErr := crypto.Encrypt(gcm, keys.C2SNonce, counter, plaintext, nil)
+		require.NoError(t, encErr)
+		key := string(ct)
+		_, dup := seen[key]
+		require.False(t, dup, "duplicate ciphertext at counter %d implies nonce collision", counter)
+		seen[key] = struct{}{}
+	}
+}
+
+// TestErrorsExported verifies the sentinel errors are usable with errors.Is.
+func TestErrorsExported(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errors.Join(errors.New("context"), crypto.ErrCounterExhausted)
+	require.ErrorIs(t, wrapped, crypto.ErrCounterExhausted)
+
+	wrapped2 := errors.Join(errors.New("context"), crypto.ErrInvalidPairingKey)
+	require.ErrorIs(t, wrapped2, crypto.ErrInvalidPairingKey)
+
+	wrapped3 := errors.Join(errors.New("context"), crypto.ErrInvalidSessionSalt)
+	require.ErrorIs(t, wrapped3, crypto.ErrInvalidSessionSalt)
+}

--- a/pkg/api/integration_encryption_test.go
+++ b/pkg/api/integration_encryption_test.go
@@ -1,0 +1,367 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api_test
+
+import (
+	"crypto/hkdf"
+	"crypto/hmac"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/schollz/pake/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// pairingHTTPResponse captures a small subset of an httptest.Recorder.
+type pairingHTTPResponse struct {
+	body       []byte
+	statusCode int
+}
+
+// callPairingEndpoint invokes a pairing HTTP handler via httptest and
+// returns the body + status code.
+func callPairingEndpoint(t *testing.T, h http.HandlerFunc, path string, body []byte) pairingHTTPResponse {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	respBody, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	return pairingHTTPResponse{statusCode: rec.Code, body: respBody}
+}
+
+// computeIntegrationHMAC duplicates the manager's HMAC scheme so the test
+// can act as the client. Length-prefixed encoding matches pairing.go.
+func computeIntegrationHMAC(key []byte, role, name string, msgA, msgB []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	writeIntegrationLP(h, []byte("zaparoo-v1"))
+	writeIntegrationLP(h, []byte(pakeCurve))
+	writeIntegrationLP(h, []byte(role))
+	writeIntegrationLP(h, []byte(name))
+	writeIntegrationLP(h, msgA)
+	writeIntegrationLP(h, msgB)
+	return h.Sum(nil)
+}
+
+func writeIntegrationLP(w io.Writer, b []byte) {
+	var lp [4]byte
+	//nolint:gosec // bounded test inputs
+	binary.BigEndian.PutUint32(lp[:], uint32(len(b)))
+	_, _ = w.Write(lp[:])
+	_, _ = w.Write(b)
+}
+
+// hkdfInfo strings used inside the pairing manager. Duplicated here so the
+// integration test can independently derive the same keys the manager does.
+const (
+	infoConfirmA = "zaparoo-confirm-A"
+	infoConfirmB = "zaparoo-confirm-B"
+	infoPairing  = "zaparoo-pairing-v1"
+	pakeCurve    = "p256"
+)
+
+// pairAndDeriveKey runs the full PAKE handshake against a PairingManager and
+// returns the resulting database client + the pairing key the client computes.
+func pairAndDeriveKey(
+	t *testing.T,
+	mgr *api.PairingManager,
+	clientName string,
+) (storedClient *database.Client, pairingKey []byte) {
+	t.Helper()
+
+	pin, _, err := mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pakeCurve)
+	require.NoError(t, err)
+	msgA := clientPake.Bytes()
+
+	// Drive the start session via the HTTP handler so we exercise the
+	// real request/response shapes.
+	startBody, err := json.Marshal(map[string]string{
+		"pake": base64.StdEncoding.EncodeToString(msgA),
+		"name": clientName,
+	})
+	require.NoError(t, err)
+
+	startResp := callPairingEndpoint(t, mgr.HandlePairStart(), "/api/pair/start", startBody)
+	require.Equal(t, 200, startResp.statusCode, "start: %s", string(startResp.body))
+
+	var startResult struct {
+		Session string `json:"session"`
+		PAKE    string `json:"pake"`
+	}
+	require.NoError(t, json.Unmarshal(startResp.body, &startResult))
+
+	msgB, err := base64.StdEncoding.DecodeString(startResult.PAKE)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgB))
+	clientSessionKey, err := clientPake.SessionKey()
+	require.NoError(t, err)
+
+	// Derive the same confirmation keys + pairing key the server will.
+	prk, err := hkdf.Extract(sha256.New, clientSessionKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, infoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	confirmKeyB, err := hkdf.Expand(sha256.New, prk, infoConfirmB, sha256.Size)
+	require.NoError(t, err)
+	pairingKey, err = hkdf.Expand(sha256.New, prk, infoPairing, crypto.PairingKeySize)
+	require.NoError(t, err)
+
+	clientHMAC := computeIntegrationHMAC(confirmKeyA, "client", clientName, msgA, msgB)
+
+	finishBody, err := json.Marshal(map[string]string{
+		"session": startResult.Session,
+		"confirm": base64.StdEncoding.EncodeToString(clientHMAC),
+	})
+	require.NoError(t, err)
+
+	finishResp := callPairingEndpoint(t, mgr.HandlePairFinish(), "/api/pair/finish", finishBody)
+	require.Equal(t, 200, finishResp.statusCode, "finish: %s", string(finishResp.body))
+
+	var finishResult struct {
+		AuthToken string `json:"authToken"`
+		ClientID  string `json:"clientId"`
+		Confirm   string `json:"confirm"`
+	}
+	require.NoError(t, json.Unmarshal(finishResp.body, &finishResult))
+
+	// Defense in depth: assert the wire body has no pairingKey field at
+	// all. The long-term key must NEVER traverse the network.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(finishResp.body, &raw))
+	_, leaked := raw["pairingKey"]
+	require.False(t, leaked, "pairingKey must not appear in /pair/finish response body")
+
+	expectedServerHMAC := computeIntegrationHMAC(confirmKeyB, "server", clientName, msgA, msgB)
+	gotServerHMAC, err := base64.StdEncoding.DecodeString(finishResult.Confirm)
+	require.NoError(t, err)
+	require.Equal(t, expectedServerHMAC, gotServerHMAC, "server HMAC must match for client to trust")
+
+	return &database.Client{
+		ClientID:   finishResult.ClientID,
+		ClientName: clientName,
+		AuthToken:  finishResult.AuthToken,
+		PairingKey: pairingKey,
+	}, pairingKey
+}
+
+func TestIntegration_PairThenEncryptedSession(t *testing.T) {
+	t.Parallel()
+
+	// Set up a mock UserDB that captures the created client.
+	db := helpers.NewMockUserDBI()
+	var stored *database.Client
+	db.On("CountClients").Return(0, nil)
+	db.On("CreateClient", mock.AnythingOfType("*database.Client")).
+		Run(func(args mock.Arguments) {
+			c, ok := args.Get(0).(*database.Client)
+			require.True(t, ok)
+			cp := *c
+			stored = &cp
+		}).
+		Return(nil)
+
+	notifChan := make(chan models.Notification, 16)
+	pairingMgr := api.NewPairingManager(db, notifChan)
+
+	// 1. Run the full PAKE handshake.
+	c, pairingKey := pairAndDeriveKey(t, pairingMgr, "Integration App")
+	require.NotNil(t, stored, "client must be persisted to DB")
+	require.Equal(t, stored.ClientID, c.ClientID)
+	require.Equal(t, stored.AuthToken, c.AuthToken)
+	require.Equal(t, pairingKey, stored.PairingKey)
+
+	// 2. Verify clients.paired notification was sent.
+	select {
+	case notif := <-notifChan:
+		assert.Equal(t, models.NotificationClientsPaired, notif.Method)
+	default:
+		t.Fatal("expected clients.paired notification to be sent")
+	}
+
+	// Now that we have a stored client, set up the lookup expectation.
+	db.On("GetClientByToken", stored.AuthToken).Return(stored, nil)
+
+	// 3. Establish an encrypted WebSocket session using the pairing key.
+	encGateway := apimiddleware.NewEncryptionGateway(db)
+	salt := make([]byte, crypto.SessionSaltSize)
+	_, err := cryptorand.Read(salt)
+	require.NoError(t, err)
+
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+	clientGCMC2S, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	clientGCMS2C, err := crypto.NewAEAD(keys.S2CKey)
+	require.NoError(t, err)
+
+	aad := []byte(c.AuthToken + ":ws")
+	plaintextReq := []byte(`{"jsonrpc":"2.0","method":"version","id":1}`)
+	ctReq, err := crypto.Encrypt(clientGCMC2S, keys.C2SNonce, 0, plaintextReq, aad)
+	require.NoError(t, err)
+
+	firstFrame := apimiddleware.EncryptedFirstFrame{
+		Version:     apimiddleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ctReq),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	cs, decrypted, err := encGateway.EstablishSession(firstFrame, "192.168.1.50")
+	require.NoError(t, err, "first frame should decrypt with paired key")
+	assert.Equal(t, plaintextReq, decrypted)
+	require.NotNil(t, cs)
+
+	// 4. Server encrypts a response (counter 0), client decrypts.
+	plaintextResp := []byte(`{"jsonrpc":"2.0","result":{"version":"test"},"id":1}`)
+	ctResp, err := cs.EncryptOutgoing(plaintextResp)
+	require.NoError(t, err)
+
+	gotResp, err := crypto.Decrypt(clientGCMS2C, keys.S2CNonce, 0, ctResp, aad)
+	require.NoError(t, err)
+	assert.Equal(t, plaintextResp, gotResp)
+
+	// 5. Client sends a second frame (counter 1).
+	plaintextReq2 := []byte(`{"jsonrpc":"2.0","method":"systems","id":2}`)
+	ctReq2, err := crypto.Encrypt(clientGCMC2S, keys.C2SNonce, 1, plaintextReq2, aad)
+	require.NoError(t, err)
+	subFrame := apimiddleware.EncryptedFrame{
+		Ciphertext: base64.StdEncoding.EncodeToString(ctReq2),
+	}
+	gotReq2, err := cs.DecryptSubsequent(subFrame)
+	require.NoError(t, err)
+	assert.Equal(t, plaintextReq2, gotReq2)
+}
+
+func TestIntegration_RevokedClientCannotConnect(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	var stored *database.Client
+
+	db.On("CountClients").Return(0, nil)
+	db.On("CreateClient", mock.AnythingOfType("*database.Client")).
+		Run(func(args mock.Arguments) {
+			c, ok := args.Get(0).(*database.Client)
+			require.True(t, ok)
+			cp := *c
+			stored = &cp
+		}).
+		Return(nil)
+
+	notifChan := make(chan models.Notification, 4)
+	pairingMgr := api.NewPairingManager(db, notifChan)
+	_, pairingKey := pairAndDeriveKey(t, pairingMgr, "Revoke Test")
+	require.NotNil(t, stored)
+
+	// Simulate revocation: GetClientByToken returns an error.
+	db.On("GetClientByToken", stored.AuthToken).Return((*database.Client)(nil), assert.AnError)
+
+	encGateway := apimiddleware.NewEncryptionGateway(db)
+	salt := make([]byte, crypto.SessionSaltSize)
+	_, err := cryptorand.Read(salt)
+	require.NoError(t, err)
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	aad := []byte(stored.AuthToken + ":ws")
+	ct, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, []byte(`{"jsonrpc":"2.0","method":"version","id":1}`), aad)
+	require.NoError(t, err)
+
+	frame := apimiddleware.EncryptedFirstFrame{
+		Version:     apimiddleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   stored.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	_, _, err = encGateway.EstablishSession(frame, "192.168.1.50")
+	require.Error(t, err, "revoked client must not be able to establish a session")
+	require.ErrorIs(t, err, apimiddleware.ErrUnknownAuthToken)
+}
+
+func TestIntegration_WrongPairingKeyRejected(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	var stored *database.Client
+	db.On("CountClients").Return(0, nil)
+	db.On("CreateClient", mock.AnythingOfType("*database.Client")).
+		Run(func(args mock.Arguments) {
+			c, ok := args.Get(0).(*database.Client)
+			require.True(t, ok)
+			cp := *c
+			stored = &cp
+		}).
+		Return(nil)
+
+	notifChan := make(chan models.Notification, 4)
+	pairingMgr := api.NewPairingManager(db, notifChan)
+	_, _ = pairAndDeriveKey(t, pairingMgr, "Wrong Key Test")
+	require.NotNil(t, stored)
+
+	db.On("GetClientByToken", stored.AuthToken).Return(stored, nil)
+
+	// Use a DIFFERENT pairing key — server has the real one, attacker uses
+	// a guessed one. First frame must fail decryption.
+	attackerKey := make([]byte, crypto.PairingKeySize)
+	_, err := cryptorand.Read(attackerKey)
+	require.NoError(t, err)
+
+	encGateway := apimiddleware.NewEncryptionGateway(db)
+	salt := make([]byte, crypto.SessionSaltSize)
+	_, err = cryptorand.Read(salt)
+	require.NoError(t, err)
+	keys, err := crypto.DeriveSessionKeys(attackerKey, salt)
+	require.NoError(t, err)
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	aad := []byte(stored.AuthToken + ":ws")
+	ct, err := crypto.Encrypt(gcm, keys.C2SNonce, 0, []byte(`{"jsonrpc":"2.0","method":"version","id":1}`), aad)
+	require.NoError(t, err)
+
+	frame := apimiddleware.EncryptedFirstFrame{
+		Version:     apimiddleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   stored.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	_, _, err = encGateway.EstablishSession(frame, "192.168.1.50")
+	require.Error(t, err, "wrong pairing key must fail decryption")
+}

--- a/pkg/api/methods/clients.go
+++ b/pkg/api/methods/clients.go
@@ -1,0 +1,89 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"errors"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/rs/zerolog/log"
+)
+
+// ErrLocalhostOnly is returned when a non-localhost client invokes a method
+// that is restricted to local administration only.
+var ErrLocalhostOnly = errors.New("method is only available from localhost")
+
+// HandleClients lists paired clients (localhost-only).
+//
+//nolint:gocritic // single-use parameter in API handler
+func HandleClients(env requests.RequestEnv) (any, error) {
+	if !env.IsLocal {
+		return nil, models.ClientErrf("%w", ErrLocalhostOnly)
+	}
+
+	log.Info().Msg("received clients list request")
+
+	clients, err := env.Database.UserDB.ListClients()
+	if err != nil {
+		log.Error().Err(err).Msg("error listing paired clients")
+		return nil, errors.New("error listing paired clients")
+	}
+
+	resp := models.ClientsResponse{
+		Clients: make([]models.PairedClient, len(clients)),
+	}
+	for i, c := range clients {
+		resp.Clients[i] = models.PairedClient{
+			ClientID:   c.ClientID,
+			ClientName: c.ClientName,
+			CreatedAt:  c.CreatedAt,
+			LastSeenAt: c.LastSeenAt,
+		}
+	}
+	return resp, nil
+}
+
+// HandleClientsDelete revokes a paired client (localhost-only, forward-only;
+// existing sessions survive until disconnect).
+//
+//nolint:gocritic // single-use parameter in API handler
+func HandleClientsDelete(env requests.RequestEnv) (any, error) {
+	if !env.IsLocal {
+		return nil, models.ClientErrf("%w", ErrLocalhostOnly)
+	}
+
+	log.Info().Msg("received clients delete request")
+
+	var params models.ClientsDeleteParams
+	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+		log.Warn().Err(err).Msg("invalid params")
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+	if params.ClientID == "" {
+		return nil, models.ClientErrf("clientId is required")
+	}
+
+	if err := env.Database.UserDB.DeleteClient(params.ClientID); err != nil {
+		return nil, models.ClientErrf("failed to delete client: %w", err)
+	}
+	return NoContent{}, nil
+}

--- a/pkg/api/methods/clients_test.go
+++ b/pkg/api/methods/clients_test.go
@@ -1,0 +1,204 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleClients_Success(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("ListClients").Return([]database.Client{
+		{ClientID: "id-1", ClientName: "App One", CreatedAt: 1700000000, LastSeenAt: 1700001000},
+		{ClientID: "id-2", ClientName: "App Two", CreatedAt: 1700100000, LastSeenAt: 1700101000},
+	}, nil)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+	}
+
+	result, err := HandleClients(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.ClientsResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Clients, 2)
+	assert.Equal(t, "id-1", resp.Clients[0].ClientID)
+	assert.Equal(t, "App One", resp.Clients[0].ClientName)
+	assert.Equal(t, int64(1700000000), resp.Clients[0].CreatedAt)
+	assert.Equal(t, int64(1700001000), resp.Clients[0].LastSeenAt)
+	assert.Equal(t, "id-2", resp.Clients[1].ClientID)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleClients_Empty(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("ListClients").Return([]database.Client{}, nil)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+	}
+
+	result, err := HandleClients(env)
+	require.NoError(t, err)
+	resp, ok := result.(models.ClientsResponse)
+	require.True(t, ok)
+	assert.Empty(t, resp.Clients)
+}
+
+func TestHandleClients_DatabaseError(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("ListClients").Return([]database.Client{}, errors.New("db error"))
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+	}
+
+	_, err := HandleClients(env)
+	require.Error(t, err)
+}
+
+func TestHandleClients_RemoteRejected(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	// Expect no DB call since we should be rejected before reaching it.
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  false,
+	}
+
+	_, err := HandleClients(env)
+	require.ErrorIs(t, err, ErrLocalhostOnly)
+	mockUserDB.AssertNotCalled(t, "ListClients")
+}
+
+// Note on revocation semantics: HandleClientsDelete is forward-only —
+// it deletes the row but does not actively close in-flight WebSocket
+// sessions. The "new connections fail after revoke" property is
+// covered end-to-end by `TestIntegration_RevokedClientCannotConnect` in
+// `pkg/api/integration_encryption_test.go`, which mocks
+// `GetClientByToken` to return an error post-revoke and asserts
+// `EstablishSession` rejects with `ErrUnknownAuthToken`. The tests
+// below cover only the HTTP/RPC handler shape.
+
+func TestHandleClientsDelete_Success(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("DeleteClient", "client-uuid").Return(nil)
+
+	params, err := json.Marshal(models.ClientsDeleteParams{ClientID: "client-uuid"})
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+		Params:   params,
+	}
+
+	result, err := HandleClientsDelete(env)
+	require.NoError(t, err)
+	_, ok := result.(NoContent)
+	assert.True(t, ok)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleClientsDelete_MissingClientID(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	params, err := json.Marshal(models.ClientsDeleteParams{ClientID: ""})
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+		Params:   params,
+	}
+
+	_, err = HandleClientsDelete(env)
+	require.Error(t, err)
+	mockUserDB.AssertNotCalled(t, "DeleteClient")
+}
+
+func TestHandleClientsDelete_DatabaseError(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("DeleteClient", "client-uuid").Return(errors.New("not found"))
+
+	params, err := json.Marshal(models.ClientsDeleteParams{ClientID: "client-uuid"})
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  true,
+		Params:   params,
+	}
+
+	_, err = HandleClientsDelete(env)
+	require.Error(t, err)
+}
+
+func TestHandleClientsDelete_RemoteRejected(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	params, err := json.Marshal(models.ClientsDeleteParams{ClientID: "client-uuid"})
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB},
+		IsLocal:  false,
+		Params:   params,
+	}
+
+	_, err = HandleClientsDelete(env)
+	require.ErrorIs(t, err, ErrLocalhostOnly)
+	mockUserDB.AssertNotCalled(t, "DeleteClient")
+}

--- a/pkg/api/middleware/encryption.go
+++ b/pkg/api/middleware/encryption.go
@@ -1,0 +1,626 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware
+
+import (
+	"context"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/rs/zerolog/log"
+)
+
+// EncryptionProtoVersion is the current encryption protocol version. The
+// value is included in the first WebSocket frame and rejected by the server
+// if the client requests something unsupported.
+const EncryptionProtoVersion = 1
+
+// Limits and timing for the encryption session manager.
+const (
+	maxSaltsPerClient           = 200    // per-client salt dedup cap (prevents memory exhaustion)
+	maxSaltClients              = 10_000 // global cap on tracked clients in saltSeen
+	maxFailedFrameEntries       = 10_000 // global cap on failSeen entries (LRU on overflow)
+	saltWindowTTL               = 10 * time.Minute
+	failedFrameThreshold        = 10               // failures before blocking
+	failedFrameBlockDuration    = 30 * time.Second // initial block; exponential backoff follows
+	failedFrameMaxBlockDuration = 30 * time.Minute // backoff cap
+
+	// encryptionCleanupInterval is how often the cleanup goroutine runs.
+	encryptionCleanupInterval = 1 * time.Minute
+)
+
+// Encryption errors. These are returned by EncryptionGateway methods so callers
+// can map them to appropriate WebSocket close codes or plaintext errors.
+var (
+	ErrUnsupportedVersion    = errors.New("unsupported encryption version")
+	ErrInvalidFrame          = errors.New("invalid encrypted frame")
+	ErrInvalidSaltLength     = errors.New("session salt must be 16 bytes")
+	ErrDuplicateSalt         = errors.New("duplicate session salt for client")
+	ErrUnknownAuthToken      = errors.New("unknown auth token")
+	ErrConnectionBlocked     = errors.New("connection blocked due to repeated failures")
+	ErrInvalidPairingKey     = errors.New("stored pairing key is invalid")
+	ErrSessionNotEstablished = errors.New("encryption session not established")
+)
+
+// EncryptedFirstFrame is the JSON payload sent on the first WebSocket frame
+// to establish an encrypted session.
+type EncryptedFirstFrame struct {
+	Ciphertext  string `json:"e"`
+	AuthToken   string `json:"t"`
+	SessionSalt string `json:"s"`
+	Version     int    `json:"v"`
+}
+
+// EncryptedFrame is the JSON payload sent on subsequent frames after the
+// session has been established.
+type EncryptedFrame struct {
+	Ciphertext string `json:"e"`
+}
+
+// frameProbe is a permissive parse used to detect whether an incoming frame
+// looks like an encrypted first frame. This is a separate type from
+// EncryptedFirstFrame so we can detect malformed frames without rejecting
+// the connection — they're just treated as plaintext.
+type frameProbe struct {
+	E string `json:"e"`
+	T string `json:"t"`
+	S string `json:"s"`
+	V int    `json:"v"`
+}
+
+// IsEncryptedFirstFrame reports whether the given JSON bytes look like an
+// encrypted first frame (has v + e + t + s populated). False if the bytes
+// are not valid JSON or any required field is missing.
+func IsEncryptedFirstFrame(data []byte) bool {
+	var probe frameProbe
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	return probe.V > 0 && probe.E != "" && probe.T != "" && probe.S != ""
+}
+
+// ClientSession holds per-WebSocket encryption state. All AEAD calls
+// MUST happen inside the mutex (golang/go#25882, golang-fips/go#187).
+type ClientSession struct {
+	client      *database.Client
+	c2sGCM      cipher.AEAD
+	s2cGCM      cipher.AEAD
+	c2sNonce    []byte
+	s2cNonce    []byte
+	aad         []byte
+	recvCounter uint64
+	sendCounter uint64
+	mu          syncutil.Mutex
+}
+
+// AuthToken returns the auth token (immutable after construction, no lock needed).
+func (cs *ClientSession) AuthToken() string {
+	return cs.client.AuthToken
+}
+
+// DecryptIncoming decrypts with the next expected counter. Caller should
+// close the WebSocket on error.
+func (cs *ClientSession) DecryptIncoming(ciphertext []byte) ([]byte, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	plaintext, err := crypto.Decrypt(cs.c2sGCM, cs.c2sNonce, cs.recvCounter, ciphertext, cs.aad)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt incoming: %w", err)
+	}
+	cs.recvCounter++
+	return plaintext, nil
+}
+
+// EncryptOutgoing encrypts plaintext and advances the send counter.
+func (cs *ClientSession) EncryptOutgoing(plaintext []byte) ([]byte, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	ciphertext, err := crypto.Encrypt(cs.s2cGCM, cs.s2cNonce, cs.sendCounter, plaintext, cs.aad)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt outgoing: %w", err)
+	}
+	cs.sendCounter++
+	return ciphertext, nil
+}
+
+// EncryptOutgoingFrame encrypts and wraps in the {"e":"..."} JSON envelope.
+// Prefer SendEncryptedFrame when writing directly to a WebSocket (holds
+// the lock across encrypt + write to preserve counter order).
+func (cs *ClientSession) EncryptOutgoingFrame(plaintext []byte) ([]byte, error) {
+	ciphertext, err := cs.EncryptOutgoing(plaintext)
+	if err != nil {
+		return nil, err
+	}
+	wrapped, err := json.Marshal(EncryptedFrame{
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal outgoing frame: %w", err)
+	}
+	return wrapped, nil
+}
+
+// SendEncryptedFrame encrypts, wraps, and writes under the mutex so
+// concurrent writers cannot reorder counters. Counter advances only on
+// success — caller should close the connection on error.
+func (cs *ClientSession) SendEncryptedFrame(plaintext []byte, writeFn func([]byte) error) error {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	ciphertext, err := crypto.Encrypt(cs.s2cGCM, cs.s2cNonce, cs.sendCounter, plaintext, cs.aad)
+	if err != nil {
+		return fmt.Errorf("encrypt outgoing: %w", err)
+	}
+	wrapped, err := json.Marshal(EncryptedFrame{
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal outgoing frame: %w", err)
+	}
+	if err := writeFn(wrapped); err != nil {
+		return fmt.Errorf("write encrypted frame: %w", err)
+	}
+	cs.sendCounter++
+	return nil
+}
+
+// failedFrameTracker counts consecutive failed first-frame decryptions for a
+// (authToken, sourceIP) pair and tracks the current block deadline.
+type failedFrameTracker struct {
+	blockedUntil  time.Time
+	lastFailureAt time.Time
+	failures      int
+	blockCount    int // exponential backoff multiplier
+}
+
+// EncryptionGateway owns salt dedup and failed-frame rate limiting across
+// all sessions. Sessions are stored on the melody session after establishment.
+type EncryptionGateway struct {
+	db                       database.UserDBI
+	saltSeen                 map[string]map[string]time.Time
+	failSeen                 map[string]*failedFrameTracker
+	maxSaltsPerClient        int
+	maxSaltClients           int
+	maxFailEntries           int
+	saltWindowTTL            time.Duration
+	failedFrameThreshold     int
+	failedFrameBlockDuration time.Duration
+	failedFrameMaxBlock      time.Duration
+	cleanupInterval          time.Duration
+	saltMu                   syncutil.Mutex
+	failMu                   syncutil.Mutex
+}
+
+// EncryptionGatewayOption configures an EncryptionGateway at construction time.
+type EncryptionGatewayOption func(*EncryptionGateway)
+
+// WithMaxSaltsPerClient overrides the per-client salt history cap.
+func WithMaxSaltsPerClient(n int) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.maxSaltsPerClient = n }
+}
+
+// WithSaltWindowTTL overrides the salt history TTL.
+func WithSaltWindowTTL(d time.Duration) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.saltWindowTTL = d }
+}
+
+// WithFailedFrameThreshold overrides the failed-frame block threshold.
+func WithFailedFrameThreshold(n int) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.failedFrameThreshold = n }
+}
+
+// WithFailedFrameBlockDuration overrides the initial block duration.
+func WithFailedFrameBlockDuration(d time.Duration) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.failedFrameBlockDuration = d }
+}
+
+// WithFailedFrameMaxBlock overrides the cap on exponential backoff.
+func WithFailedFrameMaxBlock(d time.Duration) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.failedFrameMaxBlock = d }
+}
+
+// WithSessionCleanupInterval overrides the cleanup goroutine tick interval.
+func WithSessionCleanupInterval(d time.Duration) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.cleanupInterval = d }
+}
+
+// WithMaxSaltClients overrides the global cap on distinct clients tracked
+// in the salt deduplication map.
+func WithMaxSaltClients(n int) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.maxSaltClients = n }
+}
+
+// WithMaxFailEntries overrides the global cap on entries in the
+// failed-frame rate limiter map.
+func WithMaxFailEntries(n int) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.maxFailEntries = n }
+}
+
+// NewEncryptionGateway constructs a EncryptionGateway with default limits.
+func NewEncryptionGateway(db database.UserDBI, opts ...EncryptionGatewayOption) *EncryptionGateway {
+	m := &EncryptionGateway{
+		db:                       db,
+		saltSeen:                 make(map[string]map[string]time.Time),
+		failSeen:                 make(map[string]*failedFrameTracker),
+		maxSaltsPerClient:        maxSaltsPerClient,
+		maxSaltClients:           maxSaltClients,
+		maxFailEntries:           maxFailedFrameEntries,
+		saltWindowTTL:            saltWindowTTL,
+		failedFrameThreshold:     failedFrameThreshold,
+		failedFrameBlockDuration: failedFrameBlockDuration,
+		failedFrameMaxBlock:      failedFrameMaxBlockDuration,
+		cleanupInterval:          encryptionCleanupInterval,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// StartCleanup begins the background cleanup goroutine that evicts expired
+// salt and rate-limit entries. The goroutine exits when ctx is canceled.
+// Safe to call multiple times only with distinct contexts; callers should
+// call this once during server startup.
+func (m *EncryptionGateway) StartCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(m.cleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				m.cleanupExpired()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// EstablishSession validates, decrypts, and returns a ClientSession for the
+// first encrypted frame. Failures increment the (authToken, sourceIP) rate
+// limiter; callers should close the WebSocket on error.
+//
+// Non-constant-time: auth token validity is distinguishable by timing, but
+// tokens are already plaintext on the wire and grant no capability without
+// the 32-byte pairing key. If a future credential is NOT public on the
+// wire, these branches MUST be refactored to constant-time.
+func (m *EncryptionGateway) EstablishSession(
+	frame EncryptedFirstFrame,
+	sourceIP string,
+) (*ClientSession, []byte, error) {
+	if frame.Version != EncryptionProtoVersion {
+		return nil, nil, ErrUnsupportedVersion
+	}
+	if frame.AuthToken == "" {
+		return nil, nil, ErrUnknownAuthToken
+	}
+
+	// Rate limit by (authToken, IP) BEFORE doing any expensive work.
+	if blocked := m.isBlocked(frame.AuthToken, sourceIP); blocked {
+		return nil, nil, ErrConnectionBlocked
+	}
+
+	// Lookup before failure recording — unknown tokens skip recordFailure
+	// to prevent failSeen map exhaustion from fabricated tokens.
+	c, err := m.db.GetClientByToken(frame.AuthToken)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrUnknownAuthToken, err)
+	}
+	if c == nil {
+		return nil, nil, ErrUnknownAuthToken
+	}
+	if len(c.PairingKey) != crypto.PairingKeySize {
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, ErrInvalidPairingKey
+	}
+
+	// Validate salt (recordFailure safe — token exists).
+	salt, err := base64.StdEncoding.DecodeString(frame.SessionSalt)
+	if err != nil {
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, fmt.Errorf("%w: %w", ErrInvalidFrame, err)
+	}
+	if len(salt) != crypto.SessionSaltSize {
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, ErrInvalidSaltLength
+	}
+
+	// Reserve salt (rolled back on failure to defend against replay attacks).
+	if dupErr := m.checkAndRecordSalt(frame.AuthToken, salt); dupErr != nil {
+		// Salt dedup failures aren't rate-limited (CSPRNG bugs, not attacks).
+		return nil, nil, dupErr
+	}
+
+	keys, err := crypto.DeriveSessionKeys(c.PairingKey, salt)
+	if err != nil {
+		m.releaseSalt(frame.AuthToken, salt)
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, fmt.Errorf("derive session keys: %w", err)
+	}
+
+	c2sGCM, err := crypto.NewAEAD(keys.C2SKey)
+	if err != nil {
+		m.releaseSalt(frame.AuthToken, salt)
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, fmt.Errorf("new c2s aead: %w", err)
+	}
+	s2cGCM, err := crypto.NewAEAD(keys.S2CKey)
+	if err != nil {
+		m.releaseSalt(frame.AuthToken, salt)
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, fmt.Errorf("new s2c aead: %w", err)
+	}
+
+	cs := &ClientSession{
+		client:   c,
+		c2sGCM:   c2sGCM,
+		s2cGCM:   s2cGCM,
+		c2sNonce: keys.C2SNonce,
+		s2cNonce: keys.S2CNonce,
+		// AAD bound to DB-resolved token (resilient to future canonicalization).
+		aad:         []byte(c.AuthToken + ":ws"),
+		recvCounter: 0,
+		sendCounter: 0,
+	}
+
+	// Decrypt first frame to validate keys.
+	ciphertext, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+	if err != nil {
+		m.releaseSalt(frame.AuthToken, salt)
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, fmt.Errorf("%w: %w", ErrInvalidFrame, err)
+	}
+	plaintext, err := cs.DecryptIncoming(ciphertext)
+	if err != nil {
+		m.releaseSalt(frame.AuthToken, salt)
+		m.recordFailure(frame.AuthToken, sourceIP)
+		return nil, nil, err
+	}
+
+	// Successful first frame — clear any prior failure state.
+	m.clearFailures(frame.AuthToken, sourceIP)
+	return cs, plaintext, nil
+}
+
+// DecryptSubsequent decrypts a subsequent frame (base64 decode + validation).
+func (cs *ClientSession) DecryptSubsequent(frame EncryptedFrame) ([]byte, error) {
+	if cs == nil {
+		return nil, ErrSessionNotEstablished
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidFrame, err)
+	}
+	return cs.DecryptIncoming(ciphertext)
+}
+
+// failKey returns the lookup key for the failed-frame tracker. The NUL byte
+// separator ensures that no combination of auth token and source IP can
+// collide with a different pair (auth tokens are valid UTF-8 from a UUID
+// generator and IP strings never contain NUL).
+func failKey(authToken, sourceIP string) string {
+	return authToken + "\x00" + sourceIP
+}
+
+// isBlocked reports whether the given (authToken, sourceIP) is currently
+// blocked by the failed-frame rate limiter.
+func (m *EncryptionGateway) isBlocked(authToken, sourceIP string) bool {
+	m.failMu.Lock()
+	defer m.failMu.Unlock()
+
+	t, ok := m.failSeen[failKey(authToken, sourceIP)]
+	if !ok {
+		return false
+	}
+	if time.Now().Before(t.blockedUntil) {
+		return true
+	}
+	return false
+}
+
+// recordFailure increments the counter and applies exponential backoff blocks.
+// Enforces a global cap on failSeen with LRU eviction.
+func (m *EncryptionGateway) recordFailure(authToken, sourceIP string) {
+	m.failMu.Lock()
+	defer m.failMu.Unlock()
+
+	key := failKey(authToken, sourceIP)
+	t, ok := m.failSeen[key]
+	if !ok {
+		if len(m.failSeen) >= m.maxFailEntries {
+			m.evictOldestFailureLocked()
+		}
+		t = &failedFrameTracker{}
+		m.failSeen[key] = t
+	}
+	t.failures++
+	t.lastFailureAt = time.Now()
+
+	if t.failures >= m.failedFrameThreshold {
+		// Apply backoff. blockCount starts at 0 → 1x duration.
+		shift := t.blockCount
+		if shift > 10 {
+			shift = 10
+		}
+		dur := m.failedFrameBlockDuration << shift
+		if dur > m.failedFrameMaxBlock {
+			dur = m.failedFrameMaxBlock
+		}
+		t.blockedUntil = time.Now().Add(dur)
+		t.blockCount++
+		t.failures = 0
+		log.Warn().
+			Str("auth_token", redactToken(authToken)).
+			Str("ip", sourceIP).
+			Dur("block_duration", dur).
+			Msg("encryption: blocking after repeated first-frame failures")
+	}
+}
+
+// clearFailures decrements the backoff multiplier on success (preserving
+// attack history — deleting would let attackers reset escalation via
+// interleaved legitimate connections). Evicted by cleanupExpired when stale.
+func (m *EncryptionGateway) clearFailures(authToken, sourceIP string) {
+	m.failMu.Lock()
+	defer m.failMu.Unlock()
+	t, ok := m.failSeen[failKey(authToken, sourceIP)]
+	if !ok {
+		return
+	}
+	t.failures = 0
+	if t.blockCount > 0 {
+		t.blockCount--
+	}
+}
+
+// releaseSalt rolls back a salt reservation on failure so legitimate
+// clients can retry. Reserve-then-rollback ensures atomicity under races.
+func (m *EncryptionGateway) releaseSalt(authToken string, salt []byte) {
+	m.saltMu.Lock()
+	defer m.saltMu.Unlock()
+
+	t, ok := m.saltSeen[authToken]
+	if !ok {
+		return
+	}
+	delete(t, hex.EncodeToString(salt))
+	if len(t) == 0 {
+		delete(m.saltSeen, authToken)
+	}
+}
+
+// evictOldestFailureLocked evicts the oldest failSeen entry. Caller must hold failMu.
+func (m *EncryptionGateway) evictOldestFailureLocked() {
+	var oldestKey string
+	var oldestAt time.Time
+	for k, v := range m.failSeen {
+		if oldestKey == "" || v.lastFailureAt.Before(oldestAt) {
+			oldestKey = k
+			oldestAt = v.lastFailureAt
+		}
+	}
+	if oldestKey != "" {
+		delete(m.failSeen, oldestKey)
+	}
+}
+
+// evictOldestSaltClientLocked evicts the least-recently-active salt tracker. Caller must hold saltMu.
+func (m *EncryptionGateway) evictOldestSaltClientLocked() {
+	var oldestKey string
+	var oldestAt time.Time
+	for token, tracker := range m.saltSeen {
+		var newest time.Time
+		for _, ts := range tracker {
+			if ts.After(newest) {
+				newest = ts
+			}
+		}
+		if oldestKey == "" || newest.Before(oldestAt) {
+			oldestKey = token
+			oldestAt = newest
+		}
+	}
+	if oldestKey != "" {
+		delete(m.saltSeen, oldestKey)
+	}
+}
+
+// checkAndRecordSalt records a salt or returns ErrDuplicateSalt. Global cap
+// with LRU eviction bounds memory.
+func (m *EncryptionGateway) checkAndRecordSalt(authToken string, salt []byte) error {
+	m.saltMu.Lock()
+	defer m.saltMu.Unlock()
+
+	t, ok := m.saltSeen[authToken]
+	if !ok {
+		if len(m.saltSeen) >= m.maxSaltClients {
+			m.evictOldestSaltClientLocked()
+		}
+		t = make(map[string]time.Time)
+		m.saltSeen[authToken] = t
+	}
+
+	saltHex := hex.EncodeToString(salt)
+	if _, dup := t[saltHex]; dup {
+		return ErrDuplicateSalt
+	}
+
+	// Evict the oldest entry if we're at the cap. The cap is far above any
+	// legitimate usage so this should rarely fire.
+	if len(t) >= m.maxSaltsPerClient {
+		var oldestKey string
+		var oldestAt time.Time
+		for k, v := range t {
+			if oldestAt.IsZero() || v.Before(oldestAt) {
+				oldestKey = k
+				oldestAt = v
+			}
+		}
+		delete(t, oldestKey)
+	}
+
+	t[saltHex] = time.Now()
+	return nil
+}
+
+// cleanupExpired evicts old salt entries and stale failure trackers.
+func (m *EncryptionGateway) cleanupExpired() {
+	now := time.Now()
+
+	m.saltMu.Lock()
+	for token, tracker := range m.saltSeen {
+		for k, t := range tracker {
+			if now.Sub(t) > m.saltWindowTTL {
+				delete(tracker, k)
+			}
+		}
+		if len(tracker) == 0 {
+			delete(m.saltSeen, token)
+		}
+	}
+	m.saltMu.Unlock()
+
+	m.failMu.Lock()
+	for k, t := range m.failSeen {
+		// Drop entries with no recent activity AND no active block.
+		if now.After(t.blockedUntil) && now.Sub(t.lastFailureAt) > m.saltWindowTTL {
+			delete(m.failSeen, k)
+		}
+	}
+	m.failMu.Unlock()
+}
+
+// redactToken truncates to 8 chars for log correlation.
+func redactToken(token string) string {
+	if len(token) <= 8 {
+		return "***"
+	}
+	return token[:8] + "…"
+}

--- a/pkg/api/middleware/encryption_test.go
+++ b/pkg/api/middleware/encryption_test.go
@@ -1,0 +1,1138 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware_test
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pairedClient builds a fake paired client. Used by tests to drive the
+// session manager without going through the full PAKE flow.
+func pairedClient(t *testing.T) (client *database.Client, pairingKey []byte) {
+	t.Helper()
+	pairingKey = make([]byte, crypto.PairingKeySize)
+	_, err := cryptorand.Read(pairingKey)
+	require.NoError(t, err)
+	//nolint:gosec // test fixture; AuthToken is opaque test data, not a credential
+	client = &database.Client{
+		ClientID:   "client-uuid",
+		ClientName: "Test",
+		AuthToken:  "auth-token-uuid",
+		PairingKey: pairingKey,
+		CreatedAt:  1700000000,
+		LastSeenAt: 1700000000,
+	}
+	return client, pairingKey
+}
+
+// randomSalt returns a random 16-byte session salt.
+func randomSalt(t *testing.T) []byte {
+	t.Helper()
+	salt := make([]byte, crypto.SessionSaltSize)
+	_, err := cryptorand.Read(salt)
+	require.NoError(t, err)
+	return salt
+}
+
+// encryptFirstFrame helps tests build an encrypted first frame using the
+// same key derivation the manager will use.
+func encryptFirstFrame(t *testing.T, c *database.Client, salt, plaintext []byte, counter uint64) []byte {
+	t.Helper()
+	keys, err := crypto.DeriveSessionKeys(c.PairingKey, salt)
+	require.NoError(t, err)
+	gcm, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	aad := []byte(c.AuthToken + ":ws")
+	ct, err := crypto.Encrypt(gcm, keys.C2SNonce, counter, plaintext, aad)
+	require.NoError(t, err)
+	return ct
+}
+
+func TestIsEncryptedFirstFrame(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{name: "valid first frame", data: `{"v":1,"e":"abc","t":"tok","s":"salt"}`, want: true},
+		{name: "missing version", data: `{"e":"abc","t":"tok","s":"salt"}`, want: false},
+		{name: "missing ciphertext", data: `{"v":1,"t":"tok","s":"salt"}`, want: false},
+		{name: "missing token", data: `{"v":1,"e":"abc","s":"salt"}`, want: false},
+		{name: "missing salt", data: `{"v":1,"e":"abc","t":"tok"}`, want: false},
+		{name: "plain JSON-RPC", data: `{"jsonrpc":"2.0","method":"x","id":1}`, want: false},
+		{name: "subsequent frame", data: `{"e":"abc"}`, want: false},
+		{name: "garbage", data: `not json`, want: false},
+		{name: "empty", data: ``, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, middleware.IsEncryptedFirstFrame([]byte(tt.data)))
+		})
+	}
+}
+
+func TestEstablishSession_Success(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	plaintext := []byte(`{"jsonrpc":"2.0","method":"version","id":1}`)
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+
+	cs, decrypted, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+	assert.Equal(t, plaintext, decrypted)
+	assert.Equal(t, c.AuthToken, cs.AuthToken())
+}
+
+func TestEstablishSession_UnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	mgr := middleware.NewEncryptionGateway(db)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     99,
+		Ciphertext:  "abc",
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrUnsupportedVersion)
+}
+
+func TestEstablishSession_InvalidSaltLength(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  "abc",
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(make([]byte, 8)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrInvalidSaltLength)
+}
+
+func TestEstablishSession_UnknownAuthToken(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", "missing").
+		Return((*database.Client)(nil), assert.AnError)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("ct")),
+		AuthToken:   "missing",
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrUnknownAuthToken)
+}
+
+func TestEstablishSession_DuplicateSalt(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	plaintext := []byte(`{"jsonrpc":"2.0","method":"version","id":1}`)
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.NoError(t, err)
+
+	// Second use of the same salt must be rejected.
+	_, _, err = mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrDuplicateSalt)
+}
+
+func TestEstablishSession_FailedDecryptIncrementsLimiter(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	// Many failed lookups all hit the same client
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(3),
+		middleware.WithFailedFrameBlockDuration(50*time.Millisecond),
+	)
+
+	// Build frames with the right salt format but garbage ciphertext.
+	for range 3 {
+		frame := middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage ciphertext data here")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}
+		_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+		require.Error(t, err)
+	}
+
+	// Next attempt should hit the rate limit
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage ciphertext data here")),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrConnectionBlocked)
+
+	// A different IP for the same token should still be allowed
+	_, _, err = mgr.EstablishSession(frame, "192.168.1.51")
+	require.NotErrorIs(t, err, middleware.ErrConnectionBlocked,
+		"different IP must not be locked out")
+}
+
+func TestEstablishSession_BlockExpires(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+		middleware.WithFailedFrameBlockDuration(20*time.Millisecond),
+	)
+
+	for range 2 {
+		frame := middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage data garbage")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}
+		_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+		require.Error(t, err)
+	}
+
+	// Currently blocked
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrConnectionBlocked)
+
+	// Wait for block to expire
+	time.Sleep(40 * time.Millisecond)
+
+	// Build a valid frame so the next attempt actually succeeds (clears state)
+	salt := randomSalt(t)
+	plaintext := []byte("hello")
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+	goodFrame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	_, decrypted, err := mgr.EstablishSession(goodFrame, "192.168.1.50")
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, decrypted)
+}
+
+func TestEstablishSession_SuccessClearsFailures(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(5),
+	)
+
+	// Two failures
+	for range 2 {
+		_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}, "192.168.1.50")
+	}
+
+	// Now a successful frame
+	salt := randomSalt(t)
+	plaintext := []byte("hi")
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+	_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+
+	// More failures should not immediately block since we cleared
+	for range 4 {
+		_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}, "192.168.1.50")
+	}
+	// Still under threshold (5)
+	salt2 := randomSalt(t)
+	ct2 := encryptFirstFrame(t, c, salt2, []byte("hi"), 0)
+	_, _, err = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct2),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt2),
+	}, "192.168.1.50")
+	require.NoError(t, err, "should not be blocked yet")
+}
+
+// TestEstablishSession_BlockCountEscalates pins the exponential-backoff
+// escalation: each time the failure threshold is hit, blockCount must
+// increase. This is the property that makes the rate limiter actually
+// adapt to a sustained attacker; without it, a single 30s block would
+// be the worst-case slowdown forever.
+//
+// Also pins the shift cap at blockCount > 10 — the cap is what stops
+// `failedFrameBlockDuration << blockCount` from overflowing once an
+// attacker pushes blockCount past 64 over a long period.
+func TestEstablishSession_BlockCountEscalates(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+		// Tiny base + low cap so the test doesn't sleep for minutes when
+		// it walks blockCount up past the shift cap.
+		middleware.WithFailedFrameBlockDuration(time.Millisecond),
+		middleware.WithFailedFrameMaxBlock(50*time.Millisecond),
+	)
+
+	const ip = "192.168.1.50"
+	hitThreshold := func(round int) {
+		for i := range 2 {
+			_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+				Version: middleware.EncryptionProtoVersion,
+				Ciphertext: base64.StdEncoding.EncodeToString(
+					[]byte(fmt.Sprintf("garbage round %d attempt %d", round, i))),
+				AuthToken:   c.AuthToken,
+				SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+			}, ip)
+		}
+		// Wait for the (very short) block to expire so the next round can
+		// reach recordFailure instead of bouncing on isBlocked.
+		time.Sleep(60 * time.Millisecond)
+	}
+
+	// Walk blockCount up through several rounds. Each round must escalate.
+	for round := 1; round <= 5; round++ {
+		hitThreshold(round)
+		assert.Equal(t, round, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+			"round %d should escalate blockCount to %d", round, round)
+	}
+
+	// Push past the shift cap (10) to confirm the code path is exercised
+	// without panicking or overflowing the duration calculation.
+	for round := 6; round <= 13; round++ {
+		hitThreshold(round)
+	}
+	require.GreaterOrEqual(t,
+		mgr.FailureBlockCountForTest(c.AuthToken, ip), 13,
+		"blockCount must keep counting past the shift cap")
+
+	// One more round at the elevated count must still produce a block
+	// (capped at failedFrameMaxBlock) without panicking.
+	hitThreshold(14)
+	// The duration is clamped at failedFrameMaxBlock=50ms, but blockCount
+	// itself keeps incrementing as evidence of sustained abuse.
+	assert.GreaterOrEqual(t, mgr.FailureBlockCountForTest(c.AuthToken, ip), 14)
+}
+
+// TestEstablishSession_SuccessDecrementsBlockCount pins the fix for the
+// rate-limit-bypass bug where a successful first frame at the same
+// (authToken, sourceIP) used to delete the entire failure tracker entry,
+// erasing accumulated backoff history. After the fix, success only
+// decrements blockCount (and resets failures), so an attacker on the same
+// IP+token cannot have their escalation reset by a legitimate client.
+func TestEstablishSession_SuccessDecrementsBlockCount(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+		middleware.WithFailedFrameBlockDuration(10*time.Millisecond),
+	)
+
+	const ip = "192.168.1.50"
+
+	// Round 1: hit threshold to escalate blockCount 0 → 1.
+	for range 2 {
+		_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage round1")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}, ip)
+	}
+	require.Equal(t, 1, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+		"first round of failures should set blockCount=1")
+
+	// Wait for the active block to expire.
+	time.Sleep(20 * time.Millisecond)
+
+	// Round 2: hit threshold again to escalate to blockCount=2.
+	for range 2 {
+		_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage round2")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}, ip)
+	}
+	require.Equal(t, 2, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+		"second round of failures should escalate blockCount to 2")
+
+	// Wait for the second block to expire.
+	time.Sleep(50 * time.Millisecond)
+
+	// Legitimate client succeeds. Old behavior (delete) would set
+	// blockCount back to 0 (-1 == no entry). New behavior decrements
+	// 2 → 1 so the next attacker round still escalates from an
+	// elevated baseline.
+	salt := randomSalt(t)
+	ct := encryptFirstFrame(t, c, salt, []byte("good"), 0)
+	_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, ip)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+		"successful frame must DECREMENT blockCount, not delete the entry — "+
+			"deleting would let an attacker reset their escalation history")
+
+	// A second legitimate success decrements again to 0 (clamped at 0).
+	salt2 := randomSalt(t)
+	ct2 := encryptFirstFrame(t, c, salt2, []byte("good2"), 0)
+	_, _, err = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct2),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt2),
+	}, ip)
+	require.NoError(t, err)
+	assert.Equal(t, 0, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+		"second success should clamp blockCount at 0, not go negative")
+
+	// A third legitimate success must NOT panic or underflow.
+	salt3 := randomSalt(t)
+	ct3 := encryptFirstFrame(t, c, salt3, []byte("good3"), 0)
+	_, _, err = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct3),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt3),
+	}, ip)
+	require.NoError(t, err)
+	assert.Equal(t, 0, mgr.FailureBlockCountForTest(c.AuthToken, ip),
+		"blockCount must not underflow below 0")
+}
+
+func TestClientSession_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	plaintext := []byte("first frame")
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+	cs, decrypted, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+	require.Equal(t, plaintext, decrypted)
+
+	// Server encrypts a response — counter 0
+	respPlain := []byte(`{"result":"ok"}`)
+	respCT, err := cs.EncryptOutgoing(respPlain)
+	require.NoError(t, err)
+
+	// Client decrypts using the same salt-derived keys
+	keys, err := crypto.DeriveSessionKeys(c.PairingKey, salt)
+	require.NoError(t, err)
+	clientGCM, err := crypto.NewAEAD(keys.S2CKey)
+	require.NoError(t, err)
+	got, err := crypto.Decrypt(clientGCM, keys.S2CNonce, 0, respCT, []byte(c.AuthToken+":ws"))
+	require.NoError(t, err)
+	assert.Equal(t, respPlain, got)
+
+	// Client sends a second frame at counter 1
+	subPlain := []byte("second frame")
+	clientC2S, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	subCT, err := crypto.Encrypt(clientC2S, keys.C2SNonce, 1, subPlain, []byte(c.AuthToken+":ws"))
+	require.NoError(t, err)
+
+	subFrame := middleware.EncryptedFrame{
+		Ciphertext: base64.StdEncoding.EncodeToString(subCT),
+	}
+	gotSub, err := cs.DecryptSubsequent(subFrame)
+	require.NoError(t, err)
+	assert.Equal(t, subPlain, gotSub)
+}
+
+func TestClientSession_ReplayRejected(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	plaintext := []byte("first")
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	cs, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.NoError(t, err)
+
+	// Try to feed the same first-frame ciphertext again as a "subsequent"
+	// frame — server expects counter 1 now, so decryption fails.
+	replay := middleware.EncryptedFrame{Ciphertext: base64.StdEncoding.EncodeToString(ct)}
+	_, err = cs.DecryptSubsequent(replay)
+	require.Error(t, err)
+}
+
+func TestClientSession_OutOfOrderFails(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	ct0 := encryptFirstFrame(t, c, salt, []byte("0"), 0)
+	cs, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct0),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+
+	// Encrypt counter 5 (skipping 1-4)
+	keys, _ := crypto.DeriveSessionKeys(c.PairingKey, salt)
+	gcm, _ := crypto.NewAEAD(keys.C2SKey)
+	ct5, err := crypto.Encrypt(gcm, keys.C2SNonce, 5, []byte("five"), []byte(c.AuthToken+":ws"))
+	require.NoError(t, err)
+
+	frame := middleware.EncryptedFrame{Ciphertext: base64.StdEncoding.EncodeToString(ct5)}
+	_, err = cs.DecryptSubsequent(frame)
+	require.Error(t, err, "out-of-order counter must fail")
+}
+
+func TestEncryptOutgoingFrame_ProducesValidJSON(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	ct := encryptFirstFrame(t, c, salt, []byte("hi"), 0)
+	cs, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+
+	frame, err := cs.EncryptOutgoingFrame([]byte(`{"jsonrpc":"2.0","result":"ok","id":1}`))
+	require.NoError(t, err)
+
+	var parsed middleware.EncryptedFrame
+	require.NoError(t, json.Unmarshal(frame, &parsed))
+	assert.NotEmpty(t, parsed.Ciphertext)
+}
+
+func TestEstablishSession_DifferentClientsIndependent(t *testing.T) {
+	t.Parallel()
+
+	c1, _ := pairedClient(t)
+	c2, _ := pairedClient(t)
+	c2.AuthToken = "other-token"
+	c2.ClientID = "other-id"
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c1.AuthToken).Return(c1, nil)
+	db.On("GetClientByToken", c2.AuthToken).Return(c2, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	// Reuse the same salt across two different clients — should be allowed
+	// because the salt tracker is keyed by authToken.
+	salt := randomSalt(t)
+
+	for _, c := range []*database.Client{c1, c2} {
+		ct := encryptFirstFrame(t, c, salt, []byte("hi"), 0)
+		_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(salt),
+		}, "192.168.1.50")
+		require.NoError(t, err, "client %s", c.AuthToken)
+	}
+}
+
+func TestEstablishSession_PairingKeyWrongLength(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	c.PairingKey = make([]byte, 16) // wrong length
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("ct")),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrInvalidPairingKey)
+}
+
+// TestEstablishSession_UnknownTokenDoesNotPopulateLimiter verifies that an
+// unknown auth token does NOT create a failSeen entry. Without this rule,
+// an attacker fabricating tokens could grow the rate-limiter map without
+// bound (DoS via memory exhaustion).
+func TestEstablishSession_UnknownTokenDoesNotPopulateLimiter(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", "fabricated-1").
+		Return((*database.Client)(nil), assert.AnError)
+	db.On("GetClientByToken", "fabricated-2").
+		Return((*database.Client)(nil), assert.AnError)
+
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+	)
+
+	for _, tok := range []string{"fabricated-1", "fabricated-2"} {
+		frame := middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+			AuthToken:   tok,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}
+		_, _, err := mgr.EstablishSession(frame, "10.0.0.1")
+		require.ErrorIs(t, err, middleware.ErrUnknownAuthToken)
+	}
+
+	// A third unknown-token attempt must NOT report ErrConnectionBlocked
+	// — if the limiter were tracking unknown tokens it would be at 2/2
+	// and the next call would block. The fact that we still get
+	// ErrUnknownAuthToken proves the limiter was never engaged.
+	frame := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		AuthToken:   "fabricated-1",
+		SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+	}
+	_, _, err := mgr.EstablishSession(frame, "10.0.0.1")
+	require.ErrorIs(t, err, middleware.ErrUnknownAuthToken,
+		"unknown tokens must not populate the rate limiter")
+	require.NotErrorIs(t, err, middleware.ErrConnectionBlocked)
+}
+
+// TestEstablishSession_UnknownTokenMalformedSaltDoesNotPopulateLimiter
+// verifies that an unknown auth token does NOT create a failSeen entry even
+// when the session salt is malformed (bad base64 or wrong length). Without
+// this rule, an attacker could send fabricated tokens with garbage salts
+// and grow the rate-limiter map without bound — the salt validation would
+// reach recordFailure before the token lookup ever ran.
+func TestEstablishSession_UnknownTokenMalformedSaltDoesNotPopulateLimiter(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", "fabricated-bad-salt-1").
+		Return((*database.Client)(nil), assert.AnError)
+	db.On("GetClientByToken", "fabricated-bad-salt-2").
+		Return((*database.Client)(nil), assert.AnError)
+	db.On("GetClientByToken", "fabricated-bad-salt-3").
+		Return((*database.Client)(nil), assert.AnError)
+
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+	)
+
+	// Bad base64 salt.
+	frame1 := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		AuthToken:   "fabricated-bad-salt-1",
+		SessionSalt: "!!!not-base64!!!",
+	}
+	_, _, err := mgr.EstablishSession(frame1, "10.0.0.2")
+	require.ErrorIs(t, err, middleware.ErrUnknownAuthToken)
+
+	// Wrong-length (but valid base64) salt.
+	frame2 := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		AuthToken:   "fabricated-bad-salt-2",
+		SessionSalt: base64.StdEncoding.EncodeToString([]byte("short")),
+	}
+	_, _, err = mgr.EstablishSession(frame2, "10.0.0.2")
+	require.ErrorIs(t, err, middleware.ErrUnknownAuthToken)
+
+	// A third unknown-token attempt must NOT report ErrConnectionBlocked.
+	// If the limiter were tracking malformed-salt failures from unknown
+	// tokens it would be at 2/2 and the next call would block.
+	frame3 := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+		AuthToken:   "fabricated-bad-salt-3",
+		SessionSalt: "also-not-base64",
+	}
+	_, _, err = mgr.EstablishSession(frame3, "10.0.0.2")
+	require.ErrorIs(t, err, middleware.ErrUnknownAuthToken,
+		"unknown tokens with malformed salts must not populate the rate limiter")
+	require.NotErrorIs(t, err, middleware.ErrConnectionBlocked)
+}
+
+// TestEstablishSession_FailSeenCapEvictsOldest verifies that the failSeen
+// map is bounded. With the cap set to 3, four distinct (authToken, IP)
+// failures must result in only three entries — the oldest must be
+// evicted. The previously-evicted entry, when retried, restarts at 1
+// failure (proving its tracker was discarded).
+func TestEstablishSession_FailSeenCapEvictsOldest(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithFailedFrameThreshold(2),
+		middleware.WithMaxFailEntries(3),
+	)
+
+	// Build a frame that will fail decryption (so recordFailure is called)
+	// but for a real, known token (so the lookup succeeds and we reach
+	// recordFailure). Use a constant ciphertext but distinct source IPs to
+	// produce four distinct failKey values.
+	mkFrame := func() middleware.EncryptedFirstFrame {
+		return middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage data garbage")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}
+	}
+
+	ips := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"}
+	for _, ip := range ips {
+		_, _, err := mgr.EstablishSession(mkFrame(), ip)
+		require.Error(t, err)
+	}
+
+	// 10.0.0.1 (the oldest) was evicted. Hitting it once more should fail
+	// with a decryption error but NOT trip the rate limiter (which would
+	// require 2 failures). If the entry had survived, this would be the
+	// 2nd failure for 10.0.0.1 → ErrConnectionBlocked on the next call.
+	_, _, err := mgr.EstablishSession(mkFrame(), "10.0.0.1")
+	require.Error(t, err)
+	// Now try again — if the previous call was the 1st failure (i.e.
+	// eviction worked), this is the 2nd failure → block triggers on the
+	// NEXT call. So this call should still error with the decryption
+	// error, not with ErrConnectionBlocked.
+	_, _, err = mgr.EstablishSession(mkFrame(), "10.0.0.1")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, middleware.ErrConnectionBlocked,
+		"after eviction, the entry should restart at 0 failures")
+}
+
+// TestEstablishSession_FailedReplayDoesNotBurnSalt pins the fix for the
+// replay-burn vulnerability: an attacker who observes a legitimate first
+// frame and replays it with garbage ciphertext used to permanently burn
+// the salt, blocking the honest client from completing its handshake.
+//
+// The fix releases the salt reservation on every post-record failure
+// path, so the honest client can retry with the original salt.
+func TestEstablishSession_FailedReplayDoesNotBurnSalt(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		// Make the rate limiter forgiving so the failure path runs
+		// to completion without blocking the legitimate retry.
+		middleware.WithFailedFrameThreshold(100),
+	)
+
+	salt := randomSalt(t)
+	plaintext := []byte("legitimate")
+	good := encryptFirstFrame(t, c, salt, plaintext, 0)
+
+	// Attacker replays the legitimate (token, salt) with garbage
+	// ciphertext. The auth token is real, the salt is the one the honest
+	// client will use, but the ciphertext won't decrypt.
+	tampered := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage data garbage data garbage data")),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	_, _, err := mgr.EstablishSession(tampered, "10.0.0.99")
+	require.Error(t, err, "tampered frame must fail")
+
+	// Honest client now sends its real first frame with the SAME salt.
+	// Without the fix this would return ErrDuplicateSalt because the
+	// attacker's failed attempt burned the entry. With the fix the
+	// reservation was rolled back and the legit client succeeds.
+	honest := middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(good),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	_, decrypted, err := mgr.EstablishSession(honest, "192.168.1.50")
+	require.NoError(t, err, "honest client must be able to retry with the same salt")
+	assert.Equal(t, plaintext, decrypted)
+
+	// And now a true second use of the salt by the honest client (e.g. a
+	// reconnect with stale state) is correctly rejected.
+	_, _, err = mgr.EstablishSession(honest, "192.168.1.50")
+	require.ErrorIs(t, err, middleware.ErrDuplicateSalt,
+		"second honest use of the same salt must still be rejected")
+}
+
+// TestSendEncryptedFrame_ConcurrentWritesPreserveCounterOrder pins the
+// fix for the encrypt+write race: when multiple goroutines call
+// SendEncryptedFrame on the same session, the writeFn callback MUST be
+// invoked in the same order as the encrypted counter values, otherwise
+// the client would decrypt frames out of order and tear down the session.
+//
+// The fix holds cs.mu across encrypt + writeFn so the enqueue order
+// matches the counter order. With -race enabled this also catches any
+// reintroduction of the prior bug where the lock was released between
+// the two steps.
+func TestSendEncryptedFrame_ConcurrentWritesPreserveCounterOrder(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+
+	salt := randomSalt(t)
+	ct := encryptFirstFrame(t, c, salt, []byte("first"), 0)
+	cs, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+
+	// Build the matching client-side AEAD so we can decrypt what we
+	// observe on the wire.
+	keys, err := crypto.DeriveSessionKeys(c.PairingKey, salt)
+	require.NoError(t, err)
+	clientS2C, err := crypto.NewAEAD(keys.S2CKey)
+	require.NoError(t, err)
+	aad := []byte(c.AuthToken + ":ws")
+
+	// Capture the wire-order in which the writeFn is invoked. The
+	// `writes` slice is protected by writeMu (separate from cs.mu).
+	const totalSends = 256
+	const goroutines = 8
+	var (
+		writeMu syncutil.Mutex
+		writes  [][]byte
+	)
+	writeFn := func(b []byte) error {
+		// Copy because the caller may reuse the buffer.
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		writeMu.Lock()
+		writes = append(writes, cp)
+		writeMu.Unlock()
+		return nil
+	}
+
+	// Spawn N goroutines, each sending totalSends/N frames.
+	per := totalSends / goroutines
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := range per {
+				payload := []byte(fmt.Sprintf(`{"g":%d,"i":%d}`, gid, i))
+				if err := cs.SendEncryptedFrame(payload, writeFn); err != nil {
+					t.Errorf("send: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	require.Len(t, writes, totalSends, "every send must enqueue exactly one write")
+
+	// Decrypt every frame in wire order. The recv counter on the client
+	// side starts at 0; if the writes are in counter order, every
+	// decryption succeeds. Any out-of-order frame produces a GCM auth
+	// failure.
+	for i, w := range writes {
+		var frame middleware.EncryptedFrame
+		require.NoError(t, json.Unmarshal(w, &frame), "frame %d not valid JSON", i)
+		ct, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+		require.NoError(t, err)
+		//nolint:gosec // counter is bounded by totalSends
+		_, err = crypto.Decrypt(clientS2C, keys.S2CNonce, uint64(i), ct, aad)
+		require.NoError(t, err,
+			"frame at wire position %d failed to decrypt at counter %d — wire order does not match counter order", i, i)
+	}
+}
+
+// TestSendEncryptedFrame_CounterExhaustionReturnsError pins the
+// behavior at the AEAD counter limit: when sendCounter is at
+// math.MaxUint64, SendEncryptedFrame must NOT advance the counter,
+// must NOT call writeFn, and must return an error wrapping
+// crypto.ErrCounterExhausted. The WS handler relies on this error to
+// close the desynced session (see closeMelodySession in
+// sendWSEncryptedResponse / writeNotificationToSession).
+func TestSendEncryptedFrame_CounterExhaustionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	salt := randomSalt(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db)
+	plaintext := []byte("first frame")
+	ct := encryptFirstFrame(t, c, salt, plaintext, 0)
+	cs, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+
+	// Force the send counter to MaxUint64 — the next encrypt MUST trip
+	// the counter exhaustion check inside crypto.Encrypt without ever
+	// calling writeFn.
+	cs.SetSendCounterForTest(math.MaxUint64)
+
+	writeFnCalled := false
+	writeFn := func(_ []byte) error {
+		writeFnCalled = true
+		return nil
+	}
+
+	err = cs.SendEncryptedFrame([]byte("payload"), writeFn)
+	require.ErrorIs(t, err, crypto.ErrCounterExhausted,
+		"counter exhaustion error must be wrapped so callers can detect it")
+	assert.False(t, writeFnCalled,
+		"writeFn must NOT be called when crypto.Encrypt fails — otherwise "+
+			"a counter-exhausted session would emit garbage on the wire")
+}
+
+// TestCheckAndRecordSalt_ClientCapEvictsOldest verifies the global
+// salt-tracker cap. With the cap set to 2, three distinct clients must
+// result in only two trackers — the least-recently-active is evicted.
+func TestCheckAndRecordSalt_ClientCapEvictsOldest(t *testing.T) {
+	t.Parallel()
+
+	c1, _ := pairedClient(t)
+	c2, _ := pairedClient(t)
+	c2.AuthToken = "tok-2"
+	c3, _ := pairedClient(t)
+	c3.AuthToken = "tok-3"
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c1.AuthToken).Return(c1, nil)
+	db.On("GetClientByToken", c2.AuthToken).Return(c2, nil)
+	db.On("GetClientByToken", c3.AuthToken).Return(c3, nil)
+
+	mgr := middleware.NewEncryptionGateway(db, middleware.WithMaxSaltClients(2))
+
+	// Pair c1, c2, c3 in order. After c3, c1's tracker should be evicted.
+	for _, c := range []*database.Client{c1, c2, c3} {
+		salt := randomSalt(t)
+		ct := encryptFirstFrame(t, c, salt, []byte("hi"), 0)
+		_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(salt),
+		}, "192.168.1.50")
+		require.NoError(t, err, "client %s", c.AuthToken)
+		// Tiny delay so newest-tracker timestamps are distinguishable.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// c1's salt tracker was evicted. Reusing c1's previous salt is now
+	// allowed (the dedup state is gone). The successful pairing below
+	// proves the tracker was rebuilt.
+	salt := randomSalt(t)
+	ct := encryptFirstFrame(t, c1, salt, []byte("hi"), 0)
+	_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c1.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, "192.168.1.50")
+	require.NoError(t, err)
+}
+
+// TestCleanupExpired_EvictsBothMaps pins that cleanupExpired evicts entries
+// from BOTH the saltSeen and failSeen maps. The two paths are independent
+// so a regression in one would otherwise go uncaught.
+func TestCleanupExpired_EvictsBothMaps(t *testing.T) {
+	t.Parallel()
+
+	c, _ := pairedClient(t)
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := middleware.NewEncryptionGateway(db,
+		// Tiny TTL so any entry is "expired" after a few microseconds.
+		middleware.WithSaltWindowTTL(1*time.Nanosecond),
+		middleware.WithFailedFrameThreshold(2),
+		middleware.WithFailedFrameBlockDuration(1*time.Nanosecond),
+		middleware.WithFailedFrameMaxBlock(1*time.Nanosecond),
+	)
+
+	const ip = "192.168.1.50"
+
+	// 1. Populate saltSeen via a successful first frame.
+	salt := randomSalt(t)
+	ct := encryptFirstFrame(t, c, salt, []byte("hi"), 0)
+	_, _, err := mgr.EstablishSession(middleware.EncryptedFirstFrame{
+		Version:     middleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}, ip)
+	require.NoError(t, err)
+	require.Positive(t, mgr.SaltSeenSizeForTest(),
+		"saltSeen should have an entry after a successful first frame")
+
+	// 2. Populate failSeen by submitting garbage ciphertext that the
+	// known-token recordFailure path counts.
+	for range 2 {
+		_, _, _ = mgr.EstablishSession(middleware.EncryptedFirstFrame{
+			Version:     middleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString([]byte("garbage")),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(randomSalt(t)),
+		}, ip)
+	}
+	require.Positive(t, mgr.FailSeenSizeForTest(),
+		"failSeen should have an entry after garbage frames from a known token")
+
+	// Sleep just past the 1ns TTLs / blocks so cleanup considers everything
+	// expired.
+	time.Sleep(5 * time.Millisecond)
+
+	// 3. Cleanup must wipe BOTH maps. A regression that broke either branch
+	// would leave one of these positive.
+	mgr.CleanupExpiredForTest()
+	assert.Equal(t, 0, mgr.SaltSeenSizeForTest(),
+		"cleanupExpired must evict expired salt entries")
+	assert.Equal(t, 0, mgr.FailSeenSizeForTest(),
+		"cleanupExpired must evict expired failure trackers")
+}

--- a/pkg/api/middleware/export_test.go
+++ b/pkg/api/middleware/export_test.go
@@ -1,0 +1,57 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware
+
+// SetSendCounterForTest simulates counter exhaustion for testing.
+func (cs *ClientSession) SetSendCounterForTest(n uint64) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.sendCounter = n
+}
+
+// FailureBlockCountForTest returns the backoff multiplier (or -1 if not found).
+func (m *EncryptionGateway) FailureBlockCountForTest(authToken, sourceIP string) int {
+	m.failMu.Lock()
+	defer m.failMu.Unlock()
+	t, ok := m.failSeen[failKey(authToken, sourceIP)]
+	if !ok {
+		return -1
+	}
+	return t.blockCount
+}
+
+// CleanupExpiredForTest invokes cleanupExpired for testing.
+func (m *EncryptionGateway) CleanupExpiredForTest() {
+	m.cleanupExpired()
+}
+
+// SaltSeenSizeForTest returns the count of tracked clients in saltSeen.
+func (m *EncryptionGateway) SaltSeenSizeForTest() int {
+	m.saltMu.Lock()
+	defer m.saltMu.Unlock()
+	return len(m.saltSeen)
+}
+
+// FailSeenSizeForTest returns the count of entries in failSeen.
+func (m *EncryptionGateway) FailSeenSizeForTest() int {
+	m.failMu.Lock()
+	defer m.failMu.Unlock()
+	return len(m.failSeen)
+}

--- a/pkg/api/middleware/ipfilter.go
+++ b/pkg/api/middleware/ipfilter.go
@@ -49,21 +49,6 @@ func IsLoopbackAddr(remoteAddr string) bool {
 // supporting hot-reload of configuration.
 type IPsProvider func() []string
 
-// IPFilter manages IP allowlist filtering for both HTTP and WebSocket connections.
-// It uses a provider function to fetch the allowlist dynamically.
-type IPFilter struct {
-	getAllowedIPs IPsProvider
-}
-
-// NewIPFilter creates a new IP filter with an IPs provider function.
-// The provider is called on each request to get the current allowlist,
-// allowing configuration changes to take effect without server restart.
-func NewIPFilter(ipsProvider IPsProvider) *IPFilter {
-	return &IPFilter{
-		getAllowedIPs: ipsProvider,
-	}
-}
-
 // parseAllowedIPs parses a list of IP strings into nets and individual IPs.
 func parseAllowedIPs(allowedIPs []string) (nets []*net.IPNet, addrs []net.IP) {
 	for _, ipStr := range allowedIPs {
@@ -86,54 +71,54 @@ func parseAllowedIPs(allowedIPs []string) (nets []*net.IPNet, addrs []net.IP) {
 	return nets, addrs
 }
 
-// IsAllowed checks if an IP address is allowed.
-// Returns true if the allowlist is empty (no filtering) or if the IP matches an allowed entry.
-func (f *IPFilter) IsAllowed(remoteAddr string) bool {
-	allowedIPs := f.getAllowedIPs()
-	if len(allowedIPs) == 0 {
-		return true
-	}
-
-	ip := ParseRemoteIP(remoteAddr)
-	if ip == nil {
-		log.Warn().Str("addr", remoteAddr).Msg("failed to parse IP address")
-		return false
-	}
-
-	nets, addrs := parseAllowedIPs(allowedIPs)
-
-	for _, allowedIP := range addrs {
-		if ip.Equal(allowedIP) {
+// matchAllowedIPs reports whether ip matches any entry in the allowed list.
+// Entries can be individual IPs or CIDR ranges. Reuses parseAllowedIPs.
+func matchAllowedIPs(ip net.IP, allowed []string) bool {
+	nets, addrs := parseAllowedIPs(allowed)
+	for _, a := range addrs {
+		if ip.Equal(a) {
 			return true
 		}
 	}
-
 	for _, network := range nets {
 		if network.Contains(ip) {
 			return true
 		}
 	}
-
 	return false
 }
 
-// HTTPIPFilterMiddleware creates an HTTP middleware that filters requests by IP.
-// This middleware applies to both regular HTTP requests and WebSocket upgrade requests.
-func HTTPIPFilterMiddleware(filter *IPFilter) func(http.Handler) http.Handler {
+// NonWSIPFilterMiddleware denies non-loopback access unless AllowedIPs is configured.
+func NonWSIPFilterMiddleware(ipsProvider IPsProvider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !filter.IsAllowed(r.RemoteAddr) {
-				ip := ParseRemoteIP(r.RemoteAddr)
+			if IsLoopbackAddr(r.RemoteAddr) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			allowed := ipsProvider()
+			if len(allowed) == 0 {
+				log.Debug().
+					Str("addr", r.RemoteAddr).
+					Str("path", r.URL.Path).
+					Msg("non-WS remote access denied: AllowedIPs empty")
+				http.Error(w, "remote access disabled for this transport", http.StatusForbidden)
+				return
+			}
+			ip := ParseRemoteIP(r.RemoteAddr)
+			if ip == nil {
+				log.Warn().Str("addr", r.RemoteAddr).Msg("non-WS: failed to parse IP")
+				http.Error(w, "invalid remote address", http.StatusForbidden)
+				return
+			}
+			if !matchAllowedIPs(ip, allowed) {
 				log.Debug().
 					Str("ip", ip.String()).
 					Str("path", r.URL.Path).
-					Str("method", r.Method).
-					Msg("request from blocked IP")
-
-				http.Error(w, "Forbidden", http.StatusForbidden)
+					Msg("non-WS remote access denied: not in AllowedIPs")
+				http.Error(w, "remote access denied", http.StatusForbidden)
 				return
 			}
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/pkg/api/middleware/ipfilter_test.go
+++ b/pkg/api/middleware/ipfilter_test.go
@@ -322,6 +322,27 @@ func TestNonWSIPFilterMiddleware_RemoteNotInAllowlist(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, recorder.Code)
 }
 
+func TestNonWSIPFilterMiddleware_MalformedRemoteAddr(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(ipsProvider([]string{"192.168.1.0/24"}))
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "bad-addr"
+	recorder := httptest.NewRecorder()
+	wrapped.ServeHTTP(recorder, req)
+
+	assert.False(t, called, "next must not be called when ParseRemoteIP returns nil")
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
 func TestNonWSIPFilterMiddleware_HotReload(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/middleware/ipfilter_test.go
+++ b/pkg/api/middleware/ipfilter_test.go
@@ -117,262 +117,6 @@ func TestParseAllowedIPs(t *testing.T) {
 	}
 }
 
-func TestIPFilter_IsAllowed(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		remoteAddr string
-		allowedIPs []string
-		expected   bool
-	}{
-		{
-			name:       "empty allowlist allows all",
-			allowedIPs: []string{},
-			remoteAddr: "192.168.1.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "exact IP match",
-			allowedIPs: []string{"192.168.1.1"},
-			remoteAddr: "192.168.1.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "IP not in allowlist",
-			allowedIPs: []string{"192.168.1.1"},
-			remoteAddr: "192.168.1.2:12345",
-			expected:   false,
-		},
-		{
-			name:       "IP in CIDR range",
-			allowedIPs: []string{"192.168.1.0/24"},
-			remoteAddr: "192.168.1.100:12345",
-			expected:   true,
-		},
-		{
-			name:       "IP not in CIDR range",
-			allowedIPs: []string{"192.168.1.0/24"},
-			remoteAddr: "192.168.2.1:12345",
-			expected:   false,
-		},
-		{
-			name:       "multiple IPs, first matches",
-			allowedIPs: []string{"192.168.1.1", "10.0.0.1"},
-			remoteAddr: "192.168.1.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "multiple IPs, second matches",
-			allowedIPs: []string{"192.168.1.1", "10.0.0.1"},
-			remoteAddr: "10.0.0.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "multiple IPs, none match",
-			allowedIPs: []string{"192.168.1.1", "10.0.0.1"},
-			remoteAddr: "172.16.0.1:12345",
-			expected:   false,
-		},
-		{
-			name:       "mixed IPs and CIDRs, IP matches",
-			allowedIPs: []string{"192.168.1.1", "10.0.0.0/8"},
-			remoteAddr: "192.168.1.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "mixed IPs and CIDRs, CIDR matches",
-			allowedIPs: []string{"192.168.1.1", "10.0.0.0/8"},
-			remoteAddr: "10.5.6.7:12345",
-			expected:   true,
-		},
-		{
-			name:       "localhost IPv4",
-			allowedIPs: []string{"127.0.0.1"},
-			remoteAddr: "127.0.0.1:8080",
-			expected:   true,
-		},
-		{
-			name:       "localhost IPv6",
-			allowedIPs: []string{"::1"},
-			remoteAddr: "[::1]:8080",
-			expected:   true,
-		},
-		{
-			name:       "remote addr without port",
-			allowedIPs: []string{"192.168.1.1"},
-			remoteAddr: "192.168.1.1",
-			expected:   true,
-		},
-		{
-			name:       "invalid remote addr",
-			allowedIPs: []string{"192.168.1.1"},
-			remoteAddr: "invalid",
-			expected:   false,
-		},
-		{
-			name:       "config has IP with port, connection allowed",
-			allowedIPs: []string{"192.168.1.1:7497"},
-			remoteAddr: "192.168.1.1:12345",
-			expected:   true,
-		},
-		{
-			name:       "config has IPv6 with port, connection allowed",
-			allowedIPs: []string{"[::1]:8080"},
-			remoteAddr: "[::1]:9999",
-			expected:   true,
-		},
-		{
-			name:       "config has IP with port, different IP blocked",
-			allowedIPs: []string{"192.168.1.1:7497"},
-			remoteAddr: "192.168.1.2:12345",
-			expected:   false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			filter := NewIPFilter(ipsProvider(tt.allowedIPs))
-			result := filter.IsAllowed(tt.remoteAddr)
-
-			assert.Equal(t, tt.expected, result,
-				"IsAllowed(%q) with allowlist %v: expected %v, got %v",
-				tt.remoteAddr, tt.allowedIPs, tt.expected, result)
-		})
-	}
-}
-
-func TestHTTPIPFilterMiddleware(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name           string
-		remoteAddr     string
-		expectedBody   string
-		allowedIPs     []string
-		expectedStatus int
-	}{
-		{
-			name:           "empty allowlist allows request",
-			allowedIPs:     []string{},
-			remoteAddr:     "192.168.1.1:12345",
-			expectedStatus: http.StatusOK,
-			expectedBody:   "OK",
-		},
-		{
-			name:           "allowed IP passes through",
-			allowedIPs:     []string{"192.168.1.1"},
-			remoteAddr:     "192.168.1.1:12345",
-			expectedStatus: http.StatusOK,
-			expectedBody:   "OK",
-		},
-		{
-			name:           "blocked IP returns forbidden",
-			allowedIPs:     []string{"192.168.1.1"},
-			remoteAddr:     "192.168.1.2:12345",
-			expectedStatus: http.StatusForbidden,
-			expectedBody:   "Forbidden\n",
-		},
-		{
-			name:           "IP in CIDR range allowed",
-			allowedIPs:     []string{"192.168.1.0/24"},
-			remoteAddr:     "192.168.1.50:12345",
-			expectedStatus: http.StatusOK,
-			expectedBody:   "OK",
-		},
-		{
-			name:           "IP outside CIDR range blocked",
-			allowedIPs:     []string{"192.168.1.0/24"},
-			remoteAddr:     "192.168.2.1:12345",
-			expectedStatus: http.StatusForbidden,
-			expectedBody:   "Forbidden\n",
-		},
-		{
-			name:           "localhost allowed",
-			allowedIPs:     []string{"127.0.0.1"},
-			remoteAddr:     "127.0.0.1:8080",
-			expectedStatus: http.StatusOK,
-			expectedBody:   "OK",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			filter := NewIPFilter(ipsProvider(tt.allowedIPs))
-			middleware := HTTPIPFilterMiddleware(filter)
-
-			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte("OK"))
-			})
-
-			wrapped := middleware(handler)
-
-			//nolint:noctx // test helper, no context needed
-			req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-			req.RemoteAddr = tt.remoteAddr
-
-			recorder := httptest.NewRecorder()
-			wrapped.ServeHTTP(recorder, req)
-
-			assert.Equal(t, tt.expectedStatus, recorder.Code,
-				"expected status %d, got %d", tt.expectedStatus, recorder.Code)
-			assert.Equal(t, tt.expectedBody, recorder.Body.String(),
-				"expected body %q, got %q", tt.expectedBody, recorder.Body.String())
-		})
-	}
-}
-
-func TestHTTPIPFilterMiddleware_Integration(t *testing.T) {
-	t.Parallel()
-
-	// Test that middleware works correctly in a chain with multiple middlewares
-	filter := NewIPFilter(ipsProvider([]string{"192.168.1.0/24"}))
-	ipFilterMiddleware := HTTPIPFilterMiddleware(filter)
-
-	callCount := 0
-	testMiddleware := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			callCount++
-			next.ServeHTTP(w, r)
-		})
-	}
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
-	})
-
-	// Chain: ipFilter -> testMiddleware -> handler
-	wrapped := ipFilterMiddleware(testMiddleware(handler))
-
-	// Test allowed IP - should reach all middlewares and handler
-	callCount = 0
-	//nolint:noctx // test helper, no context needed
-	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "192.168.1.100:12345"
-	recorder := httptest.NewRecorder()
-	wrapped.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, 1, callCount, "testMiddleware should be called once")
-
-	// Test blocked IP - should not reach subsequent middlewares or handler
-	callCount = 0
-	//nolint:noctx // test helper, no context needed
-	req = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "10.0.0.1:12345"
-	recorder = httptest.NewRecorder()
-	wrapped.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusForbidden, recorder.Code)
-	assert.Equal(t, 0, callCount, "testMiddleware should not be called for blocked IP")
-}
-
 func TestParseRemoteIP(t *testing.T) {
 	t.Parallel()
 
@@ -469,86 +213,171 @@ func TestIsLoopbackAddr(t *testing.T) {
 	}
 }
 
-func TestIPFilter_HotReload(t *testing.T) {
+func TestNonWSIPFilterMiddleware_LoopbackAlwaysAllowed(t *testing.T) {
 	t.Parallel()
 
-	// Mutable IP store to simulate config reload
-	allowedIPs := []string{"192.168.1.0/24"}
-	provider := func() []string { return allowedIPs }
-
-	filter := NewIPFilter(provider)
-
-	// Initial state: 192.168.1.x allowed, 10.0.0.x blocked
-	assert.True(t, filter.IsAllowed("192.168.1.100:12345"))
-	assert.False(t, filter.IsAllowed("10.0.0.1:12345"))
-
-	// Simulate config reload: change to allow 10.0.0.0/8 instead
-	allowedIPs = []string{"10.0.0.0/8"}
-
-	// Now 10.0.0.x allowed, 192.168.1.x blocked
-	assert.False(t, filter.IsAllowed("192.168.1.100:12345"))
-	assert.True(t, filter.IsAllowed("10.0.0.1:12345"))
-
-	// Simulate config reload: allow both
-	allowedIPs = []string{"192.168.1.0/24", "10.0.0.0/8"}
-
-	assert.True(t, filter.IsAllowed("192.168.1.100:12345"))
-	assert.True(t, filter.IsAllowed("10.0.0.1:12345"))
-
-	// Simulate config reload: empty list (allow all)
-	allowedIPs = []string{}
-
-	assert.True(t, filter.IsAllowed("192.168.1.100:12345"))
-	assert.True(t, filter.IsAllowed("10.0.0.1:12345"))
-	assert.True(t, filter.IsAllowed("8.8.8.8:12345")) // Even public IPs
-}
-
-func TestHTTPIPFilterMiddleware_HotReload(t *testing.T) {
-	t.Parallel()
-
-	allowedIPs := []string{"192.168.1.100"}
-	provider := func() []string { return allowedIPs }
-
-	filter := NewIPFilter(provider)
-	middleware := HTTPIPFilterMiddleware(filter)
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
 		w.WriteHeader(http.StatusOK)
 	})
-	wrapped := middleware(handler)
+	mw := NonWSIPFilterMiddleware(ipsProvider(nil))
+	wrapped := mw(next)
 
-	// Request from allowed IP should succeed
-	//nolint:noctx // test helper, no context needed
+	tests := []string{"127.0.0.1:12345", "[::1]:12345"}
+	for _, addr := range tests {
+		called = false
+		//nolint:noctx // test helper
+		req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		req.RemoteAddr = addr
+		recorder := httptest.NewRecorder()
+		wrapped.ServeHTTP(recorder, req)
+
+		assert.True(t, called, "next should be called for %s", addr)
+		assert.Equal(t, http.StatusOK, recorder.Code, "loopback %s should be allowed", addr)
+	}
+}
+
+func TestNonWSIPFilterMiddleware_RemoteEmptyAllowlistDenied(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(ipsProvider(nil))
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
 	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "192.168.1.100:12345"
+	req.RemoteAddr = "192.168.1.50:12345"
 	recorder := httptest.NewRecorder()
 	wrapped.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
 
-	// Request from blocked IP should fail
-	//nolint:noctx // test helper, no context needed
-	req = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "192.168.1.200:12345"
-	recorder = httptest.NewRecorder()
+	assert.False(t, called, "next must not be called when remote with empty allowlist")
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+func TestNonWSIPFilterMiddleware_RemoteAllowlistedIP(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(ipsProvider([]string{"192.168.1.50"}))
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "192.168.1.50:12345"
+	recorder := httptest.NewRecorder()
 	wrapped.ServeHTTP(recorder, req)
+
+	assert.True(t, called, "allowlisted IP must be admitted")
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestNonWSIPFilterMiddleware_RemoteAllowlistedCIDR(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(ipsProvider([]string{"10.0.0.0/8"}))
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "10.0.0.107:12345"
+	recorder := httptest.NewRecorder()
+	wrapped.ServeHTTP(recorder, req)
+
+	assert.True(t, called, "IP within allowlisted CIDR must be admitted")
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestNonWSIPFilterMiddleware_RemoteNotInAllowlist(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(ipsProvider([]string{"192.168.1.50", "10.0.0.0/8"}))
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "172.16.0.5:12345"
+	recorder := httptest.NewRecorder()
+	wrapped.ServeHTTP(recorder, req)
+
+	assert.False(t, called, "IP not in allowlist must be denied")
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+func TestNonWSIPFilterMiddleware_HotReload(t *testing.T) {
+	t.Parallel()
+
+	allowedIPs := []string{}
+	provider := func() []string { return allowedIPs }
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NonWSIPFilterMiddleware(provider)
+	wrapped := mw(next)
+
+	// Initially empty allowlist, remote IP denied
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "192.168.1.50:12345"
+	recorder := httptest.NewRecorder()
+	wrapped.ServeHTTP(recorder, req)
+	assert.False(t, called)
 	assert.Equal(t, http.StatusForbidden, recorder.Code)
 
-	// Simulate config reload: allow 192.168.1.200 instead
-	allowedIPs = []string{"192.168.1.200"}
-
-	// Old IP should now be blocked
-	//nolint:noctx // test helper, no context needed
+	// Add the IP to the allowlist; next request must be admitted
+	allowedIPs = []string{"192.168.1.50"}
+	//nolint:noctx // test helper
 	req = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "192.168.1.100:12345"
+	req.RemoteAddr = "192.168.1.50:12345"
 	recorder = httptest.NewRecorder()
 	wrapped.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusForbidden, recorder.Code)
-
-	// New IP should now be allowed
-	//nolint:noctx // test helper, no context needed
-	req = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
-	req.RemoteAddr = "192.168.1.200:12345"
-	recorder = httptest.NewRecorder()
-	wrapped.ServeHTTP(recorder, req)
+	assert.True(t, called)
 	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestMatchAllowedIPs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ip      string
+		allowed []string
+		want    bool
+	}{
+		{name: "single IP match", ip: "192.168.1.50", allowed: []string{"192.168.1.50"}, want: true},
+		{name: "single IP no match", ip: "192.168.1.50", allowed: []string{"192.168.1.51"}, want: false},
+		{name: "CIDR match", ip: "10.0.0.107", allowed: []string{"10.0.0.0/8"}, want: true},
+		{name: "CIDR no match", ip: "192.168.1.50", allowed: []string{"10.0.0.0/8"}, want: false},
+		{name: "mixed match by IP", ip: "192.168.1.50", allowed: []string{"192.168.1.50", "10.0.0.0/8"}, want: true},
+		{name: "mixed match by CIDR", ip: "10.0.0.107", allowed: []string{"192.168.1.50", "10.0.0.0/8"}, want: true},
+		{name: "empty allowlist", ip: "192.168.1.50", allowed: []string{}, want: false},
+		{name: "invalid entries skipped", ip: "192.168.1.50", allowed: []string{"garbage", "192.168.1.50"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ip := ParseRemoteIP(tt.ip)
+			assert.Equal(t, tt.want, matchAllowedIPs(ip, tt.allowed))
+		})
+	}
 }

--- a/pkg/api/middleware/lastseen.go
+++ b/pkg/api/middleware/lastseen.go
@@ -1,0 +1,125 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/rs/zerolog/log"
+)
+
+// DefaultLastSeenFlushInterval is how often the LastSeenTracker flushes
+// pending updates to the database when StartFlushLoop is used without an
+// explicit interval. 30s trades a small amount of database activity for a
+// "last seen" estimate that is fresh enough to be useful in the paired
+// clients list.
+const DefaultLastSeenFlushInterval = 30 * time.Second
+
+// LastSeenTracker batches in-memory LastSeenAt updates and flushes to DB
+// periodically. High-frequency Touches collapse to one UPDATE per interval.
+type LastSeenTracker struct {
+	db    database.UserDBI
+	dirty map[string]int64
+	mu    syncutil.Mutex
+}
+
+// NewLastSeenTracker constructs a tracker bound to the given UserDBI.
+func NewLastSeenTracker(db database.UserDBI) *LastSeenTracker {
+	return &LastSeenTracker{
+		db:    db,
+		dirty: make(map[string]int64),
+	}
+}
+
+// Touch records the latest seen timestamp (newest wins, goroutine-safe).
+func (t *LastSeenTracker) Touch(authToken string, ts int64) {
+	if authToken == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if existing, ok := t.dirty[authToken]; ok && existing >= ts {
+		return
+	}
+	t.dirty[authToken] = ts
+}
+
+// Flush writes pending updates (errors logged, not fatal). Snapshots under
+// lock so concurrent Touches are not blocked.
+func (t *LastSeenTracker) Flush(ctx context.Context) {
+	t.mu.Lock()
+	if len(t.dirty) == 0 {
+		t.mu.Unlock()
+		return
+	}
+	snapshot := t.dirty
+	t.dirty = make(map[string]int64)
+	t.mu.Unlock()
+
+	for token, ts := range snapshot {
+		if err := ctx.Err(); err != nil {
+			// Re-queue remaining tokens to avoid silent loss on shutdown.
+			t.mu.Lock()
+			for rt, rts := range snapshot {
+				if existing, ok := t.dirty[rt]; !ok || existing < rts {
+					t.dirty[rt] = rts
+				}
+			}
+			t.mu.Unlock()
+			return
+		}
+		if err := t.db.UpdateClientLastSeen(token, ts); err != nil {
+			log.Warn().
+				Err(err).
+				Str("auth_token", redactToken(token)).
+				Msg("encryption: failed to persist client last seen")
+		}
+		delete(snapshot, token)
+	}
+}
+
+// StartFlushLoop runs Flush periodically with a final flush on shutdown.
+// Pass zero interval for DefaultLastSeenFlushInterval.
+func (t *LastSeenTracker) StartFlushLoop(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultLastSeenFlushInterval
+	}
+	// G118: this goroutine intentionally falls back to a fresh background
+	// context for the shutdown flush. The flush is reacting to ctx being
+	// canceled, so reusing ctx would abort every UpdateClientLastSeen call
+	// before it touched the DB and silently drop the pending updates.
+	//nolint:gosec // G118: see comment above
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				t.Flush(ctx)
+			case <-ctx.Done():
+				t.Flush(context.Background())
+				return
+			}
+		}
+	}()
+}

--- a/pkg/api/middleware/lastseen_test.go
+++ b/pkg/api/middleware/lastseen_test.go
@@ -1,0 +1,152 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLastSeenTracker_TouchKeepsNewest(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	// Older then newer — newest must win.
+	tr.Touch("token-a", 1700000100)
+	tr.Touch("token-a", 1700000200)
+	// Newer then older — older must be ignored.
+	tr.Touch("token-a", 1700000050)
+
+	db.On("UpdateClientLastSeen", "token-a", int64(1700000200)).Return(nil).Once()
+
+	tr.Flush(context.Background())
+	db.AssertExpectations(t)
+}
+
+func TestLastSeenTracker_TouchEmptyTokenIgnored(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	tr.Touch("", 1700000100)
+	// No expectations on db — Flush must be a no-op.
+	tr.Flush(context.Background())
+	db.AssertExpectations(t)
+}
+
+func TestLastSeenTracker_FlushClearsDirty(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	tr.Touch("token-a", 1700000100)
+	tr.Touch("token-b", 1700000200)
+
+	db.On("UpdateClientLastSeen", "token-a", int64(1700000100)).Return(nil).Once()
+	db.On("UpdateClientLastSeen", "token-b", int64(1700000200)).Return(nil).Once()
+	tr.Flush(context.Background())
+	db.AssertExpectations(t)
+
+	// Second flush with no Touches — must not call the db again.
+	tr.Flush(context.Background())
+	db.AssertExpectations(t)
+}
+
+func TestLastSeenTracker_FlushIgnoresDBErrors(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	tr.Touch("token-a", 1700000100)
+	tr.Touch("token-b", 1700000200)
+
+	// First update fails, second still happens — partial failure must
+	// not abort the rest of the flush.
+	db.On("UpdateClientLastSeen", mock.Anything, mock.Anything).
+		Return(assert.AnError).Once()
+	db.On("UpdateClientLastSeen", mock.Anything, mock.Anything).
+		Return(nil).Once()
+
+	tr.Flush(context.Background())
+	db.AssertExpectations(t)
+}
+
+func TestLastSeenTracker_StartFlushLoopFlushesOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	tr.Touch("token-a", 1700000100)
+
+	// The flush goroutine must drain the dirty set when ctx is canceled,
+	// even if the periodic ticker has not fired yet.
+	done := make(chan struct{}, 1)
+	db.On("UpdateClientLastSeen", "token-a", int64(1700000100)).
+		Run(func(_ mock.Arguments) { done <- struct{}{} }).
+		Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	tr.StartFlushLoop(ctx, time.Hour) // long interval ⇒ ticker won't fire
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown flush did not run within 1s")
+	}
+	db.AssertExpectations(t)
+}
+
+func TestLastSeenTracker_StartFlushLoopPeriodicFlush(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	done := make(chan struct{}, 1)
+	db.On("UpdateClientLastSeen", "token-a", int64(1700000100)).
+		Run(func(_ mock.Arguments) { done <- struct{}{} }).
+		Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tr.StartFlushLoop(ctx, 5*time.Millisecond)
+
+	tr.Touch("token-a", 1700000100)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("periodic flush did not run within 1s")
+	}
+	db.AssertExpectations(t)
+}

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -21,7 +21,6 @@ package middleware
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -40,6 +39,8 @@ const (
 type IPRateLimiter struct {
 	limiters map[string]*rateLimiterEntry
 	mu       syncutil.RWMutex
+	rate     rate.Limit
+	burst    int
 }
 
 type rateLimiterEntry struct {
@@ -47,10 +48,20 @@ type rateLimiterEntry struct {
 	lastSeen time.Time
 }
 
-// NewIPRateLimiter creates a new IP-based rate limiter with hardcoded limits
+// NewIPRateLimiter creates a new IP-based rate limiter with the default
+// API limits (100 req/min per IP, burst 20).
 func NewIPRateLimiter() *IPRateLimiter {
+	return NewIPRateLimiterWithLimits(rate.Limit(float64(RequestsPerMinute)/60.0), BurstSize)
+}
+
+// NewIPRateLimiterWithLimits creates a new IP-based rate limiter with custom
+// rate and burst settings. Used by the pairing endpoints which require a much
+// more aggressive limit (1 req/sec per IP) to throttle online PIN guessing.
+func NewIPRateLimiterWithLimits(r rate.Limit, burst int) *IPRateLimiter {
 	return &IPRateLimiter{
 		limiters: make(map[string]*rateLimiterEntry),
+		rate:     r,
+		burst:    burst,
 	}
 }
 
@@ -61,8 +72,7 @@ func (rl *IPRateLimiter) GetLimiter(ip string) *rate.Limiter {
 
 	entry, exists := rl.limiters[ip]
 	if !exists {
-		// Create new limiter with hardcoded constants
-		limiter := rate.NewLimiter(rate.Limit(float64(RequestsPerMinute)/60.0), BurstSize)
+		limiter := rate.NewLimiter(rl.rate, rl.burst)
 		entry = &rateLimiterEntry{
 			limiter:  limiter,
 			lastSeen: time.Now(),
@@ -132,7 +142,12 @@ func HTTPRateLimitMiddleware(limiter *IPRateLimiter) func(http.Handler) http.Han
 	}
 }
 
-// WebSocketRateLimitHandler wraps a WebSocket message handler with rate limiting
+// WebSocketRateLimitHandler wraps a WebSocket message handler with rate
+// limiting. When the per-IP rate limit is exceeded the connection is closed
+// rather than receiving a structured JSON-RPC error: this avoids leaking
+// plaintext frames onto encrypted sessions (which would not match the
+// {"e":...} envelope and could not be decrypted by the client) and gives
+// well-behaved clients an unambiguous "back off and reconnect" signal.
 func WebSocketRateLimitHandler(
 	limiter *IPRateLimiter,
 	handler func(*melody.Session, []byte),
@@ -146,32 +161,10 @@ func WebSocketRateLimitHandler(
 			log.Warn().
 				Str("ip", host).
 				Int("msg_size", len(msg)).
-				Msg("WebSocket rate limit exceeded")
+				Msg("WebSocket rate limit exceeded, closing connection")
 
-			type jsonRPCError struct {
-				Message string `json:"message"`
-				Code    int    `json:"code"`
-			}
-			type jsonRPCErrorResponse struct {
-				JSONRPC string       `json:"jsonrpc"`
-				ID      any          `json:"id"`
-				Error   jsonRPCError `json:"error"`
-			}
-			resp := jsonRPCErrorResponse{
-				JSONRPC: "2.0",
-				ID:      nil,
-				Error: jsonRPCError{
-					Code:    -32000,
-					Message: "Rate limit exceeded",
-				},
-			}
-			errorMsg, marshalErr := json.Marshal(resp)
-			if marshalErr != nil {
-				log.Error().Err(marshalErr).Msg("failed to marshal rate limit error")
-				return
-			}
-			if err := session.Write(errorMsg); err != nil {
-				log.Error().Err(err).Msg("failed to send rate limit error")
+			if err := session.Close(); err != nil {
+				log.Debug().Err(err).Msg("failed to close rate-limited session")
 			}
 			return
 		}

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -1,0 +1,219 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/olahol/melody"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+func TestNewIPRateLimiter_DefaultLimits(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiter()
+	assert.InDelta(t, float64(RequestsPerMinute)/60.0, float64(rl.rate), 0.001)
+	assert.Equal(t, BurstSize, rl.burst)
+}
+
+func TestNewIPRateLimiterWithLimits(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiterWithLimits(5, 2)
+	assert.InDelta(t, 5.0, float64(rl.rate), 0.001)
+	assert.Equal(t, 2, rl.burst)
+}
+
+func TestGetLimiter_CreateAndReuse(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiter()
+
+	l1 := rl.GetLimiter("192.168.1.1")
+	l2 := rl.GetLimiter("192.168.1.1")
+	l3 := rl.GetLimiter("192.168.1.2")
+
+	assert.Same(t, l1, l2, "same IP must return the same limiter")
+	assert.NotSame(t, l1, l3, "different IPs must return different limiters")
+}
+
+func TestCleanup_RemovesStaleEntries(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiter()
+
+	// Force a stale entry by setting lastSeen far in the past.
+	rl.mu.Lock()
+	rl.limiters["stale"] = &rateLimiterEntry{
+		limiter:  rate.NewLimiter(rl.rate, rl.burst),
+		lastSeen: time.Now().Add(-20 * time.Minute),
+	}
+	rl.mu.Unlock()
+
+	// Add a fresh entry via the public API.
+	rl.GetLimiter("fresh")
+
+	rl.Cleanup()
+
+	rl.mu.RLock()
+	_, staleExists := rl.limiters["stale"]
+	_, freshExists := rl.limiters["fresh"]
+	rl.mu.RUnlock()
+
+	assert.False(t, staleExists, "stale entry should be removed")
+	assert.True(t, freshExists, "fresh entry should be kept")
+}
+
+func TestStartCleanup_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiter()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rl.StartCleanup(ctx)
+	cancel()
+
+	// No assertion needed — the goroutine exits cleanly. If it doesn't,
+	// the test binary's leak detector or -race flag will catch it.
+	// Give a tiny window for the goroutine to observe the cancel.
+	time.Sleep(10 * time.Millisecond)
+}
+
+func TestHTTPRateLimitMiddleware_AllowsUnderLimit(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiterWithLimits(100, 10)
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := HTTPRateLimitMiddleware(rl)
+	wrapped := mw(next)
+
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	req.RemoteAddr = "192.168.1.1:12345"
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHTTPRateLimitMiddleware_BlocksOverLimit(t *testing.T) {
+	t.Parallel()
+	// burst=1 so the second request is rejected.
+	rl := NewIPRateLimiterWithLimits(0, 1)
+	callCount := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := HTTPRateLimitMiddleware(rl)
+	wrapped := mw(next)
+
+	for i := range 3 {
+		//nolint:noctx // test helper
+		req := httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+		req.RemoteAddr = "192.168.1.1:12345"
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+
+		if i == 0 {
+			assert.Equal(t, http.StatusOK, rec.Code, "first request should pass (burst)")
+		} else {
+			assert.Equal(t, http.StatusTooManyRequests, rec.Code, "request %d should be rate-limited", i)
+		}
+	}
+	assert.Equal(t, 1, callCount, "only the first request should reach the handler")
+}
+
+func TestHTTPRateLimitMiddleware_IsolatesIPs(t *testing.T) {
+	t.Parallel()
+	rl := NewIPRateLimiterWithLimits(0, 1)
+	mw := HTTPRateLimitMiddleware(rl)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	wrapped := mw(next)
+
+	// Exhaust IP A.
+	for range 2 {
+		//nolint:noctx // test helper
+		req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+		req.RemoteAddr = "10.0.0.1:1"
+		rec := httptest.NewRecorder()
+		wrapped.ServeHTTP(rec, req)
+	}
+
+	// IP B should still be allowed.
+	//nolint:noctx // test helper
+	req := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
+	req.RemoteAddr = "10.0.0.2:1"
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code, "different IP should not be rate-limited")
+}
+
+func TestWebSocketRateLimitHandler_ClosesOnExceed(t *testing.T) {
+	t.Parallel()
+
+	// burst=1 so only the first message is allowed.
+	rl := NewIPRateLimiterWithLimits(0, 1)
+	var handlerCalls atomic.Int32
+	inner := func(_ *melody.Session, _ []byte) {
+		handlerCalls.Add(1)
+	}
+	wrapped := WebSocketRateLimitHandler(rl, inner)
+
+	m := melody.New()
+	m.HandleMessage(wrapped)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	//nolint:bodyclose // websocket conn manages the body
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// First message should go through.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("hello")))
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, int32(1), handlerCalls.Load(), "first message should be handled")
+
+	// Second message should trigger rate limit and close the connection.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("again")))
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), handlerCalls.Load(), "second message should not reach handler")
+
+	// The server should have closed the connection.
+	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	_, _, err = conn.ReadMessage()
+	assert.Error(t, err, "connection should be closed after rate limit exceeded")
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -37,6 +37,7 @@ const (
 	NotificationPlaytimeLimitReached = "playtime.limit.reached"
 	NotificationPlaytimeLimitWarning = "playtime.limit.warning"
 	NotificationInboxAdded           = "inbox.added"
+	NotificationClientsPaired        = "clients.paired"
 )
 
 const (
@@ -73,7 +74,6 @@ const (
 	MethodPlaytimeLimitsUpdate = "settings.playtime.limits.update"
 	MethodPlaytime             = "playtime"
 	MethodClients              = "clients"
-	MethodClientsNew           = "clients.new"
 	MethodClientsDelete        = "clients.delete"
 	MethodSystems              = "systems"
 	MethodLaunchersRefresh     = "launchers.refresh"
@@ -127,6 +127,9 @@ type RequestObject struct {
 }
 
 type ErrorObject struct {
+	// Data is optional structured detail about the error. Per JSON-RPC 2.0
+	// §5.1 it MUST be a member of the error object, not a sibling.
+	Data    any    `json:"data,omitempty"`
 	Message string `json:"message"`
 	Code    int    `json:"code"`
 }

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -363,6 +363,33 @@ type InboxResponse struct {
 	Messages []InboxMessage `json:"messages"`
 }
 
+// PairedClient represents a client paired via the API encryption flow.
+// PairingKey and AuthToken are intentionally omitted from the public API
+// surface — only the metadata identifying the client is exposed.
+type PairedClient struct {
+	ClientID   string `json:"clientId"`
+	ClientName string `json:"clientName"`
+	CreatedAt  int64  `json:"createdAt"`
+	LastSeenAt int64  `json:"lastSeenAt"`
+}
+
+// ClientsResponse is the response for the clients RPC method.
+type ClientsResponse struct {
+	Clients []PairedClient `json:"clients"`
+}
+
+// ClientsDeleteParams is the parameters object for the clients.delete RPC method.
+type ClientsDeleteParams struct {
+	ClientID string `json:"clientId"`
+}
+
+// ClientsPairedNotification is the payload for the clients.paired notification,
+// broadcast when a client successfully completes the PAKE pairing flow.
+type ClientsPairedNotification struct {
+	ClientID   string `json:"clientId"`
+	ClientName string `json:"clientName"`
+}
+
 type SettingsAuthClaimResponse struct {
 	Domains []string `json:"domains"`
 }

--- a/pkg/api/models/responses_test.go
+++ b/pkg/api/models/responses_test.go
@@ -20,9 +20,11 @@
 package models
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestActiveMedia_Equal(t *testing.T) {
@@ -213,5 +215,112 @@ func TestActiveMedia_Equal(t *testing.T) {
 			result := tt.a.Equal(tt.b)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+// TestPairedClient_JSONShape pins the wire shape of the PairedClient
+// type returned by the `clients` RPC method. This test exists to catch a
+// future regression where someone embeds *database.Client (which contains
+// AuthToken and PairingKey fields) into PairedClient — that would silently
+// leak the auth token and the long-term pairing key over the API.
+//
+// The pin works by asserting the marshalled JSON has EXACTLY the expected
+// keys and that several variants of the sensitive field names are absent.
+func TestPairedClient_JSONShape(t *testing.T) {
+	t.Parallel()
+
+	pc := PairedClient{
+		ClientID:   "client-123",
+		ClientName: "Test Client",
+		CreatedAt:  1700000000,
+		LastSeenAt: 1700001000,
+	}
+	raw, err := json.Marshal(pc)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	expectedKeys := map[string]bool{
+		"clientId":   true,
+		"clientName": true,
+		"createdAt":  true,
+		"lastSeenAt": true,
+	}
+	for k := range got {
+		assert.True(t, expectedKeys[k],
+			"unexpected JSON key %q in PairedClient — could indicate a struct embed leaking sensitive fields", k)
+	}
+	for k := range expectedKeys {
+		_, ok := got[k]
+		assert.True(t, ok, "expected JSON key %q missing from PairedClient", k)
+	}
+
+	// Defense in depth: explicitly assert sensitive field names are absent
+	// even if some future serializer adds them under a different naming.
+	forbidden := []string{
+		"authToken", "auth_token", "AuthToken",
+		"pairingKey", "pairing_key", "PairingKey",
+	}
+	for _, k := range forbidden {
+		_, present := got[k]
+		assert.False(t, present,
+			"sensitive field %q must NEVER appear in PairedClient JSON", k)
+	}
+}
+
+// TestClientsResponse_JSONShape pins the wire shape of the `clients` RPC
+// list response. Catches accidental key renames.
+func TestClientsResponse_JSONShape(t *testing.T) {
+	t.Parallel()
+
+	cr := ClientsResponse{
+		Clients: []PairedClient{
+			{ClientID: "a", ClientName: "First", CreatedAt: 1, LastSeenAt: 2},
+			{ClientID: "b", ClientName: "Second", CreatedAt: 3, LastSeenAt: 4},
+		},
+	}
+	raw, err := json.Marshal(cr)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	clients, ok := got["clients"].([]any)
+	require.True(t, ok, "ClientsResponse must marshal to {clients: [...]}")
+	assert.Len(t, clients, 2)
+}
+
+// TestClientsDeleteParams_JSONShape pins the wire shape of the
+// `clients.delete` RPC parameters object.
+func TestClientsDeleteParams_JSONShape(t *testing.T) {
+	t.Parallel()
+
+	p := ClientsDeleteParams{ClientID: "abc"}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"clientId":"abc"}`, string(raw))
+}
+
+// TestClientsPairedNotification_JSONShape pins the wire shape of the
+// `clients.paired` notification payload broadcast on successful pairing.
+func TestClientsPairedNotification_JSONShape(t *testing.T) {
+	t.Parallel()
+
+	n := ClientsPairedNotification{
+		ClientID:   "id-1",
+		ClientName: "App",
+	}
+	raw, err := json.Marshal(n)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"clientId":"id-1","clientName":"App"}`, string(raw))
+
+	// Also assert no sensitive fields can leak from this notification.
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	for _, k := range []string{"authToken", "pairingKey"} {
+		_, present := got[k]
+		assert.False(t, present,
+			"clients.paired notification must never include %q", k)
 	}
 }

--- a/pkg/api/notifications/notifications.go
+++ b/pkg/api/notifications/notifications.go
@@ -123,3 +123,7 @@ func PlaytimeLimitWarning(ns chan<- models.Notification, payload models.Playtime
 func InboxAdded(ns chan<- models.Notification, payload *models.InboxMessage) {
 	sendNotification(ns, models.NotificationInboxAdded, payload)
 }
+
+func ClientsPaired(ns chan<- models.Notification, payload models.ClientsPairedNotification) {
+	sendNotification(ns, models.NotificationClientsPaired, payload)
+}

--- a/pkg/api/pairing.go
+++ b/pkg/api/pairing.go
@@ -1,0 +1,637 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"context"
+	"crypto/hkdf"
+	"crypto/hmac"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/notifications"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/schollz/pake/v3"
+)
+
+// Pairing constants.
+const (
+	pairingPINLength = 6 // ~20 bits; PAKE prevents offline brute force
+
+	// pairingPINMax is 10^pairingPINLength.
+	pairingPINMax int64 = 1_000_000
+
+	// pairingPINTTL is how long a generated PIN remains valid.
+	pairingPINTTL = 5 * time.Minute
+
+	// pairingSessionTTL is how long a /pair/start session remains valid
+	// before it must be completed via /pair/finish.
+	pairingSessionTTL = 2 * time.Minute
+
+	// pairingMaxAttempts is the maximum number of failed /pair/finish HMAC
+	// verifications across all sessions for a single PIN before the PIN is
+	// invalidated and the user must start over.
+	pairingMaxAttempts = 3
+
+	// pairingMaxClients is the maximum number of paired clients per device.
+	pairingMaxClients = 50
+
+	// pairingMaxNameLen is the maximum length in bytes of a client name.
+	pairingMaxNameLen = 128
+
+	// pairingCleanupInterval is how often the cleanup goroutine runs.
+	pairingCleanupInterval = 1 * time.Minute
+
+	pairingCurve = "p256" // P-256 for Web Crypto API compatibility
+
+	// pairingProtoVersion is the protocol version included in the HMAC
+	// transcript binding to enable future versioning.
+	pairingProtoVersion = "zaparoo-v1"
+
+	pairingMaxPakeMessageBytes = 2048 // ~3× typical message size
+)
+
+// Pairing errors (unexported; public contract is HTTP status codes + JSON).
+var (
+	errPairingInProgress     = errors.New("pairing already in progress")
+	errNoPairingPending      = errors.New("no pairing pending")
+	errPairingExpired        = errors.New("pairing expired")
+	errPairingExhausted      = errors.New("pairing attempts exhausted")
+	errPairingSessionUnknown = errors.New("pairing session unknown")
+	errPairingNameTooLong    = errors.New("client name too long")
+	errPairingNameEmpty      = errors.New("client name required")
+	errTooManyClients        = errors.New("maximum number of paired clients reached")
+	errPairingHMACMismatch   = errors.New("pairing confirmation HMAC mismatch")
+	errPairingMessageTooLong = errors.New("pairing PAKE message too long")
+)
+
+// HKDF info strings used to derive confirmation keys and the long-term
+// pairing key from the raw PAKE session key.
+const (
+	pairingInfoConfirmA = "zaparoo-confirm-A"
+	pairingInfoConfirmB = "zaparoo-confirm-B"
+	pairingInfoPairing  = "zaparoo-pairing-v1"
+)
+
+// pairingSession represents an in-flight PAKE exchange.
+type pairingSession struct {
+	createdAt  time.Time
+	pake       *pake.Pake
+	sessionID  string
+	name       string
+	msgA       []byte // raw bytes received from client at /pair/start
+	msgB       []byte // raw bytes sent to client at /pair/start
+	sessionKey []byte // raw PAKE session key
+}
+
+// PairingManager owns the PIN and in-flight sessions (single mutex protects all state).
+type PairingManager struct {
+	pinExpiresAt    time.Time
+	db              database.UserDBI
+	notifChan       chan<- models.Notification
+	sessions        map[string]*pairingSession
+	pin             string
+	pinAttempts     int
+	maxClients      int
+	maxAttempts     int
+	maxNameLen      int
+	pinTTL          time.Duration
+	sessionTTL      time.Duration
+	cleanupInterval time.Duration
+	mu              syncutil.Mutex
+}
+
+// PairingOption configures a PairingManager at construction time.
+type PairingOption func(*PairingManager)
+
+// WithPairingPINTTL overrides the PIN time-to-live (default 5min).
+func WithPairingPINTTL(d time.Duration) PairingOption {
+	return func(m *PairingManager) { m.pinTTL = d }
+}
+
+// WithPairingSessionTTL overrides the /pair/start session TTL (default 2min).
+func WithPairingSessionTTL(d time.Duration) PairingOption {
+	return func(m *PairingManager) { m.sessionTTL = d }
+}
+
+// WithPairingMaxClients overrides the maximum paired clients (default 50).
+func WithPairingMaxClients(n int) PairingOption {
+	return func(m *PairingManager) { m.maxClients = n }
+}
+
+// WithPairingMaxAttempts overrides the maximum PIN attempts (default 3).
+func WithPairingMaxAttempts(n int) PairingOption {
+	return func(m *PairingManager) { m.maxAttempts = n }
+}
+
+// WithPairingCleanupInterval overrides the cleanup goroutine tick interval.
+func WithPairingCleanupInterval(d time.Duration) PairingOption {
+	return func(m *PairingManager) { m.cleanupInterval = d }
+}
+
+// NewPairingManager constructs a PairingManager (pass nil notifChan to disable notifications).
+func NewPairingManager(
+	db database.UserDBI,
+	notifChan chan<- models.Notification,
+	opts ...PairingOption,
+) *PairingManager {
+	m := &PairingManager{
+		db:              db,
+		notifChan:       notifChan,
+		sessions:        make(map[string]*pairingSession),
+		maxClients:      pairingMaxClients,
+		maxAttempts:     pairingMaxAttempts,
+		maxNameLen:      pairingMaxNameLen,
+		pinTTL:          pairingPINTTL,
+		sessionTTL:      pairingSessionTTL,
+		cleanupInterval: pairingCleanupInterval,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// StartCleanup begins the background cleanup goroutine. The goroutine exits
+// when ctx is canceled. Safe to call multiple times only with distinct
+// contexts; callers should call this once during server startup.
+func (m *PairingManager) StartCleanup(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(m.cleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				m.cleanupExpired()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// PendingPIN returns the currently displayed PIN and its expiry, or an empty
+// PIN if no pairing is in progress.
+func (m *PairingManager) PendingPIN() (pin string, expiresAt time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pin == "" || time.Now().After(m.pinExpiresAt) {
+		return "", time.Time{}
+	}
+	return m.pin, m.pinExpiresAt
+}
+
+// StartPairing generates a new PIN (fails fast if clients are at max).
+func (m *PairingManager) StartPairing() (pin string, expiresAt time.Time, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.pin != "" && time.Now().Before(m.pinExpiresAt) {
+		return "", time.Time{}, errPairingInProgress
+	}
+
+	// Fail fast if full (re-checked in finishSession as defense in depth).
+	count, countErr := m.db.CountClients()
+	if countErr != nil {
+		return "", time.Time{}, fmt.Errorf("count clients: %w", countErr)
+	}
+	if count >= m.maxClients {
+		return "", time.Time{}, errTooManyClients
+	}
+
+	pin, err = generatePIN()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generate pin: %w", err)
+	}
+	m.pin = pin
+	m.pinExpiresAt = time.Now().Add(m.pinTTL)
+	m.pinAttempts = 0
+	// Drop any leftover sessions from a previous PIN — they cannot succeed.
+	m.sessions = make(map[string]*pairingSession)
+	return pin, m.pinExpiresAt, nil
+}
+
+// CancelPairing clears the current PIN and any in-flight sessions. Safe to
+// call when no pairing is in progress.
+func (m *PairingManager) CancelPairing() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearPINLocked()
+}
+
+// clearPINLocked resets all pairing state. Caller must hold mu.
+func (m *PairingManager) clearPINLocked() {
+	m.pin = ""
+	m.pinExpiresAt = time.Time{}
+	m.pinAttempts = 0
+	m.sessions = make(map[string]*pairingSession)
+}
+
+// pairStartRequest is the JSON request body for POST /api/pair/start.
+type pairStartRequest struct {
+	PAKE string `json:"pake"` // base64(client PAKE message A)
+	Name string `json:"name"`
+}
+
+// pairStartResponse is the JSON response body for POST /api/pair/start.
+type pairStartResponse struct {
+	Session string `json:"session"`
+	PAKE    string `json:"pake"` // base64(server PAKE message B)
+}
+
+// pairFinishRequest is the JSON request body for POST /api/pair/finish.
+type pairFinishRequest struct {
+	Session string `json:"session"`
+	Confirm string `json:"confirm"` // base64(client HMAC)
+}
+
+// pairFinishResponse is the JSON response body for POST /api/pair/finish.
+// The pairing key is NEVER transmitted: the client derives it independently
+// from the PAKE session key via HKDF-Expand(prk, "zaparoo-pairing-v1", 32).
+type pairFinishResponse struct {
+	AuthToken string `json:"authToken"`
+	ClientID  string `json:"clientId"`
+	Confirm   string `json:"confirm"` // base64(server HMAC)
+}
+
+// startSession runs the server side of the PAKE exchange and stores a
+// new in-flight session. Returns the sessionID and the server's PAKE
+// message B for the client.
+func (m *PairingManager) startSession(name string, msgA []byte) (sessionID string, msgB []byte, err error) {
+	if name == "" {
+		return "", nil, errPairingNameEmpty
+	}
+	if len(name) > m.maxNameLen {
+		return "", nil, errPairingNameTooLong
+	}
+	if len(msgA) > pairingMaxPakeMessageBytes {
+		return "", nil, errPairingMessageTooLong
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.pin == "" {
+		return "", nil, errNoPairingPending
+	}
+	if time.Now().After(m.pinExpiresAt) {
+		m.clearPINLocked()
+		return "", nil, errPairingExpired
+	}
+	if m.pinAttempts >= m.maxAttempts {
+		m.clearPINLocked()
+		return "", nil, errPairingExhausted
+	}
+
+	// Server initializes as responder (role 1).
+	server, err := pake.InitCurve([]byte(m.pin), 1, pairingCurve)
+	if err != nil {
+		return "", nil, fmt.Errorf("pake init: %w", err)
+	}
+	if updateErr := server.Update(msgA); updateErr != nil {
+		return "", nil, fmt.Errorf("pake update with client message: %w", updateErr)
+	}
+
+	sessionKey, err := server.SessionKey()
+	if err != nil {
+		return "", nil, fmt.Errorf("derive pake session key: %w", err)
+	}
+
+	// Capture serialized state before mutation.
+	msgB = server.Bytes()
+
+	sessionID = uuid.New().String()
+	m.sessions[sessionID] = &pairingSession{
+		sessionID:  sessionID,
+		pake:       server,
+		sessionKey: sessionKey,
+		msgA:       append([]byte(nil), msgA...),
+		msgB:       append([]byte(nil), msgB...),
+		name:       name,
+		createdAt:  time.Now(),
+	}
+	return sessionID, msgB, nil
+}
+
+// PairingResult is the outcome of a successful PAKE handshake. The Client is
+// persisted to the database; the ServerHMAC must be returned to the client so
+// it can verify the server's identity.
+type PairingResult struct {
+	Client     *database.Client
+	ServerHMAC []byte
+}
+
+// finishSession verifies HMAC, persists client, and publishes notification
+// (notification sent after releasing mu to avoid deadlock).
+func (m *PairingManager) finishSession(sessionID string, clientHMAC []byte) (*PairingResult, error) {
+	m.mu.Lock()
+	result, notifyPayload, err := m.finishSessionLocked(sessionID, clientHMAC)
+	m.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	if notifyPayload != nil && m.notifChan != nil {
+		notifications.ClientsPaired(m.notifChan, *notifyPayload)
+	}
+	return result, nil
+}
+
+// finishSessionLocked performs locked pairing validation. Caller must hold mu.
+func (m *PairingManager) finishSessionLocked(
+	sessionID string,
+	clientHMAC []byte,
+) (*PairingResult, *models.ClientsPairedNotification, error) {
+	sess, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, nil, errPairingSessionUnknown
+	}
+
+	if time.Since(sess.createdAt) > m.sessionTTL {
+		delete(m.sessions, sessionID)
+		return nil, nil, errPairingExpired
+	}
+
+	// Derive confirmation keys + pairing key from the raw PAKE session key.
+	prk, err := hkdf.Extract(sha256.New, sess.sessionKey, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hkdf extract: %w", err)
+	}
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hkdf expand confirm A: %w", err)
+	}
+	confirmKeyB, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmB, sha256.Size)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hkdf expand confirm B: %w", err)
+	}
+	derivedPairingKey, err := hkdf.Expand(sha256.New, prk, pairingInfoPairing, crypto.PairingKeySize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hkdf expand pairing key: %w", err)
+	}
+
+	// Verify client HMAC (wrong PIN or brute-force on mismatch).
+	expectedClient := computePairingHMAC(confirmKeyA, "client", sess.name, sess.msgA, sess.msgB)
+	if !hmac.Equal(expectedClient, clientHMAC) {
+		delete(m.sessions, sessionID)
+		m.pinAttempts++
+		if m.pinAttempts >= m.maxAttempts {
+			m.clearPINLocked()
+			return nil, nil, errPairingExhausted
+		}
+		return nil, nil, errPairingHMACMismatch
+	}
+
+	// Enforce client cap (safe without transaction — mu serializes access).
+	count, err := m.db.CountClients()
+	if err != nil {
+		return nil, nil, fmt.Errorf("count clients: %w", err)
+	}
+	if count >= m.maxClients {
+		// Don't reset the PIN — the operator can revoke a client and retry.
+		delete(m.sessions, sessionID)
+		return nil, nil, errTooManyClients
+	}
+
+	now := time.Now().Unix()
+	c := &database.Client{
+		ClientID:   uuid.New().String(),
+		ClientName: sess.name,
+		AuthToken:  uuid.New().String(),
+		PairingKey: derivedPairingKey,
+		CreatedAt:  now,
+		LastSeenAt: now,
+	}
+	if createErr := m.db.CreateClient(c); createErr != nil {
+		return nil, nil, fmt.Errorf("create client: %w", createErr)
+	}
+
+	serverHMAC := computePairingHMAC(confirmKeyB, "server", sess.name, sess.msgA, sess.msgB)
+
+	// Pairing succeeded — clean up state.
+	delete(m.sessions, sessionID)
+	m.clearPINLocked()
+
+	notifyPayload := &models.ClientsPairedNotification{
+		ClientID:   c.ClientID,
+		ClientName: c.ClientName,
+	}
+	return &PairingResult{Client: c, ServerHMAC: serverHMAC}, notifyPayload, nil
+}
+
+// cleanupExpired removes expired PIN and sessions. Called by the cleanup
+// goroutine on each tick.
+func (m *PairingManager) cleanupExpired() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	if m.pin != "" && now.After(m.pinExpiresAt) {
+		log.Debug().Msg("pairing: PIN expired, clearing")
+		// clearPINLocked also wipes m.sessions, so the per-session loop
+		// below is not needed in this branch. Any change that decouples
+		// session wiping from clearPINLocked must drop this early return.
+		m.clearPINLocked()
+		return
+	}
+	for id, sess := range m.sessions {
+		if now.Sub(sess.createdAt) > m.sessionTTL {
+			delete(m.sessions, id)
+		}
+	}
+}
+
+// generatePIN returns a zero-padded decimal PIN of pairingPINLength digits
+// using crypto/rand. Returns an error if the random source fails.
+func generatePIN() (string, error) {
+	n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(pairingPINMax))
+	if err != nil {
+		return "", fmt.Errorf("rand int: %w", err)
+	}
+	return fmt.Sprintf("%0*d", pairingPINLength, n.Int64()), nil
+}
+
+// computePairingHMAC returns HMAC-SHA256 with length-prefixed fields
+// (prevents canonicalization attacks).
+func computePairingHMAC(key []byte, role, name string, msgA, msgB []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	writeLP(h, []byte(pairingProtoVersion))
+	writeLP(h, []byte(pairingCurve))
+	writeLP(h, []byte(role))
+	writeLP(h, []byte(name))
+	writeLP(h, msgA)
+	writeLP(h, msgB)
+	return h.Sum(nil)
+}
+
+// writeLP writes a 4-byte big-endian length prefix then bytes.
+func writeLP(h io.Writer, b []byte) {
+	var lp [4]byte
+	//nolint:gosec // input length is bounded by caller; never exceeds uint32 max
+	binary.BigEndian.PutUint32(lp[:], uint32(len(b)))
+	_, _ = h.Write(lp[:])
+	_, _ = h.Write(b)
+}
+
+// HandlePairStart runs the PAKE exchange and returns sessionID + server message.
+func (m *PairingManager) HandlePairStart() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		const maxBodySize = 16 * 1024
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+		var req pairStartRequest
+		if decErr := json.NewDecoder(r.Body).Decode(&req); decErr != nil {
+			pairingErrorResponse(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		msgA, decErr := base64.StdEncoding.DecodeString(req.PAKE)
+		if decErr != nil || len(msgA) == 0 {
+			pairingErrorResponse(w, http.StatusBadRequest, "invalid pake message")
+			return
+		}
+
+		sessionID, msgB, err := m.startSession(req.Name, msgA)
+		if err != nil {
+			status, msg := pairingErrorStatus(err)
+			pairingErrorResponse(w, status, msg)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, pairStartResponse{
+			Session: sessionID,
+			PAKE:    base64.StdEncoding.EncodeToString(msgB),
+		})
+	}
+}
+
+// HandlePairFinish verifies HMAC, persists client, and returns auth token + confirmation.
+func (m *PairingManager) HandlePairFinish() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		const maxBodySize = 4 * 1024
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+		var req pairFinishRequest
+		if decErr := json.NewDecoder(r.Body).Decode(&req); decErr != nil {
+			pairingErrorResponse(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		clientHMAC, decErr := base64.StdEncoding.DecodeString(req.Confirm)
+		if decErr != nil || len(clientHMAC) == 0 {
+			pairingErrorResponse(w, http.StatusBadRequest, "invalid confirmation")
+			return
+		}
+
+		result, err := m.finishSession(req.Session, clientHMAC)
+		if err != nil {
+			// Audit-log security-relevant failures with the source IP.
+			// Other errors (expired session, unknown session, etc.) are
+			// handled by the generic mapping below.
+			logFailedPairingAttempt(r, err)
+			status, msg := pairingErrorStatus(err)
+			pairingErrorResponse(w, status, msg)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, pairFinishResponse{
+			AuthToken: result.Client.AuthToken,
+			ClientID:  result.Client.ClientID,
+			Confirm:   base64.StdEncoding.EncodeToString(result.ServerHMAC),
+		})
+	}
+}
+
+// logFailedPairingAttempt logs HMAC mismatch and exhaustion (not operational errors).
+func logFailedPairingAttempt(r *http.Request, err error) {
+	switch {
+	case errors.Is(err, errPairingHMACMismatch):
+		log.Warn().
+			Str("source_ip", sourceIPForAudit(r)).
+			Str("event", "pairing_hmac_mismatch").
+			Msg("pairing: failed PIN verification")
+	case errors.Is(err, errPairingExhausted):
+		log.Warn().
+			Str("source_ip", sourceIPForAudit(r)).
+			Str("event", "pairing_attempts_exhausted").
+			Msg("pairing: PIN attempts exhausted, PIN invalidated")
+	}
+}
+
+// sourceIPForAudit returns parsed source IP (or "unknown"), IPv6-safe.
+func sourceIPForAudit(r *http.Request) string {
+	if ip := apimiddleware.ParseRemoteIP(r.RemoteAddr); ip != nil {
+		return ip.String()
+	}
+	return "unknown"
+}
+
+// pairingErrorStatus maps a manager error to the HTTP status + public message.
+func pairingErrorStatus(err error) (status int, msg string) {
+	switch {
+	case errors.Is(err, errNoPairingPending):
+		return http.StatusBadRequest, "no pairing in progress"
+	case errors.Is(err, errPairingExpired):
+		return http.StatusGone, "pairing expired"
+	case errors.Is(err, errPairingExhausted):
+		return http.StatusForbidden, "too many failed attempts"
+	case errors.Is(err, errPairingSessionUnknown):
+		return http.StatusNotFound, "unknown pairing session"
+	case errors.Is(err, errPairingNameTooLong):
+		return http.StatusBadRequest, "client name too long"
+	case errors.Is(err, errPairingNameEmpty):
+		return http.StatusBadRequest, "client name required"
+	case errors.Is(err, errPairingMessageTooLong):
+		return http.StatusBadRequest, "PAKE message too long"
+	case errors.Is(err, errTooManyClients):
+		return http.StatusForbidden, "maximum paired clients reached"
+	case errors.Is(err, errPairingHMACMismatch):
+		return http.StatusUnauthorized, "wrong PIN"
+	default:
+		log.Error().Err(err).Msg("pairing internal error")
+		return http.StatusInternalServerError, "internal error"
+	}
+}
+
+// pairingErrorResponse writes a JSON error to the HTTP response.
+func pairingErrorResponse(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+// writeJSON writes a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		log.Error().Err(err).Msg("failed to encode JSON response")
+	}
+}

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -684,13 +684,17 @@ func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
 	t.Cleanup(func() { log.Logger = originalLogger })
 
 	h := newPairingHarness(t, WithPairingMaxAttempts(1))
-	_, _, err := h.mgr.StartPairing()
+	pin, _, err := h.mgr.StartPairing()
 	require.NoError(t, err)
 
 	// One allowed attempt → first failure trips errPairingExhausted.
 	// Drive the failed attempt through the HTTP handler so the audit log
 	// path is exercised.
-	wrongPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	wrongPIN := "000000"
+	if pin == wrongPIN {
+		wrongPIN = "111111"
+	}
+	wrongPake, err := pake.InitCurve([]byte(wrongPIN), 0, pairingCurve)
 	require.NoError(t, err)
 	msgA := wrongPake.Bytes()
 	startBody, err := json.Marshal(pairStartRequest{

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -1,0 +1,873 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"bytes"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/schollz/pake/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// pairingTestHarness wraps a manager and a mock DB so tests can simulate the
+// full pair flow without HTTP plumbing.
+type pairingTestHarness struct {
+	mgr       *PairingManager
+	db        *helpers.MockUserDBI
+	notifChan chan models.Notification
+	created   *atomic.Pointer[database.Client]
+}
+
+func newPairingHarness(t *testing.T, opts ...PairingOption) *pairingTestHarness {
+	t.Helper()
+	db := helpers.NewMockUserDBI()
+	notifChan := make(chan models.Notification, 16)
+	created := &atomic.Pointer[database.Client]{}
+
+	db.On("CountClients").Return(0, nil).Maybe()
+	db.On("CreateClient", mock.AnythingOfType("*database.Client")).
+		Run(func(args mock.Arguments) {
+			c, ok := args.Get(0).(*database.Client)
+			if !ok || c == nil {
+				return
+			}
+			cp := *c
+			created.Store(&cp)
+		}).
+		Return(nil).
+		Maybe()
+
+	mgr := NewPairingManager(db, notifChan, opts...)
+	return &pairingTestHarness{
+		mgr:       mgr,
+		db:        db,
+		notifChan: notifChan,
+		created:   created,
+	}
+}
+
+// runHandshake executes a successful PAKE handshake against the manager and
+// returns the resulting Client + the pairing key the client derived. Tests
+// that need wrong-PIN behavior can call the lower-level methods directly.
+func (h *pairingTestHarness) runHandshake(
+	t *testing.T,
+	pin, name string,
+) (clientResp *database.Client, pairingKey []byte) {
+	t.Helper()
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := clientPake.Bytes()
+
+	sessionID, msgB, err := h.mgr.startSession(name, msgA)
+	require.NoError(t, err)
+
+	require.NoError(t, clientPake.Update(msgB))
+	clientSessionKey, err := clientPake.SessionKey()
+	require.NoError(t, err)
+
+	prk, err := hkdf.Extract(sha256.New, clientSessionKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	confirmKeyB, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmB, sha256.Size)
+	require.NoError(t, err)
+	derivedPairingKey, err := hkdf.Expand(sha256.New, prk, pairingInfoPairing, crypto.PairingKeySize)
+	require.NoError(t, err)
+
+	clientHMAC := computePairingHMAC(confirmKeyA, "client", name, msgA, msgB)
+
+	result, err := h.mgr.finishSession(sessionID, clientHMAC)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Client)
+
+	expectedServer := computePairingHMAC(confirmKeyB, "server", name, msgA, msgB)
+	require.Equal(t, expectedServer, result.ServerHMAC, "server HMAC must match what client computes")
+	require.Equal(t, derivedPairingKey, result.Client.PairingKey, "pairing keys must agree")
+
+	return result.Client, result.Client.PairingKey
+}
+
+func TestStartPairing_GeneratesPIN(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, expiresAt, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	assert.Len(t, pin, pairingPINLength)
+	for _, c := range pin {
+		assert.True(t, c >= '0' && c <= '9', "PIN must be all digits, got %q", pin)
+	}
+	assert.True(t, expiresAt.After(time.Now()), "expiry must be in the future")
+}
+
+func TestStartPairing_AlreadyInProgress(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+	_, _, err = h.mgr.StartPairing()
+	require.ErrorIs(t, err, errPairingInProgress)
+}
+
+func TestStartPairing_AfterCancel(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+	h.mgr.CancelPairing()
+	_, _, err = h.mgr.StartPairing()
+	require.NoError(t, err, "should be able to start a new pairing after cancel")
+}
+
+func TestStartPairing_AfterExpiry(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingPINTTL(10*time.Millisecond))
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	time.Sleep(20 * time.Millisecond)
+
+	_, _, err = h.mgr.StartPairing()
+	require.NoError(t, err, "expired PIN should not block a new one")
+}
+
+func TestPendingPIN_Empty(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, _ := h.mgr.PendingPIN()
+	assert.Empty(t, pin)
+}
+
+func TestPendingPIN_Active(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	gotPIN, _ := h.mgr.PendingPIN()
+	assert.Equal(t, pin, gotPIN)
+}
+
+func TestPendingPIN_Expired(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingPINTTL(5*time.Millisecond))
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+	time.Sleep(15 * time.Millisecond)
+
+	pin, _ := h.mgr.PendingPIN()
+	assert.Empty(t, pin, "expired PIN should not be returned")
+}
+
+// TestStartSession_RejectsOversizedPakeMessage pins the input length cap
+// for the PAKE message. The cap is well above any legitimate message size
+// (a real P-256 client message is ~633 bytes vs the 2048-byte cap), so
+// the cap only kicks in for clearly-malformed input.
+func TestStartSession_RejectsOversizedPakeMessage(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	huge := make([]byte, pairingMaxPakeMessageBytes+1)
+	_, _, err = h.mgr.startSession("Test App", huge)
+	require.ErrorIs(t, err, errPairingMessageTooLong)
+}
+
+func TestSuccessfulHandshake(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	c, pairingKey := h.runHandshake(t, pin, "Test App")
+
+	assert.NotEmpty(t, c.ClientID)
+	assert.NotEmpty(t, c.AuthToken)
+	assert.Equal(t, "Test App", c.ClientName)
+	assert.Len(t, pairingKey, crypto.PairingKeySize)
+
+	// PIN should have been cleared
+	pin2, _ := h.mgr.PendingPIN()
+	assert.Empty(t, pin2)
+
+	// Notification should have been sent
+	select {
+	case notif := <-h.notifChan:
+		assert.Equal(t, models.NotificationClientsPaired, notif.Method)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected clients.paired notification")
+	}
+}
+
+func TestWrongPIN_Rejected(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// Use a wrong PIN — different session key, HMAC will not match.
+	wrongPake, err := pake.InitCurve([]byte("999999"), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := wrongPake.Bytes()
+	sessionID, msgB, err := h.mgr.startSession("App", msgA)
+	require.NoError(t, err)
+
+	require.NoError(t, wrongPake.Update(msgB))
+	clientKey, err := wrongPake.SessionKey()
+	require.NoError(t, err)
+
+	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+
+	// Compute an HMAC with the wrong key — server will reject it.
+	wrongHMAC := computePairingHMAC(confirmKeyA, "client", "App", msgA, msgB)
+	_, err = h.mgr.finishSession(sessionID, wrongHMAC)
+	require.ErrorIs(t, err, errPairingHMACMismatch)
+}
+
+func TestMaxAttempts_PINInvalidatedAfterExhaustion(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingMaxAttempts(2))
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	for i := range 2 {
+		wrongPake, pkErr := pake.InitCurve([]byte("999999"), 0, pairingCurve)
+		require.NoError(t, pkErr)
+		msgA := wrongPake.Bytes()
+		sessionID, _, sErr := h.mgr.startSession("App", msgA)
+		require.NoError(t, sErr)
+		_, finishErr := h.mgr.finishSession(sessionID, []byte("garbage hmac"))
+		if i < 1 {
+			require.ErrorIs(t, finishErr, errPairingHMACMismatch, "attempt %d should mismatch", i)
+		} else {
+			require.ErrorIs(t, finishErr, errPairingExhausted, "final attempt should exhaust")
+		}
+	}
+
+	// PIN should be cleared
+	pin, _ := h.mgr.PendingPIN()
+	assert.Empty(t, pin)
+}
+
+func TestPairStart_NameTooLong(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession(strings.Repeat("a", pairingMaxNameLen+1), clientPake.Bytes())
+	require.ErrorIs(t, err, errPairingNameTooLong)
+}
+
+func TestPairStart_NameEmpty(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession("", clientPake.Bytes())
+	require.ErrorIs(t, err, errPairingNameEmpty)
+}
+
+func TestPairStart_NoPendingPIN(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	clientPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession("App", clientPake.Bytes())
+	require.ErrorIs(t, err, errNoPairingPending)
+}
+
+func TestPairStart_PINExpired(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingPINTTL(5*time.Millisecond))
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+	time.Sleep(15 * time.Millisecond)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession("App", clientPake.Bytes())
+	require.ErrorIs(t, err, errPairingExpired)
+}
+
+func TestPairFinish_SessionExpired(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingSessionTTL(5*time.Millisecond))
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	sessionID, _, err := h.mgr.startSession("App", clientPake.Bytes())
+	require.NoError(t, err)
+
+	time.Sleep(15 * time.Millisecond)
+
+	_, err = h.mgr.finishSession(sessionID, []byte("anything"))
+	require.ErrorIs(t, err, errPairingExpired)
+}
+
+func TestPairFinish_UnknownSession(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, err := h.mgr.finishSession("nonexistent", []byte("x"))
+	require.ErrorIs(t, err, errPairingSessionUnknown)
+}
+
+// TestPairFinish_ConcurrentCallsOneWins pins that two concurrent
+// finishSession calls with the same sessionID serialize correctly: exactly
+// one succeeds, and the other gets errPairingSessionUnknown because the
+// winning goroutine deleted the session under the lock.
+func TestPairFinish_ConcurrentCallsOneWins(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := clientPake.Bytes()
+
+	sessionID, msgB, err := h.mgr.startSession("ConcurrentApp", msgA)
+	require.NoError(t, err)
+
+	require.NoError(t, clientPake.Update(msgB))
+	sessionKey, err := clientPake.SessionKey()
+	require.NoError(t, err)
+
+	prk, err := hkdf.Extract(sha256.New, sessionKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	validHMAC := computePairingHMAC(confirmKeyA, "client", "ConcurrentApp", msgA, msgB)
+
+	type result struct {
+		res *PairingResult
+		err error
+	}
+	ch := make(chan result, 2)
+
+	for range 2 {
+		go func() {
+			r, finishErr := h.mgr.finishSession(sessionID, validHMAC)
+			ch <- result{res: r, err: finishErr}
+		}()
+	}
+
+	r1 := <-ch
+	r2 := <-ch
+
+	successes := 0
+	unknowns := 0
+	for _, r := range []result{r1, r2} {
+		switch r.err { //nolint:errorlint // exhaustive expected-error matching
+		case nil:
+			require.NotNil(t, r.res, "successful result must be non-nil")
+			successes++
+		default:
+			require.ErrorIs(t, r.err, errPairingSessionUnknown,
+				"the loser must see errPairingSessionUnknown, not a different error")
+			unknowns++
+		}
+	}
+	assert.Equal(t, 1, successes, "exactly one goroutine must succeed")
+	assert.Equal(t, 1, unknowns, "exactly one goroutine must lose")
+}
+
+// TestMaxClients_StartPairingFailsFast pins the fail-fast behavior in
+// StartPairing: when the client table is already at max, the operator
+// must not even get a PIN. This avoids the bad UX where the operator
+// types a PIN into a new device only to be rejected at /pair/finish.
+func TestMaxClients_StartPairingFailsFast(t *testing.T) {
+	t.Parallel()
+	db := helpers.NewMockUserDBI()
+	notifChan := make(chan models.Notification, 4)
+	db.On("CountClients").Return(50, nil)
+	mgr := NewPairingManager(db, notifChan, WithPairingMaxClients(50))
+
+	_, _, err := mgr.StartPairing()
+	require.ErrorIs(t, err, errTooManyClients)
+}
+
+// TestMaxClients_FinishSessionDefenseInDepth covers the residual
+// finishSession check that fires when a client is added between
+// StartPairing and finishSession. There is no production code path that
+// can do this today (the only way to add a client is via the same
+// PairingManager under m.mu), but the check exists as defense in depth
+// and we don't want it to silently rot.
+func TestMaxClients_FinishSessionDefenseInDepth(t *testing.T) {
+	t.Parallel()
+	db := helpers.NewMockUserDBI()
+	notifChan := make(chan models.Notification, 4)
+	// First CountClients (StartPairing) → 0 ⇒ proceed.
+	// Subsequent CountClients (finishSession) → 50 ⇒ reject.
+	db.On("CountClients").Return(0, nil).Once()
+	db.On("CountClients").Return(50, nil)
+	mgr := NewPairingManager(db, notifChan, WithPairingMaxClients(50))
+
+	pin, _, err := mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := clientPake.Bytes()
+	sessionID, msgB, err := mgr.startSession("App", msgA)
+	require.NoError(t, err)
+
+	require.NoError(t, clientPake.Update(msgB))
+	clientKey, err := clientPake.SessionKey()
+	require.NoError(t, err)
+	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	clientHMAC := computePairingHMAC(confirmKeyA, "client", "App", msgA, msgB)
+
+	_, err = mgr.finishSession(sessionID, clientHMAC)
+	require.ErrorIs(t, err, errTooManyClients)
+}
+
+func TestStartPairing_WipesOldSessions(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin1, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin1), 0, pairingCurve)
+	require.NoError(t, err)
+	sessionID, _, err := h.mgr.startSession("App", clientPake.Bytes())
+	require.NoError(t, err)
+
+	h.mgr.CancelPairing()
+	_, _, err = h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// Old session should no longer be findable.
+	_, err = h.mgr.finishSession(sessionID, []byte("x"))
+	require.ErrorIs(t, err, errPairingSessionUnknown)
+}
+
+func TestHTTPHandlers_FullFlow(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	startHandler := h.mgr.HandlePairStart()
+	finishHandler := h.mgr.HandlePairFinish()
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := clientPake.Bytes()
+
+	startBody, err := json.Marshal(pairStartRequest{
+		PAKE: base64.StdEncoding.EncodeToString(msgA),
+		Name: "Web App",
+	})
+	require.NoError(t, err)
+
+	startReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader(string(startBody)))
+	startReq.Header.Set("Content-Type", "application/json")
+	startRec := httptest.NewRecorder()
+	startHandler.ServeHTTP(startRec, startReq)
+	require.Equal(t, http.StatusOK, startRec.Code, "start: %s", startRec.Body.String())
+
+	var startResp pairStartResponse
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	require.NotEmpty(t, startResp.Session)
+
+	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
+	require.NoError(t, err)
+
+	require.NoError(t, clientPake.Update(msgB))
+	clientKey, err := clientPake.SessionKey()
+	require.NoError(t, err)
+	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	confirmKeyB, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmB, sha256.Size)
+	require.NoError(t, err)
+	derivedPairingKey, err := hkdf.Expand(sha256.New, prk, pairingInfoPairing, crypto.PairingKeySize)
+	require.NoError(t, err)
+
+	clientHMAC := computePairingHMAC(confirmKeyA, "client", "Web App", msgA, msgB)
+
+	finishBody, err := json.Marshal(pairFinishRequest{
+		Session: startResp.Session,
+		Confirm: base64.StdEncoding.EncodeToString(clientHMAC),
+	})
+	require.NoError(t, err)
+
+	finishReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/finish",
+		strings.NewReader(string(finishBody)))
+	finishReq.Header.Set("Content-Type", "application/json")
+	finishRec := httptest.NewRecorder()
+	finishHandler.ServeHTTP(finishRec, finishReq)
+	require.Equal(t, http.StatusOK, finishRec.Code, "finish: %s", finishRec.Body.String())
+
+	var finishResp pairFinishResponse
+	require.NoError(t, json.Unmarshal(finishRec.Body.Bytes(), &finishResp))
+
+	assert.NotEmpty(t, finishResp.AuthToken)
+	assert.NotEmpty(t, finishResp.ClientID)
+
+	// The pairing key MUST NOT be on the wire — verify by checking the
+	// JSON body has no pairingKey field at all.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(finishRec.Body.Bytes(), &raw))
+	_, leaked := raw["pairingKey"]
+	assert.False(t, leaked, "pairingKey must not be transmitted in /pair/finish response")
+
+	// The client derives the pairing key locally; verify it matches what
+	// the server stored in the database.
+	storedClient := h.created.Load()
+	require.NotNil(t, storedClient, "CreateClient must have been called")
+	assert.Equal(t, derivedPairingKey, storedClient.PairingKey,
+		"client-derived pairing key must match what the server stored")
+
+	gotServerHMAC, err := base64.StdEncoding.DecodeString(finishResp.Confirm)
+	require.NoError(t, err)
+	expectedServerHMAC := computePairingHMAC(confirmKeyB, "server", "Web App", msgA, msgB)
+	assert.Equal(t, expectedServerHMAC, gotServerHMAC, "server HMAC must match")
+}
+
+// TestHandlePairFinish_AuditLogsHMACMismatch verifies that a wrong-PIN
+// /pair/finish attempt produces a warn-level audit log line including the
+// source IP and the pairing_hmac_mismatch event tag.
+//
+// Not t.Parallel — mutates the global zerolog logger to capture output.
+func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	h := newPairingHarness(t)
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// Drive a wrong-PIN handshake at the HTTP layer so the handler runs
+	// the audit log path. Use a wrong PAKE password — the resulting HMAC
+	// will not match the server's expected value.
+	startHandler := h.mgr.HandlePairStart()
+	finishHandler := h.mgr.HandlePairFinish()
+
+	wrongPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	require.NoError(t, err)
+	if pin == "000000" {
+		// Astronomically unlikely but possible — use a different wrong PIN.
+		wrongPake, err = pake.InitCurve([]byte("111111"), 0, pairingCurve)
+		require.NoError(t, err)
+	}
+	msgA := wrongPake.Bytes()
+
+	startBody, err := json.Marshal(pairStartRequest{
+		PAKE: base64.StdEncoding.EncodeToString(msgA),
+		Name: "App",
+	})
+	require.NoError(t, err)
+	startReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader(string(startBody)))
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.RemoteAddr = "203.0.113.42:54321"
+	startRec := httptest.NewRecorder()
+	startHandler.ServeHTTP(startRec, startReq)
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp pairStartResponse
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
+	require.NoError(t, err)
+	require.NoError(t, wrongPake.Update(msgB))
+	clientKey, err := wrongPake.SessionKey()
+	require.NoError(t, err)
+	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	wrongHMAC := computePairingHMAC(confirmKeyA, "client", "App", msgA, msgB)
+
+	finishBody, err := json.Marshal(pairFinishRequest{
+		Session: startResp.Session,
+		Confirm: base64.StdEncoding.EncodeToString(wrongHMAC),
+	})
+	require.NoError(t, err)
+	finishReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/finish",
+		strings.NewReader(string(finishBody)))
+	finishReq.Header.Set("Content-Type", "application/json")
+	finishReq.RemoteAddr = "203.0.113.42:54321"
+	finishRec := httptest.NewRecorder()
+	finishHandler.ServeHTTP(finishRec, finishReq)
+	require.Equal(t, http.StatusUnauthorized, finishRec.Code)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "pairing_hmac_mismatch", "audit log must tag the event")
+	assert.Contains(t, logged, "203.0.113.42", "audit log must include source IP")
+}
+
+// TestHandlePairFinish_AuditLogsExhaustion verifies that exhausting the
+// PIN attempts via the HTTP handler produces a pairing_attempts_exhausted
+// audit log line.
+//
+// Not t.Parallel — mutates the global zerolog logger.
+func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	h := newPairingHarness(t, WithPairingMaxAttempts(1))
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// One allowed attempt → first failure trips errPairingExhausted.
+	// Drive the failed attempt through the HTTP handler so the audit log
+	// path is exercised.
+	wrongPake, err := pake.InitCurve([]byte("000000"), 0, pairingCurve)
+	require.NoError(t, err)
+	msgA := wrongPake.Bytes()
+	startBody, err := json.Marshal(pairStartRequest{
+		PAKE: base64.StdEncoding.EncodeToString(msgA),
+		Name: "App",
+	})
+	require.NoError(t, err)
+	startReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader(string(startBody)))
+	startReq.Header.Set("Content-Type", "application/json")
+	startReq.RemoteAddr = "198.51.100.7:8080"
+	startRec := httptest.NewRecorder()
+	h.mgr.HandlePairStart().ServeHTTP(startRec, startReq)
+	require.Equal(t, http.StatusOK, startRec.Code)
+
+	var startResp pairStartResponse
+	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
+	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
+	require.NoError(t, err)
+	require.NoError(t, wrongPake.Update(msgB))
+	clientKey, err := wrongPake.SessionKey()
+	require.NoError(t, err)
+	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	wrongHMAC := computePairingHMAC(confirmKeyA, "client", "App", msgA, msgB)
+
+	finishBody, err := json.Marshal(pairFinishRequest{
+		Session: startResp.Session,
+		Confirm: base64.StdEncoding.EncodeToString(wrongHMAC),
+	})
+	require.NoError(t, err)
+	finishReq := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/finish",
+		strings.NewReader(string(finishBody)))
+	finishReq.Header.Set("Content-Type", "application/json")
+	finishReq.RemoteAddr = "198.51.100.7:8080"
+	finishRec := httptest.NewRecorder()
+	h.mgr.HandlePairFinish().ServeHTTP(finishRec, finishReq)
+	require.Equal(t, http.StatusForbidden, finishRec.Code)
+
+	logged := buf.String()
+	assert.Contains(t, logged, "pairing_attempts_exhausted",
+		"audit log must tag the exhaustion event")
+	assert.Contains(t, logged, "198.51.100.7",
+		"audit log must include source IP")
+}
+
+func TestHTTPHandler_BadRequestJSON(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+	startHandler := h.mgr.HandlePairStart()
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader("not json"))
+	rec := httptest.NewRecorder()
+	startHandler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHTTPHandler_BadBase64(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+	startHandler := h.mgr.HandlePairStart()
+
+	body, err := json.Marshal(pairStartRequest{PAKE: "not-base64!!", Name: "App"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	startHandler.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestGeneratePIN_AllDigits(t *testing.T) {
+	t.Parallel()
+	for range 100 {
+		pin, err := generatePIN()
+		require.NoError(t, err)
+		assert.Len(t, pin, pairingPINLength)
+		for _, c := range pin {
+			assert.True(t, c >= '0' && c <= '9', "non-digit in pin %q", pin)
+		}
+	}
+}
+
+func TestComputePairingHMAC_Deterministic(t *testing.T) {
+	t.Parallel()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	a := computePairingHMAC(key, "client", "App", []byte("a"), []byte("b"))
+	b := computePairingHMAC(key, "client", "App", []byte("a"), []byte("b"))
+	assert.Equal(t, a, b)
+}
+
+func TestComputePairingHMAC_DifferentRolesDifferent(t *testing.T) {
+	t.Parallel()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	a := computePairingHMAC(key, "client", "App", []byte("a"), []byte("b"))
+	b := computePairingHMAC(key, "server", "App", []byte("a"), []byte("b"))
+	assert.NotEqual(t, a, b)
+}
+
+func TestComputePairingHMAC_LengthPrefixingPreventsCollision(t *testing.T) {
+	t.Parallel()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	// Without length prefixing, "ab" + "c" and "a" + "bc" would produce the
+	// same HMAC for the same role/version. With length prefixing, they must
+	// differ.
+	a := computePairingHMAC(key, "client", "ab", []byte("c"), []byte("d"))
+	b := computePairingHMAC(key, "client", "a", []byte("bc"), []byte("d"))
+	assert.NotEqual(t, a, b, "length prefix must prevent canonicalization collision")
+}
+
+// TestComputePairingHMAC_RoleNameBoundary pins the length-prefix protection
+// at the (role | name) field boundary. Without length-prefixing, an attacker
+// could shift characters between role and name to forge an HMAC for a
+// different (role, name) pair that hashes to the same input bytes.
+func TestComputePairingHMAC_RoleNameBoundary(t *testing.T) {
+	t.Parallel()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	// Both inputs have role+name = "clientApp" if naively concatenated.
+	a := computePairingHMAC(key, "client", "App", []byte("msgA"), []byte("msgB"))
+	b := computePairingHMAC(key, "clien", "tApp", []byte("msgA"), []byte("msgB"))
+	assert.NotEqual(t, a, b,
+		"length prefix must distinguish (role=client, name=App) from (role=clien, name=tApp)")
+}
+
+// TestComputePairingHMAC_MsgABoundary pins the length-prefix protection at
+// the (msgA | msgB) field boundary. PAKE messages have fixed structure in
+// production, but the HMAC scheme must still defend against canonicalization
+// across this boundary in case message lengths ever vary.
+func TestComputePairingHMAC_MsgABoundary(t *testing.T) {
+	t.Parallel()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	// Both inputs have msgA+msgB = "abc" if naively concatenated.
+	a := computePairingHMAC(key, "client", "App", []byte("ab"), []byte("c"))
+	b := computePairingHMAC(key, "client", "App", []byte("a"), []byte("bc"))
+	assert.NotEqual(t, a, b,
+		"length prefix must distinguish (msgA=ab, msgB=c) from (msgA=a, msgB=bc)")
+}
+
+func TestCleanupExpired_RemovesOldSessions(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t,
+		WithPairingPINTTL(time.Hour),
+		WithPairingSessionTTL(5*time.Millisecond),
+	)
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession("App", clientPake.Bytes())
+	require.NoError(t, err)
+
+	time.Sleep(15 * time.Millisecond)
+	h.mgr.cleanupExpired()
+
+	h.mgr.mu.Lock()
+	defer h.mgr.mu.Unlock()
+	assert.Empty(t, h.mgr.sessions, "expired session should be removed")
+	assert.NotEmpty(t, h.mgr.pin, "PIN should still be valid")
+}
+
+func TestCleanupExpired_RemovesExpiredPIN(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t, WithPairingPINTTL(5*time.Millisecond))
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	time.Sleep(15 * time.Millisecond)
+	h.mgr.cleanupExpired()
+
+	pin, _ := h.mgr.PendingPIN()
+	assert.Empty(t, pin)
+}

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -160,12 +160,12 @@ func TestStartPairing_AfterCancel(t *testing.T) {
 
 func TestStartPairing_AfterExpiry(t *testing.T) {
 	t.Parallel()
-	h := newPairingHarness(t, WithPairingPINTTL(10*time.Millisecond))
+	h := newPairingHarness(t, WithPairingPINTTL(50*time.Millisecond))
 
 	_, _, err := h.mgr.StartPairing()
 	require.NoError(t, err)
 
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	_, _, err = h.mgr.StartPairing()
 	require.NoError(t, err, "expired PIN should not block a new one")

--- a/pkg/api/router_wiring_test.go
+++ b/pkg/api/router_wiring_test.go
@@ -1,0 +1,251 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// buildWiringTestRouter constructs a minimal chi router that mirrors the
+// middleware stack and route grouping in api.Start(). Handlers are stub
+// "OK" responders so the test can isolate middleware behavior — the goal
+// is to assert that the right middleware is applied to the right route
+// group, not to exercise the underlying handler logic (which is covered
+// by unit tests in this package).
+//
+// IMPORTANT: this duplicates the wiring shape from server.go's Start().
+// If the production wiring drifts (a middleware moves between groups,
+// a new group is added, etc.), this test will not catch it. Code review
+// is the safety net for that drift; this test catches regressions in
+// the *behavior* of the wiring as it exists today.
+func buildWiringTestRouter(allowedIPs []string) http.Handler {
+	r := chi.NewRouter()
+
+	rateLimiter := apimiddleware.NewIPRateLimiter()
+	// Pairing limiter: 1 req/sec, burst 1 — same as api.Start().
+	pairingRateLimiter := apimiddleware.NewIPRateLimiterWithLimits(rate.Limit(1), 1)
+
+	apiRateLimitMiddleware := apimiddleware.HTTPRateLimitMiddleware(rateLimiter)
+	pairingRateMiddleware := apimiddleware.HTTPRateLimitMiddleware(pairingRateLimiter)
+	nonWSIPFilter := apimiddleware.NonWSIPFilterMiddleware(func() []string {
+		return allowedIPs
+	})
+
+	stubOK := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}
+
+	// Pairing group: stacked rate limiters (general first, pairing
+	// second), no IP filter.
+	r.Group(func(r chi.Router) {
+		r.Use(apiRateLimitMiddleware)
+		r.Use(pairingRateMiddleware)
+		r.Post("/api/pair/start", stubOK)
+		r.Post("/api/pair/finish", stubOK)
+	})
+
+	// WebSocket group: rate limiter only, no IP filter (encryption
+	// or API key auth handles security inside the upgrade).
+	r.Group(func(r chi.Router) {
+		r.Use(apiRateLimitMiddleware)
+		r.Get("/api", stubOK)
+		r.Get("/api/v0", stubOK)
+		r.Get("/api/v0.1", stubOK)
+	})
+
+	// Non-WS group: NonWSIPFilter + rate limiter — locked down to
+	// localhost / AllowedIPs.
+	r.Group(func(r chi.Router) {
+		r.Use(nonWSIPFilter)
+		r.Use(apiRateLimitMiddleware)
+		r.Post("/api", stubOK)
+		r.Post("/api/v0", stubOK)
+		r.Post("/api/v0.1", stubOK)
+		r.Get("/r/*", stubOK)
+		r.Get("/run/*", stubOK)
+	})
+
+	// SSE group: same as non-WS group.
+	r.Group(func(r chi.Router) {
+		r.Use(nonWSIPFilter)
+		r.Use(apiRateLimitMiddleware)
+		r.Get("/api/events", stubOK)
+		r.Get("/api/v0/events", stubOK)
+		r.Get("/api/v0.1/events", stubOK)
+	})
+
+	// Outer router endpoints — no per-group middleware.
+	r.Get("/health", stubOK)
+	r.Get("/app/*", stubOK)
+
+	return r
+}
+
+func doWiringRequest(
+	t *testing.T,
+	srv *httptest.Server,
+	method, path, remoteAddr string,
+) (status int, body string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, srv.URL+path, http.NoBody)
+	require.NoError(t, err)
+
+	// Override the source IP that the server sees by routing through a
+	// custom dialer is overkill — the simplest path is to issue the
+	// request via the test server's handler directly with a fabricated
+	// RemoteAddr.
+	rec := httptest.NewRecorder()
+	httpReq := req.Clone(req.Context())
+	httpReq.RemoteAddr = remoteAddr
+	srv.Config.Handler.ServeHTTP(rec, httpReq)
+
+	bodyBytes, err := io.ReadAll(rec.Body)
+	require.NoError(t, err)
+	return rec.Code, string(bodyBytes)
+}
+
+// TestRouterWiring_PairingReachableFromRemote pins that the pairing
+// endpoints are NOT behind NonWSIPFilterMiddleware — a remote client
+// must be able to start pairing without being on the AllowedIPs list.
+func TestRouterWiring_PairingReachableFromRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodPost, "/api/pair/start", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusOK, status,
+		"pairing route must be reachable from a remote IP without AllowedIPs")
+}
+
+// TestRouterWiring_PairingRateLimited pins that the strict pairing
+// rate limiter is wired into the pairing group: a second back-to-back
+// request from the same IP must hit the burst-1 limit.
+func TestRouterWiring_PairingRateLimited(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	const remote = "203.0.113.7:11111"
+	status1, _ := doWiringRequest(t, srv, http.MethodPost, "/api/pair/start", remote)
+	require.Equal(t, http.StatusOK, status1, "first pairing request must succeed")
+
+	// Burst is 1, so the second back-to-back request from the same IP
+	// must be rejected by the pairing rate limiter (or by the stacked
+	// general limiter if the burst lines up; either is acceptable).
+	status2, _ := doWiringRequest(t, srv, http.MethodPost, "/api/pair/start", remote)
+	assert.Equal(t, http.StatusTooManyRequests, status2,
+		"second back-to-back pairing request from the same IP must be rate-limited")
+}
+
+// TestRouterWiring_NonWSDeniesRemoteEmptyAllowlist pins that POST /api
+// (non-WS HTTP transport) is locked down to localhost when AllowedIPs
+// is empty: a remote client must get 403, not 200.
+func TestRouterWiring_NonWSDeniesRemoteEmptyAllowlist(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodPost, "/api", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusForbidden, status,
+		"non-WS POST from remote must be denied with empty AllowedIPs")
+}
+
+// TestRouterWiring_NonWSAllowsLoopback pins that loopback addresses
+// always bypass NonWSIPFilterMiddleware, even with an empty allowlist.
+func TestRouterWiring_NonWSAllowsLoopback(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodPost, "/api", "127.0.0.1:54321")
+	assert.Equal(t, http.StatusOK, status,
+		"non-WS POST from loopback must succeed even with empty AllowedIPs")
+}
+
+// TestRouterWiring_NonWSAllowsExplicitlyAllowedRemote pins that a remote
+// IP listed in AllowedIPs is allowed through.
+func TestRouterWiring_NonWSAllowsExplicitlyAllowedRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter([]string{"203.0.113.5"}))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodPost, "/api", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusOK, status,
+		"non-WS POST from explicitly allowed remote IP must succeed")
+}
+
+// TestRouterWiring_SSEDeniesRemoteEmptyAllowlist pins that the SSE
+// routes share the non-WS lockdown: empty AllowedIPs ⇒ remote 403.
+func TestRouterWiring_SSEDeniesRemoteEmptyAllowlist(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodGet, "/api/events", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusForbidden, status,
+		"SSE GET from remote must be denied with empty AllowedIPs")
+}
+
+// TestRouterWiring_HealthReachableFromRemote pins the behavior that /health
+// is in the outer router and reachable from any IP (load balancers, uptime
+// checks, app discovery flow).
+func TestRouterWiring_HealthReachableFromRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, body := doWiringRequest(t, srv, http.MethodGet, "/health", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusOK, status,
+		"/health must be reachable from a remote IP without AllowedIPs")
+	assert.Equal(t, "ok", strings.TrimSpace(body))
+}
+
+// TestRouterWiring_AppReachableFromRemote pins that /app/* is in the
+// outer router and reachable from any IP (the web app is the primary
+// way users interact with their device).
+func TestRouterWiring_AppReachableFromRemote(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(buildWiringTestRouter(nil))
+	defer srv.Close()
+
+	status, _ := doWiringRequest(t, srv, http.MethodGet, "/app/index.html", "203.0.113.5:54321")
+	assert.Equal(t, http.StatusOK, status,
+		"/app/* must be reachable from a remote IP without AllowedIPs")
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/olahol/melody"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/time/rate"
 )
 
 var allowedOrigins = []string{
@@ -269,6 +270,9 @@ func NewMethodMap() *MethodMap {
 		models.MethodInbox:       methods.HandleInbox,
 		models.MethodInboxDelete: methods.HandleInboxDelete,
 		models.MethodInboxClear:  methods.HandleInboxClear,
+		// clients (paired API clients)
+		models.MethodClients:       methods.HandleClients,
+		models.MethodClientsDelete: methods.HandleClientsDelete,
 		// auth
 		models.MethodSettingsAuthClaim: func(env requests.RequestEnv) (any, error) {
 			return methods.HandleSettingsAuthClaim(env, zapscript.FetchWellKnown)
@@ -672,6 +676,10 @@ func privateNetworkAccessMiddleware(next http.Handler) http.Handler {
 
 // broadcastNotifications consumes and broadcasts all incoming API
 // notifications to all connected clients.
+//
+// Iteration is synchronous to preserve strict notification ordering (e.g.
+// media.started/stopped sequences): each session's encrypt + write completes
+// before the next session is touched.
 func broadcastNotifications(
 	st *state.State,
 	session *melody.Melody,
@@ -695,16 +703,48 @@ func broadcastNotifications(
 				continue
 			}
 
-			// TODO: this will not work with encryption
-			// Broadcast synchronously to maintain strict notification ordering.
-			// This is critical for media.started/stopped sequences where order matters.
-			// The broadcastNotifications goroutine already runs async, so we don't need
-			// another level of async that would cause out-of-order delivery.
-			err = session.Broadcast(data)
-			if err != nil {
-				logWSWriteError(err, "broadcasting notification")
-			}
+			broadcastToSessions(session, data)
 		}
+	}
+}
+
+// broadcastToSessions sends a notification to every connected session,
+// encrypting per-session for sessions that have established encryption.
+// Errors on individual sessions are logged but do not stop the broadcast.
+func broadcastToSessions(session *melody.Melody, plaintext []byte) {
+	sessions, err := session.Sessions()
+	if err != nil {
+		logWSWriteError(err, "fetching sessions for broadcast")
+		return
+	}
+	for _, s := range sessions {
+		if s == nil || s.IsClosed() {
+			continue
+		}
+		writeNotificationToSession(s, plaintext)
+	}
+}
+
+// writeNotificationToSession writes a single notification to a single
+// melody session, encrypting if the session has an established encryption
+// session. For encrypted sessions the encrypt + enqueue happens under the
+// per-session mutex via SendEncryptedFrame so concurrent writers cannot
+// reorder counters on the wire.
+//
+// On any send-side encryption failure (counter exhaustion, AEAD setup
+// error, write failure) the session is closed: a desynced session
+// cannot recover and keeping it open hides the bug from the client.
+func writeNotificationToSession(s *melody.Session, plaintext []byte) {
+	cs := getClientSession(s)
+	if cs == nil {
+		if err := s.Write(plaintext); err != nil {
+			logWSWriteError(err, "broadcasting plaintext notification")
+		}
+		return
+	}
+	if err := cs.SendEncryptedFrame(plaintext, s.Write); err != nil {
+		logWSWriteError(err, "broadcasting encrypted notification")
+		closeMelodySession(s)
 	}
 }
 
@@ -837,6 +877,11 @@ func processRequestObject(
 // handleWSMessage parses all incoming WS requests, identifies what type of
 // JSON-RPC object they may be and forwards them to the appropriate function
 // to handle that type of message.
+//
+// When encryption is enabled the handler also performs transparent
+// decryption of encrypted frames and encryption of responses. The first
+// frame on a new connection determines whether the session is encrypted
+// (has v + e + t + s) or plaintext.
 func handleWSMessage(
 	methodMap *MethodMap,
 	platform platforms.Platform,
@@ -848,6 +893,8 @@ func handleWSMessage(
 	limitsManager *playtime.LimitsManager,
 	player audio.Player,
 	indexPauser *syncutil.Pauser,
+	encGateway *apimiddleware.EncryptionGateway,
+	lastSeenTracker *apimiddleware.LastSeenTracker,
 ) func(session *melody.Session, msg []byte) {
 	return func(session *melody.Session, msg []byte) {
 		defer func() {
@@ -860,11 +907,60 @@ func handleWSMessage(
 			}
 		}()
 
-		// ping command for heartbeat operation
-		if bytes.Equal(msg, []byte("ping")) {
-			err := session.Write([]byte("pong"))
-			if err != nil {
+		clientIP := apimiddleware.ParseRemoteIP(session.Request.RemoteAddr)
+		isLocal := apimiddleware.IsLoopbackAddr(session.Request.RemoteAddr)
+		var sourceIP string
+		if clientIP != nil {
+			sourceIP = clientIP.String()
+		}
+		encryptionEnabled := cfg.EncryptionEnabled()
+
+		// An unparseable RemoteAddr would collapse all such clients onto a
+		// shared empty-string rate-limit bucket — a false positive could
+		// then block every other unparseable client for the same auth
+		// token. In practice net/http always populates RemoteAddr from the
+		// underlying TCP conn, so this only fires if a future reverse-proxy
+		// header parser writes a malformed value. Reject the connection
+		// rather than risk a degenerate limiter state. Plaintext local
+		// connections do not need a sourceIP and are not rate-limited per
+		// (token, IP), so they are exempt.
+		if sourceIP == "" && encryptionEnabled && !isLocal {
+			log.Warn().
+				Str("remote_addr", session.Request.RemoteAddr).
+				Msg("ws: rejecting encrypted connection from unparseable remote addr")
+			closeMelodySession(session)
+			return
+		}
+
+		// Decrypt the incoming frame if needed and update the per-session
+		// encryption state. Returns the plaintext to dispatch and the
+		// resolved client session (or nil for plaintext sessions).
+		plaintext, cs, ok := decryptIncomingFrame(
+			session, msg, encGateway, encryptionEnabled, isLocal, sourceIP)
+		if !ok {
+			return
+		}
+
+		// Mark the paired client as recently seen. The tracker batches
+		// these in memory and the flush goroutine persists them on a
+		// 30-second cadence (and once more on graceful shutdown).
+		// Plaintext sessions have no associated paired client, so cs is
+		// nil and Touch is skipped.
+		if cs != nil && lastSeenTracker != nil {
+			lastSeenTracker.Touch(cs.AuthToken(), time.Now().Unix())
+		}
+
+		// Heartbeat ping/pong runs on the decrypted plaintext so encrypted
+		// sessions get an encrypted pong, and remote plaintext probes are
+		// rejected by decryptIncomingFrame before reaching this point.
+		if bytes.Equal(plaintext, []byte("ping")) {
+			if err := writePong(session.Write, cs); err != nil {
+				// Encrypted send failed (counter exhausted, write error,
+				// etc.) — the encrypted session is desynced and cannot
+				// recover. Plaintext sessions are also closed because a
+				// write failure means the wire is gone.
 				logWSWriteError(err, "sending pong")
+				closeMelodySession(session)
 			}
 			return
 		}
@@ -872,8 +968,6 @@ func handleWSMessage(
 		reqCtx, reqCancel := context.WithTimeout(st.GetContext(), config.APIRequestTimeout)
 		defer reqCancel()
 
-		rawIP := strings.SplitN(session.Request.RemoteAddr, ":", 2)
-		clientIP := net.ParseIP(rawIP[0])
 		env := requests.RequestEnv{
 			Context:       reqCtx,
 			Platform:      platform,
@@ -886,30 +980,202 @@ func handleWSMessage(
 			TokenQueue:    inTokenQueue,
 			ConfirmQueue:  confirmQueue,
 			IndexPauser:   indexPauser,
-			IsLocal:       clientIP.IsLoopback(),
+			IsLocal:       isLocal,
 			ClientID:      session.Request.RemoteAddr,
 		}
 
-		result := processRequestObject(methodMap, env, msg)
+		result := processRequestObject(methodMap, env, plaintext)
 		if !result.ShouldReply {
 			// Notifications and incoming responses don't get replies
 			return
 		}
 		if result.Error != nil {
-			err := sendWSError(session, result.ID, *result.Error)
+			err := sendWSEncryptedError(session, cs, result.ID, *result.Error)
 			if err != nil {
 				logWSWriteError(err, "error sending error response")
+				// Encrypted send failed (counter exhausted, write
+				// error, etc.) — the encrypted session is desynced
+				// and cannot recover. Plaintext sessions are also
+				// closed because a write failure means the wire is
+				// gone.
+				closeMelodySession(session)
 			}
 		} else {
-			err := sendWSResponse(session, result.ID, result.Result)
+			err := sendWSEncryptedResponse(session, cs, result.ID, result.Result)
 			if err != nil {
 				logWSWriteError(err, "error sending response")
+				closeMelodySession(session)
 			}
 		}
 		if result.AfterWrite != nil {
 			result.AfterWrite()
 		}
 	}
+}
+
+// decryptIncomingFrame is the encryption decision point for WebSocket frames.
+// It handles three cases:
+//
+//   - The session already has an encryption state attached → decrypt with it.
+//   - The session has no state and the frame looks like an encrypted first
+//     frame → establish a new session.
+//   - The frame is plaintext → allowed only when encryption is disabled or
+//     the connection is loopback.
+//
+// Returns (plaintext bytes to dispatch, the active client session if any, ok).
+// On policy rejection or decryption failure, the WebSocket is closed and the
+// caller should return immediately.
+func decryptIncomingFrame(
+	session *melody.Session,
+	msg []byte,
+	encGateway *apimiddleware.EncryptionGateway,
+	encryptionEnabled bool,
+	isLocal bool,
+	sourceIP string,
+) (plaintext []byte, cs *apimiddleware.ClientSession, ok bool) {
+	// Already-established encrypted session: decrypt with the stored state.
+	if cs = getClientSession(session); cs != nil {
+		var frame apimiddleware.EncryptedFrame
+		if err := json.Unmarshal(msg, &frame); err != nil || frame.Ciphertext == "" {
+			log.Warn().Err(err).Msg("ws: malformed encrypted frame on established session")
+			closeMelodySession(session)
+			return nil, nil, false
+		}
+		pt, err := cs.DecryptSubsequent(frame)
+		if err != nil {
+			log.Warn().Err(err).Msg("ws: decryption failed on established session")
+			closeMelodySession(session)
+			return nil, nil, false
+		}
+		return pt, cs, true
+	}
+
+	// No session yet: detect whether this is an encrypted first frame.
+	if apimiddleware.IsEncryptedFirstFrame(msg) {
+		var frame apimiddleware.EncryptedFirstFrame
+		if err := json.Unmarshal(msg, &frame); err != nil {
+			log.Warn().Err(err).Msg("ws: malformed encrypted first frame")
+			closeMelodySession(session)
+			return nil, nil, false
+		}
+		if frame.Version != apimiddleware.EncryptionProtoVersion {
+			data, marshalErr := unsupportedEncryptionVersionResponse()
+			if marshalErr == nil {
+				sendWSPlaintext(session, data)
+			}
+			closeMelodySession(session)
+			return nil, nil, false
+		}
+		newSession, pt, err := encGateway.EstablishSession(frame, sourceIP)
+		if err != nil {
+			log.Warn().Err(err).Msg("ws: failed to establish encrypted session")
+			closeMelodySession(session)
+			return nil, nil, false
+		}
+		setClientSession(session, newSession)
+		return pt, newSession, true
+	}
+
+	// Plaintext frame: only allowed when encryption is disabled, or from
+	// loopback (localhost is always exempt so the TUI / local clients keep
+	// working without pairing).
+	if encryptionEnabled && !isLocal {
+		data, marshalErr := encryptionRequiredErrorResponse()
+		if marshalErr == nil {
+			sendWSPlaintext(session, data)
+		}
+		closeMelodySession(session)
+		return nil, nil, false
+	}
+	return msg, nil, true
+}
+
+// closeMelodySession best-effort closes a melody WebSocket session, logging
+// any error at debug level (the connection may already be closed).
+func closeMelodySession(session *melody.Session) {
+	if err := session.Close(); err != nil {
+		log.Debug().Err(err).Msg("ws: failed to close session")
+	}
+}
+
+// writePong sends a "pong" heartbeat reply to the client. Plaintext
+// sessions get the raw "pong" bytes; encrypted sessions go through
+// SendEncryptedFrame so the encrypt + enqueue happens under the
+// per-session mutex (preventing wire reorder against concurrent
+// broadcasts).
+//
+// writeFn receives the bytes to emit on the wire. Production callers pass
+// session.Write from a melody session; tests pass a capturing function to
+// inspect the wire shape without mocking melody.
+func writePong(writeFn func([]byte) error, cs *apimiddleware.ClientSession) error {
+	if cs == nil {
+		if err := writeFn([]byte("pong")); err != nil {
+			return fmt.Errorf("write plaintext pong: %w", err)
+		}
+		return nil
+	}
+	if err := cs.SendEncryptedFrame([]byte("pong"), writeFn); err != nil {
+		return fmt.Errorf("send encrypted pong: %w", err)
+	}
+	return nil
+}
+
+// sendWSEncryptedResponse marshals a JSON-RPC response and sends it over the
+// WebSocket, encrypting it if the session has an established encryption
+// session, otherwise sending it as plaintext. For encrypted sessions the
+// encrypt + enqueue happens under the per-session mutex via
+// SendEncryptedFrame so concurrent writers cannot reorder counters on the
+// wire.
+func sendWSEncryptedResponse(
+	session *melody.Session,
+	cs *apimiddleware.ClientSession,
+	id models.RPCID,
+	result any,
+) error {
+	if cs == nil {
+		return sendWSResponse(session, id, result)
+	}
+	resp := models.ResponseObject{
+		JSONRPC: "2.0",
+		ID:      id,
+		Result:  result,
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	if err := cs.SendEncryptedFrame(data, session.Write); err != nil {
+		return fmt.Errorf("send encrypted response: %w", err)
+	}
+	return nil
+}
+
+// sendWSEncryptedError sends a JSON-RPC error, encrypted if the session is
+// encrypted. For encrypted sessions the encrypt + enqueue happens under
+// the per-session mutex via SendEncryptedFrame so concurrent writers
+// cannot reorder counters on the wire.
+func sendWSEncryptedError(
+	session *melody.Session,
+	cs *apimiddleware.ClientSession,
+	id models.RPCID,
+	rpcErr models.ErrorObject,
+) error {
+	if cs == nil {
+		return sendWSError(session, id, rpcErr)
+	}
+	resp := models.ResponseErrorObject{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &rpcErr,
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal error response: %w", err)
+	}
+	if err := cs.SendEncryptedFrame(data, session.Write); err != nil {
+		return fmt.Errorf("send encrypted error: %w", err)
+	}
+	return nil
 }
 
 func handlePostRequest(
@@ -957,8 +1223,6 @@ func handlePostRequest(
 		context.AfterFunc(st.GetContext(), reqCancel)
 		defer reqCancel()
 
-		rawIP := strings.SplitN(r.RemoteAddr, ":", 2)
-		clientIP := net.ParseIP(rawIP[0])
 		env := requests.RequestEnv{
 			Context:       reqCtx,
 			Platform:      platform,
@@ -971,7 +1235,7 @@ func handlePostRequest(
 			TokenQueue:    inTokenQueue,
 			ConfirmQueue:  confirmQueue,
 			IndexPauser:   indexPauser,
-			IsLocal:       clientIP.IsLoopback(),
+			IsLocal:       apimiddleware.IsLoopbackAddr(r.RemoteAddr),
 			ClientID:      r.RemoteAddr,
 		}
 
@@ -1095,11 +1359,19 @@ func Start(
 	rateLimiter := apimiddleware.NewIPRateLimiter()
 	rateLimiter.StartCleanup(st.GetContext())
 
-	ipFilter := apimiddleware.NewIPFilter(cfg.AllowedIPs)
+	// Pairing endpoints have a much more aggressive rate limit (1 req/sec
+	// per IP) to throttle online PIN guessing attacks. The PAKE protocol
+	// itself prevents offline attacks, but rate limiting is defense in
+	// depth against the only feasible online attack: trying many PINs.
+	pairingRateLimiter := apimiddleware.NewIPRateLimiterWithLimits(rate.Limit(1), 1)
+	pairingRateLimiter.StartCleanup(st.GetContext())
+
 	authConfig := apimiddleware.NewAuthConfig(config.GetAPIKeys)
 
-	// Global middleware for all routes
-	r.Use(apimiddleware.HTTPIPFilterMiddleware(ipFilter))
+	// Global middleware applied to all routes. IP filtering is applied
+	// per-group: non-WS transports use NonWSIPFilterMiddleware
+	// (deny-by-default for remote), while pairing, app, health, and
+	// WebSocket routes remain remote-accessible.
 	r.Use(middleware.Recoverer)
 	r.Use(cors.Handler(cors.Options{
 		AllowOriginFunc: originValidator,
@@ -1111,6 +1383,7 @@ func Start(
 
 	// Rate limiting only for API routes, not static assets
 	apiRateLimitMiddleware := apimiddleware.HTTPRateLimitMiddleware(rateLimiter)
+	nonWSIPFilter := apimiddleware.NonWSIPFilterMiddleware(cfg.AllowedIPs)
 
 	if config.IsDevelopmentVersion() {
 		r.Mount("/debug", middleware.Profiler())
@@ -1118,6 +1391,20 @@ func Start(
 	}
 
 	methodMap := NewMethodMap()
+
+	// Construct the pairing manager and the encryption session manager.
+	// Both have background cleanup goroutines tied to the service context.
+	pairingMgr := NewPairingManager(db.UserDB, st.Notifications)
+	pairingMgr.StartCleanup(st.GetContext())
+
+	encGateway := apimiddleware.NewEncryptionGateway(db.UserDB)
+	encGateway.StartCleanup(st.GetContext())
+
+	// LastSeen tracker batches paired-client activity in memory and
+	// flushes to Clients.LastSeenAt every 30 seconds. A final flush runs
+	// on graceful shutdown via StartFlushLoop's ctx.Done() branch.
+	lastSeenTracker := apimiddleware.NewLastSeenTracker(db.UserDB)
+	lastSeenTracker.StartFlushLoop(st.GetContext(), apimiddleware.DefaultLastSeenFlushInterval)
 
 	session := melody.New()
 	defer func() {
@@ -1130,34 +1417,115 @@ func Start(
 		log.Debug().Msgf("websocket origin: %s", origin)
 		return checkWebSocketOrigin(origin, staticOrigins, cfg.AllowedOrigins, port)
 	}
+	// melody's Session.Write is a non-blocking enqueue onto a per-session
+	// output channel (default size 256). When that channel fills, the
+	// frame is silently dropped and Write still returns nil — for
+	// encrypted sessions this would silently desync the send counter
+	// against the wire and the client's next decrypt would fail GCM auth.
+	// Force-close the underlying TCP connection so the session is torn
+	// down promptly and the client reconnects cleanly instead of seeing
+	// unexplained decryption errors.
+	//
+	// We bypass session.Close() here because it would enqueue a
+	// CloseMessage envelope onto the same full output channel and re-enter
+	// this errorHandler in an infinite recursion. Closing the underlying
+	// conn directly causes writePump to fail on its next write, exit, and
+	// run the normal session close path.
+	session.HandleError(func(s *melody.Session, herr error) {
+		if errors.Is(herr, melody.ErrMessageBufferFull) {
+			cs := getClientSession(s)
+			if cs != nil {
+				tok := cs.AuthToken()
+				if len(tok) > 8 {
+					tok = tok[:8] + "..."
+				}
+				log.Warn().
+					Str("auth_token", tok).
+					Msg("ws: encrypted session output buffer full, force-closing to avoid counter desync")
+			} else {
+				log.Warn().Msg("ws: plaintext session output buffer full, force-closing")
+			}
+			if conn := s.WebsocketConnection(); conn != nil {
+				if cerr := conn.Close(); cerr != nil {
+					log.Debug().Err(cerr).Msg("ws: error force-closing overflowed session")
+				}
+			}
+		}
+	})
 	wsNotifications, wsSubID := notifBroker.Subscribe(100)
 	go func() {
 		broadcastNotifications(st, session, wsNotifications)
 		notifBroker.Unsubscribe(wsSubID)
 	}()
 
-	// API routes (with request timeout)
+	// Pairing endpoints — accessible to remote clients (rate-limited only).
+	// Unencrypted by design: PAKE establishes the shared key without ever
+	// transmitting it.
+	//
+	// Both limiters are stacked: the general apiRateLimitMiddleware runs
+	// first (cheap check, shared budget) and the stricter pairingRateMiddleware
+	// (1 req/sec per IP) runs second. Stacking prevents a client from
+	// pairing while simultaneously scraping other endpoints from the same
+	// IP, and provides defense in depth if pairingRateLimiter is ever
+	// misconfigured.
+	pairingRateMiddleware := apimiddleware.HTTPRateLimitMiddleware(pairingRateLimiter)
 	r.Group(func(r chi.Router) {
+		r.Use(apiRateLimitMiddleware)
+		r.Use(pairingRateMiddleware)
+		r.Use(middleware.NoCache)
+		r.Use(middleware.Timeout(config.APIRequestTimeout))
+		r.Post("/api/pair/start", pairingMgr.HandlePairStart())
+		r.Post("/api/pair/finish", pairingMgr.HandlePairFinish())
+	})
+
+	// WebSocket handler. When encryption is disabled, API key auth is
+	// enforced at upgrade time. When encryption is enabled, auth is
+	// deferred to the first encrypted frame — successful first-frame
+	// decryption proves the client holds a valid pairing key. Localhost is
+	// always exempt.
+	wsHandler := func(w http.ResponseWriter, r *http.Request, version string) {
+		if !cfg.EncryptionEnabled() {
+			if !apimiddleware.WebSocketAuthHandler(authConfig, r) {
+				http.Error(w, "Unauthorized: API key required", http.StatusUnauthorized)
+				return
+			}
+		}
+		err := session.HandleRequest(w, r)
+		if err != nil {
+			log.Warn().Err(err).Str("version", version).Msg("websocket upgrade failed")
+		}
+	}
+
+	// WebSocket routes — open to remote clients regardless of AllowedIPs.
+	// Encryption (when enabled) or API key auth (when disabled) is the
+	// security mechanism here.
+	r.Group(func(r chi.Router) {
+		r.Use(apiRateLimitMiddleware)
+		r.Use(middleware.NoCache)
+		r.Use(middleware.Timeout(config.APIRequestTimeout))
+
+		r.Get("/api", func(w http.ResponseWriter, r *http.Request) {
+			wsHandler(w, r, "latest")
+		})
+		r.Get("/api/v0", func(w http.ResponseWriter, r *http.Request) {
+			wsHandler(w, r, "v0")
+		})
+		r.Get("/api/v0.1", func(w http.ResponseWriter, r *http.Request) {
+			wsHandler(w, r, "v0.1")
+		})
+	})
+
+	// Non-WebSocket API routes (HTTP POST + REST GET) — restricted to
+	// localhost by default; remote access requires explicit AllowedIPs.
+	// These transports do not support encryption; the IP allowlist plus
+	// API key auth are the security boundary.
+	r.Group(func(r chi.Router) {
+		r.Use(nonWSIPFilter)
 		r.Use(apimiddleware.HTTPAuthMiddleware(authConfig))
 		r.Use(apiRateLimitMiddleware)
 		r.Use(middleware.NoCache)
 		r.Use(middleware.Timeout(config.APIRequestTimeout))
 
-		// WebSocket handler that checks auth before upgrade
-		wsHandler := func(w http.ResponseWriter, r *http.Request, version string) {
-			if !apimiddleware.WebSocketAuthHandler(authConfig, r) {
-				http.Error(w, "Unauthorized: API key required", http.StatusUnauthorized)
-				return
-			}
-			err := session.HandleRequest(w, r)
-			if err != nil {
-				log.Warn().Err(err).Str("version", version).Msg("websocket upgrade failed")
-			}
-		}
-
-		r.Get("/api", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "latest")
-		})
 		postHandler := handlePostRequest(
 			methodMap, platform, cfg, st,
 			inTokenQueue, confirmQueue,
@@ -1165,15 +1533,7 @@ func Start(
 			indexPauser,
 		)
 		r.Post("/api", postHandler)
-
-		r.Get("/api/v0", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "v0")
-		})
 		r.Post("/api/v0", postHandler)
-
-		r.Get("/api/v0.1", func(w http.ResponseWriter, r *http.Request) {
-			wsHandler(w, r, "v0.1")
-		})
 		r.Post("/api/v0.1", postHandler)
 
 		// REST action endpoints
@@ -1182,8 +1542,10 @@ func Start(
 		r.Get("/run/*", methods.HandleRunRest(cfg, st, inTokenQueue))
 	})
 
-	// SSE routes (long-lived connections, no request timeout)
+	// SSE routes (long-lived connections, no request timeout). Same
+	// localhost-by-default policy as the non-WS API routes.
 	r.Group(func(r chi.Router) {
+		r.Use(nonWSIPFilter)
 		r.Use(apimiddleware.HTTPAuthMiddleware(authConfig))
 		r.Use(apiRateLimitMiddleware)
 		r.Use(middleware.NoCache)
@@ -1198,7 +1560,8 @@ func Start(
 		rateLimiter,
 		handleWSMessage(
 			methodMap, platform, cfg, st, inTokenQueue, confirmQueue,
-			db, limitsManager, player, indexPauser,
+			db, limitsManager, player, indexPauser, encGateway,
+			lastSeenTracker,
 		),
 	))
 
@@ -1208,9 +1571,11 @@ func Start(
 		http.Redirect(w, r, "/app/", http.StatusFound)
 	})
 
-	// the health endpoint is behind every standard middleware we added
-	// the response is a simple string on purpose, we want just to be able
-	// to see if the server is up and answering
+	// /health is intentionally remote-accessible with no IP filter, no
+	// API key auth, and no rate limiting (only the global Recoverer/CORS
+	// middleware applies) so load balancers, uptime checks, and the
+	// app's discovery flow can reach it without credentials. The plain
+	// "OK" response intentionally leaks no information beyond liveness.
 	r.Get("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))

--- a/pkg/api/server_encryption.go
+++ b/pkg/api/server_encryption.go
@@ -1,0 +1,95 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/olahol/melody"
+	"github.com/rs/zerolog/log"
+)
+
+// melodySessionEncryptionKey attaches ClientSession to melody session storage.
+const melodySessionEncryptionKey = "encryption_session"
+
+// getClientSession returns the encryption session (or nil for plaintext).
+func getClientSession(session *melody.Session) *apimiddleware.ClientSession {
+	v, ok := session.Get(melodySessionEncryptionKey)
+	if !ok {
+		return nil
+	}
+	cs, ok := v.(*apimiddleware.ClientSession)
+	if !ok {
+		return nil
+	}
+	return cs
+}
+
+// setClientSession attaches an encryption session to a melody session.
+func setClientSession(session *melody.Session, cs *apimiddleware.ClientSession) {
+	session.Set(melodySessionEncryptionKey, cs)
+}
+
+// encryptionRequiredErrorResponse returns a JSON-RPC error for plaintext
+// frames when encryption is required.
+func encryptionRequiredErrorResponse() ([]byte, error) {
+	data, err := json.Marshal(models.ResponseErrorObject{
+		JSONRPC: "2.0",
+		ID:      models.NullRPCID,
+		Error: &models.ErrorObject{
+			Code:    -32002,
+			Message: "encryption required for remote connections",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal encryption-required error: %w", err)
+	}
+	return data, nil
+}
+
+// unsupportedEncryptionVersionResponse returns a version mismatch error
+// (per JSON-RPC 2.0 §5.1).
+func unsupportedEncryptionVersionResponse() ([]byte, error) {
+	data, err := json.Marshal(models.ResponseErrorObject{
+		JSONRPC: "2.0",
+		ID:      models.NullRPCID,
+		Error: &models.ErrorObject{
+			Code:    -32001,
+			Message: "unsupported encryption version",
+			Data: map[string]any{
+				"supported": []int{apimiddleware.EncryptionProtoVersion},
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal unsupported-version error: %w", err)
+	}
+	return data, nil
+}
+
+// sendWSPlaintext sends plaintext before encryption handshake completes.
+func sendWSPlaintext(session *melody.Session, data []byte) {
+	if err := session.Write(data); err != nil {
+		log.Debug().Err(err).Msg("failed to write plaintext WS message")
+	}
+}

--- a/pkg/api/server_encryption_test.go
+++ b/pkg/api/server_encryption_test.go
@@ -1,0 +1,240 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"crypto/cipher"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWritePong_Plaintext verifies that without an established encryption
+// session the heartbeat reply is the raw bytes "pong" (preserves the
+// existing client contract for plaintext sessions).
+func TestWritePong_Plaintext(t *testing.T) {
+	t.Parallel()
+
+	var got []byte
+	capture := func(b []byte) error {
+		got = append([]byte(nil), b...)
+		return nil
+	}
+	require.NoError(t, writePong(capture, nil))
+	assert.Equal(t, []byte("pong"), got)
+}
+
+// TestWritePong_Encrypted verifies that on an established encryption
+// session the heartbeat reply is wrapped in an AEAD frame whose decrypted
+// body is "pong". This pins the fix for the ping-bypass bug where the
+// heartbeat used to bypass encryption entirely. The test exercises the
+// real production path (writePong → SendEncryptedFrame) with a capturing
+// writer in place of melody's session.Write.
+func TestWritePong_Encrypted(t *testing.T) {
+	t.Parallel()
+
+	cs, clientSecrets := establishTestEncryptionSession(t)
+
+	var got []byte
+	capture := func(b []byte) error {
+		got = append([]byte(nil), b...)
+		return nil
+	}
+	require.NoError(t, writePong(capture, cs))
+
+	var frame apimiddleware.EncryptedFrame
+	require.NoError(t, json.Unmarshal(got, &frame))
+	require.NotEmpty(t, frame.Ciphertext, "encrypted pong must produce a non-empty ciphertext")
+
+	ct, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+	require.NoError(t, err)
+
+	pt, err := crypto.Decrypt(
+		clientSecrets.s2cGCM,
+		clientSecrets.s2cNonce,
+		0, // first server-to-client frame
+		ct,
+		clientSecrets.aad,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("pong"), pt)
+}
+
+// testEncryptionPeerSecrets holds the cipher state the *client* side of an
+// established session needs to decrypt server messages. Tests use it to
+// verify wire shape end-to-end.
+type testEncryptionPeerSecrets struct {
+	s2cGCM   cipher.AEAD
+	s2cNonce []byte
+	aad      []byte
+}
+
+// establishTestEncryptionSession constructs a real *apimiddleware.ClientSession
+// the same way the production server does: pair a fake client, build a valid
+// encrypted first frame, and run it through EncryptionGateway.EstablishSession.
+// Returns the resulting session and the matching client-side cipher state.
+func establishTestEncryptionSession(t *testing.T) (*apimiddleware.ClientSession, *testEncryptionPeerSecrets) {
+	t.Helper()
+
+	pairingKey := make([]byte, crypto.PairingKeySize)
+	_, err := cryptorand.Read(pairingKey)
+	require.NoError(t, err)
+
+	//nolint:gosec // test fixture; AuthToken is opaque test data, not a credential
+	c := &database.Client{
+		ClientID:   "test-client",
+		ClientName: "Test",
+		AuthToken:  "test-auth-token",
+		PairingKey: pairingKey,
+	}
+
+	db := helpers.NewMockUserDBI()
+	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	mgr := apimiddleware.NewEncryptionGateway(db)
+
+	salt := make([]byte, crypto.SessionSaltSize)
+	_, err = cryptorand.Read(salt)
+	require.NoError(t, err)
+
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+
+	clientC2S, err := crypto.NewAEAD(keys.C2SKey)
+	require.NoError(t, err)
+	clientS2C, err := crypto.NewAEAD(keys.S2CKey)
+	require.NoError(t, err)
+
+	aad := []byte(c.AuthToken + ":ws")
+	plaintextReq := []byte(`{"jsonrpc":"2.0","method":"version","id":1}`)
+	ct, err := crypto.Encrypt(clientC2S, keys.C2SNonce, 0, plaintextReq, aad)
+	require.NoError(t, err)
+
+	first := apimiddleware.EncryptedFirstFrame{
+		Version:     apimiddleware.EncryptionProtoVersion,
+		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+		AuthToken:   c.AuthToken,
+		SessionSalt: base64.StdEncoding.EncodeToString(salt),
+	}
+	cs, _, err := mgr.EstablishSession(first, "192.168.1.50")
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+
+	return cs, &testEncryptionPeerSecrets{
+		s2cGCM:   clientS2C,
+		s2cNonce: keys.S2CNonce,
+		aad:      aad,
+	}
+}
+
+// TestRemoteAddrParsing_IPv6Loopback pins the IPv6-aware parsing path used
+// by handleWSMessage and handlePostRequest. The previous implementation
+// used strings.SplitN(addr, ":", 2) which mangled IPv6 brackets — `[::1]`
+// became `[`, ParseIP returned nil, IPv6 loopback was treated as remote,
+// and every IPv6 client shared the same `<nil>` rate-limit bucket.
+//
+// This test fails if anyone reverts to a non-bracket-aware parser.
+func TestRemoteAddrParsing_IPv6Loopback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		wantIPStr  string
+		wantLocal  bool
+	}{
+		{
+			name:       "IPv4 loopback",
+			remoteAddr: "127.0.0.1:54321",
+			wantLocal:  true,
+			wantIPStr:  "127.0.0.1",
+		},
+		{
+			name:       "IPv6 loopback bracketed",
+			remoteAddr: "[::1]:54321",
+			wantLocal:  true,
+			wantIPStr:  "::1",
+		},
+		{
+			name:       "IPv4 remote",
+			remoteAddr: "192.168.1.50:9000",
+			wantLocal:  false,
+			wantIPStr:  "192.168.1.50",
+		},
+		{
+			name:       "IPv6 remote",
+			remoteAddr: "[2001:db8::1]:9000",
+			wantLocal:  false,
+			wantIPStr:  "2001:db8::1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ip := apimiddleware.ParseRemoteIP(tc.remoteAddr)
+			require.NotNil(t, ip, "ParseRemoteIP must not return nil for valid host:port")
+			assert.Equal(t, tc.wantIPStr, ip.String())
+			assert.Equal(t, tc.wantLocal, apimiddleware.IsLoopbackAddr(tc.remoteAddr))
+		})
+	}
+}
+
+// TestUnsupportedEncryptionVersionResponse_WireShape pins the JSON wire
+// format of the -32001 error to JSON-RPC 2.0 §5.1: the `data` field MUST
+// be nested inside the `error` object, not a top-level sibling.
+func TestUnsupportedEncryptionVersionResponse_WireShape(t *testing.T) {
+	t.Parallel()
+
+	raw, err := unsupportedEncryptionVersionResponse()
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(raw, &parsed))
+
+	// JSON-RPC envelope
+	assert.Equal(t, "2.0", parsed["jsonrpc"])
+	assert.Nil(t, parsed["id"], "id must be null on protocol-level errors")
+
+	// `data` MUST NOT be at the top level — it belongs inside `error`.
+	_, dataAtTop := parsed["data"]
+	assert.False(t, dataAtTop,
+		"data must be nested inside error per JSON-RPC 2.0 §5.1, not a sibling")
+
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok, "error must be an object")
+	assert.InDelta(t, float64(-32001), errObj["code"], 0)
+	assert.Equal(t, "unsupported encryption version", errObj["message"])
+
+	errData, ok := errObj["data"].(map[string]any)
+	require.True(t, ok, "error.data must be an object")
+	supported, ok := errData["supported"].([]any)
+	require.True(t, ok, "error.data.supported must be an array")
+	require.Len(t, supported, 1)
+	assert.InDelta(t, float64(1), supported[0], 0,
+		"only protocol version 1 is currently supported")
+}

--- a/pkg/config/configencryption.go
+++ b/pkg/config/configencryption.go
@@ -1,0 +1,42 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+// EncryptionEnabled returns whether WebSocket encryption is enabled. When
+// true, remote WebSocket clients must send an encrypted first frame derived
+// from a paired key; plaintext WebSocket connections from non-loopback
+// addresses are rejected. When false (the default), all WebSocket
+// connections are accepted as plaintext and API key authentication applies.
+//
+// Localhost connections are always allowed plaintext regardless of this
+// setting.
+func (c *Instance) EncryptionEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.vals.Service.Encryption
+}
+
+// SetEncryptionEnabled toggles WebSocket encryption. The caller is
+// responsible for calling Save() to persist the change.
+func (c *Instance) SetEncryptionEnabled(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Service.Encryption = enabled
+}

--- a/pkg/config/configencryption_test.go
+++ b/pkg/config/configencryption_test.go
@@ -1,0 +1,74 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptionEnabled_DefaultsFalse(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	assert.False(t, cfg.EncryptionEnabled(), "missing field should default to false")
+}
+
+func TestSetEncryptionEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+
+	cfg.SetEncryptionEnabled(true)
+	assert.True(t, cfg.EncryptionEnabled())
+
+	cfg.SetEncryptionEnabled(false)
+	assert.False(t, cfg.EncryptionEnabled())
+}
+
+// TestServiceEncryption_OmitEmpty pins the omitempty behavior of the
+// Service.Encryption field. A fresh install (or a config with encryption
+// disabled) must NOT write `encryption = false` into config.toml. Without
+// this test, an accidental drop of the omitempty tag would silently change
+// config file contents for every user on the next save.
+func TestServiceEncryption_OmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Case 1: zero-value Service must not emit encryption.
+	data, err := toml.Marshal(Service{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "encryption",
+		"zero-value Service must omit the encryption field")
+
+	// Case 2: Service{Encryption: true} must emit encryption = true.
+	data, err = toml.Marshal(Service{Encryption: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "encryption = true",
+		"Service{Encryption: true} must emit encryption = true")
+
+	// Case 3: round-trip — marshalling then unmarshalling must preserve
+	// the enabled state.
+	var got Service
+	require.NoError(t, toml.Unmarshal(data, &got))
+	assert.True(t, got.Encryption, "round-trip must preserve encryption = true")
+}

--- a/pkg/config/configservice.go
+++ b/pkg/config/configservice.go
@@ -37,15 +37,21 @@ func isValidAPIPort(port int) bool {
 }
 
 type Service struct {
-	APIPort        *int      `toml:"api_port,omitempty"`
-	Discovery      Discovery `toml:"discovery,omitempty"`
-	DeviceID       string    `toml:"device_id"`
-	APIListen      string    `toml:"api_listen,omitempty"`
-	AllowRun       []string  `toml:"allow_run,omitempty,multiline"`
+	APIPort   *int      `toml:"api_port,omitempty"`
+	Discovery Discovery `toml:"discovery,omitempty"`
+	DeviceID  string    `toml:"device_id"`
+	APIListen string    `toml:"api_listen,omitempty"`
+	// AllowRun is the list of allowed run patterns.
+	AllowRun       []string `toml:"allow_run,omitempty,multiline"`
 	allowRunRe     []*regexp.Regexp
 	AllowedOrigins []string   `toml:"allowed_origins,omitempty"`
 	AllowedIPs     []string   `toml:"allowed_ips,omitempty"`
 	Publishers     Publishers `toml:"publishers,omitempty"`
+	// Encryption enables PAKE pairing + AES-256-GCM on the WebSocket
+	// transport. False (the default) accepts plaintext WebSocket connections
+	// with API key authentication. True requires paired clients for remote
+	// WebSocket connections; localhost is always exempt.
+	Encryption bool `toml:"encryption,omitempty"`
 }
 
 type Publishers struct {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -114,6 +114,18 @@ type InboxMessage struct {
 	ProfileID int64     `json:"profileId"`
 }
 
+// Client represents a paired API client. AuthToken and PairingKey are
+// hidden from JSON (API uses models.PairedClient instead).
+type Client struct {
+	ClientID   string `json:"clientId"`
+	ClientName string `json:"clientName"`
+	AuthToken  string `json:"-"`
+	PairingKey []byte `json:"-"`
+	DBID       int64  `json:"-"`
+	CreatedAt  int64  `json:"createdAt"`
+	LastSeenAt int64  `json:"lastSeenAt"`
+}
+
 type System struct {
 	SystemID string
 	Name     string
@@ -357,6 +369,12 @@ type UserDBI interface {
 	GetInboxMessages() ([]InboxMessage, error)
 	DeleteInboxMessage(id int64) error
 	DeleteAllInboxMessages() (int64, error)
+	CreateClient(c *Client) error
+	GetClientByToken(authToken string) (*Client, error)
+	ListClients() ([]Client, error)
+	DeleteClient(clientID string) error
+	UpdateClientLastSeen(authToken string, lastSeenAt int64) error
+	CountClients() (int, error)
 }
 
 type MediaDBI interface {

--- a/pkg/database/userdb/clients.go
+++ b/pkg/database/userdb/clients.go
@@ -1,0 +1,48 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+)
+
+func (db *UserDB) CreateClient(c *database.Client) error {
+	return sqlCreateClient(db.ctx, db.sql, c)
+}
+
+func (db *UserDB) GetClientByToken(authToken string) (*database.Client, error) {
+	return sqlGetClientByToken(db.ctx, db.sql, authToken)
+}
+
+func (db *UserDB) ListClients() ([]database.Client, error) {
+	return sqlListClients(db.ctx, db.sql)
+}
+
+func (db *UserDB) DeleteClient(clientID string) error {
+	return sqlDeleteClient(db.ctx, db.sql, clientID)
+}
+
+func (db *UserDB) UpdateClientLastSeen(authToken string, lastSeenAt int64) error {
+	return sqlUpdateClientLastSeen(db.ctx, db.sql, authToken, lastSeenAt)
+}
+
+func (db *UserDB) CountClients() (int, error) {
+	return sqlCountClients(db.ctx, db.sql)
+}

--- a/pkg/database/userdb/clients_test.go
+++ b/pkg/database/userdb/clients_test.go
@@ -1,0 +1,254 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	clientSelectByTokenRe = `SELECT DBID, ClientID, ClientName, AuthToken, ` +
+		`PairingKey, CreatedAt, LastSeenAt FROM Clients WHERE AuthToken = \?`
+	clientSelectListRe = `SELECT DBID, ClientID, ClientName, AuthToken, ` +
+		`PairingKey, CreatedAt, LastSeenAt FROM Clients ORDER BY CreatedAt DESC`
+)
+
+var clientRowColumns = []string{
+	"DBID", "ClientID", "ClientName", "AuthToken", "PairingKey", "CreatedAt", "LastSeenAt",
+}
+
+func newTestClient() *database.Client {
+	//nolint:gosec // test fixture; AuthToken is opaque test data, not a credential
+	return &database.Client{
+		ClientID:   "client-uuid-1",
+		ClientName: "Test App",
+		AuthToken:  "auth-token-uuid",
+		PairingKey: []byte("0123456789abcdef0123456789abcdef"),
+		CreatedAt:  1700000000,
+		LastSeenAt: 1700000100,
+	}
+}
+
+func TestSqlCreateClient_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	c := newTestClient()
+	mock.ExpectQuery(`INSERT INTO Clients`).
+		WithArgs(c.ClientID, c.ClientName, c.AuthToken, c.PairingKey, c.CreatedAt, c.LastSeenAt).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(int64(42)))
+
+	err = sqlCreateClient(context.Background(), db, c)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), c.DBID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSqlCreateClient_RejectsAuthTokenWithColon pins the constraint that
+// auth tokens cannot contain ':' — the encryption AAD scheme uses
+// `<authToken>:ws` and would become ambiguous if the token itself
+// contained a colon. The check is enforced both in Go (clean error) and
+// at the schema level via a CHECK constraint.
+func TestSqlCreateClient_RejectsAuthTokenWithColon(t *testing.T) {
+	t.Parallel()
+	db, _, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	c := newTestClient()
+	c.AuthToken = "evil:token"
+	err = sqlCreateClient(context.Background(), db, c)
+	require.ErrorIs(t, err, ErrInvalidAuthToken)
+}
+
+func TestSqlCreateClient_DatabaseError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	c := newTestClient()
+	mock.ExpectQuery(`INSERT INTO Clients`).
+		WithArgs(c.ClientID, c.ClientName, c.AuthToken, c.PairingKey, c.CreatedAt, c.LastSeenAt).
+		WillReturnError(sqlmock.ErrCancelled)
+
+	err = sqlCreateClient(context.Background(), db, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to insert client")
+}
+
+func TestSqlGetClientByToken_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	c := newTestClient()
+	mock.ExpectQuery(clientSelectByTokenRe).
+		WithArgs(c.AuthToken).
+		WillReturnRows(sqlmock.NewRows(clientRowColumns).
+			AddRow(int64(7), c.ClientID, c.ClientName, c.AuthToken, c.PairingKey, c.CreatedAt, c.LastSeenAt))
+
+	got, err := sqlGetClientByToken(context.Background(), db, c.AuthToken)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(7), got.DBID)
+	assert.Equal(t, c.ClientID, got.ClientID)
+	assert.Equal(t, c.ClientName, got.ClientName)
+	assert.Equal(t, c.AuthToken, got.AuthToken)
+	assert.Equal(t, c.PairingKey, got.PairingKey)
+	assert.Equal(t, c.CreatedAt, got.CreatedAt)
+	assert.Equal(t, c.LastSeenAt, got.LastSeenAt)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetClientByToken_NotFound(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(clientSelectByTokenRe).
+		WithArgs("missing").
+		WillReturnRows(sqlmock.NewRows(clientRowColumns))
+
+	got, err := sqlGetClientByToken(context.Background(), db, "missing")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "client not found")
+}
+
+func TestSqlListClients_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	key1 := []byte("key-1-key-1-key-1-key-1-key-1-12")
+	key2 := []byte("key-2-key-2-key-2-key-2-key-2-12")
+	rows := sqlmock.NewRows(clientRowColumns).
+		AddRow(int64(1), "id-1", "App One", "tok-1", key1, int64(1000), int64(2000)).
+		AddRow(int64(2), "id-2", "App Two", "tok-2", key2, int64(1100), int64(2100))
+
+	mock.ExpectQuery(clientSelectListRe).WillReturnRows(rows)
+
+	got, err := sqlListClients(context.Background(), db)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "id-1", got[0].ClientID)
+	assert.Equal(t, "id-2", got[1].ClientID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlListClients_Empty(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(clientSelectListRe).
+		WillReturnRows(sqlmock.NewRows(clientRowColumns))
+
+	got, err := sqlListClients(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestSqlDeleteClient_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`DELETE FROM Clients WHERE ClientID = \?`).
+		WithArgs("client-uuid-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = sqlDeleteClient(context.Background(), db, "client-uuid-1")
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlDeleteClient_NotFound(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`DELETE FROM Clients WHERE ClientID = \?`).
+		WithArgs("missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err = sqlDeleteClient(context.Background(), db, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client not found")
+}
+
+func TestSqlUpdateClientLastSeen_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE Clients SET LastSeenAt = \? WHERE AuthToken = \?`).
+		WithArgs(int64(1700001000), "tok").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = sqlUpdateClientLastSeen(context.Background(), db, "tok", 1700001000)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlCountClients_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM Clients`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
+	got, err := sqlCountClients(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, 5, got)
+}
+
+func TestSqlCountClients_Empty(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM Clients`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	got, err := sqlCountClients(context.Background(), db)
+	require.NoError(t, err)
+	assert.Equal(t, 0, got)
+}

--- a/pkg/database/userdb/clients_test.go
+++ b/pkg/database/userdb/clients_test.go
@@ -101,6 +101,7 @@ func TestSqlCreateClient_DatabaseError(t *testing.T) {
 	err = sqlCreateClient(context.Background(), db, c)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to insert client")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlGetClientByToken_Success(t *testing.T) {
@@ -142,6 +143,7 @@ func TestSqlGetClientByToken_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, got)
 	assert.Contains(t, err.Error(), "client not found")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlListClients_Success(t *testing.T) {
@@ -178,6 +180,7 @@ func TestSqlListClients_Empty(t *testing.T) {
 	got, err := sqlListClients(context.Background(), db)
 	require.NoError(t, err)
 	assert.Empty(t, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlDeleteClient_Success(t *testing.T) {
@@ -208,6 +211,7 @@ func TestSqlDeleteClient_NotFound(t *testing.T) {
 	err = sqlDeleteClient(context.Background(), db, "missing")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "client not found")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlUpdateClientLastSeen_Success(t *testing.T) {
@@ -237,6 +241,7 @@ func TestSqlCountClients_Success(t *testing.T) {
 	got, err := sqlCountClients(context.Background(), db)
 	require.NoError(t, err)
 	assert.Equal(t, 5, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlCountClients_Empty(t *testing.T) {
@@ -251,4 +256,5 @@ func TestSqlCountClients_Empty(t *testing.T) {
 	got, err := sqlCountClients(context.Background(), db)
 	require.NoError(t, err)
 	assert.Equal(t, 0, got)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/userdb/migrations/20260407062033_create_clients_table.sql
+++ b/pkg/database/userdb/migrations/20260407062033_create_clients_table.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create table Clients
+(
+    DBID       INTEGER PRIMARY KEY,
+    ClientID   text    not null unique,
+    ClientName text    not null,
+    AuthToken  text    not null unique
+        check (instr(AuthToken, ':') = 0),
+    PairingKey blob    not null,
+    CreatedAt  integer not null,
+    LastSeenAt integer not null
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+drop table Clients;
+-- +goose StatementEnd

--- a/pkg/database/userdb/migrations/20260407062033_create_clients_table.sql
+++ b/pkg/database/userdb/migrations/20260407062033_create_clients_table.sql
@@ -8,7 +8,8 @@ create table Clients
     ClientName text    not null,
     AuthToken  text    not null unique
         check (instr(AuthToken, ':') = 0),
-    PairingKey blob    not null,
+    PairingKey blob    not null
+        check (length(PairingKey) = 32),
     CreatedAt  integer not null,
     LastSeenAt integer not null
 );

--- a/pkg/database/userdb/sql.go
+++ b/pkg/database/userdb/sql.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -53,6 +54,7 @@ func sqlTruncate(ctx context.Context, db *sql.DB) error {
 	sqlStmt := `
 	delete from History;
 	delete from Mappings;
+	delete from Clients;
 	vacuum;
 	`
 	_, err := db.ExecContext(ctx, sqlStmt)
@@ -730,4 +732,114 @@ func sqlDeleteAllInboxMessages(ctx context.Context, db *sql.DB) (int64, error) {
 	}
 
 	return rowsAffected, nil
+}
+
+// ErrInvalidAuthToken rejects ':' in auth tokens (AAD uses `<token>:ws`;
+// also enforced by SQL CHECK).
+var ErrInvalidAuthToken = errors.New("auth token must not contain ':'")
+
+func sqlCreateClient(ctx context.Context, db *sql.DB, c *database.Client) error {
+	if strings.ContainsRune(c.AuthToken, ':') {
+		return ErrInvalidAuthToken
+	}
+	var dbid int64
+	err := db.QueryRowContext(ctx, `
+		INSERT INTO Clients (ClientID, ClientName, AuthToken, PairingKey, CreatedAt, LastSeenAt)
+		VALUES (?, ?, ?, ?, ?, ?)
+		RETURNING DBID;
+	`, c.ClientID, c.ClientName, c.AuthToken, c.PairingKey, c.CreatedAt, c.LastSeenAt).Scan(&dbid)
+	if err != nil {
+		return fmt.Errorf("failed to insert client: %w", err)
+	}
+	c.DBID = dbid
+	return nil
+}
+
+func sqlGetClientByToken(ctx context.Context, db *sql.DB, authToken string) (*database.Client, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT DBID, ClientID, ClientName, AuthToken, PairingKey, CreatedAt, LastSeenAt
+		FROM Clients
+		WHERE AuthToken = ?;
+	`, authToken)
+
+	c := database.Client{}
+	err := row.Scan(&c.DBID, &c.ClientID, &c.ClientName, &c.AuthToken, &c.PairingKey, &c.CreatedAt, &c.LastSeenAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("client not found: %w", err)
+		}
+		return nil, fmt.Errorf("failed to scan client row: %w", err)
+	}
+	return &c, nil
+}
+
+func sqlListClients(ctx context.Context, db *sql.DB) ([]database.Client, error) {
+	list := make([]database.Client, 0)
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT DBID, ClientID, ClientName, AuthToken, PairingKey, CreatedAt, LastSeenAt
+		FROM Clients
+		ORDER BY CreatedAt DESC;
+	`)
+	if err != nil {
+		return list, fmt.Errorf("failed to query clients: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql rows")
+		}
+	}()
+
+	for rows.Next() {
+		c := database.Client{}
+		if scanErr := rows.Scan(
+			&c.DBID, &c.ClientID, &c.ClientName, &c.AuthToken,
+			&c.PairingKey, &c.CreatedAt, &c.LastSeenAt,
+		); scanErr != nil {
+			return list, fmt.Errorf("failed to scan client row: %w", scanErr)
+		}
+		list = append(list, c)
+	}
+
+	if err = rows.Err(); err != nil {
+		return list, fmt.Errorf("error iterating client rows: %w", err)
+	}
+	return list, nil
+}
+
+func sqlDeleteClient(ctx context.Context, db *sql.DB, clientID string) error {
+	result, err := db.ExecContext(ctx, `DELETE FROM Clients WHERE ClientID = ?;`, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to execute client delete: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("client not found: %s", clientID)
+	}
+	return nil
+}
+
+func sqlUpdateClientLastSeen(ctx context.Context, db *sql.DB, authToken string, lastSeenAt int64) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE Clients SET LastSeenAt = ? WHERE AuthToken = ?;`,
+		lastSeenAt, authToken,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update client last seen: %w", err)
+	}
+	return nil
+}
+
+func sqlCountClients(ctx context.Context, db *sql.DB) (int, error) {
+	var count int
+	err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM Clients;`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count clients: %w", err)
+	}
+	return count, nil
 }

--- a/pkg/database/userdb/sql.go
+++ b/pkg/database/userdb/sql.go
@@ -824,6 +824,9 @@ func sqlDeleteClient(ctx context.Context, db *sql.DB, clientID string) error {
 	return nil
 }
 
+// sqlUpdateClientLastSeen is a fire-and-forget used by the async LastSeenTracker.
+// It intentionally does not check RowsAffected — a deleted client is a normal
+// no-op here, unlike sqlDeleteClient which reports "not found" to the caller.
 func sqlUpdateClientLastSeen(ctx context.Context, db *sql.DB, authToken string, lastSeenAt int64) error {
 	_, err := db.ExecContext(ctx,
 		`UPDATE Clients SET LastSeenAt = ? WHERE AuthToken = ?;`,

--- a/pkg/database/userdb/sql_test.go
+++ b/pkg/database/userdb/sql_test.go
@@ -683,14 +683,18 @@ func TestSqlGetZapLinkCache_NotFound(t *testing.T) {
 
 // Database Management Function Tests
 
+// TestSqlTruncate_Success pins that sqlTruncate wipes every user table
+// (History, Mappings, Clients) and runs VACUUM. The Clients clause is
+// load-bearing: paired clients must not survive a Truncate, otherwise
+// auth tokens would outlive the data the user thought they erased.
 func TestSqlTruncate_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(`delete from History.*delete from Mappings.*vacuum`).
-		WillReturnResult(sqlmock.NewResult(0, 2)) // 2 tables affected
+	mock.ExpectExec(`(?s)delete from History.*delete from Mappings.*delete from Clients.*vacuum`).
+		WillReturnResult(sqlmock.NewResult(0, 3)) // 3 tables affected
 
 	err = sqlTruncate(context.Background(), db)
 	require.NoError(t, err)
@@ -703,7 +707,7 @@ func TestSqlTruncate_DatabaseError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectExec(`delete from History.*delete from Mappings.*vacuum`).
+	mock.ExpectExec(`(?s)delete from History.*delete from Mappings.*delete from Clients.*vacuum`).
 		WillReturnError(sqlmock.ErrCancelled)
 
 	err = sqlTruncate(context.Background(), db)

--- a/pkg/database/userdb/userdb_integration_test.go
+++ b/pkg/database/userdb/userdb_integration_test.go
@@ -453,3 +453,139 @@ func TestInbox_CategoryUpsert_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, messages, 3, "Should have 3 messages (category is per-profile)")
 }
+
+func TestClientCRUD_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	// Empty list initially
+	clients, err := userDB.ListClients()
+	require.NoError(t, err)
+	assert.Empty(t, clients, "Clients should be empty initially")
+
+	count, err := userDB.CountClients()
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "Client count should be 0 initially")
+
+	// Create two clients
+	c1 := database.Client{
+		ClientID:   "client-1",
+		ClientName: "First App",
+		AuthToken:  "token-1",
+		PairingKey: []byte("key-1-key-1-key-1-key-1-key-1-12"),
+		CreatedAt:  1700000000,
+		LastSeenAt: 1700000000,
+	}
+	err = userDB.CreateClient(&c1)
+	require.NoError(t, err, "Should be able to create first client")
+	assert.Positive(t, c1.DBID, "Should have assigned a DBID")
+
+	c2 := database.Client{
+		ClientID:   "client-2",
+		ClientName: "Second App",
+		AuthToken:  "token-2",
+		PairingKey: []byte("key-2-key-2-key-2-key-2-key-2-12"),
+		CreatedAt:  1700001000,
+		LastSeenAt: 1700001000,
+	}
+	err = userDB.CreateClient(&c2)
+	require.NoError(t, err, "Should be able to create second client")
+
+	// Count
+	count, err = userDB.CountClients()
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// List — ordered by CreatedAt DESC, so c2 first
+	clients, err = userDB.ListClients()
+	require.NoError(t, err)
+	require.Len(t, clients, 2)
+	assert.Equal(t, "client-2", clients[0].ClientID)
+	assert.Equal(t, "client-1", clients[1].ClientID)
+
+	// Get by token
+	got, err := userDB.GetClientByToken("token-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "client-1", got.ClientID)
+	assert.Equal(t, "First App", got.ClientName)
+	assert.Equal(t, c1.PairingKey, got.PairingKey)
+
+	// Get by missing token
+	_, err = userDB.GetClientByToken("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client not found")
+
+	// Update last seen
+	err = userDB.UpdateClientLastSeen("token-1", 1700009999)
+	require.NoError(t, err)
+
+	got, err = userDB.GetClientByToken("token-1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1700009999), got.LastSeenAt)
+
+	// Delete one
+	err = userDB.DeleteClient("client-1")
+	require.NoError(t, err)
+
+	count, err = userDB.CountClients()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Delete missing
+	err = userDB.DeleteClient("nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "client not found")
+
+	// Unique constraints — duplicate ClientID rejected
+	dupID := database.Client{
+		ClientID:   "client-2",
+		ClientName: "dup",
+		AuthToken:  "token-3",
+		PairingKey: []byte("key-3-key-3-key-3-key-3-key-3-12"),
+		CreatedAt:  1700002000,
+		LastSeenAt: 1700002000,
+	}
+	err = userDB.CreateClient(&dupID)
+	require.Error(t, err, "Duplicate ClientID should be rejected")
+
+	// Unique constraints — duplicate AuthToken rejected
+	dupTok := database.Client{
+		ClientID:   "client-3",
+		ClientName: "dup",
+		AuthToken:  "token-2",
+		PairingKey: []byte("key-3-key-3-key-3-key-3-key-3-12"),
+		CreatedAt:  1700002000,
+		LastSeenAt: 1700002000,
+	}
+	err = userDB.CreateClient(&dupTok)
+	require.Error(t, err, "Duplicate AuthToken should be rejected")
+}
+
+// TestClientAuthTokenColonCheckConstraint_Integration pins the SQL CHECK
+// constraint that forbids `:` in AuthToken at the schema level. The Go-side
+// check in sqlCreateClient is exercised by clients_test.go; this test
+// bypasses the Go check via raw SQL so a regression that removed only the
+// schema constraint would still be caught.
+func TestClientAuthTokenColonCheckConstraint_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	// Bypass sqlCreateClient by inserting directly into the underlying
+	// *sql.DB. The Clients table CHECK clause must reject the colon-bearing
+	// token without any Go-level validation involved.
+	pairingKey := []byte("key-x-key-x-key-x-key-x-key-x-12")
+	_, err := userDB.sql.ExecContext(context.Background(), `
+		INSERT INTO Clients (ClientID, ClientName, AuthToken, PairingKey, CreatedAt, LastSeenAt)
+		VALUES (?, ?, ?, ?, ?, ?);
+	`, "raw-id", "Raw App", "evil:token", pairingKey, int64(1700000000), int64(1700000000))
+	require.Error(t, err, "SQL CHECK constraint must reject AuthToken containing ':'")
+	assert.Contains(t, err.Error(), "CHECK",
+		"the failure should originate from a CHECK constraint, not a different error path")
+}

--- a/pkg/database/userdb/userdb_integration_test.go
+++ b/pkg/database/userdb/userdb_integration_test.go
@@ -580,7 +580,7 @@ func TestClientAuthTokenColonCheckConstraint_Integration(t *testing.T) {
 	// Bypass sqlCreateClient by inserting directly into the underlying
 	// *sql.DB. The Clients table CHECK clause must reject the colon-bearing
 	// token without any Go-level validation involved.
-	pairingKey := []byte("key-x-key-x-key-x-key-x-key-x-12")
+	pairingKey := []byte("key-x-key-x-key-x-key-x-key-x-ab")
 	_, err := userDB.sql.ExecContext(context.Background(), `
 		INSERT INTO Clients (ClientID, ClientName, AuthToken, PairingKey, CreatedAt, LastSeenAt)
 		VALUES (?, ?, ?, ?, ?, ?);

--- a/pkg/service/discovery/discovery.go
+++ b/pkg/service/discovery/discovery.go
@@ -49,6 +49,13 @@ var virtualInterfacePrefixes = []string{
 	"cni", "flannel", "cali", "tunl", "wg",
 }
 
+// defaultTXTRecords is intentionally empty: device ID, version, and platform
+// are exposed only via the authenticated API. Broadcasting them on the LAN
+// would expose information useful for targeted attacks (version → known
+// vulnerabilities, platform → attack surface). Any change to this slice must
+// be pinned by TestDefaultTXTRecordsAreEmpty.
+var defaultTXTRecords = []string{}
+
 // getPreferredInterfaces returns network interfaces suitable for mDNS registration.
 // It filters out loopback, down, non-multicast, and virtual interfaces.
 func getPreferredInterfaces() ([]net.Interface, error) {
@@ -106,17 +113,15 @@ type Service struct {
 	server       *zeroconf.Server
 	cfg          *config.Instance
 	cancelFunc   context.CancelFunc
-	platformID   string
 	instanceName string
 	stopped      bool
 	mu           syncutil.Mutex
 }
 
 // New creates a new discovery service.
-func New(cfg *config.Instance, platformID string) *Service {
+func New(cfg *config.Instance) *Service {
 	return &Service{
-		cfg:        cfg,
-		platformID: platformID,
+		cfg: cfg,
 	}
 }
 
@@ -158,11 +163,9 @@ func (s *Service) Start() error {
 func (s *Service) tryRegister() bool {
 	port := s.cfg.APIPort()
 
-	txtRecords := []string{
-		"id=" + s.cfg.DeviceID(),
-		"version=" + config.AppVersion,
-		"platform=" + s.platformID,
-	}
+	// See defaultTXTRecords for the rationale behind broadcasting an empty
+	// TXT record set.
+	txtRecords := defaultTXTRecords
 
 	ifaces, err := getPreferredInterfaces()
 	if err != nil {

--- a/pkg/service/discovery/discovery_test.go
+++ b/pkg/service/discovery/discovery_test.go
@@ -29,41 +29,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNew(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name       string
-		platformID string
-	}{
-		{"mister platform", "mister"},
-		{"linux platform", "linux"},
-		{"steamos platform", "steamos"},
-		{"windows platform", "windows"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			svc := New(nil, tt.platformID)
-
-			assert.NotNil(t, svc)
-			assert.Equal(t, tt.platformID, svc.platformID)
-		})
-	}
-}
-
 func TestServiceType(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "_zaparoo._tcp", ServiceType)
 }
 
+// TestDefaultTXTRecordsAreEmpty pins the security-driven design that mDNS
+// service announcements carry NO TXT records. See defaultTXTRecords doc
+// comment for the rationale.
+func TestDefaultTXTRecordsAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, defaultTXTRecords,
+		"mDNS TXT records must remain empty to avoid leaking version/platform/id on the LAN")
+}
+
 func TestStopIdempotent(t *testing.T) {
 	t.Parallel()
 
-	svc := New(nil, "test")
+	svc := New(nil)
 
 	// Stop should be safe to call multiple times even when not started
 	svc.Stop()
@@ -77,7 +62,7 @@ func TestStopIdempotent(t *testing.T) {
 func TestInstanceNameBeforeStart(t *testing.T) {
 	t.Parallel()
 
-	svc := New(nil, "test")
+	svc := New(nil)
 
 	// InstanceName should return empty string before Start() is called
 	assert.Empty(t, svc.InstanceName())
@@ -94,7 +79,7 @@ func TestInstanceNameWhenDiscoveryDisabled(t *testing.T) {
 	// Disable discovery
 	cfg.SetDiscoveryEnabled(false)
 
-	svc := New(cfg, "test")
+	svc := New(cfg)
 	err = svc.Start()
 	require.NoError(t, err)
 
@@ -114,7 +99,7 @@ func TestInstanceNameUsesHostname(t *testing.T) {
 	expectedHostname, err := os.Hostname()
 	require.NoError(t, err)
 
-	svc := New(cfg, "test")
+	svc := New(cfg)
 
 	// Start will fail at zeroconf.Register, but instanceName is set
 	// before Register is called, so we can still verify the resolution
@@ -134,7 +119,7 @@ func TestInstanceNameUsesConfigOverride(t *testing.T) {
 	// Set a custom instance name in config
 	cfg.SetDiscoveryInstanceName("my-custom-name")
 
-	svc := New(cfg, "test")
+	svc := New(cfg)
 	_ = svc.Start() // Ignore error - Register may fail without network
 
 	// instanceName should use the config override, not hostname

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -310,7 +310,7 @@ func Start(
 	go checkAndResumeOptimization(db, st.Notifications, indexPauser)
 
 	log.Info().Msg("starting mDNS discovery service")
-	discoveryService := discovery.New(cfg, pl.ID())
+	discoveryService := discovery.New(cfg)
 	if discoveryErr := discoveryService.Start(); discoveryErr != nil {
 		log.Warn().Err(discoveryErr).Msg("mDNS discovery initialization failed")
 	}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -416,6 +416,70 @@ func (m *MockUserDBI) DeleteAllInboxMessages() (int64, error) {
 	return rowsDeleted, nil
 }
 
+func (m *MockUserDBI) CreateClient(c *database.Client) error {
+	args := m.Called(c)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI create client failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) GetClientByToken(authToken string) (*database.Client, error) {
+	args := m.Called(authToken)
+	if result, ok := args.Get(0).(*database.Client); ok {
+		if err := args.Error(1); err != nil {
+			return nil, fmt.Errorf("mock UserDBI get client by token failed: %w", err)
+		}
+		return result, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock UserDBI get client by token failed: %w", err)
+	}
+	return nil, nil //nolint:nilnil // mock returns nil when no client is configured
+}
+
+func (m *MockUserDBI) ListClients() ([]database.Client, error) {
+	args := m.Called()
+	if clients, ok := args.Get(0).([]database.Client); ok {
+		if err := args.Error(1); err != nil {
+			return clients, fmt.Errorf("mock UserDBI list clients failed: %w", err)
+		}
+		return clients, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock UserDBI list clients failed: %w", err)
+	}
+	return nil, nil
+}
+
+func (m *MockUserDBI) DeleteClient(clientID string) error {
+	args := m.Called(clientID)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI delete client failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) UpdateClientLastSeen(authToken string, lastSeenAt int64) error {
+	args := m.Called(authToken, lastSeenAt)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI update client last seen failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) CountClients() (int, error) {
+	args := m.Called()
+	count, ok := args.Get(0).(int)
+	if !ok {
+		count = 0
+	}
+	if err := args.Error(1); err != nil {
+		return count, fmt.Errorf("mock UserDBI count clients failed: %w", err)
+	}
+	return count, nil
+}
+
 // MockMediaDBI is a mock implementation of the MediaDBI interface using testify/mock
 type MockMediaDBI struct {
 	mock.Mock


### PR DESCRIPTION
## Summary

- PAKE-based client pairing (schollz/pake/v3, P-256) with 6-digit PIN and HMAC confirmation
- AES-256-GCM per-session encryption for WebSocket with HKDF-derived directional keys
- Non-WS transports (HTTP POST, SSE, REST GET) locked to localhost by default
- Paired client management: Clients table, `clients`/`clients.delete` RPC methods
- mDNS TXT records stripped (no version/platform/id broadcast)
- Client SDK docs at `docs/api/encryption.md`

Encryption defaults to **off**. Localhost is always exempt. This is PR1 (server); TUI pairing menu is PR2.

## Transport policy changes

When `AllowedIPs` is empty (default) and encryption is off (default):

| Transport | Localhost | Remote (old) | Remote (new) |
|---|---|---|---|
| **WebSocket** | Open | Open (API key) | Open (API key) — **no change** |
| **HTTP POST** (`/api`) | Open | Open (API key) | **Blocked (403)** |
| **SSE** (`/api/events`) | Open | Open (API key) | **Blocked (403)** |
| **REST GET** (`/run/*` etc) | Open | Open (API key) | **Blocked (403)** |
| **Pairing** (`/api/pair/*`) | Open | N/A (new) | Open (rate-limited) |
| **Health** (`/health`) | Open | Open | Open — **no change** |
| **App** (`/app/*`) | Open | Open | Open — **no change** |

Remote HTTP POST, SSE, and REST GET users who currently rely on an empty `AllowedIPs` must add their IP/CIDR to restore access. WebSocket (the primary transport for all clients) is unaffected.

When `AllowedIPs` is populated, listed IPs can access all transports as before.

## New dependencies

- `github.com/schollz/pake/v3` v3.1.1 (PAKE protocol)
- `github.com/google/uuid` (already indirect, now direct for client IDs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end WebSocket encryption with a PIN-based pairing flow (PAKE), per-session keys, and encrypted JSON-RPC framing.
  * Pairing HTTP endpoints (/api/pair/start, /api/pair/finish) with rate limiting and a one-time PIN flow.
  * Localhost-only paired-client management: list and delete paired devices; server emits a "clients.paired" notification.
  * Config toggle to enable/disable WebSocket encryption and automatic last-seen tracking for paired clients.
  * Non-WebSocket HTTP/SSE routes are now restricted by allowlist; pairing endpoints remain remotely reachable.

* **Documentation**
  * New comprehensive guide documenting the WebSocket encryption protocol, pairing flow, and client examples.

* **Bug Fixes / Reliability**
  * Background cleanup, rate-limit and replay protections, and counter exhaustion guards to improve session robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->