### PR TITLE
perf(api): harden media browsing under image load

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -470,6 +470,7 @@ func GenerateMediaDB(
 			return
 		}
 		log.Info().Msg("finished generating media db successfully")
+		mediaImageNoImages.clear()
 		notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 			Exists:     true,
 			Indexing:   false,

--- a/pkg/api/methods/media_alias.go
+++ b/pkg/api/methods/media_alias.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 )
 
 func singletonMediaAliasesEnabled(env *requests.RequestEnv) bool {
@@ -65,14 +66,16 @@ func equivalentMediaIDs(env *requests.RequestEnv, row *database.MediaFullRow) ([
 		ids = append(ids, media.DBID)
 	}
 
-	child, err := env.Database.MediaDB.FindSingleDescendantMedia(env.Context, row.System.DBID, row.Path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find child alias media: %w", err)
+	if helpers.IsZip(row.Path) {
+		child, err := env.Database.MediaDB.FindSingleDescendantMedia(env.Context, row.System.DBID, row.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find child alias media: %w", err)
+		}
+		add(child)
 	}
-	add(child)
 
 	parentPath := strings.TrimSuffix(row.ParentDir, "/")
-	if parentPath == "" || parentPath == row.Path {
+	if parentPath == "" || parentPath == row.Path || !helpers.IsZip(parentPath) {
 		return ids, nil
 	}
 

--- a/pkg/api/methods/media_alias_test.go
+++ b/pkg/api/methods/media_alias_test.go
@@ -72,8 +72,6 @@ func TestEquivalentMediaIDsParentChildAliases(t *testing.T) {
 	}
 	parent := &database.Media{DBID: 10, Path: "roms/Game.zip"}
 
-	mockDB.On("FindSingleDescendantMedia", mock.Anything, int64(1), row.Path).
-		Return((*database.Media)(nil), nil)
 	mockDB.On("FindSingleDescendantMedia", mock.Anything, int64(1), "roms/Game.zip").
 		Return(&database.Media{DBID: 20, Path: row.Path}, nil)
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, int64(1), "roms/Game.zip").Return(parent, nil)
@@ -102,22 +100,24 @@ func TestEquivalentMediaIDsSkipsEmptyOrSelfParent(t *testing.T) {
 		Platform: platform,
 	}
 
-	for _, row := range []*database.MediaFullRow{
-		{
-			Media:  database.Media{DBID: 20, Path: "roms/Game.nes"},
-			System: database.System{DBID: 1},
-		},
-		{
-			Media:  database.Media{DBID: 21, Path: "roms/Game.zip", ParentDir: "roms/Game.zip/"},
-			System: database.System{DBID: 1},
-		},
-	} {
-		mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, row.Path).
-			Return((*database.Media)(nil), nil).Once()
-		ids, err := equivalentMediaIDs(env, row)
-		require.NoError(t, err)
-		assert.Equal(t, []int64{row.DBID}, ids)
+	plain := &database.MediaFullRow{
+		Media:  database.Media{DBID: 20, Path: "roms/Game.nes"},
+		System: database.System{DBID: 1},
 	}
+	ids, err := equivalentMediaIDs(env, plain)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{plain.DBID}, ids)
+	mockDB.AssertNotCalled(t, "FindSingleDescendantMedia", mock.Anything, plain.System.DBID, plain.Path)
+
+	zipSelf := &database.MediaFullRow{
+		Media:  database.Media{DBID: 21, Path: "roms/Game.zip", ParentDir: "roms/Game.zip/"},
+		System: database.System{DBID: 1},
+	}
+	mockDB.On("FindSingleDescendantMedia", mock.Anything, zipSelf.System.DBID, zipSelf.Path).
+		Return((*database.Media)(nil), nil).Once()
+	ids, err = equivalentMediaIDs(env, zipSelf)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{zipSelf.DBID}, ids)
 
 	mockDB.AssertExpectations(t)
 	platform.AssertExpectations(t)

--- a/pkg/api/methods/media_alias_test.go
+++ b/pkg/api/methods/media_alias_test.go
@@ -107,7 +107,7 @@ func TestEquivalentMediaIDsSkipsEmptyOrSelfParent(t *testing.T) {
 	ids, err := equivalentMediaIDs(env, plain)
 	require.NoError(t, err)
 	assert.Equal(t, []int64{plain.DBID}, ids)
-	mockDB.AssertNotCalled(t, "FindSingleDescendantMedia", mock.Anything, plain.System.DBID, plain.Path)
+	mockDB.AssertNumberOfCalls(t, "FindSingleDescendantMedia", 0)
 
 	zipSelf := &database.MediaFullRow{
 		Media:  database.Media{DBID: 21, Path: "roms/Game.zip", ParentDir: "roms/Game.zip/"},

--- a/pkg/api/methods/media_history_test.go
+++ b/pkg/api/methods/media_history_test.go
@@ -154,6 +154,32 @@ func TestHandleMediaHistory_WithMediaIDAndRelativePath(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestMediaResponseMediaIDs_BoundsSlowLookup(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "slow.nes")
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil).Once()
+	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
+		Run(func(args mock.Arguments) {
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			<-ctx.Done()
+		}).
+		Return(nil, context.DeadlineExceeded).
+		Once()
+
+	started := time.Now()
+	mediaIDs := mediaResponseMediaIDs(&requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}, []mediaPathRef{{SystemID: "NES", Path: mediaPath}})
+
+	assert.Less(t, time.Since(started), 2*time.Second)
+	assert.Empty(t, mediaIDs)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaHistory_WithLimit(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -29,11 +29,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/rs/zerolog/log"
@@ -43,7 +45,12 @@ import (
 const (
 	misterMediaImageMaxBytes  = int64(2 * 1024 * 1024)
 	defaultMediaImageMaxBytes = int64(8 * 1024 * 1024)
+	mediaImageNoImageMax      = 4096
 )
+
+// mediaImageSem limits concurrent image lookups so high-volume image misses do
+// not saturate SQLite and starve browse/status calls.
+var mediaImageSem = make(chan struct{}, 1)
 
 // defaultImageTypes is the preference order used when no imageTypes param is provided.
 var defaultImageTypes = []string{
@@ -77,8 +84,85 @@ type mediaImageSource struct {
 	isMedia bool
 }
 
+type mediaImageNotFoundError struct {
+	system string
+	path   string
+}
+
+type mediaImageNoImageCache struct {
+	mu      syncutil.Mutex
+	entries map[string]error
+}
+
+var mediaImageNoImages = &mediaImageNoImageCache{entries: make(map[string]error)}
+
 func (e *mediaBinaryTooLargeError) Error() string {
 	return fmt.Sprintf("media binary %q is too large: %d bytes exceeds %d byte limit", e.path, e.size, e.max)
+}
+
+func (e *mediaImageNotFoundError) Error() string {
+	return fmt.Sprintf("no image found for media: system=%q path=%q", e.system, filepath.ToSlash(e.path))
+}
+
+func mediaImageNoImageMediaIDKey(mediaID int64, prefs []string) string {
+	return fmt.Sprintf("id:%d\x00%s", mediaID, strings.Join(prefs, "\x00"))
+}
+
+func mediaImageNoImagePathKey(system, path string, prefs []string) string {
+	return fmt.Sprintf("path:%s\x00%s\x00%s", system, filepath.ToSlash(path), strings.Join(prefs, "\x00"))
+}
+
+func mediaImageNoImageRequestKey(ref mediaRefParam, prefs []string) string {
+	if ref.MediaID != nil {
+		return mediaImageNoImageMediaIDKey(*ref.MediaID, prefs)
+	}
+	return mediaImageNoImagePathKey(ref.System, ref.Path, prefs)
+}
+
+func (c *mediaImageNoImageCache) get(key string) (error, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	err, ok := c.entries[key]
+	return err, ok
+}
+
+func (c *mediaImageNoImageCache) add(key string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if len(c.entries) >= mediaImageNoImageMax {
+		for existing := range c.entries {
+			delete(c.entries, existing)
+			break
+		}
+	}
+
+	var noImage *mediaImageNotFoundError
+	if errors.As(err, &noImage) {
+		c.entries[key] = noImage
+		return
+	}
+	c.entries[key] = err
+}
+
+func (c *mediaImageNoImageCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]error)
+}
+
+func mediaImageNoImageError(row *database.MediaFullRow) error {
+	return models.QuietClientErr(&mediaImageNotFoundError{system: row.System.SystemID, path: row.Path})
+}
+
+func cachedMediaImageNoImageError(err error) error {
+	return models.QuietClientErr(err)
+}
+
+func isMediaImageNoImageError(err error) bool {
+	var noImage *mediaImageNotFoundError
+	return errors.As(err, &noImage)
 }
 
 // resolveImageTypeTag converts a short image type name to the full property TypeTag.
@@ -124,10 +208,25 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	if err != nil {
 		return nil, err
 	}
+	prefs := imagePrefs(nil, ref.ImageTypes)
+	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
+	if err, ok := mediaImageNoImages.get(noImageKey); ok {
+		return nil, cachedMediaImageNoImageError(err)
+	}
+
+	select {
+	case mediaImageSem <- struct{}{}:
+		defer func() { <-mediaImageSem }()
+	case <-env.Context.Done():
+		return nil, env.Context.Err()
+	}
+	if err, ok := mediaImageNoImages.get(noImageKey); ok {
+		return nil, cachedMediaImageNoImageError(err)
+	}
 
 	maxBytes := mediaImageMaxBytes(env.Platform)
 	if ref.MediaID == nil {
-		return handleMediaImageSinglePath(&env, ref, maxBytes)
+		return handleMediaImageSinglePath(&env, ref, prefs, noImageKey, maxBytes)
 	}
 
 	resolved, err := resolveMediaRefs(&env, []mediaRefParam{ref})
@@ -149,10 +248,13 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		return nil, fmt.Errorf("failed to get title properties: %w", err)
 	}
 
-	prefs := imagePrefs(nil, ref.ImageTypes)
-	return selectMediaImageFromSources(
+	image, err := selectMediaImageFromSources(
 		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
 	)
+	if isMediaImageNoImageError(err) {
+		mediaImageNoImages.add(noImageKey, err)
+	}
+	return image, err
 }
 
 func parseMediaImageRequest(raw json.RawMessage) (mediaRefParam, error) {
@@ -171,7 +273,13 @@ func parseMediaImageRequest(raw json.RawMessage) (mediaRefParam, error) {
 	return ref, nil
 }
 
-func handleMediaImageSinglePath(env *requests.RequestEnv, ref mediaRefParam, maxBytes int64) (any, error) {
+func handleMediaImageSinglePath(
+	env *requests.RequestEnv,
+	ref mediaRefParam,
+	prefs []string,
+	noImageKey string,
+	maxBytes int64,
+) (any, error) {
 	db := env.Database.MediaDB
 	row, err := resolveMediaBySystemAndPath(env, ref.System, ref.Path)
 	if err != nil {
@@ -187,9 +295,13 @@ func handleMediaImageSinglePath(env *requests.RequestEnv, ref mediaRefParam, max
 		return nil, fmt.Errorf("failed to get title properties: %w", err)
 	}
 
-	return selectMediaImageFromSources(
-		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, imagePrefs(nil, ref.ImageTypes), maxBytes,
+	image, err := selectMediaImageFromSources(
+		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
 	)
+	if isMediaImageNoImageError(err) {
+		mediaImageNoImages.add(noImageKey, err)
+	}
+	return image, err
 }
 
 func imagePrefs(topLevel, itemLevel []string) []string {
@@ -321,9 +433,7 @@ func selectMediaImageFromSources(
 		Strs("titleImageProps", imagePropertyTypeTags(titleProps)).
 		Msg("media.image: no image found")
 
-	return models.MediaImageResponse{}, models.ClientErrf(
-		"no image found for media: system=%q path=%q", row.System.SystemID, filepath.ToSlash(row.Path),
-	)
+	return models.MediaImageResponse{}, mediaImageNoImageError(row)
 }
 
 func loadMediaImageProperty(

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -90,8 +90,8 @@ type mediaImageNotFoundError struct {
 }
 
 type mediaImageNoImageCache struct {
-	mu      syncutil.Mutex
 	entries map[string]error
+	mu      syncutil.Mutex
 }
 
 var mediaImageNoImages = &mediaImageNoImageCache{entries: make(map[string]error)}
@@ -119,12 +119,12 @@ func mediaImageNoImageRequestKey(ref mediaRefParam, prefs []string) string {
 	return mediaImageNoImagePathKey(ref.System, ref.Path, prefs)
 }
 
-func (c *mediaImageNoImageCache) get(key string) (error, bool) {
+func (c *mediaImageNoImageCache) get(key string) (bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	err, ok := c.entries[key]
-	return err, ok
+	return ok, err
 }
 
 func (c *mediaImageNoImageCache) add(key string, err error) {
@@ -153,11 +153,11 @@ func (c *mediaImageNoImageCache) clear() {
 }
 
 func mediaImageNoImageError(row *database.MediaFullRow) error {
-	return models.QuietClientErr(&mediaImageNotFoundError{system: row.System.SystemID, path: row.Path})
+	return fmt.Errorf("%w", models.QuietClientErr(&mediaImageNotFoundError{system: row.System.SystemID, path: row.Path}))
 }
 
 func cachedMediaImageNoImageError(err error) error {
-	return models.QuietClientErr(err)
+	return fmt.Errorf("%w", models.QuietClientErr(err))
 }
 
 func isMediaImageNoImageError(err error) bool {
@@ -210,8 +210,8 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	}
 	prefs := imagePrefs(nil, ref.ImageTypes)
 	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
-	if err, ok := mediaImageNoImages.get(noImageKey); ok {
-		return nil, cachedMediaImageNoImageError(err)
+	if ok, cachedErr := mediaImageNoImages.get(noImageKey); ok {
+		return nil, cachedMediaImageNoImageError(cachedErr)
 	}
 
 	select {
@@ -220,8 +220,8 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	case <-env.Context.Done():
 		return nil, env.Context.Err()
 	}
-	if err, ok := mediaImageNoImages.get(noImageKey); ok {
-		return nil, cachedMediaImageNoImageError(err)
+	if ok, cachedErr := mediaImageNoImages.get(noImageKey); ok {
+		return nil, cachedMediaImageNoImageError(cachedErr)
 	}
 
 	maxBytes := mediaImageMaxBytes(env.Platform)

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -52,6 +52,8 @@ const (
 // not saturate SQLite and starve browse/status calls.
 var mediaImageSem = make(chan struct{}, 1)
 
+var mediaImageBeforeSemAcquire func()
+
 // defaultImageTypes is the preference order used when no imageTypes param is provided.
 var defaultImageTypes = []string{
 	"image", "thumbnail", "boxart", "boxart3d", "screenshot", "wheel", "titleshot", "map",
@@ -85,8 +87,9 @@ type mediaImageSource struct {
 }
 
 type mediaImageNotFoundError struct {
-	system string
-	path   string
+	system                      string
+	path                        string
+	fileBackedCandidatesChecked bool
 }
 
 type mediaImageNoImageCache struct {
@@ -152,8 +155,12 @@ func (c *mediaImageNoImageCache) clear() {
 	c.entries = make(map[string]error)
 }
 
-func mediaImageNoImageError(row *database.MediaFullRow) error {
-	noImage := &mediaImageNotFoundError{system: row.System.SystemID, path: row.Path}
+func mediaImageNoImageError(row *database.MediaFullRow, fileBackedCandidatesChecked bool) error {
+	noImage := &mediaImageNotFoundError{
+		system:                      row.System.SystemID,
+		path:                        row.Path,
+		fileBackedCandidatesChecked: fileBackedCandidatesChecked,
+	}
 	return fmt.Errorf("%w", models.QuietClientErr(noImage))
 }
 
@@ -161,9 +168,9 @@ func cachedMediaImageNoImageError(err error) error {
 	return fmt.Errorf("%w", models.QuietClientErr(err))
 }
 
-func isMediaImageNoImageError(err error) bool {
+func isCacheableMediaImageNoImageError(err error) bool {
 	var noImage *mediaImageNotFoundError
-	return errors.As(err, &noImage)
+	return errors.As(err, &noImage) && !noImage.fileBackedCandidatesChecked
 }
 
 // resolveImageTypeTag converts a short image type name to the full property TypeTag.
@@ -214,6 +221,9 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	if ok, cachedErr := mediaImageNoImages.get(noImageKey); ok {
 		return nil, cachedMediaImageNoImageError(cachedErr)
 	}
+	if mediaImageBeforeSemAcquire != nil {
+		mediaImageBeforeSemAcquire()
+	}
 
 	select {
 	case mediaImageSem <- struct{}{}:
@@ -252,7 +262,7 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	image, err := selectMediaImageFromSources(
 		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
 	)
-	if isMediaImageNoImageError(err) {
+	if isCacheableMediaImageNoImageError(err) {
 		mediaImageNoImages.add(noImageKey, err)
 	}
 	return image, err
@@ -299,7 +309,7 @@ func handleMediaImageSinglePath(
 	image, err := selectMediaImageFromSources(
 		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
 	)
-	if isMediaImageNoImageError(err) {
+	if isCacheableMediaImageNoImageError(err) {
 		mediaImageNoImages.add(noImageKey, err)
 	}
 	return image, err
@@ -392,6 +402,7 @@ func selectMediaImageFromSources(
 	}
 	sources = append(sources, mediaImageSource{buildPropsMap(titleProps), false})
 
+	fileBackedCandidatesChecked := false
 	seen := make(map[string]bool, len(prefs))
 	for _, t := range prefs {
 		typeTag, ok := resolveImageTypeTag(t)
@@ -406,6 +417,9 @@ func selectMediaImageFromSources(
 				continue
 			}
 
+			if prop.Text != "" {
+				fileBackedCandidatesChecked = true
+			}
 			image, stale, err := loadMediaImageProperty(ctx, fs, db, row, &prop, src, typeTag, maxBytes)
 			if stale {
 				delete(src.propMap, typeTag)
@@ -434,7 +448,7 @@ func selectMediaImageFromSources(
 		Strs("titleImageProps", imagePropertyTypeTags(titleProps)).
 		Msg("media.image: no image found")
 
-	return models.MediaImageResponse{}, mediaImageNoImageError(row)
+	return models.MediaImageResponse{}, mediaImageNoImageError(row, fileBackedCandidatesChecked)
 }
 
 func loadMediaImageProperty(

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -153,7 +153,8 @@ func (c *mediaImageNoImageCache) clear() {
 }
 
 func mediaImageNoImageError(row *database.MediaFullRow) error {
-	return fmt.Errorf("%w", models.QuietClientErr(&mediaImageNotFoundError{system: row.System.SystemID, path: row.Path}))
+	noImage := &mediaImageNotFoundError{system: row.System.SystemID, path: row.Path}
+	return fmt.Errorf("%w", models.QuietClientErr(noImage))
 }
 
 func cachedMediaImageNoImageError(err error) error {

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -455,6 +455,45 @@ func TestHandleMediaImage_NoImageCacheSkipsPropertyFetch(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaImage_MissingFileBackedImageIsNotCached(t *testing.T) {
+	mediaImageNoImages.clear()
+	t.Cleanup(mediaImageNoImages.clear)
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := makeMediaFullRow(408, 4080)
+	imagePath := filepath.Join(t.TempDir(), "boxart.png")
+	params := json.RawMessage(`{"mediaId":408,"imageTypes":["boxart"]}`)
+
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{row.DBID}).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil).Once()
+	mockDB.On("GetMediaProperties", mock.Anything, row.DBID).
+		Return([]database.MediaProperty{{TypeTag: "property:image-boxart", Text: imagePath}}, nil).Once()
+	mockDB.On("GetMediaTitleProperties", mock.Anything, row.Title.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+
+	env := makeMediaImageEnv(t, mockDB, params)
+	_, err := HandleMediaImage(env)
+	require.Error(t, err)
+	var noImage *mediaImageNotFoundError
+	require.ErrorAs(t, err, &noImage)
+
+	require.NoError(t, os.WriteFile(imagePath, []byte("boxart"), 0o600))
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{row.DBID}).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil).Once()
+	mockDB.On("GetMediaProperties", mock.Anything, row.DBID).
+		Return([]database.MediaProperty{{TypeTag: "property:image-boxart", Text: imagePath}}, nil).Once()
+	mockDB.On("GetMediaTitleProperties", mock.Anything, row.Title.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+
+	result, err := HandleMediaImage(env)
+	require.NoError(t, err)
+	resp, ok := result.(models.MediaImageResponse)
+	require.True(t, ok)
+	assert.Equal(t, "property:image-boxart", resp.TypeTag)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("boxart")), resp.Data)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaImage_NoImagePathCacheSkipsMediaDB(t *testing.T) {
 	mediaImageNoImages.clear()
 	t.Cleanup(mediaImageNoImages.clear)
@@ -515,6 +554,10 @@ func TestHandleMediaImage_NoImageCacheRecheckedAfterSemaphore(t *testing.T) {
 	prefs := imagePrefs(nil, ref.ImageTypes)
 	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
 
+	reachedSem := make(chan struct{})
+	mediaImageBeforeSemAcquire = func() { close(reachedSem) }
+	t.Cleanup(func() { mediaImageBeforeSemAcquire = nil })
+
 	done := make(chan error, 1)
 	env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
 	go func() {
@@ -522,7 +565,11 @@ func TestHandleMediaImage_NoImageCacheRecheckedAfterSemaphore(t *testing.T) {
 		done <- handleErr
 	}()
 
-	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-reachedSem:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for media image handler to reach semaphore")
+	}
 	mediaImageNoImages.add(
 		noImageKey,
 		&mediaImageNotFoundError{system: "NES", path: filepath.Join("games", "test-407.rom")},

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -365,8 +366,6 @@ func TestMediaImagePropSources_IncludesSingletonAliasSources(t *testing.T) {
 	parentPath := filepath.ToSlash(filepath.Join("roms", "Game.zip"))
 	parent := &database.Media{DBID: 10, Path: parentPath}
 
-	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, row.Path).
-		Return((*database.Media)(nil), nil).Once()
 	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, parentPath).
 		Return(&row.Media, nil).Once()
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, row.System.DBID, parentPath).
@@ -414,6 +413,147 @@ func TestHandleMediaImage_NoMatchFound(t *testing.T) {
 	assert.Contains(t, err.Error(), `path="/games/missing.rom"`)
 	assert.NotContains(t, err.Error(), "NES//games")
 	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaImage_NoImageCacheSkipsPropertyFetch(t *testing.T) {
+	mediaImageNoImages.clear()
+	t.Cleanup(mediaImageNoImages.clear)
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := makeMediaFullRow(404, 4040)
+
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{row.DBID}).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil).Once()
+	mockDB.On("GetMediaProperties", mock.Anything, row.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+	mockDB.On("GetMediaTitleProperties", mock.Anything, row.Title.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+
+	env := makeMediaImageEnv(t, mockDB, json.RawMessage(`{"mediaId":404,"imageTypes":["boxart"]}`))
+	_, err := HandleMediaImage(env)
+	require.Error(t, err)
+	var firstNoImage *mediaImageNotFoundError
+	require.ErrorAs(t, err, &firstNoImage)
+
+	_, err = HandleMediaImage(env)
+	require.Error(t, err)
+	var secondNoImage *mediaImageNotFoundError
+	require.ErrorAs(t, err, &secondNoImage)
+
+	mediaImageNoImages.clear()
+	mockDB.On("GetMediaProperties", mock.Anything, row.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+	mockDB.On("GetMediaTitleProperties", mock.Anything, row.Title.DBID).
+		Return([]database.MediaProperty{}, nil).Once()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{row.DBID}).
+		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil).Once()
+	_, err = HandleMediaImage(env)
+	require.Error(t, err)
+	var thirdNoImage *mediaImageNotFoundError
+	require.ErrorAs(t, err, &thirdNoImage)
+
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaImage_NoImagePathCacheSkipsMediaDB(t *testing.T) {
+	mediaImageNoImages.clear()
+	t.Cleanup(mediaImageNoImages.clear)
+
+	row := makeMediaFullRow(405, 4050)
+	params := mediaImageParams(row, `"imageTypes": ["boxart"]`)
+	ref, err := parseMediaImageRequest(params)
+	require.NoError(t, err)
+	prefs := imagePrefs(nil, ref.ImageTypes)
+	mediaImageNoImages.add(
+		mediaImageNoImageRequestKey(ref, prefs),
+		&mediaImageNotFoundError{system: row.System.SystemID, path: row.Path},
+	)
+
+	env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
+	_, err = HandleMediaImage(env)
+	require.Error(t, err)
+
+	var quietErr *models.QuietClientError
+	require.ErrorAs(t, err, &quietErr)
+	var noImage *mediaImageNotFoundError
+	require.ErrorAs(t, err, &noImage)
+}
+
+func TestHandleMediaImage_NoImageCacheBypassesSemaphore(t *testing.T) {
+	mediaImageNoImages.clear()
+	t.Cleanup(mediaImageNoImages.clear)
+
+	mediaImageSem <- struct{}{}
+	defer func() { <-mediaImageSem }()
+
+	params := json.RawMessage(`{"mediaId":406,"imageTypes":["boxart"]}`)
+	ref, err := parseMediaImageRequest(params)
+	require.NoError(t, err)
+	prefs := imagePrefs(nil, ref.ImageTypes)
+	mediaImageNoImages.add(
+		mediaImageNoImageRequestKey(ref, prefs),
+		&mediaImageNotFoundError{system: "NES", path: filepath.Join("games", "test-406.rom")},
+	)
+
+	env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
+	_, err = HandleMediaImage(env)
+	require.Error(t, err)
+
+	var quietErr *models.QuietClientError
+	require.ErrorAs(t, err, &quietErr)
+}
+
+func TestHandleMediaImage_NoImageCacheRecheckedAfterSemaphore(t *testing.T) {
+	mediaImageNoImages.clear()
+	t.Cleanup(mediaImageNoImages.clear)
+
+	mediaImageSem <- struct{}{}
+
+	params := json.RawMessage(`{"mediaId":407,"imageTypes":["boxart"]}`)
+	ref, err := parseMediaImageRequest(params)
+	require.NoError(t, err)
+	prefs := imagePrefs(nil, ref.ImageTypes)
+	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
+
+	done := make(chan error, 1)
+	go func() {
+		env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
+		_, handleErr := HandleMediaImage(env)
+		done <- handleErr
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	mediaImageNoImages.add(
+		noImageKey,
+		&mediaImageNotFoundError{system: "NES", path: filepath.Join("games", "test-407.rom")},
+	)
+	<-mediaImageSem
+
+	select {
+	case err = <-done:
+		require.Error(t, err)
+		var quietErr *models.QuietClientError
+		require.ErrorAs(t, err, &quietErr)
+		var noImage *mediaImageNotFoundError
+		require.ErrorAs(t, err, &noImage)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for media image handler")
+	}
+}
+
+func TestHandleMediaImage_ContextCanceledWhileWaitingForSemaphore(t *testing.T) {
+	mediaImageSem <- struct{}{}
+	defer func() {
+		<-mediaImageSem
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), json.RawMessage(`{"mediaId":1}`))
+	env.Context = ctx
+
+	_, err := HandleMediaImage(env)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 // TestHandleMediaImage_MediaNotFound verifies that an error is returned when no

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -516,8 +516,8 @@ func TestHandleMediaImage_NoImageCacheRecheckedAfterSemaphore(t *testing.T) {
 	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
 
 	done := make(chan error, 1)
+	env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
 	go func() {
-		env := makeMediaImageEnv(t, testhelpers.NewMockMediaDBI(), params)
 		_, handleErr := HandleMediaImage(env)
 		done <- handleErr
 	}()

--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -434,8 +434,6 @@ func TestHandleMediaMeta_MediaIDMergesSingletonAliasMetadata(t *testing.T) {
 		Once()
 	mockDB.On("GetMediaTitlePropertyMetadataByMediaTitleDBIDs", mock.Anything, []int64{row.Title.DBID}).
 		Return(map[int64][]database.MediaProperty{}, nil).Once()
-	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, row.Path).
-		Return((*database.Media)(nil), nil).Twice()
 	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, parentPath).
 		Return(&row.Media, nil).Twice()
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, row.System.DBID, parentPath).
@@ -487,8 +485,6 @@ func TestMergedMediaMeta_MergesSingletonAliasMetadata(t *testing.T) {
 	parentPath := filepath.ToSlash(filepath.Join("roms", "Game.zip"))
 	parent := &database.Media{DBID: 10, Path: parentPath}
 
-	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, row.Path).
-		Return((*database.Media)(nil), nil).Once()
 	mockDB.On("FindSingleDescendantMedia", mock.Anything, row.System.DBID, parentPath).
 		Return(&row.Media, nil).Once()
 	mockDB.On("FindMediaBySystemAndPath", mock.Anything, row.System.DBID, parentPath).

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -21,11 +21,14 @@ package methods
 
 import (
 	"context"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog/log"
 )
+
+const optionalDBEnrichmentTimeout = 500 * time.Millisecond
 
 type mediaPathRef struct {
 	SystemID string
@@ -49,7 +52,16 @@ func mediaResponseMediaIDs(env *requests.RequestEnv, refs []mediaPathRef) map[me
 	if env == nil || env.Database == nil {
 		return nil
 	}
-	return mediaIDsByPath(env.Context, env.Database.MediaDB, refs)
+	ctx, cancel := optionalDBEnrichmentContext(env.Context)
+	defer cancel()
+	return mediaIDsByPath(ctx, env.Database.MediaDB, refs)
+}
+
+func optionalDBEnrichmentContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, optionalDBEnrichmentTimeout)
 }
 
 func mediaIDsByPath(ctx context.Context, db database.MediaDBI, refs []mediaPathRef) map[mediaPathRef]int64 {

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -210,6 +210,9 @@ func populateScrapedMediaCountExact(
 ) {
 	count, ok := queryScrapedMediaCount(ctx, db, status.ScraperID)
 	if !ok {
+		if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK {
+			status.TotalScraped = cached
+		}
 		return
 	}
 	status.TotalScraped = count
@@ -432,6 +435,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 			status := scrapingStatusFromUpdate(scrapeCtx, scraperID, params.Force, &update, paused)
 			if update.Done {
 				populateScrapedMediaCountExact(env.State.GetContext(), db, &status)
+				mediaImageNoImages.clear()
 			} else {
 				populateScrapedMediaCountCached(env.State.GetContext(), db, &status)
 			}
@@ -454,6 +458,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 				terminalStatus.State = scrapeStateCancelled
 			}
 			populateScrapedMediaCountExact(env.State.GetContext(), db, &terminalStatus)
+			mediaImageNoImages.clear()
 			publishScrapingStatus(ns, &terminalStatus)
 		}
 		log.Info().Str("scraper", scraperID).Msg("scraper run complete")
@@ -484,7 +489,9 @@ func HandleMediaScrapeStatus(env requests.RequestEnv) (any, error) {
 		return status, nil
 	}
 
-	populateScrapedMediaCount(env.Context, env.Database, &status)
+	countCtx, cancel := optionalDBEnrichmentContext(env.Context)
+	defer cancel()
+	populateScrapedMediaCount(countCtx, env.Database, &status)
 
 	return status, nil
 }

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -390,6 +390,56 @@ func TestHandleMediaScrapeStatus_IgnoresScrapedCountError(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaScrapeStatus_BoundsSlowScrapedCount(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetTotalScrapedMediaCount", assertmock.Anything).
+		Run(func(args assertmock.Arguments) {
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			<-ctx.Done()
+		}).
+		Return(0, context.DeadlineExceeded).
+		Once()
+
+	started := time.Now()
+	result, err := HandleMediaScrapeStatus(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockDB},
+	})
+
+	require.NoError(t, err)
+	assert.Less(t, time.Since(started), 2*time.Second)
+	status, ok := result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Zero(t, status.TotalScraped)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaScrapeStatus_UsesCachedCountWhenRefreshTimesOut(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	scrapingStatusInstance.updateCountCache("", 9, time.Now())
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetTotalScrapedMediaCount", assertmock.Anything).
+		Return(0, context.DeadlineExceeded).
+		Once()
+
+	result, err := HandleMediaScrapeStatus(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockDB},
+	})
+
+	require.NoError(t, err)
+	status, ok := result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Equal(t, 9, status.TotalScraped)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrapeStatus_UsesScrapePauser(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()

--- a/pkg/api/models/client_error.go
+++ b/pkg/api/models/client_error.go
@@ -29,6 +29,13 @@ type ClientError struct {
 	Err error
 }
 
+// QuietClientError is an expected client-facing error that should not be logged
+// as a warning for every occurrence. Use for high-volume misses where the JSON-RPC
+// error response is still correct, but warning logs would create noise.
+type QuietClientError struct {
+	Err error
+}
+
 func (e *ClientError) Error() string {
 	return e.Err.Error()
 }
@@ -37,12 +44,40 @@ func (e *ClientError) Unwrap() error {
 	return e.Err
 }
 
+func (e *QuietClientError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *QuietClientError) Unwrap() error {
+	return e.Err
+}
+
+func (e *QuietClientError) As(target any) bool {
+	clientErr, ok := target.(**ClientError)
+	if !ok {
+		return false
+	}
+	*clientErr = &ClientError{Err: e.Err}
+	return true
+}
+
 // ClientErr wraps an error as a ClientError.
 func ClientErr(err error) error {
 	return &ClientError{Err: err}
 }
 
+// QuietClientErr wraps an error as a QuietClientError.
+func QuietClientErr(err error) error {
+	return &QuietClientError{Err: err}
+}
+
 // ClientErrf creates a new formatted ClientError.
 func ClientErrf(format string, a ...any) error {
 	return &ClientError{Err: fmt.Errorf(format, a...)}
+}
+
+// QuietClientErrf creates a formatted ClientError that the API server logs at
+// debug level instead of warning level.
+func QuietClientErrf(format string, a ...any) error {
+	return &QuietClientError{Err: fmt.Errorf(format, a...)}
 }

--- a/pkg/api/models/client_error.go
+++ b/pkg/api/models/client_error.go
@@ -76,8 +76,8 @@ func ClientErrf(format string, a ...any) error {
 	return &ClientError{Err: fmt.Errorf(format, a...)}
 }
 
-// QuietClientErrf creates a formatted ClientError that the API server logs at
-// debug level instead of warning level.
+// QuietClientErrf creates a formatted QuietClientError that the API server logs
+// at debug level instead of warning level.
 func QuietClientErrf(format string, a ...any) error {
 	return &QuietClientError{Err: fmt.Errorf(format, a...)}
 }

--- a/pkg/api/models/client_error_test.go
+++ b/pkg/api/models/client_error_test.go
@@ -64,3 +64,21 @@ func TestClientErrf_DetectedByErrorsAs(t *testing.T) {
 	var clientErr *models.ClientError
 	assert.ErrorAs(t, err, &clientErr)
 }
+
+func TestQuietClientErr_DetectedAsQuietAndClientError(t *testing.T) {
+	err := models.QuietClientErr(errSentinel)
+
+	var quietErr *models.QuietClientError
+	require.ErrorAs(t, err, &quietErr)
+	assert.Equal(t, errSentinel, quietErr.Err)
+
+	var clientErr *models.ClientError
+	require.ErrorAs(t, err, &clientErr)
+	assert.Equal(t, errSentinel, clientErr.Err)
+}
+
+func TestQuietClientErrf_FormatsMessage(t *testing.T) {
+	err := models.QuietClientErrf("bad input: %s", "foo")
+	require.Error(t, err)
+	assert.Equal(t, "bad input: foo", err.Error())
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -386,8 +386,11 @@ func handleRequest(
 
 	resp, err := fn(env)
 	if err != nil {
+		var quietErr *models.QuietClientError
 		var clientErr *models.ClientError
-		if errors.As(err, &clientErr) {
+		if errors.As(err, &quietErr) {
+			log.Debug().Err(err).Str("method", req.Method).Msg("client error")
+		} else if errors.As(err, &clientErr) {
 			log.Warn().Err(err).Str("method", req.Method).Msg("client error")
 		} else {
 			log.Error().Err(err).Str("method", req.Method).Msg("error handling request")

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -343,6 +343,7 @@ type SearchResultWithCursor struct {
 	Tags          []TagInfo
 	ZapScriptTags []TagInfo // Disambiguating tags only (tags that differ across sibling variants)
 	MediaID       int64
+	MediaTitleID  int64 `json:"-"`
 }
 
 // ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -102,8 +102,8 @@ func sqlBrowseDirectories(
 		return nil, err
 	}
 	if ready {
-		results, cacheErr := sqlBrowseDirectoriesFromCache(ctx, db, opts)
-		if cacheErr != nil || len(results) > 0 {
+		results, parentFound, cacheErr := sqlBrowseDirectoriesFromCache(ctx, db, opts)
+		if cacheErr != nil || parentFound {
 			return results, cacheErr
 		}
 
@@ -149,13 +149,17 @@ func sqlBrowseDirectoriesFromCache(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseDirectoriesOptions,
-) ([]database.BrowseDirectoryResult, error) {
+) ([]database.BrowseDirectoryResult, bool, error) {
 	parentID, ok, err := sqlBrowseDirID(ctx, db, opts.PathPrefix)
-	if err != nil || !ok {
-		return nil, err
+	if err != nil {
+		return nil, false, err
+	}
+	if !ok {
+		return nil, false, nil
 	}
 	if len(opts.Systems) == 1 {
-		return sqlBrowseDirectoriesFromCacheForSingleSystem(ctx, db, parentID, opts.Systems[0].ID)
+		results, cacheErr := sqlBrowseDirectoriesFromCacheForSingleSystem(ctx, db, parentID, opts.Systems[0].ID)
+		return results, true, cacheErr
 	}
 
 	args := []any{parentID}
@@ -173,7 +177,7 @@ func sqlBrowseDirectoriesFromCache(
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("browse cache directories query: %w", err)
+		return nil, true, fmt.Errorf("browse cache directories query: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
@@ -182,15 +186,15 @@ func sqlBrowseDirectoriesFromCache(
 		var r database.BrowseDirectoryResult
 		var systemIDs string
 		if scanErr := rows.Scan(&r.Name, &r.FileCount, &systemIDs); scanErr != nil {
-			return nil, fmt.Errorf("browse cache directories scan: %w", scanErr)
+			return nil, true, fmt.Errorf("browse cache directories scan: %w", scanErr)
 		}
 		r.SystemIDs = splitBrowseSystemIDs(systemIDs)
 		results = append(results, r)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
-		return nil, fmt.Errorf("browse cache directories rows: %w", rowsErr)
+		return nil, true, fmt.Errorf("browse cache directories rows: %w", rowsErr)
 	}
-	return results, nil
+	return results, true, nil
 }
 
 func sqlBrowseDirectoriesFromCacheForSingleSystem(
@@ -233,11 +237,13 @@ func sqlBrowseDirectoriesFromMedia(
 	db sqlQueryable,
 	pathPrefix string,
 ) ([]database.BrowseDirectoryResult, error) {
+	pathCondition, pathArgs := browsePathPrefixCondition("Path", pathPrefix)
+	args := append([]any{pathPrefix}, pathArgs...)
 	rows, err := db.QueryContext(ctx,
 		`WITH matched AS (
 			 SELECT substr(Path, length(?) + 1) AS Rest
 			 FROM Media
-			 WHERE IsMissing = 0 AND Path LIKE ? || '%'
+			 WHERE IsMissing = 0 AND `+pathCondition+`
 		 )
 		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
 			COUNT(*) AS FileCount
@@ -245,7 +251,7 @@ func sqlBrowseDirectoriesFromMedia(
 		 WHERE instr(Rest, '/') > 0
 		 GROUP BY Name
 		 ORDER BY Name ASC`,
-		pathPrefix, pathPrefix,
+		args...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("browse directories media query: %w", err)
@@ -272,15 +278,17 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
 	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
-	args := make([]any, 0, 2+len(systemArgs))
-	args = append(args, opts.PathPrefix, opts.PathPrefix)
+	pathCondition, pathArgs := browsePathPrefixCondition("m.Path", opts.PathPrefix)
+	args := make([]any, 0, 1+len(pathArgs)+len(systemArgs))
+	args = append(args, opts.PathPrefix)
+	args = append(args, pathArgs...)
 	args = append(args, systemArgs...)
 	rows, err := db.QueryContext(ctx,
 		`WITH matched AS (
 			 SELECT substr(m.Path, length(?) + 1) AS Rest, s.SystemID
 			 FROM Media m
 			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause+`
+			 WHERE m.IsMissing = 0 AND `+pathCondition+` AND `+systemClause+`
 		 )
 		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
 			COUNT(*) AS FileCount,
@@ -310,6 +318,13 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 		return nil, fmt.Errorf("browse directories by system media rows: %w", rowsErr)
 	}
 	return results, nil
+}
+
+func browsePathPrefixCondition(column string, pathPrefix string) (string, []any) {
+	if upper := stringPrefixUpperBound(pathPrefix); upper != "" {
+		return column + ` >= ? AND ` + column + ` < ?`, []any{pathPrefix, upper}
+	}
+	return column + ` LIKE ? || '%'`, []any{pathPrefix}
 }
 
 func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
@@ -369,7 +384,7 @@ func sqlBrowseFilesFromMedia(
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
 	where, args := browseFilesBaseCondition(opts)
-	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID
+	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID, mt.DBID
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
@@ -391,7 +406,7 @@ func sqlBrowseFilesFromMedia(
 	var results []database.SearchResultWithCursor
 	for rows.Next() {
 		var r database.SearchResultWithCursor
-		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID); scanErr != nil {
+		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID); scanErr != nil {
 			return nil, fmt.Errorf("browse files scan: %w", scanErr)
 		}
 		results = append(results, r)
@@ -414,54 +429,7 @@ func sqlBrowseFilesFromMedia(
 		Dur("queryDuration", queryElapsed).
 		Dur("tagsDuration", tagsElapsed).
 		Msg("browse files step timing")
-	if len(results) == 0 && opts.Cursor == nil {
-		descendants, countErr := sqlBrowseDescendantCount(ctx, db, opts.PathPrefix, opts.Systems)
-		if countErr != nil {
-			log.Debug().
-				Err(countErr).
-				Str("pathPrefix", opts.PathPrefix).
-				Strs("systems", browseSystemIDsForLog(opts.Systems)).
-				Msg("browse files descendant diagnostic failed")
-		} else {
-			event := log.Debug()
-			if descendants > 0 {
-				event = log.Warn()
-			}
-			event.
-				Str("pathPrefix", opts.PathPrefix).
-				Strs("systems", browseSystemIDsForLog(opts.Systems)).
-				Int("directFiles", 0).
-				Int("descendantFiles", descendants).
-				Msg("browse files returned no direct media")
-		}
-	}
 	return results, nil
-}
-
-func sqlBrowseDescendantCount(
-	ctx context.Context,
-	db sqlQueryable,
-	pathPrefix string,
-	systems []systemdefs.System,
-) (int, error) {
-	conditions := []string{`m.IsMissing = 0`, `m.Path LIKE ? || '%'`}
-	args := []any{pathPrefix}
-	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", systems); systemClause != "" {
-		conditions = append(conditions, systemClause)
-		args = append(args, systemArgs...)
-	}
-
-	var count int
-	if err := db.QueryRowContext(ctx,
-		`SELECT COUNT(*)
-		 FROM Media m
-		 INNER JOIN Systems s ON m.SystemDBID = s.DBID
-		 WHERE `+strings.Join(conditions, " AND "),
-		args...,
-	).Scan(&count); err != nil {
-		return 0, fmt.Errorf("browse descendant count: %w", err)
-	}
-	return count, nil
 }
 
 func sqlBrowseFileCount(

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -320,7 +320,7 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	return results, nil
 }
 
-func browsePathPrefixCondition(column string, pathPrefix string) (string, []any) {
+func browsePathPrefixCondition(column, pathPrefix string) (string, []any) {
 	if upper := stringPrefixUpperBound(pathPrefix); upper != "" {
 		return column + ` >= ? AND ` + column + ` < ?`, []any{pathPrefix, upper}
 	}

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -320,7 +320,7 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	return results, nil
 }
 
-func browsePathPrefixCondition(column, pathPrefix string) (string, []any) {
+func browsePathPrefixCondition(column, pathPrefix string) (condition string, args []any) {
 	if upper := stringPrefixUpperBound(pathPrefix); upper != "" {
 		return column + ` >= ? AND ` + column + ` < ?`, []any{pathPrefix, upper}
 	}

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -1,0 +1,155 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+const browseBenchRows = 1000
+
+func BenchmarkBrowseFiles_TagAttach_100(b *testing.B) {
+	benchBrowseFilesTagAttach(b, "no-tags", false)
+	benchBrowseFilesTagAttach(b, "with-tags", true)
+}
+
+func benchBrowseFilesTagAttach(b *testing.B, name string, withTags bool) {
+	b.Helper()
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		ctx := context.Background()
+		mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+		defer cleanup()
+		parentDir := seedBenchBrowseDB(b, mediaDB, browseBenchRows, withTags)
+
+		opts := &database.BrowseFilesOptions{PathPrefix: parentDir, Limit: 100}
+		b.ResetTimer()
+		for b.Loop() {
+			results, err := mediaDB.BrowseFiles(ctx, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(results) != 100 {
+				b.Fatalf("expected 100 results, got %d", len(results))
+			}
+		}
+	})
+}
+
+func setupBrowseBenchMediaDB(b *testing.B) (mediaDB *MediaDB, cleanup func()) {
+	b.Helper()
+	tempDir, err := os.MkdirTemp("", "zaparoo-browse-bench-mediadb-*")
+	require.NoError(b, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
+
+	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
+	require.NoError(b, err)
+	cleanup = func() {
+		if mediaDB != nil {
+			_ = mediaDB.Close()
+		}
+		_ = os.RemoveAll(tempDir)
+	}
+	return mediaDB, cleanup
+}
+
+func seedBenchBrowseDB(b *testing.B, mediaDB *MediaDB, rows int, withTags bool) string {
+	b.Helper()
+	ctx := context.Background()
+	parentDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "bench")) + "/"
+	tx, err := mediaDB.sql.BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'Bench', 'Bench');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES
+			(1, 'user', 0),
+			(2, 'genre', 0),
+			(3, 'year', 1),
+			(4, 'developer', 1);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES
+			(1, 1, 'favorite'),
+			(2, 2, 'action'),
+			(3, 2, 'arcade'),
+			(4, 3, '1990'),
+			(5, 3, '1991'),
+			(6, 4, 'bench-dev');
+	`)
+	require.NoError(b, err)
+
+	titleStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 1, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, titleStmt.Close()) }()
+
+	mediaStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (?, ?, 1, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, mediaStmt.Close()) }()
+
+	mediaTagStmt, err := tx.PrepareContext(ctx, `INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, mediaTagStmt.Close()) }()
+
+	titleTagStmt, err := tx.PrepareContext(ctx, `INSERT INTO MediaTitleTags (MediaTitleDBID, TagDBID) VALUES (?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, titleTagStmt.Close()) }()
+
+	for i := 1; i <= rows; i++ {
+		mediaID := int64(i)
+		slug := fmt.Sprintf("browse-game-%05d", i)
+		name := fmt.Sprintf("Browse Game %05d", i)
+		path := filepath.ToSlash(filepath.Join(parentDir, fmt.Sprintf("browse-game-%05d.zip", i)))
+		_, err = titleStmt.ExecContext(ctx, mediaID, slug, name)
+		require.NoError(b, err)
+		_, err = mediaStmt.ExecContext(ctx, mediaID, mediaID, path, parentDir)
+		require.NoError(b, err)
+		if !withTags {
+			continue
+		}
+		if i%10 == 0 {
+			_, err = mediaTagStmt.ExecContext(ctx, mediaID, int64(1))
+			require.NoError(b, err)
+		}
+		_, err = mediaTagStmt.ExecContext(ctx, mediaID, int64(2+i%2))
+		require.NoError(b, err)
+		_, err = titleTagStmt.ExecContext(ctx, mediaID, int64(4+i%2))
+		require.NoError(b, err)
+		_, err = titleTagStmt.ExecContext(ctx, mediaID, int64(6))
+		require.NoError(b, err)
+	}
+
+	require.NoError(b, tx.Commit())
+	return parentDir
+}

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -123,58 +123,6 @@ func TestLogBrowseMediaCountsBySystem_RowsError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSqlBrowseDescendantCount_Unfiltered(t *testing.T) {
-	t.Parallel()
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	romsDir := browseTestDir("roms", "psx")
-	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE").
-		WithArgs(romsDir).
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(273))
-
-	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, nil)
-	require.NoError(t, err)
-	assert.Equal(t, 273, count)
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseDescendantCount_SystemFiltered(t *testing.T) {
-	t.Parallel()
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	romsDir := browseTestDir("roms", "psx")
-	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE.*s\\.SystemID IN").
-		WithArgs(romsDir, "PSX").
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(273))
-
-	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, []systemdefs.System{{ID: "PSX"}})
-	require.NoError(t, err)
-	assert.Equal(t, 273, count)
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestSqlBrowseDescendantCount_QueryError(t *testing.T) {
-	t.Parallel()
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	romsDir := browseTestDir("roms", "psx")
-	mock.ExpectQuery("SELECT COUNT\\(\\*\\).*FROM Media m.*INNER JOIN Systems s.*WHERE").
-		WithArgs(romsDir).
-		WillReturnError(sql.ErrConnDone)
-
-	count, err := sqlBrowseDescendantCount(context.Background(), db, romsDir, nil)
-	require.Error(t, err)
-	assert.Equal(t, 0, count)
-	assert.Contains(t, err.Error(), "browse descendant count")
-	require.NoError(t, mock.ExpectationsWereMet())
-}
-
 func TestSqlBrowseDirectoriesFromCache_ReturnsSystemCounts(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()
@@ -215,7 +163,7 @@ func TestSqlBrowseDirectories_FallsBackWhenCacheNotReady(t *testing.T) {
 		WillReturnError(sql.ErrNoRows)
 	romsDir := browseTestDir("roms")
 	mock.ExpectQuery("WITH matched AS").
-		WithArgs(romsDir, romsDir).
+		WithArgs(romsDir, romsDir, stringPrefixUpperBound(romsDir)).
 		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}).AddRow("SNES", 2))
 
 	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
@@ -227,7 +175,7 @@ func TestSqlBrowseDirectories_FallsBackWhenCacheNotReady(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSqlBrowseDirectories_FallsBackWhenReadyCacheIsEmpty(t *testing.T) {
+func TestSqlBrowseDirectories_ReturnsEmptyWhenReadyCacheParentHasNoChildren(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -241,8 +189,29 @@ func TestSqlBrowseDirectories_FallsBackWhenReadyCacheIsEmpty(t *testing.T) {
 	mock.ExpectQuery("SELECT d.Name, c.FileCount").
 		WithArgs(int64(10), "PSX").
 		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: psxDir,
+		Systems:    []systemdefs.System{{ID: "PSX"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectories_FallsBackWhenReadyCacheParentMissing(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	psxDir := browseTestDir("media", "fat", "games", "PSX")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(psxDir).
+		WillReturnError(sql.ErrNoRows)
 	mock.ExpectQuery("WITH matched AS").
-		WithArgs(psxDir, psxDir, "PSX").
+		WithArgs(psxDir, psxDir, stringPrefixUpperBound(psxDir), "PSX").
 		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).AddRow("USA", 273, "PSX"))
 
 	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -130,13 +130,26 @@ func (db *MediaDB) FindSingleDescendantMedia(
 	}
 
 	prefix := strings.TrimRight(dirPath, "/") + "/"
-	rows, err := db.sql.QueryContext(ctx, `
+	upper := stringPrefixUpperBound(prefix)
+	query := `
 		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
 		FROM Media
-		WHERE SystemDBID = ? AND IsMissing = 0 AND substr(Path, 1, length(?)) = ?
+		WHERE SystemDBID = ? AND IsMissing = 0 AND Path >= ? AND Path < ?
 		ORDER BY Path ASC, DBID ASC
 		LIMIT 2
-	`, systemDBID, prefix, prefix)
+	`
+	args := []any{systemDBID, prefix, upper}
+	if upper == "" {
+		query = `
+			SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+			FROM Media
+			WHERE SystemDBID = ? AND IsMissing = 0 AND Path >= ? AND substr(Path, 1, length(?)) = ?
+			ORDER BY Path ASC, DBID ASC
+			LIMIT 2
+		`
+		args = []any{systemDBID, prefix, prefix, prefix}
+	}
+	rows, err := db.sql.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query FindSingleDescendantMedia: %w", err)
 	}
@@ -168,6 +181,20 @@ func (db *MediaDB) FindSingleDescendantMedia(
 		return nil, nil //nolint:nilnil // zero or ambiguous descendants are not singleton aliases
 	}
 	return &matches[0], nil
+}
+
+func stringPrefixUpperBound(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	b := []byte(prefix)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] != 0xff {
+			b[i]++
+			return string(b[:i+1])
+		}
+	}
+	return ""
 }
 
 // FindMediaBySystemAndPathFold returns the Media row for the given system and

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -243,6 +243,28 @@ func TestFindSingleDescendantMedia_UsesByteExactPrefix(t *testing.T) {
 	assert.Equal(t, int64(6), caseExact.DBID)
 }
 
+func TestStringPrefixUpperBound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{name: "empty", prefix: "", want: ""},
+		{name: "ascii", prefix: "roms/Game/", want: "roms/Game0"},
+		{name: "carry", prefix: string([]byte{'a', 0xff}), want: "b"},
+		{name: "no bound", prefix: string([]byte{0xff, 0xff}), want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, stringPrefixUpperBound(tt.prefix))
+		})
+	}
+}
+
 // --- FindMediaBySystemAndPathFold ---
 
 func TestFindMediaBySystemAndPathFold_ExactMatch(t *testing.T) {

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -51,6 +51,9 @@ func fetchAndAttachTags(
 	if len(results) == 0 {
 		return nil
 	}
+	if allResultsHaveTitleIDs(results) {
+		return fetchAndAttachTagsByResultIDs(ctx, db, results)
+	}
 
 	mediaIDs := make([]int64, len(results))
 	for i, result := range results {
@@ -124,27 +127,151 @@ func fetchAndAttachTags(
 		if scanErr := tagsRows.Scan(&mediaID, &tag, &tagType); scanErr != nil {
 			return fmt.Errorf("failed to scan tags result: %w", scanErr)
 		}
-
-		tagInfo := database.TagInfo{
-			Tag:  dbtags.UnpadTagValue(tag),
-			Type: tagType,
-		}
-		mediaSeen, ok := seen[mediaID]
-		if !ok {
-			mediaSeen = make(map[database.TagInfo]struct{})
-			seen[mediaID] = mediaSeen
-		}
-		if _, dup := mediaSeen[tagInfo]; dup {
-			continue
-		}
-		mediaSeen[tagInfo] = struct{}{}
-		tagsMap[mediaID] = append(tagsMap[mediaID], tagInfo)
+		appendTagInfo(tagsMap, seen, mediaID, tag, tagType)
 	}
 	if err = tagsRows.Err(); err != nil {
 		return fmt.Errorf("tags rows iteration error: %w", err)
 	}
 
-	// Stable order for clients (the SQL no longer ORDERs the rows).
+	finishAttachTags(results, tagsMap)
+	logFetchAndAttachTagsTiming(results, len(tagsMap), unionStarted)
+	return nil
+}
+
+func allResultsHaveTitleIDs(results []database.SearchResultWithCursor) bool {
+	for i := range results {
+		if results[i].MediaTitleID == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func fetchAndAttachTagsByResultIDs(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	mediaIDs := make([]int64, len(results))
+	titleToMediaIDs := make(map[int64][]int64, len(results))
+	seenTitles := make(map[int64]struct{}, len(results))
+	titleIDs := make([]int64, 0, len(results))
+	for i, result := range results {
+		mediaIDs[i] = result.MediaID
+		titleToMediaIDs[result.MediaTitleID] = append(titleToMediaIDs[result.MediaTitleID], result.MediaID)
+		if _, ok := seenTitles[result.MediaTitleID]; ok {
+			continue
+		}
+		seenTitles[result.MediaTitleID] = struct{}{}
+		titleIDs = append(titleIDs, result.MediaTitleID)
+	}
+
+	mediaPlaceholders := prepareVariadic("?", ",", len(mediaIDs))
+	titlePlaceholders := prepareVariadic("?", ",", len(titleIDs))
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	tagsQuery := `
+		SELECT
+			0 as SourceKind,
+			MediaTags.MediaDBID as SourceDBID,
+			Tags.Tag,
+			TagTypes.Type
+		FROM MediaTags
+		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTags.MediaDBID IN (` + mediaPlaceholders + `)
+
+		UNION ALL
+
+		SELECT
+			1 as SourceKind,
+			MediaTitleTags.MediaTitleDBID as SourceDBID,
+			Tags.Tag,
+			TagTypes.Type
+		FROM MediaTitleTags
+		JOIN Tags ON Tags.DBID = MediaTitleTags.TagDBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTitleTags.MediaTitleDBID IN (` + titlePlaceholders + `)`
+
+	tagsArgs := make([]any, 0, len(mediaIDs)+len(titleIDs))
+	for _, id := range mediaIDs {
+		tagsArgs = append(tagsArgs, id)
+	}
+	for _, id := range titleIDs {
+		tagsArgs = append(tagsArgs, id)
+	}
+
+	unionStarted := time.Now()
+	tagsStmt, err := db.PrepareContext(ctx, tagsQuery)
+	if err != nil {
+		return fmt.Errorf("failed to prepare tags query: %w", err)
+	}
+	defer func() {
+		if closeErr := tagsStmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close tags statement")
+		}
+	}()
+
+	tagsRows, err := tagsStmt.QueryContext(ctx, tagsArgs...)
+	if err != nil {
+		return fmt.Errorf("failed to execute tags query: %w", err)
+	}
+	defer func() {
+		if closeErr := tagsRows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close tags rows")
+		}
+	}()
+
+	tagsMap := make(map[int64][]database.TagInfo)
+	seen := make(map[int64]map[database.TagInfo]struct{})
+	for tagsRows.Next() {
+		var sourceKind int
+		var sourceID int64
+		var tag, tagType string
+		if scanErr := tagsRows.Scan(&sourceKind, &sourceID, &tag, &tagType); scanErr != nil {
+			return fmt.Errorf("failed to scan tags result: %w", scanErr)
+		}
+
+		mediaIDsForTag := []int64{sourceID}
+		if sourceKind == 1 {
+			mediaIDsForTag = titleToMediaIDs[sourceID]
+		}
+		for _, mediaID := range mediaIDsForTag {
+			appendTagInfo(tagsMap, seen, mediaID, tag, tagType)
+		}
+	}
+	if err = tagsRows.Err(); err != nil {
+		return fmt.Errorf("tags rows iteration error: %w", err)
+	}
+
+	finishAttachTags(results, tagsMap)
+	logFetchAndAttachTagsTiming(results, len(tagsMap), unionStarted)
+	return nil
+}
+
+func appendTagInfo(
+	tagsMap map[int64][]database.TagInfo,
+	seen map[int64]map[database.TagInfo]struct{},
+	mediaID int64,
+	tag string,
+	tagType string,
+) {
+	tagInfo := database.TagInfo{
+		Tag:  dbtags.UnpadTagValue(tag),
+		Type: tagType,
+	}
+	mediaSeen, ok := seen[mediaID]
+	if !ok {
+		mediaSeen = make(map[database.TagInfo]struct{})
+		seen[mediaID] = mediaSeen
+	}
+	if _, dup := mediaSeen[tagInfo]; dup {
+		return
+	}
+	mediaSeen[tagInfo] = struct{}{}
+	tagsMap[mediaID] = append(tagsMap[mediaID], tagInfo)
+}
+
+func finishAttachTags(results []database.SearchResultWithCursor, tagsMap map[int64][]database.TagInfo) {
 	for mediaID := range tagsMap {
 		tags := tagsMap[mediaID]
 		sort.Slice(tags, func(i, j int) bool {
@@ -162,24 +289,24 @@ func fetchAndAttachTags(
 			results[i].Tags = []database.TagInfo{}
 		}
 	}
+}
 
+func logFetchAndAttachTagsTiming(
+	results []database.SearchResultWithCursor,
+	tagPairs int,
+	unionStarted time.Time,
+) {
 	unionElapsed := time.Since(unionStarted)
-
-	// Compute disambiguating ZapScript tags in-memory.
-	// A tag type is disambiguating when results sharing the same title name
-	// have different values for that tag type (e.g., "2" vs "4" for players).
 	zsStarted := time.Now()
 	computeZapScriptTags(results)
 	zsElapsed := time.Since(zsStarted)
 
 	log.Debug().
 		Int("rows", len(results)).
-		Int("tagPairs", len(tagsMap)).
+		Int("tagPairs", tagPairs).
 		Dur("unionDuration", unionElapsed).
 		Dur("zapscriptDuration", zsElapsed).
 		Msg("fetch and attach tags timing")
-
-	return nil
 }
 
 // computeZapScriptTags determines which tags are disambiguating across sibling

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -152,22 +152,20 @@ func fetchAndAttachTagsByResultIDs(
 	db sqlQueryable,
 	results []database.SearchResultWithCursor,
 ) error {
-	mediaIDs := make([]int64, len(results))
-	titleToMediaIDs := make(map[int64][]int64, len(results))
-	seenTitles := make(map[int64]struct{}, len(results))
-	titleIDs := make([]int64, 0, len(results))
-	for i, result := range results {
-		mediaIDs[i] = result.MediaID
-		titleToMediaIDs[result.MediaTitleID] = append(titleToMediaIDs[result.MediaTitleID], result.MediaID)
-		if _, ok := seenTitles[result.MediaTitleID]; ok {
-			continue
-		}
-		seenTitles[result.MediaTitleID] = struct{}{}
-		titleIDs = append(titleIDs, result.MediaTitleID)
+	tagIDs := collectResultTagIDs(results)
+	unionStarted := time.Now()
+	hasTags, err := resultIDsHaveTags(ctx, db, tagIDs.mediaIDs, tagIDs.titleIDs)
+	if err != nil {
+		return err
+	}
+	if !hasTags {
+		finishAttachTags(results, nil)
+		logFetchAndAttachTagsTiming(results, 0, unionStarted)
+		return nil
 	}
 
-	mediaPlaceholders := prepareVariadic("?", ",", len(mediaIDs))
-	titlePlaceholders := prepareVariadic("?", ",", len(titleIDs))
+	mediaPlaceholders := prepareVariadic("?", ",", len(tagIDs.mediaIDs))
+	titlePlaceholders := prepareVariadic("?", ",", len(tagIDs.titleIDs))
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
 	tagsQuery := `
 		SELECT
@@ -192,15 +190,14 @@ func fetchAndAttachTagsByResultIDs(
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
 		WHERE MediaTitleTags.MediaTitleDBID IN (` + titlePlaceholders + `)`
 
-	tagsArgs := make([]any, 0, len(mediaIDs)+len(titleIDs))
-	for _, id := range mediaIDs {
+	tagsArgs := make([]any, 0, len(tagIDs.mediaIDs)+len(tagIDs.titleIDs))
+	for _, id := range tagIDs.mediaIDs {
 		tagsArgs = append(tagsArgs, id)
 	}
-	for _, id := range titleIDs {
+	for _, id := range tagIDs.titleIDs {
 		tagsArgs = append(tagsArgs, id)
 	}
 
-	unionStarted := time.Now()
 	tagsStmt, err := db.PrepareContext(ctx, tagsQuery)
 	if err != nil {
 		return fmt.Errorf("failed to prepare tags query: %w", err)
@@ -233,7 +230,7 @@ func fetchAndAttachTagsByResultIDs(
 
 		mediaIDsForTag := []int64{sourceID}
 		if sourceKind == 1 {
-			mediaIDsForTag = titleToMediaIDs[sourceID]
+			mediaIDsForTag = tagIDs.titleToMediaIDs[sourceID]
 		}
 		for _, mediaID := range mediaIDsForTag {
 			appendTagInfo(tagsMap, seen, mediaID, tag, tagType)
@@ -246,6 +243,55 @@ func fetchAndAttachTagsByResultIDs(
 	finishAttachTags(results, tagsMap)
 	logFetchAndAttachTagsTiming(results, len(tagsMap), unionStarted)
 	return nil
+}
+
+type resultTagIDs struct {
+	titleToMediaIDs map[int64][]int64
+	mediaIDs        []int64
+	titleIDs        []int64
+}
+
+func collectResultTagIDs(results []database.SearchResultWithCursor) resultTagIDs {
+	tagIDs := resultTagIDs{
+		mediaIDs:        make([]int64, len(results)),
+		titleToMediaIDs: make(map[int64][]int64, len(results)),
+		titleIDs:        make([]int64, 0, len(results)),
+	}
+	seenTitles := make(map[int64]struct{}, len(results))
+	for i, result := range results {
+		tagIDs.mediaIDs[i] = result.MediaID
+		tagIDs.titleToMediaIDs[result.MediaTitleID] = append(
+			tagIDs.titleToMediaIDs[result.MediaTitleID], result.MediaID,
+		)
+		if _, ok := seenTitles[result.MediaTitleID]; ok {
+			continue
+		}
+		seenTitles[result.MediaTitleID] = struct{}{}
+		tagIDs.titleIDs = append(tagIDs.titleIDs, result.MediaTitleID)
+	}
+	return tagIDs
+}
+
+func resultIDsHaveTags(ctx context.Context, db sqlQueryable, mediaIDs, titleIDs []int64) (bool, error) {
+	mediaPlaceholders := prepareVariadic("?", ",", len(mediaIDs))
+	titlePlaceholders := prepareVariadic("?", ",", len(titleIDs))
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	query := `SELECT EXISTS(SELECT 1 FROM MediaTags WHERE MediaDBID IN (` + mediaPlaceholders + `) LIMIT 1)
+		OR EXISTS(SELECT 1 FROM MediaTitleTags WHERE MediaTitleDBID IN (` + titlePlaceholders + `) LIMIT 1)`
+
+	args := make([]any, 0, len(mediaIDs)+len(titleIDs))
+	for _, id := range mediaIDs {
+		args = append(args, id)
+	}
+	for _, id := range titleIDs {
+		args = append(args, id)
+	}
+
+	var hasTags bool
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&hasTags); err != nil {
+		return false, fmt.Errorf("failed to check result tags: %w", err)
+	}
+	return hasTags, nil
 }
 
 func appendTagInfo(
@@ -327,12 +373,32 @@ func computeZapScriptTags(results []database.SearchResultWithCursor) {
 
 	// Group results by SystemID+Name to find siblings (same title within a system)
 	nameGroups := make(map[string][]int) // "SystemID/Name" → indices into results
+	hasSiblings := false
 	for i := range results {
 		key := results[i].SystemID + "/" + results[i].Name
 		nameGroups[key] = append(nameGroups[key], i)
+		if len(nameGroups[key]) > 1 {
+			hasSiblings = true
+		}
+	}
+	if !hasSiblings {
+		for i := range results {
+			if results[i].ZapScriptTags == nil {
+				results[i].ZapScriptTags = []database.TagInfo{}
+			}
+		}
+		return
 	}
 
 	for _, indices := range nameGroups {
+		if len(indices) < 2 {
+			for _, idx := range indices {
+				if results[idx].ZapScriptTags == nil {
+					results[idx].ZapScriptTags = []database.TagInfo{}
+				}
+			}
+			continue
+		}
 		// For each eligible tag type, collect distinct values across siblings
 		disambiguating := make(map[string]bool) // tag types that need disambiguation
 

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -22,6 +22,7 @@ package mediadb
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -282,6 +283,40 @@ func TestFetchAndAttachTags_MultipleResults(t *testing.T) {
 	assert.Equal(t, "1990", results[2].Tags[1].Tag)
 	assert.Equal(t, "year", results[2].Tags[1].Type)
 
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachTags_ResultTitleIDsAvoidMediaJoin(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, MediaTitleID: 10, SystemID: "nes", Name: "Game", Path: filepath.Join("games", "a.nes")},
+		{MediaID: 2, MediaTitleID: 10, SystemID: "nes", Name: "Game", Path: filepath.Join("games", "b.nes")},
+		{MediaID: 3, MediaTitleID: 30, SystemID: "snes", Name: "Other", Path: filepath.Join("games", "c.sfc")},
+	}
+
+	tagRows := sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "Type"}).
+		AddRow(0, int64(1), "Rev A", "rev").
+		AddRow(1, int64(10), "Action", "genre").
+		AddRow(1, int64(30), "1990", "year")
+
+	mock.ExpectPrepare(`SELECT.*SourceKind.*SourceDBID.*FROM MediaTags.*FROM MediaTitleTags`).
+		ExpectQuery().
+		WithArgs(int64(1), int64(2), int64(3), int64(10), int64(30)).
+		WillReturnRows(tagRows)
+
+	err = fetchAndAttachTags(context.Background(), db, results)
+	require.NoError(t, err)
+
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "Action", Type: "genre"},
+		{Tag: "Rev A", Type: "rev"},
+	}, results[0].Tags)
+	assert.Equal(t, []database.TagInfo{{Tag: "Action", Type: "genre"}}, results[1].Tags)
+	assert.Equal(t, []database.TagInfo{{Tag: "1990", Type: "year"}}, results[2].Tags)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -303,6 +303,9 @@ func TestFetchAndAttachTags_ResultTitleIDsAvoidMediaJoin(t *testing.T) {
 		AddRow(1, int64(10), "Action", "genre").
 		AddRow(1, int64(30), "1990", "year")
 
+	mock.ExpectQuery(`SELECT EXISTS.*MediaTags.*MediaTitleTags`).
+		WithArgs(int64(1), int64(2), int64(3), int64(10), int64(30)).
+		WillReturnRows(sqlmock.NewRows([]string{"hasTags"}).AddRow(true))
 	mock.ExpectPrepare(`SELECT.*SourceKind.*SourceDBID.*FROM MediaTags.*FROM MediaTitleTags`).
 		ExpectQuery().
 		WithArgs(int64(1), int64(2), int64(3), int64(10), int64(30)).
@@ -317,6 +320,30 @@ func TestFetchAndAttachTags_ResultTitleIDsAvoidMediaJoin(t *testing.T) {
 	}, results[0].Tags)
 	assert.Equal(t, []database.TagInfo{{Tag: "Action", Type: "genre"}}, results[1].Tags)
 	assert.Equal(t, []database.TagInfo{{Tag: "1990", Type: "year"}}, results[2].Tags)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachTags_ResultTitleIDsNoTagsSkipsFullFetch(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, MediaTitleID: 10, SystemID: "nes", Name: "Game A", Path: filepath.Join("games", "a.nes")},
+		{MediaID: 2, MediaTitleID: 20, SystemID: "nes", Name: "Game B", Path: filepath.Join("games", "b.nes")},
+	}
+
+	mock.ExpectQuery(`SELECT EXISTS.*MediaTags.*MediaTitleTags`).
+		WithArgs(int64(1), int64(2), int64(10), int64(20)).
+		WillReturnRows(sqlmock.NewRows([]string{"hasTags"}).AddRow(false))
+
+	err = fetchAndAttachTags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.Empty(t, results[0].Tags)
+	assert.Empty(t, results[1].Tags)
+	assert.NotNil(t, results[0].ZapScriptTags)
+	assert.NotNil(t, results[1].ZapScriptTags)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## Summary
- throttle and cache media.image misses to reduce SQLite pressure during browsing
- remove browse hot-path diagnostic/fallback scans and optimize remaining path fallback ranges
- bound optional media history/scrape status enrichment so startup responses do not wait on slow DB lookups

## Validation
- go test ./pkg/api/models/ ./pkg/api/methods/ ./pkg/database/mediadb/
- pre-push: task lint-fix
- pre-push: task test
- pre-push: task cross-lint:all
- profiled on 10.0.0.107:7497; CPU/image duplicate and browse timings improved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved "no image" caching and serialized image lookups for faster, more consistent image responses
  * Introduced a quiet client error to reduce noisy warnings for expected client failures

* **Bug Fixes**
  * Timeouts/bounds added to several DB lookups so requests complete promptly
  * Scrape/status updates now reset derived image state so UI reflects fresh results
  * Better handling of archive (zip) alias resolution to avoid incorrect aliasing

* **Tests**
  * Added coverage for caching, semaphore/timeout behavior, tag/search cases, and browse benchmarks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->