### PR TITLE
feat(api): add system-aware media browse

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -522,7 +522,7 @@ An object:
 
 Browse indexed media content by directory, similar to navigating a file manager. Supports filesystem paths, virtual URI schemes (e.g. `mame-arcade://`), and paginated results.
 
-When called without a `path` parameter (or with an empty path), returns top-level root entries including filesystem roots and virtual scheme roots.
+When called without a `path` parameter (or with an empty path), returns top-level root entries including filesystem roots and virtual scheme roots. When `systems` is provided without `path`, returns populated launcher routes for those systems only. Pass the same `systems` filter when browsing a returned route to keep shared paths scoped to the selected systems.
 
 #### Parameters
 
@@ -531,8 +531,10 @@ All parameters are optional. When called with no parameters, returns root entrie
 | Key        | Type   | Required | Description                                                                                                |
 | :--------- | :----- | :------- | :--------------------------------------------------------------------------------------------------------- |
 | path       | string | No       | Directory path to browse. Omit or set empty to list root entries. Supports filesystem paths and virtual URI schemes (e.g. `mame-arcade://`). |
+| systems    | string[] | No     | Case-sensitive list of system IDs to restrict route discovery and browse results to. A missing key or empty list preserves unfiltered behavior. |
+| fuzzySystem | boolean | No     | Enable fuzzy matching for system IDs in the `systems` array (e.g., `"snes"` matches `"SNES"`). |
 | maxResults | number | No       | Maximum results per page. Default is 100, maximum is 1000.                                                 |
-| cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page.                     |
+| cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page. Cursors are valid only with the same path, systems, letter, and sort parameters. |
 | letter     | string | No       | Filter results to entries starting with this letter.                                                       |
 | sort       | string | No       | Sort order. One of: `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. The `filename` variants sort by full file path. |
 
@@ -554,7 +556,8 @@ All parameters are optional. When called with no parameters, returns root entrie
 | type         | string   | Yes      | Entry type: `root`, `directory`, or `media`.                                                     |
 | fileCount    | number   | No       | Number of files in this directory. Present on `root` and `directory` entries.                     |
 | group        | string   | No       | Launcher group name. Present on virtual scheme `root` entries.                                   |
-| systemId     | string   | No       | System ID for the media (e.g. `SNES`). Present on `media` entries.                               |
+| systemId     | string   | No       | System ID for the media or single-system filtered route (e.g. `SNES`). Present on `media` entries and filtered `root` entries when exactly one system applies. |
+| systemIds    | string[] | No       | System IDs represented by a filtered `root` or `directory` entry.                                |
 | zapScript    | string   | No       | ZapScript command to launch this media. Present on `media` entries.                              |
 | relativePath | string   | No       | Relative path from root directory. Present on `media` entries.                                   |
 | tags         | object[] | No       | Tags attached to the media. Each object has `tag` (string) and `type` (string). Present on `media` entries. |
@@ -567,7 +570,45 @@ All parameters are optional. When called with no parameters, returns root entrie
 | pageSize    | number | Yes      | The requested page size.                                 |
 | nextCursor  | string | No       | Opaque cursor for the next page. Absent on the last page. |
 
-#### Example
+#### System route example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "media.browse",
+  "params": {
+    "systems": ["SNES"]
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "path": "",
+    "entries": [
+      {
+        "name": "SNES",
+        "path": "/roms/SNES",
+        "type": "root",
+        "fileCount": 150,
+        "systemId": "SNES",
+        "systemIds": ["SNES"]
+      }
+    ],
+    "totalFiles": 0
+  }
+}
+```
+
+#### Browse path example
 
 ##### Request
 

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
 )
@@ -112,8 +113,21 @@ func HandleMediaBrowse(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		sort = *params.Sort
 	}
 
+	var systems []systemdefs.System
+	if params.Systems != nil && len(*params.Systems) > 0 {
+		fuzzy := params.FuzzySystem != nil && *params.FuzzySystem
+		var resolveErr error
+		systems, resolveErr = resolveSystems(*params.Systems, fuzzy)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+	}
+
 	// No path → return root entries
 	if params.Path == nil || *params.Path == "" {
+		if len(systems) > 0 {
+			return browseSystemRoots(&env, systems)
+		}
 		return browseRoots(&env)
 	}
 
@@ -121,11 +135,11 @@ func HandleMediaBrowse(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	// Virtual path (contains ://)
 	if strings.Contains(path, "://") {
-		return browseVirtual(&env, path, cursor, maxResults, params.Letter, sort)
+		return browseVirtual(&env, path, cursor, maxResults, params.Letter, sort, systems)
 	}
 
 	// Filesystem path
-	return browseFilesystem(&env, path, cursor, maxResults, params.Letter, sort)
+	return browseFilesystem(&env, path, cursor, maxResults, params.Letter, sort, systems)
 }
 
 // browseRoots returns the top-level root entries: filesystem roots with indexed
@@ -145,7 +159,7 @@ func browseRoots(env *requests.RequestEnv) (any, error) {
 	}
 
 	// Get virtual scheme roots
-	virtualSchemes, err := env.Database.MediaDB.BrowseVirtualSchemes(ctx)
+	virtualSchemes, err := env.Database.MediaDB.BrowseVirtualSchemes(ctx, database.BrowseVirtualSchemesOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error getting virtual schemes: %w", err)
 	}
@@ -189,6 +203,101 @@ func browseRoots(env *requests.RequestEnv) (any, error) {
 	}, nil
 }
 
+func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (any, error) {
+	routes := buildSystemBrowseRouteCandidates(env, systems)
+	counts, err := env.Database.MediaDB.BrowseRouteCounts(env.Context, database.BrowseRouteCountsOptions{
+		Routes:  routes,
+		Systems: systems,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error getting system route counts: %w", err)
+	}
+
+	entries := make([]models.BrowseEntry, 0, len(routes))
+	schemeGroups := buildSchemeGroupMap(env)
+	for _, route := range routes {
+		count, ok := counts[route]
+		if !ok || count.FileCount == 0 {
+			continue
+		}
+
+		fileCount := count.FileCount
+		entry := models.BrowseEntry{
+			Name:      browseRouteDisplayName(route),
+			Path:      route,
+			Type:      "root",
+			FileCount: &fileCount,
+			SystemIDs: count.SystemIDs,
+		}
+		if len(count.SystemIDs) == 1 {
+			entry.SystemID = &count.SystemIDs[0]
+		}
+		if group, ok := schemeGroups[route]; ok {
+			entry.Group = &group
+		}
+		entries = append(entries, entry)
+	}
+
+	return models.BrowseResults{Entries: entries}, nil
+}
+
+func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []systemdefs.System) []string {
+	if env.LauncherCache == nil {
+		return nil
+	}
+
+	var rootDirs []string
+	if env.Platform != nil {
+		rootDirs = env.Platform.RootDirs(env.Config)
+	}
+
+	routes := make([]string, 0)
+	seen := make(map[string]bool)
+	addRoute := func(route string) {
+		if route == "" || seen[route] {
+			return
+		}
+		seen[route] = true
+		routes = append(routes, route)
+	}
+
+	for i := range systems {
+		launchers := env.LauncherCache.GetLaunchersBySystem(systems[i].ID)
+		for j := range launchers {
+			launcher := &launchers[j]
+			for _, scheme := range launcher.Schemes {
+				addRoute(scheme + "://")
+			}
+
+			if launcher.SkipFilesystemScan {
+				continue
+			}
+			for _, folder := range launcher.Folders {
+				if filepath.IsAbs(folder) {
+					addRoute(filepath.ToSlash(filepath.Clean(folder)))
+					continue
+				}
+				for _, root := range rootDirs {
+					addRoute(filepath.ToSlash(filepath.Clean(filepath.Join(root, folder))))
+				}
+			}
+		}
+	}
+
+	return routes
+}
+
+func browseRouteDisplayName(route string) string {
+	if strings.Contains(route, "://") {
+		return schemeDisplayName(route)
+	}
+	trimmed := strings.TrimSuffix(route, "/")
+	if trimmed == "" {
+		return route
+	}
+	return filepath.Base(trimmed)
+}
+
 // browseFilesystem lists the immediate children of a filesystem directory path
 // by querying the indexed media database.
 func browseFilesystem(
@@ -198,6 +307,7 @@ func browseFilesystem(
 	maxResults int,
 	letter *string,
 	sort string,
+	systems []systemdefs.System,
 ) (any, error) {
 	// Normalize the path
 	cleaned := filepath.ToSlash(filepath.Clean(path))
@@ -228,7 +338,10 @@ func browseFilesystem(
 	var dirs []database.BrowseDirectoryResult
 	if cursor == nil {
 		var err error
-		dirs, err = env.Database.MediaDB.BrowseDirectories(ctx, prefix)
+		dirs, err = env.Database.MediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			PathPrefix: prefix,
+			Systems:    systems,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("error browsing directories: %w", err)
 		}
@@ -241,6 +354,7 @@ func browseFilesystem(
 		Limit:      maxResults + 1,
 		Letter:     letter,
 		Sort:       sort,
+		Systems:    systems,
 	}
 	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
 	if err != nil {
@@ -250,7 +364,11 @@ func browseFilesystem(
 	// Get total file count (skip when no files and no cursor — count is obviously 0)
 	var totalFiles int
 	if len(files) > 0 || cursor != nil {
-		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, prefix, letter)
+		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+			PathPrefix: prefix,
+			Letter:     letter,
+			Systems:    systems,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("error getting file count: %w", err)
 		}
@@ -267,6 +385,7 @@ func browseVirtual(
 	maxResults int,
 	letter *string,
 	sort string,
+	systems []systemdefs.System,
 ) (any, error) {
 	// Validate scheme is known
 	if !isKnownVirtualScheme(env, schemePath) {
@@ -281,13 +400,18 @@ func browseVirtual(
 		Limit:      maxResults + 1,
 		Letter:     letter,
 		Sort:       sort,
+		Systems:    systems,
 	}
 	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error browsing virtual media: %w", err)
 	}
 
-	totalFiles, err := env.Database.MediaDB.BrowseFileCount(ctx, schemePath, letter)
+	totalFiles, err := env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		PathPrefix: schemePath,
+		Letter:     letter,
+		Systems:    systems,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error getting virtual file count: %w", err)
 	}
@@ -319,6 +443,7 @@ func buildBrowseResponse(
 			Path:      path + "/" + dir.Name,
 			Type:      "directory",
 			FileCount: &dir.FileCount,
+			SystemIDs: dir.SystemIDs,
 		})
 	}
 

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -204,7 +204,10 @@ func browseRoots(env *requests.RequestEnv) (any, error) {
 }
 
 func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (any, error) {
-	routes := buildSystemBrowseRouteCandidates(env, systems)
+	routes, err := buildSystemBrowseRouteCandidates(env, systems)
+	if err != nil {
+		return nil, err
+	}
 	counts, err := env.Database.MediaDB.BrowseRouteCounts(env.Context, database.BrowseRouteCountsOptions{
 		Routes:  routes,
 		Systems: systems,
@@ -241,11 +244,7 @@ func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (a
 	return models.BrowseResults{Entries: entries}, nil
 }
 
-func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []systemdefs.System) []string {
-	if env.LauncherCache == nil {
-		return nil
-	}
-
+func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []systemdefs.System) ([]string, error) {
 	var rootDirs []string
 	if env.Platform != nil {
 		rootDirs = env.Platform.RootDirs(env.Config)
@@ -268,30 +267,73 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 		addRoute(filepath.ToSlash(cleaned))
 	}
 
-	for i := range systems {
-		launchers := env.LauncherCache.GetLaunchersBySystem(systems[i].ID)
-		for j := range launchers {
-			launcher := &launchers[j]
-			for _, scheme := range launcher.Schemes {
-				addRoute(scheme + "://")
-			}
+	if env.LauncherCache != nil {
+		for i := range systems {
+			launchers := env.LauncherCache.GetLaunchersBySystem(systems[i].ID)
+			for j := range launchers {
+				launcher := &launchers[j]
+				for _, scheme := range launcher.Schemes {
+					addRoute(scheme + "://")
+				}
 
-			if launcher.SkipFilesystemScan {
-				continue
-			}
-			for _, folder := range launcher.Folders {
-				if filepath.IsAbs(folder) {
-					addFilesystemRoute(folder)
+				if launcher.SkipFilesystemScan {
 					continue
 				}
-				for _, root := range rootDirs {
-					addFilesystemRoute(filepath.Join(root, folder))
+				for _, folder := range launcher.Folders {
+					if filepath.IsAbs(folder) {
+						addFilesystemRoute(folder)
+						continue
+					}
+					for _, root := range rootDirs {
+						addFilesystemRoute(filepath.Join(root, folder))
+					}
 				}
 			}
 		}
 	}
 
-	return routes
+	if env.Database.MediaDB != nil {
+		for _, root := range rootDirs {
+			prefix := filepath.ToSlash(filepath.Clean(root))
+			if !strings.HasSuffix(prefix, "/") {
+				prefix += "/"
+			}
+			fileCount, err := env.Database.MediaDB.BrowseFileCount(env.Context, database.BrowseFileCountOptions{
+				PathPrefix: prefix,
+				Systems:    systems,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error getting system root file count: %w", err)
+			}
+			if fileCount > 0 {
+				addFilesystemRoute(root)
+			}
+
+			dirs, err := env.Database.MediaDB.BrowseDirectories(env.Context, database.BrowseDirectoriesOptions{
+				PathPrefix: prefix,
+				Systems:    systems,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error getting system route directories: %w", err)
+			}
+			for _, dir := range dirs {
+				addFilesystemRoute(filepath.Join(root, dir.Name))
+			}
+		}
+
+		virtualSchemes, err := env.Database.MediaDB.BrowseVirtualSchemes(
+			env.Context,
+			database.BrowseVirtualSchemesOptions{Systems: systems},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error getting system virtual routes: %w", err)
+		}
+		for _, scheme := range virtualSchemes {
+			addRoute(scheme.Scheme)
+		}
+	}
+
+	return routes, nil
 }
 
 func isPathUnderRootDirs(path string, rootDirs []string) bool {

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -260,6 +260,13 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 		seen[route] = true
 		routes = append(routes, route)
 	}
+	addFilesystemRoute := func(route string) {
+		cleaned := filepath.Clean(route)
+		if !isPathUnderRootDirs(cleaned, rootDirs) {
+			return
+		}
+		addRoute(filepath.ToSlash(cleaned))
+	}
 
 	for i := range systems {
 		launchers := env.LauncherCache.GetLaunchersBySystem(systems[i].ID)
@@ -274,17 +281,28 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 			}
 			for _, folder := range launcher.Folders {
 				if filepath.IsAbs(folder) {
-					addRoute(filepath.ToSlash(filepath.Clean(folder)))
+					addFilesystemRoute(folder)
 					continue
 				}
 				for _, root := range rootDirs {
-					addRoute(filepath.ToSlash(filepath.Clean(filepath.Join(root, folder))))
+					addFilesystemRoute(filepath.Join(root, folder))
 				}
 			}
 		}
 	}
 
 	return routes
+}
+
+func isPathUnderRootDirs(path string, rootDirs []string) bool {
+	for _, root := range rootDirs {
+		cleanedRoot := filepath.Clean(root)
+		rel, err := filepath.Rel(cleanedRoot, path)
+		if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 func browseRouteDisplayName(route string) string {

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -106,7 +107,12 @@ func browseFileCountSystemOpts(pathPrefix, systemID string) any {
 }
 
 func browseTestAbsPath(parts ...string) string {
-	return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	root := filepath.VolumeName(wd) + string(filepath.Separator)
+	return filepath.Join(append([]string{root}, parts...)...)
 }
 
 func TestHandleMediaBrowse_RootLevel(t *testing.T) {
@@ -604,6 +610,51 @@ func TestHandleMediaBrowse_VirtualScheme(t *testing.T) {
 	assert.Equal(t, 1, browseResults.TotalFiles)
 	assert.Equal(t, "media", browseResults.Entries[0].Type)
 	assert.Equal(t, "Team Fortress 2", browseResults.Entries[0].Name)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_VirtualFiltersBySystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{browseTestAbsPath("roms")})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "Steam", SystemID: "Windows", Schemes: []string{"steam"}},
+		})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseFiles", mock.Anything, browseFilesSystemOpts("steam://", "Windows")).
+		Return([]database.SearchResultWithCursor{
+			{
+				SystemID: "Windows", Name: "Team Fortress 2",
+				Path: "steam://440/Team%20Fortress%202", MediaID: 10,
+			},
+		}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts("steam://", "Windows")).
+		Return(1, nil)
+
+	path := "steam://"
+	systems := []string{"Windows"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:    &path,
+		Systems: &systems,
+	})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, "steam://", browseResults.Path)
+	assert.Equal(t, 1, browseResults.TotalFiles)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Equal(t, "media", browseResults.Entries[0].Type)
+	require.NotNil(t, browseResults.Entries[0].SystemID)
+	assert.Equal(t, "Windows", *browseResults.Entries[0].SystemID)
 
 	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -68,6 +68,42 @@ func newBrowseEnv(
 	}
 }
 
+func browseDirectoriesOpts(pathPrefix string) any {
+	return mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 0
+	})
+}
+
+func browseFileCountOpts(pathPrefix string, letter *string) any {
+	return mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+		if opts.PathPrefix != pathPrefix || len(opts.Systems) != 0 {
+			return false
+		}
+		if letter == nil {
+			return opts.Letter == nil
+		}
+		return opts.Letter != nil && *opts.Letter == *letter
+	})
+}
+
+func browseDirectoriesSystemOpts(pathPrefix, systemID string) any {
+	return mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
+	})
+}
+
+func browseFilesSystemOpts(pathPrefix, systemID string) any {
+	return mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
+	})
+}
+
+func browseFileCountSystemOpts(pathPrefix, systemID string) any {
+	return mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
+	})
+}
+
 func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	t.Parallel()
 
@@ -83,7 +119,7 @@ func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseRootCounts", mock.Anything, mock.Anything).
 		Return(map[string]*int{"/roms": intPtr(500)}, nil)
-	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything).
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, database.BrowseVirtualSchemesOptions{}).
 		Return([]database.BrowseVirtualScheme{
 			{Scheme: "steam://", FileCount: 42},
 		}, nil)
@@ -113,6 +149,51 @@ func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
+			{ID: "SharedSNES", SystemID: "SNES", Folders: []string{"shared"}},
+			{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}},
+		})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
+			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
+				assert.ElementsMatch(t, []string{"/roms/SNES", "/roms/shared"}, opts.Routes)
+		}),
+	).Return(map[string]database.BrowseRouteCount{
+		"/roms/SNES": {Path: "/roms/SNES", FileCount: 12, SystemIDs: []string{"SNES"}},
+	}, nil)
+
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Systems: &systems})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "root", entry.Type)
+	assert.Equal(t, "SNES", entry.Name)
+	assert.Equal(t, "/roms/SNES", entry.Path)
+	assert.Equal(t, []string{"SNES"}, entry.SystemIDs)
+	require.NotNil(t, entry.SystemID)
+	assert.Equal(t, "SNES", *entry.SystemID)
+	require.NotNil(t, entry.FileCount)
+	assert.Equal(t, 12, *entry.FileCount)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 	t.Parallel()
 
@@ -124,7 +205,7 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/")).
 		Return([]database.BrowseDirectoryResult{
 			{Name: "NES", FileCount: 100},
 			{Name: "SNES", FileCount: 200},
@@ -132,7 +213,7 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{}, nil)
 	// BrowseFileCount is skipped when BrowseFiles returns empty and no cursor
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/", nil)).
 		Return(0, nil).Maybe()
 
 	path := "/roms"
@@ -169,7 +250,7 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
@@ -182,7 +263,7 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 				Path: "/roms/SNES/Zelda.sfc", MediaID: 2,
 			},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
 		Return(2, nil)
 
 	path := "/roms/SNES"
@@ -206,6 +287,54 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_FilesystemFiltersBySystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts("/roms/shared/", "SNES")).
+		Return([]database.BrowseDirectoryResult{
+			{Name: "RPG", FileCount: 3, SystemIDs: []string{"SNES"}},
+		}, nil)
+	mockMediaDB.On("BrowseFiles", mock.Anything, browseFilesSystemOpts("/roms/shared/", "SNES")).
+		Return([]database.SearchResultWithCursor{
+			{
+				SystemID: "snes", Name: "Chrono Trigger",
+				Path: "/roms/shared/Chrono Trigger.sfc", MediaID: 7,
+			},
+		}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts("/roms/shared/", "SNES")).
+		Return(1, nil)
+
+	path := "/roms/shared"
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:    &path,
+		Systems: &systems,
+	})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, 1, browseResults.TotalFiles)
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, "directory", browseResults.Entries[0].Type)
+	assert.Equal(t, []string{"SNES"}, browseResults.Entries[0].SystemIDs)
+	assert.Equal(t, "media", browseResults.Entries[1].Type)
+	require.NotNil(t, browseResults.Entries[1].SystemID)
+	assert.Equal(t, "snes", *browseResults.Entries[1].SystemID)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_Pagination(t *testing.T) {
 	t.Parallel()
 
@@ -219,7 +348,7 @@ func TestHandleMediaBrowse_Pagination(t *testing.T) {
 	// Return 3 results when limit is maxResults+1=3 (maxResults=2),
 	// triggering hasNextPage=true.
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
@@ -227,7 +356,7 @@ func TestHandleMediaBrowse_Pagination(t *testing.T) {
 			{SystemID: "snes", Name: "Beta", Path: "/roms/SNES/Beta.sfc", MediaID: 2},
 			{SystemID: "snes", Name: "Gamma", Path: "/roms/SNES/Gamma.sfc", MediaID: 3},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
 		Return(5, nil)
 
 	path := "/roms/SNES"
@@ -292,7 +421,7 @@ func TestHandleMediaBrowse_CursorRoundTrip(t *testing.T) {
 	).Return([]database.SearchResultWithCursor{
 		{SystemID: "snes", Name: "Zelda", Path: "/roms/SNES/Zelda.sfc", MediaID: 8},
 	}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
 		Return(10, nil)
 
 	path := "/roms/SNES"
@@ -329,7 +458,7 @@ func TestHandleMediaBrowse_FilenameSortCursor(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
@@ -337,7 +466,7 @@ func TestHandleMediaBrowse_FilenameSortCursor(t *testing.T) {
 			{SystemID: "snes", Name: "Beta", Path: "/roms/SNES/beta.sfc", MediaID: 2},
 			{SystemID: "snes", Name: "Gamma", Path: "/roms/SNES/gamma.sfc", MediaID: 3},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
 		Return(5, nil)
 
 	path := "/roms/SNES"
@@ -380,7 +509,7 @@ func TestHandleMediaBrowse_NameDescSort(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
@@ -388,7 +517,7 @@ func TestHandleMediaBrowse_NameDescSort(t *testing.T) {
 			{SystemID: "snes", Name: "Mario", Path: "/roms/SNES/Mario.sfc", MediaID: 2},
 			{SystemID: "snes", Name: "Alpha", Path: "/roms/SNES/Alpha.sfc", MediaID: 1},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
 		Return(5, nil)
 
 	path := "/roms/SNES"
@@ -440,7 +569,7 @@ func TestHandleMediaBrowse_VirtualScheme(t *testing.T) {
 				Path: "steam://440/Team%20Fortress%202", MediaID: 10,
 			},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "steam://", (*string)(nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("steam://", nil)).
 		Return(1, nil)
 
 	path := "steam://"
@@ -559,7 +688,7 @@ func TestHandleMediaBrowse_VirtualGrouping(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseRootCounts", mock.Anything, []string{}).
 		Return(map[string]*int{}, nil)
-	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything).
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, database.BrowseVirtualSchemesOptions{}).
 		Return([]database.BrowseVirtualScheme{
 			{Scheme: "kodi-episode://", FileCount: 200},
 			{Scheme: "kodi-movie://", FileCount: 80},
@@ -600,7 +729,7 @@ func TestHandleMediaBrowse_WithLetterFilter(t *testing.T) {
 
 	letterM := "M"
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
@@ -609,7 +738,7 @@ func TestHandleMediaBrowse_WithLetterFilter(t *testing.T) {
 				Path: "/roms/SNES/Mega Man X.sfc", MediaID: 5,
 			},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, "/roms/SNES/", &letterM).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", &letterM)).
 		Return(15, nil)
 
 	path := "/roms/SNES"
@@ -661,7 +790,7 @@ func TestHandleMediaBrowse_FilesystemError(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, "/roms/SNES/").
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult(nil), errors.New("disk io error"))
 
 	path := "/roms/SNES"

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -106,6 +106,13 @@ func browseFileCountSystemOpts(pathPrefix, systemID string) any {
 	})
 }
 
+func browseVirtualSchemesSystemOpts(t *testing.T, systemID string) any {
+	t.Helper()
+	return mock.MatchedBy(func(opts database.BrowseVirtualSchemesOptions) bool {
+		return len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
+	})
+}
+
 func browseTestAbsPath(parts ...string) string {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -182,6 +189,13 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 		})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
+	romsPrefix := filepath.ToSlash(romsRoot) + "/"
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "SNES")).
+		Return(0, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "SNES")).
+		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
 	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
 		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
 			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
@@ -208,6 +222,98 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	assert.Equal(t, "SNES", *entry.SystemID)
 	require.NotNil(t, entry.FileCount)
 	assert.Equal(t, 12, *entry.FileCount)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_SystemRootRoutesIncludesIndexedDirectories(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	customPath := filepath.Join(romsRoot, "custom")
+	customAPIPath := filepath.ToSlash(customPath)
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{romsRoot})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	romsPrefix := filepath.ToSlash(romsRoot) + "/"
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "SNES")).
+		Return(0, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "SNES")).
+		Return([]database.BrowseDirectoryResult{{Name: "custom", FileCount: 3, SystemIDs: []string{"SNES"}}}, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{{Scheme: "steam://", FileCount: 2, SystemIDs: []string{"SNES"}}}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
+			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
+				assert.ElementsMatch(t, []string{customAPIPath, "steam://"}, opts.Routes)
+		}),
+	).Return(map[string]database.BrowseRouteCount{
+		customAPIPath: {Path: customAPIPath, FileCount: 3, SystemIDs: []string{"SNES"}},
+		"steam://":    {Path: "steam://", FileCount: 2, SystemIDs: []string{"SNES"}},
+	}, nil)
+
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Systems: &systems})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, customAPIPath, browseResults.Entries[0].Path)
+	assert.Equal(t, "steam://", browseResults.Entries[1].Path)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_SystemRootRoutesIncludesRootMedia(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	romsAPIPath := filepath.ToSlash(romsRoot)
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{romsRoot})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	romsPrefix := filepath.ToSlash(romsRoot) + "/"
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "SNES")).
+		Return(1, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "SNES")).
+		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
+			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
+				assert.ElementsMatch(t, []string{romsAPIPath}, opts.Routes)
+		}),
+	).Return(map[string]database.BrowseRouteCount{
+		romsAPIPath: {Path: romsAPIPath, FileCount: 1, SystemIDs: []string{"SNES"}},
+	}, nil)
+
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Systems: &systems})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "root", entry.Type)
+	assert.Equal(t, "roms", entry.Name)
+	assert.Equal(t, romsAPIPath, entry.Path)
+	require.NotNil(t, entry.FileCount)
+	assert.Equal(t, 1, *entry.FileCount)
 
 	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -104,13 +105,18 @@ func browseFileCountSystemOpts(pathPrefix, systemID string) any {
 	})
 }
 
+func browseTestAbsPath(parts ...string) string {
+	return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
+}
+
 func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{
 			{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}},
@@ -153,13 +159,19 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	snesPath := filepath.Join(romsRoot, "SNES")
+	sharedPath := filepath.Join(romsRoot, "shared")
+	snesAPIPath := filepath.ToSlash(snesPath)
+	sharedAPIPath := filepath.ToSlash(sharedPath)
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{
 			{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
 			{ID: "SharedSNES", SystemID: "SNES", Folders: []string{"shared"}},
+			{ID: "OutsideSNES", SystemID: "SNES", Folders: []string{browseTestAbsPath("tmp", "outside")}},
 			{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}},
 		})
 
@@ -167,10 +179,10 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
 		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
 			return len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES" &&
-				assert.ElementsMatch(t, []string{"/roms/SNES", "/roms/shared"}, opts.Routes)
+				assert.ElementsMatch(t, []string{snesAPIPath, sharedAPIPath}, opts.Routes)
 		}),
 	).Return(map[string]database.BrowseRouteCount{
-		"/roms/SNES": {Path: "/roms/SNES", FileCount: 12, SystemIDs: []string{"SNES"}},
+		snesAPIPath: {Path: snesAPIPath, FileCount: 12, SystemIDs: []string{"SNES"}},
 	}, nil)
 
 	systems := []string{"SNES"}
@@ -184,7 +196,7 @@ func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	entry := browseResults.Entries[0]
 	assert.Equal(t, "root", entry.Type)
 	assert.Equal(t, "SNES", entry.Name)
-	assert.Equal(t, "/roms/SNES", entry.Path)
+	assert.Equal(t, snesAPIPath, entry.Path)
 	assert.Equal(t, []string{"SNES"}, entry.SystemIDs)
 	require.NotNil(t, entry.SystemID)
 	assert.Equal(t, "SNES", *entry.SystemID)
@@ -198,9 +210,10 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{})
 
@@ -291,28 +304,32 @@ func TestHandleMediaBrowse_FilesystemFiltersBySystem(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	sharedPath := filepath.Join(romsRoot, "shared")
+	sharedPrefix := filepath.ToSlash(sharedPath) + "/"
+	chronoPath := filepath.ToSlash(filepath.Join(sharedPath, "Chrono Trigger.sfc"))
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts("/roms/shared/", "SNES")).
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(sharedPrefix, "SNES")).
 		Return([]database.BrowseDirectoryResult{
 			{Name: "RPG", FileCount: 3, SystemIDs: []string{"SNES"}},
 		}, nil)
-	mockMediaDB.On("BrowseFiles", mock.Anything, browseFilesSystemOpts("/roms/shared/", "SNES")).
+	mockMediaDB.On("BrowseFiles", mock.Anything, browseFilesSystemOpts(sharedPrefix, "SNES")).
 		Return([]database.SearchResultWithCursor{
 			{
 				SystemID: "snes", Name: "Chrono Trigger",
-				Path: "/roms/shared/Chrono Trigger.sfc", MediaID: 7,
+				Path: chronoPath, MediaID: 7,
 			},
 		}, nil)
-	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts("/roms/shared/", "SNES")).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(sharedPrefix, "SNES")).
 		Return(1, nil)
 
-	path := "/roms/shared"
+	path := filepath.ToSlash(sharedPath)
 	systems := []string{"SNES"}
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
 		Path:    &path,

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -31,8 +31,9 @@ import (
 )
 
 const (
-	RequestsPerMinute = 100 // Simple limit - 100 requests per minute per IP
-	BurstSize         = 20  // Allow burst of 20 requests
+	RequestsPerMinute      = 100 // Simple limit - 100 requests per minute per IP
+	BurstSize              = 20  // Allow burst of 20 requests
+	WebSocketRateLimitWait = 2 * time.Second
 )
 
 // IPRateLimiter manages rate limiters per IP address for both HTTP and WebSocket
@@ -152,12 +153,22 @@ func WebSocketRateLimitHandler(
 	limiter *IPRateLimiter,
 	handler func(*melody.Session, []byte),
 ) func(*melody.Session, []byte) {
+	return WebSocketRateLimitHandlerWithWait(limiter, WebSocketRateLimitWait, handler)
+}
+
+func WebSocketRateLimitHandlerWithWait(
+	limiter *IPRateLimiter,
+	waitTimeout time.Duration,
+	handler func(*melody.Session, []byte),
+) func(*melody.Session, []byte) {
 	return func(session *melody.Session, msg []byte) {
 		ip := ParseRemoteIP(session.Request.RemoteAddr)
 		host := ip.String()
 		rl := limiter.GetLimiter(host)
 
-		if !rl.Allow() {
+		ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+		defer cancel()
+		if err := rl.Wait(ctx); err != nil {
 			log.Warn().
 				Str("ip", host).
 				Int("msg_size", len(msg)).

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -168,12 +168,8 @@ func WebSocketRateLimitHandlerWithWait(
 
 		ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
 		defer cancel()
+		waitTimeoutValue := waitTimeout
 		if err := rl.Wait(ctx); err != nil {
-			waitTimeoutValue := time.Duration(0)
-			if deadline, ok := ctx.Deadline(); ok {
-				waitTimeoutValue = time.Until(deadline)
-			}
-
 			log.Warn().
 				Err(err).
 				Str("ip", host).

--- a/pkg/api/middleware/ratelimit.go
+++ b/pkg/api/middleware/ratelimit.go
@@ -169,10 +169,17 @@ func WebSocketRateLimitHandlerWithWait(
 		ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
 		defer cancel()
 		if err := rl.Wait(ctx); err != nil {
+			waitTimeoutValue := time.Duration(0)
+			if deadline, ok := ctx.Deadline(); ok {
+				waitTimeoutValue = time.Until(deadline)
+			}
+
 			log.Warn().
+				Err(err).
 				Str("ip", host).
 				Int("msg_size", len(msg)).
-				Msg("WebSocket rate limit exceeded, closing connection")
+				Str("wait_timeout", waitTimeoutValue.String()).
+				Msg("WebSocket rate limit wait failed, closing connection")
 
 			if err := session.Close(); err != nil {
 				log.Debug().Err(err).Msg("failed to close rate-limited session")

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -255,8 +255,9 @@ func TestWebSocketRateLimitHandler_ClosesAfterWaitTimeout(t *testing.T) {
 	}, 500*time.Millisecond, 10*time.Millisecond, "first message should be handled")
 
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("again")))
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int32(1), handlerCalls.Load(), "second message should not reach handler")
+	assert.Never(t, func() bool {
+		return handlerCalls.Load() != 1
+	}, 150*time.Millisecond, 10*time.Millisecond, "second message should not reach handler")
 
 	// The server should have closed the connection.
 	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -21,6 +21,8 @@ package middleware
 
 import (
 	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -205,8 +207,9 @@ func TestWebSocketRateLimitHandler_WaitsForToken(t *testing.T) {
 
 	// First message should go through.
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("hello")))
-	time.Sleep(20 * time.Millisecond)
-	assert.Equal(t, int32(1), handlerCalls.Load(), "first message should be handled")
+	require.Eventually(t, func() bool {
+		return handlerCalls.Load() == 1
+	}, 500*time.Millisecond, 10*time.Millisecond, "first message should be handled")
 
 	// Second message should wait for a token and then reach the handler.
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("again")))
@@ -258,5 +261,18 @@ func TestWebSocketRateLimitHandler_ClosesAfterWaitTimeout(t *testing.T) {
 	// The server should have closed the connection.
 	_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
 	_, _, err = conn.ReadMessage()
-	assert.Error(t, err, "connection should be closed after rate limit exceeded")
+	require.Error(t, err, "connection should be closed after rate limit exceeded")
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		assert.False(t, netErr.Timeout(), "connection read should fail from server close, not read timeout")
+	}
+	assert.True(t,
+		websocket.IsCloseError(err,
+			websocket.CloseNormalClosure,
+			websocket.CloseGoingAway,
+			websocket.CloseAbnormalClosure,
+			websocket.CloseNoStatusReceived,
+		) || websocket.IsUnexpectedCloseError(err),
+		"connection read should return a websocket close error, got %v", err,
+	)
 }

--- a/pkg/api/middleware/ratelimit_test.go
+++ b/pkg/api/middleware/ratelimit_test.go
@@ -177,16 +177,17 @@ func TestHTTPRateLimitMiddleware_IsolatesIPs(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code, "different IP should not be rate-limited")
 }
 
-func TestWebSocketRateLimitHandler_ClosesOnExceed(t *testing.T) {
+func TestWebSocketRateLimitHandler_WaitsForToken(t *testing.T) {
 	t.Parallel()
 
-	// burst=1 so only the first message is allowed.
-	rl := NewIPRateLimiterWithLimits(0, 1)
+	// burst=1 allows the first message immediately; the second waits for
+	// the next token instead of closing the session.
+	rl := NewIPRateLimiterWithLimits(rate.Every(50*time.Millisecond), 1)
 	var handlerCalls atomic.Int32
 	inner := func(_ *melody.Session, _ []byte) {
 		handlerCalls.Add(1)
 	}
-	wrapped := WebSocketRateLimitHandler(rl, inner)
+	wrapped := WebSocketRateLimitHandlerWithWait(rl, 250*time.Millisecond, inner)
 
 	m := melody.New()
 	m.HandleMessage(wrapped)
@@ -207,7 +208,49 @@ func TestWebSocketRateLimitHandler_ClosesOnExceed(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, int32(1), handlerCalls.Load(), "first message should be handled")
 
-	// Second message should trigger rate limit and close the connection.
+	// Second message should wait for a token and then reach the handler.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("again")))
+	require.Eventually(t, func() bool {
+		return handlerCalls.Load() == 2
+	}, 500*time.Millisecond, 10*time.Millisecond, "second message should be handled after backpressure wait")
+
+	// The server should keep the connection open.
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("third")))
+	require.Eventually(t, func() bool {
+		return handlerCalls.Load() == 3
+	}, 500*time.Millisecond, 10*time.Millisecond, "connection should remain usable after waiting")
+}
+
+func TestWebSocketRateLimitHandler_ClosesAfterWaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	// burst=1 and no refill forces the second message to exceed the bounded wait.
+	rl := NewIPRateLimiterWithLimits(0, 1)
+	var handlerCalls atomic.Int32
+	inner := func(_ *melody.Session, _ []byte) {
+		handlerCalls.Add(1)
+	}
+	wrapped := WebSocketRateLimitHandlerWithWait(rl, 20*time.Millisecond, inner)
+
+	m := melody.New()
+	m.HandleMessage(wrapped)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	//nolint:bodyclose // websocket conn manages the body
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("hello")))
+	require.Eventually(t, func() bool {
+		return handlerCalls.Load() == 1
+	}, 500*time.Millisecond, 10*time.Millisecond, "first message should be handled")
+
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("again")))
 	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, int32(1), handlerCalls.Load(), "second message should not reach handler")

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -33,11 +33,13 @@ type SearchParams struct {
 }
 
 type BrowseParams struct {
-	Path       *string `json:"path,omitempty"`
-	MaxResults *int    `json:"maxResults,omitempty" validate:"omitempty,gt=0,max=1000"`
-	Cursor     *string `json:"cursor,omitempty"`
-	Letter     *string `json:"letter,omitempty" validate:"omitempty,letter"`
-	Sort       *string `json:"sort,omitempty" validate:"omitempty,oneof=name-asc name-desc filename-asc filename-desc"`
+	Systems     *[]string `json:"systems" validate:"omitempty,dive,min=1"`
+	FuzzySystem *bool     `json:"fuzzySystem,omitempty"`
+	Path        *string   `json:"path,omitempty"`
+	MaxResults  *int      `json:"maxResults,omitempty" validate:"omitempty,gt=0,max=1000"`
+	Cursor      *string   `json:"cursor,omitempty"`
+	Letter      *string   `json:"letter,omitempty" validate:"omitempty,letter"`
+	Sort        *string   `json:"sort,omitempty" validate:"omitempty,oneof=name-asc name-desc filename-asc filename-desc"`
 }
 
 type MediaIndexParams struct {

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -53,6 +53,7 @@ type TagsResponse struct {
 }
 
 type BrowseEntry struct {
+	SystemIDs []string           `json:"systemIds,omitempty"`
 	SystemID  *string            `json:"systemId,omitempty"`
 	RelPath   *string            `json:"relativePath,omitempty"`
 	ZapScript *string            `json:"zapScript,omitempty"`

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -206,7 +206,14 @@ func GroupTagFiltersByOperator(filters []zapscript.TagFilter) (and, not, or []za
 // BrowseDirectoryResult represents a subdirectory found during browse navigation.
 type BrowseDirectoryResult struct {
 	Name      string
+	SystemIDs []string
 	FileCount int
+}
+
+// BrowseDirectoriesOptions contains parameters for the BrowseDirectories query.
+type BrowseDirectoriesOptions struct {
+	PathPrefix string
+	Systems    []systemdefs.System
 }
 
 // BrowseCursor holds the keyset pagination state for browse queries.
@@ -223,12 +230,40 @@ type BrowseFilesOptions struct {
 	Letter     *string
 	PathPrefix string
 	Sort       string
+	Systems    []systemdefs.System
 	Limit      int
+}
+
+// BrowseFileCountOptions contains parameters for the BrowseFileCount query.
+type BrowseFileCountOptions struct {
+	Letter     *string
+	PathPrefix string
+	Systems    []systemdefs.System
 }
 
 // BrowseVirtualScheme represents a virtual URI scheme with indexed content.
 type BrowseVirtualScheme struct {
-	Scheme    string // e.g., "steam://"
+	Scheme    string
+	SystemIDs []string
+	FileCount int
+}
+
+// BrowseVirtualSchemesOptions contains parameters for BrowseVirtualSchemes.
+type BrowseVirtualSchemesOptions struct {
+	Systems []systemdefs.System
+}
+
+// BrowseRouteCountsOptions contains candidate route paths to resolve against
+// indexed media for system-scoped browse root discovery.
+type BrowseRouteCountsOptions struct {
+	Systems []systemdefs.System
+	Routes  []string
+}
+
+// BrowseRouteCount represents a populated browse route and its media count.
+type BrowseRouteCount struct {
+	Path      string
+	SystemIDs []string
 	FileCount int
 }
 
@@ -464,11 +499,12 @@ type MediaDBI interface {
 	SearchMediaPathGlob(systems []systemdefs.System, query string) ([]SearchResult, error)
 
 	// Browse methods for directory-style navigation of indexed content
-	BrowseDirectories(ctx context.Context, pathPrefix string) ([]BrowseDirectoryResult, error)
+	BrowseDirectories(ctx context.Context, opts BrowseDirectoriesOptions) ([]BrowseDirectoryResult, error)
 	BrowseFiles(ctx context.Context, opts *BrowseFilesOptions) ([]SearchResultWithCursor, error)
-	BrowseFileCount(ctx context.Context, pathPrefix string, letter *string) (int, error)
-	BrowseVirtualSchemes(ctx context.Context) ([]BrowseVirtualScheme, error)
+	BrowseFileCount(ctx context.Context, opts BrowseFileCountOptions) (int, error)
+	BrowseVirtualSchemes(ctx context.Context, opts BrowseVirtualSchemesOptions) ([]BrowseVirtualScheme, error)
 	BrowseRootCounts(ctx context.Context, rootDirs []string) (map[string]*int, error)
+	BrowseRouteCounts(ctx context.Context, opts BrowseRouteCountsOptions) (map[string]BrowseRouteCount, error)
 	PopulateBrowseCache(ctx context.Context) error
 
 	IndexedSystems() ([]string, error)

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -202,6 +202,11 @@ func (db *MediaDB) markBrowseCacheDirty(systemDBIDs ...int64) {
 	}
 	for _, systemDBID := range systemDBIDs {
 		db.browseCacheDirtyDBIDs[systemDBID] = struct{}{}
+		if len(db.browseCacheDirtyDBIDs) > maxSelectiveInvalidationSystems {
+			db.browseCacheDirtyAll = true
+			db.browseCacheDirtyDBIDs = nil
+			return
+		}
 	}
 }
 
@@ -224,7 +229,8 @@ func (db *MediaDB) flushBrowseCacheInvalidation() error {
 	for systemDBID := range db.browseCacheDirtyDBIDs {
 		systemDBIDs = append(systemDBIDs, systemDBID)
 	}
-	err := sqlInvalidateBrowseCache(db.ctx, db.sql, systemDBIDs, db.browseCacheDirtyAll)
+	allSystems := db.browseCacheDirtyAll || len(systemDBIDs) > maxSelectiveInvalidationSystems
+	err := sqlInvalidateBrowseCache(db.ctx, db.sql, systemDBIDs, allSystems)
 	if err != nil {
 		return err
 	}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -210,7 +210,10 @@ func (db *MediaDB) invalidateBrowseCacheForMediaChange(systemDBIDs ...int64) err
 		db.markBrowseCacheDirty(systemDBIDs...)
 		return nil
 	}
-	return sqlInvalidateBrowseCache(db.ctx, db.conn(), systemDBIDs, len(systemDBIDs) == 0)
+	if err := sqlInvalidateBrowseCache(db.ctx, db.conn(), systemDBIDs, len(systemDBIDs) == 0); err != nil {
+		log.Debug().Err(err).Msg("failed to invalidate browse cache after media change")
+	}
+	return nil
 }
 
 func (db *MediaDB) flushBrowseCacheInvalidation() error {
@@ -222,8 +225,11 @@ func (db *MediaDB) flushBrowseCacheInvalidation() error {
 		systemDBIDs = append(systemDBIDs, systemDBID)
 	}
 	err := sqlInvalidateBrowseCache(db.ctx, db.sql, systemDBIDs, db.browseCacheDirtyAll)
+	if err != nil {
+		return err
+	}
 	db.clearBrowseCacheInvalidation()
-	return err
+	return nil
 }
 
 func (db *MediaDB) clearBrowseCacheInvalidation() {

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -63,6 +63,10 @@ const (
 // defaultSlugSearchLimit is the max results returned by slug-based search methods.
 const defaultSlugSearchLimit = 50
 
+// maxSelectiveInvalidationSystems avoids huge per-commit IN clauses and debug
+// logs during full-library indexing while preserving selective reindexing wins.
+const maxSelectiveInvalidationSystems = 32
+
 // getSqliteConnParams constructs the SQLite connection string.
 func getSqliteConnParams() string {
 	return "?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000" +
@@ -310,6 +314,22 @@ var secondaryIndexes = []secondaryIndex{
 		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsecache_parent ON BrowseCache(ParentPath)",
 	},
 	{name: "idx_media_parentdir", ddl: "CREATE INDEX IF NOT EXISTS idx_media_parentdir ON Media(ParentDir)"},
+	{
+		name: "idx_browsesystemcache_parent",
+		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_parent ON BrowseSystemCache(SystemDBID, ParentPath)",
+	},
+	{
+		name: "idx_browsesystemcache_dir",
+		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_dir ON BrowseSystemCache(DirPath)",
+	},
+	{
+		name: "idx_browsesystemcache_virtual",
+		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_virtual ON BrowseSystemCache(SystemDBID, IsVirtual)",
+	},
+	{
+		name: "idx_media_parentdir_system",
+		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_parentdir_system ON Media(ParentDir, SystemDBID)",
+	},
 }
 
 // DropSecondaryIndexes drops all secondary indexes to speed up bulk inserts.
@@ -603,6 +623,9 @@ func (db *MediaDB) cacheInvalidationScopeForCommittedTransaction() invalidationS
 	if len(systemIDs) == 0 {
 		return invalidationScope{AllSystems: true}
 	}
+	if len(systemIDs) > maxSelectiveInvalidationSystems {
+		return invalidationScope{AllSystems: true}
+	}
 
 	return invalidationScope{SystemIDs: systemIDs}
 }
@@ -675,44 +698,53 @@ func (db *MediaDB) closeAllPreparedStatements() {
 	}
 }
 
-// closeAllBatchInserters closes all batch inserters and sets them to nil
-func (db *MediaDB) closeAllBatchInserters() {
+// closeAllBatchInserters closes all batch inserters and sets them to nil.
+func (db *MediaDB) closeAllBatchInserters() error {
+	var closeErrs []error
 	if db.batchInsertSystem != nil {
 		if closeErr := db.batchInsertSystem.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertSystem")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertSystem: %w", closeErr))
 		}
 		db.batchInsertSystem = nil
 	}
 	if db.batchInsertMediaTitle != nil {
 		if closeErr := db.batchInsertMediaTitle.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertMediaTitle")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertMediaTitle: %w", closeErr))
 		}
 		db.batchInsertMediaTitle = nil
 	}
 	if db.batchInsertMedia != nil {
 		if closeErr := db.batchInsertMedia.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertMedia")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertMedia: %w", closeErr))
 		}
 		db.batchInsertMedia = nil
 	}
 	if db.batchInsertTag != nil {
 		if closeErr := db.batchInsertTag.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertTag")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertTag: %w", closeErr))
 		}
 		db.batchInsertTag = nil
 	}
 	if db.batchInsertTagType != nil {
 		if closeErr := db.batchInsertTagType.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertTagType")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertTagType: %w", closeErr))
 		}
 		db.batchInsertTagType = nil
 	}
 	if db.batchInsertMediaTag != nil {
 		if closeErr := db.batchInsertMediaTag.Close(); closeErr != nil {
 			log.Warn().Err(closeErr).Msg("failed to close batch inserter: batchInsertMediaTag")
+			closeErrs = append(closeErrs, fmt.Errorf("batchInsertMediaTag: %w", closeErr))
 		}
 		db.batchInsertMediaTag = nil
 	}
+
+	return errors.Join(closeErrs...)
 }
 
 // RollbackTransaction rolls back the current transaction and cleans up resources
@@ -726,7 +758,7 @@ func (db *MediaDB) RollbackTransaction() error {
 
 	// Clean up prepared statements and batch inserters first
 	db.closeAllPreparedStatements()
-	db.closeAllBatchInserters()
+	_ = db.closeAllBatchInserters()
 
 	// Rollback the transaction
 	err := db.tx.Rollback()
@@ -749,7 +781,7 @@ func (db *MediaDB) rollbackAndLogError() {
 
 	// Clean up prepared statements and batch inserters first
 	db.closeAllPreparedStatements()
-	db.closeAllBatchInserters()
+	_ = db.closeAllBatchInserters()
 
 	// Rollback the transaction
 	if rbErr := db.tx.Rollback(); rbErr != nil {
@@ -962,7 +994,16 @@ func (db *MediaDB) CommitTransaction() error {
 	// Flush all batch inserters before committing (if any were created)
 	// Check if batch inserters exist rather than relying on a mode flag
 	if db.batchInsertSystem != nil {
-		db.closeAllBatchInserters()
+		if closeErr := db.closeAllBatchInserters(); closeErr != nil {
+			if rbErr := db.tx.Rollback(); rbErr != nil {
+				db.tx = nil
+				db.inTransaction = false
+				return fmt.Errorf("failed to flush batch inserts: %w; rollback also failed: %w", closeErr, rbErr)
+			}
+			db.tx = nil
+			db.inTransaction = false
+			return fmt.Errorf("failed to flush batch inserts: %w", closeErr)
+		}
 	} else {
 		// Clean up prepared statements
 		db.closeAllPreparedStatements()
@@ -1052,12 +1093,12 @@ func (db *MediaDB) WALCheckpoint() error {
 
 // BrowseDirectories returns distinct immediate subdirectory names under the given path prefix.
 func (db *MediaDB) BrowseDirectories(
-	ctx context.Context, pathPrefix string,
+	ctx context.Context, opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseDirectories(ctx, db.conn(), pathPrefix)
+	return sqlBrowseDirectories(ctx, db.conn(), opts)
 }
 
 // BrowseFiles returns indexed media files that are immediate children of the given path prefix.
@@ -1072,22 +1113,22 @@ func (db *MediaDB) BrowseFiles(
 
 // BrowseFileCount returns the total number of immediate child files under a path prefix.
 func (db *MediaDB) BrowseFileCount(
-	ctx context.Context, pathPrefix string, letter *string,
+	ctx context.Context, opts database.BrowseFileCountOptions,
 ) (int, error) {
 	if db.sql == nil {
 		return 0, ErrNullSQL
 	}
-	return sqlBrowseFileCount(ctx, db.conn(), pathPrefix, letter)
+	return sqlBrowseFileCount(ctx, db.conn(), opts)
 }
 
 // BrowseVirtualSchemes returns distinct URI schemes present in indexed media.
 func (db *MediaDB) BrowseVirtualSchemes(
-	ctx context.Context,
+	ctx context.Context, opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseVirtualSchemes(ctx, db.conn())
+	return sqlBrowseVirtualSchemes(ctx, db.conn(), opts)
 }
 
 // BrowseRootCounts returns a map of root directory to count of indexed media
@@ -1100,6 +1141,16 @@ func (db *MediaDB) BrowseRootCounts(
 		return nil, ErrNullSQL
 	}
 	return sqlBrowseRootCounts(ctx, db.conn(), rootDirs)
+}
+
+// BrowseRouteCounts returns populated route counts for system-scoped browse roots.
+func (db *MediaDB) BrowseRouteCounts(
+	ctx context.Context, opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+	return sqlBrowseRouteCounts(ctx, db.conn(), opts)
 }
 
 // PopulateBrowseCache rebuilds the BrowseCache table from the current Media data.

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -78,8 +78,8 @@ type MediaDB struct {
 	clock                 clockwork.Clock
 	ctx                   context.Context
 	pl                    platforms.Platform
-	batchInsertTagType    *BatchInserter
-	batchInsertMedia      *BatchInserter
+	batchInsertMediaTitle *BatchInserter
+	stmtInsertMediaTitle  *sql.Stmt
 	stmtInsertMedia       *sql.Stmt
 	tx                    *sql.Tx
 	stmtInsertSystem      *sql.Stmt
@@ -89,11 +89,12 @@ type MediaDB struct {
 	batchInsertMediaTag   *BatchInserter
 	batchInsertSystem     *BatchInserter
 	batchInsertTag        *BatchInserter
-	batchInsertMediaTitle *BatchInserter
+	batchInsertTagType    *BatchInserter
 	stmtInsertMediaTag    *sql.Stmt
-	stmtInsertMediaTitle  *sql.Stmt
+	batchInsertMedia      *BatchInserter
 	slugSearchCache       atomic.Pointer[SlugSearchCache]
 	inMemoryTagCache      atomic.Pointer[tagCache]
+	browseCacheDirtyDBIDs map[int64]struct{}
 	dbPath                string
 	backgroundOps         sync.WaitGroup
 	vacuumRetryDelay      time.Duration
@@ -103,6 +104,7 @@ type MediaDB struct {
 	isOptimizing          atomic.Bool
 	needsIndexRebuild     atomic.Bool
 	inTransaction         bool
+	browseCacheDirtyAll   bool
 }
 
 // sqlQueryable is the subset of *sql.DB and *sql.Tx needed by SQL helpers.
@@ -177,6 +179,56 @@ func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 			log.Warn().Err(err).Msg("failed to invalidate slug resolution cache for specific systems")
 		}
 	}
+}
+
+func invalidationScopeForSystemIDs(systemIDs []string) invalidationScope {
+	if len(systemIDs) == 0 || len(systemIDs) > maxSelectiveInvalidationSystems {
+		return invalidationScope{AllSystems: true}
+	}
+	return invalidationScope{SystemIDs: systemIDs}
+}
+
+func (db *MediaDB) markBrowseCacheDirty(systemDBIDs ...int64) {
+	if len(systemDBIDs) == 0 {
+		db.browseCacheDirtyAll = true
+		db.browseCacheDirtyDBIDs = nil
+		return
+	}
+	if db.browseCacheDirtyAll {
+		return
+	}
+	if db.browseCacheDirtyDBIDs == nil {
+		db.browseCacheDirtyDBIDs = make(map[int64]struct{}, len(systemDBIDs))
+	}
+	for _, systemDBID := range systemDBIDs {
+		db.browseCacheDirtyDBIDs[systemDBID] = struct{}{}
+	}
+}
+
+func (db *MediaDB) invalidateBrowseCacheForMediaChange(systemDBIDs ...int64) error {
+	if db.inTransaction {
+		db.markBrowseCacheDirty(systemDBIDs...)
+		return nil
+	}
+	return sqlInvalidateBrowseCache(db.ctx, db.conn(), systemDBIDs, len(systemDBIDs) == 0)
+}
+
+func (db *MediaDB) flushBrowseCacheInvalidation() error {
+	if !db.browseCacheDirtyAll && len(db.browseCacheDirtyDBIDs) == 0 {
+		return nil
+	}
+	systemDBIDs := make([]int64, 0, len(db.browseCacheDirtyDBIDs))
+	for systemDBID := range db.browseCacheDirtyDBIDs {
+		systemDBIDs = append(systemDBIDs, systemDBID)
+	}
+	err := sqlInvalidateBrowseCache(db.ctx, db.sql, systemDBIDs, db.browseCacheDirtyAll)
+	db.clearBrowseCacheInvalidation()
+	return err
+}
+
+func (db *MediaDB) clearBrowseCacheInvalidation() {
+	db.browseCacheDirtyAll = false
+	db.browseCacheDirtyDBIDs = nil
 }
 
 func OpenMediaDB(ctx context.Context, pl platforms.Platform) (*MediaDB, error) {
@@ -440,10 +492,8 @@ func (db *MediaDB) UpdateLastGenerated() error {
 			log.Warn().Err(getSystemsErr).
 				Msg("failed to load indexing systems for cache invalidation; clearing all caches")
 			db.invalidateCaches(invalidationScope{AllSystems: true})
-		case len(systemIDs) > 0:
-			db.invalidateCaches(invalidationScope{SystemIDs: systemIDs})
 		default:
-			db.invalidateCaches(invalidationScope{AllSystems: true})
+			db.invalidateCaches(invalidationScopeForSystemIDs(systemIDs))
 		}
 	}
 
@@ -541,6 +591,9 @@ func (db *MediaDB) Truncate() error {
 	if err != nil {
 		return err
 	}
+	if err := sqlInvalidateBrowseCache(db.ctx, db.sql, nil, true); err != nil {
+		return err
+	}
 
 	// Invalidate all caches after full truncation
 	db.invalidateCaches(invalidationScope{AllSystems: true})
@@ -555,9 +608,12 @@ func (db *MediaDB) TruncateSystems(systemIDs []string) error {
 	if err != nil {
 		return err
 	}
+	if err := sqlInvalidateBrowseCache(db.ctx, db.sql, nil, true); err != nil {
+		return err
+	}
 
 	// Invalidate caches for the affected systems
-	db.invalidateCaches(invalidationScope{SystemIDs: systemIDs})
+	db.invalidateCaches(invalidationScopeForSystemIDs(systemIDs))
 	return nil
 }
 
@@ -620,14 +676,7 @@ func (db *MediaDB) cacheInvalidationScopeForCommittedTransaction() invalidationS
 		return invalidationScope{AllSystems: true}
 	}
 
-	if len(systemIDs) == 0 {
-		return invalidationScope{AllSystems: true}
-	}
-	if len(systemIDs) > maxSelectiveInvalidationSystems {
-		return invalidationScope{AllSystems: true}
-	}
-
-	return invalidationScope{SystemIDs: systemIDs}
+	return invalidationScopeForSystemIDs(systemIDs)
 }
 
 // SetSQLForTesting allows injection of a sql.DB instance for testing purposes.
@@ -764,6 +813,7 @@ func (db *MediaDB) RollbackTransaction() error {
 	err := db.tx.Rollback()
 	db.tx = nil
 	db.inTransaction = false // Clear transaction flag (no cache invalidation needed on rollback)
+	db.clearBrowseCacheInvalidation()
 	if err != nil {
 		return fmt.Errorf("failed to rollback transaction: %w", err)
 	}
@@ -789,6 +839,7 @@ func (db *MediaDB) rollbackAndLogError() {
 	}
 	db.tx = nil
 	db.inTransaction = false
+	db.clearBrowseCacheInvalidation()
 }
 
 func (db *MediaDB) BeginTransaction(batchEnabled bool) error {
@@ -998,10 +1049,12 @@ func (db *MediaDB) CommitTransaction() error {
 			if rbErr := db.tx.Rollback(); rbErr != nil {
 				db.tx = nil
 				db.inTransaction = false
+				db.clearBrowseCacheInvalidation()
 				return fmt.Errorf("failed to flush batch inserts: %w; rollback also failed: %w", closeErr, rbErr)
 			}
 			db.tx = nil
 			db.inTransaction = false
+			db.clearBrowseCacheInvalidation()
 			return fmt.Errorf("failed to flush batch inserts: %w", closeErr)
 		}
 	} else {
@@ -1016,10 +1069,12 @@ func (db *MediaDB) CommitTransaction() error {
 		if rbErr := db.tx.Rollback(); rbErr != nil {
 			db.tx = nil
 			db.inTransaction = false
+			db.clearBrowseCacheInvalidation()
 			return fmt.Errorf("commit failed: %w; rollback also failed: %w", err, rbErr)
 		}
 		db.tx = nil
 		db.inTransaction = false
+		db.clearBrowseCacheInvalidation()
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -1030,6 +1085,9 @@ func (db *MediaDB) CommitTransaction() error {
 	// During selective indexing, preserve unaffected in-memory slug cache coverage
 	// so post-index searches for untouched systems stay warm.
 	db.invalidateCaches(db.cacheInvalidationScopeForCommittedTransaction())
+	if err := db.flushBrowseCacheInvalidation(); err != nil {
+		return err
+	}
 
 	// Run manual WAL checkpoint after commit to keep WAL size bounded during indexing
 	// Use TRUNCATE to reset the WAL file after commit, keeping reads fast
@@ -1994,6 +2052,7 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 		if err != nil {
 			return row, fmt.Errorf("failed to add media to batch: %w", err)
 		}
+		db.markBrowseCacheDirty(row.SystemDBID)
 		// Return row as-is (DBID is already set by caller)
 		return row, nil
 	}
@@ -2008,6 +2067,11 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 	// Only invalidate cache if NOT in a transaction (transactions invalidate once on commit)
 	if err == nil && !db.inTransaction {
 		db.invalidateCaches(invalidationScope{AllSystems: true})
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(result.SystemDBID); invalidateErr != nil {
+			return result, invalidateErr
+		}
+	} else if err == nil {
+		db.markBrowseCacheDirty(result.SystemDBID)
 	}
 
 	return result, err
@@ -2021,6 +2085,11 @@ func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
 	err := sqlUpdateMediaTitle(db.ctx, db.conn(), mediaDBID, mediaTitleDBID)
 	if err == nil && !db.inTransaction {
 		db.invalidateCaches(invalidationScope{AllSystems: true})
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(); invalidateErr != nil {
+			return invalidateErr
+		}
+	} else if err == nil {
+		db.markBrowseCacheDirty()
 	}
 
 	return err
@@ -2059,6 +2128,11 @@ func (db *MediaDB) BulkSetMediaMissing(dbids map[int]struct{}) error {
 	err := sqlBulkSetMediaMissing(db.ctx, db.conn(), dbids)
 	if err == nil && !db.inTransaction {
 		db.invalidateCaches(invalidationScope{AllSystems: true})
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(); invalidateErr != nil {
+			return invalidateErr
+		}
+	} else if err == nil {
+		db.markBrowseCacheDirty()
 	}
 	return err
 }
@@ -2070,6 +2144,19 @@ func (db *MediaDB) ResetMissingFlags(systemDBIDs []int) error {
 	err := sqlResetMissingFlags(db.ctx, db.conn(), systemDBIDs)
 	if err == nil && !db.inTransaction {
 		db.invalidateCaches(invalidationScope{AllSystems: true})
+		dirtySystemDBIDs := make([]int64, len(systemDBIDs))
+		for i, systemDBID := range systemDBIDs {
+			dirtySystemDBIDs[i] = int64(systemDBID)
+		}
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(dirtySystemDBIDs...); invalidateErr != nil {
+			return invalidateErr
+		}
+	} else if err == nil {
+		dirtySystemDBIDs := make([]int64, len(systemDBIDs))
+		for i, systemDBID := range systemDBIDs {
+			dirtySystemDBIDs[i] = int64(systemDBID)
+		}
+		db.markBrowseCacheDirty(dirtySystemDBIDs...)
 	}
 	return err
 }

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -2262,6 +2262,100 @@ func TestMediaDB_CommitTransaction_SelectiveIndexingPreservesUnchangedSlugCache_
 	assert.True(t, cache.CanServeSystems([]string{snesSystem.ID}))
 }
 
+func TestMediaDB_CommitTransaction_ReturnsBatchFlushError_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	require.NoError(t, mediaDB.batchInsertSystem.Add(int64(1), "NES", "NES"))
+	require.NoError(t, mediaDB.batchInsertSystem.Add(int64(1), "SNES", "SNES"))
+
+	err := mediaDB.CommitTransaction()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to flush batch inserts")
+}
+
+func TestMediaDB_CacheInvalidationScope_UsesAllSystemsForBroadIndexing_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	systemIDs := make([]string, maxSelectiveInvalidationSystems+1)
+	for i := range systemIDs {
+		systemIDs[i] = fmt.Sprintf("system-%d", i)
+	}
+	require.NoError(t, mediaDB.SetIndexingSystems(systemIDs))
+	require.NoError(t, mediaDB.SetIndexingStatus(IndexingStatusRunning))
+
+	scope := mediaDB.cacheInvalidationScopeForCommittedTransaction()
+	assert.True(t, scope.AllSystems)
+	assert.Empty(t, scope.SystemIDs)
+}
+
+func TestMediaDB_SystemBrowseFallsBackWhenSystemCacheEmpty_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	snesSystem, err := systemdefs.GetSystem("SNES")
+	require.NoError(t, err)
+
+	sharedRoot := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "shared"))
+	rpgDir := filepath.ToSlash(filepath.Join(sharedRoot, "RPG"))
+	gamePath := filepath.ToSlash(filepath.Join(rpgDir, "game.sfc"))
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: snesSystem.ID, Name: snesSystem.ID})
+	require.NoError(t, err)
+	insertedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       slugs.Slugify(snesSystem.GetMediaType(), "Direct Browse Game"),
+		Name:       "Direct Browse Game",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     insertedSystem.DBID,
+		MediaTitleDBID: insertedTitle.DBID,
+		Path:           gamePath,
+		ParentDir:      rpgDir + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	_, err = mediaDB.sql.ExecContext(ctx, "DELETE FROM BrowseSystemCache")
+	require.NoError(t, err)
+
+	routeCounts, err := mediaDB.BrowseRouteCounts(ctx, database.BrowseRouteCountsOptions{
+		Routes:  []string{sharedRoot},
+		Systems: []systemdefs.System{*snesSystem},
+	})
+	require.NoError(t, err)
+	require.Contains(t, routeCounts, sharedRoot)
+	assert.Equal(t, 1, routeCounts[sharedRoot].FileCount)
+	assert.Equal(t, []string{snesSystem.ID}, routeCounts[sharedRoot].SystemIDs)
+
+	dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		PathPrefix: sharedRoot + "/",
+		Systems:    []systemdefs.System{*snesSystem},
+	})
+	require.NoError(t, err)
+	require.Len(t, dirs, 1)
+	assert.Equal(t, "RPG", dirs[0].Name)
+	assert.Equal(t, 1, dirs[0].FileCount)
+	assert.Equal(t, []string{snesSystem.ID}, dirs[0].SystemIDs)
+}
+
 func TestMediaDB_SearchMediaWithFilters_SelectiveIndexingKeepsUnchangedSystemsCacheEligible_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -151,6 +152,120 @@ func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {
 	}
 
 	return db, cleanup
+}
+
+func insertSystemWithMedia(t *testing.T, mediaDB *MediaDB, systemID, titleName, mediaPath string) database.System {
+	t.Helper()
+
+	insertedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: systemID, Name: systemID})
+	require.NoError(t, err)
+	insertSystemMedia(t, mediaDB, insertedSystem, titleName, mediaPath)
+	return insertedSystem
+}
+
+func insertSystemMedia(t *testing.T, mediaDB *MediaDB, system database.System, titleName, mediaPath string) {
+	t.Helper()
+
+	sys, err := systemdefs.GetSystem(system.SystemID)
+	require.NoError(t, err)
+	parentDir := ""
+	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
+		parentDir = mediaPath[:idx+3]
+	} else {
+		parentDir = filepath.ToSlash(filepath.Dir(mediaPath)) + "/"
+	}
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: system.DBID,
+		Slug:       slugs.Slugify(sys.GetMediaType(), titleName),
+		Name:       titleName,
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     system.DBID,
+		MediaTitleDBID: insertedTitle.DBID,
+		Path:           mediaPath,
+		ParentDir:      parentDir,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+}
+
+func assertBrowseCacheRow(
+	t *testing.T,
+	mediaDB *MediaDB,
+	table string,
+	systemDBID int64,
+	dirPath string,
+	wantParentPath string,
+	wantName string,
+	wantFileCount int,
+	wantVirtual bool,
+) {
+	t.Helper()
+
+	var query string
+	var args []any
+	switch table {
+	case "BrowseCache":
+		query = "SELECT ParentPath, Name, FileCount, IsVirtual FROM BrowseCache WHERE DirPath = ?"
+		args = []any{dirPath}
+	case "BrowseSystemCache":
+		query = `SELECT ParentPath, Name, FileCount, IsVirtual
+			FROM BrowseSystemCache WHERE SystemDBID = ? AND DirPath = ?`
+		args = []any{systemDBID, dirPath}
+	default:
+		t.Fatalf("unexpected browse cache table %q", table)
+	}
+
+	var parentPath, name string
+	var fileCount int
+	var isVirtual bool
+	err := mediaDB.sql.QueryRowContext(context.Background(), query, args...).Scan(
+		&parentPath, &name, &fileCount, &isVirtual,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, wantParentPath, parentPath)
+	assert.Equal(t, wantName, name)
+	assert.Equal(t, wantFileCount, fileCount)
+	assert.Equal(t, wantVirtual, isVirtual)
+}
+
+func seedBrowseCacheRows(t *testing.T, mediaDB *MediaDB, systemDBIDs ...int64) {
+	t.Helper()
+
+	ctx := context.Background()
+	romsPath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms")) + "/"
+	_, err := mediaDB.sql.ExecContext(ctx,
+		"INSERT INTO BrowseCache (DirPath, ParentPath, Name, FileCount, IsVirtual) VALUES (?, ?, ?, ?, ?)",
+		romsPath, "", "roms", 2, false,
+	)
+	require.NoError(t, err)
+	for _, systemDBID := range systemDBIDs {
+		_, err = mediaDB.sql.ExecContext(ctx,
+			`INSERT INTO BrowseSystemCache (SystemDBID, DirPath, ParentPath, Name, FileCount, IsVirtual)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			systemDBID, romsPath, "", "roms", 1, false,
+		)
+		require.NoError(t, err)
+	}
+}
+
+func countTableRows(t *testing.T, mediaDB *MediaDB, table, where string, args ...any) int {
+	t.Helper()
+
+	if table != "BrowseCache" && table != "BrowseSystemCache" {
+		t.Fatalf("unexpected table %q", table)
+	}
+	query := "SELECT COUNT(*) FROM " + table
+	if where != "" {
+		query += " WHERE " + where
+	}
+	var count int
+	err := mediaDB.sql.QueryRowContext(context.Background(), query, args...).Scan(&count)
+	require.NoError(t, err)
+	return count
 }
 
 func assertIndexExists(t *testing.T, mediaDB *MediaDB, indexName string) {
@@ -2354,6 +2469,106 @@ func TestMediaDB_SystemBrowseFallsBackWhenSystemCacheEmpty_Integration(t *testin
 	assert.Equal(t, "RPG", dirs[0].Name)
 	assert.Equal(t, 1, dirs[0].FileCount)
 	assert.Equal(t, []string{snesSystem.ID}, dirs[0].SystemIDs)
+}
+
+func TestSqlPopulateBrowseCache_PopulatesSystemAndGlobalCounts_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	snesSystem := insertSystemWithMedia(t, mediaDB, "SNES", "Super RPG",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "RPG", "super-rpg.sfc")))
+	nesSystem := insertSystemWithMedia(t, mediaDB, "NES", "Super Mario Bros",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "nes", "mario.nes")))
+	insertSystemMedia(t, mediaDB, snesSystem, "Steam Game", "steam://440/Team%20Fortress%202")
+
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql))
+
+	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0, "/", "", "/", 2, false)
+	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0,
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms"))+"/", "", "roms", 2, false)
+	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0, "steam://", "", "steam://", 1, true)
+
+	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", snesSystem.DBID, "/", "", "/", 1, false)
+	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", nesSystem.DBID, "/", "", "/", 1, false)
+	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", snesSystem.DBID, "steam://", "", "steam://", 1, true)
+}
+
+func TestSqlInvalidateBrowseCache_DeletesScopedSystemRows_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	nesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	snesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
+	require.NoError(t, err)
+	seedBrowseCacheRows(t, mediaDB, nesSystem.DBID, snesSystem.DBID)
+
+	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, []int64{nesSystem.DBID}, false))
+
+	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseCache", ""))
+	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseSystemCache", "SystemDBID = ?", nesSystem.DBID))
+	assert.Equal(t, 1, countTableRows(t, mediaDB, "BrowseSystemCache", "SystemDBID = ?", snesSystem.DBID))
+}
+
+func TestSqlInvalidateBrowseCache_DeletesAllRows_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	nesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	snesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
+	require.NoError(t, err)
+	seedBrowseCacheRows(t, mediaDB, nesSystem.DBID, snesSystem.DBID)
+
+	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, nil, true))
+
+	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseCache", ""))
+	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseSystemCache", ""))
+}
+
+func TestMediaDB_UnfilteredBrowseReadsFromMediaWhenBrowseCacheEmpty_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	snesSystem := insertSystemWithMedia(t, mediaDB, "SNES", "Super RPG",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "RPG", "super-rpg.sfc")))
+	insertSystemMedia(t, mediaDB, snesSystem, "Action Game",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "Action", "action.sfc")))
+	insertSystemMedia(t, mediaDB, snesSystem, "Steam Game", "steam://440/Team%20Fortress%202")
+	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, nil, true))
+
+	romsPrefix := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms")) + "/"
+	dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{PathPrefix: romsPrefix})
+	require.NoError(t, err)
+	require.Len(t, dirs, 1)
+	assert.Equal(t, "snes", dirs[0].Name)
+	assert.Equal(t, 2, dirs[0].FileCount)
+
+	schemes, err := mediaDB.BrowseVirtualSchemes(ctx, database.BrowseVirtualSchemesOptions{})
+	require.NoError(t, err)
+	require.Len(t, schemes, 1)
+	assert.Equal(t, "steam://", schemes[0].Scheme)
+	assert.Equal(t, 1, schemes[0].FileCount)
 }
 
 func TestMediaDB_SearchMediaWithFilters_SelectiveIndexingKeepsUnchangedSystemsCacheEligible_Integration(t *testing.T) {

--- a/pkg/database/mediadb/migrations/20260429142159_system_browse_cache.sql
+++ b/pkg/database/mediadb/migrations/20260429142159_system_browse_cache.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS BrowseSystemCache (
+    SystemDBID INTEGER NOT NULL,
+    DirPath    TEXT    NOT NULL,
+    ParentPath TEXT    NOT NULL DEFAULT '',
+    Name       TEXT    NOT NULL DEFAULT '',
+    FileCount  INT     NOT NULL DEFAULT 0,
+    IsVirtual  INT     NOT NULL DEFAULT 0,
+    PRIMARY KEY (SystemDBID, DirPath),
+    FOREIGN KEY (SystemDBID) REFERENCES Systems(DBID) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_parent ON BrowseSystemCache(SystemDBID, ParentPath);
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_dir ON BrowseSystemCache(DirPath);
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_virtual ON BrowseSystemCache(SystemDBID, IsVirtual);
+CREATE INDEX IF NOT EXISTS idx_media_parentdir_system ON Media(ParentDir, SystemDBID);
+
+-- Existing databases need a browse-cache rebuild to populate BrowseSystemCache.
+INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES ('OptimizationStatus', 'pending');
+INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES ('OptimizationStep', 'browse_cache');
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_media_parentdir_system;
+DROP INDEX IF EXISTS idx_browsesystemcache_virtual;
+DROP INDEX IF EXISTS idx_browsesystemcache_dir;
+DROP INDEX IF EXISTS idx_browsesystemcache_parent;
+DROP TABLE IF EXISTS BrowseSystemCache;

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -56,13 +56,16 @@ func expectBrowseCacheStep(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "browse_cache").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// PopulateBrowseCache: SELECT (empty), BEGIN, DELETE, Prepare, COMMIT
-	mock.ExpectQuery("SELECT Path FROM Media").
-		WillReturnRows(sqlmock.NewRows([]string{"Path"}))
+	// PopulateBrowseCache: SELECT (empty), BEGIN, DELETEs, Prepares, COMMIT
+	mock.ExpectQuery("SELECT SystemDBID, Path FROM Media").
+		WillReturnRows(sqlmock.NewRows([]string{"SystemDBID", "Path"}))
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM BrowseCache").
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM BrowseSystemCache").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectPrepare("INSERT INTO BrowseCache")
+	mock.ExpectPrepare("INSERT INTO BrowseSystemCache")
 	mock.ExpectCommit()
 }
 

--- a/pkg/database/mediadb/slug_cache.go
+++ b/pkg/database/mediadb/slug_cache.go
@@ -193,7 +193,7 @@ func (db *MediaDB) InvalidateSlugCacheForSystems(ctx context.Context, systemIDs 
 		return fmt.Errorf("failed to invalidate slug cache for systems: %w", err)
 	}
 
-	log.Debug().Strs("system_ids", systemIDs).Msg("invalidated slug resolution cache for systems")
+	log.Debug().Int("system_count", len(systemIDs)).Msg("invalidated slug resolution cache for systems")
 	return nil
 }
 

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -21,22 +21,50 @@ package mediadb
 
 import (
 	"context"
+	stdsql "database/sql"
 	"fmt"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 )
+
+func browseSystemFilterClause(column string, systems []systemdefs.System) (clause string, args []any) {
+	if len(systems) == 0 {
+		return "", nil
+	}
+
+	placeholders := make([]string, len(systems))
+	args = make([]any, len(systems))
+	for i := range systems {
+		placeholders[i] = "?"
+		args[i] = systems[i].ID
+	}
+
+	return column + " IN (" + strings.Join(placeholders, ",") + ")", args
+}
+
+func splitBrowseSystemIDs(ids string) []string {
+	if ids == "" {
+		return nil
+	}
+	return strings.Split(ids, ",")
+}
 
 // sqlBrowseDirectories returns distinct immediate subdirectory names under the
 // given path prefix from BrowseCache, along with the precomputed file count.
 func sqlBrowseDirectories(
 	ctx context.Context,
 	db sqlQueryable,
-	pathPrefix string,
+	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
+	if len(opts.Systems) > 0 {
+		return sqlBrowseDirectoriesForSystems(ctx, db, opts)
+	}
+
 	rows, err := db.QueryContext(ctx,
 		`SELECT Name, FileCount FROM BrowseCache WHERE ParentPath = ? ORDER BY Name ASC`,
-		pathPrefix,
+		opts.PathPrefix,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("browse directories query: %w", err)
@@ -58,6 +86,111 @@ func sqlBrowseDirectories(
 	return results, nil
 }
 
+func sqlBrowseDirectoriesForSystems(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
+	results, err := sqlBrowseDirectoriesForSystemsFromCache(ctx, db, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		return results, nil
+	}
+
+	return sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, opts)
+}
+
+func sqlBrowseDirectoriesForSystemsFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	args := make([]any, 0, 1+len(systemArgs))
+	args = append(args, opts.PathPrefix)
+	args = append(args, systemArgs...)
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT b.Name, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
+		 FROM BrowseSystemCache b
+		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
+		 WHERE b.ParentPath = ? AND `+systemClause+`
+		 GROUP BY b.DirPath, b.Name
+		 ORDER BY b.Name ASC`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("browse directories by system query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseDirectoryResult
+	for rows.Next() {
+		var r database.BrowseDirectoryResult
+		var systemIDs string
+		if err := rows.Scan(&r.Name, &r.FileCount, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse directories by system scan: %w", err)
+		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse directories by system rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func sqlBrowseDirectoriesForSystemsFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	args := make([]any, 0, 2+len(systemArgs))
+	args = append(args, opts.PathPrefix, opts.PathPrefix)
+	args = append(args, systemArgs...)
+
+	rows, err := db.QueryContext(ctx,
+		`WITH matched AS (
+			 SELECT s.SystemID, substr(m.Path, length(?) + 1) AS Rest
+			 FROM Media m
+			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause+`
+		 )
+		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
+			COUNT(*) AS FileCount,
+			GROUP_CONCAT(DISTINCT SystemID)
+		 FROM matched
+		 WHERE instr(Rest, '/') > 0
+		 GROUP BY Name
+		 ORDER BY Name ASC`,
+		args...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("browse directories by system media query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseDirectoryResult
+	for rows.Next() {
+		var r database.BrowseDirectoryResult
+		var systemIDs string
+		if err := rows.Scan(&r.Name, &r.FileCount, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse directories by system media scan: %w", err)
+		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse directories by system media rows: %w", err)
+	}
+
+	return results, nil
+}
+
 // browseFilesBaseCondition returns the WHERE clause and args for filtering
 // immediate children of a path prefix, with optional letter filter.
 // Uses the ParentDir column for direct index lookup instead of range scan.
@@ -66,13 +199,17 @@ func browseFilesBaseCondition(
 ) (where string, args []any) {
 	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "mt.Name")
 
-	conditions := make([]string, 0, 2+len(letterClauses))
+	conditions := make([]string, 0, 3+len(letterClauses))
 	conditions = append(conditions, `m.ParentDir = ?`, `m.IsMissing = 0`)
 	conditions = append(conditions, letterClauses...)
 
 	args = make([]any, 0, 1+len(letterArgs))
 	args = append(args, opts.PathPrefix)
 	args = append(args, letterArgs...)
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		conditions = append(conditions, systemClause)
+		args = append(args, systemArgs...)
+	}
 
 	where = strings.Join(conditions, " AND ")
 	return where, args
@@ -121,7 +258,7 @@ func sqlBrowseFiles(
 		SELECT s.SystemID, mt.Name, m.Path, m.DBID
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
-		INNER JOIN Systems s ON mt.SystemDBID = s.DBID
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
 
 	if opts.Cursor != nil {
@@ -163,18 +300,19 @@ func sqlBrowseFiles(
 func sqlBrowseFileCount(
 	ctx context.Context,
 	db sqlQueryable,
-	pathPrefix string,
-	letter *string,
+	opts database.BrowseFileCountOptions,
 ) (int, error) {
 	where, args := browseFilesBaseCondition(&database.BrowseFilesOptions{
-		PathPrefix: pathPrefix,
-		Letter:     letter,
+		PathPrefix: opts.PathPrefix,
+		Letter:     opts.Letter,
+		Systems:    opts.Systems,
 	})
 
 	query := `
 		SELECT COUNT(*)
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
 
 	var count int
@@ -190,7 +328,12 @@ func sqlBrowseFileCount(
 func sqlBrowseVirtualSchemes(
 	ctx context.Context,
 	db sqlQueryable,
+	opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
+	if len(opts.Systems) > 0 {
+		return sqlBrowseVirtualSchemesForSystems(ctx, db, opts)
+	}
+
 	rows, err := db.QueryContext(ctx,
 		`SELECT DirPath, FileCount FROM BrowseCache
 		 WHERE IsVirtual = 1 ORDER BY DirPath ASC`)
@@ -212,6 +355,188 @@ func sqlBrowseVirtualSchemes(
 	}
 
 	return results, nil
+}
+
+func sqlBrowseVirtualSchemesForSystems(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseVirtualSchemesOptions,
+) ([]database.BrowseVirtualScheme, error) {
+	systemClause, args := browseSystemFilterClause("s.SystemID", opts.Systems)
+	rows, err := db.QueryContext(ctx,
+		`SELECT b.DirPath, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
+		 FROM BrowseSystemCache b
+		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
+		 WHERE b.IsVirtual = 1 AND `+systemClause+`
+		 GROUP BY b.DirPath
+		 ORDER BY b.DirPath ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse virtual schemes by system query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseVirtualScheme
+	for rows.Next() {
+		var r database.BrowseVirtualScheme
+		var systemIDs string
+		if err := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse virtual schemes by system scan: %w", err)
+		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse virtual schemes by system rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func browseRouteCacheKey(route string) string {
+	if strings.Contains(route, "://") || route == "" || strings.HasSuffix(route, "/") {
+		return route
+	}
+	return route + "/"
+}
+
+func sqlBrowseRouteCounts(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	if len(opts.Routes) == 0 || len(opts.Systems) == 0 {
+		return make(map[string]database.BrowseRouteCount), nil
+	}
+
+	counts, err := sqlBrowseRouteCountsFromCache(ctx, db, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	missingRoutes := make([]string, 0, len(opts.Routes))
+	for _, route := range opts.Routes {
+		if _, ok := counts[route]; !ok {
+			missingRoutes = append(missingRoutes, route)
+		}
+	}
+	if len(missingRoutes) == 0 {
+		return counts, nil
+	}
+
+	mediaCounts, err := sqlBrowseRouteCountsFromMedia(ctx, db, database.BrowseRouteCountsOptions{
+		Systems: opts.Systems,
+		Routes:  missingRoutes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for route, count := range mediaCounts {
+		counts[route] = count
+	}
+
+	return counts, nil
+}
+
+func sqlBrowseRouteCountsFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
+
+	routeKeys := make([]string, len(opts.Routes))
+	keyToRoute := make(map[string]string, len(opts.Routes))
+	args := make([]any, 0, len(opts.Routes)+len(opts.Systems))
+	for i, route := range opts.Routes {
+		key := browseRouteCacheKey(route)
+		routeKeys[i] = key
+		keyToRoute[key] = route
+		args = append(args, key)
+	}
+
+	routePlaceholders := make([]string, len(routeKeys))
+	for i := range routePlaceholders {
+		routePlaceholders[i] = "?"
+	}
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	args = append(args, systemArgs...)
+
+	rows, err := db.QueryContext(ctx,
+		`SELECT b.DirPath, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
+		 FROM BrowseSystemCache b
+		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
+		 WHERE b.DirPath IN (`+strings.Join(routePlaceholders, ",")+
+			`) AND `+systemClause+`
+		 GROUP BY b.DirPath`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse route counts query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var dirPath string
+		var count int
+		var systemIDs string
+		if err := rows.Scan(&dirPath, &count, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse route counts scan: %w", err)
+		}
+		route, ok := keyToRoute[dirPath]
+		if !ok {
+			continue
+		}
+		counts[route] = database.BrowseRouteCount{
+			Path:      route,
+			FileCount: count,
+			SystemIDs: splitBrowseSystemIDs(systemIDs),
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse route counts rows: %w", err)
+	}
+
+	return counts, nil
+}
+
+func sqlBrowseRouteCountsFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
+	if len(opts.Routes) == 0 || len(opts.Systems) == 0 {
+		return counts, nil
+	}
+
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	for _, route := range opts.Routes {
+		prefix := browseRouteCacheKey(route)
+		args := make([]any, 0, 1+len(systemArgs))
+		args = append(args, prefix)
+		args = append(args, systemArgs...)
+
+		var count int
+		var systemIDs stdsql.NullString
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*), GROUP_CONCAT(DISTINCT s.SystemID)
+			 FROM Media m
+			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause,
+			args...,
+		).Scan(&count, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse route counts media scan: %w", err)
+		}
+		if count == 0 {
+			continue
+		}
+
+		counts[route] = database.BrowseRouteCount{
+			Path:      route,
+			FileCount: count,
+			SystemIDs: splitBrowseSystemIDs(systemIDs.String),
+		}
+	}
+
+	return counts, nil
 }
 
 // sqlBrowseRootCounts looks up precomputed file counts for root directories

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	stdsql "database/sql"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -95,11 +96,72 @@ func sqlBrowseDirectoriesForSystems(
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
+	missingSystems := browseMissingSystems(opts.Systems, browseCoveredSystemIDsFromDirectories(results))
+	if len(missingSystems) == 0 {
 		return results, nil
 	}
 
-	return sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, opts)
+	mediaResults, err := sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, database.BrowseDirectoriesOptions{
+		PathPrefix: opts.PathPrefix,
+		Systems:    missingSystems,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeBrowseDirectoryResults(results, mediaResults), nil
+}
+
+func browseCoveredSystemIDsFromDirectories(results []database.BrowseDirectoryResult) map[string]struct{} {
+	covered := make(map[string]struct{})
+	for _, result := range results {
+		for _, systemID := range result.SystemIDs {
+			covered[systemID] = struct{}{}
+		}
+	}
+	return covered
+}
+
+func browseMissingSystems(systems []systemdefs.System, covered map[string]struct{}) []systemdefs.System {
+	missing := make([]systemdefs.System, 0, len(systems))
+	for _, system := range systems {
+		if _, ok := covered[system.ID]; !ok {
+			missing = append(missing, system)
+		}
+	}
+	return missing
+}
+
+func mergeBrowseDirectoryResults(
+	base []database.BrowseDirectoryResult,
+	extra []database.BrowseDirectoryResult,
+) []database.BrowseDirectoryResult {
+	if len(extra) == 0 {
+		return base
+	}
+
+	byName := make(map[string]*database.BrowseDirectoryResult, len(base)+len(extra))
+	for i := range base {
+		result := base[i]
+		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
+		byName[result.Name] = &result
+	}
+	for _, result := range extra {
+		if existing, ok := byName[result.Name]; ok {
+			existing.FileCount += result.FileCount
+			existing.SystemIDs = uniqueBrowseSystemIDs(append(existing.SystemIDs, result.SystemIDs...))
+			continue
+		}
+		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
+		byName[result.Name] = &result
+	}
+
+	merged := make([]database.BrowseDirectoryResult, 0, len(byName))
+	for _, result := range byName {
+		merged = append(merged, *result)
+	}
+	sort.Slice(merged, func(i, j int) bool { return merged[i].Name < merged[j].Name })
+	return merged
 }
 
 func sqlBrowseDirectoriesForSystemsFromCache(
@@ -216,8 +278,8 @@ func browseFilesBaseCondition(
 }
 
 // browseSortClause returns the ORDER BY clause for the given sort option.
-func browseSortClause(sort string) string {
-	switch sort {
+func browseSortClause(sortOrder string) string {
+	switch sortOrder {
 	case "name-desc":
 		return "mt.Name DESC, m.DBID DESC"
 	case "filename-asc":
@@ -231,8 +293,8 @@ func browseSortClause(sort string) string {
 
 // browseCursorCondition returns the keyset pagination WHERE clause fragment for
 // the given sort order. The caller must append (sortValue, lastID) as args.
-func browseCursorCondition(sort string) string {
-	switch sort {
+func browseCursorCondition(sortOrder string) string {
+	switch sortOrder {
 	case "name-desc":
 		return ` AND (mt.Name, m.DBID) < (?, ?)`
 	case "filename-asc":
@@ -413,28 +475,61 @@ func sqlBrowseRouteCounts(
 		return nil, err
 	}
 
-	missingRoutes := make([]string, 0, len(opts.Routes))
+	missingByRoute := make(map[string][]systemdefs.System, len(opts.Routes))
 	for _, route := range opts.Routes {
-		if _, ok := counts[route]; !ok {
-			missingRoutes = append(missingRoutes, route)
+		covered := make(map[string]struct{})
+		if count, ok := counts[route]; ok {
+			for _, systemID := range count.SystemIDs {
+				covered[systemID] = struct{}{}
+			}
+		}
+		if missingSystems := browseMissingSystems(opts.Systems, covered); len(missingSystems) > 0 {
+			missingByRoute[route] = missingSystems
 		}
 	}
-	if len(missingRoutes) == 0 {
+	if len(missingByRoute) == 0 {
 		return counts, nil
 	}
 
-	mediaCounts, err := sqlBrowseRouteCountsFromMedia(ctx, db, database.BrowseRouteCountsOptions{
-		Systems: opts.Systems,
-		Routes:  missingRoutes,
-	})
-	if err != nil {
-		return nil, err
-	}
-	for route, count := range mediaCounts {
-		counts[route] = count
+	for route, missingSystems := range missingByRoute {
+		mediaCounts, err := sqlBrowseRouteCountsFromMedia(ctx, db, database.BrowseRouteCountsOptions{
+			Systems: missingSystems,
+			Routes:  []string{route},
+		})
+		if err != nil {
+			return nil, err
+		}
+		mediaCount, ok := mediaCounts[route]
+		if !ok {
+			continue
+		}
+		if cachedCount, ok := counts[route]; ok {
+			cachedCount.FileCount += mediaCount.FileCount
+			cachedCount.SystemIDs = uniqueBrowseSystemIDs(append(cachedCount.SystemIDs, mediaCount.SystemIDs...))
+			counts[route] = cachedCount
+			continue
+		}
+		mediaCount.SystemIDs = uniqueBrowseSystemIDs(mediaCount.SystemIDs)
+		counts[route] = mediaCount
 	}
 
 	return counts, nil
+}
+
+func uniqueBrowseSystemIDs(systemIDs []string) []string {
+	if len(systemIDs) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(systemIDs))
+	unique := make([]string, 0, len(systemIDs))
+	for _, systemID := range systemIDs {
+		if _, ok := seen[systemID]; ok {
+			continue
+		}
+		seen[systemID] = struct{}{}
+		unique = append(unique, systemID)
+	}
+	return unique
 }
 
 func sqlBrowseRouteCountsFromCache(

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -49,7 +49,7 @@ func splitBrowseSystemIDs(ids string) []string {
 	if ids == "" {
 		return nil
 	}
-	return strings.Split(ids, ",")
+	return uniqueBrowseSystemIDs(strings.Split(ids, ","))
 }
 
 // sqlBrowseDirectories returns distinct immediate subdirectory names under the
@@ -63,9 +63,24 @@ func sqlBrowseDirectories(
 		return sqlBrowseDirectoriesForSystems(ctx, db, opts)
 	}
 
+	results, err := sqlBrowseDirectoriesFromCache(ctx, db, opts.PathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		return results, nil
+	}
+	return sqlBrowseDirectoriesFromMedia(ctx, db, opts.PathPrefix)
+}
+
+func sqlBrowseDirectoriesFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	pathPrefix string,
+) ([]database.BrowseDirectoryResult, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT Name, FileCount FROM BrowseCache WHERE ParentPath = ? ORDER BY Name ASC`,
-		opts.PathPrefix,
+		pathPrefix,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("browse directories query: %w", err)
@@ -82,6 +97,45 @@ func sqlBrowseDirectories(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("browse directories rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func sqlBrowseDirectoriesFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	pathPrefix string,
+) ([]database.BrowseDirectoryResult, error) {
+	rows, err := db.QueryContext(ctx,
+		`WITH matched AS (
+			 SELECT substr(Path, length(?) + 1) AS Rest
+			 FROM Media
+			 WHERE IsMissing = 0 AND Path LIKE ? || '%'
+		 )
+		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
+			COUNT(*) AS FileCount
+		 FROM matched
+		 WHERE instr(Rest, '/') > 0
+		 GROUP BY Name
+		 ORDER BY Name ASC`,
+		pathPrefix, pathPrefix,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("browse directories media query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseDirectoryResult
+	for rows.Next() {
+		var r database.BrowseDirectoryResult
+		if err := rows.Scan(&r.Name, &r.FileCount); err != nil {
+			return nil, fmt.Errorf("browse directories media scan: %w", err)
+		}
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse directories media rows: %w", err)
 	}
 
 	return results, nil
@@ -396,6 +450,20 @@ func sqlBrowseVirtualSchemes(
 		return sqlBrowseVirtualSchemesForSystems(ctx, db, opts)
 	}
 
+	results, err := sqlBrowseVirtualSchemesFromCache(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if len(results) > 0 {
+		return results, nil
+	}
+	return sqlBrowseVirtualSchemesFromMedia(ctx, db)
+}
+
+func sqlBrowseVirtualSchemesFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+) ([]database.BrowseVirtualScheme, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT DirPath, FileCount FROM BrowseCache
 		 WHERE IsVirtual = 1 ORDER BY DirPath ASC`)
@@ -414,6 +482,37 @@ func sqlBrowseVirtualSchemes(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("browse virtual schemes rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func sqlBrowseVirtualSchemesFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+) ([]database.BrowseVirtualScheme, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT substr(Path, 1, instr(Path, '://') + 2) AS Scheme,
+			COUNT(*) AS FileCount
+		 FROM Media
+		 WHERE IsMissing = 0 AND instr(Path, '://') > 0
+		 GROUP BY Scheme
+		 ORDER BY Scheme ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("browse virtual schemes media query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseVirtualScheme
+	for rows.Next() {
+		var r database.BrowseVirtualScheme
+		if err := rows.Scan(&r.Scheme, &r.FileCount); err != nil {
+			return nil, fmt.Errorf("browse virtual schemes media scan: %w", err)
+		}
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse virtual schemes media rows: %w", err)
 	}
 
 	return results, nil
@@ -632,6 +731,7 @@ func uniqueBrowseSystemIDs(systemIDs []string) []string {
 		seen[systemID] = struct{}{}
 		unique = append(unique, systemID)
 	}
+	sort.Strings(unique)
 	return unique
 }
 

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -424,6 +424,72 @@ func sqlBrowseVirtualSchemesForSystems(
 	db sqlQueryable,
 	opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
+	results, err := sqlBrowseVirtualSchemesForSystemsFromCache(ctx, db, opts)
+	if err != nil {
+		return nil, err
+	}
+	missingSystems := browseMissingSystems(opts.Systems, browseCoveredSystemIDsFromVirtualSchemes(results))
+	if len(missingSystems) == 0 {
+		return results, nil
+	}
+
+	mediaResults, err := sqlBrowseVirtualSchemesForSystemsFromMedia(ctx, db, database.BrowseVirtualSchemesOptions{
+		Systems: missingSystems,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mergeBrowseVirtualSchemes(results, mediaResults), nil
+}
+
+func browseCoveredSystemIDsFromVirtualSchemes(results []database.BrowseVirtualScheme) map[string]struct{} {
+	covered := make(map[string]struct{})
+	for _, result := range results {
+		for _, systemID := range result.SystemIDs {
+			covered[systemID] = struct{}{}
+		}
+	}
+	return covered
+}
+
+func mergeBrowseVirtualSchemes(
+	base []database.BrowseVirtualScheme,
+	extra []database.BrowseVirtualScheme,
+) []database.BrowseVirtualScheme {
+	if len(extra) == 0 {
+		return base
+	}
+
+	byScheme := make(map[string]*database.BrowseVirtualScheme, len(base)+len(extra))
+	for i := range base {
+		result := base[i]
+		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
+		byScheme[result.Scheme] = &result
+	}
+	for _, result := range extra {
+		if existing, ok := byScheme[result.Scheme]; ok {
+			existing.FileCount += result.FileCount
+			existing.SystemIDs = uniqueBrowseSystemIDs(append(existing.SystemIDs, result.SystemIDs...))
+			continue
+		}
+		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
+		byScheme[result.Scheme] = &result
+	}
+
+	merged := make([]database.BrowseVirtualScheme, 0, len(byScheme))
+	for _, result := range byScheme {
+		merged = append(merged, *result)
+	}
+	sort.Slice(merged, func(i, j int) bool { return merged[i].Scheme < merged[j].Scheme })
+	return merged
+}
+
+func sqlBrowseVirtualSchemesForSystemsFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseVirtualSchemesOptions,
+) ([]database.BrowseVirtualScheme, error) {
 	systemClause, args := browseSystemFilterClause("s.SystemID", opts.Systems)
 	rows, err := db.QueryContext(ctx,
 		`SELECT b.DirPath, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
@@ -449,6 +515,43 @@ func sqlBrowseVirtualSchemesForSystems(
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("browse virtual schemes by system rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func sqlBrowseVirtualSchemesForSystemsFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseVirtualSchemesOptions,
+) ([]database.BrowseVirtualScheme, error) {
+	systemClause, args := browseSystemFilterClause("s.SystemID", opts.Systems)
+	rows, err := db.QueryContext(ctx,
+		`SELECT substr(m.Path, 1, instr(m.Path, '://') + 2) AS Scheme,
+			COUNT(*) AS FileCount,
+			GROUP_CONCAT(DISTINCT s.SystemID)
+		 FROM Media m
+		 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		 WHERE m.IsMissing = 0 AND instr(m.Path, '://') > 0 AND `+systemClause+`
+		 GROUP BY Scheme
+		 ORDER BY Scheme ASC`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse virtual schemes by system media query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseVirtualScheme
+	for rows.Next() {
+		var r database.BrowseVirtualScheme
+		var systemIDs string
+		if err := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse virtual schemes by system media scan: %w", err)
+		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("browse virtual schemes by system media rows: %w", err)
 	}
 
 	return results, nil

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -172,6 +172,10 @@ func sqlInvalidateBrowseCache(ctx context.Context, db sqlQueryable, systemDBIDs 
 //	"/media/fat/"            → ("/media/", "fat")
 //	"steam://"               → ("", "steam://")
 func browseCacheParentAndName(dirPath string) (parentPath, name string) {
+	if dirPath == "/" {
+		return "", "/"
+	}
+
 	// Virtual schemes have no parent
 	if strings.Contains(dirPath, "://") {
 		return "", dirPath

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -139,6 +139,32 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
+func sqlInvalidateBrowseCache(ctx context.Context, db sqlQueryable, systemDBIDs []int64, allSystems bool) error {
+	if _, err := db.ExecContext(ctx, "DELETE FROM BrowseCache"); err != nil {
+		return fmt.Errorf("failed to invalidate browse cache: %w", err)
+	}
+
+	if allSystems || len(systemDBIDs) == 0 {
+		if _, err := db.ExecContext(ctx, "DELETE FROM BrowseSystemCache"); err != nil {
+			return fmt.Errorf("failed to invalidate system browse cache: %w", err)
+		}
+		return nil
+	}
+
+	placeholders := prepareVariadic("?", ",", len(systemDBIDs))
+	args := make([]any, len(systemDBIDs))
+	for i, systemDBID := range systemDBIDs {
+		args[i] = systemDBID
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	stmt := fmt.Sprintf("DELETE FROM BrowseSystemCache WHERE SystemDBID IN (%s)", placeholders)
+	if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
+		return fmt.Errorf("failed to invalidate scoped system browse cache: %w", err)
+	}
+	return nil
+}
+
 // browseCacheParentAndName extracts the parent path and display name from a
 // directory path or virtual scheme.
 //

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -144,7 +144,7 @@ func sqlInvalidateBrowseCache(ctx context.Context, db sqlQueryable, systemDBIDs 
 		return fmt.Errorf("failed to invalidate browse cache: %w", err)
 	}
 
-	if allSystems || len(systemDBIDs) == 0 {
+	if allSystems || len(systemDBIDs) == 0 || len(systemDBIDs) > maxSelectiveInvalidationSystems {
 		if _, err := db.ExecContext(ctx, "DELETE FROM BrowseSystemCache"); err != nil {
 			return fmt.Errorf("failed to invalidate system browse cache: %w", err)
 		}

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -29,12 +29,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type browseSystemCacheKey struct {
+	dirPath    string
+	systemDBID int64
+}
+
 // sqlPopulateBrowseCache rebuilds the BrowseCache table from the current Media
 // data. Reads all paths, extracts every directory level, then bulk-inserts
 // aggregated counts.
 func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 	// Read all paths from Media
-	rows, err := db.QueryContext(ctx, "SELECT Path FROM Media WHERE IsMissing = 0")
+	rows, err := db.QueryContext(ctx, "SELECT SystemDBID, Path FROM Media WHERE IsMissing = 0")
 	if err != nil {
 		return fmt.Errorf("browse cache: failed to query paths: %w", err)
 	}
@@ -44,9 +49,11 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 	// ancestor directories. Virtual scheme paths (containing "://") only
 	// contribute to their scheme prefix.
 	dirCounts := make(map[string]int)
+	systemDirCounts := make(map[browseSystemCacheKey]int)
 	for rows.Next() {
+		var systemDBID int64
 		var p string
-		if scanErr := rows.Scan(&p); scanErr != nil {
+		if scanErr := rows.Scan(&systemDBID, &p); scanErr != nil {
 			return fmt.Errorf("browse cache: failed to scan path: %w", scanErr)
 		}
 
@@ -54,6 +61,7 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 			idx := strings.Index(p, "://")
 			scheme := p[:idx+3]
 			dirCounts[scheme]++
+			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: scheme}]++
 			continue
 		}
 
@@ -61,10 +69,12 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		dir := path.Dir(p)
 		for dir != "" && dir != "." && dir != "/" {
 			dirCounts[dir+"/"]++
+			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: dir + "/"}]++
 			dir = path.Dir(dir)
 		}
 		if dir == "/" {
 			dirCounts["/"]++
+			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: "/"}]++
 		}
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
@@ -82,6 +92,9 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 	if _, delErr := tx.ExecContext(ctx, "DELETE FROM BrowseCache"); delErr != nil {
 		return fmt.Errorf("failed to clear browse cache: %w", delErr)
 	}
+	if _, delErr := tx.ExecContext(ctx, "DELETE FROM BrowseSystemCache"); delErr != nil {
+		return fmt.Errorf("failed to clear system browse cache: %w", delErr)
+	}
 
 	stmt, err := tx.PrepareContext(ctx,
 		"INSERT INTO BrowseCache (DirPath, ParentPath, Name, FileCount, IsVirtual) VALUES (?, ?, ?, ?, ?)")
@@ -98,11 +111,31 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
+	systemStmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO BrowseSystemCache
+		 (SystemDBID, DirPath, ParentPath, Name, FileCount, IsVirtual)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+	)
+	if err != nil {
+		return fmt.Errorf("browse cache: failed to prepare system insert: %w", err)
+	}
+	defer func() { _ = systemStmt.Close() }()
+
+	for key, count := range systemDirCounts {
+		parentPath, name := browseCacheParentAndName(key.dirPath)
+		isVirtual := strings.Contains(key.dirPath, "://")
+		if _, insertErr := systemStmt.ExecContext(
+			ctx, key.systemDBID, key.dirPath, parentPath, name, count, isVirtual,
+		); insertErr != nil {
+			return fmt.Errorf("browse cache: failed to insert system cache %s: %w", key.dirPath, insertErr)
+		}
+	}
+
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("browse cache: failed to commit: %w", err)
 	}
 
-	log.Info().Int("entries", len(dirCounts)).Msg("browse cache populated")
+	log.Info().Int("entries", len(dirCounts)).Int("systemEntries", len(systemDirCounts)).Msg("browse cache populated")
 	return nil
 }
 

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -158,7 +158,7 @@ func TestSqlBrowseVirtualSchemes_WithSystemsMergesPartialCache(t *testing.T) {
 	assert.Equal(t, []string{"DOS"}, schemes[0].SystemIDs)
 	assert.Equal(t, "steam://", schemes[1].Scheme)
 	assert.Equal(t, 5, schemes[1].FileCount)
-	assert.Equal(t, []string{"Steam", "DOS"}, schemes[1].SystemIDs)
+	assert.Equal(t, []string{"DOS", "Steam"}, schemes[1].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -222,7 +222,7 @@ func TestSqlBrowseDirectories_WithSystemsUsesSystemCache(t *testing.T) {
 	require.Len(t, dirs, 1)
 	assert.Equal(t, "RPG", dirs[0].Name)
 	assert.Equal(t, 8, dirs[0].FileCount)
-	assert.Equal(t, []string{"SNES", "Genesis"}, dirs[0].SystemIDs)
+	assert.Equal(t, []string{"Genesis", "SNES"}, dirs[0].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -293,7 +293,7 @@ func TestSqlBrowseDirectories_WithSystemsMergesPartialCache(t *testing.T) {
 	require.Len(t, dirs, 2)
 	assert.Equal(t, "RPG", dirs[0].Name)
 	assert.Equal(t, 5, dirs[0].FileCount)
-	assert.Equal(t, []string{"SNES", "Genesis"}, dirs[0].SystemIDs)
+	assert.Equal(t, []string{"Genesis", "SNES"}, dirs[0].SystemIDs)
 	assert.Equal(t, "Shooter", dirs[1].Name)
 	assert.Equal(t, 1, dirs[1].FileCount)
 	assert.Equal(t, []string{"Genesis"}, dirs[1].SystemIDs)
@@ -371,7 +371,7 @@ func TestSqlBrowseRouteCounts_MergesPartialCache(t *testing.T) {
 
 	require.Contains(t, counts, sharedRoute)
 	assert.Equal(t, 5, counts[sharedRoute].FileCount)
-	assert.Equal(t, []string{"SNES", "Genesis"}, counts[sharedRoute].SystemIDs)
+	assert.Equal(t, []string{"Genesis", "SNES"}, counts[sharedRoute].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -29,6 +30,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func browseTestPrefix(path string) string {
+	return filepath.ToSlash(path) + "/"
+}
+
+func browseTestAbsPath(parts ...string) string {
+	return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
+}
 
 func TestSqlBrowseRootCounts_PassesArgs(t *testing.T) {
 	t.Parallel()
@@ -121,16 +130,17 @@ func TestSqlBrowseDirectories_WithSystemsUsesSystemCache(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
 
 	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
-		WithArgs("/roms/shared/", "SNES", "Genesis").
+		WithArgs(sharedPrefix, "SNES", "Genesis").
 		WillReturnRows(
 			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
 				AddRow("RPG", 8, "SNES,Genesis"),
 		)
 
 	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
-		PathPrefix: "/roms/shared/",
+		PathPrefix: sharedPrefix,
 		Systems: []systemdefs.System{
 			{ID: "SNES"},
 			{ID: "Genesis"},
@@ -152,19 +162,20 @@ func TestSqlBrowseDirectories_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
 
 	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
-		WithArgs("/roms/shared/", "SNES").
+		WithArgs(sharedPrefix, "SNES").
 		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}))
 	mock.ExpectQuery(`(?s)WITH matched AS .*FROM Media m.*m.Path LIKE \? \|\| '%'`).
-		WithArgs("/roms/shared/", "/roms/shared/", "SNES").
+		WithArgs(sharedPrefix, sharedPrefix, "SNES").
 		WillReturnRows(
 			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
 				AddRow("RPG", 2, "SNES"),
 		)
 
 	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
-		PathPrefix: "/roms/shared/",
+		PathPrefix: sharedPrefix,
 		Systems:    []systemdefs.System{{ID: "SNES"}},
 	})
 	require.NoError(t, err)
@@ -177,36 +188,119 @@ func TestSqlBrowseDirectories_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseDirectories_WithSystemsMergesPartialCache(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
+
+	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
+		WithArgs(sharedPrefix, "SNES", "Genesis").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+				AddRow("RPG", 2, "SNES"),
+		)
+	mock.ExpectQuery(`(?s)WITH matched AS .*FROM Media m.*m.Path LIKE \? \|\| '%'`).
+		WithArgs(sharedPrefix, sharedPrefix, "Genesis").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+				AddRow("RPG", 3, "Genesis").
+				AddRow("Shooter", 1, "Genesis"),
+		)
+
+	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: sharedPrefix,
+		Systems: []systemdefs.System{
+			{ID: "SNES"},
+			{ID: "Genesis"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, dirs, 2)
+	assert.Equal(t, "RPG", dirs[0].Name)
+	assert.Equal(t, 5, dirs[0].FileCount)
+	assert.Equal(t, []string{"SNES", "Genesis"}, dirs[0].SystemIDs)
+	assert.Equal(t, "Shooter", dirs[1].Name)
+	assert.Equal(t, 1, dirs[1].FileCount)
+	assert.Equal(t, []string{"Genesis"}, dirs[1].SystemIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseRouteCounts_ReturnsOnlyPopulatedRoutes(t *testing.T) {
 	t.Parallel()
 
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	snesRoute := filepath.ToSlash(browseTestAbsPath("roms", "SNES"))
+	sharedRoute := filepath.ToSlash(browseTestAbsPath("roms", "shared"))
+	snesPrefix := browseTestPrefix(browseTestAbsPath("roms", "SNES"))
+	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
 
 	mock.ExpectQuery(
 		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
 	).
-		WithArgs("/roms/SNES/", "/roms/shared/", "SNES").
+		WithArgs(snesPrefix, sharedPrefix, "SNES").
 		WillReturnRows(
 			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
-				AddRow("/roms/SNES/", 12, "SNES"),
+				AddRow(snesPrefix, 12, "SNES"),
 		)
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
-		WithArgs("/roms/shared/", "SNES").
+		WithArgs(sharedPrefix, "SNES").
 		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(0, nil))
 
 	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes:  []string{"/roms/SNES", "/roms/shared"},
+		Routes:  []string{snesRoute, sharedRoute},
 		Systems: []systemdefs.System{{ID: "SNES"}},
 	})
 	require.NoError(t, err)
 
-	require.Contains(t, counts, "/roms/SNES")
-	assert.Equal(t, "/roms/SNES", counts["/roms/SNES"].Path)
-	assert.Equal(t, 12, counts["/roms/SNES"].FileCount)
-	assert.Equal(t, []string{"SNES"}, counts["/roms/SNES"].SystemIDs)
-	assert.NotContains(t, counts, "/roms/shared")
+	require.Contains(t, counts, snesRoute)
+	assert.Equal(t, snesRoute, counts[snesRoute].Path)
+	assert.Equal(t, 12, counts[snesRoute].FileCount)
+	assert.Equal(t, []string{"SNES"}, counts[snesRoute].SystemIDs)
+	assert.NotContains(t, counts, sharedRoute)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseRouteCounts_MergesPartialCache(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	sharedRoute := filepath.ToSlash(browseTestAbsPath("roms", "shared"))
+	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
+
+	mock.ExpectQuery(
+		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
+	).
+		WithArgs(sharedPrefix, "SNES", "Genesis").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
+				AddRow(sharedPrefix, 2, "SNES"),
+		)
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
+		WithArgs(sharedPrefix, "Genesis").
+		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(3, "Genesis"))
+
+	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
+		Routes: []string{sharedRoute},
+		Systems: []systemdefs.System{
+			{ID: "SNES"},
+			{ID: "Genesis"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, counts, sharedRoute)
+	assert.Equal(t, 5, counts[sharedRoute].FileCount)
+	assert.Equal(t, []string{"SNES", "Genesis"}, counts[sharedRoute].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -217,25 +311,27 @@ func TestSqlBrowseRouteCounts_ReadsFromMediaWhenSystemCacheEmpty(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	snesRoute := filepath.ToSlash(browseTestAbsPath("roms", "SNES"))
+	snesPrefix := browseTestPrefix(browseTestAbsPath("roms", "SNES"))
 
 	mock.ExpectQuery(
 		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
 	).
-		WithArgs("/roms/SNES/", "SNES").
+		WithArgs(snesPrefix, "SNES").
 		WillReturnRows(sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}))
 	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
-		WithArgs("/roms/SNES/", "SNES").
+		WithArgs(snesPrefix, "SNES").
 		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(3, "SNES"))
 
 	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes:  []string{"/roms/SNES"},
+		Routes:  []string{snesRoute},
 		Systems: []systemdefs.System{{ID: "SNES"}},
 	})
 	require.NoError(t, err)
 
-	require.Contains(t, counts, "/roms/SNES")
-	assert.Equal(t, 3, counts["/roms/SNES"].FileCount)
-	assert.Equal(t, []string{"SNES"}, counts["/roms/SNES"].SystemIDs)
+	require.Contains(t, counts, snesRoute)
+	assert.Equal(t, 3, counts[snesRoute].FileCount)
+	assert.Equal(t, []string{"SNES"}, counts[snesRoute].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -124,6 +124,77 @@ func TestSqlBrowseVirtualSchemes_UsesIsVirtual(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseVirtualSchemes_WithSystemsMergesPartialCache(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(
+		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
+	).
+		WithArgs("Steam", "DOS").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
+				AddRow("steam://", 2, "Steam"),
+		)
+	mock.ExpectQuery(`(?s)SELECT substr\(m.Path, 1, instr\(m.Path, '://'\) \+ 2\).*FROM Media m`).
+		WithArgs("DOS").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Scheme", "FileCount", "SystemIDs"}).
+				AddRow("gog://", 4, "DOS").
+				AddRow("steam://", 3, "DOS"),
+		)
+
+	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
+		Systems: []systemdefs.System{{ID: "Steam"}, {ID: "DOS"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, schemes, 2)
+	assert.Equal(t, "gog://", schemes[0].Scheme)
+	assert.Equal(t, 4, schemes[0].FileCount)
+	assert.Equal(t, []string{"DOS"}, schemes[0].SystemIDs)
+	assert.Equal(t, "steam://", schemes[1].Scheme)
+	assert.Equal(t, 5, schemes[1].FileCount)
+	assert.Equal(t, []string{"Steam", "DOS"}, schemes[1].SystemIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseVirtualSchemes_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(
+		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
+	).
+		WithArgs("Steam").
+		WillReturnRows(sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}))
+	mock.ExpectQuery(`(?s)SELECT substr\(m.Path, 1, instr\(m.Path, '://'\) \+ 2\).*FROM Media m`).
+		WithArgs("Steam").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Scheme", "FileCount", "SystemIDs"}).
+				AddRow("steam://", 7, "Steam"),
+		)
+
+	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
+		Systems: []systemdefs.System{{ID: "Steam"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, schemes, 1)
+	assert.Equal(t, "steam://", schemes[0].Scheme)
+	assert.Equal(t, 7, schemes[0].FileCount)
+	assert.Equal(t, []string{"Steam"}, schemes[0].SystemIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseDirectories_WithSystemsUsesSystemCache(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -102,7 +103,7 @@ func TestSqlBrowseVirtualSchemes_UsesIsVirtual(t *testing.T) {
 				AddRow("igdb://", 30),
 		)
 
-	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db)
+	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{})
 	require.NoError(t, err)
 
 	require.Len(t, schemes, 2)
@@ -110,6 +111,131 @@ func TestSqlBrowseVirtualSchemes_UsesIsVirtual(t *testing.T) {
 	assert.Equal(t, 150, schemes[0].FileCount)
 	assert.Equal(t, "igdb://", schemes[1].Scheme)
 	assert.Equal(t, 30, schemes[1].FileCount)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectories_WithSystemsUsesSystemCache(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
+		WithArgs("/roms/shared/", "SNES", "Genesis").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+				AddRow("RPG", 8, "SNES,Genesis"),
+		)
+
+	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: "/roms/shared/",
+		Systems: []systemdefs.System{
+			{ID: "SNES"},
+			{ID: "Genesis"},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, dirs, 1)
+	assert.Equal(t, "RPG", dirs[0].Name)
+	assert.Equal(t, 8, dirs[0].FileCount)
+	assert.Equal(t, []string{"SNES", "Genesis"}, dirs[0].SystemIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectories_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
+		WithArgs("/roms/shared/", "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}))
+	mock.ExpectQuery(`(?s)WITH matched AS .*FROM Media m.*m.Path LIKE \? \|\| '%'`).
+		WithArgs("/roms/shared/", "/roms/shared/", "SNES").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+				AddRow("RPG", 2, "SNES"),
+		)
+
+	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: "/roms/shared/",
+		Systems:    []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, dirs, 1)
+	assert.Equal(t, "RPG", dirs[0].Name)
+	assert.Equal(t, 2, dirs[0].FileCount)
+	assert.Equal(t, []string{"SNES"}, dirs[0].SystemIDs)
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseRouteCounts_ReturnsOnlyPopulatedRoutes(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(
+		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
+	).
+		WithArgs("/roms/SNES/", "/roms/shared/", "SNES").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
+				AddRow("/roms/SNES/", 12, "SNES"),
+		)
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
+		WithArgs("/roms/shared/", "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(0, nil))
+
+	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
+		Routes:  []string{"/roms/SNES", "/roms/shared"},
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, counts, "/roms/SNES")
+	assert.Equal(t, "/roms/SNES", counts["/roms/SNES"].Path)
+	assert.Equal(t, 12, counts["/roms/SNES"].FileCount)
+	assert.Equal(t, []string{"SNES"}, counts["/roms/SNES"].SystemIDs)
+	assert.NotContains(t, counts, "/roms/shared")
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseRouteCounts_ReadsFromMediaWhenSystemCacheEmpty(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(
+		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
+	).
+		WithArgs("/roms/SNES/", "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}))
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
+		WithArgs("/roms/SNES/", "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(3, "SNES"))
+
+	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
+		Routes:  []string{"/roms/SNES"},
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, counts, "/roms/SNES")
+	assert.Equal(t, 3, counts["/roms/SNES"].FileCount)
+	assert.Equal(t, []string{"SNES"}, counts["/roms/SNES"].SystemIDs)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -996,14 +996,27 @@ func NewNamesIndex(
 			dir := filepath.Dir(file.Path)
 			filesByDir[dir] = append(filesByDir[dir], file)
 		}
+		if len(files) >= 1000 {
+			log.Debug().
+				Str("system", systemID).
+				Int("files", len(files)).
+				Int("directories", len(filesByDir)).
+				Msg("grouped scanned files by directory")
+		}
 
 		stripPolicyByDir := make(map[string]bool)
 		for dir, dirFiles := range filesByDir {
 			// Use 50% threshold and require at least 5 files to apply heuristic
 			stripPolicyByDir[dir] = detectNumberingPattern(dirFiles, 0.5, 5)
 		}
+		if len(files) >= 1000 {
+			log.Debug().
+				Str("system", systemID).
+				Int("directories", len(stripPolicyByDir)).
+				Msg("calculated directory strip policies")
+		}
 
-		for _, file := range files {
+		for fileIdx, file := range files {
 			// Check for cancellation or pause between file processing
 			select {
 			case <-ctx.Done():
@@ -1017,6 +1030,13 @@ func NewNamesIndex(
 
 			// Start transaction if needed (at start of system OR after mid-system commit)
 			if !batchStarted {
+				if len(files) >= 1000 {
+					log.Debug().
+						Str("system", systemID).
+						Int("processed", fileIdx).
+						Int("remaining", len(files)-fileIdx).
+						Msg("beginning media indexing transaction")
+				}
 				if beginErr := db.BeginTransaction(true); beginErr != nil {
 					return 0, fmt.Errorf("failed to begin new transaction: %w", beginErr)
 				}
@@ -1039,9 +1059,20 @@ func NewNamesIndex(
 				return 0, fmt.Errorf("unrecoverable error adding media path %q: %w", file.Path, addErr)
 			}
 			filesInBatch++
+			if len(files) >= 1000 && (fileIdx+1)%1000 == 0 {
+				log.Debug().
+					Str("system", systemID).
+					Int("processed", fileIdx+1).
+					Int("total", len(files)).
+					Msg("processed media paths")
+			}
 
 			// Commit if we hit file limit (memory safety - even mid-system)
 			if filesInBatch >= maxFilesPerTransaction {
+				log.Debug().
+					Str("system", systemID).
+					Int("files", filesInBatch).
+					Msg("committing media indexing batch")
 				commitStart := time.Now()
 				if commitErr := db.CommitTransaction(); commitErr != nil {
 					return 0, fmt.Errorf("failed to commit batch transaction (file limit): %w", commitErr)
@@ -1073,6 +1104,10 @@ func NewNamesIndex(
 		}
 
 		if batchStarted {
+			log.Debug().
+				Str("system", systemID).
+				Int("files", filesInBatch).
+				Msg("committing media indexing system transaction")
 			commitStart := time.Now()
 			if commitErr := db.CommitTransaction(); commitErr != nil {
 				return 0, fmt.Errorf("failed to commit system transaction: %w", commitErr)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1971,9 +1971,9 @@ func SystemMatcher() any {
 // Browse methods
 
 func (m *MockMediaDBI) BrowseDirectories(
-	ctx context.Context, pathPrefix string,
+	ctx context.Context, opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
-	args := m.Called(ctx, pathPrefix)
+	args := m.Called(ctx, opts)
 	if results, ok := args.Get(0).([]database.BrowseDirectoryResult); ok {
 		if err := args.Error(1); err != nil {
 			return results, fmt.Errorf("mock operation failed: %w", err)
@@ -2003,9 +2003,9 @@ func (m *MockMediaDBI) BrowseFiles(
 }
 
 func (m *MockMediaDBI) BrowseFileCount(
-	ctx context.Context, pathPrefix string, letter *string,
+	ctx context.Context, opts database.BrowseFileCountOptions,
 ) (int, error) {
-	args := m.Called(ctx, pathPrefix, letter)
+	args := m.Called(ctx, opts)
 	if count, ok := args.Get(0).(int); ok {
 		if err := args.Error(1); err != nil {
 			return count, fmt.Errorf("mock operation failed: %w", err)
@@ -2019,9 +2019,9 @@ func (m *MockMediaDBI) BrowseFileCount(
 }
 
 func (m *MockMediaDBI) BrowseVirtualSchemes(
-	ctx context.Context,
+	ctx context.Context, opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
-	args := m.Called(ctx)
+	args := m.Called(ctx, opts)
 	if results, ok := args.Get(0).([]database.BrowseVirtualScheme); ok {
 		if err := args.Error(1); err != nil {
 			return results, fmt.Errorf("mock operation failed: %w", err)
@@ -2032,6 +2032,22 @@ func (m *MockMediaDBI) BrowseVirtualSchemes(
 		return nil, fmt.Errorf("mock operation failed: %w", err)
 	}
 	return []database.BrowseVirtualScheme{}, nil
+}
+
+func (m *MockMediaDBI) BrowseRouteCounts(
+	ctx context.Context, opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	args := m.Called(ctx, opts)
+	if results, ok := args.Get(0).(map[string]database.BrowseRouteCount); ok {
+		if err := args.Error(1); err != nil {
+			return results, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return results, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return map[string]database.BrowseRouteCount{}, nil
 }
 
 func (m *MockMediaDBI) BrowseRootCounts(


### PR DESCRIPTION
## Summary
- Add `systems` filtering to `media.browse`, including populated system route discovery and `systemIds` metadata for route/directory entries.
- Add per-system browse cache storage with narrow direct-media reads when the cache is not yet populated after upgrade.
- Tighten indexing transaction error handling and add low-volume indexing breadcrumbs around the post-scan commit window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-scoped media browsing: filter results by one or more systems (optional fuzzy matching). Root/directory entries now include applicable systemIds (and systemId when exactly one system applies). Browse omits empty routes.

* **Behavior Changes**
  * WebSocket rate limiting now waits (bounded backpressure) rather than immediately closing on exceed.

* **Documentation**
  * API docs updated with new system-filter parameters, tightened cursor validity, and a system-route example.

* **Tests**
  * Added/expanded tests for system-scoped browsing, route counts, pagination, and rate-limit wait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->