### PR TITLE
fix(ci): truncate debug log that stalls GitHub Actions runner

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    timeout-minutes: 45
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -157,7 +157,9 @@ mode = "unrestricted"`))
 	// lsq is buffered so goroutines spawned by processTokenQueue and timedExit
 	// can complete their sends after context cancellation.
 	scanQueue := make(chan readers.Scan)
-	itq := make(chan tokens.Token)
+	// Buffer itq so readerManager doesn't block on processTokenQueue,
+	// reducing scheduling sensitivity under deadlock+race.
+	itq := make(chan tokens.Token, 1)
 	lsq := make(chan *tokens.Token, 10)
 	plq := make(chan *playlists.Playlist, 10)
 

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -256,7 +256,7 @@ func getRemoteZapScript(urlStr, platform string) ([]byte, error) {
 		return nil, errors.New("invalid content type")
 	}
 
-	log.Debug().Msgf("zap link body: %s", string(body))
+	log.Debug().Int("size", len(body)).Msg("received zap link body")
 
 	return body, nil
 }


### PR DESCRIPTION
## Summary

- Replace unbounded ZapLink body debug log with a size-only log to fix CI test job taking ~28 minutes

The debug log at `zaplinks.go:259` printed the entire ZapLink response body (up to 1 MiB) as a single line. `TestGetRemoteZapScript_OversizedResponse` triggered this with a 1,048,680-character log line, hitting a known GitHub Actions runner bug ([actions/runner#1031](https://github.com/actions/runner/issues/1031)) where long log lines cause the runner to stall for tens of minutes processing them. All other packages completed in 26 seconds while the runner spent ~28 minutes processing this single log line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced CI job maximum runtime to speed pipeline turnaround.
  * Optimized debug logging to record only the size of received zap link bodies instead of full content.
* **Tests**
  * Updated test harness to use a buffered token queue to stabilize asynchronous test interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->