### PR TITLE
fix(linux): relax user service sandbox

### DIFF
--- a/pkg/platforms/linux/installer/conf/zaparoo.service
+++ b/pkg/platforms/linux/installer/conf/zaparoo.service
@@ -15,37 +15,9 @@ KillMode=control-group
 StandardOutput=journal
 StandardError=journal
 
-# Security - File System
-PrivateTmp=true
-ReadWritePaths=%h/.config/zaparoo %h/.local/share/zaparoo
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectControlGroups=true
-ProtectKernelLogs=true
-
-# Security - Devices (USB/serial readers, optical drives)
-PrivateDevices=false
-DevicePolicy=closed
-DeviceAllow=/dev/ttyUSB* rw
-DeviceAllow=/dev/ttyACM* rw
-DeviceAllow=/dev/bus/usb rw
-DeviceAllow=/dev/sr* r
-DeviceAllow=char-usb_device rw
-
-# Security - Privileges
-NoNewPrivileges=true
-ProtectClock=true
-ProtectHostname=true
-RestrictSUIDSGID=true
-RestrictRealtime=true
-LockPersonality=true
-
-# Security - Network
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
-
-# Security - System Calls
-SystemCallFilter=@system-service @process
-SystemCallArchitectures=native
+# Zaparoo launches desktop and game processes that need normal user-session
+# access to display, audio, GPU, input, Flatpak, Steam, Wine/Proton, and custom
+# launchers. Avoid systemd sandboxing here because child processes inherit it.
 
 [Install]
 WantedBy=default.target

--- a/pkg/platforms/linux/installer/install_test.go
+++ b/pkg/platforms/linux/installer/install_test.go
@@ -207,14 +207,40 @@ func TestInstallService(t *testing.T) {
 
 				content, readErr := os.ReadFile(servicePath) //nolint:gosec // reads installed test fixture
 				require.NoError(t, readErr, "should be able to read service file")
+				serviceContent := string(content)
 				execPath, execErr := os.Executable()
 				require.NoError(t, execErr)
 				execPath, execErr = filepath.EvalSymlinks(execPath)
 				require.NoError(t, execErr)
-				assert.Contains(t, string(content), "Type=simple")
-				assert.Contains(t, string(content), "ExecStart="+execPath+" -daemon")
-				assert.Contains(t, string(content), "TimeoutStopSec=15s")
-				assert.Contains(t, string(content), "KillMode=control-group")
+				assert.Contains(t, serviceContent, "Type=simple")
+				assert.Contains(t, serviceContent, "ExecStart="+execPath+" -daemon")
+				assert.Contains(t, serviceContent, "TimeoutStopSec=15s")
+				assert.Contains(t, serviceContent, "KillMode=control-group")
+				assert.Contains(t, serviceContent, "Avoid systemd sandboxing here")
+
+				restrictedDirectives := []string{
+					"PrivateTmp=",
+					"ReadWritePaths=",
+					"ProtectKernelTunables=",
+					"ProtectKernelModules=",
+					"ProtectControlGroups=",
+					"ProtectKernelLogs=",
+					"PrivateDevices=",
+					"DevicePolicy=",
+					"DeviceAllow=",
+					"NoNewPrivileges=",
+					"ProtectClock=",
+					"ProtectHostname=",
+					"RestrictSUIDSGID=",
+					"RestrictRealtime=",
+					"LockPersonality=",
+					"RestrictAddressFamilies=",
+					"SystemCallFilter=",
+					"SystemCallArchitectures=",
+				}
+				for _, directive := range restrictedDirectives {
+					assert.NotContains(t, serviceContent, directive)
+				}
 			}
 
 			cmd.AssertExpectations(t)


### PR DESCRIPTION
## Summary
- Remove inherited systemd sandboxing from the generic Linux user service so launched desktop/game processes run with normal user-session access.
- Keep service lifecycle settings such as restart behavior, stop timeout, kill mode, and journal logging.
- Add installer regression coverage to ensure restrictive sandbox directives stay out of the installed service file.

Closes #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Service configuration updated to modify runtime restrictions and access controls, allowing the service to operate with standard user-session permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->