### PR TITLE
fix(mister): exclude default boot files from media index

### DIFF
--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -469,12 +469,12 @@ func GetFiles(
 			mu.Lock()
 			for i := range zipFiles {
 				abs := filepath.Join(p, zipFiles[i])
-				if matcher.MatchSystemFile(system.ID, abs) {
+				if matcher.MatchSystemFileForScan(system.ID, abs) {
 					results = append(results, abs)
 				}
 			}
 			mu.Unlock()
-		} else if matcher.MatchSystemFile(system.ID, p) {
+		} else if matcher.MatchSystemFileForScan(system.ID, p) {
 			mu.Lock()
 			results = append(results, p)
 			mu.Unlock()

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2279,6 +2279,58 @@ func TestGetFiles_ZipsAsDirs(t *testing.T) {
 	assert.False(t, foundFiles["readme.txt"])
 }
 
+func TestGetFiles_RespectsLauncherScanExcludes(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	gamesDir := filepath.Join(rootDir, "nes")
+	require.NoError(t, os.MkdirAll(gamesDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(gamesDir, "game.rom"), []byte("game"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(gamesDir, "boot.rom"), []byte("boot"), 0o600))
+
+	zipPath := filepath.Join(gamesDir, "boot.zip")
+	zipFile, err := os.Create(zipPath) //nolint:gosec // test file in t.TempDir()
+	require.NoError(t, err)
+	w := zip.NewWriter(zipFile)
+	fw, createErr := w.Create("boot.vhd")
+	require.NoError(t, createErr)
+	_, writeErr := fw.Write([]byte("boot"))
+	require.NoError(t, writeErr)
+	require.NoError(t, w.Close())
+	require.NoError(t, zipFile.Close())
+
+	launcher := platforms.Launcher{
+		ID:           "nes-launcher",
+		SystemID:     systemdefs.SystemNES,
+		Folders:      []string{"nes"},
+		Extensions:   []string{".rom", ".vhd"},
+		ScanExcludes: []string{"boot.rom", "boot.zip/boot.vhd"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemNES, gamesDir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Join(gamesDir, "game.rom")}, files)
+}
+
 func TestNewNamesIndex_PausesAndResumes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -22,6 +22,7 @@ package helpers
 import (
 	"errors"
 	"os"
+	stdpath "path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -227,6 +228,7 @@ type launcherPrecomp struct {
 	rootPairs     []string // normRoot + "/" + normFolder for every root × relative-folder combination
 	absFolders    []string // normalized absolute folder paths (already normalized from folderCache)
 	extensions    []string // pre-lowercased extensions
+	scanExcludes  []string // pre-normalized scan-only exclude patterns
 }
 
 // LauncherMatcher provides optimized path matching with pre-normalized paths.
@@ -313,6 +315,9 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 		for _, e := range l.Extensions {
 			lp.extensions = append(lp.extensions, strings.ToLower(e))
 		}
+		for _, exclude := range l.ScanExcludes {
+			lp.scanExcludes = append(lp.scanExcludes, NormalizePathForComparison(exclude))
+		}
 
 		precomp[l.ID] = lp
 	}
@@ -346,6 +351,93 @@ func (m *LauncherMatcher) MatchSystemFile(systemID, path string) bool {
 		Int("launchersChecked", len(launchers)).
 		Msg("no launcher matched file")
 
+	return false
+}
+
+// MatchSystemFileForScan returns true if path matches a launcher for the given
+// system and is not blocked by that launcher's scan-only exclude patterns.
+func (m *LauncherMatcher) MatchSystemFileForScan(systemID, path string) bool {
+	lowerPath := strings.ToLower(path)
+	normPath := NormalizePathForComparison(path)
+
+	launchers := GlobalLauncherCache.GetLaunchersBySystem(systemID)
+	matchedExcluded := false
+	for i := range launchers {
+		launcher := &launchers[i]
+		if !m.pathIsLauncher(launcher, path, lowerPath, normPath) {
+			continue
+		}
+		if m.pathIsExcludedFromScan(launcher, normPath) {
+			matchedExcluded = true
+			continue
+		}
+		return true
+	}
+
+	if matchedExcluded {
+		log.Trace().
+			Str("system", systemID).
+			Str("path", path).
+			Msg("file matched launcher but was excluded from media scan")
+		return false
+	}
+
+	log.Trace().
+		Str("system", systemID).
+		Str("path", path).
+		Int("launchersChecked", len(launchers)).
+		Msg("no launcher matched file")
+
+	return false
+}
+
+func (m *LauncherMatcher) pathIsExcludedFromScan(l *platforms.Launcher, normPath string) bool {
+	var excludes []string
+	if lc := m.precomp[l.ID]; lc != nil {
+		excludes = lc.scanExcludes
+	} else {
+		for _, exclude := range l.ScanExcludes {
+			excludes = append(excludes, NormalizePathForComparison(exclude))
+		}
+	}
+
+	if len(excludes) == 0 {
+		return false
+	}
+
+	base := stdpath.Base(normPath)
+	trimmedPath := strings.TrimPrefix(normPath, "/")
+	for _, pattern := range excludes {
+		if pattern == "" || pattern == "." {
+			continue
+		}
+		if scanExcludePatternMatches(trimmedPath, base, pattern) {
+			log.Trace().
+				Str("launcher", l.ID).
+				Str("path", normPath).
+				Str("pattern", pattern).
+				Msg("file excluded from media scan")
+			return true
+		}
+	}
+	return false
+}
+
+func scanExcludePatternMatches(trimmedPath, base, pattern string) bool {
+	pattern = strings.TrimPrefix(pattern, "/")
+	if !strings.Contains(pattern, "/") {
+		matched, err := stdpath.Match(pattern, base)
+		return err == nil && matched
+	}
+
+	parts := strings.Split(trimmedPath, "/")
+	for i := range parts {
+		suffix := strings.Join(parts[i:], "/")
+		matched, err := stdpath.Match(pattern, suffix)
+		if err == nil && matched {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -181,16 +181,17 @@ func TestLauncherMatcher_MatchSystemFile(t *testing.T) {
 
 func TestLauncherMatcher_MatchSystemFileForScanExcludes(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{})
-	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
 		{
 			ID:           "NESLauncher",
 			SystemID:     "NES",
 			Folders:      []string{"nes"},
-			Extensions:   []string{".rom", ".vhd"},
-			ScanExcludes: []string{"boot.rom", "boot.zip/boot.vhd"},
+			Extensions:   []string{".rom", ".vhd", ".sav", ".srm"},
+			ScanExcludes: []string{"boot.rom", "boot.zip/boot.vhd", "*.sav"},
 		},
 	})
 
@@ -208,15 +209,25 @@ func TestLauncherMatcher_MatchSystemFileForScanExcludes(t *testing.T) {
 
 	matcher := NewLauncherMatcher(cfg, mockPlatform)
 
-	assert.True(t, matcher.MatchSystemFile("NES", "/roms/nes/game.rom"))
-	assert.True(t, matcher.MatchSystemFileForScan("NES", "/roms/nes/game.rom"))
+	gamePath := filepath.Join(rootDir, "nes", "game.rom")
+	assert.True(t, matcher.MatchSystemFile("NES", gamePath))
+	assert.True(t, matcher.MatchSystemFileForScan("NES", gamePath))
 
-	assert.True(t, matcher.MatchSystemFile("NES", "/roms/nes/boot.rom"))
-	assert.False(t, matcher.MatchSystemFileForScan("NES", "/roms/nes/boot.rom"))
+	bootPath := filepath.Join(rootDir, "nes", "boot.rom")
+	assert.True(t, matcher.MatchSystemFile("NES", bootPath))
+	assert.False(t, matcher.MatchSystemFileForScan("NES", bootPath))
 
-	zipBootPath := "/roms/nes/boot.zip/boot.vhd"
+	zipBootPath := filepath.Join(rootDir, "nes", "boot.zip", "boot.vhd")
 	assert.True(t, matcher.MatchSystemFile("NES", zipBootPath))
 	assert.False(t, matcher.MatchSystemFileForScan("NES", zipBootPath))
+
+	wildcardSavePath := filepath.Join(rootDir, "nes", "zelda.sav")
+	assert.True(t, matcher.MatchSystemFile("NES", wildcardSavePath))
+	assert.False(t, matcher.MatchSystemFileForScan("NES", wildcardSavePath))
+
+	nonMatchingWildcardPath := filepath.Join(rootDir, "nes", "zelda.srm")
+	assert.True(t, matcher.MatchSystemFile("NES", nonMatchingWildcardPath))
+	assert.True(t, matcher.MatchSystemFileForScan("NES", nonMatchingWildcardPath))
 }
 
 func TestLauncherMatcher_RootSlashAndDotFolder(t *testing.T) {

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -179,6 +179,46 @@ func TestLauncherMatcher_MatchSystemFile(t *testing.T) {
 	assert.False(t, matcher.MatchSystemFile("NES", "/roms/nes/.hidden.nes"))
 }
 
+func TestLauncherMatcher_MatchSystemFileForScanExcludes(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{
+			ID:           "NESLauncher",
+			SystemID:     "NES",
+			Folders:      []string{"nes"},
+			Extensions:   []string{".rom", ".vhd"},
+			ScanExcludes: []string{"boot.rom", "boot.zip/boot.vhd"},
+		},
+	})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+
+	assert.True(t, matcher.MatchSystemFile("NES", "/roms/nes/game.rom"))
+	assert.True(t, matcher.MatchSystemFileForScan("NES", "/roms/nes/game.rom"))
+
+	assert.True(t, matcher.MatchSystemFile("NES", "/roms/nes/boot.rom"))
+	assert.False(t, matcher.MatchSystemFileForScan("NES", "/roms/nes/boot.rom"))
+
+	zipBootPath := "/roms/nes/boot.zip/boot.vhd"
+	assert.True(t, matcher.MatchSystemFile("NES", zipBootPath))
+	assert.False(t, matcher.MatchSystemFileForScan("NES", zipBootPath))
+}
+
 func TestLauncherMatcher_RootSlashAndDotFolder(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	mockPlatform := mocks.NewMockPlatform()

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -38,6 +38,15 @@ var mglIndexingSkippedLaunchers = map[string]struct{}{
 	"ScummVM":      {},
 }
 
+var misterDefaultScanExcludes = []string{
+	"boot.rom",
+	"boot.vhd",
+	"boot.zip/boot.vhd",
+	"blank.vhd",
+	"blank.zip/blank.vhd",
+	"empty_hdd.zip/boot.vhd",
+}
+
 func checkInZip(path string) string {
 	if !strings.HasSuffix(strings.ToLower(path), ".zip") {
 		return path
@@ -866,6 +875,17 @@ func enableMGLIndexing(launchers []platforms.Launcher) []platforms.Launcher {
 		launcher.Extensions = append(launcher.Extensions, ".mgl")
 	}
 
+	return launchers
+}
+
+func applyDefaultScanExcludes(launchers []platforms.Launcher) []platforms.Launcher {
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SystemID == "" || len(launcher.Folders) == 0 || launcher.SkipFilesystemScan {
+			continue
+		}
+		launcher.ScanExcludes = append(launcher.ScanExcludes, misterDefaultScanExcludes...)
+	}
 	return launchers
 }
 
@@ -2129,5 +2149,5 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		},
 	}
 
-	return enableMGLIndexing(launchers)
+	return applyDefaultScanExcludes(enableMGLIndexing(launchers))
 }

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
@@ -453,6 +454,26 @@ func TestLLAPISuperGrafxLauncherExists(t *testing.T) {
 	require.NotNil(t, found, "LLAPISuperGrafx launcher should exist")
 	assert.Equal(t, "SuperGrafx", found.SystemID,
 		"LLAPISuperGrafx must use SystemSuperGrafx so .sgx slots are found")
+}
+
+func TestCreateLaunchersAppliesDefaultScanExcludes(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	var colecoLauncher *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == systemdefs.SystemColecoVision {
+			colecoLauncher = &launchers[i]
+			break
+		}
+	}
+
+	require.NotNil(t, colecoLauncher, "ColecoVision launcher should exist")
+	assert.Contains(t, colecoLauncher.ScanExcludes, "boot.rom")
+	assert.Contains(t, colecoLauncher.ScanExcludes, "boot.vhd")
+	assert.Contains(t, colecoLauncher.ScanExcludes, "boot.zip/boot.vhd")
 }
 
 func TestArcadeLauncherExtensions(t *testing.T) {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -260,6 +260,11 @@ type Launcher struct {
 	Schemes []string
 	// Extensions to match for files during a standard scan.
 	Extensions []string
+	// ScanExcludes are case-insensitive slash-normalized glob patterns that
+	// prevent matched files from being indexed. Patterns without a slash match
+	// the base filename; patterns with a slash can match any path suffix. They
+	// only affect media scanning; direct path launches can still match the launcher.
+	ScanExcludes []string
 	// Folders to scan for files, relative to the root folders of the platform.
 	Folders []string
 	// Lifecycle determines how the launcher process is managed.


### PR DESCRIPTION
## Summary
- add scan-only launcher exclude patterns for media indexing
- apply MiSTer defaults for boot/blank VHD/ROM files
- keep direct path launch matching unchanged

## Checks
- go test -race ./pkg/helpers ./pkg/platforms/mister ./pkg/database/mediascanner
- go vet ./pkg/helpers ./pkg/platforms/mister ./pkg/database/mediascanner
- golangci-lint run ./pkg/helpers ./pkg/platforms/mister ./pkg/database/mediascanner

Closes #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launchers can now exclude specific files from media scanning using normalized, case-insensitive pattern filters; excluded files remain directly launchable.
  * MiSTer platform now applies sensible default scan exclusions for common boot assets to reduce library clutter.

* **Tests**
  * Added tests validating scan-exclude behavior during media scans and launcher matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->