### PR TITLE
fix(api): improve media image resizing and scrape counts

### DIFF
--- a/pkg/api/methods/media_batch.go
+++ b/pkg/api/methods/media_batch.go
@@ -38,6 +38,7 @@ const (
 
 type mediaRefParam struct {
 	MediaID    *int64   `json:"mediaId,omitempty"`
+	MaxSize    *int32   `json:"maxSize,omitempty"`
 	System     string   `json:"system,omitempty"`
 	Path       string   `json:"path,omitempty"`
 	ImageTypes []string `json:"imageTypes,omitempty"`

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -26,6 +26,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,6 +44,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
+	"golang.org/x/image/draw"
+	_ "golang.org/x/image/webp" // register WebP decoder for image.Decode
 )
 
 const (
@@ -73,6 +79,84 @@ var imageTypeTags = map[string]string{
 	"map":        tags.PropertyTypeTag(tags.TagPropertyImageMap),
 	"marquee":    tags.PropertyTypeTag(tags.TagPropertyImageMarquee),
 	"fanart":     tags.PropertyTypeTag(tags.TagPropertyImageFanart),
+}
+
+// rawMediaImage carries raw image bytes and metadata before base64-encoding.
+// Used to allow the semaphore to be released before CPU-intensive resize/encode.
+type rawMediaImage struct {
+	contentType string
+	text        string // original file path, for extension derivation fallback
+	typeTag     string
+	binary      []byte
+}
+
+// resizeImageIfNeeded decodes binary, and if either dimension exceeds maxSize,
+// scales it down to fit within a maxSize×maxSize bounding box and re-encodes
+// opaque images as JPEG (q85) or transparent images as PNG. Returns the original
+// bytes unchanged when no resize is needed or when the source cannot be decoded.
+func resizeImageIfNeeded(binary []byte, contentType string, maxSize int) (resized []byte, resizedType string) {
+	if maxSize <= 0 || len(binary) == 0 {
+		return binary, contentType
+	}
+	src, _, err := image.Decode(bytes.NewReader(binary))
+	if err != nil {
+		return binary, contentType
+	}
+	bounds := src.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	if w <= maxSize && h <= maxSize {
+		return binary, contentType
+	}
+	larger := w
+	if h > larger {
+		larger = h
+	}
+	scale := float64(maxSize) / float64(larger)
+	newW := int(math.Round(float64(w) * scale))
+	newH := int(math.Round(float64(h) * scale))
+	if newW < 1 {
+		newW = 1
+	}
+	if newH < 1 {
+		newH = 1
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, newW, newH))
+	draw.ApproxBiLinear.Scale(dst, dst.Bounds(), src, bounds, draw.Over, nil)
+	var out bytes.Buffer
+	outputType := "image/jpeg"
+	if imageHasTransparency(src) {
+		outputType = "image/png"
+		if err := png.Encode(&out, dst); err != nil {
+			return binary, contentType
+		}
+	} else if err := jpeg.Encode(&out, dst, &jpeg.Options{Quality: 85}); err != nil {
+		return binary, contentType
+	}
+	log.Debug().
+		Str("contentType", contentType).
+		Str("resizedContentType", outputType).
+		Int("maxSize", maxSize).
+		Int("width", w).
+		Int("height", h).
+		Int("resizedWidth", newW).
+		Int("resizedHeight", newH).
+		Int("inputBytes", len(binary)).
+		Int("resizedBytes", out.Len()).
+		Msg("media.image: resized image")
+	return out.Bytes(), outputType
+}
+
+func imageHasTransparency(img image.Image) bool {
+	bounds := img.Bounds()
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			_, _, _, alpha := img.At(x, y).RGBA()
+			if alpha != 0xffff {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 type mediaBinaryTooLargeError struct {
@@ -227,45 +311,42 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 
 	select {
 	case mediaImageSem <- struct{}{}:
-		defer func() { <-mediaImageSem }()
 	case <-env.Context.Done():
 		return nil, env.Context.Err()
 	}
 	if ok, cachedErr := mediaImageNoImages.get(noImageKey); ok {
+		<-mediaImageSem
 		return nil, cachedMediaImageNoImageError(cachedErr)
 	}
 
 	maxBytes := mediaImageMaxBytes(env.Platform)
+	var raw *rawMediaImage
 	if ref.MediaID == nil {
-		return handleMediaImageSinglePath(&env, ref, prefs, noImageKey, maxBytes)
+		raw, err = loadRawMediaImageSinglePath(&env, ref, prefs, maxBytes)
+	} else {
+		raw, err = loadRawMediaImageByID(&env, ref, prefs, maxBytes)
 	}
-
-	resolved, err := resolveMediaRefs(&env, []mediaRefParam{ref})
-	if err != nil {
-		return nil, err
-	}
-	if resolved[0].Err != nil {
-		return nil, resolved[0].Err
-	}
-
-	db := env.Database.MediaDB
-	row := resolved[0].Row
-	mediaPropSources, err := mediaImagePropSources(&env, row)
-	if err != nil {
-		return nil, err
-	}
-	titleProps, err := db.GetMediaTitleProperties(env.Context, row.Title.DBID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get title properties: %w", err)
-	}
-
-	image, err := selectMediaImageFromSources(
-		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
-	)
+	// Cache the no-image result while holding the semaphore so concurrent
+	// waiters see it immediately after sem release.
 	if isCacheableMediaImageNoImageError(err) {
 		mediaImageNoImages.add(noImageKey, err)
 	}
-	return image, err
+	<-mediaImageSem // release before CPU-intensive decode/resize/encode
+
+	if err != nil {
+		return nil, err
+	}
+
+	binary, ct := raw.binary, raw.contentType
+	if ref.MaxSize != nil && *ref.MaxSize > 0 {
+		binary, ct = resizeImageIfNeeded(binary, ct, int(*ref.MaxSize))
+	}
+	return models.MediaImageResponse{
+		Extension:   mediaContentExtension(ct, raw.text),
+		ContentType: ct,
+		Data:        base64.StdEncoding.EncodeToString(binary),
+		TypeTag:     raw.typeTag,
+	}, nil
 }
 
 func parseMediaImageRequest(raw json.RawMessage) (mediaRefParam, error) {
@@ -284,19 +365,17 @@ func parseMediaImageRequest(raw json.RawMessage) (mediaRefParam, error) {
 	return ref, nil
 }
 
-func handleMediaImageSinglePath(
+func loadRawMediaImageSinglePath(
 	env *requests.RequestEnv,
 	ref mediaRefParam,
 	prefs []string,
-	noImageKey string,
 	maxBytes int64,
-) (any, error) {
+) (*rawMediaImage, error) {
 	db := env.Database.MediaDB
 	row, err := resolveMediaBySystemAndPath(env, ref.System, ref.Path)
 	if err != nil {
 		return nil, err
 	}
-
 	mediaPropSources, err := mediaImagePropSources(env, row)
 	if err != nil {
 		return nil, err
@@ -305,14 +384,37 @@ func handleMediaImageSinglePath(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get title properties: %w", err)
 	}
-
-	image, err := selectMediaImageFromSources(
+	return selectRawMediaImageFromSources(
 		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
 	)
-	if isCacheableMediaImageNoImageError(err) {
-		mediaImageNoImages.add(noImageKey, err)
+}
+
+func loadRawMediaImageByID(
+	env *requests.RequestEnv,
+	ref mediaRefParam,
+	prefs []string,
+	maxBytes int64,
+) (*rawMediaImage, error) {
+	resolved, err := resolveMediaRefs(env, []mediaRefParam{ref})
+	if err != nil {
+		return nil, err
 	}
-	return image, err
+	if resolved[0].Err != nil {
+		return nil, resolved[0].Err
+	}
+	db := env.Database.MediaDB
+	row := resolved[0].Row
+	mediaPropSources, err := mediaImagePropSources(env, row)
+	if err != nil {
+		return nil, err
+	}
+	titleProps, err := db.GetMediaTitleProperties(env.Context, row.Title.DBID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get title properties: %w", err)
+	}
+	return selectRawMediaImageFromSources(
+		env.Context, afero.NewOsFs(), db, row, mediaPropSources, titleProps, prefs, maxBytes,
+	)
 }
 
 func imagePrefs(topLevel, itemLevel []string) []string {
@@ -386,7 +488,7 @@ func mediaImagePropSources(env *requests.RequestEnv, row *database.MediaFullRow)
 	return sources, nil
 }
 
-func selectMediaImageFromSources(
+func selectRawMediaImageFromSources(
 	ctx context.Context,
 	fs afero.Fs,
 	db database.MediaDBI,
@@ -395,7 +497,7 @@ func selectMediaImageFromSources(
 	titleProps []database.MediaProperty,
 	prefs []string,
 	maxBytes int64,
-) (models.MediaImageResponse, error) {
+) (*rawMediaImage, error) {
 	sources := make([]mediaImageSource, 0, len(mediaPropSources)+1)
 	for _, props := range mediaPropSources {
 		sources = append(sources, mediaImageSource{buildPropsMap(props), true})
@@ -420,16 +522,16 @@ func selectMediaImageFromSources(
 			if prop.Text != "" {
 				fileBackedCandidatesChecked = true
 			}
-			image, stale, err := loadMediaImageProperty(ctx, fs, db, row, &prop, src, typeTag, maxBytes)
+			raw, stale, err := loadRawMediaImageProperty(ctx, fs, db, row, &prop, src, typeTag, maxBytes)
 			if stale {
 				delete(src.propMap, typeTag)
 				continue
 			}
 			if err != nil {
-				return models.MediaImageResponse{}, err
+				return nil, err
 			}
-			if image != nil {
-				return *image, nil
+			if raw != nil {
+				return raw, nil
 			}
 		}
 	}
@@ -448,10 +550,10 @@ func selectMediaImageFromSources(
 		Strs("titleImageProps", imagePropertyTypeTags(titleProps)).
 		Msg("media.image: no image found")
 
-	return models.MediaImageResponse{}, mediaImageNoImageError(row, fileBackedCandidatesChecked)
+	return nil, mediaImageNoImageError(row, fileBackedCandidatesChecked)
 }
 
-func loadMediaImageProperty(
+func loadRawMediaImageProperty(
 	ctx context.Context,
 	fs afero.Fs,
 	db database.MediaDBI,
@@ -460,7 +562,7 @@ func loadMediaImageProperty(
 	src mediaImageSource,
 	typeTag string,
 	maxBytes int64,
-) (*models.MediaImageResponse, bool, error) {
+) (*rawMediaImage, bool, error) {
 	var binary []byte
 	contentType := mediaContentType(prop.ContentType, prop.Text)
 
@@ -499,11 +601,11 @@ func loadMediaImageProperty(
 		return nil, false, nil
 	}
 
-	return &models.MediaImageResponse{
-		Extension:   mediaContentExtension(contentType, prop.Text),
-		ContentType: contentType,
-		Data:        base64.StdEncoding.EncodeToString(binary),
-		TypeTag:     typeTag,
+	return &rawMediaImage{
+		binary:      binary,
+		contentType: contentType,
+		text:        prop.Text,
+		typeTag:     typeTag,
 	}, false, nil
 }
 

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -45,7 +45,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"golang.org/x/image/draw"
-	_ "golang.org/x/image/webp" // register WebP decoder for image.Decode
 )
 
 const (
@@ -98,7 +97,7 @@ func resizeImageIfNeeded(binary []byte, contentType string, maxSize int) (resize
 	if maxSize <= 0 || len(binary) == 0 {
 		return binary, contentType
 	}
-	src, _, err := image.Decode(bytes.NewReader(binary))
+	src, err := decodeResizableImage(binary, contentType)
 	if err != nil {
 		return binary, contentType
 	}
@@ -144,6 +143,38 @@ func resizeImageIfNeeded(binary []byte, contentType string, maxSize int) (resize
 		Int("resizedBytes", out.Len()).
 		Msg("media.image: resized image")
 	return out.Bytes(), outputType
+}
+
+func decodeResizableImage(binary []byte, contentType string) (image.Image, error) {
+	decodeJPEG := func() (image.Image, error) {
+		img, err := jpeg.Decode(bytes.NewReader(binary))
+		if err != nil {
+			return nil, fmt.Errorf("decode JPEG for resize: %w", err)
+		}
+		return img, nil
+	}
+	decodePNG := func() (image.Image, error) {
+		img, err := png.Decode(bytes.NewReader(binary))
+		if err != nil {
+			return nil, fmt.Errorf("decode PNG for resize: %w", err)
+		}
+		return img, nil
+	}
+
+	switch extensionFromContentType(contentType) {
+	case "jpg":
+		return decodeJPEG()
+	case "png":
+		return decodePNG()
+	}
+
+	if bytes.HasPrefix(binary, []byte("\x89PNG\r\n\x1a\n")) {
+		return decodePNG()
+	}
+	if len(binary) >= 2 && binary[0] == 0xff && binary[1] == 0xd8 {
+		return decodeJPEG()
+	}
+	return nil, fmt.Errorf("unsupported image type for resize: %s", contentType)
 }
 
 func imageHasTransparency(img image.Image) bool {

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"image"
 	"image/color"
-	"image/jpeg"
 	"image/png"
 	"os"
 	"path/filepath"
@@ -136,8 +135,6 @@ func TestResizeImageIfNeeded_OpaqueImageUsesJPEG(t *testing.T) {
 	assert.Equal(t, "jpeg", decodedType)
 	assert.Equal(t, 2, decoded.Bounds().Dx())
 	assert.Equal(t, 2, decoded.Bounds().Dy())
-	_, err = jpeg.Decode(bytes.NewReader(resized))
-	assert.NoError(t, err)
 }
 
 // TestHandleMediaImage_DefaultPrefs_TitleBlobFound verifies that when no imageTypes

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -20,10 +20,15 @@
 package methods
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,6 +88,56 @@ func mediaImageParams(row *database.MediaFullRow, extra string) json.RawMessage 
 		extra = ", " + extra
 	}
 	return json.RawMessage(fmt.Sprintf(`{"system": %q, "path": %q%s}`, row.System.SystemID, row.Path, extra))
+}
+
+func TestResizeImageIfNeeded_TransparentPNGPreservesAlpha(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := range 4 {
+		for x := range 4 {
+			src.Set(x, y, color.RGBA{R: 255, A: 255})
+		}
+	}
+	src.Set(0, 0, color.RGBA{G: 255, A: 64})
+
+	var in bytes.Buffer
+	require.NoError(t, png.Encode(&in, src))
+
+	resized, contentType := resizeImageIfNeeded(in.Bytes(), "image/png", 2)
+	require.Equal(t, "image/png", contentType)
+
+	decoded, decodedType, err := image.Decode(bytes.NewReader(resized))
+	require.NoError(t, err)
+	assert.Equal(t, "png", decodedType)
+	assert.Equal(t, 2, decoded.Bounds().Dx())
+	assert.Equal(t, 2, decoded.Bounds().Dy())
+	assert.True(t, imageHasTransparency(decoded))
+}
+
+func TestResizeImageIfNeeded_OpaqueImageUsesJPEG(t *testing.T) {
+	t.Parallel()
+
+	src := image.NewRGBA(image.Rect(0, 0, 4, 4))
+	for y := range 4 {
+		for x := range 4 {
+			src.Set(x, y, color.RGBA{R: 255, G: 128, B: 64, A: 255})
+		}
+	}
+
+	var in bytes.Buffer
+	require.NoError(t, png.Encode(&in, src))
+
+	resized, contentType := resizeImageIfNeeded(in.Bytes(), "image/png", 2)
+	require.Equal(t, "image/jpeg", contentType)
+
+	decoded, decodedType, err := image.Decode(bytes.NewReader(resized))
+	require.NoError(t, err)
+	assert.Equal(t, "jpeg", decodedType)
+	assert.Equal(t, 2, decoded.Bounds().Dx())
+	assert.Equal(t, 2, decoded.Bounds().Dy())
+	_, err = jpeg.Decode(bytes.NewReader(resized))
+	assert.NoError(t, err)
 }
 
 // TestHandleMediaImage_DefaultPrefs_TitleBlobFound verifies that when no imageTypes

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -260,8 +260,9 @@ func populateScrapedMediaCountCached(
 	}
 
 	count, ok := queryScrapedMediaCount(ctx, db, status.ScraperID)
+	queryDone := time.Now()
 	if !ok {
-		scrapingStatusInstance.updateCountFailure(status.ScraperID, now)
+		scrapingStatusInstance.updateCountFailure(status.ScraperID, queryDone)
 		if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK {
 			status.TotalScraped = cached
 		}
@@ -271,7 +272,7 @@ func populateScrapedMediaCountCached(
 		count = cached
 	}
 	status.TotalScraped = count
-	scrapingStatusInstance.updateCountCache(status.ScraperID, count, now)
+	scrapingStatusInstance.updateCountCache(status.ScraperID, count, queryDone)
 }
 
 func scrapeCountStatusContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -42,6 +43,8 @@ import (
 // management and safe concurrent access.
 const (
 	scrapeTotalScrapedRefreshInterval = 5 * time.Second
+	scrapeTotalScrapedFailureBackoff  = 60 * time.Second
+	scrapeTotalScrapedStatusTimeout   = 2 * time.Second
 	scrapeStateIdle                   = "idle"
 	scrapeStateRunning                = "running"
 	scrapeStatePaused                 = "paused"
@@ -52,6 +55,7 @@ const (
 
 type scrapedCountCache struct {
 	lastRefresh time.Time
+	lastFailure time.Time
 	scraperID   string
 	count       int
 	valid       bool
@@ -177,6 +181,15 @@ func (s *scrapingStatus) getAnyCountCache(scraperID string) (int, bool) {
 	return s.countCache.count, true
 }
 
+func (s *scrapingStatus) countRefreshBackedOff(scraperID string, now time.Time) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.countCache.scraperID != scraperID || s.countCache.lastFailure.IsZero() {
+		return false
+	}
+	return now.Sub(s.countCache.lastFailure) < scrapeTotalScrapedFailureBackoff
+}
+
 func (s *scrapingStatus) updateCountCache(scraperID string, count int, now time.Time) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -191,6 +204,15 @@ func (s *scrapingStatus) updateCountCache(scraperID string, count int, now time.
 	}
 }
 
+func (s *scrapingStatus) updateCountFailure(scraperID string, now time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.countCache.scraperID != scraperID {
+		s.countCache = scrapedCountCache{scraperID: scraperID}
+	}
+	s.countCache.lastFailure = now
+}
+
 func publishScrapingStatus(ns chan<- models.Notification, status *models.ScrapingStatusResponse) {
 	scrapingStatusInstance.setLatest(status)
 	notifications.MediaScraping(ns, status)
@@ -201,7 +223,7 @@ func populateScrapedMediaCount(
 	db *database.Database,
 	status *models.ScrapingStatusResponse,
 ) {
-	populateScrapedMediaCountExact(ctx, db, status)
+	populateScrapedMediaCountCached(ctx, db, status)
 }
 
 func populateScrapedMediaCountExact(
@@ -225,13 +247,21 @@ func populateScrapedMediaCountCached(
 	db *database.Database,
 	status *models.ScrapingStatusResponse,
 ) {
-	if cached, ok := scrapingStatusInstance.getFreshCountCache(status.ScraperID, time.Now()); ok {
+	now := time.Now()
+	if cached, ok := scrapingStatusInstance.getFreshCountCache(status.ScraperID, now); ok {
 		status.TotalScraped = cached
+		return
+	}
+	if scrapingStatusInstance.countRefreshBackedOff(status.ScraperID, now) {
+		if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK {
+			status.TotalScraped = cached
+		}
 		return
 	}
 
 	count, ok := queryScrapedMediaCount(ctx, db, status.ScraperID)
 	if !ok {
+		scrapingStatusInstance.updateCountFailure(status.ScraperID, now)
 		if cached, cachedOK := scrapingStatusInstance.getAnyCountCache(status.ScraperID); cachedOK {
 			status.TotalScraped = cached
 		}
@@ -241,7 +271,14 @@ func populateScrapedMediaCountCached(
 		count = cached
 	}
 	status.TotalScraped = count
-	scrapingStatusInstance.updateCountCache(status.ScraperID, count, time.Now())
+	scrapingStatusInstance.updateCountCache(status.ScraperID, count, now)
+}
+
+func scrapeCountStatusContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, scrapeTotalScrapedStatusTimeout)
 }
 
 func queryScrapedMediaCount(ctx context.Context, db *database.Database, scraperID string) (int, bool) {
@@ -249,19 +286,35 @@ func queryScrapedMediaCount(ctx context.Context, db *database.Database, scraperI
 		return 0, false
 	}
 
+	started := time.Now()
+	queryKind := "total"
 	var (
 		count int
 		err   error
 	)
 	if scraperID != "" {
+		queryKind = "per_scraper"
 		count, err = db.MediaDB.GetScrapedMediaCount(ctx, scraperID)
 	} else {
 		count, err = db.MediaDB.GetTotalScrapedMediaCount(ctx)
 	}
+	duration := time.Since(started)
 	if err != nil {
-		log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to get scraped media count")
+		timedOut := errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded)
+		log.Warn().Err(err).
+			Str("scraper", scraperID).
+			Str("queryKind", queryKind).
+			Int64("durationMs", duration.Milliseconds()).
+			Bool("timeout", timedOut).
+			Msg("failed to get scraped media count")
 		return 0, false
 	}
+	log.Debug().
+		Str("scraper", scraperID).
+		Str("queryKind", queryKind).
+		Int64("durationMs", duration.Milliseconds()).
+		Int("count", count).
+		Msg("got scraped media count")
 	return count, true
 }
 
@@ -539,7 +592,7 @@ func HandleMediaScrapeStatus(env requests.RequestEnv) (any, error) {
 		return status, nil
 	}
 
-	countCtx, cancel := optionalDBEnrichmentContext(env.Context)
+	countCtx, cancel := scrapeCountStatusContext(env.Context)
 	defer cancel()
 	populateScrapedMediaCount(countCtx, env.Database, &status)
 

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -367,7 +367,7 @@ func TestHandleMediaScrapeStatus_NoRun(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
-func TestHandleMediaScrapeStatus_RefreshesExactCountDespiteCache(t *testing.T) {
+func TestHandleMediaScrapeStatus_UsesFreshCachedCount(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()
 
@@ -384,7 +384,6 @@ func TestHandleMediaScrapeStatus_RefreshesExactCountDespiteCache(t *testing.T) {
 	})
 
 	mockDB := testhelpers.NewMockMediaDBI()
-	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(12, nil).Once()
 
 	result, err := HandleMediaScrapeStatus(requests.RequestEnv{
 		Context:  context.Background(),
@@ -393,8 +392,8 @@ func TestHandleMediaScrapeStatus_RefreshesExactCountDespiteCache(t *testing.T) {
 	require.NoError(t, err)
 	status, ok := result.(models.ScrapingStatusResponse)
 	require.True(t, ok)
-	assert.Equal(t, 12, status.TotalScraped)
-	mockDB.AssertExpectations(t)
+	assert.Equal(t, 5, status.TotalScraped)
+	mockDB.AssertNotCalled(t, "GetScrapedMediaCount", assertmock.Anything, "test-scraper")
 }
 
 func TestHandleMediaScrapeStatus_TracksLatestProgress(t *testing.T) {
@@ -492,7 +491,7 @@ func TestHandleMediaScrapeStatus_BoundsSlowScrapedCount(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	assert.Less(t, time.Since(started), 2*time.Second)
+	assert.Less(t, time.Since(started), 3*time.Second)
 	status, ok := result.(models.ScrapingStatusResponse)
 	require.True(t, ok)
 	assert.Zero(t, status.TotalScraped)
@@ -502,7 +501,7 @@ func TestHandleMediaScrapeStatus_BoundsSlowScrapedCount(t *testing.T) {
 func TestHandleMediaScrapeStatus_UsesCachedCountWhenRefreshTimesOut(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()
-	scrapingStatusInstance.updateCountCache("", 9, time.Now())
+	scrapingStatusInstance.updateCountCache("", 9, time.Now().Add(-scrapeTotalScrapedRefreshInterval-time.Second))
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	mockDB.On("GetTotalScrapedMediaCount", assertmock.Anything).
@@ -518,6 +517,35 @@ func TestHandleMediaScrapeStatus_UsesCachedCountWhenRefreshTimesOut(t *testing.T
 	status, ok := result.(models.ScrapingStatusResponse)
 	require.True(t, ok)
 	assert.Equal(t, 9, status.TotalScraped)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaScrapeStatus_BacksOffAfterScrapedCountTimeout(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetTotalScrapedMediaCount", assertmock.Anything).
+		Return(0, context.DeadlineExceeded).
+		Once()
+
+	result, err := HandleMediaScrapeStatus(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockDB},
+	})
+	require.NoError(t, err)
+	status, ok := result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Zero(t, status.TotalScraped)
+
+	result, err = HandleMediaScrapeStatus(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockDB},
+	})
+	require.NoError(t, err)
+	status, ok = result.(models.ScrapingStatusResponse)
+	require.True(t, ok)
+	assert.Zero(t, status.TotalScraped)
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -350,10 +350,8 @@ func (db *MediaDB) GetScrapedMediaCount(ctx context.Context, scraperID string) (
 	return count, nil
 }
 
-// GetTotalScrapedMediaCount returns the number of distinct media rows with
-// scraper metadata. Sentinel tags are included, but the count also covers rows
-// whose title/media properties were written by scrapers so metadata remains
-// reflected after reindex paths that preserve properties but rebuild media tags.
+// GetTotalScrapedMediaCount returns the number of distinct media rows marked
+// as successfully scraped by any scraper sentinel tag.
 func (db *MediaDB) GetTotalScrapedMediaCount(ctx context.Context) (int, error) {
 	if db.sql == nil {
 		return 0, ErrNullSQL
@@ -363,7 +361,7 @@ func (db *MediaDB) GetTotalScrapedMediaCount(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to find scraper sentinel tags: %w", err)
 	}
-	count, err := countScrapedMediaCoverage(ctx, db.sql, tagDBIDs)
+	count, err := countMediaTagsForTagDBIDs(ctx, db.sql, tagDBIDs)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count scraped media: %w", err)
 	}
@@ -483,31 +481,6 @@ func countMediaTagsForTagDBIDs(ctx context.Context, db *sql.DB, tagDBIDs []int64
 	query := `SELECT COUNT(DISTINCT MediaDBID) FROM MediaTags WHERE TagDBID IN (` + placeholders + `)`
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("failed to count media tag rows: %w", err)
-	}
-	return count, nil
-}
-
-func countScrapedMediaCoverage(ctx context.Context, db *sql.DB, tagDBIDs []int64) (int, error) {
-	queries := []string{
-		`SELECT MediaDBID FROM MediaProperties`,
-		`SELECT m.DBID
-			FROM Media m
-			JOIN MediaTitleProperties p ON p.MediaTitleDBID = m.MediaTitleDBID`,
-	}
-	args := make([]any, 0, len(tagDBIDs))
-	if len(tagDBIDs) > 0 {
-		placeholders := prepareVariadic("?", ",", len(tagDBIDs))
-		queries = append(queries, `SELECT MediaDBID FROM MediaTags WHERE TagDBID IN (`+placeholders+`)`)
-		for _, tagDBID := range tagDBIDs {
-			args = append(args, tagDBID)
-		}
-	}
-
-	var count int
-	//nolint:gosec // Safe: queries are static plus generated placeholders.
-	query := `SELECT COUNT(*) FROM (` + strings.Join(queries, ` UNION `) + `)`
-	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-		return 0, fmt.Errorf("failed to count scraped media coverage: %w", err)
 	}
 	return count, nil
 }

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -535,7 +535,7 @@ func TestGetTotalScrapedMediaCount_DistinctMedia(t *testing.T) {
 	assert.Equal(t, 2, count)
 }
 
-func TestGetTotalScrapedMediaCount_IncludesTitlePropertyCoverage(t *testing.T) {
+func TestGetTotalScrapedMediaCount_TitlePropertyOnlyDoesNotCount(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)
 	defer cleanup()
@@ -552,10 +552,10 @@ func TestGetTotalScrapedMediaCount_IncludesTitlePropertyCoverage(t *testing.T) {
 
 	count, err := mediaDB.GetTotalScrapedMediaCount(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 2, count)
+	assert.Equal(t, 0, count)
 }
 
-func TestGetTotalScrapedMediaCount_IncludesOnlyMediaPropertyRow(t *testing.T) {
+func TestGetTotalScrapedMediaCount_MediaPropertyOnlyDoesNotCount(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)
 	defer cleanup()
@@ -572,7 +572,7 @@ func TestGetTotalScrapedMediaCount_IncludesOnlyMediaPropertyRow(t *testing.T) {
 
 	count, err := mediaDB.GetTotalScrapedMediaCount(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 0, count)
 }
 
 func TestGetTotalScrapedMediaCount_MissingSentinelsReturnsZero(t *testing.T) {


### PR DESCRIPTION
## Summary
- preserve transparency when resizing media images and log resize dimensions
- allow batched media image requests to pass maxSize
- cache scrape count lookups with backoff and use sentinel tags for total scraped counts
- give scrape status counts a dedicated timeout so startup contention can complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image requests can include an optional MaxSize to return resized images.
  * Resizing preserves PNG transparency; opaque images are returned as optimized JPEGs when appropriate.

* **Performance / Stability**
  * Media scrape status now uses cached counts with failure backoff to reduce DB load during timeouts.

* **Tests**
  * Added tests for image resizing (transparency and JPEG conversion) and scrape-count backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->