### PR TITLE
test(api): add encryption protocol vectors

### DIFF
--- a/pkg/api/crypto/crypto_kat_test.go
+++ b/pkg/api/crypto/crypto_kat_test.go
@@ -1,0 +1,125 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package crypto_test
+
+import (
+	"bytes"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKAT_DeriveSessionKeysMatchesSpecLabels independently re-derives the
+// four session values using the literal info strings from
+// docs/api/encryption.md. If the implementation's info-string constants
+// drift from the spec, this test fails — and any JS/Swift/Kotlin client
+// compatibility breaks at the same moment.
+func TestKAT_DeriveSessionKeysMatchesSpecLabels(t *testing.T) {
+	t.Parallel()
+
+	pairingKey := bytes.Repeat([]byte{0x42}, crypto.PairingKeySize)
+	salt := bytes.Repeat([]byte{0xAA}, crypto.SessionSaltSize)
+
+	keys, err := crypto.DeriveSessionKeys(pairingKey, salt)
+	require.NoError(t, err)
+
+	prk, err := hkdf.Extract(sha256.New, pairingKey, salt)
+	require.NoError(t, err)
+
+	expC2SKey, err := hkdf.Expand(sha256.New, prk, "zaparoo-c2s-v1", 32)
+	require.NoError(t, err)
+	expS2CKey, err := hkdf.Expand(sha256.New, prk, "zaparoo-s2c-v1", 32)
+	require.NoError(t, err)
+	expC2SNonce, err := hkdf.Expand(sha256.New, prk, "zaparoo-c2s-nonce-v1", 12)
+	require.NoError(t, err)
+	expS2CNonce, err := hkdf.Expand(sha256.New, prk, "zaparoo-s2c-nonce-v1", 12)
+	require.NoError(t, err)
+
+	assert.Equal(t, expC2SKey, keys.C2SKey, "c2s key info string must be 'zaparoo-c2s-v1'")
+	assert.Equal(t, expS2CKey, keys.S2CKey, "s2c key info string must be 'zaparoo-s2c-v1'")
+	assert.Equal(t, expC2SNonce, keys.C2SNonce, "c2s nonce info string must be 'zaparoo-c2s-nonce-v1'")
+	assert.Equal(t, expS2CNonce, keys.S2CNonce, "s2c nonce info string must be 'zaparoo-s2c-nonce-v1'")
+}
+
+// TestKAT_NonceXORConstruction pins the nonce derivation: the spec says
+// nonce[0:4] = base[0:4] and nonce[4:12] = base[4:12] XOR (counter as
+// 8 bytes big-endian). buildNonce is unexported, so we exercise it via
+// Encrypt and compare against gcm.Seal called with a manually constructed
+// nonce.
+func TestKAT_NonceXORConstruction(t *testing.T) {
+	t.Parallel()
+
+	base := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c}
+	plaintext := []byte("zaparoo")
+	aad := []byte("auth-token:ws")
+	key := bytes.Repeat([]byte{0x77}, crypto.AESKeySize)
+
+	gcm, err := crypto.NewAEAD(key)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name        string
+		expectNonce []byte
+		counter     uint64
+	}{
+		{
+			name:        "counter_0_leaves_base_unchanged",
+			counter:     0,
+			expectNonce: base,
+		},
+		{
+			// 1 → BE = 00 00 00 00 00 00 00 01; XOR'd into base[4:12]:
+			//   05^00 06^00 07^00 08^00 09^00 0a^00 0b^00 0c^01
+			//   = 05 06 07 08 09 0a 0b 0d
+			name:        "counter_1",
+			counter:     1,
+			expectNonce: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0d},
+		},
+		{
+			// MaxUint64-1 = 0xFF FF FF FF FF FF FF FE — XORs every byte.
+			// MaxUint64 itself is rejected with ErrCounterExhausted.
+			name:    "counter_near_max_xors_every_byte",
+			counter: 0xFFFFFFFFFFFFFFFE,
+			expectNonce: []byte{
+				0x01, 0x02, 0x03, 0x04,
+				0x05 ^ 0xFF, 0x06 ^ 0xFF, 0x07 ^ 0xFF, 0x08 ^ 0xFF,
+				0x09 ^ 0xFF, 0x0a ^ 0xFF, 0x0b ^ 0xFF, 0x0c ^ 0xFE,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotCT, err := crypto.Encrypt(gcm, base, tc.counter, plaintext, aad)
+			require.NoError(t, err)
+
+			refCT := gcm.Seal(nil, tc.expectNonce, plaintext, aad)
+			assert.Equal(t, refCT, gotCT,
+				"Encrypt with counter=%d must use nonce = base XOR BE64(counter) at bytes [4:12]",
+				tc.counter)
+		})
+	}
+}

--- a/pkg/api/crypto/pake_kat_test.go
+++ b/pkg/api/crypto/pake_kat_test.go
@@ -1,0 +1,68 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package crypto_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKAT_PakeWireFormat_SpecExample uses the verbatim message-A example
+// from docs/api/encryption.md and confirms it round-trips through the
+// implementation's encode/decode without any field rename, type change,
+// or coordinate-format mutation. Acts as a frozen contract for client
+// implementors quoting the spec.
+func TestKAT_PakeWireFormat_SpecExample(t *testing.T) {
+	t.Parallel()
+
+	specExample := []byte(`{
+		"role": 0,
+		"ux": "793136080485469241208656611513609866400481671852",
+		"uy": "59748757929350367369315811184980635230185250460108398961713395032485227207304",
+		"vx": "1086685267857089638167386722555472967068468061489",
+		"vy": "9157340230202296554417312816309453883742349874205386245733062928888341584123",
+		"xx": "48439561293906451759052585252797914202762949526041747995844080717082404635286",
+		"xy": "36134250956749795798585127919587881956611106672985015071877198253568414405109",
+		"yx": "0",
+		"yy": "0"
+	}`)
+
+	internal, err := crypto.DecodePakeMessage(specExample)
+	require.NoError(t, err, "spec example must decode")
+
+	wire, err := crypto.EncodePakeMessage(internal)
+	require.NoError(t, err, "decoded message must re-encode")
+
+	var got, want map[string]any
+	require.NoError(t, json.Unmarshal(wire, &got))
+	require.NoError(t, json.Unmarshal(specExample, &want))
+
+	assert.Equal(t, want, got, "wire format must round-trip the spec example exactly")
+
+	for _, k := range []string{"ux", "uy", "vx", "vy", "xx", "xy", "yx", "yy"} {
+		_, isString := got[k].(string)
+		assert.True(t, isString,
+			"field %q must be a JSON string per spec (avoids IEEE-754 truncation)", k)
+	}
+}

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -22,8 +22,11 @@ package api
 import (
 	"bytes"
 	"crypto/hkdf"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -930,4 +933,134 @@ func TestCleanupExpired_RemovesExpiredPIN(t *testing.T) {
 
 	pin, _ := h.mgr.PendingPIN()
 	assert.Empty(t, pin)
+}
+
+// TestKAT_PairingHMAC_TranscriptStructure pins the LP-encoded transcript
+// from docs/api/encryption.md:
+//
+//	LP("zaparoo-v1") || LP("p256") || LP(role) || LP(name) || LP(MsgA) || LP(MsgB)
+//
+// where LP(x) = 4-byte BE uint32 length || x. If a future edit reorders
+// fields, drops one, or changes the LP encoding, this test fails.
+func TestKAT_PairingHMAC_TranscriptStructure(t *testing.T) {
+	t.Parallel()
+
+	key := bytes.Repeat([]byte{0xAB}, sha256.Size)
+	const role = "client"
+	const name = "Test App"
+	msgA := []byte(`{"role":0,"ux":"1","uy":"2","vx":"3","vy":"4","xx":"5","xy":"6","yx":"0","yy":"0"}`)
+	msgB := []byte(`{"role":1,"ux":"1","uy":"2","vx":"3","vy":"4","xx":"7","xy":"8","yx":"9","yy":"10"}`)
+
+	got := computePairingHMAC(key, role, name, msgA, msgB)
+
+	// Independent reconstruction directly from the spec text.
+	h := hmac.New(sha256.New, key)
+	for _, b := range [][]byte{
+		[]byte("zaparoo-v1"),
+		[]byte("p256"),
+		[]byte(role),
+		[]byte(name),
+		msgA,
+		msgB,
+	} {
+		var lp [4]byte
+		//nolint:gosec // bounded test inputs
+		binary.BigEndian.PutUint32(lp[:], uint32(len(b)))
+		_, _ = h.Write(lp[:])
+		_, _ = h.Write(b)
+	}
+	want := h.Sum(nil)
+
+	assert.Equal(t, want, got,
+		"HMAC must equal hmac(key, LP('zaparoo-v1') || LP('p256') || LP(role) || LP(name) || LP(MsgA) || LP(MsgB))")
+}
+
+// TestKAT_PairingHMAC_FrozenVector locks the HMAC output to a fixed hex
+// string. Acts as a cross-language test vector that JS/Swift/Kotlin
+// clients can copy verbatim to verify their own HMAC implementation.
+//
+// Bootstrap: on first run the placeholder constants are kept; the test
+// logs the actual hex via t.Logf without asserting. Replace the
+// placeholders with the logged hex to lock the vector. After that, any
+// change to the transcript format makes the test fail.
+func TestKAT_PairingHMAC_FrozenVector(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("0123456789abcdef0123456789abcdef") // 32 ASCII bytes
+	const name = "vectors"
+	msgA := []byte("AAAA")
+	msgB := []byte("BBBBBBBB")
+
+	clientHMAC := computePairingHMAC(key, "client", name, msgA, msgB)
+	serverHMAC := computePairingHMAC(key, "server", name, msgA, msgB)
+
+	// Frozen vectors — copy verbatim into JS/Swift/Kotlin client tests to
+	// verify their HMAC implementation matches the server.
+	const expectedClientHex = "8115121a13e707846e9957bfbb556dead52fd0952911a9c437a19a98e9b4a24d"
+	const expectedServerHex = "20a62cf030b6de31ccbd094dc9bb03fbeb1e7f028a37e0206c2885bd594252c3"
+
+	assert.Equal(t, expectedClientHex, hex.EncodeToString(clientHMAC),
+		"frozen client HMAC vector — protocol break if this changes")
+	assert.Equal(t, expectedServerHex, hex.EncodeToString(serverHMAC),
+		"frozen server HMAC vector — protocol break if this changes")
+	assert.NotEqual(t, expectedClientHex, expectedServerHex,
+		"client and server HMACs must differ (different role labels)")
+}
+
+// TestPairFinish_PINExhaustionInvalidatesOtherInFlightSessions checks the
+// multi-session case: if one client exhausts the PIN's attempts, another
+// client's in-flight session under the same PIN becomes unusable too.
+// TestMaxAttempts_PINInvalidatedAfterExhaustion only covers single-session
+// exhaustion — this pins the cross-session blast radius.
+func TestPairFinish_PINExhaustionInvalidatesOtherInFlightSessions(t *testing.T) {
+	t.Parallel()
+	// maxAttempts=1: a single wrong HMAC exhausts the PIN. Each finishSession
+	// call deletes its own session before incrementing pinAttempts, so a
+	// loop on one session would just hit ErrPairingSessionUnknown — we need
+	// exhaustion to land on a *different* session's lookup to demonstrate
+	// the cross-session blast radius.
+	h := newPairingHarness(t, WithPairingMaxAttempts(1))
+
+	pin, _, err := h.mgr.StartPairing()
+	require.NoError(t, err)
+
+	// Client A starts a session.
+	clientAPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgABytesA, err := crypto.EncodePakeMessage(clientAPake.Bytes())
+	require.NoError(t, err)
+	sessionA, _, err := h.mgr.startSession("Client A", msgABytesA)
+	require.NoError(t, err)
+
+	// Client B starts a second session under the same PIN.
+	clientBPake, err := pake.InitCurve([]byte(pin), 0, pairingCurve)
+	require.NoError(t, err)
+	msgABytesB, err := crypto.EncodePakeMessage(clientBPake.Bytes())
+	require.NoError(t, err)
+	sessionB, msgBBytesB, err := h.mgr.startSession("Client B", msgABytesB)
+	require.NoError(t, err)
+
+	// Drive client B to a CORRECT HMAC so we know its session would have
+	// otherwise succeeded.
+	msgBInternal, err := crypto.DecodePakeMessage(msgBBytesB)
+	require.NoError(t, err)
+	require.NoError(t, clientBPake.Update(msgBInternal))
+	clientBSessionKey, err := clientBPake.SessionKey()
+	require.NoError(t, err)
+	salt := slices.Concat(msgABytesB, msgBBytesB)
+	prk, err := hkdf.Extract(sha256.New, clientBSessionKey, salt)
+	require.NoError(t, err)
+	confirmKeyA, err := hkdf.Expand(sha256.New, prk, pairingInfoConfirmA, sha256.Size)
+	require.NoError(t, err)
+	correctHMACForB := computePairingHMAC(confirmKeyA, "client", "Client B", msgABytesB, msgBBytesB)
+
+	// One wrong attempt exhausts the PIN and wipes all sessions.
+	_, err = h.mgr.finishSession(sessionA, []byte("wrong hmac"))
+	require.ErrorIs(t, err, errPairingExhausted)
+
+	// Client B's CORRECT HMAC must now fail — the manager wiped sessions
+	// when the PIN was invalidated, so the lookup misses.
+	_, err = h.mgr.finishSession(sessionB, correctHMACForB)
+	require.ErrorIs(t, err, errPairingSessionUnknown,
+		"B's session must be wiped when A exhausts the PIN")
 }

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -1,0 +1,232 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/gorilla/websocket"
+	"github.com/olahol/melody"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRemoteListener wraps a real listener so tests can pretend connections
+// arrived from a non-loopback address. Required because melody/net.http
+// expose RemoteAddr through the underlying net.Conn — the only clean way
+// to override it is at the listener layer.
+type fakeRemoteListener struct {
+	net.Listener
+	fakeAddr net.Addr
+}
+
+func (l *fakeRemoteListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err //nolint:wrapcheck // pass-through wrapper for tests
+	}
+	return &fakeRemoteConn{Conn: c, fakeAddr: l.fakeAddr}, nil
+}
+
+type fakeRemoteConn struct {
+	net.Conn
+	fakeAddr net.Addr
+}
+
+func (c *fakeRemoteConn) RemoteAddr() net.Addr { return c.fakeAddr }
+
+// startWSServer spins up a minimal httptest server whose only message
+// handler is decryptIncomingFrame. fakeRemote, if non-nil, replaces the
+// connection's RemoteAddr to simulate a non-loopback client.
+func startWSServer(
+	t *testing.T,
+	encryptionEnabled bool,
+	gateway *apimiddleware.EncryptionGateway,
+	fakeRemote net.Addr,
+) (wsURL string, cleanup func()) {
+	t.Helper()
+
+	m := melody.New()
+	m.HandleMessage(func(s *melody.Session, msg []byte) {
+		clientIP := apimiddleware.ParseRemoteIP(s.Request.RemoteAddr)
+		isLocal := apimiddleware.IsLoopbackAddr(s.Request.RemoteAddr)
+		var sourceIP string
+		if clientIP != nil {
+			sourceIP = clientIP.String()
+		}
+		pt, _, ok := decryptIncomingFrame(s, msg, gateway, encryptionEnabled, isLocal, sourceIP)
+		if !ok {
+			return
+		}
+		// Echo plaintext back so the loopback bypass test can observe success.
+		_ = s.Write(pt)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+
+	srv := httptest.NewUnstartedServer(mux)
+	if fakeRemote != nil {
+		var lc net.ListenConfig
+		ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		srv.Listener = &fakeRemoteListener{Listener: ln, fakeAddr: fakeRemote}
+	}
+	srv.Start()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	wsURL = "ws://" + u.Host + "/api"
+
+	cleanup = func() {
+		_ = m.Close()
+		srv.Close()
+	}
+	return wsURL, cleanup
+}
+
+// dialWS opens a gorilla/websocket connection. Caller must close the conn.
+func dialWS(t *testing.T, wsURL string) *websocket.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	c, resp, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
+	require.NoError(t, err)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return c
+}
+
+// TestWSEncryption_RemotePlaintextRejectedWhenEnabled pins:
+// remote IP + encryption=true + plaintext frame → -32002 plaintext error,
+// then connection closed.
+func TestWSEncryption_RemotePlaintextRejectedWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	gateway := apimiddleware.NewEncryptionGateway(helpers.NewMockUserDBI())
+	fakeRemote := &net.TCPAddr{IP: net.ParseIP("203.0.113.5"), Port: 12345}
+
+	wsURL, cleanup := startWSServer(t, true, gateway, fakeRemote)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	// Send a plaintext JSON-RPC request — not an encrypted first frame.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"version","id":1}`)))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err, "server must send a plaintext error before closing")
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(msg, &parsed))
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, float64(-32002), errObj["code"], 0,
+		"remote plaintext on encryption=true must trigger -32002")
+
+	// Subsequent read should fail (server closed the connection).
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err)
+}
+
+// TestWSEncryption_UnsupportedVersionPlaintextError pins:
+// well-formed first frame with v=2 → -32001 plaintext error + close.
+func TestWSEncryption_UnsupportedVersionPlaintextError(t *testing.T) {
+	t.Parallel()
+
+	gateway := apimiddleware.NewEncryptionGateway(helpers.NewMockUserDBI())
+	fakeRemote := &net.TCPAddr{IP: net.ParseIP("203.0.113.5"), Port: 12345}
+
+	wsURL, cleanup := startWSServer(t, true, gateway, fakeRemote)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	frame := apimiddleware.EncryptedFirstFrame{
+		Version:     2,
+		Ciphertext:  "AA==",
+		AuthToken:   "00000000-0000-0000-0000-000000000000",
+		SessionSalt: strings.Repeat("A", 24), // base64 of 16 bytes
+	}
+	//nolint:gosec // G117 false positive: hardcoded all-zero UUID, not a credential
+	body, err := json.Marshal(frame)
+	require.NoError(t, err)
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, body))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(msg, &parsed))
+	errObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.InDelta(t, float64(-32001), errObj["code"], 0,
+		"unsupported encryption version must trigger -32001")
+
+	// data.supported must be present per JSON-RPC 2.0 §5.1.
+	errData, ok := errObj["data"].(map[string]any)
+	require.True(t, ok)
+	supported, ok := errData["supported"].([]any)
+	require.True(t, ok)
+	require.Len(t, supported, 1)
+	assert.InDelta(t, float64(1), supported[0], 0)
+}
+
+// TestWSEncryption_LoopbackPlaintextAllowedWhenEnabled pins the spec
+// contract: even with encryption=true, plaintext from 127.0.0.1 works
+// without pairing. Run without overriding RemoteAddr — httptest naturally
+// uses 127.0.0.1.
+func TestWSEncryption_LoopbackPlaintextAllowedWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	gateway := apimiddleware.NewEncryptionGateway(helpers.NewMockUserDBI())
+
+	wsURL, cleanup := startWSServer(t, true, gateway, nil)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	plaintext := []byte(`{"jsonrpc":"2.0","method":"version","id":1}`)
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, plaintext))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, got, err := conn.ReadMessage()
+	require.NoError(t, err, "loopback plaintext must be accepted on encryption=true")
+	assert.Equal(t, plaintext, got, "test echo handler returns the plaintext unchanged")
+}

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -180,7 +179,7 @@ func TestWSEncryption_UnsupportedVersionPlaintextError(t *testing.T) {
 		Version:     2,
 		Ciphertext:  "AA==",
 		AuthToken:   "00000000-0000-0000-0000-000000000000",
-		SessionSalt: strings.Repeat("A", 24), // base64 of 16 bytes
+		SessionSalt: "3zMzoum7Y3eh+peN25WzDg==", // base64 of 16 bytes
 	}
 	//nolint:gosec // G117 false positive: hardcoded all-zero UUID, not a credential
 	body, err := json.Marshal(frame)


### PR DESCRIPTION
## Summary
- add KAT coverage for API encryption key derivation, nonce construction, PAKE wire format, and pairing HMAC transcript
- add WebSocket encryption behavior tests for remote plaintext rejection, unsupported versions, and loopback plaintext allowance
- add regression coverage for multi-session pairing PIN exhaustion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests
* Added KATs verifying cryptographic session key derivation and nonce construction behavior.
* Added PAKE wire-format encoding/decoding contract test to ensure deterministic JSON round-trip.
* Expanded PIN exhaustion checks to cover multi-session interactions and failure behavior.
* Added WebSocket end-to-end tests for encrypted/unencrypted frames, remote-address handling, and protocol version error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->