### PR TITLE
feat(mister): index MGL files in core folders

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -870,11 +870,11 @@ func enableMGLIndexing(launchers []platforms.Launcher) []platforms.Launcher {
 }
 
 func launcherSupportsFolderMGL(launcher *platforms.Launcher) bool {
-	if launcher.SystemID == "" || len(launcher.Folders) == 0 || launcher.SkipFilesystemScan || launcher.Launch == nil {
+	if _, skipped := mglIndexingSkippedLaunchers[launcher.ID]; skipped {
 		return false
 	}
-	_, skipped := mglIndexingSkippedLaunchers[launcher.ID]
-	return !skipped
+	return launcher.SystemID != "" && len(launcher.Folders) > 0 &&
+		!launcher.SkipFilesystemScan && launcher.Launch != nil
 }
 
 func launcherHasExtension(launcher *platforms.Launcher, extension string) bool {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -33,6 +33,11 @@ const (
 	scriptConsoleVT   = "3"
 )
 
+var mglIndexingSkippedLaunchers = map[string]struct{}{
+	"GenericVideo": {},
+	"ScummVM":      {},
+}
+
 func checkInZip(path string) string {
 	if !strings.HasSuffix(strings.ToLower(path), ".zip") {
 		return path
@@ -852,10 +857,39 @@ func createVideoLauncher(pl *Platform) platforms.Launcher {
 	}
 }
 
+func enableMGLIndexing(launchers []platforms.Launcher) []platforms.Launcher {
+	for i := range launchers {
+		launcher := &launchers[i]
+		if !launcherSupportsFolderMGL(launcher) || launcherHasExtension(launcher, ".mgl") {
+			continue
+		}
+		launcher.Extensions = append(launcher.Extensions, ".mgl")
+	}
+
+	return launchers
+}
+
+func launcherSupportsFolderMGL(launcher *platforms.Launcher) bool {
+	if launcher.SystemID == "" || len(launcher.Folders) == 0 || launcher.SkipFilesystemScan || launcher.Launch == nil {
+		return false
+	}
+	_, skipped := mglIndexingSkippedLaunchers[launcher.ID]
+	return !skipped
+}
+
+func launcherHasExtension(launcher *platforms.Launcher, extension string) bool {
+	for _, ext := range launcher.Extensions {
+		if strings.EqualFold(ext, extension) {
+			return true
+		}
+	}
+	return false
+}
+
 // CreateLaunchers creates all standard MiSTer launchers for the given platform.
 // This is exported for use by MiSTeX and other MiSTer variants.
 func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
-	return []platforms.Launcher{
+	launchers := []platforms.Launcher{
 		// Consoles
 		{
 			ID:         systemdefs.System3DO,
@@ -2090,8 +2124,10 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 				if err != nil {
 					return nil, fmt.Errorf("failed to set active game: %w", err)
 				}
-				return nil, nil
+				return nil, nil //nolint:nilnil // MiSTer launches don't return a process handle
 			},
 		},
 	}
+
+	return enableMGLIndexing(launchers)
 }

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -475,6 +475,48 @@ func TestArcadeLauncherExtensions(t *testing.T) {
 	assert.Contains(t, arcadeLauncher.Extensions, ".mgl")
 }
 
+func TestMGLIndexingAddedToFolderLaunchers(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	findLauncher := func(id string) *platforms.Launcher {
+		for i := range launchers {
+			if launchers[i].ID == id {
+				return &launchers[i]
+			}
+		}
+		return nil
+	}
+
+	snesLauncher := findLauncher("SNES")
+	require.NotNil(t, snesLauncher, "SNES launcher should exist")
+	assert.Contains(t, snesLauncher.Extensions, ".mgl")
+
+	dualRAMLauncher := findLauncher("DualRAM3DO")
+	require.NotNil(t, dualRAMLauncher, "DualRAM3DO launcher should exist")
+	assert.NotContains(t, dualRAMLauncher.Extensions, ".mgl")
+
+	genericLauncher := findLauncher("Generic")
+	require.NotNil(t, genericLauncher, "Generic launcher should exist")
+	assert.Equal(t, 1, countExtension(genericLauncher.Extensions, ".mgl"))
+
+	arcadeLauncher := findLauncher("Arcade")
+	require.NotNil(t, arcadeLauncher, "Arcade launcher should exist")
+	assert.Equal(t, 1, countExtension(arcadeLauncher.Extensions, ".mgl"))
+}
+
+func countExtension(extensions []string, want string) int {
+	count := 0
+	for _, extension := range extensions {
+		if strings.EqualFold(extension, want) {
+			count++
+		}
+	}
+	return count
+}
+
 // Regression test: N64 launcher should support .v64 extension (byte-swapped ROM format)
 func TestN64LauncherExtensions(t *testing.T) {
 	t.Parallel()

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -480,6 +480,8 @@ func TestMGLIndexingAddedToFolderLaunchers(t *testing.T) {
 
 	pl := NewPlatform()
 	launchers := CreateLaunchers(pl)
+	launchers = append(launchers, createVideoLauncher(pl), createScummVMLauncher(pl))
+	launchers = enableMGLIndexing(launchers)
 
 	findLauncher := func(id string) *platforms.Launcher {
 		for i := range launchers {
@@ -505,6 +507,14 @@ func TestMGLIndexingAddedToFolderLaunchers(t *testing.T) {
 	arcadeLauncher := findLauncher("Arcade")
 	require.NotNil(t, arcadeLauncher, "Arcade launcher should exist")
 	assert.Equal(t, 1, countExtension(arcadeLauncher.Extensions, ".mgl"))
+
+	videoLauncher := findLauncher("GenericVideo")
+	require.NotNil(t, videoLauncher, "GenericVideo launcher should exist")
+	assert.NotContains(t, videoLauncher.Extensions, ".mgl")
+
+	scummVMLauncher := findLauncher("ScummVM")
+	require.NotNil(t, scummVMLauncher, "ScummVM launcher should exist")
+	assert.NotContains(t, scummVMLauncher.Extensions, ".mgl")
 }
 
 func countExtension(extensions []string, want string) int {


### PR DESCRIPTION
Adds MiSTer .mgl indexing to folder-based core launchers while leaving generic, scanner-only, and non-core launchers alone. Existing .mgl launchers keep a single extension entry. Validated with task lint-fix and task test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic `.mgl` file indexing for eligible MiSTer launcher folders; SNES and other folder-based launchers now include `.mgl`
  * Certain launchers (e.g., DualRAM3DO, GenericVideo, ScummVM) are excluded from automatic `.mgl` indexing; Generic and Arcade include a single `.mgl` entry

* **Tests**
  * Added regression tests verifying `.mgl` indexing behavior across launcher types and case-insensitive extension handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->