### PR TITLE
fix(mediascanner): use scanner-provided display names as title

### DIFF
--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -233,6 +233,7 @@ func addTestMediaPaths(t *testing.T, mediaDB database.MediaDBI, paths ...string)
 			state,
 			"NES",
 			path,
+			"",
 			false,
 			false,
 			nil,

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -117,7 +117,11 @@ func logSafeRequest(req *models.RequestObject) {
 	log.Debug().Str("method", req.Method).Interface("id", req.ID).Msg("received request")
 }
 
-// logSafeResponse logs a response but truncates large content to prevent recursive logging issues
+// logSafeResponse logs a response but redacts large or binary fields. Any
+// response shape that can carry base64-encoded media (image blobs, meta
+// property data, screenshots, log dumps) MUST be matched explicitly here —
+// the default case omits the result body entirely so a forgotten type
+// cannot accidentally dump megabytes of base64 into the debug log.
 func logSafeResponse(result any) {
 	switch resp := result.(type) {
 	case models.LogDownloadResponse:
@@ -140,6 +144,10 @@ func logSafeResponse(result any) {
 			Str("contentType", resp.ContentType).
 			Int("data_len", len(resp.Data)).
 			Msg("sending response")
+	case models.MediaImageBatchResponse:
+		log.Debug().
+			Int("items", len(resp.Items)).
+			Msg("sending response: media.image batch")
 	case models.MediaMetaResponse:
 		log.Debug().
 			Str("system", resp.Media.Title.System.ID).
@@ -147,8 +155,12 @@ func logSafeResponse(result any) {
 			Int("media_properties", len(resp.Media.Properties)).
 			Int("title_properties", len(resp.Media.Title.Properties)).
 			Msg("sending response")
+	case models.MediaMetaBatchResponse:
+		log.Debug().
+			Int("items", len(resp.Items)).
+			Msg("sending response: media.meta batch")
 	default:
-		log.Debug().Interface("result", result).Msg("sending response")
+		log.Debug().Str("type", fmt.Sprintf("%T", result)).Msg("sending response")
 	}
 }
 
@@ -444,7 +456,14 @@ func logWSWriteError(err error, msg string) {
 }
 
 func handleResponse(resp models.ResponseObject) error {
-	log.Debug().Interface("response", resp).Msg("received response")
+	// Avoid logging resp.Result — inbound responses can carry base64 media
+	// blobs (e.g. media.image, media.meta property data) and dumping the
+	// whole map would flood the debug log.
+	ev := log.Debug().Interface("id", resp.ID)
+	if resp.Error != nil {
+		ev = ev.Int("errorCode", resp.Error.Code).Str("errorMessage", resp.Error.Message)
+	}
+	ev.Msg("received response")
 	return nil
 }
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -458,10 +458,20 @@ func logWSWriteError(err error, msg string) {
 func handleResponse(resp models.ResponseObject) error {
 	// Avoid logging resp.Result — inbound responses can carry base64 media
 	// blobs (e.g. media.image, media.meta property data) and dumping the
-	// whole map would flood the debug log.
+	// whole map would flood the debug log. Error messages cross the same
+	// 4 MB WS boundary, so cap them too.
+	const maxErrorMessageLen = 200
 	ev := log.Debug().Interface("id", resp.ID)
 	if resp.Error != nil {
-		ev = ev.Int("errorCode", resp.Error.Code).Str("errorMessage", resp.Error.Message)
+		ev = ev.Int("errorCode", resp.Error.Code)
+		msg := resp.Error.Message
+		if len(msg) > maxErrorMessageLen {
+			ev = ev.Str("errorMessage", msg[:maxErrorMessageLen]).
+				Bool("errorMessageTruncated", true).
+				Int("errorMessageLen", len(msg))
+		} else {
+			ev = ev.Str("errorMessage", msg)
+		}
 	}
 	ev.Msg("received response")
 	return nil

--- a/pkg/api/server_logging_test.go
+++ b/pkg/api/server_logging_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLogSafeResponse(t *testing.T) {
@@ -94,6 +95,194 @@ func TestLogSafeResponse(t *testing.T) {
 
 			// Should always contain the debug message
 			assert.Contains(t, logOutput, "sending response")
+		})
+	}
+}
+
+// TestLogSafeResponse_BatchRedaction verifies the new batch-response branches
+// log only an item count and never include the per-item base64 blob.
+func TestLogSafeResponse_BatchRedaction(t *testing.T) {
+	const secretBlob = "AAAABASE64SECRETPAYLOAD=="
+
+	imageItem := models.MediaImageResponse{
+		TypeTag:     "property:image-boxart",
+		ContentType: "image/png",
+		Data:        secretBlob,
+	}
+	textValue := "ignored"
+	dataValue := secretBlob
+	metaProp := models.MediaMetaPropertyItem{
+		Data:        &dataValue,
+		Text:        textValue,
+		ContentType: "image/png",
+	}
+	metaItem := models.MediaMetaMediaResponse{
+		Path: "/roms/snes/game.sfc",
+		Properties: map[string]models.MediaMetaPropertyItem{
+			"image-boxart": metaProp,
+		},
+	}
+
+	tests := []struct {
+		result         any
+		name           string
+		expectMsgFrag  string
+		expectKeyFrag  string
+		expectItemsVal string
+	}{
+		{
+			name: "MediaImageBatchResponse logs items count only",
+			result: models.MediaImageBatchResponse{
+				Items: []models.MediaImageBatchItemResponse{
+					{Image: &imageItem},
+					{Image: &imageItem},
+				},
+			},
+			expectMsgFrag:  "media.image batch",
+			expectKeyFrag:  `"items":2`,
+			expectItemsVal: "2",
+		},
+		{
+			name: "MediaMetaBatchResponse logs items count only",
+			result: models.MediaMetaBatchResponse{
+				Items: []models.MediaMetaBatchItemResponse{
+					{Media: &metaItem},
+				},
+			},
+			expectMsgFrag:  "media.meta batch",
+			expectKeyFrag:  `"items":1`,
+			expectItemsVal: "1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			originalLogger := log.Logger
+			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+			defer func() { log.Logger = originalLogger }()
+
+			logSafeResponse(tt.result)
+
+			out := buf.String()
+			assert.Contains(t, out, tt.expectMsgFrag)
+			assert.Contains(t, out, tt.expectKeyFrag)
+			// The base64 payload from any per-item field must never reach the log.
+			assert.NotContains(t, out, secretBlob, "batch redaction must not leak per-item payload")
+		})
+	}
+}
+
+// TestLogSafeResponse_DefaultOmitsBody verifies the default case logs only
+// the result type and never serializes unknown response bodies, so a forgotten
+// future response shape cannot leak base64 blobs.
+func TestLogSafeResponse_DefaultOmitsBody(t *testing.T) {
+	type secretShape struct {
+		Marker string `json:"marker"`
+		Blob   string `json:"blob"`
+	}
+
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = originalLogger }()
+
+	logSafeResponse(secretShape{Marker: "should-not-appear", Blob: "AAAABASE64=="})
+
+	out := buf.String()
+	assert.Contains(t, out, "sending response")
+	assert.Contains(t, out, "secretShape", "default case must include the type name")
+	assert.NotContains(t, out, "should-not-appear", "default case must omit body")
+	assert.NotContains(t, out, "AAAABASE64==", "default case must omit body")
+}
+
+// TestHandleResponse covers inbound-response logging: that resp.Result is
+// never serialized, that the error block is included only when present, and
+// that long error messages are truncated with metadata indicating it.
+func TestHandleResponse(t *testing.T) {
+	const longMsg = "x"
+	tests := []struct {
+		name              string
+		resp              models.ResponseObject
+		mustNotContain    []string
+		mustContain       []string
+		expectTruncatedOn bool
+	}{
+		{
+			name: "result is never logged",
+			resp: models.ResponseObject{
+				JSONRPC: "2.0",
+				ID:      models.NewStringID("req-1"),
+				Result:  map[string]any{"data": "AAAABASE64BLOB==", "secret": "hush"},
+			},
+			mustContain:    []string{"received response", "req-1"},
+			mustNotContain: []string{"AAAABASE64BLOB==", "hush"},
+		},
+		{
+			name: "no error means no error fields",
+			resp: models.ResponseObject{
+				JSONRPC: "2.0",
+				ID:      models.NewStringID("req-2"),
+			},
+			mustContain:    []string{"received response", "req-2"},
+			mustNotContain: []string{"errorCode", "errorMessage"},
+		},
+		{
+			name: "short error message is logged in full",
+			resp: models.ResponseObject{
+				JSONRPC: "2.0",
+				ID:      models.NewStringID("req-3"),
+				Error: &models.ErrorObject{
+					Code:    -32600,
+					Message: "invalid request",
+				},
+			},
+			mustContain: []string{
+				"errorCode", "-32600",
+				"errorMessage", "invalid request",
+			},
+			mustNotContain: []string{"errorMessageTruncated", "errorMessageLen"},
+		},
+		{
+			name: "long error message is truncated",
+			resp: models.ResponseObject{
+				JSONRPC: "2.0",
+				ID:      models.NewStringID("req-4"),
+				Error: &models.ErrorObject{
+					Code:    -32000,
+					Message: strings.Repeat(longMsg, 5000),
+				},
+			},
+			mustContain: []string{
+				"errorCode",
+				"errorMessageTruncated",
+				"errorMessageLen",
+			},
+			expectTruncatedOn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			originalLogger := log.Logger
+			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+			defer func() { log.Logger = originalLogger }()
+
+			require.NoError(t, handleResponse(tt.resp))
+
+			out := buf.String()
+			for _, s := range tt.mustContain {
+				assert.Contains(t, out, s)
+			}
+			for _, s := range tt.mustNotContain {
+				assert.NotContains(t, out, s)
+			}
+			if tt.expectTruncatedOn {
+				// Truncated body must not contain the full repeated payload.
+				assert.NotContains(t, out, strings.Repeat(longMsg, 5000))
+				assert.Contains(t, out, `"errorMessageTruncated":true`)
+			}
 		})
 	}
 }

--- a/pkg/database/mediascanner/batch_resume_test.go
+++ b/pkg/database/mediascanner/batch_resume_test.go
@@ -113,7 +113,7 @@ func TestBatchModeResumeIndexing(t *testing.T) {
 			entries := batch.Entries[systemID]
 			for _, entry := range entries {
 				titleIndex, mediaIndex, addErr := AddMediaPath(
-					mediaDB, scanState, systemID, entry.Path, false, false, nil, "",
+					mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "",
 				)
 				require.NoError(t, addErr)
 				assert.Positive(t, titleIndex, "Title index should be > 0")
@@ -170,7 +170,7 @@ func TestBatchModeResumeIndexing(t *testing.T) {
 		newEntries := testdata.CreateReproducibleBatch([]string{"Genesis"}, 2)
 		for _, entry := range newEntries.Entries["Genesis"] {
 			titleIndex, mediaIndex, addErr := AddMediaPath(
-				mediaDB, resumeState, "Genesis", entry.Path, false, false, nil, "",
+				mediaDB, resumeState, "Genesis", entry.Path, "", false, false, nil, "",
 			)
 			require.NoError(t, addErr)
 
@@ -233,7 +233,7 @@ func TestBatchModeResumeIndexing(t *testing.T) {
 		// This should NOT create duplicates thanks to scanState maps
 		nesEntries := batch.Entries["NES"]
 		for _, entry := range nesEntries {
-			_, _, addErr := AddMediaPath(mediaDB, reindexState, "NES", entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(mediaDB, reindexState, "NES", entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr, "Re-indexing should not fail")
 		}
 
@@ -325,7 +325,7 @@ func TestBatchModeSelectiveIndexing(t *testing.T) {
 		for _, systemID := range testSystems {
 			entries := batch.Entries[systemID]
 			for _, entry := range entries {
-				_, _, addErr := AddMediaPath(mediaDB, scanState, systemID, entry.Path, false, false, nil, "")
+				_, _, addErr := AddMediaPath(mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "")
 				require.NoError(t, addErr)
 			}
 		}
@@ -408,7 +408,7 @@ func TestBatchModeSelectiveIndexing(t *testing.T) {
 		nesEntries := batch.Entries["NES"]
 		for _, entry := range nesEntries {
 			titleIndex, mediaIndex, addErr := AddMediaPath(
-				mediaDB, selectiveState, "NES", entry.Path, false, false, nil, "",
+				mediaDB, selectiveState, "NES", entry.Path, "", false, false, nil, "",
 			)
 			require.NoError(t, addErr)
 
@@ -519,10 +519,10 @@ func TestBatchMode_DuplicateDetection(t *testing.T) {
 
 		// Add same file twice
 		testPath := "/roms/nes/game1.nes"
-		title1, media1, addErr1 := AddMediaPath(mediaDB, scanState, "NES", testPath, false, false, nil, "")
+		title1, media1, addErr1 := AddMediaPath(mediaDB, scanState, "NES", testPath, "", false, false, nil, "")
 		require.NoError(t, addErr1)
 
-		title2, media2, addErr2 := AddMediaPath(mediaDB, scanState, "NES", testPath, false, false, nil, "")
+		title2, media2, addErr2 := AddMediaPath(mediaDB, scanState, "NES", testPath, "", false, false, nil, "")
 		require.NoError(t, addErr2)
 
 		// Second attempt should return same IDs (no duplicate insert)
@@ -570,7 +570,7 @@ func TestBatchMode_DuplicateDetection(t *testing.T) {
 
 		// Try to add the same file again (it's in the database and scanState)
 		testPath := "/roms/nes/game1.nes"
-		_, media, err := AddMediaPath(mediaDB, scanState, "NES", testPath, false, false, nil, "")
+		_, media, err := AddMediaPath(mediaDB, scanState, "NES", testPath, "", false, false, nil, "")
 		require.NoError(t, err)
 
 		// Should not create a new entry
@@ -639,7 +639,7 @@ func TestResumeTruncatesPartialSystem(t *testing.T) {
 	}
 	require.NoError(t, mediaDB.BeginTransaction(true))
 	for _, entry := range allEntries[:partialFiles] {
-		_, _, addErr := AddMediaPath(mediaDB, firstRunState, systemID, entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(mediaDB, firstRunState, systemID, entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr, "first partial index should succeed")
 	}
 	require.NoError(t, mediaDB.CommitTransaction())
@@ -693,7 +693,7 @@ func TestResumeTruncatesPartialSystem(t *testing.T) {
 	// Re-index all files from scratch — must not produce UNIQUE violations.
 	require.NoError(t, mediaDB.BeginTransaction(true))
 	for _, entry := range allEntries {
-		_, _, addErr := AddMediaPath(mediaDB, resumeState, systemID, entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(mediaDB, resumeState, systemID, entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr, "resume re-index must not fail with UNIQUE constraint")
 	}
 	require.NoError(t, mediaDB.CommitTransaction())

--- a/pkg/database/mediascanner/filename_tags_config_test.go
+++ b/pkg/database/mediascanner/filename_tags_config_test.go
@@ -43,7 +43,7 @@ func TestGetPathFragments_FilenameTagsConfig(t *testing.T) {
 	testPath := "/games/nes/Super Mario Bros (USA, Europe) (Rev 1).nes"
 
 	// Test with filename tags enabled
-	fragmentsEnabled := GetPathFragments(PathFragmentParams{
+	fragmentsEnabled := GetPathFragments(&PathFragmentParams{
 		Config:              cfgEnabled,
 		Path:                testPath,
 		NoExt:               false,
@@ -58,7 +58,7 @@ func TestGetPathFragments_FilenameTagsConfig(t *testing.T) {
 	require.Contains(t, fragmentsEnabled.Tags, "lang:en", "English language tag should be extracted")
 
 	// Test with filename tags disabled
-	fragmentsDisabled := GetPathFragments(PathFragmentParams{
+	fragmentsDisabled := GetPathFragments(&PathFragmentParams{
 		Config:              cfgDisabled,
 		Path:                testPath,
 		NoExt:               false,
@@ -68,7 +68,7 @@ func TestGetPathFragments_FilenameTagsConfig(t *testing.T) {
 	require.Empty(t, fragmentsDisabled.Tags, "filename tags should not be extracted when disabled")
 
 	// Test with nil config (should behave as enabled for backward compatibility)
-	fragmentsNil := GetPathFragments(PathFragmentParams{
+	fragmentsNil := GetPathFragments(&PathFragmentParams{
 		Config:              nil,
 		Path:                testPath,
 		NoExt:               false,
@@ -94,7 +94,7 @@ func TestGetPathFragments_CacheKeyWithConfig(t *testing.T) {
 	testPath := "/games/nes/Super Mario Bros (USA).nes"
 
 	// Get fragments with enabled config
-	fragments1 := GetPathFragments(PathFragmentParams{
+	fragments1 := GetPathFragments(&PathFragmentParams{
 		Config:              cfgEnabled,
 		Path:                testPath,
 		NoExt:               false,
@@ -104,7 +104,7 @@ func TestGetPathFragments_CacheKeyWithConfig(t *testing.T) {
 	require.NotEmpty(t, fragments1.Tags, "should have tags when enabled")
 
 	// Get fragments with disabled config - should return different result
-	fragments2 := GetPathFragments(PathFragmentParams{
+	fragments2 := GetPathFragments(&PathFragmentParams{
 		Config:              cfgDisabled,
 		Path:                testPath,
 		NoExt:               false,
@@ -114,14 +114,14 @@ func TestGetPathFragments_CacheKeyWithConfig(t *testing.T) {
 	require.Empty(t, fragments2.Tags, "should have no tags when disabled")
 
 	// Verify cache works correctly by calling again with same configs
-	fragments1Again := GetPathFragments(PathFragmentParams{
+	fragments1Again := GetPathFragments(&PathFragmentParams{
 		Config:              cfgEnabled,
 		Path:                testPath,
 		NoExt:               false,
 		StripLeadingNumbers: false,
 		SystemID:            "",
 	})
-	fragments2Again := GetPathFragments(PathFragmentParams{
+	fragments2Again := GetPathFragments(&PathFragmentParams{
 		Config:              cfgDisabled,
 		Path:                testPath,
 		NoExt:               false,

--- a/pkg/database/mediascanner/id_continuity_test.go
+++ b/pkg/database/mediascanner/id_continuity_test.go
@@ -82,7 +82,7 @@ func TestIDContinuityAfterResume(t *testing.T) {
 			for range 3 { // 3 games per system
 				entry := generator.GenerateMediaEntry(systemID)
 				titleIndex, mediaIndex, _ := AddMediaPath(
-					mediaDB, scanState, systemID, entry.Path, false, false, nil, "",
+					mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "",
 				)
 				assert.Positive(t, titleIndex, "Title index should be positive")
 				assert.Positive(t, mediaIndex, "Media index should be positive")
@@ -143,7 +143,7 @@ func TestIDContinuityAfterResume(t *testing.T) {
 		for i := range 2 { // 2 games for Genesis
 			entry := generator.GenerateMediaEntry("Genesis")
 			titleIndex, mediaIndex, _ := AddMediaPath(
-				mediaDB, resumeState, "Genesis", entry.Path, false, false, nil, "",
+				mediaDB, resumeState, "Genesis", entry.Path, "", false, false, nil, "",
 			)
 
 			// These are the critical assertions - IDs must continue from where Phase 1 left off
@@ -159,7 +159,9 @@ func TestIDContinuityAfterResume(t *testing.T) {
 		// Add more games to existing system (NES)
 		for i := range 2 { // 2 more NES games
 			entry := generator.GenerateMediaEntry("NES")
-			titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, resumeState, "NES", entry.Path, false, false, nil, "")
+			titleIndex, mediaIndex, _ := AddMediaPath(
+				mediaDB, resumeState, "NES", entry.Path, "", false, false, nil, "",
+			)
 
 			// These should continue the sequence
 			// +2 for Genesis games, +i for this loop, +1 for next ID
@@ -234,12 +236,12 @@ func TestIDContinuityWithGaps(t *testing.T) {
 
 		// Create a few entries normally to establish the schema
 		entry1 := generator.GenerateMediaEntry("NES")
-		titleIndex1, mediaIndex1, _ := AddMediaPath(mediaDB, scanState, "NES", entry1.Path, false, false, nil, "")
+		titleIndex1, mediaIndex1, _ := AddMediaPath(mediaDB, scanState, "NES", entry1.Path, "", false, false, nil, "")
 		assert.Positive(t, titleIndex1)
 		assert.Positive(t, mediaIndex1)
 
 		entry2 := generator.GenerateMediaEntry("SNES")
-		titleIndex2, mediaIndex2, _ := AddMediaPath(mediaDB, scanState, "SNES", entry2.Path, false, false, nil, "")
+		titleIndex2, mediaIndex2, _ := AddMediaPath(mediaDB, scanState, "SNES", entry2.Path, "", false, false, nil, "")
 		assert.Positive(t, titleIndex2)
 		assert.Positive(t, mediaIndex2)
 
@@ -255,12 +257,16 @@ func TestIDContinuityWithGaps(t *testing.T) {
 		require.NoError(t, err)
 
 		entry3 := generator.GenerateMediaEntry("Genesis")
-		titleIndex3, mediaIndex3, _ := AddMediaPath(mediaDB, scanState, "Genesis", entry3.Path, false, false, nil, "")
+		titleIndex3, mediaIndex3, _ := AddMediaPath(
+			mediaDB, scanState, "Genesis", entry3.Path, "", false, false, nil, "",
+		)
 		assert.Positive(t, titleIndex3)
 		assert.Positive(t, mediaIndex3)
 
 		entry4 := generator.GenerateMediaEntry("GameBoy")
-		titleIndex4, mediaIndex4, _ := AddMediaPath(mediaDB, scanState, "GameBoy", entry4.Path, false, false, nil, "")
+		titleIndex4, mediaIndex4, _ := AddMediaPath(
+			mediaDB, scanState, "GameBoy", entry4.Path, "", false, false, nil, "",
+		)
 		assert.Positive(t, titleIndex4)
 		assert.Positive(t, mediaIndex4)
 
@@ -323,7 +329,7 @@ func TestIDContinuityWithGaps(t *testing.T) {
 		generator := testdata.NewTestDataGenerator(3000)
 		entry := generator.GenerateMediaEntry("ColecoVision")
 		titleIndex, mediaIndex, _ := AddMediaPath(
-			mediaDB, resumeState, "ColecoVision", entry.Path, false, false, nil, "",
+			mediaDB, resumeState, "ColecoVision", entry.Path, "", false, false, nil, "",
 		)
 
 		// Should get the next ID after the highest, not fill gaps
@@ -396,7 +402,7 @@ func TestIDContinuityWithLargeNumbers(t *testing.T) {
 		// Create some initial data normally
 		generator := testdata.NewTestDataGenerator(4000)
 		entry1 := generator.GenerateMediaEntry("NES")
-		titleIndex1, mediaIndex1, _ := AddMediaPath(mediaDB, scanState, "NES", entry1.Path, false, false, nil, "")
+		titleIndex1, mediaIndex1, _ := AddMediaPath(mediaDB, scanState, "NES", entry1.Path, "", false, false, nil, "")
 		assert.Positive(t, titleIndex1)
 		assert.Positive(t, mediaIndex1)
 
@@ -450,7 +456,9 @@ func TestIDContinuityWithLargeNumbers(t *testing.T) {
 
 		generator := testdata.NewTestDataGenerator(4000)
 		entry := generator.GenerateMediaEntry("GameBoy")
-		titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, resumeState, "GameBoy", entry.Path, false, false, nil, "")
+		titleIndex, mediaIndex, _ := AddMediaPath(
+			mediaDB, resumeState, "GameBoy", entry.Path, "", false, false, nil, "",
+		)
 
 		// Should continue from large ID
 		expectedTitleID := int(finalMaxTitleID) + 1
@@ -505,7 +513,7 @@ func TestConcurrentIDGeneration(t *testing.T) {
 
 		for i := range 5 {
 			entry := generator.GenerateMediaEntry("NES")
-			titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, scanState, "NES", entry.Path, false, false, nil, "")
+			titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, scanState, "NES", entry.Path, "", false, false, nil, "")
 
 			expectedTitleIDs = append(expectedTitleIDs, titleIndex)
 			expectedMediaIDs = append(expectedMediaIDs, mediaIndex)

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -40,18 +40,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type PathFragmentKey struct {
-	Path                string
-	FilenameTags        bool
-	StripLeadingNumbers bool
-}
-
 // PathFragmentParams contains parameters for GetPathFragments.
 type PathFragmentParams struct {
-	Config              *config.Instance
-	Path                string
-	SystemID            string
-	MediaType           slugs.MediaType // Pre-resolved media type; skips systemdefs lookup if set
+	Config    *config.Instance
+	Path      string
+	SystemID  string
+	MediaType slugs.MediaType // Pre-resolved media type; skips systemdefs lookup if set
+	// ProvidedName, when non-empty, overrides the title that would otherwise be
+	// parsed from the filename. Tags are still extracted from the filename.
+	// Slug derives from ProvidedName when set, so any downstream consumer that
+	// looks titles up by slug must supply the same ProvidedName to compute a
+	// matching slug (see gamelistxml.LoadRecords for an example).
+	ProvidedName        string
 	NoExt               bool
 	StripLeadingNumbers bool
 }
@@ -108,19 +108,21 @@ func AddMediaPath(
 	ss *database.ScanState,
 	systemID string,
 	path string,
+	providedName string,
 	noExt bool,
 	stripLeadingNumbers bool,
 	cfg *config.Instance,
 	mediaType slugs.MediaType,
 ) (titleIndex, mediaIndex int, err error) {
 	existingMedia := false
-	pf := GetPathFragments(PathFragmentParams{
+	pf := GetPathFragments(&PathFragmentParams{
 		Config:              cfg,
 		Path:                path,
 		NoExt:               noExt,
 		StripLeadingNumbers: stripLeadingNumbers,
 		SystemID:            systemID,
 		MediaType:           mediaType,
+		ProvidedName:        providedName,
 	})
 
 	systemIndex := 0
@@ -1078,7 +1080,7 @@ func PopulateScanStateForSelectiveIndexing(
 	return nil
 }
 
-func GetPathFragments(params PathFragmentParams) MediaPathFragments {
+func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 	f := MediaPathFragments{}
 
 	// don't clean the :// in custom scheme paths
@@ -1129,7 +1131,11 @@ func GetPathFragments(params PathFragmentParams) MediaPathFragments {
 		f.FileName, _ = strings.CutSuffix(fileBase, f.Ext)
 	}
 
-	f.Title = tags.ParseTitleFromFilename(f.FileName, params.StripLeadingNumbers)
+	if params.ProvidedName != "" {
+		f.Title = params.ProvidedName
+	} else {
+		f.Title = tags.ParseTitleFromFilename(f.FileName, params.StripLeadingNumbers)
+	}
 
 	// Use pre-resolved media type if provided, otherwise look up from system ID
 	mediaType := params.MediaType
@@ -1152,7 +1158,11 @@ func GetPathFragments(params PathFragmentParams) MediaPathFragments {
 	// original title. This ensures Slug is never empty while the search
 	// logic (mediadb.go) falls back to the Name field for these cases.
 	if f.Slug == "" {
-		f.Slug = strings.ToLower(f.FileName)
+		if params.ProvidedName != "" {
+			f.Slug = strings.ToLower(params.ProvidedName)
+		} else {
+			f.Slug = strings.ToLower(f.FileName)
+		}
 	}
 
 	// Extract tags from filename only if enabled in config (default to enabled for nil config)

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -1131,8 +1131,9 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 		f.FileName, _ = strings.CutSuffix(fileBase, f.Ext)
 	}
 
-	if params.ProvidedName != "" {
-		f.Title = params.ProvidedName
+	trimmedName := strings.TrimSpace(params.ProvidedName)
+	if trimmedName != "" {
+		f.Title = trimmedName
 	} else {
 		f.Title = tags.ParseTitleFromFilename(f.FileName, params.StripLeadingNumbers)
 	}
@@ -1158,8 +1159,8 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 	// original title. This ensures Slug is never empty while the search
 	// logic (mediadb.go) falls back to the Name field for these cases.
 	if f.Slug == "" {
-		if params.ProvidedName != "" {
-			f.Slug = strings.ToLower(params.ProvidedName)
+		if trimmedName != "" {
+			f.Slug = strings.ToLower(trimmedName)
 		} else {
 			f.Slug = strings.ToLower(f.FileName)
 		}

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -86,7 +86,7 @@ func TestFlushScanStateMaps_MidSystemFileLimitBoundary(t *testing.T) {
 
 		require.NoError(t, mediaDB.BeginTransaction(true))
 		_, _, err := AddMediaPath(
-			mediaDB, scanState, systemID, disc1Path, false, false, nil, slugs.MediaTypeGame,
+			mediaDB, scanState, systemID, disc1Path, "", false, false, nil, slugs.MediaTypeGame,
 		)
 		require.NoError(t, err, "disc 1 insert should succeed")
 		require.NoError(t, mediaDB.CommitTransaction())
@@ -97,7 +97,7 @@ func TestFlushScanStateMaps_MidSystemFileLimitBoundary(t *testing.T) {
 
 		require.NoError(t, mediaDB.BeginTransaction(true))
 		_, _, err = AddMediaPath(
-			mediaDB, scanState, systemID, disc2Path, false, false, nil, slugs.MediaTypeGame,
+			mediaDB, scanState, systemID, disc2Path, "", false, false, nil, slugs.MediaTypeGame,
 		)
 		require.NoError(t, err, "disc 2 insert should succeed")
 		require.NoError(t, mediaDB.CommitTransaction())
@@ -203,7 +203,9 @@ func TestAddMediaPath_NonUniqueError(t *testing.T) {
 	mockDB.On("GetTotalMediaCount").Return(0, nil).Maybe()
 
 	// Call AddMediaPath with a TV show path
-	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "TV", "kodi-show://1/Loki", false, false, nil, "")
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "TV", "kodi-show://1/Loki", "", false, false, nil, "",
+	)
 
 	// Function should return error and (0, 0) for non-recoverable errors
 	require.Error(t, err, "should return error for non-recoverable database errors")
@@ -216,6 +218,48 @@ func TestAddMediaPath_NonUniqueError(t *testing.T) {
 
 	// Verify all mocks were called as expected (FindSystem should NOT have been called)
 	mockDB.AssertExpectations(t)
+}
+
+// TestAddMediaPath_ProvidedNameUsedAsTitle verifies that scanners which
+// know the human-readable display name (NeoGeo romsets.xml, ScummVM
+// game.Description, ES-DE/Batocera gamelist, Kodi labels, etc.) flow
+// that name through to the persisted MediaTitle row instead of having
+// it overwritten by filename-derived parsing.
+func TestAddMediaPath_ProvidedNameUsedAsTitle(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	state := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, state))
+
+	path := string(filepath.Separator) + filepath.Join("media", "fat", "games", "NEOGEO", "mslug.zip")
+
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	titleIndex, _, err := AddMediaPath(
+		mediaDB, state, "NeoGeo", path, "Metal Slug", true, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.Positive(t, titleIndex)
+
+	titles, err := mediaDB.GetTitlesBySystemID("NeoGeo")
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "Metal Slug", titles[0].Name,
+		"MediaTitle.Name must come from ProvidedName, not filename")
+	assert.Equal(t, "metalslug", titles[0].Slug,
+		"slug must derive from the provided name")
 }
 
 func TestAddMediaPath_ReindexesExistingMediaRefreshesDerivedMetadata(t *testing.T) {
@@ -245,7 +289,7 @@ func TestAddMediaPath_ReindexesExistingMediaRefreshesDerivedMetadata(t *testing.
 	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
 	require.NoError(t, mediaDB.BeginTransaction(true))
 	correctTitleID, mediaID, err := AddMediaPath(
-		mediaDB, initialState, "NES", path, false, false, nil, slugs.MediaTypeGame,
+		mediaDB, initialState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
 	)
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
@@ -293,7 +337,7 @@ func TestAddMediaPath_ReindexesExistingMediaRefreshesDerivedMetadata(t *testing.
 	require.NoError(t, PopulatePersistentScanStateForSystem(ctx, mediaDB, refreshState, "NES"))
 
 	require.NoError(t, mediaDB.BeginTransaction(true))
-	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, "", false, false, nil, slugs.MediaTypeGame)
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
 
@@ -340,7 +384,9 @@ func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testi
 		MissingMedia:  map[int]struct{}{20: {}},
 	}
 
-	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
@@ -373,7 +419,9 @@ func TestAddMediaPath_RepairsExistingMediaParentDir(t *testing.T) {
 	wantParentDir := filepath.ToSlash(filepath.Join("roms", "NES")) + "/"
 	mockDB.On("UpdateMediaParentDir", int64(20), wantParentDir).Return(nil).Once()
 
-	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
@@ -403,7 +451,9 @@ func TestAddMediaPath_ReconcileExistingMediaTagsPreservesUserTags(t *testing.T) 
 		MissingMedia: map[int]struct{}{20: {}},
 	}
 
-	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
@@ -433,7 +483,7 @@ func TestAddMediaPath_LoadedScanStatePreservesUserTags(t *testing.T) {
 	}
 	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
 	require.NoError(t, mediaDB.BeginTransaction(true))
-	_, mediaID, err := AddMediaPath(mediaDB, initialState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	_, mediaID, err := AddMediaPath(mediaDB, initialState, "NES", path, "", false, false, nil, slugs.MediaTypeGame)
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
 
@@ -458,7 +508,7 @@ func TestAddMediaPath_LoadedScanStatePreservesUserTags(t *testing.T) {
 	require.NoError(t, PopulatePersistentScanStateForSystem(ctx, mediaDB, refreshState, "NES"))
 
 	require.NoError(t, mediaDB.BeginTransaction(true))
-	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, "", false, false, nil, slugs.MediaTypeGame)
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
 
@@ -495,7 +545,9 @@ func TestAddMediaPath_ExistingMediaWithoutTagStateDoesNotDeleteAllTags(t *testin
 	mockDB.On("InsertMediaTag", database.MediaTag{TagDBID: 8, MediaDBID: 20}).
 		Return(database.MediaTag{}, nil).Once()
 
-	titleIndex, mediaIndex, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
 	require.NoError(t, err)
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
@@ -528,7 +580,7 @@ func TestAddMediaPath_ReconcileExistingMediaTagsDoesNotMutateStateOnInsertFailur
 	mockDB.On("InsertMediaTag", database.MediaTag{TagDBID: 8, MediaDBID: 20}).
 		Return(database.MediaTag{}, depFlushErr).Once()
 
-	_, _, err := AddMediaPath(mockDB, scanState, "NES", path, false, false, nil, slugs.MediaTypeGame)
+	_, _, err := AddMediaPath(mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error reconciling media tags")
 	assert.Empty(t, scanState.MediaTagIDs[20])
@@ -852,9 +904,10 @@ func TestAddMediaPath_PopulatesSlugMetadata(t *testing.T) {
 				scanState,
 				"SNES",
 				tt.path,
-				false, // skipExisting
+				"",    // name
 				false, // noExt
-				nil,   // extra tags
+				false, // stripLeadingNumbers
+				nil,   // cfg
 				"",    // mediaType
 			)
 
@@ -1034,7 +1087,7 @@ func TestGetPathFragments_VirtualPathsWithEncoding(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := GetPathFragments(PathFragmentParams{
+			result := GetPathFragments(&PathFragmentParams{
 				Config:              nil,
 				Path:                tc.path,
 				NoExt:               tc.noExt,
@@ -1076,7 +1129,7 @@ func TestGetPathFragments_PreResolvedMediaType(t *testing.T) {
 	// Use a Movie media type with a game-like path. The slug pipeline
 	// varies by media type, so different types produce different slugs
 	// when the title contains scene-style artifacts.
-	result := GetPathFragments(PathFragmentParams{
+	result := GetPathFragments(&PathFragmentParams{
 		Path:      "/games/snes/Super Mario World.sfc",
 		SystemID:  "snes",
 		MediaType: slugs.MediaTypeMovie,
@@ -1086,7 +1139,7 @@ func TestGetPathFragments_PreResolvedMediaType(t *testing.T) {
 	// the Movie pipeline (which strips different artifacts). If the
 	// pre-resolved type were ignored and the system looked up, we'd get
 	// MediaTypeGame instead.
-	resultDefault := GetPathFragments(PathFragmentParams{
+	resultDefault := GetPathFragments(&PathFragmentParams{
 		Path:     "/games/snes/Super Mario World.sfc",
 		SystemID: "snes",
 		// MediaType left empty — falls back to systemdefs lookup (Game)
@@ -1097,6 +1150,40 @@ func TestGetPathFragments_PreResolvedMediaType(t *testing.T) {
 	assert.NotEmpty(t, result.Slug, "pre-resolved MediaType path should produce a slug")
 	assert.NotEmpty(t, resultDefault.Slug, "fallback path should produce a slug")
 	assert.Equal(t, result.Title, resultDefault.Title, "title extraction should be identical regardless of media type")
+}
+
+// TestGetPathFragments_ProvidedName verifies that a non-empty ProvidedName
+// overrides the title parsed from the filename. The slug derives from the
+// override, and tags are still extracted from the filename.
+func TestGetPathFragments_ProvidedName(t *testing.T) {
+	t.Parallel()
+
+	// NeoGeo case: filename "mslug.zip" should be displayed as "Metal Slug"
+	// when the scanner provides the AltName from romsets.xml.
+	withName := GetPathFragments(&PathFragmentParams{
+		Path:         "/media/fat/games/NEOGEO/mslug.zip",
+		SystemID:     "NeoGeo",
+		ProvidedName: "Metal Slug",
+	})
+	assert.Equal(t, "Metal Slug", withName.Title, "ProvidedName must be used as title")
+	assert.Equal(t, "metalslug", withName.Slug, "slug must derive from provided name")
+
+	// Without ProvidedName, the title falls back to filename parsing.
+	withoutName := GetPathFragments(&PathFragmentParams{
+		Path:     "/media/fat/games/NEOGEO/mslug.zip",
+		SystemID: "NeoGeo",
+	})
+	assert.Equal(t, "mslug", withoutName.Title, "filename-derived title without ProvidedName")
+
+	// ProvidedName overrides title even when the filename has tag-like
+	// content; tags themselves are still extracted from the filename.
+	tagged := GetPathFragments(&PathFragmentParams{
+		Path:         "/games/snes/sm64 (USA) (Rev 1).sfc",
+		SystemID:     "snes",
+		ProvidedName: "Super Mario 64",
+	})
+	assert.Equal(t, "Super Mario 64", tagged.Title, "ProvidedName wins over tagged filename")
+	assert.Contains(t, tagged.Tags, "region:us", "USA region tag must still be extracted from filename")
 }
 
 // TestGetPathFragments_MalformedVirtualPaths tests graceful handling of malformed virtual paths
@@ -1160,7 +1247,7 @@ func TestGetPathFragments_MalformedVirtualPaths(t *testing.T) {
 
 			if tc.shouldPanic {
 				assert.Panics(t, func() {
-					GetPathFragments(PathFragmentParams{
+					GetPathFragments(&PathFragmentParams{
 						Config:              nil,
 						Path:                tc.path,
 						NoExt:               tc.noExt,
@@ -1170,7 +1257,7 @@ func TestGetPathFragments_MalformedVirtualPaths(t *testing.T) {
 				}, tc.description)
 			} else {
 				assert.NotPanics(t, func() {
-					result := GetPathFragments(PathFragmentParams{
+					result := GetPathFragments(&PathFragmentParams{
 						Config:              nil,
 						Path:                tc.path,
 						NoExt:               tc.noExt,
@@ -1224,14 +1311,14 @@ func TestGetPathFragments_VirtualPathsVsRegularPaths(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			virtualResult := GetPathFragments(PathFragmentParams{
+			virtualResult := GetPathFragments(&PathFragmentParams{
 				Config:              nil,
 				Path:                tc.virtualPath,
 				NoExt:               true,
 				StripLeadingNumbers: false,
 				SystemID:            "",
 			})
-			regularResult := GetPathFragments(PathFragmentParams{
+			regularResult := GetPathFragments(&PathFragmentParams{
 				Config:              nil,
 				Path:                tc.regularPath,
 				NoExt:               false,
@@ -1321,7 +1408,7 @@ func TestAddMediaPath_ExtensionTag_UniqueConstraintClassification(t *testing.T) 
 		mockDB.On("InsertMediaTag", expectedTag).
 			Return(database.MediaTag{}, uniqueErr).Once()
 
-		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, false, false, nil, "")
+		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, "", false, false, nil, "")
 
 		require.NoError(t, err, "UNIQUE-non-dep-flush must not propagate from AddMediaPath")
 		output := buf.String()
@@ -1347,7 +1434,7 @@ func TestAddMediaPath_ExtensionTag_UniqueConstraintClassification(t *testing.T) 
 		mockDB.On("InsertMediaTag", expectedTag).
 			Return(database.MediaTag{}, depFlushErr).Once()
 
-		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, false, false, nil, "")
+		_, _, err := AddMediaPath(mockDB, newScanState(), systemID, path, "", false, false, nil, "")
 
 		require.Error(t, err, "dep-flush error must propagate from AddMediaPath")
 		output := buf.String()

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -1158,10 +1158,13 @@ func TestGetPathFragments_PreResolvedMediaType(t *testing.T) {
 func TestGetPathFragments_ProvidedName(t *testing.T) {
 	t.Parallel()
 
+	neoGeoPath := string(filepath.Separator) + filepath.Join("media", "fat", "games", "NEOGEO", "mslug.zip")
+	snesPath := string(filepath.Separator) + filepath.Join("games", "snes", "sm64 (USA) (Rev 1).sfc")
+
 	// NeoGeo case: filename "mslug.zip" should be displayed as "Metal Slug"
 	// when the scanner provides the AltName from romsets.xml.
 	withName := GetPathFragments(&PathFragmentParams{
-		Path:         "/media/fat/games/NEOGEO/mslug.zip",
+		Path:         neoGeoPath,
 		SystemID:     "NeoGeo",
 		ProvidedName: "Metal Slug",
 	})
@@ -1170,7 +1173,7 @@ func TestGetPathFragments_ProvidedName(t *testing.T) {
 
 	// Without ProvidedName, the title falls back to filename parsing.
 	withoutName := GetPathFragments(&PathFragmentParams{
-		Path:     "/media/fat/games/NEOGEO/mslug.zip",
+		Path:     neoGeoPath,
 		SystemID: "NeoGeo",
 	})
 	assert.Equal(t, "mslug", withoutName.Title, "filename-derived title without ProvidedName")
@@ -1178,7 +1181,7 @@ func TestGetPathFragments_ProvidedName(t *testing.T) {
 	// ProvidedName overrides title even when the filename has tag-like
 	// content; tags themselves are still extracted from the filename.
 	tagged := GetPathFragments(&PathFragmentParams{
-		Path:         "/games/snes/sm64 (USA) (Rev 1).sfc",
+		Path:         snesPath,
 		SystemID:     "snes",
 		ProvidedName: "Super Mario 64",
 	})

--- a/pkg/database/mediascanner/integration_test.go
+++ b/pkg/database/mediascanner/integration_test.go
@@ -74,7 +74,7 @@ func TestResumeWithRealDatabase(t *testing.T) {
 			entries := batch.Entries[systemID]
 			for _, entry := range entries {
 				titleIndex, mediaIndex, _ := AddMediaPath(
-					mediaDB, scanState, systemID, entry.Path, false, false, nil, "",
+					mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "",
 				)
 				assert.Positive(t, titleIndex, "Title index should be > 0")
 				assert.Positive(t, mediaIndex, "Media index should be > 0")
@@ -167,7 +167,9 @@ func TestResumeWithRealDatabase(t *testing.T) {
 
 		// Add one more system with games
 		newEntry := testdata.NewTestDataGenerator(12345).GenerateMediaEntry("Gameboy")
-		titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, resumeState, "Gameboy", newEntry.Path, false, false, nil, "")
+		titleIndex, mediaIndex, _ := AddMediaPath(
+			mediaDB, resumeState, "Gameboy", newEntry.Path, "", false, false, nil, "",
+		)
 
 		// Verify the new IDs are sequential from where we left off
 		assert.Equal(t, originalTitlesIndex+1, titleIndex, "New title should get next available ID")
@@ -222,8 +224,8 @@ func TestUniqueConstraintHandling(t *testing.T) {
 		testEntry1 := testdata.NewTestDataGenerator(11111).GenerateMediaEntry("NES")
 		testEntry2 := testdata.NewTestDataGenerator(22222).GenerateMediaEntry("SNES")
 
-		_, _, _ = AddMediaPath(mediaDB, scanState, "NES", testEntry1.Path, false, false, nil, "")
-		_, _, _ = AddMediaPath(mediaDB, scanState, "SNES", testEntry2.Path, false, false, nil, "")
+		_, _, _ = AddMediaPath(mediaDB, scanState, "NES", testEntry1.Path, "", false, false, nil, "")
+		_, _, _ = AddMediaPath(mediaDB, scanState, "SNES", testEntry2.Path, "", false, false, nil, "")
 
 		err = mediaDB.CommitTransaction()
 		require.NoError(t, err)
@@ -257,9 +259,11 @@ func TestUniqueConstraintHandling(t *testing.T) {
 		// This used to cause "UNIQUE constraint failed: Systems.DBID" because
 		// PopulateScanStateFromDB wasn't working and indexes started from 0 again
 		titleIndex1, mediaIndex1, _ := AddMediaPath(
-			mediaDB, resumeState, "Genesis", testEntry3.Path, false, false, nil, "",
+			mediaDB, resumeState, "Genesis", testEntry3.Path, "", false, false, nil, "",
 		)
-		titleIndex2, mediaIndex2, _ := AddMediaPath(mediaDB, resumeState, "NES", testEntry4.Path, false, false, nil, "")
+		titleIndex2, mediaIndex2, _ := AddMediaPath(
+			mediaDB, resumeState, "NES", testEntry4.Path, "", false, false, nil, "",
+		)
 
 		// Verify no constraint violations and IDs are sequential
 		assert.Greater(t, titleIndex1, 2, "New title should have ID > 2")
@@ -321,7 +325,7 @@ func TestDatabaseStateConsistency(t *testing.T) {
 
 		// Add specific test data
 		entry := testdata.NewTestDataGenerator(55555).GenerateMediaEntry("PSX")
-		_, _, _ = AddMediaPath(mediaDB, scanState, "PSX", entry.Path, false, false, nil, "")
+		_, _, _ = AddMediaPath(mediaDB, scanState, "PSX", entry.Path, "", false, false, nil, "")
 
 		err = mediaDB.CommitTransaction()
 		require.NoError(t, err)
@@ -397,7 +401,7 @@ func TestSelectiveIndexingPreservesTagTypes(t *testing.T) {
 		for _, systemID := range testSystems {
 			entries := batch.Entries[systemID]
 			for _, entry := range entries {
-				_, _, addErr := AddMediaPath(mediaDB, scanState, systemID, entry.Path, false, false, nil, "")
+				_, _, addErr := AddMediaPath(mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "")
 				require.NoError(t, addErr, "Should add media without error")
 			}
 		}
@@ -449,7 +453,7 @@ func TestSelectiveIndexingPreservesTagTypes(t *testing.T) {
 
 		amigaEntries := batch.Entries["Amiga"]
 		for _, entry := range amigaEntries {
-			_, _, addErr := AddMediaPath(mediaDB, reindexState, "Amiga", entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(mediaDB, reindexState, "Amiga", entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr, "Should add Amiga media without TagType errors")
 		}
 
@@ -519,7 +523,7 @@ func TestReindexSameSystemTwice(t *testing.T) {
 		amigaEntries := batch.Entries["Amiga"]
 		for _, entry := range amigaEntries {
 			_, _, addErr := AddMediaPath(
-				mediaDB, scanState, "Amiga", entry.Path, false, false, nil, "",
+				mediaDB, scanState, "Amiga", entry.Path, "", false, false, nil, "",
 			)
 			if addErr != nil {
 				return addErr
@@ -922,7 +926,7 @@ func TestSlugGenerationPipeline(t *testing.T) {
 			require.NoError(t, err)
 
 			titleIndex, mediaIndex, addErr := AddMediaPath(
-				mediaDB, scanState, tt.systemID, tt.path,
+				mediaDB, scanState, tt.systemID, tt.path, "",
 				false, tt.stripLeadingNumbers, nil, "",
 			)
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -1033,7 +1033,9 @@ func NewNamesIndex(
 			dir := filepath.Dir(file.Path)
 			shouldStrip := stripPolicyByDir[dir]
 
-			_, _, addErr := AddMediaPath(db, &scanState, systemID, file.Path, file.NoExt, shouldStrip, cfg, mediaType)
+			_, _, addErr := AddMediaPath(
+				db, &scanState, systemID, file.Path, file.Name, file.NoExt, shouldStrip, cfg, mediaType,
+			)
 			if addErr != nil {
 				var sqliteErr sqlite3.Error
 				if errors.As(addErr, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique &&

--- a/pkg/database/mediascanner/mediascanner_bench_test.go
+++ b/pkg/database/mediascanner/mediascanner_bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkGetPathFragments(b *testing.B) {
 				NoExt:    tc.name == "NoExt",
 			}
 			for b.Loop() {
-				GetPathFragments(params)
+				GetPathFragments(&params)
 			}
 		})
 	}
@@ -114,7 +114,7 @@ func BenchmarkGetPathFragments_Batch(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				for _, fn := range filenames {
-					GetPathFragments(PathFragmentParams{
+					GetPathFragments(&PathFragmentParams{
 						Config:   nil,
 						Path:     fn,
 						SystemID: "NES",
@@ -279,7 +279,7 @@ func BenchmarkAddMediaPath_MockDB(b *testing.B) {
 				ss := newScanState()
 				seedMockScanState(ss)
 				for i, fn := range filenames {
-					_, _, err := AddMediaPath(mockDB, ss, "nes", fn, false, false, nil, "")
+					_, _, err := AddMediaPath(mockDB, ss, "nes", fn, "", false, false, nil, "")
 					if i == 0 && err != nil {
 						b.Fatal(err)
 					}
@@ -315,7 +315,7 @@ func BenchmarkAddMediaPath_RealDB(b *testing.B) {
 				// Mid-system file-limit commits do not flush dedup maps;
 				// flushes only happen between systems (single-system bench).
 				for i, fn := range filenames {
-					_, _, err := AddMediaPath(db, ss, "nes", fn, false, false, nil, "")
+					_, _, err := AddMediaPath(db, ss, "nes", fn, "", false, false, nil, "")
 					if i == 0 && err != nil {
 						b.Fatal(err)
 					}
@@ -364,7 +364,7 @@ func BenchmarkIndexingPipeline_EndToEnd(b *testing.B) {
 							batchStarted = true
 						}
 
-						_, _, err := AddMediaPath(db, ss, sys, fn, false, false, nil, "")
+						_, _, err := AddMediaPath(db, ss, sys, fn, "", false, false, nil, "")
 						if filesInBatch == 0 && err != nil {
 							b.Fatal(err)
 						}
@@ -403,7 +403,7 @@ func BenchmarkGetPathFragments_PeakMemory(b *testing.B) {
 
 	results := make([]MediaPathFragments, len(filenames))
 	for i, fn := range filenames {
-		results[i] = GetPathFragments(PathFragmentParams{
+		results[i] = GetPathFragments(&PathFragmentParams{
 			Config:   nil,
 			Path:     fn,
 			SystemID: "NES",

--- a/pkg/database/mediascanner/resume_scenarios_test.go
+++ b/pkg/database/mediascanner/resume_scenarios_test.go
@@ -82,7 +82,7 @@ func TestEndToEndResumeScenarios(t *testing.T) {
 			entries := batch.Entries[systemID]
 			for _, entry := range entries {
 				titleIndex, mediaIndex, _ := AddMediaPath(
-					mediaDB, scanState, systemID, entry.Path, false, false, nil, "",
+					mediaDB, scanState, systemID, entry.Path, "", false, false, nil, "",
 				)
 				assert.Positive(t, titleIndex, "Title index should be > 0")
 				assert.Positive(t, mediaIndex, "Media index should be > 0")
@@ -175,7 +175,9 @@ func TestEndToEndResumeScenarios(t *testing.T) {
 
 		// Add one more system with games
 		newEntry := testdata.NewTestDataGenerator(12345).GenerateMediaEntry("Gameboy")
-		titleIndex, mediaIndex, _ := AddMediaPath(mediaDB, resumeState, "Gameboy", newEntry.Path, false, false, nil, "")
+		titleIndex, mediaIndex, _ := AddMediaPath(
+			mediaDB, resumeState, "Gameboy", newEntry.Path, "", false, false, nil, "",
+		)
 
 		// Verify the new IDs are sequential from where we left off
 		assert.Equal(t, originalTitlesIndex+1, titleIndex, "New title should get next available ID")

--- a/pkg/database/mediascanner/selective_update_test.go
+++ b/pkg/database/mediascanner/selective_update_test.go
@@ -69,7 +69,7 @@ func TestSelectiveUpdate_EmptyCache(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -126,7 +126,7 @@ func TestSelectiveUpdate_EmptyCache(t *testing.T) {
 
 	nesEntries := batch.Entries["nes"]
 	for _, entry := range nesEntries {
-		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr)
 	}
 
@@ -176,7 +176,7 @@ func TestSelectiveUpdate_MultipleSystemsEmpty(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -216,7 +216,7 @@ func TestSelectiveUpdate_MultipleSystemsEmpty(t *testing.T) {
 	for _, systemID := range systemsToReindex {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, selectiveState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, selectiveState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -274,7 +274,7 @@ func TestSelectiveUpdate_LargeDatabase(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -349,7 +349,7 @@ func TestSelectiveUpdate_GlobalEntitiesLazyLoad(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -403,7 +403,7 @@ func TestSelectiveUpdate_GlobalEntitiesLazyLoad(t *testing.T) {
 
 	nesEntries := batch.Entries["nes"]
 	for _, entry := range nesEntries {
-		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr)
 	}
 
@@ -512,7 +512,7 @@ func TestSelectiveUpdate_DuplicateTagPrevention(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -560,7 +560,7 @@ func TestSelectiveUpdate_DuplicateTagPrevention(t *testing.T) {
 
 	nesEntries := batch.Entries["nes"]
 	for _, entry := range nesEntries {
-		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr)
 	}
 
@@ -628,7 +628,7 @@ func TestSelectiveUpdate_MediaTagAssociationsPreserved(t *testing.T) {
 	for _, systemID := range testSystems {
 		entries := batch.Entries[systemID]
 		for _, entry := range entries {
-			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, false, false, nil, "")
+			_, _, addErr := AddMediaPath(db, initialState, systemID, entry.Path, "", false, false, nil, "")
 			require.NoError(t, addErr)
 		}
 	}
@@ -671,7 +671,7 @@ func TestSelectiveUpdate_MediaTagAssociationsPreserved(t *testing.T) {
 
 	nesEntries := batch.Entries["nes"]
 	for _, entry := range nesEntries {
-		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(db, selectiveState, "nes", entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr)
 	}
 

--- a/pkg/database/mediascanner/truncate_regression_test.go
+++ b/pkg/database/mediascanner/truncate_regression_test.go
@@ -111,7 +111,7 @@ func indexSystems(
 	require.NoError(t, db.BeginTransaction(false))
 	for _, sys := range systems {
 		for _, entry := range batch.Entries[sys] {
-			_, _, err := AddMediaPath(db, state, sys, entry.Path, false, false, nil, "")
+			_, _, err := AddMediaPath(db, state, sys, entry.Path, "", false, false, nil, "")
 			require.NoError(t, err, "AddMediaPath failed for system %s", sys)
 		}
 	}
@@ -153,7 +153,7 @@ func TestTruncateResume_SharedTagsPreserved(t *testing.T) {
 
 	require.NoError(t, db.BeginTransaction(false))
 	for _, entry := range batch.Entries["C64"][:5] {
-		_, _, err := AddMediaPath(db, state, "C64", entry.Path, false, false, nil, "")
+		_, _, err := AddMediaPath(db, state, "C64", entry.Path, "", false, false, nil, "")
 		require.NoError(t, err)
 	}
 	require.NoError(t, db.CommitTransaction())
@@ -249,7 +249,7 @@ func TestTruncateResume_MultipleSystemsIndexed(t *testing.T) {
 	// Step 2: partially index C64 (simulates the mid-index interrupt).
 	require.NoError(t, db.BeginTransaction(false))
 	for _, entry := range batch.Entries[partialSystem][:partialGameCount] {
-		_, _, err := AddMediaPath(db, state, partialSystem, entry.Path, false, false, nil, "")
+		_, _, err := AddMediaPath(db, state, partialSystem, entry.Path, "", false, false, nil, "")
 		require.NoError(t, err)
 	}
 	require.NoError(t, db.CommitTransaction())
@@ -310,7 +310,7 @@ func TestTruncateResume_MultipleSystemsIndexed(t *testing.T) {
 
 	require.NoError(t, db.BeginTransaction(false))
 	for _, entry := range batch.Entries[partialSystem] {
-		_, _, addErr := AddMediaPath(db, resumeState, partialSystem, entry.Path, false, false, nil, "")
+		_, _, addErr := AddMediaPath(db, resumeState, partialSystem, entry.Path, "", false, false, nil, "")
 		require.NoError(t, addErr, "re-index must not fail with UNIQUE or FK violation")
 	}
 	require.NoError(t, db.CommitTransaction())

--- a/pkg/database/mediascanner/virtual_path_integration_test.go
+++ b/pkg/database/mediascanner/virtual_path_integration_test.go
@@ -241,6 +241,7 @@ func TestVirtualPath_EndToEndFlow(t *testing.T) {
 				scanState,
 				tc.systemID,
 				virtualPath,
+				"",    // name
 				false, // noExt
 				false, // stripLeadingNumbers
 				nil,   // cfg
@@ -393,6 +394,7 @@ func TestVirtualPath_MalformedGracefulHandling(t *testing.T) {
 				scanState,
 				tc.systemID,
 				tc.virtualPath,
+				"",
 				false,
 				false,
 				nil,
@@ -489,6 +491,7 @@ func TestVirtualPath_HTTPURLHandling(t *testing.T) {
 				scanState,
 				tc.systemID,
 				tc.url,
+				"",
 				false,
 				false,
 				nil,

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -240,11 +240,12 @@ outer:
 				continue
 			}
 
-			pf := mediascanner.GetPathFragments(mediascanner.PathFragmentParams{
-				Config:   g.cfg,
-				Path:     resolved,
-				SystemID: system.ID,
-				NoExt:    true,
+			pf := mediascanner.GetPathFragments(&mediascanner.PathFragmentParams{
+				Config:       g.cfg,
+				Path:         resolved,
+				SystemID:     system.ID,
+				NoExt:        true,
+				ProvidedName: gl.Games[i].Name,
 			})
 
 			title, ok := titlesBySlug[pf.Slug]

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -40,7 +40,7 @@ import (
 // slugFor computes the MediaTitle slug that would be stored for a ROM path
 // using the same parameters as the scraper's LoadRecords call.
 func slugFor(systemID, path string) string {
-	return mediascanner.GetPathFragments(mediascanner.PathFragmentParams{
+	return mediascanner.GetPathFragments(&mediascanner.PathFragmentParams{
 		SystemID: systemID,
 		Path:     path,
 		NoExt:    true,
@@ -298,6 +298,54 @@ func TestLoadRecords_SlugMatch(t *testing.T) {
 	assert.Equal(t, filepath.Join(root, "media", "image"), records[0].AvailableMediaDirs["image"])
 }
 
+// TestLoadRecords_NameDerivedSlugMatch verifies the scraper matches titles
+// whose stored slug derives from a scanner-provided display name rather than
+// the filename. This is a regression test for the fix where the indexer uses
+// ScanResult.Name (e.g. NeoGeo AltName, gamelist.xml <name>) to build the
+// MediaTitle slug, requiring the scraper to also derive its lookup slug from
+// gamelist.xml's <name> rather than the filename.
+func TestLoadRecords_NameDerivedSlugMatch(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./mslug.zip</path><name>Metal Slug</name></game>
+</gameList>`), 0o600))
+
+	// Indexer would have stored the slug derived from ProvidedName="Metal Slug",
+	// not from the filename "mslug". Build titlesBySlug accordingly.
+	nameSlug := mediascanner.GetPathFragments(&mediascanner.PathFragmentParams{
+		SystemID:     "NeoGeo",
+		Path:         filepath.Join(root, "mslug.zip"),
+		NoExt:        true,
+		ProvidedName: "Metal Slug",
+	}).Slug
+
+	// Confirm the test setup actually exercises the regression: the
+	// name-derived slug must differ from a filename-derived one.
+	filenameSlug := slugFor("NeoGeo", filepath.Join(root, "mslug.zip"))
+	require.NotEqual(t, filenameSlug, nameSlug,
+		"test precondition: name-derived slug must differ from filename-derived")
+
+	titlesBySlug := map[string]database.MediaTitle{
+		nameSlug: {DBID: 42, Slug: nameSlug, Name: "Metal Slug"},
+	}
+	mediaByTitleDBID := map[int64]int64{42: 7}
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "NeoGeo", ROMPaths: []string{root}},
+		titlesBySlug,
+		mediaByTitleDBID,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1, "scraper must match the title via name-derived slug")
+	assert.Equal(t, "Metal Slug", records[0].Game.Name)
+	assert.Equal(t, int64(42), records[0].MatchedTitleDBID)
+	assert.Equal(t, int64(7), records[0].MatchedMediaDBID)
+}
+
 // TestLoadRecords_SkipsMissingAndMalformedGameLists verifies that ROM roots
 // without a gamelist.xml and roots with a malformed file are silently skipped.
 func TestLoadRecords_SkipsMissingAndMalformedGameLists(t *testing.T) {
@@ -346,14 +394,14 @@ func TestLoadRecords_FirstWins(t *testing.T) {
 	root1 := t.TempDir()
 	root2 := t.TempDir()
 
-	writeGamelist := func(dir, name string) {
+	writeGamelist := func(dir string) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "gamelist.xml"), []byte(`
 <gameList>
-  <game><path>./game.nes</path><name>`+name+`</name></game>
+  <game><path>./game.nes</path><name>Game</name></game>
 </gameList>`), 0o600))
 	}
-	writeGamelist(root1, "Game A")
-	writeGamelist(root2, "Game B")
+	writeGamelist(root1)
+	writeGamelist(root2)
 
 	slug := slugFor("nes", filepath.Join(root1, "game.nes"))
 	titlesBySlug := map[string]database.MediaTitle{
@@ -369,7 +417,7 @@ func TestLoadRecords_FirstWins(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, records, 1, "second root's duplicate slug must be skipped")
-	assert.Equal(t, "Game A", records[0].Game.Name, "first root wins")
+	assert.Equal(t, root1, records[0].SystemRootPath, "first root wins")
 }
 
 // TestLoadRecords_NoMediaForTitle verifies that a slug match with no

--- a/pkg/service/scan_to_launch_bench_test.go
+++ b/pkg/service/scan_to_launch_bench_test.go
@@ -84,7 +84,7 @@ func setupPipelineBench(b *testing.B, n int) *pipelineBenchEnv {
 		b.Fatal(err)
 	}
 	for i, fn := range filenames {
-		_, _, err := mediascanner.AddMediaPath(mediaDB, ss, "NES", fn, false, false, nil, "")
+		_, _, err := mediascanner.AddMediaPath(mediaDB, ss, "NES", fn, "", false, false, nil, "")
 		if i == 0 && err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/zapscript/titles/resolve_bench_test.go
+++ b/pkg/zapscript/titles/resolve_bench_test.go
@@ -71,7 +71,7 @@ func setupResolveBenchDB(b *testing.B, n int) (
 		b.Fatal(err)
 	}
 	for i, fn := range filenames {
-		_, _, err := mediascanner.AddMediaPath(db, ss, "nes", fn, false, false, nil, "")
+		_, _, err := mediascanner.AddMediaPath(db, ss, "nes", fn, "", false, false, nil, "")
 		if i == 0 && err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
- `ScanResult.Name` was populated by several scanners (NeoGeo romsets.xml, ScummVM, ES-DE/Batocera/RetroPie gamelist.xml, Kodi, Heroic, LaunchBox/RetroBat) but ignored by the indexing pipeline, so titles came out as ROM filenames (e.g. `mslug` instead of `Metal Slug` on MiSTer NeoGeo).
- Plumb the name through `AddMediaPath` and `GetPathFragments` via a new `ProvidedName` field on `PathFragmentParams`. When set it overrides the filename-parsed title; tags are still extracted from the filename so region/revision/disc tags are preserved.
- Slug now derives from the title, so the `gamelistxml` scraper passes the gamelist `<name>` to compute a matching lookup slug. Without this the read side would silently miss every title whose stored slug now derives from the display name.

Closes #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media items can accept an externally provided display name; when given, it’s used as the media title and for slug generation.

* **Bug Fixes**
  * Slug generation now falls back to the provided name to avoid empty slugs for unusual filenames.

* **Chores**
  * Reduced verbose media payloads in debug logs to prevent flooding with large/binary content.

* **Tests**
  * Expanded tests for slug/name behavior and safe logging of media batch responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->