### PR TITLE
feat(mister): add VirtualBoy launcher

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -933,6 +933,20 @@ var Systems = map[string]Core{
 			// },
 		},
 	},
+	"VirtualBoy": {
+		ID:  "VirtualBoy",
+		RBF: "_Console/VirtualBoy",
+		Slots: []Slot{
+			{
+				Exts: []string{".vb"},
+				Mgl: &MGLParams{
+					Delay:  1,
+					Method: "f",
+					Index:  1,
+				},
+			},
+		},
+	},
 	"WonderSwan": {
 		ID:  "WonderSwan",
 		RBF: "_Console/WonderSwan",

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -1170,6 +1170,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemVectrex),
 		},
 		{
+			ID:         systemdefs.SystemVirtualBoy,
+			SystemID:   systemdefs.SystemVirtualBoy,
+			Folders:    []string{"VirtualBoy"},
+			Extensions: []string{".vb"},
+			Launch:     launch(pl, systemdefs.SystemVirtualBoy),
+		},
+		{
 			ID:         systemdefs.SystemWonderSwan,
 			SystemID:   systemdefs.SystemWonderSwan,
 			Folders:    []string{"WonderSwan"},


### PR DESCRIPTION
## Summary

- Adds a `VirtualBoy` core entry to `pkg/platforms/mister/cores/cores.go` (RBF `_Console/VirtualBoy`, extension `.vb`, MGL `delay=1 type=f index=1`).
- Registers the launcher in `pkg/platforms/mister/launchers.go` (folder `VirtualBoy`, extension `.vb`).

Values match the working MGL posted in #769. MiSTeX picks this up automatically via `mister.CreateLaunchers`.

Closes #769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Virtual Boy system support, enabling playback of .vb game files on MiSTer platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->