### PR TITLE
fix(helpers): resolve fuzz crashes in DecodeURIIfNeeded and FilenameFromPath

### DIFF
--- a/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/2f33ed11876b7a01
+++ b/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/2f33ed11876b7a01
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("https://000000/0000%80")

--- a/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/4ec218b9e58eabec
+++ b/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/4ec218b9e58eabec
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("steAm://%/%2F")

--- a/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/5e5f04a1d77ed26a
+++ b/pkg/helpers/testdata/fuzz/FuzzDecodeURIIfNeeded/5e5f04a1d77ed26a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("steAm:///%//")

--- a/pkg/helpers/testdata/fuzz/FuzzFilenameFromPath/c8a94dd46f34b25f
+++ b/pkg/helpers/testdata/fuzz/FuzzFilenameFromPath/c8a94dd46f34b25f
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("//")

--- a/pkg/helpers/uris.go
+++ b/pkg/helpers/uris.go
@@ -74,17 +74,19 @@ func DecodeURIIfNeeded(uri string) string {
 
 	// Handle Zaparoo custom virtual paths
 	if shared.IsCustomScheme(schemeLower) {
-		result, err := virtualpath.ParseVirtualPathStr(uri)
-		if err != nil {
-			log.Debug().Err(err).Str("uri", uri).Msg("failed to parse custom scheme URI, using as-is")
-			return uri
+		// Decode each path segment independently to preserve unencoded
+		// slash structure while decoding percent-encoded characters.
+		rest := strings.TrimRight(parsed.Rest, "/")
+		segments := strings.Split(rest, "/")
+		for i, seg := range segments {
+			decoded, err := url.PathUnescape(seg)
+			if err == nil && utf8.ValidString(decoded) {
+				// Re-encode any slashes from %2F so they don't become
+				// structural separators on subsequent passes
+				segments[i] = strings.ReplaceAll(decoded, "/", "%2F")
+			}
 		}
-		// Reconstruct with decoded name
-		reconstructed := result.Scheme + "://" + result.ID
-		if result.Name != "" {
-			reconstructed += "/" + result.Name
-		}
-		// Query params preserved (fragments are kept as part of query if present)
+		reconstructed := parsed.Scheme + "://" + strings.Join(segments, "/")
 		if parsed.Query != "" {
 			reconstructed += "?" + parsed.Query
 		}
@@ -187,9 +189,9 @@ func DecodeURIIfNeeded(uri string) string {
 		decodedPath := pathPart
 		if pathPart != "" {
 			decoded, err := url.PathUnescape(pathPart)
-			if err == nil {
+			if err == nil && utf8.ValidString(decoded) {
 				decodedPath = decoded
-			} else {
+			} else if err != nil {
 				log.Debug().Err(err).Str("uri", uri).Msg("failed to decode web URI path, using as-is")
 			}
 		}
@@ -291,7 +293,7 @@ func FilenameFromPath(p string) string {
 					}
 					// Decode URL encoding and return with extension intact
 					decoded, err := url.PathUnescape(lastSegment)
-					if err == nil {
+					if err == nil && utf8.ValidString(decoded) {
 						return decoded
 					}
 				}
@@ -306,6 +308,9 @@ func FilenameFromPath(p string) string {
 	// Replace backslashes with forward slashes to handle Windows paths on any OS
 	normalizedPath := strings.ReplaceAll(p, "\\", "/")
 	b := path.Base(normalizedPath)
+	if b == "/" || b == "." {
+		return ""
+	}
 	e := path.Ext(normalizedPath)
 	if !IsValidExtension(e) {
 		e = ""

--- a/pkg/helpers/uris_test.go
+++ b/pkg/helpers/uris_test.go
@@ -39,7 +39,7 @@ func TestDecodeURIIfNeeded(t *testing.T) {
 		{
 			name:     "steam_with_url_encoding",
 			input:    "steam://123/Super%20Hot%2FCold",
-			expected: "steam://123/Super Hot/Cold",
+			expected: "steam://123/Super Hot%2FCold",
 		},
 		{
 			name:     "kodi_movie_with_url_encoding",

--- a/pkg/helpers/virtualpath/virtualpath.go
+++ b/pkg/helpers/virtualpath/virtualpath.go
@@ -174,8 +174,8 @@ func ParseVirtualPathStr(virtualPath string) (VirtualPathResult, error) {
 	}
 
 	if len(idAndName) == 2 {
-		// Remove trailing slash
-		namePart := strings.TrimSuffix(idAndName[1], "/")
+		// Remove trailing slashes
+		namePart := strings.TrimRight(idAndName[1], "/")
 		if namePart != "" {
 			decoded, err := decodePathComponent(namePart)
 			if err != nil {


### PR DESCRIPTION
## Summary

- Fix `DecodeURIIfNeeded` producing invalid UTF-8 when `url.PathUnescape` decodes bytes like `%80` to non-UTF-8 sequences
- Fix `DecodeURIIfNeeded` idempotence failures for custom schemes by decoding path segments individually, preserving unencoded slash structure while re-encoding decoded `%2F`
- Fix `FilenameFromPath` returning `"/"` for inputs like `"//"` where `path.Base` returns a separator
- Fix `ParseVirtualPathStr` inconsistent trailing slash handling (`TrimSuffix` → `TrimRight`)
- Add crash corpus files from nightly fuzz runs as regression tests

Fixes #675, fixes #667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fuzz test cases for URI decoding and filename extraction functions.

* **Bug Fixes**
  * Improved URI decoding for custom schemes with enhanced UTF-8 validation and character normalization.
  * Strengthened filename extraction from URLs with stricter UTF-8 validation.
  * Fixed path normalization to correctly handle multiple trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->