### PR TITLE
fix(mediascanner): skip macOS junk files and throttle indexing notifications

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -301,6 +301,9 @@ func GenerateMediaDB(
 		defer db.MediaDB.BackgroundOperationDone()
 		defer debug.FreeOSMemory()
 
+		var lastNotifTime time.Time
+		const notifThrottleInterval = 250 * time.Millisecond
+
 		total, err := mediascanner.NewNamesIndex(indexCtx, pl, cfg, systems, db, func(status mediascanner.IndexStatus) {
 			var desc string
 			switch {
@@ -323,6 +326,8 @@ func GenerateMediaDB(
 					}
 				}
 			}
+
+			// Always update in-memory status for polling clients.
 			statusInstance.set(indexingStatusVals{
 				indexing:    true,
 				totalSteps:  status.Total,
@@ -330,6 +335,19 @@ func GenerateMediaDB(
 				currentDesc: desc,
 				totalFiles:  status.Files,
 			})
+
+			// Throttle WebSocket push notifications to prevent
+			// channel overflow during bursts (e.g. resume skipping
+			// many completed systems). Phase changes and the final
+			// step are always sent so clients see start/end.
+			now := time.Now()
+			isPhaseChange := status.Phase == mediascanner.PhaseDiscovering ||
+				status.Phase == mediascanner.PhaseInitializing
+			isFinalStep := status.Step == status.Total
+			if !isPhaseChange && !isFinalStep && now.Sub(lastNotifTime) < notifThrottleInterval {
+				return
+			}
+			lastNotifTime = now
 
 			notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 				Exists:             false,

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -386,11 +386,29 @@ func GetFiles(
 		}
 
 		if d.IsDir() {
+			dirName := filepath.Base(p)
+			// Skip macOS metadata directories and hidden directories.
+			// __MACOSX contains Apple resource fork files that are not
+			// real archives. Dot-prefixed directories are OS metadata
+			// that never contain game ROMs. The walk root is exempt so
+			// that a user-configured dot-prefixed folder still works.
+			if p != path && (dirName == "__MACOSX" || dirName[0] == '.') {
+				return filepath.SkipDir
+			}
+
 			markerPath := filepath.Join(p, ".zaparooignore")
 			if _, statErr := statWithContext(ctx, markerPath); statErr == nil {
 				log.Info().Str("path", p).Msg("skipping directory with .zaparooignore marker")
 				return filepath.SkipDir
 			}
+			return nil
+		}
+
+		// Skip macOS AppleDouble resource fork files before the zip
+		// check — they carry valid-looking extensions (.zip etc.) but
+		// are not real archives.
+		baseName := filepath.Base(p)
+		if len(baseName) >= 2 && baseName[0] == '.' && baseName[1] == '_' {
 			return nil
 		}
 
@@ -441,13 +459,25 @@ func GetFiles(
 			Msg("directory walk found entries but no files matched any launcher")
 	}
 
-	if walkElapsed > 15*time.Second {
-		log.Warn().
-			Str("system", systemID).
-			Str("path", path).
-			Int64("entriesScanned", scanned).
-			Dur("elapsed", walkElapsed).
-			Msg("directory walk took longer than expected - large directory or slow storage")
+	// Warn when the walk rate is slow rather than when absolute elapsed
+	// time is high. A 33K-entry directory legitimately takes ~19s on
+	// MiSTer ARM + USB 2.0; only warn when the filesystem is genuinely
+	// sluggish (< 500 entries/sec sustained over at least 5 seconds).
+	const (
+		minSlowWalkElapsed = 5 * time.Second
+		minEntriesPerSec   = 500.0
+	)
+	if walkElapsed > minSlowWalkElapsed && scanned > 0 {
+		rate := float64(scanned) / walkElapsed.Seconds()
+		if rate < minEntriesPerSec {
+			log.Warn().
+				Str("system", systemID).
+				Str("path", path).
+				Int64("entriesScanned", scanned).
+				Dur("elapsed", walkElapsed).
+				Float64("entriesPerSec", rate).
+				Msg("directory walk is slow - possible stale mount or degraded storage")
+		}
 	}
 
 	return results, nil

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2111,3 +2111,165 @@ func TestNewNamesIndex_PausesAndResumes(t *testing.T) {
 		t.Fatal("indexing did not complete after resume")
 	}
 }
+
+// TestGetFiles_SkipsMacOSDirectories verifies that __MACOSX directories are
+// completely skipped during the directory walk, preventing wasted I/O on
+// Apple resource fork files that masquerade as valid zip archives.
+func TestGetFiles_SkipsMacOSDirectories(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+
+	rootDir := t.TempDir()
+
+	// Create a real game file
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "game.nes"), []byte("data"), 0o600))
+
+	// Create a __MACOSX directory with a fake .nes file inside
+	macDir := filepath.Join(rootDir, "__MACOSX")
+	require.NoError(t, os.MkdirAll(macDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(macDir, "._game.nes"), []byte("apple"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(macDir, "ghost.nes"), []byte("apple"), 0o600))
+
+	launcher := platforms.Launcher{
+		ID:         "nes-launcher",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{rootDir},
+		Extensions: []string{".nes"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemNES, rootDir)
+	require.NoError(t, err)
+
+	assert.Len(t, files, 1, "should only find the real game file")
+	assert.Equal(t, filepath.Join(rootDir, "game.nes"), files[0])
+}
+
+// TestGetFiles_SkipsDotDirectories verifies that hidden directories (starting
+// with .) are skipped during the walk. These include .Spotlight-V100, .Trashes,
+// .fseventsd, etc.
+func TestGetFiles_SkipsDotDirectories(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+
+	rootDir := t.TempDir()
+
+	// Create a real game file
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "zelda.nes"), []byte("data"), 0o600))
+
+	// Create hidden directories with files that would match
+	for _, dir := range []string{".Spotlight-V100", ".Trashes", ".fseventsd"} {
+		hiddenDir := filepath.Join(rootDir, dir)
+		require.NoError(t, os.MkdirAll(hiddenDir, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(hiddenDir, "fake.nes"), []byte("data"), 0o600))
+	}
+
+	launcher := platforms.Launcher{
+		ID:         "nes-launcher",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{rootDir},
+		Extensions: []string{".nes"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemNES, rootDir)
+	require.NoError(t, err)
+
+	assert.Len(t, files, 1, "should only find the real game file, not files in hidden dirs")
+	assert.Equal(t, filepath.Join(rootDir, "zelda.nes"), files[0])
+}
+
+// TestGetFiles_SkipsAppleDoubleFiles verifies that macOS AppleDouble resource
+// fork files (._Something.zip) are skipped before the zip check, preventing
+// wasted I/O on files that look like zip archives but are not.
+func TestGetFiles_SkipsAppleDoubleFiles(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+
+	rootDir := t.TempDir()
+
+	// Create a real zip with a game inside
+	zipPath := filepath.Join(rootDir, "games.zip")
+	zipFile, err := os.Create(zipPath) //nolint:gosec // test file in t.TempDir()
+	require.NoError(t, err)
+	w := zip.NewWriter(zipFile)
+	fw, createErr := w.Create("game.nes")
+	require.NoError(t, createErr)
+	_, writeErr := fw.Write([]byte("data"))
+	require.NoError(t, writeErr)
+	require.NoError(t, w.Close())
+	require.NoError(t, zipFile.Close())
+
+	// Create an AppleDouble resource fork file with .zip extension.
+	// This is not a valid zip and would cause an error if opened.
+	require.NoError(t, os.WriteFile(filepath.Join(rootDir, "._games.zip"), []byte("apple-resource-fork"), 0o600))
+
+	launcher := platforms.Launcher{
+		ID:         "nes-launcher",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{rootDir},
+		Extensions: []string{".nes"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemNES, rootDir)
+	require.NoError(t, err)
+
+	// Should find only the game inside the real zip, not the ._games.zip
+	assert.Len(t, files, 1, "should find only the game inside the real zip")
+	assert.Contains(t, files[0], "game.nes")
+}


### PR DESCRIPTION
- Skip `__MACOSX` directories, dot-prefixed hidden directories (`.Spotlight-V100`, `.Trashes`, etc.), and AppleDouble resource fork files (`._*`) during the `GetFiles()` directory walk, before the zip check. A user's C64 game pack contained 1,399 `._*.zip` resource forks that were each opened and failed as invalid zips.
- Throttle `MediaIndexing` WebSocket push notifications to max 1 per 250ms in the indexing update callback. During resume, completed systems are skipped rapidly, flooding the 100-buffer broker subscriber channel. In-memory status polling is unaffected (always updated). Phase changes and the final step always send immediately.
- Replace the fixed 15-second slow walk warning threshold with a rate-based check (< 500 entries/sec over 5+ seconds). A 33K-entry C64 directory at ~1,750 entries/sec on MiSTer ARM + USB 2.0 was triggering false positives.
- The primary crash cause in the issue (GOMEMLIMIT=49MB causing GC thrashing) is already fixed on main by 0916b88e.

Closes #677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media library scans now properly exclude macOS-specific metadata directories and hidden dot-prefixed directories
  * AppleDouble resource fork files are filtered out from scan results
  * Scan performance warnings now use rate-based metrics for more accurate reporting

* **Performance**
  * Media indexing notifications have been optimized for improved responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->