### PR TITLE
fix(api): use ASCII field names and string coordinates in PAKE wire format

### DIFF
--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -33,11 +33,11 @@ sequenceDiagram
     Note over C: User types PIN into client
     Note over C: A = pake.InitCurve(pin, 0, "p256")
 
-    C->>Z: POST /api/pair/start<br/>{ pake: base64(A.Bytes()), name: "MyApp" }
-    Note over Z: B = pake.InitCurve(pin, 1, "p256")<br/>B.Update(A.Bytes())
-    Z->>C: 200 { session: uuid, pake: base64(B.Bytes()) }
+    C->>Z: POST /api/pair/start<br/>{ pake: base64(wireFormat(A)), name: "MyApp" }
+    Note over Z: B = pake.InitCurve(pin, 1, "p256")<br/>B.Update(wireFormat(A))
+    Z->>C: 200 { session: uuid, pake: base64(wireFormat(B)) }
 
-    Note over C: A.Update(B.Bytes())<br/>sessionKey = A.SessionKey()<br/>prk = HKDF-Extract(sessionKey, nil)<br/>confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)<br/>confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)<br/>pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
+    Note over C: A.Update(wireFormat(B))<br/>sessionKey = A.SessionKey()<br/>prk = HKDF-Extract(sessionKey, nil)<br/>confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)<br/>confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)<br/>pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
 
     C->>Z: POST /api/pair/finish<br/>{ session: uuid, confirm: base64(HMAC) }
     Note over Z: Verify client HMAC, persist client
@@ -62,6 +62,40 @@ LP("zaparoo-v1") || LP("p256") || LP(role) || LP(clientName) || LP(MsgA) || LP(M
 ```
 
 Where `role` is `"client"` or `"server"`, and `MsgA`/`MsgB` are the **raw bytes sent over the wire** (not the result of calling `pake.Bytes()` again after `Update()`).
+
+### PAKE message format
+
+The `pake` field in `/pair/start` request and response carries a base64-encoded JSON object. The PAKE protocol is based on [schollz/pake](https://github.com/schollz/pake) v3 using the P-256 curve. The wire format uses ASCII field names and string-encoded coordinates for cross-language compatibility.
+
+| Field | Type | Description |
+|---|---|---|
+| `role` | number | `0` (initiator/client) or `1` (responder/server) |
+| `ux` | string | U-point x-coordinate, decimal integer |
+| `uy` | string | U-point y-coordinate, decimal integer |
+| `vx` | string | V-point x-coordinate, decimal integer |
+| `vy` | string | V-point y-coordinate, decimal integer |
+| `xx` | string | X-point x-coordinate, decimal integer |
+| `xy` | string | X-point y-coordinate, decimal integer |
+| `yx` | string | Y-point x-coordinate, decimal integer |
+| `yy` | string | Y-point y-coordinate, decimal integer |
+
+All coordinate values are arbitrary-precision integers encoded as **quoted decimal strings** (not bare JSON numbers). This avoids precision loss in JSON parsers that use IEEE 754 doubles. Fields for points not yet computed in the current protocol step are `"0"`.
+
+Example client message (role 0, message A — Y not yet computed):
+
+```json
+{
+  "role": 0,
+  "ux": "793136080485469241208656611513609866400481671852",
+  "uy": "59748757929350367369315811184980635230185250460108398961713395032485227207304",
+  "vx": "1086685267857089638167386722555472967068468061489",
+  "vy": "9157340230202296554417312816309453883742349874205386245733062928888341584123",
+  "xx": "48439561293906451759052585252797914202762949526041747995844080717082404635286",
+  "xy": "36134250956749795798585127919587881956611106672985015071877198253568414405109",
+  "yx": "0",
+  "yy": "0"
+}
+```
 
 ### Pairing limits
 

--- a/pkg/api/crypto/pake.go
+++ b/pkg/api/crypto/pake.go
@@ -137,7 +137,7 @@ func bigIntToStr(n *big.Int) string {
 
 func strToBigInt(s, field string) (*big.Int, error) {
 	if s == "" {
-		return new(big.Int), nil
+		return nil, fmt.Errorf("%w: field %q has empty coordinate", ErrInvalidPakeMessage, field)
 	}
 	n, ok := new(big.Int).SetString(s, 10)
 	if !ok {

--- a/pkg/api/crypto/pake.go
+++ b/pkg/api/crypto/pake.go
@@ -1,0 +1,150 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// ErrInvalidPakeMessage is returned when a PAKE message cannot be decoded.
+var ErrInvalidPakeMessage = errors.New("invalid PAKE message")
+
+// PakeMessage is the wire format for PAKE exchange messages. All elliptic
+// curve coordinates are decimal strings to avoid precision loss in non-Go
+// JSON parsers (IEEE 754 doubles only hold 53 bits).
+type PakeMessage struct {
+	UX   string `json:"ux"`
+	UY   string `json:"uy"`
+	VX   string `json:"vx"`
+	VY   string `json:"vy"`
+	XX   string `json:"xx"`
+	XY   string `json:"xy"`
+	YX   string `json:"yx"`
+	YY   string `json:"yy"`
+	Role int    `json:"role"`
+}
+
+// pakeInternal mirrors the schollz/pake/v3 Pake struct's exported fields.
+// The library has no JSON struct tags, so json.Marshal uses the raw Go field
+// names — which contain Unicode subscript characters (U+1D64, U+1D65).
+//
+//nolint:tagliatelle // tags must match pake library's Unicode field names exactly
+type pakeInternal struct {
+	UU   *big.Int `json:"Uᵤ"`
+	UV   *big.Int `json:"Uᵥ"`
+	VU   *big.Int `json:"Vᵤ"`
+	VV   *big.Int `json:"Vᵥ"`
+	XU   *big.Int `json:"Xᵤ"`
+	XV   *big.Int `json:"Xᵥ"`
+	YU   *big.Int `json:"Yᵤ"`
+	YV   *big.Int `json:"Yᵥ"`
+	Role int      `json:"Role"`
+}
+
+// EncodePakeMessage converts the pake library's internal JSON (from
+// pake.Bytes()) into the clean wire format with ASCII field names and
+// string-quoted coordinates.
+func EncodePakeMessage(internal []byte) ([]byte, error) {
+	var p pakeInternal
+	if err := json.Unmarshal(internal, &p); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPakeMessage, err)
+	}
+	wire := PakeMessage{
+		Role: p.Role,
+		UX:   bigIntToStr(p.UU),
+		UY:   bigIntToStr(p.UV),
+		VX:   bigIntToStr(p.VU),
+		VY:   bigIntToStr(p.VV),
+		XX:   bigIntToStr(p.XU),
+		XY:   bigIntToStr(p.XV),
+		YX:   bigIntToStr(p.YU),
+		YY:   bigIntToStr(p.YV),
+	}
+	b, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("encode pake wire message: %w", err)
+	}
+	return b, nil
+}
+
+// DecodePakeMessage converts the wire-format JSON (ASCII field names,
+// string-quoted coordinates) back into the pake library's internal format
+// so it can be passed to pake.Update().
+func DecodePakeMessage(wire []byte) ([]byte, error) {
+	var msg PakeMessage
+	if err := json.Unmarshal(wire, &msg); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPakeMessage, err)
+	}
+	p := pakeInternal{Role: msg.Role}
+	var err error
+	if p.UU, err = strToBigInt(msg.UX, "ux"); err != nil {
+		return nil, err
+	}
+	if p.UV, err = strToBigInt(msg.UY, "uy"); err != nil {
+		return nil, err
+	}
+	if p.VU, err = strToBigInt(msg.VX, "vx"); err != nil {
+		return nil, err
+	}
+	if p.VV, err = strToBigInt(msg.VY, "vy"); err != nil {
+		return nil, err
+	}
+	if p.XU, err = strToBigInt(msg.XX, "xx"); err != nil {
+		return nil, err
+	}
+	if p.XV, err = strToBigInt(msg.XY, "xy"); err != nil {
+		return nil, err
+	}
+	if p.YU, err = strToBigInt(msg.YX, "yx"); err != nil {
+		return nil, err
+	}
+	if p.YV, err = strToBigInt(msg.YY, "yy"); err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("encode pake internal message: %w", err)
+	}
+	return b, nil
+}
+
+func bigIntToStr(n *big.Int) string {
+	if n == nil {
+		return "0"
+	}
+	return n.Text(10)
+}
+
+func strToBigInt(s, field string) (*big.Int, error) {
+	if s == "" {
+		return new(big.Int), nil
+	}
+	n, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, fmt.Errorf("%w: field %q is not a valid integer", ErrInvalidPakeMessage, field)
+	}
+	if n.Sign() < 0 {
+		return nil, fmt.Errorf("%w: field %q must not be negative", ErrInvalidPakeMessage, field)
+	}
+	return n, nil
+}

--- a/pkg/api/crypto/pake_test.go
+++ b/pkg/api/crypto/pake_test.go
@@ -215,6 +215,13 @@ func TestDecodePakeMessage_NegativeCoordinate(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
 }
 
+func TestDecodePakeMessage_EmptyCoordinate(t *testing.T) {
+	t.Parallel()
+	empty := `{"role":0,"ux":"","uy":"0","vx":"0","vy":"0","xx":"0","xy":"0","yx":"0","yy":"0"}`
+	_, err := DecodePakeMessage([]byte(empty))
+	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
+}
+
 func TestEncodePakeMessage_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	_, err := EncodePakeMessage([]byte("not json"))

--- a/pkg/api/crypto/pake_test.go
+++ b/pkg/api/crypto/pake_test.go
@@ -1,0 +1,222 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package crypto
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"unicode"
+
+	"github.com/schollz/pake/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodePakeMessage_ASCIIFieldNames(t *testing.T) {
+	t.Parallel()
+	client, err := pake.InitCurve([]byte("123456"), 0, "p256")
+	require.NoError(t, err)
+
+	wire, err := EncodePakeMessage(client.Bytes())
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(wire, &raw))
+
+	expectedKeys := []string{"role", "ux", "uy", "vx", "vy", "xx", "xy", "yx", "yy"}
+	for _, key := range expectedKeys {
+		_, ok := raw[key]
+		assert.True(t, ok, "expected key %q in wire format", key)
+	}
+
+	for key := range raw {
+		for _, r := range key {
+			assert.Less(t, r, unicode.MaxASCII, "key %q contains non-ASCII character", key)
+		}
+	}
+}
+
+func TestEncodePakeMessage_CoordinatesAreStrings(t *testing.T) {
+	t.Parallel()
+	client, err := pake.InitCurve([]byte("123456"), 0, "p256")
+	require.NoError(t, err)
+
+	wire, err := EncodePakeMessage(client.Bytes())
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(wire, &raw))
+
+	coordFields := []string{"ux", "uy", "vx", "vy", "xx", "xy", "yx", "yy"}
+	for _, field := range coordFields {
+		val := raw[field]
+		assert.NotEmpty(t, val, "field %q should be present", field)
+		assert.Equal(t, byte('"'), val[0],
+			"field %q should be a quoted string, got: %s", field, string(val))
+	}
+
+	// role should be a number, not a string
+	roleVal := raw["role"]
+	assert.NotEqual(t, byte('"'), roleVal[0], "role should be a number")
+}
+
+func TestRoundTrip_EncodeDecodePreservesData(t *testing.T) {
+	t.Parallel()
+	client, err := pake.InitCurve([]byte("654321"), 0, "p256")
+	require.NoError(t, err)
+
+	internal := client.Bytes()
+
+	wire, err := EncodePakeMessage(internal)
+	require.NoError(t, err)
+
+	roundTripped, err := DecodePakeMessage(wire)
+	require.NoError(t, err)
+
+	// Unmarshal both into generic maps to compare values
+	var orig map[string]any
+	var rt map[string]any
+	require.NoError(t, json.Unmarshal(internal, &orig))
+	require.NoError(t, json.Unmarshal(roundTripped, &rt))
+
+	assert.InDelta(t, orig["Role"], rt["Role"], 0,
+		"Role must survive round-trip")
+
+	// The Unicode-keyed fields in orig should match their round-tripped values.
+	// orig has bare numbers, rt has bare numbers (both are pake internal format).
+	pairs := [][2]string{
+		{"Uᵤ", "Uᵤ"},
+		{"Uᵥ", "Uᵥ"},
+		{"Vᵤ", "Vᵤ"},
+		{"Vᵥ", "Vᵥ"},
+		{"Xᵤ", "Xᵤ"},
+		{"Xᵥ", "Xᵥ"},
+		{"Yᵤ", "Yᵤ"},
+		{"Yᵥ", "Yᵥ"},
+	}
+	for _, p := range pairs {
+		// json.Unmarshal into any produces float64 for numbers, which loses
+		// precision. Use json.Number via decoder instead.
+		origN := jsonNumberFromBytes(t, internal, p[0])
+		rtN := jsonNumberFromBytes(t, roundTripped, p[1])
+		assert.Equal(t, origN, rtN, "field %q must survive round-trip", p[0])
+	}
+}
+
+// jsonNumberFromBytes extracts a json.Number for the given key using
+// json.Decoder with UseNumber to preserve arbitrary-precision integers.
+func jsonNumberFromBytes(t *testing.T, data []byte, key string) string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var m map[string]any
+	require.NoError(t, dec.Decode(&m))
+	v, ok := m[key]
+	if !ok || v == nil {
+		return "0"
+	}
+	n, ok := v.(json.Number)
+	require.True(t, ok, "expected json.Number for key %q, got %T", key, v)
+	return n.String()
+}
+
+func TestFullHandshake_ThroughWireFormat(t *testing.T) {
+	t.Parallel()
+	pin := []byte("999999")
+
+	// Client (role 0) generates message A
+	client, err := pake.InitCurve(pin, 0, "p256")
+	require.NoError(t, err)
+
+	msgAWire, err := EncodePakeMessage(client.Bytes())
+	require.NoError(t, err)
+
+	// Server (role 1) processes message A
+	server, err := pake.InitCurve(pin, 1, "p256")
+	require.NoError(t, err)
+
+	msgAInternal, err := DecodePakeMessage(msgAWire)
+	require.NoError(t, err)
+	require.NoError(t, server.Update(msgAInternal))
+
+	msgBWire, err := EncodePakeMessage(server.Bytes())
+	require.NoError(t, err)
+
+	// Client processes message B
+	msgBInternal, err := DecodePakeMessage(msgBWire)
+	require.NoError(t, err)
+	require.NoError(t, client.Update(msgBInternal))
+
+	// Both sides derive the same session key
+	clientKey, err := client.SessionKey()
+	require.NoError(t, err)
+	serverKey, err := server.SessionKey()
+	require.NoError(t, err)
+	assert.Equal(t, clientKey, serverKey, "session keys must match through wire format")
+}
+
+func TestEncodePakeMessage_NilFieldsEncodeAsZero(t *testing.T) {
+	t.Parallel()
+	// Role 1 before Update() has nil X and Y fields
+	server, err := pake.InitCurve([]byte("000000"), 1, "p256")
+	require.NoError(t, err)
+
+	wire, err := EncodePakeMessage(server.Bytes())
+	require.NoError(t, err)
+
+	var msg PakeMessage
+	require.NoError(t, json.Unmarshal(wire, &msg))
+
+	// X and Y should be "0" since role-1 hasn't computed them yet
+	assert.Equal(t, "0", msg.XX)
+	assert.Equal(t, "0", msg.XY)
+	assert.Equal(t, "0", msg.YX)
+	assert.Equal(t, "0", msg.YY)
+	// U and V should be non-zero (curve base points)
+	assert.NotEqual(t, "0", msg.UX)
+	assert.NotEqual(t, "0", msg.UY)
+}
+
+func TestDecodePakeMessage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := DecodePakeMessage([]byte("not json"))
+	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
+}
+
+func TestDecodePakeMessage_InvalidCoordinate(t *testing.T) {
+	t.Parallel()
+	bad := `{"role":0,"ux":"not_a_number","uy":"0","vx":"0","vy":"0","xx":"0","xy":"0","yx":"0","yy":"0"}`
+	_, err := DecodePakeMessage([]byte(bad))
+	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
+}
+
+func TestDecodePakeMessage_NegativeCoordinate(t *testing.T) {
+	t.Parallel()
+	neg := `{"role":0,"ux":"-42","uy":"0","vx":"0","vy":"0","xx":"0","xy":"0","yx":"0","yy":"0"}`
+	_, err := DecodePakeMessage([]byte(neg))
+	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
+}
+
+func TestEncodePakeMessage_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := EncodePakeMessage([]byte("not json"))
+	assert.ErrorIs(t, err, ErrInvalidPakeMessage)
+}

--- a/pkg/api/integration_encryption_test.go
+++ b/pkg/api/integration_encryption_test.go
@@ -109,7 +109,8 @@ func pairAndDeriveKey(
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pakeCurve)
 	require.NoError(t, err)
-	msgA := clientPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
 
 	// Drive the start session via the HTTP handler so we exercise the
 	// real request/response shapes.
@@ -130,7 +131,9 @@ func pairAndDeriveKey(
 
 	msgB, err := base64.StdEncoding.DecodeString(startResult.PAKE)
 	require.NoError(t, err)
-	require.NoError(t, clientPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgBInternal))
 	clientSessionKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 

--- a/pkg/api/pairing.go
+++ b/pkg/api/pairing.go
@@ -621,6 +621,8 @@ func pairingErrorStatus(err error) (status int, msg string) {
 		return http.StatusBadRequest, "client name required"
 	case errors.Is(err, errPairingMessageTooLong):
 		return http.StatusBadRequest, "PAKE message too long"
+	case errors.Is(err, crypto.ErrInvalidPakeMessage):
+		return http.StatusBadRequest, "invalid PAKE message"
 	case errors.Is(err, errTooManyClients):
 		return http.StatusForbidden, "maximum paired clients reached"
 	case errors.Is(err, errPairingHMACMismatch):

--- a/pkg/api/pairing.go
+++ b/pkg/api/pairing.go
@@ -315,12 +315,18 @@ func (m *PairingManager) startSession(name string, msgA []byte) (sessionID strin
 		return "", nil, errPairingExhausted
 	}
 
+	// Decode the wire-format PAKE message into the library's internal format.
+	msgAInternal, err := crypto.DecodePakeMessage(msgA)
+	if err != nil {
+		return "", nil, fmt.Errorf("decode client pake message: %w", err)
+	}
+
 	// Server initializes as responder (role 1).
 	server, err := pake.InitCurve([]byte(m.pin), 1, pairingCurve)
 	if err != nil {
 		return "", nil, fmt.Errorf("pake init: %w", err)
 	}
-	if updateErr := server.Update(msgA); updateErr != nil {
+	if updateErr := server.Update(msgAInternal); updateErr != nil {
 		return "", nil, fmt.Errorf("pake update with client message: %w", updateErr)
 	}
 
@@ -329,8 +335,11 @@ func (m *PairingManager) startSession(name string, msgA []byte) (sessionID strin
 		return "", nil, fmt.Errorf("derive pake session key: %w", err)
 	}
 
-	// Capture serialized state before mutation.
-	msgB = server.Bytes()
+	// Encode the server's PAKE response into the clean wire format.
+	msgB, err = crypto.EncodePakeMessage(server.Bytes())
+	if err != nil {
+		return "", nil, fmt.Errorf("encode server pake message: %w", err)
+	}
 
 	sessionID = uuid.New().String()
 	m.sessions[sessionID] = &pairingSession{

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -797,6 +797,26 @@ func TestHTTPHandler_BadBase64(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestHTTPHandler_MalformedPakeMessage(t *testing.T) {
+	t.Parallel()
+	h := newPairingHarness(t)
+
+	_, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// Valid base64 but invalid PAKE wire format JSON inside.
+	malformed := base64.StdEncoding.EncodeToString([]byte(`{"role":0,"ux":"not_a_number"}`))
+	body, err := json.Marshal(pairStartRequest{PAKE: malformed, Name: "App"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/pair/start",
+		strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	h.mgr.HandlePairStart().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestGeneratePIN_AllDigits(t *testing.T) {
 	t.Parallel()
 	for range 100 {

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -91,12 +91,15 @@ func (h *pairingTestHarness) runHandshake(
 	t.Helper()
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := clientPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
 
 	sessionID, msgB, err := h.mgr.startSession(name, msgA)
 	require.NoError(t, err)
 
-	require.NoError(t, clientPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgBInternal))
 	clientSessionKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 
@@ -255,11 +258,14 @@ func TestWrongPIN_Rejected(t *testing.T) {
 	// Use a wrong PIN — different session key, HMAC will not match.
 	wrongPake, err := pake.InitCurve([]byte("999999"), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := wrongPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(wrongPake.Bytes())
+	require.NoError(t, err)
 	sessionID, msgB, err := h.mgr.startSession("App", msgA)
 	require.NoError(t, err)
 
-	require.NoError(t, wrongPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, wrongPake.Update(msgBInternal))
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
 
@@ -284,7 +290,8 @@ func TestMaxAttempts_PINInvalidatedAfterExhaustion(t *testing.T) {
 	for i := range 2 {
 		wrongPake, pkErr := pake.InitCurve([]byte("999999"), 0, pairingCurve)
 		require.NoError(t, pkErr)
-		msgA := wrongPake.Bytes()
+		msgA, encErr := crypto.EncodePakeMessage(wrongPake.Bytes())
+		require.NoError(t, encErr)
 		sessionID, _, sErr := h.mgr.startSession("App", msgA)
 		require.NoError(t, sErr)
 		_, finishErr := h.mgr.finishSession(sessionID, []byte("garbage hmac"))
@@ -359,7 +366,9 @@ func TestPairFinish_SessionExpired(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	sessionID, _, err := h.mgr.startSession("App", clientPake.Bytes())
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
+	sessionID, _, err := h.mgr.startSession("App", msgA)
 	require.NoError(t, err)
 
 	time.Sleep(15 * time.Millisecond)
@@ -389,12 +398,15 @@ func TestPairFinish_ConcurrentCallsOneWins(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := clientPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
 
 	sessionID, msgB, err := h.mgr.startSession("ConcurrentApp", msgA)
 	require.NoError(t, err)
 
-	require.NoError(t, clientPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgBInternal))
 	sessionKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 
@@ -473,11 +485,14 @@ func TestMaxClients_FinishSessionDefenseInDepth(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := clientPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
 	sessionID, msgB, err := mgr.startSession("App", msgA)
 	require.NoError(t, err)
 
-	require.NoError(t, clientPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgBInternal))
 	clientKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
@@ -499,7 +514,9 @@ func TestStartPairing_WipesOldSessions(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin1), 0, pairingCurve)
 	require.NoError(t, err)
-	sessionID, _, err := h.mgr.startSession("App", clientPake.Bytes())
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
+	sessionID, _, err := h.mgr.startSession("App", msgA)
 	require.NoError(t, err)
 
 	h.mgr.CancelPairing()
@@ -523,7 +540,8 @@ func TestHTTPHandlers_FullFlow(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := clientPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
 
 	startBody, err := json.Marshal(pairStartRequest{
 		PAKE: base64.StdEncoding.EncodeToString(msgA),
@@ -545,7 +563,9 @@ func TestHTTPHandlers_FullFlow(t *testing.T) {
 	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
 	require.NoError(t, err)
 
-	require.NoError(t, clientPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, clientPake.Update(msgBInternal))
 	clientKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
@@ -626,7 +646,8 @@ func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
 		wrongPake, err = pake.InitCurve([]byte("111111"), 0, pairingCurve)
 		require.NoError(t, err)
 	}
-	msgA := wrongPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(wrongPake.Bytes())
+	require.NoError(t, err)
 
 	startBody, err := json.Marshal(pairStartRequest{
 		PAKE: base64.StdEncoding.EncodeToString(msgA),
@@ -645,7 +666,9 @@ func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
 	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
 	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
 	require.NoError(t, err)
-	require.NoError(t, wrongPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, wrongPake.Update(msgBInternal))
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
 	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
@@ -696,7 +719,8 @@ func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
 	}
 	wrongPake, err := pake.InitCurve([]byte(wrongPIN), 0, pairingCurve)
 	require.NoError(t, err)
-	msgA := wrongPake.Bytes()
+	msgA, err := crypto.EncodePakeMessage(wrongPake.Bytes())
+	require.NoError(t, err)
 	startBody, err := json.Marshal(pairStartRequest{
 		PAKE: base64.StdEncoding.EncodeToString(msgA),
 		Name: "App",
@@ -714,7 +738,9 @@ func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
 	require.NoError(t, json.Unmarshal(startRec.Body.Bytes(), &startResp))
 	msgB, err := base64.StdEncoding.DecodeString(startResp.PAKE)
 	require.NoError(t, err)
-	require.NoError(t, wrongPake.Update(msgB))
+	msgBInternal, err := crypto.DecodePakeMessage(msgB)
+	require.NoError(t, err)
+	require.NoError(t, wrongPake.Update(msgBInternal))
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
 	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
@@ -850,7 +876,9 @@ func TestCleanupExpired_RemovesOldSessions(t *testing.T) {
 
 	clientPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
 	require.NoError(t, err)
-	_, _, err = h.mgr.startSession("App", clientPake.Bytes())
+	msgA, err := crypto.EncodePakeMessage(clientPake.Bytes())
+	require.NoError(t, err)
+	_, _, err = h.mgr.startSession("App", msgA)
 	require.NoError(t, err)
 
 	time.Sleep(15 * time.Millisecond)


### PR DESCRIPTION
- Add a translation layer (`pkg/api/crypto/pake.go`) between the schollz/pake library's internal JSON format and the wire format, replacing Unicode subscript field names (`Uᵤ`, `Uᵥ`, etc.) with lowercase ASCII names (`ux`, `uy`, etc.) and encoding big.Int coordinates as quoted decimal strings instead of bare JSON numbers
- Apply encode/decode in `startSession` so clients send and receive the clean wire format while the pake library continues using its own format internally
- Reject negative coordinate values at the decode boundary as defense-in-depth
- Document the PAKE message format in `docs/api/encryption.md` with a field table and example message
- Update all pairing tests and integration tests to round-trip through the wire format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated encryption API docs with a detailed PAKE message format, examples, and clarified pairing flow bytes/encoding.

* **Refactor**
  * Standardized PAKE wire-format encoding/decoding across the pairing flow for consistent interoperability.

* **Tests**
  * Added comprehensive tests covering wire-format conversions, full client/server handshakes, nil-coordinate handling, and round-trip preservation.

* **Bug Fixes**
  * Pairing endpoint now returns 400 Bad Request for malformed PAKE messages; tests added to assert this.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->