### PR TITLE
fix: support AmigaVision launch paths

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -330,6 +330,29 @@ func newIndexingStatus() *indexingStatus {
 
 var statusInstance = newIndexingStatus()
 
+func activeMediaPausesMediaWork(media *models.ActiveMedia) bool {
+	if media == nil {
+		return false
+	}
+	slot, err := mediaslot.Normalize(media.Slot)
+	if err != nil {
+		log.Warn().Err(err).Str("slot", media.Slot).Msg("active media has invalid slot; pausing media work")
+		return true
+	}
+	return slot == mediaslot.Primary
+}
+
+func syncMediaWorkPauserWithActiveMedia(media *models.ActiveMedia, pauser *syncutil.Pauser) {
+	if pauser == nil {
+		return
+	}
+	if activeMediaPausesMediaWork(media) {
+		pauser.Pause()
+		return
+	}
+	pauser.Resume()
+}
+
 func GenerateMediaDB(
 	ctx context.Context,
 	pl platforms.Platform,
@@ -568,6 +591,12 @@ func HandleGenerateMedia(env requests.RequestEnv) (any, error) {
 		if len(systems) == 0 {
 			return nil, models.ClientErrf("at least one system must be specified for selective indexing")
 		}
+	}
+
+	// Reconcile with current primary-media state before reporting initial
+	// paused status. This clears stale pauses left by non-primary media events.
+	if env.State != nil {
+		syncMediaWorkPauserWithActiveMedia(env.State.ActiveMedia(), env.IndexPauser)
 	}
 
 	// Use app-scoped context — indexing outlives the API request

--- a/pkg/api/methods/media_pauser_test.go
+++ b/pkg/api/methods/media_pauser_test.go
@@ -1,0 +1,68 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncMediaWorkPauserWithActiveMedia_ResumesWithoutPrimaryMedia(t *testing.T) {
+	pauser := syncutil.NewPauser()
+	pauser.Pause()
+
+	syncMediaWorkPauserWithActiveMedia(nil, pauser)
+
+	assert.False(t, pauser.IsPaused())
+}
+
+func TestSyncMediaWorkPauserWithActiveMedia_ResumesForBackgroundSlot(t *testing.T) {
+	pauser := syncutil.NewPauser()
+	pauser.Pause()
+	media := models.NewActiveMedia("Audio", "Audio", "song.mp3", "Song", "native-audio")
+	media.Slot = mediaslot.Background
+
+	syncMediaWorkPauserWithActiveMedia(media, pauser)
+
+	assert.False(t, pauser.IsPaused())
+}
+
+func TestSyncMediaWorkPauserWithActiveMedia_PausesForPrimarySlot(t *testing.T) {
+	pauser := syncutil.NewPauser()
+	media := models.NewActiveMedia("NES", "NES", "game.nes", "Game", "NES")
+
+	syncMediaWorkPauserWithActiveMedia(media, pauser)
+
+	assert.True(t, pauser.IsPaused())
+}
+
+func TestSyncMediaWorkPauserWithActiveMedia_PausesForInvalidSlot(t *testing.T) {
+	pauser := syncutil.NewPauser()
+	media := models.NewActiveMedia("NES", "NES", "game.nes", "Game", "NES")
+	media.Slot = "sideways"
+
+	syncMediaWorkPauserWithActiveMedia(media, pauser)
+
+	assert.True(t, pauser.IsPaused())
+}

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -485,6 +485,10 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 	scrapeCtx, cancelFunc := context.WithCancel(env.State.GetContext())
 	scrapingStatusInstance.setCancelFunc(cancelFunc)
 
+	// Reconcile with current primary-media state before reporting initial
+	// paused status. This clears stale pauses left by non-primary media events.
+	syncMediaWorkPauserWithActiveMedia(env.State.ActiveMedia(), env.ScrapePauser)
+
 	paused := env.ScrapePauser != nil && env.ScrapePauser.IsPaused()
 	opts := scraper.ScrapeOptions{Systems: params.Systems, RunID: runID, Force: params.Force, Pauser: env.ScrapePauser}
 	ch := make(chan scraper.ScrapeUpdate, 32)

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -289,6 +289,89 @@ func TestHandleMediaScrape_HappyPath(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaScrape_ResumesStalePauseForBackgroundMedia(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	mockDB.On("ClearScrapingOperation").Return(nil).Once()
+	mockDB.On("WALCheckpoint").Return(nil).Once()
+	mockDB.On("TrackBackgroundOperation").Return()
+	mockDB.On("BackgroundOperationDone").Return()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(0, nil)
+
+	pauser := syncutil.NewPauser()
+	pauser.Pause()
+	var scraperSawPaused bool
+	testScraper := platforms.Scraper{
+		ID:   "test-scraper",
+		Name: "Test Scraper",
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, opts scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			scraperSawPaused = opts.Pauser != nil && opts.Pauser.IsPaused()
+			go func() {
+				ch <- scraper.ScrapeUpdate{Done: true}
+				close(ch)
+			}()
+			return nil
+		},
+	}
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{"test-scraper": testScraper})
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	t.Cleanup(st.StopService)
+	background := models.NewActiveMedia("Audio", "Audio", "song.mp3", "Song", platforms.NativeAudioLauncherID)
+	st.SetBackgroundMedia(background)
+
+	env := requests.RequestEnv{
+		Context:      context.Background(),
+		Platform:     pl,
+		State:        st,
+		Database:     &database.Database{MediaDB: mockDB},
+		Params:       json.RawMessage(`{"scraperId":"test-scraper"}`),
+		ScrapePauser: pauser,
+	}
+
+	result, err := HandleMediaScrape(env)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+	assert.False(t, scraperSawPaused)
+	assert.False(t, pauser.IsPaused())
+
+	var gotStart bool
+	timeout := time.After(2 * time.Second)
+	for !gotStart {
+		select {
+		case n := <-ns:
+			if n.Method != models.NotificationMediaScraping {
+				continue
+			}
+			var payload models.ScrapingStatusResponse
+			require.NoError(t, json.Unmarshal(n.Params, &payload))
+			if payload.Scraping && !payload.Done {
+				assert.False(t, payload.Paused)
+				gotStart = true
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for initial media.scraping notification")
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond)
+	mockDB.AssertExpectations(t)
+}
+
 func TestHandleMediaScrape_FatalUpdateDoesNotSynthesizeDone(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	ClearScrapingStatus()

--- a/pkg/platforms/mister/cores/cores_test.go
+++ b/pkg/platforms/mister/cores/cores_test.go
@@ -71,6 +71,47 @@ func writeAmigaVisionTestInstall(t *testing.T, path, game string, withImage bool
 	}
 }
 
+func TestHookAmiga_WritesBootFileForVirtualBrowsePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	writeAmigaVisionTestInstall(t, validPath, "Valid Game", true)
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = hookAmiga(cfg, nil, filepath.Join(validPath, "Games", "Valid Game"))
+	require.NoError(t, err)
+
+	bootFile, err := os.ReadFile(filepath.Join(validPath, "shared", "ags_boot")) //nolint:gosec // Test temp path
+	require.NoError(t, err)
+	assert.Equal(t, "Valid Game\n", string(bootFile))
+}
+
+func TestHookAmiga_IgnoresNonAmigaVisionVirtualPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "games", "Amiga", "Games", "Other Game")
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	override, err := hookAmiga(cfg, nil, path)
+	require.NoError(t, err)
+	assert.Empty(t, override)
+	assert.NoFileExists(t, filepath.Join(root, "games", "Amiga", "shared", "ags_boot"))
+}
+
 func TestPathToMGLDef(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/cores/cores_test.go
+++ b/pkg/platforms/mister/cores/cores_test.go
@@ -93,6 +93,29 @@ func TestHookAmiga_WritesBootFileForVirtualBrowsePath(t *testing.T) {
 	assert.Equal(t, "Valid Game\n", string(bootFile))
 }
 
+func TestHookAmiga_WritesBootFileForDemosVirtualBrowsePath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	writeAmigaVisionTestInstall(t, validPath, "Valid Game", true)
+	require.NoError(t, os.WriteFile(filepath.Join(validPath, "listings", "demos.txt"), []byte("Valid Demo\n"), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = hookAmiga(cfg, nil, filepath.Join(validPath, "Demos", "Valid Demo"))
+	require.NoError(t, err)
+
+	bootFile, err := os.ReadFile(filepath.Join(validPath, "shared", "ags_boot")) //nolint:gosec // Test temp path
+	require.NoError(t, err)
+	assert.Equal(t, "Valid Demo\n", string(bootFile))
+}
+
 func TestHookAmiga_IgnoresNonAmigaVisionVirtualPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/cores/hooks.go
+++ b/pkg/platforms/mister/cores/hooks.go
@@ -37,6 +37,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type amigaVisionLaunchTarget struct {
+	InstallPath string
+	ListingName string
+	GameName    string
+	Virtual     bool
+}
+
 func copySetnameBios(cfg *config.Instance, origCore, newCore *Core, name string) error {
 	var biosPath string
 
@@ -168,15 +175,45 @@ func hookAo486(_ *config.Instance, system *Core, path string) (string, error) {
 	return mgl, nil
 }
 
-func hookAmiga(cfg *config.Instance, _ *Core, path string) (string, error) {
-	dirPath := strings.ToLower(filepath.Dir(path))
-	if !strings.HasSuffix(dirPath, "listings/games.txt") && !strings.HasSuffix(dirPath, "listings/demos.txt") {
-		return "", nil
+func amigaVisionLaunchParts(path string) (amigaVisionLaunchTarget, bool) {
+	dir := filepath.Dir(path)
+	dirPath := strings.ToLower(filepath.ToSlash(dir))
+	if strings.HasSuffix(dirPath, "listings/games.txt") || strings.HasSuffix(dirPath, "listings/demos.txt") {
+		return amigaVisionLaunchTarget{
+			InstallPath: filepath.Clean(filepath.Join(dir, "..", "..")),
+			ListingName: filepath.Base(dir),
+			GameName:    filepath.Base(path),
+		}, true
 	}
 
-	gameName := filepath.Base(path)
-	listingName := filepath.Base(filepath.Dir(path))
-	installPath := filepath.Clean(filepath.Join(filepath.Dir(path), "..", ".."))
+	switch strings.ToLower(filepath.Base(dir)) {
+	case "games":
+		return amigaVisionLaunchTarget{
+			InstallPath: filepath.Clean(filepath.Join(dir, "..")),
+			ListingName: "games.txt",
+			GameName:    filepath.Base(path),
+			Virtual:     true,
+		}, true
+	case "demos":
+		return amigaVisionLaunchTarget{
+			InstallPath: filepath.Clean(filepath.Join(dir, "..")),
+			ListingName: "demos.txt",
+			GameName:    filepath.Base(path),
+			Virtual:     true,
+		}, true
+	default:
+		return amigaVisionLaunchTarget{}, false
+	}
+}
+
+func hookAmiga(cfg *config.Instance, _ *Core, path string) (string, error) {
+	target, ok := amigaVisionLaunchParts(path)
+	if !ok {
+		return "", nil
+	}
+	installPath := target.InstallPath
+	listingName := target.ListingName
+	gameName := target.GameName
 	bootImagePath := amigaVisionBootImagePath(installPath)
 	bootImageFound := bootImagePath != ""
 	log.Debug().
@@ -189,13 +226,21 @@ func hookAmiga(cfg *config.Instance, _ *Core, path string) (string, error) {
 		Msg("AmigaVision launch hook detected listing entry")
 	if !bootImageFound {
 		activeInstallPath := findAmigaVisionInstallPath(cfg, listingName, gameName)
-		if activeInstallPath != "" {
+		switch {
+		case activeInstallPath != "":
 			log.Debug().
 				Str("candidate_install_path", installPath).
 				Str("active_install_path", activeInstallPath).
 				Msg("AmigaVision launch hook using active install path")
 			installPath = activeInstallPath
-		} else {
+		case target.Virtual && !amigaListingContains(installPath, listingName, gameName):
+			log.Debug().
+				Str("candidate_install_path", installPath).
+				Str("game", gameName).
+				Str("listing", listingName).
+				Msg("AmigaVision virtual path ignored: no boot image or listing match")
+			return "", nil
+		default:
 			log.Warn().
 				Str("candidate_install_path", installPath).
 				Str("game", gameName).

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -221,8 +221,129 @@ func TestAmigaScanner_IgnoresStaleListingRoot(t *testing.T) {
 	results, err := amigaLauncher.Scanner(context.Background(), cfg, "Amiga", nil)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, filepath.Join(validPath, "listings", "games.txt", "Valid Game"), results[0].Path)
+	assert.Equal(t, filepath.Join(validPath, "Games", "Valid Game"), results[0].Path)
 	assert.Equal(t, "Valid Game", results[0].Name)
+}
+
+func TestAmigaScanner_AddsGamesAndDemosSubfolders(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	writeAmigaVisionInstall(t, validPath, "Valid Game")
+	require.NoError(t, os.WriteFile(filepath.Join(validPath, "listings", "demos.txt"), []byte("Valid Demo\n"), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(cfg))
+
+	results, err := amigaLauncher.Scanner(context.Background(), cfg, "Amiga", nil)
+	require.NoError(t, err)
+	assert.Contains(t, results, platforms.ScanResult{
+		Path:  filepath.Join(validPath, "Games", "Valid Game"),
+		Name:  "Valid Game",
+		NoExt: true,
+	})
+	assert.Contains(t, results, platforms.ScanResult{
+		Path:  filepath.Join(validPath, "Demos", "Valid Demo"),
+		Name:  "Valid Demo",
+		NoExt: true,
+	})
+}
+
+func TestAmigaScanner_FiltersListingFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	writeAmigaVisionInstall(t, validPath, "Valid Game")
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(cfg))
+	initial := []platforms.ScanResult{{Path: filepath.Join(validPath, "listings", "games.txt")}}
+
+	results, err := amigaLauncher.Scanner(context.Background(), cfg, "Amiga", initial)
+	require.NoError(t, err)
+	assert.NotContains(t, results, platforms.ScanResult{Path: filepath.Join(validPath, "listings", "games.txt")})
+	assert.Contains(t, results, platforms.ScanResult{
+		Path:  filepath.Join(validPath, "Games", "Valid Game"),
+		Name:  "Valid Game",
+		NoExt: true,
+	})
+}
+
+func TestAmigaScanner_AddsVirtualMGLFiles(t *testing.T) {
+	t.Parallel()
+
+	installPath := filepath.Join(t.TempDir(), "games", "Amiga")
+	mglDir := t.TempDir()
+	amigaMGL := filepath.Join(mglDir, "Amiga.mgl")
+	amiga500MGL := filepath.Join(mglDir, "Amiga 500.mgl")
+	require.NoError(t, os.WriteFile(amigaMGL, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(amiga500MGL, []byte("test"), 0o600))
+
+	mglPaths := []string{
+		amigaMGL,
+		amiga500MGL,
+		filepath.Join(mglDir, "Missing.mgl"),
+	}
+	results := amigaVisionMGLScanResults(installPath, mglPaths)
+
+	assert.Equal(t, []platforms.ScanResult{
+		{Path: filepath.Join(installPath, "Amiga.mgl"), Name: "Amiga"},
+		{Path: filepath.Join(installPath, "Amiga 500.mgl"), Name: "Amiga 500"},
+	}, results)
+}
+
+func TestResolveAmigaVisionVirtualMGLPath(t *testing.T) {
+	mglDir := t.TempDir()
+	realMGL := filepath.Join(mglDir, "Amiga.mgl")
+	virtualMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga.mgl")
+	realVirtualMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga.mgl")
+	require.NoError(t, os.WriteFile(realMGL, []byte("test"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Dir(realVirtualMGL), 0o700))
+	require.NoError(t, os.WriteFile(realVirtualMGL, []byte("test"), 0o600))
+
+	oldPaths := amigaVisionMGLPaths
+	amigaVisionMGLPaths = []string{realMGL}
+	t.Cleanup(func() { amigaVisionMGLPaths = oldPaths })
+
+	missingMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga 500.mgl")
+	nonMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Readme.txt")
+
+	assert.Equal(t, realMGL, resolveAmigaVisionVirtualMGLPath(virtualMGL))
+	assert.Equal(t, realVirtualMGL, resolveAmigaVisionVirtualMGLPath(realVirtualMGL))
+	assert.Equal(t, missingMGL, resolveAmigaVisionVirtualMGLPath(missingMGL))
+	assert.Equal(t, nonMGL, resolveAmigaVisionVirtualMGLPath(nonMGL))
+}
+
+func TestAmigaLauncher_TestRequiresAmigaVisionVirtualPath(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	writeAmigaVisionInstall(t, validPath, "Valid Game")
+	nonAmigaVisionPath := filepath.Join(root, "other", "Amiga")
+	require.NoError(t, os.MkdirAll(filepath.Join(nonAmigaVisionPath, "Games"), 0o700))
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(&config.Instance{}))
+
+	assert.True(t, amigaLauncher.Test(nil, filepath.Join(validPath, "Games", "Valid Game")))
+	assert.False(t, amigaLauncher.Test(nil, filepath.Join(nonAmigaVisionPath, "Games", "Other Game")))
 }
 
 func TestAmigaScanner_RequiresBootImage(t *testing.T) {

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -285,6 +285,26 @@ func TestAmigaScanner_FiltersListingFiles(t *testing.T) {
 	})
 }
 
+func TestAmigaLauncher_DoesNotMatchListingBackupFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root, filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(cfg))
+	assert.True(t, amigaLauncher.Test(cfg, filepath.Join(validPath, "listings", "games.txt")))
+	assert.True(t, amigaLauncher.Test(cfg, filepath.Join(validPath, "listings", "demos.txt")))
+	assert.False(t, amigaLauncher.Test(cfg, filepath.Join(validPath, "listings", "games.txt.bak")))
+	assert.False(t, amigaLauncher.Test(cfg, filepath.Join(validPath, "listings", "demos.txt.bak")))
+}
+
 func TestAmigaScanner_AddsVirtualMGLFiles(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -109,6 +109,33 @@ func checkInZip(path string) string {
 	return path
 }
 
+func resolveAmigaVisionVirtualMGLPath(path string) string {
+	if filepath.Ext(strings.ToLower(path)) != ".mgl" {
+		return path
+	}
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+
+	base := filepath.Base(path)
+	for _, mglPath := range amigaVisionMGLPaths {
+		if !strings.EqualFold(base, filepath.Base(mglPath)) {
+			continue
+		}
+		if _, err := os.Stat(mglPath); err == nil {
+			return mglPath
+		}
+	}
+	return path
+}
+
+func launchAmiga(pl platforms.Platform) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	genericLaunch := launch(pl, systemdefs.SystemAmiga)
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
+		return genericLaunch(cfg, resolveAmigaVisionVirtualMGLPath(path), opts)
+	}
+}
+
 func launch(
 	pl platforms.Platform, coreID string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1179,9 +1179,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		Folders:    []string{"Amiga"},
 		Extensions: []string{".adf"},
 		Test: func(_ *config.Instance, path string) bool {
-			lowerPath := filepath.ToSlash(strings.ToLower(path))
-			if strings.Contains(lowerPath, filepath.ToSlash(amigaVisionGamesListing)) ||
-				strings.Contains(lowerPath, filepath.ToSlash(amigaVisionDemosListing)) {
+			if isAmigaVisionListingFile(path) {
 				return true
 			}
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -52,6 +52,35 @@ import (
 	"github.com/spf13/afero"
 )
 
+const (
+	amigaVisionGamesListing   = "listings/games.txt"
+	amigaVisionDemosListing   = "listings/demos.txt"
+	amigaVisionGamesBrowseDir = "Games"
+	amigaVisionDemosBrowseDir = "Demos"
+)
+
+type amigaVisionListing struct {
+	Path      string
+	BrowseDir string
+}
+
+type amigaVisionVirtualPath struct {
+	InstallPath string
+	ListingName string
+	GameName    string
+}
+
+var (
+	amigaVisionListings = []amigaVisionListing{
+		{Path: amigaVisionGamesListing, BrowseDir: amigaVisionGamesBrowseDir},
+		{Path: amigaVisionDemosListing, BrowseDir: amigaVisionDemosBrowseDir},
+	}
+	amigaVisionMGLPaths = []string{
+		filepath.Join(misterconfig.SDRootDir, "_Computer", "Amiga.mgl"),
+		filepath.Join(misterconfig.SDRootDir, "_Computer", "Amiga 500.mgl"),
+	}
+)
+
 // arcadeCardLaunchCache stores the last arcade game launched via card to prevent duplicate tracker notifications.
 type arcadeCardLaunchCache struct {
 	timestamp time.Time
@@ -1020,6 +1049,122 @@ func isPreferredAmigaVisionPath(path string) bool {
 	return strings.HasSuffix(strings.ToLower(filepath.Clean(path)), filepath.Join("games", "amiga"))
 }
 
+func isAmigaVisionListingFile(path string) bool {
+	cleanPath := filepath.ToSlash(strings.ToLower(filepath.Clean(path)))
+	for _, listing := range amigaVisionListings {
+		if strings.HasSuffix(cleanPath, "/"+filepath.ToSlash(listing.Path)) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterAmigaVisionListingFiles(results []platforms.ScanResult) []platforms.ScanResult {
+	filtered := make([]platforms.ScanResult, 0, len(results))
+	for _, result := range results {
+		if isAmigaVisionListingFile(result.Path) {
+			continue
+		}
+		filtered = append(filtered, result)
+	}
+	return filtered
+}
+
+func amigaVisionVirtualPathParts(path string) (amigaVisionVirtualPath, bool) {
+	dir := filepath.Dir(path)
+	switch strings.ToLower(filepath.Base(dir)) {
+	case strings.ToLower(amigaVisionGamesBrowseDir):
+		return amigaVisionVirtualPath{
+			InstallPath: filepath.Clean(filepath.Join(dir, "..")),
+			ListingName: "games.txt",
+			GameName:    filepath.Base(path),
+		}, true
+	case strings.ToLower(amigaVisionDemosBrowseDir):
+		return amigaVisionVirtualPath{
+			InstallPath: filepath.Clean(filepath.Join(dir, "..")),
+			ListingName: "demos.txt",
+			GameName:    filepath.Base(path),
+		}, true
+	default:
+		return amigaVisionVirtualPath{}, false
+	}
+}
+
+func amigaVisionListingContainsGame(installPath, listingName, gameName string) bool {
+	f, err := os.Open(filepath.Join(installPath, "listings", listingName)) //nolint:gosec // Internal amiga listing path
+	if err != nil {
+		return false
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("unable to close amiga txt")
+		}
+	}()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if scanner.Text() == gameName {
+			return true
+		}
+	}
+	return false
+}
+
+func isAmigaVisionVirtualPath(path string) bool {
+	virtualPath, ok := amigaVisionVirtualPathParts(path)
+	if !ok {
+		return false
+	}
+	return hasAmigaVisionImage(virtualPath.InstallPath) ||
+		amigaVisionListingContainsGame(virtualPath.InstallPath, virtualPath.ListingName, virtualPath.GameName)
+}
+
+func scanAmigaVisionListingFile(path, installPath string, listing amigaVisionListing) []platforms.ScanResult {
+	f, err := os.Open(path) //nolint:gosec // Internal amiga games/demos path
+	if err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("unable to open amiga txt")
+		return nil
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Str("path", path).Msg("unable to close amiga txt")
+		}
+	}()
+
+	var results []platforms.ScanResult
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		name := strings.TrimSpace(scanner.Text())
+		if name == "" {
+			continue
+		}
+		results = append(results, platforms.ScanResult{
+			Path:  filepath.Join(installPath, listing.BrowseDir, name),
+			Name:  name,
+			NoExt: true,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("unable to scan amiga txt")
+	}
+	return results
+}
+
+func amigaVisionMGLScanResults(installPath string, mglPaths []string) []platforms.ScanResult {
+	results := make([]platforms.ScanResult, 0, len(mglPaths))
+	for _, mglPath := range mglPaths {
+		if _, err := os.Stat(mglPath); err != nil {
+			continue
+		}
+		name := filepath.Base(mglPath)
+		results = append(results, platforms.ScanResult{
+			Path: filepath.Join(installPath, name),
+			Name: strings.TrimSuffix(name, filepath.Ext(name)),
+		})
+	}
+	return results
+}
+
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	// Launchers is invoked from many hot paths (token scans, RPC handlers,
 	// indexing). The Refresh fast path stats only the snapshot directories
@@ -1028,20 +1173,21 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	cores.GlobalRBFCache.SetPersistPath(filepath.Join(helpers.DataDir(p), config.CacheDir, cores.RBFCacheFileName))
 	cores.GlobalRBFCache.Refresh()
 
-	aGamesPath := "listings/games.txt"
-	aDemosPath := "listings/demos.txt"
 	amiga := platforms.Launcher{
 		ID:         systemdefs.SystemAmiga,
 		SystemID:   systemdefs.SystemAmiga,
 		Folders:    []string{"Amiga"},
 		Extensions: []string{".adf"},
 		Test: func(_ *config.Instance, path string) bool {
-			if strings.Contains(path, aGamesPath) || strings.Contains(path, aDemosPath) {
+			lowerPath := filepath.ToSlash(strings.ToLower(path))
+			if strings.Contains(lowerPath, filepath.ToSlash(amigaVisionGamesListing)) ||
+				strings.Contains(lowerPath, filepath.ToSlash(amigaVisionDemosListing)) {
 				return true
 			}
-			return false
+
+			return isAmigaVisionVirtualPath(path)
 		},
-		Launch: launch(p, systemdefs.SystemAmiga),
+		Launch: launchAmiga(p),
 		Scanner: func(
 			ctx context.Context,
 			cfg *config.Instance,
@@ -1056,7 +1202,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 
 			log.Info().Msg("starting amigavision scan")
 
-			var fullPaths []string
+			results = filterAmigaVisionListingFiles(results)
 
 			s, err := systemdefs.GetSystem(systemdefs.SystemAmiga)
 			if err != nil {
@@ -1078,35 +1224,14 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				default:
 				}
 
-				for _, txt := range []string{aGamesPath, aDemosPath} {
-					tp, err := mediascanner.FindPath(ctx, filepath.Join(sf.Path, txt))
-					if err == nil {
-						f, err := os.Open(tp) //nolint:gosec // Internal amiga games/demos path
-						if err != nil {
-							log.Warn().Err(err).Msg("unable to open amiga txt")
-							continue
-						}
-
-						scanner := bufio.NewScanner(f)
-						for scanner.Scan() {
-							fp := filepath.Join(sf.Path, txt, scanner.Text())
-							fullPaths = append(fullPaths, fp)
-						}
-
-						err = f.Close()
-						if err != nil {
-							log.Warn().Err(err).Msg("unable to close amiga txt")
-						}
+				for _, listing := range amigaVisionListings {
+					tp, err := mediascanner.FindPath(ctx, filepath.Join(sf.Path, listing.Path))
+					if err != nil {
+						continue
 					}
+					results = append(results, scanAmigaVisionListingFile(tp, sf.Path, listing)...)
 				}
-			}
-
-			for _, p := range fullPaths {
-				results = append(results, platforms.ScanResult{
-					Path:  p,
-					Name:  filepath.Base(p),
-					NoExt: true,
-				})
+				results = append(results, amigaVisionMGLScanResults(sf.Path, amigaVisionMGLPaths)...)
 			}
 
 			log.Debug().Int("results", len(results)).Msg("amigavision scan completed")

--- a/pkg/service/indexpause.go
+++ b/pkg/service/indexpause.go
@@ -23,11 +23,13 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/notifications"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/broker"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/rs/zerolog/log"
@@ -47,8 +49,8 @@ func watchGameForIndexPause(
 	notifChan, subID := b.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
 	defer b.Unsubscribe(subID)
 
-	gameActive := st.ActiveMedia() != nil
-	handleIndexPauseNotifications(ctx, notifChan, ns, pauser, gameActive, methods.IsIndexing)
+	primaryActive := func() bool { return activeMediaPausesMediaWork(st.ActiveMedia()) }
+	handleIndexPauseNotifications(ctx, notifChan, ns, pauser, primaryActive(), methods.IsIndexing, primaryActive)
 }
 
 // watchGameForScrapePause mirrors media indexing pause behavior for metadata
@@ -63,8 +65,10 @@ func watchGameForScrapePause(
 	notifChan, subID := b.Subscribe(32, models.NotificationStarted, models.NotificationStopped)
 	defer b.Unsubscribe(subID)
 
-	gameActive := st.ActiveMedia() != nil
-	handleScrapePauseNotifications(ctx, notifChan, ns, pauser, gameActive, methods.IsScrapingRunning)
+	primaryActive := func() bool { return activeMediaPausesMediaWork(st.ActiveMedia()) }
+	handleScrapePauseNotifications(
+		ctx, notifChan, ns, pauser, primaryActive(), methods.IsScrapingRunning, primaryActive,
+	)
 }
 
 // handleIndexPauseNotifications is the core loop that pauses/resumes the
@@ -81,12 +85,13 @@ func handleIndexPauseNotifications(
 	pauser *syncutil.Pauser,
 	gameAlreadyActive bool,
 	isActive func() bool,
+	primaryActive ...func() bool,
 ) {
 	handleMediaPauseNotifications(
 		ctx, notifChan, pauser, gameAlreadyActive, isActive, "media indexing",
 		func(paused bool) {
 			sendIndexPauseNotification(ns, paused)
-		},
+		}, primaryActive...,
 	)
 }
 
@@ -97,13 +102,69 @@ func handleScrapePauseNotifications(
 	pauser *syncutil.Pauser,
 	gameAlreadyActive bool,
 	isActive func() bool,
+	primaryActive ...func() bool,
 ) {
 	handleMediaPauseNotifications(
 		ctx, notifChan, pauser, gameAlreadyActive, isActive, "media scraping",
 		func(paused bool) {
 			sendScrapePauseNotification(ns, paused)
-		},
+		}, primaryActive...,
 	)
+}
+
+func activeMediaPausesMediaWork(media *models.ActiveMedia) bool {
+	if media == nil {
+		return false
+	}
+	slot, err := mediaslot.Normalize(media.Slot)
+	if err != nil {
+		log.Warn().Err(err).Str("slot", media.Slot).Msg("active media has invalid slot; pausing media work")
+		return true
+	}
+	return slot == mediaslot.Primary
+}
+
+func notificationIsPrimarySlot(notif models.Notification) bool {
+	if len(notif.Params) == 0 {
+		return true
+	}
+
+	var payload struct {
+		Slot string `json:"slot"`
+	}
+	if err := json.Unmarshal(notif.Params, &payload); err != nil {
+		log.Warn().Err(err).Str("method", notif.Method).Msg("media pause notification has invalid payload")
+		return true
+	}
+
+	slot, err := mediaslot.Normalize(payload.Slot)
+	if err != nil {
+		log.Warn().Err(err).Str("method", notif.Method).Str("slot", payload.Slot).
+			Msg("media pause notification has invalid slot")
+		return true
+	}
+	return slot == mediaslot.Primary
+}
+
+func primaryActiveFunc(primaryActive []func() bool) func() bool {
+	if len(primaryActive) == 0 || primaryActive[0] == nil {
+		return nil
+	}
+	return primaryActive[0]
+}
+
+func shouldPauseForMediaStarted(notif models.Notification, primaryActive ...func() bool) bool {
+	if isPrimaryActive := primaryActiveFunc(primaryActive); isPrimaryActive != nil {
+		return isPrimaryActive()
+	}
+	return notificationIsPrimarySlot(notif)
+}
+
+func shouldResumeForMediaStopped(notif models.Notification, primaryActive ...func() bool) bool {
+	if isPrimaryActive := primaryActiveFunc(primaryActive); isPrimaryActive != nil {
+		return !isPrimaryActive()
+	}
+	return notificationIsPrimarySlot(notif)
 }
 
 func handleMediaPauseNotifications(
@@ -114,6 +175,7 @@ func handleMediaPauseNotifications(
 	isActive func() bool,
 	label string,
 	sendPauseNotification func(bool),
+	primaryActive ...func() bool,
 ) {
 	defer pauser.Resume()
 
@@ -133,12 +195,18 @@ func handleMediaPauseNotifications(
 			}
 			switch notif.Method {
 			case models.NotificationStarted:
+				if !shouldPauseForMediaStarted(notif, primaryActive...) {
+					continue
+				}
 				pauser.Pause()
 				log.Info().Msg(label + " paused: game started")
 				if isActive() {
 					sendPauseNotification(true)
 				}
 			case models.NotificationStopped:
+				if !shouldResumeForMediaStopped(notif, primaryActive...) || !pauser.IsPaused() {
+					continue
+				}
 				pauser.Resume()
 				log.Info().Msg(label + " resumed: game stopped")
 				if isActive() {

--- a/pkg/service/indexpause_test.go
+++ b/pkg/service/indexpause_test.go
@@ -36,6 +36,15 @@ import (
 func alwaysActive() bool { return true }
 func neverActive() bool  { return false }
 
+func mediaLifecycleNotification(t *testing.T, method, slot string) models.Notification {
+	t.Helper()
+	params, err := json.Marshal(struct {
+		Slot string `json:"slot"`
+	}{Slot: slot})
+	require.NoError(t, err)
+	return models.Notification{Method: method, Params: params}
+}
+
 // drainNotification reads a single notification from ns, failing if none
 // arrives within the timeout.
 func drainNotification(t *testing.T, ns <-chan models.Notification) models.Notification {
@@ -47,6 +56,19 @@ func drainNotification(t *testing.T, ns <-chan models.Notification) models.Notif
 		t.Fatal("expected notification but none received")
 		return models.Notification{}
 	}
+}
+
+func TestActiveMediaPausesMediaWork_BackgroundSlot(t *testing.T) {
+	media := models.NewActiveMedia("Audio", "Audio", "song.mp3", "Song", "native-audio")
+	media.Slot = "background"
+
+	assert.False(t, activeMediaPausesMediaWork(media))
+}
+
+func TestActiveMediaPausesMediaWork_PrimarySlot(t *testing.T) {
+	media := models.NewActiveMedia("NES", "NES", "game.nes", "Game", "NES")
+
+	assert.True(t, activeMediaPausesMediaWork(media))
 }
 
 func TestHandleIndexPauseNotifications_PausesOnStarted(t *testing.T) {
@@ -70,6 +92,186 @@ func TestHandleIndexPauseNotifications_PausesOnStarted(t *testing.T) {
 	var resp models.IndexingStatusResponse
 	require.NoError(t, json.Unmarshal(notif.Params, &resp))
 	assert.True(t, resp.Paused)
+}
+
+func TestHandleIndexPauseNotifications_PausesOnInvalidSlot(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStarted, "tertiary")
+
+	require.Eventually(t, pauser.IsPaused,
+		500*time.Millisecond, 10*time.Millisecond)
+	notif := drainNotification(t, ns)
+	assert.Equal(t, models.NotificationMediaIndexing, notif.Method)
+}
+
+func TestHandleIndexPauseNotifications_PausesOnMalformedParams(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive)
+
+	ch <- models.Notification{Method: models.NotificationStarted, Params: []byte("{")}
+
+	require.Eventually(t, pauser.IsPaused,
+		500*time.Millisecond, 10*time.Millisecond)
+	notif := drainNotification(t, ns)
+	assert.Equal(t, models.NotificationMediaIndexing, notif.Method)
+}
+
+func TestHandleIndexPauseNotifications_IgnoresStartedWhenNoPrimaryActive(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, neverActive)
+
+	ch <- models.Notification{Method: models.NotificationStarted}
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent without primary media: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleIndexPauseNotifications_PausesStartedWhenPrimaryActive(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, alwaysActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStarted, "background")
+
+	require.Eventually(t, pauser.IsPaused,
+		500*time.Millisecond, 10*time.Millisecond)
+	notif := drainNotification(t, ns)
+	assert.Equal(t, models.NotificationMediaIndexing, notif.Method)
+}
+
+func TestHandleIndexPauseNotifications_IgnoresStoppedWhenAlreadyUnpaused(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, neverActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStopped, "background")
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent for no-op stopped event: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleScrapePauseNotifications_IgnoresStoppedWhenAlreadyUnpaused(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleScrapePauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, neverActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStopped, "background")
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent for no-op stopped event: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleIndexPauseNotifications_DoesNotResumeStoppedWhilePrimaryActive(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+	pauser.Pause()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, alwaysActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStopped, "background")
+
+	assert.Never(t, func() bool { return !pauser.IsPaused() }, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent while primary remains active: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleIndexPauseNotifications_IgnoresBackgroundStarted(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStarted, "background")
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent for background media: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleIndexPauseNotifications_IgnoresBackgroundStoppedWhilePaused(t *testing.T) {
+	ch := make(chan models.Notification, 2)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleIndexPauseNotifications(ctx, ch, ns, pauser, false, alwaysActive)
+
+	ch <- models.Notification{Method: models.NotificationStarted}
+	require.Eventually(t, pauser.IsPaused,
+		500*time.Millisecond, 10*time.Millisecond)
+	drainNotification(t, ns)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStopped, "background")
+
+	assert.Never(t, func() bool { return !pauser.IsPaused() }, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent for background media: %+v", notif)
+	default:
+	}
 }
 
 func TestHandleIndexPauseNotifications_ResumesOnStopped(t *testing.T) {
@@ -206,6 +408,46 @@ func TestHandleIndexPauseNotifications_NoNotificationWhenNotIndexing(t *testing.
 		t.Fatalf("unexpected notification sent when not indexing: %+v", notif)
 	case <-time.After(100 * time.Millisecond):
 		// expected — no notification
+	}
+}
+
+func TestHandleScrapePauseNotifications_IgnoresStartedWhenNoPrimaryActive(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleScrapePauseNotifications(ctx, ch, ns, pauser, false, alwaysActive, neverActive)
+
+	ch <- models.Notification{Method: models.NotificationStarted}
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent without primary media: %+v", notif)
+	default:
+	}
+}
+
+func TestHandleScrapePauseNotifications_IgnoresBackgroundStarted(t *testing.T) {
+	ch := make(chan models.Notification, 1)
+	ns := make(chan models.Notification, 10)
+	pauser := syncutil.NewPauser()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go handleScrapePauseNotifications(ctx, ch, ns, pauser, false, alwaysActive)
+
+	ch <- mediaLifecycleNotification(t, models.NotificationStarted, "background")
+
+	assert.Never(t, pauser.IsPaused, 100*time.Millisecond, 10*time.Millisecond)
+	select {
+	case notif := <-ns:
+		t.Fatalf("unexpected notification sent for background media: %+v", notif)
+	default:
 	}
 }
 

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -419,13 +419,9 @@ func getLaunchClosure(
 		action := env.Cmd.AdvArgs.Get(zapscript.KeyAction)
 		setName := env.Cmd.AdvArgs.Get(zapscript.KeySetName)
 		setNameSameDir := env.Cmd.AdvArgs.Get(zapscript.KeySetNameSameDir)
-		slot := env.Cmd.AdvArgs.Get(zapscript.KeySlot)
-		if slot == "" && env.Playlist.Active != nil && env.Playlist.Active.Slot != "" {
-			slot = env.Playlist.Active.Slot
-		}
-		normalizedSlot, err := mediaslot.Normalize(slot)
+		normalizedSlot, err := commandSlot(env)
 		if err != nil {
-			return fmt.Errorf("normalize media slot: %w", err)
+			return err
 		}
 
 		var opts *platforms.LaunchOptions

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/spf13/afero"
@@ -161,6 +163,40 @@ launcher = "genesis-default"
 
 	require.NoError(t, err, "cmdLaunch should not return error")
 	assert.True(t, result.MediaChanged, "MediaChanged should be true")
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_InheritsCurrentPlaylistBackgroundSlot(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	absPath := filepath.Join(t.TempDir(), "song.mp3")
+
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+	mockPlatform.On("LaunchMedia", cfg, absPath,
+		(*platforms.Launcher)(nil),
+		(*database.Database)(nil),
+		mock.MatchedBy(func(opts *platforms.LaunchOptions) bool {
+			return opts != nil && opts.Slot == mediaslot.Background
+		}),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{absPath},
+		},
+		Cfg: cfg,
+		Playlist: playlists.PlaylistController{
+			Current: &playlists.Playlist{Slot: mediaslot.Background},
+		},
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
 	mockPlatform.AssertExpectations(t)
 }
 


### PR DESCRIPTION
Summary:
- Add MiSTer AmigaVision virtual browse paths and launch handling for Games/Demos paths.
- Resolve AmigaVision MGL launch targets while keeping listing-file launches compatible.
- Scope media indexing/scraping pause behavior to primary-slot active media and share ZapScript launch slot handling.

Checks:
- go build ./...
- go test -race ./pkg/api/methods/
- go test -race ./pkg/service/
- go test ./pkg/zapscript/
- go test ./pkg/platforms/mister/... -run TestHookAmiga\|TestAmigaScanner
- golangci-lint run --fix

Closes #953

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Amiga/AmigaVision platform scanning and launching, including virtual path and MGL remapping support
  * Media launches now inherit the current playlist’s slot (including background slot)

* **Bug Fixes**
  * Media indexing and scraping pause/resume now correctly distinguishes primary vs background media
  * Automatically clears stale pause states to resume correctly for the current primary-media context

* **Tests**
  * Expanded unit test coverage for pause/resume behavior and AmigaVision virtual-path handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->