### PR TITLE
feat(api): add favorite media tags

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -232,7 +232,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods are used to execute actions and request data back from the API. The current API provides **58 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
+Methods are used to execute actions and request data back from the API. The current API provides **59 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
 
 | ID                              | Description                                                                           |
 | :------------------------------ | :------------------------------------------------------------------------------------ |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -247,6 +247,7 @@ Methods are used to execute actions and request data back from the API. The curr
 | media.active.update             | Update the currently active media information.                                        |
 | media.search                    | Query the media database and return all matching indexed media.                       |
 | media.tags                      | Query available tags for filtering media search results.                              |
+| media.tags.update               | Add or remove user tags for indexed media.                                            |
 | media.generate                  | Start a new media database index.                                                     |
 | media.generate.cancel           | Cancel any currently running media database indexing operation.                       |
 | media.generate.resume           | Resume paused media database indexing.                                                |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -761,6 +761,63 @@ have finite vocabularies per system and are always returned in full without trun
 }
 ```
 
+### media.tags.update
+
+Add or remove user tags for an indexed media item.
+
+The initial mutable tag is `user:favorite`. It appears in normal media tag results and can be queried with `media.search` tag filters such as `user:favorite`, `-user:favorite`, and `~user:favorite`.
+
+#### Parameters
+
+| Key     | Type     | Required | Description                                               |
+| :------ | :------- | :------- | :-------------------------------------------------------- |
+| mediaId | number   | No       | Media DBID to update. Cannot be mixed with system/path.   |
+| system  | string   | No       | System ID for path-based lookup. Required when using path. |
+| path    | string   | No       | Media path for path-based lookup. Required with system.    |
+| add     | string[] | No       | Tags to add. Currently only `user:favorite` is mutable.    |
+| remove  | string[] | No       | Tags to remove. Currently only `user:favorite` is mutable. |
+
+Either `mediaId` or `system` plus `path` is required. At least one of `add` or `remove` is required. Search operators (`+`, `-`, `~`) are not valid in mutation requests.
+
+#### Result
+
+| Key  | Type                         | Required | Description                          |
+| :--- | :--------------------------- | :------- | :----------------------------------- |
+| tags | [TagInfo](#taginfo-object)[] | Yes      | Effective tags for the media item.   |
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "a1b2c3d4-7a5d-11ef-9c7b-020304050607",
+  "method": "media.tags.update",
+  "params": {
+    "mediaId": 42,
+    "add": ["user:favorite"]
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "a1b2c3d4-7a5d-11ef-9c7b-020304050607",
+  "result": {
+    "tags": [
+      {
+        "type": "user",
+        "tag": "favorite"
+      }
+    ]
+  }
+}
+```
+
 ### media.generate
 
 Create a new media database index.

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -210,7 +210,7 @@ func TestHandleMediaImage_MediaNotFound(t *testing.T) {
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	system := database.System{DBID: 100, SystemID: "NES", Name: "NES"}
-	mediaPath := filepath.Join("games", "missing.rom")
+	mediaPath := filepath.ToSlash(filepath.Join("games", "missing.rom"))
 	mockDB.On("FindSystemBySystemID", "NES").Return(system, nil)
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, system.DBID, mediaPath).
 		Return((*database.Media)(nil), nil)

--- a/pkg/api/methods/media_tags_update.go
+++ b/pkg/api/methods/media_tags_update.go
@@ -1,0 +1,172 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/filters"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/rs/zerolog/log"
+)
+
+func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocritic // API handler shape
+	log.Info().Msg("received media tags update request")
+
+	var params models.MediaTagsUpdateParams
+	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	if len(params.Add) == 0 && len(params.Remove) == 0 {
+		return nil, models.ClientErrf("invalid params: add or remove is required")
+	}
+	if err := validateMediaRef(mediaRefParam{MediaID: params.MediaID, System: params.System, Path: params.Path}); err != nil {
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	add, err := parseMutableUserTags(params.Add)
+	if err != nil {
+		return nil, models.ClientErrf("invalid add tags: %w", err)
+	}
+	remove, err := parseMutableUserTags(params.Remove)
+	if err != nil {
+		return nil, models.ClientErrf("invalid remove tags: %w", err)
+	}
+
+	resolved, err := resolveMediaRefs(&env, []mediaRefParam{{
+		MediaID: params.MediaID,
+		System:  params.System,
+		Path:    params.Path,
+	}})
+	if err != nil {
+		return nil, err
+	}
+	if len(resolved) != 1 || resolved[0].Err != nil || resolved[0].Row == nil {
+		if len(resolved) == 1 && resolved[0].Err != nil {
+			return nil, resolved[0].Err
+		}
+		return nil, models.ClientErrf("media not found")
+	}
+
+	row := resolved[0].Row
+	for _, tag := range remove {
+		if err := removeMediaUserTag(env.Database.MediaDB, row.DBID, tag); err != nil {
+			return nil, err
+		}
+	}
+	for _, tag := range add {
+		if err := addMediaUserTag(env.Database.MediaDB, row.DBID, tag); err != nil {
+			return nil, err
+		}
+	}
+
+	fileTags, err := env.Database.MediaDB.GetMediaTagsByMediaDBID(env.Context, row.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media tags: %w", err)
+	}
+	titleTags, err := env.Database.MediaDB.GetMediaTitleTagsByMediaTitleDBID(env.Context, row.Title.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get media title tags: %w", err)
+	}
+
+	return models.TagsResponse{Tags: append(fileTags, titleTags...)}, nil
+}
+
+func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
+	if len(rawTags) == 0 {
+		return nil, nil
+	}
+	for _, raw := range rawTags {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			return nil, fmt.Errorf("tag cannot be empty")
+		}
+		if strings.HasPrefix(trimmed, "+") || strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "~") {
+			return nil, fmt.Errorf("tag operators are not allowed for mutation: %q", raw)
+		}
+	}
+
+	parsed, err := filters.ParseTagFilters(rawTags)
+	if err != nil {
+		return nil, err
+	}
+	for _, tag := range parsed {
+		if tag.Type != string(tags.TagTypeUser) || tag.Value != string(tags.TagUserFavorite) {
+			return nil, fmt.Errorf("only %s:%s can be mutated", tags.TagTypeUser, tags.TagUserFavorite)
+		}
+	}
+
+	return parsed, nil
+}
+
+func addMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.TagFilter) error {
+	tagType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type:        tag.Type,
+		IsExclusive: tags.IsExclusiveType(tags.TagType(tag.Type)),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find or insert tag type: %w", err)
+	}
+
+	tagRow, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tagType.DBID, Tag: tag.Value})
+	if err != nil {
+		return fmt.Errorf("failed to find or insert tag: %w", err)
+	}
+
+	if _, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{MediaDBID: mediaDBID, TagDBID: tagRow.DBID}); err != nil {
+		return fmt.Errorf("failed to find or insert media tag: %w", err)
+	}
+
+	return nil
+}
+
+func removeMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.TagFilter) error {
+	tagType, err := mediaDB.FindTagType(database.TagType{Type: tag.Type})
+	if err != nil {
+		return ignoreMissingTag(err)
+	}
+
+	tagRow, err := mediaDB.FindTag(database.Tag{TypeDBID: tagType.DBID, Tag: tag.Value})
+	if err != nil {
+		return ignoreMissingTag(err)
+	}
+
+	if err = mediaDB.DeleteMediaTag(mediaDBID, tagRow.DBID); err != nil {
+		return fmt.Errorf("failed to delete media tag: %w", err)
+	}
+
+	return nil
+}
+
+func ignoreMissingTag(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
+}

--- a/pkg/api/methods/media_tags_update.go
+++ b/pkg/api/methods/media_tags_update.go
@@ -46,7 +46,12 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 	if len(params.Add) == 0 && len(params.Remove) == 0 {
 		return nil, models.ClientErrf("invalid params: add or remove is required")
 	}
-	if err := validateMediaRef(mediaRefParam{MediaID: params.MediaID, System: params.System, Path: params.Path}); err != nil {
+	mediaRef := mediaRefParam{
+		MediaID: params.MediaID,
+		System:  params.System,
+		Path:    params.Path,
+	}
+	if err := validateMediaRef(mediaRef); err != nil {
 		return nil, models.ClientErrf("invalid params: %w", err)
 	}
 
@@ -59,11 +64,7 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 		return nil, models.ClientErrf("invalid remove tags: %w", err)
 	}
 
-	resolved, err := resolveMediaRefs(&env, []mediaRefParam{{
-		MediaID: params.MediaID,
-		System:  params.System,
-		Path:    params.Path,
-	}})
+	resolved, err := resolveMediaRefs(&env, []mediaRefParam{mediaRef})
 	if err != nil {
 		return nil, err
 	}
@@ -75,15 +76,8 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 	}
 
 	row := resolved[0].Row
-	for _, tag := range remove {
-		if err := removeMediaUserTag(env.Database.MediaDB, row.DBID, tag); err != nil {
-			return nil, err
-		}
-	}
-	for _, tag := range add {
-		if err := addMediaUserTag(env.Database.MediaDB, row.DBID, tag); err != nil {
-			return nil, err
-		}
+	if updateErr := updateMediaUserTags(env.Database.MediaDB, row.DBID, remove, add); updateErr != nil {
+		return nil, updateErr
 	}
 
 	fileTags, err := env.Database.MediaDB.GetMediaTagsByMediaDBID(env.Context, row.DBID)
@@ -105,7 +99,7 @@ func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
 	for _, raw := range rawTags {
 		trimmed := strings.TrimSpace(raw)
 		if trimmed == "" {
-			return nil, fmt.Errorf("tag cannot be empty")
+			return nil, errors.New("tag cannot be empty")
 		}
 		if strings.HasPrefix(trimmed, "+") || strings.HasPrefix(trimmed, "-") || strings.HasPrefix(trimmed, "~") {
 			return nil, fmt.Errorf("tag operators are not allowed for mutation: %q", raw)
@@ -114,7 +108,7 @@ func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
 
 	parsed, err := filters.ParseTagFilters(rawTags)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse tag filters: %w", err)
 	}
 	for _, tag := range parsed {
 		if tag.Type != string(tags.TagTypeUser) || tag.Value != string(tags.TagUserFavorite) {
@@ -123,6 +117,43 @@ func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
 	}
 
 	return parsed, nil
+}
+
+func updateMediaUserTags(
+	mediaDB database.MediaDBI,
+	mediaDBID int64,
+	remove []zapscript.TagFilter,
+	add []zapscript.TagFilter,
+) error {
+	if err := mediaDB.BeginTransaction(false); err != nil {
+		return fmt.Errorf("failed to begin media tag update transaction: %w", err)
+	}
+
+	for _, tag := range remove {
+		if err := removeMediaUserTag(mediaDB, mediaDBID, tag); err != nil {
+			rollbackMediaTagUpdate(mediaDB)
+			return err
+		}
+	}
+	for _, tag := range add {
+		if err := addMediaUserTag(mediaDB, mediaDBID, tag); err != nil {
+			rollbackMediaTagUpdate(mediaDB)
+			return err
+		}
+	}
+
+	if err := mediaDB.CommitTransaction(); err != nil {
+		rollbackMediaTagUpdate(mediaDB)
+		return fmt.Errorf("failed to commit media tag update transaction: %w", err)
+	}
+
+	return nil
+}
+
+func rollbackMediaTagUpdate(mediaDB database.MediaDBI) {
+	if rbErr := mediaDB.RollbackTransaction(); rbErr != nil {
+		log.Error().Err(rbErr).Msg("failed to rollback media tag update transaction")
+	}
 }
 
 func addMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.TagFilter) error {
@@ -139,7 +170,11 @@ func addMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.T
 		return fmt.Errorf("failed to find or insert tag: %w", err)
 	}
 
-	if _, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{MediaDBID: mediaDBID, TagDBID: tagRow.DBID}); err != nil {
+	mediaTag := database.MediaTag{
+		MediaDBID: mediaDBID,
+		TagDBID:   tagRow.DBID,
+	}
+	if _, err = mediaDB.FindOrInsertMediaTag(mediaTag); err != nil {
 		return fmt.Errorf("failed to find or insert media tag: %w", err)
 	}
 

--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -22,6 +22,7 @@ package methods
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -103,6 +104,55 @@ func TestHandleMediaTagsUpdate_RejectsEmptyTags(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaTagsUpdate_RejectsUnsupportedTags(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["genre:platform"]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "only user:favorite can be mutated")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaTagsUpdate_RollsBackWhenAddFails(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: mediaTagsUpdateRow()}, nil).Once()
+	mockDB.On("BeginTransaction", false).Return(nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
+		Return(database.TagType{}, errors.New("tag type insert failed")).Once()
+	mockDB.On("RollbackTransaction").Return(nil).Once()
+
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find or insert tag type")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaTagsUpdate_RollsBackWhenCommitFails(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: mediaTagsUpdateRow()}, nil).Once()
+	mockDB.On("BeginTransaction", false).Return(nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
+		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeUser)}, nil).Once()
+	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagUserFavorite)}).
+		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagUserFavorite)}, nil).Once()
+	mockDB.On("FindOrInsertMediaTag", database.MediaTag{MediaDBID: 1, TagDBID: 12}).
+		Return(database.MediaTag{MediaDBID: 1, TagDBID: 12}, nil).Once()
+	mockDB.On("CommitTransaction").Return(errors.New("commit failed")).Once()
+	mockDB.On("RollbackTransaction").Return(nil).Once()
+
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to commit media tag update transaction")
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
 	t.Parallel()
 
@@ -156,6 +206,18 @@ func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
 	))
 	require.NoError(t, err)
 	assertTagsContainFavorite(t, result)
+}
+
+func mediaTagsUpdateRow() database.MediaFullRow {
+	return database.MediaFullRow{
+		Media: database.Media{DBID: 1},
+		Title: database.MediaTitle{DBID: 10},
+		System: database.System{
+			DBID:     100,
+			SystemID: "NES",
+			Name:     "NES",
+		},
+	}
 }
 
 func addTestMediaPaths(t *testing.T, mediaDB database.MediaDBI, paths ...string) []int64 {

--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -1,0 +1,227 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMediaTagsUpdateEnv(mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+	return requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Params:   []byte(params),
+	}
+}
+
+func TestHandleMediaTagsUpdate_AddsFavoriteTag(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := database.MediaFullRow{
+		Media: database.Media{DBID: 1},
+		Title: database.MediaTitle{DBID: 10},
+		System: database.System{
+			DBID:     100,
+			SystemID: "NES",
+			Name:     "NES",
+		},
+	}
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
+		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeUser)}, nil).Once()
+	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagUserFavorite)}).
+		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagUserFavorite)}, nil).Once()
+	mockDB.On("FindOrInsertMediaTag", database.MediaTag{MediaDBID: 1, TagDBID: 12}).
+		Return(database.MediaTag{DBID: 13, MediaDBID: 1, TagDBID: 12}, nil).Once()
+	mockDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(1)).
+		Return([]database.TagInfo{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}}, nil).Once()
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
+		Return([]database.TagInfo{}, nil).Once()
+
+	result, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	require.NoError(t, err)
+
+	resp, ok := result.(models.TagsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []database.TagInfo{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}}, resp.Tags)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaTagsUpdate_RejectsSearchOperators(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["~user:favorite"]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag operators are not allowed")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaTagsUpdate_RejectsEmptyTags(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":[" "]}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tag cannot be empty")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	favoritePath := filepath.Join("roms", "NES", "Favorite Game.nes")
+	otherPath := filepath.Join("roms", "NES", "Other Game.nes")
+	mediaIDs := addTestMediaPaths(t, mediaDB, favoritePath, otherPath)
+	favoriteID := mediaIDs[0]
+	otherID := mediaIDs[1]
+
+	baseEnv := requests.RequestEnv{
+		Context:  ctx,
+		Database: &database.Database{MediaDB: mediaDB},
+	}
+
+	result, err := HandleMediaTagsUpdate(withParams(baseEnv, fmt.Sprintf(`{"mediaId":%d,"add":["user:favorite"]}`, favoriteID)))
+	require.NoError(t, err)
+	assertTagsContainFavorite(t, result)
+
+	searchResult := searchByTags(t, baseEnv, []string{"user:favorite"})
+	require.Len(t, searchResult.Results, 1)
+	assert.Equal(t, favoriteID, searchResult.Results[0].MediaID)
+	assert.Contains(t, searchResult.Results[0].Tags, database.TagInfo{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)})
+
+	searchResult = searchByTags(t, baseEnv, []string{"-user:favorite"})
+	require.Len(t, searchResult.Results, 1)
+	assert.Equal(t, otherID, searchResult.Results[0].MediaID)
+
+	tagsResult, err := HandleMediaTags(baseEnv)
+	require.NoError(t, err)
+	assertTagsContainFavorite(t, tagsResult)
+
+	result, err = HandleMediaTagsUpdate(withParams(baseEnv, fmt.Sprintf(`{"mediaId":%d,"remove":["user:favorite"]}`, favoriteID)))
+	require.NoError(t, err)
+	assertTagsDoNotContainFavorite(t, result)
+
+	searchResult = searchByTags(t, baseEnv, []string{"user:favorite"})
+	assert.Empty(t, searchResult.Results)
+
+	result, err = HandleMediaTagsUpdate(withParams(
+		baseEnv,
+		fmt.Sprintf(`{"system":"NES","path":%q,"add":["user:favorite"]}`, filepath.ToSlash(favoritePath)),
+	))
+	require.NoError(t, err)
+	assertTagsContainFavorite(t, result)
+}
+
+func addTestMediaPaths(t *testing.T, mediaDB database.MediaDBI, paths ...string) []int64 {
+	t.Helper()
+
+	state := newTestScanState()
+	require.NoError(t, mediascanner.SeedCanonicalTags(mediaDB, state))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	mediaIDs := make([]int64, 0, len(paths))
+	for _, path := range paths {
+		_, mediaID, err := mediascanner.AddMediaPath(mediaDB, state, "NES", path, false, false, nil, slugs.MediaTypeGame)
+		require.NoError(t, err)
+		mediaIDs = append(mediaIDs, int64(mediaID))
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	return mediaIDs
+}
+
+func newTestScanState() *database.ScanState {
+	return &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+}
+
+func withParams(env requests.RequestEnv, params string) requests.RequestEnv {
+	env.Params = []byte(params)
+	return env
+}
+
+func searchByTags(t *testing.T, env requests.RequestEnv, rawTags []string) models.SearchResults {
+	t.Helper()
+
+	params := models.SearchParams{Tags: &rawTags}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	result, err := HandleMediaSearch(withParams(env, string(paramsJSON)))
+	require.NoError(t, err)
+	searchResult, ok := result.(models.SearchResults)
+	require.True(t, ok)
+
+	return searchResult
+}
+
+func assertTagsContainFavorite(t *testing.T, result any) {
+	t.Helper()
+
+	resp, ok := result.(models.TagsResponse)
+	require.True(t, ok)
+	assert.True(t, hasFavoriteTag(resp.Tags), "expected favorite tag in %+v", resp.Tags)
+}
+
+func assertTagsDoNotContainFavorite(t *testing.T, result any) {
+	t.Helper()
+
+	resp, ok := result.(models.TagsResponse)
+	require.True(t, ok)
+	assert.False(t, hasFavoriteTag(resp.Tags), "expected no favorite tag in %+v", resp.Tags)
+}
+
+func hasFavoriteTag(tagList []database.TagInfo) bool {
+	for _, tag := range tagList {
+		if tag.Type == string(tags.TagTypeUser) && tag.Tag == string(tags.TagUserFavorite) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -61,12 +61,14 @@ func TestHandleMediaTagsUpdate_AddsFavoriteTag(t *testing.T) {
 	}
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("BeginTransaction", false).Return(nil).Once()
 	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
 		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeUser)}, nil).Once()
 	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagUserFavorite)}).
 		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagUserFavorite)}, nil).Once()
 	mockDB.On("FindOrInsertMediaTag", database.MediaTag{MediaDBID: 1, TagDBID: 12}).
 		Return(database.MediaTag{DBID: 13, MediaDBID: 1, TagDBID: 12}, nil).Once()
+	mockDB.On("CommitTransaction").Return(nil).Once()
 	mockDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(1)).
 		Return([]database.TagInfo{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}}, nil).Once()
 	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
@@ -119,16 +121,20 @@ func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
 		Database: &database.Database{MediaDB: mediaDB},
 	}
 
-	result, err := HandleMediaTagsUpdate(withParams(baseEnv, fmt.Sprintf(`{"mediaId":%d,"add":["user:favorite"]}`, favoriteID)))
+	addParams := fmt.Sprintf(`{"mediaId":%d,"add":["user:favorite"]}`, favoriteID)
+	result, err := HandleMediaTagsUpdate(withParams(&baseEnv, addParams))
 	require.NoError(t, err)
 	assertTagsContainFavorite(t, result)
 
-	searchResult := searchByTags(t, baseEnv, []string{"user:favorite"})
+	searchResult := searchByTags(t, &baseEnv, []string{"user:favorite"})
 	require.Len(t, searchResult.Results, 1)
 	assert.Equal(t, favoriteID, searchResult.Results[0].MediaID)
-	assert.Contains(t, searchResult.Results[0].Tags, database.TagInfo{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)})
+	assert.Contains(t, searchResult.Results[0].Tags, database.TagInfo{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	})
 
-	searchResult = searchByTags(t, baseEnv, []string{"-user:favorite"})
+	searchResult = searchByTags(t, &baseEnv, []string{"-user:favorite"})
 	require.Len(t, searchResult.Results, 1)
 	assert.Equal(t, otherID, searchResult.Results[0].MediaID)
 
@@ -136,15 +142,16 @@ func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
 	require.NoError(t, err)
 	assertTagsContainFavorite(t, tagsResult)
 
-	result, err = HandleMediaTagsUpdate(withParams(baseEnv, fmt.Sprintf(`{"mediaId":%d,"remove":["user:favorite"]}`, favoriteID)))
+	removeParams := fmt.Sprintf(`{"mediaId":%d,"remove":["user:favorite"]}`, favoriteID)
+	result, err = HandleMediaTagsUpdate(withParams(&baseEnv, removeParams))
 	require.NoError(t, err)
 	assertTagsDoNotContainFavorite(t, result)
 
-	searchResult = searchByTags(t, baseEnv, []string{"user:favorite"})
+	searchResult = searchByTags(t, &baseEnv, []string{"user:favorite"})
 	assert.Empty(t, searchResult.Results)
 
 	result, err = HandleMediaTagsUpdate(withParams(
-		baseEnv,
+		&baseEnv,
 		fmt.Sprintf(`{"system":"NES","path":%q,"add":["user:favorite"]}`, filepath.ToSlash(favoritePath)),
 	))
 	require.NoError(t, err)
@@ -159,7 +166,16 @@ func addTestMediaPaths(t *testing.T, mediaDB database.MediaDBI, paths ...string)
 	require.NoError(t, mediaDB.BeginTransaction(true))
 	mediaIDs := make([]int64, 0, len(paths))
 	for _, path := range paths {
-		_, mediaID, err := mediascanner.AddMediaPath(mediaDB, state, "NES", path, false, false, nil, slugs.MediaTypeGame)
+		_, mediaID, err := mediascanner.AddMediaPath(
+			mediaDB,
+			state,
+			"NES",
+			path,
+			false,
+			false,
+			nil,
+			slugs.MediaTypeGame,
+		)
 		require.NoError(t, err)
 		mediaIDs = append(mediaIDs, int64(mediaID))
 	}
@@ -181,12 +197,13 @@ func newTestScanState() *database.ScanState {
 	}
 }
 
-func withParams(env requests.RequestEnv, params string) requests.RequestEnv {
-	env.Params = []byte(params)
-	return env
+func withParams(env *requests.RequestEnv, params string) requests.RequestEnv {
+	next := *env
+	next.Params = []byte(params)
+	return next
 }
 
-func searchByTags(t *testing.T, env requests.RequestEnv, rawTags []string) models.SearchResults {
+func searchByTags(t *testing.T, env *requests.RequestEnv, rawTags []string) models.SearchResults {
 	t.Helper()
 
 	params := models.SearchParams{Tags: &rawTags}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -60,6 +60,7 @@ const (
 	MethodMediaIndex           = "media.index" // DEPRECATED
 	MethodMediaSearch          = "media.search"
 	MethodMediaTags            = "media.tags"
+	MethodMediaTagsUpdate      = "media.tags.update"
 	MethodMediaActive          = "media.active"
 	MethodMediaHistory         = "media.history"
 	MethodMediaHistoryTop      = "media.history.top"

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -184,6 +184,14 @@ type MediaMetaParams struct {
 	Path    string `json:"path"   validate:"omitempty,min=1"`
 }
 
+type MediaTagsUpdateParams struct {
+	MediaID *int64   `json:"mediaId,omitempty"`
+	System  string   `json:"system" validate:"omitempty,min=1"`
+	Path    string   `json:"path"   validate:"omitempty,min=1"`
+	Add     []string `json:"add,omitempty" validate:"omitempty,dive,min=1"`
+	Remove  []string `json:"remove,omitempty" validate:"omitempty,dive,min=1"`
+}
+
 type MediaImageParams struct {
 	MediaID    *int64   `json:"mediaId,omitempty"`
 	System     string   `json:"system"            validate:"omitempty,min=1"`

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -238,6 +238,7 @@ func NewMethodMap() *MethodMap {
 		models.MethodMediaSearch:         methods.HandleMediaSearch,
 		models.MethodMediaBrowse:         methods.HandleMediaBrowse,
 		models.MethodMediaTags:           methods.HandleMediaTags,
+		models.MethodMediaTagsUpdate:     methods.HandleMediaTagsUpdate,
 		models.MethodMediaActive:         methods.HandleActiveMedia,
 		models.MethodMediaActiveUpdate:   methods.HandleUpdateActiveMedia,
 		models.MethodMediaCleanOrphans:   methods.HandleMediaCleanOrphans,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -400,19 +400,20 @@ type SearchFilters struct {
 }
 
 type ScanState struct {
-	SystemIDs     map[string]int
-	TitleIDs      map[string]int
-	MediaIDs      map[string]int
-	MediaTitleIDs map[int]int // Existing media DBID -> MediaTitleDBID for persistent reconciliation
-	MediaTagIDs   map[int]map[int]struct{}
-	TagTypeIDs    map[string]int
-	TagIDs        map[string]int
-	MissingMedia  map[int]struct{} // DBIDs of media not yet re-found during scan
-	SystemsIndex  int
-	TitlesIndex   int
-	MediaIndex    int
-	TagTypesIndex int
-	TagsIndex     int
+	SystemIDs       map[string]int
+	TitleIDs        map[string]int
+	MediaIDs        map[string]int
+	MediaTitleIDs   map[int]int // Existing media DBID -> MediaTitleDBID for persistent reconciliation
+	MediaTagIDs     map[int]map[int]struct{}
+	TagTypeIDs      map[string]int
+	TagIDs          map[string]int
+	UserOwnedTagIDs map[int]bool
+	MissingMedia    map[int]struct{} // DBIDs of media not yet re-found during scan
+	SystemsIndex    int
+	TitlesIndex     int
+	MediaIndex      int
+	TagTypesIndex   int
+	TagsIndex       int
 }
 
 // JournalMode represents SQLite journal mode

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -128,6 +128,62 @@ func insertTaggedGame(
 	require.NoError(t, err)
 }
 
+func TestMediaTagCompositeLookupAndDelete(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	t.Cleanup(cleanup)
+
+	insertedTagType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "user"})
+	require.NoError(t, err)
+	insertedTag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: insertedTagType.DBID, Tag: "favorite"})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: "nes", Name: "NES"})
+	require.NoError(t, err)
+	insertedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "favoritegame",
+		Name:       "Favorite Game",
+	})
+	require.NoError(t, err)
+	insertedMedia, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     insertedSystem.DBID,
+		MediaTitleDBID: insertedTitle.DBID,
+		Path:           filepath.Join("roms", "nes", "favorite.nes"),
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMediaTag(database.MediaTag{
+		MediaDBID: insertedMedia.DBID,
+		TagDBID:   insertedTag.DBID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	found, err := mediaDB.FindMediaTag(database.MediaTag{
+		MediaDBID: insertedMedia.DBID,
+		TagDBID:   insertedTag.DBID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, insertedMedia.DBID, found.MediaDBID)
+	assert.Equal(t, insertedTag.DBID, found.TagDBID)
+
+	_, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{
+		MediaDBID: insertedMedia.DBID,
+		TagDBID:   insertedTag.DBID,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.DeleteMediaTag(insertedMedia.DBID, insertedTag.DBID))
+	_, err = mediaDB.FindMediaTag(database.MediaTag{
+		MediaDBID: insertedMedia.DBID,
+		TagDBID:   insertedTag.DBID,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}
+
 func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {
 	// Create temp directory that the mock platform will use
 	tempDir, err := os.MkdirTemp("", "zaparoo-test-mediadb-*")

--- a/pkg/database/mediadb/sql_media_tags.go
+++ b/pkg/database/mediadb/sql_media_tags.go
@@ -34,13 +34,10 @@ func sqlFindMediaTag(ctx context.Context, db sqlQueryable, mediaTag database.Med
 	var row database.MediaTag
 	stmt, err := db.PrepareContext(ctx, `
 		select
-		DBID, MediaDBID, TagDBID
+		MediaDBID, TagDBID
 		from MediaTags
-		where DBID = ?
-		or (
-			MediaDBID = ?
-			and TagDBID = ?
-		)
+		where MediaDBID = ?
+		and TagDBID = ?
 		LIMIT 1;
 	`)
 	if err != nil {
@@ -52,11 +49,9 @@ func sqlFindMediaTag(ctx context.Context, db sqlQueryable, mediaTag database.Med
 		}
 	}()
 	err = stmt.QueryRowContext(ctx,
-		mediaTag.DBID,
 		mediaTag.MediaDBID,
 		mediaTag.TagDBID,
 	).Scan(
-		&row.DBID,
 		&row.MediaDBID,
 		&row.TagDBID,
 	)

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -380,16 +380,24 @@ func reconcileExistingMediaTags(
 }
 
 func isUserOwnedTagID(ss *database.ScanState, tagIndex int) bool {
+	ensureUserOwnedTagIDs(ss)
+	return ss.UserOwnedTagIDs[tagIndex]
+}
+
+func ensureUserOwnedTagIDs(ss *database.ScanState) {
+	if ss.UserOwnedTagIDs != nil {
+		return
+	}
+
+	ss.UserOwnedTagIDs = make(map[int]bool)
 	for tagKey, id := range ss.TagIDs {
-		if id != tagIndex {
+		tagType, _, found := strings.Cut(tagKey, ":")
+		if !found || !tags.IsUserOwnedType(tags.TagType(tagType)) {
 			continue
 		}
 
-		tagType, _, found := strings.Cut(tagKey, ":")
-		return found && tags.IsUserOwnedType(tags.TagType(tagType))
+		ss.UserOwnedTagIDs[id] = true
 	}
-
-	return false
 }
 
 func insertDesiredMediaTags(
@@ -732,10 +740,14 @@ func PopulateScanStateFromDB(ctx context.Context, db database.MediaDBI, ss *data
 	if err != nil {
 		return fmt.Errorf("failed to get existing tags: %w", err)
 	}
+	ss.UserOwnedTagIDs = make(map[int]bool)
 	for _, tag := range allTags {
 		tagType := tagTypeByDBID[tag.TypeDBID]
 		compositeKey := database.TagKey(tagType, tag.Tag)
 		ss.TagIDs[compositeKey] = int(tag.DBID)
+		if tags.IsUserOwnedType(tags.TagType(tagType)) {
+			ss.UserOwnedTagIDs[int(tag.DBID)] = true
+		}
 	}
 
 	log.Debug().

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -356,6 +356,10 @@ func reconcileExistingMediaTags(
 		if _, ok := desiredTagIDs[tagIndex]; ok {
 			continue
 		}
+		if isUserOwnedTagID(ss, tagIndex) {
+			desiredTagIDs[tagIndex] = struct{}{}
+			continue
+		}
 		if err := db.DeleteMediaTag(int64(mediaIndex), int64(tagIndex)); err != nil {
 			return fmt.Errorf("failed to delete media tag %d: %w", tagIndex, err)
 		}
@@ -373,6 +377,19 @@ func reconcileExistingMediaTags(
 	ss.MediaTagIDs[mediaIndex] = cloneMediaTagSet(desiredTagIDs)
 
 	return nil
+}
+
+func isUserOwnedTagID(ss *database.ScanState, tagIndex int) bool {
+	for tagKey, id := range ss.TagIDs {
+		if id != tagIndex {
+			continue
+		}
+
+		tagType, _, found := strings.Cut(tagKey, ":")
+		return found && tags.IsUserOwnedType(tags.TagType(tagType))
+	}
+
+	return false
 }
 
 func insertDesiredMediaTags(

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -352,6 +352,98 @@ func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testi
 	mockDB.AssertExpectations(t)
 }
 
+func TestAddMediaPath_ReconcileExistingMediaTagsPreservesUserTags(t *testing.T) {
+	t.Parallel()
+
+	mockDB := helpers.NewMockMediaDBI()
+	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
+	scanState := &database.ScanState{
+		SystemIDs:     map[string]int{"NES": 1},
+		TitleIDs:      map[string]int{"NES:supermariobrothers": 10},
+		MediaIDs:      map[string]int{database.MediaKey("NES", pathKey): 20},
+		MediaTitleIDs: map[int]int{20: 10},
+		MediaTagIDs:   map[int]map[int]struct{}{20: {8: {}, 9: {}}},
+		TagTypeIDs:    map[string]int{string(tags.TagTypeExtension): 7, string(tags.TagTypeUser): 11},
+		TagIDs: map[string]int{
+			database.TagKey(string(tags.TagTypeExtension), "nes"):                   8,
+			database.TagKey(string(tags.TagTypeUser), string(tags.TagUserFavorite)): 9,
+		},
+		MissingMedia: map[int]struct{}{20: {}},
+	}
+
+	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	assert.Equal(t, 10, titleIndex)
+	assert.Equal(t, 20, mediaIndex)
+	assert.Contains(t, scanState.MediaTagIDs[20], 8)
+	assert.Contains(t, scanState.MediaTagIDs[20], 9)
+	mockDB.AssertNotCalled(t, "DeleteMediaTag", mock.Anything, mock.Anything)
+	mockDB.AssertExpectations(t)
+}
+
+func TestAddMediaPath_LoadedScanStatePreservesUserTags(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	initialState := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, mediaID, err := AddMediaPath(mediaDB, initialState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	userType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false})
+	require.NoError(t, err)
+	userTag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: userType.DBID, Tag: string(tags.TagUserFavorite)})
+	require.NoError(t, err)
+	_, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{MediaDBID: int64(mediaID), TagDBID: userTag.DBID})
+	require.NoError(t, err)
+
+	refreshState := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, PopulateScanStateFromDB(ctx, mediaDB, refreshState))
+	require.NoError(t, PopulatePersistentScanStateForSystem(ctx, mediaDB, refreshState, "NES"))
+
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	var favoriteCount int
+	err = mediaDB.UnsafeGetSQLDb().QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM MediaTags mt
+		JOIN Tags t ON t.DBID = mt.TagDBID
+		JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+		WHERE mt.MediaDBID = ? AND tt.Type = ? AND t.Tag = ?`,
+		mediaID, string(tags.TagTypeUser), string(tags.TagUserFavorite),
+	).Scan(&favoriteCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, favoriteCount)
+}
+
 func TestAddMediaPath_ExistingMediaWithoutTagStateDoesNotDeleteAllTags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -129,6 +129,11 @@ const (
 	TagTypeRating        TagType = "rating"        // Numeric rating (scraped, stored as integer 0-100)
 	TagTypeGenre         TagType = "genre"         // Game genre (scraped from external sources; additive)
 	TagTypeGameFamily    TagType = "gamefamily"    // Game family/series (scraped from EmulationStation family field)
+	TagTypeUser          TagType = "user"
+)
+
+const (
+	TagUserFavorite TagValue = "favorite"
 )
 
 // Tag Format:

--- a/pkg/database/tags/tags_test.go
+++ b/pkg/database/tags/tags_test.go
@@ -67,6 +67,7 @@ func TestTagTypeConstants(t *testing.T) {
 		{"Media", TagTypeMedia, "media"},
 		{"Extension", TagTypeExtension, "extension"},
 		{"Unknown", TagTypeUnknown, "unknown"},
+		{"User", TagTypeUser, "user"},
 	}
 
 	for _, tt := range tests {
@@ -85,7 +86,7 @@ func TestTagTypeNaming(t *testing.T) {
 		TagTypeLang, TagTypeUnfinished, TagTypeRerelease, TagTypeRev, TagTypeSet,
 		TagTypeAlt, TagTypeUnlicensed, TagTypeMameParent, TagTypeRegion, TagTypeYear,
 		TagTypeVideo, TagTypeCopyright, TagTypeDump, TagTypeMedia, TagTypeExtension,
-		TagTypeUnknown,
+		TagTypeUnknown, TagTypeUser,
 	}
 
 	for _, tagType := range allTypes {
@@ -112,6 +113,14 @@ func TestTagTypeNaming(t *testing.T) {
 				"TagType must only contain lowercase letters and numbers, starting with a letter")
 		})
 	}
+}
+
+func TestIsUserOwnedType(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsUserOwnedType(TagTypeUser))
+	assert.False(t, IsUserOwnedType(TagTypeGenre))
+	assert.False(t, IsUserOwnedType(TagType("custom")))
 }
 
 // TestCanonicalTagDefinitionsCompleteness verifies all TagTypes have entries

--- a/pkg/database/tags/tagtypes.go
+++ b/pkg/database/tags/tagtypes.go
@@ -70,3 +70,9 @@ var CanonicalIsExclusive = map[TagType]bool{
 func IsExclusiveType(t TagType) bool {
 	return CanonicalIsExclusive[t]
 }
+
+// IsUserOwnedType returns true for tag types that users can mutate directly.
+// Scanner reconciliation must preserve these even when generated metadata changes.
+func IsUserOwnedType(t TagType) bool {
+	return t == TagTypeUser
+}


### PR DESCRIPTION
## Summary
- Add `media.tags.update` for mutating the `user:favorite` media tag by media ID or system/path.
- Preserve user-owned media tags during scanner reconciliation and fix `MediaTags` lookup for the composite-key schema.
- Document the endpoint and cover mutation, search, tag-list, scanner preservation, and Windows path expectation behavior with focused tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added media.tags.update API to add/remove user tags (currently supports favorite) on indexed media by ID or system+path.

* **Documentation**
  * API docs updated with method details, parameter rules, examples and response shape.

* **Bug Fixes**
  * Scan/reindex preserves user-owned tags so favorites are no longer removed during rescans.

* **Tests**
  * Added unit and integration tests covering tag mutations, validation, rollback, and scan-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->