### PR TITLE
fix(ci): remove lint-and-test from build workflow for SignPath compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,14 +43,6 @@ env:
   BUILD_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
-  lint-and-test:
-    uses: ./.github/workflows/lint-and-test.yml
-    permissions:
-      contents: read
-      pull-requests: read
-      packages: read
-      security-events: write
-
   ensure-zigcc:
     uses: ./.github/workflows/zigcc-build.yml
     permissions:
@@ -92,8 +84,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [lint-and-test, create-release, ensure-zigcc]
-    if: ${{ !cancelled() && needs.lint-and-test.result == 'success' && needs.ensure-zigcc.result == 'success' }}
+    needs: [create-release, ensure-zigcc]
+    if: ${{ !cancelled() && needs.ensure-zigcc.result == 'success' }}
     permissions:
       contents: write # Needed for uploading release assets
       packages: read # Needed for pulling Docker images from ghcr.io


### PR DESCRIPTION
## Summary

- Remove `lint-and-test` reusable workflow call from the release build workflow
- SignPath rejects signing when any job in the artifact chain ran on non-GitHub-hosted runners, and `lint-and-test` uses Ubicloud runners
- Lint and test already runs independently on push to main and on PRs, so it's redundant in the release build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build workflow pipeline configuration to streamline job dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->