### PR TITLE
test(zapscript): fix Windows random path expectation

### DIFF
--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	posixpath "path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -237,9 +236,9 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// absolute path, use database query to find random media with this path prefix
 	// this includes virtual paths and zips as options
 	if filepath.IsAbs(query) {
-		cleanedPath := posixpath.Clean(query)
+		cleanedPath := filepath.Clean(query)
 		mediaQuery := database.MediaQuery{
-			PathPrefix: cleanedPath,
+			PathPrefix: filepath.ToSlash(cleanedPath),
 			Tags:       tagFilters,
 		}
 		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -985,6 +985,7 @@ func TestCmdRandom_AbsolutePathFilesystemFallbackAppliesInferredGroupDefault(t *
 	require.NoError(t, os.MkdirAll(dir, 0o750))
 	romPath := filepath.Join(dir, "Sonic.bin")
 	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
+	wantPathPrefix := dir
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
@@ -1008,7 +1009,7 @@ launcher = "RA"
 	mockMediaDB.On("RandomGameWithQuery",
 		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
-			return q.PathPrefix == filepath.ToSlash(dir)
+			return q.PathPrefix == wantPathPrefix
 		}),
 	).Return(database.SearchResult{}, sql.ErrNoRows)
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -944,11 +944,12 @@ launcher = "RA"
 
 	queryPath := filepath.Join(launchTestAbsPath("games"), "GENESIS")
 	romPath := filepath.Join(queryPath, "Sonic.bin")
+	wantPathPrefix := filepath.ToSlash(queryPath)
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("RandomGameWithQuery",
 		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
-			return q.PathPrefix == filepath.ToSlash(queryPath)
+			return q.PathPrefix == wantPathPrefix
 		}),
 	).Return(database.SearchResult{SystemID: "genesis", Path: romPath}, nil)
 
@@ -985,7 +986,7 @@ func TestCmdRandom_AbsolutePathFilesystemFallbackAppliesInferredGroupDefault(t *
 	require.NoError(t, os.MkdirAll(dir, 0o750))
 	romPath := filepath.Join(dir, "Sonic.bin")
 	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
-	wantPathPrefix := dir
+	wantPathPrefix := filepath.ToSlash(dir)
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}


### PR DESCRIPTION
## Summary
- normalize absolute `launch.random` query prefixes with `filepath.ToSlash(filepath.Clean(query))` so DB `Media.Path LIKE` matching uses stored slash-separated paths
- keep native cleaned filesystem paths for `os.ReadDir` fallback and launch selection
- update Windows path expectations in zapscript tests

Ref #917

## Verified
- go test ./pkg/zapscript
- task lint-fix

Failing main run checked: https://github.com/ZaparooProject/zaparoo-core/actions/runs/27126422166
