### PR TITLE
feat(mister): add .chd extension to 3DO launcher

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -607,7 +607,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:         systemdefs.System3DO,
 			SystemID:   systemdefs.System3DO,
 			Folders:    []string{"3DO"},
-			Extensions: []string{".iso", ".cue"},
+			Extensions: []string{".iso", ".cue", ".chd"},
 			Launch:     launch(pl, systemdefs.System3DO),
 		},
 		{


### PR DESCRIPTION
## Summary
- Add `.chd` to the MiSTer 3DO launcher's recognised extensions alongside `.iso` and `.cue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for .chd extension in the 3DO launcher, enabling proper handling of 3DO disc/image files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->