### PR TITLE
fix(database): preserve media set markers in display names

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -758,13 +758,14 @@ func buildBrowseResponse(
 			result := database.SearchResultWithCursor{
 				MediaID:       alias.Row.DBID,
 				SystemID:      alias.Row.System.SystemID,
-				Name:          alias.Row.Title.Name,
+				Name:          browseMediaDisplayName(alias.Row.Path, alias.Row.SortName, alias.Row.Title.Name),
 				Path:          alias.Row.Path,
 				Tags:          alias.Tags,
 				ZapScriptTags: alias.ZapScriptTags,
 				HasCover:      alias.HasCover,
 			}
 			mediaEntry := buildMediaEntry(&result, env, rootDirs)
+			entry.Name = mediaEntry.Name
 			entry.MediaID = mediaEntry.MediaID
 			entry.SystemID = mediaEntry.SystemID
 			entry.RelPath = mediaEntry.RelPath
@@ -817,6 +818,24 @@ func buildBrowseResponse(
 		Pagination: pagination,
 		TotalFiles: totalFiles,
 	}, nil
+}
+
+func browseMediaDisplayName(path, sortName, titleName string) string {
+	if sortName != "" {
+		return sortName
+	}
+
+	base := filepath.Base(path)
+	if base != "." && base != string(filepath.Separator) {
+		if ext := filepath.Ext(base); ext != "" {
+			base = base[:len(base)-len(ext)]
+		}
+		if base != "" {
+			return base
+		}
+	}
+
+	return titleName
 }
 
 // buildMediaEntry converts a SearchResultWithCursor into a BrowseEntry of type "media".

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -491,6 +491,62 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestBuildBrowseResponse_SingletonAnnotation_UsesMediaSortName(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 1, SystemID: "PSX"}
+	systems := []systemdefs.System{{ID: "PSX"}}
+	path := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	dirName := "D (USA)"
+	dirPath := filepath.ToSlash(filepath.Join(path, dirName))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      filepath.ToSlash(filepath.Join(dirPath, "D (USA) (Disc 1).chd")),
+			ParentDir: dirPath + "/",
+			SortName:  "D (Disc 1)",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "D"},
+		System: psxSystem,
+	}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+	}}
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+		Return(alias, nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"PSX"}}},
+		nil, defaultMaxResults, 0, "", systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "directory", entry.Type)
+	assert.Equal(t, "D (Disc 1)", entry.Name)
+	assert.Equal(t, dirPath, entry.Path)
+	assert.Equal(t, row.DBID, entry.MediaID)
+	require.NotNil(t, entry.SystemID)
+	assert.Equal(t, "PSX", *entry.SystemID)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -491,60 +491,97 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	mockPlatform.AssertExpectations(t)
 }
 
-func TestBuildBrowseResponse_SingletonAnnotation_UsesMediaSortName(t *testing.T) {
+func TestBuildBrowseResponse_SingletonAnnotation_UsesMediaDisplayNameFallbacks(t *testing.T) {
 	t.Parallel()
 
 	psxSystem := database.System{DBID: 1, SystemID: "PSX"}
 	systems := []systemdefs.System{{ID: "PSX"}}
 	path := filepath.ToSlash(filepath.Join("roms", "PSX"))
-	dirName := "D (USA)"
-	dirPath := filepath.ToSlash(filepath.Join(path, dirName))
-	row := database.MediaFullRow{
-		Media: database.Media{
-			DBID:      20,
-			Path:      filepath.ToSlash(filepath.Join(dirPath, "D (USA) (Disc 1).chd")),
-			ParentDir: dirPath + "/",
-			SortName:  "D (Disc 1)",
+
+	tests := []struct {
+		name      string
+		dirName   string
+		mediaPath string
+		sortName  string
+		titleName string
+		wantName  string
+	}{
+		{
+			name:      "sort name",
+			dirName:   "D (USA)",
+			mediaPath: filepath.ToSlash(filepath.Join("roms", "PSX", "D (USA)", "D (USA) (Disc 1).chd")),
+			sortName:  "D (Disc 1)",
+			titleName: "D",
+			wantName:  "D (Disc 1)",
 		},
-		Title:  database.MediaTitle{DBID: 30, Name: "D"},
-		System: psxSystem,
+		{
+			name:      "path basename",
+			dirName:   "D (USA)",
+			mediaPath: filepath.ToSlash(filepath.Join("roms", "PSX", "D (USA)", "D (USA) (Disc 2).chd")),
+			titleName: "D",
+			wantName:  "D (USA) (Disc 2)",
+		},
+		{
+			name:      "title name",
+			dirName:   "No Path",
+			titleName: "Title Fallback",
+			wantName:  "Title Fallback",
+		},
 	}
-	alias := []database.SingletonContainerAlias{{
-		ChildDir:      dirPath + "/",
-		Row:           row,
-		Tags:          []database.TagInfo{},
-		ZapScriptTags: []database.TagInfo{},
-	}}
 
-	mockMediaDB := helpers.NewMockMediaDBI()
-	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
-	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
-		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
-		Return(alias, nil).Once()
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	env := &requests.RequestEnv{
-		Context:  context.Background(),
-		Database: &database.Database{MediaDB: mockMediaDB},
-		Platform: mockPlatform,
+			dirPath := filepath.ToSlash(filepath.Join(path, tt.dirName))
+			row := database.MediaFullRow{
+				Media: database.Media{
+					DBID:      int64(20 + i),
+					Path:      tt.mediaPath,
+					ParentDir: dirPath + "/",
+					SortName:  tt.sortName,
+				},
+				Title:  database.MediaTitle{DBID: int64(30 + i), Name: tt.titleName},
+				System: psxSystem,
+			}
+			alias := []database.SingletonContainerAlias{{
+				ChildDir:      dirPath + "/",
+				Row:           row,
+				Tags:          []database.TagInfo{},
+				ZapScriptTags: []database.TagInfo{},
+			}}
+
+			mockMediaDB := helpers.NewMockMediaDBI()
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+			mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+			mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+				[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+				Return(alias, nil).Once()
+
+			env := &requests.RequestEnv{
+				Context:  context.Background(),
+				Database: &database.Database{MediaDB: mockMediaDB},
+				Platform: mockPlatform,
+			}
+			result, err := buildBrowseResponse(env, path,
+				[]database.BrowseDirectoryResult{{Name: tt.dirName, FileCount: 1, SystemIDs: []string{"PSX"}}},
+				nil, defaultMaxResults, 0, "", systems)
+			require.NoError(t, err)
+			browseResults, ok := result.(models.BrowseResults)
+			require.True(t, ok)
+			require.Len(t, browseResults.Entries, 1)
+			entry := browseResults.Entries[0]
+			assert.Equal(t, "directory", entry.Type)
+			assert.Equal(t, tt.wantName, entry.Name)
+			assert.Equal(t, dirPath, entry.Path)
+			assert.Equal(t, row.DBID, entry.MediaID)
+			require.NotNil(t, entry.SystemID)
+			assert.Equal(t, "PSX", *entry.SystemID)
+			mockMediaDB.AssertExpectations(t)
+			mockPlatform.AssertExpectations(t)
+		})
 	}
-	result, err := buildBrowseResponse(env, path,
-		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"PSX"}}},
-		nil, defaultMaxResults, 0, "", systems)
-	require.NoError(t, err)
-	browseResults, ok := result.(models.BrowseResults)
-	require.True(t, ok)
-	require.Len(t, browseResults.Entries, 1)
-	entry := browseResults.Entries[0]
-	assert.Equal(t, "directory", entry.Type)
-	assert.Equal(t, "D (Disc 1)", entry.Name)
-	assert.Equal(t, dirPath, entry.Path)
-	assert.Equal(t, row.DBID, entry.MediaID)
-	require.NotNil(t, entry.SystemID)
-	assert.Equal(t, "PSX", *entry.SystemID)
-	mockMediaDB.AssertExpectations(t)
-	mockPlatform.AssertExpectations(t)
 }
 
 func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *testing.T) {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -491,6 +491,7 @@ type ScanState struct {
 	MediaIDs           map[string]int
 	MediaTitleIDs      map[int]int      // Existing media DBID -> MediaTitleDBID for persistent reconciliation
 	MediaNeedsSortName map[int]struct{} // Media DBIDs with SortName='' needing a write on next title update
+	MediaSortNames     map[int]string   // Existing media DBID -> per-file display/sort title for persistent reconciliation
 	MediaParentDirs    map[int]string
 	MediaTagIDs        map[int]map[int]struct{}
 	TagTypeIDs         map[string]int

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -491,18 +491,19 @@ type ScanState struct {
 	MediaIDs           map[string]int
 	MediaTitleIDs      map[int]int      // Existing media DBID -> MediaTitleDBID for persistent reconciliation
 	MediaNeedsSortName map[int]struct{} // Media DBIDs with SortName='' needing a write on next title update
-	MediaSortNames     map[int]string   // Existing media DBID -> per-file display/sort title for persistent reconciliation
-	MediaParentDirs    map[int]string
-	MediaTagIDs        map[int]map[int]struct{}
-	TagTypeIDs         map[string]int
-	TagIDs             map[string]int
-	UserOwnedTagIDs    map[int]bool
-	MissingMedia       map[int]struct{} // DBIDs of media not yet re-found during scan
-	SystemsIndex       int
-	TitlesIndex        int
-	MediaIndex         int
-	TagTypesIndex      int
-	TagsIndex          int
+	// Existing media DBID -> per-file display/sort title for persistent reconciliation.
+	MediaSortNames  map[int]string
+	MediaParentDirs map[int]string
+	MediaTagIDs     map[int]map[int]struct{}
+	TagTypeIDs      map[string]int
+	TagIDs          map[string]int
+	UserOwnedTagIDs map[int]bool
+	MissingMedia    map[int]struct{} // DBIDs of media not yet re-found during scan
+	SystemsIndex    int
+	TitlesIndex     int
+	MediaIndex      int
+	TagTypesIndex   int
+	TagsIndex       int
 }
 
 // JournalMode represents SQLite journal mode

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -873,6 +873,7 @@ func (db *MediaDB) Close() error {
 	db.WaitForBackgroundOperations()
 
 	logSQLTraceSummary()
+	clearUtilityTagCacheFor(db.sql)
 
 	err := db.sql.Close()
 	if err != nil {

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -71,6 +71,7 @@ const (
 	IndexingStatusCompleted = "completed"
 	IndexingStatusFailed    = "failed"
 	IndexingStatusCancelled = "cancelled"
+	IndexingStatusCorrupt   = "corrupt"
 )
 
 // defaultSlugSearchLimit is the max results returned by slug-based search methods.
@@ -82,9 +83,11 @@ const maxSelectiveInvalidationSystems = 32
 
 const mediaStatsCacheWriteTimeout = 100 * time.Millisecond
 
-// getSqliteConnParams constructs the SQLite connection string.
+// getSqliteConnParams constructs the SQLite connection string. MediaDB stores
+// user-owned metadata as well as rebuildable index rows, so use synchronous=FULL
+// even in WAL mode; power loss during MiSTer indexing must not corrupt committed data.
 func getSqliteConnParams() string {
-	return "?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000" +
+	return "?_journal_mode=WAL&_synchronous=FULL&_busy_timeout=5000" +
 		"&_cache_size=-8192&_temp_store=FILE&_mmap_size=0" +
 		"&_page_size=8192&_foreign_keys=ON&_txlock=immediate"
 }

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -53,11 +53,12 @@ const (
 
 // utilityTagCache memoises resolved utility tag DBIDs per DB connection so
 // fetchAndAttachUtilityTags avoids 2 PK-lookup queries per browse page.
-// Keyed by the db pointer identity so test mocks with different addresses stay
-// isolated. Cleared by clearUtilityTagCache when utility tag DBIDs can change.
+// Keyed by the db handle itself so closed handles cannot be confused with later
+// handles that reuse the same pointer address. Cleared by clearUtilityTagCache
+// when utility tag DBIDs can change.
 var (
 	utilityTagCacheMu  syncutil.RWMutex
-	utilityTagCacheMap map[string]map[int64]database.TagInfo
+	utilityTagCacheMap map[sqlQueryable]map[int64]database.TagInfo
 )
 
 func clearUtilityTagCache() {
@@ -66,16 +67,30 @@ func clearUtilityTagCache() {
 	utilityTagCacheMap = nil
 }
 
+func clearUtilityTagCacheFor(db sqlQueryable) {
+	if db == nil {
+		return
+	}
+
+	utilityTagCacheMu.Lock()
+	defer utilityTagCacheMu.Unlock()
+	if utilityTagCacheMap == nil {
+		return
+	}
+	delete(utilityTagCacheMap, db)
+	if len(utilityTagCacheMap) == 0 {
+		utilityTagCacheMap = nil
+	}
+}
+
 // resolveUtilityTagDBIDs returns a map from DB tag DBID → TagInfo for each
-// entry in tags.UtilityTags. Results are memoised per db pointer so each
+// entry in tags.UtilityTags. Results are memoised per db handle so each
 // MediaDB instance (or test mock) has its own cache slot, and
 // clearUtilityTagCache clears all slots when utility tag DBIDs can change.
 func resolveUtilityTagDBIDs(ctx context.Context, db sqlQueryable) (map[int64]database.TagInfo, error) {
-	dbKey := fmt.Sprintf("%p", db)
-
 	utilityTagCacheMu.RLock()
 	if utilityTagCacheMap != nil {
-		if cached, ok := utilityTagCacheMap[dbKey]; ok {
+		if cached, ok := utilityTagCacheMap[db]; ok {
 			utilityTagCacheMu.RUnlock()
 			return cached, nil
 		}
@@ -109,9 +124,9 @@ func resolveUtilityTagDBIDs(ctx context.Context, db sqlQueryable) (map[int64]dat
 
 	utilityTagCacheMu.Lock()
 	if utilityTagCacheMap == nil {
-		utilityTagCacheMap = make(map[string]map[int64]database.TagInfo)
+		utilityTagCacheMap = make(map[sqlQueryable]map[int64]database.TagInfo)
 	}
-	utilityTagCacheMap[dbKey] = tagInfoByDBID
+	utilityTagCacheMap[db] = tagInfoByDBID
 	utilityTagCacheMu.Unlock()
 	return tagInfoByDBID, nil
 }
@@ -774,7 +789,7 @@ func fetchAndAttachCoverFlags(
 // intentionally excluded from browse — the grid only needs utility tags; the
 // detail pane fetches everything via media.meta.
 //
-// Utility tag DBID resolution is memoised in utilityTagCacheVal and only re-run
+// Utility tag DBID resolution is memoised in utilityTagCacheMap and only re-run
 // when clearUtilityTagCache is called after tag dictionary changes.
 //
 // Assumption: utility tags are media-level user tags — no title-level join is

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -2520,7 +2520,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 
 	stmt, err := db.sql.PrepareContext(ctx, `
 		SELECT
-			m.DBID, m.Path, m.ParentDir, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
+			m.DBID, m.Path, m.ParentDir, m.SortName, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
 			mt.DBID, mt.Slug, mt.SecondarySlug, mt.Name, mt.SlugLength, mt.SlugWordCount, mt.SystemDBID,
 			s.DBID, s.SystemID, s.Name
 		FROM Media m
@@ -2540,7 +2540,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 
 	var row database.MediaFullRow
 	err = stmt.QueryRowContext(ctx, mediaDBID).Scan(
-		&row.DBID, &row.Path, &row.ParentDir, &row.IsMissing,
+		&row.DBID, &row.Path, &row.ParentDir, &row.SortName, &row.IsMissing,
 		&row.MediaTitleDBID, &row.SystemDBID,
 		&row.Title.DBID, &row.Title.Slug, &row.Title.SecondarySlug, &row.Title.Name,
 		&row.Title.SlugLength, &row.Title.SlugWordCount, &row.Title.SystemDBID,
@@ -2570,7 +2570,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
 	rows, err := db.sql.QueryContext(ctx, `
 		SELECT
-			m.DBID, m.Path, m.ParentDir, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
+			m.DBID, m.Path, m.ParentDir, m.SortName, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
 			mt.DBID, mt.Slug, mt.SecondarySlug, mt.Name, mt.SlugLength, mt.SlugWordCount, mt.SystemDBID,
 			s.DBID, s.SystemID, s.Name
 		FROM Media m
@@ -2590,7 +2590,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 	for rows.Next() {
 		var row database.MediaFullRow
 		if err := rows.Scan(
-			&row.DBID, &row.Path, &row.ParentDir, &row.IsMissing,
+			&row.DBID, &row.Path, &row.ParentDir, &row.SortName, &row.IsMissing,
 			&row.MediaTitleDBID, &row.SystemDBID,
 			&row.Title.DBID, &row.Title.Slug, &row.Title.SecondarySlug, &row.Title.Name,
 			&row.Title.SlugLength, &row.Title.SlugWordCount, &row.Title.SystemDBID,

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2158,7 +2158,9 @@ func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
 	gamePath := filepath.ToSlash(filepath.Join(parent, "Game", "Game.chd"))
 	_, err := mediaDB.sql.ExecContext(ctx, `
 		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'game', 'Game');
-		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+		INSERT INTO Media (
+			DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName
+		) VALUES (1, 1, 2, ?, ?, 'Game (Disc 1)');
 	`, gamePath, gameDir)
 	require.NoError(t, err)
 
@@ -2170,6 +2172,7 @@ func TestResolveSingletonContainerAliases_SingleFileIsAliased(t *testing.T) {
 	assert.Equal(t, gameDir, aliases[0].ChildDir)
 	assert.Equal(t, int64(1), aliases[0].Row.DBID)
 	assert.Equal(t, "Game", aliases[0].Row.Title.Name)
+	assert.Equal(t, "Game (Disc 1)", aliases[0].Row.SortName)
 	assert.Equal(t, "PSX", aliases[0].Row.System.SystemID)
 	assert.Empty(t, aliases[0].ZapScriptTags)
 }

--- a/pkg/database/mediadb/wal_checkpoint_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_test.go
@@ -148,14 +148,14 @@ func TestWALCheckpointing(t *testing.T) {
 	require.Equal(t, 4, count) // 1 initial + 3 additional
 }
 
-// TestConnectionParameters verifies the memory-safe connection parameters
+// TestConnectionParameters verifies the durable, memory-safe connection parameters.
 func TestConnectionParameters(t *testing.T) {
 	connParams := getSqliteConnParams()
 
-	// Verify key memory-safe parameters are present
-	// These settings are optimized for all platforms including low-RAM devices (e.g. MiSTer 256MB)
+	// Verify key durable and memory-safe parameters are present.
+	// MediaDB can contain user-owned metadata, so commits must survive hard power loss.
 	require.Contains(t, connParams, "_journal_mode=WAL")
-	require.Contains(t, connParams, "_synchronous=NORMAL")
+	require.Contains(t, connParams, "_synchronous=FULL")
 	require.Contains(t, connParams, "_cache_size=-8192") // 8MB cache (safe on 256MB systems)
 	require.Contains(t, connParams, "_temp_store=FILE")  // temp tables on disk for safe VACUUM
 	require.Contains(t, connParams, "_mmap_size=0")      // disabled to avoid memory pressure

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -92,6 +92,9 @@ func FlushScanStateMaps(ss *database.ScanState) {
 	for k := range ss.MediaTitleIDs {
 		delete(ss.MediaTitleIDs, k)
 	}
+	for k := range ss.MediaSortNames {
+		delete(ss.MediaSortNames, k)
+	}
 	for mediaID := range ss.MediaTagIDs {
 		delete(ss.MediaTagIDs, mediaID)
 	}
@@ -160,6 +163,10 @@ func AddMediaPathWithPrefixPolicy(
 
 	titleKey := database.TitleKey(systemID, pf.Slug)
 	canonicalTitleName := pf.Title
+	displayTitleName := pf.DisplayTitle
+	if displayTitleName == "" {
+		displayTitleName = canonicalTitleName
+	}
 	if foundTitleIndex, ok := ss.TitleIDs[titleKey]; !ok {
 		ss.TitlesIndex++
 		titleIndex = ss.TitlesIndex
@@ -204,7 +211,7 @@ func AddMediaPathWithPrefixPolicy(
 			DBID:           int64(mediaIndex),
 			Path:           pf.Path,
 			ParentDir:      parentDir,
-			SortName:       canonicalTitleName,
+			SortName:       displayTitleName,
 			MediaTitleDBID: int64(titleIndex),
 			SystemDBID:     int64(systemIndex),
 		})
@@ -215,6 +222,9 @@ func AddMediaPathWithPrefixPolicy(
 		ss.MediaIDs[mediaKey] = mediaIndex
 		if ss.MediaTitleIDs != nil {
 			ss.MediaTitleIDs[mediaIndex] = titleIndex
+		}
+		if ss.MediaSortNames != nil {
+			ss.MediaSortNames[mediaIndex] = displayTitleName
 		}
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[mediaIndex] = parentDir
@@ -238,12 +248,17 @@ func AddMediaPathWithPrefixPolicy(
 		}
 		_, needsSortName := ss.MediaNeedsSortName[mediaIndex]
 		existingTitleIndex, titleKnown := ss.MediaTitleIDs[mediaIndex]
-		if !titleKnown || existingTitleIndex != titleIndex || needsSortName {
-			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex), canonicalTitleName); err != nil {
+		existingSortName, sortNameKnown := ss.MediaSortNames[mediaIndex]
+		sortNameChanged := ss.MediaSortNames != nil && (!sortNameKnown || existingSortName != displayTitleName)
+		if !titleKnown || existingTitleIndex != titleIndex || needsSortName || sortNameChanged {
+			if err := db.UpdateMediaTitle(int64(mediaIndex), int64(titleIndex), displayTitleName); err != nil {
 				return 0, 0, fmt.Errorf("error updating media title %s: %w", pf.Path, err)
 			}
 			if ss.MediaTitleIDs != nil {
 				ss.MediaTitleIDs[mediaIndex] = titleIndex
+			}
+			if ss.MediaSortNames != nil {
+				ss.MediaSortNames[mediaIndex] = displayTitleName
 			}
 			if ss.MediaNeedsSortName != nil {
 				delete(ss.MediaNeedsSortName, mediaIndex)
@@ -522,13 +537,14 @@ func cloneMediaTagSet(tagIDs map[int]struct{}) map[int]struct{} {
 }
 
 type MediaPathFragments struct {
-	Path       string
-	FileName   string
-	Title      string
-	Slug       string
-	SlugTokens []string
-	Ext        string
-	Tags       []string
+	Path         string
+	FileName     string
+	Title        string
+	DisplayTitle string
+	Slug         string
+	SlugTokens   []string
+	Ext          string
+	Tags         []string
 }
 
 func getTagsFromFileName(filename string, mediaType slugs.MediaType) []string {
@@ -840,6 +856,9 @@ func PopulateScanStateForSystem(
 		if ss.MediaNeedsSortName != nil && m.SortName == "" {
 			ss.MediaNeedsSortName[int(m.DBID)] = struct{}{}
 		}
+		if ss.MediaSortNames != nil {
+			ss.MediaSortNames[int(m.DBID)] = m.SortName
+		}
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
 		}
@@ -941,6 +960,9 @@ func PopulatePersistentScanStateForSystem(
 		}
 		if ss.MediaNeedsSortName != nil && m.SortName == "" {
 			ss.MediaNeedsSortName[int(m.DBID)] = struct{}{}
+		}
+		if ss.MediaSortNames != nil {
+			ss.MediaSortNames[int(m.DBID)] = m.SortName
 		}
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
@@ -1181,6 +1203,7 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 	trimmedName := strings.TrimSpace(params.ProvidedName)
 	if trimmedName != "" {
 		f.Title = trimmedName
+		f.DisplayTitle = trimmedName
 	} else {
 		prefixPolicy := params.PrefixPolicy
 		if !prefixPolicy.Enabled && params.StripLeadingNumbers {
@@ -1190,6 +1213,10 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 			fileNameForTitle = stripped
 		}
 		f.Title = tags.ParseTitleFromFilename(fileNameForTitle, false)
+		f.DisplayTitle = tags.ParseDisplayTitleFromFilename(fileNameForTitle, false)
+	}
+	if f.DisplayTitle == "" {
+		f.DisplayTitle = f.Title
 	}
 
 	// Use pre-resolved media type if provided, otherwise look up from system ID

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -193,11 +193,6 @@ func AddMediaPathWithPrefixPolicy(
 		}
 	} else {
 		titleIndex = foundTitleIndex
-		if ss.TitleNames != nil {
-			if existingName, ok := ss.TitleNames[titleIndex]; ok && existingName != "" {
-				canonicalTitleName = existingName
-			}
-		}
 	}
 
 	mediaKey := database.MediaKey(systemID, pf.Path)

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -147,6 +147,9 @@ func TestFlushScanStateMaps_ClearsPerSystemMetadataCaches(t *testing.T) {
 		MediaTitleIDs: map[int]int{
 			10: 20,
 		},
+		MediaSortNames: map[int]string{
+			10: "Title (Disc 1)",
+		},
 		MediaTagIDs: map[int]map[int]struct{}{
 			10: {30: {}},
 		},
@@ -159,9 +162,133 @@ func TestFlushScanStateMaps_ClearsPerSystemMetadataCaches(t *testing.T) {
 	assert.Empty(t, scanState.TitleIDs)
 	assert.Empty(t, scanState.MediaIDs)
 	assert.Empty(t, scanState.MediaTitleIDs)
+	assert.Empty(t, scanState.MediaSortNames)
 	assert.Empty(t, scanState.MediaTagIDs)
 	assert.Equal(t, 1, scanState.SystemIDs["system"])
 	assert.Equal(t, 1, scanState.TagIDs["tag"])
+}
+
+func newIndexingPipelineScanState() *database.ScanState {
+	return &database.ScanState{
+		SystemIDs:       make(map[string]int),
+		TitleIDs:        make(map[string]int),
+		TitleNames:      make(map[int]string),
+		MediaIDs:        make(map[string]int),
+		MediaTitleIDs:   make(map[int]int),
+		MediaSortNames:  make(map[int]string),
+		MediaParentDirs: make(map[int]string),
+		MediaTagIDs:     make(map[int]map[int]struct{}),
+		TagTypeIDs:      make(map[string]int),
+		TagIDs:          make(map[string]int),
+	}
+}
+
+func mediaTagStringsForPath(t *testing.T, mediaDB *mediadb.MediaDB, path string) []string {
+	t.Helper()
+
+	rows, err := mediaDB.UnsafeGetSQLDb().QueryContext(context.Background(), `
+		SELECT tt.Type, t.Tag
+		FROM Media m
+		JOIN MediaTags mt ON mt.MediaDBID = m.DBID
+		JOIN Tags t ON t.DBID = mt.TagDBID
+		JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+		WHERE m.Path = ?
+		ORDER BY tt.Type, t.Tag
+	`, filepath.ToSlash(path))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	tagStrings := make([]string, 0)
+	for rows.Next() {
+		var tagType, tag string
+		require.NoError(t, rows.Scan(&tagType, &tag))
+		tagStrings = append(tagStrings, tagType+":"+tags.UnpadTagValue(tag))
+	}
+	require.NoError(t, rows.Err())
+
+	return tagStrings
+}
+
+func TestAddMediaPath_StructuralDisplayTitleDoesNotChangeSlug(t *testing.T) {
+	t.Parallel()
+
+	const systemID = "PSX"
+	disc1Path := filepath.Join(string(filepath.Separator), "roms", systemID, "Final Fantasy VII (Disc 1).cue")
+	disc2Path := filepath.Join(string(filepath.Separator), "roms", systemID, "Final Fantasy VII (Disc 2).cue")
+
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	scanState := newIndexingPipelineScanState()
+
+	require.NoError(t, SeedCanonicalTags(mediaDB, scanState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err := AddMediaPath(mediaDB, scanState, systemID, disc1Path, "", false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	_, _, err = AddMediaPath(mediaDB, scanState, systemID, disc2Path, "", false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err := mediaDB.GetTitlesBySystemID(systemID)
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "Final Fantasy VII", titles[0].Name)
+	assert.Equal(t, "finalfantasy7", titles[0].Slug)
+
+	mediaRows, err := mediaDB.GetMediaBySystemID(systemID)
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 2)
+
+	sortNamesByPath := make(map[string]string, len(mediaRows))
+	for _, row := range mediaRows {
+		sortNamesByPath[row.Path] = row.SortName
+	}
+	assert.Equal(t, "Final Fantasy VII (Disc 1)", sortNamesByPath[filepath.ToSlash(disc1Path)])
+	assert.Equal(t, "Final Fantasy VII (Disc 2)", sortNamesByPath[filepath.ToSlash(disc2Path)])
+
+	disc1Tags := mediaTagStringsForPath(t, mediaDB, disc1Path)
+	assert.Contains(t, disc1Tags, "media:disc")
+	assert.Contains(t, disc1Tags, "disc:1")
+
+	disc2Tags := mediaTagStringsForPath(t, mediaDB, disc2Path)
+	assert.Contains(t, disc2Tags, "media:disc")
+	assert.Contains(t, disc2Tags, "disc:2")
+}
+
+func TestAddMediaPath_ExistingMediaSortNameUpdatesToStructuralDisplayTitle(t *testing.T) {
+	t.Parallel()
+
+	const systemID = "PSX"
+	discPath := filepath.Join(string(filepath.Separator), "roms", systemID, "Final Fantasy VII (Disc 1).cue")
+	storedPath := filepath.ToSlash(discPath)
+
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	initialState := newIndexingPipelineScanState()
+	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err := AddMediaPath(mediaDB, initialState, systemID, discPath, "", false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	_, err = mediaDB.UnsafeGetSQLDb().ExecContext(
+		context.Background(), `UPDATE Media SET SortName = ? WHERE Path = ?`, "Final Fantasy VII", storedPath,
+	)
+	require.NoError(t, err)
+
+	reindexState := newIndexingPipelineScanState()
+	require.NoError(t, PopulateScanStateFromDB(context.Background(), mediaDB, reindexState))
+	require.NoError(t, PopulatePersistentScanStateForSystem(context.Background(), mediaDB, reindexState, systemID))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err = AddMediaPath(mediaDB, reindexState, systemID, discPath, "", false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	mediaRows, err := mediaDB.GetMediaBySystemID(systemID)
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	assert.Equal(t, "Final Fantasy VII (Disc 1)", mediaRows[0].SortName)
 }
 
 // TestAddMediaPath_NonUniqueError tests that non-UNIQUE errors fail immediately

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -48,7 +48,9 @@ import (
 
 // Batch configuration for transaction optimization
 const (
-	maxFilesPerTransaction = 10000
+	maxFilesPerTransaction      = 10000
+	mediaDatabaseCorruptMessage = "media database is corrupt; manual repair or rebuild required; " +
+		"original database left untouched"
 )
 
 func detectBrowsePrefixPolicy(files []platforms.ScanResult, threshold float64, minFiles int) browseprefix.Policy {
@@ -63,6 +65,17 @@ func detectBrowsePrefixPolicy(files []platforms.ScanResult, threshold float64, m
 // Kept for focused scanner tests; production code uses detectBrowsePrefixPolicy.
 func detectNumberingPattern(files []platforms.ScanResult, threshold float64, minFiles int) bool {
 	return detectBrowsePrefixPolicy(files, threshold, minFiles).Kind == browseprefix.KindRank
+}
+
+func isSQLiteDatabaseCorrupt(err error) bool {
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code == sqlite3.ErrCorrupt || sqliteErr.Code == sqlite3.ErrNotADB
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "database disk image is malformed") ||
+		strings.Contains(msg, "file is not a database")
 }
 
 type PathResult struct {
@@ -658,6 +671,8 @@ func NewNamesIndex(
 		if setErr := db.SetIndexingStatus(""); setErr != nil {
 			log.Error().Err(setErr).Msg("failed to clear indexing status after failed run")
 		}
+	case mediadb.IndexingStatusCorrupt:
+		return 0, errors.New(mediaDatabaseCorruptMessage)
 	}
 
 	// Build launcher metadata once so runnable-system filtering and scanner
@@ -763,10 +778,23 @@ func NewNamesIndex(
 	}
 	log.Info().Msgf("starting indexing for requested systems: %v (runnable: %v)", requestedSystemIDs, currentSystemIDs)
 
-	// Populate scan state from existing DB (max IDs, system map, tag maps)
+	// Populate scan state from existing DB (max IDs, system map, tag maps).
+	// TODO: Design a salvage-safe update-index path that does not require a
+	// full existing Tags scan before any rebuild can start. A corrupt Tags table
+	// currently blocks all update-index attempts, even when the caller would be
+	// willing to regenerate scanner-owned data.
 	if err = PopulateScanStateForSelectiveIndexing(ctx, db, &scanState, []string{}); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return handleCancellation(ctx, db, "Media indexing cancelled during scan state population")
+		}
+		if isSQLiteDatabaseCorrupt(err) {
+			if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
+				log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
+			}
+			if setErr := db.SetLastIndexedSystem(""); setErr != nil {
+				log.Error().Err(setErr).Msg("failed to clear last indexed system after corrupt database detection")
+			}
+			return 0, fmt.Errorf("%s: %w", mediaDatabaseCorruptMessage, err)
 		}
 		return 0, fmt.Errorf("failed to populate scan state: %w", err)
 	}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -747,6 +747,7 @@ func NewNamesIndex(
 		MediaIDs:           make(map[string]int),
 		MediaTitleIDs:      make(map[int]int),
 		MediaNeedsSortName: make(map[int]struct{}),
+		MediaSortNames:     make(map[int]string),
 		MediaParentDirs:    make(map[int]string),
 		MediaTagIDs:        make(map[int]map[int]struct{}),
 		TagTypesIndex:      0,
@@ -1186,6 +1187,7 @@ func NewNamesIndex(
 	scanState.MediaIDs = nil
 	scanState.MediaTitleIDs = nil
 	scanState.MediaNeedsSortName = nil
+	scanState.MediaSortNames = nil
 	scanState.MediaParentDirs = nil
 	scanState.MediaTagIDs = nil
 	scanState.TagTypeIDs = nil

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -616,6 +616,27 @@ func TestNewNamesIndex_ReportsSystemBeforeLoadingExistingData(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestNewNamesIndex_PreexistingCorruptFastFail(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCorrupt, nil).Twice()
+
+	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{{ID: "NES"}},
+		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, func(IndexStatus) {}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "media database is corrupt")
+	assert.Contains(t, err.Error(), "original database left untouched")
+	mockMediaDB.AssertNotCalled(t, "GetAllSystems")
+	mockMediaDB.AssertNotCalled(t, "GetAllTags")
+	mockMediaDB.AssertNotCalled(t, "GetAllTagTypes")
+	mockMediaDB.AssertNotCalled(t, "SetIndexingSystems", mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestNewNamesIndex_CorruptExistingTagsMarksDatabaseCorrupt(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -30,12 +30,14 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -612,6 +614,38 @@ func TestNewNamesIndex_ReportsSystemBeforeLoadingExistingData(t *testing.T) {
 	assert.Less(t, indexOf("status:nes"), indexOf("load:nes"), "events: %v", events)
 	assert.Less(t, indexOf("status:snes"), indexOf("load:snes"), "events: %v", events)
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestNewNamesIndex_CorruptExistingTagsMarksDatabaseCorrupt(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", mock.Anything).Return([]platforms.Launcher{})
+	mockPlatform.On("RootDirs", mock.Anything).Return([]string{})
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Twice()
+	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
+	mockMediaDB.On("SetIndexingSystems", []string{"NES"}).Return(nil).Once()
+	mockMediaDB.On("GetMaxSystemID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTitleID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxMediaID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagTypeID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetMaxTagID").Return(int64(0), nil).Once()
+	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
+	mockMediaDB.On("GetAllTags").Return(nil, sqlite3.Error{Code: sqlite3.ErrCorrupt}).Once()
+	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil).Once()
+	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
+
+	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{{ID: "NES"}},
+		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, func(IndexStatus) {}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "media database is corrupt")
+	assert.Contains(t, err.Error(), "original database left untouched")
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
 }
 
 // TestNewNamesIndex_ResumeSystemNotFound tests handling when last indexed system is no longer available

--- a/pkg/database/mediascanner/sqlite_corruption_test.go
+++ b/pkg/database/mediascanner/sqlite_corruption_test.go
@@ -1,0 +1,68 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSQLiteDatabaseCorrupt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{
+			name: "corrupt sqlite code",
+			err:  sqlite3.Error{Code: sqlite3.ErrCorrupt},
+			want: true,
+		},
+		{
+			name: "not a database sqlite code",
+			err:  fmt.Errorf("wrapped: %w", sqlite3.Error{Code: sqlite3.ErrNotADB}),
+			want: true,
+		},
+		{
+			name: "corrupt message fallback",
+			err:  errors.New("database disk image is malformed"),
+			want: true,
+		},
+		{
+			name: "ordinary error",
+			err:  errors.New("temporary query failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isSQLiteDatabaseCorrupt(tt.err))
+		})
+	}
+}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -251,14 +251,14 @@ func orderedScrapeSystemIDs(indexed, requested []string) []string {
 		indexedSet[id] = struct{}{}
 	}
 
-	ids := indexed
+	candidateIDs := indexed
 	if len(requested) > 0 {
-		ids = requested
+		candidateIDs = requested
 	}
 
-	seen := make(map[string]struct{}, len(ids))
-	ordered := make([]string, 0, len(ids))
-	for _, id := range ids {
+	seen := make(map[string]struct{}, len(candidateIDs))
+	ordered := make([]string, 0, len(candidateIDs))
+	for _, id := range candidateIDs {
 		if _, ok := indexedSet[id]; !ok {
 			continue
 		}

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -245,6 +245,32 @@ func NewPlatformScraper() platforms.Scraper {
 	}
 }
 
+func orderedScrapeSystemIDs(indexed, requested []string) []string {
+	indexedSet := make(map[string]struct{}, len(indexed))
+	for _, id := range indexed {
+		indexedSet[id] = struct{}{}
+	}
+
+	ids := indexed
+	if len(requested) > 0 {
+		ids = requested
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	ordered := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := indexedSet[id]; !ok {
+			continue
+		}
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	return ordered
+}
+
 // resolveSystemsFromPlatform builds the list of ScrapeSystem values by
 // querying the indexed systems from mdb, looking up their definitions, and
 // resolving ROM root paths via the platform launcher configuration.
@@ -260,26 +286,11 @@ func resolveSystemsFromPlatform(
 		return nil, fmt.Errorf("resolveSystemsFromPlatform: list indexed systems: %w", err)
 	}
 
-	want := make(map[string]struct{}, len(indexed))
-	if len(systemIDs) == 0 {
-		for _, id := range indexed {
-			want[id] = struct{}{}
-		}
-	} else {
-		indexedSet := make(map[string]struct{}, len(indexed))
-		for _, id := range indexed {
-			indexedSet[id] = struct{}{}
-		}
-		for _, id := range systemIDs {
-			if _, ok := indexedSet[id]; ok {
-				want[id] = struct{}{}
-			}
-		}
-	}
+	wantedIDs := orderedScrapeSystemIDs(indexed, systemIDs)
 
-	dbSystems := make(map[string]database.System, len(want))
-	sysDefs := make([]systemdefs.System, 0, len(want))
-	for sysID := range want {
+	dbSystems := make(map[string]database.System, len(wantedIDs))
+	sysDefs := make([]systemdefs.System, 0, len(wantedIDs))
+	for _, sysID := range wantedIDs {
 		sys, err := mdb.FindSystemBySystemID(sysID)
 		if err != nil {
 			return nil, fmt.Errorf("resolveSystemsFromPlatform: look up system %q: %w", sysID, err)

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -1021,6 +1021,25 @@ func TestScrape_DBError(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestOrderedScrapeSystemIDs_DefaultPreservesIndexedOrder(t *testing.T) {
+	t.Parallel()
+
+	indexed := []string{"atari2600", "gb", "nes", "snes"}
+	got := orderedScrapeSystemIDs(indexed, nil)
+
+	assert.Equal(t, []string{"atari2600", "gb", "nes", "snes"}, got)
+}
+
+func TestOrderedScrapeSystemIDs_RequestedPreservesRequestedOrder(t *testing.T) {
+	t.Parallel()
+
+	indexed := []string{"atari2600", "gb", "nes", "snes"}
+	requested := []string{"snes", "missing", "nes", "snes", "gb"}
+	got := orderedScrapeSystemIDs(indexed, requested)
+
+	assert.Equal(t, []string{"snes", "nes", "gb"}, got)
+}
+
 // --- MapToDB ---
 
 func TestMapToDB_FullGame(t *testing.T) {

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -102,7 +102,12 @@ func resolveEditionTag(qualifier, suffix string, src TagSource) CanonicalTag {
 // group has two or more tokens (e.g. "disc-3", not bare "disc" which allTagMappings handles).
 var structuralPrefixes = map[string]bool{
 	"disc":    true,
+	"disk":    true,
+	"file":    true,
 	"part":    true,
+	"tape":    true,
+	"cd":      true,
+	"side":    true,
 	"book":    true,
 	"program": true,
 	"chapter": true,
@@ -111,6 +116,28 @@ var structuralPrefixes = map[string]bool{
 	"track":   true,
 	"vol":     true,
 	"volume":  true,
+}
+
+var structuralMediaPrefixes = map[string]TagValue{
+	"disc": TagMediaDisc,
+	"disk": TagMediaDisk,
+	"file": TagMediaFile,
+	"part": TagMediaPart,
+	"tape": TagMediaTape,
+	"cd":   TagMediaDisc,
+}
+
+var structuralRomanNumbers = map[string]string{
+	"i":    "1",
+	"ii":   "2",
+	"iii":  "3",
+	"iv":   "4",
+	"v":    "5",
+	"vi":   "6",
+	"vii":  "7",
+	"viii": "8",
+	"ix":   "9",
+	"x":    "10",
 }
 
 // catalogNumberRE matches catalog/part-number shapes like "kd02", "ap009", "pbpx-95205", "v512".
@@ -249,6 +276,111 @@ func hasTagType(ts []CanonicalTag, tt TagType) bool {
 		}
 	}
 	return false
+}
+
+func normalizeStructuralNumber(s string) (string, bool) {
+	if s == "" {
+		return "", false
+	}
+	if roman, ok := structuralRomanNumbers[s]; ok {
+		return roman, true
+	}
+	for i := range len(s) {
+		if !isDigit(s[i]) {
+			return "", false
+		}
+	}
+	normalized := strings.TrimLeft(s, "0")
+	if normalized == "" {
+		normalized = "0"
+	}
+	return normalized, true
+}
+
+func structuralSideValue(s string) (TagValue, bool) {
+	switch s {
+	case "a", "1":
+		return TagMediaSideA, true
+	case "b", "2":
+		return TagMediaSideB, true
+	case "c", "3":
+		return TagMediaSideC, true
+	case "d", "4":
+		return TagMediaSideD, true
+	default:
+		return "", false
+	}
+}
+
+func compactStructuralMediaTag(normalized string, source TagSource) ([]CanonicalTag, bool) {
+	for prefix, mediaValue := range structuralMediaPrefixes {
+		if !strings.HasPrefix(normalized, prefix) || len(normalized) == len(prefix) {
+			continue
+		}
+		number, ok := normalizeStructuralNumber(normalized[len(prefix):])
+		if !ok {
+			continue
+		}
+		return []CanonicalTag{
+			{Type: TagTypeMedia, Value: mediaValue, Source: source},
+			{Type: TagTypeDisc, Value: TagValue(number), Source: source},
+		}, true
+	}
+	return nil, false
+}
+
+func parseStructuralSetTag(normalized string, source TagSource) ([]CanonicalTag, bool) {
+	if normalized == "" {
+		return nil, false
+	}
+
+	if strings.HasPrefix(normalized, "side-") {
+		if sideValue, ok := structuralSideValue(strings.TrimPrefix(normalized, "side-")); ok {
+			return []CanonicalTag{{Type: TagTypeMedia, Value: sideValue, Source: source}}, true
+		}
+	}
+
+	tokens := strings.Split(normalized, "-")
+	if len(tokens) < 2 {
+		return compactStructuralMediaTag(normalized, source)
+	}
+
+	mediaValue, ok := structuralMediaPrefixes[tokens[0]]
+	if !ok {
+		return nil, false
+	}
+	number, ok := normalizeStructuralNumber(tokens[1])
+	if !ok {
+		return nil, false
+	}
+
+	results := []CanonicalTag{
+		{Type: TagTypeMedia, Value: mediaValue, Source: source},
+		{Type: TagTypeDisc, Value: TagValue(number), Source: source},
+	}
+
+	next := 2
+	if len(tokens) >= next+2 && tokens[next] == "of" {
+		total, totalOK := normalizeStructuralNumber(tokens[next+1])
+		if !totalOK {
+			return nil, false
+		}
+		results = append(results, CanonicalTag{Type: TagTypeDiscTotal, Value: TagValue(total), Source: source})
+		next += 2
+	}
+	if len(tokens) >= next+2 && tokens[next] == "side" {
+		sideValue, sideOK := structuralSideValue(tokens[next+1])
+		if !sideOK {
+			return nil, false
+		}
+		results = append(results, CanonicalTag{Type: TagTypeMedia, Value: sideValue, Source: source})
+		next += 2
+	}
+	if next != len(tokens) {
+		return nil, false
+	}
+
+	return results, true
 }
 
 // langMap maps 3-letter ROM language codes to 2-letter ISO 639-1 codes.
@@ -495,20 +627,26 @@ func extractSpecialPatternsForMedia(
 
 	// Pattern 1: "Disc/Disk X of Y [Side A/B/C/D]" - most common multi-disc format
 	if m := findDiscPattern(remaining); m.ok {
+		mediaValue := TagMediaDisc
+		if strings.HasPrefix(strings.ToLower(remaining[m.start:m.start+5]), "(disk") {
+			mediaValue = TagMediaDisk
+		}
+		discNumber, _ := normalizeStructuralNumber(remaining[m.cap1s:m.cap1e])
+		discTotal, _ := normalizeStructuralNumber(remaining[m.cap2s:m.cap2e])
 		tags = append(tags,
 			CanonicalTag{
 				Type:   TagTypeMedia,
-				Value:  TagValue("disc"),
+				Value:  mediaValue,
 				Source: TagSourceBracketed,
 			},
 			CanonicalTag{
 				Type:   TagTypeDisc,
-				Value:  TagValue(remaining[m.cap1s:m.cap1e]),
+				Value:  TagValue(discNumber),
 				Source: TagSourceBracketed,
 			},
 			CanonicalTag{
 				Type:   TagTypeDiscTotal,
-				Value:  TagValue(remaining[m.cap2s:m.cap2e]),
+				Value:  TagValue(discTotal),
 				Source: TagSourceBracketed,
 			},
 		)
@@ -939,6 +1077,10 @@ func disambiguateTag(ctx *ParseContext) []CanonicalTag {
 	// For parentheses tags, normalize and process
 	normalized := cachedNormalizeTag(ctx.CurrentTag)
 
+	if structuralTags, ok := parseStructuralSetTag(normalized, TagSourceBracketed); ok {
+		return structuralTags
+	}
+
 	// First check if it's a multi-language tag (En,Fr,De)
 	if multiLang := parseMultiLanguageTag(normalized); multiLang != nil {
 		return multiLang
@@ -1008,6 +1150,10 @@ func mapBracketTag(tag string, mediaType slugs.MediaType) []CanonicalTag {
 
 	// Normalize the tag for regular processing
 	normalized := cachedNormalizeTag(tag)
+
+	if structuralTags, ok := parseStructuralSetTag(normalized, TagSourceBracketed); ok {
+		return structuralTags
+	}
 
 	// Check for multi-language patterns (en-fr-de, En,Fr,De, En+Fr)
 	if langTags := parseMultiLanguageTag(normalized); langTags != nil {
@@ -1428,6 +1574,52 @@ func stripSceneArtifacts(input string) string {
 	return result
 }
 
+func stripMetadataBracketsForDisplay(s string) string {
+	var result strings.Builder
+	result.Grow(len(s))
+
+	for i := 0; i < len(s); i++ {
+		open := s[i]
+		var close byte
+		switch open {
+		case '(':
+			close = ')'
+		case '[':
+			close = ']'
+		case '{':
+			close = '}'
+		case '<':
+			close = '>'
+		default:
+			_ = result.WriteByte(open)
+			continue
+		}
+
+		start := i
+		depth := 1
+		for i++; i < len(s); i++ {
+			switch s[i] {
+			case open:
+				depth++
+			case close:
+				depth--
+				if depth == 0 {
+					content := s[start+1 : i]
+					if _, ok := parseStructuralSetTag(cachedNormalizeTag(content), TagSourceBracketed); ok {
+						_, _ = result.WriteString(s[start : i+1])
+					}
+					break
+				}
+			}
+			if depth == 0 {
+				break
+			}
+		}
+	}
+
+	return strings.TrimSpace(result.String())
+}
+
 // ParseTitleFromFilename extracts a clean, human-readable display title from a filename.
 // It removes metadata brackets and normalizes common filename artifacts for better presentation.
 //
@@ -1456,6 +1648,17 @@ func stripSceneArtifacts(input string) string {
 // code duplication. However, it only applies transformations appropriate for display
 // titles (no Roman numeral conversion, edition stripping, etc.).
 func ParseTitleFromFilename(filename string, stripLeadingNumbers bool) string {
+	return parseTitleFromFilename(filename, stripLeadingNumbers, false)
+}
+
+// ParseDisplayTitleFromFilename extracts a per-file display title while preserving
+// structural set markers such as "(Disc 1)", "(Disk 2 of 4)", and "(File 3)".
+// The canonical title parser still strips those markers before slug generation.
+func ParseDisplayTitleFromFilename(filename string, stripLeadingNumbers bool) string {
+	return parseTitleFromFilename(filename, stripLeadingNumbers, true)
+}
+
+func parseTitleFromFilename(filename string, stripLeadingNumbers bool, preserveStructuralTags bool) string {
 	// Import the slugs package for shared normalization functions
 	// This eliminates code duplication while keeping display-appropriate behavior
 	title := filename
@@ -1520,9 +1723,13 @@ func ParseTitleFromFilename(filename string, stripLeadingNumbers bool) string {
 		title = strings.TrimSpace(title)
 	}
 
-	// Step 7: Remove all bracket content using shared function from slugs package
-	// This handles nested brackets and all bracket types uniformly
-	title = slugs.StripMetadataBrackets(title)
+	// Step 7: Remove bracket metadata. Per-file display titles retain
+	// structural set markers, while canonical titles strip every bracket group.
+	if preserveStructuralTags {
+		title = stripMetadataBracketsForDisplay(title)
+	} else {
+		title = slugs.StripMetadataBrackets(title)
+	}
 	title = strings.TrimSpace(title)
 
 	// Step 8: Normalize multiple spaces to single space

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -1580,16 +1580,16 @@ func stripMetadataBracketsForDisplay(s string) string {
 
 	for i := 0; i < len(s); i++ {
 		open := s[i]
-		var close byte
+		var closeBracket byte
 		switch open {
 		case '(':
-			close = ')'
+			closeBracket = ')'
 		case '[':
-			close = ']'
+			closeBracket = ']'
 		case '{':
-			close = '}'
+			closeBracket = '}'
 		case '<':
-			close = '>'
+			closeBracket = '>'
 		default:
 			_ = result.WriteByte(open)
 			continue
@@ -1601,14 +1601,13 @@ func stripMetadataBracketsForDisplay(s string) string {
 			switch s[i] {
 			case open:
 				depth++
-			case close:
+			case closeBracket:
 				depth--
 				if depth == 0 {
 					content := s[start+1 : i]
 					if _, ok := parseStructuralSetTag(cachedNormalizeTag(content), TagSourceBracketed); ok {
 						_, _ = result.WriteString(s[start : i+1])
 					}
-					break
 				}
 			}
 			if depth == 0 {
@@ -1648,17 +1647,17 @@ func stripMetadataBracketsForDisplay(s string) string {
 // code duplication. However, it only applies transformations appropriate for display
 // titles (no Roman numeral conversion, edition stripping, etc.).
 func ParseTitleFromFilename(filename string, stripLeadingNumbers bool) string {
-	return parseTitleFromFilename(filename, stripLeadingNumbers, false)
+	return parseFilenameTitle(filename, stripLeadingNumbers, false)
 }
 
 // ParseDisplayTitleFromFilename extracts a per-file display title while preserving
 // structural set markers such as "(Disc 1)", "(Disk 2 of 4)", and "(File 3)".
 // The canonical title parser still strips those markers before slug generation.
 func ParseDisplayTitleFromFilename(filename string, stripLeadingNumbers bool) string {
-	return parseTitleFromFilename(filename, stripLeadingNumbers, true)
+	return parseFilenameTitle(filename, stripLeadingNumbers, true)
 }
 
-func parseTitleFromFilename(filename string, stripLeadingNumbers bool, preserveStructuralTags bool) string {
+func parseFilenameTitle(filename string, stripLeadingNumbers, preserveStructuralTags bool) string {
 	// Import the slugs package for shared normalization functions
 	// This eliminates code duplication while keeping display-appropriate behavior
 	title := filename

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -1245,7 +1245,7 @@ func TestParseBracesAndAngles_FullPipeline(t *testing.T) {
 		{
 			name:         "TOSEC Final dev-status",
 			filename:     "The Fall (Final)(2018)(Disk 2 of 2).adf",
-			wantContains: []string{"unfinished:final", "year:2018", "media:disc", "disc:2", "disctotal:2"},
+			wantContains: []string{"unfinished:final", "year:2018", "media:disk", "disc:2", "disctotal:2"},
 		},
 		{
 			name:         "TOSEC Final without year",
@@ -1256,7 +1256,7 @@ func TestParseBracesAndAngles_FullPipeline(t *testing.T) {
 			name:     "Disk N of M with Side A - publisher from TOSEC slot",
 			filename: "Alter Ego (1985)(Activision)(Disk 1 of 3 Side A)[cr].do",
 			wantContains: []string{
-				"publisher:activision", "media:disc", "disc:1", "disctotal:3", "media:side-a", "dump:cracked",
+				"publisher:activision", "media:disk", "disc:1", "disctotal:3", "media:side-a", "dump:cracked",
 			},
 		},
 		{
@@ -1918,7 +1918,139 @@ func TestParseTitleFromFilename_SceneReleases(t *testing.T) {
 	}
 }
 
-// TestExtractSpecialPatterns_MediaMetadata tests extraction of TV show, comic, and music metadata.
+func TestParseDisplayTitleFromFilename_PreservesOnlyStructuralSetMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		display   string
+		canonical string
+	}{
+		{
+			name:      "disc number preserved for display only",
+			input:     "Final Fantasy VII (Disc 1).cue",
+			display:   "Final Fantasy VII (Disc 1)",
+			canonical: "Final Fantasy VII",
+		},
+		{
+			name:      "disk total preserved and region stripped",
+			input:     "Adventure (Disk 2 of 4) (USA).dsk",
+			display:   "Adventure (Disk 2 of 4)",
+			canonical: "Adventure",
+		},
+		{
+			name:      "file number preserved and dump tag stripped",
+			input:     "Magazine (File 3) [!].zip",
+			display:   "Magazine (File 3)",
+			canonical: "Magazine",
+		},
+		{
+			name:      "side marker preserved",
+			input:     "Cassette Game (Side A) (Europe).tap",
+			display:   "Cassette Game (Side A)",
+			canonical: "Cassette Game",
+		},
+		{
+			name:      "compact cd marker preserved",
+			input:     "Album (CD1) [FLAC].chd",
+			display:   "Album (CD1)",
+			canonical: "Album",
+		},
+		{
+			name:      "normal metadata stripped",
+			input:     "Super Mario Bros (USA) [!].sfc",
+			display:   "Super Mario Bros",
+			canonical: "Super Mario Bros",
+		},
+		{
+			name:      "nonnumeric structural word stripped",
+			input:     "Famicom Game (Disk Writer).fds",
+			display:   "Famicom Game",
+			canonical: "Famicom Game",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.display, ParseDisplayTitleFromFilename(tt.input, false), "display title mismatch")
+			assert.Equal(t, tt.canonical, ParseTitleFromFilename(tt.input, false), "canonical title mismatch")
+		})
+	}
+}
+
+func TestParseFilenameToCanonicalTags_StructuralSetMarkers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		filename        string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:         "disc number",
+			filename:     "Final Fantasy VII (Disc 1).cue",
+			wantContains: []string{"media:disc", "disc:1"},
+		},
+		{
+			name:         "zero-padded disc number and total",
+			filename:     "Final Fantasy VIII (Disc 02 of 04).cue",
+			wantContains: []string{"media:disc", "disc:2", "disctotal:4"},
+		},
+		{
+			name:            "disk number with total",
+			filename:        "Adventure (Disk 2 of 4).dsk",
+			wantContains:    []string{"media:disk", "disc:2", "disctotal:4"},
+			wantNotContains: []string{"media:disc"},
+		},
+		{
+			name:         "file number",
+			filename:     "Magazine (File 3).zip",
+			wantContains: []string{"media:file", "disc:3"},
+		},
+		{
+			name:         "roman part number",
+			filename:     "Story (Part II).bin",
+			wantContains: []string{"media:part", "disc:2"},
+		},
+		{
+			name:         "side marker",
+			filename:     "Cassette Game (Side B).tap",
+			wantContains: []string{"media:side-b"},
+		},
+		{
+			name:         "compact cd marker",
+			filename:     "Album (CD1).chd",
+			wantContains: []string{"media:disc", "disc:1"},
+		},
+		{
+			name:            "nonnumeric disk phrase is not structural",
+			filename:        "Famicom Game (Disk Writer).fds",
+			wantContains:    []string{"distribution:disk-writer"},
+			wantNotContains: []string{"media:disk", "disc:writer"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTags(tt.filename)
+			gotStrings := make([]string, len(got))
+			for i, tag := range got {
+				gotStrings[i] = tag.String()
+			}
+			for _, want := range tt.wantContains {
+				assert.Contains(t, gotStrings, want)
+			}
+			for _, unexpected := range tt.wantNotContains {
+				assert.NotContains(t, gotStrings, unexpected)
+			}
+		})
+	}
+}
+
 func TestExtractSpecialPatterns_MediaMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -2053,7 +2053,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			ID:         systemdefs.SystemArcade,
 			SystemID:   systemdefs.SystemArcade,
 			Folders:    []string{"_Arcade"},
-			Extensions: []string{".mra"},
+			Extensions: []string{".mra", ".mgl"},
 			Launch:     launchArcade(pl, systemdefs.SystemArcade),
 		},
 		{

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -455,6 +455,26 @@ func TestLLAPISuperGrafxLauncherExists(t *testing.T) {
 		"LLAPISuperGrafx must use SystemSuperGrafx so .sgx slots are found")
 }
 
+func TestArcadeLauncherExtensions(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	var arcadeLauncher *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == "Arcade" {
+			arcadeLauncher = &launchers[i]
+			break
+		}
+	}
+
+	require.NotNil(t, arcadeLauncher, "Arcade launcher should exist")
+	assert.Equal(t, []string{"_Arcade"}, arcadeLauncher.Folders)
+	assert.Contains(t, arcadeLauncher.Extensions, ".mra")
+	assert.Contains(t, arcadeLauncher.Extensions, ".mgl")
+}
+
 // Regression test: N64 launcher should support .v64 extension (byte-swapped ROM format)
 func TestN64LauncherExtensions(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Summary:
- Keep disc/disk/file/part/side markers in per-media display names while leaving canonical titles and slugs grouped.
- Preserve marker-aware names for singleton media-container aliases so grid/list browse paths use the same Core display name.
- Add structural filename tag parsing coverage, including zero-padded disc numbers and disk/file variants.
- Preserve deterministic gamelist.xml scrape order, including requested system order.
- Index MiSTer _Arcade .mgl files through the Arcade launcher.
- Mark corrupt media DBs with an explicit `corrupt` indexing status without moving/deleting user data.
- Harden MediaDB writes with SQLite `synchronous=FULL` because MediaDB now contains non-rebuildable metadata.

Checked:
- go test ./pkg/database/tags ./pkg/database/mediascanner ./pkg/database/scraper/...
- go test ./pkg/database/...
- go test ./pkg/platforms/mister
- go test ./pkg/api/methods ./pkg/database/mediadb ./pkg/database/mediascanner ./pkg/database/tags
- go test ./pkg/database/mediadb ./pkg/database/mediascanner
- golangci-lint run --fix pkg/api/methods/ pkg/database/mediadb/ pkg/database/mediascanner/
- golangci-lint run --fix pkg/platforms/mister/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persistent media sort-name handling and cache clearing during rescans.
  * Better title/sort reconciliation for multi-disc/multi-file items.
  * Improved detection and user-facing handling when the media database is corrupt.

* **New Features**
  * Filename parsing preserves structural media markers (disc/side/part) in display titles.
  * Display titles retain structural info while stripping other metadata.
  * Arcade launcher now recognizes an additional extension.

* **Tests**
  * Added coverage for structural parsing, sort-name behavior, ordered system filtering, corruption handling, and launcher extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->