### PR TITLE
fix(media): surface indexed browse entries

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -296,17 +296,26 @@ func systemRootEntryCoveredByDescendant(entries []models.BrowseEntry, parentIdx 
 		return false
 	}
 
+	descendantCount := 0
+	foundDescendant := false
 	for childIdx := range entries {
 		if childIdx == parentIdx {
 			continue
 		}
 
-		if isStrictFilesystemDescendant(entries[childIdx].Path, parent.Path) {
-			return true
+		child := entries[childIdx]
+		if !isStrictFilesystemDescendant(child.Path, parent.Path) {
+			continue
 		}
+		if child.FileCount == nil {
+			return false
+		}
+
+		foundDescendant = true
+		descendantCount += *child.FileCount
 	}
 
-	return false
+	return foundDescendant && descendantCount == *parent.FileCount
 }
 
 func isStrictFilesystemDescendant(childPath, parentPath string) bool {

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -301,11 +301,7 @@ func systemRootEntryCoveredByDescendant(entries []models.BrowseEntry, parentIdx 
 			continue
 		}
 
-		child := entries[childIdx]
-		if child.FileCount == nil || *child.FileCount != *parent.FileCount {
-			continue
-		}
-		if isStrictFilesystemDescendant(child.Path, parent.Path) {
+		if isStrictFilesystemDescendant(entries[childIdx].Path, parent.Path) {
 			return true
 		}
 	}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -290,7 +290,7 @@ func TestHandleMediaBrowse_SystemRootRoutesDedupesCoveredParent(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	romsPrefix := filepath.ToSlash(romsRoot) + "/"
 	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "NES")).
-		Return(10, nil)
+		Return(15, nil)
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "NES")).
 		Return([]database.BrowseDirectoryResult{{Name: "NES", FileCount: 10, SystemIDs: []string{"NES"}}}, nil)
 	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "NES")).
@@ -301,7 +301,7 @@ func TestHandleMediaBrowse_SystemRootRoutesDedupesCoveredParent(t *testing.T) {
 				assert.ElementsMatch(t, []string{nesAPIPath, romsAPIPath}, opts.Routes)
 		}),
 	).Return(map[string]database.BrowseRouteCount{
-		romsAPIPath: {Path: romsAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
+		romsAPIPath: {Path: romsAPIPath, FileCount: 15, SystemIDs: []string{"NES"}},
 		nesAPIPath:  {Path: nesAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
 	}, nil)
 
@@ -386,13 +386,13 @@ func TestDedupeSystemRootEntries(t *testing.T) {
 			want: []string{"/media/fat/games/NES"},
 		},
 		{
-			name: "parent keeps union across children",
+			name: "children absorb parent with aggregate count",
 			entries: []models.BrowseEntry{
 				{Path: "/media/fat/games", FileCount: count(15)},
 				{Path: "/media/fat/games/NES", FileCount: count(10)},
 				{Path: "/media/fat/games/NES Hacks", FileCount: count(5)},
 			},
-			want: []string{"/media/fat/games", "/media/fat/games/NES", "/media/fat/games/NES Hacks"},
+			want: []string{"/media/fat/games/NES", "/media/fat/games/NES Hacks"},
 		},
 		{
 			name: "sibling equal counts are unrelated",

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -290,7 +290,7 @@ func TestHandleMediaBrowse_SystemRootRoutesDedupesCoveredParent(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	romsPrefix := filepath.ToSlash(romsRoot) + "/"
 	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(romsPrefix, "NES")).
-		Return(15, nil)
+		Return(10, nil)
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesSystemOpts(romsPrefix, "NES")).
 		Return([]database.BrowseDirectoryResult{{Name: "NES", FileCount: 10, SystemIDs: []string{"NES"}}}, nil)
 	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "NES")).
@@ -301,7 +301,7 @@ func TestHandleMediaBrowse_SystemRootRoutesDedupesCoveredParent(t *testing.T) {
 				assert.ElementsMatch(t, []string{nesAPIPath, romsAPIPath}, opts.Routes)
 		}),
 	).Return(map[string]database.BrowseRouteCount{
-		romsAPIPath: {Path: romsAPIPath, FileCount: 15, SystemIDs: []string{"NES"}},
+		romsAPIPath: {Path: romsAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
 		nesAPIPath:  {Path: nesAPIPath, FileCount: 10, SystemIDs: []string{"NES"}},
 	}, nil)
 
@@ -371,6 +371,9 @@ func TestDedupeSystemRootEntries(t *testing.T) {
 	t.Parallel()
 
 	count := func(v int) *int { return &v }
+	path := func(parts ...string) string {
+		return filepath.Join(append([]string{string(filepath.Separator)}, parts...)...)
+	}
 
 	tests := []struct {
 		name    string
@@ -380,44 +383,61 @@ func TestDedupeSystemRootEntries(t *testing.T) {
 		{
 			name: "single child absorbs parent",
 			entries: []models.BrowseEntry{
-				{Path: "/media/fat/games", FileCount: count(10)},
-				{Path: "/media/fat/games/NES", FileCount: count(10)},
+				{Path: path("media", "fat", "games"), FileCount: count(10)},
+				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},
 			},
-			want: []string{"/media/fat/games/NES"},
+			want: []string{path("media", "fat", "games", "NES")},
 		},
 		{
 			name: "children absorb parent with aggregate count",
 			entries: []models.BrowseEntry{
-				{Path: "/media/fat/games", FileCount: count(15)},
-				{Path: "/media/fat/games/NES", FileCount: count(10)},
-				{Path: "/media/fat/games/NES Hacks", FileCount: count(5)},
+				{Path: path("media", "fat", "games"), FileCount: count(15)},
+				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},
+				{Path: path("media", "fat", "games", "NES Hacks"), FileCount: count(5)},
 			},
-			want: []string{"/media/fat/games/NES", "/media/fat/games/NES Hacks"},
+			want: []string{path("media", "fat", "games", "NES"), path("media", "fat", "games", "NES Hacks")},
+		},
+		{
+			name: "parent retained when descendants do not cover count",
+			entries: []models.BrowseEntry{
+				{Path: path("media", "fat", "games"), FileCount: count(20)},
+				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},
+				{Path: path("media", "fat", "games", "NES Hacks"), FileCount: count(5)},
+			},
+			want: []string{
+				path("media", "fat", "games"),
+				path("media", "fat", "games", "NES"),
+				path("media", "fat", "games", "NES Hacks"),
+			},
 		},
 		{
 			name: "sibling equal counts are unrelated",
 			entries: []models.BrowseEntry{
-				{Path: "/media/fat/games/NES", FileCount: count(10)},
-				{Path: "/media/fat/alt/NES", FileCount: count(10)},
+				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},
+				{Path: path("media", "fat", "alt", "NES"), FileCount: count(10)},
 			},
-			want: []string{"/media/fat/games/NES", "/media/fat/alt/NES"},
+			want: []string{path("media", "fat", "games", "NES"), path("media", "fat", "alt", "NES")},
 		},
 		{
 			name: "nil counts are not deduped",
 			entries: []models.BrowseEntry{
-				{Path: "/media/fat/games", FileCount: nil},
-				{Path: "/media/fat/games/NES", FileCount: count(10)},
-				{Path: "/media/fat/games/SNES", FileCount: nil},
+				{Path: path("media", "fat", "games"), FileCount: nil},
+				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},
+				{Path: path("media", "fat", "games", "SNES"), FileCount: nil},
 			},
-			want: []string{"/media/fat/games", "/media/fat/games/NES", "/media/fat/games/SNES"},
+			want: []string{
+				path("media", "fat", "games"),
+				path("media", "fat", "games", "NES"),
+				path("media", "fat", "games", "SNES"),
+			},
 		},
 		{
 			name: "string prefix is not ancestry",
 			entries: []models.BrowseEntry{
-				{Path: "/media/fat/games", FileCount: count(10)},
-				{Path: "/media/fat/games-extra", FileCount: count(10)},
+				{Path: path("media", "fat", "games"), FileCount: count(10)},
+				{Path: path("media", "fat", "games-extra"), FileCount: count(10)},
 			},
-			want: []string{"/media/fat/games", "/media/fat/games-extra"},
+			want: []string{path("media", "fat", "games"), path("media", "fat", "games-extra")},
 		},
 		{
 			name: "virtual schemes are ignored",

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -411,6 +411,17 @@ func TestDedupeSystemRootEntries(t *testing.T) {
 			},
 		},
 		{
+			name: "unknown descendant count retains parent",
+			entries: []models.BrowseEntry{
+				{Path: path("media", "fat", "games"), FileCount: count(20)},
+				{Path: path("media", "fat", "games", "NES"), FileCount: nil},
+			},
+			want: []string{
+				path("media", "fat", "games"),
+				path("media", "fat", "games", "NES"),
+			},
+		},
+		{
 			name: "sibling equal counts are unrelated",
 			entries: []models.BrowseEntry{
 				{Path: path("media", "fat", "games", "NES"), FileCount: count(10)},

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -358,6 +358,7 @@ type TitleWithSystem struct {
 // MediaWithFullPath represents a Media item with its associated title and system information
 type MediaWithFullPath struct {
 	Path           string
+	ParentDir      string
 	TitleSlug      string
 	SystemID       string
 	DBID           int64
@@ -404,6 +405,7 @@ type ScanState struct {
 	TitleIDs        map[string]int
 	MediaIDs        map[string]int
 	MediaTitleIDs   map[int]int // Existing media DBID -> MediaTitleDBID for persistent reconciliation
+	MediaParentDirs map[int]string
 	MediaTagIDs     map[int]map[int]struct{}
 	TagTypeIDs      map[string]int
 	TagIDs          map[string]int
@@ -577,8 +579,10 @@ type MediaDBI interface {
 	InsertMedia(row Media) (Media, error)
 	FindOrInsertMedia(row Media) (Media, error)
 	UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error
+	UpdateMediaParentDir(mediaDBID int64, parentDir string) error
 	DeleteMediaTags(mediaDBID int64) error
 	DeleteMediaTag(mediaDBID, tagDBID int64) error
+	TemporaryRepairJobsPending(ctx context.Context) (bool, error)
 
 	FindTagType(row TagType) (TagType, error)
 	InsertTagType(row TagType) (TagType, error)

--- a/pkg/database/mediadb/concurrent_operations_test.go
+++ b/pkg/database/mediadb/concurrent_operations_test.go
@@ -53,6 +53,7 @@ func TestConcurrentOptimizationPrevention(t *testing.T) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -275,6 +276,7 @@ func TestAtomicOptimizationFlag(t *testing.T) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -326,10 +328,11 @@ func TestOptimizationInterruption(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// analyze is now first; failure aborts before page_prefetch/browse_cache
+	// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "analyze").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2169,6 +2169,46 @@ func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
 	return err
 }
 
+func (db *MediaDB) UpdateMediaParentDir(mediaDBID int64, parentDir string) error {
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+
+	err := sqlUpdateMediaParentDir(db.ctx, db.conn(), mediaDBID, parentDir)
+	if err == nil && !db.inTransaction {
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(); invalidateErr != nil {
+			return invalidateErr
+		}
+	} else if err == nil {
+		db.markBrowseCacheDirty()
+	}
+
+	return err
+}
+
+func (db *MediaDB) TemporaryRepairJobsPending(ctx context.Context) (bool, error) {
+	if db.sql == nil {
+		return false, ErrNullSQL
+	}
+	current, err := sqlTemporaryParentDirRepairVersionCurrent(ctx, db.sql)
+	if err != nil {
+		return false, err
+	}
+	if current {
+		return false, nil
+	}
+
+	pending, err := sqlEmptyMediaParentDirsExist(ctx, db.sql)
+	if err != nil || pending {
+		return pending, err
+	}
+
+	if err := sqlMarkTemporaryParentDirRepairComplete(ctx, db.sql); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
 func (db *MediaDB) DeleteMediaTags(mediaDBID int64) error {
 	if db.sql == nil {
 		return ErrNullSQL
@@ -2529,13 +2569,20 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	// indexing completes. Background optimization improves query performance
 	// after the database is already open for searches.
 	//
-	// Step order matters: ANALYZE runs first to update query-planner statistics,
-	// improving plan quality for early searches. The page-prefetch warms the OS
-	// buffer cache for the tables the search path joins. BrowseCache and WAL
-	// checkpoint follow as non-critical housekeeping.
+	// Step order matters: temporary repair jobs run before cache rebuilds so
+	// upgraded databases are corrected without blocking startup. ANALYZE then
+	// updates query-planner statistics, the page-prefetch warms the OS buffer
+	// cache for the tables the search path joins, and BrowseCache/WAL checkpoint
+	// follow as non-critical housekeeping.
 	db.needsIndexRebuild.Store(false)
 
 	steps = append(steps,
+		optimizationStep{
+			name: "temporary_repair_parent_dirs", fn: func() error {
+				return db.runTemporaryParentDirRepair(db.ctx, pauser)
+			},
+			maxRetries: 0, retryDelay: rd,
+		},
 		optimizationStep{
 			name: "analyze", fn: db.Analyze,
 			maxRetries: 2, retryDelay: rd,

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2150,6 +2150,11 @@ func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
 	if db.sql == nil {
 		return ErrNullSQL
 	}
+	if db.batchInsertMediaTitle != nil {
+		if err := db.batchInsertMediaTitle.Flush(); err != nil {
+			return fmt.Errorf("failed to flush media title batch before update: %w", err)
+		}
+	}
 
 	err := sqlUpdateMediaTitle(db.ctx, db.conn(), mediaDBID, mediaTitleDBID)
 	if err == nil && !db.inTransaction {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -2452,6 +2452,48 @@ func TestMediaDB_CommitTransaction_ReturnsBatchFlushError_Integration(t *testing
 	assert.ErrorContains(t, err, "failed to flush batch inserts")
 }
 
+func TestMediaDB_UpdateMediaTitle_FlushesPendingTitleBatch_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: "Amiga", Name: "Amiga"})
+	require.NoError(t, err)
+	oldTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "oldtitle",
+		Name:       "Old Title",
+	})
+	require.NoError(t, err)
+	insertedMedia, err := mediaDB.InsertMedia(database.Media{
+		MediaTitleDBID: oldTitle.DBID,
+		SystemDBID:     insertedSystem.DBID,
+		Path:           filepath.Join("games", "Amiga", "listings", "games.txt", "Old Title"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	newTitleDBID := oldTitle.DBID + 1
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, err = mediaDB.InsertMediaTitle(&database.MediaTitle{
+		DBID:       newTitleDBID,
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "newtitle",
+		Name:       "New Title",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpdateMediaTitle(insertedMedia.DBID, newTitleDBID))
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	updatedMedia, err := mediaDB.FindMedia(database.Media{DBID: insertedMedia.DBID})
+	require.NoError(t, err)
+	assert.Equal(t, newTitleDBID, updatedMedia.MediaTitleDBID)
+}
+
 func TestMediaDB_CacheInvalidationScope_UsesAllSystemsForBroadIndexing_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -2494,6 +2494,98 @@ func TestMediaDB_UpdateMediaTitle_FlushesPendingTitleBatch_Integration(t *testin
 	assert.Equal(t, newTitleDBID, updatedMedia.MediaTitleDBID)
 }
 
+func TestMediaDB_TemporaryParentDirRepair_RestoresDirectBrowse_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	gameDir := filepath.ToSlash(filepath.Join("roms", "PSX", "USA")) + "/"
+	gamePath := gameDir + "Example Game.chd"
+
+	repairedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "PSX", Name: "PSX"})
+	require.NoError(t, err)
+	repairedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: repairedSystem.DBID,
+		Slug:       "examplegame",
+		Name:       "Example Game",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     repairedSystem.DBID,
+		MediaTitleDBID: repairedTitle.DBID,
+		Path:           gamePath,
+		ParentDir:      "",
+	})
+	require.NoError(t, err)
+
+	files, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{PathPrefix: gameDir, Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, files)
+
+	repairPending, err := mediaDB.TemporaryRepairJobsPending(ctx)
+	require.NoError(t, err)
+	assert.True(t, repairPending)
+	require.NoError(t, mediaDB.runTemporaryParentDirRepair(ctx, nil))
+
+	files, err = mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{PathPrefix: gameDir, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, gamePath, files[0].Path)
+
+	repairedMedia, err := mediaDB.FindMedia(database.Media{SystemDBID: repairedSystem.DBID, Path: gamePath})
+	require.NoError(t, err)
+	assert.Equal(t, gameDir, repairedMedia.ParentDir)
+
+	repairPending, err = mediaDB.TemporaryRepairJobsPending(ctx)
+	require.NoError(t, err)
+	assert.False(t, repairPending)
+}
+
+func TestMediaDB_TemporaryParentDirRepair_MarksCurrentWhenNoEmptyRows_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	gameDir := filepath.ToSlash(filepath.Join("roms", "NES")) + "/"
+	gamePath := gameDir + "Example Game.nes"
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: system.DBID,
+		Slug:       "examplegame",
+		Name:       "Example Game",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     system.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           gamePath,
+		ParentDir:      gameDir,
+	})
+	require.NoError(t, err)
+
+	repairPending, err := mediaDB.TemporaryRepairJobsPending(ctx)
+	require.NoError(t, err)
+	assert.False(t, repairPending)
+
+	var version string
+	err = mediaDB.sql.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigTemporaryRepairParentDirVersion,
+	).Scan(&version)
+	require.NoError(t, err)
+	assert.Equal(t, temporaryRepairParentDirVersion, version)
+}
+
 func TestMediaDB_CacheInvalidationScope_UsesAllSystemsForBroadIndexing_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -42,6 +42,15 @@ func expectAnalyzeStep(mock sqlmock.Sqlmock) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
 
+func expectTemporaryParentDirRepairStepNoop(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigOptimizationStep, "temporary_repair_parent_dirs").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigTemporaryRepairParentDirVersion).
+		WillReturnRows(sqlmock.NewRows([]string{"Value"}).AddRow(temporaryRepairParentDirVersion))
+}
+
 func expectPagePrefetchStep(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "page_prefetch").
@@ -292,10 +301,11 @@ func TestRunBackgroundOptimization_Success(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// Steps run in order: analyze → page_prefetch → browse_cache → wal_checkpoint
+	// Steps run in order: temporary_repair_parent_dirs → analyze → page_prefetch → browse_cache → wal_checkpoint
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -325,10 +335,11 @@ func TestRunBackgroundOptimization_FailureHandling(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// analyze is now the first step; failure aborts before page_prefetch/browse_cache
+	// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "analyze").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -367,6 +378,7 @@ func TestRunBackgroundOptimization_PagePrefetchCancellationAborts(t *testing.T) 
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "page_prefetch").
@@ -404,6 +416,7 @@ func TestConcurrentOptimization(t *testing.T) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -501,6 +514,7 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "running").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		expectTemporaryParentDirRepairStepNoop(mock)
 		expectAnalyzeStep(mock)
 		expectPostAnalyzeSteps(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -549,10 +563,11 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 			vacuumRetryDelay:  1 * time.Millisecond,
 		}
 
-		// analyze is first; failure aborts before page_prefetch/browse_cache
+		// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "running").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		expectTemporaryParentDirRepairStepNoop(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStep, "analyze").
 			WillReturnResult(sqlmock.NewResult(1, 1))
@@ -608,6 +623,7 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "running").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		expectTemporaryParentDirRepairStepNoop(mock)
 		expectAnalyzeStep(mock)
 		expectPostAnalyzeSteps(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
@@ -689,6 +705,7 @@ func TestRunBackgroundOptimization_PausesAndResumes(t *testing.T) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	expectTemporaryParentDirRepairStepNoop(mock)
 	expectAnalyzeStep(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/rs/zerolog/log"
 )
 
 func browseSystemFilterClause(column string, systems []systemdefs.System) (clause string, args []any) {
@@ -100,12 +101,47 @@ func sqlBrowseDirectories(
 		return nil, err
 	}
 	if ready {
-		return sqlBrowseDirectoriesFromCache(ctx, db, opts)
+		results, cacheErr := sqlBrowseDirectoriesFromCache(ctx, db, opts)
+		if cacheErr != nil || len(results) > 0 {
+			return results, cacheErr
+		}
+
+		fallback, fallbackErr := sqlBrowseDirectoriesFromMediaFallback(ctx, db, opts)
+		if fallbackErr != nil {
+			return nil, fallbackErr
+		}
+		if len(fallback) > 0 {
+			log.Warn().
+				Str("pathPrefix", opts.PathPrefix).
+				Strs("systems", browseSystemIDsForLog(opts.Systems)).
+				Int("directories", len(fallback)).
+				Msg("browse cache returned no directories; using media fallback")
+		}
+		return fallback, nil
 	}
+	return sqlBrowseDirectoriesFromMediaFallback(ctx, db, opts)
+}
+
+func sqlBrowseDirectoriesFromMediaFallback(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
 	if len(opts.Systems) > 0 {
 		return sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, opts)
 	}
 	return sqlBrowseDirectoriesFromMedia(ctx, db, opts.PathPrefix)
+}
+
+func browseSystemIDsForLog(systems []systemdefs.System) []string {
+	if len(systems) == 0 {
+		return nil
+	}
+	systemIDs := make([]string, 0, len(systems))
+	for i := range systems {
+		systemIDs = append(systemIDs, systems[i].ID)
+	}
+	return systemIDs
 }
 
 func sqlBrowseDirectoriesFromCache(
@@ -364,7 +400,54 @@ func sqlBrowseFilesFromMedia(
 	if err := fetchAndAttachTags(ctx, db, results); err != nil {
 		return nil, fmt.Errorf("browse files tags: %w", err)
 	}
+	if len(results) == 0 && opts.Cursor == nil {
+		descendants, countErr := sqlBrowseDescendantCount(ctx, db, opts.PathPrefix, opts.Systems)
+		if countErr != nil {
+			log.Debug().
+				Err(countErr).
+				Str("pathPrefix", opts.PathPrefix).
+				Strs("systems", browseSystemIDsForLog(opts.Systems)).
+				Msg("browse files descendant diagnostic failed")
+		} else {
+			event := log.Debug()
+			if descendants > 0 {
+				event = log.Warn()
+			}
+			event.
+				Str("pathPrefix", opts.PathPrefix).
+				Strs("systems", browseSystemIDsForLog(opts.Systems)).
+				Int("directFiles", 0).
+				Int("descendantFiles", descendants).
+				Msg("browse files returned no direct media")
+		}
+	}
 	return results, nil
+}
+
+func sqlBrowseDescendantCount(
+	ctx context.Context,
+	db sqlQueryable,
+	pathPrefix string,
+	systems []systemdefs.System,
+) (int, error) {
+	conditions := []string{`m.IsMissing = 0`, `m.Path LIKE ? || '%'`}
+	args := []any{pathPrefix}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", systems); systemClause != "" {
+		conditions = append(conditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		 FROM Media m
+		 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		 WHERE `+strings.Join(conditions, " AND "),
+		args...,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("browse descendant count: %w", err)
+	}
+	return count, nil
 }
 
 func sqlBrowseFileCount(

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -87,6 +87,7 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		Int("media", builder.mediaRows).
 		Int("counts", len(builder.counts)).
 		Msg("browse cache media scan complete")
+	logBrowseMediaCountsBySystem(ctx, tx)
 
 	deleteStarted := time.Now()
 	for _, stmt := range []string{
@@ -127,6 +128,41 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		Dur("duration", time.Since(started)).
 		Msg("browse cache populated")
 	return nil
+}
+
+func logBrowseMediaCountsBySystem(ctx context.Context, tx *sql.Tx) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT s.SystemID,
+			COUNT(*) AS TotalMedia,
+			SUM(CASE WHEN m.IsMissing = 0 THEN 1 ELSE 0 END) AS CurrentMedia,
+			SUM(CASE WHEN m.IsMissing != 0 THEN 1 ELSE 0 END) AS MissingMedia
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		GROUP BY s.SystemID
+		ORDER BY s.SystemID`)
+	if err != nil {
+		log.Debug().Err(err).Msg("browse media system counts diagnostic failed")
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var systemID string
+		var totalMedia, currentMedia, missingMedia int
+		if scanErr := rows.Scan(&systemID, &totalMedia, &currentMedia, &missingMedia); scanErr != nil {
+			log.Debug().Err(scanErr).Msg("browse media system counts diagnostic scan failed")
+			return
+		}
+		log.Debug().
+			Str("system", systemID).
+			Int("totalMedia", totalMedia).
+			Int("currentMedia", currentMedia).
+			Int("missingMedia", missingMedia).
+			Msg("browse media system count")
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		log.Debug().Err(rowsErr).Msg("browse media system counts diagnostic rows failed")
+	}
 }
 
 func scanBrowseCacheMedia(ctx context.Context, tx *sql.Tx, builder *browseCacheBuilder) error {

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -100,6 +100,36 @@ func TestSqlBrowseDirectories_FallsBackWhenCacheNotReady(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseDirectories_FallsBackWhenReadyCacheIsEmpty(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	psxDir := browseTestDir("media", "fat", "games", "PSX")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(psxDir).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	mock.ExpectQuery("SELECT d.Name, c.FileCount").
+		WithArgs(int64(10), "PSX").
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}))
+	mock.ExpectQuery("WITH matched AS").
+		WithArgs(psxDir, psxDir, "PSX").
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).AddRow("USA", 273, "PSX"))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: psxDir,
+		Systems:    []systemdefs.System{{ID: "PSX"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "USA", results[0].Name)
+	assert.Equal(t, 273, results[0].FileCount)
+	assert.Equal(t, []string{"PSX"}, results[0].SystemIDs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseVirtualSchemesFromCache_ReturnsEmptyWithoutMediaFallback(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -22,6 +22,7 @@ package mediadb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -46,6 +47,132 @@ func expectBrowseCacheReady(mock sqlmock.Sqlmock) {
 		WillReturnRows(sqlmock.NewRows([]string{"Value"}).AddRow(browseCacheSchemaVersion))
 	mock.ExpectQuery("SELECT 1 FROM BrowseDirs LIMIT 1").
 		WillReturnRows(sqlmock.NewRows([]string{"1"}).AddRow(1))
+}
+
+func TestLogBrowseMediaCountsBySystem_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT s.SystemID").WillReturnRows(sqlmock.NewRows(
+		[]string{"SystemID", "TotalMedia", "CurrentMedia", "MissingMedia"},
+	).AddRow("NES", 10, 8, 2))
+	mock.ExpectRollback()
+
+	logBrowseMediaCountsBySystem(context.Background(), tx)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLogBrowseMediaCountsBySystem_QueryError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT s.SystemID").WillReturnError(errors.New("query failed"))
+	mock.ExpectRollback()
+
+	logBrowseMediaCountsBySystem(context.Background(), tx)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLogBrowseMediaCountsBySystem_ScanError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT s.SystemID").WillReturnRows(sqlmock.NewRows(
+		[]string{"SystemID", "TotalMedia", "CurrentMedia", "MissingMedia"},
+	).AddRow("NES", "not-an-int", 8, 2))
+	mock.ExpectRollback()
+
+	logBrowseMediaCountsBySystem(context.Background(), tx)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLogBrowseMediaCountsBySystem_RowsError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT s.SystemID").WillReturnRows(sqlmock.NewRows(
+		[]string{"SystemID", "TotalMedia", "CurrentMedia", "MissingMedia"},
+	).AddRow("NES", 10, 8, 2).RowError(0, errors.New("rows failed")))
+	mock.ExpectRollback()
+
+	logBrowseMediaCountsBySystem(context.Background(), tx)
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDescendantCount_Unfiltered(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	romsDir := browseTestDir("roms", "psx")
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE").
+		WithArgs(romsDir).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(273))
+
+	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 273, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDescendantCount_SystemFiltered(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	romsDir := browseTestDir("roms", "psx")
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE.*s\\.SystemID IN").
+		WithArgs(romsDir, "PSX").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(273))
+
+	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, []systemdefs.System{{ID: "PSX"}})
+	require.NoError(t, err)
+	assert.Equal(t, 273, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDescendantCount_QueryError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	romsDir := browseTestDir("roms", "psx")
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE").
+		WithArgs(romsDir).
+		WillReturnError(sql.ErrConnDone)
+
+	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, nil)
+	require.Error(t, err)
+	assert.Equal(t, 0, count)
+	assert.Contains(t, err.Error(), "browse descendant count")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSqlBrowseDirectoriesFromCache_ReturnsSystemCounts(t *testing.T) {

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -30,13 +30,16 @@ import (
 )
 
 const (
-	DBConfigLastGeneratedAt    = "LastGeneratedAt"
-	DBConfigOptimizationStatus = "OptimizationStatus"
-	DBConfigOptimizationStep   = "OptimizationStep"
-	DBConfigIndexingStatus     = "IndexingStatus"
-	DBConfigLastIndexedSystem  = "LastIndexedSystem"
-	DBConfigIndexingSystems    = "IndexingSystems"
-	DBConfigBrowseIndexVersion = "BrowseIndexVersion"
+	DBConfigLastGeneratedAt                 = "LastGeneratedAt"
+	DBConfigOptimizationStatus              = "OptimizationStatus"
+	DBConfigOptimizationStep                = "OptimizationStep"
+	DBConfigIndexingStatus                  = "IndexingStatus"
+	DBConfigLastIndexedSystem               = "LastIndexedSystem"
+	DBConfigIndexingSystems                 = "IndexingSystems"
+	DBConfigBrowseIndexVersion              = "BrowseIndexVersion"
+	DBConfigTemporaryRepairParentDirVersion = "TemporaryRepairParentDirVersion"
+
+	temporaryRepairParentDirVersion = "1"
 )
 
 func sqlUpdateLastGenerated(ctx context.Context, db sqlQueryable) error {

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -200,7 +200,7 @@ func sqlGetTotalMediaCount(ctx context.Context, db *sql.DB) (int, error) {
 // sqlGetMediaWithFullPath retrieves all media with their associated title and system information using JOIN queries.
 func sqlGetMediaWithFullPath(ctx context.Context, db *sql.DB) ([]database.MediaWithFullPath, error) {
 	query := `
-		SELECT m.DBID, m.Path, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -220,7 +220,9 @@ func sqlGetMediaWithFullPath(ctx context.Context, db *sql.DB) ([]database.MediaW
 	for rows.Next() {
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
-		if err := rows.Scan(&m.DBID, &m.Path, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID); err != nil {
+		if err := rows.Scan(
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+		); err != nil {
 			return nil, fmt.Errorf("failed to scan media with full path: %w", err)
 		}
 		media = append(media, m)
@@ -250,7 +252,7 @@ func sqlGetMediaWithFullPathExcluding(
 
 	//nolint:gosec // using parameterized placeholders, not user input
 	query := fmt.Sprintf(`
-		SELECT m.DBID, m.Path, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -272,7 +274,9 @@ func sqlGetMediaWithFullPathExcluding(
 	for rows.Next() {
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
-		if err := rows.Scan(&m.DBID, &m.Path, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID); err != nil {
+		if err := rows.Scan(
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+		); err != nil {
 			return nil, fmt.Errorf("failed to scan media with full path: %w", err)
 		}
 		media = append(media, m)
@@ -284,7 +288,7 @@ func sqlGetMediaWithFullPathExcluding(
 // This is used for lazy loading during resume to avoid loading ALL media upfront.
 func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaWithFullPath, error) {
 	query := `
-		SELECT m.DBID, m.Path, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -305,7 +309,9 @@ func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]
 	for rows.Next() {
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
-		if err := rows.Scan(&m.DBID, &m.Path, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID); err != nil {
+		if err := rows.Scan(
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+		); err != nil {
 			return nil, fmt.Errorf("failed to scan media for system %s: %w", systemID, err)
 		}
 		media = append(media, m)

--- a/pkg/database/mediadb/sql_parent_dir_repair.go
+++ b/pkg/database/mediadb/sql_parent_dir_repair.go
@@ -1,0 +1,288 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/rs/zerolog/log"
+)
+
+const temporaryParentDirRepairBatchSize = 500
+
+type temporaryParentDirRepairStats struct {
+	Scanned int64
+	Updated int64
+}
+
+type parentDirRepairRow struct {
+	Path      string
+	ParentDir string
+	DBID      int64
+}
+
+// ParentDirForMediaPath returns the immediate browse parent for an indexed media path.
+func ParentDirForMediaPath(path string) string {
+	if idx := strings.Index(path, "://"); idx >= 0 {
+		return path[:idx+3]
+	}
+	if lastSlash := strings.LastIndex(path, "/"); lastSlash >= 0 {
+		return path[:lastSlash+1]
+	}
+	return ""
+}
+
+func sqlUpdateMediaParentDir(ctx context.Context, db sqlQueryable, mediaDBID int64, parentDir string) error {
+	if _, err := db.ExecContext(
+		ctx,
+		`UPDATE Media SET ParentDir = ? WHERE DBID = ?`,
+		parentDir,
+		mediaDBID,
+	); err != nil {
+		return fmt.Errorf("failed to update media parent dir: %w", err)
+	}
+
+	return nil
+}
+
+func sqlTemporaryParentDirRepairVersionCurrent(ctx context.Context, db sqlQueryable) (bool, error) {
+	var version string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigTemporaryRepairParentDirVersion,
+	).Scan(&version)
+	if err == nil {
+		return version == temporaryRepairParentDirVersion, nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("failed to read temporary parent dir repair version: %w", err)
+	}
+	return false, nil
+}
+
+func sqlEmptyMediaParentDirsExist(ctx context.Context, db sqlQueryable) (bool, error) {
+	var exists int
+	err := db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM Media
+		WHERE ParentDir = ''
+		LIMIT 1
+	`).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to check empty media parent dirs: %w", err)
+	}
+	return exists == 1, nil
+}
+
+func sqlMarkTemporaryParentDirRepairComplete(ctx context.Context, db sqlQueryable) error {
+	if _, err := db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigTemporaryRepairParentDirVersion,
+		temporaryRepairParentDirVersion,
+	); err != nil {
+		return fmt.Errorf("failed to mark temporary parent dir repair complete: %w", err)
+	}
+
+	return nil
+}
+
+func (db *MediaDB) runTemporaryParentDirRepair(ctx context.Context, pauser *syncutil.Pauser) error {
+	current, err := sqlTemporaryParentDirRepairVersionCurrent(ctx, db.sql)
+	if err != nil {
+		return err
+	}
+	if current {
+		log.Debug().Msg("temporary repair job skipped: media parent directories already repaired")
+		return nil
+	}
+
+	pending, err := sqlEmptyMediaParentDirsExist(ctx, db.sql)
+	if err != nil {
+		return err
+	}
+	if !pending {
+		markErr := sqlMarkTemporaryParentDirRepairComplete(ctx, db.sql)
+		if markErr != nil {
+			return markErr
+		}
+		log.Debug().Msg("temporary repair job skipped: media parent directories already repaired")
+		return nil
+	}
+
+	started := time.Now()
+	log.Info().Msg("temporary repair job started: media parent directories")
+
+	stats, err := db.repairMediaParentDirs(ctx, pauser)
+	if err != nil {
+		return err
+	}
+
+	if err := sqlMarkTemporaryParentDirRepairComplete(ctx, db.sql); err != nil {
+		return err
+	}
+
+	if stats.Updated > 0 {
+		if err := sqlInvalidateBrowseCache(ctx, db.sql); err != nil {
+			return fmt.Errorf("failed to invalidate browse cache after temporary parent dir repair: %w", err)
+		}
+	}
+
+	log.Info().
+		Int64("scanned", stats.Scanned).
+		Int64("updated", stats.Updated).
+		Dur("elapsed", time.Since(started)).
+		Msg("temporary repair job completed: media parent directories")
+
+	return nil
+}
+
+func (db *MediaDB) repairMediaParentDirs(
+	ctx context.Context,
+	pauser *syncutil.Pauser,
+) (temporaryParentDirRepairStats, error) {
+	stats := temporaryParentDirRepairStats{}
+	lastDBID := int64(0)
+
+	for {
+		if err := pauser.Wait(ctx); err != nil {
+			return stats, fmt.Errorf("temporary parent dir repair paused: %w", err)
+		}
+
+		rows, err := db.loadParentDirRepairRows(ctx, lastDBID, temporaryParentDirRepairBatchSize)
+		if err != nil {
+			return stats, err
+		}
+		if len(rows) == 0 {
+			return stats, nil
+		}
+
+		updates := make([]parentDirRepairRow, 0, len(rows))
+		for _, row := range rows {
+			stats.Scanned++
+			lastDBID = row.DBID
+			row.ParentDir = ParentDirForMediaPath(row.Path)
+			updates = append(updates, row)
+		}
+
+		if len(updates) == 0 {
+			continue
+		}
+
+		updated, err := db.updateParentDirRepairRows(ctx, updates)
+		if err != nil {
+			return stats, err
+		}
+		stats.Updated += updated
+
+		log.Debug().
+			Int64("scanned", stats.Scanned).
+			Int64("updated", stats.Updated).
+			Msg("temporary repair job progress: media parent directories")
+	}
+}
+
+func (db *MediaDB) loadParentDirRepairRows(
+	ctx context.Context, lastDBID int64, limit int,
+) ([]parentDirRepairRow, error) {
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT DBID, Path, ParentDir
+		FROM Media
+		WHERE DBID > ? AND ParentDir = ''
+		ORDER BY DBID
+		LIMIT ?
+	`, lastDBID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query media parent dirs for temporary repair: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close parent dir repair rows")
+		}
+	}()
+
+	results := make([]parentDirRepairRow, 0, limit)
+	for rows.Next() {
+		var row parentDirRepairRow
+		if err := rows.Scan(&row.DBID, &row.Path, &row.ParentDir); err != nil {
+			return nil, fmt.Errorf("failed to scan media parent dir repair row: %w", err)
+		}
+		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate media parent dir repair rows: %w", err)
+	}
+
+	return results, nil
+}
+
+func (db *MediaDB) updateParentDirRepairRows(ctx context.Context, rows []parentDirRepairRow) (int64, error) {
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin temporary parent dir repair transaction: %w", err)
+	}
+
+	updated := int64(0)
+	committed := false
+	defer func() {
+		if !committed {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				log.Warn().Err(rollbackErr).Msg("failed to roll back temporary parent dir repair transaction")
+			}
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, `UPDATE Media SET ParentDir = ? WHERE DBID = ? AND ParentDir = ''`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare temporary parent dir repair update: %w", err)
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close temporary parent dir repair statement")
+		}
+	}()
+
+	for _, row := range rows {
+		res, err := stmt.ExecContext(ctx, row.ParentDir, row.DBID)
+		if err != nil {
+			return 0, fmt.Errorf("failed to update media parent dir %d: %w", row.DBID, err)
+		}
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			return 0, fmt.Errorf("failed to read media parent dir update count: %w", err)
+		}
+		updated += rowsAffected
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit temporary parent dir repair transaction: %w", err)
+	}
+	committed = true
+
+	return updated, nil
+}

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1365,12 +1365,12 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 
 	systemID := "nes"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Path", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"}).
-		AddRow(int64(1), "/games/mario.nes", int64(10), int64(100), "supermariobros", "nes").
-		AddRow(int64(2), "/games/zelda.nes", int64(11), int64(100), "legendofzelda", "nes").
-		AddRow(int64(3), "/games/metroid.nes", int64(12), int64(100), "metroid", "nes")
+	rows := sqlmock.NewRows([]string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"}).
+		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10), int64(100), "supermariobros", "nes").
+		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11), int64(100), "legendofzelda", "nes").
+		AddRow(int64(3), "/games/metroid.nes", "/games/", int64(12), int64(100), "metroid", "nes")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
@@ -1382,6 +1382,7 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 	// Check first result
 	assert.Equal(t, int64(1), results[0].DBID)
 	assert.Equal(t, "/games/mario.nes", results[0].Path)
+	assert.Equal(t, "/games/", results[0].ParentDir)
 	assert.Equal(t, int64(10), results[0].MediaTitleDBID)
 	assert.Equal(t, "supermariobros", results[0].TitleSlug)
 	assert.Equal(t, "nes", results[0].SystemID)
@@ -1407,9 +1408,9 @@ func TestSqlGetMediaBySystemID_EmptyResult(t *testing.T) {
 
 	systemID := "nonexistent"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Path", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"})
+	rows := sqlmock.NewRows([]string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"})
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
@@ -1428,7 +1429,7 @@ func TestSqlGetMediaBySystemID_QueryError(t *testing.T) {
 
 	systemID := "nes"
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
 
@@ -1452,7 +1453,7 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"DBID", "Path"}).
 		AddRow(int64(1), "/games/mario.nes")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -98,6 +98,9 @@ func FlushScanStateMaps(ss *database.ScanState) {
 	for mediaID := range ss.MediaTagIDs {
 		delete(ss.MediaTagIDs, mediaID)
 	}
+	for mediaID := range ss.MediaParentDirs {
+		delete(ss.MediaParentDirs, mediaID)
+	}
 }
 
 func AddMediaPath(
@@ -169,13 +172,7 @@ func AddMediaPath(
 		ss.MediaIndex++
 		mediaIndex = ss.MediaIndex
 
-		// Compute immediate parent directory for indexed browse lookups.
-		var parentDir string
-		if idx := strings.Index(pf.Path, "://"); idx >= 0 {
-			parentDir = pf.Path[:idx+3]
-		} else if lastSlash := strings.LastIndex(pf.Path, "/"); lastSlash >= 0 {
-			parentDir = pf.Path[:lastSlash+1]
-		}
+		parentDir := mediadb.ParentDirForMediaPath(pf.Path)
 
 		_, err := db.InsertMedia(database.Media{
 			DBID:           int64(mediaIndex),
@@ -192,12 +189,25 @@ func AddMediaPath(
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[mediaIndex] = titleIndex
 		}
+		if ss.MediaParentDirs != nil {
+			ss.MediaParentDirs[mediaIndex] = parentDir
+		}
 	} else {
 		existingMedia = true
 		mediaIndex = foundMediaIndex
+		parentDir := mediadb.ParentDirForMediaPath(pf.Path)
 		// Mark as found during persistent indexing (not missing)
 		if ss.MissingMedia != nil {
 			delete(ss.MissingMedia, foundMediaIndex)
+		}
+		if ss.MediaParentDirs != nil {
+			existingParentDir, ok := ss.MediaParentDirs[mediaIndex]
+			if !ok || existingParentDir != parentDir {
+				if err := db.UpdateMediaParentDir(int64(mediaIndex), parentDir); err != nil {
+					return 0, 0, fmt.Errorf("error updating media parent dir %s: %w", pf.Path, err)
+				}
+				ss.MediaParentDirs[mediaIndex] = parentDir
+			}
 		}
 		if existingTitleIndex, ok := ss.MediaTitleIDs[mediaIndex]; !ok || existingTitleIndex != titleIndex {
 			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex)); err != nil {
@@ -788,6 +798,9 @@ func PopulateScanStateForSystem(
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[int(m.DBID)] = int(m.MediaTitleDBID)
 		}
+		if ss.MediaParentDirs != nil {
+			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
+		}
 	}
 
 	if ss.MediaTagIDs != nil {
@@ -880,6 +893,9 @@ func PopulatePersistentScanStateForSystem(
 		ss.MediaIDs[mediaKey] = int(m.DBID)
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[int(m.DBID)] = int(m.MediaTitleDBID)
+		}
+		if ss.MediaParentDirs != nil {
+			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
 		}
 		ss.MissingMedia[int(m.DBID)] = struct{}{}
 	}

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -352,6 +352,37 @@ func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testi
 	mockDB.AssertExpectations(t)
 }
 
+func TestAddMediaPath_RepairsExistingMediaParentDir(t *testing.T) {
+	t.Parallel()
+
+	mockDB := helpers.NewMockMediaDBI()
+	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
+	scanState := &database.ScanState{
+		SystemIDs:       map[string]int{"NES": 1},
+		TitleIDs:        map[string]int{"NES:supermariobrothers": 10},
+		MediaIDs:        map[string]int{database.MediaKey("NES", pathKey): 20},
+		MediaTitleIDs:   map[int]int{20: 10},
+		MediaParentDirs: map[int]string{20: ""},
+		MediaTagIDs:     map[int]map[int]struct{}{20: {8: {}}},
+		TagTypeIDs:      map[string]int{string(tags.TagTypeExtension): 7},
+		TagIDs:          map[string]int{database.TagKey(string(tags.TagTypeExtension), "nes"): 8},
+		MissingMedia:    map[int]struct{}{20: {}},
+	}
+
+	wantParentDir := filepath.ToSlash(filepath.Join("roms", "NES")) + "/"
+	mockDB.On("UpdateMediaParentDir", int64(20), wantParentDir).Return(nil).Once()
+
+	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	assert.Equal(t, 10, titleIndex)
+	assert.Equal(t, 20, mediaIndex)
+	assert.Equal(t, wantParentDir, scanState.MediaParentDirs[20])
+	assert.NotContains(t, scanState.MissingMedia, 20)
+	mockDB.AssertNotCalled(t, "UpdateMediaTitle", mock.Anything, mock.Anything)
+	mockDB.AssertExpectations(t)
+}
+
 func TestAddMediaPath_ReconcileExistingMediaTagsPreservesUserTags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -744,19 +744,20 @@ func NewNamesIndex(
 
 	// Initialize scan state
 	scanState := database.ScanState{
-		SystemsIndex:  0,
-		SystemIDs:     make(map[string]int),
-		TitlesIndex:   0,
-		TitleIDs:      make(map[string]int),
-		MediaIndex:    0,
-		MediaIDs:      make(map[string]int),
-		MediaTitleIDs: make(map[int]int),
-		MediaTagIDs:   make(map[int]map[int]struct{}),
-		TagTypesIndex: 0,
-		TagTypeIDs:    make(map[string]int),
-		TagsIndex:     0,
-		TagIDs:        make(map[string]int),
-		MissingMedia:  make(map[int]struct{}),
+		SystemsIndex:    0,
+		SystemIDs:       make(map[string]int),
+		TitlesIndex:     0,
+		TitleIDs:        make(map[string]int),
+		MediaIndex:      0,
+		MediaIDs:        make(map[string]int),
+		MediaTitleIDs:   make(map[int]int),
+		MediaParentDirs: make(map[int]string),
+		MediaTagIDs:     make(map[int]map[int]struct{}),
+		TagTypesIndex:   0,
+		TagTypeIDs:      make(map[string]int),
+		TagsIndex:       0,
+		TagIDs:          make(map[string]int),
+		MissingMedia:    make(map[int]struct{}),
 	}
 
 	// 3. Set up scan state — persistent mode is always active
@@ -1174,6 +1175,7 @@ func NewNamesIndex(
 	scanState.TitleIDs = nil
 	scanState.MediaIDs = nil
 	scanState.MediaTitleIDs = nil
+	scanState.MediaParentDirs = nil
 	scanState.MediaTagIDs = nil
 	scanState.TagTypeIDs = nil
 	scanState.TagIDs = nil

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -192,7 +192,7 @@ func Start(
 	backgroundWG.Add(1)
 	go func() {
 		defer backgroundWG.Done()
-		runStartupMaintenance(st.GetContext(), cfg, db)
+		runStartupMaintenance(st.GetContext(), cfg, db, indexPauser)
 	}()
 
 	backgroundWG.Add(1)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -503,10 +503,30 @@ func TestRunMediaDBStartupMaintenance_CancelledSkipsTagCacheWarmup(t *testing.T)
 	mockMediaDB.On("UnsafeGetSQLDb").Return(nil).Once()
 	mockMediaDB.On("BackgroundOperationDone").Once()
 
-	runMediaDBStartupMaintenance(ctx, mockMediaDB)
+	runMediaDBStartupMaintenance(ctx, mockMediaDB, nil)
 
 	mockMediaDB.AssertExpectations(t)
 	mockMediaDB.AssertNotCalled(t, "RebuildTagCache")
+}
+
+func TestRunMediaDBStartupMaintenance_PassesPauserToTemporaryRepairOptimization(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	pauser := syncutil.NewPauser()
+	ctx := context.Background()
+	mockMediaDB.On("TrackBackgroundOperation").Once()
+	mockMediaDB.On("UnsafeGetSQLDb").Return(nil).Once()
+	mockMediaDB.On("RebuildTagCache").Return(nil).Once()
+	mockMediaDB.On("TemporaryRepairJobsPending", ctx).Return(true, nil).Once()
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockMediaDB.On("RunBackgroundOptimization", mock.Anything, pauser).Once()
+	mockMediaDB.On("BackgroundOperationDone").Once()
+
+	runMediaDBStartupMaintenance(ctx, mockMediaDB, pauser)
+
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestStartPublishers_DisabledPublisher(t *testing.T) {

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb/boltmigration"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -215,7 +216,7 @@ func pruneExpiredZapLinkHosts(db *database.Database) {
 	}
 }
 
-func runMediaDBStartupMaintenance(ctx context.Context, db database.MediaDBI) {
+func runMediaDBStartupMaintenance(ctx context.Context, db database.MediaDBI, pauser *syncutil.Pauser) {
 	if db == nil {
 		log.Warn().Msg("skipping media database startup maintenance: media database is nil")
 		return
@@ -245,15 +246,52 @@ func runMediaDBStartupMaintenance(ctx context.Context, db database.MediaDBI) {
 	if err := db.RebuildTagCache(); err != nil {
 		log.Warn().Err(err).Msg("failed to warm tag cache on startup")
 	}
+
+	if startupMaintenanceCancelled(ctx, "skipping temporary media repair jobs: startup maintenance cancelled") {
+		return
+	}
+
+	pending, err := db.TemporaryRepairJobsPending(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check temporary media repair jobs")
+		return
+	}
+	if !pending {
+		return
+	}
+
+	indexingStatus, err := db.GetIndexingStatus()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check indexing status before temporary media repair jobs")
+		return
+	}
+	if indexingStatus == mediadb.IndexingStatusRunning || indexingStatus == mediadb.IndexingStatusPending {
+		log.Info().Str("indexingStatus", indexingStatus).
+			Msg("temporary media repair jobs pending; deferring until indexing completes")
+		return
+	}
+
+	optimizationStatus, err := db.GetOptimizationStatus()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check optimization status before temporary media repair jobs")
+		return
+	}
+	if optimizationStatus == mediadb.IndexingStatusRunning {
+		log.Info().Msg("temporary media repair jobs pending; optimization already running")
+		return
+	}
+
+	log.Info().Msg("temporary media repair jobs pending; starting background optimization")
+	db.RunBackgroundOptimization(nil, pauser)
 }
 
-func runStartupMaintenance(ctx context.Context, cfg *config.Instance, db *database.Database) {
+func runStartupMaintenance(ctx context.Context, cfg *config.Instance, db *database.Database, pauser *syncutil.Pauser) {
 	if db == nil {
 		log.Warn().Msg("skipping startup maintenance: database is nil")
 		return
 	}
 
-	runMediaDBStartupMaintenance(ctx, db.MediaDB)
+	runMediaDBStartupMaintenance(ctx, db.MediaDB, pauser)
 	cleanupHistoryRetention(ctx, cfg, db)
 	if startupMaintenanceCancelled(ctx, "skipping zaplink host pruning: startup maintenance cancelled") {
 		return

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1021,6 +1021,15 @@ func (m *MockMediaDBI) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
 	return nil
 }
 
+func (m *MockMediaDBI) UpdateMediaParentDir(mediaDBID int64, parentDir string) error {
+	m.trackDatabaseOperation() // Track if called outside transaction
+	args := m.Called(mediaDBID, parentDir)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) DeleteMediaTags(mediaDBID int64) error {
 	m.trackDatabaseOperation() // Track if called outside transaction
 	args := m.Called(mediaDBID)
@@ -1198,6 +1207,14 @@ func (m *MockMediaDBI) GetOptimizationStep() (string, error) {
 
 func (m *MockMediaDBI) RunBackgroundOptimization(statusCallback func(optimizing bool), pauser *syncutil.Pauser) {
 	m.Called(statusCallback, pauser)
+}
+
+func (m *MockMediaDBI) TemporaryRepairJobsPending(ctx context.Context) (bool, error) {
+	args := m.Called(ctx)
+	if err := args.Error(1); err != nil {
+		return args.Bool(0), fmt.Errorf("mock operation failed: %w", err)
+	}
+	return args.Bool(0), nil
 }
 
 func (m *MockMediaDBI) WaitForBackgroundOperations() {

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -299,6 +299,7 @@ func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path str
 		}
 	}
 
+	var firstNonNotExistErr error
 	for _, candidate := range candidates {
 		resolvedPath, err := findPathCaseInsensitive(fs, candidate)
 		if err == nil {
@@ -311,6 +312,12 @@ func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path str
 		if errors.Is(err, errAmbiguousPath) {
 			return "", err
 		}
+		if !errors.Is(err, os.ErrNotExist) && firstNonNotExistErr == nil {
+			firstNonNotExistErr = err
+		}
+	}
+	if firstNonNotExistErr != nil {
+		return "", firstNonNotExistErr
 	}
 
 	return path, fmt.Errorf("%w: %s", ErrFileNotFound, path)

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -269,10 +269,6 @@ func normalizeVirtualLookupPath(path string) string {
 // Check all games folders for a relative path to a file
 func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
 	lookupPath := normalizeVirtualLookupPath(path)
-	if filepath.IsAbs(lookupPath) {
-		return path, nil
-	}
-
 	ps := strings.Split(lookupPath, string(filepath.Separator))
 	statPath := lookupPath
 	var virtualParts []string
@@ -285,15 +281,26 @@ func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path str
 		ext := filepath.Ext(strings.ToLower(p))
 		if ext == ".zip" || ext == ".txt" {
 			statPath = filepath.Join(ps[:i+1]...)
+			if filepath.IsAbs(lookupPath) && !filepath.IsAbs(statPath) {
+				statPath = filepath.Join(string(filepath.Separator), statPath)
+			}
 			virtualParts = ps[i+1:]
 			log.Debug().Msgf("found zip/txt, setting stat path: %s", statPath)
 			break
 		}
 	}
 
-	for _, gf := range pl.RootDirs(cfg) {
-		fullPath := filepath.Join(gf, statPath)
-		resolvedPath, err := findPathCaseInsensitive(fs, fullPath)
+	candidates := []string{statPath}
+	if !filepath.IsAbs(statPath) {
+		rootDirs := pl.RootDirs(cfg)
+		candidates = make([]string, 0, len(rootDirs))
+		for _, gf := range rootDirs {
+			candidates = append(candidates, filepath.Join(gf, statPath))
+		}
+	}
+
+	for _, candidate := range candidates {
+		resolvedPath, err := findPathCaseInsensitive(fs, candidate)
 		if err == nil {
 			log.Debug().Msgf("found file: %s", resolvedPath)
 			if len(virtualParts) > 0 {

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -210,6 +210,8 @@ func forwardCmd(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 func findPathCaseInsensitive(fs afero.Fs, path string) (string, error) {
 	if _, err := fs.Stat(path); err == nil {
 		return path, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("failed to stat path %s: %w", path, err)
 	}
 
 	cleanPath := filepath.Clean(path)

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -205,6 +205,52 @@ func forwardCmd(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 	return result, nil
 }
 
+func findPathCaseInsensitive(path string) (string, error) {
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	}
+
+	cleanPath := filepath.Clean(path)
+	volume := filepath.VolumeName(cleanPath)
+	pathWithoutVolume := strings.TrimPrefix(cleanPath, volume)
+	isAbs := filepath.IsAbs(cleanPath)
+	parts := strings.Split(pathWithoutVolume, string(filepath.Separator))
+
+	current := volume
+	if isAbs {
+		current += string(filepath.Separator)
+	} else if current == "" {
+		current = "."
+	}
+
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		entries, err := os.ReadDir(current)
+		if err != nil {
+			return "", fmt.Errorf("failed to read directory %s: %w", current, err)
+		}
+
+		matched := ""
+		for _, entry := range entries {
+			if entry.Name() == part {
+				matched = entry.Name()
+				break
+			}
+			if matched == "" && strings.EqualFold(entry.Name(), part) {
+				matched = entry.Name()
+			}
+		}
+		if matched == "" {
+			return "", os.ErrNotExist
+		}
+		current = filepath.Join(current, matched)
+	}
+
+	return current, nil
+}
+
 // Check all games folders for a relative path to a file
 func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
 	if filepath.IsAbs(path) {
@@ -213,6 +259,7 @@ func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string,
 
 	ps := strings.Split(path, string(filepath.Separator))
 	statPath := path
+	var virtualParts []string
 
 	// if the file is inside a zip or virtual list, we just check that file exists
 	// TODO: both of these things are very specific to mister, it would be good to
@@ -222,6 +269,7 @@ func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string,
 		ext := filepath.Ext(strings.ToLower(p))
 		if ext == ".zip" || ext == ".txt" {
 			statPath = filepath.Join(ps[:i+1]...)
+			virtualParts = ps[i+1:]
 			log.Debug().Msgf("found zip/txt, setting stat path: %s", statPath)
 			break
 		}
@@ -229,9 +277,13 @@ func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string,
 
 	for _, gf := range pl.RootDirs(cfg) {
 		fullPath := filepath.Join(gf, statPath)
-		if _, err := os.Stat(fullPath); err == nil {
-			log.Debug().Msgf("found file: %s", fullPath)
-			return filepath.Join(gf, path), nil
+		resolvedPath, err := findPathCaseInsensitive(fullPath)
+		if err == nil {
+			log.Debug().Msgf("found file: %s", resolvedPath)
+			if len(virtualParts) > 0 {
+				return filepath.Join(append([]string{resolvedPath}, virtualParts...)...), nil
+			}
+			return resolvedPath, nil
 		}
 	}
 

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -42,14 +42,16 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript/advargs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript/titles"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 var (
-	ErrArgCount     = errors.New("invalid number of arguments")
-	ErrRequiredArgs = errors.New("arguments are required")
-	ErrRemoteSource = errors.New("cannot run from remote source")
-	ErrFileNotFound = errors.New("file not found")
-	ErrNoHistory    = errors.New("no play history available")
+	ErrArgCount      = errors.New("invalid number of arguments")
+	ErrRequiredArgs  = errors.New("arguments are required")
+	ErrRemoteSource  = errors.New("cannot run from remote source")
+	ErrFileNotFound  = errors.New("file not found")
+	ErrNoHistory     = errors.New("no play history available")
+	errAmbiguousPath = errors.New("ambiguous case-insensitive path")
 )
 
 // getLauncherIDs extracts launcher IDs from the platform for validation context.
@@ -205,8 +207,8 @@ func forwardCmd(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 	return result, nil
 }
 
-func findPathCaseInsensitive(path string) (string, error) {
-	if _, err := os.Stat(path); err == nil {
+func findPathCaseInsensitive(fs afero.Fs, path string) (string, error) {
+	if _, err := fs.Stat(path); err == nil {
 		return path, nil
 	}
 
@@ -227,38 +229,52 @@ func findPathCaseInsensitive(path string) (string, error) {
 		if part == "" {
 			continue
 		}
-		entries, err := os.ReadDir(current)
+		entries, err := afero.ReadDir(fs, current)
 		if err != nil {
 			return "", fmt.Errorf("failed to read directory %s: %w", current, err)
 		}
 
-		matched := ""
+		exactMatched := false
+		var foldMatches []string
 		for _, entry := range entries {
 			if entry.Name() == part {
-				matched = entry.Name()
+				current = filepath.Join(current, entry.Name())
+				exactMatched = true
 				break
 			}
-			if matched == "" && strings.EqualFold(entry.Name(), part) {
-				matched = entry.Name()
+			if strings.EqualFold(entry.Name(), part) {
+				foldMatches = append(foldMatches, entry.Name())
 			}
 		}
-		if matched == "" {
+		if exactMatched {
+			continue
+		}
+		if len(foldMatches) == 0 {
 			return "", os.ErrNotExist
 		}
-		current = filepath.Join(current, matched)
+		if len(foldMatches) > 1 {
+			return "", fmt.Errorf("%w: component %q in %s matches %s", errAmbiguousPath, part, current,
+				strings.Join(foldMatches, ", "))
+		}
+		current = filepath.Join(current, foldMatches[0])
 	}
 
 	return current, nil
 }
 
+func normalizeVirtualLookupPath(path string) string {
+	return filepath.FromSlash(strings.ReplaceAll(path, `\`, "/"))
+}
+
 // Check all games folders for a relative path to a file
-func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
-	if filepath.IsAbs(path) {
+func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
+	lookupPath := normalizeVirtualLookupPath(path)
+	if filepath.IsAbs(lookupPath) {
 		return path, nil
 	}
 
-	ps := strings.Split(path, string(filepath.Separator))
-	statPath := path
+	ps := strings.Split(lookupPath, string(filepath.Separator))
+	statPath := lookupPath
 	var virtualParts []string
 
 	// if the file is inside a zip or virtual list, we just check that file exists
@@ -277,13 +293,16 @@ func findFile(pl platforms.Platform, cfg *config.Instance, path string) (string,
 
 	for _, gf := range pl.RootDirs(cfg) {
 		fullPath := filepath.Join(gf, statPath)
-		resolvedPath, err := findPathCaseInsensitive(fullPath)
+		resolvedPath, err := findPathCaseInsensitive(fs, fullPath)
 		if err == nil {
 			log.Debug().Msgf("found file: %s", resolvedPath)
 			if len(virtualParts) > 0 {
 				return filepath.Join(append([]string{resolvedPath}, virtualParts...)...), nil
 			}
 			return resolvedPath, nil
+		}
+		if errors.Is(err, errAmbiguousPath) {
+			return "", err
 		}
 	}
 

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/installer"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 func applySystemDefaultLauncher(env *platforms.CmdEnv, systemID string) string {
@@ -412,7 +413,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// this always takes precedence over the system/path format (but is not totally cross platform)
 	var findErr error
 	var p string
-	if p, findErr = findFile(pl, env.Cfg, path); findErr == nil {
+	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path); findErr == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -475,7 +476,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		log.Debug().Msgf("checking system path: %s", systemPath)
 		var systemFindErr error
 		var fp string
-		if fp, systemFindErr = findFile(pl, env.Cfg, systemPath); systemFindErr == nil {
+		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath); systemFindErr == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -666,7 +667,7 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 		return platforms.CmdResult{}, err
 	}
 
-	path, err := findFile(pl, env.Cfg, entry.MediaPath)
+	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, entry.MediaPath)
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -317,7 +317,7 @@ func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
 	fs := afero.NewMemMapFs()
-	rootDir := filepath.Join(string(filepath.Separator), "games")
+	rootDir := filepath.Join(t.TempDir(), "games")
 	virtualGame := "Neo Turf Masters (turfmast).neo"
 	zipPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip")
 	relativePath := filepath.Join("NeoGeo", "NEOGEO.zip", virtualGame)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -334,6 +334,28 @@ func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestFindFile_ResolvesCaseInsensitiveAbsoluteVirtualZipPath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	fs := afero.NewMemMapFs()
+	rootDir := filepath.Join(string(filepath.Separator), "games")
+	virtualGame := "Neo Turf Masters (turfmast).neo"
+	zipPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip")
+	absolutePath := filepath.Join(rootDir, "neogeo", "NEOGEO.zip", virtualGame)
+	expectedPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip", virtualGame)
+
+	require.NoError(t, fs.MkdirAll(filepath.Dir(zipPath), 0o700))
+	require.NoError(t, afero.WriteFile(fs, zipPath, []byte("test"), 0o600))
+
+	result, err := findFile(fs, mockPlatform, cfg, absolutePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, result)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestFindFile_ResolvesCaseInsensitiveVirtualTxtPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -310,6 +310,28 @@ launcher = "snes-retroarch"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	rootDir := t.TempDir()
+	virtualGame := "Neo Turf Masters (turfmast).neo"
+	zipPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip")
+	relativePath := filepath.Join("NeoGeo", "NEOGEO.zip", virtualGame)
+	expectedPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip", virtualGame)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(zipPath), 0o700))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+
+	result, err := findFile(mockPlatform, cfg, relativePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, result)
+	mockPlatform.AssertExpectations(t)
+}
+
 // TestCmdLaunch_FileNotFound verifies that ErrFileNotFound is returned when file doesn't exist
 func TestCmdLaunch_FileNotFound(t *testing.T) {
 	t.Parallel()

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -315,20 +316,65 @@ func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
-	rootDir := t.TempDir()
+	fs := afero.NewMemMapFs()
+	rootDir := filepath.Join(string(filepath.Separator), "games")
 	virtualGame := "Neo Turf Masters (turfmast).neo"
 	zipPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip")
 	relativePath := filepath.Join("NeoGeo", "NEOGEO.zip", virtualGame)
 	expectedPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip", virtualGame)
 
-	require.NoError(t, os.MkdirAll(filepath.Dir(zipPath), 0o700))
-	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(zipPath), 0o700))
+	require.NoError(t, afero.WriteFile(fs, zipPath, []byte("test"), 0o600))
 	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
 
-	result, err := findFile(mockPlatform, cfg, relativePath)
+	result, err := findFile(fs, mockPlatform, cfg, relativePath)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedPath, result)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestFindFile_ResolvesCaseInsensitiveVirtualTxtPath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	fs := afero.NewMemMapFs()
+	rootDir := filepath.Join(string(filepath.Separator), "games")
+	virtualGame := "Favorite Game.sfc"
+	txtPath := filepath.Join(rootDir, "SNES", "Favorites.txt")
+	relativePath := filepath.Join("snes", "Favorites.txt", virtualGame)
+	expectedPath := filepath.Join(rootDir, "SNES", "Favorites.txt", virtualGame)
+
+	require.NoError(t, fs.MkdirAll(filepath.Dir(txtPath), 0o700))
+	require.NoError(t, afero.WriteFile(fs, txtPath, []byte("test"), 0o600))
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+
+	result, err := findFile(fs, mockPlatform, cfg, relativePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, result)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestFindFile_ReturnsAmbiguousCaseInsensitivePathError(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	fs := afero.NewMemMapFs()
+	rootDir := filepath.Join(string(filepath.Separator), "games")
+	relativePath := filepath.Join("neogeo", "game.zip")
+
+	require.NoError(t, fs.MkdirAll(filepath.Join(rootDir, "NEOGEO"), 0o700))
+	require.NoError(t, fs.MkdirAll(filepath.Join(rootDir, "NeoGeo"), 0o700))
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+
+	result, err := findFile(fs, mockPlatform, cfg, relativePath)
+
+	require.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "ambiguous case-insensitive path")
 	mockPlatform.AssertExpectations(t)
 }
 

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 const plsHeader = "[playlist]"
@@ -297,7 +298,7 @@ func loadPlaylist(pl platforms.Platform, env platforms.CmdEnv) (*playlists.Playl
 		return playlists.NewPlaylist(plsArg.ID, plsArg.Name, items), nil
 	}
 
-	path, err := findFile(pl, env.Cfg, env.Cmd.Args[0])
+	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, env.Cmd.Args[0])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Fix media browse system-root dedupe so aggregate ancestor roots do not trap clients above concrete system roots.
- Fall back to media-derived directory browse results when a ready browse cache returns no children, and add diagnostics for empty direct browse results plus per-system current/missing media counts.
- Flush pending media title batches before title updates and resolve case-insensitive virtual ZIP paths for launch lookups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fix system-root dedupe so parent is removed only when all strict descendants reliably sum to the parent.
  * Ensure pending media-title batches are flushed before applying title updates.

* **New Features**
  * Automatic temporary repair job and API to update media parent-directory metadata.
  * Startup maintenance now runs repair with index-pausing support.

* **Improvements**
  * Browse uses cache fallback with richer diagnostics; media results include parent-dir.
  * Case-insensitive resolution for archive/virtual file paths.

* **Tests**
  * Added/updated tests covering dedupe, parent-dir repair, cache fallback, diagnostics, and path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->