### PR TITLE
fix(mediascanner): fix media index hang on resume from interrupted run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ task deadlock          # Detect lock ordering violations
 # DON'T use file-level golangci-lint (not well supported)
 # golangci-lint run pkg/config/config.go  # BAD
 
+# Find total index duration from MCP logs:
+# grep "media indexing completed" <log-file>
+
 # GitHub Actions workflow linting (use when editing .github/workflows/*.yml)
 actionlint .github/workflows/fuzz.yml    # Lint a specific workflow
 actionlint                                # Lint all workflows

--- a/pkg/database/mediadb/sql_maintenance.go
+++ b/pkg/database/mediadb/sql_maintenance.go
@@ -72,65 +72,151 @@ func sqlTruncateSystems(ctx context.Context, db *sql.DB, systemIDs []string) err
 		return nil
 	}
 
-	// Create placeholders for IN clause
-	placeholders := prepareVariadic("?", ",", len(systemIDs))
-
-	// Convert systemIDs to interface slice for query parameters
-	args := make([]any, len(systemIDs))
+	// String placeholders for SystemID lookups (e.g. SlugResolutionCache keyed by string).
+	strPlaceholders := prepareVariadic("?", ",", len(systemIDs))
+	strArgs := make([]any, len(systemIDs))
 	for i, id := range systemIDs {
-		args[i] = id
+		strArgs[i] = id
 	}
 
-	// With proper foreign keys, just delete Systems
-	// CASCADE handles: MediaTitles → Media → MediaTags
-	//                  MediaTitles → SupportingMedia
-	//                  MediaTitles → MediaTitleTags
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
-	deleteStmt := fmt.Sprintf("DELETE FROM Systems WHERE SystemID IN (%s)", placeholders)
-	_, err := db.ExecContext(ctx, deleteStmt, args...)
+	// Pin to a single connection: PRAGMA foreign_keys is session-local, so the PRAGMA
+	// and the subsequent DELETEs must execute on the same connection.
+	conn, err := db.Conn(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to delete systems: %w", err)
+		return fmt.Errorf("failed to acquire connection for system truncation: %w", err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Str("systems", fmt.Sprintf("%v", systemIDs)).
+				Msg("failed to release connection after system truncation")
+		}
+	}()
+
+	// Resolve SystemID strings → SystemDBID integers so subsequent statements
+	// use primary-key lookups instead of string scans.
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	rows, err := conn.QueryContext(ctx,
+		fmt.Sprintf("SELECT DBID FROM Systems WHERE SystemID IN (%s)", strPlaceholders), strArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to resolve system DBIDs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var systemDBIDs []any
+	for rows.Next() {
+		var dbid int64
+		if scanErr := rows.Scan(&dbid); scanErr != nil {
+			return fmt.Errorf("failed to scan system DBID: %w", scanErr)
+		}
+		systemDBIDs = append(systemDBIDs, dbid)
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate system DBIDs: %w", err)
 	}
 
-	// Clean up orphaned tags (RESTRICT prevents cascade, so we handle these separately)
-	// Only deletes truly orphaned tags that aren't referenced anywhere
-	// IMPORTANT: Do NOT delete TagTypes during selective indexing - they are global infrastructure
-	// shared across all systems. Deleting them would break other systems' media that reference
-	// TagTypes not used by the system being reindexed (e.g., "Extension" TagType).
-	cleanupStmt := `
-		DELETE FROM Tags WHERE DBID NOT IN (
-			SELECT TagDBID FROM MediaTags WHERE TagDBID IS NOT NULL
-			UNION
-			SELECT TagDBID FROM MediaTitleTags WHERE TagDBID IS NOT NULL
-			UNION
-			SELECT TypeTagDBID FROM SupportingMedia WHERE TypeTagDBID IS NOT NULL
-		);
-	`
-	_, err = db.ExecContext(ctx, cleanupStmt)
-	if err != nil {
+	if len(systemDBIDs) == 0 {
+		return nil // None of the given systemIDs exist; nothing to do.
+	}
+
+	dbidPlaceholders := prepareVariadic("?", ",", len(systemDBIDs))
+
+	// Step 1: collect Tag DBIDs referenced by the target systems BEFORE any deletes.
+	// Only these tags can become orphans — bounding the later cleanup to this set
+	// avoids a full-table scan of MediaTags/MediaTitleTags/SupportingMedia.
+	if _, err = conn.ExecContext(ctx,
+		"CREATE TEMP TABLE IF NOT EXISTS _tts_candidate_tags (DBID INTEGER PRIMARY KEY)"); err != nil {
+		return fmt.Errorf("failed to create candidate tags temp table: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS _tts_candidate_tags")
+	}()
+
+	// Each UNION branch needs its own copy of the system DBID args.
+	candidateArgs := append(append(append([]any{}, systemDBIDs...), systemDBIDs...), systemDBIDs...)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx, fmt.Sprintf(`
+		INSERT OR IGNORE INTO _tts_candidate_tags (DBID)
+		    SELECT TagDBID FROM MediaTags
+		        WHERE MediaDBID IN (SELECT DBID FROM Media WHERE SystemDBID IN (%[1]s))
+		UNION
+		    SELECT TagDBID FROM MediaTitleTags
+		        WHERE MediaTitleDBID IN (SELECT DBID FROM MediaTitles WHERE SystemDBID IN (%[1]s))
+		UNION
+		    SELECT TypeTagDBID FROM SupportingMedia
+		        WHERE MediaTitleDBID IN (SELECT DBID FROM MediaTitles WHERE SystemDBID IN (%[1]s))`,
+		dbidPlaceholders), candidateArgs...); err != nil {
+		return fmt.Errorf("failed to collect candidate tags: %w", err)
+	}
+
+	// Disable FK enforcement to delete children in explicit order without CASCADE overhead.
+	// On MiSTer SD card, cascading 50K–200K child rows is orders of magnitude slower than
+	// scoped explicit DELETEs.
+	if _, err = conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("failed to disable foreign keys: %w", err)
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "PRAGMA foreign_keys = ON")
+	}()
+
+	// Delete children in reverse dependency order, scoped to target SystemDBIDs.
+	// MediaTags references Media(DBID) — must route through Media.SystemDBID.
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM MediaTags WHERE MediaDBID IN (SELECT DBID FROM Media WHERE SystemDBID IN (%s))",
+		dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete MediaTags: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM MediaTitleTags WHERE MediaTitleDBID IN (SELECT DBID FROM MediaTitles WHERE SystemDBID IN (%s))",
+		dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete MediaTitleTags: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM SupportingMedia WHERE MediaTitleDBID IN (SELECT DBID FROM MediaTitles WHERE SystemDBID IN (%s))",
+		dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete SupportingMedia: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM Media WHERE SystemDBID IN (%s)", dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete Media: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM MediaTitles WHERE SystemDBID IN (%s)", dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete MediaTitles: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx,
+		fmt.Sprintf("DELETE FROM Systems WHERE DBID IN (%s)", dbidPlaceholders), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete Systems: %w", err)
+	}
+
+	// Orphan tag cleanup: delete Tags that were only referenced by the truncated systems.
+	// NOT EXISTS uses the mediatags_tag_media_idx / MediaTitleTags PK / SupportingMedia index
+	// for O(log n) lookups rather than a full-table scan.
+	// IMPORTANT: TagTypes are deliberately NOT deleted — they are global infrastructure shared
+	// across all systems; deleting them would break remaining systems' tag references.
+	if _, err = conn.ExecContext(ctx, `
+		DELETE FROM Tags
+		    WHERE DBID IN (SELECT DBID FROM _tts_candidate_tags)
+		      AND NOT EXISTS (SELECT 1 FROM MediaTags       WHERE TagDBID     = Tags.DBID)
+		      AND NOT EXISTS (SELECT 1 FROM MediaTitleTags  WHERE TagDBID     = Tags.DBID)
+		      AND NOT EXISTS (SELECT 1 FROM SupportingMedia WHERE TypeTagDBID = Tags.DBID)`); err != nil {
 		return fmt.Errorf("failed to clean up orphaned tags: %w", err)
 	}
 
-	// Invalidate media count cache since system data was modified
-	_, err = db.ExecContext(ctx, "DELETE FROM MediaCountCache")
-	if err != nil {
-		// Log warning but don't fail the operation - cache invalidation is not critical
+	// Cache invalidation — not FK-dependent, so these run after PRAGMA FK ON restores.
+	if _, err = conn.ExecContext(ctx, "DELETE FROM MediaCountCache"); err != nil {
 		log.Warn().Err(err).Msg("failed to invalidate media count cache during system truncation")
 	}
-
-	// Invalidate system tags cache since system data was modified
-	_, err = db.ExecContext(ctx, "DELETE FROM SystemTagsCache")
-	if err != nil {
-		// Log warning but don't fail the operation - cache invalidation is not critical
+	if _, err = conn.ExecContext(ctx, "DELETE FROM SystemTagsCache"); err != nil {
 		log.Warn().Err(err).Msg("failed to invalidate system tags cache during system truncation")
 	}
-
-	// Invalidate slug resolution cache for the affected systems
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
-	slugCacheDeleteStmt := fmt.Sprintf("DELETE FROM SlugResolutionCache WHERE SystemID IN (%s)", placeholders)
-	_, err = db.ExecContext(ctx, slugCacheDeleteStmt, args...)
-	if err != nil {
-		// Log warning but don't fail the operation - cache invalidation is not critical
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	slugStmt := fmt.Sprintf("DELETE FROM SlugResolutionCache WHERE SystemID IN (%s)", strPlaceholders)
+	if _, err = conn.ExecContext(ctx, slugStmt, strArgs...); err != nil {
 		log.Warn().Err(err).Msg("failed to invalidate slug resolution cache during system truncation")
 	}
 

--- a/pkg/database/mediadb/sql_maintenance.go
+++ b/pkg/database/mediadb/sql_maintenance.go
@@ -127,7 +127,7 @@ func sqlTruncateSystems(ctx context.Context, db *sql.DB, systemIDs []string) err
 		return fmt.Errorf("failed to create candidate tags temp table: %w", err)
 	}
 	defer func() {
-		_, _ = conn.ExecContext(ctx, "DROP TABLE IF EXISTS _tts_candidate_tags")
+		_, _ = conn.ExecContext(context.Background(), "DROP TABLE IF EXISTS _tts_candidate_tags")
 	}()
 
 	// Each UNION branch needs its own copy of the system DBID args.
@@ -154,7 +154,7 @@ func sqlTruncateSystems(ctx context.Context, db *sql.DB, systemIDs []string) err
 		return fmt.Errorf("failed to disable foreign keys: %w", err)
 	}
 	defer func() {
-		_, _ = conn.ExecContext(ctx, "PRAGMA foreign_keys = ON")
+		_, _ = conn.ExecContext(context.Background(), "PRAGMA foreign_keys = ON")
 	}()
 
 	// Delete children in reverse dependency order, scoped to target SystemDBIDs.

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -237,12 +238,15 @@ func TestSqlInsertSystemWithPreparedStmt_Success(t *testing.T) {
 
 // setupTruncateTestDB inserts minimal data into a real SQLite media DB:
 //   - Two TagTypes ("genre", "platform")
-//   - Three Tags: "Action" (genre, id=1), "RPG" (genre, id=2), "Extension" (platform, id=3)
+//   - Four Tags: "Action" (genre, id=1), "RPG" (genre, id=2), "Extension" (platform, id=3), "Cover" (platform, id=4)
 //   - Systems NES (id=1) and SNES (id=2)
 //   - One MediaTitle + one Media per system
 //   - MediaTags: NES media → Tag 1 ("Action") + Tag 2 ("RPG"); SNES media → Tag 1 ("Action") only
+//   - MediaTitleTags: NES mario title → Tag 2 ("RPG")
+//   - SupportingMedia: NES mario title → Tag 4 ("Cover")
 //
-// Tag 1 is shared by both systems; Tag 2 is NES-only; Tag 3 is never referenced by any media.
+// Tag 1 is shared by both systems; Tag 2 is NES-only (via MediaTags and MediaTitleTags);
+// Tag 3 is never referenced; Tag 4 is NES-only (via SupportingMedia).
 // Returns the *sql.DB handle from the opened MediaDB so callers can run assertions.
 func setupTruncateTestDB(t *testing.T) (*MediaDB, *sql.DB) {
 	t.Helper()
@@ -254,15 +258,29 @@ func setupTruncateTestDB(t *testing.T) (*MediaDB, *sql.DB) {
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO TagTypes (DBID, Type) VALUES (1, 'genre'), (2, 'platform');
-		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES (1, 1, 'Action'), (2, 1, 'RPG'), (3, 2, 'Extension');
+		INSERT INTO Tags (DBID, TypeDBID, Tag)
+		    VALUES (1, 1, 'Action'), (2, 1, 'RPG'), (3, 2, 'Extension'), (4, 2, 'Cover');
 		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'NES', 'Nintendo'), (2, 'SNES', 'Super Nintendo');
 		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name)
 		    VALUES (1, 1, 'mario', 'Mario'), (2, 2, 'zelda', 'Zelda');
-		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES
-		    (1, 1, 1, '/roms/nes/mario.nes'),
-		    (2, 2, 2, '/roms/snes/zelda.sfc');
-		INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (1, 1), (1, 2), (2, 1);
+		INSERT INTO MediaTitleTags (MediaTitleDBID, TagDBID) VALUES (1, 2);
 	`)
+	require.NoError(t, err)
+
+	mediaPath1 := filepath.Join("roms", "nes", "mario.nes")
+	mediaPath2 := filepath.Join("roms", "snes", "zelda.sfc")
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (1, 1, 1, ?), (2, 2, 2, ?)",
+		mediaPath1, mediaPath2)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (1, 1), (1, 2), (2, 1)")
+	require.NoError(t, err)
+
+	coverPath := filepath.Join("roms", "nes", "mario.png")
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO SupportingMedia (DBID, MediaTitleDBID, TypeTagDBID, Path, ContentType) VALUES (1, 1, 4, ?, ?)",
+		coverPath, "image/png")
 	require.NoError(t, err)
 
 	return mediaDB, db
@@ -293,7 +311,7 @@ func TestSqlTruncateSystems_Success(t *testing.T) {
 	assert.Equal(t, 0, systemCount, "all systems should be deleted")
 	assert.Equal(t, 0, mediaCount, "all media should be deleted")
 	assert.Equal(t, 0, titleCount, "all media titles should be deleted")
-	// Tags 1 and 2 were in MediaTags → now orphans → deleted. Tag 3 was never in MediaTags → kept.
+	// Tags 1, 2, 4 were referenced by deleted systems → now orphans → deleted. Tag 3 never referenced → kept.
 	assert.Equal(t, 1, tagCount, "only the unreferenced tag should remain")
 
 	// TagTypes must never be deleted
@@ -320,16 +338,19 @@ func TestSqlTruncateSystems_SingleSystem(t *testing.T) {
 	assert.Equal(t, 0, nesCount, "NES media should be deleted")
 	assert.Equal(t, 1, snesCount, "SNES media should remain")
 
-	// Tag 2 ("RPG") was only referenced by NES media → deleted as orphan.
+	// Tag 2 ("RPG") was only referenced by NES (MediaTags + MediaTitleTags) → deleted as orphan.
+	// Tag 4 ("Cover") was only in SupportingMedia for NES → deleted as orphan.
 	// Tag 1 ("Action") is still referenced by SNES media → must survive.
 	// Tag 3 ("Extension") was never referenced → must survive.
-	var tag1, tag2, tag3 int
+	var tag1, tag2, tag3, tag4 int
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 1").Scan(&tag1))
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 2").Scan(&tag2))
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 3").Scan(&tag3))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 4").Scan(&tag4))
 	assert.Equal(t, 1, tag1, "shared tag (Action) must survive")
 	assert.Equal(t, 0, tag2, "NES-only tag (RPG) should be deleted")
 	assert.Equal(t, 1, tag3, "unreferenced tag (Extension) must survive")
+	assert.Equal(t, 0, tag4, "NES-only SupportingMedia tag (Cover) should be deleted")
 }
 
 func TestSqlTruncateSystems_NonExistent(t *testing.T) {

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -235,105 +235,127 @@ func TestSqlInsertSystemWithPreparedStmt_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSqlTruncateSystems_Success(t *testing.T) {
-	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
+// setupTruncateTestDB inserts minimal data into a real SQLite media DB:
+//   - Two TagTypes ("genre", "platform")
+//   - Three Tags: "Action" (genre, id=1), "RPG" (genre, id=2), "Extension" (platform, id=3)
+//   - Systems NES (id=1) and SNES (id=2)
+//   - One MediaTitle + one Media per system
+//   - MediaTags: NES media → Tag 1 ("Action") + Tag 2 ("RPG"); SNES media → Tag 1 ("Action") only
+//
+// Tag 1 is shared by both systems; Tag 2 is NES-only; Tag 3 is never referenced by any media.
+// Returns the *sql.DB handle from the opened MediaDB so callers can run assertions.
+func setupTruncateTestDB(t *testing.T) (*MediaDB, *sql.DB) {
+	t.Helper()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	db := mediaDB.sql
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO TagTypes (DBID, Type) VALUES (1, 'genre'), (2, 'platform');
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES (1, 1, 'Action'), (2, 1, 'RPG'), (3, 2, 'Extension');
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'NES', 'Nintendo'), (2, 'SNES', 'Super Nintendo');
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name)
+		    VALUES (1, 1, 'mario', 'Mario'), (2, 2, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES
+		    (1, 1, 1, '/roms/nes/mario.nes'),
+		    (2, 2, 2, '/roms/snes/zelda.sfc');
+		INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (1, 1), (1, 2), (2, 1);
+	`)
 	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
 
-	systemIDs := []string{"NES", "SNES", "Genesis"}
-
-	// Expect Systems deletion (CASCADE handles all related records)
-	mock.ExpectExec(`DELETE FROM Systems WHERE SystemID IN \(\?,\?,\?\)`).
-		WithArgs("NES", "SNES", "Genesis").
-		WillReturnResult(sqlmock.NewResult(0, 3))
-
-	// Expect cleanup of orphaned tags (RESTRICT prevented cascade, so we clean separately)
-	// Note: TagTypes are NOT deleted as they are global infrastructure shared across systems
-	mock.ExpectExec(`DELETE FROM Tags WHERE DBID NOT IN`).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	err = sqlTruncateSystems(context.Background(), db, systemIDs)
-	assert.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
+	return mediaDB, db
 }
 
 func TestSqlTruncateSystems_EmptyList(t *testing.T) {
 	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
 
-	// Should return immediately without any database operations
-	err = sqlTruncateSystems(context.Background(), db, []string{})
+	err := sqlTruncateSystems(context.Background(), mediaDB.sql, []string{})
 	assert.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlTruncateSystems_Success(t *testing.T) {
+	t.Parallel()
+	_, db := setupTruncateTestDB(t)
+	ctx := context.Background()
+
+	err := sqlTruncateSystems(ctx, db, []string{"NES", "SNES"})
+	require.NoError(t, err)
+
+	var systemCount, mediaCount, titleCount, tagCount int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Systems").Scan(&systemCount))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&mediaCount))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM MediaTitles").Scan(&titleCount))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags").Scan(&tagCount))
+	assert.Equal(t, 0, systemCount, "all systems should be deleted")
+	assert.Equal(t, 0, mediaCount, "all media should be deleted")
+	assert.Equal(t, 0, titleCount, "all media titles should be deleted")
+	// Tags 1 and 2 were in MediaTags → now orphans → deleted. Tag 3 was never in MediaTags → kept.
+	assert.Equal(t, 1, tagCount, "only the unreferenced tag should remain")
+
+	// TagTypes must never be deleted
+	var typeCount int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM TagTypes").Scan(&typeCount))
+	assert.Equal(t, 2, typeCount, "TagTypes must be preserved")
 }
 
 func TestSqlTruncateSystems_SingleSystem(t *testing.T) {
 	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
+	_, db := setupTruncateTestDB(t)
+	ctx := context.Background()
+
+	err := sqlTruncateSystems(ctx, db, []string{"NES"})
 	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
 
-	systemIDs := []string{"NES"}
+	var nesCount, snesCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM Media WHERE SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = 'NES')
+	`).Scan(&nesCount))
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM Media WHERE SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = 'SNES')
+	`).Scan(&snesCount))
+	assert.Equal(t, 0, nesCount, "NES media should be deleted")
+	assert.Equal(t, 1, snesCount, "SNES media should remain")
 
-	// Expect Systems deletion (CASCADE handles all related records)
-	mock.ExpectExec(`DELETE FROM Systems WHERE SystemID IN \(\?\)`).
-		WithArgs("NES").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	// Expect cleanup of orphaned tags (RESTRICT prevented cascade, so we clean separately)
-	// Note: TagTypes are NOT deleted as they are global infrastructure shared across systems
-	mock.ExpectExec(`DELETE FROM Tags WHERE DBID NOT IN`).
-		WillReturnResult(sqlmock.NewResult(0, 0))
-
-	err = sqlTruncateSystems(context.Background(), db, systemIDs)
-	assert.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
+	// Tag 2 ("RPG") was only referenced by NES media → deleted as orphan.
+	// Tag 1 ("Action") is still referenced by SNES media → must survive.
+	// Tag 3 ("Extension") was never referenced → must survive.
+	var tag1, tag2, tag3 int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 1").Scan(&tag1))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 2").Scan(&tag2))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Tags WHERE DBID = 3").Scan(&tag3))
+	assert.Equal(t, 1, tag1, "shared tag (Action) must survive")
+	assert.Equal(t, 0, tag2, "NES-only tag (RPG) should be deleted")
+	assert.Equal(t, 1, tag3, "unreferenced tag (Extension) must survive")
 }
 
-func TestSqlTruncateSystems_SystemsDeletionFailure(t *testing.T) {
+func TestSqlTruncateSystems_NonExistent(t *testing.T) {
 	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
+	_, db := setupTruncateTestDB(t)
+	ctx := context.Background()
+
+	// Truncating a system that doesn't exist should be a no-op without error.
+	err := sqlTruncateSystems(ctx, db, []string{"GameBoy"})
 	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
 
-	systemIDs := []string{"NES"}
-
-	// Expect Systems deletion to fail
-	mock.ExpectExec(`DELETE FROM Systems WHERE SystemID IN \(\?\)`).
-		WithArgs("NES").
-		WillReturnError(sql.ErrConnDone)
-
-	err = sqlTruncateSystems(context.Background(), db, systemIDs)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete systems")
-	assert.NoError(t, mock.ExpectationsWereMet())
+	var systemCount int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM Systems").Scan(&systemCount))
+	assert.Equal(t, 2, systemCount, "existing systems should be untouched")
 }
 
-func TestSqlTruncateSystems_CleanupFailure(t *testing.T) {
+func TestSqlTruncateSystems_CancelledContext(t *testing.T) {
 	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
 
-	systemIDs := []string{"NES"}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
 
-	// Expect Systems deletion to succeed
-	mock.ExpectExec(`DELETE FROM Systems WHERE SystemID IN \(\?\)`).
-		WithArgs("NES").
-		WillReturnResult(sqlmock.NewResult(0, 1))
-
-	// Expect cleanup to fail
-	// Note: TagTypes are NOT deleted as they are global infrastructure shared across systems
-	mock.ExpectExec(`DELETE FROM Tags WHERE DBID NOT IN`).
-		WillReturnError(sql.ErrConnDone)
-
-	err = sqlTruncateSystems(context.Background(), db, systemIDs)
+	err := sqlTruncateSystems(ctx, mediaDB.sql, []string{"NES"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to clean up orphaned tags")
-	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestPrepareVariadic_Success(t *testing.T) {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -717,9 +717,9 @@ func NewNamesIndex(
 
 			log.Info().Msg("database truncation completed")
 		} else {
-			// Selective indexing
-			// DELETE mode disables FKs for performance, but TruncateSystems() relies on CASCADE
-			// to properly delete Media/MediaTitles/MediaTags when a System is deleted
+			// Selective indexing — same optimised TruncateSystems path as resume:
+			// FKs are disabled internally, children are deleted in explicit order,
+			// no CASCADE walk.
 			log.Info().Msgf(
 				"performing selective truncation for systems: %v",
 				currentSystemIDs,

--- a/pkg/database/mediascanner/truncate_regression_test.go
+++ b/pkg/database/mediascanner/truncate_regression_test.go
@@ -1,0 +1,329 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+// Regression tests for sqlTruncateSystems correctness.
+//
+// These tests guard against two bugs that were fixed together:
+//
+//  1. CASCADE DELETE stall: the old implementation deleted Systems rows with FK CASCADE
+//     enabled, causing SQLite to walk 50K–200K child rows on SD card. The fix uses
+//     PRAGMA foreign_keys=OFF + explicit child-first DELETEs.
+//
+//  2. Orphan tag cleanup full-table scan: the old implementation used
+//     NOT IN (SELECT ... UNION SELECT ... UNION SELECT ...)
+//     against the full MediaTags/MediaTitleTags/SupportingMedia tables (hundreds of
+//     thousands of rows after other systems are indexed). The fix bounds the cleanup to
+//     a pre-collected candidate set and uses NOT EXISTS for index-friendly lookups.
+//
+// Both bugs only manifested at scale — small test DBs worked fine — so these tests
+// use enough systems/files to exercise the shared-tag and FK-integrity invariants
+// that distinguish the buggy from the correct implementation.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner/testdata"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertFKIntegrity fails the test if any child table contains rows whose parent
+// key no longer exists. Catches regressions where TruncateSystems leaves orphaned
+// rows in a sibling system's data.
+func assertFKIntegrity(t *testing.T, ctx context.Context, sqlDB *sql.DB) { //nolint:revive // t before ctx is standard test helper convention
+	t.Helper()
+
+	checks := []struct {
+		name  string
+		query string
+	}{
+		{
+			"Media.MediaTitleDBID → MediaTitles",
+			`SELECT COUNT(*) FROM Media m
+			 LEFT JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
+			 WHERE mt.DBID IS NULL`,
+		},
+		{
+			"Media.SystemDBID → Systems",
+			`SELECT COUNT(*) FROM Media m
+			 LEFT JOIN Systems s ON s.DBID = m.SystemDBID
+			 WHERE s.DBID IS NULL`,
+		},
+		{
+			"MediaTags.MediaDBID → Media",
+			`SELECT COUNT(*) FROM MediaTags mtg
+			 LEFT JOIN Media m ON m.DBID = mtg.MediaDBID
+			 WHERE m.DBID IS NULL`,
+		},
+		{
+			"MediaTags.TagDBID → Tags",
+			`SELECT COUNT(*) FROM MediaTags mtg
+			 LEFT JOIN Tags t ON t.DBID = mtg.TagDBID
+			 WHERE t.DBID IS NULL`,
+		},
+		{
+			"MediaTitles.SystemDBID → Systems",
+			`SELECT COUNT(*) FROM MediaTitles mt
+			 LEFT JOIN Systems s ON s.DBID = mt.SystemDBID
+			 WHERE s.DBID IS NULL`,
+		},
+	}
+
+	for _, c := range checks {
+		var orphans int
+		require.NoError(t, sqlDB.QueryRowContext(ctx, c.query).Scan(&orphans),
+			"FK integrity query failed: %s", c.name)
+		assert.Equal(t, 0, orphans, "FK violation: %s has %d orphaned rows", c.name, orphans)
+	}
+}
+
+// indexSystems fully indexes the given systems via AddMediaPath inside a single transaction.
+func indexSystems(
+	t *testing.T,
+	db database.MediaDBI,
+	state *database.ScanState,
+	systems []string,
+	batch testdata.TestBatch,
+) {
+	t.Helper()
+	require.NoError(t, db.BeginTransaction(false))
+	for _, sys := range systems {
+		for _, entry := range batch.Entries[sys] {
+			_, _, err := AddMediaPath(db, state, sys, entry.Path, false, false, nil, "")
+			require.NoError(t, err, "AddMediaPath failed for system %s", sys)
+		}
+	}
+	require.NoError(t, db.CommitTransaction())
+}
+
+// TestTruncateResume_SharedTagsPreserved guards against the orphan tag cleanup
+// over-deleting tags that are shared with still-indexed systems.
+//
+// Before the fix, the NOT IN (SELECT UNION ...) orphan cleanup ran against ALL rows
+// in MediaTags. After truncating one system, it correctly excluded tags still referenced
+// by other systems — but this was a full table scan that could take seconds. If the query
+// logic ever had a bug, shared tags could be incorrectly deleted, corrupting remaining data.
+//
+// This test verifies that tags referenced by multiple systems survive truncation of one.
+func TestTruncateResume_SharedTagsPreserved(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	defer cleanup()
+
+	// Use enough games per system that genre tags (from the fixed generator list of 14
+	// genres) will collide across systems — i.e., both NES and C64 will have an "Action"
+	// or "RPG" MediaTag, creating shared Tags rows in the DB.
+	batch := testdata.CreateReproducibleBatch([]string{"NES", "C64"}, 15)
+
+	state := &database.ScanState{
+		SystemIDs:  make(map[string]int),
+		TitleIDs:   make(map[string]int),
+		MediaIDs:   make(map[string]int),
+		TagTypeIDs: make(map[string]int),
+		TagIDs:     make(map[string]int),
+	}
+	require.NoError(t, SeedCanonicalTags(db, state))
+
+	// Fully index NES, then partially index C64 (5 of 15 files — simulates interrupt).
+	indexSystems(t, db, state, []string{"NES"}, batch)
+
+	require.NoError(t, db.BeginTransaction(false))
+	for _, entry := range batch.Entries["C64"][:5] {
+		_, _, err := AddMediaPath(db, state, "C64", entry.Path, false, false, nil, "")
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.CommitTransaction())
+
+	// Record how many tags the NES system references before truncating C64.
+	sqlDB := db.UnsafeGetSQLDb()
+	var nesTagCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT mtg.TagDBID)
+		FROM MediaTags mtg
+		INNER JOIN Media m ON m.DBID = mtg.MediaDBID
+		INNER JOIN Systems s ON s.DBID = m.SystemDBID
+		WHERE s.SystemID = 'NES'
+	`).Scan(&nesTagCount))
+	require.Positive(t, nesTagCount, "NES must have tags for this test to be meaningful")
+
+	// Truncate the partially-indexed C64 system.
+	require.NoError(t, db.TruncateSystems([]string{"C64"}))
+
+	// All NES tags must still exist — the orphan cleanup must not touch them.
+	var survivingNESTags int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(DISTINCT mtg.TagDBID)
+		FROM MediaTags mtg
+		INNER JOIN Media m ON m.DBID = mtg.MediaDBID
+		INNER JOIN Systems s ON s.DBID = m.SystemDBID
+		WHERE s.SystemID = 'NES'
+	`).Scan(&survivingNESTags))
+	assert.Equal(t, nesTagCount, survivingNESTags,
+		"all tags referenced by NES must survive C64 truncation")
+
+	// NES media count must be unchanged.
+	var nesMedia int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM Media m
+		INNER JOIN Systems s ON s.DBID = m.SystemDBID
+		WHERE s.SystemID = 'NES'
+	`).Scan(&nesMedia))
+	assert.Equal(t, 15, nesMedia, "NES media must be untouched after C64 truncation")
+
+	// C64 system row must be gone.
+	var c64Systems int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM Systems WHERE SystemID = 'C64'
+	`).Scan(&c64Systems))
+	assert.Equal(t, 0, c64Systems, "C64 system must be gone after truncation")
+
+	// No FK violations anywhere in the remaining data.
+	assertFKIntegrity(t, ctx, sqlDB)
+}
+
+// TestTruncateResume_MultipleSystemsIndexed is the primary regression test for the
+// stall reported in PR #705: the indexer froze during C64 resume because TruncateSystems
+// had to CASCADE-delete through ~200K rows already indexed by other systems, and then
+// run a NOT IN full-table scan across those same rows for orphan cleanup.
+//
+// This test replicates the essential structure:
+//   - N systems fully indexed (large dataset that exercises the orphan scan cost)
+//   - One system partially indexed (simulates the interrupted C64 run)
+//   - TruncateSystems on the partial system
+//   - Re-index the partial system from scratch
+//   - Verify no duplicates, no FK violations, correct final counts
+func TestTruncateResume_MultipleSystemsIndexed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	defer cleanup()
+
+	// Multiple fully-indexed systems (simulates the 239K-file MiSTer library that
+	// made the orphan table scan expensive in the bug report).
+	const gamesPerSystem = 20
+	const partialGameCount = 8
+	const partialSystem = "C64"
+	fullSystems := []string{"NES", "SNES", "Genesis", "GBA", "PSX"}
+	allSystems := make([]string, len(fullSystems)+1)
+	copy(allSystems, fullSystems)
+	allSystems[len(fullSystems)] = partialSystem
+	batch := testdata.CreateReproducibleBatch(allSystems, gamesPerSystem)
+
+	state := &database.ScanState{
+		SystemIDs:  make(map[string]int),
+		TitleIDs:   make(map[string]int),
+		MediaIDs:   make(map[string]int),
+		TagTypeIDs: make(map[string]int),
+		TagIDs:     make(map[string]int),
+	}
+	require.NoError(t, SeedCanonicalTags(db, state))
+
+	// Step 1: fully index the non-C64 systems.
+	indexSystems(t, db, state, fullSystems, batch)
+
+	// Step 2: partially index C64 (simulates the mid-index interrupt).
+	require.NoError(t, db.BeginTransaction(false))
+	for _, entry := range batch.Entries[partialSystem][:partialGameCount] {
+		_, _, err := AddMediaPath(db, state, partialSystem, entry.Path, false, false, nil, "")
+		require.NoError(t, err)
+	}
+	require.NoError(t, db.CommitTransaction())
+
+	sqlDB := db.UnsafeGetSQLDb()
+
+	var beforeTotalMedia int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&beforeTotalMedia))
+	expectedPartial := len(fullSystems)*gamesPerSystem + partialGameCount
+	assert.Equal(t, expectedPartial, beforeTotalMedia, "pre-truncation count should match indexed files")
+
+	// Step 3: simulate resume — TruncateSystems on the partial C64 data.
+	// This is where the stall occurred in the bug report.
+	require.NoError(t, db.TruncateSystems([]string{partialSystem}))
+
+	// Step 4: C64 rows must be gone; all other systems intact.
+	var afterTruncateMedia int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&afterTruncateMedia))
+	assert.Equal(t, len(fullSystems)*gamesPerSystem, afterTruncateMedia,
+		"after truncating C64, only fully-indexed system media should remain")
+
+	for _, sys := range fullSystems {
+		var count int
+		require.NoError(t, sqlDB.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM Media m
+			INNER JOIN Systems s ON s.DBID = m.SystemDBID
+			WHERE s.SystemID = ?`, sys).Scan(&count))
+		assert.Equal(t, gamesPerSystem, count, "system %s must have all games after C64 truncation", sys)
+	}
+
+	// Step 5: no FK violations in the remaining data.
+	assertFKIntegrity(t, ctx, sqlDB)
+
+	// Step 6: re-index C64 from scratch — mirrors the production resume path.
+	// PopulateScanStateFromDB is called before the main loop in mediascanner.go,
+	// then the partial system is truncated and re-indexed.
+	resumeState := &database.ScanState{
+		SystemIDs:  make(map[string]int),
+		TitleIDs:   make(map[string]int),
+		MediaIDs:   make(map[string]int),
+		TagTypeIDs: state.TagTypeIDs,
+		TagIDs:     state.TagIDs,
+	}
+	require.NoError(t, PopulateScanStateFromDB(ctx, db, resumeState))
+	delete(resumeState.SystemIDs, partialSystem)
+
+	allTags, err := db.GetAllTags()
+	require.NoError(t, err)
+	tagTypeByDBID := make(map[int64]string, len(resumeState.TagTypeIDs))
+	for tt, id := range resumeState.TagTypeIDs {
+		tagTypeByDBID[int64(id)] = tt
+	}
+	resumeState.TagIDs = make(map[string]int, len(allTags))
+	for _, tag := range allTags {
+		resumeState.TagIDs[database.TagKey(tagTypeByDBID[tag.TypeDBID], tag.Tag)] = int(tag.DBID)
+	}
+	require.NoError(t, SeedCanonicalTags(db, resumeState))
+
+	require.NoError(t, db.BeginTransaction(false))
+	for _, entry := range batch.Entries[partialSystem] {
+		_, _, addErr := AddMediaPath(db, resumeState, partialSystem, entry.Path, false, false, nil, "")
+		require.NoError(t, addErr, "re-index must not fail with UNIQUE or FK violation")
+	}
+	require.NoError(t, db.CommitTransaction())
+
+	// Step 7: final counts — all systems complete, no duplicates, no FK violations.
+	var finalTotal int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&finalTotal))
+	assert.Equal(t, len(allSystems)*gamesPerSystem, finalTotal,
+		"after full re-index, total media must equal all systems × games per system")
+
+	duplicates, err := db.CheckForDuplicateMediaTitles()
+	require.NoError(t, err)
+	assert.Empty(t, duplicates, "no duplicate MediaTitles allowed after resume re-index")
+
+	assertFKIntegrity(t, ctx, sqlDB)
+}


### PR DESCRIPTION
- `sqlTruncateSystems` used `DELETE FROM Systems` with FK CASCADE enabled, causing SQLite to walk 50K–200K child rows on slow storage (SD card) before each System row was removed.
- Orphan tag cleanup used `NOT IN (SELECT … UNION SELECT … UNION SELECT …)` against the full `MediaTags`/`MediaTitleTags`/`SupportingMedia` tables — a full-table scan that grew proportionally with the total indexed library size.
- Rewritten to: pin to a single connection (PRAGMA is session-local), resolve SystemID strings to integer DBIDs upfront, pre-collect candidate orphan tag DBIDs into a TEMP TABLE before any deletes, disable FK enforcement and delete children in explicit reverse-dependency order by SystemDBID, then do a bounded `NOT EXISTS` orphan tag cleanup.
- Converts `sqlTruncateSystems` unit tests from sqlmock to a real SQLite fixture so they cover actual DELETE ordering and orphan-detection correctness.
- Adds regression tests in `pkg/database/mediascanner/` exercising shared-tag preservation and FK integrity across the full resume flow at scale.
- Both the resume path and the selective system indexing path route through `TruncateSystems`, so both benefit.

Closes #691
Closes #611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved media-system removal to more safely delete system data while preserving shared tags and ensuring referential integrity.

* **Documentation**
  * Added guidance for estimating total media indexing duration from logs.

* **Tests**
  * Added integration and regression tests validating truncation behavior, tag preservation, FK integrity, resumability, and cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->