### PR TITLE
fix(helpers): relax URI decode fuzz invariant

### DIFF
--- a/pkg/helpers/uris.go
+++ b/pkg/helpers/uris.go
@@ -79,7 +79,7 @@ func shouldKeepCustomSegmentEscaped(r rune) bool {
 
 // decodeCustomSchemeSegment decodes only percent-escaped bytes that are safe to
 // materialize, preserving literal reserved characters and keeping structural
-// escapes encoded for idempotence.
+// escapes encoded so custom virtual paths keep their parse boundaries.
 func decodeCustomSchemeSegment(raw string) string {
 	if !strings.Contains(raw, "%") {
 		return raw
@@ -181,8 +181,8 @@ func DecodeURIIfNeeded(uri string) string {
 	if shared.IsStandardSchemeForDecoding(schemeLower) {
 		// Per RFC 3986, '#' introduces the fragment and takes precedence over
 		// '?', which ParseURIComponents picks up as the query separator.
-		// Extract fragment from the raw URI first so that a fragment containing
-		// '?' doesn't shift on a second parse pass (idempotence).
+		// Extract fragment from the raw URI first so a fragment containing '?'
+		// does not shift into the query component.
 		var fragment string
 		fragURI := uri
 		if idx := strings.Index(uri, "#"); idx >= 0 {

--- a/pkg/helpers/uris_fuzz_test.go
+++ b/pkg/helpers/uris_fuzz_test.go
@@ -71,17 +71,24 @@ func FuzzDecodeURIIfNeeded(f *testing.F) {
 			}
 		}
 
-		// Property 4: Should preserve scheme if present and valid
-		if strings.Contains(uri, "://") && !virtualpath.ContainsControlChar(uri) {
+		// Property 4: Should preserve scheme if present
+		if utf8.ValidString(uri) && strings.Contains(uri, "://") && !virtualpath.ContainsControlChar(uri) {
 			schemeEnd := strings.Index(uri, "://")
 			schemeEnd2 := strings.Index(result, "://")
-			if schemeEnd >= 0 && schemeEnd2 >= 0 {
-				origScheme := strings.ToLower(uri[:schemeEnd])
-				resultScheme := strings.ToLower(result[:schemeEnd2])
-				// Only check if original scheme is valid
-				if virtualpath.IsValidScheme(origScheme) {
-					if origScheme != resultScheme {
-						t.Errorf("Scheme changed: %q -> %q", origScheme, resultScheme)
+			if schemeEnd >= 0 {
+				origScheme := uri[:schemeEnd]
+				origSchemeLower := strings.ToLower(origScheme)
+				if schemeEnd2 < 0 {
+					t.Errorf("Scheme separator removed: %q -> %q", uri[:schemeEnd+3], result)
+				} else {
+					resultScheme := result[:schemeEnd2]
+					resultSchemeLower := strings.ToLower(resultScheme)
+					if virtualpath.IsValidScheme(origSchemeLower) {
+						if origSchemeLower != resultSchemeLower {
+							t.Errorf("Scheme changed: %q -> %q", origSchemeLower, resultSchemeLower)
+						}
+					} else if origScheme != resultScheme {
+						t.Errorf("Unsupported scheme changed: %q -> %q", origScheme, resultScheme)
 					}
 				}
 			}

--- a/pkg/helpers/uris_fuzz_test.go
+++ b/pkg/helpers/uris_fuzz_test.go
@@ -47,6 +47,7 @@ func FuzzDecodeURIIfNeeded(f *testing.F) {
 	f.Add("https://example.com/games/My%20Game.iso") // HTTPS
 	f.Add("ftp://server/My%20File.zip")              // FTP (should not decode)
 	f.Add("myscheme://data%20here")                  // Unknown scheme
+	f.Add("http:///%25000")                          // Double-encoded percent sequence
 
 	f.Fuzz(func(t *testing.T, uri string) {
 		// Call function - should never panic
@@ -70,14 +71,7 @@ func FuzzDecodeURIIfNeeded(f *testing.F) {
 			}
 		}
 
-		// Property 4: Idempotence - decoding twice should equal decoding once
-		result2 := DecodeURIIfNeeded(result)
-		if result2 != result {
-			t.Errorf("Not idempotent: decode(%q)=%q, decode(decode(%q))=%q",
-				uri, result, uri, result2)
-		}
-
-		// Property 5: Should preserve scheme if present and valid
+		// Property 4: Should preserve scheme if present and valid
 		if strings.Contains(uri, "://") && !virtualpath.ContainsControlChar(uri) {
 			schemeEnd := strings.Index(uri, "://")
 			schemeEnd2 := strings.Index(result, "://")

--- a/pkg/helpers/uris_test.go
+++ b/pkg/helpers/uris_test.go
@@ -73,6 +73,11 @@ func TestDecodeURIIfNeeded(t *testing.T) {
 			input:    "https://example.com/games/My%20Game.iso",
 			expected: "https://example.com/games/My Game.iso",
 		},
+		{
+			name:     "http_double_encoded_percent_sequence",
+			input:    "http:///%25000",
+			expected: "http:///%000",
+		},
 
 		// No encoding (should return as-is)
 		{
@@ -943,13 +948,13 @@ func TestDecodeURIIfNeeded_MalformedGracefulFallback(t *testing.T) {
 			name:        "double_encoding",
 			input:       "steam://999/Name%2520Here",
 			expected:    "steam://999/Name%2520Here",
-			description: "Literal % in decoded segment is re-encoded for idempotence",
+			description: "Literal % in decoded segment stays encoded to preserve custom path structure",
 		},
 		{
 			name:        "triple_encoding",
 			input:       "kodi-movie://100/Name%252520Here",
 			expected:    "kodi-movie://100/Name%252520Here",
-			description: "Literal % in decoded segment is re-encoded for idempotence",
+			description: "Literal % in decoded segment stays encoded to preserve custom path structure",
 		},
 		{
 			name:        "custom_scheme_literal_hashes_stay_literal",

--- a/pkg/testing/FUZZ_TESTING.md
+++ b/pkg/testing/FUZZ_TESTING.md
@@ -94,9 +94,9 @@ f.Fuzz(func(t *testing.T, input string) {
         t.Errorf("Invalid UTF-8: %q", result)
     }
 
-    // Property: Idempotence - decode twice = decode once
-    if DecodeURIIfNeeded(result) != result {
-        t.Errorf("Not idempotent: %q", input)
+    // Property: Unknown schemes should not be decoded
+    if strings.HasPrefix(input, "example://") && result != input {
+        t.Errorf("Unknown scheme changed: %q -> %q", input, result)
     }
 })
 


### PR DESCRIPTION
## Summary
- Remove the broad DecodeURIIfNeeded idempotence fuzz assertion that flagged valid single-pass HTTP decoding behavior.
- Add regression coverage for the `%25000` fuzz input and keep custom virtual path preservation focused on parse boundaries.
- Update fuzz testing guidance to use product-relevant invariants instead of decoder idempotence.

Fixes #735
Fixes #723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified URI decoding comments to explain why percent-escapes remain encoded for parse-boundary preservation.

* **Tests**
  * Added coverage for double-encoded URI sequences.
  * Updated fuzz test invariants and assertions to remove idempotence checks and strengthen scheme-handling validation.
  * Adjusted unit test expectations and descriptions for encoding edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->