### PR TITLE
feat(api): add batch media metadata lookups

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -285,10 +285,12 @@ None.
 
 | Key              | Type     | Required | Description                                |
 | :--------------- | :------- | :------- | :----------------------------------------- |
+| mediaId          | number   | No       | Opaque media database row ID for efficient follow-up `media.meta` and `media.image` requests. Omitted when the active path cannot be resolved in the current media database. |
 | launcherId       | string   | Yes      | ID of the launcher.                        |
 | systemId         | string   | Yes      | ID of the system.                          |
 | systemName       | string   | Yes      | Display name of the system.                |
 | mediaPath        | string   | Yes      | Path to the media file.                    |
+| relativePath     | string   | No       | Launcher-relative convenience path, when it can be derived. Not a stable media identity. |
 | mediaName        | string   | Yes      | Display name of the media.                 |
 | started          | string   | Yes      | Timestamp when media started in RFC3339 format. |
 | zapScript        | string   | Yes      | ZapScript command to launch this media item. |
@@ -375,6 +377,7 @@ An object:
 
 | Key       | Type                     | Required | Description                                                                                                 |
 | :-------- | :----------------------- | :------- | :---------------------------------------------------------------------------------------------------------- |
+| mediaId   | number                   | No       | Opaque media database row ID for efficient follow-up `media.meta` and `media.image` requests.                |
 | system    | [System](#system-object) | Yes      | System which the media has been indexed under.                                                              |
 | name      | string                   | Yes      | A human-readable version of the result's filename without a file extension.                                 |
 | path      | string                   | Yes      | Canonical indexed media path. Use with `system.id` for `media.meta` and `media.image`. |
@@ -431,6 +434,7 @@ An object:
   "result": {
     "results": [
       {
+        "mediaId": 123,
         "name": "240p Test Suite (PD) v0.03 tepples",
         "path": "/media/fat/games/Gameboy/240p Test Suite (PD) v0.03 tepples.gb",
         "relativePath": "Gameboy/240p Test Suite (PD) v0.03 tepples.gb",
@@ -487,6 +491,7 @@ An object:
   "result": {
     "results": [
       {
+        "mediaId": 456,
         "name": "Super Mario Bros.",
         "path": "/media/fat/games/NES/Super Mario Bros.nes",
         "relativePath": "NES/Super Mario Bros.nes",
@@ -554,6 +559,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 
 | Key          | Type     | Required | Description                                                                                      |
 | :----------- | :------- | :------- | :----------------------------------------------------------------------------------------------- |
+| mediaId      | number   | No       | Opaque media database row ID. Present on `media` entries for efficient follow-up `media.meta` and `media.image` requests. |
 | name         | string   | Yes      | Display name of the entry.                                                                       |
 | path         | string   | Yes      | Full path to the entry.                                                                          |
 | type         | string   | Yes      | Entry type: `root`, `directory`, or `media`.                                                     |
@@ -643,6 +649,7 @@ All parameters are optional. When called with no parameters, returns root entrie
         "fileCount": 42
       },
       {
+        "mediaId": 42,
         "name": "Super Mario World",
         "path": "/roms/SNES/Super Mario World.sfc",
         "type": "media",
@@ -655,6 +662,7 @@ All parameters are optional. When called with no parameters, returns root entrie
         ]
       },
       {
+        "mediaId": 43,
         "name": "The Legend of Zelda - A Link to the Past",
         "path": "/roms/SNES/The Legend of Zelda - A Link to the Past.sfc",
         "type": "media",
@@ -917,11 +925,13 @@ Returns an [ActiveMedia](#active-media-object) object if media is currently acti
   "jsonrpc": "2.0",
   "id": "47f80537-7a5d-11ef-9c7b-020304050607",
   "result": {
+    "mediaId": 42,
     "started": "2024-09-24T17:49:42.938167429+08:00",
     "launcherId": "SNES",
     "systemId": "SNES",
     "systemName": "Super Nintendo Entertainment System",
     "mediaPath": "/roms/snes/Super Mario World (USA).sfc",
+    "relativePath": "snes/Super Mario World (USA).sfc",
     "mediaName": "Super Mario World",
     "zapScript": "@SNES/Super Mario World",
     "launcherControls": ["load_state", "save_state", "toggle_menu"]
@@ -1000,10 +1010,12 @@ Optionally, an object:
 
 | Key        | Type   | Required | Description                                            |
 | :--------- | :----- | :------- | :----------------------------------------------------- |
+| mediaId    | number | No       | Opaque media database row ID for efficient follow-up `media.meta` and `media.image` requests. Omitted when the history path cannot be resolved in the current media database. |
 | systemId   | string | Yes      | ID of the system.                                      |
 | systemName | string | Yes      | Display name of the system.                            |
 | mediaName  | string | Yes      | Display name of the media.                             |
 | mediaPath  | string | Yes      | Path to the media file.                                |
+| relativePath | string | No     | Launcher-relative convenience path, when it can be derived. Not a stable media identity. |
 | launcherId | string | Yes      | ID of the launcher used.                               |
 | startedAt  | string | Yes      | Timestamp when media started in RFC3339 format.        |
 | endedAt    | string | No       | Timestamp when media stopped in RFC3339 format. Omitted if media is still active. |
@@ -1033,10 +1045,12 @@ Optionally, an object:
   "result": {
     "entries": [
       {
+        "mediaId": 42,
         "systemId": "SNES",
         "systemName": "Super Nintendo Entertainment System",
         "mediaName": "Super Mario World",
         "mediaPath": "/roms/snes/Super Mario World (USA).sfc",
+        "relativePath": "snes/Super Mario World (USA).sfc",
         "launcherId": "SNES",
         "startedAt": "2025-01-22T14:30:00Z",
         "endedAt": "2025-01-22T15:15:30Z",
@@ -1076,10 +1090,12 @@ Optionally, an object:
 
 | Key           | Type   | Required | Description                                            |
 | :------------ | :----- | :------- | :----------------------------------------------------- |
+| mediaId       | number | No       | Opaque media database row ID for efficient follow-up `media.meta` and `media.image` requests. Omitted when the history path cannot be resolved in the current media database. |
 | systemId      | string | Yes      | ID of the system.                                      |
 | systemName    | string | Yes      | Display name of the system.                            |
 | mediaName     | string | Yes      | Display name of the media.                             |
 | mediaPath     | string | Yes      | Path to the media file (from most recent session).     |
+| relativePath  | string | No       | Launcher-relative convenience path, when it can be derived. Not a stable media identity. |
 | totalPlayTime | number | Yes      | Total play time across all sessions in seconds.        |
 | sessionCount  | number | Yes      | Number of play sessions.                               |
 | lastPlayedAt  | string | Yes      | Timestamp of the most recent session in RFC3339 format. |
@@ -1109,10 +1125,12 @@ Optionally, an object:
   "result": {
     "entries": [
       {
+        "mediaId": 42,
         "systemId": "SNES",
         "systemName": "Super Nintendo Entertainment System",
         "mediaName": "Super Mario World",
         "mediaPath": "/roms/snes/Super Mario World (USA).sfc",
+        "relativePath": "snes/Super Mario World (USA).sfc",
         "totalPlayTime": 7200,
         "sessionCount": 12,
         "lastPlayedAt": "2026-02-14T20:30:00Z"
@@ -1148,6 +1166,7 @@ An object:
 
 | Key        | Type                         | Required | Description                                                                                 |
 | :--------- | :--------------------------- | :------- | :------------------------------------------------------------------------------------------ |
+| mediaId    | number                       | No       | Opaque media database row ID for efficient follow-up `media.meta` and `media.image` requests. |
 | system     | [System](#system-object)     | Yes      | System the media was found in.                                                              |
 | name       | string                       | Yes      | Display name of the matched media.                                                          |
 | path       | string                       | Yes      | Path to the media file.                                                                     |
@@ -1180,6 +1199,7 @@ An object:
   "id": "b2c3d4e5-7a5d-11ef-9c7b-020304050607",
   "result": {
     "match": {
+      "mediaId": 42,
       "system": {
         "id": "SNES",
         "name": "Super Nintendo Entertainment System",
@@ -1223,7 +1243,7 @@ An object:
 
 Return the full metadata graph for one indexed media row, including its title, system, tags, and scraped properties.
 
-Use this when a client has a search, browse, or lookup result and needs all metadata attached to that row. Identify media by the result's `system.id` and canonical `path`. Launcher-relative paths in the `systemId/path` shape are accepted as a compatibility fallback when they resolve to exactly one indexed media row. Properties are separated by scope: `media.properties` applies to the specific ROM/file row, and `media.title.properties` applies to the shared title.
+Use this when a client has a search, browse, or lookup result and needs all metadata attached to that row. Identify media by the result's `mediaId` when available, or by `system.id` and canonical `path`. Launcher-relative paths in the `system/path` shape are accepted as a compatibility fallback when they resolve to exactly one indexed media row. Properties are separated by scope: `media.properties` applies to the specific ROM/file row, and `media.title.properties` applies to the shared title.
 
 #### Parameters
 
@@ -1231,8 +1251,12 @@ An object:
 
 | Key    | Type   | Required | Description                         |
 | :----- | :----- | :------- | :---------------------------------- |
-| system | string | Yes      | System ID for the media row.        |
-| path   | string | Yes      | Canonical indexed media path.       |
+| mediaId | number | No      | Opaque media database row ID from search, browse, or lookup. Cannot be mixed with `system`/`path`. |
+| system | string | No       | System ID for the media row. Required when `mediaId` is omitted. |
+| path   | string | No       | Canonical indexed media path. Required when `mediaId` is omitted. |
+| items  | object[] | No     | Batch request items. Each item uses either `mediaId` or `system`/`path`. Maximum 100 items. Cannot be mixed with top-level media ref fields. |
+
+Single requests return the existing single `media` response shape. Batch requests return `{ "items": [...] }` in input order. Each batch item contains either `media` or `error`, so one missing media row does not fail the whole batch.
 
 #### Result
 
@@ -1331,6 +1355,22 @@ Property keys are canonical type tags such as `property:description`, `property:
 }
 ```
 
+##### Batch Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "d4e5f6a7-7a5d-11ef-9c7b-020304050608",
+  "method": "media.meta",
+  "params": {
+    "items": [
+      {"mediaId": 42},
+      {"system": "SNES", "path": "/roms/snes/Super Metroid.sfc"}
+    ]
+  }
+}
+```
+
 ### media.image
 
 Return the best matching image for one indexed media row as base64-encoded data.
@@ -1339,15 +1379,19 @@ Return the best matching image for one indexed media row as base64-encoded data.
 
 #### Parameters
 
-An object identifying the media row by `(system, path)`. Canonical indexed paths are preferred. Launcher-relative paths in the `systemId/path` shape are accepted as a compatibility fallback when they resolve to exactly one indexed media row.
+An object identifying the media row by `mediaId` or `(system, path)`. Canonical indexed paths are preferred. Launcher-relative paths in the `system/path` shape are accepted as a compatibility fallback when they resolve to exactly one indexed media row.
 
 | Key        | Type     | Required | Description                                                                 |
 | :--------- | :------- | :------- | :-------------------------------------------------------------------------- |
-| system     | string   | Yes      | System ID.                                                                  |
-| path       | string   | Yes      | Canonical indexed media path.                                               |
+| mediaId    | number   | No       | Opaque media database row ID from search, browse, or lookup. Cannot be mixed with `system`/`path`. |
+| system     | string   | No       | System ID. Required when `mediaId` is omitted.                              |
+| path       | string   | No       | Canonical indexed media path. Required when `mediaId` is omitted.            |
 | imageTypes | string[] | No       | Image type preference order. Defaults to `image`, `boxart`, `screenshot`, `wheel`, `titleshot`, `map`, `marquee`, `fanart`. |
+| items      | object[] | No       | Batch request items. Each item uses either `mediaId` or `system`/`path`, and may include item-level `imageTypes`. Maximum 50 items. Cannot be mixed with top-level media ref fields. |
 
 Supported image type values are `image`, `boxart`, `screenshot`, `wheel`, `titleshot`, `map`, `marquee`, and `fanart`. They resolve to canonical property tags such as `property:image-image` and `property:image-boxart`.
+
+Single requests return the existing single image response shape. Batch requests return `{ "items": [...] }` in input order. Each batch item contains either `image` or `error`. Top-level `imageTypes` applies to all batch items unless an item has its own `imageTypes` override.
 
 #### Result
 
@@ -1371,6 +1415,23 @@ Supported image type values are `image`, `boxart`, `screenshot`, `wheel`, `title
     "system": "SNES",
     "path": "/roms/snes/Super Mario World.sfc",
     "imageTypes": ["boxart", "image"]
+  }
+}
+```
+
+##### Batch Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "e5f6a7b8-7a5d-11ef-9c7b-020304050608",
+  "method": "media.image",
+  "params": {
+    "imageTypes": ["boxart", "image"],
+    "items": [
+      {"mediaId": 42},
+      {"mediaId": 43, "imageTypes": ["screenshot"]}
+    ]
   }
 }
 ```

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -131,8 +131,8 @@ JSON-RPC methods:
 | `media.scrape` | Starts a scraper run as a background operation |
 | `media.scrape.status` | Returns the latest scraper status snapshot |
 | `media.scrape.cancel` | Cancels the active scraper run |
-| `media.meta` | Returns tags and properties for one media row and its title |
-| `media.image` | Returns the best matching image property as base64 data |
+| `media.meta` | Returns tags and properties for one or more media rows and their titles |
+| `media.image` | Returns the best matching image property as base64 data for one or more media rows |
 | `media.clean.orphans` | Removes missing media rows and orphaned related data |
 
 `media.scrape` params:
@@ -162,6 +162,6 @@ Progress is queryable with `media.scrape.status` and broadcast as `media.scrapin
 
 Only one scraper can run at a time, and scraping is mutually exclusive with media indexing.
 
-`media.meta` returns the full metadata graph for a single media row: media-level tags and properties, title-level tags and properties, and the stored system identity.
+`media.meta` returns the full metadata graph for media rows: media-level tags and properties, title-level tags and properties, and the stored system identity. Single requests accept `mediaId` or `system`/`path` and keep the single-response shape; batch requests use `items` and return per-item results.
 
-`media.image` accepts image type preferences such as `image`, `boxart`, `screenshot`, `wheel`, `titleshot`, `map`, `marquee`, and `fanart`. These resolve to canonical image property tags; for example `boxart` becomes `property:image-boxart` and `image` becomes `property:image-image`. Media-level properties are preferred over title-level properties for the same type. Stale file paths are removed automatically and lookup falls through to the next available source.
+`media.image` accepts image type preferences such as `image`, `boxart`, `screenshot`, `wheel`, `titleshot`, `map`, `marquee`, and `fanart`. These resolve to canonical image property tags; for example `boxart` becomes `property:image-boxart` and `image` becomes `property:image-image`. Media-level properties are preferred over title-level properties for the same type. Stale file paths are removed automatically and lookup falls through to the next available source. Batch requests use `items`, with optional per-item `imageTypes` overriding the top-level preference order.

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -692,6 +692,7 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		}
 
 		results = append(results, models.SearchResultMedia{
+			MediaID:   result.MediaID,
 			RelPath:   relPath,
 			System:    resultSystem,
 			Name:      result.Name,
@@ -801,9 +802,16 @@ func HandleMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 			}
 		}
 		zapScript := database.BuildTitleZapScript(system.ID, activeMedia.Name, zapScriptTags)
+		mediaIDs := mediaResponseMediaIDs(&env, []mediaPathRef{{
+			SystemID: system.ID,
+			Path:     activeMedia.Path,
+		}})
+		ref := mediaPathRef{SystemID: system.ID, Path: activeMedia.Path}
 
 		activeResp := models.ActiveMediaResponse{
 			ActiveMedia: models.ActiveMedia{
+				MediaID:          mediaIDs[ref],
+				RelPath:          mediaResponseRelativePath(&env, system.ID, activeMedia.Path),
 				Started:          activeMedia.Started,
 				LauncherID:       activeMedia.LauncherID,
 				SystemID:         system.ID,
@@ -939,9 +947,16 @@ func HandleActiveMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		}
 	}
 	zapScript := database.BuildTitleZapScript(media.SystemID, media.Name, zapScriptTags)
+	mediaIDs := mediaResponseMediaIDs(&env, []mediaPathRef{{
+		SystemID: media.SystemID,
+		Path:     media.Path,
+	}})
+	ref := mediaPathRef{SystemID: media.SystemID, Path: media.Path}
 
 	resp := models.ActiveMediaResponse{
 		ActiveMedia: models.ActiveMedia{
+			MediaID:          mediaIDs[ref],
+			RelPath:          mediaResponseRelativePath(&env, media.SystemID, media.Path),
 			Started:          media.Started,
 			LauncherID:       media.LauncherID,
 			SystemID:         media.SystemID,

--- a/pkg/api/methods/media_active_test.go
+++ b/pkg/api/methods/media_active_test.go
@@ -22,12 +22,16 @@ package methods
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -113,6 +117,10 @@ func TestHandleActiveMedia_WithZapScript(t *testing.T) {
 			if tt.setupMock != nil {
 				tt.setupMock(mockMediaDB)
 			}
+			mockMediaDB.On("FindSystemBySystemID", mock.Anything).
+				Return(database.System{}, errors.New("not found")).Maybe()
+			mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
+				Return(map[string]database.Media{}, nil).Maybe()
 
 			// Create state and set active media
 			appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
@@ -234,6 +242,10 @@ func TestHandleMedia_WithActiveMediaZapScript(t *testing.T) {
 			if tt.setupMock != nil {
 				tt.setupMock(mockMediaDB)
 			}
+			mockMediaDB.On("FindSystemBySystemID", mock.Anything).
+				Return(database.System{}, errors.New("not found")).Maybe()
+			mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
+				Return(map[string]database.Media{}, nil).Maybe()
 
 			// Standard mocks needed for HandleMedia to work
 			// GetOptimizationStatus is always called
@@ -282,6 +294,107 @@ func TestHandleMedia_WithActiveMediaZapScript(t *testing.T) {
 	}
 }
 
+func TestHandleActiveMedia_WithMediaIDAndRelativePath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	rootDir := filepath.Join(string(filepath.Separator), "mock", "roms")
+	mediaPath := filepath.Join(rootDir, "NES", "game.nes")
+	relPath := filepath.ToSlash(filepath.Join("NES", "game.nes"))
+
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "nes-launcher", SystemID: "NES", Folders: []string{"NES"}},
+	})
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	defer appState.StopService()
+	drainNotifications(t, ns)
+	appState.SetActiveMedia(models.NewActiveMedia("NES", "NES", mediaPath, "Game", "test-launcher"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
+		Return([]database.TagInfo{}, nil)
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
+		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		State:         appState,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
+	}
+
+	result, err := HandleActiveMedia(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.ActiveMediaResponse)
+	require.True(t, ok)
+	assert.Equal(t, int64(42), resp.MediaID)
+	require.NotNil(t, resp.RelPath)
+	assert.Equal(t, relPath, *resp.RelPath)
+	assert.Equal(t, "@NES/Game", resp.ZapScript)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMedia_WithActiveMediaIDAndRelativePath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	rootDir := filepath.Join(string(filepath.Separator), "mock", "roms")
+	mediaPath := filepath.Join(rootDir, "NES", "game.nes")
+	relPath := filepath.ToSlash(filepath.Join("NES", "game.nes"))
+
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "nes-launcher", SystemID: "NES", Folders: []string{"NES"}},
+	})
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	defer appState.StopService()
+	drainNotifications(t, ns)
+	appState.SetActiveMedia(models.NewActiveMedia("NES", "NES", mediaPath, "Game", "test-launcher"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
+		Return([]database.TagInfo{}, nil)
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
+		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+	mockMediaDB.On("GetOptimizationStatus").Return("", nil)
+	mockMediaDB.On("GetLastGenerated").Return(time.Now(), nil)
+	mockMediaDB.On("GetTotalMediaCount").Return(100, nil)
+	ClearIndexingStatus()
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		State:         appState,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
+	}
+
+	result, err := HandleMedia(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Active, 1)
+	assert.Equal(t, int64(42), resp.Active[0].MediaID)
+	require.NotNil(t, resp.Active[0].RelPath)
+	assert.Equal(t, relPath, *resp.Active[0].RelPath)
+	assert.Equal(t, "@NES/Game", resp.Active[0].ZapScript)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleActiveMedia_WithLauncherControls(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +411,10 @@ func TestHandleActiveMedia_WithLauncherControls(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, mock.Anything, mock.Anything).
 		Return([]database.TagInfo{}, nil)
+	mockMediaDB.On("FindSystemBySystemID", mock.Anything).
+		Return(database.System{}, errors.New("not found")).Maybe()
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]database.Media{}, nil).Maybe()
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),
@@ -328,6 +445,10 @@ func TestHandleActiveMedia_WithoutLauncherControls(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, mock.Anything, mock.Anything).
 		Return([]database.TagInfo{}, nil)
+	mockMediaDB.On("FindSystemBySystemID", mock.Anything).
+		Return(database.System{}, errors.New("not found")).Maybe()
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
+		Return(map[string]database.Media{}, nil).Maybe()
 
 	env := requests.RequestEnv{
 		Context:  context.Background(),

--- a/pkg/api/methods/media_batch.go
+++ b/pkg/api/methods/media_batch.go
@@ -209,6 +209,9 @@ func resolveMediaRefs(env *requests.RequestEnv, refs []mediaRefParam) ([]resolve
 	for id := range uniqueIDs {
 		ids = append(ids, id)
 	}
+	if len(ids) == 0 {
+		return resolved, nil
+	}
 	rows, err := env.Database.MediaDB.GetMediaWithTitleAndSystemByIDs(env.Context, ids)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get media: %w", err)

--- a/pkg/api/methods/media_batch.go
+++ b/pkg/api/methods/media_batch.go
@@ -1,0 +1,251 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+)
+
+const (
+	maxMediaMetaBatchItems  = 100
+	maxMediaImageBatchItems = 50
+)
+
+type mediaRefParam struct {
+	MediaID    *int64   `json:"mediaId,omitempty"`
+	System     string   `json:"system,omitempty"`
+	Path       string   `json:"path,omitempty"`
+	ImageTypes []string `json:"imageTypes,omitempty"`
+}
+
+type mediaBatchParams struct {
+	Items      []mediaRefParam `json:"items"`
+	ImageTypes []string        `json:"imageTypes,omitempty"`
+}
+
+type parsedMediaRequest struct {
+	Items      []mediaRefParam
+	ImageTypes []string
+	Batch      bool
+}
+
+type resolvedMediaItem struct {
+	Row *database.MediaFullRow
+	Err error
+}
+
+func parseMediaRequest(raw json.RawMessage, maxItems int) (parsedMediaRequest, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+	}
+
+	_, hasItems := fields["items"]
+	hasTopRef := hasJSONField(fields, "mediaId") || hasJSONField(fields, "system") || hasJSONField(fields, "path")
+	if hasItems && hasTopRef {
+		return parsedMediaRequest{}, models.ClientErrf("invalid params: items cannot be mixed with top-level media ref")
+	}
+
+	if hasItems {
+		var params mediaBatchParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+		}
+		if len(params.Items) == 0 {
+			return parsedMediaRequest{}, models.ClientErrf("invalid params: items is required")
+		}
+		if len(params.Items) > maxItems {
+			return parsedMediaRequest{}, models.ClientErrf("invalid params: items exceeds max of %d", maxItems)
+		}
+		for i := range params.Items {
+			if err := validateMediaRef(params.Items[i]); err != nil {
+				return parsedMediaRequest{}, models.ClientErrf("invalid params: items[%d]: %w", i, err)
+			}
+			if err := validateImageTypes(params.Items[i].ImageTypes); err != nil {
+				return parsedMediaRequest{}, models.ClientErrf("invalid params: items[%d]: %w", i, err)
+			}
+		}
+		if err := validateImageTypes(params.ImageTypes); err != nil {
+			return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+		}
+		return parsedMediaRequest{Items: params.Items, ImageTypes: params.ImageTypes, Batch: true}, nil
+	}
+
+	var item mediaRefParam
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+	}
+	if err := validateMediaRef(item); err != nil {
+		return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+	}
+	if err := validateImageTypes(item.ImageTypes); err != nil {
+		return parsedMediaRequest{}, models.ClientErrf("invalid params: %w", err)
+	}
+	return parsedMediaRequest{Items: []mediaRefParam{item}, ImageTypes: item.ImageTypes}, nil
+}
+
+func hasJSONField(fields map[string]json.RawMessage, name string) bool {
+	_, ok := fields[name]
+	return ok
+}
+
+func validateMediaRef(ref mediaRefParam) error {
+	if ref.MediaID != nil {
+		if *ref.MediaID <= 0 {
+			return validation.ErrInvalidParams
+		}
+		if ref.System != "" || ref.Path != "" {
+			return errors.New("mediaId cannot be mixed with system/path")
+		}
+		return nil
+	}
+	if ref.System == "" || ref.Path == "" {
+		return errors.New("mediaId or system/path is required")
+	}
+	return nil
+}
+
+func validateImageTypes(types []string) error {
+	for _, imageType := range types {
+		if imageType == "" {
+			return errors.New("imageTypes entries must be non-empty")
+		}
+	}
+	return nil
+}
+
+func resolveMediaRefs(env *requests.RequestEnv, refs []mediaRefParam) ([]resolvedMediaItem, error) {
+	resolved := make([]resolvedMediaItem, len(refs))
+	mediaIDs := make([]int64, len(refs))
+	uniqueIDs := make(map[int64]bool)
+
+	pathGroups := make(map[string][]string)
+	pathIndexes := make(map[string][]int)
+	for i, ref := range refs {
+		if ref.MediaID != nil {
+			mediaIDs[i] = *ref.MediaID
+			uniqueIDs[*ref.MediaID] = true
+			continue
+		}
+
+		key := ref.System + "\x00" + ref.Path
+		if len(pathIndexes[key]) == 0 {
+			pathGroups[ref.System] = append(pathGroups[ref.System], ref.Path)
+		}
+		pathIndexes[key] = append(pathIndexes[key], i)
+	}
+
+	for systemID, paths := range pathGroups {
+		system, err := env.Database.MediaDB.FindSystemBySystemID(systemID)
+		if errors.Is(err, sql.ErrNoRows) {
+			for _, path := range paths {
+				for _, index := range pathIndexes[systemID+"\x00"+path] {
+					resolved[index].Err = models.ClientErrf("system not found: %s", systemID)
+				}
+			}
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve system: %w", err)
+		}
+
+		exact, err := env.Database.MediaDB.FindMediaBySystemAndPaths(env.Context, system.DBID, paths)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find media: %w", err)
+		}
+
+		for _, path := range paths {
+			media, ok := exact[path]
+			if !ok {
+				fallback, fallbackErr := resolveRelativeMediaPath(env, system, path)
+				if fallbackErr != nil {
+					for _, index := range pathIndexes[systemID+"\x00"+path] {
+						resolved[index].Err = fallbackErr
+					}
+					continue
+				}
+				if fallback == nil {
+					for _, index := range pathIndexes[systemID+"\x00"+path] {
+						resolved[index].Err = models.ClientErrf("media not found: %s/%s", systemID, path)
+					}
+					continue
+				}
+				media = *fallback
+			}
+
+			for _, index := range pathIndexes[systemID+"\x00"+path] {
+				mediaIDs[index] = media.DBID
+				uniqueIDs[media.DBID] = true
+			}
+		}
+	}
+
+	ids := make([]int64, 0, len(uniqueIDs))
+	for id := range uniqueIDs {
+		ids = append(ids, id)
+	}
+	rows, err := env.Database.MediaDB.GetMediaWithTitleAndSystemByIDs(env.Context, ids)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media: %w", err)
+	}
+
+	for i, id := range mediaIDs {
+		if resolved[i].Err != nil {
+			continue
+		}
+		row, ok := rows[id]
+		if !ok {
+			resolved[i].Err = models.ClientErrf("media not found: mediaId %d", id)
+			continue
+		}
+		resolved[i].Row = &row
+	}
+
+	return resolved, nil
+}
+
+func uniqueMediaAndTitleIDs(resolved []resolvedMediaItem) (mediaIDs, titleIDs []int64) {
+	mediaSeen := make(map[int64]bool)
+	titleSeen := make(map[int64]bool)
+	mediaIDs = make([]int64, 0, len(resolved))
+	titleIDs = make([]int64, 0, len(resolved))
+	for _, item := range resolved {
+		if item.Row == nil {
+			continue
+		}
+		if !mediaSeen[item.Row.DBID] {
+			mediaSeen[item.Row.DBID] = true
+			mediaIDs = append(mediaIDs, item.Row.DBID)
+		}
+		if !titleSeen[item.Row.Title.DBID] {
+			titleSeen[item.Row.Title.DBID] = true
+			titleIDs = append(titleIDs, item.Row.Title.DBID)
+		}
+	}
+	return mediaIDs, titleIDs
+}

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -662,6 +662,7 @@ func buildMediaEntry(
 	rootDirs []string,
 ) models.BrowseEntry {
 	entry := models.BrowseEntry{
+		MediaID:  result.MediaID,
 		Name:     result.Name,
 		Path:     result.Path,
 		Type:     "media",

--- a/pkg/api/methods/media_history.go
+++ b/pkg/api/methods/media_history.go
@@ -84,11 +84,20 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	if hasNextPage {
 		entries = entries[:limit]
 	}
+	mediaRefs := make([]mediaPathRef, 0, len(entries))
+	for i := range entries {
+		mediaRefs = append(mediaRefs, mediaPathRef{
+			SystemID: entries[i].SystemID,
+			Path:     entries[i].MediaPath,
+		})
+	}
+	mediaIDs := mediaResponseMediaIDs(&env, mediaRefs)
 
 	responseEntries := make([]models.MediaHistoryResponseEntry, 0, len(entries))
 	for i := range entries {
 		entry := &entries[i]
 		startedAt := entry.StartTime.Format(time.RFC3339)
+		ref := mediaPathRef{SystemID: entry.SystemID, Path: entry.MediaPath}
 
 		var endedAt *string
 		if entry.EndTime != nil {
@@ -97,6 +106,8 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 		}
 
 		responseEntries = append(responseEntries, models.MediaHistoryResponseEntry{
+			MediaID:    mediaIDs[ref],
+			RelPath:    mediaResponseRelativePath(&env, entry.SystemID, entry.MediaPath),
 			SystemID:   entry.SystemID,
 			SystemName: entry.SystemName,
 			MediaName:  entry.MediaName,

--- a/pkg/api/methods/media_history_test.go
+++ b/pkg/api/methods/media_history_test.go
@@ -23,14 +23,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,6 +83,75 @@ func TestHandleMediaHistory_NoParams(t *testing.T) {
 	assert.Equal(t, 25, resp.Pagination.PageSize)
 
 	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_WithMediaIDAndRelativePath(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	now := time.Now()
+	rootDir := filepath.Join(string(filepath.Separator), "mock", "roms")
+	mediaPath := filepath.Join(rootDir, "NES", "smb.nes")
+	missingPath := filepath.Join(rootDir, "NES", "missing.nes")
+	relPath := filepath.ToSlash(filepath.Join("NES", "smb.nes"))
+
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "nes-launcher", SystemID: "NES", Folders: []string{"NES"}},
+	})
+
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).Return([]database.MediaHistoryEntry{
+		{
+			DBID:       1,
+			SystemID:   "NES",
+			SystemName: "Nintendo Entertainment System",
+			MediaName:  "Super Mario Bros",
+			MediaPath:  mediaPath,
+			LauncherID: "retroarch-nes",
+			StartTime:  now,
+			PlayTime:   1800,
+		},
+		{
+			DBID:       2,
+			SystemID:   "NES",
+			SystemName: "Nintendo Entertainment System",
+			MediaName:  "Missing Game",
+			MediaPath:  missingPath,
+			LauncherID: "retroarch-nes",
+			StartTime:  now,
+			PlayTime:   60,
+		},
+	}, nil)
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath, missingPath}).
+		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
+	}
+
+	result, err := HandleMediaHistory(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, 2)
+	assert.Equal(t, int64(42), resp.Entries[0].MediaID)
+	require.NotNil(t, resp.Entries[0].RelPath)
+	assert.Equal(t, relPath, *resp.Entries[0].RelPath)
+	assert.Zero(t, resp.Entries[1].MediaID)
+	require.NotNil(t, resp.Entries[1].RelPath)
+	assert.Equal(t, filepath.ToSlash(filepath.Join("NES", "missing.nes")), *resp.Entries[1].RelPath)
+
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestHandleMediaHistory_WithLimit(t *testing.T) {

--- a/pkg/api/methods/media_history_top.go
+++ b/pkg/api/methods/media_history_top.go
@@ -75,11 +75,22 @@ func HandleMediaHistoryTop(env requests.RequestEnv) (any, error) {
 		log.Error().Err(err).Msg("error getting media history top")
 		return nil, fmt.Errorf("error getting media history top: %w", err)
 	}
+	mediaRefs := make([]mediaPathRef, 0, len(entries))
+	for i := range entries {
+		mediaRefs = append(mediaRefs, mediaPathRef{
+			SystemID: entries[i].SystemID,
+			Path:     entries[i].MediaPath,
+		})
+	}
+	mediaIDs := mediaResponseMediaIDs(&env, mediaRefs)
 
 	responseEntries := make([]models.MediaHistoryTopEntry, 0, len(entries))
 	for i := range entries {
 		entry := &entries[i]
+		ref := mediaPathRef{SystemID: entry.SystemID, Path: entry.MediaPath}
 		responseEntries = append(responseEntries, models.MediaHistoryTopEntry{
+			MediaID:       mediaIDs[ref],
+			RelPath:       mediaResponseRelativePath(&env, entry.SystemID, entry.MediaPath),
 			SystemID:      entry.SystemID,
 			SystemName:    entry.SystemName,
 			MediaName:     entry.MediaName,

--- a/pkg/api/methods/media_history_top_test.go
+++ b/pkg/api/methods/media_history_top_test.go
@@ -23,14 +23,20 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -70,6 +76,60 @@ func TestHandleMediaHistoryTop_NoParams(t *testing.T) {
 	assert.Equal(t, now.Format(time.RFC3339), resp.Entries[0].LastPlayedAt)
 
 	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryTop_WithMediaIDAndRelativePath(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	now := time.Now()
+	rootDir := filepath.Join(string(filepath.Separator), "mock", "roms")
+	mediaPath := filepath.Join(rootDir, "SNES", "smw.sfc")
+	relPath := filepath.ToSlash(filepath.Join("SNES", "smw.sfc"))
+
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "snes-launcher", SystemID: "SNES", Folders: []string{"SNES"}},
+	})
+
+	mockUserDB.On("GetMediaHistoryTop", []string(nil), (*time.Time)(nil), 25).Return([]database.MediaHistoryTopEntry{
+		{
+			SystemID:      "SNES",
+			SystemName:    "Super Nintendo Entertainment System",
+			MediaName:     "Super Mario World",
+			MediaPath:     mediaPath,
+			TotalPlayTime: 7200,
+			SessionCount:  12,
+			LastPlayedAt:  now,
+		},
+	}, nil)
+	mockMediaDB.On("FindSystemBySystemID", "SNES").Return(database.System{DBID: 10}, nil)
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
+		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
+	}
+
+	result, err := HandleMediaHistoryTop(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaHistoryTopResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, int64(42), resp.Entries[0].MediaID)
+	require.NotNil(t, resp.Entries[0].RelPath)
+	assert.Equal(t, relPath, *resp.Entries[0].RelPath)
+
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestHandleMediaHistoryTop_CustomLimit(t *testing.T) {

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -83,6 +83,10 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	}
 
 	mediaIDs, titleIDs := uniqueMediaAndTitleIDs(resolved)
+	if params.Batch && len(mediaIDs) == 0 {
+		return buildMediaImageBatchErrorResponse(resolved), nil
+	}
+
 	db := env.Database.MediaDB
 	mediaProps, err := db.GetMediaPropertiesByMediaDBIDs(env.Context, mediaIDs)
 	if err != nil {
@@ -123,6 +127,18 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		items[i].Image = &image
 	}
 	return models.MediaImageBatchResponse{Items: items}, nil
+}
+
+func buildMediaImageBatchErrorResponse(resolved []resolvedMediaItem) models.MediaImageBatchResponse {
+	items := make([]models.MediaImageBatchItemResponse, len(resolved))
+	for i, item := range resolved {
+		if item.Err == nil {
+			continue
+		}
+		errText := item.Err.Error()
+		items[i].Error = &errText
+	}
+	return models.MediaImageBatchResponse{Items: items}
 }
 
 func handleMediaImageSinglePath(env *requests.RequestEnv, ref mediaRefParam) (any, error) {

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -20,13 +20,13 @@
 package methods
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/rs/zerolog/log"
@@ -69,34 +69,99 @@ func buildPropsMap(props []database.MediaProperty) map[string]database.MediaProp
 // priority over title-level properties for the same TypeTag. If a matching
 // property has no inline binary data the file at the Text path is read from disk.
 func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
-	var params models.MediaImageParams
-	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
-		return nil, models.ClientErrf("invalid params: %w", err)
+	params, err := parseMediaRequest(env.Params, maxMediaImageBatchItems)
+	if err != nil {
+		return nil, err
+	}
+	if !params.Batch && params.Items[0].MediaID == nil {
+		return handleMediaImageSinglePath(&env, params.Items[0])
 	}
 
-	ctx := env.Context
-	db := env.Database.MediaDB
-
-	row, err := resolveMediaBySystemAndPath(&env, params.System, params.Path)
+	resolved, err := resolveMediaRefs(&env, params.Items)
 	if err != nil {
 		return nil, err
 	}
 
-	mediaProps, err := db.GetMediaProperties(ctx, row.DBID)
+	mediaIDs, titleIDs := uniqueMediaAndTitleIDs(resolved)
+	db := env.Database.MediaDB
+	mediaProps, err := db.GetMediaPropertiesByMediaDBIDs(env.Context, mediaIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get media properties: %w", err)
 	}
-
-	titleProps, err := db.GetMediaTitleProperties(ctx, row.Title.DBID)
+	titleProps, err := db.GetMediaTitlePropertiesByMediaTitleDBIDs(env.Context, titleIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get title properties: %w", err)
 	}
 
-	prefs := params.ImageTypes
-	if len(prefs) == 0 {
-		prefs = defaultImageTypes
+	if !params.Batch {
+		if resolved[0].Err != nil {
+			return nil, resolved[0].Err
+		}
+		prefs := imagePrefs(params.ImageTypes, params.Items[0].ImageTypes)
+		return selectMediaImage(
+			env.Context, db, resolved[0].Row,
+			mediaProps[resolved[0].Row.DBID], titleProps[resolved[0].Row.Title.DBID], prefs,
+		)
 	}
 
+	items := make([]models.MediaImageBatchItemResponse, len(resolved))
+	for i, item := range resolved {
+		if item.Err != nil {
+			errText := item.Err.Error()
+			items[i].Error = &errText
+			continue
+		}
+		prefs := imagePrefs(params.ImageTypes, params.Items[i].ImageTypes)
+		image, imageErr := selectMediaImage(
+			env.Context, db, item.Row, mediaProps[item.Row.DBID], titleProps[item.Row.Title.DBID], prefs,
+		)
+		if imageErr != nil {
+			errText := imageErr.Error()
+			items[i].Error = &errText
+			continue
+		}
+		items[i].Image = &image
+	}
+	return models.MediaImageBatchResponse{Items: items}, nil
+}
+
+func handleMediaImageSinglePath(env *requests.RequestEnv, ref mediaRefParam) (any, error) {
+	db := env.Database.MediaDB
+	row, err := resolveMediaBySystemAndPath(env, ref.System, ref.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaProps, err := db.GetMediaProperties(env.Context, row.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media properties: %w", err)
+	}
+	titleProps, err := db.GetMediaTitleProperties(env.Context, row.Title.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get title properties: %w", err)
+	}
+
+	return selectMediaImage(env.Context, db, row, mediaProps, titleProps, imagePrefs(nil, ref.ImageTypes))
+}
+
+func imagePrefs(topLevel, itemLevel []string) []string {
+	if len(itemLevel) > 0 {
+		return itemLevel
+	}
+	if len(topLevel) > 0 {
+		return topLevel
+	}
+	return defaultImageTypes
+}
+
+func selectMediaImage(
+	ctx context.Context,
+	db database.MediaDBI,
+	row *database.MediaFullRow,
+	mediaProps []database.MediaProperty,
+	titleProps []database.MediaProperty,
+	prefs []string,
+) (models.MediaImageResponse, error) {
 	mediaMap := buildPropsMap(mediaProps)
 	titleMap := buildPropsMap(titleProps)
 
@@ -134,10 +199,13 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 
 			binary := prop.Binary
 			if len(binary) == 0 && prop.Text != "" {
-				binary, err = os.ReadFile(prop.Text)
-				if err != nil {
-					if !os.IsNotExist(err) {
-						return nil, fmt.Errorf("media.image: read image file %q: %w", prop.Text, err)
+				var readErr error
+				binary, readErr = os.ReadFile(prop.Text)
+				if readErr != nil {
+					if !os.IsNotExist(readErr) {
+						return models.MediaImageResponse{}, fmt.Errorf(
+							"media.image: read image file %q: %w", prop.Text, readErr,
+						)
 					}
 
 					// File is gone — remove the stale property.
@@ -163,10 +231,12 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 					prop = titleProp
 					binary = prop.Binary
 					if len(binary) == 0 && prop.Text != "" {
-						binary, err = os.ReadFile(prop.Text)
-						if err != nil {
-							if !os.IsNotExist(err) {
-								return nil, fmt.Errorf("media.image: read image file %q: %w", prop.Text, err)
+						binary, readErr = os.ReadFile(prop.Text)
+						if readErr != nil {
+							if !os.IsNotExist(readErr) {
+								return models.MediaImageResponse{}, fmt.Errorf(
+									"media.image: read image file %q: %w", prop.Text, readErr,
+								)
 							}
 
 							delErr := db.DeleteMediaTitleProperty(ctx, row.Title.DBID, prop.TypeTagDBID)
@@ -194,5 +264,7 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		}
 	}
 
-	return nil, models.ClientErrf("no image found for media: %s/%s", params.System, params.Path)
+	return models.MediaImageResponse{}, models.ClientErrf(
+		"no image found for media: %s/%s", row.System.SystemID, row.Path,
+	)
 }

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -251,6 +251,54 @@ func TestHandleMediaImage_ImageTypeResolvesToImageImage(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaImage_BatchByMediaIDUsesItemImageTypes(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := makeMediaFullRow(5, 50)
+	mediaBlob := []byte("media-boxart")
+	titleBlob := []byte("title-screenshot")
+
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil)
+	mockDB.On("GetMediaPropertiesByMediaDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{
+			row.DBID: {
+				{TypeTag: "property:image-boxart", ContentType: "image/png", Binary: mediaBlob},
+			},
+		}, nil)
+	mockDB.On("GetMediaTitlePropertiesByMediaTitleDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{
+			row.Title.DBID: {
+				{TypeTag: "property:image-screenshot", ContentType: "image/jpeg", Binary: titleBlob},
+			},
+		}, nil)
+
+	env := makeMediaImageEnv(t, mockDB, json.RawMessage(`{
+		"imageTypes": ["boxart"],
+		"items": [
+			{"mediaId": 5},
+			{"mediaId": 5, "imageTypes": ["screenshot"]},
+			{"mediaId": 999}
+		]
+	}`))
+	result, err := HandleMediaImage(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaImageBatchResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Items, 3)
+	require.NotNil(t, resp.Items[0].Image)
+	assert.Equal(t, "property:image-boxart", resp.Items[0].Image.TypeTag)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(mediaBlob), resp.Items[0].Image.Data)
+	require.NotNil(t, resp.Items[1].Image)
+	assert.Equal(t, "property:image-screenshot", resp.Items[1].Image.TypeTag)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(titleBlob), resp.Items[1].Image.Data)
+	require.NotNil(t, resp.Items[2].Error)
+	assert.Contains(t, *resp.Items[2].Error, "mediaId 999")
+	mockDB.AssertExpectations(t)
+}
+
 // TestHandleMediaImage_FileReadError_DeletesAndContinues verifies that when a
 // property's Text path is unreadable, the stale property is deleted (DB + in-memory)
 // and the handler continues to the next preference. With no remaining image the

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -228,13 +228,12 @@ func TestHandleMediaImage_BatchPathMissesSkipPropertyFetch(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
+	missingPath := filepath.Join("games", "missing.rom")
 	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{}, sql.ErrNoRows)
 
-	env := makeMediaImageEnv(t, mockDB, json.RawMessage(`{
-		"items": [
-			{"system":"NES","path":"games/missing.rom"}
-		]
-	}`))
+	env := makeMediaImageEnv(t, mockDB, json.RawMessage(
+		fmt.Sprintf(`{"items":[{"system":"NES","path":%q}]}`, missingPath),
+	))
 	result, err := HandleMediaImage(env)
 	require.NoError(t, err)
 

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -220,6 +221,28 @@ func TestHandleMediaImage_MediaNotFound(t *testing.T) {
 
 	var clientErr *models.ClientError
 	require.ErrorAs(t, err, &clientErr)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaImage_BatchPathMissesSkipPropertyFetch(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{}, sql.ErrNoRows)
+
+	env := makeMediaImageEnv(t, mockDB, json.RawMessage(`{
+		"items": [
+			{"system":"NES","path":"games/missing.rom"}
+		]
+	}`))
+	result, err := HandleMediaImage(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaImageBatchResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Items, 1)
+	require.NotNil(t, resp.Items[0].Error)
+	assert.Contains(t, *resp.Items[0].Error, "system not found: NES")
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/media_lookup.go
+++ b/pkg/api/methods/media_lookup.go
@@ -111,6 +111,7 @@ func HandleMediaLookup(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	return models.MediaLookupResponse{
 		Match: &models.MediaLookupMatch{
+			MediaID:    result.Result.MediaID,
 			RelPath:    relPath,
 			System:     resultSystem,
 			Name:       result.Result.Name,

--- a/pkg/api/methods/media_meta.go
+++ b/pkg/api/methods/media_meta.go
@@ -44,8 +44,15 @@ func HandleMediaMeta(env requests.RequestEnv) (any, error) { //nolint:gocritic /
 	if err != nil {
 		return nil, err
 	}
+	if !params.Batch && resolved[0].Err != nil {
+		return nil, resolved[0].Err
+	}
 
 	mediaIDs, titleIDs := uniqueMediaAndTitleIDs(resolved)
+	if params.Batch && len(mediaIDs) == 0 {
+		return buildMediaMetaBatchErrorResponse(resolved), nil
+	}
+
 	db := env.Database.MediaDB
 	mediaTags, err := db.GetMediaTagsByMediaDBIDs(env.Context, mediaIDs)
 	if err != nil {
@@ -65,9 +72,6 @@ func HandleMediaMeta(env requests.RequestEnv) (any, error) { //nolint:gocritic /
 	}
 
 	if !params.Batch {
-		if resolved[0].Err != nil {
-			return nil, resolved[0].Err
-		}
 		return buildMediaMetaResponse(
 			resolved[0].Row,
 			mediaTags[resolved[0].Row.DBID], titleTags[resolved[0].Row.Title.DBID],
@@ -90,6 +94,18 @@ func HandleMediaMeta(env requests.RequestEnv) (any, error) { //nolint:gocritic /
 		items[i].Media = &response.Media
 	}
 	return models.MediaMetaBatchResponse{Items: items}, nil
+}
+
+func buildMediaMetaBatchErrorResponse(resolved []resolvedMediaItem) models.MediaMetaBatchResponse {
+	items := make([]models.MediaMetaBatchItemResponse, len(resolved))
+	for i, item := range resolved {
+		if item.Err == nil {
+			continue
+		}
+		errText := item.Err.Error()
+		items[i].Error = &errText
+	}
+	return models.MediaMetaBatchResponse{Items: items}
 }
 
 func handleMediaMetaSinglePath(env *requests.RequestEnv, ref mediaRefParam) (any, error) {

--- a/pkg/api/methods/media_meta.go
+++ b/pkg/api/methods/media_meta.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 )
 
@@ -33,66 +32,125 @@ import (
 // the Media itself, its parent MediaTitle, System, level-separated Tags, and
 // level-separated Properties (with binary data base64-encoded inline).
 func HandleMediaMeta(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
-	var params models.MediaMetaParams
-	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
-		return nil, models.ClientErrf("invalid params: %w", err)
+	params, err := parseMediaRequest(env.Params, maxMediaMetaBatchItems)
+	if err != nil {
+		return nil, err
+	}
+	if !params.Batch && params.Items[0].MediaID == nil {
+		return handleMediaMetaSinglePath(&env, params.Items[0])
 	}
 
-	ctx := env.Context
-	db := env.Database.MediaDB
-
-	row, err := resolveMediaBySystemAndPath(&env, params.System, params.Path)
+	resolved, err := resolveMediaRefs(&env, params.Items)
 	if err != nil {
 		return nil, err
 	}
 
-	mediaTags, err := db.GetMediaTagsByMediaDBID(ctx, row.DBID)
+	mediaIDs, titleIDs := uniqueMediaAndTitleIDs(resolved)
+	db := env.Database.MediaDB
+	mediaTags, err := db.GetMediaTagsByMediaDBIDs(env.Context, mediaIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get media tags: %w", err)
 	}
-
-	titleTags, err := db.GetMediaTitleTagsByMediaTitleDBID(ctx, row.Title.DBID)
+	titleTags, err := db.GetMediaTitleTagsByMediaTitleDBIDs(env.Context, titleIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get title tags: %w", err)
 	}
-
-	mediaProps, err := db.GetMediaProperties(ctx, row.DBID)
+	mediaProps, err := db.GetMediaPropertiesByMediaDBIDs(env.Context, mediaIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get media properties: %w", err)
 	}
-
-	titleProps, err := db.GetMediaTitleProperties(ctx, row.Title.DBID)
+	titleProps, err := db.GetMediaTitlePropertiesByMediaTitleDBIDs(env.Context, titleIDs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get title properties: %w", err)
 	}
 
+	if !params.Batch {
+		if resolved[0].Err != nil {
+			return nil, resolved[0].Err
+		}
+		return buildMediaMetaResponse(
+			resolved[0].Row,
+			mediaTags[resolved[0].Row.DBID], titleTags[resolved[0].Row.Title.DBID],
+			mediaProps[resolved[0].Row.DBID], titleProps[resolved[0].Row.Title.DBID],
+		), nil
+	}
+
+	items := make([]models.MediaMetaBatchItemResponse, len(resolved))
+	for i, item := range resolved {
+		if item.Err != nil {
+			errText := item.Err.Error()
+			items[i].Error = &errText
+			continue
+		}
+		response := buildMediaMetaResponse(
+			item.Row,
+			mediaTags[item.Row.DBID], titleTags[item.Row.Title.DBID],
+			mediaProps[item.Row.DBID], titleProps[item.Row.Title.DBID],
+		)
+		items[i].Media = &response.Media
+	}
+	return models.MediaMetaBatchResponse{Items: items}, nil
+}
+
+func handleMediaMetaSinglePath(env *requests.RequestEnv, ref mediaRefParam) (any, error) {
+	db := env.Database.MediaDB
+	row, err := resolveMediaBySystemAndPath(env, ref.System, ref.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaTags, err := db.GetMediaTagsByMediaDBID(env.Context, row.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media tags: %w", err)
+	}
+	titleTags, err := db.GetMediaTitleTagsByMediaTitleDBID(env.Context, row.Title.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get title tags: %w", err)
+	}
+	mediaProps, err := db.GetMediaProperties(env.Context, row.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media properties: %w", err)
+	}
+	titleProps, err := db.GetMediaTitleProperties(env.Context, row.Title.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get title properties: %w", err)
+	}
+
+	return buildMediaMetaResponse(row, mediaTags, titleTags, mediaProps, titleProps), nil
+}
+
+func buildMediaMetaResponse(
+	row *database.MediaFullRow,
+	mediaTags []database.TagInfo,
+	titleTags []database.TagInfo,
+	mediaProps []database.MediaProperty,
+	titleProps []database.MediaProperty,
+) models.MediaMetaResponse {
 	var secondarySlug *string
 	if row.Title.SecondarySlug.Valid {
 		secondarySlug = &row.Title.SecondarySlug.String
 	}
 
-	return models.MediaMetaResponse{
-		Media: models.MediaMetaMediaResponse{
-			Path:       row.Path,
-			ParentDir:  row.ParentDir,
-			IsMissing:  row.IsMissing,
-			Tags:       mediaTags,
-			Properties: mapMediaProperties(mediaProps),
-			Title: models.MediaMetaTitleResponse{
-				Slug:          row.Title.Slug,
-				SecondarySlug: secondarySlug,
-				Name:          row.Title.Name,
-				SlugLength:    row.Title.SlugLength,
-				SlugWordCount: row.Title.SlugWordCount,
-				System: models.MediaMetaSystemResponse{
-					ID:   row.System.SystemID,
-					Name: row.System.Name,
-				},
-				Tags:       titleTags,
-				Properties: mapMediaProperties(titleProps),
+	return models.MediaMetaResponse{Media: models.MediaMetaMediaResponse{
+		Path:       row.Path,
+		ParentDir:  row.ParentDir,
+		IsMissing:  row.IsMissing,
+		Tags:       mediaTags,
+		Properties: mapMediaProperties(mediaProps),
+		Title: models.MediaMetaTitleResponse{
+			Slug:          row.Title.Slug,
+			SecondarySlug: secondarySlug,
+			Name:          row.Title.Name,
+			SlugLength:    row.Title.SlugLength,
+			SlugWordCount: row.Title.SlugWordCount,
+			System: models.MediaMetaSystemResponse{
+				ID:   row.System.SystemID,
+				Name: row.System.Name,
 			},
+			Tags:       titleTags,
+			Properties: mapMediaProperties(titleProps),
 		},
-	}, nil
+	}}
 }
 
 // mapMediaProperties converts a []database.MediaProperty slice into a map keyed

--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -202,6 +202,46 @@ func TestHandleMediaMeta_BatchByMediaIDPartialSuccess(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaMeta_MediaIDSuccess(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := makeMediaFullRow(3, 30)
+	row.System = database.System{DBID: 100, SystemID: "NES", Name: "NES"}
+	row.Title.Name = "Media ID Game"
+
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil)
+	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{row.DBID: {{Tag: "genre:platformer", Type: "genre"}}}, nil)
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{row.Title.DBID: {{Tag: "publisher:nintendo", Type: "publisher"}}}, nil)
+	mockDB.On("GetMediaPropertiesByMediaDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{
+			row.DBID: {{TypeTag: "property:description", Text: "media desc"}},
+		}, nil)
+	mockDB.On("GetMediaTitlePropertiesByMediaTitleDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{
+			row.Title.DBID: {{TypeTag: "property:description", Text: "title desc"}},
+		}, nil)
+
+	env := makeMediaMetaEnv(t, mockDB, `{"mediaId":3}`)
+	result, err := HandleMediaMeta(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaResponse)
+	require.True(t, ok)
+	assert.Equal(t, row.Path, resp.Media.Path)
+	assert.Equal(t, "Media ID Game", resp.Media.Title.Name)
+	require.Len(t, resp.Media.Tags, 1)
+	assert.Equal(t, "genre:platformer", resp.Media.Tags[0].Tag)
+	require.Len(t, resp.Media.Title.Tags, 1)
+	assert.Equal(t, "publisher:nintendo", resp.Media.Title.Tags[0].Tag)
+	assert.Equal(t, "media desc", resp.Media.Properties["property:description"].Text)
+	assert.Equal(t, "title desc", resp.Media.Title.Properties["property:description"].Text)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaMeta_MediaNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -219,6 +219,60 @@ func TestHandleMediaMeta_MediaNotFound(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaMeta_MediaIDNotFoundSkipsMetadataFetch(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
+		Return(map[int64]database.MediaFullRow{}, nil)
+
+	env := makeMediaMetaEnv(t, mockDB, `{"mediaId":999}`)
+	_, err := HandleMediaMeta(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mediaId 999")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMeta_BatchPathMissesSkipMediaIDFetch(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	missingPath := filepath.Join("games", "missing.rom")
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{}, sql.ErrNoRows)
+
+	env := makeMediaMetaEnv(t, mockDB, fmt.Sprintf(`{"items":[{"system":"NES","path":%q}]}`, missingPath))
+	result, err := HandleMediaMeta(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaBatchResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Items, 1)
+	require.NotNil(t, resp.Items[0].Error)
+	assert.Contains(t, *resp.Items[0].Error, "system not found: NES")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMeta_BatchAllMediaIDMissesSkipMetadataFetch(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
+		Return(map[int64]database.MediaFullRow{}, nil)
+
+	env := makeMediaMetaEnv(t, mockDB, `{"items":[{"mediaId":999},{"mediaId":1000}]}`)
+	result, err := HandleMediaMeta(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaBatchResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Items, 2)
+	require.NotNil(t, resp.Items[0].Error)
+	require.NotNil(t, resp.Items[1].Error)
+	assert.Contains(t, *resp.Items[0].Error, "mediaId 999")
+	assert.Contains(t, *resp.Items[1].Error, "mediaId 1000")
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaMeta_InvalidParams(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -165,6 +165,43 @@ func TestHandleMediaMeta_BinaryPropertyBase64Encoded(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaMeta_BatchByMediaIDPartialSuccess(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := makeMediaFullRow(3, 30)
+	row.System = database.System{DBID: 100, SystemID: "NES", Name: "NES"}
+	row.Title.Name = "Batch Game"
+
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil)
+	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{row.DBID: {{Tag: "genre:platformer", Type: "genre"}}}, nil)
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{row.Title.DBID: {{Tag: "publisher:nintendo", Type: "publisher"}}}, nil)
+	mockDB.On("GetMediaPropertiesByMediaDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{
+			row.DBID: {{TypeTag: "property:description", Text: "media desc"}},
+		}, nil)
+	mockDB.On("GetMediaTitlePropertiesByMediaTitleDBIDs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.MediaProperty{}, nil)
+
+	env := makeMediaMetaEnv(t, mockDB, `{"items":[{"mediaId":3},{"mediaId":999}]}`)
+	result, err := HandleMediaMeta(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaBatchResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Items, 2)
+	require.NotNil(t, resp.Items[0].Media)
+	assert.Equal(t, row.Path, resp.Items[0].Media.Path)
+	assert.Equal(t, "Batch Game", resp.Items[0].Media.Title.Name)
+	assert.Contains(t, resp.Items[0].Media.Properties, "property:description")
+	require.NotNil(t, resp.Items[1].Error)
+	assert.Contains(t, *resp.Items[1].Error, "mediaId 999")
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaMeta_MediaNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -1,0 +1,92 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
+)
+
+type mediaPathRef struct {
+	SystemID string
+	Path     string
+}
+
+func mediaResponseRelativePath(env *requests.RequestEnv, systemID, path string) *string {
+	if env == nil || env.LauncherCache == nil || env.Platform == nil {
+		return nil
+	}
+
+	rootDirs := env.Platform.RootDirs(env.Config)
+	rel := env.LauncherCache.ToRelativePath(rootDirs, systemID, path)
+	if rel == path {
+		return nil
+	}
+	return &rel
+}
+
+func mediaResponseMediaIDs(env *requests.RequestEnv, refs []mediaPathRef) map[mediaPathRef]int64 {
+	if env == nil || env.Database == nil {
+		return nil
+	}
+	return mediaIDsByPath(env.Context, env.Database.MediaDB, refs)
+}
+
+func mediaIDsByPath(ctx context.Context, db database.MediaDBI, refs []mediaPathRef) map[mediaPathRef]int64 {
+	if db == nil || len(refs) == 0 {
+		return nil
+	}
+
+	pathsBySystem := make(map[string][]string)
+	seen := make(map[mediaPathRef]bool)
+	for _, ref := range refs {
+		if ref.SystemID == "" || ref.Path == "" || seen[ref] {
+			continue
+		}
+		seen[ref] = true
+		pathsBySystem[ref.SystemID] = append(pathsBySystem[ref.SystemID], ref.Path)
+	}
+
+	mediaIDs := make(map[mediaPathRef]int64)
+	for systemID, paths := range pathsBySystem {
+		system, err := db.FindSystemBySystemID(systemID)
+		if err != nil {
+			log.Debug().Err(err).Str("system", systemID).Msg("could not resolve media IDs for system")
+			continue
+		}
+
+		mediaByPath, err := db.FindMediaBySystemAndPaths(ctx, system.DBID, paths)
+		if err != nil {
+			log.Debug().Err(err).Str("system", systemID).Msg("could not resolve media IDs by path")
+			continue
+		}
+
+		for path, media := range mediaByPath {
+			if media.DBID > 0 {
+				mediaIDs[mediaPathRef{SystemID: systemID, Path: path}] = media.DBID
+			}
+		}
+	}
+
+	return mediaIDs
+}

--- a/pkg/api/methods/media_response_helpers_test.go
+++ b/pkg/api/methods/media_response_helpers_test.go
@@ -1,0 +1,76 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestMediaIDsByPath_DeduplicatesRefsAndSkipsInvalidRefs(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	pathOne := filepath.Join("games", "one.rom")
+	pathTwo := filepath.Join("games", "two.rom")
+	refs := []mediaPathRef{
+		{SystemID: "NES", Path: pathOne},
+		{SystemID: "NES", Path: pathOne},
+		{SystemID: "NES", Path: pathTwo},
+		{SystemID: "", Path: pathTwo},
+		{SystemID: "NES", Path: ""},
+	}
+
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 7, SystemID: "NES"}, nil)
+	mockDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(7), []string{pathOne, pathTwo}).Return(
+		map[string]database.Media{
+			pathOne: {DBID: 10, Path: pathOne},
+			pathTwo: {DBID: 11, Path: pathTwo},
+		}, nil,
+	)
+
+	ids := mediaIDsByPath(context.Background(), mockDB, refs)
+
+	assert.Equal(t, map[mediaPathRef]int64{
+		{SystemID: "NES", Path: pathOne}: 10,
+		{SystemID: "NES", Path: pathTwo}: 11,
+	}, ids)
+	mockDB.AssertExpectations(t)
+}
+
+func TestMediaIDsByPath_SkipsUnresolvableSystems(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	path := filepath.Join("games", "missing.rom")
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{}, sql.ErrNoRows)
+
+	ids := mediaIDsByPath(context.Background(), mockDB, []mediaPathRef{{SystemID: "NES", Path: path}})
+
+	assert.Empty(t, ids)
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -179,13 +179,15 @@ type MediaHistoryTopParams struct {
 }
 
 type MediaMetaParams struct {
-	System string `json:"system" validate:"required,min=1"`
-	Path   string `json:"path"   validate:"required,min=1"`
+	MediaID *int64 `json:"mediaId,omitempty"`
+	System  string `json:"system" validate:"omitempty,min=1"`
+	Path    string `json:"path"   validate:"omitempty,min=1"`
 }
 
 type MediaImageParams struct {
-	System     string   `json:"system"            validate:"required,min=1"`
-	Path       string   `json:"path"              validate:"required,min=1"`
+	MediaID    *int64   `json:"mediaId,omitempty"`
+	System     string   `json:"system"            validate:"omitempty,min=1"`
+	Path       string   `json:"path"              validate:"omitempty,min=1"`
 	ImageTypes []string `json:"imageTypes"        validate:"omitempty,dive,min=1"`
 }
 

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -35,6 +35,7 @@ type SearchResultMedia struct {
 	Path      string             `json:"path"`
 	ZapScript string             `json:"zapScript"`
 	Tags      []database.TagInfo `json:"tags"`
+	MediaID   int64              `json:"mediaId,omitempty"`
 }
 
 type PaginationInfo struct {
@@ -54,7 +55,6 @@ type TagsResponse struct {
 }
 
 type BrowseEntry struct {
-	SystemIDs []string           `json:"systemIds,omitempty"`
 	SystemID  *string            `json:"systemId,omitempty"`
 	RelPath   *string            `json:"relativePath,omitempty"`
 	ZapScript *string            `json:"zapScript,omitempty"`
@@ -63,7 +63,9 @@ type BrowseEntry struct {
 	Name      string             `json:"name"`
 	Path      string             `json:"path"`
 	Type      string             `json:"type"`
+	SystemIDs []string           `json:"systemIds,omitempty"`
 	Tags      []database.TagInfo `json:"tags,omitempty"`
+	MediaID   int64              `json:"mediaId,omitempty"`
 }
 
 type BrowseResults struct {
@@ -190,6 +192,7 @@ type ReaderResponse struct {
 }
 
 type MediaHistoryResponseEntry struct {
+	RelPath    *string `json:"relativePath,omitempty"`
 	EndedAt    *string `json:"endedAt,omitempty"`
 	SystemID   string  `json:"systemId"`
 	SystemName string  `json:"systemName"`
@@ -198,6 +201,7 @@ type MediaHistoryResponseEntry struct {
 	LauncherID string  `json:"launcherId"`
 	StartedAt  string  `json:"startedAt"`
 	PlayTime   int     `json:"playTime"`
+	MediaID    int64   `json:"mediaId,omitempty"`
 }
 
 type MediaHistoryResponse struct {
@@ -206,13 +210,15 @@ type MediaHistoryResponse struct {
 }
 
 type MediaHistoryTopEntry struct {
-	SystemID      string `json:"systemId"`
-	SystemName    string `json:"systemName"`
-	MediaName     string `json:"mediaName"`
-	MediaPath     string `json:"mediaPath"`
-	LastPlayedAt  string `json:"lastPlayedAt"`
-	TotalPlayTime int    `json:"totalPlayTime"`
-	SessionCount  int    `json:"sessionCount"`
+	RelPath       *string `json:"relativePath,omitempty"`
+	SystemID      string  `json:"systemId"`
+	SystemName    string  `json:"systemName"`
+	MediaName     string  `json:"mediaName"`
+	MediaPath     string  `json:"mediaPath"`
+	LastPlayedAt  string  `json:"lastPlayedAt"`
+	TotalPlayTime int     `json:"totalPlayTime"`
+	SessionCount  int     `json:"sessionCount"`
+	MediaID       int64   `json:"mediaId,omitempty"`
 }
 
 type MediaHistoryTopResponse struct {
@@ -263,6 +269,15 @@ type MediaMetaResponse struct {
 	Media MediaMetaMediaResponse `json:"media"`
 }
 
+type MediaMetaBatchItemResponse struct {
+	Media *MediaMetaMediaResponse `json:"media,omitempty"`
+	Error *string                 `json:"error,omitempty"`
+}
+
+type MediaMetaBatchResponse struct {
+	Items []MediaMetaBatchItemResponse `json:"items"`
+}
+
 // MediaImageResponse is the response for the media.image method.
 // It contains the best-match image for a media record, base64-encoded.
 type MediaImageResponse struct {
@@ -270,6 +285,15 @@ type MediaImageResponse struct {
 	ContentType string  `json:"contentType"`
 	Data        string  `json:"data"`    // base64-encoded blob
 	TypeTag     string  `json:"typeTag"` // e.g. "property:image-boxart"
+}
+
+type MediaImageBatchItemResponse struct {
+	Image *MediaImageResponse `json:"image,omitempty"`
+	Error *string             `json:"error,omitempty"`
+}
+
+type MediaImageBatchResponse struct {
+	Items []MediaImageBatchItemResponse `json:"items"`
 }
 
 // ScrapingStatusResponse is broadcast as a "media.scraping" notification for
@@ -294,6 +318,7 @@ type MediaLookupMatch struct {
 	Path       string             `json:"path"`
 	ZapScript  string             `json:"zapScript"`
 	Tags       []database.TagInfo `json:"tags"`
+	MediaID    int64              `json:"mediaId,omitempty"`
 	Confidence float64            `json:"confidence"`
 }
 
@@ -318,6 +343,7 @@ type ScrapersResponse struct {
 }
 
 type ActiveMedia struct {
+	RelPath          *string   `json:"relativePath,omitempty"`
 	Started          time.Time `json:"started"`
 	LauncherID       string    `json:"launcherId"`
 	SystemID         string    `json:"systemId"`
@@ -325,6 +351,7 @@ type ActiveMedia struct {
 	Path             string    `json:"mediaPath"`
 	Name             string    `json:"mediaName"`
 	LauncherControls []string  `json:"launcherControls,omitempty"`
+	MediaID          int64     `json:"mediaId,omitempty"`
 }
 
 // NewActiveMedia creates a new ActiveMedia with the current timestamp.

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -76,6 +76,8 @@ var allowedOrigins = []string{
 	"http://localhost",      // Fallback/development
 }
 
+const websocketMaxMessageSize = 4 * 1024 * 1024
+
 var JSONRPCErrorParseError = models.ErrorObject{
 	Code:    -32700,
 	Message: "Parse error",
@@ -106,6 +108,12 @@ func makeJSONRPCError(code int, message string) models.ErrorObject {
 		Code:    code,
 		Message: message,
 	}
+}
+
+func newWebSocketSession() *melody.Melody {
+	session := melody.New()
+	session.Config.MaxMessageSize = websocketMaxMessageSize
+	return session
 }
 
 // logSafeRequest logs a request but avoids logging sensitive or large content
@@ -1510,7 +1518,7 @@ func StartWithReady(
 		<-lastSeenDone
 	}()
 
-	session := melody.New()
+	session := newWebSocketSession()
 	defer func() {
 		if err := session.Close(); err != nil {
 			log.Error().Err(err).Msg("WebSocket session close error")

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -20,6 +20,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net"
@@ -72,7 +73,7 @@ func startWSServer(
 ) (wsURL string, cleanup func()) {
 	t.Helper()
 
-	m := melody.New()
+	m := newWebSocketSession()
 	m.HandleMessage(func(s *melody.Session, msg []byte) {
 		clientIP := apimiddleware.ParseRemoteIP(s.Request.RemoteAddr)
 		isLocal := apimiddleware.IsLoopbackAddr(s.Request.RemoteAddr)
@@ -228,4 +229,28 @@ func TestWSEncryption_LoopbackPlaintextAllowedWhenEnabled(t *testing.T) {
 	_, got, err := conn.ReadMessage()
 	require.NoError(t, err, "loopback plaintext must be accepted on encryption=true")
 	assert.Equal(t, plaintext, got, "test echo handler returns the plaintext unchanged")
+}
+
+func TestWSAcceptsBatchSizedRequests(t *testing.T) {
+	t.Parallel()
+
+	gateway := apimiddleware.NewEncryptionGateway(helpers.NewMockUserDBI())
+
+	wsURL, cleanup := startWSServer(t, true, gateway, nil)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	payload := bytes.Repeat([]byte("a"), 2048)
+	message := append([]byte(`{"jsonrpc":"2.0","method":"test.echo","params":{"path":"`), payload...)
+	message = append(message, []byte(`"},"id":1}`)...)
+	require.Greater(t, len(message), 512, "payload must exceed melody's default message limit")
+	require.Less(t, len(message), websocketMaxMessageSize)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, message))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, got, err := conn.ReadMessage()
+	require.NoError(t, err, "batch-sized request should not be rejected with close code 1009")
+	assert.Equal(t, message, got)
 }

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -253,4 +254,29 @@ func TestWSAcceptsBatchSizedRequests(t *testing.T) {
 	_, got, err := conn.ReadMessage()
 	require.NoError(t, err, "batch-sized request should not be rejected with close code 1009")
 	assert.Equal(t, message, got)
+}
+
+func TestWSRejectsOverLimitRequests(t *testing.T) {
+	t.Parallel()
+
+	gateway := apimiddleware.NewEncryptionGateway(helpers.NewMockUserDBI())
+
+	wsURL, cleanup := startWSServer(t, true, gateway, nil)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	payload := bytes.Repeat([]byte("a"), websocketMaxMessageSize)
+	message := append([]byte(`{"jsonrpc":"2.0","method":"test.echo","params":{"path":"`), payload...)
+	message = append(message, []byte(`"},"id":1}`)...)
+	require.Greater(t, len(message), websocketMaxMessageSize)
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, message))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err, "over-limit request should be rejected")
+	if !websocket.IsCloseError(err, websocket.CloseMessageTooBig) {
+		assert.Contains(t, strings.ToLower(err.Error()), "message too big")
+	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -640,6 +640,7 @@ type MediaDBI interface {
 	// FindMediaBySystemAndPath returns the Media row matching systemDBID and path,
 	// or nil, nil when no row is found.
 	FindMediaBySystemAndPath(ctx context.Context, systemDBID int64, path string) (*Media, error)
+	FindMediaBySystemAndPaths(ctx context.Context, systemDBID int64, paths []string) (map[string]Media, error)
 
 	// FindMediaBySystemAndPathFold returns the Media row matching systemDBID and
 	// path using a case-insensitive path comparison, or nil, nil when no row is
@@ -688,10 +689,14 @@ type MediaDBI interface {
 	// GetMediaTitleProperties returns all properties for a MediaTitle row,
 	// with TypeTagDBID resolved to the tag value string.
 	GetMediaTitleProperties(ctx context.Context, mediaTitleDBID int64) ([]MediaProperty, error)
+	GetMediaTitlePropertiesByMediaTitleDBIDs(
+		ctx context.Context, mediaTitleDBIDs []int64,
+	) (map[int64][]MediaProperty, error)
 
 	// GetMediaProperties returns all properties for a Media row,
 	// with TypeTagDBID resolved to the tag value string.
 	GetMediaProperties(ctx context.Context, mediaDBID int64) ([]MediaProperty, error)
+	GetMediaPropertiesByMediaDBIDs(ctx context.Context, mediaDBIDs []int64) (map[int64][]MediaProperty, error)
 
 	// DeleteMediaTitleProperty removes a single property row from MediaTitleProperties
 	// identified by (mediaTitleDBID, typeTagDBID). A no-op if the row does not exist.
@@ -706,14 +711,17 @@ type MediaDBI interface {
 	// Media row with the given DBID exists. IsMissing is NOT filtered — metadata
 	// remains accessible for missing files.
 	GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int64) (*MediaFullRow, error)
+	GetMediaWithTitleAndSystemByIDs(ctx context.Context, mediaDBIDs []int64) (map[int64]MediaFullRow, error)
 
 	// GetMediaTagsByMediaDBID returns the file-level tags (MediaTags) for a
 	// single Media row. Does not include title-level tags.
 	GetMediaTagsByMediaDBID(ctx context.Context, mediaDBID int64) ([]TagInfo, error)
+	GetMediaTagsByMediaDBIDs(ctx context.Context, mediaDBIDs []int64) (map[int64][]TagInfo, error)
 
 	// GetMediaTitleTagsByMediaTitleDBID returns the title-level tags
 	// (MediaTitleTags) for a single MediaTitle row.
 	GetMediaTitleTagsByMediaTitleDBID(ctx context.Context, mediaTitleDBID int64) ([]TagInfo, error)
+	GetMediaTitleTagsByMediaTitleDBIDs(ctx context.Context, mediaTitleDBIDs []int64) (map[int64][]TagInfo, error)
 
 	// UpsertMediaBlob inserts a blob into MediaBlobs when no row with the same
 	// SHA-256 hash of framed content type and bytes already exists, then returns its DBID.

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -72,6 +72,55 @@ func (db *MediaDB) FindMediaBySystemAndPath(
 	return &row, nil
 }
 
+func (db *MediaDB) FindMediaBySystemAndPaths(
+	ctx context.Context, systemDBID int64, paths []string,
+) (map[string]database.Media, error) {
+	results := make(map[string]database.Media, len(paths))
+	if len(paths) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := make([]any, 0, len(paths)+1)
+	args = append(args, systemDBID)
+	for _, path := range paths {
+		args = append(args, path)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+		FROM Media
+		WHERE SystemDBID = ? AND Path IN (`+prepareVariadic("?", ",", len(paths))+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query FindMediaBySystemAndPaths: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	for rows.Next() {
+		var row database.Media
+		if err := rows.Scan(
+			&row.DBID,
+			&row.MediaTitleDBID,
+			&row.SystemDBID,
+			&row.Path,
+			&row.ParentDir,
+			&row.IsMissing,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan FindMediaBySystemAndPaths: %w", err)
+		}
+		results[row.Path] = row
+	}
+	return results, rows.Err()
+}
+
 // FindMediaBySystemAndPathFold returns the Media row for the given system and
 // path using a case-insensitive path comparison, or nil, nil when not found.
 // LOWER() in SQLite covers ASCII only, which is sufficient for filesystem paths.
@@ -849,6 +898,40 @@ func (db *MediaDB) GetMediaTitleProperties(
 	return scanProperties(rows)
 }
 
+func (db *MediaDB) GetMediaTitlePropertiesByMediaTitleDBIDs(
+	ctx context.Context, mediaTitleDBIDs []int64,
+) (map[int64][]database.MediaProperty, error) {
+	results := make(map[int64][]database.MediaProperty, len(mediaTitleDBIDs))
+	if len(mediaTitleDBIDs) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := int64Args(mediaTitleDBIDs)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT mtp.MediaTitleDBID, tt.Type || ':' || t.Tag, mtp.TypeTagDBID, mtp.Text,
+		       mtp.BlobDBID, mb.ContentType, mb.Data
+		FROM MediaTitleProperties mtp
+		JOIN Tags t      ON mtp.TypeTagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		LEFT JOIN MediaBlobs mb ON mtp.BlobDBID = mb.DBID
+		WHERE mtp.MediaTitleDBID IN (`+prepareVariadic("?", ",", len(mediaTitleDBIDs))+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query GetMediaTitlePropertiesByMediaTitleDBIDs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	return scanGroupedProperties(rows)
+}
+
 // GetMediaProperties returns all MediaProperties rows for the given Media record.
 // TypeTag is populated as "type:value" from the joined Tags/TagTypes rows.
 func (db *MediaDB) GetMediaProperties(ctx context.Context, mediaDBID int64) ([]database.MediaProperty, error) {
@@ -884,6 +967,40 @@ func (db *MediaDB) GetMediaProperties(ctx context.Context, mediaDBID int64) ([]d
 	}()
 
 	return scanProperties(rows)
+}
+
+func (db *MediaDB) GetMediaPropertiesByMediaDBIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64][]database.MediaProperty, error) {
+	results := make(map[int64][]database.MediaProperty, len(mediaDBIDs))
+	if len(mediaDBIDs) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := int64Args(mediaDBIDs)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT mp.MediaDBID, tt.Type || ':' || t.Tag, mp.TypeTagDBID, mp.Text,
+		       mp.BlobDBID, mb.ContentType, mb.Data
+		FROM MediaProperties mp
+		JOIN Tags t      ON mp.TypeTagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		LEFT JOIN MediaBlobs mb ON mp.BlobDBID = mb.DBID
+		WHERE mp.MediaDBID IN (`+prepareVariadic("?", ",", len(mediaDBIDs))+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query GetMediaPropertiesByMediaDBIDs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	return scanGroupedProperties(rows)
 }
 
 // GetMediaWithTitleAndSystem fetches a Media record together with its parent
@@ -931,6 +1048,54 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 	return &row, nil
 }
 
+func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64]database.MediaFullRow, error) {
+	results := make(map[int64]database.MediaFullRow, len(mediaDBIDs))
+	if len(mediaDBIDs) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := int64Args(mediaDBIDs)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT
+			m.DBID, m.Path, m.ParentDir, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
+			mt.DBID, mt.Slug, mt.SecondarySlug, mt.Name, mt.SlugLength, mt.SlugWordCount, mt.SystemDBID,
+			s.DBID, s.SystemID, s.Name
+		FROM Media m
+		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
+		INNER JOIN Systems s ON mt.SystemDBID = s.DBID
+		WHERE m.DBID IN (`+prepareVariadic("?", ",", len(mediaDBIDs))+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query GetMediaWithTitleAndSystemByIDs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	for rows.Next() {
+		var row database.MediaFullRow
+		if err := rows.Scan(
+			&row.DBID, &row.Path, &row.ParentDir, &row.IsMissing,
+			&row.MediaTitleDBID, &row.SystemDBID,
+			&row.Title.DBID, &row.Title.Slug, &row.Title.SecondarySlug, &row.Title.Name,
+			&row.Title.SlugLength, &row.Title.SlugWordCount, &row.Title.SystemDBID,
+			&row.System.DBID, &row.System.SystemID, &row.System.Name,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan GetMediaWithTitleAndSystemByIDs: %w", err)
+		}
+		results[row.DBID] = row
+	}
+	return results, rows.Err()
+}
+
 // GetMediaTagsByMediaDBID returns the file-level tags (MediaTags) for a single
 // Media row, ordered by type then tag value.
 func (db *MediaDB) GetMediaTagsByMediaDBID(ctx context.Context, mediaDBID int64) ([]database.TagInfo, error) {
@@ -966,6 +1131,39 @@ func (db *MediaDB) GetMediaTagsByMediaDBID(ctx context.Context, mediaDBID int64)
 	}()
 
 	return scanTagInfos(rows)
+}
+
+func (db *MediaDB) GetMediaTagsByMediaDBIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64][]database.TagInfo, error) {
+	results := make(map[int64][]database.TagInfo, len(mediaDBIDs))
+	if len(mediaDBIDs) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := int64Args(mediaDBIDs)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT MediaTags.MediaDBID, Tags.Tag, TagTypes.Type
+		FROM MediaTags
+		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTags.MediaDBID IN (`+prepareVariadic("?", ",", len(mediaDBIDs))+`)
+		ORDER BY MediaTags.MediaDBID, TagTypes.Type, Tags.Tag
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query GetMediaTagsByMediaDBIDs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	return scanGroupedTagInfos(rows)
 }
 
 // GetMediaTitleTagsByMediaTitleDBID returns the title-level tags (MediaTitleTags)
@@ -1007,6 +1205,39 @@ func (db *MediaDB) GetMediaTitleTagsByMediaTitleDBID(
 	return scanTagInfos(rows)
 }
 
+func (db *MediaDB) GetMediaTitleTagsByMediaTitleDBIDs(
+	ctx context.Context, mediaTitleDBIDs []int64,
+) (map[int64][]database.TagInfo, error) {
+	results := make(map[int64][]database.TagInfo, len(mediaTitleDBIDs))
+	if len(mediaTitleDBIDs) == 0 {
+		return results, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := int64Args(mediaTitleDBIDs)
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT MediaTitleTags.MediaTitleDBID, Tags.Tag, TagTypes.Type
+		FROM MediaTitleTags
+		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTitleTags.MediaTitleDBID IN (`+prepareVariadic("?", ",", len(mediaTitleDBIDs))+`)
+		ORDER BY MediaTitleTags.MediaTitleDBID, TagTypes.Type, Tags.Tag
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query GetMediaTitleTagsByMediaTitleDBIDs: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	return scanGroupedTagInfos(rows)
+}
+
 func scanTagInfos(rows *sql.Rows) ([]database.TagInfo, error) {
 	result := make([]database.TagInfo, 0)
 	for rows.Next() {
@@ -1016,6 +1247,20 @@ func scanTagInfos(rows *sql.Rows) ([]database.TagInfo, error) {
 		}
 		t.Tag = tags.UnpadTagValue(t.Tag)
 		result = append(result, t)
+	}
+	return result, rows.Err()
+}
+
+func scanGroupedTagInfos(rows *sql.Rows) (map[int64][]database.TagInfo, error) {
+	result := make(map[int64][]database.TagInfo)
+	for rows.Next() {
+		var dbid int64
+		var t database.TagInfo
+		if err := rows.Scan(&dbid, &t.Tag, &t.Type); err != nil {
+			return nil, fmt.Errorf("failed to scan grouped TagInfo: %w", err)
+		}
+		t.Tag = tags.UnpadTagValue(t.Tag)
+		result[dbid] = append(result[dbid], t)
 	}
 	return result, rows.Err()
 }
@@ -1044,4 +1289,44 @@ func scanProperties(rows *sql.Rows) ([]database.MediaProperty, error) {
 		props = []database.MediaProperty{}
 	}
 	return props, rows.Err()
+}
+
+func scanGroupedProperties(rows *sql.Rows) (map[int64][]database.MediaProperty, error) {
+	result := make(map[int64][]database.MediaProperty)
+	for rows.Next() {
+		var dbid int64
+		prop, err := scanPropertyWithDBID(rows, &dbid)
+		if err != nil {
+			return nil, err
+		}
+		result[dbid] = append(result[dbid], prop)
+	}
+	return result, rows.Err()
+}
+
+func scanPropertyWithDBID(rows *sql.Rows, dbid *int64) (database.MediaProperty, error) {
+	var p database.MediaProperty
+	var blobDBID sql.NullInt64
+	var contentType sql.NullString
+	var binary []byte
+	if err := rows.Scan(
+		dbid, &p.TypeTag, &p.TypeTagDBID, &p.Text,
+		&blobDBID, &contentType, &binary,
+	); err != nil {
+		return database.MediaProperty{}, fmt.Errorf("failed to scan grouped MediaProperty: %w", err)
+	}
+	if blobDBID.Valid {
+		p.BlobDBID = &blobDBID.Int64
+	}
+	p.ContentType = contentType.String
+	p.Binary = binary
+	return p, nil
+}
+
+func int64Args(values []int64) []any {
+	args := make([]any, len(values))
+	for i, value := range values {
+		args[i] = value
+	}
+	return args
 }

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -608,6 +608,101 @@ func TestGetMediaProperties_RoundTrip(t *testing.T) {
 	assert.Nil(t, got[0].Binary)
 }
 
+func TestGetMediaBatchMetadata_RoundTrip(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	zeldaPath := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, zeldaPath)
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, []database.TagInfo{{Type: "developer", Tag: "nintendo"}}))
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 2, []database.TagInfo{{Type: "developer", Tag: "capcom"}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 1, []database.TagInfo{{Type: "developer", Tag: "title-one"}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 2, []database.TagInfo{{Type: "developer", Tag: "title-two"}}))
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, 1, []database.MediaProperty{{
+		TypeTag: "property:image-boxart",
+		Text:    filepath.Join("art", "mario.png"),
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, 2, []database.MediaProperty{{
+		TypeTag: "property:image-boxart",
+		Text:    filepath.Join("art", "zelda.png"),
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, 1, []database.MediaProperty{{
+		TypeTag: "property:description",
+		Text:    "Mario description",
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, 2, []database.MediaProperty{{
+		TypeTag: "property:description",
+		Text:    "Zelda description",
+	}}))
+
+	rows, err := mediaDB.GetMediaWithTitleAndSystemByIDs(ctx, []int64{1, 2, 999})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, filepath.ToSlash(filepath.Join("roms", "mario.nes")), rows[1].Path)
+	assert.Equal(t, "Mario", rows[1].Title.Name)
+	assert.Equal(t, "NES", rows[1].System.SystemID)
+	assert.Equal(t, zeldaPath, rows[2].Path)
+	assert.Equal(t, "Zelda", rows[2].Title.Name)
+
+	mediaTags, err := mediaDB.GetMediaTagsByMediaDBIDs(ctx, []int64{1, 2})
+	require.NoError(t, err)
+	assert.Equal(t, []database.TagInfo{{Tag: "nintendo", Type: "developer"}}, mediaTags[1])
+	assert.Equal(t, []database.TagInfo{{Tag: "capcom", Type: "developer"}}, mediaTags[2])
+
+	titleTags, err := mediaDB.GetMediaTitleTagsByMediaTitleDBIDs(ctx, []int64{1, 2})
+	require.NoError(t, err)
+	assert.Equal(t, []database.TagInfo{{Tag: "title-one", Type: "developer"}}, titleTags[1])
+	assert.Equal(t, []database.TagInfo{{Tag: "title-two", Type: "developer"}}, titleTags[2])
+
+	mediaProps, err := mediaDB.GetMediaPropertiesByMediaDBIDs(ctx, []int64{1, 2})
+	require.NoError(t, err)
+	require.Len(t, mediaProps[1], 1)
+	require.Len(t, mediaProps[2], 1)
+	assert.Equal(t, filepath.Join("art", "mario.png"), mediaProps[1][0].Text)
+	assert.Equal(t, filepath.Join("art", "zelda.png"), mediaProps[2][0].Text)
+
+	titleProps, err := mediaDB.GetMediaTitlePropertiesByMediaTitleDBIDs(ctx, []int64{1, 2})
+	require.NoError(t, err)
+	require.Len(t, titleProps[1], 1)
+	require.Len(t, titleProps[2], 1)
+	assert.Equal(t, "Mario description", titleProps[1][0].Text)
+	assert.Equal(t, "Zelda description", titleProps[2][0].Text)
+}
+
+func TestGetMediaBatchMetadata_EmptyIDsReturnEmptyMaps(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaRows, err := mediaDB.GetMediaWithTitleAndSystemByIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, mediaRows)
+
+	mediaTags, err := mediaDB.GetMediaTagsByMediaDBIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, mediaTags)
+
+	titleTags, err := mediaDB.GetMediaTitleTagsByMediaTitleDBIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, titleTags)
+
+	mediaProps, err := mediaDB.GetMediaPropertiesByMediaDBIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, mediaProps)
+
+	titleProps, err := mediaDB.GetMediaTitlePropertiesByMediaTitleDBIDs(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, titleProps)
+}
+
 // --- FindMediaTitlesWithoutSentinel ---
 
 func TestFindMediaTitlesWithoutSentinel_AllUnseen(t *testing.T) {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2130,6 +2130,16 @@ func (m *MockMediaDBI) FindMediaBySystemAndPath(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) FindMediaBySystemAndPaths(
+	ctx context.Context, systemDBID int64, paths []string,
+) (map[string]database.Media, error) {
+	args := m.Called(ctx, systemDBID, paths)
+	if result, ok := args.Get(0).(map[string]database.Media); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) FindMediaBySystemAndPathFold(
 	ctx context.Context, systemDBID int64, path string,
 ) (*database.Media, error) {
@@ -2229,9 +2239,29 @@ func (m *MockMediaDBI) GetMediaTitleProperties(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) GetMediaTitlePropertiesByMediaTitleDBIDs(
+	ctx context.Context, mediaTitleDBIDs []int64,
+) (map[int64][]database.MediaProperty, error) {
+	args := m.Called(ctx, mediaTitleDBIDs)
+	if result, ok := args.Get(0).(map[int64][]database.MediaProperty); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) GetMediaProperties(ctx context.Context, mediaDBID int64) ([]database.MediaProperty, error) {
 	args := m.Called(ctx, mediaDBID)
 	if result, ok := args.Get(0).([]database.MediaProperty); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
+func (m *MockMediaDBI) GetMediaPropertiesByMediaDBIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64][]database.MediaProperty, error) {
+	args := m.Called(ctx, mediaDBIDs)
+	if result, ok := args.Get(0).(map[int64][]database.MediaProperty); ok {
 		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 	}
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
@@ -2281,6 +2311,16 @@ func (m *MockMediaDBI) GetMediaWithTitleAndSystem(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) GetMediaWithTitleAndSystemByIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64]database.MediaFullRow, error) {
+	args := m.Called(ctx, mediaDBIDs)
+	if result, ok := args.Get(0).(map[int64]database.MediaFullRow); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) GetMediaTagsByMediaDBID(
 	ctx context.Context, mediaDBID int64,
 ) ([]database.TagInfo, error) {
@@ -2291,11 +2331,31 @@ func (m *MockMediaDBI) GetMediaTagsByMediaDBID(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) GetMediaTagsByMediaDBIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64][]database.TagInfo, error) {
+	args := m.Called(ctx, mediaDBIDs)
+	if result, ok := args.Get(0).(map[int64][]database.TagInfo); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) GetMediaTitleTagsByMediaTitleDBID(
 	ctx context.Context, mediaTitleDBID int64,
 ) ([]database.TagInfo, error) {
 	args := m.Called(ctx, mediaTitleDBID)
 	if result, ok := args.Get(0).([]database.TagInfo); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
+func (m *MockMediaDBI) GetMediaTitleTagsByMediaTitleDBIDs(
+	ctx context.Context, mediaTitleDBIDs []int64,
+) (map[int64][]database.TagInfo, error) {
+	args := m.Called(ctx, mediaTitleDBIDs)
+	if result, ok := args.Get(0).(map[int64][]database.TagInfo); ok {
 		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 	}
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design


### PR DESCRIPTION
## Summary
- Add batch `media.meta` and `media.image` requests with `mediaId` support, bulk MediaDB lookups, and per-item errors.
- Expose `mediaId` on search, browse, lookup, active, and history responses, plus `relativePath` on active/history responses.
- Update API docs and add focused tests for batch media metadata/image and active/history response enrichment.

## Verified
- `go test ./pkg/api/methods/`
- `task lint-fix`
- `go test ./pkg/...`
- `task cross-lint:all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now include mediaId; browse entries include tags and history/top include computed relativePath. media.meta returns full metadata and supports single or batch lookup by mediaId or system+path. media.image supports batch requests with per-item image-type preferences and robust fallback when files are missing. WebSocket accepts larger batch-sized requests.

* **Documentation**
  * API docs updated with mediaId examples, batch rules, response shapes, and examples.

* **Tests**
  * Expanded tests for batch flows, per-item errors, mediaId/path resolution, image selection, and relativePath.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->