### PR TITLE
fix(zapscript): apply system launcher defaults to path launches

### DIFF
--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -95,7 +95,10 @@ func resolveLauncherRefForSystem(
 	}
 
 	for i := range launchers {
-		if strings.EqualFold(launchers[i].ID, ref) {
+		if !strings.EqualFold(launchers[i].ID, ref) {
+			continue
+		}
+		if launchers[i].SystemID == "" || strings.EqualFold(launchers[i].SystemID, systemID) {
 			return launchers[i].ID, true
 		}
 	}

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -41,17 +41,113 @@ import (
 	"github.com/spf13/afero"
 )
 
-func applySystemDefaultLauncher(env *platforms.CmdEnv, systemID string) string {
+func applySystemDefaultLauncher(pl platforms.Platform, env *platforms.CmdEnv, systemID string) string {
 	current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
 	if current != "" {
 		return current
 	}
-	if defaults, ok := env.Cfg.LookupSystemDefaults(systemID); ok && defaults.Launcher != "" {
-		log.Info().Msgf("using system default launcher for %s: %s", systemID, defaults.Launcher)
-		env.Cmd.AdvArgs = env.Cmd.AdvArgs.With(zapscript.KeyLauncher, defaults.Launcher)
-		return defaults.Launcher
+
+	defaults, ok := env.Cfg.LookupSystemDefaults(systemID)
+	if !ok || defaults.Launcher == "" {
+		return ""
 	}
-	return ""
+
+	launcherID, found := resolveLauncherRefForSystem(pl, env, defaults.Launcher, systemID)
+	if !found {
+		log.Warn().
+			Str("system", systemID).
+			Str("launcher", defaults.Launcher).
+			Msg("system default launcher not found")
+		return ""
+	}
+
+	log.Info().
+		Str("system", systemID).
+		Str("launcher", launcherID).
+		Str("ref", defaults.Launcher).
+		Msg("using system default launcher")
+	env.Cmd.AdvArgs = env.Cmd.AdvArgs.With(zapscript.KeyLauncher, launcherID)
+	return launcherID
+}
+
+func resolveLauncherRefForSystem(
+	pl platforms.Platform,
+	env *platforms.CmdEnv,
+	ref string,
+	systemID string,
+) (string, bool) {
+	launchers := pl.Launchers(env.Cfg)
+	for i := range launchers {
+		if strings.EqualFold(launchers[i].SystemID, systemID) && strings.EqualFold(launchers[i].ID, ref) {
+			return launchers[i].ID, true
+		}
+	}
+
+	for i := range launchers {
+		if !strings.EqualFold(launchers[i].SystemID, systemID) {
+			continue
+		}
+		for _, group := range launchers[i].Groups {
+			if strings.EqualFold(group, ref) {
+				return launchers[i].ID, true
+			}
+		}
+	}
+
+	for i := range launchers {
+		if strings.EqualFold(launchers[i].ID, ref) {
+			return launchers[i].ID, true
+		}
+	}
+
+	return "", false
+}
+
+func applySystemDefaultLauncherForPath(pl platforms.Platform, env *platforms.CmdEnv, path string) string {
+	if current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher); current != "" {
+		return current
+	}
+
+	launcher, found := inferLauncherForPath(pl, env, path)
+	if !found || launcher.SystemID == "" {
+		log.Debug().Str("path", path).Msg("could not infer system default launcher from path")
+		return ""
+	}
+	return applySystemDefaultLauncher(pl, env, launcher.SystemID)
+}
+
+func inferLauncherForPath(pl platforms.Platform, env *platforms.CmdEnv, path string) (platforms.Launcher, bool) {
+	launchers := pl.Launchers(env.Cfg)
+	best := -1
+	bestScore := -1
+	for i := range launchers {
+		if !helpers.PathIsLauncher(env.Cfg, pl, &launchers[i], path) {
+			continue
+		}
+		score := launcherInferenceScore(&launchers[i])
+		if score > bestScore {
+			best = i
+			bestScore = score
+		}
+	}
+	if best == -1 {
+		return platforms.Launcher{}, false
+	}
+	return launchers[best], true
+}
+
+func launcherInferenceScore(l *platforms.Launcher) int {
+	score := 0
+	if len(l.Schemes) > 0 {
+		score += 1000
+	}
+	if len(l.Folders) > 0 {
+		score += 100
+	}
+	if l.SystemID != "" {
+		score += 10
+	}
+	return score
 }
 
 //nolint:gocritic // single-use parameter in command handler
@@ -123,6 +219,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", gameErr)
 		}
 
+		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		if launchErr := launch(game.Path); launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -161,6 +258,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			if randomErr != nil {
 				return platforms.CmdResult{}, fmt.Errorf("failed to select random file: %w", randomErr)
 			}
+			applySystemDefaultLauncherForPath(pl, &env, file)
 			if launchErr := launch(file); launchErr != nil {
 				return platforms.CmdResult{
 					MediaChanged: true,
@@ -173,6 +271,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("failed to find random media for path '%s': %w", query, searchErr)
 		}
 
+		applySystemDefaultLauncher(pl, &env, searchResult.SystemID)
 		if launchErr := launch(searchResult.Path); launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -218,6 +317,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", randomErr)
 			}
 
+			applySystemDefaultLauncher(pl, &env, game.SystemID)
 			if launchErr := launch(game.Path); launchErr != nil {
 				return platforms.CmdResult{
 					MediaChanged: true,
@@ -243,6 +343,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				fmt.Errorf("failed to get random game matching '%s': %w", searchQuery, randomErr)
 		}
 
+		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		if launchErr := launch(game.Path); launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -281,6 +382,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", err)
 	}
 
+	applySystemDefaultLauncher(pl, &env, game.SystemID)
 	if err := launch(game.Path); err != nil {
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -393,7 +495,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			log.Warn().Err(lookupErr).Str("system", args.System).
 				Msg("system arg provided but lookup failed - falling back to auto-detection")
 		} else {
-			applySystemDefaultLauncher(&env, system.ID)
+			applySystemDefaultLauncher(pl, &env, system.ID)
 		}
 	}
 
@@ -402,6 +504,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// if it's an absolute path, just try launch it
 	if filepath.IsAbs(path) {
 		log.Debug().Msgf("launching absolute path: %s", path)
+		applySystemDefaultLauncherForPath(pl, &env, path)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(path)
@@ -410,6 +513,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// match for uri style launch syntax
 	if helpers.ReURI.MatchString(path) {
 		log.Debug().Msgf("launching uri: %s", path)
+		applySystemDefaultLauncherForPath(pl, &env, path)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(path)
@@ -421,6 +525,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	var p string
 	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path); findErr == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
+		applySystemDefaultLauncherForPath(pl, &env, p)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(p)
@@ -447,7 +552,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("failed to lookup system '%s': %w", systemID, err)
 	}
 
-	applySystemDefaultLauncher(&env, system.ID)
+	applySystemDefaultLauncher(pl, &env, system.ID)
 
 	log.Info().Msgf("launching system: %s, path: %s", systemID, lookupPath)
 
@@ -484,6 +589,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		var fp string
 		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath); systemFindErr == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
+			applySystemDefaultLauncherForPath(pl, &env, fp)
 			return platforms.CmdResult{
 				MediaChanged: true,
 			}, launch(fp)
@@ -514,6 +620,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		log.Info().Msgf("found result: %s", res[0].Path)
 
 		game := res[0]
+		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(game.Path)
@@ -565,6 +672,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", query)
 		}
 
+		applySystemDefaultLauncher(pl, &env, res[0].SystemID)
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, launch(res[0].Path)
@@ -610,6 +718,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", searchQuery)
 	}
 
+	applySystemDefaultLauncher(pl, &env, res[0].SystemID)
 	return platforms.CmdResult{
 		MediaChanged: true,
 	}, launch(res[0].Path)
@@ -678,7 +787,7 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 		return platforms.CmdResult{}, err
 	}
 
-	applySystemDefaultLauncher(&env, entry.SystemID)
+	applySystemDefaultLauncher(pl, &env, entry.SystemID)
 	launch := getLaunchClosure(pl, &env)
 
 	log.Info().

--- a/pkg/zapscript/launch_last_test.go
+++ b/pkg/zapscript/launch_last_test.go
@@ -338,6 +338,56 @@ func TestCmdLaunchLast_LauncherAdvarg(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdLaunchLast_AbsolutePathAppliesGroupDefaultWithinHistorySystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := helpers.NewMockUserDBI()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "snes"
+launcher = "RA"
+`))
+	rootDir := t.TempDir()
+	absPath := createTestFile(t, rootDir, "SNES/Mario.sfc")
+
+	launchers := []platforms.Launcher{
+		{ID: "RA-Genesis", SystemID: "genesis", Groups: []string{"RA"}},
+		{ID: "snes-explicit", SystemID: "snes"},
+		{ID: "RA-SNES", SystemID: "snes", Groups: []string{"RA"}},
+	}
+
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 10).
+		Return([]database.MediaHistoryEntry{
+			makeHistoryEntry(absPath, "Mario", "snes"),
+		}, nil)
+
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockPlatform.On("LaunchMedia", cfg, absPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "RA-SNES"
+		}),
+		mock.AnythingOfType("*database.Database"),
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name:    "launch.last",
+			AdvArgs: zapscript.NewAdvArgs(nil),
+		},
+		Cfg:      cfg,
+		Database: &database.Database{UserDB: mockUserDB},
+	}
+
+	result, err := cmdLaunchLast(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockUserDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunchLast_LaunchErrorReturnsMediaChanged(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -317,6 +317,24 @@ launcher = "RA"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestResolveLauncherRefForSystem_SkipsWrongSystemIDMatch(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	launchers := []platforms.Launcher{
+		{ID: "shared-id", SystemID: "nes"},
+		{ID: "other", SystemID: "genesis"},
+	}
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+
+	launcherID, found := resolveLauncherRefForSystem(mockPlatform, &platforms.CmdEnv{Cfg: cfg}, "shared-id", "genesis")
+
+	assert.False(t, found)
+	assert.Empty(t, launcherID)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunch_SetNameArgsPassedThrough(t *testing.T) {
 	t.Parallel()
 
@@ -733,6 +751,117 @@ launcher = "genesis-alt"
 		Cmd: zapscript.Command{
 			Name: "launch.random",
 			Args: []string{"all"},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AbsolutePathDBBackedGroupDefaultWithinResultSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "RA"
+`))
+
+	launchers := []platforms.Launcher{
+		{ID: "RA-NES", SystemID: "nes", Groups: []string{"RA"}},
+		{ID: "genesis-explicit", SystemID: "genesis"},
+		{ID: "RA-Genesis", SystemID: "genesis", Groups: []string{"RA"}},
+	}
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+
+	queryPath := filepath.Join(launchTestAbsPath("games"), "GENESIS")
+	romPath := filepath.Join(queryPath, "Sonic.bin")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery",
+		mock.MatchedBy(func(q *database.MediaQuery) bool {
+			return q.PathPrefix == filepath.ToSlash(queryPath)
+		}),
+	).Return(database.SearchResult{SystemID: "genesis", Path: romPath}, nil)
+
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "RA-Genesis"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{queryPath},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AbsolutePathFilesystemFallbackAppliesInferredGroupDefault(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	dir := filepath.Join(rootDir, "GENESIS")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	romPath := filepath.Join(dir, "Sonic.bin")
+	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "RA"
+`))
+
+	launchers := []platforms.Launcher{
+		{ID: "genesis-base", SystemID: "genesis", Folders: []string{"GENESIS"}, Extensions: []string{".bin"}},
+		{ID: "RA-NES", SystemID: "nes", Groups: []string{"RA"}},
+		{ID: "genesis-explicit", SystemID: "genesis"},
+		{ID: "RA-Genesis", SystemID: "genesis", Groups: []string{"RA"}},
+	}
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: rootDir}).Maybe()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery",
+		mock.MatchedBy(func(q *database.MediaQuery) bool {
+			return q.PathPrefix == filepath.ToSlash(dir)
+		}),
+	).Return(database.SearchResult{}, sql.ErrNoRows)
+
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "RA-Genesis"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{dir},
 		},
 		Cfg:      cfg,
 		Database: &database.Database{MediaDB: mockMediaDB},

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -161,6 +161,162 @@ launcher = "genesis-default"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdLaunch_AbsolutePathAppliesInferredSystemDefault(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	rootDir := t.TempDir()
+	romPath := filepath.Join(rootDir, "GENESIS", "game.bin")
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-alt"
+`))
+
+	baseLauncher := platforms.Launcher{
+		ID:         "genesis-base",
+		SystemID:   "genesis",
+		Folders:    []string{"GENESIS"},
+		Extensions: []string{".bin"},
+	}
+	altLauncher := platforms.Launcher{
+		ID:         "genesis-alt",
+		SystemID:   "genesis",
+		Folders:    []string{"GENESIS"},
+		Extensions: []string{".bin"},
+	}
+	launchers := []platforms.Launcher{baseLauncher, altLauncher}
+
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: rootDir}).Maybe()
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-alt"
+		}),
+		(*database.Database)(nil),
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{romPath},
+		},
+		Cfg: cfg,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_AbsolutePathExplicitLauncherOverridesInferredDefault(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	rootDir := t.TempDir()
+	romPath := filepath.Join(rootDir, "GENESIS", "game.bin")
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-alt"
+`))
+
+	explicitLauncher := platforms.Launcher{
+		ID:         "genesis-explicit",
+		SystemID:   "genesis",
+		Folders:    []string{"GENESIS"},
+		Extensions: []string{".bin"},
+	}
+	altLauncher := platforms.Launcher{
+		ID:         "genesis-alt",
+		SystemID:   "genesis",
+		Folders:    []string{"GENESIS"},
+		Extensions: []string{".bin"},
+	}
+	launchers := []platforms.Launcher{explicitLauncher, altLauncher}
+
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-explicit"
+		}),
+		(*database.Database)(nil),
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{romPath},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				"launcher": "genesis-explicit",
+			}),
+		},
+		Cfg: cfg,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_SystemDefaultGroupResolvesWithinTargetSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	rootDir := t.TempDir()
+	romPath := filepath.Join(rootDir, "GENESIS", "game.bin")
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "RA"
+`))
+
+	baseLauncher := platforms.Launcher{
+		ID:         "genesis-base",
+		SystemID:   "genesis",
+		Folders:    []string{"GENESIS"},
+		Extensions: []string{".bin"},
+	}
+	nesRALauncher := platforms.Launcher{ID: "RANES", SystemID: "nes", Groups: []string{"RA"}}
+	genesisRALauncher := platforms.Launcher{ID: "RAGenesis", SystemID: "genesis", Groups: []string{"RA"}}
+	launchers := []platforms.Launcher{baseLauncher, nesRALauncher, genesisRALauncher}
+
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockPlatform.On("RootDirs", cfg).Return([]string{rootDir})
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: rootDir}).Maybe()
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "RAGenesis"
+		}),
+		(*database.Database)(nil),
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{romPath},
+		},
+		Cfg: cfg,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunch_SetNameArgsPassedThrough(t *testing.T) {
 	t.Parallel()
 
@@ -494,6 +650,99 @@ func TestCmdLaunch_FileNotFound(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFileNotFound, "should return ErrFileNotFound for missing file")
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdSearch_AppliesDefaultFromResultSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-alt"
+`))
+
+	altLauncher := platforms.Launcher{ID: "genesis-alt", SystemID: "genesis"}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{altLauncher})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "sonic" && filters.Limit == 1
+		}),
+	).Return([]database.SearchResultWithCursor{
+		{SystemID: "genesis", Path: filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")},
+	}, nil)
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-alt"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.search",
+			Args: []string{"sonic"},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdSearch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AppliesDefaultFromResultSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-alt"
+`))
+
+	altLauncher := platforms.Launcher{ID: "genesis-alt", SystemID: "genesis"}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{altLauncher})
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything).
+		Return(database.SearchResult{SystemID: "genesis", Path: romPath}, nil)
+
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-alt"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{"all"},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }
 

--- a/pkg/zapscript/titles.go
+++ b/pkg/zapscript/titles.go
@@ -67,7 +67,7 @@ func cmdTitle(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult,
 		return platforms.CmdResult{}, fmt.Errorf("invalid advanced arguments: %w", parseErr)
 	}
 
-	args.Launcher = applySystemDefaultLauncher(&env, system.ID)
+	args.Launcher = applySystemDefaultLauncher(pl, &env, system.ID)
 	launch := getLaunchClosure(pl, &env)
 
 	// Collect all launchers for this system to enable file type prioritization


### PR DESCRIPTION
## Summary
- apply configured system default launchers to path-based launches once the system can be inferred
- apply defaults to launch.search and launch.random based on the selected media result
- resolve launcher group defaults within the target system so API-accepted group values launch correctly

Verified locally with go test ./pkg/zapscript/, go test ./pkg/api/methods/, and task lint-fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-default launcher selection now automatically applies when launching, searching, and using random media.
  * Path-based launcher inference picks the best launcher for a given file path when no explicit launcher is set.
  * Explicit launcher arguments continue to override inferred or system-default choices.

* **Tests**
  * Added comprehensive tests covering launcher inference, system-default resolution, group-default behavior, and history-based launcher selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->