### PR TITLE
ci: add SBOM generation and artifact attestations to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,6 +437,54 @@ jobs:
           PKG_VERSION="${VERSION//-/_}"
           gh release upload "$tag" "_build/packages/batocera/zaparoo-core-${PKG_VERSION}-1-any.pkg.tar.zst" --clobber
 
+  attest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Attest release artifacts
+    needs: [sign-windows, build-batocera-any]
+    if: ${{ !cancelled() && !inputs.test_build && needs.sign-windows.result == 'success' }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.BUILD_TAG }}
+        run: |
+          mkdir -p _release
+          gh release download "$tag" --dir _release \
+            --pattern "zaparoo-*.tar.gz" \
+            --pattern "zaparoo-*.zip" \
+            --pattern "zaparoo-core-*.pkg.tar.zst" \
+            --pattern "zaparoo-*-setup.exe"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          format: spdx-json
+          output-file: _release/sbom.spdx.json
+
+      - name: Attest build provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: '_release/zaparoo-*'
+
+      - name: Attest SBOM
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: '_release/zaparoo-*'
+          sbom-path: _release/sbom.spdx.json
+
+      - name: Upload SBOM to release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.BUILD_TAG }}
+        run: gh release upload "$tag" _release/sbom.spdx.json --clobber
+
 #  build_mac_app:
 #    runs-on: macos-12
 #    name: Package and release Mac app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
     timeout-minutes: 15
     name: Attest release artifacts
     needs: [sign-windows, build-batocera-any]
-    if: ${{ !cancelled() && !inputs.test_build && needs.sign-windows.result == 'success' }}
+    if: ${{ !cancelled() && !inputs.test_build && needs.sign-windows.result == 'success' && needs.build-batocera-any.result == 'success' }}
     permissions:
       contents: write
       id-token: write

--- a/pkg/api/middleware/encryption.go
+++ b/pkg/api/middleware/encryption.go
@@ -29,12 +29,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-	"github.com/rs/zerolog/log"
-
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog/log"
 )
 
 // EncryptionProtoVersion is the current encryption protocol version. The

--- a/pkg/api/middleware/encryption.go
+++ b/pkg/api/middleware/encryption.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog/log"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
-	"github.com/rs/zerolog/log"
 )
 
 // EncryptionProtoVersion is the current encryption protocol version. The
@@ -204,6 +206,7 @@ type failedFrameTracker struct {
 // all sessions. Sessions are stored on the melody session after establishment.
 type EncryptionGateway struct {
 	db                       database.UserDBI
+	clock                    clockwork.Clock
 	saltSeen                 map[string]map[string]time.Time
 	failSeen                 map[string]*failedFrameTracker
 	maxSaltsPerClient        int
@@ -263,6 +266,11 @@ func WithMaxFailEntries(n int) EncryptionGatewayOption {
 	return func(m *EncryptionGateway) { m.maxFailEntries = n }
 }
 
+// WithClock overrides the clock used for timestamps (useful for testing).
+func WithClock(c clockwork.Clock) EncryptionGatewayOption {
+	return func(m *EncryptionGateway) { m.clock = c }
+}
+
 // NewEncryptionGateway constructs a EncryptionGateway with default limits.
 func NewEncryptionGateway(db database.UserDBI, opts ...EncryptionGatewayOption) *EncryptionGateway {
 	m := &EncryptionGateway{
@@ -280,6 +288,9 @@ func NewEncryptionGateway(db database.UserDBI, opts ...EncryptionGatewayOption) 
 	}
 	for _, opt := range opts {
 		opt(m)
+	}
+	if m.clock == nil {
+		m.clock = clockwork.NewRealClock()
 	}
 	return m
 }
@@ -439,7 +450,7 @@ func (m *EncryptionGateway) isBlocked(authToken, sourceIP string) bool {
 	if !ok {
 		return false
 	}
-	if time.Now().Before(t.blockedUntil) {
+	if m.clock.Now().Before(t.blockedUntil) {
 		return true
 	}
 	return false
@@ -461,7 +472,7 @@ func (m *EncryptionGateway) recordFailure(authToken, sourceIP string) {
 		m.failSeen[key] = t
 	}
 	t.failures++
-	t.lastFailureAt = time.Now()
+	t.lastFailureAt = m.clock.Now()
 
 	if t.failures >= m.failedFrameThreshold {
 		// Apply backoff. blockCount starts at 0 → 1x duration.
@@ -473,7 +484,7 @@ func (m *EncryptionGateway) recordFailure(authToken, sourceIP string) {
 		if dur > m.failedFrameMaxBlock {
 			dur = m.failedFrameMaxBlock
 		}
-		t.blockedUntil = time.Now().Add(dur)
+		t.blockedUntil = m.clock.Now().Add(dur)
 		t.blockCount++
 		t.failures = 0
 		log.Warn().
@@ -586,13 +597,13 @@ func (m *EncryptionGateway) checkAndRecordSalt(authToken string, salt []byte) er
 		delete(t, oldestKey)
 	}
 
-	t[saltHex] = time.Now()
+	t[saltHex] = m.clock.Now()
 	return nil
 }
 
 // cleanupExpired evicts old salt entries and stale failure trackers.
 func (m *EncryptionGateway) cleanupExpired() {
-	now := time.Now()
+	now := m.clock.Now()
 
 	m.saltMu.Lock()
 	for token, tracker := range m.saltSeen {

--- a/pkg/api/middleware/encryption_test.go
+++ b/pkg/api/middleware/encryption_test.go
@@ -29,15 +29,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // pairedClient builds a fake paired client. Used by tests to drive the

--- a/pkg/api/middleware/encryption_test.go
+++ b/pkg/api/middleware/encryption_test.go
@@ -29,13 +29,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // pairedClient builds a fake paired client. Used by tests to drive the
@@ -801,9 +803,11 @@ func TestEstablishSession_FailSeenCapEvictsOldest(t *testing.T) {
 	c, _ := pairedClient(t)
 	db := helpers.NewMockUserDBI()
 	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	fakeClock := clockwork.NewFakeClock()
 	mgr := middleware.NewEncryptionGateway(db,
 		middleware.WithFailedFrameThreshold(2),
 		middleware.WithMaxFailEntries(3),
+		middleware.WithClock(fakeClock),
 	)
 
 	// Build a frame that will fail decryption (so recordFailure is called)
@@ -819,10 +823,13 @@ func TestEstablishSession_FailSeenCapEvictsOldest(t *testing.T) {
 		}
 	}
 
+	// Advance the fake clock between iterations so each entry gets a
+	// distinct lastFailureAt timestamp, making LRU eviction deterministic.
 	ips := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"}
 	for _, ip := range ips {
 		_, _, err := mgr.EstablishSession(mkFrame(), ip)
 		require.Error(t, err)
+		fakeClock.Advance(time.Second)
 	}
 
 	// 10.0.0.1 (the oldest) was evicted. Hitting it once more should fail


### PR DESCRIPTION
## Summary

- Add new `attest` job that runs after all build and signing jobs complete
- Downloads all release assets, generates SPDX SBOM, creates Sigstore-signed build provenance and SBOM attestations
- SBOM uploaded as a release asset
- Skipped for test builds
- Release artifacts verifiable with `gh attestation verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated build attestations and SBOM generation now attach a machine-readable SBOM to releases and record verifiable build provenance for published packages, improving supply-chain traceability.
* **Bug Fixes**
  * Improved determinism in session rate-limiting behavior to reduce unexpected eviction/blocking anomalies.
* **Tests**
  * Tests updated to use controllable clocks for reliable, deterministic verification of failure/eviction logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->