### PR TITLE
feat(mister): add RBF disambiguation cache and load_path config override

### DIFF
--- a/pkg/config/configlaunchers.go
+++ b/pkg/config/configlaunchers.go
@@ -51,6 +51,11 @@ type LaunchersDefault struct {
 	// - "" or "run": Default behavior (launch/play the media)
 	// - "details": Show media details/info page instead of launching
 	Action string `toml:"action,omitempty"`
+	// LoadPath specifies the implementation file the launcher should load.
+	// Format is launcher-specific. For MiSTer, this is an MGL-form RBF path
+	// like "_Unstable/SNES" (no extension, relative to /media/fat). Launchers
+	// that do not load an implementation file ignore this field.
+	LoadPath string `toml:"load_path,omitempty"`
 }
 
 type LaunchersCustom struct {
@@ -142,6 +147,9 @@ func (c *Instance) LookupLauncherDefaults(launcherID string, groups []string) La
 			if entry.Action != "" {
 				result.Action = entry.Action
 			}
+			if entry.LoadPath != "" {
+				result.LoadPath = entry.LoadPath
+			}
 		}
 	}
 
@@ -150,6 +158,7 @@ func (c *Instance) LookupLauncherDefaults(launcherID string, groups []string) La
 		Str("resolvedServerURL", result.ServerURL).
 		Str("resolvedAction", result.Action).
 		Str("resolvedInstallDir", result.InstallDir).
+		Str("resolvedLoadPath", result.LoadPath).
 		Msg("LookupLauncherDefaults: resolution complete")
 
 	return result

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -402,6 +402,20 @@ func TestLookupLauncherDefaults_LaterEntryOverridesLoadPath(t *testing.T) {
 	assert.Equal(t, "_Unstable/SNES", result.LoadPath, "later entry must win")
 }
 
+func TestLookupLauncherDefaults_LoadPathTOMLRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "Nintendo64"
+load_path = "_LLAPI/N64_LLAPI"
+`))
+
+	result := cfg.LookupLauncherDefaults("Nintendo64", nil)
+	assert.Equal(t, "_LLAPI/N64_LLAPI", result.LoadPath, "load_path must survive TOML round-trip")
+}
+
 func TestLoadTOML_LauncherDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -162,6 +162,7 @@ func TestLookupLauncherDefaults(t *testing.T) {
 		expectedServerURL string
 		expectedAction    string
 		expectedInstall   string
+		expectedLoadPath  string
 		groups            []string
 		defaults          []LaunchersDefault
 	}{
@@ -322,6 +323,25 @@ func TestLookupLauncherDefaults(t *testing.T) {
 			expectedAction:    "details",
 			expectedInstall:   "/movies",
 		},
+		{
+			name:       "group match propagates load_path",
+			launcherID: "SNES",
+			groups:     []string{"MiSTer"},
+			defaults: []LaunchersDefault{
+				{Launcher: "MiSTer", LoadPath: "_Unstable/SNES"},
+			},
+			expectedLoadPath: "_Unstable/SNES",
+		},
+		{
+			name:       "exact launcher overrides group load_path",
+			launcherID: "SNES",
+			groups:     []string{"MiSTer"},
+			defaults: []LaunchersDefault{
+				{Launcher: "MiSTer", LoadPath: "_Unstable/SNES"},
+				{Launcher: "SNES", LoadPath: "_Console/SNES"},
+			},
+			expectedLoadPath: "_Console/SNES",
+		},
 	}
 
 	for _, tt := range tests {
@@ -342,8 +362,44 @@ func TestLookupLauncherDefaults(t *testing.T) {
 			assert.Equal(t, tt.expectedServerURL, result.ServerURL, "ServerURL mismatch")
 			assert.Equal(t, tt.expectedAction, result.Action, "Action mismatch")
 			assert.Equal(t, tt.expectedInstall, result.InstallDir, "InstallDir mismatch")
+			assert.Equal(t, tt.expectedLoadPath, result.LoadPath, "LoadPath mismatch")
 		})
 	}
+}
+
+func TestLookupLauncherDefaults_MergesLoadPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Launchers: Launchers{
+				Default: []LaunchersDefault{
+					{Launcher: "SNES", LoadPath: "_Unstable/SNES"},
+				},
+			},
+		},
+	}
+
+	result := cfg.LookupLauncherDefaults("SNES", nil)
+	assert.Equal(t, "_Unstable/SNES", result.LoadPath)
+}
+
+func TestLookupLauncherDefaults_LaterEntryOverridesLoadPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Launchers: Launchers{
+				Default: []LaunchersDefault{
+					{Launcher: "SNES", LoadPath: "_Homebrew/SNES"},
+					{Launcher: "SNES", LoadPath: "_Unstable/SNES"},
+				},
+			},
+		},
+	}
+
+	result := cfg.LookupLauncherDefaults("SNES", nil)
+	assert.Equal(t, "_Unstable/SNES", result.LoadPath, "later entry must win")
 }
 
 func TestLoadTOML_LauncherDefaults(t *testing.T) {

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -22,8 +22,10 @@
 package cores
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/rs/zerolog/log"
 )
@@ -75,20 +77,20 @@ func (c *RBFCache) populateCache() {
 	rbfFiles, err := shallowScanRBF()
 	if err != nil {
 		log.Warn().Err(err).Msg("RBF cache: scan failed, using empty cache")
-		c.buildFromRBFs(nil)
+		c.BuildFromRBFs(nil)
 		return
 	}
-	c.buildFromRBFs(rbfFiles)
+	c.BuildFromRBFs(rbfFiles)
 	log.Info().
 		Int("rbf_files", len(rbfFiles)).
 		Int("systems_mapped", len(c.bySystemID)).
 		Msg("RBF cache initialized")
 }
 
-// buildFromRBFs deterministically rebuilds bySystemID and byShortName from a
+// BuildFromRBFs deterministically rebuilds bySystemID and byShortName from a
 // scanned RBF list, preferring each system's canonical directory when multiple
 // RBFs share a short name. No filesystem access; safe to call in tests.
-func (c *RBFCache) buildFromRBFs(rbfFiles []RBFInfo) {
+func (c *RBFCache) BuildFromRBFs(rbfFiles []RBFInfo) {
 	c.bySystemID = make(map[string]RBFInfo)
 	c.byShortName = make(map[string][]RBFInfo)
 
@@ -168,46 +170,41 @@ func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 	return selectByCanonicalDir(c.byShortName[strings.ToLower(shortName)], canonicalDir)
 }
 
-// ResolveRBFPath returns the cached RBF path for a system, or falls back to
-// the hardcoded path if not cached.
-func ResolveRBFPath(systemID, hardcodedRBF string) string {
-	if cached, ok := GlobalRBFCache.GetBySystemID(systemID); ok {
-		log.Debug().
-			Str("system", systemID).
-			Str("cached_path", cached.MglName).
-			Str("hardcoded_path", hardcodedRBF).
-			Msg("RBF resolved from cache")
-		return cached.MglName
+// Resolve returns the RBFInfo for a core, honoring config load_path override,
+// then alt core LauncherID, then system ID. It errors if load_path is set but
+// doesn't match a scanned RBF, or if no lookup succeeds.
+func (c *RBFCache) Resolve(cfg *config.Instance, core *Core) (RBFInfo, error) {
+	key := core.LauncherID
+	if key == "" {
+		key = core.ID
 	}
 
-	return hardcodedRBF
-}
-
-// ResolveRBFPathForLauncher resolves RBF path using launcherID if available,
-// falling back to systemID lookup for main cores.
-func ResolveRBFPathForLauncher(launcherID, systemID, hardcodedRBF string) string {
-	// Try launcherID first (for alt cores)
-	if launcherID != "" {
-		if cached, ok := GlobalRBFCache.GetByLauncherID(launcherID); ok {
-			log.Debug().
-				Str("launcher", launcherID).
-				Str("cached_path", cached.MglName).
-				Msg("RBF resolved by launcher ID")
-			return cached.MglName
+	if cfg != nil {
+		if lp := cfg.LookupLauncherDefaults(key, nil).LoadPath; lp != "" {
+			rbfInfo, ok := c.GetByMglPath(lp)
+			if !ok {
+				return RBFInfo{}, fmt.Errorf(
+					"configured load_path %q for %s not found in RBF cache", lp, core.ID,
+				)
+			}
+			log.Debug().Str("system", core.ID).Str("load_path", lp).Msg("core overridden by config load_path")
+			return rbfInfo, nil
 		}
 	}
 
-	// Fall back to systemID lookup (for main cores)
-	if cached, ok := GlobalRBFCache.GetBySystemID(systemID); ok {
-		log.Debug().
-			Str("system", systemID).
-			Str("cached_path", cached.MglName).
-			Msg("RBF resolved by system ID")
-		return cached.MglName
+	if core.LauncherID != "" {
+		if rbfInfo, ok := c.GetByLauncherID(core.LauncherID); ok {
+			return rbfInfo, nil
+		}
 	}
 
-	// Final fallback to hardcoded path
-	return hardcodedRBF
+	rbfInfo, ok := c.GetBySystemID(core.ID)
+	if !ok {
+		return RBFInfo{}, fmt.Errorf(
+			"no core found for system %s (launcher %s, not in cache)", core.ID, key,
+		)
+	}
+	return rbfInfo, nil
 }
 
 // Count returns the number of cached entries.

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -57,7 +57,7 @@ func selectByCanonicalDir(candidates []RBFInfo, canonicalDir string) (RBFInfo, b
 	}
 	for _, c := range candidates {
 		dir, _ := splitRBFPath(c.MglName)
-		if dir == canonicalDir {
+		if strings.EqualFold(dir, canonicalDir) {
 			return c, true
 		}
 	}

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -22,6 +22,7 @@
 package cores
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -174,6 +175,9 @@ func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 // then alt core LauncherID, then system ID. It errors if load_path is set but
 // doesn't match a scanned RBF, or if no lookup succeeds.
 func (c *RBFCache) Resolve(cfg *config.Instance, core *Core) (RBFInfo, error) {
+	if core == nil {
+		return RBFInfo{}, errors.New("nil core")
+	}
 	key := core.LauncherID
 	if key == "" {
 		key = core.ID

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -135,14 +135,28 @@ func (c *RBFCache) GetByShortName(shortName string) (RBFInfo, bool) {
 }
 
 // GetByMglPath resolves a user-supplied MGL path (e.g. "_Unstable/SNES") to a
-// scanned RBFInfo, preferring the directory embedded in the path. Returns false
-// if no scanned RBF matches the short name.
+// scanned RBFInfo. When the path includes a directory, the match is strict: a
+// wrong directory returns (RBFInfo{}, false) instead of a silent fallback to
+// another core. A bare short name (no directory) returns the first candidate.
 func (c *RBFCache) GetByMglPath(mglPath string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	canonicalDir, shortName := splitRBFPath(mglPath)
-	return selectByCanonicalDir(c.byShortName[strings.ToLower(shortName)], canonicalDir)
+	candidates := c.byShortName[strings.ToLower(shortName)]
+	if len(candidates) == 0 {
+		return RBFInfo{}, false
+	}
+	if canonicalDir == "" {
+		return candidates[0], true
+	}
+	for _, candidate := range candidates {
+		dir, _ := splitRBFPath(candidate.MglName)
+		if strings.EqualFold(dir, canonicalDir) {
+			return candidate, true
+		}
+	}
+	return RBFInfo{}, false
 }
 
 // RegisterAltCore registers an alt core's expected RBF path.
@@ -156,8 +170,10 @@ func (c *RBFCache) RegisterAltCore(launcherID, rbfPath string) {
 	c.byLauncherID[launcherID] = rbfPath
 }
 
-// GetByLauncherID returns the resolved RBF path for an alt core launcher,
-// preferring the directory registered for that launcher.
+// GetByLauncherID returns the resolved RBF path for an alt core launcher.
+// When the registered path includes a directory, the match is strict: a
+// directory mismatch returns (RBFInfo{}, false) rather than silently falling
+// back to a different directory's core.
 func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -168,7 +184,20 @@ func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 	}
 
 	canonicalDir, shortName := splitRBFPath(rbfPath)
-	return selectByCanonicalDir(c.byShortName[strings.ToLower(shortName)], canonicalDir)
+	candidates := c.byShortName[strings.ToLower(shortName)]
+	if len(candidates) == 0 {
+		return RBFInfo{}, false
+	}
+	if canonicalDir == "" {
+		return candidates[0], true
+	}
+	for _, candidate := range candidates {
+		dir, _ := splitRBFPath(candidate.MglName)
+		if strings.EqualFold(dir, canonicalDir) {
+			return candidate, true
+		}
+	}
+	return RBFInfo{}, false
 }
 
 // Resolve returns the RBFInfo for a core, honoring config load_path override,

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -28,16 +28,41 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// RBFCache provides O(1) lookups of RBF paths by system ID, short name, or launcher ID.
+// RBFCache provides lookups of RBF paths by system ID, short name, or launcher ID.
 type RBFCache struct {
 	bySystemID   map[string]RBFInfo
-	byShortName  map[string]RBFInfo
-	byLauncherID map[string]string // launcherID → rbfPath (unresolved)
+	byShortName  map[string][]RBFInfo // short name (lower) → all scanned RBFs with that short name
+	byLauncherID map[string]string    // launcherID → rbfPath (unresolved)
 	mu           syncutil.RWMutex
 }
 
 // GlobalRBFCache is the singleton instance for the MiSTer platform.
 var GlobalRBFCache = &RBFCache{}
+
+// splitRBFPath splits an RBF path like "_Console/SNES" into ("_Console", "SNES").
+// A bare short name returns ("", name).
+func splitRBFPath(rbfPath string) (dir, shortName string) {
+	if idx := strings.LastIndex(rbfPath, "/"); idx >= 0 {
+		return rbfPath[:idx], rbfPath[idx+1:]
+	}
+	return "", rbfPath
+}
+
+// selectByCanonicalDir prefers the candidate whose MglName directory equals canonicalDir.
+// Falls back to the first candidate when no canonical match exists. Returns false only
+// when candidates is empty.
+func selectByCanonicalDir(candidates []RBFInfo, canonicalDir string) (RBFInfo, bool) {
+	if len(candidates) == 0 {
+		return RBFInfo{}, false
+	}
+	for _, c := range candidates {
+		dir, _ := splitRBFPath(c.MglName)
+		if dir == canonicalDir {
+			return c, true
+		}
+	}
+	return candidates[0], true
+}
 
 // Refresh scans for RBF files and rebuilds the cache.
 func (c *RBFCache) Refresh() {
@@ -47,39 +72,41 @@ func (c *RBFCache) Refresh() {
 }
 
 func (c *RBFCache) populateCache() {
-	c.bySystemID = make(map[string]RBFInfo)
-	c.byShortName = make(map[string]RBFInfo)
-
 	rbfFiles, err := shallowScanRBF()
 	if err != nil {
 		log.Warn().Err(err).Msg("RBF cache: scan failed, using empty cache")
+		c.buildFromRBFs(nil)
 		return
 	}
+	c.buildFromRBFs(rbfFiles)
+	log.Info().
+		Int("rbf_files", len(rbfFiles)).
+		Int("systems_mapped", len(c.bySystemID)).
+		Msg("RBF cache initialized")
+}
+
+// buildFromRBFs deterministically rebuilds bySystemID and byShortName from a
+// scanned RBF list, preferring each system's canonical directory when multiple
+// RBFs share a short name. No filesystem access; safe to call in tests.
+func (c *RBFCache) buildFromRBFs(rbfFiles []RBFInfo) {
+	c.bySystemID = make(map[string]RBFInfo)
+	c.byShortName = make(map[string][]RBFInfo)
 
 	for _, rbf := range rbfFiles {
 		key := strings.ToLower(rbf.ShortName)
-		c.byShortName[key] = rbf
+		c.byShortName[key] = append(c.byShortName[key], rbf)
 	}
 
 	for _, system := range Systems {
 		if system.RBF == "" {
 			continue
 		}
-
-		shortName := system.RBF
-		if idx := strings.LastIndex(shortName, "/"); idx >= 0 {
-			shortName = shortName[idx+1:]
-		}
-
-		if rbf, ok := c.byShortName[strings.ToLower(shortName)]; ok {
+		canonicalDir, shortName := splitRBFPath(system.RBF)
+		candidates := c.byShortName[strings.ToLower(shortName)]
+		if rbf, ok := selectByCanonicalDir(candidates, canonicalDir); ok {
 			c.bySystemID[system.ID] = rbf
 		}
 	}
-
-	log.Info().
-		Int("rbf_files", len(rbfFiles)).
-		Int("systems_mapped", len(c.bySystemID)).
-		Msg("RBF cache initialized")
 }
 
 // GetBySystemID returns the cached RBFInfo for a system ID.
@@ -91,13 +118,28 @@ func (c *RBFCache) GetBySystemID(systemID string) (RBFInfo, bool) {
 	return rbf, ok
 }
 
-// GetByShortName returns the cached RBFInfo for a short name. Case-insensitive.
+// GetByShortName returns the first cached RBFInfo for a short name. Case-insensitive.
+// For directory-aware lookup, use GetBySystemID or GetByLauncherID.
 func (c *RBFCache) GetByShortName(shortName string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	rbf, ok := c.byShortName[strings.ToLower(shortName)]
-	return rbf, ok
+	candidates := c.byShortName[strings.ToLower(shortName)]
+	if len(candidates) == 0 {
+		return RBFInfo{}, false
+	}
+	return candidates[0], true
+}
+
+// GetByMglPath resolves a user-supplied MGL path (e.g. "_Unstable/SNES") to a
+// scanned RBFInfo, preferring the directory embedded in the path. Returns false
+// if no scanned RBF matches the short name.
+func (c *RBFCache) GetByMglPath(mglPath string) (RBFInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	canonicalDir, shortName := splitRBFPath(mglPath)
+	return selectByCanonicalDir(c.byShortName[strings.ToLower(shortName)], canonicalDir)
 }
 
 // RegisterAltCore registers an alt core's expected RBF path.
@@ -111,7 +153,8 @@ func (c *RBFCache) RegisterAltCore(launcherID, rbfPath string) {
 	c.byLauncherID[launcherID] = rbfPath
 }
 
-// GetByLauncherID returns the resolved RBF path for an alt core launcher.
+// GetByLauncherID returns the resolved RBF path for an alt core launcher,
+// preferring the directory registered for that launcher.
 func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -121,14 +164,8 @@ func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 		return RBFInfo{}, false
 	}
 
-	// Extract short name and look up in byShortName
-	shortName := rbfPath
-	if idx := strings.LastIndex(rbfPath, "/"); idx >= 0 {
-		shortName = rbfPath[idx+1:]
-	}
-
-	info, ok := c.byShortName[strings.ToLower(shortName)]
-	return info, ok
+	canonicalDir, shortName := splitRBFPath(rbfPath)
+	return selectByCanonicalDir(c.byShortName[strings.ToLower(shortName)], canonicalDir)
 }
 
 // ResolveRBFPath returns the cached RBF path for a system, or falls back to
@@ -178,5 +215,9 @@ func (c *RBFCache) Count() (systems, rbfs int) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	return len(c.bySystemID), len(c.byShortName)
+	total := 0
+	for _, v := range c.byShortName {
+		total += len(v)
+	}
+	return len(c.bySystemID), total
 }

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -142,13 +142,13 @@ func TestRBFCacheGetBySystemID_CacheHit(t *testing.T) {
 				MglName:   "_Console/NES",
 			},
 		},
-		byShortName: map[string]RBFInfo{
-			"nes": {
+		byShortName: map[string][]RBFInfo{
+			"nes": {{
 				Path:      "/media/fat/_Console/NES_20231212.rbf",
 				Filename:  "NES_20231212.rbf",
 				ShortName: "NES",
 				MglName:   "_Console/NES",
-			},
+			}},
 		},
 	}
 
@@ -285,7 +285,7 @@ func TestGetByLauncherID_RegisteredButNotInShortNameCache(t *testing.T) {
 	t.Parallel()
 
 	cache := &RBFCache{
-		byShortName: make(map[string]RBFInfo),
+		byShortName: make(map[string][]RBFInfo),
 	}
 
 	// Register an alt core
@@ -300,13 +300,13 @@ func TestGetByLauncherID_CacheHit(t *testing.T) {
 	t.Parallel()
 
 	cache := &RBFCache{
-		byShortName: map[string]RBFInfo{
-			"psx2xcpu": {
+		byShortName: map[string][]RBFInfo{
+			"psx2xcpu": {{
 				Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
 				Filename:  "PSX2XCPU_20240101.rbf",
 				ShortName: "PSX2XCPU",
 				MglName:   "_Other/PSX2XCPU",
-			},
+			}},
 		},
 	}
 
@@ -324,13 +324,13 @@ func TestGetByLauncherID_ExtractsShortNameFromPath(t *testing.T) {
 	t.Parallel()
 
 	cache := &RBFCache{
-		byShortName: map[string]RBFInfo{
-			"n64_80mhz": {
+		byShortName: map[string][]RBFInfo{
+			"n64_80mhz": {{
 				Path:      "/media/fat/_Other/N64_80MHz_20240101.rbf",
 				Filename:  "N64_80MHz_20240101.rbf",
 				ShortName: "N64_80MHz",
 				MglName:   "_Other/N64_80MHz",
-			},
+			}},
 		},
 	}
 
@@ -366,19 +366,19 @@ func TestResolveRBFPathForLauncher_LauncherIDTakesPriority(t *testing.T) {
 			MglName:   "_Console/PSX",
 		},
 	}
-	GlobalRBFCache.byShortName = map[string]RBFInfo{
-		"psx": {
+	GlobalRBFCache.byShortName = map[string][]RBFInfo{
+		"psx": {{
 			Path:      "/media/fat/_Console/PSX_20240101.rbf",
 			Filename:  "PSX_20240101.rbf",
 			ShortName: "PSX",
 			MglName:   "_Console/PSX",
-		},
-		"psx2xcpu": {
+		}},
+		"psx2xcpu": {{
 			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
 			Filename:  "PSX2XCPU_20240101.rbf",
 			ShortName: "PSX2XCPU",
 			MglName:   "_Other/PSX2XCPU",
-		},
+		}},
 	}
 	GlobalRBFCache.byLauncherID = map[string]string{
 		"2XPSX": "_Other/PSX2XCPU",
@@ -410,7 +410,7 @@ func TestResolveRBFPathForLauncher_FallbackChain(t *testing.T) {
 	// Setup empty cache
 	GlobalRBFCache.mu.Lock()
 	GlobalRBFCache.bySystemID = make(map[string]RBFInfo)
-	GlobalRBFCache.byShortName = make(map[string]RBFInfo)
+	GlobalRBFCache.byShortName = make(map[string][]RBFInfo)
 	GlobalRBFCache.byLauncherID = make(map[string]string)
 	GlobalRBFCache.mu.Unlock()
 
@@ -442,7 +442,7 @@ func TestResolveRBFPathForLauncher_LauncherNotFoundFallsBackToSystemID(t *testin
 			MglName:   "_Console/PSX",
 		},
 	}
-	GlobalRBFCache.byShortName = make(map[string]RBFInfo)
+	GlobalRBFCache.byShortName = make(map[string][]RBFInfo)
 	GlobalRBFCache.byLauncherID = make(map[string]string)
 	GlobalRBFCache.mu.Unlock()
 
@@ -478,19 +478,19 @@ func TestRegression_Issue477_AltCoreUsesWrongRBFPath(t *testing.T) {
 			MglName:   "_Console/PSX",
 		},
 	}
-	GlobalRBFCache.byShortName = map[string]RBFInfo{
-		"psx": {
+	GlobalRBFCache.byShortName = map[string][]RBFInfo{
+		"psx": {{
 			Path:      "/media/fat/_Console/PSX_20240101.rbf",
 			Filename:  "PSX_20240101.rbf",
 			ShortName: "PSX",
 			MglName:   "_Console/PSX",
-		},
-		"psx2xcpu": {
+		}},
+		"psx2xcpu": {{
 			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
 			Filename:  "PSX2XCPU_20240101.rbf",
 			ShortName: "PSX2XCPU",
 			MglName:   "_Other/PSX2XCPU",
-		},
+		}},
 	}
 	GlobalRBFCache.byLauncherID = map[string]string{
 		"2XPSX": "_Other/PSX2XCPU",
@@ -514,4 +514,234 @@ func TestRegression_Issue477_AltCoreUsesWrongRBFPath(t *testing.T) {
 	// Test 3: Verify they are different - this is the core of the bug
 	assert.NotEqual(t, mainPSXPath, altCorePath,
 		"alt core should resolve to different path than main core even though they share systemID")
+}
+
+func TestSplitRBFPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input     string
+		wantDir   string
+		wantShort string
+	}{
+		{"_Console/SNES", "_Console", "SNES"},
+		{"_ConsolePWM/_Turbo/PSX2XCPU_PWM", "_ConsolePWM/_Turbo", "PSX2XCPU_PWM"},
+		{"SNES", "", "SNES"},
+		{"", "", ""},
+		{"_Console/", "_Console", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			dir, short := splitRBFPath(tc.input)
+			assert.Equal(t, tc.wantDir, dir)
+			assert.Equal(t, tc.wantShort, short)
+		})
+	}
+}
+
+func TestSelectByCanonicalDir(t *testing.T) {
+	t.Parallel()
+
+	console := RBFInfo{Path: "/media/fat/_Console/SNES_20240101.rbf", ShortName: "SNES", MglName: "_Console/SNES"}
+	unstable := RBFInfo{Path: "/media/fat/_Unstable/SNES_20251001.rbf", ShortName: "SNES", MglName: "_Unstable/SNES"}
+	rootLevel := RBFInfo{Path: "/media/fat/SNES_20240101.rbf", ShortName: "SNES", MglName: "SNES"}
+
+	tests := []struct {
+		name         string
+		canonicalDir string
+		wantMglName  string
+		candidates   []RBFInfo
+		wantOk       bool
+	}{
+		{
+			name:         "empty candidates",
+			candidates:   nil,
+			canonicalDir: "_Console",
+			wantOk:       false,
+		},
+		{
+			name:         "single candidate any dir",
+			candidates:   []RBFInfo{unstable},
+			canonicalDir: "_Console",
+			wantOk:       true,
+			wantMglName:  "_Unstable/SNES",
+		},
+		{
+			name:         "canonical match wins",
+			candidates:   []RBFInfo{unstable, console},
+			canonicalDir: "_Console",
+			wantOk:       true,
+			wantMglName:  "_Console/SNES",
+		},
+		{
+			name:         "canonical match wins reversed order",
+			candidates:   []RBFInfo{console, unstable},
+			canonicalDir: "_Console",
+			wantOk:       true,
+			wantMglName:  "_Console/SNES",
+		},
+		{
+			name:         "no canonical match falls back to first",
+			candidates:   []RBFInfo{unstable, console},
+			canonicalDir: "_Homebrew",
+			wantOk:       true,
+			wantMglName:  "_Unstable/SNES",
+		},
+		{
+			name:         "empty canonical dir falls back to first when no root-level core",
+			candidates:   []RBFInfo{unstable, console},
+			canonicalDir: "",
+			wantOk:       true,
+			wantMglName:  "_Unstable/SNES",
+		},
+		{
+			name:         "empty canonical dir selects root-level core",
+			candidates:   []RBFInfo{console, unstable, rootLevel},
+			canonicalDir: "",
+			wantOk:       true,
+			wantMglName:  "SNES",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := selectByCanonicalDir(tc.candidates, tc.canonicalDir)
+			assert.Equal(t, tc.wantOk, ok)
+			if ok {
+				assert.Equal(t, tc.wantMglName, got.MglName)
+			}
+		})
+	}
+}
+
+func TestBuildFromRBFs_PrefersCanonicalDir(t *testing.T) {
+	t.Parallel()
+
+	console := RBFInfo{
+		Path:      "/media/fat/_Console/SNES_20240101.rbf",
+		Filename:  "SNES_20240101.rbf",
+		ShortName: "SNES",
+		MglName:   "_Console/SNES",
+	}
+	unstable := RBFInfo{
+		Path:      "/media/fat/_Unstable/SNES_20251001.rbf",
+		Filename:  "SNES_20251001.rbf",
+		ShortName: "SNES",
+		MglName:   "_Unstable/SNES",
+	}
+
+	// Canonical dir wins regardless of iteration order
+	for _, files := range [][]RBFInfo{
+		{console, unstable},
+		{unstable, console},
+	} {
+		cache := &RBFCache{}
+		cache.buildFromRBFs(files)
+
+		rbf, ok := cache.bySystemID["SNES"]
+		assert.True(t, ok, "SNES should be mapped")
+		assert.Equal(t, "_Console/SNES", rbf.MglName, "canonical dir must win")
+	}
+}
+
+func TestBuildFromRBFs_FallsBackToNonCanonical(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.buildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Unstable/SNES_20251001.rbf",
+		Filename:  "SNES_20251001.rbf",
+		ShortName: "SNES",
+		MglName:   "_Unstable/SNES",
+	}})
+
+	rbf, ok := cache.bySystemID["SNES"]
+	assert.True(t, ok, "SNES should be mapped via fallback")
+	assert.Equal(t, "_Unstable/SNES", rbf.MglName, "fallback to non-canonical when canonical absent")
+}
+
+func TestGetByLauncherID_PrefersCanonicalDir(t *testing.T) {
+	t.Parallel()
+
+	other := RBFInfo{
+		Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
+		Filename:  "PSX2XCPU_20240101.rbf",
+		ShortName: "PSX2XCPU",
+		MglName:   "_Other/PSX2XCPU",
+	}
+	unstable := RBFInfo{
+		Path:      "/media/fat/_Unstable/PSX2XCPU_20251001.rbf",
+		Filename:  "PSX2XCPU_20251001.rbf",
+		ShortName: "PSX2XCPU",
+		MglName:   "_Unstable/PSX2XCPU",
+	}
+
+	cache := &RBFCache{
+		byShortName: map[string][]RBFInfo{
+			"psx2xcpu": {unstable, other},
+		},
+	}
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	rbf, found := cache.GetByLauncherID("2XPSX")
+	assert.True(t, found)
+	assert.Equal(t, "_Other/PSX2XCPU", rbf.MglName, "registered canonical dir must win")
+
+	// Fallback when only non-canonical dir present
+	cache2 := &RBFCache{
+		byShortName: map[string][]RBFInfo{
+			"psx2xcpu": {unstable},
+		},
+	}
+	cache2.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	rbf, found = cache2.GetByLauncherID("2XPSX")
+	assert.True(t, found)
+	assert.Equal(t, "_Unstable/PSX2XCPU", rbf.MglName, "falls back to available dir when canonical absent")
+}
+
+func TestGetByMglPath(t *testing.T) {
+	t.Parallel()
+
+	console := RBFInfo{
+		Path:      "/media/fat/_Console/SNES_20240101.rbf",
+		Filename:  "SNES_20240101.rbf",
+		ShortName: "SNES",
+		MglName:   "_Console/SNES",
+	}
+	unstable := RBFInfo{
+		Path:      "/media/fat/_Unstable/SNES_20251001.rbf",
+		Filename:  "SNES_20251001.rbf",
+		ShortName: "SNES",
+		MglName:   "_Unstable/SNES",
+	}
+
+	cache := &RBFCache{
+		byShortName: map[string][]RBFInfo{
+			"snes": {console, unstable},
+		},
+	}
+
+	// Prefers the directory embedded in the mgl path
+	rbf, ok := cache.GetByMglPath("_Unstable/SNES")
+	assert.True(t, ok)
+	assert.Equal(t, "_Unstable/SNES", rbf.MglName)
+
+	rbf, ok = cache.GetByMglPath("_Console/SNES")
+	assert.True(t, ok)
+	assert.Equal(t, "_Console/SNES", rbf.MglName)
+
+	// Falls back to first candidate when dir not found
+	rbf, ok = cache.GetByMglPath("_Homebrew/SNES")
+	assert.True(t, ok)
+	assert.Equal(t, "_Console/SNES", rbf.MglName)
+
+	// Returns false when short name unknown
+	_, ok = cache.GetByMglPath("_Console/Unknown12345")
+	assert.False(t, ok)
 }

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -24,7 +24,9 @@ package cores
 import (
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRBFCacheRefresh_Basic(t *testing.T) {
@@ -39,49 +41,6 @@ func TestRBFCacheRefresh_Basic(t *testing.T) {
 	// On non-MiSTer systems, counts will be 0 (empty cache is valid)
 	assert.GreaterOrEqual(t, systems, 0, "systems count should be non-negative")
 	assert.GreaterOrEqual(t, rbfs, 0, "rbfs count should be non-negative")
-}
-
-func TestResolveRBFPath_Fallback(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name         string
-		systemID     string
-		hardcodedRBF string
-	}{
-		{
-			name:         "unknown system uses hardcoded",
-			systemID:     "UnknownSystem12345",
-			hardcodedRBF: "_Console/Unknown",
-		},
-		{
-			name:         "empty system ID uses hardcoded",
-			systemID:     "",
-			hardcodedRBF: "_Console/Empty",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := ResolveRBFPath(tc.systemID, tc.hardcodedRBF)
-
-			// On empty/unknown system, should return hardcoded path
-			assert.Equal(t, tc.hardcodedRBF, result, "should return hardcoded path for unknown system")
-		})
-	}
-}
-
-func TestResolveRBFPath_NeverEmpty(t *testing.T) {
-	t.Parallel()
-
-	// Even with empty inputs, should return something
-	result := ResolveRBFPath("", "")
-	assert.Empty(t, result, "empty hardcoded returns empty")
-
-	result = ResolveRBFPath("NES", "_Console/NES")
-	assert.NotEmpty(t, result, "should never return empty for valid input")
 }
 
 func TestRBFCacheGetByShortName_CaseInsensitive(t *testing.T) {
@@ -167,38 +126,6 @@ func TestRBFCacheGetBySystemID_CacheHit(t *testing.T) {
 	systems, rbfs := cache.Count()
 	assert.Equal(t, 1, systems)
 	assert.Equal(t, 1, rbfs)
-}
-
-func TestResolveRBFPath_CacheHit(t *testing.T) {
-	// Save and restore GlobalRBFCache state
-	originalBySystemID := GlobalRBFCache.bySystemID
-	originalByShortName := GlobalRBFCache.byShortName
-	defer func() {
-		GlobalRBFCache.mu.Lock()
-		GlobalRBFCache.bySystemID = originalBySystemID
-		GlobalRBFCache.byShortName = originalByShortName
-		GlobalRBFCache.mu.Unlock()
-	}()
-
-	// Populate cache with test data
-	GlobalRBFCache.mu.Lock()
-	GlobalRBFCache.bySystemID = map[string]RBFInfo{
-		"SNES": {
-			Path:      "/media/fat/_Console/SNES_20240101.rbf",
-			Filename:  "SNES_20240101.rbf",
-			ShortName: "SNES",
-			MglName:   "_Console/SNES",
-		},
-	}
-	GlobalRBFCache.mu.Unlock()
-
-	// Test cache hit returns cached path, not hardcoded
-	result := ResolveRBFPath("SNES", "_OldPath/SNES")
-	assert.Equal(t, "_Console/SNES", result, "should return cached path, not hardcoded")
-
-	// Test cache miss still returns hardcoded
-	result = ResolveRBFPath("Genesis", "_Console/Genesis")
-	assert.Equal(t, "_Console/Genesis", result, "should return hardcoded for cache miss")
 }
 
 func TestRBFCacheThreadSafety(t *testing.T) {
@@ -343,177 +270,112 @@ func TestGetByLauncherID_ExtractsShortNameFromPath(t *testing.T) {
 	assert.Equal(t, "_Other/N64_80MHz", rbf.MglName)
 }
 
-func TestResolveRBFPathForLauncher_LauncherIDTakesPriority(t *testing.T) {
-	// Save and restore GlobalRBFCache state
-	originalBySystemID := GlobalRBFCache.bySystemID
-	originalByShortName := GlobalRBFCache.byShortName
-	originalByLauncherID := GlobalRBFCache.byLauncherID
-	defer func() {
-		GlobalRBFCache.mu.Lock()
-		GlobalRBFCache.bySystemID = originalBySystemID
-		GlobalRBFCache.byShortName = originalByShortName
-		GlobalRBFCache.byLauncherID = originalByLauncherID
-		GlobalRBFCache.mu.Unlock()
-	}()
-
-	// Setup cache with both system and alt core entries
-	GlobalRBFCache.mu.Lock()
-	GlobalRBFCache.bySystemID = map[string]RBFInfo{
-		"PSX": {
-			Path:      "/media/fat/_Console/PSX_20240101.rbf",
-			Filename:  "PSX_20240101.rbf",
-			ShortName: "PSX",
-			MglName:   "_Console/PSX",
-		},
-	}
-	GlobalRBFCache.byShortName = map[string][]RBFInfo{
-		"psx": {{
-			Path:      "/media/fat/_Console/PSX_20240101.rbf",
-			Filename:  "PSX_20240101.rbf",
-			ShortName: "PSX",
-			MglName:   "_Console/PSX",
-		}},
-		"psx2xcpu": {{
-			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
-			Filename:  "PSX2XCPU_20240101.rbf",
-			ShortName: "PSX2XCPU",
-			MglName:   "_Other/PSX2XCPU",
-		}},
-	}
-	GlobalRBFCache.byLauncherID = map[string]string{
-		"2XPSX": "_Other/PSX2XCPU",
-	}
-	GlobalRBFCache.mu.Unlock()
-
-	// When launcherID is provided and found, should use alt core path
-	result := ResolveRBFPathForLauncher("2XPSX", "PSX", "_Console/PSX")
-	assert.Equal(t, "_Other/PSX2XCPU", result, "launcherID lookup should take priority over systemID")
-
-	// When launcherID is empty, should fall back to systemID
-	result = ResolveRBFPathForLauncher("", "PSX", "_Console/PSX")
-	assert.Equal(t, "_Console/PSX", result, "should fall back to systemID when launcherID is empty")
-}
-
-func TestResolveRBFPathForLauncher_FallbackChain(t *testing.T) {
-	// Save and restore GlobalRBFCache state
-	originalBySystemID := GlobalRBFCache.bySystemID
-	originalByShortName := GlobalRBFCache.byShortName
-	originalByLauncherID := GlobalRBFCache.byLauncherID
-	defer func() {
-		GlobalRBFCache.mu.Lock()
-		GlobalRBFCache.bySystemID = originalBySystemID
-		GlobalRBFCache.byShortName = originalByShortName
-		GlobalRBFCache.byLauncherID = originalByLauncherID
-		GlobalRBFCache.mu.Unlock()
-	}()
-
-	// Setup empty cache
-	GlobalRBFCache.mu.Lock()
-	GlobalRBFCache.bySystemID = make(map[string]RBFInfo)
-	GlobalRBFCache.byShortName = make(map[string][]RBFInfo)
-	GlobalRBFCache.byLauncherID = make(map[string]string)
-	GlobalRBFCache.mu.Unlock()
-
-	// When nothing is cached, should fall back to hardcoded
-	result := ResolveRBFPathForLauncher("UnknownLauncher", "UnknownSystem", "_Console/Fallback")
-	assert.Equal(t, "_Console/Fallback", result, "should fall back to hardcoded path")
-}
-
-func TestResolveRBFPathForLauncher_LauncherNotFoundFallsBackToSystemID(t *testing.T) {
-	// Save and restore GlobalRBFCache state
-	originalBySystemID := GlobalRBFCache.bySystemID
-	originalByShortName := GlobalRBFCache.byShortName
-	originalByLauncherID := GlobalRBFCache.byLauncherID
-	defer func() {
-		GlobalRBFCache.mu.Lock()
-		GlobalRBFCache.bySystemID = originalBySystemID
-		GlobalRBFCache.byShortName = originalByShortName
-		GlobalRBFCache.byLauncherID = originalByLauncherID
-		GlobalRBFCache.mu.Unlock()
-	}()
-
-	// Setup cache with system entry only
-	GlobalRBFCache.mu.Lock()
-	GlobalRBFCache.bySystemID = map[string]RBFInfo{
-		"PSX": {
-			Path:      "/media/fat/_Console/PSX_20240101.rbf",
-			Filename:  "PSX_20240101.rbf",
-			ShortName: "PSX",
-			MglName:   "_Console/PSX",
-		},
-	}
-	GlobalRBFCache.byShortName = make(map[string][]RBFInfo)
-	GlobalRBFCache.byLauncherID = make(map[string]string)
-	GlobalRBFCache.mu.Unlock()
-
-	// When launcherID is not found, should fall back to systemID
-	result := ResolveRBFPathForLauncher("UnknownLauncher", "PSX", "_Console/OldPSX")
-	assert.Equal(t, "_Console/PSX", result, "should fall back to systemID when launcherID not found")
-}
-
 // TestRegression_Issue477_AltCoreUsesWrongRBFPath is a regression test for GitHub issue #477.
-// The bug: 2XPSX launcher didn't work correctly because ResolveRBFPath looked up cached RBF
-// paths by systemID only. Alt cores like 2XPSX share the same systemID ("PSX") as the main
-// core, so the cache returned the main core's path instead of the alt core's path.
+// Before the fix, alt cores like 2XPSX shared systemID ("PSX") with the main core, so the
+// lookup returned the main core's path instead of the alt core's path.
 func TestRegression_Issue477_AltCoreUsesWrongRBFPath(t *testing.T) {
-	// Save and restore GlobalRBFCache state
-	originalBySystemID := GlobalRBFCache.bySystemID
-	originalByShortName := GlobalRBFCache.byShortName
-	originalByLauncherID := GlobalRBFCache.byLauncherID
-	defer func() {
-		GlobalRBFCache.mu.Lock()
-		GlobalRBFCache.bySystemID = originalBySystemID
-		GlobalRBFCache.byShortName = originalByShortName
-		GlobalRBFCache.byLauncherID = originalByLauncherID
-		GlobalRBFCache.mu.Unlock()
-	}()
+	t.Parallel()
 
-	// Setup: Simulate a MiSTer with both standard PSX and 2XPSX cores installed
-	GlobalRBFCache.mu.Lock()
-	GlobalRBFCache.bySystemID = map[string]RBFInfo{
-		"PSX": {
-			Path:      "/media/fat/_Console/PSX_20240101.rbf",
-			Filename:  "PSX_20240101.rbf",
-			ShortName: "PSX",
-			MglName:   "_Console/PSX",
-		},
-	}
-	GlobalRBFCache.byShortName = map[string][]RBFInfo{
-		"psx": {{
-			Path:      "/media/fat/_Console/PSX_20240101.rbf",
-			Filename:  "PSX_20240101.rbf",
-			ShortName: "PSX",
-			MglName:   "_Console/PSX",
-		}},
-		"psx2xcpu": {{
-			Path:      "/media/fat/_Other/PSX2XCPU_20240101.rbf",
-			Filename:  "PSX2XCPU_20240101.rbf",
-			ShortName: "PSX2XCPU",
-			MglName:   "_Other/PSX2XCPU",
-		}},
-	}
-	GlobalRBFCache.byLauncherID = map[string]string{
-		"2XPSX": "_Other/PSX2XCPU",
-	}
-	GlobalRBFCache.mu.Unlock()
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/PSX_20240101.rbf", ShortName: "PSX", MglName: "_Console/PSX"},
+		{Path: "/media/fat/_Other/PSX2XCPU_20240101.rbf", ShortName: "PSX2XCPU", MglName: "_Other/PSX2XCPU"},
+	})
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
 
-	// THE BUG: Before the fix, calling ResolveRBFPath("PSX", "_Other/PSX2XCPU") for the
-	// 2XPSX launcher would return "_Console/PSX" (the main core) instead of "_Other/PSX2XCPU"
-	// because the lookup was done by systemID ("PSX"), not by launcherID.
+	mainCore := &Core{ID: "PSX", RBF: "_Console/PSX"}
+	mainInfo, err := cache.Resolve(nil, mainCore)
+	require.NoError(t, err)
+	assert.Equal(t, "_Console/PSX", mainInfo.MglName, "main PSX launcher should use standard PSX core")
 
-	// Test 1: Main PSX launcher (no launcherID) should get the standard PSX core
-	mainPSXPath := ResolveRBFPathForLauncher("", "PSX", "_Console/PSX")
-	assert.Equal(t, "_Console/PSX", mainPSXPath,
-		"main PSX launcher should use standard PSX core")
+	altCore := &Core{ID: "PSX", LauncherID: "2XPSX", RBF: "_Console/PSX"}
+	altInfo, err := cache.Resolve(nil, altCore)
+	require.NoError(t, err)
+	assert.Equal(t, "_Other/PSX2XCPU", altInfo.MglName, "2XPSX launcher should use PSX2XCPU core")
 
-	// Test 2: 2XPSX alt core launcher should get the PSX2XCPU core, NOT the standard PSX core
-	altCorePath := ResolveRBFPathForLauncher("2XPSX", "PSX", "_Other/PSX2XCPU")
-	assert.Equal(t, "_Other/PSX2XCPU", altCorePath,
-		"2XPSX launcher should use PSX2XCPU core, not standard PSX core")
-
-	// Test 3: Verify they are different - this is the core of the bug
-	assert.NotEqual(t, mainPSXPath, altCorePath,
+	assert.NotEqual(t, mainInfo.MglName, altInfo.MglName,
 		"alt core should resolve to different path than main core even though they share systemID")
+}
+
+func TestRBFCache_Resolve_LoadPath(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/SNES_20260311.rbf", ShortName: "SNES", MglName: "_Console/SNES"},
+		{Path: "/media/fat/_Unstable/SNES_20260101.rbf", ShortName: "SNES", MglName: "_Unstable/SNES"},
+	})
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "SNES"
+load_path = "_Unstable/SNES"
+`))
+
+	got, err := cache.Resolve(cfg, &Core{ID: "SNES", RBF: "_Console/SNES"})
+	require.NoError(t, err)
+	assert.Equal(t, "/media/fat/_Unstable/SNES_20260101.rbf", got.Path)
+}
+
+func TestRBFCache_Resolve_LoadPathInvalid(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/SNES_20260311.rbf", ShortName: "SNES", MglName: "_Console/SNES"},
+	})
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "SNES"
+load_path = "_LLAPI/NonExistentCore"
+`))
+
+	_, err := cache.Resolve(cfg, &Core{ID: "SNES", RBF: "_Console/SNES"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "_LLAPI/NonExistentCore")
+}
+
+func TestRBFCache_Resolve_AltCoreUsesLauncherID(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/PSX_20240101.rbf", ShortName: "PSX", MglName: "_Console/PSX"},
+		{Path: "/media/fat/_Other/PSX2XCPU_20240101.rbf", ShortName: "PSX2XCPU", MglName: "_Other/PSX2XCPU"},
+	})
+	cache.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
+
+	got, err := cache.Resolve(nil, &Core{ID: "PSX", LauncherID: "2XPSX", RBF: "_Console/PSX"})
+	require.NoError(t, err)
+	assert.Equal(t, "/media/fat/_Other/PSX2XCPU_20240101.rbf", got.Path)
+}
+
+func TestRBFCache_Resolve_AltCoreFallsBackToSystemID(t *testing.T) {
+	t.Parallel()
+
+	// LauncherID set but not registered — should fall back to system ID lookup.
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/PSX_20240101.rbf", ShortName: "PSX", MglName: "_Console/PSX"},
+	})
+
+	got, err := cache.Resolve(nil, &Core{ID: "PSX", LauncherID: "2XPSX", RBF: "_Console/PSX"})
+	require.NoError(t, err)
+	assert.Equal(t, "/media/fat/_Console/PSX_20240101.rbf", got.Path)
+}
+
+func TestRBFCache_Resolve_NotInCache(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs(nil)
+
+	_, err := cache.Resolve(nil, &Core{ID: "Nintendo64", RBF: "_Console/N64"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Nintendo64")
 }
 
 func TestSplitRBFPath(t *testing.T) {
@@ -641,7 +503,7 @@ func TestBuildFromRBFs_PrefersCanonicalDir(t *testing.T) {
 		{unstable, console},
 	} {
 		cache := &RBFCache{}
-		cache.buildFromRBFs(files)
+		cache.BuildFromRBFs(files)
 
 		rbf, ok := cache.bySystemID["SNES"]
 		assert.True(t, ok, "SNES should be mapped")
@@ -653,7 +515,7 @@ func TestBuildFromRBFs_FallsBackToNonCanonical(t *testing.T) {
 	t.Parallel()
 
 	cache := &RBFCache{}
-	cache.buildFromRBFs([]RBFInfo{{
+	cache.BuildFromRBFs([]RBFInfo{{
 		Path:      "/media/fat/_Unstable/SNES_20251001.rbf",
 		Filename:  "SNES_20251001.rbf",
 		ShortName: "SNES",

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -554,7 +554,7 @@ func TestGetByLauncherID_PrefersCanonicalDir(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, "_Other/PSX2XCPU", rbf.MglName, "registered canonical dir must win")
 
-	// Fallback when only non-canonical dir present
+	// Returns false when only a non-matching directory is present
 	cache2 := &RBFCache{
 		byShortName: map[string][]RBFInfo{
 			"psx2xcpu": {unstable},
@@ -562,9 +562,8 @@ func TestGetByLauncherID_PrefersCanonicalDir(t *testing.T) {
 	}
 	cache2.RegisterAltCore("2XPSX", "_Other/PSX2XCPU")
 
-	rbf, found = cache2.GetByLauncherID("2XPSX")
-	assert.True(t, found)
-	assert.Equal(t, "_Unstable/PSX2XCPU", rbf.MglName, "falls back to available dir when canonical absent")
+	_, found = cache2.GetByLauncherID("2XPSX")
+	assert.False(t, found, "directory mismatch should not resolve")
 }
 
 func TestGetByMglPath(t *testing.T) {
@@ -598,10 +597,9 @@ func TestGetByMglPath(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, "_Console/SNES", rbf.MglName)
 
-	// Falls back to first candidate when dir not found
-	rbf, ok = cache.GetByMglPath("_Homebrew/SNES")
-	assert.True(t, ok)
-	assert.Equal(t, "_Console/SNES", rbf.MglName)
+	// Returns false when dir doesn't match any candidate
+	_, ok = cache.GetByMglPath("_Homebrew/SNES")
+	assert.False(t, ok)
 
 	// Returns false when short name unknown
 	_, ok = cache.GetByMglPath("_Console/Unknown12345")

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -82,25 +82,11 @@ func xmlEscapeAttr(v string) string {
 	return r.Replace(v)
 }
 
-func GenerateMgl(cfg *config.Instance, core *cores.Core, path, override string) (string, error) {
+func GenerateMgl(core *cores.Core, rbfPath, path, override string) (string, error) {
 	if core == nil {
 		return "", errors.New("no core supplied for MGL generation")
 	}
 
-	key := core.LauncherID
-	if key == "" {
-		key = core.ID
-	}
-	var rbfPath string
-	if cfg != nil {
-		if lp := cfg.LookupLauncherDefaults(key, nil).LoadPath; lp != "" {
-			rbfPath = lp
-			log.Debug().Str("launcher", key).Str("load_path", lp).Msg("RBF overridden by config load_path")
-		}
-	}
-	if rbfPath == "" {
-		rbfPath = cores.ResolveRBFPathForLauncher(core.LauncherID, core.ID, core.RBF)
-	}
 	mgl := fmt.Sprintf("<mistergamedescription>\n\t<rbf>%s</rbf>\n", rbfPath)
 
 	if core.SetName != "" {
@@ -188,6 +174,11 @@ func launchFile(path string) error {
 }
 
 func launchTempMgl(cfg *config.Instance, system *cores.Core, path string) error {
+	rbfInfo, err := cores.GlobalRBFCache.Resolve(cfg, system)
+	if err != nil {
+		return fmt.Errorf("resolving core RBF: %w", err)
+	}
+
 	override, err := cores.RunSystemHook(cfg, system, path)
 	if err != nil {
 		return fmt.Errorf("failed to run system hook: %w", err)
@@ -196,7 +187,7 @@ func launchTempMgl(cfg *config.Instance, system *cores.Core, path string) error 
 		log.Debug().Str("system", system.ID).Str("hook_result", override).Msg("system hook executed")
 	}
 
-	mgl, err := GenerateMgl(cfg, system, path, override)
+	mgl, err := GenerateMgl(system, rbfInfo.MglName, path, override)
 	if err != nil {
 		return fmt.Errorf("failed to generate MGL: %w", err)
 	}
@@ -316,23 +307,9 @@ func LaunchCore(cfg *config.Instance, _ platforms.Platform, system *cores.Core) 
 		return LaunchGame(cfg, system, "")
 	}
 
-	var rbfInfo cores.RBFInfo
-	var ok bool
-	coreKey := system.LauncherID
-	if coreKey == "" {
-		coreKey = system.ID
-	}
-	if lp := cfg.LookupLauncherDefaults(coreKey, nil).LoadPath; lp != "" {
-		rbfInfo, ok = cores.GlobalRBFCache.GetByMglPath(lp)
-		if !ok {
-			return fmt.Errorf("configured load_path %q for system %s not found in RBF cache", lp, system.ID)
-		}
-		log.Debug().Str("system", system.ID).Str("load_path", lp).Msg("core overridden by config load_path")
-	} else {
-		rbfInfo, ok = cores.GlobalRBFCache.GetBySystemID(system.ID)
-		if !ok {
-			return fmt.Errorf("no core found for system %s (not in cache)", system.ID)
-		}
+	rbfInfo, err := cores.GlobalRBFCache.Resolve(cfg, system)
+	if err != nil {
+		return fmt.Errorf("resolving core RBF: %w", err)
 	}
 	path := rbfInfo.Path
 

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -82,12 +82,25 @@ func xmlEscapeAttr(v string) string {
 	return r.Replace(v)
 }
 
-func GenerateMgl(core *cores.Core, path, override string) (string, error) {
+func GenerateMgl(cfg *config.Instance, core *cores.Core, path, override string) (string, error) {
 	if core == nil {
 		return "", errors.New("no core supplied for MGL generation")
 	}
 
-	rbfPath := cores.ResolveRBFPathForLauncher(core.LauncherID, core.ID, core.RBF)
+	key := core.LauncherID
+	if key == "" {
+		key = core.ID
+	}
+	var rbfPath string
+	if cfg != nil {
+		if lp := cfg.LookupLauncherDefaults(key, nil).LoadPath; lp != "" {
+			rbfPath = lp
+			log.Debug().Str("launcher", key).Str("load_path", lp).Msg("RBF overridden by config load_path")
+		}
+	}
+	if rbfPath == "" {
+		rbfPath = cores.ResolveRBFPathForLauncher(core.LauncherID, core.ID, core.RBF)
+	}
 	mgl := fmt.Sprintf("<mistergamedescription>\n\t<rbf>%s</rbf>\n", rbfPath)
 
 	if core.SetName != "" {
@@ -183,15 +196,11 @@ func launchTempMgl(cfg *config.Instance, system *cores.Core, path string) error 
 		log.Debug().Str("system", system.ID).Str("hook_result", override).Msg("system hook executed")
 	}
 
-	mgl, err := GenerateMgl(system, path, override)
+	mgl, err := GenerateMgl(cfg, system, path, override)
 	if err != nil {
 		return fmt.Errorf("failed to generate MGL: %w", err)
 	}
-	resolvedRBF := cores.ResolveRBFPathForLauncher(system.LauncherID, system.ID, system.RBF)
-	log.Debug().
-		Str("system", system.ID).
-		Str("rbf", resolvedRBF).
-		Msg("MGL generated successfully")
+	log.Debug().Str("system", system.ID).Msg("MGL generated successfully")
 	log.Debug().Str("mgl_content", mgl).Msg("generated MGL content")
 
 	tmpFile, err := writeTempFile(mgl)
@@ -307,9 +316,23 @@ func LaunchCore(cfg *config.Instance, _ platforms.Platform, system *cores.Core) 
 		return LaunchGame(cfg, system, "")
 	}
 
-	rbfInfo, ok := cores.GlobalRBFCache.GetBySystemID(system.ID)
-	if !ok {
-		return fmt.Errorf("no core found for system %s (not in cache)", system.ID)
+	var rbfInfo cores.RBFInfo
+	var ok bool
+	coreKey := system.LauncherID
+	if coreKey == "" {
+		coreKey = system.ID
+	}
+	if lp := cfg.LookupLauncherDefaults(coreKey, nil).LoadPath; lp != "" {
+		rbfInfo, ok = cores.GlobalRBFCache.GetByMglPath(lp)
+		if !ok {
+			return fmt.Errorf("configured load_path %q for system %s not found in RBF cache", lp, system.ID)
+		}
+		log.Debug().Str("system", system.ID).Str("load_path", lp).Msg("core overridden by config load_path")
+	} else {
+		rbfInfo, ok = cores.GlobalRBFCache.GetBySystemID(system.ID)
+		if !ok {
+			return fmt.Errorf("no core found for system %s (not in cache)", system.ID)
+		}
 	}
 	path := rbfInfo.Path
 

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -323,7 +324,8 @@ func TestGenerateMgl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := GenerateMgl(tt.core, tt.path, tt.override)
+			cfg := &config.Instance{}
+			got, err := GenerateMgl(cfg, tt.core, tt.path, tt.override)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -405,6 +407,98 @@ func TestWriteCurrentPath(t *testing.T) {
 	}
 }
 
+func TestGenerateMgl_LoadPathOverride(t *testing.T) {
+	t.Parallel()
+
+	core := &cores.Core{
+		ID:  "SNES",
+		RBF: "_Console/SNES",
+		Slots: []cores.Slot{
+			{
+				Exts: []string{".sfc"},
+				Mgl: &cores.MGLParams{
+					Delay:  2,
+					Method: "f",
+					Index:  1,
+				},
+			},
+		},
+	}
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "SNES"
+load_path = "_Unstable/SNES"
+`))
+
+	got, err := GenerateMgl(cfg, core, "/media/fat/games/SNES/game.sfc", "")
+	require.NoError(t, err)
+	assert.Contains(t, got, "<rbf>_Unstable/SNES</rbf>", "load_path override must appear in MGL")
+	assert.NotContains(t, got, "_Console/SNES", "canonical path must not appear when overridden")
+}
+
+func TestGenerateMgl_LoadPathOverride_UsesLauncherID(t *testing.T) {
+	t.Parallel()
+
+	// LauncherID is set (alt core). load_path is configured under the LauncherID,
+	// not the system ID. GenerateMgl must prefer LauncherID as the lookup key.
+	core := &cores.Core{
+		ID:         "PSX",
+		LauncherID: "2XPSX",
+		RBF:        "_Console/PSX",
+		Slots: []cores.Slot{
+			{
+				Exts: []string{".chd"},
+				Mgl: &cores.MGLParams{
+					Delay:  1,
+					Method: "f",
+					Index:  1,
+				},
+			},
+		},
+	}
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "2XPSX"
+load_path = "_Other/PSX2XCPU"
+`))
+
+	got, err := GenerateMgl(cfg, core, "/media/fat/games/PSX/game.chd", "")
+	require.NoError(t, err)
+	assert.Contains(t, got, "<rbf>_Other/PSX2XCPU</rbf>", "LauncherID-keyed load_path must win")
+	assert.NotContains(t, got, "_Console/PSX", "system ID path must not appear when LauncherID is set")
+}
+
+func TestGenerateMgl_NoLoadPath_FallsBackToCoreRBF(t *testing.T) {
+	t.Parallel()
+
+	// Use a fake system ID that is never present in GlobalRBFCache so the
+	// fallback to core.RBF is guaranteed regardless of other tests' cache state.
+	core := &cores.Core{
+		ID:  "FakeSystem_NotInCache",
+		RBF: "_Custom/FakeCore",
+		Slots: []cores.Slot{
+			{
+				Exts: []string{".rom"},
+				Mgl: &cores.MGLParams{
+					Delay:  1,
+					Method: "f",
+					Index:  1,
+				},
+			},
+		},
+	}
+
+	cfg := &config.Instance{}
+
+	got, err := GenerateMgl(cfg, core, "/media/fat/games/Fake/game.rom", "")
+	require.NoError(t, err)
+	assert.Contains(t, got, "<rbf>_Custom/FakeCore</rbf>", "no load_path should fall back to core.RBF")
+}
+
 func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	t.Parallel()
 
@@ -424,7 +518,8 @@ func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	}
 
 	// Try to launch a .sfc file with NES core - no matching slot
-	_, err := GenerateMgl(core, "/media/fat/games/NES/game.sfc", "")
+	cfg := &config.Instance{}
+	_, err := GenerateMgl(cfg, core, "/media/fat/games/NES/game.sfc", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no matching mgl args")
 }

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -324,8 +323,11 @@ func TestGenerateMgl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := &config.Instance{}
-			got, err := GenerateMgl(cfg, tt.core, tt.path, tt.override)
+			rbfPath := ""
+			if tt.core != nil {
+				rbfPath = tt.core.RBF
+			}
+			got, err := GenerateMgl(tt.core, rbfPath, tt.path, tt.override)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -407,98 +409,6 @@ func TestWriteCurrentPath(t *testing.T) {
 	}
 }
 
-func TestGenerateMgl_LoadPathOverride(t *testing.T) {
-	t.Parallel()
-
-	core := &cores.Core{
-		ID:  "SNES",
-		RBF: "_Console/SNES",
-		Slots: []cores.Slot{
-			{
-				Exts: []string{".sfc"},
-				Mgl: &cores.MGLParams{
-					Delay:  2,
-					Method: "f",
-					Index:  1,
-				},
-			},
-		},
-	}
-
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
-[[launchers.default]]
-launcher = "SNES"
-load_path = "_Unstable/SNES"
-`))
-
-	got, err := GenerateMgl(cfg, core, "/media/fat/games/SNES/game.sfc", "")
-	require.NoError(t, err)
-	assert.Contains(t, got, "<rbf>_Unstable/SNES</rbf>", "load_path override must appear in MGL")
-	assert.NotContains(t, got, "_Console/SNES", "canonical path must not appear when overridden")
-}
-
-func TestGenerateMgl_LoadPathOverride_UsesLauncherID(t *testing.T) {
-	t.Parallel()
-
-	// LauncherID is set (alt core). load_path is configured under the LauncherID,
-	// not the system ID. GenerateMgl must prefer LauncherID as the lookup key.
-	core := &cores.Core{
-		ID:         "PSX",
-		LauncherID: "2XPSX",
-		RBF:        "_Console/PSX",
-		Slots: []cores.Slot{
-			{
-				Exts: []string{".chd"},
-				Mgl: &cores.MGLParams{
-					Delay:  1,
-					Method: "f",
-					Index:  1,
-				},
-			},
-		},
-	}
-
-	cfg := &config.Instance{}
-	require.NoError(t, cfg.LoadTOML(`
-[[launchers.default]]
-launcher = "2XPSX"
-load_path = "_Other/PSX2XCPU"
-`))
-
-	got, err := GenerateMgl(cfg, core, "/media/fat/games/PSX/game.chd", "")
-	require.NoError(t, err)
-	assert.Contains(t, got, "<rbf>_Other/PSX2XCPU</rbf>", "LauncherID-keyed load_path must win")
-	assert.NotContains(t, got, "_Console/PSX", "system ID path must not appear when LauncherID is set")
-}
-
-func TestGenerateMgl_NoLoadPath_FallsBackToCoreRBF(t *testing.T) {
-	t.Parallel()
-
-	// Use a fake system ID that is never present in GlobalRBFCache so the
-	// fallback to core.RBF is guaranteed regardless of other tests' cache state.
-	core := &cores.Core{
-		ID:  "FakeSystem_NotInCache",
-		RBF: "_Custom/FakeCore",
-		Slots: []cores.Slot{
-			{
-				Exts: []string{".rom"},
-				Mgl: &cores.MGLParams{
-					Delay:  1,
-					Method: "f",
-					Index:  1,
-				},
-			},
-		},
-	}
-
-	cfg := &config.Instance{}
-
-	got, err := GenerateMgl(cfg, core, "/media/fat/games/Fake/game.rom", "")
-	require.NoError(t, err)
-	assert.Contains(t, got, "<rbf>_Custom/FakeCore</rbf>", "no load_path should fall back to core.RBF")
-}
-
 func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	t.Parallel()
 
@@ -518,8 +428,7 @@ func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	}
 
 	// Try to launch a .sfc file with NES core - no matching slot
-	cfg := &config.Instance{}
-	_, err := GenerateMgl(cfg, core, "/media/fat/games/NES/game.sfc", "")
+	_, err := GenerateMgl(core, core.RBF, "/media/fat/games/NES/game.sfc", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no matching mgl args")
 }

--- a/pkg/platforms/shared/kodi/client_test.go
+++ b/pkg/platforms/shared/kodi/client_test.go
@@ -837,7 +837,9 @@ func TestNewClient_UsesConfigurationSystem(t *testing.T) {
 	}
 }
 
-// Helper function to create config instance with Kodi defaults for testing
+// Helper function to create config instance with Kodi defaults for testing.
+//
+//nolint:gocritic // hugeParam: value copy is intentional — pointer would introduce nil-deref risk in test helper
 func createTestConfigWithKodiDefaults(t *testing.T, defaults config.LaunchersDefault) *config.Instance {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- `byShortName` in the RBF cache changed from `map[string]RBFInfo` to `map[string][]RBFInfo` to handle multiple RBF files sharing the same short name (e.g. three N64 cores across `_Console/`, `_LLAPI/`, `_YCConsole/`)
- `selectByCanonicalDir` picks the correct candidate by matching the directory from the system definition, with a fallback to the first candidate
- Adds `load_path` field to `LaunchersDefault` config, allowing users to pin a specific RBF for any launcher without editing system definitions
- `GenerateMgl` accepts `*config.Instance` and checks `load_path` before falling back to cache resolution
- `LaunchCore` uses the same `load_path` logic via `GetByMglPath` for core-only launches
- Config reload is sufficient to apply `load_path` changes — no restart required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional configurable load_path for launchers to specify custom core file locations.

* **Improvements**
  * Core selection now handles multiple candidates and prefers matches by canonical directory.
  * Launch/resolution now uses a deterministic resolver and surfaces clearer errors when resolution or configured load_path fail.
  * MGL generation and launch paths use resolved core metadata explicitly.

* **Tests**
  * Expanded coverage for load_path handling, multi-candidate selection, directory-preference, and resolution error cases.

* **Documentation**
  * Minor test comment clarifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->