### PR TITLE
fix(api): refresh local origins during validation

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -598,6 +598,7 @@ func isPrivateIP(ipStr string) bool {
 func isAllowedOrigin(
 	origin string,
 	staticOrigins []string,
+	localIPsProvider LocalIPsProvider,
 	customOriginsProvider OriginsProvider,
 	apiPort int,
 	allowEmptyOrigin bool,
@@ -616,6 +617,16 @@ func isAllowedOrigin(
 	for _, allowed := range staticOrigins {
 		if strings.EqualFold(origin, allowed) {
 			log.Debug().Msgf("%s origin: %s allowed (static match)", logPrefix, origin)
+			return true
+		}
+	}
+
+	// Check current local IP origins dynamically. Network interfaces may not
+	// have addresses when the API server starts, especially during first boot.
+	localOrigins := expandLocalIPOrigins(localIPsProvider(), apiPort)
+	for _, allowed := range localOrigins {
+		if strings.EqualFold(origin, allowed) {
+			log.Debug().Msgf("%s origin: %s allowed (current local IP match)", logPrefix, origin)
 			return true
 		}
 	}
@@ -666,10 +677,9 @@ func expandCustomOrigins(customOrigins []string, port int) []string {
 	return result
 }
 
-// buildStaticAllowedOrigins creates the static part of allowed origins (base + local IPs).
-func buildStaticAllowedOrigins(baseOrigins, localIPs []string, port int) []string {
-	result := make([]string, 0, len(baseOrigins)+len(localIPs)*2)
-	result = append(result, baseOrigins...)
+// expandLocalIPOrigins creates allowed origins for current local interface IPs.
+func expandLocalIPOrigins(localIPs []string, port int) []string {
+	result := make([]string, 0, len(localIPs)*2)
 
 	for _, localIP := range localIPs {
 		result = append(result,
@@ -677,6 +687,15 @@ func buildStaticAllowedOrigins(baseOrigins, localIPs []string, port int) []strin
 			fmt.Sprintf("https://%s:%d", localIP, port),
 		)
 	}
+
+	return result
+}
+
+// buildStaticAllowedOrigins creates the static part of allowed origins (base + local IPs).
+func buildStaticAllowedOrigins(baseOrigins, localIPs []string, port int) []string {
+	result := make([]string, 0, len(baseOrigins)+len(localIPs)*2)
+	result = append(result, baseOrigins...)
+	result = append(result, expandLocalIPOrigins(localIPs, port)...)
 
 	return result
 }
@@ -691,15 +710,19 @@ func buildDynamicAllowedOrigins(baseOrigins, localIPs []string, port int, custom
 // OriginsProvider is a function that returns custom origins from config.
 type OriginsProvider func() []string
 
+// LocalIPsProvider is a function that returns current local interface IPs.
+type LocalIPsProvider func() []string
+
 // makeOriginValidator creates an origin validation function for CORS middleware.
 // It checks against static origins and dynamically fetches custom origins on each request.
 func makeOriginValidator(
 	staticOrigins []string,
+	localIPsProvider LocalIPsProvider,
 	customOriginsProvider OriginsProvider,
 	port int,
 ) func(*http.Request, string) bool {
 	return func(_ *http.Request, origin string) bool {
-		return isAllowedOrigin(origin, staticOrigins, customOriginsProvider, port, false, "cors")
+		return isAllowedOrigin(origin, staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors")
 	}
 }
 
@@ -1422,13 +1445,15 @@ func StartWithReady(
 		fmt.Sprintf("https://127.0.0.1:%d", port),
 	)
 
-	localIPs := helpers.GetAllLocalIPs()
+	localIPsProvider := LocalIPsProvider(helpers.GetAllLocalIPs)
+	localIPs := localIPsProvider()
 	for _, localIP := range localIPs {
 		log.Debug().Msgf("adding local IP to allowed origins: %s", localIP)
 	}
 
-	// Build static origins (base + local IPs + mDNS + OS hostname)
-	staticOrigins := buildStaticAllowedOrigins(baseOrigins, localIPs, port)
+	// Build static origins (base + mDNS + OS hostname). Local IP origins are
+	// checked dynamically because network interfaces may appear after startup.
+	staticOrigins := buildStaticAllowedOrigins(baseOrigins, nil, port)
 
 	if mdnsHostname != "" {
 		mdnsLocal := mdnsHostname + ".local"
@@ -1453,8 +1478,8 @@ func StartWithReady(
 
 	log.Debug().Msgf("staticOrigins: %v", staticOrigins)
 
-	// Create origin validator that checks static origins + dynamic custom origins
-	originValidator := makeOriginValidator(staticOrigins, cfg.AllowedOrigins, port)
+	// Create origin validator that checks static origins + dynamic local IP/custom origins.
+	originValidator := makeOriginValidator(staticOrigins, localIPsProvider, cfg.AllowedOrigins, port)
 
 	r := chi.NewRouter()
 
@@ -1531,7 +1556,7 @@ func StartWithReady(
 	session.Upgrader.CheckOrigin = func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
 		log.Debug().Msgf("websocket origin: %s", origin)
-		return isAllowedOrigin(origin, staticOrigins, cfg.AllowedOrigins, port, true, "websocket")
+		return isAllowedOrigin(origin, staticOrigins, localIPsProvider, cfg.AllowedOrigins, port, true, "websocket")
 	}
 	// melody's Session.Write is a non-blocking enqueue onto a per-session
 	// output channel (default size 256). When that channel fills, the

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -384,6 +384,7 @@ func TestIsAllowedOrigin_WebSocketPolicy(t *testing.T) {
 		"http://192.168.1.100:7497",
 		"http://MiSTer.local:7497", // Mixed case hostname
 	}
+	localIPsProvider := func() []string { return nil }
 	customOriginsProvider := func() []string { return nil }
 	apiPort := 7497
 
@@ -452,7 +453,9 @@ func TestIsAllowedOrigin_WebSocketPolicy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := isAllowedOrigin(tt.origin, staticOrigins, customOriginsProvider, apiPort, true, "websocket")
+			result := isAllowedOrigin(
+				tt.origin, staticOrigins, localIPsProvider, customOriginsProvider, apiPort, true, "websocket",
+			)
 			require.Equal(t, tt.expected, result, "isAllowedOrigin result mismatch for %s", tt.origin)
 		})
 	}
@@ -574,19 +577,57 @@ func TestOriginPolicy_HappyPaths(t *testing.T) {
 	t.Parallel()
 
 	port := 7497
-	staticOrigins := buildStaticAllowedOrigins(allowedOrigins, []string{"10.0.0.50"}, port)
-	provider := func() []string { return nil }
+	staticOrigins := buildStaticAllowedOrigins(allowedOrigins, nil, port)
+	localIPsProvider := func() []string { return []string{"10.0.0.50"} }
+	customOriginsProvider := func() []string { return nil }
 
 	// Browser loading the bundled web UI from the device uses the device URL as Origin.
-	assert.True(t, isAllowedOrigin("http://10.0.0.50:7497", staticOrigins, provider, port, true, "websocket"))
-	assert.True(t, isAllowedOrigin("http://10.0.0.50:7497", staticOrigins, provider, port, false, "cors"))
+	assert.True(t, isAllowedOrigin(
+		"http://10.0.0.50:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, true, "websocket",
+	))
+	assert.True(t, isAllowedOrigin(
+		"http://10.0.0.50:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
 
 	// Native clients may omit Origin on WebSocket connections.
-	assert.True(t, isAllowedOrigin("", staticOrigins, provider, port, true, "websocket"))
+	assert.True(t, isAllowedOrigin("", staticOrigins, localIPsProvider, customOriginsProvider, port, true, "websocket"))
 
 	// The hosted app is trusted by default.
-	assert.True(t, isAllowedOrigin("https://zaparoo.app", staticOrigins, provider, port, true, "websocket"))
-	assert.True(t, isAllowedOrigin("https://zaparoo.app", staticOrigins, provider, port, false, "cors"))
+	assert.True(t, isAllowedOrigin(
+		"https://zaparoo.app", staticOrigins, localIPsProvider, customOriginsProvider, port, true, "websocket",
+	))
+	assert.True(t, isAllowedOrigin(
+		"https://zaparoo.app", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+}
+
+func TestOriginPolicy_DelayedLocalIPAvailability(t *testing.T) {
+	t.Parallel()
+
+	port := 7497
+	staticOrigins := buildStaticAllowedOrigins(allowedOrigins, nil, port)
+	localIPs := []string(nil)
+	localIPsProvider := func() []string { return localIPs }
+	customOriginsProvider := func() []string { return nil }
+
+	assert.False(t, isAllowedOrigin(
+		"http://192.168.1.50:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+
+	localIPs = []string{"192.168.1.50"}
+
+	assert.True(t, isAllowedOrigin(
+		"http://192.168.1.50:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+	assert.True(t, isAllowedOrigin(
+		"https://192.168.1.50:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, true, "websocket",
+	))
+	assert.False(t, isAllowedOrigin(
+		"http://192.168.1.51:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+	assert.False(t, isAllowedOrigin(
+		"http://192.168.1.50:8100", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
 }
 
 // TestServerBindFailureStopsService verifies that when the API server fails to bind
@@ -739,18 +780,21 @@ func TestIsAllowedOrigin_WebSocketHotReload(t *testing.T) {
 		"http://localhost:7497",
 	}
 	apiPort := 7497
+	localIPsProvider := func() []string { return nil }
 
 	// Mutable custom origins to simulate config reload
 	customOrigins := []string{"http://myapp.example.com"}
 	provider := func() []string { return customOrigins }
 
 	// Initial state: custom origin allowed
-	assert.True(t, isAllowedOrigin("http://myapp.example.com", staticOrigins, provider, apiPort, true, "websocket"))
 	assert.True(t, isAllowedOrigin(
-		"http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+		"http://myapp.example.com", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
+	))
+	assert.True(t, isAllowedOrigin(
+		"http://myapp.example.com:7497", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
 	))
 	assert.False(t, isAllowedOrigin(
-		"http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+		"http://other.example.com:7497", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
 	))
 
 	// Simulate config reload: change custom origins
@@ -758,16 +802,20 @@ func TestIsAllowedOrigin_WebSocketHotReload(t *testing.T) {
 
 	// Old custom origin should now be rejected (not private IP, not localhost)
 	assert.False(t, isAllowedOrigin(
-		"http://myapp.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+		"http://myapp.example.com:7497", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
 	))
 	// New custom origin should be allowed
-	assert.True(t, isAllowedOrigin("http://other.example.com", staticOrigins, provider, apiPort, true, "websocket"))
 	assert.True(t, isAllowedOrigin(
-		"http://other.example.com:7497", staticOrigins, provider, apiPort, true, "websocket",
+		"http://other.example.com", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
+	))
+	assert.True(t, isAllowedOrigin(
+		"http://other.example.com:7497", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
 	))
 
 	// Static origins should always work regardless of custom origins
-	assert.True(t, isAllowedOrigin("http://localhost:7497", staticOrigins, provider, apiPort, true, "websocket"))
+	assert.True(t, isAllowedOrigin(
+		"http://localhost:7497", staticOrigins, localIPsProvider, provider, apiPort, true, "websocket",
+	))
 }
 
 func TestMakeOriginValidator_HotReload(t *testing.T) {
@@ -781,9 +829,10 @@ func TestMakeOriginValidator_HotReload(t *testing.T) {
 
 	// Mutable custom origins to simulate config reload
 	customOrigins := []string{"myapp.local"}
+	localIPsProvider := func() []string { return nil }
 	provider := func() []string { return customOrigins }
 
-	validator := makeOriginValidator(staticOrigins, provider, port)
+	validator := makeOriginValidator(staticOrigins, localIPsProvider, provider, port)
 
 	// Static origins always work
 	assert.True(t, validator(nil, "http://localhost:7497"))
@@ -818,8 +867,9 @@ func TestMakeOriginValidator_RejectsImplicitLocalhostPorts(t *testing.T) {
 		"http://192.168.1.100:7497",
 	}
 	port := 7497
+	localIPsProvider := func() []string { return nil }
 	provider := func() []string { return nil }
-	validator := makeOriginValidator(staticOrigins, provider, port)
+	validator := makeOriginValidator(staticOrigins, localIPsProvider, provider, port)
 
 	tests := []struct {
 		name     string
@@ -892,8 +942,9 @@ func TestMakeOriginValidator_ExplicitCustomLocalhostPort(t *testing.T) {
 
 	staticOrigins := []string{"http://localhost:7497"}
 	customOrigins := []string{"http://localhost:8100", "127.0.0.1:8100"}
+	localIPsProvider := func() []string { return nil }
 	provider := func() []string { return customOrigins }
-	validator := makeOriginValidator(staticOrigins, provider, 7497)
+	validator := makeOriginValidator(staticOrigins, localIPsProvider, provider, 7497)
 
 	assert.True(t, validator(nil, "http://localhost:8100"))
 	assert.True(t, validator(nil, "http://127.0.0.1:8100"))


### PR DESCRIPTION
## Summary
- refresh local interface IP origins during CORS/WebSocket origin validation
- keep static built-in, localhost, mDNS, and hostname origins unchanged
- add regression coverage for delayed local IP availability

## Checks
- go test ./pkg/api/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CORS origin validation now dynamically uses current local interface IPs instead of relying on static startup-time configuration, improving reliability for local network access.

* **Tests**
  * Updated origin validation test coverage to include dynamic local IP scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->