### PR TITLE
fix(database): canonicalize scraped tag values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ZaparooProject/zaparoo-core/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	fyne.io/systray v1.12.1

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -205,9 +205,10 @@ type MediaBlob struct {
 }
 
 type Tag struct {
-	Tag      string
-	DBID     int64
-	TypeDBID int64
+	Tag         string
+	DisplayName string
+	DBID        int64
+	TypeDBID    int64
 }
 
 type MediaTag struct {
@@ -230,6 +231,7 @@ type SearchResult struct {
 type TagInfo struct {
 	Tag   string `json:"tag"`
 	Type  string `json:"type"`
+	Label string `json:"label,omitempty"`
 	Count int64  `json:"count,omitempty"`
 }
 

--- a/pkg/database/filters/parser.go
+++ b/pkg/database/filters/parser.go
@@ -90,9 +90,9 @@ func ParseTagFilters(tagSlice []string) ([]zapscript.TagFilter, error) {
 		tagType := strings.TrimSpace(parts[0])
 		tagValue := strings.TrimSpace(parts[1])
 
-		// Apply full normalization FIRST
+		// Apply type-aware normalization FIRST.
 		normalizedType := tags.NormalizeTag(tagType)
-		normalizedValue := tags.NormalizeTag(tagValue)
+		normalizedValue := tags.NormalizeTagValue(normalizedType, tagValue)
 
 		// Validate AFTER normalization to catch cases where normalization strips everything
 		if normalizedType == "" || normalizedValue == "" {

--- a/pkg/database/filters/parser_test.go
+++ b/pkg/database/filters/parser_test.go
@@ -196,6 +196,13 @@ func TestParseTagFilters_Normalization(t *testing.T) {
 				{Type: "unfinished", Value: "demo", Operator: zapscript.TagOperatorNOT},
 			},
 		},
+		{
+			name:  "Company value uses slug pipeline",
+			input: []string{"developer:Nintendo R&D1"},
+			expected: []zapscript.TagFilter{
+				{Type: "developer", Value: "nintendo-r-and-d1", Operator: zapscript.TagOperatorAND},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/database/mediadb/migrations/20260601120000_tag_display_names.sql
+++ b/pkg/database/mediadb/migrations/20260601120000_tag_display_names.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE Tags ADD COLUMN DisplayName text NOT NULL DEFAULT '';
+
+-- +goose Down
+
+ALTER TABLE Tags DROP COLUMN DisplayName;

--- a/pkg/database/mediadb/slug_cache.go
+++ b/pkg/database/mediadb/slug_cache.go
@@ -229,13 +229,13 @@ func (db *MediaDB) GetMediaByDBID(ctx context.Context, mediaDBID int64) (databas
 
 	// Fetch tags from both MediaTags (file-level) and MediaTitleTags (title-level)
 	rows, err := db.conn().QueryContext(ctx, `
-		SELECT Tags.Tag, TagTypes.Type
+		SELECT Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTags
 		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
 		WHERE MediaTags.MediaDBID = ?
 		UNION
-		SELECT Tags.Tag, TagTypes.Type
+		SELECT Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM Media
 		JOIN MediaTitleTags ON MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
 		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
@@ -255,7 +255,7 @@ func (db *MediaDB) GetMediaByDBID(ctx context.Context, mediaDBID int64) (databas
 	result.Tags = make([]database.TagInfo, 0)
 	for rows.Next() {
 		var tag database.TagInfo
-		if scanErr := rows.Scan(&tag.Tag, &tag.Type); scanErr != nil {
+		if scanErr := rows.Scan(&tag.Tag, &tag.Type, &tag.Label); scanErr != nil {
 			return result, fmt.Errorf("failed to scan tag: %w", scanErr)
 		}
 		tag.Tag = tags.UnpadTagValue(tag.Tag)

--- a/pkg/database/mediadb/sql_cache.go
+++ b/pkg/database/mediadb/sql_cache.go
@@ -240,13 +240,14 @@ func sqlGetSystemTagsCached(
 
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
 	sqlQuery := `
-		SELECT TagType, Tag, SUM(Count) AS Count
-		FROM SystemTagsCache
-		WHERE SystemDBID IN (` +
+		SELECT stc.TagType, stc.Tag, t.DisplayName, SUM(stc.Count) AS Count
+		FROM SystemTagsCache stc
+		JOIN Tags t ON stc.TagDBID = t.DBID
+		WHERE stc.SystemDBID IN (` +
 		prepareVariadic("?", ",", len(args)) +
 		`)
-		GROUP BY TagType, Tag
-		ORDER BY TagType, Tag`
+		GROUP BY stc.TagType, stc.Tag, t.DisplayName
+		ORDER BY stc.TagType, stc.Tag`
 
 	stmt, err := db.PrepareContext(ctx, sqlQuery)
 	if err != nil {
@@ -270,14 +271,15 @@ func sqlGetSystemTagsCached(
 
 	result := make([]database.TagInfo, 0, 100)
 	for rows.Next() {
-		var tagType, tag string
+		var tagType, tag, label string
 		var count int64
-		if scanErr := rows.Scan(&tagType, &tag, &count); scanErr != nil {
+		if scanErr := rows.Scan(&tagType, &tag, &label, &count); scanErr != nil {
 			return nil, fmt.Errorf("failed to scan cached tag result: %w", scanErr)
 		}
 		result = append(result, database.TagInfo{
 			Type:  tagType,
 			Tag:   tags.UnpadTagValue(tag),
+			Label: label,
 			Count: count,
 		})
 	}

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -647,10 +647,13 @@ func (c *scrapeWriteTxContext) resolveTagType(
 }
 
 func (c *scrapeWriteTxContext) resolveTag(
-	ctx context.Context, typeDBID int64, typeName, tagValue string,
+	ctx context.Context, typeDBID int64, typeName, tagValue, displayName string,
 ) (int64, error) {
 	key := tagCacheKey{typeDBID: typeDBID, tag: tagValue}
 	if cached, ok := c.tags[key]; ok {
+		if err := c.setTagDisplayName(ctx, cached, displayName); err != nil {
+			return 0, err
+		}
 		return cached, nil
 	}
 
@@ -661,8 +664,8 @@ func (c *scrapeWriteTxContext) resolveTag(
 	).Scan(&tagDBID)
 	if errors.Is(err, sql.ErrNoRows) {
 		if _, insertErr := c.tx.ExecContext(ctx,
-			`INSERT OR IGNORE INTO Tags (TypeDBID, Tag) VALUES (?, ?)`,
-			typeDBID, tagValue,
+			`INSERT OR IGNORE INTO Tags (TypeDBID, Tag, DisplayName) VALUES (?, ?, ?)`,
+			typeDBID, tagValue, displayName,
 		); insertErr != nil {
 			return 0, fmt.Errorf("failed to insert tag %q:%q: %w", typeName, tagValue, insertErr)
 		}
@@ -676,8 +679,23 @@ func (c *scrapeWriteTxContext) resolveTag(
 		return 0, fmt.Errorf("failed to look up tag DBID for %q:%q: %w", typeName, tagValue, err)
 	}
 
+	if err := c.setTagDisplayName(ctx, tagDBID, displayName); err != nil {
+		return 0, err
+	}
 	c.tags[key] = tagDBID
 	return tagDBID, nil
+}
+
+func (c *scrapeWriteTxContext) setTagDisplayName(ctx context.Context, tagDBID int64, displayName string) error {
+	if displayName == "" {
+		return nil
+	}
+	if _, err := c.tx.ExecContext(ctx,
+		`UPDATE Tags SET DisplayName = ? WHERE DBID = ? AND DisplayName = ''`, displayName, tagDBID,
+	); err != nil {
+		return fmt.Errorf("failed to update tag display name: %w", err)
+	}
+	return nil
 }
 
 func (c *scrapeWriteTxContext) resolvePropertyTypeTag(ctx context.Context, typeTag string) (int64, error) {
@@ -866,7 +884,7 @@ func preloadTagsByType(
 				continue
 			}
 			if _, err := writeCtx.tx.ExecContext(ctx,
-				`INSERT OR IGNORE INTO Tags (TypeDBID, Tag) VALUES (?, ?)`, typeDBID, value,
+				`INSERT OR IGNORE INTO Tags (TypeDBID, Tag, DisplayName) VALUES (?, ?, '')`, typeDBID, value,
 			); err != nil {
 				return fmt.Errorf("failed to insert tag %q: %w", value, err)
 			}
@@ -1141,7 +1159,7 @@ func upsertTagsWithContext(
 
 		for _, ti := range e.tags {
 			tagValue := tags.PadTagValue(ti.Tag)
-			tagDBID, err := writeCtx.resolveTag(ctx, e.dbid, typeName, tagValue)
+			tagDBID, err := writeCtx.resolveTag(ctx, e.dbid, typeName, tagValue, ti.Label)
 			if err != nil {
 				return err
 			}
@@ -1494,7 +1512,7 @@ func upsertMediaTitleTagsBulkWithContext(
 			resolved := make([]int64, 0, len(tagInfos))
 			for _, ti := range tagInfos {
 				tagValue := tags.PadTagValue(ti.Tag)
-				tagDBID, err := writeCtx.resolveTag(ctx, typeDBID, typeName, tagValue)
+				tagDBID, err := writeCtx.resolveTag(ctx, typeDBID, typeName, tagValue, ti.Label)
 				if err != nil {
 					return err
 				}
@@ -1662,7 +1680,9 @@ func upsertScrapeSentinelsBulkWithContext(
 			}
 			exclusiveDeletes[typeDBID][target.MediaDBID] = struct{}{}
 		}
-		tagDBID, err := writeCtx.resolveTag(ctx, typeDBID, sentinel.Type, tags.PadTagValue(sentinel.Tag))
+		tagDBID, err := writeCtx.resolveTag(
+			ctx, typeDBID, sentinel.Type, tags.PadTagValue(sentinel.Tag), sentinel.Label,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -570,8 +570,8 @@ func TestApplyScrapeResult_WritesSentinelLastPayload(t *testing.T) {
 
 	err := mediaDB.ApplyScrapeResult(ctx, 1, 1, &database.ScrapeWrite{
 		Sentinel:  database.TagInfo{Type: "scraper.test", Tag: "scraped"},
-		MediaTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
-		TitleTags: []database.TagInfo{{Type: "developer", Tag: "nintendo"}},
+		MediaTags: []database.TagInfo{{Type: "developer", Tag: "nintendo", Label: "Nintendo"}},
+		TitleTags: []database.TagInfo{{Type: "publisher", Tag: "nintendo", Label: "Nintendo"}},
 		TitleProps: []database.MediaProperty{{
 			TypeTag: "property:description",
 			Text:    "A classic",
@@ -597,6 +597,11 @@ func TestApplyScrapeResult_WritesSentinelLastPayload(t *testing.T) {
 		}
 		return false
 	})
+
+	usedTags, err := mediaDB.GetAllUsedTags(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, usedTags, database.TagInfo{Type: "developer", Tag: "nintendo", Label: "Nintendo", Count: 1})
+	assert.Contains(t, usedTags, database.TagInfo{Type: "publisher", Tag: "nintendo", Label: "Nintendo", Count: 1})
 
 	mediaProps, err := mediaDB.GetMediaProperties(ctx, 1)
 	require.NoError(t, err)

--- a/pkg/database/mediadb/sql_tags.go
+++ b/pkg/database/mediadb/sql_tags.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	insertTagSQL     = `INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES (?, ?, ?)`
+	insertTagSQL     = `INSERT INTO Tags (DBID, TypeDBID, Tag, DisplayName) VALUES (?, ?, ?, ?)`
 	insertTagTypeSQL = `INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES (?, ?, ?)`
 )
 
@@ -132,7 +132,7 @@ func sqlFindTag(ctx context.Context, db sqlQueryable, tagType database.Tag) (dat
 	paddedTag := tags.PadTagValue(tagType.Tag)
 	stmt, err := db.PrepareContext(ctx, `
 		select
-		DBID, TypeDBID, Tag
+		DBID, TypeDBID, Tag, DisplayName
 		from Tags
 		where (DBID = ? and TypeDBID = ?)
 		or (TypeDBID = ? and (Tag = ? or Tag = ?))
@@ -156,6 +156,7 @@ func sqlFindTag(ctx context.Context, db sqlQueryable, tagType database.Tag) (dat
 		&row.DBID,
 		&row.TypeDBID,
 		&row.Tag,
+		&row.DisplayName,
 	)
 	if err != nil {
 		return row, fmt.Errorf("failed to scan tag row: %w", err)
@@ -171,7 +172,7 @@ func sqlInsertTagWithPreparedStmt(ctx context.Context, stmt *sql.Stmt, row datab
 	}
 
 	paddedTag := tags.PadTagValue(row.Tag)
-	res, err := stmt.ExecContext(ctx, dbID, row.TypeDBID, paddedTag)
+	res, err := stmt.ExecContext(ctx, dbID, row.TypeDBID, paddedTag, row.DisplayName)
 	if err != nil {
 		return row, fmt.Errorf("failed to execute prepared insert tag statement: %w", err)
 	}
@@ -202,7 +203,7 @@ func sqlInsertTag(ctx context.Context, db *sql.DB, row database.Tag) (database.T
 	}()
 
 	paddedTag := tags.PadTagValue(row.Tag)
-	res, err := stmt.ExecContext(ctx, dbID, row.TypeDBID, paddedTag)
+	res, err := stmt.ExecContext(ctx, dbID, row.TypeDBID, paddedTag, row.DisplayName)
 	if err != nil {
 		return row, fmt.Errorf("failed to execute insert tag statement: %w", err)
 	}
@@ -217,7 +218,7 @@ func sqlInsertTag(ctx context.Context, db *sql.DB, row database.Tag) (database.T
 }
 
 func sqlGetAllTags(ctx context.Context, db *sql.DB) ([]database.Tag, error) {
-	rows, err := db.QueryContext(ctx, "SELECT DBID, Tag, TypeDBID FROM Tags ORDER BY DBID")
+	rows, err := db.QueryContext(ctx, "SELECT DBID, Tag, TypeDBID, DisplayName FROM Tags ORDER BY DBID")
 	if err != nil {
 		return nil, fmt.Errorf("failed to query tags: %w", err)
 	}
@@ -230,7 +231,7 @@ func sqlGetAllTags(ctx context.Context, db *sql.DB) ([]database.Tag, error) {
 	dbTags := make([]database.Tag, 0)
 	for rows.Next() {
 		var tag database.Tag
-		if err := rows.Scan(&tag.DBID, &tag.Tag, &tag.TypeDBID); err != nil {
+		if err := rows.Scan(&tag.DBID, &tag.Tag, &tag.TypeDBID, &tag.DisplayName); err != nil {
 			return nil, fmt.Errorf("failed to scan tag: %w", err)
 		}
 		tag.Tag = tags.UnpadTagValue(tag.Tag)
@@ -268,7 +269,7 @@ func sqlGetAllUsedTags(ctx context.Context, db *sql.DB) ([]database.TagInfo, err
 	// (MediaTitleTags) sources; the outer GROUP BY+SUM merges them per tag.
 	// mediatags_tag_media_idx and mediatitletags_tag_idx make both GROUP BYs fast.
 	sqlQuery := `
-		SELECT tt.Type, t.Tag, SUM(cnt) AS Count
+		SELECT tt.Type, t.Tag, t.DisplayName, SUM(cnt) AS Count
 		FROM (
 			SELECT TagDBID, COUNT(*) AS cnt FROM MediaTags GROUP BY TagDBID
 			UNION ALL
@@ -276,7 +277,7 @@ func sqlGetAllUsedTags(ctx context.Context, db *sql.DB) ([]database.TagInfo, err
 		) agg
 		JOIN Tags t ON agg.TagDBID = t.DBID
 		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-		GROUP BY t.DBID, tt.Type, t.Tag
+		GROUP BY t.DBID, tt.Type, t.Tag, t.DisplayName
 		ORDER BY tt.Type, t.Tag`
 
 	stmt, err := db.PrepareContext(ctx, sqlQuery)
@@ -301,14 +302,15 @@ func sqlGetAllUsedTags(ctx context.Context, db *sql.DB) ([]database.TagInfo, err
 
 	result := make([]database.TagInfo, 0, 100)
 	for rows.Next() {
-		var tagType, tag string
+		var tagType, tag, label string
 		var count int64
-		if scanErr := rows.Scan(&tagType, &tag, &count); scanErr != nil {
+		if scanErr := rows.Scan(&tagType, &tag, &label, &count); scanErr != nil {
 			return nil, fmt.Errorf("failed to scan all used tag result: %w", scanErr)
 		}
 		result = append(result, database.TagInfo{
 			Type:  tagType,
 			Tag:   tags.UnpadTagValue(tag),
+			Label: label,
 			Count: count,
 		})
 	}
@@ -342,7 +344,7 @@ func sqlGetTags(
 
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
 	sqlQuery := `
-		SELECT DISTINCT TagTypes.Type, Tags.Tag
+		SELECT DISTINCT TagTypes.Type, Tags.Tag, Tags.DisplayName
 		FROM TagTypes
 		JOIN Tags ON TagTypes.DBID = Tags.TypeDBID
 		WHERE Tags.DBID IN (
@@ -384,13 +386,14 @@ func sqlGetTags(
 
 	result := make([]database.TagInfo, 0, 100)
 	for rows.Next() {
-		var tagType, tag string
-		if scanErr := rows.Scan(&tagType, &tag); scanErr != nil {
+		var tagType, tag, label string
+		if scanErr := rows.Scan(&tagType, &tag, &label); scanErr != nil {
 			return nil, fmt.Errorf("failed to scan optimized tag result: %w", scanErr)
 		}
 		result = append(result, database.TagInfo{
-			Type: tagType,
-			Tag:  tags.UnpadTagValue(tag),
+			Type:  tagType,
+			Tag:   tags.UnpadTagValue(tag),
+			Label: label,
 		})
 	}
 

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -136,8 +136,8 @@ func TestSqlFindTag_ScopesByTypeDBID(t *testing.T) {
 		Tag:      "2",
 	}
 
-	rows := sqlmock.NewRows([]string{"DBID", "TypeDBID", "Tag"}).
-		AddRow(10, 2, "0002")
+	rows := sqlmock.NewRows([]string{"DBID", "TypeDBID", "Tag", "DisplayName"}).
+		AddRow(10, 2, "0002", "")
 
 	mock.ExpectPrepare(`select.*from Tags.*where.*TypeDBID.*LIMIT 1;`).
 		ExpectQuery().
@@ -615,10 +615,10 @@ func TestSqlGetTags(t *testing.T) {
 	mock.ExpectPrepare("SELECT DISTINCT TagTypes.Type, Tags.Tag.*FROM TagTypes.*JOIN.*ORDER BY").
 		ExpectQuery().
 		WithArgs("NES", "SNES", "NES", "SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag"}).
-			AddRow("genre", "Action").
-			AddRow("genre", "Adventure").
-			AddRow("year", "1990"))
+		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag", "DisplayName"}).
+			AddRow("genre", "Action", "").
+			AddRow("genre", "Adventure", "").
+			AddRow("year", "1990", ""))
 
 	results, err := sqlGetTags(context.Background(), db, systems)
 
@@ -643,12 +643,12 @@ func TestSqlGetAllUsedTags_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, SUM\(cnt\) AS Count`).
+	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, t\.DisplayName, SUM\(cnt\) AS Count`).
 		ExpectQuery().
-		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag", "Count"}).
-			AddRow("genre", "Action", int64(7)).
-			AddRow("genre", "RPG", int64(3)).
-			AddRow("year", "1990", int64(12)))
+		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag", "DisplayName", "Count"}).
+			AddRow("genre", "Action", "", int64(7)).
+			AddRow("genre", "RPG", "", int64(3)).
+			AddRow("year", "1990", "", int64(12)))
 
 	results, err := sqlGetAllUsedTags(context.Background(), db)
 
@@ -668,9 +668,9 @@ func TestSqlGetAllUsedTags_ScanError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, SUM\(cnt\) AS Count`).
+	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, t\.DisplayName, SUM\(cnt\) AS Count`).
 		ExpectQuery().
-		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag"}). // missing Count column
+		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag"}). // missing DisplayName and Count columns
 										AddRow("genre", "Action"))
 
 	_, err = sqlGetAllUsedTags(context.Background(), db)
@@ -685,9 +685,9 @@ func TestSqlGetAllUsedTags_Empty(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, SUM\(cnt\) AS Count`).
+	mock.ExpectPrepare(`SELECT tt\.Type, t\.Tag, t\.DisplayName, SUM\(cnt\) AS Count`).
 		ExpectQuery().
-		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag", "Count"}))
+		WillReturnRows(sqlmock.NewRows([]string{"Type", "Tag", "DisplayName", "Count"}))
 
 	results, err := sqlGetAllUsedTags(context.Background(), db)
 	require.NoError(t, err)
@@ -752,12 +752,14 @@ func TestSqlGetSystemTagsCached_Success(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(2))
 
 	// Mock main query
-	mock.ExpectPrepare(`SELECT TagType, Tag, SUM\(Count\) AS Count FROM SystemTagsCache WHERE SystemDBID IN.*`).
+	mock.ExpectPrepare(
+		`SELECT stc\.TagType, stc\.Tag, t\.DisplayName, SUM\(stc\.Count\) AS Count.*FROM SystemTagsCache stc.*`,
+	).
 		ExpectQuery().WithArgs(1, 2).
-		WillReturnRows(sqlmock.NewRows([]string{"TagType", "Tag", "Count"}).
-			AddRow("genre", "Action", int64(12)).
-			AddRow("genre", "Adventure", int64(4)).
-			AddRow("year", "1990", int64(7)))
+		WillReturnRows(sqlmock.NewRows([]string{"TagType", "Tag", "DisplayName", "Count"}).
+			AddRow("genre", "Action", "", int64(12)).
+			AddRow("genre", "Adventure", "", int64(4)).
+			AddRow("year", "1990", "", int64(7)))
 
 	results, err := sqlGetSystemTagsCached(context.Background(), db, systems)
 

--- a/pkg/database/mediadb/tag_cache.go
+++ b/pkg/database/mediadb/tag_cache.go
@@ -55,6 +55,7 @@ func (c *tagCache) tagsForSystems(systems []systemdefs.System) []database.TagInf
 	}
 
 	counts := make(map[tagKey]int64)
+	labels := make(map[tagKey]string)
 	order := make([]tagKey, 0)
 	for _, sys := range systems {
 		for _, tag := range c.bySystem[sys.ID] {
@@ -62,13 +63,18 @@ func (c *tagCache) tagsForSystems(systems []systemdefs.System) []database.TagInf
 			if _, exists := counts[k]; !exists {
 				order = append(order, k)
 			}
+			if labels[k] == "" {
+				labels[k] = tag.Label
+			}
 			counts[k] += tag.Count
 		}
 	}
 
 	result := make([]database.TagInfo, 0, len(order))
 	for _, k := range order {
-		result = append(result, database.TagInfo{Type: k.typ, Tag: k.tag, Count: counts[k]})
+		result = append(result, database.TagInfo{
+			Type: k.typ, Tag: k.tag, Label: labels[k], Count: counts[k],
+		})
 	}
 	return result
 }
@@ -78,9 +84,10 @@ func (c *tagCache) tagsForSystems(systems []systemdefs.System) []database.TagInf
 // systems so the global list reflects aggregate popularity.
 func buildTagCache(ctx context.Context, db *sql.DB) (*tagCache, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT s.SystemID, stc.TagType, stc.Tag, stc.Count
+		SELECT s.SystemID, stc.TagType, stc.Tag, t.DisplayName, stc.Count
 		FROM SystemTagsCache stc
 		JOIN Systems s ON stc.SystemDBID = s.DBID
+		JOIN Tags t ON stc.TagDBID = t.DBID
 		ORDER BY stc.TagType, stc.Tag`)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query system tags cache: %w", err)
@@ -92,22 +99,26 @@ func buildTagCache(ctx context.Context, db *sql.DB) (*tagCache, error) {
 	}
 
 	allCounts := make(map[tagKey]int64)
+	allLabels := make(map[tagKey]string)
 	allOrder := make([]tagKey, 0)
 
 	for rows.Next() {
-		var systemID, tagType, tag string
+		var systemID, tagType, tag, label string
 		var count int64
-		if err := rows.Scan(&systemID, &tagType, &tag, &count); err != nil {
+		if err := rows.Scan(&systemID, &tagType, &tag, &label, &count); err != nil {
 			return nil, fmt.Errorf("failed to scan tag cache row: %w", err)
 		}
 
 		unpadded := dbtags.UnpadTagValue(tag)
-		ti := database.TagInfo{Type: tagType, Tag: unpadded, Count: count}
+		ti := database.TagInfo{Type: tagType, Tag: unpadded, Label: label, Count: count}
 		cache.bySystem[systemID] = append(cache.bySystem[systemID], ti)
 
 		k := tagKey{tagType, unpadded}
 		if _, exists := allCounts[k]; !exists {
 			allOrder = append(allOrder, k)
+		}
+		if allLabels[k] == "" {
+			allLabels[k] = label
 		}
 		allCounts[k] += count
 	}
@@ -118,7 +129,7 @@ func buildTagCache(ctx context.Context, db *sql.DB) (*tagCache, error) {
 	cache.allTags = make([]database.TagInfo, 0, len(allOrder))
 	for _, k := range allOrder {
 		cache.allTags = append(cache.allTags, database.TagInfo{
-			Type: k.typ, Tag: k.tag, Count: allCounts[k],
+			Type: k.typ, Tag: k.tag, Label: allLabels[k], Count: allCounts[k],
 		})
 	}
 

--- a/pkg/database/mediadb/tag_cache.go
+++ b/pkg/database/mediadb/tag_cache.go
@@ -115,6 +115,8 @@ func buildTagCache(ctx context.Context, db *sql.DB) (*tagCache, error) {
 
 		k := tagKey{tagType, unpadded}
 		if _, exists := allCounts[k]; !exists {
+			// Rows are ordered by type and tag, so global deduplication uses
+			// the first non-empty label seen for each tag as its display label.
 			allOrder = append(allOrder, k)
 		}
 		if allLabels[k] == "" {

--- a/pkg/database/mediadb/tag_cache_test.go
+++ b/pkg/database/mediadb/tag_cache_test.go
@@ -123,12 +123,12 @@ func TestBuildTagCache_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, stc.Count`).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "TagType", "Tag", "Count"}).
-			AddRow("nes", "genre", "Action", int64(5)).
-			AddRow("nes", "genre", "RPG", int64(3)).
-			AddRow("snes", "genre", "Action", int64(2)).
-			AddRow("snes", "year", "1992", int64(1)))
+	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, t.DisplayName, stc.Count`).
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "TagType", "Tag", "DisplayName", "Count"}).
+			AddRow("nes", "genre", "Action", "", int64(5)).
+			AddRow("nes", "genre", "RPG", "", int64(3)).
+			AddRow("snes", "genre", "Action", "", int64(2)).
+			AddRow("snes", "year", "1992", "", int64(1)))
 
 	cache, err := buildTagCache(context.Background(), db)
 
@@ -155,8 +155,8 @@ func TestBuildTagCache_EmptyTable(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, stc.Count`).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "TagType", "Tag", "Count"}))
+	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, t.DisplayName, stc.Count`).
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "TagType", "Tag", "DisplayName", "Count"}))
 
 	cache, err := buildTagCache(context.Background(), db)
 
@@ -172,7 +172,7 @@ func TestBuildTagCache_QueryError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, stc.Count`).
+	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, t.DisplayName, stc.Count`).
 		WillReturnError(errors.New("connection lost"))
 
 	_, err = buildTagCache(context.Background(), db)
@@ -188,9 +188,9 @@ func TestBuildTagCache_ScanError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, stc.Count`).
+	mock.ExpectQuery(`SELECT s.SystemID, stc.TagType, stc.Tag, t.DisplayName, stc.Count`).
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "TagType"}).
-			AddRow("nes", "genre")) // Missing Tag and Count columns
+			AddRow("nes", "genre")) // Missing Tag, DisplayName, and Count columns
 
 	_, err = buildTagCache(context.Background(), db)
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -939,10 +939,10 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 	// --- MediaTitleTags: title-level, shared across all ROMs ---
 
 	if game.Developer != "" {
-		titleTags = append(titleTags, database.TagInfo{Type: string(tags.TagTypeDeveloper), Tag: game.Developer})
+		titleTags = appendNormalizedTag(titleTags, string(tags.TagTypeDeveloper), game.Developer, game.Developer)
 	}
 	if game.Publisher != "" {
-		titleTags = append(titleTags, database.TagInfo{Type: string(tags.TagTypePublisher), Tag: game.Publisher})
+		titleTags = appendNormalizedTag(titleTags, string(tags.TagTypePublisher), game.Publisher, game.Publisher)
 	}
 	if game.ReleaseDate != "" {
 		if year := extractYear(game.ReleaseDate); year != "" {
@@ -955,7 +955,7 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		}
 	}
 	if game.Genre != "" {
-		titleTags = append(titleTags, database.TagInfo{Type: string(tags.TagTypeGenre), Tag: game.Genre})
+		titleTags = appendNormalizedTag(titleTags, string(tags.TagTypeGenre), game.Genre, game.Genre)
 	}
 	// Players: title-level because it describes the game, not a per-ROM variant.
 	// Exclusive type: only the highest player count is kept per title.
@@ -965,13 +965,12 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		}
 	}
 	if game.ArcadeSystemName != "" {
-		titleTags = append(titleTags, database.TagInfo{
-			Type: string(tags.TagTypeArcadeBoard),
-			Tag:  game.ArcadeSystemName,
-		})
+		titleTags = appendNormalizedTag(
+			titleTags, string(tags.TagTypeArcadeBoard), game.ArcadeSystemName, game.ArcadeSystemName,
+		)
 	}
 	if game.Family != "" {
-		titleTags = append(titleTags, database.TagInfo{Type: string(tags.TagTypeGameFamily), Tag: game.Family})
+		titleTags = appendNormalizedTag(titleTags, string(tags.TagTypeGameFamily), game.Family, game.Family)
 	}
 
 	// --- MediaTitleProperties: title-level shared static content ---
@@ -1188,9 +1187,17 @@ func splitCSV(s string) []string {
 
 func appendCSVTags(tagInfos []database.TagInfo, tagType, raw string) []database.TagInfo {
 	for _, value := range splitCSV(raw) {
-		tagInfos = append(tagInfos, database.TagInfo{Type: tagType, Tag: strings.ToLower(value)})
+		tagInfos = appendNormalizedTag(tagInfos, tagType, value, "")
 	}
 	return tagInfos
+}
+
+func appendNormalizedTag(tagInfos []database.TagInfo, tagType, raw, label string) []database.TagInfo {
+	normalized := tags.NormalizeTagValue(tagType, raw)
+	if normalized == "" {
+		return tagInfos
+	}
+	return append(tagInfos, database.TagInfo{Type: tagType, Tag: normalized, Label: label})
 }
 
 // pathProp resolves esPath to an absolute path and returns a MediaProperty for

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -781,11 +781,17 @@ func TestMapToDB_FullGame(t *testing.T) {
 	assert.Contains(t, result.MediaTags, database.TagInfo{Type: string(tags.TagTypeRegion), Tag: "usa"})
 
 	// Title-level tags
-	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeDeveloper), Tag: "Nintendo"})
-	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypePublisher), Tag: "Nintendo"})
+	assert.Contains(t, result.TitleTags, database.TagInfo{
+		Type: string(tags.TagTypeDeveloper), Tag: "nintendo", Label: "Nintendo",
+	})
+	assert.Contains(t, result.TitleTags, database.TagInfo{
+		Type: string(tags.TagTypePublisher), Tag: "nintendo", Label: "Nintendo",
+	})
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeYear), Tag: "1985"})
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeRating), Tag: "75"})
-	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypeGenre), Tag: "Platform"})
+	assert.Contains(t, result.TitleTags, database.TagInfo{
+		Type: string(tags.TagTypeGenre), Tag: "platform", Label: "Platform",
+	})
 	assert.Contains(t, result.TitleTags, database.TagInfo{Type: string(tags.TagTypePlayers), Tag: "4"})
 
 	// Title-level properties
@@ -849,7 +855,9 @@ func TestMapToDB_ArcadeBoard(t *testing.T) {
 	}
 	titleTags := (&GamelistXMLScraper{}).MapToDB(&rec).TitleTags
 	require.NotEmpty(t, titleTags)
-	assert.Contains(t, titleTags, database.TagInfo{Type: string(tags.TagTypeArcadeBoard), Tag: "CPS2"})
+	assert.Contains(t, titleTags, database.TagInfo{
+		Type: string(tags.TagTypeArcadeBoard), Tag: "cps2", Label: "CPS2",
+	})
 }
 
 // --- MapToDB ScreenScraper ID ---
@@ -1527,7 +1535,9 @@ func TestMapToDB_GameFamily(t *testing.T) {
 	t.Parallel()
 	rec := GamelistRecord{Game: esapi.Game{Family: "Mario"}}
 	titleTags := (&GamelistXMLScraper{}).MapToDB(&rec).TitleTags
-	assert.Contains(t, titleTags, database.TagInfo{Type: string(tags.TagTypeGameFamily), Tag: "Mario"})
+	assert.Contains(t, titleTags, database.TagInfo{
+		Type: string(tags.TagTypeGameFamily), Tag: "mario", Label: "Mario",
+	})
 }
 
 func TestMapToDB_Manual(t *testing.T) {
@@ -1946,7 +1956,7 @@ func TestProcessCompanionEntries_ChildByExactPath(t *testing.T) {
 		{Type: string(tags.TagTypeRegion), Tag: "usa"},
 		{Type: string(tags.TagTypeLang), Tag: "en"},
 	}
-	titleTags := []database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev Corp"}}
+	titleTags := []database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "dev-corp", Label: "Dev Corp"}}
 	mockDB := helpers.NewMockMediaDBI()
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20),
 		companionWriteMatcher(childTags, titleTags, companionXMLGameIDProps("42"))).Return(nil)
@@ -1976,7 +1986,7 @@ func TestProcessCompanionEntries_ChildBySlugFile(t *testing.T) {
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(40), int64(30),
 		companionWriteMatcher(
 			nil,
-			[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}},
+			[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "dev", Label: "Dev"}},
 			companionXMLGameIDProps("99"),
 		)).Return(nil)
 
@@ -2030,7 +2040,7 @@ func TestProcessCompanionEntries_ChildBySlugFileWritesAllTitleMedia(t *testing.T
 		assert.Empty(t, target.Write.MediaTags, "slug child should not write file-level tags for target %d", i)
 	}
 	assert.Equal(t,
-		[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}},
+		[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "dev", Label: "Dev"}},
 		mockDB.batches[0][0].Write.TitleTags,
 	)
 	assert.Equal(t, companionXMLGameIDProps("99"), mockDB.batches[0][0].Write.TitleProps)
@@ -2496,7 +2506,7 @@ func TestProcessCompanionEntries_NoRegionLangStillWritesSentinel(t *testing.T) {
 	mockDB.On("ApplyScrapeResult", mock.Anything, int64(5), int64(6),
 		companionWriteMatcher(
 			nil,
-			[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "Dev"}},
+			[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "dev", Label: "Dev"}},
 			companionXMLGameIDProps("1"),
 		)).Return(nil)
 

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -169,18 +169,6 @@ func cachedNormalizeTag(s string) string {
 	return v
 }
 
-// slugifyCompanyName converts a raw company/person name to a dash-joined slug suitable
-// for storage as an open-valued tag (publisher, developer, credit). Uses the full slug
-// pipeline via NormalizeToWords so "&", accents, punctuation etc. are handled correctly
-// ("T&E Soft" → "t-and-e-soft", "Coktel Vision" → "coktel-vision").
-func slugifyCompanyName(raw string) TagValue {
-	words := slugs.NormalizeToWords(raw)
-	if len(words) == 0 {
-		return TagValue(cachedNormalizeTag(raw))
-	}
-	return TagValue(strings.Join(words, "-"))
-}
-
 // classifyUnmappedParen inspects a normalized paren group that allTagMappings did not match
 // and returns the appropriate CanonicalTag slice plus a classified flag.
 //   - classified=false: unrecognized — caller should try positional heuristics or emit unknown:.
@@ -1213,14 +1201,14 @@ func mapParenthesisTag(tag string, ctx *ParseContext) []CanonicalTag {
 		if ctx.CurrentIndex == 0 && ctx.YearExtractedFromFile {
 			return []CanonicalTag{{
 				Type:   TagTypePublisher,
-				Value:  slugifyCompanyName(ctx.CurrentTag),
+				Value:  NormalizeCompanyName(ctx.CurrentTag),
 				Source: TagSourceBracketed,
 			}}
 		}
 		if looksLikeCompanyName(tag) {
 			return []CanonicalTag{{
 				Type:   TagTypeCredit,
-				Value:  slugifyCompanyName(ctx.CurrentTag),
+				Value:  NormalizeCompanyName(ctx.CurrentTag),
 				Source: TagSourceBracketed,
 			}}
 		}

--- a/pkg/database/tags/normalization.go
+++ b/pkg/database/tags/normalization.go
@@ -1,0 +1,49 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tags
+
+import (
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+)
+
+// NormalizeCompanyName converts a raw company/person name to a dash-joined slug
+// suitable for open-valued company tags (publisher, developer, credit). Uses the
+// full slug word pipeline so ampersands, accents, and punctuation are handled
+// consistently ("T&E Soft" → "t-and-e-soft").
+func NormalizeCompanyName(raw string) TagValue {
+	words := slugs.NormalizeToWords(raw)
+	if len(words) == 0 {
+		return TagValue(NormalizeTag(raw))
+	}
+	return TagValue(strings.Join(words, "-"))
+}
+
+// NormalizeTagValue normalizes a raw tag value for canonical storage and lookup.
+// Numeric padding is storage-only and intentionally not applied here.
+func NormalizeTagValue(tagType, raw string) string {
+	switch TagType(NormalizeTag(tagType)) {
+	case TagTypeDeveloper, TagTypePublisher, TagTypeCredit:
+		return string(NormalizeCompanyName(raw))
+	default:
+		return NormalizeTag(raw)
+	}
+}

--- a/pkg/database/tags/normalization_test.go
+++ b/pkg/database/tags/normalization_test.go
@@ -23,6 +23,48 @@ import (
 	"testing"
 )
 
+func TestNormalizeTagValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		tagType string
+		input   string
+		want    string
+	}{
+		{
+			name:    "developer company punctuation",
+			tagType: string(TagTypeDeveloper),
+			input:   "Nintendo R&D1",
+			want:    "nintendo-r-and-d1",
+		},
+		{
+			name:    "publisher ampersand",
+			tagType: string(TagTypePublisher),
+			input:   "T&E Soft",
+			want:    "t-and-e-soft",
+		},
+		{
+			name:    "credit accents",
+			tagType: string(TagTypeCredit),
+			input:   "Coktel Visión",
+			want:    "coktel-vision",
+		},
+		{
+			name:    "generic tag value",
+			tagType: string(TagTypeGenre),
+			input:   "Action RPG",
+			want:    "action-rpg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeTagValue(tt.tagType, tt.input); got != tt.want {
+				t.Fatalf("NormalizeTagValue(%q, %q) = %q, want %q", tt.tagType, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeTag(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Summary:
- canonicalize scraped/filter tag values with type-aware normalization
- preserve original scraped names via tag display labels
- include display labels in tag listing/cache paths

Verified:
- task lint-fix
- go test ./pkg/database/...
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tags now include human-readable display names (labels) alongside canonical normalized values; listings and APIs surface these labels.

* **Improvements**
  * Tag ingestion, search, aggregation, and caching preserve and surface display names.
  * Better normalization for company/developer/publisher/credit tag values for consistent canonical forms.

* **Tests**
  * Added/updated tests for tag normalization, labeling, cache, and listing behavior.

* **Chores**
  * Go toolchain requirement updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->