### PR TITLE
fix: publish signed update manifests and restore native CI coverage

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -107,11 +107,6 @@ jobs:
           packages: libnfc-dev libgtk-3-dev libx11-dev libpcsclite-dev libasound2-dev
           version: 1.1
 
-      - name: Install dependencies (macOS)
-        if: matrix.os == 'macos'
-        run: |
-          brew install libusb pkg-config
-
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -335,11 +330,6 @@ jobs:
       - name: Download Go modules (non-Windows)
         if: matrix.os != 'windows'
         run: go mod download
-
-      - name: Install dependencies (macOS)
-        if: matrix.os == 'macos'
-        run: |
-          brew install libusb pkg-config
 
       - name: Run native tests (Windows)
         if: matrix.os == 'windows'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -58,6 +58,15 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
           Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
 
+      - name: Set up MSYS2 (Windows)
+        if: matrix.os == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: pkgconf
+          path-type: inherit
+
       - name: Restore Go cache (Unix)
         if: matrix.os != 'windows'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -82,7 +91,13 @@ jobs:
             ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
             ${{ runner.os }}-go-
 
-      - name: Download Go modules
+      - name: Download Go modules (Windows)
+        if: matrix.os == 'windows'
+        shell: msys2 {0}
+        run: go mod download
+
+      - name: Download Go modules (non-Windows)
+        if: matrix.os != 'windows'
         run: go mod download
 
       - name: Cache APT packages (Ubuntu)
@@ -96,22 +111,6 @@ jobs:
         if: matrix.os == 'macos'
         run: |
           brew install libusb pkg-config
-
-      - name: Cache scoop packages (Windows)
-        if: matrix.os == 'windows'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~\scoop
-          key: ${{ runner.os }}-scoop-pkg-config
-
-      - name: Install dependencies (Windows)
-        if: matrix.os == 'windows'
-        shell: pwsh
-        run: |
-          if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
-            irm get.scoop.sh | iex
-          }
-          scoop install pkg-config
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
@@ -141,7 +140,7 @@ jobs:
 
       - name: Run full tests (Windows)
         if: matrix.os == 'windows'
-        shell: bash
+        shell: msys2 {0}
         env:
           GOMAXPROCS: 2
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
@@ -295,6 +294,15 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
           Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
 
+      - name: Set up MSYS2 (Windows)
+        if: matrix.os == 'windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: pkgconf
+          path-type: inherit
+
       - name: Restore Go cache (macOS)
         if: matrix.os == 'macos'
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -319,7 +327,13 @@ jobs:
             ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
             ${{ runner.os }}-go-
 
-      - name: Download Go modules
+      - name: Download Go modules (Windows)
+        if: matrix.os == 'windows'
+        shell: msys2 {0}
+        run: go mod download
+
+      - name: Download Go modules (non-Windows)
+        if: matrix.os != 'windows'
         run: go mod download
 
       - name: Install dependencies (macOS)
@@ -327,25 +341,9 @@ jobs:
         run: |
           brew install libusb pkg-config
 
-      - name: Cache scoop packages (Windows)
-        if: matrix.os == 'windows'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~\scoop
-          key: ${{ runner.os }}-scoop-pkg-config
-
-      - name: Install dependencies (Windows)
-        if: matrix.os == 'windows'
-        shell: pwsh
-        run: |
-          if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
-            irm get.scoop.sh | iex
-          }
-          scoop install pkg-config
-
       - name: Run native tests (Windows)
         if: matrix.os == 'windows'
-        shell: bash
+        shell: msys2 {0}
         env:
           GOMAXPROCS: 2
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -260,10 +260,130 @@ jobs:
             ${{ env.ZIGCC_IMAGE }} \
             bash -c 'curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b /home/build/bin 2>&1 | tail -1 && PATH="/home/build/bin:$PATH" golangci-lint run --timeout=5m'
 
+  native-pr-tests:
+    name: Native PR Tests
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 12
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: macos-latest
+          - os: windows
+            runner: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Configure Go paths for Windows
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "D:\go-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-mod-cache" | Out-Null
+          New-Item -ItemType Directory -Force -Path "D:\go-tmp" | Out-Null
+          Add-Content -Path $env:GITHUB_ENV -Value "GOCACHE=D:\go-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOMODCACHE=D:\go-mod-cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "GOTMPDIR=D:\go-tmp"
+
+      - name: Restore Go cache (macOS)
+        if: matrix.os == 'macos'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: no-match-${{ runner.os }}-native-pr
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
+            ${{ runner.os }}-go-
+
+      - name: Restore Go cache (Windows)
+        if: matrix.os == 'windows'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            D:\go-mod-cache
+            D:\go-cache
+          key: no-match-${{ runner.os }}-native-pr
+          restore-keys: |
+            ${{ runner.os }}-go-${{ hashFiles('go.mod') }}-
+            ${{ runner.os }}-go-
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          brew install libusb pkg-config
+
+      - name: Cache scoop packages (Windows)
+        if: matrix.os == 'windows'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~\scoop
+          key: ${{ runner.os }}-scoop-pkg-config
+
+      - name: Install dependencies (Windows)
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          if (-not (Get-Command scoop -ErrorAction SilentlyContinue)) {
+            irm get.scoop.sh | iex
+          }
+          scoop install pkg-config
+
+      - name: Run native tests (Windows)
+        if: matrix.os == 'windows'
+        shell: bash
+        env:
+          GOMAXPROCS: 2
+        run: |
+          go test -v -race \
+            ./pkg/api \
+            ./pkg/helpers \
+            ./pkg/helpers/command \
+            ./pkg/readers/externaldrive \
+            ./pkg/platforms/shared/steam \
+            ./pkg/platforms/shared/steam/steamtracker \
+            ./pkg/service/restart \
+            ./pkg/ui/systray
+
+      - name: Run native tests (macOS)
+        if: matrix.os == 'macos'
+        run: |
+          go test -v -race \
+            ./pkg/api \
+            ./pkg/helpers \
+            ./pkg/helpers/command \
+            ./pkg/readers/externaldrive \
+            ./pkg/platforms/shared/steam \
+            ./pkg/platforms/shared/steam/steamtracker \
+            ./pkg/service/restart \
+            ./pkg/ui/systray
+
+      - name: Upload rapid failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rapid-failures-native-${{ matrix.os }}
+          path: '**/testdata/rapid/**/*.fail'
+          if-no-files-found: ignore
+
   ci-status:
     name: CI Status
     if: always() && !cancelled()
-    needs: [ci, cross-lint]
+    needs: [ci, cross-lint, native-pr-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -275,6 +395,11 @@ jobs:
           CROSS_RESULT="${{ needs.cross-lint.result }}"
           if [ "$CROSS_RESULT" != "success" ] && [ "$CROSS_RESULT" != "skipped" ]; then
             echo "CI failed: cross-lint=$CROSS_RESULT"
+            exit 1
+          fi
+          NATIVE_RESULT="${{ needs.native-pr-tests.result }}"
+          if [ "$NATIVE_RESULT" != "success" ] && [ "$NATIVE_RESULT" != "skipped" ]; then
+            echo "CI failed: native-pr-tests=$NATIVE_RESULT"
             exit 1
           fi
           echo "CI passed"

--- a/.github/workflows/publish-update-manifest.yml
+++ b/.github/workflows/publish-update-manifest.yml
@@ -7,82 +7,15 @@ permissions:
   contents: read
 
 jobs:
-  publish-stable:
-    # Publish manifest for stable releases (no pre-releases like v2.10.0-rc3)
-    if: ${{ !github.event.release.prerelease }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    name: Publish stable update manifest to CDN
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: |
-            scripts/generate-update-manifest/
-            go.mod
-            go.sum
-          sparse-checkout-cone-mode: false
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          cache: false
-      - name: Download release assets
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p _assets
-          gh release download "${{ github.event.release.tag_name }}" --dir _assets \
-            --pattern "zaparoo-*.tar.gz" \
-            --pattern "zaparoo-*.zip"
-      - name: Generate and sign checksums
-        env:
-          UPDATE_SIGNING_KEY: ${{ secrets.UPDATE_SIGNING_KEY }}
-        run: |
-          if ! ls _assets/zaparoo-* >/dev/null 2>&1; then
-            echo "No release assets found" >&2; exit 1
-          fi
-          if [ -z "$UPDATE_SIGNING_KEY" ]; then
-            echo "UPDATE_SIGNING_KEY secret is not configured" >&2; exit 1
-          fi
-          cd _assets && sha256sum zaparoo-* > checksums.txt && cd ..
-          install -m 600 /dev/stdin /tmp/signing.pem <<< "$UPDATE_SIGNING_KEY"
-          openssl pkeyutl -sign -inkey /tmp/signing.pem -rawin \
-            -in _assets/checksums.txt > _assets/checksums.txt.sig
-          rm /tmp/signing.pem
-      - name: Generate manifest
-        env:
-          RELEASE_NOTES: ${{ github.event.release.body }}
-        run: |
-          go run scripts/generate-update-manifest/main.go \
-            --version "${{ github.event.release.tag_name }}" \
-            --assets-dir _assets \
-            --release-notes "$RELEASE_NOTES" \
-            --output _manifest/manifest.yaml
-          cp _assets/checksums.txt _manifest/checksums.txt
-          cp _assets/checksums.txt.sig _manifest/checksums.txt.sig
-      - name: Upload manifest to Bunny.net storage
-        uses: R-J-dev/bunny-deploy@ae25fa670b732ffc8dba84c872fb203d2a365229 # v3.0.0
-        with:
-          storage-zone-password: ${{ secrets.BUNNY_STORAGE_ZONE_PASSWORD }}
-          storage-endpoint: "https://storage.bunnycdn.com"
-          storage-zone-name: ${{ secrets.BUNNY_STORAGE_ZONE }}
-          directory-to-upload: "_manifest"
-          target-directory: "ZaparooProject/zaparoo-core"
-          concurrency: "10"
-          access-key: ${{ secrets.BUNNY_API_KEY }}
-          pull-zone-id: ${{ secrets.BUNNY_PULL_ZONE_ID }}
-          enable-purge-pull-zone: true
-          replication-timeout: "15000"
-
-  publish-beta:
-    # Publish manifest for pre-releases (beta, rc, alpha) but not nightlies
-    if: ${{ github.event.release.prerelease && !contains(github.event.release.tag_name, 'nightly') }}
+  publish-update-manifest:
+    # Publish manifests for stable releases and non-nightly pre-releases.
+    if: ${{ !github.event.release.prerelease || !contains(github.event.release.tag_name, 'nightly') }}
     concurrency:
       group: publish-update-manifest
       cancel-in-progress: false
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    name: Publish beta update manifest to CDN
+    name: Publish update manifest to CDN
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -92,83 +25,140 @@ jobs:
             go.mod
             go.sum
           sparse-checkout-cone-mode: false
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
-      - name: Download existing manifest from CDN
-        run: |
-          mkdir -p _existing
-          # Download existing manifest, checksums, and signature (may not exist yet)
-          curl -sf "https://updates.zaparoo.org/ZaparooProject/zaparoo-core/manifest.yaml" \
-            -o _existing/manifest.yaml || true
-          curl -sf "https://updates.zaparoo.org/ZaparooProject/zaparoo-core/checksums.txt" \
-            -o _existing/checksums.txt || true
-          curl -sf "https://updates.zaparoo.org/ZaparooProject/zaparoo-core/checksums.txt.sig" \
-            -o _existing/checksums.txt.sig || true
-      - name: Download release assets
+
+      - name: Fetch release metadata
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p _assets
-          gh release download "${{ github.event.release.tag_name }}" --dir _assets \
-            --pattern "zaparoo-*.tar.gz" \
-            --pattern "zaparoo-*.zip"
-      - name: Generate checksums, merge with existing, and sign
+          set -euo pipefail
+          mkdir -p _release
+          gh release view "${{ github.event.release.tag_name }}" \
+            --json assets,tagName,url,publishedAt \
+            > _release/release.json
+
+      - name: Download and verify existing metadata
         env:
-          UPDATE_SIGNING_KEY: ${{ secrets.UPDATE_SIGNING_KEY }}
+          ALLOW_BOOTSTRAP_MANIFEST: ${{ vars.ALLOW_BOOTSTRAP_UPDATE_MANIFEST }}
         run: |
-          if ! ls _assets/zaparoo-* >/dev/null 2>&1; then
-            echo "No release assets found" >&2; exit 1
+          set -euo pipefail
+          mkdir -p _existing
+          base_url="https://updates.zaparoo.org/ZaparooProject/zaparoo-core"
+
+          if curl -fsS "$base_url/manifest.yaml" -o _existing/manifest.yaml && \
+             curl -fsS "$base_url/checksums.txt" -o _existing/checksums.txt && \
+             curl -fsS "$base_url/checksums.txt.sig" -o _existing/checksums.txt.sig; then
+            touch _existing/metadata-present
+          elif [ "${ALLOW_BOOTSTRAP_MANIFEST:-false}" = "true" ]; then
+            echo "Existing update metadata missing; bootstrapping because ALLOW_BOOTSTRAP_UPDATE_MANIFEST=true"
+          else
+            echo "Existing update metadata is missing or incomplete; refusing to replace it" >&2
+            exit 1
           fi
-          if [ -z "$UPDATE_SIGNING_KEY" ]; then
-            echo "UPDATE_SIGNING_KEY secret is not configured" >&2; exit 1
-          fi
-          cd _assets && sha256sum zaparoo-* > checksums.txt && cd ..
-          # Merge with existing checksums only after verifying their signature
-          if [ -f _existing/checksums.txt ] && [ -f _existing/checksums.txt.sig ]; then
-            # Convert embedded ed25519 public key to PEM for OpenSSL
-            RAW_PUB=$(tr -d '[:space:]' < pkg/service/updater/update_signing.pub)
+
+          if [ -f _existing/metadata-present ]; then
+            raw_pub=$(tr -d '[:space:]' < pkg/service/updater/update_signing.pub)
             {
               echo "-----BEGIN PUBLIC KEY-----"
-              (echo -n 'MCowBQYDK2VwAyEA' | base64 -d; echo -n "$RAW_PUB" | base64 -d) | base64 | fold -w 64
+              (echo -n 'MCowBQYDK2VwAyEA' | base64 -d; echo -n "$raw_pub" | base64 -d) | base64 | fold -w 64
               echo "-----END PUBLIC KEY-----"
             } > /tmp/verify.pem
-            if openssl pkeyutl -verify -pubin -inkey /tmp/verify.pem -rawin \
-                 -in _existing/checksums.txt -sigfile _existing/checksums.txt.sig; then
-              echo "Existing checksums signature verified, merging"
-              cat _assets/checksums.txt _existing/checksums.txt \
-                | awk '{ key=$2 } !seen[key]++ { print }' > _merged_checksums.txt
-              mv _merged_checksums.txt _assets/checksums.txt
-            else
-              echo "WARNING: Existing checksums signature verification failed, skipping merge" >&2
-            fi
+            openssl pkeyutl -verify -pubin -inkey /tmp/verify.pem -rawin \
+              -in _existing/checksums.txt -sigfile _existing/checksums.txt.sig
             rm -f /tmp/verify.pem
-          elif [ -f _existing/checksums.txt ]; then
-            echo "WARNING: Existing checksums found without signature, skipping merge" >&2
           fi
-          install -m 600 /dev/stdin /tmp/signing.pem <<< "$UPDATE_SIGNING_KEY"
-          openssl pkeyutl -sign -inkey /tmp/signing.pem -rawin \
-            -in _assets/checksums.txt > _assets/checksums.txt.sig
-          rm /tmp/signing.pem
-      - name: Generate manifest
+
+      - name: Generate and sign metadata
         env:
           RELEASE_NOTES: ${{ github.event.release.body }}
+          UPDATE_SIGNING_KEY: ${{ secrets.UPDATE_SIGNING_KEY }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          MERGE_FLAG=()
-          if [ -f _existing/manifest.yaml ]; then
-            MERGE_FLAG=(--merge _existing/manifest.yaml)
+          set -euo pipefail
+          if [ -z "$UPDATE_SIGNING_KEY" ]; then
+            echo "UPDATE_SIGNING_KEY secret is not configured" >&2
+            exit 1
           fi
+
+          mkdir -p _manifest _work
+          selected_count=$(jq '[.assets[] | select((.name | startswith("zaparoo-")) and ((.name | endswith(".tar.gz")) or (.name | endswith(".zip"))))] | length' _release/release.json)
+          digest_count=$(jq '[.assets[] | select((.name | startswith("zaparoo-")) and ((.name | endswith(".tar.gz")) or (.name | endswith(".zip")))) | select((.digest // "") | startswith("sha256:"))] | length' _release/release.json)
+          if [ "$selected_count" -eq 0 ]; then
+            echo "No update release assets found" >&2
+            exit 1
+          fi
+          if [ "$selected_count" -ne "$digest_count" ]; then
+            echo "One or more update release assets are missing sha256 digests" >&2
+            exit 1
+          fi
+
+          jq -r '.assets[]
+            | select((.name | startswith("zaparoo-")) and ((.name | endswith(".tar.gz")) or (.name | endswith(".zip"))))
+            | "\(.digest | sub("^sha256:"; ""))  \(.name)"' \
+            _release/release.json > _work/new-checksums.txt
+
+          if [ -f _existing/metadata-present ]; then
+            cat _work/new-checksums.txt _existing/checksums.txt \
+              | awk '{ key=$2 } !seen[key]++ { print }' > _manifest/checksums.txt
+          else
+            cp _work/new-checksums.txt _manifest/checksums.txt
+          fi
+
+          install -m 600 /dev/stdin /tmp/signing.pem <<< "$UPDATE_SIGNING_KEY"
+          openssl pkeyutl -sign -inkey /tmp/signing.pem -rawin \
+            -in _manifest/checksums.txt > _manifest/checksums.txt.sig
+          rm /tmp/signing.pem
+
+          raw_pub=$(tr -d '[:space:]' < pkg/service/updater/update_signing.pub)
+          {
+            echo "-----BEGIN PUBLIC KEY-----"
+            (echo -n 'MCowBQYDK2VwAyEA' | base64 -d; echo -n "$raw_pub" | base64 -d) | base64 | fold -w 64
+            echo "-----END PUBLIC KEY-----"
+          } > /tmp/verify.pem
+          openssl pkeyutl -verify -pubin -inkey /tmp/verify.pem -rawin \
+            -in _manifest/checksums.txt -sigfile _manifest/checksums.txt.sig
+          rm -f /tmp/verify.pem
+
+          merge_flag=()
+          if [ -f _existing/metadata-present ]; then
+            merge_flag=(--merge _existing/manifest.yaml)
+          fi
+          prerelease_flag=()
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            prerelease_flag=(--prerelease)
+          fi
+
           go run scripts/generate-update-manifest/main.go \
             --version "${{ github.event.release.tag_name }}" \
-            --assets-dir _assets \
+            --github-release _release/release.json \
+            --metadata-dir _manifest \
             --release-notes "$RELEASE_NOTES" \
-            --prerelease \
-            "${MERGE_FLAG[@]}" \
+            "${prerelease_flag[@]}" \
+            "${merge_flag[@]}" \
             --output _manifest/manifest.yaml
-          cp _assets/checksums.txt _manifest/checksums.txt
-          cp _assets/checksums.txt.sig _manifest/checksums.txt.sig
+
+      - name: Validate publish directory
+        run: |
+          set -euo pipefail
+          files=$(find _manifest -maxdepth 1 -type f -printf '%f\n' | sort | paste -sd ',' -)
+          if [ "$files" != "checksums.txt,checksums.txt.sig,manifest.yaml" ]; then
+            echo "Unexpected files in _manifest: $files" >&2
+            exit 1
+          fi
+          if grep -q 'updates.zaparoo.org.*/zaparoo-' _manifest/manifest.yaml; then
+            echo "Manifest contains CDN-hosted release archive URLs" >&2
+            exit 1
+          fi
+          if grep -Eq '^ +url: (zaparoo-|v[^/]+/zaparoo-)' _manifest/manifest.yaml; then
+            echo "Manifest contains relative release archive URLs" >&2
+            exit 1
+          fi
+
       - name: Upload manifest to Bunny.net storage
         uses: R-J-dev/bunny-deploy@ae25fa670b732ffc8dba84c872fb203d2a365229 # v3.0.0
         with:
@@ -180,5 +170,6 @@ jobs:
           concurrency: "10"
           access-key: ${{ secrets.BUNNY_API_KEY }}
           pull-zone-id: ${{ secrets.BUNNY_PULL_ZONE_ID }}
+          enable-delete-action: false
           enable-purge-pull-zone: true
           replication-timeout: "15000"

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -702,6 +702,7 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			mockMediaDB.On("Truncate").Return(nil).Maybe()
 			mockMediaDB.On("CreateSecondaryIndexes").Return(nil).Maybe()
 			mockMediaDB.On("PopulateSystemTagsCacheForSystems", mock.Anything, mock.Anything).Return(nil).Maybe()
+			mockMediaDB.On("RefreshSlugSearchCacheForSystems", mock.Anything, mock.Anything).Return(nil).Maybe()
 			mockMediaDB.On("RunBackgroundOptimization", mock.Anything, mock.Anything).Return().Maybe()
 			mockMediaDB.On("TrackBackgroundOperation").Return().Maybe()
 			mockMediaDB.On("BackgroundOperationDone").Return().Maybe()

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -62,7 +62,7 @@ func TestStartWithReadyReportsBindFailure(t *testing.T) {
 
 	fs := helpers.NewMemoryFS()
 	configDir := t.TempDir()
-	cfg, err := helpers.NewTestConfigWithPort(fs, configDir, tcpAddr.Port)
+	cfg, err := helpers.NewTestConfigWithListenAndPort(fs, configDir, "127.0.0.1", tcpAddr.Port)
 	require.NoError(t, err)
 
 	st, notifCh := state.NewState(platform, "test-boot-uuid")
@@ -74,7 +74,17 @@ func TestStartWithReadyReportsBindFailure(t *testing.T) {
 	tokenQueue := make(chan tokens.Token, 1)
 	ready := make(chan error, 1)
 
-	err = StartWithReady(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil, ready)
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- StartWithReady(platform, cfg, st, tokenQueue, nil, db, nil, notifBroker, "", nil, nil, ready)
+	}()
+
+	select {
+	case err = <-serverErr:
+	case <-time.After(2 * time.Second):
+		st.StopService()
+		t.Fatal("StartWithReady did not return after bind failure")
+	}
 	require.Error(t, err)
 	select {
 	case readyErr := <-ready:
@@ -559,7 +569,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	testPort := 9100 // Use a fixed port for this test
 	fs1 := helpers.NewMemoryFS()
 	configDir1 := t.TempDir()
-	cfg1, err := helpers.NewTestConfigWithPort(fs1, configDir1, testPort)
+	cfg1, err := helpers.NewTestConfigWithListenAndPort(fs1, configDir1, "127.0.0.1", testPort)
 	require.NoError(t, err)
 
 	st1, notifCh1 := state.NewState(platform1, "test-boot-uuid-1")
@@ -603,7 +613,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 
 	fs2 := helpers.NewMemoryFS()
 	configDir2 := t.TempDir()
-	cfg2, err := helpers.NewTestConfigWithPort(fs2, configDir2, testPort) // Same port!
+	cfg2, err := helpers.NewTestConfigWithListenAndPort(fs2, configDir2, "127.0.0.1", testPort) // Same port!
 	require.NoError(t, err)
 
 	st2, notifCh2 := state.NewState(platform2, "test-boot-uuid-2")

--- a/pkg/service/updater/http_source.go
+++ b/pkg/service/updater/http_source.go
@@ -37,7 +37,12 @@ func (s *validationChainHTTPSource) ListReleases(
 	ctx context.Context,
 	repository selfupdate.Repository,
 ) ([]selfupdate.SourceRelease, error) {
-	return s.source.ListReleases(ctx, repository)
+	releases, err := s.source.ListReleases(ctx, repository)
+	if err != nil {
+		return nil, fmt.Errorf("listing releases from wrapped source: %w", err)
+	}
+
+	return releases, nil
 }
 
 func (s *validationChainHTTPSource) DownloadReleaseAsset(
@@ -49,7 +54,12 @@ func (s *validationChainHTTPSource) DownloadReleaseAsset(
 		return nil, selfupdate.ErrInvalidRelease
 	}
 	if rel.AssetID == assetID || rel.ValidationAssetID == assetID {
-		return s.source.DownloadReleaseAsset(ctx, rel, assetID)
+		reader, err := s.source.DownloadReleaseAsset(ctx, rel, assetID)
+		if err != nil {
+			return nil, fmt.Errorf("downloading asset %d from wrapped source: %w", assetID, err)
+		}
+
+		return reader, nil
 	}
 
 	for _, validationAsset := range rel.ValidationChain {
@@ -69,15 +79,21 @@ func (s *validationChainHTTPSource) downloadURL(ctx context.Context, url string)
 	client := &http.Client{Transport: s.transport}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating validation asset request: %w", err)
 	}
 
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("downloading validation asset: %w", err)
 	}
 	if res.StatusCode != http.StatusOK {
-		res.Body.Close()
+		if closeErr := res.Body.Close(); closeErr != nil {
+			return nil, fmt.Errorf(
+				"HTTP request failed with status code %d and closing response body: %w",
+				res.StatusCode,
+				closeErr,
+			)
+		}
 		return nil, fmt.Errorf("HTTP request failed with status code %d", res.StatusCode)
 	}
 

--- a/pkg/service/updater/http_source.go
+++ b/pkg/service/updater/http_source.go
@@ -1,0 +1,87 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	selfupdate "github.com/creativeprojects/go-selfupdate"
+)
+
+type validationChainHTTPSource struct {
+	source    selfupdate.Source
+	transport *http.Transport
+}
+
+func (s *validationChainHTTPSource) ListReleases(
+	ctx context.Context,
+	repository selfupdate.Repository,
+) ([]selfupdate.SourceRelease, error) {
+	return s.source.ListReleases(ctx, repository)
+}
+
+func (s *validationChainHTTPSource) DownloadReleaseAsset(
+	ctx context.Context,
+	rel *selfupdate.Release,
+	assetID int64,
+) (io.ReadCloser, error) {
+	if rel == nil {
+		return nil, selfupdate.ErrInvalidRelease
+	}
+	if rel.AssetID == assetID || rel.ValidationAssetID == assetID {
+		return s.source.DownloadReleaseAsset(ctx, rel, assetID)
+	}
+
+	for _, validationAsset := range rel.ValidationChain {
+		if validationAsset.ValidationAssetID == assetID {
+			return s.downloadURL(ctx, validationAsset.ValidationAssetURL)
+		}
+	}
+
+	return nil, fmt.Errorf("asset ID %d: %w", assetID, selfupdate.ErrAssetNotFound)
+}
+
+func (s *validationChainHTTPSource) downloadURL(ctx context.Context, url string) (io.ReadCloser, error) {
+	if url == "" {
+		return nil, selfupdate.ErrAssetNotFound
+	}
+
+	client := &http.Client{Transport: s.transport}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode != http.StatusOK {
+		res.Body.Close()
+		return nil, fmt.Errorf("HTTP request failed with status code %d", res.StatusCode)
+	}
+
+	return res.Body, nil
+}
+
+var _ selfupdate.Source = (*validationChainHTTPSource)(nil)

--- a/pkg/service/updater/http_source.go
+++ b/pkg/service/updater/http_source.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	selfupdate "github.com/creativeprojects/go-selfupdate"
 )
@@ -32,6 +33,8 @@ type validationChainHTTPSource struct {
 	source    selfupdate.Source
 	transport *http.Transport
 }
+
+const validationAssetDownloadTimeout = 30 * time.Second
 
 func (s *validationChainHTTPSource) ListReleases(
 	ctx context.Context,
@@ -76,7 +79,10 @@ func (s *validationChainHTTPSource) downloadURL(ctx context.Context, url string)
 		return nil, selfupdate.ErrAssetNotFound
 	}
 
-	client := &http.Client{Transport: s.transport}
+	client := &http.Client{Timeout: validationAssetDownloadTimeout}
+	if s.transport != nil {
+		client.Transport = s.transport
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating validation asset request: %w", err)

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -45,9 +45,10 @@ type Result struct {
 }
 
 func makeUpdater(_ context.Context, platformID, channel string) (*selfupdate.Updater, selfupdate.Repository, error) {
+	transport := tlsroots.Transport(nil)
 	source, err := selfupdate.NewHttpSource(selfupdate.HttpConfig{
 		BaseURL:   updateURL,
-		Transport: tlsroots.Transport(nil),
+		Transport: transport,
 	})
 	if err != nil {
 		return nil, selfupdate.RepositorySlug{}, fmt.Errorf("creating update source: %w", err)
@@ -61,7 +62,7 @@ func makeUpdater(_ context.Context, platformID, channel string) (*selfupdate.Upd
 	}
 
 	updater, err := selfupdate.NewUpdater(selfupdate.Config{
-		Source:     source,
+		Source:     &validationChainHTTPSource{source: source, transport: transport},
 		Validator:  validator,
 		Filters:    []string{filter},
 		Prerelease: channel == config.UpdateChannelBeta,

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -251,22 +251,36 @@ func TestValidationChainHTTPSource_DownloadsNestedValidationAsset(t *testing.T) 
 	}))
 	t.Cleanup(server.Close)
 
-	source := &validationChainHTTPSource{source: stubSource{}, transport: http.DefaultTransport.(*http.Transport).Clone()}
+	source := &validationChainHTTPSource{
+		source:    stubSource{},
+		transport: http.DefaultTransport.(*http.Transport).Clone(),
+	}
 	release := &selfupdate.Release{
 		AssetID:           1,
 		ValidationAssetID: 2,
+		//nolint:govet // Field order is fixed by go-selfupdate's exported Release type.
 		ValidationChain: []struct {
 			ValidationAssetID                       int64
 			ValidationAssetName, ValidationAssetURL string
 		}{
-			{ValidationAssetID: 2, ValidationAssetName: "checksums.txt", ValidationAssetURL: server.URL + "/checksums.txt"},
-			{ValidationAssetID: 3, ValidationAssetName: "checksums.txt.sig", ValidationAssetURL: server.URL + "/checksums.txt.sig"},
+			{
+				ValidationAssetID:   2,
+				ValidationAssetName: "checksums.txt",
+				ValidationAssetURL:  server.URL + "/checksums.txt",
+			},
+			{
+				ValidationAssetID:   3,
+				ValidationAssetName: "checksums.txt.sig",
+				ValidationAssetURL:  server.URL + "/checksums.txt.sig",
+			},
 		},
 	}
 
 	reader, err := source.DownloadReleaseAsset(t.Context(), release, 3)
 	require.NoError(t, err)
-	defer reader.Close()
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
 
 	data, err := io.ReadAll(reader)
 	require.NoError(t, err)

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -38,14 +39,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type stubSource struct{}
+type stubSource struct {
+	data string
+}
 
 func (stubSource) ListReleases(context.Context, selfupdate.Repository) ([]selfupdate.SourceRelease, error) {
 	return nil, nil
 }
 
-func (stubSource) DownloadReleaseAsset(context.Context, *selfupdate.Release, int64) (io.ReadCloser, error) {
-	return nil, selfupdate.ErrAssetNotFound
+func (s stubSource) DownloadReleaseAsset(context.Context, *selfupdate.Release, int64) (io.ReadCloser, error) {
+	if s.data == "" {
+		return nil, selfupdate.ErrAssetNotFound
+	}
+
+	return io.NopCloser(strings.NewReader(s.data)), nil
 }
 
 func TestCheck_DevelopmentVersion(t *testing.T) {
@@ -255,26 +262,7 @@ func TestValidationChainHTTPSource_DownloadsNestedValidationAsset(t *testing.T) 
 		source:    stubSource{},
 		transport: http.DefaultTransport.(*http.Transport).Clone(),
 	}
-	release := &selfupdate.Release{
-		AssetID:           1,
-		ValidationAssetID: 2,
-		//nolint:govet // Field order is fixed by go-selfupdate's exported Release type.
-		ValidationChain: []struct {
-			ValidationAssetID                       int64
-			ValidationAssetName, ValidationAssetURL string
-		}{
-			{
-				ValidationAssetID:   2,
-				ValidationAssetName: "checksums.txt",
-				ValidationAssetURL:  server.URL + "/checksums.txt",
-			},
-			{
-				ValidationAssetID:   3,
-				ValidationAssetName: "checksums.txt.sig",
-				ValidationAssetURL:  server.URL + "/checksums.txt.sig",
-			},
-		},
-	}
+	release := testValidationChainRelease(server.URL)
 
 	reader, err := source.DownloadReleaseAsset(t.Context(), release, 3)
 	require.NoError(t, err)
@@ -285,4 +273,106 @@ func TestValidationChainHTTPSource_DownloadsNestedValidationAsset(t *testing.T) 
 	data, err := io.ReadAll(reader)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("signature"), data)
+}
+
+func TestValidationChainHTTPSource_DownloadReleaseAssetBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil release returns error", func(t *testing.T) {
+		t.Parallel()
+
+		source := &validationChainHTTPSource{source: stubSource{data: "primary"}}
+		reader, err := source.DownloadReleaseAsset(t.Context(), nil, 1)
+		require.ErrorIs(t, err, selfupdate.ErrInvalidRelease)
+		assert.Nil(t, reader)
+	})
+
+	t.Run("delegates primary asset", func(t *testing.T) {
+		t.Parallel()
+
+		source := &validationChainHTTPSource{source: stubSource{data: "primary"}}
+		reader, err := source.DownloadReleaseAsset(t.Context(), testValidationChainRelease(""), 1)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, reader.Close())
+		}()
+
+		data, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, "primary", string(data))
+	})
+
+	t.Run("delegates first validation asset", func(t *testing.T) {
+		t.Parallel()
+
+		source := &validationChainHTTPSource{source: stubSource{data: "primary"}}
+		reader, err := source.DownloadReleaseAsset(t.Context(), testValidationChainRelease(""), 2)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, reader.Close())
+		}()
+
+		data, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, "primary", string(data))
+	})
+
+	t.Run("unknown asset returns error", func(t *testing.T) {
+		t.Parallel()
+
+		source := &validationChainHTTPSource{source: stubSource{data: "primary"}}
+		reader, err := source.DownloadReleaseAsset(t.Context(), testValidationChainRelease(""), 99)
+		require.ErrorIs(t, err, selfupdate.ErrAssetNotFound)
+		assert.Nil(t, reader)
+	})
+
+	t.Run("empty nested validation URL returns error", func(t *testing.T) {
+		t.Parallel()
+
+		source := &validationChainHTTPSource{source: stubSource{data: "primary"}}
+		release := testValidationChainRelease("")
+		release.ValidationChain[1].ValidationAssetURL = ""
+		reader, err := source.DownloadReleaseAsset(t.Context(), release, 3)
+		require.ErrorIs(t, err, selfupdate.ErrAssetNotFound)
+		assert.Nil(t, reader)
+	})
+
+	t.Run("non-OK nested validation response returns error", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.NotFoundHandler())
+		t.Cleanup(server.Close)
+
+		source := &validationChainHTTPSource{
+			source:    stubSource{data: "primary"},
+			transport: http.DefaultTransport.(*http.Transport).Clone(),
+		}
+		reader, err := source.DownloadReleaseAsset(t.Context(), testValidationChainRelease(server.URL), 3)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "status code 404")
+		assert.Nil(t, reader)
+	})
+}
+
+func testValidationChainRelease(serverURL string) *selfupdate.Release {
+	return &selfupdate.Release{
+		AssetID:           1,
+		ValidationAssetID: 2,
+		//nolint:govet // Field order is fixed by go-selfupdate's exported Release type.
+		ValidationChain: []struct {
+			ValidationAssetID                       int64
+			ValidationAssetName, ValidationAssetURL string
+		}{
+			{
+				ValidationAssetID:   2,
+				ValidationAssetName: "checksums.txt",
+				ValidationAssetURL:  serverURL + "/checksums.txt",
+			},
+			{
+				ValidationAssetID:   3,
+				ValidationAssetName: "checksums.txt.sig",
+				ValidationAssetURL:  serverURL + "/checksums.txt.sig",
+			},
+		},
+	}
 }

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -22,6 +22,9 @@ package updater
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -29,10 +32,21 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	selfupdate "github.com/creativeprojects/go-selfupdate"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type stubSource struct{}
+
+func (stubSource) ListReleases(context.Context, selfupdate.Repository) ([]selfupdate.SourceRelease, error) {
+	return nil, nil
+}
+
+func (stubSource) DownloadReleaseAsset(context.Context, *selfupdate.Release, int64) (io.ReadCloser, error) {
+	return nil, selfupdate.ErrAssetNotFound
+}
 
 func TestCheck_DevelopmentVersion(t *testing.T) {
 	devVersions := []string{"DEVELOPMENT", "abc1234-dev"}
@@ -226,4 +240,35 @@ func TestApply_CancelledContext(t *testing.T) {
 	version, err := Apply(ctx, "linux", "stable")
 	require.Error(t, err)
 	assert.Empty(t, version)
+}
+
+func TestValidationChainHTTPSource_DownloadsNestedValidationAsset(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/checksums.txt.sig", r.URL.Path)
+		_, _ = w.Write([]byte("signature"))
+	}))
+	t.Cleanup(server.Close)
+
+	source := &validationChainHTTPSource{source: stubSource{}, transport: http.DefaultTransport.(*http.Transport).Clone()}
+	release := &selfupdate.Release{
+		AssetID:           1,
+		ValidationAssetID: 2,
+		ValidationChain: []struct {
+			ValidationAssetID                       int64
+			ValidationAssetName, ValidationAssetURL string
+		}{
+			{ValidationAssetID: 2, ValidationAssetName: "checksums.txt", ValidationAssetURL: server.URL + "/checksums.txt"},
+			{ValidationAssetID: 3, ValidationAssetName: "checksums.txt.sig", ValidationAssetURL: server.URL + "/checksums.txt.sig"},
+		},
+	}
+
+	reader, err := source.DownloadReleaseAsset(t.Context(), release, 3)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("signature"), data)
 }

--- a/pkg/testing/helpers/fs.go
+++ b/pkg/testing/helpers/fs.go
@@ -402,8 +402,16 @@ func NewTestConfig(fs *FSHelper, configDir string) (*config.Instance, error) {
 // If fs is provided, its in-memory filesystem is used for config file operations.
 // If fs is nil, the real OS filesystem is used.
 func NewTestConfigWithPort(fs *FSHelper, configDir string, port int) (*config.Instance, error) {
+	return NewTestConfigWithListenAndPort(fs, configDir, "", port)
+}
+
+// NewTestConfigWithListenAndPort creates a config instance for testing with a
+// specific API listen host and port. If fs is provided, its in-memory filesystem
+// is used for config file operations. If fs is nil, the real OS filesystem is used.
+func NewTestConfigWithListenAndPort(fs *FSHelper, configDir, listenHost string, port int) (*config.Instance, error) {
 	defaults := config.BaseDefaults
 	defaults.Service.APIPort = &port
+	defaults.Service.APIListen = listenHost
 
 	if fs != nil {
 		cfg, err := config.NewConfigWithFs(configDir, defaults, fs.Fs)

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -159,7 +159,7 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 			continue
 		}
 
-		if !strings.HasPrefix(name, "zaparoo-") && name != "checksums.txt" && name != "checksums.txt.sig" {
+		if !isUpdateArchive(name) && name != "checksums.txt" && name != "checksums.txt.sig" {
 			continue
 		}
 
@@ -263,6 +263,23 @@ func loadGithubRelease(fs afero.Fs, path string) (*githubRelease, error) {
 	return &release, nil
 }
 
+func validateGithubReleaseMetadata(release *githubRelease, version string) error {
+	if release.TagName == "" {
+		return errors.New("GitHub release metadata is missing tagName")
+	}
+	if release.TagName != version {
+		return fmt.Errorf("GitHub release metadata tag %q does not match version %q", release.TagName, version)
+	}
+	if release.URL == "" {
+		return fmt.Errorf("GitHub release metadata for %s is missing url", release.TagName)
+	}
+	if release.PublishedAt.IsZero() {
+		return fmt.Errorf("GitHub release metadata for %s is missing publishedAt", release.TagName)
+	}
+
+	return nil
+}
+
 func isUpdateArchive(name string) bool {
 	return strings.HasPrefix(name, "zaparoo-") &&
 		(strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip"))
@@ -359,11 +376,8 @@ func main() {
 		if loadErr != nil {
 			log.Fatal().Err(loadErr).Msg("error loading GitHub release metadata")
 		}
-		if release.TagName != "" && release.TagName != *version {
-			log.Fatal().
-				Str("metadata_tag", release.TagName).
-				Str("version", *version).
-				Msg("GitHub release metadata tag mismatch")
+		if validateErr := validateGithubReleaseMetadata(release, *version); validateErr != nil {
+			log.Fatal().Err(validateErr).Msg("invalid GitHub release metadata")
 		}
 		assets, assetsErr := assetsFromGithubRelease(fs, release, *metadataDir)
 		if assetsErr != nil {

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -200,7 +200,7 @@ func buildManifestFromAssets(
 		startAssetID = existing.LastAssetID
 	}
 
-	var assets []*asset
+	assets := make([]*asset, 0, len(releaseAssets))
 	assetID := startAssetID
 	for _, releaseAsset := range releaseAssets {
 		assetID++
@@ -259,7 +259,8 @@ func loadGithubRelease(path string) (*githubRelease, error) {
 }
 
 func isUpdateArchive(name string) bool {
-	return strings.HasPrefix(name, "zaparoo-") && (strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip"))
+	return strings.HasPrefix(name, "zaparoo-") &&
+		(strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip"))
 }
 
 func assetsFromGithubRelease(release *githubRelease, metadataDir string) ([]releaseAsset, error) {
@@ -271,11 +272,7 @@ func assetsFromGithubRelease(release *githubRelease, metadataDir string) ([]rele
 		if githubAsset.URL == "" {
 			return nil, fmt.Errorf("GitHub asset %s has no download URL", githubAsset.Name)
 		}
-		assets = append(assets, releaseAsset{
-			Name: githubAsset.Name,
-			URL:  githubAsset.URL,
-			Size: githubAsset.Size,
-		})
+		assets = append(assets, releaseAsset(githubAsset))
 	}
 
 	metadataFiles := []string{"checksums.txt", "checksums.txt.sig"}
@@ -353,13 +350,24 @@ func main() {
 			log.Fatal().Err(loadErr).Msg("error loading GitHub release metadata")
 		}
 		if release.TagName != "" && release.TagName != *version {
-			log.Fatal().Str("metadata_tag", release.TagName).Str("version", *version).Msg("GitHub release metadata tag mismatch")
+			log.Fatal().
+				Str("metadata_tag", release.TagName).
+				Str("version", *version).
+				Msg("GitHub release metadata tag mismatch")
 		}
 		assets, assetsErr := assetsFromGithubRelease(release, *metadataDir)
 		if assetsErr != nil {
 			log.Fatal().Err(assetsErr).Msg("error loading GitHub release assets")
 		}
-		m, err = buildManifestFromAssets(*version, release.URL, release.PublishedAt, *releaseNotes, *prerelease, assets, existing)
+		m, err = buildManifestFromAssets(
+			*version,
+			release.URL,
+			release.PublishedAt,
+			*releaseNotes,
+			*prerelease,
+			assets,
+			existing,
+		)
 	} else {
 		m, err = buildManifest(*version, *assetsDir, *releaseNotes, *prerelease, existing)
 	}

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -22,6 +22,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -62,7 +63,28 @@ type asset struct {
 	Size int64  `yaml:"size"`
 }
 
+type releaseAsset struct {
+	Name string
+	URL  string
+	Size int64
+}
+
+type githubRelease struct {
+	TagName     string        `json:"tagName"`
+	URL         string        `json:"url"`
+	PublishedAt time.Time     `json:"publishedAt"`
+	Assets      []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+	Size int64  `json:"size"`
+}
+
 var errNoAssets = errors.New("no release assets found in directory")
+
+const githubReleaseDownloadBase = "https://github.com/ZaparooProject/zaparoo-core/releases/download"
 
 // loadManifest reads an existing manifest YAML file for merging.
 func loadManifest(path string) (*manifest, error) {
@@ -75,8 +97,45 @@ func loadManifest(path string) (*manifest, error) {
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing existing manifest: %w", err)
 	}
+	normalizeManifestForMerge(&m)
 
 	return &m, nil
+}
+
+func normalizeManifestForMerge(m *manifest) {
+	lastAssetID := m.LastAssetID
+	for _, release := range m.Releases {
+		for _, asset := range release.Assets {
+			if asset.ID > lastAssetID {
+				lastAssetID = asset.ID
+			}
+		}
+	}
+
+	for _, release := range m.Releases {
+		hasChecksums := false
+		hasSignature := false
+		for _, asset := range release.Assets {
+			if isUpdateArchive(asset.Name) && !strings.HasPrefix(asset.URL, githubReleaseDownloadBase+"/") {
+				asset.URL = githubReleaseDownloadBase + "/" + release.TagName + "/" + asset.Name
+			}
+			if asset.Name == "checksums.txt" {
+				hasChecksums = true
+			}
+			if asset.Name == "checksums.txt.sig" {
+				hasSignature = true
+			}
+		}
+		if hasChecksums && !hasSignature {
+			lastAssetID++
+			release.Assets = append(release.Assets, &asset{
+				ID:   lastAssetID,
+				Name: "checksums.txt.sig",
+				URL:  "checksums.txt.sig",
+			})
+		}
+	}
+	m.LastAssetID = lastAssetID
 }
 
 // buildManifest reads assetsDir for release files and returns a manifest.
@@ -87,15 +146,7 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 		return nil, fmt.Errorf("reading assets directory: %w", err)
 	}
 
-	var startReleaseID int64
-	var startAssetID int64
-	if existing != nil {
-		startReleaseID = existing.LastReleaseID
-		startAssetID = existing.LastAssetID
-	}
-
-	var assets []*asset
-	assetID := startAssetID
+	var releaseAssets []releaseAsset
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -107,7 +158,7 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 			continue
 		}
 
-		if !strings.HasPrefix(name, "zaparoo-") && name != "checksums.txt" {
+		if !strings.HasPrefix(name, "zaparoo-") && name != "checksums.txt" && name != "checksums.txt.sig" {
 			continue
 		}
 
@@ -117,21 +168,55 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 		}
 
 		assetURL := version + "/" + name
-		if name == "checksums.txt" {
+		if name == "checksums.txt" || name == "checksums.txt.sig" {
 			assetURL = name
 		}
 
-		assetID++
-		assets = append(assets, &asset{
-			ID:   assetID,
+		releaseAssets = append(releaseAssets, releaseAsset{
 			Name: name,
 			Size: info.Size(),
 			URL:  assetURL,
 		})
 	}
 
+	return buildManifestFromAssets(version, "", time.Now().UTC(), releaseNotes, prerelease, releaseAssets, existing)
+}
+
+// buildManifestFromAssets returns a manifest from already-resolved asset metadata.
+// When merging with an existing manifest, IDs continue from the existing values.
+func buildManifestFromAssets(
+	version string,
+	releaseURL string,
+	publishedAt time.Time,
+	releaseNotes string,
+	prerelease bool,
+	releaseAssets []releaseAsset,
+	existing *manifest,
+) (*manifest, error) {
+	var startReleaseID int64
+	var startAssetID int64
+	if existing != nil {
+		startReleaseID = existing.LastReleaseID
+		startAssetID = existing.LastAssetID
+	}
+
+	var assets []*asset
+	assetID := startAssetID
+	for _, releaseAsset := range releaseAssets {
+		assetID++
+		assets = append(assets, &asset{
+			ID:   assetID,
+			Name: releaseAsset.Name,
+			Size: releaseAsset.Size,
+			URL:  releaseAsset.URL,
+		})
+	}
+
 	if len(assets) == 0 {
 		return nil, errNoAssets
+	}
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
 	}
 
 	releaseID := startReleaseID + 1
@@ -139,9 +224,9 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 		ID:           releaseID,
 		Name:         version,
 		TagName:      version,
-		URL:          "",
+		URL:          releaseURL,
 		ReleaseNotes: releaseNotes,
-		PublishedAt:  time.Now().UTC(),
+		PublishedAt:  publishedAt.UTC(),
 		Assets:       assets,
 		Prerelease:   prerelease,
 	}
@@ -157,6 +242,56 @@ func buildManifest(version, assetsDir, releaseNotes string, prerelease bool, exi
 		LastAssetID:   assetID,
 		Releases:      releases,
 	}, nil
+}
+
+func loadGithubRelease(path string) (*githubRelease, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // Path from CLI flag, not user input
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub release metadata: %w", err)
+	}
+
+	var release githubRelease
+	if err := json.Unmarshal(data, &release); err != nil {
+		return nil, fmt.Errorf("parsing GitHub release metadata: %w", err)
+	}
+
+	return &release, nil
+}
+
+func isUpdateArchive(name string) bool {
+	return strings.HasPrefix(name, "zaparoo-") && (strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip"))
+}
+
+func assetsFromGithubRelease(release *githubRelease, metadataDir string) ([]releaseAsset, error) {
+	assets := make([]releaseAsset, 0, len(release.Assets)+2)
+	for _, githubAsset := range release.Assets {
+		if !isUpdateArchive(githubAsset.Name) {
+			continue
+		}
+		if githubAsset.URL == "" {
+			return nil, fmt.Errorf("GitHub asset %s has no download URL", githubAsset.Name)
+		}
+		assets = append(assets, releaseAsset{
+			Name: githubAsset.Name,
+			URL:  githubAsset.URL,
+			Size: githubAsset.Size,
+		})
+	}
+
+	metadataFiles := []string{"checksums.txt", "checksums.txt.sig"}
+	for _, name := range metadataFiles {
+		info, err := os.Stat(filepath.Join(metadataDir, name))
+		if err != nil {
+			return nil, fmt.Errorf("reading metadata asset %s: %w", name, err)
+		}
+		assets = append(assets, releaseAsset{
+			Name: name,
+			URL:  name,
+			Size: info.Size(),
+		})
+	}
+
+	return assets, nil
 }
 
 // writeManifest marshals the manifest to YAML and writes it to outputPath.
@@ -184,15 +319,20 @@ func main() {
 
 	version := flag.String("version", "", "release version tag (e.g. v2.10.0)")
 	assetsDir := flag.String("assets-dir", "", "directory containing release asset files")
+	githubReleasePath := flag.String("github-release", "", "GitHub release metadata JSON from gh release view")
+	metadataDir := flag.String("metadata-dir", "", "directory containing checksums.txt and checksums.txt.sig")
 	releaseNotes := flag.String("release-notes", "", "release notes text to include in manifest")
 	output := flag.String("output", "manifest.yaml", "output manifest file path")
 	prerelease := flag.Bool("prerelease", false, "mark release as pre-release in manifest")
 	merge := flag.String("merge", "", "path to existing manifest to merge into")
 	flag.Parse()
 
-	if *version == "" || *assetsDir == "" {
+	if *version == "" || (*assetsDir == "" && *githubReleasePath == "") {
 		log.Fatal().Msg("usage: generate-update-manifest --version <tag> --assets-dir <dir> " +
-			"[--output <path>] [--prerelease] [--merge <path>]")
+			"[--github-release <path> --metadata-dir <dir>] [--output <path>] [--prerelease] [--merge <path>]")
+	}
+	if *githubReleasePath != "" && *metadataDir == "" {
+		log.Fatal().Msg("--metadata-dir is required with --github-release")
 	}
 
 	var existing *manifest
@@ -205,7 +345,24 @@ func main() {
 		log.Info().Int("releases", len(existing.Releases)).Msg("loaded existing manifest for merge")
 	}
 
-	m, err := buildManifest(*version, *assetsDir, *releaseNotes, *prerelease, existing)
+	var m *manifest
+	var err error
+	if *githubReleasePath != "" {
+		release, loadErr := loadGithubRelease(*githubReleasePath)
+		if loadErr != nil {
+			log.Fatal().Err(loadErr).Msg("error loading GitHub release metadata")
+		}
+		if release.TagName != "" && release.TagName != *version {
+			log.Fatal().Str("metadata_tag", release.TagName).Str("version", *version).Msg("GitHub release metadata tag mismatch")
+		}
+		assets, assetsErr := assetsFromGithubRelease(release, *metadataDir)
+		if assetsErr != nil {
+			log.Fatal().Err(assetsErr).Msg("error loading GitHub release assets")
+		}
+		m, err = buildManifestFromAssets(*version, release.URL, release.PublishedAt, *releaseNotes, *prerelease, assets, existing)
+	} else {
+		m, err = buildManifest(*version, *assetsDir, *releaseNotes, *prerelease, existing)
+	}
 	if err != nil {
 		log.Fatal().Err(err).Msg("error building manifest")
 	}

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 	"gopkg.in/yaml.v3"
 )
 
@@ -202,7 +203,11 @@ func buildManifestFromAssets(
 
 	assets := make([]*asset, 0, len(releaseAssets))
 	assetID := startAssetID
+	hasInstallableAsset := false
 	for _, releaseAsset := range releaseAssets {
+		if isUpdateArchive(releaseAsset.Name) {
+			hasInstallableAsset = true
+		}
 		assetID++
 		assets = append(assets, &asset{
 			ID:   assetID,
@@ -212,7 +217,7 @@ func buildManifestFromAssets(
 		})
 	}
 
-	if len(assets) == 0 {
+	if !hasInstallableAsset {
 		return nil, errNoAssets
 	}
 	if publishedAt.IsZero() {
@@ -244,8 +249,8 @@ func buildManifestFromAssets(
 	}, nil
 }
 
-func loadGithubRelease(path string) (*githubRelease, error) {
-	data, err := os.ReadFile(path) //nolint:gosec // Path from CLI flag, not user input
+func loadGithubRelease(fs afero.Fs, path string) (*githubRelease, error) {
+	data, err := afero.ReadFile(fs, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading GitHub release metadata: %w", err)
 	}
@@ -263,7 +268,7 @@ func isUpdateArchive(name string) bool {
 		(strings.HasSuffix(name, ".tar.gz") || strings.HasSuffix(name, ".zip"))
 }
 
-func assetsFromGithubRelease(release *githubRelease, metadataDir string) ([]releaseAsset, error) {
+func assetsFromGithubRelease(fs afero.Fs, release *githubRelease, metadataDir string) ([]releaseAsset, error) {
 	assets := make([]releaseAsset, 0, len(release.Assets)+2)
 	for _, githubAsset := range release.Assets {
 		if !isUpdateArchive(githubAsset.Name) {
@@ -277,7 +282,7 @@ func assetsFromGithubRelease(release *githubRelease, metadataDir string) ([]rele
 
 	metadataFiles := []string{"checksums.txt", "checksums.txt.sig"}
 	for _, name := range metadataFiles {
-		info, err := os.Stat(filepath.Join(metadataDir, name))
+		info, err := fs.Stat(filepath.Join(metadataDir, name))
 		if err != nil {
 			return nil, fmt.Errorf("reading metadata asset %s: %w", name, err)
 		}
@@ -324,9 +329,14 @@ func main() {
 	merge := flag.String("merge", "", "path to existing manifest to merge into")
 	flag.Parse()
 
+	fs := afero.NewOsFs()
+
 	if *version == "" || (*assetsDir == "" && *githubReleasePath == "") {
 		log.Fatal().Msg("usage: generate-update-manifest --version <tag> --assets-dir <dir> " +
 			"[--github-release <path> --metadata-dir <dir>] [--output <path>] [--prerelease] [--merge <path>]")
+	}
+	if *assetsDir != "" && *githubReleasePath != "" {
+		log.Fatal().Msg("--assets-dir and --github-release are mutually exclusive")
 	}
 	if *githubReleasePath != "" && *metadataDir == "" {
 		log.Fatal().Msg("--metadata-dir is required with --github-release")
@@ -345,7 +355,7 @@ func main() {
 	var m *manifest
 	var err error
 	if *githubReleasePath != "" {
-		release, loadErr := loadGithubRelease(*githubReleasePath)
+		release, loadErr := loadGithubRelease(fs, *githubReleasePath)
 		if loadErr != nil {
 			log.Fatal().Err(loadErr).Msg("error loading GitHub release metadata")
 		}
@@ -355,7 +365,7 @@ func main() {
 				Str("version", *version).
 				Msg("GitHub release metadata tag mismatch")
 		}
-		assets, assetsErr := assetsFromGithubRelease(release, *metadataDir)
+		assets, assetsErr := assetsFromGithubRelease(fs, release, *metadataDir)
 		if assetsErr != nil {
 			log.Fatal().Err(assetsErr).Msg("error loading GitHub release assets")
 		}

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -20,9 +20,11 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,6 +68,94 @@ func TestBuildManifest_ValidAssets(t *testing.T) {
 	assert.Equal(t, "v2.10.0/zaparoo-windows_amd64.zip", assetsByName["zaparoo-windows_amd64.zip"].URL)
 	assert.Equal(t, int64(256), assetsByName["checksums.txt"].Size)
 	assert.Equal(t, "checksums.txt", assetsByName["checksums.txt"].URL)
+}
+
+func TestBuildManifest_IncludesChecksumSignature(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createAssetFile(t, dir, "zaparoo-linux_amd64.tar.gz", 1024)
+	createAssetFile(t, dir, "checksums.txt", 256)
+	createAssetFile(t, dir, "checksums.txt.sig", 64)
+
+	m, err := buildManifest("v2.10.0", dir, "", false, nil)
+	require.NoError(t, err)
+
+	assetsByName := make(map[string]*asset)
+	for _, a := range m.Releases[0].Assets {
+		assetsByName[a.Name] = a
+	}
+	assert.Equal(t, "checksums.txt", assetsByName["checksums.txt"].URL)
+	assert.Equal(t, "checksums.txt.sig", assetsByName["checksums.txt.sig"].URL)
+}
+
+func TestBuildManifestFromGithubRelease(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createAssetFile(t, dir, "checksums.txt", 128)
+	createAssetFile(t, dir, "checksums.txt.sig", 64)
+
+	publishedAt := time.Date(2026, 4, 27, 1, 2, 3, 0, time.UTC)
+	release := &githubRelease{
+		TagName:     "v2.11.0",
+		URL:         "https://github.com/ZaparooProject/zaparoo-core/releases/tag/v2.11.0",
+		PublishedAt: publishedAt,
+		Assets: []githubAsset{
+			{
+				Name: "zaparoo-linux_amd64-2.11.0.tar.gz",
+				URL:  "https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.11.0/zaparoo-linux_amd64-2.11.0.tar.gz",
+				Size: 1024,
+			},
+			{
+				Name: "zaparoo-amd64-2.11.0-setup.exe",
+				URL:  "https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.11.0/zaparoo-amd64-2.11.0-setup.exe",
+				Size: 2048,
+			},
+		},
+	}
+
+	assets, err := assetsFromGithubRelease(release, dir)
+	require.NoError(t, err)
+	m, err := buildManifestFromAssets("v2.11.0", release.URL, release.PublishedAt, "notes", false, assets, nil)
+	require.NoError(t, err)
+
+	require.Len(t, m.Releases, 1)
+	releaseManifest := m.Releases[0]
+	assert.Equal(t, release.URL, releaseManifest.URL)
+	assert.Equal(t, publishedAt, releaseManifest.PublishedAt)
+	require.Len(t, releaseManifest.Assets, 3)
+
+	assetsByName := make(map[string]*asset)
+	for _, a := range releaseManifest.Assets {
+		assetsByName[a.Name] = a
+	}
+	assert.Equal(t,
+		"https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.11.0/zaparoo-linux_amd64-2.11.0.tar.gz",
+		assetsByName["zaparoo-linux_amd64-2.11.0.tar.gz"].URL,
+	)
+	assert.NotContains(t, assetsByName, "zaparoo-amd64-2.11.0-setup.exe")
+	assert.Equal(t, "checksums.txt", assetsByName["checksums.txt"].URL)
+	assert.Equal(t, "checksums.txt.sig", assetsByName["checksums.txt.sig"].URL)
+}
+
+func TestLoadGithubRelease(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	releasePath := filepath.Join(dir, "release.json")
+	release := githubRelease{
+		TagName: "v1.0.0",
+		Assets:  []githubAsset{{Name: "zaparoo-linux_amd64-1.0.0.tar.gz", URL: "https://example.com/asset", Size: 100}},
+	}
+	data, err := json.Marshal(release)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(releasePath, data, 0o600))
+
+	loaded, err := loadGithubRelease(releasePath)
+	require.NoError(t, err)
+	assert.Equal(t, "v1.0.0", loaded.TagName)
+	require.Len(t, loaded.Assets, 1)
 }
 
 func TestBuildManifest_SkipsNonAssetFiles(t *testing.T) {
@@ -334,6 +424,45 @@ func TestLoadManifest(t *testing.T) {
 	assert.Equal(t, int64(1), loaded.LastAssetID)
 	require.Len(t, loaded.Releases, 1)
 	assert.Equal(t, "v2.10.0", loaded.Releases[0].TagName)
+}
+
+func TestLoadManifest_NormalizesArchiveURLsToGitHub(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+
+	original := &manifest{
+		LastReleaseID: 1,
+		LastAssetID:   2,
+		Releases: []*release{
+			{
+				ID:      1,
+				Name:    "v2.10.0",
+				TagName: "v2.10.0",
+				Assets: []*asset{
+					{ID: 1, Name: "zaparoo-linux_amd64-2.10.0.tar.gz", Size: 100, URL: "zaparoo-linux_amd64-2.10.0.tar.gz"},
+					{ID: 2, Name: "checksums.txt", Size: 100, URL: "checksums.txt"},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, writeManifest(original, manifestPath))
+
+	loaded, err := loadManifest(manifestPath)
+	require.NoError(t, err)
+	require.Len(t, loaded.Releases, 1)
+	require.Len(t, loaded.Releases[0].Assets, 3)
+	assert.Equal(t,
+		"https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.10.0/zaparoo-linux_amd64-2.10.0.tar.gz",
+		loaded.Releases[0].Assets[0].URL,
+	)
+	assert.Equal(t, "checksums.txt", loaded.Releases[0].Assets[1].URL)
+	assert.Equal(t, int64(3), loaded.Releases[0].Assets[2].ID)
+	assert.Equal(t, "checksums.txt.sig", loaded.Releases[0].Assets[2].Name)
+	assert.Equal(t, "checksums.txt.sig", loaded.Releases[0].Assets[2].URL)
+	assert.Equal(t, int64(3), loaded.LastAssetID)
 }
 
 func TestLoadManifest_NonexistentFile(t *testing.T) {

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -118,7 +119,7 @@ func TestBuildManifestFromGithubRelease(t *testing.T) {
 		},
 	}
 
-	assets, err := assetsFromGithubRelease(release, dir)
+	assets, err := assetsFromGithubRelease(afero.NewOsFs(), release, dir)
 	require.NoError(t, err)
 	m, err := buildManifestFromAssets("v2.11.0", release.URL, release.PublishedAt, "notes", false, assets, nil)
 	require.NoError(t, err)
@@ -145,20 +146,45 @@ func TestBuildManifestFromGithubRelease(t *testing.T) {
 func TestLoadGithubRelease(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	releasePath := filepath.Join(dir, "release.json")
+	fs := afero.NewMemMapFs()
+	releasePath := "release.json"
 	release := githubRelease{
 		TagName: "v1.0.0",
 		Assets:  []githubAsset{{Name: "zaparoo-linux_amd64-1.0.0.tar.gz", URL: "https://example.com/asset", Size: 100}},
 	}
 	data, err := json.Marshal(release)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(releasePath, data, 0o600))
+	require.NoError(t, afero.WriteFile(fs, releasePath, data, 0o600))
 
-	loaded, err := loadGithubRelease(releasePath)
+	loaded, err := loadGithubRelease(fs, releasePath)
 	require.NoError(t, err)
 	assert.Equal(t, "v1.0.0", loaded.TagName)
 	require.Len(t, loaded.Assets, 1)
+}
+
+func TestBuildManifest_OnlyMetadataFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createAssetFile(t, dir, "checksums.txt", 256)
+	createAssetFile(t, dir, "checksums.txt.sig", 64)
+
+	m, err := buildManifest("v1.0.0", dir, "", false, nil)
+	require.ErrorIs(t, err, errNoAssets)
+	assert.Nil(t, m)
+}
+
+func TestBuildManifestFromAssets_OnlyMetadataFiles(t *testing.T) {
+	t.Parallel()
+
+	assets := []releaseAsset{
+		{Name: "checksums.txt", URL: "checksums.txt", Size: 256},
+		{Name: "checksums.txt.sig", URL: "checksums.txt.sig", Size: 64},
+	}
+
+	m, err := buildManifestFromAssets("v1.0.0", "", time.Time{}, "", false, assets, nil)
+	require.ErrorIs(t, err, errNoAssets)
+	assert.Nil(t, m)
 }
 
 func TestBuildManifest_SkipsNonAssetFiles(t *testing.T) {

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -162,6 +162,64 @@ func TestLoadGithubRelease(t *testing.T) {
 	require.Len(t, loaded.Assets, 1)
 }
 
+func TestValidateGithubReleaseMetadata(t *testing.T) {
+	t.Parallel()
+
+	publishedAt := time.Date(2026, 4, 27, 1, 2, 3, 0, time.UTC)
+	tests := []struct {
+		name    string
+		release *githubRelease
+		wantErr string
+	}{
+		{
+			name: "valid",
+			release: &githubRelease{
+				TagName:     "v1.0.0",
+				URL:         "https://github.com/ZaparooProject/zaparoo-core/releases/tag/v1.0.0",
+				PublishedAt: publishedAt,
+			},
+		},
+		{
+			name:    "missing tag",
+			release: &githubRelease{URL: "https://example.com", PublishedAt: publishedAt},
+			wantErr: "missing tagName",
+		},
+		{
+			name: "tag mismatch",
+			release: &githubRelease{
+				TagName:     "v1.0.1",
+				URL:         "https://example.com",
+				PublishedAt: publishedAt,
+			},
+			wantErr: "does not match version",
+		},
+		{
+			name:    "missing url",
+			release: &githubRelease{TagName: "v1.0.0", PublishedAt: publishedAt},
+			wantErr: "missing url",
+		},
+		{
+			name:    "missing published at",
+			release: &githubRelease{TagName: "v1.0.0", URL: "https://example.com"},
+			wantErr: "missing publishedAt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateGithubReleaseMetadata(tt.release, "v1.0.0")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestBuildManifest_OnlyMetadataFiles(t *testing.T) {
 	t.Parallel()
 
@@ -192,6 +250,7 @@ func TestBuildManifest_SkipsNonAssetFiles(t *testing.T) {
 
 	dir := t.TempDir()
 	createAssetFile(t, dir, "zaparoo-linux_amd64.tar.gz", 100)
+	createAssetFile(t, dir, "zaparoo-linux_amd64-setup.exe", 100)
 	createAssetFile(t, dir, "README.md", 50)
 	createAssetFile(t, dir, "random-file.txt", 50)
 

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -92,6 +92,9 @@ func TestBuildManifest_IncludesChecksumSignature(t *testing.T) {
 func TestBuildManifestFromGithubRelease(t *testing.T) {
 	t.Parallel()
 
+	archiveURL := githubReleaseDownloadBase + "/v2.11.0/zaparoo-linux_amd64-2.11.0.tar.gz"
+	setupURL := githubReleaseDownloadBase + "/v2.11.0/zaparoo-amd64-2.11.0-setup.exe"
+
 	dir := t.TempDir()
 	createAssetFile(t, dir, "checksums.txt", 128)
 	createAssetFile(t, dir, "checksums.txt.sig", 64)
@@ -104,12 +107,12 @@ func TestBuildManifestFromGithubRelease(t *testing.T) {
 		Assets: []githubAsset{
 			{
 				Name: "zaparoo-linux_amd64-2.11.0.tar.gz",
-				URL:  "https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.11.0/zaparoo-linux_amd64-2.11.0.tar.gz",
+				URL:  archiveURL,
 				Size: 1024,
 			},
 			{
 				Name: "zaparoo-amd64-2.11.0-setup.exe",
-				URL:  "https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.11.0/zaparoo-amd64-2.11.0-setup.exe",
+				URL:  setupURL,
 				Size: 2048,
 			},
 		},
@@ -441,7 +444,12 @@ func TestLoadManifest_NormalizesArchiveURLsToGitHub(t *testing.T) {
 				Name:    "v2.10.0",
 				TagName: "v2.10.0",
 				Assets: []*asset{
-					{ID: 1, Name: "zaparoo-linux_amd64-2.10.0.tar.gz", Size: 100, URL: "zaparoo-linux_amd64-2.10.0.tar.gz"},
+					{
+						ID:   1,
+						Name: "zaparoo-linux_amd64-2.10.0.tar.gz",
+						Size: 100,
+						URL:  "zaparoo-linux_amd64-2.10.0.tar.gz",
+					},
 					{ID: 2, Name: "checksums.txt", Size: 100, URL: "checksums.txt"},
 				},
 			},


### PR DESCRIPTION
## Summary
- Rewrite update manifest publishing to upload signed metadata only, fail closed on broken existing metadata, and reference GitHub Release assets instead of CDN-hosted binaries.
- Fix updater validation-chain downloads so signed checksums can resolve nested signature assets.
- Make API bind-failure tests deterministic across platforms and add targeted native macOS/Windows PR test coverage.

## Verification
- go test ./scripts/generate-update-manifest/
- go test ./pkg/service/updater/
- go test -run 'TestStartWithReadyReportsBindFailure|TestServerBindFailureStopsService' ./pkg/api/
- go test ./pkg/api/
- go test -race ./pkg/api ./pkg/helpers ./pkg/helpers/command ./pkg/readers/externaldrive ./pkg/platforms/shared/steam ./pkg/platforms/shared/steam/steamtracker ./pkg/service/restart ./pkg/ui/systray
- actionlint .github/workflows/publish-update-manifest.yml
- actionlint .github/workflows/lint-and-test.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update manifest now sources metadata and checksums directly from GitHub releases and supports nested validation assets for update verification.

* **Bug Fixes**
  * Improved server startup reliability with explicit listen configuration and faster bind-failure detection.

* **Tests**
  * Added PR-only native tests for macOS and Windows and expanded unit/integration tests for updater and manifest generation.

* **Chores**
  * CI updated to run native PR tests and consolidated the release manifest publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->