### PR TITLE
feat: encryption feedback - pairing CLI, docs rewrite

### DIFF
--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -1,110 +1,81 @@
 # API Encryption
 
-> **Status**: Available in Zaparoo Core 2.x. Disabled by default.
-
-The Zaparoo API supports application-layer encryption on the WebSocket transport using a PAKE-based pairing flow and AES-256-GCM with per-session HKDF-derived keys. This document describes the wire protocol for client SDK implementors.
+Zaparoo encrypts WebSocket traffic using PAKE-based pairing and AES-256-GCM with per-session HKDF-derived keys. This is the wire protocol reference for client implementors.
 
 ## Overview
 
-- **Pairing**: One-time PAKE2 (P-256) handshake. The user enters a 6-digit PIN displayed on the Zaparoo device into the client app. A shared 32-byte pairing key is derived without ever transmitting the PIN.
-- **Encryption**: AES-256-GCM with implicit counter-derived nonces on every WebSocket frame after the first.
-- **Per-session keys**: On each new WebSocket connection the client generates a random 16-byte session salt; both sides derive ephemeral session keys via HKDF-SHA256 using the pairing key as IKM and the session salt as the HKDF salt. Counters reset to 0 each session.
-- **Scope**: Encryption applies to **WebSocket only**. Non-WebSocket transports (HTTP POST, SSE, REST GET) are restricted to localhost by default and require an explicit IP allowlist for remote access.
+- **Pairing**: One-time PAKE2 (P-256) handshake. User enters a 6-digit PIN from the Zaparoo device into the client app. Both sides derive a shared 32-byte pairing key — the PIN is never transmitted.
+- **Encryption**: AES-256-GCM with counter-derived nonces on every WebSocket frame.
+- **Per-session keys**: Each WebSocket connection generates a random 16-byte session salt. Both sides derive ephemeral keys via HKDF-SHA256 (pairing key as IKM, session salt as HKDF salt).
+- **Scope**: WebSocket only. HTTP POST, SSE, and REST GET are localhost-restricted by default.
 
-## Encryption setting
+## Configuration
 
-The server has a single boolean setting `encryption` (in the `[service]` section of `config.toml`):
+Set `encryption` in `[service]` of `config.toml`:
 
 | Value | Behavior |
 |---|---|
-| `false` (default) | No encryption. All WebSocket connections accepted as plaintext; API key authentication applies. |
-| `true` | Remote WebSocket connections must send an encrypted first frame derived from a paired key. Plaintext WebSocket connections from non-loopback addresses are rejected. API key authentication for the WebSocket transport is bypassed (the pairing key proves identity). Localhost is always exempt — local plaintext WebSocket connections continue to work without pairing. |
-
-The `encryption` setting only affects the WebSocket transport. HTTP POST, SSE, and REST GET endpoints always use the IP allowlist + API key auth model and are unaffected.
+| `false` (default) | No encryption. All WebSocket connections accepted as plaintext. |
+| `true` | Remote WebSocket connections must send an encrypted first frame from a paired client. Localhost plaintext connections still work without pairing. |
 
 ## Pairing flow
 
-Pairing happens over plain HTTP (the PAKE protocol provides its own security). Two round trips establish a shared 32-byte pairing key.
+Two HTTP round trips establish a shared 32-byte pairing key.
 
-```text
-TUI                     Server                       Client App
-───                     ──────                       ──────────
-User: "Pair device"
-                        Generate 6-digit PIN
-Display PIN             Store PIN (5min expiry)
+```mermaid
+sequenceDiagram
+    participant Z as Zaparoo
+    participant C as Client
 
-                                                     User types PIN
-                                                     A = pake.InitCurve(pin, 0, "p256")
+    Note over Z: User triggers "Pair device"
+    Note over Z: Generate + display 6-digit PIN (5 min expiry)
 
-                        ← POST /api/pair/start ────────────────
-                          { "pake": base64(A.Bytes()),
-                            "name": "MyApp" }
+    Note over C: User types PIN into client
+    Note over C: A = pake.InitCurve(pin, 0, "p256")
 
-                        B = pake.InitCurve(pin, 1, "p256")
-                        B.Update(A.Bytes())
+    C->>Z: POST /api/pair/start<br/>{ pake: base64(A.Bytes()), name: "MyApp" }
+    Note over Z: B = pake.InitCurve(pin, 1, "p256")<br/>B.Update(A.Bytes())
+    Z->>C: 200 { session: uuid, pake: base64(B.Bytes()) }
 
-                        ── 200 { "session": uuid, ──────────→
-                             "pake": base64(B.Bytes()) }
+    Note over C: A.Update(B.Bytes())<br/>sessionKey = A.SessionKey()<br/>prk = HKDF-Extract(sessionKey, nil)<br/>confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)<br/>confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)<br/>pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
 
-                                                     A.Update(B.Bytes())
-                                                     sessionKey = A.SessionKey()
-                                                     prk = HKDF-Extract(sessionKey, nil)
-                                                     confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)
-                                                     confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)
-                                                     pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
+    C->>Z: POST /api/pair/finish<br/>{ session: uuid, confirm: base64(HMAC) }
+    Note over Z: Verify client HMAC, persist client
+    Z->>C: 200 { authToken: uuid, clientId: uuid, confirm: base64(HMAC) }
 
-                        ← POST /api/pair/finish ───────────────
-                          { "session": uuid,
-                            "confirm": base64(HMAC-SHA256(
-                              confirmKeyA,
-                              LP("zaparoo-v1") || LP("p256") ||
-                              LP("client") || LP(name) ||
-                              LP(MsgA) || LP(MsgB))) }
-
-                        Verify client HMAC.
-                        On success: persist client, return:
-
-                        ── 200 { "authToken": uuid, ────────→
-                             "clientId": uuid,
-                             "confirm": base64(HMAC(
-                               confirmKeyB, "server" || ...)) }
-
-                                                     Verify server HMAC.
-                                                     Store authToken + pairingKey securely.
-                                                     (pairingKey was derived locally above —
-                                                      it is NEVER sent over the wire.)
-PIN cleared
+    Note over C: Verify server HMAC<br/>Store authToken + pairingKey
+    Note over Z: Clear PIN
 ```
 
-### Length-prefixed encoding
+### HMAC transcript
 
-The HMAC inputs use length-prefixed encoding to prevent canonicalization attacks: each variable-length field is encoded as a 4-byte big-endian length prefix followed by the bytes.
+Confirm HMACs use length-prefixed encoding:
 
 ```text
 LP(field) = 4-byte big-endian uint32 length || field bytes
 ```
 
-The HMAC transcript is:
+Full transcript:
 
 ```text
 LP("zaparoo-v1") || LP("p256") || LP(role) || LP(clientName) || LP(MsgA) || LP(MsgB)
 ```
 
-where `role` is the literal string `"client"` or `"server"`, and `MsgA` / `MsgB` are the **raw bytes** sent over the wire at `/pair/start` (NOT the result of calling `pake.Bytes()` again after `Update()`, which would mutate the state and produce different bytes).
+Where `role` is `"client"` or `"server"`, and `MsgA`/`MsgB` are the **raw bytes sent over the wire** (not the result of calling `pake.Bytes()` again after `Update()`).
 
 ### Pairing limits
 
-- **PIN**: 6 decimal digits, generated with `crypto/rand`. ~20 bits of entropy.
+- **PIN**: 6 decimal digits, `crypto/rand`. ~20 bits of entropy.
 - **Expiry**: 5 minutes from PIN generation.
-- **Attempts**: 3 failed `/pair/finish` HMAC verifications across all sessions for the same PIN before the PIN is invalidated.
-- **Sessions**: A `/pair/start` session expires after 2 minutes if `/pair/finish` is not called.
+- **Attempts**: 3 failed HMAC verifications per PIN before invalidation.
+- **Sessions**: `/pair/start` session expires after 2 minutes.
 - **Client name**: max 128 bytes.
-- **Max paired clients**: 50 per device. The 51st pairing attempt is rejected.
-- **Rate limit**: 1 request/sec per IP on `/api/pair/*` endpoints.
+- **Max paired clients**: 50 per device.
+- **Rate limit**: 1 req/sec per IP on `/api/pair/*`.
 
-## Encryption — WebSocket message format
+## Message format
 
-After pairing, every WebSocket connection begins with an encrypted first frame that establishes the session.
+Every encrypted WebSocket connection starts with a first frame that establishes the session.
 
 ### First frame (client → server)
 
@@ -117,13 +88,12 @@ After pairing, every WebSocket connection begins with an encrypted first frame t
 }
 ```
 
-- `v`: Protocol version. Currently `1`. The server returns a plaintext error if unsupported:
-  ```json
-  {"jsonrpc": "2.0", "id": null, "error": {"code": -32001, "message": "unsupported encryption version", "data": {"supported": [1]}}}
-  ```
-- `e`: AES-256-GCM ciphertext of the JSON-RPC request, base64-encoded.
-- `t`: Auth token (UUID) identifying the paired client. Sent in plaintext as a key lookup; not a secret.
-- `s`: 16-byte random session salt, base64-encoded. **Must be exactly 16 bytes.** The server rejects any other size.
+| Field | Description |
+|---|---|
+| `v` | Protocol version. Currently `1`. Server returns a plaintext error if unsupported (see [Errors](#errors)). |
+| `e` | AES-256-GCM ciphertext of the JSON-RPC request, base64-encoded. |
+| `t` | Auth token (UUID) identifying the paired client. Not a secret — used for key lookup. |
+| `s` | 16-byte random session salt, base64-encoded. Must be exactly 16 bytes. |
 
 ### Subsequent frames (both directions)
 
@@ -133,11 +103,13 @@ After pairing, every WebSocket connection begins with an encrypted first frame t
 }
 ```
 
-The counter is implicit — both sides start at 0 and increment by 1 per frame. WebSocket is TCP (ordered, reliable) so sender and receiver always agree on the next counter value. **If decryption fails the connection is closed** — there is no recovery.
+Counters are implicit: both sides start at 0 and increment per frame. WebSocket guarantees ordering. If decryption fails, the connection is closed.
 
-### Inside the encrypted payload
+Server notifications (e.g. `media.started`) use this same format, encrypted with the session keys.
 
-Once decrypted, the payload is standard JSON-RPC 2.0:
+### Decrypted payload
+
+Standard JSON-RPC 2.0:
 
 ```json
 {
@@ -148,9 +120,11 @@ Once decrypted, the payload is standard JSON-RPC 2.0:
 }
 ```
 
-## Session key derivation
+## Session cryptography
 
-On each new WebSocket connection (NOT once per pairing), the client generates a random session salt and derives ephemeral session keys via HKDF-SHA256.
+Each WebSocket connection derives its own ephemeral keys from a fresh random session salt.
+
+### Key derivation
 
 ```text
 prk     = HKDF-Extract(SHA-256, ikm=pairingKey, salt=sessionSalt)
@@ -160,69 +134,46 @@ c2sBase = HKDF-Expand(SHA-256, prk, info="zaparoo-c2s-nonce-v1", length=12)
 s2cBase = HKDF-Expand(SHA-256, prk, info="zaparoo-s2c-nonce-v1", length=12)
 ```
 
-Separate keys + nonce bases per direction prevent reflection attacks and eliminate cross-direction nonce collision.
+### Nonces
 
-### Counter-derived nonces
-
-The 12-byte AES-GCM nonce for each frame is derived by XORing a 64-bit big-endian counter into the **last 8 bytes** of the 12-byte nonce base. The first 4 bytes of the base are unchanged.
+12-byte AES-GCM nonce per frame: XOR a big-endian counter into the last 8 bytes of the nonce base:
 
 ```text
-nonce[0:4] = base[0:4]
+nonce[0:4]  = base[0:4]
 nonce[4:12] = base[4:12] XOR (counter as 8 bytes big-endian)
 ```
 
-Counters never wrap or reuse — disconnect and reconnect with a fresh salt to start over.
+Counters don't wrap. Disconnect and reconnect with a fresh salt to start over.
 
-## AAD (Additional Authenticated Data)
+### AAD
 
-Every encrypt/decrypt operation binds the ciphertext to the auth token via AAD:
+All encrypt/decrypt operations bind ciphertext to the session:
 
 ```text
 aad = authToken + ":ws"
 ```
 
-This prevents an attacker from substituting ciphertexts across sessions even if they somehow obtained the keys.
+## Security limits
 
-## Server-to-client notifications
+- **Salt reuse**: The server rejects duplicate session salts per client (200-entry / 10-minute sliding window). Always use a CSPRNG for session salts.
+- **Failed frames**: 10 consecutive first-frame decryption failures per (authToken, IP) triggers a 30-second block with exponential backoff, capped at 30 minutes.
 
-The server broadcasts notifications (e.g. `media.started`) to all connected clients. For encrypted sessions the server encrypts each notification with the per-session keys before sending. The wire format is the same as a regular outgoing frame:
+## Client dependencies
 
-```json
-{
-    "e": "<base64(ciphertext)>"
-}
-```
-
-## Duplicate session salt rejection
-
-The server maintains a per-client in-memory list of recently seen session salts (sliding window of 200 entries / 10 minutes). If a client reuses a salt, the connection is rejected. This protects against broken client CSPRNGs producing duplicate salts, which would cause catastrophic AES-GCM nonce reuse.
-
-**Always use `crypto/random` (or platform equivalent) to generate session salts.** Never derive them from time, sequence numbers, or other predictable sources.
-
-## Failed-frame rate limiting
-
-The server tracks consecutive failed first-frame decryptions per `(authToken, sourceIP)` pair. After 10 consecutive failures, that combination is blocked for 30 seconds (exponential backoff on repeated blocks, capped at 30 minutes). Successful first frames reset the counter.
-
-## Client crypto dependencies
-
-Two phases with different requirements:
-
-**Pairing (one-time)**: Requires raw P-256 elliptic curve point arithmetic. No platform's built-in crypto API exposes this directly. Client SDKs need:
+**Pairing** needs raw P-256 elliptic curve point arithmetic:
 
 | Platform | Library |
 |---|---|
-| JavaScript | [`@noble/curves`](https://github.com/paulmillr/noble-curves) (audited, zero deps) |
+| JavaScript | [`@noble/curves`](https://github.com/paulmillr/noble-curves) |
 | Python | `ecdsa` or `cryptography` |
-| Swift | [Swift Crypto](https://github.com/apple/swift-crypto) or OpenSSL binding |
-| Kotlin/Android | Bouncy Castle `ECPoint` (ships on Android) |
+| Swift | [Swift Crypto](https://github.com/apple/swift-crypto) |
+| Kotlin/Android | Bouncy Castle `ECPoint` |
 | C#/.NET | BouncyCastle NuGet |
 | Rust | `p256` crate |
 
-**Per-connection encryption (every session)**: Only needs HKDF-SHA256 + AES-256-GCM + HMAC-SHA256, all available in platform stdlib (Web Crypto, CryptoKit, JCE, .NET, RustCrypto).
+**Per-connection encryption** is just HKDF-SHA256 + AES-256-GCM + HMAC-SHA256, all in platform stdlibs (Web Crypto, CryptoKit, JCE, .NET, RustCrypto).
 
-## Client-side key storage
-
-Recommend platform-appropriate secure storage:
+## Client key storage
 
 | Platform | Recommended storage |
 |---|---|
@@ -231,125 +182,81 @@ Recommend platform-appropriate secure storage:
 | Web/Electron | OS keychain via `keytar` or similar |
 | CLI tools | File mode `0600` in user config directory |
 
-The pairing key (32 bytes) and auth token (UUID) must both be stored. The auth token is not a secret but is paired with the key — losing one renders the other useless.
+Store both the pairing key (32 bytes) and auth token (UUID). The auth token isn't secret, but it's bound to the key. Lose either and you need to re-pair.
 
-## Error handling
+## Errors
 
-| HTTP status | Endpoint | Meaning |
+HTTP errors on pairing endpoints:
+
+| Status | Endpoint | Meaning |
 |---|---|---|
 | 400 | `/pair/*` | Malformed request body or PAKE message |
 | 401 | `/pair/finish` | HMAC mismatch (wrong PIN) |
-| 403 | `/pair/start` | Maximum paired clients reached, or attempts exhausted |
+| 403 | `/pair/start` | Max paired clients reached, or attempts exhausted |
 | 404 | `/pair/finish` | Unknown session ID |
 | 410 | `/pair/*` | Pairing PIN expired |
 | 429 | `/pair/*` | Rate limit exceeded |
 
-WebSocket-level errors (sent as a plaintext JSON-RPC error then connection closed):
+WebSocket errors (plaintext JSON-RPC error, then connection closed):
 
 | Code | Meaning |
 |---|---|
 | -32001 | Unsupported encryption version |
-| -32002 | Server has encryption enabled and requires an encrypted first frame from this remote client |
+| -32002 | Encryption required — server requires an encrypted first frame from remote clients |
 
-## Discovering server requirements
+## Connection lifecycle
 
-A client that does not yet know whether the server has encryption enabled should:
+If the client doesn't know whether encryption is on:
 
 1. Try connecting plaintext.
-2. If the server returns the `-32002` error, the client must pair before reconnecting.
-3. If the user has not paired yet, prompt them to initiate pairing from the Zaparoo device's TUI.
-4. Run the PAKE handshake (`/pair/start` then `/pair/finish`); locally derive `pairingKey` from the PAKE session key via `HKDF-Expand(prk, "zaparoo-pairing-v1", 32)` (the server never returns it). Store `authToken` and the derived `pairingKey` securely.
-5. On all subsequent WebSocket connections, generate a fresh session salt, derive session keys, and send the encrypted first frame.
+2. If the server returns `-32002`, you need to pair first.
+3. Prompt the user to start pairing from the Zaparoo device.
+4. Run the PAKE handshake (`/pair/start` → `/pair/finish`). Derive `pairingKey` locally via HKDF (see [Pairing flow](#pairing-flow)). Store `authToken` and `pairingKey`.
+5. On future connections: fresh session salt, derive session keys (see [Session cryptography](#session-cryptography)), send the encrypted first frame.
 
 ## Non-WebSocket transports
 
-HTTP POST, SSE, and REST GET endpoints (`/api`, `/api/events`, `/r/*`, `/run/*`) are restricted to localhost by default. To allow remote access, the server operator must add IPs (or CIDR ranges) to the `allowed_ips` config field. These transports do **not** support encryption — they exist for simple DIY integrations on trusted networks. API key authentication still applies.
+HTTP POST, SSE, and REST GET (`/api`, `/api/events`, `/r/*`, `/run/*`) are localhost-only by default. Add IPs or CIDR ranges to `allowed_ips` in config for remote access. No encryption on these transports, they're for simple integrations on trusted networks. API key auth still applies.
 
-## Minimal JavaScript example
+## Pseudocode example
 
-```javascript
-// After pairing, the client has stored: authToken (string), pairingKey (Uint8Array, 32 bytes)
+Encrypted session lifecycle, assuming pairing is already done:
 
-async function deriveSessionKeys(pairingKey, sessionSalt) {
-    const ikm = await crypto.subtle.importKey("raw", pairingKey, "HKDF", false, ["deriveBits"]);
-    const expand = async (info, length) => crypto.subtle.deriveBits(
-        { name: "HKDF", hash: "SHA-256", salt: sessionSalt, info: new TextEncoder().encode(info) },
-        ikm,
-        length * 8,
-    );
-    return {
-        c2sKey: new Uint8Array(await expand("zaparoo-c2s-v1", 32)),
-        s2cKey: new Uint8Array(await expand("zaparoo-s2c-v1", 32)),
-        c2sBase: new Uint8Array(await expand("zaparoo-c2s-nonce-v1", 12)),
-        s2cBase: new Uint8Array(await expand("zaparoo-s2c-nonce-v1", 12)),
-    };
-}
+```text
+function connect(url, authToken, pairingKey):
+    sessionSalt = random_bytes(16)
 
-function buildNonce(base, counter) {
-    const nonce = new Uint8Array(12);
-    nonce.set(base);
-    const view = new DataView(nonce.buffer);
-    const hi = Number((counter >> 32n) & 0xffffffffn);
-    const lo = Number(counter & 0xffffffffn);
-    view.setUint32(4, view.getUint32(4) ^ hi, false);
-    view.setUint32(8, view.getUint32(8) ^ lo, false);
-    return nonce;
-}
+    // Derive per-session keys via HKDF-SHA256
+    prk     = hkdf_extract(sha256, ikm=pairingKey, salt=sessionSalt)
+    c2sKey  = hkdf_expand(prk, info="zaparoo-c2s-v1",       len=32)
+    s2cKey  = hkdf_expand(prk, info="zaparoo-s2c-v1",       len=32)
+    c2sBase = hkdf_expand(prk, info="zaparoo-c2s-nonce-v1", len=12)
+    s2cBase = hkdf_expand(prk, info="zaparoo-s2c-nonce-v1", len=12)
 
-async function connectEncrypted(wsUrl, authToken, pairingKey) {
-    const sessionSalt = crypto.getRandomValues(new Uint8Array(16));
-    const keys = await deriveSessionKeys(pairingKey, sessionSalt);
-    const c2sKey = await crypto.subtle.importKey("raw", keys.c2sKey, "AES-GCM", false, ["encrypt"]);
-    const s2cKey = await crypto.subtle.importKey("raw", keys.s2cKey, "AES-GCM", false, ["decrypt"]);
-    const aad = new TextEncoder().encode(authToken + ":ws");
+    aad         = encode(authToken + ":ws")
+    sendCounter = 0
+    recvCounter = 0
 
-    let sendCounter = 0n;
-    let recvCounter = 0n;
+    ws = websocket_connect(url)
 
-    const ws = new WebSocket(wsUrl);
+    function send(method, params):
+        payload = json_encode({ jsonrpc: "2.0", method, params, id: next_id() })
+        nonce   = xor_counter(c2sBase, sendCounter)
+        ct      = aes_gcm_encrypt(c2sKey, nonce, aad, payload)
+        frame   = { e: base64(ct) }
+        if sendCounter == 0:
+            frame.v = 1
+            frame.t = authToken
+            frame.s = base64(sessionSalt)
+        sendCounter++
+        ws.send(json_encode(frame))
 
-    const opened = new Promise((resolve, reject) => {
-        ws.onopen = () => resolve();
-        ws.onerror = (e) => reject(e);
-    });
+    function on_receive(raw):
+        frame = json_decode(raw)
+        nonce = xor_counter(s2cBase, recvCounter)
+        pt    = aes_gcm_decrypt(s2cKey, nonce, aad, base64_decode(frame.e))
+        recvCounter++
+        return json_decode(pt)
 
-    async function sendRPC(method, params) {
-        await opened;
-        const payload = JSON.stringify({ jsonrpc: "2.0", method, params, id: Date.now() });
-        const counter = sendCounter++;
-        const nonce = buildNonce(keys.c2sBase, counter);
-        const ct = await crypto.subtle.encrypt(
-            { name: "AES-GCM", iv: nonce, additionalData: aad },
-            c2sKey,
-            new TextEncoder().encode(payload),
-        );
-        const ctB64 = btoa(String.fromCharCode(...new Uint8Array(ct)));
-        const msg = { e: ctB64 };
-        if (counter === 0n) {
-            msg.v = 1;
-            msg.t = authToken;
-            msg.s = btoa(String.fromCharCode(...sessionSalt));
-        }
-        ws.send(JSON.stringify(msg));
-    }
-
-    ws.onmessage = async (ev) => {
-        const frame = JSON.parse(ev.data);
-        if (!frame.e) return;
-        const ct = Uint8Array.from(atob(frame.e), (c) => c.charCodeAt(0));
-        const counter = recvCounter++;
-        const nonce = buildNonce(keys.s2cBase, counter);
-        const pt = await crypto.subtle.decrypt(
-            { name: "AES-GCM", iv: nonce, additionalData: aad },
-            s2cKey,
-            ct,
-        );
-        handleResponse(JSON.parse(new TextDecoder().decode(pt)));
-    };
-
-    await opened;
-    return { sendRPC };
-}
+    return { send, on_receive }
 ```
-
-This is a minimal working example. Production clients should add reconnection logic, error handling for HMAC mismatches, and secure storage for the pairing key.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -28,7 +28,7 @@ It's highly recommended to target your application at the specific minor version
 
 An example address for connecting to the API: `ws://10.0.0.123:7497/api/v0.1`
 
-The connection requires no special configuration or authentication to initiate.
+The connection requires no special configuration or authentication to initiate. When [encryption](./encryption) is enabled, remote clients must complete a one-time pairing and encrypt all WebSocket traffic.
 
 ### HTTP POST
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Build scripts work on Linux, Mac and Windows (natively or WSL). Just make sure a
 
 - [Go](https://go.dev/)
 
-  Version 1.25 or newer. The build script assumes your Go path is in the default location, for caching between Docker build environments: `$HOME/go`
+  Version 1.26 or newer. The build script assumes your Go path is in the default location, for caching between Docker build environments: `$HOME/go`
 
 - [Task](https://taskfile.dev/)
 - [Docker](https://www.docker.com/)

--- a/docs/media-titles.md
+++ b/docs/media-titles.md
@@ -1,600 +1,263 @@
-# Title Normalization and Matching System
+# Title normalization and matching
 
-Zaparoo Core's title normalization and matching system enables users to launch games using natural language titles (e.g., "The Legend of Zelda: Ocarina of Time") that are fuzzy-matched against indexed ROM filenames. This document provides a high-level overview of how the system works.
+Zaparoo matches games by title, not filename. Write a game name like "The Legend of Zelda: Ocarina of Time" and it gets fuzzy-matched against indexed ROM filenames. Both the query and the filenames go through the same slug pipeline, so naming differences wash out.
 
-## Overview
+Slugs are not IDs. They're a normalized form used for matching. The original titles and filenames stick around for display and fallback matching.
 
-The system lets users look up games by **natural language titles** rather than exact filenames or unique identifiers. Titles can be written in various forms (with or without articles, with Roman numerals or digits, with typos, etc.) and the system will find matching games through progressive normalization and fallback strategies.
+Offline-first, no hashing (too slow on MiSTer FPGA / older Pis). English heuristics only for now.
 
-**Key Concept:** Slugs are **not IDs**. They are an intermediary normalization step that enables fuzzy matching between user queries and indexed filenames. The system normalizes both sides:
+## How it works
 
-- **User input** → normalize → slug → match against database
-- **Filenames** → normalize → slug → store in database
-
-The original input title and filename are preserved for additional context during resolution.
-
-## Why This Approach?
-
-The system works around several constraints:
-
-- **No hashing**: Too slow on low-resource devices (MiSTer FPGA, older Raspberry Pis)
-- **Offline-first**: No dependency on online services or internet access
-- **Cross-device portability**: Tokens work across different devices despite different file naming schemes
-
-**Advantages:**
-
-- Natural language names on NFC/QR tokens work universally
-- Third-party apps don't need special integration - just write the game name
-- System can be improved over time without breaking compatibility
-- Makes local media search much more useful
-
-**Limitations:**
-
-- No cross-language support (and currently prioritizes English heuristics)
-- Conflicts can occur (mitigated by system namespacing and tags)
-- Best-effort normalization rather than perfect accuracy
-
-## How It Works
-
-### 1. Indexing
+### Indexing
 
 When scanning media, Zaparoo:
 
-1. Cleans path and extracts filename (strips file extension and path)
-2. Parses filename to extract clean display title (8-step pipeline - see Filename Parser section)
-3. Extracts tags from filename using bracket disambiguation (4-step pipeline - see Filename Parser section)
-4. Determines media type from system (Game, TVShow, Movie, Music, Image, Audio, Video, Application)
-5. Runs media-type-aware slugification on title (two-phase normalization - see Slug Normalization section)
-6. Stores path, title, slug, tags, and metadata in database for fast searching
+1. Cleans path and extracts filename (strips extension and path)
+2. Parses filename to extract a clean display title (see [Filename parser](#filename-parser))
+3. Extracts tags from brackets/parentheses (see [Tag extraction](#tag-extraction))
+4. Determines media type from the system (Game, TVShow, Movie, Music, Image, Audio, Video, Application)
+5. Slugifies the title using media-type-aware normalization (see [Slug normalization](#slug-normalization))
+6. Stores path, title, slug, tags, and metadata in the database
 
-### 2. Resolution (Query-Based Launching)
+### Resolution
 
-When launching by title query (e.g., `launch.title("NES/Super Mario Bros")`), Zaparoo:
+When launching by title (e.g. `launch.title` with arg `NES/Super Mario Bros`):
 
 1. Parses `SystemID/GameName` format
-2. Validates format and looks up system in database
-3. Extracts tags from three sources in user query (advanced args, canonical tags, filename-style metadata)
-4. Merges tags with priority hierarchy
-5. Slugifies game name using media-type-aware normalization (same as indexing)
-6. Checks cache for previous resolutions
-7. Tries multiple matching strategies in order until finding a match (see Matching Strategies section)
-8. Applies confidence scoring and filtering to select best result
-9. Caches successful resolution for future queries
-
-**Note:** The user's query is processed separately from filenames. Users can include tags in their queries using filename-style `(USA)`, canonical `(+region:us)`, or advanced args `?tags=region:us` formats.
+2. Extracts and merges tags from the query (three sources — see [Tags in queries](#tags-in-queries))
+3. Slugifies the game name using the same normalization as indexing
+4. Tries matching strategies in order until finding a result (see [Matching strategies](#matching-strategies))
+5. Scores and filters results to pick the best match
+6. Caches the resolution for future queries
 
 ---
 
-## Slug Normalization
+## Slug normalization
 
-Slug normalization uses a **two-phase architecture** that converts titles into a canonical form. Both indexing and resolution use identical normalization.
+Two-phase pipeline that converts titles into a canonical form. Indexing and resolution run the same normalization.
 
-**Implementation:** `pkg/database/slugs/slugify.go` → `Slugify(mediaType MediaType, input string)`
+`pkg/database/slugs/slugify.go` → `Slugify(mediaType, input)`
 
-### Two-Phase Architecture
+### Phase 1: Media-specific parsing
 
-#### Phase 1: Media-Specific Parsing
+Format-specific normalization runs before the universal pass.
 
-Applies format-specific normalization based on media type **before** universal normalization.
+**Games** (`pkg/database/slugs/media_parsing_game.go`):
 
-**For Games** (`ParseGame`):
+Width normalization first (fullwidth → ASCII), then:
 
-Width normalization is applied first (fullwidth separators → ASCII for detection), then 9 steps:
-
-1. Split titles and strip articles: "The Zelda: Link's Awakening" → "Zelda Link's Awakening"
+1. Split on `:` and strip leading articles: "The Zelda: Link's Awakening" → "Zelda Link's Awakening"
 2. Strip trailing articles: "Legend, The" → "Legend"
 3. Strip metadata brackets: `(USA)`, `[!]`, `{Europe}` → removed
 4. Strip edition/version suffixes: "Edition", "Version", "v1.0" → removed
-5. Normalize symbols/separators (preserve commas for trailing articles)
+5. Normalize symbols/separators (preserve commas for trailing article detection)
 6. Expand abbreviations: "Bros" → "brothers", "vs" → "versus", "Dr" → "doctor"
 7. Expand number words: "one" → "1", "two" → "2" (1-20)
 8. Normalize ordinals: "2nd" → "2", "3rd" → "3"
 9. Convert roman numerals: "VII" → "7", "II" → "2" (preserves "X" in "Mega Man X")
 
-**For TV Shows** (`ParseTVShow`):
+**TV Shows** (`pkg/database/slugs/media_parsing_tv.go`):
 
-Width normalization is applied first, then 9 steps:
+Width normalization first, then:
 
-1. Scene tag stripping: quality, codec, source tags (1080p, x264, BluRay, etc.)
-2. Dot normalization: scene release dots → spaces
-3. Strip metadata brackets: `[720p]`, `(extended)` → removed
-4. Normalize date episodes: YYYY-MM-DD, DD-MM-YYYY (with `.`, `/`, `-` separators) → canonical `YYYY-MM-DD`
-5. Normalize season-based formats: `S01E02`, `s01e02`, `1x02`, `S01.E02`, `S01_E02`, multi-episode (`S01E01-E02`) → `s01e02`
-6. Normalize absolute numbering: `Episode 001`, `Ep 42`, `E001`, `#001` (anime), leading numbers → `e001`
-7. Component reordering: episode marker placed after show name ("S01E02 - Show - Title" → "Show s01e02 Title")
-8. Split titles and strip articles: "The Show: Episode Title" → "Show Episode Title"
-9. Strip trailing articles: "Show, The" → "Show"
+1. Strip scene tags: quality, codec, source (1080p, x264, BluRay, etc.)
+2. Dots → spaces (scene release convention)
+3. Strip metadata brackets
+4. Normalize date episodes: various date formats → `YYYY-MM-DD`
+5. Normalize season-based: `S01E02`, `1x02`, `S01.E02` → `s01e02`
+6. Normalize absolute numbering: `Episode 001`, `Ep 42`, `#001` → `e001`
+7. Reorder components: episode marker placed after show name
+8. Split titles and strip articles
+9. Strip trailing articles
 
-**For Movies** (`ParseMovie`):
-1. Width normalization (fullwidth separators → ASCII for detection)
-2. Scene tag stripping: quality, codec, source, HDR, 3D tags (preserves edition qualifiers like "Extended", "Unrated", "Director's Cut")
-3. Dot normalization: scene release dots → spaces
-4. Edition suffix stripping: trailing "Edition", "Version", "Cut", "Release" removed (preserves qualifiers: "Director's Cut Edition" → "Director's")
-5. Bracket stripping: `(2024)`, `{imdb-tt1234567}` → removed (years extracted as tags)
-6. Split titles and strip articles: "The Movie: Subtitle" → "Movie Subtitle"
-7. Strip trailing articles: "Movie, The" → "Movie"
+**Movies** (`pkg/database/slugs/media_parsing_movie.go`):
 
-**For Music** (`ParseMusic`):
-1. Width normalization (fullwidth separators → ASCII for detection)
-2. Scene tag stripping: format (FLAC, MP3), quality (V0, 320, 24bit), source (CD, Vinyl, WEB), release group (preserves edition qualifiers like "Remastered", "Deluxe")
-3. Separator normalization: dots, underscores, dashes → spaces
-4. Bracket stripping: `(1979)`, `[FLAC]` → removed (years extracted as tags)
-5. Disc number stripping: CD1, CD2, Disc 1 → removed
-6. Strip leading article: "The Beatles Abbey Road" → "Beatles Abbey Road"
-7. Strip trailing articles: "Album, The" → "Album"
-8. Whitespace collapse: multiple spaces → single space
+1. Width normalization
+2. Strip scene tags (preserves edition qualifiers like "Extended", "Director's Cut")
+3. Dots → spaces
+4. Strip edition suffixes: "Edition", "Version", "Cut", "Release"
+5. Strip brackets (years extracted as tags)
+6. Split titles and strip articles
+7. Strip trailing articles
 
-**For Image/Audio/Video/Application**:
-- Pass through to Phase 2 universal normalization only (no media-specific parsing yet)
+**Music** (`pkg/database/slugs/media_parsing_music.go`):
 
-#### Phase 2: Universal Normalization (`normalizeInternal`)
+1. Width normalization
+2. Strip scene tags: format (FLAC, MP3), quality (V0, 320), source (CD, Vinyl, WEB)
+3. Separators → spaces (dots, underscores, dashes)
+4. Strip brackets (years extracted as tags)
+5. Strip disc numbers: CD1, Disc 1 → removed
+6. Strip leading article: "The Beatles" → "Beatles"
+7. Strip trailing articles
+8. Collapse whitespace
+
+**Image/Audio/Video/Application**: Pass through to Phase 2 only.
+
+### Phase 2: Universal normalization
+
+`pkg/database/slugs/slugify.go` → `normalizeInternal()`
 
 Applied after media-specific parsing:
 
-1. **Width Normalization** - Fullwidth → Halfwidth (ASCII), Halfwidth → Fullwidth (CJK)
-2. **Punctuation Normalization** - Curly quotes, fancy dashes → standard ASCII
-3. **Unicode Normalization** - Remove symbols (™©®), remove diacritics (Pokémon → Pokemon), script-aware processing
-4. **Symbols & Separators** - `&` → `and`, separators → spaces: "Sonic & Knuckles" → "Sonic and Knuckles"
-5. **Period Conversion** - All periods → spaces (safe after abbreviations expanded)
-6. **Lowercasing** - Convert to lowercase
+1. Width normalization — fullwidth → halfwidth (ASCII), halfwidth → fullwidth (CJK)
+2. Punctuation normalization — curly quotes, fancy dashes → ASCII equivalents
+3. Unicode normalization — remove symbols (™©®), strip diacritics (Pokémon → Pokemon)
+4. Symbols and separators — `&` → `and`, separators → spaces
+5. Periods → spaces (safe after abbreviation expansion)
+6. Lowercase
 
-**Final Stage** (in `Slugify`/`SlugifyWithTokens`):
+Final: strip all non-alphanumeric characters (script-aware for non-Latin text).
 
-7. **Character Filtering** - Remove non-alphanumeric, multi-script aware
-
-### Complete Example (Games)
+### Example
 
 ```
 Input:  "The Legend of Zelda: Ocarina of Time (USA) [!]"
 
-Phase 1 (ParseGame):
-  Step 1: Split & strip articles → "Legend of Zelda Ocarina of Time (USA) [!]"
-  Step 3:   Strip brackets → "Legend of Zelda Ocarina of Time"
-  Step 9:   Roman numerals (none) → "Legend of Zelda Ocarina of Time"
+Phase 1 (Game):
+  Split & strip articles → "Legend of Zelda Ocarina of Time (USA) [!]"
+  Strip brackets         → "Legend of Zelda Ocarina of Time"
 
-Phase 2 (normalizeInternal):
-  Step 6:   Lowercase → "legend of zelda ocarina of time"
+Phase 2:
+  Lowercase              → "legend of zelda ocarina of time"
 
 Final:
-  Character filtering → "legendofzeldaocarinaoftime"
-
-Output: "legendofzeldaocarinaoftime"
+  Strip non-alphanumeric → "legendofzeldaocarinaoftime"
 ```
 
-### Multi-Script Support
+### Multi-script support
 
-The system preserves non-Latin scripts (CJK, Cyrillic, Arabic, etc.) while aggressively normalizing Latin text:
+`pkg/database/slugs/scripts.go`
 
-- **Latin titles**: Full normalization, ASCII output
-- **CJK titles**: Preserved characters, essential marks kept
-- **Mixed titles**: Both portions concatenated, searchable by either part
-
-**Example:**
+Non-Latin scripts (CJK, Cyrillic, Arabic, etc.) are kept intact while Latin text gets full normalization. Mixed titles just concatenate both parts:
 
 ```
-Input:  "Street Fighter ストリートファイター"
-Output: "streetfighterストリートファイター"
+"Street Fighter ストリートファイター" → "streetfighterストリートファイター"
 ```
 
-This makes the title searchable by either the Latin or CJK portion.
+You can search by either portion. Script-specific rules handle diacritics differently per writing system (Arabic vowel marks get stripped, Indic vowel marks are preserved, etc.).
 
 ---
 
-## Filename Parser (Indexing)
+## Filename parser
 
-During media indexing, Zaparoo parses filenames to extract clean titles and metadata tags. This happens when scanning ROM directories, media libraries, or individual files.
+Filenames are parsed during indexing to pull out clean titles and metadata tags.
 
-**Implementation:** `pkg/database/mediascanner/indexing_pipeline.go` → `GetPathFragments()`, `pkg/database/tags/filename_parser.go`
+`pkg/database/mediascanner/indexing_pipeline.go` → `GetPathFragments()`
+`pkg/database/tags/filename_parser.go`
 
-### Indexing Pipeline
+### Title extraction
 
-When a file is indexed, the system:
+`tags.ParseTitleFromFilename(filename, stripLeadingNumbers)` — 8-step pipeline:
 
-1. **Cleans path** - Normalizes to forward slashes, handles URIs
-2. **Extracts filename** - Strips file extension and path
-3. **Parses title** - Extracts clean display title from filename
-4. **Extracts tags** - Parses metadata from brackets/parentheses
-5. **Slugifies title** - Creates normalized slug for matching
-6. **Stores in database** - Saves path, title, slug, and tags
+1. **Remove extension** — strips `.zip`, `.nes`, `.mkv` etc. (2-4 char extensions only)
+2. **Strip release group** — `-YIFY`, `-SPARKS` at end (uppercase, 3+ chars)
+3. **Normalize separators** — if filename has no spaces and 2+ dots/underscores/dashes, convert all to spaces. Detects scene releases and ROM naming conventions.
+4. **Strip scene artifacts** — only after a year if found. Removes resolution, source, codec, audio, HDR, status tags. Protects titles like "Cam (2018)" where "Cam" is the actual title.
+5. **Strip episode markers** — `S01E02`, `s1e2` removed from display title (kept for tag extraction)
+6. **Strip leading numbers** — optional, only when directory context shows list-style numbering (`01 - Game Name` → `Game Name`)
+7. **Remove bracket content** — all `()`, `[]`, `{}`, `<>` and their contents
+8. **Normalize whitespace** — collapse multiple spaces, trim
 
-### Title Extraction from Filename
+Examples:
 
-**Function:** `tags.ParseTitleFromFilename(filename, stripLeadingNumbers)`
-
-Extracts a clean display title from a filename by removing metadata and normalizing artifacts.
-
-#### The 8-Step Pipeline
-
-1. **Remove File Extension**
-   - Strips `.zip`, `.nes`, `.mkv`, etc.
-   - Only removes if 2-4 characters after last dot
-   - Example: `"game.nes"` → `"game"`
-
-2. **Strip Release Group**
-   - Removes scene release group suffix: `-GROUP` at end
-   - Must be uppercase, 3+ characters
-   - Example: `"Movie-YIFY"` → `"Movie"`
-   - **Done early** before hyphen → space conversion
-
-3. **Normalize Filename Separators** (contextual)
-   - **Trigger:** Filename has no spaces AND 2+ separators (dots, underscores, or dashes)
-   - **Action:** Convert all `.`, `_`, `-` → spaces
-   - Examples:
-     - `"The.Dark.Knight.2008.mkv"` → `"The Dark Knight 2008"`
-     - `"super_mario_bros.sfc"` → `"super mario bros"`
-     - `"mega-man-x.nes"` → `"mega man x"`
-   - **Heuristic:** Detects scene releases and ROM naming conventions
-
-4. **Strip Scene Release Artifacts** (contextual)
-   - **Trigger:** Only strips from text AFTER a year (if found)
-   - **Protects titles:** `"Cam (2018)"` keeps "Cam" (it's the title, not a scene tag)
-   - **Removed patterns:**
-     - Resolution: `720p`, `1080p`, `2160p`, `4K`, `UHD`
-     - Source: `BluRay`, `WEB-DL`, `WEBRip`, `HDTV`, `DVDRip`, `CAM`, `TS`
-     - Video codec: `x264`, `x265`, `h264`, `HEVC`, `AVC`
-     - Audio codec: `AAC`, `AC3`, `DTS`, `DD5.1`, `TrueHD`, `Atmos`
-     - HDR: `HDR`, `HDR10`, `Dolby Vision`
-     - Status: `PROPER`, `REPACK`, `INTERNAL`, `LIMITED`
-   - Example: `"The Dark Knight 2008 1080p BluRay x264"` → `"The Dark Knight 2008"`
-
-5. **Strip Episode Markers**
-   - Removes TV show episode patterns: `S01E02`, `s1e2`
-   - Keeps them for tag extraction but removes from display title
-   - Example: `"Breaking Bad S01E02 Title"` → `"Breaking Bad Title"`
-
-6. **Strip Leading Numbers** (optional)
-   - Only when `stripLeadingNumbers=true` (detected from directory context)
-   - Removes list prefixes: `"1. "`, `"01 - "`, `"05-"`
-   - Example: `"01 - Game Name"` → `"Game Name"`
-   - **Contextual:** Only enabled when directory shows list-style numbering
-
-7. **Remove All Bracket Content**
-   - **Function:** `slugs.StripMetadataBrackets()`
-   - Removes: `()`, `[]`, `{}`, `<>`
-   - Handles nested brackets
-   - Example: `"Game (USA) [!] {Europe}"` → `"Game"`
-   - Example: `"Movie (2008) (Blu-ray)"` → `"Movie"`
-
-8. **Normalize Whitespace**
-   - Collapses multiple spaces to single space
-   - Trims leading/trailing spaces
-   - Final cleanup after all transformations
-
-### Title Extraction Examples
-
-**ROM filename:**
 ```
-Input:  "Super Mario Bros. III (USA) (Rev A) [!].nes"
-Step 1: Remove extension → "Super Mario Bros. III (USA) (Rev A) [!]"
-Step 7: Remove brackets → "Super Mario Bros. III"
-Step 8: Normalize whitespace → "Super Mario Bros. III"
-Output: "Super Mario Bros. III"
+"Super Mario Bros. III (USA) (Rev A) [!].nes"
+  → remove ext → strip brackets → "Super Mario Bros. III"
+
+"The.Dark.Knight.2008.1080p.BluRay.x264-YIFY.mkv"
+  → remove ext → strip group → normalize seps → strip scene → "The Dark Knight 2008"
+
+"Breaking.Bad.S01E02.Gray.Matter.720p.mkv"
+  → normalize seps → strip scene → strip episode → "Breaking Bad Gray Matter"
 ```
 
-**Scene release:**
+### Tag extraction
+
+`tags.ParseFilenameToCanonicalTags(filename)` — 4-step pipeline:
+
+**Step 1: Special patterns** — extracts patterns outside brackets: disc numbers (`Disc 1 of 2` → `disc:1`), revisions (`Rev A` → `rev:a`), versions (`v1.2` → `rev:1-2`), years (`1997` → `year:1997`), episodes (`S01E02` → `season:1`, `episode:2`), issues, tracks, translations.
+
+**Step 2: Bracket content** — state machine parser extracts `()`, `{}`, `<>` tags separately from `[]` tags.
+
+**Step 3: Parentheses tags** — context-aware disambiguation:
+- First paren tag → region if it matches the known region list (USA, Europe, Japan, etc.)
+- Subsequent tags → language, version, dev status
+- Multi-value: `(En,Fr,De)` → `lang:en`, `lang:fr`, `lang:de`
+
+**Step 4: Square bracket tags** — always dump info or modifications:
+- `[!]` → `dump:verified`, `[b]` → `dump:bad`, `[h]` → `hack:yes`, `[T+En]` → `translation:en`
+
+Example:
+
 ```
-Input:  "The.Dark.Knight.2008.1080p.BluRay.x264-YIFY.mkv"
-Step 1: Remove extension → "The.Dark.Knight.2008.1080p.BluRay.x264-YIFY"
-Step 2: Strip release group → "The.Dark.Knight.2008.1080p.BluRay.x264"
-Step 3: Normalize separators → "The Dark Knight 2008 1080p BluRay x264"
-Step 4: Strip scene artifacts (after year) → "The Dark Knight 2008"
-Output: "The Dark Knight 2008"
+"Super Mario Bros. 3 (USA) (Rev A) [!].nes"
+  → [rev:a, region:us, dump:verified]
+
+"Zelda (Europe) (En,Fr,De,Es,It).gba"
+  → [region:eu, lang:en, lang:fr, lang:de, lang:es, lang:it]
 ```
-
-**TV show:**
-```
-Input:  "Breaking.Bad.S01E02.Gray.Matter.720p.mkv"
-Step 3: Normalize separators → "Breaking Bad S01E02 Gray Matter 720p"
-Step 4: Strip scene artifacts → "Breaking Bad S01E02 Gray Matter"
-Step 5: Strip episode marker → "Breaking Bad Gray Matter"
-Output: "Breaking Bad Gray Matter"
-```
-
-### Tag Extraction from Filename
-
-**Function:** `tags.ParseFilenameToCanonicalTags(filename)`
-
-Extracts metadata tags from filenames following No-Intro and TOSEC conventions.
-
-#### The 4-Step Pipeline
-
-**Step 1: Extract Special Patterns**
-- **Function:** `extractSpecialPatterns()`
-- Finds patterns that appear outside brackets:
-  - **Disc numbers**: `(Disc 1 of 2)` → `disc:1`, `discof:2`
-  - **Revisions**: `(Rev A)`, `(Rev 1)` → `rev:a`, `rev:1`
-  - **Volumes**: `(Vol. 2)`, `(Volume 3)` → `volume:2`
-  - **Versions**: `(v1.2)`, `v3.0` → `rev:1-2`, `rev:3-0`
-  - **Years**: `(1997)` → `year:1997`
-  - **Episodes**: `S01E02`, `1x05` → `season:1`, `episode:2`
-  - **Issues**: `#12`, `Issue 5` → `issue:12`
-  - **Tracks**: `01 -`, `Track 03` → `track:1`
-  - **Translations**: `T+En`, `T-Fr v1.0` → `translation:en`, `translation-:fr`
-  - **Bracketless versions**: `v1.0`, `v1.2.3` outside brackets → `rev:1-0` (only if no version already extracted)
-  - **Edition/version words**: "Edition", "Version" (+ multi-language equivalents) → `edition:edition` or `edition:version` (inferred, not removed from title)
-- Removes matched patterns from string for cleaner bracket extraction
-
-**Step 2: Extract Bracket Content**
-- **Function:** `extractTags()`
-- State machine parser for brackets:
-  - `()`, `{}`, `<>` → parentheses tags (region, language, dev status)
-  - `[]` → square bracket tags (dump info, hacks)
-- Returns two separate lists for disambiguation
-
-**Step 3: Process Parentheses Tags**
-- **Function:** `disambiguateTag()` with `BracketTypeParen`
-- Context-aware parsing with positional rules:
-  - **First paren tag** → usually region (if matches known region)
-  - **Subsequent tags** → language, version, dev status, etc.
-- Handles multi-value tags: `(En,Fr,De)` → `lang:en`, `lang:fr`, `lang:de`
-- **Tag types recognized:**
-  - Regions: `USA`, `Europe`, `Japan`, `World`, etc.
-  - Languages: `En`, `Fr`, `De`, `Ja`, etc. (2-3 letter codes)
-  - Dev status: `Beta`, `Proto`, `Alpha`, `Demo`
-  - Versions: `v1.0`, `Rev A`, `Alt`
-  - Years: `1997`, `2008`
-
-**Step 4: Process Square Bracket Tags**
-- **Function:** `disambiguateTag()` with `BracketTypeSquare`
-- Always dump-related or modification info:
-  - **Dump status**: `[!]` → `dump:verified`, `[b]` → `dump:bad`
-  - **Hacks**: `[h]`, `[h1]` → `hack:yes`, `hack:1`
-  - **Translations**: `[T+En]` → `translation:en`
-  - **Trainer**: `[t]`, `[t1]` → `trainer:yes`, `trainer:1`
-  - **Fixes**: `[f]` → `fix:yes`
-  - **Overdumps**: `[o]` → `overdump:yes`
-
-### Tag Extraction Examples
-
-**ROM filename:**
-```
-Input:  "Super Mario Bros. 3 (USA) (Rev A) [!].nes"
-
-Step 1: Extract special patterns
-  → Rev: rev:a (from "(Rev A)")
-  → Remaining: "Super Mario Bros. 3 (USA) [!].nes"
-
-Step 2: Extract brackets
-  → Paren tags: ["USA"]
-  → Square tags: ["!"]
-
-Step 3: Process paren tags
-  → "USA" (position 0, first tag) → region:us
-
-Step 4: Process square tags
-  → "!" → dump:verified
-
-Output: [rev:a, region:us, dump:verified]
-```
-
-**Multi-language ROM:**
-```
-Input:  "Zelda (Europe) (En,Fr,De,Es,It).gba"
-
-Step 2: Extract brackets
-  → Paren tags: ["Europe", "En,Fr,De,Es,It"]
-
-Step 3: Process paren tags (position 0)
-  → "Europe" → region:eu
-
-Step 3: Process paren tags (position 1)
-  → "En,Fr,De,Es,It" (multi-value) → lang:en, lang:fr, lang:de, lang:es, lang:it
-
-Output: [region:eu, lang:en, lang:fr, lang:de, lang:es, lang:it]
-```
-
-**Unfinished ROM:**
-```
-Input:  "Star Fox 2 (Beta) (1995).sfc"
-
-Step 1: Extract special patterns
-  → Year: year:1995
-  → Remaining: "Star Fox 2 (Beta).sfc"
-
-Step 3: Process paren tags
-  → "Beta" → unfinished:beta
-
-Output: [year:1995, unfinished:beta]
-```
-
-**Scene release:**
-```
-Input:  "The.Dark.Knight.2008.1080p.BluRay.x264-YIFY.mkv"
-
-Step 1: Extract special patterns
-  → Year: year:2008
-  → Remaining: (no brackets to extract)
-
-Output: [year:2008]
-```
-
-### Disambiguation Rules
-
-The system uses **positional** and **bracket-type** rules for disambiguation:
-
-**Positional Rules** (parentheses):
-1. **First tag** → region (if matches known region list)
-2. **Subsequent tags** → language, version, dev status
-3. **Context-aware** → checks previously processed tags
-
-**Bracket Type Rules:**
-- **Parentheses/Braces/Angles** → metadata (region, language, version, dev status)
-- **Square brackets** → always dump info or modifications (hacks, trainers, fixes)
-
-**Special Handling:**
-- **Multi-value tags**: `(En,Fr,De)` → creates multiple lang tags
-- **Composite tags**: `(En,Fr)` in Europe ROM → both languages extracted
-- **Inferred tags**: "Edition" in plain text → marked as `TagSourceInferred`, skipped for filtering
 
 ---
 
-## Matching Strategies
+## Matching strategies
 
-Resolution tries strategies **in order** until finding results. Each strategy is more lenient than the last.
+Resolution tries strategies in order, each more lenient than the last, until something matches.
 
-**Implementation:** `pkg/zapscript/titles.go` → `cmdTitle()`
-
-### Strategy Flow
+`pkg/zapscript/titles/resolve.go`
 
 ```
-1. Check cache
-   ↓ (miss)
-2. Exact match (with tags)
-   ↓ (no results OR low confidence)
-3. Exact match (without tags)
-   ↓ (no results)
+1. Cache lookup
+   ↓ miss
+2. Exact slug match (with tag filters)
+   ↓ no results or low confidence
+3. Exact slug match (without tags)
+   ↓ no results
 4. Secondary title match
-   ↓ (no results)
-5. Advanced fuzzy matching
-   ├─ Token signature (word-order independent)
-   ├─ Jaro-Winkler (typo tolerance)
-   └─ Damerau-Levenshtein tie-breaking
-   ↓ (no results)
+   ↓ no results
+5. Fuzzy matching
+   ↓ no results
 6. Main title only
-   ↓ (no results)
-7. Progressive trim (last resort)
+   ↓ no results
+7. Progressive trim
 ```
 
-### Strategy Details
+**Cache** — keyed by SystemID + Slug + Tags. Returns immediately on hit.
 
-#### 1. Cache Lookup
+**Exact match with tags** — direct slug lookup with tags as filters. Early exit if confidence >= 0.95.
 
-- Fast path: checks previous resolutions
-- Keyed by: SystemID + Slug + Tags
+**Exact match without tags** — same lookup, tags ignored. Tags become soft preferences during result selection.
 
-#### 2. Exact Match (with tags)
+**Secondary title** — handles mismatched subtitles. Bidirectional: "Zelda: Ocarina of Time" matches "Ocarina of Time" and vice versa.
 
-- Direct slug lookup
-- Tags applied as filters
-- **Early exit** if confidence ≥ 0.95 (high confidence)
+**Fuzzy matching** — pre-filter (±2 chars length diff), then: token signature (word-order-independent), Jaro-Winkler (typo tolerance, 0.85+ similarity), Damerau-Levenshtein for tie-breaking top candidates.
 
-#### 3. Exact Match (without tags)
+**Main title only** — uses just the part before the first delimiter. "Zelda: Ocarina" matches "Zelda" and "Zelda: Ocarina of Time".
 
-- Same slug lookup, tags ignored
-- Tags become soft preferences during result selection
+**Progressive trim** — removes words from the end of the query, max 3 iterations. "Legend of Zelda Link's Awakening DX" tries progressively shorter slugs.
 
-#### 4. Secondary Title Match
+### Tags in queries
 
-Handles mismatched secondary titles (bidirectional):
+Tags come from three sources (highest priority wins):
 
-- Query has secondary, DB doesn't: "Zelda: Ocarina" → matches "Ocarina of Time"
-- Query simple, DB has secondary: "Ocarina" → matches "Zelda: Ocarina of Time"
+1. **Advanced args**: `NES/Zelda?tags=region:us,-unfinished:beta` — explicit, overrides everything
+2. **Inline canonical**: `NES/Zelda (+region:us) (-unfinished:beta)` — `+` for AND, `-` for NOT
+3. **Filename-style**: `NES/Zelda (USA) (1986)` — auto-extracted, lowest priority
 
-#### 5. Advanced Fuzzy Matching
+### Result selection
 
-Uses a pre-filter (±3 chars, ±1 word) then tries three algorithms:
+When multiple results match, they get filtered and scored:
 
-- **Token signature**: Order-independent word matching
-- **Jaro-Winkler**: Typo tolerance, prefix-weighted (0.85+ similarity)
-- **Damerau-Levenshtein**: Tie-breaking for top 5 candidates
+**Confidence** is a base score from the strategy (0.85–1.0), adjusted by tag matching:
+- >= 0.95: launch immediately
+- >= 0.70: launch with info
+- >= 0.60: launch with warning
+- < 0.60: error
 
-#### 6. Main Title Only
-
-Searches using just the main title portion (bidirectional):
-
-- Query has secondary, DB doesn't: "Zelda: Ocarina" → matches "Zelda"
-- Query simple, DB has secondary: "Zelda" → matches "Zelda: Ocarina of Time"
-
-#### 7. Progressive Trim
-
-Progressively removes words from the end of the original query (max 3 iterations):
-
-- "Legend of Zelda Link's Awakening DX" → tries "...Awakening", "...Link's", "...Zelda" (then slugifies each)
-
----
-
-## Result Selection
-
-When multiple results match, the system applies filtering and scoring:
-
-### Confidence Scoring
-
-Base confidence from strategy (0.85-1.0) is adjusted by tag matching:
-
-- **High confidence (≥0.95)**: Launch immediately
-- **Acceptable (≥0.70)**: Launch with info message
-- **Minimum (≥0.60)**: Launch with warning
-- **Below 0.60**: Error out
-
-### Filtering Priority
-
-1. **User-specified tags** - Filter to exact matches (if provided)
-2. **Exclude variants** - Remove unfinished (demo, beta, proto, alpha, sample, preview, prerelease), unlicensed (hack, translation, bootleg, clone), and bad dumps
-3. **Exclude re-releases** - Remove reboxed editions, re-releases
-4. **Preferred regions** - Match user's region config
-5. **Preferred languages** - Match user's language config
-6. **File type priority** - Prefer file types based on launcher extension order (earlier = better)
-7. **Quality-based tie-breaking** - Select best file using:
-   - Numeric suffix penalty (avoids duplicates like "game (1).zip")
-   - Path depth (prefers files in organized folders over deep backups)
-   - Character density (cleaner filenames preferred)
-   - Filename length (shorter is simpler)
-
----
-
-## Tag System
-
-Tags are used for filtering and disambiguation during indexing and resolution.
-
-### Tag Extraction (During Indexing)
-
-Tags are automatically extracted from filenames during media scanning using the **Filename Parser** (see section above for complete details).
-
-**Common tag types:**
-- **Regions**: `(USA)`, `(Europe)`, `(Japan)` → `region:us`, `region:eu`, `region:jp`
-- **Languages**: `(En)`, `(Fr,De)` → `lang:en`, `lang:fr`, `lang:de`
-- **Years**: `(1997)` → `year:1997`
-- **Dump info**: `[!]` → `dump:verified`, `[b]` → `dump:bad`
-- **Development**: `(Beta)`, `(Proto)` → `unfinished:beta`, `unfinished:proto`
-- **Revisions**: `(Rev A)` → `rev:a`
-- **Episodes**: `S01E02`, `1x05` → `season:01`, `episode:02`
-- **Discs**: `(Disc 1 of 2)` → `disc:1`, `discof:2`
-
-**See "Filename Parser" section** for the complete 4-step tag extraction pipeline with disambiguation rules.
-
-### Tag Usage in Queries
-
-Tags can be specified in three ways (with priority hierarchy):
-
-1. **Advanced args** (highest priority): `NES/Zelda?tags=region:us,-unfinished:beta`
-   - Explicit user requirements via `?tags=` parameter
-   - Format: `tag:value` or `-tag:value` (NOT operator)
-   - Overrides all other tag sources
-
-2. **Inline canonical tags** (medium priority): `NES/Zelda (+region:us) (-unfinished:beta)`
-   - Explicit tag filters with operators in parentheses
-   - Supports: `(+tag:value)` AND, `(-tag:value)` NOT, `(tag:value)` AND (default)
-   - Overrides filename-style tags
-
-3. **Filename-style** (lowest priority): `NES/Zelda (USA) (1986)` (auto-extracted)
-   - Automatically parsed from filename metadata in parentheses
-   - Always treated as AND filters
-   - Used only when no conflicting higher-priority tags exist
-
----
-
-## Implementation Notes
-
-### Key Files
-
-**Indexing Pipeline:**
-- **Main indexing orchestrator**: `pkg/database/mediascanner/indexing_pipeline.go`
-- **Filename title extraction**: `pkg/database/tags/filename_parser.go` → `ParseTitleFromFilename()`
-- **Filename tag extraction**: `pkg/database/tags/filename_parser.go` → `ParseFilenameToCanonicalTags()`
-
-**Slug Normalization:**
-- **Core slugification**: `pkg/database/slugs/slugify.go`
-- **Media parsing (dispatcher)**: `pkg/database/slugs/media_parsing.go`
-- **Game parsing**: `pkg/database/slugs/media_parsing_game.go`
-- **TV show parsing**: `pkg/database/slugs/media_parsing_tv.go`
-- **Movie parsing**: `pkg/database/slugs/media_parsing_movie.go`
-- **Music parsing**: `pkg/database/slugs/media_parsing_music.go`
-- **Normalization helpers**: `pkg/database/slugs/normalization.go`
-- **Script detection**: `pkg/database/slugs/scripts.go`
-
-**Query Resolution (Title-based launching):**
-- **Query parser & resolution**: `pkg/zapscript/titles.go` → `cmdTitle()`
-- **Matching strategies**: `pkg/zapscript/titles/strategies.go`
-- **Result selection**: `pkg/zapscript/titles/selection.go`
-- **Fuzzy matching**: `pkg/database/matcher/fuzzy.go`
-- **Query tag extraction & merging**: `pkg/zapscript/titles/tags.go`
+**Filtering** (in order):
+1. User-specified tag filters
+2. Exclude variants: unfinished (demo, beta, proto), unlicensed (hack, translation, bootleg), bad dumps
+3. Exclude re-releases
+4. Preferred regions from user config
+5. Preferred languages from user config
+6. File type priority based on launcher extension order
+7. Quality tie-breaking: numeric suffix penalty, path depth, character density, filename length

--- a/pkg/api/methods/pairing.go
+++ b/pkg/api/methods/pairing.go
@@ -1,0 +1,70 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/rs/zerolog/log"
+)
+
+// PairingController is the subset of PairingManager needed by the RPC handlers.
+type PairingController interface {
+	StartPairing() (pin string, expiresAt time.Time, err error)
+	CancelPairing()
+}
+
+// HandleClientsPairStart returns a handler that initiates a new pairing flow.
+// Localhost-only — the user must have physical access to the device.
+func HandleClientsPairStart(mgr PairingController) func(requests.RequestEnv) (any, error) {
+	return func(env requests.RequestEnv) (any, error) {
+		if !env.IsLocal {
+			return nil, models.ClientErrf("%w", ErrLocalhostOnly)
+		}
+
+		log.Info().Msg("received clients.pair.start request")
+
+		pin, expiresAt, err := mgr.StartPairing()
+		if err != nil {
+			return nil, models.ClientErrf("failed to start pairing: %w", err)
+		}
+
+		return models.ClientsPairStartResponse{
+			PIN:       pin,
+			ExpiresAt: expiresAt.Unix(),
+		}, nil
+	}
+}
+
+// HandleClientsPairCancel returns a handler that cancels the active pairing flow.
+// Localhost-only.
+func HandleClientsPairCancel(mgr PairingController) func(requests.RequestEnv) (any, error) {
+	return func(env requests.RequestEnv) (any, error) {
+		if !env.IsLocal {
+			return nil, models.ClientErrf("%w", ErrLocalhostOnly)
+		}
+
+		log.Info().Msg("received clients.pair.cancel request")
+		mgr.CancelPairing()
+		return NoContent{}, nil
+	}
+}

--- a/pkg/api/methods/pairing_test.go
+++ b/pkg/api/methods/pairing_test.go
@@ -1,0 +1,103 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockPairingController struct {
+	expiresAt time.Time
+	err       error
+	pin       string
+	cancelled bool
+}
+
+func (m *mockPairingController) StartPairing() (string, time.Time, error) {
+	return m.pin, m.expiresAt, m.err
+}
+
+func (m *mockPairingController) CancelPairing() {
+	m.cancelled = true
+}
+
+func TestHandleClientsPairStart_Success(t *testing.T) {
+	t.Parallel()
+	expires := time.Now().Add(5 * time.Minute)
+	mgr := &mockPairingController{pin: "123456", expiresAt: expires}
+	handler := HandleClientsPairStart(mgr)
+
+	result, err := handler(requests.RequestEnv{IsLocal: true})
+	require.NoError(t, err)
+
+	resp, ok := result.(models.ClientsPairStartResponse)
+	require.True(t, ok)
+	assert.Equal(t, "123456", resp.PIN)
+	assert.Equal(t, expires.Unix(), resp.ExpiresAt)
+}
+
+func TestHandleClientsPairStart_RemoteRejected(t *testing.T) {
+	t.Parallel()
+	mgr := &mockPairingController{pin: "123456", expiresAt: time.Now()}
+	handler := HandleClientsPairStart(mgr)
+
+	_, err := handler(requests.RequestEnv{IsLocal: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "localhost")
+}
+
+func TestHandleClientsPairStart_Error(t *testing.T) {
+	t.Parallel()
+	mgr := &mockPairingController{err: errors.New("pairing in progress")}
+	handler := HandleClientsPairStart(mgr)
+
+	_, err := handler(requests.RequestEnv{IsLocal: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pairing in progress")
+}
+
+func TestHandleClientsPairCancel_Success(t *testing.T) {
+	t.Parallel()
+	mgr := &mockPairingController{}
+	handler := HandleClientsPairCancel(mgr)
+
+	result, err := handler(requests.RequestEnv{IsLocal: true})
+	require.NoError(t, err)
+	assert.IsType(t, NoContent{}, result)
+	assert.True(t, mgr.cancelled)
+}
+
+func TestHandleClientsPairCancel_RemoteRejected(t *testing.T) {
+	t.Parallel()
+	mgr := &mockPairingController{}
+	handler := HandleClientsPairCancel(mgr)
+
+	_, err := handler(requests.RequestEnv{IsLocal: false})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "localhost")
+	assert.False(t, mgr.cancelled, "CancelPairing must not be called for remote requests")
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -75,6 +75,8 @@ const (
 	MethodPlaytime             = "playtime"
 	MethodClients              = "clients"
 	MethodClientsDelete        = "clients.delete"
+	MethodClientsPairStart     = "clients.pair.start"
+	MethodClientsPairCancel    = "clients.pair.cancel"
 	MethodSystems              = "systems"
 	MethodLaunchersRefresh     = "launchers.refresh"
 	MethodHistory              = "tokens.history"

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -383,6 +383,12 @@ type ClientsDeleteParams struct {
 	ClientID string `json:"clientId"`
 }
 
+// ClientsPairStartResponse is the response for the clients.pair.start RPC method.
+type ClientsPairStartResponse struct {
+	PIN       string `json:"pin"`
+	ExpiresAt int64  `json:"expiresAt"`
+}
+
 // ClientsPairedNotification is the payload for the clients.paired notification,
 // broadcast when a client successfully completes the PAKE pairing flow.
 type ClientsPairedNotification struct {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1397,6 +1397,17 @@ func Start(
 	pairingMgr := NewPairingManager(db.UserDB, st.Notifications)
 	pairingMgr.StartCleanup(st.GetContext())
 
+	// Register pairing RPC methods. These close over the pairingMgr so
+	// they must be added after it is created, not in NewMethodMap().
+	if err := methodMap.AddMethod(models.MethodClientsPairStart,
+		methods.HandleClientsPairStart(pairingMgr)); err != nil {
+		log.Error().Err(err).Msg("error adding clients.pair.start method")
+	}
+	if err := methodMap.AddMethod(models.MethodClientsPairCancel,
+		methods.HandleClientsPairCancel(pairingMgr)); err != nil {
+		log.Error().Err(err).Msg("error adding clients.pair.cancel method")
+	}
+
 	encGateway := apimiddleware.NewEncryptionGateway(db.UserDB)
 	encGateway.StartCleanup(st.GetContext())
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -282,7 +282,9 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 		}
 
 		_, _ = fmt.Fprint(os.Stderr, "Pairing successful!\n")
-		_, _ = fmt.Println(result)
+		sanitizedResult := strings.ReplaceAll(result, "\n", "")
+		sanitizedResult = strings.ReplaceAll(sanitizedResult, "\r", "")
+		_, _ = fmt.Println(sanitizedResult)
 		os.Exit(0)
 	case *f.Reload:
 		_, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsReload, "")

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -51,6 +51,7 @@ type Flags struct {
 	ShowLoader *string
 	ShowPicker *string
 	Reload     *bool
+	Pair       *bool
 }
 
 // SetupFlags defines all common CLI flags between platforms.
@@ -95,6 +96,11 @@ func SetupFlags() *Flags {
 			"reload",
 			false,
 			"reload config and mappings from disk",
+		),
+		Pair: flag.Bool(
+			"pair",
+			false,
+			"start pairing flow and display PIN for client to enter",
 		),
 	}
 }
@@ -238,6 +244,45 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 		}
 
 		_, _ = fmt.Println(resp)
+		os.Exit(0)
+	case *f.Pair:
+		resp, err := client.LocalClient(context.Background(), cfg, models.MethodClientsPairStart, "")
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error starting pairing: %v\n", err)
+			os.Exit(1)
+		}
+
+		var pairResp models.ClientsPairStartResponse
+		unmarshalErr := json.Unmarshal([]byte(resp), &pairResp)
+		if unmarshalErr != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error parsing response: %v\n", unmarshalErr)
+			os.Exit(1)
+		}
+
+		_, _ = fmt.Fprintf(os.Stderr, "Pairing PIN: %s\n", pairResp.PIN)
+		_, _ = fmt.Fprint(os.Stderr, "Enter this PIN in your client app. Waiting for pairing...\n")
+
+		// Cancel pairing on ctrl-c.
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			<-sigs
+			_, _ = client.LocalClient(context.Background(), cfg, models.MethodClientsPairCancel, "")
+			_, _ = fmt.Fprint(os.Stderr, "\nPairing cancelled.\n")
+			os.Exit(0)
+		}()
+
+		result, err := client.WaitNotification(
+			context.Background(), -1,
+			cfg, models.NotificationClientsPaired,
+		)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Error waiting for pairing: %v\n", err)
+			os.Exit(1)
+		}
+
+		_, _ = fmt.Fprint(os.Stderr, "Pairing successful!\n")
+		_, _ = fmt.Println(result)
 		os.Exit(0)
 	case *f.Reload:
 		_, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsReload, "")


### PR DESCRIPTION
## Summary

- Add `clients.pair.start` and `clients.pair.cancel` JSON-RPC methods so pairing can be triggered programmatically
- Add `-pair` CLI flag that starts a pairing flow, displays the PIN, and waits for completion
- Rewrite `docs/api/encryption.md` for clarity: replace ASCII flowchart with Mermaid sequence diagram, replace JS example with pseudocode, cut inline justifications (356 → 264 lines)
- Rewrite `docs/media-titles.md`: remove AI-generated tone, cut redundant sections (601 → 262 lines)
- Fix Go version in `docs/index.md` (1.25 → 1.26)
- Add encryption cross-reference to `docs/api/index.md`