### PR TITLE
perf(api): fix slow browse for disc-folder game libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ worktrees/
 .mcp.json
 
 CLAUDE.md
+core.log

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.etcd.io/bbolt v1.4.3
 	go.uber.org/goleak v1.3.0
 	golang.design/x/clipboard v0.7.1
+	golang.org/x/image v0.38.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/text v0.37.0
@@ -127,7 +128,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
-	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/net v0.54.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -471,6 +471,7 @@ func GenerateMediaDB(
 		}
 		log.Info().Msg("finished generating media db successfully")
 		mediaImageNoImages.clear()
+		WipeMediaThumbCache()
 		notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 			Exists:     true,
 			Indexing:   false,

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -678,28 +678,46 @@ func buildBrowseResponse(
 	// browsing a single system. This replaces the previous per-directory query
 	// loop (~5 DB queries × N dirs) with a fixed handful of batch queries.
 	var singletonAliases map[string]database.SingletonContainerAlias
-	if len(dirs) > 0 && len(systems) == 1 &&
-		singletonMediaAliasesEnabled(env) &&
-		env.Database != nil && env.Database.MediaDB != nil {
-		prefix := path
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
-		system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systems[0].ID)
-		if sysErr == nil {
-			aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
-				env.Context, system.DBID, prefix,
-			)
-			if aliasErr == nil && len(aliases) > 0 {
-				singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
-				for i := range aliases {
-					singletonAliases[aliases[i].ChildDir] = aliases[i]
+	if len(dirs) > 0 && env.Database != nil && env.Database.MediaDB != nil {
+		// Determine which system to resolve against. Use the explicit filter if
+		// exactly one system was requested; otherwise infer from the directory
+		// entries (all dirs with media must belong to the same single system).
+		var systemID string
+		if len(systems) == 1 {
+			systemID = systems[0].ID
+		} else if len(systems) == 0 {
+			for _, dir := range dirs {
+				if len(dir.SystemIDs) == 0 {
+					continue
 				}
-			} else if aliasErr != nil {
-				log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
+				if len(dir.SystemIDs) > 1 || (systemID != "" && systemID != dir.SystemIDs[0]) {
+					systemID = ""
+					break
+				}
+				systemID = dir.SystemIDs[0]
 			}
-		} else {
-			log.Debug().Err(sysErr).Str("system", systems[0].ID).Msg("browse singleton alias system lookup failed")
+		}
+		if systemID != "" && singletonMediaAliasesEnabled(env) {
+			prefix := path
+			if !strings.HasSuffix(prefix, "/") {
+				prefix += "/"
+			}
+			system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
+			if sysErr == nil {
+				aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
+					env.Context, system.DBID, prefix,
+				)
+				if aliasErr == nil && len(aliases) > 0 {
+					singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
+					for i := range aliases {
+						singletonAliases[aliases[i].ChildDir] = aliases[i]
+					}
+				} else if aliasErr != nil {
+					log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
+				}
+			} else {
+				log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
+			}
 		}
 	}
 

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -674,9 +674,10 @@ func buildBrowseResponse(
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
 
-	// Batch-resolve singleton container aliases for the whole directory page when
-	// browsing a single system. This replaces the previous per-directory query
-	// loop (~5 DB queries × N dirs) with a fixed handful of batch queries.
+	// Batch-resolve singleton container aliases for the page's candidate
+	// directories when browsing a single system. Only small dirs (recursive
+	// FileCount <= maxSingletonAliasCandidateFiles) are considered, so large
+	// trees like MiSTer's _Arcade/_alternatives are never scanned.
 	var singletonAliases map[string]database.SingletonContainerAlias
 	if len(dirs) > 0 && env.Database != nil && env.Database.MediaDB != nil {
 		// Determine which system to resolve against. Use the explicit filter if
@@ -697,15 +698,31 @@ func buildBrowseResponse(
 				systemID = dir.SystemIDs[0]
 			}
 		}
-		if systemID != "" && singletonMediaAliasesEnabled(env) {
+		var candidates []database.SingletonAliasCandidate
+		if systemID != "" {
 			prefix := path
 			if !strings.HasSuffix(prefix, "/") {
 				prefix += "/"
 			}
+			for _, dir := range dirs {
+				if !isSingletonDirectoryAliasCandidate(dir.FileCount) {
+					continue
+				}
+				if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
+					continue
+				}
+				candidates = append(candidates, database.SingletonAliasCandidate{
+					ChildDir:  prefix + dir.Name + "/",
+					FileCount: dir.FileCount,
+				})
+			}
+		}
+		if len(candidates) > 0 && singletonMediaAliasesEnabled(env) {
+			started := time.Now()
 			system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
 			if sysErr == nil {
 				aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
-					env.Context, system.DBID, prefix,
+					env.Context, system.DBID, candidates,
 				)
 				if aliasErr == nil && len(aliases) > 0 {
 					singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
@@ -718,6 +735,12 @@ func buildBrowseResponse(
 			} else {
 				log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
 			}
+			log.Debug().
+				Str("path", path).
+				Int("candidates", len(candidates)).
+				Int("aliases", len(singletonAliases)).
+				Dur("duration", time.Since(started)).
+				Msg("browse singleton alias resolution timing")
 		}
 	}
 
@@ -739,6 +762,7 @@ func buildBrowseResponse(
 				Path:          alias.Row.Path,
 				Tags:          alias.Tags,
 				ZapScriptTags: alias.ZapScriptTags,
+				HasCover:      alias.HasCover,
 			}
 			mediaEntry := buildMediaEntry(&result, env, rootDirs)
 			entry.MediaID = mediaEntry.MediaID
@@ -746,6 +770,7 @@ func buildBrowseResponse(
 			entry.RelPath = mediaEntry.RelPath
 			entry.ZapScript = mediaEntry.ZapScript
 			entry.Tags = mediaEntry.Tags
+			entry.HasCover = mediaEntry.HasCover
 		}
 		entries = append(entries, entry)
 	}
@@ -819,6 +844,14 @@ func buildMediaEntry(
 	}
 
 	return entry
+}
+
+// isSingletonDirectoryAliasCandidate bounds the dirs considered for singleton
+// alias resolution: real disc-folder containers hold a handful of files, and
+// the cap keeps the batch query from fetching rows for large directory trees.
+func isSingletonDirectoryAliasCandidate(fileCount int) bool {
+	const maxSingletonAliasCandidateFiles = 64
+	return fileCount > 0 && fileCount <= maxSingletonAliasCandidateFiles
 }
 
 // isPathUnderRoots checks if the given path is at or under one of the allowed root directories.

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -746,6 +746,7 @@ func buildMediaEntry(
 		Type:     "media",
 		SystemID: &result.SystemID,
 		Tags:     result.Tags,
+		HasCover: result.HasCover,
 	}
 
 	zapScript := result.ZapScript()

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -597,7 +597,7 @@ func browseFilesystem(
 		}
 	}
 
-	return buildBrowseResponse(env, cleaned, dirs, files, maxResults, totalFiles, sort)
+	return buildBrowseResponse(env, cleaned, dirs, files, maxResults, totalFiles, sort, systems)
 }
 
 // browseVirtual lists all indexed media entries under a virtual URI scheme.
@@ -648,7 +648,7 @@ func browseVirtual(
 		}
 	}
 
-	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, sort)
+	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, sort, systems)
 }
 
 // buildBrowseResponse assembles the BrowseResults from directories, files, and pagination info.
@@ -660,6 +660,7 @@ func buildBrowseResponse(
 	maxResults int,
 	totalFiles int,
 	sort string,
+	systems []systemdefs.System,
 ) (any, error) {
 	hasNextPage := len(files) > maxResults
 	if hasNextPage {
@@ -673,6 +674,35 @@ func buildBrowseResponse(
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
 
+	// Batch-resolve singleton container aliases for the whole directory page when
+	// browsing a single system. This replaces the previous per-directory query
+	// loop (~5 DB queries × N dirs) with a fixed handful of batch queries.
+	var singletonAliases map[string]database.SingletonContainerAlias
+	if len(dirs) > 0 && len(systems) == 1 &&
+		singletonMediaAliasesEnabled(env) &&
+		env.Database != nil && env.Database.MediaDB != nil {
+		prefix := path
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+		system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systems[0].ID)
+		if sysErr == nil {
+			aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
+				env.Context, system.DBID, prefix,
+			)
+			if aliasErr == nil && len(aliases) > 0 {
+				singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
+				for i := range aliases {
+					singletonAliases[aliases[i].ChildDir] = aliases[i]
+				}
+			} else if aliasErr != nil {
+				log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
+			}
+		} else {
+			log.Debug().Err(sysErr).Str("system", systems[0].ID).Msg("browse singleton alias system lookup failed")
+		}
+	}
+
 	// Add directory entries
 	for _, dir := range dirs {
 		dirPath := filepath.ToSlash(filepath.Join(path, dir.Name))
@@ -683,8 +713,21 @@ func buildBrowseResponse(
 			FileCount: &dir.FileCount,
 			SystemIDs: dir.SystemIDs,
 		}
-		if isSingletonDirectoryAliasCandidate(dir.FileCount) {
-			annotateSingletonDirectoryEntry(env, &entry, dirPath, dir.SystemIDs, rootDirs)
+		if alias, ok := singletonAliases[dirPath+"/"]; ok {
+			result := database.SearchResultWithCursor{
+				MediaID:       alias.Row.DBID,
+				SystemID:      alias.Row.System.SystemID,
+				Name:          alias.Row.Title.Name,
+				Path:          alias.Row.Path,
+				Tags:          alias.Tags,
+				ZapScriptTags: alias.ZapScriptTags,
+			}
+			mediaEntry := buildMediaEntry(&result, env, rootDirs)
+			entry.MediaID = mediaEntry.MediaID
+			entry.SystemID = mediaEntry.SystemID
+			entry.RelPath = mediaEntry.RelPath
+			entry.ZapScript = mediaEntry.ZapScript
+			entry.Tags = mediaEntry.Tags
 		}
 		entries = append(entries, entry)
 	}
@@ -758,69 +801,6 @@ func buildMediaEntry(
 	}
 
 	return entry
-}
-
-func isSingletonDirectoryAliasCandidate(fileCount int) bool {
-	const maxSingletonAliasCandidateFiles = 64
-	return fileCount > 0 && fileCount <= maxSingletonAliasCandidateFiles
-}
-
-func annotateSingletonDirectoryEntry(
-	env *requests.RequestEnv,
-	entry *models.BrowseEntry,
-	dirPath string,
-	systemIDs []string,
-	rootDirs []string,
-) {
-	if env == nil || entry == nil || env.Database == nil || len(systemIDs) != 1 || !singletonMediaAliasesEnabled(env) {
-		return
-	}
-
-	db := env.Database.MediaDB
-	system, err := db.FindSystemBySystemID(systemIDs[0])
-	if err != nil {
-		log.Debug().Err(err).Str("system", systemIDs[0]).Msg("browse singleton directory system lookup failed")
-		return
-	}
-	media, err := db.FindSingleContainerLaunchMedia(env.Context, system.DBID, dirPath)
-	if err != nil {
-		log.Debug().Err(err).Str("path", dirPath).Msg("browse singleton directory lookup failed")
-		return
-	}
-	if media == nil {
-		return
-	}
-
-	row, err := db.GetMediaWithTitleAndSystem(env.Context, media.DBID)
-	if err != nil || row == nil {
-		log.Debug().Err(err).Int64("mediaDBID", media.DBID).Msg("browse singleton directory media lookup failed")
-		return
-	}
-	tags, err := db.GetMediaTagsByMediaDBID(env.Context, row.DBID)
-	if err != nil {
-		log.Debug().Err(err).Int64("mediaDBID", row.DBID).Msg("browse singleton directory tag lookup failed")
-		return
-	}
-	zapTags, err := db.GetZapScriptTagsBySystemAndPath(env.Context, row.System.SystemID, row.Path)
-	if err != nil {
-		log.Debug().Err(err).Int64("mediaDBID", row.DBID).Msg("browse singleton directory zapscript tag lookup failed")
-		return
-	}
-
-	result := database.SearchResultWithCursor{
-		MediaID:       row.DBID,
-		SystemID:      row.System.SystemID,
-		Name:          row.Title.Name,
-		Path:          row.Path,
-		Tags:          tags,
-		ZapScriptTags: zapTags,
-	}
-	mediaEntry := buildMediaEntry(&result, env, rootDirs)
-	entry.MediaID = mediaEntry.MediaID
-	entry.SystemID = mediaEntry.SystemID
-	entry.RelPath = mediaEntry.RelPath
-	entry.ZapScript = mediaEntry.ZapScript
-	entry.Tags = mediaEntry.Tags
 }
 
 // isPathUnderRoots checks if the given path is at or under one of the allowed root directories.

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -431,105 +432,121 @@ func TestHandleMediaBrowse_SystemRootRoutesUsesCachedCandidates(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
-func TestAnnotateSingletonDirectoryEntry_WhenZipsAsDirsEnabled(t *testing.T) {
+func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testing.T) {
 	t.Parallel()
+
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	systems := []systemdefs.System{{ID: "NES"}}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+	dirName := "Game.zip"
+	dirPath := filepath.ToSlash(filepath.Join(path, dirName))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      filepath.ToSlash(filepath.Join(dirPath, "Game.nes")),
+			ParentDir: dirPath + "/",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
+		System: nesSystem,
+	}
+	tags := []database.TagInfo{{Type: "favorite", Tag: "true", Label: "Favorite"}}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          tags,
+		ZapScriptTags: []database.TagInfo{},
+	}}
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
-	entry := models.BrowseEntry{
-		Name:      "Game.zip",
-		Path:      filepath.ToSlash(filepath.Join("roms", "Game.zip")),
-		Type:      "directory",
-		FileCount: intPtr(1),
-		SystemIDs: []string{"NES"},
-	}
-	row := &database.MediaFullRow{
-		Media: database.Media{
-			DBID:      20,
-			Path:      filepath.ToSlash(filepath.Join("roms", "Game.zip", "Game.nes")),
-			ParentDir: filepath.ToSlash(filepath.Join("roms", "Game.zip")) + "/",
-		},
-		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
-		System: database.System{DBID: 1, SystemID: "NES"},
-	}
-
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(row.System, nil).Once()
-	mockMediaDB.On("FindSingleContainerLaunchMedia", mock.Anything, row.System.DBID, entry.Path).
-		Return(&row.Media, nil).Once()
-	mockMediaDB.On("GetMediaWithTitleAndSystem", mock.Anything, row.DBID).Return(row, nil).Once()
-	mockMediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, row.DBID).
-		Return([]database.TagInfo{{Type: "favorite", Tag: "true", Label: "Favorite"}}, nil).Once()
-	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", row.Path).
-		Return([]database.TagInfo{}, nil).Once()
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
 		Context:  context.Background(),
 		Database: &database.Database{MediaDB: mockMediaDB},
 		Platform: mockPlatform,
 	}
-	annotateSingletonDirectoryEntry(env, &entry, entry.Path, entry.SystemIDs, nil)
-
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
+		nil, defaultMaxResults, 0, "", systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "directory", entry.Type)
 	assert.Equal(t, row.DBID, entry.MediaID)
 	require.NotNil(t, entry.SystemID)
 	assert.Equal(t, "NES", *entry.SystemID)
 	require.NotNil(t, entry.ZapScript)
 	assert.NotEmpty(t, *entry.ZapScript)
-	assert.Equal(t, []database.TagInfo{{Type: "favorite", Tag: "true", Label: "Favorite"}}, entry.Tags)
+	assert.Equal(t, tags, entry.Tags)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }
 
-func TestAnnotateSingletonDirectoryEntry_WhenZipsAsDirsDisabledSkipsLookup(t *testing.T) {
+func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsDisabledSkipsLookup(t *testing.T) {
 	t.Parallel()
+
+	systems := []systemdefs.System{{ID: "NES"}}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: false}).Once()
-	entry := models.BrowseEntry{
-		Path:      filepath.ToSlash(filepath.Join("roms", "Game.zip")),
-		Type:      "directory",
-		FileCount: intPtr(1),
-		SystemIDs: []string{"NES"},
-	}
+
 	env := &requests.RequestEnv{
 		Context:  context.Background(),
 		Database: &database.Database{MediaDB: mockMediaDB},
 		Platform: mockPlatform,
 	}
-	annotateSingletonDirectoryEntry(env, &entry, entry.Path, entry.SystemIDs, nil)
-
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: "Game.zip", FileCount: 1, SystemIDs: []string{"NES"}}},
+		nil, defaultMaxResults, 0, "", systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
 	assert.Zero(t, entry.MediaID)
 	assert.Nil(t, entry.ZapScript)
 	mockMediaDB.AssertNotCalled(t, "FindSystemBySystemID", mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases", mock.Anything)
 	mockPlatform.AssertExpectations(t)
 }
 
 func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 	t.Parallel()
 
-	mockMediaDB := helpers.NewMockMediaDBI()
-	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	psxSystem := database.System{DBID: 1, SystemID: "PSX"}
+	systems := []systemdefs.System{{ID: "PSX"}}
 	path := filepath.ToSlash(filepath.Join("roms", "PSX"))
 	dirPath := filepath.ToSlash(filepath.Join(path, "Game"))
-	row := &database.MediaFullRow{
+	row := database.MediaFullRow{
 		Media: database.Media{
 			DBID:      20,
 			Path:      filepath.ToSlash(filepath.Join(dirPath, "Game.cue")),
 			ParentDir: dirPath + "/",
 		},
 		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
-		System: database.System{DBID: 1, SystemID: "PSX"},
+		System: psxSystem,
 	}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+	}}
 
-	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(row.System, nil).Once()
-	mockMediaDB.On("FindSingleContainerLaunchMedia", mock.Anything, row.System.DBID, dirPath).
-		Return(&row.Media, nil).Once()
-	mockMediaDB.On("GetMediaWithTitleAndSystem", mock.Anything, row.DBID).Return(row, nil).Once()
-	mockMediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, row.DBID).Return([]database.TagInfo{}, nil).Once()
-	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "PSX", row.Path).
-		Return([]database.TagInfo{}, nil).Once()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID, path+"/").
+		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
 		Context:  context.Background(),
@@ -538,7 +555,7 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "Game", FileCount: 2, SystemIDs: []string{"PSX"}}},
-		nil, defaultMaxResults, 0, "")
+		nil, defaultMaxResults, 0, "", systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -555,15 +572,17 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	t.Parallel()
 
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	systems := []systemdefs.System{{ID: "NES"}}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
-	path := filepath.ToSlash(filepath.Join("roms", "NES"))
-	dirPath := filepath.ToSlash(filepath.Join(path, "Collection"))
-
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 1, SystemID: "NES"}, nil).Once()
-	mockMediaDB.On("FindSingleContainerLaunchMedia", mock.Anything, int64(1), dirPath).
-		Return((*database.Media)(nil), nil).Once()
+	// ResolveSingletonContainerAliases returns nil — no alias for the nested dir.
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+		Return([]database.SingletonContainerAlias(nil), nil).Once()
 
 	env := &requests.RequestEnv{
 		Context:  context.Background(),
@@ -572,7 +591,7 @@ func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "Collection", FileCount: 1, SystemIDs: []string{"NES"}}},
-		nil, defaultMaxResults, 0, "")
+		nil, defaultMaxResults, 0, "", systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -461,7 +461,8 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
 	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
 		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
@@ -516,7 +517,8 @@ func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *tes
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
 	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
 		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
@@ -600,7 +602,8 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
 	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID, path+"/").
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 2}}).
 		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
@@ -636,7 +639,8 @@ func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
 	// ResolveSingletonContainerAliases returns nil — no alias for the nested dir.
 	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: path + "/Collection/", FileCount: 1}}).
 		Return([]database.SingletonContainerAlias(nil), nil).Once()
 
 	env := &requests.RequestEnv{
@@ -657,6 +661,160 @@ func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	assert.Nil(t, entry.ZapScript)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
+}
+
+func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirSkipsLookup(t *testing.T) {
+	t.Parallel()
+
+	// A directory above the candidate file cap (e.g. MiSTer's
+	// _Arcade/_alternatives tree) must not trigger any alias resolution —
+	// no Settings, system lookup, or resolver calls at all.
+	systems := []systemdefs.System{{ID: "Arcade"}}
+	path := filepath.ToSlash(filepath.Join("media", "fat", "_Arcade"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: "_alternatives", FileCount: 5000, SystemIDs: []string{"Arcade"}}},
+		nil, defaultMaxResults, 0, "", systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Zero(t, entry.MediaID)
+	assert.Nil(t, entry.ZapScript)
+	mockMediaDB.AssertNotCalled(t, "FindSystemBySystemID", mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases", mock.Anything)
+	mockPlatform.AssertNotCalled(t, "Settings")
+}
+
+func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirExcludedFromCandidates(t *testing.T) {
+	t.Parallel()
+
+	// When the page mixes small candidate dirs with an oversized one, only
+	// the small dirs are passed to the resolver.
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	systems := []systemdefs.System{{ID: "NES"}}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+	dirPath := filepath.ToSlash(filepath.Join(path, "Game"))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      filepath.ToSlash(filepath.Join(dirPath, "Game.nes")),
+			ParentDir: dirPath + "/",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
+		System: nesSystem,
+	}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+	}}
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+		Return(alias, nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "Game", FileCount: 1, SystemIDs: []string{"NES"}},
+			{Name: "Collection", FileCount: 500, SystemIDs: []string{"NES"}},
+		},
+		nil, defaultMaxResults, 0, "", systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, row.DBID, browseResults.Entries[0].MediaID)
+	assert.Zero(t, browseResults.Entries[1].MediaID)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestBuildBrowseResponse_SingletonAnnotation_HasCoverPropagated(t *testing.T) {
+	t.Parallel()
+
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	systems := []systemdefs.System{{ID: "NES"}}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+	dirName := "Game.zip"
+	dirPath := filepath.ToSlash(filepath.Join(path, dirName))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      filepath.ToSlash(filepath.Join(dirPath, "Game.nes")),
+			ParentDir: dirPath + "/",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
+		System: nesSystem,
+	}
+
+	tests := []struct {
+		name          string
+		aliasHasCover bool
+	}{
+		{name: "HasCover true propagates", aliasHasCover: true},
+		{name: "HasCover false propagates", aliasHasCover: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			alias := []database.SingletonContainerAlias{{
+				ChildDir:      dirPath + "/",
+				Row:           row,
+				Tags:          []database.TagInfo{},
+				ZapScriptTags: []database.TagInfo{},
+				HasCover:      tt.aliasHasCover,
+			}}
+
+			mockMediaDB := helpers.NewMockMediaDBI()
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+			mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+			mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+				[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+				Return(alias, nil).Once()
+
+			env := &requests.RequestEnv{
+				Context:  context.Background(),
+				Database: &database.Database{MediaDB: mockMediaDB},
+				Platform: mockPlatform,
+			}
+			result, err := buildBrowseResponse(env, path,
+				[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
+				nil, defaultMaxResults, 0, "", systems)
+			require.NoError(t, err)
+			browseResults, ok := result.(models.BrowseResults)
+			require.True(t, ok)
+			require.Len(t, browseResults.Entries, 1)
+			entry := browseResults.Entries[0]
+			assert.Equal(t, "directory", entry.Type)
+			assert.Equal(t, row.DBID, entry.MediaID)
+			assert.Equal(t, tt.aliasHasCover, entry.HasCover)
+			mockMediaDB.AssertExpectations(t)
+			mockPlatform.AssertExpectations(t)
+		})
+	}
 }
 
 func TestDedupeSystemRootEntries(t *testing.T) {

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -488,6 +488,61 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *testing.T) {
+	t.Parallel()
+
+	// systems filter is empty — system must be inferred from dir.SystemIDs.
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+	dirName := "Game.zip"
+	dirPath := filepath.ToSlash(filepath.Join(path, dirName))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      filepath.ToSlash(filepath.Join(dirPath, "Game.nes")),
+			ParentDir: dirPath + "/",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "Game"},
+		System: nesSystem,
+	}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+	}}
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID, path+"/").
+		Return(alias, nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	// No systems filter passed — inferred from dir.SystemIDs.
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
+		nil, defaultMaxResults, 0, "", nil)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "directory", entry.Type)
+	assert.Equal(t, row.DBID, entry.MediaID)
+	require.NotNil(t, entry.SystemID)
+	assert.Equal(t, "NES", *entry.SystemID)
+	require.NotNil(t, entry.ZapScript)
+	assert.NotEmpty(t, *entry.ZapScript)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsDisabledSkipsLookup(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -455,6 +455,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 		Row:           row,
 		Tags:          tags,
 		ZapScriptTags: []database.TagInfo{},
+		HasCover:      true,
 	}}
 
 	mockMediaDB := helpers.NewMockMediaDBI()
@@ -485,6 +486,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	require.NotNil(t, entry.ZapScript)
 	assert.NotEmpty(t, *entry.ZapScript)
 	assert.Equal(t, tags, entry.Tags)
+	assert.True(t, entry.HasCover)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }
@@ -545,6 +547,38 @@ func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *tes
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestBuildBrowseResponse_SingletonAnnotation_SkipsLookupForMixedDirSystems(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.ToSlash(filepath.Join("roms", "shared"))
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "NES", FileCount: 1, SystemIDs: []string{"NES"}},
+			{Name: "SNES", FileCount: 1, SystemIDs: []string{"SNES"}},
+		},
+		nil, defaultMaxResults, 0, "", nil)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+	for _, entry := range browseResults.Entries {
+		assert.Zero(t, entry.MediaID)
+		assert.Nil(t, entry.ZapScript)
+	}
+	mockPlatform.AssertNotCalled(t, "Settings")
+	mockMediaDB.AssertNotCalled(t, "FindSystemBySystemID", mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsDisabledSkipsLookup(t *testing.T) {
 	t.Parallel()
 
@@ -596,6 +630,7 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 		Row:           row,
 		Tags:          []database.TagInfo{},
 		ZapScriptTags: []database.TagInfo{},
+		HasCover:      true,
 	}}
 
 	mockMediaDB := helpers.NewMockMediaDBI()
@@ -623,6 +658,7 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 	assert.Equal(t, row.DBID, entry.MediaID)
 	require.NotNil(t, entry.ZapScript)
 	assert.NotEmpty(t, *entry.ZapScript)
+	assert.True(t, entry.HasCover)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -32,6 +32,7 @@ import (
 	"image/jpeg"
 	"image/png"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -69,7 +70,10 @@ var mediaImageBeforeSemAcquire func()
 
 // mediaThumbCachePointer is the process-wide thumbnail disk cache stored as an
 // atomic pointer so concurrent StartWithReady calls in tests do not race on it.
-var mediaThumbCachePointer atomic.Pointer[mediaThumbCache]
+var (
+	mediaThumbCachePointer    atomic.Pointer[mediaThumbCache]
+	mediaThumbCacheGeneration atomic.Uint64
+)
 
 // mediaThumbCache persists resized cover images to disk so that the expensive
 // decode+bilinear-resize+transparency-scan is only performed once per unique
@@ -84,14 +88,28 @@ var mediaThumbCachePointer atomic.Pointer[mediaThumbCache]
 // resolved typeTag. It enables a pre-semaphore cache hit that skips the entire
 // image-load pipeline for warm repeat requests.
 type mediaThumbCache struct {
+	fs            afero.Fs
 	resolvedTypes map[string]string
 	dir           string
 	resolvedMu    syncutil.RWMutex
 }
 
 func newMediaThumbCache(pl platforms.Platform) *mediaThumbCache {
-	dir := filepath.Join(helpers.DataDir(pl), config.CacheDir, mediaThumbCacheDirName)
-	return &mediaThumbCache{dir: dir, resolvedTypes: make(map[string]string)}
+	return newMediaThumbCacheWithFS(pl, nil)
+}
+
+func newMediaThumbCacheWithFS(pl platforms.Platform, fs afero.Fs) *mediaThumbCache {
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
+	dir := filepath.Join(helpers.DataDir(pl), config.CacheDir, mediaThumbCacheDirName, "current")
+	return &mediaThumbCache{fs: fs, dir: dir, resolvedTypes: make(map[string]string)}
+}
+
+func (c *mediaThumbCache) nextGeneration() *mediaThumbCache {
+	generation := mediaThumbCacheGeneration.Add(1)
+	dir := filepath.Join(filepath.Dir(c.dir), fmt.Sprintf("gen-%d", generation))
+	return &mediaThumbCache{fs: c.fs, dir: dir, resolvedTypes: make(map[string]string)}
 }
 
 // earlyThumbKey returns a cache key derived only from request-time parameters
@@ -143,21 +161,42 @@ func hashThumbKey(key string) string {
 	return hex.EncodeToString(h[:])
 }
 
+type thumbCacheFormat struct {
+	ext         string
+	contentType string
+}
+
+var thumbCacheFormats = []thumbCacheFormat{
+	{ext: ".jpg", contentType: "image/jpeg"},
+	{ext: ".png", contentType: "image/png"},
+	{ext: ".gif", contentType: "image/gif"},
+	{ext: ".webp", contentType: "image/webp"},
+}
+
+func thumbCacheExtension(contentType string, data []byte) string {
+	ext := extensionFromContentType(contentType)
+	if ext == "" && len(data) > 0 {
+		ext = extensionFromContentType(http.DetectContentType(data))
+	}
+	for _, format := range thumbCacheFormats {
+		if strings.TrimPrefix(format.ext, ".") == ext {
+			return format.ext
+		}
+	}
+	return ""
+}
+
 // get looks up a cached resized image. Returns (data, contentType, true) on
 // hit, or (nil, "", false) on miss or any I/O error.
 func (c *mediaThumbCache) get(
 	ref mediaRefParam, typeTag string, maxSize int,
 ) (data []byte, contentType string, found bool) {
 	hash := hashThumbKey(thumbKey(ref, typeTag, maxSize))
-	for _, ext := range []string{".jpg", ".png"} {
+	for _, format := range thumbCacheFormats {
 		//nolint:gosec // path is constructed from a controlled dir + SHA-256 hash + fixed extension
-		b, err := os.ReadFile(filepath.Join(c.dir, hash+ext))
+		b, err := afero.ReadFile(c.fs, filepath.Join(c.dir, hash+format.ext))
 		if err == nil {
-			ct := "image/jpeg"
-			if ext == ".png" {
-				ct = "image/png"
-			}
-			return b, ct, true
+			return b, format.contentType, true
 		}
 	}
 	return nil, "", false
@@ -167,17 +206,17 @@ func (c *mediaThumbCache) get(
 // ignored — the caller always has the bytes in memory and must not fail on a
 // cache write error.
 func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, data []byte, contentType string) {
-	ext := ".jpg"
-	if strings.Contains(contentType, "png") {
-		ext = ".png"
+	ext := thumbCacheExtension(contentType, data)
+	if ext == "" {
+		return
 	}
-	if err := os.MkdirAll(c.dir, 0o750); err != nil { //nolint:gosec // cache dir, 0o750 is intentional
+	if err := c.fs.MkdirAll(c.dir, 0o750); err != nil { //nolint:gosec // cache dir, 0o750 is intentional
 		log.Debug().Err(err).Str("dir", c.dir).Msg("media.image: thumb cache: failed to create dir")
 		return
 	}
 	hash := hashThumbKey(thumbKey(ref, typeTag, maxSize))
 	path := filepath.Join(c.dir, hash+ext)
-	if err := os.WriteFile(path, data, 0o600); err != nil { //nolint:gosec // cache file, 0o600 is intentional
+	if err := afero.WriteFile(c.fs, path, data, 0o600); err != nil { //nolint:gosec // cache file, 0o600 is intentional
 		log.Debug().Err(err).Str("path", path).Msg("media.image: thumb cache: failed to write")
 	}
 }
@@ -186,7 +225,7 @@ func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, da
 // resolved-type memo. Called after a successful full media reindex so stale
 // entries do not accumulate.
 func (c *mediaThumbCache) wipe() {
-	if err := os.RemoveAll(c.dir); err != nil {
+	if err := c.fs.RemoveAll(c.dir); err != nil {
 		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache after reindex")
 	} else {
 		log.Info().Str("dir", c.dir).Msg("media.image: thumb cache wiped after reindex")
@@ -207,8 +246,9 @@ func InitMediaThumbCache(pl platforms.Platform) {
 // WipeMediaThumbCache removes all cached thumbnails. Called after a successful
 // full reindex so the cache does not serve stale art.
 func WipeMediaThumbCache() {
-	if tc := mediaThumbCachePointer.Load(); tc != nil {
-		tc.wipe()
+	if old := mediaThumbCachePointer.Load(); old != nil {
+		mediaThumbCachePointer.Store(old.nextGeneration())
+		old.wipe()
 	}
 }
 

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -79,13 +79,47 @@ var mediaThumbCachePointer atomic.Pointer[mediaThumbCache]
 //
 // Keys are SHA-256 hashes of the logical identity string; values are stored as
 // <hash>.jpg or <hash>.png to encode the content-type implicitly.
+//
+// resolvedTypes is an in-memory map from early key (identity+prefs+maxSize) to
+// resolved typeTag. It enables a pre-semaphore cache hit that skips the entire
+// image-load pipeline for warm repeat requests.
 type mediaThumbCache struct {
-	dir string
+	resolvedTypes map[string]string
+	dir           string
+	resolvedMu    syncutil.RWMutex
 }
 
 func newMediaThumbCache(pl platforms.Platform) *mediaThumbCache {
 	dir := filepath.Join(helpers.DataDir(pl), config.CacheDir, mediaThumbCacheDirName)
-	return &mediaThumbCache{dir: dir}
+	return &mediaThumbCache{dir: dir, resolvedTypes: make(map[string]string)}
+}
+
+// earlyThumbKey returns a cache key derived only from request-time parameters
+// (no typeTag needed). Used for the pre-semaphore resolved-type memo.
+func earlyThumbKey(ref mediaRefParam, prefs []string, maxSize int) string {
+	var identity string
+	if ref.MediaID != nil {
+		identity = fmt.Sprintf("id:%d", *ref.MediaID)
+	} else {
+		identity = fmt.Sprintf("path:%s:%s", ref.System, filepath.ToSlash(ref.Path))
+	}
+	return fmt.Sprintf("early:%s:[%s]:%d", identity, strings.Join(prefs, ","), maxSize)
+}
+
+// getResolvedTypeTag returns the previously resolved typeTag for this request,
+// or "" and false when not yet memoised.
+func (c *mediaThumbCache) getResolvedTypeTag(ref mediaRefParam, prefs []string, maxSize int) (string, bool) {
+	c.resolvedMu.RLock()
+	defer c.resolvedMu.RUnlock()
+	tag, ok := c.resolvedTypes[earlyThumbKey(ref, prefs, maxSize)]
+	return tag, ok
+}
+
+// setResolvedTypeTag records the resolved typeTag for future pre-semaphore hits.
+func (c *mediaThumbCache) setResolvedTypeTag(ref mediaRefParam, prefs []string, maxSize int, typeTag string) {
+	c.resolvedMu.Lock()
+	defer c.resolvedMu.Unlock()
+	c.resolvedTypes[earlyThumbKey(ref, prefs, maxSize)] = typeTag
 }
 
 // thumbKey returns the cache key string for a resize request. The key encodes
@@ -148,14 +182,18 @@ func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, da
 	}
 }
 
-// wipe removes the entire thumbnail cache directory. Called after a successful
-// full media reindex so stale entries do not accumulate.
+// wipe removes the entire thumbnail cache directory and clears the in-memory
+// resolved-type memo. Called after a successful full media reindex so stale
+// entries do not accumulate.
 func (c *mediaThumbCache) wipe() {
 	if err := os.RemoveAll(c.dir); err != nil {
 		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache after reindex")
 	} else {
 		log.Info().Str("dir", c.dir).Msg("media.image: thumb cache wiped after reindex")
 	}
+	c.resolvedMu.Lock()
+	c.resolvedTypes = make(map[string]string)
+	c.resolvedMu.Unlock()
 }
 
 // InitMediaThumbCache creates or replaces the process-wide thumb cache for the
@@ -462,6 +500,26 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		return nil, err
 	}
 	prefs := imagePrefs(nil, ref.ImageTypes)
+
+	// Pre-semaphore fast path: if this exact request was served before and the
+	// disk thumbnail is still present, return it without ever acquiring the
+	// semaphore or loading the original full-size image from disk.
+	if ref.MaxSize != nil && *ref.MaxSize > 0 {
+		maxSize := int(*ref.MaxSize)
+		if tc := mediaThumbCachePointer.Load(); tc != nil {
+			if resolvedTag, ok := tc.getResolvedTypeTag(ref, prefs, maxSize); ok {
+				if cached, cachedCT, cacheHit := tc.get(ref, resolvedTag, maxSize); cacheHit {
+					return models.MediaImageResponse{
+						Extension:   mediaContentExtension(cachedCT, ""),
+						ContentType: cachedCT,
+						Data:        base64.StdEncoding.EncodeToString(cached),
+						TypeTag:     resolvedTag,
+					}, nil
+				}
+			}
+		}
+	}
+
 	noImageKey := mediaImageNoImageRequestKey(ref, prefs)
 	if ok, cachedErr := mediaImageNoImages.get(noImageKey); ok {
 		return nil, cachedMediaImageNoImageError(cachedErr)
@@ -501,8 +559,14 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 	binary, ct := raw.binary, raw.contentType
 	if ref.MaxSize != nil && *ref.MaxSize > 0 {
 		maxSize := int(*ref.MaxSize)
+		tc := mediaThumbCachePointer.Load()
+		// Record the resolved typeTag so the pre-semaphore path can find the
+		// disk file on the next request without loading the original image.
+		if tc != nil {
+			tc.setResolvedTypeTag(ref, prefs, maxSize, raw.typeTag)
+		}
 		// Check the disk thumb cache before doing the expensive decode+resize.
-		if tc := mediaThumbCachePointer.Load(); tc != nil {
+		if tc != nil {
 			if cached, cachedCT, ok := tc.get(ref, raw.typeTag, maxSize); ok {
 				return models.MediaImageResponse{
 					Extension:   mediaContentExtension(cachedCT, raw.text),
@@ -514,7 +578,7 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		}
 		binary, ct = resizeImageIfNeeded(binary, ct, maxSize)
 		// Write to the disk cache on a miss so future requests skip the resize.
-		if tc := mediaThumbCachePointer.Load(); tc != nil {
+		if tc != nil {
 			tc.set(ref, raw.typeTag, maxSize, binary, ct)
 		}
 	}

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -22,7 +22,9 @@ package methods
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,11 +36,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
@@ -51,6 +56,9 @@ const (
 	misterMediaImageMaxBytes  = int64(2 * 1024 * 1024)
 	defaultMediaImageMaxBytes = int64(8 * 1024 * 1024)
 	mediaImageNoImageMax      = 4096
+	// mediaThumbCacheDirName is the sub-directory under the core cache dir where
+	// resized thumbnail files are persisted across restarts.
+	mediaThumbCacheDirName = "thumbs"
 )
 
 // mediaImageSem limits concurrent image lookups so high-volume image misses do
@@ -58,6 +66,113 @@ const (
 var mediaImageSem = make(chan struct{}, 1)
 
 var mediaImageBeforeSemAcquire func()
+
+// mediaThumbCachePointer is the process-wide thumbnail disk cache stored as an
+// atomic pointer so concurrent StartWithReady calls in tests do not race on it.
+var mediaThumbCachePointer atomic.Pointer[mediaThumbCache]
+
+// mediaThumbCache persists resized cover images to disk so that the expensive
+// decode+bilinear-resize+transparency-scan is only performed once per unique
+// (identity, imageType, maxSize) triple. The cache survives core restarts and
+// reboots; it is wiped entirely when a full media reindex completes (because
+// MediaDB row IDs change and file-backed image paths may have moved).
+//
+// Keys are SHA-256 hashes of the logical identity string; values are stored as
+// <hash>.jpg or <hash>.png to encode the content-type implicitly.
+type mediaThumbCache struct {
+	dir string
+}
+
+func newMediaThumbCache(pl platforms.Platform) *mediaThumbCache {
+	dir := filepath.Join(helpers.DataDir(pl), config.CacheDir, mediaThumbCacheDirName)
+	return &mediaThumbCache{dir: dir}
+}
+
+// thumbKey returns the cache key string for a resize request. The key encodes
+// the stable identity (media-ID or system+path) plus the resolved image-type tag
+// and target size. Media IDs change on reindex, but the whole cache is wiped
+// then, so they are safe to use here.
+func thumbKey(ref mediaRefParam, typeTag string, maxSize int) string {
+	var identity string
+	if ref.MediaID != nil {
+		identity = fmt.Sprintf("id:%d", *ref.MediaID)
+	} else {
+		identity = fmt.Sprintf("path:%s:%s", ref.System, filepath.ToSlash(ref.Path))
+	}
+	return fmt.Sprintf("%s:%s:%d", identity, typeTag, maxSize)
+}
+
+// hashThumbKey converts a key string to the 64-character hex filename prefix
+// used on disk.
+func hashThumbKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}
+
+// get looks up a cached resized image. Returns (data, contentType, true) on
+// hit, or (nil, "", false) on miss or any I/O error.
+func (c *mediaThumbCache) get(
+	ref mediaRefParam, typeTag string, maxSize int,
+) (data []byte, contentType string, found bool) {
+	hash := hashThumbKey(thumbKey(ref, typeTag, maxSize))
+	for _, ext := range []string{".jpg", ".png"} {
+		//nolint:gosec // path is constructed from a controlled dir + SHA-256 hash + fixed extension
+		b, err := os.ReadFile(filepath.Join(c.dir, hash+ext))
+		if err == nil {
+			ct := "image/jpeg"
+			if ext == ".png" {
+				ct = "image/png"
+			}
+			return b, ct, true
+		}
+	}
+	return nil, "", false
+}
+
+// set writes resized image bytes to the disk cache. Failures are logged and
+// ignored — the caller always has the bytes in memory and must not fail on a
+// cache write error.
+func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, data []byte, contentType string) {
+	ext := ".jpg"
+	if strings.Contains(contentType, "png") {
+		ext = ".png"
+	}
+	if err := os.MkdirAll(c.dir, 0o750); err != nil { //nolint:gosec // cache dir, 0o750 is intentional
+		log.Debug().Err(err).Str("dir", c.dir).Msg("media.image: thumb cache: failed to create dir")
+		return
+	}
+	hash := hashThumbKey(thumbKey(ref, typeTag, maxSize))
+	path := filepath.Join(c.dir, hash+ext)
+	if err := os.WriteFile(path, data, 0o600); err != nil { //nolint:gosec // cache file, 0o600 is intentional
+		log.Debug().Err(err).Str("path", path).Msg("media.image: thumb cache: failed to write")
+	}
+}
+
+// wipe removes the entire thumbnail cache directory. Called after a successful
+// full media reindex so stale entries do not accumulate.
+func (c *mediaThumbCache) wipe() {
+	if err := os.RemoveAll(c.dir); err != nil {
+		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache after reindex")
+	} else {
+		log.Info().Str("dir", c.dir).Msg("media.image: thumb cache wiped after reindex")
+	}
+}
+
+// InitMediaThumbCache creates or replaces the process-wide thumb cache for the
+// given platform. Must be called once during service start, before any
+// media.image requests are handled. Uses atomic store so concurrent
+// StartWithReady calls in tests do not race.
+func InitMediaThumbCache(pl platforms.Platform) {
+	mediaThumbCachePointer.Store(newMediaThumbCache(pl))
+}
+
+// WipeMediaThumbCache removes all cached thumbnails. Called after a successful
+// full reindex so the cache does not serve stale art.
+func WipeMediaThumbCache() {
+	if tc := mediaThumbCachePointer.Load(); tc != nil {
+		tc.wipe()
+	}
+}
 
 // defaultImageTypes is the preference order used when no imageTypes param is provided.
 var defaultImageTypes = []string{
@@ -177,7 +292,22 @@ func decodeResizableImage(binary []byte, contentType string) (image.Image, error
 	return nil, fmt.Errorf("unsupported image type for resize: %s", contentType)
 }
 
+// imageHasTransparency reports whether img contains any non-opaque pixel.
+// It short-circuits for common opaque types before falling back to a
+// pixel-by-pixel scan — avoiding O(w×h) work on ARM for JPEG sources.
 func imageHasTransparency(img image.Image) bool {
+	// Types that are always fully opaque — no alpha channel possible.
+	switch img.(type) {
+	case *image.YCbCr, *image.Gray, *image.Gray16, *image.CMYK:
+		return false
+	}
+	// Types that have an Opaque() helper — use it to avoid a pixel scan when
+	// the image was decoded with a known-opaque palette or alpha mask.
+	type opaque interface{ Opaque() bool }
+	if o, ok := img.(opaque); ok {
+		return !o.Opaque()
+	}
+	// Fallback: per-pixel scan for any remaining type (e.g. *image.Paletted).
 	bounds := img.Bounds()
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
@@ -370,7 +500,23 @@ func HandleMediaImage(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 
 	binary, ct := raw.binary, raw.contentType
 	if ref.MaxSize != nil && *ref.MaxSize > 0 {
-		binary, ct = resizeImageIfNeeded(binary, ct, int(*ref.MaxSize))
+		maxSize := int(*ref.MaxSize)
+		// Check the disk thumb cache before doing the expensive decode+resize.
+		if tc := mediaThumbCachePointer.Load(); tc != nil {
+			if cached, cachedCT, ok := tc.get(ref, raw.typeTag, maxSize); ok {
+				return models.MediaImageResponse{
+					Extension:   mediaContentExtension(cachedCT, raw.text),
+					ContentType: cachedCT,
+					Data:        base64.StdEncoding.EncodeToString(cached),
+					TypeTag:     raw.typeTag,
+				}, nil
+			}
+		}
+		binary, ct = resizeImageIfNeeded(binary, ct, maxSize)
+		// Write to the disk cache on a miss so future requests skip the resize.
+		if tc := mediaThumbCachePointer.Load(); tc != nil {
+			tc.set(ref, raw.typeTag, maxSize, binary, ct)
+		}
 	}
 	return models.MediaImageResponse{
 		Extension:   mediaContentExtension(ct, raw.text),

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -87,6 +88,68 @@ func mediaImageParams(row *database.MediaFullRow, extra string) json.RawMessage 
 		extra = ", " + extra
 	}
 	return json.RawMessage(fmt.Sprintf(`{"system": %q, "path": %q%s}`, row.System.SystemID, row.Path, extra))
+}
+
+func TestMediaThumbCache_GetSetAndWipe(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	cache := &mediaThumbCache{
+		fs:            fs,
+		dir:           filepath.Join("cache", "thumbs", "current"),
+		resolvedTypes: make(map[string]string),
+	}
+	mediaID := int64(1)
+	ref := mediaRefParam{MediaID: &mediaID}
+
+	_, _, found := cache.get(ref, "property:image-boxart", 100)
+	assert.False(t, found)
+
+	cache.set(ref, "property:image-boxart", 100, []byte("png-data"), "image/png")
+	data, contentType, found := cache.get(ref, "property:image-boxart", 100)
+	require.True(t, found)
+	assert.Equal(t, []byte("png-data"), data)
+	assert.Equal(t, "image/png", contentType)
+
+	cache.wipe()
+	_, _, found = cache.get(ref, "property:image-boxart", 100)
+	assert.False(t, found)
+}
+
+func TestMediaThumbCache_SkipsUnsupportedContentType(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	cache := &mediaThumbCache{
+		fs:            fs,
+		dir:           filepath.Join("cache", "thumbs", "current"),
+		resolvedTypes: make(map[string]string),
+	}
+	mediaID := int64(1)
+	ref := mediaRefParam{MediaID: &mediaID}
+
+	cache.set(ref, "property:image-boxart", 100, []byte("not an image"), "text/plain")
+	_, _, found := cache.get(ref, "property:image-boxart", 100)
+	assert.False(t, found)
+}
+
+func TestWipeMediaThumbCache_SwapsGenerationBeforeWiping(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	oldCache := &mediaThumbCache{
+		fs:            fs,
+		dir:           filepath.Join("cache", "thumbs", "current"),
+		resolvedTypes: make(map[string]string),
+	}
+	mediaThumbCachePointer.Store(oldCache)
+	t.Cleanup(func() { mediaThumbCachePointer.Store(nil) })
+
+	WipeMediaThumbCache()
+
+	newCache := mediaThumbCachePointer.Load()
+	require.NotNil(t, newCache)
+	assert.NotEqual(t, oldCache.dir, newCache.dir)
+	_, err := fs.Stat(oldCache.dir)
+	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestResizeImageIfNeeded_TransparentPNGPreservesAlpha(t *testing.T) {

--- a/pkg/api/methods/media_meta.go
+++ b/pkg/api/methods/media_meta.go
@@ -236,6 +236,15 @@ func buildMediaMetaResponse(
 	if row.Title.SecondarySlug.Valid {
 		secondarySlug = &row.Title.SecondarySlug.String
 	}
+	// Guard nil slices so they marshal to [] not null. The grouped tag scanner
+	// omits DBIDs with zero tags from its map, so callers may receive nil from
+	// a map lookup when no tags exist.
+	if mediaTags == nil {
+		mediaTags = []database.TagInfo{}
+	}
+	if titleTags == nil {
+		titleTags = []database.TagInfo{}
+	}
 
 	return models.MediaMetaResponse{Media: models.MediaMetaMediaResponse{
 		Path:                row.Path,
@@ -274,7 +283,7 @@ func availableImageTypes(props []database.MediaProperty) []string {
 		}
 	}
 	if len(seen) == 0 {
-		return nil
+		return []string{}
 	}
 
 	result := make([]string, 0, len(seen))

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -66,6 +66,11 @@ type BrowseEntry struct {
 	SystemIDs []string           `json:"systemIds,omitempty"`
 	Tags      []database.TagInfo `json:"tags,omitempty"`
 	MediaID   int64              `json:"mediaId,omitempty"`
+	// HasCover is true when the media or its title has at least one image
+	// property row. Only set for media-type entries. Omitted when false so
+	// older clients that don't know this field behave as if it is true (i.e.,
+	// they still request covers).
+	HasCover bool `json:"hasCover,omitempty"`
 }
 
 type BrowseResults struct {

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -67,9 +67,9 @@ type BrowseEntry struct {
 	Tags      []database.TagInfo `json:"tags,omitempty"`
 	MediaID   int64              `json:"mediaId,omitempty"`
 	// HasCover is true when the media or its title has at least one image
-	// property row. Only set for media-type entries. Omitted when false so
-	// older clients that don't know this field behave as if it is true (i.e.,
-	// they still request covers).
+	// property row. Only set for media-type entries and singleton-aliased
+	// directory entries. Always emitted (never omitempty) so clients can
+	// skip cover requests for entries without art.
 	HasCover bool `json:"hasCover"`
 }
 

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -70,7 +70,7 @@ type BrowseEntry struct {
 	// property row. Only set for media-type entries. Omitted when false so
 	// older clients that don't know this field behave as if it is true (i.e.,
 	// they still request covers).
-	HasCover bool `json:"hasCover,omitempty"`
+	HasCover bool `json:"hasCover"`
 }
 
 type BrowseResults struct {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1427,6 +1427,8 @@ func StartWithReady(
 		}
 	}
 
+	methods.InitMediaThumbCache(platform)
+
 	// Extract port from listen address or use default
 	port := cfg.APIPort()
 	listenAddr := cfg.APIListen()

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -273,6 +273,18 @@ type SingletonContainerAlias struct {
 	Tags          []TagInfo
 	ZapScriptTags []TagInfo
 	Row           MediaFullRow
+	HasCover      bool
+}
+
+// SingletonAliasCandidate identifies a child directory to consider for
+// singleton-container alias resolution. ChildDir must end with a trailing
+// slash. FileCount is the recursive per-system media count for the directory
+// (from the browse cache) — when it exceeds the number of direct media rows,
+// the directory contains nested subdirectories and is not a singleton
+// container.
+type SingletonAliasCandidate struct {
+	ChildDir  string
+	FileCount int
 }
 
 // BrowseDirectoriesOptions contains parameters for the BrowseDirectories query.
@@ -748,14 +760,15 @@ type MediaDBI interface {
 	// direct contents of containerPath for systemDBID, or nil, nil when the
 	// container is empty, nested-only, or ambiguous.
 	FindSingleContainerLaunchMedia(ctx context.Context, systemDBID int64, containerPath string) (*Media, error)
-	// ResolveSingletonContainerAliases resolves all child directories under
-	// parentPrefix for systemDBID in a single scan, returning one
-	// SingletonContainerAlias per child dir that collapses to a single launch
-	// target. Directories with nested subdirs or ambiguous contents are omitted.
+	// ResolveSingletonContainerAliases resolves the given candidate child
+	// directories for systemDBID in a single batch query, returning one
+	// SingletonContainerAlias per candidate that collapses to a single launch
+	// target. Candidates with nested subdirs (recursive FileCount exceeding
+	// their direct media rows) or ambiguous contents are omitted.
 	// ZapScriptTags are populated via in-memory disambiguation (same approach
 	// as the search path) and will be empty for unambiguous titles.
 	ResolveSingletonContainerAliases(
-		ctx context.Context, systemDBID int64, parentPrefix string,
+		ctx context.Context, systemDBID int64, candidates []SingletonAliasCandidate,
 	) ([]SingletonContainerAlias, error)
 
 	// FindMediaBySystemAndPathFold returns the Media row matching systemDBID and

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -353,6 +353,10 @@ type SearchResultWithCursor struct {
 	ZapScriptTags []TagInfo // Disambiguating tags only (tags that differ across sibling variants)
 	MediaID       int64
 	MediaTitleID  int64 `json:"-"`
+	// HasCover is true when the media or its title has at least one image
+	// property row in MediaProperties or MediaTitleProperties. Set by the
+	// browse files path; not populated by search/other paths.
+	HasCover bool
 }
 
 // ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -486,6 +486,7 @@ type SearchFilters struct {
 type ScanState struct {
 	SystemIDs          map[string]int
 	TitleIDs           map[string]int
+	TitleNames         map[int]string
 	MediaIDs           map[string]int
 	MediaTitleIDs      map[int]int      // Existing media DBID -> MediaTitleDBID for persistent reconciliation
 	MediaNeedsSortName map[int]struct{} // Media DBIDs with SortName='' needing a write on next title update

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -266,6 +266,15 @@ type BrowseDirectoryResult struct {
 	FileCount int
 }
 
+// SingletonContainerAlias is the resolved launch media for a child directory
+// whose contents collapse to a single logical launch target.
+type SingletonContainerAlias struct {
+	ChildDir      string
+	Tags          []TagInfo
+	ZapScriptTags []TagInfo
+	Row           MediaFullRow
+}
+
 // BrowseDirectoriesOptions contains parameters for the BrowseDirectories query.
 type BrowseDirectoriesOptions struct {
 	PathPrefix string
@@ -739,6 +748,15 @@ type MediaDBI interface {
 	// direct contents of containerPath for systemDBID, or nil, nil when the
 	// container is empty, nested-only, or ambiguous.
 	FindSingleContainerLaunchMedia(ctx context.Context, systemDBID int64, containerPath string) (*Media, error)
+	// ResolveSingletonContainerAliases resolves all child directories under
+	// parentPrefix for systemDBID in a single scan, returning one
+	// SingletonContainerAlias per child dir that collapses to a single launch
+	// target. Directories with nested subdirs or ambiguous contents are omitted.
+	// ZapScriptTags are populated via in-memory disambiguation (same approach
+	// as the search path) and will be empty for unambiguous titles.
+	ResolveSingletonContainerAliases(
+		ctx context.Context, systemDBID int64, parentPrefix string,
+	) ([]SingletonContainerAlias, error)
 
 	// FindMediaBySystemAndPathFold returns the Media row matching systemDBID and
 	// path using a case-insensitive path comparison, or nil, nil when no row is

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -153,6 +153,7 @@ type MediaTitle struct {
 type Media struct {
 	Path           string
 	ParentDir      string
+	SortName       string // write-once copy of MediaTitles.Name; titles never update so no propagation is needed
 	DBID           int64
 	MediaTitleDBID int64
 	SystemDBID     int64
@@ -407,6 +408,7 @@ type MediaWithFullPath struct {
 	ParentDir      string
 	TitleSlug      string
 	SystemID       string
+	SortName       string
 	DBID           int64
 	MediaTitleDBID int64
 }
@@ -461,21 +463,22 @@ type SearchFilters struct {
 }
 
 type ScanState struct {
-	SystemIDs       map[string]int
-	TitleIDs        map[string]int
-	MediaIDs        map[string]int
-	MediaTitleIDs   map[int]int // Existing media DBID -> MediaTitleDBID for persistent reconciliation
-	MediaParentDirs map[int]string
-	MediaTagIDs     map[int]map[int]struct{}
-	TagTypeIDs      map[string]int
-	TagIDs          map[string]int
-	UserOwnedTagIDs map[int]bool
-	MissingMedia    map[int]struct{} // DBIDs of media not yet re-found during scan
-	SystemsIndex    int
-	TitlesIndex     int
-	MediaIndex      int
-	TagTypesIndex   int
-	TagsIndex       int
+	SystemIDs          map[string]int
+	TitleIDs           map[string]int
+	MediaIDs           map[string]int
+	MediaTitleIDs      map[int]int      // Existing media DBID -> MediaTitleDBID for persistent reconciliation
+	MediaNeedsSortName map[int]struct{} // Media DBIDs with SortName='' needing a write on next title update
+	MediaParentDirs    map[int]string
+	MediaTagIDs        map[int]map[int]struct{}
+	TagTypeIDs         map[string]int
+	TagIDs             map[string]int
+	UserOwnedTagIDs    map[int]bool
+	MissingMedia       map[int]struct{} // DBIDs of media not yet re-found during scan
+	SystemsIndex       int
+	TitlesIndex        int
+	MediaIndex         int
+	TagTypesIndex      int
+	TagsIndex          int
 }
 
 // JournalMode represents SQLite journal mode
@@ -662,7 +665,7 @@ type MediaDBI interface {
 	FindMedia(row Media) (Media, error)
 	InsertMedia(row Media) (Media, error)
 	FindOrInsertMedia(row Media) (Media, error)
-	UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error
+	UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortName string) error
 	UpdateMediaParentDir(mediaDBID int64, parentDir string) error
 	DeleteMediaTags(mediaDBID int64) error
 	DeleteMediaTag(mediaDBID, tagDBID int64) error

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -119,6 +119,7 @@ type MediaDB struct {
 	needsIndexRebuild     atomic.Bool
 	inTransaction         bool
 	browseCacheDirty      bool
+	utilityTagCacheDirty  bool
 }
 
 // sqlQueryable is the subset of *sql.DB and *sql.Tx needed by SQL helpers.
@@ -144,12 +145,16 @@ type invalidationScope struct {
 	SystemIDs               []string
 	AllSystems              bool
 	PreserveSlugSearchCache bool
+	UtilityTagDBIDsChanged  bool
 }
 
 // invalidateCaches handles all cache invalidation in one place
 func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 	db.inMemoryTagCache.Store(nil)
-	clearUtilityTagCache()
+	if scope.UtilityTagDBIDsChanged {
+		clearUtilityTagCache()
+		db.utilityTagCacheDirty = false
+	}
 	switch {
 	case scope.AllSystems:
 		if !scope.PreserveSlugSearchCache {
@@ -214,6 +219,10 @@ func (db *MediaDB) DropSlugSearchCacheForSystems(systemIDs []string) {
 
 func (db *MediaDB) markBrowseCacheDirty() {
 	db.browseCacheDirty = true
+}
+
+func (db *MediaDB) markUtilityTagCacheDirty() {
+	db.utilityTagCacheDirty = true
 }
 
 func (db *MediaDB) invalidateBrowseCacheForMediaChange() error {
@@ -282,6 +291,7 @@ func (db *MediaDB) Open() error {
 	}
 	sqlInstance.SetMaxOpenConns(2)
 	db.sql = sqlInstance
+	clearUtilityTagCache()
 
 	if !exists {
 		log.Debug().Msg("media database is new, allocating schema")
@@ -700,7 +710,7 @@ func (db *MediaDB) Truncate() error {
 	}
 
 	// Invalidate all caches after full truncation
-	db.invalidateCaches(invalidationScope{AllSystems: true})
+	db.invalidateCaches(invalidationScope{AllSystems: true, UtilityTagDBIDsChanged: true})
 
 	// Reclaim disk space freed by the truncation
 	if err := sqlVacuum(db.ctx, db.sql); err != nil {
@@ -723,7 +733,9 @@ func (db *MediaDB) TruncateSystems(systemIDs []string) error {
 	}
 
 	// Invalidate caches for the affected systems
-	db.invalidateCaches(invalidationScopeForSystemIDs(systemIDs))
+	scope := invalidationScopeForSystemIDs(systemIDs)
+	scope.UtilityTagDBIDsChanged = true
+	db.invalidateCaches(scope)
 	return nil
 }
 
@@ -807,7 +819,7 @@ func (db *MediaDB) CleanMediaOrphans(ctx context.Context) (int64, error) {
 	}
 
 	if deleted > 0 {
-		db.invalidateCaches(invalidationScope{AllSystems: true})
+		db.invalidateCaches(invalidationScope{AllSystems: true, UtilityTagDBIDsChanged: true})
 		if err := sqlInvalidateBrowseCache(ctx, db.sql); err != nil {
 			log.Warn().Err(err).Msg("failed to invalidate browse cache after orphan cleanup")
 		}
@@ -840,26 +852,35 @@ func (db *MediaDB) cacheInvalidationScopeForCommittedTransaction() invalidationS
 	status, statusErr := sqlGetIndexingStatus(db.ctx, db.sql)
 	if statusErr != nil {
 		log.Warn().Err(statusErr).Msg("failed to determine indexing status for cache invalidation")
-		return invalidationScope{AllSystems: true}
+		scope := invalidationScope{AllSystems: true}
+		scope.UtilityTagDBIDsChanged = db.utilityTagCacheDirty
+		return scope
 	}
 
 	if status != IndexingStatusRunning && status != IndexingStatusPending {
-		return invalidationScope{AllSystems: true}
+		scope := invalidationScope{AllSystems: true}
+		scope.UtilityTagDBIDsChanged = db.utilityTagCacheDirty
+		return scope
 	}
 
 	systemIDs, getSystemsErr := sqlGetIndexingSystems(db.ctx, db.sql)
 	if getSystemsErr != nil {
 		log.Warn().Err(getSystemsErr).Msg("failed to load indexing systems for cache invalidation")
-		return invalidationScope{AllSystems: true}
+		scope := invalidationScope{AllSystems: true}
+		scope.UtilityTagDBIDsChanged = db.utilityTagCacheDirty
+		return scope
 	}
 
-	return invalidationScopeForSystemIDs(systemIDs)
+	scope := invalidationScopeForSystemIDs(systemIDs)
+	scope.UtilityTagDBIDsChanged = db.utilityTagCacheDirty
+	return scope
 }
 
 // SetSQLForTesting allows injection of a sql.DB instance for testing purposes.
 // This method should only be used in tests to set up in-memory databases.
 func (db *MediaDB) SetSQLForTesting(ctx context.Context, sqlDB *sql.DB, platform platforms.Platform) error {
 	db.sql = sqlDB
+	clearUtilityTagCache()
 	db.ctx = ctx
 	db.pl = platform
 	db.clock = clockwork.NewRealClock()
@@ -991,6 +1012,7 @@ func (db *MediaDB) RollbackTransaction() error {
 	db.tx = nil
 	db.inTransaction = false // Clear transaction flag (no cache invalidation needed on rollback)
 	db.clearBrowseCacheInvalidation()
+	db.utilityTagCacheDirty = false
 	if err != nil {
 		return fmt.Errorf("failed to rollback transaction: %w", err)
 	}
@@ -1017,6 +1039,7 @@ func (db *MediaDB) rollbackAndLogError() {
 	db.tx = nil
 	db.inTransaction = false
 	db.clearBrowseCacheInvalidation()
+	db.utilityTagCacheDirty = false
 }
 
 func (db *MediaDB) BeginTransaction(batchEnabled bool) error {
@@ -1229,11 +1252,13 @@ func (db *MediaDB) CommitTransaction() error {
 				db.tx = nil
 				db.inTransaction = false
 				db.clearBrowseCacheInvalidation()
+				db.utilityTagCacheDirty = false
 				return fmt.Errorf("failed to flush batch inserts: %w; rollback also failed: %w", closeErr, rbErr)
 			}
 			db.tx = nil
 			db.inTransaction = false
 			db.clearBrowseCacheInvalidation()
+			db.utilityTagCacheDirty = false
 			return fmt.Errorf("failed to flush batch inserts: %w", closeErr)
 		}
 	} else {
@@ -1249,11 +1274,13 @@ func (db *MediaDB) CommitTransaction() error {
 			db.tx = nil
 			db.inTransaction = false
 			db.clearBrowseCacheInvalidation()
+			db.utilityTagCacheDirty = false
 			return fmt.Errorf("commit failed: %w; rollback also failed: %w", err, rbErr)
 		}
 		db.tx = nil
 		db.inTransaction = false
 		db.clearBrowseCacheInvalidation()
+		db.utilityTagCacheDirty = false
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
@@ -2469,6 +2496,7 @@ func (db *MediaDB) InsertTagType(row database.TagType) (database.TagType, error)
 		if err != nil {
 			return row, fmt.Errorf("failed to add tag type to batch: %w", err)
 		}
+		db.markUtilityTagCacheDirty()
 		// Return row as-is (DBID is already set by caller)
 		return row, nil
 	}
@@ -2482,7 +2510,9 @@ func (db *MediaDB) InsertTagType(row database.TagType) (database.TagType, error)
 
 	// Only invalidate cache if NOT in a transaction (transactions invalidate once on commit)
 	if err == nil && !db.inTransaction {
-		db.invalidateCaches(invalidationScope{AllSystems: true})
+		db.invalidateCaches(invalidationScope{AllSystems: true, UtilityTagDBIDsChanged: true})
+	} else if err == nil {
+		db.markUtilityTagCacheDirty()
 	}
 
 	return result, err
@@ -2510,6 +2540,7 @@ func (db *MediaDB) InsertTag(row database.Tag) (database.Tag, error) {
 		if err != nil {
 			return row, fmt.Errorf("failed to add tag to batch: %w", err)
 		}
+		db.markUtilityTagCacheDirty()
 		// Return row as-is (DBID is already set by caller)
 		return row, nil
 	}
@@ -2523,7 +2554,9 @@ func (db *MediaDB) InsertTag(row database.Tag) (database.Tag, error) {
 
 	// Only invalidate cache if NOT in a transaction (transactions invalidate once on commit)
 	if err == nil && !db.inTransaction {
-		db.invalidateCaches(invalidationScope{AllSystems: true})
+		db.invalidateCaches(invalidationScope{AllSystems: true, UtilityTagDBIDsChanged: true})
+	} else if err == nil {
+		db.markUtilityTagCacheDirty()
 	}
 
 	return result, err

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -149,6 +149,7 @@ type invalidationScope struct {
 // invalidateCaches handles all cache invalidation in one place
 func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 	db.inMemoryTagCache.Store(nil)
+	clearUtilityTagCache()
 	switch {
 	case scope.AllSystems:
 		if !scope.PreserveSlugSearchCache {

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -386,6 +386,10 @@ var secondaryIndexes = []secondaryIndex{
 		name: "idx_media_parentdir_system",
 		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_parentdir_system ON Media(ParentDir, SystemDBID)",
 	},
+	{
+		name: "idx_media_browse_sort",
+		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID)",
+	},
 }
 
 // DropSecondaryIndexes drops all secondary indexes to speed up bulk inserts.
@@ -1063,8 +1067,10 @@ func (db *MediaDB) BeginTransaction(batchEnabled bool) error {
 			return fmt.Errorf("failed to create batch inserter for media titles: %w", err)
 		}
 
-		if db.batchInsertMedia, err = NewBatchInserterWithOptions(db.ctx, tx, "Media",
-			[]string{"DBID", "MediaTitleDBID", "SystemDBID", "Path", "ParentDir"}, db.batchSize, false); err != nil {
+		mediaColumns := []string{"DBID", "MediaTitleDBID", "SystemDBID", "Path", "ParentDir", "SortName"}
+		if db.batchInsertMedia, err = NewBatchInserterWithOptions(
+			db.ctx, tx, "Media", mediaColumns, db.batchSize, false,
+		); err != nil {
 			db.rollbackAndLogError()
 			return fmt.Errorf("failed to create batch inserter for media: %w", err)
 		}
@@ -1291,7 +1297,7 @@ func (db *MediaDB) insertMediaTitleWithPreparedStmt(row *database.MediaTitle) (d
 	return sqlInsertMediaTitleWithPreparedStmt(db.ctx, db.stmtInsertMediaTitle, row)
 }
 
-func (db *MediaDB) insertMediaWithPreparedStmt(row database.Media) (database.Media, error) {
+func (db *MediaDB) insertMediaWithPreparedStmt(row *database.Media) (database.Media, error) {
 	return sqlInsertMediaWithPreparedStmt(db.ctx, db.stmtInsertMedia, row)
 }
 
@@ -2252,11 +2258,13 @@ func (db *MediaDB) FindOrInsertMediaTitle(row *database.MediaTitle) (database.Me
 	return system, err
 }
 
-func (db *MediaDB) FindMedia(row database.Media) (database.Media, error) {
-	return sqlFindMedia(db.ctx, db.conn(), row)
+// FindMedia implements MediaDBI. Param is by value because the interface is.
+func (db *MediaDB) FindMedia(row database.Media) (database.Media, error) { //nolint:gocritic
+	return sqlFindMedia(db.ctx, db.conn(), &row)
 }
 
-func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
+// InsertMedia implements MediaDBI. Param is by value because the interface is.
+func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
 	var result database.Media
 	var err error
 
@@ -2268,6 +2276,7 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 			row.SystemDBID,
 			row.Path,
 			row.ParentDir,
+			row.SortName,
 		)
 		if err != nil {
 			return row, fmt.Errorf("failed to add media to batch: %w", err)
@@ -2279,9 +2288,9 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 
 	// Use prepared statement if in transaction, otherwise fall back to original method
 	if db.stmtInsertMedia != nil {
-		result, err = db.insertMediaWithPreparedStmt(row)
+		result, err = db.insertMediaWithPreparedStmt(&row)
 	} else {
-		result, err = sqlInsertMedia(db.ctx, db.sql, row)
+		result, err = sqlInsertMedia(db.ctx, db.sql, &row)
 	}
 
 	// Only invalidate cache if NOT in a transaction (transactions invalidate once on commit)
@@ -2297,7 +2306,7 @@ func (db *MediaDB) InsertMedia(row database.Media) (database.Media, error) {
 	return result, err
 }
 
-func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
+func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortName string) error {
 	if db.sql == nil {
 		return ErrNullSQL
 	}
@@ -2307,7 +2316,7 @@ func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
 		}
 	}
 
-	err := sqlUpdateMediaTitle(db.ctx, db.conn(), mediaDBID, mediaTitleDBID)
+	err := sqlUpdateMediaTitle(db.ctx, db.conn(), mediaDBID, mediaTitleDBID, sortName)
 	if err == nil && !db.inTransaction {
 		db.invalidateCaches(invalidationScope{AllSystems: true})
 		if invalidateErr := db.invalidateBrowseCacheForMediaChange(); invalidateErr != nil {
@@ -2431,7 +2440,8 @@ func (db *MediaDB) ResetMissingFlags(systemDBIDs []int) error {
 	return err
 }
 
-func (db *MediaDB) FindOrInsertMedia(row database.Media) (database.Media, error) {
+// FindOrInsertMedia implements MediaDBI. Param is by value because the interface is.
+func (db *MediaDB) FindOrInsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
 	system, err := db.FindMedia(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		system, err = db.InsertMedia(row)

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -2897,12 +2897,14 @@ func TestMediaDB_UpdateMediaTitle_FlushesPendingTitleBatch_Integration(t *testin
 		Name:       "New Title",
 	})
 	require.NoError(t, err)
-	require.NoError(t, mediaDB.UpdateMediaTitle(insertedMedia.DBID, newTitleDBID, "New Title"))
+	expectedSortName := "New Title"
+	require.NoError(t, mediaDB.UpdateMediaTitle(insertedMedia.DBID, newTitleDBID, expectedSortName))
 	require.NoError(t, mediaDB.CommitTransaction())
 
 	updatedMedia, err := mediaDB.FindMedia(database.Media{DBID: insertedMedia.DBID})
 	require.NoError(t, err)
 	assert.Equal(t, newTitleDBID, updatedMedia.MediaTitleDBID)
+	assert.Equal(t, expectedSortName, updatedMedia.SortName)
 }
 
 func TestMediaDB_TemporaryParentDirRepair_RestoresDirectBrowse_Integration(t *testing.T) {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -320,6 +320,7 @@ func insertSystemMedia(t *testing.T, mediaDB *MediaDB, system database.System, t
 		MediaTitleDBID: insertedTitle.DBID,
 		Path:           mediaPath,
 		ParentDir:      parentDir,
+		SortName:       titleName,
 	})
 	require.NoError(t, err)
 	require.NoError(t, mediaDB.CommitTransaction())
@@ -2896,7 +2897,7 @@ func TestMediaDB_UpdateMediaTitle_FlushesPendingTitleBatch_Integration(t *testin
 		Name:       "New Title",
 	})
 	require.NoError(t, err)
-	require.NoError(t, mediaDB.UpdateMediaTitle(insertedMedia.DBID, newTitleDBID))
+	require.NoError(t, mediaDB.UpdateMediaTitle(insertedMedia.DBID, newTitleDBID, "New Title"))
 	require.NoError(t, mediaDB.CommitTransaction())
 
 	updatedMedia, err := mediaDB.FindMedia(database.Media{DBID: insertedMedia.DBID})
@@ -3844,6 +3845,7 @@ func TestMediaDB_BrowseFiles_UsesRankPrefixSortForNumberedCollections(t *testing
 			MediaTitleDBID: title.DBID,
 			Path:           entry.path,
 			ParentDir:      dir,
+			SortName:       entry.name,
 		})
 		require.NoError(t, insertErr)
 	}

--- a/pkg/database/mediadb/migrations/20260609120000_media_sortname.sql
+++ b/pkg/database/mediadb/migrations/20260609120000_media_sortname.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE Media ADD COLUMN SortName TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_media_browse_sort;
+ALTER TABLE Media DROP COLUMN SortName;

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -33,6 +33,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// imagePropertyTagPrefix is the common prefix for all image property TypeTag
+// values (e.g. "property:image-image", "property:image-boxart", …).
+// All image type tags in the Tags table start with this string, so a LIKE
+// filter with this prefix selects exactly the set of image property types.
+const imagePropertyTagPrefix = "property:image-"
+
 const (
 	browseSortRankPrefixAsc  = "rank-prefix-asc"
 	browseSortRankPrefixDesc = "rank-prefix-desc"
@@ -526,6 +532,10 @@ func sqlBrowseFilesFromMedia(
 	}
 	tagsElapsed := time.Since(tagsStarted)
 
+	if err := fetchAndAttachCoverFlags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse files cover flags: %w", err)
+	}
+
 	log.Debug().
 		Str("pathPrefix", opts.PathPrefix).
 		Strs("systems", browseSystemIDsForLog(opts.Systems)).
@@ -534,6 +544,79 @@ func sqlBrowseFilesFromMedia(
 		Dur("tagsDuration", tagsElapsed).
 		Msg("browse files step timing")
 	return results, nil
+}
+
+// fetchAndAttachCoverFlags sets HasCover on each result based on whether the
+// media or its title has at least one image property row. A single UNION ALL
+// query covers both MediaProperties (media-level) and MediaTitleProperties
+// (title-level), both of which are indexed by their respective IDs. Results
+// with no image property get HasCover=false; the browse response omits that
+// field so that older clients (without this field) continue to request covers.
+func fetchAndAttachCoverFlags(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+
+	mediaIDs := make([]int64, len(results))
+	for i := range results {
+		mediaIDs[i] = results[i].MediaID
+	}
+
+	placeholders := prepareVariadic("?", ",", len(mediaIDs))
+	args := make([]any, 0, len(mediaIDs)*2)
+	for _, id := range mediaIDs {
+		args = append(args, id)
+	}
+	for _, id := range mediaIDs {
+		args = append(args, id)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	query := `
+		SELECT DISTINCT sub.MediaDBID
+		FROM (
+			SELECT mp.MediaDBID
+			FROM MediaProperties mp
+			JOIN Tags t ON t.DBID = mp.TypeTagDBID
+			WHERE mp.MediaDBID IN (` + placeholders + `)
+			  AND t.Tag LIKE '` + imagePropertyTagPrefix + `%'
+
+			UNION ALL
+
+			SELECT m.DBID AS MediaDBID
+			FROM Media m
+			JOIN MediaTitleProperties mtp ON mtp.MediaTitleDBID = m.MediaTitleDBID
+			JOIN Tags t ON t.DBID = mtp.TypeTagDBID
+			WHERE m.DBID IN (` + placeholders + `)
+			  AND t.Tag LIKE '` + imagePropertyTagPrefix + `%'
+		) sub`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("browse cover flags query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	withCover := make(map[int64]bool, len(results))
+	for rows.Next() {
+		var id int64
+		if scanErr := rows.Scan(&id); scanErr != nil {
+			return fmt.Errorf("browse cover flags scan: %w", scanErr)
+		}
+		withCover[id] = true
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("browse cover flags rows: %w", err)
+	}
+
+	for i := range results {
+		results[i].HasCover = withCover[results[i].MediaID]
+	}
+	return nil
 }
 
 func sqlBrowseFileCount(

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -24,6 +24,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/rs/zerolog/log"
 )
 
@@ -48,6 +50,71 @@ const (
 	browseSortDatePrefixAsc  = "date-prefix-asc"
 	browseSortDatePrefixDesc = "date-prefix-desc"
 )
+
+// utilityTagCache memoises resolved utility tag DBIDs per DB connection so
+// fetchAndAttachUtilityTags avoids 2 PK-lookup queries per browse page.
+// Keyed by the db pointer identity so test mocks with different addresses stay
+// isolated. Cleared entirely by clearUtilityTagCache via invalidateCaches.
+var (
+	utilityTagCacheMu  syncutil.RWMutex
+	utilityTagCacheMap map[string]map[int64]database.TagInfo
+)
+
+func clearUtilityTagCache() {
+	utilityTagCacheMu.Lock()
+	defer utilityTagCacheMu.Unlock()
+	utilityTagCacheMap = nil
+}
+
+// resolveUtilityTagDBIDs returns a map from DB tag DBID → TagInfo for each
+// entry in tags.UtilityTags. Results are memoised per db pointer so each
+// MediaDB instance (or test mock) has its own cache slot, and
+// clearUtilityTagCache (called from invalidateCaches) clears all slots.
+func resolveUtilityTagDBIDs(ctx context.Context, db sqlQueryable) (map[int64]database.TagInfo, error) {
+	dbKey := fmt.Sprintf("%p", db)
+
+	utilityTagCacheMu.RLock()
+	if utilityTagCacheMap != nil {
+		if cached, ok := utilityTagCacheMap[dbKey]; ok {
+			utilityTagCacheMu.RUnlock()
+			return cached, nil
+		}
+	}
+	utilityTagCacheMu.RUnlock()
+
+	tagInfoByDBID := make(map[int64]database.TagInfo, len(tags.UtilityTags))
+	for _, ct := range tags.UtilityTags {
+		tagTypeRow, err := sqlFindTagType(ctx, db, database.TagType{Type: string(ct.Type)})
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("browse utility tags: look up tag type %q: %w", ct.Type, err)
+			}
+			continue
+		}
+		tagRow, err := sqlFindTag(ctx, db, database.Tag{
+			TypeDBID: tagTypeRow.DBID,
+			Tag:      string(ct.Value),
+		})
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("browse utility tags: look up tag %q: %w", ct.Value, err)
+			}
+			continue
+		}
+		tagInfoByDBID[tagRow.DBID] = database.TagInfo{
+			Tag:  string(ct.Value),
+			Type: string(ct.Type),
+		}
+	}
+
+	utilityTagCacheMu.Lock()
+	if utilityTagCacheMap == nil {
+		utilityTagCacheMap = make(map[string]map[int64]database.TagInfo)
+	}
+	utilityTagCacheMap[dbKey] = tagInfoByDBID
+	utilityTagCacheMu.Unlock()
+	return tagInfoByDBID, nil
+}
 
 func browseSystemFilterClause(column string, systems []systemdefs.System) (clause string, args []any) {
 	if len(systems) == 0 {
@@ -520,6 +587,15 @@ func sqlBrowseFilesFromMedia(
 		); scanErr != nil {
 			return nil, fmt.Errorf("browse files scan: %w", scanErr)
 		}
+		// SortName is '' on rows that pre-date the migration; derive a display
+		// name from the filename so the grid is never empty until reindex.
+		if r.Name == "" {
+			base := filepath.Base(r.Path)
+			if ext := filepath.Ext(base); ext != "" {
+				base = base[:len(base)-len(ext)]
+			}
+			r.Name = base
+		}
 		r.SortMode = sortMode
 		results = append(results, r)
 	}
@@ -538,6 +614,13 @@ func sqlBrowseFilesFromMedia(
 		return nil, fmt.Errorf("browse files cover flags: %w", err)
 	}
 
+	// Disambiguate sibling variants: same SystemID+Name within the page get
+	// ZapScriptTags populated so the tag-write path can produce unambiguous
+	// ZapScript strings. Zero extra queries when there are no siblings (typical).
+	if err := fetchAndDisambiguateSiblings(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse files sibling disambiguation: %w", err)
+	}
+
 	log.Debug().
 		Str("pathPrefix", opts.PathPrefix).
 		Strs("systems", browseSystemIDsForLog(opts.Systems)).
@@ -548,12 +631,71 @@ func sqlBrowseFilesFromMedia(
 	return results, nil
 }
 
+// fetchAndDisambiguateSiblings populates ZapScriptTags on results that share
+// the same SystemID+Name (disc variants, regional editions, etc.) so the
+// tag-write path can build an unambiguous ZapScript string. For pages with no
+// sibling groups — the common case — the function returns immediately after the
+// grouping check with no DB queries. When siblings are present, a single batch
+// tag fetch is issued only for the affected media IDs.
+func fetchAndDisambiguateSiblings(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+
+	nameGroups := make(map[string][]int, len(results))
+	for i := range results {
+		key := results[i].SystemID + "\x00" + results[i].Name
+		nameGroups[key] = append(nameGroups[key], i)
+	}
+
+	var siblingIndices []int
+	for _, indices := range nameGroups {
+		if len(indices) >= 2 {
+			siblingIndices = append(siblingIndices, indices...)
+		}
+	}
+
+	if len(siblingIndices) == 0 {
+		for i := range results {
+			results[i].ZapScriptTags = []database.TagInfo{}
+		}
+		return nil
+	}
+
+	// Fetch full tags only for the sibling results (single batch query).
+	siblingResults := make([]database.SearchResultWithCursor, len(siblingIndices))
+	for i, idx := range siblingIndices {
+		siblingResults[i] = results[idx]
+	}
+	if err := fetchAndAttachTagsByResultIDs(ctx, db, siblingResults); err != nil {
+		return fmt.Errorf("sibling tag fetch: %w", err)
+	}
+	computeZapScriptTags(siblingResults)
+
+	// Write ZapScriptTags back; non-sibling entries get an empty slice.
+	siblingTagMap := make(map[int64][]database.TagInfo, len(siblingIndices))
+	for i, idx := range siblingIndices {
+		siblingTagMap[results[idx].MediaID] = siblingResults[i].ZapScriptTags
+	}
+	for i := range results {
+		if zapTags, ok := siblingTagMap[results[i].MediaID]; ok {
+			results[i].ZapScriptTags = zapTags
+		} else {
+			results[i].ZapScriptTags = []database.TagInfo{}
+		}
+	}
+	return nil
+}
+
 // fetchAndAttachCoverFlags sets HasCover on each result based on whether the
 // media or its title has at least one image property row. A single UNION ALL
 // query covers both MediaProperties (media-level) and MediaTitleProperties
 // (title-level), both of which are indexed by their respective IDs. Results
-// with no image property get HasCover=false; the browse response omits that
-// field so that older clients (without this field) continue to request covers.
+// with no image property get HasCover=false.
 func fetchAndAttachCoverFlags(
 	ctx context.Context,
 	db sqlQueryable,
@@ -632,6 +774,9 @@ func fetchAndAttachCoverFlags(
 // intentionally excluded from browse — the grid only needs utility tags; the
 // detail pane fetches everything via media.meta.
 //
+// Utility tag DBID resolution is memoised in utilityTagCacheVal and only re-run
+// when clearUtilityTagCache is called (via invalidateCaches on any tag write).
+//
 // Assumption: utility tags are media-level user tags — no title-level join is
 // needed. Add a title-level leg here if a future utility tag lives at the title
 // level.
@@ -644,30 +789,9 @@ func fetchAndAttachUtilityTags(
 		return nil
 	}
 
-	// Resolve each utility tag entry to its database DBID.
-	tagInfoByDBID := make(map[int64]database.TagInfo, len(tags.UtilityTags))
-	for _, ct := range tags.UtilityTags {
-		tagTypeRow, err := sqlFindTagType(ctx, db, database.TagType{Type: string(ct.Type)})
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("browse utility tags: look up tag type %q: %w", ct.Type, err)
-			}
-			continue
-		}
-		tagRow, err := sqlFindTag(ctx, db, database.Tag{
-			TypeDBID: tagTypeRow.DBID,
-			Tag:      string(ct.Value),
-		})
-		if err != nil {
-			if !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("browse utility tags: look up tag %q: %w", ct.Value, err)
-			}
-			continue
-		}
-		tagInfoByDBID[tagRow.DBID] = database.TagInfo{
-			Tag:  string(ct.Value),
-			Type: string(ct.Type),
-		}
+	tagInfoByDBID, err := resolveUtilityTagDBIDs(ctx, db)
+	if err != nil {
+		return err
 	}
 	if len(tagInfoByDBID) == 0 {
 		// None of the utility tags exist in the DB yet — nothing to attach.

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -54,7 +54,7 @@ const (
 // utilityTagCache memoises resolved utility tag DBIDs per DB connection so
 // fetchAndAttachUtilityTags avoids 2 PK-lookup queries per browse page.
 // Keyed by the db pointer identity so test mocks with different addresses stay
-// isolated. Cleared entirely by clearUtilityTagCache via invalidateCaches.
+// isolated. Cleared by clearUtilityTagCache when utility tag DBIDs can change.
 var (
 	utilityTagCacheMu  syncutil.RWMutex
 	utilityTagCacheMap map[string]map[int64]database.TagInfo
@@ -69,7 +69,7 @@ func clearUtilityTagCache() {
 // resolveUtilityTagDBIDs returns a map from DB tag DBID → TagInfo for each
 // entry in tags.UtilityTags. Results are memoised per db pointer so each
 // MediaDB instance (or test mock) has its own cache slot, and
-// clearUtilityTagCache (called from invalidateCaches) clears all slots.
+// clearUtilityTagCache clears all slots when utility tag DBIDs can change.
 func resolveUtilityTagDBIDs(ctx context.Context, db sqlQueryable) (map[int64]database.TagInfo, error) {
 	dbKey := fmt.Sprintf("%p", db)
 
@@ -775,7 +775,7 @@ func fetchAndAttachCoverFlags(
 // detail pane fetches everything via media.meta.
 //
 // Utility tag DBID resolution is memoised in utilityTagCacheVal and only re-run
-// when clearUtilityTagCache is called (via invalidateCaches on any tag write).
+// when clearUtilityTagCache is called after tag dictionary changes.
 //
 // Assumption: utility tags are media-level user tags — no title-level join is
 // needed. Add a title-level leg here if a future utility tag lives at the title

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -22,6 +22,7 @@ package mediadb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -30,14 +31,16 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/rs/zerolog/log"
 )
 
-// imagePropertyTagPrefix is the common prefix for all image property TypeTag
-// values (e.g. "property:image-image", "property:image-boxart", …).
-// All image type tags in the Tags table start with this string, so a LIKE
-// filter with this prefix selects exactly the set of image property types.
-const imagePropertyTagPrefix = "property:image-"
+// imagePropertyValuePrefix is the common prefix for all image property tag
+// values stored in the Tags table (e.g. "image-boxart", "image-screenshot").
+// The "property:" type part lives in TagTypes.Type; Tags.Tag holds only the
+// value, so the LIKE filter uses this value-only prefix paired with a
+// TagTypes join on tt.Type = tags.TagTypeProperty.
+const imagePropertyValuePrefix = "image-"
 
 const (
 	browseSortRankPrefixAsc  = "rank-prefix-asc"
@@ -342,7 +345,7 @@ func browsePathPrefixCondition(column, pathPrefix string) (condition string, arg
 }
 
 func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
-	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "mt.Name")
+	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "m.SortName")
 	conditions := make([]string, 0, 3+len(letterClauses))
 	conditions = append(conditions, `m.ParentDir = ?`, `m.IsMissing = 0`)
 	conditions = append(conditions, letterClauses...)
@@ -366,7 +369,7 @@ func browseRankPrefixSortExpr() string {
 	filename := browseFilenameExpr()
 	return `CASE WHEN substr(` + filename + `, 1, 1) BETWEEN '0' AND '9' ` +
 		`THEN printf('%010d:%s', CAST(` + filename + ` AS INTEGER), ` + filename + `) ` +
-		`ELSE 'zzzzzzzzzz:' || mt.Name END`
+		`ELSE 'zzzzzzzzzz:' || m.SortName END`
 }
 
 func browseSortExpr(sortOrder string) string {
@@ -378,7 +381,7 @@ func browseSortExpr(sortOrder string) string {
 	case browseSortDatePrefixAsc, browseSortDatePrefixDesc:
 		return browseFilenameExpr()
 	default:
-		return "mt.Name"
+		return "m.SortName"
 	}
 }
 
@@ -491,9 +494,8 @@ func sqlBrowseFilesFromMedia(
 	where, args := browseFilesBaseCondition(opts)
 	sortMode := resolveBrowseSortMode(ctx, db, opts)
 	sortExpr := browseSortExpr(sortMode)
-	query := `SELECT s.SystemID, mt.Name, m.Path, m.DBID, mt.DBID, ` + sortExpr + ` AS SortValue
+	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, ` + sortExpr + ` AS SortValue
 		FROM Media m
-		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
 	if opts.Cursor != nil {
@@ -527,7 +529,7 @@ func sqlBrowseFilesFromMedia(
 	queryElapsed := time.Since(queryStarted)
 
 	tagsStarted := time.Now()
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := fetchAndAttachUtilityTags(ctx, db, results); err != nil {
 		return nil, fmt.Errorf("browse files tags: %w", err)
 	}
 	tagsElapsed := time.Since(tagsStarted)
@@ -581,18 +583,22 @@ func fetchAndAttachCoverFlags(
 		FROM (
 			SELECT mp.MediaDBID
 			FROM MediaProperties mp
-			JOIN Tags t ON t.DBID = mp.TypeTagDBID
+			JOIN Tags t      ON t.DBID  = mp.TypeTagDBID
+			JOIN TagTypes tt ON tt.DBID = t.TypeDBID
 			WHERE mp.MediaDBID IN (` + placeholders + `)
-			  AND t.Tag LIKE '` + imagePropertyTagPrefix + `%'
+			  AND tt.Type = '` + string(tags.TagTypeProperty) + `'
+			  AND t.Tag LIKE '` + imagePropertyValuePrefix + `%'
 
 			UNION ALL
 
 			SELECT m.DBID AS MediaDBID
 			FROM Media m
 			JOIN MediaTitleProperties mtp ON mtp.MediaTitleDBID = m.MediaTitleDBID
-			JOIN Tags t ON t.DBID = mtp.TypeTagDBID
+			JOIN Tags t      ON t.DBID  = mtp.TypeTagDBID
+			JOIN TagTypes tt ON tt.DBID = t.TypeDBID
 			WHERE m.DBID IN (` + placeholders + `)
-			  AND t.Tag LIKE '` + imagePropertyTagPrefix + `%'
+			  AND tt.Type = '` + string(tags.TagTypeProperty) + `'
+			  AND t.Tag LIKE '` + imagePropertyValuePrefix + `%'
 		) sub`
 
 	rows, err := db.QueryContext(ctx, query, args...)
@@ -619,6 +625,107 @@ func fetchAndAttachCoverFlags(
 	return nil
 }
 
+// fetchAndAttachUtilityTags attaches every tag in tags.UtilityTags to any
+// result that has one. A browse page normally has few or no utility-tagged
+// entries, so the query returns near-zero rows against the composite PRIMARY
+// KEY(MediaDBID, TagDBID) index on MediaTags. Full metadata tags are
+// intentionally excluded from browse — the grid only needs utility tags; the
+// detail pane fetches everything via media.meta.
+//
+// Assumption: utility tags are media-level user tags — no title-level join is
+// needed. Add a title-level leg here if a future utility tag lives at the title
+// level.
+func fetchAndAttachUtilityTags(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	if len(results) == 0 {
+		return nil
+	}
+
+	// Resolve each utility tag entry to its database DBID.
+	tagInfoByDBID := make(map[int64]database.TagInfo, len(tags.UtilityTags))
+	for _, ct := range tags.UtilityTags {
+		tagTypeRow, err := sqlFindTagType(ctx, db, database.TagType{Type: string(ct.Type)})
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("browse utility tags: look up tag type %q: %w", ct.Type, err)
+			}
+			continue
+		}
+		tagRow, err := sqlFindTag(ctx, db, database.Tag{
+			TypeDBID: tagTypeRow.DBID,
+			Tag:      string(ct.Value),
+		})
+		if err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("browse utility tags: look up tag %q: %w", ct.Value, err)
+			}
+			continue
+		}
+		tagInfoByDBID[tagRow.DBID] = database.TagInfo{
+			Tag:  string(ct.Value),
+			Type: string(ct.Type),
+		}
+	}
+	if len(tagInfoByDBID) == 0 {
+		// None of the utility tags exist in the DB yet — nothing to attach.
+		return nil
+	}
+
+	mediaIDs := make([]int64, len(results))
+	for i := range results {
+		mediaIDs[i] = results[i].MediaID
+	}
+
+	tagDBIDs := make([]int64, 0, len(tagInfoByDBID))
+	for id := range tagInfoByDBID {
+		tagDBIDs = append(tagDBIDs, id)
+	}
+
+	mediaPH := prepareVariadic("?", ",", len(mediaIDs))
+	tagPH := prepareVariadic("?", ",", len(tagDBIDs))
+	args := make([]any, 0, len(mediaIDs)+len(tagDBIDs))
+	for _, id := range mediaIDs {
+		args = append(args, id)
+	}
+	for _, id := range tagDBIDs {
+		args = append(args, id)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	query := `SELECT mt.MediaDBID, mt.TagDBID FROM MediaTags mt
+		WHERE mt.MediaDBID IN (` + mediaPH + `) AND mt.TagDBID IN (` + tagPH + `)`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("browse utility tags query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	toAttach := make(map[int64][]database.TagInfo)
+	for rows.Next() {
+		var mediaDBID, tagDBID int64
+		if scanErr := rows.Scan(&mediaDBID, &tagDBID); scanErr != nil {
+			return fmt.Errorf("browse utility tags scan: %w", scanErr)
+		}
+		if info, ok := tagInfoByDBID[tagDBID]; ok {
+			toAttach[mediaDBID] = append(toAttach[mediaDBID], info)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("browse utility tags rows: %w", err)
+	}
+
+	for i := range results {
+		if infos, ok := toAttach[results[i].MediaID]; ok {
+			results[i].Tags = append(results[i].Tags, infos...)
+		}
+	}
+	return nil
+}
+
 func sqlBrowseFileCount(
 	ctx context.Context,
 	db sqlQueryable,
@@ -639,7 +746,6 @@ func sqlBrowseFileCountFromMedia(
 	})
 	query := `SELECT COUNT(*)
 		FROM Media m
-		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE ` + where
 	var count int

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -113,7 +113,7 @@ func seedBenchBrowseDB(b *testing.B, mediaDB *MediaDB, rows int, withTags bool) 
 	defer func() { require.NoError(b, titleStmt.Close()) }()
 
 	mediaStmt, err := tx.PrepareContext(ctx, `
-		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (?, ?, 1, ?, ?)
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName) VALUES (?, ?, 1, ?, ?, ?)
 	`)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, mediaStmt.Close()) }()
@@ -133,7 +133,7 @@ func seedBenchBrowseDB(b *testing.B, mediaDB *MediaDB, rows int, withTags bool) 
 		path := filepath.ToSlash(filepath.Join(parentDir, fmt.Sprintf("browse-game-%05d.zip", i)))
 		_, err = titleStmt.ExecContext(ctx, mediaID, slug, name)
 		require.NoError(b, err)
-		_, err = mediaStmt.ExecContext(ctx, mediaID, mediaID, path, parentDir)
+		_, err = mediaStmt.ExecContext(ctx, mediaID, mediaID, path, parentDir, name)
 		require.NoError(b, err)
 		if !withTags {
 			continue

--- a/pkg/database/mediadb/sql_browse_plan_test.go
+++ b/pkg/database/mediadb/sql_browse_plan_test.go
@@ -1,0 +1,256 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// arcadeScaleRows matches the Arcade system size on the MiSTer test device
+// (~826 entries) where the 515ms queryDuration was originally measured.
+const arcadeScaleRows = 826
+
+// TestBrowseFilesQueryPlan_NameSortHasNoFilesort asserts that the name-sort
+// browse query uses idx_media_browse_sort (no MediaTitles join, no filesort).
+// Fails loudly if a regression introduces USE TEMP B-TREE FOR ORDER BY or
+// accesses the MediaTitles table.
+func TestBrowseFilesQueryPlan_NameSortHasNoFilesort(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, arcadeScaleRows)
+	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql))
+
+	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE m.ParentDir = ? AND m.IsMissing = 0
+		ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`
+
+	rows, err := mediaDB.sql.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, parentDir, 301)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var planLines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		planLines = append(planLines, detail)
+	}
+	require.NoError(t, rows.Err())
+
+	plan := strings.Join(planLines, "\n")
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"name-sort browse must not filesort; idx_media_browse_sort should serve the ORDER BY")
+	assert.NotContains(t, plan, "MediaTitles",
+		"name-sort browse must not access MediaTitles; SortName is now on Media")
+}
+
+// TestExplainBrowseFilesQuery is a diagnostic helper that prints EXPLAIN QUERY
+// PLAN output and warm-timing for each browse-query variant at Arcade scale
+// (~826 rows in one directory). Run manually with:
+//
+//	go test -run TestExplainBrowseFilesQuery -v ./pkg/database/mediadb/
+func TestExplainBrowseFilesQuery(t *testing.T) {
+	t.Skip("diagnostic helper; run manually with -run TestExplainBrowseFilesQuery -v")
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, arcadeScaleRows)
+
+	// Run ANALYZE to populate sqlite_stat1 so the planner has index cardinality
+	// stats matching a production database.
+	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql))
+
+	dumpScraperPragmas(ctx, t, mediaDB.sql)
+	dumpSQLiteStats(ctx, t, mediaDB.sql)
+
+	// midName is the name of the 300th row — used as the cursor value for the
+	// non-first-page cases so we test the keyset seek half-way through.
+	midName := fmt.Sprintf("Browse Game %05d", 300)
+	midID := int64(300)
+
+	// Each case records the SQL and args for both EXPLAIN and warm timing.
+	// These match what sqlBrowseFilesFromMedia now generates (no MediaTitles join).
+	type browseCase struct {
+		name  string
+		query string
+		args  []any
+	}
+
+	cases := []browseCase{
+		{
+			name: "name-sort first-page (no cursor)",
+			// Filter ParentDir + IsMissing via idx_media_browse_sort, sort by
+			// m.SortName — no filesort, no MediaTitles join.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+				FROM Media m
+				INNER JOIN Systems s ON m.SystemDBID = s.DBID
+				WHERE m.ParentDir = ? AND m.IsMissing = 0
+				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+			args: []any{parentDir, 301},
+		},
+		{
+			name: "name-sort non-first-page (with cursor)",
+			// Keyset cursor on (m.SortName, m.DBID) — same table as the filter,
+			// so the index can serve the seek directly.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+				FROM Media m
+				INNER JOIN Systems s ON m.SystemDBID = s.DBID
+				WHERE m.ParentDir = ? AND m.IsMissing = 0
+				  AND (m.SortName, m.DBID) > (?, ?)
+				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+			args: []any{parentDir, midName, midID, 301},
+		},
+		{
+			name: "filename-sort first-page",
+			// Sort key is m.Path — no MediaTitles join needed.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.Path AS SortValue
+				FROM Media m
+				INNER JOIN Systems s ON m.SystemDBID = s.DBID
+				WHERE m.ParentDir = ? AND m.IsMissing = 0
+				ORDER BY m.Path ASC, m.DBID ASC LIMIT ?`,
+			args: []any{parentDir, 301},
+		},
+		{
+			name: "name-sort with letter filter",
+			// Letter filter now uses m.SortName — stays on the same table, no
+			// separate MediaTitles lookup.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+				FROM Media m
+				INNER JOIN Systems s ON m.SystemDBID = s.DBID
+				WHERE m.ParentDir = ? AND m.IsMissing = 0
+				  AND UPPER(SUBSTR(m.SortName, 1, 1)) = ?
+				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+			// "B" matches "Browse Game ..." — all rows pass.
+			args: []any{parentDir, "B", 301},
+		},
+	}
+
+	const warmRuns = 100
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			explainQueryPlan(ctx, t, mediaDB.sql, tc.query, tc.args...)
+
+			// Warm timing: run the query warmRuns times and drain results.
+			// This measures CPU cost on a cached (warm) database; it won't
+			// reproduce cold-flash I/O from the device but will reveal the
+			// absolute SQL execution cost and sort structure.
+			start := time.Now()
+			for range warmRuns {
+				func() {
+					rows, err := mediaDB.sql.QueryContext(ctx, tc.query, tc.args...)
+					require.NoError(t, err)
+					defer func() { require.NoError(t, rows.Close()) }()
+					for rows.Next() {
+					}
+					require.NoError(t, rows.Err())
+				}()
+			}
+			elapsed := time.Since(start)
+			t.Logf("warm timing: %d runs total=%s per-query=%s",
+				warmRuns, elapsed, elapsed/time.Duration(warmRuns))
+		})
+	}
+}
+
+// setupBrowsePlanTestDB opens a fresh temporary MediaDB for browse plan
+// diagnostics. Mirrors setupBrowseBenchMediaDB but uses testing.T.
+func setupBrowsePlanTestDB(t *testing.T) (mediaDB *MediaDB, cleanup func()) {
+	t.Helper()
+	tempDir, err := os.MkdirTemp("", "zaparoo-browse-plan-mediadb-*")
+	require.NoError(t, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
+
+	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
+	require.NoError(t, err)
+	cleanup = func() {
+		if mediaDB != nil {
+			_ = mediaDB.Close()
+		}
+		_ = os.RemoveAll(tempDir)
+	}
+	return mediaDB, cleanup
+}
+
+// seedBrowsePlanTestDB inserts rows rows into a single directory under a single
+// system and commits in one transaction. Returns the parentDir used so callers
+// can build browse opts. Mirrors seedBenchBrowseDB but uses testing.T.
+func seedBrowsePlanTestDB(t *testing.T, mediaDB *MediaDB, rows int) (parentDir string) {
+	t.Helper()
+	ctx := context.Background()
+	parentDir = filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "arcade")) + "/"
+	tx, err := mediaDB.sql.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'MiSTer:Arcade', 'Arcade');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES (1, 'user', 0);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES (1, 1, 'favorite');
+	`)
+	require.NoError(t, err)
+
+	titleStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 1, ?, ?)
+	`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, titleStmt.Close()) }()
+
+	mediaStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName) VALUES (?, ?, 1, ?, ?, ?)
+	`)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, mediaStmt.Close()) }()
+
+	for i := 1; i <= rows; i++ {
+		id := int64(i)
+		slug := fmt.Sprintf("browse-game-%05d", i)
+		name := fmt.Sprintf("Browse Game %05d", i)
+		path := filepath.ToSlash(filepath.Join(parentDir, fmt.Sprintf("browse-game-%05d.mra", i)))
+		_, err = titleStmt.ExecContext(ctx, id, slug, name)
+		require.NoError(t, err)
+		_, err = mediaStmt.ExecContext(ctx, id, id, path, parentDir, name)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, tx.Commit())
+	return parentDir
+}

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -487,6 +487,53 @@ func TestFetchAndAttachUtilityTags_WithFavorites(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestFetchAndAttachUtilityTags_TagTypeRealDBError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, Name: "Game"},
+	}
+
+	// Simulate a real DB error (not ErrNoRows) on the tag type lookup.
+	mock.ExpectPrepare(`select.*DBID.*Type.*IsExclusive.*from TagTypes`).
+		ExpectQuery().
+		WithArgs(int64(0), string(tags.UtilityTags[0].Type)).
+		WillReturnError(sql.ErrConnDone)
+
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browse utility tags")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachUtilityTags_TagRealDBError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, Name: "Game"},
+	}
+
+	// Tag type found; then a real DB error on the tag value lookup.
+	mock.ExpectPrepare(`select.*DBID.*Type.*IsExclusive.*from TagTypes`).
+		ExpectQuery().
+		WithArgs(int64(0), string(tags.UtilityTags[0].Type)).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID", "Type", "IsExclusive"}).AddRow(int64(5), "user", false))
+	mock.ExpectPrepare(`select.*DBID.*TypeDBID.*Tag.*DisplayName.*from Tags`).
+		ExpectQuery().
+		WillReturnError(sql.ErrConnDone)
+
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browse utility tags")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestFetchAndAttachCoverFlags_EmptyResults(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -801,6 +801,36 @@ func TestFetchAndDisambiguateSiblings_EmptyResults(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestFetchAndDisambiguateSiblings_DuplicateNamesFetchTags(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, MediaTitleID: 10, SystemID: "NES", Name: "Same Game"},
+		{MediaID: 2, MediaTitleID: 11, SystemID: "NES", Name: "Same Game"},
+	}
+
+	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM MediaTags`).
+		WithArgs(int64(1), int64(2), int64(10), int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"HasTags"}).AddRow(true))
+	mock.ExpectPrepare(`SELECT\s+0 as SourceKind`).
+		ExpectQuery().
+		WithArgs(int64(1), int64(2), int64(10), int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "DisplayName", "Type"}).
+			AddRow(0, int64(1), "USA", "United States", "release").
+			AddRow(0, int64(2), "Japan", "Japan", "release"))
+
+	err = fetchAndDisambiguateSiblings(context.Background(), db, results)
+	require.NoError(t, err)
+	require.Len(t, results[0].ZapScriptTags, 1)
+	require.Len(t, results[1].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Tag: "USA", Type: "release", Label: "United States"}, results[0].ZapScriptTags[0])
+	assert.Equal(t, database.TagInfo{Tag: "Japan", Type: "release", Label: "Japan"}, results[1].ZapScriptTags[0])
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // TestBrowseFiles_SortNameFallback_Integration verifies that a media row with
 // SortName=” (pre-migration) gets its display name derived from the file path
 // rather than emitting an empty Name field.
@@ -823,11 +853,11 @@ func TestBrowseFiles_SortNameFallback_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	parentDir := "/roms/nes/"
+	parentDir := browseTestDir("roms", "nes")
 	media, err := mediaDB.InsertMedia(database.Media{
 		SystemDBID:     sys.DBID,
 		MediaTitleDBID: title.DBID,
-		Path:           "/roms/nes/mygame.nes",
+		Path:           browseTestPath("roms", "nes", "mygame.nes"),
 		ParentDir:      parentDir,
 		SortName:       "", // intentionally empty — simulates a pre-migration row
 	})

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -378,6 +380,113 @@ func TestSqlBrowseRootCountsFromCache_ReturnsZeroForMissingRoot(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestFetchAndAttachUtilityTags_EmptyResults(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{}
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachUtilityTags_TagTypeAbsent(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, Name: "Game"},
+	}
+
+	// One sqlFindTagType prepare+query per entry in UtilityTags; empty rows =
+	// ErrNoRows = skip. Loop over all entries so the test stays valid if the list grows.
+	for _, ct := range tags.UtilityTags {
+		mock.ExpectPrepare(`select.*DBID.*Type.*IsExclusive.*from TagTypes`).
+			ExpectQuery().
+			WithArgs(int64(0), string(ct.Type)).
+			WillReturnRows(sqlmock.NewRows([]string{"DBID", "Type", "IsExclusive"}))
+	}
+
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.Empty(t, results[0].Tags)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachUtilityTags_NoFavorites(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 10, Name: "Game A"},
+		{MediaID: 11, Name: "Game B"},
+	}
+
+	mock.ExpectPrepare(`select.*DBID.*Type.*IsExclusive.*from TagTypes`).
+		ExpectQuery().
+		WithArgs(int64(0), "user").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID", "Type", "IsExclusive"}).AddRow(int64(5), "user", false))
+
+	tagRows := sqlmock.NewRows([]string{"DBID", "TypeDBID", "Tag", "DisplayName"}).
+		AddRow(int64(42), int64(5), "favorite", "")
+	mock.ExpectPrepare(`select.*DBID.*TypeDBID.*Tag.*DisplayName.*from Tags`).
+		ExpectQuery().
+		WillReturnRows(tagRows)
+
+	// MediaTags query returns no rows — neither entry has any utility tag.
+	mock.ExpectQuery(`SELECT mt\.MediaDBID, mt\.TagDBID FROM MediaTags`).
+		WithArgs(int64(10), int64(11), int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "TagDBID"}))
+
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.Empty(t, results[0].Tags)
+	assert.Empty(t, results[1].Tags)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachUtilityTags_WithFavorites(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 20, Name: "Favorited Game"},
+		{MediaID: 21, Name: "Regular Game"},
+	}
+
+	mock.ExpectPrepare(`select.*DBID.*Type.*IsExclusive.*from TagTypes`).
+		ExpectQuery().
+		WithArgs(int64(0), "user").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID", "Type", "IsExclusive"}).AddRow(int64(5), "user", false))
+
+	tagRows := sqlmock.NewRows([]string{"DBID", "TypeDBID", "Tag", "DisplayName"}).
+		AddRow(int64(42), int64(5), "favorite", "")
+	mock.ExpectPrepare(`select.*DBID.*TypeDBID.*Tag.*DisplayName.*from Tags`).
+		ExpectQuery().
+		WillReturnRows(tagRows)
+
+	// Only media ID 20 has the favorite utility tag.
+	mock.ExpectQuery(`SELECT mt\.MediaDBID, mt\.TagDBID FROM MediaTags`).
+		WithArgs(int64(20), int64(21), int64(42)).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "TagDBID"}).AddRow(int64(20), int64(42)))
+
+	err = fetchAndAttachUtilityTags(context.Background(), db, results)
+	require.NoError(t, err)
+	require.Len(t, results[0].Tags, 1, "favorited entry should have one tag")
+	assert.Equal(t, "favorite", results[0].Tags[0].Tag)
+	assert.Equal(t, "user", results[0].Tags[0].Type)
+	assert.Empty(t, results[1].Tags, "non-favorited entry should have no tags")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestFetchAndAttachCoverFlags_EmptyResults(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -480,4 +589,131 @@ func TestFetchAndAttachCoverFlags_QueryError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "browse cover flags query")
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Integration tests use a real SQLite DB to verify the query joins correctly
+// against the canonical tag schema. These catch schema/prefix mismatches that
+// pure sqlmock tests cannot — sqlmock never executes real SQL.
+
+// seedImagePropertyTags inserts the minimal TagTypes/Tags rows needed to call
+// UpsertMediaProperties/UpsertMediaTitleProperties in a bare setupTempMediaDB.
+// A full index run would seed all canonical tags; these tests need only the
+// property type and image-boxart tag.
+func seedImagePropertyTags(t *testing.T, mediaDB *MediaDB) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT OR IGNORE INTO TagTypes (DBID, Type, IsExclusive) VALUES (900, 'property', 0);
+		INSERT OR IGNORE INTO Tags (DBID, TypeDBID, Tag) VALUES (901, 900, 'image-boxart');
+	`)
+	require.NoError(t, err)
+}
+
+func TestFetchAndAttachCoverFlags_Integration_MediaLevelProperty(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	seedImagePropertyTags(t, mediaDB)
+
+	ctx := context.Background()
+
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	// Insert two media rows: one will get an image property, one will not.
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	titleA, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Game With Cover"),
+		Name:       "Game With Cover",
+	})
+	require.NoError(t, err)
+	mediaA, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: titleA.DBID,
+		Path:           filepath.Join("roms", "nes", "with_cover.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+
+	titleB, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Game Without Cover"),
+		Name:       "Game Without Cover",
+	})
+	require.NoError(t, err)
+	mediaB, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: titleB.DBID,
+		Path:           filepath.Join("roms", "nes", "no_cover.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Write a media-level image property only for mediaA.
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, mediaA.DBID, []database.MediaProperty{
+		{TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageBoxart), Text: filepath.Join("art", "with_cover.png")},
+	}))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaA.DBID, MediaTitleID: titleA.DBID, Name: "Game With Cover"},
+		{MediaID: mediaB.DBID, MediaTitleID: titleB.DBID, Name: "Game Without Cover"},
+	}
+
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql, results))
+	assert.True(t, results[0].HasCover, "media with image property should have HasCover=true")
+	assert.False(t, results[1].HasCover, "media without image property should have HasCover=false")
+}
+
+func TestFetchAndAttachCoverFlags_Integration_TitleLevelProperty(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	seedImagePropertyTags(t, mediaDB)
+
+	ctx := context.Background()
+
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	// Two media sharing one title; cover is on the title, not the media.
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Shared Title"),
+		Name:       "Shared Title",
+	})
+	require.NoError(t, err)
+	mediaA, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "rev_a.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	mediaB, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "rev_b.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Write the image property at the title level only.
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, title.DBID, []database.MediaProperty{
+		{TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageBoxart), Text: filepath.Join("art", "shared.png")},
+	}))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaA.DBID, MediaTitleID: title.DBID, Name: "Rev A"},
+		{MediaID: mediaB.DBID, MediaTitleID: title.DBID, Name: "Rev B"},
+	}
+
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql, results))
+	assert.True(t, results[0].HasCover, "media whose title has an image property should have HasCover=true")
+	assert.True(t, results[1].HasCover, "media whose title has an image property should have HasCover=true")
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -375,4 +376,108 @@ func TestSqlBrowseRootCountsFromCache_ReturnsZeroForMissingRoot(t *testing.T) {
 	require.NotNil(t, counts[nesRoot])
 	assert.Equal(t, 0, *counts[nesRoot])
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachCoverFlags_EmptyResults(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{}
+	err = fetchAndAttachCoverFlags(context.Background(), db, results)
+	assert.NoError(t, err)
+	// No DB operations should occur for empty input.
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachCoverFlags_NoCoverEntries(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, Name: "NoCoverGame"},
+		{MediaID: 2, Name: "AnotherNoCoverGame"},
+	}
+
+	// Query returns no rows — neither media ID has any image property.
+	mock.ExpectQuery(`SELECT DISTINCT sub\.MediaDBID`).
+		WithArgs(int64(1), int64(2), int64(1), int64(2)).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID"}))
+
+	err = fetchAndAttachCoverFlags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.False(t, results[0].HasCover, "entry with no image property should have HasCover=false")
+	assert.False(t, results[1].HasCover, "entry with no image property should have HasCover=false")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachCoverFlags_MediaLevelCover(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 10, Name: "GameWithCover"},
+		{MediaID: 20, Name: "GameWithoutCover"},
+	}
+
+	// Query returns mediaID 10 as having a cover (media-level property).
+	mock.ExpectQuery(`SELECT DISTINCT sub\.MediaDBID`).
+		WithArgs(int64(10), int64(20), int64(10), int64(20)).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID"}).AddRow(int64(10)))
+
+	err = fetchAndAttachCoverFlags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.True(t, results[0].HasCover, "entry with image property should have HasCover=true")
+	assert.False(t, results[1].HasCover, "entry without image property should have HasCover=false")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachCoverFlags_TitleLevelCover(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Both media share a title; the title-level cover property means both
+	// should be marked as having a cover.
+	results := []database.SearchResultWithCursor{
+		{MediaID: 30, MediaTitleID: 100, Name: "GameA"},
+		{MediaID: 31, MediaTitleID: 100, Name: "GameA (Rev B)"},
+	}
+
+	// Query returns both media IDs (via the title-level UNION ALL leg).
+	mock.ExpectQuery(`SELECT DISTINCT sub\.MediaDBID`).
+		WithArgs(int64(30), int64(31), int64(30), int64(31)).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID"}).AddRow(int64(30)).AddRow(int64(31)))
+
+	err = fetchAndAttachCoverFlags(context.Background(), db, results)
+	require.NoError(t, err)
+	assert.True(t, results[0].HasCover)
+	assert.True(t, results[1].HasCover)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchAndAttachCoverFlags_QueryError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 5, Name: "SomeGame"},
+	}
+
+	mock.ExpectQuery(`SELECT DISTINCT sub\.MediaDBID`).
+		WithArgs(int64(5), int64(5)).
+		WillReturnError(errors.New("db unavailable"))
+
+	err = fetchAndAttachCoverFlags(context.Background(), db, results)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "browse cover flags query")
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -764,3 +764,86 @@ func TestFetchAndAttachCoverFlags_Integration_TitleLevelProperty(t *testing.T) {
 	assert.True(t, results[0].HasCover, "media whose title has an image property should have HasCover=true")
 	assert.True(t, results[1].HasCover, "media whose title has an image property should have HasCover=true")
 }
+
+// TestFetchAndDisambiguateSiblings_NoSiblings verifies that when all entries on
+// the page have unique names, ZapScriptTags is set to an empty slice with no
+// DB queries.
+func TestFetchAndDisambiguateSiblings_NoSiblings(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: 1, MediaTitleID: 10, SystemID: "NES", Name: "Game A"},
+		{MediaID: 2, MediaTitleID: 11, SystemID: "NES", Name: "Game B"},
+		{MediaID: 3, MediaTitleID: 12, SystemID: "NES", Name: "Game C"},
+	}
+
+	// No DB queries should be issued — grouping is pure in-memory.
+	err = fetchAndDisambiguateSiblings(context.Background(), db, results)
+	require.NoError(t, err)
+	for i, r := range results {
+		assert.Equal(t, []database.TagInfo{}, r.ZapScriptTags, "entry %d should have empty ZapScriptTags", i)
+	}
+	assert.NoError(t, mock.ExpectationsWereMet(), "no DB queries expected")
+}
+
+// TestFetchAndDisambiguateSiblings_EmptyResults verifies the empty-input guard.
+func TestFetchAndDisambiguateSiblings_EmptyResults(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	err = fetchAndDisambiguateSiblings(context.Background(), db, nil)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestBrowseFiles_SortNameFallback_Integration verifies that a media row with
+// SortName=” (pre-migration) gets its display name derived from the file path
+// rather than emitting an empty Name field.
+func TestBrowseFiles_SortNameFallback_Integration(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Expected Name"),
+		Name:       "Expected Name",
+	})
+	require.NoError(t, err)
+
+	parentDir := "/roms/nes/"
+	media, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           "/roms/nes/mygame.nes",
+		ParentDir:      parentDir,
+		SortName:       "", // intentionally empty — simulates a pre-migration row
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Blank out SortName directly so the scan loop hits the fallback path.
+	_, err = mediaDB.sql.ExecContext(ctx, `UPDATE Media SET SortName = '' WHERE DBID = ?`, media.DBID)
+	require.NoError(t, err)
+
+	results, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: parentDir,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "mygame", results[0].Name,
+		"SortName='' should fall back to filename-without-extension")
+}

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -31,14 +31,14 @@ import (
 )
 
 const insertMediaSQL = `INSERT INTO Media
-	(DBID, MediaTitleDBID, SystemDBID, Path, ParentDir)
-	VALUES (?, ?, ?, ?, ?)`
+	(DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName)
+	VALUES (?, ?, ?, ?, ?, ?)`
 
-func sqlFindMedia(ctx context.Context, db sqlQueryable, media database.Media) (database.Media, error) {
+func sqlFindMedia(ctx context.Context, db sqlQueryable, media *database.Media) (database.Media, error) {
 	var row database.Media
 	stmt, err := db.PrepareContext(ctx, `
 		select
-		DBID, MediaTitleDBID, SystemDBID, Path, ParentDir
+		DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName
 		from Media
 		where DBID = ?
 		or (
@@ -73,6 +73,7 @@ func sqlFindMedia(ctx context.Context, db sqlQueryable, media database.Media) (d
 		&row.SystemDBID,
 		&row.Path,
 		&row.ParentDir,
+		&row.SortName,
 	)
 	if err != nil {
 		return row, fmt.Errorf("failed to scan media row: %w", err)
@@ -80,7 +81,7 @@ func sqlFindMedia(ctx context.Context, db sqlQueryable, media database.Media) (d
 	return row, nil
 }
 
-func sqlInsertMediaWithPreparedStmt(ctx context.Context, stmt *sql.Stmt, row database.Media) (database.Media, error) {
+func sqlInsertMediaWithPreparedStmt(ctx context.Context, stmt *sql.Stmt, row *database.Media) (database.Media, error) {
 	var dbID any
 	if row.DBID != 0 {
 		dbID = row.DBID
@@ -93,21 +94,22 @@ func sqlInsertMediaWithPreparedStmt(ctx context.Context, stmt *sql.Stmt, row dat
 		row.SystemDBID,
 		row.Path,
 		row.ParentDir,
+		row.SortName,
 	)
 	if err != nil {
-		return row, fmt.Errorf("failed to execute prepared insert media statement: %w", err)
+		return *row, fmt.Errorf("failed to execute prepared insert media statement: %w", err)
 	}
 
 	lastID, err := res.LastInsertId()
 	if err != nil {
-		return row, fmt.Errorf("failed to get last insert ID for media: %w", err)
+		return *row, fmt.Errorf("failed to get last insert ID for media: %w", err)
 	}
 
 	row.DBID = lastID
-	return row, nil
+	return *row, nil
 }
 
-func sqlInsertMedia(ctx context.Context, db *sql.DB, row database.Media) (database.Media, error) {
+func sqlInsertMedia(ctx context.Context, db *sql.DB, row *database.Media) (database.Media, error) {
 	var dbID any
 	if row.DBID != 0 {
 		dbID = row.DBID
@@ -115,7 +117,7 @@ func sqlInsertMedia(ctx context.Context, db *sql.DB, row database.Media) (databa
 
 	stmt, err := db.PrepareContext(ctx, insertMediaSQL)
 	if err != nil {
-		return row, fmt.Errorf("failed to prepare insert media statement: %w", err)
+		return *row, fmt.Errorf("failed to prepare insert media statement: %w", err)
 	}
 	defer func() {
 		if closeErr := stmt.Close(); closeErr != nil {
@@ -130,25 +132,29 @@ func sqlInsertMedia(ctx context.Context, db *sql.DB, row database.Media) (databa
 		row.SystemDBID,
 		row.Path,
 		row.ParentDir,
+		row.SortName,
 	)
 	if err != nil {
-		return row, fmt.Errorf("failed to execute insert media statement: %w", err)
+		return *row, fmt.Errorf("failed to execute insert media statement: %w", err)
 	}
 
 	lastID, err := res.LastInsertId()
 	if err != nil {
-		return row, fmt.Errorf("failed to get last insert ID for media: %w", err)
+		return *row, fmt.Errorf("failed to get last insert ID for media: %w", err)
 	}
 
 	row.DBID = lastID
-	return row, nil
+	return *row, nil
 }
 
-func sqlUpdateMediaTitle(ctx context.Context, db sqlQueryable, mediaDBID, mediaTitleDBID int64) error {
+func sqlUpdateMediaTitle(
+	ctx context.Context, db sqlQueryable, mediaDBID, mediaTitleDBID int64, sortName string,
+) error {
 	if _, err := db.ExecContext(
 		ctx,
-		`UPDATE Media SET MediaTitleDBID = ? WHERE DBID = ?`,
+		`UPDATE Media SET MediaTitleDBID = ?, SortName = ? WHERE DBID = ?`,
 		mediaTitleDBID,
+		sortName,
 		mediaDBID,
 	); err != nil {
 		return fmt.Errorf("failed to update media title: %w", err)
@@ -200,7 +206,7 @@ func sqlGetTotalMediaCount(ctx context.Context, db *sql.DB) (int, error) {
 // sqlGetMediaWithFullPath retrieves all media with their associated title and system information using JOIN queries.
 func sqlGetMediaWithFullPath(ctx context.Context, db *sql.DB) ([]database.MediaWithFullPath, error) {
 	query := `
-		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -221,7 +227,7 @@ func sqlGetMediaWithFullPath(ctx context.Context, db *sql.DB) ([]database.MediaW
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
 		if err := rows.Scan(
-			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &m.SortName, &systemDBID, &m.TitleSlug, &m.SystemID,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan media with full path: %w", err)
 		}
@@ -252,7 +258,7 @@ func sqlGetMediaWithFullPathExcluding(
 
 	//nolint:gosec // using parameterized placeholders, not user input
 	query := fmt.Sprintf(`
-		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -275,7 +281,7 @@ func sqlGetMediaWithFullPathExcluding(
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
 		if err := rows.Scan(
-			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &m.SortName, &systemDBID, &m.TitleSlug, &m.SystemID,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan media with full path: %w", err)
 		}
@@ -288,7 +294,7 @@ func sqlGetMediaWithFullPathExcluding(
 // This is used for lazy loading during resume to avoid loading ALL media upfront.
 func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaWithFullPath, error) {
 	query := `
-		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SystemDBID, t.Slug, s.SystemID
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName, m.SystemDBID, t.Slug, s.SystemID
 		FROM Media m
 		JOIN MediaTitles t ON m.MediaTitleDBID = t.DBID
 		JOIN Systems s ON t.SystemDBID = s.DBID
@@ -310,7 +316,7 @@ func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]
 		var m database.MediaWithFullPath
 		var systemDBID int64 // Temporary variable for the extra field
 		if err := rows.Scan(
-			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &systemDBID, &m.TitleSlug, &m.SystemID,
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &m.SortName, &systemDBID, &m.TitleSlug, &m.SystemID,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan media for system %s: %w", systemID, err)
 		}

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -173,7 +173,7 @@ func sqlDeleteMediaTags(ctx context.Context, db sqlQueryable, mediaDBID int64) e
 
 func sqlGetAllMedia(ctx context.Context, db *sql.DB) ([]database.Media, error) {
 	rows, err := db.QueryContext(ctx,
-		"SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir FROM Media ORDER BY DBID")
+		"SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName FROM Media ORDER BY DBID")
 	if err != nil {
 		return nil, fmt.Errorf("failed to query media: %w", err)
 	}
@@ -186,7 +186,7 @@ func sqlGetAllMedia(ctx context.Context, db *sql.DB) ([]database.Media, error) {
 	media := make([]database.Media, 0)
 	for rows.Next() {
 		var m database.Media
-		if err := rows.Scan(&m.DBID, &m.MediaTitleDBID, &m.SystemDBID, &m.Path, &m.ParentDir); err != nil {
+		if err := rows.Scan(&m.DBID, &m.MediaTitleDBID, &m.SystemDBID, &m.Path, &m.ParentDir, &m.SortName); err != nil {
 			return nil, fmt.Errorf("failed to scan media: %w", err)
 		}
 		media = append(media, m)

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -2914,3 +2914,156 @@ func int64Args(values []int64) []any {
 	}
 	return args
 }
+
+// ResolveSingletonContainerAliases implements MediaDBI.
+// It scans all media under parentPrefix for systemDBID in a single query, groups
+// them by immediate child directory, and returns one SingletonContainerAlias per
+// child dir that collapses to a single logical launch target. Directories with
+// nested subdirectories or ambiguous file sets are omitted. Tags and
+// ZapScriptTags are populated via two batch queries plus in-memory
+// disambiguation — the same approach used by the search path.
+func (db *MediaDB) ResolveSingletonContainerAliases(
+	ctx context.Context,
+	systemDBID int64,
+	parentPrefix string,
+) ([]database.SingletonContainerAlias, error) {
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+	if !strings.HasSuffix(parentPrefix, "/") {
+		parentPrefix += "/"
+	}
+
+	// One query for every media row under the parent for this system.
+	upper := stringPrefixUpperBound(parentPrefix)
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if upper != "" {
+		rows, err = db.sql.QueryContext(ctx, `
+			SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+			FROM Media
+			WHERE SystemDBID = ? AND IsMissing = 0 AND Path >= ? AND Path < ?
+			ORDER BY Path
+		`, systemDBID, parentPrefix, upper)
+	} else {
+		rows, err = db.sql.QueryContext(ctx, `
+			SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+			FROM Media
+			WHERE SystemDBID = ? AND IsMissing = 0 AND substr(Path, 1, length(?)) = ?
+			ORDER BY Path
+		`, systemDBID, parentPrefix, parentPrefix)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve singleton aliases query: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	// Group rows by the immediate child directory under parentPrefix.
+	// childDirRows maps "parentPrefix + childName + /" → contained Media rows.
+	childDirRows := make(map[string][]database.Media)
+	for rows.Next() {
+		var m database.Media
+		if scanErr := rows.Scan(
+			&m.DBID, &m.MediaTitleDBID, &m.SystemDBID, &m.Path, &m.ParentDir, &m.IsMissing,
+		); scanErr != nil {
+			return nil, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
+		}
+		rest := strings.TrimPrefix(m.Path, parentPrefix)
+		slash := strings.Index(rest, "/")
+		if slash < 0 {
+			// Direct file under parentPrefix, not inside a child dir — skip.
+			continue
+		}
+		childDir := parentPrefix + rest[:slash] + "/"
+		childDirRows[childDir] = append(childDirRows[childDir], m)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
+	}
+
+	// For each child dir: skip if any row has a different ParentDir (nested
+	// subdirectory). Otherwise apply selectContainerLaunchMedia to pick the
+	// launch target (mirrors the logic in FindSingleContainerLaunchMedia).
+	type candidate struct {
+		childDir string
+		media    database.Media
+	}
+	candidates := make([]candidate, 0, len(childDirRows))
+	for childDir, dirRows := range childDirRows {
+		hasNested := false
+		directRows := make([]database.Media, 0, len(dirRows))
+		for _, m := range dirRows {
+			if m.ParentDir != childDir {
+				hasNested = true
+				break
+			}
+			directRows = append(directRows, m)
+		}
+		if hasNested {
+			continue
+		}
+		chosen := selectContainerLaunchMedia(directRows)
+		if chosen == nil {
+			continue
+		}
+		candidates = append(candidates, candidate{childDir: childDir, media: *chosen})
+	}
+	if len(candidates) == 0 {
+		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
+	}
+
+	// Batch-fetch full rows (title + system) and file-level tags.
+	mediaDBIDs := make([]int64, 0, len(candidates))
+	for _, c := range candidates {
+		mediaDBIDs = append(mediaDBIDs, c.media.DBID)
+	}
+	fullRows, err := db.GetMediaWithTitleAndSystemByIDs(ctx, mediaDBIDs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve singleton aliases full rows: %w", err)
+	}
+	tagsMap, err := db.GetMediaTagsByMediaDBIDs(ctx, mediaDBIDs)
+	if err != nil {
+		return nil, fmt.Errorf("resolve singleton aliases tags: %w", err)
+	}
+
+	// Build the alias list and a parallel synthetic results slice for in-memory
+	// ZapScript disambiguation (same approach as computeZapScriptTags in the
+	// search path — no extra DB queries).
+	aliases := make([]database.SingletonContainerAlias, 0, len(candidates))
+	synthetic := make([]database.SearchResultWithCursor, 0, len(candidates))
+	for _, c := range candidates {
+		row, ok := fullRows[c.media.DBID]
+		if !ok {
+			continue
+		}
+		mediaTags := tagsMap[c.media.DBID]
+		if mediaTags == nil {
+			mediaTags = []database.TagInfo{}
+		}
+		aliases = append(aliases, database.SingletonContainerAlias{
+			ChildDir: c.childDir,
+			Row:      row,
+			Tags:     mediaTags,
+		})
+		synthetic = append(synthetic, database.SearchResultWithCursor{
+			SystemID: row.System.SystemID,
+			Name:     row.Title.Name,
+			MediaID:  row.DBID,
+			Tags:     mediaTags,
+		})
+	}
+
+	// In-memory ZapScript disambiguation across the resolved set.
+	computeZapScriptTags(synthetic)
+	for i := range aliases {
+		aliases[i].ZapScriptTags = synthetic[i].ZapScriptTags
+	}
+
+	return aliases, nil
+}

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -2916,45 +2916,45 @@ func int64Args(values []int64) []any {
 }
 
 // ResolveSingletonContainerAliases implements MediaDBI.
-// It scans all media under parentPrefix for systemDBID in a single query, groups
-// them by immediate child directory, and returns one SingletonContainerAlias per
-// child dir that collapses to a single logical launch target. Directories with
-// nested subdirectories or ambiguous file sets are omitted. Tags and
+// It fetches the direct media rows of every candidate child directory in a
+// single ParentDir IN query and returns one SingletonContainerAlias per
+// candidate that collapses to a single logical launch target. Candidates whose
+// recursive FileCount exceeds their direct row count contain nested
+// subdirectories and are omitted, as are ambiguous file sets. Tags and
 // ZapScriptTags are populated via two batch queries plus in-memory
 // disambiguation — the same approach used by the search path.
 func (db *MediaDB) ResolveSingletonContainerAliases(
 	ctx context.Context,
 	systemDBID int64,
-	parentPrefix string,
+	dirCandidates []database.SingletonAliasCandidate,
 ) ([]database.SingletonContainerAlias, error) {
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	if !strings.HasSuffix(parentPrefix, "/") {
-		parentPrefix += "/"
+	if len(dirCandidates) == 0 {
+		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
 	}
 
-	// One query for every media row under the parent for this system.
-	upper := stringPrefixUpperBound(parentPrefix)
-	var (
-		rows *sql.Rows
-		err  error
-	)
-	if upper != "" {
-		rows, err = db.sql.QueryContext(ctx, `
-			SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
-			FROM Media
-			WHERE SystemDBID = ? AND IsMissing = 0 AND Path >= ? AND Path < ?
-			ORDER BY Path
-		`, systemDBID, parentPrefix, upper)
-	} else {
-		rows, err = db.sql.QueryContext(ctx, `
-			SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
-			FROM Media
-			WHERE SystemDBID = ? AND IsMissing = 0 AND substr(Path, 1, length(?)) = ?
-			ORDER BY Path
-		`, systemDBID, parentPrefix, parentPrefix)
+	expectedCounts := make(map[string]int, len(dirCandidates))
+	args := make([]any, 0, 1+len(dirCandidates))
+	args = append(args, systemDBID)
+	for _, c := range dirCandidates {
+		childDir := c.ChildDir
+		if !strings.HasSuffix(childDir, "/") {
+			childDir += "/"
+		}
+		expectedCounts[childDir] = c.FileCount
+		args = append(args, childDir)
 	}
+
+	// One query for the direct media rows of all candidate dirs, served by
+	// idx_media_parentdir_system.
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+		FROM Media
+		WHERE SystemDBID = ? AND IsMissing = 0 AND ParentDir IN (`+
+		prepareVariadic("?", ",", len(dirCandidates))+`)`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases query: %w", err)
 	}
@@ -2964,9 +2964,7 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		}
 	}()
 
-	// Group rows by the immediate child directory under parentPrefix.
-	// childDirRows maps "parentPrefix + childName + /" → contained Media rows.
-	childDirRows := make(map[string][]database.Media)
+	childDirRows := make(map[string][]database.Media, len(dirCandidates))
 	for rows.Next() {
 		var m database.Media
 		if scanErr := rows.Scan(
@@ -2974,45 +2972,30 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		); scanErr != nil {
 			return nil, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
 		}
-		rest := strings.TrimPrefix(m.Path, parentPrefix)
-		slash := strings.Index(rest, "/")
-		if slash < 0 {
-			// Direct file under parentPrefix, not inside a child dir — skip.
-			continue
-		}
-		childDir := parentPrefix + rest[:slash] + "/"
-		childDirRows[childDir] = append(childDirRows[childDir], m)
+		childDirRows[m.ParentDir] = append(childDirRows[m.ParentDir], m)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
 		return nil, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
 	}
 
-	// For each child dir: skip if any row has a different ParentDir (nested
-	// subdirectory). Otherwise apply selectContainerLaunchMedia to pick the
-	// launch target (mirrors the logic in FindSingleContainerLaunchMedia).
-	type candidate struct {
+	// For each candidate dir: skip if the recursive FileCount exceeds the
+	// direct rows (media in nested subdirectories). Otherwise apply
+	// selectContainerLaunchMedia to pick the launch target (mirrors the logic
+	// in FindSingleContainerLaunchMedia).
+	type resolved struct {
 		childDir string
 		media    database.Media
 	}
-	candidates := make([]candidate, 0, len(childDirRows))
-	for childDir, dirRows := range childDirRows {
-		hasNested := false
-		directRows := make([]database.Media, 0, len(dirRows))
-		for _, m := range dirRows {
-			if m.ParentDir != childDir {
-				hasNested = true
-				break
-			}
-			directRows = append(directRows, m)
-		}
-		if hasNested {
+	candidates := make([]resolved, 0, len(childDirRows))
+	for childDir, directRows := range childDirRows {
+		if len(directRows) != expectedCounts[childDir] {
 			continue
 		}
 		chosen := selectContainerLaunchMedia(directRows)
 		if chosen == nil {
 			continue
 		}
-		candidates = append(candidates, candidate{childDir: childDir, media: *chosen})
+		candidates = append(candidates, resolved{childDir: childDir, media: *chosen})
 	}
 	if len(candidates) == 0 {
 		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
@@ -3063,6 +3046,15 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	computeZapScriptTags(synthetic)
 	for i := range aliases {
 		aliases[i].ZapScriptTags = synthetic[i].ZapScriptTags
+	}
+
+	// Batch cover-flag check: one indexed UNION ALL query for all alias media.
+	// Populates HasCover so aliased directory entries show art in the grid.
+	if err := fetchAndAttachCoverFlags(ctx, db.sql, synthetic); err != nil {
+		return nil, fmt.Errorf("resolve singleton aliases cover flags: %w", err)
+	}
+	for i := range aliases {
+		aliases[i].HasCover = synthetic[i].HasCover
 	}
 
 	return aliases, nil

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2080,6 +2080,10 @@ func setupAliasTestDB(t *testing.T) (mediaDB *MediaDB, cleanup func()) {
 	return mediaDB, cleanup
 }
 
+func aliasTestDir(parent string, parts ...string) string {
+	return filepath.ToSlash(filepath.Join(append([]string{parent}, parts...)...)) + "/"
+}
+
 func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupAliasTestDB(t)
@@ -2087,7 +2091,7 @@ func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameDir := parent + "/Game/"
+	gameDir := aliasTestDir(parent, "Game")
 	gamePath := filepath.ToSlash(filepath.Join(parent, "Game", "Game.chd"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
 		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'game', 'Game');
@@ -2114,7 +2118,7 @@ func TestResolveSingletonContainerAliases_CueBinIsAliasedToCue(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameDir := parent + "/Disc/"
+	gameDir := aliasTestDir(parent, "Disc")
 	cuePath := filepath.ToSlash(filepath.Join(parent, "Disc", "Game.cue"))
 	binPath := filepath.ToSlash(filepath.Join(parent, "Disc", "Game.bin"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
@@ -2143,8 +2147,8 @@ func TestResolveSingletonContainerAliases_NestedSubdirIsNotAliased(t *testing.T)
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "NES"))
-	collDir := parent + "/Collection/"
-	subDir := parent + "/Collection/Sub/"
+	collDir := aliasTestDir(parent, "Collection")
+	subDir := aliasTestDir(parent, "Collection", "Sub")
 	_, err := mediaDB.sql.ExecContext(ctx, `
 		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 1, 'game', 'Game');
 		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
@@ -2169,7 +2173,7 @@ func TestResolveSingletonContainerAliases_M3UAliasedForMultiDisc(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameDir := parent + "/MultiDisc/"
+	gameDir := aliasTestDir(parent, "MultiDisc")
 	m3uPath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Game.m3u"))
 	cuePath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Disc1.cue"))
 	binPath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Disc1.bin"))
@@ -2200,7 +2204,7 @@ func TestResolveSingletonContainerAliases_TagsAttachedOnAlias(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameDir := parent + "/Tagged/"
+	gameDir := aliasTestDir(parent, "Tagged")
 	gamePath := filepath.ToSlash(filepath.Join(parent, "Tagged", "game.chd"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
 		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'tagged-game', 'Tagged Game');
@@ -2226,8 +2230,8 @@ func TestResolveSingletonContainerAliases_MultipleDirsInOneScan(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameADir := parent + "/GameA/"
-	gameBDir := parent + "/GameB/"
+	gameADir := aliasTestDir(parent, "GameA")
+	gameBDir := aliasTestDir(parent, "GameB")
 	gameAPath := filepath.ToSlash(filepath.Join(parent, "GameA", "GameA.chd"))
 	gameBPath := filepath.ToSlash(filepath.Join(parent, "GameB", "GameB.chd"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
@@ -2275,8 +2279,8 @@ func TestResolveSingletonContainerAliases_CountMismatchSkipsDir(t *testing.T) {
 	ctx := context.Background()
 
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	gameDir := parent + "/Game/"
-	subDir := parent + "/Game/Extras/"
+	gameDir := aliasTestDir(parent, "Game")
+	subDir := aliasTestDir(parent, "Game", "Extras")
 	gamePath := filepath.ToSlash(filepath.Join(parent, "Game", "Game.chd"))
 	extraPath := filepath.ToSlash(filepath.Join(parent, "Game", "Extras", "bonus.chd"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
@@ -2296,6 +2300,30 @@ func TestResolveSingletonContainerAliases_CountMismatchSkipsDir(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, aliases)
+}
+
+func TestResolveSingletonContainerAliases_RootPrefixIsHandled(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	gameDir := aliasTestDir("", "Game")
+	gamePath := filepath.ToSlash(filepath.Join("Game", "Game.chd"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'game', 'Game');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+	`, gamePath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, gameDir, aliases[0].ChildDir)
+	assert.Equal(t, gamePath, aliases[0].Row.Path)
+	assert.Equal(t, int64(1), aliases[0].Row.DBID)
 }
 
 func TestResolveSingletonContainerAliases_NoCandidatesReturnsNil(t *testing.T) {
@@ -2327,10 +2355,10 @@ func TestResolveSingletonContainerAliases_HasCoverSet(t *testing.T) {
 	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
 
 	// gameWithCover — media-level image property inserted below.
-	coverDir := parent + "/WithCover/"
+	coverDir := aliasTestDir(parent, "WithCover")
 	coverPath := filepath.ToSlash(filepath.Join(parent, "WithCover", "cover.chd"))
 	// gameNoCover — no property.
-	noCoverDir := parent + "/NoCover/"
+	noCoverDir := aliasTestDir(parent, "NoCover")
 	noCoverPath := filepath.ToSlash(filepath.Join(parent, "NoCover", "nocov.chd"))
 
 	_, err = mediaDB.sql.ExecContext(ctx, `

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2095,7 +2095,9 @@ func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
 	`, gamePath, gameDir)
 	require.NoError(t, err)
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 1},
+	})
 	require.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, gameDir, aliases[0].ChildDir)
@@ -2125,7 +2127,9 @@ func TestResolveSingletonContainerAliases_CueBinIsAliasedToCue(t *testing.T) {
 	`, cuePath, gameDir, binPath, gameDir)
 	require.NoError(t, err)
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 2},
+	})
 	require.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, gameDir, aliases[0].ChildDir)
@@ -2148,9 +2152,12 @@ func TestResolveSingletonContainerAliases_NestedSubdirIsNotAliased(t *testing.T)
 	`,
 		filepath.ToSlash(filepath.Join(parent, "Collection", "Sub", "game.nes")), subDir)
 	require.NoError(t, err)
-	_ = collDir
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 1, parent+"/")
+	// Collection's recursive FileCount is 1 but it has no direct media rows —
+	// the count mismatch marks it as nested and it must not be aliased.
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 1, []database.SingletonAliasCandidate{
+		{ChildDir: collDir, FileCount: 1},
+	})
 	require.NoError(t, err)
 	assert.Empty(t, aliases)
 }
@@ -2178,7 +2185,9 @@ func TestResolveSingletonContainerAliases_M3UAliasedForMultiDisc(t *testing.T) {
 	`, m3uPath, gameDir, cuePath, gameDir, binPath, gameDir)
 	require.NoError(t, err)
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 3},
+	})
 	require.NoError(t, err)
 	require.Len(t, aliases, 1)
 	assert.Equal(t, m3uPath, aliases[0].Row.Path)
@@ -2200,7 +2209,9 @@ func TestResolveSingletonContainerAliases_TagsAttachedOnAlias(t *testing.T) {
 	`, gamePath, gameDir)
 	require.NoError(t, err)
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 1},
+	})
 	require.NoError(t, err)
 	require.Len(t, aliases, 1)
 	require.Len(t, aliases[0].Tags, 1)
@@ -2229,7 +2240,10 @@ func TestResolveSingletonContainerAliases_MultipleDirsInOneScan(t *testing.T) {
 	`, gameAPath, gameADir, gameBPath, gameBDir)
 	require.NoError(t, err)
 
-	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameADir, FileCount: 1},
+		{ChildDir: gameBDir, FileCount: 1},
+	})
 	require.NoError(t, err)
 	require.Len(t, aliases, 2)
 
@@ -2243,4 +2257,108 @@ func TestResolveSingletonContainerAliases_MultipleDirsInOneScan(t *testing.T) {
 	if b, ok := byDir[gameBDir]; assert.True(t, ok, "missing GameB alias") {
 		assert.Equal(t, gameBPath, b.Row.Path)
 	}
+
+	// A dir not passed as a candidate must not be resolved even though its
+	// media rows exist in the table.
+	aliases, err = mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameADir, FileCount: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, gameADir, aliases[0].ChildDir)
+}
+
+func TestResolveSingletonContainerAliases_CountMismatchSkipsDir(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := parent + "/Game/"
+	subDir := parent + "/Game/Extras/"
+	gamePath := filepath.ToSlash(filepath.Join(parent, "Game", "Game.chd"))
+	extraPath := filepath.ToSlash(filepath.Join(parent, "Game", "Extras", "bonus.chd"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'game', 'Game'),
+			(2, 2, 'bonus', 'Bonus');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?);
+	`, gamePath, gameDir, extraPath, subDir)
+	require.NoError(t, err)
+
+	// Game has one direct row but a recursive FileCount of 2 (the nested
+	// Extras file), so it must be skipped.
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: 2},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+func TestResolveSingletonContainerAliases_NoCandidatesReturnsNil(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(context.Background(), 2, nil)
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+// TestResolveSingletonContainerAliases_HasCoverSet verifies that HasCover is
+// true when the aliased media's title has a scraped image property, and false
+// when it does not.
+func TestResolveSingletonContainerAliases_HasCoverSet(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed the minimal tag rows needed by fetchAndAttachCoverFlags.
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT OR IGNORE INTO TagTypes (DBID, Type, IsExclusive) VALUES (900, 'property', 0);
+		INSERT OR IGNORE INTO Tags    (DBID, TypeDBID, Tag)      VALUES (901, 900, 'image-boxart');
+	`)
+	require.NoError(t, err)
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+
+	// gameWithCover — media-level image property inserted below.
+	coverDir := parent + "/WithCover/"
+	coverPath := filepath.ToSlash(filepath.Join(parent, "WithCover", "cover.chd"))
+	// gameNoCover — no property.
+	noCoverDir := parent + "/NoCover/"
+	noCoverPath := filepath.ToSlash(filepath.Join(parent, "NoCover", "nocov.chd"))
+
+	_, err = mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'with-cover', 'With Cover'),
+			(2, 2, 'no-cover',   'No Cover');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?);
+	`, coverPath, coverDir, noCoverPath, noCoverDir)
+	require.NoError(t, err)
+
+	// MediaProperties row for media DBID=1.
+	_, err = mediaDB.sql.ExecContext(ctx,
+		`INSERT INTO MediaProperties (MediaDBID, TypeTagDBID, Text) VALUES (1, 901, 'cover.jpg')`)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: coverDir, FileCount: 1},
+		{ChildDir: noCoverDir, FileCount: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 2)
+
+	byDir := make(map[string]database.SingletonContainerAlias, 2)
+	for _, a := range aliases {
+		byDir[a.ChildDir] = a
+	}
+	assert.True(t, byDir[coverDir].HasCover, "aliased dir with image property should have HasCover=true")
+	assert.False(t, byDir[noCoverDir].HasCover, "aliased dir without image property should have HasCover=false")
 }

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2054,3 +2054,193 @@ func TestGetMediaTitleProperties_NoBlobIsNilBlobDBID(t *testing.T) {
 	assert.Empty(t, got[0].ContentType)
 	assert.Nil(t, got[0].Binary)
 }
+
+// --- ResolveSingletonContainerAliases ---
+
+// setupAliasTestDB returns a MediaDB seeded with:
+//   - Systems: NES (1), PSX (2)
+//   - TagTypes: "favorite" (additive, 10)
+//   - Tags: "favorite:true" (10)
+//
+// Callers insert their own MediaTitles and Media.
+func setupAliasTestDB(t *testing.T) (mediaDB *MediaDB, cleanup func()) {
+	t.Helper()
+	mediaDB, cleanup = setupTempMediaDB(t)
+	ctx := context.Background()
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES
+			(1, 'NES', 'Nintendo'),
+			(2, 'PSX', 'PlayStation');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES
+			(10, 'favorite', 0);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES
+			(10, 10, 'true');
+	`)
+	require.NoError(t, err)
+	return mediaDB, cleanup
+}
+
+func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := parent + "/Game/"
+	gamePath := filepath.ToSlash(filepath.Join(parent, "Game", "Game.chd"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'game', 'Game');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+	`, gamePath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, gameDir, aliases[0].ChildDir)
+	assert.Equal(t, int64(1), aliases[0].Row.DBID)
+	assert.Equal(t, "Game", aliases[0].Row.Title.Name)
+	assert.Equal(t, "PSX", aliases[0].Row.System.SystemID)
+	assert.Empty(t, aliases[0].ZapScriptTags)
+}
+
+func TestResolveSingletonContainerAliases_CueBinIsAliasedToCue(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := parent + "/Disc/"
+	cuePath := filepath.ToSlash(filepath.Join(parent, "Disc", "Game.cue"))
+	binPath := filepath.ToSlash(filepath.Join(parent, "Disc", "Game.bin"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'game-cue', 'Game'),
+			(2, 2, 'game-bin', 'Game Bin');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?);
+	`, cuePath, gameDir, binPath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, gameDir, aliases[0].ChildDir)
+	assert.Equal(t, cuePath, aliases[0].Row.Path)
+}
+
+func TestResolveSingletonContainerAliases_NestedSubdirIsNotAliased(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "NES"))
+	collDir := parent + "/Collection/"
+	subDir := parent + "/Collection/Sub/"
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 1, 'game', 'Game');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 1, ?, ?);
+	`,
+		filepath.ToSlash(filepath.Join(parent, "Collection", "Sub", "game.nes")), subDir)
+	require.NoError(t, err)
+	_ = collDir
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 1, parent+"/")
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+func TestResolveSingletonContainerAliases_M3UAliasedForMultiDisc(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := parent + "/MultiDisc/"
+	m3uPath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Game.m3u"))
+	cuePath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Disc1.cue"))
+	binPath := filepath.ToSlash(filepath.Join(parent, "MultiDisc", "Disc1.bin"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'game-m3u', 'Game'),
+			(2, 2, 'disc1-cue', 'Disc1 Cue'),
+			(3, 2, 'disc1-bin', 'Disc1 Bin');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?),
+			(3, 3, 2, ?, ?);
+	`, m3uPath, gameDir, cuePath, gameDir, binPath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, m3uPath, aliases[0].Row.Path)
+}
+
+func TestResolveSingletonContainerAliases_TagsAttachedOnAlias(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := parent + "/Tagged/"
+	gamePath := filepath.ToSlash(filepath.Join(parent, "Tagged", "game.chd"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'tagged-game', 'Tagged Game');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+		INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (1, 10);
+	`, gamePath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	require.Len(t, aliases[0].Tags, 1)
+	assert.Equal(t, "true", aliases[0].Tags[0].Tag)
+	assert.Equal(t, "favorite", aliases[0].Tags[0].Type)
+}
+
+func TestResolveSingletonContainerAliases_MultipleDirsInOneScan(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameADir := parent + "/GameA/"
+	gameBDir := parent + "/GameB/"
+	gameAPath := filepath.ToSlash(filepath.Join(parent, "GameA", "GameA.chd"))
+	gameBPath := filepath.ToSlash(filepath.Join(parent, "GameB", "GameB.chd"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'game-a', 'Game A'),
+			(2, 2, 'game-b', 'Game B');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?);
+	`, gameAPath, gameADir, gameBPath, gameBDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, parent+"/")
+	require.NoError(t, err)
+	require.Len(t, aliases, 2)
+
+	byDir := make(map[string]database.SingletonContainerAlias, 2)
+	for _, a := range aliases {
+		byDir[a.ChildDir] = a
+	}
+	if a, ok := byDir[gameADir]; assert.True(t, ok, "missing GameA alias") {
+		assert.Equal(t, gameAPath, a.Row.Path)
+	}
+	if b, ok := byDir[gameBDir]; assert.True(t, ok, "missing GameB alias") {
+		assert.Equal(t, gameBPath, b.Row.Path)
+	}
+}

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1368,12 +1368,16 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 	systemID := "nes"
 
 	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
+	marioPath := filepath.Join(gamesDir, "mario.nes")
+	zeldaPath := filepath.Join(gamesDir, "zelda.nes")
+	metroidPath := filepath.Join(gamesDir, "metroid.nes")
 	rows := sqlmock.NewRows(cols).
-		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+		AddRow(int64(1), marioPath, gamesDir, int64(10),
 			"Super Mario Bros.", int64(100), "supermariobros", "nes").
-		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11),
+		AddRow(int64(2), zeldaPath, gamesDir, int64(11),
 			"The Legend of Zelda", int64(100), "legendofzelda", "nes").
-		AddRow(int64(3), "/games/metroid.nes", "/games/", int64(12), "Metroid", int64(100), "metroid", "nes")
+		AddRow(int64(3), metroidPath, gamesDir, int64(12), "Metroid", int64(100), "metroid", "nes")
 
 	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
@@ -1386,8 +1390,8 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 
 	// Check first result
 	assert.Equal(t, int64(1), results[0].DBID)
-	assert.Equal(t, "/games/mario.nes", results[0].Path)
-	assert.Equal(t, "/games/", results[0].ParentDir)
+	assert.Equal(t, marioPath, results[0].Path)
+	assert.Equal(t, gamesDir, results[0].ParentDir)
 	assert.Equal(t, int64(10), results[0].MediaTitleDBID)
 	assert.Equal(t, "Super Mario Bros.", results[0].SortName)
 	assert.Equal(t, "supermariobros", results[0].TitleSlug)
@@ -1395,12 +1399,12 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 
 	// Check second result
 	assert.Equal(t, int64(2), results[1].DBID)
-	assert.Equal(t, "/games/zelda.nes", results[1].Path)
+	assert.Equal(t, zeldaPath, results[1].Path)
 	assert.Equal(t, "legendofzelda", results[1].TitleSlug)
 
 	// Check third result
 	assert.Equal(t, int64(3), results[2].DBID)
-	assert.Equal(t, "/games/metroid.nes", results[2].Path)
+	assert.Equal(t, metroidPath, results[2].Path)
 	assert.Equal(t, "metroid", results[2].TitleSlug)
 
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -1720,10 +1724,12 @@ func TestSqlGetMediaWithFullPath_Success(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
 	rows := sqlmock.NewRows(cols).
-		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+		AddRow(int64(1), filepath.Join(gamesDir, "mario.nes"), gamesDir, int64(10),
 			"Super Mario Bros.", int64(100), "supermariobros", "nes").
-		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11), "Zelda", int64(100), "legendofzelda", "nes")
+		AddRow(int64(2), filepath.Join(gamesDir, "zelda.nes"), gamesDir, int64(11),
+			"Zelda", int64(100), "legendofzelda", "nes")
 
 	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
 		WillReturnRows(rows)
@@ -1779,8 +1785,9 @@ func TestSqlGetMediaWithFullPathExcluding_EmptyExcludes(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
 	rows := sqlmock.NewRows(cols).
-		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+		AddRow(int64(1), filepath.Join(gamesDir, "mario.nes"), gamesDir, int64(10),
 			"Super Mario Bros.", int64(100), "supermariobros", "nes")
 
 	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
@@ -1800,8 +1807,10 @@ func TestSqlGetMediaWithFullPathExcluding_WithExcludes(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
 	rows := sqlmock.NewRows(cols).
-		AddRow(int64(2), "/games/zelda.snes", "/games/", int64(11), "Zelda", int64(101), "legendofzelda", "snes")
+		AddRow(int64(2), filepath.Join(gamesDir, "zelda.snes"), gamesDir, int64(11),
+			"Zelda", int64(101), "legendofzelda", "snes")
 
 	mock.ExpectQuery(`SELECT m\.DBID.*WHERE s\.SystemID NOT IN`).
 		WithArgs("nes").

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1681,3 +1681,153 @@ func TestSqlSearchMediaByTitleDBIDs_WithLetter(t *testing.T) {
 	assert.Len(t, results, 1)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestSqlUpdateMediaTitle_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE Media SET MediaTitleDBID = \?, SortName = \? WHERE DBID = \?`).
+		WithArgs(int64(10), "Super Mario Bros.", int64(1)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = sqlUpdateMediaTitle(context.Background(), db, 1, 10, "Super Mario Bros.")
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlUpdateMediaTitle_ExecError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE Media SET MediaTitleDBID = \?, SortName = \? WHERE DBID = \?`).
+		WithArgs(int64(10), "Super Mario Bros.", int64(1)).
+		WillReturnError(sql.ErrConnDone)
+
+	err = sqlUpdateMediaTitle(context.Background(), db, 1, 10, "Super Mario Bros.")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update media title")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPath_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+			"Super Mario Bros.", int64(100), "supermariobros", "nes").
+		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11), "Zelda", int64(100), "legendofzelda", "nes")
+
+	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
+		WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithFullPath(context.Background(), db)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, int64(1), results[0].DBID)
+	assert.Equal(t, "Super Mario Bros.", results[0].SortName)
+	assert.Equal(t, "supermariobros", results[0].TitleSlug)
+	assert.Equal(t, "nes", results[0].SystemID)
+	assert.Equal(t, int64(2), results[1].DBID)
+	assert.Equal(t, "Zelda", results[1].SortName)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPath_QueryError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
+		WillReturnError(sql.ErrConnDone)
+
+	results, err := sqlGetMediaWithFullPath(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to query media with full path")
+	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPath_EmptyResult(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
+		WillReturnRows(sqlmock.NewRows(cols))
+
+	results, err := sqlGetMediaWithFullPath(context.Background(), db)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPathExcluding_EmptyExcludes(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+			"Super Mario Bros.", int64(100), "supermariobros", "nes")
+
+	mock.ExpectQuery(`SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName`).
+		WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithFullPathExcluding(context.Background(), db, []string{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Super Mario Bros.", results[0].SortName)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPathExcluding_WithExcludes(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(2), "/games/zelda.snes", "/games/", int64(11), "Zelda", int64(101), "legendofzelda", "snes")
+
+	mock.ExpectQuery(`SELECT m\.DBID.*WHERE s\.SystemID NOT IN`).
+		WithArgs("nes").
+		WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithFullPathExcluding(context.Background(), db, []string{"nes"})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Zelda", results[0].SortName)
+	assert.Equal(t, "snes", results[0].SystemID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithFullPathExcluding_QueryError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT m\.DBID.*WHERE s\.SystemID NOT IN`).
+		WithArgs("nes").
+		WillReturnError(sql.ErrConnDone)
+
+	results, err := sqlGetMediaWithFullPathExcluding(context.Background(), db, []string{"nes"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to query media with full path excluding")
+	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1367,12 +1367,15 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 
 	systemID := "nes"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"}).
-		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10), int64(100), "supermariobros", "nes").
-		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11), int64(100), "legendofzelda", "nes").
-		AddRow(int64(3), "/games/metroid.nes", "/games/", int64(12), int64(100), "metroid", "nes")
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(1), "/games/mario.nes", "/games/", int64(10),
+			"Super Mario Bros.", int64(100), "supermariobros", "nes").
+		AddRow(int64(2), "/games/zelda.nes", "/games/", int64(11),
+			"The Legend of Zelda", int64(100), "legendofzelda", "nes").
+		AddRow(int64(3), "/games/metroid.nes", "/games/", int64(12), "Metroid", int64(100), "metroid", "nes")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
@@ -1386,6 +1389,7 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 	assert.Equal(t, "/games/mario.nes", results[0].Path)
 	assert.Equal(t, "/games/", results[0].ParentDir)
 	assert.Equal(t, int64(10), results[0].MediaTitleDBID)
+	assert.Equal(t, "Super Mario Bros.", results[0].SortName)
 	assert.Equal(t, "supermariobros", results[0].TitleSlug)
 	assert.Equal(t, "nes", results[0].SystemID)
 
@@ -1410,9 +1414,10 @@ func TestSqlGetMediaBySystemID_EmptyResult(t *testing.T) {
 
 	systemID := "nonexistent"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SystemDBID", "Slug", "SystemID"})
+	emptyCols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "SystemDBID", "Slug", "SystemID"}
+	rows := sqlmock.NewRows(emptyCols)
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
@@ -1431,7 +1436,7 @@ func TestSqlGetMediaBySystemID_QueryError(t *testing.T) {
 
 	systemID := "nes"
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
 
@@ -1455,7 +1460,7 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"DBID", "Path"}).
 		AddRow(int64(1), "/games/mario.nes")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SystemDBID, ` +
+	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName, m\.SystemDBID, ` +
 		`t\.Slug, s\.SystemID.*FROM Media m.*WHERE s\.SystemID = \?`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -159,6 +159,7 @@ func AddMediaPathWithPrefixPolicy(
 	}
 
 	titleKey := database.TitleKey(systemID, pf.Slug)
+	canonicalTitleName := pf.Title
 	if foundTitleIndex, ok := ss.TitleIDs[titleKey]; !ok {
 		ss.TitlesIndex++
 		titleIndex = ss.TitlesIndex
@@ -180,8 +181,16 @@ func AddMediaPathWithPrefixPolicy(
 			return 0, 0, fmt.Errorf("error inserting media title %s: %w", pf.Title, err)
 		}
 		ss.TitleIDs[titleKey] = titleIndex
+		if ss.TitleNames != nil {
+			ss.TitleNames[titleIndex] = canonicalTitleName
+		}
 	} else {
 		titleIndex = foundTitleIndex
+		if ss.TitleNames != nil {
+			if existingName, ok := ss.TitleNames[titleIndex]; ok && existingName != "" {
+				canonicalTitleName = existingName
+			}
+		}
 	}
 
 	mediaKey := database.MediaKey(systemID, pf.Path)
@@ -195,7 +204,7 @@ func AddMediaPathWithPrefixPolicy(
 			DBID:           int64(mediaIndex),
 			Path:           pf.Path,
 			ParentDir:      parentDir,
-			SortName:       pf.Title,
+			SortName:       canonicalTitleName,
 			MediaTitleDBID: int64(titleIndex),
 			SystemDBID:     int64(systemIndex),
 		})
@@ -230,7 +239,7 @@ func AddMediaPathWithPrefixPolicy(
 		_, needsSortName := ss.MediaNeedsSortName[mediaIndex]
 		existingTitleIndex, titleKnown := ss.MediaTitleIDs[mediaIndex]
 		if !titleKnown || existingTitleIndex != titleIndex || needsSortName {
-			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex), pf.Title); err != nil {
+			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex), canonicalTitleName); err != nil {
 				return 0, 0, fmt.Errorf("error updating media title %s: %w", pf.Path, err)
 			}
 			if ss.MediaTitleIDs != nil {
@@ -817,6 +826,9 @@ func PopulateScanStateForSystem(
 	for _, title := range stateData.titles {
 		titleKey := database.TitleKey(title.SystemID, title.Slug)
 		ss.TitleIDs[titleKey] = int(title.DBID)
+		if ss.TitleNames != nil {
+			ss.TitleNames[int(title.DBID)] = title.Name
+		}
 	}
 
 	for _, m := range stateData.media {
@@ -916,6 +928,9 @@ func PopulatePersistentScanStateForSystem(
 	for _, title := range stateData.titles {
 		titleKey := database.TitleKey(title.SystemID, title.Slug)
 		ss.TitleIDs[titleKey] = int(title.DBID)
+		if ss.TitleNames != nil {
+			ss.TitleNames[int(title.DBID)] = title.Name
+		}
 	}
 
 	for _, m := range stateData.media {

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -195,6 +195,7 @@ func AddMediaPathWithPrefixPolicy(
 			DBID:           int64(mediaIndex),
 			Path:           pf.Path,
 			ParentDir:      parentDir,
+			SortName:       pf.Title,
 			MediaTitleDBID: int64(titleIndex),
 			SystemDBID:     int64(systemIndex),
 		})
@@ -226,12 +227,17 @@ func AddMediaPathWithPrefixPolicy(
 				ss.MediaParentDirs[mediaIndex] = parentDir
 			}
 		}
-		if existingTitleIndex, ok := ss.MediaTitleIDs[mediaIndex]; !ok || existingTitleIndex != titleIndex {
-			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex)); err != nil {
+		_, needsSortName := ss.MediaNeedsSortName[mediaIndex]
+		existingTitleIndex, titleKnown := ss.MediaTitleIDs[mediaIndex]
+		if !titleKnown || existingTitleIndex != titleIndex || needsSortName {
+			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex), pf.Title); err != nil {
 				return 0, 0, fmt.Errorf("error updating media title %s: %w", pf.Path, err)
 			}
 			if ss.MediaTitleIDs != nil {
 				ss.MediaTitleIDs[mediaIndex] = titleIndex
+			}
+			if ss.MediaNeedsSortName != nil {
+				delete(ss.MediaNeedsSortName, mediaIndex)
 			}
 		}
 	}
@@ -819,6 +825,9 @@ func PopulateScanStateForSystem(
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[int(m.DBID)] = int(m.MediaTitleDBID)
 		}
+		if ss.MediaNeedsSortName != nil && m.SortName == "" {
+			ss.MediaNeedsSortName[int(m.DBID)] = struct{}{}
+		}
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
 		}
@@ -914,6 +923,9 @@ func PopulatePersistentScanStateForSystem(
 		ss.MediaIDs[mediaKey] = int(m.DBID)
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[int(m.DBID)] = int(m.MediaTitleDBID)
+		}
+		if ss.MediaNeedsSortName != nil && m.SortName == "" {
+			ss.MediaNeedsSortName[int(m.DBID)] = struct{}{}
 		}
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -407,6 +407,7 @@ func TestAddMediaPath_WritesSortNameWhenExistingMediaHasEmptySortName(t *testing
 	scanState := &database.ScanState{
 		SystemIDs:          map[string]int{"NES": 1},
 		TitleIDs:           map[string]int{"NES:supermariobrothers": 10},
+		TitleNames:         map[int]string{10: "Super Mario Bros"},
 		MediaIDs:           map[string]int{database.MediaKey("NES", pathKey): 20},
 		MediaTitleIDs:      map[int]int{20: 10}, // same title — would not normally trigger UpdateMediaTitle
 		MediaNeedsSortName: map[int]struct{}{20: {}},
@@ -423,7 +424,7 @@ func TestAddMediaPath_WritesSortNameWhenExistingMediaHasEmptySortName(t *testing
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
 	assert.NotContains(t, scanState.MissingMedia, 20)
-	mockDB.AssertCalled(t, "UpdateMediaTitle", int64(20), int64(10), mock.Anything)
+	mockDB.AssertCalled(t, "UpdateMediaTitle", int64(20), int64(10), "Super Mario Bros")
 	assert.NotContains(t, scanState.MediaNeedsSortName, 20)
 	mockDB.AssertExpectations(t)
 }

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -1520,3 +1520,53 @@ func TestAddMediaPath_ExtensionTag_UniqueConstraintClassification(t *testing.T) 
 		mockDB.AssertExpectations(t)
 	})
 }
+
+func TestPopulateScanStateForSystem_TracksEmptySortNameInNeedsSortNameMap(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	// Insert a path that gets SortName populated normally.
+	insertState := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, insertState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, populatedID, err := AddMediaPath(
+		mediaDB, insertState, "NES", filepath.Join("roms", "Zelda.nes"), "", false, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Simulate a pre-migration row: clear SortName directly so it's empty.
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+	_, err = sqlDB.ExecContext(ctx, `UPDATE Media SET SortName = '' WHERE DBID = ?`, populatedID)
+	require.NoError(t, err)
+
+	ss := &database.ScanState{
+		SystemIDs:          make(map[string]int),
+		TitleIDs:           make(map[string]int),
+		MediaIDs:           make(map[string]int),
+		MediaTitleIDs:      make(map[int]int),
+		MediaNeedsSortName: make(map[int]struct{}),
+		MediaParentDirs:    make(map[int]string),
+		MediaTagIDs:        make(map[int]map[int]struct{}),
+		TagTypeIDs:         make(map[string]int),
+		TagIDs:             make(map[string]int),
+		MissingMedia:       make(map[int]struct{}),
+	}
+
+	require.NoError(t, PopulateScanStateForSystem(ctx, mediaDB, ss, "NES"))
+
+	assert.Contains(t, ss.MediaNeedsSortName, populatedID,
+		"media with empty SortName must appear in MediaNeedsSortName")
+}

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -391,10 +391,40 @@ func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testi
 	assert.Equal(t, 10, titleIndex)
 	assert.Equal(t, 20, mediaIndex)
 	assert.NotContains(t, scanState.MissingMedia, 20)
-	mockDB.AssertNotCalled(t, "UpdateMediaTitle", mock.Anything, mock.Anything)
+	mockDB.AssertNotCalled(t, "UpdateMediaTitle", mock.Anything, mock.Anything, mock.Anything)
 	mockDB.AssertNotCalled(t, "DeleteMediaTag", mock.Anything, mock.Anything)
 	mockDB.AssertNotCalled(t, "DeleteMediaTags", mock.Anything)
 	mockDB.AssertNotCalled(t, "InsertMediaTag", mock.Anything)
+	mockDB.AssertExpectations(t)
+}
+
+func TestAddMediaPath_WritesSortNameWhenExistingMediaHasEmptySortName(t *testing.T) {
+	t.Parallel()
+
+	mockDB := helpers.NewMockMediaDBI()
+	path := filepath.Join("roms", "NES", "Super Mario Bros.nes")
+	pathKey := filepath.ToSlash(path)
+	scanState := &database.ScanState{
+		SystemIDs:          map[string]int{"NES": 1},
+		TitleIDs:           map[string]int{"NES:supermariobrothers": 10},
+		MediaIDs:           map[string]int{database.MediaKey("NES", pathKey): 20},
+		MediaTitleIDs:      map[int]int{20: 10}, // same title — would not normally trigger UpdateMediaTitle
+		MediaNeedsSortName: map[int]struct{}{20: {}},
+		MediaTagIDs:        map[int]map[int]struct{}{20: {8: {}}},
+		TagTypeIDs:         map[string]int{string(tags.TagTypeExtension): 7},
+		TagIDs:             map[string]int{database.TagKey(string(tags.TagTypeExtension), "nes"): 8},
+		MissingMedia:       map[int]struct{}{20: {}},
+	}
+
+	titleIndex, mediaIndex, err := AddMediaPath(
+		mockDB, scanState, "NES", path, "", false, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 10, titleIndex)
+	assert.Equal(t, 20, mediaIndex)
+	assert.NotContains(t, scanState.MissingMedia, 20)
+	mockDB.AssertCalled(t, "UpdateMediaTitle", int64(20), int64(10), mock.Anything)
+	assert.NotContains(t, scanState.MediaNeedsSortName, 20)
 	mockDB.AssertExpectations(t)
 }
 
@@ -427,7 +457,7 @@ func TestAddMediaPath_RepairsExistingMediaParentDir(t *testing.T) {
 	assert.Equal(t, 20, mediaIndex)
 	assert.Equal(t, wantParentDir, scanState.MediaParentDirs[20])
 	assert.NotContains(t, scanState.MissingMedia, 20)
-	mockDB.AssertNotCalled(t, "UpdateMediaTitle", mock.Anything, mock.Anything)
+	mockDB.AssertNotCalled(t, "UpdateMediaTitle", mock.Anything, mock.Anything, mock.Anything)
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -737,6 +737,7 @@ func NewNamesIndex(
 		SystemIDs:          make(map[string]int),
 		TitlesIndex:        0,
 		TitleIDs:           make(map[string]int),
+		TitleNames:         make(map[int]string),
 		MediaIndex:         0,
 		MediaIDs:           make(map[string]int),
 		MediaTitleIDs:      make(map[int]int),

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -733,20 +733,21 @@ func NewNamesIndex(
 
 	// Initialize scan state
 	scanState := database.ScanState{
-		SystemsIndex:    0,
-		SystemIDs:       make(map[string]int),
-		TitlesIndex:     0,
-		TitleIDs:        make(map[string]int),
-		MediaIndex:      0,
-		MediaIDs:        make(map[string]int),
-		MediaTitleIDs:   make(map[int]int),
-		MediaParentDirs: make(map[int]string),
-		MediaTagIDs:     make(map[int]map[int]struct{}),
-		TagTypesIndex:   0,
-		TagTypeIDs:      make(map[string]int),
-		TagsIndex:       0,
-		TagIDs:          make(map[string]int),
-		MissingMedia:    make(map[int]struct{}),
+		SystemsIndex:       0,
+		SystemIDs:          make(map[string]int),
+		TitlesIndex:        0,
+		TitleIDs:           make(map[string]int),
+		MediaIndex:         0,
+		MediaIDs:           make(map[string]int),
+		MediaTitleIDs:      make(map[int]int),
+		MediaNeedsSortName: make(map[int]struct{}),
+		MediaParentDirs:    make(map[int]string),
+		MediaTagIDs:        make(map[int]map[int]struct{}),
+		TagTypesIndex:      0,
+		TagTypeIDs:         make(map[string]int),
+		TagsIndex:          0,
+		TagIDs:             make(map[string]int),
+		MissingMedia:       make(map[int]struct{}),
 	}
 
 	// 3. Set up scan state — persistent mode is always active
@@ -1172,6 +1173,7 @@ func NewNamesIndex(
 	scanState.TitleIDs = nil
 	scanState.MediaIDs = nil
 	scanState.MediaTitleIDs = nil
+	scanState.MediaNeedsSortName = nil
 	scanState.MediaParentDirs = nil
 	scanState.MediaTagIDs = nil
 	scanState.TagTypeIDs = nil

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -136,6 +136,14 @@ const (
 	TagUserFavorite TagValue = "favorite"
 )
 
+// UtilityTags are non-metadata tags the browse grid renders directly
+// (currently the favorite star) and are therefore always attached to browse
+// results. All other (metadata) tags are excluded from browse and fetched on
+// demand via media.meta. Add an entry here when the grid renders a new tag.
+var UtilityTags = []CanonicalTag{
+	{Type: TagTypeUser, Value: TagUserFavorite},
+}
+
 // Tag Format:
 //   - Flat tags: Just the value (e.g., "trackball", "quiz")
 //   - Hierarchical tags: Colon-separated (e.g., "joystick:4", "sports:wrestling")

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -878,10 +878,9 @@ func (s *Service) startService() {
 	}
 
 	if result.RestartRequested != nil && result.RestartRequested() {
-		if execErr := s.restartServiceBinary(); execErr != nil {
-			log.Error().Err(execErr).Msg("failed to re-exec for restart")
-			os.Exit(1)
-		}
+		execErr := s.restartServiceBinary()
+		log.Error().Err(execErr).Msg("failed to re-exec for restart")
+		os.Exit(1)
 	}
 
 	os.Exit(0)

--- a/pkg/service/idle/scheduler_test.go
+++ b/pkg/service/idle/scheduler_test.go
@@ -236,9 +236,12 @@ func TestScheduler_WaitForIdle_QuietWindowResetsOnRequest(t *testing.T) {
 		// Expected — still waiting.
 	}
 
-	// Advance past the reset quiet window.
+	// Advance well past the reset quiet window. WaitForIdle may briefly
+	// observe the mid-test request in flight and park on its in-flight poll
+	// interval before the RequestEnded wake arrives, so this must cover both
+	// the quiet-window timer and that poll path.
 	require.NoError(t, fc.BlockUntilContext(ctx, 1))
-	fc.Advance(70 * time.Millisecond)
+	fc.Advance(300 * time.Millisecond)
 	select {
 	case err := <-errCh:
 		require.NoError(t, err)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2368,6 +2368,19 @@ func (m *MockMediaDBI) FindSingleContainerLaunchMedia(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) ResolveSingletonContainerAliases(
+	ctx context.Context, systemDBID int64, parentPrefix string,
+) ([]database.SingletonContainerAlias, error) {
+	if !m.hasExpectedCall("ResolveSingletonContainerAliases") {
+		return nil, nil //nolint:nilnil // default mock behavior for tests that do not exercise batch aliasing
+	}
+	args := m.Called(ctx, systemDBID, parentPrefix)
+	if result, ok := args.Get(0).([]database.SingletonContainerAlias); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) FindMediaBySystemAndPathFold(
 	ctx context.Context, systemDBID int64, path string,
 ) (*database.Media, error) {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -991,7 +991,7 @@ func (m *MockMediaDBI) FindOrInsertMediaTitle(row *database.MediaTitle) (databas
 }
 
 // Media CRUD methods
-func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) {
+func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) { //nolint:gocritic
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
 		if err := args.Error(1); err != nil {
@@ -1005,7 +1005,7 @@ func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) {
 	return database.Media{}, nil
 }
 
-func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) {
+func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
 	m.trackDatabaseOperation() // Track if called outside transaction
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
@@ -1020,7 +1020,7 @@ func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) {
 	return database.Media{}, nil
 }
 
-func (m *MockMediaDBI) FindOrInsertMedia(row database.Media) (database.Media, error) {
+func (m *MockMediaDBI) FindOrInsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
 		if err := args.Error(1); err != nil {
@@ -1034,9 +1034,9 @@ func (m *MockMediaDBI) FindOrInsertMedia(row database.Media) (database.Media, er
 	return database.Media{}, nil
 }
 
-func (m *MockMediaDBI) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64) error {
+func (m *MockMediaDBI) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortName string) error {
 	m.trackDatabaseOperation() // Track if called outside transaction
-	args := m.Called(mediaDBID, mediaTitleDBID)
+	args := m.Called(mediaDBID, mediaTitleDBID, sortName)
 	if err := args.Error(0); err != nil {
 		return fmt.Errorf("mock operation failed: %w", err)
 	}
@@ -2116,7 +2116,7 @@ func NewMockMediaDBI() *MockMediaDBI {
 	mockMediaDB.On("DropSecondaryIndexes").Return(nil).Maybe()
 	mockMediaDB.On("BulkSetMediaMissing", mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("ResetMissingFlags", mock.Anything).Return(nil).Maybe()
-	mockMediaDB.On("UpdateMediaTitle", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockMediaDB.On("UpdateMediaTitle", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("DeleteMediaTags", mock.Anything).Return(nil).Maybe()
 	return mockMediaDB
 }

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2369,12 +2369,12 @@ func (m *MockMediaDBI) FindSingleContainerLaunchMedia(
 }
 
 func (m *MockMediaDBI) ResolveSingletonContainerAliases(
-	ctx context.Context, systemDBID int64, parentPrefix string,
+	ctx context.Context, systemDBID int64, candidates []database.SingletonAliasCandidate,
 ) ([]database.SingletonContainerAlias, error) {
 	if !m.hasExpectedCall("ResolveSingletonContainerAliases") {
 		return nil, nil //nolint:nilnil // default mock behavior for tests that do not exercise batch aliasing
 	}
-	args := m.Called(ctx, systemDBID, parentPrefix)
+	args := m.Called(ctx, systemDBID, candidates)
 	if result, ok := args.Get(0).([]database.SingletonContainerAlias); ok {
 		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 	}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -991,7 +991,9 @@ func (m *MockMediaDBI) FindOrInsertMediaTitle(row *database.MediaTitle) (databas
 }
 
 // Media CRUD methods
-func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) { //nolint:gocritic
+//
+//nolint:gocritic // matches MediaDBI value-parameter signature
+func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) {
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
 		if err := args.Error(1); err != nil {
@@ -1005,7 +1007,8 @@ func (m *MockMediaDBI) FindMedia(row database.Media) (database.Media, error) { /
 	return database.Media{}, nil
 }
 
-func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
+//nolint:gocritic // matches MediaDBI value-parameter signature
+func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) {
 	m.trackDatabaseOperation() // Track if called outside transaction
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
@@ -1020,7 +1023,8 @@ func (m *MockMediaDBI) InsertMedia(row database.Media) (database.Media, error) {
 	return database.Media{}, nil
 }
 
-func (m *MockMediaDBI) FindOrInsertMedia(row database.Media) (database.Media, error) { //nolint:gocritic
+//nolint:gocritic // matches MediaDBI value-parameter signature
+func (m *MockMediaDBI) FindOrInsertMedia(row database.Media) (database.Media, error) {
 	args := m.Called(row)
 	if media, ok := args.Get(0).(database.Media); ok {
 		if err := args.Error(1); err != nil {


### PR DESCRIPTION
## Summary

### Batch singleton-container directory annotation (30s → sub-second)

The dominant cost for PSX/disc-folder libraries was the singleton-container collapse feature (v2.14.0): for each directory entry the handler fired ~5 serialised DB queries including a heavy 4-CTE zapscript disambiguation query. With 411 PSX game folders this produced ~2000 queries on a single SQLite connection over an SD card, causing ~30s first-page load.

Replaced with `ResolveSingletonContainerAliases` — a single MediaDBI call that handles an entire parent directory in 4 queries regardless of how many subdirs it contains:
1. One scan of all media under the parent for the system
2. In-memory grouping + container selection (same `selectContainerLaunchMedia` logic)
3. `GetMediaWithTitleAndSystemByIDs` batch
4. `GetMediaTagsByMediaDBIDs` batch

ZapScript disambiguation uses the same in-memory `computeZapScriptTags` path as search and file-browse.

The system for resolution is taken from the explicit `systems` filter if provided, otherwise inferred from `BrowseDirectoryResult.SystemIDs` — so the collapse works for any client browsing by path without a filter.

**Verified on device (MiSTer, PSX, per-game CHD subfolders):**
- 77-dir page: 67ms total (72 annotated, 5 multi-disc plain — correct)
- 89-dir page: 69ms total (81 annotated, 8 multi-disc plain — correct)
- bin/cue containers resolve to the `.cue` file as expected
- Multi-disc games remain as browseable folders (not collapsed)

**Net change:** N-dir × 5 queries → 4 queries flat.

### `Media.SortName` denormalization (515ms/page → tens of ms for file-browse)

- Adds `Media.SortName` column — a write-once copy of `MediaTitles.Name` written at index time — so browse queries drop the per-row `MediaTitles` JOIN entirely
- Adds keyset index `idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID)` so name-sort browse uses an index scan instead of a filesort
- Fixes persistent re-scan upgrade path: `MediaNeedsSortName` in `ScanState` tracks rows where `SortName=''` and forces a `UpdateMediaTitle` write even when the title DBID is unchanged

Migration adds the column and index only — no backfill. Users must reindex after upgrading to populate `SortName`. Until reindexed, name-sort browse falls back to insertion order (degraded, not broken).

**Root cause of 515ms/page on MiSTer Arcade:** ~826 random `MediaTitles` PK reads (one per row just for `Name`) plus `USE TEMP B-TREE FOR ORDER BY` (filesort because sort key was in the joined table). After this change: index-ordered scan, no JOIN, no filesort.

### Other fixes

- Fixes `fetchAndAttachCoverFlags` to use a `TagTypes` JOIN for the property type filter (was matching wrong column)
- Adds `UtilityTags` and `fetchAndAttachUtilityTags` to avoid fetching all tags on every browse page
- Fixes `fetchAndAttachUtilityTags` to propagate real DB errors instead of swallowing them
- `hasCover` is always emitted in browse responses (was `omitempty`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent on-disk thumbnail cache for resized media (with startup init and cache wipe support)
  * Browse entries now indicate cover availability and better surface single-file container directories as launchable targets
  * Browse grid shows utility tags (e.g. favorites)

* **Bug Fixes**
  * Empty tag and image-type lists now serialize as [] instead of null

* **Chores**
  * Database: added sort-name support, migration and index for improved browse sorting/performance
  * .gitignore updated to exclude extra top-level files

* **Tests**
  * Expanded unit and integration tests for browse, cover detection, aliasing and sorting behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->