### PR TITLE
fix(ci): handle branch protection in contributors workflow and fix Windows test paths

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Contribute List
         uses: akhilmhdh/contributors-readme-action@83ea0b4f1ac928fbfe88b9e8460a932a528eb79f # v2.3.11
         with:
-          auto_detect_branch_protection: false
+          auto_detect_branch_protection: true
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/pkg/helpers/launchers_test.go
+++ b/pkg/helpers/launchers_test.go
@@ -91,11 +91,15 @@ func TestParseCustomLaunchers_NewFields(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
+	// Use t.TempDir() so paths are absolute on all platforms (including Windows)
+	absDir := t.TempDir()
+	mediaDir := filepath.Join(absDir, "media", "videos")
+
 	customLaunchers := []config.LaunchersCustom{
 		{
 			ID:         "TestLauncher",
 			Execute:    "echo [[media_path]]",
-			MediaDirs:  []string{"/media/videos"},
+			MediaDirs:  []string{mediaDir},
 			FileExts:   []string{".mp4", ".mkv"},
 			Groups:     []string{"Video", "MediaPlayers"},
 			Schemes:    []string{"test", "mytest"},
@@ -125,7 +129,7 @@ func TestParseCustomLaunchers_NewFields(t *testing.T) {
 	assert.Equal(t, []string{"test", "mytest"}, launcher1.Schemes)
 	assert.True(t, launcher1.AllowListOnly)
 	assert.Equal(t, platforms.LifecycleFireAndForget, launcher1.Lifecycle)
-	assert.Equal(t, []string{"/media/videos"}, launcher1.Folders)
+	assert.Equal(t, []string{mediaDir}, launcher1.Folders)
 	assert.Equal(t, []string{".mp4", ".mkv"}, launcher1.Extensions)
 
 	// Test second launcher with blocking lifecycle
@@ -222,12 +226,17 @@ func TestParseCustomLaunchers_AbsolutePathWithSystemID(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
+	// Use t.TempDir() so paths are absolute on all platforms (including Windows)
+	absDir := t.TempDir()
+	romsDir := filepath.Join(absDir, "emulation", "roms", "ps2")
+	gamesDir := filepath.Join(absDir, "mnt", "games", "ps2")
+
 	customLaunchers := []config.LaunchersCustom{
 		{
 			ID:        "ps2-custom",
 			System:    "PS2",
 			Execute:   "pcsx2 [[media_path]]",
-			MediaDirs: []string{"/emulation/roms/ps2", "/mnt/games/ps2"},
+			MediaDirs: []string{romsDir, gamesDir},
 			FileExts:  []string{"iso", ".bin", "MDF", " .chd "},
 		},
 	}
@@ -239,7 +248,7 @@ func TestParseCustomLaunchers_AbsolutePathWithSystemID(t *testing.T) {
 
 	assert.Equal(t, "ps2-custom", l.ID)
 	assert.Equal(t, "PS2", l.SystemID, "SystemID should be the canonical ID from LookupSystem")
-	assert.Equal(t, []string{"/emulation/roms/ps2", "/mnt/games/ps2"}, l.Folders,
+	assert.Equal(t, []string{romsDir, gamesDir}, l.Folders,
 		"MediaDirs should map directly to Folders")
 	assert.Equal(t, []string{".iso", ".bin", ".mdf", ".chd"}, l.Extensions,
 		"FileExts should be dot-prefixed and lowercased")


### PR DESCRIPTION
## Summary

- Enable `auto_detect_branch_protection` in the contributors README workflow so it creates a PR instead of failing when pushing directly to the protected main branch
- Use `t.TempDir()` for absolute paths in `TestParseCustomLaunchers_NewFields` and `TestParseCustomLaunchers_AbsolutePathWithSystemID` so they pass on Windows where Unix-style paths like `/media/videos` are not considered absolute

Also closed #682 — fuzz crashes were already fixed by 818f62cd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with dynamic temporary directory setup instead of hard-coded paths.

* **Chores**
  * Enhanced branch protection detection in contributor workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->