### PR TITLE
feat(api): add browse v2 index

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -73,6 +74,15 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 
 // browseSem limits concurrent media.browse requests to avoid saturating SQLite.
 var browseSem = make(chan struct{}, 3)
+
+func logBrowseTiming(operation, path string, started time.Time, rows int) {
+	log.Debug().
+		Str("operation", operation).
+		Str("path", path).
+		Int("rows", rows).
+		Dur("duration", time.Since(started)).
+		Msg("media browse query completed")
+}
 
 // HandleMediaBrowse handles the media.browse API method for directory-style
 // navigation of indexed media content.
@@ -204,10 +214,22 @@ func browseRoots(env *requests.RequestEnv) (any, error) {
 }
 
 func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (any, error) {
+	started := time.Now()
 	routes, err := buildSystemBrowseRouteCandidates(env, systems)
 	if err != nil {
 		return nil, err
 	}
+	systemIDs := make([]string, 0, len(systems))
+	for _, system := range systems {
+		systemIDs = append(systemIDs, system.ID)
+	}
+	log.Debug().
+		Strs("systems", systemIDs).
+		Int("routes", len(routes)).
+		Dur("elapsed", time.Since(started)).
+		Msg("media browse system root candidates built")
+
+	started = time.Now()
 	counts, err := env.Database.MediaDB.BrowseRouteCounts(env.Context, database.BrowseRouteCountsOptions{
 		Routes:  routes,
 		Systems: systems,
@@ -215,6 +237,12 @@ func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (a
 	if err != nil {
 		return nil, fmt.Errorf("error getting system route counts: %w", err)
 	}
+	log.Debug().
+		Strs("systems", systemIDs).
+		Int("routes", len(routes)).
+		Int("counts", len(counts)).
+		Dur("elapsed", time.Since(started)).
+		Msg("media browse system root counts loaded")
 
 	entries := make([]models.BrowseEntry, 0, len(routes))
 	schemeGroups := buildSchemeGroupMap(env)
@@ -241,7 +269,67 @@ func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (a
 		entries = append(entries, entry)
 	}
 
+	entries = dedupeSystemRootEntries(entries)
+
 	return models.BrowseResults{Entries: entries}, nil
+}
+
+func dedupeSystemRootEntries(entries []models.BrowseEntry) []models.BrowseEntry {
+	if len(entries) < 2 {
+		return entries
+	}
+
+	filtered := make([]models.BrowseEntry, 0, len(entries))
+	for i := range entries {
+		if systemRootEntryCoveredByDescendant(entries, i) {
+			continue
+		}
+		filtered = append(filtered, entries[i])
+	}
+
+	return filtered
+}
+
+func systemRootEntryCoveredByDescendant(entries []models.BrowseEntry, parentIdx int) bool {
+	parent := entries[parentIdx]
+	if parent.FileCount == nil {
+		return false
+	}
+
+	for childIdx := range entries {
+		if childIdx == parentIdx {
+			continue
+		}
+
+		child := entries[childIdx]
+		if child.FileCount == nil || *child.FileCount != *parent.FileCount {
+			continue
+		}
+		if isStrictFilesystemDescendant(child.Path, parent.Path) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isStrictFilesystemDescendant(childPath, parentPath string) bool {
+	if strings.Contains(childPath, "://") || strings.Contains(parentPath, "://") {
+		return false
+	}
+
+	child := filepath.Clean(childPath)
+	parent := filepath.Clean(parentPath)
+	if child == parent {
+		return false
+	}
+
+	parentWithSeparator := parent
+	if !strings.HasSuffix(parentWithSeparator, string(filepath.Separator)) {
+		parentWithSeparator += string(filepath.Separator)
+	}
+
+	return strings.HasPrefix(child, parentWithSeparator)
 }
 
 func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []systemdefs.System) ([]string, error) {
@@ -298,10 +386,12 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 			if !strings.HasSuffix(prefix, "/") {
 				prefix += "/"
 			}
+			started := time.Now()
 			fileCount, err := env.Database.MediaDB.BrowseFileCount(env.Context, database.BrowseFileCountOptions{
 				PathPrefix: prefix,
 				Systems:    systems,
 			})
+			logBrowseTiming("system_root_file_count", prefix, started, fileCount)
 			if err != nil {
 				return nil, fmt.Errorf("error getting system root file count: %w", err)
 			}
@@ -309,10 +399,12 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 				addFilesystemRoute(root)
 			}
 
+			started = time.Now()
 			dirs, err := env.Database.MediaDB.BrowseDirectories(env.Context, database.BrowseDirectoriesOptions{
 				PathPrefix: prefix,
 				Systems:    systems,
 			})
+			logBrowseTiming("system_root_directories", prefix, started, len(dirs))
 			if err != nil {
 				return nil, fmt.Errorf("error getting system route directories: %w", err)
 			}
@@ -321,10 +413,12 @@ func buildSystemBrowseRouteCandidates(env *requests.RequestEnv, systems []system
 			}
 		}
 
+		started := time.Now()
 		virtualSchemes, err := env.Database.MediaDB.BrowseVirtualSchemes(
 			env.Context,
 			database.BrowseVirtualSchemesOptions{Systems: systems},
 		)
+		logBrowseTiming("system_virtual_schemes", "", started, len(virtualSchemes))
 		if err != nil {
 			return nil, fmt.Errorf("error getting system virtual routes: %w", err)
 		}
@@ -398,10 +492,12 @@ func browseFilesystem(
 	var dirs []database.BrowseDirectoryResult
 	if cursor == nil {
 		var err error
+		started := time.Now()
 		dirs, err = env.Database.MediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
 			PathPrefix: prefix,
 			Systems:    systems,
 		})
+		logBrowseTiming("directories", prefix, started, len(dirs))
 		if err != nil {
 			return nil, fmt.Errorf("error browsing directories: %w", err)
 		}
@@ -416,7 +512,9 @@ func browseFilesystem(
 		Sort:       sort,
 		Systems:    systems,
 	}
+	started := time.Now()
 	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
+	logBrowseTiming("files", prefix, started, len(files))
 	if err != nil {
 		return nil, fmt.Errorf("error browsing files: %w", err)
 	}
@@ -424,11 +522,13 @@ func browseFilesystem(
 	// Get total file count (skip when no files and no cursor — count is obviously 0)
 	var totalFiles int
 	if len(files) > 0 || cursor != nil {
+		started = time.Now()
 		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
 			PathPrefix: prefix,
 			Letter:     letter,
 			Systems:    systems,
 		})
+		logBrowseTiming("file_count", prefix, started, totalFiles)
 		if err != nil {
 			return nil, fmt.Errorf("error getting file count: %w", err)
 		}
@@ -462,16 +562,20 @@ func browseVirtual(
 		Sort:       sort,
 		Systems:    systems,
 	}
+	started := time.Now()
 	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
+	logBrowseTiming("virtual_files", schemePath, started, len(files))
 	if err != nil {
 		return nil, fmt.Errorf("error browsing virtual media: %w", err)
 	}
 
+	started = time.Now()
 	totalFiles, err := env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
 		PathPrefix: schemePath,
 		Letter:     letter,
 		Systems:    systems,
 	})
+	logBrowseTiming("virtual_file_count", schemePath, started, totalFiles)
 	if err != nil {
 		return nil, fmt.Errorf("error getting virtual file count: %w", err)
 	}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -271,6 +271,55 @@ func TestHandleMediaBrowse_SystemRootRoutesIncludesIndexedDirectories(t *testing
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_SystemRootRoutesDedupesCoveredParent(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	nesPath := filepath.Join(romsRoot, "NES")
+	romsAPIPath := filepath.ToSlash(romsRoot)
+	nesAPIPath := filepath.ToSlash(nesPath)
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{romsRoot})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "NES", SystemID: "NES", Folders: []string{"NES"}},
+		})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	romsPrefix := filepath.ToSlash(romsRoot) + "/"
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "NES")).
+		Return(10, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "NES")).
+		Return([]database.BrowseDirectoryResult{{Name: "NES", FileCount: 10, SystemIDs: []string{"NES"}}}, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "NES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseRouteCountsOptions) bool {
+			return len(opts.Systems) == 1 && opts.Systems[0].ID == "NES" &&
+				assert.ElementsMatch(t, []string{nesAPIPath, romsAPIPath}, opts.Routes)
+		}),
+	).Return(map[string]database.BrowseRouteCount{
+		romsAPIPath: {Path: romsAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
+		nesAPIPath:  {Path: nesAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
+	}, nil)
+
+	systems := []string{"NES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Systems: &systems})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Equal(t, nesAPIPath, browseResults.Entries[0].Path)
+	require.NotNil(t, browseResults.Entries[0].FileCount)
+	assert.Equal(t, 10, *browseResults.Entries[0].FileCount)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_SystemRootRoutesIncludesRootMedia(t *testing.T) {
 	t.Parallel()
 
@@ -316,6 +365,83 @@ func TestHandleMediaBrowse_SystemRootRoutesIncludesRootMedia(t *testing.T) {
 	assert.Equal(t, 1, *entry.FileCount)
 
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestDedupeSystemRootEntries(t *testing.T) {
+	t.Parallel()
+
+	count := func(v int) *int { return &v }
+
+	tests := []struct {
+		name    string
+		entries []models.BrowseEntry
+		want    []string
+	}{
+		{
+			name: "single child absorbs parent",
+			entries: []models.BrowseEntry{
+				{Path: "/media/fat/games", FileCount: count(10)},
+				{Path: "/media/fat/games/NES", FileCount: count(10)},
+			},
+			want: []string{"/media/fat/games/NES"},
+		},
+		{
+			name: "parent keeps union across children",
+			entries: []models.BrowseEntry{
+				{Path: "/media/fat/games", FileCount: count(15)},
+				{Path: "/media/fat/games/NES", FileCount: count(10)},
+				{Path: "/media/fat/games/NES Hacks", FileCount: count(5)},
+			},
+			want: []string{"/media/fat/games", "/media/fat/games/NES", "/media/fat/games/NES Hacks"},
+		},
+		{
+			name: "sibling equal counts are unrelated",
+			entries: []models.BrowseEntry{
+				{Path: "/media/fat/games/NES", FileCount: count(10)},
+				{Path: "/media/fat/alt/NES", FileCount: count(10)},
+			},
+			want: []string{"/media/fat/games/NES", "/media/fat/alt/NES"},
+		},
+		{
+			name: "nil counts are not deduped",
+			entries: []models.BrowseEntry{
+				{Path: "/media/fat/games", FileCount: nil},
+				{Path: "/media/fat/games/NES", FileCount: count(10)},
+				{Path: "/media/fat/games/SNES", FileCount: nil},
+			},
+			want: []string{"/media/fat/games", "/media/fat/games/NES", "/media/fat/games/SNES"},
+		},
+		{
+			name: "string prefix is not ancestry",
+			entries: []models.BrowseEntry{
+				{Path: "/media/fat/games", FileCount: count(10)},
+				{Path: "/media/fat/games-extra", FileCount: count(10)},
+			},
+			want: []string{"/media/fat/games", "/media/fat/games-extra"},
+		},
+		{
+			name: "virtual schemes are ignored",
+			entries: []models.BrowseEntry{
+				{Path: "box://", FileCount: count(10)},
+				{Path: "box://NES", FileCount: count(10)},
+			},
+			want: []string{"box://", "box://NES"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := dedupeSystemRootEntries(tt.entries)
+			gotPaths := make([]string, 0, len(got))
+			for _, entry := range got {
+				gotPaths = append(gotPaths, entry.Path)
+			}
+
+			assert.Equal(t, tt.want, gotPaths)
+		})
+	}
 }
 
 func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {

--- a/pkg/database/mediadb/letterfilter.go
+++ b/pkg/database/mediadb/letterfilter.go
@@ -21,6 +21,41 @@ package mediadb
 
 import "strings"
 
+const browseNameSymbolBucket = "#"
+
+// BrowseNameFirstChar returns the indexed first-character bucket used by
+// media.browse letter filters.
+func BrowseNameFirstChar(name string) string {
+	if name == "" {
+		return browseNameSymbolBucket
+	}
+
+	first := strings.ToUpper(name[:1])
+	if first >= "A" && first <= "Z" {
+		return first
+	}
+	if first >= "0" && first <= "9" {
+		return "0-9"
+	}
+	return browseNameSymbolBucket
+}
+
+func buildBrowseNameCharFilter(column string, letter *string) (clause string, args []any) {
+	if letter == nil || *letter == "" {
+		return "", nil
+	}
+
+	letterValue := strings.ToUpper(*letter)
+	switch {
+	case letterValue == "0-9", letterValue == browseNameSymbolBucket:
+		return column + " = ?", []any{letterValue}
+	case len(letterValue) == 1 && letterValue >= "A" && letterValue <= "Z":
+		return column + " = ?", []any{letterValue}
+	default:
+		return "", nil
+	}
+}
+
 // BuildLetterFilterSQL constructs SQL WHERE clauses for filtering by the first
 // character of a column. Supports single letters (A-Z), "0-9" for numeric
 // starts, and "#" for symbols (non-alphanumeric).

--- a/pkg/database/mediadb/letterfilter_test.go
+++ b/pkg/database/mediadb/letterfilter_test.go
@@ -116,3 +116,27 @@ func TestBuildLetterFilterSQL(t *testing.T) {
 		})
 	}
 }
+
+func TestBrowseNameFirstChar(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "uppercase letter", in: "Metroid", want: "M"},
+		{name: "lowercase letter", in: "zelda", want: "Z"},
+		{name: "number", in: "1942", want: "0-9"},
+		{name: "symbol", in: "_hidden", want: "#"},
+		{name: "empty", in: "", want: "#"},
+		{name: "non ascii", in: "Étoile", want: "#"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, BrowseNameFirstChar(tt.in))
+		})
+	}
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -373,23 +373,7 @@ var secondaryIndexes = []secondaryIndex{
 		name: "idx_slug_cache_media",
 		ddl:  "CREATE INDEX IF NOT EXISTS idx_slug_cache_media ON SlugResolutionCache(MediaDBID)",
 	},
-	{
-		name: "idx_browsecache_parent",
-		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsecache_parent ON BrowseCache(ParentPath)",
-	},
 	{name: "idx_media_parentdir", ddl: "CREATE INDEX IF NOT EXISTS idx_media_parentdir ON Media(ParentDir)"},
-	{
-		name: "idx_browsesystemcache_parent",
-		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_parent ON BrowseSystemCache(SystemDBID, ParentPath)",
-	},
-	{
-		name: "idx_browsesystemcache_dir",
-		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_dir ON BrowseSystemCache(DirPath)",
-	},
-	{
-		name: "idx_browsesystemcache_virtual",
-		ddl:  "CREATE INDEX IF NOT EXISTS idx_browsesystemcache_virtual ON BrowseSystemCache(SystemDBID, IsVirtual)",
-	},
 	{
 		name: "idx_media_parentdir_system",
 		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_parentdir_system ON Media(ParentDir, SystemDBID)",
@@ -2060,7 +2044,13 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 
 	// Use batch inserter if available
 	if db.batchInsertMedia != nil {
-		err = db.batchInsertMedia.Add(row.DBID, row.MediaTitleDBID, row.SystemDBID, row.Path, row.ParentDir)
+		err = db.batchInsertMedia.Add(
+			row.DBID,
+			row.MediaTitleDBID,
+			row.SystemDBID,
+			row.Path,
+			row.ParentDir,
+		)
 		if err != nil {
 			return row, fmt.Errorf("failed to add media to batch: %w", err)
 		}

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -192,70 +192,46 @@ func insertSystemMedia(t *testing.T, mediaDB *MediaDB, system database.System, t
 	require.NoError(t, mediaDB.CommitTransaction())
 }
 
-func assertBrowseCacheRow(
+func assertBrowseV2Dir(
 	t *testing.T,
 	mediaDB *MediaDB,
-	table string,
-	systemDBID int64,
 	dirPath string,
-	wantParentPath string,
 	wantName string,
-	wantFileCount int,
 	wantVirtual bool,
 ) {
 	t.Helper()
 
-	var query string
-	var args []any
-	switch table {
-	case "BrowseCache":
-		query = "SELECT ParentPath, Name, FileCount, IsVirtual FROM BrowseCache WHERE DirPath = ?"
-		args = []any{dirPath}
-	case "BrowseSystemCache":
-		query = `SELECT ParentPath, Name, FileCount, IsVirtual
-			FROM BrowseSystemCache WHERE SystemDBID = ? AND DirPath = ?`
-		args = []any{systemDBID, dirPath}
-	default:
-		t.Fatalf("unexpected browse cache table %q", table)
-	}
-
-	var parentPath, name string
-	var fileCount int
+	var name string
 	var isVirtual bool
-	err := mediaDB.sql.QueryRowContext(context.Background(), query, args...).Scan(
-		&parentPath, &name, &fileCount, &isVirtual,
+	err := mediaDB.sql.QueryRowContext(
+		context.Background(),
+		"SELECT Name, IsVirtual FROM BrowseDirs WHERE Path = ?",
+		dirPath,
+	).Scan(
+		&name, &isVirtual,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, wantParentPath, parentPath)
 	assert.Equal(t, wantName, name)
-	assert.Equal(t, wantFileCount, fileCount)
 	assert.Equal(t, wantVirtual, isVirtual)
 }
 
-func seedBrowseCacheRows(t *testing.T, mediaDB *MediaDB, systemDBIDs ...int64) {
+func browseV2DirID(t *testing.T, mediaDB *MediaDB, dirPath string) int64 {
 	t.Helper()
 
-	ctx := context.Background()
-	romsPath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms")) + "/"
-	_, err := mediaDB.sql.ExecContext(ctx,
-		"INSERT INTO BrowseCache (DirPath, ParentPath, Name, FileCount, IsVirtual) VALUES (?, ?, ?, ?, ?)",
-		romsPath, "", "roms", 2, false,
-	)
+	var id int64
+	err := mediaDB.sql.QueryRowContext(
+		context.Background(),
+		"SELECT DBID FROM BrowseDirs WHERE Path = ?",
+		dirPath,
+	).Scan(&id)
 	require.NoError(t, err)
-	for _, systemDBID := range systemDBIDs {
-		_, err = mediaDB.sql.ExecContext(ctx,
-			`INSERT INTO BrowseSystemCache (SystemDBID, DirPath, ParentPath, Name, FileCount, IsVirtual)
-			 VALUES (?, ?, ?, ?, ?, ?)`,
-			systemDBID, romsPath, "", "roms", 1, false,
-		)
-		require.NoError(t, err)
-	}
+	return id
 }
 
 func countTableRows(t *testing.T, mediaDB *MediaDB, table, where string, args ...any) int {
 	t.Helper()
 
-	if table != "BrowseCache" && table != "BrowseSystemCache" {
+	if table != "BrowseDirs" && table != "BrowseEntries" && table != "BrowseDirCounts" {
 		t.Fatalf("unexpected table %q", table)
 	}
 	query := "SELECT COUNT(*) FROM " + table
@@ -279,6 +255,19 @@ func assertIndexExists(t *testing.T, mediaDB *MediaDB, indexName string) {
 	).Scan(&found)
 	require.NoError(t, err)
 	assert.Equal(t, indexName, found)
+}
+
+func getDBConfigValue(t *testing.T, mediaDB *MediaDB, name string) string {
+	t.Helper()
+
+	var value string
+	err := mediaDB.sql.QueryRowContext(
+		context.Background(),
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		name,
+	).Scan(&value)
+	require.NoError(t, err)
+	return value
 }
 
 func TestMediaDB_OpenClose_Integration(t *testing.T) {
@@ -2414,7 +2403,7 @@ func TestMediaDB_CacheInvalidationScope_UsesAllSystemsForBroadIndexing_Integrati
 	assert.Empty(t, scope.SystemIDs)
 }
 
-func TestMediaDB_SystemBrowseFallsBackWhenSystemCacheEmpty_Integration(t *testing.T) {
+func TestMediaDB_SystemBrowseFallsBackWhenBrowseV2NotReady_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -2448,7 +2437,10 @@ func TestMediaDB_SystemBrowseFallsBackWhenSystemCacheEmpty_Integration(t *testin
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
 
-	_, err = mediaDB.sql.ExecContext(ctx, "DELETE FROM BrowseSystemCache")
+	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, nil, true))
+	assert.Equal(t, "0", getDBConfigValue(t, mediaDB, DBConfigBrowseIndexVersion))
+
+	_, err = mediaDB.sql.ExecContext(ctx, "DELETE FROM BrowseDirs")
 	require.NoError(t, err)
 
 	routeCounts, err := mediaDB.BrowseRouteCounts(ctx, database.BrowseRouteCountsOptions{
@@ -2487,18 +2479,39 @@ func TestSqlPopulateBrowseCache_PopulatesSystemAndGlobalCounts_Integration(t *te
 	insertSystemMedia(t, mediaDB, snesSystem, "Steam Game", "steam://440/Team%20Fortress%202")
 
 	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql))
+	assert.Equal(t, browseIndexVersion, getDBConfigValue(t, mediaDB, DBConfigBrowseIndexVersion))
 
-	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0, "/", "", "/", 2, false)
-	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0,
-		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms"))+"/", "", "roms", 2, false)
-	assertBrowseCacheRow(t, mediaDB, "BrowseCache", 0, "steam://", "", "steam://", 1, true)
+	romsDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms")) + "/"
+	assertBrowseV2Dir(t, mediaDB, "/", "/", false)
+	assertBrowseV2Dir(t, mediaDB, romsDir, "roms", false)
+	assertBrowseV2Dir(t, mediaDB, "steam://", "steam://", true)
 
-	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", snesSystem.DBID, "/", "", "/", 1, false)
-	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", nesSystem.DBID, "/", "", "/", 1, false)
-	assertBrowseCacheRow(t, mediaDB, "BrowseSystemCache", snesSystem.DBID, "steam://", "", "steam://", 1, true)
+	rootID := browseV2DirID(t, mediaDB, "/")
+	romsID := browseV2DirID(t, mediaDB, romsDir)
+	steamID := browseV2DirID(t, mediaDB, "steam://")
+
+	assert.Equal(t, 2, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ParentDirDBID = ? AND ChildDirDBID = ?", rootID, rootID))
+	assert.Equal(t, 2, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ParentDirDBID = ? AND ChildDirDBID = ?", rootID, romsID))
+	assert.Equal(t, 1, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ChildDirDBID = ? AND SystemDBID = ?", steamID, snesSystem.DBID))
+	assert.Equal(t, 1, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ChildDirDBID = ? AND SystemDBID = ?", romsID, nesSystem.DBID))
+
+	rootCounts, err := mediaDB.BrowseRootCounts(ctx, []string{"/"})
+	require.NoError(t, err)
+	require.NotNil(t, rootCounts["/"])
+	assert.Equal(t, 2, *rootCounts["/"])
+
+	rootDirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{PathPrefix: "/"})
+	require.NoError(t, err)
+	require.Len(t, rootDirs, 1)
+	assert.Equal(t, "roms", rootDirs[0].Name)
+	assert.Equal(t, 2, rootDirs[0].FileCount)
 }
 
-func TestSqlInvalidateBrowseCache_DeletesScopedSystemRows_Integration(t *testing.T) {
+func TestSqlInvalidateBrowseCache_MarksBrowseV2Stale_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -2507,38 +2520,16 @@ func TestSqlInvalidateBrowseCache_DeletesScopedSystemRows_Integration(t *testing
 	defer cleanup()
 
 	ctx := context.Background()
-	nesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	_, err := mediaDB.sql.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigBrowseIndexVersion,
+		browseIndexVersion,
+	)
 	require.NoError(t, err)
-	snesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
-	require.NoError(t, err)
-	seedBrowseCacheRows(t, mediaDB, nesSystem.DBID, snesSystem.DBID)
 
-	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, []int64{nesSystem.DBID}, false))
+	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, []int64{1}, false))
 
-	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseCache", ""))
-	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseSystemCache", "SystemDBID = ?", nesSystem.DBID))
-	assert.Equal(t, 1, countTableRows(t, mediaDB, "BrowseSystemCache", "SystemDBID = ?", snesSystem.DBID))
-}
-
-func TestSqlInvalidateBrowseCache_DeletesAllRows_Integration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
-	t.Parallel()
-	mediaDB, cleanup := setupTempMediaDB(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	nesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
-	require.NoError(t, err)
-	snesSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
-	require.NoError(t, err)
-	seedBrowseCacheRows(t, mediaDB, nesSystem.DBID, snesSystem.DBID)
-
-	require.NoError(t, sqlInvalidateBrowseCache(ctx, mediaDB.sql, nil, true))
-
-	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseCache", ""))
-	assert.Equal(t, 0, countTableRows(t, mediaDB, "BrowseSystemCache", ""))
+	assert.Equal(t, "0", getDBConfigValue(t, mediaDB, DBConfigBrowseIndexVersion))
 }
 
 func TestMediaDB_UnfilteredBrowseReadsFromMediaWhenBrowseCacheEmpty_Integration(t *testing.T) {

--- a/pkg/database/mediadb/migrations/20260430054834_browse_v2.sql
+++ b/pkg/database/mediadb/migrations/20260430054834_browse_v2.sql
@@ -1,0 +1,99 @@
+-- +goose Up
+DROP INDEX IF EXISTS idx_media_parentdir_path;
+DROP INDEX IF EXISTS idx_media_parentdir_system_path;
+DROP INDEX IF EXISTS idx_media_parentdir_browsename;
+DROP INDEX IF EXISTS idx_media_parentdir_system_browsename;
+DROP INDEX IF EXISTS idx_media_parentdir_browsechar_name;
+DROP INDEX IF EXISTS idx_media_parentdir_system_browsechar_name;
+DROP INDEX IF EXISTS idx_browsecache_parent_name;
+DROP INDEX IF EXISTS idx_browsesystemcache_parent_name;
+DROP INDEX IF EXISTS idx_browsecache_parent;
+DROP INDEX IF EXISTS idx_browsecache_virtual;
+DROP INDEX IF EXISTS idx_browsesystemcache_parent;
+DROP INDEX IF EXISTS idx_browsesystemcache_dir;
+DROP INDEX IF EXISTS idx_browsesystemcache_virtual;
+
+DROP TABLE IF EXISTS BrowseSystemCache;
+DROP TABLE IF EXISTS BrowseCache;
+
+CREATE TABLE IF NOT EXISTS BrowseDirs (
+    DBID integer primary key,
+    ParentDirDBID integer,
+    Path text unique not null,
+    Name text not null,
+    IsVirtual bool default false,
+    foreign key (ParentDirDBID) references BrowseDirs (DBID) on delete cascade
+);
+
+CREATE TABLE IF NOT EXISTS BrowseEntries (
+    ParentDirDBID integer not null,
+    MediaDBID integer primary key,
+    SystemDBID integer not null,
+    Name text not null,
+    NameFirstChar text not null,
+    FileName text not null,
+    foreign key (ParentDirDBID) references BrowseDirs (DBID) on delete cascade,
+    foreign key (MediaDBID) references Media (DBID) on delete cascade,
+    foreign key (SystemDBID) references Systems (DBID) on delete cascade
+);
+
+CREATE TABLE IF NOT EXISTS BrowseDirCounts (
+    ParentDirDBID integer not null,
+    ChildDirDBID integer not null,
+    SystemDBID integer not null,
+    FileCount integer not null,
+    primary key (ParentDirDBID, ChildDirDBID, SystemDBID),
+    foreign key (ParentDirDBID) references BrowseDirs (DBID) on delete cascade,
+    foreign key (ChildDirDBID) references BrowseDirs (DBID) on delete cascade,
+    foreign key (SystemDBID) references Systems (DBID) on delete cascade
+);
+
+CREATE INDEX IF NOT EXISTS idx_browsedirs_parent_name ON BrowseDirs(ParentDirDBID, Name);
+CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_name ON BrowseEntries(ParentDirDBID, SystemDBID, Name, MediaDBID);
+CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_file ON BrowseEntries(ParentDirDBID, SystemDBID, FileName, MediaDBID);
+CREATE INDEX IF NOT EXISTS idx_browsedircounts_parent_system ON BrowseDirCounts(ParentDirDBID, SystemDBID);
+CREATE INDEX IF NOT EXISTS idx_browsedircounts_child_system ON BrowseDirCounts(ChildDirDBID, SystemDBID);
+
+INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES ('BrowseIndexVersion', '0');
+INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES ('OptimizationStatus', 'pending');
+INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES ('OptimizationStep', 'browse_cache');
+DELETE FROM DBConfig WHERE Name = 'BrowseSortReady';
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_browsedircounts_child_system;
+DROP INDEX IF EXISTS idx_browsedircounts_parent_system;
+DROP INDEX IF EXISTS idx_browseentries_parent_system_file;
+DROP INDEX IF EXISTS idx_browseentries_parent_system_name;
+DROP INDEX IF EXISTS idx_browsedirs_parent_name;
+
+DROP TABLE IF EXISTS BrowseDirCounts;
+DROP TABLE IF EXISTS BrowseEntries;
+DROP TABLE IF EXISTS BrowseDirs;
+
+CREATE TABLE IF NOT EXISTS BrowseCache (
+    DirPath text primary key,
+    ParentPath text not null,
+    Name text not null,
+    FileCount integer not null,
+    IsVirtual bool default false
+);
+
+CREATE INDEX IF NOT EXISTS idx_browsecache_parent ON BrowseCache(ParentPath);
+CREATE INDEX IF NOT EXISTS idx_browsecache_virtual ON BrowseCache(IsVirtual);
+
+CREATE TABLE IF NOT EXISTS BrowseSystemCache (
+    SystemDBID integer not null,
+    DirPath text not null,
+    ParentPath text not null,
+    Name text not null,
+    FileCount integer not null,
+    IsVirtual bool default false,
+    primary key (SystemDBID, DirPath),
+    foreign key (SystemDBID) references Systems (DBID) on delete cascade
+);
+
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_parent ON BrowseSystemCache(SystemDBID, ParentPath);
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_dir ON BrowseSystemCache(DirPath);
+CREATE INDEX IF NOT EXISTS idx_browsesystemcache_virtual ON BrowseSystemCache(SystemDBID, IsVirtual);
+
+DELETE FROM DBConfig WHERE Name = 'BrowseIndexVersion';

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -56,16 +56,33 @@ func expectBrowseCacheStep(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "browse_cache").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// PopulateBrowseCache: SELECT (empty), BEGIN, DELETEs, Prepares, COMMIT
-	mock.ExpectQuery("SELECT SystemDBID, Path FROM Media").
-		WillReturnRows(sqlmock.NewRows([]string{"SystemDBID", "Path"}))
+	// PopulateBrowseCache: BEGIN, SELECT (empty), index drops, DELETEs, root dir insert,
+	// index creates, count prepare, COMMIT.
 	mock.ExpectBegin()
-	mock.ExpectExec("DELETE FROM BrowseCache").
+	mock.ExpectQuery("SELECT m.DBID, m.SystemDBID, m.Path, mt.Name").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID", "SystemDBID", "Path", "Name"}))
+	mock.ExpectExec("DROP INDEX IF EXISTS idx_browseentries_parent_system_name").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectExec("DELETE FROM BrowseSystemCache").
+	mock.ExpectExec("DROP INDEX IF EXISTS idx_browseentries_parent_system_file").
 		WillReturnResult(sqlmock.NewResult(0, 0))
-	mock.ExpectPrepare("INSERT INTO BrowseCache")
-	mock.ExpectPrepare("INSERT INTO BrowseSystemCache")
+	mock.ExpectExec("DELETE FROM BrowseDirCounts").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM BrowseEntries").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("DELETE FROM BrowseDirs").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPrepare("INSERT INTO BrowseDirs").
+		ExpectExec().
+		WithArgs(int64(1), nil, "/", "/", false).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_name").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_file").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectPrepare("INSERT INTO BrowseDirCounts")
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigBrowseIndexVersion, browseIndexVersion).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 }
 

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -21,7 +21,7 @@ package mediadb
 
 import (
 	"context"
-	stdsql "database/sql"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
@@ -45,6 +45,44 @@ func browseSystemFilterClause(column string, systems []systemdefs.System) (claus
 	return column + " IN (" + strings.Join(placeholders, ",") + ")", args
 }
 
+func sqlBrowseV2Ready(ctx context.Context, db sqlQueryable) (bool, error) {
+	var version string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigBrowseIndexVersion,
+	).Scan(&version)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("browse v2 readiness query: %w", err)
+	}
+	if version != browseIndexVersion {
+		return false, nil
+	}
+
+	var exists int
+	err = db.QueryRowContext(ctx, `SELECT 1 FROM BrowseDirs LIMIT 1`).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("browse v2 table readiness query: %w", err)
+	}
+	return true, nil
+}
+
+func sqlBrowseDirID(ctx context.Context, db sqlQueryable, dirPath string) (id int64, ok bool, err error) {
+	err = db.QueryRowContext(ctx, `SELECT DBID FROM BrowseDirs WHERE Path = ?`, dirPath).Scan(&id)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("browse v2 dir lookup: %w", err)
+	}
+	return id, true, nil
+}
+
 func splitBrowseSystemIDs(ids string) []string {
 	if ids == "" {
 		return nil
@@ -52,53 +90,104 @@ func splitBrowseSystemIDs(ids string) []string {
 	return uniqueBrowseSystemIDs(strings.Split(ids, ","))
 }
 
-// sqlBrowseDirectories returns distinct immediate subdirectory names under the
-// given path prefix from BrowseCache, along with the precomputed file count.
 func sqlBrowseDirectories(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
-	if len(opts.Systems) > 0 {
-		return sqlBrowseDirectoriesForSystems(ctx, db, opts)
-	}
-
-	results, err := sqlBrowseDirectoriesFromCache(ctx, db, opts.PathPrefix)
+	ready, err := sqlBrowseV2Ready(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
-		return results, nil
+	if ready {
+		return sqlBrowseDirectoriesV2(ctx, db, opts)
+	}
+	if len(opts.Systems) > 0 {
+		return sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, opts)
 	}
 	return sqlBrowseDirectoriesFromMedia(ctx, db, opts.PathPrefix)
 }
 
-func sqlBrowseDirectoriesFromCache(
+func sqlBrowseDirectoriesV2(
 	ctx context.Context,
 	db sqlQueryable,
-	pathPrefix string,
+	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
-	rows, err := db.QueryContext(ctx,
-		`SELECT Name, FileCount FROM BrowseCache WHERE ParentPath = ? ORDER BY Name ASC`,
-		pathPrefix,
-	)
+	parentID, ok, err := sqlBrowseDirID(ctx, db, opts.PathPrefix)
+	if err != nil || !ok {
+		return nil, err
+	}
+	if len(opts.Systems) == 1 {
+		return sqlBrowseDirectoriesV2ForSingleSystem(ctx, db, parentID, opts.Systems[0].ID)
+	}
+
+	args := []any{parentID}
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	query := `SELECT d.Name, SUM(c.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
+		FROM BrowseDirCounts c
+		INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
+		INNER JOIN Systems s ON c.SystemDBID = s.DBID
+		WHERE c.ParentDirDBID = ? AND c.ChildDirDBID != c.ParentDirDBID AND d.IsVirtual = 0`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += ` GROUP BY d.DBID, d.Name ORDER BY d.Name ASC`
+
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("browse directories query: %w", err)
+		return nil, fmt.Errorf("browse v2 directories query: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var results []database.BrowseDirectoryResult
 	for rows.Next() {
 		var r database.BrowseDirectoryResult
-		if err := rows.Scan(&r.Name, &r.FileCount); err != nil {
-			return nil, fmt.Errorf("browse directories scan: %w", err)
+		var systemIDs string
+		if scanErr := rows.Scan(&r.Name, &r.FileCount, &systemIDs); scanErr != nil {
+			return nil, fmt.Errorf("browse v2 directories scan: %w", scanErr)
 		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse directories rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse v2 directories rows: %w", rowsErr)
 	}
+	return results, nil
+}
 
+func sqlBrowseDirectoriesV2ForSingleSystem(
+	ctx context.Context,
+	db sqlQueryable,
+	parentID int64,
+	systemID string,
+) ([]database.BrowseDirectoryResult, error) {
+	rows, err := db.QueryContext(ctx, `SELECT d.Name, c.FileCount
+		FROM BrowseDirCounts c
+		INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
+		INNER JOIN Systems s ON c.SystemDBID = s.DBID
+		WHERE c.ParentDirDBID = ?
+			AND c.ChildDirDBID != c.ParentDirDBID
+			AND d.IsVirtual = 0
+			AND s.SystemID = ?
+		ORDER BY d.Name ASC`, parentID, systemID)
+	if err != nil {
+		return nil, fmt.Errorf("browse v2 single-system directories query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseDirectoryResult
+	for rows.Next() {
+		var r database.BrowseDirectoryResult
+		if scanErr := rows.Scan(&r.Name, &r.FileCount); scanErr != nil {
+			return nil, fmt.Errorf("browse v2 single-system directories scan: %w", scanErr)
+		}
+		r.SystemIDs = []string{systemID}
+		results = append(results, r)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse v2 single-system directories rows: %w", rowsErr)
+	}
 	return results, nil
 }
 
@@ -129,133 +218,14 @@ func sqlBrowseDirectoriesFromMedia(
 	var results []database.BrowseDirectoryResult
 	for rows.Next() {
 		var r database.BrowseDirectoryResult
-		if err := rows.Scan(&r.Name, &r.FileCount); err != nil {
-			return nil, fmt.Errorf("browse directories media scan: %w", err)
+		if scanErr := rows.Scan(&r.Name, &r.FileCount); scanErr != nil {
+			return nil, fmt.Errorf("browse directories media scan: %w", scanErr)
 		}
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse directories media rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse directories media rows: %w", rowsErr)
 	}
-
-	return results, nil
-}
-
-func sqlBrowseDirectoriesForSystems(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseDirectoriesOptions,
-) ([]database.BrowseDirectoryResult, error) {
-	results, err := sqlBrowseDirectoriesForSystemsFromCache(ctx, db, opts)
-	if err != nil {
-		return nil, err
-	}
-	missingSystems := browseMissingSystems(opts.Systems, browseCoveredSystemIDsFromDirectories(results))
-	if len(missingSystems) == 0 {
-		return results, nil
-	}
-
-	mediaResults, err := sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, database.BrowseDirectoriesOptions{
-		PathPrefix: opts.PathPrefix,
-		Systems:    missingSystems,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return mergeBrowseDirectoryResults(results, mediaResults), nil
-}
-
-func browseCoveredSystemIDsFromDirectories(results []database.BrowseDirectoryResult) map[string]struct{} {
-	covered := make(map[string]struct{})
-	for _, result := range results {
-		for _, systemID := range result.SystemIDs {
-			covered[systemID] = struct{}{}
-		}
-	}
-	return covered
-}
-
-func browseMissingSystems(systems []systemdefs.System, covered map[string]struct{}) []systemdefs.System {
-	missing := make([]systemdefs.System, 0, len(systems))
-	for _, system := range systems {
-		if _, ok := covered[system.ID]; !ok {
-			missing = append(missing, system)
-		}
-	}
-	return missing
-}
-
-func mergeBrowseDirectoryResults(
-	base []database.BrowseDirectoryResult,
-	extra []database.BrowseDirectoryResult,
-) []database.BrowseDirectoryResult {
-	if len(extra) == 0 {
-		return base
-	}
-
-	byName := make(map[string]*database.BrowseDirectoryResult, len(base)+len(extra))
-	for i := range base {
-		result := base[i]
-		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
-		byName[result.Name] = &result
-	}
-	for _, result := range extra {
-		if existing, ok := byName[result.Name]; ok {
-			existing.FileCount += result.FileCount
-			existing.SystemIDs = uniqueBrowseSystemIDs(append(existing.SystemIDs, result.SystemIDs...))
-			continue
-		}
-		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
-		byName[result.Name] = &result
-	}
-
-	merged := make([]database.BrowseDirectoryResult, 0, len(byName))
-	for _, result := range byName {
-		merged = append(merged, *result)
-	}
-	sort.Slice(merged, func(i, j int) bool { return merged[i].Name < merged[j].Name })
-	return merged
-}
-
-func sqlBrowseDirectoriesForSystemsFromCache(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseDirectoriesOptions,
-) ([]database.BrowseDirectoryResult, error) {
-	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
-	args := make([]any, 0, 1+len(systemArgs))
-	args = append(args, opts.PathPrefix)
-	args = append(args, systemArgs...)
-
-	rows, err := db.QueryContext(ctx,
-		`SELECT b.Name, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
-		 FROM BrowseSystemCache b
-		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
-		 WHERE b.ParentPath = ? AND `+systemClause+`
-		 GROUP BY b.DirPath, b.Name
-		 ORDER BY b.Name ASC`,
-		args...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("browse directories by system query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var results []database.BrowseDirectoryResult
-	for rows.Next() {
-		var r database.BrowseDirectoryResult
-		var systemIDs string
-		if err := rows.Scan(&r.Name, &r.FileCount, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse directories by system scan: %w", err)
-		}
-		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
-		results = append(results, r)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse directories by system rows: %w", err)
-	}
-
 	return results, nil
 }
 
@@ -268,10 +238,9 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	args := make([]any, 0, 2+len(systemArgs))
 	args = append(args, opts.PathPrefix, opts.PathPrefix)
 	args = append(args, systemArgs...)
-
 	rows, err := db.QueryContext(ctx,
 		`WITH matched AS (
-			 SELECT s.SystemID, substr(m.Path, length(?) + 1) AS Rest
+			 SELECT substr(m.Path, length(?) + 1) AS Rest, s.SystemID
 			 FROM Media m
 			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
 			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause+`
@@ -294,27 +263,20 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	for rows.Next() {
 		var r database.BrowseDirectoryResult
 		var systemIDs string
-		if err := rows.Scan(&r.Name, &r.FileCount, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse directories by system media scan: %w", err)
+		if scanErr := rows.Scan(&r.Name, &r.FileCount, &systemIDs); scanErr != nil {
+			return nil, fmt.Errorf("browse directories by system media scan: %w", scanErr)
 		}
 		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse directories by system media rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse directories by system media rows: %w", rowsErr)
 	}
-
 	return results, nil
 }
 
-// browseFilesBaseCondition returns the WHERE clause and args for filtering
-// immediate children of a path prefix, with optional letter filter.
-// Uses the ParentDir column for direct index lookup instead of range scan.
-func browseFilesBaseCondition(
-	opts *database.BrowseFilesOptions,
-) (where string, args []any) {
+func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
 	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "mt.Name")
-
 	conditions := make([]string, 0, 3+len(letterClauses))
 	conditions = append(conditions, `m.ParentDir = ?`, `m.IsMissing = 0`)
 	conditions = append(conditions, letterClauses...)
@@ -327,11 +289,23 @@ func browseFilesBaseCondition(
 		args = append(args, systemArgs...)
 	}
 
-	where = strings.Join(conditions, " AND ")
-	return where, args
+	return strings.Join(conditions, " AND "), args
 }
 
-// browseSortClause returns the ORDER BY clause for the given sort option.
+func browseV2FilesBaseCondition(opts *database.BrowseFilesOptions, parentID int64) (where string, args []any) {
+	conditions := []string{`b.ParentDirDBID = ?`}
+	args = []any{parentID}
+	if letterClause, letterArgs := buildBrowseNameCharFilter("b.NameFirstChar", opts.Letter); letterClause != "" {
+		conditions = append(conditions, letterClause)
+		args = append(args, letterArgs...)
+	}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		conditions = append(conditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+	return strings.Join(conditions, " AND "), args
+}
+
 func browseSortClause(sortOrder string) string {
 	switch sortOrder {
 	case "name-desc":
@@ -340,13 +314,24 @@ func browseSortClause(sortOrder string) string {
 		return "m.Path ASC, m.DBID ASC"
 	case "filename-desc":
 		return "m.Path DESC, m.DBID DESC"
-	default: // "name-asc" or empty
+	default:
 		return "mt.Name ASC, m.DBID ASC"
 	}
 }
 
-// browseCursorCondition returns the keyset pagination WHERE clause fragment for
-// the given sort order. The caller must append (sortValue, lastID) as args.
+func browseV2SortClause(sortOrder string) string {
+	switch sortOrder {
+	case "name-desc":
+		return "b.Name DESC, b.MediaDBID DESC"
+	case "filename-asc":
+		return "b.FileName ASC, b.MediaDBID ASC"
+	case "filename-desc":
+		return "b.FileName DESC, b.MediaDBID DESC"
+	default:
+		return "b.Name ASC, b.MediaDBID ASC"
+	}
+}
+
 func browseCursorCondition(sortOrder string) string {
 	switch sortOrder {
 	case "name-desc":
@@ -355,33 +340,110 @@ func browseCursorCondition(sortOrder string) string {
 		return ` AND (m.Path, m.DBID) > (?, ?)`
 	case "filename-desc":
 		return ` AND (m.Path, m.DBID) < (?, ?)`
-	default: // "name-asc" or empty
+	default:
 		return ` AND (mt.Name, m.DBID) > (?, ?)`
 	}
 }
 
-// sqlBrowseFiles returns indexed media files that are immediate children of the
-// given path prefix (no further '/' after the prefix). Supports cursor-based
-// pagination, letter filtering, and sort order.
+func browseV2CursorCondition(sortOrder string) string {
+	switch sortOrder {
+	case "name-desc":
+		return ` AND (b.Name, b.MediaDBID) < (?, ?)`
+	case "filename-asc":
+		return ` AND (b.FileName, b.MediaDBID) > (?, ?)`
+	case "filename-desc":
+		return ` AND (b.FileName, b.MediaDBID) < (?, ?)`
+	default:
+		return ` AND (b.Name, b.MediaDBID) > (?, ?)`
+	}
+}
+
+func browseV2CursorSortValue(opts *database.BrowseFilesOptions) string {
+	if opts.Cursor == nil {
+		return ""
+	}
+	if opts.Sort != "filename-asc" && opts.Sort != "filename-desc" {
+		return opts.Cursor.SortValue
+	}
+	_, fileName := browseV2ParentAndFileName(opts.Cursor.SortValue)
+	return fileName
+}
+
 func sqlBrowseFiles(
 	ctx context.Context,
 	db sqlQueryable,
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
-	where, args := browseFilesBaseCondition(opts)
+	ready, err := sqlBrowseV2Ready(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if ready {
+		return sqlBrowseFilesV2(ctx, db, opts)
+	}
+	return sqlBrowseFilesFromMedia(ctx, db, opts)
+}
 
-	query := `
-		SELECT s.SystemID, mt.Name, m.Path, m.DBID
+func sqlBrowseFilesV2(
+	ctx context.Context,
+	db sqlQueryable,
+	opts *database.BrowseFilesOptions,
+) ([]database.SearchResultWithCursor, error) {
+	parentID, ok, err := sqlBrowseDirID(ctx, db, opts.PathPrefix)
+	if err != nil || !ok {
+		return nil, err
+	}
+	where, args := browseV2FilesBaseCondition(opts, parentID)
+	query := `SELECT s.SystemID, b.Name, m.Path, b.MediaDBID
+		FROM BrowseEntries b
+		INNER JOIN Media m ON b.MediaDBID = m.DBID
+		INNER JOIN Systems s ON b.SystemDBID = s.DBID
+		WHERE ` + where
+	if opts.Cursor != nil {
+		query += browseV2CursorCondition(opts.Sort)
+		args = append(args, browseV2CursorSortValue(opts), opts.Cursor.LastID)
+	}
+	query += ` ORDER BY ` + browseV2SortClause(opts.Sort) + ` LIMIT ?`
+	args = append(args, opts.Limit)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse v2 files query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.SearchResultWithCursor
+	for rows.Next() {
+		var r database.SearchResultWithCursor
+		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID); scanErr != nil {
+			return nil, fmt.Errorf("browse v2 files scan: %w", scanErr)
+		}
+		results = append(results, r)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse v2 files rows: %w", rowsErr)
+	}
+	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse v2 files tags: %w", err)
+	}
+	return results, nil
+}
+
+func sqlBrowseFilesFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts *database.BrowseFilesOptions,
+) ([]database.SearchResultWithCursor, error) {
+	where, args := browseFilesBaseCondition(opts)
+	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
-
 	if opts.Cursor != nil {
 		query += browseCursorCondition(opts.Sort)
 		args = append(args, opts.Cursor.SortValue, opts.Cursor.LastID)
 	}
-
 	query += ` ORDER BY ` + browseSortClause(opts.Sort) + ` LIMIT ?`
 	args = append(args, opts.Limit)
 
@@ -394,26 +456,54 @@ func sqlBrowseFiles(
 	var results []database.SearchResultWithCursor
 	for rows.Next() {
 		var r database.SearchResultWithCursor
-		if err := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID); err != nil {
-			return nil, fmt.Errorf("browse files scan: %w", err)
+		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID); scanErr != nil {
+			return nil, fmt.Errorf("browse files scan: %w", scanErr)
 		}
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse files rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse files rows: %w", rowsErr)
 	}
-
 	if err := fetchAndAttachTags(ctx, db, results); err != nil {
 		return nil, fmt.Errorf("browse files tags: %w", err)
 	}
-
 	return results, nil
 }
 
-// sqlBrowseFileCount returns the total number of immediate child files under
-// a path prefix, with optional letter filtering. Used for total count in
-// pagination responses.
 func sqlBrowseFileCount(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseFileCountOptions,
+) (int, error) {
+	ready, err := sqlBrowseV2Ready(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	if ready {
+		return sqlBrowseFileCountV2(ctx, db, opts)
+	}
+	return sqlBrowseFileCountFromMedia(ctx, db, opts)
+}
+
+func sqlBrowseFileCountV2(ctx context.Context, db sqlQueryable, opts database.BrowseFileCountOptions) (int, error) {
+	parentID, ok, err := sqlBrowseDirID(ctx, db, opts.PathPrefix)
+	if err != nil || !ok {
+		return 0, err
+	}
+	where, args := browseV2FilesBaseCondition(&database.BrowseFilesOptions{
+		PathPrefix: opts.PathPrefix,
+		Letter:     opts.Letter,
+		Systems:    opts.Systems,
+	}, parentID)
+	query := `SELECT COUNT(*) FROM BrowseEntries b INNER JOIN Systems s ON b.SystemDBID = s.DBID WHERE ` + where
+	var count int
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("browse v2 file count: %w", err)
+	}
+	return count, nil
+}
+
+func sqlBrowseFileCountFromMedia(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseFileCountOptions,
@@ -423,74 +513,81 @@ func sqlBrowseFileCount(
 		Letter:     opts.Letter,
 		Systems:    opts.Systems,
 	})
-
-	query := `
-		SELECT COUNT(*)
+	query := `SELECT COUNT(*)
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
-
 	var count int
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("browse file count: %w", err)
 	}
-
 	return count, nil
 }
 
-// sqlBrowseVirtualSchemes returns distinct URI schemes present in indexed media,
-// with the count of media entries for each scheme.
 func sqlBrowseVirtualSchemes(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
-	if len(opts.Systems) > 0 {
-		return sqlBrowseVirtualSchemesForSystems(ctx, db, opts)
-	}
-
-	results, err := sqlBrowseVirtualSchemesFromCache(ctx, db)
+	ready, err := sqlBrowseV2Ready(ctx, db)
 	if err != nil {
 		return nil, err
 	}
-	if len(results) > 0 {
-		return results, nil
+	if ready {
+		return sqlBrowseVirtualSchemesV2(ctx, db, opts)
+	}
+	if len(opts.Systems) > 0 {
+		return sqlBrowseVirtualSchemesForSystemsFromMedia(ctx, db, opts)
 	}
 	return sqlBrowseVirtualSchemesFromMedia(ctx, db)
 }
 
-func sqlBrowseVirtualSchemesFromCache(
+func sqlBrowseVirtualSchemesV2(
 	ctx context.Context,
 	db sqlQueryable,
+	opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {
-	rows, err := db.QueryContext(ctx,
-		`SELECT DirPath, FileCount FROM BrowseCache
-		 WHERE IsVirtual = 1 ORDER BY DirPath ASC`)
+	rootID, ok, err := sqlBrowseDirID(ctx, db, "")
+	if err != nil || !ok {
+		return nil, err
+	}
+	args := []any{rootID}
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	query := `SELECT d.Path, SUM(c.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
+		FROM BrowseDirCounts c
+		INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
+		INNER JOIN Systems s ON c.SystemDBID = s.DBID
+		WHERE c.ParentDirDBID = ? AND d.IsVirtual = 1`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += ` GROUP BY d.DBID, d.Path ORDER BY d.Path ASC`
+
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("browse virtual schemes query: %w", err)
+		return nil, fmt.Errorf("browse v2 virtual schemes query: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var results []database.BrowseVirtualScheme
 	for rows.Next() {
 		var r database.BrowseVirtualScheme
-		if err := rows.Scan(&r.Scheme, &r.FileCount); err != nil {
-			return nil, fmt.Errorf("browse virtual schemes scan: %w", err)
+		var systemIDs string
+		if scanErr := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); scanErr != nil {
+			return nil, fmt.Errorf("browse v2 virtual schemes scan: %w", scanErr)
 		}
+		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse virtual schemes rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse v2 virtual schemes rows: %w", rowsErr)
 	}
-
 	return results, nil
 }
 
-func sqlBrowseVirtualSchemesFromMedia(
-	ctx context.Context,
-	db sqlQueryable,
-) ([]database.BrowseVirtualScheme, error) {
+func sqlBrowseVirtualSchemesFromMedia(ctx context.Context, db sqlQueryable) ([]database.BrowseVirtualScheme, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT substr(Path, 1, instr(Path, '://') + 2) AS Scheme,
 			COUNT(*) AS FileCount
@@ -506,116 +603,14 @@ func sqlBrowseVirtualSchemesFromMedia(
 	var results []database.BrowseVirtualScheme
 	for rows.Next() {
 		var r database.BrowseVirtualScheme
-		if err := rows.Scan(&r.Scheme, &r.FileCount); err != nil {
-			return nil, fmt.Errorf("browse virtual schemes media scan: %w", err)
+		if scanErr := rows.Scan(&r.Scheme, &r.FileCount); scanErr != nil {
+			return nil, fmt.Errorf("browse virtual schemes media scan: %w", scanErr)
 		}
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse virtual schemes media rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse virtual schemes media rows: %w", rowsErr)
 	}
-
-	return results, nil
-}
-
-func sqlBrowseVirtualSchemesForSystems(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseVirtualSchemesOptions,
-) ([]database.BrowseVirtualScheme, error) {
-	results, err := sqlBrowseVirtualSchemesForSystemsFromCache(ctx, db, opts)
-	if err != nil {
-		return nil, err
-	}
-	missingSystems := browseMissingSystems(opts.Systems, browseCoveredSystemIDsFromVirtualSchemes(results))
-	if len(missingSystems) == 0 {
-		return results, nil
-	}
-
-	mediaResults, err := sqlBrowseVirtualSchemesForSystemsFromMedia(ctx, db, database.BrowseVirtualSchemesOptions{
-		Systems: missingSystems,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return mergeBrowseVirtualSchemes(results, mediaResults), nil
-}
-
-func browseCoveredSystemIDsFromVirtualSchemes(results []database.BrowseVirtualScheme) map[string]struct{} {
-	covered := make(map[string]struct{})
-	for _, result := range results {
-		for _, systemID := range result.SystemIDs {
-			covered[systemID] = struct{}{}
-		}
-	}
-	return covered
-}
-
-func mergeBrowseVirtualSchemes(
-	base []database.BrowseVirtualScheme,
-	extra []database.BrowseVirtualScheme,
-) []database.BrowseVirtualScheme {
-	if len(extra) == 0 {
-		return base
-	}
-
-	byScheme := make(map[string]*database.BrowseVirtualScheme, len(base)+len(extra))
-	for i := range base {
-		result := base[i]
-		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
-		byScheme[result.Scheme] = &result
-	}
-	for _, result := range extra {
-		if existing, ok := byScheme[result.Scheme]; ok {
-			existing.FileCount += result.FileCount
-			existing.SystemIDs = uniqueBrowseSystemIDs(append(existing.SystemIDs, result.SystemIDs...))
-			continue
-		}
-		result.SystemIDs = uniqueBrowseSystemIDs(result.SystemIDs)
-		byScheme[result.Scheme] = &result
-	}
-
-	merged := make([]database.BrowseVirtualScheme, 0, len(byScheme))
-	for _, result := range byScheme {
-		merged = append(merged, *result)
-	}
-	sort.Slice(merged, func(i, j int) bool { return merged[i].Scheme < merged[j].Scheme })
-	return merged
-}
-
-func sqlBrowseVirtualSchemesForSystemsFromCache(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseVirtualSchemesOptions,
-) ([]database.BrowseVirtualScheme, error) {
-	systemClause, args := browseSystemFilterClause("s.SystemID", opts.Systems)
-	rows, err := db.QueryContext(ctx,
-		`SELECT b.DirPath, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
-		 FROM BrowseSystemCache b
-		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
-		 WHERE b.IsVirtual = 1 AND `+systemClause+`
-		 GROUP BY b.DirPath
-		 ORDER BY b.DirPath ASC`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("browse virtual schemes by system query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var results []database.BrowseVirtualScheme
-	for rows.Next() {
-		var r database.BrowseVirtualScheme
-		var systemIDs string
-		if err := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse virtual schemes by system scan: %w", err)
-		}
-		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
-		results = append(results, r)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse virtual schemes by system rows: %w", err)
-	}
-
 	return results, nil
 }
 
@@ -643,16 +638,15 @@ func sqlBrowseVirtualSchemesForSystemsFromMedia(
 	for rows.Next() {
 		var r database.BrowseVirtualScheme
 		var systemIDs string
-		if err := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse virtual schemes by system media scan: %w", err)
+		if scanErr := rows.Scan(&r.Scheme, &r.FileCount, &systemIDs); scanErr != nil {
+			return nil, fmt.Errorf("browse virtual schemes by system media scan: %w", scanErr)
 		}
 		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
 		results = append(results, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse virtual schemes by system media rows: %w", err)
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse virtual schemes by system media rows: %w", rowsErr)
 	}
-
 	return results, nil
 }
 
@@ -671,50 +665,127 @@ func sqlBrowseRouteCounts(
 	if len(opts.Routes) == 0 || len(opts.Systems) == 0 {
 		return make(map[string]database.BrowseRouteCount), nil
 	}
-
-	counts, err := sqlBrowseRouteCountsFromCache(ctx, db, opts)
+	ready, err := sqlBrowseV2Ready(ctx, db)
 	if err != nil {
 		return nil, err
 	}
+	if ready {
+		return sqlBrowseRouteCountsV2(ctx, db, opts)
+	}
+	return sqlBrowseRouteCountsFromMedia(ctx, db, opts)
+}
 
-	missingByRoute := make(map[string][]systemdefs.System, len(opts.Routes))
+func sqlBrowseRouteCountsV2(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
 	for _, route := range opts.Routes {
-		covered := make(map[string]struct{})
-		if count, ok := counts[route]; ok {
-			for _, systemID := range count.SystemIDs {
-				covered[systemID] = struct{}{}
-			}
-		}
-		if missingSystems := browseMissingSystems(opts.Systems, covered); len(missingSystems) > 0 {
-			missingByRoute[route] = missingSystems
-		}
-	}
-	if len(missingByRoute) == 0 {
-		return counts, nil
-	}
-
-	for route, missingSystems := range missingByRoute {
-		mediaCounts, err := sqlBrowseRouteCountsFromMedia(ctx, db, database.BrowseRouteCountsOptions{
-			Systems: missingSystems,
-			Routes:  []string{route},
-		})
+		dirID, ok, err := sqlBrowseDirID(ctx, db, browseRouteCacheKey(route))
 		if err != nil {
 			return nil, err
 		}
-		mediaCount, ok := mediaCounts[route]
 		if !ok {
 			continue
 		}
-		if cachedCount, ok := counts[route]; ok {
-			cachedCount.FileCount += mediaCount.FileCount
-			cachedCount.SystemIDs = uniqueBrowseSystemIDs(append(cachedCount.SystemIDs, mediaCount.SystemIDs...))
-			counts[route] = cachedCount
+		args := append([]any{dirID}, systemArgs...)
+		var count int
+		var systemIDs sql.NullString
+		err = db.QueryRowContext(ctx,
+			`SELECT COALESCE(SUM(c.FileCount), 0), GROUP_CONCAT(DISTINCT s.SystemID)
+			 FROM BrowseDirCounts c
+			 INNER JOIN Systems s ON c.SystemDBID = s.DBID
+			 WHERE c.ChildDirDBID = ? AND `+systemClause,
+			args...,
+		).Scan(&count, &systemIDs)
+		if err != nil {
+			return nil, fmt.Errorf("browse v2 route counts query: %w", err)
+		}
+		if count == 0 {
 			continue
 		}
-		mediaCount.SystemIDs = uniqueBrowseSystemIDs(mediaCount.SystemIDs)
-		counts[route] = mediaCount
+		counts[route] = database.BrowseRouteCount{
+			Path:      route,
+			FileCount: count,
+			SystemIDs: splitBrowseSystemIDs(systemIDs.String),
+		}
 	}
+	return counts, nil
+}
 
+func sqlBrowseRouteCountsFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseRouteCountsOptions,
+) (map[string]database.BrowseRouteCount, error) {
+	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
+	if len(opts.Routes) == 0 || len(opts.Systems) == 0 {
+		return counts, nil
+	}
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	for _, route := range opts.Routes {
+		prefix := browseRouteCacheKey(route)
+		args := append([]any{prefix}, systemArgs...)
+		var count int
+		var systemIDs sql.NullString
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*), GROUP_CONCAT(DISTINCT s.SystemID)
+			 FROM Media m
+			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause,
+			args...,
+		).Scan(&count, &systemIDs); err != nil {
+			return nil, fmt.Errorf("browse route counts media scan: %w", err)
+		}
+		if count == 0 {
+			continue
+		}
+		counts[route] = database.BrowseRouteCount{
+			Path:      route,
+			FileCount: count,
+			SystemIDs: splitBrowseSystemIDs(systemIDs.String),
+		}
+	}
+	return counts, nil
+}
+
+func sqlBrowseRootCounts(ctx context.Context, db sqlQueryable, rootDirs []string) (map[string]*int, error) {
+	counts := make(map[string]*int, len(rootDirs))
+	for _, root := range rootDirs {
+		counts[root] = nil
+	}
+	if len(rootDirs) == 0 {
+		return counts, nil
+	}
+	ready, err := sqlBrowseV2Ready(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if !ready {
+		return counts, nil
+	}
+	for _, root := range rootDirs {
+		count := 0
+		counts[root] = &count
+		dirID, ok, lookupErr := sqlBrowseDirID(ctx, db, browseRouteCacheKey(root))
+		if lookupErr != nil {
+			return nil, lookupErr
+		}
+		if !ok {
+			continue
+		}
+		var dbCount int
+		if scanErr := db.QueryRowContext(ctx,
+			`SELECT COALESCE(SUM(FileCount), 0) FROM BrowseDirCounts WHERE ChildDirDBID = ?`,
+			dirID,
+		).Scan(&dbCount); scanErr != nil {
+			return nil, fmt.Errorf("browse v2 root counts query: %w", scanErr)
+		}
+		c := dbCount
+		counts[root] = &c
+	}
 	return counts, nil
 }
 
@@ -733,168 +804,4 @@ func uniqueBrowseSystemIDs(systemIDs []string) []string {
 	}
 	sort.Strings(unique)
 	return unique
-}
-
-func sqlBrowseRouteCountsFromCache(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseRouteCountsOptions,
-) (map[string]database.BrowseRouteCount, error) {
-	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
-
-	routeKeys := make([]string, len(opts.Routes))
-	keyToRoute := make(map[string]string, len(opts.Routes))
-	args := make([]any, 0, len(opts.Routes)+len(opts.Systems))
-	for i, route := range opts.Routes {
-		key := browseRouteCacheKey(route)
-		routeKeys[i] = key
-		keyToRoute[key] = route
-		args = append(args, key)
-	}
-
-	routePlaceholders := make([]string, len(routeKeys))
-	for i := range routePlaceholders {
-		routePlaceholders[i] = "?"
-	}
-	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
-	args = append(args, systemArgs...)
-
-	rows, err := db.QueryContext(ctx,
-		`SELECT b.DirPath, SUM(b.FileCount), GROUP_CONCAT(DISTINCT s.SystemID)
-		 FROM BrowseSystemCache b
-		 INNER JOIN Systems s ON b.SystemDBID = s.DBID
-		 WHERE b.DirPath IN (`+strings.Join(routePlaceholders, ",")+
-			`) AND `+systemClause+`
-		 GROUP BY b.DirPath`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("browse route counts query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	for rows.Next() {
-		var dirPath string
-		var count int
-		var systemIDs string
-		if err := rows.Scan(&dirPath, &count, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse route counts scan: %w", err)
-		}
-		route, ok := keyToRoute[dirPath]
-		if !ok {
-			continue
-		}
-		counts[route] = database.BrowseRouteCount{
-			Path:      route,
-			FileCount: count,
-			SystemIDs: splitBrowseSystemIDs(systemIDs),
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse route counts rows: %w", err)
-	}
-
-	return counts, nil
-}
-
-func sqlBrowseRouteCountsFromMedia(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseRouteCountsOptions,
-) (map[string]database.BrowseRouteCount, error) {
-	counts := make(map[string]database.BrowseRouteCount, len(opts.Routes))
-	if len(opts.Routes) == 0 || len(opts.Systems) == 0 {
-		return counts, nil
-	}
-
-	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
-	for _, route := range opts.Routes {
-		prefix := browseRouteCacheKey(route)
-		args := make([]any, 0, 1+len(systemArgs))
-		args = append(args, prefix)
-		args = append(args, systemArgs...)
-
-		var count int
-		var systemIDs stdsql.NullString
-		if err := db.QueryRowContext(ctx,
-			`SELECT COUNT(*), GROUP_CONCAT(DISTINCT s.SystemID)
-			 FROM Media m
-			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause,
-			args...,
-		).Scan(&count, &systemIDs); err != nil {
-			return nil, fmt.Errorf("browse route counts media scan: %w", err)
-		}
-		if count == 0 {
-			continue
-		}
-
-		counts[route] = database.BrowseRouteCount{
-			Path:      route,
-			FileCount: count,
-			SystemIDs: splitBrowseSystemIDs(systemIDs.String),
-		}
-	}
-
-	return counts, nil
-}
-
-// sqlBrowseRootCounts looks up precomputed file counts for root directories
-// from BrowseCache. Returns nil *int for roots where the cache has no entry
-// (cache not yet populated or no indexed content under that root).
-func sqlBrowseRootCounts(
-	ctx context.Context,
-	db sqlQueryable,
-	rootDirs []string,
-) (map[string]*int, error) {
-	if len(rootDirs) == 0 {
-		return make(map[string]*int), nil
-	}
-
-	// Build prefix list and map prefixes back to original root strings.
-	prefixes := make([]string, len(rootDirs))
-	prefixToRoot := make(map[string]string, len(rootDirs))
-	args := make([]any, len(rootDirs))
-	for i, root := range rootDirs {
-		prefix := root
-		if prefix != "" && prefix[len(prefix)-1] != '/' {
-			prefix += "/"
-		}
-		prefixes[i] = prefix
-		prefixToRoot[prefix] = root
-		args[i] = prefix
-	}
-
-	placeholders := make([]string, len(prefixes))
-	for i := range placeholders {
-		placeholders[i] = "?"
-	}
-
-	rows, err := db.QueryContext(ctx,
-		`SELECT DirPath, FileCount FROM BrowseCache WHERE DirPath IN (`+
-			strings.Join(placeholders, ",")+`)`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("browse root counts query: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	// Initialize all roots as cache miss (nil), then fill from results.
-	counts := make(map[string]*int, len(rootDirs))
-	for _, root := range rootDirs {
-		counts[root] = nil
-	}
-	for rows.Next() {
-		var dirPath string
-		var count int
-		if err := rows.Scan(&dirPath, &count); err != nil {
-			return nil, fmt.Errorf("browse root counts scan: %w", err)
-		}
-		if root, ok := prefixToRoot[dirPath]; ok {
-			c := count
-			counts[root] = &c
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("browse root counts rows: %w", err)
-	}
-
-	return counts, nil
 }

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -24,170 +24,405 @@ import (
 	"database/sql"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
 
-type browseSystemCacheKey struct {
-	dirPath    string
-	systemDBID int64
+const browseIndexVersion = "2"
+
+type browseV2Dir struct {
+	parentID  *int64
+	path      string
+	name      string
+	id        int64
+	isVirtual bool
 }
 
-// sqlPopulateBrowseCache rebuilds the BrowseCache table from the current Media
-// data. Reads all paths, extracts every directory level, then bulk-inserts
-// aggregated counts.
+type browseV2Entry struct {
+	name        string
+	nameChar    string
+	fileName    string
+	mediaDBID   int64
+	systemDBID  int64
+	parentDirID int64
+}
+
+type browseV2CountKey struct {
+	parentDirID int64
+	childDirID  int64
+	systemDBID  int64
+}
+
+type browseV2Builder struct {
+	dirs      map[string]*browseV2Dir
+	counts    map[browseV2CountKey]int
+	entries   []browseV2Entry
+	nextDirID int64
+}
+
+func newBrowseV2Builder() *browseV2Builder {
+	return &browseV2Builder{
+		dirs:      make(map[string]*browseV2Dir),
+		counts:    make(map[browseV2CountKey]int),
+		nextDirID: 1,
+	}
+}
+
+// sqlPopulateBrowseCache rebuilds the compact browse v2 tables from current,
+// non-missing media rows. The historical method name is kept because the
+// background optimization step still calls this "browse_cache".
 func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
-	// Read all paths from Media
-	rows, err := db.QueryContext(ctx, "SELECT SystemDBID, Path FROM Media WHERE IsMissing = 0")
-	if err != nil {
-		return fmt.Errorf("browse cache: failed to query paths: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
+	started := time.Now()
+	readStarted := time.Now()
+	builder := newBrowseV2Builder()
+	builder.ensureDir("/")
 
-	// Count files per directory prefix. Each path contributes to all its
-	// ancestor directories. Virtual scheme paths (containing "://") only
-	// contribute to their scheme prefix.
-	dirCounts := make(map[string]int)
-	systemDirCounts := make(map[browseSystemCacheKey]int)
-	for rows.Next() {
-		var systemDBID int64
-		var p string
-		if scanErr := rows.Scan(&systemDBID, &p); scanErr != nil {
-			return fmt.Errorf("browse cache: failed to scan path: %w", scanErr)
-		}
-
-		if strings.Contains(p, "://") {
-			idx := strings.Index(p, "://")
-			scheme := p[:idx+3]
-			dirCounts[scheme]++
-			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: scheme}]++
-			continue
-		}
-
-		// Filesystem path: extract every ancestor directory.
-		dir := path.Dir(p)
-		for dir != "" && dir != "." && dir != "/" {
-			dirCounts[dir+"/"]++
-			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: dir + "/"}]++
-			dir = path.Dir(dir)
-		}
-		if dir == "/" {
-			dirCounts["/"]++
-			systemDirCounts[browseSystemCacheKey{systemDBID: systemDBID, dirPath: "/"}]++
-		}
-	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return fmt.Errorf("browse cache: rows iteration error: %w", rowsErr)
-	}
-
-	// Bulk insert BrowseCache entries inside a transaction so the old cache
-	// remains visible to concurrent readers until the new data is committed.
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("browse cache: failed to begin transaction: %w", err)
+		return fmt.Errorf("browse v2: failed to begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if _, delErr := tx.ExecContext(ctx, "DELETE FROM BrowseCache"); delErr != nil {
-		return fmt.Errorf("failed to clear browse cache: %w", delErr)
+	if err := scanBrowseV2Media(ctx, tx, builder); err != nil {
+		return err
 	}
-	if _, delErr := tx.ExecContext(ctx, "DELETE FROM BrowseSystemCache"); delErr != nil {
-		return fmt.Errorf("failed to clear system browse cache: %w", delErr)
+	log.Debug().
+		Dur("duration", time.Since(readStarted)).
+		Int("dirs", len(builder.dirs)).
+		Int("entries", len(builder.entries)).
+		Int("counts", len(builder.counts)).
+		Msg("browse v2 media scan complete")
+
+	deleteStarted := time.Now()
+	if err := dropBrowseV2EntryIndexes(ctx, tx); err != nil {
+		return err
+	}
+	for _, stmt := range []string{
+		"DELETE FROM BrowseDirCounts",
+		"DELETE FROM BrowseEntries",
+		"DELETE FROM BrowseDirs",
+	} {
+		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
+			return fmt.Errorf("browse v2: failed to clear tables: %w", execErr)
+		}
+	}
+	log.Debug().Dur("duration", time.Since(deleteStarted)).Msg("browse v2 cleared old entries")
+
+	if err := insertBrowseV2Dirs(ctx, tx, builder.dirs); err != nil {
+		return err
+	}
+	if err := insertBrowseV2Entries(ctx, tx, builder.entries); err != nil {
+		return err
+	}
+	if err := createBrowseV2EntryIndexes(ctx, tx); err != nil {
+		return err
+	}
+	if err := insertBrowseV2Counts(ctx, tx, builder.counts); err != nil {
+		return err
 	}
 
-	stmt, err := tx.PrepareContext(ctx,
-		"INSERT INTO BrowseCache (DirPath, ParentPath, Name, FileCount, IsVirtual) VALUES (?, ?, ?, ?, ?)")
+	if _, cfgErr := tx.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigBrowseIndexVersion,
+		browseIndexVersion,
+	); cfgErr != nil {
+		return fmt.Errorf("browse v2: failed to mark index ready: %w", cfgErr)
+	}
+
+	commitStarted := time.Now()
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("browse v2: failed to commit: %w", err)
+	}
+	log.Debug().Dur("duration", time.Since(commitStarted)).Msg("browse v2 transaction committed")
+
+	log.Info().
+		Int("dirs", len(builder.dirs)).
+		Int("entries", len(builder.entries)).
+		Int("counts", len(builder.counts)).
+		Dur("duration", time.Since(started)).
+		Msg("browse v2 populated")
+	return nil
+}
+
+func scanBrowseV2Media(ctx context.Context, tx *sql.Tx, builder *browseV2Builder) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT m.DBID, m.SystemDBID, m.Path, mt.Name
+		FROM Media m
+		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
+		WHERE m.IsMissing = 0
+		ORDER BY m.DBID`)
 	if err != nil {
-		return fmt.Errorf("browse cache: failed to prepare insert: %w", err)
+		return fmt.Errorf("browse v2: failed to query media: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var mediaDBID, systemDBID int64
+		var mediaPath, title string
+		if scanErr := rows.Scan(&mediaDBID, &systemDBID, &mediaPath, &title); scanErr != nil {
+			return fmt.Errorf("browse v2: failed to scan media: %w", scanErr)
+		}
+		builder.addMedia(mediaDBID, systemDBID, mediaPath, title)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return fmt.Errorf("browse v2: rows iteration error: %w", rowsErr)
+	}
+	return nil
+}
+
+func (b *browseV2Builder) addMedia(mediaDBID, systemDBID int64, mediaPath, title string) {
+	parentPath, fileName := browseV2ParentAndFileName(mediaPath)
+	parent := b.ensureDir(parentPath)
+	b.entries = append(b.entries, browseV2Entry{
+		mediaDBID:   mediaDBID,
+		systemDBID:  systemDBID,
+		parentDirID: parent.id,
+		name:        title,
+		nameChar:    BrowseNameFirstChar(title),
+		fileName:    fileName,
+	})
+
+	for _, pair := range b.countPairsForPath(mediaPath) {
+		key := browseV2CountKey{
+			parentDirID: pair.parent.id,
+			childDirID:  pair.child.id,
+			systemDBID:  systemDBID,
+		}
+		b.counts[key]++
+	}
+}
+
+func (b *browseV2Builder) ensureDir(dirPath string) *browseV2Dir {
+	if dir, ok := b.dirs[dirPath]; ok {
+		return dir
+	}
+	parentPath, name, isVirtual := browseV2DirParentAndName(dirPath)
+	var parentID *int64
+	if parentPath != "" {
+		parent := b.ensureDir(parentPath)
+		parentID = &parent.id
+	}
+	dir := &browseV2Dir{
+		id:        b.nextDirID,
+		path:      dirPath,
+		name:      name,
+		parentID:  parentID,
+		isVirtual: isVirtual,
+	}
+	b.nextDirID++
+	b.dirs[dirPath] = dir
+	return dir
+}
+
+type browseV2CountPair struct {
+	parent *browseV2Dir
+	child  *browseV2Dir
+}
+
+func (b *browseV2Builder) countPairsForPath(mediaPath string) []browseV2CountPair {
+	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
+		return []browseV2CountPair{{parent: b.ensureDir(""), child: b.ensureDir(mediaPath[:idx+3])}}
+	}
+
+	dirs := browseV2AncestorDirs(mediaPath)
+	pairs := make([]browseV2CountPair, 0, len(dirs)+1)
+	root := b.ensureDir("/")
+	pairs = append(pairs, browseV2CountPair{parent: root, child: root})
+	for i := 0; i+1 < len(dirs); i++ {
+		pairs = append(pairs, browseV2CountPair{
+			parent: b.ensureDir(dirs[i]),
+			child:  b.ensureDir(dirs[i+1]),
+		})
+	}
+	return pairs
+}
+
+func browseV2AncestorDirs(mediaPath string) []string {
+	dirs := []string{"/"}
+	if !strings.HasPrefix(mediaPath, "/") {
+		mediaPath = "/" + mediaPath
+	}
+	dir := path.Dir(mediaPath)
+	if dir == "." || dir == "/" || dir == "" {
+		return dirs
+	}
+
+	parts := strings.Split(strings.Trim(dir, "/"), "/")
+	current := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current += "/" + part
+		dirs = append(dirs, current+"/")
+	}
+	return dirs
+}
+
+func browseV2ParentAndFileName(mediaPath string) (parentPath, fileName string) {
+	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
+		return mediaPath[:idx+3], strings.TrimPrefix(mediaPath[idx+3:], "/")
+	}
+	if !strings.HasPrefix(mediaPath, "/") {
+		mediaPath = "/" + mediaPath
+	}
+	if lastSlash := strings.LastIndex(mediaPath, "/"); lastSlash >= 0 {
+		return mediaPath[:lastSlash+1], mediaPath[lastSlash+1:]
+	}
+	return "", mediaPath
+}
+
+func browseV2DirParentAndName(dirPath string) (parentPath, name string, isVirtual bool) {
+	if dirPath == "" {
+		return "", "", false
+	}
+	if strings.Contains(dirPath, "://") {
+		return "", dirPath, true
+	}
+	if dirPath == "/" {
+		return "", "/", false
+	}
+	trimmed := strings.TrimSuffix(dirPath, "/")
+	parent := path.Dir(trimmed)
+	if parent == "." {
+		return "", path.Base(trimmed), false
+	}
+	if parent == "/" {
+		return "/", path.Base(trimmed), false
+	}
+	return parent + "/", path.Base(trimmed), false
+}
+
+func insertBrowseV2Dirs(ctx context.Context, tx *sql.Tx, dirs map[string]*browseV2Dir) error {
+	started := time.Now()
+	stmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO BrowseDirs (DBID, ParentDirDBID, Path, Name, IsVirtual) VALUES (?, ?, ?, ?, ?)")
+	if err != nil {
+		return fmt.Errorf("browse v2: failed to prepare dir insert: %w", err)
 	}
 	defer func() { _ = stmt.Close() }()
 
-	for dirPath, count := range dirCounts {
-		parentPath, name := browseCacheParentAndName(dirPath)
-		isVirtual := strings.Contains(dirPath, "://")
-		if _, insertErr := stmt.ExecContext(ctx, dirPath, parentPath, name, count, isVirtual); insertErr != nil {
-			return fmt.Errorf("browse cache: failed to insert %s: %w", dirPath, insertErr)
+	ordered := make([]*browseV2Dir, 0, len(dirs))
+	for _, dir := range dirs {
+		ordered = append(ordered, dir)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].id < ordered[j].id })
+
+	for _, dir := range ordered {
+		_, insertErr := stmt.ExecContext(ctx, dir.id, dir.parentID, dir.path, dir.name, dir.isVirtual)
+		if insertErr != nil {
+			return fmt.Errorf("browse v2: failed to insert dir %s: %w", dir.path, insertErr)
 		}
 	}
-
-	systemStmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO BrowseSystemCache
-		 (SystemDBID, DirPath, ParentPath, Name, FileCount, IsVirtual)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-	)
-	if err != nil {
-		return fmt.Errorf("browse cache: failed to prepare system insert: %w", err)
-	}
-	defer func() { _ = systemStmt.Close() }()
-
-	for key, count := range systemDirCounts {
-		parentPath, name := browseCacheParentAndName(key.dirPath)
-		isVirtual := strings.Contains(key.dirPath, "://")
-		if _, insertErr := systemStmt.ExecContext(
-			ctx, key.systemDBID, key.dirPath, parentPath, name, count, isVirtual,
-		); insertErr != nil {
-			return fmt.Errorf("browse cache: failed to insert system cache %s: %w", key.dirPath, insertErr)
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("browse cache: failed to commit: %w", err)
-	}
-
-	log.Info().Int("entries", len(dirCounts)).Int("systemEntries", len(systemDirCounts)).Msg("browse cache populated")
+	log.Debug().Dur("duration", time.Since(started)).Int("entries", len(dirs)).Msg("browse v2 dirs inserted")
 	return nil
 }
 
-func sqlInvalidateBrowseCache(ctx context.Context, db sqlQueryable, systemDBIDs []int64, allSystems bool) error {
-	if _, err := db.ExecContext(ctx, "DELETE FROM BrowseCache"); err != nil {
-		return fmt.Errorf("failed to invalidate browse cache: %w", err)
-	}
-
-	if allSystems || len(systemDBIDs) == 0 || len(systemDBIDs) > maxSelectiveInvalidationSystems {
-		if _, err := db.ExecContext(ctx, "DELETE FROM BrowseSystemCache"); err != nil {
-			return fmt.Errorf("failed to invalidate system browse cache: %w", err)
+func insertBrowseV2Entries(ctx context.Context, tx *sql.Tx, entries []browseV2Entry) error {
+	started := time.Now()
+	const chunkSize = 100
+	for start := 0; start < len(entries); start += chunkSize {
+		end := start + chunkSize
+		if end > len(entries) {
+			end = len(entries)
 		}
+		if err := insertBrowseV2EntryChunk(ctx, tx, entries[start:end]); err != nil {
+			return err
+		}
+	}
+	log.Debug().Dur("duration", time.Since(started)).Int("entries", len(entries)).Msg("browse v2 entries inserted")
+	return nil
+}
+
+func dropBrowseV2EntryIndexes(ctx context.Context, tx *sql.Tx) error {
+	started := time.Now()
+	for _, stmt := range []string{
+		"DROP INDEX IF EXISTS idx_browseentries_parent_system_name",
+		"DROP INDEX IF EXISTS idx_browseentries_parent_system_file",
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("browse v2: failed to drop entry index: %w", err)
+		}
+	}
+	log.Debug().Dur("duration", time.Since(started)).Msg("browse v2 entry indexes dropped")
+	return nil
+}
+
+func createBrowseV2EntryIndexes(ctx context.Context, tx *sql.Tx) error {
+	started := time.Now()
+	for _, stmt := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_name
+			ON BrowseEntries(ParentDirDBID, SystemDBID, Name, MediaDBID)`,
+		`CREATE INDEX IF NOT EXISTS idx_browseentries_parent_system_file
+			ON BrowseEntries(ParentDirDBID, SystemDBID, FileName, MediaDBID)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("browse v2: failed to create entry index: %w", err)
+		}
+	}
+	log.Debug().Dur("duration", time.Since(started)).Msg("browse v2 entry indexes created")
+	return nil
+}
+
+func insertBrowseV2EntryChunk(ctx context.Context, tx *sql.Tx, entries []browseV2Entry) error {
+	if len(entries) == 0 {
 		return nil
 	}
-
-	placeholders := prepareVariadic("?", ",", len(systemDBIDs))
-	args := make([]any, len(systemDBIDs))
-	for i, systemDBID := range systemDBIDs {
-		args[i] = systemDBID
+	placeholders := make([]string, len(entries))
+	args := make([]any, 0, len(entries)*6)
+	for i, entry := range entries {
+		placeholders[i] = "(?, ?, ?, ?, ?, ?)"
+		args = append(args,
+			entry.parentDirID,
+			entry.mediaDBID,
+			entry.systemDBID,
+			entry.name,
+			entry.nameChar,
+			entry.fileName,
+		)
 	}
-
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
-	stmt := fmt.Sprintf("DELETE FROM BrowseSystemCache WHERE SystemDBID IN (%s)", placeholders)
-	if _, err := db.ExecContext(ctx, stmt, args...); err != nil {
-		return fmt.Errorf("failed to invalidate scoped system browse cache: %w", err)
+	//nolint:gosec // The dynamic SQL only expands internally generated value placeholders.
+	query := `INSERT INTO BrowseEntries
+		(ParentDirDBID, MediaDBID, SystemDBID, Name, NameFirstChar, FileName)
+		VALUES ` + strings.Join(placeholders, ",")
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("browse v2: failed to insert entry chunk: %w", err)
 	}
 	return nil
 }
 
-// browseCacheParentAndName extracts the parent path and display name from a
-// directory path or virtual scheme.
-//
-//	"/media/fat/games/SNES/" → ("/media/fat/games/", "SNES")
-//	"/media/fat/"            → ("/media/", "fat")
-//	"steam://"               → ("", "steam://")
-func browseCacheParentAndName(dirPath string) (parentPath, name string) {
-	if dirPath == "/" {
-		return "", "/"
+func insertBrowseV2Counts(ctx context.Context, tx *sql.Tx, counts map[browseV2CountKey]int) error {
+	started := time.Now()
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO BrowseDirCounts (ParentDirDBID, ChildDirDBID, SystemDBID, FileCount)
+		VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("browse v2: failed to prepare count insert: %w", err)
 	}
+	defer func() { _ = stmt.Close() }()
 
-	// Virtual schemes have no parent
-	if strings.Contains(dirPath, "://") {
-		return "", dirPath
+	for key, count := range counts {
+		if _, insertErr := stmt.ExecContext(
+			ctx, key.parentDirID, key.childDirID, key.systemDBID, count,
+		); insertErr != nil {
+			return fmt.Errorf("browse v2: failed to insert count: %w", insertErr)
+		}
 	}
+	log.Debug().Dur("duration", time.Since(started)).Int("entries", len(counts)).Msg("browse v2 counts inserted")
+	return nil
+}
 
-	// Strip trailing slash, split into parent + name
-	trimmed := strings.TrimSuffix(dirPath, "/")
-	parent := path.Dir(trimmed)
-	name = path.Base(trimmed)
-
-	if parent == "/" || parent == "." {
-		return "", name
+func sqlInvalidateBrowseCache(ctx context.Context, db sqlQueryable, _ []int64, _ bool) error {
+	_, err := db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigBrowseIndexVersion,
+		"0",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to mark browse v2 stale: %w", err)
 	}
-	return parent + "/", name
+	return nil
 }

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -24,6 +24,7 @@ import (
 	"database/sql"
 	"fmt"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -174,6 +175,7 @@ func scanBrowseV2Media(ctx context.Context, tx *sql.Tx, builder *browseV2Builder
 }
 
 func (b *browseV2Builder) addMedia(mediaDBID, systemDBID int64, mediaPath, title string) {
+	mediaPath = browseV2NormalizePath(mediaPath)
 	parentPath, fileName := browseV2ParentAndFileName(mediaPath)
 	parent := b.ensureDir(parentPath)
 	b.entries = append(b.entries, browseV2Entry{
@@ -223,6 +225,7 @@ type browseV2CountPair struct {
 }
 
 func (b *browseV2Builder) countPairsForPath(mediaPath string) []browseV2CountPair {
+	mediaPath = browseV2NormalizePath(mediaPath)
 	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
 		return []browseV2CountPair{{parent: b.ensureDir(""), child: b.ensureDir(mediaPath[:idx+3])}}
 	}
@@ -241,6 +244,7 @@ func (b *browseV2Builder) countPairsForPath(mediaPath string) []browseV2CountPai
 }
 
 func browseV2AncestorDirs(mediaPath string) []string {
+	mediaPath = browseV2NormalizePath(mediaPath)
 	dirs := []string{"/"}
 	if !strings.HasPrefix(mediaPath, "/") {
 		mediaPath = "/" + mediaPath
@@ -263,6 +267,7 @@ func browseV2AncestorDirs(mediaPath string) []string {
 }
 
 func browseV2ParentAndFileName(mediaPath string) (parentPath, fileName string) {
+	mediaPath = browseV2NormalizePath(mediaPath)
 	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
 		return mediaPath[:idx+3], strings.TrimPrefix(mediaPath[idx+3:], "/")
 	}
@@ -273,6 +278,31 @@ func browseV2ParentAndFileName(mediaPath string) (parentPath, fileName string) {
 		return mediaPath[:lastSlash+1], mediaPath[lastSlash+1:]
 	}
 	return "", mediaPath
+}
+
+func browseV2NormalizePath(mediaPath string) string {
+	if mediaPath == "" {
+		return "/"
+	}
+	if idx := strings.Index(mediaPath, "://"); idx >= 0 {
+		prefix := mediaPath[:idx+3]
+		pathPart := browseV2CleanPathPart(mediaPath[idx+3:])
+		if pathPart == "/" {
+			return prefix
+		}
+		return prefix + strings.TrimPrefix(pathPart, "/")
+	}
+
+	return browseV2CleanPathPart(mediaPath)
+}
+
+func browseV2CleanPathPart(pathPart string) string {
+	pathPart = strings.ReplaceAll(pathPart, "\\", string(filepath.Separator))
+	cleaned := filepath.ToSlash(filepath.Clean(pathPart))
+	if cleaned == "." {
+		return "/"
+	}
+	return cleaned
 }
 
 func browseV2DirParentAndName(dirPath string) (parentPath, name string, isVirtual bool) {

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -162,6 +162,32 @@ func TestBrowseV2Builder_NormalizesRelativeFilesystemDirs(t *testing.T) {
 	assert.NotContains(t, builder.dirs, "./")
 }
 
+func TestBrowseV2Builder_NormalizesFilesystemPathSeparators(t *testing.T) {
+	t.Parallel()
+
+	builder := newBrowseV2Builder()
+	builder.ensureDir("/")
+	builder.addMedia(1, 2, `roms\\snes//RPG/../Action/game.sfc`, "Game")
+
+	assert.Contains(t, builder.dirs, "/roms/")
+	assert.Contains(t, builder.dirs, "/roms/snes/")
+	assert.Contains(t, builder.dirs, "/roms/snes/Action/")
+	assert.NotContains(t, builder.dirs, `/roms\\snes/`)
+	assert.Equal(t, "game.sfc", builder.entries[0].fileName)
+}
+
+func TestBrowseV2Builder_NormalizesURIPathPortion(t *testing.T) {
+	t.Parallel()
+
+	builder := newBrowseV2Builder()
+	builder.ensureDir("/")
+	builder.addMedia(1, 2, `steam://440\\Team Fortress 2/../Team Fortress 2`, "Game")
+
+	assert.Contains(t, builder.dirs, "steam://")
+	assert.NotContains(t, builder.dirs, `steam://440\\Team Fortress 2/../`)
+	assert.Equal(t, "440/Team Fortress 2", builder.entries[0].fileName)
+}
+
 func TestSqlBrowseRootCountsV2_ReturnsZeroForMissingRoot(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -111,6 +111,25 @@ func TestSqlBrowseVirtualSchemesV2_ReturnsEmptyWithoutMediaFallback(t *testing.T
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseVirtualSchemesV2_ReturnsEmptyWhenRootMissing(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseV2Ready(mock)
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("").
+		WillReturnError(sql.ErrNoRows)
+
+	results, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseRouteCountsV2_UsesChildDirCounts(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -21,7 +21,7 @@ package mediadb
 
 import (
 	"context"
-	"path/filepath"
+	"database/sql"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -31,414 +31,159 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func browseTestPrefix(path string) string {
-	return filepath.ToSlash(path) + "/"
+func expectBrowseV2Ready(mock sqlmock.Sqlmock) {
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigBrowseIndexVersion).
+		WillReturnRows(sqlmock.NewRows([]string{"Value"}).AddRow(browseIndexVersion))
+	mock.ExpectQuery("SELECT 1 FROM BrowseDirs LIMIT 1").
+		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
 }
 
-func browseTestAbsPath(parts ...string) string {
-	return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
-}
-
-func TestSqlBrowseRootCounts_PassesArgs(t *testing.T) {
+func TestSqlBrowseDirectoriesV2_ReturnsSystemCounts(t *testing.T) {
 	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectQuery(`SELECT DirPath, FileCount FROM BrowseCache WHERE DirPath IN`).
-		WithArgs("/roms/SNES/", "/roms/NES/").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount"}).
-				AddRow("/roms/SNES/", 42).
-				AddRow("/roms/NES/", 17),
-		)
+	expectBrowseV2Ready(mock)
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("/media/fat/games/").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	mock.ExpectQuery("SELECT d.Name, c.FileCount").
+		WithArgs(int64(10), "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}).
+			AddRow("SNES", 42))
+
+	snes := systemdefs.System{ID: "SNES"}
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: "/media/fat/games/",
+		Systems:    []systemdefs.System{snes},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "SNES", results[0].Name)
+	assert.Equal(t, 42, results[0].FileCount)
+	assert.Equal(t, []string{"SNES"}, results[0].SystemIDs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectories_FallsBackWhenV2NotReady(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigBrowseIndexVersion).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("WITH matched AS").
+		WithArgs("/roms/", "/roms/").
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}).AddRow("SNES", 2))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: "/roms/",
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "SNES", results[0].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseVirtualSchemesV2_ReturnsEmptyWithoutMediaFallback(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseV2Ready(mock)
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(1))
+	mock.ExpectQuery("SELECT d.Path, SUM").
+		WithArgs(int64(1), "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"Path", "FileCount", "SystemIDs"}))
+
+	results, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseRouteCountsV2_UsesChildDirCounts(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseV2Ready(mock)
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("/media/fat/games/SNES/").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(99))
+	mock.ExpectQuery("SELECT COALESCE\\(SUM").
+		WithArgs(int64(99), "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(123, "SNES"))
+
+	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
+		Routes:  []string{"/media/fat/games/SNES"},
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 123, counts["/media/fat/games/SNES"].FileCount)
+	assert.Equal(t, []string{"SNES"}, counts["/media/fat/games/SNES"].SystemIDs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestBrowseV2CursorSortValue_UsesFileNameForFilenameSort(t *testing.T) {
+	t.Parallel()
+
+	value := browseV2CursorSortValue(&database.BrowseFilesOptions{
+		Sort: "filename-asc",
+		Cursor: &database.BrowseCursor{
+			SortValue: "/media/fat/games/SNES/Super Metroid.sfc",
+			LastID:    42,
+		},
+	})
+
+	assert.Equal(t, "Super Metroid.sfc", value)
+}
+
+func TestBrowseV2Builder_NormalizesRelativeFilesystemDirs(t *testing.T) {
+	t.Parallel()
+
+	builder := newBrowseV2Builder()
+	builder.ensureDir("/")
+	builder.addMedia(1, 2, "roms/nes/game.nes", "Game")
+
+	assert.Contains(t, builder.dirs, "/")
+	assert.Contains(t, builder.dirs, "/roms/")
+	assert.Contains(t, builder.dirs, "/roms/nes/")
+	assert.NotContains(t, builder.dirs, "./")
+}
+
+func TestSqlBrowseRootCountsV2_ReturnsZeroForMissingRoot(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseV2Ready(mock)
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("/roms/SNES/").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(7))
+	mock.ExpectQuery("SELECT COALESCE\\(SUM\\(FileCount\\)").
+		WithArgs(int64(7)).
+		WillReturnRows(sqlmock.NewRows([]string{"FileCount"}).AddRow(10))
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs("/roms/NES/").
+		WillReturnError(sql.ErrNoRows)
 
 	counts, err := sqlBrowseRootCounts(context.Background(), db, []string{"/roms/SNES", "/roms/NES"})
 	require.NoError(t, err)
-
 	require.NotNil(t, counts["/roms/SNES"])
-	assert.Equal(t, 42, *counts["/roms/SNES"])
+	assert.Equal(t, 10, *counts["/roms/SNES"])
 	require.NotNil(t, counts["/roms/NES"])
-	assert.Equal(t, 17, *counts["/roms/NES"])
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseRootCounts_CacheMiss(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	// Only one of two roots is in the cache.
-	mock.ExpectQuery(`SELECT DirPath, FileCount FROM BrowseCache WHERE DirPath IN`).
-		WithArgs("/roms/SNES/", "/roms/NES/").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount"}).
-				AddRow("/roms/SNES/", 42),
-		)
-
-	counts, err := sqlBrowseRootCounts(context.Background(), db, []string{"/roms/SNES", "/roms/NES"})
-	require.NoError(t, err)
-
-	require.NotNil(t, counts["/roms/SNES"])
-	assert.Equal(t, 42, *counts["/roms/SNES"])
-	assert.Nil(t, counts["/roms/NES"])
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseRootCounts_Empty(t *testing.T) {
-	t.Parallel()
-
-	counts, err := sqlBrowseRootCounts(context.Background(), nil, []string{})
-	require.NoError(t, err)
-	assert.Empty(t, counts)
-}
-
-func TestSqlBrowseVirtualSchemes_UsesIsVirtual(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	mock.ExpectQuery(`SELECT DirPath, FileCount FROM BrowseCache WHERE IsVirtual = 1`).
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount"}).
-				AddRow("steam://", 150).
-				AddRow("igdb://", 30),
-		)
-
-	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{})
-	require.NoError(t, err)
-
-	require.Len(t, schemes, 2)
-	assert.Equal(t, "steam://", schemes[0].Scheme)
-	assert.Equal(t, 150, schemes[0].FileCount)
-	assert.Equal(t, "igdb://", schemes[1].Scheme)
-	assert.Equal(t, 30, schemes[1].FileCount)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseVirtualSchemes_WithSystemsMergesPartialCache(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	mock.ExpectQuery(
-		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
-	).
-		WithArgs("Steam", "DOS").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
-				AddRow("steam://", 2, "Steam"),
-		)
-	mock.ExpectQuery(`(?s)SELECT substr\(m.Path, 1, instr\(m.Path, '://'\) \+ 2\).*FROM Media m`).
-		WithArgs("DOS").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Scheme", "FileCount", "SystemIDs"}).
-				AddRow("gog://", 4, "DOS").
-				AddRow("steam://", 3, "DOS"),
-		)
-
-	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
-		Systems: []systemdefs.System{{ID: "Steam"}, {ID: "DOS"}},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, schemes, 2)
-	assert.Equal(t, "gog://", schemes[0].Scheme)
-	assert.Equal(t, 4, schemes[0].FileCount)
-	assert.Equal(t, []string{"DOS"}, schemes[0].SystemIDs)
-	assert.Equal(t, "steam://", schemes[1].Scheme)
-	assert.Equal(t, 5, schemes[1].FileCount)
-	assert.Equal(t, []string{"DOS", "Steam"}, schemes[1].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseVirtualSchemes_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	mock.ExpectQuery(
-		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
-	).
-		WithArgs("Steam").
-		WillReturnRows(sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}))
-	mock.ExpectQuery(`(?s)SELECT substr\(m.Path, 1, instr\(m.Path, '://'\) \+ 2\).*FROM Media m`).
-		WithArgs("Steam").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Scheme", "FileCount", "SystemIDs"}).
-				AddRow("steam://", 7, "Steam"),
-		)
-
-	schemes, err := sqlBrowseVirtualSchemes(context.Background(), db, database.BrowseVirtualSchemesOptions{
-		Systems: []systemdefs.System{{ID: "Steam"}},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, schemes, 1)
-	assert.Equal(t, "steam://", schemes[0].Scheme)
-	assert.Equal(t, 7, schemes[0].FileCount)
-	assert.Equal(t, []string{"Steam"}, schemes[0].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseDirectories_WithSystemsUsesSystemCache(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
-
-	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
-		WithArgs(sharedPrefix, "SNES", "Genesis").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
-				AddRow("RPG", 8, "SNES,Genesis"),
-		)
-
-	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
-		PathPrefix: sharedPrefix,
-		Systems: []systemdefs.System{
-			{ID: "SNES"},
-			{ID: "Genesis"},
-		},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, dirs, 1)
-	assert.Equal(t, "RPG", dirs[0].Name)
-	assert.Equal(t, 8, dirs[0].FileCount)
-	assert.Equal(t, []string{"Genesis", "SNES"}, dirs[0].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseDirectories_WithSystemsReadsFromMediaWhenCacheEmpty(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
-
-	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
-		WithArgs(sharedPrefix, "SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}))
-	mock.ExpectQuery(`(?s)WITH matched AS .*FROM Media m.*m.Path LIKE \? \|\| '%'`).
-		WithArgs(sharedPrefix, sharedPrefix, "SNES").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
-				AddRow("RPG", 2, "SNES"),
-		)
-
-	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
-		PathPrefix: sharedPrefix,
-		Systems:    []systemdefs.System{{ID: "SNES"}},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, dirs, 1)
-	assert.Equal(t, "RPG", dirs[0].Name)
-	assert.Equal(t, 2, dirs[0].FileCount)
-	assert.Equal(t, []string{"SNES"}, dirs[0].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseDirectories_WithSystemsMergesPartialCache(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
-
-	mock.ExpectQuery(`(?s)SELECT b.Name, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`).
-		WithArgs(sharedPrefix, "SNES", "Genesis").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
-				AddRow("RPG", 2, "SNES"),
-		)
-	mock.ExpectQuery(`(?s)WITH matched AS .*FROM Media m.*m.Path LIKE \? \|\| '%'`).
-		WithArgs(sharedPrefix, sharedPrefix, "Genesis").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
-				AddRow("RPG", 3, "Genesis").
-				AddRow("Shooter", 1, "Genesis"),
-		)
-
-	dirs, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
-		PathPrefix: sharedPrefix,
-		Systems: []systemdefs.System{
-			{ID: "SNES"},
-			{ID: "Genesis"},
-		},
-	})
-	require.NoError(t, err)
-
-	require.Len(t, dirs, 2)
-	assert.Equal(t, "RPG", dirs[0].Name)
-	assert.Equal(t, 5, dirs[0].FileCount)
-	assert.Equal(t, []string{"Genesis", "SNES"}, dirs[0].SystemIDs)
-	assert.Equal(t, "Shooter", dirs[1].Name)
-	assert.Equal(t, 1, dirs[1].FileCount)
-	assert.Equal(t, []string{"Genesis"}, dirs[1].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseRouteCounts_ReturnsOnlyPopulatedRoutes(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	snesRoute := filepath.ToSlash(browseTestAbsPath("roms", "SNES"))
-	sharedRoute := filepath.ToSlash(browseTestAbsPath("roms", "shared"))
-	snesPrefix := browseTestPrefix(browseTestAbsPath("roms", "SNES"))
-	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
-
-	mock.ExpectQuery(
-		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
-	).
-		WithArgs(snesPrefix, sharedPrefix, "SNES").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
-				AddRow(snesPrefix, 12, "SNES"),
-		)
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
-		WithArgs(sharedPrefix, "SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(0, nil))
-
-	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes:  []string{snesRoute, sharedRoute},
-		Systems: []systemdefs.System{{ID: "SNES"}},
-	})
-	require.NoError(t, err)
-
-	require.Contains(t, counts, snesRoute)
-	assert.Equal(t, snesRoute, counts[snesRoute].Path)
-	assert.Equal(t, 12, counts[snesRoute].FileCount)
-	assert.Equal(t, []string{"SNES"}, counts[snesRoute].SystemIDs)
-	assert.NotContains(t, counts, sharedRoute)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseRouteCounts_MergesPartialCache(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	sharedRoute := filepath.ToSlash(browseTestAbsPath("roms", "shared"))
-	sharedPrefix := browseTestPrefix(browseTestAbsPath("roms", "shared"))
-
-	mock.ExpectQuery(
-		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
-	).
-		WithArgs(sharedPrefix, "SNES", "Genesis").
-		WillReturnRows(
-			sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}).
-				AddRow(sharedPrefix, 2, "SNES"),
-		)
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
-		WithArgs(sharedPrefix, "Genesis").
-		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(3, "Genesis"))
-
-	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes: []string{sharedRoute},
-		Systems: []systemdefs.System{
-			{ID: "SNES"},
-			{ID: "Genesis"},
-		},
-	})
-	require.NoError(t, err)
-
-	require.Contains(t, counts, sharedRoute)
-	assert.Equal(t, 5, counts[sharedRoute].FileCount)
-	assert.Equal(t, []string{"Genesis", "SNES"}, counts[sharedRoute].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseRouteCounts_ReadsFromMediaWhenSystemCacheEmpty(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-	snesRoute := filepath.ToSlash(browseTestAbsPath("roms", "SNES"))
-	snesPrefix := browseTestPrefix(browseTestAbsPath("roms", "SNES"))
-
-	mock.ExpectQuery(
-		`(?s)SELECT b.DirPath, SUM\(b.FileCount\), GROUP_CONCAT\(DISTINCT s.SystemID\).*BrowseSystemCache`,
-	).
-		WithArgs(snesPrefix, "SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"DirPath", "FileCount", "SystemIDs"}))
-	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\), GROUP_CONCAT\(DISTINCT s.SystemID\).*FROM Media m`).
-		WithArgs(snesPrefix, "SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"FileCount", "SystemIDs"}).AddRow(3, "SNES"))
-
-	counts, err := sqlBrowseRouteCounts(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes:  []string{snesRoute},
-		Systems: []systemdefs.System{{ID: "SNES"}},
-	})
-	require.NoError(t, err)
-
-	require.Contains(t, counts, snesRoute)
-	assert.Equal(t, 3, counts[snesRoute].FileCount)
-	assert.Equal(t, []string{"SNES"}, counts[snesRoute].SystemIDs)
-
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseFiles_BasicQuery(t *testing.T) {
-	t.Parallel()
-
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	// SELECT s.SystemID, mt.Name, m.Path, m.DBID
-	mock.ExpectQuery(`SELECT .+ FROM Media m`).
-		WillReturnRows(
-			sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-				AddRow("snes", "Super Mario World", "/roms/SNES/smw.sfc", 1).
-				AddRow("snes", "Zelda", "/roms/SNES/zelda.sfc", 2),
-		)
-
-	// fetchAndAttachTags uses Prepare + Query
-	mock.ExpectPrepare(`SELECT MediaDBID.*Tag.*Type FROM`).
-		ExpectQuery().
-		WithArgs(int64(1), int64(2), int64(1), int64(2)).
-		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
-
-	results, err := sqlBrowseFiles(context.Background(), db, &database.BrowseFilesOptions{
-		PathPrefix: "/roms/SNES/",
-		Limit:      10,
-	})
-	require.NoError(t, err)
-
-	require.Len(t, results, 2)
-	assert.Equal(t, "Super Mario World", results[0].Name)
-	assert.Equal(t, "Zelda", results[1].Name)
-	assert.Equal(t, int64(1), results[0].MediaID)
-	assert.Equal(t, int64(2), results[1].MediaID)
-
+	assert.Equal(t, 0, *counts["/roms/NES"])
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -36,6 +36,7 @@ const (
 	DBConfigIndexingStatus     = "IndexingStatus"
 	DBConfigLastIndexedSystem  = "LastIndexedSystem"
 	DBConfigIndexingSystems    = "IndexingSystems"
+	DBConfigBrowseIndexVersion = "BrowseIndexVersion"
 )
 
 func sqlUpdateLastGenerated(ctx context.Context, db sqlQueryable) error {

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -30,7 +30,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const insertMediaSQL = `INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (?, ?, ?, ?, ?)`
+const insertMediaSQL = `INSERT INTO Media
+	(DBID, MediaTitleDBID, SystemDBID, Path, ParentDir)
+	VALUES (?, ?, ?, ?, ?)`
 
 func sqlFindMedia(ctx context.Context, db sqlQueryable, media database.Media) (database.Media, error) {
 	var row database.Media
@@ -84,7 +86,14 @@ func sqlInsertMediaWithPreparedStmt(ctx context.Context, stmt *sql.Stmt, row dat
 		dbID = row.DBID
 	}
 
-	res, err := stmt.ExecContext(ctx, dbID, row.MediaTitleDBID, row.SystemDBID, row.Path, row.ParentDir)
+	res, err := stmt.ExecContext(
+		ctx,
+		dbID,
+		row.MediaTitleDBID,
+		row.SystemDBID,
+		row.Path,
+		row.ParentDir,
+	)
 	if err != nil {
 		return row, fmt.Errorf("failed to execute prepared insert media statement: %w", err)
 	}
@@ -114,7 +123,14 @@ func sqlInsertMedia(ctx context.Context, db *sql.DB, row database.Media) (databa
 		}
 	}()
 
-	res, err := stmt.ExecContext(ctx, dbID, row.MediaTitleDBID, row.SystemDBID, row.Path, row.ParentDir)
+	res, err := stmt.ExecContext(
+		ctx,
+		dbID,
+		row.MediaTitleDBID,
+		row.SystemDBID,
+		row.Path,
+		row.ParentDir,
+	)
 	if err != nil {
 		return row, fmt.Errorf("failed to execute insert media statement: %w", err)
 	}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -781,7 +781,6 @@ func NewNamesIndex(
 			log.Error().Err(setErr).Msg("failed to clear last indexed system")
 		}
 	}
-
 	// Seed canonical tags based on tag existence, independent of resume state
 	if scanState.TagTypesIndex == 0 {
 		log.Info().Msg("seeding known tags")

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -620,6 +620,65 @@ func TestNewNamesIndex_ResumeSystemNotFound(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestNewNamesIndex_FullFreshRunDoesNotDropSecondaryIndexes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("Launchers", mock.Anything).Return([]platforms.Launcher{})
+	mockPlatform.On("RootDirs", mock.Anything).Return([]string{})
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	allSystems := systemdefs.AllSystems()
+	requestedSystemIDs := make([]string, 0, len(allSystems))
+	for _, system := range allSystems {
+		requestedSystemIDs = append(requestedSystemIDs, system.ID)
+	}
+
+	mockMediaDB.On("BeginTransaction", mock.AnythingOfType("bool")).Return(nil).Maybe()
+	mockMediaDB.On("CommitTransaction").Return(nil).Maybe()
+	mockMediaDB.On("RollbackTransaction").Return(nil).Maybe()
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Twice()
+	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
+	mockMediaDB.On("GetMaxSystemID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTitleID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxMediaID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagTypeID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
+	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
+	mockMediaDB.On("InsertTagType", mock.AnythingOfType("database.TagType")).Return(database.TagType{}, nil).Maybe()
+	mockMediaDB.On("InsertTag", mock.AnythingOfType("database.Tag")).Return(database.Tag{}, nil).Maybe()
+	mockMediaDB.On("SetIndexingSystems", requestedSystemIDs).Return(nil).Once()
+	mockMediaDB.On("SetIndexingStatus", "running").Return(nil).Once()
+	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Twice()
+	mockMediaDB.On("CreateSecondaryIndexes").Return(nil).Once()
+	mockMediaDB.On("UpdateLastGenerated").Return(nil).Once()
+	mockMediaDB.On("PopulateSystemTagsCache", mock.Anything).Return(nil).Once()
+	mockMediaDB.On("RebuildSlugSearchCache").Return(nil).Once()
+	mockMediaDB.On("RebuildTagCache").Return(nil).Once()
+	mockMediaDB.On("SetIndexingStatus", "completed").Return(nil).Once()
+	mockMediaDB.On("SetIndexingSystems", []string(nil)).Return(nil).Once()
+	mockMediaDB.On("InvalidateCountCache").Return(nil).Once()
+	mockMediaDB.On("SetOptimizationStatus", "pending").Return(nil).Once()
+
+	_, err := NewNamesIndex(
+		context.Background(),
+		mockPlatform,
+		cfg,
+		allSystems,
+		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		func(IndexStatus) {},
+		nil,
+	)
+	require.NoError(t, err)
+	mockMediaDB.AssertNotCalled(t, "DropSecondaryIndexes")
+	mockMediaDB.AssertExpectations(t)
+}
+
 // TestNewNamesIndex_FailedIndexingRecovery tests handling previous failed indexing
 func TestNewNamesIndex_FailedIndexingRecovery(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 type ServiceEntry func() (*service.StartResult, error)
@@ -57,6 +58,7 @@ type ServiceEntry func() (*service.StartResult, error)
 type Service struct {
 	pl     platforms.Platform
 	cfg    *config.Instance
+	fs     afero.Fs
 	start  ServiceEntry
 	stop   func() error
 	done   <-chan struct{}
@@ -117,9 +119,17 @@ func NewService(args ServiceArgs) (*Service, error) {
 	return &Service{
 		daemon: !args.NoDaemon,
 		cfg:    args.Config,
+		fs:     afero.NewOsFs(),
 		start:  args.Entry,
 		pl:     args.Platform,
 	}, nil
+}
+
+func (s *Service) filesystem() afero.Fs {
+	if s.fs != nil {
+		return s.fs
+	}
+	return afero.NewOsFs()
 }
 
 // Create new PID file using current process PID.
@@ -260,18 +270,19 @@ func (s *Service) stopService() error {
 // package-manager target can be replaced while the daemon is running.
 func (s *Service) prepareBinary(binPath string) (string, error) {
 	started := time.Now()
+	fs := s.filesystem()
 	dataDir := helpers.DataDir(s.pl)
-	if err := os.MkdirAll(dataDir, 0o750); err != nil {
+	if err := fs.MkdirAll(dataDir, 0o750); err != nil {
 		return "", fmt.Errorf("error creating data directory: %w", err)
 	}
 
-	sourceInfo, err := os.Stat(binPath) //nolint:gosec // G703: binPath from os.Executable()/ZAPAROO_APP.
+	sourceInfo, err := fs.Stat(binPath)
 	if err != nil {
 		return "", fmt.Errorf("error statting binary: %w", err)
 	}
 	sourceChangeTimeNS := fileChangeTimeNS(sourceInfo)
 
-	manifest, manifestErr := readServiceBinaryManifest(dataDir)
+	manifest, manifestErr := readServiceBinaryManifest(fs, dataDir)
 	if manifestErr != nil && !errors.Is(manifestErr, os.ErrNotExist) {
 		log.Debug().Err(manifestErr).Msg("error reading service binary manifest")
 	}
@@ -279,7 +290,7 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 		servicePath := serviceCachePath(dataDir, binPath, manifest.SourceHash)
 		if filepath.Clean(manifest.ServicePath) == filepath.Clean(servicePath) &&
 			serviceCachePathValid(manifest.ServicePath, dataDir) {
-			cachedInfo, statErr := os.Stat(manifest.ServicePath)
+			cachedInfo, statErr := fs.Stat(manifest.ServicePath)
 			switch {
 			case statErr == nil && manifest.matchesServiceMetadata(cachedInfo):
 				log.Debug().
@@ -301,7 +312,7 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 	}
 
 	hashStarted := time.Now()
-	sourceHash, err := hashFileSHA256(binPath)
+	sourceHash, err := hashFileSHA256(fs, binPath)
 	if err != nil {
 		return "", err
 	}
@@ -311,21 +322,21 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 		Msg("hashed service source binary")
 	servicePath := serviceCachePath(dataDir, binPath, sourceHash)
 
-	if _, statErr := os.Stat(servicePath); statErr != nil {
+	if _, statErr := fs.Stat(servicePath); statErr != nil {
 		if !errors.Is(statErr, os.ErrNotExist) {
 			return "", fmt.Errorf("error checking service binary: %w", statErr)
 		}
-		copyErr := copyServiceBinary(binPath, servicePath)
+		copyErr := copyServiceBinary(fs, binPath, servicePath)
 		if copyErr != nil {
 			return "", copyErr
 		}
 	} else {
-		cachedHash, hashErr := hashFileSHA256(servicePath)
+		cachedHash, hashErr := hashFileSHA256(fs, servicePath)
 		if hashErr != nil {
 			return "", hashErr
 		}
 		if cachedHash != sourceHash {
-			copyErr := copyServiceBinary(binPath, servicePath)
+			copyErr := copyServiceBinary(fs, binPath, servicePath)
 			if copyErr != nil {
 				return "", copyErr
 			}
@@ -334,7 +345,7 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 		}
 	}
 
-	serviceInfo, err := os.Stat(servicePath)
+	serviceInfo, err := fs.Stat(servicePath)
 	if err != nil {
 		return "", fmt.Errorf("error statting service binary: %w", err)
 	}
@@ -350,7 +361,7 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 		ServiceModTimeNS:    serviceInfo.ModTime().UnixNano(),
 		ServiceChangeTimeNS: fileChangeTimeNS(serviceInfo),
 	}
-	manifestWriteErr := writeServiceBinaryManifest(dataDir, &newManifest)
+	manifestWriteErr := writeServiceBinaryManifest(fs, dataDir, &newManifest)
 	if manifestWriteErr != nil {
 		return "", manifestWriteErr
 	}
@@ -365,26 +376,25 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 	return servicePath, nil
 }
 
-func copyServiceBinary(binPath, servicePath string) error {
+func copyServiceBinary(fs afero.Fs, binPath, servicePath string) error {
 	ext := filepath.Ext(binPath)
 	name := strings.TrimSuffix(filepath.Base(binPath), ext)
 
-	//nolint:gosec // G304: binPath from os.Executable()
-	binFile, err := os.Open(binPath)
+	binFile, err := fs.Open(binPath)
 	if err != nil {
 		return fmt.Errorf("error opening binary: %w", err)
 	}
 	defer func() { _ = binFile.Close() }()
 
-	tmpFile, err := os.CreateTemp(filepath.Dir(servicePath), name+".*.tmp")
+	tmpFile, err := afero.TempFile(fs, filepath.Dir(servicePath), name+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("error creating temporary service binary: %w", err)
 	}
 	tmpPath := tmpFile.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
+	defer func() { _ = fs.Remove(tmpPath) }()
 	defer func() { _ = tmpFile.Close() }()
 
-	chmodErr := tmpFile.Chmod(0o700)
+	chmodErr := fs.Chmod(tmpPath, 0o700)
 	if chmodErr != nil {
 		return fmt.Errorf("error setting service binary permissions: %w", chmodErr)
 	}
@@ -396,7 +406,7 @@ func copyServiceBinary(binPath, servicePath string) error {
 	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("error closing service binary: %w", err)
 	}
-	if err := os.Rename(tmpPath, servicePath); err != nil {
+	if err := fs.Rename(tmpPath, servicePath); err != nil {
 		return fmt.Errorf("error replacing service binary: %w", err)
 	}
 
@@ -408,9 +418,9 @@ func copyServiceBinary(binPath, servicePath string) error {
 func (*Service) cleanupServiceBinary() {
 }
 
-func readServiceBinaryManifest(dataDir string) (*serviceBinaryManifest, error) {
+func readServiceBinaryManifest(fs afero.Fs, dataDir string) (*serviceBinaryManifest, error) {
 	path := filepath.Join(dataDir, serviceManifestName)
-	data, err := os.ReadFile(path) //nolint:gosec // G304: path is internal DataDir manifest.
+	data, err := afero.ReadFile(fs, path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil, os.ErrNotExist
@@ -425,7 +435,7 @@ func readServiceBinaryManifest(dataDir string) (*serviceBinaryManifest, error) {
 	return &manifest, nil
 }
 
-func writeServiceBinaryManifest(dataDir string, manifest *serviceBinaryManifest) error {
+func writeServiceBinaryManifest(fs afero.Fs, dataDir string, manifest *serviceBinaryManifest) error {
 	data, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return fmt.Errorf("error encoding service binary manifest: %w", err)
@@ -433,12 +443,12 @@ func writeServiceBinaryManifest(dataDir string, manifest *serviceBinaryManifest)
 	data = append(data, '\n')
 
 	manifestPath := filepath.Join(dataDir, serviceManifestName)
-	tmpFile, err := os.CreateTemp(dataDir, serviceManifestName+".*.tmp")
+	tmpFile, err := afero.TempFile(fs, dataDir, serviceManifestName+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("error creating temporary service binary manifest: %w", err)
 	}
 	tmpPath := tmpFile.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
+	defer func() { _ = fs.Remove(tmpPath) }()
 	defer func() { _ = tmpFile.Close() }()
 
 	if _, err := tmpFile.Write(data); err != nil {
@@ -447,7 +457,7 @@ func writeServiceBinaryManifest(dataDir string, manifest *serviceBinaryManifest)
 	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("error closing service binary manifest: %w", err)
 	}
-	if err := os.Rename(tmpPath, manifestPath); err != nil {
+	if err := fs.Rename(tmpPath, manifestPath); err != nil {
 		return fmt.Errorf("error replacing service binary manifest: %w", err)
 	}
 	return nil
@@ -504,7 +514,10 @@ func timespecFieldNS(field reflect.Value) int64 {
 }
 
 func serviceCachePath(dataDir, binPath, sourceHash string) string {
-	ext := filepath.Ext(binPath)
+	ext := ""
+	if filepath.Ext(binPath) == ".sh" {
+		ext = ".sh"
+	}
 	return filepath.Join(dataDir, "zaparoo."+shortServiceHash(sourceHash)+ext)
 }
 
@@ -515,9 +528,8 @@ func shortServiceHash(sourceHash string) string {
 	return sourceHash[:serviceHashLength]
 }
 
-func hashFileSHA256(path string) (string, error) {
-	//nolint:gosec // G304: path from os.Executable()/ZAPAROO_APP.
-	file, err := os.Open(path)
+func hashFileSHA256(fs afero.Fs, path string) (string, error) {
+	file, err := fs.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("error opening binary for hash: %w", err)
 	}
@@ -573,8 +585,9 @@ func isServiceCacheFilename(name string) bool {
 }
 
 func (s *Service) cleanupServiceBinaries(currentPath, previousPath string) {
+	fs := s.filesystem()
 	dataDir := helpers.DataDir(s.pl)
-	entries, err := os.ReadDir(dataDir)
+	entries, err := afero.ReadDir(fs, dataDir)
 	if err != nil {
 		log.Debug().Err(err).Msg("error reading service binary cache directory")
 		return
@@ -592,12 +605,7 @@ func (s *Service) cleanupServiceBinaries(currentPath, previousPath string) {
 		if entry.IsDir() || !isServiceCacheFilename(entry.Name()) {
 			continue
 		}
-		info, infoErr := entry.Info()
-		if infoErr != nil {
-			log.Debug().Err(infoErr).Str("name", entry.Name()).Msg("error checking service binary cache file")
-			continue
-		}
-		candidates = append(candidates, info)
+		candidates = append(candidates, entry)
 	}
 
 	for len(keep) < serviceCopiesToKeep {
@@ -618,7 +626,7 @@ func (s *Service) cleanupServiceBinaries(currentPath, previousPath string) {
 			log.Debug().Str("path", cleanPath).Msg("skipping cleanup of running service binary")
 			continue
 		}
-		if err := os.Remove(cleanPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fs.Remove(cleanPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Debug().Err(err).Str("path", cleanPath).Msg("error removing stale service binary")
 		}
 	}

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -25,6 +25,9 @@ package daemon
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,6 +36,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -45,7 +49,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
 	"github.com/rs/zerolog/log"
 )
 
@@ -75,12 +78,34 @@ type commandWaiter struct {
 	once sync.Once
 }
 
+type serviceBinaryManifest struct {
+	SourcePath          string `json:"sourcePath"`
+	SourceHash          string `json:"sourceHash"`
+	ServicePath         string `json:"servicePath"`
+	SourceSize          int64  `json:"sourceSize"`
+	SourceModTimeNS     int64  `json:"sourceModTimeNs"`
+	SourceChangeTimeNS  int64  `json:"sourceChangeTimeNs"`
+	ServiceSize         int64  `json:"serviceSize"`
+	ServiceModTimeNS    int64  `json:"serviceModTimeNs"`
+	ServiceChangeTimeNS int64  `json:"serviceChangeTimeNs"`
+}
+
+type restartExecConfig struct {
+	serviceBin string
+	binPath    string
+	args       []string
+	env        []string
+}
+
 const (
 	serviceStopTimeout        = 10 * time.Second
 	serviceKillTimeout        = 3 * time.Second
 	serviceStopPollInterval   = 100 * time.Millisecond
 	servicePortReleaseTimeout = 3 * time.Second
 	daemonReadyTimeout        = 3 * time.Second
+	serviceManifestName       = "service_manifest.json"
+	serviceHashLength         = 16
+	serviceCopiesToKeep       = 2
 )
 
 func NewService(args ServiceArgs) (*Service, error) {
@@ -228,69 +253,415 @@ func (s *Service) stopService() error {
 		return err
 	}
 
-	s.cleanupServiceBinary()
-
 	return nil
 }
 
-// prepareBinary copies the binary into DataDir so the original can be
-// replaced by external updaters while the service is running.
+// prepareBinary keeps a persistent service binary cache in DataDir so the
+// package-manager target can be replaced while the daemon is running.
 func (s *Service) prepareBinary(binPath string) (string, error) {
-	ext := filepath.Ext(binPath)
-	name := strings.TrimSuffix(filepath.Base(binPath), ext)
-	copyName := name + ".service" + ext
+	started := time.Now()
 	dataDir := helpers.DataDir(s.pl)
-	copyPath := filepath.Join(dataDir, copyName)
-
 	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return "", fmt.Errorf("error creating data directory: %w", err)
 	}
 
-	equal, eqErr := filesEqual(binPath, copyPath)
-	if eqErr != nil {
-		log.Warn().Err(eqErr).Msg("error comparing binaries, proceeding with copy")
-	} else if equal {
-		log.Debug().Msg("skipping binary copy, service binary already up to date")
-		return copyPath, nil
+	sourceInfo, err := os.Stat(binPath) //nolint:gosec // G703: binPath from os.Executable()/ZAPAROO_APP.
+	if err != nil {
+		return "", fmt.Errorf("error statting binary: %w", err)
 	}
+	sourceChangeTimeNS := fileChangeTimeNS(sourceInfo)
+
+	manifest, manifestErr := readServiceBinaryManifest(dataDir)
+	if manifestErr != nil && !errors.Is(manifestErr, os.ErrNotExist) {
+		log.Debug().Err(manifestErr).Msg("error reading service binary manifest")
+	}
+	if manifest != nil && manifest.matchesSourceMetadata(binPath, sourceInfo, sourceChangeTimeNS) {
+		servicePath := serviceCachePath(dataDir, binPath, manifest.SourceHash)
+		if filepath.Clean(manifest.ServicePath) == filepath.Clean(servicePath) &&
+			serviceCachePathValid(manifest.ServicePath, dataDir) {
+			cachedInfo, statErr := os.Stat(manifest.ServicePath)
+			switch {
+			case statErr == nil && manifest.matchesServiceMetadata(cachedInfo):
+				log.Debug().
+					Str("path", manifest.ServicePath).
+					Dur("duration", time.Since(started)).
+					Msg("using cached service binary from manifest")
+				s.cleanupServiceBinaries(manifest.ServicePath, "")
+				return manifest.ServicePath, nil
+			case statErr != nil && !errors.Is(statErr, os.ErrNotExist):
+				log.Debug().Err(statErr).Str("path", manifest.ServicePath).Msg("error checking cached service binary")
+			case statErr == nil:
+				log.Debug().
+					Str("path", manifest.ServicePath).
+					Int64("cachedSize", cachedInfo.Size()).
+					Int64("cachedModTimeNs", cachedInfo.ModTime().UnixNano()).
+					Msg("cached service binary metadata mismatch")
+			}
+		}
+	}
+
+	hashStarted := time.Now()
+	sourceHash, err := hashFileSHA256(binPath)
+	if err != nil {
+		return "", err
+	}
+	log.Debug().
+		Dur("duration", time.Since(hashStarted)).
+		Str("hash", shortServiceHash(sourceHash)).
+		Msg("hashed service source binary")
+	servicePath := serviceCachePath(dataDir, binPath, sourceHash)
+
+	if _, statErr := os.Stat(servicePath); statErr != nil {
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return "", fmt.Errorf("error checking service binary: %w", statErr)
+		}
+		copyErr := copyServiceBinary(binPath, servicePath)
+		if copyErr != nil {
+			return "", copyErr
+		}
+	} else {
+		cachedHash, hashErr := hashFileSHA256(servicePath)
+		if hashErr != nil {
+			return "", hashErr
+		}
+		if cachedHash != sourceHash {
+			copyErr := copyServiceBinary(binPath, servicePath)
+			if copyErr != nil {
+				return "", copyErr
+			}
+		} else {
+			log.Debug().Str("path", servicePath).Msg("using existing hashed service binary")
+		}
+	}
+
+	serviceInfo, err := os.Stat(servicePath)
+	if err != nil {
+		return "", fmt.Errorf("error statting service binary: %w", err)
+	}
+
+	newManifest := serviceBinaryManifest{
+		SourcePath:          binPath,
+		SourceSize:          sourceInfo.Size(),
+		SourceModTimeNS:     sourceInfo.ModTime().UnixNano(),
+		SourceChangeTimeNS:  sourceChangeTimeNS,
+		SourceHash:          sourceHash,
+		ServicePath:         servicePath,
+		ServiceSize:         serviceInfo.Size(),
+		ServiceModTimeNS:    serviceInfo.ModTime().UnixNano(),
+		ServiceChangeTimeNS: fileChangeTimeNS(serviceInfo),
+	}
+	manifestWriteErr := writeServiceBinaryManifest(dataDir, &newManifest)
+	if manifestWriteErr != nil {
+		return "", manifestWriteErr
+	}
+
+	previousPath := ""
+	if manifest != nil {
+		previousPath = manifest.ServicePath
+	}
+	s.cleanupServiceBinaries(servicePath, previousPath)
+
+	log.Debug().Str("path", servicePath).Dur("duration", time.Since(started)).Msg("prepared service binary")
+	return servicePath, nil
+}
+
+func copyServiceBinary(binPath, servicePath string) error {
+	ext := filepath.Ext(binPath)
+	name := strings.TrimSuffix(filepath.Base(binPath), ext)
 
 	//nolint:gosec // G304: binPath from os.Executable()
 	binFile, err := os.Open(binPath)
 	if err != nil {
-		return "", fmt.Errorf("error opening binary: %w", err)
+		return fmt.Errorf("error opening binary: %w", err)
 	}
 	defer func() { _ = binFile.Close() }()
 
-	//nolint:gosec // creates service binary copy in data dir
-	copyFile, err := os.OpenFile(
-		copyPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o700,
-	)
+	tmpFile, err := os.CreateTemp(filepath.Dir(servicePath), name+".*.tmp")
 	if err != nil {
-		return "", fmt.Errorf("error creating service binary: %w", err)
+		return fmt.Errorf("error creating temporary service binary: %w", err)
 	}
-	defer func() { _ = copyFile.Close() }()
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	defer func() { _ = tmpFile.Close() }()
 
-	_, err = io.Copy(copyFile, binFile)
+	chmodErr := tmpFile.Chmod(0o700)
+	if chmodErr != nil {
+		return fmt.Errorf("error setting service binary permissions: %w", chmodErr)
+	}
+
+	_, err = io.Copy(tmpFile, binFile)
 	if err != nil {
-		return "", fmt.Errorf("error copying binary: %w", err)
+		return fmt.Errorf("error copying binary: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing service binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, servicePath); err != nil {
+		return fmt.Errorf("error replacing service binary: %w", err)
 	}
 
-	return copyPath, nil
+	return nil
 }
 
-// cleanupServiceBinary removes the service binary copy from DataDir.
-func (s *Service) cleanupServiceBinary() {
-	exePath, err := os.Executable()
+// cleanupServiceBinary is retained for older call paths. Cached service
+// binaries are pruned by prepareBinary so normal restarts can reuse them.
+func (*Service) cleanupServiceBinary() {
+}
+
+func readServiceBinaryManifest(dataDir string) (*serviceBinaryManifest, error) {
+	path := filepath.Join(dataDir, serviceManifestName)
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is internal DataDir manifest.
 	if err != nil {
-		log.Error().Err(err).Msg("error getting executable path")
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, os.ErrNotExist
+		}
+		return nil, fmt.Errorf("error reading service binary manifest: %w", err)
+	}
+
+	var manifest serviceBinaryManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("error parsing service binary manifest: %w", err)
+	}
+	return &manifest, nil
+}
+
+func writeServiceBinaryManifest(dataDir string, manifest *serviceBinaryManifest) error {
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error encoding service binary manifest: %w", err)
+	}
+	data = append(data, '\n')
+
+	manifestPath := filepath.Join(dataDir, serviceManifestName)
+	tmpFile, err := os.CreateTemp(dataDir, serviceManifestName+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("error creating temporary service binary manifest: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	defer func() { _ = tmpFile.Close() }()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		return fmt.Errorf("error writing service binary manifest: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("error closing service binary manifest: %w", err)
+	}
+	if err := os.Rename(tmpPath, manifestPath); err != nil {
+		return fmt.Errorf("error replacing service binary manifest: %w", err)
+	}
+	return nil
+}
+
+func (m *serviceBinaryManifest) matchesSourceMetadata(binPath string, info os.FileInfo, changeTimeNS int64) bool {
+	return m.SourcePath == binPath &&
+		m.SourceSize == info.Size() &&
+		m.SourceModTimeNS == info.ModTime().UnixNano() &&
+		m.SourceChangeTimeNS != 0 &&
+		m.SourceChangeTimeNS == changeTimeNS &&
+		m.SourceHash != "" &&
+		m.ServicePath != ""
+}
+
+func (m *serviceBinaryManifest) matchesServiceMetadata(info os.FileInfo) bool {
+	return m.ServiceSize == info.Size() &&
+		m.ServiceModTimeNS == info.ModTime().UnixNano() &&
+		m.ServiceChangeTimeNS != 0 &&
+		m.ServiceChangeTimeNS == fileChangeTimeNS(info)
+}
+
+func fileChangeTimeNS(info os.FileInfo) int64 {
+	if info == nil || info.Sys() == nil {
+		return 0
+	}
+
+	sys := reflect.ValueOf(info.Sys())
+	if sys.Kind() == reflect.Pointer {
+		sys = sys.Elem()
+	}
+	if !sys.IsValid() || sys.Kind() != reflect.Struct {
+		return 0
+	}
+
+	for _, name := range []string{"Ctim", "Ctimespec"} {
+		if ns := timespecFieldNS(sys.FieldByName(name)); ns != 0 {
+			return ns
+		}
+	}
+	return 0
+}
+
+func timespecFieldNS(field reflect.Value) int64 {
+	if !field.IsValid() || field.Kind() != reflect.Struct {
+		return 0
+	}
+	sec := field.FieldByName("Sec")
+	nsec := field.FieldByName("Nsec")
+	if !sec.IsValid() || !nsec.IsValid() || !sec.CanInt() || !nsec.CanInt() {
+		return 0
+	}
+	return sec.Int()*int64(time.Second) + nsec.Int()
+}
+
+func serviceCachePath(dataDir, binPath, sourceHash string) string {
+	ext := filepath.Ext(binPath)
+	return filepath.Join(dataDir, "zaparoo."+shortServiceHash(sourceHash)+ext)
+}
+
+func shortServiceHash(sourceHash string) string {
+	if len(sourceHash) <= serviceHashLength {
+		return sourceHash
+	}
+	return sourceHash[:serviceHashLength]
+}
+
+func hashFileSHA256(path string) (string, error) {
+	//nolint:gosec // G304: path from os.Executable()/ZAPAROO_APP.
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("error opening binary for hash: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, file); err != nil {
+		return "", fmt.Errorf("error hashing binary: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func serviceCachePathValid(path, dataDir string) bool {
+	if path == "" {
+		return false
+	}
+	cleanDataDir := filepath.Clean(dataDir)
+	cleanPath := filepath.Clean(path)
+	rel, err := filepath.Rel(cleanDataDir, cleanPath)
+	if err != nil || rel == "." || filepath.IsAbs(rel) || strings.HasPrefix(rel, "..") {
+		return false
+	}
+	return filepath.Dir(rel) == "." && isServiceCacheFilename(filepath.Base(rel))
+}
+
+func isServiceCacheFilename(name string) bool {
+	if name == "" || strings.Contains(name, string(filepath.Separator)) {
+		return false
+	}
+	if name == "zaparoo.service" || name == "zaparoo.service.sh" {
+		return true
+	}
+
+	const prefix = "zaparoo."
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	hash := strings.TrimPrefix(name, prefix)
+	if strings.HasSuffix(hash, ".sh") {
+		hash = strings.TrimSuffix(hash, ".sh")
+	} else if strings.Contains(hash, ".") {
+		return false
+	}
+	if len(hash) != serviceHashLength {
+		return false
+	}
+	for _, c := range hash {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) cleanupServiceBinaries(currentPath, previousPath string) {
+	dataDir := helpers.DataDir(s.pl)
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		log.Debug().Err(err).Msg("error reading service binary cache directory")
 		return
 	}
-	if !strings.HasPrefix(exePath, helpers.DataDir(s.pl)) {
-		return
+
+	keep := map[string]struct{}{}
+	for _, path := range []string{currentPath, previousPath} {
+		if serviceCachePathValid(path, dataDir) {
+			keep[filepath.Clean(path)] = struct{}{}
+		}
 	}
-	if rmErr := os.Remove(exePath); rmErr != nil {
-		log.Error().Err(rmErr).Msg("error removing service binary")
+
+	candidates := make([]os.FileInfo, 0)
+	for _, entry := range entries {
+		if entry.IsDir() || !isServiceCacheFilename(entry.Name()) {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			log.Debug().Err(infoErr).Str("name", entry.Name()).Msg("error checking service binary cache file")
+			continue
+		}
+		candidates = append(candidates, info)
 	}
+
+	for len(keep) < serviceCopiesToKeep {
+		newestPath := newestUnkeptServiceBinary(dataDir, candidates, keep)
+		if newestPath == "" {
+			break
+		}
+		keep[newestPath] = struct{}{}
+	}
+
+	for _, info := range candidates {
+		path := filepath.Join(dataDir, info.Name())
+		cleanPath := filepath.Clean(path)
+		if _, ok := keep[cleanPath]; ok {
+			continue
+		}
+		if s.isRunningServiceBinary(cleanPath) {
+			log.Debug().Str("path", cleanPath).Msg("skipping cleanup of running service binary")
+			continue
+		}
+		if err := os.Remove(cleanPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Debug().Err(err).Str("path", cleanPath).Msg("error removing stale service binary")
+		}
+	}
+}
+
+func newestUnkeptServiceBinary(dataDir string, candidates []os.FileInfo, keep map[string]struct{}) string {
+	newestPath := ""
+	var newestModTime time.Time
+	for _, info := range candidates {
+		path := filepath.Clean(filepath.Join(dataDir, info.Name()))
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		if newestPath == "" || info.ModTime().After(newestModTime) {
+			newestPath = path
+			newestModTime = info.ModTime()
+		}
+	}
+	return newestPath
+}
+
+func (s *Service) isRunningServiceBinary(path string) bool {
+	pid, err := s.Pid()
+	if err != nil || pid <= 0 || runtime.GOOS != "linux" {
+		return false
+	}
+	cleanPath := filepath.Clean(path)
+	exePath, err := os.Readlink(filepath.Join(procDir(), strconv.Itoa(pid), "exe"))
+	if err == nil && filepath.Clean(exePath) == cleanPath {
+		return true
+	}
+
+	cmdlinePath := filepath.Join(procDir(), strconv.Itoa(pid), "cmdline")
+	cmdline, err := os.ReadFile(cmdlinePath) //nolint:gosec // reads process status for service management
+	if err != nil {
+		return false
+	}
+	for _, arg := range strings.Split(string(cmdline), "\x00") {
+		if filepath.Clean(arg) == cleanPath {
+			return true
+		}
+	}
+	return false
 }
 
 // filesEqual reports whether the files at pathA and pathB have identical
@@ -425,11 +796,7 @@ func (s *Service) startService() {
 	}
 
 	if result.RestartRequested != nil && result.RestartRequested() {
-		log.Info().Msg("restart requested, re-executing binary")
-
-		s.cleanupServiceBinary()
-
-		if execErr := restart.Exec(); execErr != nil {
+		if execErr := s.restartServiceBinary(); execErr != nil {
 			log.Error().Err(execErr).Msg("failed to re-exec for restart")
 			os.Exit(1)
 		}
@@ -438,8 +805,77 @@ func (s *Service) startService() {
 	os.Exit(0)
 }
 
+func (s *Service) restartServiceBinary() error {
+	cfg, err := s.restartExecConfig(os.Args, os.Environ())
+	if err != nil {
+		return err
+	}
+
+	log.Info().
+		Str("binary", cfg.serviceBin).
+		Str("source", cfg.binPath).
+		Strs("args", os.Args).
+		Msg("restart requested, re-executing service binary")
+
+	//nolint:gosec // Safe: serviceBin is prepared from os.Executable() or ZAPAROO_APP.
+	err = syscall.Exec(cfg.serviceBin, cfg.args, cfg.env)
+	return fmt.Errorf("exec failed: %w", err)
+}
+
+func (s *Service) restartExecConfig(
+	args []string,
+	env []string,
+) (restartExecConfig, error) {
+	binPath, err := serviceSourceBinaryPath()
+	if err != nil {
+		return restartExecConfig{}, err
+	}
+	serviceBin, err := s.prepareBinary(binPath)
+	if err != nil {
+		return restartExecConfig{}, err
+	}
+	return restartExecConfig{
+		serviceBin: serviceBin,
+		binPath:    binPath,
+		args:       serviceExecArgs(serviceBin, args),
+		env:        serviceExecEnv(env, binPath),
+	}, nil
+}
+
+func serviceSourceBinaryPath() (string, error) {
+	if appPath := os.Getenv(config.AppEnv); appPath != "" {
+		return appPath, nil
+	}
+	exePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("error getting absolute binary path: %w", err)
+	}
+	return exePath, nil
+}
+
+func serviceExecEnv(env []string, appPath string) []string {
+	appEnv := fmt.Sprintf("%s=%s", config.AppEnv, appPath)
+	for i, value := range env {
+		if strings.HasPrefix(value, config.AppEnv+"=") {
+			env[i] = appEnv
+			return env
+		}
+	}
+	return append(env, appEnv)
+}
+
+func serviceExecArgs(serviceBin string, args []string) []string {
+	if len(args) == 0 {
+		return []string{serviceBin}
+	}
+	execArgs := append([]string(nil), args...)
+	execArgs[0] = serviceBin
+	return execArgs
+}
+
 // Start a new service daemon in the background.
 func (s *Service) Start() error {
+	started := time.Now()
 	running, err := s.Running()
 	if err != nil {
 		return err
@@ -448,29 +884,23 @@ func (s *Service) Start() error {
 		return errors.New("service already running")
 	}
 
-	binPath := ""
-	appPath := os.Getenv(config.AppEnv)
-	if appPath != "" {
-		binPath = appPath
-	} else {
-		exePath, exeErr := os.Executable()
-		if exeErr != nil {
-			return fmt.Errorf("error getting absolute binary path: %w", exeErr)
-		}
-		binPath = exePath
+	binPath, err := serviceSourceBinaryPath()
+	if err != nil {
+		return err
 	}
 
+	prepareStarted := time.Now()
 	serviceBin, err := s.prepareBinary(binPath)
 	if err != nil {
 		return err
 	}
+	log.Debug().Dur("duration", time.Since(prepareStarted)).Msg("service binary prepared")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	//nolint:gosec // Safe: executes copy of current binary for service restart
 	cmd := exec.CommandContext(ctx, serviceBin, "-service", "exec")
-	env := os.Environ()
-	cmd.Env = env
+	cmd.Env = serviceExecEnv(os.Environ(), binPath)
 
 	// Detach from parent: create new session
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -483,12 +913,13 @@ func (s *Service) Start() error {
 	if _, statErr := os.Stat(configPath); statErr == nil {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", config.CfgEnv, configPath))
 	}
-	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", config.AppEnv, binPath))
 
+	cmdStarted := time.Now()
 	err = cmd.Start()
 	if err != nil {
 		return fmt.Errorf("error starting service: %w", err)
 	}
+	log.Debug().Dur("duration", time.Since(cmdStarted)).Msg("service process start command completed")
 
 	err = cmd.Process.Release()
 	if err != nil {
@@ -504,7 +935,7 @@ func (s *Service) Start() error {
 		return fmt.Errorf("service started but PID file not found: %w", pidErr)
 	}
 
-	log.Info().Msgf("service process started with PID %d", pid)
+	log.Info().Int("pid", pid).Dur("duration", time.Since(started)).Msg("service process started")
 
 	running, err = s.Running()
 	if err != nil {
@@ -655,14 +1086,7 @@ func procDir() string {
 }
 
 func pathLooksLikeServiceBinary(path, dataDir string) bool {
-	if path == "" || dataDir == "" {
-		return false
-	}
-	rel, err := filepath.Rel(filepath.Clean(dataDir), filepath.Clean(path))
-	if err != nil || rel == "." || filepath.IsAbs(rel) || strings.HasPrefix(rel, "..") {
-		return false
-	}
-	return filepath.Dir(rel) == "." && strings.Contains(filepath.Base(rel), ".service")
+	return serviceCachePathValid(path, dataDir)
 }
 
 func waitForPIDExit(

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -293,6 +293,9 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 			cachedInfo, statErr := fs.Stat(manifest.ServicePath)
 			switch {
 			case statErr == nil && manifest.matchesServiceMetadata(cachedInfo):
+				if chmodErr := ensureServiceBinaryExecutable(fs, manifest.ServicePath); chmodErr != nil {
+					return "", chmodErr
+				}
 				log.Debug().
 					Str("path", manifest.ServicePath).
 					Dur("duration", time.Since(started)).
@@ -341,6 +344,9 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 				return "", copyErr
 			}
 		} else {
+			if chmodErr := ensureServiceBinaryExecutable(fs, servicePath); chmodErr != nil {
+				return "", chmodErr
+			}
 			log.Debug().Str("path", servicePath).Msg("using existing hashed service binary")
 		}
 	}
@@ -374,6 +380,13 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 
 	log.Debug().Str("path", servicePath).Dur("duration", time.Since(started)).Msg("prepared service binary")
 	return servicePath, nil
+}
+
+func ensureServiceBinaryExecutable(fs afero.Fs, servicePath string) error {
+	if err := fs.Chmod(servicePath, 0o700); err != nil {
+		return fmt.Errorf("error setting service binary permissions: %w", err)
+	}
+	return nil
 }
 
 func copyServiceBinary(fs afero.Fs, binPath, servicePath string) error {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -139,6 +140,44 @@ func TestPrepareBinary_NoExtension(t *testing.T) {
 	result, err := svc.prepareBinary(srcPath)
 	require.NoError(t, err)
 	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}$`, filepath.Base(result))
+}
+
+func TestPrepareBinary_StripsNonShellExtension(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.bin")
+	require.NoError(t, os.WriteFile(srcPath, []byte("data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}$`, filepath.Base(result))
+	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
+}
+
+func TestPrepareBinary_UsesConfiguredFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{
+		DataDir: string(filepath.Separator) + "data",
+		TempDir: string(filepath.Separator) + "temp",
+	})
+	svc := &Service{pl: pl, fs: fs}
+	srcPath := filepath.Join(string(filepath.Separator), "src", "zaparoo.bin")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(srcPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, srcPath, []byte("data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}$`, filepath.Base(result))
+	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
+
+	content, err := afero.ReadFile(fs, result)
+	require.NoError(t, err)
+	assert.Equal(t, "data", string(content))
 }
 
 func TestPrepareBinary_MissingSource(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -87,7 +87,7 @@ func writeFakeServiceScript(t *testing.T, pidFile, eventLog string) string {
 	return scriptPath
 }
 
-func TestPrepareBinary_CopiesWithServiceSuffix(t *testing.T) {
+func TestPrepareBinary_CopiesWithHashName(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t)
 
@@ -99,10 +99,11 @@ func TestPrepareBinary_CopiesWithServiceSuffix(t *testing.T) {
 	result, err := svc.prepareBinary(srcPath)
 	require.NoError(t, err)
 
-	assert.Equal(t, "zaparoo.service.sh", filepath.Base(result))
+	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}\.sh$`, filepath.Base(result))
 	content, err := os.ReadFile(result) //nolint:gosec // G304: test file
 	require.NoError(t, err)
 	assert.Equal(t, "binary-content", string(content))
+	assert.FileExists(t, filepath.Join(svc.pl.Settings().DataDir, serviceManifestName))
 }
 
 func TestPrepareBinary_CreatesDataDir(t *testing.T) {
@@ -137,7 +138,7 @@ func TestPrepareBinary_NoExtension(t *testing.T) {
 
 	result, err := svc.prepareBinary(srcPath)
 	require.NoError(t, err)
-	assert.Equal(t, "zaparoo.service", filepath.Base(result))
+	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}$`, filepath.Base(result))
 }
 
 func TestPrepareBinary_MissingSource(t *testing.T) {
@@ -147,7 +148,7 @@ func TestPrepareBinary_MissingSource(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist", "binary")
 	_, err := svc.prepareBinary(missing)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "error opening binary")
+	assert.Contains(t, err.Error(), "error statting binary")
 }
 
 func TestCleanupServiceBinary_RemovesFromDataDir(t *testing.T) {
@@ -267,6 +268,73 @@ func TestPrepareBinary_SkipsCopyWhenIdentical(t *testing.T) {
 	assert.Equal(t, pastTime.Unix(), info.ModTime().Unix(), "file should not have been rewritten")
 }
 
+func TestPrepareBinary_RepairsCorruptCachedCopy(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(result, []byte("cached-copy"), 0o600))
+
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, result, result2)
+
+	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
+	require.NoError(t, err)
+	assert.Equal(t, "binary-data", string(content))
+}
+
+func TestPrepareBinary_RepairsCachedCopyWhenSizeDiffers(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(result, []byte("short"), 0o600))
+
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, result, result2)
+
+	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
+	require.NoError(t, err)
+	assert.Equal(t, "binary-data", string(content))
+}
+
+func TestPrepareBinary_DetectsSameSizeSameModTimeSourceChange(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	modTime := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-1"), 0o600))
+	require.NoError(t, os.Chtimes(srcPath, modTime, modTime))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-2"), 0o600))
+	require.NoError(t, os.Chtimes(srcPath, modTime, modTime))
+
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.NotEqual(t, result, result2)
+
+	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
+	require.NoError(t, err)
+	assert.Equal(t, "version-2", string(content))
+}
+
 func TestPrepareBinary_CopiesWhenContentDiffers(t *testing.T) {
 	t.Parallel()
 	svc := newTestService(t)
@@ -280,14 +348,84 @@ func TestPrepareBinary_CopiesWhenContentDiffers(t *testing.T) {
 
 	// Update the source binary.
 	require.NoError(t, os.WriteFile(srcPath, []byte("version-2"), 0o600))
+	futureTime := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(srcPath, futureTime, futureTime))
 
 	result2, err := svc.prepareBinary(srcPath)
 	require.NoError(t, err)
-	assert.Equal(t, result, result2)
+	assert.NotEqual(t, result, result2)
 
 	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
 	require.NoError(t, err)
 	assert.Equal(t, "version-2", string(content))
+}
+
+func TestPrepareBinary_ReplacesViaTemporaryFile(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-1"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(srcPath, []byte("version-2"), 0o600))
+	futureTime := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(srcPath, futureTime, futureTime))
+	result2, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, result, result2)
+	content, err := os.ReadFile(result2) //nolint:gosec // G304: test file
+	require.NoError(t, err)
+	assert.Equal(t, "version-2", string(content))
+
+	info, err := os.Stat(result2)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o700), info.Mode().Perm())
+
+	entries, err := os.ReadDir(filepath.Dir(result2))
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), ".tmp")
+	}
+}
+
+func TestPrepareBinary_CleansLegacyAndStaleServiceCopies(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	dataDir := svc.pl.Settings().DataDir
+
+	legacyPath := filepath.Join(dataDir, "zaparoo.service.sh")
+	stalePath := filepath.Join(dataDir, "zaparoo.0000000000000000.sh")
+	previousPath := filepath.Join(dataDir, "zaparoo.1111111111111111.sh")
+	unrelatedPath := filepath.Join(dataDir, "backup.2222222222222222.sh")
+	wrongHashPath := filepath.Join(dataDir, "zaparoo.33333333333333333.sh")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("legacy"), 0o600))
+	require.NoError(t, os.WriteFile(stalePath, []byte("stale"), 0o600))
+	require.NoError(t, os.WriteFile(previousPath, []byte("previous"), 0o600))
+	require.NoError(t, os.WriteFile(unrelatedPath, []byte("unrelated"), 0o600))
+	require.NoError(t, os.WriteFile(wrongHashPath, []byte("wrong hash"), 0o600))
+	oldTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(stalePath, oldTime, oldTime))
+	require.NoError(t, os.Chtimes(legacyPath, oldTime.Add(time.Hour), oldTime.Add(time.Hour)))
+	require.NoError(t, os.Chtimes(previousPath, oldTime.Add(2*time.Hour), oldTime.Add(2*time.Hour)))
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("current"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	assert.FileExists(t, result)
+	assert.FileExists(t, previousPath)
+	assert.FileExists(t, unrelatedPath)
+	assert.FileExists(t, wrongHashPath)
+	assert.NoFileExists(t, legacyPath)
+	assert.NoFileExists(t, stalePath)
 }
 
 func TestRestart_StartsWhenServiceNotRunning(t *testing.T) {
@@ -477,9 +615,46 @@ func TestPathLooksLikeServiceBinaryRequiresDirectDataDirChild(t *testing.T) {
 	dataDir := filepath.Join(t.TempDir(), "data")
 	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.service"), dataDir))
 	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.service.sh"), dataDir))
+	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.0123456789abcdef.sh"), dataDir))
+	assert.True(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.0123456789abcdef"), dataDir))
 	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "nested", "zaparoo.service"), dataDir))
 	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.not-a-hash.sh"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "zaparoo.0123456789abcdef.bin"), dataDir))
+	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(dataDir, "fake-service.0123456789abcdef.sh"), dataDir))
 	assert.False(t, pathLooksLikeServiceBinary(filepath.Join(t.TempDir(), "zaparoo.service"), dataDir))
+}
+
+func TestServiceExecEnvPreservesOriginalAppPath(t *testing.T) {
+	t.Parallel()
+
+	env := serviceExecEnv([]string{"A=B", config.AppEnv + "=/old/path"}, "/new/path")
+	assert.Equal(t, []string{"A=B", config.AppEnv + "=/new/path"}, env)
+
+	env = serviceExecEnv([]string{"A=B"}, "/new/path")
+	assert.Equal(t, []string{"A=B", config.AppEnv + "=/new/path"}, env)
+}
+
+func TestRestartExecConfigUsesCachedServiceBinary(t *testing.T) {
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-data"), 0o600))
+	t.Setenv(config.AppEnv, srcPath)
+
+	cfg, err := svc.restartExecConfig(
+		[]string{"old-cache", "-service", "exec"},
+		[]string{"A=B", config.AppEnv + "=/old/path"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, srcPath, cfg.binPath)
+	assert.NotEqual(t, srcPath, cfg.serviceBin)
+	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}\.sh$`, filepath.Base(cfg.serviceBin))
+	assert.FileExists(t, cfg.serviceBin)
+	assert.Equal(t, []string{cfg.serviceBin, "-service", "exec"}, cfg.args)
+	assert.Contains(t, cfg.env, config.AppEnv+"="+srcPath)
 }
 
 func TestRunningRemovesStalePIDFile(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -24,6 +24,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"os/exec"
@@ -156,26 +157,48 @@ func TestPrepareBinary_StripsNonShellExtension(t *testing.T) {
 	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
 }
 
+func TestPrepareBinary_NormalizesReusedCachedBinaryPermissions(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo")
+	require.NoError(t, os.WriteFile(srcPath, []byte("data"), 0o600))
+
+	result, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(result, 0o600))
+	require.NoError(t, os.Remove(filepath.Join(svc.pl.Settings().DataDir, serviceManifestName)))
+
+	result, err = svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(result)
+	require.NoError(t, err)
+	assert.Equal(t, fs.FileMode(0o700), info.Mode().Perm())
+	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
+}
+
 func TestPrepareBinary_UsesConfiguredFilesystem(t *testing.T) {
 	t.Parallel()
 
-	fs := afero.NewMemMapFs()
+	memFS := afero.NewMemMapFs()
 	pl := mocks.NewMockPlatform()
 	pl.On("Settings").Return(platforms.Settings{
 		DataDir: string(filepath.Separator) + "data",
 		TempDir: string(filepath.Separator) + "temp",
 	})
-	svc := &Service{pl: pl, fs: fs}
+	svc := &Service{pl: pl, fs: memFS}
 	srcPath := filepath.Join(string(filepath.Separator), "src", "zaparoo.bin")
-	require.NoError(t, fs.MkdirAll(filepath.Dir(srcPath), 0o750))
-	require.NoError(t, afero.WriteFile(fs, srcPath, []byte("data"), 0o600))
+	require.NoError(t, memFS.MkdirAll(filepath.Dir(srcPath), 0o750))
+	require.NoError(t, afero.WriteFile(memFS, srcPath, []byte("data"), 0o600))
 
 	result, err := svc.prepareBinary(srcPath)
 	require.NoError(t, err)
 	assert.Regexp(t, `^zaparoo\.[0-9a-f]{16}$`, filepath.Base(result))
 	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
 
-	content, err := afero.ReadFile(fs, result)
+	content, err := afero.ReadFile(memFS, result)
 	require.NoError(t, err)
 	assert.Equal(t, "data", string(content))
 }


### PR DESCRIPTION
## Summary
- Replace the legacy browse cache with browse v2 directory, entry, and count tables backed by a migration and optimization invalidation.
- Update media browse queries and system root responses to use the new index while falling back safely before the index is ready.
- Improve service binary restart handling with hashed cached binaries and manifest-based reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate system-root entries from browse results via improved deduplication.

* **Refactor**
  * Rolled out a new Browse v2 indexing pipeline and storage model for more reliable browsing and counts.
  * Improved service binary caching with persistent cached copies, safer replace/prune logic, and updated restart behavior.
  * Enhanced name-first-character normalization for more accurate browse filtering.

* **Tests**
  * Expanded tests for browse deduplication, Browse v2 flows, and service binary caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->