### PR TITLE
fix: gamelist artwork matching and scrape status

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -38,12 +38,16 @@ import (
 
 // browseCursorData is the JSON-serializable keyset cursor for browse pagination.
 type browseCursorData struct {
-	SortValue string `json:"sortValue"`
-	LastID    int64  `json:"lastId"`
+	SortValue  string `json:"sortValue"`
+	LastID     int64  `json:"lastId"`
+	TotalFiles int    `json:"totalFiles,omitempty"`
 }
 
-func encodeBrowseCursor(lastID int64, sortValue string) (string, error) {
+func encodeBrowseCursor(lastID int64, sortValue string, totalFiles ...int) (string, error) {
 	data := browseCursorData{LastID: lastID, SortValue: sortValue}
+	if len(totalFiles) > 0 && totalFiles[0] > 0 {
+		data.TotalFiles = totalFiles[0]
+	}
 	b, err := json.Marshal(data)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal browse cursor: %w", err)
@@ -67,8 +71,9 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 	}
 
 	return &database.BrowseCursor{
-		LastID:    data.LastID,
-		SortValue: data.SortValue,
+		LastID:     data.LastID,
+		SortValue:  data.SortValue,
+		TotalFiles: data.TotalFiles,
 	}, nil
 }
 
@@ -560,9 +565,12 @@ func browseFilesystem(
 		return nil, fmt.Errorf("error browsing files: %w", err)
 	}
 
-	// Get total file count (skip when no files and no cursor — count is obviously 0)
+	// Get total file count. First-page cursors carry this forward so loading
+	// additional pages in large directories does not repeat the same count query.
 	var totalFiles int
-	if len(files) > 0 || cursor != nil {
+	if cursor != nil && cursor.TotalFiles > 0 {
+		totalFiles = cursor.TotalFiles
+	} else if len(files) > 0 || cursor != nil {
 		started = time.Now()
 		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
 			PathPrefix: prefix,
@@ -610,15 +618,20 @@ func browseVirtual(
 		return nil, fmt.Errorf("error browsing virtual media: %w", err)
 	}
 
-	started = time.Now()
-	totalFiles, err := env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
-		PathPrefix: schemePath,
-		Letter:     letter,
-		Systems:    systems,
-	})
-	logBrowseTiming("virtual_file_count", schemePath, started, totalFiles)
-	if err != nil {
-		return nil, fmt.Errorf("error getting virtual file count: %w", err)
+	var totalFiles int
+	if cursor != nil && cursor.TotalFiles > 0 {
+		totalFiles = cursor.TotalFiles
+	} else {
+		started = time.Now()
+		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+			PathPrefix: schemePath,
+			Letter:     letter,
+			Systems:    systems,
+		})
+		logBrowseTiming("virtual_file_count", schemePath, started, totalFiles)
+		if err != nil {
+			return nil, fmt.Errorf("error getting virtual file count: %w", err)
+		}
 	}
 
 	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, sort)
@@ -681,7 +694,7 @@ func buildBrowseResponse(
 			default:
 				sortValue = lastResult.Name
 			}
-			encoded, encErr := encodeBrowseCursor(lastResult.MediaID, sortValue)
+			encoded, encErr := encodeBrowseCursor(lastResult.MediaID, sortValue, totalFiles)
 			if encErr != nil {
 				return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
 			}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -872,6 +872,46 @@ func TestHandleMediaBrowse_CursorRoundTrip(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_CursorTotalFilesSkipsCountQuery(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	cursorStr, err := encodeBrowseCursor(5, "Mario", 10)
+	require.NoError(t, err)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseFiles", mock.Anything,
+		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+			return opts.Cursor != nil && opts.Cursor.TotalFiles == 10 && opts.PathPrefix == "/roms/SNES/"
+		}),
+	).Return([]database.SearchResultWithCursor{
+		{SystemID: "snes", Name: "Zelda", Path: "/roms/SNES/Zelda.sfc", MediaID: 8},
+	}, nil)
+
+	path := "/roms/SNES"
+	maxResults := 5
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:       &path,
+		MaxResults: &maxResults,
+		Cursor:     &cursorStr,
+	})
+
+	result, browseErr := HandleMediaBrowse(env)
+	require.NoError(t, browseErr)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, 10, browseResults.TotalFiles)
+	mockMediaDB.AssertNotCalled(t, "BrowseFileCount", mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_FilenameSortCursor(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -876,9 +876,13 @@ func TestHandleMediaBrowse_CursorTotalFilesSkipsCountQuery(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	snesPath := filepath.Join(romsRoot, "SNES")
+	snesAPIPath := filepath.ToSlash(snesPath)
+	snesPrefix := snesAPIPath + "/"
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{})
 
@@ -888,13 +892,52 @@ func TestHandleMediaBrowse_CursorTotalFilesSkipsCountQuery(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseFiles", mock.Anything,
 		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
-			return opts.Cursor != nil && opts.Cursor.TotalFiles == 10 && opts.PathPrefix == "/roms/SNES/"
+			return opts.Cursor != nil && opts.Cursor.TotalFiles == 10 && opts.PathPrefix == snesPrefix
 		}),
 	).Return([]database.SearchResultWithCursor{
-		{SystemID: "snes", Name: "Zelda", Path: "/roms/SNES/Zelda.sfc", MediaID: 8},
+		{SystemID: "snes", Name: "Zelda", Path: filepath.ToSlash(filepath.Join(snesPath, "Zelda.sfc")), MediaID: 8},
 	}, nil)
 
-	path := "/roms/SNES"
+	maxResults := 5
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:       &snesAPIPath,
+		MaxResults: &maxResults,
+		Cursor:     &cursorStr,
+	})
+
+	result, browseErr := HandleMediaBrowse(env)
+	require.NoError(t, browseErr)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, 10, browseResults.TotalFiles)
+	mockMediaDB.AssertNotCalled(t, "BrowseFileCount", mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_VirtualCursorTotalFilesSkipsCountQuery(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{browseTestAbsPath("roms")})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}}})
+
+	cursorStr, err := encodeBrowseCursor(5, "Mario", 10)
+	require.NoError(t, err)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseFiles", mock.Anything,
+		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+			return opts.Cursor != nil && opts.Cursor.TotalFiles == 10 && opts.PathPrefix == "steam://"
+		}),
+	).Return([]database.SearchResultWithCursor{
+		{SystemID: "pc", Name: "Portal", Path: "steam://620", MediaID: 8},
+	}, nil)
+
+	path := "steam://"
 	maxResults := 5
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
 		Path:       &path,

--- a/pkg/api/methods/media_operation_guard.go
+++ b/pkg/api/methods/media_operation_guard.go
@@ -39,14 +39,14 @@ func startIndexingIfNoScrape() error {
 	return nil
 }
 
-func startScrapingIfNoIndex(scraperID string) error {
+func startScrapingIfNoIndex(scraperID string, force bool) error {
 	mediaOperationMu.Lock()
 	defer mediaOperationMu.Unlock()
 
 	if statusInstance.isRunning() {
 		return models.ClientErrf("media indexing is in progress")
 	}
-	if !scrapingStatusInstance.startIfNotRunning(scraperID) {
+	if !scrapingStatusInstance.startIfNotRunning(scraperID, force) {
 		return models.ClientErrf("scraping already in progress")
 	}
 	return nil

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -58,11 +58,11 @@ type scrapedCountCache struct {
 
 type scrapingStatus struct {
 	cancelFunc context.CancelFunc
-	countCache scrapedCountCache
 	scraperID  string
-	force      bool
+	countCache scrapedCountCache
 	latest     models.ScrapingStatusResponse
 	mu         syncutil.RWMutex
+	force      bool
 	running    bool
 }
 

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -60,12 +60,13 @@ type scrapingStatus struct {
 	cancelFunc context.CancelFunc
 	countCache scrapedCountCache
 	scraperID  string
+	force      bool
 	latest     models.ScrapingStatusResponse
 	mu         syncutil.RWMutex
 	running    bool
 }
 
-func (s *scrapingStatus) startIfNotRunning(scraperID string) bool {
+func (s *scrapingStatus) startIfNotRunning(scraperID string, force bool) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.running {
@@ -73,11 +74,13 @@ func (s *scrapingStatus) startIfNotRunning(scraperID string) bool {
 	}
 	s.running = true
 	s.scraperID = scraperID
+	s.force = force
 	s.countCache = scrapedCountCache{}
 	s.latest = models.ScrapingStatusResponse{
 		ScraperID: scraperID,
 		State:     scrapeStateRunning,
 		Scraping:  true,
+		Force:     force,
 	}
 	return true
 }
@@ -87,6 +90,7 @@ func (s *scrapingStatus) clear() {
 	defer s.mu.Unlock()
 	s.running = false
 	s.scraperID = ""
+	s.force = false
 	s.cancelFunc = nil
 	s.latest = models.ScrapingStatusResponse{}
 	s.countCache = scrapedCountCache{}
@@ -103,6 +107,7 @@ func (s *scrapingStatus) clearIfOwner(scraperID string) {
 	}
 	s.running = false
 	s.scraperID = ""
+	s.force = false
 	s.cancelFunc = nil
 }
 
@@ -115,7 +120,9 @@ func (s *scrapingStatus) setLatest(status *models.ScrapingStatusResponse) {
 func (s *scrapingStatus) getLatest() models.ScrapingStatusResponse {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.latest
+	status := s.latest
+	status.Force = s.force
+	return status
 }
 
 func (s *scrapingStatus) setCancelFunc(cancelFunc context.CancelFunc) {
@@ -297,6 +304,7 @@ func scrapeState(scrapeCtx context.Context, update *scraper.ScrapeUpdate, paused
 func scrapingStatusFromUpdate(
 	scrapeCtx context.Context,
 	scraperID string,
+	force bool,
 	update *scraper.ScrapeUpdate,
 	paused bool,
 ) models.ScrapingStatusResponse {
@@ -312,6 +320,7 @@ func scrapingStatusFromUpdate(
 		Done:               update.Done,
 		Paused:             paused && !update.Done,
 		State:              scrapeState(scrapeCtx, update, paused && !update.Done),
+		Force:              force,
 		TotalSteps:         ptrIfPositive(update.TotalSteps),
 		CurrentStep:        ptrIfPositive(update.CurrentStep),
 		CurrentStepDisplay: ptrIfNotEmpty(display),
@@ -373,7 +382,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		return nil, fmt.Errorf("scraper %q has no Scrape function", s.ID)
 	}
 
-	if err := startScrapingIfNoIndex(params.ScraperID); err != nil {
+	if err := startScrapingIfNoIndex(params.ScraperID, params.Force); err != nil {
 		return nil, err
 	}
 
@@ -402,6 +411,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		State:     initialState,
 		Scraping:  true,
 		Paused:    paused,
+		Force:     params.Force,
 	}
 	populateScrapedMediaCountExact(env.State.GetContext(), db, &initialStatus)
 	publishScrapingStatus(ns, &initialStatus)
@@ -419,7 +429,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 				receivedDone = true
 			}
 			paused := env.ScrapePauser != nil && env.ScrapePauser.IsPaused()
-			status := scrapingStatusFromUpdate(scrapeCtx, scraperID, &update, paused)
+			status := scrapingStatusFromUpdate(scrapeCtx, scraperID, params.Force, &update, paused)
 			if update.Done {
 				populateScrapedMediaCountExact(env.State.GetContext(), db, &status)
 			} else {
@@ -435,6 +445,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		if !receivedDone {
 			terminalStatus := scrapingStatusInstance.getLatest()
 			terminalStatus.ScraperID = scraperID
+			terminalStatus.Force = params.Force
 			terminalStatus.Scraping = false
 			terminalStatus.Done = true
 			terminalStatus.Paused = false

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -159,7 +159,7 @@ func TestHandleMediaScrape_IndexingInProgress(t *testing.T) {
 func TestHandleMediaScrape_AlreadyRunning(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()
-	scrapingStatusInstance.startIfNotRunning("test-scraper")
+	scrapingStatusInstance.startIfNotRunning("test-scraper", false)
 	defer scrapingStatusInstance.clear()
 
 	mockDB := testhelpers.NewMockMediaDBI()
@@ -464,7 +464,7 @@ func TestHandleMediaScrapeCancel_CancelsActive(t *testing.T) {
 	ClearScrapingStatus()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	scrapingStatusInstance.startIfNotRunning("test-scraper")
+	scrapingStatusInstance.startIfNotRunning("test-scraper", false)
 	scrapingStatusInstance.setCancelFunc(cancel)
 	defer func() {
 		cancel()
@@ -498,7 +498,7 @@ func TestHandleMediaScrapeResume_ResumesPausedScrape(t *testing.T) {
 	t.Cleanup(st.StopService)
 	drainNotifications(t, ns)
 
-	scrapingStatusInstance.startIfNotRunning("test-scraper")
+	scrapingStatusInstance.startIfNotRunning("test-scraper", false)
 	defer scrapingStatusInstance.clear()
 	pauser := syncutil.NewPauser()
 	pauser.Pause()
@@ -552,7 +552,7 @@ func TestHandleMediaScrapeResume_NotPaused(t *testing.T) {
 func TestScrapingStatus_ClearIfOwner_MatchingID_Clears(t *testing.T) {
 	t.Parallel()
 	s := &scrapingStatus{}
-	s.startIfNotRunning("my-scraper")
+	s.startIfNotRunning("my-scraper", false)
 	s.clearIfOwner("my-scraper")
 	assert.False(t, s.isRunning())
 }
@@ -560,7 +560,7 @@ func TestScrapingStatus_ClearIfOwner_MatchingID_Clears(t *testing.T) {
 func TestScrapingStatus_ClearIfOwner_MismatchedID_Preserves(t *testing.T) {
 	t.Parallel()
 	s := &scrapingStatus{}
-	s.startIfNotRunning("owner-a")
+	s.startIfNotRunning("owner-a", false)
 	s.clearIfOwner("owner-b")
 	assert.True(t, s.isRunning(), "non-owner clearIfOwner must not clear state")
 	s.clear()
@@ -727,14 +727,16 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 	mockDB.On("BackgroundOperationDone").Return()
 	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "progress-scraper").Return(3, nil)
 
+	var gotForceOption bool
 	progressScraper := platforms.Scraper{
 		ID:   "progress-scraper",
 		Name: "Progress Scraper",
 		Scrape: func(
 			_ context.Context, _ *config.Instance, _ platforms.Platform,
-			_ afero.Fs, _ *database.Database, _ scraper.ScrapeOptions,
+			_ afero.Fs, _ *database.Database, opts scraper.ScrapeOptions,
 			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
 		) error {
+			gotForceOption = opts.Force
 			go func() {
 				defer close(ch)
 				ch <- scraper.ScrapeUpdate{
@@ -763,7 +765,7 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 		Platform: pl,
 		State:    st,
 		Database: &database.Database{MediaDB: mockDB},
-		Params:   json.RawMessage(`{"scraperId":"progress-scraper"}`),
+		Params:   json.RawMessage(`{"scraperId":"progress-scraper","force":true}`),
 	}
 
 	result, err := HandleMediaScrape(env)
@@ -773,6 +775,7 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 	var gotDone bool
 	var maxProcessed int
 	var sawCurrentSystem bool
+	var sawForce bool
 	timeout := time.After(2 * time.Second)
 	for !gotDone {
 		select {
@@ -782,6 +785,9 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 			}
 			var p models.ScrapingStatusResponse
 			require.NoError(t, json.Unmarshal(n.Params, &p))
+			if p.Force {
+				sawForce = true
+			}
 			if p.Processed > maxProcessed {
 				maxProcessed = p.Processed
 			}
@@ -804,6 +810,8 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 		}
 	}
 
+	assert.True(t, gotForceOption, "force option should be passed to scraper")
+	assert.True(t, sawForce, "scrape status should expose active force scrape")
 	assert.Equal(t, 10, maxProcessed, "progress updates should reflect actual processed count")
 	assert.True(t, sawCurrentSystem, "progress updates should expose currentSystem and step fields")
 	require.Eventually(t, func() bool {

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -552,17 +552,19 @@ func TestHandleMediaScrapeResume_NotPaused(t *testing.T) {
 func TestScrapingStatus_ClearIfOwner_MatchingID_Clears(t *testing.T) {
 	t.Parallel()
 	s := &scrapingStatus{}
-	s.startIfNotRunning("my-scraper", false)
+	s.startIfNotRunning("my-scraper", true)
 	s.clearIfOwner("my-scraper")
 	assert.False(t, s.isRunning())
+	assert.False(t, s.force)
 }
 
 func TestScrapingStatus_ClearIfOwner_MismatchedID_Preserves(t *testing.T) {
 	t.Parallel()
 	s := &scrapingStatus{}
-	s.startIfNotRunning("owner-a", false)
+	s.startIfNotRunning("owner-a", true)
 	s.clearIfOwner("owner-b")
 	assert.True(t, s.isRunning(), "non-owner clearIfOwner must not clear state")
+	assert.True(t, s.force, "non-owner clearIfOwner must preserve force state")
 	s.clear()
 }
 

--- a/pkg/api/middleware/encryption_test.go
+++ b/pkg/api/middleware/encryption_test.go
@@ -258,9 +258,11 @@ func TestEstablishSession_BlockExpires(t *testing.T) {
 	c, _ := pairedClient(t)
 	db := helpers.NewMockUserDBI()
 	db.On("GetClientByToken", c.AuthToken).Return(c, nil)
+	clock := clockwork.NewFakeClock()
 	mgr := middleware.NewEncryptionGateway(db,
+		middleware.WithClock(clock),
 		middleware.WithFailedFrameThreshold(2),
-		middleware.WithFailedFrameBlockDuration(20*time.Millisecond),
+		middleware.WithFailedFrameBlockDuration(time.Minute),
 	)
 
 	for range 2 {
@@ -284,8 +286,8 @@ func TestEstablishSession_BlockExpires(t *testing.T) {
 	_, _, err := mgr.EstablishSession(frame, "192.168.1.50")
 	require.ErrorIs(t, err, middleware.ErrConnectionBlocked)
 
-	// Wait for block to expire
-	time.Sleep(40 * time.Millisecond)
+	// Advance the fake clock past the block window without relying on CI timer scheduling.
+	clock.Advance(time.Minute + time.Millisecond)
 
 	// Build a valid frame so the next attempt actually succeeds (clears state)
 	salt := randomSalt(t)

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -318,6 +318,7 @@ type ScrapingStatusResponse struct {
 	Scraping           bool                          `json:"scraping"`
 	Done               bool                          `json:"done"`
 	Paused             bool                          `json:"paused"`
+	Force              bool                          `json:"force"`
 }
 
 type MediaLookupMatch struct {

--- a/pkg/api/ws_dispatcher.go
+++ b/pkg/api/ws_dispatcher.go
@@ -209,6 +209,10 @@ func (d *wsSessionDispatcher) worker(queue <-chan *wsRequestJob) {
 }
 
 func (d *wsSessionDispatcher) runJob(job *wsRequestJob) {
+	ctx, cancel := context.WithTimeout(d.ctx, config.APIRequestTimeout)
+	job.env.Context = ctx
+	job.cancel = cancel
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error().Interface("panic", r).Msg("panic in websocket request worker")
@@ -329,8 +333,7 @@ func enqueueWSRequest(
 ) error {
 	method := methodFromAPIRequestPayload(msg)
 	priority := classifyAPIMethod(method)
-	ctx, cancel := context.WithTimeout(d.ctx, config.APIRequestTimeout)
-	env.Context = ctx
+	env.Context = d.ctx
 	job := &wsRequestJob{
 		methodMap: methodMap,
 		env:       env,
@@ -338,11 +341,9 @@ func enqueueWSRequest(
 		msg:       append([]byte(nil), msg...),
 		cs:        cs,
 		tracker:   tracker,
-		cancel:    cancel,
 		image:     isImageAPIMethod(method),
 	}
 	if err := d.enqueue(job, priority); err != nil {
-		cancel()
 		return fmt.Errorf("enqueue websocket request: %w", err)
 	}
 	return nil

--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -249,6 +249,59 @@ func TestWebSocketPriorityDispatcherNotificationsDoNotReply(t *testing.T) {
 	require.Error(t, err, "JSON-RPC notifications must not receive responses")
 }
 
+func TestWebSocketRunJobStartsTimeoutAtExecution(t *testing.T) {
+	t.Parallel()
+
+	parentCtx, parentCancel := context.WithCancel(t.Context())
+	defer parentCancel()
+	d := &wsSessionDispatcher{
+		ctx:       parentCtx,
+		responses: make(chan *wsResponseJob, 1),
+	}
+
+	started := time.Now()
+	remainingCh := make(chan time.Duration, 1)
+	var methodMap MethodMap
+	require.NoError(t, methodMap.AddMethod("test.timeout", func(env requests.RequestEnv) (any, error) {
+		deadline, ok := env.Context.Deadline()
+		require.True(t, ok, "runJob should install per-request deadline")
+		started = time.Now()
+		remainingCh <- time.Until(deadline)
+		return map[string]string{"ok": "true"}, nil
+	}))
+
+	enqueuedCtx, enqueuedCancel := context.WithTimeout(parentCtx, time.Millisecond)
+	defer enqueuedCancel()
+	job := &wsRequestJob{
+		methodMap: &methodMap,
+		env:       &requests.RequestEnv{Context: enqueuedCtx},
+		method:    "test.timeout",
+		msg:       []byte(`{"jsonrpc":"2.0","method":"test.timeout","id":1}`),
+	}
+	time.Sleep(25 * time.Millisecond)
+	require.Error(t, enqueuedCtx.Err(), "pre-existing enqueue-time context should be expired")
+
+	d.runJob(job)
+	require.NotNil(t, job.cancel, "runJob should install cancel func")
+	defer job.cancel()
+
+	select {
+	case remaining := <-remainingCh:
+		assert.Greater(t, remaining, config.APIRequestTimeout-250*time.Millisecond)
+		assert.WithinDuration(t, time.Now(), started, 250*time.Millisecond)
+	case <-time.After(time.Second):
+		t.Fatal("handler did not run")
+	}
+
+	select {
+	case resp := <-d.responses:
+		require.NotNil(t, resp.cancel)
+		assert.True(t, resp.result.ShouldReply)
+	case <-time.After(time.Second):
+		t.Fatal("response was not queued")
+	}
+}
+
 func TestCloseWSDispatcherCancelsQueuedRequests(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -267,10 +267,12 @@ type BrowseDirectoriesOptions struct {
 
 // BrowseCursor holds the keyset pagination state for browse queries.
 // SortValue is the value of the sort column (Name or Path) from the last
-// result, and LastID is the DBID tiebreaker.
+// result, LastID is the DBID tiebreaker, and TotalFiles carries the first-page
+// count so cursor pages do not need to rerun the same count query.
 type BrowseCursor struct {
-	SortValue string
-	LastID    int64
+	SortValue  string
+	LastID     int64
+	TotalFiles int
 }
 
 // BrowseFilesOptions contains parameters for the BrowseFiles query.

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -323,8 +323,10 @@ func (db *MediaDB) GetScrapedMediaCount(ctx context.Context, scraperID string) (
 	return count, nil
 }
 
-// GetTotalScrapedMediaCount returns the number of distinct media rows marked as
-// successfully scraped by any scraper.
+// GetTotalScrapedMediaCount returns the number of distinct media rows with
+// scraper metadata. Sentinel tags are included, but the count also covers rows
+// whose title/media properties were written by scrapers so metadata remains
+// reflected after reindex paths that preserve properties but rebuild media tags.
 func (db *MediaDB) GetTotalScrapedMediaCount(ctx context.Context) (int, error) {
 	if db.sql == nil {
 		return 0, ErrNullSQL
@@ -334,7 +336,7 @@ func (db *MediaDB) GetTotalScrapedMediaCount(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to find scraper sentinel tags: %w", err)
 	}
-	count, err := countMediaTagsForTagDBIDs(ctx, db.sql, tagDBIDs)
+	count, err := countScrapedMediaCoverage(ctx, db.sql, tagDBIDs)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count scraped media: %w", err)
 	}
@@ -454,6 +456,31 @@ func countMediaTagsForTagDBIDs(ctx context.Context, db *sql.DB, tagDBIDs []int64
 	query := `SELECT COUNT(DISTINCT MediaDBID) FROM MediaTags WHERE TagDBID IN (` + placeholders + `)`
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("failed to count media tag rows: %w", err)
+	}
+	return count, nil
+}
+
+func countScrapedMediaCoverage(ctx context.Context, db *sql.DB, tagDBIDs []int64) (int, error) {
+	queries := []string{
+		`SELECT MediaDBID FROM MediaProperties`,
+		`SELECT m.DBID
+			FROM Media m
+			JOIN MediaTitleProperties p ON p.MediaTitleDBID = m.MediaTitleDBID`,
+	}
+	args := make([]any, 0, len(tagDBIDs))
+	if len(tagDBIDs) > 0 {
+		placeholders := prepareVariadic("?", ",", len(tagDBIDs))
+		queries = append(queries, `SELECT MediaDBID FROM MediaTags WHERE TagDBID IN (`+placeholders+`)`)
+		for _, tagDBID := range tagDBIDs {
+			args = append(args, tagDBID)
+		}
+	}
+
+	var count int
+	//nolint:gosec // Safe: queries are static plus generated placeholders.
+	query := `SELECT COUNT(*) FROM (` + strings.Join(queries, ` UNION `) + `)`
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count scraped media coverage: %w", err)
 	}
 	return count, nil
 }

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -513,6 +513,26 @@ func TestGetTotalScrapedMediaCount_DistinctMedia(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
+func TestGetTotalScrapedMediaCount_IncludesTitlePropertyCoverage(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath2 := filepath.ToSlash(filepath.Join("roms", "zelda-rev-a.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 1, 1, ?);
+	`, mediaPath2)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, 1, []database.MediaProperty{
+		{TypeTag: "property:description", Text: "scraped metadata"},
+	}))
+
+	count, err := mediaDB.GetTotalScrapedMediaCount(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
 func TestGetTotalScrapedMediaCount_MissingSentinelsReturnsZero(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -533,6 +533,26 @@ func TestGetTotalScrapedMediaCount_IncludesTitlePropertyCoverage(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
+func TestGetTotalScrapedMediaCount_IncludesOnlyMediaPropertyRow(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath2 := filepath.ToSlash(filepath.Join("roms", "mario-rev-a.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 1, 1, ?);
+	`, mediaPath2)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, 1, []database.MediaProperty{
+		{TypeTag: "property:description", Text: "media-only scraped metadata"},
+	}))
+
+	count, err := mediaDB.GetTotalScrapedMediaCount(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
 func TestGetTotalScrapedMediaCount_MissingSentinelsReturnsZero(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -93,11 +93,13 @@ var mediaDirCandidates = map[string][]string{
 	string(tags.TagPropertyImageThumbnail): {
 		"thumbnail", "thumbnails", "box2dfront", "boxart2dfront", "supporttexture",
 	},
-	string(tags.TagPropertyImageMarquee):   {"marquee", "marquees"},
-	string(tags.TagPropertyImageWheel):     {"wheel", "wheels", "logo", "logos"},
-	string(tags.TagPropertyImageFanart):    {"fanart", "fanarts"},
-	string(tags.TagPropertyImageTitleshot): {"titleshot", "titleshots", "titlescreen", "titlescreens", "screenshottitle"},
-	string(tags.TagPropertyImageMap):       {"map", "maps"},
+	string(tags.TagPropertyImageMarquee): {"marquee", "marquees"},
+	string(tags.TagPropertyImageWheel):   {"wheel", "wheels", "logo", "logos"},
+	string(tags.TagPropertyImageFanart):  {"fanart", "fanarts"},
+	string(tags.TagPropertyImageTitleshot): {
+		"titleshot", "titleshots", "titlescreen", "titlescreens", "screenshottitle",
+	},
+	string(tags.TagPropertyImageMap): {"map", "maps"},
 }
 
 // GamelistXMLScraper loads and maps EmulationStation gamelist.xml records.
@@ -424,7 +426,9 @@ outer:
 
 			pathMedia, matchedPathKey, pathOK := matchMediaByResolvedPath(indexes.MediaByPathFold, resolved)
 
-			if title, ok := indexes.TitlesBySlug[pf.Slug]; ok {
+			title, titleOK := indexes.TitlesBySlug[pf.Slug]
+			switch {
+			case titleOK:
 				if pathOK && pathMedia.MediaTitleDBID == title.DBID {
 					slugMatches++
 					slugPathSelections++
@@ -472,7 +476,7 @@ outer:
 					MediaLevelWriteSafe: mediaLevelWriteSafe,
 				})
 				delete(indexes.TitlesBySlug, pf.Slug)
-			} else if pathOK {
+			case pathOK:
 				pathOnlyFallbacks++
 				log.Debug().
 					Str("system", system.ID).
@@ -493,7 +497,7 @@ outer:
 					MediaLevelWriteSafe: true,
 				})
 				delete(indexes.MediaByPathFold, matchedPathKey)
-			} else if titleSlugKnown(indexes, pf.Slug) {
+			case titleSlugKnown(indexes, pf.Slug):
 				unmatchedRecords++
 				log.Debug().
 					Str("system", system.ID).
@@ -502,7 +506,7 @@ outer:
 					Str("name", game.Name).
 					Str("slug", pf.Slug).
 					Msg("gamelistxml: slug exists for another or already-scraped title, skipping path-only fallback")
-			} else {
+			default:
 				unmatchedRecords++
 			}
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -81,9 +81,11 @@ type slugMediaSelection struct {
 // media sub-directory names (under <systemRootPath>/media/) that may hold
 // artwork for that property. The first matching directory that contains the
 // expected filename wins.
+var fallbackArtworkExtensions = []string{".png", ".jpg", ".jpeg", ".webp"}
+
 var mediaDirCandidates = map[string][]string{
 	string(tags.TagPropertyImageImage):      {"image", "images"},
-	string(tags.TagPropertyImageBoxart):     {"boxart", "boxart2d", "boxart2dfront", "box2dfront"},
+	string(tags.TagPropertyImageBoxart):     {"boxart", "boxart2d", "box2d", "boxart2dfront", "box2dfront"},
 	string(tags.TagPropertyImageBoxart3D):   {"boxart3d"},
 	string(tags.TagPropertyImageBoxartSide): {"boxart2dside"},
 	string(tags.TagPropertyImageBoxartBack): {"boxart2dback"},
@@ -92,9 +94,9 @@ var mediaDirCandidates = map[string][]string{
 		"thumbnail", "thumbnails", "box2dfront", "boxart2dfront", "supporttexture",
 	},
 	string(tags.TagPropertyImageMarquee):   {"marquee", "marquees"},
-	string(tags.TagPropertyImageWheel):     {"wheel", "wheels"},
+	string(tags.TagPropertyImageWheel):     {"wheel", "wheels", "logo", "logos"},
 	string(tags.TagPropertyImageFanart):    {"fanart", "fanarts"},
-	string(tags.TagPropertyImageTitleshot): {"titleshot", "titleshots", "screenshottitle"},
+	string(tags.TagPropertyImageTitleshot): {"titleshot", "titleshots", "titlescreen", "titlescreens", "screenshottitle"},
 	string(tags.TagPropertyImageMap):       {"map", "maps"},
 }
 
@@ -420,7 +422,25 @@ outer:
 				ProvidedName: game.Name,
 			})
 
+			pathMedia, matchedPathKey, pathOK := matchMediaByResolvedPath(indexes.MediaByPathFold, resolved)
+
 			if title, ok := indexes.TitlesBySlug[pf.Slug]; ok {
+				if pathOK && pathMedia.MediaTitleDBID == title.DBID {
+					slugMatches++
+					slugPathSelections++
+					records = append(records, &GamelistRecord{
+						SystemRootPath:      file.RootPath,
+						AvailableMediaDirs:  file.AvailableMediaDirs,
+						Game:                *game,
+						MatchKind:           gamelistMatchSlugPath,
+						MatchedTitleDBID:    title.DBID,
+						MatchedMediaDBID:    pathMedia.DBID,
+						MediaLevelWriteSafe: true,
+					})
+					delete(indexes.MediaByPathFold, matchedPathKey)
+					continue
+				}
+
 				selection := selectMediaForSlugMatch(indexes, title.DBID, resolved)
 				if selection.media.DBID == 0 {
 					log.Debug().
@@ -452,6 +472,27 @@ outer:
 					MediaLevelWriteSafe: mediaLevelWriteSafe,
 				})
 				delete(indexes.TitlesBySlug, pf.Slug)
+			} else if pathOK {
+				pathOnlyFallbacks++
+				log.Debug().
+					Str("system", system.ID).
+					Str("path", game.Path).
+					Str("resolved", resolved).
+					Str("name", game.Name).
+					Str("slug", pf.Slug).
+					Int64("mediaDBID", pathMedia.DBID).
+					Int64("mediaTitleDBID", pathMedia.MediaTitleDBID).
+					Msg("gamelistxml: path-only fallback matched record")
+				records = append(records, &GamelistRecord{
+					SystemRootPath:      file.RootPath,
+					AvailableMediaDirs:  file.AvailableMediaDirs,
+					Game:                *game,
+					MatchKind:           gamelistMatchPathOnly,
+					MatchedTitleDBID:    pathMedia.MediaTitleDBID,
+					MatchedMediaDBID:    pathMedia.DBID,
+					MediaLevelWriteSafe: true,
+				})
+				delete(indexes.MediaByPathFold, matchedPathKey)
 			} else if titleSlugKnown(indexes, pf.Slug) {
 				unmatchedRecords++
 				log.Debug().
@@ -461,27 +502,6 @@ outer:
 					Str("name", game.Name).
 					Str("slug", pf.Slug).
 					Msg("gamelistxml: slug exists for another or already-scraped title, skipping path-only fallback")
-			} else if media, matchedKey, ok := matchMediaByResolvedPath(indexes.MediaByPathFold, resolved); ok {
-				pathOnlyFallbacks++
-				log.Debug().
-					Str("system", system.ID).
-					Str("path", game.Path).
-					Str("resolved", resolved).
-					Str("name", game.Name).
-					Str("slug", pf.Slug).
-					Int64("mediaDBID", media.DBID).
-					Int64("mediaTitleDBID", media.MediaTitleDBID).
-					Msg("gamelistxml: path-only fallback matched record")
-				records = append(records, &GamelistRecord{
-					SystemRootPath:      file.RootPath,
-					AvailableMediaDirs:  file.AvailableMediaDirs,
-					Game:                *game,
-					MatchKind:           gamelistMatchPathOnly,
-					MatchedTitleDBID:    media.MediaTitleDBID,
-					MatchedMediaDBID:    media.DBID,
-					MediaLevelWriteSafe: true,
-				})
-				delete(indexes.MediaByPathFold, matchedKey)
 			} else {
 				unmatchedRecords++
 			}
@@ -1327,7 +1347,7 @@ func findMediaFileProp(
 	if stem == "" || stem == "." {
 		return nil
 	}
-	return findMediaFilePropFS(afero.NewOsFs(), typeTag, []string{stem + ".png"}, candidates, availableDirs)
+	return findMediaFilePropFS(afero.NewOsFs(), typeTag, fallbackArtworkNames(stem), candidates, availableDirs)
 }
 
 func artworkFallbackNames(gamePath, systemRootPath string) []string {
@@ -1350,17 +1370,32 @@ func artworkFallbackNames(gamePath, systemRootPath string) []string {
 		return nil
 	}
 
-	flat := stem + ".png"
+	flatNames := fallbackArtworkNames(stem)
 	dir := filepath.Dir(rel)
 	if dir == "." || dir == "" {
-		return []string{flat}
+		return flatNames
 	}
 
-	nested := filepath.Join(dir, flat)
-	if nested == flat {
-		return []string{flat}
+	fallbackNames := make([]string, 0, len(flatNames)*2)
+	for _, flat := range flatNames {
+		nested := filepath.Join(dir, flat)
+		if nested != flat {
+			fallbackNames = append(fallbackNames, nested)
+		}
 	}
-	return []string{nested, flat}
+	fallbackNames = append(fallbackNames, flatNames...)
+	return fallbackNames
+}
+
+func fallbackArtworkNames(stem string) []string {
+	if stem == "" || stem == "." {
+		return nil
+	}
+	names := make([]string, 0, len(fallbackArtworkExtensions))
+	for _, ext := range fallbackArtworkExtensions {
+		names = append(names, stem+ext)
+	}
+	return names
 }
 
 func findMediaFilePropFS(
@@ -1389,7 +1424,7 @@ func findMediaFilePropFS(
 				return &database.MediaProperty{
 					TypeTag:     typeTag,
 					Text:        filepath.ToSlash(candidate),
-					ContentType: "image/png",
+					ContentType: mimeFromExt(candidate),
 				}
 			}
 		}

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -515,7 +515,37 @@ func TestLoadRecords_SlugMatchSelectsExactMediaPath(t *testing.T) {
 	assert.True(t, records[0].MediaLevelWriteSafe)
 }
 
-func TestLoadRecords_SkipsPathOnlyFallbackWhenSlugKnown(t *testing.T) {
+func TestLoadRecords_DuplicateNameExactPathsAllMediaSafe(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	disc1Path := filepath.Join(root, "Game (Disc 1).cue")
+	disc2Path := filepath.Join(root, "Game (Disc 2).cue")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./Game (Disc 1).cue</path><name>Game</name></game>
+  <game><path>./Game (Disc 2).cue</path><name>Game</name></game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 60, MediaTitleDBID: 50, Path: disc1Path},
+			database.Media{DBID: 61, MediaTitleDBID: 50, Path: disc2Path}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, int64(60), records[0].MatchedMediaDBID)
+	assert.Equal(t, int64(61), records[1].MatchedMediaDBID)
+	for _, record := range records {
+		assert.Equal(t, int64(50), record.MatchedTitleDBID)
+		assert.Equal(t, gamelistMatchSlugPath, record.MatchKind)
+		assert.True(t, record.MediaLevelWriteSafe)
+	}
+}
+
+func TestLoadRecords_KnownSlugDoesNotBlockExactPathFallback(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -526,6 +556,34 @@ func TestLoadRecords_SkipsPathOnlyFallbackWhenSlugKnown(t *testing.T) {
 </gameList>`), 0o600))
 
 	indexes := mediaByPath(database.Media{DBID: 70, MediaTitleDBID: 80, Path: gamePath})
+	indexes.AllTitlesBySlug = map[string]database.MediaTitle{
+		"knowntitle": {DBID: 90, Slug: "knowntitle", Name: "Known Title"},
+	}
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}},
+		indexes,
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(80), records[0].MatchedTitleDBID)
+	assert.Equal(t, int64(70), records[0].MatchedMediaDBID)
+	assert.Equal(t, gamelistMatchPathOnly, records[0].MatchKind)
+	assert.True(t, records[0].MediaLevelWriteSafe)
+}
+
+func TestLoadRecords_SkipsPathOnlyFallbackWhenSlugKnownWithoutExactPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	indexedPath := filepath.Join(root, "indexed.nes")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./conflict.nes</path><name>Known Title</name></game>
+</gameList>`), 0o600))
+
+	indexes := mediaByPath(database.Media{DBID: 70, MediaTitleDBID: 80, Path: indexedPath})
 	indexes.AllTitlesBySlug = map[string]database.MediaTitle{
 		"knowntitle": {DBID: 90, Slug: "knowntitle", Name: "Known Title"},
 	}
@@ -1215,6 +1273,78 @@ func TestMapToDB_FilesystemFallback_Boxart(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "filesystem fallback boxart property missing")
+}
+
+func TestMapToDB_FallbackFindsBox2DLogoTitleScreenDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	box2DDir := filepath.Join(root, "media", "box2d")
+	logoDir := filepath.Join(root, "media", "logo")
+	titleScreenDir := filepath.Join(root, "media", "titlescreen")
+	for _, dir := range []string{box2DDir, logoDir, titleScreenDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o750))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "Game.png"), []byte{}, 0o600))
+	}
+
+	rec := GamelistRecord{
+		SystemRootPath: root,
+		AvailableMediaDirs: map[string]string{
+			"box2d":       box2DDir,
+			"logo":        logoDir,
+			"titlescreen": titleScreenDir,
+		},
+		Game: esapi.Game{Path: "./Game.nes"},
+	}
+
+	result := (&GamelistXMLScraper{}).MapToDB(&rec)
+	props := map[string]string{}
+	for _, p := range result.MediaProps {
+		props[p.TypeTag] = p.Text
+	}
+
+	propType := string(tags.TagTypeProperty) + ":"
+	assert.Equal(t,
+		filepath.ToSlash(filepath.Join(box2DDir, "Game.png")),
+		props[propType+string(tags.TagPropertyImageBoxart)],
+	)
+	assert.Equal(t,
+		filepath.ToSlash(filepath.Join(logoDir, "Game.png")),
+		props[propType+string(tags.TagPropertyImageWheel)],
+	)
+	assert.Equal(t,
+		filepath.ToSlash(filepath.Join(titleScreenDir, "Game.png")),
+		props[propType+string(tags.TagPropertyImageTitleshot)],
+	)
+}
+
+func TestMapToDB_FallbackFindsJPGMediaFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	imgDir := filepath.Join(root, "media", "images")
+	imgPath := filepath.Join(imgDir, "Game.jpg")
+	require.NoError(t, os.MkdirAll(imgDir, 0o750))
+	require.NoError(t, os.WriteFile(imgPath, []byte{}, 0o600))
+
+	rec := GamelistRecord{
+		SystemRootPath:     root,
+		AvailableMediaDirs: map[string]string{"images": imgDir},
+		Game:               esapi.Game{Path: "./Game.nes"},
+	}
+
+	result := (&GamelistXMLScraper{}).MapToDB(&rec)
+
+	propKey := string(tags.TagTypeProperty) + ":" + string(tags.TagPropertyImageImage)
+	var found bool
+	for _, p := range result.MediaProps {
+		if p.TypeTag == propKey {
+			found = true
+			assert.Equal(t, filepath.ToSlash(imgPath), p.Text)
+			assert.Equal(t, "image/jpeg", p.ContentType)
+		}
+	}
+	assert.True(t, found, "jpg filesystem fallback image property missing")
 }
 
 func TestMapToDB_FilesystemFallback_XMLWins(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix gamelist.xml matching so duplicate-name exact paths all receive media-level artwork
- support zapscraper fallback artwork folders/extensions
- make browse pagination more reliable under queued websocket load and large directories
- report scraped status from actual metadata coverage and expose active force scrapes
- stabilize encryption block-expiry test that was failing on main CI

Validated locally with focused Go package tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added force scraping option for media indexing
  * Optimized pagination by carrying total file counts across pages
  * Enhanced artwork discovery with multi-format and nested-directory fallbacks

* **Bug Fixes**
  * Improved WebSocket request timeout handling at execution time
  * Corrected scraped media counting to include title/property coverage

* **Tests**
  * Added/expanded tests for forced scrapes, cursor file-count reuse, artwork fallbacks, and websocket timeout behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->