### PR TITLE
feat(api): prioritize websocket requests

### DIFF
--- a/pkg/api/request_priority.go
+++ b/pkg/api/request_priority.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/rs/zerolog/log"
 )
 
 type apiRequestPriority int
@@ -81,6 +82,7 @@ func classifyAPIMethod(method string) apiRequestPriority {
 func methodFromAPIRequestPayload(msg []byte) string {
 	var req models.RequestObject
 	if err := json.Unmarshal(msg, &req); err != nil {
+		log.Debug().Err(err).Msg("failed to unmarshal API request payload")
 		return ""
 	}
 	return strings.ToLower(req.Method)

--- a/pkg/api/request_priority.go
+++ b/pkg/api/request_priority.go
@@ -1,0 +1,95 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+)
+
+type apiRequestPriority int
+
+const (
+	apiPriorityHigh apiRequestPriority = iota
+	apiPriorityNormal
+	apiPriorityLow
+)
+
+func classifyAPIMethod(method string) apiRequestPriority {
+	method = strings.ToLower(method)
+
+	switch method {
+	case models.MethodMediaTagsUpdate,
+		models.MethodRun,
+		models.MethodRunScript,
+		models.MethodLaunch,
+		models.MethodStop,
+		models.MethodConfirm,
+		models.MethodSettingsUpdate,
+		models.MethodPlaytimeLimitsUpdate,
+		models.MethodClientsDelete,
+		models.MethodInboxDelete,
+		models.MethodInboxClear,
+		models.MethodReadersWrite,
+		models.MethodReadersWriteCancel,
+		models.MethodMediaActiveUpdate,
+		models.MethodMediaControl,
+		models.MethodMappingsNew,
+		models.MethodMappingsDelete,
+		models.MethodMappingsUpdate,
+		models.MethodMappingsReload:
+		return apiPriorityHigh
+	case models.MethodMediaImage,
+		models.MethodMediaGenerate,
+		models.MethodMediaGenerateCancel,
+		models.MethodMediaGenerateResume,
+		models.MethodMediaIndex,
+		models.MethodMediaScrape,
+		models.MethodMediaScrapeStatus,
+		models.MethodMediaScrapeCancel,
+		models.MethodMediaScrapeResume,
+		models.MethodMediaCleanOrphans,
+		models.MethodSettingsLogsDownload:
+		return apiPriorityLow
+	default:
+		if strings.HasPrefix(method, "media.scrape") || strings.HasPrefix(method, "media.generate") {
+			return apiPriorityLow
+		}
+		return apiPriorityNormal
+	}
+}
+
+func methodFromAPIRequestPayload(msg []byte) string {
+	var req models.RequestObject
+	if err := json.Unmarshal(msg, &req); err != nil {
+		return ""
+	}
+	return strings.ToLower(req.Method)
+}
+
+func isImageAPIMethod(method string) bool {
+	return strings.EqualFold(method, models.MethodMediaImage)
+}
+
+func isMediaDBTransactionAPIMethod(method string) bool {
+	return strings.EqualFold(method, models.MethodMediaTagsUpdate)
+}

--- a/pkg/api/request_priority_test.go
+++ b/pkg/api/request_priority_test.go
@@ -1,0 +1,128 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyAPIMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		want   apiRequestPriority
+	}{
+		{"high media tags update", models.MethodMediaTagsUpdate, apiPriorityHigh},
+		{"high run case insensitive", "RUN", apiPriorityHigh},
+		{"low media generate", models.MethodMediaGenerate, apiPriorityLow},
+		{"low media image", models.MethodMediaImage, apiPriorityLow},
+		{"low scrape prefix", "media.scrape.queue", apiPriorityLow},
+		{"low generate prefix", "media.generate.extra", apiPriorityLow},
+		{"unknown normal", "custom.method", apiPriorityNormal},
+		{"empty normal", "", apiPriorityNormal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, classifyAPIMethod(tt.method))
+		})
+	}
+}
+
+func TestMethodFromAPIRequestPayload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want string
+		msg  []byte
+	}{
+		{
+			name: "valid lower",
+			msg:  []byte(`{"jsonrpc":"2.0","method":"media.image","id":1}`),
+			want: "media.image",
+		},
+		{
+			name: "valid mixed case",
+			msg:  []byte(`{"jsonrpc":"2.0","method":"Media.Tags.Update","id":1}`),
+			want: "media.tags.update",
+		},
+		{name: "missing method", msg: []byte(`{"jsonrpc":"2.0","id":1}`), want: ""},
+		{name: "empty method", msg: []byte(`{"jsonrpc":"2.0","method":"","id":1}`), want: ""},
+		{name: "malformed json", msg: []byte(`{"jsonrpc":"2.0","method":`), want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, methodFromAPIRequestPayload(tt.msg))
+		})
+	}
+}
+
+func TestIsImageAPIMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		want   bool
+	}{
+		{"image exact", models.MethodMediaImage, true},
+		{"image case insensitive", "MEDIA.IMAGE", true},
+		{"other method", models.MethodMediaMeta, false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isImageAPIMethod(tt.method))
+		})
+	}
+}
+
+func TestIsMediaDBTransactionAPIMethod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		want   bool
+	}{
+		{"tags update exact", models.MethodMediaTagsUpdate, true},
+		{"tags update case insensitive", "MEDIA.TAGS.UPDATE", true},
+		{"image false", models.MethodMediaImage, false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isMediaDBTransactionAPIMethod(tt.method))
+		})
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -963,8 +963,12 @@ func handleWSMessage(
 	tracker RequestTracker,
 ) func(session *melody.Session, msg []byte) {
 	return func(session *melody.Session, msg []byte) {
+		trackerActive := false
 		defer func() {
 			if r := recover(); r != nil {
+				if trackerActive && tracker != nil {
+					tracker.RequestEnded()
+				}
 				log.Error().Interface("panic", r).Msg("panic in websocket handler")
 				err := sendWSError(session, models.NullRPCID, JSONRPCErrorInternalError)
 				if err != nil {
@@ -973,14 +977,23 @@ func handleWSMessage(
 			}
 		}()
 
-		// Bracket the entire per-message lifecycle (decrypt → dispatch →
-		// marshal → write → AfterWrite) so the idle scheduler doesn't
-		// see inFlight == 0 while a response is still being serialized.
-		// Pong fast-paths are intentionally counted: they're still wire
-		// activity and their cost is negligible.
+		// Bracket the entire per-message lifecycle (decrypt → queue → dispatch →
+		// marshal → write → AfterWrite) so the idle scheduler doesn't see
+		// inFlight == 0 while queued or serialized work is still active.
+		// Once a request is queued, the dispatcher ends the tracker after the
+		// response write (or no-reply completion).
 		if tracker != nil {
 			tracker.RequestStarted()
-			defer tracker.RequestEnded()
+			trackerActive = true
+		}
+		endTrackedRequest := func() {
+			if trackerActive && tracker != nil {
+				tracker.RequestEnded()
+			}
+			trackerActive = false
+		}
+		handoffTrackedRequest := func() {
+			trackerActive = false
 		}
 
 		clientIP := apimiddleware.ParseRemoteIP(session.Request.RemoteAddr)
@@ -1005,6 +1018,7 @@ func handleWSMessage(
 				Str("remote_addr", session.Request.RemoteAddr).
 				Msg("ws: rejecting encrypted connection from unparseable remote addr")
 			closeMelodySession(session)
+			endTrackedRequest()
 			return
 		}
 
@@ -1014,6 +1028,7 @@ func handleWSMessage(
 		plaintext, cs, ok := decryptIncomingFrame(
 			session, msg, encGateway, encryptionEnabled, isLocal, sourceIP)
 		if !ok {
+			endTrackedRequest()
 			return
 		}
 
@@ -1029,23 +1044,21 @@ func handleWSMessage(
 		// Heartbeat ping/pong runs on the decrypted plaintext so encrypted
 		// sessions get an encrypted pong, and remote plaintext probes are
 		// rejected by decryptIncomingFrame before reaching this point.
+		dispatcher := getOrCreateWSDispatcher(st.GetContext(), session)
+
 		if bytes.Equal(plaintext, []byte("ping")) {
-			if err := writePong(session.Write, cs); err != nil {
-				// Encrypted send failed (counter exhausted, write error,
-				// etc.) — the encrypted session is desynced and cannot
-				// recover. Plaintext sessions are also closed because a
-				// write failure means the wire is gone.
-				logWSWriteError(err, "sending pong")
+			if err := dispatcher.enqueuePong(cs, tracker); err != nil {
+				logWSWriteError(err, "queueing pong")
+				endTrackedRequest()
 				closeMelodySession(session)
+				return
 			}
+			handoffTrackedRequest()
 			return
 		}
 
-		reqCtx, reqCancel := context.WithTimeout(st.GetContext(), config.APIRequestTimeout)
-		defer reqCancel()
-
 		env := requests.RequestEnv{
-			Context:       reqCtx,
+			Context:       st.GetContext(),
 			Platform:      platform,
 			Config:        cfg,
 			State:         st,
@@ -1061,32 +1074,18 @@ func handleWSMessage(
 			ClientID:      session.Request.RemoteAddr,
 		}
 
-		result := processRequestObject(methodMap, env, plaintext)
-		if !result.ShouldReply {
-			// Notifications and incoming responses don't get replies
+		if err := enqueueWSRequest(dispatcher, methodMap, &env, plaintext, cs, tracker); err != nil {
+			log.Warn().Err(err).Msg("failed to queue websocket request")
+			endTrackedRequest()
+			if sendErr := sendWSEncryptedError(
+				session, cs, models.NullRPCID, JSONRPCErrorInternalError,
+			); sendErr != nil {
+				logWSWriteError(sendErr, "error sending queue failure response")
+				closeMelodySession(session)
+			}
 			return
 		}
-		if result.Error != nil {
-			err := sendWSEncryptedError(session, cs, result.ID, *result.Error)
-			if err != nil {
-				logWSWriteError(err, "error sending error response")
-				// Encrypted send failed (counter exhausted, write
-				// error, etc.) — the encrypted session is desynced
-				// and cannot recover. Plaintext sessions are also
-				// closed because a write failure means the wire is
-				// gone.
-				closeMelodySession(session)
-			}
-		} else {
-			err := sendWSEncryptedResponse(session, cs, result.ID, result.Result)
-			if err != nil {
-				logWSWriteError(err, "error sending response")
-				closeMelodySession(session)
-			}
-		}
-		if result.AfterWrite != nil {
-			result.AfterWrite()
-		}
+		handoffTrackedRequest()
 	}
 }
 
@@ -1569,6 +1568,9 @@ func StartWithReady(
 	// this errorHandler in an infinite recursion. Closing the underlying
 	// conn directly causes writePump to fail on its next write, exit, and
 	// run the normal session close path.
+	session.HandleDisconnect(func(s *melody.Session) {
+		closeWSDispatcher(s)
+	})
 	session.HandleError(func(s *melody.Session, herr error) {
 		if errors.Is(herr, melody.ErrMessageBufferFull) {
 			cs := getClientSession(s)

--- a/pkg/api/ws_dispatcher.go
+++ b/pkg/api/ws_dispatcher.go
@@ -1,0 +1,349 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/olahol/melody"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	wsHighConcurrency       = 1
+	wsNormalConcurrency     = 4
+	wsLowConcurrency        = 2
+	wsQueueSize             = 256
+	wsResponseQueueSize     = 256
+	wsGlobalImageConcurrent = 2
+)
+
+var (
+	wsGlobalImageSlots = make(chan struct{}, wsGlobalImageConcurrent)
+	wsMediaDBMu        syncutil.RWMutex
+)
+
+const wsDispatcherSessionKey = "api.ws.dispatcher"
+
+type wsRequestJob struct {
+	tracker   RequestTracker
+	methodMap *MethodMap
+	cs        *apimiddleware.ClientSession
+	cancel    context.CancelFunc
+	env       *requests.RequestEnv
+	method    string
+	msg       []byte
+	image     bool
+}
+
+type wsResponseJob struct {
+	tracker RequestTracker
+	cs      *apimiddleware.ClientSession
+	cancel  context.CancelFunc
+	result  requestResult
+	pong    bool
+}
+
+type wsSessionDispatcher struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	session   *melody.Session
+	high      chan *wsRequestJob
+	normal    chan *wsRequestJob
+	low       chan *wsRequestJob
+	responses chan *wsResponseJob
+}
+
+func getOrCreateWSDispatcher(parent context.Context, session *melody.Session) *wsSessionDispatcher {
+	if existing, ok := session.Get(wsDispatcherSessionKey); ok {
+		if d, ok := existing.(*wsSessionDispatcher); ok {
+			return d
+		}
+	}
+
+	ctx, cancel := context.WithCancel(parent)
+	d := &wsSessionDispatcher{
+		ctx:       ctx,
+		cancel:    cancel,
+		session:   session,
+		high:      make(chan *wsRequestJob, wsQueueSize),
+		normal:    make(chan *wsRequestJob, wsQueueSize),
+		low:       make(chan *wsRequestJob, wsQueueSize),
+		responses: make(chan *wsResponseJob, wsResponseQueueSize),
+	}
+	session.Set(wsDispatcherSessionKey, d)
+	d.start()
+	return d
+}
+
+func closeWSDispatcher(session *melody.Session) {
+	existing, ok := session.Get(wsDispatcherSessionKey)
+	if !ok {
+		return
+	}
+	d, ok := existing.(*wsSessionDispatcher)
+	if !ok {
+		return
+	}
+	d.close()
+}
+
+func (d *wsSessionDispatcher) close() {
+	d.cancel()
+	d.drainQueuedJobs(d.high)
+	d.drainQueuedJobs(d.normal)
+	d.drainQueuedJobs(d.low)
+	d.drainQueuedResponses()
+}
+
+func (*wsSessionDispatcher) drainQueuedJobs(queue <-chan *wsRequestJob) {
+	for {
+		select {
+		case job := <-queue:
+			if job.cancel != nil {
+				job.cancel()
+			}
+			if job.tracker != nil {
+				job.tracker.RequestEnded()
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (d *wsSessionDispatcher) drainQueuedResponses() {
+	for {
+		select {
+		case resp := <-d.responses:
+			if resp.cancel != nil {
+				resp.cancel()
+			}
+			if resp.tracker != nil {
+				resp.tracker.RequestEnded()
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (d *wsSessionDispatcher) start() {
+	for range wsHighConcurrency {
+		go d.worker(d.high)
+	}
+	for range wsNormalConcurrency {
+		go d.worker(d.normal)
+	}
+	for range wsLowConcurrency {
+		go d.worker(d.low)
+	}
+	go d.writer()
+}
+
+func (d *wsSessionDispatcher) enqueue(job *wsRequestJob, priority apiRequestPriority) error {
+	var q chan *wsRequestJob
+	switch priority {
+	case apiPriorityHigh:
+		q = d.high
+	case apiPriorityLow:
+		q = d.low
+	default:
+		q = d.normal
+	}
+
+	select {
+	case <-d.ctx.Done():
+		return d.ctx.Err()
+	case q <- job:
+		return nil
+	default:
+		return errors.New("websocket request queue is full")
+	}
+}
+
+func (d *wsSessionDispatcher) enqueuePong(cs *apimiddleware.ClientSession, tracker RequestTracker) error {
+	select {
+	case <-d.ctx.Done():
+		return d.ctx.Err()
+	case d.responses <- &wsResponseJob{cs: cs, tracker: tracker, pong: true}:
+		return nil
+	default:
+		return errors.New("websocket response queue is full")
+	}
+}
+
+func (d *wsSessionDispatcher) worker(queue <-chan *wsRequestJob) {
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case job := <-queue:
+			d.runJob(job)
+		}
+	}
+}
+
+func (d *wsSessionDispatcher) runJob(job *wsRequestJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).Msg("panic in websocket request worker")
+			d.enqueueResponse(&wsResponseJob{
+				result: requestResult{ID: models.NullRPCID, Error: &JSONRPCErrorInternalError, ShouldReply: true},
+				cs:     job.cs, tracker: job.tracker, cancel: job.cancel,
+			})
+		}
+	}()
+
+	if job.image {
+		select {
+		case <-job.env.Context.Done():
+			d.finishWithoutReply(job)
+			return
+		case <-d.ctx.Done():
+			d.finishWithoutReply(job)
+			return
+		case wsGlobalImageSlots <- struct{}{}:
+			defer func() { <-wsGlobalImageSlots }()
+		}
+	}
+
+	unlock := lockMediaDBForAPIMethod(job.method)
+	defer unlock()
+
+	result := processRequestObject(job.methodMap, *job.env, job.msg)
+	d.enqueueResponse(&wsResponseJob{result: result, cs: job.cs, tracker: job.tracker, cancel: job.cancel})
+}
+
+func lockMediaDBForAPIMethod(method string) func() {
+	if isMediaDBTransactionAPIMethod(method) {
+		wsMediaDBMu.Lock()
+		return wsMediaDBMu.Unlock
+	}
+	wsMediaDBMu.RLock()
+	return wsMediaDBMu.RUnlock
+}
+
+func (d *wsSessionDispatcher) finishWithoutReply(job *wsRequestJob) {
+	d.enqueueResponse(&wsResponseJob{
+		result:  requestResult{ShouldReply: false},
+		cs:      job.cs,
+		tracker: job.tracker,
+		cancel:  job.cancel,
+	})
+}
+
+func (d *wsSessionDispatcher) enqueueResponse(resp *wsResponseJob) {
+	select {
+	case <-d.ctx.Done():
+		if resp.cancel != nil {
+			resp.cancel()
+		}
+		if resp.tracker != nil {
+			resp.tracker.RequestEnded()
+		}
+	case d.responses <- resp:
+	}
+}
+
+func (d *wsSessionDispatcher) writer() {
+	for {
+		select {
+		case <-d.ctx.Done():
+			return
+		case resp := <-d.responses:
+			d.writeResponse(resp)
+		}
+	}
+}
+
+func (d *wsSessionDispatcher) writeResponse(resp *wsResponseJob) {
+	defer func() {
+		if resp.cancel != nil {
+			resp.cancel()
+		}
+		if resp.tracker != nil {
+			resp.tracker.RequestEnded()
+		}
+	}()
+
+	if resp.pong {
+		if err := writePong(d.session.Write, resp.cs); err != nil {
+			logWSWriteError(err, "sending pong")
+			closeMelodySession(d.session)
+		}
+		return
+	}
+
+	if !resp.result.ShouldReply {
+		return
+	}
+
+	if resp.result.Error != nil {
+		if err := sendWSEncryptedError(d.session, resp.cs, resp.result.ID, *resp.result.Error); err != nil {
+			logWSWriteError(err, "error sending error response")
+			closeMelodySession(d.session)
+		}
+	} else {
+		if err := sendWSEncryptedResponse(d.session, resp.cs, resp.result.ID, resp.result.Result); err != nil {
+			logWSWriteError(err, "error sending response")
+			closeMelodySession(d.session)
+		}
+	}
+	if resp.result.AfterWrite != nil {
+		resp.result.AfterWrite()
+	}
+}
+
+func enqueueWSRequest(
+	d *wsSessionDispatcher,
+	methodMap *MethodMap,
+	env *requests.RequestEnv,
+	msg []byte,
+	cs *apimiddleware.ClientSession,
+	tracker RequestTracker,
+) error {
+	method := methodFromAPIRequestPayload(msg)
+	priority := classifyAPIMethod(method)
+	ctx, cancel := context.WithTimeout(d.ctx, config.APIRequestTimeout)
+	env.Context = ctx
+	job := &wsRequestJob{
+		methodMap: methodMap,
+		env:       env,
+		method:    method,
+		msg:       append([]byte(nil), msg...),
+		cs:        cs,
+		tracker:   tracker,
+		cancel:    cancel,
+		image:     isImageAPIMethod(method),
+	}
+	if err := d.enqueue(job, priority); err != nil {
+		cancel()
+		return fmt.Errorf("enqueue websocket request: %w", err)
+	}
+	return nil
+}

--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -1,0 +1,283 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/gorilla/websocket"
+	"github.com/olahol/melody"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func indexRPCID(ids []models.RPCID, target models.RPCID) int {
+	for i, id := range ids {
+		if id.Equal(target) {
+			return i
+		}
+	}
+	return -1
+}
+
+func startPriorityWSServer(t *testing.T, methodMap *MethodMap) (wsURL string, cleanup func()) {
+	t.Helper()
+
+	cfg, err := config.NewConfig(t.TempDir(), config.BaseDefaults)
+	require.NoError(t, err)
+	st, _ := state.NewState(nil, "test-boot")
+
+	m := newWebSocketSession()
+	m.HandleDisconnect(func(s *melody.Session) {
+		closeWSDispatcher(s)
+	})
+	m.HandleMessage(handleWSMessage(
+		methodMap, nil, cfg, st, nil, nil,
+		nil, nil, nil, nil, nil,
+		nil, nil, nil,
+	))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+
+	srv := httptest.NewServer(mux)
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	cleanup = func() {
+		st.StopService()
+		_ = m.Close()
+		srv.Close()
+	}
+	return "ws://" + u.Host + "/api", cleanup
+}
+
+func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) {
+	t.Parallel()
+
+	var methodMap MethodMap
+	require.NoError(t, methodMap.AddMethod(models.MethodMediaImage, func(env requests.RequestEnv) (any, error) {
+		select {
+		case <-time.After(250 * time.Millisecond):
+			return map[string]string{"kind": "image"}, nil
+		case <-env.Context.Done():
+			return nil, env.Context.Err()
+		}
+	}))
+	require.NoError(t, methodMap.AddMethod(models.MethodMediaTagsUpdate, func(requests.RequestEnv) (any, error) {
+		return map[string]string{"kind": "favorite"}, nil
+	}))
+
+	wsURL, cleanup := startPriorityWSServer(t, &methodMap)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	for id := 1; id <= 3; id++ {
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+			[]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"media.image","id":%d}`, id))))
+	}
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"media.tags.update","params":{"mediaId":1,"add":["user:favorite"]},"id":4}`)))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	seen := make([]models.RPCID, 0, 4)
+	for range 4 {
+		_, msg, err := conn.ReadMessage()
+		require.NoError(t, err)
+		var resp models.ResponseObject
+		require.NoError(t, json.Unmarshal(msg, &resp))
+		seen = append(seen, resp.ID)
+	}
+
+	favoriteIndex := indexRPCID(seen, models.NewNumberID(4))
+	thirdImageIndex := indexRPCID(seen, models.NewNumberID(3))
+	require.NotEqual(t, -1, favoriteIndex)
+	require.NotEqual(t, -1, thirdImageIndex)
+	assert.Less(t, favoriteIndex, thirdImageIndex, "mutation should bypass queued image work")
+}
+
+func TestWebSocketPriorityDispatcherPreservesHighPriorityOrder(t *testing.T) {
+	t.Parallel()
+
+	firstDone := make(chan struct{})
+	var methodMap MethodMap
+	require.NoError(t, methodMap.AddMethod(models.MethodRun, func(requests.RequestEnv) (any, error) {
+		time.Sleep(150 * time.Millisecond)
+		close(firstDone)
+		return map[string]string{"kind": "run"}, nil
+	}))
+	require.NoError(t, methodMap.AddMethod(models.MethodStop, func(requests.RequestEnv) (any, error) {
+		select {
+		case <-firstDone:
+			return map[string]string{"kind": "stop"}, nil
+		default:
+			return map[string]string{"kind": "stop-before-run"}, nil
+		}
+	}))
+
+	wsURL, cleanup := startPriorityWSServer(t, &methodMap)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"run","id":1}`)))
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"stop","id":2}`)))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	var resp models.ResponseObject
+	require.NoError(t, json.Unmarshal(msg, &resp))
+	assert.Equal(t, models.NewNumberID(1), resp.ID)
+
+	_, msg, err = conn.ReadMessage()
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(msg, &resp))
+	assert.Equal(t, models.NewNumberID(2), resp.ID)
+}
+
+func TestWebSocketPriorityDispatcherMediaTransactionBlocksMediaReads(t *testing.T) {
+	t.Parallel()
+
+	txStarted := make(chan struct{})
+	releaseTx := make(chan struct{})
+	metaStarted := make(chan struct{}, 1)
+	var methodMap MethodMap
+	require.NoError(t, methodMap.AddMethod(models.MethodMediaTagsUpdate, func(env requests.RequestEnv) (any, error) {
+		close(txStarted)
+		select {
+		case <-releaseTx:
+			return map[string]string{"kind": "favorite"}, nil
+		case <-env.Context.Done():
+			return nil, env.Context.Err()
+		}
+	}))
+	require.NoError(t, methodMap.AddMethod(models.MethodMediaMeta, func(requests.RequestEnv) (any, error) {
+		metaStarted <- struct{}{}
+		return map[string]string{"kind": "meta"}, nil
+	}))
+
+	wsURL, cleanup := startPriorityWSServer(t, &methodMap)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"media.tags.update","id":1}`)))
+	select {
+	case <-txStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("media.tags.update did not start")
+	}
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"media.meta","id":2}`)))
+
+	select {
+	case <-metaStarted:
+		t.Fatal("media.meta ran while media.tags.update transaction lane was active")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(releaseTx)
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, _, err := conn.ReadMessage()
+	require.NoError(t, err)
+	_, _, err = conn.ReadMessage()
+	require.NoError(t, err)
+}
+
+func TestWebSocketPriorityDispatcherNotificationsDoNotReply(t *testing.T) {
+	t.Parallel()
+
+	var methodMap MethodMap
+	require.NoError(t, methodMap.AddMethod("test.notify", func(requests.RequestEnv) (any, error) {
+		return map[string]string{"ok": "true"}, nil
+	}))
+
+	wsURL, cleanup := startPriorityWSServer(t, &methodMap)
+	defer cleanup()
+
+	conn := dialWS(t, wsURL)
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"test.notify"}`)))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(200*time.Millisecond)))
+	_, _, err := conn.ReadMessage()
+	require.Error(t, err, "JSON-RPC notifications must not receive responses")
+}
+
+func TestCloseWSDispatcherCancelsQueuedRequests(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	d := &wsSessionDispatcher{
+		ctx:       ctx,
+		cancel:    cancel,
+		high:      make(chan *wsRequestJob, wsQueueSize),
+		normal:    make(chan *wsRequestJob, wsQueueSize),
+		low:       make(chan *wsRequestJob, wsQueueSize),
+		responses: make(chan *wsResponseJob, wsResponseQueueSize),
+	}
+
+	tracker := &countingRequestTracker{}
+	tracker.RequestStarted()
+	jobCtx, jobCancel := context.WithCancel(ctx)
+	require.NoError(t, d.enqueue(&wsRequestJob{
+		env:     &requests.RequestEnv{Context: jobCtx},
+		tracker: tracker,
+		cancel:  jobCancel,
+	}, apiPriorityHigh))
+
+	d.close()
+	assert.Equal(t, 0, tracker.inFlight())
+	assert.Error(t, jobCtx.Err())
+}
+
+type countingRequestTracker struct {
+	count int
+}
+
+func (t *countingRequestTracker) RequestStarted() { t.count++ }
+
+func (t *countingRequestTracker) RequestEnded() { t.count-- }
+
+func (t *countingRequestTracker) inFlight() int { return t.count }

--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -133,10 +133,14 @@ func TestWebSocketPriorityDispatcherPreservesHighPriorityOrder(t *testing.T) {
 
 	firstDone := make(chan struct{})
 	var methodMap MethodMap
-	require.NoError(t, methodMap.AddMethod(models.MethodRun, func(requests.RequestEnv) (any, error) {
-		time.Sleep(150 * time.Millisecond)
-		close(firstDone)
-		return map[string]string{"kind": "run"}, nil
+	require.NoError(t, methodMap.AddMethod(models.MethodRun, func(env requests.RequestEnv) (any, error) {
+		select {
+		case <-time.After(150 * time.Millisecond):
+			close(firstDone)
+			return map[string]string{"kind": "run"}, nil
+		case <-env.Context.Done():
+			return nil, env.Context.Err()
+		}
 	}))
 	require.NoError(t, methodMap.AddMethod(models.MethodStop, func(requests.RequestEnv) (any, error) {
 		select {


### PR DESCRIPTION
## Summary
- add prioritized WebSocket request dispatch with serialized per-session writes
- route user-blocking mutations ahead of queued image/background work
- throttle media.image work and guard shared MediaDB transaction access
- add regression coverage for priority bypass, ordered commands, notifications, cancellation, and MediaDB transaction blocking

Validated with `task lint-fix`, focused API/MediaDB tests, and `task test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized WebSocket request handling with improved lifecycle tracking and request dispatch coordination for enhanced responsiveness under concurrent load

* **Tests**
  * Added comprehensive test suite validating request prioritization behavior, transaction handling, and proper dispatcher shutdown scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->