### PR TITLE
fix(launchers): log argv after SplitCommand at both call sites

### DIFF
--- a/pkg/helpers/launchers.go
+++ b/pkg/helpers/launchers.go
@@ -197,6 +197,9 @@ func ParseCustomLaunchers(
 					return nil, errors.New("execute command is empty after parsing")
 				}
 
+				log.Debug().Str("launcherID", launcherID).Str("command", output).Strs("argv", parts).
+					Msg("executing custom launcher")
+
 				//nolint:gosec,noctx // User-configured launcher commands, managed via lifecycle
 				cmd := exec.Command(parts[0], parts[1:]...)
 				cmd.Dir = ExeDir()
@@ -208,9 +211,6 @@ func ParseCustomLaunchers(
 				} else {
 					cmd.Env = append(os.Environ(), "ZAPAROO_ENVIRONMENT="+string(envJSON))
 				}
-
-				log.Debug().Str("launcherID", launcherID).Str("command", output).
-					Msg("executing custom launcher")
 
 				if err = cmd.Start(); err != nil {
 					log.Error().Err(err).Msgf("error running custom launcher: %s", output)

--- a/pkg/helpers/launchers_test.go
+++ b/pkg/helpers/launchers_test.go
@@ -304,7 +304,7 @@ func TestParseCustomLaunchers_LaunchLogsArgvAndFailsOnMissingBinary(t *testing.T
 
 	// Calling Launch hits the argv log line then fails at cmd.Start because the
 	// binary does not exist. The error confirms we reached the execution path.
-	_, err = launchers[0].Launch(cfg, "/some/game.bin", nil)
+	_, err = launchers[0].Launch(cfg, filepath.Join("some", "game.bin"), nil)
 	assert.Error(t, err, "expected error for nonexistent binary")
 }
 

--- a/pkg/helpers/launchers_test.go
+++ b/pkg/helpers/launchers_test.go
@@ -283,6 +283,31 @@ func TestParseCustomLaunchers_EmptyExecuteLeavesLaunchNil(t *testing.T) {
 	assert.Nil(t, l.Launch, "Launch should be nil when Execute is empty")
 }
 
+func TestParseCustomLaunchers_LaunchLogsArgvAndFailsOnMissingBinary(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test")
+
+	customLaunchers := []config.LaunchersCustom{
+		{
+			ID:      "TestExec",
+			Execute: "nonexistent-binary-zaparoo-test [[media_path]]",
+		},
+	}
+
+	launchers := ParseCustomLaunchers(mockPlatform, customLaunchers)
+	require.Len(t, launchers, 1)
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{})
+	require.NoError(t, err)
+
+	// Calling Launch hits the argv log line then fails at cmd.Start because the
+	// binary does not exist. The error confirms we reached the execution path.
+	_, err = launchers[0].Launch(cfg, "/some/game.bin", nil)
+	assert.Error(t, err, "expected error for nonexistent binary")
+}
+
 func TestFormatExtensions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/helpers/shellsplit_test.go
+++ b/pkg/helpers/shellsplit_test.go
@@ -310,6 +310,44 @@ func TestSplitCommand(t *testing.T) {
 			input: `echo "hello"""`,
 			want:  []string{"echo", `hello"`},
 		},
+		// Windows DuckStation-style launcher: reporter wrapped [[media_path]] in '"..."' expecting
+		// the double-quotes to survive into PowerShell -ArgumentList. SplitCommand correctly
+		// preserves the literal " chars (single-quote group keeps them), but PowerShell
+		// subsequently evaluates "D:\..." as a double-quoted string literal and strips the outer
+		// ", leaving an unquoted path that Windows re-splits on spaces — yielding "Unknown
+		// parameter: '-'". This case pins the current SplitCommand output so any future change
+		// must explicitly acknowledge the downstream quoting impact.
+		{
+			name: "Windows PS Start-Process: single-quoted double-quoted path (current behaviour)",
+			input: `powershell -Command Start-Process -FilePath duckstation.exe ` +
+				`-ArgumentList '"D:\path with spaces\game.bin"'`,
+			want: []string{
+				"powershell", "-Command", "Start-Process", "-FilePath", "duckstation.exe",
+				"-ArgumentList", `"D:\path with spaces\game.bin"`,
+			},
+		},
+		// Fix 1: drop PowerShell entirely. Direct exe with a double-quoted path. SplitCommand
+		// strips the " group markers and returns the bare path as a single token; Go re-quotes
+		// it correctly for Windows argv parsing, so the program receives the full path intact.
+		{
+			name:  "Windows direct exe with quoted path (fix: no nested shell)",
+			input: `"D:\Emulation\duckstation.exe" "D:\path with spaces\game.bin"`,
+			want:  []string{`D:\Emulation\duckstation.exe`, `D:\path with spaces\game.bin`},
+		},
+		// Fix 2: keep PowerShell, use the & call operator. The entire PS script is wrapped in
+		// a single double-quoted token, so SplitCommand delivers it as one argv entry. PS
+		// receives the script text via -Command and invokes & with the path as a single-quoted
+		// PS string, which PS quotes correctly for the child without a Start-Process re-parse.
+		{
+			name: "Windows PS with & call operator: -Command script as single argv token (fix)",
+			input: `powershell -WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass ` +
+				`-Command "& 'D:\Emulation\duckstation.exe' 'D:\path with spaces\game.bin'"`,
+			want: []string{
+				"powershell", "-WindowStyle", "Hidden", "-NoProfile",
+				"-ExecutionPolicy", "Bypass",
+				"-Command", `& 'D:\Emulation\duckstation.exe' 'D:\path with spaces\game.bin'`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/utils.go
+++ b/pkg/zapscript/utils.go
@@ -98,6 +98,8 @@ func cmdExecute(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, errors.New("execute command is empty")
 	}
 
+	log.Debug().Str("command", execStr).Strs("argv", tokenArgs).Msg("executing zapscript command")
+
 	ctx, cancel := context.WithTimeout(context.Background(), ExecuteTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## Summary

- Adds `Strs("argv", parts)` to the debug log in the custom launcher closure (`pkg/helpers/launchers.go`) so the post-split argument vector is visible in logs alongside the raw command string
- Adds the equivalent log in `cmdExecute` (`pkg/zapscript/utils.go`) so ZapScript `**execute` commands get the same visibility
- Pins three `SplitCommand` test cases covering the Windows PowerShell `Start-Process` quoting pattern that produced the DuckStation `Unknown parameter: '-'` failure report, plus both working template alternatives

The argv log makes the quoting failure immediately diagnosable: the new log line shows each token separately, so a reporter can see at a glance whether their path is being split where it shouldn't be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Windows/PowerShell command-parsing coverage with additional scenarios and a new test validating launcher execution path when a binary cannot be started.

* **Chores**
  * Improved debug logging around custom launcher and command execution to include richer diagnostic details for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->