### PR TITLE
fix(api): add HKDF transcript salt and fix API doc inaccuracies

### DIFF
--- a/docs/api/encryption.md
+++ b/docs/api/encryption.md
@@ -4,7 +4,7 @@ Zaparoo encrypts WebSocket traffic using PAKE-based pairing and AES-256-GCM with
 
 ## Overview
 
-- **Pairing**: One-time PAKE2 (P-256) handshake. User enters a 6-digit PIN from the Zaparoo device into the client app. Both sides derive a shared 32-byte pairing key — the PIN is never transmitted.
+- **Pairing**: One-time PAKE2 (P-256) handshake. User enters a 6-digit PIN from the Zaparoo device into the client app. Both sides derive a shared 32-byte pairing key. The PIN is never transmitted.
 - **Encryption**: AES-256-GCM with counter-derived nonces on every WebSocket frame.
 - **Per-session keys**: Each WebSocket connection generates a random 16-byte session salt. Both sides derive ephemeral keys via HKDF-SHA256 (pairing key as IKM, session salt as HKDF salt).
 - **Scope**: WebSocket only. HTTP POST, SSE, and REST GET are localhost-restricted by default.
@@ -37,7 +37,7 @@ sequenceDiagram
     Note over Z: B = pake.InitCurve(pin, 1, "p256")<br/>B.Update(wireFormat(A))
     Z->>C: 200 { session: uuid, pake: base64(wireFormat(B)) }
 
-    Note over C: A.Update(wireFormat(B))<br/>sessionKey = A.SessionKey()<br/>prk = HKDF-Extract(sessionKey, nil)<br/>confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)<br/>confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)<br/>pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
+    Note over C: A.Update(wireFormat(B))<br/>sessionKey = A.SessionKey()<br/>salt = msgA || msgB<br/>prk = HKDF-Extract(sessionKey, salt)<br/>confirmKeyA = HKDF-Expand(prk, "zaparoo-confirm-A", 32)<br/>confirmKeyB = HKDF-Expand(prk, "zaparoo-confirm-B", 32)<br/>pairingKey = HKDF-Expand(prk, "zaparoo-pairing-v1", 32)
 
     C->>Z: POST /api/pair/finish<br/>{ session: uuid, confirm: base64(HMAC) }
     Note over Z: Verify client HMAC, persist client
@@ -65,7 +65,7 @@ Where `role` is `"client"` or `"server"`, and `MsgA`/`MsgB` are the **raw bytes 
 
 ### PAKE message format
 
-The `pake` field in `/pair/start` request and response carries a base64-encoded JSON object. The PAKE protocol is based on [schollz/pake](https://github.com/schollz/pake) v3 using the P-256 curve. The wire format uses ASCII field names and string-encoded coordinates for cross-language compatibility.
+The `pake` field in `/pair/start` request and response carries a base64-encoded JSON object. The PAKE protocol is based on [schollz/pake](https://github.com/schollz/pake) v3 using the P-256 curve. Coordinates are string-encoded for cross-language compatibility.
 
 | Field | Type | Description |
 |---|---|---|
@@ -81,7 +81,7 @@ The `pake` field in `/pair/start` request and response carries a base64-encoded 
 
 All coordinate values are arbitrary-precision integers encoded as **quoted decimal strings** (not bare JSON numbers). This avoids precision loss in JSON parsers that use IEEE 754 doubles. Fields for points not yet computed in the current protocol step are `"0"`.
 
-Example client message (role 0, message A — Y not yet computed):
+Example client message (role 0, message A, Y not yet computed):
 
 ```json
 {
@@ -126,7 +126,7 @@ Every encrypted WebSocket connection starts with a first frame that establishes 
 |---|---|
 | `v` | Protocol version. Currently `1`. Server returns a plaintext error if unsupported (see [Errors](#errors)). |
 | `e` | AES-256-GCM ciphertext of the JSON-RPC request, base64-encoded. |
-| `t` | Auth token (UUID) identifying the paired client. Not a secret — used for key lookup. |
+| `t` | Auth token (UUID) identifying the paired client. Not a secret; used for key lookup only. |
 | `s` | 16-byte random session salt, base64-encoded. Must be exactly 16 bytes. |
 
 ### Subsequent frames (both directions)
@@ -236,7 +236,7 @@ WebSocket errors (plaintext JSON-RPC error, then connection closed):
 | Code | Meaning |
 |---|---|
 | -32001 | Unsupported encryption version |
-| -32002 | Encryption required — server requires an encrypted first frame from remote clients |
+| -32002 | Encryption required. Remote clients must send an encrypted first frame. |
 
 ## Connection lifecycle
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,7 +1,7 @@
 # Core API
 
 :::warning
-This API is not finalized. A version 1 release will be announced when it is ready for production. You're welcome to use the API as is, but be aware parts may breaking changes may still happen.
+This API is not finalized. A version 1 release will be announced when it is ready for production. You're welcome to use the API as is, but be aware that breaking changes may still happen.
 :::
 
 The **Core API** is available on and published by every device running the [Zaparoo Core](../../core) software. This API allows management of all Zaparoo features locally and remotely. The [Zaparoo](https://zaparoo.app/) app uses this API for all communication with Zaparoo devices, as do most of the flags when Zaparoo is run via the command line.
@@ -146,17 +146,23 @@ Every request sent must have a matching response. An example response to the `me
   "jsonrpc": "2.0",
   "id": "4b5da056-a5d4-436b-b4e6-b96231e99969",
   "result": {
-    "media": [
+    "results": [
       {
         "system": {
           "id": "Gameboy",
           "name": "Gameboy"
         },
         "name": "240p Test Suite (PD) v0.03 tepples",
-        "path": "Gameboy/240p Test Suite (PD) v0.03 tepples.gb"
+        "path": "Gameboy/240p Test Suite (PD) v0.03 tepples.gb",
+        "zapScript": "@Gameboy/240p Test Suite (PD) v0.03 tepples",
+        "tags": []
       }
     ],
-    "total": 1
+    "total": 1,
+    "pagination": {
+      "hasNextPage": false,
+      "pageSize": 100
+    }
   }
 }
 ```
@@ -165,12 +171,12 @@ Every request sent must have a matching response. An example response to the `me
 
 | Key     | Type   | Required | Description                                                                                                                                                     |
 | :------ | :----- | :------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| jsonrpc | number | Yes      | Same as a [request](#requests).                                                                                                                                 |
+| jsonrpc | string | Yes      | Same as a [request](#requests).                                                                                                                                 |
 | id      | string | Yes      | Same as a [request](#requests). The same ID sent by the original request.                                                                                       |
 | result  | any    | No\*     | Return value of the method. May be `null` depending on the method, will be missing if there was an error. See [methods](#methods) for possible values.          |
 | error   | Error  | No\*     | If a method failed, this key will be populated with the error details and the result key will be empty. See [below](#response-errors) for details about errors. |
 
-##### Response Errors
+##### Response errors
 
 If a method fails, it will populate the `error` key in the response object with details about the failure. An example of a failed request:
 

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -306,7 +306,7 @@ None.
 }
 ```
 
-##### Response (Database Ready)
+##### Response (database ready)
 
 ```json
 {
@@ -324,7 +324,7 @@ None.
 }
 ```
 
-##### Response (Optimization in Progress)
+##### Response (optimization in progress)
 
 ```json
 {
@@ -554,7 +554,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | type         | string   | Yes      | Entry type: `root`, `directory`, or `media`.                                                     |
 | fileCount    | number   | No       | Number of files in this directory. Present on `root` and `directory` entries.                     |
 | group        | string   | No       | Launcher group name. Present on virtual scheme `root` entries.                                   |
-| systemId     | string   | No       | System ID for the media (e.g. `snes`). Present on `media` entries.                               |
+| systemId     | string   | No       | System ID for the media (e.g. `SNES`). Present on `media` entries.                               |
 | zapScript    | string   | No       | ZapScript command to launch this media. Present on `media` entries.                              |
 | relativePath | string   | No       | Relative path from root directory. Present on `media` entries.                                   |
 | tags         | object[] | No       | Tags attached to the media. Each object has `tag` (string) and `type` (string). Present on `media` entries. |
@@ -574,10 +574,10 @@ All parameters are optional. When called with no parameters, returns root entrie
 ```json
 {
   "jsonrpc": "2.0",
-  "id": "d4e5f6a7-3456-7890-bcde-f01234567890",
+  "id": 1,
   "method": "media.browse",
   "params": {
-    "path": "/media/fat/games/SNES",
+    "path": "/roms/SNES",
     "maxResults": 3
   }
 }
@@ -588,38 +588,46 @@ All parameters are optional. When called with no parameters, returns root entrie
 ```json
 {
   "jsonrpc": "2.0",
-  "id": "d4e5f6a7-3456-7890-bcde-f01234567890",
+  "id": 1,
   "result": {
-    "path": "/media/fat/games/SNES",
+    "path": "/roms/SNES",
     "entries": [
       {
         "name": "RPGs",
-        "path": "/media/fat/games/SNES/RPGs",
+        "path": "/roms/SNES/RPGs",
         "type": "directory",
         "fileCount": 42
       },
       {
         "name": "Super Mario World",
-        "path": "/media/fat/games/SNES/Super Mario World.sfc",
+        "path": "/roms/SNES/Super Mario World.sfc",
         "type": "media",
-        "systemId": "snes",
-        "zapScript": "**launch:/media/fat/games/SNES/Super Mario World.sfc",
-        "relativePath": "Super Mario World.sfc"
+        "systemId": "SNES",
+        "zapScript": "@SNES/Super Mario World",
+        "relativePath": "Super Mario World.sfc",
+        "tags": [
+          {"tag": "1990", "type": "year"},
+          {"tag": "2", "type": "players"}
+        ]
       },
       {
         "name": "The Legend of Zelda - A Link to the Past",
-        "path": "/media/fat/games/SNES/The Legend of Zelda - A Link to the Past.sfc",
+        "path": "/roms/SNES/The Legend of Zelda - A Link to the Past.sfc",
         "type": "media",
-        "systemId": "snes",
-        "zapScript": "**launch:/media/fat/games/SNES/The Legend of Zelda - A Link to the Past.sfc",
-        "relativePath": "The Legend of Zelda - A Link to the Past.sfc"
+        "systemId": "SNES",
+        "zapScript": "@SNES/The Legend of Zelda - A Link to the Past",
+        "relativePath": "The Legend of Zelda - A Link to the Past.sfc",
+        "tags": [
+          {"tag": "1991", "type": "year"},
+          {"tag": "1", "type": "players"}
+        ]
       }
     ],
     "totalFiles": 150,
     "pagination": {
       "hasNextPage": true,
       "pageSize": 3,
-      "nextCursor": "eyJzb3J0VmFsdWUiOiJUaGUgTGVnZW5kIG9mIFplbGRhIiwibGFzdElkIjo0Mn0="
+      "nextCursor": "eyJzb3J0VmFsdWUiOiJUaGUgTGVnZW5kIG9mIFplbGRhIC0gQSBMaW5rIHRvIHRoZSBQYXN0IiwibGFzdElkIjo0Mn0="
     }
   }
 }
@@ -725,7 +733,7 @@ Returns `null` on success. Indexing runs in the background after the response is
 
 #### Examples
 
-##### Full Index Request
+##### Full index request
 
 ```json
 {
@@ -745,7 +753,7 @@ Returns `null` on success. Indexing runs in the background after the response is
 }
 ```
 
-##### Selective Index Request
+##### Selective index request
 
 ```json
 {
@@ -794,7 +802,7 @@ None.
 }
 ```
 
-##### Response (Indexing was running)
+##### Response (indexing was running)
 
 ```json
 {
@@ -806,7 +814,7 @@ None.
 }
 ```
 
-##### Response (No indexing running)
+##### Response (no indexing running)
 
 ```json
 {
@@ -842,7 +850,7 @@ Returns an [ActiveMedia](#active-media-object) object if media is currently acti
 }
 ```
 
-##### Response (No Active Media)
+##### Response (no active media)
 
 ```json
 {
@@ -852,7 +860,7 @@ Returns an [ActiveMedia](#active-media-object) object if media is currently acti
 }
 ```
 
-##### Response (Media Active)
+##### Response (media active)
 
 ```json
 {
@@ -1113,7 +1121,7 @@ An object:
 }
 ```
 
-##### Response (Match Found)
+##### Response (match found)
 
 ```json
 {
@@ -1147,7 +1155,7 @@ An object:
 }
 ```
 
-##### Response (No Match)
+##### Response (no match)
 
 ```json
 {
@@ -1551,7 +1559,7 @@ None.
 }
 ```
 
-##### Response (Reset State)
+##### Response (reset state)
 
 ```json
 {
@@ -1567,7 +1575,7 @@ None.
 }
 ```
 
-##### Response (Active Game with Limits)
+##### Response (active game with limits)
 
 ```json
 {
@@ -1587,7 +1595,7 @@ None.
 }
 ```
 
-##### Response (Cooldown State)
+##### Response (cooldown state)
 
 ```json
 {
@@ -2350,7 +2358,7 @@ Returns `null` on success.
 
 ## Input
 
-Direct platform input control for remote control use cases. These methods bypass the token pipeline entirely — no hooks, history, or sound effects are triggered.
+Direct platform input control for remote control use cases. These methods bypass the token pipeline entirely: no hooks, history, or sound effects are triggered.
 
 The input macro format is identical to what goes after the `:` in a ZapScript `input.keyboard` or `input.gamepad` command on a token. Each character is a separate keypress, `{...}` groups are special keys/combos, and `\` is the escape character.
 

--- a/docs/api/notifications.md
+++ b/docs/api/notifications.md
@@ -164,7 +164,7 @@ Sent during media database generation to indicate indexing progress and completi
 
 #### Examples
 
-##### Indexing In Progress
+##### Indexing in progress
 
 ```json
 {
@@ -182,7 +182,7 @@ Sent during media database generation to indicate indexing progress and completi
 }
 ```
 
-##### Optimization In Progress
+##### Optimization in progress
 
 ```json
 {
@@ -198,7 +198,7 @@ Sent during media database generation to indicate indexing progress and completi
 }
 ```
 
-##### Database Ready
+##### Database ready
 
 ```json
 {
@@ -227,7 +227,7 @@ Sent when a playtime limit (session or daily) has been reached and enforced by t
 
 #### Examples
 
-##### Session Limit Reached
+##### Session limit reached
 
 ```json
 {
@@ -239,7 +239,7 @@ Sent when a playtime limit (session or daily) has been reached and enforced by t
 }
 ```
 
-##### Daily Limit Reached
+##### Daily limit reached
 
 ```json
 {

--- a/pkg/api/integration_encryption_test.go
+++ b/pkg/api/integration_encryption_test.go
@@ -30,6 +30,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -138,7 +139,8 @@ func pairAndDeriveKey(
 	require.NoError(t, err)
 
 	// Derive the same confirmation keys + pairing key the server will.
-	prk, err := hkdf.Extract(sha256.New, clientSessionKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientSessionKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, infoConfirmA, sha256.Size)
 	require.NoError(t, err)

--- a/pkg/api/pairing.go
+++ b/pkg/api/pairing.go
@@ -33,6 +33,7 @@ import (
 	"io"
 	"math/big"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
@@ -393,7 +394,10 @@ func (m *PairingManager) finishSessionLocked(
 	}
 
 	// Derive confirmation keys + pairing key from the raw PAKE session key.
-	prk, err := hkdf.Extract(sha256.New, sess.sessionKey, nil)
+	// Use the concatenated PAKE wire messages as HKDF salt to bind key
+	// derivation to this specific handshake transcript.
+	salt := slices.Concat(sess.msgA, sess.msgB)
+	prk, err := hkdf.Extract(sha256.New, sess.sessionKey, salt)
 	if err != nil {
 		return nil, nil, fmt.Errorf("hkdf extract: %w", err)
 	}

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -103,7 +104,8 @@ func (h *pairingTestHarness) runHandshake(
 	clientSessionKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 
-	prk, err := hkdf.Extract(sha256.New, clientSessionKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientSessionKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -269,7 +271,8 @@ func TestWrongPIN_Rejected(t *testing.T) {
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
 
-	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -410,7 +413,8 @@ func TestPairFinish_ConcurrentCallsOneWins(t *testing.T) {
 	sessionKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
 
-	prk, err := hkdf.Extract(sha256.New, sessionKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, sessionKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -495,7 +499,8 @@ func TestMaxClients_FinishSessionDefenseInDepth(t *testing.T) {
 	require.NoError(t, clientPake.Update(msgBInternal))
 	clientKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
-	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -568,7 +573,8 @@ func TestHTTPHandlers_FullFlow(t *testing.T) {
 	require.NoError(t, clientPake.Update(msgBInternal))
 	clientKey, err := clientPake.SessionKey()
 	require.NoError(t, err)
-	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -671,7 +677,8 @@ func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
 	require.NoError(t, wrongPake.Update(msgBInternal))
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
-	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)
@@ -743,7 +750,8 @@ func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
 	require.NoError(t, wrongPake.Update(msgBInternal))
 	clientKey, err := wrongPake.SessionKey()
 	require.NoError(t, err)
-	prk, err := hkdf.Extract(sha256.New, clientKey, nil)
+	salt := slices.Concat(msgA, msgB)
+	prk, err := hkdf.Extract(sha256.New, clientKey, salt)
 	require.NoError(t, err)
 	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
 	require.NoError(t, err)


### PR DESCRIPTION
- Use `msgA || msgB` as the HKDF salt when deriving pairing keys, binding key derivation to the handshake transcript instead of using nil salt
- Fix `media.browse` doc example: wrong `zapScript` format (`**launch:` instead of `@SystemID/`), lowercase `systemId`, missing `tags` field, truncated cursor value
- Fix `index.md` media.search example: wrong response key (`media` instead of `results`), missing `zapScript`/`tags`/`pagination` fields, `jsonrpc` response type listed as `number` instead of `string`
- Fix grammar error in API warning banner
- Remove em dashes and normalize heading case to sentence case across all API docs
- Update `encryption.md` pairing flow diagram and PAKE format description to reflect the salt change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified encryption and key derivation flows in API documentation.
  * Updated API response schema with pagination metadata and additional media fields.
  * Improved example consistency and formatting across API endpoints.
  * Corrected JSON-RPC protocol field type specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->