### PR TITLE
fix(mediascanner): fix media index hang on resume from interrupted run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ For architecture details, API reference, and key concepts: [docs/ARCHITECTURE.md
 - Keep diffs small and focused — one concern per change
 - Use file-scoped commands for faster feedback over full-suite runs
 - Reference existing patterns before writing new code
-- Use `filepath.Join` for path construction — cross-platform compatibility
+- Use `filepath.Join` for path construction everywhere, including test files — never hardcode POSIX-style paths like `"/roms/snes/game.sfc"` as string literals
 - Use afero for filesystem operations in testable code
 - NEVER use `sync.Mutex`/`sync.RWMutex` — use `syncutil.Mutex`/`syncutil.RWMutex` (forbidigo linter enforces this)
 - NEVER use standard `log` or `fmt.Println` — use zerolog (depguard enforces this)

--- a/pkg/database/mediadb/batch_inserter.go
+++ b/pkg/database/mediadb/batch_inserter.go
@@ -142,6 +142,8 @@ func (b *BatchInserter) Flush() error {
 				Msg("flushing dependency batch before child")
 		}
 		if err := dep.Flush(); err != nil {
+			b.buffer = b.buffer[:0]
+			b.currentCount = 0
 			return fmt.Errorf("failed to flush dependency for %s: %w: %w", b.tableName, ErrDependencyFlush, err)
 		}
 	}

--- a/pkg/database/mediadb/batch_inserter.go
+++ b/pkg/database/mediadb/batch_inserter.go
@@ -29,6 +29,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// ErrDependencyFlush is returned by Flush when a dependency batch inserter fails.
+// Callers can detect this via errors.Is to distinguish a parent-table flush failure
+// from a local constraint violation.
+var ErrDependencyFlush = errors.New("dependency flush failed")
+
 // BatchInserter manages batched multi-row inserts for a specific table
 type BatchInserter struct {
 	ctx            context.Context
@@ -137,18 +142,18 @@ func (b *BatchInserter) Flush() error {
 				Msg("flushing dependency batch before child")
 		}
 		if err := dep.Flush(); err != nil {
-			return fmt.Errorf("failed to flush dependency for %s: %w", b.tableName, err)
+			return fmt.Errorf("failed to flush dependency for %s: %w: %w", b.tableName, ErrDependencyFlush, err)
 		}
 	}
 
 	// Reuse cached statement for full-batch flushes (the common case)
 	if b.currentCount == b.cachedRowCount && b.cachedStmt != nil {
 		_, err := b.cachedStmt.ExecContext(b.ctx, b.buffer[:b.currentCount*b.columnCount]...)
+		b.buffer = b.buffer[:0]
+		b.currentCount = 0
 		if err != nil {
 			return fmt.Errorf("batch insert failed for table %s: %w", b.tableName, err)
 		}
-		b.buffer = b.buffer[:0]
-		b.currentCount = 0
 		return nil
 	}
 
@@ -180,12 +185,11 @@ func (b *BatchInserter) Flush() error {
 	}
 
 	_, err = stmt.ExecContext(b.ctx, b.buffer[:b.currentCount*b.columnCount]...)
+	b.buffer = b.buffer[:0]
+	b.currentCount = 0
 	if err != nil {
 		return fmt.Errorf("batch insert failed for table %s: %w", b.tableName, err)
 	}
-
-	b.buffer = b.buffer[:0]
-	b.currentCount = 0
 	return nil
 }
 
@@ -220,6 +224,8 @@ func (b *BatchInserter) flushChunked() error {
 
 		// Execute chunk (extracted to separate function to satisfy both sqlclosecheck and revive linters)
 		if err := b.executeChunk(chunkSize, chunkBuffer); err != nil {
+			b.buffer = b.buffer[:0]
+			b.currentCount = 0
 			return err
 		}
 
@@ -271,6 +277,8 @@ func (b *BatchInserter) flushSingleRow() error {
 	singleRowSQL := b.generateSingleRowInsertSQL()
 	stmt, err := b.tx.PrepareContext(b.ctx, singleRowSQL)
 	if err != nil {
+		b.buffer = b.buffer[:0]
+		b.currentCount = 0
 		return fmt.Errorf("failed to prepare single-row fallback insert: %w", err)
 	}
 	defer func() {
@@ -290,6 +298,8 @@ func (b *BatchInserter) flushSingleRow() error {
 				Int("row", i).
 				Msg("failed to insert row in fallback mode")
 			// Fail fast on any error to prevent silent data inconsistencies.
+			b.buffer = b.buffer[:0]
+			b.currentCount = 0
 			return fmt.Errorf("unrecoverable error during single-row fallback on row %d: %w", i, err)
 		}
 	}

--- a/pkg/database/mediadb/batch_inserter_test.go
+++ b/pkg/database/mediadb/batch_inserter_test.go
@@ -700,3 +700,62 @@ func TestBatchInserter_MultipleDependencies(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
 }
+
+// TestBatchInserter_BufferResetOnFlushFailure verifies that when a batch flush fails
+// (e.g. UNIQUE constraint), the buffer is reset so subsequent Add calls don't
+// re-trigger the same failing flush on every call.
+func TestBatchInserter_BufferResetOnFlushFailure(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE t (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	// Pre-insert row 1 (committed) so it conflicts with anything that tries to
+	// re-insert id=1.
+	_, err = db.ExecContext(ctx, `INSERT INTO t VALUES (1)`)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	// batchSize=2: the second Add triggers an auto-flush.
+	bi, err := NewBatchInserter(ctx, tx, "t", []string{"id"}, 2)
+	require.NoError(t, err)
+
+	// Add(2): count=1, no flush yet.
+	require.NoError(t, bi.Add(int64(2)))
+
+	// Add(1): count=2 → auto-flush → INSERT (2, 1) → UNIQUE fail on id=1.
+	// Error should be returned; buffer must be reset.
+	flushErr := bi.Add(int64(1))
+	require.Error(t, flushErr, "flush should fail: UNIQUE constraint on id=1")
+	require.Contains(t, flushErr.Error(), "batch insert failed")
+
+	// Buffer reset: Flush with nothing queued should be a no-op.
+	require.NoError(t, bi.Flush(), "Flush on empty buffer should be a no-op")
+
+	// Subsequent Add should not re-trigger the old failing rows.
+	require.NoError(t, bi.Add(int64(3)))
+	require.NoError(t, bi.Flush(), "Flush of row 3 only should succeed")
+
+	// Commit and confirm: pre-existing row 1 and newly inserted row 3; row 2
+	// was in the failed batch and must NOT be present.
+	require.NoError(t, tx.Commit())
+
+	var ids []int
+	rows, err := db.QueryContext(ctx, "SELECT id FROM t ORDER BY id")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id int
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []int{1, 3}, ids, "only pre-existing 1 and newly added 3 should be present")
+}

--- a/pkg/database/mediadb/batch_inserter_test.go
+++ b/pkg/database/mediadb/batch_inserter_test.go
@@ -759,3 +759,66 @@ func TestBatchInserter_BufferResetOnFlushFailure(t *testing.T) {
 	require.NoError(t, rows.Err())
 	assert.Equal(t, []int{1, 3}, ids, "only pre-existing 1 and newly added 3 should be present")
 }
+
+// TestBatchInserter_BufferResetOnDependencyFlushFailure verifies that when a parent
+// (dependency) batch fails to flush, the child's buffer is also cleared so that
+// subsequent Add calls don't replay the poisoned rows.
+func TestBatchInserter_BufferResetOnDependencyFlushFailure(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:?_foreign_keys=ON")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	_, err = db.ExecContext(ctx, `CREATE TABLE parent (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE child (
+			id        INTEGER PRIMARY KEY,
+			parent_id INTEGER NOT NULL,
+			FOREIGN KEY (parent_id) REFERENCES parent(id)
+		)`)
+	require.NoError(t, err)
+
+	// Pre-insert parent row 10 (committed) so any batch that re-inserts id=10 will
+	// UNIQUE-fail.
+	_, err = db.ExecContext(ctx, `INSERT INTO parent VALUES (10)`)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	// parentBI batchSize=3: two Adds queue without auto-flushing, so the parent
+	// buffer is still populated when childBI.Flush() triggers dep.Flush().
+	parentBI, err := NewBatchInserter(ctx, tx, "parent", []string{"id"}, 3)
+	require.NoError(t, err)
+
+	// childBI batchSize=10: won't auto-flush within this test.
+	childBI, err := NewBatchInserter(ctx, tx, "child", []string{"id", "parent_id"}, 10)
+	require.NoError(t, err)
+	childBI.SetDependencies(parentBI)
+
+	// Queue two parent rows (id=20 ok, id=10 conflicts with the pre-inserted row).
+	// Neither Add auto-flushes because batchSize=3.
+	require.NoError(t, parentBI.Add(int64(20)))
+	require.NoError(t, parentBI.Add(int64(10)))
+
+	// Queue a child row that references parent id=20.
+	require.NoError(t, childBI.Add(int64(1), int64(20)))
+
+	// childBI.Flush() calls dep (parentBI).Flush() first. The parent INSERT contains
+	// id=10, which UNIQUE-conflicts → dep.Flush() fails → childBI must return
+	// ErrDependencyFlush and must clear its own buffer (Finding 1 fix).
+	childFlushErr := childBI.Flush()
+	require.Error(t, childFlushErr)
+	require.ErrorIs(t, childFlushErr, ErrDependencyFlush, "child flush error must wrap ErrDependencyFlush")
+
+	// Child buffer cleared: a second Flush must be a no-op (currentCount==0).
+	require.NoError(t, childBI.Flush(), "second Flush on empty child buffer must be a no-op")
+
+	// Add a new child row; currentCount must be 1 (not 2) — no old poisoned row carried over.
+	require.NoError(t, childBI.Add(int64(99), int64(10)))
+	require.Equal(t, 1, childBI.currentCount,
+		"child buffer must contain only the new row, not the previously-failed one")
+}

--- a/pkg/database/mediascanner/batch_resume_test.go
+++ b/pkg/database/mediascanner/batch_resume_test.go
@@ -586,3 +586,99 @@ func TestBatchMode_DuplicateDetection(t *testing.T) {
 		assert.Equal(t, 1, count, "Should still have exactly one media entry")
 	})
 }
+
+// TestResumeTruncatesPartialSystem verifies that truncating the partially-indexed
+// lastIndexedSystem before re-processing it allows the resume to complete without
+// UNIQUE constraint violations.
+//
+// Scenario reproduced here:
+//  1. Index 5 of a system's 10 files and commit (simulating a mid-system commit
+//     that sets lastIndexedSystemID).
+//  2. Simulate resume: truncate the system, re-populate scanState from DB (now empty
+//     for this system), then re-index all 10 files.
+//  3. Assert no errors and that Media rows == total files for the system (not doubled).
+func TestResumeTruncatesPartialSystem(t *testing.T) {
+	sqlDB, err := sql.Open("sqlite3", ":memory:?_foreign_keys=ON")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	ctx := context.Background()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+
+	mediaDB := &mediadb.MediaDB{}
+	err = mediaDB.SetSQLForTesting(ctx, sqlDB, mockPlatform)
+	require.NoError(t, err)
+
+	const systemID = "NES"
+	const totalFiles = 10
+	const partialFiles = 5 // files committed in the "interrupted" first run
+
+	allEntries := testdata.CreateReproducibleBatch([]string{systemID}, totalFiles).Entries[systemID]
+	require.Len(t, allEntries, totalFiles)
+
+	// Shared base scan state (tags, etc.)
+	baseState := &database.ScanState{
+		SystemIDs:  make(map[string]int),
+		TitleIDs:   make(map[string]int),
+		MediaIDs:   make(map[string]int),
+		TagTypeIDs: make(map[string]int),
+		TagIDs:     make(map[string]int),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, baseState))
+
+	// Step 1: index the first partialFiles and commit (interrupted mid-system run).
+	firstRunState := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		TagTypeIDs:    baseState.TagTypeIDs,
+		TagIDs:        baseState.TagIDs,
+		TagTypesIndex: baseState.TagTypesIndex,
+		TagsIndex:     baseState.TagsIndex,
+	}
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	for _, entry := range allEntries[:partialFiles] {
+		_, _, addErr := AddMediaPath(mediaDB, firstRunState, systemID, entry.Path, false, false, nil, "")
+		require.NoError(t, addErr, "first partial index should succeed")
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Confirm partial state in DB: partialFiles Media rows exist.
+	var beforeCount int64
+	row := sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media")
+	require.NoError(t, row.Scan(&beforeCount))
+	require.Equal(t, int64(partialFiles), beforeCount, "partial index should have inserted %d rows", partialFiles)
+
+	// Step 2: simulate resume — truncate the partial system, then re-index all files.
+	require.NoError(t, mediaDB.TruncateSystems([]string{systemID}))
+
+	resumeState := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		TagTypeIDs:    baseState.TagTypeIDs,
+		TagIDs:        baseState.TagIDs,
+		TagTypesIndex: baseState.TagTypesIndex,
+		TagsIndex:     baseState.TagsIndex,
+	}
+	require.NoError(t, PopulateScanStateFromDB(ctx, mediaDB, resumeState))
+	// After truncation, this system has no rows — population should find nothing.
+	require.NoError(t, PopulateScanStateForSystem(ctx, mediaDB, resumeState, systemID))
+	assert.Empty(t, resumeState.MediaIDs, "MediaIDs should be empty after truncating the partial system")
+
+	// Re-index all files from scratch — must not produce UNIQUE violations.
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	for _, entry := range allEntries {
+		_, _, addErr := AddMediaPath(mediaDB, resumeState, systemID, entry.Path, false, false, nil, "")
+		require.NoError(t, addErr, "resume re-index must not fail with UNIQUE constraint")
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Final check: exactly totalFiles Media rows — no duplicates from the partial run.
+	var afterCount int64
+	row2 := sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media")
+	require.NoError(t, row2.Scan(&afterCount))
+	assert.Equal(t, int64(totalFiles), afterCount,
+		"after resume, Media count must equal totalFiles (no duplicates from partial run)")
+}

--- a/pkg/database/mediascanner/batch_resume_test.go
+++ b/pkg/database/mediascanner/batch_resume_test.go
@@ -650,9 +650,10 @@ func TestResumeTruncatesPartialSystem(t *testing.T) {
 	require.NoError(t, row.Scan(&beforeCount))
 	require.Equal(t, int64(partialFiles), beforeCount, "partial index should have inserted %d rows", partialFiles)
 
-	// Step 2: simulate resume — truncate the partial system, then re-index all files.
-	require.NoError(t, mediaDB.TruncateSystems([]string{systemID}))
-
+	// Step 2: simulate resume — mirrors production ordering in mediascanner.go:
+	// PopulateScanStateFromDB runs first (before the main loop), then TruncateSystems
+	// fires inside the loop for the partial system. This order populates SystemIDs and
+	// TagIDs with pre-truncate DBIDs, which become stale after the truncate.
 	resumeState := &database.ScanState{
 		SystemIDs:     make(map[string]int),
 		TitleIDs:      make(map[string]int),
@@ -662,7 +663,29 @@ func TestResumeTruncatesPartialSystem(t *testing.T) {
 		TagTypesIndex: baseState.TagTypesIndex,
 		TagsIndex:     baseState.TagsIndex,
 	}
+	// Populate BEFORE truncate (production order). After this, resumeState.SystemIDs
+	// contains the stale DBID for systemID, and resumeState.TagIDs may contain DBIDs
+	// for tags that the orphan-cleanup inside TruncateSystems will delete.
 	require.NoError(t, PopulateScanStateFromDB(ctx, mediaDB, resumeState))
+
+	require.NoError(t, mediaDB.TruncateSystems([]string{systemID}))
+
+	// Reconcile stale scan state after truncate — mirrors the fix in mediascanner.go.
+	// Without this block, AddMediaPath would use the stale SystemIDs DBID for InsertMediaTitle
+	// and any stale TagIDs DBIDs for InsertMediaTag, causing FK violations.
+	delete(resumeState.SystemIDs, systemID)
+	allTags, tagsErr := mediaDB.GetAllTags()
+	require.NoError(t, tagsErr)
+	tagTypeByDBID := make(map[int64]string, len(resumeState.TagTypeIDs))
+	for tt, id := range resumeState.TagTypeIDs {
+		tagTypeByDBID[int64(id)] = tt
+	}
+	resumeState.TagIDs = make(map[string]int, len(allTags))
+	for _, tag := range allTags {
+		resumeState.TagIDs[database.TagKey(tagTypeByDBID[tag.TypeDBID], tag.Tag)] = int(tag.DBID)
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, resumeState))
+
 	// After truncation, this system has no rows — population should find nothing.
 	require.NoError(t, PopulateScanStateForSystem(ctx, mediaDB, resumeState, systemID))
 	assert.Empty(t, resumeState.MediaIDs, "MediaIDs should be empty after truncating the partial system")

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -290,7 +290,13 @@ func AddMediaPath(
 			MediaDBID: int64(mediaIndex),
 		})
 		if err != nil {
-			log.Debug().Err(err).Msgf("media tag relationship already exists: %s", tagStr)
+			var sqliteErr sqlite3.Error
+			if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique &&
+				!errors.Is(err, mediadb.ErrDependencyFlush) {
+				log.Trace().Err(err).Msgf("media tag relationship already exists: %s", tagStr)
+			} else {
+				log.Error().Err(err).Str("tag", tagStr).Msgf("error inserting media tag")
+			}
 		}
 	}
 	return titleIndex, mediaIndex, nil

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -225,7 +225,8 @@ func AddMediaPath(
 			})
 			if err != nil {
 				var sqliteErr sqlite3.Error
-				if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique {
+				if errors.As(err, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique &&
+					!errors.Is(err, mediadb.ErrDependencyFlush) {
 					log.Trace().Err(err).Msgf("media tag relationship already exists for extension: %s", extWithoutDot)
 				} else {
 					log.Error().Err(err).Msgf("error inserting media tag relationship for extension: %s", extWithoutDot)

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -22,6 +22,7 @@ package mediascanner
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -829,10 +830,8 @@ func TestAddMediaPath_ExtensionTag_UniqueConstraintClassification(t *testing.T) 
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	t.Cleanup(func() { zerolog.SetGlobalLevel(prevGlobalLevel) })
 
-	const (
-		systemID = "SNES"
-		path     = "/roms/snes/SuperMario.sfc"
-	)
+	const systemID = "SNES"
+	path := filepath.Join("roms", "snes", "SuperMario.sfc")
 	const extTagDBID = int64(99)
 
 	// Pre-populate the extension tag so the InsertTag branch is skipped and only

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -20,12 +20,18 @@
 package mediascanner
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -805,4 +811,109 @@ func TestGetPathFragments_VirtualPathsVsRegularPaths(t *testing.T) {
 				tc.name, virtualResult.Slug, regularResult.Slug)
 		})
 	}
+}
+
+// TestAddMediaPath_ExtensionTag_UniqueConstraintClassification exercises the two
+// error-classification branches in the extension-tag InsertMediaTag error handler
+// (indexing_pipeline.go:226-234).
+//
+// Branch A (Trace): errors.As finds sqlite3.ErrConstraintUnique and errors.Is
+// does NOT find ErrDependencyFlush → logged at Trace, not propagated.
+//
+// Branch B (Error): the same sqlite3 error is wrapped inside ErrDependencyFlush →
+// condition fails, logged at Error, not propagated.
+//
+// Global zerolog state is mutated to capture output; must not be parallel.
+func TestAddMediaPath_ExtensionTag_UniqueConstraintClassification(t *testing.T) {
+	prevGlobalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(prevGlobalLevel) })
+
+	const (
+		systemID = "SNES"
+		path     = "/roms/snes/SuperMario.sfc"
+	)
+	const extTagDBID = int64(99)
+
+	// Pre-populate the extension tag so the InsertTag branch is skipped and only
+	// InsertMediaTag is reached, keeping mock expectations minimal.
+	newScanState := func() *database.ScanState {
+		return &database.ScanState{
+			SystemIDs:     make(map[string]int),
+			TitleIDs:      make(map[string]int),
+			MediaIDs:      make(map[string]int),
+			TagTypeIDs:    map[string]int{"extension": 1},
+			TagIDs:        map[string]int{database.TagKey("extension", "sfc"): int(extTagDBID)},
+			TagTypesIndex: 1,
+			TagsIndex:     int(extTagDBID),
+		}
+	}
+
+	// Shared mock setup for System/MediaTitle/Media insertions that succeed.
+	// InsertMediaTag expectation is added per sub-test.
+	newMockDB := func() *helpers.MockMediaDBI {
+		m := &helpers.MockMediaDBI{}
+		m.On("InsertSystem", mock.AnythingOfType("database.System")).
+			Return(database.System{DBID: 1, SystemID: systemID, Name: systemID}, nil).Once()
+		m.On("InsertMediaTitle", mock.AnythingOfType("*database.MediaTitle")).
+			Return(database.MediaTitle{DBID: 1}, nil).Once()
+		m.On("InsertMedia", mock.AnythingOfType("database.Media")).
+			Return(database.Media{DBID: 1}, nil).Once()
+		return m
+	}
+
+	// mediaIndex is incremented to 1 inside AddMediaPath; extensionTagIndex = extTagDBID.
+	expectedTag := database.MediaTag{TagDBID: extTagDBID, MediaDBID: 1}
+
+	t.Run("unique_non_dep_flush_traces", func(t *testing.T) {
+		var buf bytes.Buffer
+		prevLogger := log.Logger
+		log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+		defer func() { log.Logger = prevLogger }()
+
+		uniqueErr := sqlite3.Error{
+			Code:         sqlite3.ErrConstraint,
+			ExtendedCode: sqlite3.ErrConstraintUnique,
+		}
+		mockDB := newMockDB()
+		mockDB.On("InsertMediaTag", expectedTag).
+			Return(database.MediaTag{}, uniqueErr).Once()
+
+		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, false, false, nil, "")
+
+		require.NoError(t, err, "UNIQUE-non-dep-flush must not propagate from AddMediaPath")
+		output := buf.String()
+		assert.Contains(t, output, `"level":"trace"`, "non-dep-flush UNIQUE must be logged at trace")
+		assert.Contains(t, output, "already exists for extension", "trace message must identify the extension path")
+		assert.NotContains(t, output, `"level":"error"`, "must not log at error level for a non-dep-flush UNIQUE")
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("unique_dep_flush_errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		prevLogger := log.Logger
+		log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+		defer func() { log.Logger = prevLogger }()
+
+		// Wrap a UNIQUE sqlite3 error inside ErrDependencyFlush, matching the
+		// format produced by BatchInserter.Flush on a dependency failure.
+		depFlushErr := fmt.Errorf("failed to flush dependency for MediaTags: %w: %w",
+			mediadb.ErrDependencyFlush,
+			sqlite3.Error{Code: sqlite3.ErrConstraint, ExtendedCode: sqlite3.ErrConstraintUnique},
+		)
+		mockDB := newMockDB()
+		mockDB.On("InsertMediaTag", expectedTag).
+			Return(database.MediaTag{}, depFlushErr).Once()
+
+		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, false, false, nil, "")
+
+		require.NoError(t, err, "dep-flush error must not propagate from AddMediaPath")
+		output := buf.String()
+		assert.Contains(t, output, `"level":"error"`, "dep-flush UNIQUE must be logged at error level")
+		assert.Contains(t, output, "error inserting media tag relationship for extension",
+			"error message must name the extension path")
+		assert.NotContains(t, output, "already exists for extension",
+			"must not classify dep-flush error as a recoverable duplicate")
+		mockDB.AssertExpectations(t)
+	})
 }

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -838,6 +838,9 @@ func NewNamesIndex(
 	scannedLaunchers := make(map[string]bool)
 	// This map tracks systems that have been fully processed and committed
 	completedSystems := make(map[string]bool)
+	// Tracks whether the lastIndexedSystem's partial rows were cleaned up on resume.
+	// The truncate must fire exactly once, before the system's first file is processed.
+	resumedSystemTruncated := false
 
 	// Populate completedSystems if resuming
 	if shouldResume {
@@ -890,6 +893,20 @@ func NewNamesIndex(
 
 		// Lazy load this system's existing data for resume
 		if shouldResume {
+			// On the first encounter of the lastIndexedSystem, remove any
+			// partially-committed rows from the previous interrupted run so the
+			// re-index starts clean. Without this, FlushScanStateMaps clearing
+			// MediaIDs mid-system leaves the scanner blind to pre-existing paths,
+			// causing a UNIQUE constraint storm at ~1 file/sec.
+			if systemID == lastIndexedSystemID && !resumedSystemTruncated {
+				log.Info().Str("system", systemID).
+					Msg("truncating partial system data before resume re-index")
+				if truncErr := db.TruncateSystems([]string{systemID}); truncErr != nil {
+					return 0, fmt.Errorf("failed to truncate partial system data for resume: %w", truncErr)
+				}
+				resumedSystemTruncated = true
+			}
+
 			log.Debug().Str("system", systemID).Msg("loading existing data for system resume")
 			if loadErr := PopulateScanStateForSystem(ctx, db, &scanState, systemID); loadErr != nil {
 				// Check if this is a cancellation error

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -905,6 +905,29 @@ func NewNamesIndex(
 					return 0, fmt.Errorf("failed to truncate partial system data for resume: %w", truncErr)
 				}
 				resumedSystemTruncated = true
+
+				// TruncateSystems deletes the Systems row (invalidating the DBID cached in
+				// scanState.SystemIDs) and orphan-cleans any Tags no longer referenced by
+				// MediaTags/MediaTitleTags/SupportingMedia (invalidating DBIDs in scanState.TagIDs).
+				// Both maps were populated by PopulateScanStateFromDB before the main loop; they
+				// must be reconciled now so AddMediaPath doesn't pass stale foreign keys.
+				delete(scanState.SystemIDs, systemID)
+
+				allTags, tagsErr := db.GetAllTags()
+				if tagsErr != nil {
+					return 0, fmt.Errorf("failed to reload tags after resume truncate: %w", tagsErr)
+				}
+				tagTypeByDBID := make(map[int64]string, len(scanState.TagTypeIDs))
+				for t, id := range scanState.TagTypeIDs {
+					tagTypeByDBID[int64(id)] = t
+				}
+				scanState.TagIDs = make(map[string]int, len(allTags))
+				for _, tag := range allTags {
+					scanState.TagIDs[database.TagKey(tagTypeByDBID[tag.TypeDBID], tag.Tag)] = int(tag.DBID)
+				}
+				if seedErr := SeedCanonicalTags(db, &scanState); seedErr != nil {
+					return 0, fmt.Errorf("failed to re-seed canonical tags after resume truncate: %w", seedErr)
+				}
 			}
 
 			log.Debug().Str("system", systemID).Msg("loading existing data for system resume")

--- a/pkg/service/broker/broker.go
+++ b/pkg/service/broker/broker.go
@@ -31,24 +31,89 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// subscriberState manages a single subscription, including a drain goroutine that
+// delivers coalesced notifications when the output channel fills up.
+//
+// For coaleseable methods: if outChan is full when a notification arrives, the
+// notification is stored in the coalesced map (replacing any prior pending
+// notification for the same method) and the drain goroutine is signalled. This
+// means slow consumers see only the latest value for high-frequency progress
+// events rather than losing the update entirely.
+//
+// For all other methods: broadcast falls back to a non-blocking send with a
+// drop warning (existing behaviour).
+type subscriberState struct {
+	outChan   chan models.Notification
+	coalesced map[string]models.Notification
+	signal    chan struct{}
+	stop      chan struct{}
+	stopped   chan struct{}
+	mu        syncutil.Mutex
+}
+
+func newSubscriberState(bufferSize int) *subscriberState {
+	s := &subscriberState{
+		outChan:   make(chan models.Notification, bufferSize),
+		coalesced: make(map[string]models.Notification),
+		signal:    make(chan struct{}, 1),
+		stop:      make(chan struct{}),
+		stopped:   make(chan struct{}),
+	}
+	go s.run()
+	return s
+}
+
+func (s *subscriberState) run() {
+	defer close(s.stopped)
+	defer close(s.outChan)
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-s.signal:
+			s.mu.Lock()
+			snapshot := s.coalesced
+			s.coalesced = make(map[string]models.Notification, len(snapshot))
+			s.mu.Unlock()
+			for _, notif := range snapshot {
+				select {
+				case s.outChan <- notif:
+				case <-s.stop:
+					return
+				}
+			}
+		}
+	}
+}
+
 // Broker manages notification subscriptions and broadcasts messages to all subscribers.
 // It uses non-blocking sends to ensure that slow consumers cannot block the system.
+// For methods listed in coalesceable, a per-subscriber drain goroutine delivers the
+// latest notification whenever the output channel has space, preventing stale drops.
 type Broker struct {
-	ctx         context.Context
-	source      <-chan models.Notification
-	subscribers map[int]chan models.Notification
-	mu          syncutil.RWMutex
-	nextID      int
+	ctx          context.Context
+	source       <-chan models.Notification
+	subscribers  map[int]*subscriberState
+	coalesceable map[string]bool
+	mu           syncutil.RWMutex
+	nextID       int
 }
 
 // NewBroker creates a new notification broker that reads from the source channel
-// and broadcasts to all subscribers.
-func NewBroker(ctx context.Context, source <-chan models.Notification) *Broker {
+// and broadcasts to all subscribers. coalesceableMethods lists notification methods
+// that use last-write-wins coalescing when a subscriber's channel is full; all other
+// methods are dropped with a warning (existing behaviour).
+func NewBroker(ctx context.Context, source <-chan models.Notification, coalesceableMethods ...string) *Broker {
+	cm := make(map[string]bool, len(coalesceableMethods))
+	for _, m := range coalesceableMethods {
+		cm[m] = true
+	}
 	return &Broker{
-		ctx:         ctx,
-		source:      source,
-		subscribers: make(map[int]chan models.Notification),
-		nextID:      0,
+		ctx:          ctx,
+		source:       source,
+		subscribers:  make(map[int]*subscriberState),
+		coalesceable: cm,
+		nextID:       0,
 	}
 }
 
@@ -77,30 +142,44 @@ func (b *Broker) Start() {
 	}()
 }
 
-// broadcast sends a notification to all subscribers using non-blocking sends.
-// If a subscriber's channel is full, the notification is dropped for that subscriber
-// and a warning is logged.
+// broadcast sends a notification to all subscribers.
+// For coalesceable methods: tries a direct non-blocking send; if the channel is
+// full, stores the latest payload in the subscriber's coalesced slot and wakes
+// the drain goroutine so it can deliver when space opens.
+// For all other methods: non-blocking send with drop warning on full channel.
 func (b *Broker) broadcast(notif models.Notification) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	for id, ch := range b.subscribers {
+	coalesce := b.coalesceable[notif.Method]
+
+	for id, sub := range b.subscribers {
 		select {
-		case ch <- notif:
-			// Successfully sent to this subscriber
+		case sub.outChan <- notif:
+			// Delivered directly.
 		default:
-			// Subscriber's channel is full, drop the notification
-			log.Warn().
-				Int("subscriber_id", id).
-				Str("method", notif.Method).
-				Msg("subscriber channel full, dropping notification")
+			if coalesce {
+				// Channel full: store latest and wake drain goroutine.
+				sub.mu.Lock()
+				sub.coalesced[notif.Method] = notif
+				sub.mu.Unlock()
+				select {
+				case sub.signal <- struct{}{}:
+				default: // Signal already pending; drain goroutine will pick it up.
+				}
+			} else {
+				log.Warn().
+					Int("subscriber_id", id).
+					Str("method", notif.Method).
+					Msg("subscriber channel full, dropping notification")
+			}
 		}
 	}
 }
 
 // Subscribe creates a new subscription and returns a channel that will receive
 // notifications. The bufferSize determines how many notifications can be queued
-// before sends start blocking (and eventually dropping with warnings).
+// before coalescing (for coalesceable methods) or dropping (for all others) kicks in.
 //
 // Returns the notification channel and a subscription ID that can be used for unsubscribing.
 func (b *Broker) Subscribe(bufferSize int) (notifChan <-chan models.Notification, id int) {
@@ -110,27 +189,32 @@ func (b *Broker) Subscribe(bufferSize int) (notifChan <-chan models.Notification
 	id = b.nextID
 	b.nextID++
 
-	ch := make(chan models.Notification, bufferSize)
-	b.subscribers[id] = ch
+	sub := newSubscriberState(bufferSize)
+	b.subscribers[id] = sub
 
 	log.Debug().
 		Int("subscriber_id", id).
 		Int("buffer_size", bufferSize).
 		Msg("new subscriber registered")
 
-	notifChan = ch
+	notifChan = sub.outChan
 	return
 }
 
-// Unsubscribe removes a subscription and closes its channel.
-// It's safe to call this multiple times with the same ID.
+// Unsubscribe removes a subscription and waits for its drain goroutine to exit,
+// after which the subscription channel is closed. It is safe to call multiple
+// times with the same ID.
 func (b *Broker) Unsubscribe(id int) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if ch, ok := b.subscribers[id]; ok {
+	sub, ok := b.subscribers[id]
+	if ok {
 		delete(b.subscribers, id)
-		close(ch)
+	}
+	b.mu.Unlock()
+
+	if ok {
+		close(sub.stop) // signal drain goroutine to exit
+		<-sub.stopped   // wait; goroutine closes outChan on exit
 		log.Debug().Int("subscriber_id", id).Msg("subscriber unsubscribed")
 	}
 }
@@ -141,15 +225,17 @@ func (b *Broker) Stop() {
 	b.closeAllSubscribers()
 }
 
-// closeAllSubscribers closes all subscriber channels and clears the subscriber map.
-// This is called when the broker shuts down.
+// closeAllSubscribers stops all drain goroutines, closes all subscriber channels,
+// and clears the subscriber map.
 func (b *Broker) closeAllSubscribers() {
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	subs := b.subscribers
+	b.subscribers = make(map[int]*subscriberState)
+	b.mu.Unlock()
 
-	for id, ch := range b.subscribers {
-		close(ch)
+	for id, sub := range subs {
+		close(sub.stop)
+		<-sub.stopped // goroutine closes outChan on exit
 		log.Debug().Int("subscriber_id", id).Msg("closed subscriber channel on shutdown")
 	}
-	b.subscribers = make(map[int]chan models.Notification)
 }

--- a/pkg/service/broker/broker_test.go
+++ b/pkg/service/broker/broker_test.go
@@ -23,6 +23,7 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -348,4 +349,81 @@ func TestBroker_MultipleNotificationTypes(t *testing.T) {
 		received := <-subscriber
 		assert.Equal(t, notifications[i].Method, received.Method)
 	}
+}
+
+// TestBroker_CoalesceDropsRedundantUpdates checks that when a subscriber's channel
+// is full and a coalesceable method fires in a burst, only the latest payload is
+// delivered rather than all intermediate values being dropped silently.
+func TestBroker_CoalesceDropsRedundantUpdates(t *testing.T) {
+	t.Parallel()
+
+	const totalSent = 200
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan models.Notification, totalSent+10)
+	b := NewBroker(ctx, source, "progress.event")
+	b.Start()
+
+	// Small buffer so it fills after the first two direct sends.
+	sub, _ := b.Subscribe(2)
+
+	// Send all notifications before broker has had much time to run.
+	for i := range totalSent {
+		source <- models.Notification{
+			Method: "progress.event",
+			Params: []byte(fmt.Sprintf(`{"step":%d}`, i)),
+		}
+	}
+
+	// Drain with a timeout so we don't exit before the coalesce goroutine delivers.
+	var received []models.Notification
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case n := <-sub:
+			received = append(received, n)
+		case <-deadline:
+			goto done
+		}
+	}
+done:
+
+	// Coalescing must have reduced the message count substantially.
+	assert.NotEmpty(t, received, "subscriber should have received at least one notification")
+	assert.Less(t, len(received), totalSent,
+		"coalescing should deliver fewer messages than were sent")
+	// With buffer=2 and 200 sends, 2 go direct and at least 1 is delivered by the drain
+	// goroutine. If coalescing is broken entirely, received==2 (drops only) — this catches that.
+	assert.GreaterOrEqual(t, len(received), 3,
+		"subscriber should have received direct sends plus at least one coalesced delivery")
+}
+
+// TestBroker_CoalesceDoesNotAffectCriticalEvents verifies that non-coalesceable
+// notifications (e.g. tokens.added) are never merged or silently dropped via the
+// coalescing path — they follow the original drop-with-warning path.
+func TestBroker_CoalesceDoesNotAffectCriticalEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan models.Notification, 10)
+	// Only "progress.event" is coalesceable; tokens.added is not.
+	b := NewBroker(ctx, source, "progress.event")
+	b.Start()
+
+	// Buffer=4 so we can fill it with progress events then send a critical one.
+	sub, _ := b.Subscribe(4)
+
+	// Send a critical event first so it's received.
+	source <- models.Notification{Method: models.NotificationTokensAdded, Params: []byte(`{}`)}
+
+	// Give broker time to process.
+	time.Sleep(10 * time.Millisecond)
+
+	notif := <-sub
+	assert.Equal(t, models.NotificationTokensAdded, notif.Method,
+		"critical notification must be delivered intact")
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -212,8 +212,10 @@ func Start(
 	// TODO: define the notifications chan here instead of in state
 	st, ns := state.NewState(pl, bootUUID) // global state, notification queue (source)
 
-	// Create and start notification broker to broadcast to all consumers
-	notifBroker := broker.NewBroker(st.GetContext(), ns)
+	// Create and start notification broker to broadcast to all consumers.
+	// media.indexing is coalesceable: bursts during index/resume collapse to
+	// latest-wins so slow WebSocket consumers don't drop discrete events.
+	notifBroker := broker.NewBroker(st.GetContext(), ns, models.NotificationMediaIndexing)
 	notifBroker.Start()
 
 	// TODO: convert this to a *token channel


### PR DESCRIPTION
Fixes #688, #691.

## Root cause

When a large media index is interrupted and resumed, the system that was partially committed triggers a UNIQUE constraint storm that collapses indexing throughput to ~1 file/sec indefinitely.

Three cooperating bugs:

**1. `FlushScanStateMaps` wipes `MediaIDs` mid-resume**

On resume, `PopulateScanStateForSystem` loads the partial system's existing paths into `MediaIDs` once. The first mid-system commit (`filesInBatch >= maxFilesPerTransaction`) calls `FlushScanStateMaps`, which clears `MediaIDs`. From that point every path already in the DB bypasses the duplicate check and reaches `BatchInserter`, producing non-stop UNIQUE errors.

Fix: truncate the partial system's rows before re-indexing it (`TruncateSystems` already exists for selective reindex). The re-index then runs against a clean slate and `MediaIDs` stays aligned with the DB for the full run.

**2. `BatchInserter.Flush` does not reset buffer on failure**

When `ExecContext` fails, the buffer and `currentCount` were left intact. The next `Add` call saw `currentCount >= batchSize` and re-entered `Flush` with the same failing rows, producing a retry loop on every call. The same bug existed in `flushChunked` (exercised in production: `MediaTitles` at 5000 rows × 7 columns exceeds SQLite's 32 766 variable limit) and `flushSingleRow`. All three paths now reset before returning on error.

**3. Misleading dependency-flush error log**

`InsertMediaTag` errors were logged as `"media tag relationship already exists"` even when the actual failure was the `Media` parent batch flushing (which propagates through `SetDependencies`). Replace the fragile `strings.Contains` sentinel with an exported `ErrDependencyFlush` error type checked via `errors.Is`.

## Broker coalescing

Adds per-subscriber, per-method last-write-wins coalescing to the broker for an allowlist of high-frequency notification methods (currently `media.indexing`). When a subscriber's channel is full, the latest payload is stored in a per-method slot and delivered by a per-subscriber drain goroutine when space opens — instead of being silently dropped. This prevents the recurring "notifications clogged up" pattern without requiring producer-side throttling for every new progress event source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch insertion now clears pending rows after flush or dependency failures to avoid replaying failed writes.
  * Resume/indexing truncates and reconciles partial system state to prevent duplicate rows after interrupted runs.
  * Improved classification and logging of unique-constraint insertions to distinguish recoverable duplicates from dependency-related failures.

* **New Features**
  * Notification broker coalesces high-frequency indexing events so slow clients receive the latest update.

* **Tests**
  * Added tests covering buffer-reset on flush failures, dependency-flush behavior, resume truncation, unique-constraint classification, and broker coalescing.

* **Documentation**
  * Clarified path-construction guidance to require using platform-safe joining APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->