### PR TITLE
feat(api): expose system defaults and launcher list

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -232,7 +232,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods are used to execute actions and request data back from the API. The current API provides **59 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
+Methods are used to execute actions and request data back from the API. The current API provides **60 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
 
 | ID                              | Description                                                                           |
 | :------------------------------ | :------------------------------------------------------------------------------------ |
@@ -282,6 +282,7 @@ Methods are used to execute actions and request data back from the API. The curr
 | readers                         | List all currently connected readers and their capabilities.                          |
 | readers.write                   | Attempt to write given text to the first available write-capable reader, if possible. |
 | readers.write.cancel            | Cancel any active write operation.                                                    |
+| launchers                       | List all launchers known to the running service.                                       |
 | launchers.refresh               | Refresh the internal launcher cache, forcing a reload of launcher configurations.     |
 | version                         | Return server's current version and platform.                                         |
 | health                          | Simple health check to verify the server is running and responding.                   |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -1911,6 +1911,7 @@ None.
 | readersScanIgnoreSystems  | string[]                                  | Yes      | List of system IDs to ignore during scanning.                   |
 | errorReporting            | boolean                                   | Yes      | Whether error reporting is enabled.                             |
 | readersConnect            | [ReaderConnection](#reader-connection-object)[] | Yes      | List of manually configured reader connections.                 |
+| systemDefaults            | [SystemDefault](#system-default-object)[] | Yes      | Per-system overrides for default launcher and exit ZapScript.   |
 
 ##### Reader connection object
 
@@ -1920,6 +1921,14 @@ None.
 | path     | string | Yes      | Path or address for the reader connection.       |
 | idSource | string | No       | Source for the reader ID.                        |
 | enabled  | bool   | No       | Whether the connection is enabled. Defaults to true if omitted. |
+
+##### System default object
+
+| Key        | Type   | Required | Description                                                                                       |
+| :--------- | :----- | :------- | :------------------------------------------------------------------------------------------------ |
+| system     | string | Yes      | System ID this default applies to. Accepts canonical IDs and aliases.                             |
+| launcher   | string | No       | Launcher ID or group name to use for this system. Empty means no override.                        |
+| beforeExit | string | No       | ZapScript to run when a media instance for this system is exiting (before the new launch starts). |
 
 #### Example
 
@@ -1948,7 +1957,13 @@ None.
     "readersScanExitDelay": 0.0,
     "readersScanIgnoreSystems": ["DOS"],
     "errorReporting": true,
-    "readersConnect": []
+    "readersConnect": [],
+    "systemDefaults": [
+      {
+        "system": "Genesis",
+        "launcher": "retroarch"
+      }
+    ]
   }
 }
 ```
@@ -1974,6 +1989,7 @@ An object containing any of the following optional keys:
 | readersScanIgnoreSystems  | string[]                                  | No       | List of system IDs to ignore during scanning.                   |
 | errorReporting            | boolean                                   | No       | Whether error reporting is enabled.                             |
 | readersConnect            | [ReaderConnection](#reader-connection-object)[] | No       | List of manually configured reader connections.                 |
+| systemDefaults            | [SystemDefault](#system-default-object)[] | No       | Replace the full list of per-system launcher/exit-script overrides. Each `launcher` value, if non-empty, must match a known launcher ID or group (case-insensitive). |
 
 #### Result
 
@@ -2721,6 +2737,66 @@ Returns `null` on success.
 ```
 
 ## Launchers
+
+### launchers
+
+List all launchers known to the running service. Suitable for populating a UI launcher picker (for example, when assigning a per-system default via [settings.update](#settingsupdate)).
+
+#### Parameters
+
+None.
+
+#### Result
+
+| Key       | Type                                  | Required | Description                  |
+| :-------- | :------------------------------------ | :------- | :--------------------------- |
+| launchers | [Launcher](#launcher-object)[] | Yes      | All cached launchers, sorted by `systemId` then `id`. |
+
+##### Launcher object
+
+| Key        | Type     | Required | Description                                                                                            |
+| :--------- | :------- | :------- | :----------------------------------------------------------------------------------------------------- |
+| id         | string   | Yes      | Unique launcher identifier.                                                                            |
+| systemId   | string   | No       | The system this launcher targets. Omitted for generic launchers without a fixed system.                |
+| systemName | string   | No       | Human-readable system name resolved from system metadata. Omitted when no metadata is available.       |
+| groups     | string[] | No       | Group names this launcher belongs to. Group names are valid values for `systemDefaults.launcher`.      |
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "5b8c3a40-7a5e-11ef-88ff-020304050607",
+  "method": "launchers"
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "5b8c3a40-7a5e-11ef-88ff-020304050607",
+  "result": {
+    "launchers": [
+      {
+        "id": "retroarch",
+        "systemId": "Genesis",
+        "systemName": "Genesis",
+        "groups": ["libretro"]
+      },
+      {
+        "id": "snes9x",
+        "systemId": "SNES",
+        "systemName": "Super Nintendo",
+        "groups": ["libretro"]
+      }
+    ]
+  }
+}
+```
 
 ### launchers.refresh
 

--- a/pkg/api/methods/launchers.go
+++ b/pkg/api/methods/launchers.go
@@ -22,12 +22,54 @@ package methods
 import (
 	"errors"
 	"path/filepath"
+	"sort"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
 )
+
+func HandleLaunchers(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use
+	log.Debug().Msg("received launchers request")
+
+	if env.LauncherCache == nil {
+		return models.LaunchersResponse{Launchers: []models.Launcher{}}, nil
+	}
+
+	all := env.LauncherCache.GetAllLaunchers()
+	resp := make([]models.Launcher, 0, len(all))
+	for i := range all {
+		l := all[i]
+		var groups []string
+		if len(l.Groups) > 0 {
+			groups = make([]string, len(l.Groups))
+			copy(groups, l.Groups)
+		}
+		entry := models.Launcher{
+			ID:       l.ID,
+			SystemID: l.SystemID,
+			Groups:   groups,
+		}
+		if l.SystemID != "" {
+			if sm, mErr := assets.GetSystemMetadata(l.SystemID); mErr == nil && sm.Name != "" {
+				entry.SystemName = sm.Name
+			}
+		}
+		resp = append(resp, entry)
+	}
+
+	sort.SliceStable(resp, func(i, j int) bool {
+		if resp[i].SystemID != resp[j].SystemID {
+			return resp[i].SystemID < resp[j].SystemID
+		}
+		return resp[i].ID < resp[j].ID
+	})
+
+	return models.LaunchersResponse{Launchers: resp}, nil
+}
 
 func HandleLaunchersRefresh(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use
 	log.Info().Msg("received launchers refresh request")

--- a/pkg/api/methods/launchers_test.go
+++ b/pkg/api/methods/launchers_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	corehelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
@@ -210,4 +211,88 @@ func TestHandleLaunchersRefresh_CustomLaunchersLoadError(t *testing.T) {
 
 	// Cache should not have been refreshed
 	assert.Empty(t, testCache.GetAllLaunchers())
+}
+
+// TestHandleLaunchers_ReturnsCachedLaunchers verifies HandleLaunchers serialises
+// the cached launcher list, sorted by SystemID then ID, with identity-only fields.
+func TestHandleLaunchers_ReturnsCachedLaunchers(t *testing.T) {
+	t.Parallel()
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "snes9x", SystemID: "SNES", Groups: []string{"libretro"}},
+		{ID: "retroarch", SystemID: "Genesis"},
+		{ID: "kodi-tv", SystemID: "TV", Groups: []string{"Kodi", "KodiTV"}},
+	})
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		LauncherCache: cache,
+	}
+
+	result, err := HandleLaunchers(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.LaunchersResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Launchers, 3)
+
+	// Sorted by SystemID asc, then ID asc.
+	assert.Equal(t, "Genesis", resp.Launchers[0].SystemID)
+	assert.Equal(t, "retroarch", resp.Launchers[0].ID)
+	assert.Equal(t, "SNES", resp.Launchers[1].SystemID)
+	assert.Equal(t, "snes9x", resp.Launchers[1].ID)
+	assert.Equal(t, []string{"libretro"}, resp.Launchers[1].Groups)
+	assert.Equal(t, "TV", resp.Launchers[2].SystemID)
+	assert.Equal(t, "kodi-tv", resp.Launchers[2].ID)
+	assert.Equal(t, []string{"Kodi", "KodiTV"}, resp.Launchers[2].Groups)
+}
+
+// TestHandleLaunchers_PopulatesSystemName verifies the handler enriches each
+// launcher with the corresponding system display name from system metadata.
+func TestHandleLaunchers_PopulatesSystemName(t *testing.T) {
+	t.Parallel()
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "retroarch", SystemID: "Genesis"},
+		{ID: "noname", SystemID: ""},
+	})
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		LauncherCache: cache,
+	}
+
+	result, err := HandleLaunchers(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.LaunchersResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Launchers, 2)
+
+	// Empty SystemID launcher: no SystemName resolved.
+	assert.Empty(t, resp.Launchers[0].SystemID)
+	assert.Empty(t, resp.Launchers[0].SystemName)
+
+	// Genesis: name resolved from system metadata.
+	assert.Equal(t, "Genesis", resp.Launchers[1].SystemID)
+	assert.Equal(t, "Genesis", resp.Launchers[1].SystemName)
+}
+
+// TestHandleLaunchers_NilCacheReturnsEmpty verifies a missing launcher cache
+// is handled gracefully rather than panicking.
+func TestHandleLaunchers_NilCacheReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	env := requests.RequestEnv{
+		Context: context.Background(),
+	}
+
+	result, err := HandleLaunchers(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.LaunchersResponse)
+	require.True(t, ok)
+	assert.Empty(t, resp.Launchers)
 }

--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -46,6 +47,16 @@ func HandleSettings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 		})
 	}
 
+	defaultsCfg := env.Config.SystemDefaults()
+	systemDefaults := make([]models.SystemDefault, 0, len(defaultsCfg))
+	for _, sd := range defaultsCfg {
+		systemDefaults = append(systemDefaults, models.SystemDefault{
+			System:     sd.System,
+			Launcher:   sd.Launcher,
+			BeforeExit: sd.BeforeExit,
+		})
+	}
+
 	resp := models.SettingsResponse{
 		UpdateChannel:             env.Config.UpdateChannel(),
 		RunZapScript:              env.State.RunZapScriptEnabled(),
@@ -57,6 +68,7 @@ func HandleSettings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 		ReadersScanExitDelay:      env.Config.ReadersScan().ExitDelay,
 		ReadersScanIgnoreSystem:   make([]string, 0),
 		ReadersConnect:            readersConnect,
+		SystemDefaults:            systemDefaults,
 		ErrorReporting:            env.Config.ErrorReporting(),
 		LaunchGuardEnabled:        env.Config.LaunchGuardEnabled(),
 		LaunchGuardTimeout:        env.Config.LaunchGuardTimeout(),
@@ -111,6 +123,18 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
 		log.Warn().Err(err).Msg("invalid params")
 		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	// Pre-flight validation of inputs that depend on runtime state. Run before
+	// any mutations are applied so a validation failure here does not leave
+	// the in-memory config partially updated.
+	var systemDefaults []config.SystemsDefault
+	if params.SystemDefaults != nil {
+		var err error
+		systemDefaults, err = buildSystemDefaults(env.LauncherCache, *params.SystemDefaults)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Reload config from disk before applying mutations so that external
@@ -213,6 +237,11 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 		env.Config.SetReaderConnections(connections)
 	}
 
+	if params.SystemDefaults != nil {
+		log.Debug().Int("count", len(*params.SystemDefaults)).Msg("updating systems.default")
+		env.Config.SetSystemDefaults(systemDefaults)
+	}
+
 	err := env.Config.Save()
 	if err != nil {
 		return nil, fmt.Errorf("failed to save config: %w", err)
@@ -258,6 +287,49 @@ func HandlePlaytimeLimits(env requests.RequestEnv) (any, error) {
 	}
 
 	return resp, nil
+}
+
+// buildSystemDefaults validates the API system-defaults payload and converts
+// it to config types. The system field is already validated by struct tag;
+// here we additionally check that any non-empty launcher reference matches a
+// known launcher ID or group from the LauncherCache (case-insensitive).
+func buildSystemDefaults(cache *helpers.LauncherCache, in []models.SystemDefault) ([]config.SystemsDefault, error) {
+	out := make([]config.SystemsDefault, 0, len(in))
+	for _, sd := range in {
+		if sd.Launcher != "" {
+			if cache == nil {
+				return nil, errors.New("launcher cache unavailable, cannot validate launcher reference")
+			}
+			if !launcherRefExists(cache, sd.Launcher) {
+				return nil, models.ClientErrf("unknown launcher %q for system %q", sd.Launcher, sd.System)
+			}
+		}
+		out = append(out, config.SystemsDefault{
+			System:     sd.System,
+			Launcher:   sd.Launcher,
+			BeforeExit: sd.BeforeExit,
+		})
+	}
+	return out, nil
+}
+
+// launcherRefExists reports whether ref matches a launcher ID or any of a
+// launcher's Groups (case-insensitive). Mirrors the matching semantics used
+// by config.LookupLauncherDefaults so API validation accepts the same values
+// the launcher resolution code does.
+func launcherRefExists(cache *helpers.LauncherCache, ref string) bool {
+	all := cache.GetAllLaunchers()
+	for i := range all {
+		if strings.EqualFold(all[i].ID, ref) {
+			return true
+		}
+		for _, g := range all[i].Groups {
+			if strings.EqualFold(g, ref) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 //nolint:gocritic // single-use parameter in API handler

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -866,3 +866,308 @@ func TestHandleSettingsReload_RefreshesLauncherCache(t *testing.T) {
 
 	mockPlatform.AssertExpectations(t)
 }
+
+// TestHandleSettings_SystemDefaults verifies the settings response includes
+// configured system default launcher overrides.
+func TestHandleSettings_SystemDefaults(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{
+		Systems: config.Systems{
+			Default: []config.SystemsDefault{
+				{System: "Genesis", Launcher: "retroarch", BeforeExit: "echo bye"},
+				{System: "SNES", Launcher: "snes9x"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+		State:    appState,
+		Params:   []byte(`{}`),
+	}
+
+	result, err := HandleSettings(env)
+	require.NoError(t, err)
+	resp, ok := result.(models.SettingsResponse)
+	require.True(t, ok)
+
+	require.Len(t, resp.SystemDefaults, 2)
+	assert.Equal(t, "Genesis", resp.SystemDefaults[0].System)
+	assert.Equal(t, "retroarch", resp.SystemDefaults[0].Launcher)
+	assert.Equal(t, "echo bye", resp.SystemDefaults[0].BeforeExit)
+	assert.Equal(t, "SNES", resp.SystemDefaults[1].System)
+	assert.Equal(t, "snes9x", resp.SystemDefaults[1].Launcher)
+	assert.Empty(t, resp.SystemDefaults[1].BeforeExit)
+}
+
+// TestHandleSettingsUpdate_SystemDefaults verifies an update replaces the
+// configured system defaults when the launcher reference is known.
+func TestHandleSettingsUpdate_SystemDefaults(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "retroarch", SystemID: "Genesis", Groups: []string{"libretro"}},
+		{ID: "snes9x", SystemID: "SNES"},
+	})
+
+	params := models.UpdateSettingsParams{
+		SystemDefaults: &[]models.SystemDefault{
+			{System: "Genesis", Launcher: "retroarch", BeforeExit: "echo bye"},
+			{System: "SNES", Launcher: "snes9x"},
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      mockPlatform,
+		Config:        cfg,
+		State:         appState,
+		LauncherCache: cache,
+		Params:        paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 2)
+	assert.Equal(t, "Genesis", got[0].System)
+	assert.Equal(t, "retroarch", got[0].Launcher)
+	assert.Equal(t, "echo bye", got[0].BeforeExit)
+	assert.Equal(t, "SNES", got[1].System)
+	assert.Equal(t, "snes9x", got[1].Launcher)
+}
+
+// TestHandleSettingsUpdate_SystemDefaults_AcceptsGroup verifies a launcher
+// group name is accepted as a launcher reference, mirroring config lookup.
+func TestHandleSettingsUpdate_SystemDefaults_AcceptsGroup(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "kodi-snes", SystemID: "SNES", Groups: []string{"Kodi", "KodiTV"}},
+	})
+
+	params := models.UpdateSettingsParams{
+		SystemDefaults: &[]models.SystemDefault{
+			{System: "SNES", Launcher: "kodi"}, // matches group, case-insensitive
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      mockPlatform,
+		Config:        cfg,
+		State:         appState,
+		LauncherCache: cache,
+		Params:        paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 1)
+	assert.Equal(t, "kodi", got[0].Launcher)
+}
+
+// TestHandleSettingsUpdate_SystemDefaults_RejectsUnknownLauncher verifies the
+// handler rejects a payload referencing a launcher that doesn't exist.
+func TestHandleSettingsUpdate_SystemDefaults_RejectsUnknownLauncher(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{
+		Systems: config.Systems{
+			Default: []config.SystemsDefault{
+				{System: "Genesis", Launcher: "retroarch"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "retroarch", SystemID: "Genesis"},
+	})
+
+	params := models.UpdateSettingsParams{
+		SystemDefaults: &[]models.SystemDefault{
+			{System: "SNES", Launcher: "doesnotexist"},
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      mockPlatform,
+		Config:        cfg,
+		State:         appState,
+		LauncherCache: cache,
+		Params:        paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "doesnotexist")
+
+	// Pre-existing config should not have been replaced.
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 1)
+	assert.Equal(t, "Genesis", got[0].System)
+	assert.Equal(t, "retroarch", got[0].Launcher)
+	assert.Empty(t, got[0].BeforeExit)
+}
+
+// TestHandleSettingsUpdate_SystemDefaults_RejectsUnknownSystem verifies the
+// validate:"required,system" tag rejects payloads with an unknown system.
+func TestHandleSettingsUpdate_SystemDefaults_RejectsUnknownSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{
+		Systems: config.Systems{
+			Default: []config.SystemsDefault{
+				{System: "Genesis", Launcher: "retroarch"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "retroarch", SystemID: "Genesis"},
+	})
+
+	tests := []struct {
+		name   string
+		system string
+	}{
+		{name: "empty system rejected by required", system: ""},
+		{name: "unknown system rejected by system validator", system: "NotARealSystem"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			params := models.UpdateSettingsParams{
+				SystemDefaults: &[]models.SystemDefault{
+					{System: tt.system, Launcher: "retroarch"},
+				},
+			}
+			paramsJSON, err := json.Marshal(params)
+			require.NoError(t, err)
+
+			env := requests.RequestEnv{
+				Context:       context.Background(),
+				Platform:      mockPlatform,
+				Config:        cfg,
+				State:         appState,
+				LauncherCache: cache,
+				Params:        paramsJSON,
+			}
+
+			_, err = HandleSettingsUpdate(env)
+			require.Error(t, err)
+
+			// Pre-existing config should not have been replaced.
+			got := cfg.SystemDefaults()
+			require.Len(t, got, 1)
+			assert.Equal(t, "Genesis", got[0].System)
+		})
+	}
+}
+
+// TestHandleSettingsUpdate_SystemDefaults_AllowsEmptyLauncher verifies an
+// entry with no launcher (only before_exit) is accepted.
+func TestHandleSettingsUpdate_SystemDefaults_AllowsEmptyLauncher(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+
+	tmpDir := t.TempDir()
+	cfg, err := config.NewConfig(tmpDir, config.Values{})
+	require.NoError(t, err)
+
+	appState, ns := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() { drainCh(ns) })
+
+	cache := &corehelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{})
+
+	params := models.UpdateSettingsParams{
+		SystemDefaults: &[]models.SystemDefault{
+			{System: "Genesis", BeforeExit: "echo bye"},
+		},
+	}
+	paramsJSON, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      mockPlatform,
+		Config:        cfg,
+		State:         appState,
+		LauncherCache: cache,
+		Params:        paramsJSON,
+	}
+
+	_, err = HandleSettingsUpdate(env)
+	require.NoError(t, err)
+
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 1)
+	assert.Empty(t, got[0].Launcher)
+	assert.Equal(t, "echo bye", got[0].BeforeExit)
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -88,6 +88,7 @@ const (
 	MethodClientsPairStart     = "clients.pair.start"
 	MethodClientsPairCancel    = "clients.pair.cancel"
 	MethodSystems              = "systems"
+	MethodLaunchers            = "launchers"
 	MethodLaunchersRefresh     = "launchers.refresh"
 	MethodHistory              = "tokens.history"
 	MethodMappings             = "mappings"

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -101,16 +101,16 @@ type ReaderConnection struct {
 	IDSource string `json:"idSource,omitempty"`
 }
 
-// IsEnabled returns whether this connection is enabled.
-// nil (omitted) and true both mean enabled; only explicit false disables.
-func (r ReaderConnection) IsEnabled() bool {
-	return r.Enabled == nil || *r.Enabled
-}
-
 type SystemDefault struct {
 	System     string `json:"system" validate:"required,system"`
 	Launcher   string `json:"launcher,omitempty"`
 	BeforeExit string `json:"beforeExit,omitempty"`
+}
+
+// IsEnabled returns whether this connection is enabled.
+// nil (omitted) and true both mean enabled; only explicit false disables.
+func (r ReaderConnection) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 type UpdateSettingsParams struct {

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -107,6 +107,12 @@ func (r ReaderConnection) IsEnabled() bool {
 	return r.Enabled == nil || *r.Enabled
 }
 
+type SystemDefault struct {
+	System     string `json:"system" validate:"required,system"`
+	Launcher   string `json:"launcher,omitempty"`
+	BeforeExit string `json:"beforeExit,omitempty"`
+}
+
 type UpdateSettingsParams struct {
 	RunZapScript              *bool               `json:"runZapScript"`
 	DebugLogging              *bool               `json:"debugLogging"`
@@ -118,6 +124,7 @@ type UpdateSettingsParams struct {
 	ReadersScanExitDelay      *float32            `json:"readersScanExitDelay" validate:"omitempty,gte=0"`
 	ReadersScanIgnoreSystem   *[]string           `json:"readersScanIgnoreSystems" validate:"omitempty,dive,system"`
 	ReadersConnect            *[]ReaderConnection `json:"readersConnect,omitempty"`
+	SystemDefaults            *[]SystemDefault    `json:"systemDefaults,omitempty" validate:"omitempty,dive"`
 	AudioVolume               *int                `json:"audioVolume" validate:"omitempty,gte=0,lte=200"`
 	LaunchGuardEnabled        *bool               `json:"launchGuardEnabled"`
 	LaunchGuardTimeout        *float32            `json:"launchGuardTimeout" validate:"omitempty,gte=-1"`

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -80,6 +80,7 @@ type SettingsResponse struct {
 	ReadersScanMode           string             `json:"readersScanMode"`
 	ReadersScanIgnoreSystem   []string           `json:"readersScanIgnoreSystems"`
 	ReadersConnect            []ReaderConnection `json:"readersConnect"`
+	SystemDefaults            []SystemDefault    `json:"systemDefaults"`
 	ReadersScanExitDelay      float32            `json:"readersScanExitDelay"`
 	LaunchGuardTimeout        float32            `json:"launchGuardTimeout"`
 	LaunchGuardDelay          float32            `json:"launchGuardDelay"`
@@ -449,6 +450,17 @@ type LogDownloadResponse struct {
 	Filename string `json:"filename"`
 	Content  string `json:"content"`
 	Size     int    `json:"size"`
+}
+
+type Launcher struct {
+	ID         string   `json:"id"`
+	SystemID   string   `json:"systemId,omitempty"`
+	SystemName string   `json:"systemName,omitempty"`
+	Groups     []string `json:"groups,omitempty"`
+}
+
+type LaunchersResponse struct {
+	Launchers []Launcher `json:"launchers"`
 }
 
 type ReaderInfo struct {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -273,6 +273,7 @@ func NewMethodMap() *MethodMap {
 		// systems
 		models.MethodSystems: methods.HandleSystems,
 		// launchers
+		models.MethodLaunchers:        methods.HandleLaunchers,
 		models.MethodLaunchersRefresh: methods.HandleLaunchersRefresh,
 		// mappings
 		models.MethodMappings:       methods.HandleMappings,

--- a/pkg/config/configsystems.go
+++ b/pkg/config/configsystems.go
@@ -44,7 +44,9 @@ func (c *Instance) SystemDefaults() []SystemsDefault {
 func (c *Instance) SetSystemDefaults(defaults []SystemsDefault) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.vals.Systems.Default = defaults
+	owned := make([]SystemsDefault, len(defaults))
+	copy(owned, defaults)
+	c.vals.Systems.Default = owned
 }
 
 func (c *Instance) LookupSystemDefaults(systemID string) (SystemsDefault, bool) {

--- a/pkg/config/configsystems.go
+++ b/pkg/config/configsystems.go
@@ -41,6 +41,12 @@ func (c *Instance) SystemDefaults() []SystemsDefault {
 	return c.vals.Systems.Default
 }
 
+func (c *Instance) SetSystemDefaults(defaults []SystemsDefault) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Systems.Default = defaults
+}
+
 func (c *Instance) LookupSystemDefaults(systemID string) (SystemsDefault, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/config/configsystems_test.go
+++ b/pkg/config/configsystems_test.go
@@ -22,7 +22,9 @@ package config
 import (
 	"testing"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLookupSystemDefaultsFuzzyMatching(t *testing.T) {
@@ -184,4 +186,83 @@ func TestLookupSystemDefaultsReturnsCorrectFields(t *testing.T) {
 	assert.Equal(t, "SMS", result.System) // Original config value preserved
 	assert.Equal(t, "retroarch", result.Launcher)
 	assert.Equal(t, "echo 'goodbye'", result.BeforeExit)
+}
+
+func TestSetSystemDefaultsReplacesAllEntries(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{System: "Genesis", Launcher: "retroarch"},
+				},
+			},
+		},
+	}
+
+	cfg.SetSystemDefaults([]SystemsDefault{
+		{System: "SNES", Launcher: "snes9x", BeforeExit: "echo bye"},
+		{System: "N64", Launcher: "mupen64plus"},
+	})
+
+	got := cfg.SystemDefaults()
+	assert.Len(t, got, 2)
+	assert.Equal(t, "SNES", got[0].System)
+	assert.Equal(t, "snes9x", got[0].Launcher)
+	assert.Equal(t, "echo bye", got[0].BeforeExit)
+	assert.Equal(t, "N64", got[1].System)
+	assert.Equal(t, "mupen64plus", got[1].Launcher)
+}
+
+func TestSetSystemDefaultsClearsList(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Systems: Systems{
+				Default: []SystemsDefault{
+					{System: "Genesis", Launcher: "retroarch"},
+				},
+			},
+		},
+	}
+
+	cfg.SetSystemDefaults([]SystemsDefault{})
+	assert.Empty(t, cfg.SystemDefaults())
+}
+
+func TestSystemDefaults_SaveLoadRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	memFs := afero.NewMemMapFs()
+	cfg, err := NewConfigWithFs("/config", BaseDefaults, memFs)
+	require.NoError(t, err)
+
+	cfg.SetSystemDefaults([]SystemsDefault{
+		{System: "Genesis", Launcher: "retroarch"},
+		{System: "SNES", Launcher: "snes9x", BeforeExit: "echo bye"},
+		{System: "N64"},
+	})
+
+	err = cfg.Save()
+	require.NoError(t, err)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	got := cfg.SystemDefaults()
+	require.Len(t, got, 3)
+
+	assert.Equal(t, "Genesis", got[0].System)
+	assert.Equal(t, "retroarch", got[0].Launcher)
+	assert.Empty(t, got[0].BeforeExit)
+
+	assert.Equal(t, "SNES", got[1].System)
+	assert.Equal(t, "snes9x", got[1].Launcher)
+	assert.Equal(t, "echo bye", got[1].BeforeExit)
+
+	assert.Equal(t, "N64", got[2].System)
+	assert.Empty(t, got[2].Launcher)
+	assert.Empty(t, got[2].BeforeExit)
 }


### PR DESCRIPTION
## Summary

- Adds JSON-RPC method `launchers` returning the cached launcher list (id, systemId, systemName, groups) so a UI can populate a per-system launcher picker.
- Adds `systemDefaults` to `settings` and `settings.update`, exposing the existing `[[systems.default]]` config (system, launcher, before_exit) over the API.
- Validates each entry's launcher reference against the launcher cache (case-insensitive ID or group match) in a pre-flight pass, so a rejected payload cannot leave the in-memory config half-updated.

Mutations to `systemDefaults` take effect immediately — `applySystemDefaultLauncher` and `runBeforeExitHook` read live config at the moment of use; no restart or `launchers.refresh` needed.

API docs (`docs/api/methods.md`, `docs/api/index.md`) updated to describe the new method, the new field, and the `SystemDefault` and `Launcher` object shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "launchers" API method to list cached launchers with system and group info.
  * Added system defaults in settings to support per-system overrides for launcher selection and before-exit behavior; settings updates now validate launcher references.

* **Documentation**
  * Updated API docs to include the new method and system defaults schemas.

* **Tests**
  * Added tests covering launcher listing, sorting/enrichment, and system defaults read/update validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->