### PR TITLE
fix(media): report indexing system before state load

### DIFF
--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -859,6 +859,9 @@ func NewNamesIndex(
 		}
 
 		systemID := sys.ID
+		status.SystemID = systemID
+		status.Step++
+		update(status)
 
 		// Resolve media type once per system to avoid repeated map lookups
 		mediaType := slugs.MediaTypeGame
@@ -868,9 +871,6 @@ func NewNamesIndex(
 
 		if completedSystems[systemID] {
 			log.Debug().Msgf("skipping already indexed system: %s", systemID)
-			status.SystemID = systemID
-			status.Step++
-			update(status)
 			continue
 		}
 
@@ -886,10 +886,6 @@ func NewNamesIndex(
 
 		files := make([]platforms.ScanResult, 0)
 		systemStartTime := time.Now()
-
-		status.SystemID = systemID
-		status.Step++
-		update(status)
 
 		log.Info().
 			Str("system", systemID).

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -498,6 +498,118 @@ func TestNewNamesIndex_SuccessfulResume(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestNewNamesIndex_ReportsSystemBeforeLoadingExistingData(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	launchers := []platforms.Launcher{
+		{
+			ID:       "nes-launcher",
+			SystemID: "nes",
+			Scanner: func(
+				context.Context, *config.Instance, string, []platforms.ScanResult,
+			) ([]platforms.ScanResult, error) {
+				return nil, nil
+			},
+		},
+		{
+			ID:       "snes-launcher",
+			SystemID: "snes",
+			Scanner: func(
+				context.Context, *config.Instance, string, []platforms.ScanResult,
+			) ([]platforms.ScanResult, error) {
+				return nil, nil
+			},
+		},
+	}
+	mockPlatform.On("Launchers", mock.Anything).Return(launchers)
+	mockPlatform.On("RootDirs", mock.Anything).Return([]string{})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.InitializeFromSlice(launchers)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+
+	events := make([]string, 0)
+	recordLoad := func(systemID string) {
+		events = append(events, "load:"+systemID)
+	}
+
+	mockMediaDB.On("BeginTransaction", mock.AnythingOfType("bool")).Return(nil).Maybe()
+	mockMediaDB.On("CommitTransaction").Return(nil).Maybe()
+	mockMediaDB.On("RollbackTransaction").Return(nil).Maybe()
+	mockMediaDB.On("UpdateLastGenerated").Return(nil).Once()
+	mockMediaDB.On("CreateSecondaryIndexes").Return(nil).Once()
+	mockMediaDB.On("PopulateSystemTagsCacheForSystems", mock.Anything, mock.Anything).Return(nil).Once()
+	mockMediaDB.On("RefreshSlugSearchCacheForSystems", mock.Anything, mock.Anything).Return(nil).Once()
+	mockMediaDB.On("SetOptimizationStatus", "pending").Return(nil).Once()
+	mockMediaDB.On("InvalidateCountCache").Return(nil).Once()
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Twice()
+	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
+	mockMediaDB.On("SetIndexingSystems", []string{"nes", "snes"}).Return(nil).Once()
+	mockMediaDB.On("GetMaxSystemID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTitleID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxMediaID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagTypeID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
+	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
+	mockMediaDB.On("InsertTagType", mock.AnythingOfType("database.TagType")).Return(database.TagType{}, nil).Maybe()
+	mockMediaDB.On("InsertTag", mock.AnythingOfType("database.Tag")).Return(database.Tag{}, nil).Maybe()
+	mockMediaDB.On("SetIndexingStatus", "running").Return(nil).Once()
+	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
+	mockMediaDB.On("GetTitlesBySystemID", mock.AnythingOfType("string")).
+		Run(func(args mock.Arguments) { recordLoad(args.String(0)) }).
+		Return([]database.TitleWithSystem{}, nil).Twice()
+	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
+		Return([]database.MediaWithFullPath{}, nil).Twice()
+	mockMediaDB.On("GetMediaTagsBySystemID", mock.AnythingOfType("string")).
+		Return([]database.MediaTagLink{}, nil).Twice()
+	mockMediaDB.On("SetIndexingStatus", "completed").Return(nil).Once()
+	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
+	mockMediaDB.On("SetIndexingSystems", []string(nil)).Return(nil).Once()
+
+	updateFunc := func(status IndexStatus) {
+		if status.SystemID != "" {
+			events = append(events, "status:"+status.SystemID)
+		}
+	}
+
+	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{
+		{ID: "nes"},
+		{ID: "snes"},
+	}, &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, updateFunc, nil)
+	require.NoError(t, err)
+
+	indexOf := func(target string) int {
+		for i, event := range events {
+			if event == target {
+				return i
+			}
+		}
+		return -1
+	}
+
+	require.NotEqual(t, -1, indexOf("status:nes"), "events: %v", events)
+	require.NotEqual(t, -1, indexOf("load:nes"), "events: %v", events)
+	require.NotEqual(t, -1, indexOf("status:snes"), "events: %v", events)
+	require.NotEqual(t, -1, indexOf("load:snes"), "events: %v", events)
+	assert.Less(t, indexOf("status:nes"), indexOf("load:nes"), "events: %v", events)
+	assert.Less(t, indexOf("status:snes"), indexOf("load:snes"), "events: %v", events)
+	mockMediaDB.AssertExpectations(t)
+}
+
 // TestNewNamesIndex_ResumeSystemNotFound tests handling when last indexed system is no longer available
 func TestNewNamesIndex_ResumeSystemNotFound(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Report each media indexing system before loading that system's persisted scan state.
- Prevent progress UI from appearing stuck on the previous small system while the next large system loads existing records.
- Add a regression test covering status emission before per-system state loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed progress status reporting during media library scanning to update at the correct point in the process, eliminating duplicate and out-of-order notifications.

* **Tests**
  * Added comprehensive test to validate proper sequencing of progress updates and data loading operations during scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->