### PR TITLE
fix(tui): prevent reader edit focus soft lock

### DIFF
--- a/pkg/ui/tui/page_frame.go
+++ b/pkg/ui/tui/page_frame.go
@@ -263,7 +263,7 @@ func (pf *PageFrame) Focus(delegate func(p tview.Primitive)) {
 	if pf.content != nil {
 		delegate(pf.content)
 	} else if pf.buttonBar != nil {
-		delegate(pf.buttonBar.GetFirstButton())
+		delegate(pf.buttonBar)
 	}
 }
 

--- a/pkg/ui/tui/page_frame_test.go
+++ b/pkg/ui/tui/page_frame_test.go
@@ -126,6 +126,24 @@ func TestPageFrame_FocusButtonBar(t *testing.T) {
 	frame.FocusButtonBar()
 }
 
+func TestPageFrame_FocusDelegatesToButtonBar(t *testing.T) {
+	t.Parallel()
+
+	app := tview.NewApplication()
+	frame := NewPageFrame(app)
+	buttonBar := NewButtonBar(app)
+	buttonBar.AddButton("Test", func() {})
+	frame.SetButtonBar(buttonBar)
+
+	var focused tview.Primitive
+	frame.Focus(func(p tview.Primitive) {
+		focused = p
+	})
+
+	assert.Same(t, buttonBar, focused)
+	assert.NotSame(t, buttonBar.GetFirstButton(), focused)
+}
+
 func TestPageFrame_Chaining(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -741,7 +741,7 @@ func buildReaderEditPage(
 	formContent.AddItem(idSourceInput, 1, 0, false)
 	formContent.AddItem(enabledDisplay, 1, 0, false)
 
-	focusOrder := []tview.Primitive{driverDisplay, pathInput, idSourceInput, enabledDisplay, buttonBar.GetFirstButton()}
+	focusOrder := []tview.Primitive{driverDisplay, pathInput, idSourceInput, enabledDisplay, buttonBar}
 
 	setFocus := func(idx int) {
 		if idx < 0 {

--- a/pkg/ui/tui/settings_components_test.go
+++ b/pkg/ui/tui/settings_components_test.go
@@ -22,6 +22,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -399,6 +400,24 @@ func TestButtonBar_GetFirstButton(t *testing.T) {
 	firstBtn := bb.GetFirstButton()
 	require.NotNil(t, firstBtn)
 	assert.Equal(t, "First", firstBtn.GetLabel())
+}
+
+func TestButtonBar_InputHandlerUsesBarFocus(t *testing.T) {
+	t.Parallel()
+
+	app := tview.NewApplication()
+	bb := NewButtonBar(app)
+	bb.AddButton("Save", func() {})
+	upCalled := false
+	bb.SetOnUp(func() {
+		upCalled = true
+	})
+
+	handler := bb.InputHandler()
+	require.NotNil(t, handler)
+	handler(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone), func(tview.Primitive) {})
+
+	assert.True(t, upCalled)
 }
 
 func TestButtonBar_ChainedMethods(t *testing.T) {

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	testingmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -326,6 +328,43 @@ func TestBuildReadersSettingsMenu_ScanModeOptions(t *testing.T) {
 
 	// Verify scan mode displays Tap
 	assert.True(t, runner.ContainsText("Tap"), "Tap mode should be visible")
+}
+
+func TestBuildReaderEditPage_DownFromEnabledFocusesButtonBar(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+
+	pages := tview.NewPages()
+	cfg := &config.Instance{}
+	mockSvc := NewMockSettingsService()
+	mockReader := testingmocks.NewMockReader()
+	mockReader.SetupBasicMock()
+	mockPlatform := testingmocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", cfg).Return([]readers.Reader{mockReader})
+	configuredReaders := []models.ReaderConnection{}
+
+	runner.Start(pages)
+	runner.Draw()
+
+	runner.QueueUpdateDraw(func() {
+		buildReaderEditPage(cfg, mockSvc, pages, runner.App(), mockPlatform, &configuredReaders, 0)
+	})
+
+	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond), "Reader edit page should appear")
+
+	runner.SimulateArrowDown()
+	runner.SimulateArrowDown()
+	runner.SimulateArrowDown()
+	runner.SimulateArrowDown()
+
+	focused := runner.App().GetFocus()
+	_, focusedButtonBar := focused.(*ButtonBar)
+	_, focusedInternalButton := focused.(*tview.Button)
+	assert.True(t, focusedButtonBar, "Down from Enabled should focus the ButtonBar")
+	assert.False(t, focusedInternalButton, "Down from Enabled should not focus an internal button")
+	mockPlatform.AssertExpectations(t)
 }
 
 func TestBuildAdvancedSettingsMenu_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary
- focus the reader edit footer ButtonBar instead of its internal first button
- make PageFrame fallback focus target the ButtonBar primitive
- add regressions for ButtonBar/PageFrame focus handling

## Validation
- go test ./pkg/ui/tui/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus navigation: when a page has no main content, focus now goes to the button bar as a whole, and settings forms move focus to the button bar in the expected sequence.

* **Tests**
  * Added unit and integration tests to verify focus behavior and button-bar input handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->