### PR TITLE
build(deps): bump github.com/ZaparooProject/go-pn532 from 0.21.0 to 0.21.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	fyne.io/systray v1.11.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/ZaparooProject/go-pn532 v0.21.0
+	github.com/ZaparooProject/go-pn532 v0.21.1
 	github.com/ZaparooProject/go-zapscript v0.7.0
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0
@@ -44,7 +44,7 @@ require (
 	github.com/pressly/goose/v3 v3.27.0
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb
 	github.com/rs/zerolog v1.34.0
-	github.com/sasha-s/go-deadlock v0.3.6
+	github.com/sasha-s/go-deadlock v0.3.9
 	github.com/schollz/pake/v3 v3.1.1
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spf13/afero v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -16,10 +16,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
-github.com/ZaparooProject/go-pn532 v0.21.0 h1:IVc8BquDfwhWplbmIQAABzClKJWHSxzFl1yZA6qtmIY=
-github.com/ZaparooProject/go-pn532 v0.21.0/go.mod h1:jfI9VH7eWZuIufMYoMqxxHpu6cmMPPEsqV1XKfiZHPg=
-github.com/ZaparooProject/go-zapscript v0.6.0 h1:hoFkFsS9lSfmZ9D5bt6BXatsukzM20UNa+xQHWbRNEs=
-github.com/ZaparooProject/go-zapscript v0.6.0/go.mod h1:P5qov6iCMzYiSF3tqr8BAanvNNh/YjPuUENfmPo6Yj4=
+github.com/ZaparooProject/go-pn532 v0.21.1 h1:tVfOQBfDM4bAo3o+bZdlAxEq6qDQFcs+ILP/XxbWRx8=
+github.com/ZaparooProject/go-pn532 v0.21.1/go.mod h1:D2kfG4cxUMxVCa1gYuuMSmk7y7tWPglSQE3cr/4gJdc=
 github.com/ZaparooProject/go-zapscript v0.7.0 h1:MEpIoiX/ETOKWdYPoCaGDkUUtSCGa3ooKZI+cI8S8SQ=
 github.com/ZaparooProject/go-zapscript v0.7.0/go.mod h1:P5qov6iCMzYiSF3tqr8BAanvNNh/YjPuUENfmPo6Yj4=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
@@ -234,8 +232,8 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
-github.com/sasha-s/go-deadlock v0.3.6 h1:TR7sfOnZ7x00tWPfD397Peodt57KzMDo+9Ae9rMiUmw=
-github.com/sasha-s/go-deadlock v0.3.6/go.mod h1:CUqNyyvMxTyjFqDT7MRg9mb4Dv/btmGTqSR+rky/UXo=
+github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
+github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/schollz/pake/v3 v3.1.1 h1:lyoU5uNQ3thfjEzrahgxWWBm6+pbI1F2KAZ3gs6LIV8=
 github.com/schollz/pake/v3 v3.1.1/go.mod h1:420+m3AakXcS0n7Uwc7eRs2CosQ2YfE/vKcIkilvqZc=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=


### PR DESCRIPTION
## Summary
- Upgrades go-pn532 from v0.21.0 to v0.21.1
- Also bumps transitive dependency go-deadlock from v0.3.6 to v0.3.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies to their latest patch versions to enhance stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->