### PR TITLE
refactor(config): add LoadTOML, remove SetXxxForTesting methods

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,25 +233,47 @@ func (c *Instance) Load() error {
 
 	// Start with defaults, then unmarshal file values on top.
 	// This ensures fields not present in the file retain their default values.
-	newVals := c.defaults
-	err = toml.Unmarshal(data, &newVals)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal config: %w", err)
+	// Save old vals so we can restore on error (Load is called at runtime for
+	// config reloads — a bad file must not destroy the running config).
+	oldVals := c.vals
+	c.vals = c.defaults
+
+	if err := c.applyTOML(string(data)); err != nil {
+		c.vals = oldVals
+		return err
 	}
 
-	if newVals.ConfigSchema != SchemaVersion {
+	if c.vals.ConfigSchema != SchemaVersion {
 		log.Error().Msgf(
 			"schema version mismatch: got %d, expecting %d",
-			newVals.ConfigSchema,
+			c.vals.ConfigSchema,
 			SchemaVersion,
 		)
+		c.vals = oldVals
 		return errors.New("schema version mismatch")
 	}
 
-	c.vals = newVals
-
 	// load auth file
 	c.reloadAuth()
+
+	return nil
+}
+
+// LoadTOML unmarshals a TOML string onto the current config values and
+// rebuilds derived fields (compiled regexes, lookup maps). Fields not
+// present in the TOML are left unchanged.
+func (c *Instance) LoadTOML(data string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.applyTOML(data)
+}
+
+// applyTOML is the shared unmarshal + post-processing core.
+// Caller must hold c.mu.
+func (c *Instance) applyTOML(data string) error {
+	if err := toml.Unmarshal([]byte(data), &c.vals); err != nil {
+		return fmt.Errorf("failed to unmarshal config: %w", err)
+	}
 
 	// prepare allow files regexes
 	c.vals.Launchers.allowFileRe = make([]*regexp.Regexp, len(c.vals.Launchers.AllowFile))
@@ -698,20 +720,6 @@ func (c *Instance) IsHTTPAllowed(url string) bool {
 	return checkAllow(c.vals.ZapScript.AllowHTTP, c.vals.ZapScript.allowHTTPRe, url)
 }
 
-// SetHTTPAllowListForTesting configures the HTTP allow list for tests.
-func (c *Instance) SetHTTPAllowListForTesting(allowList []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.AllowHTTP = allowList
-	c.vals.ZapScript.allowHTTPRe = make([]*regexp.Regexp, len(allowList))
-	for i, pattern := range allowList {
-		re, err := regexp.Compile(anchorPattern(pattern))
-		if err == nil {
-			c.vals.ZapScript.allowHTTPRe[i] = re
-		}
-	}
-}
-
 // InputMode returns the configured input restriction mode.
 // defaultMode is the platform-provided default (e.g., "hotkeys" for desktop,
 // "unrestricted" for embedded).
@@ -747,38 +755,6 @@ func (c *Instance) InputBlockList() []string {
 	return c.vals.ZapScript.Input.Block
 }
 
-// SetBlockCommandsForTesting sets the command block list for tests.
-func (c *Instance) SetBlockCommandsForTesting(cmds []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.BlockCommands = cmds
-	c.vals.ZapScript.blockCommandSet = make(map[string]struct{}, len(cmds))
-	for _, cmd := range cmds {
-		c.vals.ZapScript.blockCommandSet[cmd] = struct{}{}
-	}
-}
-
-// SetInputModeForTesting sets the input mode for tests.
-func (c *Instance) SetInputModeForTesting(mode *string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.Input.Mode = mode
-}
-
-// SetInputAllowListForTesting sets the input allow list for tests.
-func (c *Instance) SetInputAllowListForTesting(keys []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.Input.Allow = keys
-}
-
-// SetInputBlockListForTesting sets the input block list for tests.
-func (c *Instance) SetInputBlockListForTesting(keys []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.Input.Block = keys
-}
-
 // SetAuthCfgForTesting sets the global auth config for testing purposes
 func SetAuthCfgForTesting(creds map[string]CredentialEntry) {
 	authCfg.Store(creds)
@@ -787,20 +763,6 @@ func SetAuthCfgForTesting(creds map[string]CredentialEntry) {
 // ClearAuthCfgForTesting clears the global auth config for testing purposes
 func ClearAuthCfgForTesting() {
 	authCfg.Store(map[string]CredentialEntry{})
-}
-
-// SetExecuteAllowListForTesting configures the execute allow list for tests.
-func (c *Instance) SetExecuteAllowListForTesting(allowList []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.ZapScript.AllowExecute = allowList
-	c.vals.ZapScript.allowExecuteRe = make([]*regexp.Regexp, len(allowList))
-	for i, pattern := range allowList {
-		re, err := regexp.Compile(anchorPattern(pattern))
-		if err == nil {
-			c.vals.ZapScript.allowExecuteRe[i] = re
-		}
-	}
 }
 
 // VirtualGamepadEnabled returns whether virtual gamepad emulation is enabled.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,7 +265,12 @@ func (c *Instance) Load() error {
 func (c *Instance) LoadTOML(data string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.applyTOML(data)
+	oldVals := c.vals
+	if err := c.applyTOML(data); err != nil {
+		c.vals = oldVals
+		return err
+	}
+	return nil
 }
 
 // applyTOML is the shared unmarshal + post-processing core.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1204,11 +1204,13 @@ func TestAnchorPattern(t *testing.T) {
 func TestAutoAnchorPreventsSubstringMatch(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Instance{}
-
 	// Without anchoring, "echo" would match "echo && rm -rf /"
 	// With anchoring, it should only match exactly "echo"
-	cfg.SetExecuteAllowListForTesting([]string{"echo"})
+	cfg := &Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["echo"]
+`))
 
 	assert.True(t, cfg.IsExecuteAllowed("echo"),
 		"exact match should be allowed")
@@ -1218,17 +1220,25 @@ func TestAutoAnchorPreventsSubstringMatch(t *testing.T) {
 		"prefix substring should be blocked")
 
 	// Pattern with .* should still allow intended matches
-	cfg.SetExecuteAllowListForTesting([]string{"/usr/bin/.*"})
+	cfg2 := &Instance{}
+	require.NoError(t, cfg2.LoadTOML(`
+[zapscript]
+allow_execute = ["/usr/bin/.*"]
+`))
 
-	assert.True(t, cfg.IsExecuteAllowed("/usr/bin/notify-send"),
+	assert.True(t, cfg2.IsExecuteAllowed("/usr/bin/notify-send"),
 		"wildcard suffix should match")
-	assert.False(t, cfg.IsExecuteAllowed("/opt/usr/bin/notify-send"),
+	assert.False(t, cfg2.IsExecuteAllowed("/opt/usr/bin/notify-send"),
 		"path prefix should not match without .*")
 
 	// Explicit substring pattern should still work
-	cfg.SetExecuteAllowListForTesting([]string{".*mister.*"})
+	cfg3 := &Instance{}
+	require.NoError(t, cfg3.LoadTOML(`
+[zapscript]
+allow_execute = [".*mister.*"]
+`))
 
-	assert.True(t, cfg.IsExecuteAllowed("misterious"),
+	assert.True(t, cfg3.IsExecuteAllowed("misterious"),
 		"explicit .*pattern.* should allow substring match")
 }
 
@@ -1267,52 +1277,52 @@ func TestIsRunAllowed(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		input     string
-		allowList []string
-		expected  bool
+		name     string
+		input    string
+		toml     string
+		expected bool
 	}{
 		{
-			name:      "empty list rejects all",
-			allowList: nil,
-			input:     "**launch:SNES",
-			expected:  false,
+			name:     "empty list rejects all",
+			toml:     "",
+			input:    "**launch:SNES",
+			expected: false,
 		},
 		{
-			name:      "single command matches",
-			allowList: []string{`\*\*launch\.random:.*`},
-			input:     "**launch.random:SNES",
-			expected:  true,
+			name:     "single command matches",
+			toml:     "[service]\nallow_run = ['\\*\\*launch\\.random:.*']",
+			input:    "**launch.random:SNES",
+			expected: true,
 		},
 		{
-			name:      "single command no match",
-			allowList: []string{`\*\*launch\.random:.*`},
-			input:     "**execute:rm -rf /",
-			expected:  false,
+			name:     "single command no match",
+			toml:     "[service]\nallow_run = ['\\*\\*launch\\.random:.*']",
+			input:    "**execute:rm -rf /",
+			expected: false,
 		},
 		{
-			name:      "chained commands all match",
-			allowList: []string{`\*\*launch\.random:.*`},
-			input:     "**launch.random:SNES||**launch.random:NES",
-			expected:  true,
+			name:     "chained commands all match",
+			toml:     "[service]\nallow_run = ['\\*\\*launch\\.random:.*']",
+			input:    "**launch.random:SNES||**launch.random:NES",
+			expected: true,
 		},
 		{
-			name:      "chained commands one fails",
-			allowList: []string{`\*\*launch\.random:.*`},
-			input:     "**launch.random:SNES||**execute:rm -rf /",
-			expected:  false,
+			name:     "chained commands one fails",
+			toml:     "[service]\nallow_run = ['\\*\\*launch\\.random:.*']",
+			input:    "**launch.random:SNES||**execute:rm -rf /",
+			expected: false,
 		},
 		{
-			name:      "auto-launch path normalizes to launch command",
-			allowList: []string{`\*\*launch:/games/.*`},
-			input:     "/games/snes/mario.sfc",
-			expected:  true,
+			name:     "auto-launch path normalizes to launch command",
+			toml:     "[service]\nallow_run = ['\\*\\*launch:/games/.*']",
+			input:    "/games/snes/mario.sfc",
+			expected: true,
 		},
 		{
-			name:      "malformed input rejected",
-			allowList: []string{".*"},
-			input:     "**",
-			expected:  false,
+			name:     "malformed input rejected",
+			toml:     "[service]\nallow_run = ['.*']",
+			input:    "**",
+			expected: false,
 		},
 	}
 
@@ -1320,9 +1330,11 @@ func TestIsRunAllowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := &Instance{}
-			cfg.SetRunAllowListForTesting(tt.allowList)
+			if tt.toml != "" {
+				require.NoError(t, cfg.LoadTOML(tt.toml))
+			}
 			assert.Equal(t, tt.expected, cfg.IsRunAllowed(tt.input),
-				"input: %s, allowList: %v", tt.input, tt.allowList)
+				"input: %s, toml: %s", tt.input, tt.toml)
 		})
 	}
 }
@@ -1331,34 +1343,34 @@ func TestIsHTTPAllowed(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		url       string
-		allowList []string
-		expected  bool
+		name     string
+		url      string
+		toml     string
+		expected bool
 	}{
 		{
-			name:      "empty list allows all",
-			allowList: nil,
-			url:       "https://anything.com",
-			expected:  true,
+			name:     "empty list allows all",
+			toml:     "",
+			url:      "https://anything.com",
+			expected: true,
 		},
 		{
-			name:      "matching URL allowed",
-			allowList: []string{`https://example\.com/.*`},
-			url:       "https://example.com/api/test",
-			expected:  true,
+			name:     "matching URL allowed",
+			toml:     `[zapscript]` + "\nallow_http = ['https://example\\.com/.*']",
+			url:      "https://example.com/api/test",
+			expected: true,
 		},
 		{
-			name:      "non-matching URL blocked",
-			allowList: []string{`https://example\.com/.*`},
-			url:       "https://evil.com/attack",
-			expected:  false,
+			name:     "non-matching URL blocked",
+			toml:     `[zapscript]` + "\nallow_http = ['https://example\\.com/.*']",
+			url:      "https://evil.com/attack",
+			expected: false,
 		},
 		{
-			name:      "anchoring prevents partial match",
-			allowList: []string{`https://example\.com`},
-			url:       "https://example.com.evil.com",
-			expected:  false,
+			name:     "anchoring prevents partial match",
+			toml:     `[zapscript]` + "\nallow_http = ['https://example\\.com']",
+			url:      "https://example.com.evil.com",
+			expected: false,
 		},
 	}
 
@@ -1366,7 +1378,9 @@ func TestIsHTTPAllowed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := &Instance{}
-			cfg.SetHTTPAllowListForTesting(tt.allowList)
+			if tt.toml != "" {
+				require.NoError(t, cfg.LoadTOML(tt.toml))
+			}
 			assert.Equal(t, tt.expected, cfg.IsHTTPAllowed(tt.url))
 		})
 	}
@@ -1376,34 +1390,34 @@ func TestIsCommandBlocked(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		command       string
-		blockCommands []string
-		expected      bool
+		name     string
+		command  string
+		toml     string
+		expected bool
 	}{
 		{
-			name:          "empty block list allows all",
-			blockCommands: nil,
-			command:       "execute",
-			expected:      false,
+			name:     "empty block list allows all",
+			toml:     "",
+			command:  "execute",
+			expected: false,
 		},
 		{
-			name:          "exact match is blocked",
-			blockCommands: []string{"execute", "http.get"},
-			command:       "execute",
-			expected:      true,
+			name:     "exact match is blocked",
+			toml:     "[zapscript]\nblock_commands = [\"execute\", \"http.get\"]",
+			command:  "execute",
+			expected: true,
 		},
 		{
-			name:          "non-matching command is allowed",
-			blockCommands: []string{"execute", "http.get"},
-			command:       "launch",
-			expected:      false,
+			name:     "non-matching command is allowed",
+			toml:     "[zapscript]\nblock_commands = [\"execute\", \"http.get\"]",
+			command:  "launch",
+			expected: false,
 		},
 		{
-			name:          "partial name is not blocked",
-			blockCommands: []string{"execute"},
-			command:       "execute.something",
-			expected:      false,
+			name:     "partial name is not blocked",
+			toml:     "[zapscript]\nblock_commands = [\"execute\"]",
+			command:  "execute.something",
+			expected: false,
 		},
 	}
 
@@ -1411,7 +1425,9 @@ func TestIsCommandBlocked(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := &Instance{}
-			cfg.SetBlockCommandsForTesting(tt.blockCommands)
+			if tt.toml != "" {
+				require.NoError(t, cfg.LoadTOML(tt.toml))
+			}
 			assert.Equal(t, tt.expected, cfg.IsCommandBlocked(tt.command))
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1239,12 +1239,21 @@ allow_execute = ["echo"]
 `))
 	assert.True(t, cfg.IsExecuteAllowed("echo"))
 
-	// Invalid TOML must return error and preserve existing state
-	err := cfg.LoadTOML(`[invalid toml !!!`)
+	// TOML that decodes debug_logging (bool) then fails on a type error
+	// for allow_execute (string where array expected). This tests that
+	// partially-applied fields are rolled back.
+	err := cfg.LoadTOML(`
+debug_logging = true
+
+[zapscript]
+allow_execute = "not-an-array"
+`)
 	require.Error(t, err)
 
 	assert.True(t, cfg.IsExecuteAllowed("echo"),
 		"state must be preserved after LoadTOML error")
+	assert.False(t, cfg.IsExecuteAllowed("not-an-array"),
+		"partial decode must not leak into state")
 }
 
 func TestLoadTOML_RebuildsDerivedFields(t *testing.T) {
@@ -1279,6 +1288,16 @@ allow_execute = ["rm"]
 		"regex must be recompiled after LoadTOML")
 	assert.False(t, cfg.IsExecuteAllowed("echo"),
 		"old regex must be replaced")
+
+	// Other derived fields must be retained from the first LoadTOML
+	assert.True(t, cfg.IsHTTPAllowed("https://example.com/foo"),
+		"allowHTTPRe must be retained")
+	assert.False(t, cfg.IsHTTPAllowed("https://evil.com"),
+		"allowHTTPRe must still block non-matching URLs")
+	assert.True(t, cfg.IsCommandBlocked("http.get"),
+		"blockCommandSet must be retained")
+	assert.True(t, cfg.IsRunAllowed("**launch:test"),
+		"allowRunRe must be retained")
 }
 
 func TestLoad_RollbackOnSchemaError(t *testing.T) {
@@ -1295,9 +1314,15 @@ allow_execute = ["echo"]
 `))
 	assert.True(t, cfg.IsExecuteAllowed("echo"))
 
-	// Write a config file with wrong schema version
+	// Write a config file with wrong schema version but valid fields —
+	// Load() will decode allow_execute = ["rm"] before schema check fails,
+	// so this verifies rollback undoes the partial decode.
 	cfgPath := filepath.Join(tempDir, CfgFile)
-	err = os.WriteFile(cfgPath, []byte(`config_schema = 9999`), 0o600)
+	err = os.WriteFile(cfgPath, []byte(`config_schema = 9999
+
+[zapscript]
+allow_execute = ["rm"]
+`), 0o600)
 	require.NoError(t, err)
 
 	// Load should fail but preserve running config
@@ -1305,6 +1330,8 @@ allow_execute = ["echo"]
 	require.Error(t, err)
 	assert.True(t, cfg.IsExecuteAllowed("echo"),
 		"Load must preserve running config on schema error")
+	assert.False(t, cfg.IsExecuteAllowed("rm"),
+		"bad config values must not leak into running config")
 }
 
 func TestAutoAnchorPreventsSubstringMatch(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1201,6 +1201,112 @@ func TestAnchorPattern(t *testing.T) {
 	}
 }
 
+func TestLoadTOML_PartialMerge(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["echo"]
+block_commands = ["http.get"]
+`))
+
+	// Baseline
+	assert.True(t, cfg.IsExecuteAllowed("echo"))
+	assert.True(t, cfg.IsCommandBlocked("http.get"))
+
+	// Partial update — only change block_commands, leave allow_execute untouched
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+block_commands = ["execute"]
+`))
+
+	// allow_execute unchanged
+	assert.True(t, cfg.IsExecuteAllowed("echo"),
+		"partial merge must not clear unrelated fields")
+	// block_commands updated
+	assert.False(t, cfg.IsCommandBlocked("http.get"))
+	assert.True(t, cfg.IsCommandBlocked("execute"))
+}
+
+func TestLoadTOML_InvalidTOMLPreservesState(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["echo"]
+`))
+	assert.True(t, cfg.IsExecuteAllowed("echo"))
+
+	// Invalid TOML must return error and preserve existing state
+	err := cfg.LoadTOML(`[invalid toml !!!`)
+	require.Error(t, err)
+
+	assert.True(t, cfg.IsExecuteAllowed("echo"),
+		"state must be preserved after LoadTOML error")
+}
+
+func TestLoadTOML_RebuildsDerivedFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["echo"]
+allow_http = ['https://example\.com/.*']
+block_commands = ["http.get"]
+
+[service]
+allow_run = ['.*']
+`))
+
+	assert.True(t, cfg.IsExecuteAllowed("echo"))
+	assert.False(t, cfg.IsExecuteAllowed("rm"))
+	assert.True(t, cfg.IsHTTPAllowed("https://example.com/foo"))
+	assert.False(t, cfg.IsHTTPAllowed("https://evil.com"))
+	assert.True(t, cfg.IsCommandBlocked("http.get"))
+	assert.False(t, cfg.IsCommandBlocked("launch"))
+	assert.True(t, cfg.IsRunAllowed("**launch:test"))
+
+	// Update regexes — derived fields must be rebuilt
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["rm"]
+`))
+
+	assert.True(t, cfg.IsExecuteAllowed("rm"),
+		"regex must be recompiled after LoadTOML")
+	assert.False(t, cfg.IsExecuteAllowed("echo"),
+		"old regex must be replaced")
+}
+
+func TestLoad_RollbackOnSchemaError(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cfg, err := NewConfig(tempDir, BaseDefaults)
+	require.NoError(t, err)
+
+	// Set up known state
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript]
+allow_execute = ["echo"]
+`))
+	assert.True(t, cfg.IsExecuteAllowed("echo"))
+
+	// Write a config file with wrong schema version
+	cfgPath := filepath.Join(tempDir, CfgFile)
+	err = os.WriteFile(cfgPath, []byte(`config_schema = 9999`), 0o600)
+	require.NoError(t, err)
+
+	// Load should fail but preserve running config
+	err = cfg.Load()
+	require.Error(t, err)
+	assert.True(t, cfg.IsExecuteAllowed("echo"),
+		"Load must preserve running config on schema error")
+}
+
 func TestAutoAnchorPreventsSubstringMatch(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/configlaunchers.go
+++ b/pkg/config/configlaunchers.go
@@ -154,13 +154,6 @@ func (c *Instance) LookupLauncherDefaults(launcherID string, groups []string) La
 	return result
 }
 
-// SetLauncherDefaultsForTesting sets launcher defaults for testing purposes.
-func (c *Instance) SetLauncherDefaultsForTesting(defaults []LaunchersDefault) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.Launchers.Default = defaults
-}
-
 func (c *Instance) LoadCustomLaunchers(launchersDir string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -73,56 +73,56 @@ func TestLaunchersBeforeMediaStart(t *testing.T) {
 	}
 }
 
-func TestSetExecuteAllowListForTesting(t *testing.T) {
+func TestLoadTOML_ExecuteAllowList(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		testCmd   string
-		allowList []string
-		expected  bool
+		name     string
+		testCmd  string
+		toml     string
+		expected bool
 	}{
 		{
-			name:      "empty allow list blocks all",
-			allowList: []string{},
-			testCmd:   "echo hello",
-			expected:  false,
+			name:     "empty allow list blocks all",
+			toml:     `[zapscript]` + "\n" + `allow_execute = []`,
+			testCmd:  "echo hello",
+			expected: false,
 		},
 		{
-			name:      "wildcard allows all",
-			allowList: []string{".*"},
-			testCmd:   "echo hello",
-			expected:  true,
+			name:     "wildcard allows all",
+			toml:     `[zapscript]` + "\n" + `allow_execute = [".*"]`,
+			testCmd:  "echo hello",
+			expected: true,
 		},
 		{
-			name:      "specific command allowed",
-			allowList: []string{"^echo$"},
-			testCmd:   "echo",
-			expected:  true,
+			name:     "specific command allowed",
+			toml:     `[zapscript]` + "\n" + `allow_execute = ["^echo$"]`,
+			testCmd:  "echo",
+			expected: true,
 		},
 		{
-			name:      "specific command not in list blocked",
-			allowList: []string{"^echo$"},
-			testCmd:   "rm -rf",
-			expected:  false,
+			name:     "specific command not in list blocked",
+			toml:     `[zapscript]` + "\n" + `allow_execute = ["^echo$"]`,
+			testCmd:  "rm -rf",
+			expected: false,
 		},
 		{
-			name:      "path pattern matching",
-			allowList: []string{"/usr/bin/.*"},
-			testCmd:   "/usr/bin/notify-send",
-			expected:  true,
+			name:     "path pattern matching",
+			toml:     `[zapscript]` + "\n" + `allow_execute = ["/usr/bin/.*"]`,
+			testCmd:  "/usr/bin/notify-send",
+			expected: true,
 		},
 		{
-			name:      "multiple patterns",
-			allowList: []string{"^echo$", "^notify-send$"},
-			testCmd:   "notify-send",
-			expected:  true,
+			name:     "multiple patterns",
+			toml:     `[zapscript]` + "\n" + `allow_execute = ["^echo$", "^notify-send$"]`,
+			testCmd:  "notify-send",
+			expected: true,
 		},
 		{
-			name:      "invalid regex is skipped gracefully",
-			allowList: []string{"[invalid", "^echo$"},
-			testCmd:   "echo",
-			expected:  true,
+			name:     "invalid regex is skipped gracefully",
+			toml:     `[zapscript]` + "\n" + `allow_execute = ["[invalid", "^echo$"]`,
+			testCmd:  "echo",
+			expected: true,
 		},
 	}
 
@@ -131,25 +131,26 @@ func TestSetExecuteAllowListForTesting(t *testing.T) {
 			t.Parallel()
 
 			cfg := &Instance{}
-			cfg.SetExecuteAllowListForTesting(tt.allowList)
+			require.NoError(t, cfg.LoadTOML(tt.toml))
 
 			result := cfg.IsExecuteAllowed(tt.testCmd)
-			assert.Equal(t, tt.expected, result, "command: %s, allowList: %v", tt.testCmd, tt.allowList)
+			assert.Equal(t, tt.expected, result, "command: %s, toml: %s", tt.testCmd, tt.toml)
 		})
 	}
 }
 
-func TestSetExecuteAllowListForTesting_CompilesRegex(t *testing.T) {
+func TestLoadTOML_CompilesExecuteRegex(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{"^test.*", "^echo$"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = ["^test.*", "^echo$"]`))
 
-	// Verify internal state was set correctly
-	assert.Len(t, cfg.vals.ZapScript.AllowExecute, 2)
-	assert.Len(t, cfg.vals.ZapScript.allowExecuteRe, 2)
-	assert.NotNil(t, cfg.vals.ZapScript.allowExecuteRe[0])
-	assert.NotNil(t, cfg.vals.ZapScript.allowExecuteRe[1])
+	// Verify behavior: matching commands are allowed
+	assert.True(t, cfg.IsExecuteAllowed("testing123"))
+	assert.True(t, cfg.IsExecuteAllowed("echo"))
+	// Verify behavior: non-matching commands are blocked
+	assert.False(t, cfg.IsExecuteAllowed("rm -rf"))
 }
 
 func TestLookupLauncherDefaults(t *testing.T) {
@@ -345,20 +346,21 @@ func TestLookupLauncherDefaults(t *testing.T) {
 	}
 }
 
-func TestSetLauncherDefaultsForTesting(t *testing.T) {
+func TestLoadTOML_LauncherDefaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Instance{}
 
-	defaults := []LaunchersDefault{
-		{Launcher: "Steam", Action: "details"},
-		{Launcher: "GOG", Action: "run", InstallDir: "/opt/gog"},
-	}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
 
-	cfg.SetLauncherDefaultsForTesting(defaults)
-
-	// Verify defaults were set
-	assert.Len(t, cfg.vals.Launchers.Default, 2)
+[[launchers.default]]
+launcher = "GOG"
+action = "run"
+install_dir = "/opt/gog"
+`))
 
 	// Verify Steam default
 	steamDefault := cfg.LookupLauncherDefaults("Steam", nil)
@@ -433,11 +435,17 @@ func TestLauncherDefaults_SaveLoadRoundTrip(t *testing.T) {
 	cfg, err := NewConfig(tempDir, BaseDefaults)
 	require.NoError(t, err)
 
-	// Set launcher defaults using the testing helper
-	cfg.SetLauncherDefaultsForTesting([]LaunchersDefault{
-		{Launcher: "Steam", Action: "details"},
-		{Launcher: "GOG", Action: "run", InstallDir: "/games/gog"},
-	})
+	// Set launcher defaults using LoadTOML
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
+
+[[launchers.default]]
+launcher = "GOG"
+action = "run"
+install_dir = "/games/gog"
+`))
 
 	// Save and reload
 	err = cfg.Save()

--- a/pkg/config/configservice.go
+++ b/pkg/config/configservice.go
@@ -153,20 +153,6 @@ func (c *Instance) HasAllowRun() bool {
 	return len(c.vals.Service.AllowRun) > 0
 }
 
-// SetRunAllowListForTesting configures the run allow list for tests.
-func (c *Instance) SetRunAllowListForTesting(allowList []string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.Service.AllowRun = allowList
-	c.vals.Service.allowRunRe = make([]*regexp.Regexp, len(allowList))
-	for i, pattern := range allowList {
-		re, err := regexp.Compile(anchorPattern(pattern))
-		if err == nil {
-			c.vals.Service.allowRunRe[i] = re
-		}
-	}
-}
-
 func (c *Instance) GetMQTTPublishers() []MQTTPublisher {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/config/configsystems.go
+++ b/pkg/config/configsystems.go
@@ -55,10 +55,3 @@ func (c *Instance) LookupSystemDefaults(systemID string) (SystemsDefault, bool) 
 	}
 	return SystemsDefault{}, false
 }
-
-// SetSystemDefaultsForTesting sets system defaults for testing purposes
-func (c *Instance) SetSystemDefaultsForTesting(defaults []SystemsDefault) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.Systems.Default = defaults
-}

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -49,9 +49,11 @@ func TestResolveAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure launcher with action=details in config
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", Action: "details"},
-		})
+		require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
+`))
 
 		// Opts specifies action=run, should override config
 		opts := &platforms.LaunchOptions{Action: "run"}
@@ -68,9 +70,11 @@ func TestResolveAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure launcher with action=details in config
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", Action: "details"},
-		})
+		require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
+`))
 
 		// Opts has empty action
 		opts := &platforms.LaunchOptions{Action: ""}
@@ -87,9 +91,11 @@ func TestResolveAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure launcher with action=details in config
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", Action: "details"},
-		})
+		require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
+`))
 
 		action := platforms.ResolveAction(nil, cfg, steamLauncher)
 
@@ -124,9 +130,11 @@ func TestResolveAction(t *testing.T) {
 		cfg, err := helpers.NewTestConfig(fs, t.TempDir())
 		require.NoError(t, err)
 
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", Action: "details"},
-		})
+		require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Steam"
+action = "details"
+`))
 
 		action := platforms.ResolveAction(nil, cfg, emptyLauncher)
 
@@ -141,9 +149,11 @@ func TestResolveAction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure action for "PC" group, not specific launcher ID
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "PC", Action: "browse"},
-		})
+		require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "PC"
+action = "browse"
+`))
 
 		action := platforms.ResolveAction(nil, cfg, steamWithGroups)
 

--- a/pkg/platforms/shared/steam/client_darwin_test.go
+++ b/pkg/platforms/shared/steam/client_darwin_test.go
@@ -23,11 +23,11 @@ package steam
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -97,9 +97,11 @@ func TestClientFindSteamDir(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure custom install dir
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", InstallDir: customPath},
-		})
+		require.NoError(t, cfg.LoadTOML(fmt.Sprintf(`
+[[launchers.default]]
+launcher = "Steam"
+install_dir = %q
+`, customPath)))
 
 		client := NewClient(Options{
 			FallbackPath: "/fallback/steam",

--- a/pkg/platforms/shared/steam/client_linux_test.go
+++ b/pkg/platforms/shared/steam/client_linux_test.go
@@ -23,11 +23,11 @@ package steam
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -208,9 +208,11 @@ func TestClientFindSteamDir(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure custom install dir
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", InstallDir: customPath},
-		})
+		require.NoError(t, cfg.LoadTOML(fmt.Sprintf(`
+[[launchers.default]]
+launcher = "Steam"
+install_dir = %q
+`, customPath)))
 
 		client := NewClient(Options{
 			FallbackPath: "/fallback/steam",

--- a/pkg/platforms/shared/steam/client_windows_test.go
+++ b/pkg/platforms/shared/steam/client_windows_test.go
@@ -23,11 +23,11 @@ package steam
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
@@ -49,9 +49,11 @@ func TestClientFindSteamDir(t *testing.T) {
 		require.NoError(t, err)
 
 		// Configure custom install dir
-		cfg.SetLauncherDefaultsForTesting([]config.LaunchersDefault{
-			{Launcher: "Steam", InstallDir: customPath},
-		})
+		require.NoError(t, cfg.LoadTOML(fmt.Sprintf(`
+[[launchers.default]]
+launcher = "Steam"
+install_dir = %q
+`, customPath)))
 
 		client := NewClient(Options{
 			FallbackPath: "C:\\fallback\\steam",

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -76,8 +76,8 @@ func setupScanBehavior(
 
 	cfg.SetScanMode(scanMode)
 	cfg.SetScanExitDelay(exitDelay)
-	unrestricted := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&unrestricted)
+	require.NoError(t, cfg.LoadTOML(`[zapscript.input]
+mode = "unrestricted"`))
 
 	mockPlayer := mocks.NewMockPlayer()
 	mockPlayer.SetupNoOpMock()

--- a/pkg/zapscript/http_test.go
+++ b/pkg/zapscript/http_test.go
@@ -21,6 +21,7 @@ package zapscript
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -212,7 +213,8 @@ func TestCmdHTTPGet_AllowListEmpty_AllAllowed(t *testing.T) {
 
 func TestCmdHTTPGet_AllowListBlocks(t *testing.T) {
 	cfg := &config.Instance{}
-	cfg.SetHTTPAllowListForTesting([]string{`https://example\.com/.*`})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_http = ['https://example\.com/.*']`))
 
 	env := platforms.CmdEnv{
 		Cfg: cfg,
@@ -239,7 +241,7 @@ func TestCmdHTTPGet_AllowListPermits(t *testing.T) {
 	t.Cleanup(config.ClearAuthCfgForTesting)
 
 	cfg := &config.Instance{}
-	cfg.SetHTTPAllowListForTesting([]string{server.URL + "/.*"})
+	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[zapscript]\nallow_http = ['%s/.*']", server.URL)))
 
 	env := platforms.CmdEnv{
 		Cfg: cfg,
@@ -262,7 +264,8 @@ func TestCmdHTTPGet_AllowListPermits(t *testing.T) {
 
 func TestCmdHTTPPost_AllowListBlocks(t *testing.T) {
 	cfg := &config.Instance{}
-	cfg.SetHTTPAllowListForTesting([]string{`https://example\.com/.*`})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_http = ['https://example\.com/.*']`))
 
 	env := platforms.CmdEnv{
 		Cfg: cfg,
@@ -289,7 +292,7 @@ func TestCmdHTTPPost_AllowListPermits(t *testing.T) {
 	t.Cleanup(config.ClearAuthCfgForTesting)
 
 	cfg := &config.Instance{}
-	cfg.SetHTTPAllowListForTesting([]string{server.URL + "/.*"})
+	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[zapscript]\nallow_http = ['%s/.*']", server.URL)))
 
 	env := platforms.CmdEnv{
 		Cfg: cfg,

--- a/pkg/zapscript/input_test.go
+++ b/pkg/zapscript/input_test.go
@@ -71,9 +71,11 @@ func TestCheckInputKey_CombosMode(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeCombos
-	cfg.SetInputModeForTesting(&mode)
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "combos"
+block = []
+`))
 
 	// Special keys and combos allowed
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{f1}"))
@@ -95,8 +97,10 @@ func TestCheckInputKey_UnrestrictedMode(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&mode)
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "unrestricted"
+`))
 
 	// Everything passes on embedded (no default block list)
 	assert.NoError(t, checkInputKey(cfg, platformids.Mister, "a"))
@@ -109,8 +113,10 @@ func TestCheckInputKey_DefaultBlockList(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&mode)
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "unrestricted"
+`))
 
 	// Default block list applied on desktop
 	err := checkInputKey(cfg, platformids.Linux, "{ctrl+alt+t}")
@@ -134,9 +140,11 @@ func TestCheckInputKey_CustomBlockList(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&mode)
-	cfg.SetInputBlockListForTesting([]string{"{f12}", "{ctrl+q}"})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "unrestricted"
+block = ["{f12}", "{ctrl+q}"]
+`))
 
 	// Custom blocked key
 	err := checkInputKey(cfg, platformids.Linux, "{f12}")
@@ -152,9 +160,11 @@ func TestCheckInputKey_EmptyBlockListClearsDefaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&mode)
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "unrestricted"
+block = []
+`))
 
 	// Default-blocked keys now allowed because block = [] clears defaults
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{ctrl+alt+t}"))
@@ -165,9 +175,11 @@ func TestCheckInputKey_AllowStrictMode(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeCombos
-	cfg.SetInputModeForTesting(&mode)
-	cfg.SetInputAllowListForTesting([]string{"p", "{f1}", "{ctrl+q}"})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "combos"
+allow = ["p", "{f1}", "{ctrl+q}"]
+`))
 
 	// Only allowed keys pass
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "p"))
@@ -189,10 +201,12 @@ func TestCheckInputKey_AllowOverridesBlockList(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	mode := config.InputModeUnrestricted
-	cfg.SetInputModeForTesting(&mode)
 	// Allow includes a default-blocked key
-	cfg.SetInputAllowListForTesting([]string{"{ctrl+alt+delete}", "{f1}"})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "unrestricted"
+allow = ["{ctrl+alt+delete}", "{f1}"]
+`))
 
 	// Allowed even though it's in default block list — allow is strict mode,
 	// block list doesn't apply when allow is set
@@ -234,9 +248,11 @@ func TestCheckInputKey_UnknownModeDefaultsToCombos(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	bogus := "bogus-mode"
-	cfg.SetInputModeForTesting(&bogus)
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+mode = "bogus-mode"
+block = []
+`))
 
 	// Special keys allowed
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{f1}"))
@@ -255,7 +271,10 @@ func TestCmdKeyboard_CombosBlocksSingleChar(t *testing.T) {
 	mockPlatform.On("ID").Return(platformids.Linux)
 
 	cfg := &config.Instance{}
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+block = []
+`))
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -278,7 +297,10 @@ func TestCmdKeyboard_CombosAllowsSpecialKey(t *testing.T) {
 	mockPlatform.On("KeyboardPress", "{f1}").Return(nil)
 
 	cfg := &config.Instance{}
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+block = []
+`))
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -300,7 +322,10 @@ func TestCmdKeyboard_BracedSingleCharRejected(t *testing.T) {
 	mockPlatform.On("ID").Return(platformids.Linux)
 
 	cfg := &config.Instance{}
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+block = []
+`))
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -322,7 +347,10 @@ func TestCmdGamepad_CombosBlocksSingleChar(t *testing.T) {
 	mockPlatform.On("ID").Return(platformids.Linux)
 
 	cfg := &config.Instance{}
-	cfg.SetInputBlockListForTesting([]string{})
+	require.NoError(t, cfg.LoadTOML(`
+[zapscript.input]
+block = []
+`))
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{

--- a/pkg/zapscript/input_test.go
+++ b/pkg/zapscript/input_test.go
@@ -31,6 +31,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newCfgFromTOML(t testing.TB, toml string) *config.Instance {
+	t.Helper()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(toml))
+	return cfg
+}
+
 func TestIsSpecialKey(t *testing.T) {
 	t.Parallel()
 
@@ -70,12 +77,11 @@ func TestDefaultInputMode(t *testing.T) {
 func TestCheckInputKey_CombosMode(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "combos"
 block = []
-`))
+`)
 
 	// Special keys and combos allowed
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{f1}"))
@@ -96,11 +102,10 @@ block = []
 func TestCheckInputKey_UnrestrictedMode(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "unrestricted"
-`))
+`)
 
 	// Everything passes on embedded (no default block list)
 	assert.NoError(t, checkInputKey(cfg, platformids.Mister, "a"))
@@ -112,11 +117,10 @@ mode = "unrestricted"
 func TestCheckInputKey_DefaultBlockList(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "unrestricted"
-`))
+`)
 
 	// Default block list applied on desktop
 	err := checkInputKey(cfg, platformids.Linux, "{ctrl+alt+t}")
@@ -139,12 +143,11 @@ mode = "unrestricted"
 func TestCheckInputKey_CustomBlockList(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "unrestricted"
 block = ["{f12}", "{ctrl+q}"]
-`))
+`)
 
 	// Custom blocked key
 	err := checkInputKey(cfg, platformids.Linux, "{f12}")
@@ -159,12 +162,11 @@ block = ["{f12}", "{ctrl+q}"]
 func TestCheckInputKey_EmptyBlockListClearsDefaults(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "unrestricted"
 block = []
-`))
+`)
 
 	// Default-blocked keys now allowed because block = [] clears defaults
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{ctrl+alt+t}"))
@@ -174,12 +176,11 @@ block = []
 func TestCheckInputKey_AllowStrictMode(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "combos"
 allow = ["p", "{f1}", "{ctrl+q}"]
-`))
+`)
 
 	// Only allowed keys pass
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "p"))
@@ -200,13 +201,12 @@ allow = ["p", "{f1}", "{ctrl+q}"]
 func TestCheckInputKey_AllowOverridesBlockList(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
 	// Allow includes a default-blocked key
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "unrestricted"
 allow = ["{ctrl+alt+delete}", "{f1}"]
-`))
+`)
 
 	// Allowed even though it's in default block list — allow is strict mode,
 	// block list doesn't apply when allow is set
@@ -247,12 +247,11 @@ func TestCheckInputKey_UnrestrictedDefaultOnEmbedded(t *testing.T) {
 func TestCheckInputKey_UnknownModeDefaultsToCombos(t *testing.T) {
 	t.Parallel()
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 mode = "bogus-mode"
 block = []
-`))
+`)
 
 	// Special keys allowed
 	assert.NoError(t, checkInputKey(cfg, platformids.Linux, "{f1}"))
@@ -270,11 +269,10 @@ func TestCmdKeyboard_CombosBlocksSingleChar(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return(platformids.Linux)
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 block = []
-`))
+`)
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -296,11 +294,10 @@ func TestCmdKeyboard_CombosAllowsSpecialKey(t *testing.T) {
 	mockPlatform.On("ID").Return(platformids.Linux)
 	mockPlatform.On("KeyboardPress", "{f1}").Return(nil)
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 block = []
-`))
+`)
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -321,11 +318,10 @@ func TestCmdKeyboard_BracedSingleCharRejected(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return(platformids.Linux)
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 block = []
-`))
+`)
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{
@@ -346,11 +342,10 @@ func TestCmdGamepad_CombosBlocksSingleChar(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return(platformids.Linux)
 
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
+	cfg := newCfgFromTOML(t, `
 [zapscript.input]
 block = []
-`))
+`)
 
 	env := platforms.CmdEnv{
 		Cmd: gozapscript.Command{

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -44,12 +44,11 @@ func TestCmdLaunch_SystemArgAppliesDefaults(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 
 	cfg := &config.Instance{}
-	cfg.SetSystemDefaultsForTesting([]config.SystemsDefault{
-		{
-			System:   "genesis",
-			Launcher: "genesis-retroarch",
-		},
-	})
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-retroarch"
+`))
 
 	genesisLauncher := platforms.Launcher{
 		ID:       "genesis-retroarch",
@@ -95,12 +94,11 @@ func TestCmdLaunch_LauncherArgOverridesSystemArg(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 
 	cfg := &config.Instance{}
-	cfg.SetSystemDefaultsForTesting([]config.SystemsDefault{
-		{
-			System:   "genesis",
-			Launcher: "genesis-default",
-		},
-	})
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-default"
+`))
 
 	explicitLauncher := platforms.Launcher{
 		ID:       "genesis-explicit",
@@ -210,12 +208,11 @@ func TestCmdLaunch_DelegationToTitlePreservesLauncher(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 
 	cfg := &config.Instance{}
-	cfg.SetSystemDefaultsForTesting([]config.SystemsDefault{
-		{
-			System:   "snes",
-			Launcher: "snes-retroarch",
-		},
-	})
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "snes"
+launcher = "snes-retroarch"
+`))
 
 	snesLauncher := platforms.Launcher{
 		ID:       "snes-retroarch",
@@ -274,12 +271,11 @@ func TestCmdLaunch_SystemPathFormatUsesDefaultLauncher(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "game.sfc"), []byte("test"), 0o600))
 
 	cfg := &config.Instance{}
-	cfg.SetSystemDefaultsForTesting([]config.SystemsDefault{
-		{
-			System:   "snes",
-			Launcher: "snes-retroarch",
-		},
-	})
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "snes"
+launcher = "snes-retroarch"
+`))
 
 	snesLauncher := platforms.Launcher{
 		ID:       "snes-retroarch",

--- a/pkg/zapscript/utils_test.go
+++ b/pkg/zapscript/utils_test.go
@@ -38,7 +38,8 @@ func TestCmdExecute_ZaparooEnvironmentSet(t *testing.T) {
 
 	// Create a minimal config that allows execute
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{".*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
 
 	// Create expression env
 	exprEnv := &zapscript.ArgExprEnv{
@@ -90,7 +91,8 @@ func TestCmdExecute_ZaparooEnvironmentContainsExpectedFields(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{".*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
 
 	exprEnv := &zapscript.ArgExprEnv{
 		Platform: "mister",
@@ -133,7 +135,8 @@ func TestCmdExecute_StderrCapture(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{".*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
 
 	// Create a command that writes to stderr and exits with error
 	// Use bash with proper quoting
@@ -167,7 +170,8 @@ func TestCmdExecute_UnsafeBlocked(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{".*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
 
 	cmd := zapscript.Command{
 		Name: "execute",
@@ -215,7 +219,8 @@ func TestCmdExecute_EmptyArgs(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{".*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = [".*"]`))
 
 	cmd := zapscript.Command{
 		Name: "execute",
@@ -265,7 +270,8 @@ func TestCmdExecute_SourceControlAllowedWhenInList(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Instance{}
-	cfg.SetExecuteAllowListForTesting([]string{"echo.*"})
+	require.NoError(t, cfg.LoadTOML(`[zapscript]
+allow_execute = ["echo.*"]`))
 
 	cmd := zapscript.Command{
 		Name: "execute",


### PR DESCRIPTION
## Summary
- Add `LoadTOML(data string) error` method to `config.Instance` that parses a TOML snippet and rebuilds all derived fields (compiled regexes, lookup maps)
- Refactor `Load()` to share unmarshal + post-processing via private `applyTOML()`, preserving atomic swap on reload failure
- Remove 9 `SetXxxForTesting` methods and rewrite ~50 call sites across 15 test files to use declarative TOML snippets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Config reloads now roll back on invalid or incompatible updates, preserving the running settings.

* **New Features**
  * TOML-based config loading merges partial updates and reliably rebuilds derived allow/block patterns so changes take immediate effect.

* **Tests**
  * Test suites updated to exercise TOML-driven configuration scenarios instead of in-memory test-only setters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->