### PR TITLE
fix(media): resume interrupted force scrapes

### DIFF
--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -53,6 +53,8 @@ For each system, the normal loop:
 
 The sentinel tag format is `scraper.<id>:scraped`, for example `scraper.gamelist.xml:scraped`. Writing it last is intentional: if a normal record write fails, the transaction rolls back and the missing sentinel leaves that media row eligible for retry.
 
+Force scrapes also persist a run ID and write `scraper-run.<id>:<run-id>` to each media row completed in that operation. If Core restarts mid-force-scrape, resume reuses that run ID and skips rows already marked for the same run while still refreshing older rows that only had the normal sentinel. Run markers are removed when the operation reaches a terminal state.
+
 Per-record write failures are non-fatal: they increment `Skipped`, emit `Err`, and continue. Fatal setup/load/database errors end the run with a terminal update unless caused by context cancellation.
 
 ## Tags And Properties

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
@@ -440,11 +441,15 @@ func ResumeMediaScrape(env *requests.RequestEnv, operation database.ScrapingOper
 		Systems:   operation.Systems,
 		Force:     operation.Force,
 	}
-	_, err := startMediaScrape(env, params)
+	_, err := startMediaScrapeWithRunID(env, params, operation.RunID)
 	return err
 }
 
 func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams) (any, error) {
+	return startMediaScrapeWithRunID(env, params, "")
+}
+
+func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScrapeParams, runID string) (any, error) {
 	platformScrapers := env.Platform.Scrapers(env.Config)
 	s, ok := platformScrapers[params.ScraperID]
 	if !ok {
@@ -458,9 +463,13 @@ func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams)
 		return nil, err
 	}
 
+	if params.Force && runID == "" {
+		runID = uuid.NewString()
+	}
 	operation := database.ScrapingOperation{
 		ScraperID: params.ScraperID,
 		Systems:   params.Systems,
+		RunID:     runID,
 		Force:     params.Force,
 	}
 	if err := env.Database.MediaDB.SetScrapingOperation(operation); err != nil {
@@ -477,7 +486,7 @@ func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams)
 	scrapingStatusInstance.setCancelFunc(cancelFunc)
 
 	paused := env.ScrapePauser != nil && env.ScrapePauser.IsPaused()
-	opts := scraper.ScrapeOptions{Systems: params.Systems, Force: params.Force, Pauser: env.ScrapePauser}
+	opts := scraper.ScrapeOptions{Systems: params.Systems, RunID: runID, Force: params.Force, Pauser: env.ScrapePauser}
 	ch := make(chan scraper.ScrapeUpdate, 32)
 	if err := s.Scrape(scrapeCtx, env.Config, env.Platform, afero.NewOsFs(), env.Database, opts, nil, ch); err != nil {
 		cancelFunc()
@@ -557,6 +566,14 @@ func startMediaScrape(env *requests.RequestEnv, params models.MediaScrapeParams)
 		}
 		if err := db.MediaDB.SetScrapingStatus(finalStatus); err != nil {
 			log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to persist scraping terminal status")
+		}
+		if params.Force && runID != "" {
+			if err := db.MediaDB.ClearScrapeRunMarkers(env.State.GetContext(), scraperID, runID); err != nil {
+				log.Warn().Err(err).
+					Str("scraper", scraperID).
+					Str("runID", runID).
+					Msg("failed to clear scrape run markers")
+			}
 		}
 		if finalStatus == mediadb.IndexingStatusCompleted || finalStatus == mediadb.IndexingStatusCancelled {
 			if err := db.MediaDB.ClearScrapingOperation(); err != nil {

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -1010,11 +1010,24 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 	statusInstance.clear()
 
 	mockDB := testhelpers.NewMockMediaDBI()
+	var persistedRunID string
+	mockDB.On("SetScrapingOperation", assertmock.MatchedBy(func(operation database.ScrapingOperation) bool {
+		persistedRunID = operation.RunID
+		return operation.ScraperID == "progress-scraper" && operation.Force && operation.RunID != ""
+	})).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	runIDMatcher := assertmock.MatchedBy(func(runID string) bool {
+		return runID != "" && runID == persistedRunID
+	})
+	mockDB.On("ClearScrapeRunMarkers", assertmock.Anything, "progress-scraper", runIDMatcher).
+		Return(nil).Once()
 	mockDB.On("TrackBackgroundOperation").Return()
 	mockDB.On("BackgroundOperationDone").Return()
 	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "progress-scraper").Return(3, nil)
 
 	var gotForceOption bool
+	var gotRunID string
 	progressScraper := platforms.Scraper{
 		ID:   "progress-scraper",
 		Name: "Progress Scraper",
@@ -1024,6 +1037,7 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
 		) error {
 			gotForceOption = opts.Force
+			gotRunID = opts.RunID
 			go func() {
 				defer close(ch)
 				ch <- scraper.ScrapeUpdate{
@@ -1098,6 +1112,8 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 	}
 
 	assert.True(t, gotForceOption, "force option should be passed to scraper")
+	assert.Equal(t, persistedRunID, gotRunID, "generated run ID should be passed to scraper")
+	assert.NotEmpty(t, gotRunID, "force scrape should get a resumable run ID")
 	assert.True(t, sawForce, "scrape status should expose active force scrape")
 	assert.Equal(t, 10, maxProcessed, "progress updates should reflect actual processed count")
 	assert.True(t, sawCurrentSystem, "progress updates should expose currentSystem and step fields")

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -583,11 +583,17 @@ func TestResumeMediaScrape_RestoresStoredOptions(t *testing.T) {
 	ClearScrapingStatus()
 	statusInstance.clear()
 
-	operation := database.ScrapingOperation{ScraperID: "resume-scraper", Systems: []string{"SNES"}, Force: true}
+	operation := database.ScrapingOperation{
+		ScraperID: "resume-scraper",
+		Systems:   []string{"SNES"},
+		RunID:     "resume-run",
+		Force:     true,
+	}
 	mockDB := testhelpers.NewMockMediaDBI()
 	mockDB.On("SetScrapingOperation", operation).Return(nil).Once()
 	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
 	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	mockDB.On("ClearScrapeRunMarkers", assertmock.Anything, "resume-scraper", "resume-run").Return(nil).Once()
 	mockDB.On("TrackBackgroundOperation").Return().Once()
 	mockDB.On("BackgroundOperationDone").Return().Once()
 	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "resume-scraper").Return(0, nil)
@@ -618,6 +624,7 @@ func TestResumeMediaScrape_RestoresStoredOptions(t *testing.T) {
 
 	require.NoError(t, ResumeMediaScrape(&env, operation))
 	assert.Equal(t, []string{"SNES"}, gotOptions.Systems)
+	assert.Equal(t, "resume-run", gotOptions.RunID)
 	assert.True(t, gotOptions.Force)
 	require.Eventually(t, func() bool {
 		return !IsScrapingRunning()

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -42,6 +42,7 @@ type Database struct {
 
 type ScrapingOperation struct {
 	ScraperID string   `json:"scraperId"`
+	RunID     string   `json:"runId,omitempty"`
 	Systems   []string `json:"systems"`
 	Force     bool     `json:"force"`
 }
@@ -792,6 +793,14 @@ type MediaDBI interface {
 	// GetScrapedMediaIDs returns media DBIDs in a system already marked as scraped
 	// by scraperID.
 	GetScrapedMediaIDs(ctx context.Context, scraperID string, systemDBID int64) (map[int64]struct{}, error)
+
+	// GetScrapeRunMediaIDs returns media DBIDs in a system completed during a
+	// specific scraper run.
+	GetScrapeRunMediaIDs(ctx context.Context, scraperID, runID string, systemDBID int64) (map[int64]struct{}, error)
+
+	// ClearScrapeRunMarkers removes per-run completion markers after a scraper
+	// operation reaches a terminal state.
+	ClearScrapeRunMarkers(ctx context.Context, scraperID, runID string) error
 
 	// UpsertMediaTags writes tags to MediaTags for a specific Media row.
 	// Exclusive types (TagTypes.IsExclusive=1) delete existing tags of that type

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -484,6 +484,56 @@ func (db *MediaDB) GetScrapedMediaIDs(
 	if err != nil {
 		return nil, fmt.Errorf("failed to find scraper sentinel tag for scraper %q: %w", scraperID, err)
 	}
+	mediaIDs, err := getMediaIDsForTagDBIDs(ctx, db.sql, systemDBID, tagDBIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query scraped media IDs for scraper %q: %w", scraperID, err)
+	}
+	return mediaIDs, nil
+}
+
+// GetScrapeRunMediaIDs returns media DBIDs in systemDBID completed during a
+// specific persisted scraper run.
+func (db *MediaDB) GetScrapeRunMediaIDs(
+	ctx context.Context, scraperID, runID string, systemDBID int64,
+) (map[int64]struct{}, error) {
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+	if runID == "" {
+		return map[int64]struct{}{}, nil
+	}
+
+	tagDBIDs, err := findScraperSentinelTagDBIDs(ctx, db.sql, string(tags.ScraperRunType(scraperID)), runID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find scraper run tag for scraper %q run %q: %w", scraperID, runID, err)
+	}
+	mediaIDs, err := getMediaIDsForTagDBIDs(ctx, db.sql, systemDBID, tagDBIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query scrape run media IDs for scraper %q run %q: %w", scraperID, runID, err)
+	}
+	return mediaIDs, nil
+}
+
+// ClearScrapeRunMarkers removes per-run completion markers after a scraper
+// operation reaches a terminal state.
+func (db *MediaDB) ClearScrapeRunMarkers(ctx context.Context, scraperID, runID string) error {
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	if runID == "" {
+		return nil
+	}
+
+	tagDBIDs, err := findScraperSentinelTagDBIDs(ctx, db.sql, string(tags.ScraperRunType(scraperID)), runID)
+	if err != nil {
+		return fmt.Errorf("failed to find scraper run tag for scraper %q run %q: %w", scraperID, runID, err)
+	}
+	return clearMediaTagsForTagDBIDs(ctx, db.sql, tagDBIDs)
+}
+
+func getMediaIDsForTagDBIDs(
+	ctx context.Context, db *sql.DB, systemDBID int64, tagDBIDs []int64,
+) (map[int64]struct{}, error) {
 	if len(tagDBIDs) == 0 {
 		return map[int64]struct{}{}, nil
 	}
@@ -506,9 +556,9 @@ func (db *MediaDB) GetScrapedMediaIDs(
 		WHERE m.SystemDBID = ?
 		  AND mt.MediaDBID = m.DBID
 		  AND mt.TagDBID IN (` + placeholders + `)`
-	rows, err := db.sql.QueryContext(ctx, query, args...)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query scraped media IDs for scraper %q: %w", scraperID, err)
+		return nil, fmt.Errorf("failed to query media IDs for tag DBIDs: %w", err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
@@ -520,14 +570,40 @@ func (db *MediaDB) GetScrapedMediaIDs(
 	for rows.Next() {
 		var mediaDBID int64
 		if err := rows.Scan(&mediaDBID); err != nil {
-			return nil, fmt.Errorf("failed to scan scraped media ID: %w", err)
+			return nil, fmt.Errorf("failed to scan tagged media ID: %w", err)
 		}
 		mediaIDs[mediaDBID] = struct{}{}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate scraped media IDs: %w", err)
+		return nil, fmt.Errorf("failed to iterate tagged media IDs: %w", err)
 	}
 	return mediaIDs, nil
+}
+
+func clearMediaTagsForTagDBIDs(ctx context.Context, db *sql.DB, tagDBIDs []int64) error {
+	if len(tagDBIDs) == 0 {
+		return nil
+	}
+
+	placeholders := prepareVariadic("?", ",", len(tagDBIDs))
+	args := make([]any, 0, len(tagDBIDs))
+	for _, tagDBID := range tagDBIDs {
+		args = append(args, tagDBID)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	if _, err := db.ExecContext(ctx, `DELETE FROM MediaTags WHERE TagDBID IN (`+placeholders+`)`, args...); err != nil {
+		return fmt.Errorf("failed to delete media tag links: %w", err)
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	if _, err := db.ExecContext(ctx, `
+		DELETE FROM Tags
+		WHERE DBID IN (`+placeholders+`)
+		  AND NOT EXISTS (SELECT 1 FROM MediaTags WHERE MediaTags.TagDBID = Tags.DBID)
+	`, args...); err != nil {
+		return fmt.Errorf("failed to delete unreferenced tags: %w", err)
+	}
+	return nil
 }
 
 func findScraperSentinelTagDBIDs(ctx context.Context, db *sql.DB, scraperType, tagValue string) ([]int64, error) {

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -755,6 +755,37 @@ func TestGetScrapeRunMediaIDs(t *testing.T) {
 	ids, err = mediaDB.GetScrapeRunMediaIDs(ctx, "test", "run-1", 1)
 	require.NoError(t, err)
 	assert.Empty(t, ids)
+
+	var remainingRunTags int
+	err = mediaDB.sql.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM Tags t
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		WHERE tt.Type = 'scraper-run.test'
+	`).Scan(&remainingRunTags)
+	require.NoError(t, err)
+	assert.Equal(t, 1, remainingRunTags, "only the unrelated run marker should remain")
+}
+
+func TestScrapeRunMarkers_EmptyRunIDIsNoop(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ids, err := mediaDB.GetScrapeRunMediaIDs(ctx, "test", "", 1)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+	require.NoError(t, mediaDB.ClearScrapeRunMarkers(ctx, "test", ""))
+}
+
+func TestClearScrapeRunMarkers_MissingRunIsNoop(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, mediaDB.ClearScrapeRunMarkers(ctx, "test", "missing-run"))
 }
 
 func TestApplyScrapeResult_WritesSentinelLastPayload(t *testing.T) {

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -725,6 +725,38 @@ func TestGetScrapedMediaIDs_MissingSentinelReturnsEmptySet(t *testing.T) {
 	assert.Empty(t, ids)
 }
 
+func TestGetScrapeRunMediaIDs(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath2 := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, mediaPath2)
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, []database.TagInfo{{
+		Type: string(tags.ScraperRunType("test")),
+		Tag:  "run-1",
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 2, []database.TagInfo{{
+		Type: string(tags.ScraperRunType("test")),
+		Tag:  "run-2",
+	}}))
+
+	ids, err := mediaDB.GetScrapeRunMediaIDs(ctx, "test", "run-1", 1)
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]struct{}{1: {}}, ids)
+
+	require.NoError(t, mediaDB.ClearScrapeRunMarkers(ctx, "test", "run-1"))
+	ids, err = mediaDB.GetScrapeRunMediaIDs(ctx, "test", "run-1", 1)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestApplyScrapeResult_WritesSentinelLastPayload(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupScraperTestDB(t)

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -543,6 +543,17 @@ const (
 	companionWriteBatchSize = 10
 )
 
+func shouldUseRunMarker(opts scraper.ScrapeOptions) bool {
+	return opts.Force && opts.RunID != ""
+}
+
+func appendRunMarker(scraperID string, opts scraper.ScrapeOptions, write *database.ScrapeWrite) {
+	if !shouldUseRunMarker(opts) || write == nil {
+		return
+	}
+	write.MediaTags = append(write.MediaTags, scraper.RunTagInfo(scraperID, opts.RunID))
+}
+
 // scrapeLoop runs the full load→match→write cycle for all systems, emitting
 // progress updates on ch. It closes ch when done.
 func (g *GamelistXMLScraper) scrapeLoop(
@@ -657,7 +668,20 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			return
 		}
 		scrapedIDs := map[int64]struct{}{}
-		if !opts.Force {
+		if opts.Force {
+			if shouldUseRunMarker(opts) {
+				var scrapeRunErr error
+				scrapedIDs, scrapeRunErr = mdb.GetScrapeRunMediaIDs(ctx, id, opts.RunID, system.DBID)
+				if scrapeRunErr != nil {
+					if errors.Is(scrapeRunErr, context.Canceled) || errors.Is(scrapeRunErr, context.DeadlineExceeded) {
+						sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
+						return
+					}
+					sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, FatalErr: scrapeRunErr, Done: true})
+					return
+				}
+			}
+		} else {
 			var scrapedErr error
 			scrapedIDs, scrapedErr = mdb.GetScrapedMediaIDs(ctx, id, system.DBID)
 			if scrapedErr != nil {
@@ -868,16 +892,18 @@ func (g *GamelistXMLScraper) scrapeLoop(
 				return
 			}
 
+			write := &database.ScrapeWrite{
+				Sentinel:   scraper.SentinelTagInfo(id),
+				MediaTags:  mapped.MediaTags,
+				MediaProps: mapped.MediaProps,
+				TitleTags:  mapped.TitleTags,
+				TitleProps: mapped.TitleProps,
+			}
+			appendRunMarker(id, opts, write)
 			writeTarget := database.ScrapeWriteTarget{
 				MediaDBID:      record.MatchedMediaDBID,
 				MediaTitleDBID: record.MatchedTitleDBID,
-				Write: &database.ScrapeWrite{
-					Sentinel:   scraper.SentinelTagInfo(id),
-					MediaTags:  mapped.MediaTags,
-					MediaProps: mapped.MediaProps,
-					TitleTags:  mapped.TitleTags,
-					TitleProps: mapped.TitleProps,
-				},
+				Write:          write,
 			}
 			writeStart := time.Now()
 			writeErr := mdb.ApplyScrapeResult(ctx, writeTarget.MediaDBID, writeTarget.MediaTitleDBID, writeTarget.Write)
@@ -1979,6 +2005,7 @@ func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
 			if matched.MediaLevelWriteSafe {
 				write.MediaTags = companionChildTags(c)
 			}
+			appendRunMarker("gamelist.xml", opts, write)
 			titlePayloadKey := companionTitlePayloadKey(write)
 			if existingKey, ok := titlePayloadByTitleDBID[media.MediaTitleDBID]; !ok {
 				titlePayloadByTitleDBID[media.MediaTitleDBID] = titlePayloadKey

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -2447,15 +2447,22 @@ func TestProcessCompanionEntries_ForceRewritesAlreadyScraped(t *testing.T) {
 	root := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(companionXML), 0o600))
 
+	const runID = "companion-run"
 	resolvedPath := filepath.ToSlash(filepath.Join(root, "child.rom"))
+	runMarkerMatcher := mock.MatchedBy(func(w *database.ScrapeWrite) bool {
+		return w != nil && assert.Contains(t, w.MediaTags, database.TagInfo{
+			Type: string(tags.ScraperRunType("gamelist.xml")),
+			Tag:  runID,
+		})
+	})
 	mockDB := helpers.NewMockMediaDBI()
-	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), mock.Anything).Return(nil)
+	mockDB.On("ApplyScrapeResult", mock.Anything, int64(10), int64(20), runMarkerMatcher).Return(nil)
 
 	s := &GamelistXMLScraper{db: mockDB}
 	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: 1}
 	indexes := mediaByPath(database.Media{DBID: 10, MediaTitleDBID: 20, Path: resolvedPath})
 	stats := s.processCompanionEntries(
-		context.Background(), scraper.ScrapeOptions{Force: true}, system, mockDB, indexes, nil,
+		context.Background(), scraper.ScrapeOptions{RunID: runID, Force: true}, system, mockDB, indexes, nil,
 	)
 	assertCompanionCounts(t, &stats, 1, 1, 0)
 	mockDB.AssertExpectations(t)

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -3167,6 +3167,69 @@ func TestScrapeLoop_NormalMode_Success(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestScrapeLoop_ForceResumeSkipsCompletedRunMedia(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first.nes")
+	secondPath := filepath.Join(root, "second.nes")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`
+<gameList>
+  <game><path>./first.nes</path><name>First</name></game>
+  <game><path>./second.nes</path><name>Second</name></game>
+</gameList>`), 0o600))
+
+	const (
+		firstTitleDBID  = int64(1)
+		firstMediaDBID  = int64(10)
+		secondTitleDBID = int64(2)
+		secondMediaDBID = int64(20)
+		systemDBID      = int64(100)
+		runID           = "resume-run"
+	)
+
+	writeMatcher := mock.MatchedBy(func(w *database.ScrapeWrite) bool {
+		return w != nil && assert.Contains(t, w.MediaTags, database.TagInfo{
+			Type: string(tags.ScraperRunType("gamelist.xml")),
+			Tag:  runID,
+		})
+	})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetTitlesBySystemID", "nes").Return([]database.TitleWithSystem{
+		{DBID: firstTitleDBID, SystemDBID: systemDBID, Slug: "first", Name: "First"},
+		{DBID: secondTitleDBID, SystemDBID: systemDBID, Slug: "second", Name: "Second"},
+	}, nil)
+	mockDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{
+		{DBID: firstMediaDBID, MediaTitleDBID: firstTitleDBID, Path: firstPath},
+		{DBID: secondMediaDBID, MediaTitleDBID: secondTitleDBID, Path: secondPath},
+	}, nil)
+	mockDB.On("GetScrapeRunMediaIDs", mock.Anything, "gamelist.xml", runID, systemDBID).
+		Return(map[int64]struct{}{firstMediaDBID: {}}, nil)
+	mockDB.On("ApplyScrapeResult", mock.Anything, secondMediaDBID, secondTitleDBID, writeMatcher).Return(nil)
+
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "nes", ROMPaths: []string{root}, DBID: systemDBID}
+	ch := make(chan scraper.ScrapeUpdate, 128)
+
+	s.scrapeLoop(context.Background(), scraper.ScrapeOptions{
+		Pauser: syncutil.NewPauser(),
+		RunID:  runID,
+		Force:  true,
+	}, []scraper.ScrapeSystem{system}, mockDB, ch)
+
+	updates := drainChannel(ch)
+	var done scraper.ScrapeUpdate
+	for _, u := range updates {
+		if u.Done {
+			done = u
+		}
+	}
+	require.True(t, done.Done)
+	assert.Equal(t, 1, done.Processed)
+	assert.Equal(t, 1, done.Matched)
+	assert.Equal(t, 0, done.Skipped)
+	mockDB.AssertExpectations(t)
+}
+
 func TestScrapeLoop_Issue794ZipAsDirMedia(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/pkg/database/scraper/run.go
+++ b/pkg/database/scraper/run.go
@@ -33,6 +33,15 @@ func SentinelTagInfo(scraperID string) database.TagInfo {
 	}
 }
 
+// RunTagInfo returns the per-run marker written to media rows completed during
+// a persisted scraper operation.
+func RunTagInfo(scraperID, runID string) database.TagInfo {
+	return database.TagInfo{
+		Type: string(tags.ScraperRunType(scraperID)),
+		Tag:  runID,
+	}
+}
+
 // RunScraper creates a ScrapeUpdate channel, calls fn (which must start its own
 // goroutine and close the channel when done), and returns the read end.
 // If fn returns an error synchronously, a terminal FatalErr update is emitted

--- a/pkg/database/scraper/run_test.go
+++ b/pkg/database/scraper/run_test.go
@@ -70,3 +70,9 @@ func TestSentinelTagInfo(t *testing.T) {
 	tag := scraper.SentinelTagInfo("myscr")
 	assert.Equal(t, database.TagInfo{Type: "scraper.myscr", Tag: "scraped"}, tag)
 }
+
+func TestRunTagInfo(t *testing.T) {
+	t.Parallel()
+	tag := scraper.RunTagInfo("myscr", "run-123")
+	assert.Equal(t, database.TagInfo{Type: "scraper-run.myscr", Tag: "run-123"}, tag)
+}

--- a/pkg/database/scraper/scraper.go
+++ b/pkg/database/scraper/scraper.go
@@ -45,6 +45,9 @@ type ScrapeOptions struct {
 	// Pauser pauses scrape work while another foreground activity needs the system.
 	Pauser *syncutil.Pauser
 
+	// RunID identifies a persisted scraper operation across restarts.
+	RunID string
+
 	// Systems limits scraping to these system IDs. Nil or empty means all systems.
 	Systems []string
 

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -76,6 +76,17 @@ func ScraperTypeTag(scraperID string) string {
 	return CanonicalTag{Type: ScraperType(scraperID), Value: TagScraperScraped}.String()
 }
 
+// ScraperRunType returns the dynamic tag type used to mark media completed
+// during one persisted scraper run.
+func ScraperRunType(scraperID string) TagType {
+	return TagType("scraper-run." + scraperID)
+}
+
+// ScraperRunTypeTag returns the full run marker TypeTag string for a scraper run.
+func ScraperRunTypeTag(scraperID, runID string) string {
+	return CanonicalTag{Type: ScraperRunType(scraperID), Value: TagValue(runID)}.String()
+}
+
 // Tag type constants - these define the top-level categories for our hierarchical tag system
 // Format: Type defines the category, tags within each type use colon-separated hierarchies
 const (

--- a/pkg/database/tags/tags_test.go
+++ b/pkg/database/tags/tags_test.go
@@ -115,6 +115,15 @@ func TestTagTypeNaming(t *testing.T) {
 	}
 }
 
+func TestScraperTagHelpers(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, TagType("scraper.gamelist.xml"), ScraperType("gamelist.xml"))
+	assert.Equal(t, "scraper.gamelist.xml:scraped", ScraperTypeTag("gamelist.xml"))
+	assert.Equal(t, TagType("scraper-run.gamelist.xml"), ScraperRunType("gamelist.xml"))
+	assert.Equal(t, "scraper-run.gamelist.xml:run-123", ScraperRunTypeTag("gamelist.xml", "run-123"))
+}
+
 func TestIsUserOwnedType(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2431,6 +2431,27 @@ func (m *MockMediaDBI) GetScrapedMediaIDs(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) GetScrapeRunMediaIDs(
+	ctx context.Context, scraperID, runID string, systemDBID int64,
+) (map[int64]struct{}, error) {
+	args := m.Called(ctx, scraperID, runID, systemDBID)
+	if result, ok := args.Get(0).(map[int64]struct{}); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
+func (m *MockMediaDBI) ClearScrapeRunMarkers(ctx context.Context, scraperID, runID string) error {
+	if !m.hasExpectation("ClearScrapeRunMarkers") {
+		return nil
+	}
+	args := m.Called(ctx, scraperID, runID)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) UpsertMediaTags(ctx context.Context, mediaDBID int64, tags []database.TagInfo) error {
 	args := m.Called(ctx, mediaDBID, tags)
 	if err := args.Error(0); err != nil {


### PR DESCRIPTION
## Summary
- persist run IDs for force scrape operations and reuse them on resume
- mark media completed during a force scrape run so resumed runs skip completed work
- clear run markers on terminal scrape states

Closes #926

Checked: `task lint-fix`; `go test ./pkg/api/methods/ ./pkg/database/mediadb/ ./pkg/database/scraper/gamelistxml/ ./pkg/service/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added run ID tracking for forced scrapes so resume operations skip items already marked for that run and clear run markers when complete.

* **Documentation**
  * Documented force-scrape run ID behavior and resume/marker lifecycle.

* **Refactor**
  * Centralized scraped-media lookup and introduced helpers for per-run marker handling.

* **Tests**
  * Added unit and DB tests covering run ID persistence, resume skips, clearing markers, and tag helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->