### PR TITLE
fix(service): add context cancellation to itq channel sends in readerManager

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -193,12 +193,13 @@ jobs:
   cross-lint:
     name: Cross Lint
     if: github.event_name == 'pull_request'
-    runs-on: ubicloud-standard-4
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         target: [windows, darwin]
+        runner: [ubicloud-standard-4]
 
     steps:
       - name: Checkout code

--- a/pkg/service/reader_manager_test.go
+++ b/pkg/service/reader_manager_test.go
@@ -20,7 +20,9 @@
 package service
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -1387,4 +1389,237 @@ func TestReaderManager_LaunchGuard_APIConfirmAfterMediaStops(t *testing.T) {
 	env.confirmQueue <- result
 	err := <-result
 	assert.Error(t, err)
+}
+
+// TestReaderManager_ContextCancellation_ItqSend verifies that readerManager
+// exits cleanly when context is canceled while blocked on an itq send.
+// This is a regression test for a deadlock where bare itq sends had no
+// context cancellation support.
+func TestReaderManager_ContextCancellation_ItqSend(t *testing.T) {
+	t.Parallel()
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	mockPlayer := mocks.NewMockPlayer()
+	mockPlayer.SetupNoOpMock()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	mockPlatform.On("LookupMapping", mock.Anything).Return("", false)
+
+	st, notifCh := state.NewState(mockPlatform, "test-boot-uuid")
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockUserDB.On("GetEnabledMappings").Return([]database.Mapping{}, nil)
+	db := &database.Database{
+		UserDB:  mockUserDB,
+		MediaDB: testhelpers.NewMockMediaDBI(),
+	}
+
+	scanQueue := make(chan readers.Scan)
+	itq := make(chan tokens.Token) // unbuffered, no consumer
+	lsq := make(chan *tokens.Token, 10)
+	plq := make(chan *playlists.Playlist, 10)
+	cfq := make(chan chan error, 10)
+
+	svc := &ServiceContext{
+		Platform:            mockPlatform,
+		Config:              cfg,
+		State:               st,
+		DB:                  db,
+		LaunchSoftwareQueue: lsq,
+		PlaylistQueue:       plq,
+		ConfirmQueue:        cfq,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		readerManager(svc, itq, scanQueue, mockPlayer, nil)
+	}()
+
+	// Send a scan — readerManager will block on itq <- because nothing reads itq.
+	// scanQueue is unbuffered so this returns once readerManager reads it.
+	scanQueue <- readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "card-1",
+			Text:     "/rom/game.rom",
+			ScanTime: time.Now(),
+			Source:   tokens.SourceReader,
+		},
+	}
+
+	// Wait for TokensAdded notification — SetActiveCard fires this immediately
+	// before the itq send, so readerManager is at the blocked send when we
+	// receive it.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case n := <-notifCh:
+			if n.Method == models.NotificationTokensAdded {
+				goto ready
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for TokensAdded notification")
+		}
+	}
+ready:
+
+	// Cancel context — readerManager must exit despite blocked itq send
+	st.StopService()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// readerManager exited cleanly
+	case <-time.After(5 * time.Second):
+		t.Fatal("readerManager did not exit after context cancellation (deadlock)")
+	}
+
+	// Drain notifications
+	for {
+		select {
+		case <-notifCh:
+		default:
+			return
+		}
+	}
+}
+
+// TestReaderManager_ContextCancellation_ConfirmItqSend verifies that when
+// context is canceled while the confirm path is blocked sending to itq, the
+// result channel receives a context error (not ErrNoStagedToken).
+func TestReaderManager_ContextCancellation_ConfirmItqSend(t *testing.T) {
+	t.Parallel()
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+	cfg.SetLaunchGuard(true)
+	cfg.SetLaunchGuardRequireConfirm(true)
+
+	mockPlayer := mocks.NewMockPlayer()
+	mockPlayer.SetupNoOpMock()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	mockPlatform.On("LookupMapping", mock.Anything).Return("", false)
+
+	st, notifCh := state.NewState(mockPlatform, "test-boot-uuid")
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockUserDB.On("GetEnabledMappings").Return([]database.Mapping{}, nil)
+	db := &database.Database{
+		UserDB:  mockUserDB,
+		MediaDB: testhelpers.NewMockMediaDBI(),
+	}
+
+	scanQueue := make(chan readers.Scan)
+	itq := make(chan tokens.Token) // unbuffered, no consumer
+	lsq := make(chan *tokens.Token, 10)
+	plq := make(chan *playlists.Playlist, 10)
+	cfq := make(chan chan error, 10)
+
+	svc := &ServiceContext{
+		Platform:            mockPlatform,
+		Config:              cfg,
+		State:               st,
+		DB:                  db,
+		LaunchSoftwareQueue: lsq,
+		PlaylistQueue:       plq,
+		ConfirmQueue:        cfq,
+	}
+
+	// Set active media so launch guard stages instead of sending directly
+	st.SetActiveMedia(&models.ActiveMedia{
+		LauncherID: "test",
+		SystemID:   "nes",
+		Name:       "Current Game",
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		readerManager(svc, itq, scanQueue, mockPlayer, nil)
+	}()
+
+	// Send a media-launching scan — gets staged, not sent to itq
+	scanQueue <- readers.Scan{
+		Source: "test-reader",
+		Token: &tokens.Token{
+			UID:      "card-1",
+			Text:     "**launch.system:snes",
+			ScanTime: time.Now(),
+			Source:   tokens.SourceReader,
+		},
+	}
+
+	// Wait for the staged notification
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case n := <-notifCh:
+			if n.Method == models.NotificationTokensStaged {
+				goto staged
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for staged notification")
+		}
+	}
+staged:
+
+	// Send a removal to clear the active card. This doesn't clear the staged
+	// token (media is still active). scanQueue is unbuffered so this returns
+	// once readerManager has processed it and is back at its select.
+	scanQueue <- readers.Scan{Source: "test-reader", Token: nil}
+
+	// Send confirm — readerManager reads from cfq, calls SetActiveCard
+	// (fires TokensAdded since we cleared the card above), then blocks on
+	// itq <- confirmed.
+	resultCh := make(chan error, 1)
+	cfq <- resultCh
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case n := <-notifCh:
+			if n.Method == models.NotificationTokensAdded {
+				goto confirmed
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for TokensAdded notification from confirm path")
+		}
+	}
+confirmed:
+
+	// Cancel context — confirm path should return context error, not ErrNoStagedToken
+	st.StopService()
+
+	select {
+	case err := <-resultCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("confirm result never received (deadlock)")
+	}
+
+	wg.Wait()
+
+	// Drain notifications
+	for {
+		select {
+		case <-notifCh:
+		default:
+			return
+		}
+	}
 }

--- a/pkg/service/reader_manager_test.go
+++ b/pkg/service/reader_manager_test.go
@@ -22,7 +22,6 @@ package service
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
@@ -1434,12 +1433,27 @@ func TestReaderManager_ContextCancellation_ItqSend(t *testing.T) {
 		ConfirmQueue:        cfq,
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan struct{})
 	go func() {
-		defer wg.Done()
 		readerManager(svc, itq, scanQueue, mockPlayer, nil)
+		close(done)
 	}()
+
+	t.Cleanup(func() {
+		st.StopService()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("readerManager did not exit during cleanup")
+		}
+		for {
+			select {
+			case <-notifCh:
+			default:
+				return
+			}
+		}
+	})
 
 	// Send a scan — readerManager will block on itq <- because nothing reads itq.
 	// scanQueue is unbuffered so this returns once readerManager reads it.
@@ -1472,26 +1486,10 @@ ready:
 	// Cancel context — readerManager must exit despite blocked itq send
 	st.StopService()
 
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
 	select {
 	case <-done:
-		// readerManager exited cleanly
 	case <-time.After(5 * time.Second):
 		t.Fatal("readerManager did not exit after context cancellation (deadlock)")
-	}
-
-	// Drain notifications
-	for {
-		select {
-		case <-notifCh:
-		default:
-			return
-		}
 	}
 }
 
@@ -1546,12 +1544,27 @@ func TestReaderManager_ContextCancellation_ConfirmItqSend(t *testing.T) {
 		Name:       "Current Game",
 	})
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan struct{})
 	go func() {
-		defer wg.Done()
 		readerManager(svc, itq, scanQueue, mockPlayer, nil)
+		close(done)
 	}()
+
+	t.Cleanup(func() {
+		st.StopService()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("readerManager did not exit during cleanup")
+		}
+		for {
+			select {
+			case <-notifCh:
+			default:
+				return
+			}
+		}
+	})
 
 	// Send a media-launching scan — gets staged, not sent to itq
 	scanQueue <- readers.Scan{
@@ -1612,14 +1625,9 @@ confirmed:
 		t.Fatal("confirm result never received (deadlock)")
 	}
 
-	wg.Wait()
-
-	// Drain notifications
-	for {
-		select {
-		case <-notifCh:
-		default:
-			return
-		}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("readerManager did not exit after context cancellation (deadlock)")
 	}
 }

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -428,7 +428,12 @@ preprocessing:
 			confirmed := *stagedToken
 			stagedToken = nil
 			svc.State.SetActiveCard(confirmed)
-			itq <- confirmed
+			select {
+			case itq <- confirmed:
+			case <-svc.State.GetContext().Done():
+				result <- ErrNoStagedToken
+				break preprocessing
+			}
 			result <- nil
 			continue preprocessing
 		case <-guardDelay:
@@ -495,7 +500,11 @@ preprocessing:
 				// Let the preprocessor know what's on the reader now
 				proc.Process(scan, readerError)
 				svc.State.SetActiveCard(confirmed)
-				itq <- confirmed
+				select {
+				case itq <- confirmed:
+				case <-svc.State.GetContext().Done():
+					break preprocessing
+				}
 				continue preprocessing
 			}
 		}
@@ -608,7 +617,11 @@ preprocessing:
 			}
 
 			log.Info().Msgf("sending token to queue: %v", scan)
-			itq <- *scan
+			select {
+			case itq <- *scan:
+			case <-svc.State.GetContext().Done():
+				break preprocessing
+			}
 
 		case scanReaderErrorRemoval:
 			log.Warn().

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -431,7 +431,7 @@ preprocessing:
 			select {
 			case itq <- confirmed:
 			case <-svc.State.GetContext().Done():
-				result <- ErrNoStagedToken
+				result <- svc.State.GetContext().Err()
 				break preprocessing
 			}
 			result <- nil

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -157,9 +157,7 @@ mode = "unrestricted"`))
 	// lsq is buffered so goroutines spawned by processTokenQueue and timedExit
 	// can complete their sends after context cancellation.
 	scanQueue := make(chan readers.Scan)
-	// Buffer itq so readerManager doesn't block on processTokenQueue,
-	// reducing scheduling sensitivity under deadlock+race.
-	itq := make(chan tokens.Token, 1)
+	itq := make(chan tokens.Token)
 	lsq := make(chan *tokens.Token, 10)
 	plq := make(chan *playlists.Playlist, 10)
 


### PR DESCRIPTION
- The three `itq <-` sends in `readerManager` (lines 431, 498, 611) were bare channel sends with no context cancellation support. If `processTokenQueue` exits via `context.Done()` while `readerManager` is between reading `scanQueue` and reaching an `itq` send, `readerManager` blocks forever.
- Under `-tags=deadlock -race`, the processing overhead widens this window enough for test cleanup (`StopService`) to cancel the context while `readerManager` is mid-processing, causing `wg.Wait()` to hang until go-deadlock's 30s timeout fires.
- Wrap all three `itq` sends in `select` with `context.Done()` so `readerManager` can exit cleanly during shutdown.
- Revert the `itq` buffer from 237b6bd0 which was a bandaid that shrank the race window without eliminating it. The channel is now unbuffered again, matching production (`service.go:219`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior to avoid blocking during token dispatch; pending token sends now respect cancellation and return errors to waiting confirm requests when appropriate.

* **Tests**
  * Added regression tests for context-cancellation paths; updated test harness to use unbuffered token channels to validate reader shutdown and confirm-error behavior.

* **Chores**
  * CI workflow adjusted to select runner via matrix configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->