### PR TITLE
fix(mister): add LLAPISuperGrafx launcher for .sgx files on LLAPI cores

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -1112,6 +1112,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemSuperGrafx),
 		},
 		{
+			ID:       "LLAPISuperGrafx",
+			SystemID: systemdefs.SystemSuperGrafx,
+			Launch:   launchAltCore("LLAPISuperGrafx", systemdefs.SystemSuperGrafx, "_LLAPI/TurboGrafx16_LLAPI"),
+		},
+		{
 			ID:         systemdefs.SystemTurboGrafx16,
 			SystemID:   systemdefs.SystemTurboGrafx16,
 			Folders:    []string{"TGFX16"},

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -434,6 +434,26 @@ func TestBuildScummVMCommand_DifferentTargets(t *testing.T) {
 	}
 }
 
+// Regression test: LLAPISuperGrafx launcher must exist for .sgx files on LLAPI cores (#635)
+func TestLLAPISuperGrafxLauncherExists(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	var found *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == "LLAPISuperGrafx" {
+			found = &launchers[i]
+			break
+		}
+	}
+
+	require.NotNil(t, found, "LLAPISuperGrafx launcher should exist")
+	assert.Equal(t, "SuperGrafx", found.SystemID,
+		"LLAPISuperGrafx must use SystemSuperGrafx so .sgx slots are found")
+}
+
 // Regression test: N64 launcher should support .v64 extension (byte-swapped ROM format)
 func TestN64LauncherExtensions(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Add `LLAPISuperGrafx` launcher so `.sgx` (SuperGrafx) games can be launched with LLAPI cores on MiSTer
- `LLAPITurboGrafx16` uses `cores.GetCore("TurboGrafx16")` which only has `.bin`/`.pce` slots (Index 0), so `.sgx` files fail with "system has no matching mgl args"
- New launcher uses `SystemSuperGrafx` (which has the `.sgx` slot with Index 1) with the same `_LLAPI/TurboGrafx16_LLAPI` RBF path, matching the existing Atari2600/Atari7800 LLAPI pattern

Closes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled LLAPI launcher support for SuperGrafx games on the MiSTer platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->