### PR TITLE
feat(mister): add DualRAM alt launchers for 3DO, Jaguar, PSX, Saturn

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -611,6 +611,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.System3DO),
 		},
 		{
+			ID:       "DualRAM3DO",
+			SystemID: systemdefs.System3DO,
+			Launch:   launchAltCore("DualRAM3DO", systemdefs.System3DO, "_Console (Dual SDRAM)/3DO"),
+		},
+		{
 			ID:         systemdefs.SystemAdventureVision,
 			SystemID:   systemdefs.SystemAdventureVision,
 			Folders:    []string{"AVision"},
@@ -841,6 +846,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemJaguar),
 		},
 		{
+			ID:       "DualRAMJaguar",
+			SystemID: systemdefs.SystemJaguar,
+			Launch:   launchAltCore("DualRAMJaguar", systemdefs.SystemJaguar, "_Console (Dual SDRAM)/Jaguar"),
+		},
+		{
 			ID:         systemdefs.SystemJaguarCD,
 			SystemID:   systemdefs.SystemJaguarCD,
 			Folders:    []string{"Jaguar"},
@@ -1026,6 +1036,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("PWM2XPSX", systemdefs.SystemPSX, "_ConsolePWM/_Turbo/PSX2XCPU_PWM"),
 		},
 		{
+			ID:       "DualRAMPSX",
+			SystemID: systemdefs.SystemPSX,
+			Launch:   launchAltCore("DualRAMPSX", systemdefs.SystemPSX, "_Console (Dual SDRAM)/PSX"),
+		},
+		{
 			ID:         systemdefs.SystemSega32X,
 			SystemID:   systemdefs.SystemSega32X,
 			Folders:    []string{"S32X"},
@@ -1079,6 +1094,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "PWMSaturn",
 			SystemID: systemdefs.SystemSaturn,
 			Launch:   launchAltCore("PWMSaturn", systemdefs.SystemSaturn, "_ConsolePWM/Saturn_PWM"),
+		},
+		{
+			ID:       "DualRAMSaturn",
+			SystemID: systemdefs.SystemSaturn,
+			Launch:   launchAltCore("DualRAMSaturn", systemdefs.SystemSaturn, "_Console (Dual SDRAM)/Saturn"),
 		},
 		{
 			ID:         systemdefs.SystemSNES,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -479,3 +479,37 @@ func TestN64LauncherExtensions(t *testing.T) {
 			"N64 launcher should support %s extension", ext)
 	}
 }
+
+func TestDualRAMLaunchersExist(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	cases := []struct {
+		id       string
+		systemID string
+	}{
+		{"DualRAM3DO", "3DO"},
+		{"DualRAMJaguar", "Jaguar"},
+		{"DualRAMPSX", "PSX"},
+		{"DualRAMSaturn", "Saturn"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			var found *platforms.Launcher
+			for i := range launchers {
+				if launchers[i].ID == tc.id {
+					found = &launchers[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "%s launcher should exist", tc.id)
+			assert.Equal(t, tc.systemID, found.SystemID,
+				"%s must inherit slots from %s", tc.id, tc.systemID)
+		})
+	}
+}


### PR DESCRIPTION
- Adds `DualRAM3DO`, `DualRAMJaguar`, `DualRAMPSX`, and `DualRAMSaturn` alt launchers targeting cores from the [TheJesusFish/Dual-Ram-Console-Cores](https://github.com/TheJesusFish/Dual-Ram-Console-Cores) repo, which distributes dual-SDRAM builds into `/media/fat/_Console (Dual SDRAM)/`.
- Each launcher uses `launchAltCore` with the path `_Console (Dual SDRAM)/<Core>` — the existing RBF cache picks up the folder automatically (any `_`-prefixed dir under `/media/fat` is scanned) and falls back to the canonical system core if the dual-ram RBF is absent.
- No `Folders`/`Extensions` set; slot config is inherited from the canonical system launcher via `cores.GetCore(systemID)`, matching the pattern used by LLAPI and PWM alt launchers.
- Also picked up by MiSTeX automatically since it calls `mister.CreateLaunchers`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for dual SDRAM configurations on MiSTer for 3DO, Jaguar, PSX, and Saturn systems, enabling alternate core usage with expanded memory capacity.

* **Tests**
  * Added validation tests for new dual RAM launcher configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->