### PR TITLE
fix(tui): improve manage media scrape flow

### DIFF
--- a/pkg/ui/tui/generatedb.go
+++ b/pkg/ui/tui/generatedb.go
@@ -198,20 +198,7 @@ func loadMediaManageInitialState(cfg *config.Instance) mediaManageInitialState {
 	}
 }
 
-func waitMediaManageUpdate(
-	ctx context.Context,
-	cfg *config.Instance,
-) (mediaManageUpdate, error) {
-	method, resp, err := client.WaitNotifications(
-		ctx, mediaManagePollInterval,
-		cfg,
-		models.NotificationMediaIndexing,
-		models.NotificationMediaScraping,
-	)
-	if err != nil {
-		return mediaManageUpdate{}, fmt.Errorf("failed to wait for notification: %w", err)
-	}
-
+func parseMediaManageUpdate(method, resp string) (mediaManageUpdate, error) {
 	switch method {
 	case models.NotificationMediaIndexing:
 		var status models.IndexingStatusResponse
@@ -228,6 +215,23 @@ func waitMediaManageUpdate(
 	default:
 		return mediaManageUpdate{}, fmt.Errorf("unexpected notification method: %s", method)
 	}
+}
+
+func waitMediaManageUpdate(
+	ctx context.Context,
+	cfg *config.Instance,
+) (mediaManageUpdate, error) {
+	method, resp, err := client.WaitNotifications(
+		ctx, mediaManagePollInterval,
+		cfg,
+		models.NotificationMediaIndexing,
+		models.NotificationMediaScraping,
+	)
+	if err != nil {
+		return mediaManageUpdate{}, fmt.Errorf("failed to wait for notification: %w", err)
+	}
+
+	return parseMediaManageUpdate(method, resp)
 }
 
 type ProgressBar struct {

--- a/pkg/ui/tui/generatedb.go
+++ b/pkg/ui/tui/generatedb.go
@@ -37,6 +37,7 @@ import (
 )
 
 const (
+	mediaManageLoadingPage  = "loading"
 	mediaManageInitialPage  = "initial"
 	mediaManageSetupPage    = "scrape_setup"
 	mediaManageSystemsPage  = "scrape_systems"
@@ -152,6 +153,49 @@ type mediaManageUpdate struct {
 	indexing models.IndexingStatusResponse
 	method   string
 	scraping models.ScrapingStatusResponse
+}
+
+type mediaManageInitialState struct {
+	media        models.MediaResponse
+	mediaErr     error
+	scrapeStatus models.ScrapingStatusResponse
+	scrapeErr    error
+}
+
+func loadMediaManageInitialState(cfg *config.Instance) mediaManageInitialState {
+	type mediaResult struct {
+		media models.MediaResponse
+		err   error
+	}
+	type scrapeResult struct {
+		status models.ScrapingStatusResponse
+		err    error
+	}
+
+	mediaCh := make(chan mediaResult, 1)
+	scrapeCh := make(chan scrapeResult, 1)
+
+	go func() {
+		ctx, cancel := tuiContext()
+		defer cancel()
+		media, err := getMediaState(ctx, cfg)
+		mediaCh <- mediaResult{media: media, err: err}
+	}()
+	go func() {
+		ctx, cancel := tuiContext()
+		defer cancel()
+		status, err := getScrapeStatus(ctx, cfg)
+		scrapeCh <- scrapeResult{status: status, err: err}
+	}()
+
+	media := <-mediaCh
+	scrape := <-scrapeCh
+	return mediaManageInitialState{
+		media:        media.media,
+		mediaErr:     media.err,
+		scrapeStatus: scrape.status,
+		scrapeErr:    scrape.err,
+	}
 }
 
 func waitMediaManageUpdate(
@@ -338,27 +382,50 @@ func formatScrapeProgress(status *models.ScrapingStatusResponse, scraperName str
 	} else if status.ScraperID != "" {
 		parts = append(parts, status.ScraperID)
 	}
-	if status.SystemID != "" {
+	if status.CurrentSystem != nil && status.CurrentSystem.SystemName != "" {
+		parts = append(parts, status.CurrentSystem.SystemName)
+	} else if status.CurrentSystem != nil && status.CurrentSystem.SystemID != "" {
+		parts = append(parts, status.CurrentSystem.SystemID)
+	} else if status.SystemID != "" {
 		parts = append(parts, status.SystemID)
 	}
 
-	prefix := strings.Join(parts, " - ")
-	if prefix != "" {
-		prefix += "\n"
+	lines := make([]string, 0, 4)
+	if prefix := strings.Join(parts, " - "); prefix != "" {
+		lines = append(lines, prefix)
 	}
-	if status.Total > 0 {
-		progress := "Records"
-		if status.Paused {
-			progress = "Paused"
+	if status.CurrentStep != nil && status.TotalSteps != nil {
+		overall := fmt.Sprintf("Overall: %d / %d", *status.CurrentStep, *status.TotalSteps)
+		if status.CurrentStepDisplay != nil && *status.CurrentStepDisplay != "" {
+			overall = fmt.Sprintf("Overall: %s (%d / %d)",
+				*status.CurrentStepDisplay, *status.CurrentStep, *status.TotalSteps)
 		}
-		return fmt.Sprintf("%s%s: %d / %d\nMatched: %d  Skipped: %d",
-			prefix, progress, status.Processed, status.Total, status.Matched, status.Skipped)
+		lines = append(lines, overall)
 	}
+
+	processed := status.Processed
+	total := status.Total
+	matched := status.Matched
+	skipped := status.Skipped
+	if status.CurrentSystem != nil {
+		processed = status.CurrentSystem.Processed
+		total = status.CurrentSystem.Total
+		matched = status.CurrentSystem.Matched
+		skipped = status.CurrentSystem.Skipped
+	}
+	progress := "Records"
 	if status.Paused {
-		return fmt.Sprintf("%sPaused\nMatched: %d  Skipped: %d", prefix, status.Matched, status.Skipped)
+		progress = "Paused"
 	}
-	return fmt.Sprintf("%sRecords: %d processed\nMatched: %d  Skipped: %d",
-		prefix, status.Processed, status.Matched, status.Skipped)
+	if total > 0 {
+		lines = append(lines, fmt.Sprintf("%s: %d / %d", progress, processed, total))
+	} else if status.Paused {
+		lines = append(lines, "Paused")
+	} else {
+		lines = append(lines, fmt.Sprintf("Records: %d processed", processed))
+	}
+	lines = append(lines, fmt.Sprintf("Matched: %d  Skipped: %d", matched, skipped))
+	return strings.Join(lines, "\n")
 }
 
 func mediaIndexProgress(current, total int) float64 {
@@ -366,6 +433,39 @@ func mediaIndexProgress(current, total int) float64 {
 		return 0
 	}
 	return float64(current) / float64(total)
+}
+
+func scrapeOverallProgress(status models.ScrapingStatusResponse) float64 {
+	if status.CurrentStep != nil && status.TotalSteps != nil {
+		return mediaIndexProgress(*status.CurrentStep, *status.TotalSteps)
+	}
+	return mediaIndexProgress(status.Processed, status.Total)
+}
+
+func scrapeCurrentSystemProgress(status models.ScrapingStatusResponse) float64 {
+	if status.CurrentSystem != nil {
+		return mediaIndexProgress(status.CurrentSystem.Processed, status.CurrentSystem.Total)
+	}
+	return mediaIndexProgress(status.Processed, status.Total)
+}
+
+func handleMediaManageEscape(
+	statePages *tview.Pages,
+	goBack func(),
+	showInitial func(),
+	closeSystemsPage func(),
+) {
+	frontPage, _ := statePages.GetFrontPage()
+	switch frontPage {
+	case mediaManageSystemsPage:
+		closeSystemsPage()
+	case mediaManageSetupPage, mediaManageProgressPage:
+		showInitial()
+	case mediaManageCompletePage, mediaManageInitialPage, mediaManageLoadingPage:
+		goBack()
+	default:
+		goBack()
+	}
 }
 
 // BuildGenerateDBPage creates the media management page with PageFrame.
@@ -382,10 +482,11 @@ func BuildGenerateDBPage(
 		cancel()
 		pages.SwitchToPage(PageMain)
 	}
-	frame.SetOnEscape(goBack)
 
 	progressBar := NewProgressBar()
 	progressBar.SetBorder(true)
+	systemProgressBar := NewProgressBar()
+	systemProgressBar.SetBorder(true)
 
 	progressStatusText := tview.NewTextView().
 		SetTextAlign(tview.AlignCenter).
@@ -394,10 +495,15 @@ func BuildGenerateDBPage(
 	completeText := tview.NewTextView().
 		SetTextAlign(tview.AlignCenter)
 
-	var refreshInitial, showInitial, refreshScrapeSetup, showScrapeSetup, startScrapeFromSetup func()
+	var renderInitial func(mediaManageInitialState)
+	var showInitial, refreshScrapeSetup, showScrapeSetup, startScrapeFromSetup func()
+	var closeScrapeSystemsPage func()
 	var showIndexProgress func(models.IndexingStatusResponse)
 	var showScrapeProgress func(models.ScrapingStatusResponse)
-	var createCompleteButtonBar, getProgressButtonBar func() *ButtonBar
+	var createCompleteButtonBar func() *ButtonBar
+	var createProgressButtonBar func(paused bool) *ButtonBar
+	var setProgressButtonBar func(paused bool)
+	var progressButtonBarPaused *bool
 
 	statePages := tview.NewPages()
 	initialList := NewSettingsList(pages, PageMain).
@@ -481,96 +587,79 @@ func BuildGenerateDBPage(
 	progressTitle := tview.NewTextView().
 		SetText("Working...").
 		SetTextAlign(tview.AlignCenter)
-	progressContent.AddItem(nil, 0, 1, false)
-	progressContent.AddItem(progressTitle, 1, 0, false)
-	progressContent.AddItem(progressBar, 3, 0, false)
-	progressContent.AddItem(progressStatusText, 3, 0, false)
-	progressContent.AddItem(nil, 0, 1, false)
+	showIndexProgressLayout := func() {
+		progressContent.Clear()
+		progressContent.AddItem(nil, 0, 1, false)
+		progressContent.AddItem(progressTitle, 1, 0, false)
+		progressContent.AddItem(progressBar, 3, 0, false)
+		progressContent.AddItem(progressStatusText, 3, 0, false)
+		progressContent.AddItem(nil, 0, 1, false)
+	}
+	showScrapeProgressLayout := func() {
+		progressContent.Clear()
+		progressContent.AddItem(nil, 0, 1, false)
+		progressContent.AddItem(progressTitle, 1, 0, false)
+		progressContent.AddItem(progressBar, 3, 0, false)
+		progressContent.AddItem(systemProgressBar, 3, 0, false)
+		progressContent.AddItem(progressStatusText, 4, 0, false)
+		progressContent.AddItem(nil, 0, 1, false)
+	}
+	showIndexProgressLayout()
 
 	completeContent := tview.NewFlex().SetDirection(tview.FlexRow)
 	completeContent.AddItem(nil, 0, 1, false)
 	completeContent.AddItem(completeText, 3, 0, false)
 	completeContent.AddItem(nil, 0, 1, false)
 
-	statePages.AddPage(mediaManageInitialPage, initialList.List, true, true)
+	loadingText := tview.NewTextView().
+		SetTextAlign(tview.AlignCenter).
+		SetText("Loading media status...")
+	loadingContent := tview.NewFlex().SetDirection(tview.FlexRow)
+	loadingContent.AddItem(nil, 0, 1, false)
+	loadingContent.AddItem(loadingText, 1, 0, false)
+	loadingContent.AddItem(nil, 0, 1, false)
+
+	statePages.AddPage(mediaManageLoadingPage, loadingContent, true, true)
+	statePages.AddPage(mediaManageInitialPage, initialList.List, true, false)
 	statePages.AddPage(mediaManageSetupPage, scrapeSetupList.List, true, false)
 	statePages.AddPage(mediaManageProgressPage, progressContent, true, false)
 	statePages.AddPage(mediaManageCompletePage, completeContent, true, false)
 
-	var progressButtonBar *ButtonBar
-	getProgressButtonBar = func() *ButtonBar {
-		if progressButtonBar != nil {
-			return progressButtonBar
-		}
-		bar := NewButtonBar(app)
-		bar.AddButtonWithHelp("Cancel", "Stop current operation", func() {
-			ShowConfirmModal(pages, app, "Cancel the current media operation?", func() {
-				operation := getOperation()
-				if operation == "" {
-					frame.FocusButtonBar()
-					return
-				}
+	closeScrapeSystemsPage = func() {
+		refreshScrapeSetup()
+		statePages.RemovePage(mediaManageSystemsPage)
+		statePages.SwitchToPage(mediaManageSetupPage)
+		app.SetFocus(scrapeSetupList.List)
+	}
+	frame.SetOnEscape(func() {
+		handleMediaManageEscape(statePages, goBack, showInitial, closeScrapeSystemsPage)
+	})
 
-				progressStatusText.SetText("Cancelling...")
-				frame.SetHelpText("Cancelling...")
-				frame.FocusButtonBar()
-
-				go func(operation string) {
-					cancelCtx, cancelReq := tuiContext()
-					defer cancelReq()
-
-					var err error
-					switch operation {
-					case mediaManageIndex:
-						err = cancelMediaIndex(cancelCtx, cfg)
-					case mediaManageScrape:
-						err = cancelMediaScrape(cancelCtx, cfg)
-					}
-					if err != nil {
-						log.Warn().Err(err).Msg("error cancelling media operation")
-						app.QueueUpdateDraw(func() {
-							ShowErrorModal(pages, app, err.Error(), func() {
-								frame.FocusButtonBar()
-							})
-						})
-						return
-					}
-
-					app.QueueUpdateDraw(func() {
-						setCancelled(operation)
-						setOperation("")
-						setProgressVisible(false)
-						completeText.SetText("Media operation cancelled.")
-						statePages.SwitchToPage(mediaManageCompletePage)
-						frame.SetHelpText("Operation cancelled")
-						frame.SetButtonBar(createCompleteButtonBar())
-						frame.FocusButtonBar()
-					})
-				}(operation)
-			}, func() {
-				frame.FocusButtonBar()
-			})
-		})
-		bar.AddButtonWithHelp("Resume", "Continue paused operation", func() {
+	cancelCurrentOperation := func() {
+		ShowConfirmModal(pages, app, "Cancel the current media operation?", func() {
 			operation := getOperation()
 			if operation == "" {
 				frame.FocusButtonBar()
 				return
 			}
 
+			progressStatusText.SetText("Cancelling...")
+			frame.SetHelpText("Cancelling...")
+			frame.FocusButtonBar()
+
 			go func(operation string) {
-				resumeCtx, cancelReq := tuiContext()
+				cancelCtx, cancelReq := tuiContext()
 				defer cancelReq()
 
 				var err error
 				switch operation {
 				case mediaManageIndex:
-					err = resumeMediaIndex(resumeCtx, cfg)
+					err = cancelMediaIndex(cancelCtx, cfg)
 				case mediaManageScrape:
-					err = resumeMediaScrape(resumeCtx, cfg)
+					err = cancelMediaScrape(cancelCtx, cfg)
 				}
 				if err != nil {
-					log.Warn().Err(err).Msg("error resuming media operation")
+					log.Warn().Err(err).Msg("error cancelling media operation")
 					app.QueueUpdateDraw(func() {
 						ShowErrorModal(pages, app, err.Error(), func() {
 							frame.FocusButtonBar()
@@ -580,20 +669,78 @@ func BuildGenerateDBPage(
 				}
 
 				app.QueueUpdateDraw(func() {
-					progressStatusText.SetText("Resuming...")
-					frame.SetHelpText("Stop current operation")
+					setCancelled(operation)
+					setOperation("")
+					setProgressVisible(false)
+					completeText.SetText("Media operation cancelled.")
+					statePages.SwitchToPage(mediaManageCompletePage)
+					frame.SetHelpText("Operation cancelled")
+					frame.SetButtonBar(createCompleteButtonBar())
 					frame.FocusButtonBar()
 				})
 			}(operation)
+		}, func() {
+			frame.FocusButtonBar()
 		})
+	}
+	resumeCurrentOperation := func() {
+		operation := getOperation()
+		if operation == "" {
+			frame.FocusButtonBar()
+			return
+		}
+
+		go func(operation string) {
+			resumeCtx, cancelReq := tuiContext()
+			defer cancelReq()
+
+			var err error
+			switch operation {
+			case mediaManageIndex:
+				err = resumeMediaIndex(resumeCtx, cfg)
+			case mediaManageScrape:
+				err = resumeMediaScrape(resumeCtx, cfg)
+			}
+			if err != nil {
+				log.Warn().Err(err).Msg("error resuming media operation")
+				app.QueueUpdateDraw(func() {
+					ShowErrorModal(pages, app, err.Error(), func() {
+						frame.FocusButtonBar()
+					})
+				})
+				return
+			}
+
+			app.QueueUpdateDraw(func() {
+				progressStatusText.SetText("Resuming...")
+				frame.SetHelpText("Stop current operation")
+				setProgressButtonBar(false)
+			})
+		}(operation)
+	}
+	createProgressButtonBar = func(paused bool) *ButtonBar {
+		bar := NewButtonBar(app)
+		if paused {
+			bar.AddButtonWithHelp("Resume", "Continue paused operation", resumeCurrentOperation)
+		} else {
+			bar.AddButtonWithHelp("Cancel", "Stop current operation", cancelCurrentOperation)
+		}
 		bar.AddButtonWithHelp("Back", "Continue in background", showInitial)
-		bar.focusedIndex = 2
+		bar.focusedIndex = 1
 		bar.SetupNavigation(showInitial)
 		bar.SetHelpCallback(func(help string) {
 			frame.SetHelpText(help)
 		})
-		progressButtonBar = bar
-		return progressButtonBar
+		return bar
+	}
+	setProgressButtonBar = func(paused bool) {
+		if progressButtonBarPaused != nil && *progressButtonBarPaused == paused && frame.GetButtonBar() != nil {
+			frame.FocusButtonBar()
+			return
+		}
+		progressButtonBarPaused = &paused
+		frame.SetButtonBar(createProgressButtonBar(paused))
+		frame.FocusButtonBar()
 	}
 
 	createCompleteButtonBar = func() *ButtonBar {
@@ -605,37 +752,30 @@ func BuildGenerateDBPage(
 		return bar
 	}
 
-	refreshInitial = func() {
+	renderInitial = func(state mediaManageInitialState) {
 		setProgressVisible(false)
 		initialList.ClearItems()
 
-		mediaCtx, mediaCancel := tuiContext()
-		media, mediaErr := getMediaState(mediaCtx, cfg)
-		mediaCancel()
-
-		scrapeCtx, scrapeCancel := tuiContext()
-		scrapeStatus, scrapeErr := getScrapeStatus(scrapeCtx, cfg)
-		scrapeCancel()
-
 		dbLabel := "Update index: unavailable"
-		if mediaErr == nil {
-			dbLabel = formatDBMenuLabel(media.Database)
+		if state.mediaErr == nil {
+			dbLabel = formatDBMenuLabel(state.media.Database)
 		}
 		scrapeLabel := "Scrape metadata: unavailable"
-		if scrapeErr == nil {
-			scrapeLabel = formatScrapeMenuLabel(&scrapeStatus)
+		if state.scrapeErr == nil {
+			scrapeLabel = formatScrapeMenuLabel(&state.scrapeStatus)
 		}
-		if (mediaErr != nil || !media.Database.Indexing) && (scrapeErr != nil || !scrapeStatus.Scraping) {
+		if (state.mediaErr != nil || !state.media.Database.Indexing) &&
+			(state.scrapeErr != nil || !state.scrapeStatus.Scraping) {
 			setOperation("")
 		}
 
 		switch {
-		case mediaErr == nil && media.Database.Indexing:
+		case state.mediaErr == nil && state.media.Database.Indexing:
 			setOperation(mediaManageIndex)
 			initialList.AddAction(dbLabel, "View index progress", func() {
-				showIndexProgress(media.Database)
+				showIndexProgress(state.media.Database)
 			})
-		case scrapeErr == nil && scrapeStatus.Scraping:
+		case state.scrapeErr == nil && state.scrapeStatus.Scraping:
 			initialList.AddAction(mediaIndexBlockedByScrapeLabel(), "Wait for scrape to finish", func() {})
 		default:
 			initialList.AddAction(dbLabel, "Scan media folders", func() {
@@ -649,24 +789,24 @@ func BuildGenerateDBPage(
 				}
 				setOperation(mediaManageIndex)
 				setCancelled("")
+				showIndexProgressLayout()
 				progressTitle.SetText("Updating media index...")
 				progressBar.SetProgress(0)
 				progressStatusText.SetText("Starting scan...")
 				statePages.SwitchToPage(mediaManageProgressPage)
 				setProgressVisible(true)
 				frame.SetHelpText("Stop current operation")
-				frame.SetButtonBar(getProgressButtonBar())
-				frame.FocusButtonBar()
+				setProgressButtonBar(false)
 			})
 		}
 
 		switch {
-		case scrapeErr == nil && scrapeStatus.Scraping:
+		case state.scrapeErr == nil && state.scrapeStatus.Scraping:
 			setOperation(mediaManageScrape)
 			initialList.AddAction(scrapeLabel, "View scrape progress", func() {
-				showScrapeProgress(scrapeStatus)
+				showScrapeProgress(state.scrapeStatus)
 			})
-		case mediaErr == nil && media.Database.Indexing:
+		case state.mediaErr == nil && state.media.Database.Indexing:
 			initialList.AddAction(mediaScrapeBlockedByIndexLabel(), "Wait for index to finish", func() {})
 		default:
 			initialList.AddNavAction(scrapeLabel, "Scrape indexed media", showScrapeSetup)
@@ -676,11 +816,25 @@ func BuildGenerateDBPage(
 	}
 
 	showInitial = func() {
-		frame.SetHelpText("Update index or scrape metadata")
-		refreshInitial()
-		statePages.SwitchToPage(mediaManageInitialPage)
+		frame.SetHelpText("")
+		statePages.SwitchToPage(mediaManageLoadingPage)
 		frame.SetButtonBar(nil)
-		app.SetFocus(initialList.List)
+		app.SetFocus(frame)
+
+		go func() {
+			state := loadMediaManageInitialState(cfg)
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			app.QueueUpdateDraw(func() {
+				renderInitial(state)
+				statePages.SwitchToPage(mediaManageInitialPage)
+				frame.SetHelpText("Update index or scrape metadata")
+				app.SetFocus(initialList.List)
+			})
+		}()
 	}
 
 	refreshScrapeSetup = func() {
@@ -725,10 +879,7 @@ func BuildGenerateDBPage(
 					})
 					selector.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 						if event.Key() == tcell.KeyEscape {
-							refreshScrapeSetup()
-							statePages.RemovePage(mediaManageSystemsPage)
-							statePages.SwitchToPage(mediaManageSetupPage)
-							app.SetFocus(scrapeSetupList.List)
+							closeScrapeSystemsPage()
 							return nil
 						}
 						return event
@@ -821,46 +972,61 @@ func BuildGenerateDBPage(
 			Force:     scrapeState.force,
 		}
 
-		startCtx, startCancel := tuiContext()
-		err := startMediaScrape(startCtx, cfg, params)
-		startCancel()
-		if err != nil {
-			log.Warn().Err(err).Msg("error starting media scrape")
-			showError(err)
-			return
-		}
-
 		setOperation(mediaManageScrape)
 		setCancelled("")
-		progressTitle.SetText("Scraping metadata...")
+		showScrapeProgressLayout()
+		progressTitle.SetText("Starting scrape...")
 		progressBar.SetProgress(0)
-		progressStatusText.SetText(formatScrapeProgress(&models.ScrapingStatusResponse{
-			ScraperID: scraper.ID,
-			Scraping:  true,
-		}, scraper.Name))
+		systemProgressBar.SetProgress(0)
+		progressStatusText.SetText("")
 		statePages.SwitchToPage(mediaManageProgressPage)
 		setProgressVisible(true)
 		frame.SetHelpText("Stop current operation")
-		frame.SetButtonBar(getProgressButtonBar())
-		frame.FocusButtonBar()
+		setProgressButtonBar(false)
+
+		go func() {
+			startCtx, startCancel := tuiContext()
+			err := startMediaScrape(startCtx, cfg, params)
+			startCancel()
+			if err != nil {
+				log.Warn().Err(err).Msg("error starting media scrape")
+				app.QueueUpdateDraw(func() {
+					showError(err)
+				})
+				return
+			}
+
+			status := models.ScrapingStatusResponse{
+				ScraperID: scraper.ID,
+				Scraping:  true,
+			}
+			app.QueueUpdateDraw(func() {
+				progressTitle.SetText("Scraping metadata...")
+				progressBar.SetProgress(scrapeOverallProgress(status))
+				systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
+				progressStatusText.SetText(formatScrapeProgress(&status, scraper.Name))
+				frame.SetHelpText("Stop current operation")
+				setProgressButtonBar(false)
+			})
+		}()
 	}
 
 	updateIndexProgress := func(current, total int, status string) {
 		app.QueueUpdateDraw(func() {
+			showIndexProgressLayout()
 			progressTitle.SetText("Updating media index...")
 			progressBar.SetProgress(mediaIndexProgress(current, total))
 			progressStatusText.SetText(status)
+			setProgressButtonBar(false)
 		})
 	}
 
 	updateScrapeProgress := func(status models.ScrapingStatusResponse) {
 		app.QueueUpdateDraw(func() {
+			showScrapeProgressLayout()
 			progressTitle.SetText("Scraping metadata...")
-			if status.Total > 0 {
-				progressBar.SetProgress(float64(status.Processed) / float64(status.Total))
-			} else {
-				progressBar.SetProgress(0)
-			}
+			progressBar.SetProgress(scrapeOverallProgress(status))
+			systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
 			scraperName := ""
 			for _, scraper := range scrapeState.scrapers {
 				if scraper.ID == status.ScraperID {
@@ -869,12 +1035,14 @@ func BuildGenerateDBPage(
 				}
 			}
 			progressStatusText.SetText(formatScrapeProgress(&status, scraperName))
+			setProgressButtonBar(status.Paused)
 		})
 	}
 
 	showIndexProgress = func(status models.IndexingStatusResponse) {
 		setOperation(mediaManageIndex)
 		setCancelled("")
+		showIndexProgressLayout()
 		progressTitle.SetText("Updating media index...")
 		if status.CurrentStep != nil && status.TotalSteps != nil {
 			progressBar.SetProgress(mediaIndexProgress(*status.CurrentStep, *status.TotalSteps))
@@ -889,25 +1057,21 @@ func BuildGenerateDBPage(
 		statePages.SwitchToPage(mediaManageProgressPage)
 		setProgressVisible(true)
 		frame.SetHelpText("Stop current operation")
-		frame.SetButtonBar(getProgressButtonBar())
-		frame.FocusButtonBar()
+		setProgressButtonBar(status.Paused)
 	}
 
 	showScrapeProgress = func(status models.ScrapingStatusResponse) {
 		setOperation(mediaManageScrape)
 		setCancelled("")
+		showScrapeProgressLayout()
 		progressTitle.SetText("Scraping metadata...")
-		if status.Total > 0 {
-			progressBar.SetProgress(float64(status.Processed) / float64(status.Total))
-		} else {
-			progressBar.SetProgress(0)
-		}
+		progressBar.SetProgress(scrapeOverallProgress(status))
+		systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
 		progressStatusText.SetText(formatScrapeProgress(&status, ""))
 		statePages.SwitchToPage(mediaManageProgressPage)
 		setProgressVisible(true)
 		frame.SetHelpText("Stop current operation")
-		frame.SetButtonBar(getProgressButtonBar())
-		frame.FocusButtonBar()
+		setProgressButtonBar(status.Paused)
 	}
 
 	showIndexComplete := func(filesFound int) {
@@ -976,23 +1140,9 @@ func BuildGenerateDBPage(
 		}
 	}
 
-	mediaCtx, mediaCancel := tuiContext()
-	defer mediaCancel()
-	media, err := getMediaState(mediaCtx, cfg)
-	scrapeCtx, scrapeCancel := tuiContext()
-	scrapeStatus, scrapeErr := getScrapeStatus(scrapeCtx, cfg)
-	scrapeCancel()
-
-	switch {
-	case err != nil:
-		showInitial()
-	case media.Database.Indexing:
-		showInitial()
-	case scrapeErr == nil && scrapeStatus.Scraping:
-		showInitial()
-	default:
-		showInitial()
-	}
+	frame.SetContent(statePages)
+	pages.AddAndSwitchToPage(PageGenerateDB, frame, true)
+	showInitial()
 
 	go func() {
 		defer cancel()
@@ -1069,12 +1219,4 @@ func BuildGenerateDBPage(
 			}
 		}
 	}()
-
-	frame.SetContent(statePages)
-	pages.AddAndSwitchToPage(PageGenerateDB, frame, true)
-	if isProgressVisible() {
-		frame.FocusButtonBar()
-	} else {
-		app.SetFocus(initialList.List)
-	}
 }

--- a/pkg/ui/tui/generatedb.go
+++ b/pkg/ui/tui/generatedb.go
@@ -156,20 +156,20 @@ type mediaManageUpdate struct {
 }
 
 type mediaManageInitialState struct {
-	media        models.MediaResponse
 	mediaErr     error
-	scrapeStatus models.ScrapingStatusResponse
 	scrapeErr    error
+	media        models.MediaResponse
+	scrapeStatus models.ScrapingStatusResponse
 }
 
 func loadMediaManageInitialState(cfg *config.Instance) mediaManageInitialState {
 	type mediaResult struct {
-		media models.MediaResponse
 		err   error
+		media models.MediaResponse
 	}
 	type scrapeResult struct {
-		status models.ScrapingStatusResponse
 		err    error
+		status models.ScrapingStatusResponse
 	}
 
 	mediaCh := make(chan mediaResult, 1)
@@ -382,11 +382,12 @@ func formatScrapeProgress(status *models.ScrapingStatusResponse, scraperName str
 	} else if status.ScraperID != "" {
 		parts = append(parts, status.ScraperID)
 	}
-	if status.CurrentSystem != nil && status.CurrentSystem.SystemName != "" {
+	switch {
+	case status.CurrentSystem != nil && status.CurrentSystem.SystemName != "":
 		parts = append(parts, status.CurrentSystem.SystemName)
-	} else if status.CurrentSystem != nil && status.CurrentSystem.SystemID != "" {
+	case status.CurrentSystem != nil && status.CurrentSystem.SystemID != "":
 		parts = append(parts, status.CurrentSystem.SystemID)
-	} else if status.SystemID != "" {
+	case status.SystemID != "":
 		parts = append(parts, status.SystemID)
 	}
 
@@ -417,11 +418,12 @@ func formatScrapeProgress(status *models.ScrapingStatusResponse, scraperName str
 	if status.Paused {
 		progress = "Paused"
 	}
-	if total > 0 {
+	switch {
+	case total > 0:
 		lines = append(lines, fmt.Sprintf("%s: %d / %d", progress, processed, total))
-	} else if status.Paused {
+	case status.Paused:
 		lines = append(lines, "Paused")
-	} else {
+	default:
 		lines = append(lines, fmt.Sprintf("Records: %d processed", processed))
 	}
 	lines = append(lines, fmt.Sprintf("Matched: %d  Skipped: %d", matched, skipped))
@@ -435,14 +437,14 @@ func mediaIndexProgress(current, total int) float64 {
 	return float64(current) / float64(total)
 }
 
-func scrapeOverallProgress(status models.ScrapingStatusResponse) float64 {
+func scrapeOverallProgress(status *models.ScrapingStatusResponse) float64 {
 	if status.CurrentStep != nil && status.TotalSteps != nil {
 		return mediaIndexProgress(*status.CurrentStep, *status.TotalSteps)
 	}
 	return mediaIndexProgress(status.Processed, status.Total)
 }
 
-func scrapeCurrentSystemProgress(status models.ScrapingStatusResponse) float64 {
+func scrapeCurrentSystemProgress(status *models.ScrapingStatusResponse) float64 {
 	if status.CurrentSystem != nil {
 		return mediaIndexProgress(status.CurrentSystem.Processed, status.CurrentSystem.Total)
 	}
@@ -1002,8 +1004,8 @@ func BuildGenerateDBPage(
 			}
 			app.QueueUpdateDraw(func() {
 				progressTitle.SetText("Scraping metadata...")
-				progressBar.SetProgress(scrapeOverallProgress(status))
-				systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
+				progressBar.SetProgress(scrapeOverallProgress(&status))
+				systemProgressBar.SetProgress(scrapeCurrentSystemProgress(&status))
 				progressStatusText.SetText(formatScrapeProgress(&status, scraper.Name))
 				frame.SetHelpText("Stop current operation")
 				setProgressButtonBar(false)
@@ -1025,8 +1027,8 @@ func BuildGenerateDBPage(
 		app.QueueUpdateDraw(func() {
 			showScrapeProgressLayout()
 			progressTitle.SetText("Scraping metadata...")
-			progressBar.SetProgress(scrapeOverallProgress(status))
-			systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
+			progressBar.SetProgress(scrapeOverallProgress(&status))
+			systemProgressBar.SetProgress(scrapeCurrentSystemProgress(&status))
 			scraperName := ""
 			for _, scraper := range scrapeState.scrapers {
 				if scraper.ID == status.ScraperID {
@@ -1065,8 +1067,8 @@ func BuildGenerateDBPage(
 		setCancelled("")
 		showScrapeProgressLayout()
 		progressTitle.SetText("Scraping metadata...")
-		progressBar.SetProgress(scrapeOverallProgress(status))
-		systemProgressBar.SetProgress(scrapeCurrentSystemProgress(status))
+		progressBar.SetProgress(scrapeOverallProgress(&status))
+		systemProgressBar.SetProgress(scrapeCurrentSystemProgress(&status))
 		progressStatusText.SetText(formatScrapeProgress(&status, ""))
 		statePages.SwitchToPage(mediaManageProgressPage)
 		setProgressVisible(true)

--- a/pkg/ui/tui/generatedb_test.go
+++ b/pkg/ui/tui/generatedb_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -255,6 +256,27 @@ func TestFormatScrapeProgress(t *testing.T) {
 			Paused:    true,
 		}, ""),
 	)
+
+	currentStep := 2
+	totalSteps := 5
+	display := "Super Nintendo"
+	assert.Equal(t,
+		"ScreenScraper - SNES\nOverall: Super Nintendo (2 / 5)\nRecords: 4 / 12\nMatched: 3  Skipped: 1",
+		formatScrapeProgress(&models.ScrapingStatusResponse{
+			ScraperID:          "screenscraper",
+			CurrentStep:        &currentStep,
+			TotalSteps:         &totalSteps,
+			CurrentStepDisplay: &display,
+			CurrentSystem: &models.ScrapeSystemProgressResponse{
+				SystemID:   "snes",
+				SystemName: "SNES",
+				Processed:  4,
+				Total:      12,
+				Matched:    3,
+				Skipped:    1,
+			},
+		}, "ScreenScraper"),
+	)
 }
 
 func TestBlockedMediaOperationMenuLabels(t *testing.T) {
@@ -311,6 +333,30 @@ func TestFormatScrapeSystemsLabel(t *testing.T) {
 	assert.Equal(t, "nes", formatScrapeSystemsLabel([]string{"nes"}, systems))
 }
 
+func TestScrapeProgressHelpers(t *testing.T) {
+	t.Parallel()
+
+	currentStep := 2
+	totalSteps := 5
+	status := models.ScrapingStatusResponse{
+		CurrentStep: &currentStep,
+		TotalSteps:  &totalSteps,
+		Processed:   7,
+		Total:       10,
+		CurrentSystem: &models.ScrapeSystemProgressResponse{
+			Processed: 3,
+			Total:     6,
+		},
+	}
+
+	assert.InDelta(t, 0.4, scrapeOverallProgress(status), 0.001)
+	assert.InDelta(t, 0.5, scrapeCurrentSystemProgress(status), 0.001)
+	assert.InDelta(t, 0.7, scrapeOverallProgress(models.ScrapingStatusResponse{
+		Processed: 7,
+		Total:     10,
+	}), 0.001)
+}
+
 func TestMediaIndexProgress(t *testing.T) {
 	t.Parallel()
 
@@ -347,6 +393,106 @@ func TestMediaIndexProgress(t *testing.T) {
 			assert.InDelta(t, tt.expected, result, 0.001)
 		})
 	}
+}
+
+func TestHandleMediaManageEscape(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		frontPage   string
+		wantBack    bool
+		wantInitial bool
+		wantSystems bool
+	}{
+		{
+			name:        "systems returns to setup",
+			frontPage:   mediaManageSystemsPage,
+			wantSystems: true,
+		},
+		{
+			name:        "setup returns to initial",
+			frontPage:   mediaManageSetupPage,
+			wantInitial: true,
+		},
+		{
+			name:        "progress returns to initial",
+			frontPage:   mediaManageProgressPage,
+			wantInitial: true,
+		},
+		{
+			name:      "complete exits manage media",
+			frontPage: mediaManageCompletePage,
+			wantBack:  true,
+		},
+		{
+			name:      "initial exits manage media",
+			frontPage: mediaManageInitialPage,
+			wantBack:  true,
+		},
+		{
+			name:      "loading exits manage media",
+			frontPage: mediaManageLoadingPage,
+			wantBack:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			statePages := tview.NewPages()
+			for _, page := range []string{
+				mediaManageLoadingPage,
+				mediaManageInitialPage,
+				mediaManageSetupPage,
+				mediaManageProgressPage,
+				mediaManageCompletePage,
+				mediaManageSystemsPage,
+			} {
+				statePages.AddPage(page, tview.NewTextView().SetText(page), true, page == mediaManageInitialPage)
+			}
+			statePages.SwitchToPage(tt.frontPage)
+
+			backCalled := false
+			initialCalled := false
+			systemsCalled := false
+
+			handleMediaManageEscape(
+				statePages,
+				func() { backCalled = true },
+				func() { initialCalled = true },
+				func() { systemsCalled = true },
+			)
+
+			assert.Equal(t, tt.wantBack, backCalled)
+			assert.Equal(t, tt.wantInitial, initialCalled)
+			assert.Equal(t, tt.wantSystems, systemsCalled)
+		})
+	}
+}
+
+func TestHandleMediaManageEscape_SystemsPagePreservesSelection(t *testing.T) {
+	t.Parallel()
+
+	statePages := tview.NewPages()
+	statePages.AddPage(mediaManageSetupPage, tview.NewTextView().SetText("setup"), true, false)
+	statePages.AddPage(mediaManageSystemsPage, tview.NewTextView().SetText("systems"), true, true)
+	selected := []string{"nes"}
+
+	handleMediaManageEscape(
+		statePages,
+		func() { selected = nil },
+		func() { selected = nil },
+		func() {
+			statePages.RemovePage(mediaManageSystemsPage)
+			statePages.SwitchToPage(mediaManageSetupPage)
+		},
+	)
+
+	frontPage, _ := statePages.GetFrontPage()
+	assert.Equal(t, mediaManageSetupPage, frontPage)
+	assert.Equal(t, []string{"nes"}, selected)
 }
 
 // intPtr is a helper to create *int.

--- a/pkg/ui/tui/generatedb_test.go
+++ b/pkg/ui/tui/generatedb_test.go
@@ -277,6 +277,58 @@ func TestFormatScrapeProgress(t *testing.T) {
 			},
 		}, "ScreenScraper"),
 	)
+	assert.Equal(t,
+		"screenscraper - arcade\nOverall: 2 / 5\nPaused\nMatched: 0  Skipped: 0",
+		formatScrapeProgress(&models.ScrapingStatusResponse{
+			ScraperID:   "screenscraper",
+			CurrentStep: &currentStep,
+			TotalSteps:  &totalSteps,
+			Paused:      true,
+			CurrentSystem: &models.ScrapeSystemProgressResponse{
+				SystemID:  "arcade",
+				Processed: 1,
+			},
+		}, ""),
+	)
+}
+
+func TestParseMediaManageUpdate(t *testing.T) {
+	t.Parallel()
+
+	currentStep := 3
+	indexing, err := parseMediaManageUpdate(
+		models.NotificationMediaIndexing,
+		`{"indexing":true,"paused":true,"currentStep":3,"totalSteps":10}`,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, models.NotificationMediaIndexing, indexing.method)
+	assert.True(t, indexing.indexing.Indexing)
+	assert.True(t, indexing.indexing.Paused)
+	assert.Equal(t, &currentStep, indexing.indexing.CurrentStep)
+
+	scraping, err := parseMediaManageUpdate(
+		models.NotificationMediaScraping,
+		`{"scraping":true,"scraperId":"screenscraper","currentSystem":{"systemId":"nes","processed":4,"total":9}}`,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, models.NotificationMediaScraping, scraping.method)
+	assert.True(t, scraping.scraping.Scraping)
+	assert.Equal(t, "screenscraper", scraping.scraping.ScraperID)
+	assert.Equal(t, "nes", scraping.scraping.CurrentSystem.SystemID)
+	assert.Equal(t, 4, scraping.scraping.CurrentSystem.Processed)
+}
+
+func TestParseMediaManageUpdateErrors(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseMediaManageUpdate(models.NotificationMediaIndexing, `{`)
+	assert.ErrorContains(t, err, "failed to unmarshal indexing status response")
+
+	_, err = parseMediaManageUpdate(models.NotificationMediaScraping, `{`)
+	assert.ErrorContains(t, err, "failed to unmarshal scraping status response")
+
+	_, err = parseMediaManageUpdate("media.unknown", `{}`)
+	assert.ErrorContains(t, err, "unexpected notification method")
 }
 
 func TestBlockedMediaOperationMenuLabels(t *testing.T) {

--- a/pkg/ui/tui/generatedb_test.go
+++ b/pkg/ui/tui/generatedb_test.go
@@ -349,12 +349,13 @@ func TestScrapeProgressHelpers(t *testing.T) {
 		},
 	}
 
-	assert.InDelta(t, 0.4, scrapeOverallProgress(status), 0.001)
-	assert.InDelta(t, 0.5, scrapeCurrentSystemProgress(status), 0.001)
-	assert.InDelta(t, 0.7, scrapeOverallProgress(models.ScrapingStatusResponse{
+	assert.InDelta(t, 0.4, scrapeOverallProgress(&status), 0.001)
+	assert.InDelta(t, 0.5, scrapeCurrentSystemProgress(&status), 0.001)
+	fallbackStatus := models.ScrapingStatusResponse{
 		Processed: 7,
 		Total:     10,
-	}), 0.001)
+	}
+	assert.InDelta(t, 0.7, scrapeOverallProgress(&fallbackStatus), 0.001)
 }
 
 func TestMediaIndexProgress(t *testing.T) {

--- a/pkg/ui/tui/generatedb_test.go
+++ b/pkg/ui/tui/generatedb_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewProgressBar(t *testing.T) {
@@ -300,7 +301,7 @@ func TestParseMediaManageUpdate(t *testing.T) {
 		models.NotificationMediaIndexing,
 		`{"indexing":true,"paused":true,"currentStep":3,"totalSteps":10}`,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, models.NotificationMediaIndexing, indexing.method)
 	assert.True(t, indexing.indexing.Indexing)
 	assert.True(t, indexing.indexing.Paused)
@@ -310,7 +311,7 @@ func TestParseMediaManageUpdate(t *testing.T) {
 		models.NotificationMediaScraping,
 		`{"scraping":true,"scraperId":"screenscraper","currentSystem":{"systemId":"nes","processed":4,"total":9}}`,
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, models.NotificationMediaScraping, scraping.method)
 	assert.True(t, scraping.scraping.Scraping)
 	assert.Equal(t, "screenscraper", scraping.scraping.ScraperID)
@@ -322,13 +323,13 @@ func TestParseMediaManageUpdateErrors(t *testing.T) {
 	t.Parallel()
 
 	_, err := parseMediaManageUpdate(models.NotificationMediaIndexing, `{`)
-	assert.ErrorContains(t, err, "failed to unmarshal indexing status response")
+	require.ErrorContains(t, err, "failed to unmarshal indexing status response")
 
 	_, err = parseMediaManageUpdate(models.NotificationMediaScraping, `{`)
-	assert.ErrorContains(t, err, "failed to unmarshal scraping status response")
+	require.ErrorContains(t, err, "failed to unmarshal scraping status response")
 
 	_, err = parseMediaManageUpdate("media.unknown", `{}`)
-	assert.ErrorContains(t, err, "unexpected notification method")
+	require.ErrorContains(t, err, "unexpected notification method")
 }
 
 func TestBlockedMediaOperationMenuLabels(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep scrape system selections when returning from the selector with Esc
- show Manage Media and scrape-start loading states immediately
- add overall/current-system scrape progress bars and simplify progress controls

Closes #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading screen and async initialization for "Manage Media".
  * Enhanced progress UI with overall and per-system progress (separate system progress bar) and clearer status text.

* **Bug Fixes**
  * Improved Escape key behavior and navigation during media operations.
  * Reworked progress controls and button behavior for pause/resume/cancel states.

* **Tests**
  * Added tests for progress formatting, progress helper logic, update parsing, and escape handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->