### PR TITLE
feat: add virtual launchable support

### DIFF
--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/rs/zerolog/log"
 )
 
@@ -68,6 +69,15 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 		}
 
 		respSystems = append(respSystems, sr)
+	}
+
+	for _, system := range launchables.DefaultRegistry.Systems(env.Platform) {
+		respSystems = append(respSystems, models.System{
+			ID:        launchables.EncodeID(system.ID),
+			Name:      system.Name,
+			Category:  system.Category,
+			ZapScript: system.ZapScript(),
+		})
 	}
 
 	return models.SystemsResponse{

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/rs/zerolog/log"
 )
@@ -71,7 +72,7 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 		respSystems = append(respSystems, sr)
 	}
 
-	for _, system := range launchables.Systems(env.Config, env.Platform) {
+	for _, system := range helpers.GlobalLauncherCache.GetLaunchableSystems() {
 		respSystems = append(respSystems, models.System{
 			ID:        launchables.EncodeID(system.ID),
 			Name:      system.Name,

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -71,7 +71,7 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 		respSystems = append(respSystems, sr)
 	}
 
-	for _, system := range launchables.DefaultRegistry.Systems(env.Platform) {
+	for _, system := range launchables.Systems(env.Config, env.Platform) {
 		respSystems = append(respSystems, models.System{
 			ID:        launchables.EncodeID(system.ID),
 			Name:      system.Name,

--- a/pkg/api/methods/virtual_launchables_test.go
+++ b/pkg/api/methods/virtual_launchables_test.go
@@ -1,0 +1,89 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withLaunchablesRegistry(t *testing.T, registry *launchables.Registry) {
+	t.Helper()
+	oldRegistry := launchables.DefaultRegistry
+	launchables.DefaultRegistry = registry
+	t.Cleanup(func() {
+		launchables.DefaultRegistry = oldRegistry
+	})
+}
+
+func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	registry := launchables.MustNewRegistry([]launchables.VirtualSystem{
+		{
+			ID:          id,
+			Name:        "Chess",
+			Category:    "Other",
+			PlatformIDs: []string{"test-platform"},
+			Launch: func(
+				*config.Instance,
+				platforms.Platform,
+				string,
+				*platforms.LaunchOptions,
+			) (*os.Process, error) {
+				return &os.Process{}, nil
+			},
+		},
+	}, nil)
+	withLaunchablesRegistry(t, registry)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		Database: &database.Database{MediaDB: mockMediaDB},
+	})
+
+	require.NoError(t, err)
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	require.Len(t, response.Systems, 1)
+	assert.Equal(t, launchables.EncodeID(id), response.Systems[0].ID)
+	assert.Equal(t, "Chess", response.Systems[0].Name)
+	assert.Equal(t, "Other", response.Systems[0].Category)
+	assert.Equal(t, "zaparoo://"+launchables.EncodeID(id)+"/Chess", response.Systems[0].ZapScript)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}

--- a/pkg/api/methods/virtual_launchables_test.go
+++ b/pkg/api/methods/virtual_launchables_test.go
@@ -36,39 +36,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func withLaunchablesRegistry(t *testing.T, registry *launchables.Registry) {
-	t.Helper()
-	oldRegistry := launchables.DefaultRegistry
-	launchables.DefaultRegistry = registry
-	t.Cleanup(func() {
-		launchables.DefaultRegistry = oldRegistry
-	})
+type apiLaunchablePlatform struct {
+	*mocks.MockPlatform
+	defs []launchables.Launchable
+}
+
+func (p *apiLaunchablePlatform) Launchables(*config.Instance) []launchables.Launchable {
+	return p.defs
 }
 
 func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-	registry := launchables.MustNewRegistry([]launchables.VirtualSystem{
-		{
-			ID:          id,
-			Name:        "Chess",
-			Category:    "Other",
-			PlatformIDs: []string{"test-platform"},
-			Launch: func(
-				*config.Instance,
-				platforms.Platform,
-				string,
-				*platforms.LaunchOptions,
-			) (*os.Process, error) {
-				return &os.Process{}, nil
-			},
-		},
-	}, nil)
-	withLaunchablesRegistry(t, registry)
-
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
-	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("ID").Return("test-platform")
+	mockPlatform := &apiLaunchablePlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []launchables.Launchable{
+			launchables.VirtualSystem{
+				ID:       id,
+				Name:     "Chess",
+				Category: "Other",
+				Launch: func(
+					*config.Instance,
+					string,
+					*platforms.LaunchOptions,
+				) (*os.Process, error) {
+					return &os.Process{}, nil
+				},
+			},
+		},
+	}
 
 	result, err := HandleSystems(requests.RequestEnv{
 		Platform: mockPlatform,
@@ -85,5 +82,4 @@ func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 	assert.Equal(t, "Other", response.Systems[0].Category)
 	assert.Equal(t, "zaparoo://"+launchables.EncodeID(id)+"/Chess", response.Systems[0].ZapScript)
 	mockMediaDB.AssertExpectations(t)
-	mockPlatform.AssertExpectations(t)
 }

--- a/pkg/api/methods/virtual_launchables_test.go
+++ b/pkg/api/methods/virtual_launchables_test.go
@@ -27,12 +27,14 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	corehelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,7 +49,7 @@ func (p *apiLaunchablePlatform) Launchables(*config.Instance) []launchables.Laun
 
 func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB := testhelpers.NewMockMediaDBI()
 	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
 	mockPlatform := &apiLaunchablePlatform{
 		MockPlatform: mocks.NewMockPlatform(),
@@ -66,6 +68,14 @@ func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 			},
 		},
 	}
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+	originalCache := corehelpers.GlobalLauncherCache
+	cache := &corehelpers.LauncherCache{}
+	cache.Initialize(mockPlatform, &config.Instance{})
+	corehelpers.GlobalLauncherCache = cache
+	t.Cleanup(func() {
+		corehelpers.GlobalLauncherCache = originalCache
+	})
 
 	result, err := HandleSystems(requests.RequestEnv{
 		Platform: mockPlatform,

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -127,6 +127,7 @@ type System struct {
 	ID           string  `json:"id,omitempty"`
 	Name         string  `json:"name,omitempty"`
 	Category     string  `json:"category,omitempty"`
+	ZapScript    string  `json:"zapScript,omitempty"`
 }
 
 type SystemsResponse struct {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/charlievieth/fastwalk"
 	sqlite3 "github.com/mattn/go-sqlite3"
@@ -688,6 +689,7 @@ func NewNamesIndex(
 	// Build launcher metadata once so runnable-system filtering and scanner
 	// execution both use the same launcher set even when the global cache is stale.
 	allLaunchers := platform.Launchers(cfg)
+	allLaunchers = append(allLaunchers, launchables.DefaultRegistry.Launchers(platform)...)
 	launcherCache := &helpers.LauncherCache{}
 	launcherCache.InitializeFromSlice(allLaunchers)
 
@@ -711,6 +713,9 @@ func NewNamesIndex(
 		if allLaunchers[i].SystemID == "" && allLaunchers[i].Scanner != nil {
 			anyScanners = append(anyScanners, &allLaunchers[i])
 		}
+	}
+	for _, item := range launchables.DefaultRegistry.Media(platform) {
+		systemsWithScanners[item.SystemID] = true
 	}
 
 	existingSystems, getExistingSystemsErr := db.GetAllSystems()
@@ -1016,6 +1021,17 @@ func NewNamesIndex(
 				continue
 			}
 			files = append(files, results...)
+		}
+
+		// 4. Registry-backed virtual media. These are indexed as normal MediaDB
+		// rows with zaparoo:// paths, so search, browse, paging, and missing-state
+		// handling stay in one place.
+		for _, item := range launchables.DefaultRegistry.MediaForSystem(platform, systemID) {
+			files = append(files, platforms.ScanResult{
+				Path:  item.ZapScript(),
+				Name:  item.Name,
+				NoExt: true,
+			})
 		}
 
 		if len(files) == 0 {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -575,6 +575,17 @@ type IndexStatus struct {
 // during key steps.
 //
 // Returns the total number of files indexed.
+func newIndexLauncherCache(
+	cfg *config.Instance,
+	platform platforms.Platform,
+) (*helpers.LauncherCache, []platforms.Launcher) {
+	allLaunchers := platform.Launchers(cfg)
+	allLaunchers = append(allLaunchers, launchables.DefaultRegistry.Launchers(platform)...)
+	launcherCache := &helpers.LauncherCache{}
+	launcherCache.InitializeFromSlice(allLaunchers)
+	return launcherCache, allLaunchers
+}
+
 func NewNamesIndex(
 	ctx context.Context,
 	platform platforms.Platform,
@@ -688,10 +699,7 @@ func NewNamesIndex(
 
 	// Build launcher metadata once so runnable-system filtering and scanner
 	// execution both use the same launcher set even when the global cache is stale.
-	allLaunchers := platform.Launchers(cfg)
-	allLaunchers = append(allLaunchers, launchables.DefaultRegistry.Launchers(platform)...)
-	launcherCache := &helpers.LauncherCache{}
-	launcherCache.InitializeFromSlice(allLaunchers)
+	launcherCache, allLaunchers := newIndexLauncherCache(cfg, platform)
 
 	// Get the ordered list of systems for this run (deterministic by ID)
 	update(IndexStatus{Phase: PhaseDiscovering})

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -580,7 +580,7 @@ func newIndexLauncherCache(
 	platform platforms.Platform,
 ) (*helpers.LauncherCache, []platforms.Launcher) {
 	allLaunchers := platform.Launchers(cfg)
-	allLaunchers = append(allLaunchers, launchables.DefaultRegistry.Launchers(platform)...)
+	allLaunchers = append(allLaunchers, launchables.Launchers(cfg, platform)...)
 	launcherCache := &helpers.LauncherCache{}
 	launcherCache.InitializeFromSlice(allLaunchers)
 	return launcherCache, allLaunchers
@@ -722,7 +722,7 @@ func NewNamesIndex(
 			anyScanners = append(anyScanners, &allLaunchers[i])
 		}
 	}
-	for _, item := range launchables.DefaultRegistry.Media(platform) {
+	for _, item := range launchables.Media(cfg, platform) {
 		systemsWithScanners[item.SystemID] = true
 	}
 
@@ -1031,10 +1031,10 @@ func NewNamesIndex(
 			files = append(files, results...)
 		}
 
-		// 4. Registry-backed virtual media. These are indexed as normal MediaDB
+		// 4. Platform-defined virtual media. These are indexed as normal MediaDB
 		// rows with zaparoo:// paths, so search, browse, paging, and missing-state
 		// handling stay in one place.
-		for _, item := range launchables.DefaultRegistry.MediaForSystem(platform, systemID) {
+		for _, item := range launchables.MediaForSystem(cfg, platform, systemID) {
 			files = append(files, platforms.ScanResult{
 				Path:  item.ZapScript(),
 				Name:  item.Name,

--- a/pkg/database/mediascanner/virtual_launchables_test.go
+++ b/pkg/database/mediascanner/virtual_launchables_test.go
@@ -1,0 +1,125 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func withMediascannerLaunchablesRegistry(t *testing.T, registry *launchables.Registry) {
+	t.Helper()
+	oldRegistry := launchables.DefaultRegistry
+	launchables.DefaultRegistry = registry
+	t.Cleanup(func() {
+		launchables.DefaultRegistry = oldRegistry
+	})
+}
+
+func testVirtualLaunch() launchables.LaunchFunc {
+	return func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error) {
+		return &os.Process{}, nil
+	}
+}
+
+func TestNewIndexLauncherCacheIncludesRegistryLaunchers(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	item := launchables.VirtualMedia{
+		ID:          id,
+		SystemID:    systemdefs.SystemCPS3,
+		Name:        "Street Fighter III: 3rd Strike",
+		PlatformIDs: []string{"test-platform"},
+		Launch:      testVirtualLaunch(),
+	}
+	withMediascannerLaunchablesRegistry(t, launchables.MustNewRegistry(nil, []launchables.VirtualMedia{item}))
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "NativeLauncher", SystemID: systemdefs.SystemCPS3},
+	})
+	cfg := &config.Instance{}
+
+	launcherCache, allLaunchers := newIndexLauncherCache(cfg, platform)
+
+	assert.Len(t, allLaunchers, 2)
+	systemLaunchers := launcherCache.GetLaunchersBySystem(systemdefs.SystemCPS3)
+	require.Len(t, systemLaunchers, 2)
+	assert.True(t, helpers.PathIsLauncher(cfg, platform, &systemLaunchers[1], item.ZapScript()))
+	wrongURI := "zaparoo://aaaaaaaaaaaaaaaaaaaaaaaaaa/Wrong"
+	assert.False(t, helpers.PathIsLauncher(cfg, platform, &systemLaunchers[1], wrongURI))
+	platform.AssertExpectations(t)
+}
+
+func TestNewNamesIndexIndexesVirtualMediaAndPreservesVirtualSystems(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	item := launchables.VirtualMedia{
+		ID:          id,
+		SystemID:    systemdefs.SystemCPS3,
+		Name:        "Street Fighter III: 3rd Strike",
+		PlatformIDs: []string{"test-platform"},
+		Launch:      testVirtualLaunch(),
+	}
+	withMediascannerLaunchablesRegistry(t, launchables.MustNewRegistry(nil, []launchables.VirtualMedia{item}))
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+
+	count, err := NewNamesIndex(
+		context.Background(),
+		platform,
+		cfg,
+		[]systemdefs.System{{ID: systemdefs.SystemCPS3}},
+		db,
+		func(IndexStatus) {},
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+	media, err := db.MediaDB.GetMediaBySystemID(systemdefs.SystemCPS3)
+	require.NoError(t, err)
+	require.Len(t, media, 1)
+	assert.Equal(t, item.ZapScript(), media[0].Path)
+	assert.Equal(t, systemdefs.SystemCPS3, media[0].SystemID)
+	platform.AssertExpectations(t)
+}

--- a/pkg/database/mediascanner/virtual_launchables_test.go
+++ b/pkg/database/mediascanner/virtual_launchables_test.go
@@ -74,9 +74,19 @@ func TestNewIndexLauncherCacheIncludesPlatformLaunchers(t *testing.T) {
 	assert.Len(t, allLaunchers, 2)
 	systemLaunchers := launcherCache.GetLaunchersBySystem(systemdefs.SystemCPS3)
 	require.Len(t, systemLaunchers, 2)
-	assert.True(t, helpers.PathIsLauncher(cfg, platform, &systemLaunchers[1], item.ZapScript()))
+
+	virtualLauncherID := "ZaparooVirtual-" + launchables.EncodeID(id)
+	var virtualLauncher *platforms.Launcher
+	for i := range systemLaunchers {
+		if systemLaunchers[i].ID == virtualLauncherID {
+			virtualLauncher = &systemLaunchers[i]
+			break
+		}
+	}
+	require.NotNil(t, virtualLauncher)
+	assert.True(t, helpers.PathIsLauncher(cfg, platform, virtualLauncher, item.ZapScript()))
 	wrongURI := "zaparoo://aaaaaaaaaaaaaaaaaaaaaaaaaa/Wrong"
-	assert.False(t, helpers.PathIsLauncher(cfg, platform, &systemLaunchers[1], wrongURI))
+	assert.False(t, helpers.PathIsLauncher(cfg, platform, virtualLauncher, wrongURI))
 	platform.AssertExpectations(t)
 }
 

--- a/pkg/database/mediascanner/virtual_launchables_test.go
+++ b/pkg/database/mediascanner/virtual_launchables_test.go
@@ -37,34 +37,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func withMediascannerLaunchablesRegistry(t *testing.T, registry *launchables.Registry) {
-	t.Helper()
-	oldRegistry := launchables.DefaultRegistry
-	launchables.DefaultRegistry = registry
-	t.Cleanup(func() {
-		launchables.DefaultRegistry = oldRegistry
-	})
+type mediascannerLaunchablePlatform struct {
+	*mocks.MockPlatform
+	defs []launchables.Launchable
+}
+
+func (p *mediascannerLaunchablePlatform) Launchables(*config.Instance) []launchables.Launchable {
+	return p.defs
 }
 
 func testVirtualLaunch() launchables.LaunchFunc {
-	return func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 		return &os.Process{}, nil
 	}
 }
 
-func TestNewIndexLauncherCacheIncludesRegistryLaunchers(t *testing.T) {
+func TestNewIndexLauncherCacheIncludesPlatformLaunchers(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	item := launchables.VirtualMedia{
-		ID:          id,
-		SystemID:    systemdefs.SystemCPS3,
-		Name:        "Street Fighter III: 3rd Strike",
-		PlatformIDs: []string{"test-platform"},
-		Launch:      testVirtualLaunch(),
+		ID:       id,
+		SystemID: systemdefs.SystemCPS3,
+		Name:     "Street Fighter III: 3rd Strike",
+		Launch:   testVirtualLaunch(),
 	}
-	withMediascannerLaunchablesRegistry(t, launchables.MustNewRegistry(nil, []launchables.VirtualMedia{item}))
-
-	platform := mocks.NewMockPlatform()
-	platform.On("ID").Return("test-platform")
+	platform := &mediascannerLaunchablePlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs:         []launchables.Launchable{item},
+	}
 	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
 		{ID: "NativeLauncher", SystemID: systemdefs.SystemCPS3},
 	})
@@ -84,13 +83,11 @@ func TestNewIndexLauncherCacheIncludesRegistryLaunchers(t *testing.T) {
 func TestNewNamesIndexIndexesVirtualMediaAndPreservesVirtualSystems(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	item := launchables.VirtualMedia{
-		ID:          id,
-		SystemID:    systemdefs.SystemCPS3,
-		Name:        "Street Fighter III: 3rd Strike",
-		PlatformIDs: []string{"test-platform"},
-		Launch:      testVirtualLaunch(),
+		ID:       id,
+		SystemID: systemdefs.SystemCPS3,
+		Name:     "Street Fighter III: 3rd Strike",
+		Launch:   testVirtualLaunch(),
 	}
-	withMediascannerLaunchablesRegistry(t, launchables.MustNewRegistry(nil, []launchables.VirtualMedia{item}))
 
 	fs := testhelpers.NewMemoryFS()
 	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
@@ -99,8 +96,10 @@ func TestNewNamesIndexIndexesVirtualMediaAndPreservesVirtualSystems(t *testing.T
 	db, cleanup := testhelpers.NewTestDatabase(t)
 	defer cleanup()
 
-	platform := mocks.NewMockPlatform()
-	platform.On("ID").Return("test-platform")
+	platform := &mediascannerLaunchablePlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs:         []launchables.Launchable{item},
+	}
 	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
 	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
 

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -33,9 +33,10 @@ import (
 // LauncherCache provides fast O(1) launcher lookups by system ID.
 // This replaces the expensive O(n*m) pl.Launchers() calls in hot paths.
 type LauncherCache struct {
-	bySystemID   map[string][]platforms.Launcher
-	allLaunchers []platforms.Launcher
-	mu           syncutil.RWMutex
+	bySystemID        map[string][]platforms.Launcher
+	allLaunchers      []platforms.Launcher
+	launchableSystems []launchables.VirtualSystem
+	mu                syncutil.RWMutex
 }
 
 // GlobalLauncherCache is the singleton instance used throughout the application.
@@ -45,14 +46,16 @@ var GlobalLauncherCache = &LauncherCache{}
 // Optional extra launchers (e.g. the native-audio launcher) are appended after
 // deduplication. This should be called once at startup after custom launchers are loaded.
 func (lc *LauncherCache) Initialize(pl platforms.Platform, cfg *config.Instance, extra ...platforms.Launcher) {
+	launchableSystems, launchableMedia := launchables.Available(cfg, pl)
 	all := pl.Launchers(cfg)
-	all = append(all, launchables.Launchers(cfg, pl)...)
+	all = append(all, launchables.LaunchersFor(launchableSystems, launchableMedia)...)
 	for i := range extra {
 		if !launcherInSlice(all, extra[i].ID) {
 			all = append(all, extra[i])
 		}
 	}
 	lc.rebuildFromSlice(all)
+	lc.setLaunchableSystems(launchableSystems)
 
 	lc.mu.RLock()
 	defer lc.mu.RUnlock()
@@ -94,6 +97,16 @@ func (lc *LauncherCache) GetAllLaunchers() []platforms.Launcher {
 	return result
 }
 
+// GetLaunchableSystems returns available virtual systems cached during launcher initialization.
+func (lc *LauncherCache) GetLaunchableSystems() []launchables.VirtualSystem {
+	lc.mu.RLock()
+	defer lc.mu.RUnlock()
+
+	result := make([]launchables.VirtualSystem, len(lc.launchableSystems))
+	copy(result, lc.launchableSystems)
+	return result
+}
+
 // InitializeFromSlice builds the launcher cache from a pre-built slice of launchers.
 // This is useful for testing or when launchers are already available.
 func (lc *LauncherCache) InitializeFromSlice(launchers []platforms.Launcher) {
@@ -105,6 +118,7 @@ func (lc *LauncherCache) rebuildFromSlice(launchers []platforms.Launcher) {
 	defer lc.mu.Unlock()
 	lc.allLaunchers = make([]platforms.Launcher, len(launchers))
 	copy(lc.allLaunchers, launchers)
+	lc.launchableSystems = nil
 
 	lc.bySystemID = make(map[string][]platforms.Launcher)
 	for i := range launchers {
@@ -113,6 +127,12 @@ func (lc *LauncherCache) rebuildFromSlice(launchers []platforms.Launcher) {
 			lc.bySystemID[launcher.SystemID] = append(lc.bySystemID[launcher.SystemID], launcher)
 		}
 	}
+}
+
+func (lc *LauncherCache) setLaunchableSystems(systems []launchables.VirtualSystem) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	lc.launchableSystems = append([]launchables.VirtualSystem(nil), systems...)
 }
 
 // GetLauncherByID finds a launcher by its unique ID.

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -46,7 +46,7 @@ var GlobalLauncherCache = &LauncherCache{}
 // deduplication. This should be called once at startup after custom launchers are loaded.
 func (lc *LauncherCache) Initialize(pl platforms.Platform, cfg *config.Instance, extra ...platforms.Launcher) {
 	all := pl.Launchers(cfg)
-	all = append(all, launchables.DefaultRegistry.Launchers(pl)...)
+	all = append(all, launchables.Launchers(cfg, pl)...)
 	for i := range extra {
 		if !launcherInSlice(all, extra[i].ID) {
 			all = append(all, extra[i])

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/rs/zerolog/log"
 )
@@ -45,6 +46,7 @@ var GlobalLauncherCache = &LauncherCache{}
 // deduplication. This should be called once at startup after custom launchers are loaded.
 func (lc *LauncherCache) Initialize(pl platforms.Platform, cfg *config.Instance, extra ...platforms.Launcher) {
 	all := pl.Launchers(cfg)
+	all = append(all, launchables.DefaultRegistry.Launchers(pl)...)
 	for i := range extra {
 		if !launcherInSlice(all, extra[i].ID) {
 			all = append(all, extra[i])

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -151,6 +151,8 @@ func (lc *LauncherCache) GetLauncherByID(id string) *platforms.Launcher {
 
 // Refresh rebuilds the cache with updated launcher data.
 // This can be called via API to refresh the cache without restarting.
+// During refresh, concurrent GetLaunchableSystems calls may briefly see no
+// virtual systems while the cache is rebuilt; they reappear after initialization.
 func (lc *LauncherCache) Refresh(pl platforms.Platform, cfg *config.Instance) {
 	lc.Initialize(pl, cfg)
 }

--- a/pkg/helpers/launcher_cache_test.go
+++ b/pkg/helpers/launcher_cache_test.go
@@ -21,14 +21,62 @@ package helpers
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetLaunchableSystems_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	systems := []launchables.VirtualSystem{
+		{ID: id, Name: "Chess", Category: "Other"},
+	}
+	cache := &LauncherCache{}
+	cache.setLaunchableSystems(systems)
+	systems[0].Name = "Mutated Source"
+
+	got := cache.GetLaunchableSystems()
+	require.Len(t, got, 1)
+	assert.Equal(t, id, got[0].ID)
+	assert.Equal(t, "Chess", got[0].Name)
+	assert.Equal(t, "Other", got[0].Category)
+
+	got[0].Name = "Mutated Result"
+	gotAgain := cache.GetLaunchableSystems()
+	require.Len(t, gotAgain, 1)
+	assert.Equal(t, "Chess", gotAgain[0].Name)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.Len(t, cache.GetLaunchableSystems(), 1)
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetLaunchableSystems_EmptyCache(t *testing.T) {
+	t.Parallel()
+
+	cache := &LauncherCache{}
+	got := cache.GetLaunchableSystems()
+	assert.Empty(t, got)
+
+	got = append(got, launchables.VirtualSystem{Name: "Mutated Result"})
+	assert.Len(t, got, 1)
+	assert.Empty(t, cache.GetLaunchableSystems())
+}
 
 func TestGetLauncherByID_Found(t *testing.T) {
 	t.Parallel()

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -459,6 +459,9 @@ func (m *LauncherMatcher) pathIsLauncher(
 
 	for _, scheme := range l.Schemes {
 		if strings.HasPrefix(lp, scheme+":") {
+			if l.Test != nil {
+				return l.Test(m.cfg, path)
+			}
 			return true
 		}
 	}

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -95,6 +95,9 @@ func PathIsLauncher(
 	for _, scheme := range l.Schemes {
 		// scheme is already lowercase in launcher definitions
 		if strings.HasPrefix(lp, scheme+":") {
+			if l.Test != nil {
+				return l.Test(cfg, path)
+			}
 			return true
 		}
 	}

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -381,6 +381,21 @@ func TestLauncherSpecificity(t *testing.T) {
 	}
 }
 
+func TestPathIsLauncher_SchemeUsesTestFunction(t *testing.T) {
+	t.Parallel()
+
+	launcher := platforms.Launcher{
+		ID:      "Virtual",
+		Schemes: []string{"zaparoo"},
+		Test: func(_ *config.Instance, path string) bool {
+			return path == "zaparoo://expected/Game"
+		},
+	}
+
+	assert.True(t, PathIsLauncher(nil, nil, &launcher, "zaparoo://expected/Game"))
+	assert.False(t, PathIsLauncher(nil, nil, &launcher, "zaparoo://other/Game"))
+}
+
 func TestFindLauncher_SpecificOverGeneric(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	mockPlatform := mocks.NewMockPlatform()

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -100,6 +100,39 @@ func TestLauncherMatcher_PassesSamePathToTestFunc(t *testing.T) {
 	assert.Equal(t, `c:\roms\custom\game.rom`, matcherSeen)
 }
 
+func TestLauncherMatcher_SchemeUsesTestFunction(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	launcher := platforms.Launcher{
+		ID:       "VirtualLauncher",
+		SystemID: "Virtual",
+		Schemes:  []string{"zaparoo"},
+		Test: func(_ *config.Instance, path string) bool {
+			return path == "zaparoo://expected/Game"
+		},
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+	assert.True(t, matcher.MatchSystemFile("Virtual", "zaparoo://expected/Game"))
+	assert.False(t, matcher.MatchSystemFile("Virtual", "zaparoo://other/Game"))
+}
+
 func TestLauncherMatcher_NilPlatformDoesNotSynthesizeMediaPaths(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	launcher := platforms.Launcher{

--- a/pkg/launchables/ids.go
+++ b/pkg/launchables/ids.go
@@ -1,0 +1,36 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package launchables
+
+import "github.com/google/uuid"
+
+// Define stable launchable UUIDs here, then import them from the platform
+// package that owns the actual launch behavior.
+var (
+	MisterOtherChess         = uuid.MustParse("cc7bb790-cc2c-47d2-aecc-fdd192e9d1e1")
+	MisterOtherDonut         = uuid.MustParse("65fc7c57-559b-4114-82db-7e96d1164cd6")
+	MisterOtherEpochGalaxyII = uuid.MustParse("d6443fe6-1c01-48f7-aa1d-30aca8fdc967")
+	MisterOtherFlappyBird    = uuid.MustParse("2b1c5f98-3a74-450e-8984-347e31c4a602")
+	MisterOtherGameOfLife    = uuid.MustParse("cc28721f-9239-4931-b10f-2a5c6180d26f")
+	MisterOtherGBMidi        = uuid.MustParse("565a41bc-7c9e-43a4-afcf-781659efe338")
+	MisterOtherGenMidi       = uuid.MustParse("91fafc5c-25d1-4356-b5b5-3628573d77b3")
+	MisterOtherSlugCross     = uuid.MustParse("e05893a4-59ee-4919-a3cd-47ff8c5e518d")
+	MisterOtherTomyScramble  = uuid.MustParse("349dfee7-bc32-4004-b377-ff8fe8083836")
+)

--- a/pkg/launchables/launchables.go
+++ b/pkg/launchables/launchables.go
@@ -17,8 +17,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
-// Package launchables defines virtual launch targets exposed through existing
-// system and media API shapes without inserting synthetic system definitions.
+// Package launchables defines shared IDs and URI helpers for platform-owned
+// virtual launch targets.
 package launchables
 
 import (
@@ -46,45 +46,44 @@ var encodedIDRe = regexp.MustCompile(`^[a-z2-7]{26}$`)
 
 var uuidBase32 = base32.StdEncoding.WithPadding(base32.NoPadding)
 
-// LaunchFunc executes a code-defined virtual target. The path argument is the
-// zaparoo:// URI that selected this launchable.
-type LaunchFunc func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error)
+// LaunchFunc executes a platform-defined virtual target. The path argument is
+// the zaparoo:// URI that selected this launchable.
+type LaunchFunc func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error)
+
+// Launchable is implemented by all platform-defined virtual launch targets.
+type Launchable interface {
+	isLaunchable()
+}
+
+// Provider is optionally implemented by platforms with launchable targets.
+type Provider interface {
+	Launchables(*config.Instance) []Launchable
+}
 
 // VirtualSystem is a launch-only entry returned from the systems endpoint.
 // ID is encoded into zaparoo:// URIs and must be globally unique.
 type VirtualSystem struct {
-	Launch      LaunchFunc
-	Name        string
-	Category    string
-	PlatformIDs []string
-	ID          uuid.UUID
+	Launch LaunchFunc
+	// Test reports whether the launchable is available. Nil means always available.
+	Test     func(*config.Instance) bool
+	Name     string
+	Category string
+	ID       uuid.UUID
 }
 
 // VirtualMedia is a single launch-only media-shaped entry attached to a real
 // Zaparoo system and indexed into MediaDB as a virtual URI path.
 type VirtualMedia struct {
-	Launch      LaunchFunc
-	SystemID    string
-	Name        string
-	PlatformIDs []string
-	ID          uuid.UUID
+	Launch LaunchFunc
+	// Test reports whether the launchable is available. Nil means always available.
+	Test     func(*config.Instance) bool
+	SystemID string
+	Name     string
+	ID       uuid.UUID
 }
 
-// Registry contains all code-defined virtual launch targets.
-type Registry struct {
-	byID    map[uuid.UUID]string
-	systems []VirtualSystem
-	media   []VirtualMedia
-}
-
-// SystemDefinitions is the central code-defined list of launch-only systems.
-var SystemDefinitions = []VirtualSystem{}
-
-// MediaDefinitions is the central code-defined list of virtual media items.
-var MediaDefinitions = []VirtualMedia{}
-
-// DefaultRegistry is used by API handlers, indexing, and virtual launchers.
-var DefaultRegistry = MustNewRegistry(SystemDefinitions, MediaDefinitions)
+func (VirtualSystem) isLaunchable() {}
+func (VirtualMedia) isLaunchable()  {}
 
 // EncodeID converts a UUID to canonical lowercase RFC 4648 base32 without padding.
 func EncodeID(id uuid.UUID) string {
@@ -123,50 +122,113 @@ func makeURI(id uuid.UUID, name string) string {
 	return fmt.Sprintf("%s://%s/%s", Scheme, EncodeID(id), url.PathEscape(name))
 }
 
-// NewRegistry validates and indexes virtual launch definitions.
-func NewRegistry(systems []VirtualSystem, media []VirtualMedia) (*Registry, error) {
-	r := &Registry{
-		byID:    make(map[uuid.UUID]string, len(systems)+len(media)),
-		systems: append([]VirtualSystem(nil), systems...),
-		media:   append([]VirtualMedia(nil), media...),
+// Launchables returns validated launchables defined by a platform.
+func Launchables(cfg *config.Instance, pl platforms.Platform) []Launchable {
+	provider, ok := pl.(Provider)
+	if !ok {
+		return nil
 	}
-
-	for i := range r.systems {
-		entry := &r.systems[i]
-		if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
-			return nil, fmt.Errorf("virtual system %q: %w", entry.Name, err)
-		}
-		if entry.Category == "" {
-			return nil, fmt.Errorf("virtual system %q: category is required", entry.Name)
-		}
-		if err := r.addID(entry.ID, "system", entry.Name); err != nil {
-			return nil, err
-		}
+	defs := provider.Launchables(cfg)
+	if len(defs) == 0 {
+		return nil
 	}
-
-	for i := range r.media {
-		entry := &r.media[i]
-		if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
-			return nil, fmt.Errorf("virtual media %q: %w", entry.Name, err)
-		}
-		if _, err := systemdefs.GetSystem(entry.SystemID); err != nil {
-			return nil, fmt.Errorf("virtual media %q: invalid system %q: %w", entry.Name, entry.SystemID, err)
-		}
-		if err := r.addID(entry.ID, "media", entry.Name); err != nil {
-			return nil, err
-		}
-	}
-
-	return r, nil
-}
-
-// MustNewRegistry panics when registry definitions are invalid.
-func MustNewRegistry(systems []VirtualSystem, media []VirtualMedia) *Registry {
-	r, err := NewRegistry(systems, media)
-	if err != nil {
+	if err := validateLaunchables(defs); err != nil {
 		panic(err)
 	}
-	return r
+	return filterAvailable(cfg, defs)
+}
+
+func filterAvailable(cfg *config.Instance, defs []Launchable) []Launchable {
+	out := make([]Launchable, 0, len(defs))
+	for i := range defs {
+		switch entry := defs[i].(type) {
+		case VirtualSystem:
+			if entry.Test == nil || entry.Test(cfg) {
+				out = append(out, entry)
+			}
+		case *VirtualSystem:
+			if entry.Test == nil || entry.Test(cfg) {
+				out = append(out, entry)
+			}
+		case VirtualMedia:
+			if entry.Test == nil || entry.Test(cfg) {
+				out = append(out, entry)
+			}
+		case *VirtualMedia:
+			if entry.Test == nil || entry.Test(cfg) {
+				out = append(out, entry)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func validateLaunchables(defs []Launchable) error {
+	seen := make(map[uuid.UUID]string, len(defs))
+	for i := range defs {
+		switch entry := defs[i].(type) {
+		case VirtualSystem:
+			if err := validateSystem(entry); err != nil {
+				return err
+			}
+			if err := addID(seen, entry.ID, "system", entry.Name); err != nil {
+				return err
+			}
+		case *VirtualSystem:
+			if entry == nil {
+				return errors.New("nil virtual system")
+			}
+			if err := validateSystem(*entry); err != nil {
+				return err
+			}
+			if err := addID(seen, entry.ID, "system", entry.Name); err != nil {
+				return err
+			}
+		case VirtualMedia:
+			if err := validateMedia(entry); err != nil {
+				return err
+			}
+			if err := addID(seen, entry.ID, "media", entry.Name); err != nil {
+				return err
+			}
+		case *VirtualMedia:
+			if entry == nil {
+				return errors.New("nil virtual media")
+			}
+			if err := validateMedia(*entry); err != nil {
+				return err
+			}
+			if err := addID(seen, entry.ID, "media", entry.Name); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported launchable type %T", defs[i])
+		}
+	}
+	return nil
+}
+
+func validateSystem(entry VirtualSystem) error {
+	if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
+		return fmt.Errorf("virtual system %q: %w", entry.Name, err)
+	}
+	if entry.Category == "" {
+		return fmt.Errorf("virtual system %q: category is required", entry.Name)
+	}
+	return nil
+}
+
+func validateMedia(entry VirtualMedia) error {
+	if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
+		return fmt.Errorf("virtual media %q: %w", entry.Name, err)
+	}
+	if _, err := systemdefs.GetSystem(entry.SystemID); err != nil {
+		return fmt.Errorf("virtual media %q: invalid system %q: %w", entry.Name, entry.SystemID, err)
+	}
+	return nil
 }
 
 func validateCommon(id uuid.UUID, name string, launch LaunchFunc) error {
@@ -182,41 +244,45 @@ func validateCommon(id uuid.UUID, name string, launch LaunchFunc) error {
 	return nil
 }
 
-func (r *Registry) addID(id uuid.UUID, typ, name string) error {
+func addID(seen map[uuid.UUID]string, id uuid.UUID, typ, name string) error {
 	label := typ + ":" + name
-	if existing, ok := r.byID[id]; ok {
+	if existing, ok := seen[id]; ok {
 		return fmt.Errorf("duplicate launchable id %s for %s and %s", EncodeID(id), existing, label)
 	}
-	r.byID[id] = label
+	seen[id] = label
 	return nil
 }
 
-// Systems returns virtual systems available for this platform.
-func (r *Registry) Systems(pl platforms.Platform) []VirtualSystem {
-	if len(r.systems) == 0 {
+// Systems returns virtual systems defined by this platform.
+func Systems(cfg *config.Instance, pl platforms.Platform) []VirtualSystem {
+	defs := Launchables(cfg, pl)
+	if len(defs) == 0 {
 		return nil
 	}
-	platformID := platformID(pl)
-	out := make([]VirtualSystem, 0, len(r.systems))
-	for i := range r.systems {
-		entry := &r.systems[i]
-		if platformMatches(platformID, entry.PlatformIDs) {
+	out := make([]VirtualSystem, 0, len(defs))
+	for i := range defs {
+		switch entry := defs[i].(type) {
+		case VirtualSystem:
+			out = append(out, entry)
+		case *VirtualSystem:
 			out = append(out, *entry)
 		}
 	}
 	return out
 }
 
-// Media returns virtual media available for this platform.
-func (r *Registry) Media(pl platforms.Platform) []VirtualMedia {
-	if len(r.media) == 0 {
+// Media returns virtual media defined by this platform.
+func Media(cfg *config.Instance, pl platforms.Platform) []VirtualMedia {
+	defs := Launchables(cfg, pl)
+	if len(defs) == 0 {
 		return nil
 	}
-	platformID := platformID(pl)
-	out := make([]VirtualMedia, 0, len(r.media))
-	for i := range r.media {
-		entry := &r.media[i]
-		if platformMatches(platformID, entry.PlatformIDs) {
+	out := make([]VirtualMedia, 0, len(defs))
+	for i := range defs {
+		switch entry := defs[i].(type) {
+		case VirtualMedia:
+			out = append(out, entry)
+		case *VirtualMedia:
 			out = append(out, *entry)
 		}
 	}
@@ -224,8 +290,8 @@ func (r *Registry) Media(pl platforms.Platform) []VirtualMedia {
 }
 
 // MediaForSystem returns virtual media for a real Zaparoo system ID.
-func (r *Registry) MediaForSystem(pl platforms.Platform, systemID string) []VirtualMedia {
-	media := r.Media(pl)
+func MediaForSystem(cfg *config.Instance, pl platforms.Platform, systemID string) []VirtualMedia {
+	media := Media(cfg, pl)
 	out := make([]VirtualMedia, 0, len(media))
 	for i := range media {
 		if media[i].SystemID == systemID {
@@ -235,44 +301,44 @@ func (r *Registry) MediaForSystem(pl platforms.Platform, systemID string) []Virt
 	return out
 }
 
-// Launchers returns scheme launchers that execute code-defined launchables.
-func (r *Registry) Launchers(pl platforms.Platform) []platforms.Launcher {
-	if len(r.systems) == 0 && len(r.media) == 0 {
+// Launchers returns scheme launchers that execute platform-defined launchables.
+func Launchers(cfg *config.Instance, pl platforms.Platform) []platforms.Launcher {
+	defs := Launchables(cfg, pl)
+	if len(defs) == 0 {
 		return nil
 	}
-	platformID := platformID(pl)
-	launchers := make([]platforms.Launcher, 0, len(r.systems)+len(r.media))
-	for i := range r.systems {
-		entry := &r.systems[i]
-		if platformMatches(platformID, entry.PlatformIDs) {
-			launchers = append(launchers, systemLauncher(pl, entry))
-		}
-	}
-	for i := range r.media {
-		entry := &r.media[i]
-		if platformMatches(platformID, entry.PlatformIDs) {
-			launchers = append(launchers, mediaLauncher(pl, entry))
+	launchers := make([]platforms.Launcher, 0, len(defs))
+	for i := range defs {
+		switch entry := defs[i].(type) {
+		case VirtualSystem:
+			launchers = append(launchers, systemLauncher(entry))
+		case *VirtualSystem:
+			launchers = append(launchers, systemLauncher(*entry))
+		case VirtualMedia:
+			launchers = append(launchers, mediaLauncher(entry))
+		case *VirtualMedia:
+			launchers = append(launchers, mediaLauncher(*entry))
 		}
 	}
 	return launchers
 }
 
-func systemLauncher(pl platforms.Platform, entry *VirtualSystem) platforms.Launcher {
+func systemLauncher(entry VirtualSystem) platforms.Launcher {
 	return platforms.Launcher{
 		ID:      launcherID(entry.ID),
 		Schemes: []string{Scheme},
 		Test:    pathMatchesID(entry.ID),
-		Launch:  launchWith(pl, entry.ID, entry.Launch),
+		Launch:  launchWith(entry.ID, entry.Launch),
 	}
 }
 
-func mediaLauncher(pl platforms.Platform, entry *VirtualMedia) platforms.Launcher {
+func mediaLauncher(entry VirtualMedia) platforms.Launcher {
 	return platforms.Launcher{
 		ID:       launcherID(entry.ID),
 		SystemID: entry.SystemID,
 		Schemes:  []string{Scheme},
 		Test:     pathMatchesID(entry.ID),
-		Launch:   launchWith(pl, entry.ID, entry.Launch),
+		Launch:   launchWith(entry.ID, entry.Launch),
 	}
 }
 
@@ -288,7 +354,6 @@ func pathMatchesID(id uuid.UUID) func(*config.Instance, string) bool {
 }
 
 func launchWith(
-	pl platforms.Platform,
 	id uuid.UUID,
 	launch LaunchFunc,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
@@ -300,27 +365,8 @@ func launchWith(
 		if !ok || pathID != id {
 			return nil, fmt.Errorf("zaparoo URI %q does not match launcher %s", path, launcherID(id))
 		}
-		return launch(cfg, pl, path, opts)
+		return launch(cfg, path, opts)
 	}
-}
-
-func platformID(pl platforms.Platform) string {
-	if pl == nil {
-		return ""
-	}
-	return pl.ID()
-}
-
-func platformMatches(platformID string, allowed []string) bool {
-	if len(allowed) == 0 {
-		return true
-	}
-	for _, id := range allowed {
-		if strings.EqualFold(platformID, id) {
-			return true
-		}
-	}
-	return false
 }
 
 // ParseURI extracts the UUID from a zaparoo URI. The path is decorative.

--- a/pkg/launchables/launchables.go
+++ b/pkg/launchables/launchables.go
@@ -253,40 +253,43 @@ func addID(seen map[uuid.UUID]string, id uuid.UUID, typ, name string) error {
 	return nil
 }
 
-// Systems returns virtual systems defined by this platform.
-func Systems(cfg *config.Instance, pl platforms.Platform) []VirtualSystem {
+// Available returns available virtual systems and media defined by this platform.
+func Available(cfg *config.Instance, pl platforms.Platform) ([]VirtualSystem, []VirtualMedia) {
 	defs := Launchables(cfg, pl)
 	if len(defs) == 0 {
-		return nil
+		return nil, nil
 	}
-	out := make([]VirtualSystem, 0, len(defs))
+	return split(defs)
+}
+
+func split(defs []Launchable) ([]VirtualSystem, []VirtualMedia) {
+	systems := make([]VirtualSystem, 0, len(defs))
+	media := make([]VirtualMedia, 0, len(defs))
 	for i := range defs {
 		switch entry := defs[i].(type) {
 		case VirtualSystem:
-			out = append(out, entry)
+			systems = append(systems, entry)
 		case *VirtualSystem:
-			out = append(out, *entry)
+			systems = append(systems, *entry)
+		case VirtualMedia:
+			media = append(media, entry)
+		case *VirtualMedia:
+			media = append(media, *entry)
 		}
 	}
-	return out
+	return systems, media
+}
+
+// Systems returns virtual systems defined by this platform.
+func Systems(cfg *config.Instance, pl platforms.Platform) []VirtualSystem {
+	systems, _ := Available(cfg, pl)
+	return systems
 }
 
 // Media returns virtual media defined by this platform.
 func Media(cfg *config.Instance, pl platforms.Platform) []VirtualMedia {
-	defs := Launchables(cfg, pl)
-	if len(defs) == 0 {
-		return nil
-	}
-	out := make([]VirtualMedia, 0, len(defs))
-	for i := range defs {
-		switch entry := defs[i].(type) {
-		case VirtualMedia:
-			out = append(out, entry)
-		case *VirtualMedia:
-			out = append(out, *entry)
-		}
-	}
-	return out
+	_, media := Available(cfg, pl)
+	return media
 }
 
 // MediaForSystem returns virtual media for a real Zaparoo system ID.
@@ -303,22 +306,21 @@ func MediaForSystem(cfg *config.Instance, pl platforms.Platform, systemID string
 
 // Launchers returns scheme launchers that execute platform-defined launchables.
 func Launchers(cfg *config.Instance, pl platforms.Platform) []platforms.Launcher {
-	defs := Launchables(cfg, pl)
-	if len(defs) == 0 {
+	systems, media := Available(cfg, pl)
+	return LaunchersFor(systems, media)
+}
+
+// LaunchersFor returns scheme launchers for already-filtered launchables.
+func LaunchersFor(systems []VirtualSystem, media []VirtualMedia) []platforms.Launcher {
+	if len(systems) == 0 && len(media) == 0 {
 		return nil
 	}
-	launchers := make([]platforms.Launcher, 0, len(defs))
-	for i := range defs {
-		switch entry := defs[i].(type) {
-		case VirtualSystem:
-			launchers = append(launchers, systemLauncher(entry))
-		case *VirtualSystem:
-			launchers = append(launchers, systemLauncher(*entry))
-		case VirtualMedia:
-			launchers = append(launchers, mediaLauncher(entry))
-		case *VirtualMedia:
-			launchers = append(launchers, mediaLauncher(*entry))
-		}
+	launchers := make([]platforms.Launcher, 0, len(systems)+len(media))
+	for i := range systems {
+		launchers = append(launchers, systemLauncher(systems[i]))
+	}
+	for i := range media {
+		launchers = append(launchers, mediaLauncher(media[i]))
 	}
 	return launchers
 }

--- a/pkg/launchables/launchables.go
+++ b/pkg/launchables/launchables.go
@@ -1,0 +1,350 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package launchables defines virtual launch targets exposed through existing
+// system and media API shapes without inserting synthetic system definitions.
+package launchables
+
+import (
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/google/uuid"
+)
+
+const Scheme = "zaparoo"
+
+const encodedIDLength = 26
+
+const launcherIDPrefix = "ZaparooVirtual-"
+
+var encodedIDRe = regexp.MustCompile(`^[a-z2-7]{26}$`)
+
+var uuidBase32 = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// LaunchFunc executes a code-defined virtual target. The path argument is the
+// zaparoo:// URI that selected this launchable.
+type LaunchFunc func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error)
+
+// VirtualSystem is a launch-only entry returned from the systems endpoint.
+// ID is encoded into zaparoo:// URIs and must be globally unique.
+type VirtualSystem struct {
+	Launch      LaunchFunc
+	Name        string
+	Category    string
+	PlatformIDs []string
+	ID          uuid.UUID
+}
+
+// VirtualMedia is a single launch-only media-shaped entry attached to a real
+// Zaparoo system and indexed into MediaDB as a virtual URI path.
+type VirtualMedia struct {
+	Launch      LaunchFunc
+	SystemID    string
+	Name        string
+	PlatformIDs []string
+	ID          uuid.UUID
+}
+
+// Registry contains all code-defined virtual launch targets.
+type Registry struct {
+	byID    map[uuid.UUID]string
+	systems []VirtualSystem
+	media   []VirtualMedia
+}
+
+// SystemDefinitions is the central code-defined list of launch-only systems.
+var SystemDefinitions = []VirtualSystem{}
+
+// MediaDefinitions is the central code-defined list of virtual media items.
+var MediaDefinitions = []VirtualMedia{}
+
+// DefaultRegistry is used by API handlers, indexing, and virtual launchers.
+var DefaultRegistry = MustNewRegistry(SystemDefinitions, MediaDefinitions)
+
+// EncodeID converts a UUID to canonical lowercase RFC 4648 base32 without padding.
+func EncodeID(id uuid.UUID) string {
+	return strings.ToLower(uuidBase32.EncodeToString(id[:]))
+}
+
+// DecodeID decodes a canonical zaparoo URI host ID. Input is case-insensitive.
+func DecodeID(s string) (uuid.UUID, error) {
+	var id uuid.UUID
+	normalized := strings.ToLower(strings.TrimSpace(s))
+	if len(normalized) != encodedIDLength || !encodedIDRe.MatchString(normalized) {
+		return id, fmt.Errorf("invalid launchable id %q", s)
+	}
+	raw, err := uuidBase32.DecodeString(strings.ToUpper(normalized))
+	if err != nil {
+		return id, fmt.Errorf("decode launchable id: %w", err)
+	}
+	if len(raw) != len(id) {
+		return id, fmt.Errorf("decoded launchable id has %d bytes", len(raw))
+	}
+	copy(id[:], raw)
+	return id, nil
+}
+
+// ZapScript returns the generated zaparoo URI for a virtual system.
+func (s *VirtualSystem) ZapScript() string {
+	return makeURI(s.ID, s.Name)
+}
+
+// ZapScript returns the generated zaparoo URI for a virtual media item.
+func (m *VirtualMedia) ZapScript() string {
+	return makeURI(m.ID, m.Name)
+}
+
+func makeURI(id uuid.UUID, name string) string {
+	return fmt.Sprintf("%s://%s/%s", Scheme, EncodeID(id), url.PathEscape(name))
+}
+
+// NewRegistry validates and indexes virtual launch definitions.
+func NewRegistry(systems []VirtualSystem, media []VirtualMedia) (*Registry, error) {
+	r := &Registry{
+		byID:    make(map[uuid.UUID]string, len(systems)+len(media)),
+		systems: append([]VirtualSystem(nil), systems...),
+		media:   append([]VirtualMedia(nil), media...),
+	}
+
+	for i := range r.systems {
+		entry := &r.systems[i]
+		if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
+			return nil, fmt.Errorf("virtual system %q: %w", entry.Name, err)
+		}
+		if entry.Category == "" {
+			return nil, fmt.Errorf("virtual system %q: category is required", entry.Name)
+		}
+		if err := r.addID(entry.ID, "system", entry.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range r.media {
+		entry := &r.media[i]
+		if err := validateCommon(entry.ID, entry.Name, entry.Launch); err != nil {
+			return nil, fmt.Errorf("virtual media %q: %w", entry.Name, err)
+		}
+		if _, err := systemdefs.GetSystem(entry.SystemID); err != nil {
+			return nil, fmt.Errorf("virtual media %q: invalid system %q: %w", entry.Name, entry.SystemID, err)
+		}
+		if err := r.addID(entry.ID, "media", entry.Name); err != nil {
+			return nil, err
+		}
+	}
+
+	return r, nil
+}
+
+// MustNewRegistry panics when registry definitions are invalid.
+func MustNewRegistry(systems []VirtualSystem, media []VirtualMedia) *Registry {
+	r, err := NewRegistry(systems, media)
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+func validateCommon(id uuid.UUID, name string, launch LaunchFunc) error {
+	if id == uuid.Nil {
+		return errors.New("id is required")
+	}
+	if name == "" {
+		return errors.New("name is required")
+	}
+	if launch == nil {
+		return errors.New("launch function is required")
+	}
+	return nil
+}
+
+func (r *Registry) addID(id uuid.UUID, typ, name string) error {
+	label := typ + ":" + name
+	if existing, ok := r.byID[id]; ok {
+		return fmt.Errorf("duplicate launchable id %s for %s and %s", EncodeID(id), existing, label)
+	}
+	r.byID[id] = label
+	return nil
+}
+
+// Systems returns virtual systems available for this platform.
+func (r *Registry) Systems(pl platforms.Platform) []VirtualSystem {
+	if len(r.systems) == 0 {
+		return nil
+	}
+	platformID := platformID(pl)
+	out := make([]VirtualSystem, 0, len(r.systems))
+	for i := range r.systems {
+		entry := &r.systems[i]
+		if platformMatches(platformID, entry.PlatformIDs) {
+			out = append(out, *entry)
+		}
+	}
+	return out
+}
+
+// Media returns virtual media available for this platform.
+func (r *Registry) Media(pl platforms.Platform) []VirtualMedia {
+	if len(r.media) == 0 {
+		return nil
+	}
+	platformID := platformID(pl)
+	out := make([]VirtualMedia, 0, len(r.media))
+	for i := range r.media {
+		entry := &r.media[i]
+		if platformMatches(platformID, entry.PlatformIDs) {
+			out = append(out, *entry)
+		}
+	}
+	return out
+}
+
+// MediaForSystem returns virtual media for a real Zaparoo system ID.
+func (r *Registry) MediaForSystem(pl platforms.Platform, systemID string) []VirtualMedia {
+	media := r.Media(pl)
+	out := make([]VirtualMedia, 0, len(media))
+	for i := range media {
+		if media[i].SystemID == systemID {
+			out = append(out, media[i])
+		}
+	}
+	return out
+}
+
+// Launchers returns scheme launchers that execute code-defined launchables.
+func (r *Registry) Launchers(pl platforms.Platform) []platforms.Launcher {
+	if len(r.systems) == 0 && len(r.media) == 0 {
+		return nil
+	}
+	platformID := platformID(pl)
+	launchers := make([]platforms.Launcher, 0, len(r.systems)+len(r.media))
+	for i := range r.systems {
+		entry := &r.systems[i]
+		if platformMatches(platformID, entry.PlatformIDs) {
+			launchers = append(launchers, systemLauncher(pl, entry))
+		}
+	}
+	for i := range r.media {
+		entry := &r.media[i]
+		if platformMatches(platformID, entry.PlatformIDs) {
+			launchers = append(launchers, mediaLauncher(pl, entry))
+		}
+	}
+	return launchers
+}
+
+func systemLauncher(pl platforms.Platform, entry *VirtualSystem) platforms.Launcher {
+	return platforms.Launcher{
+		ID:      launcherID(entry.ID),
+		Schemes: []string{Scheme},
+		Test:    pathMatchesID(entry.ID),
+		Launch:  launchWith(pl, entry.ID, entry.Launch),
+	}
+}
+
+func mediaLauncher(pl platforms.Platform, entry *VirtualMedia) platforms.Launcher {
+	return platforms.Launcher{
+		ID:       launcherID(entry.ID),
+		SystemID: entry.SystemID,
+		Schemes:  []string{Scheme},
+		Test:     pathMatchesID(entry.ID),
+		Launch:   launchWith(pl, entry.ID, entry.Launch),
+	}
+}
+
+func launcherID(id uuid.UUID) string {
+	return launcherIDPrefix + EncodeID(id)
+}
+
+func pathMatchesID(id uuid.UUID) func(*config.Instance, string) bool {
+	return func(_ *config.Instance, path string) bool {
+		pathID, ok, err := ParseURI(path)
+		return err == nil && ok && pathID == id
+	}
+}
+
+func launchWith(
+	pl platforms.Platform,
+	id uuid.UUID,
+	launch LaunchFunc,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
+		pathID, ok, err := ParseURI(path)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || pathID != id {
+			return nil, fmt.Errorf("zaparoo URI %q does not match launcher %s", path, launcherID(id))
+		}
+		return launch(cfg, pl, path, opts)
+	}
+}
+
+func platformID(pl platforms.Platform) string {
+	if pl == nil {
+		return ""
+	}
+	return pl.ID()
+}
+
+func platformMatches(platformID string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, id := range allowed {
+		if strings.EqualFold(platformID, id) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseURI extracts the UUID from a zaparoo URI. The path is decorative.
+func ParseURI(rawURI string) (uuid.UUID, bool, error) {
+	var id uuid.UUID
+	u, err := url.Parse(rawURI)
+	if err != nil {
+		return id, false, fmt.Errorf("parse zaparoo URI: %w", err)
+	}
+	if !strings.EqualFold(u.Scheme, Scheme) {
+		return id, false, nil
+	}
+	if u.Host == "" {
+		return id, true, errors.New("zaparoo URI missing id host")
+	}
+	id, err = DecodeID(u.Host)
+	if err != nil {
+		return id, true, err
+	}
+	return id, true, nil
+}
+
+// IsURI reports whether s uses the zaparoo virtual launch URI scheme.
+func IsURI(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && strings.EqualFold(u.Scheme, Scheme)
+}

--- a/pkg/launchables/launchables_test.go
+++ b/pkg/launchables/launchables_test.go
@@ -20,6 +20,7 @@
 package launchables
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -33,8 +34,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testProviderPlatform struct {
+	*mocks.MockPlatform
+	defs []Launchable
+}
+
+func (p *testProviderPlatform) Launchables(*config.Instance) []Launchable {
+	return p.defs
+}
+
 func testLaunch() LaunchFunc {
-	return func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 		return nil, nil
 	}
 }
@@ -64,68 +74,87 @@ func TestParseURI_UsesHostID(t *testing.T) {
 	assert.Equal(t, id, decoded)
 }
 
-func TestRegistryFiltersByPlatformAndSystem(t *testing.T) {
-	misterID := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-	linuxID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
-	openID := uuid.MustParse("21890f4a-33e8-4d44-d3a8-56824d352000")
-	linuxMediaID := uuid.MustParse("31890f4a-33e8-4d44-d3a8-56824d352000")
-	registry := MustNewRegistry([]VirtualSystem{
-		{
-			ID:          misterID,
-			Name:        "Chess Club",
-			Category:    "Other",
-			PlatformIDs: []string{"mister"},
-			Launch:      testLaunch(),
+func TestLaunchablesReturnsPlatformDefinitions(t *testing.T) {
+	systemID := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	mediaID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualSystem{ID: systemID, Name: "Chess Club", Category: "Other", Launch: testLaunch()},
+			VirtualMedia{
+				ID:       mediaID,
+				SystemID: systemdefs.SystemCPS3,
+				Name:     "Street Fighter III",
+				Launch:   testLaunch(),
+			},
 		},
-		{
-			ID:          linuxID,
-			Name:        "Linux Only",
-			Category:    "Other",
-			PlatformIDs: []string{"linux"},
-			Launch:      testLaunch(),
-		},
-	}, []VirtualMedia{
-		{
-			ID:       openID,
-			SystemID: systemdefs.SystemCPS3,
-			Name:     "Street Fighter III: 3rd Strike",
-			Launch:   testLaunch(),
-		},
-		{
-			ID:          linuxMediaID,
-			SystemID:    systemdefs.SystemNES,
-			Name:        "Linux Media",
-			PlatformIDs: []string{"linux"},
-			Launch:      testLaunch(),
-		},
-	})
-	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("ID").Return("MiSTer")
+	}
 
-	systems := registry.Systems(mockPlatform)
-	media := registry.MediaForSystem(mockPlatform, systemdefs.SystemCPS3)
+	defs := Launchables(&config.Instance{}, platform)
+	systems := Systems(&config.Instance{}, platform)
+	media := MediaForSystem(&config.Instance{}, platform, systemdefs.SystemCPS3)
 
+	require.Len(t, defs, 2)
 	require.Len(t, systems, 1)
 	assert.Equal(t, "Chess Club", systems[0].Name)
 	require.Len(t, media, 1)
-	assert.Equal(t, "Street Fighter III: 3rd Strike", media[0].Name)
-	assert.Equal(t, "zaparoo://"+EncodeID(openID)+"/Street%20Fighter%20III:%203rd%20Strike", media[0].ZapScript())
-	mockPlatform.AssertExpectations(t)
+	assert.Equal(t, "Street Fighter III", media[0].Name)
+	assert.Equal(t, "zaparoo://"+EncodeID(mediaID)+"/Street%20Fighter%20III", media[0].ZapScript())
 }
 
-func TestRegistryLaunchers_FilterByURIID(t *testing.T) {
+func TestLaunchablesReturnsNilForPlatformsWithoutDefinitions(t *testing.T) {
+	platform := mocks.NewMockPlatform()
+
+	assert.Nil(t, Launchables(&config.Instance{}, platform))
+	assert.Nil(t, Systems(&config.Instance{}, platform))
+	assert.Nil(t, Media(&config.Instance{}, platform))
+	assert.Nil(t, Launchers(&config.Instance{}, platform))
+}
+
+func TestLaunchablesFiltersUnavailableDefinitions(t *testing.T) {
+	availableID := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	unavailableID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualSystem{
+				ID:       availableID,
+				Name:     "Available",
+				Category: "Other",
+				Launch:   testLaunch(),
+				Test:     func(*config.Instance) bool { return true },
+			},
+			VirtualSystem{
+				ID:       unavailableID,
+				Name:     "Unavailable",
+				Category: "Other",
+				Launch:   testLaunch(),
+				Test:     func(*config.Instance) bool { return false },
+			},
+		},
+	}
+
+	defs := Launchables(&config.Instance{}, platform)
+	systems := Systems(&config.Instance{}, platform)
+	launchers := Launchers(&config.Instance{}, platform)
+
+	require.Len(t, defs, 1)
+	require.Len(t, systems, 1)
+	require.Len(t, launchers, 1)
+	assert.Equal(t, "Available", systems[0].Name)
+}
+
+func TestPlatformLaunchers_FilterByURIID(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	otherID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
-	registry := MustNewRegistry([]VirtualSystem{
-		{
-			ID:       id,
-			Name:     "Chess",
-			Category: "Other",
-			Launch:   testLaunch(),
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualSystem{ID: id, Name: "Chess", Category: "Other", Launch: testLaunch()},
 		},
-	}, nil)
+	}
 
-	launchers := registry.Launchers(nil)
+	launchers := Launchers(&config.Instance{}, platform)
 
 	require.Len(t, launchers, 1)
 	assert.Equal(t, []string{Scheme}, launchers[0].Schemes)
@@ -133,54 +162,53 @@ func TestRegistryLaunchers_FilterByURIID(t *testing.T) {
 	assert.False(t, launchers[0].Test(nil, "zaparoo://"+EncodeID(otherID)+"/Other"))
 }
 
-func TestRegistryLaunchers_LaunchMatchingURI(t *testing.T) {
+func TestPlatformLaunchers_LaunchMatchingURI(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("ID").Return("test-platform")
 	called := false
-	registry := MustNewRegistry(nil, []VirtualMedia{
-		{
-			ID:       id,
-			SystemID: systemdefs.SystemCPS3,
-			Name:     "Street Fighter III: 3rd Strike",
-			Launch: func(
-				cfg *config.Instance,
-				pl platforms.Platform,
-				path string,
-				opts *platforms.LaunchOptions,
-			) (*os.Process, error) {
-				called = true
-				assert.NotNil(t, cfg)
-				assert.Same(t, mockPlatform, pl)
-				assert.Equal(t, "zaparoo://"+EncodeID(id)+"/Street%20Fighter%20III:%203rd%20Strike", path)
-				assert.NotNil(t, opts)
-				return &os.Process{}, nil
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualMedia{
+				ID:       id,
+				SystemID: systemdefs.SystemCPS3,
+				Name:     "Street Fighter III: 3rd Strike",
+				Launch: func(
+					cfg *config.Instance,
+					path string,
+					opts *platforms.LaunchOptions,
+				) (*os.Process, error) {
+					called = true
+					assert.NotNil(t, cfg)
+					assert.Equal(t, "zaparoo://"+EncodeID(id)+"/Street%20Fighter%20III:%203rd%20Strike", path)
+					assert.NotNil(t, opts)
+					return &os.Process{}, nil
+				},
 			},
 		},
-	})
+	}
 
-	launchers := registry.Launchers(mockPlatform)
+	launchers := Launchers(&config.Instance{}, platform)
+	media := Media(&config.Instance{}, platform)
 	require.Len(t, launchers, 1)
-	process, err := launchers[0].Launch(&config.Instance{}, registry.media[0].ZapScript(), &platforms.LaunchOptions{})
+	require.Len(t, media, 1)
+	process, err := launchers[0].Launch(&config.Instance{}, media[0].ZapScript(), &platforms.LaunchOptions{})
 
 	require.NoError(t, err)
 	assert.NotNil(t, process)
 	assert.True(t, called)
 }
 
-func TestRegistryLaunchers_RejectMismatchedURI(t *testing.T) {
+func TestPlatformLaunchers_RejectMismatchedURI(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	otherID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
-	registry := MustNewRegistry([]VirtualSystem{
-		{
-			ID:       id,
-			Name:     "Chess",
-			Category: "Other",
-			Launch:   testLaunch(),
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualSystem{ID: id, Name: "Chess", Category: "Other", Launch: testLaunch()},
 		},
-	}, nil)
+	}
 
-	launchers := registry.Launchers(nil)
+	launchers := Launchers(&config.Instance{}, platform)
 	require.Len(t, launchers, 1)
 	process, err := launchers[0].Launch(&config.Instance{}, "zaparoo://"+EncodeID(otherID)+"/Chess", nil)
 
@@ -204,65 +232,99 @@ func TestParseURIRejectsInvalidVirtualPaths(t *testing.T) {
 }
 
 func TestIsURI(t *testing.T) {
-	assert.True(t, IsURI("ZAPAROO://"+EncodeID(uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000"))+"/Chess"))
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+
+	assert.True(t, IsURI("ZAPAROO://"+EncodeID(id)+"/Chess"))
 	assert.False(t, IsURI("steam://123/Chess"))
 }
 
-func TestNewRegistryRejectsIncompleteDefinitions(t *testing.T) {
-	_, err := NewRegistry([]VirtualSystem{{Name: "Missing ID", Category: "Other", Launch: testLaunch()}}, nil)
-	require.ErrorContains(t, err, "id is required")
-
-	_, err = NewRegistry([]VirtualSystem{
-		{ID: uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000"), Category: "Other", Launch: testLaunch()},
-	}, nil)
-	require.ErrorContains(t, err, "name is required")
-
-	_, err = NewRegistry([]VirtualSystem{
-		{ID: uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000"), Name: "Missing Launch", Category: "Other"},
-	}, nil)
-	require.ErrorContains(t, err, "launch function is required")
-
-	_, err = NewRegistry([]VirtualSystem{
-		{ID: uuid.MustParse("21890f4a-33e8-4d44-d3a8-56824d352000"), Name: "Missing Category", Launch: testLaunch()},
-	}, nil)
-	require.ErrorContains(t, err, "category is required")
+func requirePanicContains(t *testing.T, expected string, f func()) {
+	t.Helper()
+	defer func() {
+		recovered := recover()
+		require.NotNil(t, recovered)
+		assert.Contains(t, fmt.Sprint(recovered), expected)
+	}()
+	f()
 }
 
-func TestNewRegistryRejectsDuplicateIDs(t *testing.T) {
-	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-
-	_, err := NewRegistry([]VirtualSystem{
-		{
-			ID:       id,
-			Name:     "Chess",
-			Category: "Other",
-			Launch:   testLaunch(),
-		},
-	}, []VirtualMedia{
-		{
-			ID:       id,
-			SystemID: systemdefs.SystemCPS3,
-			Name:     "Street Fighter III: 3rd Strike",
-			Launch:   testLaunch(),
-		},
+func TestLaunchablesRejectsIncompleteDefinitions(t *testing.T) {
+	assert.PanicsWithError(t, "virtual system \"Missing ID\": id is required", func() {
+		Launchables(&config.Instance{}, &testProviderPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			defs: []Launchable{
+				VirtualSystem{Name: "Missing ID", Category: "Other", Launch: testLaunch()},
+			},
+		})
 	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate launchable id")
+	assert.PanicsWithError(t, "virtual system \"\": name is required", func() {
+		Launchables(&config.Instance{}, &testProviderPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			defs: []Launchable{
+				VirtualSystem{
+					ID:       uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000"),
+					Category: "Other",
+					Launch:   testLaunch(),
+				},
+			},
+		})
+	})
+	assert.PanicsWithError(t, "virtual system \"Missing Launch\": launch function is required", func() {
+		Launchables(&config.Instance{}, &testProviderPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			defs: []Launchable{
+				VirtualSystem{
+					ID:       uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000"),
+					Name:     "Missing Launch",
+					Category: "Other",
+				},
+			},
+		})
+	})
+	assert.PanicsWithError(t, "virtual system \"Missing Category\": category is required", func() {
+		Launchables(&config.Instance{}, &testProviderPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			defs: []Launchable{
+				VirtualSystem{
+					ID:     uuid.MustParse("21890f4a-33e8-4d44-d3a8-56824d352000"),
+					Name:   "Missing Category",
+					Launch: testLaunch(),
+				},
+			},
+		})
+	})
 }
 
-func TestNewRegistryRejectsInvalidMediaSystem(t *testing.T) {
+func TestLaunchablesRejectsDuplicateIDs(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
-
-	_, err := NewRegistry(nil, []VirtualMedia{
-		{
-			ID:       id,
-			SystemID: "Chess",
-			Name:     "Chess",
-			Launch:   testLaunch(),
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualSystem{ID: id, Name: "Chess", Category: "Other", Launch: testLaunch()},
+			VirtualMedia{
+				ID:       id,
+				SystemID: systemdefs.SystemCPS3,
+				Name:     "Street Fighter III",
+				Launch:   testLaunch(),
+			},
 		},
-	})
+	}
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid system")
+	requirePanicContains(t, "duplicate launchable id", func() {
+		Launchables(&config.Instance{}, platform)
+	})
+}
+
+func TestLaunchablesRejectsInvalidMediaSystem(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	platform := &testProviderPlatform{
+		MockPlatform: mocks.NewMockPlatform(),
+		defs: []Launchable{
+			VirtualMedia{ID: id, SystemID: "Chess", Name: "Chess", Launch: testLaunch()},
+		},
+	}
+
+	requirePanicContains(t, "invalid system \"Chess\"", func() {
+		Launchables(&config.Instance{}, platform)
+	})
 }

--- a/pkg/launchables/launchables_test.go
+++ b/pkg/launchables/launchables_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,6 +64,55 @@ func TestParseURI_UsesHostID(t *testing.T) {
 	assert.Equal(t, id, decoded)
 }
 
+func TestRegistryFiltersByPlatformAndSystem(t *testing.T) {
+	misterID := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	linuxID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
+	openID := uuid.MustParse("21890f4a-33e8-4d44-d3a8-56824d352000")
+	linuxMediaID := uuid.MustParse("31890f4a-33e8-4d44-d3a8-56824d352000")
+	registry := MustNewRegistry([]VirtualSystem{
+		{
+			ID:          misterID,
+			Name:        "Chess Club",
+			Category:    "Other",
+			PlatformIDs: []string{"mister"},
+			Launch:      testLaunch(),
+		},
+		{
+			ID:          linuxID,
+			Name:        "Linux Only",
+			Category:    "Other",
+			PlatformIDs: []string{"linux"},
+			Launch:      testLaunch(),
+		},
+	}, []VirtualMedia{
+		{
+			ID:       openID,
+			SystemID: systemdefs.SystemCPS3,
+			Name:     "Street Fighter III: 3rd Strike",
+			Launch:   testLaunch(),
+		},
+		{
+			ID:          linuxMediaID,
+			SystemID:    systemdefs.SystemNES,
+			Name:        "Linux Media",
+			PlatformIDs: []string{"linux"},
+			Launch:      testLaunch(),
+		},
+	})
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("MiSTer")
+
+	systems := registry.Systems(mockPlatform)
+	media := registry.MediaForSystem(mockPlatform, systemdefs.SystemCPS3)
+
+	require.Len(t, systems, 1)
+	assert.Equal(t, "Chess Club", systems[0].Name)
+	require.Len(t, media, 1)
+	assert.Equal(t, "Street Fighter III: 3rd Strike", media[0].Name)
+	assert.Equal(t, "zaparoo://"+EncodeID(openID)+"/Street%20Fighter%20III:%203rd%20Strike", media[0].ZapScript())
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestRegistryLaunchers_FilterByURIID(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	otherID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
@@ -81,6 +131,101 @@ func TestRegistryLaunchers_FilterByURIID(t *testing.T) {
 	assert.Equal(t, []string{Scheme}, launchers[0].Schemes)
 	assert.True(t, launchers[0].Test(nil, "zaparoo://"+EncodeID(id)+"/Chess"))
 	assert.False(t, launchers[0].Test(nil, "zaparoo://"+EncodeID(otherID)+"/Other"))
+}
+
+func TestRegistryLaunchers_LaunchMatchingURI(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+	called := false
+	registry := MustNewRegistry(nil, []VirtualMedia{
+		{
+			ID:       id,
+			SystemID: systemdefs.SystemCPS3,
+			Name:     "Street Fighter III: 3rd Strike",
+			Launch: func(
+				cfg *config.Instance,
+				pl platforms.Platform,
+				path string,
+				opts *platforms.LaunchOptions,
+			) (*os.Process, error) {
+				called = true
+				assert.NotNil(t, cfg)
+				assert.Same(t, mockPlatform, pl)
+				assert.Equal(t, "zaparoo://"+EncodeID(id)+"/Street%20Fighter%20III:%203rd%20Strike", path)
+				assert.NotNil(t, opts)
+				return &os.Process{}, nil
+			},
+		},
+	})
+
+	launchers := registry.Launchers(mockPlatform)
+	require.Len(t, launchers, 1)
+	process, err := launchers[0].Launch(&config.Instance{}, registry.media[0].ZapScript(), &platforms.LaunchOptions{})
+
+	require.NoError(t, err)
+	assert.NotNil(t, process)
+	assert.True(t, called)
+}
+
+func TestRegistryLaunchers_RejectMismatchedURI(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	otherID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
+	registry := MustNewRegistry([]VirtualSystem{
+		{
+			ID:       id,
+			Name:     "Chess",
+			Category: "Other",
+			Launch:   testLaunch(),
+		},
+	}, nil)
+
+	launchers := registry.Launchers(nil)
+	require.Len(t, launchers, 1)
+	process, err := launchers[0].Launch(&config.Instance{}, "zaparoo://"+EncodeID(otherID)+"/Chess", nil)
+
+	require.Error(t, err)
+	assert.Nil(t, process)
+	assert.Contains(t, err.Error(), "does not match launcher")
+}
+
+func TestParseURIRejectsInvalidVirtualPaths(t *testing.T) {
+	_, ok, err := ParseURI("steam://123/Game")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, ok, err = ParseURI("zaparoo:///missing-host")
+	require.Error(t, err)
+	assert.True(t, ok)
+
+	_, ok, err = ParseURI("zaparoo://bad/Game")
+	require.Error(t, err)
+	assert.True(t, ok)
+}
+
+func TestIsURI(t *testing.T) {
+	assert.True(t, IsURI("ZAPAROO://"+EncodeID(uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000"))+"/Chess"))
+	assert.False(t, IsURI("steam://123/Chess"))
+}
+
+func TestNewRegistryRejectsIncompleteDefinitions(t *testing.T) {
+	_, err := NewRegistry([]VirtualSystem{{Name: "Missing ID", Category: "Other", Launch: testLaunch()}}, nil)
+	require.ErrorContains(t, err, "id is required")
+
+	_, err = NewRegistry([]VirtualSystem{
+		{ID: uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000"), Category: "Other", Launch: testLaunch()},
+	}, nil)
+	require.ErrorContains(t, err, "name is required")
+
+	_, err = NewRegistry([]VirtualSystem{
+		{ID: uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000"), Name: "Missing Launch", Category: "Other"},
+	}, nil)
+	require.ErrorContains(t, err, "launch function is required")
+
+	_, err = NewRegistry([]VirtualSystem{
+		{ID: uuid.MustParse("21890f4a-33e8-4d44-d3a8-56824d352000"), Name: "Missing Category", Launch: testLaunch()},
+	}, nil)
+	require.ErrorContains(t, err, "category is required")
 }
 
 func TestNewRegistryRejectsDuplicateIDs(t *testing.T) {

--- a/pkg/launchables/launchables_test.go
+++ b/pkg/launchables/launchables_test.go
@@ -1,0 +1,123 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package launchables
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLaunch() LaunchFunc {
+	return func(*config.Instance, platforms.Platform, string, *platforms.LaunchOptions) (*os.Process, error) {
+		return nil, nil
+	}
+}
+
+func TestEncodeID_Base32UUID(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+
+	encoded := EncodeID(id)
+
+	assert.Len(t, encoded, 26)
+	assert.Equal(t, strings.ToLower(encoded), encoded)
+	assert.Regexp(t, `^[a-z2-7]{26}$`, encoded)
+
+	decoded, err := DecodeID(strings.ToUpper(encoded))
+	require.NoError(t, err)
+	assert.Equal(t, id, decoded)
+}
+
+func TestParseURI_UsesHostID(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	rawURI := "zaparoo://" + EncodeID(id) + "/Street%20Fighter%20III"
+
+	decoded, ok, err := ParseURI(rawURI)
+
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, id, decoded)
+}
+
+func TestRegistryLaunchers_FilterByURIID(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	otherID := uuid.MustParse("11890f4a-33e8-4d44-d3a8-56824d352000")
+	registry := MustNewRegistry([]VirtualSystem{
+		{
+			ID:       id,
+			Name:     "Chess",
+			Category: "Other",
+			Launch:   testLaunch(),
+		},
+	}, nil)
+
+	launchers := registry.Launchers(nil)
+
+	require.Len(t, launchers, 1)
+	assert.Equal(t, []string{Scheme}, launchers[0].Schemes)
+	assert.True(t, launchers[0].Test(nil, "zaparoo://"+EncodeID(id)+"/Chess"))
+	assert.False(t, launchers[0].Test(nil, "zaparoo://"+EncodeID(otherID)+"/Other"))
+}
+
+func TestNewRegistryRejectsDuplicateIDs(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+
+	_, err := NewRegistry([]VirtualSystem{
+		{
+			ID:       id,
+			Name:     "Chess",
+			Category: "Other",
+			Launch:   testLaunch(),
+		},
+	}, []VirtualMedia{
+		{
+			ID:       id,
+			SystemID: systemdefs.SystemCPS3,
+			Name:     "Street Fighter III: 3rd Strike",
+			Launch:   testLaunch(),
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate launchable id")
+}
+
+func TestNewRegistryRejectsInvalidMediaSystem(t *testing.T) {
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+
+	_, err := NewRegistry(nil, []VirtualMedia{
+		{
+			ID:       id,
+			SystemID: "Chess",
+			Name:     "Chess",
+			Launch:   testLaunch(),
+		},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid system")
+}

--- a/pkg/platforms/mister/launchables.go
+++ b/pkg/platforms/mister/launchables.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+package mister
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
+	"github.com/rs/zerolog/log"
+)
+
+const misterLaunchableCategoryOther = "Other"
+
+// Launchables exposes launch-only MiSTer _Other entries that do not already
+// have media or alternate-core launchers.
+func (p *Platform) Launchables(*config.Instance) []launchables.Launchable {
+	return []launchables.Launchable{
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherChess,
+			Name:     "Chess",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/Chess"),
+			Test:     testOtherCore("Chess"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherDonut,
+			Name:     "Donut",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/Donut"),
+			Test:     testOtherCore("Donut"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherEpochGalaxyII,
+			Name:     "Epoch Galaxy II",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/EpochGalaxyII"),
+			Test:     testOtherCore("EpochGalaxyII"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherFlappyBird,
+			Name:     "Flappy Bird",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/FlappyBird"),
+			Test:     testOtherCore("FlappyBird"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherGameOfLife,
+			Name:     "Game of Life",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/GameOfLife"),
+			Test:     testOtherCore("GameOfLife"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherGBMidi,
+			Name:     "GBMidi",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/GBMidi"),
+			Test:     testOtherCore("GBMidi"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherGenMidi,
+			Name:     "GenMidi",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/GenMidi"),
+			Test:     testOtherCore("GenMidi"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherSlugCross,
+			Name:     "Slug Cross",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/SlugCross"),
+			Test:     testOtherCore("SlugCross"),
+		},
+		launchables.VirtualSystem{
+			ID:       launchables.MisterOtherTomyScramble,
+			Name:     "Tomy Scramble",
+			Category: misterLaunchableCategoryOther,
+			Launch:   p.launchOtherCore("_Other/TomyScramble"),
+			Test:     testOtherCore("TomyScramble"),
+		},
+	}
+}
+
+func testOtherCore(shortName string) func(*config.Instance) bool {
+	return func(*config.Instance) bool {
+		return otherCoreExists(misterconfig.SDRootDir, shortName)
+	}
+}
+
+func otherCoreExists(rootDir, shortName string) bool {
+	matches, err := filepath.Glob(filepath.Join(rootDir, "_Other", shortName+"*.rbf"))
+	return err == nil && len(matches) > 0
+}
+
+func (p *Platform) launchOtherCore(
+	corePath string,
+) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	return func(_ *config.Instance, _ string, _ *platforms.LaunchOptions) (*os.Process, error) {
+		if err := p.ConsoleManager().Close(); err != nil {
+			log.Warn().Err(err).Msg("failed to close console before FPGA launch")
+		}
+		if err := mgls.LaunchShortCore(corePath); err != nil {
+			return nil, fmt.Errorf("failed to launch MiSTer core %s: %w", corePath, err)
+		}
+		return nil, nil //nolint:nilnil // MiSTer launches don't return a process handle
+	}
+}

--- a/pkg/platforms/mister/launchables.go
+++ b/pkg/platforms/mister/launchables.go
@@ -25,63 +25,63 @@ func (p *Platform) Launchables(*config.Instance) []launchables.Launchable {
 			ID:       launchables.MisterOtherChess,
 			Name:     "Chess",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/Chess"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "Chess")),
 			Test:     testOtherCore("Chess"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherDonut,
 			Name:     "Donut",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/Donut"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "Donut")),
 			Test:     testOtherCore("Donut"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherEpochGalaxyII,
 			Name:     "Epoch Galaxy II",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/EpochGalaxyII"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "EpochGalaxyII")),
 			Test:     testOtherCore("EpochGalaxyII"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherFlappyBird,
 			Name:     "Flappy Bird",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/FlappyBird"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "FlappyBird")),
 			Test:     testOtherCore("FlappyBird"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherGameOfLife,
 			Name:     "Game of Life",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/GameOfLife"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "GameOfLife")),
 			Test:     testOtherCore("GameOfLife"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherGBMidi,
 			Name:     "GBMidi",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/GBMidi"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "GBMidi")),
 			Test:     testOtherCore("GBMidi"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherGenMidi,
 			Name:     "GenMidi",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/GenMidi"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "GenMidi")),
 			Test:     testOtherCore("GenMidi"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherSlugCross,
 			Name:     "Slug Cross",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/SlugCross"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "SlugCross")),
 			Test:     testOtherCore("SlugCross"),
 		},
 		launchables.VirtualSystem{
 			ID:       launchables.MisterOtherTomyScramble,
 			Name:     "Tomy Scramble",
 			Category: misterLaunchableCategoryOther,
-			Launch:   p.launchOtherCore("_Other/TomyScramble"),
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "TomyScramble")),
 			Test:     testOtherCore("TomyScramble"),
 		},
 	}
@@ -98,14 +98,40 @@ func otherCoreExists(rootDir, shortName string) bool {
 	return err == nil && len(matches) > 0
 }
 
+func (p *Platform) closeLaunchConsole() error {
+	if p.closeConsole != nil {
+		if err := p.closeConsole(); err != nil {
+			return fmt.Errorf("close MiSTer console: %w", err)
+		}
+		return nil
+	}
+	if err := p.ConsoleManager().Close(); err != nil {
+		return fmt.Errorf("close MiSTer console: %w", err)
+	}
+	return nil
+}
+
+func (p *Platform) launchShortCoreFile(corePath string) error {
+	if p.launchShortCore != nil {
+		if err := p.launchShortCore(corePath); err != nil {
+			return fmt.Errorf("launch MiSTer short core: %w", err)
+		}
+		return nil
+	}
+	if err := mgls.LaunchShortCore(corePath); err != nil {
+		return fmt.Errorf("launch MiSTer short core: %w", err)
+	}
+	return nil
+}
+
 func (p *Platform) launchOtherCore(
 	corePath string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 	return func(_ *config.Instance, _ string, _ *platforms.LaunchOptions) (*os.Process, error) {
-		if err := p.ConsoleManager().Close(); err != nil {
+		if err := p.closeLaunchConsole(); err != nil {
 			log.Warn().Err(err).Msg("failed to close console before FPGA launch")
 		}
-		if err := mgls.LaunchShortCore(corePath); err != nil {
+		if err := p.launchShortCoreFile(corePath); err != nil {
 			return nil, fmt.Errorf("failed to launch MiSTer core %s: %w", corePath, err)
 		}
 		return nil, nil //nolint:nilnil // MiSTer launches don't return a process handle

--- a/pkg/platforms/mister/launchables_test.go
+++ b/pkg/platforms/mister/launchables_test.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaunchablesOtherCoreDefinitions(t *testing.T) {
+	items := (&Platform{}).Launchables(&config.Instance{})
+
+	require.Len(t, items, 9)
+	seen := make(map[string]bool, len(items))
+	for _, item := range items {
+		system, ok := item.(launchables.VirtualSystem)
+		require.True(t, ok)
+		assert.Equal(t, "Other", system.Category)
+		assert.NotNil(t, system.Launch)
+		assert.NotNil(t, system.Test)
+		assert.NotEmpty(t, system.ZapScript())
+		seen[system.Name] = true
+	}
+
+	for _, name := range []string{
+		"Chess",
+		"Donut",
+		"Epoch Galaxy II",
+		"Flappy Bird",
+		"Game of Life",
+		"GBMidi",
+		"GenMidi",
+		"Slug Cross",
+		"Tomy Scramble",
+	} {
+		assert.True(t, seen[name], name)
+	}
+}
+
+func TestOtherCoreExists(t *testing.T) {
+	rootDir := t.TempDir()
+	otherDir := filepath.Join(rootDir, "_Other")
+	require.NoError(t, os.MkdirAll(otherDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "Chess_20240410.rbf"), nil, 0o600))
+
+	assert.True(t, otherCoreExists(rootDir, "Chess"))
+	assert.False(t, otherCoreExists(rootDir, "Donut"))
+}

--- a/pkg/platforms/mister/launchables_test.go
+++ b/pkg/platforms/mister/launchables_test.go
@@ -3,6 +3,7 @@
 package mister
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +42,50 @@ func TestLaunchablesOtherCoreDefinitions(t *testing.T) {
 	} {
 		assert.True(t, seen[name], name)
 	}
+}
+
+func TestLaunchOtherCoreUsesInjectedLauncher(t *testing.T) {
+	corePath := filepath.Join("_Other", "Chess")
+	closed := false
+	var launched string
+	p := &Platform{
+		closeConsole: func() error {
+			closed = true
+			return nil
+		},
+		launchShortCore: func(path string) error {
+			launched = path
+			return nil
+		},
+	}
+
+	process, err := p.launchOtherCore(corePath)(&config.Instance{}, "", nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, process)
+	assert.True(t, closed)
+	assert.Equal(t, corePath, launched)
+}
+
+func TestLaunchOtherCoreReturnsInjectedLaunchError(t *testing.T) {
+	corePath := filepath.Join("_Other", "Chess")
+	launchErr := errors.New("launch failed")
+	closed := false
+	p := &Platform{
+		closeConsole: func() error {
+			closed = true
+			return errors.New("close failed")
+		},
+		launchShortCore: func(string) error {
+			return launchErr
+		},
+	}
+
+	process, err := p.launchOtherCore(corePath)(&config.Instance{}, "", nil)
+
+	require.ErrorIs(t, err, launchErr)
+	assert.Nil(t, process)
+	assert.True(t, closed)
 }
 
 func TestOtherCoreExists(t *testing.T) {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -76,6 +76,8 @@ type Platform struct {
 	activeMedia         func() *models.ActiveMedia
 	textMap             map[string]string
 	consoleManager      *MiSTerConsoleManager
+	launchShortCore     func(string) error
+	closeConsole        func() error
 	lastLauncher        platforms.Launcher
 	arcadeCardLaunch    arcadeCardLaunchCache
 	stopIntent          platforms.StopIntent
@@ -85,7 +87,8 @@ type Platform struct {
 
 func NewPlatform() *Platform {
 	p := &Platform{
-		platformMu: syncutil.Mutex{},
+		platformMu:      syncutil.Mutex{},
+		launchShortCore: mgls.LaunchShortCore,
 	}
 	p.consoleManager = newConsoleManager(p)
 	return p

--- a/pkg/zapscript/virtual_launchables_test.go
+++ b/pkg/zapscript/virtual_launchables_test.go
@@ -1,0 +1,36 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapscript
+
+import (
+	"testing"
+
+	gozapscript "github.com/ZaparooProject/go-zapscript"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckZapLink_IgnoresVirtualPathSchemes(t *testing.T) {
+	cmd := gozapscript.Command{Args: []string{"zaparoo://mfsg22lomvzxiyi/Chess"}}
+	target, err := checkZapLink(nil, nil, nil, cmd)
+
+	require.NoError(t, err)
+	assert.Empty(t, target)
+}

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -348,12 +348,11 @@ func checkZapLink(
 		return "", nil
 	}
 	value := cmd.Args[0]
-	platform := pl.ID()
-
 	if !isZapLink(value, db) {
 		return "", nil
 	}
 
+	platform := pl.ID()
 	log.Info().Msgf("checking zap link: %s", value)
 	body, err := getRemoteZapScript(value, platform)
 	if isOfflineError(err) {

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -34,10 +34,12 @@ import (
 	"strings"
 	"testing"
 
+	gozapscript "github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -600,6 +602,42 @@ func TestIsZapLink_SuccessIsCached(t *testing.T) {
 	assert.True(t, result)
 
 	mockUserDB.AssertExpectations(t)
+}
+
+func TestCheckZapLinkFetchesSupportedRemoteScript(t *testing.T) {
+	t.Parallel()
+
+	expected := "**launch.system:snes"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case WellKnownPath:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"zapscript": 1}`))
+		case "/token":
+			assert.Equal(t, "mister", r.Header.Get(HeaderZaparooPlatform))
+			w.Header().Set("Content-Type", MIMEZaparooZapScript)
+			_, _ = w.Write([]byte(expected))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	db := &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}
+	mockUserDB.On("GetZapLinkHost", server.URL).Return(false, false, nil)
+	mockUserDB.On("UpdateZapLinkHost", server.URL, 1).Return(nil)
+	mockUserDB.On("UpdateZapLinkCache", server.URL+"/token", expected).Return(nil)
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("mister")
+
+	target, err := checkZapLink(nil, platform, db, gozapscript.Command{Args: []string{server.URL + "/token"}})
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, target)
+	mockUserDB.AssertExpectations(t)
+	platform.AssertExpectations(t)
 }
 
 // FetchWellKnown Tests


### PR DESCRIPTION
Summary:
- add code-defined virtual launchables with compact zaparoo:// UUID URIs
- inject launch-only systems into the systems API and index virtual media into MediaDB
- add zaparoo scheme launchers plus scheme Test filtering so multiple virtual launchers can coexist

Verified locally with go test and golangci-lint on changed packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in virtual systems and virtual media to system listings and media indexing.
  * System API responses now include the system’s `zapScript` URL (for `zaparoo://` links).
  * Introduced Linux MiSTer “Other” cores as virtual launch targets (when available on disk).
* **Refactor**
  * Media indexing and launcher matching now incorporate the built-in virtual launch targets.
  * Launcher scheme matching now honors a launcher-specific `Test` rule when provided.
* **Tests**
  * Added/expanded unit tests covering virtual launch target registry behavior, virtual-system inclusion, media indexing, scheme-based launcher matching, and MiSTer “Other” core availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->