### PR TITLE
feat(scraper): add ES media folder scraper

### DIFF
--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -2,7 +2,10 @@
 
 The scraper subsystem enriches existing MediaDB records with metadata from external sources. The filesystem scanner owns record creation; scrapers update records that already exist.
 
-The only current scraper implementation is `gamelist.xml`, which imports EmulationStation metadata such as developer, publisher, genre, rating, player count, descriptions, artwork paths, videos, manuals, and ScreenScraper game IDs.
+Current scraper implementations:
+
+- `gamelist.xml` imports EmulationStation metadata such as developer, publisher, genre, rating, player count, descriptions, artwork paths, videos, manuals, and ScreenScraper game IDs.
+- `media-folder` imports image paths from EmulationStation-style `media/` folders under each system folder. It does not read `gamelist.xml`, download assets, or write non-image metadata. A force run (re-scrape) also deletes stale image properties whose paths match the same local media-folder convention and whose replacement file is no longer found.
 
 ## Code Layout
 
@@ -10,6 +13,8 @@ The only current scraper implementation is `gamelist.xml`, which imports Emulati
 |---|---|
 | `pkg/database/scraper/` | Shared scrape types (`ScrapeOptions`, `ScrapeUpdate`), sentinel helper, and small channel startup helper |
 | `pkg/database/scraper/gamelistxml/` | EmulationStation `gamelist.xml` scraper loop, matcher, mapper, and companion-entry handling |
+| `pkg/database/scraper/localmedia/` | EmulationStation `media/` folder image-path importer |
+| `pkg/platforms/shared/esmedia/` | Shared EmulationStation media-folder path resolver |
 | `pkg/platforms/*` | Platform scraper registration through `Platform.Scrapers` |
 | `pkg/database/mediadb/sql_scraper.go` | MediaDB scraper read/write helpers, property/blob helpers, and metadata graph queries |
 | `pkg/api/methods/media_scrape.go` | JSON-RPC scrape start/status/cancel/resume handlers and scraper listing |

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"html"
 	"math"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -46,6 +45,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esmedia"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
@@ -76,31 +76,6 @@ type slugMediaSelection struct {
 	matchKind gamelistMatchKind
 	key       string
 	media     database.Media
-}
-
-// mediaDirCandidates maps each TagPropertyImage value to the ordered list of
-// media sub-directory names (under <systemRootPath>/media/) that may hold
-// artwork for that property. The first matching directory that contains the
-// expected filename wins.
-var fallbackArtworkExtensions = []string{".png", ".jpg", ".jpeg", ".webp"}
-
-var mediaDirCandidates = map[string][]string{
-	string(tags.TagPropertyImageImage):      {"image", "images"},
-	string(tags.TagPropertyImageBoxart):     {"boxart", "boxart2d", "box2d", "boxart2dfront", "box2dfront"},
-	string(tags.TagPropertyImageBoxart3D):   {"boxart3d"},
-	string(tags.TagPropertyImageBoxartSide): {"boxart2dside"},
-	string(tags.TagPropertyImageBoxartBack): {"boxart2dback"},
-	string(tags.TagPropertyImageScreenshot): {"screenshot", "screenshots"},
-	string(tags.TagPropertyImageThumbnail): {
-		"thumbnail", "thumbnails", "box2dfront", "boxart2dfront", "supporttexture",
-	},
-	string(tags.TagPropertyImageMarquee): {"marquee", "marquees"},
-	string(tags.TagPropertyImageWheel):   {"wheel", "wheels", "logo", "logos"},
-	string(tags.TagPropertyImageFanart):  {"fanart", "fanarts"},
-	string(tags.TagPropertyImageTitleshot): {
-		"titleshot", "titleshots", "titlescreen", "titlescreens", "screenshottitle",
-	},
-	string(tags.TagPropertyImageMap): {"map", "maps"},
 }
 
 // GamelistXMLScraper loads and maps EmulationStation gamelist.xml records.
@@ -422,7 +397,7 @@ outer:
 				continue
 			}
 
-			resolved := resolveESPath(game.Path, file.RootPath)
+			resolved := esmedia.ResolvePath(game.Path, file.RootPath)
 			if resolved == "" {
 				invalidPaths++
 				continue
@@ -1112,7 +1087,7 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		if p == nil {
 			p = findMediaFilePropFS(
 				g.filesystem(), key, fallbackNames,
-				mediaDirCandidates[string(propValue)], record.AvailableMediaDirs,
+				esmedia.ArtworkDirCandidates[string(propValue)], record.AvailableMediaDirs,
 			)
 		}
 		if p != nil {
@@ -1156,52 +1131,6 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		TitleTags:  titleTags,
 		TitleProps: titleProps,
 	}
-}
-
-// resolveESPath converts an EmulationStation path to an absolute filesystem path.
-//
-//   - "./relative" or "relative" → filepath.Join(systemRootPath, rest)
-//   - "~/..." → filepath.Join(os.UserHomeDir(), rest)
-//   - Already absolute → cleaned as-is
-//
-// Returns "" if the result is not absolute, input is empty, or the resolved path
-// escapes systemRootPath.
-func resolveESPath(esPath, systemRootPath string) string {
-	if esPath == "" {
-		return ""
-	}
-	rootAbs, err := filepath.Abs(systemRootPath)
-	if err != nil {
-		return ""
-	}
-	rootAbs = filepath.Clean(rootAbs)
-
-	var abs string
-	switch {
-	case strings.HasPrefix(esPath, "~/"):
-		home, homeErr := os.UserHomeDir()
-		if homeErr != nil {
-			return ""
-		}
-		abs = filepath.Join(home, esPath[2:])
-	case filepath.IsAbs(esPath):
-		abs = filepath.Clean(esPath)
-	default:
-		// Handles both "./relative" and "relative".
-		rel := strings.TrimPrefix(esPath, "./")
-		abs = filepath.Join(rootAbs, rel)
-	}
-
-	abs, err = filepath.Abs(abs)
-	if err != nil || !filepath.IsAbs(abs) {
-		return ""
-	}
-	abs = filepath.Clean(abs)
-	rel, err := filepath.Rel(rootAbs, abs)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return ""
-	}
-	return abs
 }
 
 // normalizePlayers extracts the maximum player count from an ES players string.
@@ -1330,68 +1259,21 @@ func pathProp(typeTag, esPath, systemRootPath string, externalAssetRoots []strin
 // bound to the system ROM root. Absolute paths can also resolve under configured
 // external asset roots for platforms whose storage routes intentionally overlap.
 func resolveESAssetPath(esPath, systemRootPath string, externalAssetRoots []string) string {
-	abs, ok := resolveESPathAbs(esPath, systemRootPath)
+	abs, ok := esmedia.ResolvePathAbs(esPath, systemRootPath)
 	if !ok {
 		return ""
 	}
-	if pathWithinRoot(abs, systemRootPath) {
+	if esmedia.PathWithinRoot(abs, systemRootPath) {
 		return abs
 	}
 	if filepath.IsAbs(esPath) || strings.HasPrefix(esPath, "~/") {
 		for _, root := range externalAssetRoots {
-			if pathWithinRoot(abs, root) {
+			if esmedia.PathWithinRoot(abs, root) {
 				return abs
 			}
 		}
 	}
 	return ""
-}
-
-func resolveESPathAbs(esPath, systemRootPath string) (string, bool) {
-	if esPath == "" {
-		return "", false
-	}
-	rootAbs, err := filepath.Abs(systemRootPath)
-	if err != nil {
-		return "", false
-	}
-	rootAbs = filepath.Clean(rootAbs)
-
-	var abs string
-	switch {
-	case strings.HasPrefix(esPath, "~/"):
-		home, homeErr := os.UserHomeDir()
-		if homeErr != nil {
-			return "", false
-		}
-		abs = filepath.Join(home, esPath[2:])
-	case filepath.IsAbs(esPath):
-		abs = filepath.Clean(esPath)
-	default:
-		rel := strings.TrimPrefix(esPath, "./")
-		abs = filepath.Join(rootAbs, rel)
-	}
-
-	abs, err = filepath.Abs(abs)
-	if err != nil || !filepath.IsAbs(abs) {
-		return "", false
-	}
-	return filepath.Clean(abs), true
-}
-
-func pathWithinRoot(path, root string) bool {
-	pathAbs, err := filepath.Abs(path)
-	if err != nil {
-		return false
-	}
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return false
-	}
-	pathAbs = filepath.Clean(pathAbs)
-	rootAbs = filepath.Clean(rootAbs)
-	rel, err := filepath.Rel(rootAbs, pathAbs)
-	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // textProp creates a plain-text MediaProperty.
@@ -1407,22 +1289,11 @@ func textProp(typeTag, text string) database.MediaProperty {
 // directory name → absolute path for every sub-directory found. Returns nil
 // when media/ does not exist or cannot be read — callers treat nil as empty.
 func statMediaDirs(rootPath string) map[string]string {
-	return statMediaDirsFS(afero.NewOsFs(), rootPath)
+	return esmedia.StatMediaDirs(rootPath)
 }
 
 func statMediaDirsFS(fs afero.Fs, rootPath string) map[string]string {
-	mediaRoot := filepath.Join(rootPath, "media")
-	entries, err := afero.ReadDir(fs, mediaRoot)
-	if err != nil {
-		return nil
-	}
-	dirs := make(map[string]string, len(entries))
-	for _, e := range entries {
-		if e.IsDir() {
-			dirs[e.Name()] = filepath.Join(mediaRoot, e.Name())
-		}
-	}
-	return dirs
+	return esmedia.StatMediaDirsFS(fs, rootPath)
 }
 
 // findMediaFileProp searches for <stem>.png inside the first candidate
@@ -1440,51 +1311,11 @@ func findMediaFileProp(
 }
 
 func artworkFallbackNames(gamePath, systemRootPath string) []string {
-	resolved := resolveESPath(gamePath, systemRootPath)
-	if resolved == "" {
-		return nil
-	}
-
-	rootAbs, err := filepath.Abs(systemRootPath)
-	if err != nil {
-		return nil
-	}
-	rel, err := filepath.Rel(filepath.Clean(rootAbs), filepath.Clean(resolved))
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return nil
-	}
-
-	stem := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
-	if stem == "" || stem == "." {
-		return nil
-	}
-
-	flatNames := fallbackArtworkNames(stem)
-	dir := filepath.Dir(rel)
-	if dir == "." || dir == "" {
-		return flatNames
-	}
-
-	fallbackNames := make([]string, 0, len(flatNames)*2)
-	for _, flat := range flatNames {
-		nested := filepath.Join(dir, flat)
-		if nested != flat {
-			fallbackNames = append(fallbackNames, nested)
-		}
-	}
-	fallbackNames = append(fallbackNames, flatNames...)
-	return fallbackNames
+	return esmedia.ArtworkFallbackNames(gamePath, systemRootPath)
 }
 
 func fallbackArtworkNames(stem string) []string {
-	if stem == "" || stem == "." {
-		return nil
-	}
-	names := make([]string, 0, len(fallbackArtworkExtensions))
-	for _, ext := range fallbackArtworkExtensions {
-		names = append(names, stem+ext)
-	}
-	return names
+	return esmedia.FallbackArtworkNames(stem)
 }
 
 func findMediaFilePropFS(
@@ -1494,31 +1325,15 @@ func findMediaFilePropFS(
 	candidates []string,
 	availableDirs map[string]string,
 ) *database.MediaProperty {
-	if len(fallbackNames) == 0 {
+	file := esmedia.FindFileFS(fs, fallbackNames, candidates, availableDirs)
+	if file == nil {
 		return nil
 	}
-	for _, dir := range candidates {
-		dirPath, ok := availableDirs[dir]
-		if !ok {
-			continue
-		}
-		for _, name := range fallbackNames {
-			cleanName := filepath.Clean(name)
-			if name == "" || cleanName == "." || cleanName == ".." ||
-				strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
-				continue
-			}
-			candidate := filepath.Join(dirPath, name)
-			if exists, err := afero.Exists(fs, candidate); err == nil && exists {
-				return &database.MediaProperty{
-					TypeTag:     typeTag,
-					Text:        filepath.ToSlash(candidate),
-					ContentType: mimeFromExt(candidate),
-				}
-			}
-		}
+	return &database.MediaProperty{
+		TypeTag:     typeTag,
+		Text:        file.Path,
+		ContentType: file.ContentType,
 	}
-	return nil
 }
 
 func titleSlugKnown(indexes loadRecordIndexes, slug string) bool {
@@ -1867,7 +1682,7 @@ func companionEntriesFromParsed(
 					GameID:             game.ScreenScraperIDAttr,
 				})
 			case game.ParentIDAttr != "" && game.Path != "":
-				resolved := resolveESPath(game.Path, file.RootPath)
+				resolved := esmedia.ResolvePath(game.Path, file.RootPath)
 				if resolved == "" {
 					unresolvedChildPaths++
 					continue
@@ -2283,33 +2098,5 @@ func companionChildTags(c companionChild) []database.TagInfo {
 
 // mimeFromExt returns a MIME type based on file extension.
 func mimeFromExt(path string) string {
-	ext := strings.ToLower(filepath.Ext(path))
-	switch ext {
-	case ".png":
-		return "image/png"
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".gif":
-		return "image/gif"
-	case ".webp":
-		return "image/webp"
-	case ".mp4":
-		return "video/mp4"
-	case ".mkv":
-		return "video/x-matroska"
-	case ".avi":
-		return "video/avi"
-	case ".pdf":
-		return "application/pdf"
-	case ".mp3":
-		return "audio/mpeg"
-	case ".m4a", ".m4b":
-		return "audio/mp4"
-	case ".mpg", ".mpeg":
-		return "video/mpeg"
-	case ".m4v":
-		return "video/mp4"
-	default:
-		return "application/octet-stream"
-	}
+	return esmedia.MimeFromExt(path)
 }

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1266,7 +1266,7 @@ func resolveESAssetPath(esPath, systemRootPath string, externalAssetRoots []stri
 	if esmedia.PathWithinRoot(abs, systemRootPath) {
 		return abs
 	}
-	if filepath.IsAbs(esPath) || strings.HasPrefix(esPath, "~/") {
+	if filepath.IsAbs(esPath) || esmedia.IsHomeRelativePath(esPath) {
 		for _, root := range externalAssetRoots {
 			if esmedia.PathWithinRoot(abs, root) {
 				return abs

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -72,19 +73,19 @@ func TestCleanField_Empty(t *testing.T) {
 	assert.Empty(t, cleanField(""))
 }
 
-// --- resolveESPath ---
+// --- esmedia.ResolvePath ---
 
 func TestResolveESPath_RelativeDotSlash(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	got := resolveESPath("./roms/mario.nes", root)
+	got := esmedia.ResolvePath("./roms/mario.nes", root)
 	assert.Equal(t, filepath.Join(root, "roms", "mario.nes"), got)
 }
 
 func TestResolveESPath_RelativeNoDot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	got := resolveESPath("roms/mario.nes", root)
+	got := esmedia.ResolvePath("roms/mario.nes", root)
 	assert.Equal(t, filepath.Join(root, "roms", "mario.nes"), got)
 }
 
@@ -92,7 +93,7 @@ func TestResolveESPath_AbsoluteInsideRoot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	absPath := filepath.Join(root, "roms", "mario.nes")
-	got := resolveESPath(absPath, root)
+	got := esmedia.ResolvePath(absPath, root)
 	assert.Equal(t, absPath, got)
 }
 
@@ -100,20 +101,20 @@ func TestResolveESPath_AbsoluteOutsideRoot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	absPath := filepath.Join(root, "mario.nes")
-	got := resolveESPath(absPath, filepath.Join(root, "other"))
+	got := esmedia.ResolvePath(absPath, filepath.Join(root, "other"))
 	assert.Empty(t, got)
 }
 
 func TestResolveESPath_Empty(t *testing.T) {
 	t.Parallel()
-	got := resolveESPath("", t.TempDir())
+	got := esmedia.ResolvePath("", t.TempDir())
 	assert.Empty(t, got)
 }
 
 func TestResolveESPath_PathTraversal(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	got := resolveESPath("../../etc/passwd", root)
+	got := esmedia.ResolvePath("../../etc/passwd", root)
 	// Relative paths that escape systemRootPath must be rejected.
 	assert.Empty(t, got, "path traversal outside root must return empty string")
 }
@@ -121,7 +122,7 @@ func TestResolveESPath_PathTraversal(t *testing.T) {
 func TestResolveESPath_TraversalToAbsolute(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	got := resolveESPath("../../../etc/passwd", root)
+	got := esmedia.ResolvePath("../../../etc/passwd", root)
 	assert.Empty(t, got, "deep traversal outside root must return empty string")
 }
 
@@ -1778,13 +1779,13 @@ func TestMapToDB_FilesystemFallback_BoxartBack(t *testing.T) {
 	assert.True(t, found, "filesystem fallback boxartback property missing")
 }
 
-// --- resolveESPath additional ---
+// --- esmedia.ResolvePath additional ---
 
 func TestResolveESPath_HomeRelativeEscapesRoot(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	// ~/... resolves to home dir, which is outside t.TempDir().
-	got := resolveESPath("~/games/mario.nes", root)
+	got := esmedia.ResolvePath("~/games/mario.nes", root)
 	assert.Empty(t, got, "home-relative path escaping system root must be rejected")
 }
 
@@ -1795,7 +1796,7 @@ func TestResolveESPath_HomeRelativeInsideRoot(t *testing.T) {
 		t.Skip("cannot determine home dir")
 	}
 	// Use home dir itself as the system root so ~/relative stays inside.
-	got := resolveESPath("~/games/mario.nes", home)
+	got := esmedia.ResolvePath("~/games/mario.nes", home)
 	assert.Equal(t, filepath.Join(home, "games", "mario.nes"), got)
 }
 
@@ -2225,7 +2226,7 @@ func TestLoadCompanionEntries_EntrySkippedNoIdNoPath(t *testing.T) {
 func TestLoadCompanionEntries_ChildPathTraversalRejected(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	// Child path escapes root → resolveESPath returns "" → child skipped.
+	// Child path escapes root → esmedia.ResolvePath returns "" → child skipped.
 	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
   <game id="1" source="ZaparooCompanion">
     <name>Parent</name>

--- a/pkg/database/scraper/localmedia/scraper.go
+++ b/pkg/database/scraper/localmedia/scraper.go
@@ -204,6 +204,7 @@ func (s *scraperImpl) scrapeLoop(
 				staleDeleted, cleanupErr = s.deleteStaleLocalMediaProps(ctx, media, system.ROMPaths, props)
 				if cleanupErr != nil {
 					skipped++
+					processed++
 					ch <- scraper.ScrapeUpdate{
 						Err:         cleanupErr,
 						SystemID:    system.ID,
@@ -234,6 +235,7 @@ func (s *scraperImpl) scrapeLoop(
 				}
 				if err := s.db.ApplyScrapeResult(ctx, media.DBID, media.MediaTitleDBID, write); err != nil {
 					skipped++
+					processed++
 					ch <- scraper.ScrapeUpdate{
 						Err:         fmt.Errorf("localmedia: write media %d: %w", media.DBID, err),
 						SystemID:    system.ID,

--- a/pkg/database/scraper/localmedia/scraper.go
+++ b/pkg/database/scraper/localmedia/scraper.go
@@ -1,0 +1,394 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package localmedia imports EmulationStation-style media folder artwork.
+package localmedia
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esmedia"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+const scraperID = "media-folder"
+
+var artworkPropertyOrder = []tags.TagValue{ //nolint:gochecknoglobals // Stable scraper property order.
+	tags.TagPropertyImageImage,
+	tags.TagPropertyImageThumbnail,
+	tags.TagPropertyImageBoxart,
+	tags.TagPropertyImageBoxart3D,
+	tags.TagPropertyImageBoxartSide,
+	tags.TagPropertyImageBoxartBack,
+	tags.TagPropertyImageScreenshot,
+	tags.TagPropertyImageMarquee,
+	tags.TagPropertyImageWheel,
+	tags.TagPropertyImageFanart,
+	tags.TagPropertyImageTitleshot,
+	tags.TagPropertyImageMap,
+}
+
+type scraperImpl struct {
+	db database.MediaDBI
+	fs afero.Fs
+}
+
+// NewPlatformScraper returns a scraper that imports image paths from local
+// EmulationStation media directories under each system folder.
+func NewPlatformScraper() platforms.Scraper {
+	return platforms.Scraper{
+		ID:                 scraperID,
+		Name:               "ES media folders",
+		SupportedSystemIDs: []string{},
+		Scrape: func(
+			ctx context.Context,
+			cfg *config.Instance,
+			pl platforms.Platform,
+			fs afero.Fs,
+			db *database.Database,
+			opts scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions,
+			ch chan<- scraper.ScrapeUpdate,
+		) error {
+			systems, err := resolveSystemsFromPlatform(ctx, cfg, pl, db.MediaDB, opts.Systems)
+			if err != nil {
+				return fmt.Errorf("localmedia: resolve systems: %w", err)
+			}
+			s := &scraperImpl{db: db.MediaDB, fs: fs}
+			go s.scrapeLoop(ctx, opts, systems, ch)
+			return nil
+		},
+	}
+}
+
+func resolveSystemsFromPlatform(
+	ctx context.Context,
+	cfg *config.Instance,
+	pl platforms.Platform,
+	mdb database.MediaDBI,
+	systemIDs []string,
+) ([]scraper.ScrapeSystem, error) {
+	indexed, err := mdb.IndexedSystems()
+	if err != nil {
+		return nil, fmt.Errorf("list indexed systems: %w", err)
+	}
+
+	wantedIDs := orderedScrapeSystemIDs(indexed, systemIDs)
+	dbSystems := make(map[string]database.System, len(wantedIDs))
+	sysDefs := make([]systemdefs.System, 0, len(wantedIDs))
+	for _, sysID := range wantedIDs {
+		sys, err := mdb.FindSystemBySystemID(sysID)
+		if err != nil {
+			return nil, fmt.Errorf("look up system %q: %w", sysID, err)
+		}
+		systemDef, err := systemdefs.GetSystem(sysID)
+		if err != nil {
+			log.Debug().Err(err).Str("system", sysID).Msg("localmedia: unknown system definition, skipping")
+			continue
+		}
+		dbSystems[sysID] = sys
+		sysDefs = append(sysDefs, *systemDef)
+	}
+
+	pathsBySystem := make(map[string][]string, len(sysDefs))
+	for _, pathResult := range mediascanner.GetSystemPaths(ctx, cfg, pl, pl.RootDirs(cfg), sysDefs) {
+		pathsBySystem[pathResult.System.ID] = append(pathsBySystem[pathResult.System.ID], pathResult.Path)
+	}
+
+	result := make([]scraper.ScrapeSystem, 0, len(sysDefs))
+	for _, sys := range sysDefs {
+		romPaths := pathsBySystem[sys.ID]
+		if len(romPaths) == 0 {
+			log.Debug().Str("system", sys.ID).Msg("localmedia: no launcher paths found, skipping")
+			continue
+		}
+		result = append(result, scraper.ScrapeSystem{DBID: dbSystems[sys.ID].DBID, ID: sys.ID, ROMPaths: romPaths})
+	}
+	return result, nil
+}
+
+func orderedScrapeSystemIDs(indexed, requested []string) []string {
+	indexedSet := make(map[string]struct{}, len(indexed))
+	for _, id := range indexed {
+		indexedSet[id] = struct{}{}
+	}
+
+	candidateIDs := indexed
+	if len(requested) > 0 {
+		candidateIDs = requested
+	}
+
+	seen := make(map[string]struct{}, len(candidateIDs))
+	ordered := make([]string, 0, len(candidateIDs))
+	for _, id := range candidateIDs {
+		if _, ok := indexedSet[id]; !ok {
+			continue
+		}
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		ordered = append(ordered, id)
+	}
+	return ordered
+}
+
+func (s *scraperImpl) scrapeLoop(
+	ctx context.Context,
+	opts scraper.ScrapeOptions,
+	systems []scraper.ScrapeSystem,
+	ch chan<- scraper.ScrapeUpdate,
+) {
+	defer close(ch)
+	for systemIdx, system := range systems {
+		if err := waitForScrape(ctx, opts); err != nil {
+			ch <- scraper.ScrapeUpdate{FatalErr: err, Done: true}
+			return
+		}
+
+		mediaRows, err := s.db.GetMediaBySystemID(system.ID)
+		if err != nil {
+			ch <- scraper.ScrapeUpdate{
+				FatalErr: fmt.Errorf("localmedia: load media for %s: %w", system.ID, err),
+				Done:     true,
+			}
+			return
+		}
+
+		processed, matched, skipped := 0, 0, 0
+		availableDirs := s.availableDirsByRoot(system.ROMPaths)
+		ch <- scraper.ScrapeUpdate{
+			SystemID:    system.ID,
+			Total:       len(mediaRows),
+			TotalSteps:  len(systems),
+			CurrentStep: systemIdx + 1,
+		}
+
+		for mediaIdx := range mediaRows {
+			media := &mediaRows[mediaIdx]
+			if err := waitForScrape(ctx, opts); err != nil {
+				ch <- scraper.ScrapeUpdate{FatalErr: err, Done: true}
+				return
+			}
+
+			props := s.mediaPropsForPath(media.Path, system.ROMPaths, availableDirs)
+			staleDeleted := 0
+			if opts.Force {
+				var cleanupErr error
+				staleDeleted, cleanupErr = s.deleteStaleLocalMediaProps(ctx, media, system.ROMPaths, props)
+				if cleanupErr != nil {
+					skipped++
+					ch <- scraper.ScrapeUpdate{
+						Err:         cleanupErr,
+						SystemID:    system.ID,
+						Processed:   processed,
+						Total:       len(mediaRows),
+						Matched:     matched,
+						Skipped:     skipped,
+						TotalSteps:  len(systems),
+						CurrentStep: systemIdx + 1,
+					}
+					continue
+				}
+			}
+
+			if len(props) == 0 {
+				if staleDeleted > 0 {
+					matched++
+				} else {
+					skipped++
+				}
+			} else {
+				write := &database.ScrapeWrite{
+					Sentinel:   scraper.SentinelTagInfo(scraperID),
+					MediaProps: props,
+				}
+				if opts.RunID != "" {
+					write.MediaTags = append(write.MediaTags, scraper.RunTagInfo(scraperID, opts.RunID))
+				}
+				if err := s.db.ApplyScrapeResult(ctx, media.DBID, media.MediaTitleDBID, write); err != nil {
+					skipped++
+					ch <- scraper.ScrapeUpdate{
+						Err:         fmt.Errorf("localmedia: write media %d: %w", media.DBID, err),
+						SystemID:    system.ID,
+						Processed:   processed,
+						Total:       len(mediaRows),
+						Matched:     matched,
+						Skipped:     skipped,
+						TotalSteps:  len(systems),
+						CurrentStep: systemIdx + 1,
+					}
+					continue
+				}
+				matched++
+			}
+
+			processed++
+			ch <- scraper.ScrapeUpdate{
+				SystemID:    system.ID,
+				Processed:   processed,
+				Total:       len(mediaRows),
+				Matched:     matched,
+				Skipped:     skipped,
+				TotalSteps:  len(systems),
+				CurrentStep: systemIdx + 1,
+			}
+		}
+	}
+	ch <- scraper.ScrapeUpdate{TotalSteps: len(systems), CurrentStep: len(systems), Done: true}
+}
+
+func waitForScrape(ctx context.Context, opts scraper.ScrapeOptions) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if opts.Pauser != nil {
+		if err := opts.Pauser.Wait(ctx); err != nil {
+			return fmt.Errorf("localmedia: wait while paused: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *scraperImpl) availableDirsByRoot(roots []string) map[string]map[string]string {
+	result := make(map[string]map[string]string, len(roots))
+	for _, root := range roots {
+		result[root] = esmedia.StatMediaDirsFS(s.fs, root)
+	}
+	return result
+}
+
+func (s *scraperImpl) mediaPropsForPath(
+	path string,
+	roots []string,
+	availableDirs map[string]map[string]string,
+) []database.MediaProperty {
+	props := make([]database.MediaProperty, 0)
+	for _, root := range roots {
+		fallbackNames := esmedia.ArtworkFallbackNames(path, root)
+		if len(fallbackNames) == 0 {
+			continue
+		}
+		for _, propValue := range artworkPropertyOrder {
+			file := esmedia.FindFileFS(
+				s.fs,
+				fallbackNames,
+				esmedia.ArtworkDirCandidates[string(propValue)],
+				availableDirs[root],
+			)
+			if file == nil {
+				continue
+			}
+			props = append(props, database.MediaProperty{
+				TypeTag:     tags.PropertyTypeTag(propValue),
+				Text:        filepath.ToSlash(file.Path),
+				ContentType: file.ContentType,
+			})
+		}
+		if len(props) > 0 {
+			return props
+		}
+	}
+	return props
+}
+
+func (s *scraperImpl) deleteStaleLocalMediaProps(
+	ctx context.Context,
+	media *database.MediaWithFullPath,
+	roots []string,
+	foundProps []database.MediaProperty,
+) (int, error) {
+	existingProps, err := s.db.GetMediaPropertyMetadata(ctx, media.DBID)
+	if err != nil {
+		return 0, fmt.Errorf("localmedia: load media properties for %d: %w", media.DBID, err)
+	}
+
+	foundTypes := make(map[string]struct{}, len(foundProps))
+	for _, prop := range foundProps {
+		foundTypes[prop.TypeTag] = struct{}{}
+	}
+
+	deleted := 0
+	for _, prop := range existingProps {
+		if _, found := foundTypes[prop.TypeTag]; found {
+			continue
+		}
+		if prop.TypeTagDBID == 0 || !isLocalMediaPropForPath(&prop, media.Path, roots) {
+			continue
+		}
+		if err := s.db.DeleteMediaProperty(ctx, media.DBID, prop.TypeTagDBID); err != nil {
+			return deleted, fmt.Errorf("localmedia: delete stale media property %d/%d: %w",
+				media.DBID, prop.TypeTagDBID, err)
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+func isLocalMediaPropForPath(prop *database.MediaProperty, mediaPath string, roots []string) bool {
+	propValue, ok := imagePropertyValue(prop.TypeTag)
+	if !ok || prop.Text == "" {
+		return false
+	}
+	candidates := esmedia.ArtworkDirCandidates[propValue]
+	if len(candidates) == 0 {
+		return false
+	}
+
+	propPath := filepath.Clean(filepath.FromSlash(prop.Text))
+	for _, root := range roots {
+		fallbackNames := esmedia.ArtworkFallbackNames(mediaPath, root)
+		if len(fallbackNames) == 0 {
+			continue
+		}
+		for _, dir := range candidates {
+			for _, name := range fallbackNames {
+				candidate := filepath.Clean(filepath.Join(root, "media", dir, name))
+				if propPath == candidate {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func imagePropertyValue(typeTag string) (string, bool) {
+	prefix := string(tags.TagTypeProperty) + ":"
+	if len(typeTag) <= len(prefix) || typeTag[:len(prefix)] != prefix {
+		return "", false
+	}
+	value := typeTag[len(prefix):]
+	if _, ok := esmedia.ArtworkDirCandidates[value]; !ok {
+		return "", false
+	}
+	return value, true
+}

--- a/pkg/database/scraper/localmedia/scraper_test.go
+++ b/pkg/database/scraper/localmedia/scraper_test.go
@@ -109,6 +109,19 @@ func TestScrape_ImportsLocalMediaFolderArtwork(t *testing.T) {
 	pl.AssertExpectations(t)
 }
 
+func TestOrderedScrapeSystemIDs(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]string{"SNES", "NES"},
+		orderedScrapeSystemIDs([]string{"NES", "SNES", "GB"}, []string{"SNES", "NES", "SNES", "PSX"}),
+	)
+	assert.Equal(t,
+		[]string{"NES", "SNES"},
+		orderedScrapeSystemIDs([]string{"NES", "SNES"}, nil),
+	)
+}
+
 func TestDeleteStaleLocalMediaProps_DeletesOnlyMissingLocalConventionProps(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +164,100 @@ func TestDeleteStaleLocalMediaProps_DeletesOnlyMissingLocalConventionProps(t *te
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, deleted)
+	mockDB.AssertExpectations(t)
+}
+
+func TestScrape_WriteErrorIncrementsProcessed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "nes")
+	romPath := filepath.Join(systemRoot, "Game.nes")
+	boxartPath := filepath.Join(systemRoot, "media", "boxart", "Game.png")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, os.MkdirAll(systemRoot, 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(boxartPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, boxartPath, []byte("boxart"), 0o600))
+
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	pl := mocks.NewMockPlatform()
+	pl.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	pl.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{{
+		ID:         "nes",
+		SystemID:   "NES",
+		Folders:    []string{"nes"},
+		Extensions: []string{".nes"},
+	}})
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 1, SystemID: "NES", Name: "NES"}, nil)
+	mockDB.On("GetMediaBySystemID", "NES").Return([]database.MediaWithFullPath{
+		{DBID: 11, MediaTitleDBID: 101, Path: romPath, SystemID: "NES"},
+	}, nil)
+	mockDB.On("ApplyScrapeResult", mock.Anything, int64(11), int64(101), mock.Anything).
+		Return(assert.AnError).Once()
+
+	ch := make(chan scraper.ScrapeUpdate, 32)
+	err = NewPlatformScraper().Scrape(
+		context.Background(), cfg, pl, fs, &database.Database{MediaDB: mockDB}, scraper.ScrapeOptions{}, nil, ch,
+	)
+	require.NoError(t, err)
+
+	var errUpdate scraper.ScrapeUpdate
+	for update := range ch {
+		if update.Err != nil {
+			errUpdate = update
+		}
+	}
+	assert.Equal(t, 1, errUpdate.Processed)
+	assert.Equal(t, 1, errUpdate.Skipped)
+	mockDB.AssertExpectations(t)
+}
+
+func TestScrape_CleanupErrorIncrementsProcessed(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "nes")
+	romPath := filepath.Join(systemRoot, "Game.nes")
+	require.NoError(t, os.MkdirAll(systemRoot, 0o750))
+
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	pl := mocks.NewMockPlatform()
+	pl.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	pl.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{{
+		ID:         "nes",
+		SystemID:   "NES",
+		Folders:    []string{"nes"},
+		Extensions: []string{".nes"},
+	}})
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 1, SystemID: "NES", Name: "NES"}, nil)
+	mockDB.On("GetMediaBySystemID", "NES").Return([]database.MediaWithFullPath{
+		{DBID: 11, MediaTitleDBID: 101, Path: romPath, SystemID: "NES"},
+	}, nil)
+	mockDB.On("GetMediaPropertyMetadata", mock.Anything, int64(11)).Return(nil, assert.AnError).Once()
+
+	ch := make(chan scraper.ScrapeUpdate, 32)
+	err = NewPlatformScraper().Scrape(
+		context.Background(), cfg, pl, afero.NewMemMapFs(), &database.Database{MediaDB: mockDB},
+		scraper.ScrapeOptions{Force: true}, nil, ch,
+	)
+	require.NoError(t, err)
+
+	var errUpdate scraper.ScrapeUpdate
+	for update := range ch {
+		if update.Err != nil {
+			errUpdate = update
+		}
+	}
+	assert.Equal(t, 1, errUpdate.Processed)
+	assert.Equal(t, 1, errUpdate.Skipped)
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/database/scraper/localmedia/scraper_test.go
+++ b/pkg/database/scraper/localmedia/scraper_test.go
@@ -1,0 +1,174 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package localmedia
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrape_ImportsLocalMediaFolderArtwork(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "nes")
+	romPath := filepath.Join(systemRoot, "Subdir", "Game.nes")
+	missingPath := filepath.Join(systemRoot, "Missing.nes")
+	boxartPath := filepath.Join(systemRoot, "media", "boxart", "Subdir", "Game.png")
+	screenshotPath := filepath.Join(systemRoot, "media", "screenshots", "Subdir", "Game.jpg")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, os.MkdirAll(systemRoot, 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(boxartPath), 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(screenshotPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, boxartPath, []byte("boxart"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, screenshotPath, []byte("screenshot"), 0o600))
+
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	pl := mocks.NewMockPlatform()
+	pl.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	pl.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{{
+		ID:         "nes",
+		SystemID:   "NES",
+		Folders:    []string{"nes"},
+		Extensions: []string{".nes"},
+	}})
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+	mockDB.On("FindSystemBySystemID", "NES").Return(database.System{DBID: 1, SystemID: "NES", Name: "NES"}, nil)
+	mockDB.On("GetMediaBySystemID", "NES").Return([]database.MediaWithFullPath{
+		{DBID: 11, MediaTitleDBID: 101, Path: romPath, SystemID: "NES"},
+		{DBID: 12, MediaTitleDBID: 102, Path: missingPath, SystemID: "NES"},
+	}, nil)
+	mockDB.On(
+		"ApplyScrapeResult",
+		mock.Anything,
+		int64(11),
+		int64(101),
+		mock.MatchedBy(func(write *database.ScrapeWrite) bool {
+			if write == nil {
+				return false
+			}
+			assert.Equal(t, scraper.SentinelTagInfo(scraperID), write.Sentinel)
+			require.Len(t, write.MediaProps, 2)
+			assert.Equal(t, tags.PropertyTypeTag(tags.TagPropertyImageBoxart), write.MediaProps[0].TypeTag)
+			assert.Equal(t, filepath.ToSlash(boxartPath), write.MediaProps[0].Text)
+			assert.Equal(t, "image/png", write.MediaProps[0].ContentType)
+			assert.Equal(t, tags.PropertyTypeTag(tags.TagPropertyImageScreenshot), write.MediaProps[1].TypeTag)
+			assert.Equal(t, filepath.ToSlash(screenshotPath), write.MediaProps[1].Text)
+			assert.Equal(t, "image/jpeg", write.MediaProps[1].ContentType)
+			return true
+		}),
+	).Return(nil).Once()
+
+	ch := make(chan scraper.ScrapeUpdate, 32)
+	s := NewPlatformScraper()
+	err = s.Scrape(
+		context.Background(), cfg, pl, fs, &database.Database{MediaDB: mockDB},
+		scraper.ScrapeOptions{}, nil, ch,
+	)
+	require.NoError(t, err)
+
+	var last scraper.ScrapeUpdate
+	for update := range ch {
+		last = update
+	}
+	assert.True(t, last.Done)
+	mockDB.AssertExpectations(t)
+	pl.AssertExpectations(t)
+}
+
+func TestDeleteStaleLocalMediaProps_DeletesOnlyMissingLocalConventionProps(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mediaPath := filepath.Join(root, "Game.nes")
+	staleLocalPath := filepath.Join(root, "media", "boxart", "Game.png")
+	keptLocalPath := filepath.Join(root, "media", "screenshots", "Game.jpg")
+	foreignPath := filepath.Join(root, "custom-art", "Game.png")
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaPropertyMetadata", mock.Anything, int64(11)).Return([]database.MediaProperty{
+		{
+			TypeTag:     tags.PropertyTypeTag(tags.TagPropertyImageBoxart),
+			TypeTagDBID: 101,
+			Text:        filepath.ToSlash(staleLocalPath),
+		},
+		{
+			TypeTag:     tags.PropertyTypeTag(tags.TagPropertyImageScreenshot),
+			TypeTagDBID: 102,
+			Text:        filepath.ToSlash(keptLocalPath),
+		},
+		{
+			TypeTag:     tags.PropertyTypeTag(tags.TagPropertyImageImage),
+			TypeTagDBID: 103,
+			Text:        filepath.ToSlash(foreignPath),
+		},
+	}, nil)
+	mockDB.On("DeleteMediaProperty", mock.Anything, int64(11), int64(101)).Return(nil).Once()
+
+	s := &scraperImpl{db: mockDB, fs: afero.NewMemMapFs()}
+	media := &database.MediaWithFullPath{
+		DBID:           11,
+		MediaTitleDBID: 101,
+		Path:           mediaPath,
+		SystemID:       "NES",
+	}
+	deleted, err := s.deleteStaleLocalMediaProps(context.Background(), media, []string{root}, []database.MediaProperty{{
+		TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageScreenshot),
+		Text:    filepath.ToSlash(keptLocalPath),
+	}})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	mockDB.AssertExpectations(t)
+}
+
+func TestMediaPropsForPath_UsesFlatFallbackAfterMirroredPath(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := filepath.Join("roms", "nes")
+	romPath := filepath.Join(root, "Subdir", "Game.nes")
+	flatCoverPath := filepath.Join(root, "media", "covers", "Game.webp")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(flatCoverPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, flatCoverPath, []byte("cover"), 0o600))
+
+	s := &scraperImpl{fs: fs}
+	props := s.mediaPropsForPath(romPath, []string{root}, s.availableDirsByRoot([]string{root}))
+
+	require.Len(t, props, 1)
+	assert.Equal(t, tags.PropertyTypeTag(tags.TagPropertyImageBoxart), props[0].TypeTag)
+	assert.Equal(t, filepath.ToSlash(flatCoverPath), props[0].Text)
+	assert.Equal(t, "image/webp", props[0].ContentType)
+}

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -848,6 +849,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/batocera/scrapers_test.go
+++ b/pkg/platforms/batocera/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package batocera
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -284,6 +285,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/libreelec/scrapers_test.go
+++ b/pkg/platforms/libreelec/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package libreelec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -261,6 +262,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -1322,8 +1323,9 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }
 
 // SetArcadeCardLaunch caches the arcade setname when launching via card.

--- a/pkg/platforms/mister/scrapers_test.go
+++ b/pkg/platforms/mister/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package mister
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -370,8 +371,9 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }
 
 func (*Platform) ShowNotice(

--- a/pkg/platforms/mistex/scrapers_test.go
+++ b/pkg/platforms/mistex/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package mistex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/recalbox/platform.go
+++ b/pkg/platforms/recalbox/platform.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -269,6 +270,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/recalbox/scrapers_test.go
+++ b/pkg/platforms/recalbox/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package recalbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/replayos/platform.go
+++ b/pkg/platforms/replayos/platform.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -346,8 +347,9 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }
 
 // launchGame spawns a background goroutine that deletes the autostart file

--- a/pkg/platforms/replayos/scrapers_test.go
+++ b/pkg/platforms/replayos/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package replayos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/retropie/platform.go
+++ b/pkg/platforms/retropie/platform.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -269,6 +270,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/retropie/scrapers_test.go
+++ b/pkg/platforms/retropie/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package retropie
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := (&Platform{}).Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/shared/esmedia/artwork.go
+++ b/pkg/platforms/shared/esmedia/artwork.go
@@ -226,7 +226,7 @@ func ResolvePathAbs(esPath, systemRootPath string) (string, bool) {
 
 	var abs string
 	switch {
-	case strings.HasPrefix(esPath, "~/"):
+	case IsHomeRelativePath(esPath):
 		home, homeErr := os.UserHomeDir()
 		if homeErr != nil {
 			return "", false
@@ -244,6 +244,11 @@ func ResolvePathAbs(esPath, systemRootPath string) (string, bool) {
 		return "", false
 	}
 	return filepath.Clean(abs), true
+}
+
+// IsHomeRelativePath reports whether an ES path starts with ~/ or ~\.
+func IsHomeRelativePath(esPath string) bool {
+	return strings.HasPrefix(esPath, "~/") || strings.HasPrefix(esPath, `~\`)
 }
 
 // PathWithinRoot reports whether path is inside root after absolute-path cleanup.

--- a/pkg/platforms/shared/esmedia/artwork.go
+++ b/pkg/platforms/shared/esmedia/artwork.go
@@ -1,0 +1,263 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package esmedia resolves local EmulationStation-style media folders and paths.
+package esmedia
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/spf13/afero"
+)
+
+// File is a local media file discovered in an EmulationStation media folder.
+type File struct {
+	Path        string
+	ContentType string
+}
+
+// ArtworkExtensions are checked in order when deriving artwork filenames.
+//
+//nolint:gochecknoglobals // Package-level EmulationStation media convention.
+var ArtworkExtensions = []string{".png", ".jpg", ".jpeg", ".webp"}
+
+// ArtworkDirCandidates maps each TagPropertyImage value to ordered media
+// sub-directory names under <systemRootPath>/media/.
+//
+//nolint:gochecknoglobals // Package-level EmulationStation media convention.
+var ArtworkDirCandidates = map[string][]string{
+	string(tags.TagPropertyImageImage): {"image", "images", "miximages", "custom"},
+	string(tags.TagPropertyImageBoxart): {
+		"boxart", "boxart2d", "box2d", "boxart2dfront", "box2dfront", "cover", "covers",
+	},
+	string(tags.TagPropertyImageBoxart3D):   {"boxart3d", "3dbox", "3dboxes"},
+	string(tags.TagPropertyImageBoxartSide): {"boxart2dside"},
+	string(tags.TagPropertyImageBoxartBack): {"boxart2dback", "backcover", "backcovers"},
+	string(tags.TagPropertyImageScreenshot): {"screenshot", "screenshots"},
+	string(tags.TagPropertyImageThumbnail): {
+		"thumbnail", "thumbnails", "box2dfront", "boxart2dfront", "supporttexture",
+	},
+	string(tags.TagPropertyImageMarquee): {"marquee", "marquees"},
+	string(tags.TagPropertyImageWheel):   {"wheel", "wheels", "logo", "logos"},
+	string(tags.TagPropertyImageFanart):  {"fanart", "fanarts"},
+	string(tags.TagPropertyImageTitleshot): {
+		"titleshot", "titleshots", "titlescreen", "titlescreens", "screenshottitle",
+	},
+	string(tags.TagPropertyImageMap): {"map", "maps"},
+}
+
+// StatMediaDirs reads <rootPath>/media and returns subdirectory name to path.
+func StatMediaDirs(rootPath string) map[string]string {
+	return StatMediaDirsFS(afero.NewOsFs(), rootPath)
+}
+
+// StatMediaDirsFS reads <rootPath>/media using fs and returns subdirectory name to path.
+func StatMediaDirsFS(fs afero.Fs, rootPath string) map[string]string {
+	mediaRoot := filepath.Join(rootPath, "media")
+	entries, err := afero.ReadDir(fs, mediaRoot)
+	if err != nil {
+		return nil
+	}
+	dirs := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs[e.Name()] = filepath.Join(mediaRoot, e.Name())
+		}
+	}
+	return dirs
+}
+
+// ArtworkFallbackNames returns candidate artwork filenames for gamePath under
+// systemRootPath. For games in subdirectories, mirrored paths are checked before
+// flat filenames.
+func ArtworkFallbackNames(gamePath, systemRootPath string) []string {
+	resolved := ResolvePath(gamePath, systemRootPath)
+	if resolved == "" {
+		return nil
+	}
+
+	rootAbs, err := filepath.Abs(systemRootPath)
+	if err != nil {
+		return nil
+	}
+	rel, err := filepath.Rel(filepath.Clean(rootAbs), filepath.Clean(resolved))
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil
+	}
+
+	stem := strings.TrimSuffix(filepath.Base(rel), filepath.Ext(rel))
+	if stem == "" || stem == "." {
+		return nil
+	}
+
+	flatNames := FallbackArtworkNames(stem)
+	dir := filepath.Dir(rel)
+	if dir == "." || dir == "" {
+		return flatNames
+	}
+
+	fallbackNames := make([]string, 0, len(flatNames)*2)
+	for _, flat := range flatNames {
+		nested := filepath.Join(dir, flat)
+		if nested != flat {
+			fallbackNames = append(fallbackNames, nested)
+		}
+	}
+	fallbackNames = append(fallbackNames, flatNames...)
+	return fallbackNames
+}
+
+// FallbackArtworkNames returns <stem> plus each supported artwork extension.
+func FallbackArtworkNames(stem string) []string {
+	if stem == "" || stem == "." {
+		return nil
+	}
+	names := make([]string, 0, len(ArtworkExtensions))
+	for _, ext := range ArtworkExtensions {
+		names = append(names, stem+ext)
+	}
+	return names
+}
+
+// FindFileFS searches candidate directories for fallbackNames in order.
+func FindFileFS(
+	fs afero.Fs,
+	fallbackNames []string,
+	candidates []string,
+	availableDirs map[string]string,
+) *File {
+	if len(fallbackNames) == 0 {
+		return nil
+	}
+	for _, dir := range candidates {
+		dirPath, ok := availableDirs[dir]
+		if !ok {
+			continue
+		}
+		for _, name := range fallbackNames {
+			cleanName := filepath.Clean(name)
+			if name == "" || cleanName == "." || cleanName == ".." ||
+				strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) {
+				continue
+			}
+			candidate := filepath.Join(dirPath, name)
+			if exists, err := afero.Exists(fs, candidate); err == nil && exists {
+				return &File{Path: filepath.ToSlash(candidate), ContentType: MimeFromExt(candidate)}
+			}
+		}
+	}
+	return nil
+}
+
+// MimeFromExt returns a MIME type based on file extension.
+func MimeFromExt(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".mp4":
+		return "video/mp4"
+	case ".mkv":
+		return "video/x-matroska"
+	case ".avi":
+		return "video/avi"
+	case ".pdf":
+		return "application/pdf"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".m4a", ".m4b":
+		return "audio/mp4"
+	case ".mpg", ".mpeg":
+		return "video/mpeg"
+	case ".m4v":
+		return "video/mp4"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// ResolvePath converts an EmulationStation path to an absolute path under
+// systemRootPath. Paths that cannot be resolved or escape systemRootPath return
+// an empty string.
+func ResolvePath(esPath, systemRootPath string) string {
+	abs, ok := ResolvePathAbs(esPath, systemRootPath)
+	if !ok || !PathWithinRoot(abs, systemRootPath) {
+		return ""
+	}
+	return abs
+}
+
+// ResolvePathAbs converts an EmulationStation path to an absolute filesystem
+// path without enforcing that the result stays inside systemRootPath.
+func ResolvePathAbs(esPath, systemRootPath string) (string, bool) {
+	if esPath == "" {
+		return "", false
+	}
+	rootAbs, err := filepath.Abs(systemRootPath)
+	if err != nil {
+		return "", false
+	}
+	rootAbs = filepath.Clean(rootAbs)
+
+	var abs string
+	switch {
+	case strings.HasPrefix(esPath, "~/"):
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "", false
+		}
+		abs = filepath.Join(home, esPath[2:])
+	case filepath.IsAbs(esPath):
+		abs = filepath.Clean(esPath)
+	default:
+		rel := strings.TrimPrefix(esPath, "./")
+		abs = filepath.Join(rootAbs, rel)
+	}
+
+	abs, err = filepath.Abs(abs)
+	if err != nil || !filepath.IsAbs(abs) {
+		return "", false
+	}
+	return filepath.Clean(abs), true
+}
+
+// PathWithinRoot reports whether path is inside root after absolute-path cleanup.
+func PathWithinRoot(path, root string) bool {
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	pathAbs = filepath.Clean(pathAbs)
+	rootAbs = filepath.Clean(rootAbs)
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/pkg/platforms/shared/esmedia/artwork_test.go
+++ b/pkg/platforms/shared/esmedia/artwork_test.go
@@ -1,0 +1,181 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package esmedia
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtworkFallbackNames_RootFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gamePath := filepath.Join(root, "Game.nes")
+
+	assert.Equal(t, []string{
+		"Game.png",
+		"Game.jpg",
+		"Game.jpeg",
+		"Game.webp",
+	}, ArtworkFallbackNames(gamePath, root))
+}
+
+func TestArtworkFallbackNames_NestedFileMirrorsThenFlat(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	gamePath := filepath.Join(root, "Subdir", "Game.nes")
+
+	assert.Equal(t, []string{
+		filepath.Join("Subdir", "Game.png"),
+		filepath.Join("Subdir", "Game.jpg"),
+		filepath.Join("Subdir", "Game.jpeg"),
+		filepath.Join("Subdir", "Game.webp"),
+		"Game.png",
+		"Game.jpg",
+		"Game.jpeg",
+		"Game.webp",
+	}, ArtworkFallbackNames(gamePath, root))
+}
+
+func TestArtworkFallbackNames_RejectsEscapedPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outside := filepath.Join(filepath.Dir(root), "Other", "Game.nes")
+
+	assert.Nil(t, ArtworkFallbackNames(outside, root))
+}
+
+func TestFallbackArtworkNames(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"Game.png", "Game.jpg", "Game.jpeg", "Game.webp"}, FallbackArtworkNames("Game"))
+	assert.Nil(t, FallbackArtworkNames(""))
+	assert.Nil(t, FallbackArtworkNames("."))
+}
+
+func TestStatMediaDirsFS(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := filepath.Join("roms", "nes")
+	require.NoError(t, fs.MkdirAll(filepath.Join(root, "media", "boxart"), 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Join(root, "media", "screenshots"), 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(root, "media", "file.txt"), []byte("x"), 0o600))
+
+	dirs := StatMediaDirsFS(fs, root)
+	assert.Equal(t, filepath.Join(root, "media", "boxart"), dirs["boxart"])
+	assert.Equal(t, filepath.Join(root, "media", "screenshots"), dirs["screenshots"])
+	assert.NotContains(t, dirs, "file.txt")
+}
+
+func TestFindFileFS_UsesCandidateAndNameOrder(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := filepath.Join("roms", "nes")
+	boxartDir := filepath.Join(root, "media", "boxart")
+	coverDir := filepath.Join(root, "media", "covers")
+	require.NoError(t, fs.MkdirAll(boxartDir, 0o750))
+	require.NoError(t, fs.MkdirAll(coverDir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(boxartDir, "Game.jpg"), []byte("jpg"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(coverDir, "Game.png"), []byte("png"), 0o600))
+
+	file := FindFileFS(
+		fs,
+		[]string{"Game.png", "Game.jpg"},
+		[]string{"boxart", "covers"},
+		map[string]string{"boxart": boxartDir, "covers": coverDir},
+	)
+
+	require.NotNil(t, file)
+	assert.Equal(t, filepath.ToSlash(filepath.Join(boxartDir, "Game.jpg")), file.Path)
+	assert.Equal(t, "image/jpeg", file.ContentType)
+}
+
+func TestFindFileFS_RejectsTraversalNames(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	dir := filepath.Join("roms", "nes", "media", "boxart")
+	require.NoError(t, fs.MkdirAll(dir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(dir, "Game.png"), []byte("png"), 0o600))
+
+	file := FindFileFS(fs, []string{filepath.Join("..", "Game.png"), "Game.png"}, []string{"boxart"}, map[string]string{
+		"boxart": dir,
+	})
+
+	require.NotNil(t, file)
+	assert.Equal(t, filepath.ToSlash(filepath.Join(dir, "Game.png")), file.Path)
+}
+
+func TestResolvePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	resolved := ResolvePath(filepath.Join("Subdir", "Game.nes"), root)
+	assert.Equal(t, filepath.Join(root, "Subdir", "Game.nes"), resolved)
+
+	escaped := ResolvePath(filepath.Join("..", "Other", "Game.nes"), root)
+	assert.Empty(t, escaped)
+}
+
+func TestResolvePathAbs_Home(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	resolved, ok := ResolvePathAbs(filepath.Join("~", "Assets", "Game.png"), t.TempDir())
+	require.True(t, ok)
+	assert.Equal(t, filepath.Join(home, "Assets", "Game.png"), resolved)
+}
+
+func TestPathWithinRoot(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	assert.True(t, PathWithinRoot(filepath.Join(root, "Subdir", "Game.nes"), root))
+	assert.False(t, PathWithinRoot(filepath.Join(filepath.Dir(root), "Other", "Game.nes"), root))
+}
+
+func TestMimeFromExt(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "image/png", MimeFromExt("Game.PNG"))
+	assert.Equal(t, "image/jpeg", MimeFromExt("Game.jpeg"))
+	assert.Equal(t, "image/webp", MimeFromExt("Game.webp"))
+	assert.Equal(t, "application/pdf", MimeFromExt("Manual.pdf"))
+	assert.Equal(t, "application/octet-stream", MimeFromExt("Game.unknown"))
+}
+
+func TestArtworkDirCandidates_ContainsExpectedESDirs(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, ArtworkDirCandidates[string(tags.TagPropertyImageBoxart)], "covers")
+	assert.Contains(t, ArtworkDirCandidates[string(tags.TagPropertyImageBoxart3D)], "3dboxes")
+	assert.Contains(t, ArtworkDirCandidates[string(tags.TagPropertyImageScreenshot)], "screenshots")
+	assert.Contains(t, ArtworkDirCandidates[string(tags.TagPropertyImageTitleshot)], "titlescreens")
+}

--- a/pkg/platforms/shared/esmedia/artwork_test.go
+++ b/pkg/platforms/shared/esmedia/artwork_test.go
@@ -20,6 +20,7 @@
 package esmedia
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -78,6 +79,17 @@ func TestFallbackArtworkNames(t *testing.T) {
 	assert.Nil(t, FallbackArtworkNames("."))
 }
 
+func TestStatMediaDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "media", "boxart"), 0o750))
+	dirs := StatMediaDirs(root)
+
+	assert.Equal(t, filepath.Join(root, "media", "boxart"), dirs["boxart"])
+	assert.Nil(t, StatMediaDirs(filepath.Join(root, "missing")))
+}
+
 func TestStatMediaDirsFS(t *testing.T) {
 	t.Parallel()
 
@@ -117,6 +129,19 @@ func TestFindFileFS_UsesCandidateAndNameOrder(t *testing.T) {
 	assert.Equal(t, "image/jpeg", file.ContentType)
 }
 
+func TestFindFileFS_NotFound(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := filepath.Join("roms", "nes")
+	boxartDir := filepath.Join(root, "media", "boxart")
+	require.NoError(t, fs.MkdirAll(boxartDir, 0o750))
+
+	file := FindFileFS(fs, []string{"Missing.png"}, []string{"boxart"}, map[string]string{"boxart": boxartDir})
+
+	assert.Nil(t, file)
+}
+
 func TestFindFileFS_RejectsTraversalNames(t *testing.T) {
 	t.Parallel()
 
@@ -144,13 +169,54 @@ func TestResolvePath(t *testing.T) {
 	assert.Empty(t, escaped)
 }
 
+func TestResolvePathAbs_Empty(t *testing.T) {
+	t.Parallel()
+
+	resolved, ok := ResolvePathAbs("", t.TempDir())
+	assert.False(t, ok)
+	assert.Empty(t, resolved)
+}
+
+func TestResolvePathAbs_Absolute(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "Assets", "Game.png")
+	resolved, ok := ResolvePathAbs(path, t.TempDir())
+	require.True(t, ok)
+	assert.Equal(t, path, resolved)
+}
+
 func TestResolvePathAbs_Home(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 
 	resolved, ok := ResolvePathAbs(filepath.Join("~", "Assets", "Game.png"), t.TempDir())
 	require.True(t, ok)
 	assert.Equal(t, filepath.Join(home, "Assets", "Game.png"), resolved)
+}
+
+func TestResolvePathAbs_HomeBackslash(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	resolved, ok := ResolvePathAbs(`~\Assets\Game.png`, t.TempDir())
+	require.True(t, ok)
+	expected := filepath.Clean(home + string(filepath.Separator) + `Assets\Game.png`)
+	assert.Equal(t, expected, resolved)
+	assert.True(t, IsHomeRelativePath(`~\Assets\Game.png`))
+}
+
+func TestResolvePath_HomeBackslashInsideRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	resolved := ResolvePath(`~\games\mario.nes`, home)
+	expected := filepath.Clean(home + string(filepath.Separator) + `games\mario.nes`)
+	assert.Equal(t, expected, resolved)
 }
 
 func TestPathWithinRoot(t *testing.T) {
@@ -164,11 +230,26 @@ func TestPathWithinRoot(t *testing.T) {
 func TestMimeFromExt(t *testing.T) {
 	t.Parallel()
 
-	assert.Equal(t, "image/png", MimeFromExt("Game.PNG"))
-	assert.Equal(t, "image/jpeg", MimeFromExt("Game.jpeg"))
-	assert.Equal(t, "image/webp", MimeFromExt("Game.webp"))
-	assert.Equal(t, "application/pdf", MimeFromExt("Manual.pdf"))
-	assert.Equal(t, "application/octet-stream", MimeFromExt("Game.unknown"))
+	cases := map[string]string{
+		"Game.PNG":      "image/png",
+		"Game.jpeg":     "image/jpeg",
+		"Animation.gif": "image/gif",
+		"Game.webp":     "image/webp",
+		"Video.mp4":     "video/mp4",
+		"Video.mkv":     "video/x-matroska",
+		"Video.avi":     "video/avi",
+		"Manual.pdf":    "application/pdf",
+		"Song.mp3":      "audio/mpeg",
+		"Song.m4a":      "audio/mp4",
+		"Book.m4b":      "audio/mp4",
+		"Video.mpg":     "video/mpeg",
+		"Video.mpeg":    "video/mpeg",
+		"Video.m4v":     "video/mp4",
+		"Game.unknown":  "application/octet-stream",
+	}
+	for path, want := range cases {
+		assert.Equal(t, want, MimeFromExt(path), path)
+	}
 }
 
 func TestArtworkDirCandidates_ContainsExpectedESDirs(t *testing.T) {

--- a/pkg/platforms/shared/esmedia/artwork_test.go
+++ b/pkg/platforms/shared/esmedia/artwork_test.go
@@ -20,7 +20,6 @@
 package esmedia
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -77,17 +76,6 @@ func TestFallbackArtworkNames(t *testing.T) {
 	assert.Equal(t, []string{"Game.png", "Game.jpg", "Game.jpeg", "Game.webp"}, FallbackArtworkNames("Game"))
 	assert.Nil(t, FallbackArtworkNames(""))
 	assert.Nil(t, FallbackArtworkNames("."))
-}
-
-func TestStatMediaDirs(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	require.NoError(t, os.MkdirAll(filepath.Join(root, "media", "boxart"), 0o750))
-	dirs := StatMediaDirs(root)
-
-	assert.Equal(t, filepath.Join(root, "media", "boxart"), dirs["boxart"])
-	assert.Nil(t, StatMediaDirs(filepath.Join(root, "missing")))
 }
 
 func TestStatMediaDirsFS(t *testing.T) {

--- a/pkg/platforms/shared/linuxbase/base.go
+++ b/pkg/platforms/shared/linuxbase/base.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -363,6 +364,7 @@ func (*Base) ManagedByPackageManager() bool {
 
 // Scrapers returns the default set of metadata scrapers for Linux-based platforms.
 func (*Base) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }

--- a/pkg/platforms/shared/linuxbase/scrapers_test.go
+++ b/pkg/platforms/shared/linuxbase/scrapers_test.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package linuxbase
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScrapers_RegisterGamelistAndMediaFolder(t *testing.T) {
+	t.Parallel()
+
+	scrapers := NewBase("test").Scrapers(nil)
+
+	require.Contains(t, scrapers, "gamelist.xml")
+	require.Contains(t, scrapers, "media-folder")
+	assert.NotNil(t, scrapers["gamelist.xml"].Scrape)
+	assert.NotNil(t, scrapers["media-folder"].Scrape)
+}

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/gamelistxml"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper/localmedia"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -448,6 +449,7 @@ func (*Platform) ManagedByPackageManager() bool {
 }
 
 func (*Platform) Scrapers(_ *config.Instance) map[string]platforms.Scraper {
-	s := gamelistxml.NewPlatformScraper()
-	return map[string]platforms.Scraper{s.ID: s}
+	gamelist := gamelistxml.NewPlatformScraper()
+	media := localmedia.NewPlatformScraper()
+	return map[string]platforms.Scraper{gamelist.ID: gamelist, media.ID: media}
 }


### PR DESCRIPTION
## Summary
- add shared EmulationStation media-folder resolver utilities
- add media-folder scraper for importing local image paths and cleaning stale local props on re-scrape
- reuse shared resolver from gamelist.xml scraper and register media-folder scraper across platforms

## Validation
- go test ./pkg/platforms/shared/esmedia ./pkg/database/scraper/localmedia ./pkg/database/scraper/gamelistxml ./pkg/api/methods
- golangci-lint run pkg/platforms/shared/esmedia pkg/database/scraper/localmedia pkg/database/scraper/gamelistxml pkg/api/methods
- go test ./pkg/platforms/batocera ./pkg/platforms/libreelec ./pkg/platforms/mister ./pkg/platforms/mistex ./pkg/platforms/recalbox ./pkg/platforms/replayos ./pkg/platforms/retropie ./pkg/platforms/shared/linuxbase
- golangci-lint run pkg/platforms/batocera pkg/platforms/libreelec pkg/platforms/mister pkg/platforms/mistex pkg/platforms/recalbox pkg/platforms/replayos pkg/platforms/retropie pkg/platforms/shared/linuxbase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **media-folder** scraper to import artwork from EmulationStation-style `media/` folders across supported platforms (including thumbnails, boxart variants, screenshots, and more).
  * Force runs now remove stale local-media properties when local artwork files are no longer present.
* **Improvements**
  * Enhanced shared EmulationStation artwork/path resolution used by both gamelist-based and local-media scraping, with safer path handling and more consistent MIME detection.
* **Documentation**
  * Updated scraper documentation to reflect multiple active scraper implementations.
* **Tests**
  * Expanded coverage for local-media importing, stale cleanup, artwork discovery, path safety, and platform scraper registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->