### PR TITLE
fix(windows): hold mode with RetroBat and relative config paths

### DIFF
--- a/pkg/config/configlaunchers.go
+++ b/pkg/config/configlaunchers.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -68,7 +69,7 @@ type LaunchersCustom struct {
 func (c *Instance) DefaultMediaDir() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.vals.Launchers.MediaDir
+	return pathutil.ResolveRelativePath(c.vals.Launchers.MediaDir)
 }
 
 func (c *Instance) LaunchersBeforeMediaStart() string {
@@ -243,8 +244,12 @@ func (c *Instance) IndexRoots() []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	var roots []string
 	if c.vals.Launchers.MediaDir != "" {
-		return append([]string{c.vals.Launchers.MediaDir}, c.vals.Launchers.IndexRoot...)
+		roots = append(roots, pathutil.ResolveRelativePath(c.vals.Launchers.MediaDir))
 	}
-	return c.vals.Launchers.IndexRoot
+	for _, r := range c.vals.Launchers.IndexRoot {
+		roots = append(roots, pathutil.ResolveRelativePath(r))
+	}
+	return roots
 }

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -674,6 +674,31 @@ execute = "echo good"
 	assert.Equal(t, "GoodLauncher", customs[0].ID)
 }
 
+func TestIndexRoots_ResolvesRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skip("os.Executable() unavailable")
+	}
+	exeDir := filepath.Dir(exe)
+
+	cfg := &Instance{
+		vals: Values{
+			Launchers: Launchers{
+				MediaDir:  "roms",
+				IndexRoot: []string{"/absolute/path", "relative/dir"},
+			},
+		},
+	}
+
+	roots := cfg.IndexRoots()
+	require.Len(t, roots, 3)
+	assert.Equal(t, filepath.Join(exeDir, "roms"), roots[0])
+	assert.Equal(t, "/absolute/path", roots[1])
+	assert.Equal(t, filepath.Join(exeDir, "relative", "dir"), roots[2])
+}
+
 func TestLoadCustomLaunchers_NestedDirectories(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -683,11 +683,13 @@ func TestIndexRoots_ResolvesRelativePaths(t *testing.T) {
 	}
 	exeDir := filepath.Dir(exe)
 
+	absDir := t.TempDir()
+
 	cfg := &Instance{
 		vals: Values{
 			Launchers: Launchers{
 				MediaDir:  "roms",
-				IndexRoot: []string{"/absolute/path", "relative/dir"},
+				IndexRoot: []string{absDir, "relative/dir"},
 			},
 		},
 	}
@@ -695,7 +697,7 @@ func TestIndexRoots_ResolvesRelativePaths(t *testing.T) {
 	roots := cfg.IndexRoots()
 	require.Len(t, roots, 3)
 	assert.Equal(t, filepath.Join(exeDir, "roms"), roots[0])
-	assert.Equal(t, "/absolute/path", roots[1])
+	assert.Equal(t, absDir, roots[1])
 	assert.Equal(t, filepath.Join(exeDir, "relative", "dir"), roots[2])
 }
 

--- a/pkg/helpers/launchers.go
+++ b/pkg/helpers/launchers.go
@@ -117,15 +117,20 @@ func ParseCustomLaunchers(
 
 		exts := formatExtensions(v.FileExts)
 
+		resolvedDirs := make([]string, len(v.MediaDirs))
+		for j, dir := range v.MediaDirs {
+			resolvedDirs[j] = ResolveRelativePath(dir)
+		}
+
 		log.Info().Str("launcherID", launcherID).Str("systemID", launcherSystemID).
-			Strs("folders", v.MediaDirs).Strs("extensions", exts).
+			Strs("folders", resolvedDirs).Strs("extensions", exts).
 			Int("lifecycle", int(lifecycle)).
 			Msg("registered custom launcher")
 
 		launcher := platforms.Launcher{
 			ID:            launcherID,
 			SystemID:      launcherSystemID,
-			Folders:       v.MediaDirs,
+			Folders:       resolvedDirs,
 			Extensions:    exts,
 			Groups:        launcherGroups,
 			Schemes:       v.Schemes,
@@ -194,6 +199,7 @@ func ParseCustomLaunchers(
 
 				//nolint:gosec,noctx // User-configured launcher commands, managed via lifecycle
 				cmd := exec.Command(parts[0], parts[1:]...)
+				cmd.Dir = ExeDir()
 
 				// Pass ZAPAROO_ENVIRONMENT JSON env var
 				envJSON, jsonErr := json.Marshal(exprEnv)

--- a/pkg/helpers/launchers_test.go
+++ b/pkg/helpers/launchers_test.go
@@ -20,6 +20,7 @@
 package helpers
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -268,7 +269,7 @@ func TestParseCustomLaunchers_EmptyExecuteLeavesLaunchNil(t *testing.T) {
 
 	assert.Equal(t, "movies", l.ID)
 	assert.Equal(t, "Video", l.SystemID)
-	assert.Equal(t, []string{"movies"}, l.Folders)
+	assert.Equal(t, []string{filepath.Join(ExeDir(), "movies")}, l.Folders)
 	assert.Equal(t, []string{".mp4", ".mkv"}, l.Extensions)
 	assert.Nil(t, l.Launch, "Launch should be nil when Execute is empty")
 }

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -29,6 +29,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformsshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/rs/zerolog/log"
@@ -391,12 +392,13 @@ func PathToLaunchers(
 }
 
 func ExeDir() string {
-	exe, err := os.Executable()
-	if err != nil {
-		return ""
-	}
+	return pathutil.ExeDir()
+}
 
-	return filepath.Dir(exe)
+// ResolveRelativePath resolves a path relative to ExeDir if it is not
+// absolute. Absolute and empty paths are returned unchanged.
+func ResolveRelativePath(path string) string {
+	return pathutil.ResolveRelativePath(path)
 }
 
 type PathInfo struct {

--- a/pkg/helpers/paths_test.go
+++ b/pkg/helpers/paths_test.go
@@ -876,8 +876,8 @@ func TestResolveRelativePath(t *testing.T) {
 		},
 		{
 			name:     "absolute path unchanged",
-			path:     "/usr/share/games",
-			expected: "/usr/share/games",
+			path:     exeDir,
+			expected: exeDir,
 		},
 		{
 			name:     "relative path resolved to ExeDir",

--- a/pkg/helpers/paths_test.go
+++ b/pkg/helpers/paths_test.go
@@ -20,6 +20,7 @@
 package helpers
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -851,6 +852,55 @@ func TestGetPathInfo_VirtualPathNoPanic(t *testing.T) {
 				result := GetPathInfo(path)
 				t.Logf("Malformed path handled: %q → Filename=%q", path, result.Filename)
 			}, "Should not panic on malformed path: %s", path)
+		})
+	}
+}
+
+func TestResolveRelativePath(t *testing.T) {
+	t.Parallel()
+
+	exeDir := ExeDir()
+	if exeDir == "" {
+		t.Skip("ExeDir() returned empty, cannot test relative path resolution")
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "empty string unchanged",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "absolute path unchanged",
+			path:     "/usr/share/games",
+			expected: "/usr/share/games",
+		},
+		{
+			name:     "relative path resolved to ExeDir",
+			path:     filepath.Join("roms", "nes"),
+			expected: filepath.Join(exeDir, "roms", "nes"),
+		},
+		{
+			name:     "dot relative path resolved",
+			path:     "./games",
+			expected: filepath.Join(exeDir, "games"),
+		},
+		{
+			name:     "single filename resolved",
+			path:     "roms",
+			expected: filepath.Join(exeDir, "roms"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ResolveRelativePath(tt.path)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/helpers/pathutil/pathutil.go
+++ b/pkg/helpers/pathutil/pathutil.go
@@ -1,0 +1,51 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package pathutil provides path resolution utilities with no dependencies on
+// other Zaparoo packages. This allows both config and helpers to use these
+// functions without circular imports.
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ExeDir returns the directory containing the currently running executable.
+// Returns an empty string if the executable path cannot be determined.
+func ExeDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return filepath.Dir(exe)
+}
+
+// ResolveRelativePath resolves a path relative to ExeDir if it is not
+// absolute. Absolute and empty paths are returned unchanged.
+func ResolveRelativePath(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	exeDir := ExeDir()
+	if exeDir == "" {
+		return path
+	}
+	return filepath.Join(exeDir, path)
+}

--- a/pkg/helpers/pathutil/pathutil_test.go
+++ b/pkg/helpers/pathutil/pathutil_test.go
@@ -46,8 +46,8 @@ func TestResolveRelativePath(t *testing.T) {
 		},
 		{
 			name:     "absolute path unchanged",
-			path:     "/usr/share/games",
-			expected: "/usr/share/games",
+			path:     exeDir,
+			expected: exeDir,
 		},
 		{
 			name:     "relative path resolved to ExeDir",

--- a/pkg/helpers/pathutil/pathutil_test.go
+++ b/pkg/helpers/pathutil/pathutil_test.go
@@ -1,0 +1,87 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package pathutil
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveRelativePath(t *testing.T) {
+	t.Parallel()
+
+	exeDir := ExeDir()
+	if exeDir == "" {
+		t.Skip("ExeDir() returned empty, cannot test relative path resolution")
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "empty string unchanged",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "absolute path unchanged",
+			path:     "/usr/share/games",
+			expected: "/usr/share/games",
+		},
+		{
+			name:     "relative path resolved to ExeDir",
+			path:     filepath.Join("roms", "nes"),
+			expected: filepath.Join(exeDir, "roms", "nes"),
+		},
+		{
+			name:     "dot relative path resolved",
+			path:     "./games",
+			expected: filepath.Join(exeDir, "games"),
+		},
+		{
+			name:     "single filename resolved",
+			path:     "roms",
+			expected: filepath.Join(exeDir, "roms"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := ResolveRelativePath(tt.path)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExeDir(t *testing.T) {
+	t.Parallel()
+
+	dir := ExeDir()
+	if dir == "" {
+		t.Skip("ExeDir() returned empty")
+	}
+
+	assert.True(t, filepath.IsAbs(dir), "ExeDir should return an absolute path")
+}

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -191,7 +191,10 @@ func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
 	p.processMu.Lock()
 
 	customKill := p.lastLauncher.Kill
+	p.lastLauncher = platforms.Launcher{}
+
 	if customKill != nil {
+		p.trackedProcess = nil
 		p.processMu.Unlock()
 		log.Debug().Msg("using custom Kill function for launcher")
 		if err := customKill(&config.Instance{}); err != nil {

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -67,6 +67,7 @@ type Platform struct {
 	customPlatformToSystem  map[string]string   // e.g., "Mame Arcade" -> "arcade"
 	systemToCustomPlatforms map[string][]string // e.g., "arcade" -> ["Mame Arcade", "Mame Classics"]
 	trackedProcess          *os.Process
+	lastLauncher            platforms.Launcher
 	launchBoxPipe           *LaunchBoxPipeServer
 	steamTracker            *steamtracker.WindowsPlatformIntegration
 	processMu               syncutil.RWMutex
@@ -180,17 +181,32 @@ func (p *Platform) SetTrackedProcess(proc *os.Process) {
 	log.Debug().Msgf("set tracked process: %v", proc)
 }
 
-func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
+func (p *Platform) setLastLauncher(l *platforms.Launcher) {
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
+	p.lastLauncher = *l
+}
 
-	// Kill tracked process if exists
-	if p.trackedProcess != nil {
-		if err := p.trackedProcess.Kill(); err != nil {
-			log.Warn().Err(err).Msg("failed to kill tracked process")
+func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
+	p.processMu.Lock()
+
+	customKill := p.lastLauncher.Kill
+	if customKill != nil {
+		p.processMu.Unlock()
+		log.Debug().Msg("using custom Kill function for launcher")
+		if err := customKill(&config.Instance{}); err != nil {
+			log.Warn().Err(err).Msg("custom Kill function failed")
 		}
-		p.trackedProcess = nil
-		log.Debug().Msg("killed tracked process")
+	} else {
+		// Kill tracked process if exists
+		if p.trackedProcess != nil {
+			if err := p.trackedProcess.Kill(); err != nil {
+				log.Warn().Err(err).Msg("failed to kill tracked process")
+			}
+			p.trackedProcess = nil
+			log.Debug().Msg("killed tracked process")
+		}
+		p.processMu.Unlock()
 	}
 
 	p.setActiveMedia(nil)
@@ -233,6 +249,8 @@ func (p *Platform) LaunchMedia(
 	if err != nil {
 		return fmt.Errorf("launch media: error launching: %w", err)
 	}
+
+	p.setLastLauncher(launcher)
 
 	return nil
 }

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -64,15 +64,15 @@ import (
 type Platform struct {
 	activeMedia             func() *models.ActiveMedia
 	setActiveMedia          func(*models.ActiveMedia)
-	customPlatformToSystem  map[string]string   // e.g., "Mame Arcade" -> "arcade"
-	systemToCustomPlatforms map[string][]string // e.g., "arcade" -> ["Mame Arcade", "Mame Classics"]
+	customPlatformToSystem  map[string]string
+	systemToCustomPlatforms map[string][]string
 	trackedProcess          *os.Process
-	lastLauncher            platforms.Launcher
 	launchBoxPipe           *LaunchBoxPipeServer
 	steamTracker            *steamtracker.WindowsPlatformIntegration
+	lastLauncher            platforms.Launcher
 	processMu               syncutil.RWMutex
-	launchBoxPipeLock       syncutil.Mutex
 	platformMappingsMu      syncutil.RWMutex
+	launchBoxPipeLock       syncutil.Mutex
 }
 
 func (*Platform) ID() string {

--- a/pkg/platforms/windows/platform_test.go
+++ b/pkg/platforms/windows/platform_test.go
@@ -22,9 +22,13 @@
 package windows
 
 import (
+	"os/exec"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,6 +56,82 @@ func TestWindowsHasKodiLocalLauncher(t *testing.T) {
 	}
 
 	require.NotNil(t, kodiLocal, "KodiLocalVideo launcher should exist")
+}
+
+func TestStopActiveLauncher_CustomKill(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		customKillFunc    func(*config.Instance) error
+		customKillCalled  bool
+		hasTrackedProcess bool
+	}{
+		{
+			name: "custom Kill function is called when defined",
+			customKillFunc: func(_ *config.Instance) error {
+				return nil
+			},
+			customKillCalled:  true,
+			hasTrackedProcess: true,
+		},
+		{
+			name: "custom Kill function error is logged but not fatal",
+			customKillFunc: func(_ *config.Instance) error {
+				return assert.AnError
+			},
+			customKillCalled:  true,
+			hasTrackedProcess: true,
+		},
+		{
+			name:              "tracked process killed when no custom Kill defined",
+			customKillFunc:    nil,
+			customKillCalled:  false,
+			hasTrackedProcess: true,
+		},
+		{
+			name:              "no kill attempted when no tracked process and no custom Kill",
+			customKillFunc:    nil,
+			customKillCalled:  false,
+			hasTrackedProcess: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &Platform{}
+			p.setActiveMedia = func(_ *models.ActiveMedia) {}
+
+			killCalled := false
+			var launcher platforms.Launcher
+			if tt.customKillFunc != nil {
+				launcher.Kill = func(cfg *config.Instance) error {
+					killCalled = true
+					return tt.customKillFunc(cfg)
+				}
+			}
+			p.setLastLauncher(&launcher)
+
+			if tt.hasTrackedProcess {
+				cmd := exec.Command("cmd", "/C", "timeout", "/T", "10")
+				err := cmd.Start()
+				require.NoError(t, err)
+				defer func() {
+					if cmd.Process != nil {
+						_ = cmd.Process.Kill()
+					}
+				}()
+				p.SetTrackedProcess(cmd.Process)
+			}
+
+			err := p.StopActiveLauncher(platforms.StopForPreemption)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.customKillCalled, killCalled, "custom Kill called mismatch")
+		})
+	}
 }
 
 func TestWindowsHasAllKodiLaunchers(t *testing.T) {

--- a/pkg/platforms/windows/platform_test.go
+++ b/pkg/platforms/windows/platform_test.go
@@ -22,6 +22,7 @@
 package windows
 
 import (
+	"context"
 	"os/exec"
 	"testing"
 
@@ -62,8 +63,8 @@ func TestStopActiveLauncher_CustomKill(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
 		customKillFunc    func(*config.Instance) error
+		name              string
 		customKillCalled  bool
 		hasTrackedProcess bool
 	}{
@@ -115,7 +116,7 @@ func TestStopActiveLauncher_CustomKill(t *testing.T) {
 			p.setLastLauncher(&launcher)
 
 			if tt.hasTrackedProcess {
-				cmd := exec.Command("cmd", "/C", "timeout", "/T", "10")
+				cmd := exec.CommandContext(context.Background(), "cmd", "/C", "timeout", "/T", "10")
 				err := cmd.Start()
 				require.NoError(t, err)
 				defer func() {

--- a/scripts/tasks/cross-lint.yml
+++ b/scripts/tasks/cross-lint.yml
@@ -23,7 +23,7 @@ tasks:
           CXX: "zig c++ -w --target=x86_64-windows-gnu"
           EXEC: >-
             bash -c 'curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /home/build/bin 2>&1 | tail -1
-            && PATH="/home/build/bin:$PATH" golangci-lint run --timeout=5m'
+            && PATH="/home/build/bin:$PATH" golangci-lint run --fix --timeout=5m'
           EXTRA_DOCKER_ARGS: >-
             -e GOOS=windows
             -e GOARCH=amd64
@@ -52,7 +52,7 @@ tasks:
             -F/opt/macosx-sdk/System/Library/Frameworks
           EXEC: >-
             bash -c 'curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /home/build/bin 2>&1 | tail -1
-            && PATH="/home/build/bin:$PATH" golangci-lint run --timeout=5m'
+            && PATH="/home/build/bin:$PATH" golangci-lint run --fix --timeout=5m'
           EXTRA_DOCKER_ARGS: >-
             -e GOOS=darwin
             -e GOARCH=amd64
@@ -72,7 +72,7 @@ tasks:
           CXX: "zig c++ -target x86_64-linux-gnu"
           EXEC: >-
             bash -c 'curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /home/build/bin 2>&1 | tail -1
-            && PATH="/home/build/bin:$PATH" golangci-lint run --timeout=5m'
+            && PATH="/home/build/bin:$PATH" golangci-lint run --fix --timeout=5m'
           EXTRA_DOCKER_ARGS: >-
             -e GOOS=linux
             -e GOARCH=amd64

--- a/scripts/tasks/cross-lint.yml
+++ b/scripts/tasks/cross-lint.yml
@@ -58,31 +58,8 @@ tasks:
             -e GOARCH=amd64
             -e CGO_ENABLED=1
 
-  linux:
-    desc: Run golangci-lint targeting Linux via zigcc (for non-Linux developers)
-    cmds:
-      - task: setup
-      - task: :docker:run
-        vars:
-          IMAGE_NAME: zaparoo/zigcc
-          PLATFORM: linux
-          BUILD_OS: linux
-          BUILD_ARCH: amd64
-          CC: "zig cc -target x86_64-linux-gnu"
-          CXX: "zig c++ -target x86_64-linux-gnu"
-          EXEC: >-
-            bash -c 'curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /home/build/bin 2>&1 | tail -1
-            && PATH="/home/build/bin:$PATH" golangci-lint run --fix --timeout=5m'
-          EXTRA_DOCKER_ARGS: >-
-            -e GOOS=linux
-            -e GOARCH=amd64
-            -e CGO_ENABLED=1
-            -e CGO_CFLAGS="-I/opt/libnfc/x86_64-linux-gnu/include"
-            -e CGO_LDFLAGS="-L/opt/libnfc/x86_64-linux-gnu/lib -L/opt/deps/x86_64-linux-gnu/lib /opt/libnfc/x86_64-linux-gnu/lib/libnfc.a /opt/deps/x86_64-linux-gnu/lib/libusb.a /opt/deps/x86_64-linux-gnu/lib/libusb-1.0.a -ldl"
-
   all:
-    desc: Run golangci-lint for all platforms via zigcc
+    desc: Run golangci-lint for Windows and macOS via zigcc
     cmds:
       - task: windows
       - task: mac
-      - task: linux


### PR DESCRIPTION
## Summary

- Fix hold mode not stopping RetroBat games on Windows by adding `lastLauncher` tracking to `StopActiveLauncher`, matching the MiSTer platform pattern
- Resolve relative `media_dir`, `index_root`, and custom launcher `media_dirs` config paths relative to the executable directory instead of the unpredictable process CWD
- Set `cmd.Dir` for custom launcher `execute` commands so relative paths resolve relative to the executable
- Extract `ExeDir` and `ResolveRelativePath` into `pkg/helpers/pathutil` to avoid circular imports between config and helpers

Closes #642

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Relative media and index paths are now resolved against the application's executable, preventing broken/misplaced launcher folders.
  * Launcher execution now runs with the correct working directory for more reliable launches.

* **New Features**
  * Custom launchers can specify custom termination logic so stop/kill behavior follows the launcher's preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->