### PR TITLE
perf(daemon): skip service binary copy when unchanged

### DIFF
--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -23,6 +23,7 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -170,6 +171,14 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 		return "", fmt.Errorf("error creating data directory: %w", err)
 	}
 
+	equal, eqErr := filesEqual(binPath, copyPath)
+	if eqErr != nil {
+		log.Warn().Err(eqErr).Msg("error comparing binaries, proceeding with copy")
+	} else if equal {
+		log.Debug().Msg("skipping binary copy, service binary already up to date")
+		return copyPath, nil
+	}
+
 	//nolint:gosec // G304: binPath from os.Executable()
 	binFile, err := os.Open(binPath)
 	if err != nil {
@@ -206,6 +215,63 @@ func (s *Service) cleanupServiceBinary() {
 	}
 	if rmErr := os.Remove(exePath); rmErr != nil {
 		log.Error().Err(rmErr).Msg("error removing service binary")
+	}
+}
+
+// filesEqual reports whether the files at pathA and pathB have identical
+// contents. Returns false (not an error) if pathB does not exist. A size
+// comparison is performed first as a fast pre-filter before streaming.
+func filesEqual(pathA, pathB string) (bool, error) {
+	infoA, err := os.Stat(pathA) //nolint:gosec // G703: paths from os.Executable() and internal DataDir
+	if err != nil {
+		return false, fmt.Errorf("error statting source: %w", err)
+	}
+
+	infoB, err := os.Stat(pathB) //nolint:gosec // G703: paths from os.Executable() and internal DataDir
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error statting destination: %w", err)
+	}
+
+	if infoA.Size() != infoB.Size() {
+		return false, nil
+	}
+
+	//nolint:gosec // G304: paths from os.Executable() and internal DataDir
+	fa, err := os.Open(pathA)
+	if err != nil {
+		return false, fmt.Errorf("error opening source: %w", err)
+	}
+	defer func() { _ = fa.Close() }()
+
+	//nolint:gosec // G304: paths from os.Executable() and internal DataDir
+	fb, err := os.Open(pathB)
+	if err != nil {
+		return false, fmt.Errorf("error opening destination: %w", err)
+	}
+	defer func() { _ = fb.Close() }()
+
+	bufA := make([]byte, 32*1024)
+	bufB := make([]byte, 32*1024)
+	for {
+		nA, errA := fa.Read(bufA)
+		nB, errB := fb.Read(bufB)
+
+		if !bytes.Equal(bufA[:nA], bufB[:nB]) {
+			return false, nil
+		}
+
+		if errA == io.EOF && errB == io.EOF {
+			return true, nil
+		}
+		if errA != nil {
+			return false, fmt.Errorf("error reading source: %w", errA)
+		}
+		if errB != nil {
+			return false, fmt.Errorf("error reading destination: %w", errB)
+		}
 	}
 }
 

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -126,4 +127,121 @@ func TestCleanupServiceBinary_RemovesFromDataDir(t *testing.T) {
 	// and won't remove anything. This verifies the safety guard works.
 	svc.cleanupServiceBinary()
 	assert.FileExists(t, result)
+}
+
+func TestFilesEqual_IdenticalFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	content := []byte("same content")
+	require.NoError(t, os.WriteFile(a, content, 0o600))
+	require.NoError(t, os.WriteFile(b, content, 0o600))
+
+	equal, err := filesEqual(a, b)
+	require.NoError(t, err)
+	assert.True(t, equal)
+}
+
+func TestFilesEqual_EmptyFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(a, []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(b, []byte{}, 0o600))
+
+	equal, err := filesEqual(a, b)
+	require.NoError(t, err)
+	assert.True(t, equal)
+}
+
+func TestFilesEqual_DifferentContent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(a, []byte("content a"), 0o600))
+	require.NoError(t, os.WriteFile(b, []byte("content b"), 0o600))
+
+	equal, err := filesEqual(a, b)
+	require.NoError(t, err)
+	assert.False(t, equal)
+}
+
+func TestFilesEqual_DifferentSizes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	require.NoError(t, os.WriteFile(a, []byte("short"), 0o600))
+	require.NoError(t, os.WriteFile(b, []byte("much longer content"), 0o600))
+
+	equal, err := filesEqual(a, b)
+	require.NoError(t, err)
+	assert.False(t, equal)
+}
+
+func TestFilesEqual_DestinationMissing(t *testing.T) {
+	t.Parallel()
+	a := filepath.Join(t.TempDir(), "a")
+	require.NoError(t, os.WriteFile(a, []byte("data"), 0o600))
+
+	equal, err := filesEqual(a, "/nonexistent/file")
+	require.NoError(t, err)
+	assert.False(t, equal)
+}
+
+func TestFilesEqual_SourceMissing(t *testing.T) {
+	t.Parallel()
+	_, err := filesEqual("/nonexistent/file", "/also/nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error statting source")
+}
+
+func TestPrepareBinary_SkipsCopyWhenIdentical(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	// Set mtime to a known past value so any rewrite is detectable.
+	pastTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(result, pastTime, pastTime))
+
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, result, result2)
+
+	info, err := os.Stat(result2)
+	require.NoError(t, err)
+	assert.Equal(t, pastTime.Unix(), info.ModTime().Unix(), "file should not have been rewritten")
+}
+
+func TestPrepareBinary_CopiesWhenContentDiffers(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo")
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-1"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	// Update the source binary.
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-2"), 0o600))
+
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, result, result2)
+
+	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
+	require.NoError(t, err)
+	assert.Equal(t, "version-2", string(content))
 }

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -104,7 +104,8 @@ func TestPrepareBinary_MissingSource(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t)
 
-	_, err := svc.prepareBinary("/nonexistent/binary")
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "binary")
+	_, err := svc.prepareBinary(missing)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error opening binary")
 }
@@ -187,14 +188,17 @@ func TestFilesEqual_DestinationMissing(t *testing.T) {
 	a := filepath.Join(t.TempDir(), "a")
 	require.NoError(t, os.WriteFile(a, []byte("data"), 0o600))
 
-	equal, err := filesEqual(a, "/nonexistent/file")
+	missing := filepath.Join(t.TempDir(), "does-not-exist", "file")
+	equal, err := filesEqual(a, missing)
 	require.NoError(t, err)
 	assert.False(t, equal)
 }
 
 func TestFilesEqual_SourceMissing(t *testing.T) {
 	t.Parallel()
-	_, err := filesEqual("/nonexistent/file", "/also/nonexistent")
+	missingA := filepath.Join(t.TempDir(), "does-not-exist", "source")
+	missingB := filepath.Join(t.TempDir(), "does-not-exist", "dest")
+	_, err := filesEqual(missingA, missingB)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error statting source")
 }


### PR DESCRIPTION
## Summary

- Compare source and destination binaries before copying in `prepareBinary` to avoid unnecessary writes on SD card devices
- Size pre-filter + streaming byte comparison; errors fall through to normal copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents unnecessary binary rewrites by detecting when the destination already matches the source.

* **Tests**
  * Added comprehensive tests covering file comparisons (identical, empty, different content/size, missing files) and binary update flows (skips copy when identical; rewrites when content differs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->