### PR TITLE
test: fix Windows path test assumptions

### DIFF
--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -137,7 +137,7 @@ func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseRootCounts", mock.Anything, mock.Anything).
-		Return(map[string]*int{"/roms": intPtr(500)}, nil)
+		Return(map[string]*int{romsRoot: intPtr(500)}, nil)
 	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, database.BrowseVirtualSchemesOptions{}).
 		Return([]database.BrowseVirtualScheme{
 			{Scheme: "steam://", FileCount: 42},
@@ -154,7 +154,7 @@ func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	// Filesystem root
 	assert.Equal(t, "root", browseResults.Entries[0].Type)
 	assert.Equal(t, "roms", browseResults.Entries[0].Name)
-	assert.Equal(t, "/roms", browseResults.Entries[0].Path)
+	assert.Equal(t, romsRoot, browseResults.Entries[0].Path)
 	require.NotNil(t, browseResults.Entries[0].FileCount)
 	assert.Equal(t, 500, *browseResults.Entries[0].FileCount)
 
@@ -487,7 +487,8 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 		Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/")).
+	romsAPIPath := filepath.ToSlash(romsRoot)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts(romsAPIPath+"/")).
 		Return([]database.BrowseDirectoryResult{
 			{Name: "NES", FileCount: 100},
 			{Name: "SNES", FileCount: 200},
@@ -495,10 +496,10 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{}, nil)
 	// BrowseFileCount is skipped when BrowseFiles returns empty and no cursor
-	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/", nil)).
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts(romsAPIPath+"/", nil)).
 		Return(0, nil).Maybe()
 
-	path := "/roms"
+	path := romsAPIPath
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
 		Path: &path,
 	})
@@ -508,12 +509,12 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
-	assert.Equal(t, "/roms", browseResults.Path)
+	assert.Equal(t, romsAPIPath, browseResults.Path)
 	require.Len(t, browseResults.Entries, 2)
 
 	assert.Equal(t, "directory", browseResults.Entries[0].Type)
 	assert.Equal(t, "NES", browseResults.Entries[0].Name)
-	assert.Equal(t, "/roms/NES", browseResults.Entries[0].Path)
+	assert.Equal(t, romsAPIPath+"/NES", browseResults.Entries[0].Path)
 	require.NotNil(t, browseResults.Entries[0].FileCount)
 	assert.Equal(t, 100, *browseResults.Entries[0].FileCount)
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -38,6 +38,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func launchTestAbsPath(parts ...string) string {
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	root := filepath.VolumeName(wd) + string(filepath.Separator)
+	return filepath.Join(append([]string{root}, parts...)...)
+}
+
 // TestCmdLaunch_SystemArgAppliesDefaults verifies that system arg applies system defaults when no explicit launcher
 func TestCmdLaunch_SystemArgAppliesDefaults(t *testing.T) {
 	t.Parallel()
@@ -340,7 +349,7 @@ func TestFindFile_ResolvesCaseInsensitiveAbsoluteVirtualZipPath(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
 	fs := afero.NewMemMapFs()
-	rootDir := filepath.Join(string(filepath.Separator), "games")
+	rootDir := launchTestAbsPath("games")
 	virtualGame := "Neo Turf Masters (turfmast).neo"
 	zipPath := filepath.Join(rootDir, "NEOGEO", "NEOGEO.zip")
 	absolutePath := filepath.Join(rootDir, "neogeo", "NEOGEO.zip", virtualGame)
@@ -362,7 +371,7 @@ func TestFindFile_ResolvesCaseInsensitiveVirtualTxtPath(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
 	fs := afero.NewMemMapFs()
-	rootDir := filepath.Join(string(filepath.Separator), "games")
+	rootDir := launchTestAbsPath("games")
 	virtualGame := "Favorite Game.sfc"
 	txtPath := filepath.Join(rootDir, "SNES", "Favorites.txt")
 	relativePath := filepath.Join("snes", "Favorites.txt", virtualGame)
@@ -385,7 +394,7 @@ func TestFindFile_ReturnsAmbiguousCaseInsensitivePathError(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
 	fs := afero.NewMemMapFs()
-	rootDir := filepath.Join(string(filepath.Separator), "games")
+	rootDir := launchTestAbsPath("games")
 	relativePath := filepath.Join("neogeo", "game.zip")
 
 	require.NoError(t, fs.MkdirAll(filepath.Join(rootDir, "NEOGEO"), 0o700))


### PR DESCRIPTION
## Summary
- Use platform-derived media browse roots in tests instead of hard-coded POSIX paths.
- Build zapscript virtual path test roots from the current drive/root so Windows treats them as absolute paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated media browse test expectations to use dynamically computed absolute paths for improved flexibility.
  * Enhanced path resolution tests with a new helper for consistent cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->