### PR TITLE
fix(batocera): start game tracker when ES API unavailable at startup

### DIFF
--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -145,8 +145,9 @@ func (p *Platform) StartPost(
 		if err != nil {
 			if attempt == maxRetries {
 				log.Warn().Err(err).Msg("ES API unavailable after retries, continuing without active media detection")
-				p.setActiveMedia(nil)
-				return nil
+				// Don't return: the background tracker (started below) keeps
+				// polling and detects games once the ES API becomes available.
+				break
 			}
 
 			delay := time.Duration(1<<attempt) * baseDelay
@@ -165,15 +166,13 @@ func (p *Platform) StartPost(
 			systemID, err := fromBatoceraSystem(gameResp.SystemName)
 			if err != nil {
 				log.Warn().Err(err).Msgf("failed to convert system %s, setting no active media", gameResp.SystemName)
-				p.setActiveMedia(nil)
-				return nil
+				break
 			}
 
 			systemMeta, err := assets.GetSystemMetadata(systemID)
 			if err != nil {
 				log.Warn().Err(err).Msgf("failed to get system metadata for %s, setting no active media", systemID)
-				p.setActiveMedia(nil)
-				return nil
+				break
 			}
 
 			game = models.NewActiveMedia(

--- a/pkg/platforms/batocera/tracker_test.go
+++ b/pkg/platforms/batocera/tracker_test.go
@@ -59,6 +59,69 @@ func TestBackgroundTracker_StartsCorrectly(t *testing.T) {
 	}
 }
 
+// TestBackgroundTracker_StartsWhenESAPIUnavailableAtStartup is a regression test
+// for #936: when the ES API is unavailable during the startup probe (e.g.
+// EmulationStation hasn't finished booting), StartPost must still start the
+// background tracker. Previously it returned early and the tracker never ran, so
+// externally launched games were never detected for the whole session.
+func TestBackgroundTracker_StartsWhenESAPIUnavailableAtStartup(t *testing.T) {
+	// Note: Not using t.Parallel() because MockESAPIServer binds to hardcoded port 1234
+
+	fs := helpers.NewMemoryFS()
+	cfg, err := helpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	// Real clock so the short startup backoff actually elapses and the tracker
+	// ticker fires; maxStartupRetries keeps the failing probe fast (~100ms).
+	platform := &Platform{
+		clock:             clockwork.NewRealClock(),
+		maxStartupRetries: 1,
+	}
+
+	var mediaMu syncutil.RWMutex
+	var capturedMedia *models.ActiveMedia
+	setActiveMedia := func(media *models.ActiveMedia) {
+		mediaMu.Lock()
+		capturedMedia = media
+		mediaMu.Unlock()
+	}
+	activeMedia := func() *models.ActiveMedia {
+		mediaMu.RLock()
+		defer mediaMu.RUnlock()
+		return capturedMedia
+	}
+
+	// No mock ES API server is running yet, so the startup probe on :1234 is
+	// refused and exhausts its retries.
+	err = platform.StartPost(t.Context(), cfg, nil, activeMedia, setActiveMedia, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		if platform.stopTracker != nil {
+			_ = platform.stopTracker()
+		}
+	}()
+
+	// Regression assertion: the tracker must start despite the failed probe.
+	require.NotNil(t, platform.stopTracker,
+		"tracker should start even when the ES API is unavailable at startup")
+
+	// The ES API now comes up with an externally launched game. The already
+	// running tracker should pick it up on its next poll.
+	mockESAPI := helpers.NewMockESAPIServer(t)
+	mockESAPI.WithRunningGame(&esapi.RunningGameResponse{
+		Name:       "Sonic the Hedgehog",
+		Path:       "/userdata/roms/genesis/sonic.md",
+		SystemName: "megadrive",
+	})
+
+	require.Eventually(t, func() bool {
+		mediaMu.RLock()
+		defer mediaMu.RUnlock()
+		return capturedMedia != nil && capturedMedia.Path == "/userdata/roms/genesis/sonic.md"
+	}, 6*time.Second, 100*time.Millisecond,
+		"tracker should detect the externally launched game once the ES API is available")
+}
+
 // TestBackgroundTracker_DetectsExternalGameLaunch tests that the tracker detects
 // when a game is launched externally (not by Zaparoo)
 func TestBackgroundTracker_DetectsExternalGameLaunch(t *testing.T) {

--- a/pkg/platforms/batocera/tracker_test.go
+++ b/pkg/platforms/batocera/tracker_test.go
@@ -122,6 +122,58 @@ func TestBackgroundTracker_StartsWhenESAPIUnavailableAtStartup(t *testing.T) {
 		"tracker should detect the externally launched game once the ES API is available")
 }
 
+// TestBackgroundTracker_StartsWhenStartupGameSystemUnknown covers the case where
+// the startup probe finds a running game but its system can't be mapped. StartPost
+// must not bail out: it should leave active media empty and still start the
+// background tracker (same #936 class of early-return bug).
+func TestBackgroundTracker_StartsWhenStartupGameSystemUnknown(t *testing.T) {
+	// Note: Not using t.Parallel() because MockESAPIServer binds to hardcoded port 1234
+
+	mockESAPI := helpers.NewMockESAPIServer(t)
+	mockESAPI.WithRunningGame(&esapi.RunningGameResponse{
+		Name:       "Mystery Game",
+		Path:       "/userdata/roms/unknownsystem/mystery.bin",
+		SystemName: "this-is-not-a-real-batocera-system",
+	})
+
+	fs := helpers.NewMemoryFS()
+	cfg, err := helpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	platform := &Platform{
+		clock: fakeClock,
+	}
+
+	var mediaMu syncutil.RWMutex
+	var capturedMedia *models.ActiveMedia
+	setActiveMedia := func(media *models.ActiveMedia) {
+		mediaMu.Lock()
+		capturedMedia = media
+		mediaMu.Unlock()
+	}
+	activeMedia := func() *models.ActiveMedia {
+		mediaMu.RLock()
+		defer mediaMu.RUnlock()
+		return capturedMedia
+	}
+
+	err = platform.StartPost(t.Context(), cfg, nil, activeMedia, setActiveMedia, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		if platform.stopTracker != nil {
+			_ = platform.stopTracker()
+		}
+	}()
+
+	// Unmappable startup game: no active media, but the tracker still starts.
+	require.NotNil(t, platform.stopTracker,
+		"tracker should start even when the startup game's system is unknown")
+	mediaMu.RLock()
+	assert.Nil(t, capturedMedia, "unmappable startup game should not be set as active media")
+	mediaMu.RUnlock()
+}
+
 // TestBackgroundTracker_DetectsExternalGameLaunch tests that the tracker detects
 // when a game is launched externally (not by Zaparoo)
 func TestBackgroundTracker_DetectsExternalGameLaunch(t *testing.T) {


### PR DESCRIPTION
- `StartPost` returned early when the EmulationStation API was not yet reachable during the startup probe, skipping the background game tracker for the entire session.
- With the tracker never running, externally launched games were never detected, so "currently playing" only ever reflected games launched through Zaparoo.
- Replaced the early `return nil` exits in the startup probe loop with `break` so every path falls through to tracker startup; the tracker polls every 2s and recovers once the ES API becomes available.
- Added a regression test covering an ES API that is unavailable at startup and comes up afterward.

Closes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improve startup reliability: background game tracking now keeps running when the system API is unavailable at startup, restoring media detection once it becomes available.
* Improve resilience: if a running game is detected but its system metadata can’t be resolved, the tracker continues instead of stopping early.

## Tests
* Added regression coverage for delayed system API availability and unknown startup game systems to prevent future behavior regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->