### PR TITLE
fix(mister): increase Saturn MGL delay and fix cross-compilation

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -815,7 +815,7 @@ var Systems = map[string]Core{
 				Label: "Disk",
 				Exts:  []string{".cue", ".chd"},
 				Mgl: &MGLParams{
-					Delay:  1,
+					Delay:  2,
 					Method: "s",
 					Index:  0,
 				},

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -175,7 +175,12 @@ func launchTempMgl(cfg *config.Instance, system *cores.Core, path string) error 
 	if err != nil {
 		return fmt.Errorf("failed to generate MGL: %w", err)
 	}
-	log.Debug().Str("system", system.ID).Str("rbf", system.RBF).Msg("MGL generated successfully")
+	resolvedRBF := cores.ResolveRBFPathForLauncher(system.LauncherID, system.ID, system.RBF)
+	log.Debug().
+		Str("system", system.ID).
+		Str("rbf", resolvedRBF).
+		Msg("MGL generated successfully")
+	log.Debug().Str("mgl_content", mgl).Msg("generated MGL content")
 
 	tmpFile, err := writeTempFile(mgl)
 	if err != nil {

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -70,6 +70,18 @@ func ReadMRA(path string) (MRA, error) {
 	return mra, nil
 }
 
+// xmlEscapeAttr escapes XML-reserved characters for use in attribute values.
+// MiSTer's MGL parser (SXMLC) decodes these entities when reading paths.
+func xmlEscapeAttr(v string) string {
+	r := s.NewReplacer(
+		"&", "&amp;",
+		"<", "&lt;",
+		">", "&gt;",
+		`"`, "&quot;",
+	)
+	return r.Replace(v)
+}
+
 func GenerateMgl(core *cores.Core, path, override string) (string, error) {
 	if core == nil {
 		return "", errors.New("no core supplied for MGL generation")
@@ -103,7 +115,7 @@ func GenerateMgl(core *cores.Core, path, override string) (string, error) {
 
 	mgl += fmt.Sprintf(
 		"\t<file delay=\"%d\" type=%q index=\"%d\" path=\"../../../../..%s\"/>\n",
-		mglDef.Delay, mglDef.Method, mglDef.Index, path,
+		mglDef.Delay, mglDef.Method, mglDef.Index, xmlEscapeAttr(path),
 	)
 
 	if mglDef.ResetDelay > 0 {

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -247,6 +247,30 @@ func TestGenerateMgl(t *testing.T) {
 </mistergamedescription>`,
 		},
 		{
+			name: "Saturn CHD with special characters in filename",
+			core: &cores.Core{
+				ID:  "Saturn",
+				RBF: "_Console/Saturn",
+				Slots: []cores.Slot{
+					{
+						Label: "Disk",
+						Exts:  []string{".cue", ".chd"},
+						Mgl: &cores.MGLParams{
+							Delay:  2,
+							Method: "s",
+							Index:  0,
+						},
+					},
+				},
+			},
+			path: "/media/fat/games/Saturn/America/NiGHTS into Dreams... (USA, Brazil).chd",
+			want: "<mistergamedescription>\n\t<rbf>_Console/Saturn</rbf>\n" +
+				"\t<file delay=\"2\" type=\"s\" index=\"0\" " +
+				"path=\"../../../../../media/fat/games/Saturn/America/" +
+				"NiGHTS into Dreams... (USA, Brazil).chd\"/>\n" +
+				"</mistergamedescription>",
+		},
+		{
 			name: "override takes precedence over path",
 			core: &cores.Core{
 				ID:  "NES",

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -271,6 +271,30 @@ func TestGenerateMgl(t *testing.T) {
 				"</mistergamedescription>",
 		},
 		{
+			name: "path with XML-reserved characters is escaped",
+			core: &cores.Core{
+				ID:  "Genesis",
+				RBF: "_Console/MegaDrive",
+				Slots: []cores.Slot{
+					{
+						Exts: []string{".bin", ".gen", ".md"},
+						Mgl: &cores.MGLParams{
+							Delay:  1,
+							Method: "f",
+							Index:  1,
+						},
+					},
+				},
+			},
+			path: `/media/fat/games/MegaDrive/Sonic & Knuckles "Lock-On".bin`,
+			want: "<mistergamedescription>\n" +
+				"\t<rbf>_Console/MegaDrive</rbf>\n" +
+				"\t<file delay=\"1\" type=\"f\" index=\"1\" " +
+				"path=\"../../../../../media/fat/games/MegaDrive/" +
+				"Sonic &amp; Knuckles &quot;Lock-On&quot;.bin\"/>\n" +
+				"</mistergamedescription>",
+		},
+		{
 			name: "override takes precedence over path",
 			core: &cores.Core{
 				ID:  "NES",

--- a/scripts/tasks/mister.yml
+++ b/scripts/tasks/mister.yml
@@ -65,7 +65,7 @@ tasks:
             name=$(basename $pkg) &&
             echo "Building $pkg -> ${name}.test" &&
             go test -c
-            -tags "netgo,osusergo,sqlite_omit_load_extension"
+            -tags "netgo,osusergo,sqlite_omit_load_extension,nopkgconfig"
             -ldflags "-linkmode external -s -w"
             -o "_build/bench_arm/${name}.test" "$pkg"
             ; done &&

--- a/scripts/tasks/zigcc.yml
+++ b/scripts/tasks/zigcc.yml
@@ -24,7 +24,7 @@ tasks:
           CXX: "zig c++ -target x86_64-linux-gnu"
           NO_STATIC: true
           EXTRA_LDFLAGS: "-linkmode external"
-          EXTRA_TAGS: "{{.EXTRA_TAGS}}"
+          EXTRA_TAGS: "nopkgconfig{{if .EXTRA_TAGS}},{{.EXTRA_TAGS}}{{end}}"
           EXTRA_DOCKER_ARGS: >-
             -e CGO_CFLAGS="-I/opt/libnfc/x86_64-linux-gnu/include"
             -e CGO_LDFLAGS="-L/opt/libnfc/x86_64-linux-gnu/lib -L/opt/deps/x86_64-linux-gnu/lib /opt/libnfc/x86_64-linux-gnu/lib/libnfc.a /opt/deps/x86_64-linux-gnu/lib/libusb.a /opt/deps/x86_64-linux-gnu/lib/libusb-1.0.a -ldl"
@@ -44,7 +44,7 @@ tasks:
           CXX: "zig c++ -target aarch64-linux-gnu"
           NO_STATIC: true
           EXTRA_LDFLAGS: "-linkmode external"
-          EXTRA_TAGS: "{{.EXTRA_TAGS}}"
+          EXTRA_TAGS: "nopkgconfig{{if .EXTRA_TAGS}},{{.EXTRA_TAGS}}{{end}}"
           EXTRA_DOCKER_ARGS: >-
             -e CGO_CFLAGS="-I/opt/libnfc/aarch64-linux-gnu/include"
             -e CGO_LDFLAGS="-L/opt/libnfc/aarch64-linux-gnu/lib -L/opt/deps/aarch64-linux-gnu/lib /opt/libnfc/aarch64-linux-gnu/lib/libnfc.a /opt/deps/aarch64-linux-gnu/lib/libusb.a /opt/deps/aarch64-linux-gnu/lib/libusb-1.0.a -ldl"
@@ -64,7 +64,7 @@ tasks:
           CXX: "zig c++ -target arm-linux-gnueabihf"
           NO_STATIC: true
           EXTRA_LDFLAGS: "-linkmode external"
-          EXTRA_TAGS: "{{.EXTRA_TAGS}}"
+          EXTRA_TAGS: "nopkgconfig{{if .EXTRA_TAGS}},{{.EXTRA_TAGS}}{{end}}"
           EXTRA_DOCKER_ARGS: >-
             -e CGO_CFLAGS="-I/opt/libnfc/arm-linux-gnueabihf/include"
             -e CGO_LDFLAGS="-L/opt/libnfc/arm-linux-gnueabihf/lib -L/opt/deps/arm-linux-gnueabihf/lib /opt/libnfc/arm-linux-gnueabihf/lib/libnfc.a /opt/deps/arm-linux-gnueabihf/lib/libusb.a /opt/deps/arm-linux-gnueabihf/lib/libusb-1.0.a -ldl"


### PR DESCRIPTION
## Summary

- Increase Saturn MGL delay from 1 to 2 seconds to give the core time to initialize its CD subsystem and backup RAM before disc mount on cold start via MGL
- Fix debug log that showed the hardcoded RBF path (`_Console/Saturn`) instead of the resolved path from cache (`_Unstable/Saturn`), and add MGL content logging
- Fix Linux cross-compilation broken by `clausecker/nfc/v2` v2.2.0 switching to `pkg-config` — add `nopkgconfig` build tag to zigcc builds that provide explicit CGO paths

Closes #637
Closes #641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adjusted Saturn disk loading delay to improve system compatibility.

* **Tests**
  * Added tests to validate handling of special characters and proper escaping in generated metadata.

* **Chores**
  * Improved debug logging to show resolved paths and generated content.
  * Updated build tasks to include an additional build tag for Linux/benchmark flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->