### PR TITLE
fix(mister): add RA set names to launchers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/ZaparooProject/go-pn532 v0.22.1
-	github.com/ZaparooProject/go-zapscript v0.8.0
+	github.com/ZaparooProject/go-zapscript v0.9.1
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0
 	github.com/bendahl/uinput v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,10 @@ github.com/ZaparooProject/go-zapscript v0.7.2 h1:BCNwi+9JGjOoxWVq0G0+B/uDqVcZ7wH
 github.com/ZaparooProject/go-zapscript v0.7.2/go.mod h1:P5qov6iCMzYiSF3tqr8BAanvNNh/YjPuUENfmPo6Yj4=
 github.com/ZaparooProject/go-zapscript v0.8.0 h1:fVmayGKJYff2bLkAtjE06gEEv+RpriQTexW2pvztfYY=
 github.com/ZaparooProject/go-zapscript v0.8.0/go.mod h1:Z3rFyQq/GA+ESpYUtCOA/2Xyftbygv4MfDCajOVDmag=
+github.com/ZaparooProject/go-zapscript v0.9.0 h1:9g7cwKorAjfWeoaJNlwrUS41E7QGZmtfkYW8qtxQl+U=
+github.com/ZaparooProject/go-zapscript v0.9.0/go.mod h1:Z3rFyQq/GA+ESpYUtCOA/2Xyftbygv4MfDCajOVDmag=
+github.com/ZaparooProject/go-zapscript v0.9.1 h1:ItO50ZbKePoK8WBbxt/OSlt+BhpBKwi6x3hNaXTFmjk=
+github.com/ZaparooProject/go-zapscript v0.9.1/go.mod h1:Z3rFyQq/GA+ESpYUtCOA/2Xyftbygv4MfDCajOVDmag=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/andygrunwald/vdf v1.1.0 h1:gmstp0R7DOepIZvWoSJY97ix7QOrsxpGPU6KusKXqvw=

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -124,7 +124,7 @@ func launch(
 
 		path = checkInZip(path)
 
-		if opts != nil && opts.SetName != "" {
+		if opts != nil && (opts.SetName != "" || opts.SetNameSameDir != "") {
 			sn := *s
 			if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
 				return nil, setNameErr
@@ -282,20 +282,27 @@ func parseSetNameSameDir(value string) (bool, error) {
 }
 
 func applySetNameOptions(core *cores.Core, opts *platforms.LaunchOptions) error {
-	if opts == nil || opts.SetName == "" {
+	if opts == nil {
 		return nil
 	}
-	if !validSetName(opts.SetName) {
-		return fmt.Errorf("invalid set_name %q", opts.SetName)
-	}
 
-	core.SetName = opts.SetName
-	core.SetNameSameDir = false
+	var sameDir bool
 	if opts.SetNameSameDir != "" {
-		sameDir, err := parseSetNameSameDir(opts.SetNameSameDir)
+		var err error
+		sameDir, err = parseSetNameSameDir(opts.SetNameSameDir)
 		if err != nil {
 			return err
 		}
+	}
+
+	if opts.SetName != "" {
+		if !validSetName(opts.SetName) {
+			return fmt.Errorf("invalid set_name %q", opts.SetName)
+		}
+		core.SetName = opts.SetName
+		core.SetNameSameDir = false
+	}
+	if opts.SetNameSameDir != "" {
 		core.SetNameSameDir = sameDir
 	}
 	return nil

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -98,7 +98,7 @@ func checkInZip(path string) string {
 func launch(
 	pl platforms.Platform, coreID string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-	return func(cfg *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		// Close console if needed - FPGA cores take over display
 		if err := pl.ConsoleManager().Close(); err != nil {
 			log.Warn().Err(err).Msg("failed to close console before FPGA launch")
@@ -123,6 +123,14 @@ func launch(
 		}
 
 		path = checkInZip(path)
+
+		if opts != nil && opts.SetName != "" {
+			sn := *s
+			if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+				return nil, setNameErr
+			}
+			s = &sn
+		}
 
 		err = mgls.LaunchGame(cfg, s, path)
 		if err != nil {
@@ -170,7 +178,7 @@ func launchSinden(
 	systemID string,
 	rbfName string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-	return func(cfg *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore(systemID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get system %s: %w", systemID, err)
@@ -195,6 +203,9 @@ func launchSinden(
 
 		sn.SetName = rbfName + "_Sinden"
 		sn.SetNameSameDir = true
+		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+			return nil, setNameErr
+		}
 
 		log.Debug().Str("rbf", sn.RBF).Msgf("launching Sinden: %v", sn)
 
@@ -243,15 +254,125 @@ func launchAggGnw(cfg *config.Instance, path string, _ *platforms.LaunchOptions)
 	return nil, nil //nolint:nilnil // MiSTer launches don't return a process handle
 }
 
+func validSetName(name string) bool {
+	if name == "" || len(name) > 31 {
+		return false
+	}
+	for i, r := range name {
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		if i > 0 && (r == '_' || r == '-' || r == ' ') {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func parseSetNameSameDir(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true, nil
+	case "0", "f", "false", "n", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid set_name_same_dir value %q", value)
+	}
+}
+
+func applySetNameOptions(core *cores.Core, opts *platforms.LaunchOptions) error {
+	if opts == nil || opts.SetName == "" {
+		return nil
+	}
+	if !validSetName(opts.SetName) {
+		return fmt.Errorf("invalid set_name %q", opts.SetName)
+	}
+
+	core.SetName = opts.SetName
+	core.SetNameSameDir = false
+	if opts.SetNameSameDir != "" {
+		sameDir, err := parseSetNameSameDir(opts.SetNameSameDir)
+		if err != nil {
+			return err
+		}
+		core.SetNameSameDir = sameDir
+	}
+	return nil
+}
+
 func launchAltCore(
 	launcherID string,
 	systemID string,
 	rbfPath string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return launchAltCoreWithDefaultSetName(launcherID, systemID, rbfPath, "")
+}
+
+func launchAltCoreWithSetName(
+	launcherID string,
+	systemID string,
+	rbfPath string,
+	setName string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return launchAltCoreWithDefaultSetName(launcherID, systemID, rbfPath, setName)
+}
+
+func retroAchievementsSetName(launcherID string) (string, bool) {
+	switch launcherID {
+	case "RAAtari7800":
+		return "RA_Atari7800", true
+	case "RAGameboy":
+		return "RA_Gameboy", true
+	case "RAGBA":
+		return "RA_GBA", true
+	case "RAMegaCD":
+		return "RA_MegaCD", true
+	case "RAMegaDrive":
+		return "RA_MegaDrive", true
+	case "RANeoGeo":
+		return "RA_NeoGeo", true
+	case "RANES":
+		return "RA_NES", true
+	case "RANintendo64":
+		return "RA_N64", true
+	case "RAPSX":
+		return "RA_PSX", true
+	case "RAS32X":
+		return "RA_S32X", true
+	case "RASMS":
+		return "RA_SMS", true
+	case "RASNES":
+		return "RA_SNES", true
+	case "RATurboGrafx16":
+		return "RA_TurboGrafx16", true
+	default:
+		return "", false
+	}
+}
+
+func launchRetroAchievementsCore(
+	launcherID string,
+	systemID string,
+	rbfPath string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	setName, ok := retroAchievementsSetName(launcherID)
+	if !ok {
+		log.Warn().Str("launcher", launcherID).Msg("missing RetroAchievements set name")
+	}
+	return launchAltCoreWithSetName(launcherID, systemID, rbfPath, setName)
+}
+
+func launchAltCoreWithDefaultSetName(
+	launcherID string,
+	systemID string,
+	rbfPath string,
+	setName string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 	// Register alt core during launcher creation
 	cores.GlobalRBFCache.RegisterAltCore(launcherID, rbfPath)
 
-	return func(cfg *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore(systemID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get system %s: %w", systemID, err)
@@ -261,6 +382,13 @@ func launchAltCore(
 		sn := *s
 		sn.LauncherID = launcherID
 		sn.RBF = rbfPath
+		if setName != "" {
+			sn.SetName = setName
+			sn.SetNameSameDir = true
+		}
+		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+			return nil, setNameErr
+		}
 
 		log.Debug().Str("rbf", sn.RBF).Str("launcher", launcherID).Msgf("launching alt core: %v", sn)
 
@@ -349,7 +477,7 @@ func launchDOS() func(*config.Instance, string, *platforms.LaunchOptions) (*os.P
 }
 
 func launchAtari2600() func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-	return func(cfg *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore("Atari2600")
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Atari2600 system: %w", err)
@@ -357,6 +485,9 @@ func launchAtari2600() func(*config.Instance, string, *platforms.LaunchOptions) 
 		path = checkInZip(path)
 
 		sn := *s
+		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+			return nil, setNameErr
+		}
 		sn.Slots = []cores.Slot{
 			{
 				Exts: []string{".a26", ".bin"},
@@ -690,7 +821,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAAtari7800",
 			SystemID: systemdefs.SystemAtari7800,
-			Launch:   launchAltCore("RAAtari7800", systemdefs.SystemAtari7800, "_RA_Cores/Cores/Atari7800"),
+			Launch: launchRetroAchievementsCore(
+				"RAAtari7800", systemdefs.SystemAtari7800, "_RA_Cores/Cores/Atari7800",
+			),
 		},
 		{
 			ID:         systemdefs.SystemAtariLynx,
@@ -763,7 +896,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAGameboy",
 			SystemID: systemdefs.SystemGameboy,
-			Launch:   launchAltCore("RAGameboy", systemdefs.SystemGameboy, "_RA_Cores/Cores/Gameboy"),
+			Launch: launchRetroAchievementsCore(
+				"RAGameboy", systemdefs.SystemGameboy, "_RA_Cores/Cores/Gameboy",
+			),
 		},
 		{
 			ID:         systemdefs.SystemGameboyColor,
@@ -815,7 +950,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAGBA",
 			SystemID: systemdefs.SystemGBA,
-			Launch:   launchAltCore("RAGBA", systemdefs.SystemGBA, "_RA_Cores/Cores/GBA"),
+			Launch:   launchRetroAchievementsCore("RAGBA", systemdefs.SystemGBA, "_RA_Cores/Cores/GBA"),
 		},
 		{
 			ID:         systemdefs.SystemGBA2P,
@@ -849,7 +984,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAMegaDrive",
 			SystemID: systemdefs.SystemGenesis,
-			Launch:   launchAltCore("RAMegaDrive", systemdefs.SystemGenesis, "_RA_Cores/Cores/MegaDrive"),
+			Launch: launchRetroAchievementsCore(
+				"RAMegaDrive", systemdefs.SystemGenesis, "_RA_Cores/Cores/MegaDrive",
+			),
 		},
 		{
 			ID:         systemdefs.SystemIntellivision,
@@ -897,7 +1034,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RASMS",
 			SystemID: systemdefs.SystemMasterSystem,
-			Launch:   launchAltCore("RASMS", systemdefs.SystemMasterSystem, "_RA_Cores/Cores/SMS"),
+			Launch: launchRetroAchievementsCore(
+				"RASMS", systemdefs.SystemMasterSystem, "_RA_Cores/Cores/SMS",
+			),
 		},
 		{
 			ID:         systemdefs.SystemMegaCD,
@@ -919,7 +1058,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAMegaCD",
 			SystemID: systemdefs.SystemMegaCD,
-			Launch:   launchAltCore("RAMegaCD", systemdefs.SystemMegaCD, "_RA_Cores/Cores/MegaCD"),
+			Launch: launchRetroAchievementsCore(
+				"RAMegaCD", systemdefs.SystemMegaCD, "_RA_Cores/Cores/MegaCD",
+			),
 		},
 		{
 			ID:         systemdefs.SystemMegaDuck,
@@ -936,7 +1077,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RANeoGeo",
 			SystemID: systemdefs.SystemNeoGeo,
-			Launch:   launchAltCore("RANeoGeo", systemdefs.SystemNeoGeo, "_RA_Cores/Cores/NeoGeo"),
+			Launch: launchRetroAchievementsCore(
+				"RANeoGeo", systemdefs.SystemNeoGeo, "_RA_Cores/Cores/NeoGeo",
+			),
 		},
 		{
 			ID:         systemdefs.SystemNeoGeoCD,
@@ -986,7 +1129,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RANES",
 			SystemID: systemdefs.SystemNES,
-			Launch:   launchAltCore("RANES", systemdefs.SystemNES, "_RA_Cores/Cores/NES"),
+			Launch:   launchRetroAchievementsCore("RANES", systemdefs.SystemNES, "_RA_Cores/Cores/NES"),
 		},
 		{
 			ID:         systemdefs.SystemNintendo64,
@@ -1025,7 +1168,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RANintendo64",
 			SystemID: systemdefs.SystemNintendo64,
-			Launch:   launchAltCore("RANintendo64", systemdefs.SystemNintendo64, "_RA_Cores/Cores/N64"),
+			Launch: launchRetroAchievementsCore(
+				"RANintendo64", systemdefs.SystemNintendo64, "_RA_Cores/Cores/N64",
+			),
 		},
 		{
 			ID:         systemdefs.SystemOdyssey2,
@@ -1088,7 +1233,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchAltCore("RAPSX", systemdefs.SystemPSX, "_RA_Cores/Cores/PSX"),
+			Launch:   launchRetroAchievementsCore("RAPSX", systemdefs.SystemPSX, "_RA_Cores/Cores/PSX"),
 		},
 		{
 			ID:         systemdefs.SystemSega32X,
@@ -1105,7 +1250,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RAS32X",
 			SystemID: systemdefs.SystemSega32X,
-			Launch:   launchAltCore("RAS32X", systemdefs.SystemSega32X, "_RA_Cores/Cores/S32X"),
+			Launch: launchRetroAchievementsCore(
+				"RAS32X", systemdefs.SystemSega32X, "_RA_Cores/Cores/S32X",
+			),
 		},
 		{
 			ID:         systemdefs.SystemSG1000,
@@ -1170,7 +1317,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RASNES",
 			SystemID: systemdefs.SystemSNES,
-			Launch:   launchAltCore("RASNES", systemdefs.SystemSNES, "_RA_Cores/Cores/SNES"),
+			Launch:   launchRetroAchievementsCore("RASNES", systemdefs.SystemSNES, "_RA_Cores/Cores/SNES"),
 		},
 		{
 			ID:       "SindenSNES",
@@ -1211,7 +1358,9 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "RATurboGrafx16",
 			SystemID: systemdefs.SystemTurboGrafx16,
-			Launch:   launchAltCore("RATurboGrafx16", systemdefs.SystemTurboGrafx16, "_RA_Cores/Cores/TurboGrafx16"),
+			Launch: launchRetroAchievementsCore(
+				"RATurboGrafx16", systemdefs.SystemTurboGrafx16, "_RA_Cores/Cores/TurboGrafx16",
+			),
 		},
 		{
 			ID:         systemdefs.SystemTurboGrafx16CD,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -573,6 +573,28 @@ func TestSetNameOptions(t *testing.T) {
 		assert.False(t, core.SetNameSameDir)
 	})
 
+	t.Run("same dir only updates existing set name", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{SetName: "ExistingName"}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{SetNameSameDir: "yes"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ExistingName", core.SetName)
+		assert.True(t, core.SetNameSameDir)
+	})
+
+	t.Run("same dir only can disable existing same dir", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{SetName: "ExistingName", SetNameSameDir: true}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{SetNameSameDir: "no"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "ExistingName", core.SetName)
+		assert.False(t, core.SetNameSameDir)
+	})
+
 	t.Run("invalid same dir", func(t *testing.T) {
 		t.Parallel()
 
@@ -581,6 +603,15 @@ func TestSetNameOptions(t *testing.T) {
 			SetName:        "CustomNES",
 			SetNameSameDir: "maybe",
 		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("invalid same dir without set name", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{SetName: "ExistingName"}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{SetNameSameDir: "maybe"})
 
 		require.Error(t, err)
 	})

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -512,6 +513,86 @@ func TestDualRAMLaunchersExist(t *testing.T) {
 				"%s must inherit slots from %s", tc.id, tc.systemID)
 		})
 	}
+}
+
+func TestRetroAchievementsSetNameMapping(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"RANES":          "RA_NES",
+		"RASNES":         "RA_SNES",
+		"RAGameboy":      "RA_Gameboy",
+		"RAGBA":          "RA_GBA",
+		"RANintendo64":   "RA_N64",
+		"RAPSX":          "RA_PSX",
+		"RAMegaDrive":    "RA_MegaDrive",
+		"RAMegaCD":       "RA_MegaCD",
+		"RASMS":          "RA_SMS",
+		"RANeoGeo":       "RA_NeoGeo",
+		"RATurboGrafx16": "RA_TurboGrafx16",
+		"RAAtari7800":    "RA_Atari7800",
+		"RAS32X":         "RA_S32X",
+	}
+
+	for launcherID, want := range cases {
+		t.Run(launcherID, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := retroAchievementsSetName(launcherID)
+			require.True(t, ok)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestSetNameOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid explicit same dir", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{
+			SetName:        "Custom_NES",
+			SetNameSameDir: "yes",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Custom_NES", core.SetName)
+		assert.True(t, core.SetNameSameDir)
+	})
+
+	t.Run("omitted same dir defaults false", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{SetNameSameDir: true}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{SetName: "CustomNES"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "CustomNES", core.SetName)
+		assert.False(t, core.SetNameSameDir)
+	})
+
+	t.Run("invalid same dir", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{
+			SetName:        "CustomNES",
+			SetNameSameDir: "maybe",
+		})
+
+		require.Error(t, err)
+	})
+
+	t.Run("invalid set name", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{}
+		err := applySetNameOptions(&core, &platforms.LaunchOptions{SetName: "../NES"})
+
+		require.Error(t, err)
+	})
 }
 
 func TestRetroAchievementsLaunchersExist(t *testing.T) {

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -95,7 +95,7 @@ func GenerateMgl(core *cores.Core, rbfPath, path, override string) (string, erro
 			sameDir = " same_dir=\"1\""
 		}
 
-		mgl += fmt.Sprintf("\t<setname%s>%s</setname>\n", sameDir, core.SetName)
+		mgl += fmt.Sprintf("\t<setname%s>%s</setname>\n", sameDir, xmlEscapeAttr(core.SetName))
 	}
 
 	if path == "" {

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -188,6 +188,17 @@ func TestGenerateMgl(t *testing.T) {
 				"\t<setname>FDS</setname>\n</mistergamedescription>",
 		},
 		{
+			name: "core with escaped setname",
+			core: &cores.Core{
+				ID:      "Custom",
+				SetName: "A&B",
+				RBF:     "_Console/NES",
+			},
+			path: "",
+			want: "<mistergamedescription>\n\t<rbf>_Console/NES</rbf>\n" +
+				"\t<setname>A&amp;B</setname>\n</mistergamedescription>",
+		},
+		{
 			name: "core with setname and same_dir",
 			core: &cores.Core{
 				ID:             "Atari2600",

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -187,6 +187,13 @@ type LaunchOptions struct {
 	// - "" or "run": Default behavior (launch/play the media)
 	// - "details": Show media details/info page instead of launching
 	Action string
+	// SetName specifies a platform-defined launch profile/core name override.
+	// On MiSTer this maps to the MGL <setname> tag.
+	SetName string
+	// SetNameSameDir is a raw optional platform-defined flag controlling whether
+	// SetName should keep the original game directory. On MiSTer this maps to the
+	// MGL setname same_dir attribute. Unsupported platforms may ignore it.
+	SetNameSameDir string
 }
 
 // Launcher defines how a platform launcher can launch media and what media it

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -311,10 +311,16 @@ func getLaunchClosure(
 	return func(path string) error {
 		launcherID := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
 		action := env.Cmd.AdvArgs.Get(zapscript.KeyAction)
+		setName := env.Cmd.AdvArgs.Get(zapscript.KeySetName)
+		setNameSameDir := env.Cmd.AdvArgs.Get(zapscript.KeySetNameSameDir)
 
 		var opts *platforms.LaunchOptions
-		if action != "" {
-			opts = &platforms.LaunchOptions{Action: action}
+		if action != "" || setName != "" || setNameSameDir != "" {
+			opts = &platforms.LaunchOptions{
+				Action:         action,
+				SetName:        setName,
+				SetNameSameDir: setNameSameDir,
+			}
 		}
 
 		if launcherID != "" {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -161,6 +161,42 @@ launcher = "genesis-default"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdLaunch_SetNameArgsPassedThrough(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	absPath := filepath.Join(t.TempDir(), "game.nes")
+
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+	mockPlatform.On("LaunchMedia", cfg, absPath,
+		(*platforms.Launcher)(nil), (*database.Database)(nil),
+		mock.MatchedBy(func(opts *platforms.LaunchOptions) bool {
+			return opts != nil &&
+				opts.SetName == "RA_NES" &&
+				opts.SetNameSameDir == "notabool" &&
+				opts.Action == ""
+		})).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{absPath},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				"set_name":          "RA_NES",
+				"set_name_same_dir": "notabool",
+			}),
+		},
+		Cfg: cfg,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
 // TestCmdLaunch_InvalidSystemArgReturnsError verifies invalid system returns validation error
 func TestCmdLaunch_InvalidSystemArgReturnsError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- add set_name/set_name_same_dir launch option pass-through using go-zapscript v0.9.1
- generate RA_* setname same_dir=1 for MiSTer RetroAchievements launchers
- validate MiSTer set_name values and escape generated setname XML

## Test
- go test ./pkg/zapscript/ ./pkg/platforms/mister/...
- golangci-lint run ./pkg/platforms/mister/... ./pkg/zapscript

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added set-name configuration for MiSTer launch profiles with validation and an option to treat set names as same-directory profiles.
  * Set-name arguments from launch commands are now honored and forwarded to launchers.

* **Bug Fixes**
  * Properly escape XML-reserved characters when emitting MGL set-name elements.

* **Tests**
  * Added tests covering set-name mapping, option handling, XML escaping, and argument pass-through.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->