### PR TITLE
feat(mister): add 3S-ARM port as Arcade launchable

### DIFF
--- a/pkg/launchables/ids.go
+++ b/pkg/launchables/ids.go
@@ -33,4 +33,5 @@ var (
 	MisterOtherGenMidi       = uuid.MustParse("91fafc5c-25d1-4356-b5b5-3628573d77b3")
 	MisterOtherSlugCross     = uuid.MustParse("e05893a4-59ee-4919-a3cd-47ff8c5e518d")
 	MisterOtherTomyScramble  = uuid.MustParse("349dfee7-bc32-4004-b377-ff8fe8083836")
+	MisterArcadeThirdStrike  = uuid.MustParse("618433aa-0e8b-4230-800e-ec33758affb7")
 )

--- a/pkg/platforms/mister/launchables.go
+++ b/pkg/platforms/mister/launchables.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
@@ -83,6 +84,16 @@ func (p *Platform) Launchables(*config.Instance) []launchables.Launchable {
 			Category: misterLaunchableCategoryOther,
 			Launch:   p.launchOtherCore(filepath.Join("_Other", "TomyScramble")),
 			Test:     testOtherCore("TomyScramble"),
+		},
+		// 3S-ARM is a native ARM port of Street Fighter III: 3rd Strike that
+		// ships as an _Other core but is a real arcade game, so it is exposed
+		// as virtual media under the Arcade system rather than an Other entry.
+		launchables.VirtualMedia{
+			ID:       launchables.MisterArcadeThirdStrike,
+			Name:     "Street Fighter III: 3rd Strike (3S-ARM)",
+			SystemID: systemdefs.SystemArcade,
+			Launch:   p.launchOtherCore(filepath.Join("_Other", "3S-ARM")),
+			Test:     testOtherCore("3S-ARM"),
 		},
 	}
 }

--- a/pkg/platforms/mister/launchables_test.go
+++ b/pkg/platforms/mister/launchables_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,16 +18,25 @@ import (
 func TestLaunchablesOtherCoreDefinitions(t *testing.T) {
 	items := (&Platform{}).Launchables(&config.Instance{})
 
-	require.Len(t, items, 9)
-	seen := make(map[string]bool, len(items))
+	require.Len(t, items, 10)
+	seenSystems := make(map[string]bool, len(items))
+	seenMedia := make(map[string]launchables.VirtualMedia, len(items))
 	for _, item := range items {
-		system, ok := item.(launchables.VirtualSystem)
-		require.True(t, ok)
-		assert.Equal(t, "Other", system.Category)
-		assert.NotNil(t, system.Launch)
-		assert.NotNil(t, system.Test)
-		assert.NotEmpty(t, system.ZapScript())
-		seen[system.Name] = true
+		switch entry := item.(type) {
+		case launchables.VirtualSystem:
+			assert.Equal(t, "Other", entry.Category)
+			assert.NotNil(t, entry.Launch)
+			assert.NotNil(t, entry.Test)
+			assert.NotEmpty(t, entry.ZapScript())
+			seenSystems[entry.Name] = true
+		case launchables.VirtualMedia:
+			assert.NotNil(t, entry.Launch)
+			assert.NotNil(t, entry.Test)
+			assert.NotEmpty(t, entry.ZapScript())
+			seenMedia[entry.Name] = entry
+		default:
+			t.Fatalf("unexpected launchable type %T", item)
+		}
 	}
 
 	for _, name := range []string{
@@ -40,8 +50,12 @@ func TestLaunchablesOtherCoreDefinitions(t *testing.T) {
 		"Slug Cross",
 		"Tomy Scramble",
 	} {
-		assert.True(t, seen[name], name)
+		assert.True(t, seenSystems[name], name)
 	}
+
+	thirdStrike, ok := seenMedia["Street Fighter III: 3rd Strike (3S-ARM)"]
+	require.True(t, ok, "3S-ARM virtual media missing")
+	assert.Equal(t, systemdefs.SystemArcade, thirdStrike.SystemID)
 }
 
 func TestLaunchOtherCoreUsesInjectedLauncher(t *testing.T) {
@@ -93,7 +107,9 @@ func TestOtherCoreExists(t *testing.T) {
 	otherDir := filepath.Join(rootDir, "_Other")
 	require.NoError(t, os.MkdirAll(otherDir, 0o750))
 	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "Chess_20240410.rbf"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(otherDir, "3S-ARM.rbf"), nil, 0o600))
 
 	assert.True(t, otherCoreExists(rootDir, "Chess"))
+	assert.True(t, otherCoreExists(rootDir, "3S-ARM"))
 	assert.False(t, otherCoreExists(rootDir, "Donut"))
 }


### PR DESCRIPTION
- Expose the 3S-ARM port (a native ARM port of Street Fighter III: 3rd Strike that ships as a MiSTer `_Other` core) as a `launchables.VirtualMedia` under the Arcade system, so it appears as a searchable, runnable arcade title in the frontend rather than a generic Other entry.
- Reuse the existing `_Other` short-core launch path (`launchOtherCore`) and availability check (`testOtherCore`), so the entry only appears when `_Other/3S-ARM*.rbf` is installed.
- Add a stable launchable UUID and update the MiSTer launchables tests to cover the mixed virtual system/media set and the hyphenated `3S-ARM` core name.

Closes #959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Street Fighter III: 3rd Strike (3S-ARM) arcade game with full platform integration and system identification.

* **Tests**
  * Updated test suite to validate the new arcade game functionality, including core existence verification and system identifier checks for proper platform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->