### PR TITLE
fix(readers): improve external drive and service lifecycle

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   fuzz:
     name: Fuzz
-    runs-on: ubicloud-standard-4
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ For architecture details, API reference, and key concepts: [docs/ARCHITECTURE.md
 - Keep diffs small and focused — one concern per change
 - Use file-scoped commands for faster feedback over full-suite runs
 - Reference existing patterns before writing new code
+- Define Go types and consts near the top of the file, before functions and methods
 - Use `filepath.Join` for path construction everywhere, including test files — never hardcode POSIX-style paths like `"/roms/snes/game.sfc"` as string literals
 - Use afero for filesystem operations in testable code
 - NEVER use `sync.Mutex`/`sync.RWMutex` — use `syncutil.Mutex`/`syncutil.RWMutex` (forbidigo linter enforces this)

--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -124,6 +124,7 @@ func run() error {
 	)
 
 	svc, err := daemon.NewService(daemon.ServiceArgs{
+		Config: cfg,
 		Entry: func() (*service.StartResult, error) {
 			return service.Start(pl, cfg)
 		},

--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -144,7 +144,7 @@ func run() error {
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
 	if runningErr != nil {
-		return runningErr
+		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {
 		startErr := svc.Start()

--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -142,17 +142,29 @@ func run() error {
 	flags.Post(cfg, pl)
 
 	// try to auto-start service if it's not running already
-	if !svc.Running() {
+	running, runningErr := svc.Running()
+	if runningErr != nil {
+		return runningErr
+	}
+	if !running {
 		startErr := svc.Start()
 		if startErr != nil {
 			log.Error().Err(startErr).Msg("could not start service")
 		}
 	}
+	isRunning := func() bool {
+		running, runningErr := svc.Running()
+		if runningErr != nil {
+			log.Error().Err(runningErr).Msg("service PID file conflict")
+			return false
+		}
+		return running
+	}
 
 	// start the tui
 	app, err := tui.BuildMain(
 		cfg, pl,
-		svc.Running,
+		isRunning,
 		path.Join(helpers.DataDir(pl), config.LogFile),
 		"storage")
 	if err != nil {

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -87,7 +87,11 @@ func run() error {
 	flags.Post(cfg, pl)
 
 	// try to auto-start service if it's not running already
-	if !svc.Running() {
+	running, runningErr := svc.Running()
+	if runningErr != nil {
+		return runningErr
+	}
+	if !running {
 		startErr := svc.Start()
 		if startErr != nil {
 			log.Error().Err(startErr).Msg("could not start service")
@@ -97,8 +101,16 @@ func run() error {
 	// display main info gui
 	err = tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
 		logDestinationPath := path.Join("/storage", config.LogFile)
+		isRunning := func() bool {
+			running, runningErr := svc.Running()
+			if runningErr != nil {
+				log.Error().Err(runningErr).Msg("service PID file conflict")
+				return false
+			}
+			return running
+		}
 		return tui.BuildMain(
-			cfg, pl, svc.Running,
+			cfg, pl, isRunning,
 			logDestinationPath, "storage",
 		)
 	})

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -89,7 +89,7 @@ func run() error {
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
 	if runningErr != nil {
-		return runningErr
+		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {
 		startErr := svc.Start()

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -69,6 +69,7 @@ func run() error {
 	cfg := cli.Setup(pl, config.BaseDefaults, nil)
 
 	svc, err := daemon.NewService(daemon.ServiceArgs{
+		Config: cfg,
 		Entry: func() (*service.StartResult, error) {
 			return service.Start(pl, cfg)
 		},

--- a/cmd/mister/gui.go
+++ b/cmd/mister/gui.go
@@ -113,7 +113,15 @@ func displayServiceInfo(pl platforms.Platform, cfg *config.Instance, service *da
 	// Asturur > Wizzo
 	err := tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
 		logDestinationPath := path.Join(misterconfig.DataDir, config.LogFile)
-		return tui.BuildMain(cfg, pl, service.Running, logDestinationPath, "SD card")
+		isRunning := func() bool {
+			running, err := service.Running()
+			if err != nil {
+				log.Error().Err(err).Msg("service PID file conflict")
+				return false
+			}
+			return running
+		}
+		return tui.BuildMain(cfg, pl, isRunning, logDestinationPath, "SD card")
 	})
 	if err != nil {
 		return fmt.Errorf("failed to build and display service info: %w", err)

--- a/cmd/mister/main.go
+++ b/cmd/mister/main.go
@@ -208,7 +208,11 @@ func run() error {
 	}
 
 	// try to auto-start service if it's not running already
-	if !svc.Running() {
+	running, runningErr := svc.Running()
+	if runningErr != nil {
+		return runningErr
+	}
+	if !running {
 		log.Info().Msg("service not running, attempting to auto-start")
 
 		if startErr := svc.Start(); startErr != nil {

--- a/cmd/mister/main.go
+++ b/cmd/mister/main.go
@@ -184,6 +184,7 @@ func run() error {
 	}
 
 	svc, err := daemon.NewService(daemon.ServiceArgs{
+		Config: cfg,
 		Entry: func() (*service.StartResult, error) {
 			return service.Start(pl, cfg)
 		},

--- a/cmd/mister/main.go
+++ b/cmd/mister/main.go
@@ -210,7 +210,7 @@ func run() error {
 	// try to auto-start service if it's not running already
 	running, runningErr := svc.Running()
 	if runningErr != nil {
-		return runningErr
+		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {
 		log.Info().Msg("service not running, attempting to auto-start")

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -144,6 +144,7 @@ func run() error {
 	)
 
 	svc, err := daemon.NewService(daemon.ServiceArgs{
+		Config: cfg,
 		Entry: func() (*service.StartResult, error) {
 			return service.Start(pl, cfg)
 		},

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -172,7 +172,11 @@ func run() error {
 		_, _ = fmt.Println("Added Zaparoo to MiSTeX startup.")
 	}
 
-	if !svc.Running() {
+	running, runningErr := svc.Running()
+	if runningErr != nil {
+		return runningErr
+	}
+	if !running {
 		err := svc.Start()
 		_, _ = fmt.Println("Zaparoo service not running, starting...")
 		if err != nil {

--- a/cmd/mistex/main.go
+++ b/cmd/mistex/main.go
@@ -174,7 +174,7 @@ func run() error {
 
 	running, runningErr := svc.Running()
 	if runningErr != nil {
-		return runningErr
+		return fmt.Errorf("error checking service status: %w", runningErr)
 	}
 	if !running {
 		err := svc.Start()

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	fyne.io/systray v1.12.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Microsoft/go-winio v0.6.2
-	github.com/ZaparooProject/go-pn532 v0.22.0
+	github.com/ZaparooProject/go-pn532 v0.22.1
 	github.com/ZaparooProject/go-zapscript v0.7.2
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
-github.com/ZaparooProject/go-pn532 v0.22.0 h1:XuqjkheYhF8I9jUwk91WYriRooHKMzbT5fUgGpna51E=
-github.com/ZaparooProject/go-pn532 v0.22.0/go.mod h1:NwYx5IE0zAU70ZikNpoPiOF5MUlDn3fD8xImpZixW1k=
+github.com/ZaparooProject/go-pn532 v0.22.1 h1:Dtuc+sXYZtuNZP+8/DQv68V1MOHUxRAOMVYsqvVFAfQ=
+github.com/ZaparooProject/go-pn532 v0.22.1/go.mod h1:NwYx5IE0zAU70ZikNpoPiOF5MUlDn3fD8xImpZixW1k=
 github.com/ZaparooProject/go-zapscript v0.7.2 h1:BCNwi+9JGjOoxWVq0G0+B/uDqVcZ7wHsdmrUjbOa+bE=
 github.com/ZaparooProject/go-zapscript v0.7.2/go.mod h1:P5qov6iCMzYiSF3tqr8BAanvNNh/YjPuUENfmPo6Yj4=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -118,17 +118,20 @@ func TestEnabled(t *testing.T) {
 
 func TestInitConfiguresSentryPrivacyOptions(t *testing.T) {
 	originalLogger := log.Logger
+	logDir := t.TempDir()
 	t.Cleanup(func() {
 		Close()
+		closeErr := corehelpers.CloseLogging()
 		log.Logger = originalLogger
 		enabled = false
 		sentryWriter = nil
 		closeOnce = sync.Once{}
 		sentry.CurrentHub().BindClient(nil)
+		require.NoError(t, closeErr)
 	})
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Settings").Return(platforms.Settings{LogDir: t.TempDir()})
+	mockPlatform.On("Settings").Return(platforms.Settings{LogDir: logDir})
 	require.NoError(t, corehelpers.InitLogging(mockPlatform, []io.Writer{io.Discard}))
 
 	require.NoError(t, Init(true, "device-id", "1.2.3", "linux"))

--- a/pkg/api/methods/media_control.go
+++ b/pkg/api/methods/media_control.go
@@ -67,7 +67,7 @@ func HandleMediaControl(env requests.RequestEnv) (any, error) { //nolint:gocriti
 		err = control.Func(env.Context, env.Config, platforms.ControlParams{Args: params.Args})
 	case control.Script != "":
 		exprEnv := zapscript.GetExprEnv(env.Platform, env.Config, env.State, nil, nil)
-		err = zapscript.RunControlScript(env.Platform, env.Config, env.Database, control.Script, &exprEnv)
+		err = zapscript.RunControlScript(env.Context, env.Platform, env.Config, env.Database, control.Script, &exprEnv)
 	default:
 		err = fmt.Errorf("control %q has no implementation", params.Action)
 	}

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -78,6 +78,36 @@ func TestHandleRunRestReturnsWhenServiceContextCancelled(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 }
 
+func TestHandleRunReturnsWhenRequestContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+	st, _ := state.NewState(platform, "test-boot-uuid")
+
+	env := requests.RequestEnv{
+		Context:    ctx,
+		State:      st,
+		TokenQueue: make(chan tokens.Token),
+		Params:     []byte(`"SNES/Super Metroid.sfc"`),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := HandleRun(env)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("run handler blocked on token queue after request cancellation")
+	}
+}
+
 func TestValidateAddMappingParams(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -34,12 +36,47 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHandleRunRestReturnsWhenServiceContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+	st, _ := state.NewState(platform, "test-boot-uuid")
+	st.StopService()
+
+	tokenQueue := make(chan tokens.Token)
+	router := chi.NewRouter()
+	router.Get("/run/*", HandleRunRest(cfg, st, tokenQueue))
+
+	req := httptest.NewRequestWithContext(
+		context.Background(), http.MethodGet, "/run/SNES/Super%20Metroid.sfc", http.NoBody,
+	)
+	req.RemoteAddr = "127.0.0.1:1234"
+	recorder := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		router.ServeHTTP(recorder, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("REST run handler blocked on token queue after service cancellation")
+	}
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+}
 
 func TestValidateAddMappingParams(t *testing.T) {
 	t.Parallel()

--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -115,7 +115,11 @@ func HandleRun(env requests.RequestEnv) (any, error) { //nolint:gocritic // sing
 
 	// TODO: how do we report back errors? put channel in queue
 	env.State.SetActiveCard(t)
-	env.TokenQueue <- t
+	select {
+	case env.TokenQueue <- t:
+	case <-env.Context.Done():
+		return nil, env.Context.Err()
+	}
 
 	return NoContent{}, nil
 }
@@ -159,7 +163,14 @@ func HandleRunRest(
 		}
 
 		st.SetActiveCard(t)
-		itq <- t
+		select {
+		case itq <- t:
+		case <-r.Context().Done():
+			return
+		case <-st.GetContext().Done():
+			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+			return
+		}
 	}
 }
 

--- a/pkg/api/middleware/lastseen.go
+++ b/pkg/api/middleware/lastseen.go
@@ -99,17 +99,20 @@ func (t *LastSeenTracker) Flush(ctx context.Context) {
 }
 
 // StartFlushLoop runs Flush periodically with a final flush on shutdown.
-// Pass zero interval for DefaultLastSeenFlushInterval.
-func (t *LastSeenTracker) StartFlushLoop(ctx context.Context, interval time.Duration) {
+// Pass zero interval for DefaultLastSeenFlushInterval. The returned channel is
+// closed after the final flush has completed.
+func (t *LastSeenTracker) StartFlushLoop(ctx context.Context, interval time.Duration) <-chan struct{} {
 	if interval <= 0 {
 		interval = DefaultLastSeenFlushInterval
 	}
+	done := make(chan struct{})
 	// G118: this goroutine intentionally falls back to a fresh background
 	// context for the shutdown flush. The flush is reacting to ctx being
 	// canceled, so reusing ctx would abort every UpdateClientLastSeen call
 	// before it touched the DB and silently drop the pending updates.
 	//nolint:gosec // G118: see comment above
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
@@ -122,4 +125,5 @@ func (t *LastSeenTracker) StartFlushLoop(ctx context.Context, interval time.Dura
 			}
 		}
 	}()
+	return done
 }

--- a/pkg/api/middleware/lastseen_test.go
+++ b/pkg/api/middleware/lastseen_test.go
@@ -126,6 +126,49 @@ func TestLastSeenTracker_StartFlushLoopFlushesOnShutdown(t *testing.T) {
 	db.AssertExpectations(t)
 }
 
+func TestLastSeenTracker_StartFlushLoopDoneWaitsForFinalFlush(t *testing.T) {
+	t.Parallel()
+
+	db := helpers.NewMockUserDBI()
+	tr := middleware.NewLastSeenTracker(db)
+
+	tr.Touch("token-a", 1700000100)
+
+	flushStarted := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	db.On("UpdateClientLastSeen", "token-a", int64(1700000100)).
+		Run(func(_ mock.Arguments) {
+			close(flushStarted)
+			<-releaseFlush
+		}).
+		Return(nil).Once()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := tr.StartFlushLoop(ctx, time.Hour)
+	cancel()
+
+	select {
+	case <-flushStarted:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown flush did not start within 1s")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("flush loop reported done before final flush completed")
+	default:
+	}
+
+	close(releaseFlush)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("flush loop did not finish after final flush completed")
+	}
+	db.AssertExpectations(t)
+}
+
 func TestLastSeenTracker_StartFlushLoopPeriodicFlush(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1297,7 +1297,36 @@ func Start(
 	mdnsHostname string,
 	player audio.Player,
 	indexPauser *syncutil.Pauser,
-) {
+) error {
+	return StartWithReady(
+		platform, cfg, st, inTokenQueue, confirmQueue, db, limitsManager,
+		notifBroker, mdnsHostname, player, indexPauser, nil,
+	)
+}
+
+// StartWithReady starts the API web server and reports bind success or failure
+// before blocking for shutdown. This lets service startup fail synchronously
+// when the configured API port is unavailable.
+func StartWithReady(
+	platform platforms.Platform,
+	cfg *config.Instance,
+	st *state.State,
+	inTokenQueue chan<- tokens.Token,
+	confirmQueue chan<- chan error,
+	db *database.Database,
+	limitsManager *playtime.LimitsManager,
+	notifBroker *broker.Broker,
+	mdnsHostname string,
+	player audio.Player,
+	indexPauser *syncutil.Pauser,
+	ready chan<- error,
+) error {
+	notifyReady := func(err error) {
+		if ready != nil {
+			ready <- err
+		}
+	}
+
 	// Extract port from listen address or use default
 	port := cfg.APIPort()
 	listenAddr := cfg.APIListen()
@@ -1411,7 +1440,10 @@ func Start(
 	// flushes to Clients.LastSeenAt every 30 seconds. A final flush runs
 	// on graceful shutdown via StartFlushLoop's ctx.Done() branch.
 	lastSeenTracker := apimiddleware.NewLastSeenTracker(db.UserDB)
-	lastSeenTracker.StartFlushLoop(st.GetContext(), apimiddleware.DefaultLastSeenFlushInterval)
+	lastSeenDone := lastSeenTracker.StartFlushLoop(st.GetContext(), apimiddleware.DefaultLastSeenFlushInterval)
+	defer func() {
+		<-lastSeenDone
+	}()
 
 	session := melody.New()
 	defer func() {
@@ -1611,33 +1643,34 @@ func Start(
 	}
 
 	serverDone := make(chan error, 1)
-	serverReady := make(chan struct{})
+
+	log.Info().Str("listen", cfg.APIListen()).Msg("starting HTTP server")
+	log.Debug().Msg("HTTP server attempting to bind")
+
+	// Create the listener before reporting startup success so callers can fail
+	// fast when the configured API port is already in use.
+	lc := &net.ListenConfig{}
+	listener, err := lc.Listen(st.GetContext(), "tcp", server.Addr)
+	if err != nil {
+		bindErr := fmt.Errorf("failed to bind API listener: %w", err)
+		log.Error().Err(bindErr).Msg("failed to bind to port")
+		notifyReady(bindErr)
+		st.StopService()
+		return bindErr
+	}
+
+	// If port 0 was requested, update config with the actual bound port
+	// so callers can discover which port the server is listening on.
+	if port == 0 {
+		if addr, ok := listener.Addr().(*net.TCPAddr); ok {
+			_ = cfg.SetAPIPort(addr.Port)
+		}
+	}
+
+	log.Debug().Msg("HTTP server bound to port, ready to accept connections")
+	notifyReady(nil)
 
 	go func() {
-		log.Info().Str("listen", cfg.APIListen()).Msg("starting HTTP server")
-		log.Debug().Msg("HTTP server goroutine started, attempting to bind")
-
-		// Create a listener to ensure we can bind to the port before continuing
-		lc := &net.ListenConfig{}
-		listener, err := lc.Listen(st.GetContext(), "tcp", server.Addr)
-		if err != nil {
-			log.Error().Err(err).Msg("failed to bind to port")
-			serverDone <- err
-			return
-		}
-
-		// If port 0 was requested, update config with the actual bound port
-		// so callers can discover which port the server is listening on.
-		if port == 0 {
-			if addr, ok := listener.Addr().(*net.TCPAddr); ok {
-				_ = cfg.SetAPIPort(addr.Port)
-			}
-		}
-
-		// Signal that server is ready to accept connections
-		log.Debug().Msg("HTTP server bound to port, ready to accept connections")
-		close(serverReady)
-
 		// Start serving
 		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error().Err(err).Msg("HTTP server error")
@@ -1648,19 +1681,7 @@ func Start(
 		}
 	}()
 
-	log.Debug().Msg("HTTP server goroutine launched, waiting for server to be ready")
-
-	// Wait for server to be ready or fail to start
-	select {
-	case <-serverReady:
-		log.Debug().Msg("HTTP server is ready to accept connections")
-	case err := <-serverDone:
-		if err != nil {
-			log.Error().Err(err).Msg("API server failed to start, stopping service")
-			st.StopService()
-			return
-		}
-	}
+	log.Debug().Msg("HTTP server goroutine launched")
 
 	select {
 	case <-st.GetContext().Done():
@@ -1669,9 +1690,9 @@ func Start(
 		if err != nil {
 			log.Error().Err(err).Msg("API server failed during operation, stopping service")
 			st.StopService()
-			return
+			return err
 		}
-		return
+		return nil
 	}
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -1679,7 +1700,9 @@ func Start(
 
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Error().Err(err).Msg("HTTP server shutdown error")
-	} else {
-		log.Info().Msg("HTTP server shutdown complete")
+		return fmt.Errorf("HTTP server shutdown error: %w", err)
 	}
+
+	log.Info().Msg("HTTP server shutdown complete")
+	return nil
 }

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -44,6 +45,40 @@ func newTestBroker(ctx context.Context, source <-chan models.Notification) *brok
 	b := broker.NewBroker(ctx, source)
 	b.Start()
 	return b
+}
+
+func TestStartWithReadyReportsBindFailure(t *testing.T) {
+	t.Parallel()
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, listener.Close()) }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+
+	fs := helpers.NewMemoryFS()
+	configDir := t.TempDir()
+	cfg, err := helpers.NewTestConfigWithPort(fs, configDir, tcpAddr.Port)
+	require.NoError(t, err)
+
+	st, notifCh := state.NewState(platform, "test-boot-uuid")
+	notifBroker := newTestBroker(st.GetContext(), notifCh)
+	db := &database.Database{
+		UserDB:  helpers.NewMockUserDBI(),
+		MediaDB: helpers.NewMockMediaDBI(),
+	}
+	tokenQueue := make(chan tokens.Token, 1)
+	ready := make(chan error, 1)
+
+	err = StartWithReady(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil, ready)
+	require.Error(t, err)
+	require.Error(t, <-ready)
+	assert.Contains(t, err.Error(), "bind")
+	assert.ErrorIs(t, st.GetContext().Err(), context.Canceled)
 }
 
 // TestServerStartupConcurrency validates that the API server properly synchronizes
@@ -85,7 +120,7 @@ func TestServerStartupConcurrency(t *testing.T) {
 			serverDone := make(chan struct{})
 			go func() {
 				defer close(serverDone)
-				Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+				_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 			}()
 			// Cleanup: stop service first, then wait for server goroutine to fully exit
 			defer func() {
@@ -154,7 +189,7 @@ func TestServerStartupImmediateConnection(t *testing.T) {
 	serverDone := make(chan struct{})
 	go func() {
 		defer close(serverDone)
-		Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 	// Cleanup: stop service first, then wait for server goroutine to fully exit
 	defer func() {
@@ -238,7 +273,7 @@ func TestServerListenContextCancellation(t *testing.T) {
 
 	go func() {
 		defer close(done)
-		Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 
 	// Wait for completion or timeout
@@ -529,7 +564,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	server1Done := make(chan struct{})
 	go func() {
 		defer close(server1Done)
-		Start(platform1, cfg1, st1, tokenQueue1, nil, db1, nil, notifBroker1, "", nil, nil)
+		_ = Start(platform1, cfg1, st1, tokenQueue1, nil, db1, nil, notifBroker1, "", nil, nil)
 	}()
 
 	// Wait for first server to be ready
@@ -572,7 +607,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	server2Done := make(chan struct{})
 	go func() {
 		defer close(server2Done)
-		Start(platform2, cfg2, st2, tokenQueue2, nil, db2, nil, notifBroker2, "", nil, nil)
+		_ = Start(platform2, cfg2, st2, tokenQueue2, nil, db2, nil, notifBroker2, "", nil, nil)
 	}()
 
 	// Wait for the second server's context to be cancelled (StopService called)
@@ -731,7 +766,7 @@ func TestSSE_ReceivesNotifications(t *testing.T) {
 	serverDone := make(chan struct{})
 	go func() {
 		defer close(serverDone)
-		Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 	defer func() {
 		st.StopService()

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -79,10 +79,10 @@ func TestStartWithReadyReportsBindFailure(t *testing.T) {
 	select {
 	case readyErr := <-ready:
 		require.Error(t, readyErr)
+		assert.Contains(t, readyErr.Error(), "bind")
 	case <-time.After(time.Second):
 		t.Fatal("StartWithReady returned an error without signaling ready")
 	}
-	assert.Contains(t, err.Error(), "bind")
 	assert.ErrorIs(t, st.GetContext().Err(), context.Canceled)
 }
 

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -123,15 +123,17 @@ func TestServerStartupConcurrency(t *testing.T) {
 
 			// Start server in a separate goroutine
 			serverDone := make(chan struct{})
+			serverErr := make(chan error, 1)
 			go func() {
 				defer close(serverDone)
-				_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+				serverErr <- Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 			}()
 			// Cleanup: stop service first, then wait for server goroutine to fully exit
 			defer func() {
 				st.StopService()
 				close(tokenQueue)
 				<-serverDone
+				require.NoError(t, <-serverErr)
 			}()
 
 			// Test that server becomes available and responds correctly
@@ -192,15 +194,17 @@ func TestServerStartupImmediateConnection(t *testing.T) {
 
 	// Start server in a separate goroutine
 	serverDone := make(chan struct{})
+	serverErr := make(chan error, 1)
 	go func() {
 		defer close(serverDone)
-		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		serverErr <- Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 	// Cleanup: stop service first, then wait for server goroutine to fully exit
 	defer func() {
 		st.StopService()
 		close(tokenQueue)
 		<-serverDone
+		require.NoError(t, <-serverErr)
 	}()
 
 	// Create connection attempt channel
@@ -270,20 +274,21 @@ func TestServerListenContextCancellation(t *testing.T) {
 	tokenQueue := make(chan tokens.Token, 1)
 	defer close(tokenQueue) // Safe here since context is already cancelled
 
-	// This should fail quickly because the context is already cancelled
-	// If net.Listen is used (not context-aware), it will succeed in binding
-	// If net.ListenConfig.Listen is used with context, it will fail fast
+	// This should return quickly because the context is already cancelled.
+	// If startup ignores the context, it would take longer or hang.
 	done := make(chan struct{})
+	serverErr := make(chan error, 1)
 	start := time.Now()
 
 	go func() {
 		defer close(done)
-		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		serverErr <- Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 
 	// Wait for completion or timeout
 	select {
 	case <-done:
+		require.NoError(t, <-serverErr)
 		elapsed := time.Since(start)
 		// With context cancellation, this should complete very quickly (< 100ms)
 		// Without context awareness, it would take longer or hang
@@ -567,9 +572,10 @@ func TestServerBindFailureStopsService(t *testing.T) {
 
 	// Start first server
 	server1Done := make(chan struct{})
+	server1Err := make(chan error, 1)
 	go func() {
 		defer close(server1Done)
-		_ = Start(platform1, cfg1, st1, tokenQueue1, nil, db1, nil, notifBroker1, "", nil, nil)
+		server1Err <- Start(platform1, cfg1, st1, tokenQueue1, nil, db1, nil, notifBroker1, "", nil, nil)
 	}()
 
 	// Wait for first server to be ready
@@ -610,9 +616,10 @@ func TestServerBindFailureStopsService(t *testing.T) {
 
 	// Start second server - it should fail to bind and call StopService
 	server2Done := make(chan struct{})
+	server2Err := make(chan error, 1)
 	go func() {
 		defer close(server2Done)
-		_ = Start(platform2, cfg2, st2, tokenQueue2, nil, db2, nil, notifBroker2, "", nil, nil)
+		server2Err <- Start(platform2, cfg2, st2, tokenQueue2, nil, db2, nil, notifBroker2, "", nil, nil)
 	}()
 
 	// Wait for the second server's context to be cancelled (StopService called)
@@ -630,7 +637,11 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	close(tokenQueue1)
 	close(tokenQueue2)
 	<-server1Done
+	require.NoError(t, <-server1Err)
 	<-server2Done
+	bindErr := <-server2Err
+	require.Error(t, bindErr)
+	assert.Contains(t, bindErr.Error(), "bind")
 }
 
 // TestBuildDynamicAllowedOrigins_HTTPURLWithoutPortAddsPortVariant is a regression
@@ -769,14 +780,16 @@ func TestSSE_ReceivesNotifications(t *testing.T) {
 	tokenQueue := make(chan tokens.Token, 1)
 
 	serverDone := make(chan struct{})
+	serverErr := make(chan error, 1)
 	go func() {
 		defer close(serverDone)
-		_ = Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
+		serverErr <- Start(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil)
 	}()
 	defer func() {
 		st.StopService()
 		close(tokenQueue)
 		<-serverDone
+		require.NoError(t, <-serverErr)
 	}()
 
 	// Wait for server to bind and update config with actual port

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -76,7 +76,12 @@ func TestStartWithReadyReportsBindFailure(t *testing.T) {
 
 	err = StartWithReady(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil, ready)
 	require.Error(t, err)
-	require.Error(t, <-ready)
+	select {
+	case readyErr := <-ready:
+		require.Error(t, readyErr)
+	case <-time.After(time.Second):
+		t.Fatal("StartWithReady returned an error without signaling ready")
+	}
 	assert.Contains(t, err.Error(), "bind")
 	assert.ErrorIs(t, st.GetContext().Err(), context.Canceled)
 }

--- a/pkg/config/configreaders.go
+++ b/pkg/config/configreaders.go
@@ -63,6 +63,26 @@ type ReadersConnect struct {
 	IDSource string `toml:"id_source,omitempty"`
 }
 
+// DriverInfo contains driver metadata needed for enabled/auto-detect checks.
+// This is a subset of reader metadata to avoid circular imports.
+type DriverInfo struct {
+	ID                string
+	DefaultEnabled    bool
+	DefaultAutoDetect bool
+}
+
+// ReaderEnableContext selects the reader usage path being evaluated.
+type ReaderEnableContext string
+
+const (
+	// ReaderEnableContextCandidate filters platform-supported reader instances.
+	ReaderEnableContextCandidate ReaderEnableContext = "candidate"
+	// ReaderEnableContextManualConnect evaluates a configured [[readers.connect]] entry.
+	ReaderEnableContextManualConnect ReaderEnableContext = "manual_connect"
+	// ReaderEnableContextAutoDetect evaluates whether a reader may probe for devices.
+	ReaderEnableContextAutoDetect ReaderEnableContext = "auto_detect"
+)
+
 // IsEnabled returns whether this connection is enabled.
 // nil (omitted) and true both mean enabled; only explicit false disables.
 func (r ReadersConnect) IsEnabled() bool {
@@ -241,11 +261,17 @@ func (c *Instance) SetReaderConnections(rcs []ReadersConnect) {
 	c.vals.Readers.Connect = rcs
 }
 
-func (c *Instance) IsDriverEnabled(driverID string, defaultEnabled bool) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+func (c *Instance) hasEnabledReaderConnectionLocked(driverID string) bool {
+	normalizedID := normalizeDriverID(driverID)
+	for _, conn := range c.vals.Readers.Connect {
+		if conn.IsEnabled() && normalizeDriverID(conn.Driver) == normalizedID {
+			return true
+		}
+	}
+	return false
+}
 
-	// Try normalized ID first, then fall back to original
+func (c *Instance) isDriverEnabledLocked(driverID string, defaultEnabled bool) bool {
 	normalizedID := normalizeDriverID(driverID)
 	for key, cfg := range c.vals.Readers.Drivers {
 		if normalizeDriverID(key) == normalizedID && cfg.Enabled != nil {
@@ -255,32 +281,7 @@ func (c *Instance) IsDriverEnabled(driverID string, defaultEnabled bool) bool {
 	return defaultEnabled
 }
 
-// DriverInfo contains driver metadata needed for enabled/auto-detect checks.
-// This is a subset of reader metadata to avoid circular imports.
-type DriverInfo struct {
-	ID                string
-	DefaultEnabled    bool
-	DefaultAutoDetect bool
-}
-
-// IsDriverEnabledForConnect checks if a driver should be enabled for a
-// user-defined [[readers.connect]] entry. Returns true unless explicitly disabled.
-// Having a connect entry implicitly enables the driver.
-func (c *Instance) IsDriverEnabledForConnect(driver DriverInfo) bool {
-	return c.IsDriverEnabled(driver.ID, true)
-}
-
-// IsDriverEnabledForAutoDetect checks if a driver should be enabled for
-// auto-detection. Uses the driver's DefaultEnabled if not explicitly configured.
-func (c *Instance) IsDriverEnabledForAutoDetect(driver DriverInfo) bool {
-	return c.IsDriverEnabled(driver.ID, driver.DefaultEnabled)
-}
-
-func (c *Instance) IsDriverAutoDetectEnabled(driverID string, defaultAutoDetect bool) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	// Try normalized ID first, then fall back to original
+func (c *Instance) isDriverAutoDetectEnabledLocked(driverID string, defaultAutoDetect bool) bool {
 	normalizedID := normalizeDriverID(driverID)
 	for key, cfg := range c.vals.Readers.Drivers {
 		if normalizeDriverID(key) == normalizedID && cfg.AutoDetect != nil {
@@ -289,6 +290,28 @@ func (c *Instance) IsDriverAutoDetectEnabled(driverID string, defaultAutoDetect 
 	}
 
 	return c.vals.Readers.AutoDetect && defaultAutoDetect
+}
+
+// IsReaderEnabled centralizes reader enablement rules across platform lists,
+// manual connections, and auto-detection.
+func (c *Instance) IsReaderEnabled(driver DriverInfo, context ReaderEnableContext) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	switch context {
+	case ReaderEnableContextCandidate:
+		if c.isDriverEnabledLocked(driver.ID, driver.DefaultEnabled) {
+			return true
+		}
+		return c.hasEnabledReaderConnectionLocked(driver.ID) && c.isDriverEnabledLocked(driver.ID, true)
+	case ReaderEnableContextManualConnect:
+		return c.isDriverEnabledLocked(driver.ID, true)
+	case ReaderEnableContextAutoDetect:
+		return c.isDriverEnabledLocked(driver.ID, driver.DefaultEnabled) &&
+			c.isDriverAutoDetectEnabledLocked(driver.ID, driver.DefaultAutoDetect)
+	default:
+		return false
+	}
 }
 
 func (c *Instance) ScanHistory() int {

--- a/pkg/config/configreaders_test.go
+++ b/pkg/config/configreaders_test.go
@@ -113,8 +113,8 @@ func TestIsReaderEnabled(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		driver  DriverInfo
 		context ReaderEnableContext
+		driver  DriverInfo
 		want    bool
 	}{
 		{

--- a/pkg/config/configreaders_test.go
+++ b/pkg/config/configreaders_test.go
@@ -82,230 +82,29 @@ func TestConnectionStringNormalization(t *testing.T) {
 	}
 }
 
-func TestIsDriverEnabledNormalization(t *testing.T) {
+func TestIsReaderEnabled(t *testing.T) {
 	t.Parallel()
 
-	// Create instance with old underscore format in config
-	cfg := &Instance{
-		vals: Values{
-			Readers: Readers{
-				Drivers: map[string]DriverConfig{
-					"simple_serial": {
-						Enabled: boolPtr(true),
-					},
-					"acr122_pcsc": {
-						Enabled: boolPtr(false),
-					},
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name           string
-		driverID       string
-		defaultEnabled bool
-		expected       bool
-	}{
-		{
-			name:           "lookup with new format finds old config",
-			driverID:       "simpleserial",
-			defaultEnabled: false,
-			expected:       true,
-		},
-		{
-			name:           "lookup with old format finds old config",
-			driverID:       "simple_serial",
-			defaultEnabled: false,
-			expected:       true,
-		},
-		{
-			name:           "disabled driver returns false",
-			driverID:       "acr122pcsc",
-			defaultEnabled: true,
-			expected:       false,
-		},
-		{
-			name:           "missing driver returns default",
-			driverID:       "pn532uart",
-			defaultEnabled: true,
-			expected:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := cfg.IsDriverEnabled(tt.driverID, tt.defaultEnabled)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-// TestIsDriverEnabledForConnect tests the behavior when a driver has a
-// [[readers.connect]] entry. The driver is implicitly enabled unless
-// explicitly disabled in config.
-func TestIsDriverEnabledForConnect(t *testing.T) {
-	t.Parallel()
-
-	cfg := &Instance{
-		vals: Values{
-			Readers: Readers{
-				Drivers: map[string]DriverConfig{
-					"externaldrive": {
-						Enabled: boolPtr(false), // explicitly disabled
-					},
-					"simpleserial": {
-						Enabled: boolPtr(true), // explicitly enabled
-					},
-					// pn532 has no config - not explicitly set (nil)
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name     string
-		driver   DriverInfo
-		expected bool
-	}{
-		{
-			name: "explicitly disabled driver is blocked",
-			driver: DriverInfo{
-				ID:             "externaldrive",
-				DefaultEnabled: false, // matches real externaldrive
-			},
-			expected: false,
-		},
-		{
-			name: "explicitly enabled driver is allowed",
-			driver: DriverInfo{
-				ID:             "simpleserial",
-				DefaultEnabled: true,
-			},
-			expected: true,
-		},
-		{
-			name: "driver with no config is implicitly enabled",
-			driver: DriverInfo{
-				ID:             "pn532",
-				DefaultEnabled: true,
-			},
-			expected: true,
-		},
-		{
-			name: "driver with DefaultEnabled=false but no config is still enabled for connect",
-			driver: DriverInfo{
-				ID:             "newdriver",
-				DefaultEnabled: false, // would be disabled for auto-detect
-			},
-			expected: true, // but enabled for connect entries
-		},
-		{
-			name: "normalized ID matches explicit disable",
-			driver: DriverInfo{
-				ID:             "external_drive",
-				DefaultEnabled: false,
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := cfg.IsDriverEnabledForConnect(tt.driver)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-// TestIsDriverEnabledForAutoDetect tests the behavior for auto-detection.
-// The driver's DefaultEnabled is used when not explicitly configured.
-func TestIsDriverEnabledForAutoDetect(t *testing.T) {
-	t.Parallel()
-
-	cfg := &Instance{
-		vals: Values{
-			Readers: Readers{
-				Drivers: map[string]DriverConfig{
-					"externaldrive": {
-						Enabled: boolPtr(true), // explicitly enabled (overrides default)
-					},
-					"simpleserial": {
-						Enabled: boolPtr(false), // explicitly disabled
-					},
-					// pn532 has no config - uses DefaultEnabled
-				},
-			},
-		},
-	}
-
-	tests := []struct {
-		name     string
-		driver   DriverInfo
-		expected bool
-	}{
-		{
-			name: "explicitly enabled overrides DefaultEnabled=false",
-			driver: DriverInfo{
-				ID:             "externaldrive",
-				DefaultEnabled: false,
-			},
-			expected: true,
-		},
-		{
-			name: "explicitly disabled overrides DefaultEnabled=true",
-			driver: DriverInfo{
-				ID:             "simpleserial",
-				DefaultEnabled: true,
-			},
-			expected: false,
-		},
-		{
-			name: "no config with DefaultEnabled=true is enabled",
-			driver: DriverInfo{
-				ID:             "pn532",
-				DefaultEnabled: true,
-			},
-			expected: true,
-		},
-		{
-			name: "no config with DefaultEnabled=false is disabled",
-			driver: DriverInfo{
-				ID:             "newdriver",
-				DefaultEnabled: false,
-			},
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := cfg.IsDriverEnabledForAutoDetect(tt.driver)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestIsDriverAutoDetectEnabledNormalization(t *testing.T) {
-	t.Parallel()
-
-	// Create instance with old underscore format in config
+	falseValue := false
 	cfg := &Instance{
 		vals: Values{
 			Readers: Readers{
 				AutoDetect: true,
+				Connect: []ReadersConnect{
+					{Driver: "newdriver"},
+					{Driver: "externaldrive"},
+					{Driver: "disabledconn", Enabled: &falseValue},
+				},
 				Drivers: map[string]DriverConfig{
-					"simple_serial": {
-						AutoDetect: boolPtr(false),
+					"externaldrive": {
+						Enabled: boolPtr(false),
 					},
-					"acr122_pcsc": {
-						AutoDetect: boolPtr(true),
+					"simple_serial": {
+						Enabled: boolPtr(true),
+					},
+					"auto_off": {
+						Enabled:    boolPtr(true),
+						AutoDetect: boolPtr(false),
 					},
 				},
 			},
@@ -313,34 +112,122 @@ func TestIsDriverAutoDetectEnabledNormalization(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		driverID          string
-		defaultAutoDetect bool
-		expected          bool
+		name    string
+		driver  DriverInfo
+		context ReaderEnableContext
+		want    bool
 	}{
 		{
-			name:              "lookup with new format finds old config",
-			driverID:          "simpleserial",
-			defaultAutoDetect: true,
-			expected:          false,
+			name: "candidate includes default enabled driver",
+			driver: DriverInfo{
+				ID:             "pn532",
+				DefaultEnabled: true,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    true,
 		},
 		{
-			name:              "lookup with old format finds old config",
-			driverID:          "simple_serial",
-			defaultAutoDetect: true,
-			expected:          false,
+			name: "candidate normalizes driver config keys",
+			driver: DriverInfo{
+				ID:             "simpleserial",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    true,
 		},
 		{
-			name:              "enabled driver returns true",
-			driverID:          "acr122pcsc",
-			defaultAutoDetect: false,
-			expected:          true,
+			name: "candidate skips default disabled driver without connect entry",
+			driver: DriverInfo{
+				ID:             "unuseddriver",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    false,
 		},
 		{
-			name:              "missing driver returns global auto detect",
-			driverID:          "pn532uart",
-			defaultAutoDetect: true,
-			expected:          true,
+			name: "candidate includes default disabled driver with connect entry",
+			driver: DriverInfo{
+				ID:             "newdriver",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    true,
+		},
+		{
+			name: "candidate skips disabled connect entry",
+			driver: DriverInfo{
+				ID:             "disabledconn",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    false,
+		},
+		{
+			name: "candidate respects explicit disable even with connect entry",
+			driver: DriverInfo{
+				ID:             "external_drive",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextCandidate,
+			want:    false,
+		},
+		{
+			name: "manual connect allows default disabled driver",
+			driver: DriverInfo{
+				ID:             "newdriver",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextManualConnect,
+			want:    true,
+		},
+		{
+			name: "manual connect respects explicit disable",
+			driver: DriverInfo{
+				ID:             "externaldrive",
+				DefaultEnabled: false,
+			},
+			context: ReaderEnableContextManualConnect,
+			want:    false,
+		},
+		{
+			name: "auto-detect includes default enabled driver",
+			driver: DriverInfo{
+				ID:                "pn532",
+				DefaultEnabled:    true,
+				DefaultAutoDetect: true,
+			},
+			context: ReaderEnableContextAutoDetect,
+			want:    true,
+		},
+		{
+			name: "auto-detect ignores manual connect enablement",
+			driver: DriverInfo{
+				ID:                "newdriver",
+				DefaultEnabled:    false,
+				DefaultAutoDetect: true,
+			},
+			context: ReaderEnableContextAutoDetect,
+			want:    false,
+		},
+		{
+			name: "auto-detect respects explicit driver enable",
+			driver: DriverInfo{
+				ID:                "simpleserial",
+				DefaultEnabled:    false,
+				DefaultAutoDetect: true,
+			},
+			context: ReaderEnableContextAutoDetect,
+			want:    true,
+		},
+		{
+			name: "auto-detect respects explicit auto-detect disable",
+			driver: DriverInfo{
+				ID:                "autooff",
+				DefaultEnabled:    true,
+				DefaultAutoDetect: true,
+			},
+			context: ReaderEnableContextAutoDetect,
+			want:    false,
 		},
 	}
 
@@ -348,8 +235,8 @@ func TestIsDriverAutoDetectEnabledNormalization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := cfg.IsDriverAutoDetectEnabled(tt.driverID, tt.defaultAutoDetect)
-			assert.Equal(t, tt.expected, result)
+			result := cfg.IsReaderEnabled(tt.driver, tt.context)
+			assert.Equal(t, tt.want, result)
 		})
 	}
 }

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -328,10 +328,11 @@ func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testi
 
 	mockDB := helpers.NewMockMediaDBI()
 	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
 	scanState := &database.ScanState{
 		SystemIDs:     map[string]int{"NES": 1},
 		TitleIDs:      map[string]int{"NES:supermariobrothers": 10},
-		MediaIDs:      map[string]int{database.MediaKey("NES", path): 20},
+		MediaIDs:      map[string]int{database.MediaKey("NES", pathKey): 20},
 		MediaTitleIDs: map[int]int{20: 10},
 		MediaTagIDs:   map[int]map[int]struct{}{20: {8: {}}},
 		TagTypeIDs:    map[string]int{string(tags.TagTypeExtension): 7},
@@ -356,10 +357,11 @@ func TestAddMediaPath_ExistingMediaWithoutTagStateDoesNotDeleteAllTags(t *testin
 
 	mockDB := helpers.NewMockMediaDBI()
 	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
 	scanState := &database.ScanState{
 		SystemIDs:     map[string]int{"NES": 1},
 		TitleIDs:      map[string]int{"NES:supermariobrothers": 10},
-		MediaIDs:      map[string]int{database.MediaKey("NES", path): 20},
+		MediaIDs:      map[string]int{database.MediaKey("NES", pathKey): 20},
 		MediaTitleIDs: map[int]int{20: 10},
 		MediaTagIDs:   nil,
 		TagTypeIDs:    map[string]int{string(tags.TagTypeExtension): 7},
@@ -384,10 +386,11 @@ func TestAddMediaPath_ReconcileExistingMediaTagsDoesNotMutateStateOnInsertFailur
 
 	mockDB := helpers.NewMockMediaDBI()
 	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
 	scanState := &database.ScanState{
 		SystemIDs:     map[string]int{"NES": 1},
 		TitleIDs:      map[string]int{"NES:supermariobrothers": 10},
-		MediaIDs:      map[string]int{database.MediaKey("NES", path): 20},
+		MediaIDs:      map[string]int{database.MediaKey("NES", pathKey): 20},
 		MediaTitleIDs: map[int]int{20: 10},
 		MediaTagIDs:   map[int]map[int]struct{}{20: {}},
 		TagTypeIDs:    map[string]int{string(tags.TagTypeExtension): 7},

--- a/pkg/groovyproxy/server.go
+++ b/pkg/groovyproxy/server.go
@@ -134,12 +134,15 @@ func Start(
 			default:
 				buf := make([]byte, 1024)
 				rlen, _, readErr := coreConn.ReadFrom(buf)
-				if rlen > 0 && readErr != nil {
+				if errors.Is(readErr, net.ErrClosed) {
+					return
+				}
+				if readErr != nil {
 					log.Warn().Err(readErr).Msg("error reading GMC command packet from Groovy core")
 					continue
 				}
-				if errors.Is(readErr, net.ErrClosed) {
-					return
+				if rlen == 0 {
+					continue
 				}
 				select {
 				case gmcChan <- buf[:rlen]:
@@ -150,7 +153,21 @@ func Start(
 		}
 	}()
 
-	freq, _ := time.ParseDuration(beaconInterval)
+	freq, parseErr := time.ParseDuration(beaconInterval)
+	if parseErr != nil || freq <= 0 {
+		log.Warn().
+			Err(parseErr).
+			Str("interval", beaconInterval).
+			Msg("invalid GMC proxy beacon interval, using default")
+		freq, parseErr = time.ParseDuration(config.DefaultGmcProxyBeaconInterval)
+		if parseErr != nil || freq <= 0 {
+			log.Error().
+				Err(parseErr).
+				Str("interval", config.DefaultGmcProxyBeaconInterval).
+				Msg("invalid default GMC proxy beacon interval, aborting GMC Proxy")
+			return
+		}
+	}
 	beaconTicker = time.NewTicker(freq)
 	for {
 		select {
@@ -171,7 +188,7 @@ func Start(
 			log.Debug().Msg("Receieved GMC Load Event")
 			// **local: can prefix any valid Zapscript to run locally without proxy
 			switch {
-			case bytes.Equal(gmcBytes[:10], []byte("zapscript:")):
+			case bytes.HasPrefix(gmcBytes, []byte("zapscript:")):
 				log.Debug().Msg("GMC Execute is Zapscript Format, running as Token")
 				text := string(gmcBytes[10:])
 				t := tokens.Token{
@@ -191,7 +208,7 @@ func Start(
 					log.Warn().Err(writeErr).Msg("error forwarding GMC from Groovy core to proxy")
 				}
 			default:
-				log.Warn().Err(err).Msg("error forwarding GMC from Groovy core to proxy")
+				log.Warn().Int("packet_length", len(gmcBytes)).Msg("no GMC proxy address available, skipping forward")
 			}
 		case <-ctx.Done():
 			log.Debug().Msg("Closing GMC Proxy via context cancellation")

--- a/pkg/groovyproxy/server.go
+++ b/pkg/groovyproxy/server.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -51,10 +52,28 @@ func Start(
 	coreConn, err := lc.ListenPacket(ctx, "udp4", ":0")
 	if err != nil {
 		log.Error().Err(err).Msg("error creating GMC Groovy Core listener socket, aborting GMC Proxy")
+		return
 	}
+	var proxyConn net.PacketConn
+	var readerWG sync.WaitGroup
+	var beaconTicker *time.Ticker
+	defer func() {
+		if beaconTicker != nil {
+			beaconTicker.Stop()
+		}
+		if closeErr := coreConn.Close(); closeErr != nil {
+			log.Error().Err(closeErr).Msg("error closing core connection")
+		}
+		if proxyConn != nil {
+			if closeErr := proxyConn.Close(); closeErr != nil {
+				log.Error().Err(closeErr).Msg("error closing proxy connection")
+			}
+		}
+		readerWG.Wait()
+	}()
 
 	// Allow external GMC command runners to beacon to this proxy for forwarding
-	proxyConn, err := lc.ListenPacket(ctx, "udp4", fmt.Sprintf(":%v", proxyGMCPort))
+	proxyConn, err = lc.ListenPacket(ctx, "udp4", fmt.Sprintf(":%v", proxyGMCPort))
 	if err != nil {
 		log.Error().Err(err).Msg("error creating GMC Proxy listener socket, aborting GMC Proxy")
 		return
@@ -71,7 +90,9 @@ func Start(
 	var proxyAddr *net.Addr
 	proxyAddrChan := make(chan net.Addr)
 	// Listen for Proxy Server Beacons to get proxyAddr for forwarding
+	readerWG.Add(1)
 	go func() {
+		defer readerWG.Done()
 		defer close(proxyAddrChan)
 		for {
 			select {
@@ -87,14 +108,20 @@ func Start(
 				if errors.Is(readErr, net.ErrClosed) {
 					return
 				}
-				proxyAddrChan <- addr
+				select {
+				case proxyAddrChan <- addr:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()
 
 	// Listen for Core GMC commands
 	gmcChan := make(chan []byte)
+	readerWG.Add(1)
 	go func() {
+		defer readerWG.Done()
 		defer close(gmcChan)
 		for {
 			select {
@@ -110,13 +137,17 @@ func Start(
 				if errors.Is(readErr, net.ErrClosed) {
 					return
 				}
-				gmcChan <- buf[:rlen]
+				select {
+				case gmcChan <- buf[:rlen]:
+				case <-ctx.Done():
+					return
+				}
 			}
 		}
 	}()
 
 	freq, _ := time.ParseDuration(beaconInterval)
-	beaconTicker := time.NewTicker(freq)
+	beaconTicker = time.NewTicker(freq)
 	for {
 		select {
 		case <-beaconTicker.C:
@@ -124,9 +155,15 @@ func Start(
 			if writeErr != nil {
 				log.Warn().Err(writeErr).Msg("error sending GMC beacon to Groovy core")
 			}
-		case addr := <-proxyAddrChan:
+		case addr, ok := <-proxyAddrChan:
+			if !ok {
+				return
+			}
 			proxyAddr = &addr
-		case gmcBytes := <-gmcChan:
+		case gmcBytes, ok := <-gmcChan:
+			if !ok {
+				return
+			}
 			log.Debug().Msg("Receieved GMC Load Event")
 			// **local: can prefix any valid Zapscript to run locally without proxy
 			switch {
@@ -139,7 +176,11 @@ func Start(
 					Source:   tokens.SourceGMC,
 				}
 				st.SetActiveCard(t)
-				itq <- t
+				select {
+				case itq <- t:
+				case <-ctx.Done():
+					return
+				}
 			case proxyAddr != nil:
 				_, writeErr := proxyConn.WriteTo(gmcBytes, *proxyAddr)
 				if writeErr != nil {
@@ -150,13 +191,7 @@ func Start(
 			}
 		case <-ctx.Done():
 			log.Debug().Msg("Closing GMC Proxy via context cancellation")
-			beaconTicker.Stop()
-			if err := coreConn.Close(); err != nil {
-				log.Error().Err(err).Msg("error closing core connection")
-			}
-			if err := proxyConn.Close(); err != nil {
-				log.Error().Err(err).Msg("error closing proxy connection")
-			}
+			return
 		}
 	}
 }

--- a/pkg/groovyproxy/server.go
+++ b/pkg/groovyproxy/server.go
@@ -101,12 +101,16 @@ func Start(
 			default:
 				buf := make([]byte, 1024)
 				_, addr, readErr := proxyConn.ReadFrom(buf)
-				if addr == nil || readErr != nil {
+				if errors.Is(readErr, net.ErrClosed) {
+					return
+				}
+				if readErr != nil {
 					log.Warn().Err(readErr).Msg("error reading GMC proxy beacon")
 					continue
 				}
-				if errors.Is(readErr, net.ErrClosed) {
-					return
+				if addr == nil {
+					log.Warn().Msg("GMC proxy beacon missing source address")
+					continue
 				}
 				select {
 				case proxyAddrChan <- addr:

--- a/pkg/groovyproxy/server_test.go
+++ b/pkg/groovyproxy/server_test.go
@@ -20,6 +20,7 @@
 package groovyproxy
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -33,7 +34,8 @@ import (
 )
 
 func TestStartAcceptsZapscriptFromGroovyCore(t *testing.T) {
-	coreConn, err := net.ListenPacket("udp4", "127.0.0.1:32105")
+	lc := net.ListenConfig{}
+	coreConn, err := lc.ListenPacket(context.Background(), "udp4", "127.0.0.1:32105")
 	if err != nil {
 		t.Skipf("Groovy Core GMC port unavailable: %v", err)
 	}

--- a/pkg/groovyproxy/server_test.go
+++ b/pkg/groovyproxy/server_test.go
@@ -1,0 +1,83 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package groovyproxy
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartAcceptsZapscriptFromGroovyCore(t *testing.T) {
+	coreConn, err := net.ListenPacket("udp4", "127.0.0.1:32105")
+	if err != nil {
+		t.Skipf("Groovy Core GMC port unavailable: %v", err)
+	}
+	defer func() { _ = coreConn.Close() }()
+
+	proxyPort := 0
+	beaconInterval := "10ms"
+	defaults := config.BaseDefaults
+	defaults.Groovy.GmcProxyPort = &proxyPort
+	defaults.Groovy.GmcProxyBeaconInterval = &beaconInterval
+	cfg, err := config.NewConfig(t.TempDir(), defaults)
+	require.NoError(t, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	itq := make(chan tokens.Token, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Start(cfg, st, itq)
+	}()
+	t.Cleanup(func() {
+		st.StopService()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Error("GMC proxy did not stop after context cancellation")
+		}
+	})
+
+	buf := make([]byte, 1)
+	require.NoError(t, coreConn.SetReadDeadline(time.Now().Add(time.Second)))
+	_, coreProxyAddr, err := coreConn.ReadFrom(buf)
+	require.NoError(t, err)
+
+	_, err = coreConn.WriteTo([]byte("zapscript:**input.keyboard:{f2}"), coreProxyAddr)
+	require.NoError(t, err)
+
+	select {
+	case token := <-itq:
+		assert.Equal(t, "**input.keyboard:{f2}", token.Text)
+		assert.Equal(t, tokens.SourceGMC, token.Source)
+		assert.False(t, token.ScanTime.IsZero())
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for GMC zapscript token")
+	}
+}

--- a/pkg/groovyproxy/server_test.go
+++ b/pkg/groovyproxy/server_test.go
@@ -51,7 +51,7 @@ func TestStartAcceptsZapscriptFromGroovyCore(t *testing.T) {
 
 	mockPlatform := mocks.NewMockPlatform()
 	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
-	itq := make(chan tokens.Token, 1)
+	itq := make(chan tokens.Token)
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
@@ -81,5 +81,46 @@ func TestStartAcceptsZapscriptFromGroovyCore(t *testing.T) {
 		assert.False(t, token.ScanTime.IsZero())
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for GMC zapscript token")
+	}
+}
+
+func TestStartStopsWhenZapscriptTokenSendBlocked(t *testing.T) {
+	lc := net.ListenConfig{}
+	coreConn, err := lc.ListenPacket(context.Background(), "udp4", "127.0.0.1:32105")
+	if err != nil {
+		t.Skipf("Groovy Core GMC port unavailable: %v", err)
+	}
+	defer func() { _ = coreConn.Close() }()
+
+	proxyPort := 0
+	beaconInterval := "10ms"
+	defaults := config.BaseDefaults
+	defaults.Groovy.GmcProxyPort = &proxyPort
+	defaults.Groovy.GmcProxyBeaconInterval = &beaconInterval
+	cfg, err := config.NewConfig(t.TempDir(), defaults)
+	require.NoError(t, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	itq := make(chan tokens.Token)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Start(cfg, st, itq)
+	}()
+
+	buf := make([]byte, 1)
+	require.NoError(t, coreConn.SetReadDeadline(time.Now().Add(time.Second)))
+	_, coreProxyAddr, err := coreConn.ReadFrom(buf)
+	require.NoError(t, err)
+
+	_, err = coreConn.WriteTo([]byte("zapscript:**input.keyboard:{f2}"), coreProxyAddr)
+	require.NoError(t, err)
+
+	st.StopService()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("GMC proxy did not stop while zapscript token send was blocked")
 	}
 }

--- a/pkg/helpers/logging.go
+++ b/pkg/helpers/logging.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -52,6 +53,7 @@ func EnsureDirectories(pl platforms.Platform) error {
 }
 
 var (
+	logMu         syncutil.RWMutex
 	logFileWriter *lumberjack.Logger
 	logWriter     io.Writer
 )
@@ -60,6 +62,9 @@ func InitLogging(pl platforms.Platform, writers []io.Writer) error {
 	if err := CloseLogging(); err != nil {
 		return fmt.Errorf("failed to close previous log file: %w", err)
 	}
+
+	logMu.Lock()
+	defer logMu.Unlock()
 
 	logFileWriter = &lumberjack.Logger{
 		Filename:   filepath.Join(pl.Settings().LogDir, config.LogFile),
@@ -83,12 +88,18 @@ func InitLogging(pl platforms.Platform, writers []io.Writer) error {
 // LogWriter returns the underlying io.Writer used by the logger.
 // This is useful for adding additional writers (e.g., telemetry) after initialization.
 func LogWriter() io.Writer {
+	logMu.RLock()
+	defer logMu.RUnlock()
+
 	return logWriter
 }
 
 // CloseLogging closes the active file logger so tests and shutdown paths can
 // safely remove the log directory on Windows.
 func CloseLogging() error {
+	logMu.Lock()
+	defer logMu.Unlock()
+
 	if logFileWriter == nil {
 		return nil
 	}

--- a/pkg/helpers/logging.go
+++ b/pkg/helpers/logging.go
@@ -96,5 +96,8 @@ func CloseLogging() error {
 	err := logFileWriter.Close()
 	logFileWriter = nil
 	logWriter = nil
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to close log file writer: %w", err)
+	}
+	return nil
 }

--- a/pkg/helpers/logging.go
+++ b/pkg/helpers/logging.go
@@ -51,14 +51,22 @@ func EnsureDirectories(pl platforms.Platform) error {
 	return nil
 }
 
-var logWriter io.Writer
+var (
+	logFileWriter *lumberjack.Logger
+	logWriter     io.Writer
+)
 
 func InitLogging(pl platforms.Platform, writers []io.Writer) error {
-	logWriters := []io.Writer{&lumberjack.Logger{
+	if err := CloseLogging(); err != nil {
+		return fmt.Errorf("failed to close previous log file: %w", err)
+	}
+
+	logFileWriter = &lumberjack.Logger{
 		Filename:   filepath.Join(pl.Settings().LogDir, config.LogFile),
 		MaxSize:    1,
 		MaxBackups: 2,
-	}}
+	}
+	logWriters := []io.Writer{logFileWriter}
 
 	if len(writers) > 0 {
 		logWriters = append(logWriters, writers...)
@@ -76,4 +84,17 @@ func InitLogging(pl platforms.Platform, writers []io.Writer) error {
 // This is useful for adding additional writers (e.g., telemetry) after initialization.
 func LogWriter() io.Writer {
 	return logWriter
+}
+
+// CloseLogging closes the active file logger so tests and shutdown paths can
+// safely remove the log directory on Windows.
+func CloseLogging() error {
+	if logFileWriter == nil {
+		return nil
+	}
+
+	err := logFileWriter.Close()
+	logFileWriter = nil
+	logWriter = nil
+	return err
 }

--- a/pkg/helpers/logging_test.go
+++ b/pkg/helpers/logging_test.go
@@ -26,8 +26,10 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -205,6 +207,34 @@ type testWriter struct{}
 
 func (*testWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
+}
+
+func TestCloseLoggingReleasesLogFile(t *testing.T) {
+	// Note: Cannot use t.Parallel() because InitLogging modifies global log.Logger
+	originalLogger := log.Logger
+	t.Cleanup(func() {
+		_ = CloseLogging()
+		log.Logger = originalLogger
+	})
+
+	testRoot := t.TempDir()
+	logDir := filepath.Join(testRoot, "logs")
+	platform := mocks.NewMockPlatform()
+	platform.On("Settings").Return(platforms.Settings{
+		TempDir: filepath.Join(testRoot, "temp"),
+		LogDir:  logDir,
+	})
+
+	require.NoError(t, EnsureDirectories(platform))
+	require.NoError(t, InitLogging(platform, nil))
+
+	log.Info().Msg("open log file for close test")
+	require.FileExists(t, filepath.Join(logDir, config.LogFile))
+	require.NoError(t, CloseLogging())
+
+	require.NoError(t, os.RemoveAll(logDir))
+	_, err := os.Stat(logDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestInitLoggingIntegration(t *testing.T) {

--- a/pkg/helpers/logging_test.go
+++ b/pkg/helpers/logging_test.go
@@ -213,7 +213,9 @@ func TestCloseLoggingReleasesLogFile(t *testing.T) {
 	// Note: Cannot use t.Parallel() because InitLogging modifies global log.Logger
 	originalLogger := log.Logger
 	t.Cleanup(func() {
-		_ = CloseLogging()
+		if err := CloseLogging(); err != nil {
+			t.Errorf("CloseLogging failed: %v", err)
+		}
 		log.Logger = originalLogger
 	})
 

--- a/pkg/helpers/utils.go
+++ b/pkg/helpers/utils.go
@@ -143,10 +143,18 @@ func AlphaMapKeys[V any](m map[string]V) []string {
 }
 
 func WaitForInternet(maxTries int) bool {
-	for range maxTries {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	return WaitForInternetContext(context.Background(), maxTries)
+}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com", http.NoBody)
+func WaitForInternetContext(ctx context.Context, maxTries int) bool {
+	for range maxTries {
+		if ctx.Err() != nil {
+			return false
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, "https://api.github.com", http.NoBody)
 		if err != nil {
 			cancel()
 			continue
@@ -160,7 +168,11 @@ func WaitForInternet(maxTries int) bool {
 			}
 			return true
 		}
-		time.Sleep(1 * time.Second)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(1 * time.Second):
+		}
 	}
 	return false
 }

--- a/pkg/helpers/utils_test.go
+++ b/pkg/helpers/utils_test.go
@@ -20,6 +20,7 @@
 package helpers
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"sort"
@@ -33,6 +34,25 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWaitForInternetContextReturnsWhenCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- WaitForInternetContext(ctx, 1)
+	}()
+
+	select {
+	case got := <-done:
+		assert.False(t, got)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("WaitForInternetContext blocked after context cancellation")
+	}
+}
 
 func TestTokensEqual(t *testing.T) {
 	t.Parallel()

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -88,7 +88,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -85,7 +85,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/linux/installer/conf/zaparoo.service
+++ b/pkg/platforms/linux/installer/conf/zaparoo.service
@@ -8,6 +8,8 @@ Type=simple
 ExecStart={{.ExecPath}} -daemon
 Restart=on-failure
 RestartSec=5s
+TimeoutStopSec=15s
+KillMode=control-group
 
 # Logging
 StandardOutput=journal

--- a/pkg/platforms/linux/installer/install_test.go
+++ b/pkg/platforms/linux/installer/install_test.go
@@ -204,6 +204,17 @@ func TestInstallService(t *testing.T) {
 				servicePath := filepath.Join(xdg.ConfigHome, "systemd", "user", "zaparoo.service")
 				_, err := os.Stat(servicePath)
 				require.NoError(t, err, "service file should be installed")
+
+				content, readErr := os.ReadFile(servicePath) //nolint:gosec // reads installed test fixture
+				require.NoError(t, readErr, "should be able to read service file")
+				execPath, execErr := os.Executable()
+				require.NoError(t, execErr)
+				execPath, execErr = filepath.EvalSymlinks(execPath)
+				require.NoError(t, execErr)
+				assert.Contains(t, string(content), "Type=simple")
+				assert.Contains(t, string(content), "ExecStart="+execPath+" -daemon")
+				assert.Contains(t, string(content), "TimeoutStopSec=15s")
+				assert.Contains(t, string(content), "KillMode=control-group")
 			}
 
 			cmd.AssertExpectations(t)

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -60,7 +60,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -137,7 +137,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -77,7 +77,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -123,6 +123,7 @@ type Control struct {
 // command. Every command run has access to and can modify it.
 type CmdEnv struct {
 	LauncherCtx   context.Context
+	ServiceCtx    context.Context
 	Playlist      playlists.PlaylistController
 	Cfg           *config.Instance
 	Database      *database.Database

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -122,7 +122,10 @@ type Control struct {
 // CmdEnv is the local state of a scanned token, as it processes each ZapScript
 // command. Every command run has access to and can modify it.
 type CmdEnv struct {
-	LauncherCtx   context.Context
+	// LauncherCtx is canceled when a new launcher starts and replaces the current one.
+	LauncherCtx context.Context
+	// ServiceCtx is canceled during full service shutdown or process stop. Use it
+	// for work tied to service lifetime rather than the current launcher lifetime.
 	ServiceCtx    context.Context
 	Playlist      playlists.PlaylistController
 	Cfg           *config.Instance

--- a/pkg/platforms/recalbox/platform.go
+++ b/pkg/platforms/recalbox/platform.go
@@ -83,7 +83,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/retropie/platform.go
+++ b/pkg/platforms/retropie/platform.go
@@ -83,7 +83,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/shared/linuxbase/readers.go
+++ b/pkg/platforms/shared/linuxbase/readers.go
@@ -57,7 +57,12 @@ func SupportedReaders(cfg *config.Instance, p platforms.Platform) []readers.Read
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/platforms/shared/linuxbase/readers_test.go
+++ b/pkg/platforms/shared/linuxbase/readers_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
@@ -109,4 +110,30 @@ func TestSupportedReadersReturnsUniqueReaders(t *testing.T) {
 			"reader ID %q should not appear more than once", id)
 		seenIDs[id] = true
 	}
+}
+
+func TestSupportedReadersIncludesConfiguredDefaultDisabledReader(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+
+	fsHelper := helpers.NewOSFS()
+	cfg, err := helpers.NewTestConfig(fsHelper, configDir)
+	require.NoError(t, err)
+	cfg.SetReaderConnections([]config.ReadersConnect{{Driver: "externaldrive"}})
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+
+	supportedReaders := SupportedReaders(cfg, mockPlatform)
+
+	var found bool
+	for _, reader := range supportedReaders {
+		if reader.Metadata().ID == "externaldrive" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "configured readers should be available even when disabled by default")
 }

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -95,7 +95,12 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 	var enabled []readers.Reader
 	for _, r := range allReaders {
 		metadata := r.Metadata()
-		if cfg.IsDriverEnabled(metadata.ID, metadata.DefaultEnabled) {
+		driver := config.DriverInfo{
+			ID:                metadata.ID,
+			DefaultEnabled:    metadata.DefaultEnabled,
+			DefaultAutoDetect: metadata.DefaultAutoDetect,
+		}
+		if cfg.IsReaderEnabled(driver, config.ReaderEnableContextCandidate) {
 			enabled = append(enabled, r)
 		}
 	}

--- a/pkg/readers/externaldrive/externaldrive_test.go
+++ b/pkg/readers/externaldrive/externaldrive_test.go
@@ -246,6 +246,22 @@ func TestDetect_DetectorInstantiation(t *testing.T) {
 	assert.NotNil(t, unmounts, "Unmounts channel should not be nil")
 }
 
+func requireChannelClosedAfterDrain[T any](t *testing.T, ch <-chan T, name string) {
+	t.Helper()
+
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("%s channel should be closed after Stop()", name)
+		}
+	}
+}
+
 func TestMountDetector_StartStop(t *testing.T) {
 	// Create a new detector
 	detector, err := NewMountDetector()
@@ -260,10 +276,8 @@ func TestMountDetector_StartStop(t *testing.T) {
 	detector.Stop()
 
 	// Verify channels are closed after Stop()
-	_, eventsOpen := <-detector.Events()
-	_, unmountsOpen := <-detector.Unmounts()
-	assert.False(t, eventsOpen, "Events channel should be closed after Stop()")
-	assert.False(t, unmountsOpen, "Unmounts channel should be closed after Stop()")
+	requireChannelClosedAfterDrain(t, detector.Events(), "Events")
+	requireChannelClosedAfterDrain(t, detector.Unmounts(), "Unmounts")
 }
 
 func TestMountDetector_MultipleStopCalls(t *testing.T) {

--- a/pkg/readers/externaldrive/externaldrive_test.go
+++ b/pkg/readers/externaldrive/externaldrive_test.go
@@ -42,6 +42,8 @@ const (
 	testEventTimeout = 2 * time.Second
 	// testNoEventTimeout is the time to wait to verify no event occurs
 	testNoEventTimeout = 200 * time.Millisecond
+	// testStopTimeout is the maximum time to wait for detector shutdown
+	testStopTimeout = time.Second
 )
 
 // testContext returns a context with the specified timeout for test synchronization.
@@ -249,7 +251,7 @@ func TestDetect_DetectorInstantiation(t *testing.T) {
 func requireChannelClosedAfterDrain[T any](t *testing.T, ch <-chan T, name string) {
 	t.Helper()
 
-	timeout := time.After(time.Second)
+	timeout := time.After(testStopTimeout)
 	for {
 		select {
 		case _, ok := <-ch:

--- a/pkg/readers/externaldrive/mount_detector_linux.go
+++ b/pkg/readers/externaldrive/mount_detector_linux.go
@@ -24,6 +24,7 @@ package externaldrive
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -44,11 +45,14 @@ const (
 	udisks2BlockInterface = "org.freedesktop.UDisks2.Block"
 	udisks2FSInterface    = "org.freedesktop.UDisks2.Filesystem"
 	dbusObjectManager     = "org.freedesktop.DBus.ObjectManager"
+	dbusProperties        = "org.freedesktop.DBus.Properties"
 
 	// fallbackRescanInterval is the maximum time between mount rescans.
 	// This ensures mounts are detected even when poll() doesn't fire events
 	// on some minimal Linux systems (like Batocera).
 	fallbackRescanInterval = 1 * time.Second
+
+	dbusCallTimeout = 3 * time.Second
 )
 
 // linuxMountDetector implements MountDetector for Linux using D-Bus/UDisks2.
@@ -59,6 +63,9 @@ type linuxMountDetector struct {
 	stopChan     chan struct{}
 	mountedDevs  map[string]MountEvent
 	pathMappings map[dbus.ObjectPath]string // objectPath -> deviceID mapping for reliable unmount detection
+	blockProps   map[dbus.ObjectPath]map[string]dbus.Variant
+	blockReader  func(dbus.ObjectPath) (map[string]dbus.Variant, error)
+	mountReader  func(dbus.ObjectPath) []string
 	wg           sync.WaitGroup
 	mu           syncutil.RWMutex
 	stopOnce     sync.Once
@@ -137,6 +144,9 @@ func NewMountDetector() (MountDetector, error) {
 			stopChan:     make(chan struct{}),
 			mountedDevs:  make(map[string]MountEvent),
 			pathMappings: make(map[dbus.ObjectPath]string),
+			blockProps:   make(map[dbus.ObjectPath]map[string]dbus.Variant),
+			blockReader:  nil,
+			mountReader:  nil,
 		}, nil
 	}
 
@@ -180,6 +190,15 @@ func (d *linuxMountDetector) Start() error {
 		return fmt.Errorf("failed to add match for InterfacesRemoved: %w", err)
 	}
 
+	if err := d.conn.AddMatchSignal(
+		dbus.WithMatchPathNamespace(dbus.ObjectPath(udisks2Path)),
+		dbus.WithMatchInterface(dbusProperties),
+		dbus.WithMatchMember("PropertiesChanged"),
+	); err != nil {
+		_ = d.conn.Close()
+		return fmt.Errorf("failed to add match for PropertiesChanged: %w", err)
+	}
+
 	// Create signal channel
 	signalChan := make(chan *dbus.Signal, 10)
 	d.conn.Signal(signalChan)
@@ -187,6 +206,11 @@ func (d *linuxMountDetector) Start() error {
 	// Start listening goroutine
 	d.wg.Add(1)
 	go d.listenForSignals(signalChan)
+
+	// Existing mounted drives may not emit InterfacesAdded after the reader starts.
+	// Seed the detector from UDisks2's current object state before relying on signals.
+	d.wg.Add(1)
+	go d.scanExistingObjects()
 
 	return nil
 }
@@ -214,6 +238,7 @@ func (d *linuxMountDetector) Forget(deviceID string) {
 	for path, id := range d.pathMappings {
 		if id == deviceID {
 			delete(d.pathMappings, path)
+			delete(d.blockProps, path)
 			break
 		}
 	}
@@ -238,8 +263,38 @@ func (d *linuxMountDetector) listenForSignals(signalChan chan *dbus.Signal) {
 				d.handleInterfacesAdded(signal)
 			case dbusObjectManager + ".InterfacesRemoved":
 				d.handleInterfacesRemoved(signal)
+			case dbusProperties + ".PropertiesChanged":
+				d.handlePropertiesChanged(signal)
 			}
 		}
+	}
+}
+
+func (d *linuxMountDetector) scanExistingObjects() {
+	defer d.wg.Done()
+
+	ctx, cancel := context.WithTimeout(context.Background(), dbusCallTimeout)
+	defer cancel()
+
+	obj := d.conn.Object(udisks2Service, dbus.ObjectPath(udisks2Path))
+	var objects map[dbus.ObjectPath]map[string]map[string]dbus.Variant
+	if err := obj.CallWithContext(ctx, dbusObjectManager+".GetManagedObjects", 0).Store(&objects); err != nil {
+		log.Debug().Err(err).Msg("failed to enumerate UDisks2 objects")
+		return
+	}
+
+	d.processManagedObjects(objects)
+}
+
+func (d *linuxMountDetector) processManagedObjects(objects map[dbus.ObjectPath]map[string]map[string]dbus.Variant) {
+	for objectPath, interfaces := range objects {
+		blockProps, hasBlock := interfaces[udisks2BlockInterface]
+		fsProps, hasFS := interfaces[udisks2FSInterface]
+		if !hasBlock || !hasFS {
+			continue
+		}
+
+		d.processObjectMount(objectPath, blockProps, fsProps, "initial scan")
 	}
 }
 
@@ -258,65 +313,112 @@ func (d *linuxMountDetector) handleInterfacesAdded(signal *dbus.Signal) {
 		return
 	}
 
-	// Check if this is a filesystem device
 	blockProps, hasBlock := interfaces[udisks2BlockInterface]
-	_, hasFS := interfaces[udisks2FSInterface]
+	fsProps, hasFS := interfaces[udisks2FSInterface]
 
 	if !hasBlock || !hasFS {
 		return
 	}
 
+	d.processObjectMount(objectPath, blockProps, fsProps, "interface added")
+}
+
+func (d *linuxMountDetector) processObjectMount(
+	objectPath dbus.ObjectPath,
+	blockProps map[string]dbus.Variant,
+	fsProps map[string]dbus.Variant,
+	source string,
+) {
+	d.mu.Lock()
+	d.blockProps[objectPath] = blockProps
+	d.mu.Unlock()
+
+	mountPoints := mountPointsFromProps(fsProps)
+	if len(mountPoints) == 0 {
+		log.Debug().Str("path", string(objectPath)).Str("source", source).Msg("filesystem has no mount points")
+		return
+	}
+
+	event, ok := d.buildMountEvent(objectPath, blockProps, mountPoints[0])
+	if !ok {
+		return
+	}
+
+	d.registerMountEvent(objectPath, &event, source)
+}
+
+func (d *linuxMountDetector) buildMountEvent(
+	objectPath dbus.ObjectPath,
+	blockProps map[string]dbus.Variant,
+	mountPath string,
+) (MountEvent, bool) {
+	if mountPath == "" {
+		return MountEvent{}, false
+	}
+
 	// Check if device is removable (not a system device)
 	if hintSystem, ok := blockProps["HintSystem"]; ok {
 		if isSystem, ok := hintSystem.Value().(bool); ok && isSystem {
-			return
+			return MountEvent{}, false
 		}
 	}
 
 	if hintIgnore, ok := blockProps["HintIgnore"]; ok {
 		if shouldIgnore, ok := hintIgnore.Value().(bool); ok && shouldIgnore {
-			return
+			return MountEvent{}, false
 		}
-	}
-
-	// Extract mount points
-	mountPoints := d.getMountPoints(string(objectPath))
-	if len(mountPoints) == 0 {
-		return
 	}
 
 	// Extract device information
 	deviceID := d.getDeviceID(blockProps)
 	if deviceID == "" {
 		log.Debug().Str("path", string(objectPath)).Msg("device has no ID, skipping")
-		return
+		return MountEvent{}, false
 	}
 
 	deviceNode := d.getDeviceNode(blockProps)
 	volumeLabel := d.getVolumeLabel(blockProps)
 	deviceType := d.getDeviceType(blockProps)
 
-	// Create mount event
-	event := MountEvent{
+	return MountEvent{
 		DeviceID:    deviceID,
 		DeviceNode:  deviceNode,
-		MountPath:   mountPoints[0], // Use first mount point
+		MountPath:   mountPath,
 		VolumeLabel: volumeLabel,
 		DeviceType:  deviceType,
+	}, true
+}
+
+func (d *linuxMountDetector) registerMountEvent(objectPath dbus.ObjectPath, event *MountEvent, source string) {
+	d.mu.Lock()
+	existing, exists := d.mountedDevs[event.DeviceID]
+	if exists && existing.MountPath == event.MountPath {
+		d.mu.Unlock()
+		log.Debug().
+			Str("device_id", event.DeviceID).
+			Str("mount_path", event.MountPath).
+			Str("source", source).
+			Msg("mount event already tracked")
+		return
 	}
 
-	// Store and emit event
-	d.mu.Lock()
-	d.mountedDevs[deviceID] = event
-	d.pathMappings[objectPath] = deviceID
+	d.mountedDevs[event.DeviceID] = *event
+	for path, deviceID := range d.pathMappings {
+		if deviceID == event.DeviceID && path != objectPath {
+			delete(d.pathMappings, path)
+			delete(d.blockProps, path)
+		}
+	}
+	d.pathMappings[objectPath] = event.DeviceID
 	d.mu.Unlock()
 
 	select {
-	case d.events <- event:
+	case d.events <- *event:
 		log.Debug().
-			Str("device_id", deviceID).
+			Str("device_id", event.DeviceID).
 			Str("mount_path", event.MountPath).
-			Str("label", volumeLabel).
+			Str("label", event.VolumeLabel).
+			Str("source", source).
 			Msg("mount event detected")
 	case <-d.stopChan:
 		return
@@ -351,12 +453,79 @@ func (d *linuxMountDetector) handleInterfacesRemoved(signal *dbus.Signal) {
 		return
 	}
 
-	// Use deterministic mapping to find device by object path
+	d.removeMountByObjectPath(objectPath)
+}
+
+func (d *linuxMountDetector) handlePropertiesChanged(signal *dbus.Signal) {
+	if len(signal.Body) < 2 {
+		return
+	}
+
+	if signal.Path == "" {
+		return
+	}
+
+	interfaceName, ok := signal.Body[0].(string)
+	if !ok || interfaceName != udisks2FSInterface {
+		return
+	}
+
+	changedProps, propsOK := signal.Body[1].(map[string]dbus.Variant)
+	if !propsOK {
+		return
+	}
+
+	mountPointsChanged := false
+	fsProps := map[string]dbus.Variant{}
+	if mountPoints, hasMountPoints := changedProps["MountPoints"]; hasMountPoints {
+		mountPointsChanged = true
+		fsProps["MountPoints"] = mountPoints
+	}
+
+	if !mountPointsChanged && len(signal.Body) >= 3 {
+		if invalidatedProps, invalidatedOK := signal.Body[2].([]string); invalidatedOK {
+			for _, prop := range invalidatedProps {
+				if prop == "MountPoints" {
+					mountPointsChanged = true
+					fsProps["MountPoints"] = dbus.MakeVariant(d.currentMountPoints(signal.Path))
+					break
+				}
+			}
+		}
+	}
+
+	if !mountPointsChanged {
+		return
+	}
+
+	mountPoints := mountPointsFromProps(fsProps)
+	if len(mountPoints) == 0 {
+		d.removeMountByObjectPath(signal.Path)
+		return
+	}
+
+	d.mu.RLock()
+	blockProps, ok := d.blockProps[signal.Path]
+	d.mu.RUnlock()
+	if !ok {
+		var err error
+		blockProps, err = d.currentBlockProperties(signal.Path)
+		if err != nil {
+			log.Debug().Err(err).Str("path", string(signal.Path)).Msg("failed to read block properties")
+			return
+		}
+	}
+
+	d.processObjectMount(signal.Path, blockProps, fsProps, "properties changed")
+}
+
+func (d *linuxMountDetector) removeMountByObjectPath(objectPath dbus.ObjectPath) {
 	d.mu.Lock()
 	deviceID, exists := d.pathMappings[objectPath]
 	if exists {
 		delete(d.mountedDevs, deviceID)
 		delete(d.pathMappings, objectPath)
+		delete(d.blockProps, objectPath)
 	}
 	d.mu.Unlock()
 
@@ -372,20 +541,104 @@ func (d *linuxMountDetector) handleInterfacesRemoved(signal *dbus.Signal) {
 	}
 }
 
-func (d *linuxMountDetector) getMountPoints(objectPath string) []string {
-	obj := d.conn.Object(udisks2Service, dbus.ObjectPath(objectPath))
-	var mountPoints [][]byte
+func (d *linuxMountDetector) currentMountPoints(objectPath dbus.ObjectPath) []string {
+	if d.mountReader != nil {
+		return d.mountReader(objectPath)
+	}
+	return d.readMountPoints(objectPath)
+}
 
-	if err := obj.Call(udisks2FSInterface+".GetMountPoints", 0).Store(&mountPoints); err != nil {
+func (d *linuxMountDetector) readMountPoints(objectPath dbus.ObjectPath) []string {
+	if d.conn == nil {
 		return nil
 	}
 
-	result := make([]string, 0, len(mountPoints))
-	for _, mp := range mountPoints {
+	ctx, cancel := context.WithTimeout(context.Background(), dbusCallTimeout)
+	defer cancel()
+
+	obj := d.conn.Object(udisks2Service, objectPath)
+	var mountPoints dbus.Variant
+	if err := obj.CallWithContext(
+		ctx,
+		dbusProperties+".Get",
+		0,
+		udisks2FSInterface,
+		"MountPoints",
+	).Store(&mountPoints); err != nil {
+		return nil
+	}
+
+	return mountPointsFromVariant(mountPoints)
+}
+
+func (d *linuxMountDetector) currentBlockProperties(objectPath dbus.ObjectPath) (map[string]dbus.Variant, error) {
+	if d.blockReader != nil {
+		return d.blockReader(objectPath)
+	}
+	return d.readBlockProperties(objectPath)
+}
+
+func (d *linuxMountDetector) readBlockProperties(objectPath dbus.ObjectPath) (map[string]dbus.Variant, error) {
+	if d.conn == nil {
+		return nil, errors.New("D-Bus connection is not initialized")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dbusCallTimeout)
+	defer cancel()
+
+	obj := d.conn.Object(udisks2Service, objectPath)
+	var blockProps map[string]dbus.Variant
+	if err := obj.CallWithContext(
+		ctx,
+		dbusProperties+".GetAll",
+		0,
+		udisks2BlockInterface,
+	).Store(&blockProps); err != nil {
+		return nil, fmt.Errorf("get block properties: %w", err)
+	}
+	return blockProps, nil
+}
+
+func mountPointsFromProps(props map[string]dbus.Variant) []string {
+	mountPoints, ok := props["MountPoints"]
+	if !ok {
+		return nil
+	}
+	return mountPointsFromVariant(mountPoints)
+}
+
+func mountPointsFromVariant(mountPoints dbus.Variant) []string {
+	switch value := mountPoints.Value().(type) {
+	case [][]byte:
+		return mountPointsFromBytes(value)
+	case []string:
+		return mountPointsFromStrings(value)
+	default:
+		return nil
+	}
+}
+
+func mountPointsFromBytes(value [][]byte) []string {
+	result := make([]string, 0, len(value))
+	for _, mp := range value {
 		if len(mp) > 0 {
 			// Remove trailing null byte if present
 			path := string(mp)
 			path = strings.TrimRight(path, "\x00")
+			if path != "" {
+				result = append(result, path)
+			}
+		}
+	}
+
+	return result
+}
+
+func mountPointsFromStrings(value []string) []string {
+	result := make([]string, 0, len(value))
+	for _, mp := range value {
+		path := strings.TrimRight(mp, "\x00")
+		if path != "" {
 			result = append(result, path)
 		}
 	}
@@ -411,7 +664,7 @@ func (*linuxMountDetector) getDeviceID(props map[string]dbus.Variant) string {
 	// Last resort: device name
 	if device, ok := props["Device"]; ok {
 		if devicePath, ok := device.Value().([]byte); ok && len(devicePath) > 0 {
-			return string(devicePath)
+			return strings.TrimRight(string(devicePath), "\x00")
 		}
 	}
 

--- a/pkg/readers/externaldrive/mount_detector_linux_test.go
+++ b/pkg/readers/externaldrive/mount_detector_linux_test.go
@@ -234,6 +234,26 @@ func TestProcessObjectMount_DoesNotDuplicateTrackedMount(t *testing.T) {
 	requireNoMountEvent(t, detector)
 }
 
+func TestRegisterMountEventReplacesStaleObjectPathForDevice(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	oldPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+	newPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdc1")
+	oldMountPath := absTestPath("run", "media", "user", "OLD")
+	newMountPath := absTestPath("run", "media", "user", "NEW")
+
+	detector.processObjectMount(oldPath, testBlockProps("uuid-1"), testFSProps(oldMountPath), "test")
+	_ = requireMountEvent(t, detector)
+	detector.processObjectMount(newPath, testBlockProps("uuid-1"), testFSProps(newMountPath), "test")
+	_ = requireMountEvent(t, detector)
+
+	detector.mu.RLock()
+	defer detector.mu.RUnlock()
+	assert.Equal(t, "uuid-1", detector.pathMappings[newPath])
+	assert.NotContains(t, detector.pathMappings, oldPath)
+	assert.NotContains(t, detector.blockProps, oldPath)
+	assert.Equal(t, newMountPath, detector.mountedDevs["uuid-1"].MountPath)
+}
+
 func TestPropertiesChanged_EmitsMountAfterEmptyInterfacesAdded(t *testing.T) {
 	detector := newLinuxMountDetectorForTest()
 	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")

--- a/pkg/readers/externaldrive/mount_detector_linux_test.go
+++ b/pkg/readers/externaldrive/mount_detector_linux_test.go
@@ -22,12 +22,79 @@
 package externaldrive
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func newLinuxMountDetectorForTest() *linuxMountDetector {
+	return &linuxMountDetector{
+		events:       make(chan MountEvent, 10),
+		unmounts:     make(chan string, 10),
+		stopChan:     make(chan struct{}),
+		mountedDevs:  make(map[string]MountEvent),
+		pathMappings: make(map[dbus.ObjectPath]string),
+		blockProps:   make(map[dbus.ObjectPath]map[string]dbus.Variant),
+	}
+}
+
+func absTestPath(parts ...string) string {
+	return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
+}
+
+func testBlockProps(deviceID string) map[string]dbus.Variant {
+	devicePath := absTestPath("dev", "sdb1")
+	return map[string]dbus.Variant{
+		"IdUUID":        dbus.MakeVariant(deviceID),
+		"Device":        dbus.MakeVariant([]byte(devicePath + "\x00")),
+		"IdLabel":       dbus.MakeVariant("CARD"),
+		"ConnectionBus": dbus.MakeVariant("usb"),
+	}
+}
+
+func testFSProps(mountPath string) map[string]dbus.Variant {
+	return map[string]dbus.Variant{
+		"MountPoints": dbus.MakeVariant([][]byte{[]byte(mountPath + "\x00")}),
+	}
+}
+
+func requireMountEvent(t *testing.T, detector *linuxMountDetector) MountEvent {
+	t.Helper()
+
+	select {
+	case event := <-detector.events:
+		return event
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for mount event")
+		return MountEvent{}
+	}
+}
+
+func requireNoMountEvent(t *testing.T, detector *linuxMountDetector) {
+	t.Helper()
+
+	select {
+	case event := <-detector.events:
+		require.Failf(t, "unexpected mount event", "%+v", event)
+	default:
+	}
+}
+
+func requireUnmountEvent(t *testing.T, detector *linuxMountDetector) string {
+	t.Helper()
+
+	select {
+	case deviceID := <-detector.unmounts:
+		return deviceID
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for unmount event")
+		return ""
+	}
+}
 
 func TestGetDeviceID_UUID_Priority(t *testing.T) {
 	t.Parallel()
@@ -62,13 +129,14 @@ func TestGetDeviceID_Device_LastResort(t *testing.T) {
 	t.Parallel()
 
 	detector := &linuxMountDetector{}
+	devicePath := absTestPath("dev", "sdd1")
 
 	props := map[string]dbus.Variant{
-		"Device": dbus.MakeVariant([]byte("/dev/sdd1")),
+		"Device": dbus.MakeVariant([]byte(devicePath + "\x00")),
 	}
 
 	deviceID := detector.getDeviceID(props)
-	assert.Equal(t, "/dev/sdd1", deviceID, "Device name should be last resort")
+	assert.Equal(t, devicePath, deviceID, "Device name should be last resort")
 }
 
 func TestGetDeviceID_EmptyUUID_FallsBackToSerial(t *testing.T) {
@@ -93,11 +161,187 @@ func TestGetDeviceID_EmptySerial_FallsBackToDevice(t *testing.T) {
 	props := map[string]dbus.Variant{
 		"IdUUID":   dbus.MakeVariant(""),
 		"IdSerial": dbus.MakeVariant(""),
-		"Device":   dbus.MakeVariant([]byte("/dev/sde1")),
+		"Device":   dbus.MakeVariant([]byte(absTestPath("dev", "sde1"))),
 	}
 
 	deviceID := detector.getDeviceID(props)
-	assert.Equal(t, "/dev/sde1", deviceID, "Empty serial should trigger device fallback")
+	assert.Equal(t, absTestPath("dev", "sde1"), deviceID, "Empty serial should trigger device fallback")
+}
+
+func TestMountPointsFromVariant_TrimsTrailingNulls(t *testing.T) {
+	t.Parallel()
+
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	mountPoints := mountPointsFromVariant(dbus.MakeVariant([][]byte{
+		[]byte(mountPath + "\x00"),
+		[]byte("\x00"),
+	}))
+
+	assert.Equal(t, []string{mountPath}, mountPoints)
+}
+
+func TestProcessManagedObjects_EmitsExistingMountedFilesystem(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+
+	detector.processManagedObjects(map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+		objectPath: {
+			udisks2BlockInterface: testBlockProps("uuid-1"),
+			udisks2FSInterface:    testFSProps(mountPath),
+		},
+	})
+
+	event := requireMountEvent(t, detector)
+	assert.Equal(t, "uuid-1", event.DeviceID)
+	assert.Equal(t, absTestPath("dev", "sdb1"), event.DeviceNode)
+	assert.Equal(t, mountPath, event.MountPath)
+	assert.Equal(t, "CARD", event.VolumeLabel)
+	assert.Equal(t, "USB", event.DeviceType)
+}
+
+func TestProcessManagedObjects_SkipsSystemAndIgnoredFilesystems(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	systemProps := testBlockProps("system")
+	systemProps["HintSystem"] = dbus.MakeVariant(true)
+	ignoredProps := testBlockProps("ignored")
+	ignoredProps["HintIgnore"] = dbus.MakeVariant(true)
+
+	detector.processManagedObjects(map[dbus.ObjectPath]map[string]map[string]dbus.Variant{
+		dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sda1"): {
+			udisks2BlockInterface: systemProps,
+			udisks2FSInterface:    testFSProps(mountPath),
+		},
+		dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1"): {
+			udisks2BlockInterface: ignoredProps,
+			udisks2FSInterface:    testFSProps(mountPath),
+		},
+	})
+
+	requireNoMountEvent(t, detector)
+}
+
+func TestProcessObjectMount_DoesNotDuplicateTrackedMount(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+
+	detector.processObjectMount(objectPath, testBlockProps("uuid-1"), testFSProps(mountPath), "test")
+	_ = requireMountEvent(t, detector)
+	detector.processObjectMount(objectPath, testBlockProps("uuid-1"), testFSProps(mountPath), "test")
+
+	requireNoMountEvent(t, detector)
+}
+
+func TestPropertiesChanged_EmitsMountAfterEmptyInterfacesAdded(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+	mountPath := absTestPath("run", "media", "user", "CARD")
+
+	detector.handleInterfacesAdded(&dbus.Signal{
+		Name: dbusObjectManager + ".InterfacesAdded",
+		Body: []any{
+			objectPath,
+			map[string]map[string]dbus.Variant{
+				udisks2BlockInterface: testBlockProps("uuid-1"),
+				udisks2FSInterface: {
+					"MountPoints": dbus.MakeVariant([][]byte{}),
+				},
+			},
+		},
+	})
+	requireNoMountEvent(t, detector)
+
+	detector.handlePropertiesChanged(&dbus.Signal{
+		Name: dbusProperties + ".PropertiesChanged",
+		Path: objectPath,
+		Body: []any{
+			udisks2FSInterface,
+			map[string]dbus.Variant{"MountPoints": dbus.MakeVariant([][]byte{[]byte(mountPath + "\x00")})},
+			[]string{},
+		},
+	})
+
+	event := requireMountEvent(t, detector)
+	assert.Equal(t, "uuid-1", event.DeviceID)
+	assert.Equal(t, mountPath, event.MountPath)
+}
+
+func TestPropertiesChanged_EmptyMountPointsEmitsUnmount(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+	mountPath := absTestPath("run", "media", "user", "CARD")
+
+	detector.processObjectMount(objectPath, testBlockProps("uuid-1"), testFSProps(mountPath), "test")
+	_ = requireMountEvent(t, detector)
+	detector.handlePropertiesChanged(&dbus.Signal{
+		Name: dbusProperties + ".PropertiesChanged",
+		Path: objectPath,
+		Body: []any{
+			udisks2FSInterface,
+			map[string]dbus.Variant{"MountPoints": dbus.MakeVariant([][]byte{})},
+			[]string{},
+		},
+	})
+
+	deviceID := requireUnmountEvent(t, detector)
+	assert.Equal(t, "uuid-1", deviceID)
+}
+
+func TestPropertiesChanged_InvalidatedMountPointsUsesCurrentValue(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	detector.mountReader = func(path dbus.ObjectPath) []string {
+		require.Equal(t, objectPath, path)
+		return []string{mountPath}
+	}
+	detector.blockReader = func(path dbus.ObjectPath) (map[string]dbus.Variant, error) {
+		require.Equal(t, objectPath, path)
+		return testBlockProps("uuid-1"), nil
+	}
+
+	detector.handlePropertiesChanged(&dbus.Signal{
+		Name: dbusProperties + ".PropertiesChanged",
+		Path: objectPath,
+		Body: []any{
+			udisks2FSInterface,
+			map[string]dbus.Variant{},
+			[]string{"MountPoints"},
+		},
+	})
+
+	event := requireMountEvent(t, detector)
+	assert.Equal(t, "uuid-1", event.DeviceID)
+	assert.Equal(t, mountPath, event.MountPath)
+}
+
+func TestPropertiesChanged_FetchesBlockPropsWhenMissingFromCache(t *testing.T) {
+	detector := newLinuxMountDetectorForTest()
+	objectPath := dbus.ObjectPath("/org/freedesktop/UDisks2/block_devices/sdb1")
+	mountPath := absTestPath("run", "media", "user", "CARD")
+	blockReaderCalls := 0
+	detector.blockReader = func(path dbus.ObjectPath) (map[string]dbus.Variant, error) {
+		blockReaderCalls++
+		require.Equal(t, objectPath, path)
+		return testBlockProps("uuid-1"), nil
+	}
+
+	detector.handlePropertiesChanged(&dbus.Signal{
+		Name: dbusProperties + ".PropertiesChanged",
+		Path: objectPath,
+		Body: []any{
+			udisks2FSInterface,
+			map[string]dbus.Variant{"MountPoints": dbus.MakeVariant([][]byte{[]byte(mountPath + "\x00")})},
+			[]string{},
+		},
+	})
+
+	event := requireMountEvent(t, detector)
+	assert.Equal(t, "uuid-1", event.DeviceID)
+	assert.Equal(t, mountPath, event.MountPath)
+	assert.Equal(t, 1, blockReaderCalls)
 }
 
 func TestGetDeviceID_NoProperties(t *testing.T) {

--- a/pkg/readers/externaldrive/mount_detector_linux_test.go
+++ b/pkg/readers/externaldrive/mount_detector_linux_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testNoMountEventTimeout = 100 * time.Millisecond
+
 func newLinuxMountDetectorForTest() *linuxMountDetector {
 	return &linuxMountDetector{
 		events:       make(chan MountEvent, 10),
@@ -80,7 +82,7 @@ func requireNoMountEvent(t *testing.T, detector *linuxMountDetector) {
 	select {
 	case event := <-detector.events:
 		require.Failf(t, "unexpected mount event", "%+v", event)
-	default:
+	case <-time.After(testNoMountEventTimeout):
 	}
 }
 

--- a/pkg/readers/externaldrive/mount_detector_linux_test.go
+++ b/pkg/readers/externaldrive/mount_detector_linux_test.go
@@ -31,7 +31,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testNoMountEventTimeout = 100 * time.Millisecond
+const (
+	testMountEventTimeout   = time.Second
+	testNoMountEventTimeout = 300 * time.Millisecond
+)
 
 func newLinuxMountDetectorForTest() *linuxMountDetector {
 	return &linuxMountDetector{
@@ -70,7 +73,7 @@ func requireMountEvent(t *testing.T, detector *linuxMountDetector) MountEvent {
 	select {
 	case event := <-detector.events:
 		return event
-	case <-time.After(time.Second):
+	case <-time.After(testMountEventTimeout):
 		require.Fail(t, "timed out waiting for mount event")
 		return MountEvent{}
 	}
@@ -92,7 +95,7 @@ func requireUnmountEvent(t *testing.T, detector *linuxMountDetector) string {
 	select {
 	case deviceID := <-detector.unmounts:
 		return deviceID
-	case <-time.After(time.Second):
+	case <-time.After(testMountEventTimeout):
 		require.Fail(t, "timed out waiting for unmount event")
 		return ""
 	}

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -363,7 +363,12 @@ func (r *Reader) IDs() []string {
 
 func (r *Reader) Detect(connected []string) string {
 	metadata := r.Metadata()
-	if !r.cfg.IsDriverAutoDetectEnabled(metadata.ID, metadata.DefaultAutoDetect) {
+	driver := config.DriverInfo{
+		ID:                metadata.ID,
+		DefaultEnabled:    metadata.DefaultEnabled,
+		DefaultAutoDetect: metadata.DefaultAutoDetect,
+	}
+	if !r.cfg.IsReaderEnabled(driver, config.ReaderEnableContextAutoDetect) {
 		return ""
 	}
 

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -597,7 +597,7 @@ func (*Reader) Detect(connected []string) string {
 	defer cancel()
 	devices, err := detection.DetectAll(ctx, &opts)
 	if err != nil {
-		if errors.Is(err, detection.ErrNoDevicesFound) {
+		if isExpectedDetectionMiss(err) {
 			log.Trace().Msg("no PN532 devices found during detection")
 		} else {
 			log.Warn().Err(err).Msg("PN532 detection returned unexpected error")
@@ -678,6 +678,10 @@ func (*Reader) Detect(connected []string) string {
 	// All detected devices are already in use
 	log.Trace().Msg("pn532: all detected devices are already connected")
 	return ""
+}
+
+func isExpectedDetectionMiss(err error) bool {
+	return errors.Is(err, detection.ErrNoDevicesFound) || errors.Is(err, detection.ErrDetectionTimeout)
 }
 
 func (r *Reader) Path() string {

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -587,11 +587,7 @@ func (*Reader) Detect(connected []string) string {
 	log.Trace().Msgf("PN532: ignoring paths: %v", ignorePaths)
 
 	// Try to detect PN532 devices
-	opts := detection.DefaultOptions()
-	opts.Timeout = quickDetectionTimeout
-	opts.Mode = detection.Safe
-	opts.Blocklist = createVIDPIDBlocklist()
-	opts.IgnorePaths = ignorePaths
+	opts := newDetectionOptions(ignorePaths)
 
 	ctx, cancel := context.WithTimeout(context.Background(), quickDetectionTimeout)
 	defer cancel()
@@ -682,6 +678,23 @@ func (*Reader) Detect(connected []string) string {
 
 func isExpectedDetectionMiss(err error) bool {
 	return errors.Is(err, detection.ErrNoDevicesFound) || errors.Is(err, detection.ErrDetectionTimeout)
+}
+
+// defaultDetectionTransports limits PN532 auto-detect to transports safe for
+// broad desktop scans. I2C is still available through explicit reader config,
+// but active auto-probing every /dev/i2c-* bus can wedge in kernel ioctls.
+func defaultDetectionTransports() []string {
+	return []string{detection.TransportUART}
+}
+
+func newDetectionOptions(ignorePaths []string) detection.Options {
+	opts := detection.DefaultOptions()
+	opts.Timeout = quickDetectionTimeout
+	opts.Mode = detection.Safe
+	opts.Blocklist = createVIDPIDBlocklist()
+	opts.IgnorePaths = ignorePaths
+	opts.Transports = defaultDetectionTransports()
+	return opts
 }
 
 func (r *Reader) Path() string {

--- a/pkg/readers/pn532/pn532_test.go
+++ b/pkg/readers/pn532/pn532_test.go
@@ -79,6 +79,14 @@ func TestIDs(t *testing.T) {
 	assert.Equal(t, expectedIDs, ids)
 }
 
+func TestIsExpectedDetectionMiss(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isExpectedDetectionMiss(detection.ErrNoDevicesFound))
+	assert.True(t, isExpectedDetectionMiss(detection.ErrDetectionTimeout))
+	assert.False(t, isExpectedDetectionMiss(errors.New("serial permission denied")))
+}
+
 func TestCapabilities(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/readers/pn532/pn532_test.go
+++ b/pkg/readers/pn532/pn532_test.go
@@ -87,6 +87,20 @@ func TestIsExpectedDetectionMiss(t *testing.T) {
 	assert.False(t, isExpectedDetectionMiss(errors.New("serial permission denied")))
 }
 
+func TestNewDetectionOptions_DefaultsToUARTOnly(t *testing.T) {
+	t.Parallel()
+
+	ignorePaths := []string{"/dev/ttyUSB0"}
+	opts := newDetectionOptions(ignorePaths)
+
+	assert.Equal(t, quickDetectionTimeout, opts.Timeout)
+	assert.Equal(t, detection.Safe, opts.Mode)
+	assert.Equal(t, []string{detection.TransportUART}, opts.Transports)
+	assert.NotContains(t, opts.Transports, detection.TransportI2C)
+	assert.Equal(t, ignorePaths, opts.IgnorePaths)
+	assert.NotEmpty(t, opts.Blocklist)
+}
+
 func TestCapabilities(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/autodetect.go
+++ b/pkg/service/autodetect.go
@@ -78,13 +78,7 @@ func (ad *AutoDetector) DetectReaders(
 			}
 		}
 
-		// Check if driver is enabled (explicit config or default)
-		if !cfg.IsDriverEnabledForAutoDetect(driver) {
-			closeUnused()
-			continue
-		}
-
-		if !cfg.IsDriverAutoDetectEnabled(metadata.ID, metadata.DefaultAutoDetect) {
+		if !cfg.IsReaderEnabled(driver, config.ReaderEnableContextAutoDetect) {
 			closeUnused()
 			continue
 		}

--- a/pkg/service/context.go
+++ b/pkg/service/context.go
@@ -20,6 +20,8 @@
 package service
 
 import (
+	"sync"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -38,4 +40,5 @@ type ServiceContext struct {
 	LaunchSoftwareQueue chan *tokens.Token
 	PlaylistQueue       chan *playlists.Playlist
 	ConfirmQueue        chan chan error
+	BackgroundWG        *sync.WaitGroup
 }

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -190,7 +190,7 @@ func servicePIDConflictError(pid int) error {
 func (s *Service) Running() (bool, error) {
 	pid, err := s.Pid()
 	if err != nil {
-		return false, nil
+		return false, fmt.Errorf("error reading service PID: %w", err)
 	}
 
 	if pid == 0 {
@@ -453,9 +453,9 @@ func (s *Service) Start() error {
 	if appPath != "" {
 		binPath = appPath
 	} else {
-		exePath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("error getting absolute binary path: %w", err)
+		exePath, exeErr := os.Executable()
+		if exeErr != nil {
+			return fmt.Errorf("error getting absolute binary path: %w", exeErr)
 		}
 		binPath = exePath
 	}
@@ -764,11 +764,11 @@ func (s *Service) Restart() error {
 		}
 	}
 
-	if err := waitForPIDExit(oldPID, serviceStopTimeout, serviceStopPollInterval, pidRunning); err != nil {
-		return err
+	if waitErr := waitForPIDExit(oldPID, serviceStopTimeout, serviceStopPollInterval, pidRunning); waitErr != nil {
+		return waitErr
 	}
-	if err := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
-		return err
+	if waitErr := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); waitErr != nil {
+		return waitErr
 	}
 
 	err = s.Start()
@@ -854,7 +854,9 @@ func SpawnDaemon(cfg *config.Instance) (cleanup func(), err error) {
 					if err := stopProcess(process, pid, waiter.wait); err != nil {
 						log.Error().Err(err).Int("pid", pid).Msg("error stopping daemon subprocess")
 					}
-					if err := waitForAPIPortRelease(cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
+					if err := waitForAPIPortRelease(
+						cfg, servicePortReleaseTimeout, serviceStopPollInterval,
+					); err != nil {
 						log.Warn().Err(err).Msg("daemon subprocess stopped but API port is still in use")
 					}
 				})

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -179,31 +179,38 @@ func validatePIDFileInfo(info os.FileInfo) error {
 	return nil
 }
 
+func servicePIDConflictError(pid int) error {
+	return fmt.Errorf(
+		"service PID file points to live process %d that does not match the Zaparoo service binary",
+		pid,
+	)
+}
+
 // Running returns true if the service is running.
-func (s *Service) Running() bool {
+func (s *Service) Running() (bool, error) {
 	pid, err := s.Pid()
 	if err != nil {
-		return false
+		return false, nil
 	}
 
 	if pid == 0 {
-		return false
+		return false, nil
 	}
 
 	if pidRunning(pid) {
 		if s.pidMatchesService(pid) {
-			return true
+			return true, nil
 		}
 		log.Warn().
 			Int("pid", pid).
 			Msg("service PID file points to live process that does not match service binary")
-		return false
+		return false, servicePIDConflictError(pid)
 	}
 
 	if rmErr := s.removePidFile(); rmErr != nil {
 		log.Debug().Err(rmErr).Int("pid", pid).Msg("failed to remove stale service PID file")
 	}
-	return false
+	return false, nil
 }
 
 func (s *Service) stopService() error {
@@ -363,14 +370,19 @@ func (s *Service) setupStopService() {
 
 // Starts the service and blocks until the service is stopped.
 func (s *Service) startService() {
-	if s.Running() {
+	running, err := s.Running()
+	if err != nil {
+		log.Error().Err(err).Msg("service PID file conflict")
+		os.Exit(1)
+	}
+	if running {
 		log.Error().Msg("service already running")
 		os.Exit(1)
 	}
 
 	log.Info().Msg("starting service")
 
-	err := s.createPidFile()
+	err = s.createPidFile()
 	if err != nil {
 		log.Error().Err(err).Msg("error creating pid file")
 		os.Exit(1)
@@ -428,7 +440,11 @@ func (s *Service) startService() {
 
 // Start a new service daemon in the background.
 func (s *Service) Start() error {
-	if s.Running() {
+	running, err := s.Running()
+	if err != nil {
+		return err
+	}
+	if running {
 		return errors.New("service already running")
 	}
 
@@ -490,7 +506,11 @@ func (s *Service) Start() error {
 
 	log.Info().Msgf("service process started with PID %d", pid)
 
-	if !s.Running() {
+	running, err = s.Running()
+	if err != nil {
+		return err
+	}
+	if !running {
 		return fmt.Errorf("service process %d started but is no longer running", pid)
 	}
 
@@ -728,8 +748,11 @@ func apiDialAddresses(cfg *config.Instance) []string {
 // pidRunning has confirmed the old process is gone before the replacement starts.
 func (s *Service) Restart() error {
 	oldPID := 0
-	if s.Running() {
-		var err error
+	running, err := s.Running()
+	if err != nil {
+		return err
+	}
+	if running {
 		oldPID, err = s.Pid()
 		if err != nil {
 			return err
@@ -748,7 +771,7 @@ func (s *Service) Restart() error {
 		return err
 	}
 
-	err := s.Start()
+	err = s.Start()
 	if err != nil {
 		return err
 	}
@@ -764,7 +787,12 @@ func (s *Service) WaitForAPI(cfg *config.Instance, maxWait, checkInterval time.D
 		return nil
 	}
 
-	if !s.Running() {
+	running, err := s.Running()
+	if err != nil {
+		log.Error().Err(err).Msg("service PID file conflict")
+		return err
+	}
+	if !running {
 		log.Error().Msg("service process is no longer running")
 		return errors.New("service process crashed during startup")
 	}
@@ -804,6 +832,7 @@ func SpawnDaemon(cfg *config.Instance) (cleanup func(), err error) {
 		return nil, fmt.Errorf("failed to start daemon: %w", err)
 	}
 	waiter := newCommandWaiter(cmd)
+	var cleanupOnce sync.Once
 	log.Info().Int("pid", cmd.Process.Pid).Msg("daemon subprocess started")
 
 	// Wait for service to be ready
@@ -812,17 +841,23 @@ func SpawnDaemon(cfg *config.Instance) (cleanup func(), err error) {
 		if client.IsServiceRunning(cfg) {
 			log.Info().Int("pid", cmd.Process.Pid).Msg("daemon API is ready")
 			return func() {
-				if cmd.Process == nil {
-					return
-				}
+				cleanupOnce.Do(func() {
+					if cmd.Process == nil {
+						return
+					}
 
-				log.Info().Int("pid", cmd.Process.Pid).Msg("stopping daemon subprocess")
-				if err := stopProcess(cmd.Process, cmd.Process.Pid, waiter.wait); err != nil {
-					log.Error().Err(err).Int("pid", cmd.Process.Pid).Msg("error stopping daemon subprocess")
-				}
-				if err := waitForAPIPortRelease(cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
-					log.Warn().Err(err).Msg("daemon subprocess stopped but API port is still in use")
-				}
+					process := cmd.Process
+					pid := process.Pid
+					defer func() { cmd.Process = nil }()
+
+					log.Info().Int("pid", pid).Msg("stopping daemon subprocess")
+					if err := stopProcess(process, pid, waiter.wait); err != nil {
+						log.Error().Err(err).Int("pid", pid).Msg("error stopping daemon subprocess")
+					}
+					if err := waitForAPIPortRelease(cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
+						log.Warn().Err(err).Msg("daemon subprocess stopped but API port is still in use")
+					}
+				})
 			}, nil
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -864,7 +899,12 @@ func (s *Service) ServiceHandler(cmd *string) error {
 		}
 		os.Exit(0)
 	case "status":
-		if s.Running() {
+		running, err := s.Running()
+		if err != nil {
+			log.Error().Err(err).Msg("service PID file conflict")
+			os.Exit(1)
+		}
+		if running {
 			_, _ = fmt.Println("started")
 			os.Exit(0)
 		}

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -28,12 +28,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -50,6 +53,7 @@ type ServiceEntry func() (*service.StartResult, error)
 
 type Service struct {
 	pl     platforms.Platform
+	cfg    *config.Instance
 	start  ServiceEntry
 	stop   func() error
 	done   <-chan struct{}
@@ -58,9 +62,26 @@ type Service struct {
 
 type ServiceArgs struct {
 	Platform platforms.Platform
+	Config   *config.Instance
 	Entry    ServiceEntry
 	NoDaemon bool
 }
+
+type processWaitFunc func(time.Duration) error
+
+type commandWaiter struct {
+	done chan error
+	once sync.Once
+	cmd  *exec.Cmd
+}
+
+const (
+	serviceStopTimeout        = 10 * time.Second
+	serviceKillTimeout        = 3 * time.Second
+	serviceStopPollInterval   = 100 * time.Millisecond
+	servicePortReleaseTimeout = 3 * time.Second
+	daemonReadyTimeout        = 3 * time.Second
+)
 
 func NewService(args ServiceArgs) (*Service, error) {
 	err := os.MkdirAll(args.Platform.Settings().TempDir, 0o750)
@@ -70,6 +91,7 @@ func NewService(args ServiceArgs) (*Service, error) {
 
 	return &Service{
 		daemon: !args.NoDaemon,
+		cfg:    args.Config,
 		start:  args.Entry,
 		pl:     args.Platform,
 	}, nil
@@ -79,16 +101,30 @@ func NewService(args ServiceArgs) (*Service, error) {
 func (s *Service) createPidFile() error {
 	pidPath := filepath.Join(s.pl.Settings().TempDir, config.PidFile)
 	pid := os.Getpid()
-	err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o600)
+	file, err := os.OpenFile(
+		pidPath,
+		os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create PID file: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	_, err = file.WriteString(strconv.Itoa(pid))
 	if err != nil {
 		return fmt.Errorf("failed to write PID file: %w", err)
 	}
+
 	return nil
 }
 
 func (s *Service) removePidFile() error {
 	err := os.Remove(filepath.Join(s.pl.Settings().TempDir, config.PidFile))
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
 		return fmt.Errorf("failed to remove PID file: %w", err)
 	}
 	return nil
@@ -99,22 +135,47 @@ func (s *Service) Pid() (int, error) {
 	pid := 0
 	pidPath := filepath.Join(s.pl.Settings().TempDir, config.PidFile)
 
-	if _, err := os.Stat(pidPath); err == nil {
-		//nolint:gosec // Safe: reads PID files for service management
-		pidFile, err := os.ReadFile(pidPath)
-		if err != nil {
-			return pid, fmt.Errorf("error reading pid file: %w", err)
+	info, err := os.Lstat(pidPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return pid, nil
 		}
-
-		pidInt, err := strconv.Atoi(string(pidFile))
-		if err != nil {
-			return pid, fmt.Errorf("error parsing pid: %w", err)
-		}
-
-		pid = pidInt
+		return pid, fmt.Errorf("error checking pid file: %w", err)
+	}
+	if err := validatePIDFileInfo(info); err != nil {
+		return pid, err
 	}
 
+	//nolint:gosec // Safe: PID file path is validated before reading
+	pidFile, err := os.ReadFile(pidPath)
+	if err != nil {
+		return pid, fmt.Errorf("error reading pid file: %w", err)
+	}
+
+	pidInt, err := strconv.Atoi(string(pidFile))
+	if err != nil {
+		return pid, fmt.Errorf("error parsing pid: %w", err)
+	}
+
+	pid = pidInt
 	return pid, nil
+}
+
+func validatePIDFileInfo(info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("pid file is a symlink")
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("pid file is not a regular file")
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return errors.New("pid file is group or world writable")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok && stat.Uid != uint32(os.Geteuid()) {
+		return fmt.Errorf("pid file is owned by uid %d, expected %d", stat.Uid, os.Geteuid())
+	}
+	return nil
 }
 
 // Running returns true if the service is running.
@@ -128,14 +189,18 @@ func (s *Service) Running() bool {
 		return false
 	}
 
-	process, err := os.FindProcess(pid)
-	if err != nil {
+	if pidRunning(pid) {
+		if s.pidMatchesService(pid) {
+			return true
+		}
+		log.Warn().Int("pid", pid).Msg("service PID file points to a live process that does not match the service binary")
 		return false
 	}
 
-	err = process.Signal(syscall.Signal(0))
-
-	return err == nil
+	if rmErr := s.removePidFile(); rmErr != nil {
+		log.Debug().Err(rmErr).Int("pid", pid).Msg("failed to remove stale service PID file")
+	}
+	return false
 }
 
 func (s *Service) stopService() error {
@@ -431,13 +496,18 @@ func (s *Service) Start() error {
 
 // Stop the service daemon.
 func (s *Service) Stop() error {
-	if !s.Running() {
-		return errors.New("service not running")
-	}
-
 	pid, err := s.Pid()
 	if err != nil {
 		return err
+	}
+	if pid == 0 {
+		return errors.New("service not running")
+	}
+	if !pidRunning(pid) {
+		return s.removePidFile()
+	}
+	if !s.pidMatchesService(pid) {
+		return fmt.Errorf("refusing to stop PID %d because it does not match the Zaparoo service binary", pid)
 	}
 
 	process, err := os.FindProcess(pid)
@@ -445,12 +515,57 @@ func (s *Service) Stop() error {
 		return fmt.Errorf("failed to find process: %w", err)
 	}
 
-	err = process.Signal(syscall.SIGTERM)
-	if err != nil {
-		return fmt.Errorf("failed to send SIGTERM to process: %w", err)
+	if err := stopProcess(process, pid, func(timeout time.Duration) error {
+		return waitForPIDExit(pid, timeout, serviceStopPollInterval, pidRunning)
+	}); err != nil {
+		return err
+	}
+
+	if err := s.removePidFile(); err != nil {
+		return err
+	}
+	if err := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func stopProcess(process *os.Process, pid int, wait processWaitFunc) error {
+	if process == nil {
+		return errors.New("process is nil")
+	}
+
+	if err := signalProcess(process, pid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("failed to send SIGTERM to process %d: %w", pid, err)
+	}
+
+	if err := wait(serviceStopTimeout); err == nil {
+		return nil
+	} else {
+		log.Warn().Err(err).Int("pid", pid).Msg("process did not stop after SIGTERM, sending SIGKILL")
+	}
+
+	if err := signalProcess(process, pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("failed to send SIGKILL to process %d: %w", pid, err)
+	}
+	if err := wait(serviceKillTimeout); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func signalProcess(process *os.Process, pid int, signal syscall.Signal) error {
+	if pid > 0 {
+		if err := syscall.Kill(-pid, signal); err == nil || !errors.Is(err, syscall.ESRCH) {
+			return err
+		}
+	}
+	return process.Signal(signal)
 }
 
 func pidRunning(pid int) bool {
@@ -459,7 +574,58 @@ func pidRunning(pid int) bool {
 	}
 
 	err := syscall.Kill(pid, syscall.Signal(0))
-	return err == nil || errors.Is(err, syscall.EPERM)
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return false
+	}
+	return !pidIsZombie(pid)
+}
+
+func pidIsZombie(pid int) bool {
+	statPath := filepath.Join("/proc", strconv.Itoa(pid), "stat")
+	data, err := os.ReadFile(statPath) //nolint:gosec // reads process status for service management
+	if err != nil {
+		return false
+	}
+
+	fieldsStart := strings.LastIndexByte(string(data), ')')
+	if fieldsStart == -1 || fieldsStart+2 >= len(data) {
+		return false
+	}
+	return data[fieldsStart+2] == 'Z'
+}
+
+func (s *Service) pidMatchesService(pid int) bool {
+	if runtime.GOOS != "linux" {
+		return true
+	}
+
+	dataDir := helpers.DataDir(s.pl)
+	exePath, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
+	if err == nil && pathLooksLikeServiceBinary(exePath, dataDir) {
+		return true
+	}
+
+	cmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline")) //nolint:gosec // reads process status for service management
+	if err != nil {
+		return false
+	}
+	for _, arg := range strings.Split(string(cmdline), "\x00") {
+		if pathLooksLikeServiceBinary(arg, dataDir) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathLooksLikeServiceBinary(path, dataDir string) bool {
+	if path == "" || dataDir == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(dataDir), filepath.Clean(path))
+	if err != nil || rel == "." || filepath.IsAbs(rel) || strings.HasPrefix(rel, "..") {
+		return false
+	}
+	return filepath.Dir(rel) == "." && strings.Contains(filepath.Base(rel), ".service")
 }
 
 func waitForPIDExit(
@@ -483,6 +649,72 @@ func waitForPIDExit(
 	return nil
 }
 
+func waitForAPIPortRelease(cfg *config.Instance, timeout, pollInterval time.Duration) error {
+	if cfg == nil || cfg.APIPort() == 0 {
+		return nil
+	}
+
+	addrs := apiDialAddresses(cfg)
+	deadline := time.Now().Add(timeout)
+	for {
+		released := true
+		for _, addr := range addrs {
+			conn, err := net.DialTimeout("tcp", addr, pollInterval)
+			if err != nil {
+				continue
+			}
+			released = false
+			_ = conn.Close()
+		}
+		if released {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout waiting for API port %s to release", strings.Join(addrs, ", "))
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+func newCommandWaiter(cmd *exec.Cmd) *commandWaiter {
+	return &commandWaiter{
+		cmd:  cmd,
+		done: make(chan error, 1),
+	}
+}
+
+func (w *commandWaiter) wait(timeout time.Duration) error {
+	w.once.Do(func() {
+		go func() { w.done <- w.cmd.Wait() }()
+	})
+
+	select {
+	case err := <-w.done:
+		if err != nil && !errors.Is(err, os.ErrProcessDone) {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout waiting for process %d to stop", w.cmd.Process.Pid)
+	}
+}
+
+func apiDialAddresses(cfg *config.Instance) []string {
+	host, port, err := net.SplitHostPort(cfg.APIListen())
+	if err != nil {
+		return []string{net.JoinHostPort("127.0.0.1", strconv.Itoa(cfg.APIPort()))}
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		return []string{net.JoinHostPort("127.0.0.1", port), net.JoinHostPort("::1", port)}
+	}
+	return []string{net.JoinHostPort(host, port)}
+}
+
 // Restart is intentionally idempotent: if Running reports no live PID, Stop and
 // waitForPIDExit are skipped and Start is called directly. When a PID is still
 // active, Restart follows the full Stop -> waitForPIDExit -> Start sequence so
@@ -502,7 +734,10 @@ func (s *Service) Restart() error {
 		}
 	}
 
-	if err := waitForPIDExit(oldPID, 10*time.Second, 500*time.Millisecond, pidRunning); err != nil {
+	if err := waitForPIDExit(oldPID, serviceStopTimeout, serviceStopPollInterval, pidRunning); err != nil {
+		return err
+	}
+	if err := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
 		return err
 	}
 
@@ -561,43 +796,35 @@ func SpawnDaemon(cfg *config.Instance) (cleanup func(), err error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start daemon: %w", err)
 	}
+	waiter := newCommandWaiter(cmd)
+	log.Info().Int("pid", cmd.Process.Pid).Msg("daemon subprocess started")
 
 	// Wait for service to be ready
-	ready := false
-	for range 30 {
+	deadline := time.Now().Add(daemonReadyTimeout)
+	for time.Now().Before(deadline) {
 		if client.IsServiceRunning(cfg) {
-			ready = true
-			break
+			log.Info().Int("pid", cmd.Process.Pid).Msg("daemon API is ready")
+			return func() {
+				if cmd.Process == nil {
+					return
+				}
+
+				log.Info().Int("pid", cmd.Process.Pid).Msg("stopping daemon subprocess")
+				if err := stopProcess(cmd.Process, cmd.Process.Pid, waiter.wait); err != nil {
+					log.Error().Err(err).Int("pid", cmd.Process.Pid).Msg("error stopping daemon subprocess")
+				}
+				if err := waitForAPIPortRelease(cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
+					log.Warn().Err(err).Msg("daemon subprocess stopped but API port is still in use")
+				}
+			}, nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	if !ready {
-		_ = cmd.Process.Kill()
-		return nil, errors.New("daemon failed to start within 3 seconds")
+	if err := stopProcess(cmd.Process, cmd.Process.Pid, waiter.wait); err != nil {
+		log.Warn().Err(err).Int("pid", cmd.Process.Pid).Msg("failed to clean up daemon subprocess after startup timeout")
 	}
-
-	log.Info().Msg("daemon subprocess started")
-
-	// Return cleanup function
-	return func() {
-		if cmd.Process == nil {
-			return
-		}
-
-		log.Info().Msg("stopping daemon subprocess")
-		_ = cmd.Process.Signal(syscall.SIGTERM)
-
-		done := make(chan error, 1)
-		go func() { done <- cmd.Wait() }()
-
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			log.Warn().Msg("daemon shutdown timed out, killing")
-			_ = cmd.Process.Kill()
-		}
-	}, nil
+	return nil, errors.New("daemon failed to start within 3 seconds")
 }
 
 func (s *Service) ServiceHandler(cmd *string) error {

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -70,9 +70,9 @@ type ServiceArgs struct {
 type processWaitFunc func(time.Duration) error
 
 type commandWaiter struct {
+	cmd  *exec.Cmd
 	done chan error
 	once sync.Once
-	cmd  *exec.Cmd
 }
 
 const (
@@ -101,6 +101,7 @@ func NewService(args ServiceArgs) (*Service, error) {
 func (s *Service) createPidFile() error {
 	pidPath := filepath.Join(s.pl.Settings().TempDir, config.PidFile)
 	pid := os.Getpid()
+	//nolint:gosec // PID path is derived from the configured temp directory and fixed filename.
 	file, err := os.OpenFile(
 		pidPath,
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW,
@@ -142,8 +143,8 @@ func (s *Service) Pid() (int, error) {
 		}
 		return pid, fmt.Errorf("error checking pid file: %w", err)
 	}
-	if err := validatePIDFileInfo(info); err != nil {
-		return pid, err
+	if validateErr := validatePIDFileInfo(info); validateErr != nil {
+		return pid, validateErr
 	}
 
 	//nolint:gosec // Safe: PID file path is validated before reading
@@ -172,7 +173,7 @@ func validatePIDFileInfo(info os.FileInfo) error {
 		return errors.New("pid file is group or world writable")
 	}
 	stat, ok := info.Sys().(*syscall.Stat_t)
-	if ok && stat.Uid != uint32(os.Geteuid()) {
+	if ok && int64(stat.Uid) != int64(os.Geteuid()) {
 		return fmt.Errorf("pid file is owned by uid %d, expected %d", stat.Uid, os.Geteuid())
 	}
 	return nil
@@ -193,7 +194,9 @@ func (s *Service) Running() bool {
 		if s.pidMatchesService(pid) {
 			return true
 		}
-		log.Warn().Int("pid", pid).Msg("service PID file points to a live process that does not match the service binary")
+		log.Warn().
+			Int("pid", pid).
+			Msg("service PID file points to live process that does not match service binary")
 		return false
 	}
 
@@ -524,11 +527,7 @@ func (s *Service) Stop() error {
 	if err := s.removePidFile(); err != nil {
 		return err
 	}
-	if err := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval)
 }
 
 func stopProcess(process *os.Process, pid int, wait processWaitFunc) error {
@@ -543,29 +542,30 @@ func stopProcess(process *os.Process, pid int, wait processWaitFunc) error {
 		return fmt.Errorf("failed to send SIGTERM to process %d: %w", pid, err)
 	}
 
-	if err := wait(serviceStopTimeout); err == nil {
+	stopErr := wait(serviceStopTimeout)
+	if stopErr == nil {
 		return nil
-	} else {
-		log.Warn().Err(err).Int("pid", pid).Msg("process did not stop after SIGTERM, sending SIGKILL")
 	}
+	log.Warn().Err(stopErr).Int("pid", pid).Msg("process did not stop after SIGTERM, sending SIGKILL")
 
 	if err := signalProcess(process, pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return fmt.Errorf("failed to send SIGKILL to process %d: %w", pid, err)
 	}
-	if err := wait(serviceKillTimeout); err != nil {
-		return err
-	}
-
-	return nil
+	return wait(serviceKillTimeout)
 }
 
-func signalProcess(process *os.Process, pid int, signal syscall.Signal) error {
+func signalProcess(process *os.Process, pid int, sig syscall.Signal) error {
 	if pid > 0 {
-		if err := syscall.Kill(-pid, signal); err == nil || !errors.Is(err, syscall.ESRCH) {
-			return err
+		if err := syscall.Kill(-pid, sig); err == nil {
+			return nil
+		} else if !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("failed to signal process group %d: %w", pid, err)
 		}
 	}
-	return process.Signal(signal)
+	if err := process.Signal(sig); err != nil {
+		return fmt.Errorf("failed to signal process %d: %w", pid, err)
+	}
+	return nil
 }
 
 func pidRunning(pid int) bool {
@@ -581,7 +581,7 @@ func pidRunning(pid int) bool {
 }
 
 func pidIsZombie(pid int) bool {
-	statPath := filepath.Join("/proc", strconv.Itoa(pid), "stat")
+	statPath := filepath.Join(procDir(), strconv.Itoa(pid), "stat")
 	data, err := os.ReadFile(statPath) //nolint:gosec // reads process status for service management
 	if err != nil {
 		return false
@@ -600,12 +600,13 @@ func (s *Service) pidMatchesService(pid int) bool {
 	}
 
 	dataDir := helpers.DataDir(s.pl)
-	exePath, err := os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
+	exePath, err := os.Readlink(filepath.Join(procDir(), strconv.Itoa(pid), "exe"))
 	if err == nil && pathLooksLikeServiceBinary(exePath, dataDir) {
 		return true
 	}
 
-	cmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline")) //nolint:gosec // reads process status for service management
+	cmdlinePath := filepath.Join(procDir(), strconv.Itoa(pid), "cmdline")
+	cmdline, err := os.ReadFile(cmdlinePath) //nolint:gosec // reads process status for service management
 	if err != nil {
 		return false
 	}
@@ -615,6 +616,10 @@ func (s *Service) pidMatchesService(pid int) bool {
 		}
 	}
 	return false
+}
+
+func procDir() string {
+	return string(filepath.Separator) + "proc"
 }
 
 func pathLooksLikeServiceBinary(path, dataDir string) bool {
@@ -659,7 +664,9 @@ func waitForAPIPortRelease(cfg *config.Instance, timeout, pollInterval time.Dura
 	for {
 		released := true
 		for _, addr := range addrs {
-			conn, err := net.DialTimeout("tcp", addr, pollInterval)
+			ctx, cancel := context.WithTimeout(context.Background(), pollInterval)
+			conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			cancel()
 			if err != nil {
 				continue
 			}
@@ -822,7 +829,10 @@ func SpawnDaemon(cfg *config.Instance) (cleanup func(), err error) {
 	}
 
 	if err := stopProcess(cmd.Process, cmd.Process.Pid, waiter.wait); err != nil {
-		log.Warn().Err(err).Int("pid", cmd.Process.Pid).Msg("failed to clean up daemon subprocess after startup timeout")
+		log.Warn().
+			Err(err).
+			Int("pid", cmd.Process.Pid).
+			Msg("failed to clean up daemon subprocess after startup timeout")
 	}
 	return nil, errors.New("daemon failed to start within 3 seconds")
 }

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -427,11 +427,12 @@ func TestPIDRunningTreatsZombieAsStopped(t *testing.T) {
 func TestWaitForAPIPortRelease(t *testing.T) {
 	t.Parallel()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer func() { _ = listener.Close() }()
 
-	addr := listener.Addr().(*net.TCPAddr)
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
 	cfg, err := testhelpers.NewTestConfig(testhelpers.NewOSFS(), t.TempDir())
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetAPIPort(addr.Port))
@@ -456,7 +457,7 @@ func TestStopProcessTerminatesCommand(t *testing.T) {
 
 func TestStopProcessTerminatesProcessGroup(t *testing.T) {
 	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
-	process := exec.CommandContext(
+	process := exec.CommandContext( //nolint:gosec // test starts a controlled shell script.
 		context.Background(),
 		"sh",
 		"-c",
@@ -504,6 +505,7 @@ func TestPidRejectsGroupWritableFile(t *testing.T) {
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
 	require.NoError(t, os.WriteFile(pidFile, []byte("123"), 0o600))
+	//nolint:gosec // Intentionally invalid permissions for validation test.
 	require.NoError(t, os.Chmod(pidFile, 0o620))
 
 	_, err := svc.Pid()

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -24,16 +24,20 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,17 +313,7 @@ func TestRestart_ReplacesRunningService(t *testing.T) {
 	eventLog := filepath.Join(t.TempDir(), "events.log")
 	t.Setenv(config.AppEnv, writeFakeServiceScript(t, pidFile, eventLog))
 
-	oldProcess := exec.CommandContext(context.Background(), "sleep", "1000")
-	require.NoError(t, oldProcess.Start())
-	defer func() {
-		_ = oldProcess.Process.Kill()
-	}()
-	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(oldProcess.Process.Pid)), 0o600))
-
-	oldProcessExited := make(chan error, 1)
-	go func() {
-		oldProcessExited <- oldProcess.Wait()
-	}()
+	require.NoError(t, svc.Start())
 
 	oldPID, err := svc.Pid()
 	require.NoError(t, err)
@@ -334,10 +328,6 @@ func TestRestart_ReplacesRunningService(t *testing.T) {
 	})
 
 	require.NoError(t, svc.Restart())
-	oldExitErr := <-oldProcessExited
-	if oldExitErr != nil {
-		require.Contains(t, oldExitErr.Error(), "terminated", oldExitErr.Error())
-	}
 
 	newPID, err := svc.Pid()
 	require.NoError(t, err)
@@ -348,6 +338,190 @@ func TestRestart_ReplacesRunningService(t *testing.T) {
 	content, err := os.ReadFile(eventLog) //nolint:gosec // test-controlled file
 	require.NoError(t, err)
 	assert.Contains(t, string(content), fmt.Sprintf("started:%d", newPID))
+}
+
+func TestStop_WaitsForProcessExitAndRemovesPIDFile(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	eventLog := filepath.Join(t.TempDir(), "events.log")
+	t.Setenv(config.AppEnv, writeFakeServiceScript(t, pidFile, eventLog))
+
+	require.NoError(t, svc.Start())
+
+	require.NoError(t, svc.Stop())
+	assert.NoFileExists(t, pidFile)
+	assert.False(t, svc.Running())
+}
+
+func TestStopRemovesStalePIDFileWithoutKillingUnrelatedProcess(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	err := svc.Stop()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the Zaparoo service binary")
+	assert.True(t, pidRunning(process.Process.Pid))
+	assert.FileExists(t, pidFile)
+}
+
+func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	assert.False(t, svc.Running())
+	assert.True(t, pidRunning(process.Process.Pid))
+	assert.FileExists(t, pidFile)
+}
+
+func TestPathLooksLikeServiceBinaryRequiresDirectDataDirChild(t *testing.T) {
+	t.Parallel()
+
+	dataDir := filepath.Join(t.TempDir(), "data")
+	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.service"), dataDir))
+	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.service.sh"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "nested", "zaparoo.service"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(t.TempDir(), "zaparoo.service"), dataDir))
+}
+
+func TestRunningRemovesStalePIDFile(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	require.NoError(t, os.WriteFile(pidFile, []byte("99999999"), 0o600))
+
+	assert.False(t, svc.Running())
+	assert.NoFileExists(t, pidFile)
+}
+
+func TestPIDRunningTreatsZombieAsStopped(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("zombie detection uses Linux /proc status")
+	}
+
+	process := exec.CommandContext(context.Background(), "sh", "-c", "exit 0")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Wait() })
+
+	require.Eventually(t, func() bool {
+		return pidIsZombie(process.Process.Pid)
+	}, time.Second, 10*time.Millisecond)
+	assert.False(t, pidRunning(process.Process.Pid))
+}
+
+func TestWaitForAPIPortRelease(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	cfg, err := testhelpers.NewTestConfig(testhelpers.NewOSFS(), t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetAPIPort(addr.Port))
+
+	err = waitForAPIPortRelease(cfg, 20*time.Millisecond, 5*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout waiting for API port")
+
+	require.NoError(t, listener.Close())
+	require.NoError(t, waitForAPIPortRelease(cfg, time.Second, 5*time.Millisecond))
+}
+
+func TestStopProcessTerminatesCommand(t *testing.T) {
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+
+	waiter := newCommandWaiter(process)
+	require.NoError(t, stopProcess(process.Process, process.Process.Pid, waiter.wait))
+	assert.False(t, pidRunning(process.Process.Pid))
+}
+
+func TestStopProcessTerminatesProcessGroup(t *testing.T) {
+	childPIDPath := filepath.Join(t.TempDir(), "child.pid")
+	process := exec.CommandContext(
+		context.Background(),
+		"sh",
+		"-c",
+		fmt.Sprintf("sleep 1000 & printf '%%s' \"$!\" > %q; wait", childPIDPath),
+	)
+	process.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = syscall.Kill(-process.Process.Pid, syscall.SIGKILL) })
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(childPIDPath)
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
+	childPIDBytes, err := os.ReadFile(childPIDPath) //nolint:gosec // test-controlled file
+	require.NoError(t, err)
+	childPID, err := strconv.Atoi(string(childPIDBytes))
+	require.NoError(t, err)
+	require.True(t, pidRunning(childPID))
+
+	waiter := newCommandWaiter(process)
+	require.NoError(t, stopProcess(process.Process, process.Process.Pid, waiter.wait))
+	assert.False(t, pidRunning(process.Process.Pid))
+	require.Eventually(t, func() bool {
+		return !pidRunning(childPID)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestPidRejectsSymlink(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	require.NoError(t, os.Symlink(filepath.Join(t.TempDir(), "target.pid"), pidFile))
+
+	_, err := svc.Pid()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pid file is a symlink")
+}
+
+func TestPidRejectsGroupWritableFile(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	require.NoError(t, os.WriteFile(pidFile, []byte("123"), 0o600))
+	require.NoError(t, os.Chmod(pidFile, 0o620))
+
+	_, err := svc.Pid()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pid file is group or world writable")
+}
+
+func TestCreatePidFileRejectsExistingSymlink(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	require.NoError(t, os.Symlink(filepath.Join(t.TempDir(), "target.pid"), pidFile))
+
+	err := svc.createPidFile()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create PID file")
 }
 
 func TestWaitForPIDExit_ReturnsImmediatelyForInvalidPID(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -57,6 +57,14 @@ func newTestService(t *testing.T) *Service {
 	return &Service{pl: pl}
 }
 
+func requireServiceRunning(t *testing.T, svc *Service) bool {
+	t.Helper()
+
+	running, err := svc.Running()
+	require.NoError(t, err)
+	return running
+}
+
 func writeFakeServiceScript(t *testing.T, pidFile, eventLog string) string {
 	t.Helper()
 
@@ -289,19 +297,19 @@ func TestRestart_StartsWhenServiceNotRunning(t *testing.T) {
 	t.Setenv(config.AppEnv, writeFakeServiceScript(t, pidFile, eventLog))
 	t.Cleanup(func() {
 		pid, err := svc.Pid()
-		if err == nil && pid > 0 && svc.Running() {
+		if err == nil && pid > 0 && requireServiceRunning(t, svc) {
 			require.NoError(t, svc.Stop())
 		}
 		_ = os.Remove(pidFile)
 	})
 
-	require.False(t, svc.Running())
+	require.False(t, requireServiceRunning(t, svc))
 	require.NoError(t, svc.Restart())
 
 	pid, err := svc.Pid()
 	require.NoError(t, err)
 	assert.Positive(t, pid)
-	assert.True(t, svc.Running())
+	assert.True(t, requireServiceRunning(t, svc))
 
 	require.FileExists(t, pidFile)
 }
@@ -321,7 +329,7 @@ func TestRestart_ReplacesRunningService(t *testing.T) {
 
 	t.Cleanup(func() {
 		pid, pidErr := svc.Pid()
-		if pidErr == nil && pid > 0 && svc.Running() {
+		if pidErr == nil && pid > 0 && requireServiceRunning(t, svc) {
 			require.NoError(t, svc.Stop())
 		}
 		_ = os.Remove(pidFile)
@@ -333,7 +341,7 @@ func TestRestart_ReplacesRunningService(t *testing.T) {
 	require.NoError(t, err)
 	assert.Positive(t, newPID)
 	assert.NotEqual(t, oldPID, newPID)
-	assert.True(t, svc.Running())
+	assert.True(t, requireServiceRunning(t, svc))
 
 	content, err := os.ReadFile(eventLog) //nolint:gosec // test-controlled file
 	require.NoError(t, err)
@@ -351,7 +359,7 @@ func TestStop_WaitsForProcessExitAndRemovesPIDFile(t *testing.T) {
 
 	require.NoError(t, svc.Stop())
 	assert.NoFileExists(t, pidFile)
-	assert.False(t, svc.Running())
+	assert.False(t, requireServiceRunning(t, svc))
 }
 
 func TestStopRemovesStalePIDFileWithoutKillingUnrelatedProcess(t *testing.T) {
@@ -381,7 +389,63 @@ func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
 	t.Cleanup(func() { _ = process.Process.Kill() })
 	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
 
-	assert.False(t, svc.Running())
+	running, runningErr := svc.Running()
+	assert.False(t, running)
+	require.Error(t, runningErr)
+	assert.Contains(t, runningErr.Error(), "does not match the Zaparoo service binary")
+	assert.True(t, pidRunning(process.Process.Pid))
+	assert.FileExists(t, pidFile)
+}
+
+func TestStartFailsForLiveUnrelatedPID(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	err := svc.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the Zaparoo service binary")
+	assert.True(t, pidRunning(process.Process.Pid))
+	assert.FileExists(t, pidFile)
+}
+
+func TestRestartFailsForLiveUnrelatedPID(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	err := svc.Restart()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the Zaparoo service binary")
+	assert.True(t, pidRunning(process.Process.Pid))
+	assert.FileExists(t, pidFile)
+}
+
+func TestWaitForAPIReturnsPIDConflict(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sleep", "1000")
+	require.NoError(t, process.Start())
+	t.Cleanup(func() { _ = process.Process.Kill() })
+	require.NoError(t, os.WriteFile(pidFile, []byte(strconv.Itoa(process.Process.Pid)), 0o600))
+
+	cfg, err := testhelpers.NewTestConfig(testhelpers.NewOSFS(), t.TempDir())
+	require.NoError(t, err)
+	err = svc.WaitForAPI(cfg, time.Nanosecond, time.Nanosecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match the Zaparoo service binary")
 	assert.True(t, pidRunning(process.Process.Pid))
 	assert.FileExists(t, pidFile)
 }
@@ -405,7 +469,7 @@ func TestRunningRemovesStalePIDFile(t *testing.T) {
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
 	require.NoError(t, os.WriteFile(pidFile, []byte("99999999"), 0o600))
 
-	assert.False(t, svc.Running())
+	assert.False(t, requireServiceRunning(t, svc))
 	assert.NoFileExists(t, pidFile)
 }
 

--- a/pkg/service/indexpause.go
+++ b/pkg/service/indexpause.go
@@ -66,6 +66,8 @@ func handleIndexPauseNotifications(
 	gameAlreadyActive bool,
 	isActive func() bool,
 ) {
+	defer pauser.Resume()
+
 	if gameAlreadyActive {
 		pauser.Pause()
 		log.Info().Msg("media indexing paused: game already active")
@@ -95,9 +97,6 @@ func handleIndexPauseNotifications(
 				}
 			}
 		case <-ctx.Done():
-			// Resume on shutdown so a paused indexer can see the context
-			// cancellation and exit cleanly.
-			pauser.Resume()
 			return
 		}
 	}

--- a/pkg/service/indexpause_test.go
+++ b/pkg/service/indexpause_test.go
@@ -159,6 +159,33 @@ func TestHandleIndexPauseNotifications_ExitsOnChannelClose(t *testing.T) {
 	}
 }
 
+func TestHandleIndexPauseNotifications_ResumesWhenPausedAndChannelCloses(t *testing.T) {
+	ch := make(chan models.Notification)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleIndexPauseNotifications(
+			context.Background(), ch, ns, pauser, true, alwaysActive,
+		)
+	}()
+
+	require.Eventually(t, pauser.IsPaused,
+		500*time.Millisecond, 10*time.Millisecond)
+	drainNotification(t, ns)
+
+	close(ch)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("handleIndexPauseNotifications did not exit on channel close")
+	}
+	assert.False(t, pauser.IsPaused())
+}
+
 func TestHandleIndexPauseNotifications_NoNotificationWhenNotIndexing(t *testing.T) {
 	ch := make(chan models.Notification, 1)
 	ns := make(chan models.Notification, 10)

--- a/pkg/service/playtime/limits.go
+++ b/pkg/service/playtime/limits.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -82,6 +83,7 @@ type LimitsManager struct {
 	clock                 clockwork.Clock
 	ctx                   context.Context
 	cooldownTimer         clockwork.Timer
+	done                  chan struct{}
 	warningsGiven         map[time.Duration]bool
 	db                    *database.Database
 	notificationsSend     chan<- models.Notification
@@ -92,10 +94,12 @@ type LimitsManager struct {
 	sessionResetTimeout   time.Duration
 	sessionCumulativeTime time.Duration
 	subscriptionID        int
+	wg                    sync.WaitGroup
 	mu                    syncutil.Mutex
 	enabledMu             syncutil.Mutex
 	sessionStartReliable  bool
 	enabled               bool
+	stopping              bool
 }
 
 // NewLimitsManager creates a new LimitsManager instance.
@@ -111,6 +115,8 @@ func NewLimitsManager(
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	close(done)
 
 	// Get session reset timeout from config
 	// 0 means disabled (session never resets)
@@ -126,6 +132,7 @@ func NewLimitsManager(
 		player:              player,
 		ctx:                 ctx,
 		cancel:              cancel,
+		done:                done,
 		warningsGiven:       make(map[time.Duration]bool),
 		sessionResetTimeout: sessionResetTimeout,
 		enabled:             false, // Start disabled, caller must enable
@@ -141,20 +148,38 @@ type Broker interface {
 // Start begins monitoring for time limit enforcement.
 // It subscribes to the broker to listen for media.started and media.stopped events.
 func (tm *LimitsManager) Start(broker Broker, notificationsSend chan<- models.Notification) {
+	done := make(chan struct{})
+
 	tm.mu.Lock()
 	tm.notificationsSend = notificationsSend
+	tm.done = done
+	tm.stopping = false
 	tm.mu.Unlock()
 
 	// Subscribe to broker for media.started and media.stopped events
 	notifChan, subID := broker.Subscribe(10)
 	tm.subscriptionID = subID
 
-	go tm.handleNotifications(notifChan, broker)
+	go func() {
+		defer close(done)
+		tm.handleNotifications(notifChan, broker)
+	}()
 }
 
 // Stop shuts down the LimitsManager.
 func (tm *LimitsManager) Stop() {
+	tm.mu.Lock()
+	tm.stopping = true
+	done := tm.done
+	tm.mu.Unlock()
+
 	tm.cancel()
+
+	if done != nil {
+		<-done
+	}
+
+	tm.wg.Wait()
 }
 
 // SetEnabled enables or disables limit enforcement at runtime.
@@ -254,6 +279,11 @@ func (tm *LimitsManager) OnMediaStarted() {
 	}
 
 	tm.mu.Lock()
+	if tm.stopping {
+		tm.mu.Unlock()
+		return
+	}
+
 	now := tm.clock.Now()
 
 	// Cancel cooldown timer if it exists
@@ -288,6 +318,7 @@ func (tm *LimitsManager) OnMediaStarted() {
 	tm.sessionStartMono = time.Now() // Monotonic clock for accurate duration
 	tm.sessionStartReliable = helpers.IsClockReliable(now)
 	tm.warningsGiven = make(map[time.Duration]bool)
+	tm.wg.Add(1)
 	tm.mu.Unlock()
 
 	if !tm.sessionStartReliable {
@@ -297,16 +328,19 @@ func (tm *LimitsManager) OnMediaStarted() {
 	}
 
 	// Start the check loop
-	go tm.checkLoop()
+	go func() {
+		defer tm.wg.Done()
+		tm.checkLoop()
+	}()
 }
 
 // OnMediaStopped handles media.stopped events and stops time tracking.
 func (tm *LimitsManager) OnMediaStopped() {
 	tm.mu.Lock()
-	defer tm.mu.Unlock()
 
-	if tm.state != StateActive {
+	if tm.stopping || tm.state != StateActive {
 		// Only stop if we're actually active
+		tm.mu.Unlock()
 		return
 	}
 
@@ -333,8 +367,17 @@ func (tm *LimitsManager) OnMediaStopped() {
 	// Start cooldown timer if timeout is configured
 	if tm.sessionResetTimeout > 0 {
 		tm.cooldownTimer = tm.clock.NewTimer(tm.sessionResetTimeout)
-		go tm.cooldownTimerLoop()
+		tm.wg.Add(1)
+		tm.mu.Unlock()
+
+		go func() {
+			defer tm.wg.Done()
+			tm.cooldownTimerLoop()
+		}()
+		return
 	}
+
+	tm.mu.Unlock()
 }
 
 // cooldownTimerLoop waits for the cooldown timer to expire and transitions to reset.
@@ -375,6 +418,9 @@ func (tm *LimitsManager) checkLoop() {
 	defer ticker.Stop()
 
 	// Immediate check
+	if tm.ctx.Err() != nil {
+		return
+	}
 	tm.checkLimits()
 
 	for {

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
@@ -33,10 +34,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type limitsStopTestBroker struct {
+	notifications chan models.Notification
+	unsubscribed  chan struct{}
+}
+
+func (b *limitsStopTestBroker) Subscribe(_ int) (notifications <-chan models.Notification, subscriptionID int) {
+	return b.notifications, 1
+}
+
+func (b *limitsStopTestBroker) Unsubscribe(_ int) {
+	close(b.unsubscribed)
+}
+
 func newNoOpMockPlayer() *mocks.MockPlayer {
 	p := mocks.NewMockPlayer()
 	p.SetupNoOpMock()
 	return p
+}
+
+func TestLimitsManagerStopWaitsForNotificationHandler(t *testing.T) {
+	t.Parallel()
+
+	broker := &limitsStopTestBroker{
+		notifications: make(chan models.Notification),
+		unsubscribed:  make(chan struct{}),
+	}
+	tm := NewLimitsManager(&database.Database{}, nil, &config.Instance{}, clockwork.NewFakeClock(), newNoOpMockPlayer())
+
+	tm.Start(broker, make(chan models.Notification, 1))
+	tm.Stop()
+
+	select {
+	case <-broker.unsubscribed:
+	default:
+		t.Fatal("expected Stop to wait for notification handler unsubscribe")
+	}
 }
 
 func TestIsClockReliable(t *testing.T) {

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -72,6 +72,28 @@ func TestLimitsManagerStopWaitsForNotificationHandler(t *testing.T) {
 	}
 }
 
+func TestLimitsManagerIgnoresMediaStartedAfterStop(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+	cfg.SetPlaytimeLimitsEnabled(true)
+	tm := NewLimitsManager(
+		&database.Database{}, nil, cfg, clockwork.NewFakeClockAt(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)),
+		newNoOpMockPlayer(),
+	)
+
+	tm.Stop()
+	tm.OnMediaStarted()
+
+	tm.mu.Lock()
+	state := tm.state
+	sessionStart := tm.sessionStart
+	tm.mu.Unlock()
+	assert.Equal(t, StateReset, state)
+	assert.True(t, sessionStart.IsZero())
+}
+
 func TestIsClockReliable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -23,29 +23,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	apimodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/fixtures"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type limitsStopTestBroker struct {
-	notifications chan models.Notification
-	unsubscribed  chan struct{}
-}
-
-func (b *limitsStopTestBroker) Subscribe(_ int) (notifications <-chan models.Notification, subscriptionID int) {
-	return b.notifications, 1
-}
-
-func (b *limitsStopTestBroker) Unsubscribe(_ int) {
-	close(b.unsubscribed)
-}
 
 func newNoOpMockPlayer() *mocks.MockPlayer {
 	p := mocks.NewMockPlayer()
@@ -56,17 +44,14 @@ func newNoOpMockPlayer() *mocks.MockPlayer {
 func TestLimitsManagerStopWaitsForNotificationHandler(t *testing.T) {
 	t.Parallel()
 
-	broker := &limitsStopTestBroker{
-		notifications: make(chan models.Notification),
-		unsubscribed:  make(chan struct{}),
-	}
+	broker := fixtures.NewStopNotificationBroker()
 	tm := NewLimitsManager(&database.Database{}, nil, &config.Instance{}, clockwork.NewFakeClock(), newNoOpMockPlayer())
 
-	tm.Start(broker, make(chan models.Notification, 1))
+	tm.Start(broker, make(chan apimodels.Notification, 1))
 	tm.Stop()
 
 	select {
-	case <-broker.unsubscribed:
+	case <-broker.Unsubscribed:
 	default:
 		t.Fatal("expected Stop to wait for notification handler unsubscribe")
 	}

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -101,6 +101,7 @@ func runTokenZapScript(
 		}
 
 		result, err := zapscript.RunCommand(
+			svc.State.GetContext(),
 			svc.Platform, svc.Config,
 			playlists.PlaylistController{
 				Active: pls,
@@ -229,7 +230,15 @@ func handlePlaylist(
 		svc.State.SetActivePlaylist(pls)
 		if pls.Playing {
 			log.Info().Any("pls", pls).Msg("setting new playlist, launching token")
-			go launchPlaylistMedia(svc, pls, activePlaylist, player)
+			if svc.BackgroundWG != nil {
+				svc.BackgroundWG.Add(1)
+			}
+			go func() {
+				if svc.BackgroundWG != nil {
+					defer svc.BackgroundWG.Done()
+				}
+				launchPlaylistMedia(svc, pls, activePlaylist, player)
+			}()
 		} else {
 			log.Info().Any("pls", pls).Msg("setting new playlist")
 		}
@@ -244,7 +253,15 @@ func handlePlaylist(
 		svc.State.SetActivePlaylist(pls)
 		if pls.Playing {
 			log.Info().Any("pls", pls).Msg("updating playlist, launching token")
-			go launchPlaylistMedia(svc, pls, activePlaylist, player)
+			if svc.BackgroundWG != nil {
+				svc.BackgroundWG.Add(1)
+			}
+			go func() {
+				if svc.BackgroundWG != nil {
+					defer svc.BackgroundWG.Done()
+				}
+				launchPlaylistMedia(svc, pls, activePlaylist, player)
+			}()
 		} else {
 			log.Info().Any("pls", pls).Msg("updating playlist")
 		}
@@ -345,7 +362,13 @@ func processTokenQueue(
 			}
 
 			// launch tokens in a separate thread
+			if svc.BackgroundWG != nil {
+				svc.BackgroundWG.Add(1)
+			}
 			go func() {
+				if svc.BackgroundWG != nil {
+					defer svc.BackgroundWG.Done()
+				}
 				defer func() {
 					if r := recover(); r != nil {
 						log.Error().Any("panic", r).Msg("recovered panic in token launch")

--- a/pkg/service/queues_playlist_test.go
+++ b/pkg/service/queues_playlist_test.go
@@ -95,6 +95,57 @@ func TestRunTokenZapScript_ClearsPlaylistOnMediaChange(t *testing.T) {
 	}
 }
 
+func TestRunTokenZapScript_ReturnsWhenPlaylistClearBlockedByShutdown(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	mockPlatform.On("LookupMapping", mock.Anything).Return("", false).Maybe()
+
+	cfg := &config.Instance{}
+	st, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() {
+		st.StopService()
+		for {
+			select {
+			case <-ns:
+			default:
+				return
+			}
+		}
+	})
+	mockPlatform.On("ReturnToMenu").Run(func(mock.Arguments) {
+		st.StopService()
+	}).Return(nil)
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockUserDB.On("GetEnabledMappings").Return([]database.Mapping{}, nil).Maybe()
+	mockUserDB.On("GetSupportedZapLinkHosts").Return([]string{}, nil).Maybe()
+	svc := &ServiceContext{
+		Platform:            mockPlatform,
+		Config:              cfg,
+		State:               st,
+		DB:                  &database.Database{UserDB: mockUserDB},
+		LaunchSoftwareQueue: make(chan *tokens.Token, 10),
+	}
+
+	plq := make(chan *playlists.Playlist)
+	plsc := playlists.PlaylistController{Queue: plq}
+	token := tokens.Token{
+		Text:     "**launch.system:menu",
+		ScanTime: time.Now(),
+	}
+
+	err := runTokenZapScript(svc, token, plsc, nil, false)
+
+	require.ErrorContains(t, err, "service shutting down")
+	select {
+	case pls := <-plq:
+		t.Fatalf("playlist queue should remain blocked during shutdown, got: %v", pls)
+	default:
+	}
+}
+
 func TestRunTokenZapScript_SkipsPlaylistClearForPlaylistSource(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -283,7 +283,11 @@ func timedExit(
 			log.Warn().Msgf("error killing launcher: %s", err)
 		}
 
-		svc.LaunchSoftwareQueue <- nil
+		select {
+		case svc.LaunchSoftwareQueue <- nil:
+		case <-svc.State.GetContext().Done():
+			return
+		}
 	}()
 
 	return exitTimer
@@ -336,7 +340,13 @@ func readerManager(
 	}
 
 	// manage reader connections
+	if svc.BackgroundWG != nil {
+		svc.BackgroundWG.Add(1)
+	}
 	go func() {
+		if svc.BackgroundWG != nil {
+			defer svc.BackgroundWG.Done()
+		}
 		log.Info().Msgf("reader manager started, auto-detect=%v", svc.Config.AutoDetect())
 		sleepMonitor := helpers.NewSleepWakeMonitor(5 * time.Second)
 		readerConnectAttempts := 0

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -128,9 +128,7 @@ func connectReaders(
 					DefaultAutoDetect: metadata.DefaultAutoDetect,
 				}
 
-				// For user-defined connect entries, driver is implicitly enabled
-				// unless explicitly disabled in config.
-				if !cfg.IsDriverEnabledForConnect(driver) {
+				if !cfg.IsReaderEnabled(driver, config.ReaderEnableContextManualConnect) {
 					if closeErr := r.Close(); closeErr != nil {
 						log.Debug().Err(closeErr).Msg("error closing unused reader")
 					}

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -23,13 +23,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -593,6 +596,77 @@ func TestTimedExitConditions_ReaderIDRequired(t *testing.T) {
 				tt.expectedReason, sourceIsReader, readerExists, hasRemovableCap)
 		})
 	}
+}
+
+func TestTimedExitReturnsWhenLaunchQueueBlockedAndContextCancelled(t *testing.T) {
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg.SetScanMode(config.ScanModeHold)
+	cfg.SetScanExitDelay(0.001)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{}).Maybe()
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+
+	readerID := "pn532-1234567890abcdef"
+	mockReader := mocks.NewMockReader()
+	mockReader.On("ReaderID").Return(readerID)
+	mockReader.On("Connected").Return(true)
+	mockReader.On("Path").Return("/dev/test")
+	mockReader.On("Info").Return("Test Reader")
+	mockReader.On("Metadata").Return(readers.DriverMetadata{
+		ID:          "mock-reader",
+		Description: "Mock Reader for Testing",
+	})
+	mockReader.On("Capabilities").Return([]readers.Capability{readers.CapabilityRemovable})
+	st.SetReader(mockReader)
+
+	st.SetActiveCard(tokens.Token{
+		UID:      "abc123",
+		Text:     "**launch.system:nes",
+		Source:   tokens.SourceReader,
+		ReaderID: readerID,
+		ScanTime: time.Now(),
+	})
+	st.SetSoftwareToken(&tokens.Token{Text: "NES/Super Mario Bros.nes"})
+	st.SetActiveMedia(models.NewActiveMedia("nes", "NES", "game.nes", "Game", "launcher"))
+
+	stopCalled := make(chan struct{})
+	mockPlatform.On("StopActiveLauncher", platforms.StopForMenu).
+		Run(func(_ mock.Arguments) {
+			st.StopService()
+			close(stopCalled)
+		}).
+		Return(nil).Once()
+
+	launchQueue := make(chan *tokens.Token)
+	svc := &ServiceContext{
+		Platform:            mockPlatform,
+		Config:              cfg,
+		State:               st,
+		LaunchSoftwareQueue: launchQueue,
+	}
+	clock := clockwork.NewFakeClock()
+
+	exitTimer := timedExit(svc, clock, nil)
+	require.NotNil(t, exitTimer)
+	clock.Advance(time.Millisecond)
+
+	select {
+	case <-stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timed exit did not reach launcher stop")
+	}
+
+	assert.Never(t, func() bool {
+		select {
+		case <-launchQueue:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond)
+	mockPlatform.AssertExpectations(t)
 }
 
 // TestReaderErrorRecovery_PrevTokenPreservation tests that prevToken is

--- a/pkg/service/scan_to_launch_bench_test.go
+++ b/pkg/service/scan_to_launch_bench_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
@@ -184,6 +185,7 @@ func BenchmarkScanToLaunch_ExactMatch(b *testing.B) {
 		// 3. Command execution (real RunCommand -> cmdTitle -> ResolveTitle -> mock launch)
 		for i, cmd := range script.Cmds {
 			_, err = zapscript.RunCommand(
+				context.Background(),
 				env.pl, env.cfg, playlists.PlaylistController{}, token, cmd,
 				len(script.Cmds), i, env.db, env.lm, &env.exprEnv,
 			)
@@ -225,6 +227,7 @@ func BenchmarkScanToLaunch_DirectPath(b *testing.B) {
 		// 3. Command execution (cmdLaunch with direct path)
 		for i, cmd := range script.Cmds {
 			_, err = zapscript.RunCommand(
+				context.Background(),
 				env.pl, env.cfg, playlists.PlaylistController{}, token, cmd,
 				len(script.Cmds), i, env.db, env.lm, &env.exprEnv,
 			)
@@ -278,6 +281,7 @@ func BenchmarkScanToLaunch_WithMapping(b *testing.B) {
 		// 3. Command execution
 		for i, cmd := range script.Cmds {
 			_, err = zapscript.RunCommand(
+				context.Background(),
 				env.pl, env.cfg, playlists.PlaylistController{}, token, cmd,
 				len(script.Cmds), i, env.db, env.lm, &env.exprEnv,
 			)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api"
@@ -131,6 +132,22 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	return db, nil
 }
 
+func closeDatabase(db *database.Database) {
+	if db == nil {
+		return
+	}
+	if db.UserDB != nil {
+		if err := db.UserDB.Close(); err != nil {
+			log.Warn().Err(err).Msg("error closing user database")
+		}
+	}
+	if db.MediaDB != nil {
+		if err := db.MediaDB.Close(); err != nil {
+			log.Warn().Err(err).Msg("error closing media database")
+		}
+	}
+}
+
 // cleanupHistoryOnStartup performs all history cleanup operations at service startup
 func cleanupHistoryOnStartup(cfg *config.Instance, db *database.Database) {
 	// Cleanup old scan history entries if retention is configured
@@ -223,6 +240,7 @@ func Start(
 	lsq := make(chan *tokens.Token)       // launch software queue
 	plq := make(chan *playlists.Playlist) // playlist event queue
 	cfq := make(chan chan error)          // launch guard confirm queue
+	backgroundWG := &sync.WaitGroup{}
 
 	err := setupEnvironment(pl)
 	if err != nil {
@@ -248,17 +266,10 @@ func Start(
 	cleanupHistoryOnStartup(cfg, db)
 
 	pruneExpiredZapLinkHosts(db)
-	go zapscript.PreWarmZapLinkHosts(db, helpers.WaitForInternet)
 
 	// Initialize inbox service for system notifications
 	log.Info().Msg("initializing inbox service")
 	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
-
-	go updater.CheckAndNotify(
-		st.GetContext(), cfg, pl.ID(), st.Inbox(),
-		helpers.WaitForInternet, updater.Check,
-		pl.ManagedByPackageManager(),
-	)
 
 	// Initialize playtime limits system (always create for runtime enable/disable)
 	log.Info().Msg("initializing playtime limits")
@@ -276,6 +287,7 @@ func Start(
 		LaunchSoftwareQueue: lsq,
 		PlaylistQueue:       plq,
 		ConfirmQueue:        cfq,
+		BackgroundWG:        backgroundWG,
 	}
 
 	// Set up the OnMediaStart hook
@@ -304,25 +316,68 @@ func Start(
 
 	// Create index pauser to pause media indexing while a game is running.
 	indexPauser := syncutil.NewPauser()
-	go watchGameForIndexPause(st.GetContext(), notifBroker, st, st.Notifications, indexPauser)
 
-	log.Info().Msg("checking for interrupted media indexing")
-	go checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
+	discoveryService := discovery.New(cfg)
 
-	log.Info().Msg("checking for interrupted media optimization")
-	go checkAndResumeOptimization(db, st.Notifications, indexPauser)
+	log.Info().Msg("starting API service")
+	apiReady := make(chan error, 1)
+	apiDone := make(chan error, 1)
+	go func() {
+		apiDone <- api.StartWithReady(
+			pl, cfg, st, itq, cfq, db, limitsManager,
+			notifBroker, discoveryService.InstanceName(), player, indexPauser,
+			apiReady,
+		)
+	}()
+
+	if apiErr := <-apiReady; apiErr != nil {
+		discoveryService.Stop()
+		if stopErr := pl.Stop(); stopErr != nil {
+			log.Warn().Msgf("error stopping platform after API startup failure: %s", stopErr)
+		}
+		if apiDoneErr := <-apiDone; apiDoneErr != nil {
+			log.Debug().Err(apiDoneErr).Msg("API service returned after startup failure")
+		}
+		limitsManager.Stop()
+		notifBroker.Stop()
+		closeDatabase(db)
+		return nil, fmt.Errorf("api startup failed: %w", apiErr)
+	}
 
 	log.Info().Msg("starting mDNS discovery service")
-	discoveryService := discovery.New(cfg)
 	if discoveryErr := discoveryService.Start(); discoveryErr != nil {
 		log.Warn().Err(discoveryErr).Msg("mDNS discovery initialization failed")
 	}
 
-	log.Info().Msg("starting API service")
-	go api.Start(
-		pl, cfg, st, itq, cfq, db, limitsManager,
-		notifBroker, discoveryService.InstanceName(), player, indexPauser,
-	)
+	backgroundWG.Add(1)
+	go func() {
+		defer backgroundWG.Done()
+		zapscript.PreWarmZapLinkHostsContext(st.GetContext(), db, helpers.WaitForInternetContext)
+	}()
+	backgroundWG.Add(1)
+	go func() {
+		defer backgroundWG.Done()
+		updater.CheckAndNotify(
+			st.GetContext(), cfg, pl.ID(), st.Inbox(),
+			helpers.WaitForInternetContext, updater.Check,
+			pl.ManagedByPackageManager(),
+		)
+	}()
+	go watchGameForIndexPause(st.GetContext(), notifBroker, st, st.Notifications, indexPauser)
+
+	log.Info().Msg("checking for interrupted media indexing")
+	backgroundWG.Add(1)
+	go func() {
+		defer backgroundWG.Done()
+		checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
+	}()
+
+	log.Info().Msg("checking for interrupted media optimization")
+	backgroundWG.Add(1)
+	go func() {
+		defer backgroundWG.Done()
+		checkAndResumeOptimization(db, st.Notifications, indexPauser)
+	}()
 
 	// Build slug search cache after API is listening to avoid blocking startup
 	if db.MediaDB != nil {
@@ -347,37 +402,54 @@ func Start(
 		clock: clockwork.NewRealClock(),
 	}
 	historyNotifications, _ := notifBroker.Subscribe(100)
-	go historyTracker.listen(historyNotifications)
+	historyListenDone := make(chan struct{})
+	go func() {
+		defer close(historyListenDone)
+		historyTracker.listen(historyNotifications)
+	}()
 	log.Info().Msg("starting media history PlayTime updater")
-	go historyTracker.updatePlayTime(st.GetContext())
+	historyUpdateDone := make(chan struct{})
+	go func() {
+		defer close(historyUpdateDone)
+		historyTracker.updatePlayTime(st.GetContext())
+	}()
 
 	// Start clock reliability monitor for timestamp healing (MiSTer NTP sync)
 	log.Info().Msg("starting clock reliability monitor")
-	go monitorClockAndHealTimestamps(st.GetContext(), db, bootUUID)
+	clockMonitorDone := make(chan struct{})
+	go func() {
+		defer close(clockMonitorDone)
+		monitorClockAndHealTimestamps(st.GetContext(), db, bootUUID)
+	}()
 
 	if cfg.GmcProxyEnabled() {
 		log.Info().Msg("starting GroovyMiSTer GMC Proxy service")
-		go groovyproxy.Start(cfg, st, itq)
+		backgroundWG.Add(1)
+		go func() {
+			defer backgroundWG.Done()
+			groovyproxy.Start(cfg, st, itq)
+		}()
 	}
 
 	log.Info().Msg("starting reader manager")
-	go readerManager(svc, itq, make(chan readers.Scan), player, nil)
+	readerManagerDone := make(chan struct{})
+	go func() {
+		defer close(readerManagerDone)
+		readerManager(svc, itq, make(chan readers.Scan), player, nil)
+	}()
 
 	log.Info().Msg("starting input token queue manager")
-	go processTokenQueue(svc, itq, limitsManager, player)
-
-	log.Info().Msg("running platform post start")
-	err = pl.StartPost(cfg, st.LauncherManager(), st.ActiveMedia, st.SetActiveMedia, db)
-	if err != nil {
-		log.Error().Err(err).Msg("platform post start error")
-		return nil, fmt.Errorf("platform start post failed: %w", err)
-	}
-	log.Info().Msg("platform post start completed, service fully initialized")
+	processTokenQueueDone := make(chan struct{})
+	go func() {
+		defer close(processTokenQueueDone)
+		processTokenQueue(svc, itq, limitsManager, player)
+	}()
 
 	doneCh := make(chan struct{})
 	go func() {
 		<-st.GetContext().Done()
 		log.Info().Msg("service context cancelled, running cleanup")
+		indexPauser.Resume()
 
 		discoveryService.Stop()
 		cancelPublisherFanOut()
@@ -387,15 +459,36 @@ func Start(
 		if stopErr := pl.Stop(); stopErr != nil {
 			log.Warn().Msgf("error stopping platform: %s", stopErr)
 		}
+		if apiErr := <-apiDone; apiErr != nil {
+			log.Error().Err(apiErr).Msg("API service stopped with error")
+		}
+		limitsManager.Stop()
 		notifBroker.Stop()
+		<-historyListenDone
+		<-historyUpdateDone
+		<-clockMonitorDone
+		<-processTokenQueueDone
+		<-readerManagerDone
+		backgroundWG.Wait()
 		close(plq)
 		close(lsq)
 		close(itq)
 		close(cfq)
+		closeDatabase(db)
 
 		log.Info().Msg("service cleanup completed")
 		close(doneCh)
 	}()
+
+	log.Info().Msg("running platform post start")
+	err = pl.StartPost(cfg, st.LauncherManager(), st.ActiveMedia, st.SetActiveMedia, db)
+	if err != nil {
+		log.Error().Err(err).Msg("platform post start error")
+		st.StopService()
+		<-doneCh
+		return nil, fmt.Errorf("platform start post failed: %w", err)
+	}
+	log.Info().Msg("platform post start completed, service fully initialized")
 
 	return &StartResult{
 		Stop: func() error {
@@ -763,7 +856,7 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 		status == mediadb.IndexingStatusRunning ||
 		status == mediadb.IndexingStatusFailed {
 		log.Info().Msgf("detected incomplete optimization (status: %s), automatically resuming", status)
-		go db.MediaDB.RunBackgroundOptimization(func(optimizing bool) {
+		db.MediaDB.RunBackgroundOptimization(func(optimizing bool) {
 			notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 				Exists:     true,
 				Indexing:   false,

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -20,6 +20,9 @@
 package service
 
 import (
+	"context"
+	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +31,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -35,6 +39,47 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestStartReturnsErrorWhenAPIPortIsOccupied(t *testing.T) {
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, listener.Close()) }()
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	testRoot := t.TempDir()
+	settings := platforms.Settings{
+		ConfigDir: testRoot,
+		DataDir:   testRoot,
+		LogDir:    testRoot,
+		TempDir:   testRoot,
+	}
+
+	cfg, err := testhelpers.NewTestConfigWithPort(nil, testRoot, tcpAddr.Port)
+	require.NoError(t, err)
+	cfg.SetAutoUpdate(false)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("mock-platform")
+	mockPlatform.On("Settings").Return(settings)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{testRoot})
+	mockPlatform.On("SupportedReaders", mock.AnythingOfType("*config.Instance")).Return([]readers.Reader{})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+	mockPlatform.On("ManagedByPackageManager").Return(false)
+	mockPlatform.On("StartPre", cfg).Return(nil)
+	mockPlatform.On("Stop").Return(nil).Maybe()
+
+	svcResult, err := Start(mockPlatform, cfg)
+	require.Nil(t, svcResult)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api startup failed")
+	assert.True(t, strings.Contains(err.Error(), "bind") || strings.Contains(err.Error(), "address already in use"))
+	mockPlatform.AssertNotCalled(
+		t, "StartPost", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
+	mockPlatform.AssertCalled(t, "Stop")
+}
 
 func TestCheckAndResumeIndexing_NoInterruption(t *testing.T) {
 	// Note: Not using t.Parallel() due to global statusInstance usage in GenerateMediaDB

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -138,7 +138,7 @@ func CheckAndNotify(
 	cfg *config.Instance,
 	platformID string,
 	inboxSvc *inbox.Service,
-	waitFn func(int) bool,
+	waitFn func(context.Context, int) bool,
 	checkFn CheckFn,
 	managedInstall bool,
 ) {
@@ -147,8 +147,11 @@ func CheckAndNotify(
 		return
 	}
 
-	if !waitFn(30) {
+	if !waitFn(ctx, 30) {
 		log.Warn().Msg("no internet connectivity, skipping update check")
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 
@@ -168,6 +171,9 @@ func CheckAndNotify(
 			Str("current", result.CurrentVersion).
 			Str("latest", result.LatestVersion).
 			Msg("no update available")
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -66,7 +66,7 @@ func TestApply_DevelopmentVersion(t *testing.T) {
 	}
 }
 
-func alwaysOnline(_ int) bool { return true }
+func alwaysOnline(_ context.Context, _ int) bool { return true }
 
 func TestCheckAndNotify_ManagedInstallDefaultsOff(t *testing.T) {
 	t.Parallel()
@@ -74,7 +74,7 @@ func TestCheckAndNotify_ManagedInstallDefaultsOff(t *testing.T) {
 	cfg := &config.Instance{} // AutoUpdate is nil
 
 	waitCalled := false
-	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ int) bool {
+	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ context.Context, _ int) bool {
 		waitCalled = true
 		return true
 	}, Check, true)
@@ -89,7 +89,7 @@ func TestCheckAndNotify_DisabledConfig(t *testing.T) {
 	cfg.SetAutoUpdate(false)
 
 	waitCalled := false
-	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ int) bool {
+	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ context.Context, _ int) bool {
 		waitCalled = true
 		return true
 	}, Check, false)
@@ -114,7 +114,7 @@ func TestCheckAndNotify_NoInternet(t *testing.T) {
 	cfg := &config.Instance{}
 	cfg.SetAutoUpdate(true)
 
-	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ int) bool {
+	CheckAndNotify(t.Context(), cfg, "linux", nil, func(_ context.Context, _ int) bool {
 		return false
 	}, Check, false)
 }

--- a/pkg/testing/fixtures/notification_broker.go
+++ b/pkg/testing/fixtures/notification_broker.go
@@ -1,0 +1,42 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package fixtures
+
+import "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+
+type StopNotificationBroker struct {
+	Notifications chan models.Notification
+	Unsubscribed  chan struct{}
+}
+
+func NewStopNotificationBroker() *StopNotificationBroker {
+	return &StopNotificationBroker{
+		Notifications: make(chan models.Notification),
+		Unsubscribed:  make(chan struct{}),
+	}
+}
+
+func (b *StopNotificationBroker) Subscribe(_ int) (notifications <-chan models.Notification, subscriptionID int) {
+	return b.Notifications, 1
+}
+
+func (b *StopNotificationBroker) Unsubscribe(_ int) {
+	close(b.Unsubscribed)
+}

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -22,6 +22,7 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package zapscript
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -291,7 +292,9 @@ func GetExprEnv(
 // RunCommand parses and runs a single ZapScript command.
 // The lm parameter is only needed for media-launching commands (launch guard);
 // pass nil for contexts where media launches are not allowed (e.g. control scripts).
+
 func RunCommand(
+	serviceCtx context.Context,
 	pl platforms.Platform,
 	cfg *config.Instance,
 	plsc playlists.PlaylistController,
@@ -364,6 +367,7 @@ func RunCommand(
 	env := platforms.CmdEnv{
 		Cmd:           cmd,
 		Cfg:           cfg,
+		ServiceCtx:    serviceCtx,
 		Playlist:      plsc,
 		Source:        token.Source,
 		TotalCommands: totalCmds,

--- a/pkg/zapscript/control.go
+++ b/pkg/zapscript/control.go
@@ -20,6 +20,7 @@
 package zapscript
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -102,6 +103,7 @@ func RunControlScript(
 
 	for i, cmd := range parsed.Cmds {
 		_, err := RunCommand(
+			context.Background(),
 			pl, cfg,
 			playlists.PlaylistController{},
 			token,

--- a/pkg/zapscript/control.go
+++ b/pkg/zapscript/control.go
@@ -68,12 +68,17 @@ func isControlAllowed(cmdName string) bool {
 // All commands are validated before any are executed to prevent partial execution.
 // The exprEnv is passed directly to each command instead of building from state.
 func RunControlScript(
+	ctx context.Context,
 	pl platforms.Platform,
 	cfg *config.Instance,
 	db *database.Database,
 	script string,
 	exprEnv *gozapscript.ArgExprEnv,
 ) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	parser := gozapscript.NewParser(script)
 	parsed, err := parser.ParseScript()
 	if err != nil {
@@ -102,8 +107,12 @@ func RunControlScript(
 	}
 
 	for i, cmd := range parsed.Cmds {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("control script canceled: %w", err)
+		}
+
 		_, err := RunCommand(
-			context.Background(),
+			ctx,
 			pl, cfg,
 			playlists.PlaylistController{},
 			token,

--- a/pkg/zapscript/control_cmd.go
+++ b/pkg/zapscript/control_cmd.go
@@ -102,7 +102,14 @@ func cmdControl(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 		}
 		err = control.Func(ctx, env.Cfg, platforms.ControlParams{Args: args})
 	case control.Script != "":
-		err = RunControlScript(pl, env.Cfg, env.Database, control.Script, env.ExprEnv)
+		ctx := env.ServiceCtx
+		if ctx == nil {
+			ctx = env.LauncherCtx
+		}
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		err = RunControlScript(ctx, pl, env.Cfg, env.Database, control.Script, env.ExprEnv)
 	default:
 		err = fmt.Errorf("control %q has no implementation", action)
 	}

--- a/pkg/zapscript/control_cmd_test.go
+++ b/pkg/zapscript/control_cmd_test.go
@@ -103,6 +103,39 @@ func TestCmdControl_SuccessWithScript(t *testing.T) {
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f2}")
 }
 
+func TestCmdControl_ScriptUsesServiceContext(t *testing.T) {
+	t.Parallel()
+
+	serviceCtx, cancelService := context.WithCancel(context.Background())
+	cancelService()
+	launcherCtx := context.Background()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test")
+	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+		{
+			ID: "test-launcher",
+			Controls: map[string]platforms.Control{
+				"save_state": {Script: "**input.keyboard:{f2}"},
+			},
+		},
+	})
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "control",
+			Args: []string{"save_state"},
+		},
+		ExprEnv:     newControlExprEnv("test-launcher"),
+		ServiceCtx:  serviceCtx,
+		LauncherCtx: launcherCtx,
+	}
+
+	_, err := cmdControl(mockPlatform, env)
+	require.ErrorIs(t, err, context.Canceled)
+	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
+}
+
 func TestCmdControl_ScriptExprEnvPropagation(t *testing.T) {
 	// Skipped: input macro commands (input.keyboard, input.gamepad) don't support
 	// expression evaluation in go-zapscript's parseInputMacroArg.

--- a/pkg/zapscript/control_test.go
+++ b/pkg/zapscript/control_test.go
@@ -56,7 +56,10 @@ func TestRunControlScript_MultiCommand(t *testing.T) {
 	cfg := &config.Instance{}
 	exprEnv := gozapscript.ArgExprEnv{Platform: "test"}
 
-	err := RunControlScript(context.Background(), mockPlatform, cfg, nil, "**input.keyboard:{f2}||**input.keyboard:{f5}", &exprEnv)
+	err := RunControlScript(
+		context.Background(), mockPlatform, cfg, nil,
+		"**input.keyboard:{f2}||**input.keyboard:{f5}", &exprEnv,
+	)
 	require.NoError(t, err)
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f2}")
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f5}")
@@ -106,7 +109,10 @@ func TestRunControlScript_RejectsBeforeExecuting(t *testing.T) {
 
 	// Valid command first, then a forbidden launch command.
 	// The valid command must NOT execute.
-	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**launch:/path/to/game", nil)
+	err := RunControlScript(
+		context.Background(), mockPlatform, &config.Instance{}, nil,
+		"**input.keyboard:{f2}||**launch:/path/to/game", nil,
+	)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
 }
@@ -117,7 +123,10 @@ func TestRunControlScript_RejectsPlaylistInMultiCommand(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
-	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**playlist.play", nil)
+	err := RunControlScript(
+		context.Background(), mockPlatform, &config.Instance{}, nil,
+		"**input.keyboard:{f2}||**playlist.play", nil,
+	)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
 }

--- a/pkg/zapscript/control_test.go
+++ b/pkg/zapscript/control_test.go
@@ -20,6 +20,7 @@
 package zapscript
 
 import (
+	"context"
 	"testing"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
@@ -39,7 +40,7 @@ func TestRunControlScript_SingleCommand(t *testing.T) {
 	cfg := &config.Instance{}
 	exprEnv := gozapscript.ArgExprEnv{Platform: "test"}
 
-	err := RunControlScript(mockPlatform, cfg, nil, "**input.keyboard:{f2}", &exprEnv)
+	err := RunControlScript(context.Background(), mockPlatform, cfg, nil, "**input.keyboard:{f2}", &exprEnv)
 	require.NoError(t, err)
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f2}")
 }
@@ -55,7 +56,7 @@ func TestRunControlScript_MultiCommand(t *testing.T) {
 	cfg := &config.Instance{}
 	exprEnv := gozapscript.ArgExprEnv{Platform: "test"}
 
-	err := RunControlScript(mockPlatform, cfg, nil, "**input.keyboard:{f2}||**input.keyboard:{f5}", &exprEnv)
+	err := RunControlScript(context.Background(), mockPlatform, cfg, nil, "**input.keyboard:{f2}||**input.keyboard:{f5}", &exprEnv)
 	require.NoError(t, err)
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f2}")
 	mockPlatform.AssertCalled(t, "KeyboardPress", "{f5}")
@@ -67,7 +68,7 @@ func TestRunControlScript_RejectsLaunchCommands(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
-	err := RunControlScript(mockPlatform, &config.Instance{}, nil, "**launch:/path/to/game", nil)
+	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**launch:/path/to/game", nil)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	assert.Contains(t, err.Error(), "launch")
 }
@@ -78,7 +79,7 @@ func TestRunControlScript_RejectsPlaylistCommands(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
-	err := RunControlScript(mockPlatform, &config.Instance{}, nil, "**playlist.play", nil)
+	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**playlist.play", nil)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	assert.Contains(t, err.Error(), "playlist.play")
 }
@@ -86,14 +87,14 @@ func TestRunControlScript_RejectsPlaylistCommands(t *testing.T) {
 func TestRunControlScript_EmptyScript(t *testing.T) {
 	t.Parallel()
 
-	err := RunControlScript(nil, &config.Instance{}, nil, "", nil)
+	err := RunControlScript(context.Background(), nil, &config.Instance{}, nil, "", nil)
 	require.Error(t, err)
 }
 
 func TestRunControlScript_InvalidSyntax(t *testing.T) {
 	t.Parallel()
 
-	err := RunControlScript(nil, &config.Instance{}, nil, "**", nil)
+	err := RunControlScript(context.Background(), nil, &config.Instance{}, nil, "**", nil)
 	require.Error(t, err)
 }
 
@@ -105,7 +106,7 @@ func TestRunControlScript_RejectsBeforeExecuting(t *testing.T) {
 
 	// Valid command first, then a forbidden launch command.
 	// The valid command must NOT execute.
-	err := RunControlScript(mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**launch:/path/to/game", nil)
+	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**launch:/path/to/game", nil)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
 }
@@ -116,7 +117,7 @@ func TestRunControlScript_RejectsPlaylistInMultiCommand(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
-	err := RunControlScript(mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**playlist.play", nil)
+	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}||**playlist.play", nil)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
 }
@@ -127,9 +128,23 @@ func TestRunControlScript_RejectsControlCommand(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 
-	err := RunControlScript(mockPlatform, &config.Instance{}, nil, "**control:toggle_pause", nil)
+	err := RunControlScript(context.Background(), mockPlatform, &config.Instance{}, nil, "**control:toggle_pause", nil)
 	require.ErrorIs(t, err, ErrControlCommandNotAllowed)
 	assert.Contains(t, err.Error(), "control")
+}
+
+func TestRunControlScript_StopsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := RunControlScript(ctx, mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}", nil)
+	require.ErrorIs(t, err, context.Canceled)
+	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
 }
 
 func TestIsControlCommand(t *testing.T) {

--- a/pkg/zapscript/control_test.go
+++ b/pkg/zapscript/control_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -154,6 +155,26 @@ func TestRunControlScript_StopsWhenContextCanceled(t *testing.T) {
 	err := RunControlScript(ctx, mockPlatform, &config.Instance{}, nil, "**input.keyboard:{f2}", nil)
 	require.ErrorIs(t, err, context.Canceled)
 	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f2}")
+}
+
+func TestRunControlScript_CancelsMidExecution(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mockPlatform.On("KeyboardPress", "{f2}").
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil)
+
+	err := RunControlScript(
+		ctx, mockPlatform, &config.Instance{}, nil,
+		"**input.keyboard:{f2}||**input.keyboard:{f3}", nil,
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	mockPlatform.AssertCalled(t, "KeyboardPress", "{f2}")
+	mockPlatform.AssertNotCalled(t, "KeyboardPress", "{f3}")
 }
 
 func TestIsControlCommand(t *testing.T) {

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -66,6 +66,32 @@ type ArgPlaylist struct {
 	Items []ArgPlaylistItem `json:"items"`
 }
 
+func queuePlaylistUpdate(env *platforms.CmdEnv, pls *playlists.Playlist) error {
+	if env.LauncherCtx == nil && env.ServiceCtx == nil {
+		env.Playlist.Queue <- pls
+		return nil
+	}
+
+	var launcherDone <-chan struct{}
+	if env.LauncherCtx != nil {
+		launcherDone = env.LauncherCtx.Done()
+	}
+
+	var serviceDone <-chan struct{}
+	if env.ServiceCtx != nil {
+		serviceDone = env.ServiceCtx.Done()
+	}
+
+	select {
+	case env.Playlist.Queue <- pls:
+		return nil
+	case <-launcherDone:
+		return env.LauncherCtx.Err()
+	case <-serviceDone:
+		return env.ServiceCtx.Err()
+	}
+}
+
 func readPlsFile(path string) ([]playlists.PlaylistItem, error) {
 	//nolint:gosec // Safe: reads playlist files for media management
 	content, err := os.ReadFile(path)
@@ -312,7 +338,9 @@ func cmdPlaylistPlay(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 		(len(env.Cmd.Args) == 0 || env.Cmd.Args[0] == "") {
 		log.Info().Msg("starting paused playlist")
 		pls := playlists.Play(*env.Playlist.Active)
-		env.Playlist.Queue <- pls
+		if err := queuePlaylistUpdate(&env, pls); err != nil {
+			return platforms.CmdResult{}, err
+		}
 		return platforms.CmdResult{
 			PlaylistChanged: true,
 			Playlist:        pls,
@@ -326,7 +354,9 @@ func cmdPlaylistPlay(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 
 	log.Info().Any("items", pls.Items).Msgf("play playlist: %v", env.Cmd.Args)
 	pls = playlists.Play(*pls)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	return platforms.CmdResult{
 		PlaylistChanged: true,
@@ -342,7 +372,9 @@ func cmdPlaylistLoad(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 	}
 
 	log.Info().Any("items", pls.Items).Msgf("load playlist: %s", env.Cmd.Args)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	return platforms.CmdResult{
 		PlaylistChanged: true,
@@ -413,7 +445,9 @@ func cmdPlaylistOpen(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 	}
 
 	log.Info().Any("items", pls.Items).Msgf("open playlist: %s", env.Cmd.Args)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	if err := pl.ShowPicker(env.Cfg, widgetmodels.PickerArgs{
 		Title:    pls.Name,
@@ -438,7 +472,9 @@ func cmdPlaylistNext(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdR
 	}
 
 	pls := playlists.Next(*env.Playlist.Active)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	return platforms.CmdResult{
 		PlaylistChanged: true,
@@ -453,7 +489,9 @@ func cmdPlaylistPrevious(_ platforms.Platform, env platforms.CmdEnv) (platforms.
 	}
 
 	pls := playlists.Previous(*env.Playlist.Active)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	return platforms.CmdResult{
 		PlaylistChanged: true,
@@ -484,7 +522,9 @@ func cmdPlaylistGoto(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdR
 	}
 
 	pls := playlists.Goto(*env.Playlist.Active, newIndex)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	return platforms.CmdResult{
 		PlaylistChanged: true,
@@ -498,7 +538,9 @@ func cmdPlaylistStop(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 		return platforms.CmdResult{}, errors.New("no playlist active")
 	}
 
-	env.Playlist.Queue <- nil
+	if err := queuePlaylistUpdate(&env, nil); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	if err := pl.StopActiveLauncher(platforms.StopForMenu); err != nil {
 		return platforms.CmdResult{
@@ -519,7 +561,9 @@ func cmdPlaylistPause(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cm
 	}
 
 	pls := playlists.Pause(*env.Playlist.Active)
-	env.Playlist.Queue <- pls
+	if err := queuePlaylistUpdate(&env, pls); err != nil {
+		return platforms.CmdResult{}, err
+	}
 
 	if err := pl.StopActiveLauncher(platforms.StopForMenu); err != nil {
 		return platforms.CmdResult{

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -20,6 +20,7 @@
 package zapscript
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,6 +41,42 @@ func newPlaylistTestPlatform() *mocks.MockPlatform {
 	mp := mocks.NewMockPlatform()
 	mp.On("Launchers", mock.Anything).Return([]platforms.Launcher{}).Maybe()
 	return mp
+}
+
+func TestQueuePlaylistUpdateReturnsWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	env := platforms.CmdEnv{
+		LauncherCtx: ctx,
+		Playlist: playlists.PlaylistController{
+			Queue: make(chan *playlists.Playlist),
+		},
+	}
+
+	err := queuePlaylistUpdate(&env, &playlists.Playlist{})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueuePlaylistUpdateReturnsWhenServiceContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	env := platforms.CmdEnv{
+		ServiceCtx: ctx,
+		Playlist: playlists.PlaylistController{
+			Queue: make(chan *playlists.Playlist),
+		},
+	}
+
+	err := queuePlaylistUpdate(&env, &playlists.Playlist{})
+
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestReadPlsFile(t *testing.T) {

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -384,8 +384,21 @@ func checkZapLink(
 // This is called during startup to reduce latency on first zaplink access.
 // It makes HEAD requests to /.well-known/zaparoo for each supported base URL.
 func PreWarmZapLinkHosts(db *database.Database, checkInternet func(int) bool) {
-	if !checkInternet(3) {
+	PreWarmZapLinkHostsContext(context.Background(), db, func(_ context.Context, maxTries int) bool {
+		return checkInternet(maxTries)
+	})
+}
+
+func PreWarmZapLinkHostsContext(
+	ctx context.Context,
+	db *database.Database,
+	checkInternet func(context.Context, int) bool,
+) {
+	if !checkInternet(ctx, 3) {
 		log.Debug().Msg("no internet connectivity, skipping zaplink pre-warming")
+		return
+	}
+	if ctx.Err() != nil {
 		return
 	}
 
@@ -409,10 +422,14 @@ func PreWarmZapLinkHosts(db *database.Database, checkInternet func(int) bool) {
 		wg.Add(1)
 		go func(u string) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 
-			preWarmHost(u, db, currentZapFetchClient())
+			preWarmHost(ctx, u, db, currentZapFetchClient())
 		}(baseURL)
 	}
 
@@ -421,10 +438,10 @@ func PreWarmZapLinkHosts(db *database.Database, checkInternet func(int) bool) {
 }
 
 // preWarmHost makes a HEAD request to a base URL's well-known endpoint to warm caches.
-func preWarmHost(baseURL string, db *database.Database, client httpDoer) {
+func preWarmHost(ctx context.Context, baseURL string, db *database.Database, client httpDoer) {
 	wellKnownURL := baseURL + WellKnownPath
 
-	ctx, cancel := context.WithTimeout(context.Background(), preWarmTimeout)
+	ctx, cancel := context.WithTimeout(ctx, preWarmTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, wellKnownURL, http.NoBody)
@@ -445,6 +462,9 @@ func preWarmHost(baseURL string, db *database.Database, client httpDoer) {
 	}()
 
 	if resp.StatusCode == http.StatusOK {
+		if ctx.Err() != nil {
+			return
+		}
 		u, parseErr := url.Parse(wellKnownURL)
 		if parseErr != nil {
 			return

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -242,6 +242,27 @@ func TestPreWarmZapLinkHosts_NoInternet(t *testing.T) {
 	mockUserDB.AssertNotCalled(t, "GetSupportedZapLinkHosts")
 }
 
+func TestPreWarmZapLinkHostsContext_CancelledAfterConnectivityCheckSkipsDatabase(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	db := &database.Database{
+		UserDB:  mockUserDB,
+		MediaDB: mockMediaDB,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	checkInternet := func(_ context.Context, _ int) bool {
+		cancel()
+		return true
+	}
+
+	PreWarmZapLinkHostsContext(ctx, db, checkInternet)
+
+	mockUserDB.AssertNotCalled(t, "GetSupportedZapLinkHosts")
+}
+
 func TestPreWarmZapLinkHosts_EmptyHosts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -292,7 +292,7 @@ func TestPreWarmHost_HTTPError(t *testing.T) {
 	mockClient.On("Do", mock.Anything).Return(nil, errors.New("connection refused"))
 
 	// Should handle error gracefully without panicking
-	preWarmHost("https://example.com", db, mockClient)
+	preWarmHost(t.Context(), "https://example.com", db, mockClient)
 
 	mockClient.AssertExpectations(t)
 	mockUserDB.AssertNotCalled(t, "UpdateZapLinkHost")
@@ -315,7 +315,7 @@ func TestPreWarmHost_NonOKStatus(t *testing.T) {
 	}
 	mockClient.On("Do", mock.Anything).Return(resp, nil)
 
-	preWarmHost("https://example.com", db, mockClient)
+	preWarmHost(t.Context(), "https://example.com", db, mockClient)
 
 	mockClient.AssertExpectations(t)
 	// UpdateZapLinkHost should not be called for non-OK status
@@ -362,7 +362,7 @@ func TestPreWarmHost_Success(t *testing.T) {
 	// Expect UpdateZapLinkHost to be called on success
 	mockUserDB.On("UpdateZapLinkHost", server.URL, 1).Return(nil)
 
-	preWarmHost(server.URL, db, server.Client())
+	preWarmHost(t.Context(), server.URL, db, server.Client())
 
 	assert.True(t, headRequestReceived, "HEAD request should have been made")
 	mockUserDB.AssertExpectations(t)
@@ -387,7 +387,7 @@ func TestPreWarmHost_DoesNotSendHeaders(t *testing.T) {
 		MediaDB: mockMediaDB,
 	}
 
-	preWarmHost("https://example.com", db, mockClient)
+	preWarmHost(t.Context(), "https://example.com", db, mockClient)
 
 	require.NotNil(t, capturedReq)
 	assert.Equal(t, http.MethodHead, capturedReq.Method)


### PR DESCRIPTION
## Summary
- Add UDisks2/inotify external drive mount detection and centralize reader enablement so configured default-disabled readers can start reliably.
- Harden service startup, cleanup, daemon lifecycle, and queue/background goroutine cancellation to avoid stale listeners and DB-after-close races.
- Update PN532 detection to go-pn532 v0.22.1 and keep broad auto-detect on UART-only transports to avoid unsafe desktop I2C probing.
- Move fuzz CI to the free GitHub runner and fix Windows/lint regressions found while validating the branch.

## Verification
- `go test -count=1 ./pkg/service ./pkg/api ./pkg/cli ./pkg/service/daemon ./pkg/service/updater ./pkg/zapscript ./pkg/groovyproxy ./pkg/readers/pn532 ./cmd/...`
- `go test ./pkg/helpers ./internal/telemetry ./pkg/database/mediascanner`
- `go test -race ./internal/telemetry`
- `go test -race ./pkg/database/mediascanner`
- `golangci-lint run --fix`
- `actionlint .github/workflows/fuzz.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Linux external-drive mount detection with duplicate suppression and stale-state cleanup
  * Hardened service lifecycle and PID handling with safer staged shutdowns and API-port release waits
  * Prevents blocking in HTTP/REST handlers and internal queues; safer background shutdown sequencing

* **New Features**
  * Centralized reader enablement gate with candidate/manual/auto-detect contexts
  * Explicit logging shutdown to reliably release log files
  * Command and playlist operations now respect service cancellation contexts

* **Tests**
  * Expanded coverage across mount detection, daemon lifecycle, reader enablement, logging, shutdown, and context-cancellation paths

* **Documentation**
  * Added contributor rule on declaration ordering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->