### PR TITLE
feat(config): add enabled field to reader connections

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -1301,6 +1301,7 @@ None.
 | driver   | string | Yes      | Reader driver type (e.g., "pn532uart", "acr122pcsc"). |
 | path     | string | Yes      | Path or address for the reader connection.       |
 | idSource | string | No       | Source for the reader ID.                        |
+| enabled  | bool   | No       | Whether the connection is enabled. Defaults to true if omitted. |
 
 #### Example
 

--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -39,6 +39,7 @@ func HandleSettings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 	readersConnect := make([]models.ReaderConnection, 0, len(connectCfg))
 	for _, rc := range connectCfg {
 		readersConnect = append(readersConnect, models.ReaderConnection{
+			Enabled:  rc.Enabled,
 			Driver:   rc.Driver,
 			Path:     rc.Path,
 			IDSource: rc.IDSource,
@@ -203,6 +204,7 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 		connections := make([]config.ReadersConnect, 0, len(*params.ReadersConnect))
 		for _, rc := range *params.ReadersConnect {
 			connections = append(connections, config.ReadersConnect{
+				Enabled:  rc.Enabled,
 				Driver:   rc.Driver,
 				Path:     rc.Path,
 				IDSource: rc.IDSource,

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -43,6 +43,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func drainCh(ch <-chan models.Notification) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
 // TestHandlePlaytimeLimitsUpdate_ReEnableWithActiveMedia tests that re-enabling
 // playtime limits while a game is already running correctly triggers a session start.
 // This is a regression test for the bug where disabling then re-enabling limits
@@ -59,7 +69,8 @@ func TestHandlePlaytimeLimitsUpdate_ReEnableWithActiveMedia(t *testing.T) {
 	require.NoError(t, err)
 	cfg.SetPlaytimeLimitsEnabled(false) // Start with limits disabled
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	// Use a reliable time (2025) so clock checks pass
 	baseTime := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
@@ -134,7 +145,8 @@ func TestHandlePlaytimeLimitsUpdate_ReEnableWithNoActiveMedia(t *testing.T) {
 	require.NoError(t, err)
 	cfg.SetPlaytimeLimitsEnabled(false) // Start with limits disabled
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	// No active media - simulate no game running
 
@@ -201,7 +213,8 @@ func TestHandleSettings_ReaderConnections(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -236,7 +249,8 @@ func TestHandleSettings_EmptyReaderConnections(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -267,7 +281,8 @@ func TestHandleSettingsUpdate_ReaderConnections(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	params := models.UpdateSettingsParams{
 		ReadersConnect: &[]models.ReaderConnection{
@@ -310,7 +325,8 @@ func TestHandleSettings_ErrorReportingDefault(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -343,7 +359,8 @@ func TestHandleSettings_ErrorReportingEnabled(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -375,7 +392,8 @@ func TestHandleSettingsUpdate_ErrorReportingEnable(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.ErrorReporting(), "errorReporting should start as false")
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	enabled := true
 	params := models.UpdateSettingsParams{
@@ -413,7 +431,8 @@ func TestHandleSettingsUpdate_ErrorReportingDisable(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, cfg.ErrorReporting(), "errorReporting should start as true")
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	disabled := false
 	params := models.UpdateSettingsParams{
@@ -447,7 +466,8 @@ func TestHandleSettingsUpdate_UpdateChannel(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config.UpdateChannelStable, cfg.UpdateChannel())
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	beta := config.UpdateChannelBeta
 	params := models.UpdateSettingsParams{
@@ -482,7 +502,8 @@ func TestHandleSettingsUpdate_ReaderConnectionsWithIDSource(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	params := models.UpdateSettingsParams{
 		ReadersConnect: &[]models.ReaderConnection{
@@ -511,6 +532,96 @@ func TestHandleSettingsUpdate_ReaderConnectionsWithIDSource(t *testing.T) {
 	assert.Equal(t, "uid", readers[0].IDSource)
 }
 
+// TestHandleSettings_ReaderConnectionsEnabled tests that the enabled field
+// is passed through in the settings response.
+func TestHandleSettings_ReaderConnectionsEnabled(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	f := false
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{
+		Readers: config.Readers{
+			Connect: []config.ReadersConnect{
+				{Driver: "pn532"},
+				{Driver: "externaldrive", Enabled: &f},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Params:   []byte(`{}`),
+	}
+
+	result, err := HandleSettings(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.SettingsResponse)
+	require.True(t, ok)
+
+	require.Len(t, resp.ReadersConnect, 2)
+	assert.Nil(t, resp.ReadersConnect[0].Enabled)
+	require.NotNil(t, resp.ReadersConnect[1].Enabled)
+	assert.False(t, *resp.ReadersConnect[1].Enabled)
+}
+
+// TestHandleSettingsUpdate_ReaderConnectionsEnabled tests that the enabled
+// field is preserved when updating reader connections via the API.
+func TestHandleSettingsUpdate_ReaderConnectionsEnabled(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	f := false
+	tr := true
+	params := models.UpdateSettingsParams{
+		ReadersConnect: &[]models.ReaderConnection{
+			{Driver: "pn532", Path: "/dev/ttyUSB0"},
+			{Driver: "externaldrive", Enabled: &tr},
+			{Driver: "libnfc", Enabled: &f},
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Params:   paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	readers := cfg.Readers().Connect
+	require.Len(t, readers, 3)
+	assert.Nil(t, readers[0].Enabled, "nil enabled should pass through")
+	require.NotNil(t, readers[1].Enabled)
+	assert.True(t, *readers[1].Enabled, "explicit true should pass through")
+	require.NotNil(t, readers[2].Enabled)
+	assert.False(t, *readers[2].Enabled, "explicit false should pass through")
+}
+
 func TestHandleSettings_LaunchGuardDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -521,7 +632,8 @@ func TestHandleSettings_LaunchGuardDefaults(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -553,7 +665,8 @@ func TestHandleSettingsUpdate_LaunchGuard(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	enabled := true
 	timeout := float32(30)
@@ -612,7 +725,8 @@ func TestHandleSettingsUpdate_PreservesExternalEdits(t *testing.T) {
 	err = os.WriteFile(cfgPath, []byte(content), 0o600) //nolint:gosec // test path
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	// Call HandleSettingsUpdate changing a different field (error_reporting)
 	enabled := true
@@ -648,7 +762,8 @@ func TestHandleSettings_AudioVolumeDefault(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -677,7 +792,8 @@ func TestHandleSettingsUpdate_AudioVolume(t *testing.T) {
 	cfg, err := config.NewConfig(tmpDir, config.Values{})
 	require.NoError(t, err)
 
-	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
 
 	mockPlayer := mocks.NewMockPlayer()
 	mockPlayer.SetupNoOpMock()

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -93,9 +93,16 @@ type ReaderWriteCancelParams struct {
 }
 
 type ReaderConnection struct {
+	Enabled  *bool  `json:"enabled,omitempty"`
 	Driver   string `json:"driver" validate:"required,min=1"`
 	Path     string `json:"path"`
 	IDSource string `json:"idSource,omitempty"`
+}
+
+// IsEnabled returns whether this connection is enabled.
+// nil (omitted) and true both mean enabled; only explicit false disables.
+func (r ReaderConnection) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 type UpdateSettingsParams struct {

--- a/pkg/api/models/params_test.go
+++ b/pkg/api/models/params_test.go
@@ -1,0 +1,63 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestReaderConnection_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rc       ReaderConnection
+		expected bool
+	}{
+		{
+			name:     "nil enabled means enabled (default)",
+			rc:       ReaderConnection{Driver: "pn532"},
+			expected: true,
+		},
+		{
+			name:     "explicit true means enabled",
+			rc:       ReaderConnection{Driver: "pn532", Enabled: boolPtr(true)},
+			expected: true,
+		},
+		{
+			name:     "explicit false means disabled",
+			rc:       ReaderConnection{Driver: "pn532", Enabled: boolPtr(false)},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.rc.IsEnabled())
+		})
+	}
+}

--- a/pkg/config/configreaders.go
+++ b/pkg/config/configreaders.go
@@ -57,9 +57,16 @@ type ScanLaunchGuard struct {
 }
 
 type ReadersConnect struct {
+	Enabled  *bool  `toml:"enabled,omitempty"`
 	Driver   string `toml:"driver"`
 	Path     string `toml:"path,omitempty"`
 	IDSource string `toml:"id_source,omitempty"`
+}
+
+// IsEnabled returns whether this connection is enabled.
+// nil (omitted) and true both mean enabled; only explicit false disables.
+func (r ReadersConnect) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 func (r ReadersConnect) ConnectionString() string {

--- a/pkg/config/configreaders_test.go
+++ b/pkg/config/configreaders_test.go
@@ -354,6 +354,39 @@ func TestIsDriverAutoDetectEnabledNormalization(t *testing.T) {
 	}
 }
 
+func TestReadersConnect_IsEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rc       ReadersConnect
+		expected bool
+	}{
+		{
+			name:     "nil enabled means enabled (default)",
+			rc:       ReadersConnect{Driver: "pn532"},
+			expected: true,
+		},
+		{
+			name:     "explicit true means enabled",
+			rc:       ReadersConnect{Driver: "pn532", Enabled: boolPtr(true)},
+			expected: true,
+		},
+		{
+			name:     "explicit false means disabled",
+			rc:       ReadersConnect{Driver: "pn532", Enabled: boolPtr(false)},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.rc.IsEnabled())
+		})
+	}
+}
+
 func TestReadersConnect_EnabledRoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/configreaders_test.go
+++ b/pkg/config/configreaders_test.go
@@ -22,9 +22,12 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package config
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConnectionStringNormalization(t *testing.T) {
@@ -349,6 +352,86 @@ func TestIsDriverAutoDetectEnabledNormalization(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestReadersConnect_EnabledRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	memFs := afero.NewMemMapFs()
+	configDir := "/config"
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, memFs)
+	require.NoError(t, err)
+
+	// Set connections with mixed enabled states
+	cfg.SetReaderConnections([]ReadersConnect{
+		{Driver: "pn532", Path: "/dev/ttyUSB0"},
+		{Driver: "externaldrive", Enabled: boolPtr(true)},
+		{Driver: "libnfc", Enabled: boolPtr(false)},
+	})
+
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	readers := cfg.Readers().Connect
+	require.Len(t, readers, 3)
+
+	assert.Nil(t, readers[0].Enabled, "nil should survive round-trip")
+	assert.Equal(t, "pn532", readers[0].Driver)
+
+	require.NotNil(t, readers[1].Enabled)
+	assert.True(t, *readers[1].Enabled, "explicit true should survive round-trip")
+	assert.Equal(t, "externaldrive", readers[1].Driver)
+
+	require.NotNil(t, readers[2].Enabled)
+	assert.False(t, *readers[2].Enabled, "explicit false should survive round-trip")
+	assert.Equal(t, "libnfc", readers[2].Driver)
+}
+
+func TestReadersConnect_EnabledFromTOML(t *testing.T) {
+	t.Parallel()
+
+	memFs := afero.NewMemMapFs()
+	configDir := "/config"
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, memFs)
+	require.NoError(t, err)
+
+	// Write config with enabled = true in [[readers.connect]] (matches docs)
+	cfgPath := filepath.Join(configDir, CfgFile)
+	content := `config_schema = 1
+
+[readers]
+auto_detect = true
+
+[[readers.connect]]
+driver = "externaldrive"
+enabled = true
+
+[readers.scan]
+mode = 'tap'
+`
+	err = afero.WriteFile(memFs, cfgPath, []byte(content), 0o600)
+	require.NoError(t, err)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	readers := cfg.Readers().Connect
+	require.Len(t, readers, 1)
+	assert.Equal(t, "externaldrive", readers[0].Driver)
+	require.NotNil(t, readers[0].Enabled, "enabled should be parsed from TOML")
+	assert.True(t, *readers[0].Enabled)
+
+	// Save and verify enabled survives
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	saved, err := afero.ReadFile(memFs, cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(saved), "enabled = true",
+		"enabled = true should survive Load/Save round-trip")
 }
 
 func boolPtr(b bool) *bool {

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -290,7 +290,7 @@ func (r *Reader) Close() error {
 	r.pnd = nil
 	r.mu.Unlock()
 
-	log.Debug().Msgf("closing device: %s", r.conn)
+	log.Debug().Msgf("closing device: %s", r.conn.ConnectionString())
 	err := pnd.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close NFC device: %w", err)

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -77,9 +77,13 @@ func connectReaders(
 	}
 
 	for _, device := range cfg.Readers().Connect {
+		if !device.IsEnabled() {
+			log.Debug().Msgf("config device disabled, skipping: %s", device.ConnectionString())
+			continue
+		}
 		if !isPathConnected(rs, device.Path) &&
 			!helpers.Contains(toConnectStrs(), device.ConnectionString()) {
-			log.Debug().Msgf("config device not connected, adding: %s", device)
+			log.Debug().Msgf("config device not connected, adding: %s", device.ConnectionString())
 			toConnect = append(toConnect, toConnectDevice{
 				connectionString: device.ConnectionString(),
 				device:           device,
@@ -128,14 +132,14 @@ func connectReaders(
 					normalizedIDs[i] = readers.NormalizeDriverID(id)
 				}
 				if helpers.Contains(normalizedIDs, rt) {
-					log.Debug().Msgf("connecting to reader: %s", device)
+					log.Debug().Msgf("connecting to reader: %s", device.connectionString)
 					err := r.Open(device.device, iq, readers.OpenOpts{})
 					if err != nil {
 						log.Warn().Msgf("error opening reader: %s", err)
 						continue
 					}
 					st.SetReader(r)
-					log.Info().Msgf("opened reader: %s", device)
+					log.Info().Msgf("opened reader: %s", device.connectionString)
 					break
 				}
 			}

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -23,12 +23,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -670,6 +673,66 @@ func TestReaderErrorRecovery_PrevTokenPreservation(t *testing.T) {
 				"prevToken should match expected value after Process")
 		})
 	}
+}
+
+// TestConnectReaders_SkipsDisabledEntries verifies that connectReaders
+// does not attempt to open readers whose Enabled field is explicitly false.
+func TestConnectReaders_SkipsDisabledEntries(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	enabledReader := mocks.NewMockReader()
+	enabledReader.On("Metadata").Return(readers.DriverMetadata{
+		ID:             "pn532",
+		DefaultEnabled: true,
+	})
+	enabledReader.On("IDs").Return([]string{"pn532"})
+	enabledReader.On("Open", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	enabledReader.On("ReaderID").Return("pn532-abc").Maybe()
+	enabledReader.On("Connected").Return(true).Maybe()
+	enabledReader.On("Path").Return("/dev/ttyUSB0").Maybe()
+	enabledReader.On("Info").Return("PN532").Maybe()
+	enabledReader.On("Capabilities").Return([]readers.Capability{}).Maybe()
+
+	mockPlatform.On("SupportedReaders", mock.Anything).Return([]readers.Reader{enabledReader})
+
+	f := false
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg.SetReaderConnections([]config.ReadersConnect{
+		{Driver: "pn532", Path: "/dev/ttyUSB0"},
+		{Driver: "pn532", Path: "/dev/ttyUSB1", Enabled: &f},
+	})
+
+	st, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() {
+		st.StopService()
+		for {
+			select {
+			case <-ns:
+			default:
+				return
+			}
+		}
+	})
+
+	iq := make(chan readers.Scan, 10)
+	err = connectReaders(mockPlatform, cfg, st, iq, nil)
+	require.NoError(t, err)
+
+	// The enabled reader should have been opened with the first connection
+	enabledReader.AssertCalled(t, "Open",
+		config.ReadersConnect{Driver: "pn532", Path: "/dev/ttyUSB0"},
+		mock.Anything, mock.Anything,
+	)
+
+	// The disabled connection should NOT have triggered an Open call
+	enabledReader.AssertNotCalled(t, "Open",
+		config.ReadersConnect{Driver: "pn532", Path: "/dev/ttyUSB1", Enabled: &f},
+		mock.Anything, mock.Anything,
+	)
 }
 
 // TestReaderErrorRecovery_FullSequence simulates the complete sequence from

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -703,7 +703,7 @@ func buildReaderEditPage(
 		if !enabledVal {
 			f := false
 			reader.Enabled = &f
-		} else if isNew {
+		} else if reader.Enabled != nil && !*reader.Enabled {
 			reader.Enabled = nil
 		}
 

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -531,6 +531,9 @@ func buildReaderListPage(
 			if reader.Path != "" {
 				display += ":" + reader.Path
 			}
+			if !reader.IsEnabled() {
+				display += " (disabled)"
+			}
 			secondary := ""
 			if reader.IDSource != "" {
 				t := CurrentTheme()
@@ -676,12 +679,33 @@ func buildReaderEditPage(
 	SetInputLabel(idSourceInput, "ID Source")
 	setupInputFieldFocus(idSourceInput)
 
+	enabledVal := reader.Enabled == nil || *reader.Enabled
+	enabledDisplay := tview.NewTextView().SetDynamicColors(true)
+	updateEnabledDisplay := func() {
+		t := CurrentTheme()
+		label := "Yes"
+		if !enabledVal {
+			label = "No"
+		}
+		enabledDisplay.SetText(fmt.Sprintf(
+			"[%s::b]Enabled:[-::-] < %s >",
+			t.LabelColorName, label,
+		))
+	}
+	updateEnabledDisplay()
+
 	buttonBar := NewButtonBar(app)
 
 	buttonBar.AddButtonWithHelp("Save", "Save reader configuration", func() {
 		reader.Driver = availableDrivers[driverIndex]
 		reader.Path = pathInput.GetText()
 		reader.IDSource = idSourceInput.GetText()
+		if !enabledVal {
+			f := false
+			reader.Enabled = &f
+		} else if isNew {
+			reader.Enabled = nil
+		}
 
 		if isNew || index >= len(*readers) {
 			*readers = append(*readers, reader)
@@ -715,8 +739,9 @@ func buildReaderEditPage(
 	formContent.AddItem(driverDisplay, 1, 0, true)
 	formContent.AddItem(pathInput, 1, 0, false)
 	formContent.AddItem(idSourceInput, 1, 0, false)
+	formContent.AddItem(enabledDisplay, 1, 0, false)
 
-	focusOrder := []tview.Primitive{driverDisplay, pathInput, idSourceInput, buttonBar.GetFirstButton()}
+	focusOrder := []tview.Primitive{driverDisplay, pathInput, idSourceInput, enabledDisplay, buttonBar.GetFirstButton()}
 
 	setFocus := func(idx int) {
 		if idx < 0 {
@@ -818,8 +843,30 @@ func buildReaderEditPage(
 		return event
 	})
 
+	enabledDisplay.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		key := event.Key()
+		if key == tcell.KeyLeft || key == tcell.KeyRight {
+			enabledVal = !enabledVal
+			updateEnabledDisplay()
+			return nil
+		}
+		if key == tcell.KeyDown || key == tcell.KeyEnter || key == tcell.KeyTab {
+			setFocus(4)
+			return nil
+		}
+		if key == tcell.KeyUp || key == tcell.KeyBacktab {
+			setFocus(2)
+			return nil
+		}
+		if key == tcell.KeyEscape {
+			goBack()
+			return nil
+		}
+		return event
+	})
+
 	buttonBar.SetOnUp(func() {
-		setFocus(2) // idSourceInput
+		setFocus(3) // enabledDisplay
 	})
 	buttonBar.SetOnDown(func() {
 		setFocus(0) // driverDisplay (wrap)


### PR DESCRIPTION
- Add `Enabled *bool` to `ReadersConnect` and `ReaderConnection` API model so `enabled = true` in `[[readers.connect]]` is no longer silently dropped by the TOML round-trip
- Add `IsEnabled()` helper on both structs to centralize the nil-means-true semantics
- Skip disabled entries in `connectReaders` and show "(disabled)" in the TUI reader list
- Add enabled toggle (left/right cycling) to the TUI reader edit form
- Fix pre-existing govet warnings where structs were passed to `%s` format verbs in reader logging
- Document the `enabled` field in the API docs Reader connection object table

Refs #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reader connections can be individually enabled/disabled via settings.
  * Disabled reader connections are skipped during connection attempts.
  * Reader list shows "(disabled)" next to disabled entries.
  * Reader settings page lets you toggle enabled/disabled per connection.

* **Documentation**
  * Reader connection docs updated with new optional "enabled" field.

* **Tests**
  * Added tests covering enabled/disabled behavior and API/config round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->