### PR TITLE
fix(scraper): resolve CD track artwork to launch media

### DIFF
--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -424,7 +424,7 @@ outer:
 				ProvidedName: game.Name,
 			})
 
-			pathMedia, matchedPathKey, pathOK := matchMediaByResolvedPath(indexes.MediaByPathFold, resolved)
+			pathMedia, matchedPathKey, pathOK := g.canonicalMediaForResolvedPath(indexes, resolved)
 
 			title, titleOK := indexes.TitlesBySlug[pf.Slug]
 			switch {
@@ -1471,6 +1471,155 @@ func selectMediaForSlugMatch(
 		return slugMediaSelection{matchKind: matchKind}
 	}
 	return slugMediaSelection{media: mediaRows[0], matchKind: matchKind}
+}
+
+func (g *GamelistXMLScraper) canonicalMediaForResolvedPath(
+	indexes loadRecordIndexes,
+	resolved string,
+) (database.Media, string, bool) {
+	media, matchedKey, ok := matchMediaByResolvedPath(indexes.MediaByPathFold, resolved)
+	if ok {
+		return media, matchedKey, true
+	}
+	if !isCDTrackLikePath(resolved) {
+		return database.Media{}, "", false
+	}
+	return g.matchCanonicalCDMedia(indexes, resolved)
+}
+
+func (g *GamelistXMLScraper) matchCanonicalCDMedia(
+	indexes loadRecordIndexes,
+	resolved string,
+) (database.Media, string, bool) {
+	m3uMatches := make(map[string]database.Media)
+	cueMatches := make(map[string]database.Media)
+	for key, media := range indexes.MediaByPathFold {
+		switch strings.ToLower(filepath.Ext(media.Path)) {
+		case ".m3u":
+			if g.m3uReferencesPath(media.Path, resolved) {
+				m3uMatches[key] = media
+			}
+		case ".cue":
+			if g.cueReferencesPath(media.Path, resolved) {
+				cueMatches[key] = media
+			}
+		}
+	}
+
+	if len(m3uMatches) == 1 {
+		for key, media := range m3uMatches {
+			return media, key, true
+		}
+	}
+	if len(m3uMatches) > 1 {
+		log.Debug().Str("path", resolved).Int("matches", len(m3uMatches)).
+			Msg("gamelistxml: track path matched multiple m3u media rows, skipping canonical match")
+		return database.Media{}, "", false
+	}
+
+	if len(cueMatches) == 1 {
+		for key, media := range cueMatches {
+			return media, key, true
+		}
+	}
+	if len(cueMatches) > 1 {
+		log.Debug().Str("path", resolved).Int("matches", len(cueMatches)).
+			Msg("gamelistxml: track path matched multiple cue media rows, skipping canonical match")
+	}
+	return database.Media{}, "", false
+}
+
+func isCDTrackLikePath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".bin", ".iso", ".wav", ".flac", ".mp3", ".ogg", ".raw", ".img":
+		return true
+	default:
+		return false
+	}
+}
+
+func (g *GamelistXMLScraper) m3uReferencesPath(m3uPath, resolved string) bool {
+	data, err := afero.ReadFile(g.filesystem(), m3uPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", m3uPath).Msg("gamelistxml: failed to read m3u for canonical match")
+		return false
+	}
+	baseDir := filepath.Dir(m3uPath)
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		entryPath := resolveReferencedPath(baseDir, line)
+		if samePath(entryPath, resolved) {
+			return true
+		}
+		if strings.EqualFold(filepath.Ext(entryPath), ".cue") && g.cueReferencesPath(entryPath, resolved) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GamelistXMLScraper) cueReferencesPath(cuePath, resolved string) bool {
+	data, err := afero.ReadFile(g.filesystem(), cuePath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", cuePath).Msg("gamelistxml: failed to read cue for canonical match")
+		return false
+	}
+	baseDir := filepath.Dir(cuePath)
+	for _, rawLine := range strings.Split(string(data), "\n") {
+		entry := parseCueFileEntry(rawLine)
+		if entry == "" {
+			continue
+		}
+		if samePath(resolveReferencedPath(baseDir, entry), resolved) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCueFileEntry(line string) string {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(strings.ToUpper(line), "FILE ") {
+		return ""
+	}
+	rest := strings.TrimSpace(line[len("FILE "):])
+	if rest == "" {
+		return ""
+	}
+	if strings.HasPrefix(rest, "\"") {
+		rest = rest[1:]
+		end := strings.Index(rest, "\"")
+		if end <= 0 {
+			return ""
+		}
+		return strings.TrimSpace(rest[:end])
+	}
+
+	upper := strings.ToUpper(rest)
+	for _, token := range []string{" BINARY", " WAVE", " MP3", " AIFF", " MOTOROLA"} {
+		if idx := strings.LastIndex(upper, token); idx > 0 {
+			return strings.TrimSpace(rest[:idx])
+		}
+	}
+	return strings.TrimSpace(rest)
+}
+
+func resolveReferencedPath(baseDir, ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	if filepath.IsAbs(ref) {
+		return filepath.Clean(ref)
+	}
+	return filepath.Clean(filepath.Join(baseDir, ref))
+}
+
+func samePath(a, b string) bool {
+	return pathFoldKey(a) == pathFoldKey(b)
 }
 
 func matchMediaByResolvedPath(

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1550,7 +1550,7 @@ func (g *GamelistXMLScraper) m3uReferencesPath(m3uPath, resolved string) bool {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		entryPath := resolveReferencedPath(baseDir, line)
+		entryPath := g.caseInsensitiveExistingPath(resolveReferencedPath(baseDir, line))
 		if samePath(entryPath, resolved) {
 			return true
 		}
@@ -1605,6 +1605,33 @@ func parseCueFileEntry(line string) string {
 		}
 	}
 	return strings.TrimSpace(rest)
+}
+
+func (g *GamelistXMLScraper) caseInsensitiveExistingPath(path string) string {
+	path = filepath.Clean(path)
+	if path == "." || path == "" {
+		return path
+	}
+	if exists, err := afero.Exists(g.filesystem(), path); err == nil && exists {
+		return path
+	}
+
+	parent := filepath.Dir(path)
+	if parent == path {
+		return path
+	}
+	actualParent := g.caseInsensitiveExistingPath(parent)
+	entries, err := afero.ReadDir(g.filesystem(), actualParent)
+	if err != nil {
+		return path
+	}
+	base := filepath.Base(path)
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), base) {
+			return filepath.Join(actualParent, entry.Name())
+		}
+	}
+	return path
 }
 
 func resolveReferencedPath(baseDir, ref string) string {

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -615,6 +615,34 @@ func TestLoadRecords_TrackPathResolvesToM3UMedia(t *testing.T) {
 	assert.True(t, records[0].MediaLevelWriteSafe)
 }
 
+func TestLoadRecords_TrackPathResolvesToM3UCueCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gameDir := filepath.Join(root, "Game")
+	cuePath := filepath.Join(gameDir, "Game (Disc 1).cue")
+	m3uPath := filepath.Join(root, "Game.m3u")
+	require.NoError(t, os.MkdirAll(gameDir, 0o750))
+	require.NoError(t, os.WriteFile(cuePath, []byte("FILE \"track01.bin\" BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(m3uPath, []byte(filepath.Join("game", "game (disc 1).CUE")+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./Game/track01.bin</path><name>Game</name></game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 61, MediaTitleDBID: 50, Path: m3uPath}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(61), records[0].MatchedMediaDBID)
+	assert.Equal(t, gamelistMatchSlugPath, records[0].MatchKind)
+	assert.True(t, records[0].MediaLevelWriteSafe)
+}
+
 func TestLoadRecords_TrackPathAmbiguousCueMatchesUnsafe(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -545,6 +545,137 @@ func TestLoadRecords_DuplicateNameExactPathsAllMediaSafe(t *testing.T) {
 	}
 }
 
+func TestLoadRecords_TrackPathResolvesToCueMedia(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gameDir := filepath.Join(root, "Game")
+	cuePath := filepath.Join(gameDir, "Game.cue")
+	require.NoError(t, os.MkdirAll(gameDir, 0o750))
+	require.NoError(t, os.WriteFile(cuePath, []byte("FILE \"track01.bin\" BINARY\n  TRACK 01 MODE2/2352\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game>
+    <path>./Game/track01.bin</path>
+    <name>Game</name>
+    <image>./media/images/Game.png</image>
+  </game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 60, MediaTitleDBID: 50, Path: cuePath}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(60), records[0].MatchedMediaDBID)
+	assert.Equal(t, gamelistMatchSlugPath, records[0].MatchKind)
+	assert.True(t, records[0].MediaLevelWriteSafe)
+
+	result := (&GamelistXMLScraper{}).MapToDB(records[0])
+	propKey := string(tags.TagTypeProperty) + ":" + string(tags.TagPropertyImageImage)
+	var found bool
+	for _, p := range result.MediaProps {
+		if p.TypeTag == propKey {
+			found = true
+			assert.Equal(t, filepath.ToSlash(filepath.Join(root, "media", "images", "Game.png")), p.Text)
+		}
+	}
+	assert.True(t, found, "canonical cue match should keep media-level explicit image property")
+}
+
+func TestLoadRecords_TrackPathResolvesToM3UMedia(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gameDir := filepath.Join(root, "Game")
+	cuePath := filepath.Join(gameDir, "Game (Disc 1).cue")
+	m3uPath := filepath.Join(root, "Game.m3u")
+	require.NoError(t, os.MkdirAll(gameDir, 0o750))
+	require.NoError(t, os.WriteFile(cuePath, []byte("FILE \"track01.bin\" BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(m3uPath, []byte(filepath.Join("Game", "Game (Disc 1).cue")+"\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./Game/track01.bin</path><name>Game</name></game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 60, MediaTitleDBID: 50, Path: cuePath},
+			database.Media{DBID: 61, MediaTitleDBID: 50, Path: m3uPath}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, int64(61), records[0].MatchedMediaDBID)
+	assert.Equal(t, gamelistMatchSlugPath, records[0].MatchKind)
+	assert.True(t, records[0].MediaLevelWriteSafe)
+}
+
+func TestLoadRecords_TrackPathAmbiguousCueMatchesUnsafe(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cue1Path := filepath.Join(root, "Game A.cue")
+	cue2Path := filepath.Join(root, "Game B.cue")
+	require.NoError(t, os.WriteFile(cue1Path, []byte("FILE track01.bin BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(cue2Path, []byte("FILE track01.bin BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./track01.bin</path><name>Game</name></game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 60, MediaTitleDBID: 50, Path: cue1Path},
+			database.Media{DBID: 61, MediaTitleDBID: 50, Path: cue2Path}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	assert.Equal(t, gamelistMatchSlugOnly, records[0].MatchKind)
+	assert.False(t, records[0].MediaLevelWriteSafe)
+}
+
+func TestLoadRecords_MultiDiscTracksResolveDistinctCues(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	disc1Dir := filepath.Join(root, "Disc 1")
+	disc2Dir := filepath.Join(root, "Disc 2")
+	disc1Cue := filepath.Join(disc1Dir, "Game (Disc 1).cue")
+	disc2Cue := filepath.Join(disc2Dir, "Game (Disc 2).cue")
+	require.NoError(t, os.MkdirAll(disc1Dir, 0o750))
+	require.NoError(t, os.MkdirAll(disc2Dir, 0o750))
+	require.NoError(t, os.WriteFile(disc1Cue, []byte("FILE track01.bin BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(disc2Cue, []byte("FILE track01.bin BINARY\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./Disc 1/track01.bin</path><name>Game</name></game>
+  <game><path>./Disc 2/track01.bin</path><name>Game</name></game>
+</gameList>`), 0o600))
+
+	records, err := (&GamelistXMLScraper{}).LoadRecords(
+		context.Background(),
+		scraper.ScrapeSystem{ID: "psx", ROMPaths: []string{root}},
+		mediaBySlugAndPath("game", &database.MediaTitle{DBID: 50, Slug: "game"},
+			database.Media{DBID: 60, MediaTitleDBID: 50, Path: disc1Cue},
+			database.Media{DBID: 61, MediaTitleDBID: 50, Path: disc2Cue}),
+	)
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	assert.Equal(t, int64(60), records[0].MatchedMediaDBID)
+	assert.Equal(t, int64(61), records[1].MatchedMediaDBID)
+	for _, record := range records {
+		assert.Equal(t, gamelistMatchSlugPath, record.MatchKind)
+		assert.True(t, record.MediaLevelWriteSafe)
+	}
+}
+
 func TestLoadRecords_KnownSlugDoesNotBlockExactPathFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- resolve gamelist CD track paths to canonical indexed .m3u or .cue media before slug-only fallback
- keep exact path matching first and skip ambiguous playlist/cue matches instead of binding artwork arbitrarily
- cover cue, m3u, ambiguous, and multi-disc track artwork matching regressions

Closes #886

Validated locally with `go test ./pkg/database/scraper/gamelistxml/` and `golangci-lint run --fix pkg/database/scraper/gamelistxml/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disc-based game detection: track files now resolve to their canonical disc media (including playlist/cue indirection), with case-insensitive lookup and preserved cue-derived properties.
  * Better handling of ambiguous matches: falls back to slug-only matching and marks uncertain media as not write-safe.
  * Improved multi-disc resolution so distinct discs become separate, write-safe records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->