### PR TITLE
perf(database): instrument and speed media indexing

### DIFF
--- a/pkg/database/mediadb/concurrent_operations_test.go
+++ b/pkg/database/mediadb/concurrent_operations_test.go
@@ -328,19 +328,19 @@ func TestOptimizationInterruption(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
+	// temporary repair runs first; pragma_optimize failure aborts before page_prefetch/browse_cache
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	expectTemporaryParentDirRepairStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
-		WithArgs(DBConfigOptimizationStep, "analyze").
+		WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	analyzeError := errors.New("database locked")
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError) // Final failure
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError) // Final failure
 
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "failed").

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -353,24 +353,17 @@ func (db *MediaDB) SetIndexingCacheSize(enable bool) {
 	}
 }
 
-// AnalyzeApproximate refreshes query-planner statistics with a bounded row sample
-// (PRAGMA analysis_limit). Used right after bulk indexing, before the synchronous
-// cache builds, so their queries plan against fresh stats instead of waiting for
-// the full ANALYZE in background optimization.
+// AnalyzeApproximate refreshes query-planner statistics before synchronous
+// cache builds. PRAGMA optimize is intentionally used instead of raw ANALYZE:
+// on modern SQLite it bounds analysis work automatically and only refreshes
+// tables likely to benefit, which avoids multi-minute full-index scans on slow
+// MiSTer storage.
 func (db *MediaDB) AnalyzeApproximate() error {
 	if db.sql == nil {
 		return ErrNullSQL
 	}
-	if _, err := db.sql.ExecContext(db.ctx, "PRAGMA analysis_limit = 400"); err != nil {
-		return fmt.Errorf("failed to set analysis_limit: %w", err)
-	}
-	defer func() {
-		if _, err := db.sql.ExecContext(db.ctx, "PRAGMA analysis_limit = 0"); err != nil {
-			log.Warn().Err(err).Msg("failed to reset analysis_limit")
-		}
-	}()
-	if _, err := db.sql.ExecContext(db.ctx, "ANALYZE"); err != nil {
-		return fmt.Errorf("failed to run approximate analyze: %w", err)
+	if _, err := db.sql.ExecContext(db.ctx, "PRAGMA optimize=0x10002"); err != nil {
+		return fmt.Errorf("failed to run pragma optimize: %w", err)
 	}
 	return nil
 }
@@ -2853,10 +2846,10 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	// after the database is already open for searches.
 	//
 	// Step order matters: temporary repair jobs run before cache rebuilds so
-	// upgraded databases are corrected without blocking startup. ANALYZE then
-	// updates query-planner statistics, the page-prefetch warms the OS buffer
-	// cache for the tables the search path joins, and BrowseCache/WAL checkpoint
-	// follow as non-critical housekeeping.
+	// upgraded databases are corrected without blocking startup. PRAGMA optimize
+	// refreshes planner statistics only where SQLite decides it is useful, the
+	// page-prefetch warms the OS buffer cache for the tables the search path
+	// joins, and BrowseCache/WAL checkpoint follow as non-critical housekeeping.
 	db.needsIndexRebuild.Store(false)
 
 	steps = append(steps,
@@ -2867,7 +2860,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			maxRetries: 0, retryDelay: rd,
 		},
 		optimizationStep{
-			name: "analyze", fn: db.Analyze,
+			name: "pragma_optimize", fn: db.AnalyzeApproximate,
 			maxRetries: 2, retryDelay: rd,
 		},
 		optimizationStep{
@@ -2895,7 +2888,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		},
 		// NOTE: VACUUM is intentionally omitted. It takes an exclusive lock
 		// for the entire duration, blocking all reads (including card scans).
-		// ANALYZE alone is sufficient for query planner performance. SQLite
+		// PRAGMA optimize is sufficient for planner maintenance here. SQLite
 		// reuses free pages on the next INSERT, so disk reclamation is not needed.
 	)
 

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -36,9 +36,9 @@ import (
 
 func expectAnalyzeStep(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
-		WithArgs(DBConfigOptimizationStep, "analyze").
+		WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	mock.ExpectExec("(?i)analyze;?").
+	mock.ExpectExec("(?i)PRAGMA optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
 
@@ -93,7 +93,7 @@ func expectWALCheckpointStep(mock sqlmock.Sqlmock) {
 		WillReturnResult(sqlmock.NewResult(0, 0))
 }
 
-// expectPostAnalyzeSteps mocks all steps that run after analyze in the
+// expectPostAnalyzeSteps mocks all steps that run after PRAGMA optimize in the
 // background optimization sequence: page_prefetch, browse_cache, wal_checkpoint.
 func expectPostAnalyzeSteps(mock sqlmock.Sqlmock) {
 	expectPagePrefetchStep(mock)
@@ -198,8 +198,8 @@ func TestSetGetOptimizationStep(t *testing.T) {
 			step: "indexes",
 		},
 		{
-			name: "analyze step",
-			step: "analyze",
+			name: "pragma optimize step",
+			step: "pragma_optimize",
 		},
 		{
 			name: "vacuum step",
@@ -301,7 +301,7 @@ func TestRunBackgroundOptimization_Success(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// Steps run in order: temporary_repair_parent_dirs → analyze → page_prefetch → browse_cache → wal_checkpoint
+	// Steps run in order: temporary_repair_parent_dirs → pragma_optimize → page_prefetch → browse_cache → wal_checkpoint
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -335,19 +335,19 @@ func TestRunBackgroundOptimization_FailureHandling(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
+	// temporary repair runs first; pragma_optimize failure aborts before page_prefetch/browse_cache
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	expectTemporaryParentDirRepairStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
-		WithArgs(DBConfigOptimizationStep, "analyze").
+		WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
-	analyzeError := errors.New("analyze failed")
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-	mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError) // all retries exhausted
+	analyzeError := errors.New("pragma optimize failed")
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+	mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError) // all retries exhausted
 
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "failed").
@@ -563,19 +563,19 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 			vacuumRetryDelay:  1 * time.Millisecond,
 		}
 
-		// temporary repair runs first; analyze failure aborts before page_prefetch/browse_cache
+		// temporary repair runs first; pragma_optimize failure aborts before page_prefetch/browse_cache
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "running").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 		expectTemporaryParentDirRepairStepNoop(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
-			WithArgs(DBConfigOptimizationStep, "analyze").
+			WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
-		analyzeError := errors.New("analyze failed")
-		mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-		mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
-		mock.ExpectExec("(?i)analyze;?").WillReturnError(analyzeError)
+		analyzeError := errors.New("pragma optimize failed")
+		mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+		mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
+		mock.ExpectExec("(?i)PRAGMA optimize").WillReturnError(analyzeError)
 
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "failed").

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -301,7 +301,8 @@ func TestRunBackgroundOptimization_Success(t *testing.T) {
 		vacuumRetryDelay:  1 * time.Millisecond,
 	}
 
-	// Steps run in order: temporary_repair_parent_dirs → pragma_optimize → page_prefetch → browse_cache → wal_checkpoint
+	// Steps run in order: temporary_repair_parent_dirs → pragma_optimize →
+	// page_prefetch → browse_cache → wal_checkpoint.
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -87,7 +87,6 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		Int("media", builder.mediaRows).
 		Int("counts", len(builder.counts)).
 		Msg("browse cache media scan complete")
-	logBrowseMediaCountsBySystem(ctx, tx)
 
 	deleteStarted := time.Now()
 	for _, stmt := range []string{

--- a/pkg/database/mediadb/sql_cache.go
+++ b/pkg/database/mediadb/sql_cache.go
@@ -31,36 +31,48 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// buildPopulateTagsSQL returns the INSERT INTO SystemTagsCache SQL with an
-// optional system filter injected into both UNION ALL branches. Pass "" for the
-// full-database variant; pass a placeholder list such as `(?, ?)` for selective
-// rebuilds (matched against SystemDBID in both branches).
-//
-// The big tables (MediaTags, MediaTitleTags) are aggregated on integer keys
-// first and Tags/TagTypes are joined onto the much smaller aggregate. Joining
-// tag metadata per base row needed several B-tree probes for every MediaTags
-// row, which dominated the post-indexing cache build on slow hardware.
-func buildPopulateTagsSQL(systemFilter string) string {
+const systemTagsCacheUpsertClause = `
+		WHERE true
+		ON CONFLICT(SystemDBID, TagDBID) DO UPDATE SET
+			Count = SystemTagsCache.Count + excluded.Count`
+
+// buildPopulateMediaTagsSQL and buildPopulateTitleTagsSQL populate the cache in
+// two smaller upserts instead of one UNION ALL + final GROUP BY. The prior shape
+// built an extra temp B-tree over already-aggregated rows; splitting preserves
+// results while reducing sort/merge work on slow storage.
+func buildPopulateMediaTagsSQL(systemFilter string) string {
 	mediaWhere := "WHERE m.IsMissing = 0"
-	titleWhere := "WHERE EXISTS(SELECT 1 FROM Media m WHERE m.MediaTitleDBID = mtl.DBID AND m.IsMissing = 0)"
 	if systemFilter != "" {
 		mediaWhere = "WHERE m.SystemDBID IN " + systemFilter + " AND m.IsMissing = 0"
-		titleWhere = "WHERE mtl.SystemDBID IN " + systemFilter +
-			" AND EXISTS(SELECT 1 FROM Media m WHERE m.MediaTitleDBID = mtl.DBID AND m.IsMissing = 0)"
 	}
 	return fmt.Sprintf(`
 		INSERT INTO SystemTagsCache (SystemDBID, TagDBID, TagType, Tag, Count)
-		SELECT agg.SystemDBID, agg.TagDBID, tt.Type, t.Tag, SUM(agg.Cnt) AS Count
+		SELECT agg.SystemDBID, agg.TagDBID, tt.Type, t.Tag, agg.Cnt AS Count
 		FROM (
 			SELECT
 				m.SystemDBID AS SystemDBID,
 				mt.TagDBID AS TagDBID,
 				COUNT(*) AS Cnt
-			FROM MediaTags mt
-			JOIN Media m ON mt.MediaDBID = m.DBID
+			FROM Media m INDEXED BY media_system_path_idx
+			CROSS JOIN MediaTags mt
 			%s
+			  AND mt.MediaDBID = m.DBID
 			GROUP BY m.SystemDBID, mt.TagDBID
-			UNION ALL
+		) agg
+		JOIN Tags t ON agg.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID`+systemTagsCacheUpsertClause, mediaWhere)
+}
+
+func buildPopulateTitleTagsSQL(systemFilter string) string {
+	titleWhere := "WHERE EXISTS(SELECT 1 FROM Media m WHERE m.MediaTitleDBID = mtl.DBID AND m.IsMissing = 0)"
+	if systemFilter != "" {
+		titleWhere = "WHERE mtl.SystemDBID IN " + systemFilter +
+			" AND EXISTS(SELECT 1 FROM Media m WHERE m.MediaTitleDBID = mtl.DBID AND m.IsMissing = 0)"
+	}
+	return fmt.Sprintf(`
+		INSERT INTO SystemTagsCache (SystemDBID, TagDBID, TagType, Tag, Count)
+		SELECT agg.SystemDBID, agg.TagDBID, tt.Type, t.Tag, agg.Cnt AS Count
+		FROM (
 			SELECT
 				mtl.SystemDBID AS SystemDBID,
 				mtt.TagDBID AS TagDBID,
@@ -71,42 +83,36 @@ func buildPopulateTagsSQL(systemFilter string) string {
 			GROUP BY mtl.SystemDBID, mtt.TagDBID
 		) agg
 		JOIN Tags t ON agg.TagDBID = t.DBID
-		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-		GROUP BY agg.SystemDBID, agg.TagDBID, tt.Type, t.Tag`, mediaWhere, titleWhere)
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID`+systemTagsCacheUpsertClause, titleWhere)
 }
 
 // sqlPopulateSystemTagsCache - Populates the SystemTagsCache table for fast tag lookups
 // This should be called after media indexing to ensure cache is up to date
 func sqlPopulateSystemTagsCache(ctx context.Context, db *sql.DB) error {
-	// Clear existing cache
-	clearStmt, err := db.PrepareContext(ctx, "DELETE FROM SystemTagsCache")
+	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to prepare clear cache statement: %w", err)
+		return fmt.Errorf("failed to begin system tags cache transaction: %w", err)
 	}
+	committed := false
 	defer func() {
-		if closeErr := clearStmt.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close clear cache statement")
+		if !committed {
+			_ = tx.Rollback()
 		}
 	}()
 
-	if _, execErr := clearStmt.ExecContext(ctx); execErr != nil {
+	if _, execErr := tx.ExecContext(ctx, "DELETE FROM SystemTagsCache"); execErr != nil {
 		return fmt.Errorf("failed to clear system tags cache: %w", execErr)
 	}
-
-	populateStmt, err := db.PrepareContext(ctx, buildPopulateTagsSQL(""))
-	if err != nil {
-		return fmt.Errorf("failed to prepare populate cache statement: %w", err)
+	if _, execErr := tx.ExecContext(ctx, buildPopulateMediaTagsSQL("")); execErr != nil {
+		return fmt.Errorf("failed to populate media tags cache rows: %w", execErr)
 	}
-	defer func() {
-		if closeErr := populateStmt.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close populate cache statement")
-		}
-	}()
-
-	if _, err := populateStmt.ExecContext(ctx); err != nil {
-		return fmt.Errorf("failed to populate system tags cache: %w", err)
+	if _, execErr := tx.ExecContext(ctx, buildPopulateTitleTagsSQL("")); execErr != nil {
+		return fmt.Errorf("failed to populate title tags cache rows: %w", execErr)
 	}
-
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("failed to commit system tags cache transaction: %w", commitErr)
+	}
+	committed = true
 	return nil
 }
 
@@ -147,49 +153,44 @@ func sqlPopulateSystemTagsCacheForSystems(
 		return nil // No systems found in database
 	}
 
-	// Step 2: Delete cache entries for these systems
+	// Step 2: Delete cache entries for these systems and repopulate them in
+	// one transaction. This keeps WAL FULL durability while avoiding separate
+	// fsyncs for clear/media/title phases.
 	placeholders := prepareVariadic("?", ",", len(systemDBIDs))
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
-	deleteSQL := fmt.Sprintf("DELETE FROM SystemTagsCache WHERE SystemDBID IN (%s)", placeholders)
-	deleteStmt, err := db.PrepareContext(ctx, deleteSQL)
-	if err != nil {
-		return fmt.Errorf("failed to prepare selective cache clear statement: %w", err)
-	}
-	defer func() {
-		if closeErr := deleteStmt.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close selective cache clear statement")
-		}
-	}()
-
 	args := make([]any, len(systemDBIDs))
 	for i, id := range systemDBIDs {
 		args[i] = id
 	}
 
-	if _, execErr := deleteStmt.ExecContext(ctx, args...); execErr != nil {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin selective system tags cache transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
+	deleteSQL := fmt.Sprintf("DELETE FROM SystemTagsCache WHERE SystemDBID IN (%s)", placeholders)
+	if _, execErr := tx.ExecContext(ctx, deleteSQL, args...); execErr != nil {
 		return fmt.Errorf("failed to clear cache for specific systems: %w", execErr)
 	}
 
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?", no user data interpolated
 	placeholderList := fmt.Sprintf("(%s)", placeholders)
-	populateStmt, err := db.PrepareContext(ctx, buildPopulateTagsSQL(placeholderList))
-	if err != nil {
-		return fmt.Errorf("failed to prepare selective cache populate statement: %w", err)
+	if _, execErr := tx.ExecContext(ctx, buildPopulateMediaTagsSQL(placeholderList), args...); execErr != nil {
+		return fmt.Errorf("failed to populate media cache rows for specific systems: %w", execErr)
 	}
-	defer func() {
-		if closeErr := populateStmt.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close selective cache populate statement")
-		}
-	}()
-
-	// Double args for the UNION's second WHERE clause
-	populateArgs := make([]any, 0, len(args)*2)
-	populateArgs = append(populateArgs, args...)
-	populateArgs = append(populateArgs, args...)
-
-	if _, execErr := populateStmt.ExecContext(ctx, populateArgs...); execErr != nil {
-		return fmt.Errorf("failed to populate cache for specific systems: %w", execErr)
+	if _, execErr := tx.ExecContext(ctx, buildPopulateTitleTagsSQL(placeholderList), args...); execErr != nil {
+		return fmt.Errorf("failed to populate title cache rows for specific systems: %w", execErr)
 	}
+	if commitErr := tx.Commit(); commitErr != nil {
+		return fmt.Errorf("failed to commit selective system tags cache transaction: %w", commitErr)
+	}
+	committed = true
 
 	log.Debug().Int("system_count", len(systems)).Msg("populated system tags cache for specific systems")
 	return nil

--- a/pkg/database/mediadb/sql_cache.go
+++ b/pkg/database/mediadb/sql_cache.go
@@ -32,7 +32,6 @@ import (
 )
 
 const systemTagsCacheUpsertClause = `
-		WHERE true
 		ON CONFLICT(SystemDBID, TagDBID) DO UPDATE SET
 			Count = SystemTagsCache.Count + excluded.Count`
 

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -294,13 +294,15 @@ func sqlGetMediaWithFullPathExcluding(
 // This is used for lazy loading during resume to avoid loading ALL media upfront.
 // Single-table query on Media: this runs once per system over every media row,
 // and no caller reads TitleSlug, so the MediaTitles join would only add a
-// per-row B-tree probe. SystemID is filled from the argument.
+// per-row B-tree probe. SystemID is filled from the argument. Ordering by Path
+// lets SQLite stream from media_system_path_idx instead of filtering by system
+// and then building a temp sort by DBID for large systems.
 func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaWithFullPath, error) {
 	query := `
 		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName
-		FROM Media m
+		FROM Media m INDEXED BY media_system_path_idx
 		WHERE m.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
-		ORDER BY m.DBID
+		ORDER BY m.Path
 	`
 	rows, err := db.QueryContext(ctx, query, systemID)
 	if err != nil {

--- a/pkg/database/mediadb/sql_media_tags.go
+++ b/pkg/database/mediadb/sql_media_tags.go
@@ -157,10 +157,10 @@ func sqlDeleteMediaTagsByTagIDs(ctx context.Context, db sqlQueryable, mediaDBID 
 func sqlGetMediaTagsBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaTagLink, error) {
 	query := `
 		SELECT mt.MediaDBID, mt.TagDBID
-		FROM MediaTags mt
-		JOIN Media m ON mt.MediaDBID = m.DBID
-		JOIN Systems s ON m.SystemDBID = s.DBID
-		WHERE s.SystemID = ?
+		FROM Media m INDEXED BY media_system_path_idx
+		CROSS JOIN MediaTags mt
+		WHERE m.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
+		  AND mt.MediaDBID = m.DBID
 	`
 	return sqlQueryMediaTagLinksBySystemID(ctx, db, query, systemID, systemID)
 }
@@ -208,10 +208,10 @@ func sqlGetScannerMediaTagsBySystemID(
 
 	query := `
 		SELECT mt.MediaDBID, mt.TagDBID
-		FROM MediaTags mt
-		JOIN Media m ON mt.MediaDBID = m.DBID
-		JOIN Systems s ON m.SystemDBID = s.DBID
-		WHERE s.SystemID = ?
+		FROM Media m INDEXED BY media_system_path_idx
+		CROSS JOIN MediaTags mt
+		WHERE m.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
+		  AND mt.MediaDBID = m.DBID
 	`
 	links, err := sqlQueryMediaTagLinksBySystemID(ctx, db, query, systemID, systemID)
 	if err != nil {

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1368,6 +1368,11 @@ func TestCheckForDuplicateMediaTitles_WithDuplicates(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+const mediaBySystemIDQueryPattern = `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
+	`FROM Media m INDEXED BY media_system_path_idx.*` +
+	`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
+	`ORDER BY m\.Path`
+
 func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -1386,9 +1391,7 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 		AddRow(int64(2), zeldaPath, gamesDir, int64(11), "The Legend of Zelda").
 		AddRow(int64(3), metroidPath, gamesDir, int64(12), "Metroid")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
-	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
+	mock.ExpectQuery(mediaBySystemIDQueryPattern).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
 
@@ -1425,9 +1428,7 @@ func TestSqlGetMediaBySystemID_EmptyResult(t *testing.T) {
 	emptyCols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName"}
 	rows := sqlmock.NewRows(emptyCols)
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
-	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
+	mock.ExpectQuery(mediaBySystemIDQueryPattern).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
 
@@ -1444,9 +1445,7 @@ func TestSqlGetMediaBySystemID_QueryError(t *testing.T) {
 
 	systemID := "nes"
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
-	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
+	mock.ExpectQuery(mediaBySystemIDQueryPattern).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
 
@@ -1468,9 +1467,7 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"DBID", "Path"}).
 		AddRow(int64(1), "/games/mario.nes")
 
-	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
-	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
+	mock.ExpectQuery(mediaBySystemIDQueryPattern).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
 

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -36,6 +36,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const mediaBySystemIDQueryPattern = `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
+	`FROM Media m INDEXED BY media_system_path_idx.*` +
+	`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
+	`ORDER BY m\.Path`
+
 func TestSqlUpdateLastGenerated_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -1063,6 +1068,36 @@ func TestSqlPopulateSystemTagsCacheForSystems_InsertError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlPopulateSystemTagsCacheForSystems_CommitError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	systems := []systemdefs.System{{ID: "nes"}}
+
+	mock.ExpectPrepare("SELECT DBID FROM Systems WHERE SystemID = ?").
+		ExpectQuery().WithArgs("nes").
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(1))
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE mtl.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 3))
+	mock.ExpectCommit().WillReturnError(sql.ErrTxDone)
+
+	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to commit selective system tags cache transaction")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlSearchMediaBySlug_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -1429,11 +1464,6 @@ func TestCheckForDuplicateMediaTitles_WithDuplicates(t *testing.T) {
 	assert.Contains(t, duplicates[1], "count=3")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
-
-const mediaBySystemIDQueryPattern = `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-	`FROM Media m INDEXED BY media_system_path_idx.*` +
-	`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
-	`ORDER BY m\.Path`
 
 func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 	t.Parallel()

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -701,15 +701,14 @@ func TestSqlPopulateSystemTagsCache_Success(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	// Expect DELETE statement to clear cache
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache").
-		ExpectExec().
-		WillReturnResult(sqlmock.NewResult(0, 5)) // Deleted 5 rows
-
-	// Expect INSERT statement to populate cache
-	mock.ExpectPrepare(`INSERT INTO SystemTagsCache.*`).
-		ExpectExec().
-		WillReturnResult(sqlmock.NewResult(1, 10)) // Inserted 10 rows
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+		WillReturnResult(sqlmock.NewResult(1, 6))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
+		WillReturnResult(sqlmock.NewResult(1, 4))
+	mock.ExpectCommit()
 
 	err = sqlPopulateSystemTagsCache(context.Background(), db)
 	assert.NoError(t, err)
@@ -722,10 +721,10 @@ func TestSqlPopulateSystemTagsCache_ClearError(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	// Expect DELETE statement to fail
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache").
-		ExpectExec().
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache").
 		WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
 
 	err = sqlPopulateSystemTagsCache(context.Background(), db)
 	require.Error(t, err)
@@ -847,15 +846,17 @@ func TestSqlPopulateSystemTagsCacheForSystems_Success(t *testing.T) {
 	systemStmt.ExpectQuery().WithArgs("snes").
 		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(2))
 
-	// Mock selective delete for these systems
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
-		ExpectExec().WithArgs(1, 2).
-		WillReturnResult(sqlmock.NewResult(0, 10)) // Deleted 10 old cache entries
-
-	// Mock selective INSERT for these systems (args doubled for UNION)
-	mock.ExpectPrepare(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
-		ExpectExec().WithArgs(1, 2, 1, 2).
-		WillReturnResult(sqlmock.NewResult(1, 15)) // Inserted 15 new cache entries
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1, 2).
+		WillReturnResult(sqlmock.NewResult(0, 10))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
+		WithArgs(1, 2).
+		WillReturnResult(sqlmock.NewResult(1, 9))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE mtl.SystemDBID IN.*`).
+		WithArgs(1, 2).
+		WillReturnResult(sqlmock.NewResult(1, 6))
+	mock.ExpectCommit()
 
 	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
 	assert.NoError(t, err)
@@ -889,15 +890,17 @@ func TestSqlPopulateSystemTagsCacheForSystems_SingleSystem(t *testing.T) {
 		ExpectQuery().WithArgs("nes").
 		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(1))
 
-	// Mock selective delete
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
-		ExpectExec().WithArgs(1).
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 5))
-
-	// Mock selective INSERT (args doubled for UNION)
-	mock.ExpectPrepare(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
-		ExpectExec().WithArgs(1, 1).
-		WillReturnResult(sqlmock.NewResult(1, 8))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE mtl.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 3))
+	mock.ExpectCommit()
 
 	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
 	assert.NoError(t, err)
@@ -924,13 +927,17 @@ func TestSqlPopulateSystemTagsCacheForSystems_NonExistentSystem(t *testing.T) {
 		WillReturnError(sql.ErrNoRows) // System not found
 
 	// Should still process NES successfully
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
-		ExpectExec().WithArgs(1).
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 5))
-
-	mock.ExpectPrepare(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
-		ExpectExec().WithArgs(1, 1).
-		WillReturnResult(sqlmock.NewResult(1, 8))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE mtl.SystemDBID IN.*`).
+		WithArgs(1).
+		WillReturnResult(sqlmock.NewResult(1, 3))
+	mock.ExpectCommit()
 
 	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
 	assert.NoError(t, err, "should continue processing valid systems even if some don't exist")
@@ -952,9 +959,11 @@ func TestSqlPopulateSystemTagsCacheForSystems_DeleteError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(1))
 
 	// Mock delete failure
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
-		ExpectExec().WithArgs(1).
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1).
 		WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
 
 	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
 	require.Error(t, err)
@@ -977,18 +986,18 @@ func TestSqlPopulateSystemTagsCacheForSystems_InsertError(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(1))
 
 	// Mock delete success
-	mock.ExpectPrepare("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
-		ExpectExec().WithArgs(1).
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache WHERE SystemDBID IN.*").
+		WithArgs(1).
 		WillReturnResult(sqlmock.NewResult(0, 5))
-
-	// Mock insert failure (args doubled for UNION)
-	mock.ExpectPrepare(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
-		ExpectExec().WithArgs(1, 1).
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*WHERE m.SystemDBID IN.*`).
+		WithArgs(1).
 		WillReturnError(sql.ErrTxDone)
+	mock.ExpectRollback()
 
 	err = sqlPopulateSystemTagsCacheForSystems(context.Background(), db, systems)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to populate cache for specific systems")
+	assert.Contains(t, err.Error(), "failed to populate media cache rows for specific systems")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -1378,7 +1387,7 @@ func TestSqlGetMediaBySystemID_Success(t *testing.T) {
 		AddRow(int64(3), metroidPath, gamesDir, int64(12), "Metroid")
 
 	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.DBID`
+		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
@@ -1417,7 +1426,7 @@ func TestSqlGetMediaBySystemID_EmptyResult(t *testing.T) {
 	rows := sqlmock.NewRows(emptyCols)
 
 	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.DBID`
+		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
@@ -1436,7 +1445,7 @@ func TestSqlGetMediaBySystemID_QueryError(t *testing.T) {
 	systemID := "nes"
 
 	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.DBID`
+		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)
@@ -1460,7 +1469,7 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 		AddRow(int64(1), "/games/mario.nes")
 
 	mediaBySystemQuery := `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName ` +
-		`FROM Media m.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.DBID`
+		`FROM Media m INDEXED BY media_system_path_idx.*WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
 	mock.ExpectQuery(mediaBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetMediaBySystemID(context.Background(), db, systemID)

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	dbtags "github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -729,6 +730,67 @@ func TestSqlPopulateSystemTagsCache_ClearError(t *testing.T) {
 	err = sqlPopulateSystemTagsCache(context.Background(), db)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to clear system tags cache")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlPopulateSystemTagsCache_MediaInsertError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+		WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
+
+	err = sqlPopulateSystemTagsCache(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to populate media tags cache rows")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlPopulateSystemTagsCache_TitleInsertError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+		WillReturnResult(sqlmock.NewResult(1, 6))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
+		WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
+
+	err = sqlPopulateSystemTagsCache(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to populate title tags cache rows")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlPopulateSystemTagsCache_CommitError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("DELETE FROM SystemTagsCache").
+		WillReturnResult(sqlmock.NewResult(0, 5))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+		WillReturnResult(sqlmock.NewResult(1, 6))
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
+		WillReturnResult(sqlmock.NewResult(1, 4))
+	mock.ExpectCommit().WillReturnError(sql.ErrTxDone)
+
+	err = sqlPopulateSystemTagsCache(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to commit system tags cache transaction")
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -1474,6 +1536,88 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to scan media for system nes")
 	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaTagsBySystemID_UsesSystemMediaIndex(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows := sqlmock.NewRows([]string{"MediaDBID", "TagDBID"}).
+		AddRow(int64(1), int64(10)).
+		AddRow(int64(2), int64(11))
+
+	mediaTagsBySystemQuery := `SELECT mt\.MediaDBID, mt\.TagDBID.*` +
+		`FROM Media m INDEXED BY media_system_path_idx.*` +
+		`CROSS JOIN MediaTags mt.*` +
+		`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
+		`AND mt\.MediaDBID = m\.DBID`
+	mock.ExpectQuery(mediaTagsBySystemQuery).WithArgs("nes").WillReturnRows(rows)
+
+	links, err := sqlGetMediaTagsBySystemID(context.Background(), db, "nes")
+
+	require.NoError(t, err)
+	assert.Equal(t, []database.MediaTagLink{
+		{MediaDBID: 1, TagDBID: 10},
+		{MediaDBID: 2, TagDBID: 11},
+	}, links)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetScannerMediaTagsBySystemID_FiltersUserTags(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t\.DBID.*FROM Tags t.*JOIN TagTypes tt.*WHERE tt\.Type = \?`).
+		WithArgs(string(dbtags.TagTypeUser)).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(int64(99)))
+	rows := sqlmock.NewRows([]string{"MediaDBID", "TagDBID"}).
+		AddRow(int64(1), int64(10)).
+		AddRow(int64(1), int64(99)).
+		AddRow(int64(2), int64(11))
+	mediaTagsBySystemQuery := `SELECT mt\.MediaDBID, mt\.TagDBID.*` +
+		`FROM Media m INDEXED BY media_system_path_idx.*` +
+		`CROSS JOIN MediaTags mt.*` +
+		`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
+		`AND mt\.MediaDBID = m\.DBID`
+	mock.ExpectQuery(mediaTagsBySystemQuery).WithArgs("nes").WillReturnRows(rows)
+
+	links, err := sqlGetScannerMediaTagsBySystemID(context.Background(), db, "nes")
+
+	require.NoError(t, err)
+	assert.Equal(t, []database.MediaTagLink{
+		{MediaDBID: 1, TagDBID: 10},
+		{MediaDBID: 2, TagDBID: 11},
+	}, links)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetScannerMediaTagsBySystemID_ReturnsLinksWhenNoUserTags(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t\.DBID.*FROM Tags t.*JOIN TagTypes tt.*WHERE tt\.Type = \?`).
+		WithArgs(string(dbtags.TagTypeUser)).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}))
+	rows := sqlmock.NewRows([]string{"MediaDBID", "TagDBID"}).
+		AddRow(int64(1), int64(10))
+	mediaTagsBySystemQuery := `SELECT mt\.MediaDBID, mt\.TagDBID.*` +
+		`FROM Media m INDEXED BY media_system_path_idx.*` +
+		`CROSS JOIN MediaTags mt.*` +
+		`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
+		`AND mt\.MediaDBID = m\.DBID`
+	mock.ExpectQuery(mediaTagsBySystemQuery).WithArgs("nes").WillReturnRows(rows)
+
+	links, err := sqlGetScannerMediaTagsBySystemID(context.Background(), db, "nes")
+
+	require.NoError(t, err)
+	assert.Equal(t, []database.MediaTagLink{{MediaDBID: 1, TagDBID: 10}}, links)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -885,7 +885,9 @@ func loadSystemStateData(
 	}
 
 	// Load titles for this system
+	titlesStart := time.Now()
 	titles, err := db.GetTitlesBySystemID(systemID)
+	titlesElapsed := time.Since(titlesStart)
 	if err != nil {
 		return systemStateData{}, fmt.Errorf("failed to get titles for system %s: %w", systemID, err)
 	}
@@ -898,14 +900,19 @@ func loadSystemStateData(
 	}
 
 	// Load media for this system
+	mediaStart := time.Now()
 	media, err := db.GetMediaBySystemID(systemID)
+	mediaElapsed := time.Since(mediaStart)
 	if err != nil {
 		return systemStateData{}, fmt.Errorf("failed to get media for system %s: %w", systemID, err)
 	}
 
 	mediaTags := []database.MediaTagLink(nil)
+	mediaTagsElapsed := time.Duration(0)
 	if loadMediaTags {
+		mediaTagsStart := time.Now()
 		mediaTags, err = db.GetScannerMediaTagsBySystemID(systemID)
+		mediaTagsElapsed = time.Since(mediaTagsStart)
 		if err != nil {
 			return systemStateData{}, fmt.Errorf("failed to get scanner media tags for system %s: %w", systemID, err)
 		}
@@ -916,6 +923,9 @@ func loadSystemStateData(
 		Int("titles", len(titles)).
 		Int("media", len(media)).
 		Int("mediaTags", len(mediaTags)).
+		Dur("titlesDuration", titlesElapsed).
+		Dur("mediaDuration", mediaElapsed).
+		Dur("mediaTagsDuration", mediaTagsElapsed).
 		Dur("elapsed", time.Since(startTime)).
 		Msg("loaded existing data for system resume")
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -590,7 +590,7 @@ func NewNamesIndex(
 	phaseMetricsStart := runMetricsStart
 	logPhaseMetrics := func(phase string) {
 		phaseMetricsEnd := metrics.Capture(ctx, true)
-		perfmetrics.AddDelta(log.Info().Str("phase", phase), phaseMetricsStart, phaseMetricsEnd).
+		perfmetrics.AddDelta(log.Info().Str("phase", phase), &phaseMetricsStart, &phaseMetricsEnd).
 			Msg("media indexing phase metrics")
 		phaseMetricsStart = phaseMetricsEnd
 	}
@@ -1203,8 +1203,8 @@ func NewNamesIndex(
 				Str("system", systemID).
 				Int("files", len(files)).
 				Dur("elapsed", systemElapsed),
-			systemMetricsStart,
-			systemMetricsEnd,
+			&systemMetricsStart,
+			&systemMetricsEnd,
 		).Msg("completed system indexing")
 
 		if systemElapsed > 30*time.Second {
@@ -1416,8 +1416,8 @@ func NewNamesIndex(
 			Int("files", indexedFiles).
 			Int("systemsCompleted", len(indexedSystems)).
 			Dur("elapsed", indexElapsed),
-		runMetricsStart,
-		indexMetricsEnd,
+		&runMetricsStart,
+		&indexMetricsEnd,
 	).Msg("media indexing resource summary")
 
 	if err != nil {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/perfmetrics"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
@@ -584,6 +585,15 @@ func NewNamesIndex(
 ) (int, error) {
 	db := fdb.MediaDB
 	indexStartTime := time.Now()
+	metrics := perfmetrics.NewRecorderForDB(db)
+	runMetricsStart := metrics.Capture(ctx, true)
+	phaseMetricsStart := runMetricsStart
+	logPhaseMetrics := func(phase string) {
+		phaseMetricsEnd := metrics.Capture(ctx, true)
+		perfmetrics.AddDelta(log.Info().Str("phase", phase), phaseMetricsStart, phaseMetricsEnd).
+			Msg("media indexing phase metrics")
+		phaseMetricsStart = phaseMetricsEnd
+	}
 
 	// Activate the NormalizeTag cache for the duration of this indexing run.
 	// The bracket vocabulary is small (~200–400 unique strings), so the cache
@@ -687,6 +697,7 @@ func NewNamesIndex(
 	for _, v := range getSystemPathsForLauncherCache(ctx, platform.RootDirs(cfg), systems, launcherCache) {
 		systemPaths[v.System.ID] = append(systemPaths[v.System.ID], v.Path)
 	}
+	logPhaseMetrics("path_discovery")
 	update(IndexStatus{Phase: PhaseInitializing})
 
 	systemsWithScanners := make(map[string]bool, len(allLaunchers))
@@ -799,6 +810,8 @@ func NewNamesIndex(
 		return 0, fmt.Errorf("failed to populate scan state: %w", err)
 	}
 
+	logPhaseMetrics("initial_state_population")
+
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusRunning); setErr != nil {
 		log.Error().Err(setErr).Msg("failed to set indexing status to running")
 	}
@@ -890,6 +903,7 @@ func NewNamesIndex(
 			return handleCancellationWithRollback(ctx, db, "Media indexing cancelled while paused")
 		}
 
+		systemMetricsStart := metrics.Capture(ctx, false)
 		systemID := sys.ID
 		status.SystemID = systemID
 		status.Step++
@@ -1183,11 +1197,15 @@ func NewNamesIndex(
 		completedSystems[systemID] = true
 
 		systemElapsed := time.Since(systemStartTime)
-		log.Info().
-			Str("system", systemID).
-			Int("files", len(files)).
-			Dur("elapsed", systemElapsed).
-			Msg("completed system indexing")
+		systemMetricsEnd := metrics.Capture(ctx, false)
+		perfmetrics.AddDelta(
+			log.Info().
+				Str("system", systemID).
+				Int("files", len(files)).
+				Dur("elapsed", systemElapsed),
+			systemMetricsStart,
+			systemMetricsEnd,
+		).Msg("completed system indexing")
 
 		if systemElapsed > 30*time.Second {
 			log.Warn().
@@ -1201,6 +1219,8 @@ func NewNamesIndex(
 		// Populate* re-loads them for the next system.
 		FlushScanStateMaps(&scanState)
 	}
+
+	logPhaseMetrics("systems")
 
 	status.Step++
 	status.SystemID = ""
@@ -1232,6 +1252,7 @@ func NewNamesIndex(
 		log.Error().Err(idxErr).Msg("failed to create secondary indexes")
 	}
 	log.Info().Dur("elapsed", time.Since(t0)).Msg("CreateSecondaryIndexes complete")
+	logPhaseMetrics("create_secondary_indexes")
 
 	// Mark database as complete and ready for use. UpdateLastGenerated clears
 	// SystemTagsCache and SlugResolutionCache via invalidateCaches, so cache
@@ -1240,6 +1261,7 @@ func NewNamesIndex(
 	if err != nil {
 		return 0, fmt.Errorf("failed to update last generated timestamp: %w", err)
 	}
+	logPhaseMetrics("update_last_generated")
 
 	status.Phase = PhaseBuildingCaches
 	update(status)
@@ -1274,7 +1296,8 @@ func NewNamesIndex(
 	if analyzeErr := db.AnalyzeApproximate(); analyzeErr != nil {
 		log.Warn().Err(analyzeErr).Msg("failed to refresh planner statistics before cache builds")
 	}
-	log.Info().Dur("elapsed", time.Since(t0)).Msg("AnalyzeApproximate complete")
+	log.Info().Dur("elapsed", time.Since(t0)).Msg("PragmaOptimize complete")
+	logPhaseMetrics("pragma_optimize")
 
 	// Populate caches after UpdateLastGenerated. For selective scans we rebuild
 	// the persisted per-system SQL cache, refresh in-memory slug coverage for the
@@ -1290,12 +1313,14 @@ func NewNamesIndex(
 			Dur("elapsed", time.Since(t0)).
 			Int("systems", len(indexedSystemDefs)).
 			Msg("PopulateSystemTagsCacheForSystems complete")
+		logPhaseMetrics("populate_system_tags_cache")
 
 		t0 = time.Now()
 		if cacheErr := db.RebuildTagCache(); cacheErr != nil {
 			log.Error().Err(cacheErr).Msg("failed to rebuild tag cache after selective indexing")
 		}
 		log.Info().Dur("elapsed", time.Since(t0)).Msg("RebuildTagCache complete")
+		logPhaseMetrics("rebuild_tag_cache")
 
 		t0 = time.Now()
 		if cacheErr := db.RefreshSlugSearchCacheForSystems(ctx, indexedSystems); cacheErr != nil {
@@ -1305,23 +1330,27 @@ func NewNamesIndex(
 			Dur("elapsed", time.Since(t0)).
 			Int("systems", len(indexedSystems)).
 			Msg("RefreshSlugSearchCacheForSystems complete")
+		logPhaseMetrics("refresh_slug_search_cache")
 	} else {
 		if cacheErr := db.PopulateSystemTagsCache(ctx); cacheErr != nil {
 			log.Error().Err(cacheErr).Msg("failed to populate system tags cache")
 		}
 		log.Info().Dur("elapsed", time.Since(t0)).Msg("PopulateSystemTagsCache complete")
+		logPhaseMetrics("populate_system_tags_cache")
 
 		t0 = time.Now()
 		if cacheErr := db.RebuildSlugSearchCache(); cacheErr != nil {
 			log.Error().Err(cacheErr).Msg("failed to rebuild slug search cache")
 		}
 		log.Info().Dur("elapsed", time.Since(t0)).Msg("RebuildSlugSearchCache complete")
+		logPhaseMetrics("rebuild_slug_search_cache")
 
 		t0 = time.Now()
 		if cacheErr := db.RebuildTagCache(); cacheErr != nil {
 			log.Error().Err(cacheErr).Msg("failed to rebuild tag cache")
 		}
 		log.Info().Dur("elapsed", time.Since(t0)).Msg("RebuildTagCache complete")
+		logPhaseMetrics("rebuild_tag_cache")
 	}
 
 	// Bump the index generation counter so persisted cache files written
@@ -1347,6 +1376,7 @@ func NewNamesIndex(
 			log.Error().Err(persistErr).Msg("failed to persist slug search cache to disk")
 		}
 	}
+	logPhaseMetrics("persist_caches")
 
 	// Mark indexing as completed and clear indexing metadata
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCompleted); setErr != nil {
@@ -1380,6 +1410,15 @@ func NewNamesIndex(
 
 	indexedFiles = status.Files
 	indexElapsed := time.Since(indexStartTime)
+	indexMetricsEnd := metrics.Capture(ctx, true)
+	perfmetrics.AddDelta(
+		log.Info().
+			Int("files", indexedFiles).
+			Int("systemsCompleted", len(indexedSystems)).
+			Dur("elapsed", indexElapsed),
+		runMetricsStart,
+		indexMetricsEnd,
+	).Msg("media indexing resource summary")
 
 	if err != nil {
 		log.Error().

--- a/pkg/database/perfmetrics/perfmetrics.go
+++ b/pkg/database/perfmetrics/perfmetrics.go
@@ -1,0 +1,271 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Package perfmetrics captures coarse process and SQLite resource counters for
+// long media operations. Snapshots are best-effort: missing /proc support or
+// PRAGMA failures should never affect indexing or scraping behavior.
+package perfmetrics
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type ProcessIO struct {
+	RChar               int64
+	WChar               int64
+	Syscr               int64
+	Syscw               int64
+	ReadBytes           int64
+	WriteBytes          int64
+	CancelledWriteBytes int64
+}
+
+type RuntimeStats struct {
+	AllocBytes      uint64
+	TotalAllocBytes uint64
+	SysBytes        uint64
+	HeapAllocBytes  uint64
+	HeapSysBytes    uint64
+	HeapObjects     uint64
+	Mallocs         uint64
+	Frees           uint64
+	GCCycles        uint32
+	GCPauseNs       uint64
+	Goroutines      int
+	CgoCalls        int64
+}
+
+type DBStats struct {
+	DBBytes               int64
+	WALBytes              int64
+	SHMBytes              int64
+	PageCount             int64
+	FreelistCount         int64
+	PageSize              int64
+	CacheSize             int64
+	WALBusy               int64
+	WALFrames             int64
+	WALCheckpointedFrames int64
+}
+
+type Snapshot struct {
+	At      time.Time
+	IO      ProcessIO
+	Runtime RuntimeStats
+	DB      DBStats
+	IOOK    bool
+	DBOK    bool
+}
+
+type Recorder struct {
+	dbPath string
+	sqlDB  *sql.DB
+}
+
+func NewRecorder(dbPath string, sqlDB *sql.DB) Recorder {
+	return Recorder{dbPath: dbPath, sqlDB: sqlDB}
+}
+
+type DBProvider interface {
+	GetDBPath() string
+	UnsafeGetSQLDb() *sql.DB
+}
+
+func NewRecorderForDB(db DBProvider) (recorder Recorder) {
+	defer func() {
+		if recover() != nil {
+			recorder = Recorder{}
+		}
+	}()
+	if db == nil {
+		return Recorder{}
+	}
+	return NewRecorder(db.GetDBPath(), db.UnsafeGetSQLDb())
+}
+
+func (r Recorder) Capture(ctx context.Context, includeDB bool) Snapshot {
+	s := Snapshot{At: time.Now()}
+	if ioStats, ok := readProcessIO(); ok {
+		s.IO = ioStats
+		s.IOOK = true
+	}
+	s.Runtime = readRuntimeStats()
+	if includeDB {
+		if dbStats, ok := readDBStats(ctx, r.dbPath, r.sqlDB); ok {
+			s.DB = dbStats
+			s.DBOK = true
+		}
+	}
+	return s
+}
+
+func AddDelta(event *zerolog.Event, start Snapshot, end Snapshot) *zerolog.Event {
+	event.Dur("wallDuration", end.At.Sub(start.At))
+
+	if start.IOOK && end.IOOK {
+		event.
+			Int64("procReadBytes", end.IO.ReadBytes-start.IO.ReadBytes).
+			Int64("procWriteBytes", end.IO.WriteBytes-start.IO.WriteBytes).
+			Int64("procReadSyscalls", end.IO.Syscr-start.IO.Syscr).
+			Int64("procWriteSyscalls", end.IO.Syscw-start.IO.Syscw).
+			Int64("procReadChars", end.IO.RChar-start.IO.RChar).
+			Int64("procWriteChars", end.IO.WChar-start.IO.WChar).
+			Int64("procCancelledWriteBytes", end.IO.CancelledWriteBytes-start.IO.CancelledWriteBytes)
+	}
+
+	event.
+		Uint64("allocBytes", end.Runtime.TotalAllocBytes-start.Runtime.TotalAllocBytes).
+		Uint64("mallocs", end.Runtime.Mallocs-start.Runtime.Mallocs).
+		Uint64("frees", end.Runtime.Frees-start.Runtime.Frees).
+		Uint32("gcCycles", end.Runtime.GCCycles-start.Runtime.GCCycles).
+		Uint64("gcPauseNs", end.Runtime.GCPauseNs-start.Runtime.GCPauseNs).
+		Int64("cgoCalls", end.Runtime.CgoCalls-start.Runtime.CgoCalls).
+		Uint64("heapAllocBytes", end.Runtime.HeapAllocBytes).
+		Uint64("heapSysBytes", end.Runtime.HeapSysBytes).
+		Uint64("heapObjects", end.Runtime.HeapObjects).
+		Int("goroutines", end.Runtime.Goroutines)
+
+	if end.DBOK {
+		event.
+			Int64("dbBytes", end.DB.DBBytes).
+			Int64("dbWalBytes", end.DB.WALBytes).
+			Int64("dbShmBytes", end.DB.SHMBytes).
+			Int64("dbPageCount", end.DB.PageCount).
+			Int64("dbFreelistCount", end.DB.FreelistCount).
+			Int64("dbPageSize", end.DB.PageSize).
+			Int64("dbCacheSize", end.DB.CacheSize).
+			Int64("dbWalBusy", end.DB.WALBusy).
+			Int64("dbWalFrames", end.DB.WALFrames).
+			Int64("dbWalCheckpointedFrames", end.DB.WALCheckpointedFrames)
+	}
+	if start.DBOK && end.DBOK {
+		event.
+			Int64("dbBytesDelta", end.DB.DBBytes-start.DB.DBBytes).
+			Int64("dbWalBytesDelta", end.DB.WALBytes-start.DB.WALBytes).
+			Int64("dbShmBytesDelta", end.DB.SHMBytes-start.DB.SHMBytes)
+	}
+
+	return event
+}
+
+func readProcessIO() (ProcessIO, bool) {
+	f, err := os.Open("/proc/self/io")
+	if err != nil {
+		return ProcessIO{}, false
+	}
+	defer func() { _ = f.Close() }()
+
+	var stats ProcessIO
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		name, raw, ok := strings.Cut(scanner.Text(), ":")
+		if !ok {
+			continue
+		}
+		value, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+		if err != nil {
+			continue
+		}
+		switch name {
+		case "rchar":
+			stats.RChar = value
+		case "wchar":
+			stats.WChar = value
+		case "syscr":
+			stats.Syscr = value
+		case "syscw":
+			stats.Syscw = value
+		case "read_bytes":
+			stats.ReadBytes = value
+		case "write_bytes":
+			stats.WriteBytes = value
+		case "cancelled_write_bytes":
+			stats.CancelledWriteBytes = value
+		}
+	}
+	return stats, scanner.Err() == nil
+}
+
+func readRuntimeStats() RuntimeStats {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return RuntimeStats{
+		AllocBytes:      mem.Alloc,
+		TotalAllocBytes: mem.TotalAlloc,
+		SysBytes:        mem.Sys,
+		HeapAllocBytes:  mem.HeapAlloc,
+		HeapSysBytes:    mem.HeapSys,
+		HeapObjects:     mem.HeapObjects,
+		Mallocs:         mem.Mallocs,
+		Frees:           mem.Frees,
+		GCCycles:        mem.NumGC,
+		GCPauseNs:       mem.PauseTotalNs,
+		Goroutines:      runtime.NumGoroutine(),
+		CgoCalls:        runtime.NumCgoCall(),
+	}
+}
+
+func readDBStats(ctx context.Context, dbPath string, sqlDB *sql.DB) (DBStats, bool) {
+	var stats DBStats
+	if dbPath != "" {
+		stats.DBBytes = fileSize(dbPath)
+		stats.WALBytes = fileSize(dbPath + "-wal")
+		stats.SHMBytes = fileSize(dbPath + "-shm")
+	}
+	if sqlDB == nil {
+		return stats, dbPath != ""
+	}
+
+	if v, ok := querySingleInt(ctx, sqlDB, "PRAGMA page_count;"); ok {
+		stats.PageCount = v
+	}
+	if v, ok := querySingleInt(ctx, sqlDB, "PRAGMA freelist_count;"); ok {
+		stats.FreelistCount = v
+	}
+	if v, ok := querySingleInt(ctx, sqlDB, "PRAGMA page_size;"); ok {
+		stats.PageSize = v
+	}
+	if v, ok := querySingleInt(ctx, sqlDB, "PRAGMA cache_size;"); ok {
+		stats.CacheSize = v
+	}
+	if busy, frames, checkpointed, ok := queryWALStats(ctx, sqlDB); ok {
+		stats.WALBusy = busy
+		stats.WALFrames = frames
+		stats.WALCheckpointedFrames = checkpointed
+	}
+	return stats, true
+}
+
+func fileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+func querySingleInt(ctx context.Context, db *sql.DB, query string) (int64, bool) {
+	var value int64
+	if err := db.QueryRowContext(ctx, query).Scan(&value); err != nil {
+		return 0, false
+	}
+	return value, true
+}
+
+func queryWALStats(ctx context.Context, db *sql.DB) (int64, int64, int64, bool) {
+	var busy, frames, checkpointed int64
+	if err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint(NOOP);").Scan(&busy, &frames, &checkpointed); err != nil {
+		return 0, 0, 0, false
+	}
+	return busy, frames, checkpointed, true
+}

--- a/pkg/database/perfmetrics/perfmetrics.go
+++ b/pkg/database/perfmetrics/perfmetrics.go
@@ -1,6 +1,21 @@
 // Zaparoo Core
 // Copyright (c) 2026 The Zaparoo Project Contributors.
 // SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
 // Package perfmetrics captures coarse process and SQLite resource counters for
 // long media operations. Snapshots are best-effort: missing /proc support or
@@ -68,8 +83,8 @@ type Snapshot struct {
 }
 
 type Recorder struct {
-	dbPath string
 	sqlDB  *sql.DB
+	dbPath string
 }
 
 func NewRecorder(dbPath string, sqlDB *sql.DB) Recorder {
@@ -109,7 +124,7 @@ func (r Recorder) Capture(ctx context.Context, includeDB bool) Snapshot {
 	return s
 }
 
-func AddDelta(event *zerolog.Event, start Snapshot, end Snapshot) *zerolog.Event {
+func AddDelta(event *zerolog.Event, start, end *Snapshot) *zerolog.Event {
 	event.Dur("wallDuration", end.At.Sub(start.At))
 
 	if start.IOOK && end.IOOK {
@@ -238,10 +253,10 @@ func readDBStats(ctx context.Context, dbPath string, sqlDB *sql.DB) (DBStats, bo
 	if v, ok := querySingleInt(ctx, sqlDB, "PRAGMA cache_size;"); ok {
 		stats.CacheSize = v
 	}
-	if busy, frames, checkpointed, ok := queryWALStats(ctx, sqlDB); ok {
-		stats.WALBusy = busy
-		stats.WALFrames = frames
-		stats.WALCheckpointedFrames = checkpointed
+	if walStats, ok := queryWALStats(ctx, sqlDB); ok {
+		stats.WALBusy = walStats.busy
+		stats.WALFrames = walStats.frames
+		stats.WALCheckpointedFrames = walStats.checkpointed
 	}
 	return stats, true
 }
@@ -262,10 +277,20 @@ func querySingleInt(ctx context.Context, db *sql.DB, query string) (int64, bool)
 	return value, true
 }
 
-func queryWALStats(ctx context.Context, db *sql.DB) (int64, int64, int64, bool) {
-	var busy, frames, checkpointed int64
-	if err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint(NOOP);").Scan(&busy, &frames, &checkpointed); err != nil {
-		return 0, 0, 0, false
+type walCheckpointStats struct {
+	busy         int64
+	frames       int64
+	checkpointed int64
+}
+
+func queryWALStats(ctx context.Context, db *sql.DB) (walCheckpointStats, bool) {
+	var stats walCheckpointStats
+	if err := db.QueryRowContext(ctx, "PRAGMA wal_checkpoint(NOOP);").Scan(
+		&stats.busy,
+		&stats.frames,
+		&stats.checkpointed,
+	); err != nil {
+		return walCheckpointStats{}, false
 	}
-	return busy, frames, checkpointed, true
+	return stats, true
 }

--- a/pkg/database/perfmetrics/perfmetrics_test.go
+++ b/pkg/database/perfmetrics/perfmetrics_test.go
@@ -1,0 +1,211 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package perfmetrics
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type panicDBProvider struct{}
+
+func (panicDBProvider) GetDBPath() string {
+	panic("unexpected GetDBPath call")
+}
+
+func (panicDBProvider) UnsafeGetSQLDb() *sql.DB {
+	panic("unexpected UnsafeGetSQLDb call")
+}
+
+func TestNewRecorderForDB_RecoversFromProviderPanic(t *testing.T) {
+	t.Parallel()
+
+	recorder := NewRecorderForDB(panicDBProvider{})
+
+	assert.Equal(t, Recorder{}, recorder)
+}
+
+func TestReadDBStats_CombinesFileAndSQLiteStats(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "media.db")
+	require.NoError(t, writeSizedFile(dbPath, 11))
+	require.NoError(t, writeSizedFile(dbPath+"-wal", 17))
+	require.NoError(t, writeSizedFile(dbPath+"-shm", 23))
+
+	mock.ExpectQuery(`PRAGMA page_count;`).
+		WillReturnRows(sqlmock.NewRows([]string{"page_count"}).AddRow(101))
+	mock.ExpectQuery(`PRAGMA freelist_count;`).
+		WillReturnRows(sqlmock.NewRows([]string{"freelist_count"}).AddRow(7))
+	mock.ExpectQuery(`PRAGMA page_size;`).
+		WillReturnRows(sqlmock.NewRows([]string{"page_size"}).AddRow(4096))
+	mock.ExpectQuery(`PRAGMA cache_size;`).
+		WillReturnRows(sqlmock.NewRows([]string{"cache_size"}).AddRow(-32768))
+	mock.ExpectQuery(`PRAGMA wal_checkpoint\(NOOP\);`).
+		WillReturnRows(sqlmock.NewRows([]string{"busy", "log", "checkpointed"}).AddRow(0, 12, 9))
+
+	stats, ok := readDBStats(context.Background(), dbPath, db)
+
+	require.True(t, ok)
+	assert.Equal(t, int64(11), stats.DBBytes)
+	assert.Equal(t, int64(17), stats.WALBytes)
+	assert.Equal(t, int64(23), stats.SHMBytes)
+	assert.Equal(t, int64(101), stats.PageCount)
+	assert.Equal(t, int64(7), stats.FreelistCount)
+	assert.Equal(t, int64(4096), stats.PageSize)
+	assert.Equal(t, int64(-32768), stats.CacheSize)
+	assert.Equal(t, int64(0), stats.WALBusy)
+	assert.Equal(t, int64(12), stats.WALFrames)
+	assert.Equal(t, int64(9), stats.WALCheckpointedFrames)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAddDelta_LogsProcessRuntimeAndDBDeltas(t *testing.T) {
+	t.Parallel()
+
+	start := Snapshot{
+		At: time.Unix(100, 0),
+		IO: ProcessIO{
+			RChar:               100,
+			WChar:               200,
+			Syscr:               3,
+			Syscw:               4,
+			ReadBytes:           1000,
+			WriteBytes:          2000,
+			CancelledWriteBytes: 5,
+		},
+		Runtime: RuntimeStats{
+			TotalAllocBytes: 10,
+			Mallocs:         20,
+			Frees:           5,
+			GCCycles:        1,
+			GCPauseNs:       100,
+			CgoCalls:        7,
+		},
+		DB: DBStats{
+			DBBytes:  100,
+			WALBytes: 10,
+			SHMBytes: 20,
+		},
+		IOOK: true,
+		DBOK: true,
+	}
+	end := Snapshot{
+		At: time.Unix(100, int64(50*time.Millisecond)),
+		IO: ProcessIO{
+			RChar:               150,
+			WChar:               275,
+			Syscr:               8,
+			Syscw:               10,
+			ReadBytes:           1300,
+			WriteBytes:          2600,
+			CancelledWriteBytes: 9,
+		},
+		Runtime: RuntimeStats{
+			TotalAllocBytes: 40,
+			HeapAllocBytes:  400,
+			HeapSysBytes:    800,
+			HeapObjects:     12,
+			Mallocs:         29,
+			Frees:           11,
+			GCCycles:        3,
+			GCPauseNs:       175,
+			Goroutines:      4,
+			CgoCalls:        17,
+		},
+		DB: DBStats{
+			DBBytes:               125,
+			WALBytes:              30,
+			SHMBytes:              20,
+			PageCount:             50,
+			FreelistCount:         2,
+			PageSize:              4096,
+			CacheSize:             -32768,
+			WALBusy:               0,
+			WALFrames:             6,
+			WALCheckpointedFrames: 5,
+		},
+		IOOK: true,
+		DBOK: true,
+	}
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+	AddDelta(logger.Info(), &start, &end).Msg("metrics")
+
+	var fields map[string]any
+	decoder := json.NewDecoder(&buf)
+	decoder.UseNumber()
+	require.NoError(t, decoder.Decode(&fields))
+	assertJSONNumber(t, fields, "procReadBytes", "300")
+	assertJSONNumber(t, fields, "procWriteBytes", "600")
+	assertJSONNumber(t, fields, "procReadSyscalls", "5")
+	assertJSONNumber(t, fields, "procWriteSyscalls", "6")
+	assertJSONNumber(t, fields, "procReadChars", "50")
+	assertJSONNumber(t, fields, "procWriteChars", "75")
+	assertJSONNumber(t, fields, "procCancelledWriteBytes", "4")
+	assertJSONNumber(t, fields, "allocBytes", "30")
+	assertJSONNumber(t, fields, "mallocs", "9")
+	assertJSONNumber(t, fields, "frees", "6")
+	assertJSONNumber(t, fields, "gcCycles", "2")
+	assertJSONNumber(t, fields, "gcPauseNs", "75")
+	assertJSONNumber(t, fields, "cgoCalls", "10")
+	assertJSONNumber(t, fields, "heapAllocBytes", "400")
+	assertJSONNumber(t, fields, "heapSysBytes", "800")
+	assertJSONNumber(t, fields, "heapObjects", "12")
+	assertJSONNumber(t, fields, "goroutines", "4")
+	assertJSONNumber(t, fields, "dbBytes", "125")
+	assertJSONNumber(t, fields, "dbWalBytes", "30")
+	assertJSONNumber(t, fields, "dbShmBytes", "20")
+	assertJSONNumber(t, fields, "dbBytesDelta", "25")
+	assertJSONNumber(t, fields, "dbWalBytesDelta", "20")
+	assertJSONNumber(t, fields, "dbShmBytesDelta", "0")
+}
+
+func assertJSONNumber(t *testing.T, fields map[string]any, name, expected string) {
+	t.Helper()
+	number, ok := fields[name].(json.Number)
+	require.True(t, ok, "field %s should be a JSON number", name)
+	assert.Equal(t, expected, number.String())
+}
+
+func writeSizedFile(path string, size int) error {
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), size), 0o600); err != nil {
+		return fmt.Errorf("write sized file: %w", err)
+	}
+	return nil
+}

--- a/pkg/database/perfmetrics/perfmetrics_test.go
+++ b/pkg/database/perfmetrics/perfmetrics_test.go
@@ -25,13 +25,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/rs/zerolog"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,11 +61,12 @@ func TestReadDBStats_CombinesFileAndSQLiteStats(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
+	fs := afero.NewOsFs()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "media.db")
-	require.NoError(t, writeSizedFile(dbPath, 11))
-	require.NoError(t, writeSizedFile(dbPath+"-wal", 17))
-	require.NoError(t, writeSizedFile(dbPath+"-shm", 23))
+	require.NoError(t, writeSizedFile(fs, dbPath, 11))
+	require.NoError(t, writeSizedFile(fs, dbPath+"-wal", 17))
+	require.NoError(t, writeSizedFile(fs, dbPath+"-shm", 23))
 
 	mock.ExpectQuery(`PRAGMA page_count;`).
 		WillReturnRows(sqlmock.NewRows([]string{"page_count"}).AddRow(101))
@@ -203,8 +204,8 @@ func assertJSONNumber(t *testing.T, fields map[string]any, name, expected string
 	assert.Equal(t, expected, number.String())
 }
 
-func writeSizedFile(path string, size int) error {
-	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), size), 0o600); err != nil {
+func writeSizedFile(fs afero.Fs, path string, size int) error {
+	if err := afero.WriteFile(fs, path, bytes.Repeat([]byte("x"), size), 0o600); err != nil {
 		return fmt.Errorf("write sized file: %w", err)
 	}
 	return nil

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -989,8 +989,8 @@ func (g *GamelistXMLScraper) scrapeLoop(
 				Dur("avgWriteDuration", regularWriteStats.averageDuration()).
 				Dur("maxWriteDuration", regularWriteStats.MaxDuration).
 				Int("writes", regularWriteStats.Writes),
-			systemMetricsStart,
-			systemMetricsEnd,
+			&systemMetricsStart,
+			&systemMetricsEnd,
 		).Msg("gamelistxml: completed system scrape")
 		totalProcessed += companion.Processed + processed
 		totalMatched += companion.Matched + matched

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/perfmetrics"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
@@ -577,6 +578,7 @@ func (g *GamelistXMLScraper) scrapeLoop(
 	defer close(ch)
 
 	const id = "gamelist.xml"
+	metrics := perfmetrics.NewRecorderForDB(mdb)
 	var totalProcessed, totalMatched, totalSkipped int
 	totalSteps := len(systems)
 
@@ -598,6 +600,10 @@ func (g *GamelistXMLScraper) scrapeLoop(
 
 	for i, system := range systems {
 		currentStep := i + 1
+		systemStart := time.Now()
+		systemMetricsStart := metrics.Capture(ctx, false)
+		var titleLoadDuration, allTitlesLoadDuration, mediaLoadDuration time.Duration
+		var scrapedIDsLoadDuration, parseDuration, recordLoadDuration time.Duration
 		sendUpdate := func(update scraper.ScrapeUpdate) {
 			update.TotalSteps = totalSteps
 			update.CurrentStep = currentStep
@@ -622,7 +628,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		titlesBySlug := make(map[string]database.MediaTitle)
 		allTitlesBySlug := make(map[string]database.MediaTitle)
 		if opts.Force {
+			titlesStart := time.Now()
 			allTitles, titlesErr := mdb.GetTitlesBySystemID(system.ID)
+			titleLoadDuration = time.Since(titlesStart)
 			if titlesErr != nil {
 				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
 					sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -641,7 +649,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		} else {
 			sentinel := scraper.SentinelTagInfo(id)
 			sentinelTag := sentinel.Type + ":" + sentinel.Tag
+			titlesStart := time.Now()
 			unscraped, titlesErr := mdb.FindMediaTitlesWithoutSentinel(ctx, system.DBID, sentinelTag)
+			titleLoadDuration = time.Since(titlesStart)
 			if titlesErr != nil {
 				if errors.Is(titlesErr, context.Canceled) || errors.Is(titlesErr, context.DeadlineExceeded) {
 					sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -653,7 +663,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			for _, t := range unscraped {
 				titlesBySlug[t.Slug] = t
 			}
+			allTitlesStart := time.Now()
 			allTitles, allTitlesErr := mdb.GetTitlesBySystemID(system.ID)
+			allTitlesLoadDuration = time.Since(allTitlesStart)
 			if allTitlesErr != nil {
 				if errors.Is(allTitlesErr, context.Canceled) || errors.Is(allTitlesErr, context.DeadlineExceeded) {
 					sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -669,7 +681,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 		}
 
+		mediaStart := time.Now()
 		allMedia, mediaErr := mdb.GetMediaBySystemID(system.ID)
+		mediaLoadDuration = time.Since(mediaStart)
 		if mediaErr != nil {
 			if errors.Is(mediaErr, context.Canceled) || errors.Is(mediaErr, context.DeadlineExceeded) {
 				sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -682,7 +696,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		if opts.Force {
 			if shouldUseRunMarker(opts) {
 				var scrapeRunErr error
+				scrapedIDsStart := time.Now()
 				scrapedIDs, scrapeRunErr = mdb.GetScrapeRunMediaIDs(ctx, id, opts.RunID, system.DBID)
+				scrapedIDsLoadDuration = time.Since(scrapedIDsStart)
 				if scrapeRunErr != nil {
 					if errors.Is(scrapeRunErr, context.Canceled) || errors.Is(scrapeRunErr, context.DeadlineExceeded) {
 						sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -694,7 +710,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 		} else {
 			var scrapedErr error
+			scrapedIDsStart := time.Now()
 			scrapedIDs, scrapedErr = mdb.GetScrapedMediaIDs(ctx, id, system.DBID)
+			scrapedIDsLoadDuration = time.Since(scrapedIDsStart)
 			if scrapedErr != nil {
 				if errors.Is(scrapedErr, context.Canceled) || errors.Is(scrapedErr, context.DeadlineExceeded) {
 					sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -728,7 +746,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			}
 		}
 
+		parseStart := time.Now()
 		parsed, parseErr := g.loadParsedGamelistSystem(ctx, system)
+		parseDuration = time.Since(parseStart)
 		if parseErr != nil {
 			if errors.Is(parseErr, context.Canceled) || errors.Is(parseErr, context.DeadlineExceeded) {
 				sendUpdate(scraper.ScrapeUpdate{SystemID: system.ID, Done: true})
@@ -763,7 +783,9 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			continue
 		}
 
+		recordLoadStart := time.Now()
 		records, loadErr := g.loadRecordsFromParsed(ctx, system, indexes, parsed)
+		recordLoadDuration = time.Since(recordLoadStart)
 		if loadErr != nil {
 			if errors.Is(loadErr, context.Canceled) || errors.Is(loadErr, context.DeadlineExceeded) {
 				sendUpdate(scraper.ScrapeUpdate{
@@ -944,6 +966,32 @@ func (g *GamelistXMLScraper) scrapeLoop(
 			return
 		}
 		logScrapeWriteStats("gamelistxml: regular write stats", system.ID, &regularWriteStats)
+		systemMetricsEnd := metrics.Capture(ctx, false)
+		perfmetrics.AddDelta(
+			log.Info().
+				Str("scraper", id).
+				Str("system", system.ID).
+				Int("records", totalRecords).
+				Int("companionProcessed", companion.Processed).
+				Int("processed", companion.Processed+processed).
+				Int("matched", companion.Matched+matched).
+				Int("skipped", companion.Skipped+skipped).
+				Int("titleCandidates", len(titlesBySlug)).
+				Int("mediaCandidates", len(indexes.MediaByPathFold)).
+				Dur("elapsed", time.Since(systemStart)).
+				Dur("titleLoadDuration", titleLoadDuration).
+				Dur("allTitlesLoadDuration", allTitlesLoadDuration).
+				Dur("mediaLoadDuration", mediaLoadDuration).
+				Dur("scrapedIDsLoadDuration", scrapedIDsLoadDuration).
+				Dur("parseDuration", parseDuration).
+				Dur("recordLoadDuration", recordLoadDuration).
+				Dur("writeDuration", regularWriteStats.TotalDuration).
+				Dur("avgWriteDuration", regularWriteStats.averageDuration()).
+				Dur("maxWriteDuration", regularWriteStats.MaxDuration).
+				Int("writes", regularWriteStats.Writes),
+			systemMetricsStart,
+			systemMetricsEnd,
+		).Msg("gamelistxml: completed system scrape")
 		totalProcessed += companion.Processed + processed
 		totalMatched += companion.Matched + matched
 		totalSkipped += companion.Skipped + skipped


### PR DESCRIPTION
## Summary
- add best-effort process/runtime/SQLite metrics around media indexing and gamelist scraping
- replace synchronous/background ANALYZE work with PRAGMA optimize while keeping WAL FULL durability unchanged
- tune hot media/tag queries and system tag cache population using existing indexes
- remove debug-only browse-cache per-system count scan from background optimization

## Verification
- task lint-fix
- go test ./pkg/database/mediadb ./pkg/database/perfmetrics ./pkg/database/mediascanner ./pkg/database/scraper/gamelistxml

## Field results
- full MiSTer index observed around 8m09s with new metrics
- background optimization reduced from roughly 4m23s to 1m37s after replacing full ANALYZE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end performance metrics and detailed phase timings for media indexing and scraping.

* **Improvements**
  * Improved database query plans and index usage for media and tag lookups.
  * Background planner maintenance now uses a more robust optimize routine with retries.

* **Other Changes**
  * System-tags cache rebuild refactored to transactional, incremental upserts.
  * Removed per-system diagnostic counts from browse-cache rebuilds; tests updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->