### PR TITLE
fix(ci): grant missing permissions for lint-and-test reusable workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      packages: read
+      security-events: write
 
   ensure-zigcc:
     uses: ./.github/workflows/zigcc-build.yml


### PR DESCRIPTION
## Summary

- Add `packages: read` and `security-events: write` to the `lint-and-test` job permissions in `build.yml`, matching what `lint-and-test.yml` declares
- Fixes the tag push workflow failure where GitHub rejected the reusable workflow call because those permissions defaulted to `none`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration permissions to enhance build and security capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->