### PR TITLE
feat(mister): add GameGear2P core and fix NGP/NGPC handheld categories

### DIFF
--- a/pkg/assets/systems/GameGear2P.json
+++ b/pkg/assets/systems/GameGear2P.json
@@ -1,0 +1,7 @@
+{
+  "id": "GameGear2P",
+  "name": "Game Gear (2 Player)",
+  "category": "Handheld",
+  "releaseDate": "1990-10-06",
+  "manufacturer": "Sega"
+}

--- a/pkg/assets/systems/NeoGeoPocket.json
+++ b/pkg/assets/systems/NeoGeoPocket.json
@@ -1,7 +1,7 @@
 {
   "id": "NeoGeoPocket",
   "name": "Neo Geo Pocket",
-  "category": "Console",
+  "category": "Handheld",
   "releaseDate": "",
   "manufacturer": ""
 }

--- a/pkg/assets/systems/NeoGeoPocketColor.json
+++ b/pkg/assets/systems/NeoGeoPocketColor.json
@@ -1,7 +1,7 @@
 {
   "id": "NeoGeoPocketColor",
   "name": "Neo Geo Pocket Color",
-  "category": "Console",
+  "category": "Handheld",
   "releaseDate": "",
   "manufacturer": ""
 }

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -263,6 +263,7 @@ const (
 	SystemGameboy2P         = "Gameboy2P"
 	SystemGameCube          = "GameCube"
 	SystemGameGear          = "GameGear"
+	SystemGameGear2P        = "GameGear2P"
 	SystemGameNWatch        = "GameNWatch"
 	SystemGameCom           = "GameCom"
 	SystemGBA               = "GBA"
@@ -559,6 +560,9 @@ var Systems = map[string]System{
 		ID:      SystemGameGear,
 		Aliases: []string{"GG"},
 		Slugs:   []string{"segagamegear"},
+	},
+	SystemGameGear2P: {
+		ID: SystemGameGear2P,
 	},
 	SystemGameNWatch: {
 		ID:    SystemGameNWatch,

--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -417,6 +417,21 @@ var Systems = map[string]Core{
 			},
 		},
 	},
+	"GameGear2P": {
+		ID:      "GameGear2P",
+		SetName: "GameGear2P",
+		RBF:     "_Console/GameGear2P",
+		Slots: []Slot{
+			{
+				Exts: []string{".gg"},
+				Mgl: &MGLParams{
+					Delay:  1,
+					Method: "f",
+					Index:  2,
+				},
+			},
+		},
+	},
 	"GameNWatch": {
 		ID:  "GameNWatch",
 		RBF: "_Console/GnW",

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -1177,6 +1177,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemGameGear),
 		},
 		{
+			ID:         systemdefs.SystemGameGear2P,
+			SystemID:   systemdefs.SystemGameGear2P,
+			Folders:    []string{"GameGear2P"},
+			Extensions: []string{".gg"},
+			Launch:     launch(pl, systemdefs.SystemGameGear2P),
+		},
+		{
 			ID:         systemdefs.SystemGameNWatch,
 			SystemID:   systemdefs.SystemGameNWatch,
 			Folders:    []string{"GameNWatch"},


### PR DESCRIPTION
- Recategorize Neo Geo Pocket and Neo Geo Pocket Color from `Console` to `Handheld` in their system metadata, matching other handhelds.
- Add `GameGear2P` as a new MiSTer system (systemdef, metadata JSON, core entry, and launcher), modeled on the existing `Gameboy2P` system. It uses the dedicated `_Console/GameGear2P` RBF and scans the `GameGear2P` folder for `.gg` files.

Closes #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Game Gear 2-player gaming mode with complete system support, including system configuration, emulator setup, and launcher functionality.

* **Bug Fixes**
  * Corrected system categorization for Neo Geo Pocket and Neo Geo Pocket Color to properly reflect their handheld device classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->