### PR TITLE
fix(mediadb): bound indexing-time lookup paths

### DIFF
--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -259,14 +259,12 @@ func TestWebSocketRunJobStartsTimeoutAtExecution(t *testing.T) {
 		responses: make(chan *wsResponseJob, 1),
 	}
 
-	started := time.Now()
-	remainingCh := make(chan time.Duration, 1)
+	deadlineCh := make(chan time.Time, 1)
 	var methodMap MethodMap
 	require.NoError(t, methodMap.AddMethod("test.timeout", func(env requests.RequestEnv) (any, error) {
 		deadline, ok := env.Context.Deadline()
 		require.True(t, ok, "runJob should install per-request deadline")
-		started = time.Now()
-		remainingCh <- time.Until(deadline)
+		deadlineCh <- deadline
 		return map[string]string{"ok": "true"}, nil
 	}))
 
@@ -281,14 +279,15 @@ func TestWebSocketRunJobStartsTimeoutAtExecution(t *testing.T) {
 	time.Sleep(25 * time.Millisecond)
 	require.Error(t, enqueuedCtx.Err(), "pre-existing enqueue-time context should be expired")
 
+	beforeRun := time.Now()
 	d.runJob(job)
 	require.NotNil(t, job.cancel, "runJob should install cancel func")
 	defer job.cancel()
 
 	select {
-	case remaining := <-remainingCh:
-		assert.Greater(t, remaining, config.APIRequestTimeout-250*time.Millisecond)
-		assert.WithinDuration(t, time.Now(), started, 250*time.Millisecond)
+	case deadline := <-deadlineCh:
+		assert.True(t, deadline.After(beforeRun), "deadline should not reuse expired enqueue-time context")
+		assert.True(t, deadline.Before(beforeRun.Add(config.APIRequestTimeout+time.Second)))
 	case <-time.After(time.Second):
 		t.Fatal("handler did not run")
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -587,7 +587,7 @@ type MediaDBI interface {
 	GetIndexingSystems() ([]string, error)
 	TruncateSystems(systemIDs []string) error
 
-	SearchMediaPathExact(systems []systemdefs.System, query string) ([]SearchResult, error)
+	SearchMediaPathExact(ctx context.Context, systems []systemdefs.System, query string) ([]SearchResult, error)
 	SearchMediaWithFilters(ctx context.Context, filters *SearchFilters) ([]SearchResultWithCursor, error)
 	SearchMediaBySlug(
 		ctx context.Context, systemID string, slug string, tags []zapscript.TagFilter,
@@ -628,8 +628,8 @@ type MediaDBI interface {
 
 	IndexedSystems() ([]string, error)
 	SystemIndexed(system *systemdefs.System) bool
-	RandomGame(systems []systemdefs.System) (SearchResult, error)
-	RandomGameWithQuery(query *MediaQuery) (SearchResult, error)
+	RandomGame(ctx context.Context, systems []systemdefs.System) (SearchResult, error)
+	RandomGameWithQuery(ctx context.Context, query *MediaQuery) (SearchResult, error)
 	GetTotalMediaCount() (int, error)
 	GetScrapedMediaCount(ctx context.Context, scraperID string) (int, error)
 	GetTotalScrapedMediaCount(ctx context.Context) (int, error)

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -80,6 +80,8 @@ const defaultSlugSearchLimit = 50
 // logs during full-library indexing while preserving selective reindexing wins.
 const maxSelectiveInvalidationSystems = 32
 
+const mediaStatsCacheWriteTimeout = 100 * time.Millisecond
+
 // getSqliteConnParams constructs the SQLite connection string.
 func getSqliteConnParams() string {
 	return "?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000" +
@@ -139,8 +141,9 @@ func (db *MediaDB) conn() sqlQueryable {
 
 // invalidationScope describes what data was changed to determine cache invalidation scope
 type invalidationScope struct {
-	SystemIDs  []string
-	AllSystems bool
+	SystemIDs               []string
+	AllSystems              bool
+	PreserveSlugSearchCache bool
 }
 
 // invalidateCaches handles all cache invalidation in one place
@@ -148,7 +151,9 @@ func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 	db.inMemoryTagCache.Store(nil)
 	switch {
 	case scope.AllSystems:
-		db.slugSearchCache.Store(nil)
+		if !scope.PreserveSlugSearchCache {
+			db.slugSearchCache.Store(nil)
+		}
 	case len(scope.SystemIDs) > 0:
 		if cache := db.slugSearchCache.Load(); cache != nil {
 			db.slugSearchCache.Store(cache.withoutSystems(scope.SystemIDs))
@@ -198,6 +203,12 @@ func invalidationScopeForSystemIDs(systemIDs []string) invalidationScope {
 		return invalidationScope{AllSystems: true}
 	}
 	return invalidationScope{SystemIDs: systemIDs}
+}
+
+func (db *MediaDB) DropSlugSearchCacheForSystems(systemIDs []string) {
+	if cache := db.slugSearchCache.Load(); cache != nil {
+		db.slugSearchCache.Store(cache.withoutSystems(systemIDs))
+	}
 }
 
 func (db *MediaDB) markBrowseCacheDirty() {
@@ -480,13 +491,18 @@ func (db *MediaDB) UpdateLastGenerated() error {
 	// Only invalidate cache if NOT in a transaction (transactions invalidate once on commit)
 	if err == nil && !db.inTransaction {
 		systemIDs, getSystemsErr := db.GetIndexingSystems()
+		indexingStatus, statusErr := db.GetIndexingStatus()
+		isIndexing := statusErr == nil &&
+			(indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending)
 		switch {
 		case getSystemsErr != nil:
 			log.Warn().Err(getSystemsErr).
 				Msg("failed to load indexing systems for cache invalidation; clearing all caches")
 			db.invalidateCaches(invalidationScope{AllSystems: true})
 		default:
-			db.invalidateCaches(invalidationScopeForSystemIDs(systemIDs))
+			scope := invalidationScopeForSystemIDs(systemIDs)
+			scope.PreserveSlugSearchCache = isIndexing && !scope.AllSystems
+			db.invalidateCaches(scope)
 		}
 	}
 
@@ -1193,9 +1209,21 @@ func (db *MediaDB) CommitTransaction() error {
 	db.tx = nil
 	db.inTransaction = false
 
-	// During selective indexing, preserve unaffected in-memory slug cache coverage
-	// so post-index searches for untouched systems stay warm.
-	db.invalidateCaches(db.cacheInvalidationScopeForCommittedTransaction())
+	// During indexing, keep last-good slug search coverage available for
+	// foreground launches/searches, but still invalidate durable/count caches so
+	// random queries never trust stale MediaCountCache ranges after a commit.
+	indexingStatus, statusErr := sqlGetIndexingStatus(db.ctx, db.sql)
+	if statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to determine indexing status for cache invalidation")
+		db.invalidateCaches(invalidationScope{AllSystems: true})
+	} else if indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending {
+		scope := db.cacheInvalidationScopeForCommittedTransaction()
+		scope.PreserveSlugSearchCache = true
+		db.invalidateCaches(scope)
+		log.Debug().Str("status", indexingStatus).Msg("invalidated committed caches during indexing batch commit")
+	} else {
+		db.invalidateCaches(db.cacheInvalidationScopeForCommittedTransaction())
+	}
 	if err := db.flushBrowseCacheInvalidation(); err != nil {
 		return err
 	}
@@ -1267,7 +1295,7 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseDirectories(ctx, db.conn(), opts)
+	return sqlBrowseDirectories(ctx, db.sql, opts)
 }
 
 // BrowseFiles returns indexed media files that are immediate children of the given path prefix.
@@ -1277,7 +1305,7 @@ func (db *MediaDB) BrowseFiles(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseFiles(ctx, db.conn(), opts)
+	return sqlBrowseFiles(ctx, db.sql, opts)
 }
 
 // BrowseFileCount returns the total number of immediate child files under a path prefix.
@@ -1287,7 +1315,7 @@ func (db *MediaDB) BrowseFileCount(
 	if db.sql == nil {
 		return 0, ErrNullSQL
 	}
-	return sqlBrowseFileCount(ctx, db.conn(), opts)
+	return sqlBrowseFileCount(ctx, db.sql, opts)
 }
 
 // BrowseVirtualSchemes returns distinct URI schemes present in indexed media.
@@ -1297,7 +1325,7 @@ func (db *MediaDB) BrowseVirtualSchemes(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseVirtualSchemes(ctx, db.conn(), opts)
+	return sqlBrowseVirtualSchemes(ctx, db.sql, opts)
 }
 
 // BrowseRootCounts returns a map of root directory to count of indexed media
@@ -1309,7 +1337,7 @@ func (db *MediaDB) BrowseRootCounts(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseRootCounts(ctx, db.conn(), rootDirs)
+	return sqlBrowseRootCounts(ctx, db.sql, rootDirs)
 }
 
 // BrowseRouteCounts returns populated route counts for system-scoped browse roots.
@@ -1319,7 +1347,7 @@ func (db *MediaDB) BrowseRouteCounts(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseRouteCounts(ctx, db.conn(), opts)
+	return sqlBrowseRouteCounts(ctx, db.sql, opts)
 }
 
 // BrowseSystemRootCandidates returns, in two batched queries, the immediate
@@ -1332,7 +1360,7 @@ func (db *MediaDB) BrowseSystemRootCandidates(
 	if db.sql == nil {
 		return database.BrowseSystemRootCandidates{}, false, ErrNullSQL
 	}
-	return sqlBrowseSystemRootCandidates(ctx, db.conn(), opts)
+	return sqlBrowseSystemRootCandidates(ctx, db.sql, opts)
 }
 
 // PopulateBrowseCache rebuilds the BrowseCache table from the current Media data.
@@ -1344,11 +1372,13 @@ func (db *MediaDB) PopulateBrowseCache(ctx context.Context) error {
 }
 
 // SearchMediaPathExact returns indexed names matching an exact query (case-insensitive).
-func (db *MediaDB) SearchMediaPathExact(systems []systemdefs.System, query string) ([]database.SearchResult, error) {
+func (db *MediaDB) SearchMediaPathExact(
+	ctx context.Context, systems []systemdefs.System, query string,
+) ([]database.SearchResult, error) {
 	if db.sql == nil {
 		return make([]database.SearchResult, 0), ErrNullSQL
 	}
-	return sqlSearchMediaPathExact(db.ctx, db.conn(), systems, query)
+	return sqlSearchMediaPathExact(ctx, db.sql, systems, query)
 }
 
 func (db *MediaDB) SearchMediaWithFilters(
@@ -1432,7 +1462,7 @@ func (db *MediaDB) SearchMediaWithFilters(
 		}
 
 		return sqlSearchMediaByTitleDBIDs(
-			ctx, db.conn(), candidateIDs, filters.Tags,
+			ctx, db.sql, candidateIDs, filters.Tags,
 			filters.Letter, filters.Cursor, filters.Limit)
 	}
 
@@ -1445,7 +1475,7 @@ func (db *MediaDB) SearchMediaWithFilters(
 		Bool("includeName", includeName).
 		Msg("media search falling back to SQL LIKE path")
 	results, err := sqlSearchMediaWithFilters(
-		ctx, db.conn(), filters.Systems, variantGroups, qWords, filters.Tags,
+		ctx, db.sql, filters.Systems, variantGroups, qWords, filters.Tags,
 		filters.Letter, filters.Cursor, filters.Limit, includeName)
 
 	return results, err
@@ -1488,7 +1518,7 @@ func (db *MediaDB) slugCacheSearch(
 	// Skip SQL-level tag filters for cache path — the Go-side selection
 	// logic handles missing/conflicting tags gracefully, and the INTERSECT
 	// subqueries are the most expensive part of the query on slow storage.
-	results, err := sqlSearchMediaByTitleDBIDs(ctx, db.conn(), candidates, nil, nil, nil, defaultSlugSearchLimit)
+	results, err := sqlSearchMediaByTitleDBIDs(ctx, db.sql, candidates, nil, nil, nil, defaultSlugSearchLimit)
 	log.Debug().
 		Str("system", systemID).
 		Int("candidates", len(candidates)).
@@ -1509,7 +1539,7 @@ func (db *MediaDB) SearchMediaBySlug(
 	// SQL fallback (cache not ready) still applies tag filters in the query
 	// for performance. The cache path skips SQL tag filters — Go-side
 	// selection handles tag matching in both cases.
-	return sqlSearchMediaBySlug(ctx, db.conn(), systemID, slug, tags)
+	return sqlSearchMediaBySlug(ctx, db.sql, systemID, slug, tags)
 }
 
 func (db *MediaDB) SearchMediaBySecondarySlug(
@@ -1522,7 +1552,7 @@ func (db *MediaDB) SearchMediaBySecondarySlug(
 		(*SlugSearchCache).ExactSecondarySlugMatch); ok || err != nil {
 		return results, err
 	}
-	return sqlSearchMediaBySecondarySlug(ctx, db.conn(), systemID, secondarySlug, tags)
+	return sqlSearchMediaBySecondarySlug(ctx, db.sql, systemID, secondarySlug, tags)
 }
 
 func (db *MediaDB) SearchMediaBySlugPrefix(
@@ -1535,7 +1565,7 @@ func (db *MediaDB) SearchMediaBySlugPrefix(
 		(*SlugSearchCache).PrefixSlugMatch); ok || err != nil {
 		return results, err
 	}
-	return sqlSearchMediaBySlugPrefix(ctx, db.conn(), systemID, slugPrefix, tags)
+	return sqlSearchMediaBySlugPrefix(ctx, db.sql, systemID, slugPrefix, tags)
 }
 
 // SearchMediaBySlugIn searches for media items matching any of the provided slugs using an IN clause.
@@ -1571,10 +1601,10 @@ func (db *MediaDB) SearchMediaBySlugIn(
 		if len(candidates) == 0 {
 			return []database.SearchResultWithCursor{}, nil
 		}
-		return sqlSearchMediaByTitleDBIDs(ctx, db.conn(), candidates, tags, nil, nil, defaultSlugSearchLimit)
+		return sqlSearchMediaByTitleDBIDs(ctx, db.sql, candidates, tags, nil, nil, defaultSlugSearchLimit)
 	}
 
-	return sqlSearchMediaBySlugIn(ctx, db.conn(), systemID, slugList, tags)
+	return sqlSearchMediaBySlugIn(ctx, db.sql, systemID, slugList, tags)
 }
 
 // GetTitlesWithPreFilter retrieves media titles filtered by slug length and word count ranges.
@@ -1587,8 +1617,9 @@ func (db *MediaDB) GetTitlesWithPreFilter(
 		return make([]database.MediaTitle, 0), ErrNullSQL
 	}
 
-	// Look up system DBID
-	system, err := db.FindSystemBySystemID(systemID)
+	// Look up system DBID from committed state. This path is used by foreground
+	// title resolution and must not read the active indexing transaction.
+	system, err := sqlFindSystemBySystemID(ctx, db.sql, systemID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find system '%s': %w", systemID, err)
 	}
@@ -1746,7 +1777,7 @@ func (db *MediaDB) SearchMediaPathGlob(systems []systemdefs.System, query string
 
 	if len(variantGroups) == 0 {
 		// return random instead
-		rnd, err := db.RandomGame(systems)
+		rnd, err := db.RandomGame(db.ctx, systems)
 		if err != nil {
 			return nullResults, err
 		}
@@ -1755,7 +1786,7 @@ func (db *MediaDB) SearchMediaPathGlob(systems []systemdefs.System, query string
 
 	// TODO: since we approximated a glob, we should actually check
 	//       result paths against base glob to confirm
-	return sqlSearchMediaPathParts(db.ctx, db.conn(), systems, variantGroups)
+	return sqlSearchMediaPathParts(db.ctx, db.sql, systems, variantGroups)
 }
 
 // SystemIndexed returns true if a specific system is indexed in the media database.
@@ -1776,7 +1807,7 @@ func (db *MediaDB) IndexedSystems() ([]string, error) {
 }
 
 // RandomGame returns a random game from specified systems.
-func (db *MediaDB) RandomGame(systems []systemdefs.System) (database.SearchResult, error) {
+func (db *MediaDB) RandomGame(ctx context.Context, systems []systemdefs.System) (database.SearchResult, error) {
 	var result database.SearchResult
 	if db.sql == nil {
 		return result, ErrNullSQL
@@ -1803,7 +1834,7 @@ func (db *MediaDB) RandomGame(systems []systemdefs.System) (database.SearchResul
 			if !ok {
 				return result, sql.ErrNoRows
 			}
-			return sqlGetRandomMediaForTitle(db.ctx, db.conn(), titleDBID)
+			return sqlGetRandomMediaForTitle(ctx, db.sql, titleDBID)
 		}
 	}
 
@@ -1812,7 +1843,7 @@ func (db *MediaDB) RandomGame(systems []systemdefs.System) (database.SearchResul
 	for i, sys := range systems {
 		systemIDs[i] = sys.ID
 	}
-	indexedIDs, err := sqlFilterIndexedSystems(db.ctx, db.conn(), systemIDs)
+	indexedIDs, err := sqlFilterIndexedSystems(ctx, db.sql, systemIDs)
 	if err != nil {
 		return result, fmt.Errorf("failed to filter indexed systems: %w", err)
 	}
@@ -1829,11 +1860,11 @@ func (db *MediaDB) RandomGame(systems []systemdefs.System) (database.SearchResul
 		return result, fmt.Errorf("failed to get system definition: %w", sysErr)
 	}
 
-	return sqlRandomGame(db.ctx, db.conn(), sys)
+	return sqlRandomGame(ctx, db.sql, sys)
 }
 
 // RandomGameWithQuery returns a random game matching the specified MediaQuery.
-func (db *MediaDB) RandomGameWithQuery(query *database.MediaQuery) (database.SearchResult, error) {
+func (db *MediaDB) RandomGameWithQuery(ctx context.Context, query *database.MediaQuery) (database.SearchResult, error) {
 	var result database.SearchResult
 	if db.sql == nil {
 		return result, ErrNullSQL
@@ -1858,13 +1889,13 @@ func (db *MediaDB) RandomGameWithQuery(query *database.MediaQuery) (database.Sea
 			if !ok {
 				return result, sql.ErrNoRows
 			}
-			return sqlGetRandomMediaForTitle(db.ctx, db.conn(), titleDBID)
+			return sqlGetRandomMediaForTitle(ctx, db.sql, titleDBID)
 		}
 	}
 
 	// For SQL fallback, filter to indexed systems and pick one for equal weight
 	if len(query.Systems) > 1 {
-		indexedSystems, filterErr := sqlFilterIndexedSystems(db.ctx, db.conn(), query.Systems)
+		indexedSystems, filterErr := sqlFilterIndexedSystems(ctx, db.sql, query.Systems)
 		if filterErr != nil {
 			return result, fmt.Errorf("failed to filter indexed systems: %w", filterErr)
 		}
@@ -1881,25 +1912,31 @@ func (db *MediaDB) RandomGameWithQuery(query *database.MediaQuery) (database.Sea
 	}
 
 	// Check MediaCountCache for complex queries or when slug cache unavailable
-	if stats, found := db.GetCachedStats(db.ctx, query); found {
+	if stats, found := db.GetCachedStats(ctx, query); found {
 		if stats.Count == 0 {
 			return result, sql.ErrNoRows
 		}
-		return db.randomGameWithStats(query, stats)
+		return db.randomGameWithStats(ctx, query, stats)
 	}
 
 	// Cache miss - use the full SQL implementation and cache the stats
-	result, stats, err := sqlRandomGameWithQueryAndStats(db.ctx, db.conn(), query)
+	result, stats, err := sqlRandomGameWithQueryAndStats(ctx, db.sql, query)
 	if err != nil {
 		return result, err
 	}
 
 	// Cache the stats for future use (best effort - don't fail if caching fails)
-	if cacheErr := db.SetCachedStats(db.ctx, query, stats); cacheErr != nil {
-		log.Warn().Err(cacheErr).Msg("failed to cache media query stats")
-	}
+	db.cacheMediaStats(ctx, query, stats)
 
 	return result, nil
+}
+
+func (db *MediaDB) cacheMediaStats(ctx context.Context, query *database.MediaQuery, stats MediaStats) {
+	cacheCtx, cancel := context.WithTimeout(ctx, mediaStatsCacheWriteTimeout)
+	defer cancel()
+	if cacheErr := db.SetCachedStats(cacheCtx, query, stats); cacheErr != nil {
+		log.Warn().Err(cacheErr).Msg("failed to cache media query stats")
+	}
 }
 
 // GetTotalMediaCount returns the total number of media entries in the database.
@@ -1931,7 +1968,7 @@ func (db *MediaDB) GetCachedStats(ctx context.Context, query *database.MediaQuer
 	}
 
 	var stats MediaStats
-	err = db.conn().QueryRowContext(ctx,
+	err = db.sql.QueryRowContext(ctx,
 		"SELECT Count, MinDBID, MaxDBID FROM MediaCountCache WHERE QueryHash = ?",
 		queryHash).Scan(&stats.Count, &stats.MinDBID, &stats.MaxDBID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1946,7 +1983,9 @@ func (db *MediaDB) GetCachedStats(ctx context.Context, query *database.MediaQuer
 }
 
 // randomGameWithStats generates a random game selection using cached statistics.
-func (db *MediaDB) randomGameWithStats(query *database.MediaQuery, stats MediaStats) (database.SearchResult, error) {
+func (db *MediaDB) randomGameWithStats(
+	ctx context.Context, query *database.MediaQuery, stats MediaStats,
+) (database.SearchResult, error) {
 	var row database.SearchResult
 
 	// Generate random DBID within the range
@@ -1972,7 +2011,7 @@ func (db *MediaDB) randomGameWithStats(query *database.MediaQuery, stats MediaSt
 	`, whereClause)
 
 	args = append(args, targetDBID)
-	err = db.conn().QueryRowContext(db.ctx, selectQuery, args...).Scan(
+	err = db.sql.QueryRowContext(ctx, selectQuery, args...).Scan(
 		&row.SystemID,
 		&row.Path,
 	)
@@ -1988,7 +2027,7 @@ func (db *MediaDB) randomGameWithStats(query *database.MediaQuery, stats MediaSt
 			LIMIT 1
 		`, whereClause)
 		args[len(args)-1] = targetDBID // Replace the last argument
-		err = db.conn().QueryRowContext(db.ctx, selectQuery, args...).Scan(
+		err = db.sql.QueryRowContext(ctx, selectQuery, args...).Scan(
 			&row.SystemID,
 			&row.Path,
 		)
@@ -2005,6 +2044,9 @@ func (db *MediaDB) SetCachedStats(ctx context.Context, query *database.MediaQuer
 	if db.sql == nil {
 		return ErrNullSQL
 	}
+	if db.inTransaction {
+		return nil
+	}
 
 	queryHash, err := db.generateQueryHash(query)
 	if err != nil {
@@ -2016,7 +2058,7 @@ func (db *MediaDB) SetCachedStats(ctx context.Context, query *database.MediaQuer
 		return fmt.Errorf("failed to marshal query params: %w", err)
 	}
 
-	_, err = db.conn().ExecContext(ctx, `
+	_, err = db.sql.ExecContext(ctx, `
 		INSERT OR REPLACE INTO MediaCountCache (QueryHash, QueryParams, Count, MinDBID, MaxDBID, LastUpdated)
 		VALUES (?, ?, ?, ?, ?, ?)
 	`, queryHash, string(queryParams), stats.Count, stats.MinDBID, stats.MaxDBID, time.Now().Unix())

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1213,15 +1213,16 @@ func (db *MediaDB) CommitTransaction() error {
 	// foreground launches/searches, but still invalidate durable/count caches so
 	// random queries never trust stale MediaCountCache ranges after a commit.
 	indexingStatus, statusErr := sqlGetIndexingStatus(db.ctx, db.sql)
-	if statusErr != nil {
+	switch {
+	case statusErr != nil:
 		log.Warn().Err(statusErr).Msg("failed to determine indexing status for cache invalidation")
 		db.invalidateCaches(invalidationScope{AllSystems: true})
-	} else if indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending {
+	case indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending:
 		scope := db.cacheInvalidationScopeForCommittedTransaction()
 		scope.PreserveSlugSearchCache = true
 		db.invalidateCaches(scope)
 		log.Debug().Str("status", indexingStatus).Msg("invalidated committed caches during indexing batch commit")
-	} else {
+	default:
 		db.invalidateCaches(db.cacheInvalidationScopeForCommittedTransaction())
 	}
 	if err := db.flushBrowseCacheInvalidation(); err != nil {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -650,19 +650,25 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test exact search - must match full path
-	results, err := mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Super Mario Bros.nes")
+	results, err := mediaDB.SearchMediaPathExact(
+		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Super Mario Bros.nes",
+	)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "Super Mario Bros", results[0].Name)
 
 	// Test case-insensitive search - must match full path
-	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Mega Man.nes")
+	results, err = mediaDB.SearchMediaPathExact(
+		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Mega Man.nes",
+	)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "Mega Man", results[0].Name)
 
 	// Test no match
-	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Zelda.nes")
+	results, err = mediaDB.SearchMediaPathExact(
+		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Zelda.nes",
+	)
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -912,12 +918,16 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Indexed systems after truncate: %v", systems)
 
-	results, err := mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*snesSystem}, "/roms/snes/game.sfc")
+	results, err := mediaDB.SearchMediaPathExact(
+		context.Background(), []systemdefs.System{*snesSystem}, "/roms/snes/game.sfc",
+	)
 	require.NoError(t, err)
 	t.Logf("Search results: %+v", results)
 	assert.Len(t, results, 1)
 
-	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/game.nes")
+	results, err = mediaDB.SearchMediaPathExact(
+		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/game.nes",
+	)
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -2385,7 +2395,9 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 
 	mixedSystemIDs := []string{nesSystem.ID, snesSystem.ID, genesisSystem.ID, gbSystem.ID}
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{Systems: mixedSystemIDs})
+		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+			Systems: mixedSystemIDs,
+		})
 		require.NoError(t, randErr, "RandomGameWithQuery SQL path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGameWithQuery SQL path returned non-indexed system %s", result.SystemID)
@@ -2404,7 +2416,9 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 	}
 
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{Systems: mixedSystemIDs})
+		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+			Systems: mixedSystemIDs,
+		})
 		require.NoError(t, randErr, "RandomGameWithQuery cache path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGameWithQuery cache path returned non-indexed system %s", result.SystemID)

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -255,6 +255,38 @@ func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {
 	return db, cleanup
 }
 
+func TestMediaDB_ForegroundSlugSearchIgnoresUncommittedIndexTransaction(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Committed Game", filepath.Join("roms", "nes", "committed.nes"))
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	defer func() { _ = mediaDB.RollbackTransaction() }()
+
+	pendingTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: system.DBID,
+		Slug:       "pendinggame",
+		Name:       "Pending Game",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     system.DBID,
+		MediaTitleDBID: pendingTitle.DBID,
+		Path:           filepath.Join("roms", "nes", "pending.nes"),
+	})
+	require.NoError(t, err)
+
+	results, err := mediaDB.SearchMediaBySlug(context.Background(), "NES", "pendinggame", nil)
+	require.NoError(t, err)
+	require.Empty(t, results)
+
+	results, err = mediaDB.SearchMediaBySlug(context.Background(), "NES", "committedgame", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Committed Game", results[0].Name)
+}
+
 func insertSystemWithMedia(t *testing.T, mediaDB *MediaDB, systemID, titleName, mediaPath string) database.System {
 	t.Helper()
 
@@ -618,19 +650,19 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test exact search - must match full path
-	results, err := mediaDB.SearchMediaPathExact([]systemdefs.System{*nesSystem}, "/roms/nes/Super Mario Bros.nes")
+	results, err := mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Super Mario Bros.nes")
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "Super Mario Bros", results[0].Name)
 
 	// Test case-insensitive search - must match full path
-	results, err = mediaDB.SearchMediaPathExact([]systemdefs.System{*nesSystem}, "/roms/nes/Mega Man.nes")
+	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Mega Man.nes")
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "Mega Man", results[0].Name)
 
 	// Test no match
-	results, err = mediaDB.SearchMediaPathExact([]systemdefs.System{*nesSystem}, "/roms/nes/Zelda.nes")
+	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Zelda.nes")
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -680,7 +712,7 @@ func TestMediaDB_RandomGame_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test random game
-	result, err := mediaDB.RandomGame([]systemdefs.System{*nesSystem})
+	result, err := mediaDB.RandomGame(context.Background(), []systemdefs.System{*nesSystem})
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
 	assert.NotEmpty(t, result.Path)
@@ -689,14 +721,39 @@ func TestMediaDB_RandomGame_Integration(t *testing.T) {
 	query := database.MediaQuery{
 		Systems: []string{nesSystem.ID},
 	}
-	result, err = mediaDB.RandomGameWithQuery(&query)
+	result, err = mediaDB.RandomGameWithQuery(context.Background(), &query)
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
 
 	// Test that cache is working - second call should use cache
-	result2, err := mediaDB.RandomGameWithQuery(&query)
+	result2, err := mediaDB.RandomGameWithQuery(context.Background(), &query)
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result2.SystemID)
+}
+
+func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = mediaDB.SearchMediaPathExact(ctx, []systemdefs.System{*nesSystem}, "/roms/nes/game.nes")
+	require.Error(t, err)
+
+	_, err = mediaDB.RandomGame(ctx, []systemdefs.System{*nesSystem})
+	require.Error(t, err)
+
+	query := database.MediaQuery{Systems: []string{nesSystem.ID}}
+	_, err = mediaDB.RandomGameWithQuery(ctx, &query)
+	require.Error(t, err)
 }
 
 func TestMediaDB_CacheInvalidation_Integration(t *testing.T) {
@@ -751,7 +808,7 @@ func TestMediaDB_CacheInvalidation_Integration(t *testing.T) {
 	query := database.MediaQuery{
 		Systems: []string{nesSystem.ID},
 	}
-	_, err = mediaDB.RandomGameWithQuery(&query)
+	_, err = mediaDB.RandomGameWithQuery(context.Background(), &query)
 	require.NoError(t, err)
 
 	// Verify cache exists
@@ -855,12 +912,12 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("Indexed systems after truncate: %v", systems)
 
-	results, err := mediaDB.SearchMediaPathExact([]systemdefs.System{*snesSystem}, "/roms/snes/game.sfc")
+	results, err := mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*snesSystem}, "/roms/snes/game.sfc")
 	require.NoError(t, err)
 	t.Logf("Search results: %+v", results)
 	assert.Len(t, results, 1)
 
-	results, err = mediaDB.SearchMediaPathExact([]systemdefs.System{*nesSystem}, "/roms/nes/game.nes")
+	results, err = mediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/game.nes")
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }
@@ -1124,7 +1181,7 @@ func TestMediaDB_ConcurrentReads_Integration(t *testing.T) {
 
 	for range numReaders {
 		go func() {
-			result, err := mediaDB.RandomGame([]systemdefs.System{*nesSystem})
+			result, err := mediaDB.RandomGame(context.Background(), []systemdefs.System{*nesSystem})
 			if err != nil {
 				errChan <- err
 				return
@@ -2223,12 +2280,12 @@ func TestMediaDB_CacheFastPath_MatchesSQL_Integration(t *testing.T) {
 	}
 
 	// --- Phase 3: Verify RandomGame and RandomGameWithQuery via cache ---
-	result, err := mediaDB.RandomGame([]systemdefs.System{*nesSystem})
+	result, err := mediaDB.RandomGame(context.Background(), []systemdefs.System{*nesSystem})
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
 	assert.NotEmpty(t, result.Path)
 
-	result, err = mediaDB.RandomGameWithQuery(&database.MediaQuery{
+	result, err = mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
 		Systems: []string{nesSystem.ID},
 	})
 	require.NoError(t, err)
@@ -2236,7 +2293,7 @@ func TestMediaDB_CacheFastPath_MatchesSQL_Integration(t *testing.T) {
 	assert.NotEmpty(t, result.Path)
 
 	// RandomGameWithQuery with multiple systems
-	result, err = mediaDB.RandomGameWithQuery(&database.MediaQuery{
+	result, err = mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
 		Systems: []string{nesSystem.ID, snesSystem.ID},
 	})
 	require.NoError(t, err)
@@ -2244,7 +2301,7 @@ func TestMediaDB_CacheFastPath_MatchesSQL_Integration(t *testing.T) {
 	assert.NotEmpty(t, result.Path)
 
 	// RandomGame with empty system filter should fail
-	_, err = mediaDB.RandomGame(nil)
+	_, err = mediaDB.RandomGame(context.Background(), nil)
 	require.Error(t, err)
 }
 
@@ -2320,7 +2377,7 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 	assert.Nil(t, mediaDB.slugSearchCache.Load(), "cache should be nil before build")
 
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGame(mixedSystems)
+		result, randErr := mediaDB.RandomGame(context.Background(), mixedSystems)
 		require.NoError(t, randErr, "RandomGame SQL path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGame SQL path returned non-indexed system %s", result.SystemID)
@@ -2328,7 +2385,7 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 
 	mixedSystemIDs := []string{nesSystem.ID, snesSystem.ID, genesisSystem.ID, gbSystem.ID}
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGameWithQuery(&database.MediaQuery{Systems: mixedSystemIDs})
+		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{Systems: mixedSystemIDs})
 		require.NoError(t, randErr, "RandomGameWithQuery SQL path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGameWithQuery SQL path returned non-indexed system %s", result.SystemID)
@@ -2340,14 +2397,14 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 	require.NotNil(t, mediaDB.slugSearchCache.Load())
 
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGame(mixedSystems)
+		result, randErr := mediaDB.RandomGame(context.Background(), mixedSystems)
 		require.NoError(t, randErr, "RandomGame cache path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGame cache path returned non-indexed system %s", result.SystemID)
 	}
 
 	for i := range 20 {
-		result, randErr := mediaDB.RandomGameWithQuery(&database.MediaQuery{Systems: mixedSystemIDs})
+		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{Systems: mixedSystemIDs})
 		require.NoError(t, randErr, "RandomGameWithQuery cache path iteration %d", i)
 		assert.True(t, indexedIDs[result.SystemID],
 			"RandomGameWithQuery cache path returned non-indexed system %s", result.SystemID)
@@ -2355,19 +2412,19 @@ func TestMediaDB_RandomGame_MixedSystems_Integration(t *testing.T) {
 
 	// --- Edge case: ALL systems non-indexed ---
 	nonIndexedSystems := []systemdefs.System{*genesisSystem, *gbSystem}
-	_, err = mediaDB.RandomGame(nonIndexedSystems)
+	_, err = mediaDB.RandomGame(context.Background(), nonIndexedSystems)
 	require.ErrorIs(t, err, sql.ErrNoRows, "RandomGame with all non-indexed systems should return ErrNoRows")
 
-	_, err = mediaDB.RandomGameWithQuery(&database.MediaQuery{
+	_, err = mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
 		Systems: []string{genesisSystem.ID, gbSystem.ID},
 	})
 	require.ErrorIs(t, err, sql.ErrNoRows, "RandomGameWithQuery with all non-indexed systems should return ErrNoRows")
 
 	// --- Edge case: single non-indexed system ---
-	_, err = mediaDB.RandomGame([]systemdefs.System{*genesisSystem})
+	_, err = mediaDB.RandomGame(context.Background(), []systemdefs.System{*genesisSystem})
 	require.ErrorIs(t, err, sql.ErrNoRows, "RandomGame with single non-indexed system should return ErrNoRows")
 
-	_, err = mediaDB.RandomGameWithQuery(&database.MediaQuery{
+	_, err = mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
 		Systems: []string{genesisSystem.ID},
 	})
 	require.ErrorIs(t, err, sql.ErrNoRows, "RandomGameWithQuery with single non-indexed system should return ErrNoRows")
@@ -2481,7 +2538,211 @@ func TestMediaDB_RefreshSlugSearchCacheForSystems_Integration(t *testing.T) {
 	assert.Equal(t, filepath.Join("roms", "snes", "zelda.sfc"), results[0].Path)
 }
 
-func TestMediaDB_CommitTransaction_SelectiveIndexingPreservesUnchangedSlugCache_Integration(t *testing.T) {
+func TestMediaDB_IndexingInvalidationPreservesSlugSearchCacheWhenRequested_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: nesSystem.ID, Name: nesSystem.ID})
+	require.NoError(t, err)
+	insertedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       slugs.Slugify(slugs.MediaTypeGame, "Super Mario Bros"),
+		Name:       "Super Mario Bros",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     insertedSystem.DBID,
+		MediaTitleDBID: insertedTitle.DBID,
+		Path:           filepath.Join("roms", "nes", "smb.nes"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	require.NotNil(t, mediaDB.slugSearchCache.Load())
+
+	mediaDB.invalidateCaches(invalidationScope{AllSystems: true, PreserveSlugSearchCache: true})
+	require.NotNil(t, mediaDB.slugSearchCache.Load())
+	assert.True(t, mediaDB.slugSearchCache.Load().CanServeSystems([]string{nesSystem.ID}))
+
+	mediaDB.invalidateCaches(invalidationScope{AllSystems: true})
+	assert.Nil(t, mediaDB.slugSearchCache.Load())
+}
+
+func TestMediaDB_UpdateLastGenerated_FullIndexClearsSlugSearchCache_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: nesSystem.ID, Name: nesSystem.ID})
+	require.NoError(t, err)
+	insertedTitle, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       slugs.Slugify(slugs.MediaTypeGame, "Super Mario Bros"),
+		Name:       "Super Mario Bros",
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     insertedSystem.DBID,
+		MediaTitleDBID: insertedTitle.DBID,
+		Path:           filepath.Join("roms", "nes", "smb.nes"),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	require.NotNil(t, mediaDB.slugSearchCache.Load())
+
+	require.NoError(t, mediaDB.SetIndexingSystems(nil))
+	require.NoError(t, mediaDB.SetIndexingStatus(IndexingStatusRunning))
+	defer func() {
+		require.NoError(t, mediaDB.SetIndexingStatus(""))
+		require.NoError(t, mediaDB.SetIndexingSystems(nil))
+	}()
+
+	require.NoError(t, mediaDB.UpdateLastGenerated())
+	assert.Nil(t, mediaDB.slugSearchCache.Load())
+}
+
+func TestMediaDB_DropSlugSearchCacheForSystems_RemovesOnlyTouchedSystems_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	snesSystem, err := systemdefs.GetSystem("SNES")
+	require.NoError(t, err)
+
+	insertGame := func(system *systemdefs.System, titleName string, relPath string) {
+		t.Helper()
+
+		require.NoError(t, mediaDB.BeginTransaction(false))
+		insertedSystem, insertErr := mediaDB.FindOrInsertSystem(database.System{SystemID: system.ID, Name: system.ID})
+		require.NoError(t, insertErr)
+		insertedTitle, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(slugs.MediaTypeGame, titleName),
+			Name:       titleName,
+		})
+		require.NoError(t, insertErr)
+		_, insertErr = mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           relPath,
+		})
+		require.NoError(t, insertErr)
+		require.NoError(t, mediaDB.CommitTransaction())
+	}
+
+	insertGame(nesSystem, "Super Mario Bros", filepath.Join("roms", "nes", "smb.nes"))
+	insertGame(snesSystem, "The Legend of Zelda", filepath.Join("roms", "snes", "zelda.sfc"))
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+
+	mediaDB.DropSlugSearchCacheForSystems([]string{nesSystem.ID})
+	cache := mediaDB.slugSearchCache.Load()
+	require.NotNil(t, cache)
+	assert.False(t, cache.complete)
+	assert.False(t, cache.CanServeSystems([]string{nesSystem.ID}))
+	assert.True(t, cache.CanServeSystems([]string{snesSystem.ID}))
+
+	results, err := mediaDB.SearchMediaBySlug(context.Background(), snesSystem.ID, "The Legend of Zelda", nil)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	results, err = mediaDB.SearchMediaBySlug(context.Background(), nesSystem.ID, "Super Mario Bros", nil)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+}
+
+func TestMediaDB_RandomGameWithQuery_PartialSlugCacheFallsBackToSQL_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	snesSystem, err := systemdefs.GetSystem("SNES")
+	require.NoError(t, err)
+
+	insertGame := func(system *systemdefs.System, titleName string, relPath string) {
+		t.Helper()
+
+		require.NoError(t, mediaDB.BeginTransaction(false))
+		insertedSystem, insertErr := mediaDB.FindOrInsertSystem(database.System{SystemID: system.ID, Name: system.ID})
+		require.NoError(t, insertErr)
+		insertedTitle, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(slugs.MediaTypeGame, titleName),
+			Name:       titleName,
+		})
+		require.NoError(t, insertErr)
+		_, insertErr = mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           relPath,
+		})
+		require.NoError(t, insertErr)
+		require.NoError(t, mediaDB.CommitTransaction())
+	}
+
+	insertGame(nesSystem, "Super Mario Bros", filepath.Join("roms", "nes", "smb.nes"))
+	insertGame(snesSystem, "The Legend of Zelda", filepath.Join("roms", "snes", "zelda.sfc"))
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	mediaDB.DropSlugSearchCacheForSystems([]string{snesSystem.ID})
+
+	seenSNES := false
+	for range 100 {
+		result, randErr := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+			Systems: []string{nesSystem.ID, snesSystem.ID},
+		})
+		require.NoError(t, randErr)
+		assert.Contains(t, []string{nesSystem.ID, snesSystem.ID}, result.SystemID)
+		if result.SystemID == snesSystem.ID {
+			seenSNES = true
+			break
+		}
+	}
+	assert.True(t, seenSNES, "partial slug cache should not silently exclude uncached requested systems")
+}
+
+func TestMediaDB_CacheMediaStats_CanceledContextIsNonFatal_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	query := &database.MediaQuery{Systems: []string{"NES"}}
+	mediaDB.cacheMediaStats(ctx, query, MediaStats{Count: 1, MinDBID: 1, MaxDBID: 1})
+
+	_, found := mediaDB.GetCachedStats(context.Background(), query)
+	assert.False(t, found)
+}
+
+func TestMediaDB_CommitTransaction_IndexingPreservesLastGoodSlugCache_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -2531,6 +2792,15 @@ func TestMediaDB_CommitTransaction_SelectiveIndexingPreservesUnchangedSlugCache_
 	assert.True(t, cache.complete)
 	assert.True(t, cache.CanServeSystems([]string{nesSystem.ID, snesSystem.ID}))
 
+	statsQuery := &database.MediaQuery{Systems: []string{nesSystem.ID}}
+	require.NoError(t, mediaDB.SetCachedStats(context.Background(), statsQuery, MediaStats{
+		Count:   1,
+		MinDBID: 1,
+		MaxDBID: 1,
+	}))
+	_, found := mediaDB.GetCachedStats(context.Background(), statsQuery)
+	require.True(t, found)
+
 	require.NoError(t, mediaDB.SetIndexingSystems([]string{nesSystem.ID}))
 	require.NoError(t, mediaDB.SetIndexingStatus(IndexingStatusRunning))
 	defer func() {
@@ -2545,6 +2815,8 @@ func TestMediaDB_CommitTransaction_SelectiveIndexingPreservesUnchangedSlugCache_
 	assert.False(t, cache.complete)
 	assert.False(t, cache.CanServeSystems([]string{nesSystem.ID}))
 	assert.True(t, cache.CanServeSystems([]string{snesSystem.ID}))
+	_, found = mediaDB.GetCachedStats(context.Background(), statsQuery)
+	assert.False(t, found, "indexing commits should invalidate stale MediaCountCache while preserving slug cache")
 }
 
 func TestMediaDB_CommitTransaction_ReturnsBatchFlushError_Integration(t *testing.T) {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -618,14 +618,17 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create test media titles and media
+	superMarioPath := filepath.Join("roms", "nes", "Super Mario Bros.nes")
+	megaManPath := filepath.Join("roms", "nes", "Mega Man.nes")
+	zeldaPath := filepath.Join("roms", "nes", "Zelda.nes")
 	testGames := []struct {
 		name string
 		path string
 	}{
-		{"Super Mario Bros", "/roms/nes/Super Mario Bros.nes"},
-		{"Super Mario Bros 2", "/roms/nes/Super Mario Bros 2.nes"},
-		{"Mega Man", "/roms/nes/Mega Man.nes"},
-		{"Mega Man 2", "/roms/nes/Mega Man 2.nes"},
+		{"Super Mario Bros", superMarioPath},
+		{"Super Mario Bros 2", filepath.Join("roms", "nes", "Super Mario Bros 2.nes")},
+		{"Mega Man", megaManPath},
+		{"Mega Man 2", filepath.Join("roms", "nes", "Mega Man 2.nes")},
 	}
 
 	for _, game := range testGames {
@@ -651,7 +654,7 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 
 	// Test exact search - must match full path
 	results, err := mediaDB.SearchMediaPathExact(
-		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Super Mario Bros.nes",
+		context.Background(), []systemdefs.System{*nesSystem}, superMarioPath,
 	)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -659,7 +662,7 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 
 	// Test case-insensitive search - must match full path
 	results, err = mediaDB.SearchMediaPathExact(
-		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Mega Man.nes",
+		context.Background(), []systemdefs.System{*nesSystem}, megaManPath,
 	)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
@@ -667,7 +670,7 @@ func TestMediaDB_SearchMediaPathExact_Integration(t *testing.T) {
 
 	// Test no match
 	results, err = mediaDB.SearchMediaPathExact(
-		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/Zelda.nes",
+		context.Background(), []systemdefs.System{*nesSystem}, zeldaPath,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, results)
@@ -751,7 +754,9 @@ func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err = mediaDB.SearchMediaPathExact(ctx, []systemdefs.System{*nesSystem}, "/roms/nes/game.nes")
+	_, err = mediaDB.SearchMediaPathExact(
+		ctx, []systemdefs.System{*nesSystem}, filepath.Join("roms", "nes", "game.nes"),
+	)
 	require.Error(t, err)
 
 	_, err = mediaDB.RandomGame(ctx, []systemdefs.System{*nesSystem})
@@ -856,9 +861,10 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	insertedNES, err := mediaDB.InsertSystem(nesSystemDB)
 	require.NoError(t, err)
 
+	nesPath := filepath.Join("roms", "nes", "game.nes")
 	nesTitle := database.MediaTitle{
 		SystemDBID: insertedNES.DBID,
-		Slug:       slugs.Slugify(slugs.MediaTypeGame, helpers.FilenameFromPath("/roms/nes/game.nes")),
+		Slug:       slugs.Slugify(slugs.MediaTypeGame, helpers.FilenameFromPath(nesPath)),
 		Name:       "NES Game",
 	}
 	insertedNESTitle, err := mediaDB.InsertMediaTitle(&nesTitle)
@@ -867,7 +873,7 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	nesMedia := database.Media{
 		SystemDBID:     insertedNES.DBID,
 		MediaTitleDBID: insertedNESTitle.DBID,
-		Path:           "/roms/nes/game.nes",
+		Path:           nesPath,
 	}
 	_, err = mediaDB.InsertMedia(nesMedia)
 	require.NoError(t, err)
@@ -880,9 +886,10 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	insertedSNES, err := mediaDB.InsertSystem(snesSystemDB)
 	require.NoError(t, err)
 
+	snesPath := filepath.Join("roms", "snes", "game.sfc")
 	snesTitle := database.MediaTitle{
 		SystemDBID: insertedSNES.DBID,
-		Slug:       slugs.Slugify(slugs.MediaTypeGame, helpers.FilenameFromPath("/roms/snes/game.sfc")),
+		Slug:       slugs.Slugify(slugs.MediaTypeGame, helpers.FilenameFromPath(snesPath)),
 		Name:       "SNES Game",
 	}
 	insertedSNESTitle, err := mediaDB.InsertMediaTitle(&snesTitle)
@@ -891,7 +898,7 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	snesMedia := database.Media{
 		SystemDBID:     insertedSNES.DBID,
 		MediaTitleDBID: insertedSNESTitle.DBID,
-		Path:           "/roms/snes/game.sfc",
+		Path:           snesPath,
 	}
 	_, err = mediaDB.InsertMedia(snesMedia)
 	require.NoError(t, err)
@@ -919,14 +926,14 @@ func TestMediaDB_TruncateSystems_Integration(t *testing.T) {
 	t.Logf("Indexed systems after truncate: %v", systems)
 
 	results, err := mediaDB.SearchMediaPathExact(
-		context.Background(), []systemdefs.System{*snesSystem}, "/roms/snes/game.sfc",
+		context.Background(), []systemdefs.System{*snesSystem}, snesPath,
 	)
 	require.NoError(t, err)
 	t.Logf("Search results: %+v", results)
 	assert.Len(t, results, 1)
 
 	results, err = mediaDB.SearchMediaPathExact(
-		context.Background(), []systemdefs.System{*nesSystem}, "/roms/nes/game.nes",
+		context.Background(), []systemdefs.System{*nesSystem}, nesPath,
 	)
 	require.NoError(t, err)
 	assert.Empty(t, results)

--- a/pkg/database/mediadb/slug_cache.go
+++ b/pkg/database/mediadb/slug_cache.go
@@ -92,7 +92,7 @@ func (db *MediaDB) GetCachedSlugResolution(
 		return 0, "", false
 	}
 
-	err = db.conn().QueryRowContext(ctx,
+	err = db.sql.QueryRowContext(ctx,
 		"SELECT MediaDBID, Strategy FROM SlugResolutionCache WHERE CacheKey = ?",
 		cacheKey).Scan(&mediaDBID, &strategy)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -131,7 +131,7 @@ func (db *MediaDB) SetCachedSlugResolution(
 		return fmt.Errorf("failed to marshal tag filters: %w", err)
 	}
 
-	_, err = db.conn().ExecContext(ctx, `
+	_, err = db.sql.ExecContext(ctx, `
 		INSERT OR REPLACE INTO SlugResolutionCache
 		(CacheKey, SystemID, Slug, TagFilters, MediaDBID, Strategy, LastUpdated)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -206,8 +206,9 @@ func (db *MediaDB) GetMediaByDBID(ctx context.Context, mediaDBID int64) (databas
 
 	result := database.SearchResultWithCursor{}
 
-	// Query for media information
-	err := db.conn().QueryRowContext(ctx, `
+	// Query for media information from committed state. Foreground title
+	// resolution must not read an active indexing transaction.
+	err := db.sql.QueryRowContext(ctx, `
 		SELECT
 			Systems.SystemID,
 			MediaTitles.Name,
@@ -228,7 +229,7 @@ func (db *MediaDB) GetMediaByDBID(ctx context.Context, mediaDBID int64) (databas
 	}
 
 	// Fetch tags from both MediaTags (file-level) and MediaTitleTags (title-level)
-	rows, err := db.conn().QueryContext(ctx, `
+	rows, err := db.sql.QueryContext(ctx, `
 		SELECT Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTags
 		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
@@ -293,7 +294,7 @@ func (db *MediaDB) GetZapScriptTagsBySystemAndPath(
 		}
 	}
 
-	rows, err := db.conn().QueryContext(ctx, fmt.Sprintf(`
+	rows, err := db.sql.QueryContext(ctx, fmt.Sprintf(`
 		WITH Target AS (
 			SELECT Media.DBID, Media.MediaTitleDBID
 			FROM Media

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -70,6 +70,10 @@ type PathResult struct {
 	System systemdefs.System
 }
 
+type slugSearchCacheDropper interface {
+	DropSlugSearchCacheForSystems(systemIDs []string)
+}
+
 // FindPath case-insensitively finds a file/folder at a path and returns the actual filesystem case.
 // On case-insensitive filesystems (Windows, macOS), this ensures we get the real case from the filesystem
 // rather than preserving the input case, which prevents case-mismatch issues during string comparisons.
@@ -858,6 +862,10 @@ func NewNamesIndex(
 		if completedSystems[systemID] {
 			log.Debug().Msgf("skipping already indexed system: %s", systemID)
 			continue
+		}
+
+		if dropper, ok := db.(slugSearchCacheDropper); ok {
+			dropper.DropSlugSearchCacheForSystems([]string{systemID})
 		}
 
 		scanState.MissingMedia = make(map[int]struct{})

--- a/pkg/platforms/launch.go
+++ b/pkg/platforms/launch.go
@@ -20,10 +20,12 @@
 package platforms
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -34,8 +36,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const activeMediaLookupTimeout = 2 * time.Second
+
 // LaunchParams contains all dependencies required for launching media.
 type LaunchParams struct {
+	// Context scopes best-effort post-launch metadata lookups.
+	Context        context.Context
 	Platform       Platform
 	Config         *config.Instance
 	SetActiveMedia func(*models.ActiveMedia)
@@ -93,6 +99,13 @@ func nativeLaunchPath(path string) string {
 		return path
 	}
 	return filepath.FromSlash(path)
+}
+
+func activeMediaLookupContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, activeMediaLookupTimeout)
 }
 
 // DoLaunch launches the given path and updates the active media with it if
@@ -181,7 +194,9 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 	displayName := tags.ParseTitleFromFilename(getDisplayName(params.Path), false)
 
 	if params.DB != nil && params.DB.MediaDB != nil {
-		results, searchErr := params.DB.MediaDB.SearchMediaPathExact(nil, params.Path)
+		ctx, cancel := activeMediaLookupContext(params.Context)
+		results, searchErr := params.DB.MediaDB.SearchMediaPathExact(ctx, nil, params.Path)
+		cancel()
 		if searchErr == nil && len(results) > 0 {
 			if systemID == "" && results[0].SystemID != "" {
 				systemID = results[0].SystemID

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -475,6 +476,52 @@ func TestDoLaunch_NoSystemIDSkipsActiveMedia(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Nil(t, activeMedia, "ActiveMedia should NOT be set when no SystemID")
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestDoLaunch_ActiveMediaLookupUsesProvidedContext(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("StopActiveLauncher", platforms.StopForPreemption).Return(nil).Once()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaPathExact",
+		mock.MatchedBy(func(ctx context.Context) bool {
+			return ctx.Err() != nil
+		}),
+		mock.Anything,
+		"/test/path.rom",
+	).Return([]database.SearchResult{}, context.Canceled).Once()
+
+	launcher := &platforms.Launcher{
+		ID:        "test-launcher",
+		SystemID:  "test-system",
+		Lifecycle: platforms.LifecycleFireAndForget,
+		Launch: func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+			return nil, nil
+		},
+	}
+
+	var activeMedia *models.ActiveMedia
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	params := &platforms.LaunchParams{
+		Context:        ctx,
+		Platform:       mockPlatform,
+		Config:         &config.Instance{},
+		SetActiveMedia: func(media *models.ActiveMedia) { activeMedia = media },
+		Launcher:       launcher,
+		DB:             &database.Database{MediaDB: mockMediaDB},
+		Path:           "/test/path.rom",
+	}
+
+	err := platforms.DoLaunch(params, func(_ string) string { return "path" })
+
+	require.NoError(t, err)
+	require.NotNil(t, activeMedia)
+	assert.Equal(t, "path", activeMedia.Name)
+	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }
 

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -499,7 +499,7 @@ func TestDoLaunch_ActiveMediaLookupUsesProvidedContext(t *testing.T) {
 		SystemID:  "test-system",
 		Lifecycle: platforms.LifecycleFireAndForget,
 		Launch: func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-			return nil, nil
+			return &os.Process{}, nil
 		},
 	}
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -269,6 +269,7 @@ func (p *Platform) StartPost(
 	p.setActiveMedia = setActiveMedia
 
 	tr, stopTr, err := tracker.StartTracker(
+		ctx,
 		cfg,
 		p,
 		activeMedia,

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -60,6 +60,7 @@ type arcadeCardLaunchCache struct {
 
 type Platform struct {
 	shared.LinuxInput
+	ctx                 context.Context
 	dbLoadTime          time.Time
 	lastUIHidden        time.Time
 	launcherManager     platforms.LauncherContextManager
@@ -264,6 +265,7 @@ func (p *Platform) StartPost(
 	db *database.Database,
 	scheduler *idle.Scheduler,
 ) error {
+	p.ctx = ctx
 	p.launcherManager = launcherManager
 	p.activeMedia = activeMedia
 	p.setActiveMedia = setActiveMedia
@@ -654,6 +656,7 @@ func (p *Platform) LaunchMedia(
 		Int("available_launchers", len(launchers)).
 		Msg("launching media")
 	err := platforms.DoLaunch(&platforms.LaunchParams{
+		Context:        p.ctx,
 		Config:         cfg,
 		Platform:       p,
 		SetActiveMedia: p.setActiveMedia,

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -30,7 +30,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const ArcadeSystem = "Arcade"
+const (
+	ArcadeSystem       = "Arcade"
+	mediaLookupTimeout = 2 * time.Second
+)
 
 // platformWithArcadeCache is an optional interface for platforms that support arcade card launch caching.
 type platformWithArcadeCache interface {
@@ -49,6 +52,7 @@ type Tracker struct {
 	pl               platforms.Platform
 	setActiveMedia   func(*models.ActiveMedia)
 	cfg              *config.Instance
+	serviceCtx       context.Context
 	activeMedia      func() *models.ActiveMedia
 	db               *database.Database
 	ActiveSystemName string
@@ -101,6 +105,7 @@ func generateNameMap(pl platforms.Platform) []NameMapping {
 }
 
 func NewTracker(
+	ctx context.Context,
 	pl platforms.Platform,
 	cfg *config.Instance,
 	activeMedia func() *models.ActiveMedia,
@@ -116,6 +121,7 @@ func NewTracker(
 	return &Tracker{
 		pl:               pl,
 		cfg:              cfg,
+		serviceCtx:       ctx,
 		db:               db,
 		ActiveCore:       "",
 		ActiveSystem:     "",
@@ -127,6 +133,14 @@ func NewTracker(
 		activeMedia:      activeMedia,
 		setActiveMedia:   setActiveMedia,
 	}, nil
+}
+
+func (tr *Tracker) mediaLookupContext() (context.Context, context.CancelFunc) {
+	parent := tr.serviceCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, mediaLookupTimeout)
 }
 
 func (tr *Tracker) ReloadNameMap() {
@@ -336,7 +350,9 @@ func (tr *Tracker) loadGame() {
 	name := tags.ParseTitleFromFilename(pathInfo.Name, false)
 	if tr.db != nil && tr.db.MediaDB != nil {
 		systems := []systemdefs.System{{ID: system.ID}}
-		results, searchErr := tr.db.MediaDB.SearchMediaPathExact(systems, path)
+		ctx, cancel := tr.mediaLookupContext()
+		results, searchErr := tr.db.MediaDB.SearchMediaPathExact(ctx, systems, path)
+		cancel()
 		if searchErr == nil && len(results) > 0 && results[0].Name != "" {
 			name = results[0].Name
 			log.Debug().Str("path", path).Msg("tracker using indexed display name")
@@ -578,13 +594,14 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 }
 
 func StartTracker(
+	ctx context.Context,
 	cfg *config.Instance,
 	pl platforms.Platform,
 	activeMedia func() *models.ActiveMedia,
 	setActiveMedia func(*models.ActiveMedia),
 	db *database.Database,
 ) (*Tracker, func() error, error) {
-	tr, err := NewTracker(pl, cfg, activeMedia, setActiveMedia, db)
+	tr, err := NewTracker(ctx, pl, cfg, activeMedia, setActiveMedia, db)
 	if err != nil {
 		log.Error().Msgf("error creating tracker: %s", err)
 		return nil, nil, err

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package tracker
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMediaLookupContextUsesServiceContext(t *testing.T) {
+	t.Parallel()
+
+	serviceCtx, cancelService := context.WithCancel(context.Background())
+	tr := &Tracker{serviceCtx: serviceCtx}
+
+	ctx, cancelLookup := tr.mediaLookupContext()
+	defer cancelLookup()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("MediaDB lookup context should not be canceled before service context")
+	default:
+	}
+
+	cancelService()
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("MediaDB lookup context should follow service context")
+	}
+}

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -111,7 +111,7 @@ func (p *Platform) StartPre(cfg *config.Instance) error {
 }
 
 func (p *Platform) StartPost(
-	_ context.Context,
+	ctx context.Context,
 	cfg *config.Instance,
 	_ platforms.LauncherContextManager,
 	activeMedia func() *models.ActiveMedia,
@@ -123,6 +123,7 @@ func (p *Platform) StartPost(
 	p.setActiveMedia = setActiveMedia
 
 	tr, stopTr, err := tracker.StartTracker(
+		ctx,
 		cfg,
 		p,
 		activeMedia,

--- a/pkg/platforms/shared/linuxbase/base.go
+++ b/pkg/platforms/shared/linuxbase/base.go
@@ -56,6 +56,7 @@ const (
 // Platforms embed this struct and override methods as needed.
 type Base struct {
 	launcherManager platforms.LauncherContextManager
+	serviceCtx      context.Context
 	clock           clockwork.Clock
 	activeMedia     func() *models.ActiveMedia
 	setActiveMedia  func(*models.ActiveMedia)
@@ -89,7 +90,7 @@ func (*Base) StartPre(_ *config.Instance) error {
 
 // StartPost initializes the platform after service startup.
 func (b *Base) StartPost(
-	_ context.Context,
+	ctx context.Context,
 	_ *config.Instance,
 	launcherManager platforms.LauncherContextManager,
 	activeMedia func() *models.ActiveMedia,
@@ -98,6 +99,7 @@ func (b *Base) StartPost(
 	_ *idle.Scheduler,
 ) error {
 	b.launcherManager = launcherManager
+	b.serviceCtx = ctx
 	b.activeMedia = activeMedia
 	b.setActiveMedia = setActiveMedia
 	return nil
@@ -283,6 +285,7 @@ func (b *Base) LaunchMedia(
 
 	log.Info().Msgf("launch media: using launcher %s for: %s", launcher.ID, path)
 	err = platforms.DoLaunch(&platforms.LaunchParams{
+		Context:        b.serviceCtx,
 		Config:         cfg,
 		Platform:       p,
 		SetActiveMedia: b.setActiveMedia,

--- a/pkg/testing/examples/database_example_test.go
+++ b/pkg/testing/examples/database_example_test.go
@@ -20,6 +20,7 @@
 package examples
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -78,7 +79,7 @@ func TestDatabaseMockUsage(t *testing.T) {
 
 		// Set up expectations
 		mockMediaDB.On("IndexedSystems").Return([]string{"atari2600", "gb", "snes"}, nil)
-		mockMediaDB.On("SearchMediaPathExact", testSystemDefs, "Tetris").
+		mockMediaDB.On("SearchMediaPathExact", context.Background(), testSystemDefs, "Tetris").
 			Return([]database.SearchResult{expectedResults[1]}, nil)
 		mockMediaDB.On("FindSystem", fixtures.Systems.Atari2600).Return(fixtures.Systems.Atari2600, nil)
 
@@ -88,7 +89,7 @@ func TestDatabaseMockUsage(t *testing.T) {
 		assert.Len(t, systems, 3)
 		assert.Contains(t, systems, "atari2600")
 
-		results, err := mockMediaDB.SearchMediaPathExact(testSystemDefs, "Tetris")
+		results, err := mockMediaDB.SearchMediaPathExact(context.Background(), testSystemDefs, "Tetris")
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 		assert.Equal(t, "Tetris", results[0].Name)
@@ -328,7 +329,7 @@ func TestIntegrationExample(t *testing.T) {
 		mockUserDB.On("GetMapping", testMapping.DBID).Return(testMapping, nil)
 		mockUserDB.On("AddHistory", &testHistory).Return(nil)
 
-		mockMediaDB.On("SearchMediaPathExact", fixtures.GetTestSystemDefs(), "Pitfall").
+		mockMediaDB.On("SearchMediaPathExact", context.Background(), fixtures.GetTestSystemDefs(), "Pitfall").
 			Return(testResults, nil)
 		testSystems := fixtures.GetTestSystemDefs()
 		mockMediaDB.On("SystemIndexed", &testSystems[0]).Return(true)
@@ -344,7 +345,7 @@ func TestIntegrationExample(t *testing.T) {
 		assert.Equal(t, "zelda:*", mapping.Pattern)
 
 		// 2. Search for media in MediaDB
-		results, err := mockMediaDB.SearchMediaPathExact(testSystems, "Pitfall")
+		results, err := mockMediaDB.SearchMediaPathExact(context.Background(), testSystems, "Pitfall")
 		require.NoError(t, err)
 		assert.Len(t, results, 1)
 		assert.Equal(t, "Pitfall!", results[0].Name)

--- a/pkg/testing/examples/service_state_management_test.go
+++ b/pkg/testing/examples/service_state_management_test.go
@@ -20,6 +20,7 @@
 package examples
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
@@ -413,7 +414,7 @@ func TestStateIntegrationWithServices(t *testing.T) {
 
 		// Setup database expectations
 		userDB.On("AddHistory", helpers.HistoryEntryMatcher()).Return(nil)
-		mediaDB.On("SearchMediaPathExact", fixtures.GetTestSystemDefs(),
+		mediaDB.On("SearchMediaPathExact", mock.Anything, fixtures.GetTestSystemDefs(),
 			helpers.TextMatcher()).Return(fixtures.SearchResults.Collection, nil)
 		platform.On("LaunchMedia",
 			mock.AnythingOfType("*config.Instance"),
@@ -442,7 +443,7 @@ func TestStateIntegrationWithServices(t *testing.T) {
 		assert.Equal(t, token.UID, lastToken.UID)
 
 		// 4. Simulate successful media launch
-		searchResults, err := mediaDB.SearchMediaPathExact(fixtures.GetTestSystemDefs(), token.Text)
+		searchResults, err := mediaDB.SearchMediaPathExact(context.Background(), fixtures.GetTestSystemDefs(), token.Text)
 		require.NoError(t, err)
 		require.NotEmpty(t, searchResults)
 

--- a/pkg/testing/examples/service_state_management_test.go
+++ b/pkg/testing/examples/service_state_management_test.go
@@ -443,7 +443,9 @@ func TestStateIntegrationWithServices(t *testing.T) {
 		assert.Equal(t, token.UID, lastToken.UID)
 
 		// 4. Simulate successful media launch
-		searchResults, err := mediaDB.SearchMediaPathExact(context.Background(), fixtures.GetTestSystemDefs(), token.Text)
+		searchResults, err := mediaDB.SearchMediaPathExact(
+			context.Background(), fixtures.GetTestSystemDefs(), token.Text,
+		)
 		require.NoError(t, err)
 		require.NotEmpty(t, searchResults)
 

--- a/pkg/testing/examples/service_zapscript_test.go
+++ b/pkg/testing/examples/service_zapscript_test.go
@@ -155,8 +155,10 @@ func TestZapScriptExecution(t *testing.T) {
 				switch tt.commands[0] {
 				case "LAUNCH":
 					// Mock media database search
-					mockMediaDB.On("SearchMediaPathExact", context.Background(), []systemdefs.System(nil), tt.commands[1]).
-						Return([]database.SearchResult{fixtures.SearchResults.Collection[0]}, nil)
+					mockMediaDB.On(
+						"SearchMediaPathExact",
+						context.Background(), []systemdefs.System(nil), tt.commands[1],
+					).Return([]database.SearchResult{fixtures.SearchResults.Collection[0]}, nil)
 					platform.On("LaunchMedia",
 						cfg,
 						fixtures.SearchResults.Collection[0].Path,
@@ -178,7 +180,9 @@ func TestZapScriptExecution(t *testing.T) {
 				switch tt.commands[0] {
 				case "LAUNCH":
 					// Simulate the workflow: search for media, then launch it
-					results, err := mockMediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System(nil), tt.commands[1])
+					results, err := mockMediaDB.SearchMediaPathExact(
+						context.Background(), []systemdefs.System(nil), tt.commands[1],
+					)
 					require.NoError(t, err)
 					require.Len(t, results, 1, "Should find media")
 

--- a/pkg/testing/examples/service_zapscript_test.go
+++ b/pkg/testing/examples/service_zapscript_test.go
@@ -20,6 +20,7 @@
 package examples
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -154,7 +155,7 @@ func TestZapScriptExecution(t *testing.T) {
 				switch tt.commands[0] {
 				case "LAUNCH":
 					// Mock media database search
-					mockMediaDB.On("SearchMediaPathExact", []systemdefs.System(nil), tt.commands[1]).
+					mockMediaDB.On("SearchMediaPathExact", context.Background(), []systemdefs.System(nil), tt.commands[1]).
 						Return([]database.SearchResult{fixtures.SearchResults.Collection[0]}, nil)
 					platform.On("LaunchMedia",
 						cfg,
@@ -177,7 +178,7 @@ func TestZapScriptExecution(t *testing.T) {
 				switch tt.commands[0] {
 				case "LAUNCH":
 					// Simulate the workflow: search for media, then launch it
-					results, err := mockMediaDB.SearchMediaPathExact([]systemdefs.System(nil), tt.commands[1])
+					results, err := mockMediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System(nil), tt.commands[1])
 					require.NoError(t, err)
 					require.Len(t, results, 1, "Should find media")
 
@@ -290,7 +291,7 @@ func TestZapScriptComplexWorkflow(t *testing.T) {
 
 	// Set expectations for complex workflow
 	mockUserDB.On("AddHistory", helpers.HistoryEntryMatcher()).Return(nil)
-	mockMediaDB.On("SearchMediaPathExact", []systemdefs.System(nil), "Complex Game").
+	mockMediaDB.On("SearchMediaPathExact", context.Background(), []systemdefs.System(nil), "Complex Game").
 		Return([]database.SearchResult{fixtures.SearchResults.Collection[0]}, nil)
 	platform.On("LaunchMedia",
 		cfg,
@@ -304,7 +305,7 @@ func TestZapScriptComplexWorkflow(t *testing.T) {
 	// This demonstrates the TDD infrastructure capabilities
 
 	// Step 1: Search and launch media
-	results, err := mockMediaDB.SearchMediaPathExact([]systemdefs.System(nil), "Complex Game")
+	results, err := mockMediaDB.SearchMediaPathExact(context.Background(), []systemdefs.System(nil), "Complex Game")
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Should find media")
 

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -644,9 +644,9 @@ func (m *MockMediaDBI) GetLastGenerated() (time.Time, error) {
 
 // Search methods
 func (m *MockMediaDBI) SearchMediaPathExact(
-	systems []systemdefs.System, query string,
+	ctx context.Context, systems []systemdefs.System, query string,
 ) ([]database.SearchResult, error) {
-	args := m.Called(systems, query)
+	args := m.Called(ctx, systems, query)
 	if results, ok := args.Get(0).([]database.SearchResult); ok {
 		if err := args.Error(1); err != nil {
 			return results, fmt.Errorf("mock operation failed: %w", err)
@@ -861,8 +861,8 @@ func (m *MockMediaDBI) SystemIndexed(system *systemdefs.System) bool {
 	return args.Bool(0)
 }
 
-func (m *MockMediaDBI) RandomGame(systems []systemdefs.System) (database.SearchResult, error) {
-	args := m.Called(systems)
+func (m *MockMediaDBI) RandomGame(ctx context.Context, systems []systemdefs.System) (database.SearchResult, error) {
+	args := m.Called(ctx, systems)
 	if result, ok := args.Get(0).(database.SearchResult); ok {
 		if err := args.Error(1); err != nil {
 			return result, fmt.Errorf("mock operation failed: %w", err)
@@ -1915,8 +1915,8 @@ func (m *MockMediaDBI) GetZapScriptTagsBySystemAndPath(
 	return nil, nil
 }
 
-func (m *MockMediaDBI) RandomGameWithQuery(query *database.MediaQuery) (database.SearchResult, error) {
-	args := m.Called(query)
+func (m *MockMediaDBI) RandomGameWithQuery(ctx context.Context, query *database.MediaQuery) (database.SearchResult, error) {
+	args := m.Called(ctx, query)
 	if result, ok := args.Get(0).(database.SearchResult); ok {
 		if err := args.Error(1); err != nil {
 			return result, fmt.Errorf("mock operation failed: %w", err)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1915,7 +1915,9 @@ func (m *MockMediaDBI) GetZapScriptTagsBySystemAndPath(
 	return nil, nil
 }
 
-func (m *MockMediaDBI) RandomGameWithQuery(ctx context.Context, query *database.MediaQuery) (database.SearchResult, error) {
+func (m *MockMediaDBI) RandomGameWithQuery(
+	ctx context.Context, query *database.MediaQuery,
+) (database.SearchResult, error) {
 	args := m.Called(ctx, query)
 	if result, ok := args.Get(0).(database.SearchResult); ok {
 		if err := args.Error(1); err != nil {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -205,7 +205,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	tagFilters := args.Tags
 
 	gamesdb := env.Database.MediaDB
-	ctx, cancel := mediaDBLookupContext(env)
+	ctx, cancel := mediaDBLookupContext(&env)
 	defer cancel()
 
 	if strings.EqualFold(query, "all") {
@@ -610,7 +610,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		}
 		log.Info().Msgf("searching in %s: %s", system.ID, lookupPath)
 		// treat as a direct title launch
-		ctx, cancel := mediaDBLookupContext(env)
+		ctx, cancel := mediaDBLookupContext(&env)
 		defer cancel()
 		res, err := gamesdb.SearchMediaPathExact(
 			ctx,
@@ -669,7 +669,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			Tags:    tagFilters,
 			Limit:   1,
 		}
-		ctx, cancel := mediaDBLookupContext(env)
+		ctx, cancel := mediaDBLookupContext(&env)
 		defer cancel()
 		res, searchErr := gamesdb.SearchMediaWithFilters(ctx, &searchFilters)
 		if searchErr != nil {
@@ -716,7 +716,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		Tags:    tagFilters,
 		Limit:   1,
 	}
-	ctx, cancel := mediaDBLookupContext(env)
+	ctx, cancel := mediaDBLookupContext(&env)
 	defer cancel()
 	res, searchErr := gamesdb.SearchMediaWithFilters(ctx, &searchFilters)
 	if searchErr != nil {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -20,7 +20,6 @@
 package zapscript
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -206,6 +205,8 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	tagFilters := args.Tags
 
 	gamesdb := env.Database.MediaDB
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
 
 	if strings.EqualFold(query, "all") {
 		allSystems := systemdefs.AllSystems()
@@ -217,7 +218,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			Systems: systemIDs,
 			Tags:    tagFilters,
 		}
-		game, gameErr := gamesdb.RandomGameWithQuery(&mediaQuery)
+		game, gameErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
 		if gameErr != nil {
 			return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", gameErr)
 		}
@@ -241,7 +242,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			PathPrefix: cleanedPath,
 			Tags:       tagFilters,
 		}
-		searchResult, searchErr := gamesdb.RandomGameWithQuery(&mediaQuery)
+		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
 		if errors.Is(searchErr, sql.ErrNoRows) {
 			// Fallback: pick random file directly from disk for unindexed paths
 			entries, readErr := os.ReadDir(cleanedPath)
@@ -315,7 +316,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				Systems: systemIDs,
 				Tags:    tagFilters,
 			}
-			game, randomErr := gamesdb.RandomGameWithQuery(&mediaQuery)
+			game, randomErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
 			if randomErr != nil {
 				return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", randomErr)
 			}
@@ -340,7 +341,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			PathGlob: searchQuery,
 			Tags:     tagFilters,
 		}
-		game, randomErr := gamesdb.RandomGameWithQuery(&mediaQuery)
+		game, randomErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
 		if randomErr != nil {
 			return platforms.CmdResult{},
 				fmt.Errorf("failed to get random game matching '%s': %w", searchQuery, randomErr)
@@ -380,7 +381,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		Systems: systemIDs,
 		Tags:    tagFilters,
 	}
-	game, err := gamesdb.RandomGameWithQuery(&mediaQuery)
+	game, err := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
 	if err != nil {
 		return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", err)
 	}
@@ -609,7 +610,10 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		}
 		log.Info().Msgf("searching in %s: %s", system.ID, lookupPath)
 		// treat as a direct title launch
+		ctx, cancel := mediaDBLookupContext(env)
+		defer cancel()
 		res, err := gamesdb.SearchMediaPathExact(
+			ctx,
 			[]systemdefs.System{*system},
 			lookupPath,
 		)
@@ -665,8 +669,9 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			Tags:    tagFilters,
 			Limit:   1,
 		}
-		// TODO: context should come from service state
-		res, searchErr := gamesdb.SearchMediaWithFilters(context.Background(), &searchFilters)
+		ctx, cancel := mediaDBLookupContext(env)
+		defer cancel()
+		res, searchErr := gamesdb.SearchMediaWithFilters(ctx, &searchFilters)
 		if searchErr != nil {
 			return platforms.CmdResult{}, fmt.Errorf("failed to search all systems for '%s': %w", query, searchErr)
 		}
@@ -711,8 +716,9 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		Tags:    tagFilters,
 		Limit:   1,
 	}
-	// TODO: context should come from service state
-	res, searchErr := gamesdb.SearchMediaWithFilters(context.Background(), &searchFilters)
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
+	res, searchErr := gamesdb.SearchMediaWithFilters(ctx, &searchFilters)
 	if searchErr != nil {
 		return platforms.CmdResult{}, fmt.Errorf("failed to search systems for '%s': %w", searchQuery, searchErr)
 	}

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -20,12 +20,14 @@
 package zapscript
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -651,7 +653,7 @@ func TestCmdLaunch_FileNotFound(t *testing.T) {
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	// Return empty results for the media search
-	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything).
+	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, mock.Anything).
 		Return([]database.SearchResult{}, nil)
 
 	env := platforms.CmdEnv{
@@ -669,6 +671,119 @@ func TestCmdLaunch_FileNotFound(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrFileNotFound, "should return ErrFileNotFound for missing file")
 	mockPlatform.AssertExpectations(t)
+}
+
+func TestMediaDBLookupContext_UsesTimeoutWithoutServiceContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := mediaDBLookupContext(platforms.CmdEnv{})
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, time.Now().Add(mediaDBLookupTimeout), deadline, 200*time.Millisecond)
+}
+
+func TestMediaDBLookupContext_IgnoresCanceledLauncherContext(t *testing.T) {
+	t.Parallel()
+
+	launcherCtx, launcherCancel := context.WithCancel(context.Background())
+	launcherCancel()
+	serviceCtx, serviceCancel := context.WithCancel(context.Background())
+	defer serviceCancel()
+
+	ctx, cancel := mediaDBLookupContext(platforms.CmdEnv{
+		LauncherCtx: launcherCtx,
+		ServiceCtx:  serviceCtx,
+	})
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("MediaDB lookup context should not use canceled launcher context")
+	default:
+	}
+
+	serviceCancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("MediaDB lookup context should follow service context")
+	}
+}
+
+func TestCmdLaunch_ExactFallbackMediaDBLookupUsesServiceContext(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{
+		{ID: "snes-launcher", SystemID: "snes", Folders: []string{}},
+	})
+	mockPlatform.On("RootDirs", cfg).Return([]string{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, "Sonic\\Game").
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			<-ctx.Done()
+		}).
+		Return([]database.SearchResult{}, context.DeadlineExceeded)
+
+	serviceCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{"snes/Sonic\\Game"},
+		},
+		Cfg:        cfg,
+		ServiceCtx: serviceCtx,
+		Database:   &database.Database{MediaDB: mockMediaDB},
+	}
+
+	started := time.Now()
+	_, err := cmdLaunch(mockPlatform, env)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestCmdSearch_MediaDBLookupUsesServiceContext(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			<-ctx.Done()
+		}).
+		Return([]database.SearchResultWithCursor{}, context.DeadlineExceeded)
+
+	serviceCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.search",
+			Args: []string{"sonic"},
+		},
+		Cfg:        cfg,
+		ServiceCtx: serviceCtx,
+		Database:   &database.Database{MediaDB: mockMediaDB},
+	}
+
+	started := time.Now()
+	_, err := cmdSearch(mockPlatform, env)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestCmdSearch_AppliesDefaultFromResultSystem(t *testing.T) {
@@ -720,6 +835,41 @@ launcher = "genesis-alt"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			<-ctx.Done()
+		}).
+		Return(database.SearchResult{}, context.DeadlineExceeded)
+
+	serviceCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{"all"},
+		},
+		Cfg:        cfg,
+		ServiceCtx: serviceCtx,
+		Database:   &database.Database{MediaDB: mockMediaDB},
+	}
+
+	started := time.Now()
+	_, err := cmdRandom(mockPlatform, env)
+
+	require.Error(t, err)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestCmdRandom_AppliesDefaultFromResultSystem(t *testing.T) {
 	t.Parallel()
 
@@ -736,7 +886,7 @@ launcher = "genesis-alt"
 
 	romPath := filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("RandomGameWithQuery", mock.Anything).
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
 		Return(database.SearchResult{SystemID: "genesis", Path: romPath}, nil)
 
 	mockPlatform.On("LaunchMedia", cfg, romPath,
@@ -786,6 +936,7 @@ launcher = "RA"
 	romPath := filepath.Join(queryPath, "Sonic.bin")
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("RandomGameWithQuery",
+		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
 			return q.PathPrefix == filepath.ToSlash(queryPath)
 		}),
@@ -845,6 +996,7 @@ launcher = "RA"
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("RandomGameWithQuery",
+		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
 			return q.PathPrefix == filepath.ToSlash(dir)
 		}),
@@ -887,6 +1039,7 @@ func TestCmdRandom_DoubleSlashPathCleaned(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	// Expect the cleaned path (single slash) in the PathPrefix
 	mockMediaDB.On("RandomGameWithQuery",
+		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
 			return q.PathPrefix == "/media/fat/_#Insert-Coin/_#Essentials"
 		}),
@@ -938,6 +1091,7 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	// Database has no entries for this path
 	mockMediaDB.On("RandomGameWithQuery",
+		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
 			return q.PathPrefix == dir
 		}),
@@ -982,7 +1136,7 @@ func TestCmdRandom_AbsolutePathFallback_NonExistentPath(t *testing.T) {
 	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("RandomGameWithQuery", mock.Anything).
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
 		Return(database.SearchResult{}, sql.ErrNoRows)
 
 	env := platforms.CmdEnv{
@@ -1012,7 +1166,7 @@ func TestCmdRandom_AbsolutePathFallback_OnlySubdirectories(t *testing.T) {
 	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("RandomGameWithQuery", mock.Anything).
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
 		Return(database.SearchResult{}, sql.ErrNoRows)
 
 	env := platforms.CmdEnv{
@@ -1041,7 +1195,7 @@ func TestCmdRandom_AbsolutePathDBError_NoFallback(t *testing.T) {
 	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("RandomGameWithQuery", mock.Anything).
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
 		Return(database.SearchResult{}, errors.New("connection lost"))
 
 	env := platforms.CmdEnv{

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -676,7 +676,7 @@ func TestCmdLaunch_FileNotFound(t *testing.T) {
 func TestMediaDBLookupContext_UsesTimeoutWithoutServiceContext(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := mediaDBLookupContext(platforms.CmdEnv{})
+	ctx, cancel := mediaDBLookupContext(&platforms.CmdEnv{})
 	defer cancel()
 
 	deadline, ok := ctx.Deadline()
@@ -692,10 +692,11 @@ func TestMediaDBLookupContext_IgnoresCanceledLauncherContext(t *testing.T) {
 	serviceCtx, serviceCancel := context.WithCancel(context.Background())
 	defer serviceCancel()
 
-	ctx, cancel := mediaDBLookupContext(platforms.CmdEnv{
+	env := platforms.CmdEnv{
 		LauncherCtx: launcherCtx,
 		ServiceCtx:  serviceCtx,
-	})
+	}
+	ctx, cancel := mediaDBLookupContext(&env)
 	defer cancel()
 
 	select {
@@ -725,7 +726,8 @@ func TestCmdLaunch_ExactFallbackMediaDBLookupUsesServiceContext(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, "Sonic\\Game").
 		Run(func(args mock.Arguments) {
-			ctx := args.Get(0).(context.Context)
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
 			<-ctx.Done()
 		}).
 		Return([]database.SearchResult{}, context.DeadlineExceeded)
@@ -747,7 +749,9 @@ func TestCmdLaunch_ExactFallbackMediaDBLookupUsesServiceContext(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
-	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockPlatform.AssertNotCalled(
+		t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -760,7 +764,8 @@ func TestCmdSearch_MediaDBLookupUsesServiceContext(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			ctx := args.Get(0).(context.Context)
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
 			<-ctx.Done()
 		}).
 		Return([]database.SearchResultWithCursor{}, context.DeadlineExceeded)
@@ -782,7 +787,9 @@ func TestCmdSearch_MediaDBLookupUsesServiceContext(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
-	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockPlatform.AssertNotCalled(
+		t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -844,7 +851,8 @@ func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
-			ctx := args.Get(0).(context.Context)
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
 			<-ctx.Done()
 		}).
 		Return(database.SearchResult{}, context.DeadlineExceeded)
@@ -866,7 +874,9 @@ func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
-	mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockPlatform.AssertNotCalled(
+		t, "LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/zapscript/launch_title_test.go
+++ b/pkg/zapscript/launch_title_test.go
@@ -20,7 +20,6 @@
 package zapscript
 
 import (
-	"context"
 	"testing"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -140,7 +139,7 @@ func TestCmdTitle(t *testing.T) {
 					},
 				}
 				mockMediaDB.On("SearchMediaBySlug",
-					context.Background(), tt.expectedSystem, tt.expectedSlug, []zapscript.TagFilter(nil)).
+					mock.Anything, tt.expectedSystem, tt.expectedSlug, []zapscript.TagFilter(nil)).
 					Return(expectedResults, nil)
 				mockMediaDB.On("SetCachedSlugResolution",
 					mock.Anything, tt.expectedSystem, tt.expectedSlug, []zapscript.TagFilter(nil),
@@ -320,7 +319,7 @@ func TestCmdTitleWithTags(t *testing.T) {
 			Path:     "/test/path/super-mario-world.smc",
 		},
 	}
-	mockMediaDB.On("SearchMediaBySlug", context.Background(), expectedSystem, expectedSlug, expectedTags).
+	mockMediaDB.On("SearchMediaBySlug", mock.Anything, expectedSystem, expectedSlug, expectedTags).
 		Return(expectedResults, nil)
 	mockMediaDB.On("SetCachedSlugResolution",
 		mock.Anything, expectedSystem, expectedSlug, expectedTags,
@@ -471,20 +470,20 @@ func TestCmdTitleWithSubtitleFallback(t *testing.T) {
 				Return(int64(0), "", false)
 
 			mockMediaDB.On("SearchMediaBySlug",
-				context.Background(), tt.systemID, tt.initialSearchSlug, []zapscript.TagFilter(nil)).
+				mock.Anything, tt.systemID, tt.initialSearchSlug, []zapscript.TagFilter(nil)).
 				Return(tt.initialResults, nil).Once()
 
 			if len(tt.initialResults) == 0 && tt.expectFallback {
 				// Strategy 2: Exact match without tags (same slug, different tag filter)
 				// This is the new strategy that tries without tag filters
 				mockMediaDB.On("SearchMediaBySlug",
-					context.Background(), tt.systemID, tt.initialSearchSlug, []zapscript.TagFilter(nil)).
+					mock.Anything, tt.systemID, tt.initialSearchSlug, []zapscript.TagFilter(nil)).
 					Return([]database.SearchResultWithCursor{}, nil).Once()
 
 				// Strategy 3: Secondary title-only search (for titles with subtitles)
 				// Exact match: Search DB's Slug column with secondary title slug
 				mockMediaDB.On("SearchMediaBySlug",
-					context.Background(), tt.systemID, tt.fallbackSearchSlug, []zapscript.TagFilter(nil)).
+					mock.Anything, tt.systemID, tt.fallbackSearchSlug, []zapscript.TagFilter(nil)).
 					Return(tt.fallbackResults, nil).Maybe()
 
 				// Partial match: Search DB's SecondarySlug column with secondary title slug
@@ -613,7 +612,7 @@ func TestCmdTitleJaroWinklerFuzzy(t *testing.T) {
 
 			// Strategy 1 (exact match) fails
 			mockMediaDB.On("SearchMediaBySlug",
-				context.Background(), tt.systemID, tt.slug, []zapscript.TagFilter(nil)).
+				mock.Anything, tt.systemID, tt.slug, []zapscript.TagFilter(nil)).
 				Return([]database.SearchResultWithCursor{}, nil).Once()
 
 			// Strategies 2-4 don't apply (no secondary title in these test queries)
@@ -638,7 +637,7 @@ func TestCmdTitleJaroWinklerFuzzy(t *testing.T) {
 				},
 			}
 			mockMediaDB.On("SearchMediaBySlug",
-				context.Background(), tt.systemID, tt.expectedMatch, []zapscript.TagFilter(nil)).
+				mock.Anything, tt.systemID, tt.expectedMatch, []zapscript.TagFilter(nil)).
 				Return(expectedResults, nil).Once()
 
 			// Secondary title searches also fail (no ':' or '-' in query)
@@ -1544,7 +1543,7 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 			},
 		}
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), systemID, slug, []zapscript.TagFilter(nil)).
+			mock.Anything, systemID, slug, []zapscript.TagFilter(nil)).
 			Return(expectedResults, nil)
 
 		// Should update cache after successful search
@@ -1602,7 +1601,7 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 			Return(int64(0), "", false).Once()
 
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), systemID, slug, tags1).
+			mock.Anything, systemID, slug, tags1).
 			Return([]database.SearchResultWithCursor{
 				{MediaID: 100, SystemID: systemID, Path: "/usa.smc"},
 			}, nil).Once()
@@ -1637,7 +1636,7 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 			Return(int64(0), "", false).Once()
 
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), systemID, slug, tags2).
+			mock.Anything, systemID, slug, tags2).
 			Return([]database.SearchResultWithCursor{
 				{MediaID: 200, SystemID: systemID, Path: "/jp.smc"},
 			}, nil).Once()
@@ -1688,7 +1687,7 @@ func TestCmdTitleErrorHandling(t *testing.T) {
 			Return(int64(0), "", false)
 
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), "SNES", "supermarioworld", []zapscript.TagFilter(nil)).
+			mock.Anything, "SNES", "supermarioworld", []zapscript.TagFilter(nil)).
 			Return([]database.SearchResultWithCursor{}, assert.AnError)
 
 		_, err := cmdTitle(mockPlatform, env)
@@ -1728,7 +1727,7 @@ func TestCmdTitleErrorHandling(t *testing.T) {
 			{MediaID: 123, SystemID: "SNES", Name: "Super Mario World", Path: "/test/smw.smc"},
 		}
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), "SNES", "supermarioworld", []zapscript.TagFilter(nil)).
+			mock.Anything, "SNES", "supermarioworld", []zapscript.TagFilter(nil)).
 			Return(expectedResults, nil)
 
 		// Cache will be set before platform launch attempt
@@ -1874,7 +1873,7 @@ func TestCmdTitlePerformance(t *testing.T) {
 			Return(int64(0), "", false)
 
 		mockMediaDB.On("SearchMediaBySlug",
-			context.Background(), "SNES", "mario", []zapscript.TagFilter(nil)).
+			mock.Anything, "SNES", "mario", []zapscript.TagFilter(nil)).
 			Return(results, nil)
 
 		mockMediaDB.On("SetCachedSlugResolution",

--- a/pkg/zapscript/media_context.go
+++ b/pkg/zapscript/media_context.go
@@ -28,7 +28,7 @@ import (
 
 const mediaDBLookupTimeout = 2 * time.Second
 
-func mediaDBLookupContext(env platforms.CmdEnv) (context.Context, context.CancelFunc) {
+func mediaDBLookupContext(env *platforms.CmdEnv) (context.Context, context.CancelFunc) {
 	parent := env.ServiceCtx
 	if parent == nil {
 		parent = context.Background()

--- a/pkg/zapscript/media_context.go
+++ b/pkg/zapscript/media_context.go
@@ -1,0 +1,37 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapscript
+
+import (
+	"context"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+)
+
+const mediaDBLookupTimeout = 2 * time.Second
+
+func mediaDBLookupContext(env platforms.CmdEnv) (context.Context, context.CancelFunc) {
+	parent := env.ServiceCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, mediaDBLookupTimeout)
+}

--- a/pkg/zapscript/titles.go
+++ b/pkg/zapscript/titles.go
@@ -20,7 +20,6 @@
 package zapscript
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -92,7 +91,8 @@ func cmdTitle(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult,
 		launchersForSystem = helpers.GlobalLauncherCache.GetLaunchersBySystem(system.ID)
 	}
 
-	ctx := context.Background() // TODO: use proper context from env when available
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
 
 	result, err := titles.ResolveTitle(ctx, &titles.ResolveParams{
 		SystemID:       system.ID,

--- a/pkg/zapscript/titles.go
+++ b/pkg/zapscript/titles.go
@@ -91,7 +91,7 @@ func cmdTitle(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult,
 		launchersForSystem = helpers.GlobalLauncherCache.GetLaunchersBySystem(system.ID)
 	}
 
-	ctx, cancel := mediaDBLookupContext(env)
+	ctx, cancel := mediaDBLookupContext(&env)
 	defer cancel()
 
 	result, err := titles.ResolveTitle(ctx, &titles.ResolveParams{

--- a/pkg/zapscript/titles/resolve.go
+++ b/pkg/zapscript/titles/resolve.go
@@ -70,7 +70,8 @@ func cacheSlugResolution(
 ) {
 	cacheCtx, cancel := context.WithTimeout(ctx, slugResolutionCacheWriteTimeout)
 	defer cancel()
-	if cacheErr := mediadb.SetCachedSlugResolution(cacheCtx, systemID, slug, tagFilters, mediaID, strategy); cacheErr != nil {
+	cacheErr := mediadb.SetCachedSlugResolution(cacheCtx, systemID, slug, tagFilters, mediaID, strategy)
+	if cacheErr != nil {
 		log.Warn().Err(cacheErr).Msg("failed to cache slug resolution")
 	}
 }

--- a/pkg/zapscript/titles/resolve.go
+++ b/pkg/zapscript/titles/resolve.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -37,6 +38,8 @@ var (
 	ErrNoMatch       = errors.New("no matching title found")
 	ErrLowConfidence = errors.New("match confidence below minimum threshold")
 )
+
+const slugResolutionCacheWriteTimeout = 100 * time.Millisecond
 
 // ResolveResult contains the output of a title resolution.
 type ResolveResult struct {
@@ -54,6 +57,22 @@ type ResolveParams struct {
 	MediaType      slugs.MediaType
 	AdditionalTags []zapscript.TagFilter
 	Launchers      []platforms.Launcher
+}
+
+func cacheSlugResolution(
+	ctx context.Context,
+	mediadb database.MediaDBI,
+	systemID string,
+	slug string,
+	tagFilters []zapscript.TagFilter,
+	mediaID int64,
+	strategy string,
+) {
+	cacheCtx, cancel := context.WithTimeout(ctx, slugResolutionCacheWriteTimeout)
+	defer cancel()
+	if cacheErr := mediadb.SetCachedSlugResolution(cacheCtx, systemID, slug, tagFilters, mediaID, strategy); cacheErr != nil {
+		log.Warn().Err(cacheErr).Msg("failed to cache slug resolution")
+	}
 }
 
 // ResolveTitle runs the full title resolution pipeline against the media database.
@@ -127,11 +146,7 @@ func ResolveTitle(ctx context.Context, params *ResolveParams) (*ResolveResult, e
 			results, tagFilters, params.Cfg, MatchQualityExact, params.Launchers)
 
 		if confidence >= ConfidenceHigh {
-			if cacheErr := mediadb.SetCachedSlugResolution(
-				ctx, systemID, slug, tagFilters, selectedResult.MediaID, StrategyExactMatch,
-			); cacheErr != nil {
-				log.Warn().Err(cacheErr).Msg("failed to cache slug resolution")
-			}
+			cacheSlugResolution(ctx, mediadb, systemID, slug, tagFilters, selectedResult.MediaID, StrategyExactMatch)
 			return &ResolveResult{
 				Result:     selectedResult,
 				Strategy:   StrategyExactMatch,
@@ -291,12 +306,9 @@ func ResolveTitle(ctx context.Context, params *ResolveParams) (*ResolveResult, e
 		return nil, ErrLowConfidence
 	}
 
-	// Cache the successful resolution
-	if cacheErr := mediadb.SetCachedSlugResolution(
-		ctx, systemID, slug, tagFilters, bestCandidate.result.MediaID, bestCandidate.strategy,
-	); cacheErr != nil {
-		log.Warn().Err(cacheErr).Msg("failed to cache slug resolution")
-	}
+	// Cache the successful resolution without letting cache bookkeeping block
+	// launch-critical title resolution.
+	cacheSlugResolution(ctx, mediadb, systemID, slug, tagFilters, bestCandidate.result.MediaID, bestCandidate.strategy)
 
 	return &ResolveResult{
 		Result:     bestCandidate.result,

--- a/pkg/zapscript/titles/resolve_test.go
+++ b/pkg/zapscript/titles/resolve_test.go
@@ -83,7 +83,8 @@ func TestResolveTitle_StopsWhenContextCancelled(t *testing.T) {
 	mockMediaDB.On("SearchMediaBySlug",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Run(func(args mock.Arguments) {
-		ctx := args.Get(0).(context.Context)
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
 		<-ctx.Done()
 	}).Return([]database.SearchResultWithCursor{}, context.DeadlineExceeded)
 
@@ -124,7 +125,8 @@ func TestResolveTitle_CacheWriteTimeoutDoesNotFailLaunch(t *testing.T) {
 	mockMediaDB.On("SetCachedSlugResolution",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Run(func(args mock.Arguments) {
-		ctx := args.Get(0).(context.Context)
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
 		<-ctx.Done()
 	}).Return(context.DeadlineExceeded)
 

--- a/pkg/zapscript/titles/resolve_test.go
+++ b/pkg/zapscript/titles/resolve_test.go
@@ -23,7 +23,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -66,6 +68,79 @@ func setupCacheWrite(m *helpers.MockMediaDBI) {
 	m.On("SetCachedSlugResolution",
 		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 	).Return(nil)
+}
+
+func TestResolveTitle_StopsWhenContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg, err := helpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+
+	mockMediaDB.On("GetCachedSlugResolution",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(int64(0), "", false)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		<-ctx.Done()
+	}).Return([]database.SearchResultWithCursor{}, context.DeadlineExceeded)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+
+	result, err := ResolveTitle(ctx, &ResolveParams{
+		SystemID:  "NES",
+		GameName:  "Slow Game",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
+}
+
+func TestResolveTitle_CacheWriteTimeoutDoesNotFailLaunch(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg, err := helpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+
+	setupCacheMiss(mockMediaDB)
+	fastPath := filepath.Join("roms", "nes", "fast.nes")
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "nes",
+		Name:     "Fast Game",
+		Path:     fastPath,
+		MediaID:  1,
+	}}, nil)
+	mockMediaDB.On("SetCachedSlugResolution",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		<-ctx.Done()
+	}).Return(context.DeadlineExceeded)
+
+	started := time.Now()
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "NES",
+		GameName:  "Fast Game",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, fastPath, result.Result.Path)
+	assert.Less(t, time.Since(started), 500*time.Millisecond)
 }
 
 func TestResolveTitle_ErrNoMatch(t *testing.T) {

--- a/pkg/zapscript/titles/resolve_test.go
+++ b/pkg/zapscript/titles/resolve_test.go
@@ -103,6 +103,7 @@ func TestResolveTitle_StopsWhenContextCancelled(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestResolveTitle_CacheWriteTimeoutDoesNotFailLaunch(t *testing.T) {
@@ -143,6 +144,7 @@ func TestResolveTitle_CacheWriteTimeoutDoesNotFailLaunch(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, fastPath, result.Result.Path)
 	assert.Less(t, time.Since(started), 500*time.Millisecond)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestResolveTitle_ErrNoMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep foreground MediaDB reads on committed state and bound ZapScript/title/random lookup contexts
- preserve safe last-good slug caches during indexing while invalidating stale count/durable caches
- pass bounded contexts through platform launch and MiSTer tracker metadata lookups
- add regression coverage for indexing-time lookups, cache preservation, and timeout behavior

Verified locally with focused package tests, race test for mediadb, task lint-fix, and full package tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Media lookups and launch flows now respect timeouts and cancellation for more responsive launches, searches, and random selection.
  * Launch and tracker operations propagate service/operation contexts so lookups stop promptly when canceled.

* **Bug Fixes**
  * Cache invalidation refined to preserve slug-search results during indexing when safe, reducing transient search gaps and ensuring targeted cache drops.

* **Tests**
  * Expanded integration and unit tests for context propagation, cancellation, timeouts, and cache behavior to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->