### PR TITLE
chore: moving scrapers to platform configurations

### DIFF
--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -196,7 +196,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	paused := env.ScrapePauser != nil && env.ScrapePauser.IsPaused()
 	opts := scraper.ScrapeOptions{Systems: params.Systems, Force: params.Force, Pauser: env.ScrapePauser}
-	ch, err := s.Scrape(scrapeCtx, opts)
+	ch, err := s.Scrape(scrapeCtx, env.ScrapeEnv, opts)
 	if err != nil {
 		cancelFunc()
 		scrapingStatusInstance.clear()

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -52,7 +52,7 @@ type closedChannelScraper struct {
 func (s *closedChannelScraper) ID() string               { return s.id }
 func (s *closedChannelScraper) Name() string             { return s.name }
 func (*closedChannelScraper) SupportedSystems() []string { return nil }
-func (*closedChannelScraper) Scrape(_ context.Context, _ scraper.ScrapeOptions) (<-chan scraper.ScrapeUpdate, error) {
+func (*closedChannelScraper) Scrape(_ context.Context, _ scraper.ScrapeEnv, _ scraper.ScrapeOptions) (<-chan scraper.ScrapeUpdate, error) {
 	ch := make(chan scraper.ScrapeUpdate)
 	close(ch)
 	return ch, nil
@@ -404,7 +404,7 @@ type errorScraper struct {
 func (s *errorScraper) ID() string               { return s.id }
 func (*errorScraper) Name() string               { return "error scraper" }
 func (*errorScraper) SupportedSystems() []string { return nil }
-func (s *errorScraper) Scrape(_ context.Context, _ scraper.ScrapeOptions) (<-chan scraper.ScrapeUpdate, error) {
+func (s *errorScraper) Scrape(_ context.Context, _ scraper.ScrapeEnv, _ scraper.ScrapeOptions) (<-chan scraper.ScrapeUpdate, error) {
 	return nil, s.err
 }
 

--- a/pkg/api/models/requests/requests.go
+++ b/pkg/api/models/requests/requests.go
@@ -56,6 +56,9 @@ type RequestEnv struct {
 	// all in-flight requests. It is fully populated before any handlers run and
 	// must not be mutated after that point — no locking is used.
 	Scrapers     map[string]scraper.Scraper
+	// ScrapeEnv carries runtime dependencies (DB, system resolver) injected into
+	// each Scrape call. Built once per server startup alongside the Scrapers map.
+	ScrapeEnv    scraper.ScrapeEnv
 	IndexPauser  *syncutil.Pauser
 	ScrapePauser *syncutil.Pauser
 	ClientID     string

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -49,7 +49,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -884,6 +883,7 @@ func handleWSMessage(
 	encGateway *apimiddleware.EncryptionGateway,
 	lastSeenTracker *apimiddleware.LastSeenTracker,
 	scrapers map[string]scraper.Scraper,
+	scrapeEnv scraper.ScrapeEnv,
 ) func(session *melody.Session, msg []byte) {
 	return func(session *melody.Session, msg []byte) {
 		defer func() {
@@ -969,6 +969,7 @@ func handleWSMessage(
 			TokenQueue:    inTokenQueue,
 			ConfirmQueue:  confirmQueue,
 			Scrapers:      scrapers,
+			ScrapeEnv:     scrapeEnv,
 			IndexPauser:   indexPauser,
 			ScrapePauser:  scrapePauser,
 			IsLocal:       isLocal,
@@ -1182,6 +1183,7 @@ func handlePostRequest(
 	indexPauser *syncutil.Pauser,
 	scrapePauser *syncutil.Pauser,
 	scrapers map[string]scraper.Scraper,
+	scrapeEnv scraper.ScrapeEnv,
 ) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
@@ -1228,6 +1230,7 @@ func handlePostRequest(
 			TokenQueue:    inTokenQueue,
 			ConfirmQueue:  confirmQueue,
 			Scrapers:      scrapers,
+			ScrapeEnv:     scrapeEnv,
 			IndexPauser:   indexPauser,
 			ScrapePauser:  scrapePauser,
 			IsLocal:       apimiddleware.IsLoopbackAddr(r.RemoteAddr),
@@ -1283,14 +1286,14 @@ func handlePostRequest(
 	}
 }
 
-// makeSystemResolver builds a SystemResolver for the gamelist.xml scraper.
+// makeSystemResolver builds a SystemResolver for scrapers.
 // It resolves indexed system IDs to ScrapeSystem values using the same launcher
 // path discovery as media indexing, so scraper paths match scanned media paths.
 func makeSystemResolver(
 	mdb database.MediaDBI,
 	platform platforms.Platform,
 	cfg *config.Instance,
-) gamelistxml.SystemResolver {
+) scraper.SystemResolver {
 	return func(ctx context.Context, systemIDs []string) ([]scraper.ScrapeSystem, error) {
 		indexed, err := mdb.IndexedSystems()
 		if err != nil {
@@ -1628,13 +1631,17 @@ func StartWithReady(
 		})
 	})
 
-	// Build the scrapers map once; passed into RequestEnv for media.scrape.
-	gamelistScraper := gamelistxml.NewGamelistXMLScraper(
-		db.MediaDB,
-		makeSystemResolver(db.MediaDB, platform, cfg),
-	)
-	scrapers := map[string]scraper.Scraper{
-		gamelistScraper.ID(): gamelistScraper,
+	// Build scrapers from the platform and construct ScrapeEnv once.
+	// Both are passed into RequestEnv; ScrapeEnv carries runtime deps (DB,
+	// resolver) that are injected into each Scrape call rather than baked
+	// into the scraper at construction time.
+	scrapeEnv := scraper.ScrapeEnv{
+		DB:               db.MediaDB,
+		ResolveSystemsFn: makeSystemResolver(db.MediaDB, platform, cfg),
+	}
+	scrapers := make(map[string]scraper.Scraper)
+	for _, s := range platform.Scrapers(cfg) {
+		scrapers[s.ID()] = s
 	}
 
 	// Non-WebSocket API routes (HTTP POST + REST GET) — restricted to
@@ -1652,7 +1659,7 @@ func StartWithReady(
 			methodMap, platform, cfg, st,
 			inTokenQueue, confirmQueue,
 			db, limitsManager, player,
-			indexPauser, scrapePauser, scrapers,
+			indexPauser, scrapePauser, scrapers, scrapeEnv,
 		)
 		r.Post("/api", postHandler)
 		r.Post("/api/v0", postHandler)
@@ -1694,7 +1701,7 @@ func StartWithReady(
 		handleWSMessage(
 			methodMap, platform, cfg, st, inTokenQueue, confirmQueue,
 			db, limitsManager, player, indexPauser, scrapePauser, encGateway,
-			lastSeenTracker, scrapers,
+			lastSeenTracker, scrapers, scrapeEnv,
 		),
 	))
 

--- a/pkg/api/server_post_test.go
+++ b/pkg/api/server_post_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -87,7 +88,10 @@ func createTestPostHandler(t *testing.T) (http.HandlerFunc, *MethodMap) {
 	})
 
 	confirmQueue := make(chan chan error, 10)
-	handler := handlePostRequest(methodMap, platform, cfg, st, tokenQueue, confirmQueue, db, nil, nil, nil, nil, nil)
+	handler := handlePostRequest(
+		methodMap, platform, cfg, st, tokenQueue, confirmQueue,
+		db, nil, nil, nil, nil, nil, scraper.ScrapeEnv{},
+	)
 	return handler, methodMap
 }
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -75,24 +75,17 @@ var mediaDirCandidates = map[string][]string{
 	string(tags.TagPropertyImageMap):        {"map", "maps"},
 }
 
-// SystemResolver resolves ScrapeSystem values for the active system IDs.
-// The API layer injects this so the scraper can retrieve ROMPaths without
-// importing the config package.
-type SystemResolver func(ctx context.Context, systemIDs []string) ([]scraper.ScrapeSystem, error)
-
 // GamelistXMLScraper enriches Zaparoo MediaDB records from EmulationStation
 // gamelist.xml files found in each system's ROM root paths.
+// It is stateless: DB and system resolver are injected at Scrape call time via ScrapeEnv.
 type GamelistXMLScraper struct {
-	db               database.MediaDBI
-	fs               afero.Fs
-	resolveSystemsFn SystemResolver
+	fs afero.Fs
 }
 
 // NewGamelistXMLScraper creates a new GamelistXMLScraper.
-// db is used for all database operations; resolveSystemsFn provides system info
-// (DBID, ROMPaths) when Scrape is called.
-func NewGamelistXMLScraper(db database.MediaDBI, resolveSystemsFn SystemResolver) *GamelistXMLScraper {
-	return &GamelistXMLScraper{db: db, fs: afero.NewOsFs(), resolveSystemsFn: resolveSystemsFn}
+// Runtime dependencies (DB, system resolver) are supplied via ScrapeEnv when Scrape is called.
+func NewGamelistXMLScraper() *GamelistXMLScraper {
+	return &GamelistXMLScraper{fs: afero.NewOsFs()}
 }
 
 func (g *GamelistXMLScraper) filesystem() afero.Fs {
@@ -117,16 +110,16 @@ func (*GamelistXMLScraper) SupportedSystems() []string {
 	return []string{}
 }
 
-// Scrape implements [scraper.Scraper]. It resolves active systems via the
-// injected resolver and delegates to [scraper.RunScraper].
+// Scrape implements [scraper.Scraper]. It resolves active systems via env and
+// delegates to [scraper.RunScraper].
 func (g *GamelistXMLScraper) Scrape(
-	ctx context.Context, opts scraper.ScrapeOptions,
+	ctx context.Context, env scraper.ScrapeEnv, opts scraper.ScrapeOptions,
 ) (<-chan scraper.ScrapeUpdate, error) {
-	systems, err := g.resolveSystemsFn(ctx, opts.Systems)
+	systems, err := env.ResolveSystemsFn(ctx, opts.Systems)
 	if err != nil {
 		return nil, fmt.Errorf("gamelistxml: failed to resolve systems: %w", err)
 	}
-	return scraper.RunScraper[*GamelistRecord](ctx, opts, systems, g.db, g), nil
+	return scraper.RunScraper[*GamelistRecord](ctx, opts, systems, env.DB, g), nil
 }
 
 // LoadRecords loads all indexed media for the system then, for each ROM root,
@@ -136,8 +129,9 @@ func (g *GamelistXMLScraper) Scrape(
 func (g *GamelistXMLScraper) LoadRecords(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
+	db database.MediaDBI,
 ) ([]*GamelistRecord, error) {
-	media, err := g.db.GetMediaBySystemID(system.ID)
+	media, err := db.GetMediaBySystemID(system.ID)
 	if err != nil {
 		return nil, fmt.Errorf("gamelistxml: load indexed media for system %q: %w", system.ID, err)
 	}

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -278,10 +278,10 @@ func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
 		},
 	}, nil).Once()
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+	records, err := (&GamelistXMLScraper{}).LoadRecords(context.Background(), scraper.ScrapeSystem{
 		ID:       "nes",
 		ROMPaths: []string{missingRoot, malformedRoot, validRoot},
-	})
+	}, db)
 	require.NoError(t, err)
 	// Only mario has an indexed media record; zelda is silently skipped.
 	require.Len(t, records, 1)
@@ -308,10 +308,10 @@ func TestLoadRecords_ReturnsMediaPreloadError(t *testing.T) {
 	preloadErr := errors.New("media preload failed")
 	db.On("GetMediaBySystemID", "nes").Return(nil, preloadErr).Once()
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+	records, err := (&GamelistXMLScraper{}).LoadRecords(context.Background(), scraper.ScrapeSystem{
 		ID:       "nes",
 		ROMPaths: []string{root},
-	})
+	}, db)
 
 	require.Error(t, err)
 	assert.Nil(t, records)
@@ -324,11 +324,14 @@ func TestScrape_ResolverError(t *testing.T) {
 	t.Parallel()
 
 	scraperErr := errors.New("resolver failed")
-	g := NewGamelistXMLScraper(nil, func(context.Context, []string) ([]scraper.ScrapeSystem, error) {
-		return nil, scraperErr
-	})
+	g := NewGamelistXMLScraper()
+	env := scraper.ScrapeEnv{
+		ResolveSystemsFn: func(context.Context, []string) ([]scraper.ScrapeSystem, error) {
+			return nil, scraperErr
+		},
+	}
 
-	updates, err := g.Scrape(context.Background(), scraper.ScrapeOptions{Systems: []string{"nes"}})
+	updates, err := g.Scrape(context.Background(), env, scraper.ScrapeOptions{Systems: []string{"nes"}})
 	require.Error(t, err)
 	assert.Nil(t, updates)
 	require.ErrorContains(t, err, "gamelistxml: failed to resolve systems")
@@ -845,10 +848,10 @@ func TestLoadRecords_FilenameFallback_MatchesNestedMedia(t *testing.T) {
 		{Path: nestedPath, SystemID: "nes", DBID: 9, MediaTitleDBID: 99},
 	}, nil).Once()
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+	records, err := (&GamelistXMLScraper{}).LoadRecords(context.Background(), scraper.ScrapeSystem{
 		ID:       "nes",
 		ROMPaths: []string{root},
-	})
+	}, db)
 
 	require.NoError(t, err)
 	require.Len(t, records, 1)
@@ -882,10 +885,10 @@ func TestLoadRecords_FilenameFallback_NoMatchAcrossRoots(t *testing.T) {
 		{Path: media2, SystemID: "nes", DBID: 2, MediaTitleDBID: 20},
 	}, nil).Once()
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+	records, err := (&GamelistXMLScraper{}).LoadRecords(context.Background(), scraper.ScrapeSystem{
 		ID:       "nes",
 		ROMPaths: []string{root1, root2},
-	})
+	}, db)
 
 	require.NoError(t, err)
 	require.Len(t, records, 2, "filename fallback must not cross-match between ROM roots")
@@ -920,10 +923,10 @@ func TestLoadRecords_FilenameFallback_SubdirGamelistNoMatch(t *testing.T) {
 		{Path: rootPath, SystemID: "nes", DBID: 5, MediaTitleDBID: 55},
 	}, nil).Once()
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
+	records, err := (&GamelistXMLScraper{}).LoadRecords(context.Background(), scraper.ScrapeSystem{
 		ID:       "nes",
 		ROMPaths: []string{root},
-	})
+	}, db)
 
 	require.NoError(t, err)
 	require.Empty(t, records,

--- a/pkg/database/scraper/run.go
+++ b/pkg/database/scraper/run.go
@@ -87,7 +87,7 @@ func RunScraper[T any](
 			}
 
 			// Step 1: load records for this system from the source.
-			records, err := s.LoadRecords(ctx, system)
+			records, err := s.LoadRecords(ctx, system, db)
 			if err != nil {
 				// If LoadRecords failed because the context was cancelled, treat it
 				// as a clean cancellation (no FatalErr) rather than a fatal error.

--- a/pkg/database/scraper/run_test.go
+++ b/pkg/database/scraper/run_test.go
@@ -50,7 +50,7 @@ type stubLoop struct {
 
 func (s *stubLoop) ID() string { return s.id }
 
-func (s *stubLoop) LoadRecords(_ context.Context, _ scraper.ScrapeSystem) ([]stubRecord, error) {
+func (s *stubLoop) LoadRecords(_ context.Context, _ scraper.ScrapeSystem, _ database.MediaDBI) ([]stubRecord, error) {
 	return s.records, nil
 }
 

--- a/pkg/database/scraper/scraper.go
+++ b/pkg/database/scraper/scraper.go
@@ -33,6 +33,21 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 )
 
+// SystemResolver resolves system IDs to their DB identity and ROM paths.
+// Implementations query the media DB and platform to replicate the same path
+// discovery used during media indexing so scraper paths match scanned paths.
+type SystemResolver func(ctx context.Context, systemIDs []string) ([]ScrapeSystem, error)
+
+// ScrapeEnv carries runtime dependencies injected by the API layer when Scrape
+// is called. These are not stored on the scraper struct; scrapers are stateless
+// with respect to them and are safe to reuse across calls.
+type ScrapeEnv struct {
+	// DB is the media database used to load and write scrape data.
+	DB database.MediaDBI
+	// ResolveSystemsFn resolves active system IDs to ScrapeSystem values.
+	ResolveSystemsFn SystemResolver
+}
+
 // Scraper is the public interface all metadata scrapers implement.
 // Each scraper owns one source: a local file format, a REST API, etc.
 type Scraper interface {
@@ -50,14 +65,15 @@ type Scraper interface {
 
 	// Scrape starts the goroutine and returns a channel of progress updates.
 	// The channel is closed when the goroutine exits (done or cancelled).
-	Scrape(ctx context.Context, opts ScrapeOptions) (<-chan ScrapeUpdate, error)
+	// env carries runtime dependencies (DB, resolver) injected by the API layer.
+	Scrape(ctx context.Context, env ScrapeEnv, opts ScrapeOptions) (<-chan ScrapeUpdate, error)
 }
 
 // ScraperLoop is the internal interface that concrete scrapers implement to plug
 // into [RunScraper]. T is the source-specific record type (e.g. GamelistRecord).
 //
-// Concrete scrapers also implement [Scraper]; their Scrape method stores the db
-// and system list, then delegates to RunScraper with self as the ScraperLoop.
+// Concrete scrapers also implement [Scraper]; their Scrape method delegates to
+// RunScraper with self as the ScraperLoop, passing the injected db.
 type ScraperLoop[T any] interface {
 	// ID returns the same stable identifier as Scraper.ID.
 	ID() string
@@ -65,7 +81,7 @@ type ScraperLoop[T any] interface {
 	// LoadRecords returns all source records for the given system.
 	// For file-based scrapers this reads local files; for REST scrapers this
 	// queries the DB for titles that need enrichment.
-	LoadRecords(ctx context.Context, system ScrapeSystem) ([]T, error)
+	LoadRecords(ctx context.Context, system ScrapeSystem, db database.MediaDBI) ([]T, error)
 
 	// Match attempts to bind a source record to a Zaparoo Media/MediaTitle row.
 	// Returns nil when the record cannot be matched (not an error; loop skips it).

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -16,6 +16,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -803,6 +805,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(customLaunchers, launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/bazzite/platform.go
+++ b/pkg/platforms/bazzite/platform.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
@@ -159,4 +161,8 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }

--- a/pkg/platforms/chimeraos/platform.go
+++ b/pkg/platforms/chimeraos/platform.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
@@ -149,4 +151,8 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }

--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -248,6 +250,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/linux/platform.go
+++ b/pkg/platforms/linux/platform.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
@@ -170,4 +172,8 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -225,6 +227,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -18,6 +18,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -1035,6 +1037,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	ls = append(ls, amiga, neogeo, createVideoLauncher(p), createScummVMLauncher(p))
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (p *Platform) ShowNotice(

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -353,6 +355,10 @@ func (*Platform) LookupMapping(_ *tokens.Token) (string, bool) {
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	ls := mister.CreateLaunchers(p)
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ConsoleManager() platforms.ConsoleManager {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
@@ -334,6 +335,10 @@ type Platform interface {
 	// Launchers is the complete list of all launchers available on this
 	// platform.
 	Launchers(*config.Instance) []Launcher
+	// Scrapers is the list of metadata scrapers available on this platform.
+	// Each scraper receives its runtime dependencies (DB, system resolver) via
+	// ScrapeEnv when Scrape is called, not at construction time.
+	Scrapers(*config.Instance) []scraper.Scraper
 	// ShowNotice displays a string on-screen of the platform device. Returns
 	// a function that may be used to manually hide the notice and a minimum
 	// amount of time that should be waited until trying to close the notice,

--- a/pkg/platforms/recalbox/platform.go
+++ b/pkg/platforms/recalbox/platform.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -233,6 +235,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/replayos/platform.go
+++ b/pkg/platforms/replayos/platform.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -310,6 +312,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	})
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/retropie/platform.go
+++ b/pkg/platforms/retropie/platform.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -233,6 +235,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/steamos/platform.go
+++ b/pkg/platforms/steamos/platform.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
@@ -190,4 +192,8 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	}
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), ls...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -35,6 +35,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -395,6 +397,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	launchers = append(launchers, deverr.GetDevErrLaunchers()...)
 
 	return append(helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers()), launchers...)
+}
+
+func (*Platform) Scrapers(_ *config.Instance) []scraper.Scraper {
+	return []scraper.Scraper{gamelistxml.NewGamelistXMLScraper()}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/testing/mocks/platform.go
+++ b/pkg/testing/mocks/platform.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
@@ -229,6 +230,15 @@ func (m *MockPlatform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	return []platforms.Launcher{}
 }
 
+// Scrapers is the list of metadata scrapers available on this platform
+func (m *MockPlatform) Scrapers(cfg *config.Instance) []scraper.Scraper {
+	args := m.Called(cfg)
+	if scrapers, ok := args.Get(0).([]scraper.Scraper); ok {
+		return scrapers
+	}
+	return []scraper.Scraper{}
+}
+
 // ShowNotice displays a string on-screen of the platform device
 func (m *MockPlatform) ShowNotice(cfg *config.Instance, args widgetmodels.NoticeArgs,
 ) (func() error, time.Duration, error) {
@@ -348,6 +358,7 @@ func (m *MockPlatform) SetupBasicMock() {
 	m.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/mock/roms"})
 	m.On("SupportedReaders", mock.AnythingOfType("*config.Instance")).Return([]readers.Reader{})
 	m.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+	m.On("Scrapers", mock.AnythingOfType("*config.Instance")).Return([]scraper.Scraper{})
 	m.On("ManagedByPackageManager").Return(false)
 
 	// Setup common stub functions for UI methods


### PR DESCRIPTION
---

**feat(scraper): gamelist.xml filename fallback + platform-scoped scraper architecture**

## Summary

- Adds filename-based fallback matching in the `gamelist.xml` scraper so root-level gamelist entries match ROMs indexed at nested paths (MiSTer use case)
- Fixes cross-root false matches: fallback now gates on the media path being under the current ROM root, preventing same-basename files in different roots from matching the wrong gamelist entry; adds regression test
- Moves `gamelistEntry` type declaration to the top-level type section alongside other types
- Refactors scraper construction: scrapers are now stateless, declared per-platform via `Platform.Scrapers(*config.Instance)` (mirroring `Launchers`), and receive runtime dependencies (`DB`, `SystemResolver`) injected via `ScrapeEnv` at call time rather than baked into the constructor

## Changes

- `scraper.Scraper.Scrape` signature: `(ctx, opts)` → `(ctx, ScrapeEnv, opts)`
- `scraper.ScraperLoop.LoadRecords` signature adds `db database.MediaDBI` parameter
- New `ScrapeEnv` and `SystemResolver` types in `pkg/database/scraper`
- `GamelistXMLScraper` is now stateless — `NewGamelistXMLScraper()` takes no args
- `Platform` interface gains `Scrapers(*config.Instance) []scraper.Scraper`; all 13 platform implementations updated
- `server.go` builds the scraper map from `platform.Scrapers(cfg)` and constructs `ScrapeEnv` once at startup; `gamelistxml` import removed from server layer
- `MockPlatform.Scrapers` added; `SetupBasicMock` stubs it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated scraper system to receive runtime environment and dependencies at call time rather than during initialization.
  * All platforms now explicitly expose available scraper implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->