### PR TITLE
fix(api): align websocket origin validation with CORS

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -66,6 +66,7 @@ import (
 var allowedOrigins = []string{
 	"capacitor://localhost", // iOS Capacitor v3+
 	"ionic://localhost",     // iOS Capacitor v2
+	"https://zaparoo.app",   // Hosted web app
 	"https://localhost",     // Android
 	"http://localhost",      // Fallback/development
 }
@@ -501,7 +502,7 @@ func isPrivateIP(ipStr string) bool {
 	return false
 }
 
-// isAllowedOrigin validates HTTP/WebSocket origins against shared allowlist policy.
+// isAllowedOrigin validates HTTP/WebSocket origins against the explicit allowlist.
 func isAllowedOrigin(
 	origin string,
 	staticOrigins []string,
@@ -534,36 +535,6 @@ func isAllowedOrigin(
 			log.Debug().Msgf("%s origin: %s allowed (custom match)", logPrefix, origin)
 			return true
 		}
-	}
-
-	// Parse origin URL
-	u, err := url.Parse(origin)
-	if err != nil {
-		log.Debug().Msgf("%s origin: %s rejected (invalid URL: %v)", logPrefix, origin, err)
-		return false
-	}
-
-	// Allow localhost and 127.0.0.1 on any port
-	hostname := u.Hostname()
-	if hostname == "localhost" || hostname == "127.0.0.1" {
-		log.Debug().Msgf("%s origin: %s allowed (localhost any port)", logPrefix, origin)
-		return true
-	}
-
-	// Allow private IP addresses only on the correct API port
-	if isPrivateIP(hostname) {
-		port := u.Port()
-		if port == "" && (u.Scheme == "http" || u.Scheme == "https") {
-			log.Debug().Msgf("%s origin: %s rejected (private IP needs explicit port)", logPrefix, origin)
-			return false
-		}
-		if port == strconv.Itoa(apiPort) {
-			log.Debug().Msgf("%s origin: %s allowed (private IP correct port)", logPrefix, origin)
-			return true
-		}
-		log.Debug().Msgf("%s origin: %s rejected (private IP wrong port: %s, expected: %d)",
-			logPrefix, origin, port, apiPort)
-		return false
 	}
 
 	log.Debug().Msgf("%s origin: %s rejected (not allowed)", logPrefix, origin)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -501,23 +501,28 @@ func isPrivateIP(ipStr string) bool {
 	return false
 }
 
-// checkWebSocketOrigin validates WebSocket origin requests based on security policy.
-// It checks static origins and dynamically fetches custom origins from the provider.
-func checkWebSocketOrigin(
+// isAllowedOrigin validates HTTP/WebSocket origins against shared allowlist policy.
+func isAllowedOrigin(
 	origin string,
 	staticOrigins []string,
 	customOriginsProvider OriginsProvider,
 	apiPort int,
+	allowEmptyOrigin bool,
+	logPrefix string,
 ) bool {
 	if origin == "" {
-		log.Debug().Msg("websocket origin: empty origin allowed (same-origin)")
-		return true
+		if allowEmptyOrigin {
+			log.Debug().Msgf("%s origin: empty origin allowed (same-origin)", logPrefix)
+			return true
+		}
+		log.Debug().Msgf("%s origin: empty origin rejected", logPrefix)
+		return false
 	}
 
 	// Check static origins (case-insensitive)
 	for _, allowed := range staticOrigins {
 		if strings.EqualFold(origin, allowed) {
-			log.Debug().Msgf("websocket origin: %s allowed (static match)", origin)
+			log.Debug().Msgf("%s origin: %s allowed (static match)", logPrefix, origin)
 			return true
 		}
 	}
@@ -526,7 +531,7 @@ func checkWebSocketOrigin(
 	customOrigins := expandCustomOrigins(customOriginsProvider(), apiPort)
 	for _, allowed := range customOrigins {
 		if strings.EqualFold(origin, allowed) {
-			log.Debug().Msgf("websocket origin: %s allowed (custom match)", origin)
+			log.Debug().Msgf("%s origin: %s allowed (custom match)", logPrefix, origin)
 			return true
 		}
 	}
@@ -534,14 +539,14 @@ func checkWebSocketOrigin(
 	// Parse origin URL
 	u, err := url.Parse(origin)
 	if err != nil {
-		log.Debug().Msgf("websocket origin: %s rejected (invalid URL: %v)", origin, err)
+		log.Debug().Msgf("%s origin: %s rejected (invalid URL: %v)", logPrefix, origin, err)
 		return false
 	}
 
 	// Allow localhost and 127.0.0.1 on any port
 	hostname := u.Hostname()
 	if hostname == "localhost" || hostname == "127.0.0.1" {
-		log.Debug().Msgf("websocket origin: %s allowed (localhost any port)", origin)
+		log.Debug().Msgf("%s origin: %s allowed (localhost any port)", logPrefix, origin)
 		return true
 	}
 
@@ -549,19 +554,19 @@ func checkWebSocketOrigin(
 	if isPrivateIP(hostname) {
 		port := u.Port()
 		if port == "" && (u.Scheme == "http" || u.Scheme == "https") {
-			log.Debug().Msgf("websocket origin: %s rejected (private IP needs explicit port)", origin)
+			log.Debug().Msgf("%s origin: %s rejected (private IP needs explicit port)", logPrefix, origin)
 			return false
 		}
 		if port == strconv.Itoa(apiPort) {
-			log.Debug().Msgf("websocket origin: %s allowed (private IP correct port)", origin)
+			log.Debug().Msgf("%s origin: %s allowed (private IP correct port)", logPrefix, origin)
 			return true
 		}
-		log.Debug().Msgf("websocket origin: %s rejected (private IP wrong port: %s, expected: %d)",
-			origin, port, apiPort)
+		log.Debug().Msgf("%s origin: %s rejected (private IP wrong port: %s, expected: %d)",
+			logPrefix, origin, port, apiPort)
 		return false
 	}
 
-	log.Debug().Msgf("websocket origin: %s rejected (not allowed)", origin)
+	log.Debug().Msgf("%s origin: %s rejected (not allowed)", logPrefix, origin)
 	return false
 }
 
@@ -630,28 +635,8 @@ func makeOriginValidator(
 	customOriginsProvider OriginsProvider,
 	port int,
 ) func(*http.Request, string) bool {
-	staticSet := make(map[string]struct{}, len(staticOrigins))
-	for _, o := range staticOrigins {
-		staticSet[strings.ToLower(o)] = struct{}{}
-	}
-
 	return func(_ *http.Request, origin string) bool {
-		lowerOrigin := strings.ToLower(origin)
-
-		// Check static origins first
-		if _, ok := staticSet[lowerOrigin]; ok {
-			return true
-		}
-
-		// Check custom origins (fetched dynamically)
-		customOrigins := expandCustomOrigins(customOriginsProvider(), port)
-		for _, allowed := range customOrigins {
-			if strings.EqualFold(origin, allowed) {
-				return true
-			}
-		}
-
-		return false
+		return isAllowedOrigin(origin, staticOrigins, customOriginsProvider, port, false, "cors")
 	}
 }
 
@@ -1454,7 +1439,7 @@ func StartWithReady(
 	session.Upgrader.CheckOrigin = func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
 		log.Debug().Msgf("websocket origin: %s", origin)
-		return checkWebSocketOrigin(origin, staticOrigins, cfg.AllowedOrigins, port)
+		return isAllowedOrigin(origin, staticOrigins, cfg.AllowedOrigins, port, true, "websocket")
 	}
 	// melody's Session.Write is a non-blocking enqueue onto a per-session
 	// output channel (default size 256). When that channel fills, the

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -743,17 +743,25 @@ func TestIsAllowedOrigin_WebSocketHotReload(t *testing.T) {
 
 	// Initial state: custom origin allowed
 	assert.True(t, isAllowedOrigin("http://myapp.example.com", staticOrigins, provider, apiPort, true, "websocket"))
-	assert.True(t, isAllowedOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
-	assert.False(t, isAllowedOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.True(t, isAllowedOrigin(
+		"http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+	))
+	assert.False(t, isAllowedOrigin(
+		"http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+	))
 
 	// Simulate config reload: change custom origins
 	customOrigins = []string{"http://other.example.com"}
 
 	// Old custom origin should now be rejected (not private IP, not localhost)
-	assert.False(t, isAllowedOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.False(t, isAllowedOrigin(
+		"http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+	))
 	// New custom origin should be allowed
 	assert.True(t, isAllowedOrigin("http://other.example.com", staticOrigins, provider, apiPort, true, "websocket"))
-	assert.True(t, isAllowedOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.True(t, isAllowedOrigin(
+		"http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+	))
 
 	// Static origins should always work regardless of custom origins
 	assert.True(t, isAllowedOrigin("http://localhost:7497", staticOrigins, provider, apiPort, true, "websocket"))

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -369,7 +369,7 @@ func TestIsPrivateIP(t *testing.T) {
 	}
 }
 
-func TestCheckWebSocketOrigin(t *testing.T) {
+func TestIsAllowedOrigin_WebSocketPolicy(t *testing.T) {
 	t.Parallel()
 
 	staticOrigins := []string{
@@ -444,8 +444,8 @@ func TestCheckWebSocketOrigin(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := checkWebSocketOrigin(tt.origin, staticOrigins, customOriginsProvider, apiPort)
-			require.Equal(t, tt.expected, result, "checkWebSocketOrigin result mismatch for %s", tt.origin)
+			result := isAllowedOrigin(tt.origin, staticOrigins, customOriginsProvider, apiPort, true, "websocket")
+			require.Equal(t, tt.expected, result, "isAllowedOrigin result mismatch for %s", tt.origin)
 		})
 	}
 }
@@ -699,7 +699,7 @@ func TestBuildDynamicAllowedOrigins_HTTPURLWithoutPortAddsPortVariant(t *testing
 		"Bug fix: should not have https:// prepended to http:// URL")
 }
 
-func TestCheckWebSocketOrigin_HotReload(t *testing.T) {
+func TestIsAllowedOrigin_WebSocketHotReload(t *testing.T) {
 	t.Parallel()
 
 	staticOrigins := []string{
@@ -712,21 +712,21 @@ func TestCheckWebSocketOrigin_HotReload(t *testing.T) {
 	provider := func() []string { return customOrigins }
 
 	// Initial state: custom origin allowed
-	assert.True(t, checkWebSocketOrigin("http://myapp.example.com", staticOrigins, provider, apiPort))
-	assert.True(t, checkWebSocketOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort))
-	assert.False(t, checkWebSocketOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort))
+	assert.True(t, isAllowedOrigin("http://myapp.example.com", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.True(t, isAllowedOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.False(t, isAllowedOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
 
 	// Simulate config reload: change custom origins
 	customOrigins = []string{"http://other.example.com"}
 
 	// Old custom origin should now be rejected (not private IP, not localhost)
-	assert.False(t, checkWebSocketOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort))
+	assert.False(t, isAllowedOrigin("http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
 	// New custom origin should be allowed
-	assert.True(t, checkWebSocketOrigin("http://other.example.com", staticOrigins, provider, apiPort))
-	assert.True(t, checkWebSocketOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort))
+	assert.True(t, isAllowedOrigin("http://other.example.com", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.True(t, isAllowedOrigin("http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket"))
 
 	// Static origins should always work regardless of custom origins
-	assert.True(t, checkWebSocketOrigin("http://localhost:7497", staticOrigins, provider, apiPort))
+	assert.True(t, isAllowedOrigin("http://localhost:7497", staticOrigins, provider, apiPort, true, "websocket"))
 }
 
 func TestMakeOriginValidator_HotReload(t *testing.T) {
@@ -766,6 +766,69 @@ func TestMakeOriginValidator_HotReload(t *testing.T) {
 
 	// Static origins still work
 	assert.True(t, validator(nil, "http://localhost:7497"))
+}
+
+func TestMakeOriginValidator_LocalhostAnyPort(t *testing.T) {
+	t.Parallel()
+
+	staticOrigins := []string{
+		"http://localhost:7497",
+		"http://127.0.0.1:7497",
+		"http://192.168.1.100:7497",
+	}
+	port := 7497
+	provider := func() []string { return nil }
+	validator := makeOriginValidator(staticOrigins, provider, port)
+
+	tests := []struct {
+		name     string
+		origin   string
+		expected bool
+	}{
+		{
+			name:     "localhost_any_port_allowed",
+			origin:   "http://localhost:8100",
+			expected: true,
+		},
+		{
+			name:     "localhost_https_any_port_allowed",
+			origin:   "https://localhost:3000",
+			expected: true,
+		},
+		{
+			name:     "127_0_0_1_any_port_allowed",
+			origin:   "http://127.0.0.1:8100",
+			expected: true,
+		},
+		{
+			name:     "private_ip_correct_port_allowed",
+			origin:   "http://192.168.1.50:7497",
+			expected: true,
+		},
+		{
+			name:     "private_ip_wrong_port_rejected",
+			origin:   "http://192.168.1.50:8100",
+			expected: false,
+		},
+		{
+			name:     "public_ip_rejected",
+			origin:   "http://8.8.8.8:7497",
+			expected: false,
+		},
+		{
+			name:     "empty_origin_rejected",
+			origin:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := validator(nil, tt.origin)
+			require.Equal(t, tt.expected, result, "makeOriginValidator result mismatch for %s", tt.origin)
+		})
+	}
 }
 
 func TestSSE_ReceivesNotifications(t *testing.T) {

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -395,23 +395,28 @@ func TestIsAllowedOrigin_WebSocketPolicy(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "localhost_any_port_allowed",
+			name:     "localhost_other_port_rejected",
 			origin:   "http://localhost:8100",
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "localhost_https_any_port_allowed",
+			name:     "localhost_https_other_port_rejected",
 			origin:   "https://localhost:3000",
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "127_0_0_1_any_port_allowed",
+			name:     "127_0_0_1_other_port_rejected",
 			origin:   "http://127.0.0.1:8100",
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "private_ip_correct_port_allowed",
+			name:     "implicit_private_ip_correct_port_rejected",
 			origin:   "http://192.168.1.50:7497",
+			expected: false,
+		},
+		{
+			name:     "explicit_private_ip_allowed",
+			origin:   "http://192.168.1.100:7497",
 			expected: true,
 		},
 		{
@@ -554,6 +559,31 @@ func TestBuildDynamicAllowedOrigins(t *testing.T) {
 	// Trailing slashes should be trimmed
 	require.Contains(t, result, "http://trailing.local")
 	require.NotContains(t, result, "http://trailing.local/")
+}
+
+func TestDefaultAllowedOriginsIncludesHostedApp(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, allowedOrigins, "https://zaparoo.app")
+}
+
+func TestOriginPolicy_HappyPaths(t *testing.T) {
+	t.Parallel()
+
+	port := 7497
+	staticOrigins := buildStaticAllowedOrigins(allowedOrigins, []string{"10.0.0.50"}, port)
+	provider := func() []string { return nil }
+
+	// Browser loading the bundled web UI from the device uses the device URL as Origin.
+	assert.True(t, isAllowedOrigin("http://10.0.0.50:7497", staticOrigins, provider, port, true, "websocket"))
+	assert.True(t, isAllowedOrigin("http://10.0.0.50:7497", staticOrigins, provider, port, false, "cors"))
+
+	// Native clients may omit Origin on WebSocket connections.
+	assert.True(t, isAllowedOrigin("", staticOrigins, provider, port, true, "websocket"))
+
+	// The hosted app is trusted by default.
+	assert.True(t, isAllowedOrigin("https://zaparoo.app", staticOrigins, provider, port, true, "websocket"))
+	assert.True(t, isAllowedOrigin("https://zaparoo.app", staticOrigins, provider, port, false, "cors"))
 }
 
 // TestServerBindFailureStopsService verifies that when the API server fails to bind
@@ -768,7 +798,7 @@ func TestMakeOriginValidator_HotReload(t *testing.T) {
 	assert.True(t, validator(nil, "http://localhost:7497"))
 }
 
-func TestMakeOriginValidator_LocalhostAnyPort(t *testing.T) {
+func TestMakeOriginValidator_RejectsImplicitLocalhostPorts(t *testing.T) {
 	t.Parallel()
 
 	staticOrigins := []string{
@@ -786,23 +816,38 @@ func TestMakeOriginValidator_LocalhostAnyPort(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "localhost_any_port_allowed",
+			name:     "localhost_other_port_rejected",
 			origin:   "http://localhost:8100",
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "localhost_https_any_port_allowed",
+			name:     "localhost_https_other_port_rejected",
 			origin:   "https://localhost:3000",
-			expected: true,
+			expected: false,
 		},
 		{
-			name:     "127_0_0_1_any_port_allowed",
+			name:     "127_0_0_1_other_port_rejected",
 			origin:   "http://127.0.0.1:8100",
+			expected: false,
+		},
+		{
+			name:     "explicit_localhost_port_allowed",
+			origin:   "http://localhost:7497",
 			expected: true,
 		},
 		{
-			name:     "private_ip_correct_port_allowed",
+			name:     "explicit_127_0_0_1_port_allowed",
+			origin:   "http://127.0.0.1:7497",
+			expected: true,
+		},
+		{
+			name:     "implicit_private_ip_correct_port_rejected",
 			origin:   "http://192.168.1.50:7497",
+			expected: false,
+		},
+		{
+			name:     "explicit_private_ip_allowed",
+			origin:   "http://192.168.1.100:7497",
 			expected: true,
 		},
 		{
@@ -829,6 +874,19 @@ func TestMakeOriginValidator_LocalhostAnyPort(t *testing.T) {
 			require.Equal(t, tt.expected, result, "makeOriginValidator result mismatch for %s", tt.origin)
 		})
 	}
+}
+
+func TestMakeOriginValidator_ExplicitCustomLocalhostPort(t *testing.T) {
+	t.Parallel()
+
+	staticOrigins := []string{"http://localhost:7497"}
+	customOrigins := []string{"http://localhost:8100", "127.0.0.1:8100"}
+	provider := func() []string { return customOrigins }
+	validator := makeOriginValidator(staticOrigins, provider, 7497)
+
+	assert.True(t, validator(nil, "http://localhost:8100"))
+	assert.True(t, validator(nil, "http://127.0.0.1:8100"))
+	assert.False(t, validator(nil, "http://localhost:3000"))
 }
 
 func TestSSE_ReceivesNotifications(t *testing.T) {


### PR DESCRIPTION
## Summary
- Share origin validation between CORS and WebSocket using explicit static/custom allowlist matches.
- Remove WebSocket-only implicit localhost/private-IP origin shortcuts while preserving empty-origin WebSocket support for native clients.
- Add default `https://zaparoo.app` origin and regression coverage for bundled web UI, native app, hosted app, and explicit localhost dev overrides.

Closes #750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened origin validation for WebSocket and CORS requests by removing overly permissive localhost/private-IP fallbacks and enforcing stricter origin matching.

* **New Features**
  * Added https://zaparoo.app to the trusted origin list.

* **Tests**
  * Updated and expanded origin validation tests to cover stricter matching and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->