### PR TITLE
ci: use conventional title for MiSTer update PR

### DIFF
--- a/.github/workflows/mister.yml
+++ b/.github/workflows/mister.yml
@@ -58,11 +58,11 @@ jobs:
           fi
 
           git checkout -b "$BRANCH_NAME"
-          git commit -m "Update MiSTer repo for $TAG_NAME"
+          git commit -m "chore(mister): update MiSTer repo for $TAG_NAME"
           git push --set-upstream origin "$BRANCH_NAME"
 
           gh pr create \
             --base main \
             --head "$BRANCH_NAME" \
-            --title "Update MiSTer repo for $TAG_NAME" \
+            --title "chore(mister): update MiSTer repo for $TAG_NAME" \
             --body "Updates the MiSTer Downloader repo database for $TAG_NAME."


### PR DESCRIPTION
## Summary
- Update the MiSTer repo workflow's generated PR title to pass the conventional commit title gate.
- Match the generated commit message to the same conventional style for consistency.
- Confirmed other automated PR creators already use valid titles or do not create PRs.

Closes #752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration for improved commit message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->