### PR TITLE
fix(mister): launch 3DO CHD with correct MGL slot

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -103,11 +103,11 @@ var Systems = map[string]Core{
 		RBF: "_Console/3DO",
 		Slots: []Slot{
 			{
-				Exts: []string{".iso", ".cue"},
+				Exts: []string{".iso", ".cue", ".chd"},
 				Mgl: &MGLParams{
 					Delay:  1,
 					Method: "s",
-					Index:  1,
+					Index:  0,
 				},
 			},
 		},

--- a/pkg/platforms/mister/cores/cores_test.go
+++ b/pkg/platforms/mister/cores/cores_test.go
@@ -67,6 +67,16 @@ func TestPathToMGLDef(t *testing.T) {
 			wantMgl:  Systems["Nintendo64"].Slots[0].Mgl,
 		},
 		{
+			name:     "3DO CHD disk slot",
+			systemID: "3DO",
+			path:     "Need for Speed.chd",
+			wantMgl: &MGLParams{
+				Delay:  1,
+				Method: "s",
+				Index:  0,
+			},
+		},
+		{
 			name:     "Nil MGL allowed (Arcade .mra)",
 			systemID: "Arcade",
 			path:     "maze_game.mra",

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -263,11 +263,33 @@ func TestGenerateMgl(t *testing.T) {
 					},
 				},
 			},
-			path: "/media/fat/games/Saturn/America/NiGHTS into Dreams... (USA, Brazil).chd",
+			path: filepath.Join("/", "media", "fat", "games", "Saturn", "America", "NiGHTS into Dreams... (USA, Brazil).chd"),
 			want: "<mistergamedescription>\n\t<rbf>_Console/Saturn</rbf>\n" +
 				"\t<file delay=\"2\" type=\"s\" index=\"0\" " +
 				"path=\"../../../../../media/fat/games/Saturn/America/" +
 				"NiGHTS into Dreams... (USA, Brazil).chd\"/>\n" +
+				"</mistergamedescription>",
+		},
+		{
+			name: "3DO CHD uses disk slot zero",
+			core: &cores.Core{
+				ID:  "3DO",
+				RBF: "_Console/3DO",
+				Slots: []cores.Slot{
+					{
+						Exts: []string{".iso", ".cue", ".chd"},
+						Mgl: &cores.MGLParams{
+							Delay:  1,
+							Method: "s",
+							Index:  0,
+						},
+					},
+				},
+			},
+			path: filepath.Join("/", "media", "fat", "games", "3DO", "The Need for Speed.chd"),
+			want: "<mistergamedescription>\n\t<rbf>_Console/3DO</rbf>\n" +
+				"\t<file delay=\"1\" type=\"s\" index=\"0\" " +
+				"path=\"../../../../../media/fat/games/3DO/The Need for Speed.chd\"/>\n" +
 				"</mistergamedescription>",
 		},
 		{

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -263,7 +263,10 @@ func TestGenerateMgl(t *testing.T) {
 					},
 				},
 			},
-			path: filepath.Join("/", "media", "fat", "games", "Saturn", "America", "NiGHTS into Dreams... (USA, Brazil).chd"),
+			path: filepath.Join(
+				string(filepath.Separator),
+				"media", "fat", "games", "Saturn", "America", "NiGHTS into Dreams... (USA, Brazil).chd",
+			),
 			want: "<mistergamedescription>\n\t<rbf>_Console/Saturn</rbf>\n" +
 				"\t<file delay=\"2\" type=\"s\" index=\"0\" " +
 				"path=\"../../../../../media/fat/games/Saturn/America/" +
@@ -286,7 +289,10 @@ func TestGenerateMgl(t *testing.T) {
 					},
 				},
 			},
-			path: filepath.Join("/", "media", "fat", "games", "3DO", "The Need for Speed.chd"),
+			path: filepath.Join(
+				string(filepath.Separator),
+				"media", "fat", "games", "3DO", "The Need for Speed.chd",
+			),
 			want: "<mistergamedescription>\n\t<rbf>_Console/3DO</rbf>\n" +
 				"\t<file delay=\"1\" type=\"s\" index=\"0\" " +
 				"path=\"../../../../../media/fat/games/3DO/The Need for Speed.chd\"/>\n" +


### PR DESCRIPTION
## Summary
- add .chd to the MiSTer 3DO generated-MGL slot
- change the 3DO disk slot index to 0 to match the core S0 mount slot
- add regression coverage for 3DO CHD MGL params and generated MGL output

Validated with `go test ./pkg/platforms/mister/cores ./pkg/platforms/mister/mgls`.

Fixes #805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 3DO system now supports `.chd` disk image format alongside existing `.iso` and `.cue` formats

* **Tests**
  * Added regression test coverage for 3DO `.chd` disk images
  * Improved test path construction for better cross-platform reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->