### PR TITLE
fix(daemon): reuse cached service binary on startup

### DIFF
--- a/pkg/api/client/client_test.go
+++ b/pkg/api/client/client_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -59,17 +58,10 @@ func parseServerPort(t *testing.T, server *httptest.Server) int {
 	return port
 }
 
-// unusedPort returns a port that is guaranteed to not have anything listening.
-// It binds to port 0 (OS assigns a free port), gets the assigned port, then
-// closes the listener. There's a small race window but it's reliable for tests.
+// unusedPort returns port 0, which cannot have a listening TCP service.
 func unusedPort(t *testing.T) int {
 	t.Helper()
-	var lc net.ListenConfig
-	listener, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener.Close())
-	return port
+	return 0
 }
 
 func waitForWebSocketSession(server *helpers.WebSocketTestServer, timeout time.Duration) bool {

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -289,31 +289,19 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 	if manifestErr != nil && !errors.Is(manifestErr, os.ErrNotExist) {
 		log.Debug().Err(manifestErr).Msg("error reading service binary manifest")
 	}
-	if manifest != nil && manifest.matchesSourceMetadata(binPath, sourceInfo, sourceChangeTimeNS) {
-		servicePath := serviceCachePath(dataDir, binPath, manifest.SourceHash)
-		if filepath.Clean(manifest.ServicePath) == filepath.Clean(servicePath) &&
-			serviceCachePathValid(manifest.ServicePath, dataDir) {
-			cachedInfo, statErr := fs.Stat(manifest.ServicePath)
-			switch {
-			case statErr == nil && manifest.matchesServiceMetadata(cachedInfo):
-				if chmodErr := ensureServiceBinaryExecutable(fs, manifest.ServicePath); chmodErr != nil {
-					return "", chmodErr
-				}
-				log.Debug().
-					Str("path", manifest.ServicePath).
-					Dur("duration", time.Since(started)).
-					Msg("using cached service binary from manifest")
-				s.cleanupServiceBinaries(manifest.ServicePath, "")
-				return manifest.ServicePath, nil
-			case statErr != nil && !errors.Is(statErr, os.ErrNotExist):
-				log.Debug().Err(statErr).Str("path", manifest.ServicePath).Msg("error checking cached service binary")
-			case statErr == nil:
-				log.Debug().
-					Str("path", manifest.ServicePath).
-					Int64("cachedSize", cachedInfo.Size()).
-					Int64("cachedModTimeNs", cachedInfo.ModTime().UnixNano()).
-					Msg("cached service binary metadata mismatch")
-			}
+	if manifest != nil {
+		if servicePath, ok, cacheErr := s.cachedServiceBinaryFromManifest(
+			binPath,
+			sourceInfo,
+			sourceChangeTimeNS,
+			manifest,
+			started,
+			true,
+		); cacheErr != nil {
+			return "", cacheErr
+		} else if ok {
+			s.cleanupServiceBinaries(servicePath, "")
+			return servicePath, nil
 		}
 	}
 
@@ -383,6 +371,61 @@ func (s *Service) prepareBinary(binPath string) (string, error) {
 
 	log.Debug().Str("path", servicePath).Dur("duration", time.Since(started)).Msg("prepared service binary")
 	return servicePath, nil
+}
+
+func (s *Service) cachedServiceBinaryFromManifest(
+	binPath string,
+	sourceInfo os.FileInfo,
+	sourceChangeTimeNS int64,
+	manifest *serviceBinaryManifest,
+	started time.Time,
+	launchValidation bool,
+) (path string, ok bool, err error) {
+	if manifest == nil || !manifest.matchesSourceMetadata(binPath, sourceInfo, sourceChangeTimeNS) {
+		return "", false, nil
+	}
+
+	fs := s.filesystem()
+	dataDir := helpers.DataDir(s.pl)
+	servicePath := serviceCachePath(dataDir, binPath, manifest.SourceHash)
+	if filepath.Clean(manifest.ServicePath) != filepath.Clean(servicePath) ||
+		!serviceCachePathValid(manifest.ServicePath, dataDir) {
+		return "", false, nil
+	}
+
+	cachedInfo, statErr := fs.Stat(manifest.ServicePath)
+	metadataMatches := false
+	if statErr == nil {
+		metadataMatches = manifest.matchesServiceMetadata(cachedInfo)
+		if launchValidation {
+			metadataMatches = manifest.matchesServiceMetadataForLaunch(cachedInfo)
+		}
+	}
+	switch {
+	case statErr == nil && metadataMatches:
+		if chmodErr := ensureServiceBinaryExecutable(fs, manifest.ServicePath); chmodErr != nil {
+			return "", false, chmodErr
+		}
+		log.Debug().
+			Str("path", manifest.ServicePath).
+			Dur("duration", time.Since(started)).
+			Msg("using cached service binary from manifest")
+		return manifest.ServicePath, true, nil
+	case statErr != nil && !errors.Is(statErr, os.ErrNotExist):
+		log.Debug().Err(statErr).Str("path", manifest.ServicePath).Msg("error checking cached service binary")
+	case statErr == nil:
+		log.Debug().
+			Str("path", manifest.ServicePath).
+			Int64("cachedSize", cachedInfo.Size()).
+			Int64("cachedModTimeNs", cachedInfo.ModTime().UnixNano()).
+			Int64("cachedChangeTimeNs", fileChangeTimeNS(cachedInfo)).
+			Int64("manifestSize", manifest.ServiceSize).
+			Int64("manifestModTimeNs", manifest.ServiceModTimeNS).
+			Int64("manifestChangeTimeNs", manifest.ServiceChangeTimeNS).
+			Msg("cached service binary metadata mismatch")
+	}
+
+	return "", false, nil
 }
 
 func ensureServiceBinaryExecutable(fs afero.Fs, servicePath string) error {
@@ -494,6 +537,13 @@ func (m *serviceBinaryManifest) matchesServiceMetadata(info os.FileInfo) bool {
 		m.ServiceModTimeNS == info.ModTime().UnixNano() &&
 		m.ServiceChangeTimeNS != 0 &&
 		m.ServiceChangeTimeNS == fileChangeTimeNS(info)
+}
+
+func (m *serviceBinaryManifest) matchesServiceMetadataForLaunch(info os.FileInfo) bool {
+	if info == nil || m.ServiceSize != info.Size() {
+		return false
+	}
+	return m.ServiceModTimeNS == 0 || m.ServiceModTimeNS == info.ModTime().UnixNano()
 }
 
 func fileChangeTimeNS(info os.FileInfo) int64 {
@@ -866,6 +916,7 @@ func (s *Service) restartExecConfig(
 	if err != nil {
 		return restartExecConfig{}, err
 	}
+	log.Debug().Str("path", serviceBin).Msg("selected service binary for restart exec")
 	return restartExecConfig{
 		serviceBin: serviceBin,
 		binPath:    binPath,
@@ -1008,7 +1059,10 @@ func (s *Service) Start() error {
 	if err != nil {
 		return err
 	}
-	log.Debug().Dur("duration", time.Since(prepareStarted)).Msg("service binary prepared")
+	log.Debug().
+		Str("path", serviceBin).
+		Dur("duration", time.Since(prepareStarted)).
+		Msg("service binary prepared")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -275,8 +275,19 @@ func TestStart_CacheMissLaunchesCachedCopy(t *testing.T) {
 	content, err := os.ReadFile(eventLog) //nolint:gosec // test-controlled file
 	require.NoError(t, err)
 	assert.Contains(t, string(content), "started:")
+	pid, err := svc.Pid()
+	require.NoError(t, err)
+	replacement := fmt.Sprintf("#!/bin/sh\nprintf 'replaced\\n' >> %q\nprintf '%%s' \"$$\" > %q\n", eventLog, pidFile)
 	//nolint:gosec // test overwrites a test-controlled fake service script
-	require.NoError(t, os.WriteFile(sourcePath, []byte("#!/bin/sh\necho replaced\n"), 0o700))
+	require.NoError(t, os.WriteFile(sourcePath, []byte(replacement), 0o700))
+	require.NoError(t, svc.Start())
+
+	content, err = os.ReadFile(eventLog) //nolint:gosec // test-controlled file
+	require.NoError(t, err)
+	assert.NotContains(t, string(content), "replaced")
+	currentPID, err := svc.Pid()
+	require.NoError(t, err)
+	assert.Equal(t, pid, currentPID)
 }
 
 func TestPrepareBinary_UsesConfiguredFilesystem(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -215,6 +215,70 @@ func TestPrepareBinary_NormalizesReusedCachedBinaryPermissions(t *testing.T) {
 	assert.True(t, isServiceCacheFilename(filepath.Base(result)))
 }
 
+func TestPrepareBinary_UsesValidManifestCache(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-content"), 0o600))
+
+	cachedPath, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+
+	launchPath, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, cachedPath, launchPath)
+	assert.NotEqual(t, srcPath, launchPath)
+}
+
+func TestPrepareBinary_UsesCacheWhenOnlyChangeTimeDrifts(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "zaparoo.sh")
+	require.NoError(t, os.WriteFile(srcPath, []byte("binary-content"), 0o600))
+
+	cachedPath, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	manifest, err := readServiceBinaryManifest(afero.NewOsFs(), svc.pl.Settings().DataDir)
+	require.NoError(t, err)
+	manifest.ServiceChangeTimeNS++
+	require.NoError(t, writeServiceBinaryManifest(afero.NewOsFs(), svc.pl.Settings().DataDir, manifest))
+
+	launchPath, err := svc.prepareBinary(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, cachedPath, launchPath)
+	assert.NotEqual(t, srcPath, launchPath)
+}
+
+func TestStart_CacheMissLaunchesCachedCopy(t *testing.T) {
+	svc := newTestService(t)
+	settings := svc.pl.Settings()
+	pidFile := filepath.Join(settings.TempDir, config.PidFile)
+	eventLog := filepath.Join(t.TempDir(), "events.log")
+	sourcePath := writeFakeServiceScript(t, pidFile, eventLog)
+	t.Setenv(config.AppEnv, sourcePath)
+	t.Cleanup(func() {
+		pid, err := svc.Pid()
+		if err == nil && pid > 0 && requireServiceRunning(t, svc) {
+			require.NoError(t, svc.Stop())
+		}
+		_ = os.Remove(pidFile)
+	})
+
+	require.NoError(t, svc.Start())
+
+	assert.True(t, requireServiceRunning(t, svc))
+	assert.FileExists(t, filepath.Join(settings.DataDir, serviceManifestName))
+	content, err := os.ReadFile(eventLog) //nolint:gosec // test-controlled file
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "started:")
+	//nolint:gosec // test overwrites a test-controlled fake service script
+	require.NoError(t, os.WriteFile(sourcePath, []byte("#!/bin/sh\necho replaced\n"), 0o700))
+}
+
 func TestPrepareBinary_UsesConfiguredFilesystem(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -88,25 +88,31 @@ func Start(
 	cfq := make(chan chan error)          // launch guard confirm queue
 	backgroundWG := &sync.WaitGroup{}
 
+	setupStarted := time.Now()
 	err := setupEnvironment(pl)
 	if err != nil {
 		log.Error().Err(err).Msg("error setting up environment")
 		return nil, err
 	}
+	log.Debug().Dur("duration", time.Since(setupStarted)).Msg("setup environment completed")
 
 	log.Info().Msg("running platform pre start")
+	preStartStarted := time.Now()
 	err = pl.StartPre(cfg)
 	if err != nil {
 		log.Error().Err(err).Msg("platform start pre error")
 		return nil, fmt.Errorf("platform start pre failed: %w", err)
 	}
+	log.Debug().Dur("duration", time.Since(preStartStarted)).Msg("platform pre start completed")
 
 	log.Info().Msg("opening databases")
+	databaseStarted := time.Now()
 	db, err := makeDatabase(st.GetContext(), pl)
 	if err != nil {
 		log.Error().Err(err).Msgf("error opening databases")
 		return nil, err
 	}
+	log.Debug().Dur("duration", time.Since(databaseStarted)).Msg("databases opened")
 	closeHangingMediaHistoryOnStartup(db)
 
 	// Initialize inbox service for system notifications
@@ -143,19 +149,25 @@ func Start(
 	})
 
 	log.Info().Msg("loading mapping files")
+	mappingsStarted := time.Now()
 	err = cfg.LoadMappings(filepath.Join(helpers.DataDir(pl), config.MappingsDir))
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading mapping files")
 	}
+	log.Debug().Dur("duration", time.Since(mappingsStarted)).Msg("mapping files loaded")
 
 	log.Info().Msg("loading custom launchers")
+	launchersStarted := time.Now()
 	err = cfg.LoadCustomLaunchers(filepath.Join(helpers.DataDir(pl), config.LaunchersDir))
 	if err != nil {
 		log.Error().Err(err).Msgf("error loading custom launchers")
 	}
+	log.Debug().Dur("duration", time.Since(launchersStarted)).Msg("custom launchers loaded")
 
 	log.Info().Msg("initializing launcher cache")
+	launcherCacheStarted := time.Now()
 	helpers.GlobalLauncherCache.Initialize(pl, cfg)
+	log.Debug().Dur("duration", time.Since(launcherCacheStarted)).Msg("launcher cache initialized")
 
 	// Create pausers to pause heavy background media work while a game is running.
 	indexPauser := syncutil.NewPauser()
@@ -178,6 +190,7 @@ func Start(
 		)
 	}()
 
+	apiReadyStarted := time.Now()
 	if apiErr := <-apiReady; apiErr != nil {
 		discoveryService.Stop()
 		if stopErr := pl.Stop(); stopErr != nil {
@@ -191,6 +204,7 @@ func Start(
 		closeDatabase(db)
 		return nil, fmt.Errorf("api startup failed: %w", apiErr)
 	}
+	log.Debug().Dur("duration", time.Since(apiReadyStarted)).Msg("API service reported ready")
 
 	log.Info().Msg("starting mDNS discovery service")
 	if discoveryErr := discoveryService.Start(); discoveryErr != nil {
@@ -203,15 +217,25 @@ func Start(
 	// the rebuild path below covers that case.
 	var tagCacheLoaded, slugCacheLoaded bool
 	if db.MediaDB != nil {
+		tagCacheStarted := time.Now()
 		loaded, loadErr := db.MediaDB.LoadCachedTagCache()
 		if loadErr != nil {
 			log.Warn().Err(loadErr).Msg("failed to load cached tag cache from disk")
 		}
+		log.Debug().
+			Bool("loaded", loaded).
+			Dur("duration", time.Since(tagCacheStarted)).
+			Msg("cached tag cache load completed")
 		tagCacheLoaded = loaded
+		slugCacheStarted := time.Now()
 		loaded, loadErr = db.MediaDB.LoadCachedSlugSearchCache()
 		if loadErr != nil {
 			log.Warn().Err(loadErr).Msg("failed to load cached slug search cache from disk")
 		}
+		log.Debug().
+			Bool("loaded", loaded).
+			Dur("duration", time.Since(slugCacheStarted)).
+			Msg("cached slug search cache load completed")
 		slugCacheLoaded = loaded
 	}
 


### PR DESCRIPTION
## Summary
- keep daemon startup/restart executing the cached service binary instead of the source zaparoo.sh
- tolerate cached service ctime drift while preserving strict source metadata checks
- add startup timing logs and daemon tests for cache reuse, ctime drift, and source replacement while running

## Checked
- go test ./pkg/service/daemon/ ./pkg/service/
- golangci-lint run pkg/service/daemon pkg/service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service-binary cache validation and manifest handling to more reliably reuse cached launch copies and tolerate benign timestamp drift without forcing recopy.

* **Chores**
  * Added detailed startup timing and debug logs for various initialization phases.

* **Tests**
  * Added unit tests covering cached-binary/manifest validity and cache-miss launch behavior; simplified a test helper to use port 0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->