### PR TITLE
feat(mister): add RetroAchievements alt launchers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ go.work
 .claudeignore
 .opencode/
 .agent-shell/
+.pi/
 
 *.db
 *.tar

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -353,6 +353,21 @@ func TestRBFCache_Resolve_AltCoreUsesLauncherID(t *testing.T) {
 	assert.Equal(t, "/media/fat/_Other/PSX2XCPU_20240101.rbf", got.Path)
 }
 
+func TestRBFCache_Resolve_RetroAchievementsAltCore(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/NES_20240101.rbf", ShortName: "NES", MglName: "_Console/NES"},
+		{Path: "/media/fat/_RA_Cores/Cores/NES.rbf", ShortName: "NES", MglName: "_RA_Cores/Cores/NES"},
+	})
+	cache.RegisterAltCore("RANES", "_RA_Cores/Cores/NES")
+
+	got, err := cache.Resolve(nil, &Core{ID: "NES", LauncherID: "RANES", RBF: "_Console/NES"})
+	require.NoError(t, err)
+	assert.Equal(t, "_RA_Cores/Cores/NES", got.MglName)
+}
+
 func TestRBFCache_Resolve_AltCoreFallsBackToSystemID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/cores/rbf_persist.go
+++ b/pkg/platforms/mister/cores/rbf_persist.go
@@ -92,6 +92,11 @@ func snapshotDirMtimesAt(root string) (map[string]int64, error) {
 		}
 		snapshot[sub] = info.ModTime().UnixNano()
 	}
+
+	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	if info, statErr := os.Stat(raCoreDir); statErr == nil && info.IsDir() {
+		snapshot[raCoreDir] = info.ModTime().UnixNano()
+	}
 	return snapshot, nil
 }
 

--- a/pkg/platforms/mister/cores/rbf_persist_test.go
+++ b/pkg/platforms/mister/cores/rbf_persist_test.go
@@ -245,6 +245,18 @@ func TestDiffDirMtimes_MissingPath(t *testing.T) {
 	assert.Zero(t, diffs[0].CurrentMtimeNs)
 }
 
+func TestSnapshotDirMtimes_IncludesRetroAchievementsCoreDir(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	require.NoError(t, os.MkdirAll(raCoreDir, 0o750))
+
+	snapshot, err := snapshotDirMtimesAt(root)
+	require.NoError(t, err)
+	assert.Contains(t, snapshot, raCoreDir)
+}
+
 func TestRootRBFsMatch_NoFilesEqualsEmptySnapshot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/pkg/platforms/mister/cores/rbfs.go
+++ b/pkg/platforms/mister/cores/rbfs.go
@@ -38,6 +38,10 @@ type RBFInfo struct {
 }
 
 func ParseRBFPath(path string) RBFInfo {
+	return parseRBFPathAt(config.SDRootDir, path)
+}
+
+func parseRBFPathAt(root, path string) RBFInfo {
 	info := RBFInfo{
 		Path:     path,
 		Filename: filepath.Base(path),
@@ -49,8 +53,8 @@ func ParseRBFPath(path string) RBFInfo {
 		info.ShortName = strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename))
 	}
 
-	if strings.HasPrefix(path, config.SDRootDir) {
-		relDir := strings.TrimPrefix(filepath.Dir(path), config.SDRootDir+"/")
+	if strings.HasPrefix(path, root) {
+		relDir := strings.TrimPrefix(filepath.Dir(path), root+"/")
 		info.MglName = filepath.Join(relDir, info.ShortName)
 	} else {
 		info.MglName = path
@@ -59,8 +63,13 @@ func ParseRBFPath(path string) RBFInfo {
 	return info
 }
 
-// Find all rbf files in the top 2 menu levels of the SD card.
+// Find all rbf files in the top 2 menu levels of the SD card, plus
+// RetroAchievements cores under _RA_Cores/Cores.
 func shallowScanRBF() ([]RBFInfo, error) {
+	return shallowScanRBFAt(config.SDRootDir)
+}
+
+func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 	results := make([]RBFInfo, 0)
 
 	isRbf := func(file os.DirEntry) bool {
@@ -79,40 +88,48 @@ func shallowScanRBF() ([]RBFInfo, error) {
 				return RBFInfo{}, fmt.Errorf("failed to readlink %s: %w", path, err)
 			}
 
-			return ParseRBFPath(newPath), nil
+			return parseRBFPathAt(root, newPath), nil
 		}
-		return ParseRBFPath(path), nil
+		return parseRBFPathAt(root, path), nil
 	}
 
-	files, err := os.ReadDir(config.SDRootDir)
+	addRBF := func(path string) {
+		info, err := infoSymlink(path)
+		if err != nil {
+			return
+		}
+		results = append(results, info)
+	}
+
+	files, err := os.ReadDir(root)
 	if err != nil {
-		return results, fmt.Errorf("failed to read SD root directory %s: %w", config.SDRootDir, err)
+		return results, fmt.Errorf("failed to read SD root directory %s: %w", root, err)
 	}
 
 	for _, file := range files {
 		if file.IsDir() && strings.HasPrefix(file.Name(), "_") {
-			subFiles, err := os.ReadDir(filepath.Join(config.SDRootDir, file.Name()))
+			subFiles, err := os.ReadDir(filepath.Join(root, file.Name()))
 			if err != nil {
 				continue
 			}
 
 			for _, subFile := range subFiles {
 				if isRbf(subFile) {
-					path := filepath.Join(config.SDRootDir, file.Name(), subFile.Name())
-					info, err := infoSymlink(path)
-					if err != nil {
-						continue
-					}
-					results = append(results, info)
+					addRBF(filepath.Join(root, file.Name(), subFile.Name()))
 				}
 			}
 		} else if isRbf(file) {
-			path := filepath.Join(config.SDRootDir, file.Name())
-			info, err := infoSymlink(path)
-			if err != nil {
-				continue
+			addRBF(filepath.Join(root, file.Name()))
+		}
+	}
+
+	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	raCoreFiles, err := os.ReadDir(raCoreDir)
+	if err == nil {
+		for _, file := range raCoreFiles {
+			if isRbf(file) {
+				addRBF(filepath.Join(raCoreDir, file.Name()))
 			}
-			results = append(results, info)
 		}
 	}
 

--- a/pkg/platforms/mister/cores/rbfs.go
+++ b/pkg/platforms/mister/cores/rbfs.go
@@ -54,8 +54,15 @@ func parseRBFPathAt(root, path string) RBFInfo {
 	}
 
 	if strings.HasPrefix(path, root) {
-		relDir := strings.TrimPrefix(filepath.Dir(path), root+"/")
-		info.MglName = filepath.Join(relDir, info.ShortName)
+		relDir, err := filepath.Rel(root, filepath.Dir(path))
+		switch {
+		case err != nil || relDir == ".." || strings.HasPrefix(relDir, ".."+string(os.PathSeparator)):
+			info.MglName = path
+		case relDir == "." || relDir == "":
+			info.MglName = info.ShortName
+		default:
+			info.MglName = filepath.Join(relDir, info.ShortName)
+		}
 	} else {
 		info.MglName = path
 	}
@@ -83,9 +90,9 @@ func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 		}
 
 		if info.Mode()&os.ModeSymlink != 0 {
-			newPath, err := os.Readlink(path)
-			if err != nil {
-				return RBFInfo{}, fmt.Errorf("failed to readlink %s: %w", path, err)
+			newPath, readlinkErr := os.Readlink(path)
+			if readlinkErr != nil {
+				return RBFInfo{}, fmt.Errorf("failed to readlink %s: %w", path, readlinkErr)
 			}
 
 			return parseRBFPathAt(root, newPath), nil
@@ -108,8 +115,8 @@ func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 
 	for _, file := range files {
 		if file.IsDir() && strings.HasPrefix(file.Name(), "_") {
-			subFiles, err := os.ReadDir(filepath.Join(root, file.Name()))
-			if err != nil {
+			subFiles, subErr := os.ReadDir(filepath.Join(root, file.Name()))
+			if subErr != nil {
 				continue
 			}
 
@@ -124,8 +131,8 @@ func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 	}
 
 	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
-	raCoreFiles, err := os.ReadDir(raCoreDir)
-	if err == nil {
+	raCoreFiles, raErr := os.ReadDir(raCoreDir)
+	if raErr == nil {
 		for _, file := range raCoreFiles {
 			if isRbf(file) {
 				addRBF(filepath.Join(raCoreDir, file.Name()))

--- a/pkg/platforms/mister/cores/rbfs_test.go
+++ b/pkg/platforms/mister/cores/rbfs_test.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cores
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShallowScanRBF_IncludesRetroAchievementsCores(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	require.NoError(t, os.MkdirAll(raCoreDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(raCoreDir, "NES.rbf"), []byte{}, 0o600))
+
+	rbfs, err := shallowScanRBFAt(root)
+	require.NoError(t, err)
+
+	var found *RBFInfo
+	for i := range rbfs {
+		if rbfs[i].MglName == "_RA_Cores/Cores/NES" {
+			found = &rbfs[i]
+			break
+		}
+	}
+
+	require.NotNil(t, found, "RA core should be included in shallow RBF scan")
+	assert.Equal(t, "NES", found.ShortName)
+	assert.Equal(t, "NES.rbf", found.Filename)
+}

--- a/pkg/platforms/mister/cores/rbfs_test.go
+++ b/pkg/platforms/mister/cores/rbfs_test.go
@@ -41,9 +41,10 @@ func TestShallowScanRBF_IncludesRetroAchievementsCores(t *testing.T) {
 	rbfs, err := shallowScanRBFAt(root)
 	require.NoError(t, err)
 
+	expectedMglName := filepath.Join("_RA_Cores", "Cores", "NES")
 	var found *RBFInfo
 	for i := range rbfs {
-		if rbfs[i].MglName == "_RA_Cores/Cores/NES" {
+		if rbfs[i].MglName == expectedMglName {
 			found = &rbfs[i]
 			break
 		}

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -688,6 +688,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPIAtari7800", systemdefs.SystemAtari7800, "_LLAPI/Atari7800_LLAPI"),
 		},
 		{
+			ID:       "RAAtari7800",
+			SystemID: systemdefs.SystemAtari7800,
+			Launch:   launchAltCore("RAAtari7800", systemdefs.SystemAtari7800, "_RA_Cores/Cores/Atari7800"),
+		},
+		{
 			ID:         systemdefs.SystemAtariLynx,
 			SystemID:   systemdefs.SystemAtariLynx,
 			Folders:    []string{"AtariLynx"},
@@ -756,6 +761,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPIGameboy", systemdefs.SystemGameboy, "_LLAPI/Gameboy_LLAPI"),
 		},
 		{
+			ID:       "RAGameboy",
+			SystemID: systemdefs.SystemGameboy,
+			Launch:   launchAltCore("RAGameboy", systemdefs.SystemGameboy, "_RA_Cores/Cores/Gameboy"),
+		},
+		{
 			ID:         systemdefs.SystemGameboyColor,
 			SystemID:   systemdefs.SystemGameboyColor,
 			Folders:    []string{"GAMEBOY", "GBC"},
@@ -803,6 +813,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPIGBA", systemdefs.SystemGBA, "_LLAPI/GBA_LLAPI"),
 		},
 		{
+			ID:       "RAGBA",
+			SystemID: systemdefs.SystemGBA,
+			Launch:   launchAltCore("RAGBA", systemdefs.SystemGBA, "_RA_Cores/Cores/GBA"),
+		},
+		{
 			ID:         systemdefs.SystemGBA2P,
 			SystemID:   systemdefs.SystemGBA2P,
 			Folders:    []string{"GBA2P"},
@@ -830,6 +845,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "LLAPIMegaDrive",
 			SystemID: systemdefs.SystemGenesis,
 			Launch:   launchAltCore("LLAPIMegaDrive", systemdefs.SystemGenesis, "_LLAPI/MegaDrive_LLAPI"),
+		},
+		{
+			ID:       "RAMegaDrive",
+			SystemID: systemdefs.SystemGenesis,
+			Launch:   launchAltCore("RAMegaDrive", systemdefs.SystemGenesis, "_RA_Cores/Cores/MegaDrive"),
 		},
 		{
 			ID:         systemdefs.SystemIntellivision,
@@ -875,6 +895,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPISMS", systemdefs.SystemMasterSystem, "_LLAPI/SMS_LLAPI"),
 		},
 		{
+			ID:       "RASMS",
+			SystemID: systemdefs.SystemMasterSystem,
+			Launch:   launchAltCore("RASMS", systemdefs.SystemMasterSystem, "_RA_Cores/Cores/SMS"),
+		},
+		{
 			ID:         systemdefs.SystemMegaCD,
 			SystemID:   systemdefs.SystemMegaCD,
 			Folders:    []string{"MegaCD"},
@@ -892,6 +917,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPIMegaCD", systemdefs.SystemMegaCD, "_LLAPI/MegaCD_LLAPI"),
 		},
 		{
+			ID:       "RAMegaCD",
+			SystemID: systemdefs.SystemMegaCD,
+			Launch:   launchAltCore("RAMegaCD", systemdefs.SystemMegaCD, "_RA_Cores/Cores/MegaCD"),
+		},
+		{
 			ID:         systemdefs.SystemMegaDuck,
 			SystemID:   systemdefs.SystemMegaDuck,
 			Folders:    []string{"GAMEBOY", "MegaDuck"},
@@ -902,6 +932,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "LLAPINeoGeo",
 			SystemID: systemdefs.SystemNeoGeo,
 			Launch:   launchAltCore("LLAPINeoGeo", systemdefs.SystemNeoGeo, "_LLAPI/NeoGeo_LLAPI"),
+		},
+		{
+			ID:       "RANeoGeo",
+			SystemID: systemdefs.SystemNeoGeo,
+			Launch:   launchAltCore("RANeoGeo", systemdefs.SystemNeoGeo, "_RA_Cores/Cores/NeoGeo"),
 		},
 		{
 			ID:         systemdefs.SystemNeoGeoCD,
@@ -949,6 +984,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPINES", systemdefs.SystemNES, "_LLAPI/NES_LLAPI"),
 		},
 		{
+			ID:       "RANES",
+			SystemID: systemdefs.SystemNES,
+			Launch:   launchAltCore("RANES", systemdefs.SystemNES, "_RA_Cores/Cores/NES"),
+		},
+		{
 			ID:         systemdefs.SystemNintendo64,
 			SystemID:   systemdefs.SystemNintendo64,
 			Folders:    []string{"N64"},
@@ -981,6 +1021,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch: launchAltCore(
 				"PWM80MHzNintendo64", systemdefs.SystemNintendo64, "_ConsolePWM/_Turbo/N64_80MHz_PWM",
 			),
+		},
+		{
+			ID:       "RANintendo64",
+			SystemID: systemdefs.SystemNintendo64,
+			Launch:   launchAltCore("RANintendo64", systemdefs.SystemNintendo64, "_RA_Cores/Cores/N64"),
 		},
 		{
 			ID:         systemdefs.SystemOdyssey2,
@@ -1041,6 +1086,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("DualRAMPSX", systemdefs.SystemPSX, "_Console (Dual SDRAM)/PSX"),
 		},
 		{
+			ID:       "RAPSX",
+			SystemID: systemdefs.SystemPSX,
+			Launch:   launchAltCore("RAPSX", systemdefs.SystemPSX, "_RA_Cores/Cores/PSX"),
+		},
+		{
 			ID:         systemdefs.SystemSega32X,
 			SystemID:   systemdefs.SystemSega32X,
 			Folders:    []string{"S32X"},
@@ -1051,6 +1101,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "LLAPIS32X",
 			SystemID: systemdefs.SystemSega32X,
 			Launch:   launchAltCore("LLAPIS32X", systemdefs.SystemSega32X, "_LLAPI/S32X_LLAPI"),
+		},
+		{
+			ID:       "RAS32X",
+			SystemID: systemdefs.SystemSega32X,
+			Launch:   launchAltCore("RAS32X", systemdefs.SystemSega32X, "_RA_Cores/Cores/S32X"),
 		},
 		{
 			ID:         systemdefs.SystemSG1000,
@@ -1113,6 +1168,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("LLAPISNES", systemdefs.SystemSNES, "_LLAPI/SNES_LLAPI"),
 		},
 		{
+			ID:       "RASNES",
+			SystemID: systemdefs.SystemSNES,
+			Launch:   launchAltCore("RASNES", systemdefs.SystemSNES, "_RA_Cores/Cores/SNES"),
+		},
+		{
 			ID:       "SindenSNES",
 			SystemID: systemdefs.SystemSNES,
 			Launch:   launchSinden(systemdefs.SystemSNES, "SNES"),
@@ -1147,6 +1207,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "LLAPITurboGrafx16",
 			SystemID: systemdefs.SystemTurboGrafx16,
 			Launch:   launchAltCore("LLAPITurboGrafx16", systemdefs.SystemTurboGrafx16, "_LLAPI/TurboGrafx16_LLAPI"),
+		},
+		{
+			ID:       "RATurboGrafx16",
+			SystemID: systemdefs.SystemTurboGrafx16,
+			Launch:   launchAltCore("RATurboGrafx16", systemdefs.SystemTurboGrafx16, "_RA_Cores/Cores/TurboGrafx16"),
 		},
 		{
 			ID:         systemdefs.SystemTurboGrafx16CD,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -513,3 +513,46 @@ func TestDualRAMLaunchersExist(t *testing.T) {
 		})
 	}
 }
+
+func TestRetroAchievementsLaunchersExist(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	cases := []struct {
+		id       string
+		systemID string
+	}{
+		{"RANES", "NES"},
+		{"RASNES", "SNES"},
+		{"RAGameboy", "Gameboy"},
+		{"RAGBA", "GBA"},
+		{"RANintendo64", "Nintendo64"},
+		{"RAPSX", "PSX"},
+		{"RAMegaDrive", "Genesis"},
+		{"RAMegaCD", "MegaCD"},
+		{"RASMS", "MasterSystem"},
+		{"RANeoGeo", "NeoGeo"},
+		{"RATurboGrafx16", "TurboGrafx16"},
+		{"RAAtari7800", "Atari7800"},
+		{"RAS32X", "Sega32X"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			var found *platforms.Launcher
+			for i := range launchers {
+				if launchers[i].ID == tc.id {
+					found = &launchers[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "%s launcher should exist", tc.id)
+			assert.Equal(t, tc.systemID, found.SystemID,
+				"%s must inherit slots from %s", tc.id, tc.systemID)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add MiSTer RetroAchievements alternate launchers for supported odelot RA cores
- scan `_RA_Cores/Cores` so nested RA RBFs resolve through the cache
- track RA core directory mtimes for persisted RBF cache invalidation

## Validation
- `go test ./pkg/platforms/mister/cores/`
- `go test ./pkg/platforms/mister/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RetroAchievements core launchers for multiple systems and expanded RBF scanning to include the RetroAchievements cores directory.

* **Tests**
  * Added unit tests covering RBF scanning, snapshotting of RetroAchievements core directory mtimes, and resolution of RetroAchievements alt-core launchers.

* **Chores**
  * Updated .gitignore to ignore the RetroAchievements cores directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->