### PR TITLE
test(zapscript): fix fallback path prefix expectation

### DIFF
--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1095,6 +1095,7 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "game1.vhd"), []byte("x"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "game2.vhd"), []byte("x"), 0o600))
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o750))
+	wantPathPrefix := filepath.ToSlash(dir)
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
@@ -1105,7 +1106,7 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 	mockMediaDB.On("RandomGameWithQuery",
 		mock.Anything,
 		mock.MatchedBy(func(q *database.MediaQuery) bool {
-			return q.PathPrefix == dir
+			return q.PathPrefix == wantPathPrefix
 		}),
 	).Return(database.SearchResult{}, sql.ErrNoRows)
 


### PR DESCRIPTION
## Summary
- fix remaining Windows-only `launch.random` fallback test expectation for normalized DB path prefixes
- keep production code unchanged

## Verified
- go test ./pkg/zapscript
- task lint-fix

Failing main run checked: https://github.com/ZaparooProject/zaparoo-core/actions/runs/27129808950


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression test for path handling to properly normalize expected values, ensuring consistent path formatting validation across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->