### PR TITLE
fix(mister): scan NeoGeo romsets in subfolders

### DIFF
--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -351,10 +352,11 @@ func TestCollectNeoGeoRomsetEntries_DeduplicatesOverlappingRoots(t *testing.T) {
 		"mslug": "Metal Slug",
 	}
 	seen := make(map[string]struct{})
+	fs := afero.NewOsFs()
 
-	first, err := collectNeoGeoRomsetEntries(context.Background(), neoGeoPath, romsets, seen)
+	first, err := collectNeoGeoRomsetEntries(context.Background(), fs, neoGeoPath, romsets, seen)
 	require.NoError(t, err)
-	second, err := collectNeoGeoRomsetEntries(context.Background(), favoritesPath, romsets, seen)
+	second, err := collectNeoGeoRomsetEntries(context.Background(), fs, favoritesPath, romsets, seen)
 	require.NoError(t, err)
 
 	assert.Equal(t, []platforms.ScanResult{{Path: zipPath, Name: "Metal Slug", NoExt: true}}, first)

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -258,6 +258,18 @@ func findAmigaLauncher(t *testing.T, launchers []platforms.Launcher) *platforms.
 	return nil
 }
 
+func findNeoGeoLauncher(t *testing.T, launchers []platforms.Launcher) *platforms.Launcher {
+	t.Helper()
+
+	for i := range launchers {
+		if launchers[i].ID == "NeoGeo" {
+			return &launchers[i]
+		}
+	}
+	require.FailNow(t, "NeoGeo launcher should exist")
+	return nil
+}
+
 func writeAmigaVisionInstall(t *testing.T, path, game string) {
 	t.Helper()
 
@@ -276,6 +288,77 @@ func writeAmigaListings(t *testing.T, path, game string) {
 	require.NoError(t, err)
 	err = os.WriteFile(filepath.Join(listingPath, "games.txt"), []byte(game+"\n"), 0o600)
 	require.NoError(t, err)
+}
+
+func TestNeoGeoScanner_AddsNestedRomsetEntries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	favoritesPath := filepath.Join(neoGeoPath, "Favorites")
+	zipPath := filepath.Join(favoritesPath, "mslug.zip")
+	folderPath := filepath.Join(favoritesPath, "kof98")
+	nestedNeoPath := filepath.Join(favoritesPath, "collection", "game.neo")
+
+	require.NoError(t, os.MkdirAll(folderPath, 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Dir(nestedNeoPath), 0o700))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(folderPath, "crom0"), []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(nestedNeoPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(`<?xml version="1.0"?>
+<romsets>
+  <romset name="mslug" altname="Metal Slug"/>
+  <romset name="kof98" altname="King of Fighters '98"/>
+</romsets>
+`), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+	initial := []platforms.ScanResult{
+		{Path: filepath.Join(zipPath, "crom0")},
+		{Path: filepath.Join(folderPath, "crom0")},
+		{Path: nestedNeoPath},
+	}
+
+	results, err := neoGeoLauncher.Scanner(context.Background(), cfg, "NeoGeo", initial)
+	require.NoError(t, err)
+
+	assert.NotContains(t, results, platforms.ScanResult{Path: filepath.Join(zipPath, "crom0")})
+	assert.NotContains(t, results, platforms.ScanResult{Path: filepath.Join(folderPath, "crom0")})
+	assert.Contains(t, results, platforms.ScanResult{Path: nestedNeoPath})
+	assert.Contains(t, results, platforms.ScanResult{Path: zipPath, Name: "Metal Slug", NoExt: true})
+	assert.Contains(t, results, platforms.ScanResult{Path: folderPath, Name: "King of Fighters '98", NoExt: true})
+}
+
+func TestCollectNeoGeoRomsetEntries_DeduplicatesOverlappingRoots(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	favoritesPath := filepath.Join(neoGeoPath, "Favorites")
+	zipPath := filepath.Join(favoritesPath, "mslug.zip")
+	require.NoError(t, os.MkdirAll(favoritesPath, 0o700))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+
+	romsets := map[string]string{
+		"mslug": "Metal Slug",
+	}
+	seen := make(map[string]struct{})
+
+	first, err := collectNeoGeoRomsetEntries(context.Background(), neoGeoPath, romsets, seen)
+	require.NoError(t, err)
+	second, err := collectNeoGeoRomsetEntries(context.Background(), favoritesPath, romsets, seen)
+	require.NoError(t, err)
+
+	assert.Equal(t, []platforms.ScanResult{{Path: zipPath, Name: "Metal Slug", NoExt: true}}, first)
+	assert.Empty(t, second)
 }
 
 func TestFilterNeoGeoGameContents(t *testing.T) {
@@ -491,6 +574,27 @@ func TestFilterNeoGeoGameContents(t *testing.T) {
 		assert.Len(t, result, 2)
 	})
 
+	t.Run("filters nested extracted game folder contents", func(t *testing.T) {
+		t.Parallel()
+
+		romsets := map[string]string{
+			"mslug": "Metal Slug",
+		}
+
+		input := []platforms.ScanResult{
+			{Path: filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "mslug", "crom0")},
+			{Path: filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "collection", "game.neo")},
+		}
+
+		result := filterNeoGeoGameContents(input, romsets, defaultNeogeoPaths)
+
+		require.Len(t, result, 1)
+		assert.Equal(t,
+			filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "collection", "game.neo"),
+			result[0].Path,
+		)
+	})
+
 	t.Run("handles multiple NEOGEO paths", func(t *testing.T) {
 		t.Parallel()
 
@@ -590,6 +694,22 @@ func TestIsInsideGameFolder(t *testing.T) {
 
 		result := isInsideGameFolder("/media/fat/neogeo/collection/game.neo", romsets, neogeoPaths)
 		assert.False(t, result)
+	})
+
+	t.Run("returns true for path inside nested game folder", func(t *testing.T) {
+		t.Parallel()
+
+		romsets := map[string]string{
+			"mslug": "Metal Slug",
+		}
+		neogeoPaths := []string{filepath.Join(string(filepath.Separator), "media", "fat", "neogeo")}
+
+		result := isInsideGameFolder(
+			filepath.Join(string(filepath.Separator), "media", "fat", "neogeo", "favorites", "mslug", "crom0"),
+			romsets,
+			neogeoPaths,
+		)
+		assert.True(t, result)
 	})
 
 	t.Run("returns false for path not under NEOGEO", func(t *testing.T) {

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -581,18 +581,21 @@ func TestFilterNeoGeoGameContents(t *testing.T) {
 			"mslug": "Metal Slug",
 		}
 
+		nestedRomPath := filepath.Join(
+			string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "mslug", "crom0",
+		)
+		nestedNeoPath := filepath.Join(
+			string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "collection", "game.neo",
+		)
 		input := []platforms.ScanResult{
-			{Path: filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "mslug", "crom0")},
-			{Path: filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "collection", "game.neo")},
+			{Path: nestedRomPath},
+			{Path: nestedNeoPath},
 		}
 
 		result := filterNeoGeoGameContents(input, romsets, defaultNeogeoPaths)
 
 		require.Len(t, result, 1)
-		assert.Equal(t,
-			filepath.Join(string(filepath.Separator), "media", "fat", "NEOGEO", "favorites", "collection", "game.neo"),
-			result[0].Path,
-		)
+		assert.Equal(t, nestedNeoPath, result[0].Path)
 	})
 
 	t.Run("handles multiple NEOGEO paths", func(t *testing.T) {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -872,7 +872,7 @@ func collectNeoGeoRomsetEntries(
 		return nil
 	})
 	if err != nil {
-		return results, err
+		return results, fmt.Errorf("failed to walk neogeo romsets: %w", err)
 	}
 
 	return results, nil

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,6 +48,7 @@ import (
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 // arcadeCardLaunchCache stores the last arcade game launched via card to prevent duplicate tracker notifications.
@@ -801,6 +801,7 @@ func isInsideGameFolder(
 
 func collectNeoGeoRomsetEntries(
 	ctx context.Context,
+	fs afero.Fs,
 	root string,
 	romsetNames map[string]string,
 	seen map[string]struct{},
@@ -808,7 +809,7 @@ func collectNeoGeoRomsetEntries(
 	results := make([]platforms.ScanResult, 0)
 	cleanRoot := filepath.Clean(root)
 
-	err := filepath.WalkDir(cleanRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	err := afero.Walk(fs, cleanRoot, func(path string, info os.FileInfo, walkErr error) error {
 		if walkErr != nil {
 			log.Warn().Err(walkErr).Str("path", path).Msg("unable to read neogeo entry")
 			return nil
@@ -824,14 +825,14 @@ func collectNeoGeoRomsetEntries(
 			return nil
 		}
 
-		base := d.Name()
-		if d.IsDir() {
+		base := info.Name()
+		if info.IsDir() {
 			if base == "__MACOSX" || strings.HasPrefix(base, ".") {
 				return filepath.SkipDir
 			}
 
 			markerPath := filepath.Join(path, ".zaparooignore")
-			if _, statErr := os.Stat(markerPath); statErr == nil {
+			if _, statErr := fs.Stat(markerPath); statErr == nil {
 				log.Info().Str("path", path).Msg("skipping directory with .zaparooignore marker")
 				return filepath.SkipDir
 			}
@@ -842,7 +843,7 @@ func collectNeoGeoRomsetEntries(
 		isZip := filepath.Ext(lowerBase) == ".zip"
 		if isZip {
 			candidateID = strings.TrimSuffix(lowerBase, filepath.Ext(lowerBase))
-		} else if !d.IsDir() {
+		} else if !info.IsDir() {
 			return nil
 		}
 
@@ -853,7 +854,7 @@ func collectNeoGeoRomsetEntries(
 
 		cleanPath := filepath.Clean(path)
 		if _, ok := seen[cleanPath]; ok {
-			if d.IsDir() {
+			if info.IsDir() {
 				return filepath.SkipDir
 			}
 			return nil
@@ -866,7 +867,7 @@ func collectNeoGeoRomsetEntries(
 			NoExt: true,
 		})
 
-		if d.IsDir() {
+		if info.IsDir() {
 			return filepath.SkipDir
 		}
 		return nil
@@ -1184,23 +1185,28 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			}
 
 			// Second pass: read directories recursively and add launchable romset entries.
-			seenNeoGeoEntries := make(map[string]struct{})
-			for _, sf := range sfs {
-				select {
-				case <-ctx.Done():
-					return results, ctx.Err()
-				default:
-				}
-
-				entries, scanErr := collectNeoGeoRomsetEntries(ctx, sf.Path, names, seenNeoGeoEntries)
-				if scanErr != nil {
-					if ctx.Err() != nil {
+			if len(names) == 0 {
+				log.Debug().Msg("skipping neogeo recursive scan without romsets")
+			} else {
+				osFs := afero.NewOsFs()
+				seenNeoGeoEntries := make(map[string]struct{})
+				for _, sf := range sfs {
+					select {
+					case <-ctx.Done():
 						return results, ctx.Err()
+					default:
 					}
-					log.Warn().Err(scanErr).Str("path", sf.Path).Msg("unable to scan neogeo directory")
-					continue
+
+					entries, scanErr := collectNeoGeoRomsetEntries(ctx, osFs, sf.Path, names, seenNeoGeoEntries)
+					if scanErr != nil {
+						if ctx.Err() != nil {
+							return results, ctx.Err()
+						}
+						log.Warn().Err(scanErr).Str("path", sf.Path).Msg("unable to scan neogeo directory")
+						continue
+					}
+					results = append(results, entries...)
 				}
-				results = append(results, entries...)
 			}
 
 			log.Debug().Int("results", len(results)).Msg("neogeo scan completed")

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -741,18 +742,24 @@ func readRomsets(filePath string) ([]Romset, error) {
 	return romsets.Romsets, nil
 }
 
-// isInsideGameFolder checks if a path is a file inside a game folder.
-// A game folder is an immediate child directory of a NEOGEO path that matches romsets.xml.
+// isInsideGameFolder checks if a path is a file inside an extracted game folder.
+// A game folder is any directory under a NEOGEO path that matches romsets.xml.
 //
 // Example: /media/fat/games/NEOGEO/ct2k3sa/crom0
 //   - NEOGEO path: /media/fat/games/NEOGEO
-//   - First child: ct2k3sa (matches romsets -> game folder)
+//   - Directory segment: ct2k3sa (matches romsets -> game folder)
+//   - File inside: crom0
+//   - Returns true
+//
+// Example: /media/fat/games/NEOGEO/favorites/ct2k3sa/crom0
+//   - NEOGEO path: /media/fat/games/NEOGEO
+//   - Directory segment: ct2k3sa (matches romsets -> game folder)
 //   - File inside: crom0
 //   - Returns true
 //
 // Example: /media/fat/games/NEOGEO/collection/game.neo
 //   - NEOGEO path: /media/fat/games/NEOGEO
-//   - First child: collection (not in romsets -> not a game folder)
+//   - Directory segment: collection (not in romsets -> not a game folder)
 //   - Returns false
 func isInsideGameFolder(
 	lowerPath string,
@@ -782,14 +789,93 @@ func isInsideGameFolder(
 			continue // Not deep enough to be inside a folder
 		}
 
-		// First component is the potential game folder name
-		firstDir := parts[0]
-
-		if _, isGame := romsetNames[firstDir]; isGame {
-			return true
+		// Any directory segment before the file can be the game folder.
+		for _, dir := range parts[:len(parts)-1] {
+			if _, isGame := romsetNames[dir]; isGame {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func collectNeoGeoRomsetEntries(
+	ctx context.Context,
+	root string,
+	romsetNames map[string]string,
+	seen map[string]struct{},
+) ([]platforms.ScanResult, error) {
+	results := make([]platforms.ScanResult, 0)
+	cleanRoot := filepath.Clean(root)
+
+	err := filepath.WalkDir(cleanRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			log.Warn().Err(walkErr).Str("path", path).Msg("unable to read neogeo entry")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if path == cleanRoot {
+			return nil
+		}
+
+		base := d.Name()
+		if d.IsDir() {
+			if base == "__MACOSX" || strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+
+			markerPath := filepath.Join(path, ".zaparooignore")
+			if _, statErr := os.Stat(markerPath); statErr == nil {
+				log.Info().Str("path", path).Msg("skipping directory with .zaparooignore marker")
+				return filepath.SkipDir
+			}
+		}
+
+		lowerBase := strings.ToLower(base)
+		candidateID := lowerBase
+		isZip := filepath.Ext(lowerBase) == ".zip"
+		if isZip {
+			candidateID = strings.TrimSuffix(lowerBase, filepath.Ext(lowerBase))
+		} else if !d.IsDir() {
+			return nil
+		}
+
+		altName, ok := romsetNames[candidateID]
+		if !ok {
+			return nil
+		}
+
+		cleanPath := filepath.Clean(path)
+		if _, ok := seen[cleanPath]; ok {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		seen[cleanPath] = struct{}{}
+
+		results = append(results, platforms.ScanResult{
+			Path:  cleanPath,
+			Name:  altName,
+			NoExt: true,
+		})
+
+		if d.IsDir() {
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return results, err
+	}
+
+	return results, nil
 }
 
 // filterNeoGeoGameContents filters out scan results that are inside games
@@ -1097,7 +1183,8 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				results = filterNeoGeoGameContents(results, names, neogeoPaths)
 			}
 
-			// Second pass: read directories and add games
+			// Second pass: read directories recursively and add launchable romset entries.
+			seenNeoGeoEntries := make(map[string]struct{})
 			for _, sf := range sfs {
 				select {
 				case <-ctx.Done():
@@ -1105,35 +1192,15 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				default:
 				}
 
-				// read directory
-				dir, err := os.Open(sf.Path)
-				if err != nil {
-					log.Warn().Err(err).Msg("unable to open neogeo directory")
+				entries, scanErr := collectNeoGeoRomsetEntries(ctx, sf.Path, names, seenNeoGeoEntries)
+				if scanErr != nil {
+					if ctx.Err() != nil {
+						return results, ctx.Err()
+					}
+					log.Warn().Err(scanErr).Str("path", sf.Path).Msg("unable to scan neogeo directory")
 					continue
 				}
-
-				files, err := dir.Readdirnames(-1)
-				_ = dir.Close()
-
-				if err != nil {
-					log.Warn().Err(err).Msg("unable to read neogeo directory")
-					continue
-				}
-
-				for _, f := range files {
-					id := f
-					if filepath.Ext(strings.ToLower(f)) == ".zip" {
-						id = strings.TrimSuffix(f, filepath.Ext(f))
-					}
-
-					if altName, ok := names[strings.ToLower(id)]; ok {
-						results = append(results, platforms.ScanResult{
-							Path:  filepath.Join(sf.Path, f),
-							Name:  altName,
-							NoExt: true,
-						})
-					}
-				}
+				results = append(results, entries...)
 			}
 
 			log.Debug().Int("results", len(results)).Msg("neogeo scan completed")


### PR DESCRIPTION
## Summary
- recursively collect NeoGeo romset zip files and extracted romset folders under NEOGEO roots
- filter nested extracted romset internals while keeping non-romset .neo files
- add regressions for nested romsets and overlapping-root dedupe

Closes #853

## Validation
- go test ./pkg/platforms/mister/
- go test ./pkg/database/mediascanner/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for NeoGeo detection: ROMset-derived entry expansion and deduplication across overlapping directories.

* **Improvements**
  * Improved NeoGeo indexing to detect games in nested folders and eliminate duplicate entries, reducing redundant results and improving launcher accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->