### PR TITLE
fix(mister): add CA bundle fallback

### DIFF
--- a/pkg/helpers/tlsroots/tlsroots.go
+++ b/pkg/helpers/tlsroots/tlsroots.go
@@ -74,11 +74,7 @@ func ConfigureDefaults(fallbackPaths []string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if path == "" {
-		return "", nil
-	}
-
-	if os.Getenv("SSL_CERT_FILE") != path {
+	if path != "" && os.Getenv("SSL_CERT_FILE") != path {
 		if err := os.Setenv("SSL_CERT_FILE", path); err != nil {
 			return "", fmt.Errorf("setting SSL_CERT_FILE: %w", err)
 		}

--- a/pkg/helpers/tlsroots/tlsroots.go
+++ b/pkg/helpers/tlsroots/tlsroots.go
@@ -1,0 +1,144 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tlsroots
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+)
+
+var configuredRoots struct {
+	pool *x509.CertPool
+	path string
+	mu   syncutil.Mutex
+}
+
+// CertPoolWithFallback returns the system certificate pool augmented with the
+// first valid PEM bundle from fallbackPaths. SSL_CERT_FILE is used only when no
+// explicit fallback path is valid. The returned path is empty when no bundle was
+// used.
+func CertPoolWithFallback(fallbackPaths []string) (*x509.CertPool, string, error) {
+	pool, systemErr := x509.SystemCertPool()
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+
+	for _, path := range fallbackPaths {
+		if appendBundle(pool, path) {
+			return pool, path, nil
+		}
+	}
+
+	if envPath := os.Getenv("SSL_CERT_FILE"); envPath != "" {
+		if appendBundle(pool, envPath) {
+			return pool, envPath, nil
+		}
+	}
+
+	if systemErr != nil {
+		return nil, "", fmt.Errorf("failed to load system certificate pool: %w", systemErr)
+	}
+	return pool, "", nil
+}
+
+// ConfigureDefaults configures process-wide HTTP defaults to use system roots
+// augmented with a MiSTer fallback CA bundle. It also sets SSL_CERT_FILE when a
+// fallback path was selected so later SystemCertPool calls use the same bundle.
+func ConfigureDefaults(fallbackPaths []string) (string, error) {
+	configuredRoots.mu.Lock()
+	defer configuredRoots.mu.Unlock()
+
+	pool, path, err := CertPoolWithFallback(fallbackPaths)
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", nil
+	}
+
+	if os.Getenv("SSL_CERT_FILE") != path {
+		if err := os.Setenv("SSL_CERT_FILE", path); err != nil {
+			return "", fmt.Errorf("setting SSL_CERT_FILE: %w", err)
+		}
+	}
+
+	oldDefault := http.DefaultTransport
+	transport := TransportWithRoots(defaultHTTPTransport(), pool)
+	http.DefaultTransport = transport
+	if http.DefaultClient.Transport == nil || http.DefaultClient.Transport == oldDefault {
+		http.DefaultClient.Transport = transport
+	}
+
+	configuredRoots.pool = pool
+	configuredRoots.path = path
+	return path, nil
+}
+
+// Transport clones base and applies the roots configured by ConfigureDefaults.
+// If ConfigureDefaults has not selected a bundle, Transport returns a clone of
+// base using normal Go TLS root behavior.
+func Transport(base *http.Transport) *http.Transport {
+	configuredRoots.mu.Lock()
+	defer configuredRoots.mu.Unlock()
+
+	return TransportWithRoots(base, configuredRoots.pool)
+}
+
+// TransportWithRoots clones base and configures it to use roots when non-nil.
+func TransportWithRoots(base *http.Transport, roots *x509.CertPool) *http.Transport {
+	if base == nil {
+		base = defaultHTTPTransport()
+	}
+
+	transport := base.Clone()
+	if roots == nil {
+		return transport
+	}
+
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{RootCAs: roots} //nolint:gosec // RootCAs preserves TLS verification
+	} else {
+		transport.TLSClientConfig = transport.TLSClientConfig.Clone()
+		transport.TLSClientConfig.RootCAs = roots
+	}
+
+	return transport
+}
+
+func appendBundle(pool *x509.CertPool, path string) bool {
+	pem, err := os.ReadFile(path) //nolint:gosec // paths are platform-owned CA bundle locations
+	if err != nil {
+		return false
+	}
+	return pool.AppendCertsFromPEM(pem)
+}
+
+func defaultHTTPTransport() *http.Transport {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{}
+	}
+	return defaultTransport
+}

--- a/pkg/helpers/tlsroots/tlsroots_test.go
+++ b/pkg/helpers/tlsroots/tlsroots_test.go
@@ -117,7 +117,7 @@ func TestConfigureDefaults_TrustsFallbackCertificateWithDefaultClient(t *testing
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestConfigureDefaults_NoValidBundleLeavesDefaultsUnchanged(t *testing.T) {
+func TestConfigureDefaults_NoValidBundleUpdatesDefaultsWithoutSettingEnv(t *testing.T) {
 	tempDir := t.TempDir()
 	missingPath := filepath.Join(tempDir, "missing.pem")
 	restoreTLSGlobals(t)
@@ -129,8 +129,12 @@ func TestConfigureDefaults_NoValidBundleLeavesDefaultsUnchanged(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Empty(t, usedPath)
-	assert.Equal(t, oldDefaultTransport, http.DefaultTransport)
-	assert.Equal(t, oldDefaultClientTransport, http.DefaultClient.Transport)
+	assert.Empty(t, os.Getenv("SSL_CERT_FILE"))
+	require.NotSame(t, oldDefaultTransport, http.DefaultTransport)
+	assert.Same(t, http.DefaultTransport, http.DefaultClient.Transport)
+	assert.Nil(t, oldDefaultClientTransport)
+	assert.NotNil(t, configuredRoots.pool)
+	assert.Empty(t, configuredRoots.path)
 }
 
 func TestTransport_TrustsConfiguredRootsWithCustomTransport(t *testing.T) {

--- a/pkg/helpers/tlsroots/tlsroots_test.go
+++ b/pkg/helpers/tlsroots/tlsroots_test.go
@@ -20,6 +20,7 @@
 package tlsroots
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
@@ -116,6 +117,22 @@ func TestConfigureDefaults_TrustsFallbackCertificateWithDefaultClient(t *testing
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
+func TestConfigureDefaults_NoValidBundleLeavesDefaultsUnchanged(t *testing.T) {
+	tempDir := t.TempDir()
+	missingPath := filepath.Join(tempDir, "missing.pem")
+	restoreTLSGlobals(t)
+	t.Setenv("SSL_CERT_FILE", "")
+
+	oldDefaultTransport := http.DefaultTransport
+	oldDefaultClientTransport := http.DefaultClient.Transport
+	usedPath, err := ConfigureDefaults([]string{missingPath})
+
+	require.NoError(t, err)
+	assert.Empty(t, usedPath)
+	assert.Equal(t, oldDefaultTransport, http.DefaultTransport)
+	assert.Equal(t, oldDefaultClientTransport, http.DefaultClient.Transport)
+}
+
 func TestTransport_TrustsConfiguredRootsWithCustomTransport(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -141,6 +158,33 @@ func TestTransport_TrustsConfiguredRootsWithCustomTransport(t *testing.T) {
 		assert.NoError(t, resp.Body.Close())
 	}()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestTransportWithRoots_ClonesExistingTLSConfig(t *testing.T) {
+	pool := x509.NewCertPool()
+	baseConfig := &tls.Config{ServerName: "example.com"} //nolint:gosec // test-only client config
+	base := &http.Transport{TLSClientConfig: baseConfig}
+
+	transport := TransportWithRoots(base, pool)
+
+	require.NotSame(t, base, transport)
+	require.NotSame(t, baseConfig, transport.TLSClientConfig)
+	assert.Equal(t, "example.com", transport.TLSClientConfig.ServerName)
+	assert.Same(t, pool, transport.TLSClientConfig.RootCAs)
+	assert.Nil(t, baseConfig.RootCAs)
+}
+
+func TestTransportWithoutConfiguredRootsClonesBase(t *testing.T) {
+	restoreTLSGlobals(t)
+	base := &http.Transport{ResponseHeaderTimeout: 1}
+
+	transport := Transport(base)
+
+	require.NotSame(t, base, transport)
+	assert.Equal(t, base.ResponseHeaderTimeout, transport.ResponseHeaderTimeout)
+	if transport.TLSClientConfig != nil {
+		assert.Nil(t, transport.TLSClientConfig.RootCAs)
+	}
 }
 
 func restoreTLSGlobals(t *testing.T) {

--- a/pkg/helpers/tlsroots/tlsroots_test.go
+++ b/pkg/helpers/tlsroots/tlsroots_test.go
@@ -1,0 +1,173 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tlsroots
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertPoolWithFallback_UsesFirstValidBundle(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	missingPath := filepath.Join(tempDir, "missing.pem")
+	invalidPath := filepath.Join(tempDir, "invalid.pem")
+	validPath := filepath.Join(tempDir, "valid.pem")
+
+	require.NoError(t, os.WriteFile(invalidPath, []byte("not a certificate"), 0o600))
+	require.NoError(t, os.WriteFile(validPath, certPEM(t, server.Certificate()), 0o600))
+
+	pool, usedPath, err := CertPoolWithFallback([]string{missingPath, invalidPath, validPath})
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	assert.Equal(t, validPath, usedPath)
+}
+
+func TestCertPoolWithFallback_PrefersFallbackOverSSLCertFile(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	envPath := filepath.Join(tempDir, "env.pem")
+	fallbackPath := filepath.Join(tempDir, "fallback.pem")
+	restoreTLSGlobals(t)
+	t.Setenv("SSL_CERT_FILE", envPath)
+	require.NoError(t, os.WriteFile(envPath, certPEM(t, server.Certificate()), 0o600))
+	require.NoError(t, os.WriteFile(fallbackPath, certPEM(t, server.Certificate()), 0o600))
+
+	pool, usedPath, err := CertPoolWithFallback([]string{fallbackPath})
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	assert.Equal(t, fallbackPath, usedPath)
+}
+
+func TestCertPoolWithFallback_UsesSSLCertFileWhenNoFallbackIsValid(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	envPath := filepath.Join(tempDir, "env.pem")
+	missingPath := filepath.Join(tempDir, "missing.pem")
+	restoreTLSGlobals(t)
+	t.Setenv("SSL_CERT_FILE", envPath)
+	require.NoError(t, os.WriteFile(envPath, certPEM(t, server.Certificate()), 0o600))
+
+	pool, usedPath, err := CertPoolWithFallback([]string{missingPath})
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	assert.Equal(t, envPath, usedPath)
+}
+
+func TestConfigureDefaults_TrustsFallbackCertificateWithDefaultClient(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "cacert.pem")
+	require.NoError(t, os.WriteFile(certPath, certPEM(t, server.Certificate()), 0o600))
+	restoreTLSGlobals(t)
+	t.Setenv("SSL_CERT_FILE", "")
+
+	usedPath, err := ConfigureDefaults([]string{certPath})
+	require.NoError(t, err)
+	assert.Equal(t, certPath, usedPath)
+	assert.Equal(t, certPath, os.Getenv("SSL_CERT_FILE"))
+
+	resp, err := http.DefaultClient.Get(server.URL) //nolint:gosec,noctx // test server URL
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestTransport_TrustsConfiguredRootsWithCustomTransport(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "cacert.pem")
+	require.NoError(t, os.WriteFile(certPath, certPEM(t, server.Certificate()), 0o600))
+	restoreTLSGlobals(t)
+	t.Setenv("SSL_CERT_FILE", "")
+
+	usedPath, err := ConfigureDefaults([]string{certPath})
+	require.NoError(t, err)
+	assert.Equal(t, certPath, usedPath)
+
+	transport := Transport(&http.Transport{})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(server.URL) //nolint:gosec,noctx // test server URL
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, resp.Body.Close())
+	}()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func restoreTLSGlobals(t *testing.T) {
+	t.Helper()
+
+	oldDefaultTransport := http.DefaultTransport
+	oldDefaultClientTransport := http.DefaultClient.Transport
+	configuredRoots.mu.Lock()
+	oldPool := configuredRoots.pool
+	oldPath := configuredRoots.path
+	configuredRoots.mu.Unlock()
+
+	t.Cleanup(func() {
+		http.DefaultTransport = oldDefaultTransport
+		http.DefaultClient.Transport = oldDefaultClientTransport
+		configuredRoots.mu.Lock()
+		configuredRoots.pool = oldPool
+		configuredRoots.path = oldPath
+		configuredRoots.mu.Unlock()
+	})
+}
+
+func certPEM(t *testing.T, cert *x509.Certificate) []byte {
+	t.Helper()
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+}

--- a/pkg/platforms/mister/config/config.go
+++ b/pkg/platforms/mister/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -39,7 +40,10 @@ const (
 	CoreConfigFolder   = SDRootDir + "/config"
 	MenuConfigFile     = CoreConfigFolder + "/MENU.CFG"
 	DefaultIniFilename = "MiSTer.ini"
+	SystemCACert       = "/etc/ssl/certs/cacert.pem"
 )
+
+var UpdateAllDownloaderCACert = filepath.Join(ScriptsDir, ".config", "downloader", "cacert.pem")
 
 func MainHasFeature(feature string) bool {
 	if _, err := os.Stat(MainFeaturesFile); os.IsNotExist(err) {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
@@ -30,6 +31,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mistermain"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/tracker"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/installer"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/externaldrive"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/file"
@@ -42,6 +44,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
 	"github.com/rs/zerolog/log"
 )
 
@@ -142,6 +145,8 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 }
 
 func (p *Platform) StartPre(cfg *config.Instance) error {
+	configureTLSRootFallback()
+
 	if misterconfig.MainHasFeature(misterconfig.MainFeaturePicker) {
 		err := os.MkdirAll(misterconfig.MainPickerDir, 0o750)
 		if err != nil {
@@ -185,6 +190,29 @@ func (p *Platform) StartPre(cfg *config.Instance) error {
 	}
 
 	return nil
+}
+
+func configureTLSRootFallback() {
+	fallbackPaths := []string{
+		misterconfig.UpdateAllDownloaderCACert,
+		misterconfig.SystemCACert,
+	}
+
+	usedPath, err := tlsroots.ConfigureDefaults(fallbackPaths)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to configure MiSTer TLS CA fallback")
+		return
+	}
+
+	zapscript.ConfigureHTTPTransport()
+	installer.ConfigureHTTPTransport()
+
+	if usedPath == "" {
+		log.Debug().Msg("no MiSTer TLS CA fallback bundle found")
+		return
+	}
+
+	log.Info().Str("path", usedPath).Msg("configured MiSTer TLS CA fallback bundle")
 }
 
 func (p *Platform) StartPost(

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -192,20 +192,26 @@ func (p *Platform) StartPre(cfg *config.Instance) error {
 	return nil
 }
 
+var configureTLSDefaults = tlsroots.ConfigureDefaults
+
+var configureZapLinkHTTPTransport = zapscript.ConfigureHTTPTransport
+
+var configureInstallerHTTPTransport = installer.ConfigureHTTPTransport
+
 func configureTLSRootFallback() {
 	fallbackPaths := []string{
 		misterconfig.UpdateAllDownloaderCACert,
 		misterconfig.SystemCACert,
 	}
 
-	usedPath, err := tlsroots.ConfigureDefaults(fallbackPaths)
+	usedPath, err := configureTLSDefaults(fallbackPaths)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to configure MiSTer TLS CA fallback")
 		return
 	}
 
-	zapscript.ConfigureHTTPTransport()
-	installer.ConfigureHTTPTransport()
+	configureZapLinkHTTPTransport()
+	configureInstallerHTTPTransport()
 
 	if usedPath == "" {
 		log.Debug().Msg("no MiSTer TLS CA fallback bundle found")

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -23,6 +23,7 @@ package mister
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"testing"
@@ -31,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +47,60 @@ func (*mockLauncherManager) GetContext() context.Context {
 
 func (*mockLauncherManager) NewContext() context.Context {
 	return context.Background()
+}
+
+func TestConfigureTLSRootFallback_ConfiguresDefaultsAndCustomTransports(t *testing.T) {
+	restoreTLSRootFallbackHooks(t)
+
+	expectedPaths := []string{
+		misterconfig.UpdateAllDownloaderCACert,
+		misterconfig.SystemCACert,
+	}
+	var receivedPaths []string
+	zapLinkConfigured := false
+	installerConfigured := false
+	configureTLSDefaults = func(paths []string) (string, error) {
+		receivedPaths = append([]string(nil), paths...)
+		return misterconfig.UpdateAllDownloaderCACert, nil
+	}
+	configureZapLinkHTTPTransport = func() { zapLinkConfigured = true }
+	configureInstallerHTTPTransport = func() { installerConfigured = true }
+
+	configureTLSRootFallback()
+
+	assert.Equal(t, expectedPaths, receivedPaths)
+	assert.True(t, zapLinkConfigured)
+	assert.True(t, installerConfigured)
+}
+
+func TestConfigureTLSRootFallback_SkipsCustomTransportsOnDefaultError(t *testing.T) {
+	restoreTLSRootFallbackHooks(t)
+
+	zapLinkConfigured := false
+	installerConfigured := false
+	configureTLSDefaults = func(_ []string) (string, error) {
+		return "", errors.New("load roots")
+	}
+	configureZapLinkHTTPTransport = func() { zapLinkConfigured = true }
+	configureInstallerHTTPTransport = func() { installerConfigured = true }
+
+	configureTLSRootFallback()
+
+	assert.False(t, zapLinkConfigured)
+	assert.False(t, installerConfigured)
+}
+
+func restoreTLSRootFallbackHooks(t *testing.T) {
+	t.Helper()
+
+	oldConfigureTLSDefaults := configureTLSDefaults
+	oldConfigureZapLinkHTTPTransport := configureZapLinkHTTPTransport
+	oldConfigureInstallerHTTPTransport := configureInstallerHTTPTransport
+	t.Cleanup(func() {
+		configureTLSDefaults = oldConfigureTLSDefaults
+		configureZapLinkHTTPTransport = oldConfigureZapLinkHTTPTransport
+		configureInstallerHTTPTransport = oldConfigureInstallerHTTPTransport
+	})
 }
 
 func TestStopActiveLauncher_CustomKill(t *testing.T) {

--- a/pkg/platforms/shared/installer/http.go
+++ b/pkg/platforms/shared/installer/http.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/rs/zerolog/log"
 )
 
@@ -74,6 +75,17 @@ var httpClient = &http.Client{
 	Transport: &AuthTransport{
 		Base: timeoutTr,
 	},
+}
+
+// ConfigureHTTPTransport applies the process TLS root configuration to the
+// installer's custom timeout transport.
+func ConfigureHTTPTransport() {
+	transport := tlsroots.Transport(timeoutTr)
+	httpClient = &http.Client{
+		Transport: &AuthTransport{
+			Base: transport,
+		},
+	}
 }
 
 func DownloadHTTPFile(opts DownloaderArgs) error {

--- a/pkg/platforms/shared/installer/http_test.go
+++ b/pkg/platforms/shared/installer/http_test.go
@@ -21,6 +21,8 @@ package installer
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -31,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +71,44 @@ func TestDownloadHTTPFile_Success(t *testing.T) {
 	// Verify temp file was removed (renamed to final)
 	_, err = os.Stat(tempPath)
 	assert.True(t, os.IsNotExist(err), "temp file should not exist after successful download")
+}
+
+func TestConfigureHTTPTransport_TrustsConfiguredTLSRoots(t *testing.T) {
+	content := []byte("download over custom TLS roots")
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	oldHTTPClient := httpClient
+	t.Cleanup(func() {
+		httpClient = oldHTTPClient
+	})
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "cacert.pem")
+	require.NoError(t, os.WriteFile(certPath, testCertPEM(t, server.Certificate()), 0o600))
+	t.Setenv("SSL_CERT_FILE", "")
+	usedPath, err := tlsroots.ConfigureDefaults([]string{certPath})
+	require.NoError(t, err)
+	require.Equal(t, certPath, usedPath)
+	ConfigureHTTPTransport()
+
+	tempPath := filepath.Join(tempDir, "game.rom.part")
+	finalPath := filepath.Join(tempDir, "game.rom")
+	err = DownloadHTTPFile(DownloaderArgs{
+		ctx:       context.Background(),
+		url:       server.URL + "/game.rom",
+		tempPath:  tempPath,
+		finalPath: finalPath,
+	})
+
+	require.NoError(t, err)
+	data, err := os.ReadFile(finalPath) //nolint:gosec // Test file path from t.TempDir()
+	require.NoError(t, err)
+	assert.Equal(t, content, data)
 }
 
 func TestDownloadHTTPFile_ContextCancellation(t *testing.T) {
@@ -120,6 +161,15 @@ func TestDownloadHTTPFile_ContextCancellation(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func testCertPEM(t *testing.T, cert *x509.Certificate) []byte {
+	t.Helper()
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
 }
 
 func TestDownloadHTTPFile_ContextTimeout(t *testing.T) {

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -27,6 +27,7 @@ import (
 	"runtime"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	selfupdate "github.com/creativeprojects/go-selfupdate"
 	"github.com/rs/zerolog/log"
@@ -45,7 +46,8 @@ type Result struct {
 
 func makeUpdater(_ context.Context, platformID, channel string) (*selfupdate.Updater, selfupdate.Repository, error) {
 	source, err := selfupdate.NewHttpSource(selfupdate.HttpConfig{
-		BaseURL: updateURL,
+		BaseURL:   updateURL,
+		Transport: tlsroots.Transport(nil),
 	})
 	if err != nil {
 		return nil, selfupdate.RepositorySlug{}, fmt.Errorf("creating update source: %w", err)

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -21,6 +21,7 @@ package zapscript
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,6 +40,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/installer"
 	"github.com/rs/zerolog/log"
@@ -87,11 +90,32 @@ var zapFetchTransport = &http.Transport{
 	ExpectContinueTimeout: 1 * time.Second,
 }
 
-var zapFetchClient = &http.Client{
-	Transport: &installer.AuthTransport{
-		Base: zapFetchTransport,
-	},
-	Timeout: 10 * time.Second,
+var zapFetchClientMu syncutil.RWMutex
+
+var zapFetchClient = newZapFetchClient(zapFetchTransport)
+
+func newZapFetchClient(transport http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: &installer.AuthTransport{
+			Base: transport,
+		},
+		Timeout: 10 * time.Second,
+	}
+}
+
+func currentZapFetchClient() *http.Client {
+	zapFetchClientMu.RLock()
+	defer zapFetchClientMu.RUnlock()
+	return zapFetchClient
+}
+
+// ConfigureHTTPTransport applies the process TLS root configuration to ZapLink's
+// custom timeout transport.
+func ConfigureHTTPTransport() {
+	transport := tlsroots.Transport(zapFetchTransport)
+	zapFetchClientMu.Lock()
+	zapFetchClient = newZapFetchClient(transport)
+	zapFetchClientMu.Unlock()
 }
 
 // ErrWellKnownNotFound is returned when the .well-known/zaparoo endpoint
@@ -101,7 +125,7 @@ var ErrWellKnownNotFound = errors.New("well-known endpoint not found")
 // FetchWellKnown fetches and parses the .well-known/zaparoo file from a base URL.
 // Returns ErrWellKnownNotFound if the host returned 404.
 func FetchWellKnown(baseURL string) (*WellKnown, error) {
-	return doFetchWellKnown(baseURL, zapFetchClient)
+	return doFetchWellKnown(baseURL, currentZapFetchClient())
 }
 
 func doFetchWellKnown(baseURL string, client httpDoer) (*WellKnown, error) {
@@ -150,7 +174,7 @@ func doFetchWellKnown(baseURL string, client httpDoer) (*WellKnown, error) {
 
 func queryZapLinkSupport(u *url.URL) (int, error) {
 	baseURL := u.Scheme + "://" + u.Host
-	wk, err := doFetchWellKnown(baseURL, zapFetchClient)
+	wk, err := doFetchWellKnown(baseURL, currentZapFetchClient())
 	if errors.Is(err, ErrWellKnownNotFound) {
 		return 0, nil
 	}
@@ -212,7 +236,7 @@ func getRemoteZapScript(urlStr, platform string) ([]byte, error) {
 	setZapLinkHeaders(req, platform)
 	req.Header.Set("Accept", strings.Join(AcceptedMimeTypes, ", "))
 
-	resp, err := zapFetchClient.Do(req) //nolint:gosec // G704: URL from ZapLink resolution
+	resp, err := currentZapFetchClient().Do(req) //nolint:gosec // G704: URL from ZapLink resolution
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch zapscript from '%s': %w", urlStr, err)
 	}
@@ -276,6 +300,11 @@ func isOfflineError(err error) bool {
 		}
 	}
 
+	var unknownAuthorityErr x509.UnknownAuthorityError
+	if errors.As(err, &unknownAuthorityErr) {
+		return true
+	}
+
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
 		var t *os.SyscallError
@@ -301,7 +330,8 @@ func isOfflineError(err error) bool {
 		strings.Contains(lowerErrStr, "connection refused") ||
 		strings.Contains(lowerErrStr, "host is down") ||
 		strings.Contains(lowerErrStr, "i/o timeout") ||
-		strings.Contains(lowerErrStr, "tls handshake timeout") {
+		strings.Contains(lowerErrStr, "tls handshake timeout") ||
+		strings.Contains(lowerErrStr, "certificate signed by unknown authority") {
 		return true
 	}
 
@@ -382,7 +412,7 @@ func PreWarmZapLinkHosts(db *database.Database, checkInternet func(int) bool) {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			preWarmHost(u, db, zapFetchClient)
+			preWarmHost(u, db, currentZapFetchClient())
 		}(baseURL)
 	}
 

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -21,6 +21,7 @@ package zapscript
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"io"
 	"net/http"
@@ -168,6 +169,19 @@ func TestIsOfflineError(t *testing.T) {
 		{
 			name:     "tls handshake timeout",
 			err:      errors.New("tls handshake timeout"),
+			expected: true,
+		},
+		{
+			name:     "unknown certificate authority",
+			err:      x509.UnknownAuthorityError{},
+			expected: true,
+		},
+		{
+			name: "wrapped unknown certificate authority",
+			err: errors.New(
+				"Get \"https://example.com\": tls: failed to verify certificate: " +
+					"x509: certificate signed by unknown authority",
+			),
 			expected: true,
 		},
 		{

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -22,17 +22,21 @@ package zapscript
 import (
 	"context"
 	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -596,6 +600,35 @@ func TestFetchWellKnown_BasicZapScriptOnly(t *testing.T) {
 	assert.Nil(t, wk.Trusted)
 }
 
+func TestConfigureHTTPTransport_TrustsConfiguredTLSRoots(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"zapscript": 1}`))
+	}))
+	defer server.Close()
+
+	oldClient := currentZapFetchClient()
+	t.Cleanup(func() {
+		zapFetchClientMu.Lock()
+		zapFetchClient = oldClient
+		zapFetchClientMu.Unlock()
+	})
+
+	tempDir := t.TempDir()
+	certPath := filepath.Join(tempDir, "cacert.pem")
+	require.NoError(t, os.WriteFile(certPath, zapLinkCertPEM(t, server.Certificate()), 0o600))
+	t.Setenv("SSL_CERT_FILE", "")
+	usedPath, err := tlsroots.ConfigureDefaults([]string{certPath})
+	require.NoError(t, err)
+	require.Equal(t, certPath, usedPath)
+	ConfigureHTTPTransport()
+
+	wk, err := FetchWellKnown(server.URL)
+	require.NoError(t, err)
+	require.NotNil(t, wk)
+	assert.Equal(t, 1, wk.ZapScript)
+}
+
 func TestFetchWellKnown_WithAuthAndTrusted(t *testing.T) {
 	t.Parallel()
 
@@ -719,4 +752,13 @@ func TestGetRemoteZapScript_NormalResponse(t *testing.T) {
 	body, err := getRemoteZapScript(server.URL, "test")
 	require.NoError(t, err)
 	assert.Equal(t, expected, body)
+}
+
+func zapLinkCertPEM(t *testing.T, cert *x509.Certificate) []byte {
+	t.Helper()
+
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
 }


### PR DESCRIPTION
## Summary
- Configure MiSTer startup to use Update_All/system CA bundles for Go HTTPS clients when system trust is outdated.
- Add a central TLS roots helper that updates HTTP defaults and custom transports without disabling verification.
- Treat ZapLink unknown-authority failures as transient and cover the fallback behavior with focused tests.

Fixes #724 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using fallback TLS CA bundles and applying them to HTTP clients/transports so tools can trust custom server certificates.
  * Runtime reconfiguration of HTTP transport to pick up configured TLS roots.

* **Bug Fixes**
  * Treats unknown-certificate-authority errors as transient/offline to improve offline detection.

* **Tests**
  * New tests validating TLS fallback, transport cloning, and end-to-end HTTP trust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->