### PR TITLE
feat(mister): add RA Atari2600 launcher

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -335,7 +335,7 @@ func launchAltCoreWithSetName(
 
 func retroAchievementsSetName(launcherID string) (string, bool) {
 	switch launcherID {
-	case "RAAtari7800":
+	case "RAAtari2600":
 		return "RA_Atari7800", true
 	case "RAGameboy":
 		return "RA_Gameboy", true
@@ -491,9 +491,36 @@ func launchDOS() func(*config.Instance, string, *platforms.LaunchOptions) (*os.P
 	}
 }
 
+func atari2600BinTest(_ *config.Instance, path string) bool {
+	lowerPath := strings.ToLower(path)
+	// TODO: really, this should specifically check on the root dirs,
+	// 		 but we'd need to modify the test function to have access
+	//       to the platform interface. it's probably a safe enough bet
+	//       that something in an atari2600 subdir is for atari2600
+	if (strings.Contains(lowerPath, "/atari2600/") ||
+		strings.Contains(lowerPath, "/atari 2600/")) &&
+		filepath.Ext(lowerPath) == ".bin" {
+		return true
+	}
+	return false
+}
+
+func applyAtari2600Slots(core *cores.Core) {
+	core.Slots = []cores.Slot{
+		{
+			Exts: []string{".a26", ".bin"},
+			Mgl: &cores.MGLParams{
+				Delay:  1,
+				Method: "f",
+				Index:  1,
+			},
+		},
+	}
+}
+
 func launchAtari2600() func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
-		s, err := cores.GetCore("Atari2600")
+		s, err := cores.GetCore(systemdefs.SystemAtari2600)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get Atari2600 system: %w", err)
 		}
@@ -503,16 +530,45 @@ func launchAtari2600() func(*config.Instance, string, *platforms.LaunchOptions) 
 		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
 			return nil, setNameErr
 		}
-		sn.Slots = []cores.Slot{
-			{
-				Exts: []string{".a26", ".bin"},
-				Mgl: &cores.MGLParams{
-					Delay:  1,
-					Method: "f",
-					Index:  1,
-				},
-			},
+		applyAtari2600Slots(&sn)
+
+		err = mgls.LaunchGame(cfg, &sn, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to launch game: %w", err)
 		}
+
+		err = activegame.SetActiveGame(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set active game: %w", err)
+		}
+		return nil, nil
+	}
+}
+
+func launchAtari2600AltCore(
+	launcherID string,
+	rbfPath string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	cores.GlobalRBFCache.RegisterAltCore(launcherID, rbfPath)
+
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
+		s, err := cores.GetCore(systemdefs.SystemAtari2600)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get Atari2600 system: %w", err)
+		}
+		path = checkInZip(path)
+
+		sn := *s
+		sn.LauncherID = launcherID
+		sn.RBF = rbfPath
+		if setName, ok := retroAchievementsSetName(launcherID); ok {
+			sn.SetName = setName
+			sn.SetNameSameDir = true
+		}
+		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+			return nil, setNameErr
+		}
+		applyAtari2600Slots(&sn)
 
 		err = mgls.LaunchGame(cfg, &sn, path)
 		if err != nil {
@@ -805,19 +861,15 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"ATARI7800", "Atari2600"},
 			Extensions: []string{".a26"},
 			Launch:     launchAtari2600(),
-			Test: func(_ *config.Instance, path string) bool {
-				lowerPath := strings.ToLower(path)
-				// TODO: really, this should specifically check on the root dirs,
-				// 		 but we'd need to modify the test function to have access
-				//       to the platform interface. it's probably a safe enough bet
-				//       that something in an atari2600 subdir is for atari2600
-				if (strings.Contains(lowerPath, "/atari2600/") ||
-					strings.Contains(lowerPath, "/atari 2600/")) &&
-					filepath.Ext(lowerPath) == ".bin" {
-					return true
-				}
-				return false
-			},
+			Test:       atari2600BinTest,
+		},
+		{
+			ID:         "RAAtari2600",
+			SystemID:   systemdefs.SystemAtari2600,
+			Folders:    []string{"ATARI7800", "Atari2600"},
+			Extensions: []string{".a26"},
+			Launch:     launchAtari2600AltCore("RAAtari2600", "_RA_Cores/Cores/Atari7800"),
+			Test:       atari2600BinTest,
 		},
 		{
 			ID:       "LLAPIAtari2600",
@@ -852,13 +904,6 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:       "LLAPIAtari7800",
 			SystemID: systemdefs.SystemAtari7800,
 			Launch:   launchAltCore("LLAPIAtari7800", systemdefs.SystemAtari7800, "_LLAPI/Atari7800_LLAPI"),
-		},
-		{
-			ID:       "RAAtari7800",
-			SystemID: systemdefs.SystemAtari7800,
-			Launch: launchRetroAchievementsCore(
-				"RAAtari7800", systemdefs.SystemAtari7800, "_RA_Cores/Cores/Atari7800",
-			),
 		},
 		{
 			ID:         systemdefs.SystemAtariLynx,

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -518,6 +518,25 @@ func applyAtari2600Slots(core *cores.Core) {
 	}
 }
 
+func configureAtari2600AltCore(
+	core *cores.Core,
+	launcherID string,
+	rbfPath string,
+	opts *platforms.LaunchOptions,
+) error {
+	core.LauncherID = launcherID
+	core.RBF = rbfPath
+	if setName, ok := retroAchievementsSetName(launcherID); ok {
+		core.SetName = setName
+		core.SetNameSameDir = true
+	}
+	if setNameErr := applySetNameOptions(core, opts); setNameErr != nil {
+		return setNameErr
+	}
+	applyAtari2600Slots(core)
+	return nil
+}
+
 func launchAtari2600() func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore(systemdefs.SystemAtari2600)
@@ -559,16 +578,9 @@ func launchAtari2600AltCore(
 		path = checkInZip(path)
 
 		sn := *s
-		sn.LauncherID = launcherID
-		sn.RBF = rbfPath
-		if setName, ok := retroAchievementsSetName(launcherID); ok {
-			sn.SetName = setName
-			sn.SetNameSameDir = true
+		if configureErr := configureAtari2600AltCore(&sn, launcherID, rbfPath, opts); configureErr != nil {
+			return nil, configureErr
 		}
-		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
-			return nil, setNameErr
-		}
-		applyAtari2600Slots(&sn)
 
 		err = mgls.LaunchGame(cfg, &sn, path)
 		if err != nil {

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -730,6 +730,43 @@ func TestRetroAchievementsAtari2600LauncherMetadata(t *testing.T) {
 	assert.False(t, found.Test(nil, filepath.Join("roms", "ATARI7800", "game.bin")))
 }
 
+func TestConfigureAtari2600AltCore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to RA Atari7800 setname", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{ID: "Atari2600"}
+		err := configureAtari2600AltCore(&core, "RAAtari2600", "_RA_Cores/Cores/Atari7800", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "RAAtari2600", core.LauncherID)
+		assert.Equal(t, "_RA_Cores/Cores/Atari7800", core.RBF)
+		assert.Equal(t, "RA_Atari7800", core.SetName)
+		assert.True(t, core.SetNameSameDir)
+		require.Len(t, core.Slots, 1)
+		assert.ElementsMatch(t, []string{".a26", ".bin"}, core.Slots[0].Exts)
+		require.NotNil(t, core.Slots[0].Mgl)
+		assert.Equal(t, 1, core.Slots[0].Mgl.Delay)
+		assert.Equal(t, "f", core.Slots[0].Mgl.Method)
+		assert.Equal(t, 1, core.Slots[0].Mgl.Index)
+	})
+
+	t.Run("launch options override setname", func(t *testing.T) {
+		t.Parallel()
+
+		core := cores.Core{ID: "Atari2600"}
+		err := configureAtari2600AltCore(&core, "RAAtari2600", "_RA_Cores/Cores/Atari7800", &platforms.LaunchOptions{
+			SetName:        "Custom_Atari",
+			SetNameSameDir: "no",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Custom_Atari", core.SetName)
+		assert.False(t, core.SetNameSameDir)
+	})
+}
+
 func TestRetroAchievementsAtari7800LauncherRemoved(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -767,6 +767,28 @@ func TestConfigureAtari2600AltCore(t *testing.T) {
 	})
 }
 
+func TestRetroAchievementsAtari2600RejectsInvalidSetName(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	var found *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == "RAAtari2600" {
+			found = &launchers[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "RAAtari2600 launcher should exist")
+
+	_, err := found.Launch(nil, filepath.Join("roms", "Atari2600", "game.a26"), &platforms.LaunchOptions{
+		SetName: "!invalid",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid set_name")
+}
+
 func TestRetroAchievementsAtari7800LauncherRemoved(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -530,7 +530,7 @@ func TestRetroAchievementsSetNameMapping(t *testing.T) {
 		"RASMS":          "RA_SMS",
 		"RANeoGeo":       "RA_NeoGeo",
 		"RATurboGrafx16": "RA_TurboGrafx16",
-		"RAAtari7800":    "RA_Atari7800",
+		"RAAtari2600":    "RA_Atari7800",
 		"RAS32X":         "RA_S32X",
 	}
 
@@ -686,7 +686,7 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 		{"RASMS", "MasterSystem"},
 		{"RANeoGeo", "NeoGeo"},
 		{"RATurboGrafx16", "TurboGrafx16"},
-		{"RAAtari7800", "Atari7800"},
+		{"RAAtari2600", "Atari2600"},
 		{"RAS32X", "Sega32X"},
 	}
 
@@ -705,5 +705,38 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 			assert.Equal(t, tc.systemID, found.SystemID,
 				"%s must inherit slots from %s", tc.id, tc.systemID)
 		})
+	}
+}
+
+func TestRetroAchievementsAtari2600LauncherMetadata(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	var found *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == "RAAtari2600" {
+			found = &launchers[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "RAAtari2600 launcher should exist")
+	assert.Equal(t, "Atari2600", found.SystemID)
+	assert.ElementsMatch(t, []string{"ATARI7800", "Atari2600"}, found.Folders)
+	assert.Contains(t, found.Extensions, ".a26")
+	require.NotNil(t, found.Test)
+	assert.True(t, found.Test(nil, filepath.Join("roms", "Atari2600", "game.bin")))
+	assert.False(t, found.Test(nil, filepath.Join("roms", "ATARI7800", "game.bin")))
+}
+
+func TestRetroAchievementsAtari7800LauncherRemoved(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	for i := range launchers {
+		assert.NotEqual(t, "RAAtari7800", launchers[i].ID)
 	}
 }


### PR DESCRIPTION
## Summary
- add RAAtari2600 as Atari2600 media launcher using the Atari7800 RA core
- keep RA setname as RA_Atari7800 with same-dir behavior
- remove misleading RAAtari7800 launcher until genuine Atari7800 RA support exists

Checked: go test ./pkg/platforms/mister/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected RetroAchievements launcher mapping for Atari2600 games
  * Enhanced Atari2600 game detection and launcher configuration accuracy

* **Tests**
  * Added comprehensive validation tests for Atari2600 launcher functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->