### PR TITLE
fix: stabilize native service CI tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -345,7 +345,6 @@ jobs:
             ./pkg/platforms/shared/steam \
             ./pkg/platforms/shared/steam/steamtracker \
             ./pkg/service \
-            ./pkg/service/daemon \
             ./pkg/service/restart \
             ./pkg/ui/systray
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -344,6 +344,8 @@ jobs:
             ./pkg/readers/externaldrive \
             ./pkg/platforms/shared/steam \
             ./pkg/platforms/shared/steam/steamtracker \
+            ./pkg/service \
+            ./pkg/service/daemon \
             ./pkg/service/restart \
             ./pkg/ui/systray
 
@@ -357,6 +359,8 @@ jobs:
             ./pkg/readers/externaldrive \
             ./pkg/platforms/shared/steam \
             ./pkg/platforms/shared/steam/steamtracker \
+            ./pkg/service \
+            ./pkg/service/daemon \
             ./pkg/service/restart \
             ./pkg/ui/systray
 

--- a/pkg/helpers/logging_test.go
+++ b/pkg/helpers/logging_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -234,7 +235,9 @@ func TestCloseLoggingReleasesLogFile(t *testing.T) {
 	require.FileExists(t, filepath.Join(logDir, config.LogFile))
 	require.NoError(t, CloseLogging())
 
-	require.NoError(t, os.RemoveAll(logDir))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, os.RemoveAll(logDir))
+	}, time.Second, 10*time.Millisecond)
 	_, err := os.Stat(logDir)
 	require.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -578,6 +578,8 @@ func signalProcess(process *os.Process, pid int, sig syscall.Signal) error {
 	if pid > 0 {
 		if err := syscall.Kill(-pid, sig); err == nil {
 			return nil
+		} else if errors.Is(err, syscall.EPERM) {
+			log.Debug().Err(err).Int("pid", pid).Msg("failed to signal process group, falling back to process signal")
 		} else if !errors.Is(err, syscall.ESRCH) {
 			return fmt.Errorf("failed to signal process group %d: %w", pid, err)
 		}

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -539,7 +539,7 @@ func (s *Service) Stop() error {
 	}
 
 	if err := stopProcess(process, pid, func(timeout time.Duration) error {
-		return waitForPIDExit(pid, timeout, serviceStopPollInterval, pidRunning)
+		return s.waitForServiceExit(pid, timeout)
 	}); err != nil {
 		return err
 	}
@@ -548,6 +548,16 @@ func (s *Service) Stop() error {
 		return err
 	}
 	return waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval)
+}
+
+func (s *Service) waitForServiceExit(pid int, timeout time.Duration) error {
+	pidPath := filepath.Join(s.pl.Settings().TempDir, config.PidFile)
+	return waitForPIDExit(pid, timeout, serviceStopPollInterval, func(pid int) bool {
+		if _, err := os.Stat(pidPath); errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+		return pidRunning(pid)
+	})
 }
 
 func stopProcess(process *os.Process, pid int, wait processWaitFunc) error {
@@ -766,7 +776,7 @@ func (s *Service) Restart() error {
 		}
 	}
 
-	if waitErr := waitForPIDExit(oldPID, serviceStopTimeout, serviceStopPollInterval, pidRunning); waitErr != nil {
+	if waitErr := s.waitForServiceExit(oldPID, serviceStopTimeout); waitErr != nil {
 		return waitErr
 	}
 	if waitErr := waitForAPIPortRelease(s.cfg, servicePortReleaseTimeout, serviceStopPollInterval); waitErr != nil {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -363,6 +363,10 @@ func TestStop_WaitsForProcessExitAndRemovesPIDFile(t *testing.T) {
 }
 
 func TestStopRemovesStalePIDFileWithoutKillingUnrelatedProcess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("service PID identity checks use Linux /proc")
+	}
+
 	svc := newTestService(t)
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
@@ -380,6 +384,10 @@ func TestStopRemovesStalePIDFileWithoutKillingUnrelatedProcess(t *testing.T) {
 }
 
 func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("service PID identity checks use Linux /proc")
+	}
+
 	svc := newTestService(t)
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
@@ -398,6 +406,10 @@ func TestRunningReturnsFalseForLiveUnrelatedPID(t *testing.T) {
 }
 
 func TestStartFailsForLiveUnrelatedPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("service PID identity checks use Linux /proc")
+	}
+
 	svc := newTestService(t)
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
@@ -415,6 +427,10 @@ func TestStartFailsForLiveUnrelatedPID(t *testing.T) {
 }
 
 func TestRestartFailsForLiveUnrelatedPID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("service PID identity checks use Linux /proc")
+	}
+
 	svc := newTestService(t)
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)
@@ -432,6 +448,10 @@ func TestRestartFailsForLiveUnrelatedPID(t *testing.T) {
 }
 
 func TestWaitForAPIReturnsPIDConflict(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("service PID identity checks use Linux /proc")
+	}
+
 	svc := newTestService(t)
 	settings := svc.pl.Settings()
 	pidFile := filepath.Join(settings.TempDir, config.PidFile)

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -72,10 +72,11 @@ func writeFakeServiceScript(t *testing.T, pidFile, eventLog string) string {
 	scriptTemplate := "#!/bin/sh\n" +
 		"pidfile=%q\n" +
 		"eventlog=%q\n" +
+		"cleanup() { rm -f \"$pidfile\"; exit 0; }\n" +
+		"trap cleanup INT TERM HUP\n" +
 		"printf 'started:%%s\\n' \"$$\" >> \"$eventlog\"\n" +
 		"printf '%%s' \"$$\" > \"$pidfile\"\n" +
-		"sleep 2\n" +
-		"rm -f \"$pidfile\"\n"
+		"while :; do sleep 1; done\n"
 	script := fmt.Sprintf(
 		scriptTemplate,
 		pidFile,
@@ -517,9 +518,13 @@ func TestWaitForAPIPortRelease(t *testing.T) {
 
 	addr, ok := listener.Addr().(*net.TCPAddr)
 	require.True(t, ok)
-	cfg, err := testhelpers.NewTestConfig(testhelpers.NewOSFS(), t.TempDir())
+	cfg, err := testhelpers.NewTestConfigWithListenAndPort(
+		testhelpers.NewOSFS(),
+		t.TempDir(),
+		"127.0.0.1",
+		addr.Port,
+	)
 	require.NoError(t, err)
-	require.NoError(t, cfg.SetAPIPort(addr.Port))
 
 	err = waitForAPIPortRelease(cfg, 20*time.Millisecond, 5*time.Millisecond)
 	require.Error(t, err)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -56,7 +56,7 @@ func TestStartReturnsErrorWhenAPIPortIsOccupied(t *testing.T) {
 		TempDir:   testRoot,
 	}
 
-	cfg, err := testhelpers.NewTestConfigWithPort(nil, testRoot, tcpAddr.Port)
+	cfg, err := testhelpers.NewTestConfigWithListenAndPort(nil, testRoot, "127.0.0.1", tcpAddr.Port)
 	require.NoError(t, err)
 	cfg.SetAutoUpdate(false)
 


### PR DESCRIPTION
## Summary
- make the service occupied-port test bind the exact reserved loopback address
- handle macOS process-group signal denial by falling back to direct process signaling
- skip Linux /proc PID identity assertions on non-Linux and include service packages in slim native PR tests

## Verification
- go test -run TestStartReturnsErrorWhenAPIPortIsOccupied ./pkg/service/
- go test ./pkg/service/daemon/
- go test ./pkg/service/ ./pkg/service/daemon/
- go test -race ./pkg/service/ ./pkg/service/daemon/
- golangci-lint run --timeout=5m ./pkg/service/...
- actionlint .github/workflows/lint-and-test.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of permission failures when signaling processes, with graceful fallback behavior.
  * Service stop/restart now reliably waits for the service to exit before proceeding.

* **Tests**
  * Added platform guards so Linux-dependent tests run only on Linux.
  * Made test service processes more robust and ensured PID cleanup on termination.
  * Ensured tests bind to the same loopback address and port for reliable port-occupancy checks.
  * Made log-close test resilient by retrying directory removal.

* **Chores**
  * Expanded CI test coverage to include additional service packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->