### PR TITLE
fix(api): send indexing notifications for system changes

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -71,6 +71,14 @@ var cappedTagTypes = map[string]bool{
 	"search":     true,
 }
 
+type indexingNotificationState struct {
+	lastTime     time.Time
+	lastPhase    string
+	lastSystemID string
+	lastStep     int
+	hasLast      bool
+}
+
 // capTagsByCategory returns at most limit tags per type, sorted by count desc
 // then tag asc within each group. Long-tail types (credit, publisher, etc.)
 // are capped at limit; taxonomy types (region, year, lang, etc.) are returned
@@ -195,26 +203,6 @@ type indexingStatus struct {
 	indexing    bool
 }
 
-type indexingNotificationState struct {
-	lastTime     time.Time
-	lastPhase    string
-	lastSystemID string
-	lastStep     int
-	hasLast      bool
-}
-
-func isIndexingPhaseStatus(status mediascanner.IndexStatus) bool {
-	switch status.Phase {
-	case mediascanner.PhaseDiscovering,
-		mediascanner.PhaseInitializing,
-		mediascanner.PhaseCreatingIndexes,
-		mediascanner.PhaseBuildingCaches:
-		return true
-	default:
-		return false
-	}
-}
-
 func (s *indexingNotificationState) shouldSend(
 	status mediascanner.IndexStatus,
 	now time.Time,
@@ -224,9 +212,9 @@ func (s *indexingNotificationState) shouldSend(
 		status.Phase != s.lastPhase ||
 		status.SystemID != s.lastSystemID ||
 		status.Step != s.lastStep
-	isFinalStep := status.Step == status.Total
+	isFinalStep := status.Total > 0 && status.Step == status.Total
 
-	if !isIndexingPhaseStatus(status) && !isFinalStep && !visibleStepChanged && now.Sub(s.lastTime) < interval {
+	if !isFinalStep && !visibleStepChanged && now.Sub(s.lastTime) < interval {
 		return false
 	}
 

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -195,6 +195,49 @@ type indexingStatus struct {
 	indexing    bool
 }
 
+type indexingNotificationState struct {
+	lastTime     time.Time
+	lastPhase    string
+	lastSystemID string
+	lastStep     int
+	hasLast      bool
+}
+
+func isIndexingPhaseStatus(status mediascanner.IndexStatus) bool {
+	switch status.Phase {
+	case mediascanner.PhaseDiscovering,
+		mediascanner.PhaseInitializing,
+		mediascanner.PhaseCreatingIndexes,
+		mediascanner.PhaseBuildingCaches:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *indexingNotificationState) shouldSend(
+	status mediascanner.IndexStatus,
+	now time.Time,
+	interval time.Duration,
+) bool {
+	visibleStepChanged := !s.hasLast ||
+		status.Phase != s.lastPhase ||
+		status.SystemID != s.lastSystemID ||
+		status.Step != s.lastStep
+	isFinalStep := status.Step == status.Total
+
+	if !isIndexingPhaseStatus(status) && !isFinalStep && !visibleStepChanged && now.Sub(s.lastTime) < interval {
+		return false
+	}
+
+	s.lastTime = now
+	s.lastPhase = status.Phase
+	s.lastSystemID = status.SystemID
+	s.lastStep = status.Step
+	s.hasLast = true
+	return true
+}
+
 func (s *indexingStatus) get() indexingStatusVals {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -353,7 +396,7 @@ func GenerateMediaDB(
 		defer db.MediaDB.BackgroundOperationDone()
 		defer debug.FreeOSMemory()
 
-		var lastNotifTime time.Time
+		notifState := indexingNotificationState{}
 		const notifThrottleInterval = 250 * time.Millisecond
 
 		total, err := mediascanner.NewNamesIndex(indexCtx, pl, cfg, systems, db, func(status mediascanner.IndexStatus) {
@@ -392,20 +435,13 @@ func GenerateMediaDB(
 				totalFiles:  status.Files,
 			})
 
-			// Throttle WebSocket push notifications to prevent
-			// channel overflow during bursts (e.g. resume skipping
-			// many completed systems). Phase changes and the final
-			// step are always sent so clients see start/end.
-			now := time.Now()
-			isPhaseChange := status.Phase == mediascanner.PhaseDiscovering ||
-				status.Phase == mediascanner.PhaseInitializing ||
-				status.Phase == mediascanner.PhaseCreatingIndexes ||
-				status.Phase == mediascanner.PhaseBuildingCaches
-			isFinalStep := status.Step == status.Total
-			if !isPhaseChange && !isFinalStep && now.Sub(lastNotifTime) < notifThrottleInterval {
+			// Throttle duplicate WebSocket push notifications to prevent
+			// channel overflow, but always send visible progress changes so
+			// notification-only clients don't show the previous system while
+			// the next system is doing long-running work.
+			if !notifState.shouldSend(status, time.Now(), notifThrottleInterval) {
 				return
 			}
-			lastNotifTime = now
 
 			notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 				Exists:             false,

--- a/pkg/api/methods/media_status_test.go
+++ b/pkg/api/methods/media_status_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,6 +71,33 @@ func TestMediaIndexStatus_StateManagement(t *testing.T) {
 		assert.False(t, statusInstance.isRunning(), "Should not be running after clear")
 		assert.Nil(t, statusInstance.getCancelFunc(), "Should have no cancel function after clear")
 	})
+}
+
+func TestIndexingNotificationState_SendsVisibleChangesInsideThrottle(t *testing.T) {
+	baseTime := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	const throttleInterval = 250 * time.Millisecond
+
+	notifState := indexingNotificationState{}
+	amstradStatus := mediascanner.IndexStatus{SystemID: "amstradcpc", Total: 20, Step: 5}
+	arcadeStatus := mediascanner.IndexStatus{SystemID: "arcade", Total: 20, Step: 6}
+
+	assert.True(t, notifState.shouldSend(amstradStatus, baseTime, throttleInterval))
+	assert.True(t,
+		notifState.shouldSend(arcadeStatus, baseTime.Add(10*time.Millisecond), throttleInterval),
+		"system changes must bypass the throttle so clients don't stay on the previous system",
+	)
+	assert.False(t,
+		notifState.shouldSend(arcadeStatus, baseTime.Add(20*time.Millisecond), throttleInterval),
+		"duplicate status updates should still be throttled",
+	)
+	assert.True(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{SystemID: "arcade", Total: 20, Step: 7},
+			baseTime.Add(30*time.Millisecond),
+			throttleInterval,
+		),
+		"step changes are visible progress and must bypass the throttle",
+	)
 }
 
 func TestMediaIndexStatus_ThreadSafety(t *testing.T) {

--- a/pkg/api/methods/media_status_test.go
+++ b/pkg/api/methods/media_status_test.go
@@ -98,6 +98,54 @@ func TestIndexingNotificationState_SendsVisibleChangesInsideThrottle(t *testing.
 		),
 		"step changes are visible progress and must bypass the throttle",
 	)
+	assert.True(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseDiscovering},
+			baseTime.Add(40*time.Millisecond),
+			throttleInterval,
+		),
+		"phase changes are visible progress and must bypass the throttle",
+	)
+	assert.False(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseDiscovering},
+			baseTime.Add(50*time.Millisecond),
+			throttleInterval,
+		),
+		"duplicate phase updates should still be throttled",
+	)
+	assert.True(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseInitializing},
+			baseTime.Add(60*time.Millisecond),
+			throttleInterval,
+		),
+		"phase changes must bypass the throttle even when they happen quickly",
+	)
+	assert.False(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseInitializing},
+			baseTime.Add(70*time.Millisecond),
+			throttleInterval,
+		),
+		"duplicate phase updates should still be throttled after a phase change",
+	)
+	assert.True(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseInitializing, Total: 9, Step: 8},
+			baseTime.Add(80*time.Millisecond),
+			throttleInterval,
+		),
+		"step changes are visible progress before final-step completion",
+	)
+	assert.True(t,
+		notifState.shouldSend(
+			mediascanner.IndexStatus{Phase: mediascanner.PhaseInitializing, Total: 8, Step: 8},
+			baseTime.Add(90*time.Millisecond),
+			throttleInterval,
+		),
+		"final-step updates must bypass the throttle",
+	)
 }
 
 func TestMediaIndexStatus_ThreadSafety(t *testing.T) {


### PR DESCRIPTION
## Summary
- Ensure media indexing WebSocket notifications are sent when the visible phase, system, or step changes, even inside the throttle window.
- Keep throttling duplicate status updates to avoid channel pressure.
- Add regression coverage for rapid Amstrad CPC to Arcade-style transitions so notification-only clients do not remain on the previous system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Indexing status notifications now better detect meaningful progress (system, phase, or step changes) and bypass throttling for those events; final-step updates always generate notifications.

* **Tests**
  * Added test coverage validating the notification throttling and bypass behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->