### PR TITLE
perf(database): speed up media browse, history, and favorites queries

### DIFF
--- a/pkg/api/methods/media_active_test.go
+++ b/pkg/api/methods/media_active_test.go
@@ -117,10 +117,8 @@ func TestHandleActiveMedia_WithZapScript(t *testing.T) {
 			if tt.setupMock != nil {
 				tt.setupMock(mockMediaDB)
 			}
-			mockMediaDB.On("FindSystemBySystemID", mock.Anything).
-				Return(database.System{}, errors.New("not found")).Maybe()
-			mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
-				Return(map[string]database.Media{}, nil).Maybe()
+			mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, mock.Anything).
+				Return([]database.MediaPathID{}, nil).Maybe()
 
 			// Create state and set active media
 			appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
@@ -242,10 +240,8 @@ func TestHandleMedia_WithActiveMediaZapScript(t *testing.T) {
 			if tt.setupMock != nil {
 				tt.setupMock(mockMediaDB)
 			}
-			mockMediaDB.On("FindSystemBySystemID", mock.Anything).
-				Return(database.System{}, errors.New("not found")).Maybe()
-			mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, mock.Anything, mock.Anything).
-				Return(map[string]database.Media{}, nil).Maybe()
+			mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, mock.Anything).
+				Return([]database.MediaPathID{}, nil).Maybe()
 
 			// Standard mocks needed for HandleMedia to work
 			// GetOptimizationStatus is always called
@@ -316,9 +312,8 @@ func TestHandleActiveMedia_WithMediaIDAndRelativePath(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
 		Return([]database.TagInfo{}, nil)
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
-	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
-		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 
 	env := requests.RequestEnv{
 		Context:       context.Background(),
@@ -364,9 +359,8 @@ func TestHandleMedia_WithActiveMediaIDAndRelativePath(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetZapScriptTagsBySystemAndPath", mock.Anything, "NES", mediaPath).
 		Return([]database.TagInfo{}, nil)
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
-	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
-		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 	mockMediaDB.On("GetOptimizationStatus").Return("", nil)
 	mockMediaDB.On("GetLastGenerated").Return(time.Now(), nil)
 	mockMediaDB.On("GetTotalMediaCount").Return(100, nil)

--- a/pkg/api/methods/media_history.go
+++ b/pkg/api/methods/media_history.go
@@ -74,11 +74,13 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	}
 
 	// Fetch one extra to detect next page
+	queryStarted := time.Now()
 	entries, err := env.Database.UserDB.GetMediaHistory(systemIDs, lastID, limit+1)
 	if err != nil {
 		log.Error().Err(err).Msg("error getting media history")
 		return nil, fmt.Errorf("error getting media history: %w", err)
 	}
+	queryElapsed := time.Since(queryStarted)
 
 	hasNextPage := len(entries) > limit
 	if hasNextPage {
@@ -91,8 +93,11 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 			Path:     entries[i].MediaPath,
 		})
 	}
+	enrichStarted := time.Now()
 	mediaIDs := mediaResponseMediaIDs(&env, mediaRefs)
+	enrichElapsed := time.Since(enrichStarted)
 
+	buildStarted := time.Now()
 	responseEntries := make([]models.MediaHistoryResponseEntry, 0, len(entries))
 	for i := range entries {
 		entry := &entries[i]
@@ -118,6 +123,13 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 			PlayTime:   entry.PlayTime,
 		})
 	}
+
+	log.Debug().
+		Int("entries", len(responseEntries)).
+		Dur("queryDuration", queryElapsed).
+		Dur("enrichDuration", enrichElapsed).
+		Dur("buildDuration", time.Since(buildStarted)).
+		Msg("media history handler step timing")
 
 	var pagination *models.PaginationInfo
 	if len(responseEntries) > 0 {

--- a/pkg/api/methods/media_history_test.go
+++ b/pkg/api/methods/media_history_test.go
@@ -125,9 +125,8 @@ func TestHandleMediaHistory_WithMediaIDAndRelativePath(t *testing.T) {
 			PlayTime:   60,
 		},
 	}, nil)
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil)
-	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath, missingPath}).
-		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath, missingPath}).
+		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42}}, nil)
 
 	env := requests.RequestEnv{
 		Context:       context.Background(),
@@ -159,8 +158,7 @@ func TestMediaResponseMediaIDs_BoundsSlowLookup(t *testing.T) {
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mediaPath := filepath.Join(string(filepath.Separator), "games", "slow.nes")
-	mockMediaDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 10}, nil).Once()
-	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
 		Run(func(args mock.Arguments) {
 			ctx, ok := args.Get(0).(context.Context)
 			require.True(t, ok)

--- a/pkg/api/methods/media_history_top_test.go
+++ b/pkg/api/methods/media_history_top_test.go
@@ -106,9 +106,8 @@ func TestHandleMediaHistoryTop_WithMediaIDAndRelativePath(t *testing.T) {
 			LastPlayedAt:  now,
 		},
 	}, nil)
-	mockMediaDB.On("FindSystemBySystemID", "SNES").Return(database.System{DBID: 10}, nil)
-	mockMediaDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(10), []string{mediaPath}).
-		Return(map[string]database.Media{mediaPath: {DBID: 42}}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42}}, nil)
 
 	env := requests.RequestEnv{
 		Context:       context.Background(),

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -69,36 +69,47 @@ func mediaIDsByPath(ctx context.Context, db database.MediaDBI, refs []mediaPathR
 		return nil
 	}
 
-	pathsBySystem := make(map[string][]string)
-	seen := make(map[mediaPathRef]bool)
+	wanted := make(map[mediaPathRef]bool, len(refs))
+	paths := make([]string, 0, len(refs))
+	seenPaths := make(map[string]bool, len(refs))
 	for _, ref := range refs {
-		if ref.SystemID == "" || ref.Path == "" || seen[ref] {
+		if ref.SystemID == "" || ref.Path == "" || wanted[ref] {
 			continue
 		}
-		seen[ref] = true
-		pathsBySystem[ref.SystemID] = append(pathsBySystem[ref.SystemID], ref.Path)
-	}
-
-	mediaIDs := make(map[mediaPathRef]int64)
-	for systemID, paths := range pathsBySystem {
-		system, err := db.FindSystemBySystemID(systemID)
-		if err != nil {
-			log.Debug().Err(err).Str("system", systemID).Msg("could not resolve media IDs for system")
-			continue
-		}
-
-		mediaByPath, err := db.FindMediaBySystemAndPaths(ctx, system.DBID, paths)
-		if err != nil {
-			log.Debug().Err(err).Str("system", systemID).Msg("could not resolve media IDs by path")
-			continue
-		}
-
-		for path, media := range mediaByPath {
-			if media.DBID > 0 {
-				mediaIDs[mediaPathRef{SystemID: systemID, Path: path}] = media.DBID
-			}
+		wanted[ref] = true
+		if !seenPaths[ref.Path] {
+			seenPaths[ref.Path] = true
+			paths = append(paths, ref.Path)
 		}
 	}
+	if len(paths) == 0 {
+		return nil
+	}
+
+	started := time.Now()
+	rows, err := db.FindMediaIDsByPaths(ctx, paths)
+	if err != nil {
+		log.Debug().Err(err).Msg("could not resolve media IDs by path")
+		return nil
+	}
+
+	mediaIDs := make(map[mediaPathRef]int64, len(rows))
+	for _, row := range rows {
+		if row.DBID <= 0 {
+			continue
+		}
+		ref := mediaPathRef{SystemID: row.SystemID, Path: row.Path}
+		if wanted[ref] {
+			mediaIDs[ref] = row.DBID
+		}
+	}
+
+	log.Debug().
+		Int("refs", len(refs)).
+		Int("paths", len(paths)).
+		Int("resolved", len(mediaIDs)).
+		Dur("duration", time.Since(started)).
+		Msg("media ID enrichment timing")
 
 	return mediaIDs
 }

--- a/pkg/api/methods/media_response_helpers_test.go
+++ b/pkg/api/methods/media_response_helpers_test.go
@@ -21,7 +21,6 @@ package methods
 
 import (
 	"context"
-	"database/sql"
 	"path/filepath"
 	"testing"
 
@@ -45,11 +44,10 @@ func TestMediaIDsByPath_DeduplicatesRefsAndSkipsInvalidRefs(t *testing.T) {
 		{SystemID: "NES", Path: ""},
 	}
 
-	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 7, SystemID: "NES"}, nil)
-	mockDB.On("FindMediaBySystemAndPaths", mock.Anything, int64(7), []string{pathOne, pathTwo}).Return(
-		map[string]database.Media{
-			pathOne: {DBID: 10, Path: pathOne},
-			pathTwo: {DBID: 11, Path: pathTwo},
+	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{pathOne, pathTwo}).Return(
+		[]database.MediaPathID{
+			{SystemID: "NES", Path: pathOne, DBID: 10},
+			{SystemID: "NES", Path: pathTwo, DBID: 11},
 		}, nil,
 	)
 
@@ -62,15 +60,25 @@ func TestMediaIDsByPath_DeduplicatesRefsAndSkipsInvalidRefs(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
-func TestMediaIDsByPath_SkipsUnresolvableSystems(t *testing.T) {
+func TestMediaIDsByPath_IgnoresRowsForUnrequestedSystems(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
-	path := filepath.Join("games", "missing.rom")
-	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{}, sql.ErrNoRows)
+	path := filepath.Join("games", "shared.rom")
+
+	// The same path can exist under multiple systems; only the requested
+	// (system, path) pair should be resolved.
+	mockDB.On("FindMediaIDsByPaths", mock.Anything, []string{path}).Return(
+		[]database.MediaPathID{
+			{SystemID: "NES", Path: path, DBID: 10},
+			{SystemID: "FDS", Path: path, DBID: 22},
+		}, nil,
+	)
 
 	ids := mediaIDsByPath(context.Background(), mockDB, []mediaPathRef{{SystemID: "NES", Path: path}})
 
-	assert.Empty(t, ids)
+	assert.Equal(t, map[mediaPathRef]int64{
+		{SystemID: "NES", Path: path}: 10,
+	}, ids)
 	mockDB.AssertExpectations(t)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -911,7 +911,13 @@ func processRequestObject(
 		}
 
 		// ID is present (could be null or valid value) - this is a request that needs a response
+		started := time.Now()
 		resp, rpcError := handleRequest(methodMap, env, req)
+		log.Debug().
+			Str("method", req.Method).
+			Dur("duration", time.Since(started)).
+			Bool("error", rpcError != nil).
+			Msg("api request handled")
 		if rpcError != nil {
 			return requestResult{ID: req.ID, Error: rpcError, ShouldReply: true}
 		}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -169,6 +169,14 @@ type MediaFullRow struct {
 	Title MediaTitle
 }
 
+// MediaPathID identifies a Media row by its system ID and path, used for batch
+// media-ID resolution of API responses.
+type MediaPathID struct {
+	SystemID string
+	Path     string
+	DBID     int64
+}
+
 type TagType struct {
 	Type        string
 	DBID        int64
@@ -775,6 +783,9 @@ type MediaDBI interface {
 	// or nil, nil when no row is found.
 	FindMediaBySystemAndPath(ctx context.Context, systemDBID int64, path string) (*Media, error)
 	FindMediaBySystemAndPaths(ctx context.Context, systemDBID int64, paths []string) (map[string]Media, error)
+	// FindMediaIDsByPaths returns the system ID, path, and DBID of every Media
+	// row whose Path is in paths, in a single query across all systems.
+	FindMediaIDsByPaths(ctx context.Context, paths []string) ([]MediaPathID, error)
 	// FindSingleContainerLaunchMedia returns the one logical launch target in the
 	// direct contents of containerPath for systemDBID, or nil, nil when the
 	// container is empty, nested-only, or ambiguous.

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -154,6 +154,7 @@ type invalidationScope struct {
 // invalidateCaches handles all cache invalidation in one place
 func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 	db.inMemoryTagCache.Store(nil)
+	clearPrefixPolicyCache()
 	if scope.UtilityTagDBIDsChanged {
 		clearUtilityTagCache()
 		db.utilityTagCacheDirty = false
@@ -307,6 +308,7 @@ func (db *MediaDB) Open() error {
 	sqlInstance.SetMaxOpenConns(2)
 	db.sql = sqlInstance
 	clearUtilityTagCache()
+	clearPrefixPolicyCache()
 
 	if !exists {
 		log.Debug().Msg("media database is new, allocating schema")
@@ -879,6 +881,7 @@ func (db *MediaDB) Close() error {
 
 	logSQLTraceSummary()
 	clearUtilityTagCacheFor(db.sql)
+	clearPrefixPolicyCacheFor(db.sql)
 
 	err := db.sql.Close()
 	if err != nil {
@@ -922,6 +925,7 @@ func (db *MediaDB) cacheInvalidationScopeForCommittedTransaction() invalidationS
 func (db *MediaDB) SetSQLForTesting(ctx context.Context, sqlDB *sql.DB, platform platforms.Platform) error {
 	db.sql = sqlDB
 	clearUtilityTagCache()
+	clearPrefixPolicyCache()
 	db.ctx = ctx
 	db.pl = platform
 	db.clock = clockwork.NewRealClock()

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -83,6 +83,72 @@ func clearUtilityTagCacheFor(db sqlQueryable) {
 	}
 }
 
+// prefixPolicyCache memoises detected browse prefix policies per DB handle and
+// directory. Detection reads every Media.Path in the directory, which costs
+// 40-70ms per browse on SD-card hardware; the policy only changes when media
+// is reindexed, so it is cached until invalidateCaches clears it. Keyed by the
+// db handle itself for the same reason as utilityTagCacheMap.
+var (
+	prefixPolicyCacheMu  syncutil.RWMutex
+	prefixPolicyCacheMap map[sqlQueryable]map[string]browseprefix.Policy
+)
+
+func clearPrefixPolicyCache() {
+	prefixPolicyCacheMu.Lock()
+	defer prefixPolicyCacheMu.Unlock()
+	prefixPolicyCacheMap = nil
+}
+
+func clearPrefixPolicyCacheFor(db sqlQueryable) {
+	if db == nil {
+		return
+	}
+
+	prefixPolicyCacheMu.Lock()
+	defer prefixPolicyCacheMu.Unlock()
+	if prefixPolicyCacheMap == nil {
+		return
+	}
+	delete(prefixPolicyCacheMap, db)
+	if len(prefixPolicyCacheMap) == 0 {
+		prefixPolicyCacheMap = nil
+	}
+}
+
+func prefixPolicyCacheKey(pathPrefix string, systems []systemdefs.System) string {
+	if len(systems) == 0 {
+		return pathPrefix
+	}
+	ids := make([]string, len(systems))
+	for i, sys := range systems {
+		ids[i] = sys.ID
+	}
+	sort.Strings(ids)
+	return pathPrefix + "\x00" + strings.Join(ids, "\x00")
+}
+
+func cachedPrefixPolicy(db sqlQueryable, key string) (browseprefix.Policy, bool) {
+	prefixPolicyCacheMu.RLock()
+	defer prefixPolicyCacheMu.RUnlock()
+	if prefixPolicyCacheMap == nil {
+		return browseprefix.Policy{}, false
+	}
+	policy, ok := prefixPolicyCacheMap[db][key]
+	return policy, ok
+}
+
+func storePrefixPolicy(db sqlQueryable, key string, policy browseprefix.Policy) {
+	prefixPolicyCacheMu.Lock()
+	defer prefixPolicyCacheMu.Unlock()
+	if prefixPolicyCacheMap == nil {
+		prefixPolicyCacheMap = make(map[sqlQueryable]map[string]browseprefix.Policy)
+	}
+	if prefixPolicyCacheMap[db] == nil {
+		prefixPolicyCacheMap[db] = make(map[string]browseprefix.Policy)
+	}
+	prefixPolicyCacheMap[db][key] = policy
+}
+
 // resolveUtilityTagDBIDs returns a map from DB tag DBID → TagInfo for each
 // entry in tags.UtilityTags. Results are memoised per db handle so each
 // MediaDB instance (or test mock) has its own cache slot, and
@@ -498,10 +564,16 @@ func resolveBrowseSortMode(ctx context.Context, db sqlQueryable, opts *database.
 		return opts.Sort
 	}
 
-	policy, err := detectBrowsePrefixPolicy(ctx, db, opts.PathPrefix, opts.Systems)
-	if err != nil {
-		log.Debug().Err(err).Str("path", opts.PathPrefix).Msg("browse prefix policy detection failed")
-		return opts.Sort
+	cacheKey := prefixPolicyCacheKey(opts.PathPrefix, opts.Systems)
+	policy, cached := cachedPrefixPolicy(db, cacheKey)
+	if !cached {
+		var err error
+		policy, err = detectBrowsePrefixPolicy(ctx, db, opts.PathPrefix, opts.Systems)
+		if err != nil {
+			log.Debug().Err(err).Str("path", opts.PathPrefix).Msg("browse prefix policy detection failed")
+			return opts.Sort
+		}
+		storePrefixPolicy(db, cacheKey, policy)
 	}
 	if !policy.Enabled {
 		return opts.Sort
@@ -574,7 +646,9 @@ func sqlBrowseFilesFromMedia(
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
 	where, args := browseFilesBaseCondition(opts)
+	sortModeStarted := time.Now()
 	sortMode := resolveBrowseSortMode(ctx, db, opts)
+	sortModeElapsed := time.Since(sortModeStarted)
 	sortExpr := browseSortExpr(sortMode)
 	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, ` + sortExpr + ` AS SortValue
 		FROM Media m
@@ -625,13 +699,16 @@ func sqlBrowseFilesFromMedia(
 	}
 	tagsElapsed := time.Since(tagsStarted)
 
+	coverFlagsStarted := time.Now()
 	if err := fetchAndAttachCoverFlags(ctx, db, results); err != nil {
 		return nil, fmt.Errorf("browse files cover flags: %w", err)
 	}
+	coverFlagsElapsed := time.Since(coverFlagsStarted)
 
 	// Disambiguate sibling variants: same SystemID+Name within the page get
 	// ZapScriptTags populated so the tag-write path can produce unambiguous
 	// ZapScript strings. Zero extra queries when there are no siblings (typical).
+	siblingsStarted := time.Now()
 	if err := fetchAndDisambiguateSiblings(ctx, db, results); err != nil {
 		return nil, fmt.Errorf("browse files sibling disambiguation: %w", err)
 	}
@@ -640,8 +717,11 @@ func sqlBrowseFilesFromMedia(
 		Str("pathPrefix", opts.PathPrefix).
 		Strs("systems", browseSystemIDsForLog(opts.Systems)).
 		Int("rows", len(results)).
+		Dur("sortModeDuration", sortModeElapsed).
 		Dur("queryDuration", queryElapsed).
 		Dur("tagsDuration", tagsElapsed).
+		Dur("coverFlagsDuration", coverFlagsElapsed).
+		Dur("siblingsDuration", time.Since(siblingsStarted)).
 		Msg("browse files step timing")
 	return results, nil
 }

--- a/pkg/database/mediadb/sql_browse_cache_test.go
+++ b/pkg/database/mediadb/sql_browse_cache_test.go
@@ -1,0 +1,125 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/browseprefix"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSQLQueryable struct {
+	id int
+}
+
+type fakeSQLResult struct{}
+
+func (fakeSQLResult) LastInsertId() (int64, error) {
+	return 0, nil
+}
+
+func (fakeSQLResult) RowsAffected() (int64, error) {
+	return 0, nil
+}
+
+func (*fakeSQLQueryable) ExecContext(context.Context, string, ...any) (sql.Result, error) {
+	return fakeSQLResult{}, nil
+}
+
+func (*fakeSQLQueryable) PrepareContext(context.Context, string) (*sql.Stmt, error) {
+	return &sql.Stmt{}, nil
+}
+
+func (*fakeSQLQueryable) QueryContext(context.Context, string, ...any) (*sql.Rows, error) {
+	return &sql.Rows{}, nil
+}
+
+func (*fakeSQLQueryable) QueryRowContext(context.Context, string, ...any) *sql.Row {
+	return nil
+}
+
+func TestPrefixPolicyCacheKeyNormalizesSystems(t *testing.T) {
+	pathPrefix := filepath.ToSlash(filepath.Join("roms", "nes"))
+	left := prefixPolicyCacheKey(pathPrefix, []systemdefs.System{{ID: "SNES"}, {ID: "NES"}})
+	right := prefixPolicyCacheKey(pathPrefix, []systemdefs.System{{ID: "NES"}, {ID: "SNES"}})
+
+	assert.Equal(t, left, right)
+	assert.Equal(t, pathPrefix, prefixPolicyCacheKey(pathPrefix, nil))
+	assert.Equal(t, pathPrefix, prefixPolicyCacheKey(pathPrefix, []systemdefs.System{}))
+}
+
+func TestPrefixPolicyCacheRoundTrip(t *testing.T) {
+	clearPrefixPolicyCache()
+	t.Cleanup(clearPrefixPolicyCache)
+
+	db := &fakeSQLQueryable{id: 1}
+	otherDB := &fakeSQLQueryable{id: 2}
+	key := prefixPolicyCacheKey(filepath.ToSlash(filepath.Join("roms", "nes")), []systemdefs.System{{ID: "NES"}})
+	otherKey := prefixPolicyCacheKey(filepath.ToSlash(filepath.Join("roms", "snes")), []systemdefs.System{{ID: "SNES"}})
+	policy := browseprefix.Policy{Kind: browseprefix.KindRank, Enabled: true}
+
+	_, ok := cachedPrefixPolicy(db, key)
+	assert.False(t, ok)
+
+	storePrefixPolicy(db, key, policy)
+	cached, ok := cachedPrefixPolicy(db, key)
+	require.True(t, ok)
+	assert.Equal(t, policy, cached)
+
+	_, ok = cachedPrefixPolicy(otherDB, key)
+	assert.False(t, ok)
+	_, ok = cachedPrefixPolicy(db, otherKey)
+	assert.False(t, ok)
+}
+
+func TestPrefixPolicyCacheInvalidation(t *testing.T) {
+	clearPrefixPolicyCache()
+	t.Cleanup(clearPrefixPolicyCache)
+
+	db := &fakeSQLQueryable{id: 1}
+	otherDB := &fakeSQLQueryable{id: 2}
+	key := prefixPolicyCacheKey(filepath.ToSlash(filepath.Join("roms", "nes")), []systemdefs.System{{ID: "NES"}})
+	otherKey := prefixPolicyCacheKey(filepath.ToSlash(filepath.Join("roms", "snes")), []systemdefs.System{{ID: "SNES"}})
+
+	storePrefixPolicy(db, key, browseprefix.Policy{Kind: browseprefix.KindRank, Enabled: true})
+	storePrefixPolicy(otherDB, otherKey, browseprefix.Policy{Kind: browseprefix.KindDate, Enabled: true})
+
+	clearPrefixPolicyCacheFor(nil)
+	_, ok := cachedPrefixPolicy(db, key)
+	assert.True(t, ok)
+	_, ok = cachedPrefixPolicy(otherDB, otherKey)
+	assert.True(t, ok)
+
+	clearPrefixPolicyCacheFor(db)
+	_, ok = cachedPrefixPolicy(db, key)
+	assert.False(t, ok)
+	_, ok = cachedPrefixPolicy(otherDB, otherKey)
+	assert.True(t, ok)
+
+	clearPrefixPolicyCache()
+	_, ok = cachedPrefixPolicy(otherDB, otherKey)
+	assert.False(t, ok)
+}

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -132,13 +132,36 @@ func (db *MediaDB) FindMediaIDsByPaths(
 		return nil, ErrNullSQL
 	}
 
+	uniquePaths := make([]string, 0, len(paths))
+	seenPaths := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if _, ok := seenPaths[path]; ok {
+			continue
+		}
+		seenPaths[path] = struct{}{}
+		uniquePaths = append(uniquePaths, path)
+	}
+
+	results := make([]database.MediaPathID, 0, len(uniquePaths))
+	for start := 0; start < len(uniquePaths); start += sqliteMaxParams {
+		end := min(start+sqliteMaxParams, len(uniquePaths))
+		batchResults, err := findMediaIDsByPathBatch(ctx, db.sql, uniquePaths[start:end])
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, batchResults...)
+	}
+	return results, nil
+}
+
+func findMediaIDsByPathBatch(ctx context.Context, db sqlQueryable, paths []string) ([]database.MediaPathID, error) {
 	args := make([]any, 0, len(paths))
 	for _, path := range paths {
 		args = append(args, path)
 	}
 
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
-	rows, err := db.sql.QueryContext(ctx, `
+	rows, err := db.QueryContext(ctx, `
 		SELECT s.SystemID, m.Path, m.DBID
 		FROM Media m
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -122,6 +122,48 @@ func (db *MediaDB) FindMediaBySystemAndPaths(
 	return results, rows.Err()
 }
 
+func (db *MediaDB) FindMediaIDsByPaths(
+	ctx context.Context, paths []string,
+) ([]database.MediaPathID, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	args := make([]any, 0, len(paths))
+	for _, path := range paths {
+		args = append(args, path)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT s.SystemID, m.Path, m.DBID
+		FROM Media m
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE m.Path IN (`+prepareVariadic("?", ",", len(paths))+`)
+	`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query FindMediaIDsByPaths: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	results := make([]database.MediaPathID, 0, len(paths))
+	for rows.Next() {
+		var row database.MediaPathID
+		if err := rows.Scan(&row.SystemID, &row.Path, &row.DBID); err != nil {
+			return nil, fmt.Errorf("failed to scan FindMediaIDsByPaths: %w", err)
+		}
+		results = append(results, row)
+	}
+	return results, rows.Err()
+}
+
 func (db *MediaDB) FindSingleContainerLaunchMedia(
 	ctx context.Context, systemDBID int64, containerPath string,
 ) (*database.Media, error) {

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -126,6 +127,67 @@ func TestFindMediaBySystemAndPaths_EmptyInput(t *testing.T) {
 	results, err := mediaDB.FindMediaBySystemAndPaths(context.Background(), 1, nil)
 	require.NoError(t, err)
 	assert.Empty(t, results)
+}
+
+func TestFindMediaIDsByPaths_EmptyInput(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	results, err := mediaDB.FindMediaIDsByPaths(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestFindMediaIDsByPaths_ReturnsSamePathAcrossSystems(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.ToSlash(filepath.Join("roms", "mario.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (2, 'SNES', 'Super Nintendo');
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 2, 'mario', 'Mario');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 2, ?);
+	`, mediaPath)
+	require.NoError(t, err)
+
+	results, err := mediaDB.FindMediaIDsByPaths(ctx, []string{mediaPath})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []database.MediaPathID{
+		{SystemID: "NES", Path: mediaPath, DBID: 1},
+		{SystemID: "SNES", Path: mediaPath, DBID: 2},
+	}, results)
+}
+
+func TestFindMediaIDsByPaths_ChunksLargeInput(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	marioPath := filepath.ToSlash(filepath.Join("roms", "mario.nes"))
+	zeldaPath := filepath.ToSlash(filepath.Join("roms", "zelda.nes"))
+	_, err := mediaDB.sql.ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+	`, zeldaPath)
+	require.NoError(t, err)
+
+	paths := make([]string, 0, sqliteMaxParams+2)
+	paths = append(paths, marioPath)
+	for i := range sqliteMaxParams {
+		paths = append(paths, filepath.ToSlash(filepath.Join("roms", "missing", fmt.Sprintf("game-%04d.nes", i))))
+	}
+	paths = append(paths, zeldaPath)
+
+	results, err := mediaDB.FindMediaIDsByPaths(ctx, paths)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []database.MediaPathID{
+		{SystemID: "NES", Path: marioPath, DBID: 1},
+		{SystemID: "NES", Path: zeldaPath, DBID: 2},
+	}, results)
 }
 
 func TestFindSingleContainerLaunchMedia_ReturnsOnlyDirectChild(t *testing.T) {

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -687,6 +687,19 @@ func sqlSearchMediaPathParts(
 	return results, nil
 }
 
+func requestedAllSystems(systems []systemdefs.System) bool {
+	requested := make(map[string]struct{}, len(systems))
+	for _, sys := range systems {
+		requested[sys.ID] = struct{}{}
+	}
+	for _, sys := range systemdefs.AllSystems() {
+		if _, ok := requested[sys.ID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func sqlSearchMediaWithFilters(
 	ctx context.Context,
 	db sqlQueryable,
@@ -710,7 +723,7 @@ func sqlSearchMediaWithFilters(
 	// but its presence makes SQLite drive the join from Systems and scan every
 	// title instead of the handful of tag matches. Omit it in that case.
 	skipSystemFilter := len(variantGroups) == 0 && !includeName && len(tags) > 0 &&
-		len(systems) >= len(systemdefs.AllSystems())
+		requestedAllSystems(systems)
 
 	// Build system ID args
 	args := make([]any, 0)

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -704,10 +704,20 @@ func sqlSearchMediaWithFilters(
 		return nil, errors.New("no systems provided for media search")
 	}
 
+	// Tag-only browses (e.g. favorites: empty query + user:favorite) constrain
+	// Media directly via the tag subquery's rowid IN-list. When the system list
+	// covers every defined system the SystemID IN (...) clause filters nothing,
+	// but its presence makes SQLite drive the join from Systems and scan every
+	// title instead of the handful of tag matches. Omit it in that case.
+	skipSystemFilter := len(variantGroups) == 0 && !includeName && len(tags) > 0 &&
+		len(systems) >= len(systemdefs.AllSystems())
+
 	// Build system ID args
 	args := make([]any, 0)
-	for _, sys := range systems {
-		args = append(args, sys.ID)
+	if !skipSystemFilter {
+		for _, sys := range systems {
+			args = append(args, sys.ID)
+		}
 	}
 
 	// Build AND-of-ORs WHERE clause for variant groups
@@ -770,6 +780,19 @@ func sqlSearchMediaWithFilters(
 		variantArgs = append(variantArgs, letterArgs...)
 	}
 
+	systemCondition := ""
+	if !skipSystemFilter {
+		systemCondition = `Systems.SystemID IN (` +
+			prepareVariadic("?", ",", len(systems)) + `) AND `
+	}
+
+	orderCondition := ""
+	if skipSystemFilter {
+		// The tag-driven plan iterates Media rowids from the IN-list; make the
+		// cursor pagination order explicit rather than relying on scan order.
+		orderCondition = ` ORDER BY Media.DBID ASC`
+	}
+
 	//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 	mediaQuery := `
 		SELECT
@@ -780,14 +803,13 @@ func sqlSearchMediaWithFilters(
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
-		WHERE Systems.SystemID IN (` +
-		prepareVariadic("?", ",", len(systems)) +
-		`)
-		AND Media.IsMissing = 0` +
+		WHERE ` + systemCondition +
+		`Media.IsMissing = 0` +
 		variantCondition +
 		cursorCondition +
 		tagFilterCondition +
 		letterFilterCondition +
+		orderCondition +
 		` LIMIT ?`
 
 	// Assemble final args: systems → variants → tag filters → limit
@@ -796,6 +818,7 @@ func sqlSearchMediaWithFilters(
 	mediaArgs = append(mediaArgs, tagFilterArgs...) // Add tag filter args
 	mediaArgs = append(mediaArgs, limit)
 
+	queryStarted := time.Now()
 	mediaStmt, err := db.PrepareContext(ctx, mediaQuery)
 	if err != nil {
 		return results, fmt.Errorf("failed to prepare media query: %w", err)
@@ -827,11 +850,23 @@ func sqlSearchMediaWithFilters(
 	if err = mediaRows.Err(); err != nil {
 		return results, fmt.Errorf("media rows iteration error: %w", err)
 	}
+	queryElapsed := time.Since(queryStarted)
 
 	// Fetch and attach tags for all results
+	tagsStarted := time.Now()
 	if err := fetchAndAttachTags(ctx, db, results); err != nil {
 		return results, err
 	}
+
+	log.Debug().
+		Int("systems", len(systems)).
+		Int("variantGroups", len(variantGroups)).
+		Int("tagFilters", len(tags)).
+		Bool("tagDriven", skipSystemFilter).
+		Int("rows", len(results)).
+		Dur("queryDuration", queryElapsed).
+		Dur("tagsDuration", time.Since(tagsStarted)).
+		Msg("search media filters step timing")
 
 	return results, nil
 }
@@ -897,6 +932,7 @@ func sqlSearchMediaByTitleDBIDs(
 	finalArgs = append(finalArgs, extraArgs...)
 	finalArgs = append(finalArgs, limit)
 
+	queryStarted := time.Now()
 	rows, err := db.QueryContext(ctx, query, finalArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query by title DBIDs: %w", err)
@@ -914,10 +950,20 @@ func sqlSearchMediaByTitleDBIDs(
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows iteration error: %w", err)
 	}
+	queryElapsed := time.Since(queryStarted)
 
+	tagsStarted := time.Now()
 	if err := fetchAndAttachTags(ctx, db, results); err != nil {
 		return nil, err
 	}
+
+	log.Debug().
+		Int("titleDBIDs", len(titleDBIDs)).
+		Int("tagFilters", len(tags)).
+		Int("rows", len(results)).
+		Dur("queryDuration", queryElapsed).
+		Dur("tagsDuration", time.Since(tagsStarted)).
+		Msg("search media by title DBIDs step timing")
 
 	return results, nil
 }

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -22,6 +22,7 @@ package mediadb
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -604,6 +605,164 @@ func TestSqlSearchMediaWithFilters_WithTags(t *testing.T) {
 	assert.Equal(t, "NES", results[0].SystemID)
 	assert.Equal(t, "/games/mario.nes", results[0].Path)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func systemIDsAsDriverValues(systems []systemdefs.System) []driver.Value {
+	args := make([]driver.Value, 0, len(systems))
+	for _, sys := range systems {
+		args = append(args, sys.ID)
+	}
+	return args
+}
+
+const searchSystemFilterPattern = `(?s)WHERE\s+Systems\.SystemID IN \(\?(,\?)*\) AND\s+` +
+	`Media\.IsMissing = 0.*LIMIT \?`
+
+const searchVariantSystemFilterPattern = `(?s)WHERE\s+Systems\.SystemID IN \(\?(,\?)*\) AND\s+` +
+	`Media\.IsMissing = 0.*MediaTitles\.Slug LIKE.*LIMIT \?`
+
+func expectSearchTagsQuery(mock sqlmock.Sqlmock, mediaID int64) {
+	mock.ExpectPrepare("(?s)SELECT.*MediaDBID.*Tags\\.Tag.*TagTypes\\.Type.*FROM Media").
+		ExpectQuery().
+		WithArgs(mediaID, mediaID).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "DisplayName", "Type"}))
+}
+
+func TestSqlSearchMediaWithFilters_AllSystemsTagOnlySkipsSystemFilter(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	systems := systemdefs.AllSystems()
+	require.NotEmpty(t, systems)
+	tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+
+	mock.ExpectPrepare("(?s)WHERE\\s+Media\\.IsMissing = 0.*ORDER BY Media\\.DBID ASC.*LIMIT \\?").
+		ExpectQuery().
+		WithArgs("user", "favorite", "user", "favorite", 10).
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
+			AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 7))
+	expectSearchTagsQuery(mock, 7)
+
+	results, err := sqlSearchMediaWithFilters(
+		context.Background(), db, systems, nil, nil, tags, nil, nil, 10, false,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, systems[0].ID, results[0].SystemID)
+	assert.Equal(t, filepath.ToSlash(filepath.Join("roms", "favorite.rom")), results[0].Path)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlSearchMediaWithFilters_DuplicateSystemsMissingOneKeepsSystemFilter(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	allSystems := systemdefs.AllSystems()
+	require.GreaterOrEqual(t, len(allSystems), 2)
+	systems := make([]systemdefs.System, 0, len(allSystems))
+	for range allSystems {
+		systems = append(systems, allSystems[0])
+	}
+	tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+	args := systemIDsAsDriverValues(systems)
+	args = append(args, "user", "favorite", "user", "favorite", 10)
+
+	mock.ExpectPrepare(searchSystemFilterPattern).
+		ExpectQuery().
+		WithArgs(args...).
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
+			AddRow(allSystems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 8))
+	expectSearchTagsQuery(mock, 8)
+
+	results, err := sqlSearchMediaWithFilters(
+		context.Background(), db, systems, nil, nil, tags, nil, nil, 10, false,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, allSystems[0].ID, results[0].SystemID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlSearchMediaWithFilters_NonTagDrivenKeepsSystemFilter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("include name", func(t *testing.T) {
+		t.Parallel()
+		db, mock, err := testsqlmock.NewSQLMock()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		systems := systemdefs.AllSystems()
+		require.NotEmpty(t, systems)
+		tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+		args := systemIDsAsDriverValues(systems)
+		args = append(args, "user", "favorite", "user", "favorite", 10)
+
+		mock.ExpectPrepare(searchSystemFilterPattern).
+			ExpectQuery().
+			WithArgs(args...).
+			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
+				AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 9))
+		expectSearchTagsQuery(mock, 9)
+
+		results, err := sqlSearchMediaWithFilters(
+			context.Background(), db, systems, nil, nil, tags, nil, nil, 10, true,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, systems[0].ID, results[0].SystemID)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("variant groups", func(t *testing.T) {
+		t.Parallel()
+		db, mock, err := testsqlmock.NewSQLMock()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+
+		systems := systemdefs.AllSystems()
+		require.NotEmpty(t, systems)
+		tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+		args := systemIDsAsDriverValues(systems)
+		args = append(args, "%mario%", "%mario%", "user", "favorite", "user", "favorite", 10)
+
+		mock.ExpectPrepare(searchVariantSystemFilterPattern).
+			ExpectQuery().
+			WithArgs(args...).
+			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
+				AddRow(systems[0].ID, "Mario", filepath.ToSlash(filepath.Join("roms", "mario.rom")), 10))
+		expectSearchTagsQuery(mock, 10)
+
+		results, err := sqlSearchMediaWithFilters(
+			context.Background(), db, systems, [][]string{{"mario"}}, []string{"mario"}, tags, nil, nil, 10, false,
+		)
+
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, filepath.ToSlash(filepath.Join("roms", "mario.rom")), results[0].Path)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestRequestedAllSystemsRequiresUniqueSystemIDs(t *testing.T) {
+	t.Parallel()
+
+	allSystems := systemdefs.AllSystems()
+	require.GreaterOrEqual(t, len(allSystems), 2)
+	duplicatedFirst := make([]systemdefs.System, 0, len(allSystems))
+	for range allSystems {
+		duplicatedFirst = append(duplicatedFirst, allSystems[0])
+	}
+
+	assert.True(t, requestedAllSystems(allSystems))
+	assert.False(t, requestedAllSystems(duplicatedFirst))
 }
 
 func TestSqlGetTags(t *testing.T) {

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -249,6 +249,7 @@ func sqlGetMediaHistory(
 
 	where := strings.Join(conditions, " AND ")
 	args = append(args, limit)
+	queryStarted := time.Now()
 
 	//nolint:gosec // where clause uses only hardcoded column names, not user input
 	query := fmt.Sprintf(`
@@ -342,6 +343,12 @@ func sqlGetMediaHistory(
 	if err = rows.Err(); err != nil {
 		return list, fmt.Errorf("error iterating media history rows: %w", err)
 	}
+
+	log.Debug().
+		Int("systems", len(systemIDs)).
+		Int("rows", len(list)).
+		Dur("queryDuration", time.Since(queryStarted)).
+		Msg("media history query timing")
 
 	return list, nil
 }
@@ -570,6 +577,7 @@ func sqlGetMediaHistoryTop(
 	args = append(args, limit)
 
 	list := make([]database.MediaHistoryTopEntry, 0, limit)
+	queryStarted := time.Now()
 
 	q, err := db.PrepareContext(ctx, query)
 	if err != nil {
@@ -615,6 +623,12 @@ func sqlGetMediaHistoryTop(
 	if err = rows.Err(); err != nil {
 		return list, fmt.Errorf("error iterating media history top rows: %w", err)
 	}
+
+	log.Debug().
+		Int("systems", len(systemIDs)).
+		Int("rows", len(list)).
+		Dur("queryDuration", time.Since(queryStarted)).
+		Msg("media history top query timing")
 
 	return list, nil
 }

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2391,6 +2391,19 @@ func (m *MockMediaDBI) FindMediaBySystemAndPaths(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) FindMediaIDsByPaths(
+	ctx context.Context, paths []string,
+) ([]database.MediaPathID, error) {
+	if !m.hasExpectedCall("FindMediaIDsByPaths") {
+		return nil, nil
+	}
+	args := m.Called(ctx, paths)
+	if result, ok := args.Get(0).([]database.MediaPathID); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) FindSingleContainerLaunchMedia(
 	ctx context.Context, systemDBID int64, containerPath string,
 ) (*database.Media, error) {


### PR DESCRIPTION
- Adds a debug-level duration log for every JSON-RPC request in the dispatcher, plus step timing in the search, browse, and history query paths, so server-side latency can be measured per method on devices.
- Caches browse prefix-policy detection per directory. It previously fetched every Media.Path in the browsed directory on each first-page browse to choose a sort mode; measured on a MiSTer this step went from 45ms to 0.01ms on revisits.
- Resolves history media IDs with a single batched FindMediaIDsByPaths query (new MediaDBI method using media_path_idx) instead of two queries per distinct system; enrichment went from 57ms to 12ms warm, and media.history handler time from 82ms to 41ms.
- Drops the all-systems SystemID IN (...) clause for tag-only searches (the launcher's favorites query) so SQLite drives the plan from the tag subquery rowid list instead of scanning the Systems/MediaTitles/Media join; query time went from 199ms to 36ms, with an explicit ORDER BY Media.DBID for cursor pagination.
- API responses were verified identical before and after on the test device (same media IDs, cursors, and pagination).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Media path resolution now uses bulk lookup and deduplication for faster, more reliable media ID resolution.
  * Browse listings use a cached prefix-policy so repeated scans are avoided.

* **Chores**
  * Added timing and debug logging across media handlers and request processing for better performance visibility.

* **Tests**
  * Expanded and updated tests around media lookup, caching, and large-input/edge-case behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->