### PR TITLE
test(steam): cover non-Steam shortcut scanning

### DIFF
--- a/pkg/platforms/shared/steam/scanner.go
+++ b/pkg/platforms/shared/steam/scanner.go
@@ -158,6 +158,13 @@ func ScanSteamApps(steamDir string) ([]platforms.ScanResult, error) {
 // steamDir should point to the Steam root directory.
 func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 	var results []platforms.ScanResult
+	var userDirsScanned int
+	var shortcutsFilesFound int
+	var shortcutFileAccessFailures int
+	var shortcutFileReadFailures int
+	var shortcutFileParseFailures int
+	var parsedShortcuts int
+	var skippedBlankNames int
 
 	log.Debug().Str("steamDir", steamDir).Msg("scanning Steam shortcuts")
 
@@ -168,6 +175,11 @@ func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 		} else {
 			log.Warn().Err(err).Str("path", userdataDir).Msg("error accessing Steam userdata directory")
 		}
+		log.Debug().
+			Str("steamDir", steamDir).
+			Str("userdataDir", userdataDir).
+			Int("results", len(results)).
+			Msg("Steam shortcuts scan complete")
 		return results, nil
 	}
 
@@ -184,31 +196,37 @@ func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 			log.Debug().Str("name", userDir.Name()).Msg("skipping non-directory entry in userdata")
 			continue
 		}
+		userDirsScanned++
 
 		shortcutsPath := filepath.Join(userdataDir, userDir.Name(), "config", "shortcuts.vdf")
 		if _, err := os.Stat(shortcutsPath); err != nil {
 			if os.IsNotExist(err) {
 				log.Debug().Str("userId", userDir.Name()).Msg("no shortcuts.vdf for user")
 			} else {
+				shortcutFileAccessFailures++
 				log.Warn().Err(err).Str("path", shortcutsPath).Msg("error accessing shortcuts.vdf")
 			}
 			continue
 		}
+		shortcutsFilesFound++
 
 		log.Debug().Str("path", shortcutsPath).Msg("reading shortcuts")
 
 		//nolint:gosec // Safe: reads Steam config files for game library scanning
 		shortcutsData, err := os.ReadFile(shortcutsPath)
 		if err != nil {
+			shortcutFileReadFailures++
 			log.Error().Err(err).Msgf("error reading shortcuts.vdf: %s", shortcutsPath)
 			continue
 		}
 
 		shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(shortcutsData))
 		if err != nil {
+			shortcutFileParseFailures++
 			log.Error().Err(err).Msgf("error parsing shortcuts.vdf: %s", shortcutsPath)
 			continue
 		}
+		parsedShortcuts += len(shortcuts)
 
 		log.Debug().
 			Str("userId", userDir.Name()).
@@ -217,6 +235,7 @@ func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 
 		for _, shortcut := range shortcuts {
 			if shortcut.AppName == "" {
+				skippedBlankNames++
 				continue
 			}
 
@@ -233,7 +252,19 @@ func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 		}
 	}
 
-	log.Debug().Int("total", len(results)).Msg("Steam shortcuts scan complete")
+	log.Debug().
+		Str("steamDir", steamDir).
+		Str("userdataDir", userdataDir).
+		Int("userdataEntries", len(userDirs)).
+		Int("userDirsScanned", userDirsScanned).
+		Int("shortcutFilesFound", shortcutsFilesFound).
+		Int("shortcutFileAccessFailures", shortcutFileAccessFailures).
+		Int("shortcutFileReadFailures", shortcutFileReadFailures).
+		Int("shortcutFileParseFailures", shortcutFileParseFailures).
+		Int("parsedShortcuts", parsedShortcuts).
+		Int("skippedBlankNames", skippedBlankNames).
+		Int("results", len(results)).
+		Msg("Steam shortcuts scan complete")
 
 	return results, nil
 }

--- a/pkg/platforms/shared/steam/scanner.go
+++ b/pkg/platforms/shared/steam/scanner.go
@@ -178,6 +178,14 @@ func ScanSteamShortcuts(steamDir string) ([]platforms.ScanResult, error) {
 		log.Debug().
 			Str("steamDir", steamDir).
 			Str("userdataDir", userdataDir).
+			Int("userdataEntries", 0).
+			Int("userDirsScanned", userDirsScanned).
+			Int("shortcutFilesFound", shortcutsFilesFound).
+			Int("shortcutFileAccessFailures", shortcutFileAccessFailures).
+			Int("shortcutFileReadFailures", shortcutFileReadFailures).
+			Int("shortcutFileParseFailures", shortcutFileParseFailures).
+			Int("parsedShortcuts", parsedShortcuts).
+			Int("skippedBlankNames", skippedBlankNames).
 			Int("results", len(results)).
 			Msg("Steam shortcuts scan complete")
 		return results, nil

--- a/pkg/platforms/shared/steam/scanner_test.go
+++ b/pkg/platforms/shared/steam/scanner_test.go
@@ -20,11 +20,15 @@
 package steam
 
 import (
+	"bytes"
+	"encoding/binary"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/virtualpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +37,80 @@ import (
 // VDF format requires backslashes to be escaped as double backslashes.
 func vdfEscapePath(path string) string {
 	return strings.ReplaceAll(path, `\`, `\\`)
+}
+
+type testShortcut struct {
+	AppName       string
+	Exe           string
+	StartDir      string
+	LaunchOptions string
+	AppID         uint32
+	Optional      bool
+}
+
+func writeVDFString(buf *bytes.Buffer, key, value string) {
+	_ = buf.WriteByte(0x01)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(0x00)
+	_, _ = buf.WriteString(value)
+	_ = buf.WriteByte(0x00)
+}
+
+func writeVDFUint32(buf *bytes.Buffer, key string, value uint32) {
+	_ = buf.WriteByte(0x02)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(0x00)
+	var raw [4]byte
+	binary.LittleEndian.PutUint32(raw[:], value)
+	_, _ = buf.Write(raw[:])
+}
+
+func writeEmptyVDFMap(buf *bytes.Buffer, key string) {
+	_ = buf.WriteByte(0x00)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(0x00)
+	_ = buf.WriteByte(0x08)
+}
+
+func buildShortcutsVDF(shortcuts []testShortcut) []byte {
+	var buf bytes.Buffer
+
+	_ = buf.WriteByte(0x00)
+	_, _ = buf.WriteString("shortcuts")
+	_ = buf.WriteByte(0x00)
+
+	for i, shortcut := range shortcuts {
+		_ = buf.WriteByte(0x00)
+		_, _ = buf.WriteString(strconv.Itoa(i))
+		_ = buf.WriteByte(0x00)
+
+		writeVDFUint32(&buf, "appid", shortcut.AppID)
+		writeVDFString(&buf, "AppName", shortcut.AppName)
+		writeVDFString(&buf, "Exe", shortcut.Exe)
+		writeVDFString(&buf, "StartDir", shortcut.StartDir)
+		writeVDFString(&buf, "LaunchOptions", shortcut.LaunchOptions)
+
+		if shortcut.Optional {
+			writeVDFString(&buf, "icon", "")
+			writeVDFString(&buf, "ShortcutPath", "")
+			writeVDFUint32(&buf, "IsHidden", 0)
+			writeVDFUint32(&buf, "AllowDesktopConfig", 1)
+			writeVDFUint32(&buf, "AllowOverlay", 1)
+			writeEmptyVDFMap(&buf, "tags")
+		}
+
+		_ = buf.WriteByte(0x08)
+	}
+
+	_ = buf.WriteByte(0x08)
+	_ = buf.WriteByte(0x08)
+
+	return buf.Bytes()
+}
+
+func shortcutVirtualPath(appID uint32, appName string) string {
+	bpid := (uint64(appID) << 32) | 0x02000000
+	return virtualpath.CreateVirtualPath("steam", strconv.FormatUint(bpid, 10), appName)
 }
 
 func TestScanSteamApps(t *testing.T) {
@@ -199,6 +277,47 @@ func TestScanSteamShortcuts(t *testing.T) {
 
 		require.NoError(t, scanErr)
 		assert.Empty(t, results)
+	})
+
+	t.Run("scans_non_steam_shortcuts_from_user_config", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		userdataDir := filepath.Join(tempDir, "userdata", "12345678", "config")
+		require.NoError(t, os.MkdirAll(userdataDir, 0o750))
+
+		shortcuts := []testShortcut{
+			{
+				AppID:   624353111,
+				AppName: "Capcom vs. SNK 2 Mark of the Millennium 2001",
+				Exe: `"C:\Games\RetroArch\retroarch.exe" ` +
+					`-L "cores\flycast_libretro.dll" "roms\Capcom vs SNK 2.chd"`,
+				StartDir:      `"C:\Games\RetroArch"`,
+				LaunchOptions: "",
+				Optional:      true,
+			},
+			{
+				AppID:         3545518019,
+				AppName:       "Hyper Duel",
+				Exe:           `"C:\Games\RetroArch\retroarch.exe"`,
+				StartDir:      `"C:\Games\RetroArch"`,
+				LaunchOptions: `-L "cores\mednafen_saturn_libretro.dll" "roms\Hyper Duel.chd"`,
+				Optional:      false,
+			},
+		}
+		err := os.WriteFile(filepath.Join(userdataDir, "shortcuts.vdf"), buildShortcutsVDF(shortcuts), 0o600)
+		require.NoError(t, err)
+
+		results, scanErr := ScanSteamShortcuts(tempDir)
+
+		require.NoError(t, scanErr)
+		require.Len(t, results, 2)
+		assert.Equal(t, shortcuts[0].AppName, results[0].Name)
+		assert.Equal(t, shortcutVirtualPath(shortcuts[0].AppID, shortcuts[0].AppName), results[0].Path)
+		assert.True(t, results[0].NoExt)
+		assert.Equal(t, shortcuts[1].AppName, results[1].Name)
+		assert.Equal(t, shortcutVirtualPath(shortcuts[1].AppID, shortcuts[1].AppName), results[1].Path)
+		assert.True(t, results[1].NoExt)
 	})
 
 	t.Run("skips_non_directory_entries", func(t *testing.T) {

--- a/pkg/platforms/shared/steam/scanner_test.go
+++ b/pkg/platforms/shared/steam/scanner_test.go
@@ -20,8 +20,6 @@
 package steam
 
 import (
-	"bytes"
-	"encoding/binary"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/virtualpath"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/fixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,75 +36,6 @@ import (
 // VDF format requires backslashes to be escaped as double backslashes.
 func vdfEscapePath(path string) string {
 	return strings.ReplaceAll(path, `\`, `\\`)
-}
-
-type testShortcut struct {
-	AppName       string
-	Exe           string
-	StartDir      string
-	LaunchOptions string
-	AppID         uint32
-	Optional      bool
-}
-
-func writeVDFString(buf *bytes.Buffer, key, value string) {
-	_ = buf.WriteByte(0x01)
-	_, _ = buf.WriteString(key)
-	_ = buf.WriteByte(0x00)
-	_, _ = buf.WriteString(value)
-	_ = buf.WriteByte(0x00)
-}
-
-func writeVDFUint32(buf *bytes.Buffer, key string, value uint32) {
-	_ = buf.WriteByte(0x02)
-	_, _ = buf.WriteString(key)
-	_ = buf.WriteByte(0x00)
-	var raw [4]byte
-	binary.LittleEndian.PutUint32(raw[:], value)
-	_, _ = buf.Write(raw[:])
-}
-
-func writeEmptyVDFMap(buf *bytes.Buffer, key string) {
-	_ = buf.WriteByte(0x00)
-	_, _ = buf.WriteString(key)
-	_ = buf.WriteByte(0x00)
-	_ = buf.WriteByte(0x08)
-}
-
-func buildShortcutsVDF(shortcuts []testShortcut) []byte {
-	var buf bytes.Buffer
-
-	_ = buf.WriteByte(0x00)
-	_, _ = buf.WriteString("shortcuts")
-	_ = buf.WriteByte(0x00)
-
-	for i, shortcut := range shortcuts {
-		_ = buf.WriteByte(0x00)
-		_, _ = buf.WriteString(strconv.Itoa(i))
-		_ = buf.WriteByte(0x00)
-
-		writeVDFUint32(&buf, "appid", shortcut.AppID)
-		writeVDFString(&buf, "AppName", shortcut.AppName)
-		writeVDFString(&buf, "Exe", shortcut.Exe)
-		writeVDFString(&buf, "StartDir", shortcut.StartDir)
-		writeVDFString(&buf, "LaunchOptions", shortcut.LaunchOptions)
-
-		if shortcut.Optional {
-			writeVDFString(&buf, "icon", "")
-			writeVDFString(&buf, "ShortcutPath", "")
-			writeVDFUint32(&buf, "IsHidden", 0)
-			writeVDFUint32(&buf, "AllowDesktopConfig", 1)
-			writeVDFUint32(&buf, "AllowOverlay", 1)
-			writeEmptyVDFMap(&buf, "tags")
-		}
-
-		_ = buf.WriteByte(0x08)
-	}
-
-	_ = buf.WriteByte(0x08)
-	_ = buf.WriteByte(0x08)
-
-	return buf.Bytes()
 }
 
 func shortcutVirtualPath(appID uint32, appName string) string {
@@ -286,7 +216,7 @@ func TestScanSteamShortcuts(t *testing.T) {
 		userdataDir := filepath.Join(tempDir, "userdata", "12345678", "config")
 		require.NoError(t, os.MkdirAll(userdataDir, 0o750))
 
-		shortcuts := []testShortcut{
+		shortcuts := []fixtures.TestShortcut{
 			{
 				AppID:   624353111,
 				AppName: "Capcom vs. SNK 2 Mark of the Millennium 2001",
@@ -305,7 +235,7 @@ func TestScanSteamShortcuts(t *testing.T) {
 				Optional:      false,
 			},
 		}
-		err := os.WriteFile(filepath.Join(userdataDir, "shortcuts.vdf"), buildShortcutsVDF(shortcuts), 0o600)
+		err := os.WriteFile(filepath.Join(userdataDir, "shortcuts.vdf"), fixtures.BuildShortcutsVDF(shortcuts), 0o600)
 		require.NoError(t, err)
 
 		results, scanErr := ScanSteamShortcuts(tempDir)

--- a/pkg/testing/fixtures/steam.go
+++ b/pkg/testing/fixtures/steam.go
@@ -38,6 +38,7 @@ type TestShortcut struct {
 	StartDir      string
 	LaunchOptions string
 	AppID         uint32
+	IsHidden      bool
 	Optional      bool
 }
 
@@ -56,6 +57,15 @@ func writeVDFUint32(buf *bytes.Buffer, key string, value uint32) {
 	var raw [4]byte
 	binary.LittleEndian.PutUint32(raw[:], value)
 	_, _ = buf.Write(raw[:])
+}
+
+func writeVDFBool(buf *bytes.Buffer, key string, value bool) {
+	if value {
+		writeVDFUint32(buf, key, 1)
+		return
+	}
+
+	writeVDFUint32(buf, key, 0)
 }
 
 func writeEmptyVDFMap(buf *bytes.Buffer, key string) {
@@ -78,17 +88,17 @@ func BuildShortcutsVDF(shortcuts []TestShortcut) []byte {
 		_ = buf.WriteByte(VDFMapStartMarker)
 
 		writeVDFUint32(&buf, "appid", shortcut.AppID)
-		writeVDFString(&buf, "AppName", shortcut.AppName)
-		writeVDFString(&buf, "Exe", shortcut.Exe)
-		writeVDFString(&buf, "StartDir", shortcut.StartDir)
-		writeVDFString(&buf, "LaunchOptions", shortcut.LaunchOptions)
+		writeVDFString(&buf, "appname", shortcut.AppName)
+		writeVDFString(&buf, "exe", shortcut.Exe)
+		writeVDFString(&buf, "startdir", shortcut.StartDir)
+		writeVDFString(&buf, "launchoptions", shortcut.LaunchOptions)
 
 		if shortcut.Optional {
 			writeVDFString(&buf, "icon", "")
-			writeVDFString(&buf, "ShortcutPath", "")
-			writeVDFUint32(&buf, "IsHidden", 0)
-			writeVDFUint32(&buf, "AllowDesktopConfig", 1)
-			writeVDFUint32(&buf, "AllowOverlay", 1)
+			writeVDFString(&buf, "shortcutpath", "")
+			writeVDFBool(&buf, "ishidden", shortcut.IsHidden)
+			writeVDFUint32(&buf, "allowdesktopconfig", 1)
+			writeVDFUint32(&buf, "allowoverlay", 1)
 			writeEmptyVDFMap(&buf, "tags")
 		}
 

--- a/pkg/testing/fixtures/steam.go
+++ b/pkg/testing/fixtures/steam.go
@@ -1,0 +1,102 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package fixtures
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+)
+
+const (
+	VDFMapStartMarker byte = 0x00
+	VDFStringMarker   byte = 0x01
+	VDFUint32Marker   byte = 0x02
+	VDFMapEndMarker   byte = 0x08
+)
+
+type TestShortcut struct {
+	AppName       string
+	Exe           string
+	StartDir      string
+	LaunchOptions string
+	AppID         uint32
+	Optional      bool
+}
+
+func writeVDFString(buf *bytes.Buffer, key, value string) {
+	_ = buf.WriteByte(VDFStringMarker)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(VDFMapStartMarker)
+	_, _ = buf.WriteString(value)
+	_ = buf.WriteByte(VDFMapStartMarker)
+}
+
+func writeVDFUint32(buf *bytes.Buffer, key string, value uint32) {
+	_ = buf.WriteByte(VDFUint32Marker)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(VDFMapStartMarker)
+	var raw [4]byte
+	binary.LittleEndian.PutUint32(raw[:], value)
+	_, _ = buf.Write(raw[:])
+}
+
+func writeEmptyVDFMap(buf *bytes.Buffer, key string) {
+	_ = buf.WriteByte(VDFMapStartMarker)
+	_, _ = buf.WriteString(key)
+	_ = buf.WriteByte(VDFMapStartMarker)
+	_ = buf.WriteByte(VDFMapEndMarker)
+}
+
+func BuildShortcutsVDF(shortcuts []TestShortcut) []byte {
+	var buf bytes.Buffer
+
+	_ = buf.WriteByte(VDFMapStartMarker)
+	_, _ = buf.WriteString("shortcuts")
+	_ = buf.WriteByte(VDFMapStartMarker)
+
+	for i, shortcut := range shortcuts {
+		_ = buf.WriteByte(VDFMapStartMarker)
+		_, _ = buf.WriteString(strconv.Itoa(i))
+		_ = buf.WriteByte(VDFMapStartMarker)
+
+		writeVDFUint32(&buf, "appid", shortcut.AppID)
+		writeVDFString(&buf, "AppName", shortcut.AppName)
+		writeVDFString(&buf, "Exe", shortcut.Exe)
+		writeVDFString(&buf, "StartDir", shortcut.StartDir)
+		writeVDFString(&buf, "LaunchOptions", shortcut.LaunchOptions)
+
+		if shortcut.Optional {
+			writeVDFString(&buf, "icon", "")
+			writeVDFString(&buf, "ShortcutPath", "")
+			writeVDFUint32(&buf, "IsHidden", 0)
+			writeVDFUint32(&buf, "AllowDesktopConfig", 1)
+			writeVDFUint32(&buf, "AllowOverlay", 1)
+			writeEmptyVDFMap(&buf, "tags")
+		}
+
+		_ = buf.WriteByte(VDFMapEndMarker)
+	}
+
+	_ = buf.WriteByte(VDFMapEndMarker)
+	_ = buf.WriteByte(VDFMapEndMarker)
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary
- Add a regression test for non-Steam shortcuts loaded from userdata config, including realistic RetroArch shortcut command shapes.
- Add Steam shortcut scan summary counters so debug logs show whether files were found, parsed, skipped, or failed.

Refs #725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Steam shortcuts scanner diagnostics with detailed scan metrics and clearer debug logging for missing/unreadable user data; no public APIs changed.

* **Tests**
  * Added generated Steam-shortcuts fixtures and a new test validating discovered shortcuts and their metadata (names, paths, extension flags).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->