### PR TITLE
feat(api): add latest media history endpoint

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -1041,6 +1041,64 @@ Returns `null` on success.
 }
 ```
 
+### media.history.latest
+
+Return the most recent played media entry from the user database only. This is intended for startup paths that need the last played game as quickly as possible, without media database enrichment.
+
+This method does not return tags, metadata, media IDs, relative paths, pagination, end time, or play time.
+
+#### Parameters
+
+None. Empty params may be omitted or sent as `{}`.
+
+#### Result
+
+| Key   | Type                                                         | Required | Description                                                   |
+| :---- | :----------------------------------------------------------- | :------- | :------------------------------------------------------------ |
+| entry | [MediaHistoryLatestEntry](#media-history-latest-entry-object) | Yes      | Most recent media play history entry, or `null` when none exists. |
+
+##### Media history latest entry object
+
+| Key        | Type   | Required | Description                                     |
+| :--------- | :----- | :------- | :---------------------------------------------- |
+| systemId   | string | Yes      | ID of the system.                               |
+| systemName | string | Yes      | Display name of the system from the history row. |
+| mediaName  | string | Yes      | Display name of the media from the history row. |
+| mediaPath  | string | Yes      | Path to the media file from the history row.    |
+| launcherId | string | Yes      | ID of the launcher used.                        |
+| startedAt  | string | Yes      | Timestamp when media started in RFC3339 format. |
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "9f2c6a52-7a5d-11ef-9c7b-020304050607",
+  "method": "media.history.latest"
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "9f2c6a52-7a5d-11ef-9c7b-020304050607",
+  "result": {
+    "entry": {
+      "systemId": "SNES",
+      "systemName": "Super Nintendo Entertainment System",
+      "mediaName": "Super Mario World",
+      "mediaPath": "/roms/snes/Super Mario World (USA).sfc",
+      "launcherId": "SNES",
+      "startedAt": "2025-01-22T14:30:00Z"
+    }
+  }
+}
+```
+
 ### media.history
 
 Return paginated media play history.

--- a/pkg/api/methods/media_history_latest.go
+++ b/pkg/api/methods/media_history_latest.go
@@ -31,7 +31,8 @@ import (
 )
 
 func HandleMediaHistoryLatest(env requests.RequestEnv) (any, error) { //nolint:gocritic
-	if len(bytes.TrimSpace(env.Params)) > 0 && !bytes.Equal(bytes.TrimSpace(env.Params), []byte("{}")) {
+	trimmed := bytes.TrimSpace(env.Params)
+	if len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("{}")) {
 		return nil, models.ClientErr(validation.ErrInvalidParams)
 	}
 

--- a/pkg/api/methods/media_history_latest.go
+++ b/pkg/api/methods/media_history_latest.go
@@ -1,0 +1,57 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/rs/zerolog/log"
+)
+
+func HandleMediaHistoryLatest(env requests.RequestEnv) (any, error) { //nolint:gocritic
+	if len(bytes.TrimSpace(env.Params)) > 0 && !bytes.Equal(bytes.TrimSpace(env.Params), []byte("{}")) {
+		return nil, models.ClientErr(validation.ErrInvalidParams)
+	}
+
+	entry, found, err := env.Database.UserDB.GetLatestMediaHistory()
+	if err != nil {
+		log.Error().Err(err).Msg("error getting latest media history")
+		return nil, fmt.Errorf("error getting latest media history: %w", err)
+	}
+	if !found {
+		return models.MediaHistoryLatestResponse{}, nil
+	}
+
+	return models.MediaHistoryLatestResponse{
+		Entry: &models.MediaHistoryLatestEntry{
+			SystemID:   entry.SystemID,
+			SystemName: entry.SystemName,
+			MediaName:  entry.MediaName,
+			MediaPath:  entry.MediaPath,
+			LauncherID: entry.LauncherID,
+			StartedAt:  entry.StartTime.Format(time.RFC3339),
+		},
+	}, nil
+}

--- a/pkg/api/methods/media_history_latest.go
+++ b/pkg/api/methods/media_history_latest.go
@@ -30,7 +30,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func HandleMediaHistoryLatest(env requests.RequestEnv) (any, error) { //nolint:gocritic
+func HandleMediaHistoryLatest(env requests.RequestEnv) (any, error) { //nolint:gocritic // API handler signature
 	trimmed := bytes.TrimSpace(env.Params)
 	if len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("{}")) {
 		return nil, models.ClientErr(validation.ErrInvalidParams)

--- a/pkg/api/methods/media_history_latest_test.go
+++ b/pkg/api/methods/media_history_latest_test.go
@@ -1,0 +1,135 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleMediaHistoryLatest_Success(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	startedAt := time.Unix(1_770_000_000, 0).UTC()
+	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{
+		DBID:       12,
+		SystemID:   "SNES",
+		SystemName: "Super Nintendo Entertainment System",
+		MediaName:  "Super Mario World",
+		MediaPath:  "/roms/snes/Super Mario World (USA).sfc",
+		LauncherID: "SNES",
+		StartTime:  startedAt,
+	}, true, nil)
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Context: context.Background(),
+		Database: &database.Database{
+			UserDB: mockUserDB,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaHistoryLatestResponse)
+	require.True(t, ok)
+	require.NotNil(t, resp.Entry)
+	assert.Equal(t, "SNES", resp.Entry.SystemID)
+	assert.Equal(t, "Super Nintendo Entertainment System", resp.Entry.SystemName)
+	assert.Equal(t, "Super Mario World", resp.Entry.MediaName)
+	assert.Equal(t, "/roms/snes/Super Mario World (USA).sfc", resp.Entry.MediaPath)
+	assert.Equal(t, "SNES", resp.Entry.LauncherID)
+	assert.Equal(t, startedAt.Format(time.RFC3339), resp.Entry.StartedAt)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryLatest_EmptyParamsObject(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{}, false, nil)
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Params: []byte("{}"),
+		Database: &database.Database{
+			UserDB: mockUserDB,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaHistoryLatestResponse)
+	require.True(t, ok)
+	assert.Nil(t, resp.Entry)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryLatest_NoHistory(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{}, false, nil)
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Database: &database.Database{
+			UserDB: mockUserDB,
+		},
+	})
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaHistoryLatestResponse)
+	require.True(t, ok)
+	assert.Nil(t, resp.Entry)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryLatest_RejectsParams(t *testing.T) {
+	t.Parallel()
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Params: []byte(`{"limit":1}`),
+	})
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestHandleMediaHistoryLatest_DatabaseError(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{}, false, errors.New("boom"))
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Database: &database.Database{
+			UserDB: mockUserDB,
+		},
+	})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "error getting latest media history")
+	mockUserDB.AssertExpectations(t)
+}

--- a/pkg/api/methods/media_history_latest_test.go
+++ b/pkg/api/methods/media_history_latest_test.go
@@ -22,6 +22,7 @@ package methods
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -38,12 +39,13 @@ func TestHandleMediaHistoryLatest_Success(t *testing.T) {
 
 	mockUserDB := helpers.NewMockUserDBI()
 	startedAt := time.Unix(1_770_000_000, 0).UTC()
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "snes", "Super Mario World (USA).sfc"))
 	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{
 		DBID:       12,
 		SystemID:   "SNES",
 		SystemName: "Super Nintendo Entertainment System",
 		MediaName:  "Super Mario World",
-		MediaPath:  "/roms/snes/Super Mario World (USA).sfc",
+		MediaPath:  mediaPath,
 		LauncherID: "SNES",
 		StartTime:  startedAt,
 	}, true, nil)
@@ -62,7 +64,7 @@ func TestHandleMediaHistoryLatest_Success(t *testing.T) {
 	assert.Equal(t, "SNES", resp.Entry.SystemID)
 	assert.Equal(t, "Super Nintendo Entertainment System", resp.Entry.SystemName)
 	assert.Equal(t, "Super Mario World", resp.Entry.MediaName)
-	assert.Equal(t, "/roms/snes/Super Mario World (USA).sfc", resp.Entry.MediaPath)
+	assert.Equal(t, mediaPath, resp.Entry.MediaPath)
 	assert.Equal(t, "SNES", resp.Entry.LauncherID)
 	assert.Equal(t, startedAt.Format(time.RFC3339), resp.Entry.StartedAt)
 	mockUserDB.AssertExpectations(t)

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -63,6 +63,7 @@ const (
 	MethodMediaTagsUpdate      = "media.tags.update"
 	MethodMediaActive          = "media.active"
 	MethodMediaHistory         = "media.history"
+	MethodMediaHistoryLatest   = "media.history.latest"
 	MethodMediaHistoryTop      = "media.history.top"
 	MethodMediaLookup          = "media.lookup"
 	MethodMediaMeta            = "media.meta"

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -210,6 +210,19 @@ type MediaHistoryResponse struct {
 	Entries    []MediaHistoryResponseEntry `json:"entries"`
 }
 
+type MediaHistoryLatestEntry struct {
+	SystemID   string `json:"systemId"`
+	SystemName string `json:"systemName"`
+	MediaName  string `json:"mediaName"`
+	MediaPath  string `json:"mediaPath"`
+	LauncherID string `json:"launcherId"`
+	StartedAt  string `json:"startedAt"`
+}
+
+type MediaHistoryLatestResponse struct {
+	Entry *MediaHistoryLatestEntry `json:"entry"`
+}
+
 type MediaHistoryTopEntry struct {
 	RelPath       *string `json:"relativePath,omitempty"`
 	SystemID      string  `json:"systemId"`

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -256,6 +256,7 @@ func NewMethodMap() *MethodMap {
 		models.MethodMediaActiveUpdate:   methods.HandleUpdateActiveMedia,
 		models.MethodMediaCleanOrphans:   methods.HandleMediaCleanOrphans,
 		models.MethodMediaHistory:        methods.HandleMediaHistory,
+		models.MethodMediaHistoryLatest:  methods.HandleMediaHistoryLatest,
 		models.MethodMediaHistoryTop:     methods.HandleMediaHistoryTop,
 		models.MethodMediaLookup:         methods.HandleMediaLookup,
 		models.MethodMediaMeta:           methods.HandleMediaMeta,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -499,6 +499,7 @@ type UserDBI interface {
 	UpdateMediaHistoryTime(dbid int64, playTime int) error
 	CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error
 	GetMediaHistory(systemIDs []string, lastID int64, limit int) ([]MediaHistoryEntry, error)
+	GetLatestMediaHistory() (MediaHistoryEntry, bool, error)
 	GetMediaHistoryTop(systemIDs []string, since *time.Time, limit int) ([]MediaHistoryTopEntry, error)
 	CloseHangingMediaHistory() error
 	CleanupMediaHistory(retentionDays int) (int64, error)

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -22,6 +22,7 @@ package userdb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -61,6 +62,14 @@ func (db *UserDB) GetMediaHistory(systemIDs []string, lastID int64, limit int) (
 		return nil, ErrNullSQL
 	}
 	return sqlGetMediaHistory(db.ctx, db.sql, systemIDs, lastID, limit)
+}
+
+// GetLatestMediaHistory retrieves the most recent media history entry with no enrichment.
+func (db *UserDB) GetLatestMediaHistory() (database.MediaHistoryEntry, bool, error) {
+	if db.sql == nil {
+		return database.MediaHistoryEntry{}, false, ErrNullSQL
+	}
+	return sqlGetLatestMediaHistory(db.ctx, db.sql)
 }
 
 // GetMediaHistoryTop returns aggregated media history grouped by SystemID+MediaName,
@@ -335,6 +344,45 @@ func sqlGetMediaHistory(
 	}
 
 	return list, nil
+}
+
+func sqlGetLatestMediaHistory(ctx context.Context, db *sql.DB) (database.MediaHistoryEntry, bool, error) {
+	stmt, err := db.PrepareContext(ctx, `
+		SELECT DBID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID
+		FROM MediaHistory
+		ORDER BY DBID DESC
+		LIMIT 1;
+	`)
+	if err != nil {
+		return database.MediaHistoryEntry{}, false,
+			fmt.Errorf("failed to prepare latest media history query statement: %w", err)
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+
+	var entry database.MediaHistoryEntry
+	var startTimeUnix int64
+	err = stmt.QueryRowContext(ctx).Scan(
+		&entry.DBID,
+		&startTimeUnix,
+		&entry.SystemID,
+		&entry.SystemName,
+		&entry.MediaPath,
+		&entry.MediaName,
+		&entry.LauncherID,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return database.MediaHistoryEntry{}, false, nil
+		}
+		return database.MediaHistoryEntry{}, false, fmt.Errorf("failed to scan latest media history row: %w", err)
+	}
+
+	entry.StartTime = time.Unix(startTimeUnix, 0)
+	return entry, true, nil
 }
 
 func sqlCloseHangingMediaHistory(ctx context.Context, db *sql.DB) error {

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -22,6 +22,7 @@ package userdb
 import (
 	"context"
 	"math"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -308,11 +309,12 @@ func TestSqlGetLatestMediaHistory_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	startTime := time.Unix(1_770_000_000, 0).Unix()
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "snes", "game.sfc"))
 	rows := sqlmock.NewRows([]string{
 		"DBID", "StartTime", "SystemID", "SystemName", "MediaPath", "MediaName", "LauncherID",
 	}).AddRow(
 		int64(9), startTime, "SNES", "Super Nintendo Entertainment System",
-		"/roms/snes/game.sfc", "Game", "SNES",
+		mediaPath, "Game", "SNES",
 	)
 
 	mock.ExpectPrepare(`SELECT DBID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID.*`).
@@ -326,7 +328,7 @@ func TestSqlGetLatestMediaHistory_Success(t *testing.T) {
 	assert.Equal(t, "SNES", entry.SystemID)
 	assert.Equal(t, "Super Nintendo Entertainment System", entry.SystemName)
 	assert.Equal(t, "Game", entry.MediaName)
-	assert.Equal(t, "/roms/snes/game.sfc", entry.MediaPath)
+	assert.Equal(t, mediaPath, entry.MediaPath)
 	assert.Equal(t, "SNES", entry.LauncherID)
 	assert.Equal(t, time.Unix(startTime, 0), entry.StartTime)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -301,6 +301,75 @@ func TestSqlGetMediaHistory_EmptyResult(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlGetLatestMediaHistory_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	startTime := time.Unix(1_770_000_000, 0).Unix()
+	rows := sqlmock.NewRows([]string{
+		"DBID", "StartTime", "SystemID", "SystemName", "MediaPath", "MediaName", "LauncherID",
+	}).AddRow(
+		int64(9), startTime, "SNES", "Super Nintendo Entertainment System",
+		"/roms/snes/game.sfc", "Game", "SNES",
+	)
+
+	mock.ExpectPrepare(`SELECT DBID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID.*`).
+		ExpectQuery().
+		WillReturnRows(rows)
+
+	entry, found, err := sqlGetLatestMediaHistory(context.Background(), db)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, int64(9), entry.DBID)
+	assert.Equal(t, "SNES", entry.SystemID)
+	assert.Equal(t, "Super Nintendo Entertainment System", entry.SystemName)
+	assert.Equal(t, "Game", entry.MediaName)
+	assert.Equal(t, "/roms/snes/game.sfc", entry.MediaPath)
+	assert.Equal(t, "SNES", entry.LauncherID)
+	assert.Equal(t, time.Unix(startTime, 0), entry.StartTime)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetLatestMediaHistory_EmptyResult(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows([]string{
+		"DBID", "StartTime", "SystemID", "SystemName", "MediaPath", "MediaName", "LauncherID",
+	})
+
+	mock.ExpectPrepare(`SELECT DBID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID.*`).
+		ExpectQuery().
+		WillReturnRows(rows)
+
+	entry, found, err := sqlGetLatestMediaHistory(context.Background(), db)
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, entry)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetLatestMediaHistory_DatabaseError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectPrepare(`SELECT DBID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID.*`).
+		WillReturnError(sqlmock.ErrCancelled)
+
+	entry, found, err := sqlGetLatestMediaHistory(context.Background(), db)
+	require.Error(t, err)
+	assert.False(t, found)
+	assert.Empty(t, entry)
+	assert.Contains(t, err.Error(), "failed to prepare latest media history query statement")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlGetMediaHistory_DatabaseError(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -322,6 +322,19 @@ func (m *MockUserDBI) GetMediaHistory(
 	return history, nil
 }
 
+func (m *MockUserDBI) GetLatestMediaHistory() (database.MediaHistoryEntry, bool, error) {
+	args := m.Called()
+	entry, ok := args.Get(0).(database.MediaHistoryEntry)
+	if !ok {
+		entry = database.MediaHistoryEntry{}
+	}
+	found := args.Bool(1)
+	if err := args.Error(2); err != nil {
+		return entry, found, fmt.Errorf("mock UserDBI get latest media history failed: %w", err)
+	}
+	return entry, found, nil
+}
+
 func (m *MockUserDBI) GetMediaHistoryTop(
 	systemIDs []string, since *time.Time, limit int,
 ) ([]database.MediaHistoryTopEntry, error) {


### PR DESCRIPTION
## Summary
- add media.history.latest for startup-friendly last played media lookup
- query only latest MediaHistory row from UserDB without MediaDB enrichment
- document response and cover API/UserDB behavior with tests

## Verified
- go test ./pkg/database/userdb/ ./pkg/api/methods/ ./pkg/api/
- task lint-fix
- go test ./pkg/api/methods ./pkg/database/userdb ./pkg/testing/helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added media.history.latest API method to return the most-recent media history entry (or null), including system IDs/names, media name/path, launcher ID, and session start timestamp.

* **Documentation**
  * API docs updated with request/response schema and example for the new method.

* **Tests**
  * Unit tests added for API handler and database retrieval behaviors around the new method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->