### PR TITLE
test(scraper): stabilize pause cancel progress test

### DIFF
--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
@@ -3069,10 +3070,25 @@ func TestScrapeLoop_PauseCancelBeforeNextSystemPreservesProgress(t *testing.T) {
 	}()
 
 	<-paused
+
+	updates := make([]scraper.ScrapeUpdate, 0)
+	waitCtx, stopWaiting := context.WithTimeout(context.Background(), time.Second)
+	defer stopWaiting()
+	for waiting := true; waiting; {
+		select {
+		case update, ok := <-ch:
+			require.True(t, ok, "scrape loop ended before completing nes progress")
+			updates = append(updates, update)
+			waiting = update.SystemID != "nes" || update.Processed != 1 || update.Matched != 1 || update.Done
+		case <-waitCtx.Done():
+			require.FailNow(t, "timed out waiting for completed nes progress")
+		}
+	}
+
 	cancel()
 	<-done
+	updates = append(updates, drainChannel(ch)...)
 
-	updates := drainChannel(ch)
 	var doneUpdate scraper.ScrapeUpdate
 	for _, update := range updates {
 		if update.Done {


### PR DESCRIPTION
Stabilizes the flaky gamelistxml pause/cancel progress test. The test now waits until NES progress has been emitted before canceling, so cancellation is observed while paused before SNES instead of racing current-system progress emission.\n\nVerified locally with:\n- go test -tags=deadlock -race -count=50 -run TestScrapeLoop_PauseCancelBeforeNextSystemPreservesProgress ./pkg/database/scraper/gamelistxml\n- go test ./pkg/database/scraper/gamelistxml\n- go test -tags=deadlock -race -count=1 ./pkg/database/scraper/gamelistxml\n- task lint-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scraper synchronization testing with enhanced timeout-based assertions to ensure progress is properly tracked and preserved during cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->