### PR TITLE
fix(media): resume scraping and return tag labels

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -154,10 +154,10 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu' && !startsWith(github.ref, 'refs/tags/')
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
+          files: ./coverage.txt
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: true

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -459,7 +459,7 @@ func TestAnnotateSingletonDirectoryEntry_WhenZipsAsDirsEnabled(t *testing.T) {
 		Return(&row.Media, nil).Once()
 	mockMediaDB.On("GetMediaWithTitleAndSystem", mock.Anything, row.DBID).Return(row, nil).Once()
 	mockMediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, row.DBID).
-		Return([]database.TagInfo{{Type: "favorite", Tag: "true"}}, nil).Once()
+		Return([]database.TagInfo{{Type: "favorite", Tag: "true", Label: "Favorite"}}, nil).Once()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", row.Path).
 		Return([]database.TagInfo{}, nil).Once()
 
@@ -475,7 +475,7 @@ func TestAnnotateSingletonDirectoryEntry_WhenZipsAsDirsEnabled(t *testing.T) {
 	assert.Equal(t, "NES", *entry.SystemID)
 	require.NotNil(t, entry.ZapScript)
 	assert.NotEmpty(t, *entry.ZapScript)
-	assert.Equal(t, []database.TagInfo{{Type: "favorite", Tag: "true"}}, entry.Tags)
+	assert.Equal(t, []database.TagInfo{{Type: "favorite", Tag: "true", Label: "Favorite"}}, entry.Tags)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_meta_test.go
+++ b/pkg/api/methods/media_meta_test.go
@@ -72,9 +72,9 @@ func TestHandleMediaMeta_FullResult(t *testing.T) {
 	}
 	expectMediaMetaResolve(mockDB, row)
 	mockDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(1)).
-		Return([]database.TagInfo{{Tag: "genre:platformer", Type: "genre"}}, nil)
+		Return([]database.TagInfo{{Tag: "platformer", Type: "genre", Label: "Platformer"}}, nil)
 	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
-		Return([]database.TagInfo{{Tag: "developer:nintendo", Type: "developer"}}, nil)
+		Return([]database.TagInfo{{Tag: "nintendo", Type: "developer", Label: "Nintendo"}}, nil)
 	mockDB.On("GetMediaProperties", mock.Anything, int64(1)).
 		Return([]database.MediaProperty{}, nil)
 	mockDB.On("GetMediaTitleProperties", mock.Anything, int64(10)).
@@ -94,9 +94,11 @@ func TestHandleMediaMeta_FullResult(t *testing.T) {
 	assert.Equal(t, "NES", resp.Media.Title.System.Name)
 	assert.Equal(t, "super-mario-bros", resp.Media.Title.Slug)
 	assert.Len(t, resp.Media.Tags, 1)
-	assert.Equal(t, "genre:platformer", resp.Media.Tags[0].Tag)
+	assert.Equal(t, "platformer", resp.Media.Tags[0].Tag)
+	assert.Equal(t, "Platformer", resp.Media.Tags[0].Label)
 	assert.Len(t, resp.Media.Title.Tags, 1)
-	assert.Equal(t, "developer:nintendo", resp.Media.Title.Tags[0].Tag)
+	assert.Equal(t, "nintendo", resp.Media.Title.Tags[0].Tag)
+	assert.Equal(t, "Nintendo", resp.Media.Title.Tags[0].Label)
 	assert.Contains(t, resp.Media.Title.Properties, "property:description")
 	assert.Equal(t, "A classic platformer", resp.Media.Title.Properties["property:description"].Text)
 	mockDB.AssertExpectations(t)
@@ -263,13 +265,17 @@ func TestHandleMediaMeta_BatchByMediaIDPartialSuccess(t *testing.T) {
 	row := makeMediaFullRow(3, 30)
 	row.System = database.System{DBID: 100, SystemID: "NES", Name: "NES"}
 	row.Title.Name = "Batch Game"
+	mediaTags := map[int64][]database.TagInfo{
+		row.DBID: {{Tag: "platformer", Type: "genre", Label: "Platformer"}},
+	}
+	titleTags := map[int64][]database.TagInfo{
+		row.Title.DBID: {{Tag: "nintendo", Type: "publisher", Label: "Nintendo"}},
+	}
 
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
 		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil)
-	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).
-		Return(map[int64][]database.TagInfo{row.DBID: {{Tag: "genre:platformer", Type: "genre"}}}, nil)
-	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).
-		Return(map[int64][]database.TagInfo{row.Title.DBID: {{Tag: "publisher:nintendo", Type: "publisher"}}}, nil)
+	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).Return(mediaTags, nil)
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).Return(titleTags, nil)
 	mockDB.On("GetMediaPropertiesByMediaDBIDs", mock.Anything, mock.Anything).
 		Return(map[int64][]database.MediaProperty{
 			row.DBID: {{TypeTag: "property:description", Text: "media desc"}},
@@ -287,6 +293,10 @@ func TestHandleMediaMeta_BatchByMediaIDPartialSuccess(t *testing.T) {
 	require.NotNil(t, resp.Items[0].Media)
 	assert.Equal(t, row.Path, resp.Items[0].Media.Path)
 	assert.Equal(t, "Batch Game", resp.Items[0].Media.Title.Name)
+	require.Len(t, resp.Items[0].Media.Tags, 1)
+	assert.Equal(t, "Platformer", resp.Items[0].Media.Tags[0].Label)
+	require.Len(t, resp.Items[0].Media.Title.Tags, 1)
+	assert.Equal(t, "Nintendo", resp.Items[0].Media.Title.Tags[0].Label)
 	assert.Contains(t, resp.Items[0].Media.Properties, "property:description")
 	require.NotNil(t, resp.Items[1].Error)
 	assert.Contains(t, *resp.Items[1].Error, "mediaId 999")
@@ -300,13 +310,17 @@ func TestHandleMediaMeta_MediaIDSuccess(t *testing.T) {
 	row := makeMediaFullRow(3, 30)
 	row.System = database.System{DBID: 100, SystemID: "NES", Name: "NES"}
 	row.Title.Name = "Media ID Game"
+	mediaTags := map[int64][]database.TagInfo{
+		row.DBID: {{Tag: "platformer", Type: "genre", Label: "Platformer"}},
+	}
+	titleTags := map[int64][]database.TagInfo{
+		row.Title.DBID: {{Tag: "nintendo", Type: "publisher", Label: "Nintendo"}},
+	}
 
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, mock.Anything).
 		Return(map[int64]database.MediaFullRow{row.DBID: *row}, nil)
-	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).
-		Return(map[int64][]database.TagInfo{row.DBID: {{Tag: "genre:platformer", Type: "genre"}}}, nil)
-	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).
-		Return(map[int64][]database.TagInfo{row.Title.DBID: {{Tag: "publisher:nintendo", Type: "publisher"}}}, nil)
+	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, mock.Anything).Return(mediaTags, nil)
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, mock.Anything).Return(titleTags, nil)
 	mockDB.On("GetMediaPropertiesByMediaDBIDs", mock.Anything, mock.Anything).
 		Return(map[int64][]database.MediaProperty{
 			row.DBID: {{TypeTag: "property:description", Text: "media desc"}},
@@ -325,9 +339,11 @@ func TestHandleMediaMeta_MediaIDSuccess(t *testing.T) {
 	assert.Equal(t, row.Path, resp.Media.Path)
 	assert.Equal(t, "Media ID Game", resp.Media.Title.Name)
 	require.Len(t, resp.Media.Tags, 1)
-	assert.Equal(t, "genre:platformer", resp.Media.Tags[0].Tag)
+	assert.Equal(t, "platformer", resp.Media.Tags[0].Tag)
+	assert.Equal(t, "Platformer", resp.Media.Tags[0].Label)
 	require.Len(t, resp.Media.Title.Tags, 1)
-	assert.Equal(t, "publisher:nintendo", resp.Media.Title.Tags[0].Tag)
+	assert.Equal(t, "nintendo", resp.Media.Title.Tags[0].Tag)
+	assert.Equal(t, "Nintendo", resp.Media.Title.Tags[0].Label)
 	assert.Equal(t, "media desc", resp.Media.Properties["property:description"].Text)
 	assert.Equal(t, "title desc", resp.Media.Title.Properties["property:description"].Text)
 	mockDB.AssertExpectations(t)

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -481,11 +481,15 @@ func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams)
 			publishScrapingStatus(ns, &status)
 		}
 
-		// Only send a terminal notification if the channel closed without a
-		// Done=true update (e.g. scraper returned a pre-closed empty channel).
-		// Otherwise the channel already delivered the final counters and sending
-		// another zeroed-out Done would overwrite them for consumers.
-		if !receivedDone {
+		if scrapeCtx.Err() != nil {
+			finalStatus = mediadb.IndexingStatusCancelled
+		}
+
+		// Only synthesize a completed notification if the channel closed without
+		// a Done=true update and no failure/cancel status was observed.
+		// Otherwise the channel already delivered the terminal state, or there is
+		// no successful completion to announce.
+		if !receivedDone && finalStatus == mediadb.IndexingStatusCompleted {
 			terminalStatus := scrapingStatusInstance.getLatest()
 			terminalStatus.ScraperID = scraperID
 			terminalStatus.Force = params.Force
@@ -493,10 +497,6 @@ func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams)
 			terminalStatus.Done = true
 			terminalStatus.Paused = false
 			terminalStatus.State = scrapeStateCompleted
-			if scrapeCtx.Err() != nil {
-				terminalStatus.State = scrapeStateCancelled
-				finalStatus = mediadb.IndexingStatusCancelled
-			}
 			populateScrapedMediaCountExact(env.State.GetContext(), db, &terminalStatus)
 			mediaImageNoImages.clear()
 			publishScrapingStatus(ns, &terminalStatus)

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/rs/zerolog/log"
@@ -376,6 +377,20 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		return nil, models.ClientErrf("invalid params: %w", err)
 	}
 
+	return startMediaScrape(&env, params)
+}
+
+func ResumeMediaScrape(env *requests.RequestEnv, operation database.ScrapingOperation) error {
+	params := models.MediaScrapeParams{
+		ScraperID: operation.ScraperID,
+		Systems:   operation.Systems,
+		Force:     operation.Force,
+	}
+	_, err := startMediaScrape(env, params)
+	return err
+}
+
+func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams) (any, error) {
 	platformScrapers := env.Platform.Scrapers(env.Config)
 	s, ok := platformScrapers[params.ScraperID]
 	if !ok {
@@ -389,6 +404,20 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		return nil, err
 	}
 
+	operation := database.ScrapingOperation{
+		ScraperID: params.ScraperID,
+		Systems:   params.Systems,
+		Force:     params.Force,
+	}
+	if err := env.Database.MediaDB.SetScrapingOperation(operation); err != nil {
+		scrapingStatusInstance.clearIfOwner(params.ScraperID)
+		return nil, fmt.Errorf("failed to persist scraping operation: %w", err)
+	}
+	if err := env.Database.MediaDB.SetScrapingStatus(mediadb.IndexingStatusRunning); err != nil {
+		scrapingStatusInstance.clearIfOwner(params.ScraperID)
+		return nil, fmt.Errorf("failed to persist scraping status: %w", err)
+	}
+
 	// Use app-scoped context — scraping outlives the API request.
 	scrapeCtx, cancelFunc := context.WithCancel(env.State.GetContext())
 	scrapingStatusInstance.setCancelFunc(cancelFunc)
@@ -399,6 +428,9 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	if err := s.Scrape(scrapeCtx, env.Config, env.Platform, afero.NewOsFs(), env.Database, opts, nil, ch); err != nil {
 		cancelFunc()
 		scrapingStatusInstance.clear()
+		if statusErr := env.Database.MediaDB.SetScrapingStatus(mediadb.IndexingStatusFailed); statusErr != nil {
+			log.Warn().Err(statusErr).Msg("failed to persist scraping failure status")
+		}
 		return nil, fmt.Errorf("failed to start scraper: %w", err)
 	}
 
@@ -426,6 +458,7 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		defer cancelFunc()
 		defer db.MediaDB.BackgroundOperationDone()
 
+		finalStatus := mediadb.IndexingStatusCompleted
 		var receivedDone bool
 		for update := range ch {
 			if update.Done {
@@ -433,6 +466,12 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 			}
 			paused := env.ScrapePauser != nil && env.ScrapePauser.IsPaused()
 			status := scrapingStatusFromUpdate(scrapeCtx, scraperID, params.Force, &update, paused)
+			if update.FatalErr != nil {
+				finalStatus = mediadb.IndexingStatusFailed
+			}
+			if update.Done && scrapeCtx.Err() != nil {
+				finalStatus = mediadb.IndexingStatusCancelled
+			}
 			if update.Done {
 				populateScrapedMediaCountExact(env.State.GetContext(), db, &status)
 				mediaImageNoImages.clear()
@@ -456,12 +495,21 @@ func HandleMediaScrape(env requests.RequestEnv) (any, error) { //nolint:gocritic
 			terminalStatus.State = scrapeStateCompleted
 			if scrapeCtx.Err() != nil {
 				terminalStatus.State = scrapeStateCancelled
+				finalStatus = mediadb.IndexingStatusCancelled
 			}
 			populateScrapedMediaCountExact(env.State.GetContext(), db, &terminalStatus)
 			mediaImageNoImages.clear()
 			publishScrapingStatus(ns, &terminalStatus)
 		}
-		log.Info().Str("scraper", scraperID).Msg("scraper run complete")
+		if err := db.MediaDB.SetScrapingStatus(finalStatus); err != nil {
+			log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to persist scraping terminal status")
+		}
+		if finalStatus == mediadb.IndexingStatusCompleted || finalStatus == mediadb.IndexingStatusCancelled {
+			if err := db.MediaDB.ClearScrapingOperation(); err != nil {
+				log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to clear scraping operation")
+			}
+		}
+		log.Info().Str("scraper", scraperID).Str("status", finalStatus).Msg("scraper run complete")
 	}()
 
 	return nil, nil //nolint:nilnil // API handler returns nil result and nil error for async start
@@ -476,6 +524,8 @@ func HandleMediaScrapeStatus(env requests.RequestEnv) (any, error) {
 		status.State = scrapeStateIdle
 		if status.Scraping {
 			status.State = scrapeStateRunning
+		} else if persisted, ok := persistedScrapingStatus(env); ok {
+			status = persisted
 		}
 	}
 	if status.Scraping && env.ScrapePauser != nil {
@@ -499,8 +549,36 @@ func HandleMediaScrapeStatus(env requests.RequestEnv) (any, error) {
 // HandleMediaScrapeCancel cancels the currently running media.scrape operation.
 //
 //nolint:gocritic // API handler signature; large env param cannot be passed by pointer
-func HandleMediaScrapeCancel(_ requests.RequestEnv) (any, error) {
+func persistedScrapingStatus(env requests.RequestEnv) (models.ScrapingStatusResponse, bool) {
+	if env.Database == nil || env.Database.MediaDB == nil {
+		return models.ScrapingStatusResponse{}, false
+	}
+	status, err := env.Database.MediaDB.GetScrapingStatus()
+	if err != nil || (status != mediadb.IndexingStatusRunning && status != mediadb.IndexingStatusPending) {
+		return models.ScrapingStatusResponse{}, false
+	}
+	operation, found, err := env.Database.MediaDB.GetScrapingOperation()
+	if err != nil || !found || operation.ScraperID == "" {
+		return models.ScrapingStatusResponse{}, false
+	}
+	return models.ScrapingStatusResponse{
+		ScraperID: operation.ScraperID,
+		Scraping:  true,
+		State:     scrapeStateRunning,
+		Force:     operation.Force,
+	}, true
+}
+
+func HandleMediaScrapeCancel(env requests.RequestEnv) (any, error) { //nolint:gocritic // API handler signature
 	if scrapingStatusInstance.cancel() {
+		if env.Database != nil && env.Database.MediaDB != nil {
+			if err := env.Database.MediaDB.SetScrapingStatus(mediadb.IndexingStatusCancelled); err != nil {
+				log.Warn().Err(err).Msg("failed to persist scraping cancellation status")
+			}
+			if err := env.Database.MediaDB.ClearScrapingOperation(); err != nil {
+				log.Warn().Err(err).Msg("failed to clear scraping operation after cancellation")
+			}
+		}
 		return map[string]any{"message": "scraping cancelled"}, nil
 	}
 	return map[string]any{"message": "no scraping operation is currently running"}, nil

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -60,6 +60,24 @@ func emptyPlatformScraper(id, name string) platforms.Scraper {
 	}
 }
 
+func fatalUpdatePlatformScraper(id string) platforms.Scraper {
+	return platforms.Scraper{
+		ID:   id,
+		Name: "fatal update scraper",
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, _ scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			go func() {
+				ch <- scraper.ScrapeUpdate{FatalErr: errors.New("scrape failed")}
+				close(ch)
+			}()
+			return nil
+		},
+	}
+}
+
 // errorPlatformScraper returns a platforms.Scraper whose Scrape always returns err.
 func errorPlatformScraper(id string, err error) platforms.Scraper {
 	return platforms.Scraper{
@@ -268,6 +286,64 @@ func TestHandleMediaScrape_HappyPath(t *testing.T) {
 	assert.True(t, status.Done)
 
 	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaScrape_FatalUpdateDoesNotSynthesizeDone(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "fail-scraper"}).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusFailed).Return(nil).Once()
+	mockDB.On("TrackBackgroundOperation").Return()
+	mockDB.On("BackgroundOperationDone").Return()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "fail-scraper").Return(0, nil)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
+		"fail-scraper": fatalUpdatePlatformScraper("fail-scraper"),
+	})
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	t.Cleanup(st.StopService)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		State:    st,
+		Database: &database.Database{MediaDB: mockDB},
+		Params:   json.RawMessage(`{"scraperId":"fail-scraper"}`),
+	}
+
+	result, err := HandleMediaScrape(env)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	var sawFailure bool
+	for {
+		select {
+		case n := <-ns:
+			if n.Method != models.NotificationMediaScraping {
+				continue
+			}
+			var payload models.ScrapingStatusResponse
+			require.NoError(t, json.Unmarshal(n.Params, &payload))
+			assert.False(t, payload.Done, "fatal scrape must not synthesize a completed Done update")
+			if payload.State == scrapeStateFailed {
+				sawFailure = true
+			}
+		default:
+			assert.True(t, sawFailure, "expected failed scraping notification")
+			mockDB.AssertExpectations(t)
+			return
+		}
+	}
 }
 
 func TestHandleMediaScrapeStatus_NoRun(t *testing.T) {

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -197,6 +198,10 @@ func TestHandleMediaScrape_HappyPath(t *testing.T) {
 	statusInstance.clear()
 
 	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	mockDB.On("ClearScrapingOperation").Return(nil).Once()
 	mockDB.On("TrackBackgroundOperation").Return()
 	mockDB.On("BackgroundOperationDone").Return()
 	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(5, nil)

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -550,6 +550,82 @@ func TestHandleMediaScrapeStatus_UsesScrapePauser(t *testing.T) {
 // TestHandleMediaScrape_ScraperInitError verifies that when the scraper's
 // Scrape method returns an error, HandleMediaScrape propagates the error and
 // the global scraping status is cleared.
+func TestResumeMediaScrape_RestoresStoredOptions(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	operation := database.ScrapingOperation{ScraperID: "resume-scraper", Systems: []string{"SNES"}, Force: true}
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", operation).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("BackgroundOperationDone").Return().Once()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "resume-scraper").Return(0, nil)
+	mockDB.On("ClearScrapingOperation").Return(nil).Once()
+
+	var gotOptions scraper.ScrapeOptions
+	resumeScraper := platforms.Scraper{
+		ID:   "resume-scraper",
+		Name: "Resume Scraper",
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, opts scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			gotOptions = opts
+			go func() {
+				ch <- scraper.ScrapeUpdate{Done: true}
+				close(ch)
+			}()
+			return nil
+		},
+	}
+	env := makeScrapeEnv(t,
+		map[string]platforms.Scraper{"resume-scraper": resumeScraper},
+		mockDB,
+		nil,
+	)
+
+	require.NoError(t, ResumeMediaScrape(&env, operation))
+	assert.Equal(t, []string{"SNES"}, gotOptions.Systems)
+	assert.True(t, gotOptions.Force)
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaScrapeStatus_UsesPersistedRunningOperation(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	operation := database.ScrapingOperation{ScraperID: "stored-scraper", Force: true}
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusPending, nil).Once()
+	mockDB.On("GetScrapingOperation").Return(operation, true, nil).Once()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "stored-scraper").Return(12, nil).Once()
+
+	env := makeScrapeEnv(t,
+		map[string]platforms.Scraper{},
+		mockDB,
+		nil,
+	)
+
+	result, err := HandleMediaScrapeStatus(env)
+	require.NoError(t, err)
+	status, ok := result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Equal(t, "stored-scraper", status.ScraperID)
+	assert.Equal(t, "running", status.State)
+	assert.True(t, status.Scraping)
+	assert.True(t, status.Force)
+	assert.Equal(t, 12, status.TotalScraped)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrape_PersistStatusErrorClearsRunning(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -550,6 +550,27 @@ func TestHandleMediaScrapeStatus_UsesScrapePauser(t *testing.T) {
 // TestHandleMediaScrape_ScraperInitError verifies that when the scraper's
 // Scrape method returns an error, HandleMediaScrape propagates the error and
 // the global scraping status is cleared.
+func TestHandleMediaScrape_PersistOperationErrorClearsRunning(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).
+		Return(errors.New("persist failed")).Once()
+	env := makeScrapeEnv(t,
+		map[string]platforms.Scraper{"test-scraper": emptyPlatformScraper("test-scraper", "Test Scraper")},
+		mockDB,
+		models.MediaScrapeParams{ScraperID: "test-scraper"},
+	)
+
+	_, err := HandleMediaScrape(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist scraping operation")
+	assert.False(t, IsScrapingRunning())
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrape_ScraperInitError(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -550,6 +550,28 @@ func TestHandleMediaScrapeStatus_UsesScrapePauser(t *testing.T) {
 // TestHandleMediaScrape_ScraperInitError verifies that when the scraper's
 // Scrape method returns an error, HandleMediaScrape propagates the error and
 // the global scraping status is cleared.
+func TestHandleMediaScrape_PersistStatusErrorClearsRunning(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	operation := database.ScrapingOperation{ScraperID: "test-scraper"}
+	mockDB.On("SetScrapingOperation", operation).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(errors.New("status failed")).Once()
+	env := makeScrapeEnv(t,
+		map[string]platforms.Scraper{"test-scraper": emptyPlatformScraper("test-scraper", "Test Scraper")},
+		mockDB,
+		models.MediaScrapeParams{ScraperID: "test-scraper"},
+	)
+
+	_, err := HandleMediaScrape(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist scraping status")
+	assert.False(t, IsScrapingRunning())
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrape_PersistOperationErrorClearsRunning(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -532,11 +532,11 @@ func TestHandleMediaSearch_TagsOnly(t *testing.T) {
 	expectedResults := []database.SearchResultWithCursor{
 		{
 			SystemID: "NES", Name: "RPG Game 1", Path: "/games/rpg1.nes", MediaID: 1,
-			Tags: []database.TagInfo{{Tag: "RPG", Type: "genre"}},
+			Tags: []database.TagInfo{{Tag: "rpg", Type: "genre", Label: "RPG"}},
 		},
 		{
 			SystemID: "SNES", Name: "RPG Game 2", Path: "/games/rpg2.sfc", MediaID: 2,
-			Tags: []database.TagInfo{{Tag: "RPG", Type: "genre"}},
+			Tags: []database.TagInfo{{Tag: "rpg", Type: "genre", Label: "RPG"}},
 		},
 	}
 
@@ -586,8 +586,9 @@ func TestHandleMediaSearch_TagsOnly(t *testing.T) {
 	require.True(t, ok, "Should return SearchResults")
 	assert.Len(t, searchResults.Results, 2, "Should return all tagged results")
 	assert.Len(t, searchResults.Results[0].Tags, 1, "Results should have tags")
-	assert.Equal(t, "RPG", searchResults.Results[0].Tags[0].Tag)
+	assert.Equal(t, "rpg", searchResults.Results[0].Tags[0].Tag)
 	assert.Equal(t, "genre", searchResults.Results[0].Tags[0].Type)
+	assert.Equal(t, "RPG", searchResults.Results[0].Tags[0].Label)
 
 	// Verify mock was called
 	mockMediaDB.AssertExpectations(t)

--- a/pkg/api/request_priority.go
+++ b/pkg/api/request_priority.go
@@ -40,6 +40,7 @@ func classifyAPIMethod(method string) apiRequestPriority {
 
 	switch method {
 	case models.MethodMediaTagsUpdate,
+		models.MethodMediaHistoryLatest,
 		models.MethodRun,
 		models.MethodRunScript,
 		models.MethodLaunch,

--- a/pkg/api/request_priority_test.go
+++ b/pkg/api/request_priority_test.go
@@ -35,6 +35,7 @@ func TestClassifyAPIMethod(t *testing.T) {
 		want   apiRequestPriority
 	}{
 		{"high media tags update", models.MethodMediaTagsUpdate, apiPriorityHigh},
+		{"high media history latest", models.MethodMediaHistoryLatest, apiPriorityHigh},
 		{"high run case insensitive", "RUN", apiPriorityHigh},
 		{"low media generate", models.MethodMediaGenerate, apiPriorityLow},
 		{"low media image", models.MethodMediaImage, apiPriorityLow},

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -40,6 +40,12 @@ type Database struct {
 	MediaDB MediaDBI
 }
 
+type ScrapingOperation struct {
+	ScraperID string   `json:"scraperId"`
+	Systems   []string `json:"systems"`
+	Force     bool     `json:"force"`
+}
+
 // Structs for SQL records
 
 type HistoryEntry struct {
@@ -582,6 +588,11 @@ type MediaDBI interface {
 	CreateSecondaryIndexes() error
 	SetIndexingStatus(status string) error
 	GetIndexingStatus() (string, error)
+	SetScrapingStatus(status string) error
+	GetScrapingStatus() (string, error)
+	SetScrapingOperation(operation ScrapingOperation) error
+	GetScrapingOperation() (ScrapingOperation, bool, error)
+	ClearScrapingOperation() error
 	SetLastIndexedSystem(systemID string) error
 	GetLastIndexedSystem() (string, error)
 	SetIndexingSystems(systemIDs []string) error

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -572,6 +572,51 @@ func (db *MediaDB) GetIndexingStatus() (string, error) {
 	return sqlGetIndexingStatus(db.ctx, db.sql)
 }
 
+func (db *MediaDB) SetScrapingStatus(status string) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	return sqlSetScrapingStatus(db.ctx, db.conn(), status)
+}
+
+func (db *MediaDB) GetScrapingStatus() (string, error) {
+	db.sqlMu.RLock()
+	defer db.sqlMu.RUnlock()
+	if db.sql == nil {
+		return "", ErrNullSQL
+	}
+	return sqlGetScrapingStatus(db.ctx, db.sql)
+}
+
+func (db *MediaDB) SetScrapingOperation(operation database.ScrapingOperation) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	return sqlSetScrapingOperation(db.ctx, db.conn(), operation)
+}
+
+func (db *MediaDB) GetScrapingOperation() (database.ScrapingOperation, bool, error) {
+	db.sqlMu.RLock()
+	defer db.sqlMu.RUnlock()
+	if db.sql == nil {
+		return database.ScrapingOperation{}, false, ErrNullSQL
+	}
+	return sqlGetScrapingOperation(db.ctx, db.sql)
+}
+
+func (db *MediaDB) ClearScrapingOperation() error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	return sqlClearScrapingOperation(db.ctx, db.conn())
+}
+
 func (db *MediaDB) SetLastIndexedSystem(systemID string) error {
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -1039,15 +1039,17 @@ func TestMediaDB_TagsWorkflow_Integration(t *testing.T) {
 
 	// Create tags
 	actionTag := database.Tag{
-		TypeDBID: insertedTagType.DBID,
-		Tag:      "Action",
+		TypeDBID:    insertedTagType.DBID,
+		Tag:         "Action",
+		DisplayName: "Action",
 	}
 	insertedActionTag, err := mediaDB.FindOrInsertTag(actionTag)
 	require.NoError(t, err)
 
 	platformerTag := database.Tag{
-		TypeDBID: insertedTagType.DBID,
-		Tag:      "Platformer",
+		TypeDBID:    insertedTagType.DBID,
+		Tag:         "Platformer",
+		DisplayName: "Platformer",
 	}
 	insertedPlatformerTag, err := mediaDB.FindOrInsertTag(platformerTag)
 	require.NoError(t, err)
@@ -1117,6 +1119,9 @@ func TestMediaDB_TagsWorkflow_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "Super Mario Bros", results[0].Name) // Name comes from MediaTitles.Name
+	require.Len(t, results[0].Tags, 2)
+	assert.Equal(t, "Action", results[0].Tags[0].Label)
+	assert.Equal(t, "Platformer", results[0].Tags[1].Label)
 }
 
 func TestMediaDB_RollbackTransaction_Integration(t *testing.T) {

--- a/pkg/database/mediadb/scraping_config_test.go
+++ b/pkg/database/mediadb/scraping_config_test.go
@@ -71,6 +71,25 @@ func TestGetScrapingStatusNoRows(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestGetScrapingOperationNoRow(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mediaDB := &MediaDB{sql: db, ctx: context.Background()}
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ?").
+		WithArgs(DBConfigScrapingOperation).
+		WillReturnRows(sqlmock.NewRows([]string{"Value"}))
+
+	operation, found, err := mediaDB.GetScrapingOperation()
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, database.ScrapingOperation{}, operation)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSetGetClearScrapingOperation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediadb/scraping_config_test.go
+++ b/pkg/database/mediadb/scraping_config_test.go
@@ -1,0 +1,106 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetGetScrapingStatus(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mediaDB := &MediaDB{sql: db, ctx: context.Background()}
+
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigScrapingStatus, IndexingStatusRunning).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ?").
+		WithArgs(DBConfigScrapingStatus).
+		WillReturnRows(sqlmock.NewRows([]string{"Value"}).AddRow(IndexingStatusRunning))
+
+	require.NoError(t, mediaDB.SetScrapingStatus(IndexingStatusRunning))
+	status, err := mediaDB.GetScrapingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, IndexingStatusRunning, status)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetScrapingStatusNoRows(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mediaDB := &MediaDB{sql: db, ctx: context.Background()}
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ?").
+		WithArgs(DBConfigScrapingStatus).
+		WillReturnError(sql.ErrNoRows)
+
+	status, err := mediaDB.GetScrapingStatus()
+	require.NoError(t, err)
+	assert.Empty(t, status)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSetGetClearScrapingOperation(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mediaDB := &MediaDB{sql: db, ctx: context.Background()}
+	operation := database.ScrapingOperation{
+		ScraperID: "gamelistxml",
+		Systems:   []string{"snes", "genesis"},
+		Force:     true,
+	}
+	operationJSON := `{"scraperId":"gamelistxml","systems":["snes","genesis"],"force":true}`
+
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigScrapingOperation, operationJSON).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ?").
+		WithArgs(DBConfigScrapingOperation).
+		WillReturnRows(sqlmock.NewRows([]string{"Value"}).AddRow(operationJSON))
+	mock.ExpectExec("DELETE FROM DBConfig WHERE Name = ?").
+		WithArgs(DBConfigScrapingOperation).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	require.NoError(t, mediaDB.SetScrapingOperation(operation))
+	got, found, err := mediaDB.GetScrapingOperation()
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, operation, got)
+	require.NoError(t, mediaDB.ClearScrapingOperation())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/database/mediadb/scraping_config_test.go
+++ b/pkg/database/mediadb/scraping_config_test.go
@@ -71,7 +71,7 @@ func TestGetScrapingStatusNoRows(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestGetScrapingOperationNoRow(t *testing.T) {
+func TestGetScrapingOperationNoRows(t *testing.T) {
 	t.Parallel()
 
 	db, mock, err := sqlmock.New()
@@ -81,7 +81,7 @@ func TestGetScrapingOperationNoRow(t *testing.T) {
 	mediaDB := &MediaDB{sql: db, ctx: context.Background()}
 	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ?").
 		WithArgs(DBConfigScrapingOperation).
-		WillReturnRows(sqlmock.NewRows([]string{"Value"}))
+		WillReturnError(sql.ErrNoRows)
 
 	operation, found, err := mediaDB.GetScrapingOperation()
 	require.NoError(t, err)

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -27,6 +27,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 )
 
 const (
@@ -34,6 +36,8 @@ const (
 	DBConfigOptimizationStatus              = "OptimizationStatus"
 	DBConfigOptimizationStep                = "OptimizationStep"
 	DBConfigIndexingStatus                  = "IndexingStatus"
+	DBConfigScrapingStatus                  = "ScrapingStatus"
+	DBConfigScrapingOperation               = "ScrapingOperation"
 	DBConfigLastIndexedSystem               = "LastIndexedSystem"
 	DBConfigIndexingSystems                 = "IndexingSystems"
 	DBConfigBrowseIndexVersion              = "BrowseIndexVersion"
@@ -155,6 +159,75 @@ func sqlGetIndexingStatus(ctx context.Context, db *sql.DB) (string, error) {
 		return "", fmt.Errorf("failed to get indexing status: %w", err)
 	}
 	return status, nil
+}
+
+func sqlSetScrapingStatus(ctx context.Context, db sqlQueryable, status string) error {
+	_, err := db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigScrapingStatus,
+		status,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set scraping status: %w", err)
+	}
+	return nil
+}
+
+func sqlGetScrapingStatus(ctx context.Context, db *sql.DB) (string, error) {
+	var status string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigScrapingStatus,
+	).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("failed to get scraping status: %w", err)
+	}
+	return status, nil
+}
+
+func sqlSetScrapingOperation(ctx context.Context, db sqlQueryable, operation database.ScrapingOperation) error {
+	operationJSON, err := json.Marshal(operation)
+	if err != nil {
+		return fmt.Errorf("failed to marshal scraping operation: %w", err)
+	}
+	_, err = db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigScrapingOperation,
+		string(operationJSON),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set scraping operation: %w", err)
+	}
+	return nil
+}
+
+func sqlGetScrapingOperation(ctx context.Context, db *sql.DB) (database.ScrapingOperation, bool, error) {
+	var operationJSON string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigScrapingOperation,
+	).Scan(&operationJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return database.ScrapingOperation{}, false, nil
+	} else if err != nil {
+		return database.ScrapingOperation{}, false, fmt.Errorf("failed to get scraping operation: %w", err)
+	}
+
+	var operation database.ScrapingOperation
+	if err := json.Unmarshal([]byte(operationJSON), &operation); err != nil {
+		return database.ScrapingOperation{}, false, fmt.Errorf("failed to unmarshal scraping operation: %w", err)
+	}
+	return operation, true, nil
+}
+
+func sqlClearScrapingOperation(ctx context.Context, db sqlQueryable) error {
+	_, err := db.ExecContext(ctx, "DELETE FROM DBConfig WHERE Name = ?", DBConfigScrapingOperation)
+	if err != nil {
+		return fmt.Errorf("failed to clear scraping operation: %w", err)
+	}
+	return nil
 }
 
 func sqlSetLastIndexedSystem(ctx context.Context, db sqlQueryable, systemID string) error {

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -2461,7 +2461,7 @@ func (db *MediaDB) GetMediaTagsByMediaDBID(ctx context.Context, mediaDBID int64)
 	}
 
 	stmt, err := db.sql.PrepareContext(ctx, `
-		SELECT Tags.Tag, TagTypes.Type
+		SELECT Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTags
 		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
@@ -2504,7 +2504,7 @@ func (db *MediaDB) GetMediaTagsByMediaDBIDs(
 	args := int64Args(mediaDBIDs)
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
 	rows, err := db.sql.QueryContext(ctx, `
-		SELECT MediaTags.MediaDBID, Tags.Tag, TagTypes.Type
+		SELECT MediaTags.MediaDBID, Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTags
 		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
@@ -2533,7 +2533,7 @@ func (db *MediaDB) GetMediaTitleTagsByMediaTitleDBID(
 	}
 
 	stmt, err := db.sql.PrepareContext(ctx, `
-		SELECT Tags.Tag, TagTypes.Type
+		SELECT Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTitleTags
 		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
@@ -2576,7 +2576,7 @@ func (db *MediaDB) GetMediaTitleTagsByMediaTitleDBIDs(
 	args := int64Args(mediaTitleDBIDs)
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
 	rows, err := db.sql.QueryContext(ctx, `
-		SELECT MediaTitleTags.MediaTitleDBID, Tags.Tag, TagTypes.Type
+		SELECT MediaTitleTags.MediaTitleDBID, Tags.Tag, TagTypes.Type, Tags.DisplayName
 		FROM MediaTitleTags
 		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
@@ -2683,7 +2683,7 @@ func scanTagInfos(rows *sql.Rows) ([]database.TagInfo, error) {
 	result := make([]database.TagInfo, 0)
 	for rows.Next() {
 		var t database.TagInfo
-		if err := rows.Scan(&t.Tag, &t.Type); err != nil {
+		if err := rows.Scan(&t.Tag, &t.Type, &t.Label); err != nil {
 			return nil, fmt.Errorf("failed to scan TagInfo: %w", err)
 		}
 		t.Tag = tags.UnpadTagValue(t.Tag)
@@ -2697,7 +2697,7 @@ func scanGroupedTagInfos(rows *sql.Rows) (map[int64][]database.TagInfo, error) {
 	for rows.Next() {
 		var dbid int64
 		var t database.TagInfo
-		if err := rows.Scan(&dbid, &t.Tag, &t.Type); err != nil {
+		if err := rows.Scan(&dbid, &t.Tag, &t.Type, &t.Label); err != nil {
 			return nil, fmt.Errorf("failed to scan grouped TagInfo: %w", err)
 		}
 		t.Tag = tags.UnpadTagValue(t.Tag)

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -1435,10 +1435,14 @@ func TestGetMediaBatchMetadata_RoundTrip(t *testing.T) {
 	`, zeldaPath)
 	require.NoError(t, err)
 
-	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, []database.TagInfo{{Type: "developer", Tag: "nintendo"}}))
-	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 2, []database.TagInfo{{Type: "developer", Tag: "capcom"}}))
-	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 1, []database.TagInfo{{Type: "developer", Tag: "title-one"}}))
-	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 2, []database.TagInfo{{Type: "developer", Tag: "title-two"}}))
+	nintendoTag := []database.TagInfo{{Type: "developer", Tag: "nintendo", Label: "Nintendo"}}
+	capcomTag := []database.TagInfo{{Type: "developer", Tag: "capcom", Label: "Capcom"}}
+	titleOneTag := []database.TagInfo{{Type: "developer", Tag: "title-one", Label: "Title One"}}
+	titleTwoTag := []database.TagInfo{{Type: "developer", Tag: "title-two", Label: "Title Two"}}
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, nintendoTag))
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 2, capcomTag))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 1, titleOneTag))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 2, titleTwoTag))
 	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, 1, []database.MediaProperty{{
 		TypeTag: "property:image-boxart",
 		Text:    filepath.Join("art", "mario.png"),
@@ -1465,15 +1469,23 @@ func TestGetMediaBatchMetadata_RoundTrip(t *testing.T) {
 	assert.Equal(t, zeldaPath, rows[2].Path)
 	assert.Equal(t, "Zelda", rows[2].Title.Name)
 
+	singleMediaTags, err := mediaDB.GetMediaTagsByMediaDBID(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []database.TagInfo{{Tag: "nintendo", Type: "developer", Label: "Nintendo"}}, singleMediaTags)
+
+	singleTitleTags, err := mediaDB.GetMediaTitleTagsByMediaTitleDBID(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []database.TagInfo{{Tag: "title-one", Type: "developer", Label: "Title One"}}, singleTitleTags)
+
 	mediaTags, err := mediaDB.GetMediaTagsByMediaDBIDs(ctx, []int64{1, 2})
 	require.NoError(t, err)
-	assert.Equal(t, []database.TagInfo{{Tag: "nintendo", Type: "developer"}}, mediaTags[1])
-	assert.Equal(t, []database.TagInfo{{Tag: "capcom", Type: "developer"}}, mediaTags[2])
+	assert.Equal(t, []database.TagInfo{{Tag: "nintendo", Type: "developer", Label: "Nintendo"}}, mediaTags[1])
+	assert.Equal(t, []database.TagInfo{{Tag: "capcom", Type: "developer", Label: "Capcom"}}, mediaTags[2])
 
 	titleTags, err := mediaDB.GetMediaTitleTagsByMediaTitleDBIDs(ctx, []int64{1, 2})
 	require.NoError(t, err)
-	assert.Equal(t, []database.TagInfo{{Tag: "title-one", Type: "developer"}}, titleTags[1])
-	assert.Equal(t, []database.TagInfo{{Tag: "title-two", Type: "developer"}}, titleTags[2])
+	assert.Equal(t, []database.TagInfo{{Tag: "title-one", Type: "developer", Label: "Title One"}}, titleTags[1])
+	assert.Equal(t, []database.TagInfo{{Tag: "title-two", Type: "developer", Label: "Title Two"}}, titleTags[2])
 
 	mediaProps, err := mediaDB.GetMediaPropertiesByMediaDBIDs(ctx, []int64{1, 2})
 	require.NoError(t, err)

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -68,6 +68,7 @@ func fetchAndAttachTags(
 		SELECT
 			Media.DBID as MediaDBID,
 			Tags.Tag,
+			Tags.DisplayName,
 			TagTypes.Type
 		FROM Media
 		JOIN MediaTags ON MediaTags.MediaDBID = Media.DBID
@@ -80,6 +81,7 @@ func fetchAndAttachTags(
 		SELECT
 			Media.DBID as MediaDBID,
 			Tags.Tag,
+			Tags.DisplayName,
 			TagTypes.Type
 		FROM Media
 		JOIN MediaTitleTags ON MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
@@ -120,14 +122,13 @@ func fetchAndAttachTags(
 	// Build per-mediaID tag lists. The same (Tag, Type) tuple can appear in
 	// both UNION ALL legs (file-level and title-level), so dedupe with a set.
 	tagsMap := make(map[int64][]database.TagInfo)
-	seen := make(map[int64]map[database.TagInfo]struct{})
+	seen := make(map[int64]map[tagKey]int)
 	for tagsRows.Next() {
-		var mediaID int64
-		var tag, tagType string
-		if scanErr := tagsRows.Scan(&mediaID, &tag, &tagType); scanErr != nil {
+		tagRow, scanErr := scanMediaTagRow(tagsRows)
+		if scanErr != nil {
 			return fmt.Errorf("failed to scan tags result: %w", scanErr)
 		}
-		appendTagInfo(tagsMap, seen, mediaID, tag, tagType)
+		appendTagInfo(tagsMap, seen, tagRow.mediaID, tagRow.tag, tagRow.tagType, tagRow.label)
 	}
 	if err = tagsRows.Err(); err != nil {
 		return fmt.Errorf("tags rows iteration error: %w", err)
@@ -172,6 +173,7 @@ func fetchAndAttachTagsByResultIDs(
 			0 as SourceKind,
 			MediaTags.MediaDBID as SourceDBID,
 			Tags.Tag,
+			Tags.DisplayName,
 			TagTypes.Type
 		FROM MediaTags
 		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
@@ -184,6 +186,7 @@ func fetchAndAttachTagsByResultIDs(
 			1 as SourceKind,
 			MediaTitleTags.MediaTitleDBID as SourceDBID,
 			Tags.Tag,
+			Tags.DisplayName,
 			TagTypes.Type
 		FROM MediaTitleTags
 		JOIN Tags ON Tags.DBID = MediaTitleTags.TagDBID
@@ -219,21 +222,19 @@ func fetchAndAttachTagsByResultIDs(
 	}()
 
 	tagsMap := make(map[int64][]database.TagInfo)
-	seen := make(map[int64]map[database.TagInfo]struct{})
+	seen := make(map[int64]map[tagKey]int)
 	for tagsRows.Next() {
-		var sourceKind int
-		var sourceID int64
-		var tag, tagType string
-		if scanErr := tagsRows.Scan(&sourceKind, &sourceID, &tag, &tagType); scanErr != nil {
+		tagRow, scanErr := scanSourceTagRow(tagsRows)
+		if scanErr != nil {
 			return fmt.Errorf("failed to scan tags result: %w", scanErr)
 		}
 
-		mediaIDsForTag := []int64{sourceID}
-		if sourceKind == 1 {
-			mediaIDsForTag = tagIDs.titleToMediaIDs[sourceID]
+		mediaIDsForTag := []int64{tagRow.sourceID}
+		if tagRow.sourceKind == 1 {
+			mediaIDsForTag = tagIDs.titleToMediaIDs[tagRow.sourceID]
 		}
 		for _, mediaID := range mediaIDsForTag {
-			appendTagInfo(tagsMap, seen, mediaID, tag, tagType)
+			appendTagInfo(tagsMap, seen, mediaID, tagRow.tag, tagRow.tagType, tagRow.label)
 		}
 	}
 	if err = tagsRows.Err(); err != nil {
@@ -295,26 +296,99 @@ func resultIDsHaveTags(ctx context.Context, db sqlQueryable, mediaIDs, titleIDs 
 	return hasTags, nil
 }
 
+func scanMediaTagRow(rows *sql.Rows) (tagScanValues, error) {
+	dest, values, err := tagScanDest(rows)
+	if err != nil {
+		return tagScanValues{}, err
+	}
+	if err := rows.Scan(dest...); err != nil {
+		return tagScanValues{}, fmt.Errorf("scan media tag row: %w", err)
+	}
+	return *values, nil
+}
+
+func scanSourceTagRow(rows *sql.Rows) (tagScanValues, error) {
+	dest, values, err := tagScanDest(rows)
+	if err != nil {
+		return tagScanValues{}, err
+	}
+	if err := rows.Scan(dest...); err != nil {
+		return tagScanValues{}, fmt.Errorf("scan source tag row: %w", err)
+	}
+	return *values, nil
+}
+
+type tagScanValues struct {
+	tag        string
+	tagType    string
+	label      string
+	mediaID    int64
+	sourceID   int64
+	sourceKind int
+}
+
+func tagScanDest(rows *sql.Rows) ([]any, *tagScanValues, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, nil, fmt.Errorf("get tag row columns: %w", err)
+	}
+	values := &tagScanValues{}
+	dest := make([]any, len(columns))
+	hasTag := false
+	hasType := false
+	for i, column := range columns {
+		switch column {
+		case "MediaDBID":
+			dest[i] = &values.mediaID
+		case "SourceDBID":
+			dest[i] = &values.sourceID
+		case "SourceKind":
+			dest[i] = &values.sourceKind
+		case "Tag":
+			hasTag = true
+			dest[i] = &values.tag
+		case "Type":
+			hasType = true
+			dest[i] = &values.tagType
+		case "DisplayName":
+			dest[i] = &values.label
+		default:
+			var ignored any
+			dest[i] = &ignored
+		}
+	}
+	if !hasTag || !hasType {
+		return nil, nil, errors.New("tag rows missing Tag or Type column")
+	}
+	return dest, values, nil
+}
+
 func appendTagInfo(
 	tagsMap map[int64][]database.TagInfo,
-	seen map[int64]map[database.TagInfo]struct{},
+	seen map[int64]map[tagKey]int,
 	mediaID int64,
 	tag string,
 	tagType string,
+	label string,
 ) {
 	tagInfo := database.TagInfo{
-		Tag:  dbtags.UnpadTagValue(tag),
-		Type: tagType,
+		Tag:   dbtags.UnpadTagValue(tag),
+		Type:  tagType,
+		Label: label,
 	}
+	key := tagKey{typ: tagInfo.Type, tag: tagInfo.Tag}
 	mediaSeen, ok := seen[mediaID]
 	if !ok {
-		mediaSeen = make(map[database.TagInfo]struct{})
+		mediaSeen = make(map[tagKey]int)
 		seen[mediaID] = mediaSeen
 	}
-	if _, dup := mediaSeen[tagInfo]; dup {
+	if index, dup := mediaSeen[key]; dup {
+		if tagsMap[mediaID][index].Label == "" && label != "" {
+			tagsMap[mediaID][index].Label = label
+		}
 		return
 	}
-	mediaSeen[tagInfo] = struct{}{}
+	mediaSeen[key] = len(tagsMap[mediaID])
 	tagsMap[mediaID] = append(tagsMap[mediaID], tagInfo)
 }
 

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -67,7 +67,7 @@ func TestFetchAndAttachTags_SingleResultNoTags(t *testing.T) {
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
 		WithArgs(int64(1), int64(1)).
-		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}))
 
 	err = fetchAndAttachTags(context.Background(), db, results)
 	require.NoError(t, err)
@@ -92,10 +92,10 @@ func TestFetchAndAttachTags_SingleResultWithTags(t *testing.T) {
 	}
 
 	// Mock the tags query with multiple tags
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Action", "genre").
-		AddRow(int64(1), "Nintendo", "publisher").
-		AddRow(int64(1), "1985", "year")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Action", "genre", "Action").
+		AddRow(int64(1), "Nintendo", "publisher", "Nintendo").
+		AddRow(int64(1), "1985", "year", "1985")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -109,6 +109,7 @@ func TestFetchAndAttachTags_SingleResultWithTags(t *testing.T) {
 	assert.Equal(t, "genre", results[0].Tags[0].Type)
 	assert.Equal(t, "Nintendo", results[0].Tags[1].Tag)
 	assert.Equal(t, "publisher", results[0].Tags[1].Type)
+	assert.Equal(t, "Nintendo", results[0].Tags[1].Label)
 	assert.Equal(t, "1985", results[0].Tags[2].Tag)
 	assert.Equal(t, "year", results[0].Tags[2].Type)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -130,10 +131,10 @@ func TestFetchAndAttachTags_YearTagPresent(t *testing.T) {
 	}
 
 	// Mock the tags query with a 4-digit year tag
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Action", "genre").
-		AddRow(int64(1), "1985", "year").
-		AddRow(int64(1), "Nintendo", "publisher")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Action", "genre", "Action").
+		AddRow(int64(1), "1985", "year", "1985").
+		AddRow(int64(1), "Nintendo", "publisher", "Nintendo")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -202,8 +203,8 @@ func TestFetchAndAttachTags_VariousYearTags(t *testing.T) {
 				},
 			}
 
-			tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-				AddRow(int64(1), tt.yearTag, tt.yearType)
+			tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+				AddRow(int64(1), tt.yearTag, tt.yearType, tt.yearTag)
 
 			mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 				ExpectQuery().
@@ -249,13 +250,13 @@ func TestFetchAndAttachTags_MultipleResults(t *testing.T) {
 	}
 
 	// Mock the tags query with tags for multiple media items
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Action", "genre").
-		AddRow(int64(1), "1985", "year").
-		AddRow(int64(2), "Adventure", "genre").
-		AddRow(int64(2), "1986", "year").
-		AddRow(int64(3), "Platform", "genre").
-		AddRow(int64(3), "1990", "year")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Action", "genre", "Action").
+		AddRow(int64(1), "1985", "year", "1985").
+		AddRow(int64(2), "Adventure", "genre", "Adventure").
+		AddRow(int64(2), "1986", "year", "1986").
+		AddRow(int64(3), "Platform", "genre", "Platform").
+		AddRow(int64(3), "1990", "year", "1990")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -298,10 +299,10 @@ func TestFetchAndAttachTags_ResultTitleIDsAvoidMediaJoin(t *testing.T) {
 		{MediaID: 3, MediaTitleID: 30, SystemID: "snes", Name: "Other", Path: filepath.Join("games", "c.sfc")},
 	}
 
-	tagRows := sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "Type"}).
-		AddRow(0, int64(1), "Rev A", "rev").
-		AddRow(1, int64(10), "Action", "genre").
-		AddRow(1, int64(30), "1990", "year")
+	tagRows := sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(0, int64(1), "Rev A", "rev", "Revision A").
+		AddRow(1, int64(10), "Action", "genre", "Action").
+		AddRow(1, int64(30), "1990", "year", "1990")
 
 	mock.ExpectQuery(`SELECT EXISTS.*MediaTags.*MediaTitleTags`).
 		WithArgs(int64(1), int64(2), int64(3), int64(10), int64(30)).
@@ -315,12 +316,26 @@ func TestFetchAndAttachTags_ResultTitleIDsAvoidMediaJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []database.TagInfo{
-		{Tag: "Action", Type: "genre"},
-		{Tag: "Rev A", Type: "rev"},
+		{Tag: "Action", Type: "genre", Label: "Action"},
+		{Tag: "Rev A", Type: "rev", Label: "Revision A"},
 	}, results[0].Tags)
-	assert.Equal(t, []database.TagInfo{{Tag: "Action", Type: "genre"}}, results[1].Tags)
-	assert.Equal(t, []database.TagInfo{{Tag: "1990", Type: "year"}}, results[2].Tags)
+	assert.Equal(t, []database.TagInfo{{Tag: "Action", Type: "genre", Label: "Action"}}, results[1].Tags)
+	assert.Equal(t, []database.TagInfo{{Tag: "1990", Type: "year", Label: "1990"}}, results[2].Tags)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAppendTagInfo_DedupesByTypeTagAndKeepsLabel(t *testing.T) {
+	t.Parallel()
+
+	tagsMap := make(map[int64][]database.TagInfo)
+	seen := make(map[int64]map[tagKey]int)
+
+	appendTagInfo(tagsMap, seen, 1, "nintendo", "publisher", "")
+	appendTagInfo(tagsMap, seen, 1, "nintendo", "publisher", "Nintendo")
+	appendTagInfo(tagsMap, seen, 1, "nintendo", "publisher", "Nintendo Co.")
+
+	require.Len(t, tagsMap[1], 1)
+	assert.Equal(t, database.TagInfo{Tag: "nintendo", Type: "publisher", Label: "Nintendo"}, tagsMap[1][0])
 }
 
 func TestFetchAndAttachTags_ResultTitleIDsNoTagsSkipsFullFetch(t *testing.T) {
@@ -363,9 +378,9 @@ func TestFetchAndAttachTags_TagsWithMissingTypeDBID(t *testing.T) {
 	}
 
 	// Mock tags where some have empty type (from LEFT JOIN with missing TypeDBID)
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "untyped-tag", "").
-		AddRow(int64(1), "genre-tag", "genre")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "untyped-tag", "", "Untyped Tag").
+		AddRow(int64(1), "genre-tag", "genre", "Genre Tag")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -435,8 +450,8 @@ func TestFetchAndAttachTags_ScanError(t *testing.T) {
 	}
 
 	// Return row with wrong column types to cause scan error
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow("invalid", "tag", "type") // MediaDBID should be int64, not string
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow("invalid", "tag", "type", "label") // MediaDBID should be int64, not string
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -460,8 +475,8 @@ func TestFetchAndAttachTags_RowsError(t *testing.T) {
 	}
 
 	rowsErr := errors.New("rows iteration error")
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "tag1", "type1").
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "tag1", "type1", "Tag 1").
 		RowError(0, rowsErr)
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
@@ -491,11 +506,11 @@ func TestFetchAndAttachTags_MultipleYearTags(t *testing.T) {
 	}
 
 	// Multiple year tags - all should be attached
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Action", "genre").
-		AddRow(int64(1), "1985", "year").
-		AddRow(int64(1), "1986", "year").
-		AddRow(int64(1), "1987", "year")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Action", "genre", "Action").
+		AddRow(int64(1), "1985", "year", "1985").
+		AddRow(int64(1), "1986", "year", "1986").
+		AddRow(int64(1), "1987", "year", "1987")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -533,9 +548,9 @@ func TestSqlSearchMediaWithFilters_IntegrationWithTags(t *testing.T) {
 		WillReturnRows(mediaRows)
 
 	// Mock the tags query
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Action", "genre").
-		AddRow(int64(1), "1985", "year")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Action", "genre", "Action").
+		AddRow(int64(1), "1985", "year", "1985")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -571,8 +586,8 @@ func TestSqlSearchMediaBySlug_IntegrationWithTags(t *testing.T) {
 		WillReturnRows(mediaRows)
 
 	// Mock the tags query
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Platform", "genre")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Platform", "genre", "Platform")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -606,8 +621,8 @@ func TestSqlSearchMediaBySecondarySlug_IntegrationWithTags(t *testing.T) {
 		WillReturnRows(mediaRows)
 
 	// Mock the tags query
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Nintendo", "publisher")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Nintendo", "publisher", "Nintendo")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -642,10 +657,10 @@ func TestSqlSearchMediaBySlugPrefix_IntegrationWithTags(t *testing.T) {
 		WillReturnRows(mediaRows)
 
 	// Mock the tags query
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Platform", "genre").
-		AddRow(int64(2), "Platform", "genre").
-		AddRow(int64(2), "Sequel", "series")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Platform", "genre", "Platform").
+		AddRow(int64(2), "Platform", "genre", "Platform").
+		AddRow(int64(2), "Sequel", "series", "Sequel")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().
@@ -681,10 +696,10 @@ func TestSqlSearchMediaBySlugIn_IntegrationWithTags(t *testing.T) {
 		WillReturnRows(mediaRows)
 
 	// Mock the tags query
-	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}).
-		AddRow(int64(1), "Platform", "genre").
-		AddRow(int64(2), "Adventure", "genre").
-		AddRow(int64(2), "RPG", "genre")
+	tagRows := sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type", "DisplayName"}).
+		AddRow(int64(1), "Platform", "genre", "Platform").
+		AddRow(int64(2), "Adventure", "genre", "Adventure").
+		AddRow(int64(2), "RPG", "genre", "RPG")
 
 	mock.ExpectPrepare(`SELECT.*MediaDBID.*Tag.*Type FROM`).
 		ExpectQuery().

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -142,6 +142,12 @@ func checkAndResumeScraping(
 	}
 	err = methods.ResumeMediaScrape(&env, operation)
 	if err != nil {
+		if setErr := db.MediaDB.SetScrapingStatus(mediadb.IndexingStatusFailed); setErr != nil {
+			log.Warn().Err(setErr).Msg("failed to persist scraping auto-resume failure status")
+		}
+		if clearErr := db.MediaDB.ClearScrapingOperation(); clearErr != nil {
+			log.Warn().Err(clearErr).Msg("failed to clear scraping operation after auto-resume failure")
+		}
 		log.Error().Err(err).Str("scraper", operation.ScraperID).Msg("failed to start auto-resume of media scraping")
 	}
 }

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -24,6 +24,7 @@ package service
 import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/notifications"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -92,6 +93,59 @@ func checkAndResumeIndexing(
 }
 
 // checkAndResumeOptimization checks if optimization was interrupted and automatically resumes it
+func checkAndResumeScraping(
+	pl platforms.Platform,
+	cfg *config.Instance,
+	db *database.Database,
+	st *state.State,
+	pauser *syncutil.Pauser,
+) {
+	status, err := db.MediaDB.GetScrapingStatus()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to get scraping status during startup check")
+		return
+	}
+	if status != mediadb.IndexingStatusRunning && status != mediadb.IndexingStatusPending {
+		log.Debug().Msgf("scraping status is '%s', no auto-resume needed", status)
+		return
+	}
+
+	operation, found, err := db.MediaDB.GetScrapingOperation()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to get scraping operation during startup check")
+		return
+	}
+	if !found || operation.ScraperID == "" {
+		log.Warn().Msg("scraping marked incomplete but no scraping operation was stored")
+		if setErr := db.MediaDB.SetScrapingStatus(mediadb.IndexingStatusFailed); setErr != nil {
+			log.Warn().Err(setErr).Msg("failed to mark incomplete scraping as failed")
+		}
+		return
+	}
+
+	if _, ok := pl.Scrapers(cfg)[operation.ScraperID]; !ok {
+		log.Warn().Str("scraper", operation.ScraperID).Msg("stored scraper not available; marking scrape failed")
+		if setErr := db.MediaDB.SetScrapingStatus(mediadb.IndexingStatusFailed); setErr != nil {
+			log.Warn().Err(setErr).Msg("failed to mark unavailable scraper as failed")
+		}
+		return
+	}
+
+	log.Info().Str("scraper", operation.ScraperID).Msg("detected interrupted media scraping, automatically resuming")
+	env := requests.RequestEnv{
+		Context:      st.GetContext(),
+		Platform:     pl,
+		Config:       cfg,
+		State:        st,
+		Database:     db,
+		ScrapePauser: pauser,
+	}
+	err = methods.ResumeMediaScrape(&env, operation)
+	if err != nil {
+		log.Error().Err(err).Str("scraper", operation.ScraperID).Msg("failed to start auto-resume of media scraping")
+	}
+}
+
 func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notification, pauser *syncutil.Pauser) {
 	status, err := db.MediaDB.GetOptimizationStatus()
 	if err != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/groovyproxy"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
@@ -58,6 +59,32 @@ type StartResult struct {
 	Stop             func() error
 	Done             <-chan struct{}
 	RestartRequested func() bool
+}
+
+func rebuildStartupSlugSearchCache(mediaDB database.MediaDBI, slugCacheLoaded bool) {
+	if mediaDB == nil || slugCacheLoaded {
+		return
+	}
+	indexingStatus, statusErr := mediaDB.GetIndexingStatus()
+	if statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to get indexing status before slug cache rebuild")
+		return
+	}
+	if indexingStatus == mediadb.IndexingStatusRunning || indexingStatus == mediadb.IndexingStatusPending {
+		log.Debug().Str("status", indexingStatus).Msg("skipping slug search cache rebuild during indexing")
+		return
+	}
+
+	mediaDB.TrackBackgroundOperation()
+	defer mediaDB.BackgroundOperationDone()
+	if cacheErr := mediaDB.RebuildSlugSearchCache(); cacheErr != nil {
+		log.Warn().Err(cacheErr).Msg("failed to build slug search cache")
+		return
+	}
+	if persistErr := mediaDB.PersistSlugSearchCache(); persistErr != nil {
+		log.Warn().Err(persistErr).
+			Msg("failed to persist slug search cache after startup rebuild")
+	}
 }
 
 func Start(
@@ -252,28 +279,7 @@ func Start(
 			checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
 			checkAndResumeOptimization(db, st.Notifications, indexPauser)
 
-			if db.MediaDB != nil && !slugCacheLoaded {
-				indexingStatus, statusErr := db.MediaDB.GetIndexingStatus()
-				if statusErr != nil {
-					log.Warn().Err(statusErr).Msg("failed to get indexing status before slug cache rebuild")
-					return
-				}
-				if indexingStatus == mediadb.IndexingStatusRunning || indexingStatus == mediadb.IndexingStatusPending {
-					log.Debug().Str("status", indexingStatus).Msg("skipping slug search cache rebuild during indexing")
-					return
-				}
-
-				db.MediaDB.TrackBackgroundOperation()
-				defer db.MediaDB.BackgroundOperationDone()
-				if cacheErr := db.MediaDB.RebuildSlugSearchCache(); cacheErr != nil {
-					log.Warn().Err(cacheErr).Msg("failed to build slug search cache")
-					return
-				}
-				if persistErr := db.MediaDB.PersistSlugSearchCache(); persistErr != nil {
-					log.Warn().Err(persistErr).
-						Msg("failed to persist slug search cache after startup rebuild")
-				}
-			}
+			rebuildStartupSlugSearchCache(db.MediaDB, slugCacheLoaded)
 		},
 	)
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/groovyproxy"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -252,6 +253,16 @@ func Start(
 			checkAndResumeOptimization(db, st.Notifications, indexPauser)
 
 			if db.MediaDB != nil && !slugCacheLoaded {
+				indexingStatus, statusErr := db.MediaDB.GetIndexingStatus()
+				if statusErr != nil {
+					log.Warn().Err(statusErr).Msg("failed to get indexing status before slug cache rebuild")
+					return
+				}
+				if indexingStatus == mediadb.IndexingStatusRunning || indexingStatus == mediadb.IndexingStatusPending {
+					log.Debug().Str("status", indexingStatus).Msg("skipping slug search cache rebuild during indexing")
+					return
+				}
+
 				db.MediaDB.TrackBackgroundOperation()
 				defer db.MediaDB.BackgroundOperationDone()
 				if cacheErr := db.MediaDB.RebuildSlugSearchCache(); cacheErr != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -211,43 +211,60 @@ func Start(
 		log.Warn().Err(discoveryErr).Msg("mDNS discovery initialization failed")
 	}
 
-	// Load persisted slug + tag caches before launching background work so
-	// the launcher's first media.browse hits a warm cache. Both fall
-	// through to (false, nil) on a missing/stale/version-mismatched file;
-	// the rebuild path below covers that case.
-	var tagCacheLoaded, slugCacheLoaded bool
-	if db.MediaDB != nil {
-		tagCacheStarted := time.Now()
-		loaded, loadErr := db.MediaDB.LoadCachedTagCache()
-		if loadErr != nil {
-			log.Warn().Err(loadErr).Msg("failed to load cached tag cache from disk")
-		}
-		log.Debug().
-			Bool("loaded", loaded).
-			Dur("duration", time.Since(tagCacheStarted)).
-			Msg("cached tag cache load completed")
-		tagCacheLoaded = loaded
-		slugCacheStarted := time.Now()
-		loaded, loadErr = db.MediaDB.LoadCachedSlugSearchCache()
-		if loadErr != nil {
-			log.Warn().Err(loadErr).Msg("failed to load cached slug search cache from disk")
-		}
-		log.Debug().
-			Bool("loaded", loaded).
-			Dur("duration", time.Since(slugCacheStarted)).
-			Msg("cached slug search cache load completed")
-		slugCacheLoaded = loaded
-	}
+	checkAndResumeScraping(pl, cfg, db, st, scrapePauser)
 
-	backgroundWG.Add(1)
-	go func() {
-		defer backgroundWG.Done()
-		if db == nil {
-			log.Warn().Msg("skipping startup maintenance: database is nil")
-			return
-		}
-		runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)
-	}()
+	idleSched.Schedule(
+		st.GetContext(), "startup-media-work",
+		5*time.Second, 300*time.Second,
+		func(_ context.Context) {
+			if db == nil {
+				log.Warn().Msg("skipping startup media work: database is nil")
+				return
+			}
+
+			var tagCacheLoaded, slugCacheLoaded bool
+			if db.MediaDB != nil {
+				tagCacheStarted := time.Now()
+				loaded, loadErr := db.MediaDB.LoadCachedTagCache()
+				if loadErr != nil {
+					log.Warn().Err(loadErr).Msg("failed to load cached tag cache from disk")
+				}
+				log.Debug().
+					Bool("loaded", loaded).
+					Dur("duration", time.Since(tagCacheStarted)).
+					Msg("cached tag cache load completed")
+				tagCacheLoaded = loaded
+
+				slugCacheStarted := time.Now()
+				loaded, loadErr = db.MediaDB.LoadCachedSlugSearchCache()
+				if loadErr != nil {
+					log.Warn().Err(loadErr).Msg("failed to load cached slug search cache from disk")
+				}
+				log.Debug().
+					Bool("loaded", loaded).
+					Dur("duration", time.Since(slugCacheStarted)).
+					Msg("cached slug search cache load completed")
+				slugCacheLoaded = loaded
+			}
+
+			runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)
+			checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
+			checkAndResumeOptimization(db, st.Notifications, indexPauser)
+
+			if db.MediaDB != nil && !slugCacheLoaded {
+				db.MediaDB.TrackBackgroundOperation()
+				defer db.MediaDB.BackgroundOperationDone()
+				if cacheErr := db.MediaDB.RebuildSlugSearchCache(); cacheErr != nil {
+					log.Warn().Err(cacheErr).Msg("failed to build slug search cache")
+					return
+				}
+				if persistErr := db.MediaDB.PersistSlugSearchCache(); persistErr != nil {
+					log.Warn().Err(persistErr).
+						Msg("failed to persist slug search cache after startup rebuild")
+				}
+			}
+		},
+	)
 
 	// Defer non-critical "run eventually" work to the idle scheduler so it
 	// doesn't compete with the launcher's first request for the single
@@ -287,40 +304,6 @@ func Start(
 	)
 	go watchGameForIndexPause(st.GetContext(), notifBroker, st, st.Notifications, indexPauser)
 	go watchGameForScrapePause(st.GetContext(), notifBroker, st, st.Notifications, scrapePauser)
-
-	log.Info().Msg("checking for interrupted media indexing")
-	backgroundWG.Add(1)
-	go func() {
-		defer backgroundWG.Done()
-		checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
-	}()
-
-	log.Info().Msg("checking for interrupted media optimization")
-	backgroundWG.Add(1)
-	go func() {
-		defer backgroundWG.Done()
-		checkAndResumeOptimization(db, st.Notifications, indexPauser)
-	}()
-
-	// Build the slug search cache after the API is listening so it doesn't
-	// block startup. If LoadCachedSlugSearchCache already populated it from
-	// disk we skip the SQL rebuild — that's the whole point of persisting.
-	if db.MediaDB != nil && !slugCacheLoaded {
-		db.MediaDB.TrackBackgroundOperation()
-		go func() {
-			defer db.MediaDB.BackgroundOperationDone()
-			if cacheErr := db.MediaDB.RebuildSlugSearchCache(); cacheErr != nil {
-				log.Warn().Err(cacheErr).Msg("failed to build slug search cache")
-				return
-			}
-			// Best-effort persist so the next cold boot can skip the
-			// rebuild. A write failure leaves the running cache intact.
-			if persistErr := db.MediaDB.PersistSlugSearchCache(); persistErr != nil {
-				log.Warn().Err(persistErr).
-					Msg("failed to persist slug search cache after startup rebuild")
-			}
-		}()
-	}
 
 	log.Info().Msg("starting publishers")
 	publisherNotifications, _ := notifBroker.Subscribe(100)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
@@ -405,6 +406,44 @@ func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {
 
 	// Verify that no indexing was triggered for failed status
 	mockMediaDB.AssertNotCalled(t, "GetOptimizationStatus")
+}
+
+func TestCheckAndResumeScraping_StartFailurePersistsTerminalState(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	methods.ClearScrapingStatus()
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	operation := database.ScrapingOperation{ScraperID: "test-scraper"}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	mockMediaDB.On("GetScrapingOperation").Return(operation, true, nil).Once()
+	mockMediaDB.On("SetScrapingOperation", operation).Return(assert.AnError).Once()
+	mockMediaDB.On("SetScrapingStatus", mediadb.IndexingStatusFailed).Return(nil).Once()
+	mockMediaDB.On("ClearScrapingOperation").Return(nil).Once()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Scrapers", cfg).Return(map[string]platforms.Scraper{
+		"test-scraper": {
+			ID:   "test-scraper",
+			Name: "Test Scraper",
+			Scrape: func(
+				context.Context, *config.Instance, platforms.Platform, afero.Fs,
+				*database.Database, scraper.ScrapeOptions, platforms.ScraperCustomOptions,
+				chan<- scraper.ScrapeUpdate,
+			) error {
+				return nil
+			},
+		},
+	}).Twice()
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	checkAndResumeScraping(mockPlatform, cfg, &database.Database{MediaDB: mockMediaDB}, st, nil)
+
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
 }
 
 func TestCheckAndResumeOptimization_RunningStatus(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -408,6 +408,39 @@ func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {
 	mockMediaDB.AssertNotCalled(t, "GetOptimizationStatus")
 }
 
+func TestCheckAndResumeScraping_MissingOperationMarksFailed(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	methods.ClearScrapingStatus()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	mockMediaDB.On("GetScrapingOperation").Return(database.ScrapingOperation{}, false, nil).Once()
+	mockMediaDB.On("SetScrapingStatus", mediadb.IndexingStatusFailed).Return(nil).Once()
+
+	checkAndResumeScraping(
+		mocks.NewMockPlatform(), nil, &database.Database{MediaDB: mockMediaDB}, nil, nil,
+	)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestCheckAndResumeScraping_UnavailableScraperMarksFailed(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	methods.ClearScrapingStatus()
+	operation := database.ScrapingOperation{ScraperID: "missing-scraper"}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	mockMediaDB.On("GetScrapingOperation").Return(operation, true, nil).Once()
+	mockMediaDB.On("SetScrapingStatus", mediadb.IndexingStatusFailed).Return(nil).Once()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Scrapers", (*config.Instance)(nil)).Return(map[string]platforms.Scraper{}).Once()
+
+	checkAndResumeScraping(mockPlatform, nil, &database.Database{MediaDB: mockMediaDB}, nil, nil)
+
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCheckAndResumeScraping_StartFailurePersistsTerminalState(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	methods.ClearScrapingStatus()

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -162,6 +162,45 @@ func TestCleanupHistoryRetention_CancelledBeforeMediaHistory(t *testing.T) {
 	mockUserDB.AssertNotCalled(t, "CleanupMediaHistory", mock.Anything)
 }
 
+func TestRebuildStartupSlugSearchCache_SkipsWhenLoaded(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+
+	rebuildStartupSlugSearchCache(mockMediaDB, true)
+
+	mockMediaDB.AssertNotCalled(t, "GetIndexingStatus")
+	mockMediaDB.AssertNotCalled(t, "RebuildSlugSearchCache")
+}
+
+func TestRebuildStartupSlugSearchCache_StatusErrorSkipsRebuild(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return("", assert.AnError).Once()
+
+	rebuildStartupSlugSearchCache(mockMediaDB, false)
+
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "TrackBackgroundOperation")
+	mockMediaDB.AssertNotCalled(t, "RebuildSlugSearchCache")
+}
+
+func TestRebuildStartupSlugSearchCache_RebuildErrorReleasesBackgroundOperation(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockMediaDB.On("TrackBackgroundOperation").Return().Once()
+	mockMediaDB.On("RebuildSlugSearchCache").Return(assert.AnError).Once()
+	mockMediaDB.On("BackgroundOperationDone").Return().Once()
+
+	rebuildStartupSlugSearchCache(mockMediaDB, false)
+
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "PersistSlugSearchCache")
+}
+
 func TestRebuildStartupSlugSearchCache_SkipsDuringIndexing(t *testing.T) {
 	t.Parallel()
 
@@ -435,6 +474,36 @@ func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {
 
 	// Verify that no indexing was triggered for failed status
 	mockMediaDB.AssertNotCalled(t, "GetOptimizationStatus")
+}
+
+func TestCheckAndResumeScraping_StatusErrorDoesNothing(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	methods.ClearScrapingStatus()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return("", assert.AnError).Once()
+
+	checkAndResumeScraping(
+		mocks.NewMockPlatform(), nil, &database.Database{MediaDB: mockMediaDB}, nil, nil,
+	)
+
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "GetScrapingOperation")
+	mockMediaDB.AssertNotCalled(t, "SetScrapingStatus", mock.Anything)
+}
+
+func TestCheckAndResumeScraping_OperationReadErrorDoesNotMarkFailed(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	methods.ClearScrapingStatus()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	mockMediaDB.On("GetScrapingOperation").Return(database.ScrapingOperation{}, false, assert.AnError).Once()
+
+	checkAndResumeScraping(
+		mocks.NewMockPlatform(), nil, &database.Database{MediaDB: mockMediaDB}, nil, nil,
+	)
+
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "SetScrapingStatus", mock.Anything)
 }
 
 func TestCheckAndResumeScraping_MissingOperationMarksFailed(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -162,6 +162,35 @@ func TestCleanupHistoryRetention_CancelledBeforeMediaHistory(t *testing.T) {
 	mockUserDB.AssertNotCalled(t, "CleanupMediaHistory", mock.Anything)
 }
 
+func TestRebuildStartupSlugSearchCache_SkipsDuringIndexing(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+
+	rebuildStartupSlugSearchCache(mockMediaDB, false)
+
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "TrackBackgroundOperation")
+	mockMediaDB.AssertNotCalled(t, "RebuildSlugSearchCache")
+	mockMediaDB.AssertNotCalled(t, "PersistSlugSearchCache")
+}
+
+func TestRebuildStartupSlugSearchCache_RebuildsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockMediaDB.On("TrackBackgroundOperation").Return().Once()
+	mockMediaDB.On("RebuildSlugSearchCache").Return(nil).Once()
+	mockMediaDB.On("PersistSlugSearchCache").Return(nil).Once()
+	mockMediaDB.On("BackgroundOperationDone").Return().Once()
+
+	rebuildStartupSlugSearchCache(mockMediaDB, false)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestCheckAndResumeIndexing_NoInterruption(t *testing.T) {
 	// Note: Not using t.Parallel() due to global statusInstance usage in GenerateMediaDB
 	methods.ClearIndexingStatus()

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1293,6 +1293,68 @@ func (m *MockMediaDBI) GetIndexingStatus() (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockMediaDBI) hasExpectation(method string) bool {
+	for _, call := range m.ExpectedCalls {
+		if call.Method == method {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockMediaDBI) SetScrapingStatus(status string) error {
+	if !m.hasExpectation("SetScrapingStatus") {
+		return nil
+	}
+	args := m.Called(status)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) GetScrapingStatus() (string, error) {
+	if !m.hasExpectation("GetScrapingStatus") {
+		return "", nil
+	}
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockMediaDBI) SetScrapingOperation(operation database.ScrapingOperation) error {
+	if !m.hasExpectation("SetScrapingOperation") {
+		return nil
+	}
+	args := m.Called(operation)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) GetScrapingOperation() (database.ScrapingOperation, bool, error) {
+	if !m.hasExpectation("GetScrapingOperation") {
+		return database.ScrapingOperation{}, false, nil
+	}
+	args := m.Called()
+	operation, ok := args.Get(0).(database.ScrapingOperation)
+	if !ok {
+		operation = database.ScrapingOperation{}
+	}
+	return operation, args.Bool(1), args.Error(2)
+}
+
+func (m *MockMediaDBI) ClearScrapingOperation() error {
+	if !m.hasExpectation("ClearScrapingOperation") {
+		return nil
+	}
+	args := m.Called()
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) SetLastIndexedSystem(systemID string) error {
 	args := m.Called(systemID)
 	if err := args.Error(0); err != nil {


### PR DESCRIPTION
## Summary
- defer nonessential media startup work and prioritize latest media history requests
- persist/resume media scraping operations across Core restarts
- return `TagInfo.label` for media meta/search/browse tag responses

Checked: `task lint-fix`; `go test ./pkg/api/methods/ ./pkg/api/ ./pkg/database/mediadb/ ./pkg/service/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scraping operations are now persisted, resumable after restarts, and support persisted cancellation.

* **New Features / UI**
  * Tags in search and media responses now include human-readable labels alongside tag identifiers.

* **Improvements**
  * Startup now auto-detects and resumes interrupted scraping and schedules media maintenance more reliably.
  * Media-history queries are treated with higher priority for responsiveness.

* **Tests / CI**
  * Expanded tests and CI tweaks covering tag labels, scraping persistence/resume, startup behaviors, and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->