### PR TITLE
perf(scraper): speed up gamelist scrape progress and writes

### DIFF
--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -311,9 +311,9 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	scraperID := params.ScraperID
 	db.MediaDB.TrackBackgroundOperation()
 	go func() {
-		defer db.MediaDB.BackgroundOperationDone()
-		defer cancelFunc()
 		defer scrapingStatusInstance.clearIfOwner(scraperID)
+		defer cancelFunc()
+		defer db.MediaDB.BackgroundOperationDone()
 
 		var receivedDone bool
 		for update := range ch {

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -22,6 +22,7 @@ package methods
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -37,8 +38,18 @@ import (
 // scrapingStatus tracks the lifecycle of an active media.scrape operation.
 // It mirrors the indexingStatus pattern in media.go for consistent state
 // management and safe concurrent access.
+const scrapeTotalScrapedRefreshInterval = 5 * time.Second
+
+type scrapedCountCache struct {
+	lastRefresh time.Time
+	scraperID   string
+	count       int
+	valid       bool
+}
+
 type scrapingStatus struct {
 	cancelFunc context.CancelFunc
+	countCache scrapedCountCache
 	scraperID  string
 	latest     models.ScrapingStatusResponse
 	mu         syncutil.RWMutex
@@ -53,6 +64,7 @@ func (s *scrapingStatus) startIfNotRunning(scraperID string) bool {
 	}
 	s.running = true
 	s.scraperID = scraperID
+	s.countCache = scrapedCountCache{}
 	s.latest = models.ScrapingStatusResponse{
 		ScraperID: scraperID,
 		Scraping:  true,
@@ -67,6 +79,7 @@ func (s *scrapingStatus) clear() {
 	s.scraperID = ""
 	s.cancelFunc = nil
 	s.latest = models.ScrapingStatusResponse{}
+	s.countCache = scrapedCountCache{}
 }
 
 // clearIfOwner clears state only when the caller's scraperID matches the stored one.
@@ -124,6 +137,41 @@ func (s *scrapingStatus) isRunning() bool {
 	return s.running
 }
 
+func (s *scrapingStatus) getFreshCountCache(scraperID string, now time.Time) (int, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.countCache.valid || s.countCache.scraperID != scraperID {
+		return 0, false
+	}
+	if now.Sub(s.countCache.lastRefresh) >= scrapeTotalScrapedRefreshInterval {
+		return 0, false
+	}
+	return s.countCache.count, true
+}
+
+func (s *scrapingStatus) getAnyCountCache(scraperID string) (int, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.countCache.valid || s.countCache.scraperID != scraperID {
+		return 0, false
+	}
+	return s.countCache.count, true
+}
+
+func (s *scrapingStatus) updateCountCache(scraperID string, count int, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.countCache.valid && s.countCache.scraperID == scraperID && count < s.countCache.count {
+		count = s.countCache.count
+	}
+	s.countCache = scrapedCountCache{
+		scraperID:   scraperID,
+		count:       count,
+		lastRefresh: now,
+		valid:       true,
+	}
+}
+
 func publishScrapingStatus(ns chan<- models.Notification, status *models.ScrapingStatusResponse) {
 	scrapingStatusInstance.setLatest(status)
 	notifications.MediaScraping(ns, status)
@@ -134,24 +182,65 @@ func populateScrapedMediaCount(
 	db *database.Database,
 	status *models.ScrapingStatusResponse,
 ) {
-	if db == nil || db.MediaDB == nil {
+	populateScrapedMediaCountExact(ctx, db, status)
+}
+
+func populateScrapedMediaCountExact(
+	ctx context.Context,
+	db *database.Database,
+	status *models.ScrapingStatusResponse,
+) {
+	count, ok := queryScrapedMediaCount(ctx, db, status.ScraperID)
+	if !ok {
 		return
+	}
+	status.TotalScraped = count
+	scrapingStatusInstance.updateCountCache(status.ScraperID, count, time.Now())
+}
+
+func populateScrapedMediaCountCached(
+	ctx context.Context,
+	db *database.Database,
+	status *models.ScrapingStatusResponse,
+) {
+	if cached, ok := scrapingStatusInstance.getFreshCountCache(status.ScraperID, time.Now()); ok {
+		status.TotalScraped = cached
+		return
+	}
+
+	count, ok := queryScrapedMediaCount(ctx, db, status.ScraperID)
+	if !ok {
+		if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK {
+			status.TotalScraped = cached
+		}
+		return
+	}
+	if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK && count < cached {
+		count = cached
+	}
+	status.TotalScraped = count
+	scrapingStatusInstance.updateCountCache(status.ScraperID, count, time.Now())
+}
+
+func queryScrapedMediaCount(ctx context.Context, db *database.Database, scraperID string) (int, bool) {
+	if db == nil || db.MediaDB == nil {
+		return 0, false
 	}
 
 	var (
 		count int
 		err   error
 	)
-	if status.ScraperID != "" {
-		count, err = db.MediaDB.GetScrapedMediaCount(ctx, status.ScraperID)
+	if scraperID != "" {
+		count, err = db.MediaDB.GetScrapedMediaCount(ctx, scraperID)
 	} else {
 		count, err = db.MediaDB.GetTotalScrapedMediaCount(ctx)
 	}
 	if err != nil {
-		log.Warn().Err(err).Str("scraper", status.ScraperID).Msg("failed to get scraped media count")
-		return
+		log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to get scraped media count")
+		return 0, false
 	}
-	status.TotalScraped = count
+	return count, true
 }
 
 func PublishScrapePauseStatus(ns chan<- models.Notification, paused bool) {
@@ -216,7 +305,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		Scraping:  true,
 		Paused:    paused,
 	}
-	populateScrapedMediaCount(env.State.GetContext(), db, &initialStatus)
+	populateScrapedMediaCountExact(env.State.GetContext(), db, &initialStatus)
 	publishScrapingStatus(ns, &initialStatus)
 
 	scraperID := params.ScraperID
@@ -242,7 +331,11 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 				Done:      update.Done,
 				Paused:    env.ScrapePauser != nil && env.ScrapePauser.IsPaused() && !update.Done,
 			}
-			populateScrapedMediaCount(env.State.GetContext(), db, &status)
+			if update.Done {
+				populateScrapedMediaCountExact(env.State.GetContext(), db, &status)
+			} else {
+				populateScrapedMediaCountCached(env.State.GetContext(), db, &status)
+			}
 			publishScrapingStatus(ns, &status)
 		}
 
@@ -267,7 +360,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 				Done:      status.Done,
 				Paused:    status.Paused,
 			}
-			populateScrapedMediaCount(env.State.GetContext(), db, &terminalStatus)
+			populateScrapedMediaCountExact(env.State.GetContext(), db, &terminalStatus)
 			publishScrapingStatus(ns, &terminalStatus)
 		}
 		log.Info().Str("scraper", scraperID).Msg("scraper run complete")

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -286,6 +286,36 @@ func TestHandleMediaScrapeStatus_NoRun(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaScrapeStatus_RefreshesExactCountDespiteCache(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+
+	scrapingStatusInstance.updateCountCache("test-scraper", 5, time.Now())
+	publishScrapingStatus(make(chan models.Notification, 1), &models.ScrapingStatusResponse{
+		ScraperID:    "test-scraper",
+		SystemID:     "SNES",
+		Processed:    42,
+		Total:        100,
+		Matched:      38,
+		Skipped:      4,
+		TotalScraped: 5,
+		Scraping:     true,
+	})
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(12, nil).Once()
+
+	result, err := HandleMediaScrapeStatus(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockDB},
+	})
+	require.NoError(t, err)
+	status, ok := result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Equal(t, 12, status.TotalScraped)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrapeStatus_TracksLatestProgress(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()
@@ -531,6 +561,88 @@ func TestScrapingStatus_ClearIfOwner_MismatchedID_Preserves(t *testing.T) {
 	s.clearIfOwner("owner-b")
 	assert.True(t, s.isRunning(), "non-owner clearIfOwner must not clear state")
 	s.clear()
+}
+
+func TestHandleMediaScrape_CachesProgressScrapedCountAndRefreshesDone(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return()
+	mockDB.On("BackgroundOperationDone").Return()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "cached-progress").Return(5, nil).Once()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "cached-progress").Return(9, nil).Once()
+
+	progressScraper := platforms.Scraper{
+		ID:   "cached-progress",
+		Name: "Cached Progress",
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, _ scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			go func() {
+				defer close(ch)
+				ch <- scraper.ScrapeUpdate{SystemID: "SNES", Total: 30, Processed: 10, Matched: 8, Skipped: 2}
+				ch <- scraper.ScrapeUpdate{SystemID: "SNES", Total: 30, Processed: 20, Matched: 16, Skipped: 4}
+				ch <- scraper.ScrapeUpdate{
+					SystemID: "SNES", Total: 30, Processed: 30, Matched: 24, Skipped: 6, Done: true,
+				}
+			}()
+			return nil
+		},
+	}
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
+		"cached-progress": progressScraper,
+	})
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	t.Cleanup(st.StopService)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		State:    st,
+		Database: &database.Database{MediaDB: mockDB},
+		Params:   json.RawMessage(`{"scraperId":"cached-progress"}`),
+	}
+
+	result, err := HandleMediaScrape(env)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	var progressCounts []int
+	var doneCount int
+	var gotDone bool
+	timeout := time.After(2 * time.Second)
+	for !gotDone {
+		select {
+		case n := <-ns:
+			if n.Method != models.NotificationMediaScraping {
+				continue
+			}
+			var p models.ScrapingStatusResponse
+			require.NoError(t, json.Unmarshal(n.Params, &p))
+			if p.Done {
+				doneCount = p.TotalScraped
+				gotDone = true
+			} else if p.Processed > 0 {
+				progressCounts = append(progressCounts, p.TotalScraped)
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for media.scraping done notification")
+		}
+	}
+
+	assert.Equal(t, []int{5, 5}, progressCounts)
+	assert.Equal(t, 9, doneCount)
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond)
+	mockDB.AssertExpectations(t)
 }
 
 func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -404,6 +404,20 @@ type ScrapeWrite struct {
 	MediaProps []MediaProperty
 }
 
+// ScrapeWriteTarget pairs a scraper write payload with the existing Media and
+// MediaTitle rows it should enrich.
+type ScrapeWriteTarget struct {
+	Write          *ScrapeWrite
+	MediaDBID      int64
+	MediaTitleDBID int64
+}
+
+// ScrapeResultBatchApplier optionally batches scrape writes for DB
+// implementations that can keep multiple targets in one transaction.
+type ScrapeResultBatchApplier interface {
+	ApplyScrapeResults(ctx context.Context, targets []ScrapeWriteTarget) error
+}
+
 type FileInfo struct {
 	SystemID string
 	Path     string

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -264,7 +264,7 @@ func (db *MediaDB) Open() error {
 	}
 
 	log.Debug().Msg("opening media database connection")
-	sqlInstance, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	sqlInstance, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
 	if err != nil {
 		return fmt.Errorf("failed to open media database: %w", err)
 	}
@@ -758,6 +758,8 @@ func (db *MediaDB) Close() error {
 	// Wait for all background operations (optimization, etc.) to complete
 	// before closing the database connection
 	db.WaitForBackgroundOperations()
+
+	logSQLTraceSummary()
 
 	err := db.sql.Close()
 	if err != nil {

--- a/pkg/database/mediadb/sql_plan_test.go
+++ b/pkg/database/mediadb/sql_plan_test.go
@@ -1,0 +1,259 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExplainHotScraperQueries(t *testing.T) {
+	t.Skip("diagnostic helper; run manually with -run TestExplainHotScraperQueries -v")
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT COUNT(*)
+		FROM MediaTags
+		WHERE TagDBID = ?
+	`, int64(1))
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT m.DBID
+		FROM Media m INDEXED BY media_system_path_idx
+		CROSS JOIN MediaTags mt
+		WHERE m.SystemDBID = ?
+		  AND mt.MediaDBID = m.DBID
+		  AND mt.TagDBID IN (?)
+	`, int64(1), int64(1))
+
+	// Previous scraped-ID shape. Kept to compare tag-driven scan against system-driven lookup.
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT mt.MediaDBID
+		FROM MediaTags mt
+		JOIN Media m ON mt.MediaDBID = m.DBID
+		WHERE mt.TagDBID = ? AND m.SystemDBID = ?
+	`, int64(1), int64(1))
+
+	// Previous scraped-ID shape. Kept to compare the removed join/distinct overhead.
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT DISTINCT mt.MediaDBID
+		FROM MediaTags mt
+		JOIN Media m ON mt.MediaDBID = m.DBID
+		JOIN Tags t ON mt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE m.SystemDBID = ? AND tt.Type = ? AND t.Tag = ?
+	`, int64(1), "scraper.test", "scraped")
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT mt.DBID, mt.SystemDBID, mt.Slug, mt.Name
+		FROM MediaTitles mt
+		WHERE mt.SystemDBID = ?
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM Media m
+			JOIN MediaTags mtag ON m.DBID = mtag.MediaDBID
+			WHERE m.MediaTitleDBID = mt.DBID
+			  AND mtag.TagDBID IN (?)
+		  )
+	`, int64(1), int64(1))
+
+	// Previous missing-title shape. Kept to compare removed Tags/TagTypes correlated join overhead.
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT mt.DBID, mt.SystemDBID, mt.Slug, mt.Name
+		FROM MediaTitles mt
+		WHERE mt.SystemDBID = ?
+		  AND NOT EXISTS (
+			SELECT 1
+			FROM Media m
+			JOIN MediaTags mtag ON m.DBID = mtag.MediaDBID
+			JOIN Tags t         ON mtag.TagDBID = t.DBID
+			JOIN TagTypes tt    ON t.TypeDBID = tt.DBID
+			WHERE m.MediaTitleDBID = mt.DBID
+			  AND tt.Type = ?
+			  AND (t.Tag = ? OR t.Tag = ?)
+		  )
+	`, int64(1), "scraper.test", "scraped", "scraped")
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		FROM Media m
+		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
+		JOIN Systems s ON t.SystemDBID = s.DBID
+		WHERE s.SystemID = ?
+		ORDER BY m.DBID
+	`, "NES")
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		DELETE FROM MediaTitleTags
+		WHERE MediaTitleDBID IN (?, ?)
+		  AND EXISTS (
+			SELECT 1
+			FROM Tags
+			WHERE Tags.DBID = MediaTitleTags.TagDBID
+			  AND Tags.TypeDBID = ?
+		  )
+	`, int64(1), int64(2), int64(2))
+
+	// Previous production shape. Target-copy benchmark showed it scales with large tag-type cardinality.
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		DELETE FROM MediaTitleTags
+		WHERE MediaTitleDBID IN (?, ?)
+		  AND TagDBID IN (SELECT DBID FROM Tags WHERE TypeDBID = ?)
+	`, int64(1), int64(2), int64(2))
+
+	// Rejected on target: fewer statements locally, but slower batch duration on target storage.
+	// Kept here only to compare plan shape when investigating future delete alternatives.
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		WITH delete_pairs(MediaTitleDBID, TypeDBID) AS (
+			VALUES (?, ?), (?, ?)
+		)
+		DELETE FROM MediaTitleTags
+		WHERE EXISTS (
+			SELECT 1
+			FROM delete_pairs p
+			JOIN Tags t ON t.DBID = MediaTitleTags.TagDBID
+			WHERE p.MediaTitleDBID = MediaTitleTags.MediaTitleDBID
+			  AND p.TypeDBID = t.TypeDBID
+		)
+	`, int64(1), int64(2), int64(2), int64(2))
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT DBID, Tag
+		FROM Tags
+		WHERE TypeDBID = ? AND Tag IN (?, ?, ?)
+	`, int64(2), "nintendo", "capcom", "konami")
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT DBID, Type, IsExclusive
+		FROM TagTypes
+		WHERE Type IN (?, ?, ?)
+	`, "developer", "property", "scraper.test")
+
+	explainQueryPlan(ctx, t, mediaDB.sql, `
+		SELECT t.DBID, t.Tag
+		FROM Tags t
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE tt.Type = ? AND t.Tag IN (?, ?)
+	`, "property", "description", "00000000000description")
+
+	dumpScraperPragmas(ctx, t, mediaDB.sql)
+	dumpSQLiteStats(ctx, t, mediaDB.sql)
+}
+
+func explainQueryPlan(ctx context.Context, t testing.TB, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+
+	t.Logf("EXPLAIN QUERY PLAN for:%s", query)
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		t.Logf("  id=%d parent=%d detail=%s", id, parent, detail)
+	}
+	require.NoError(t, rows.Err())
+}
+
+func dumpSQLiteStats(ctx context.Context, t testing.TB, db *sql.DB) {
+	t.Helper()
+	var statTableCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM sqlite_schema
+		WHERE type = 'table' AND name = 'sqlite_stat1'
+	`).Scan(&statTableCount))
+	if statTableCount == 0 {
+		t.Log("sqlite_stat1 not present; ANALYZE has not populated planner stats")
+		return
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT tbl, idx, stat
+		FROM sqlite_stat1
+		WHERE tbl IN ('MediaTitleTags', 'MediaTags', 'Tags', 'TagTypes', 'Media', 'MediaTitles')
+		ORDER BY tbl, idx
+	`)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close sqlite_stat1 rows: %v", closeErr)
+		}
+	}()
+
+	logged := 0
+	for rows.Next() {
+		var table, index, stat string
+		require.NoError(t, rows.Scan(&table, &index, &stat))
+		t.Logf("sqlite_stat1 tbl=%s idx=%s stat=%s", table, index, stat)
+		logged++
+	}
+	require.NoError(t, rows.Err())
+	if logged == 0 {
+		t.Log("sqlite_stat1 present but no rows for hot scraper tables")
+	}
+}
+
+func dumpScraperPragmas(ctx context.Context, t testing.TB, db *sql.DB) {
+	t.Helper()
+	for _, pragma := range []string{
+		"journal_mode",
+		"synchronous",
+		"page_size",
+		"cache_size",
+		"temp_store",
+		"foreign_keys",
+		"busy_timeout",
+	} {
+		var value string
+		require.NoError(t, db.QueryRowContext(ctx, "PRAGMA "+pragma).Scan(&value))
+		t.Logf("PRAGMA %s = %s", pragma, value)
+	}
+
+	rows, err := db.QueryContext(ctx, "PRAGMA wal_checkpoint(PASSIVE)")
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+	cols, err := rows.Columns()
+	require.NoError(t, err)
+	values := make([]string, len(cols))
+	scan := make([]any, len(cols))
+	for i := range values {
+		scan[i] = &values[i]
+	}
+	for rows.Next() {
+		require.NoError(t, rows.Scan(scan...))
+		t.Logf("PRAGMA wal_checkpoint(PASSIVE) %v = %v", cols, values)
+	}
+	require.NoError(t, rows.Err())
+}

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
@@ -309,14 +310,13 @@ func (db *MediaDB) GetScrapedMediaCount(ctx context.Context, scraperID string) (
 		return 0, ErrNullSQL
 	}
 
-	var count int
-	err := db.sql.QueryRowContext(ctx, `
-		SELECT COUNT(DISTINCT mt.MediaDBID)
-		FROM MediaTags mt
-		JOIN Tags t ON mt.TagDBID = t.DBID
-		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-		WHERE tt.Type = ? AND t.Tag = ?
-	`, string(tags.ScraperType(scraperID)), string(tags.TagScraperScraped)).Scan(&count)
+	tagDBIDs, err := findScraperSentinelTagDBIDs(
+		ctx, db.sql, string(tags.ScraperType(scraperID)), string(tags.TagScraperScraped),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find scraper sentinel tag for scraper %q: %w", scraperID, err)
+	}
+	count, err := countMediaTagsForTagDBIDs(ctx, db.sql, tagDBIDs)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count scraped media for scraper %q: %w", scraperID, err)
 	}
@@ -330,14 +330,11 @@ func (db *MediaDB) GetTotalScrapedMediaCount(ctx context.Context) (int, error) {
 		return 0, ErrNullSQL
 	}
 
-	var count int
-	err := db.sql.QueryRowContext(ctx, `
-		SELECT COUNT(DISTINCT mt.MediaDBID)
-		FROM MediaTags mt
-		JOIN Tags t ON mt.TagDBID = t.DBID
-		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-		WHERE tt.Type LIKE 'scraper.%' AND t.Tag = ?
-	`, string(tags.TagScraperScraped)).Scan(&count)
+	tagDBIDs, err := findAllScraperSentinelTagDBIDs(ctx, db.sql)
+	if err != nil {
+		return 0, fmt.Errorf("failed to find scraper sentinel tags: %w", err)
+	}
+	count, err := countMediaTagsForTagDBIDs(ctx, db.sql, tagDBIDs)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count scraped media: %w", err)
 	}
@@ -353,14 +350,35 @@ func (db *MediaDB) GetScrapedMediaIDs(
 		return nil, ErrNullSQL
 	}
 
-	rows, err := db.sql.QueryContext(ctx, `
-		SELECT DISTINCT mt.MediaDBID
-		FROM MediaTags mt
-		JOIN Media m ON mt.MediaDBID = m.DBID
-		JOIN Tags t ON mt.TagDBID = t.DBID
-		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-		WHERE m.SystemDBID = ? AND tt.Type = ? AND t.Tag = ?
-	`, systemDBID, string(tags.ScraperType(scraperID)), string(tags.TagScraperScraped))
+	tagDBIDs, err := findScraperSentinelTagDBIDs(
+		ctx, db.sql, string(tags.ScraperType(scraperID)), string(tags.TagScraperScraped),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find scraper sentinel tag for scraper %q: %w", scraperID, err)
+	}
+	if len(tagDBIDs) == 0 {
+		return map[int64]struct{}{}, nil
+	}
+
+	placeholders := prepareVariadic("?", ",", len(tagDBIDs))
+	args := make([]any, 0, len(tagDBIDs)+1)
+	args = append(args, systemDBID)
+	for _, tagDBID := range tagDBIDs {
+		args = append(args, tagDBID)
+	}
+
+	selectClause := "SELECT m.DBID"
+	if len(tagDBIDs) > 1 {
+		selectClause = "SELECT DISTINCT m.DBID"
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	query := selectClause + `
+		FROM Media m INDEXED BY media_system_path_idx
+		CROSS JOIN MediaTags mt
+		WHERE m.SystemDBID = ?
+		  AND mt.MediaDBID = m.DBID
+		  AND mt.TagDBID IN (` + placeholders + `)`
+	rows, err := db.sql.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query scraped media IDs for scraper %q: %w", scraperID, err)
 	}
@@ -382,6 +400,111 @@ func (db *MediaDB) GetScrapedMediaIDs(
 		return nil, fmt.Errorf("failed to iterate scraped media IDs: %w", err)
 	}
 	return mediaIDs, nil
+}
+
+func findScraperSentinelTagDBIDs(ctx context.Context, db *sql.DB, scraperType, tagValue string) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.DBID
+		FROM Tags t
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE tt.Type = ? AND t.Tag = ?
+		ORDER BY t.DBID
+	`, scraperType, tagValue)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query scraper sentinel tag DBIDs: %w", err)
+	}
+	return scanInt64Rows(rows, "scraper sentinel tag DBID")
+}
+
+func findAllScraperSentinelTagDBIDs(ctx context.Context, db *sql.DB) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT t.DBID
+		FROM Tags t
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE tt.Type LIKE 'scraper.%' AND t.Tag = ?
+		ORDER BY t.DBID
+	`, string(tags.TagScraperScraped))
+	if err != nil {
+		return nil, fmt.Errorf("failed to query scraper sentinel tag DBIDs: %w", err)
+	}
+	return scanInt64Rows(rows, "scraper sentinel tag DBID")
+}
+
+func countMediaTagsForTagDBIDs(ctx context.Context, db *sql.DB, tagDBIDs []int64) (int, error) {
+	if len(tagDBIDs) == 0 {
+		return 0, nil
+	}
+	if len(tagDBIDs) == 1 {
+		var count int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM MediaTags WHERE TagDBID = ?`, tagDBIDs[0],
+		).Scan(&count); err != nil {
+			return 0, fmt.Errorf("failed to count media tag rows: %w", err)
+		}
+		return count, nil
+	}
+
+	placeholders := prepareVariadic("?", ",", len(tagDBIDs))
+	args := make([]any, 0, len(tagDBIDs))
+	for _, tagDBID := range tagDBIDs {
+		args = append(args, tagDBID)
+	}
+	var count int
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	query := `SELECT COUNT(DISTINCT MediaDBID) FROM MediaTags WHERE TagDBID IN (` + placeholders + `)`
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count media tag rows: %w", err)
+	}
+	return count, nil
+}
+
+func findMediaTitlesBySystemDBID(ctx context.Context, db *sql.DB, systemDBID int64) ([]database.MediaTitle, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT DBID, SystemDBID, Slug, Name
+		FROM MediaTitles
+		WHERE SystemDBID = ?
+	`, systemDBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query media titles by system DBID: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	var titles []database.MediaTitle
+	for rows.Next() {
+		var title database.MediaTitle
+		if err := rows.Scan(&title.DBID, &title.SystemDBID, &title.Slug, &title.Name); err != nil {
+			return nil, fmt.Errorf("failed to scan media title: %w", err)
+		}
+		titles = append(titles, title)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate media titles: %w", err)
+	}
+	return titles, nil
+}
+
+func scanInt64Rows(rows *sql.Rows, label string) ([]int64, error) {
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Str("label", label).Msg("failed to close rows")
+		}
+	}()
+	var values []int64
+	for rows.Next() {
+		var value int64
+		if err := rows.Scan(&value); err != nil {
+			return nil, fmt.Errorf("failed to scan %s: %w", label, err)
+		}
+		values = append(values, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate %s rows: %w", label, err)
+	}
+	return values, nil
 }
 
 // UpsertMediaTags writes tags to MediaTags for a specific Media row, respecting
@@ -437,6 +560,490 @@ func (db *MediaDB) UpsertMediaTitleTags(ctx context.Context, mediaTitleDBID int6
 	})
 }
 
+const (
+	sqliteMaxParams            = 999
+	bulkTagInsertRowsPerStmt   = 400
+	bulkPropUpsertRowsPerStmt  = 200
+	bulkDeleteEntityIDsPerStmt = sqliteMaxParams - 1
+)
+
+type scrapeBatchSQLStats struct {
+	Duration                      time.Duration
+	Targets                       int
+	TitleTagDeletes               int
+	TitleTagInsertRows            int
+	TitleTagInsertStatements      int
+	TitlePropertyUpsertRows       int
+	TitlePropertyUpsertStatements int
+	SentinelDeleteStatements      int
+	SentinelInsertRows            int
+	SentinelInsertStatements      int
+	MediaTagFallbackTargets       int
+	MediaPropFallbackTargets      int
+}
+
+type tagTypeEntry struct {
+	dbid        int64
+	isExclusive bool
+}
+
+type tagTypeGroup struct {
+	tags        []database.TagInfo
+	dbid        int64
+	isExclusive bool
+}
+
+type tagCacheKey struct {
+	tag      string
+	typeDBID int64
+}
+
+type scrapeWriteTxContext struct {
+	tx               *sql.Tx
+	tagTypes         map[string]tagTypeEntry
+	tags             map[tagCacheKey]int64
+	propertyTypeTags map[string]int64
+}
+
+func newScrapeWriteTxContext(tx *sql.Tx) *scrapeWriteTxContext {
+	return &scrapeWriteTxContext{
+		tx:               tx,
+		tagTypes:         make(map[string]tagTypeEntry),
+		tags:             make(map[tagCacheKey]int64),
+		propertyTypeTags: make(map[string]int64),
+	}
+}
+
+func (c *scrapeWriteTxContext) resolveTagType(
+	ctx context.Context, tagType string,
+) (typeDBID int64, isExclusive bool, err error) {
+	if cached, ok := c.tagTypes[tagType]; ok {
+		return cached.dbid, cached.isExclusive, nil
+	}
+
+	err = c.tx.QueryRowContext(ctx,
+		`SELECT DBID, IsExclusive FROM TagTypes WHERE Type = ? LIMIT 1`,
+		tagType,
+	).Scan(&typeDBID, &isExclusive)
+	if errors.Is(err, sql.ErrNoRows) {
+		_, insertErr := c.tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO TagTypes (Type, IsExclusive) VALUES (?, 0)`,
+			tagType,
+		)
+		if insertErr != nil {
+			return 0, false, fmt.Errorf("failed to auto-create tag type %q: %w", tagType, insertErr)
+		}
+		err = c.tx.QueryRowContext(ctx,
+			`SELECT DBID, IsExclusive FROM TagTypes WHERE Type = ? LIMIT 1`,
+			tagType,
+		).Scan(&typeDBID, &isExclusive)
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to look up tag type %q: %w", tagType, err)
+	}
+
+	c.tagTypes[tagType] = tagTypeEntry{dbid: typeDBID, isExclusive: isExclusive}
+	return typeDBID, isExclusive, nil
+}
+
+func (c *scrapeWriteTxContext) resolveTag(
+	ctx context.Context, typeDBID int64, typeName, tagValue string,
+) (int64, error) {
+	key := tagCacheKey{typeDBID: typeDBID, tag: tagValue}
+	if cached, ok := c.tags[key]; ok {
+		return cached, nil
+	}
+
+	var tagDBID int64
+	err := c.tx.QueryRowContext(ctx,
+		`SELECT DBID FROM Tags WHERE TypeDBID = ? AND Tag = ? LIMIT 1`,
+		typeDBID, tagValue,
+	).Scan(&tagDBID)
+	if errors.Is(err, sql.ErrNoRows) {
+		if _, insertErr := c.tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO Tags (TypeDBID, Tag) VALUES (?, ?)`,
+			typeDBID, tagValue,
+		); insertErr != nil {
+			return 0, fmt.Errorf("failed to insert tag %q:%q: %w", typeName, tagValue, insertErr)
+		}
+		if err = c.tx.QueryRowContext(ctx,
+			`SELECT DBID FROM Tags WHERE TypeDBID = ? AND Tag = ? LIMIT 1`,
+			typeDBID, tagValue,
+		).Scan(&tagDBID); err != nil {
+			return 0, fmt.Errorf("failed to re-query tag DBID for %q:%q: %w", typeName, tagValue, err)
+		}
+	} else if err != nil {
+		return 0, fmt.Errorf("failed to look up tag DBID for %q:%q: %w", typeName, tagValue, err)
+	}
+
+	c.tags[key] = tagDBID
+	return tagDBID, nil
+}
+
+func (c *scrapeWriteTxContext) resolvePropertyTypeTag(ctx context.Context, typeTag string) (int64, error) {
+	if cached, ok := c.propertyTypeTags[typeTag]; ok {
+		return cached, nil
+	}
+	tagDBID, err := resolvePropertyTypeTag(ctx, c.tx, typeTag)
+	if err != nil {
+		return 0, err
+	}
+	c.propertyTypeTags[typeTag] = tagDBID
+	return tagDBID, nil
+}
+
+func preloadScrapeWriteLookupCache(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, targets []database.ScrapeWriteTarget,
+) error {
+	tagTypes := make(map[string]struct{})
+	propertyTypeTags := make(map[string]struct{})
+	for _, target := range targets {
+		write := target.Write
+		for _, tag := range write.MediaTags {
+			tagTypes[tag.Type] = struct{}{}
+		}
+		for _, tag := range write.TitleTags {
+			tagTypes[tag.Type] = struct{}{}
+		}
+		if write.Sentinel.Type != "" {
+			tagTypes[write.Sentinel.Type] = struct{}{}
+		}
+		for _, prop := range write.MediaProps {
+			propertyTypeTags[prop.TypeTag] = struct{}{}
+		}
+		for _, prop := range write.TitleProps {
+			propertyTypeTags[prop.TypeTag] = struct{}{}
+		}
+	}
+	for typeTag := range propertyTypeTags {
+		idx := strings.Index(typeTag, ":")
+		if idx < 0 {
+			return fmt.Errorf("property type tag %q is not in type:value format", typeTag)
+		}
+		tagTypes[typeTag[:idx]] = struct{}{}
+	}
+	if err := preloadTagTypes(ctx, writeCtx, tagTypes); err != nil {
+		return err
+	}
+	if err := preloadWriteTags(ctx, writeCtx, targets); err != nil {
+		return err
+	}
+	return preloadPropertyTypeTags(ctx, writeCtx, propertyTypeTags)
+}
+
+func preloadTagTypes(ctx context.Context, writeCtx *scrapeWriteTxContext, tagTypes map[string]struct{}) error {
+	missing := make([]string, 0, len(tagTypes))
+	for tagType := range tagTypes {
+		if _, ok := writeCtx.tagTypes[tagType]; !ok {
+			missing = append(missing, tagType)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	if err := queryTagTypesIntoCache(ctx, writeCtx, missing); err != nil {
+		return err
+	}
+	inserted := false
+	for _, tagType := range missing {
+		if _, ok := writeCtx.tagTypes[tagType]; ok {
+			continue
+		}
+		if _, err := writeCtx.tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO TagTypes (Type, IsExclusive) VALUES (?, 0)`, tagType,
+		); err != nil {
+			return fmt.Errorf("failed to auto-create tag type %q: %w", tagType, err)
+		}
+		inserted = true
+	}
+	if !inserted {
+		return nil
+	}
+	return queryTagTypesIntoCache(ctx, writeCtx, missing)
+}
+
+func queryTagTypesIntoCache(ctx context.Context, writeCtx *scrapeWriteTxContext, tagTypes []string) error {
+	const chunkSize = sqliteMaxParams
+	for start := 0; start < len(tagTypes); start += chunkSize {
+		end := start + chunkSize
+		if end > len(tagTypes) {
+			end = len(tagTypes)
+		}
+		chunk := tagTypes[start:end]
+		args := make([]any, 0, len(chunk))
+		for _, tagType := range chunk {
+			args = append(args, tagType)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `SELECT DBID, Type, IsExclusive FROM TagTypes WHERE Type IN (` +
+			prepareVariadic("?", ",", len(chunk)) + `)`
+		if err := queryTagTypeChunk(ctx, writeCtx, query, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func queryTagTypeChunk(ctx context.Context, writeCtx *scrapeWriteTxContext, query string, args []any) error {
+	rows, err := writeCtx.tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query tag types: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close tag type rows")
+		}
+	}()
+	for rows.Next() {
+		var tagType string
+		var entry tagTypeEntry
+		if err := rows.Scan(&entry.dbid, &tagType, &entry.isExclusive); err != nil {
+			return fmt.Errorf("failed to scan tag type: %w", err)
+		}
+		writeCtx.tagTypes[tagType] = entry
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate tag types: %w", err)
+	}
+	return nil
+}
+
+func preloadWriteTags(ctx context.Context, writeCtx *scrapeWriteTxContext, targets []database.ScrapeWriteTarget) error {
+	valuesByType := make(map[int64]map[string]struct{})
+	addTag := func(tag database.TagInfo) error {
+		if tag.Type == "" {
+			return nil
+		}
+		typeEntry, ok := writeCtx.tagTypes[tag.Type]
+		if !ok {
+			return fmt.Errorf("tag type %q missing from preload cache", tag.Type)
+		}
+		if _, ok := valuesByType[typeEntry.dbid]; !ok {
+			valuesByType[typeEntry.dbid] = make(map[string]struct{})
+		}
+		valuesByType[typeEntry.dbid][tags.PadTagValue(tag.Tag)] = struct{}{}
+		return nil
+	}
+	for _, target := range targets {
+		for _, tag := range target.Write.MediaTags {
+			if err := addTag(tag); err != nil {
+				return err
+			}
+		}
+		for _, tag := range target.Write.TitleTags {
+			if err := addTag(tag); err != nil {
+				return err
+			}
+		}
+		if err := addTag(target.Write.Sentinel); err != nil {
+			return err
+		}
+	}
+	return preloadTagsByType(ctx, writeCtx, valuesByType)
+}
+
+func preloadTagsByType(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, valuesByType map[int64]map[string]struct{},
+) error {
+	for typeDBID, values := range valuesByType {
+		missing := make([]string, 0, len(values))
+		for value := range values {
+			key := tagCacheKey{typeDBID: typeDBID, tag: value}
+			if _, ok := writeCtx.tags[key]; !ok {
+				missing = append(missing, value)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		if err := queryTagsIntoCache(ctx, writeCtx, typeDBID, missing); err != nil {
+			return err
+		}
+		inserted := false
+		for _, value := range missing {
+			key := tagCacheKey{typeDBID: typeDBID, tag: value}
+			if _, ok := writeCtx.tags[key]; ok {
+				continue
+			}
+			if _, err := writeCtx.tx.ExecContext(ctx,
+				`INSERT OR IGNORE INTO Tags (TypeDBID, Tag) VALUES (?, ?)`, typeDBID, value,
+			); err != nil {
+				return fmt.Errorf("failed to insert tag %q: %w", value, err)
+			}
+			inserted = true
+		}
+		if inserted {
+			if err := queryTagsIntoCache(ctx, writeCtx, typeDBID, missing); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func queryTagsIntoCache(ctx context.Context, writeCtx *scrapeWriteTxContext, typeDBID int64, values []string) error {
+	const valuesPerQuery = sqliteMaxParams - 1
+	for start := 0; start < len(values); start += valuesPerQuery {
+		end := start + valuesPerQuery
+		if end > len(values) {
+			end = len(values)
+		}
+		chunk := values[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, typeDBID)
+		for _, value := range chunk {
+			args = append(args, value)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `SELECT DBID, Tag FROM Tags WHERE TypeDBID = ? AND Tag IN (` +
+			prepareVariadic("?", ",", len(chunk)) + `)`
+		if err := queryTagChunk(ctx, writeCtx, typeDBID, query, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func queryTagChunk(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, typeDBID int64, query string, args []any,
+) error {
+	rows, err := writeCtx.tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query tags: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close tag rows")
+		}
+	}()
+	for rows.Next() {
+		var tagDBID int64
+		var value string
+		if err := rows.Scan(&tagDBID, &value); err != nil {
+			return fmt.Errorf("failed to scan tag: %w", err)
+		}
+		writeCtx.tags[tagCacheKey{typeDBID: typeDBID, tag: value}] = tagDBID
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate tags: %w", err)
+	}
+	return nil
+}
+
+func preloadPropertyTypeTags(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, propertyTypeTags map[string]struct{},
+) error {
+	missing := make([]string, 0, len(propertyTypeTags))
+	valuesByType := make(map[string]map[string]struct{})
+	for typeTag := range propertyTypeTags {
+		if _, ok := writeCtx.propertyTypeTags[typeTag]; ok {
+			continue
+		}
+		idx := strings.Index(typeTag, ":")
+		if idx < 0 {
+			return fmt.Errorf("property type tag %q is not in type:value format", typeTag)
+		}
+		missing = append(missing, typeTag)
+		typeName := typeTag[:idx]
+		rawValue := typeTag[idx+1:]
+		if _, ok := valuesByType[typeName]; !ok {
+			valuesByType[typeName] = make(map[string]struct{})
+		}
+		valuesByType[typeName][rawValue] = struct{}{}
+		valuesByType[typeName][tags.PadTagValue(rawValue)] = struct{}{}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	for typeName, values := range valuesByType {
+		vals := make([]string, 0, len(values))
+		for value := range values {
+			vals = append(vals, value)
+		}
+		if err := queryPropertyTypeTagsIntoCache(ctx, writeCtx, typeName, vals, missing); err != nil {
+			return err
+		}
+	}
+	for _, typeTag := range missing {
+		if _, ok := writeCtx.propertyTypeTags[typeTag]; ok {
+			continue
+		}
+		if _, err := writeCtx.resolvePropertyTypeTag(ctx, typeTag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func queryPropertyTypeTagsIntoCache(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, typeName string, values, requested []string,
+) error {
+	const valuesPerQuery = sqliteMaxParams - 1
+	for start := 0; start < len(values); start += valuesPerQuery {
+		end := start + valuesPerQuery
+		if end > len(values) {
+			end = len(values)
+		}
+		chunk := values[start:end]
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, typeName)
+		for _, value := range chunk {
+			args = append(args, value)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `
+			SELECT t.DBID, t.Tag
+			FROM Tags t
+			JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+			WHERE tt.Type = ? AND t.Tag IN (` + prepareVariadic("?", ",", len(chunk)) + `)
+		`
+		if err := queryPropertyTypeTagChunk(ctx, writeCtx, typeName, requested, query, args); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func queryPropertyTypeTagChunk(
+	ctx context.Context,
+	writeCtx *scrapeWriteTxContext,
+	typeName string,
+	requested []string,
+	query string,
+	args []any,
+) error {
+	rows, err := writeCtx.tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query property type tags: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close property type tag rows")
+		}
+	}()
+	for rows.Next() {
+		var tagDBID int64
+		var value string
+		if err := rows.Scan(&tagDBID, &value); err != nil {
+			return fmt.Errorf("failed to scan property type tag: %w", err)
+		}
+		for _, typeTag := range requested {
+			idx := strings.Index(typeTag, ":")
+			if idx < 0 || typeTag[:idx] != typeName {
+				continue
+			}
+			rawValue := typeTag[idx+1:]
+			if value == rawValue || value == tags.PadTagValue(rawValue) {
+				writeCtx.propertyTypeTags[typeTag] = tagDBID
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate property type tags: %w", err)
+	}
+	return nil
+}
+
 // upsertTags is the shared implementation for UpsertMediaTags and UpsertMediaTitleTags.
 // deleteFn deletes existing tags of a type for the entity (called once per exclusive type).
 // insertFn inserts the tag link for the entity.
@@ -481,45 +1088,28 @@ func upsertTagsInTx(
 	deleteFn func(tx *sql.Tx, typeDBID int64) error,
 	insertFn func(tx *sql.Tx, tagDBID int64) error,
 ) error {
-	// Group tags by type so that deleteFn is called at most once per exclusive type.
-	type typeEntry struct {
-		tags        []database.TagInfo
-		dbid        int64
-		isExclusive bool
-	}
+	return upsertTagsWithContext(ctx, newScrapeWriteTxContext(tx), tagInfos, deleteFn, insertFn)
+}
+
+func upsertTagsWithContext(
+	ctx context.Context,
+	writeCtx *scrapeWriteTxContext,
+	tagInfos []database.TagInfo,
+	deleteFn func(tx *sql.Tx, typeDBID int64) error,
+	insertFn func(tx *sql.Tx, tagDBID int64) error,
+) error {
+	tx := writeCtx.tx
 	typeOrder := make([]string, 0, len(tagInfos)) // preserve insertion order
-	byType := make(map[string]*typeEntry, len(tagInfos))
+	byType := make(map[string]*tagTypeGroup, len(tagInfos))
 
 	for _, ti := range tagInfos {
 		e, exists := byType[ti.Type]
 		if !exists {
-			// Resolve tag type to get IsExclusive and DBID.
-			// If the type is not yet registered (e.g. a runtime scraper sentinel type),
-			// auto-create it as additive (IsExclusive=false).
-			var typeDBID int64
-			var isExclusive bool
-			err := tx.QueryRowContext(ctx,
-				`SELECT DBID, IsExclusive FROM TagTypes WHERE Type = ? LIMIT 1`,
-				ti.Type,
-			).Scan(&typeDBID, &isExclusive)
-			if errors.Is(err, sql.ErrNoRows) {
-				// Auto-create the tag type with IsExclusive=false.
-				_, insertErr := tx.ExecContext(ctx,
-					`INSERT OR IGNORE INTO TagTypes (Type, IsExclusive) VALUES (?, 0)`,
-					ti.Type,
-				)
-				if insertErr != nil {
-					return fmt.Errorf("failed to auto-create tag type %q: %w", ti.Type, insertErr)
-				}
-				err = tx.QueryRowContext(ctx,
-					`SELECT DBID, IsExclusive FROM TagTypes WHERE Type = ? LIMIT 1`,
-					ti.Type,
-				).Scan(&typeDBID, &isExclusive)
-			}
+			typeDBID, isExclusive, err := writeCtx.resolveTagType(ctx, ti.Type)
 			if err != nil {
-				return fmt.Errorf("failed to look up tag type %q: %w", ti.Type, err)
+				return err
 			}
-			e = &typeEntry{dbid: typeDBID, isExclusive: isExclusive}
+			e = &tagTypeGroup{dbid: typeDBID, isExclusive: isExclusive}
 			byType[ti.Type] = e
 			typeOrder = append(typeOrder, ti.Type)
 		}
@@ -550,34 +1140,12 @@ func upsertTagsInTx(
 		}
 
 		for _, ti := range e.tags {
-			// Resolve tag DBID; insert if missing using INSERT OR IGNORE to handle
-			// concurrent writers outside this transaction (e.g. two goroutines
-			// bootstrapping the same tag type simultaneously).
 			tagValue := tags.PadTagValue(ti.Tag)
-			var tagDBID int64
-			err := tx.QueryRowContext(ctx,
-				`SELECT DBID FROM Tags WHERE TypeDBID = ? AND Tag = ? LIMIT 1`,
-				e.dbid, tagValue,
-			).Scan(&tagDBID)
-			if errors.Is(err, sql.ErrNoRows) {
-				if _, insertErr := tx.ExecContext(ctx,
-					`INSERT OR IGNORE INTO Tags (TypeDBID, Tag) VALUES (?, ?)`,
-					e.dbid, tagValue,
-				); insertErr != nil {
-					return fmt.Errorf("failed to insert tag %q:%q: %w", typeName, ti.Tag, insertErr)
-				}
-				// Re-query after insert (handles both "we inserted" and "someone else did").
-				if err = tx.QueryRowContext(ctx,
-					`SELECT DBID FROM Tags WHERE TypeDBID = ? AND Tag = ? LIMIT 1`,
-					e.dbid, tagValue,
-				).Scan(&tagDBID); err != nil {
-					return fmt.Errorf("failed to re-query tag DBID for %q:%q: %w", typeName, ti.Tag, err)
-				}
-			} else if err != nil {
-				return fmt.Errorf("failed to look up tag DBID for %q:%q: %w", typeName, ti.Tag, err)
+			tagDBID, err := writeCtx.resolveTag(ctx, e.dbid, typeName, tagValue)
+			if err != nil {
+				return err
 			}
 
-			// Insert the tag link.
 			if err := insertFn(tx, tagDBID); err != nil {
 				return fmt.Errorf("failed to insert tag link for %q:%q: %w", typeName, ti.Tag, err)
 			}
@@ -626,16 +1194,42 @@ func upsertMediaTitleProperties(
 		if err != nil {
 			return fmt.Errorf("failed to resolve property type tag %q: %w", p.TypeTag, err)
 		}
-		_, err = q.ExecContext(ctx, `
-			INSERT INTO MediaTitleProperties (MediaTitleDBID, TypeTagDBID, Text, BlobDBID)
-			VALUES (?, ?, ?, ?)
-			ON CONFLICT(MediaTitleDBID, TypeTagDBID) DO UPDATE SET
-				Text    = excluded.Text,
-				BlobDBID = excluded.BlobDBID
-		`, mediaTitleDBID, typeTagDBID, p.Text, p.BlobDBID)
-		if err != nil {
-			return fmt.Errorf("failed to upsert MediaTitleProperty (typeTag=%q): %w", p.TypeTag, err)
+		if err := upsertMediaTitleProperty(ctx, q, mediaTitleDBID, typeTagDBID, &p); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func upsertMediaTitlePropertiesWithContext(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, mediaTitleDBID int64, props []database.MediaProperty,
+) error {
+	for _, p := range props {
+		typeTagDBID, err := writeCtx.resolvePropertyTypeTag(ctx, p.TypeTag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve property type tag %q: %w", p.TypeTag, err)
+		}
+		if err := upsertMediaTitleProperty(ctx, writeCtx.tx, mediaTitleDBID, typeTagDBID, &p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertMediaTitleProperty(
+	ctx context.Context, q sqlQueryable, mediaTitleDBID, typeTagDBID int64, p *database.MediaProperty,
+) error {
+	_, err := q.ExecContext(ctx, `
+		INSERT INTO MediaTitleProperties (MediaTitleDBID, TypeTagDBID, Text, BlobDBID)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(MediaTitleDBID, TypeTagDBID) DO UPDATE SET
+			Text    = excluded.Text,
+			BlobDBID = excluded.BlobDBID
+		WHERE MediaTitleProperties.Text IS NOT excluded.Text
+		   OR MediaTitleProperties.BlobDBID IS NOT excluded.BlobDBID
+	`, mediaTitleDBID, typeTagDBID, p.Text, p.BlobDBID)
+	if err != nil {
+		return fmt.Errorf("failed to upsert MediaTitleProperty (typeTag=%q): %w", p.TypeTag, err)
 	}
 	return nil
 }
@@ -677,8 +1271,9 @@ func (db *MediaDB) ApplyScrapeResult(
 	if db.sql == nil {
 		return ErrNullSQL
 	}
-	if write == nil {
-		return errors.New("ApplyScrapeResult: write is nil")
+	target := database.ScrapeWriteTarget{MediaDBID: mediaDBID, MediaTitleDBID: mediaTitleDBID, Write: write}
+	if err := validateScrapeWriteTarget("ApplyScrapeResult", target); err != nil {
+		return err
 	}
 
 	tx, err := db.sql.BeginTx(ctx, nil)
@@ -692,28 +1287,9 @@ func (db *MediaDB) ApplyScrapeResult(
 		}
 	}()
 
-	if len(write.MediaTags) > 0 {
-		if err := upsertMediaTagsInTx(ctx, tx, mediaDBID, write.MediaTags); err != nil {
-			return fmt.Errorf("upsert media tags: %w", err)
-		}
-	}
-	if len(write.TitleTags) > 0 {
-		if err := upsertMediaTitleTagsInTx(ctx, tx, mediaTitleDBID, write.TitleTags); err != nil {
-			return fmt.Errorf("upsert title tags: %w", err)
-		}
-	}
-	if len(write.TitleProps) > 0 {
-		if err := upsertMediaTitleProperties(ctx, tx, mediaTitleDBID, write.TitleProps); err != nil {
-			return fmt.Errorf("upsert title properties: %w", err)
-		}
-	}
-	if len(write.MediaProps) > 0 {
-		if err := upsertMediaProperties(ctx, tx, mediaDBID, write.MediaProps); err != nil {
-			return fmt.Errorf("upsert media properties: %w", err)
-		}
-	}
-	if err := upsertMediaTagsInTx(ctx, tx, mediaDBID, []database.TagInfo{write.Sentinel}); err != nil {
-		return fmt.Errorf("upsert sentinel tag: %w", err)
+	writeCtx := newScrapeWriteTxContext(tx)
+	if err := applyScrapeWriteTarget(ctx, writeCtx, target); err != nil {
+		return err
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -723,8 +1299,445 @@ func (db *MediaDB) ApplyScrapeResult(
 	return nil
 }
 
-func upsertMediaTagsInTx(ctx context.Context, tx *sql.Tx, mediaDBID int64, tagInfos []database.TagInfo) error {
-	return upsertTagsInTx(ctx, tx, tagInfos, func(tx *sql.Tx, typeDBID int64) error {
+// ApplyScrapeResults writes multiple scraper payloads in one transaction.
+// Each target's sentinel is written after its metadata, and the whole batch rolls
+// back if any target fails.
+func (db *MediaDB) ApplyScrapeResults(ctx context.Context, targets []database.ScrapeWriteTarget) error {
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	for _, target := range targets {
+		if err := validateScrapeWriteTarget("ApplyScrapeResults", target); err != nil {
+			return err
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	tx, err := db.sql.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("ApplyScrapeResults: begin transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	writeCtx := newScrapeWriteTxContext(tx)
+	stats, err := applyScrapeWriteTargetsBulk(ctx, writeCtx, targets)
+	if err != nil {
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("ApplyScrapeResults: commit: %w", err)
+	}
+	committed = true
+	stats.Duration = stats.Duration.Round(time.Microsecond)
+	log.Debug().
+		Int("targets", stats.Targets).
+		Int("title_tag_deletes", stats.TitleTagDeletes).
+		Int("title_tag_insert_rows", stats.TitleTagInsertRows).
+		Int("title_tag_insert_statements", stats.TitleTagInsertStatements).
+		Int("title_property_upsert_rows", stats.TitlePropertyUpsertRows).
+		Int("title_property_upsert_statements", stats.TitlePropertyUpsertStatements).
+		Int("sentinel_delete_statements", stats.SentinelDeleteStatements).
+		Int("sentinel_insert_rows", stats.SentinelInsertRows).
+		Int("sentinel_insert_statements", stats.SentinelInsertStatements).
+		Int("media_tag_fallback_targets", stats.MediaTagFallbackTargets).
+		Int("media_property_fallback_targets", stats.MediaPropFallbackTargets).
+		Dur("duration", stats.Duration).
+		Msg("mediadb: applied scrape results bulk")
+	return nil
+}
+
+func applyScrapeWriteTargetsBulk(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, targets []database.ScrapeWriteTarget,
+) (scrapeBatchSQLStats, error) {
+	start := time.Now()
+	stats := scrapeBatchSQLStats{Targets: len(targets)}
+	if err := preloadScrapeWriteLookupCache(ctx, writeCtx, targets); err != nil {
+		return stats, fmt.Errorf("preload scrape write lookups: %w", err)
+	}
+	for _, target := range targets {
+		write := target.Write
+		if len(write.MediaTags) > 0 {
+			stats.MediaTagFallbackTargets++
+			if err := upsertMediaTagsWithContext(ctx, writeCtx, target.MediaDBID, write.MediaTags); err != nil {
+				return stats, fmt.Errorf("upsert media tags: %w", err)
+			}
+		}
+		if len(write.MediaProps) > 0 {
+			stats.MediaPropFallbackTargets++
+			if err := upsertMediaPropertiesWithContext(ctx, writeCtx, target.MediaDBID, write.MediaProps); err != nil {
+				return stats, fmt.Errorf("upsert media properties: %w", err)
+			}
+		}
+	}
+	if err := upsertMediaTitleTagsBulkWithContext(ctx, writeCtx, targets, &stats); err != nil {
+		return stats, fmt.Errorf("upsert title tags: %w", err)
+	}
+	if err := upsertMediaTitlePropertiesBulkWithContext(ctx, writeCtx, targets, &stats); err != nil {
+		return stats, fmt.Errorf("upsert title properties: %w", err)
+	}
+	if err := upsertScrapeSentinelsBulkWithContext(ctx, writeCtx, targets, &stats); err != nil {
+		return stats, fmt.Errorf("upsert sentinel tag: %w", err)
+	}
+	stats.Duration = time.Since(start)
+	return stats, nil
+}
+
+func validateScrapeWriteTarget(method string, target database.ScrapeWriteTarget) error {
+	if target.Write == nil {
+		return fmt.Errorf("%s: write is nil", method)
+	}
+	return nil
+}
+
+func applyScrapeWriteTarget(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, target database.ScrapeWriteTarget,
+) error {
+	write := target.Write
+	if len(write.MediaTags) > 0 {
+		if err := upsertMediaTagsWithContext(ctx, writeCtx, target.MediaDBID, write.MediaTags); err != nil {
+			return fmt.Errorf("upsert media tags: %w", err)
+		}
+	}
+	if len(write.TitleTags) > 0 {
+		if err := upsertMediaTitleTagsWithContext(ctx, writeCtx, target.MediaTitleDBID, write.TitleTags); err != nil {
+			return fmt.Errorf("upsert title tags: %w", err)
+		}
+	}
+	if len(write.TitleProps) > 0 {
+		err := upsertMediaTitlePropertiesWithContext(ctx, writeCtx, target.MediaTitleDBID, write.TitleProps)
+		if err != nil {
+			return fmt.Errorf("upsert title properties: %w", err)
+		}
+	}
+	if len(write.MediaProps) > 0 {
+		if err := upsertMediaPropertiesWithContext(ctx, writeCtx, target.MediaDBID, write.MediaProps); err != nil {
+			return fmt.Errorf("upsert media properties: %w", err)
+		}
+	}
+	sentinel := []database.TagInfo{write.Sentinel}
+	if err := upsertMediaTagsWithContext(ctx, writeCtx, target.MediaDBID, sentinel); err != nil {
+		return fmt.Errorf("upsert sentinel tag: %w", err)
+	}
+	return nil
+}
+
+type titleTagTypeKey struct {
+	mediaTitleDBID int64
+	typeDBID       int64
+}
+
+type titleTagPair struct {
+	mediaTitleDBID int64
+	tagDBID        int64
+}
+
+type titlePropKey struct {
+	mediaTitleDBID int64
+	typeTagDBID    int64
+}
+
+type titlePropRow struct {
+	p   database.MediaProperty
+	key titlePropKey
+}
+
+func upsertMediaTitleTagsBulkWithContext(
+	ctx context.Context,
+	writeCtx *scrapeWriteTxContext,
+	targets []database.ScrapeWriteTarget,
+	stats *scrapeBatchSQLStats,
+) error {
+	exclusiveDeletes := make(map[int64]map[int64]struct{})
+	exclusiveFinal := make(map[titleTagTypeKey][]int64)
+	additivePairs := make(map[titleTagPair]struct{})
+
+	for _, target := range targets {
+		if len(target.Write.TitleTags) == 0 {
+			continue
+		}
+		typeOrder := make([]string, 0, len(target.Write.TitleTags))
+		byType := make(map[string][]database.TagInfo, len(target.Write.TitleTags))
+		for _, ti := range target.Write.TitleTags {
+			if _, ok := byType[ti.Type]; !ok {
+				typeOrder = append(typeOrder, ti.Type)
+			}
+			byType[ti.Type] = append(byType[ti.Type], ti)
+		}
+		for _, typeName := range typeOrder {
+			typeDBID, isExclusive, err := writeCtx.resolveTagType(ctx, typeName)
+			if err != nil {
+				return err
+			}
+			tagInfos := byType[typeName]
+			if isExclusive {
+				seen := make(map[string]struct{}, len(tagInfos))
+				for _, ti := range tagInfos {
+					seen[tags.PadTagValue(ti.Tag)] = struct{}{}
+				}
+				if len(seen) > 1 {
+					return fmt.Errorf("exclusive tag type %q received multiple values", typeName)
+				}
+				if _, ok := exclusiveDeletes[typeDBID]; !ok {
+					exclusiveDeletes[typeDBID] = make(map[int64]struct{})
+				}
+				exclusiveDeletes[typeDBID][target.MediaTitleDBID] = struct{}{}
+			}
+
+			resolved := make([]int64, 0, len(tagInfos))
+			for _, ti := range tagInfos {
+				tagValue := tags.PadTagValue(ti.Tag)
+				tagDBID, err := writeCtx.resolveTag(ctx, typeDBID, typeName, tagValue)
+				if err != nil {
+					return err
+				}
+				resolved = append(resolved, tagDBID)
+			}
+			if isExclusive {
+				exclusiveFinal[titleTagTypeKey{mediaTitleDBID: target.MediaTitleDBID, typeDBID: typeDBID}] = resolved
+				continue
+			}
+			for _, tagDBID := range resolved {
+				additivePairs[titleTagPair{mediaTitleDBID: target.MediaTitleDBID, tagDBID: tagDBID}] = struct{}{}
+			}
+		}
+	}
+
+	if err := deleteMediaTitleTagsByExclusiveType(ctx, writeCtx.tx, exclusiveDeletes, stats); err != nil {
+		return err
+	}
+
+	pairs := make([]titleTagPair, 0, len(additivePairs)+len(exclusiveFinal))
+	for pair := range additivePairs {
+		pairs = append(pairs, pair)
+	}
+	for key, tagDBIDs := range exclusiveFinal {
+		for _, tagDBID := range tagDBIDs {
+			pairs = append(pairs, titleTagPair{mediaTitleDBID: key.mediaTitleDBID, tagDBID: tagDBID})
+		}
+	}
+	return insertMediaTitleTagPairs(ctx, writeCtx.tx, pairs, stats)
+}
+
+func deleteMediaTitleTagsByExclusiveType(
+	ctx context.Context, tx *sql.Tx, exclusiveDeletes map[int64]map[int64]struct{}, stats *scrapeBatchSQLStats,
+) error {
+	for typeDBID, titleIDs := range exclusiveDeletes {
+		ids := make([]int64, 0, len(titleIDs))
+		for id := range titleIDs {
+			ids = append(ids, id)
+		}
+		for start := 0; start < len(ids); start += bulkDeleteEntityIDsPerStmt {
+			end := start + bulkDeleteEntityIDsPerStmt
+			if end > len(ids) {
+				end = len(ids)
+			}
+			chunk := ids[start:end]
+			args := make([]any, 0, len(chunk)+1)
+			for _, id := range chunk {
+				args = append(args, id)
+			}
+			args = append(args, typeDBID)
+			//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+			query := `DELETE FROM MediaTitleTags WHERE MediaTitleDBID IN (` +
+				prepareVariadic("?", ",", len(chunk)) +
+				`) AND EXISTS (` +
+				`SELECT 1 FROM Tags WHERE Tags.DBID = MediaTitleTags.TagDBID AND Tags.TypeDBID = ?` +
+				`)`
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return fmt.Errorf("failed to delete media title tags for type: %w", err)
+			}
+			stats.TitleTagDeletes++
+		}
+	}
+	return nil
+}
+
+func insertMediaTitleTagPairs(
+	ctx context.Context, tx *sql.Tx, pairs []titleTagPair, stats *scrapeBatchSQLStats,
+) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+	for start := 0; start < len(pairs); start += bulkTagInsertRowsPerStmt {
+		end := start + bulkTagInsertRowsPerStmt
+		if end > len(pairs) {
+			end = len(pairs)
+		}
+		chunk := pairs[start:end]
+		args := make([]any, 0, len(chunk)*2)
+		for _, pair := range chunk {
+			args = append(args, pair.mediaTitleDBID, pair.tagDBID)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `INSERT OR IGNORE INTO MediaTitleTags (MediaTitleDBID, TagDBID) VALUES ` +
+			prepareVariadic("(?, ?)", ",", len(chunk))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to insert media title tag links: %w", err)
+		}
+		stats.TitleTagInsertRows += len(chunk)
+		stats.TitleTagInsertStatements++
+	}
+	return nil
+}
+
+func upsertMediaTitlePropertiesBulkWithContext(
+	ctx context.Context,
+	writeCtx *scrapeWriteTxContext,
+	targets []database.ScrapeWriteTarget,
+	stats *scrapeBatchSQLStats,
+) error {
+	rowsByKey := make(map[titlePropKey]titlePropRow)
+	for _, target := range targets {
+		for _, p := range target.Write.TitleProps {
+			typeTagDBID, err := writeCtx.resolvePropertyTypeTag(ctx, p.TypeTag)
+			if err != nil {
+				return fmt.Errorf("failed to resolve property type tag %q: %w", p.TypeTag, err)
+			}
+			key := titlePropKey{mediaTitleDBID: target.MediaTitleDBID, typeTagDBID: typeTagDBID}
+			rowsByKey[key] = titlePropRow{key: key, p: p}
+		}
+	}
+	if len(rowsByKey) == 0 {
+		return nil
+	}
+	rows := make([]titlePropRow, 0, len(rowsByKey))
+	for _, row := range rowsByKey {
+		rows = append(rows, row)
+	}
+	for start := 0; start < len(rows); start += bulkPropUpsertRowsPerStmt {
+		end := start + bulkPropUpsertRowsPerStmt
+		if end > len(rows) {
+			end = len(rows)
+		}
+		chunk := rows[start:end]
+		args := make([]any, 0, len(chunk)*4)
+		for _, row := range chunk {
+			args = append(args, row.key.mediaTitleDBID, row.key.typeTagDBID, row.p.Text, row.p.BlobDBID)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `
+			INSERT INTO MediaTitleProperties (MediaTitleDBID, TypeTagDBID, Text, BlobDBID)
+			VALUES ` + prepareVariadic("(?, ?, ?, ?)", ",", len(chunk)) + `
+			ON CONFLICT(MediaTitleDBID, TypeTagDBID) DO UPDATE SET
+				Text = excluded.Text,
+				BlobDBID = excluded.BlobDBID
+			WHERE MediaTitleProperties.Text IS NOT excluded.Text
+			   OR MediaTitleProperties.BlobDBID IS NOT excluded.BlobDBID
+		`
+		if _, err := writeCtx.tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to upsert MediaTitleProperties bulk: %w", err)
+		}
+		stats.TitlePropertyUpsertRows += len(chunk)
+		stats.TitlePropertyUpsertStatements++
+	}
+	return nil
+}
+
+func upsertScrapeSentinelsBulkWithContext(
+	ctx context.Context,
+	writeCtx *scrapeWriteTxContext,
+	targets []database.ScrapeWriteTarget,
+	stats *scrapeBatchSQLStats,
+) error {
+	pairs := make([]mediaTagPair, 0, len(targets))
+	seen := make(map[mediaTagPair]struct{}, len(targets))
+	exclusiveDeletes := make(map[int64]map[int64]struct{})
+	for _, target := range targets {
+		sentinel := target.Write.Sentinel
+		typeDBID, isExclusive, err := writeCtx.resolveTagType(ctx, sentinel.Type)
+		if err != nil {
+			return err
+		}
+		if isExclusive {
+			if _, ok := exclusiveDeletes[typeDBID]; !ok {
+				exclusiveDeletes[typeDBID] = make(map[int64]struct{})
+			}
+			exclusiveDeletes[typeDBID][target.MediaDBID] = struct{}{}
+		}
+		tagDBID, err := writeCtx.resolveTag(ctx, typeDBID, sentinel.Type, tags.PadTagValue(sentinel.Tag))
+		if err != nil {
+			return err
+		}
+		pair := mediaTagPair{mediaDBID: target.MediaDBID, tagDBID: tagDBID}
+		if _, ok := seen[pair]; ok {
+			continue
+		}
+		seen[pair] = struct{}{}
+		pairs = append(pairs, pair)
+	}
+	for typeDBID, mediaIDs := range exclusiveDeletes {
+		ids := make([]int64, 0, len(mediaIDs))
+		for id := range mediaIDs {
+			ids = append(ids, id)
+		}
+		for start := 0; start < len(ids); start += bulkDeleteEntityIDsPerStmt {
+			end := start + bulkDeleteEntityIDsPerStmt
+			if end > len(ids) {
+				end = len(ids)
+			}
+			chunk := ids[start:end]
+			args := make([]any, 0, len(chunk)+1)
+			for _, id := range chunk {
+				args = append(args, id)
+			}
+			args = append(args, typeDBID)
+			//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+			query := `DELETE FROM MediaTags WHERE MediaDBID IN (` + prepareVariadic("?", ",", len(chunk)) +
+				`) AND TagDBID IN (SELECT DBID FROM Tags WHERE TypeDBID = ?)`
+			if _, err := writeCtx.tx.ExecContext(ctx, query, args...); err != nil {
+				return fmt.Errorf("failed to delete media sentinel tags for type: %w", err)
+			}
+			stats.SentinelDeleteStatements++
+		}
+	}
+	return insertMediaTagPairs(ctx, writeCtx.tx, pairs, stats)
+}
+
+type mediaTagPair struct {
+	mediaDBID int64
+	tagDBID   int64
+}
+
+func insertMediaTagPairs(
+	ctx context.Context, tx *sql.Tx, pairs []mediaTagPair, stats *scrapeBatchSQLStats,
+) error {
+	if len(pairs) == 0 {
+		return nil
+	}
+	for start := 0; start < len(pairs); start += bulkTagInsertRowsPerStmt {
+		end := start + bulkTagInsertRowsPerStmt
+		if end > len(pairs) {
+			end = len(pairs)
+		}
+		chunk := pairs[start:end]
+		args := make([]any, 0, len(chunk)*2)
+		for _, pair := range chunk {
+			args = append(args, pair.mediaDBID, pair.tagDBID)
+		}
+		//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+		query := `INSERT OR IGNORE INTO MediaTags (MediaDBID, TagDBID) VALUES ` +
+			prepareVariadic("(?, ?)", ",", len(chunk))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to insert media tag links: %w", err)
+		}
+		stats.SentinelInsertRows += len(chunk)
+		stats.SentinelInsertStatements++
+	}
+	return nil
+}
+
+func upsertMediaTagsWithContext(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, mediaDBID int64, tagInfos []database.TagInfo,
+) error {
+	return upsertTagsWithContext(ctx, writeCtx, tagInfos, func(tx *sql.Tx, typeDBID int64) error {
 		_, err := tx.ExecContext(ctx,
 			`DELETE FROM MediaTags WHERE MediaDBID = ? AND TagDBID IN (SELECT DBID FROM Tags WHERE TypeDBID = ?)`,
 			mediaDBID, typeDBID,
@@ -745,10 +1758,10 @@ func upsertMediaTagsInTx(ctx context.Context, tx *sql.Tx, mediaDBID int64, tagIn
 	})
 }
 
-func upsertMediaTitleTagsInTx(
-	ctx context.Context, tx *sql.Tx, mediaTitleDBID int64, tagInfos []database.TagInfo,
+func upsertMediaTitleTagsWithContext(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, mediaTitleDBID int64, tagInfos []database.TagInfo,
 ) error {
-	return upsertTagsInTx(ctx, tx, tagInfos, func(tx *sql.Tx, typeDBID int64) error {
+	return upsertTagsWithContext(ctx, writeCtx, tagInfos, func(tx *sql.Tx, typeDBID int64) error {
 		const q = `DELETE FROM MediaTitleTags` +
 			` WHERE MediaTitleDBID = ? AND TagDBID IN (SELECT DBID FROM Tags WHERE TypeDBID = ?)`
 		_, err := tx.ExecContext(ctx, q, mediaTitleDBID, typeDBID)
@@ -774,16 +1787,40 @@ func upsertMediaProperties(ctx context.Context, q sqlQueryable, mediaDBID int64,
 		if err != nil {
 			return fmt.Errorf("failed to resolve property type tag %q: %w", p.TypeTag, err)
 		}
-		_, err = q.ExecContext(ctx, `
-			INSERT INTO MediaProperties (MediaDBID, TypeTagDBID, Text, BlobDBID)
-			VALUES (?, ?, ?, ?)
-			ON CONFLICT(MediaDBID, TypeTagDBID) DO UPDATE SET
-				Text    = excluded.Text,
-				BlobDBID = excluded.BlobDBID
-		`, mediaDBID, typeTagDBID, p.Text, p.BlobDBID)
-		if err != nil {
-			return fmt.Errorf("failed to upsert MediaProperty (typeTag=%q): %w", p.TypeTag, err)
+		if err := upsertMediaProperty(ctx, q, mediaDBID, typeTagDBID, &p); err != nil {
+			return err
 		}
+	}
+	return nil
+}
+
+func upsertMediaPropertiesWithContext(
+	ctx context.Context, writeCtx *scrapeWriteTxContext, mediaDBID int64, props []database.MediaProperty,
+) error {
+	for _, p := range props {
+		typeTagDBID, err := writeCtx.resolvePropertyTypeTag(ctx, p.TypeTag)
+		if err != nil {
+			return fmt.Errorf("failed to resolve property type tag %q: %w", p.TypeTag, err)
+		}
+		if err := upsertMediaProperty(ctx, writeCtx.tx, mediaDBID, typeTagDBID, &p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func upsertMediaProperty(
+	ctx context.Context, q sqlQueryable, mediaDBID, typeTagDBID int64, p *database.MediaProperty,
+) error {
+	_, err := q.ExecContext(ctx, `
+		INSERT INTO MediaProperties (MediaDBID, TypeTagDBID, Text, BlobDBID)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(MediaDBID, TypeTagDBID) DO UPDATE SET
+			Text    = excluded.Text,
+			BlobDBID = excluded.BlobDBID
+	`, mediaDBID, typeTagDBID, p.Text, p.BlobDBID)
+	if err != nil {
+		return fmt.Errorf("failed to upsert MediaProperty (typeTag=%q): %w", p.TypeTag, err)
 	}
 	return nil
 }
@@ -864,15 +1901,28 @@ func (db *MediaDB) FindMediaTitlesWithoutSentinel(
 		return nil, ErrNullSQL
 	}
 
-	// Split on first colon to get the stored TagTypes.Type and the raw tag value.
 	idx := strings.Index(sentinelTag, ":")
 	if idx < 0 {
 		return nil, fmt.Errorf("sentinelTag %q is not in type:value format", sentinelTag)
 	}
 	tagType := sentinelTag[:idx]
 	tagPart := sentinelTag[idx+1:]
-	padded := tags.PadTagValue(tagPart)
+	tagDBIDs, err := findScraperSentinelTagDBIDs(ctx, db.sql, tagType, tagPart)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find sentinel tag DBIDs: %w", err)
+	}
+	if len(tagDBIDs) == 0 {
+		return findMediaTitlesBySystemDBID(ctx, db.sql, systemDBID)
+	}
 
+	placeholders := prepareVariadic("?", ",", len(tagDBIDs))
+	args := make([]any, 0, len(tagDBIDs)+1)
+	args = append(args, systemDBID)
+	for _, tagDBID := range tagDBIDs {
+		args = append(args, tagDBID)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
 	stmt, err := db.sql.PrepareContext(ctx, `
 		SELECT mt.DBID, mt.SystemDBID, mt.Slug, mt.Name
 		FROM MediaTitles mt
@@ -881,11 +1931,8 @@ func (db *MediaDB) FindMediaTitlesWithoutSentinel(
 			SELECT 1
 			FROM Media m
 			JOIN MediaTags mtag ON m.DBID = mtag.MediaDBID
-			JOIN Tags t         ON mtag.TagDBID = t.DBID
-			JOIN TagTypes tt    ON t.TypeDBID = tt.DBID
 			WHERE m.MediaTitleDBID = mt.DBID
-			  AND tt.Type = ?
-			  AND (t.Tag = ? OR t.Tag = ?)
+			  AND mtag.TagDBID IN (`+placeholders+`)
 		  )
 	`)
 	if err != nil {
@@ -897,7 +1944,7 @@ func (db *MediaDB) FindMediaTitlesWithoutSentinel(
 		}
 	}()
 
-	rows, err := stmt.QueryContext(ctx, systemDBID, tagType, tagPart, padded)
+	rows, err := stmt.QueryContext(ctx, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query FindMediaTitlesWithoutSentinel: %w", err)
 	}

--- a/pkg/database/mediadb/sql_scraper_bench_test.go
+++ b/pkg/database/mediadb/sql_scraper_bench_test.go
@@ -1,0 +1,187 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+const scraperBenchRows = 1000
+
+// These benchmarks are first-pass evidence only. A CTE delete variant was faster
+// locally but slower on target storage, so scraper SQL changes also need target
+// trace logs and EXPLAIN QUERY PLAN evidence before acceptance.
+func BenchmarkApplyScrapeResults_CompanionBatch_10(b *testing.B) {
+	benchApplyScrapeResultsCompanionBatch(b, "full", func(target *database.ScrapeWriteTarget) {
+		target.Write.TitleTags = benchTitleTags(target.MediaTitleDBID)
+		target.Write.TitleProps = benchTitleProps(target.MediaTitleDBID)
+	})
+	benchApplyScrapeResultsCompanionBatch(b, "title-tags-only", func(target *database.ScrapeWriteTarget) {
+		target.Write.TitleTags = benchTitleTags(target.MediaTitleDBID)
+	})
+	benchApplyScrapeResultsCompanionBatch(b, "title-props-only", func(target *database.ScrapeWriteTarget) {
+		target.Write.TitleProps = benchTitleProps(target.MediaTitleDBID)
+	})
+	benchApplyScrapeResultsCompanionBatch(b, "sentinel-only", func(_ *database.ScrapeWriteTarget) {})
+}
+
+func benchApplyScrapeResultsCompanionBatch(
+	b *testing.B,
+	name string,
+	customize func(target *database.ScrapeWriteTarget),
+) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		ctx := context.Background()
+		mediaDB, cleanup := setupBenchMediaDB(b, scraperBenchRows)
+		defer cleanup()
+
+		targets := make([]database.ScrapeWriteTarget, 10)
+		for i := range targets {
+			mediaDBID := int64(i + 1)
+			targets[i] = database.ScrapeWriteTarget{
+				MediaDBID:      mediaDBID,
+				MediaTitleDBID: mediaDBID,
+				Write: &database.ScrapeWrite{
+					Sentinel: database.TagInfo{Type: "scraper.bench", Tag: "scraped"},
+				},
+			}
+			customize(&targets[i])
+		}
+
+		b.ResetTimer()
+		for b.Loop() {
+			if err := mediaDB.ApplyScrapeResults(ctx, targets); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func setupBenchMediaDB(b *testing.B, rows int) (mediaDB *MediaDB, cleanup func()) {
+	b.Helper()
+	tempDir, err := os.MkdirTemp("", "zaparoo-bench-mediadb-*")
+	require.NoError(b, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
+
+	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
+	require.NoError(b, err)
+	cleanup = func() {
+		if mediaDB != nil {
+			_ = mediaDB.Close()
+		}
+		_ = os.RemoveAll(tempDir)
+	}
+
+	seedBenchScraperDB(b, mediaDB, rows)
+	return mediaDB, cleanup
+}
+
+func seedBenchScraperDB(b *testing.B, mediaDB *MediaDB, rows int) {
+	b.Helper()
+	ctx := context.Background()
+	tx, err := mediaDB.sql.BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO TagTypes (Type, IsExclusive) VALUES
+			('scraper.bench', 0),
+			('developer', 1),
+			('publisher', 1),
+			('year', 1),
+			('rating', 1),
+			('genre', 0),
+			('property', 0);
+		INSERT INTO Tags (TypeDBID, Tag)
+		SELECT DBID, 'description' FROM TagTypes WHERE Type = 'property';
+		INSERT INTO Tags (TypeDBID, Tag)
+		SELECT DBID, 'xml-game-id' FROM TagTypes WHERE Type = 'property';
+		INSERT INTO Tags (TypeDBID, Tag)
+		SELECT DBID, 'image-boxart' FROM TagTypes WHERE Type = 'property';
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'Bench', 'Bench');
+	`)
+	require.NoError(b, err)
+
+	titleStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 1, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, titleStmt.Close())
+	}()
+
+	mediaStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (?, ?, 1, ?)
+	`)
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, mediaStmt.Close())
+	}()
+
+	for i := 1; i <= rows; i++ {
+		slug := fmt.Sprintf("bench-game-%05d", i)
+		name := fmt.Sprintf("Bench Game %05d", i)
+		path := filepath.ToSlash(filepath.Join("roms", fmt.Sprintf("bench-game-%05d.zip", i)))
+		_, err = titleStmt.ExecContext(ctx, i, slug, name)
+		require.NoError(b, err)
+		_, err = mediaStmt.ExecContext(ctx, i, i, path)
+		require.NoError(b, err)
+	}
+
+	require.NoError(b, tx.Commit())
+}
+
+func benchTitleTags(mediaTitleDBID int64) []database.TagInfo {
+	return []database.TagInfo{
+		{Type: "developer", Tag: fmt.Sprintf("developer-%02d", mediaTitleDBID%10)},
+		{Type: "publisher", Tag: fmt.Sprintf("publisher-%02d", mediaTitleDBID%10)},
+		{Type: "year", Tag: fmt.Sprintf("%04d", 1980+mediaTitleDBID%40)},
+		{Type: "rating", Tag: "0.8"},
+		{Type: "genre", Tag: "action"},
+		{Type: "genre", Tag: "arcade"},
+	}
+}
+
+func benchTitleProps(mediaTitleDBID int64) []database.MediaProperty {
+	return []database.MediaProperty{
+		{TypeTag: "property:description", Text: fmt.Sprintf("Description for bench game %d", mediaTitleDBID)},
+		{TypeTag: "property:xml-game-id", Text: strconv.FormatInt(100000+mediaTitleDBID, 10)},
+		{
+			TypeTag: "property:image-boxart",
+			Text:    filepath.ToSlash(filepath.Join("media", "boxart", fmt.Sprintf("%05d.png", mediaTitleDBID))),
+		},
+	}
+}

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -480,6 +480,16 @@ func TestGetScrapedMediaCount(t *testing.T) {
 	assert.Equal(t, 1, otherCount)
 }
 
+func TestGetScrapedMediaCount_MissingSentinelReturnsZero(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	count, err := mediaDB.GetScrapedMediaCount(context.Background(), "missing")
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
 func TestGetTotalScrapedMediaCount_DistinctMedia(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)
@@ -501,6 +511,16 @@ func TestGetTotalScrapedMediaCount_DistinctMedia(t *testing.T) {
 	count, err := mediaDB.GetTotalScrapedMediaCount(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 2, count)
+}
+
+func TestGetTotalScrapedMediaCount_MissingSentinelsReturnsZero(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	count, err := mediaDB.GetTotalScrapedMediaCount(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
 }
 
 func TestGetScrapedMediaIDs(t *testing.T) {
@@ -530,6 +550,16 @@ func TestGetScrapedMediaIDs(t *testing.T) {
 	ids, err := mediaDB.GetScrapedMediaIDs(ctx, "test", 1)
 	require.NoError(t, err)
 	assert.Equal(t, map[int64]struct{}{1: {}, 2: {}}, ids)
+}
+
+func TestGetScrapedMediaIDs_MissingSentinelReturnsEmptySet(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	ids, err := mediaDB.GetScrapedMediaIDs(context.Background(), "missing", 1)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
 }
 
 func TestApplyScrapeResult_WritesSentinelLastPayload(t *testing.T) {
@@ -604,6 +634,461 @@ func TestApplyScrapeResult_RollsBackBeforeSentinel(t *testing.T) {
 	hasSentinel, err := mediaDB.MediaHasTag(ctx, 1, "scraper.test:scraped")
 	require.NoError(t, err)
 	assert.False(t, hasSentinel, "failed scrape writes must not mark the record as scraped")
+}
+
+func TestApplyScrapeResults_WritesMultipleTargets(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	targets := []database.ScrapeWriteTarget{
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				MediaTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+				TitleProps: []database.MediaProperty{{
+					TypeTag: "property:description",
+					Text:    "Mario description",
+				}},
+			},
+		},
+		{
+			MediaDBID: 2, MediaTitleDBID: 2,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+				MediaProps: []database.MediaProperty{{
+					TypeTag: "property:image-boxart",
+					Text:    filepath.ToSlash(filepath.Join("media", "boxart", "zelda.png")),
+				}},
+			},
+		},
+	}
+
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, targets))
+
+	for _, mediaDBID := range []int64{1, 2} {
+		hasSentinel, tagErr := mediaDB.MediaHasTag(ctx, mediaDBID, "scraper.test:scraped")
+		require.NoError(t, tagErr)
+		assert.True(t, hasSentinel)
+	}
+
+	titleProps, err := mediaDB.GetMediaTitleProperties(ctx, 1)
+	require.NoError(t, err)
+	assert.Condition(t, func() bool {
+		for _, prop := range titleProps {
+			if prop.TypeTag == "property:description" && prop.Text == "Mario description" {
+				return true
+			}
+		}
+		return false
+	})
+
+	mediaProps, err := mediaDB.GetMediaProperties(ctx, 2)
+	require.NoError(t, err)
+	boxartPath := filepath.ToSlash(filepath.Join("media", "boxart", "zelda.png"))
+	assert.Condition(t, func() bool {
+		for _, prop := range mediaProps {
+			if prop.TypeTag == "property:image-boxart" && prop.Text == boxartPath {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestApplyScrapeResults_SkipsUnchangedTitleMetadataAndStillWritesSentinel(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	write := &database.ScrapeWrite{
+		Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+		TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+		TitleProps: []database.MediaProperty{{
+			TypeTag: "property:description",
+			Text:    "A classic",
+		}},
+	}
+	target := database.ScrapeWriteTarget{MediaDBID: 1, MediaTitleDBID: 1, Write: write}
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{target}))
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{target}))
+
+	var titleTagLinks int
+	require.NoError(t, mediaDB.sql.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM MediaTitleTags mtt
+		JOIN Tags t ON mtt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtt.MediaTitleDBID = 1 AND tt.Type = 'developer' AND t.Tag = 'nintendo'
+	`).Scan(&titleTagLinks))
+	assert.Equal(t, 1, titleTagLinks)
+
+	var titlePropRows int
+	require.NoError(t, mediaDB.sql.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM MediaTitleProperties mtp
+		JOIN Tags t ON mtp.TypeTagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtp.MediaTitleDBID = 1
+		  AND tt.Type = 'property'
+		  AND t.Tag = 'description'
+		  AND mtp.Text = 'A classic'
+	`).Scan(&titlePropRows))
+	assert.Equal(t, 1, titlePropRows)
+
+	hasSentinel, err := mediaDB.MediaHasTag(ctx, 1, "scraper.test:scraped")
+	require.NoError(t, err)
+	assert.True(t, hasSentinel)
+}
+
+func TestApplyScrapeResults_ReplacesChangedExclusiveTitleTags(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	first := database.ScrapeWriteTarget{
+		MediaDBID: 1, MediaTitleDBID: 1,
+		Write: &database.ScrapeWrite{
+			Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+			TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+		},
+	}
+	second := database.ScrapeWriteTarget{
+		MediaDBID: 1, MediaTitleDBID: 1,
+		Write: &database.ScrapeWrite{
+			Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+			TitleTags: []database.TagInfo{{Type: "developer", Tag: "capcom"}},
+		},
+	}
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{first}))
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{second}))
+
+	var developerTags []string
+	rows, err := mediaDB.sql.QueryContext(ctx, `
+		SELECT t.Tag
+		FROM MediaTitleTags mtt
+		JOIN Tags t ON mtt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtt.MediaTitleDBID = 1 AND tt.Type = 'developer'
+		ORDER BY t.Tag
+	`)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+	for rows.Next() {
+		var tag string
+		require.NoError(t, rows.Scan(&tag))
+		developerTags = append(developerTags, tag)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"capcom"}, developerTags)
+}
+
+func TestApplyScrapeResults_ExclusiveTitleTagReplaceKeepsOtherTypes(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	first := database.ScrapeWriteTarget{
+		MediaDBID: 1, MediaTitleDBID: 1,
+		Write: &database.ScrapeWrite{
+			Sentinel: database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+			TitleTags: []database.TagInfo{
+				{Type: "developer", Tag: "nintendo"},
+				{Type: "genre", Tag: "platformer"},
+			},
+		},
+	}
+	second := database.ScrapeWriteTarget{
+		MediaDBID: 1, MediaTitleDBID: 1,
+		Write: &database.ScrapeWrite{
+			Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+			TitleTags: []database.TagInfo{{Type: "developer", Tag: "capcom"}},
+		},
+	}
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{first}))
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{second}))
+
+	assert.Equal(t, []string{"capcom"}, getTitleTagValuesForType(ctx, t, mediaDB, "developer"))
+	assert.Equal(t, []string{"platformer"}, getTitleTagValuesForType(ctx, t, mediaDB, "genre"))
+}
+
+func getTitleTagValuesForType(ctx context.Context, t *testing.T, mediaDB *MediaDB, typeName string) []string {
+	t.Helper()
+	rows, err := mediaDB.sql.QueryContext(ctx, `
+		SELECT t.Tag
+		FROM MediaTitleTags mtt
+		JOIN Tags t ON mtt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtt.MediaTitleDBID = 1 AND tt.Type = ?
+		ORDER BY t.Tag
+	`, typeName)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+
+	var values []string
+	for rows.Next() {
+		var tag string
+		require.NoError(t, rows.Scan(&tag))
+		values = append(values, tag)
+	}
+	require.NoError(t, rows.Err())
+	return values
+}
+
+func TestApplyScrapeResults_RollsBackWholeBatchBeforeSentinel(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	err = mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				MediaTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+			},
+		},
+		{
+			MediaDBID: 2, MediaTitleDBID: 2,
+			Write: &database.ScrapeWrite{
+				Sentinel: database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleProps: []database.MediaProperty{{
+					TypeTag: "property:missing-type-tag",
+					Text:    "should fail",
+				}},
+			},
+		},
+	})
+	require.Error(t, err)
+
+	for _, mediaDBID := range []int64{1, 2} {
+		hasSentinel, tagErr := mediaDB.MediaHasTag(ctx, mediaDBID, "scraper.test:scraped")
+		require.NoError(t, tagErr)
+		assert.False(t, hasSentinel)
+	}
+	hasDeveloper, err := mediaDB.MediaHasTag(ctx, 1, "developer:nintendo")
+	require.NoError(t, err)
+	assert.False(t, hasDeveloper)
+}
+
+func TestApplyScrapeResults_DoesNotDuplicateSharedTags(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	sharedWrite := func() *database.ScrapeWrite {
+		return &database.ScrapeWrite{
+			Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+			TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+		}
+	}
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{
+		{MediaDBID: 1, MediaTitleDBID: 1, Write: sharedWrite()},
+		{MediaDBID: 2, MediaTitleDBID: 2, Write: sharedWrite()},
+	}))
+
+	var tagCount int
+	require.NoError(t, mediaDB.sql.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM Tags t JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE tt.Type = 'developer' AND t.Tag = 'nintendo'
+	`).Scan(&tagCount))
+	assert.Equal(t, 1, tagCount)
+}
+
+func TestApplyScrapeResults_BulkExclusiveTitleTagLaterTargetWins(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "mario-alt.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 1, 1, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+			},
+		},
+		{
+			MediaDBID: 2, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleTags: []database.TagInfo{{Type: "developer", Tag: "capcom"}},
+			},
+		},
+	}))
+
+	var developerTags []string
+	rows, err := mediaDB.sql.QueryContext(ctx, `
+		SELECT t.Tag
+		FROM MediaTitleTags mtt
+		JOIN Tags t ON mtt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtt.MediaTitleDBID = 1 AND tt.Type = 'developer'
+		ORDER BY t.Tag
+	`)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+	for rows.Next() {
+		var tag string
+		require.NoError(t, rows.Scan(&tag))
+		developerTags = append(developerTags, tag)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"capcom"}, developerTags)
+}
+
+func TestApplyScrapeResults_BulkAdditiveTitleTagsAccumulate(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleTags: []database.TagInfo{{Type: "genre", Tag: "action"}},
+			},
+		},
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleTags: []database.TagInfo{{Type: "genre", Tag: "platformer"}},
+			},
+		},
+	}))
+
+	var genreTags []string
+	rows, err := mediaDB.sql.QueryContext(ctx, `
+		SELECT t.Tag
+		FROM MediaTitleTags mtt
+		JOIN Tags t ON mtt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtt.MediaTitleDBID = 1 AND tt.Type = 'genre'
+		ORDER BY t.Tag
+	`)
+	require.NoError(t, err)
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			t.Fatalf("failed to close rows: %v", closeErr)
+		}
+	}()
+	for rows.Next() {
+		var tag string
+		require.NoError(t, rows.Scan(&tag))
+		genreTags = append(genreTags, tag)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"action", "platformer"}, genreTags)
+}
+
+func TestApplyScrapeResults_BulkTitlePropertyLaterTargetWins(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "mario-alt.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 1, 1, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.ApplyScrapeResults(ctx, []database.ScrapeWriteTarget{
+		{
+			MediaDBID: 1, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel: database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleProps: []database.MediaProperty{{
+					TypeTag: "property:description",
+					Text:    "first",
+				}},
+			},
+		},
+		{
+			MediaDBID: 2, MediaTitleDBID: 1,
+			Write: &database.ScrapeWrite{
+				Sentinel: database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+				TitleProps: []database.MediaProperty{{
+					TypeTag: "property:description",
+					Text:    "second",
+				}},
+			},
+		},
+	}))
+
+	var text string
+	require.NoError(t, mediaDB.sql.QueryRowContext(ctx, `
+		SELECT mtp.Text
+		FROM MediaTitleProperties mtp
+		JOIN Tags t ON mtp.TypeTagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE mtp.MediaTitleDBID = 1 AND tt.Type = 'property' AND t.Tag = 'description'
+	`).Scan(&text))
+	assert.Equal(t, "second", text)
+}
+
+func TestApplyScrapeResults_RejectsNilWrite(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	err := mediaDB.ApplyScrapeResults(context.Background(), []database.ScrapeWriteTarget{
+		{MediaDBID: 1, MediaTitleDBID: 1},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write is nil")
 }
 
 // --- UpsertMediaTags ---
@@ -977,6 +1462,17 @@ func TestFindMediaTitlesWithoutSentinel_AllUnseen(t *testing.T) {
 	assert.Len(t, titles, 1, "mario title has no sentinel → should be returned")
 }
 
+func TestFindMediaTitlesWithoutSentinel_MissingSentinelReturnsAllSystemTitles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	titles, err := mediaDB.FindMediaTitlesWithoutSentinel(context.Background(), 1, "scraper.missing:scraped")
+	require.NoError(t, err)
+	assert.Len(t, titles, 1)
+	assert.Equal(t, "mario", titles[0].Slug)
+}
+
 func TestFindMediaTitlesWithoutSentinel_AfterSentinelWritten(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)
@@ -991,6 +1487,22 @@ func TestFindMediaTitlesWithoutSentinel_AfterSentinelWritten(t *testing.T) {
 	titles, err := mediaDB.FindMediaTitlesWithoutSentinel(ctx, 1, "scraper.test:scraped")
 	require.NoError(t, err)
 	assert.Empty(t, titles, "media has sentinel → title should be excluded")
+}
+
+func TestFindMediaTitlesWithoutSentinel_UsesRequestedTagValue(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, []database.TagInfo{
+		{Type: "scraper.test", Tag: "scraped"},
+	}))
+
+	titles, err := mediaDB.FindMediaTitlesWithoutSentinel(ctx, 1, "scraper.test:other")
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "mario", titles[0].Slug)
 }
 
 func TestFindMediaTitlesWithoutSentinel_WrongSystem(t *testing.T) {

--- a/pkg/database/mediadb/sql_trace_bench_test.go
+++ b/pkg/database/mediadb/sql_trace_bench_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/stretchr/testify/require"
 
 	sqlite3 "github.com/mattn/go-sqlite3"
@@ -35,7 +36,7 @@ type sqlTraceAggregate struct {
 }
 
 type sqlTraceCollector struct {
-	mu           sync.Mutex
+	mu           syncutil.Mutex
 	byStmt       map[string]*sqlTraceAggregate
 	stmtByHandle map[uintptr]string
 }

--- a/pkg/database/mediadb/sql_trace_bench_test.go
+++ b/pkg/database/mediadb/sql_trace_bench_test.go
@@ -1,0 +1,181 @@
+//go:build sqlite_trace || trace
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/require"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+const sqliteTraceBenchDriver = "sqlite3_trace_bench"
+
+var registerTraceBenchDriverOnce sync.Once
+
+type sqlTraceAggregate struct {
+	Total time.Duration
+	Max   time.Duration
+	Count int
+}
+
+type sqlTraceCollector struct {
+	mu           sync.Mutex
+	byStmt       map[string]*sqlTraceAggregate
+	stmtByHandle map[uintptr]string
+}
+
+func BenchmarkApplyScrapeResults_CompanionBatchTrace_10(b *testing.B) {
+	b.ReportAllocs()
+	collector := &sqlTraceCollector{
+		byStmt:       make(map[string]*sqlTraceAggregate),
+		stmtByHandle: make(map[uintptr]string),
+	}
+	mediaDB, cleanup := setupTraceBenchMediaDB(b, scraperBenchRows, collector)
+	defer cleanup()
+
+	targets := make([]database.ScrapeWriteTarget, 10)
+	for i := range targets {
+		mediaDBID := int64(i + 1)
+		targets[i] = database.ScrapeWriteTarget{
+			MediaDBID:      mediaDBID,
+			MediaTitleDBID: mediaDBID,
+			Write: &database.ScrapeWrite{
+				Sentinel:   database.TagInfo{Type: "scraper.bench", Tag: "scraped"},
+				TitleTags:  benchTitleTags(mediaDBID),
+				TitleProps: benchTitleProps(mediaDBID),
+			},
+		}
+	}
+
+	ctx := context.Background()
+	collector.reset()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := mediaDB.ApplyScrapeResults(ctx, targets); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	collector.logTop(b, 20)
+}
+
+func setupTraceBenchMediaDB(b *testing.B, rows int, collector *sqlTraceCollector) (*MediaDB, func()) {
+	b.Helper()
+	registerTraceBenchDriverOnce.Do(func() {
+		sql.Register(sqliteTraceBenchDriver, &sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				return conn.SetTrace(&sqlite3.TraceConfig{
+					Callback:  collector.callback,
+					EventMask: sqlite3.TraceStmt | sqlite3.TraceProfile,
+				})
+			},
+		})
+	})
+
+	tempDir, err := os.MkdirTemp("", "zaparoo-trace-bench-mediadb-*")
+	require.NoError(b, err)
+	dbPath := filepath.Join(tempDir, config.MediaDbFile)
+	sqlDB, err := sql.Open(sqliteTraceBenchDriver, dbPath+getSqliteConnParams())
+	require.NoError(b, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	mediaDB := &MediaDB{sql: sqlDB, dbPath: dbPath, ctx: context.Background()}
+	require.NoError(b, mediaDB.Allocate())
+	seedBenchScraperDB(b, mediaDB, rows)
+
+	cleanup := func() {
+		_ = mediaDB.Close()
+		_ = os.RemoveAll(tempDir)
+	}
+	return mediaDB, cleanup
+}
+
+func (c *sqlTraceCollector) reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byStmt = make(map[string]*sqlTraceAggregate)
+	c.stmtByHandle = make(map[uintptr]string)
+}
+
+func (c *sqlTraceCollector) callback(info sqlite3.TraceInfo) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if info.EventCode == sqlite3.TraceStmt {
+		stmt := normalizeSQLTraceStatement(info.StmtOrTrigger)
+		if stmt != "" {
+			c.stmtByHandle[info.StmtHandle] = stmt
+		}
+		return 0
+	}
+	if info.EventCode != sqlite3.TraceProfile {
+		return 0
+	}
+	stmt := c.stmtByHandle[info.StmtHandle]
+	if stmt == "" {
+		stmt = normalizeSQLTraceStatement(info.StmtOrTrigger)
+	}
+	if stmt == "" {
+		return 0
+	}
+	duration := time.Duration(info.RunTimeNanosec)
+	agg, ok := c.byStmt[stmt]
+	if !ok {
+		agg = &sqlTraceAggregate{}
+		c.byStmt[stmt] = agg
+	}
+	agg.Count++
+	agg.Total += duration
+	if duration > agg.Max {
+		agg.Max = duration
+	}
+	return 0
+}
+
+func (c *sqlTraceCollector) logTop(b *testing.B, limit int) {
+	b.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	type row struct {
+		stmt string
+		agg  sqlTraceAggregate
+	}
+	rows := make([]row, 0, len(c.byStmt))
+	for stmt, agg := range c.byStmt {
+		rows = append(rows, row{stmt: stmt, agg: *agg})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].agg.Total > rows[j].agg.Total
+	})
+	if len(rows) < limit {
+		limit = len(rows)
+	}
+	for i := 0; i < limit; i++ {
+		agg := rows[i].agg
+		avg := time.Duration(0)
+		if agg.Count > 0 {
+			avg = agg.Total / time.Duration(agg.Count)
+		}
+		b.Logf("sql-trace rank=%d count=%d total=%s avg=%s max=%s sql=%s",
+			i+1, agg.Count, agg.Total, avg, agg.Max, rows[i].stmt)
+	}
+}
+
+func normalizeSQLTraceStatement(stmt string) string {
+	return strings.Join(strings.Fields(stmt), " ")
+}

--- a/pkg/database/mediadb/sql_trace_runtime.go
+++ b/pkg/database/mediadb/sql_trace_runtime.go
@@ -1,0 +1,204 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build sqlite_trace || trace
+
+package mediadb
+
+import (
+	"database/sql"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	sqliteTraceRuntimeDriver = "sqlite3_zaparoo_trace"
+	sqlTraceLogInterval      = 60 * time.Second
+	sqlTraceTopStatements    = 10
+)
+
+type runtimeSQLTraceCollector struct {
+	mu         syncutil.Mutex
+	statements map[uintptr]string
+	stats      map[string]*runtimeSQLTraceStatement
+	lastLog    time.Time
+}
+
+type runtimeSQLTraceStatement struct {
+	statement string
+	operation string
+	count     int64
+	total     time.Duration
+	max       time.Duration
+	firstSeen time.Time
+	lastSeen  time.Time
+}
+
+var runtimeSQLTrace = newRuntimeSQLTraceCollector()
+
+func init() {
+	sql.Register(sqliteTraceRuntimeDriver, &sqlite3.SQLiteDriver{
+		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			if !config.IsDevelopmentVersion() {
+				return nil
+			}
+			return conn.SetTrace(&sqlite3.TraceConfig{
+				Callback:        runtimeSQLTrace.callback,
+				EventMask:       sqlite3.TraceStmt | sqlite3.TraceProfile,
+				WantExpandedSQL: false,
+			})
+		},
+	})
+}
+
+func sqliteDriverName() string {
+	if config.IsDevelopmentVersion() {
+		return sqliteTraceRuntimeDriver
+	}
+	return "sqlite3"
+}
+
+func newRuntimeSQLTraceCollector() *runtimeSQLTraceCollector {
+	return &runtimeSQLTraceCollector{
+		statements: make(map[uintptr]string),
+		stats:      make(map[string]*runtimeSQLTraceStatement),
+	}
+}
+
+func (c *runtimeSQLTraceCollector) callback(info sqlite3.TraceInfo) int {
+	switch info.EventCode {
+	case sqlite3.TraceStmt:
+		c.recordStatement(info.StmtHandle, info.StmtOrTrigger)
+	case sqlite3.TraceProfile:
+		c.recordProfile(info.StmtHandle, time.Duration(info.RunTimeNanosec))
+	}
+	return 0
+}
+
+func (c *runtimeSQLTraceCollector) recordStatement(handle uintptr, statement string) {
+	statement = normalizeRuntimeSQLStatement(statement)
+	if statement == "" || strings.HasPrefix(statement, "--") {
+		return
+	}
+	c.mu.Lock()
+	c.statements[handle] = statement
+	c.mu.Unlock()
+}
+
+func (c *runtimeSQLTraceCollector) recordProfile(handle uintptr, duration time.Duration) {
+	now := time.Now()
+	var shouldLog bool
+
+	c.mu.Lock()
+	statement := c.statements[handle]
+	if statement == "" {
+		statement = "<unknown>"
+	}
+	entry := c.stats[statement]
+	if entry == nil {
+		entry = &runtimeSQLTraceStatement{
+			statement: statement,
+			operation: sqlOperation(statement),
+			firstSeen: now,
+		}
+		c.stats[statement] = entry
+	}
+	entry.count++
+	entry.total += duration
+	if duration > entry.max {
+		entry.max = duration
+	}
+	entry.lastSeen = now
+	if c.lastLog.IsZero() || now.Sub(c.lastLog) >= sqlTraceLogInterval {
+		c.lastLog = now
+		shouldLog = true
+	}
+	c.mu.Unlock()
+
+	if shouldLog {
+		logSQLTraceSummary()
+	}
+}
+
+func logSQLTraceSummary() {
+	runtimeSQLTrace.logTop(sqlTraceTopStatements)
+}
+
+func (c *runtimeSQLTraceCollector) logTop(limit int) {
+	c.mu.Lock()
+	if len(c.stats) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	top := make([]runtimeSQLTraceStatement, 0, len(c.stats))
+	for _, entry := range c.stats {
+		top = append(top, *entry)
+	}
+	c.mu.Unlock()
+
+	sort.Slice(top, func(i, j int) bool {
+		if top[i].total == top[j].total {
+			return top[i].count > top[j].count
+		}
+		return top[i].total > top[j].total
+	})
+	if limit > len(top) {
+		limit = len(top)
+	}
+	for i := 0; i < limit; i++ {
+		entry := top[i]
+		avg := time.Duration(0)
+		if entry.count > 0 {
+			avg = entry.total / time.Duration(entry.count)
+		}
+		log.Debug().
+			Int("rank", i+1).
+			Str("operation", entry.operation).
+			Int64("count", entry.count).
+			Float64("total_duration_ms", durationMillis(entry.total)).
+			Float64("avg_duration_ms", durationMillis(avg)).
+			Float64("max_duration_ms", durationMillis(entry.max)).
+			Time("first_seen", entry.firstSeen).
+			Time("last_seen", entry.lastSeen).
+			Str("sql", entry.statement).
+			Msg("mediadb: sql trace top statement")
+	}
+}
+
+func durationMillis(duration time.Duration) float64 {
+	return float64(duration) / float64(time.Millisecond)
+}
+
+func normalizeRuntimeSQLStatement(statement string) string {
+	return strings.Join(strings.Fields(statement), " ")
+}
+
+func sqlOperation(statement string) string {
+	fields := strings.Fields(statement)
+	if len(fields) == 0 {
+		return "unknown"
+	}
+	return strings.ToUpper(fields[0])
+}

--- a/pkg/database/mediadb/sql_trace_runtime_stub.go
+++ b/pkg/database/mediadb/sql_trace_runtime_stub.go
@@ -1,0 +1,28 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !sqlite_trace && !trace
+
+package mediadb
+
+func sqliteDriverName() string {
+	return "sqlite3"
+}
+
+func logSQLTraceSummary() {}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1856,7 +1856,7 @@ func matchCompanionChildMedia(
 ) companionMediaMatch {
 	filename := filepath.Base(child.ResolvedPath)
 	if strings.EqualFold(filepath.Ext(filename), ".slug") {
-		slug := strings.TrimSuffix(filename, filepath.Ext(filename))
+		slug := strings.ToLower(strings.TrimSuffix(filename, filepath.Ext(filename)))
 		title, ok := indexes.AllTitlesBySlug[slug]
 		if !ok {
 			title, ok = indexes.TitlesBySlug[slug]

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -108,9 +108,76 @@ type GamelistXMLScraper struct {
 }
 
 type companionStats struct {
-	Processed int
-	Matched   int
-	Skipped   int
+	WriteStats             scrapeWriteStats
+	Processed              int
+	Matched                int
+	Skipped                int
+	MissingTitleSlugs      int
+	MissingTitleMedia      int
+	AmbiguousFilenames     int
+	UnmatchedFilenames     int
+	UniqueTitleWrites      int
+	DuplicateTitles        int
+	ConflictingTitleWrites int
+}
+
+type scrapeWriteStats struct {
+	UniqueTitleDBIDs map[int64]struct{}
+	TotalDuration    time.Duration
+	MaxDuration      time.Duration
+	TitleTags        int
+	MediaTags        int
+	TitleProps       int
+	MediaProps       int
+	Sentinels        int
+	Writes           int
+	Batches          int
+	BatchFallbacks   int
+}
+
+func (s *scrapeWriteStats) recordWrite(target database.ScrapeWriteTarget, duration time.Duration) {
+	s.recordDuration(duration)
+	s.recordTarget(target)
+}
+
+func (s *scrapeWriteStats) recordBatch(targets []database.ScrapeWriteTarget, duration time.Duration) {
+	s.Batches++
+	s.recordDuration(duration)
+	for _, target := range targets {
+		s.recordTarget(target)
+	}
+}
+
+func (s *scrapeWriteStats) recordDuration(duration time.Duration) {
+	if duration <= 0 {
+		return
+	}
+	s.TotalDuration += duration
+	if duration > s.MaxDuration {
+		s.MaxDuration = duration
+	}
+}
+
+func (s *scrapeWriteStats) recordTarget(target database.ScrapeWriteTarget) {
+	s.Writes++
+	s.Sentinels++
+	if target.Write == nil {
+		return
+	}
+	s.MediaTags += len(target.Write.MediaTags)
+	s.TitleTags += len(target.Write.TitleTags)
+	s.MediaProps += len(target.Write.MediaProps)
+	s.TitleProps += len(target.Write.TitleProps)
+	if s.UniqueTitleDBIDs != nil {
+		s.UniqueTitleDBIDs[target.MediaTitleDBID] = struct{}{}
+	}
+}
+
+func (s *scrapeWriteStats) averageDuration() time.Duration {
+	if s.Writes == 0 {
+		return 0
+	}
+	return s.TotalDuration / time.Duration(s.Writes)
 }
 
 type loadRecordIndexes struct {
@@ -118,6 +185,7 @@ type loadRecordIndexes struct {
 	AllTitlesBySlug  map[string]database.MediaTitle
 	MediaByPathFold  map[string]database.Media
 	MediaByTitleDBID map[int64][]database.Media
+	MediaByFilename  map[string][]database.Media
 }
 
 func (g *GamelistXMLScraper) filesystem() afero.Fs {
@@ -243,26 +311,26 @@ func resolveSystemsFromPlatform(
 	return result, nil
 }
 
-// LoadRecords iterates gamelist.xml files found under each ROM root path for
-// the given system. It prefers the original slug/title match, uses the XML path
-// to select the concrete Media row for that title when possible, and falls back
-// to path-only matching for records whose slug is not indexed.
-func (g *GamelistXMLScraper) LoadRecords(
+type parsedGamelistFile struct {
+	RootPath           string
+	GamelistPath       string
+	AvailableMediaDirs map[string]string
+	Games              []esapi.Game
+}
+
+type parsedGamelistSystem struct {
+	Files []parsedGamelistFile
+}
+
+func (g *GamelistXMLScraper) loadParsedGamelistSystem(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
-	indexes loadRecordIndexes,
-) ([]*GamelistRecord, error) {
-	var records []*GamelistRecord
-	candidateMedia := len(indexes.MediaByPathFold)
-	candidateTitles := len(indexes.TitlesBySlug)
-	var gamelistFiles, gamelistEntries, companionEntriesSkipped, invalidPaths int
-	var slugMatches, slugPathSelections, slugFirstMediaFallbacks, pathOnlyFallbacks, unmatchedRecords int
-
-outer:
+) (parsedGamelistSystem, error) {
+	var parsed parsedGamelistSystem
 	for _, rootPath := range system.ROMPaths {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return parsed, ctx.Err()
 		default:
 		}
 
@@ -278,23 +346,67 @@ outer:
 			continue
 		}
 
-		gamelistFiles++
-		gamelistEntries += len(gl.Games)
 		log.Info().
 			Str("path", gamelistPath).
 			Int("entries", len(gl.Games)).
 			Msg("gamelistxml: loaded gamelist.xml")
+		parsed.Files = append(parsed.Files, parsedGamelistFile{
+			RootPath:           rootPath,
+			GamelistPath:       gamelistPath,
+			AvailableMediaDirs: statMediaDirsFS(g.filesystem(), rootPath),
+			Games:              gl.Games,
+		})
+	}
+	return parsed, nil
+}
 
-		availableMediaDirs := statMediaDirsFS(g.filesystem(), rootPath)
+// LoadRecords iterates gamelist.xml files found under each ROM root path for
+// the given system. It prefers the original slug/title match, uses the XML path
+// to select the concrete Media row for that title when possible, and falls back
+// to path-only matching for records whose slug is not indexed.
+func (g *GamelistXMLScraper) LoadRecords(
+	ctx context.Context,
+	system scraper.ScrapeSystem,
+	indexes loadRecordIndexes,
+) ([]*GamelistRecord, error) {
+	parsed, err := g.loadParsedGamelistSystem(ctx, system)
+	if err != nil {
+		return nil, err
+	}
+	return g.loadRecordsFromParsed(ctx, system, indexes, parsed)
+}
 
-		for i := range gl.Games {
-			game := &gl.Games[i]
+func (g *GamelistXMLScraper) loadRecordsFromParsed(
+	ctx context.Context,
+	system scraper.ScrapeSystem,
+	indexes loadRecordIndexes,
+	parsed parsedGamelistSystem,
+) ([]*GamelistRecord, error) {
+	var records []*GamelistRecord
+	candidateMedia := len(indexes.MediaByPathFold)
+	candidateTitles := len(indexes.TitlesBySlug)
+	var gamelistFiles, gamelistEntries, companionEntriesSkipped, invalidPaths int
+	var slugMatches, slugPathSelections, slugFirstMediaFallbacks, pathOnlyFallbacks, unmatchedRecords int
+
+outer:
+	for _, file := range parsed.Files {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		gamelistFiles++
+		gamelistEntries += len(file.Games)
+
+		for i := range file.Games {
+			game := &file.Games[i]
 			if isCompanionGame(game) {
 				companionEntriesSkipped++
 				continue
 			}
 
-			resolved := resolveESPath(game.Path, rootPath)
+			resolved := resolveESPath(game.Path, file.RootPath)
 			if resolved == "" {
 				invalidPaths++
 				continue
@@ -331,8 +443,8 @@ outer:
 					slugFirstMediaFallbacks++
 				}
 				records = append(records, &GamelistRecord{
-					SystemRootPath:      rootPath,
-					AvailableMediaDirs:  availableMediaDirs,
+					SystemRootPath:      file.RootPath,
+					AvailableMediaDirs:  file.AvailableMediaDirs,
 					Game:                *game,
 					MatchKind:           selection.matchKind,
 					MatchedTitleDBID:    title.DBID,
@@ -361,8 +473,8 @@ outer:
 					Int64("mediaTitleDBID", media.MediaTitleDBID).
 					Msg("gamelistxml: path-only fallback matched record")
 				records = append(records, &GamelistRecord{
-					SystemRootPath:      rootPath,
-					AvailableMediaDirs:  availableMediaDirs,
+					SystemRootPath:      file.RootPath,
+					AvailableMediaDirs:  file.AvailableMediaDirs,
 					Game:                *game,
 					MatchKind:           gamelistMatchPathOnly,
 					MatchedTitleDBID:    media.MediaTitleDBID,
@@ -402,7 +514,10 @@ outer:
 	return records, nil
 }
 
-const scrapeProgressInterval = 250 * time.Millisecond
+const (
+	scrapeProgressInterval  = 250 * time.Millisecond
+	companionWriteBatchSize = 10
+)
 
 // scrapeLoop runs the full load→match→write cycle for all systems, emitting
 // progress updates on ch. It closes ch when done.
@@ -446,25 +561,16 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		case ch <- scraper.ScrapeUpdate{SystemID: system.ID, Total: 0}:
 		}
 
-		// Process ZaparooCompanion parent/child entries before regular slug scrape.
-		companion := g.processCompanionEntries(ctx, opts, system, mdb)
-
 		titlesBySlug := make(map[string]database.MediaTitle)
 		allTitlesBySlug := make(map[string]database.MediaTitle)
 		if opts.Force {
 			allTitles, titlesErr := mdb.GetTitlesBySystemID(system.ID)
 			if titlesErr != nil {
 				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
-					ch <- scraper.ScrapeUpdate{
-						SystemID: system.ID, Done: true, Processed: companion.Processed,
-						Matched: companion.Matched, Skipped: companion.Skipped,
-					}
+					ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
 					return
 				}
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, FatalErr: titlesErr,
-					Done: true, Processed: companion.Processed, Matched: companion.Matched, Skipped: companion.Skipped,
-				}
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: titlesErr, Done: true}
 				return
 			}
 			for _, t := range allTitles {
@@ -480,16 +586,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			unscraped, titlesErr := mdb.FindMediaTitlesWithoutSentinel(ctx, system.DBID, sentinelTag)
 			if titlesErr != nil {
 				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
-					ch <- scraper.ScrapeUpdate{
-						SystemID: system.ID, Done: true, Processed: companion.Processed,
-						Matched: companion.Matched, Skipped: companion.Skipped,
-					}
+					ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
 					return
 				}
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, FatalErr: titlesErr,
-					Done: true, Processed: companion.Processed, Matched: companion.Matched, Skipped: companion.Skipped,
-				}
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: titlesErr, Done: true}
 				return
 			}
 			for _, t := range unscraped {
@@ -498,16 +598,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			allTitles, allTitlesErr := mdb.GetTitlesBySystemID(system.ID)
 			if allTitlesErr != nil {
 				if errors.Is(allTitlesErr, context.Canceled) || errors.Is(allTitlesErr, context.DeadlineExceeded) {
-					ch <- scraper.ScrapeUpdate{
-						SystemID: system.ID, Done: true, Processed: companion.Processed,
-						Matched: companion.Matched, Skipped: companion.Skipped,
-					}
+					ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
 					return
 				}
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, FatalErr: allTitlesErr,
-					Done: true, Processed: companion.Processed, Matched: companion.Matched, Skipped: companion.Skipped,
-				}
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: allTitlesErr, Done: true}
 				return
 			}
 			for _, t := range allTitles {
@@ -520,16 +614,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		allMedia, mediaErr := mdb.GetMediaBySystemID(system.ID)
 		if mediaErr != nil {
 			if errors.Is(mediaErr, context.Canceled) || errors.Is(mediaErr, context.DeadlineExceeded) {
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, Done: true, Processed: companion.Processed,
-					Matched: companion.Matched, Skipped: companion.Skipped,
-				}
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
 				return
 			}
-			ch <- scraper.ScrapeUpdate{
-				SystemID: system.ID, FatalErr: mediaErr,
-				Done: true, Processed: companion.Processed, Matched: companion.Matched, Skipped: companion.Skipped,
-			}
+			ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: mediaErr, Done: true}
 			return
 		}
 		scrapedIDs := map[int64]struct{}{}
@@ -538,16 +626,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			scrapedIDs, scrapedErr = mdb.GetScrapedMediaIDs(ctx, id, system.DBID)
 			if scrapedErr != nil {
 				if errors.Is(scrapedErr, context.Canceled) || errors.Is(scrapedErr, context.DeadlineExceeded) {
-					ch <- scraper.ScrapeUpdate{
-						SystemID: system.ID, Done: true, Processed: companion.Processed,
-						Matched: companion.Matched, Skipped: companion.Skipped,
-					}
+					ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
 					return
 				}
-				ch <- scraper.ScrapeUpdate{
-					SystemID: system.ID, FatalErr: scrapedErr,
-					Done: true, Processed: companion.Processed, Matched: companion.Matched, Skipped: companion.Skipped,
-				}
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: scrapedErr, Done: true}
 				return
 			}
 		}
@@ -557,6 +639,7 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			AllTitlesBySlug:  allTitlesBySlug,
 			MediaByPathFold:  make(map[string]database.Media, len(allMedia)),
 			MediaByTitleDBID: make(map[int64][]database.Media, len(allMedia)),
+			MediaByFilename:  make(map[string][]database.Media, len(allMedia)),
 		}
 		for _, m := range allMedia {
 			media := database.Media{
@@ -567,8 +650,28 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			if _, scraped := scrapedIDs[m.DBID]; !scraped {
 				indexes.MediaByPathFold[pathFoldKey(m.Path)] = media
 				indexes.MediaByTitleDBID[m.MediaTitleDBID] = append(indexes.MediaByTitleDBID[m.MediaTitleDBID], media)
+				filenameKey := mediaFilenameKey(m.Path)
+				if filenameKey != "" {
+					indexes.MediaByFilename[filenameKey] = append(indexes.MediaByFilename[filenameKey], media)
+				}
 			}
 		}
+
+		parsed, parseErr := g.loadParsedGamelistSystem(ctx, system)
+		if parseErr != nil {
+			if errors.Is(parseErr, context.Canceled) || errors.Is(parseErr, context.DeadlineExceeded) {
+				ch <- scraper.ScrapeUpdate{SystemID: system.ID, Done: true}
+				return
+			}
+			ch <- scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: parseErr, Done: true}
+			return
+		}
+
+		companion := g.processCompanionEntriesFromParsed(ctx, opts, system, mdb, indexes, parsed, ch)
+		if !waitForResume(system.ID, companion.Processed, companion.Matched, companion.Skipped) {
+			return
+		}
+
 		if len(indexes.TitlesBySlug) == 0 && len(indexes.MediaByPathFold) == 0 {
 			if companion.Processed > 0 {
 				ch <- scraper.ScrapeUpdate{
@@ -585,7 +688,7 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			continue
 		}
 
-		records, loadErr := g.LoadRecords(ctx, system, indexes)
+		records, loadErr := g.loadRecordsFromParsed(ctx, system, indexes, parsed)
 		if loadErr != nil {
 			if errors.Is(loadErr, context.Canceled) || errors.Is(loadErr, context.DeadlineExceeded) {
 				ch <- scraper.ScrapeUpdate{
@@ -602,6 +705,7 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		}
 
 		var processed, matched, skipped int
+		regularWriteStats := scrapeWriteStats{UniqueTitleDBIDs: make(map[int64]struct{})}
 		totalRecords := len(records)
 		systemTotal := companion.Processed + totalRecords
 
@@ -712,15 +816,20 @@ func (g *GamelistXMLScraper) scrapeLoop(
 				return
 			}
 
-			writeErr := mdb.ApplyScrapeResult(
-				ctx, record.MatchedMediaDBID, record.MatchedTitleDBID,
-				&database.ScrapeWrite{
+			writeTarget := database.ScrapeWriteTarget{
+				MediaDBID:      record.MatchedMediaDBID,
+				MediaTitleDBID: record.MatchedTitleDBID,
+				Write: &database.ScrapeWrite{
 					Sentinel:   scraper.SentinelTagInfo(id),
 					MediaTags:  mapped.MediaTags,
 					MediaProps: mapped.MediaProps,
 					TitleTags:  mapped.TitleTags,
 					TitleProps: mapped.TitleProps,
-				})
+				},
+			}
+			writeStart := time.Now()
+			writeErr := mdb.ApplyScrapeResult(ctx, writeTarget.MediaDBID, writeTarget.MediaTitleDBID, writeTarget.Write)
+			regularWriteStats.recordWrite(writeTarget, time.Since(writeStart))
 			if writeErr != nil {
 				log.Warn().Err(writeErr).
 					Int64("mediaTitleDBID", record.MatchedTitleDBID).
@@ -745,6 +854,7 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		if !emitProgress(scraper.ScrapeUpdate{Processed: processed, Matched: matched, Skipped: skipped}, true) {
 			return
 		}
+		logScrapeWriteStats("gamelistxml: regular write stats", system.ID, &regularWriteStats)
 		totalProcessed += companion.Processed + processed
 		totalMatched += companion.Matched + matched
 		totalSkipped += companion.Skipped + skipped
@@ -1328,6 +1438,14 @@ func pathFoldKey(path string) string {
 	return strings.ToLower(filepath.ToSlash(filepath.Clean(path)))
 }
 
+func mediaFilenameKey(path string) string {
+	filename := filepath.Base(filepath.ToSlash(path))
+	if filename == "." || filename == string(filepath.Separator) {
+		return ""
+	}
+	return strings.ToLower(filename)
+}
+
 func readGameListXMLFS(fs afero.Fs, path string) (*esapi.GameList, error) {
 	data, err := afero.ReadFile(fs, path)
 	if err != nil {
@@ -1367,6 +1485,11 @@ type companionChild struct {
 	Lang         string
 }
 
+type companionMediaMatch struct {
+	Media               []database.Media
+	MediaLevelWriteSafe bool
+}
+
 // loadCompanionEntries scans all gamelist.xml files for the system and separates
 // entries with source="ZaparooCompanion" into parent records (id attr, no path) and
 // child records (parentid attr, has path).
@@ -1374,68 +1497,47 @@ func (g *GamelistXMLScraper) loadCompanionEntries(
 	ctx context.Context,
 	system scraper.ScrapeSystem,
 ) (parents []companionParent, children []companionChild) {
-	for _, rootPath := range system.ROMPaths {
-		select {
-		case <-ctx.Done():
-			return parents, children
-		default:
-		}
+	parsed, err := g.loadParsedGamelistSystem(ctx, system)
+	if err != nil {
+		return nil, nil
+	}
+	return companionEntriesFromParsed(ctx, system, parsed)
+}
 
-		gamelistPath := filepath.Join(rootPath, "gamelist.xml")
-		exists, statErr := afero.Exists(g.filesystem(), gamelistPath)
-		if statErr != nil || !exists {
-			continue
-		}
-
-		gl, err := readGameListXMLFS(g.filesystem(), gamelistPath)
-		if err != nil {
-			log.Warn().Err(err).Str("path", gamelistPath).
-				Msg("gamelistxml: companion: failed to read gamelist.xml")
-			continue
-		}
-
-		availableMediaDirs := statMediaDirsFS(g.filesystem(), rootPath)
-
-		for i := range gl.Games {
+func companionEntriesFromParsed(
+	ctx context.Context,
+	system scraper.ScrapeSystem,
+	parsed parsedGamelistSystem,
+) (parents []companionParent, children []companionChild) {
+	var skippedNonCompanion int
+	var skippedMalformed int
+	var unresolvedChildPaths int
+	for _, file := range parsed.Files {
+		for i := range file.Games {
 			select {
 			case <-ctx.Done():
 				return parents, children
 			default:
 			}
-			game := gl.Games[i]
+			game := file.Games[i]
 			if !isCompanionGame(&game) {
-				log.Debug().Str("source", game.Source).Msg("source not companion")
+				skippedNonCompanion++
 				continue
 			}
 			switch {
 			case game.ScreenScraperIDAttr != "" && game.Path == "":
-				log.Debug().
-					Str("gameID", game.ScreenScraperIDAttr).
-					Str("name", game.Name).
-					Str("gamelist", gamelistPath).
-					Msg("gamelistxml: companion: found parent entry")
 				parents = append(parents, companionParent{
 					Game:               game,
-					SystemRootPath:     rootPath,
-					AvailableMediaDirs: availableMediaDirs,
+					SystemRootPath:     file.RootPath,
+					AvailableMediaDirs: file.AvailableMediaDirs,
 					GameID:             game.ScreenScraperIDAttr,
 				})
 			case game.ParentIDAttr != "" && game.Path != "":
-				resolved := resolveESPath(game.Path, rootPath)
+				resolved := resolveESPath(game.Path, file.RootPath)
 				if resolved == "" {
-					log.Debug().
-						Str("path", game.Path).
-						Str("parentID", game.ParentIDAttr).
-						Str("gamelist", gamelistPath).
-						Msg("gamelistxml: companion: child path failed to resolve, skipping")
+					unresolvedChildPaths++
 					continue
 				}
-				log.Debug().
-					Str("parentID", game.ParentIDAttr).
-					Str("resolvedPath", resolved).
-					Str("region", game.Region).
-					Str("lang", game.Lang).
-					Msg("gamelistxml: companion: found child entry")
 				children = append(children, companionChild{
 					ResolvedPath: resolved,
 					ParentGameID: game.ParentIDAttr,
@@ -1443,15 +1545,18 @@ func (g *GamelistXMLScraper) loadCompanionEntries(
 					Lang:         cleanField(game.Lang),
 				})
 			default:
-				log.Debug().
-					Str("gameID", game.ScreenScraperIDAttr).
-					Str("parentID", game.ParentIDAttr).
-					Str("path", game.Path).
-					Str("name", game.Name).
-					Msg("gamelistxml: companion: entry skipped (no id+empty-path or parentid+path)")
+				skippedMalformed++
 			}
 		}
 	}
+	log.Debug().
+		Str("system", system.ID).
+		Int("parents", len(parents)).
+		Int("children", len(children)).
+		Int("skipped_non_companion", skippedNonCompanion).
+		Int("skipped_malformed", skippedMalformed).
+		Int("unresolved_child_paths", unresolvedChildPaths).
+		Msg("gamelistxml: companion: loaded entries")
 	return parents, children
 }
 
@@ -1483,8 +1588,26 @@ func (g *GamelistXMLScraper) processCompanionEntries(
 	opts scraper.ScrapeOptions,
 	system scraper.ScrapeSystem,
 	mdb database.MediaDBI,
+	indexes loadRecordIndexes,
+	ch chan<- scraper.ScrapeUpdate,
 ) companionStats {
-	parents, children := g.loadCompanionEntries(ctx, system)
+	parsed, err := g.loadParsedGamelistSystem(ctx, system)
+	if err != nil {
+		return companionStats{}
+	}
+	return g.processCompanionEntriesFromParsed(ctx, opts, system, mdb, indexes, parsed, ch)
+}
+
+func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
+	ctx context.Context,
+	opts scraper.ScrapeOptions,
+	system scraper.ScrapeSystem,
+	mdb database.MediaDBI,
+	indexes loadRecordIndexes,
+	parsed parsedGamelistSystem,
+	ch chan<- scraper.ScrapeUpdate,
+) companionStats {
+	parents, children := companionEntriesFromParsed(ctx, system, parsed)
 	if len(parents) == 0 && len(children) == 0 {
 		log.Debug().Msg("gamelistxml: companion entries not found")
 		return companionStats{}
@@ -1496,31 +1619,39 @@ func (g *GamelistXMLScraper) processCompanionEntries(
 		Int("children", len(children)).
 		Msg("gamelistxml: companion: processing entries")
 
-	// Phase 1: map each parent record to its tag+property writes.
 	parentMeta := make(map[string]scraper.MapResult, len(parents))
 	for i := range parents {
 		p := &parents[i]
 		parentMeta[p.GameID] = g.mapCompanionParentToResult(p)
-		log.Debug().
-			Str("gameID", p.GameID).
-			Str("name", p.Game.Name).
-			Int("tags", len(parentMeta[p.GameID].TitleTags)).
-			Int("props", len(parentMeta[p.GameID].TitleProps)).
-			Msg("gamelistxml: companion: parent mapped")
 	}
 	if len(children) == 0 {
 		return companionStats{}
 	}
 
-	mediaByTitleDBID, mediaErr := companionMediaByTitle(system.ID, mdb)
-	if mediaErr != nil {
-		log.Warn().Err(mediaErr).Str("system", system.ID).
-			Msg("gamelistxml: companion: failed to load media map, skipping companion entries")
-		return companionStats{Processed: len(children), Skipped: len(children)}
-	}
-
 	sentinel := scraper.SentinelTagInfo("gamelist.xml")
-	var stats companionStats
+	stats := companionStats{WriteStats: scrapeWriteStats{UniqueTitleDBIDs: make(map[int64]struct{})}}
+	lastProgress := time.Now().Add(-scrapeProgressInterval)
+	emitProgress := func(force bool) bool {
+		if ch == nil {
+			return true
+		}
+		if !force && time.Since(lastProgress) < scrapeProgressInterval {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case ch <- scraper.ScrapeUpdate{
+			SystemID:  system.ID,
+			Total:     len(children),
+			Processed: stats.Processed,
+			Matched:   stats.Matched,
+			Skipped:   stats.Skipped,
+		}:
+			lastProgress = time.Now()
+			return true
+		}
+	}
 
 	defer func() {
 		log.Info().
@@ -1530,117 +1661,238 @@ func (g *GamelistXMLScraper) processCompanionEntries(
 			Int("processed", stats.Processed).
 			Int("matched", stats.Matched).
 			Int("skipped", stats.Skipped).
+			Int("missing_title_slugs", stats.MissingTitleSlugs).
+			Int("missing_title_media", stats.MissingTitleMedia).
+			Int("ambiguous_filenames", stats.AmbiguousFilenames).
+			Int("unmatched_filenames", stats.UnmatchedFilenames).
+			Int("unique_title_writes", stats.UniqueTitleWrites).
+			Int("duplicate_title_writes", stats.DuplicateTitles).
+			Int("conflicting_title_writes", stats.ConflictingTitleWrites).
 			Bool("force", opts.Force).
 			Msg("gamelistxml: companion: finished entries")
+		logScrapeWriteStats("gamelistxml: companion write stats", system.ID, &stats.WriteStats)
 	}()
 
+	if !emitProgress(true) {
+		return stats
+	}
+	titlePayloadByTitleDBID := make(map[int64]string)
+	pendingWrites := make([]database.ScrapeWriteTarget, 0, companionWriteBatchSize)
+	flushWrites := func(force bool) bool {
+		if len(pendingWrites) == 0 || (!force && len(pendingWrites) < companionWriteBatchSize) {
+			return true
+		}
+		if !emitProgress(force) {
+			return false
+		}
+		succeeded, failed := applyCompanionWriteTargets(ctx, mdb, pendingWrites, &stats.WriteStats)
+		stats.Matched += succeeded
+		stats.Skipped += failed
+		pendingWrites = pendingWrites[:0]
+		return emitProgress(force)
+	}
 	for _, c := range children {
+		select {
+		case <-ctx.Done():
+			return stats
+		default:
+		}
 		stats.Processed++
 		meta, ok := parentMeta[c.ParentGameID]
 		if !ok {
-			log.Debug().Str("parentGameID", c.ParentGameID).
-				Msg("gamelistxml: companion: parent not found for child, skipping")
 			stats.Skipped++
+			if !emitProgress(false) {
+				return stats
+			}
 			continue
 		}
 
-		matched := g.matchCompanionChildMedia(ctx, system, c, mediaByTitleDBID, mdb)
-		if len(matched) == 0 {
+		matched := matchCompanionChildMedia(system, c, indexes, &stats)
+		if len(matched.Media) == 0 {
 			stats.Skipped++
+			if !emitProgress(false) {
+				return stats
+			}
 			continue
 		}
+		consumeCompanionMediaMatches(indexes, matched.Media)
 
-		for _, media := range matched {
-			writeErr := mdb.ApplyScrapeResult(ctx, media.DBID, media.MediaTitleDBID, &database.ScrapeWrite{
+		for _, media := range matched.Media {
+			write := &database.ScrapeWrite{
 				Sentinel:   sentinel,
-				MediaTags:  companionChildTags(c),
 				TitleTags:  meta.TitleTags,
 				TitleProps: meta.TitleProps,
-			})
-			if writeErr != nil {
-				log.Warn().Err(writeErr).
-					Int64("mediaDBID", media.DBID).
-					Int64("mediaTitleDBID", media.MediaTitleDBID).
-					Msg("gamelistxml: companion: write failed")
-				stats.Skipped++
-				continue
 			}
-			stats.Matched++
+			if matched.MediaLevelWriteSafe {
+				write.MediaTags = companionChildTags(c)
+			}
+			titlePayloadKey := companionTitlePayloadKey(write)
+			if existingKey, ok := titlePayloadByTitleDBID[media.MediaTitleDBID]; !ok {
+				titlePayloadByTitleDBID[media.MediaTitleDBID] = titlePayloadKey
+				stats.UniqueTitleWrites++
+			} else if existingKey == titlePayloadKey {
+				write.TitleTags = nil
+				write.TitleProps = nil
+				stats.DuplicateTitles++
+			} else {
+				stats.ConflictingTitleWrites++
+			}
+			pendingWrites = append(pendingWrites, database.ScrapeWriteTarget{
+				MediaDBID:      media.DBID,
+				MediaTitleDBID: media.MediaTitleDBID,
+				Write:          write,
+			})
+			if !flushWrites(false) {
+				return stats
+			}
+		}
+		if !emitProgress(false) {
+			return stats
 		}
 	}
+	if !flushWrites(true) {
+		return stats
+	}
+	_ = emitProgress(true)
 	return stats
 }
 
-func companionMediaByTitle(systemID string, mdb database.MediaDBI) (map[int64]database.Media, error) {
-	allMedia, err := mdb.GetMediaBySystemID(systemID)
-	if err != nil {
-		return nil, fmt.Errorf("load media by system %q: %w", systemID, err)
+func companionTitlePayloadKey(write *database.ScrapeWrite) string {
+	if write == nil {
+		return ""
 	}
-	mediaByTitleDBID := make(map[int64]database.Media, len(allMedia))
-	for _, m := range allMedia {
-		if _, exists := mediaByTitleDBID[m.MediaTitleDBID]; !exists {
-			mediaByTitleDBID[m.MediaTitleDBID] = database.Media{
-				DBID:           m.DBID,
-				MediaTitleDBID: m.MediaTitleDBID,
-				Path:           m.Path,
-			}
+	var b strings.Builder
+	_, _ = b.WriteString("tags:")
+	_, _ = b.WriteString(strconv.Itoa(len(write.TitleTags)))
+	for _, tag := range write.TitleTags {
+		appendKeyPart(&b, tag.Type)
+		appendKeyPart(&b, tag.Tag)
+	}
+	_, _ = b.WriteString("props:")
+	_, _ = b.WriteString(strconv.Itoa(len(write.TitleProps)))
+	for _, prop := range write.TitleProps {
+		appendKeyPart(&b, prop.TypeTag)
+		appendKeyPart(&b, prop.Text)
+		appendKeyPart(&b, prop.ContentType)
+		if prop.BlobDBID == nil {
+			_, _ = b.WriteString("nil;")
+			continue
 		}
+		appendKeyPart(&b, strconv.FormatInt(*prop.BlobDBID, 10))
 	}
-	return mediaByTitleDBID, nil
+	return b.String()
 }
 
-func (*GamelistXMLScraper) matchCompanionChildMedia(
+func appendKeyPart(b *strings.Builder, value string) {
+	_, _ = b.WriteString(strconv.Itoa(len(value)))
+	_ = b.WriteByte(':')
+	_, _ = b.WriteString(value)
+	_ = b.WriteByte(';')
+}
+
+func applyCompanionWriteTargets(
 	ctx context.Context,
+	mdb database.MediaDBI,
+	targets []database.ScrapeWriteTarget,
+	writeStats *scrapeWriteStats,
+) (succeeded, failed int) {
+	if len(targets) == 0 {
+		return 0, 0
+	}
+	if batcher, ok := mdb.(database.ScrapeResultBatchApplier); ok {
+		writeStart := time.Now()
+		err := batcher.ApplyScrapeResults(ctx, targets)
+		if err == nil {
+			writeStats.recordBatch(targets, time.Since(writeStart))
+			return len(targets), 0
+		}
+		writeStats.BatchFallbacks++
+		log.Warn().Err(err).
+			Int("targets", len(targets)).
+			Msg("gamelistxml: companion: batch write failed, falling back to per-target writes")
+	}
+
+	for _, target := range targets {
+		writeStart := time.Now()
+		err := mdb.ApplyScrapeResult(ctx, target.MediaDBID, target.MediaTitleDBID, target.Write)
+		writeStats.recordWrite(target, time.Since(writeStart))
+		if err != nil {
+			log.Warn().Err(err).
+				Int64("mediaDBID", target.MediaDBID).
+				Int64("mediaTitleDBID", target.MediaTitleDBID).
+				Msg("gamelistxml: companion: write failed")
+			failed++
+			continue
+		}
+		succeeded++
+	}
+	return succeeded, failed
+}
+
+func logScrapeWriteStats(message, systemID string, stats *scrapeWriteStats) {
+	log.Info().
+		Str("system", systemID).
+		Int("writes", stats.Writes).
+		Int("batches", stats.Batches).
+		Int("batch_fallbacks", stats.BatchFallbacks).
+		Dur("total_write_duration", stats.TotalDuration).
+		Dur("avg_write_duration", stats.averageDuration()).
+		Dur("max_write_duration", stats.MaxDuration).
+		Int("media_tag_writes", stats.MediaTags).
+		Int("title_tag_writes", stats.TitleTags).
+		Int("media_property_writes", stats.MediaProps).
+		Int("title_property_writes", stats.TitleProps).
+		Int("sentinel_writes", stats.Sentinels).
+		Int("unique_title_writes", len(stats.UniqueTitleDBIDs)).
+		Int("duplicate_title_writes", stats.Writes-len(stats.UniqueTitleDBIDs)).
+		Msg(message)
+}
+
+func matchCompanionChildMedia(
 	system scraper.ScrapeSystem,
 	child companionChild,
-	mediaByTitleDBID map[int64]database.Media,
-	mdb database.MediaDBI,
-) []database.Media {
+	indexes loadRecordIndexes,
+	stats *companionStats,
+) companionMediaMatch {
 	filename := filepath.Base(child.ResolvedPath)
-	if filepath.Ext(filename) == ".slug" {
-		slug := strings.TrimSuffix(filename, ".slug")
-		title, titleErr := mdb.FindMediaTitleBySystemAndSlug(ctx, system.DBID, slug)
-		if titleErr != nil {
-			log.Debug().Err(titleErr).Str("slug", slug).
-				Msg("gamelistxml: companion: error looking up child title by slug")
-			return nil
+	if strings.EqualFold(filepath.Ext(filename), ".slug") {
+		slug := strings.TrimSuffix(filename, filepath.Ext(filename))
+		title, ok := indexes.AllTitlesBySlug[slug]
+		if !ok {
+			title, ok = indexes.TitlesBySlug[slug]
 		}
-		if title == nil {
-			log.Debug().Str("slug", slug).
-				Msg("gamelistxml: companion: no indexed title found for child slug, skipping")
-			return nil
+		if !ok {
+			if stats != nil {
+				stats.MissingTitleSlugs++
+			}
+			return companionMediaMatch{}
 		}
-		media, ok := mediaByTitleDBID[title.DBID]
-		if !ok || media.DBID == 0 {
-			log.Debug().Int64("mediaTitleDBID", title.DBID).
-				Msg("gamelistxml: companion: no media row for slug-matched title, skipping")
-			return nil
+		mediaRows := indexes.MediaByTitleDBID[title.DBID]
+		if len(mediaRows) == 0 {
+			if stats != nil {
+				stats.MissingTitleMedia++
+			}
+			return companionMediaMatch{}
 		}
-		return []database.Media{media}
+		return companionMediaMatch{Media: cloneMediaRows(mediaRows)}
 	}
 
-	resolvedPath := filepath.ToSlash(child.ResolvedPath)
-	exact, exactErr := mdb.FindMediaBySystemAndPathFold(ctx, system.DBID, resolvedPath)
-	if exactErr != nil {
-		log.Debug().Err(exactErr).Str("path", resolvedPath).
-			Msg("gamelistxml: companion: exact child path lookup failed")
-	}
-	if exact != nil {
-		return []database.Media{*exact}
+	if media, _, ok := matchMediaByResolvedPath(indexes.MediaByPathFold, child.ResolvedPath); ok {
+		return companionMediaMatch{Media: []database.Media{media}, MediaLevelWriteSafe: true}
 	}
 
-	matched, mediaErr := mdb.FindMediaBySystemAndPathSuffix(ctx, system.DBID, filename)
-	if mediaErr != nil {
-		log.Debug().Err(mediaErr).Str("filename", filename).
-			Msg("gamelistxml: companion: error looking up child by filename")
-		return nil
-	}
+	filenameKey := mediaFilenameKey(child.ResolvedPath)
+	matched := indexes.MediaByFilename[filenameKey]
 	if len(matched) == 0 {
-		log.Debug().Str("filename", filename).
-			Msg("gamelistxml: companion: no indexed media found for child filename, skipping")
-		return nil
+		if stats != nil {
+			stats.UnmatchedFilenames++
+		}
+		return companionMediaMatch{}
 	}
 	if len(matched) > 1 {
+		if stats != nil {
+			stats.AmbiguousFilenames++
+		}
 		log.Warn().
 			Str("system", system.ID).
 			Str("path", child.ResolvedPath).
@@ -1648,9 +1900,39 @@ func (*GamelistXMLScraper) matchCompanionChildMedia(
 			Str("parentGameID", child.ParentGameID).
 			Int("matches", len(matched)).
 			Msg("gamelistxml: companion: ambiguous child filename matches, skipping")
-		return nil
+		return companionMediaMatch{}
 	}
-	return matched
+	return companionMediaMatch{Media: cloneMediaRows(matched), MediaLevelWriteSafe: true}
+}
+
+func cloneMediaRows(rows []database.Media) []database.Media {
+	return append([]database.Media(nil), rows...)
+}
+
+func consumeCompanionMediaMatches(indexes loadRecordIndexes, mediaRows []database.Media) {
+	for _, media := range mediaRows {
+		delete(indexes.MediaByPathFold, pathFoldKey(media.Path))
+		filenameKey := mediaFilenameKey(media.Path)
+		if filenameKey != "" {
+			indexes.MediaByFilename[filenameKey] = removeMediaByDBID(indexes.MediaByFilename[filenameKey], media.DBID)
+		}
+		indexes.MediaByTitleDBID[media.MediaTitleDBID] = removeMediaByDBID(
+			indexes.MediaByTitleDBID[media.MediaTitleDBID], media.DBID,
+		)
+	}
+}
+
+func removeMediaByDBID(rows []database.Media, dbid int64) []database.Media {
+	for i, row := range rows {
+		if row.DBID != dbid {
+			continue
+		}
+		copy(rows[i:], rows[i+1:])
+		var zero database.Media
+		rows[len(rows)-1] = zero
+		return rows[:len(rows)-1]
+	}
+	return rows
 }
 
 func companionChildTags(c companionChild) []database.TagInfo {

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -2563,7 +2563,10 @@ func drainBufferedUpdates(ch chan scraper.ScrapeUpdate) []scraper.ScrapeUpdate {
 	var updates []scraper.ScrapeUpdate
 	for {
 		select {
-		case update := <-ch:
+		case update, ok := <-ch:
+			if !ok {
+				return updates
+			}
 			updates = append(updates, update)
 		default:
 			return updates

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -265,15 +266,42 @@ func TestMimeFromExt_Unknown(t *testing.T) {
 
 // --- LoadRecords ---
 
+func assertCompanionCounts(t *testing.T, stats *companionStats, processed, matched, skipped int) {
+	t.Helper()
+	assert.Equal(t, processed, stats.Processed)
+	assert.Equal(t, matched, stats.Matched)
+	assert.Equal(t, skipped, stats.Skipped)
+}
+
+type batchMockMediaDB struct {
+	*helpers.MockMediaDBI
+	batchErr error
+	batches  [][]database.ScrapeWriteTarget
+}
+
+func (m *batchMockMediaDB) ApplyScrapeResults(
+	_ context.Context, targets []database.ScrapeWriteTarget,
+) error {
+	batch := append([]database.ScrapeWriteTarget(nil), targets...)
+	m.batches = append(m.batches, batch)
+	return m.batchErr
+}
+
 func mediaByPath(rows ...database.Media) loadRecordIndexes {
 	indexes := loadRecordIndexes{
 		TitlesBySlug:     map[string]database.MediaTitle{},
+		AllTitlesBySlug:  map[string]database.MediaTitle{},
 		MediaByPathFold:  make(map[string]database.Media, len(rows)),
 		MediaByTitleDBID: make(map[int64][]database.Media, len(rows)),
+		MediaByFilename:  make(map[string][]database.Media, len(rows)),
 	}
 	for _, row := range rows {
 		indexes.MediaByPathFold[pathFoldKey(row.Path)] = row
 		indexes.MediaByTitleDBID[row.MediaTitleDBID] = append(indexes.MediaByTitleDBID[row.MediaTitleDBID], row)
+		filenameKey := mediaFilenameKey(row.Path)
+		if filenameKey != "" {
+			indexes.MediaByFilename[filenameKey] = append(indexes.MediaByFilename[filenameKey], row)
+		}
 	}
 	return indexes
 }
@@ -353,6 +381,45 @@ func TestLoadRecords_SkipsCompanionChildren(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, records, "companion children must be handled only by companion processing")
+}
+
+func TestParsedGamelistFeedsCompanionAndRegularRecords(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game id="42" source="ZaparooCompanion">
+    <name>Parent</name>
+    <developer>Dev</developer>
+  </game>
+  <game parentid="42" source="ZaparooCompanion">
+    <path>./child.nes</path>
+  </game>
+  <game><path>./regular.nes</path><name>Regular</name></game>
+</gameList>`), 0o600))
+
+	s := &GamelistXMLScraper{}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}}
+	parsed, err := s.loadParsedGamelistSystem(context.Background(), system)
+	require.NoError(t, err)
+	require.Len(t, parsed.Files, 1)
+
+	parents, children := companionEntriesFromParsed(context.Background(), system, parsed)
+	require.Len(t, parents, 1)
+	require.Len(t, children, 1)
+	assert.Equal(t, filepath.Join(root, "child.nes"), children[0].ResolvedPath)
+
+	records, err := s.loadRecordsFromParsed(
+		context.Background(),
+		system,
+		mediaByPath(database.Media{DBID: 12, MediaTitleDBID: 23, Path: filepath.Join(root, "regular.nes")}),
+		parsed,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, "./regular.nes", records[0].Game.Path)
+	assert.Equal(t, int64(12), records[0].MatchedMediaDBID)
 }
 
 func TestLoadRecords_DoesNotReadNestedGameList(t *testing.T) {
@@ -1862,7 +1929,9 @@ func TestProcessCompanionEntries_NoEntries(t *testing.T) {
 	mockDB := helpers.NewMockMediaDBI()
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{}, system, mockDB, loadRecordIndexes{}, nil,
+	)
 	assert.Equal(t, companionStats{}, stats)
 	mockDB.AssertExpectations(t)
 }
@@ -1879,16 +1948,14 @@ func TestProcessCompanionEntries_ChildByExactPath(t *testing.T) {
 	}
 	titleTags := []database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev Corp"}}
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), resolvedPath).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20),
 		companionWriteMatcher(childTags, titleTags, companionXMLGameIDProps("42"))).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: resolvedPath})
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -1905,10 +1972,7 @@ func TestProcessCompanionEntries_ChildBySlugFile(t *testing.T) {
   </game>
 </gameList>`), 0o600))
 
-	title := &database.MediaTitle{DBID: 30}
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{{DBID: 40, MediaTitleDBID: 30}}, nil)
-	mockDB.On("FindMediaTitleBySystemAndSlug", mock.Anything, int64(5), "myslug").Return(title, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(40), int64(30),
 		companionWriteMatcher(
 			nil,
@@ -1918,9 +1982,92 @@ func TestProcessCompanionEntries_ChildBySlugFile(t *testing.T) {
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 5}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 40, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug.nes")})
+	indexes.AllTitlesBySlug["myslug"] = database.MediaTitle{DBID: 30, SystemDBID: 5, Slug: "myslug"}
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
+}
+
+func TestProcessCompanionEntries_ChildBySlugFileWritesAllTitleMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="99" source="ZaparooCompanion">
+    <name>Slug Game</name>
+    <developer>Dev</developer>
+  </game>
+  <game parentid="99" source="ZaparooCompanion">
+    <path>./myslug.slug</path>
+    <region>usa</region>
+    <lang>en</lang>
+  </game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 5}
+	indexes := mediaByPath(
+		database.Media{DBID: 40, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug-1.nes")},
+		database.Media{DBID: 41, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug-2.nes")},
+		database.Media{DBID: 42, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug-3.nes")},
+	)
+	indexes.AllTitlesBySlug["myslug"] = database.MediaTitle{DBID: 30, SystemDBID: 5, Slug: "myslug"}
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 1, 3, 0)
+	require.Len(t, mockDB.batches, 1)
+	require.Len(t, mockDB.batches[0], 3)
+	assert.ElementsMatch(t, []int64{40, 41, 42}, []int64{
+		mockDB.batches[0][0].MediaDBID,
+		mockDB.batches[0][1].MediaDBID,
+		mockDB.batches[0][2].MediaDBID,
+	})
+	for i, target := range mockDB.batches[0] {
+		require.NotNil(t, target.Write)
+		assert.Equal(t, scraper.SentinelTagInfo("gamelist.xml"), target.Write.Sentinel)
+		assert.Empty(t, target.Write.MediaTags, "slug child should not write file-level tags for target %d", i)
+	}
+	assert.Equal(t, []database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}}, mockDB.batches[0][0].Write.TitleTags)
+	assert.Equal(t, companionXMLGameIDProps("99"), mockDB.batches[0][0].Write.TitleProps)
+	assert.Empty(t, mockDB.batches[0][1].Write.TitleTags)
+	assert.Empty(t, mockDB.batches[0][1].Write.TitleProps)
+	assert.Empty(t, mockDB.batches[0][2].Write.TitleTags)
+	assert.Empty(t, mockDB.batches[0][2].Write.TitleProps)
+}
+
+func TestProcessCompanionEntries_DuplicateSlugChildConsumesTitleMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="99" source="ZaparooCompanion">
+    <name>Slug Game</name>
+    <developer>Dev</developer>
+  </game>
+  <game parentid="99" source="ZaparooCompanion"><path>./myslug.slug</path></game>
+  <game parentid="99" source="ZaparooCompanion"><path>./myslug.slug</path></game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 5}
+	indexes := mediaByPath(
+		database.Media{DBID: 40, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug-1.nes")},
+		database.Media{DBID: 41, MediaTitleDBID: 30, Path: filepath.Join(root, "myslug-2.nes")},
+	)
+	indexes.AllTitlesBySlug["myslug"] = database.MediaTitle{DBID: 30, SystemDBID: 5, Slug: "myslug"}
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 2, 2, 1)
+	assert.Equal(t, 1, stats.MissingTitleMedia)
+	require.Len(t, mockDB.batches, 1)
+	require.Len(t, mockDB.batches[0], 2)
+	assert.ElementsMatch(t, []int64{40, 41}, []int64{
+		mockDB.batches[0][0].MediaDBID,
+		mockDB.batches[0][1].MediaDBID,
+	})
 }
 
 func TestProcessCompanionEntries_RewritesAlreadyScraped(t *testing.T) {
@@ -1930,15 +2077,13 @@ func TestProcessCompanionEntries_RewritesAlreadyScraped(t *testing.T) {
 
 	resolvedPath := filepath.ToSlash(filepath.Join(root, "child.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), resolvedPath).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), mock.Anything).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: resolvedPath})
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -1949,15 +2094,15 @@ func TestProcessCompanionEntries_ForceRewritesAlreadyScraped(t *testing.T) {
 
 	resolvedPath := filepath.ToSlash(filepath.Join(root, "child.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), resolvedPath).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), mock.Anything).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{Force: true}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: resolvedPath})
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{Force: true}, system, mockDB, indexes, nil,
+	)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -1975,14 +2120,15 @@ func TestProcessCompanionEntries_SlugNotIndexed(t *testing.T) {
 </gameList>`), 0o600))
 
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaTitleBySystemAndSlug", mock.Anything, int64(5), "missing").
-		Return((*database.MediaTitle)(nil), nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 5}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Skipped: 1}, stats)
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{}, system, mockDB, mediaByPath(), nil,
+	)
+	assert.Equal(t, 1, stats.Processed)
+	assert.Equal(t, 1, stats.Skipped)
+	assert.Equal(t, 1, stats.MissingTitleSlugs)
 	mockDB.AssertExpectations(t)
 }
 
@@ -1996,11 +2142,12 @@ func TestProcessCompanionEntries_ParentNotFoundForChild(t *testing.T) {
 </gameList>`), 0o600))
 
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Skipped: 1}, stats)
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{}, system, mockDB, mediaByPath(), nil,
+	)
+	assertCompanionCounts(t, &stats, 1, 0, 1)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2031,17 +2178,15 @@ func TestProcessCompanionEntries_MapsIssue161CompanionArtwork(t *testing.T) {
 		propPrefix + string(tags.TagPropertyImageWheel):      filepath.Join(root, "media", "logo", "Doom.png"),
 	}
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), childPath).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
 	mockDB.On(
 		"ApplyScrapeResult", mock.Anything, int64(10), int64(20), companionArtworkWriteMatcher(t, expectedArtwork),
 	).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: childPath})
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2063,9 +2208,6 @@ func TestProcessCompanionEntries_ExternalCompanionArtwork(t *testing.T) {
 	childPath := filepath.ToSlash(filepath.Join(root, "Doom.rom"))
 	propKey := string(tags.TagTypeProperty) + ":" + string(tags.TagPropertyImageImage)
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), childPath).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
 	mockDB.On(
 		"ApplyScrapeResult", mock.Anything, int64(10), int64(20),
 		companionArtworkWriteMatcher(t, map[string]string{propKey: assetPath}),
@@ -2073,8 +2215,9 @@ func TestProcessCompanionEntries_ExternalCompanionArtwork(t *testing.T) {
 
 	s := &GamelistXMLScraper{db: mockDB, externalAssetRoots: []string{assetRoot}}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: childPath})
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2107,11 +2250,13 @@ func TestProcessCompanionEntries_StatsAggregateWithNormalProgress(t *testing.T) 
 		Return([]database.MediaTitle{{
 			DBID: normalTitleDBID, SystemDBID: systemDBID, Slug: "normal-game", Name: "Normal Game",
 		}}, nil)
+	mockDB.On("GetTitlesBySystemID", "nes").Return([]database.TitleWithSystem{{
+		DBID: normalTitleDBID, SystemDBID: systemDBID, Slug: "normal-game", Name: "Normal Game",
+	}}, nil)
 	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
+		{DBID: companionMediaDBID, MediaTitleDBID: companionTitleDBID, Path: companionPath},
 		{DBID: normalMediaDBID, MediaTitleDBID: normalTitleDBID, Path: filepath.Join(root, "normal.rom")},
 	}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, systemDBID, companionPath).
-		Return(&database.Media{DBID: companionMediaDBID, MediaTitleDBID: companionTitleDBID}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, companionMediaDBID, companionTitleDBID, mock.Anything).Return(nil)
 	mockDB.On("GetScrapedMediaIDs", mock.Anything, "gamelist.xml", systemDBID).
 		Return(map[int64]struct{}{}, nil)
@@ -2166,18 +2311,167 @@ func TestProcessCompanionEntries_EachChildUsesAtomicScrapeWrite(t *testing.T) {
 	child1Path := filepath.ToSlash(filepath.Join(root, "child1.rom"))
 	child2Path := filepath.ToSlash(filepath.Join(root, "child2.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), child1Path).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 20}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), child2Path).
-		Return(&database.Media{DBID: 11, MediaTitleDBID: 20}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), mock.Anything).Return(nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(11), int64(20), mock.Anything).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 2, Matched: 2}, stats)
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: child1Path},
+		database.Media{DBID: 11, MediaTitleDBID: 20, Path: child2Path},
+	)
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 2, 2, 0)
+	mockDB.AssertExpectations(t)
+}
+
+func TestProcessCompanionEntries_UsesBatchWritesWhenAvailable(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="42" source="ZaparooCompanion"><name>Game</name><developer>Dev</developer></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child1.rom</path></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child2.rom</path></game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: filepath.Join(root, "child1.rom")},
+		database.Media{DBID: 11, MediaTitleDBID: 21, Path: filepath.Join(root, "child2.rom")},
+	)
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 2, 2, 0)
+	require.Len(t, mockDB.batches, 1)
+	assert.Len(t, mockDB.batches[0], 2)
+	assert.Equal(t, 1, stats.WriteStats.Batches)
+	mockDB.AssertNotCalled(t, "ApplyScrapeResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestProcessCompanionEntries_DeduplicatesIdenticalTitleWrites(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="42" source="ZaparooCompanion"><name>Game</name><developer>Dev</developer></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child1.rom</path></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child2.rom</path></game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: filepath.Join(root, "child1.rom")},
+		database.Media{DBID: 11, MediaTitleDBID: 20, Path: filepath.Join(root, "child2.rom")},
+	)
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 2, 2, 0)
+	assert.Equal(t, 1, stats.UniqueTitleWrites)
+	assert.Equal(t, 1, stats.DuplicateTitles)
+	assert.Equal(t, 0, stats.ConflictingTitleWrites)
+	require.Len(t, mockDB.batches, 1)
+	require.Len(t, mockDB.batches[0], 2)
+	assert.NotEmpty(t, mockDB.batches[0][0].Write.TitleTags)
+	assert.Empty(t, mockDB.batches[0][1].Write.TitleTags)
+	assert.Empty(t, mockDB.batches[0][1].Write.TitleProps)
+}
+
+func TestProcessCompanionEntries_PreservesConflictingTitleWrites(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="1" source="ZaparooCompanion"><name>Game One</name><developer>Dev One</developer></game>
+  <game id="2" source="ZaparooCompanion"><name>Game Two</name><developer>Dev Two</developer></game>
+  <game parentid="1" source="ZaparooCompanion"><path>./child1.rom</path></game>
+  <game parentid="2" source="ZaparooCompanion"><path>./child2.rom</path></game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: filepath.Join(root, "child1.rom")},
+		database.Media{DBID: 11, MediaTitleDBID: 20, Path: filepath.Join(root, "child2.rom")},
+	)
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 2, 2, 0)
+	assert.Equal(t, 1, stats.UniqueTitleWrites)
+	assert.Equal(t, 0, stats.DuplicateTitles)
+	assert.Equal(t, 1, stats.ConflictingTitleWrites)
+	require.Len(t, mockDB.batches, 1)
+	require.Len(t, mockDB.batches[0], 2)
+	assert.NotEmpty(t, mockDB.batches[0][0].Write.TitleTags)
+	assert.NotEmpty(t, mockDB.batches[0][1].Write.TitleTags)
+}
+
+func TestProcessCompanionEntries_ThrottlesBatchProgress(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	var xml strings.Builder
+	_, _ = xml.WriteString(`<gameList><game id="42" source="ZaparooCompanion"><name>Game</name></game>`)
+	mediaRows := make([]database.Media, 0, companionWriteBatchSize+1)
+	for i := range companionWriteBatchSize + 1 {
+		name := "child" + strconv.Itoa(i) + ".rom"
+		_, _ = xml.WriteString(`<game parentid="42" source="ZaparooCompanion"><path>./` + name + `</path></game>`)
+		mediaRows = append(mediaRows, database.Media{
+			DBID: int64(i + 1), MediaTitleDBID: int64(i + 100), Path: filepath.Join(root, name),
+		})
+	}
+	_, _ = xml.WriteString(`</gameList>`)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(xml.String()), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI()}
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
+	ch := make(chan scraper.ScrapeUpdate, 128)
+
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{}, system, mockDB, mediaByPath(mediaRows...), ch,
+	)
+
+	assertCompanionCounts(t, &stats, companionWriteBatchSize+1, companionWriteBatchSize+1, 0)
+	updates := drainBufferedUpdates(ch)
+	assert.NotContains(t, updates, scraper.ScrapeUpdate{
+		SystemID: "nes", Total: companionWriteBatchSize + 1, Processed: companionWriteBatchSize,
+	})
+	assert.Contains(t, updates, scraper.ScrapeUpdate{
+		SystemID: "nes", Total: companionWriteBatchSize + 1,
+		Processed: companionWriteBatchSize + 1, Matched: companionWriteBatchSize + 1,
+	})
+}
+
+func TestProcessCompanionEntries_BatchFailureFallsBackToPerTargetWrites(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="42" source="ZaparooCompanion"><name>Game</name><developer>Dev</developer></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child1.rom</path></game>
+  <game parentid="42" source="ZaparooCompanion"><path>./child2.rom</path></game>
+</gameList>`), 0o600))
+
+	mockDB := &batchMockMediaDB{MockMediaDBI: helpers.NewMockMediaDBI(), batchErr: assert.AnError}
+	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), mock.Anything).Return(nil)
+	mockDB.On("ApplyScrapeResult", mock.Anything, int64(11), int64(21), mock.Anything).Return(assert.AnError)
+
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: filepath.Join(root, "child1.rom")},
+		database.Media{DBID: 11, MediaTitleDBID: 21, Path: filepath.Join(root, "child2.rom")},
+	)
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assertCompanionCounts(t, &stats, 2, 1, 1)
+	require.Len(t, mockDB.batches, 1)
+	assert.Equal(t, 1, stats.WriteStats.BatchFallbacks)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2196,9 +2490,6 @@ func TestProcessCompanionEntries_NoRegionLangStillWritesSentinel(t *testing.T) {
 
 	gamePath := filepath.ToSlash(filepath.Join(root, "game.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), gamePath).
-		Return(&database.Media{DBID: 5, MediaTitleDBID: 6}, nil)
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(5), int64(6),
 		companionWriteMatcher(
 			nil,
@@ -2208,8 +2499,9 @@ func TestProcessCompanionEntries_NoRegionLangStillWritesSentinel(t *testing.T) {
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Matched: 1}, stats)
+	indexes := mediaByPath(database.Media{DBID: 5, MediaTitleDBID: 6, Path: gamePath})
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2220,16 +2512,18 @@ func TestProcessCompanionEntries_AmbiguousSuffixMatchSkipped(t *testing.T) {
 
 	resolvedPath := filepath.ToSlash(filepath.Join(root, "child.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), resolvedPath).
-		Return((*database.Media)(nil), nil)
-	mockDB.On("FindMediaBySystemAndPathSuffix", mock.Anything, int64(1), "child.rom").
-		Return([]database.Media{{DBID: 10, MediaTitleDBID: 20}, {DBID: 11, MediaTitleDBID: 21}}, nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Skipped: 1}, stats)
+	indexes := mediaByPath(
+		database.Media{DBID: 10, MediaTitleDBID: 20, Path: filepath.Join(root, "one", "child.rom")},
+		database.Media{DBID: 11, MediaTitleDBID: 21, Path: filepath.Join(root, "two", "child.rom")},
+	)
+	delete(indexes.MediaByPathFold, pathFoldKey(resolvedPath))
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+	assert.Equal(t, 1, stats.Processed)
+	assert.Equal(t, 1, stats.Skipped)
+	assert.Equal(t, 1, stats.AmbiguousFilenames)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2238,18 +2532,16 @@ func TestProcessCompanionEntries_FilenameNotIndexed(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(companionXML), 0o600))
 
-	resolvedPath := filepath.ToSlash(filepath.Join(root, "child.rom"))
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(1), resolvedPath).
-		Return((*database.Media)(nil), nil)
-	mockDB.On("FindMediaBySystemAndPathSuffix", mock.Anything, int64(1), "child.rom").
-		Return([]database.Media{}, nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
-	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB)
-	assert.Equal(t, companionStats{Processed: 1, Skipped: 1}, stats)
+	stats := s.processCompanionEntries(
+		context.Background(), scraper.ScrapeOptions{}, system, mockDB, mediaByPath(), nil,
+	)
+	assert.Equal(t, 1, stats.Processed)
+	assert.Equal(t, 1, stats.Skipped)
+	assert.Equal(t, 1, stats.UnmatchedFilenames)
 	mockDB.AssertExpectations(t)
 }
 
@@ -2262,6 +2554,18 @@ func drainChannel(ch chan scraper.ScrapeUpdate) []scraper.ScrapeUpdate {
 		updates = append(updates, u)
 	}
 	return updates
+}
+
+func drainBufferedUpdates(ch chan scraper.ScrapeUpdate) []scraper.ScrapeUpdate {
+	var updates []scraper.ScrapeUpdate
+	for {
+		select {
+		case update := <-ch:
+			updates = append(updates, update)
+		default:
+			return updates
+		}
+	}
 }
 
 func TestScrapeLoop_ProgressIsPerSystem(t *testing.T) {
@@ -2360,8 +2664,6 @@ func TestScrapeLoop_ProgressIncludesCompanionBaseline(t *testing.T) {
 		{DBID: 10, MediaTitleDBID: 1000, Path: companionPath},
 		{DBID: 11, MediaTitleDBID: 1001, Path: normalPath},
 	}, nil)
-	mockDB.On("FindMediaBySystemAndPathFold", mock.Anything, int64(100), filepath.ToSlash(companionPath)).
-		Return(&database.Media{DBID: 10, MediaTitleDBID: 1000, Path: companionPath}, nil)
 	mockDB.On("GetTitlesBySystemID", "nes").Return([]database.TitleWithSystem{{
 		DBID: 1001, SystemDBID: 100, Slug: "normal", Name: "Normal",
 	}}, nil)
@@ -2713,5 +3015,54 @@ func TestScrapeLoop_AllMediaScraped_SkipsSystem(t *testing.T) {
 	}
 	require.True(t, done.Done)
 	assert.Equal(t, 0, done.Processed)
+	mockDB.AssertExpectations(t)
+}
+
+func TestScrapeLoop_CompanionSkipsAlreadyScrapedMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game id="42" source="ZaparooCompanion">
+    <name>Companion Game</name>
+  </game>
+  <game parentid="42" source="ZaparooCompanion">
+    <path>./child.rom</path>
+  </game>
+</gameList>`), 0o600))
+
+	const (
+		mediaDBID  = int64(41)
+		titleDBID  = int64(42)
+		systemDBID = int64(401)
+	)
+
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("FindMediaTitlesWithoutSentinel", mock.Anything, systemDBID, "scraper.gamelist.xml:scraped").
+		Return([]database.MediaTitle{}, nil)
+	mockDB.On("GetMediaBySystemID", "nes").
+		Return([]database.MediaWithFullPath{{
+			DBID: mediaDBID, MediaTitleDBID: titleDBID, Path: filepath.Join(root, "child.rom"),
+		}}, nil)
+	mockDB.On("GetScrapedMediaIDs", mock.Anything, "gamelist.xml", systemDBID).
+		Return(map[int64]struct{}{mediaDBID: {}}, nil)
+
+	s := &GamelistXMLScraper{db: mockDB}
+	ch := make(chan scraper.ScrapeUpdate, 128)
+	s.scrapeLoop(context.Background(), scraper.ScrapeOptions{Pauser: syncutil.NewPauser()},
+		[]scraper.ScrapeSystem{{ID: "nes", ROMPaths: []string{root}, DBID: systemDBID}}, mockDB, ch)
+
+	updates := drainChannel(ch)
+	var done scraper.ScrapeUpdate
+	for _, u := range updates {
+		if u.Done {
+			done = u
+		}
+	}
+	require.True(t, done.Done)
+	assert.Equal(t, 1, done.Processed)
+	assert.Equal(t, 0, done.Matched)
+	assert.Equal(t, 1, done.Skipped)
+	mockDB.AssertNotCalled(t, "ApplyScrapeResult", mock.Anything, mediaDBID, titleDBID, mock.Anything)
 	mockDB.AssertExpectations(t)
 }

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -2029,7 +2029,10 @@ func TestProcessCompanionEntries_ChildBySlugFileWritesAllTitleMedia(t *testing.T
 		assert.Equal(t, scraper.SentinelTagInfo("gamelist.xml"), target.Write.Sentinel)
 		assert.Empty(t, target.Write.MediaTags, "slug child should not write file-level tags for target %d", i)
 	}
-	assert.Equal(t, []database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}}, mockDB.batches[0][0].Write.TitleTags)
+	assert.Equal(t,
+		[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}},
+		mockDB.batches[0][0].Write.TitleTags,
+	)
 	assert.Equal(t, companionXMLGameIDProps("99"), mockDB.batches[0][0].Write.TitleProps)
 	assert.Empty(t, mockDB.batches[0][1].Write.TitleTags)
 	assert.Empty(t, mockDB.batches[0][1].Write.TitleProps)

--- a/scripts/tasks/mister.yml
+++ b/scripts/tasks/mister.yml
@@ -29,7 +29,7 @@ tasks:
         vars:
           PLATFORM: mister
           APP_BIN: zaparoo.sh
-          EXTRA_TAGS: embed_arcadedb
+          EXTRA_TAGS: "embed_arcadedb{{if .EXTRA_TAGS}},{{.EXTRA_TAGS}}{{end}}"
 
   deploy:
     cmds:


### PR DESCRIPTION
## Summary
- optimize scraped-count/status refreshes so scrape progress does not repeatedly run expensive count queries
- speed up mediadb scrape writes with bulk title metadata/sentinel paths plus SQL trace tooling and benchmarks
- fix ES gamelist companion .slug matching so title-level entries mark all matching media in one completed run
- throttle companion batch progress notifications to avoid websocket/log spam during large scrapes

## Validation
- go test ./pkg/database/scraper/gamelistxml
- go test ./pkg/api/methods ./pkg/database/mediadb ./pkg/database/scraper/gamelistxml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch application of scrape results and improved companion-entry handling for more efficient and accurate scraping.

* **Performance**
  * Time-based caching of scraped-media counts with short refresh behavior to reduce DB load.
  * Query/path/tag lookup optimizations and optional SQL tracing for performance analysis.

* **Refactor**
  * Scraper persistence and parsing reworked for transaction-scoped caching and bulk operations.

* **Tests**
  * Expanded unit tests, benchmarks, and diagnostic tests covering batch flows, progress handling, and sentinel/tag edge cases.

* **Chores**
  * Build-task tag handling adjusted for conditional extra tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZaparooProject/zaparoo-core/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->