### PR TITLE
fix(api): normalize media path test expectations

### DIFF
--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -170,7 +170,7 @@ func TestHandleMediaMeta_MediaNotFound(t *testing.T) {
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	system := database.System{DBID: 100, SystemID: "NES", Name: "NES"}
-	mediaPath := filepath.Join("games", "missing.rom")
+	mediaPath := filepath.ToSlash(filepath.Join("games", "missing.rom"))
 	mockDB.On("FindSystemBySystemID", "NES").Return(system, nil)
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, system.DBID, mediaPath).
 		Return((*database.Media)(nil), nil)

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -1030,7 +1030,7 @@ func TestHandleMediaSearch_RelativePaths(t *testing.T) {
 
 	rootDir := filepath.Join(string(filepath.Separator), "mock", "roms")
 	mediaPath := filepath.Join(rootDir, "NES", "mario.nes")
-	relPath := filepath.Join("NES", "mario.nes")
+	relPath := filepath.ToSlash(filepath.Join("NES", "mario.nes"))
 
 	// LauncherCache with NES launcher folder matching the mock rootDir.
 	launcherCache := &phelpers.LauncherCache{}


### PR DESCRIPTION
## Summary
- Normalize media path test expectations to slash-separated API paths
- Fix Windows-only failures in media search and media meta tests

Verified with `go test ./pkg/api/methods/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to improve cross-platform compatibility verification for media-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->