### PR TITLE
ci: create PR for MiSTer repo updates

### DIFF
--- a/.github/workflows/mister.yml
+++ b/.github/workflows/mister.yml
@@ -10,7 +10,8 @@ on:
         type: string
 
 permissions:
-  contents: write  # Needed for committing and pushing repo updates
+  contents: write  # Needed for pushing the generated repo update branch
+  pull-requests: write  # Needed for opening the repo update PR
 
 jobs:
   mister-repo:
@@ -41,9 +42,27 @@ jobs:
       - name: Create repo database
         run: |
           python3 scripts/mister/repo/generate.py ${{ steps.zaparooreleaseinfo.outputs.tag_name }}
-      - name: Commit repo database
-        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
-        with:
-          add: scripts/mister/repo/tapto.json -f -A
-          default_author: github_actions
-          message: 'Update MiSTer repo for ${{ steps.zaparooreleaseinfo.outputs.tag_name }}'
+      - name: Create repo database pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ steps.zaparooreleaseinfo.outputs.tag_name }}
+          BRANCH_NAME: mister-repo/${{ steps.zaparooreleaseinfo.outputs.tag_name }}-${{ github.run_id }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add scripts/mister/repo/tapto.json
+          if git diff --cached --quiet; then
+            echo "No MiSTer repo changes to publish."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+          git commit -m "Update MiSTer repo for $TAG_NAME"
+          git push --set-upstream origin "$BRANCH_NAME"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "Update MiSTer repo for $TAG_NAME" \
+            --body "Updates the MiSTer Downloader repo database for $TAG_NAME."

--- a/.github/workflows/mister.yml
+++ b/.github/workflows/mister.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.zaparooreleaseinfo.outputs.tag_name }}
-          BRANCH_NAME: mister-repo/${{ steps.zaparooreleaseinfo.outputs.tag_name }}-${{ github.run_id }}
+          BRANCH_NAME: mister-repo/${{ steps.zaparooreleaseinfo.outputs.tag_name }}-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Change the MiSTer Downloader repo workflow to push generated updates to a branch instead of directly to main.
- Open a pull request for generated repo database updates so branch protection rules are respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release automation now creates pull requests instead of committing directly to main, improving review and traceability.
  * Workflow generates a uniquely named branch per run and only opens a PR when staged changes are present.
  * PR title and body are derived from the release tag for clearer context.
  * CI permissions adjusted to support the new branch-and-PR publishing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->