### PR TITLE
fix(mister): support DB9 core launchers

### DIFF
--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -24,6 +24,8 @@ package cores
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -267,11 +269,22 @@ func (c *RBFCache) GetByShortName(shortName string) (RBFInfo, bool) {
 // scanned RBFInfo. When the path includes a directory, the match is strict: a
 // wrong directory returns (RBFInfo{}, false) instead of a silent fallback to
 // another core. A bare short name (no directory) returns the first candidate.
+// The short name may include a glob, used for versioned alt cores whose full
+// RBF basename changes with each release.
 func (c *RBFCache) GetByMglPath(mglPath string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	return c.getByMglPathLocked(mglPath)
+}
+
+func (c *RBFCache) getByMglPathLocked(mglPath string) (RBFInfo, bool) {
 	canonicalDir, shortName := splitRBFPath(mglPath)
+	if strings.ContainsAny(shortName, "*?[") || strings.Contains(shortName, "<date>") ||
+		strings.Contains(shortName, "<hash>") {
+		return c.getByMglGlobLocked(canonicalDir, shortName)
+	}
+
 	candidates := c.byShortName[strings.ToLower(shortName)]
 	if len(candidates) == 0 {
 		return RBFInfo{}, false
@@ -286,6 +299,91 @@ func (c *RBFCache) GetByMglPath(mglPath string) (RBFInfo, bool) {
 		}
 	}
 	return RBFInfo{}, false
+}
+
+func (c *RBFCache) getByMglGlobLocked(canonicalDir, shortNamePattern string) (RBFInfo, bool) {
+	matches := make([]RBFInfo, 0)
+	for _, candidates := range c.byShortName {
+		for _, candidate := range candidates {
+			dir, candidateShortName := splitRBFPath(candidate.MglName)
+			if canonicalDir != "" && !strings.EqualFold(dir, canonicalDir) {
+				continue
+			}
+			if !matchMglPattern(shortNamePattern, candidateShortName) {
+				continue
+			}
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) == 0 {
+		return RBFInfo{}, false
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].MglName < matches[j].MglName
+	})
+	return matches[len(matches)-1], true
+}
+
+func matchMglPattern(pattern, name string) bool {
+	if strings.Contains(pattern, "<date>") || strings.Contains(pattern, "<hash>") {
+		return matchMglTokenPattern(pattern, name)
+	}
+	matched, err := filepath.Match(strings.ToLower(pattern), strings.ToLower(name))
+	return err == nil && matched
+}
+
+func matchMglTokenPattern(pattern, name string) bool {
+	patternParts := strings.Split(pattern, "_")
+	nameParts := strings.Split(name, "_")
+	if len(patternParts) != len(nameParts) {
+		return false
+	}
+	for i, patternPart := range patternParts {
+		namePart := nameParts[i]
+		switch patternPart {
+		case "<date>":
+			if !isNDigits(namePart, 8) {
+				return false
+			}
+		case "<hash>":
+			if !isHexish(namePart) {
+				return false
+			}
+		default:
+			if !strings.EqualFold(patternPart, namePart) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isNDigits(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isHexish(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // RegisterAltCore registers an alt core's expected RBF path.
@@ -312,21 +410,52 @@ func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 		return RBFInfo{}, false
 	}
 
+	return c.getByMglPathLocked(rbfPath)
+}
+
+func (c *RBFCache) relatedCandidates(rbfPath string) []string {
 	canonicalDir, shortName := splitRBFPath(rbfPath)
-	candidates := c.byShortName[strings.ToLower(shortName)]
-	if len(candidates) == 0 {
-		return RBFInfo{}, false
+	if shortName == "" {
+		return nil
 	}
-	if canonicalDir == "" {
-		return candidates[0], true
-	}
-	for _, candidate := range candidates {
-		dir, _ := splitRBFPath(candidate.MglName)
-		if strings.EqualFold(dir, canonicalDir) {
-			return candidate, true
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	prefix := strings.ToLower(shortName) + "_"
+	candidates := make([]string, 0)
+	seen := make(map[string]struct{})
+	for key, rbfs := range c.byShortName {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		for _, rbf := range rbfs {
+			dir, _ := splitRBFPath(rbf.MglName)
+			if canonicalDir != "" && !strings.EqualFold(dir, canonicalDir) {
+				continue
+			}
+			if _, ok := seen[rbf.MglName]; ok {
+				continue
+			}
+			seen[rbf.MglName] = struct{}{}
+			candidates = append(candidates, rbf.MglName)
 		}
 	}
-	return RBFInfo{}, false
+	sort.Strings(candidates)
+	return candidates
+}
+
+func missingCoreError(core *Core, key string, candidates []string) error {
+	if len(candidates) == 0 {
+		return fmt.Errorf(
+			"no core found for system %s (launcher %s, not in cache)", core.ID, key,
+		)
+	}
+	return fmt.Errorf(
+		"no original core found for system %s (launcher %s, expected %s; not in cache); "+
+			"available fork candidates: %s; set launchers.default load_path to use one explicitly",
+		core.ID, key, core.RBF, strings.Join(candidates, ", "),
+	)
 }
 
 // Resolve returns the RBFInfo for a core, honoring config load_path override,
@@ -362,9 +491,7 @@ func (c *RBFCache) Resolve(cfg *config.Instance, core *Core) (RBFInfo, error) {
 
 	rbfInfo, ok := c.GetBySystemID(core.ID)
 	if !ok {
-		return RBFInfo{}, fmt.Errorf(
-			"no core found for system %s (launcher %s, not in cache)", core.ID, key,
-		)
+		return RBFInfo{}, missingCoreError(core, key, c.relatedCandidates(core.RBF))
 	}
 	return rbfInfo, nil
 }

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -496,6 +496,272 @@ func TestSelectByCanonicalDir(t *testing.T) {
 	}
 }
 
+func TestBuildFromRBFs_IgnoresForkOnlyDefault(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+		Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+		ShortName: "GBA_20260528_ceb4a49_DB9",
+		MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+	}})
+
+	_, ok := cache.bySystemID["GBA"]
+	assert.False(t, ok, "fork-only core must not become default GBA core")
+}
+
+func TestBuildFromRBFs_PrefersOriginalWhenForkAlsoExists(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{
+			Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+			Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+			ShortName: "GBA_20260528_ceb4a49_DB9",
+			MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+		},
+		{
+			Path:      "/media/fat/_Console/GBA_20260528.rbf",
+			Filename:  "GBA_20260528.rbf",
+			ShortName: "GBA",
+			MglName:   "_Console/GBA",
+		},
+	})
+
+	rbf, ok := cache.bySystemID["GBA"]
+	assert.True(t, ok, "original GBA core should be mapped")
+	assert.Equal(t, "_Console/GBA", rbf.MglName)
+}
+
+func TestGetByLauncherID_GlobRegisteredAltCore(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Console/MegaDrive_20260528_fef1285_DB9.rbf",
+		Filename:  "MegaDrive_20260528_fef1285_DB9.rbf",
+		ShortName: "MegaDrive_20260528_fef1285_DB9",
+		MglName:   "_Console/MegaDrive_20260528_fef1285_DB9",
+	}})
+	cache.RegisterAltCore("DB9MegaDrive", "_Console/MegaDrive_<date>_<hash>_DB9")
+
+	got, ok := cache.GetByLauncherID("DB9MegaDrive")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/MegaDrive_20260528_fef1285_DB9", got.MglName)
+}
+
+func TestRBFCache_Resolve_GlobAltCore(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Console/MegaDrive_20260528_fef1285_DB9.rbf",
+		Filename:  "MegaDrive_20260528_fef1285_DB9.rbf",
+		ShortName: "MegaDrive_20260528_fef1285_DB9",
+		MglName:   "_Console/MegaDrive_20260528_fef1285_DB9",
+	}})
+	cache.RegisterAltCore("DB9MegaDrive", "_Console/MegaDrive_<date>_<hash>_DB9")
+
+	got, err := cache.Resolve(nil, &Core{ID: "Genesis", LauncherID: "DB9MegaDrive", RBF: "_Console/MegaDrive"})
+	require.NoError(t, err)
+	assert.Equal(t, "_Console/MegaDrive_20260528_fef1285_DB9", got.MglName)
+}
+
+func TestGetByMglPath_GlobSelectsNewestMatch(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{
+			Path:      "/media/fat/_Console/GBA_20260527_aaaaaaa_DB9.rbf",
+			Filename:  "GBA_20260527_aaaaaaa_DB9.rbf",
+			ShortName: "GBA_20260527_aaaaaaa_DB9",
+			MglName:   "_Console/GBA_20260527_aaaaaaa_DB9",
+		},
+		{
+			Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+			Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+			ShortName: "GBA_20260528_ceb4a49_DB9",
+			MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+		},
+	})
+
+	got, ok := cache.GetByMglPath("_Console/GBA_<date>_<hash>_DB9")
+	require.True(t, ok)
+	assert.Equal(t, "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf", got.Path)
+}
+
+func TestGetByMglPath_GlobRespectsDirectory(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{
+			Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+			Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+			ShortName: "GBA_20260528_ceb4a49_DB9",
+			MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+		},
+		{
+			Path:      "/media/fat/_LLAPI/GBA_LLAPI_20251205.rbf",
+			Filename:  "GBA_LLAPI_20251205.rbf",
+			ShortName: "GBA_LLAPI",
+			MglName:   "_LLAPI/GBA_LLAPI",
+		},
+	})
+
+	got, ok := cache.GetByMglPath("_Console/GBA_<date>_<hash>_DB9")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/GBA_20260528_ceb4a49_DB9", got.MglName)
+}
+
+func TestGetByMglPath_DB9BasePatternExcludesVariants(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{
+			Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+			Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+			ShortName: "GBA_20260528_ceb4a49_DB9",
+			MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+		},
+		{
+			Path:      "/media/fat/_Console/GBA_accuracy_20260528_e466e14_DB9.rbf",
+			Filename:  "GBA_accuracy_20260528_e466e14_DB9.rbf",
+			ShortName: "GBA_accuracy_20260528_e466e14_DB9",
+			MglName:   "_Console/GBA_accuracy_20260528_e466e14_DB9",
+		},
+	})
+
+	got, ok := cache.GetByMglPath("_Console/GBA_<date>_<hash>_DB9")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/GBA_20260528_ceb4a49_DB9", got.MglName)
+
+	got, ok = cache.GetByMglPath("_Console/GBA_accuracy_<date>_<hash>_DB9")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/GBA_accuracy_20260528_e466e14_DB9", got.MglName)
+}
+
+func TestGetByMglPath_DB9BasePatternsExcludeKnownVariants(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		basePattern string
+		base        RBFInfo
+		variant     RBFInfo
+	}{
+		{
+			name:        "PSX excludes DualSDRAM",
+			basePattern: "_Console/PSX_<date>_<hash>_DB9",
+			base: RBFInfo{
+				Path:      "/media/fat/_Console/PSX_20260528_38792bb_DB9.rbf",
+				Filename:  "PSX_20260528_38792bb_DB9.rbf",
+				ShortName: "PSX_20260528_38792bb_DB9",
+				MglName:   "_Console/PSX_20260528_38792bb_DB9",
+			},
+			variant: RBFInfo{
+				Path:      "/media/fat/_Console/PSX_DualSDRAM_20260528_38792bb_DB9.rbf",
+				Filename:  "PSX_DualSDRAM_20260528_38792bb_DB9.rbf",
+				ShortName: "PSX_DualSDRAM_20260528_38792bb_DB9",
+				MglName:   "_Console/PSX_DualSDRAM_20260528_38792bb_DB9",
+			},
+		},
+		{
+			name:        "Saturn excludes DualSDRAM",
+			basePattern: "_Console/Saturn_<date>_<hash>_DB9",
+			base: RBFInfo{
+				Path:      "/media/fat/_Console/Saturn_20260530_d4b8f3d_DB9.rbf",
+				Filename:  "Saturn_20260530_d4b8f3d_DB9.rbf",
+				ShortName: "Saturn_20260530_d4b8f3d_DB9",
+				MglName:   "_Console/Saturn_20260530_d4b8f3d_DB9",
+			},
+			variant: RBFInfo{
+				Path:      "/media/fat/_Console/Saturn_DualSDRAM_20260530_d4b8f3d_DB9.rbf",
+				Filename:  "Saturn_DualSDRAM_20260530_d4b8f3d_DB9.rbf",
+				ShortName: "Saturn_DualSDRAM_20260530_d4b8f3d_DB9",
+				MglName:   "_Console/Saturn_DualSDRAM_20260530_d4b8f3d_DB9",
+			},
+		},
+		{
+			name:        "NeoGeo excludes 24MHz",
+			basePattern: "_Console/NeoGeo_<date>_<hash>_DB9",
+			base: RBFInfo{
+				Path:      "/media/fat/_Console/NeoGeo_20260528_9d7ef5f_DB9.rbf",
+				Filename:  "NeoGeo_20260528_9d7ef5f_DB9.rbf",
+				ShortName: "NeoGeo_20260528_9d7ef5f_DB9",
+				MglName:   "_Console/NeoGeo_20260528_9d7ef5f_DB9",
+			},
+			variant: RBFInfo{
+				Path:      "/media/fat/_Console/NeoGeo_24MHz_cpu_only_20260528_bc199bf_DB9.rbf",
+				Filename:  "NeoGeo_24MHz_cpu_only_20260528_bc199bf_DB9.rbf",
+				ShortName: "NeoGeo_24MHz_cpu_only_20260528_bc199bf_DB9",
+				MglName:   "_Console/NeoGeo_24MHz_cpu_only_20260528_bc199bf_DB9",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cache := &RBFCache{}
+			cache.BuildFromRBFs([]RBFInfo{tc.variant, tc.base})
+
+			got, ok := cache.GetByMglPath(tc.basePattern)
+			require.True(t, ok)
+			assert.Equal(t, tc.base.MglName, got.MglName)
+		})
+	}
+}
+
+func TestGetByMglPath_InvalidGlobReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+		Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+		ShortName: "GBA_20260528_ceb4a49_DB9",
+		MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+	}})
+
+	_, ok := cache.GetByMglPath("_Console/GBA_[")
+	assert.False(t, ok)
+}
+
+func TestRBFCache_Resolve_ForkRequiresExplicitLoadPath(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf",
+		Filename:  "GBA_20260528_ceb4a49_DB9.rbf",
+		ShortName: "GBA_20260528_ceb4a49_DB9",
+		MglName:   "_Console/GBA_20260528_ceb4a49_DB9",
+	}})
+
+	_, err := cache.Resolve(nil, &Core{ID: "GBA", RBF: "_Console/GBA"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no original core found for system GBA")
+	assert.Contains(t, err.Error(), "_Console/GBA_20260528_ceb4a49_DB9")
+	assert.Contains(t, err.Error(), "load_path")
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.default]]
+launcher = "GBA"
+load_path = "_Console/GBA_20260528_ceb4a49_DB9"
+`))
+
+	got, err := cache.Resolve(cfg, &Core{ID: "GBA", RBF: "_Console/GBA"})
+	require.NoError(t, err)
+	assert.Equal(t, "/media/fat/_Console/GBA_20260528_ceb4a49_DB9.rbf", got.Path)
+}
+
 func TestBuildFromRBFs_PrefersCanonicalDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/cores/rbf_persist.go
+++ b/pkg/platforms/mister/cores/rbf_persist.go
@@ -41,7 +41,7 @@ const RBFCacheFileName = "rbf_cache.gob"
 
 const (
 	rbfCacheFileMagic   = "zrbf"
-	rbfCacheFileVersion = 2
+	rbfCacheFileVersion = 3
 )
 
 // rbfCacheMaxBytes caps gob input at load time. ~200 RBFs × ~256 B per

--- a/pkg/platforms/mister/cores/rbfs.go
+++ b/pkg/platforms/mister/cores/rbfs.go
@@ -37,6 +37,18 @@ type RBFInfo struct {
 	MglName   string // relative path launch-able from MGL file
 }
 
+func stripOfficialDateSuffix(name string) string {
+	if len(name) < 10 || name[len(name)-9] != '_' {
+		return name
+	}
+	for _, r := range name[len(name)-8:] {
+		if r < '0' || r > '9' {
+			return name
+		}
+	}
+	return name[:len(name)-9]
+}
+
 func ParseRBFPath(path string) RBFInfo {
 	return parseRBFPathAt(config.SDRootDir, path)
 }
@@ -47,11 +59,7 @@ func parseRBFPathAt(root, path string) RBFInfo {
 		Filename: filepath.Base(path),
 	}
 
-	if strings.Contains(info.Filename, "_") {
-		info.ShortName = info.Filename[0:strings.LastIndex(info.Filename, "_")]
-	} else {
-		info.ShortName = strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename))
-	}
+	info.ShortName = stripOfficialDateSuffix(strings.TrimSuffix(info.Filename, filepath.Ext(info.Filename)))
 
 	if strings.HasPrefix(path, root) {
 		relDir, err := filepath.Rel(root, filepath.Dir(path))

--- a/pkg/platforms/mister/cores/rbfs_test.go
+++ b/pkg/platforms/mister/cores/rbfs_test.go
@@ -30,6 +30,67 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseRBFPath_StripsOnlyOfficialDateSuffix(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	tests := []struct {
+		name          string
+		relPath       string
+		wantShortName string
+		wantMglName   string
+	}{
+		{
+			name:          "official dated core",
+			relPath:       filepath.Join("_Console", "GBA_20260528.rbf"),
+			wantShortName: "GBA",
+			wantMglName:   filepath.Join("_Console", "GBA"),
+		},
+		{
+			name:          "underscore core strips date only",
+			relPath:       filepath.Join("_Console", "Saturn_DS_20230410.rbf"),
+			wantShortName: "Saturn_DS",
+			wantMglName:   filepath.Join("_Console", "Saturn_DS"),
+		},
+		{
+			name:          "llapi dated core strips date only",
+			relPath:       filepath.Join("_LLAPI", "GBA_LLAPI_20251205.rbf"),
+			wantShortName: "GBA_LLAPI",
+			wantMglName:   filepath.Join("_LLAPI", "GBA_LLAPI"),
+		},
+		{
+			name:          "undated alt core",
+			relPath:       filepath.Join("_Console", "PSX2XCPU.rbf"),
+			wantShortName: "PSX2XCPU",
+			wantMglName:   filepath.Join("_Console", "PSX2XCPU"),
+		},
+		{
+			name:          "db9 fork preserves full name",
+			relPath:       filepath.Join("_Console", "GBA_20260528_ceb4a49_DB9.rbf"),
+			wantShortName: "GBA_20260528_ceb4a49_DB9",
+			wantMglName:   filepath.Join("_Console", "GBA_20260528_ceb4a49_DB9"),
+		},
+		{
+			name:          "megadrive db9 fork preserves full name",
+			relPath:       filepath.Join("_Console", "MegaDrive_20260528_fef1285_DB9.rbf"),
+			wantShortName: "MegaDrive_20260528_fef1285_DB9",
+			wantMglName:   filepath.Join("_Console", "MegaDrive_20260528_fef1285_DB9"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := parseRBFPathAt(root, filepath.Join(root, tc.relPath))
+
+			assert.Equal(t, filepath.Base(tc.relPath), got.Filename)
+			assert.Equal(t, tc.wantShortName, got.ShortName)
+			assert.Equal(t, tc.wantMglName, got.MglName)
+		})
+	}
+}
+
 func TestShallowScanRBF_IncludesRetroAchievementsCores(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -316,6 +316,14 @@ func launchAltCore(
 	return launchAltCoreWithDefaultSetName(launcherID, systemID, rbfPath, "")
 }
 
+func launchDB9Core(
+	launcherID string,
+	systemID string,
+	rbfName string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return launchAltCore(launcherID, systemID, "_Console/"+rbfName+"_<date>_<hash>_DB9")
+}
+
 func launchAltCoreWithSetName(
 	launcherID string,
 	systemID string,
@@ -761,6 +769,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemAdventureVision),
 		},
 		{
+			ID:       "DB9AdventureVision",
+			SystemID: systemdefs.SystemAdventureVision,
+			Launch:   launchDB9Core("DB9AdventureVision", systemdefs.SystemAdventureVision, "AdventureVision"),
+		},
+		{
 			ID:         systemdefs.SystemArcadia,
 			SystemID:   systemdefs.SystemArcadia,
 			Folders:    []string{"Arcadia"},
@@ -780,6 +793,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"Astrocade"},
 			Extensions: []string{".bin"},
 			Launch:     launch(pl, systemdefs.SystemAstrocade),
+		},
+		{
+			ID:       "DB9Astrocade",
+			SystemID: systemdefs.SystemAstrocade,
+			Launch:   launchDB9Core("DB9Astrocade", systemdefs.SystemAstrocade, "Astrocade"),
 		},
 		{
 			ID:         systemdefs.SystemAtari2600,
@@ -814,11 +832,21 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemAtari5200),
 		},
 		{
+			ID:       "DB9Atari5200",
+			SystemID: systemdefs.SystemAtari5200,
+			Launch:   launchDB9Core("DB9Atari5200", systemdefs.SystemAtari5200, "Atari5200"),
+		},
+		{
 			ID:         systemdefs.SystemAtari7800,
 			SystemID:   systemdefs.SystemAtari7800,
 			Folders:    []string{"ATARI7800"},
 			Extensions: []string{".a78", ".bin"},
 			Launch:     launch(pl, systemdefs.SystemAtari7800),
+		},
+		{
+			ID:       "DB9Atari7800",
+			SystemID: systemdefs.SystemAtari7800,
+			Launch:   launchDB9Core("DB9Atari7800", systemdefs.SystemAtari7800, "Atari7800"),
 		},
 		{
 			ID:       "LLAPIAtari7800",
@@ -840,6 +868,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemAtariLynx),
 		},
 		{
+			ID:       "DB9AtariLynx",
+			SystemID: systemdefs.SystemAtariLynx,
+			Launch:   launchDB9Core("DB9AtariLynx", systemdefs.SystemAtariLynx, "AtariLynx"),
+		},
+		{
 			ID:         systemdefs.SystemCasioPV1000,
 			SystemID:   systemdefs.SystemCasioPV1000,
 			Folders:    []string{"Casio_PV-1000"},
@@ -847,11 +880,21 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemCasioPV1000),
 		},
 		{
+			ID:       "DB9CasioPV1000",
+			SystemID: systemdefs.SystemCasioPV1000,
+			Launch:   launchDB9Core("DB9CasioPV1000", systemdefs.SystemCasioPV1000, "Casio_PV-1000"),
+		},
+		{
 			ID:         systemdefs.SystemCDI,
 			SystemID:   systemdefs.SystemCDI,
 			Folders:    []string{"CD-i"},
 			Extensions: []string{".cue", ".chd"},
 			Launch:     launch(pl, systemdefs.SystemCDI),
+		},
+		{
+			ID:       "DB9CDI",
+			SystemID: systemdefs.SystemCDI,
+			Launch:   launchDB9Core("DB9CDI", systemdefs.SystemCDI, "CDi"),
 		},
 		{
 			ID:         systemdefs.SystemChannelF,
@@ -868,11 +911,21 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemColecoVision),
 		},
 		{
+			ID:       "DB9ColecoVision",
+			SystemID: systemdefs.SystemColecoVision,
+			Launch:   launchDB9Core("DB9ColecoVision", systemdefs.SystemColecoVision, "ColecoVision"),
+		},
+		{
 			ID:         systemdefs.SystemCreatiVision,
 			SystemID:   systemdefs.SystemCreatiVision,
 			Folders:    []string{"CreatiVision"},
 			Extensions: []string{".rom", ".bin", ".bas"},
 			Launch:     launch(pl, systemdefs.SystemCreatiVision),
+		},
+		{
+			ID:       "DB9CreatiVision",
+			SystemID: systemdefs.SystemCreatiVision,
+			Launch:   launchDB9Core("DB9CreatiVision", systemdefs.SystemCreatiVision, "CreatiVision"),
 		},
 		{
 			ID:         systemdefs.SystemFDS,
@@ -908,6 +961,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			),
 		},
 		{
+			ID:       "DB9Gameboy",
+			SystemID: systemdefs.SystemGameboy,
+			Launch:   launchDB9Core("DB9Gameboy", systemdefs.SystemGameboy, "Gameboy"),
+		},
+		{
 			ID:         systemdefs.SystemGameboyColor,
 			SystemID:   systemdefs.SystemGameboyColor,
 			Folders:    []string{"GAMEBOY", "GBC"},
@@ -920,6 +978,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"GAMEBOY2P"},
 			Extensions: []string{".gb", ".gbc"},
 			Launch:     launch(pl, systemdefs.SystemGameboy2P),
+		},
+		{
+			ID:       "DB9Gameboy2P",
+			SystemID: systemdefs.SystemGameboy2P,
+			Launch:   launchDB9Core("DB9Gameboy2P", systemdefs.SystemGameboy2P, "Gameboy2P"),
 		},
 		{
 			ID:         systemdefs.SystemGameGear,
@@ -943,6 +1006,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launchAggGnw,
 		},
 		{
+			ID:       "DB9GameNWatch",
+			SystemID: systemdefs.SystemGameNWatch,
+			Launch:   launchDB9Core("DB9GameNWatch", systemdefs.SystemGameNWatch, "GnW"),
+		},
+		{
 			ID:         systemdefs.SystemGBA,
 			SystemID:   systemdefs.SystemGBA,
 			Folders:    []string{"GBA"},
@@ -960,11 +1028,26 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchRetroAchievementsCore("RAGBA", systemdefs.SystemGBA, "_RA_Cores/Cores/GBA"),
 		},
 		{
+			ID:       "DB9GBA",
+			SystemID: systemdefs.SystemGBA,
+			Launch:   launchDB9Core("DB9GBA", systemdefs.SystemGBA, "GBA"),
+		},
+		{
+			ID:       "DB9GBAAccuracy",
+			SystemID: systemdefs.SystemGBA,
+			Launch:   launchDB9Core("DB9GBAAccuracy", systemdefs.SystemGBA, "GBA_accuracy"),
+		},
+		{
 			ID:         systemdefs.SystemGBA2P,
 			SystemID:   systemdefs.SystemGBA2P,
 			Folders:    []string{"GBA2P"},
 			Extensions: []string{".gba"},
 			Launch:     launch(pl, systemdefs.SystemGBA2P),
+		},
+		{
+			ID:       "DB9GBA2P",
+			SystemID: systemdefs.SystemGBA2P,
+			Launch:   launchDB9Core("DB9GBA2P", systemdefs.SystemGBA2P, "GBA2P"),
 		},
 		{
 			ID:         systemdefs.SystemGenesis,
@@ -994,6 +1077,16 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch: launchRetroAchievementsCore(
 				"RAMegaDrive", systemdefs.SystemGenesis, "_RA_Cores/Cores/MegaDrive",
 			),
+		},
+		{
+			ID:       "DB9MegaDrive",
+			SystemID: systemdefs.SystemGenesis,
+			Launch:   launchDB9Core("DB9MegaDrive", systemdefs.SystemGenesis, "MegaDrive"),
+		},
+		{
+			ID:       "DB9Genesis",
+			SystemID: systemdefs.SystemGenesis,
+			Launch:   launchDB9Core("DB9Genesis", systemdefs.SystemGenesis, "Genesis"),
 		},
 		{
 			ID:         systemdefs.SystemIntellivision,
@@ -1046,6 +1139,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			),
 		},
 		{
+			ID:       "DB9SMS",
+			SystemID: systemdefs.SystemMasterSystem,
+			Launch:   launchDB9Core("DB9SMS", systemdefs.SystemMasterSystem, "SMS"),
+		},
+		{
 			ID:         systemdefs.SystemMegaCD,
 			SystemID:   systemdefs.SystemMegaCD,
 			Folders:    []string{"MegaCD"},
@@ -1070,6 +1168,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			),
 		},
 		{
+			ID:       "DB9MegaCD",
+			SystemID: systemdefs.SystemMegaCD,
+			Launch:   launchDB9Core("DB9MegaCD", systemdefs.SystemMegaCD, "MegaCD"),
+		},
+		{
 			ID:         systemdefs.SystemMegaDuck,
 			SystemID:   systemdefs.SystemMegaDuck,
 			Folders:    []string{"GAMEBOY", "MegaDuck"},
@@ -1087,6 +1190,16 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch: launchRetroAchievementsCore(
 				"RANeoGeo", systemdefs.SystemNeoGeo, "_RA_Cores/Cores/NeoGeo",
 			),
+		},
+		{
+			ID:       "DB9NeoGeo",
+			SystemID: systemdefs.SystemNeoGeo,
+			Launch:   launchDB9Core("DB9NeoGeo", systemdefs.SystemNeoGeo, "NeoGeo"),
+		},
+		{
+			ID:       "DB9NeoGeo24MHz",
+			SystemID: systemdefs.SystemNeoGeo,
+			Launch:   launchDB9Core("DB9NeoGeo24MHz", systemdefs.SystemNeoGeo, "NeoGeo_24MHz_cpu_only"),
 		},
 		{
 			ID:         systemdefs.SystemNeoGeoCD,
@@ -1139,6 +1252,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchRetroAchievementsCore("RANES", systemdefs.SystemNES, "_RA_Cores/Cores/NES"),
 		},
 		{
+			ID:       "DB9NES",
+			SystemID: systemdefs.SystemNES,
+			Launch:   launchDB9Core("DB9NES", systemdefs.SystemNES, "NES"),
+		},
+		{
 			ID:         systemdefs.SystemNintendo64,
 			SystemID:   systemdefs.SystemNintendo64,
 			Folders:    []string{"N64"},
@@ -1185,6 +1303,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"ODYSSEY2"},
 			Extensions: []string{".bin"},
 			Launch:     launch(pl, systemdefs.SystemOdyssey2),
+		},
+		{
+			ID:       "DB9Odyssey2",
+			SystemID: systemdefs.SystemOdyssey2,
+			Launch:   launchDB9Core("DB9Odyssey2", systemdefs.SystemOdyssey2, "Odyssey2"),
 		},
 		{
 			ID:         systemdefs.SystemPocketChallengeV2,
@@ -1243,6 +1366,16 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchRetroAchievementsCore("RAPSX", systemdefs.SystemPSX, "_RA_Cores/Cores/PSX"),
 		},
 		{
+			ID:       "DB9PSX",
+			SystemID: systemdefs.SystemPSX,
+			Launch:   launchDB9Core("DB9PSX", systemdefs.SystemPSX, "PSX"),
+		},
+		{
+			ID:       "DB9DualRAMPSX",
+			SystemID: systemdefs.SystemPSX,
+			Launch:   launchDB9Core("DB9DualRAMPSX", systemdefs.SystemPSX, "PSX_DualSDRAM"),
+		},
+		{
 			ID:         systemdefs.SystemSega32X,
 			SystemID:   systemdefs.SystemSega32X,
 			Folders:    []string{"S32X"},
@@ -1262,6 +1395,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			),
 		},
 		{
+			ID:       "DB9Sega32X",
+			SystemID: systemdefs.SystemSega32X,
+			Launch:   launchDB9Core("DB9Sega32X", systemdefs.SystemSega32X, "S32X"),
+		},
+		{
 			ID:         systemdefs.SystemSG1000,
 			SystemID:   systemdefs.SystemSG1000,
 			Folders:    []string{"SG1000", "Coleco", "SMS"},
@@ -1274,6 +1412,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"SGB"},
 			Extensions: []string{".sgb", ".gb", ".gbc"},
 			Launch:     launch(pl, systemdefs.SystemSuperGameboy),
+		},
+		{
+			ID:       "DB9SuperGameboy",
+			SystemID: systemdefs.SystemSuperGameboy,
+			Launch:   launchDB9Core("DB9SuperGameboy", systemdefs.SystemSuperGameboy, "SGB"),
 		},
 		{
 			ID:       "LLAPISuperGameboy",
@@ -1310,6 +1453,16 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:   launchAltCore("DualRAMSaturn", systemdefs.SystemSaturn, "_Console (Dual SDRAM)/Saturn"),
 		},
 		{
+			ID:       "DB9Saturn",
+			SystemID: systemdefs.SystemSaturn,
+			Launch:   launchDB9Core("DB9Saturn", systemdefs.SystemSaturn, "Saturn"),
+		},
+		{
+			ID:       "DB9DualRAMSaturn",
+			SystemID: systemdefs.SystemSaturn,
+			Launch:   launchDB9Core("DB9DualRAMSaturn", systemdefs.SystemSaturn, "Saturn_DualSDRAM"),
+		},
+		{
 			ID:         systemdefs.SystemSNES,
 			SystemID:   systemdefs.SystemSNES,
 			Folders:    []string{"SNES"},
@@ -1325,6 +1478,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "RASNES",
 			SystemID: systemdefs.SystemSNES,
 			Launch:   launchRetroAchievementsCore("RASNES", systemdefs.SystemSNES, "_RA_Cores/Cores/SNES"),
+		},
+		{
+			ID:       "DB9SNES",
+			SystemID: systemdefs.SystemSNES,
+			Launch:   launchDB9Core("DB9SNES", systemdefs.SystemSNES, "SNES"),
 		},
 		{
 			ID:       "SindenSNES",
@@ -1370,6 +1528,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			),
 		},
 		{
+			ID:       "DB9TurboGrafx16",
+			SystemID: systemdefs.SystemTurboGrafx16,
+			Launch:   launchDB9Core("DB9TurboGrafx16", systemdefs.SystemTurboGrafx16, "TurboGrafx16"),
+		},
+		{
 			ID:         systemdefs.SystemTurboGrafx16CD,
 			SystemID:   systemdefs.SystemTurboGrafx16CD,
 			Folders:    []string{"TGFX16-CD"},
@@ -1389,6 +1552,11 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"VECTREX"},
 			Extensions: []string{".vec", ".bin", ".rom"}, // TODO: overlays (.ovr)
 			Launch:     launch(pl, systemdefs.SystemVectrex),
+		},
+		{
+			ID:       "DB9Vectrex",
+			SystemID: systemdefs.SystemVectrex,
+			Launch:   launchDB9Core("DB9Vectrex", systemdefs.SystemVectrex, "Vectrex"),
 		},
 		{
 			ID:         systemdefs.SystemVirtualBoy,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -626,6 +626,45 @@ func TestSetNameOptions(t *testing.T) {
 	})
 }
 
+func TestDB9LaunchersExist(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	cases := []struct {
+		id       string
+		systemID string
+	}{
+		{"DB9AtariLynx", "AtariLynx"},
+		{"DB9GBA", "GBA"},
+		{"DB9GBAAccuracy", "GBA"},
+		{"DB9MegaDrive", "Genesis"},
+		{"DB9Genesis", "Genesis"},
+		{"DB9NES", "NES"},
+		{"DB9SNES", "SNES"},
+		{"DB9PSX", "PSX"},
+		{"DB9Saturn", "Saturn"},
+		{"DB9DualRAMSaturn", "Saturn"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			var found *platforms.Launcher
+			for i := range launchers {
+				if launchers[i].ID == tc.id {
+					found = &launchers[i]
+					break
+				}
+			}
+			require.NotNil(t, found, "%s launcher should exist", tc.id)
+			assert.Equal(t, tc.systemID, found.SystemID)
+		})
+	}
+}
+
 func TestRetroAchievementsLaunchersExist(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -225,6 +225,7 @@ func TestGenerateMgl(t *testing.T) {
 		name     string
 		core     *cores.Core
 		path     string
+		rbfPath  string
 		override string
 		want     string
 		wantErr  bool
@@ -277,6 +278,29 @@ func TestGenerateMgl(t *testing.T) {
 			path: "",
 			want: "<mistergamedescription>\n\t<rbf>_Console/Atari7800</rbf>\n" +
 				"\t<setname same_dir=\"1\">Atari2600</setname>\n</mistergamedescription>",
+		},
+		{
+			name: "resolved db9 core uses concrete rbf path",
+			core: &cores.Core{
+				ID:  "Genesis",
+				RBF: "_Console/MegaDrive_*_DB9",
+				Slots: []cores.Slot{
+					{
+						Exts: []string{".bin", ".gen", ".md"},
+						Mgl: &cores.MGLParams{
+							Delay:  1,
+							Method: "f",
+							Index:  1,
+						},
+					},
+				},
+			},
+			path:    "/media/fat/games/Genesis/Sonic.bin",
+			rbfPath: "_Console/MegaDrive_20260528_fef1285_DB9",
+			want: `<mistergamedescription>
+	<rbf>_Console/MegaDrive_20260528_fef1285_DB9</rbf>
+	<file delay="1" type="f" index="1" path="../../../../../media/fat/games/Genesis/Sonic.bin"/>
+</mistergamedescription>`,
 		},
 		{
 			name: "standard game launch",
@@ -430,8 +454,8 @@ func TestGenerateMgl(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rbfPath := ""
-			if tt.core != nil {
+			rbfPath := tt.rbfPath
+			if tt.core != nil && rbfPath == "" {
 				rbfPath = tt.core.RBF
 			}
 			got, err := GenerateMgl(tt.core, rbfPath, tt.path, tt.override)


### PR DESCRIPTION
## Summary
- fix MiSTer RBF parsing so official dated cores strip only date suffixes while DB9/fork names stay explicit
- keep default core resolution strict to original cores and surface nearby fork candidates in errors
- add explicit DB9 alt launchers with constrained versioned matching so base launchers do not select variant cores
- bump persisted RBF cache version to force rebuild after parser change

Validation run before commit: targeted MiSTer core/platform/MGL/zapscript tests and MiSTer package lint passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DB9 joystick variant support for many console platforms (Atari 5200/7800/Lynx, NES, SNES, Genesis, Saturn, PSX, and more).
  * Enhanced core resolution with glob-pattern and wildcard support for alternative core variants.

* **Bug Fixes**
  * Improved error messages when cores are missing, now suggesting available alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->