### PR TITLE
fix: refresh last scanned for duplicate runs

### DIFF
--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -103,8 +103,8 @@ func NewState(platform platforms.Platform, bootUUID string) (state *State, notif
 func (s *State) SetActiveCard(card tokens.Token) { //nolint:gocritic // single-use parameter in state setter
 	s.mu.Lock()
 
-	if helpers.TokensEqual(&s.activeToken, &card) {
-		// ignore duplicate scans
+	if helpers.TokensEqual(&s.activeToken, &card) && card.ScanTime.IsZero() {
+		// ignore duplicate removals
 		s.mu.Unlock()
 		return
 	}

--- a/pkg/service/state/state_test.go
+++ b/pkg/service/state/state_test.go
@@ -66,6 +66,49 @@ func TestStopService_DoesNotSetRestartRequested(t *testing.T) {
 	assert.False(t, state.RestartRequested())
 }
 
+func TestSetActiveCard_DuplicateTokenRefreshesLastScanned(t *testing.T) {
+	t.Parallel()
+	mockPlatform := mocks.NewMockPlatform()
+	state, _ := NewState(mockPlatform, "test-boot-uuid")
+
+	firstScan := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	secondScan := firstScan.Add(time.Minute)
+
+	state.SetActiveCard(tokens.Token{
+		UID:      "id",
+		Text:     "same-token",
+		ScanTime: firstScan,
+	})
+	state.SetActiveCard(tokens.Token{
+		UID:      "id",
+		Text:     "same-token",
+		ScanTime: secondScan,
+	})
+
+	lastScanned := state.GetLastScanned()
+	activeToken := state.GetActiveCard()
+	assert.Equal(t, secondScan, lastScanned.ScanTime)
+	assert.Equal(t, secondScan, activeToken.ScanTime)
+}
+
+func TestSetActiveCard_DuplicateEmptyRemovalDoesNotNotify(t *testing.T) {
+	t.Parallel()
+	mockPlatform := mocks.NewMockPlatform()
+	state, notifications := NewState(mockPlatform, "test-boot-uuid")
+
+	state.SetActiveCard(tokens.Token{})
+	state.SetActiveCard(tokens.Token{})
+
+	assert.True(t, state.GetActiveCard().ScanTime.IsZero())
+	assert.True(t, state.GetLastScanned().ScanTime.IsZero())
+
+	select {
+	case notification := <-notifications:
+		require.Failf(t, "unexpected notification", "method: %s", notification.Method)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestConsumePendingWrite(t *testing.T) {
 	t.Parallel()
 	mockPlatform := mocks.NewMockPlatform()

--- a/pkg/service/state/state_test.go
+++ b/pkg/service/state/state_test.go
@@ -102,10 +102,20 @@ func TestSetActiveCard_DuplicateEmptyRemovalDoesNotNotify(t *testing.T) {
 		ScanTime: time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC),
 	}
 	state.SetActiveCard(seedToken)
-	assert.Equal(t, models.NotificationTokensAdded, (<-notifications).Method)
+	select {
+	case notification := <-notifications:
+		assert.Equal(t, models.NotificationTokensAdded, notification.Method)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for tokens added notification")
+	}
 
 	state.SetActiveCard(tokens.Token{})
-	assert.Equal(t, models.NotificationTokensRemoved, (<-notifications).Method)
+	select {
+	case notification := <-notifications:
+		assert.Equal(t, models.NotificationTokensRemoved, notification.Method)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for tokens removed notification")
+	}
 	state.SetActiveCard(tokens.Token{})
 
 	assert.Equal(t, tokens.Token{}, state.GetActiveCard())

--- a/pkg/service/state/state_test.go
+++ b/pkg/service/state/state_test.go
@@ -96,11 +96,20 @@ func TestSetActiveCard_DuplicateEmptyRemovalDoesNotNotify(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	state, notifications := NewState(mockPlatform, "test-boot-uuid")
 
+	seedToken := tokens.Token{
+		UID:      "id",
+		Text:     "seed-token",
+		ScanTime: time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC),
+	}
+	state.SetActiveCard(seedToken)
+	assert.Equal(t, models.NotificationTokensAdded, (<-notifications).Method)
+
 	state.SetActiveCard(tokens.Token{})
+	assert.Equal(t, models.NotificationTokensRemoved, (<-notifications).Method)
 	state.SetActiveCard(tokens.Token{})
 
-	assert.True(t, state.GetActiveCard().ScanTime.IsZero())
-	assert.True(t, state.GetLastScanned().ScanTime.IsZero())
+	assert.Equal(t, tokens.Token{}, state.GetActiveCard())
+	assert.Equal(t, seedToken, state.GetLastScanned())
 
 	select {
 	case notification := <-notifications:


### PR DESCRIPTION
## Summary
- refresh active and last-scanned token state when same token is run again with a new scan time
- keep duplicate empty removals as no-ops to avoid repeated removal notifications
- add regression coverage for duplicate token refresh and duplicate empty removal behavior

Closes #846

Validated with `go test ./pkg/service/state/ ./pkg/api/methods/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated scans of the same card now update scan time and trigger notifications when the timestamp changes, instead of being ignored as duplicates.
  * Removing an empty/cleared card now emits a single removal notification (no duplicate notifications on repeated clears).

* **Tests**
  * Added tests validating scan-time refresh behavior and single-notification behavior for empty card removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->