### PR TITLE
fix(media): handle prefixed collection browsing

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -544,7 +544,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | maxResults | number | No       | Maximum results per page. Default is 100, maximum is 1000.                                                 |
 | cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page. Cursors are valid only with the same path, systems, letter, and sort parameters. |
 | letter     | string | No       | Filter results to entries starting with this letter.                                                       |
-| sort       | string | No       | Sort order. One of: `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. The `filename` variants sort by full file path. |
+| sort       | string | No       | Sort order. One of: `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. Name sorting is prefix-aware for detected ranked/date collection folders. The `filename` variants sort by full file path. |
 
 #### Result
 

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -681,7 +681,8 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
 	results := make([]models.SearchResultMedia, 0, len(searchResults))
-	for _, result := range searchResults {
+	for i := range searchResults {
+		result := &searchResults[i]
 		system, err := systemdefs.GetSystem(result.SystemID)
 		if err != nil {
 			continue

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -39,6 +39,7 @@ import (
 // browseCursorData is the JSON-serializable keyset cursor for browse pagination.
 type browseCursorData struct {
 	SortValue  string `json:"sortValue"`
+	SortMode   string `json:"sortMode,omitempty"`
 	LastID     int64  `json:"lastId"`
 	TotalFiles int    `json:"totalFiles,omitempty"`
 }
@@ -47,6 +48,18 @@ func encodeBrowseCursor(lastID int64, sortValue string, totalFiles ...int) (stri
 	data := browseCursorData{LastID: lastID, SortValue: sortValue}
 	if len(totalFiles) > 0 && totalFiles[0] > 0 {
 		data.TotalFiles = totalFiles[0]
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal browse cursor: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+func encodeBrowseCursorWithMode(lastID int64, sortValue, sortMode string, totalFiles int) (string, error) {
+	data := browseCursorData{LastID: lastID, SortValue: sortValue, SortMode: sortMode}
+	if totalFiles > 0 {
+		data.TotalFiles = totalFiles
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
@@ -73,6 +86,7 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 	return &database.BrowseCursor{
 		LastID:     data.LastID,
 		SortValue:  data.SortValue,
+		SortMode:   data.SortMode,
 		TotalFiles: data.TotalFiles,
 	}, nil
 }
@@ -687,14 +701,18 @@ func buildBrowseResponse(
 		var nextCursor *string
 		if hasNextPage {
 			lastResult := files[len(files)-1]
-			var sortValue string
-			switch sort {
-			case "filename-asc", "filename-desc":
-				sortValue = lastResult.Path
-			default:
-				sortValue = lastResult.Name
+			sortValue := lastResult.SortValue
+			if sortValue == "" {
+				switch sort {
+				case "filename-asc", "filename-desc":
+					sortValue = lastResult.Path
+				default:
+					sortValue = lastResult.Name
+				}
 			}
-			encoded, encErr := encodeBrowseCursor(lastResult.MediaID, sortValue, totalFiles)
+			encoded, encErr := encodeBrowseCursorWithMode(
+				lastResult.MediaID, sortValue, lastResult.SortMode, totalFiles,
+			)
 			if encErr != nil {
 				return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
 			}

--- a/pkg/database/browseprefix/prefix.go
+++ b/pkg/database/browseprefix/prefix.go
@@ -1,0 +1,218 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package browseprefix
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	KindNone Kind = ""
+	KindRank Kind = "rank"
+	KindDate Kind = "date"
+)
+
+const (
+	DefaultThreshold = 0.5
+	DefaultMinFiles  = 5
+)
+
+type Kind string
+
+type Prefix struct {
+	Kind Kind
+	Rest string
+}
+
+type Policy struct {
+	Kind    Kind
+	Enabled bool
+}
+
+func StemFromPath(path string) string {
+	base := filepath.Base(path)
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return base
+	}
+	return strings.TrimSuffix(base, ext)
+}
+
+func ParseStem(stem string) Prefix {
+	trimmed := strings.TrimSpace(stem)
+	if trimmed == "" {
+		return Prefix{}
+	}
+	if prefix := parseDate(trimmed); prefix.Kind != KindNone {
+		return prefix
+	}
+	return parseRank(trimmed)
+}
+
+func DetectPolicyForPaths(paths []string, threshold float64, minFiles int) Policy {
+	if len(paths) < minFiles {
+		return Policy{}
+	}
+
+	dateCount := 0
+	rankCount := 0
+	for _, path := range paths {
+		prefix := ParseStem(StemFromPath(path))
+		switch prefix.Kind {
+		case KindDate:
+			dateCount++
+		case KindRank:
+			rankCount++
+		case KindNone:
+		}
+	}
+
+	fileCount := float64(len(paths))
+	if float64(dateCount)/fileCount > threshold {
+		return Policy{Kind: KindDate, Enabled: true}
+	}
+	if float64(rankCount)/fileCount > threshold {
+		return Policy{Kind: KindRank, Enabled: true}
+	}
+	return Policy{}
+}
+
+func StripWithPolicy(stem string, policy Policy) (string, bool) {
+	if !policy.Enabled {
+		return stem, false
+	}
+	prefix := ParseStem(stem)
+	if prefix.Kind != policy.Kind || prefix.Rest == "" {
+		return stem, false
+	}
+	return prefix.Rest, true
+}
+
+func parseRank(s string) Prefix {
+	digitEnd := 0
+	for digitEnd < len(s) && isASCIIDigit(s[digitEnd]) {
+		digitEnd++
+	}
+	if digitEnd == 0 || digitEnd > 3 || digitEnd == len(s) {
+		return Prefix{}
+	}
+
+	sepEnd := digitEnd
+	for sepEnd < len(s) {
+		ch := s[sepEnd]
+		if ch != '.' && ch != '-' && ch != ')' && ch != '_' && !isSpaceByte(ch) {
+			break
+		}
+		sepEnd++
+	}
+	if sepEnd == digitEnd || sepEnd == len(s) {
+		return Prefix{}
+	}
+
+	rest := strings.TrimSpace(s[sepEnd:])
+	if rest == "" {
+		return Prefix{}
+	}
+	return Prefix{Kind: KindRank, Rest: rest}
+}
+
+func parseDate(s string) Prefix {
+	if len(s) < 6 || !allDigits(s[:4]) {
+		return Prefix{}
+	}
+	year, err := strconv.Atoi(s[:4])
+	if err != nil || year < 1900 || year > 2099 {
+		return Prefix{}
+	}
+
+	pos := 4
+	if pos < len(s) && isDatePartSeparator(s[pos]) && pos+3 <= len(s) && allDigits(s[pos+1:pos+3]) {
+		month, monthErr := strconv.Atoi(s[pos+1 : pos+3])
+		if monthErr != nil || month < 1 || month > 12 {
+			return Prefix{}
+		}
+		pos += 3
+		if pos < len(s) && isDatePartSeparator(s[pos]) && pos+3 <= len(s) && allDigits(s[pos+1:pos+3]) {
+			day, dayErr := strconv.Atoi(s[pos+1 : pos+3])
+			if dayErr != nil || day < 1 || day > daysInMonth(year, month) {
+				return Prefix{}
+			}
+			pos += 3
+		}
+	}
+
+	if pos >= len(s) || !isSeparatorRune(rune(s[pos])) {
+		return Prefix{}
+	}
+	rest := strings.TrimLeftFunc(s[pos:], isSeparatorRune)
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return Prefix{}
+	}
+	return Prefix{Kind: KindDate, Rest: rest}
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range s {
+		if !isASCIIDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIDigit(ch byte) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+func isSpaceByte(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+func isDatePartSeparator(ch byte) bool {
+	return ch == '-' || ch == '.' || ch == '_'
+}
+
+func isSeparatorRune(r rune) bool {
+	return r == '-' || r == '.' || r == '_' || r == ')' || unicode.IsSpace(r)
+}
+
+func daysInMonth(year, month int) int {
+	switch month {
+	case 4, 6, 9, 11:
+		return 30
+	case 2:
+		if year%400 == 0 || (year%4 == 0 && year%100 != 0) {
+			return 29
+		}
+		return 28
+	default:
+		return 31
+	}
+}

--- a/pkg/database/browseprefix/prefix_test.go
+++ b/pkg/database/browseprefix/prefix_test.go
@@ -57,6 +57,104 @@ func TestParseStem(t *testing.T) {
 	}
 }
 
+func TestStemFromPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		path string
+		stem string
+	}{
+		{
+			name: "filename with extension",
+			path: filepath.Join("roms", "genesis", "001 - Sonic.gen"),
+			stem: "001 - Sonic",
+		},
+		{
+			name: "nested date file",
+			path: filepath.Join("roms", "genesis", "history", "1991-06-23 - Sonic.zip"),
+			stem: "1991-06-23 - Sonic",
+		},
+		{name: "no extension", path: filepath.Join("roms", "genesis", "Sonic"), stem: "Sonic"},
+		{
+			name: "dot in title",
+			path: filepath.Join("roms", "genesis", "Sonic. The Hedgehog.gen"),
+			stem: "Sonic. The Hedgehog",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.stem, StemFromPath(tt.path))
+		})
+	}
+}
+
+func TestStripWithPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		rest    string
+		parsed  Kind
+		policy  Policy
+		strips  bool
+		enabled bool
+	}{
+		{
+			name:    "enabled rank policy strips rank prefix",
+			path:    filepath.Join("roms", "genesis", "001 - Sonic.gen"),
+			policy:  Policy{Kind: KindRank, Enabled: true},
+			rest:    "Sonic",
+			strips:  true,
+			parsed:  KindRank,
+			enabled: true,
+		},
+		{
+			name:    "disabled policy keeps stem",
+			path:    filepath.Join("roms", "genesis", "001 - Sonic.gen"),
+			policy:  Policy{Kind: KindRank},
+			rest:    "001 - Sonic",
+			parsed:  KindRank,
+			enabled: false,
+		},
+		{
+			name:    "kind mismatch keeps stem",
+			path:    filepath.Join("roms", "genesis", "Sonic.gen"),
+			policy:  Policy{Kind: KindDate, Enabled: true},
+			rest:    "Sonic",
+			parsed:  KindNone,
+			enabled: true,
+		},
+		{
+			name:    "empty rest keeps stem",
+			path:    filepath.Join("roms", "genesis", "001.gen"),
+			policy:  Policy{Kind: KindRank, Enabled: true},
+			rest:    "001",
+			parsed:  KindNone,
+			enabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			stem := StemFromPath(tt.path)
+			prefix := ParseStem(stem)
+			got, ok := StripWithPolicy(stem, tt.policy)
+
+			assert.Equal(t, tt.parsed, prefix.Kind)
+			assert.Equal(t, tt.rest, got)
+			assert.Equal(t, tt.strips, ok)
+			assert.Equal(t, tt.enabled, tt.policy.Enabled)
+		})
+	}
+}
+
 func TestDetectPolicyForPathsUsesStems(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/browseprefix/prefix_test.go
+++ b/pkg/database/browseprefix/prefix_test.go
@@ -1,0 +1,73 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package browseprefix
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseStem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		stem string
+		kind Kind
+		rest string
+	}{
+		{name: "rank dash", stem: "001 - Sonic", kind: KindRank, rest: "Sonic"},
+		{name: "rank period", stem: "42. Contra", kind: KindRank, rest: "Contra"},
+		{name: "rank paren", stem: "7) Zelda", kind: KindRank, rest: "Zelda"},
+		{name: "date full", stem: "1991-06-23 - Sonic", kind: KindDate, rest: "Sonic"},
+		{name: "date dotted", stem: "1991.06.23 Sonic", kind: KindDate, rest: "Sonic"},
+		{name: "date year", stem: "1991 - Sonic", kind: KindDate, rest: "Sonic"},
+		{name: "bare numeric title", stem: "1942", kind: KindNone, rest: ""},
+		{name: "number plus letter title", stem: "3D Worldrunner", kind: KindNone, rest: ""},
+		{name: "invalid date", stem: "1991-13-01 - Sonic", kind: KindNone, rest: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ParseStem(tt.stem)
+			assert.Equal(t, tt.kind, got.Kind)
+			assert.Equal(t, tt.rest, got.Rest)
+		})
+	}
+}
+
+func TestDetectPolicyForPathsUsesStems(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{
+		filepath.Join("roms", "nes", "1942.nes"),
+		filepath.Join("roms", "nes", "007.nes"),
+		filepath.Join("roms", "nes", "3D Worldrunner.nes"),
+		filepath.Join("roms", "nes", "720 Degrees.nes"),
+		filepath.Join("roms", "nes", "8 Eyes.nes"),
+	}
+
+	policy := DetectPolicyForPaths(paths, DefaultThreshold, DefaultMinFiles)
+	assert.False(t, policy.Enabled)
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -271,6 +271,7 @@ type BrowseDirectoriesOptions struct {
 // count so cursor pages do not need to rerun the same count query.
 type BrowseCursor struct {
 	SortValue  string
+	SortMode   string
 	LastID     int64
 	TotalFiles int
 }
@@ -340,6 +341,8 @@ type SearchResultWithCursor struct {
 	SystemID      string
 	Name          string
 	Path          string
+	SortValue     string
+	SortMode      string
 	Tags          []TagInfo
 	ZapScriptTags []TagInfo // Disambiguating tags only (tags that differ across sibling variants)
 	MediaID       int64
@@ -647,6 +650,7 @@ type MediaDBI interface {
 	UpdateMediaParentDir(mediaDBID int64, parentDir string) error
 	DeleteMediaTags(mediaDBID int64) error
 	DeleteMediaTag(mediaDBID, tagDBID int64) error
+	DeleteMediaTagsByTagIDs(mediaDBID int64, tagDBIDs []int) error
 	TemporaryRepairJobsPending(ctx context.Context) (bool, error)
 
 	FindTagType(row TagType) (TagType, error)
@@ -704,6 +708,7 @@ type MediaDBI interface {
 	GetTitlesBySystemID(systemID string) ([]TitleWithSystem, error)
 	GetMediaBySystemID(systemID string) ([]MediaWithFullPath, error)
 	GetMediaTagsBySystemID(systemID string) ([]MediaTagLink, error)
+	GetScannerMediaTagsBySystemID(systemID string) ([]MediaTagLink, error)
 
 	// Scraper support methods
 

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2298,6 +2298,19 @@ func (db *MediaDB) DeleteMediaTag(mediaDBID, tagDBID int64) error {
 	return err
 }
 
+func (db *MediaDB) DeleteMediaTagsByTagIDs(mediaDBID int64, tagDBIDs []int) error {
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+
+	err := sqlDeleteMediaTagsByTagIDs(db.ctx, db.conn(), mediaDBID, tagDBIDs)
+	if err == nil && !db.inTransaction {
+		db.invalidateCaches(invalidationScope{AllSystems: true})
+	}
+
+	return err
+}
+
 func (db *MediaDB) BulkSetMediaMissing(dbids map[int]struct{}) error {
 	if db.sql == nil {
 		return ErrNullSQL
@@ -2542,6 +2555,15 @@ func (db *MediaDB) GetMediaTagsBySystemID(systemID string) ([]database.MediaTagL
 	}
 
 	return sqlGetMediaTagsBySystemID(db.ctx, db.sql, systemID)
+}
+
+// GetScannerMediaTagsBySystemID retrieves scanner-managed media-tag links for a specific system.
+func (db *MediaDB) GetScannerMediaTagsBySystemID(systemID string) ([]database.MediaTagLink, error) {
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	return sqlGetScannerMediaTagsBySystemID(db.ctx, db.sql, systemID)
 }
 
 // GetSystemsExcluding retrieves all systems except those in the excludeSystemIDs list.

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3528,11 +3528,11 @@ func TestMediaDB_BrowseFiles_UsesRankPrefixSortForNumberedCollections(t *testing
 		name string
 		slug string
 	}{
-		{path: dir + "1 - Zelda.gen", name: "Zelda", slug: "zelda"},
-		{path: dir + "2 - Sonic.gen", name: "Sonic", slug: "sonic"},
-		{path: dir + "3 - Alpha.gen", name: "Alpha", slug: "alpha"},
-		{path: dir + "4 - Beta.gen", name: "Beta", slug: "beta"},
-		{path: dir + "10 - Contra.gen", name: "Contra", slug: "contra"},
+		{path: filepath.ToSlash(filepath.Join(dir, "1 - Zelda.gen")), name: "Zelda", slug: "zelda"},
+		{path: filepath.ToSlash(filepath.Join(dir, "2 - Sonic.gen")), name: "Sonic", slug: "sonic"},
+		{path: filepath.ToSlash(filepath.Join(dir, "3 - Alpha.gen")), name: "Alpha", slug: "alpha"},
+		{path: filepath.ToSlash(filepath.Join(dir, "4 - Beta.gen")), name: "Beta", slug: "beta"},
+		{path: filepath.ToSlash(filepath.Join(dir, "10 - Contra.gen")), name: "Contra", slug: "contra"},
 	}
 	for _, entry := range entries {
 		title, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -184,6 +184,51 @@ func TestMediaTagCompositeLookupAndDelete(t *testing.T) {
 	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
+func TestMediaTagBatchDeleteByTagIDs(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	t.Cleanup(cleanup)
+
+	tagType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "extension"})
+	require.NoError(t, err)
+	tagOne, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tagType.DBID, Tag: "nes"})
+	require.NoError(t, err)
+	tagTwo, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tagType.DBID, Tag: "sfc"})
+	require.NoError(t, err)
+	tagThree, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tagType.DBID, Tag: "gen"})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	system, err := mediaDB.InsertSystem(database.System{SystemID: "nes", Name: "NES"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: system.DBID,
+		Slug:       "batchdeletegame",
+		Name:       "Batch Delete Game",
+	})
+	require.NoError(t, err)
+	media, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     system.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "batch.nes"),
+	})
+	require.NoError(t, err)
+	for _, tag := range []database.Tag{tagOne, tagTwo, tagThree} {
+		_, insertErr := mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: media.DBID, TagDBID: tag.DBID})
+		require.NoError(t, insertErr)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	require.NoError(t, mediaDB.DeleteMediaTagsByTagIDs(media.DBID, nil))
+	require.NoError(t, mediaDB.DeleteMediaTagsByTagIDs(media.DBID, []int{int(tagOne.DBID), int(tagThree.DBID)}))
+
+	remaining, err := mediaDB.GetMediaTagsBySystemID("nes")
+	require.NoError(t, err)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, tagTwo.DBID, remaining[0].TagDBID)
+}
+
 func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {
 	// Create temp directory that the mock platform will use
 	tempDir, err := os.MkdirTemp("", "zaparoo-test-mediadb-*")
@@ -3463,4 +3508,66 @@ func TestMediaDB_BrowseSystemRootCandidates_MultipleRootsBatched_Integration(t *
 	assert.False(t, result.HasMedia[cifsDir], "cifs root has no indexed media")
 	assert.Equal(t, []string{"snes"}, result.Children[romsDir])
 	assert.Equal(t, []string{"nes"}, result.Children[usbDir])
+}
+
+func TestMediaDB_BrowseFiles_UsesRankPrefixSortForNumberedCollections(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "Genesis", Name: "Genesis"})
+	require.NoError(t, err)
+
+	dir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "genesis", "best")) + "/"
+	entries := []struct {
+		path string
+		name string
+		slug string
+	}{
+		{path: dir + "1 - Zelda.gen", name: "Zelda", slug: "zelda"},
+		{path: dir + "2 - Sonic.gen", name: "Sonic", slug: "sonic"},
+		{path: dir + "3 - Alpha.gen", name: "Alpha", slug: "alpha"},
+		{path: dir + "4 - Beta.gen", name: "Beta", slug: "beta"},
+		{path: dir + "10 - Contra.gen", name: "Contra", slug: "contra"},
+	}
+	for _, entry := range entries {
+		title, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       entry.slug,
+			Name:       entry.name,
+		})
+		require.NoError(t, insertErr)
+		_, insertErr = mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           entry.path,
+			ParentDir:      dir,
+		})
+		require.NoError(t, insertErr)
+	}
+
+	files, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{PathPrefix: dir, Limit: 4})
+	require.NoError(t, err)
+	require.Len(t, files, 4)
+	assert.Equal(t, []string{"Zelda", "Sonic", "Alpha", "Beta"}, []string{
+		files[0].Name, files[1].Name, files[2].Name, files[3].Name,
+	})
+	assert.Equal(t, browseSortRankPrefixAsc, files[0].SortMode)
+
+	nextPage, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: dir,
+		Limit:      2,
+		Cursor: &database.BrowseCursor{
+			SortValue: files[3].SortValue,
+			SortMode:  files[3].SortMode,
+			LastID:    files[3].MediaID,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, nextPage, 1)
+	assert.Equal(t, "Contra", nextPage[0].Name)
 }

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -28,8 +28,16 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/rs/zerolog/log"
+)
+
+const (
+	browseSortRankPrefixAsc  = "rank-prefix-asc"
+	browseSortRankPrefixDesc = "rank-prefix-desc"
+	browseSortDatePrefixAsc  = "date-prefix-asc"
+	browseSortDatePrefixDesc = "date-prefix-desc"
 )
 
 func browseSystemFilterClause(column string, systems []systemdefs.System) (clause string, args []any) {
@@ -344,30 +352,121 @@ func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, 
 	return strings.Join(conditions, " AND "), args
 }
 
-func browseSortClause(sortOrder string) string {
+func browseFilenameExpr() string {
+	return `substr(m.Path, length(m.ParentDir) + 1)`
+}
+
+func browseRankPrefixSortExpr() string {
+	filename := browseFilenameExpr()
+	return `CASE WHEN substr(` + filename + `, 1, 1) BETWEEN '0' AND '9' ` +
+		`THEN printf('%010d:%s', CAST(` + filename + ` AS INTEGER), ` + filename + `) ` +
+		`ELSE 'zzzzzzzzzz:' || mt.Name END`
+}
+
+func browseSortExpr(sortOrder string) string {
 	switch sortOrder {
-	case "name-desc":
-		return "mt.Name DESC, m.DBID DESC"
-	case "filename-asc":
-		return "m.Path ASC, m.DBID ASC"
-	case "filename-desc":
-		return "m.Path DESC, m.DBID DESC"
+	case "filename-asc", "filename-desc":
+		return "m.Path"
+	case browseSortRankPrefixAsc, browseSortRankPrefixDesc:
+		return browseRankPrefixSortExpr()
+	case browseSortDatePrefixAsc, browseSortDatePrefixDesc:
+		return browseFilenameExpr()
 	default:
-		return "mt.Name ASC, m.DBID ASC"
+		return "mt.Name"
+	}
+}
+
+func browseSortClause(sortOrder string) string {
+	expr := browseSortExpr(sortOrder)
+	switch sortOrder {
+	case "name-desc", "filename-desc", browseSortRankPrefixDesc, browseSortDatePrefixDesc:
+		return expr + " DESC, m.DBID DESC"
+	default:
+		return expr + " ASC, m.DBID ASC"
 	}
 }
 
 func browseCursorCondition(sortOrder string) string {
+	expr := browseSortExpr(sortOrder)
 	switch sortOrder {
-	case "name-desc":
-		return ` AND (mt.Name, m.DBID) < (?, ?)`
-	case "filename-asc":
-		return ` AND (m.Path, m.DBID) > (?, ?)`
-	case "filename-desc":
-		return ` AND (m.Path, m.DBID) < (?, ?)`
+	case "name-desc", "filename-desc", browseSortRankPrefixDesc, browseSortDatePrefixDesc:
+		return ` AND (` + expr + `, m.DBID) < (?, ?)`
 	default:
-		return ` AND (mt.Name, m.DBID) > (?, ?)`
+		return ` AND (` + expr + `, m.DBID) > (?, ?)`
 	}
+}
+
+func resolveBrowseSortMode(ctx context.Context, db sqlQueryable, opts *database.BrowseFilesOptions) string {
+	if opts.Cursor != nil && opts.Cursor.SortMode != "" {
+		return opts.Cursor.SortMode
+	}
+	if opts.Letter != nil {
+		return opts.Sort
+	}
+	if opts.Sort != "" && opts.Sort != "name-asc" && opts.Sort != "name-desc" {
+		return opts.Sort
+	}
+
+	policy, err := detectBrowsePrefixPolicy(ctx, db, opts.PathPrefix, opts.Systems)
+	if err != nil {
+		log.Debug().Err(err).Str("path", opts.PathPrefix).Msg("browse prefix policy detection failed")
+		return opts.Sort
+	}
+	if !policy.Enabled {
+		return opts.Sort
+	}
+	desc := opts.Sort == "name-desc"
+	switch policy.Kind {
+	case browseprefix.KindRank:
+		if desc {
+			return browseSortRankPrefixDesc
+		}
+		return browseSortRankPrefixAsc
+	case browseprefix.KindDate:
+		if desc {
+			return browseSortDatePrefixDesc
+		}
+		return browseSortDatePrefixAsc
+	default:
+		return opts.Sort
+	}
+}
+
+func detectBrowsePrefixPolicy(
+	ctx context.Context,
+	db sqlQueryable,
+	pathPrefix string,
+	systems []systemdefs.System,
+) (browseprefix.Policy, error) {
+	conditions := []string{`m.ParentDir = ?`, `m.IsMissing = 0`}
+	args := []any{pathPrefix}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", systems); systemClause != "" {
+		conditions = append(conditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+
+	query := `SELECT m.Path
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE ` + strings.Join(conditions, " AND ")
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return browseprefix.Policy{}, fmt.Errorf("browse prefix detection query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	paths := make([]string, 0)
+	for rows.Next() {
+		var path string
+		if scanErr := rows.Scan(&path); scanErr != nil {
+			return browseprefix.Policy{}, fmt.Errorf("browse prefix detection scan: %w", scanErr)
+		}
+		paths = append(paths, path)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return browseprefix.Policy{}, fmt.Errorf("browse prefix detection rows: %w", rowsErr)
+	}
+	return browseprefix.DetectPolicyForPaths(paths, browseprefix.DefaultThreshold, browseprefix.DefaultMinFiles), nil
 }
 
 func sqlBrowseFiles(
@@ -384,16 +483,18 @@ func sqlBrowseFilesFromMedia(
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
 	where, args := browseFilesBaseCondition(opts)
-	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID, mt.DBID
+	sortMode := resolveBrowseSortMode(ctx, db, opts)
+	sortExpr := browseSortExpr(sortMode)
+	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID, mt.DBID, ` + sortExpr + ` AS SortValue
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
 	if opts.Cursor != nil {
-		query += browseCursorCondition(opts.Sort)
+		query += browseCursorCondition(sortMode)
 		args = append(args, opts.Cursor.SortValue, opts.Cursor.LastID)
 	}
-	query += ` ORDER BY ` + browseSortClause(opts.Sort) + ` LIMIT ?`
+	query += ` ORDER BY ` + browseSortClause(sortMode) + ` LIMIT ?`
 	args = append(args, opts.Limit)
 
 	queryStarted := time.Now()
@@ -406,9 +507,12 @@ func sqlBrowseFilesFromMedia(
 	var results []database.SearchResultWithCursor
 	for rows.Next() {
 		var r database.SearchResultWithCursor
-		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID); scanErr != nil {
+		if scanErr := rows.Scan(
+			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID, &r.SortValue,
+		); scanErr != nil {
 			return nil, fmt.Errorf("browse files scan: %w", scanErr)
 		}
+		r.SortMode = sortMode
 		results = append(results, r)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {

--- a/pkg/database/mediadb/sql_media_tags.go
+++ b/pkg/database/mediadb/sql_media_tags.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/rs/zerolog/log"
 )
 
@@ -132,6 +133,27 @@ func sqlDeleteMediaTag(ctx context.Context, db sqlQueryable, mediaDBID, tagDBID 
 	return nil
 }
 
+func sqlDeleteMediaTagsByTagIDs(ctx context.Context, db sqlQueryable, mediaDBID int64, tagDBIDs []int) error {
+	if len(tagDBIDs) == 0 {
+		return nil
+	}
+
+	args := make([]any, 0, len(tagDBIDs)+1)
+	args = append(args, mediaDBID)
+	for _, tagDBID := range tagDBIDs {
+		args = append(args, tagDBID)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	query := `DELETE FROM MediaTags WHERE MediaDBID = ? AND TagDBID IN (` +
+		prepareVariadic("?", ",", len(tagDBIDs)) + `)`
+	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to delete media tags by tag IDs: %w", err)
+	}
+
+	return nil
+}
+
 func sqlGetMediaTagsBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaTagLink, error) {
 	query := `
 		SELECT mt.MediaDBID, mt.TagDBID
@@ -141,9 +163,31 @@ func sqlGetMediaTagsBySystemID(ctx context.Context, db *sql.DB, systemID string)
 		WHERE s.SystemID = ?
 		ORDER BY mt.MediaDBID, mt.TagDBID
 	`
-	rows, err := db.QueryContext(ctx, query, systemID)
+	return sqlQueryMediaTagLinksBySystemID(ctx, db, query, systemID, systemID)
+}
+
+func sqlGetScannerMediaTagsBySystemID(
+	ctx context.Context, db *sql.DB, systemID string,
+) ([]database.MediaTagLink, error) {
+	query := `
+		SELECT mt.MediaDBID, mt.TagDBID
+		FROM MediaTags mt
+		JOIN Media m ON mt.MediaDBID = m.DBID
+		JOIN Systems s ON m.SystemDBID = s.DBID
+		JOIN Tags t ON mt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE s.SystemID = ? AND tt.Type != ?
+		ORDER BY mt.MediaDBID, mt.TagDBID
+	`
+	return sqlQueryMediaTagLinksBySystemID(ctx, db, query, systemID, systemID, string(tags.TagTypeUser))
+}
+
+func sqlQueryMediaTagLinksBySystemID(
+	ctx context.Context, db *sql.DB, query string, systemID string, args ...any,
+) ([]database.MediaTagLink, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query media tags for system %s: %w", systemID, err)
+		return nil, fmt.Errorf("failed to query media tags by system: %w", err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -56,8 +56,8 @@ func fetchAndAttachTags(
 	}
 
 	mediaIDs := make([]int64, len(results))
-	for i, result := range results {
-		mediaIDs[i] = result.MediaID
+	for i := range results {
+		mediaIDs[i] = results[i].MediaID
 	}
 
 	// Two indexed queries combined with UNION ALL beat a single OR JOIN
@@ -258,7 +258,8 @@ func collectResultTagIDs(results []database.SearchResultWithCursor) resultTagIDs
 		titleIDs:        make([]int64, 0, len(results)),
 	}
 	seenTitles := make(map[int64]struct{}, len(results))
-	for i, result := range results {
+	for i := range results {
+		result := &results[i]
 		tagIDs.mediaIDs[i] = result.MediaID
 		tagIDs.titleToMediaIDs[result.MediaTitleID] = append(
 			tagIDs.titleToMediaIDs[result.MediaTitleID], result.MediaID,

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
@@ -42,16 +43,12 @@ import (
 
 // PathFragmentParams contains parameters for GetPathFragments.
 type PathFragmentParams struct {
-	Config    *config.Instance
-	Path      string
-	SystemID  string
-	MediaType slugs.MediaType // Pre-resolved media type; skips systemdefs lookup if set
-	// ProvidedName, when non-empty, overrides the title that would otherwise be
-	// parsed from the filename. Tags are still extracted from the filename.
-	// Slug derives from ProvidedName when set, so any downstream consumer that
-	// looks titles up by slug must supply the same ProvidedName to compute a
-	// matching slug (see gamelistxml.LoadRecords for an example).
+	Config              *config.Instance
+	Path                string
+	SystemID            string
+	MediaType           slugs.MediaType
 	ProvidedName        string
+	PrefixPolicy        browseprefix.Policy
 	NoExt               bool
 	StripLeadingNumbers bool
 }
@@ -114,15 +111,33 @@ func AddMediaPath(
 	cfg *config.Instance,
 	mediaType slugs.MediaType,
 ) (titleIndex, mediaIndex int, err error) {
+	prefixPolicy := browseprefix.Policy{}
+	if stripLeadingNumbers {
+		prefixPolicy = browseprefix.Policy{Kind: browseprefix.KindRank, Enabled: true}
+	}
+	return AddMediaPathWithPrefixPolicy(db, ss, systemID, path, providedName, noExt, prefixPolicy, cfg, mediaType)
+}
+
+func AddMediaPathWithPrefixPolicy(
+	db database.MediaDBI,
+	ss *database.ScanState,
+	systemID string,
+	path string,
+	providedName string,
+	noExt bool,
+	prefixPolicy browseprefix.Policy,
+	cfg *config.Instance,
+	mediaType slugs.MediaType,
+) (titleIndex, mediaIndex int, err error) {
 	existingMedia := false
 	pf := GetPathFragments(&PathFragmentParams{
-		Config:              cfg,
-		Path:                path,
-		NoExt:               noExt,
-		StripLeadingNumbers: stripLeadingNumbers,
-		SystemID:            systemID,
-		MediaType:           mediaType,
-		ProvidedName:        providedName,
+		Config:       cfg,
+		Path:         path,
+		NoExt:        noExt,
+		PrefixPolicy: prefixPolicy,
+		SystemID:     systemID,
+		MediaType:    mediaType,
+		ProvidedName: providedName,
 	})
 
 	systemIndex := 0
@@ -364,6 +379,7 @@ func reconcileExistingMediaTags(
 		existingTagIDs = make(map[int]struct{})
 	}
 
+	staleTagIDs := make([]int, 0)
 	for tagIndex := range existingTagIDs {
 		if _, ok := desiredTagIDs[tagIndex]; ok {
 			continue
@@ -372,8 +388,11 @@ func reconcileExistingMediaTags(
 			desiredTagIDs[tagIndex] = struct{}{}
 			continue
 		}
-		if err := db.DeleteMediaTag(int64(mediaIndex), int64(tagIndex)); err != nil {
-			return fmt.Errorf("failed to delete media tag %d: %w", tagIndex, err)
+		staleTagIDs = append(staleTagIDs, tagIndex)
+	}
+	if len(staleTagIDs) > 0 {
+		if err := db.DeleteMediaTagsByTagIDs(int64(mediaIndex), staleTagIDs); err != nil {
+			return fmt.Errorf("failed to delete stale media tags: %w", err)
 		}
 	}
 
@@ -851,9 +870,9 @@ func loadSystemStateData(
 
 	mediaTags := []database.MediaTagLink(nil)
 	if loadMediaTags {
-		mediaTags, err = db.GetMediaTagsBySystemID(systemID)
+		mediaTags, err = db.GetScannerMediaTagsBySystemID(systemID)
 		if err != nil {
-			return systemStateData{}, fmt.Errorf("failed to get media tags for system %s: %w", systemID, err)
+			return systemStateData{}, fmt.Errorf("failed to get scanner media tags for system %s: %w", systemID, err)
 		}
 	}
 
@@ -1135,7 +1154,15 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 	if trimmedName != "" {
 		f.Title = trimmedName
 	} else {
-		f.Title = tags.ParseTitleFromFilename(f.FileName, params.StripLeadingNumbers)
+		fileNameForTitle := f.FileName
+		prefixPolicy := params.PrefixPolicy
+		if !prefixPolicy.Enabled && params.StripLeadingNumbers {
+			prefixPolicy = browseprefix.Policy{Kind: browseprefix.KindRank, Enabled: true}
+		}
+		if stripped, ok := browseprefix.StripWithPolicy(f.FileName, prefixPolicy); ok {
+			fileNameForTitle = stripped
+		}
+		f.Title = tags.ParseTitleFromFilename(fileNameForTitle, false)
 	}
 
 	// Use pre-resolved media type if provided, otherwise look up from system ID

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -1150,11 +1150,11 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 		f.FileName, _ = strings.CutSuffix(fileBase, f.Ext)
 	}
 
+	fileNameForTitle := f.FileName
 	trimmedName := strings.TrimSpace(params.ProvidedName)
 	if trimmedName != "" {
 		f.Title = trimmedName
 	} else {
-		fileNameForTitle := f.FileName
 		prefixPolicy := params.PrefixPolicy
 		if !prefixPolicy.Enabled && params.StripLeadingNumbers {
 			prefixPolicy = browseprefix.Policy{Kind: browseprefix.KindRank, Enabled: true}
@@ -1189,7 +1189,7 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 		if trimmedName != "" {
 			f.Slug = strings.ToLower(trimmedName)
 		} else {
-			f.Slug = strings.ToLower(f.FileName)
+			f.Slug = strings.ToLower(fileNameForTitle)
 		}
 	}
 

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -463,6 +463,44 @@ func TestAddMediaPath_ReconcileExistingMediaTagsPreservesUserTags(t *testing.T) 
 	mockDB.AssertExpectations(t)
 }
 
+func TestAddMediaPath_ReconcileExistingMediaTagsBatchDeletesScannerTags(t *testing.T) {
+	t.Parallel()
+
+	mockDB := helpers.NewMockMediaDBI()
+	path := filepath.Join("roms", "NES", "Super Mario Bros.sfc")
+	pathKey := filepath.ToSlash(path)
+	scanState := &database.ScanState{
+		SystemIDs:     map[string]int{"NES": 1},
+		TitleIDs:      map[string]int{"NES:supermariobrothers": 10},
+		MediaIDs:      map[string]int{database.MediaKey("NES", pathKey): 20},
+		MediaTitleIDs: map[int]int{20: 10},
+		MediaTagIDs:   map[int]map[int]struct{}{20: {8: {}, 9: {}}},
+		TagTypeIDs:    map[string]int{string(tags.TagTypeExtension): 7, string(tags.TagTypeUser): 11},
+		TagIDs: map[string]int{
+			database.TagKey(string(tags.TagTypeExtension), "nes"):                   8,
+			database.TagKey(string(tags.TagTypeExtension), "sfc"):                   10,
+			database.TagKey(string(tags.TagTypeUser), string(tags.TagUserFavorite)): 9,
+		},
+		MissingMedia: map[int]struct{}{20: {}},
+	}
+
+	mockDB.On("DeleteMediaTagsByTagIDs", int64(20), []int{8}).Return(nil).Once()
+	mockDB.On("InsertMediaTag", database.MediaTag{TagDBID: 10, MediaDBID: 20}).
+		Return(database.MediaTag{}, nil).Once()
+
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 10, titleIndex)
+	assert.Equal(t, 20, mediaIndex)
+	assert.NotContains(t, scanState.MediaTagIDs[20], 8)
+	assert.Contains(t, scanState.MediaTagIDs[20], 9)
+	assert.Contains(t, scanState.MediaTagIDs[20], 10)
+	mockDB.AssertNotCalled(t, "DeleteMediaTag", mock.Anything, mock.Anything)
+	mockDB.AssertExpectations(t)
+}
+
 func TestAddMediaPath_LoadedScanStatePreservesUserTags(t *testing.T) {
 	t.Parallel()
 
@@ -506,6 +544,9 @@ func TestAddMediaPath_LoadedScanStatePreservesUserTags(t *testing.T) {
 	}
 	require.NoError(t, PopulateScanStateFromDB(ctx, mediaDB, refreshState))
 	require.NoError(t, PopulatePersistentScanStateForSystem(ctx, mediaDB, refreshState, "NES"))
+	extensionTagID := initialState.TagIDs[database.TagKey(string(tags.TagTypeExtension), "nes")]
+	assert.Contains(t, refreshState.MediaTagIDs[mediaID], extensionTagID)
+	assert.NotContains(t, refreshState.MediaTagIDs[mediaID], int(userTag.DBID))
 
 	require.NoError(t, mediaDB.BeginTransaction(true))
 	_, _, err = AddMediaPath(mediaDB, refreshState, "NES", path, "", false, false, nil, slugs.MediaTypeGame)

--- a/pkg/database/mediascanner/integration_test.go
+++ b/pkg/database/mediascanner/integration_test.go
@@ -22,6 +22,7 @@ package mediascanner
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -717,7 +718,7 @@ func TestGetPathFragments_DatePrefixPolicy(t *testing.T) {
 	t.Parallel()
 
 	fragments := GetPathFragments(&PathFragmentParams{
-		Path:         "/roms/genesis/history/1991-06-23 - Sonic the Hedgehog (USA).gen",
+		Path:         filepath.Join("roms", "genesis", "history", "1991-06-23 - Sonic the Hedgehog (USA).gen"),
 		SystemID:     "Genesis",
 		PrefixPolicy: browseprefix.Policy{Kind: browseprefix.KindDate, Enabled: true},
 	})

--- a/pkg/database/mediascanner/integration_test.go
+++ b/pkg/database/mediascanner/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner/testdata"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -681,8 +682,8 @@ func TestAutomaticNumberStrippingDetection(t *testing.T) {
 				{Path: "/roms/nes/720 Degrees.nes"},
 				{Path: "/roms/nes/8 Eyes.nes"},
 			},
-			expectedDetection: true,
-			description:       "5/5 files match because '007.nes' matches pattern (regex sees dot from extension)",
+			expectedDetection: false,
+			description:       "filename extensions are ignored before prefix detection",
 		},
 		{
 			name: "exactly at threshold boundary",
@@ -712,6 +713,19 @@ func TestAutomaticNumberStrippingDetection(t *testing.T) {
 // TestSlugGenerationPipeline tests the complete slug generation from file path to database.
 // This integration test ensures that the context-aware leading number stripping works correctly
 // throughout the entire indexing pipeline (file path → parsed title → slug → database storage).
+func TestGetPathFragments_DatePrefixPolicy(t *testing.T) {
+	t.Parallel()
+
+	fragments := GetPathFragments(&PathFragmentParams{
+		Path:         "/roms/genesis/history/1991-06-23 - Sonic the Hedgehog (USA).gen",
+		SystemID:     "Genesis",
+		PrefixPolicy: browseprefix.Policy{Kind: browseprefix.KindDate, Enabled: true},
+	})
+
+	assert.Equal(t, "Sonic the Hedgehog", fragments.Title)
+	assert.Equal(t, "sonicthehedgehog", fragments.Slug)
+}
+
 func TestSlugGenerationPipeline(t *testing.T) {
 	ctx := context.Background()
 	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
@@ -51,33 +51,18 @@ const (
 	maxFilesPerTransaction = 10000
 )
 
-// listNumberingRegex matches file list numbering patterns like "1. ", "01 - ", "42. "
-var listNumberingRegex = regexp.MustCompile(`^\d{1,3}[.\s\-]+`)
-
-// detectNumberingPattern returns true if a significant portion of files match list numbering pattern.
-// This heuristic detects directory-wide list numbering (e.g., "1. Game.zip", "2. Game.zip")
-// to distinguish from legitimate title numbers (e.g., "1942.zip", "007.zip").
-//
-// Parameters:
-//   - files: slice of scan results to analyze
-//   - threshold: minimum ratio of matching files (0.0-1.0) to trigger stripping
-//   - minFiles: minimum number of files required to apply heuristic
-//
-// Returns true if >threshold% of files match AND file count >= minFiles.
-func detectNumberingPattern(files []platforms.ScanResult, threshold float64, minFiles int) bool {
-	if len(files) < minFiles {
-		return false // Don't apply heuristic to small file sets
-	}
-
-	matchCount := 0
+func detectBrowsePrefixPolicy(files []platforms.ScanResult, threshold float64, minFiles int) browseprefix.Policy {
+	paths := make([]string, 0, len(files))
 	for _, file := range files {
-		filename := filepath.Base(file.Path)
-		if listNumberingRegex.MatchString(filename) {
-			matchCount++
-		}
+		paths = append(paths, file.Path)
 	}
+	return browseprefix.DetectPolicyForPaths(paths, threshold, minFiles)
+}
 
-	return float64(matchCount)/float64(len(files)) > threshold
+// detectNumberingPattern returns true when a directory looks like a ranked list.
+// Kept for focused scanner tests; production code uses detectBrowsePrefixPolicy.
+func detectNumberingPattern(files []platforms.ScanResult, threshold float64, minFiles int) bool {
+	return detectBrowsePrefixPolicy(files, threshold, minFiles).Kind == browseprefix.KindRank
 }
 
 type PathResult struct {
@@ -990,16 +975,18 @@ func NewNamesIndex(
 				Msg("grouped scanned files by directory")
 		}
 
-		stripPolicyByDir := make(map[string]bool)
+		prefixPolicyByDir := make(map[string]browseprefix.Policy)
 		for dir, dirFiles := range filesByDir {
 			// Use 50% threshold and require at least 5 files to apply heuristic
-			stripPolicyByDir[dir] = detectNumberingPattern(dirFiles, 0.5, 5)
+			prefixPolicyByDir[dir] = detectBrowsePrefixPolicy(
+				dirFiles, browseprefix.DefaultThreshold, browseprefix.DefaultMinFiles,
+			)
 		}
 		if len(files) >= 1000 {
 			log.Debug().
 				Str("system", systemID).
-				Int("directories", len(stripPolicyByDir)).
-				Msg("calculated directory strip policies")
+				Int("directories", len(prefixPolicyByDir)).
+				Msg("calculated directory prefix policies")
 		}
 
 		for fileIdx, file := range files {
@@ -1031,10 +1018,10 @@ func NewNamesIndex(
 
 			// Look up stripping policy for this file's directory
 			dir := filepath.Dir(file.Path)
-			shouldStrip := stripPolicyByDir[dir]
+			prefixPolicy := prefixPolicyByDir[dir]
 
-			_, _, addErr := AddMediaPath(
-				db, &scanState, systemID, file.Path, file.Name, file.NoExt, shouldStrip, cfg, mediaType,
+			_, _, addErr := AddMediaPathWithPrefixPolicy(
+				db, &scanState, systemID, file.Path, file.Name, file.NoExt, prefixPolicy, cfg, mediaType,
 			)
 			if addErr != nil {
 				var sqliteErr sqlite3.Error

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -461,7 +461,7 @@ func TestNewNamesIndex_SuccessfulResume(t *testing.T) {
 		Return([]database.TitleWithSystem{}, nil).Maybe()
 	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaWithFullPath{}, nil).Maybe()
-	mockMediaDB.On("GetMediaTagsBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaTagLink{}, nil).Maybe()
 	// Subsequent calls: normal operation (no truncate because resuming successfully)
 	mockMediaDB.On("SetIndexingStatus", "running").Return(nil).Once()
@@ -577,7 +577,7 @@ func TestNewNamesIndex_ReportsSystemBeforeLoadingExistingData(t *testing.T) {
 		Return([]database.TitleWithSystem{}, nil).Twice()
 	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaWithFullPath{}, nil).Twice()
-	mockMediaDB.On("GetMediaTagsBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaTagLink{}, nil).Twice()
 	mockMediaDB.On("SetIndexingStatus", "completed").Return(nil).Once()
 	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
@@ -703,7 +703,7 @@ func TestNewNamesIndex_ResumeSystemNotFound(t *testing.T) {
 		Return([]database.TitleWithSystem{}, nil).Maybe()
 	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaWithFullPath{}, nil).Maybe()
-	mockMediaDB.On("GetMediaTagsBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
 		Return([]database.MediaTagLink{}, nil).Maybe()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Maybe()
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Maybe()

--- a/pkg/database/mediascanner/persistence_regression_test.go
+++ b/pkg/database/mediascanner/persistence_regression_test.go
@@ -157,7 +157,7 @@ func TestNewNamesIndex_ResumeResetMissingFlagsSkipsCompletedSystems(t *testing.T
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
 	mockMediaDB.On("GetTitlesBySystemID", "snes").Return([]database.TitleWithSystem{}, nil).Once()
 	mockMediaDB.On("GetMediaBySystemID", "snes").Return([]database.MediaWithFullPath{}, nil).Once()
-	mockMediaDB.On("GetMediaTagsBySystemID", "snes").Return([]database.MediaTagLink{}, nil).Once()
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", "snes").Return([]database.MediaTagLink{}, nil).Once()
 	mockMediaDB.On("ResetMissingFlags", []int{3}).Return(nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{
@@ -284,7 +284,7 @@ func TestNewNamesIndex_ResumeKeepsRequestedSystemsWhenSomeAreNotRunnable(t *test
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
 	mockMediaDB.On("GetTitlesBySystemID", "nes").Return([]database.TitleWithSystem{}, nil).Once()
 	mockMediaDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil).Once()
-	mockMediaDB.On("GetMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{
 		{ID: "nes"},
@@ -361,7 +361,7 @@ func TestNewNamesIndex_DependencyFlushUniqueErrorAbortsIndexing(t *testing.T) {
 	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
-	mockMediaDB.On("GetMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
+	mockMediaDB.On("GetScannerMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{{ID: "nes"}},
 		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, func(IndexStatus) {}, nil)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1057,6 +1057,15 @@ func (m *MockMediaDBI) DeleteMediaTag(mediaDBID, tagDBID int64) error {
 	return nil
 }
 
+func (m *MockMediaDBI) DeleteMediaTagsByTagIDs(mediaDBID int64, tagDBIDs []int) error {
+	m.trackDatabaseOperation() // Track if called outside transaction
+	args := m.Called(mediaDBID, tagDBIDs)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 // TagType CRUD methods
 func (m *MockMediaDBI) FindTagType(row database.TagType) (database.TagType, error) {
 	args := m.Called(row)
@@ -1661,6 +1670,21 @@ func (m *MockMediaDBI) GetMediaBySystemID(systemID string) ([]database.MediaWith
 
 // GetMediaTagsBySystemID mock method for per-system lazy loading during resume.
 func (m *MockMediaDBI) GetMediaTagsBySystemID(systemID string) ([]database.MediaTagLink, error) {
+	args := m.Called(systemID)
+	if links, ok := args.Get(0).([]database.MediaTagLink); ok {
+		if err := args.Error(1); err != nil {
+			return links, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return links, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return []database.MediaTagLink{}, nil
+}
+
+// GetScannerMediaTagsBySystemID mock method for per-system scanner-managed tag loading.
+func (m *MockMediaDBI) GetScannerMediaTagsBySystemID(systemID string) ([]database.MediaTagLink, error) {
 	args := m.Called(systemID)
 	if links, ok := args.Get(0).([]database.MediaTagLink); ok {
 		if err := args.Error(1); err != nil {

--- a/pkg/zapscript/titles/selection.go
+++ b/pkg/zapscript/titles/selection.go
@@ -164,9 +164,9 @@ func FilterByTags(
 ) []database.SearchResultWithCursor {
 	var filtered []database.SearchResultWithCursor
 
-	for _, result := range results {
-		if HasAllTags(&result, tagFilters) {
-			filtered = append(filtered, result)
+	for i := range results {
+		if HasAllTags(&results[i], tagFilters) {
+			filtered = append(filtered, results[i])
 		}
 	}
 
@@ -231,9 +231,9 @@ func HasAllTags(result *database.SearchResultWithCursor, tagFilters []zapscript.
 func FilterOutVariants(results []database.SearchResultWithCursor) []database.SearchResultWithCursor {
 	var filtered []database.SearchResultWithCursor
 
-	for _, result := range results {
-		if !IsVariant(&result) {
-			filtered = append(filtered, result)
+	for i := range results {
+		if !IsVariant(&results[i]) {
+			filtered = append(filtered, results[i])
 		}
 	}
 
@@ -291,9 +291,9 @@ func hasVariantTagFilter(tagFilters []zapscript.TagFilter) bool {
 func FilterOutRereleases(results []database.SearchResultWithCursor) []database.SearchResultWithCursor {
 	var filtered []database.SearchResultWithCursor
 
-	for _, result := range results {
-		if !IsRerelease(&result) {
-			filtered = append(filtered, result)
+	for i := range results {
+		if !IsRerelease(&results[i]) {
+			filtered = append(filtered, results[i])
 		}
 	}
 
@@ -319,15 +319,15 @@ func FilterByPreferredRegions(
 	var untagged []database.SearchResultWithCursor
 	var others []database.SearchResultWithCursor
 
-	for _, result := range results {
-		regionMatch := getRegionMatch(&result, preferredRegions)
+	for i := range results {
+		regionMatch := getRegionMatch(&results[i], preferredRegions)
 		switch regionMatch {
 		case tagMatchPreferred:
-			preferred = append(preferred, result)
+			preferred = append(preferred, results[i])
 		case tagMatchUntagged:
-			untagged = append(untagged, result)
+			untagged = append(untagged, results[i])
 		case tagMatchOther:
-			others = append(others, result)
+			others = append(others, results[i])
 		}
 	}
 
@@ -375,15 +375,15 @@ func FilterByPreferredLanguages(
 	var untagged []database.SearchResultWithCursor
 	var others []database.SearchResultWithCursor
 
-	for _, result := range results {
-		langMatch := getLanguageMatch(&result, preferredLangs)
+	for i := range results {
+		langMatch := getLanguageMatch(&results[i], preferredLangs)
 		switch langMatch {
 		case tagMatchPreferred:
-			preferred = append(preferred, result)
+			preferred = append(preferred, results[i])
 		case tagMatchUntagged:
-			untagged = append(untagged, result)
+			untagged = append(untagged, results[i])
 		case tagMatchOther:
-			others = append(others, result)
+			others = append(others, results[i])
 		}
 	}
 
@@ -685,7 +685,8 @@ func FilterByFileTypePriority(
 	}
 
 	scored := make([]scoredResult, 0, len(results))
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		ext := strings.ToLower(filepath.Ext(result.Path))
 		bestScore := 999999 // Default: no launcher match
 
@@ -701,22 +702,22 @@ func FilterByFileTypePriority(
 			}
 		}
 
-		scored = append(scored, scoredResult{result: result, score: bestScore})
+		scored = append(scored, scoredResult{result: *result, score: bestScore})
 	}
 
 	// Find minimum score
 	minScore := 999999
-	for _, s := range scored {
-		if s.score < minScore {
-			minScore = s.score
+	for i := range scored {
+		if scored[i].score < minScore {
+			minScore = scored[i].score
 		}
 	}
 
 	// Return all results with minimum score
 	var best []database.SearchResultWithCursor
-	for _, s := range scored {
-		if s.score == minScore {
-			best = append(best, s.result)
+	for i := range scored {
+		if scored[i].score == minScore {
+			best = append(best, scored[i].result)
 		}
 	}
 

--- a/pkg/zapscript/titles/strategies.go
+++ b/pkg/zapscript/titles/strategies.go
@@ -71,19 +71,20 @@ func TryMainTitleOnly(
 	var exactMatches []database.SearchResultWithCursor
 	var partialMatches []database.SearchResultWithCursor
 
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		dbMatchInfo := GenerateMatchInfo(mediaType, result.Name)
 
 		// Exact match: Query has secondary title, DB doesn't - DB's full slug matches query's main title
 		if dbMatchInfo.CanonicalSlug == mainSlug && !dbMatchInfo.HasSecondaryTitle {
-			exactMatches = append(exactMatches, result)
+			exactMatches = append(exactMatches, *result)
 			continue
 		}
 
 		// Partial match case 1: Query simple, DB has secondary - DB's main title starts with query's main
 		if strings.HasPrefix(dbMatchInfo.MainTitleSlug, mainSlug) &&
 			!matchInfo.HasSecondaryTitle && dbMatchInfo.HasSecondaryTitle {
-			partialMatches = append(partialMatches, result)
+			partialMatches = append(partialMatches, *result)
 			continue
 		}
 
@@ -93,7 +94,7 @@ func TryMainTitleOnly(
 		// Uses prefix to handle the delimiter mismatch, but only if query's full slug aligns with DB main
 		if strings.HasPrefix(dbMatchInfo.MainTitleSlug, slug) &&
 			matchInfo.HasSecondaryTitle && dbMatchInfo.HasSecondaryTitle {
-			partialMatches = append(partialMatches, result)
+			partialMatches = append(partialMatches, *result)
 		}
 	}
 
@@ -157,10 +158,11 @@ func TrySecondaryTitleExact(
 	} else if len(exactResults) > 0 {
 		// Post-filter: only keep DB entries WITHOUT secondary title
 		var filtered []database.SearchResultWithCursor
-		for _, result := range exactResults {
+		for i := range exactResults {
+			result := &exactResults[i]
 			dbMatchInfo := GenerateMatchInfo(mediaType, result.Name)
 			if !dbMatchInfo.HasSecondaryTitle {
-				filtered = append(filtered, result)
+				filtered = append(filtered, *result)
 			}
 		}
 
@@ -194,10 +196,11 @@ func TrySecondaryTitleExact(
 		if len(partialResults) > 0 {
 			// Post-filter: only keep DB entries WITH secondary title
 			var filtered []database.SearchResultWithCursor
-			for _, result := range partialResults {
+			for i := range partialResults {
+				result := &partialResults[i]
 				dbMatchInfo := GenerateMatchInfo(mediaType, result.Name)
 				if dbMatchInfo.HasSecondaryTitle {
-					filtered = append(filtered, result)
+					filtered = append(filtered, *result)
 				}
 			}
 
@@ -270,7 +273,8 @@ func TrySharedSecondaryTitle(
 	}
 
 	var filtered []database.SearchResultWithCursor
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		dbMatchInfo := GenerateMatchInfo(mediaType, result.Name)
 
 		// Require DB entry also has a secondary title with the same slug.
@@ -289,7 +293,7 @@ func TrySharedSecondaryTitle(
 			continue
 		}
 
-		filtered = append(filtered, result)
+		filtered = append(filtered, *result)
 	}
 
 	if len(filtered) == 0 {


### PR DESCRIPTION
## Summary
- add smart ranked/date prefix detection for browse sorting and scan-time title matching
- preserve metadata/artwork matching for prefixed collection filenames without requiring filename changes
- batch stale media-tag deletes and load scanner-managed tags only during indexing reconciliation

## Validation
- go test ./pkg/database/browseprefix/
- go test ./pkg/database/mediadb/
- go test ./pkg/database/mediascanner/
- go test ./pkg/api/methods/
- go test ./pkg/database/scraper/gamelistxml/
- go test ./pkg/zapscript/titles/
- go test ./pkg/testing/helpers/
- go test ./pkg/database/...
- task lint-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent prefix detection for media sorting that recognizes rank-numbered and date-prefixed filenames.
  * Pagination now preserves and respects sort mode across pages.

* **Improvements**
  * Batch media-tag operations during scanning/indexing for faster reconciliation and updates.
  * Title extraction during indexing now strips detected prefixes for cleaner titles.

* **Documentation**
  * Clarified sorting behavior for name- vs filename-based sort options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->