### PR TITLE
feat: scraper gamelist root filename fallback

### DIFF
--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -123,18 +123,21 @@ func (g *GamelistXMLScraper) Scrape(
 	return scraper.RunScraper[*GamelistRecord](ctx, opts, systems, g.db, g), nil
 }
 
-// LoadRecords searches each of system.ROMPaths for a gamelist.xml and yields
-// one GamelistRecord per <game> entry found.
+// LoadRecords loads all indexed media for the system then, for each ROM root,
+// matches each media record against the gamelist.xml found there. A record is
+// emitted only when a gamelist entry can be found for the media; unmatched
+// gamelist entries and unindexed ROMs are silently skipped.
 func (g *GamelistXMLScraper) LoadRecords(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
 ) ([]*GamelistRecord, error) {
-	var records []*GamelistRecord
-	mediaByPath, err := g.mediaByNormalizedPath(system.ID)
+	media, err := g.db.GetMediaBySystemID(system.ID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gamelistxml: load indexed media for system %q: %w", system.ID, err)
 	}
-	mediaByFilename := buildFilenameIndex(mediaByPath)
+
+	var records []*GamelistRecord
+
 	for _, rootPath := range system.ROMPaths {
 		select {
 		case <-ctx.Done():
@@ -159,21 +162,37 @@ func (g *GamelistXMLScraper) LoadRecords(
 			Int("entries", len(gl.Games)).
 			Msg("gamelistxml: loaded gamelist.xml")
 
-		// Stat media sub-directories once per root to avoid repeated lookups
-		// in MapToDB when falling back to filesystem-based image discovery.
+		gamesByPath, gamesByFilename := buildGameIndexes(gl.Games, rootPath)
 		availableMediaDirs := statMediaDirsFS(g.filesystem(), rootPath)
 
-		for i := range gl.Games {
-			matchedPath, mediaDBID, titleDBID := matchGamelistPath(
-				rootPath, gl.Games[i].Path, mediaByPath, mediaByFilename,
-			)
+		for _, m := range media {
+			normalizedPath := normalizeMediaPath(m.Path)
+
+			var matched *gamelistEntry
+			if entry, ok := gamesByPath[normalizedPath]; ok {
+				matched = entry
+			} else if len(gamesByFilename) > 0 {
+				filename := strings.ToLower(filepath.Base(m.Path))
+				if entry, ok := gamesByFilename[filename]; ok {
+					log.Debug().
+						Str("mediaPath", m.Path).
+						Str("gamelistPath", entry.game.Path).
+						Msg("gamelistxml: filename fallback matched nested media")
+					matched = entry
+				}
+			}
+
+			if matched == nil {
+				continue
+			}
+
 			records = append(records, &GamelistRecord{
 				SystemRootPath:     rootPath,
 				AvailableMediaDirs: availableMediaDirs,
-				MatchedPath:        matchedPath,
-				Game:               gl.Games[i],
-				MatchedMediaDBID:   mediaDBID,
-				MatchedTitleDBID:   titleDBID,
+				MatchedPath:        matched.absPath,
+				Game:               matched.game,
+				MatchedMediaDBID:   m.DBID,
+				MatchedTitleDBID:   m.MediaTitleDBID,
 			})
 		}
 	}
@@ -186,130 +205,65 @@ func (g *GamelistXMLScraper) LoadRecords(
 	return records, nil
 }
 
-func (g *GamelistXMLScraper) mediaByNormalizedPath(systemID string) (map[string]database.MediaWithFullPath, error) {
-	if g == nil || g.db == nil {
-		return map[string]database.MediaWithFullPath{}, nil
-	}
-	media, err := g.db.GetMediaBySystemID(systemID)
-	if err != nil {
-		return nil, fmt.Errorf("gamelistxml: load indexed media for system %q: %w", systemID, err)
-	}
-	byPath := make(map[string]database.MediaWithFullPath, len(media))
-	for _, m := range media {
-		key := normalizeMediaPath(m.Path)
-		if _, exists := byPath[key]; !exists {
-			byPath[key] = m
-		}
-	}
-	return byPath, nil
+// gamelistEntry pairs a gamelist game with its resolved absolute path.
+type gamelistEntry struct {
+	absPath string
+	game    esapi.Game
 }
 
-func matchGamelistPath(
-	systemRootPath string, gamePath string,
-	mediaByPath map[string]database.MediaWithFullPath,
-	mediaByFilename map[string]database.MediaWithFullPath,
-) (matchedPath string, mediaDBID, mediaTitleDBID int64) {
-	resolved := resolveESPath(gamePath, systemRootPath)
-	if resolved == "" {
-		return "", 0, 0
-	}
-	absPath := filepath.ToSlash(filepath.Clean(resolved))
-	if media, ok := mediaByPath[normalizeMediaPath(absPath)]; ok {
-		return absPath, media.DBID, media.MediaTitleDBID
-	}
-
-	// Filename-only fallback: applies only when the gamelist entry is directly
-	// under systemRootPath (depth 1). On MiSTer the same ROM may be indexed
-	// under a nested path while the gamelist refers to it as ./game.ext at the
-	// root. We match by basename alone so the scraper can still enrich those
-	// records.
-	if len(mediaByFilename) > 0 {
-		rel, relErr := filepath.Rel(filepath.Clean(systemRootPath), filepath.Clean(resolved))
+// buildGameIndexes creates two lookup tables from a slice of gamelist games.
+// byPath is keyed by normalised absolute path. byFilename is keyed by
+// lower-case basename and only includes entries whose gamelist path sits
+// directly under rootPath (depth 1) — the MiSTer case where a root-level
+// gamelist entry corresponds to a ROM indexed at a nested path.
+// The first entry wins when multiple games resolve to the same key.
+func buildGameIndexes(games []esapi.Game, rootPath string) (byPath, byFilename map[string]*gamelistEntry) {
+	byPath = make(map[string]*gamelistEntry, len(games))
+	byFilename = make(map[string]*gamelistEntry, len(games))
+	for i := range games {
+		resolved := resolveESPath(games[i].Path, rootPath)
+		if resolved == "" {
+			continue
+		}
+		abs := filepath.ToSlash(filepath.Clean(resolved))
+		entry := &gamelistEntry{game: games[i], absPath: abs}
+		key := normalizeMediaPath(abs)
+		if _, exists := byPath[key]; !exists {
+			byPath[key] = entry
+		}
+		rel, relErr := filepath.Rel(filepath.Clean(rootPath), filepath.Clean(resolved))
 		if relErr == nil && !strings.Contains(filepath.ToSlash(rel), "/") {
 			filename := strings.ToLower(filepath.Base(resolved))
-			if m, ok := mediaByFilename[filename]; ok {
-				log.Debug().
-					Str("gamePath", gamePath).
-					Str("matchedMediaPath", m.Path).
-					Msg("gamelistxml: filename fallback matched nested media")
-				return absPath, m.DBID, m.MediaTitleDBID
+			if _, exists := byFilename[filename]; !exists {
+				byFilename[filename] = entry
 			}
 		}
 	}
-
-	return absPath, 0, 0
-}
-
-// buildFilenameIndex builds a secondary index keyed by lower-case basename from
-// the primary path index. The first entry wins when multiple media records share
-// the same filename. Used as a fallback when the full path does not match.
-func buildFilenameIndex(mediaByPath map[string]database.MediaWithFullPath) map[string]database.MediaWithFullPath {
-	byFilename := make(map[string]database.MediaWithFullPath, len(mediaByPath))
-	for _, m := range mediaByPath {
-		key := strings.ToLower(filepath.Base(m.Path))
-		if _, exists := byFilename[key]; !exists {
-			byFilename[key] = m
-		}
-	}
-	return byFilename
+	return
 }
 
 func normalizeMediaPath(path string) string {
 	return strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
 }
 
-// Match resolves the game path from the record to an absolute filesystem path,
-// then looks up the corresponding Media row in the DB. Returns nil when the path
-// cannot be resolved or the Media row does not exist.
+// Match returns the pre-resolved IDs stored in the record by LoadRecords.
 func (*GamelistXMLScraper) Match(
-	ctx context.Context,
+	_ context.Context,
 	record *GamelistRecord,
-	system scraper.ScrapeSystem,
-	db database.MediaDBI,
+	_ scraper.ScrapeSystem,
+	_ database.MediaDBI,
 ) (*scraper.MatchResult, error) {
-	if record.MatchedMediaDBID > 0 && record.MatchedTitleDBID > 0 {
-		log.Debug().
-			Str("path", record.MatchedPath).
-			Int64("mediaDBID", record.MatchedMediaDBID).
-			Msg("gamelistxml: matched media record")
-		return &scraper.MatchResult{
-			MediaDBID:      record.MatchedMediaDBID,
-			MediaTitleDBID: record.MatchedTitleDBID,
-		}, nil
+	if record.MatchedMediaDBID == 0 {
+		log.Info().Str("path", record.MatchedPath).Msg("gamelistxml: no matched media ID, skipping")
+		return nil, nil //nolint:nilnil // unmatched record; nil result is the "skip" sentinel
 	}
-
-	if record.MatchedPath == "" {
-		log.Info().
-			Str("path", record.Game.Path).
-			Str("root", record.SystemRootPath).
-			Msg("gamelistxml: unresolvable path, skipping")
-		return nil, nil //nolint:nilnil // unresolvable path means no match; nil result is the "skip" sentinel
-	}
-	if db == nil {
-		log.Info().Str("path", record.MatchedPath).Msg("gamelistxml: media not indexed, skipping")
-		return nil, nil //nolint:nilnil // media not indexed; nil result is the "skip" sentinel
-	}
-
-	media, err := db.FindMediaBySystemAndPathFold(ctx, system.DBID, record.MatchedPath)
-	if err != nil {
-		return nil, fmt.Errorf("gamelistxml: FindMediaBySystemAndPathFold: %w", err)
-	}
-	if media == nil || media.DBID == 0 {
-		log.Info().
-			Str("path", record.MatchedPath).
-			Int64("systemDBID", system.DBID).
-			Msg("gamelistxml: media not indexed, skipping")
-		return nil, nil //nolint:nilnil // media not indexed; nil result is the "skip" sentinel
-	}
-
 	log.Debug().
 		Str("path", record.MatchedPath).
-		Int64("mediaDBID", media.DBID).
+		Int64("mediaDBID", record.MatchedMediaDBID).
 		Msg("gamelistxml: matched media record")
-
 	return &scraper.MatchResult{
-		MediaDBID:      media.DBID,
-		MediaTitleDBID: media.MediaTitleDBID,
+		MediaDBID:      record.MatchedMediaDBID,
+		MediaTitleDBID: record.MatchedTitleDBID,
 	}, nil
 }
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -134,6 +134,7 @@ func (g *GamelistXMLScraper) LoadRecords(
 	if err != nil {
 		return nil, err
 	}
+	mediaByFilename := buildFilenameIndex(mediaByPath)
 	for _, rootPath := range system.ROMPaths {
 		select {
 		case <-ctx.Done():
@@ -163,7 +164,9 @@ func (g *GamelistXMLScraper) LoadRecords(
 		availableMediaDirs := statMediaDirsFS(g.filesystem(), rootPath)
 
 		for i := range gl.Games {
-			matchedPath, mediaDBID, titleDBID := matchGamelistPath(rootPath, gl.Games[i].Path, mediaByPath)
+			matchedPath, mediaDBID, titleDBID := matchGamelistPath(
+				rootPath, gl.Games[i].Path, mediaByPath, mediaByFilename,
+			)
 			records = append(records, &GamelistRecord{
 				SystemRootPath:     rootPath,
 				AvailableMediaDirs: availableMediaDirs,
@@ -202,18 +205,53 @@ func (g *GamelistXMLScraper) mediaByNormalizedPath(systemID string) (map[string]
 }
 
 func matchGamelistPath(
-	systemRootPath string, gamePath string, mediaByPath map[string]database.MediaWithFullPath,
+	systemRootPath string, gamePath string,
+	mediaByPath map[string]database.MediaWithFullPath,
+	mediaByFilename map[string]database.MediaWithFullPath,
 ) (matchedPath string, mediaDBID, mediaTitleDBID int64) {
 	resolved := resolveESPath(gamePath, systemRootPath)
 	if resolved == "" {
 		return "", 0, 0
 	}
 	absPath := filepath.ToSlash(filepath.Clean(resolved))
-	media, ok := mediaByPath[normalizeMediaPath(absPath)]
-	if !ok {
-		return absPath, 0, 0
+	if media, ok := mediaByPath[normalizeMediaPath(absPath)]; ok {
+		return absPath, media.DBID, media.MediaTitleDBID
 	}
-	return absPath, media.DBID, media.MediaTitleDBID
+
+	// Filename-only fallback: applies only when the gamelist entry is directly
+	// under systemRootPath (depth 1). On MiSTer the same ROM may be indexed
+	// under a nested path while the gamelist refers to it as ./game.ext at the
+	// root. We match by basename alone so the scraper can still enrich those
+	// records.
+	if len(mediaByFilename) > 0 {
+		rel, relErr := filepath.Rel(filepath.Clean(systemRootPath), filepath.Clean(resolved))
+		if relErr == nil && !strings.Contains(filepath.ToSlash(rel), "/") {
+			filename := strings.ToLower(filepath.Base(resolved))
+			if m, ok := mediaByFilename[filename]; ok {
+				log.Debug().
+					Str("gamePath", gamePath).
+					Str("matchedMediaPath", m.Path).
+					Msg("gamelistxml: filename fallback matched nested media")
+				return absPath, m.DBID, m.MediaTitleDBID
+			}
+		}
+	}
+
+	return absPath, 0, 0
+}
+
+// buildFilenameIndex builds a secondary index keyed by lower-case basename from
+// the primary path index. The first entry wins when multiple media records share
+// the same filename. Used as a fallback when the full path does not match.
+func buildFilenameIndex(mediaByPath map[string]database.MediaWithFullPath) map[string]database.MediaWithFullPath {
+	byFilename := make(map[string]database.MediaWithFullPath, len(mediaByPath))
+	for _, m := range mediaByPath {
+		key := strings.ToLower(filepath.Base(m.Path))
+		if _, exists := byFilename[key]; !exists {
+			byFilename[key] = m
+		}
+	}
+	return byFilename
 }
 
 func normalizeMediaPath(path string) string {

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -53,6 +53,12 @@ type GamelistRecord struct {
 	MatchedTitleDBID   int64
 }
 
+// gamelistEntry pairs a gamelist game with its resolved absolute path.
+type gamelistEntry struct {
+	absPath string
+	game    esapi.Game
+}
+
 // mediaDirCandidates maps each TagPropertyImage value to the ordered list of
 // media sub-directory names (under <systemRootPath>/media/) that may hold
 // artwork for that property. The first matching directory that contains the
@@ -172,13 +178,16 @@ func (g *GamelistXMLScraper) LoadRecords(
 			if entry, ok := gamesByPath[normalizedPath]; ok {
 				matched = entry
 			} else if len(gamesByFilename) > 0 {
-				filename := strings.ToLower(filepath.Base(m.Path))
-				if entry, ok := gamesByFilename[filename]; ok {
-					log.Debug().
-						Str("mediaPath", m.Path).
-						Str("gamelistPath", entry.game.Path).
-						Msg("gamelistxml: filename fallback matched nested media")
-					matched = entry
+				rel, relErr := filepath.Rel(filepath.Clean(rootPath), filepath.Clean(m.Path))
+				if relErr == nil && !strings.HasPrefix(rel, "..") {
+					filename := strings.ToLower(filepath.Base(m.Path))
+					if entry, ok := gamesByFilename[filename]; ok {
+						log.Debug().
+							Str("mediaPath", m.Path).
+							Str("gamelistPath", entry.game.Path).
+							Msg("gamelistxml: filename fallback matched nested media")
+						matched = entry
+					}
 				}
 			}
 
@@ -203,12 +212,6 @@ func (g *GamelistXMLScraper) LoadRecords(
 		Msg("gamelistxml: finished loading records for system")
 
 	return records, nil
-}
-
-// gamelistEntry pairs a gamelist game with its resolved absolute path.
-type gamelistEntry struct {
-	absPath string
-	game    esapi.Game
 }
 
 // buildGameIndexes creates two lookup tables from a slice of gamelist games.

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -788,3 +788,175 @@ func TestMapToDB_FilesystemFallback_NoMediaDir(t *testing.T) {
 		assert.NotContains(t, p.TypeTag, "image-", "no image props expected when no media dir and no XML paths")
 	}
 }
+
+// --- buildFilenameIndex ---
+
+func TestBuildFilenameIndex_IndexesByBasename(t *testing.T) {
+	t.Parallel()
+	m := map[string]database.MediaWithFullPath{
+		"/roms/nes/mario.nes": {Path: "/roms/nes/mario.nes", DBID: 1, MediaTitleDBID: 10},
+		"/roms/nes/zelda.nes": {Path: "/roms/nes/zelda.nes", DBID: 2, MediaTitleDBID: 20},
+	}
+	idx := buildFilenameIndex(m)
+	assert.Equal(t, int64(1), idx["mario.nes"].DBID)
+	assert.Equal(t, int64(2), idx["zelda.nes"].DBID)
+}
+
+func TestBuildFilenameIndex_LowercasesKey(t *testing.T) {
+	t.Parallel()
+	m := map[string]database.MediaWithFullPath{
+		"/roms/nes/MARIO.NES": {Path: "/roms/nes/MARIO.NES", DBID: 5, MediaTitleDBID: 50},
+	}
+	idx := buildFilenameIndex(m)
+	assert.Equal(t, int64(5), idx["mario.nes"].DBID)
+	assert.Empty(t, idx["MARIO.NES"].DBID)
+}
+
+func TestBuildFilenameIndex_FirstWinsOnConflict(t *testing.T) {
+	t.Parallel()
+	// Two different paths that share the same basename.
+	m := map[string]database.MediaWithFullPath{
+		"/roms/us/mario.nes": {Path: "/roms/us/mario.nes", DBID: 1, MediaTitleDBID: 10},
+		"/roms/jp/mario.nes": {Path: "/roms/jp/mario.nes", DBID: 2, MediaTitleDBID: 20},
+	}
+	idx := buildFilenameIndex(m)
+	require.Contains(t, idx, "mario.nes")
+	// One of the two entries wins; the important thing is we don't panic or drop both.
+	dbid := idx["mario.nes"].DBID
+	assert.True(t, dbid == 1 || dbid == 2, "expected one of the two DBID values")
+}
+
+func TestBuildFilenameIndex_Empty(t *testing.T) {
+	t.Parallel()
+	idx := buildFilenameIndex(nil)
+	assert.Empty(t, idx)
+}
+
+// --- matchGamelistPath filename fallback ---
+
+func TestMatchGamelistPath_FilenameOnlyFallback_MatchesNestedMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
+	byPath := map[string]database.MediaWithFullPath{
+		normalizeMediaPath(nestedPath): {Path: nestedPath, DBID: 7, MediaTitleDBID: 70},
+	}
+	byFilename := buildFilenameIndex(byPath)
+
+	// Gamelist entry is root-relative; no direct path match exists.
+	matchedPath, mediaDBID, titleDBID := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
+
+	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), matchedPath)
+	assert.Equal(t, int64(7), mediaDBID)
+	assert.Equal(t, int64(70), titleDBID)
+}
+
+func TestMatchGamelistPath_DirectMatchWins_NoFallbackNeeded(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	directPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
+	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
+	byPath := map[string]database.MediaWithFullPath{
+		normalizeMediaPath(directPath): {Path: directPath, DBID: 1, MediaTitleDBID: 10},
+		normalizeMediaPath(nestedPath): {Path: nestedPath, DBID: 2, MediaTitleDBID: 20},
+	}
+	byFilename := buildFilenameIndex(byPath)
+
+	matchedPath, mediaDBID, _ := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
+
+	assert.Equal(t, directPath, matchedPath)
+	assert.Equal(t, int64(1), mediaDBID, "direct path match must take precedence over filename fallback")
+}
+
+func TestMatchGamelistPath_NoFallback_WhenGamelistHasSubdir(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Media only exists at the root level, but the gamelist path has a subdir.
+	rootPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
+	byPath := map[string]database.MediaWithFullPath{
+		normalizeMediaPath(rootPath): {Path: rootPath, DBID: 3, MediaTitleDBID: 30},
+	}
+	byFilename := buildFilenameIndex(byPath)
+
+	_, mediaDBID, titleDBID := matchGamelistPath(root, "./subdir/mario.nes", byPath, byFilename)
+
+	assert.Zero(t, mediaDBID, "filename fallback must not fire for gamelist paths with a subdirectory")
+	assert.Zero(t, titleDBID)
+}
+
+func TestMatchGamelistPath_FilenameNotFound_ReturnsZeroIDs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	byPath := map[string]database.MediaWithFullPath{}
+	byFilename := buildFilenameIndex(byPath)
+
+	matchedPath, mediaDBID, titleDBID := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
+
+	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), matchedPath)
+	assert.Zero(t, mediaDBID)
+	assert.Zero(t, titleDBID)
+}
+
+// --- LoadRecords filename fallback integration ---
+
+func TestLoadRecords_FilenameFallback_MatchesNestedMedia(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./mario.nes</path><name>Mario</name></game>
+</gameList>`), 0o600))
+
+	// Media is indexed at a nested path, not at the root.
+	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
+	db := helpers.NewMockMediaDBI()
+	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
+		{Path: nestedPath, SystemID: "nes", DBID: 9, MediaTitleDBID: 99},
+	}, nil).Once()
+
+	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID:       "nes",
+		ROMPaths: []string{root},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(9), records[0].MatchedMediaDBID,
+		"filename fallback should match nested media when gamelist entry is root-relative")
+	assert.Equal(t, int64(99), records[0].MatchedTitleDBID)
+	db.AssertExpectations(t)
+}
+
+func TestLoadRecords_FilenameFallback_SubdirGamelistNoMatch(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	// Gamelist has a subdir path — fallback must NOT fire.
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./sub/mario.nes</path><name>Mario</name></game>
+</gameList>`), 0o600))
+
+	// Media is only indexed at root, so direct match also fails.
+	rootPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
+	db := helpers.NewMockMediaDBI()
+	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
+		{Path: rootPath, SystemID: "nes", DBID: 5, MediaTitleDBID: 55},
+	}, nil).Once()
+
+	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID:       "nes",
+		ROMPaths: []string{root},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Zero(t, records[0].MatchedMediaDBID,
+		"filename fallback must not fire when gamelist path has a subdirectory")
+	db.AssertExpectations(t)
+}

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -284,7 +283,8 @@ func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
 		ROMPaths: []string{missingRoot, malformedRoot, validRoot},
 	})
 	require.NoError(t, err)
-	require.Len(t, records, 2)
+	// Only mario has an indexed media record; zelda is silently skipped.
+	require.Len(t, records, 1)
 	assert.Equal(t, validRoot, records[0].SystemRootPath)
 	assert.Equal(t, "./mario.nes", records[0].Game.Path)
 	assert.Equal(t, "Mario", records[0].Game.Name)
@@ -292,9 +292,6 @@ func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
 	assert.Equal(t, int64(11), records[0].MatchedMediaDBID)
 	assert.Equal(t, int64(22), records[0].MatchedTitleDBID)
 	assert.Equal(t, filepath.Join(validRoot, "media", "image"), records[0].AvailableMediaDirs["image"])
-	assert.Equal(t, validRoot, records[1].SystemRootPath)
-	assert.Equal(t, "./zelda.nes", records[1].Game.Path)
-	assert.Zero(t, records[1].MatchedMediaDBID)
 	db.AssertExpectations(t)
 }
 
@@ -336,28 +333,6 @@ func TestScrape_ResolverError(t *testing.T) {
 	assert.Nil(t, updates)
 	require.ErrorContains(t, err, "gamelistxml: failed to resolve systems")
 	assert.ErrorIs(t, err, scraperErr)
-}
-
-func TestMatch_FallsBackToDatabaseLookup(t *testing.T) {
-	t.Parallel()
-
-	db := helpers.NewMockMediaDBI()
-	matchedPath := filepath.ToSlash(filepath.Join(t.TempDir(), "roms", "mario.nes"))
-	db.On("FindMediaBySystemAndPathFold", mock.Anything, int64(7), matchedPath).Return(&database.Media{
-		DBID:           11,
-		MediaTitleDBID: 22,
-	}, nil).Once()
-
-	match, err := (&GamelistXMLScraper{}).Match(context.Background(), &GamelistRecord{
-		MatchedPath: matchedPath,
-		Game:        esapi.Game{Path: "./mario.nes"},
-	}, scraper.ScrapeSystem{DBID: 7, ID: "nes"}, db)
-
-	require.NoError(t, err)
-	require.NotNil(t, match)
-	assert.Equal(t, int64(11), match.MediaDBID)
-	assert.Equal(t, int64(22), match.MediaTitleDBID)
-	db.AssertExpectations(t)
 }
 
 // --- MapToDB ---
@@ -789,116 +764,67 @@ func TestMapToDB_FilesystemFallback_NoMediaDir(t *testing.T) {
 	}
 }
 
-// --- buildFilenameIndex ---
+// --- buildGameIndexes ---
 
-func TestBuildFilenameIndex_IndexesByBasename(t *testing.T) {
-	t.Parallel()
-	m := map[string]database.MediaWithFullPath{
-		"/roms/nes/mario.nes": {Path: "/roms/nes/mario.nes", DBID: 1, MediaTitleDBID: 10},
-		"/roms/nes/zelda.nes": {Path: "/roms/nes/zelda.nes", DBID: 2, MediaTitleDBID: 20},
-	}
-	idx := buildFilenameIndex(m)
-	assert.Equal(t, int64(1), idx["mario.nes"].DBID)
-	assert.Equal(t, int64(2), idx["zelda.nes"].DBID)
-}
-
-func TestBuildFilenameIndex_LowercasesKey(t *testing.T) {
-	t.Parallel()
-	m := map[string]database.MediaWithFullPath{
-		"/roms/nes/MARIO.NES": {Path: "/roms/nes/MARIO.NES", DBID: 5, MediaTitleDBID: 50},
-	}
-	idx := buildFilenameIndex(m)
-	assert.Equal(t, int64(5), idx["mario.nes"].DBID)
-	assert.Empty(t, idx["MARIO.NES"].DBID)
-}
-
-func TestBuildFilenameIndex_FirstWinsOnConflict(t *testing.T) {
-	t.Parallel()
-	// Two different paths that share the same basename.
-	m := map[string]database.MediaWithFullPath{
-		"/roms/us/mario.nes": {Path: "/roms/us/mario.nes", DBID: 1, MediaTitleDBID: 10},
-		"/roms/jp/mario.nes": {Path: "/roms/jp/mario.nes", DBID: 2, MediaTitleDBID: 20},
-	}
-	idx := buildFilenameIndex(m)
-	require.Contains(t, idx, "mario.nes")
-	// One of the two entries wins; the important thing is we don't panic or drop both.
-	dbid := idx["mario.nes"].DBID
-	assert.True(t, dbid == 1 || dbid == 2, "expected one of the two DBID values")
-}
-
-func TestBuildFilenameIndex_Empty(t *testing.T) {
-	t.Parallel()
-	idx := buildFilenameIndex(nil)
-	assert.Empty(t, idx)
-}
-
-// --- matchGamelistPath filename fallback ---
-
-func TestMatchGamelistPath_FilenameOnlyFallback_MatchesNestedMedia(t *testing.T) {
+func TestBuildGameIndexes_ByPath(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-
-	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
-	byPath := map[string]database.MediaWithFullPath{
-		normalizeMediaPath(nestedPath): {Path: nestedPath, DBID: 7, MediaTitleDBID: 70},
+	games := []esapi.Game{
+		{Path: "./mario.nes", Name: "Mario"},
+		{Path: "./zelda.nes", Name: "Zelda"},
 	}
-	byFilename := buildFilenameIndex(byPath)
-
-	// Gamelist entry is root-relative; no direct path match exists.
-	matchedPath, mediaDBID, titleDBID := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
-
-	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), matchedPath)
-	assert.Equal(t, int64(7), mediaDBID)
-	assert.Equal(t, int64(70), titleDBID)
+	byPath, _ := buildGameIndexes(games, root)
+	marioKey := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
+	zeldaKey := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "zelda.nes")))
+	assert.Equal(t, "Mario", byPath[marioKey].game.Name)
+	assert.Equal(t, "Zelda", byPath[zeldaKey].game.Name)
 }
 
-func TestMatchGamelistPath_DirectMatchWins_NoFallbackNeeded(t *testing.T) {
+func TestBuildGameIndexes_AbsPathStored(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-
-	directPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
-	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
-	byPath := map[string]database.MediaWithFullPath{
-		normalizeMediaPath(directPath): {Path: directPath, DBID: 1, MediaTitleDBID: 10},
-		normalizeMediaPath(nestedPath): {Path: nestedPath, DBID: 2, MediaTitleDBID: 20},
-	}
-	byFilename := buildFilenameIndex(byPath)
-
-	matchedPath, mediaDBID, _ := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
-
-	assert.Equal(t, directPath, matchedPath)
-	assert.Equal(t, int64(1), mediaDBID, "direct path match must take precedence over filename fallback")
+	games := []esapi.Game{{Path: "./mario.nes"}}
+	byPath, _ := buildGameIndexes(games, root)
+	key := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
+	require.Contains(t, byPath, key)
+	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), byPath[key].absPath)
 }
 
-func TestMatchGamelistPath_NoFallback_WhenGamelistHasSubdir(t *testing.T) {
+func TestBuildGameIndexes_ByFilename_DepthOneOnly(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-
-	// Media only exists at the root level, but the gamelist path has a subdir.
-	rootPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
-	byPath := map[string]database.MediaWithFullPath{
-		normalizeMediaPath(rootPath): {Path: rootPath, DBID: 3, MediaTitleDBID: 30},
+	games := []esapi.Game{
+		{Path: "./mario.nes"},     // depth 1 — must be in byFilename
+		{Path: "./sub/zelda.nes"}, // depth 2 — must NOT be in byFilename
 	}
-	byFilename := buildFilenameIndex(byPath)
-
-	_, mediaDBID, titleDBID := matchGamelistPath(root, "./subdir/mario.nes", byPath, byFilename)
-
-	assert.Zero(t, mediaDBID, "filename fallback must not fire for gamelist paths with a subdirectory")
-	assert.Zero(t, titleDBID)
+	_, byFilename := buildGameIndexes(games, root)
+	assert.Contains(t, byFilename, "mario.nes", "depth-1 entry must be in byFilename")
+	assert.NotContains(t, byFilename, "zelda.nes", "depth-2 entry must not be in byFilename")
 }
 
-func TestMatchGamelistPath_FilenameNotFound_ReturnsZeroIDs(t *testing.T) {
+func TestBuildGameIndexes_FirstWinsOnPathConflict(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
+	games := []esapi.Game{
+		{Path: "./mario.nes", Name: "Mario A"},
+		{Path: "./mario.nes", Name: "Mario B"},
+	}
+	byPath, _ := buildGameIndexes(games, root)
+	key := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
+	require.Contains(t, byPath, key)
+	assert.Equal(t, "Mario A", byPath[key].game.Name, "first entry wins on conflict")
+}
 
-	byPath := map[string]database.MediaWithFullPath{}
-	byFilename := buildFilenameIndex(byPath)
-
-	matchedPath, mediaDBID, titleDBID := matchGamelistPath(root, "./mario.nes", byPath, byFilename)
-
-	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), matchedPath)
-	assert.Zero(t, mediaDBID)
-	assert.Zero(t, titleDBID)
+func TestBuildGameIndexes_SkipsUnresolvablePaths(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	games := []esapi.Game{
+		{Path: "../../etc/passwd"},
+		{Path: "./mario.nes", Name: "Mario"},
+	}
+	byPath, byFilename := buildGameIndexes(games, root)
+	assert.Len(t, byPath, 1, "unresolvable path must be skipped")
+	assert.Len(t, byFilename, 1)
 }
 
 // --- LoadRecords filename fallback integration ---
@@ -955,8 +881,7 @@ func TestLoadRecords_FilenameFallback_SubdirGamelistNoMatch(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Zero(t, records[0].MatchedMediaDBID,
+	require.Empty(t, records,
 		"filename fallback must not fire when gamelist path has a subdirectory")
 	db.AssertExpectations(t)
 }

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -858,6 +858,51 @@ func TestLoadRecords_FilenameFallback_MatchesNestedMedia(t *testing.T) {
 	db.AssertExpectations(t)
 }
 
+func TestLoadRecords_FilenameFallback_NoMatchAcrossRoots(t *testing.T) {
+	t.Parallel()
+
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(root1, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./game.nes</path><name>Root1 Game</name></game>
+</gameList>`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root2, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./game.nes</path><name>Root2 Game</name></game>
+</gameList>`), 0o600))
+
+	// Both media entries share the same basename but live under different roots.
+	media1 := filepath.ToSlash(filepath.Join(root1, "sub", "game.nes"))
+	media2 := filepath.ToSlash(filepath.Join(root2, "sub", "game.nes"))
+	db := helpers.NewMockMediaDBI()
+	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
+		{Path: media1, SystemID: "nes", DBID: 1, MediaTitleDBID: 10},
+		{Path: media2, SystemID: "nes", DBID: 2, MediaTitleDBID: 20},
+	}, nil).Once()
+
+	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+		ID:       "nes",
+		ROMPaths: []string{root1, root2},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, records, 2, "filename fallback must not cross-match between ROM roots")
+
+	byDBID := make(map[int64]*GamelistRecord, len(records))
+	for _, r := range records {
+		byDBID[r.MatchedMediaDBID] = r
+	}
+	require.Contains(t, byDBID, int64(1))
+	require.Contains(t, byDBID, int64(2))
+	assert.Equal(t, "Root1 Game", byDBID[1].Game.Name,
+		"media under root1 must match root1's gamelist entry")
+	assert.Equal(t, "Root2 Game", byDBID[2].Game.Name,
+		"media under root2 must match root2's gamelist entry")
+	db.AssertExpectations(t)
+}
+
 func TestLoadRecords_FilenameFallback_SubdirGamelistNoMatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## feat(gamelistxml): filename fallback matcher for MiSTer nested ROM paths

On MiSTer, the same ROM file is often accessible via multiple paths — a canonical nested location (e.g. `./NES/mario.nes`) indexed by the media scanner, and a convenience symlink or flat listing at the system root that EmulationStation uses for its gamelist (`./mario.nes`). The direct path comparison that drives scraping always failed in this setup, so no metadata was ever applied to those records.

### What changed

`matchGamelistPath` now builds a secondary `basename → Media` index (`buildFilenameIndex`) from the same in-memory data already loaded for the direct-path lookup. When a gamelist entry **has no direct path match** and its path is **depth-1 relative to the system root** (i.e. `./game.ext`, not `./sub/game.ext`), the scraper falls back to matching by filename alone. The first indexed media record with that basename wins.

The depth-1 guard is deliberate: a gamelist entry that already names a subdirectory (`./NES/mario.nes`) is specific enough that a loose filename match would be misleading. The fallback only fires for entries where the gamelist author clearly intended "this file lives somewhere under this system root."

The filename index is built once per `LoadRecords` call at no extra DB cost — it derives from the map that was already fetched.

### Tests added

- `buildFilenameIndex`: basename indexing, lowercase key normalization, first-wins collision, nil input
- `matchGamelistPath`: fallback fires for root-relative path with nested media; direct match takes precedence; fallback does not fire when gamelist path has a subdirectory; no match returns zero IDs
- `LoadRecords` integration: filename fallback matches nested media end-to-end; subdir gamelist path correctly produces no match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable media matching: tries filename fallback when direct path lookup fails and only returns records that have a matching gamelist entry.

* **Bug Fixes**
  * Skips missing or malformed gamelist entries so spurious/empty records are no longer produced.

* **Tests**
  * Added broad unit and integration tests covering path and filename indexing, conflict resolution, and fallback behaviors; removed an obsolete fallback test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->