### PR TITLE
fix(mister): reduce audio CPU load and clock healing spam

### DIFF
--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -374,6 +374,9 @@ func playPCMWithMalgo(ctx context.Context, samples [][2]float64, volume float64)
 	deviceConfig.Playback.Format = malgo.FormatF32
 	deviceConfig.Playback.Channels = 2
 	deviceConfig.SampleRate = targetSampleRate
+	// MiSTer has shown high CPU and core stutter when miniaudio uses ALSA mmap
+	// while other audio clients (for example mpg123 BGM) are active.
+	deviceConfig.Alsa.NoMMap = 1
 	// Larger period gives the audio thread headroom on CPU-constrained devices
 	// (e.g. MiSTer Cortex-A9 sharing CPU with a running core), where
 	// miniaudio's small default period underruns and produces audible crackle.

--- a/pkg/service/clock_monitor.go
+++ b/pkg/service/clock_monitor.go
@@ -47,8 +47,14 @@ func monitorClockAndHealTimestamps(ctx context.Context, db *database.Database, b
 		select {
 		case <-ticker.C:
 			now := time.Now()
+			wasReliableBeforeHeal := wasReliable
 			healed = healTimestampsIfClockReliable(db, bootUUID, now, wasReliable, healed, uptime.Get)
-			wasReliable = helpers.IsClockReliable(now)
+			isReliable := helpers.IsClockReliable(now)
+			// Keep the previous unreliable state when healing fails so the next tick
+			// can retry the same NTP transition. A successful zero-row heal marks done.
+			if !isReliable || healed || wasReliableBeforeHeal {
+				wasReliable = isReliable
+			}
 
 		case <-ctx.Done():
 			return
@@ -65,13 +71,11 @@ func healTimestampsIfClockReliable(
 	getUptime uptimeProvider,
 ) bool {
 	isReliable := helpers.IsClockReliable(now)
-	if !isReliable || healed {
+	if !isReliable || wasReliable || healed {
 		return healed
 	}
 
-	log.Info().
-		Bool("was_reliable", wasReliable).
-		Msg("clock is reliable, healing timestamps")
+	log.Info().Msg("clock became reliable (NTP sync detected), healing timestamps")
 
 	// Calculate true boot time: Current Time - System Uptime
 	systemUptime, err := getUptime()
@@ -90,10 +94,10 @@ func healTimestampsIfClockReliable(
 	rowsHealed, healErr := db.UserDB.HealTimestamps(bootUUID, trueBootTime)
 	if healErr != nil {
 		log.Error().Err(healErr).Msg("failed to heal timestamps")
-	} else if rowsHealed > 0 {
-		log.Info().Int64("rows", rowsHealed).Msg("successfully healed timestamps")
-		return true
+		return healed
 	}
-
-	return healed
+	if rowsHealed > 0 {
+		log.Info().Int64("rows", rowsHealed).Msg("successfully healed timestamps")
+	}
+	return true
 }

--- a/pkg/service/clock_monitor.go
+++ b/pkg/service/clock_monitor.go
@@ -31,7 +31,19 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type uptimeProvider func() (time.Duration, error)
+type (
+	uptimeProvider       func() (time.Duration, error)
+	clockReliabilityFunc func(time.Time) bool
+	timestampHealFunc    func(
+		db *database.Database,
+		bootUUID string,
+		now time.Time,
+		wasReliable bool,
+		healed bool,
+		getUptime uptimeProvider,
+		isClockReliable clockReliabilityFunc,
+	) bool
+)
 
 // monitorClockAndHealTimestamps monitors the system clock and heals timestamps when NTP syncs.
 // This is critical for MiSTer devices that boot without RTC and initially show 1970 epoch time.
@@ -40,16 +52,40 @@ func monitorClockAndHealTimestamps(ctx context.Context, db *database.Database, b
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
+	monitorClockAndHealTimestampsWithDeps(
+		ctx,
+		db,
+		bootUUID,
+		ticker.C,
+		time.Now,
+		helpers.IsClockReliable,
+		uptime.Get,
+		healTimestampsIfClockReliableWithDeps,
+	)
+}
+
+func monitorClockAndHealTimestampsWithDeps(
+	ctx context.Context,
+	db *database.Database,
+	bootUUID string,
+	ticks <-chan time.Time,
+	nowFunc func() time.Time,
+	isClockReliable clockReliabilityFunc,
+	getUptime uptimeProvider,
+	healFunc timestampHealFunc,
+) {
 	healed := false
-	wasReliable := helpers.IsClockReliable(time.Now())
+	wasReliable := isClockReliable(nowFunc())
 
 	for {
 		select {
-		case <-ticker.C:
-			now := time.Now()
+		case now, ok := <-ticks:
+			if !ok {
+				return
+			}
 			wasReliableBeforeHeal := wasReliable
-			healed = healTimestampsIfClockReliable(db, bootUUID, now, wasReliable, healed, uptime.Get)
-			isReliable := helpers.IsClockReliable(now)
+			healed = healFunc(db, bootUUID, now, wasReliable, healed, getUptime, isClockReliable)
+			isReliable := isClockReliable(now)
 			// Keep the previous unreliable state when healing fails so the next tick
 			// can retry the same NTP transition. A successful zero-row heal marks done.
 			if !isReliable || healed || wasReliableBeforeHeal {
@@ -70,7 +106,27 @@ func healTimestampsIfClockReliable(
 	healed bool,
 	getUptime uptimeProvider,
 ) bool {
-	isReliable := helpers.IsClockReliable(now)
+	return healTimestampsIfClockReliableWithDeps(
+		db,
+		bootUUID,
+		now,
+		wasReliable,
+		healed,
+		getUptime,
+		helpers.IsClockReliable,
+	)
+}
+
+func healTimestampsIfClockReliableWithDeps(
+	db *database.Database,
+	bootUUID string,
+	now time.Time,
+	wasReliable bool,
+	healed bool,
+	getUptime uptimeProvider,
+	isClockReliable clockReliabilityFunc,
+) bool {
+	isReliable := isClockReliable(now)
 	if !isReliable || wasReliable || healed {
 		return healed
 	}

--- a/pkg/service/clock_monitor_test.go
+++ b/pkg/service/clock_monitor_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -29,21 +30,90 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestHealTimestampsIfClockReliable_RetriesUntilRowsHealed(t *testing.T) {
+func TestHealTimestampsIfClockReliable_SkipsReliableStartup(t *testing.T) {
 	t.Parallel()
 
 	mockUserDB := &testhelpers.MockUserDBI{}
 	db := &database.Database{UserDB: mockUserDB}
-	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	reliableNow := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
+
+	assert.False(t, healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, true, false, fixedUptime))
+	mockUserDB.AssertNotCalled(t, "HealTimestamps", mock.Anything, mock.Anything)
+}
+
+func TestHealTimestampsIfClockReliable_HealsOnTransition(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+	reliableNow := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
+
+	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(3), nil).Once()
+
+	healed := healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, false, false, fixedUptime)
+	assert.True(t, healed)
+
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHealTimestampsIfClockReliable_ZeroRowsMarksHealed(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+	reliableNow := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
 	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
 
 	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(0), nil).Once()
-	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(3), nil).Once()
 
-	healed := healTimestampsIfClockReliable(db, "boot-uuid", now, false, false, fixedUptime)
+	healed := healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, false, false, fixedUptime)
+	assert.True(t, healed)
+
+	healed = healTimestampsIfClockReliable(db, "boot-uuid", reliableNow.Add(time.Minute), false, healed, fixedUptime)
+	assert.True(t, healed)
+
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHealTimestampsIfClockReliable_RetriesAfterDBError(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+	reliableNow := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	boom := errors.New("boom")
+	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
+
+	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(0), boom).Once()
+	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(1), nil).Once()
+
+	healed := healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, false, false, fixedUptime)
 	assert.False(t, healed)
 
-	healed = healTimestampsIfClockReliable(db, "boot-uuid", now.Add(time.Minute), true, healed, fixedUptime)
+	healed = healTimestampsIfClockReliable(db, "boot-uuid", reliableNow.Add(time.Minute), false, healed, fixedUptime)
+	assert.True(t, healed)
+
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHealTimestampsIfClockReliable_RetriesAfterUptimeError(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+	reliableNow := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	boom := errors.New("boom")
+	failedUptime := func() (time.Duration, error) { return 0, boom }
+	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
+
+	mockUserDB.On("HealTimestamps", "boot-uuid", mock.AnythingOfType("time.Time")).Return(int64(1), nil).Once()
+
+	healed := healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, false, false, failedUptime)
+	assert.False(t, healed)
+
+	healed = healTimestampsIfClockReliable(db, "boot-uuid", reliableNow.Add(time.Minute), false, healed, fixedUptime)
 	assert.True(t, healed)
 
 	mockUserDB.AssertExpectations(t)
@@ -59,6 +129,6 @@ func TestHealTimestampsIfClockReliable_SkipsUnreliableOrAlreadyHealed(t *testing
 	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
 
 	assert.False(t, healTimestampsIfClockReliable(db, "boot-uuid", unreliableNow, false, false, fixedUptime))
-	assert.True(t, healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, true, true, fixedUptime))
+	assert.True(t, healTimestampsIfClockReliable(db, "boot-uuid", reliableNow, false, true, fixedUptime))
 	mockUserDB.AssertNotCalled(t, "HealTimestamps", mock.Anything, mock.Anything)
 }

--- a/pkg/service/clock_monitor_test.go
+++ b/pkg/service/clock_monitor_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -28,7 +29,130 @@ import (
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
+
+type monitorHealCall struct {
+	now         time.Time
+	wasReliable bool
+	healed      bool
+}
+
+func TestMonitorClockAndHealTimestamps_TransitionState(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	fixedUptime := func() (time.Duration, error) { return 2 * time.Hour, nil }
+
+	tests := []struct {
+		name                string
+		ticks               []time.Time
+		reliabilitySequence []bool
+		healReturns         []bool
+		expectedCalls       []monitorHealCall
+	}{
+		{
+			name:                "reliable startup keeps reliable state",
+			ticks:               []time.Time{baseTime.Add(time.Minute)},
+			reliabilitySequence: []bool{true, true},
+			healReturns:         []bool{false},
+			expectedCalls: []monitorHealCall{
+				{now: baseTime.Add(time.Minute), wasReliable: true, healed: false},
+			},
+		},
+		{
+			name:                "unreliable to reliable transition marks healed on success",
+			ticks:               []time.Time{baseTime.Add(time.Minute)},
+			reliabilitySequence: []bool{false, true},
+			healReturns:         []bool{true},
+			expectedCalls: []monitorHealCall{
+				{now: baseTime.Add(time.Minute), wasReliable: false, healed: false},
+			},
+		},
+		{
+			name: "unreliable to reliable transition retries after failed heal",
+			ticks: []time.Time{
+				baseTime.Add(time.Minute),
+				baseTime.Add(2 * time.Minute),
+			},
+			reliabilitySequence: []bool{false, true, true},
+			healReturns:         []bool{false, true},
+			expectedCalls: []monitorHealCall{
+				{now: baseTime.Add(time.Minute), wasReliable: false, healed: false},
+				{now: baseTime.Add(2 * time.Minute), wasReliable: false, healed: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reliabilitySequence := append([]bool(nil), tt.reliabilitySequence...)
+			healReturns := append([]bool(nil), tt.healReturns...)
+			calls := make([]monitorHealCall, 0, len(tt.expectedCalls))
+			ticks := make(chan time.Time, len(tt.ticks))
+
+			isClockReliable := func(time.Time) bool {
+				require.NotEmpty(t, reliabilitySequence)
+				next := reliabilitySequence[0]
+				reliabilitySequence = reliabilitySequence[1:]
+				return next
+			}
+			healFunc := func(
+				_ *database.Database,
+				_ string,
+				now time.Time,
+				wasReliable bool,
+				healed bool,
+				getUptime uptimeProvider,
+				isReliable clockReliabilityFunc,
+			) bool {
+				require.NotNil(t, getUptime)
+				require.NotNil(t, isReliable)
+				require.NotEmpty(t, healReturns)
+				calls = append(calls, monitorHealCall{
+					now:         now,
+					wasReliable: wasReliable,
+					healed:      healed,
+				})
+				next := healReturns[0]
+				healReturns = healReturns[1:]
+				return next
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				monitorClockAndHealTimestampsWithDeps(
+					context.Background(),
+					&database.Database{},
+					"boot-uuid",
+					ticks,
+					func() time.Time { return baseTime },
+					isClockReliable,
+					fixedUptime,
+					healFunc,
+				)
+			}()
+
+			for _, tick := range tt.ticks {
+				ticks <- tick
+			}
+			close(ticks)
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("monitor did not stop after ticker channel closed")
+			}
+
+			assert.Equal(t, tt.expectedCalls, calls)
+			assert.Empty(t, reliabilitySequence)
+			assert.Empty(t, healReturns)
+		})
+	}
+}
 
 func TestHealTimestampsIfClockReliable_SkipsReliableStartup(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -493,6 +493,20 @@ preprocessing:
 			continue preprocessing
 		}
 
+		// If a scan arrives while the timeout is also ready, process the timeout
+		// first. Otherwise Go's random select order can confirm an expired token.
+		if stagedToken != nil && guardTimeout != nil {
+			select {
+			case <-guardTimeout:
+				log.Info().Msg("launch guard: staged token expired")
+				stagedToken = nil
+				guardTimeout = nil
+				guardDelay = nil
+				delayExpired = false
+			default:
+			}
+		}
+
 		// Clear stale staged token if media has stopped since staging
 		if stagedToken != nil && svc.State.ActiveMedia() == nil {
 			log.Info().Msg("launch guard: media stopped, clearing stale staged token")


### PR DESCRIPTION
## Summary
- restore ALSA no-mmap playback for malgo on MiSTer to avoid mmap-related CPU/stutter issues with concurrent audio clients
- stop timestamp healing from retrying every minute when the clock was already reliable or no rows needed healing
- add coverage for clock-healing transition, zero-row success, and retry-on-error behavior

Validated with `go test ./pkg/service/`, `go test ./pkg/audio/`, and `go test ./pkg/readers/pn532/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced audio playback stutter on certain hardware by disabling a problematic audio mode.
  * Fixed token launch-guard timing to ensure expired staged tokens are processed deterministically.

* **Refactor**
  * Reworked clock monitoring to use injected dependencies and clearer reliability/transition handling.

* **Tests**
  * Expanded and reorganized tests for clock/timestamp healing, covering transitions, retries, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->