### PR TITLE
fix(zapscript): preserve Windows virtual path roots

### DIFF
--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -269,12 +269,19 @@ func normalizeVirtualLookupPath(path string) string {
 }
 
 func virtualStatPath(lookupPath string, parts []string, end int) string {
+	volume := filepath.VolumeName(lookupPath)
+	if filepath.IsAbs(lookupPath) && strings.HasPrefix(volume, `\\`) && len(parts) >= 4 && parts[0] == "" {
+		if end <= 4 {
+			return volume
+		}
+		return filepath.Join(append([]string{volume}, parts[4:end]...)...)
+	}
+
 	statPath := filepath.Join(parts[:end]...)
 	if !filepath.IsAbs(lookupPath) || filepath.IsAbs(statPath) {
 		return statPath
 	}
 
-	volume := filepath.VolumeName(lookupPath)
 	if volume == "" {
 		return filepath.Join(string(filepath.Separator), statPath)
 	}

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -268,6 +268,22 @@ func normalizeVirtualLookupPath(path string) string {
 	return filepath.FromSlash(strings.ReplaceAll(path, `\`, "/"))
 }
 
+func virtualStatPath(lookupPath string, parts []string, end int) string {
+	statPath := filepath.Join(parts[:end]...)
+	if !filepath.IsAbs(lookupPath) || filepath.IsAbs(statPath) {
+		return statPath
+	}
+
+	volume := filepath.VolumeName(lookupPath)
+	if volume == "" {
+		return filepath.Join(string(filepath.Separator), statPath)
+	}
+
+	statPath = strings.TrimPrefix(statPath, volume)
+	statPath = strings.TrimLeft(statPath, string(filepath.Separator))
+	return filepath.Join(volume+string(filepath.Separator), statPath)
+}
+
 // Check all games folders for a relative path to a file
 func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
 	lookupPath := normalizeVirtualLookupPath(path)
@@ -282,10 +298,7 @@ func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path str
 	for i, p := range ps {
 		ext := filepath.Ext(strings.ToLower(p))
 		if ext == ".zip" || ext == ".txt" {
-			statPath = filepath.Join(ps[:i+1]...)
-			if filepath.IsAbs(lookupPath) && !filepath.IsAbs(statPath) {
-				statPath = filepath.Join(string(filepath.Separator), statPath)
-			}
+			statPath = virtualStatPath(lookupPath, ps, i+1)
 			virtualParts = ps[i+1:]
 			log.Debug().Msgf("found zip/txt, setting stat path: %s", statPath)
 			break

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -269,26 +269,11 @@ func normalizeVirtualLookupPath(path string) string {
 }
 
 func virtualStatPath(lookupPath string, parts []string, end int) string {
-	volume := filepath.VolumeName(lookupPath)
-	if filepath.IsAbs(lookupPath) && strings.HasPrefix(volume, `\\`) && len(parts) >= 4 && parts[0] == "" {
-		if end <= 4 {
-			return volume
-		}
-		return filepath.Join(append([]string{volume}, parts[4:end]...)...)
+	if filepath.IsAbs(lookupPath) {
+		return filepath.Clean(strings.Join(parts[:end], string(filepath.Separator)))
 	}
 
-	statPath := filepath.Join(parts[:end]...)
-	if !filepath.IsAbs(lookupPath) || filepath.IsAbs(statPath) {
-		return statPath
-	}
-
-	if volume == "" {
-		return filepath.Join(string(filepath.Separator), statPath)
-	}
-
-	statPath = strings.TrimPrefix(statPath, volume)
-	statPath = strings.TrimLeft(statPath, string(filepath.Separator))
-	return filepath.Join(volume+string(filepath.Separator), statPath)
+	return filepath.Join(parts[:end]...)
 }
 
 // Check all games folders for a relative path to a file

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -45,6 +46,18 @@ func launchTestAbsPath(parts ...string) string {
 	}
 	root := filepath.VolumeName(wd) + string(filepath.Separator)
 	return filepath.Join(append([]string{root}, parts...)...)
+}
+
+func TestVirtualStatPath_PreservesAbsoluteRoot(t *testing.T) {
+	t.Parallel()
+
+	lookupPath := filepath.Join(launchTestAbsPath("games"), "neogeo", "NEOGEO.zip", "game.neo")
+	parts := strings.Split(lookupPath, string(filepath.Separator))
+
+	statPath := virtualStatPath(lookupPath, parts, len(parts)-1)
+
+	assert.True(t, filepath.IsAbs(statPath))
+	assert.Equal(t, filepath.Join(launchTestAbsPath("games"), "neogeo", "NEOGEO.zip"), statPath)
 }
 
 // TestCmdLaunch_SystemArgAppliesDefaults verifies that system arg applies system defaults when no explicit launcher

--- a/pkg/zapscript/launch_windows_test.go
+++ b/pkg/zapscript/launch_windows_test.go
@@ -1,0 +1,42 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build windows
+
+package zapscript
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualStatPath_PreservesUNCRoot(t *testing.T) {
+	t.Parallel()
+
+	lookupPath := `\\server\share\games\neogeo\NEOGEO.zip\game.neo`
+	parts := strings.Split(lookupPath, string(filepath.Separator))
+
+	statPath := virtualStatPath(lookupPath, parts, len(parts)-1)
+
+	assert.True(t, filepath.IsAbs(statPath))
+	assert.Equal(t, `\\server\share\games\neogeo\NEOGEO.zip`, statPath)
+}


### PR DESCRIPTION
## Summary
- Preserve the original absolute root/volume when truncating virtual `.zip` and `.txt` paths for existence checks.
- Add coverage for absolute virtual path truncation so malformed drive-relative paths do not slip through.

Verified:
- `gofumpt -w pkg/zapscript/commands.go pkg/zapscript/launch_test.go`
- `go test ./pkg/zapscript/`
- `task lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal path-resolution for virtual and archive-style lookup paths to ensure consistent and correct handling of absolute paths and archive prefixes across platforms.

* **Tests**
  * Added cross-platform tests that verify absolute roots and UNC-style roots are preserved during virtual path resolution, improving confidence in filesystem lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->