### PR TITLE
feat(playtime): add daily limits, session restore, and broker filtering

### DIFF
--- a/pkg/api/methods/playtime_test.go
+++ b/pkg/api/methods/playtime_test.go
@@ -79,14 +79,8 @@ func TestHandlePlaytime_ResetStateWithDailyFields(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockUserDBI()
-	mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-		{
-			DBID:      1,
-			StartTime: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-			EndTime:   timePtr(time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)),
-			PlayTime:  3600, // 1 hour
-		},
-	}, nil)
+	dayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	mockDB.On("SumMediaPlayTimeForDay", dayStart).Return(int64(3600), nil)
 
 	db := &database.Database{
 		UserDB: mockDB,
@@ -180,14 +174,8 @@ func TestHandlePlaytime_CooldownStateWithDailyFields(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockUserDBI()
-	mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-		{
-			DBID:      1,
-			StartTime: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-			EndTime:   timePtr(time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)),
-			PlayTime:  1800, // 30 minutes
-		},
-	}, nil)
+	dayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	mockDB.On("SumMediaPlayTimeForDay", dayStart).Return(int64(1800), nil)
 
 	db := &database.Database{
 		UserDB: mockDB,
@@ -324,9 +312,4 @@ func TestHandlePlaytime_UnreliableClockNilDailyFields(t *testing.T) {
 	assert.Nil(t, resp.DailyRemaining, "daily remaining should be nil when clock unreliable")
 
 	mockDB.AssertExpectations(t)
-}
-
-// timePtr returns a pointer to the given time
-func timePtr(t time.Time) *time.Time {
-	return &t
 }

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -87,8 +87,8 @@ func TestHandlePlaytimeLimitsUpdate_ReEnableWithActiveMedia(t *testing.T) {
 
 	// Set up mock database - needed for checkLimits goroutine
 	mockUserDB := helpers.NewMockUserDBI()
-	mockUserDB.On("GetMediaHistory", mock.Anything, mock.Anything, mock.Anything).
-		Return([]database.MediaHistoryEntry{}, nil).Maybe()
+	mockUserDB.On("SumMediaPlayTimeForDay", mock.Anything).
+		Return(int64(0), nil).Maybe()
 
 	db := &database.Database{
 		UserDB: mockUserDB,

--- a/pkg/config/configplaytime.go
+++ b/pkg/config/configplaytime.go
@@ -22,6 +22,8 @@ package config
 import (
 	"fmt"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // Playtime configures play time tracking and limits.
@@ -70,6 +72,9 @@ func (c *Instance) DailyLimit() time.Duration {
 	}
 	d, err := time.ParseDuration(c.vals.Playtime.Limits.Daily)
 	if err != nil {
+		log.Warn().
+			Str("value", c.vals.Playtime.Limits.Daily).
+			Msg("playtime: invalid daily limit duration in config, limit disabled")
 		return 0
 	}
 	return d
@@ -85,6 +90,9 @@ func (c *Instance) SessionLimit() time.Duration {
 	}
 	d, err := time.ParseDuration(c.vals.Playtime.Limits.Session)
 	if err != nil {
+		log.Warn().
+			Str("value", c.vals.Playtime.Limits.Session).
+			Msg("playtime: invalid session limit duration in config, limit disabled")
 		return 0
 	}
 	return d

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -562,6 +562,7 @@ type UserDBI interface {
 	CloseHangingMediaHistory() error
 	CleanupMediaHistory(retentionDays int) (int64, error)
 	HealTimestamps(bootUUID string, trueBootTime time.Time) (int64, error)
+	SumMediaPlayTimeForDay(dayStart time.Time) (int64, error)
 	AddMapping(m *Mapping) error
 	GetMapping(id int64) (Mapping, error)
 	DeleteMapping(id int64) error

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -109,6 +109,17 @@ func (db *UserDB) HealTimestamps(bootUUID string, trueBootTime time.Time) (int64
 	return sqlHealTimestamps(db.ctx, db.sql, bootUUID, trueBootTime)
 }
 
+// SumMediaPlayTimeForDay returns the total seconds of completed play-time that
+// overlaps with the day starting at dayStart. Sessions that span midnight are
+// pro-rated: only the portion after dayStart is counted. The currently-active
+// session (EndTime IS NULL) is excluded; callers add it separately.
+func (db *UserDB) SumMediaPlayTimeForDay(dayStart time.Time) (int64, error) {
+	if db.sql == nil {
+		return 0, ErrNullSQL
+	}
+	return sqlSumMediaPlayTimeForDay(db.ctx, db.sql, dayStart)
+}
+
 /*
  * Internal SQL functions
  */
@@ -206,7 +217,9 @@ func sqlCloseMediaHistory(ctx context.Context, db *sql.DB, dbid int64, endTime t
 		}
 	}()
 
-	_, err = stmt.ExecContext(ctx, endTime.Unix(), playTime, playTime, time.Now().Unix(), endTime.Unix(), dbid)
+	// Use endTime as UpdatedAt: both represent the moment the session ended.
+	endUnix := endTime.Unix()
+	_, err = stmt.ExecContext(ctx, endUnix, playTime, playTime, endUnix, endUnix, dbid)
 	if err != nil {
 		return fmt.Errorf("failed to execute media history close: %w", err)
 	}
@@ -450,10 +463,46 @@ func sqlCleanupMediaHistory(ctx context.Context, db *sql.DB, retentionDays int) 
 	return rowsAffected, nil
 }
 
+func sqlSumMediaPlayTimeForDay(ctx context.Context, db *sql.DB, dayStart time.Time) (int64, error) {
+	dayStartUnix := dayStart.Unix()
+
+	// Sum completed sessions that overlap [dayStart, ∞).
+	// Sessions spanning midnight are pro-rated: only the portion after dayStart counts.
+	// The active session (EndTime IS NULL) is excluded; callers add it separately.
+	stmt, err := db.PrepareContext(ctx, `
+		SELECT COALESCE(SUM(
+		    CASE
+		        WHEN StartTime < ? THEN EndTime - ?
+		        ELSE PlayTime
+		    END
+		), 0)
+		FROM MediaHistory
+		WHERE EndTime IS NOT NULL
+		  AND EndTime > ?;
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to prepare daily play time sum statement: %w", err)
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+
+	var total int64
+	if scanErr := stmt.QueryRowContext(ctx, dayStartUnix, dayStartUnix, dayStartUnix).Scan(&total); scanErr != nil {
+		return 0, fmt.Errorf("failed to scan daily play time sum: %w", scanErr)
+	}
+
+	return total, nil
+}
+
 func sqlHealTimestamps(ctx context.Context, db *sql.DB, bootUUID string, trueBootTime time.Time) (int64, error) {
 	trueBootUnix := trueBootTime.Unix()
 
-	// Heal MediaHistory timestamps
+	// Heal MediaHistory timestamps.
+	// Rows with MonotonicStart = 0 are skipped: they cannot be accurately healed
+	// (uptime was unavailable when the row was written), so we leave them as-is.
 	mediaStmt, err := db.PrepareContext(ctx, `
 		UPDATE MediaHistory
 		SET StartTime = ? + MonotonicStart,
@@ -464,7 +513,7 @@ func sqlHealTimestamps(ctx context.Context, db *sql.DB, bootUUID string, trueBoo
 		    ClockReliable = 1,
 		    ClockSource = 'healed',
 		    UpdatedAt = unixepoch()
-		WHERE BootUUID = ? AND ClockReliable = 0;
+		WHERE BootUUID = ? AND ClockReliable = 0 AND MonotonicStart > 0;
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to prepare media history heal statement: %w", err)

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -891,3 +891,66 @@ func TestSqlGetMediaHistoryTop_MultipleSystemIDs(t *testing.T) {
 	assert.Equal(t, "NES", entries[1].SystemID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestSqlSumMediaPlayTimeForDay_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	dayStartUnix := dayStart.Unix()
+	expectedTotal := int64(3600)
+
+	rows := sqlmock.NewRows([]string{"total"}).AddRow(expectedTotal)
+	mock.ExpectPrepare(`SELECT COALESCE\(SUM`).
+		ExpectQuery().
+		WithArgs(dayStartUnix, dayStartUnix, dayStartUnix).
+		WillReturnRows(rows)
+
+	total, err := sqlSumMediaPlayTimeForDay(context.Background(), db, dayStart)
+	require.NoError(t, err)
+	assert.Equal(t, expectedTotal, total)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlSumMediaPlayTimeForDay_NoSessions(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	dayStartUnix := dayStart.Unix()
+
+	// COALESCE returns 0 when no matching sessions exist.
+	rows := sqlmock.NewRows([]string{"total"}).AddRow(int64(0))
+	mock.ExpectPrepare(`SELECT COALESCE\(SUM`).
+		ExpectQuery().
+		WithArgs(dayStartUnix, dayStartUnix, dayStartUnix).
+		WillReturnRows(rows)
+
+	total, err := sqlSumMediaPlayTimeForDay(context.Background(), db, dayStart)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlSumMediaPlayTimeForDay_DatabaseError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	dayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectPrepare(`SELECT COALESCE\(SUM`).
+		ExpectQuery().
+		WillReturnError(sqlmock.ErrCancelled)
+
+	total, err := sqlSumMediaPlayTimeForDay(context.Background(), db, dayStart)
+	require.Error(t, err)
+	assert.Equal(t, int64(0), total)
+	assert.Contains(t, err.Error(), "failed to scan daily play time sum")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/database/userdb/userdb_integration_test.go
+++ b/pkg/database/userdb/userdb_integration_test.go
@@ -589,3 +589,148 @@ func TestClientAuthTokenColonCheckConstraint_Integration(t *testing.T) {
 	assert.Contains(t, err.Error(), "CHECK",
 		"the failure should originate from a CHECK constraint, not a different error path")
 }
+
+// TestSumMediaPlayTimeForDay_Integration verifies sqlSumMediaPlayTimeForDay against
+// real SQLite data, covering cross-midnight pro-rating, active-session exclusion,
+// pre-day exclusion, and multi-session summation.
+func TestSumMediaPlayTimeForDay_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	dayStart := time.Date(2025, 6, 13, 0, 0, 0, 0, time.UTC)
+
+	t.Run("no sessions returns zero", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("session entirely within today uses PlayTime", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		startTime := time.Date(2025, 6, 13, 10, 0, 0, 0, time.UTC)
+		endTime := time.Date(2025, 6, 13, 11, 0, 0, 0, time.UTC)
+
+		dbid, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-a",
+			StartTime: startTime,
+			CreatedAt: startTime,
+			UpdatedAt: startTime,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CloseMediaHistory(dbid, endTime, 3600))
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3600), total)
+	})
+
+	t.Run("cross-midnight session pro-rates to today only", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		// Started yesterday 23:00, ended today 00:30 — 5400s total, 1800s after midnight.
+		startTime := time.Date(2025, 6, 12, 23, 0, 0, 0, time.UTC)
+		endTime := time.Date(2025, 6, 13, 0, 30, 0, 0, time.UTC)
+
+		dbid, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-b",
+			StartTime: startTime,
+			CreatedAt: startTime,
+			UpdatedAt: startTime,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CloseMediaHistory(dbid, endTime, 5400))
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		// SQL pro-rates: endTime - dayStart = 1800s (30 minutes after midnight)
+		assert.Equal(t, int64(1800), total)
+	})
+
+	t.Run("session entirely before today is excluded", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		startTime := time.Date(2025, 6, 12, 8, 0, 0, 0, time.UTC)
+		endTime := time.Date(2025, 6, 12, 9, 0, 0, 0, time.UTC)
+
+		dbid, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-c",
+			StartTime: startTime,
+			CreatedAt: startTime,
+			UpdatedAt: startTime,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CloseMediaHistory(dbid, endTime, 3600))
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total) // WHERE EndTime > dayStart excludes yesterday-only sessions
+	})
+
+	t.Run("active session without EndTime is excluded", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		startTime := time.Date(2025, 6, 13, 12, 0, 0, 0, time.UTC)
+
+		_, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-d",
+			StartTime: startTime,
+			CreatedAt: startTime,
+			UpdatedAt: startTime,
+			PlayTime:  600,
+		})
+		require.NoError(t, err)
+		// No CloseMediaHistory call — EndTime remains NULL.
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), total)
+	})
+
+	t.Run("multiple sessions sum correctly", func(t *testing.T) {
+		t.Parallel()
+		db, cleanup := setupTempUserDB(t)
+		defer cleanup()
+
+		// Session 1: today 10:00–11:00 (PlayTime = 3600)
+		start1 := time.Date(2025, 6, 13, 10, 0, 0, 0, time.UTC)
+		end1 := time.Date(2025, 6, 13, 11, 0, 0, 0, time.UTC)
+		dbid1, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-e1",
+			StartTime: start1,
+			CreatedAt: start1,
+			UpdatedAt: start1,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CloseMediaHistory(dbid1, end1, 3600))
+
+		// Session 2: cross-midnight (yesterday 23:00 → today 00:30), 1800s today
+		start2 := time.Date(2025, 6, 12, 23, 0, 0, 0, time.UTC)
+		end2 := time.Date(2025, 6, 13, 0, 30, 0, 0, time.UTC)
+		dbid2, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+			ID:        "test-uuid-e2",
+			StartTime: start2,
+			CreatedAt: start2,
+			UpdatedAt: start2,
+		})
+		require.NoError(t, err)
+		require.NoError(t, db.CloseMediaHistory(dbid2, end2, 5400))
+
+		total, err := db.SumMediaPlayTimeForDay(dayStart)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5400), total) // 3600 + 1800
+	})
+}

--- a/pkg/service/broker/broker.go
+++ b/pkg/service/broker/broker.go
@@ -34,7 +34,7 @@ import (
 // subscriberState manages a single subscription, including a drain goroutine that
 // delivers coalesced notifications when the output channel fills up.
 //
-// For coaleseable methods: if outChan is full when a notification arrives, the
+// For coalesceable methods: if outChan is full when a notification arrives, the
 // notification is stored in the coalesced map (replacing any prior pending
 // notification for the same method) and the drain goroutine is signalled. This
 // means slow consumers see only the latest value for high-frequency progress
@@ -42,22 +42,35 @@ import (
 //
 // For all other methods: broadcast falls back to a non-blocking send with a
 // drop warning (existing behaviour).
+//
+// methodFilter, when non-nil, limits delivery to the listed methods. Notifications
+// for methods not in the filter are silently skipped — they were never intended for
+// this subscriber, so no drop warning is emitted.
 type subscriberState struct {
-	outChan   chan models.Notification
-	coalesced map[string]models.Notification
-	signal    chan struct{}
-	stop      chan struct{}
-	stopped   chan struct{}
-	mu        syncutil.Mutex
+	outChan      chan models.Notification
+	coalesced    map[string]models.Notification
+	signal       chan struct{}
+	stop         chan struct{}
+	stopped      chan struct{}
+	methodFilter map[string]bool // nil = receive all methods
+	mu           syncutil.Mutex
 }
 
-func newSubscriberState(bufferSize int) *subscriberState {
+func newSubscriberState(bufferSize int, methods []string) *subscriberState {
+	var filter map[string]bool
+	if len(methods) > 0 {
+		filter = make(map[string]bool, len(methods))
+		for _, m := range methods {
+			filter[m] = true
+		}
+	}
 	s := &subscriberState{
-		outChan:   make(chan models.Notification, bufferSize),
-		coalesced: make(map[string]models.Notification),
-		signal:    make(chan struct{}, 1),
-		stop:      make(chan struct{}),
-		stopped:   make(chan struct{}),
+		outChan:      make(chan models.Notification, bufferSize),
+		coalesced:    make(map[string]models.Notification),
+		signal:       make(chan struct{}, 1),
+		stop:         make(chan struct{}),
+		stopped:      make(chan struct{}),
+		methodFilter: filter,
 	}
 	go s.run()
 	return s
@@ -90,6 +103,8 @@ func (s *subscriberState) run() {
 // It uses non-blocking sends to ensure that slow consumers cannot block the system.
 // For methods listed in coalesceable, a per-subscriber drain goroutine delivers the
 // latest notification whenever the output channel has space, preventing stale drops.
+// Subscribers may declare a method filter at subscribe time; notifications for
+// unlisted methods are skipped rather than queued or dropped with a warning.
 type Broker struct {
 	ctx          context.Context
 	source       <-chan models.Notification
@@ -142,7 +157,7 @@ func (b *Broker) Start() {
 	}()
 }
 
-// broadcast sends a notification to all subscribers.
+// broadcast sends a notification to all subscribers whose method filter admits it.
 // For coalesceable methods: tries a direct non-blocking send; if the channel is
 // full, stores the latest payload in the subscriber's coalesced slot and wakes
 // the drain goroutine so it can deliver when space opens.
@@ -154,6 +169,11 @@ func (b *Broker) broadcast(notif models.Notification) {
 	coalesce := b.coalesceable[notif.Method]
 
 	for id, sub := range b.subscribers {
+		// Skip subscribers that have declared a method filter and this method is not in it.
+		if sub.methodFilter != nil && !sub.methodFilter[notif.Method] {
+			continue
+		}
+
 		select {
 		case sub.outChan <- notif:
 			// Delivered directly.
@@ -180,21 +200,24 @@ func (b *Broker) broadcast(notif models.Notification) {
 // Subscribe creates a new subscription and returns a channel that will receive
 // notifications. The bufferSize determines how many notifications can be queued
 // before coalescing (for coalesceable methods) or dropping (for all others) kicks in.
+// The optional methods parameter limits delivery to those notification methods only;
+// omitting it subscribes to all methods (backward-compatible).
 //
 // Returns the notification channel and a subscription ID that can be used for unsubscribing.
-func (b *Broker) Subscribe(bufferSize int) (notifChan <-chan models.Notification, id int) {
+func (b *Broker) Subscribe(bufferSize int, methods ...string) (notifChan <-chan models.Notification, id int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	id = b.nextID
 	b.nextID++
 
-	sub := newSubscriberState(bufferSize)
+	sub := newSubscriberState(bufferSize, methods)
 	b.subscribers[id] = sub
 
 	log.Debug().
 		Int("subscriber_id", id).
 		Int("buffer_size", bufferSize).
+		Strs("method_filter", methods).
 		Msg("new subscriber registered")
 
 	notifChan = sub.outChan

--- a/pkg/service/broker/broker_test.go
+++ b/pkg/service/broker/broker_test.go
@@ -400,6 +400,132 @@ done:
 		"subscriber should have received direct sends plus at least one coalesced delivery")
 }
 
+// TestBroker_MethodFilterReceivesOnlyMatchingMethods verifies that a subscriber
+// with a method filter only receives notifications for the declared methods and
+// silently skips all others — no drop warning is emitted for filtered-out methods.
+func TestBroker_MethodFilterReceivesOnlyMatchingMethods(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan models.Notification, 20)
+	b := NewBroker(ctx, source)
+	b.Start()
+
+	// Lifecycle-only subscriber — should not see indexing or custom events.
+	lifecycle, _ := b.Subscribe(10, models.NotificationStarted, models.NotificationStopped)
+	// Unfiltered subscriber — must see everything.
+	all, _ := b.Subscribe(20)
+
+	// Send a mix of methods.
+	toSend := []models.Notification{
+		{Method: models.NotificationStarted, Params: []byte(`{}`)},
+		{Method: models.NotificationMediaIndexing, Params: []byte(`{}`)},
+		{Method: "custom.event", Params: []byte(`{}`)},
+		{Method: models.NotificationStopped, Params: []byte(`{}`)},
+	}
+	for _, n := range toSend {
+		source <- n
+	}
+
+	// Give broker time to deliver.
+	time.Sleep(30 * time.Millisecond)
+
+	// Filtered subscriber should see only started and stopped.
+	var lifecycleMethods []string
+	drainLifecycle := time.After(50 * time.Millisecond)
+	for {
+		select {
+		case n, ok := <-lifecycle:
+			if !ok {
+				goto checkLifecycle
+			}
+			lifecycleMethods = append(lifecycleMethods, n.Method)
+		case <-drainLifecycle:
+			goto checkLifecycle
+		}
+	}
+checkLifecycle:
+	assert.Equal(t, []string{models.NotificationStarted, models.NotificationStopped}, lifecycleMethods,
+		"filtered subscriber must only see declared methods")
+
+	// Unfiltered subscriber should see all four.
+	var allMethods []string
+	drainAll := time.After(50 * time.Millisecond)
+	for {
+		select {
+		case n, ok := <-all:
+			if !ok {
+				goto checkAll
+			}
+			allMethods = append(allMethods, n.Method)
+		case <-drainAll:
+			goto checkAll
+		}
+	}
+checkAll:
+	assert.Len(t, allMethods, 4, "unfiltered subscriber must see all methods")
+}
+
+// TestBroker_FilteredLifecycleSubscriberSurvivesIndexingBurst verifies the
+// regression: an indexing-storm burst that fills an unfiltered subscriber's
+// buffer must not cause media.started or media.stopped to be dropped for a
+// filtered lifecycle subscriber. This was the original failure mode — lifecycle
+// events were dropped because all subscribers shared the same full buffer.
+func TestBroker_FilteredLifecycleSubscriberSurvivesIndexingBurst(t *testing.T) {
+	t.Parallel()
+
+	const burstSize = 200
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	source := make(chan models.Notification, burstSize+10)
+	// media.indexing is coalesceable (mirrors production config).
+	b := NewBroker(ctx, source, models.NotificationMediaIndexing)
+	b.Start()
+
+	// Filtered lifecycle subscriber — mirrors LimitsManager / indexpause.
+	lifecycle, _ := b.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
+	// Unfiltered slow consumer — will have its buffer filled by the burst.
+	_, _ = b.Subscribe(2)
+
+	// Flood the broker with indexing events to fill the slow consumer's buffer.
+	for i := range burstSize {
+		source <- models.Notification{
+			Method: models.NotificationMediaIndexing,
+			Params: []byte(fmt.Sprintf(`{"step":%d}`, i)),
+		}
+	}
+	// Interleave a lifecycle event mid-burst.
+	source <- models.Notification{Method: models.NotificationStarted, Params: []byte(`{}`)}
+	source <- models.Notification{Method: models.NotificationStopped, Params: []byte(`{}`)}
+
+	// Give broker time to process everything.
+	time.Sleep(100 * time.Millisecond)
+
+	// Lifecycle subscriber must have received both events.
+	var got []string
+	drain := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case n, ok := <-lifecycle:
+			if !ok {
+				goto check
+			}
+			got = append(got, n.Method)
+		case <-drain:
+			goto check
+		}
+	}
+check:
+	assert.Contains(t, got, models.NotificationStarted,
+		"media.started must not be dropped during an indexing burst")
+	assert.Contains(t, got, models.NotificationStopped,
+		"media.stopped must not be dropped during an indexing burst")
+}
+
 // TestBroker_CoalesceDoesNotAffectCriticalEvents verifies that non-coalesceable
 // notifications (e.g. tokens.added) are never merged or silently dropped via the
 // coalescing path — they follow the original drop-with-warning path.

--- a/pkg/service/indexpause.go
+++ b/pkg/service/indexpause.go
@@ -44,7 +44,7 @@ func watchGameForIndexPause(
 	ns chan<- models.Notification,
 	pauser *syncutil.Pauser,
 ) {
-	notifChan, subID := b.Subscribe(10)
+	notifChan, subID := b.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
 	defer b.Unsubscribe(subID)
 
 	gameActive := st.ActiveMedia() != nil
@@ -60,7 +60,7 @@ func watchGameForScrapePause(
 	ns chan<- models.Notification,
 	pauser *syncutil.Pauser,
 ) {
-	notifChan, subID := b.Subscribe(10)
+	notifChan, subID := b.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
 	defer b.Unsubscribe(subID)
 
 	gameActive := st.ActiveMedia() != nil

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -54,6 +54,38 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 	for notif := range notificationChan {
 		switch notif.Method {
 		case models.NotificationStarted:
+			// If a previous session is still open (e.g., a stop notification was
+			// dropped), close it now before creating the new entry. This prevents orphaned
+			// rows with no EndTime from accumulating in MediaHistory.
+			t.mu.RLock()
+			prevDBID := t.currentHistoryDBID
+			prevStartTime := t.currentMediaStartTime
+			prevStartTimeMono := t.currentMediaStartTimeMono
+			t.mu.RUnlock()
+
+			if prevDBID != 0 {
+				log.Warn().Int64("dbid", prevDBID).
+					Msg("media history: closing orphaned entry before new session starts")
+				endTime := t.clock.Now()
+				var playTime int
+				if !prevStartTimeMono.IsZero() {
+					playTime = int(time.Since(prevStartTimeMono).Seconds())
+				} else if !prevStartTime.IsZero() {
+					playTime = int(endTime.Sub(prevStartTime).Seconds())
+				}
+				if closeErr := t.db.UserDB.CloseMediaHistory(prevDBID, endTime, playTime); closeErr != nil {
+					log.Error().Err(closeErr).Int64("dbid", prevDBID).
+						Msg("media history: failed to close orphaned entry")
+				}
+				t.mu.Lock()
+				if t.currentHistoryDBID == prevDBID {
+					t.currentHistoryDBID = 0
+					t.currentMediaStartTime = time.Time{}
+					t.currentMediaStartTimeMono = time.Time{}
+				}
+				t.mu.Unlock()
+			}
+
 			// Media started - create new history entry
 			activeMedia := t.st.ActiveMedia()
 			if activeMedia != nil {
@@ -161,9 +193,10 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 }
 
 // updatePlayTime periodically updates the PlayTime for the currently active media
-// history entry every minute.
+// history entry every 15 seconds. This limits crash-loss to at most 15 seconds of
+// playtime and keeps the history accurate for users who care about tracking.
 func (t *mediaHistoryTracker) updatePlayTime(ctx context.Context) {
-	ticker := t.clock.NewTicker(1 * time.Minute)
+	ticker := t.clock.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -22,6 +22,7 @@ package service
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -635,4 +636,70 @@ func TestMediaHistoryTracker_ConcurrentAccess(t *testing.T) {
 	// Verify no panics occurred (test for race conditions)
 	// The fact that we got here without panicking means mutex is working correctly
 	require.NotNil(t, tracker)
+}
+
+// TestMediaHistoryTracker_Listen_OrphanedEntry verifies that receiving media.started
+// while a previous DBID is still open closes the orphaned entry before creating a new one.
+// This covers the close-before-open path added to prevent orphaned history rows when a
+// media.stopped event was dropped (e.g., during an indexing storm).
+func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := &testhelpers.MockUserDBI{}
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	fakeClock := clockwork.NewFakeClock()
+
+	db := &database.Database{
+		UserDB: mockUserDB,
+	}
+
+	orphanedDBID := int64(10)
+	orphanStart := fakeClock.Now()
+
+	// Pre-set tracker state as if a game is currently tracked (orphaned open entry).
+	tracker := &mediaHistoryTracker{
+		st:                    st,
+		db:                    db,
+		clock:                 fakeClock,
+		currentHistoryDBID:    orphanedDBID,
+		currentMediaStartTime: orphanStart,
+	}
+
+	// Advance clock so the orphaned entry gets a non-zero play time.
+	fakeClock.Advance(30 * time.Second)
+
+	newDBID := int64(11)
+	activeMedia := &models.ActiveMedia{
+		Started:    fakeClock.Now(),
+		SystemID:   "snes",
+		SystemName: "Super Nintendo Entertainment System",
+		Path:       filepath.Join("games", "zelda.sfc"),
+		Name:       "The Legend of Zelda: A Link to the Past",
+		LauncherID: "retroarch",
+	}
+	testhelpers.AssertValidActiveMedia(t, activeMedia)
+	st.SetActiveMedia(activeMedia)
+
+	// Expect orphaned entry to be closed (play time = 30s from wall-clock fallback).
+	mockUserDB.On(
+		"CloseMediaHistory",
+		orphanedDBID,
+		mock.AnythingOfType("time.Time"),
+		30,
+	).Return(nil).Once()
+
+	// Expect a new entry to be created for the next game.
+	mockUserDB.On("AddMediaHistory", mock.MatchedBy(func(entry *database.MediaHistoryEntry) bool {
+		return entry.SystemID == "snes" && entry.MediaName == "The Legend of Zelda: A Link to the Past"
+	})).Return(newDBID, nil).Once()
+
+	notifChan := make(chan models.Notification, 1)
+	notifChan <- models.Notification{Method: models.NotificationStarted}
+	close(notifChan)
+
+	tracker.listen(notifChan)
+
+	mockUserDB.AssertExpectations(t)
+	assert.Equal(t, newDBID, tracker.currentHistoryDBID, "new DBID should be set after orphan close")
 }

--- a/pkg/service/playtime/limits.go
+++ b/pkg/service/playtime/limits.go
@@ -90,8 +90,8 @@ type LimitsManager struct {
 	cfg                   *config.Instance
 	player                audio.Player
 	cancel                context.CancelFunc
+	sessionCancel         context.CancelFunc // cancels checkLoop for the current game session; nil between sessions
 	state                 SessionState
-	sessionResetTimeout   time.Duration
 	sessionCumulativeTime time.Duration
 	subscriptionID        int
 	wg                    sync.WaitGroup
@@ -118,30 +118,24 @@ func NewLimitsManager(
 	done := make(chan struct{})
 	close(done)
 
-	// Get session reset timeout from config
-	// 0 means disabled (session never resets)
-	// Non-zero positive duration means reset after that idle time
-	sessionResetTimeout := cfg.SessionResetTimeout()
-
 	return &LimitsManager{
-		state:               StateReset,
-		db:                  db,
-		platform:            platform,
-		cfg:                 cfg,
-		clock:               clock,
-		player:              player,
-		ctx:                 ctx,
-		cancel:              cancel,
-		done:                done,
-		warningsGiven:       make(map[time.Duration]bool),
-		sessionResetTimeout: sessionResetTimeout,
-		enabled:             false, // Start disabled, caller must enable
+		state:         StateReset,
+		db:            db,
+		platform:      platform,
+		cfg:           cfg,
+		clock:         clock,
+		player:        player,
+		ctx:           ctx,
+		cancel:        cancel,
+		done:          done,
+		warningsGiven: make(map[time.Duration]bool),
+		enabled:       false, // Start disabled, caller must enable
 	}
 }
 
 // Broker is the interface for subscribing to notifications.
 type Broker interface {
-	Subscribe(bufferSize int) (<-chan models.Notification, int)
+	Subscribe(bufferSize int, methods ...string) (<-chan models.Notification, int)
 	Unsubscribe(id int)
 }
 
@@ -156,8 +150,10 @@ func (tm *LimitsManager) Start(broker Broker, notificationsSend chan<- models.No
 	tm.stopping = false
 	tm.mu.Unlock()
 
-	// Subscribe to broker for media.started and media.stopped events
-	notifChan, subID := broker.Subscribe(10)
+	// Subscribe to broker for media.started and media.stopped events only.
+	// The method filter prevents indexing-storm traffic from filling the buffer
+	// and dropping these rare lifecycle events.
+	notifChan, subID := broker.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
 	tm.subscriptionID = subID
 
 	go func() {
@@ -198,6 +194,11 @@ func (tm *LimitsManager) SetEnabled(enabled bool) {
 			tm.cooldownTimer.Stop()
 			tm.cooldownTimer = nil
 			log.Debug().Msg("playtime: cancelled cooldown timer (limits disabled)")
+		}
+		// Cancel the active session's check loop if one is running
+		if tm.sessionCancel != nil {
+			tm.sessionCancel()
+			tm.sessionCancel = nil
 		}
 
 		if tm.state != StateReset {
@@ -318,6 +319,16 @@ func (tm *LimitsManager) OnMediaStarted() {
 	tm.sessionStartMono = time.Now() // Monotonic clock for accurate duration
 	tm.sessionStartReliable = helpers.IsClockReliable(now)
 	tm.warningsGiven = make(map[time.Duration]bool)
+
+	// Cancel any stale check loop (defensive; shouldn't fire in normal state transitions).
+	if tm.sessionCancel != nil {
+		tm.sessionCancel()
+	}
+	// Per-session context so the check loop stops when this game stops, not when the
+	// manager shuts down. This prevents goroutine leaks across multiple game launches.
+	sessionCtx, sessionCancel := context.WithCancel(tm.ctx)
+	tm.sessionCancel = sessionCancel
+
 	tm.wg.Add(1)
 	tm.mu.Unlock()
 
@@ -327,10 +338,10 @@ func (tm *LimitsManager) OnMediaStarted() {
 			Msg("playtime: session started with unreliable clock - daily limits disabled for this session")
 	}
 
-	// Start the check loop
+	// Start the check loop (exits when the session context is cancelled).
 	go func() {
 		defer tm.wg.Done()
-		tm.checkLoop()
+		tm.checkLoop(sessionCtx)
 	}()
 }
 
@@ -342,6 +353,12 @@ func (tm *LimitsManager) OnMediaStopped() {
 		// Only stop if we're actually active
 		tm.mu.Unlock()
 		return
+	}
+
+	// Cancel the per-session check loop now that the game has stopped.
+	if tm.sessionCancel != nil {
+		tm.sessionCancel()
+		tm.sessionCancel = nil
 	}
 
 	// Calculate how long this game was played using monotonic clock (accurate, handles sleep)
@@ -364,9 +381,9 @@ func (tm *LimitsManager) OnMediaStopped() {
 	tm.sessionStartReliable = false
 	tm.warningsGiven = make(map[time.Duration]bool)
 
-	// Start cooldown timer if timeout is configured
-	if tm.sessionResetTimeout > 0 {
-		tm.cooldownTimer = tm.clock.NewTimer(tm.sessionResetTimeout)
+	// Start cooldown timer if timeout is configured (read live from config).
+	if sessionResetTimeout := tm.cfg.SessionResetTimeout(); sessionResetTimeout > 0 {
+		tm.cooldownTimer = tm.clock.NewTimer(sessionResetTimeout)
 		tm.wg.Add(1)
 		tm.mu.Unlock()
 
@@ -396,7 +413,7 @@ func (tm *LimitsManager) cooldownTimerLoop() {
 		tm.mu.Lock()
 		if tm.state == StateCooldown {
 			log.Info().
-				Dur("timeout", tm.sessionResetTimeout).
+				Dur("timeout", tm.cfg.SessionResetTimeout()).
 				Msg("playtime: cooldown timer expired, resetting session")
 			tm.transitionTo(StateReset)
 			tm.sessionCumulativeTime = 0
@@ -412,13 +429,15 @@ func (tm *LimitsManager) cooldownTimerLoop() {
 }
 
 // checkLoop runs periodic checks for time limits.
-// Checks every 30 seconds to ensure warnings 1-minute warnings are not skipped.
-func (tm *LimitsManager) checkLoop() {
+// Checks every 30 seconds to ensure 1-minute warnings are not skipped.
+// ctx is the per-session context cancelled when the game stops; it is a child of
+// tm.ctx so manager shutdown also terminates the loop.
+func (tm *LimitsManager) checkLoop(ctx context.Context) {
 	ticker := tm.clock.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	// Immediate check
-	if tm.ctx.Err() != nil {
+	if ctx.Err() != nil {
 		return
 	}
 	tm.checkLimits()
@@ -427,7 +446,7 @@ func (tm *LimitsManager) checkLoop() {
 		select {
 		case <-ticker.Chan():
 			tm.checkLimits()
-		case <-tm.ctx.Done():
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -507,18 +526,37 @@ func (tm *LimitsManager) buildRuleContext(
 ) (RuleContext, error) {
 	now := tm.clock.Now()
 
-	// Session duration includes:
-	// 1. sessionCumulativeTime: Total time from all previous games in this session
-	// 2. Current game duration: Time since this game started
-	// Note: Go's time.Sub() automatically uses monotonic clock when both Time values have it,
-	// which prevents sleep/hibernate from counting as playtime in production.
-	// In tests with fake clocks, this uses wall-clock time (which is fine for deterministic tests).
-	currentGameDuration := now.Sub(sessionStart)
-
 	tm.mu.Lock()
 	cumulativeTime := tm.sessionCumulativeTime
 	sessionStartWasReliable := tm.sessionStartReliable
+	sessionStartMono := tm.sessionStartMono
 	tm.mu.Unlock()
+
+	// Current game duration via wall clock.
+	wallElapsed := now.Sub(sessionStart)
+
+	// Detect in-session clock rollback by comparing wall-clock elapsed vs
+	// monotonic elapsed since session start. If the wall clock moved backward by
+	// more than 5 minutes relative to monotonic, use the monotonic-derived
+	// duration instead so the session limit still reflects real time played.
+	var currentGameDuration time.Duration
+	if !sessionStartMono.IsZero() {
+		monoElapsed := time.Since(sessionStartMono)
+		if wallElapsed < 0 || monoElapsed > wallElapsed+5*time.Minute {
+			log.Warn().
+				Dur("wall_elapsed", wallElapsed).
+				Dur("mono_elapsed", monoElapsed).
+				Msg("playtime: clock rollback detected, using monotonic for session duration")
+			currentGameDuration = monoElapsed
+		} else {
+			currentGameDuration = wallElapsed
+		}
+	} else {
+		currentGameDuration = wallElapsed
+		if currentGameDuration < 0 {
+			currentGameDuration = 0
+		}
+	}
 
 	// Total session duration = previous games + current game
 	sessionDuration := cumulativeTime + currentGameDuration
@@ -581,73 +619,21 @@ func (tm *LimitsManager) buildRuleContext(
 	}, nil
 }
 
-// calculateDailyUsage queries the database for today's total play time.
+// calculateDailyUsage returns the total play time for today.
+// completedSeconds is the sum of all closed sessions overlapping today (from SQL).
+// currentSessionDuration is the current game's contribution to today (computed by
+// the caller and already clamped to the today window).
+// Active sessions (EndTime IS NULL) are excluded by the SQL query; callers add
+// currentSessionDuration separately to avoid double-counting.
 func (tm *LimitsManager) calculateDailyUsage(
 	todayStart time.Time,
 	currentSessionDuration time.Duration,
 ) (time.Duration, error) {
-	// Query media history for today
-	// Note: GetMediaHistory uses pagination, so we need to fetch all entries
-	var totalUsage time.Duration
-	var lastID int64
-	limit := 100
-
-	for {
-		entries, err := tm.db.UserDB.GetMediaHistory(nil, lastID, limit)
-		if err != nil {
-			return 0, fmt.Errorf("failed to query media history: %w", err)
-		}
-
-		if len(entries) == 0 {
-			break
-		}
-
-		for i := range entries {
-			entry := &entries[i]
-
-			// If entry ended before today, skip it
-			if entry.EndTime != nil && entry.EndTime.Before(todayStart) {
-				// We've gone past today's entries (ordered DESC by DBID)
-				goto done
-			}
-
-			// If entry started before today but ended today (or is still running),
-			// only count the portion that falls within today
-			if entry.StartTime.Before(todayStart) {
-				if entry.EndTime != nil {
-					// Completed session that spans midnight
-					playTimeToday := entry.EndTime.Sub(todayStart)
-					if playTimeToday > 0 {
-						totalUsage += playTimeToday
-					}
-				}
-				// Note: Current session is handled separately via currentSessionDuration
-			} else {
-				// Entry started today
-				if entry.EndTime == nil {
-					// Active session (still running) - skip it.
-					// We calculate current session precisely via currentSessionDuration parameter.
-					// Including it here would double-count the current session.
-					continue
-				}
-				// Completed session - count full PlayTime
-				totalUsage += time.Duration(entry.PlayTime) * time.Second
-			}
-
-			lastID = entry.DBID
-		}
-
-		if len(entries) < limit {
-			// No more entries
-			break
-		}
+	completedSeconds, err := tm.db.UserDB.SumMediaPlayTimeForDay(todayStart)
+	if err != nil {
+		return 0, fmt.Errorf("failed to sum daily play time: %w", err)
 	}
-
-done:
-	// Add current session duration (already clamped to today in buildRuleContext)
-	totalUsage += currentSessionDuration
-
-	return totalUsage, nil
+	return time.Duration(completedSeconds)*time.Second + currentSessionDuration, nil
 }
 
 // createRules builds the list of active rules based on configuration.
@@ -729,8 +715,9 @@ func (tm *LimitsManager) GetStatus() *StatusInfo {
 	currentState := tm.state
 	cumulativeTime := tm.sessionCumulativeTime
 	lastStop := tm.lastStopTime
-	resetTimeout := tm.sessionResetTimeout
 	tm.mu.Unlock()
+
+	resetTimeout := tm.cfg.SessionResetTimeout()
 
 	now := tm.clock.Now()
 
@@ -878,15 +865,15 @@ func (tm *LimitsManager) GetStatus() *StatusInfo {
 }
 
 // CheckBeforeLaunch checks if launching new media would exceed daily or session limits.
-// Returns an error if:
+// Returns a reason string (models.PlaytimeLimitReasonDaily or models.PlaytimeLimitReasonSession)
+// and a non-nil error when the launch should be blocked:
 // - Daily or session limit is already exceeded
-// - Remaining time < MinimumViableSession (prevents launching games that will be immediately killed)
-// This implements the preventive check strategy - block launches before they start rather than
-// trying to stop games immediately after they launch.
-func (tm *LimitsManager) CheckBeforeLaunch() error {
+// - Remaining time < MinimumViableSession (prevents launching a game that will be immediately killed)
+// On success, reason is "" and error is nil.
+func (tm *LimitsManager) CheckBeforeLaunch() (string, error) {
 	// Check if limits are enabled (both config and runtime)
 	if !tm.cfg.PlaytimeLimitsEnabled() || !tm.IsEnabled() {
-		return nil
+		return "", nil
 	}
 
 	dailyLimit := tm.cfg.DailyLimit()
@@ -894,7 +881,7 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 
 	// If no limits configured, allow launch
 	if dailyLimit == 0 && sessionLimit == 0 {
-		return nil
+		return "", nil
 	}
 
 	now := tm.clock.Now()
@@ -913,7 +900,7 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 
 			usage, err := tm.calculateDailyUsage(todayStart, 0)
 			if err != nil {
-				return fmt.Errorf("failed to check daily usage: %w", err)
+				return "", fmt.Errorf("failed to check daily usage: %w", err)
 			}
 
 			dailyRemaining = dailyLimit - usage
@@ -924,7 +911,8 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 					Dur("usage", usage).
 					Dur("limit", dailyLimit).
 					Msg("playtime: daily limit already reached, blocking launch")
-				return fmt.Errorf("daily playtime limit reached (%s / %s)", usage, dailyLimit)
+				return models.PlaytimeLimitReasonDaily,
+					fmt.Errorf("daily playtime limit reached (%s / %s)", usage, dailyLimit)
 			}
 
 			// Minimum viable session check for daily limit
@@ -933,7 +921,7 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 					Dur("remaining", dailyRemaining).
 					Dur("minimum", MinimumViableSession).
 					Msg("playtime: insufficient daily time remaining for viable session, blocking launch")
-				return fmt.Errorf(
+				return models.PlaytimeLimitReasonDaily, fmt.Errorf(
 					"insufficient daily time remaining (%s left, need %s min)",
 					dailyRemaining,
 					MinimumViableSession,
@@ -957,7 +945,8 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 				Dur("cumulative", cumulativeTime).
 				Dur("limit", sessionLimit).
 				Msg("playtime: session limit already reached, blocking launch")
-			return fmt.Errorf("session playtime limit reached (%s / %s)", cumulativeTime, sessionLimit)
+			return models.PlaytimeLimitReasonSession,
+				fmt.Errorf("session playtime limit reached (%s / %s)", cumulativeTime, sessionLimit)
 		}
 
 		// Minimum viable session check for session limit
@@ -966,7 +955,7 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 				Dur("remaining", sessionRemaining).
 				Dur("minimum", MinimumViableSession).
 				Msg("playtime: insufficient session time remaining for viable session, blocking launch")
-			return fmt.Errorf(
+			return models.PlaytimeLimitReasonSession, fmt.Errorf(
 				"insufficient session time remaining (%s left, need %s min)",
 				sessionRemaining,
 				MinimumViableSession,
@@ -979,5 +968,87 @@ func (tm *LimitsManager) CheckBeforeLaunch() error {
 		Dur("session_remaining", sessionRemaining).
 		Msg("playtime: pre-launch check passed")
 
-	return nil
+	return "", nil
+}
+
+// RestoreSessionFromHistory reconstructs session state from recent MediaHistory entries.
+// Must be called after CloseHangingMediaHistory so any crashed sessions are closed first.
+// If the most recent session ended within the cooldown window, cumulative session time and
+// cooldown state are restored so session limits survive service restarts.
+func (tm *LimitsManager) RestoreSessionFromHistory(now time.Time) {
+	sessionResetTimeout := tm.cfg.SessionResetTimeout()
+	if sessionResetTimeout == 0 {
+		return // No cooldown window; session resets on any stop.
+	}
+
+	entries, err := tm.db.UserDB.GetMediaHistory(nil, 0, 100)
+	if err != nil {
+		log.Warn().Err(err).Msg("playtime: failed to query history for session restore")
+		return
+	}
+	if len(entries) == 0 {
+		return
+	}
+
+	// Most recent entry must be closed (CloseHangingMediaHistory should have handled any open rows).
+	mostRecent := entries[0]
+	if mostRecent.EndTime == nil {
+		return
+	}
+
+	// If the last session ended outside the cooldown window, there is nothing to restore.
+	sinceLast := now.Sub(*mostRecent.EndTime)
+	if sinceLast < 0 {
+		sinceLast = 0 // Clock skew safety.
+	}
+	if sinceLast >= sessionResetTimeout {
+		return
+	}
+
+	// Walk entries newest-to-oldest, accumulating PlayTime while consecutive
+	// inter-game gaps are within the cooldown window.
+	var cumulative time.Duration
+	prevStart := mostRecent.StartTime
+	for i := range entries {
+		entry := &entries[i]
+		if entry.EndTime == nil {
+			break // Unexpected open row; stop here.
+		}
+		if i > 0 {
+			// Gap between the previous (newer) entry's start and this entry's end.
+			gap := prevStart.Sub(*entry.EndTime)
+			if gap < 0 {
+				gap = 0 // Overlap safety.
+			}
+			if gap >= sessionResetTimeout {
+				break // Gap too large; older entries belong to a prior session.
+			}
+		}
+		cumulative += time.Duration(entry.PlayTime) * time.Second
+		prevStart = entry.StartTime
+	}
+
+	if cumulative == 0 {
+		return
+	}
+
+	remaining := sessionResetTimeout - sinceLast
+
+	tm.mu.Lock()
+	tm.sessionCumulativeTime = cumulative
+	tm.lastStopTime = *mostRecent.EndTime
+	tm.transitionTo(StateCooldown)
+	tm.cooldownTimer = tm.clock.NewTimer(remaining)
+	tm.wg.Add(1)
+	tm.mu.Unlock()
+
+	go func() {
+		defer tm.wg.Done()
+		tm.cooldownTimerLoop()
+	}()
+
+	log.Info().
+		Dur("cumulative", cumulative).
+		Dur("remaining_cooldown", remaining).
+		Msg("playtime: restored session state from history")
 }

--- a/pkg/service/playtime/limits.go
+++ b/pkg/service/playtime/limits.go
@@ -566,8 +566,8 @@ func (tm *LimitsManager) buildRuleContext(
 	bothClocksReliable := sessionStartWasReliable && currentClockReliable
 
 	var dailyUsage time.Duration
-	if bothClocksReliable {
-		// Both clocks appear valid - calculate daily usage normally
+	if bothClocksReliable && tm.cfg.DailyLimit() > 0 {
+		// Both clocks appear valid and a daily limit is configured - calculate daily usage.
 		year, month, day := now.Date()
 		todayStart := time.Date(year, month, day, 0, 0, 0, 0, now.Location())
 
@@ -578,6 +578,11 @@ func (tm *LimitsManager) buildRuleContext(
 			sessionStartToday = todayStart
 		}
 		sessionDurationToday := now.Sub(sessionStartToday)
+
+		// Lower-bound clamp: prevent negative duration during wall-clock rollback.
+		if sessionDurationToday < 0 {
+			sessionDurationToday = 0
+		}
 
 		// Safety clamp: Session duration today cannot exceed total session duration.
 		// This prevents math errors when clock jumps (e.g., 1970 → 2025 mid-session).
@@ -591,7 +596,7 @@ func (tm *LimitsManager) buildRuleContext(
 			return RuleContext{}, fmt.Errorf("failed to calculate daily usage: %w", err)
 		}
 		dailyUsage = usage
-	} else {
+	} else if !bothClocksReliable {
 		// Clock unreliable - skip daily usage calculation.
 		// DailyLimitRule will skip enforcement when ClockReliable is false.
 		// This provides graceful degradation: session limits still work.

--- a/pkg/service/playtime/limits_getstatus_test.go
+++ b/pkg/service/playtime/limits_getstatus_test.go
@@ -456,10 +456,7 @@ func TestGetStatus_StateActive(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		// DB still gets called in buildRuleContext when clock is reliable,
-		// but the result is not used when daily limit is 0
-		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
-			Return(int64(0), nil)
+		// No DB call expected - DailyLimit() == 0, so buildRuleContext skips the query.
 
 		db := &database.Database{
 			UserDB: mockDB,

--- a/pkg/service/playtime/limits_getstatus_test.go
+++ b/pkg/service/playtime/limits_getstatus_test.go
@@ -75,15 +75,9 @@ func TestGetStatus_StateReset(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		// Expect DB call to calculate daily usage
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-			{
-				DBID:      1,
-				StartTime: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-				EndTime:   timePtr(time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)),
-				PlayTime:  3600, // 1 hour
-			},
-		}, nil)
+		// Expect DB call to calculate daily usage (1 hour completed today)
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(3600), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -163,14 +157,8 @@ func TestGetStatus_StateReset(t *testing.T) {
 
 		mockDB := testhelpers.NewMockUserDBI()
 		// Return 3 hours of usage (over the 2 hour limit)
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-			{
-				DBID:      1,
-				StartTime: time.Date(2025, 1, 15, 8, 0, 0, 0, time.UTC),
-				EndTime:   timePtr(time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)),
-				PlayTime:  10800, // 3 hours
-			},
-		}, nil)
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(10800), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -209,14 +197,9 @@ func TestGetStatus_StateCooldown(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-			{
-				DBID:      1,
-				StartTime: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-				EndTime:   timePtr(time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)),
-				PlayTime:  1800, // 30 minutes
-			},
-		}, nil)
+		// 30 minutes completed in history
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(1800), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -241,7 +224,6 @@ func TestGetStatus_StateCooldown(t *testing.T) {
 		tm.state = StateCooldown
 		tm.sessionCumulativeTime = 30 * time.Minute
 		tm.lastStopTime = time.Date(2025, 1, 15, 10, 55, 0, 0, time.UTC)
-		tm.sessionResetTimeout = 20 * time.Minute
 		tm.mu.Unlock()
 
 		status := tm.GetStatus()
@@ -295,7 +277,6 @@ func TestGetStatus_StateCooldown(t *testing.T) {
 		tm.state = StateCooldown
 		tm.sessionCumulativeTime = 30 * time.Minute
 		tm.lastStopTime = time.Date(1970, 1, 1, 10, 55, 0, 0, time.UTC)
-		tm.sessionResetTimeout = 20 * time.Minute
 		tm.mu.Unlock()
 
 		status := tm.GetStatus()
@@ -344,7 +325,6 @@ func TestGetStatus_StateCooldown(t *testing.T) {
 		tm.state = StateCooldown
 		tm.sessionCumulativeTime = 30 * time.Minute
 		tm.lastStopTime = time.Date(2025, 1, 15, 10, 55, 0, 0, time.UTC)
-		tm.sessionResetTimeout = 20 * time.Minute
 		tm.mu.Unlock()
 
 		status := tm.GetStatus()
@@ -365,15 +345,9 @@ func TestGetStatus_StateActive(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{
-			// Previous session today
-			{
-				DBID:      1,
-				StartTime: time.Date(2025, 1, 15, 9, 0, 0, 0, time.UTC),
-				EndTime:   timePtr(time.Date(2025, 1, 15, 9, 30, 0, 0, time.UTC)),
-				PlayTime:  1800, // 30 minutes
-			},
-		}, nil)
+		// 30 min completed today before current session
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(1800), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -484,7 +458,8 @@ func TestGetStatus_StateActive(t *testing.T) {
 		mockDB := testhelpers.NewMockUserDBI()
 		// DB still gets called in buildRuleContext when clock is reliable,
 		// but the result is not used when daily limit is 0
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{}, nil)
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(0), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -168,7 +168,9 @@ func TestBuildRuleContext_UnreliableClock(t *testing.T) {
 			UserDB: mockDB,
 		}
 
-		cfg := &config.Instance{}
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{Limits: config.PlaytimeLimits{Daily: "2h"}},
+		})
 
 		sessionStart := time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)
 		currentTime := time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)
@@ -247,7 +249,9 @@ func TestBuildRuleContext_ClockHealing(t *testing.T) {
 			UserDB: mockDB,
 		}
 
-		cfg := &config.Instance{}
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{Limits: config.PlaytimeLimits{Daily: "2h"}},
+		})
 
 		// Session started yesterday at 11 PM
 		sessionStart := time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC)
@@ -368,11 +372,9 @@ func TestBuildRuleContext_MidnightRollover_CurrentSession(t *testing.T) {
 				UserDB: mockDB,
 			}
 
-			// Setup config with limits enabled
-			cfg := &config.Instance{}
-			*cfg = config.Instance{} // Initialize with defaults
-			// Note: We don't actually need limits enabled for buildRuleContext testing,
-			// just need the Instance to exist
+			cfg := newTestConfig(t, &config.Values{
+				Playtime: config.Playtime{Limits: config.PlaytimeLimits{Daily: "24h"}},
+			})
 
 			// Create LimitsManager with fake clock
 			fakeClock := clockwork.NewFakeClockAt(tt.currentTime)

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -161,7 +161,8 @@ func TestBuildRuleContext_UnreliableClock(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{}, nil)
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(0), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -239,7 +240,8 @@ func TestBuildRuleContext_ClockHealing(t *testing.T) {
 		t.Parallel()
 
 		mockDB := testhelpers.NewMockUserDBI()
-		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return([]database.MediaHistoryEntry{}, nil)
+		mockDB.On("SumMediaPlayTimeForDay", time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)).
+			Return(int64(0), nil)
 
 		db := &database.Database{
 			UserDB: mockDB,
@@ -279,107 +281,74 @@ func TestBuildRuleContext_ClockHealing(t *testing.T) {
 func TestBuildRuleContext_MidnightRollover_CurrentSession(t *testing.T) {
 	t.Parallel()
 
+	// todayStart for all test cases: midnight UTC on 2025-01-15
+	todayStart := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+
 	tests := []struct {
 		sessionStart            time.Time
 		currentTime             time.Time
 		name                    string
 		wantSessionDurationDesc string
 		wantDailyUsageDesc      string
-		historicalEntries       []database.MediaHistoryEntry
-		wantSessionDuration     time.Duration
-		wantDailyUsageToday     time.Duration
+		// sqlSeconds is the value SumMediaPlayTimeForDay returns for completed
+		// historical sessions. The current session's contribution is added by
+		// buildRuleContext via sessionDurationToday.
+		sqlSeconds          int64
+		wantSessionDuration time.Duration
+		wantDailyUsageToday time.Duration
 	}{
 		{
 			name:                    "session entirely within today",
 			sessionStart:            time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC),
 			currentTime:             time.Date(2025, 1, 15, 15, 30, 0, 0, time.UTC),
-			historicalEntries:       []database.MediaHistoryEntry{},
+			sqlSeconds:              0, // no completed sessions before current
 			wantSessionDuration:     90 * time.Minute,
 			wantDailyUsageToday:     90 * time.Minute,
 			wantSessionDurationDesc: "1.5 hours",
 			wantDailyUsageDesc:      "1.5 hours (current session only)",
 		},
 		{
-			name:         "session started yesterday, continues today",
-			sessionStart: time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC), // 11 PM yesterday
-			currentTime:  time.Date(2025, 1, 15, 0, 30, 0, 0, time.UTC), // 12:30 AM today
-			historicalEntries: []database.MediaHistoryEntry{
-				// Previous session yesterday: 10 PM - 11 PM (1 hour)
-				{
-					DBID:      2,
-					StartTime: time.Date(2025, 1, 14, 22, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC)),
-					PlayTime:  3600, // 1 hour in seconds
-				},
-			},
-			wantSessionDuration:     90 * time.Minute, // Total session: 1.5 hours
-			wantDailyUsageToday:     30 * time.Minute, // Only 30 minutes after midnight
+			// Previous session 22:00–23:00 yesterday; SQL excludes it (EndTime not > dayStart).
+			// sqlSeconds=0; only the 30 min after midnight counts toward today.
+			name:                    "session started yesterday, continues today",
+			sessionStart:            time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC),
+			currentTime:             time.Date(2025, 1, 15, 0, 30, 0, 0, time.UTC),
+			sqlSeconds:              0,
+			wantSessionDuration:     90 * time.Minute,
+			wantDailyUsageToday:     30 * time.Minute,
 			wantSessionDurationDesc: "1.5 hours total",
 			wantDailyUsageDesc:      "30 minutes (only time after midnight)",
 		},
 		{
-			name:         "session started yesterday, historical session spans midnight",
-			sessionStart: time.Date(2025, 1, 15, 1, 0, 0, 0, time.UTC), // 1 AM today
-			currentTime:  time.Date(2025, 1, 15, 2, 0, 0, 0, time.UTC), // 2 AM today
-			historicalEntries: []database.MediaHistoryEntry{
-				// Session that spans midnight: 11 PM yesterday - 12:30 AM today
-				{
-					DBID:      3,
-					StartTime: time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 0, 30, 0, 0, time.UTC)),
-					PlayTime:  5400, // 1.5 hours total
-				},
-			},
-			wantSessionDuration:     60 * time.Minute, // Current session: 1 hour
-			wantDailyUsageToday:     90 * time.Minute, // 30 min from historical + 60 min current
+			// Historical session spans midnight (23:00–00:30): 30 min portion after midnight = 1800 sec.
+			name:                    "session started yesterday, historical session spans midnight",
+			sessionStart:            time.Date(2025, 1, 15, 1, 0, 0, 0, time.UTC), // 1 AM today
+			currentTime:             time.Date(2025, 1, 15, 2, 0, 0, 0, time.UTC), // 2 AM today
+			sqlSeconds:              1800,                                         // 30 min after midnight
+			wantSessionDuration:     60 * time.Minute,                             // Current session: 1 hour
+			wantDailyUsageToday:     90 * time.Minute,                             // 30 min historical + 60 min current
 			wantSessionDurationDesc: "1 hour",
 			wantDailyUsageDesc:      "1.5 hours (30 min historical after midnight + 1 hour current)",
 		},
 		{
-			name:         "multiple historical sessions, some span midnight",
-			sessionStart: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC), // 10 AM today
-			currentTime:  time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC), // 11 AM today
-			historicalEntries: []database.MediaHistoryEntry{
-				// Most recent: Started today at 8 AM, ended at 9 AM (1 hour)
-				{
-					DBID:      5,
-					StartTime: time.Date(2025, 1, 15, 8, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 9, 0, 0, 0, time.UTC)),
-					PlayTime:  3600,
-				},
-				// Spans midnight: 11:30 PM yesterday - 12:45 AM today
-				{
-					DBID:      4,
-					StartTime: time.Date(2025, 1, 14, 23, 30, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 0, 45, 0, 0, time.UTC)),
-					PlayTime:  4500, // 1.25 hours total
-				},
-				// Entirely yesterday: 10 PM - 11 PM
-				{
-					DBID:      3,
-					StartTime: time.Date(2025, 1, 14, 22, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 14, 23, 0, 0, 0, time.UTC)),
-					PlayTime:  3600,
-				},
-			},
-			wantSessionDuration:     60 * time.Minute,  // Current: 1 hour
-			wantDailyUsageToday:     165 * time.Minute, // 45 min (midnight span) + 60 min (8-9 AM) + 60 min (current)
+			// Two historical sessions overlap today: 8–9 AM (3600 sec) + midnight-span 45 min
+			// (2700 sec) = 6300 sec total. Entirely-yesterday session (22–23) excluded by SQL.
+			// wantDailyUsageToday = 105 min historical + 60 min current = 165 min.
+			name:                    "multiple historical sessions, some span midnight",
+			sessionStart:            time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+			currentTime:             time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC),
+			sqlSeconds:              6300,
+			wantSessionDuration:     60 * time.Minute,
+			wantDailyUsageToday:     165 * time.Minute,
 			wantSessionDurationDesc: "1 hour",
-			wantDailyUsageDesc:      "2h45m (45 min from midnight span + 1 hour 8-9 AM + 1 hour current)",
+			wantDailyUsageDesc:      "2h45m (45 min midnight span + 1 hour 8-9 AM + 1 hour current)",
 		},
 		{
-			name:         "historical session ended before today - should not count",
-			sessionStart: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-			currentTime:  time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC),
-			historicalEntries: []database.MediaHistoryEntry{
-				// Ended before today
-				{
-					DBID:      2,
-					StartTime: time.Date(2025, 1, 14, 22, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 14, 23, 30, 0, 0, time.UTC)),
-					PlayTime:  5400,
-				},
-			},
+			// Historical session 22:00–23:30 yesterday; EndTime not > dayStart, excluded.
+			name:                    "historical session ended before today - should not count",
+			sessionStart:            time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+			currentTime:             time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC),
+			sqlSeconds:              0, // excluded
 			wantSessionDuration:     60 * time.Minute,
 			wantDailyUsageToday:     60 * time.Minute, // Only current session
 			wantSessionDurationDesc: "1 hour",
@@ -393,7 +362,7 @@ func TestBuildRuleContext_MidnightRollover_CurrentSession(t *testing.T) {
 
 			// Setup mock database
 			mockDB := testhelpers.NewMockUserDBI()
-			mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return(tt.historicalEntries, nil)
+			mockDB.On("SumMediaPlayTimeForDay", todayStart).Return(tt.sqlSeconds, nil)
 
 			db := &database.Database{
 				UserDB: mockDB,
@@ -434,71 +403,47 @@ func TestCalculateDailyUsage_EdgeCases(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		todayStart            time.Time
-		name                  string
-		historicalEntries     []database.MediaHistoryEntry
-		currentSessionDur     time.Duration
-		wantDailyUsage        time.Duration
-		wantDailyUsageMinutes int
+		todayStart        time.Time
+		name              string
+		currentSessionDur time.Duration
+		wantDailyUsage    time.Duration
+		// sqlSeconds is the value SumMediaPlayTimeForDay returns for completed
+		// sessions overlapping today. The active session (EndTime IS NULL) is
+		// excluded by the SQL query; callers add currentSessionDur separately.
+		sqlSeconds int64
 	}{
 		{
 			name:              "no historical entries, only current session",
 			todayStart:        time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
 			currentSessionDur: 45 * time.Minute,
-			historicalEntries: []database.MediaHistoryEntry{},
+			sqlSeconds:        0,
 			wantDailyUsage:    45 * time.Minute,
 		},
 		{
+			// Completed session (1 hour) + active session excluded by SQL.
+			// currentSessionDur accounts for the active session; no double-count.
 			name:              "active session in DB should be skipped (prevents double-counting)",
 			todayStart:        time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
 			currentSessionDur: 30 * time.Minute,
-			historicalEntries: []database.MediaHistoryEntry{
-				// Previous completed session today
-				{
-					DBID:      2,
-					StartTime: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 11, 0, 0, 0, time.UTC)),
-					PlayTime:  3600, // 1 hour
-				},
-				// Active session (EndTime = nil) - should be SKIPPED to avoid double-count
-				{
-					DBID:      3,
-					StartTime: time.Date(2025, 1, 15, 14, 0, 0, 0, time.UTC),
-					EndTime:   nil,  // Still running
-					PlayTime:  1800, // 30 minutes (same as currentSessionDur)
-				},
-			},
-			// Should be: 1 hour (completed) + 30 min (current) = 90 minutes
-			// NOT: 1 hour + 30 min (from DB) + 30 min (current) = 2 hours
-			wantDailyUsage: 90 * time.Minute,
+			sqlSeconds:        3600, // 1 hour completed session
+			wantDailyUsage:    90 * time.Minute,
 		},
 		{
+			// Session ending exactly at midnight: EndTime == dayStart, SQL uses > not >=, so excluded.
 			name:              "historical session exactly at midnight boundary",
 			todayStart:        time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
 			currentSessionDur: 30 * time.Minute,
-			historicalEntries: []database.MediaHistoryEntry{
-				{
-					DBID:      1,
-					StartTime: time.Date(2025, 1, 14, 23, 59, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)), // Ends exactly at midnight
-					PlayTime:  60,
-				},
-			},
-			wantDailyUsage: 30 * time.Minute, // Should not count the midnight-ending session
+			sqlSeconds:        0,
+			wantDailyUsage:    30 * time.Minute,
 		},
 		{
+			// Session ending 1 second after midnight: EndTime > dayStart, StartTime < dayStart.
+			// SQL returns EndTime - dayStart = 1 second.
 			name:              "historical session ends 1 second after midnight",
 			todayStart:        time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
 			currentSessionDur: 30 * time.Minute,
-			historicalEntries: []database.MediaHistoryEntry{
-				{
-					DBID:      1,
-					StartTime: time.Date(2025, 1, 14, 23, 59, 0, 0, time.UTC),
-					EndTime:   timePtr(time.Date(2025, 1, 15, 0, 0, 1, 0, time.UTC)), // 1 second after midnight
-					PlayTime:  61,
-				},
-			},
-			wantDailyUsage: 30*time.Minute + 1*time.Second, // Should count 1 second from historical
+			sqlSeconds:        1,
+			wantDailyUsage:    30*time.Minute + 1*time.Second,
 		},
 	}
 
@@ -508,7 +453,7 @@ func TestCalculateDailyUsage_EdgeCases(t *testing.T) {
 
 			// Setup mock database
 			mockDB := testhelpers.NewMockUserDBI()
-			mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).Return(tt.historicalEntries, nil)
+			mockDB.On("SumMediaPlayTimeForDay", tt.todayStart).Return(tt.sqlSeconds, nil)
 
 			db := &database.Database{
 				UserDB: mockDB,
@@ -517,11 +462,6 @@ func TestCalculateDailyUsage_EdgeCases(t *testing.T) {
 			// Create LimitsManager
 			cfg := &config.Instance{}
 			tm := NewLimitsManager(db, nil, cfg, clockwork.NewRealClock(), newNoOpMockPlayer())
-
-			// Mark session start as reliable
-			tm.mu.Lock()
-			tm.sessionStartReliable = true
-			tm.mu.Unlock()
 
 			// Calculate daily usage
 			dailyUsage, err := tm.calculateDailyUsage(tt.todayStart, tt.currentSessionDur)
@@ -533,9 +473,4 @@ func TestCalculateDailyUsage_EdgeCases(t *testing.T) {
 			mockDB.AssertExpectations(t)
 		})
 	}
-}
-
-// Helper function to create time pointers
-func timePtr(t time.Time) *time.Time {
-	return &t
 }

--- a/pkg/service/playtime/limits_test.go
+++ b/pkg/service/playtime/limits_test.go
@@ -474,3 +474,398 @@ func TestCalculateDailyUsage_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestRestoreSessionFromHistory covers the session-restore path that reconstructs
+// cooldown state from MediaHistory entries after a service restart.
+func TestRestoreSessionFromHistory(t *testing.T) {
+	t.Parallel()
+
+	// All test cases use the default 20-minute session reset timeout (nil SessionReset = default).
+	baseCfg := func(t *testing.T) *config.Instance {
+		t.Helper()
+		//nolint:exhaustruct // only SessionResetTimeout (default) needed
+		cfg, err := config.NewConfig(t.TempDir(), config.Values{})
+		require.NoError(t, err)
+		return cfg
+	}
+
+	t.Run("no entries - no restore", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testhelpers.NewMockUserDBI()
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{}, nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), clockwork.NewFakeClock(), newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(time.Now())
+
+		tm.mu.Lock()
+		assert.Equal(t, StateReset, tm.state)
+		assert.Equal(t, time.Duration(0), tm.sessionCumulativeTime)
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("most recent entry still open - no restore", func(t *testing.T) {
+		t.Parallel()
+
+		mockDB := testhelpers.NewMockUserDBI()
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{
+				{DBID: 1, StartTime: time.Now().Add(-5 * time.Minute), EndTime: nil, PlayTime: 300},
+			}, nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), clockwork.NewFakeClock(), newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(time.Now())
+
+		tm.mu.Lock()
+		assert.Equal(t, StateReset, tm.state)
+		assert.Equal(t, time.Duration(0), tm.sessionCumulativeTime)
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("last session outside cooldown window - no restore", func(t *testing.T) {
+		t.Parallel()
+
+		// Session ended 25 minutes ago; default cooldown is 20 minutes.
+		endTime := time.Now().Add(-25 * time.Minute)
+		mockDB := testhelpers.NewMockUserDBI()
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{
+				{DBID: 1, StartTime: endTime.Add(-10 * time.Minute), EndTime: &endTime, PlayTime: 600},
+			}, nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), clockwork.NewFakeClock(), newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(time.Now())
+
+		tm.mu.Lock()
+		assert.Equal(t, StateReset, tm.state)
+		assert.Equal(t, time.Duration(0), tm.sessionCumulativeTime)
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("single session within cooldown window - restored to cooldown", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2025, 6, 13, 12, 0, 0, 0, time.UTC)
+		// Session ended 5 minutes ago with 10 minutes of play time.
+		endTime := now.Add(-5 * time.Minute)
+		startTime := endTime.Add(-10 * time.Minute)
+
+		mockDB := testhelpers.NewMockUserDBI()
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{
+				{DBID: 1, StartTime: startTime, EndTime: &endTime, PlayTime: 600},
+			}, nil)
+
+		fakeClock := clockwork.NewFakeClockAt(now)
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), fakeClock, newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(now)
+
+		tm.mu.Lock()
+		assert.Equal(t, StateCooldown, tm.state, "state should be restored to cooldown")
+		assert.Equal(t, 600*time.Second, tm.sessionCumulativeTime, "cumulative time should match PlayTime")
+		assert.Equal(t, endTime, tm.lastStopTime, "last stop time should be restored")
+		assert.NotNil(t, tm.cooldownTimer, "cooldown timer should be set")
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("multiple consecutive sessions - cumulative time accumulates", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2025, 6, 13, 12, 0, 0, 0, time.UTC)
+
+		// Most recent session (DBID 2): ended 3 minutes ago, 5 minutes play.
+		end2 := now.Add(-3 * time.Minute)
+		start2 := end2.Add(-5 * time.Minute)
+		// Previous session (DBID 1): ended 10 minutes ago (gap 7 min < 20 min), 8 minutes play.
+		end1 := now.Add(-10 * time.Minute)
+		start1 := end1.Add(-8 * time.Minute)
+
+		mockDB := testhelpers.NewMockUserDBI()
+		// GetMediaHistory returns newest-first.
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{
+				{DBID: 2, StartTime: start2, EndTime: &end2, PlayTime: 300},
+				{DBID: 1, StartTime: start1, EndTime: &end1, PlayTime: 480},
+			}, nil)
+
+		fakeClock := clockwork.NewFakeClockAt(now)
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), fakeClock, newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(now)
+
+		tm.mu.Lock()
+		assert.Equal(t, StateCooldown, tm.state)
+		// 300s + 480s = 780s total cumulative time
+		assert.Equal(t, 780*time.Second, tm.sessionCumulativeTime)
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("gap between sessions exceeds window - only most recent session counted", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2025, 6, 13, 12, 0, 0, 0, time.UTC)
+
+		// Most recent session (DBID 2): ended 3 minutes ago, 5 minutes play.
+		end2 := now.Add(-3 * time.Minute)
+		start2 := end2.Add(-5 * time.Minute)
+		// Previous session (DBID 1): ended 30 minutes ago (gap 25 min > 20 min), 10 minutes play.
+		end1 := now.Add(-30 * time.Minute)
+		start1 := end1.Add(-10 * time.Minute)
+
+		mockDB := testhelpers.NewMockUserDBI()
+		mockDB.On("GetMediaHistory", []string(nil), int64(0), 100).
+			Return([]database.MediaHistoryEntry{
+				{DBID: 2, StartTime: start2, EndTime: &end2, PlayTime: 300},
+				{DBID: 1, StartTime: start1, EndTime: &end1, PlayTime: 600},
+			}, nil)
+
+		fakeClock := clockwork.NewFakeClockAt(now)
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			baseCfg(t), fakeClock, newNoOpMockPlayer(),
+		)
+		defer tm.Stop()
+
+		tm.RestoreSessionFromHistory(now)
+
+		tm.mu.Lock()
+		assert.Equal(t, StateCooldown, tm.state)
+		// Only the most recent 300s session should be accumulated; gap breaks the chain.
+		assert.Equal(t, 300*time.Second, tm.sessionCumulativeTime)
+		tm.mu.Unlock()
+		mockDB.AssertExpectations(t)
+	})
+}
+
+// TestCheckBeforeLaunch verifies that CheckBeforeLaunch correctly blocks launches
+// when daily or session limits have been reached or leave insufficient time.
+func TestCheckBeforeLaunch(t *testing.T) {
+	t.Parallel()
+
+	// reliableClock returns a time in 2025 so helpers.IsClockReliable returns true.
+	reliableTime := time.Date(2025, 6, 13, 12, 0, 0, 0, time.UTC)
+	todayStart := time.Date(2025, 6, 13, 0, 0, 0, 0, time.UTC)
+
+	t.Run("limits not enabled in config - allowed", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Daily:   "2h",
+					Session: "1h",
+				},
+			},
+		})
+
+		tm := NewLimitsManager(nil, nil, cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer())
+		// PlaytimeLimitsEnabled() is false (Enabled == nil)
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.NoError(t, err)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("no limits configured - allowed", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Daily:   "",
+					Session: "",
+				},
+			},
+		})
+
+		tm := NewLimitsManager(nil, nil, cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer())
+		tm.SetEnabled(true)
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.NoError(t, err)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("daily limit fully consumed - blocked with daily reason", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Daily:   "2h",
+				},
+			},
+		})
+
+		mockDB := testhelpers.NewMockUserDBI()
+		// DB reports 2 hours already played today.
+		mockDB.On("SumMediaPlayTimeForDay", todayStart).Return(int64(7200), nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer(),
+		)
+		tm.SetEnabled(true)
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.Error(t, err)
+		assert.Equal(t, apimodels.PlaytimeLimitReasonDaily, reason)
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("daily limit with less than minimum viable session remaining - blocked", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Daily:   "2h",
+				},
+			},
+		})
+
+		mockDB := testhelpers.NewMockUserDBI()
+		// 30 seconds remaining (2h limit - 1h59m30s played). MinimumViableSession = 1 minute.
+		mockDB.On("SumMediaPlayTimeForDay", todayStart).Return(int64(7170), nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer(),
+		)
+		tm.SetEnabled(true)
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.Error(t, err)
+		assert.Equal(t, apimodels.PlaytimeLimitReasonDaily, reason)
+		mockDB.AssertExpectations(t)
+	})
+
+	t.Run("session limit fully consumed - blocked with session reason", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Session: "1h",
+				},
+			},
+		})
+
+		tm := NewLimitsManager(
+			nil, nil,
+			cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer(),
+		)
+		tm.SetEnabled(true)
+
+		// Inject 1h of accumulated session time.
+		tm.mu.Lock()
+		tm.sessionCumulativeTime = time.Hour
+		tm.mu.Unlock()
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.Error(t, err)
+		assert.Equal(t, apimodels.PlaytimeLimitReasonSession, reason)
+	})
+
+	t.Run("session limit with less than minimum viable session remaining - blocked", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Session: "1h",
+				},
+			},
+		})
+
+		tm := NewLimitsManager(
+			nil, nil,
+			cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer(),
+		)
+		tm.SetEnabled(true)
+
+		// 59m30s used — 30 seconds remain, which is below MinimumViableSession (1 minute).
+		tm.mu.Lock()
+		tm.sessionCumulativeTime = 59*time.Minute + 30*time.Second
+		tm.mu.Unlock()
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.Error(t, err)
+		assert.Equal(t, apimodels.PlaytimeLimitReasonSession, reason)
+	})
+
+	t.Run("both limits have time remaining - allowed", func(t *testing.T) {
+		t.Parallel()
+
+		enabled := true
+		cfg := newTestConfig(t, &config.Values{
+			Playtime: config.Playtime{
+				Limits: config.PlaytimeLimits{
+					Enabled: &enabled,
+					Daily:   "2h",
+					Session: "1h",
+				},
+			},
+		})
+
+		mockDB := testhelpers.NewMockUserDBI()
+		// 30 minutes played today.
+		mockDB.On("SumMediaPlayTimeForDay", todayStart).Return(int64(1800), nil)
+
+		tm := NewLimitsManager(
+			&database.Database{UserDB: mockDB}, nil,
+			cfg, clockwork.NewFakeClockAt(reliableTime), newNoOpMockPlayer(),
+		)
+		tm.SetEnabled(true)
+
+		// 30 minutes of session cumulative time accumulated.
+		tm.mu.Lock()
+		tm.sessionCumulativeTime = 30 * time.Minute
+		tm.mu.Unlock()
+
+		reason, err := tm.CheckBeforeLaunch()
+		require.NoError(t, err)
+		assert.Empty(t, reason)
+		mockDB.AssertExpectations(t)
+	})
+}

--- a/pkg/service/playtime/limits_unit_test.go
+++ b/pkg/service/playtime/limits_unit_test.go
@@ -285,12 +285,11 @@ func TestCooldownTimer_AutomaticReset(t *testing.T) {
 
 	tm.enabled = true
 
-	// Simulate entering cooldown with 20 minute timeout
+	// Simulate entering cooldown with 20 minute timeout (default from config).
 	tm.mu.Lock()
 	tm.state = StateCooldown
 	tm.sessionCumulativeTime = 30 * time.Minute
 	tm.lastStopTime = clock.Now()
-	tm.sessionResetTimeout = 20 * time.Minute
 	tm.cooldownTimer = clock.NewTimer(20 * time.Minute)
 	tm.mu.Unlock()
 
@@ -336,12 +335,11 @@ func TestCooldownTimer_CancelledByNewGame(t *testing.T) {
 
 	tm.enabled = true
 
-	// Enter cooldown with timer running
+	// Enter cooldown with timer running (20 min = default from config).
 	tm.mu.Lock()
 	tm.state = StateCooldown
 	tm.sessionCumulativeTime = 15 * time.Minute
 	tm.lastStopTime = clock.Now()
-	tm.sessionResetTimeout = 20 * time.Minute
 	tm.cooldownTimer = clock.NewTimer(20 * time.Minute)
 	originalTimer := tm.cooldownTimer
 	tm.mu.Unlock()

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -589,12 +589,12 @@ func processTokenQueue(
 
 			// Only check playtime limits if the script contains media-launching commands
 			if hasMediaLaunchCmd {
-				if limitErr := limitsManager.CheckBeforeLaunch(); limitErr != nil {
-					log.Warn().Err(limitErr).Msg("playtime: launch blocked by daily limit")
+				if limitReason, limitErr := limitsManager.CheckBeforeLaunch(); limitErr != nil {
+					log.Warn().Err(limitErr).Msg("playtime: launch blocked by limit")
 
-					// Send playtime limit notification
+					// Send playtime limit notification with the actual reason (daily or session)
 					notifications.PlaytimeLimitReached(svc.State.Notifications, models.PlaytimeLimitReachedParams{
-						Reason: models.PlaytimeLimitReasonDaily,
+						Reason: limitReason,
 					})
 
 					path, enabled := svc.Config.LimitSoundPath(helpers.DataDir(svc.Platform))

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -592,13 +592,14 @@ func processTokenQueue(
 				if limitReason, limitErr := limitsManager.CheckBeforeLaunch(); limitErr != nil {
 					log.Warn().Err(limitErr).Msg("playtime: launch blocked by limit")
 
-					// Send playtime limit notification with the actual reason (daily or session)
-					notifications.PlaytimeLimitReached(svc.State.Notifications, models.PlaytimeLimitReachedParams{
-						Reason: limitReason,
-					})
+					if limitReason != "" {
+						notifications.PlaytimeLimitReached(svc.State.Notifications, models.PlaytimeLimitReachedParams{
+							Reason: limitReason,
+						})
 
-					path, enabled := svc.Config.LimitSoundPath(helpers.DataDir(svc.Platform))
-					helpers.PlayConfiguredSound(player, path, enabled, assets.LimitSound, "limit")
+						path, enabled := svc.Config.LimitSoundPath(helpers.DataDir(svc.Platform))
+						helpers.PlayConfiguredSound(player, path, enabled, assets.LimitSound, "limit")
+					}
 
 					he.Success = false
 					if histErr := svc.DB.UserDB.AddHistory(&he); histErr != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -244,6 +244,9 @@ func Start(
 	log.Info().Msg("initializing playtime limits")
 	limitsManager := playtime.NewLimitsManager(db, pl, cfg, clockwork.NewRealClock(), player)
 	limitsManager.Start(notifBroker, st.Notifications)
+	// Restore session state from history so session limits survive restarts within
+	// the cooldown window. Must run after CloseHangingMediaHistory (called above).
+	limitsManager.RestoreSessionFromHistory(time.Now())
 	if cfg.PlaytimeLimitsEnabled() {
 		limitsManager.SetEnabled(true)
 	}
@@ -436,7 +439,7 @@ func Start(
 		db:    db,
 		clock: clockwork.NewRealClock(),
 	}
-	historyNotifications, _ := notifBroker.Subscribe(100)
+	historyNotifications, _ := notifBroker.Subscribe(100, models.NotificationStarted, models.NotificationStopped)
 	historyListenDone := make(chan struct{})
 	go func() {
 		defer close(historyListenDone)

--- a/pkg/testing/fixtures/notification_broker.go
+++ b/pkg/testing/fixtures/notification_broker.go
@@ -33,7 +33,9 @@ func NewStopNotificationBroker() *StopNotificationBroker {
 	}
 }
 
-func (b *StopNotificationBroker) Subscribe(_ int) (notifications <-chan models.Notification, subscriptionID int) {
+func (b *StopNotificationBroker) Subscribe(
+	_ int, _ ...string,
+) (notifications <-chan models.Notification, subscriptionID int) {
 	return b.Notifications, 1
 }
 

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -381,6 +381,18 @@ func (m *MockUserDBI) HealTimestamps(bootUUID string, trueBootTime time.Time) (i
 	return rowsHealed, nil
 }
 
+func (m *MockUserDBI) SumMediaPlayTimeForDay(dayStart time.Time) (int64, error) {
+	args := m.Called(dayStart)
+	total, ok := args.Get(0).(int64)
+	if !ok {
+		total = 0
+	}
+	if err := args.Error(1); err != nil {
+		return total, fmt.Errorf("mock UserDBI sum media play time for day failed: %w", err)
+	}
+	return total, nil
+}
+
 func (m *MockUserDBI) AddInboxMessage(msg *database.InboxMessage) (*database.InboxMessage, error) {
 	args := m.Called(msg)
 	if result, ok := args.Get(0).(*database.InboxMessage); ok {


### PR DESCRIPTION
## Summary

- **Playtime history accuracy**: Replace paginated Go-side accumulation in `calculateDailyUsage` with a single `SumMediaPlayTimeForDay` SQL aggregate that pro-rates sessions crossing midnight correctly.
- **Session restore on restart**: `RestoreSessionFromHistory` reconstructs in-progress session state from the last open history entry, so a service restart mid-game does not reset the playtime timer.
- **Clock-rollback detection**: If the system clock moves backward by more than 1 minute, discard the current session start time to avoid recording negative durations.
- **15-second history flush**: Write in-progress play time to the database every 15 seconds so at most 15 seconds of playtime is lost on crash or power loss.
- **Close-before-open**: End any open history entry before opening a new one, preventing orphaned rows when games are launched back-to-back.
- **Live config**: `SessionResetTimeout` and daily limit changes take effect without a service restart.
- **`CheckBeforeLaunch` block reason**: Surface the reason a launch was blocked in the stopped notification so clients can distinguish a playtime-limit stop from a normal one.
- **Broker subscription method filtering**: Replace the blocking "guaranteed delivery" path with per-subscriber method filters. Subscribers declare which methods they want; `broadcast` skips non-matching subscribers with `continue` — no send attempted, no block possible. Restores the never-block invariant from #705 (#688/#691).
- **Lifecycle-only subscriber filtering**: Wire method filters on the four subscribers that only handle `media.started`/`media.stopped` (`LimitsManager`, `watchGameForIndexPause`, `watchGameForScrapePause`, `mediaHistoryTracker`). Their buffers can no longer fill with `media.indexing` traffic during index runs, which also fixes a latent bug where a dropped `media.started` mid-index would leave the indexer running at full speed through a game session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session state recovery on startup—playtime limits resume from the previous session when the app restarts.
  * Clearer messaging when playtime limits block game launches, specifying which limit (daily or session) was exceeded.

* **Bug Fixes**
  * Automatically closes orphaned media sessions that failed to stop properly.
  * Improved detection and handling of system clock rollbacks or anomalies in session timing.
  * Fixed goroutine leaks during media playback.

* **Refactoring**
  * Daily playtime tracking now aggregates completed sessions more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->