### PR TITLE
feat(audio): add volume setting and preserve external config edits

### DIFF
--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -50,6 +50,7 @@ func HandleSettings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 		RunZapScript:              env.State.RunZapScriptEnabled(),
 		DebugLogging:              env.Config.DebugLogging(),
 		AudioScanFeedback:         env.Config.AudioFeedback(),
+		AudioVolume:               env.Config.AudioVolume(),
 		ReadersAutoDetect:         env.Config.Readers().AutoDetect,
 		ReadersScanMode:           env.Config.ReadersScan().Mode,
 		ReadersScanExitDelay:      env.Config.ReadersScan().ExitDelay,
@@ -95,6 +96,7 @@ func HandleSettingsReload(env requests.RequestEnv) (any, error) {
 
 	if env.Player != nil {
 		env.Player.ClearFileCache()
+		env.Player.SetVolume(float64(env.Config.AudioVolume()) / 100.0)
 	}
 
 	return NoContent{}, nil
@@ -108,6 +110,14 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
 		log.Warn().Err(err).Msg("invalid params")
 		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	// Reload config from disk before applying mutations so that external
+	// edits (e.g. user hand-editing config.toml) are not lost on save.
+	// TODO: Load+Set+Save is not atomic — concurrent handler calls can
+	// interleave. Needs a config-level transaction lock to fix properly.
+	if err := env.Config.Load(); err != nil {
+		log.Warn().Err(err).Msg("failed to reload config before settings update, using in-memory values")
 	}
 
 	if params.RunZapScript != nil {
@@ -128,6 +138,14 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 	if params.AudioScanFeedback != nil {
 		log.Debug().Bool("audioScanFeedback", *params.AudioScanFeedback).Msg("updating setting")
 		env.Config.SetAudioFeedback(*params.AudioScanFeedback)
+	}
+
+	if params.AudioVolume != nil {
+		log.Debug().Int("audioVolume", *params.AudioVolume).Msg("updating setting")
+		env.Config.SetAudioVolume(*params.AudioVolume)
+		if env.Player != nil {
+			env.Player.SetVolume(float64(*params.AudioVolume) / 100.0)
+		}
 	}
 
 	if params.ReadersAutoDetect != nil {
@@ -248,6 +266,12 @@ func HandlePlaytimeLimitsUpdate(env requests.RequestEnv) (any, error) {
 	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
 		log.Warn().Err(err).Msg("invalid params")
 		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	// Reload config from disk before applying mutations so that external
+	// edits (e.g. user hand-editing config.toml) are not lost on save.
+	if err := env.Config.Load(); err != nil {
+		log.Warn().Err(err).Msg("failed to reload config before playtime limits update, using in-memory values")
 	}
 
 	if params.Enabled != nil {

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -22,6 +22,8 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -581,6 +583,59 @@ func TestHandleSettingsUpdate_LaunchGuard(t *testing.T) {
 	assert.InDelta(t, 30, cfg.LaunchGuardTimeout(), 0)
 	assert.InDelta(t, 10, cfg.LaunchGuardDelay(), 0)
 	assert.True(t, cfg.LaunchGuardRequireConfirm())
+}
+
+// TestHandleSettingsUpdate_PreservesExternalEdits verifies that calling
+// HandleSettingsUpdate does not overwrite external edits to config.toml.
+// Regression test for the pre-save reload introduced for issue #653.
+func TestHandleSettingsUpdate_PreservesExternalEdits(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	// Save initial config so the file exists on disk
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	// Externally modify config.toml to add volume=42
+	cfgPath := tmpDir + "/" + config.CfgFile
+	data, err := os.ReadFile(cfgPath) //nolint:gosec // test path from t.TempDir()
+	require.NoError(t, err)
+	content := strings.Replace(string(data),
+		"scan_feedback = false", "scan_feedback = false\nvolume = 42", 1)
+	require.NotEqual(t, string(data), content, "replacement should have occurred")
+	err = os.WriteFile(cfgPath, []byte(content), 0o600) //nolint:gosec // test path
+	require.NoError(t, err)
+
+	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+
+	// Call HandleSettingsUpdate changing a different field (error_reporting)
+	enabled := true
+	params := models.UpdateSettingsParams{
+		ErrorReporting: &enabled,
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Params:   paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	// Both the external edit and the API change should be present
+	assert.Equal(t, 42, cfg.AudioVolume(), "external volume edit should survive settings update")
+	assert.True(t, cfg.ErrorReporting(), "API change should be applied")
 }
 
 func TestHandleSettings_AudioVolumeDefault(t *testing.T) {

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -583,6 +583,73 @@ func TestHandleSettingsUpdate_LaunchGuard(t *testing.T) {
 	assert.True(t, cfg.LaunchGuardRequireConfirm())
 }
 
+func TestHandleSettings_AudioVolumeDefault(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Params:   []byte(`{}`),
+	}
+
+	result, err := HandleSettings(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.SettingsResponse)
+	require.True(t, ok)
+
+	assert.Equal(t, 100, resp.AudioVolume, "audioVolume should default to 100")
+}
+
+func TestHandleSettingsUpdate_AudioVolume(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+
+	mockPlayer := mocks.NewMockPlayer()
+	mockPlayer.SetupNoOpMock()
+
+	vol := 50
+	params := models.UpdateSettingsParams{
+		AudioVolume: &vol,
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Player:   mockPlayer,
+		Params:   paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	assert.Equal(t, 50, cfg.AudioVolume())
+	mockPlayer.AssertCalled(t, "SetVolume", 0.5)
+}
+
 // TestHandleSettingsReload_RefreshesLauncherCache tests that HandleSettingsReload
 // refreshes the launcher cache after reloading config and custom launcher files.
 func TestHandleSettingsReload_RefreshesLauncherCache(t *testing.T) {

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -109,6 +109,7 @@ type UpdateSettingsParams struct {
 	ReadersScanExitDelay      *float32            `json:"readersScanExitDelay" validate:"omitempty,gte=0"`
 	ReadersScanIgnoreSystem   *[]string           `json:"readersScanIgnoreSystems" validate:"omitempty,dive,system"`
 	ReadersConnect            *[]ReaderConnection `json:"readersConnect,omitempty"`
+	AudioVolume               *int                `json:"audioVolume" validate:"omitempty,gte=0,lte=200"`
 	LaunchGuardEnabled        *bool               `json:"launchGuardEnabled"`
 	LaunchGuardTimeout        *float32            `json:"launchGuardTimeout" validate:"omitempty,gte=-1"`
 	LaunchGuardDelay          *float32            `json:"launchGuardDelay" validate:"omitempty,gte=0"`

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -79,6 +79,7 @@ type SettingsResponse struct {
 	ReadersScanExitDelay      float32            `json:"readersScanExitDelay"`
 	LaunchGuardTimeout        float32            `json:"launchGuardTimeout"`
 	LaunchGuardDelay          float32            `json:"launchGuardDelay"`
+	AudioVolume               int                `json:"audioVolume"`
 	RunZapScript              bool               `json:"runZapScript"`
 	DebugLogging              bool               `json:"debugLogging"`
 	AudioScanFeedback         bool               `json:"audioScanFeedback"`

--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -58,7 +58,7 @@ type MalgoPlayer struct {
 	currentCancel context.CancelFunc
 	currentDone   <-chan struct{} // closed when current playback goroutine finishes
 	fileCache     map[string][]byte
-	volume        float64 // 0.0-1.0, protected by playbackMu
+	volume        float64 // 0.0-2.0, protected by playbackMu
 	playbackGen   uint64
 	fileCacheMu   syncutil.RWMutex
 	playbackMu    syncutil.Mutex
@@ -72,7 +72,7 @@ func NewMalgoPlayer() *MalgoPlayer {
 	}
 }
 
-// SetVolume sets the playback volume (0.0-1.0). Applies to subsequent playback calls.
+// SetVolume sets the playback volume (0.0-2.0). Applies to subsequent playback calls.
 func (p *MalgoPlayer) SetVolume(volume float64) {
 	p.playbackMu.Lock()
 	defer p.playbackMu.Unlock()
@@ -387,7 +387,7 @@ func (p *MalgoPlayer) ClearFileCache() {
 }
 
 // playWAVWithMalgo plays audio samples through malgo, blocking until complete or ctx is cancelled.
-// The volume parameter (0.0-1.0) scales sample amplitude before output.
+// The volume parameter (0.0-2.0) scales sample amplitude before output.
 func playWAVWithMalgo(ctx context.Context, streamer beep.Streamer, volume float64) error {
 	malgoCtx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
 	if err != nil {

--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -50,6 +50,7 @@ type Player interface {
 	PlayBytes(data []byte) error
 	PlayFile(path string) error
 	ClearFileCache()
+	SetVolume(volume float64)
 }
 
 // MalgoPlayer implements Player using malgo for real audio hardware output.
@@ -57,6 +58,7 @@ type MalgoPlayer struct {
 	currentCancel context.CancelFunc
 	currentDone   <-chan struct{} // closed when current playback goroutine finishes
 	fileCache     map[string][]byte
+	volume        float64 // 0.0-1.0, protected by playbackMu
 	playbackGen   uint64
 	fileCacheMu   syncutil.RWMutex
 	playbackMu    syncutil.Mutex
@@ -66,7 +68,15 @@ type MalgoPlayer struct {
 func NewMalgoPlayer() *MalgoPlayer {
 	return &MalgoPlayer{
 		fileCache: make(map[string][]byte),
+		volume:    1.0,
 	}
+}
+
+// SetVolume sets the playback volume (0.0-1.0). Applies to subsequent playback calls.
+func (p *MalgoPlayer) SetVolume(volume float64) {
+	p.playbackMu.Lock()
+	defer p.playbackMu.Unlock()
+	p.volume = volume
 }
 
 func (p *MalgoPlayer) playWAV(r io.ReadCloser) error {
@@ -93,6 +103,7 @@ func (p *MalgoPlayer) playWAV(r io.ReadCloser) error {
 	p.currentDone = done
 	p.playbackGen++
 	thisGen := p.playbackGen
+	vol := p.volume
 	p.playbackMu.Unlock()
 
 	// Wait for the previous playback goroutine to fully release the audio
@@ -131,7 +142,7 @@ func (p *MalgoPlayer) playWAV(r io.ReadCloser) error {
 			p.playbackMu.Unlock()
 		}()
 
-		if err := playWAVWithMalgo(ctx, resampled); err != nil {
+		if err := playWAVWithMalgo(ctx, resampled, vol); err != nil {
 			if ctx.Err() != context.Canceled {
 				log.Warn().Err(err).Msg("failed to play audio")
 			}
@@ -210,6 +221,7 @@ func (p *MalgoPlayer) playStream(streamer beep.StreamSeekCloser, format beep.For
 	p.currentDone = done
 	p.playbackGen++
 	thisGen := p.playbackGen
+	vol := p.volume
 	p.playbackMu.Unlock()
 
 	if prevDone != nil {
@@ -238,7 +250,7 @@ func (p *MalgoPlayer) playStream(streamer beep.StreamSeekCloser, format beep.For
 			p.playbackMu.Unlock()
 		}()
 
-		if err := playWAVWithMalgo(ctx, resampled); err != nil {
+		if err := playWAVWithMalgo(ctx, resampled, vol); err != nil {
 			if ctx.Err() != context.Canceled {
 				log.Warn().Err(err).Msg("failed to play audio")
 			}
@@ -296,6 +308,7 @@ func (p *MalgoPlayer) PlayFile(path string) error {
 	p.currentDone = done
 	p.playbackGen++
 	thisGen := p.playbackGen
+	vol := p.volume
 	p.playbackMu.Unlock()
 
 	// Wait for the previous playback goroutine to fully release the audio
@@ -329,7 +342,7 @@ func (p *MalgoPlayer) PlayFile(path string) error {
 			p.playbackMu.Unlock()
 		}()
 
-		if err := playWAVWithMalgo(ctx, resampled); err != nil {
+		if err := playWAVWithMalgo(ctx, resampled, vol); err != nil {
 			if ctx.Err() != context.Canceled {
 				log.Warn().Err(err).Msg("failed to play audio")
 			}
@@ -374,7 +387,8 @@ func (p *MalgoPlayer) ClearFileCache() {
 }
 
 // playWAVWithMalgo plays audio samples through malgo, blocking until complete or ctx is cancelled.
-func playWAVWithMalgo(ctx context.Context, streamer beep.Streamer) error {
+// The volume parameter (0.0-1.0) scales sample amplitude before output.
+func playWAVWithMalgo(ctx context.Context, streamer beep.Streamer, volume float64) error {
 	malgoCtx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
 	if err != nil {
 		return fmt.Errorf("failed to initialize malgo context: %w", err)
@@ -432,11 +446,11 @@ func playWAVWithMalgo(ctx context.Context, streamer beep.Streamer) error {
 		// Convert beep's [][2]float64 samples to interleaved F32 PCM
 		offset := 0
 		for i := range n {
-			sample := float32(samples[i][0])
+			sample := float32(samples[i][0] * volume)
 			binary.LittleEndian.PutUint32(pOutputSample[offset:], math.Float32bits(sample))
 			offset += 4
 
-			sample = float32(samples[i][1])
+			sample = float32(samples[i][1] * volume)
 			binary.LittleEndian.PutUint32(pOutputSample[offset:], math.Float32bits(sample))
 			offset += 4
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -246,9 +246,24 @@ func (c *Instance) Load() error {
 	oldVals := c.vals
 	c.vals = c.defaults
 
+	// Save mappings and custom launchers — they're normally loaded from
+	// separate files via LoadMappings/LoadCustomLaunchers, not config.toml.
+	// Save() strips them before marshal, so after a round-trip they'd be
+	// empty. Restore the old values only when the TOML didn't provide new
+	// ones (a user might hand-edit config.toml to include them).
+	savedMappings := oldVals.Mappings
+	savedCustomLaunchers := oldVals.Launchers.Custom
+
 	if err := c.applyTOML(string(data)); err != nil {
 		c.vals = oldVals
 		return err
+	}
+
+	if len(c.vals.Mappings.Entry) == 0 {
+		c.vals.Mappings = savedMappings
+	}
+	if len(c.vals.Launchers.Custom) == 0 {
+		c.vals.Launchers.Custom = savedCustomLaunchers
 	}
 
 	if c.vals.ConfigSchema != SchemaVersion {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,13 @@ const (
 	UpdateChannelBeta   = "beta"
 )
 
+const configHeader = `# Zaparoo Core configuration file.
+# https://zaparoo.org/docs/core/config/
+#
+# This file is managed by the Zaparoo service. Manual edits to values are
+# preserved on next save, but comments will be lost.
+`
+
 type Values struct {
 	Groovy         Groovy    `toml:"groovy,omitempty"`
 	Input          Input     `toml:"input,omitempty"`
@@ -72,6 +79,7 @@ type Audio struct {
 	LimitSound   *string `toml:"limit_sound,omitempty"`
 	PendingSound *string `toml:"pending_sound,omitempty"`
 	ReadySound   *string `toml:"ready_sound,omitempty"`
+	Volume       *int    `toml:"volume,omitempty"`
 	ScanFeedback bool    `toml:"scan_feedback"`
 }
 
@@ -373,7 +381,8 @@ func (c *Instance) Save() error {
 	c.vals.Mappings = tmpMappings
 	c.vals.Launchers.Custom = tmpCustomLauncher
 
-	if err := afero.WriteFile(c.getFs(), c.cfgPath, data, 0o600); err != nil {
+	output := append([]byte(configHeader), data...)
+	if err := afero.WriteFile(c.getFs(), c.cfgPath, output, 0o600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 	return nil
@@ -447,6 +456,24 @@ func (c *Instance) SetAudioFeedback(enabled bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.vals.Audio.ScanFeedback = enabled
+}
+
+// AudioVolume returns the configured volume level (0-200). Defaults to 100 if unset.
+// Values above 100 amplify the audio. Clamped to [0, 200].
+func (c *Instance) AudioVolume() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.vals.Audio.Volume == nil {
+		return 100
+	}
+	return max(0, min(200, *c.vals.Audio.Volume))
+}
+
+// SetAudioVolume sets the audio volume level (0-200, default 100).
+func (c *Instance) SetAudioVolume(v int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Audio.Volume = &v
 }
 
 // SuccessSoundPath resolves the success sound file path based on config and disk overrides.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -1577,4 +1578,135 @@ func BenchmarkConfig_Load(b *testing.B) {
 	for b.Loop() {
 		_ = cfg.Load()
 	}
+}
+
+func TestAudioVolume_Default(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewConfig(t.TempDir(), BaseDefaults)
+	require.NoError(t, err)
+
+	assert.Equal(t, 100, cfg.AudioVolume(), "default volume should be 100")
+}
+
+func TestAudioVolume_SetGet(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewConfig(t.TempDir(), BaseDefaults)
+	require.NoError(t, err)
+
+	cfg.SetAudioVolume(50)
+	assert.Equal(t, 50, cfg.AudioVolume())
+
+	cfg.SetAudioVolume(0)
+	assert.Equal(t, 0, cfg.AudioVolume())
+
+	cfg.SetAudioVolume(200)
+	assert.Equal(t, 200, cfg.AudioVolume(), "max boundary should work")
+
+	cfg.SetAudioVolume(300)
+	assert.Equal(t, 200, cfg.AudioVolume(), "values above 200 should be clamped")
+
+	cfg.SetAudioVolume(-10)
+	assert.Equal(t, 0, cfg.AudioVolume(), "negative values should be clamped to 0")
+}
+
+func TestAudioVolume_SaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewConfig(t.TempDir(), BaseDefaults)
+	require.NoError(t, err)
+
+	cfg.SetAudioVolume(75)
+
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	assert.Equal(t, 75, cfg.AudioVolume(), "volume should persist after save/load")
+}
+
+func TestSave_PreservesExternalEdits(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cfg, err := NewConfig(tempDir, BaseDefaults)
+	require.NoError(t, err)
+
+	// Save initial config
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	// Externally edit the file to add audio volume
+	cfgPath := filepath.Join(tempDir, CfgFile)
+	data, err := os.ReadFile(cfgPath) //nolint:gosec // test path from t.TempDir()
+	require.NoError(t, err)
+
+	// Add volume to the existing [audio] section by inserting after "scan_feedback"
+	content := strings.Replace(string(data), "scan_feedback = true", "scan_feedback = true\nvolume = 42", 1)
+	require.NotEqual(t, string(data), content, "replacement should have occurred")
+	err = os.WriteFile(cfgPath, []byte(content), 0o600) //nolint:gosec // test path from t.TempDir()
+	require.NoError(t, err)
+
+	// Reload to pick up external edits, then modify a different field
+	err = cfg.Load()
+	require.NoError(t, err)
+	assert.Equal(t, 42, cfg.AudioVolume(), "should have loaded external edit")
+
+	cfg.SetDebugLogging(true)
+
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	// Reload and verify both the API change and external edit are present
+	err = cfg.Load()
+	require.NoError(t, err)
+	assert.Equal(t, 42, cfg.AudioVolume(), "external volume edit should be preserved")
+	assert.True(t, cfg.DebugLogging(), "API change should be present")
+}
+
+func TestSave_ConfigHeader(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cfg, err := NewConfig(tempDir, BaseDefaults)
+	require.NoError(t, err)
+
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(tempDir, CfgFile)) //nolint:gosec // test path from t.TempDir()
+	require.NoError(t, err)
+
+	assert.Contains(t, string(data), "# Zaparoo Core configuration file.",
+		"saved config should contain header comment")
+}
+
+func TestLoad_WithComments(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	cfg, err := NewConfig(tempDir, BaseDefaults)
+	require.NoError(t, err)
+
+	// Write a config file with comments
+	cfgPath := filepath.Join(tempDir, CfgFile)
+	content := fmt.Sprintf(`# My custom comment
+config_schema = %d
+debug_logging = true
+
+# Audio settings
+[audio]
+volume = 80
+`, SchemaVersion)
+	err = os.WriteFile(cfgPath, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	assert.True(t, cfg.DebugLogging())
+	assert.Equal(t, 80, cfg.AudioVolume())
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1671,14 +1671,15 @@ func TestSave_PreservesExternalEdits(t *testing.T) {
 func TestSave_ConfigHeader(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-	cfg, err := NewConfig(tempDir, BaseDefaults)
+	memFs := afero.NewMemMapFs()
+	configDir := "/config"
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, memFs)
 	require.NoError(t, err)
 
 	err = cfg.Save()
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(filepath.Join(tempDir, CfgFile)) //nolint:gosec // test path from t.TempDir()
+	data, err := afero.ReadFile(memFs, filepath.Join(configDir, CfgFile))
 	require.NoError(t, err)
 
 	assert.Contains(t, string(data), "# Zaparoo Core configuration file.",
@@ -1688,12 +1689,13 @@ func TestSave_ConfigHeader(t *testing.T) {
 func TestLoad_WithComments(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-	cfg, err := NewConfig(tempDir, BaseDefaults)
+	memFs := afero.NewMemMapFs()
+	configDir := "/config"
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, memFs)
 	require.NoError(t, err)
 
 	// Write a config file with comments
-	cfgPath := filepath.Join(tempDir, CfgFile)
+	cfgPath := filepath.Join(configDir, CfgFile)
 	content := fmt.Sprintf(`# My custom comment
 config_schema = %d
 debug_logging = true
@@ -1702,7 +1704,7 @@ debug_logging = true
 [audio]
 volume = 80
 `, SchemaVersion)
-	err = os.WriteFile(cfgPath, []byte(content), 0o600)
+	err = afero.WriteFile(memFs, cfgPath, []byte(content), 0o600)
 	require.NoError(t, err)
 
 	err = cfg.Load()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1631,8 +1631,9 @@ func TestAudioVolume_SaveLoadRoundTrip(t *testing.T) {
 func TestSave_PreservesExternalEdits(t *testing.T) {
 	t.Parallel()
 
-	tempDir := t.TempDir()
-	cfg, err := NewConfig(tempDir, BaseDefaults)
+	memFs := afero.NewMemMapFs()
+	configDir := "/config"
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, memFs)
 	require.NoError(t, err)
 
 	// Save initial config
@@ -1640,14 +1641,14 @@ func TestSave_PreservesExternalEdits(t *testing.T) {
 	require.NoError(t, err)
 
 	// Externally edit the file to add audio volume
-	cfgPath := filepath.Join(tempDir, CfgFile)
-	data, err := os.ReadFile(cfgPath) //nolint:gosec // test path from t.TempDir()
+	cfgPath := filepath.Join(configDir, CfgFile)
+	data, err := afero.ReadFile(memFs, cfgPath)
 	require.NoError(t, err)
 
 	// Add volume to the existing [audio] section by inserting after "scan_feedback"
 	content := strings.Replace(string(data), "scan_feedback = true", "scan_feedback = true\nvolume = 42", 1)
 	require.NotEqual(t, string(data), content, "replacement should have occurred")
-	err = os.WriteFile(cfgPath, []byte(content), 0o600) //nolint:gosec // test path from t.TempDir()
+	err = afero.WriteFile(memFs, cfgPath, []byte(content), 0o600)
 	require.NoError(t, err)
 
 	// Reload to pick up external edits, then modify a different field
@@ -1655,7 +1656,7 @@ func TestSave_PreservesExternalEdits(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 42, cfg.AudioVolume(), "should have loaded external edit")
 
-	cfg.SetDebugLogging(true)
+	cfg.SetErrorReporting(true)
 
 	err = cfg.Save()
 	require.NoError(t, err)
@@ -1664,7 +1665,7 @@ func TestSave_PreservesExternalEdits(t *testing.T) {
 	err = cfg.Load()
 	require.NoError(t, err)
 	assert.Equal(t, 42, cfg.AudioVolume(), "external volume edit should be preserved")
-	assert.True(t, cfg.DebugLogging(), "API change should be present")
+	assert.True(t, cfg.ErrorReporting(), "API change should be present")
 }
 
 func TestSave_ConfigHeader(t *testing.T) {

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	behaviorTimeout = 3 * time.Second
+	behaviorTimeout = 10 * time.Second
 	noEventWait     = 200 * time.Millisecond
 	testReaderID    = "test-reader-removable"
 	testReaderSrc   = "test-reader-src"

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -207,6 +207,7 @@ func Start(
 	log.Info().Msgf("boot session UUID: %s", bootUUID)
 
 	player := audio.NewMalgoPlayer()
+	player.SetVolume(float64(cfg.AudioVolume()) / 100.0)
 
 	// TODO: define the notifications chan here instead of in state
 	st, ns := state.NewState(pl, bootUUID) // global state, notification queue (source)

--- a/pkg/testing/mocks/audio.go
+++ b/pkg/testing/mocks/audio.go
@@ -40,6 +40,10 @@ func (m *MockPlayer) ClearFileCache() {
 	m.Called()
 }
 
+func (m *MockPlayer) SetVolume(volume float64) {
+	m.Called(volume)
+}
+
 // NewMockPlayer creates a new MockPlayer instance.
 func NewMockPlayer() *MockPlayer {
 	return &MockPlayer{}
@@ -50,4 +54,5 @@ func (m *MockPlayer) SetupNoOpMock() {
 	m.On("PlayBytes", mock.Anything).Return(nil).Maybe()
 	m.On("PlayFile", mock.Anything).Return(nil).Maybe()
 	m.On("ClearFileCache").Return().Maybe()
+	m.On("SetVolume", mock.Anything).Return().Maybe()
 }


### PR DESCRIPTION
- Add global audio `volume` setting (0-200, default 100) to the `[audio]` config section. Values above 100 amplify feedback sounds. Volume is applied as a sample-level multiplier in the PCM conversion loop.
- Expose `audioVolume` in the settings API (get and update). Player volume is synced on settings update and reload.
- Reload config from disk before applying API mutations in `HandleSettingsUpdate` and `HandlePlaytimeLimitsUpdate`, so manual edits to `config.toml` are not silently overwritten.
- Add a header comment to saved config files explaining that user comments will be lost on save.
- Add `SetVolume` to the `Player` interface and thread volume through `playWAVWithMalgo` via `playbackMu`-protected capture at play-start time.

Refs #653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio volume added to settings API (0–200%, default 100%); can be updated via settings and applies immediately to active playback. Service initializes player volume on start.

* **Bug Fixes**
  * Settings handlers reload on-disk config before applying updates to preserve external edits and ensure volume changes take effect.

* **Tests**
  * Added tests for volume default, updates, persistence, preservation of external edits, and updated test timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->