### PR TITLE
feat(api): add per-media launcher overrides

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -853,7 +853,6 @@ func buildMediaEntry(
 		Tags:     result.Tags,
 		HasCover: result.HasCover,
 	}
-
 	zapScript := result.ZapScript()
 	entry.ZapScript = &zapScript
 

--- a/pkg/api/methods/media_meta.go
+++ b/pkg/api/methods/media_meta.go
@@ -246,12 +246,16 @@ func buildMediaMetaResponse(
 		titleTags = []database.TagInfo{}
 	}
 
+	properties := mapMediaProperties(mediaProps)
+	launcherOverride := mediaLauncherOverride(properties)
+
 	return models.MediaMetaResponse{Media: models.MediaMetaMediaResponse{
 		Path:                row.Path,
 		ParentDir:           row.ParentDir,
 		IsMissing:           row.IsMissing,
 		Tags:                mediaTags,
-		Properties:          mapMediaProperties(mediaProps),
+		Properties:          properties,
+		LauncherOverride:    launcherOverride,
 		AvailableImageTypes: availableImageTypes(mediaProps),
 		Title: models.MediaMetaTitleResponse{
 			Slug:                row.Title.Slug,
@@ -268,6 +272,14 @@ func buildMediaMetaResponse(
 			Properties: mapMediaProperties(titleProps),
 		},
 	}}
+}
+
+func mediaLauncherOverride(props map[string]models.MediaMetaPropertyItem) *string {
+	item, ok := props[launcherOverridePropertyTypeTag()]
+	if !ok || item.Text == "" {
+		return nil
+	}
+	return &item.Text
 }
 
 func availableImageTypes(props []database.MediaProperty) []string {

--- a/pkg/api/methods/media_meta_update.go
+++ b/pkg/api/methods/media_meta_update.go
@@ -1,0 +1,220 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+)
+
+type mediaMetaUpdatePatch struct {
+	LauncherOverride    *string
+	LauncherOverrideSet bool
+}
+
+func launcherOverridePropertyTypeTag() string {
+	return tags.PropertyTypeTag(tags.TagPropertyLauncherOverride)
+}
+
+func HandleMediaMetaUpdate(env requests.RequestEnv) (any, error) { //nolint:gocritic // API handler shape
+	var params models.MediaMetaUpdateParams
+	if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	mediaRef := mediaRefParam{
+		MediaID: params.MediaID,
+		System:  params.System,
+		Path:    params.Path,
+	}
+	if err := validateMediaRef(mediaRef); err != nil {
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+	patch, err := parseMediaMetaUpdatePatch(params.Media)
+	if err != nil {
+		return nil, models.ClientErrf("invalid params: %w", err)
+	}
+
+	resolved, err := resolveMediaRefs(&env, []mediaRefParam{mediaRef})
+	if err != nil {
+		return nil, err
+	}
+	if len(resolved) != 1 || resolved[0].Err != nil || resolved[0].Row == nil {
+		if len(resolved) == 1 && resolved[0].Err != nil {
+			return nil, resolved[0].Err
+		}
+		return nil, models.ClientErrf("media not found")
+	}
+
+	row := resolved[0].Row
+	if patch.LauncherOverrideSet {
+		if patch.LauncherOverride == nil {
+			if err := clearMediaLauncherOverride(&env, row.DBID); err != nil {
+				return nil, err
+			}
+		} else {
+			launcherID, err := resolveLauncherOverrideID(&env, row.System.SystemID, *patch.LauncherOverride)
+			if err != nil {
+				return nil, err
+			}
+			if err := setMediaLauncherOverride(&env, row.DBID, launcherID); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return HandleMediaMeta(env)
+}
+
+func parseMediaMetaUpdatePatch(raw json.RawMessage) (mediaMetaUpdatePatch, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return mediaMetaUpdatePatch{}, errors.New("media update is required")
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return mediaMetaUpdatePatch{}, fmt.Errorf("media must be an object: %w", err)
+	}
+	if fields == nil {
+		return mediaMetaUpdatePatch{}, errors.New("media must be an object")
+	}
+
+	var patch mediaMetaUpdatePatch
+	for field, value := range fields {
+		switch field {
+		case "launcherOverride":
+			patch.LauncherOverrideSet = true
+			if bytes.Equal(bytes.TrimSpace(value), []byte("null")) {
+				continue
+			}
+			var launcherID string
+			if err := json.Unmarshal(value, &launcherID); err != nil {
+				return mediaMetaUpdatePatch{}, fmt.Errorf("media.launcherOverride must be a string or null: %w", err)
+			}
+			launcherID = strings.TrimSpace(launcherID)
+			if launcherID == "" {
+				return mediaMetaUpdatePatch{}, errors.New("media.launcherOverride cannot be empty; use null to clear")
+			}
+			patch.LauncherOverride = &launcherID
+		default:
+			return mediaMetaUpdatePatch{}, fmt.Errorf("unsupported media field: %s", field)
+		}
+	}
+	if !patch.LauncherOverrideSet {
+		return mediaMetaUpdatePatch{}, errors.New("no supported media updates provided")
+	}
+	return patch, nil
+}
+
+func setMediaLauncherOverride(env *requests.RequestEnv, mediaDBID int64, launcherID string) error {
+	if err := ensureLauncherOverridePropertyTag(env.Database.MediaDB); err != nil {
+		return err
+	}
+	prop := database.MediaProperty{
+		TypeTag: launcherOverridePropertyTypeTag(),
+		Text:    launcherID,
+	}
+	if err := env.Database.MediaDB.UpsertMediaProperties(
+		env.Context, mediaDBID, []database.MediaProperty{prop},
+	); err != nil {
+		return fmt.Errorf("failed to set media launcher override: %w", err)
+	}
+	return nil
+}
+
+func resolveLauncherOverrideID(env *requests.RequestEnv, systemID, requested string) (string, error) {
+	candidates := launcherCandidates(env)
+	for i := range candidates {
+		launcher := candidates[i]
+		if !strings.EqualFold(launcher.ID, requested) {
+			continue
+		}
+		if launcher.SystemID != "" && !strings.EqualFold(launcher.SystemID, systemID) {
+			return "", models.ClientErrf("launcher %s does not support system %s", launcher.ID, systemID)
+		}
+		return launcher.ID, nil
+	}
+	return "", models.ClientErrf("launcher not found: %s", requested)
+}
+
+func launcherCandidates(env *requests.RequestEnv) []platforms.Launcher {
+	if env.LauncherCache != nil {
+		return env.LauncherCache.GetAllLaunchers()
+	}
+	if env.Platform == nil {
+		return nil
+	}
+	return env.Platform.Launchers(env.Config)
+}
+
+func ensureLauncherOverridePropertyTag(mediaDB database.MediaDBI) error {
+	tagType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type:        string(tags.TagTypeProperty),
+		IsExclusive: tags.IsExclusiveType(tags.TagTypeProperty),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find or insert launcher override tag type: %w", err)
+	}
+	_, err = mediaDB.FindOrInsertTag(database.Tag{
+		TypeDBID: tagType.DBID,
+		Tag:      string(tags.TagPropertyLauncherOverride),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find or insert launcher override tag: %w", err)
+	}
+	return nil
+}
+
+func clearMediaLauncherOverride(env *requests.RequestEnv, mediaDBID int64) error {
+	mediaDB := env.Database.MediaDB
+	tagType, err := mediaDB.FindTagType(database.TagType{Type: string(tags.TagTypeProperty)})
+	if err != nil {
+		return ignoreMissingPropertyTag(err)
+	}
+	tagRow, err := mediaDB.FindTag(database.Tag{
+		TypeDBID: tagType.DBID,
+		Tag:      string(tags.TagPropertyLauncherOverride),
+	})
+	if err != nil {
+		return ignoreMissingPropertyTag(err)
+	}
+	if err := mediaDB.DeleteMediaProperty(env.Context, mediaDBID, tagRow.DBID); err != nil {
+		return fmt.Errorf("failed to clear media launcher override: %w", err)
+	}
+	return nil
+}
+
+func ignoreMissingPropertyTag(err error) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
+}

--- a/pkg/api/methods/media_meta_update_test.go
+++ b/pkg/api/methods/media_meta_update_test.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -30,6 +31,7 @@ import (
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	pmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -112,6 +114,47 @@ func TestHandleMediaMetaUpdate_SetsLauncherOverride(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaMetaUpdate_SetsLauncherOverrideFromPlatformWhenCacheMissing(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockPlatform := pmocks.NewMockPlatform()
+	mockPlatform.On("Launchers", mock.Anything).Return([]platforms.Launcher{
+		{ID: "RetroArch", SystemID: "NES"},
+	}).Once()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Once()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{
+		Type:        string(tags.TagTypeProperty),
+		IsExclusive: false,
+	}).Return(database.TagType{DBID: 11, Type: string(tags.TagTypeProperty)}, nil).Once()
+	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}).
+		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}, nil).Once()
+	mockDB.On("UpsertMediaProperties", mock.Anything, int64(1), []database.MediaProperty{{
+		TypeTag: launcherOverridePropertyTypeTag(),
+		Text:    "RetroArch",
+	}}).Return(nil).Once()
+	expectMediaMetaUpdateResponse(mockDB, &row, []database.MediaProperty{{
+		TypeTag: launcherOverridePropertyTypeTag(),
+		Text:    "RetroArch",
+	}})
+	env := makeMediaMetaUpdateEnv(mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`)
+	env.LauncherCache = nil
+	env.Platform = mockPlatform
+
+	result, err := HandleMediaMetaUpdate(env)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaResponse)
+	require.True(t, ok)
+	require.NotNil(t, resp.Media.LauncherOverride)
+	assert.Equal(t, "RetroArch", *resp.Media.LauncherOverride)
+	mockDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestHandleMediaMetaUpdate_ClearsLauncherOverride(t *testing.T) {
 	t.Parallel()
 
@@ -153,6 +196,73 @@ func TestHandleMediaMetaUpdate_RejectsWrongSystemLauncher(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
+func TestHandleMediaMetaUpdate_RejectsUnknownLauncher(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+
+	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"launcherOverride":"Missing"}}`,
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "launcher not found")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMetaUpdate_ClearIgnoresMissingPropertyTag(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("FindTagType", database.TagType{Type: string(tags.TagTypeProperty)}).
+		Return(database.TagType{}, sql.ErrNoRows).Once()
+	expectMediaMetaUpdateResponse(mockDB, &row, nil)
+
+	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
+	))
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaResponse)
+	require.True(t, ok)
+	assert.Nil(t, resp.Media.LauncherOverride)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMetaUpdate_RejectsMissingOrInvalidMediaPatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		params  string
+		wantErr string
+	}{
+		{name: "missing media", params: `{"mediaId":1}`, wantErr: "media update is required"},
+		{name: "null media", params: `{"mediaId":1,"media":null}`, wantErr: "media must be an object"},
+		{name: "empty media", params: `{"mediaId":1,"media":{}}`, wantErr: "no supported media updates provided"},
+		{
+			name:    "empty launcher override",
+			params:  `{"mediaId":1,"media":{"launcherOverride":" "}}`,
+			wantErr: "cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB := testhelpers.NewMockMediaDBI()
+			_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(mockDB, tt.params))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			mockDB.AssertExpectations(t)
+		})
+	}
+}
+
 func TestHandleMediaMetaUpdate_RejectsUnsupportedMediaField(t *testing.T) {
 	t.Parallel()
 
@@ -163,4 +273,28 @@ func TestHandleMediaMetaUpdate_RejectsUnsupportedMediaField(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported media field")
 	mockDB.AssertExpectations(t)
+}
+
+func TestParseMediaMetaUpdatePatchValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "missing media", raw: ``, wantErr: "media update is required"},
+		{name: "null media", raw: `null`, wantErr: "media must be an object"},
+		{name: "empty media object", raw: `{}`, wantErr: "no supported media updates provided"},
+		{name: "empty override string", raw: `{"launcherOverride":" "}`, wantErr: "cannot be empty"},
+		{name: "non-string override", raw: `{"launcherOverride":123}`, wantErr: "must be a string or null"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseMediaMetaUpdatePatch([]byte(tt.raw))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }

--- a/pkg/api/methods/media_meta_update_test.go
+++ b/pkg/api/methods/media_meta_update_test.go
@@ -1,0 +1,166 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMediaMetaUpdateEnv(mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "RetroArch", SystemID: "NES"},
+		{ID: "OtherSystem", SystemID: "SNES"},
+	})
+	return requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: launcherCache,
+		Params:        []byte(params),
+	}
+}
+
+func mediaMetaUpdateRow() database.MediaFullRow {
+	return database.MediaFullRow{
+		Media: database.Media{DBID: 1},
+		Title: database.MediaTitle{DBID: 10},
+		System: database.System{
+			DBID:     100,
+			SystemID: "NES",
+			Name:     "NES",
+		},
+	}
+}
+
+func expectMediaMetaUpdateResponse(
+	mockDB *testhelpers.MockMediaDBI,
+	row *database.MediaFullRow,
+	mediaProps []database.MediaProperty,
+) {
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: *row}, nil).Once()
+	mockDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, []int64{1}).
+		Return(map[int64][]database.TagInfo{}, nil).Once()
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBIDs", mock.Anything, []int64{10}).
+		Return(map[int64][]database.TagInfo{}, nil).Once()
+	mockDB.On("GetMediaPropertyMetadataByMediaDBIDs", mock.Anything, []int64{1}).
+		Return(map[int64][]database.MediaProperty{1: mediaProps}, nil).Once()
+	mockDB.On("GetMediaTitlePropertyMetadataByMediaTitleDBIDs", mock.Anything, []int64{10}).
+		Return(map[int64][]database.MediaProperty{}, nil).Once()
+}
+
+func TestHandleMediaMetaUpdate_SetsLauncherOverride(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{
+		Type:        string(tags.TagTypeProperty),
+		IsExclusive: false,
+	}).Return(database.TagType{DBID: 11, Type: string(tags.TagTypeProperty)}, nil).Once()
+	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}).
+		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}, nil).Once()
+	mockDB.On("UpsertMediaProperties", mock.Anything, int64(1), []database.MediaProperty{{
+		TypeTag: launcherOverridePropertyTypeTag(),
+		Text:    "RetroArch",
+	}}).Return(nil).Once()
+	expectMediaMetaUpdateResponse(mockDB, &row, []database.MediaProperty{{
+		TypeTag: launcherOverridePropertyTypeTag(),
+		Text:    "RetroArch",
+	}})
+
+	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`,
+	))
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaResponse)
+	require.True(t, ok)
+	require.NotNil(t, resp.Media.LauncherOverride)
+	assert.Equal(t, "RetroArch", *resp.Media.LauncherOverride)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMetaUpdate_ClearsLauncherOverride(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+	mockDB.On("FindTagType", database.TagType{Type: string(tags.TagTypeProperty)}).
+		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeProperty)}, nil).Once()
+	mockDB.On("FindTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}).
+		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagPropertyLauncherOverride)}, nil).Once()
+	mockDB.On("DeleteMediaProperty", mock.Anything, int64(1), int64(12)).Return(nil).Once()
+	expectMediaMetaUpdateResponse(mockDB, &row, nil)
+
+	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
+	))
+	require.NoError(t, err)
+
+	resp, ok := result.(models.MediaMetaResponse)
+	require.True(t, ok)
+	assert.Nil(t, resp.Media.LauncherOverride)
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMetaUpdate_RejectsWrongSystemLauncher(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	row := mediaMetaUpdateRow()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
+
+	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"launcherOverride":"OtherSystem"}}`,
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support system")
+	mockDB.AssertExpectations(t)
+}
+
+func TestHandleMediaMetaUpdate_RejectsUnsupportedMediaField(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
+		mockDB, `{"mediaId":1,"media":{"unknown":"value"}}`,
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported media field")
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -61,6 +61,7 @@ const (
 	MethodMediaSearch          = "media.search"
 	MethodMediaTags            = "media.tags"
 	MethodMediaTagsUpdate      = "media.tags.update"
+	MethodMediaMetaUpdate      = "media.meta.update"
 	MethodMediaActive          = "media.active"
 	MethodMediaHistory         = "media.history"
 	MethodMediaHistoryLatest   = "media.history.latest"

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -20,7 +20,11 @@
 //nolint:revive // custom validation tags (letter, duration, etc.) are unknown to revive
 package models
 
-import "github.com/ZaparooProject/go-zapscript"
+import (
+	"encoding/json"
+
+	"github.com/ZaparooProject/go-zapscript"
+)
 
 type SearchParams struct {
 	Systems     *[]string `json:"systems" validate:"omitempty,dive,min=1"`
@@ -205,6 +209,13 @@ type MediaTagsUpdateParams struct {
 	Path    string   `json:"path"   validate:"omitempty,min=1"`
 	Add     []string `json:"add,omitempty" validate:"omitempty,dive,min=1"`
 	Remove  []string `json:"remove,omitempty" validate:"omitempty,dive,min=1"`
+}
+
+type MediaMetaUpdateParams struct {
+	MediaID *int64          `json:"mediaId,omitempty"`
+	System  string          `json:"system" validate:"omitempty,min=1"`
+	Path    string          `json:"path"   validate:"omitempty,min=1"`
+	Media   json.RawMessage `json:"media,omitempty"`
 }
 
 type MediaImageParams struct {

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -60,17 +60,13 @@ type BrowseEntry struct {
 	ZapScript *string            `json:"zapScript,omitempty"`
 	FileCount *int               `json:"fileCount,omitempty"`
 	Group     *string            `json:"group,omitempty"`
-	Name      string             `json:"name"`
 	Path      string             `json:"path"`
 	Type      string             `json:"type"`
+	Name      string             `json:"name"`
 	SystemIDs []string           `json:"systemIds,omitempty"`
 	Tags      []database.TagInfo `json:"tags,omitempty"`
 	MediaID   int64              `json:"mediaId,omitempty"`
-	// HasCover is true when the media or its title has at least one image
-	// property row. Only set for media-type entries and singleton-aliased
-	// directory entries. Always emitted (never omitempty) so clients can
-	// skip cover requests for entries without art.
-	HasCover bool `json:"hasCover"`
+	HasCover  bool               `json:"hasCover"`
 }
 
 type BrowseResults struct {
@@ -278,6 +274,7 @@ type MediaMetaTitleResponse struct {
 // MediaMetaMediaResponse is the top-level Media object in a media.meta response.
 type MediaMetaMediaResponse struct {
 	Properties          map[string]MediaMetaPropertyItem `json:"properties"`
+	LauncherOverride    *string                          `json:"launcherOverride,omitempty"`
 	Path                string                           `json:"path"`
 	ParentDir           string                           `json:"parentDir"`
 	Tags                []database.TagInfo               `json:"tags"`

--- a/pkg/api/request_priority.go
+++ b/pkg/api/request_priority.go
@@ -40,6 +40,7 @@ func classifyAPIMethod(method string) apiRequestPriority {
 
 	switch method {
 	case models.MethodMediaTagsUpdate,
+		models.MethodMediaMetaUpdate,
 		models.MethodMediaHistoryLatest,
 		models.MethodRun,
 		models.MethodRunScript,

--- a/pkg/api/request_priority.go
+++ b/pkg/api/request_priority.go
@@ -95,5 +95,6 @@ func isImageAPIMethod(method string) bool {
 }
 
 func isMediaDBTransactionAPIMethod(method string) bool {
-	return strings.EqualFold(method, models.MethodMediaTagsUpdate)
+	return strings.EqualFold(method, models.MethodMediaTagsUpdate) ||
+		strings.EqualFold(method, models.MethodMediaMetaUpdate)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -252,6 +252,7 @@ func NewMethodMap() *MethodMap {
 		models.MethodMediaBrowse:         methods.HandleMediaBrowse,
 		models.MethodMediaTags:           methods.HandleMediaTags,
 		models.MethodMediaTagsUpdate:     methods.HandleMediaTagsUpdate,
+		models.MethodMediaMetaUpdate:     methods.HandleMediaMetaUpdate,
 		models.MethodMediaActive:         methods.HandleActiveMedia,
 		models.MethodMediaActiveUpdate:   methods.HandleUpdateActiveMedia,
 		models.MethodMediaCleanOrphans:   methods.HandleMediaCleanOrphans,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -242,6 +242,7 @@ type SearchResult struct {
 	SystemID string
 	Name     string
 	Path     string
+	MediaID  int64
 }
 
 type TagInfo struct {
@@ -393,13 +394,10 @@ type SearchResultWithCursor struct {
 	SortValue     string
 	SortMode      string
 	Tags          []TagInfo
-	ZapScriptTags []TagInfo // Disambiguating tags only (tags that differ across sibling variants)
+	ZapScriptTags []TagInfo
 	MediaID       int64
 	MediaTitleID  int64 `json:"-"`
-	// HasCover is true when the media or its title has at least one image
-	// property row in MediaProperties or MediaTitleProperties. Set by the
-	// browse files path; not populated by search/other paths.
-	HasCover bool
+	HasCover      bool
 }
 
 // ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2135,7 +2135,7 @@ func (db *MediaDB) randomGameWithStats(
 	// Get the first media item with DBID >= targetDBID
 	//nolint:gosec // whereClause is built from safe conditions, no user input
 	selectQuery := fmt.Sprintf(`
-		SELECT Systems.SystemID, Media.Path
+		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
 		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -2148,11 +2148,12 @@ func (db *MediaDB) randomGameWithStats(
 	err = db.sql.QueryRowContext(ctx, selectQuery, args...).Scan(
 		&row.SystemID,
 		&row.Path,
+		&row.MediaID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
 		selectQuery = fmt.Sprintf(`
-			SELECT Systems.SystemID, Media.Path
+			SELECT Systems.SystemID, Media.Path, Media.DBID
 			FROM Media
 			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -2164,6 +2165,7 @@ func (db *MediaDB) randomGameWithStats(
 		err = db.sql.QueryRowContext(ctx, selectQuery, args...).Scan(
 			&row.SystemID,
 			&row.Path,
+			&row.MediaID,
 		)
 	}
 	if err != nil {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -734,11 +734,13 @@ func TestMediaDB_RandomGame_Integration(t *testing.T) {
 	result, err = mediaDB.RandomGameWithQuery(context.Background(), &query)
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
+	assert.NotZero(t, result.MediaID)
 
 	// Test that cache is working - second call should use cache
 	result2, err := mediaDB.RandomGameWithQuery(context.Background(), &query)
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result2.SystemID)
+	assert.NotZero(t, result2.MediaID)
 }
 
 func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {

--- a/pkg/database/mediadb/multi_variant_search_test.go
+++ b/pkg/database/mediadb/multi_variant_search_test.go
@@ -228,15 +228,15 @@ func TestSearchMediaPathGlob_Deduplication(t *testing.T) {
 	// Total: 6 args
 	// Note: sqlSearchMediaPathParts returns different columns than sqlSearchMediaWithFilters
 
-	mock.ExpectPrepare("select Systems.SystemID, Media.Path from Systems.*").
+	mock.ExpectPrepare("select Systems.SystemID, Media.Path, Media.DBID from Systems.*").
 		ExpectQuery().
 		WithArgs(
 			"NES", "SNES", // System IDs
 			"%mario%", "%mario%", // Part 1: Slug LIKE, SecondarySlug LIKE
 			"%bros%", "%bros%", // Part 2: Slug LIKE, SecondarySlug LIKE
 		).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Path"}).
-			AddRow("NES", "/games/mario.nes"))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
+			AddRow("NES", "/games/mario.nes", int64(42)))
 
 	// sqlSearchMediaPathParts doesn't fetch tags, returns different struct
 	results, err := sqlSearchMediaPathParts(
@@ -246,6 +246,7 @@ func TestSearchMediaPathGlob_Deduplication(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 	assert.Equal(t, "/games/mario.nes", results[0].Path)
+	assert.Equal(t, int64(42), results[0].MediaID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediadb/multi_variant_search_test.go
+++ b/pkg/database/mediadb/multi_variant_search_test.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -66,11 +67,12 @@ func TestSearchMediaWithFilters_MultipleSameMediaTypeSystems(t *testing.T) {
 	// - 10
 	// Total: 7 args (bloated with duplicates)
 
+	mediaPath := filepath.Join("games", "mario.nes")
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs("NES", "SNES", "%mario%", "%mario%", 10). // Should be 5 args, not 7
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Super Mario Bros", "/games/mario.nes", int64(1)))
+			AddRow("NES", "Super Mario Bros", mediaPath, int64(1)))
 
 	// Mock tags query
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -171,6 +173,7 @@ func TestSearchMediaWithFilters_MultipleWordsMultipleSystems(t *testing.T) {
 	// Limit: 1
 	// Total: 16 args (bloated!)
 
+	mediaPath := filepath.Join("games", "smw.sfc")
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(
@@ -180,7 +183,7 @@ func TestSearchMediaWithFilters_MultipleWordsMultipleSystems(t *testing.T) {
 			10, // Limit
 		). // Should be 8 args, not 16
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("SNES", "Super Mario World", "/games/smw.sfc", int64(1)))
+			AddRow("SNES", "Super Mario World", mediaPath, int64(1)))
 
 	// Mock tags query
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -228,6 +231,7 @@ func TestSearchMediaPathGlob_Deduplication(t *testing.T) {
 	// Total: 6 args
 	// Note: sqlSearchMediaPathParts returns different columns than sqlSearchMediaWithFilters
 
+	mediaPath := filepath.Join("games", "mario.nes")
 	mock.ExpectPrepare("select Systems.SystemID, Media.Path, Media.DBID from Systems.*").
 		ExpectQuery().
 		WithArgs(
@@ -236,7 +240,7 @@ func TestSearchMediaPathGlob_Deduplication(t *testing.T) {
 			"%bros%", "%bros%", // Part 2: Slug LIKE, SecondarySlug LIKE
 		).
 		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
-			AddRow("NES", "/games/mario.nes", int64(42)))
+			AddRow("NES", mediaPath, int64(42)))
 
 	// sqlSearchMediaPathParts doesn't fetch tags, returns different struct
 	results, err := sqlSearchMediaPathParts(
@@ -245,7 +249,7 @@ func TestSearchMediaPathGlob_Deduplication(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
-	assert.Equal(t, "/games/mario.nes", results[0].Path)
+	assert.Equal(t, mediaPath, results[0].Path)
 	assert.Equal(t, int64(42), results[0].MediaID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -530,7 +530,8 @@ func sqlSearchMediaPathExact(
 		select
 			Systems.SystemID,
 			MediaTitles.Name,
-			Media.Path
+			Media.Path,
+			Media.DBID
 		from Systems
 		inner join MediaTitles
 			on Systems.DBID = MediaTitles.SystemDBID
@@ -569,6 +570,7 @@ func sqlSearchMediaPathExact(
 			&result.SystemID,
 			&result.Name,
 			&result.Path,
+			&result.MediaID,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -634,7 +636,8 @@ func sqlSearchMediaPathParts(
 	stmt, err := db.PrepareContext(ctx, `
 		select
 			Systems.SystemID,
-			Media.Path
+			Media.Path,
+			Media.DBID
 		from Systems
 		inner join MediaTitles
 			on Systems.DBID = MediaTitles.SystemDBID
@@ -674,6 +677,7 @@ func sqlSearchMediaPathParts(
 		if scanErr := rows.Scan(
 			&result.SystemID,
 			&result.Path,
+			&result.MediaID,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -1353,13 +1357,13 @@ func sqlSearchMediaBySlugIn(
 func sqlGetRandomMediaForTitle(ctx context.Context, db sqlQueryable, titleDBID int64) (database.SearchResult, error) {
 	var row database.SearchResult
 	err := db.QueryRowContext(ctx, `
-		SELECT Systems.SystemID, Media.Path
+		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
 		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
 		WHERE Media.MediaTitleDBID = ? AND Media.IsMissing = 0
 		ORDER BY RANDOM() LIMIT 1
-	`, titleDBID).Scan(&row.SystemID, &row.Path)
+	`, titleDBID).Scan(&row.SystemID, &row.Path, &row.MediaID)
 	if err != nil {
 		return row, fmt.Errorf("failed to get random media for title %d: %w", titleDBID, err)
 	}
@@ -1399,7 +1403,7 @@ func sqlRandomGame(ctx context.Context, db sqlQueryable, system *systemdefs.Syst
 
 	// Step 3: Get the first media item with DBID >= targetDBID
 	selectQuery := `
-		SELECT Systems.SystemID, Media.Path
+		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
 		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -1410,11 +1414,12 @@ func sqlRandomGame(ctx context.Context, db sqlQueryable, system *systemdefs.Syst
 	err = db.QueryRowContext(ctx, selectQuery, system.ID, targetDBID).Scan(
 		&row.SystemID,
 		&row.Path,
+		&row.MediaID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
 		selectQuery = `
-			SELECT Systems.SystemID, Media.Path
+			SELECT Systems.SystemID, Media.Path, Media.DBID
 			FROM Media
 			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -1425,6 +1430,7 @@ func sqlRandomGame(ctx context.Context, db sqlQueryable, system *systemdefs.Syst
 		err = db.QueryRowContext(ctx, selectQuery, system.ID, targetDBID).Scan(
 			&row.SystemID,
 			&row.Path,
+			&row.MediaID,
 		)
 	}
 	if err != nil {
@@ -1473,7 +1479,7 @@ func sqlRandomGameWithQueryAndStats(
 	// Step 3: Get the first media item with DBID >= targetDBID
 	//nolint:gosec // whereClause is built from safe conditions, no user input
 	selectQuery := fmt.Sprintf(`
-		SELECT Systems.SystemID, Media.Path
+		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
 		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -1486,11 +1492,12 @@ func sqlRandomGameWithQueryAndStats(
 	err = db.QueryRowContext(ctx, selectQuery, args...).Scan(
 		&row.SystemID,
 		&row.Path,
+		&row.MediaID,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
 		selectQuery = fmt.Sprintf(`
-			SELECT Systems.SystemID, Media.Path
+			SELECT Systems.SystemID, Media.Path, Media.DBID
 			FROM Media
 			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
 			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
@@ -1502,6 +1509,7 @@ func sqlRandomGameWithQueryAndStats(
 		err = db.QueryRowContext(ctx, selectQuery, args...).Scan(
 			&row.SystemID,
 			&row.Path,
+			&row.MediaID,
 		)
 	}
 	if err != nil {

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -198,11 +198,17 @@ func TestSqlSearchMediaPathExact_Success(t *testing.T) {
 			SystemID: "test-system",
 			Name:     "Test Game",
 			Path:     "/games/test.rom",
+			MediaID:  42,
 		},
 	}
 
-	rows := sqlmock.NewRows([]string{"SystemID", "Name", "Path"}).
-		AddRow(expectedResults[0].SystemID, expectedResults[0].Name, expectedResults[0].Path)
+	rows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
+		AddRow(
+			expectedResults[0].SystemID,
+			expectedResults[0].Name,
+			expectedResults[0].Path,
+			expectedResults[0].MediaID,
+		)
 
 	// Match the actual SQL query structure
 	mock.ExpectPrepare(`select.*from Systems.*inner join.*MediaTitles.*inner join.*Media.*where.*LIMIT`).
@@ -216,6 +222,7 @@ func TestSqlSearchMediaPathExact_Success(t *testing.T) {
 	assert.Equal(t, expectedResults[0].SystemID, result[0].SystemID)
 	assert.Equal(t, expectedResults[0].Name, result[0].Name)
 	assert.Equal(t, expectedResults[0].Path, result[0].Path)
+	assert.Equal(t, expectedResults[0].MediaID, result[0].MediaID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/tags/tag_values.go
+++ b/pkg/database/tags/tag_values.go
@@ -1517,13 +1517,14 @@ const (
 	// TagPropertyImageThumbnail maps to ES <thumbnail>, which in most ES forks
 	// (RPI, Sky, Batocera, ES-DE) stores cover art, not a screenshot.
 	// See esapi/gamelist.go for field-level fork documentation.
-	TagPropertyImageThumbnail TagValue = "image-thumbnail" // Thumbnail / cover image (filesystem path)
-	TagPropertyImageMarquee   TagValue = "image-marquee"   // Cabinet marquee / logo image (filesystem path)
-	TagPropertyImageWheel     TagValue = "image-wheel"     // Wheel / die-cut logo image (filesystem path)
-	TagPropertyImageFanart    TagValue = "image-fanart"    // Fan art / background image (filesystem path)
-	TagPropertyImageTitleshot TagValue = "image-titleshot" // Title screen image (filesystem path)
-	TagPropertyImageMap       TagValue = "image-map"       // In-game world/level map image (filesystem path)
-	TagPropertyVideo          TagValue = "video"           // Video clip (filesystem path)
-	TagPropertyManual         TagValue = "manual"          // Game manual PDF (filesystem path)
-	TagPropertyXMLGameID      TagValue = "xml-game-id"     // game node ID (ScreenScraper Game ID for instance)
+	TagPropertyImageThumbnail   TagValue = "image-thumbnail"   // Thumbnail / cover image (filesystem path)
+	TagPropertyImageMarquee     TagValue = "image-marquee"     // Cabinet marquee / logo image (filesystem path)
+	TagPropertyImageWheel       TagValue = "image-wheel"       // Wheel / die-cut logo image (filesystem path)
+	TagPropertyImageFanart      TagValue = "image-fanart"      // Fan art / background image (filesystem path)
+	TagPropertyImageTitleshot   TagValue = "image-titleshot"   // Title screen image (filesystem path)
+	TagPropertyImageMap         TagValue = "image-map"         // In-game world/level map image (filesystem path)
+	TagPropertyVideo            TagValue = "video"             // Video clip (filesystem path)
+	TagPropertyManual           TagValue = "manual"            // Game manual PDF (filesystem path)
+	TagPropertyXMLGameID        TagValue = "xml-game-id"       // game node ID (ScreenScraper Game ID for instance)
+	TagPropertyLauncherOverride TagValue = "launcher-override" // Per-media launcher override (launcher ID)
 )

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -939,6 +939,7 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagPropertyVideo,
 		TagPropertyManual,
 		TagPropertyXMLGameID,
+		TagPropertyLauncherOverride,
 	},
 
 	// Rating, genre, and game-family are scraped from external sources; seeded here

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
@@ -39,6 +40,108 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
+
+func launcherOverridePropertyTypeTag() string {
+	return tags.PropertyTypeTag(tags.TagPropertyLauncherOverride)
+}
+
+func applyMediaLauncherOverride(
+	pl platforms.Platform,
+	env *platforms.CmdEnv,
+	mediaDBID int64,
+	systemID string,
+) string {
+	return applyMediaLauncherOverrideWithReplace(pl, env, mediaDBID, systemID, false)
+}
+
+func applyMediaLauncherOverrideWithReplace(
+	pl platforms.Platform,
+	env *platforms.CmdEnv,
+	mediaDBID int64,
+	systemID string,
+	replaceCurrent bool,
+) string {
+	current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
+	if (current != "" && !replaceCurrent) || mediaDBID == 0 {
+		return current
+	}
+	if env.Database == nil || env.Database.MediaDB == nil {
+		return ""
+	}
+
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
+	props, err := env.Database.MediaDB.GetMediaPropertyMetadata(ctx, mediaDBID)
+	if err != nil {
+		log.Warn().Err(err).Int64("mediaDBID", mediaDBID).Msg("failed to read media launcher override")
+		return ""
+	}
+	for _, prop := range props {
+		if prop.TypeTag != launcherOverridePropertyTypeTag() {
+			continue
+		}
+		launcherRef := strings.TrimSpace(prop.Text)
+		if launcherRef == "" {
+			return ""
+		}
+		launcherID, found := resolveLauncherRefForSystem(pl, env, launcherRef, systemID)
+		if !found {
+			log.Warn().
+				Str("system", systemID).
+				Str("launcher", launcherRef).
+				Int64("mediaDBID", mediaDBID).
+				Msg("media launcher override not found")
+			return ""
+		}
+		log.Info().
+			Str("system", systemID).
+			Str("launcher", launcherID).
+			Int64("mediaDBID", mediaDBID).
+			Msg("using media launcher override")
+		env.Cmd.AdvArgs = env.Cmd.AdvArgs.With(zapscript.KeyLauncher, launcherID)
+		return launcherID
+	}
+	return ""
+}
+
+func applyMediaLauncherOverrideForPath(
+	pl platforms.Platform,
+	env *platforms.CmdEnv,
+	path string,
+	replaceCurrent bool,
+) string {
+	current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
+	if current != "" && !replaceCurrent {
+		return current
+	}
+	if env.Database == nil || env.Database.MediaDB == nil {
+		return current
+	}
+	launcher, found := inferLauncherForPath(pl, env, path)
+	if !found || launcher.SystemID == "" {
+		return current
+	}
+
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
+	system, err := env.Database.MediaDB.FindSystemBySystemID(launcher.SystemID)
+	if err != nil {
+		log.Debug().Err(err).Str("system", launcher.SystemID).Msg("failed to resolve launch path system")
+		return current
+	}
+	media, err := env.Database.MediaDB.FindMediaBySystemAndPath(ctx, system.DBID, path)
+	if errors.Is(err, sql.ErrNoRows) {
+		return current
+	}
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("failed to resolve launch path media")
+		return current
+	}
+	if media == nil {
+		return current
+	}
+	return applyMediaLauncherOverrideWithReplace(pl, env, media.DBID, launcher.SystemID, replaceCurrent)
+}
 
 func applySystemDefaultLauncher(pl platforms.Platform, env *platforms.CmdEnv, systemID string) string {
 	current := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher)
@@ -223,6 +326,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", gameErr)
 		}
 
+		applyMediaLauncherOverride(pl, &env, game.MediaID, game.SystemID)
 		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		if launchErr := launch(game.Path); launchErr != nil {
 			return platforms.CmdResult{
@@ -275,6 +379,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("failed to find random media for path '%s': %w", query, searchErr)
 		}
 
+		applyMediaLauncherOverride(pl, &env, searchResult.MediaID, searchResult.SystemID)
 		applySystemDefaultLauncher(pl, &env, searchResult.SystemID)
 		if launchErr := launch(searchResult.Path); launchErr != nil {
 			return platforms.CmdResult{
@@ -321,6 +426,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", randomErr)
 			}
 
+			applyMediaLauncherOverride(pl, &env, game.MediaID, game.SystemID)
 			applySystemDefaultLauncher(pl, &env, game.SystemID)
 			if launchErr := launch(game.Path); launchErr != nil {
 				return platforms.CmdResult{
@@ -347,6 +453,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 				fmt.Errorf("failed to get random game matching '%s': %w", searchQuery, randomErr)
 		}
 
+		applyMediaLauncherOverride(pl, &env, game.MediaID, game.SystemID)
 		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		if launchErr := launch(game.Path); launchErr != nil {
 			return platforms.CmdResult{
@@ -386,6 +493,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", err)
 	}
 
+	applyMediaLauncherOverride(pl, &env, game.MediaID, game.SystemID)
 	applySystemDefaultLauncher(pl, &env, game.SystemID)
 	if err := launch(game.Path); err != nil {
 		return platforms.CmdResult{
@@ -481,6 +589,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	if err := ParseAdvArgs(pl, &env, &args); err != nil {
 		return platforms.CmdResult{}, err
 	}
+	explicitLauncher := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher) != ""
 
 	if dler, ok := isValidRemoteFileURL(path); ok && args.System != "" {
 		installPath, err := installer.InstallRemoteFile(
@@ -513,6 +622,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// if it's an absolute path, just try launch it
 	if filepath.IsAbs(path) {
 		log.Debug().Msgf("launching absolute path: %s", path)
+		applyMediaLauncherOverrideForPath(pl, &env, path, !explicitLauncher)
 		applySystemDefaultLauncherForPath(pl, &env, path)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -522,6 +632,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// match for uri style launch syntax
 	if helpers.ReURI.MatchString(path) {
 		log.Debug().Msgf("launching uri: %s", path)
+		applyMediaLauncherOverrideForPath(pl, &env, path, !explicitLauncher)
 		applySystemDefaultLauncherForPath(pl, &env, path)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -534,6 +645,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	var p string
 	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path); findErr == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
+		applyMediaLauncherOverrideForPath(pl, &env, p, !explicitLauncher)
 		applySystemDefaultLauncherForPath(pl, &env, p)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -598,6 +710,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		var fp string
 		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath); systemFindErr == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
+			applyMediaLauncherOverrideForPath(pl, &env, fp, !explicitLauncher)
 			applySystemDefaultLauncherForPath(pl, &env, fp)
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -632,6 +745,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		log.Info().Msgf("found result: %s", res[0].Path)
 
 		game := res[0]
+		applyMediaLauncherOverrideWithReplace(pl, &env, game.MediaID, game.SystemID, !explicitLauncher)
 		applySystemDefaultLauncher(pl, &env, game.SystemID)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -685,6 +799,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", query)
 		}
 
+		applyMediaLauncherOverride(pl, &env, res[0].MediaID, res[0].SystemID)
 		applySystemDefaultLauncher(pl, &env, res[0].SystemID)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -732,6 +847,7 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, fmt.Errorf("no results found for: %s", searchQuery)
 	}
 
+	applyMediaLauncherOverride(pl, &env, res[0].MediaID, res[0].SystemID)
 	applySystemDefaultLauncher(pl, &env, res[0].SystemID)
 	return platforms.CmdResult{
 		MediaChanged: true,
@@ -801,6 +917,8 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 		return platforms.CmdResult{}, err
 	}
 
+	mediaID := mediaIDForHistoryEntry(&env, &entry)
+	applyMediaLauncherOverride(pl, &env, mediaID, entry.SystemID)
 	applySystemDefaultLauncher(pl, &env, entry.SystemID)
 	launch := getLaunchClosure(pl, &env)
 
@@ -819,4 +937,26 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 	return platforms.CmdResult{
 		MediaChanged: true,
 	}, nil
+}
+
+func mediaIDForHistoryEntry(env *platforms.CmdEnv, entry *database.MediaHistoryEntry) int64 {
+	if env.Database == nil || env.Database.MediaDB == nil {
+		return 0
+	}
+	ctx, cancel := mediaDBLookupContext(env)
+	defer cancel()
+	system, err := env.Database.MediaDB.FindSystemBySystemID(entry.SystemID)
+	if err != nil {
+		log.Debug().Err(err).Str("system", entry.SystemID).Msg("failed to resolve history system for launcher override")
+		return 0
+	}
+	media, err := env.Database.MediaDB.FindMediaBySystemAndPath(ctx, system.DBID, entry.MediaPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", entry.MediaPath).Msg("failed to resolve history media for launcher override")
+		return 0
+	}
+	if media == nil {
+		return 0
+	}
+	return media.DBID
 }

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -157,7 +157,7 @@ func TestVirtualStatPath_PreservesAbsoluteRoot(t *testing.T) {
 	assert.Equal(t, filepath.Join(launchTestAbsPath("games"), "neogeo", "NEOGEO.zip"), statPath)
 }
 
-// TestCmdLaunch_SystemArgAppliesDefaults verifies that system arg applies system defaults when no explicit launcher
+// TestApplyMediaLauncherOverride_SetsLauncherArg verifies that a media override sets the launcher AdvArg.
 func TestApplyMediaLauncherOverride_SetsLauncherArg(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -66,6 +66,130 @@ func TestVirtualStatPath_PreservesAbsoluteRoot(t *testing.T) {
 }
 
 // TestCmdLaunch_SystemArgAppliesDefaults verifies that system arg applies system defaults when no explicit launcher
+func TestApplyMediaLauncherOverride_SetsLauncherArg(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := &config.Instance{}
+	launchers := []platforms.Launcher{
+		{ID: "Default", SystemID: "NES"},
+		{ID: "RetroArch", SystemID: "NES"},
+	}
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(123)).
+		Return([]database.MediaProperty{{
+			TypeTag: launcherOverridePropertyTypeTag(),
+			Text:    "retroarch",
+		}}, nil).Once()
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name:    "launch.title",
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{}),
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	launcherID := applyMediaLauncherOverride(mockPlatform, &env, 123, "NES")
+
+	assert.Equal(t, "RetroArch", launcherID)
+	assert.Equal(t, "RetroArch", env.Cmd.AdvArgs.Get(zapscript.KeyLauncher))
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_AbsolutePathAppliesMediaLauncherOverride(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	db := &database.Database{MediaDB: mockMediaDB}
+	cfg := &config.Instance{}
+	root := t.TempDir()
+	absPath := filepath.Join(root, "game.nes")
+	launchers := []platforms.Launcher{
+		{ID: "Default", SystemID: "NES", Folders: []string{root}, Extensions: []string{".nes"}},
+		{ID: "Override", SystemID: "NES"},
+	}
+
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: t.TempDir()}).Maybe()
+	mockPlatform.On("RootDirs", cfg).Return([]string{root}).Maybe()
+	mockPlatform.On("Launchers", cfg).Return(launchers)
+	mockMediaDB.On("FindSystemBySystemID", "NES").
+		Return(database.System{DBID: 10, SystemID: "NES"}, nil).Once()
+	mockMediaDB.On("FindMediaBySystemAndPath", mock.Anything, int64(10), absPath).
+		Return(&database.Media{DBID: 123, Path: absPath}, nil).Once()
+	mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(123)).
+		Return([]database.MediaProperty{{
+			TypeTag: launcherOverridePropertyTypeTag(),
+			Text:    "Override",
+		}}, nil).Once()
+	mockPlatform.On("LaunchMedia", cfg, absPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "Override"
+		}),
+		db,
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name:    "launch",
+			Args:    []string{absPath},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{}),
+		},
+		Cfg:      cfg,
+		Database: db,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_AbsolutePathExplicitLauncherOverridesMediaOverride(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	db := &database.Database{MediaDB: mockMediaDB}
+	cfg := &config.Instance{}
+	root := t.TempDir()
+	absPath := filepath.Join(root, "game.nes")
+	explicit := platforms.Launcher{ID: "Explicit", SystemID: "NES", Folders: []string{root}}
+
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{explicit})
+	mockPlatform.On("LaunchMedia", cfg, absPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "Explicit"
+		}),
+		db,
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch",
+			Args: []string{absPath},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				"launcher": "Explicit",
+			}),
+		},
+		Cfg:      cfg,
+		Database: db,
+	}
+
+	result, err := cmdLaunch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunch_SystemArgAppliesDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -77,8 +77,8 @@ func TestMediaIDForHistoryEntry_ReturnsZeroWhenUnavailable(t *testing.T) {
 	dbErr := errors.New("database unavailable")
 
 	tests := []struct {
-		name string
 		env  func(t *testing.T) platforms.CmdEnv
+		name string
 	}{
 		{
 			name: "nil database",

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -53,6 +53,98 @@ func launchTestAbsPath(parts ...string) string {
 	return filepath.Join(append([]string{root}, parts...)...)
 }
 
+func TestMediaIDForHistoryEntry_ResolvesMedia(t *testing.T) {
+	t.Parallel()
+
+	mediaPath := filepath.Join("games", "mario.nes")
+	entry := database.MediaHistoryEntry{SystemID: "nes", MediaPath: mediaPath}
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("FindSystemBySystemID", "nes").
+		Return(database.System{DBID: 99, SystemID: "nes"}, nil).Once()
+	mockMediaDB.On("FindMediaBySystemAndPath", mock.Anything, int64(99), mediaPath).
+		Return(&database.Media{DBID: 123}, nil).Once()
+	env := platforms.CmdEnv{Database: &database.Database{MediaDB: mockMediaDB}}
+
+	assert.Equal(t, int64(123), mediaIDForHistoryEntry(&env, &entry))
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestMediaIDForHistoryEntry_ReturnsZeroWhenUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mediaPath := filepath.Join("games", "mario.nes")
+	entry := database.MediaHistoryEntry{SystemID: "nes", MediaPath: mediaPath}
+	dbErr := errors.New("database unavailable")
+
+	tests := []struct {
+		name string
+		env  func(t *testing.T) platforms.CmdEnv
+	}{
+		{
+			name: "nil database",
+			env: func(t *testing.T) platforms.CmdEnv {
+				t.Helper()
+				return platforms.CmdEnv{}
+			},
+		},
+		{
+			name: "system missing",
+			env: func(t *testing.T) platforms.CmdEnv {
+				t.Helper()
+				mockMediaDB := helpers.NewMockMediaDBI()
+				mockMediaDB.On("FindSystemBySystemID", "nes").
+					Return(database.System{}, sql.ErrNoRows).Once()
+				t.Cleanup(func() { mockMediaDB.AssertExpectations(t) })
+				return platforms.CmdEnv{Database: &database.Database{MediaDB: mockMediaDB}}
+			},
+		},
+		{
+			name: "system lookup error",
+			env: func(t *testing.T) platforms.CmdEnv {
+				t.Helper()
+				mockMediaDB := helpers.NewMockMediaDBI()
+				mockMediaDB.On("FindSystemBySystemID", "nes").
+					Return(database.System{}, dbErr).Once()
+				t.Cleanup(func() { mockMediaDB.AssertExpectations(t) })
+				return platforms.CmdEnv{Database: &database.Database{MediaDB: mockMediaDB}}
+			},
+		},
+		{
+			name: "media missing",
+			env: func(t *testing.T) platforms.CmdEnv {
+				t.Helper()
+				mockMediaDB := helpers.NewMockMediaDBI()
+				mockMediaDB.On("FindSystemBySystemID", "nes").
+					Return(database.System{DBID: 99, SystemID: "nes"}, nil).Once()
+				mockMediaDB.On("FindMediaBySystemAndPath", mock.Anything, int64(99), mediaPath).
+					Return(nil, nil).Once()
+				t.Cleanup(func() { mockMediaDB.AssertExpectations(t) })
+				return platforms.CmdEnv{Database: &database.Database{MediaDB: mockMediaDB}}
+			},
+		},
+		{
+			name: "media lookup error",
+			env: func(t *testing.T) platforms.CmdEnv {
+				t.Helper()
+				mockMediaDB := helpers.NewMockMediaDBI()
+				mockMediaDB.On("FindSystemBySystemID", "nes").
+					Return(database.System{DBID: 99, SystemID: "nes"}, nil).Once()
+				mockMediaDB.On("FindMediaBySystemAndPath", mock.Anything, int64(99), mediaPath).
+					Return(nil, dbErr).Once()
+				t.Cleanup(func() { mockMediaDB.AssertExpectations(t) })
+				return platforms.CmdEnv{Database: &database.Database{MediaDB: mockMediaDB}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := tt.env(t)
+			assert.Zero(t, mediaIDForHistoryEntry(&env, &entry))
+		})
+	}
+}
+
 func TestVirtualStatPath_PreservesAbsoluteRoot(t *testing.T) {
 	t.Parallel()
 
@@ -1003,6 +1095,54 @@ launcher = "genesis-alt"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdSearch_AppliesMediaLauncherOverride(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	overrideLauncher := platforms.Launcher{ID: "genesis-override", SystemID: "genesis"}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{overrideLauncher})
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "sonic" && filters.Limit == 1
+		}),
+	).Return([]database.SearchResultWithCursor{
+		{MediaID: 44, SystemID: "genesis", Path: romPath},
+	}, nil).Once()
+	mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(44)).
+		Return([]database.MediaProperty{{
+			TypeTag: launcherOverridePropertyTypeTag(),
+			Text:    "genesis-override",
+		}}, nil).Once()
+
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-override"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.search",
+			Args: []string{"sonic"},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdSearch(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {
 	t.Parallel()
 
@@ -1067,6 +1207,49 @@ launcher = "genesis-alt"
 		mock.Anything,
 		(*platforms.LaunchOptions)(nil),
 	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{"all"},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AppliesMediaLauncherOverride(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	overrideLauncher := platforms.Launcher{ID: "genesis-override", SystemID: "genesis"}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{overrideLauncher})
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "GENESIS", "Sonic.bin")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Return(database.SearchResult{MediaID: 55, SystemID: "genesis", Path: romPath}, nil).Once()
+	mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(55)).
+		Return([]database.MediaProperty{{
+			TypeTag: launcherOverridePropertyTypeTag(),
+			Text:    "genesis-override",
+		}}, nil).Once()
+
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		mock.MatchedBy(func(l *platforms.Launcher) bool {
+			return l != nil && l.ID == "genesis-override"
+		}),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
 
 	env := platforms.CmdEnv{
 		Cmd: zapscript.Command{

--- a/pkg/zapscript/launch_title_test.go
+++ b/pkg/zapscript/launch_title_test.go
@@ -1593,6 +1593,9 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 			int64(123), mock.AnythingOfType("string")). // strategy string
 			Return(nil).Once()
 
+		mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(123)).
+			Return([]database.MediaProperty{}, nil).Once()
+
 		mockPlatform.On(
 			"LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(nil)
@@ -1651,6 +1654,9 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 			mock.Anything, systemID, slug, tags1, int64(100), mock.AnythingOfType("string")).
 			Return(nil).Once()
 
+		mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(100)).
+			Return([]database.MediaProperty{}, nil).Once()
+
 		mockPlatform.On(
 			"LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		).Return(nil).Once()
@@ -1685,6 +1691,9 @@ func TestCmdTitleCacheBehavior(t *testing.T) {
 		mockMediaDB.On("SetCachedSlugResolution",
 			mock.Anything, systemID, slug, tags2, int64(200), mock.AnythingOfType("string")).
 			Return(nil).Once()
+
+		mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(200)).
+			Return([]database.MediaProperty{}, nil).Once()
 
 		mockPlatform.On(
 			"LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -1776,6 +1785,9 @@ func TestCmdTitleErrorHandling(t *testing.T) {
 			mock.Anything, "SNES", "supermarioworld", []zapscript.TagFilter(nil),
 			int64(123), mock.AnythingOfType("string")).
 			Return(nil).Maybe()
+
+		mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, int64(123)).
+			Return([]database.MediaProperty{}, nil).Once()
 
 		// Platform launch fails
 		mockPlatform.On("LaunchMedia", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).

--- a/pkg/zapscript/titles.go
+++ b/pkg/zapscript/titles.go
@@ -66,6 +66,7 @@ func cmdTitle(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult,
 		return platforms.CmdResult{}, fmt.Errorf("invalid advanced arguments: %w", parseErr)
 	}
 
+	explicitLauncher := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher) != ""
 	args.Launcher = applySystemDefaultLauncher(pl, &env, system.ID)
 	launch := getLaunchClosure(pl, &env)
 
@@ -112,6 +113,8 @@ func cmdTitle(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult,
 	} else {
 		log.Info().Msgf("launching with confidence %.2f: %s", result.Confidence, result.Result.Name)
 	}
+
+	applyMediaLauncherOverrideWithReplace(pl, &env, result.Result.MediaID, result.Result.SystemID, !explicitLauncher)
 
 	return platforms.CmdResult{
 		MediaChanged: true,


### PR DESCRIPTION
Summary:
- add media.meta.update support for per-media launcherOverride stored in MediaProperties
- expose launcherOverride through media.meta and apply overrides during DB-backed and direct launch paths
- keep browse/search responses unenriched while retaining internal MediaID plumbing for launch resolution

Validated with targeted Go package tests before PR creation.

Closes #911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `media.meta.update` JSON-RPC endpoint to set or clear per-media launcher overrides (with validation and system compatibility checks).
  * Media metadata responses can now include `launcherOverride`.
  * Launcher overrides are now automatically applied across launch flows (launch, search, random, title, and media history), while explicit launcher arguments take precedence.
  * Search results now include the underlying `MediaID`.
* **Tests**
  * Added/expanded automated coverage for setting/clearing launcher overrides, error cases, and end-to-end behavior across affected launch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->