### PR TITLE
fix(zapscript): clean random query path prefixes

### DIFF
--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	posixpath "path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -38,6 +39,14 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
+
+func cleanRandomMediaQueryPath(path string) string {
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if strings.HasPrefix(cleaned, "//") {
+		return posixpath.Clean(cleaned)
+	}
+	return cleaned
+}
 
 func applySystemDefaultLauncher(pl platforms.Platform, env *platforms.CmdEnv, systemID string) string {
 	current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
@@ -238,7 +247,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	if filepath.IsAbs(query) {
 		cleanedPath := filepath.Clean(query)
 		mediaQuery := database.MediaQuery{
-			PathPrefix: filepath.ToSlash(cleanedPath),
+			PathPrefix: cleanRandomMediaQueryPath(query),
 			Tags:       tagFilters,
 		}
 		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -50,6 +50,41 @@ func launchTestAbsPath(parts ...string) string {
 	return filepath.Join(append([]string{root}, parts...)...)
 }
 
+func TestCleanRandomMediaQueryPath(t *testing.T) {
+	t.Parallel()
+
+	nativePath := filepath.Join(t.TempDir(), "GENESIS")
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "posix duplicate slash",
+			path: "//media/fat/foo",
+			want: "/media/fat/foo",
+		},
+		{
+			name: "posix redundant segments",
+			path: "/media/fat/../usb/foo",
+			want: "/media/usb/foo",
+		},
+		{
+			name: "native path",
+			path: nativePath,
+			want: filepath.ToSlash(filepath.Clean(nativePath)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, cleanRandomMediaQueryPath(tc.path))
+		})
+	}
+}
+
 func TestVirtualStatPath_PreservesAbsoluteRoot(t *testing.T) {
 	t.Parallel()
 
@@ -944,7 +979,7 @@ launcher = "RA"
 
 	queryPath := filepath.Join(launchTestAbsPath("games"), "GENESIS")
 	romPath := filepath.Join(queryPath, "Sonic.bin")
-	wantPathPrefix := filepath.ToSlash(queryPath)
+	wantPathPrefix := filepath.ToSlash(filepath.Clean(queryPath))
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("RandomGameWithQuery",
 		mock.Anything,
@@ -986,7 +1021,7 @@ func TestCmdRandom_AbsolutePathFilesystemFallbackAppliesInferredGroupDefault(t *
 	require.NoError(t, os.MkdirAll(dir, 0o750))
 	romPath := filepath.Join(dir, "Sonic.bin")
 	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
-	wantPathPrefix := filepath.ToSlash(dir)
+	wantPathPrefix := filepath.ToSlash(filepath.Clean(dir))
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
@@ -1095,7 +1130,7 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "game1.vhd"), []byte("x"), 0o600))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "game2.vhd"), []byte("x"), 0o600))
 	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o750))
-	wantPathPrefix := filepath.ToSlash(dir)
+	wantPathPrefix := filepath.ToSlash(filepath.Clean(dir))
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}


### PR DESCRIPTION
## Summary
- clean `launch.random` DB query path prefixes separately from native filesystem fallback paths
- normalize stored-media query prefixes to forward slashes
- collapse duplicate leading slash for POSIX/virtual media paths like `//media/...`
- add helper coverage for native, POSIX duplicate slash, and redundant segment cases

## Verified
- go test ./pkg/zapscript
- task lint-fix
- go test ./pkg/zapscript

Failing main run checked: https://github.com/ZaparooProject/zaparoo-core/actions/runs/27131299613
