### PR TITLE
refactor(scraper): Uses a faster title-dedupe scraping routine for XML

### DIFF
--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -489,3 +489,124 @@ func TestHandleMediaScrapeResume_ResumesPausedScrape(t *testing.T) {
 	assert.True(t, payload.Scraping)
 	assert.False(t, payload.Paused)
 }
+
+func TestHandleMediaScrapeResume_NilPauser(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+
+	result, err := HandleMediaScrapeResume(requests.RequestEnv{Context: context.Background()})
+	require.NoError(t, err)
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Media scraping is not paused", resp["message"])
+}
+
+func TestHandleMediaScrapeResume_NotPaused(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+
+	pauser := syncutil.NewPauser()
+	result, err := HandleMediaScrapeResume(requests.RequestEnv{
+		Context:      context.Background(),
+		ScrapePauser: pauser,
+	})
+	require.NoError(t, err)
+	resp, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Media scraping is not paused", resp["message"])
+}
+
+func TestScrapingStatus_ClearIfOwner_MatchingID_Clears(t *testing.T) {
+	t.Parallel()
+	s := &scrapingStatus{}
+	s.startIfNotRunning("my-scraper")
+	s.clearIfOwner("my-scraper")
+	assert.False(t, s.isRunning())
+}
+
+func TestScrapingStatus_ClearIfOwner_MismatchedID_Preserves(t *testing.T) {
+	t.Parallel()
+	s := &scrapingStatus{}
+	s.startIfNotRunning("owner-a")
+	s.clearIfOwner("owner-b")
+	assert.True(t, s.isRunning(), "non-owner clearIfOwner must not clear state")
+	s.clear()
+}
+
+func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return()
+	mockDB.On("BackgroundOperationDone").Return()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "progress-scraper").Return(3, nil)
+
+	progressScraper := platforms.Scraper{
+		ID:   "progress-scraper",
+		Name: "Progress Scraper",
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, _ scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			go func() {
+				defer close(ch)
+				ch <- scraper.ScrapeUpdate{SystemID: "SNES", Total: 10, Processed: 5, Matched: 4, Skipped: 1}
+				ch <- scraper.ScrapeUpdate{
+					SystemID: "SNES", Total: 10, Processed: 10, Matched: 8, Skipped: 2, Done: true,
+				}
+			}()
+			return nil
+		},
+	}
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
+		"progress-scraper": progressScraper,
+	})
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	t.Cleanup(st.StopService)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		State:    st,
+		Database: &database.Database{MediaDB: mockDB},
+		Params:   json.RawMessage(`{"scraperId":"progress-scraper"}`),
+	}
+
+	result, err := HandleMediaScrape(env)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	var gotDone bool
+	var maxProcessed int
+	timeout := time.After(2 * time.Second)
+	for !gotDone {
+		select {
+		case n := <-ns:
+			if n.Method != models.NotificationMediaScraping {
+				continue
+			}
+			var p models.ScrapingStatusResponse
+			require.NoError(t, json.Unmarshal(n.Params, &p))
+			if p.Processed > maxProcessed {
+				maxProcessed = p.Processed
+			}
+			if p.Done {
+				gotDone = true
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for media.scraping done notification")
+		}
+	}
+
+	assert.Equal(t, 10, maxProcessed, "progress updates should reflect actual processed count")
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond)
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -48,21 +48,15 @@ import (
 	"github.com/spf13/afero"
 )
 
-// GamelistRecord is one entry from a gamelist.xml, bundled with the filesystem
-// root path that the relative ES paths should be resolved against.
+// GamelistRecord is one matched gamelist.xml entry, bundled with the filesystem
+// root path and the DB identifiers of the matched MediaTitle and one of its
+// Media rows (used as the sentinel write target).
 type GamelistRecord struct {
 	AvailableMediaDirs map[string]string
 	SystemRootPath     string
-	MatchedPath        string
 	Game               esapi.Game
 	MatchedMediaDBID   int64
 	MatchedTitleDBID   int64
-}
-
-// gamelistEntry pairs a gamelist game with its resolved absolute path.
-type gamelistEntry struct {
-	absPath string
-	game    esapi.Game
 }
 
 // mediaDirCandidates maps each TagPropertyImage value to the ordered list of
@@ -84,8 +78,9 @@ var mediaDirCandidates = map[string][]string{
 // GamelistXMLScraper loads and maps EmulationStation gamelist.xml records.
 // Use [NewPlatformScraper] to obtain a configured [platforms.Scraper].
 type GamelistXMLScraper struct {
-	db database.MediaDBI
-	fs afero.Fs
+	db  database.MediaDBI
+	fs  afero.Fs
+	cfg *config.Instance
 }
 
 func (g *GamelistXMLScraper) filesystem() afero.Fs {
@@ -117,7 +112,7 @@ func NewPlatformScraper() platforms.Scraper {
 			if err != nil {
 				return fmt.Errorf("gamelistxml: resolve systems: %w", err)
 			}
-			s := &GamelistXMLScraper{db: db.MediaDB, fs: fs}
+			s := &GamelistXMLScraper{db: db.MediaDB, fs: fs, cfg: cfg}
 			go s.scrapeLoop(ctx, opts, systems, db.MediaDB, ch)
 			return nil
 		},
@@ -194,19 +189,22 @@ func resolveSystemsFromPlatform(
 	return result, nil
 }
 
-// LoadRecords loads all indexed media for the system then, for each ROM root,
-// matches each media record against the gamelist.xml found there. A record is
-// emitted only when a gamelist entry can be found for the media; unmatched
-// gamelist entries and unindexed ROMs are silently skipped.
+// LoadRecords iterates gamelist.xml files found under each ROM root path for
+// the given system. For each game entry whose slug matches a key in
+// titlesBySlug, a [GamelistRecord] is emitted and the slug is removed from
+// titlesBySlug (first match wins across all gamelists for the system).
+// titlesBySlug is mutated by this call — callers must not reuse it.
+//
+// mediaByTitleDBID supplies the Media DBID to use as the sentinel write target:
+// it must map each MediaTitle DBID to any one of its associated Media DBIDs.
+// A record whose title DBID has no entry in mediaByTitleDBID will have
+// MatchedMediaDBID = 0 and will be skipped by the scrape loop.
 func (g *GamelistXMLScraper) LoadRecords(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
+	titlesBySlug map[string]database.MediaTitle,
+	mediaByTitleDBID map[int64]int64,
 ) ([]*GamelistRecord, error) {
-	media, err := g.db.GetMediaBySystemID(system.ID)
-	if err != nil {
-		return nil, fmt.Errorf("gamelistxml: load indexed media for system %q: %w", system.ID, err)
-	}
-
 	var records []*GamelistRecord
 
 	for _, rootPath := range system.ROMPaths {
@@ -233,41 +231,34 @@ func (g *GamelistXMLScraper) LoadRecords(
 			Int("entries", len(gl.Games)).
 			Msg("gamelistxml: loaded gamelist.xml")
 
-		gamesByPath, gamesByFilename := buildGameIndexes(gl.Games, rootPath)
 		availableMediaDirs := statMediaDirsFS(g.filesystem(), rootPath)
 
-		for _, m := range media {
-			normalizedPath := normalizeMediaPath(m.Path)
-
-			var matched *gamelistEntry
-			if entry, ok := gamesByPath[normalizedPath]; ok {
-				matched = entry
-			} else if len(gamesByFilename) > 0 {
-				rel, relErr := filepath.Rel(filepath.Clean(rootPath), filepath.Clean(m.Path))
-				if relErr == nil && !strings.HasPrefix(rel, "..") {
-					filename := strings.ToLower(filepath.Base(m.Path))
-					if entry, ok := gamesByFilename[filename]; ok {
-						log.Debug().
-							Str("mediaPath", m.Path).
-							Str("gamelistPath", entry.game.Path).
-							Msg("gamelistxml: filename fallback matched nested media")
-						matched = entry
-					}
-				}
+		for i := range gl.Games {
+			resolved := resolveESPath(gl.Games[i].Path, rootPath)
+			if resolved == "" {
+				continue
 			}
 
-			if matched == nil {
+			pf := mediascanner.GetPathFragments(mediascanner.PathFragmentParams{
+				Config:   g.cfg,
+				Path:     resolved,
+				SystemID: system.ID,
+				NoExt:    true,
+			})
+
+			title, ok := titlesBySlug[pf.Slug]
+			if !ok {
 				continue
 			}
 
 			records = append(records, &GamelistRecord{
 				SystemRootPath:     rootPath,
 				AvailableMediaDirs: availableMediaDirs,
-				MatchedPath:        matched.absPath,
-				Game:               matched.game,
-				MatchedMediaDBID:   m.DBID,
-				MatchedTitleDBID:   m.MediaTitleDBID,
+				Game:               gl.Games[i],
+				MatchedTitleDBID:   title.DBID,
+				MatchedMediaDBID:   mediaByTitleDBID[title.DBID],
 			})
+			delete(titlesBySlug, pf.Slug)
 		}
 	}
 
@@ -277,41 +268,6 @@ func (g *GamelistXMLScraper) LoadRecords(
 		Msg("gamelistxml: finished loading records for system")
 
 	return records, nil
-}
-
-// buildGameIndexes creates two lookup tables from a slice of gamelist games.
-// byPath is keyed by normalised absolute path. byFilename is keyed by
-// lower-case basename and only includes entries whose gamelist path sits
-// directly under rootPath (depth 1) — the MiSTer case where a root-level
-// gamelist entry corresponds to a ROM indexed at a nested path.
-// The first entry wins when multiple games resolve to the same key.
-func buildGameIndexes(games []esapi.Game, rootPath string) (byPath, byFilename map[string]*gamelistEntry) {
-	byPath = make(map[string]*gamelistEntry, len(games))
-	byFilename = make(map[string]*gamelistEntry, len(games))
-	for i := range games {
-		resolved := resolveESPath(games[i].Path, rootPath)
-		if resolved == "" {
-			continue
-		}
-		abs := filepath.ToSlash(filepath.Clean(resolved))
-		entry := &gamelistEntry{game: games[i], absPath: abs}
-		key := normalizeMediaPath(abs)
-		if _, exists := byPath[key]; !exists {
-			byPath[key] = entry
-		}
-		rel, relErr := filepath.Rel(filepath.Clean(rootPath), filepath.Clean(resolved))
-		if relErr == nil && !strings.Contains(filepath.ToSlash(rel), "/") {
-			filename := strings.ToLower(filepath.Base(resolved))
-			if _, exists := byFilename[filename]; !exists {
-				byFilename[filename] = entry
-			}
-		}
-	}
-	return
-}
-
-func normalizeMediaPath(path string) string {
-	return strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
 }
 
 const scrapeProgressInterval = 250 * time.Millisecond
@@ -358,7 +314,74 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		case ch <- scraper.ScrapeUpdate{SystemID: system.ID, Total: 0}:
 		}
 
-		records, loadErr := g.LoadRecords(ctx, system)
+		// Build slug → MediaTitle map: only unscraped titles unless Force.
+		titlesBySlug := make(map[string]database.MediaTitle)
+		if opts.Force {
+			allTitles, titlesErr := mdb.GetTitlesBySystemID(system.ID)
+			if titlesErr != nil {
+				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
+					ch <- scraper.ScrapeUpdate{
+						Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
+					}
+					return
+				}
+				ch <- scraper.ScrapeUpdate{
+					SystemID: system.ID, FatalErr: titlesErr,
+					Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
+				}
+				return
+			}
+			for _, t := range allTitles {
+				titlesBySlug[t.Slug] = database.MediaTitle{
+					DBID: t.DBID, SystemDBID: t.SystemDBID, Slug: t.Slug, Name: t.Name,
+				}
+			}
+		} else {
+			sentinel := scraper.SentinelTagInfo(id)
+			sentinelTag := sentinel.Type + ":" + sentinel.Tag
+			unscraped, titlesErr := mdb.FindMediaTitlesWithoutSentinel(ctx, system.DBID, sentinelTag)
+			if titlesErr != nil {
+				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
+					ch <- scraper.ScrapeUpdate{
+						Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
+					}
+					return
+				}
+				ch <- scraper.ScrapeUpdate{
+					SystemID: system.ID, FatalErr: titlesErr,
+					Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
+				}
+				return
+			}
+			for _, t := range unscraped {
+				titlesBySlug[t.Slug] = t
+			}
+		}
+
+		// Build MediaTitle DBID → first Media DBID map for sentinel writes.
+		allMedia, mediaErr := mdb.GetMediaBySystemID(system.ID)
+		if mediaErr != nil {
+			if errors.Is(mediaErr, context.Canceled) || errors.Is(mediaErr, context.DeadlineExceeded) {
+				ch <- scraper.ScrapeUpdate{
+					SystemID: system.ID, Done: true, Processed: totalProcessed,
+					Matched: totalMatched, Skipped: totalSkipped,
+				}
+				return
+			}
+			ch <- scraper.ScrapeUpdate{
+				SystemID: system.ID, FatalErr: mediaErr,
+				Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
+			}
+			return
+		}
+		mediaByTitleDBID := make(map[int64]int64, len(allMedia))
+		for _, m := range allMedia {
+			if _, exists := mediaByTitleDBID[m.MediaTitleDBID]; !exists {
+				mediaByTitleDBID[m.MediaTitleDBID] = m.DBID
+			}
+		}
+
+		records, loadErr := g.LoadRecords(ctx, system, titlesBySlug, mediaByTitleDBID)
 		if loadErr != nil {
 			if errors.Is(loadErr, context.Canceled) || errors.Is(loadErr, context.DeadlineExceeded) {
 				ch <- scraper.ScrapeUpdate{
@@ -412,26 +435,6 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 		}
 
-		scrapedMediaIDs := map[int64]struct{}{}
-		if !opts.Force {
-			var sentinelErr error
-			scrapedMediaIDs, sentinelErr = mdb.GetScrapedMediaIDs(ctx, id, system.DBID)
-			if sentinelErr != nil {
-				if errors.Is(sentinelErr, context.Canceled) || errors.Is(sentinelErr, context.DeadlineExceeded) {
-					ch <- scraper.ScrapeUpdate{
-						SystemID: system.ID, Total: totalRecords,
-						Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
-					}
-					return
-				}
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, Total: totalRecords, FatalErr: sentinelErr,
-					Done: true, Processed: totalProcessed, Matched: totalMatched, Skipped: totalSkipped,
-				}
-				return
-			}
-		}
-
 		for _, record := range records {
 			if !waitForResume(system.ID, processed, matched, skipped) {
 				return
@@ -451,24 +454,15 @@ func (g *GamelistXMLScraper) scrapeLoop(
 
 			processed++
 			if record.MatchedMediaDBID == 0 || record.MatchedTitleDBID == 0 {
-				log.Debug().Str("path", record.MatchedPath).Msg("gamelistxml: no matched DB IDs, skipping")
+				log.Debug().
+					Int64("mediaTitleDBID", record.MatchedTitleDBID).
+					Msg("gamelistxml: no matched DB IDs, skipping")
 				skipped++
 				update := scraper.ScrapeUpdate{Processed: processed, Matched: matched, Skipped: skipped}
 				if !emitProgress(update, false) {
 					return
 				}
 				continue
-			}
-
-			if !opts.Force {
-				if _, exists := scrapedMediaIDs[record.MatchedMediaDBID]; exists {
-					skipped++
-					update := scraper.ScrapeUpdate{Processed: processed, Matched: matched, Skipped: skipped}
-					if !emitProgress(update, false) {
-						return
-					}
-					continue
-				}
 			}
 
 			mapped := g.MapToDB(record)
@@ -480,14 +474,11 @@ func (g *GamelistXMLScraper) scrapeLoop(
 				ctx, record.MatchedMediaDBID, record.MatchedTitleDBID,
 				&database.ScrapeWrite{
 					Sentinel:   scraper.SentinelTagInfo(id),
-					MediaTags:  mapped.MediaTags,
 					TitleTags:  mapped.TitleTags,
 					TitleProps: mapped.TitleProps,
-					MediaProps: mapped.MediaProps,
 				})
 			if writeErr != nil {
 				log.Warn().Err(writeErr).
-					Int64("mediaDBID", record.MatchedMediaDBID).
 					Int64("mediaTitleDBID", record.MatchedTitleDBID).
 					Str("system", system.ID).
 					Msg("gamelistxml: write failed")
@@ -502,9 +493,6 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 
 			matched++
-			if !opts.Force {
-				scrapedMediaIDs[record.MatchedMediaDBID] = struct{}{}
-			}
 			if !emitProgress(scraper.ScrapeUpdate{Processed: processed, Matched: matched, Skipped: skipped}, false) {
 				return
 			}
@@ -522,18 +510,15 @@ func (g *GamelistXMLScraper) scrapeLoop(
 }
 
 // MapToDB converts a GamelistRecord into the tag and property writes to apply
-// to the matched Media and MediaTitle rows.
+// to the matched MediaTitle row. Media-level tags are not written by this
+// scraper; only title-level tags and properties are populated.
 func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
-	var mediaTags []database.TagInfo
 	var titleTags []database.TagInfo
 	var titleProps []database.MediaProperty
-	var mediaProps []database.MediaProperty
 	game := record.Game
 
 	// Normalise all string fields before mapping: unescape HTML entities,
 	// collapse control whitespace to spaces, and trim surrounding whitespace.
-	game.Lang = cleanField(game.Lang)
-	game.Region = cleanField(game.Region)
 	game.Developer = cleanField(game.Developer)
 	game.Publisher = cleanField(game.Publisher)
 	game.ReleaseDate = cleanField(game.ReleaseDate)
@@ -552,33 +537,6 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 	game.TitleShot = cleanField(game.TitleShot)
 	game.Map = cleanField(game.Map)
 	game.Manual = cleanField(game.Manual)
-
-	// --- MediaTags: ROM-level, variant-specific ---
-
-	// Lang: split comma-separated values; each becomes a separate lang: tag.
-	if game.Lang != "" {
-		for _, lang := range splitCSV(game.Lang) {
-			if lang != "" {
-				mediaTags = append(mediaTags, database.TagInfo{
-					Type: string(tags.TagTypeLang), Tag: strings.ToLower(lang),
-				})
-			}
-		}
-	}
-
-	// Region: split comma-separated values.
-	if game.Region != "" {
-		for _, region := range splitCSV(game.Region) {
-			if region != "" {
-				mediaTags = append(mediaTags, database.TagInfo{
-					Type: string(tags.TagTypeRegion), Tag: strings.ToLower(region),
-				})
-			}
-		}
-	}
-
-	// favorite/hidden/kidgame: user-state — not scraped.
-	// disc/track: owned by filename parser — not overwritten here.
 
 	// --- MediaTitleTags: title-level, shared across all ROMs ---
 
@@ -676,12 +634,9 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		titleProps = append(titleProps, *p)
 	}
 
-	// mediaProps: gamelist.xml scraper writes no ROM-level properties.
 	return scraper.MapResult{
-		MediaTags:  mediaTags,
 		TitleTags:  titleTags,
 		TitleProps: titleProps,
-		MediaProps: mediaProps,
 	}
 }
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -207,6 +207,7 @@ func (g *GamelistXMLScraper) LoadRecords(
 ) ([]*GamelistRecord, error) {
 	var records []*GamelistRecord
 
+outer:
 	for _, rootPath := range system.ROMPaths {
 		select {
 		case <-ctx.Done():
@@ -259,6 +260,9 @@ func (g *GamelistXMLScraper) LoadRecords(
 				MatchedMediaDBID:   mediaByTitleDBID[title.DBID],
 			})
 			delete(titlesBySlug, pf.Slug)
+			if len(titlesBySlug) == 0 {
+				break outer
+			}
 		}
 	}
 
@@ -356,6 +360,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			for _, t := range unscraped {
 				titlesBySlug[t.Slug] = t
 			}
+		}
+
+		if len(titlesBySlug) == 0 {
+			continue
 		}
 
 		// Build MediaTitle DBID → first Media DBID map for sentinel writes.

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -21,13 +21,13 @@ package gamelistxml
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
@@ -36,6 +36,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// slugFor computes the MediaTitle slug that would be stored for a ROM path
+// using the same parameters as the scraper's LoadRecords call.
+func slugFor(systemID, path string) string {
+	return mediascanner.GetPathFragments(mediascanner.PathFragmentParams{
+		SystemID: systemID,
+		Path:     path,
+		NoExt:    true,
+	}).Slug
+}
 
 // --- cleanField ---
 
@@ -251,6 +261,45 @@ func TestMimeFromExt_Unknown(t *testing.T) {
 
 // --- LoadRecords ---
 
+// TestLoadRecords_SlugMatch verifies that a gamelist entry whose slug matches a
+// key in titlesBySlug produces a GamelistRecord with the correct DB IDs.
+func TestLoadRecords_SlugMatch(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "media", "image"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./mario.nes</path><name>Mario</name></game>
+  <game><path>./zelda.nes</path><name>Zelda</name></game>
+</gameList>`), 0o600))
+
+	marioSlug := slugFor("nes", filepath.Join(root, "mario.nes"))
+
+	titlesBySlug := map[string]database.MediaTitle{
+		marioSlug: {DBID: 22, Slug: marioSlug},
+	}
+	mediaByTitleDBID := map[int64]int64{22: 11}
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}},
+		titlesBySlug,
+		mediaByTitleDBID,
+	)
+	require.NoError(t, err)
+	// Only mario has a matching MediaTitle slug; zelda is silently skipped.
+	require.Len(t, records, 1)
+	assert.Equal(t, root, records[0].SystemRootPath)
+	assert.Equal(t, "./mario.nes", records[0].Game.Path)
+	assert.Equal(t, "Mario", records[0].Game.Name)
+	assert.Equal(t, int64(11), records[0].MatchedMediaDBID)
+	assert.Equal(t, int64(22), records[0].MatchedTitleDBID)
+	assert.Equal(t, filepath.Join(root, "media", "image"), records[0].AvailableMediaDirs["image"])
+}
+
+// TestLoadRecords_SkipsMissingAndMalformedGameLists verifies that ROM roots
+// without a gamelist.xml and roots with a malformed file are silently skipped.
 func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
 	t.Parallel()
 
@@ -262,41 +311,71 @@ func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(malformedRoot, "gamelist.xml"), []byte(`<gameList><game>`), 0o600))
 
 	validRoot := filepath.Join(t.TempDir(), "valid")
-	require.NoError(t, os.MkdirAll(filepath.Join(validRoot, "media", "image"), 0o750))
+	require.NoError(t, os.MkdirAll(validRoot, 0o750))
 	require.NoError(t, os.WriteFile(filepath.Join(validRoot, "gamelist.xml"), []byte(`
 <gameList>
   <game><path>./mario.nes</path><name>Mario</name></game>
-  <game><path>./zelda.nes</path><name>Zelda</name></game>
 </gameList>`), 0o600))
 
-	db := helpers.NewMockMediaDBI()
-	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
-		{
-			Path:           filepath.ToSlash(filepath.Join(validRoot, "MARIO.nes")),
-			SystemID:       "nes",
-			DBID:           11,
-			MediaTitleDBID: 22,
-		},
-	}, nil).Once()
+	marioSlug := slugFor("nes", filepath.Join(validRoot, "mario.nes"))
+	titlesBySlug := map[string]database.MediaTitle{
+		marioSlug: {DBID: 5, Slug: marioSlug},
+	}
+	mediaByTitleDBID := map[int64]int64{5: 3}
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID:       "nes",
-		ROMPaths: []string{missingRoot, malformedRoot, validRoot},
-	})
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{
+			ID:       "nes",
+			ROMPaths: []string{missingRoot, malformedRoot, validRoot},
+		},
+		titlesBySlug,
+		mediaByTitleDBID,
+	)
 	require.NoError(t, err)
-	// Only mario has an indexed media record; zelda is silently skipped.
 	require.Len(t, records, 1)
-	assert.Equal(t, validRoot, records[0].SystemRootPath)
-	assert.Equal(t, "./mario.nes", records[0].Game.Path)
-	assert.Equal(t, "Mario", records[0].Game.Name)
-	assert.Equal(t, filepath.ToSlash(filepath.Join(validRoot, "mario.nes")), records[0].MatchedPath)
-	assert.Equal(t, int64(11), records[0].MatchedMediaDBID)
-	assert.Equal(t, int64(22), records[0].MatchedTitleDBID)
-	assert.Equal(t, filepath.Join(validRoot, "media", "image"), records[0].AvailableMediaDirs["image"])
-	db.AssertExpectations(t)
+	assert.Equal(t, int64(3), records[0].MatchedMediaDBID)
+	assert.Equal(t, int64(5), records[0].MatchedTitleDBID)
 }
 
-func TestLoadRecords_ReturnsMediaPreloadError(t *testing.T) {
+// TestLoadRecords_FirstWins verifies that when two gamelist roots contain an
+// entry with the same slug, only the first is recorded.
+func TestLoadRecords_FirstWins(t *testing.T) {
+	t.Parallel()
+
+	root1 := t.TempDir()
+	root2 := t.TempDir()
+
+	writeGamelist := func(dir, name string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./game.nes</path><name>`+name+`</name></game>
+</gameList>`), 0o600))
+	}
+	writeGamelist(root1, "Game A")
+	writeGamelist(root2, "Game B")
+
+	slug := slugFor("nes", filepath.Join(root1, "game.nes"))
+	titlesBySlug := map[string]database.MediaTitle{
+		slug: {DBID: 1, Slug: slug},
+	}
+	mediaByTitleDBID := map[int64]int64{1: 10}
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root1, root2}},
+		titlesBySlug,
+		mediaByTitleDBID,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "second root's duplicate slug must be skipped")
+	assert.Equal(t, "Game A", records[0].Game.Name, "first root wins")
+}
+
+// TestLoadRecords_NoMediaForTitle verifies that a slug match with no
+// corresponding Media row yields MatchedMediaDBID = 0. The scrape loop will
+// skip such records via its zero-ID guard.
+func TestLoadRecords_NoMediaForTitle(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -305,26 +384,80 @@ func TestLoadRecords_ReturnsMediaPreloadError(t *testing.T) {
   <game><path>./mario.nes</path><name>Mario</name></game>
 </gameList>`), 0o600))
 
-	db := helpers.NewMockMediaDBI()
-	preloadErr := errors.New("media preload failed")
-	db.On("GetMediaBySystemID", "nes").Return(nil, preloadErr).Once()
+	slug := slugFor("nes", filepath.Join(root, "mario.nes"))
+	titlesBySlug := map[string]database.MediaTitle{
+		slug: {DBID: 7, Slug: slug},
+	}
+	// Intentionally omit title DBID 7 from mediaByTitleDBID.
+	mediaByTitleDBID := map[int64]int64{}
 
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID:       "nes",
-		ROMPaths: []string{root},
-	})
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}},
+		titlesBySlug,
+		mediaByTitleDBID,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(7), records[0].MatchedTitleDBID)
+	assert.Equal(t, int64(0), records[0].MatchedMediaDBID)
+}
 
-	require.Error(t, err)
-	assert.Nil(t, records)
-	require.ErrorContains(t, err, `load indexed media for system "nes"`)
-	require.ErrorIs(t, err, preloadErr)
-	db.AssertExpectations(t)
+// TestLoadRecords_ContextCancellation verifies that a cancelled context causes
+// LoadRecords to return context.Canceled immediately.
+func TestLoadRecords_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./mario.nes</path><name>Mario</name></game>
+</gameList>`), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := (&GamelistXMLScraper{}).LoadRecords(
+		ctx,
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}},
+		map[string]database.MediaTitle{},
+		map[int64]int64{},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestLoadRecords_PathTraversalSkipped verifies that gamelist entries whose
+// paths escape the system root are silently skipped.
+func TestLoadRecords_PathTraversalSkipped(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>../../etc/passwd</path><name>Traversal</name></game>
+  <game><path>./mario.nes</path><name>Mario</name></game>
+</gameList>`), 0o600))
+
+	slug := slugFor("nes", filepath.Join(root, "mario.nes"))
+	titlesBySlug := map[string]database.MediaTitle{
+		slug: {DBID: 1, Slug: slug},
+	}
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}},
+		titlesBySlug,
+		map[int64]int64{1: 9},
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "traversal entry must be dropped; mario must still match")
+	assert.Equal(t, "Mario", records[0].Game.Name)
 }
 
 func TestScrape_DBError(t *testing.T) {
 	t.Parallel()
 
-	dbErr := errors.New("db failed")
+	dbErr := assert.AnError
 	mockDB := helpers.NewMockMediaDBI()
 	mockDB.On("IndexedSystems").Return([]string(nil), dbErr)
 
@@ -371,13 +504,8 @@ func TestMapToDB_FullGame(t *testing.T) {
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
 
-	// Media-level tags
-	assert.Contains(t, result.MediaTags, database.TagInfo{Type: string(tags.TagTypeLang), Tag: "en"})
-	assert.Contains(t, result.MediaTags, database.TagInfo{Type: string(tags.TagTypeRegion), Tag: "usa"})
-	// players is title-level (Fix 7): assert it is NOT in MediaTags.
-	for _, tag := range result.MediaTags {
-		assert.NotEqual(t, string(tags.TagTypePlayers), tag.Type, "players must not appear in mediaTags")
-	}
+	// Media-level tags: not written by this scraper.
+	assert.Empty(t, result.MediaTags, "gamelistxml scraper writes no media-level tags")
 
 	// Title-level tags
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeDeveloper), Tag: "Nintendo"})
@@ -385,7 +513,6 @@ func TestMapToDB_FullGame(t *testing.T) {
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeYear), Tag: "1985"})
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeRating), Tag: "75"})
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeGenre), Tag: "Platform"})
-	// players must be title-level (Fix 7).
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypePlayers), Tag: "4"})
 
 	// Title-level properties
@@ -411,38 +538,6 @@ func TestMapToDB_FullGame(t *testing.T) {
 	assert.True(t, foundVideo, "video property missing")
 
 	assert.Empty(t, result.MediaProps, "gamelistxml scraper writes no media-level properties")
-}
-
-func TestMapToDB_MultiLang(t *testing.T) {
-	t.Parallel()
-	rec := GamelistRecord{
-		Game: esapi.Game{Lang: "en, fr, de"},
-	}
-	mediaTags := (&GamelistXMLScraper{}).MapToDB(&rec).MediaTags
-
-	var langs []string
-	for _, tag := range mediaTags {
-		if tag.Type == string(tags.TagTypeLang) {
-			langs = append(langs, tag.Tag)
-		}
-	}
-	assert.ElementsMatch(t, []string{"en", "fr", "de"}, langs)
-}
-
-func TestMapToDB_MultiRegion(t *testing.T) {
-	t.Parallel()
-	rec := GamelistRecord{
-		Game: esapi.Game{Region: "usa,eur"},
-	}
-	mediaTags := (&GamelistXMLScraper{}).MapToDB(&rec).MediaTags
-
-	var regions []string
-	for _, tag := range mediaTags {
-		if tag.Type == string(tags.TagTypeRegion) {
-			regions = append(regions, tag.Tag)
-		}
-	}
-	assert.ElementsMatch(t, []string{"usa", "eur"}, regions)
 }
 
 func TestMapToDB_EmptyGame_NoTags(t *testing.T) {
@@ -772,171 +867,4 @@ func TestMapToDB_FilesystemFallback_NoMediaDir(t *testing.T) {
 	for _, p := range result.TitleProps {
 		assert.NotContains(t, p.TypeTag, "image-", "no image props expected when no media dir and no XML paths")
 	}
-}
-
-// --- buildGameIndexes ---
-
-func TestBuildGameIndexes_ByPath(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	games := []esapi.Game{
-		{Path: "./mario.nes", Name: "Mario"},
-		{Path: "./zelda.nes", Name: "Zelda"},
-	}
-	byPath, _ := buildGameIndexes(games, root)
-	marioKey := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
-	zeldaKey := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "zelda.nes")))
-	assert.Equal(t, "Mario", byPath[marioKey].game.Name)
-	assert.Equal(t, "Zelda", byPath[zeldaKey].game.Name)
-}
-
-func TestBuildGameIndexes_AbsPathStored(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	games := []esapi.Game{{Path: "./mario.nes"}}
-	byPath, _ := buildGameIndexes(games, root)
-	key := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
-	require.Contains(t, byPath, key)
-	assert.Equal(t, filepath.ToSlash(filepath.Join(root, "mario.nes")), byPath[key].absPath)
-}
-
-func TestBuildGameIndexes_ByFilename_DepthOneOnly(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	games := []esapi.Game{
-		{Path: "./mario.nes"},     // depth 1 — must be in byFilename
-		{Path: "./sub/zelda.nes"}, // depth 2 — must NOT be in byFilename
-	}
-	_, byFilename := buildGameIndexes(games, root)
-	assert.Contains(t, byFilename, "mario.nes", "depth-1 entry must be in byFilename")
-	assert.NotContains(t, byFilename, "zelda.nes", "depth-2 entry must not be in byFilename")
-}
-
-func TestBuildGameIndexes_FirstWinsOnPathConflict(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	games := []esapi.Game{
-		{Path: "./mario.nes", Name: "Mario A"},
-		{Path: "./mario.nes", Name: "Mario B"},
-	}
-	byPath, _ := buildGameIndexes(games, root)
-	key := normalizeMediaPath(filepath.ToSlash(filepath.Join(root, "mario.nes")))
-	require.Contains(t, byPath, key)
-	assert.Equal(t, "Mario A", byPath[key].game.Name, "first entry wins on conflict")
-}
-
-func TestBuildGameIndexes_SkipsUnresolvablePaths(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	games := []esapi.Game{
-		{Path: "../../etc/passwd"},
-		{Path: "./mario.nes", Name: "Mario"},
-	}
-	byPath, byFilename := buildGameIndexes(games, root)
-	assert.Len(t, byPath, 1, "unresolvable path must be skipped")
-	assert.Len(t, byFilename, 1)
-}
-
-// --- LoadRecords filename fallback integration ---
-
-func TestLoadRecords_FilenameFallback_MatchesNestedMedia(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
-<gameList>
-  <game><path>./mario.nes</path><name>Mario</name></game>
-</gameList>`), 0o600))
-
-	// Media is indexed at a nested path, not at the root.
-	nestedPath := filepath.ToSlash(filepath.Join(root, "sub", "mario.nes"))
-	db := helpers.NewMockMediaDBI()
-	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
-		{Path: nestedPath, SystemID: "nes", DBID: 9, MediaTitleDBID: 99},
-	}, nil).Once()
-
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID:       "nes",
-		ROMPaths: []string{root},
-	})
-
-	require.NoError(t, err)
-	require.Len(t, records, 1)
-	assert.Equal(t, int64(9), records[0].MatchedMediaDBID,
-		"filename fallback should match nested media when gamelist entry is root-relative")
-	assert.Equal(t, int64(99), records[0].MatchedTitleDBID)
-	db.AssertExpectations(t)
-}
-
-func TestLoadRecords_FilenameFallback_NoMatchAcrossRoots(t *testing.T) {
-	t.Parallel()
-
-	root1 := t.TempDir()
-	root2 := t.TempDir()
-
-	require.NoError(t, os.WriteFile(filepath.Join(root1, "gamelist.xml"), []byte(`
-<gameList>
-  <game><path>./game.nes</path><name>Root1 Game</name></game>
-</gameList>`), 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(root2, "gamelist.xml"), []byte(`
-<gameList>
-  <game><path>./game.nes</path><name>Root2 Game</name></game>
-</gameList>`), 0o600))
-
-	// Both media entries share the same basename but live under different roots.
-	media1 := filepath.ToSlash(filepath.Join(root1, "sub", "game.nes"))
-	media2 := filepath.ToSlash(filepath.Join(root2, "sub", "game.nes"))
-	db := helpers.NewMockMediaDBI()
-	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
-		{Path: media1, SystemID: "nes", DBID: 1, MediaTitleDBID: 10},
-		{Path: media2, SystemID: "nes", DBID: 2, MediaTitleDBID: 20},
-	}, nil).Once()
-
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID:       "nes",
-		ROMPaths: []string{root1, root2},
-	})
-
-	require.NoError(t, err)
-	require.Len(t, records, 2, "filename fallback must not cross-match between ROM roots")
-
-	byDBID := make(map[int64]*GamelistRecord, len(records))
-	for _, r := range records {
-		byDBID[r.MatchedMediaDBID] = r
-	}
-	require.Contains(t, byDBID, int64(1))
-	require.Contains(t, byDBID, int64(2))
-	assert.Equal(t, "Root1 Game", byDBID[1].Game.Name,
-		"media under root1 must match root1's gamelist entry")
-	assert.Equal(t, "Root2 Game", byDBID[2].Game.Name,
-		"media under root2 must match root2's gamelist entry")
-	db.AssertExpectations(t)
-}
-
-func TestLoadRecords_FilenameFallback_SubdirGamelistNoMatch(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	// Gamelist has a subdir path — fallback must NOT fire.
-	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
-<gameList>
-  <game><path>./sub/mario.nes</path><name>Mario</name></game>
-</gameList>`), 0o600))
-
-	// Media is only indexed at root, so direct match also fails.
-	rootPath := filepath.ToSlash(filepath.Join(root, "mario.nes"))
-	db := helpers.NewMockMediaDBI()
-	db.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
-		{Path: rootPath, SystemID: "nes", DBID: 5, MediaTitleDBID: 55},
-	}, nil).Once()
-
-	records, err := (&GamelistXMLScraper{db: db}).LoadRecords(context.Background(), scraper.ScrapeSystem{
-		ID:       "nes",
-		ROMPaths: []string{root},
-	})
-
-	require.NoError(t, err)
-	require.Empty(t, records,
-		"filename fallback must not fire when gamelist path has a subdirectory")
-	db.AssertExpectations(t)
 }

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -20,6 +20,8 @@
 package platforms_test
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -603,4 +605,59 @@ func TestDoLaunch_NativeLaunchPath(t *testing.T) {
 			mockPlatform.AssertExpectations(t)
 		})
 	}
+}
+
+func TestKeyboardControls_EmptyActions(t *testing.T) {
+	t.Parallel()
+	pl := mocks.NewMockPlatform()
+	controls := platforms.KeyboardControls(pl, map[string]string{})
+	assert.Empty(t, controls)
+}
+
+func TestKeyboardControls_BuildsMapWithCorrectKeys(t *testing.T) {
+	t.Parallel()
+	pl := mocks.NewMockPlatform()
+	controls := platforms.KeyboardControls(pl, map[string]string{
+		platforms.ControlSaveState: "{f2}",
+		platforms.ControlLoadState: "{f4}",
+	})
+	require.Len(t, controls, 2)
+	assert.Contains(t, controls, platforms.ControlSaveState)
+	assert.Contains(t, controls, platforms.ControlLoadState)
+	assert.NotNil(t, controls[platforms.ControlSaveState].Func)
+	assert.NotNil(t, controls[platforms.ControlLoadState].Func)
+}
+
+func TestKeyboardControls_InvokesPlatformKeyboardPress(t *testing.T) {
+	t.Parallel()
+	pl := mocks.NewMockPlatform()
+	pl.On("KeyboardPress", "{f2}").Return(nil)
+
+	controls := platforms.KeyboardControls(pl, map[string]string{
+		platforms.ControlSaveState: "{f2}",
+	})
+	ctrl, ok := controls[platforms.ControlSaveState]
+	require.True(t, ok)
+	require.NotNil(t, ctrl.Func)
+
+	err := ctrl.Func(context.Background(), &config.Instance{}, platforms.ControlParams{})
+	require.NoError(t, err)
+	pl.AssertExpectations(t)
+}
+
+func TestKeyboardControls_PropagatesKeyboardPressError(t *testing.T) {
+	t.Parallel()
+	pl := mocks.NewMockPlatform()
+	keyErr := errors.New("keyboard not supported")
+	pl.On("KeyboardPress", "{ctrl+q}").Return(keyErr)
+
+	controls := platforms.KeyboardControls(pl, map[string]string{
+		platforms.ControlStop: "{ctrl+q}",
+	})
+	ctrl, ok := controls[platforms.ControlStop]
+	require.True(t, ok)
+
+	err := ctrl.Func(context.Background(), &config.Instance{}, platforms.ControlParams{})
+	require.ErrorIs(t, err, keyErr)
+	pl.AssertExpectations(t)
 }


### PR DESCRIPTION
Here's the PR description:

---

## perf(scraper): rewrite gamelist.xml match loop to title-slug lookup

### Summary

The gamelist.xml scraper previously iterated indexed `Media` rows and matched each against gamelist entries via path normalization (exact path + filename fallback). For large collections this was O(media × gamelist_entries) per system per root, with two hash maps built per gamelist file.

This PR inverts the loop: `scrapeLoop` now pre-builds a `slug → MediaTitle` map (unscraped titles only, or all titles in Force mode) using `FindMediaTitlesWithoutSentinel` before calling `LoadRecords`. `LoadRecords` then iterates gamelist entries and does an O(1) slug lookup per entry, deleting matched slugs to enforce first-match-wins deduplication across multiple ROM roots.

Key structural changes:
- `LoadRecords` signature gains `titlesBySlug` and `mediaByTitleDBID` params; DB queries moved to caller (`scrapeLoop`)
- Pre-filtering via `FindMediaTitlesWithoutSentinel` replaces the post-load `scrapedMediaIDs` set — unscraped titles arrive as the lookup key set rather than being filtered after matching
- `buildGameIndexes`, `normalizeMediaPath`, and `gamelistEntry` removed
- `GamelistRecord.MatchedPath` removed — `MapToDB` uses DB IDs only
- `cfg *config.Instance` added to `GamelistXMLScraper` for slug computation via `mediascanner.GetPathFragments`
- `MapToDB` drops media-level lang/region tags; this scraper now writes title-level metadata only

### Tests

- `TestLoadRecords_SlugMatch` — slug match produces correct DB IDs
- `TestLoadRecords_FirstWins` — duplicate slug across roots: first root wins
- `TestLoadRecords_NoMediaForTitle` — slug match with no Media row yields `MatchedMediaDBID = 0`
- `TestLoadRecords_ContextCancellation` — cancelled context returns `context.Canceled`
- `TestLoadRecords_PathTraversalSkipped` — `../../etc/passwd` entries skipped; valid entry still matches
- `TestScrapingStatus_ClearIfOwner_*` — owner/non-owner clear semantics
- `TestHandleMediaScrape_EmitsProgressUpdates` — progress notifications reflect actual processed count
- `TestKeyboardControls_*` — `KeyboardControls` builder and error propagation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gamelist.xml scraping to use slug-based matching for more reliable game detection.
  * Enhanced handling of malformed or missing gamelist files during scraping.

* **Tests**
  * Added comprehensive test coverage for media scraper resume behavior.
  * Expanded test suite for gamelist.xml scraping including slug-matching validation and edge case handling.
  * Added keyboard controls functionality tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->