### PR TITLE
fix(windows): resolve cmd.exe by absolute path for shell-outs

### DIFF
--- a/pkg/helpers/comspec_windows.go
+++ b/pkg/helpers/comspec_windows.go
@@ -19,19 +19,28 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
-package systray
+package helpers
 
 import (
-	"context"
-	"os/exec"
-	"syscall"
-
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"os"
+	"path/filepath"
 )
 
-func openPath(path string) error {
-	//nolint:gosec // Safe: opens file/URL with system default handler
-	cmd := exec.CommandContext(context.Background(), helpers.ComSpec(), "/c", "start", "", path)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	return cmd.Start() //nolint:wrapcheck // internal helper
+// ComSpec returns the absolute path to the Windows command interpreter
+// (cmd.exe), resolving it without relying on %PATH%. Some machines have a
+// %PATH% that does not contain C:\Windows\System32 (e.g. a truncated or
+// stripped environment), which makes exec lookups of the bare name "cmd"
+// fail. Using an absolute path also avoids Go's exec.ErrDot protection, which
+// rejects executables found only relative to the current directory.
+//
+// %ComSpec% and %SystemRoot% are set by the OS independently of %PATH%, so
+// they survive a broken PATH.
+func ComSpec() string {
+	if cs := os.Getenv("ComSpec"); cs != "" {
+		return cs
+	}
+	if sr := os.Getenv("SystemRoot"); sr != "" {
+		return filepath.Join(sr, "System32", "cmd.exe")
+	}
+	return `C:\Windows\System32\cmd.exe`
 }

--- a/pkg/helpers/comspec_windows_test.go
+++ b/pkg/helpers/comspec_windows_test.go
@@ -19,19 +19,38 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
-package systray
+package helpers
 
 import (
-	"context"
-	"os/exec"
-	"syscall"
-
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"testing"
 )
 
-func openPath(path string) error {
-	//nolint:gosec // Safe: opens file/URL with system default handler
-	cmd := exec.CommandContext(context.Background(), helpers.ComSpec(), "/c", "start", "", path)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	return cmd.Start() //nolint:wrapcheck // internal helper
+func TestComSpec_UsesComSpecEnvWhenSet(t *testing.T) {
+	want := `D:\custom\cmd.exe`
+	t.Setenv("ComSpec", want)
+	t.Setenv("SystemRoot", `C:\Windows`)
+
+	if got := ComSpec(); got != want {
+		t.Errorf("ComSpec() = %q, want %q", got, want)
+	}
+}
+
+func TestComSpec_FallsBackToSystemRoot(t *testing.T) {
+	t.Setenv("ComSpec", "")
+	t.Setenv("SystemRoot", `C:\Windows`)
+
+	want := `C:\Windows\System32\cmd.exe`
+	if got := ComSpec(); got != want {
+		t.Errorf("ComSpec() = %q, want %q", got, want)
+	}
+}
+
+func TestComSpec_FallsBackToDefault(t *testing.T) {
+	t.Setenv("ComSpec", "")
+	t.Setenv("SystemRoot", "")
+
+	want := `C:\Windows\System32\cmd.exe`
+	if got := ComSpec(); got != want {
+		t.Errorf("ComSpec() = %q, want %q", got, want)
+	}
 }

--- a/pkg/platforms/shared/steam/client_windows.go
+++ b/pkg/platforms/shared/steam/client_windows.go
@@ -27,6 +27,7 @@ import (
 	"os"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/rs/zerolog/log"
@@ -101,7 +102,8 @@ func (c *Client) Launch(
 	// On Windows, we use "cmd /c start <url>" to open Steam URLs
 	// HideWindow prevents a console window from flashing on screen
 	cmdOpts := command.StartOptions{HideWindow: true}
-	if err := c.cmd.StartWithOptions(context.Background(), cmdOpts, "cmd", "/c", "start", steamURL); err != nil {
+	err = c.cmd.StartWithOptions(context.Background(), cmdOpts, helpers.ComSpec(), "/c", "start", steamURL)
+	if err != nil {
 		return nil, fmt.Errorf("failed to start Steam: %w", err)
 	}
 	return nil, nil //nolint:nilnil // Steam launches are fire-and-forget

--- a/pkg/platforms/shared/steam/client_windows_test.go
+++ b/pkg/platforms/shared/steam/client_windows_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/command"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
@@ -91,7 +92,7 @@ func TestClientLaunch(t *testing.T) {
 		mockCmd.ExpectedCalls = nil
 		opts := command.StartOptions{HideWindow: true}
 		args := []string{"/c", "start", "steam://rungameid/730"}
-		mockCmd.On("StartWithOptions", mock.Anything, opts, "cmd", args).Return(nil)
+		mockCmd.On("StartWithOptions", mock.Anything, opts, helpers.ComSpec(), args).Return(nil)
 
 		client := NewClientWithExecutor(Options{}, mockCmd)
 
@@ -108,7 +109,7 @@ func TestClientLaunch(t *testing.T) {
 		mockCmd.ExpectedCalls = nil
 		opts := command.StartOptions{HideWindow: true}
 		args := []string{"/c", "start", "steam://rungameid/730"}
-		mockCmd.On("StartWithOptions", mock.Anything, opts, "cmd", args).Return(nil)
+		mockCmd.On("StartWithOptions", mock.Anything, opts, helpers.ComSpec(), args).Return(nil)
 
 		client := NewClientWithExecutor(Options{}, mockCmd)
 

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -338,7 +338,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 
 				//nolint:gosec // Safe: launches Flashpoint with game ID from internal database
 				cmd := exec.CommandContext(context.Background(),
-					"cmd", "/c",
+					helpers.ComSpec(), "/c",
 					"start",
 					"flashpoint://run/"+id,
 				)
@@ -357,7 +357,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			Launch: func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
 				//nolint:gosec // Safe: opens URL in default browser via cmd start
 				cmd := exec.CommandContext(context.Background(),
-					"cmd", "/c",
+					helpers.ComSpec(), "/c",
 					"start",
 					path,
 				)
@@ -395,11 +395,11 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				// Extensions not in default PATHEXT need START command for proper execution
 				if ext == ".lnk" || ext == ".a3x" || ext == ".ahk" {
 					//nolint:gosec // Safe: executes user-configured allow-listed script
-					cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", "", path)
+					cmd = exec.CommandContext(context.Background(), helpers.ComSpec(), "/c", "start", "", path)
 				} else {
 					// .bat, .cmd work fine with direct execution
 					//nolint:gosec // Safe: executes user-configured allow-listed script
-					cmd = exec.CommandContext(context.Background(), "cmd", "/c", path)
+					cmd = exec.CommandContext(context.Background(), helpers.ComSpec(), "/c", path)
 				}
 				cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 				err := cmd.Start()


### PR DESCRIPTION
- Windows shell-outs invoked the command interpreter by the bare name `"cmd"`, resolved through `%PATH%`. On machines whose `%PATH%` lacks `C:\Windows\System32`, this fails with `executable file not found in %PATH%` or Go's `exec.ErrDot`, so systray menu actions and game launches silently do nothing while the web UI still works.
- Added `helpers.ComSpec()` which resolves `cmd.exe` via `%ComSpec%`, then `%SystemRoot%\System32\cmd.exe`, then a hardcoded default; an absolute path bypasses both `%PATH%` lookup and `exec.ErrDot`.
- Replaced the bare `"cmd"` argument with `helpers.ComSpec()` at every shell-out: systray `openPath`, the Steam launcher, and the Flashpoint, browser, and script launchers.
- The root cause is confirmed from the attached `core.log` on the reporter's machine; end-to-end confirmation on an affected Windows machine is still pending.

Refs #938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Windows command launching to reliably locate the system command interpreter using environment-aware resolution with sensible fallbacks.
* **Bug Fixes**
  * Updated multiple Windows launch paths (including Steam launching and “open path” actions) to use the resolved interpreter instead of a hardcoded value, improving reliability on misconfigured systems.
* **Tests**
  * Added Windows-only tests covering environment-based resolution and fallback behavior for the command interpreter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->