### PR TITLE
fix(steam): read VDF numbers with io.ReadFull to avoid short reads

### DIFF
--- a/internal/vdfbinary/shortcuts.go
+++ b/internal/vdfbinary/shortcuts.go
@@ -7,6 +7,7 @@ package vdfbinary
 import (
 	"errors"
 	"io"
+	"sort"
 	"strconv"
 )
 
@@ -36,15 +37,23 @@ func ParseShortcuts(buf io.Reader) ([]Shortcut, error) {
 		return []Shortcut{}, errors.New("could not find 'shortcuts' in parsed vdf")
 	}
 
-	shortcuts := make([]Shortcut, len(shortcutsMap))
-
-	for i := range shortcuts {
-		key := strconv.Itoa(i)
-
-		s, ok := shortcutsMap[key]
-		if !ok {
-			return []Shortcut{}, errors.New("vdf that should be an array does not have the corresponding index")
+	// Collect the numeric indices actually present and sort them, rather than
+	// assuming a contiguous 0..N-1 sequence — third-party tools (EmuDeck,
+	// Lutris) can leave gaps or non-numeric keys.
+	indices := make([]int, 0, len(shortcutsMap))
+	for k := range shortcutsMap {
+		idx, err := strconv.Atoi(k)
+		if err != nil {
+			continue // skip non-numeric keys defensively
 		}
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+
+	shortcuts := make([]Shortcut, 0, len(indices))
+
+	for _, idx := range indices {
+		s := shortcutsMap[strconv.Itoa(idx)]
 
 		appID, ok := s.GetUint("appid")
 		if !ok {
@@ -89,7 +98,7 @@ func ParseShortcuts(buf io.Reader) ([]Shortcut, error) {
 			}
 		}
 
-		shortcuts[i] = Shortcut{
+		shortcuts = append(shortcuts, Shortcut{
 			AppID:    appID,
 			AppName:  appName,
 			Exe:      exe,
@@ -97,7 +106,7 @@ func ParseShortcuts(buf io.Reader) ([]Shortcut, error) {
 			IsHidden: isHidden,
 			StartDir: startDir,
 			Tags:     tags,
-		}
+		})
 	}
 
 	return shortcuts, nil

--- a/internal/vdfbinary/shortcuts.go
+++ b/internal/vdfbinary/shortcuts.go
@@ -37,23 +37,27 @@ func ParseShortcuts(buf io.Reader) ([]Shortcut, error) {
 		return []Shortcut{}, errors.New("could not find 'shortcuts' in parsed vdf")
 	}
 
-	// Collect the numeric indices actually present and sort them, rather than
-	// assuming a contiguous 0..N-1 sequence — third-party tools (EmuDeck,
-	// Lutris) can leave gaps or non-numeric keys.
-	indices := make([]int, 0, len(shortcutsMap))
+	// Collect the keys actually present and sort them by numeric value, rather
+	// than assuming a contiguous 0..N-1 sequence — third-party tools (EmuDeck,
+	// Lutris) can leave gaps or non-numeric keys. The original key strings are
+	// preserved for lookup so non-canonical numeric keys (e.g. "01") still match.
+	keys := make([]string, 0, len(shortcutsMap))
 	for k := range shortcutsMap {
-		idx, err := strconv.Atoi(k)
-		if err != nil {
+		if _, err := strconv.Atoi(k); err != nil {
 			continue // skip non-numeric keys defensively
 		}
-		indices = append(indices, idx)
+		keys = append(keys, k)
 	}
-	sort.Ints(indices)
+	sort.Slice(keys, func(i, j int) bool {
+		a, _ := strconv.Atoi(keys[i])
+		b, _ := strconv.Atoi(keys[j])
+		return a < b
+	})
 
-	shortcuts := make([]Shortcut, 0, len(indices))
+	shortcuts := make([]Shortcut, 0, len(keys))
 
-	for _, idx := range indices {
-		s := shortcutsMap[strconv.Itoa(idx)]
+	for _, key := range keys {
+		s := shortcutsMap[key]
 
 		appID, ok := s.GetUint("appid")
 		if !ok {

--- a/internal/vdfbinary/shortcuts_test.go
+++ b/internal/vdfbinary/shortcuts_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"encoding/binary"
+	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -14,6 +15,14 @@ import (
 
 //go:embed testdata/shortcuts.vdf
 var shortcutVdf []byte
+
+// Synthetic fixtures build path-like VDF field values with filepath.Join rather
+// than hardcoded POSIX literals, per repo guidelines. The values are opaque
+// round-tripped field contents, so relative components are sufficient.
+var (
+	testExe      = filepath.Join("path", "to", "game")
+	testStartDir = filepath.Join("path", "to")
+)
 
 func TestParseShortcuts(t *testing.T) {
 	t.Parallel()
@@ -104,18 +113,18 @@ func TestParseShortcuts_MissingOptionalFields(t *testing.T) {
 	buf.WriteByte(0x00)          //nolint:revive // never fails
 
 	// Exe (string)
-	buf.WriteByte(0x01)              //nolint:revive // never fails
-	buf.WriteString("Exe")           //nolint:revive // never fails
-	buf.WriteByte(0x00)              //nolint:revive // never fails
-	buf.WriteString("/path/to/game") //nolint:revive // never fails
-	buf.WriteByte(0x00)              //nolint:revive // never fails
+	buf.WriteByte(0x01)      //nolint:revive // never fails
+	buf.WriteString("Exe")   //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
+	buf.WriteString(testExe) //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
 
 	// StartDir (string)
-	buf.WriteByte(0x01)         //nolint:revive // never fails
-	buf.WriteString("StartDir") //nolint:revive // never fails
-	buf.WriteByte(0x00)         //nolint:revive // never fails
-	buf.WriteString("/path/to") //nolint:revive // never fails
-	buf.WriteByte(0x00)         //nolint:revive // never fails
+	buf.WriteByte(0x01)           //nolint:revive // never fails
+	buf.WriteString("StartDir")   //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
+	buf.WriteString(testStartDir) //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
 
 	// Note: deliberately missing icon, IsHidden, and tags
 
@@ -134,8 +143,8 @@ func TestParseShortcuts_MissingOptionalFields(t *testing.T) {
 
 	assert.Equal(t, uint32(0x04030201), shortcuts[0].AppID)
 	assert.Equal(t, "Test Game", shortcuts[0].AppName)
-	assert.Equal(t, "/path/to/game", shortcuts[0].Exe)
-	assert.Equal(t, "/path/to", shortcuts[0].StartDir)
+	assert.Equal(t, testExe, shortcuts[0].Exe)
+	assert.Equal(t, testStartDir, shortcuts[0].StartDir)
 	assert.Empty(t, shortcuts[0].Icon, "missing icon should default to empty string")
 	assert.False(t, shortcuts[0].IsHidden, "missing IsHidden should default to false")
 	assert.Empty(t, shortcuts[0].Tags, "missing tags should default to empty slice")
@@ -192,7 +201,7 @@ func TestParseShortcuts_MissingRequiredField_AppName(t *testing.T) {
 	buf.WriteByte(0x01)      //nolint:revive // never fails
 	buf.WriteString("Exe")   //nolint:revive // never fails
 	buf.WriteByte(0x00)      //nolint:revive // never fails
-	buf.WriteString("/path") //nolint:revive // never fails
+	buf.WriteString(testExe) //nolint:revive // never fails
 	buf.WriteByte(0x00)      //nolint:revive // never fails
 
 	buf.WriteByte(0x08) //nolint:revive // never fails
@@ -228,11 +237,11 @@ func TestParseShortcuts_MissingRequiredField_Exe(t *testing.T) {
 	buf.WriteByte(0x00)        //nolint:revive // never fails
 
 	// Missing Exe, only StartDir
-	buf.WriteByte(0x01)         //nolint:revive // never fails
-	buf.WriteString("StartDir") //nolint:revive // never fails
-	buf.WriteByte(0x00)         //nolint:revive // never fails
-	buf.WriteString("/path")    //nolint:revive // never fails
-	buf.WriteByte(0x00)         //nolint:revive // never fails
+	buf.WriteByte(0x01)           //nolint:revive // never fails
+	buf.WriteString("StartDir")   //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
+	buf.WriteString(testStartDir) //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
 
 	buf.WriteByte(0x08) //nolint:revive // never fails
 	buf.WriteByte(0x08) //nolint:revive // never fails
@@ -266,11 +275,11 @@ func TestParseShortcuts_MissingRequiredField_StartDir(t *testing.T) {
 	buf.WriteString("Test")    //nolint:revive // never fails
 	buf.WriteByte(0x00)        //nolint:revive // never fails
 
-	buf.WriteByte(0x01)             //nolint:revive // never fails
-	buf.WriteString("Exe")          //nolint:revive // never fails
-	buf.WriteByte(0x00)             //nolint:revive // never fails
-	buf.WriteString("/path/to/exe") //nolint:revive // never fails
-	buf.WriteByte(0x00)             //nolint:revive // never fails
+	buf.WriteByte(0x01)                                 //nolint:revive // never fails
+	buf.WriteString("Exe")                              //nolint:revive // never fails
+	buf.WriteByte(0x00)                                 //nolint:revive // never fails
+	buf.WriteString(filepath.Join("path", "to", "exe")) //nolint:revive // never fails
+	buf.WriteByte(0x00)                                 //nolint:revive // never fails
 
 	// Missing StartDir
 	buf.WriteByte(0x08) //nolint:revive // never fails
@@ -374,6 +383,27 @@ func TestParseShortcuts_NonNumericKeySkipped(t *testing.T) {
 	assert.Equal(t, "Real", shortcuts[0].AppName)
 }
 
+func TestParseShortcuts_NonCanonicalNumericKey(t *testing.T) {
+	t.Parallel()
+
+	// A key like "01" parses to index 1 but is not its own canonical decimal
+	// form. Lookups must use the original key string, otherwise the entry is
+	// missed and a nil dereference panics.
+	var buf bytes.Buffer
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	buf.WriteString("shortcuts") //nolint:revive // never fails
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	writeEntry(&buf, "01", 42, "Padded Index")
+	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end root)
+
+	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, shortcuts, 1)
+	assert.Equal(t, uint32(42), shortcuts[0].AppID)
+	assert.Equal(t, "Padded Index", shortcuts[0].AppName)
+}
+
 // TestParseShortcuts_NumberAcrossBufferBoundary is the regression test for the
 // intermittent, size-dependent parse failures: a 4-byte number value whose bytes
 // straddle a 4096-byte bufio refill boundary previously caused a short read and
@@ -442,8 +472,8 @@ func writeEntry(buf *bytes.Buffer, key string, appID uint32, name string) {
 	buf.Write(idb) //nolint:revive // never fails
 
 	writeStr(buf, "AppName", name)
-	writeStr(buf, "Exe", "/path/to/game")
-	writeStr(buf, "StartDir", "/path/to")
+	writeStr(buf, "Exe", testExe)
+	writeStr(buf, "StartDir", testStartDir)
 
 	buf.WriteByte(0x08) //nolint:revive // never fails (end entry)
 }
@@ -479,8 +509,8 @@ func buildVDFWithAppIDAt(valueStart int, appID uint32) []byte {
 	buf.Write(idb) //nolint:revive // never fails
 
 	writeStr(&buf, "AppName", "Boundary Game")
-	writeStr(&buf, "Exe", "/path/to/game")
-	writeStr(&buf, "StartDir", "/path/to")
+	writeStr(&buf, "Exe", testExe)
+	writeStr(&buf, "StartDir", testStartDir)
 
 	buf.WriteByte(0x08) //nolint:revive // never fails (end entry)
 	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
@@ -518,18 +548,18 @@ func buildShortcutVDF(appNameKey, exeKey, startDirKey string) []byte {
 	buf.WriteByte(0x00)               //nolint:revive // never fails
 
 	// Exe (string) - key name varies
-	buf.WriteByte(0x01)              //nolint:revive // never fails
-	buf.WriteString(exeKey)          //nolint:revive // never fails
-	buf.WriteByte(0x00)              //nolint:revive // never fails
-	buf.WriteString("/path/to/game") //nolint:revive // never fails
-	buf.WriteByte(0x00)              //nolint:revive // never fails
+	buf.WriteByte(0x01)      //nolint:revive // never fails
+	buf.WriteString(exeKey)  //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
+	buf.WriteString(testExe) //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
 
 	// StartDir (string) - key name varies
-	buf.WriteByte(0x01)          //nolint:revive // never fails
-	buf.WriteString(startDirKey) //nolint:revive // never fails
-	buf.WriteByte(0x00)          //nolint:revive // never fails
-	buf.WriteString("/path/to")  //nolint:revive // never fails
-	buf.WriteByte(0x00)          //nolint:revive // never fails
+	buf.WriteByte(0x01)           //nolint:revive // never fails
+	buf.WriteString(startDirKey)  //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
+	buf.WriteString(testStartDir) //nolint:revive // never fails
+	buf.WriteByte(0x00)           //nolint:revive // never fails
 
 	buf.WriteByte(0x08) //nolint:revive // never fails
 	buf.WriteByte(0x08) //nolint:revive // never fails
@@ -548,8 +578,8 @@ func TestParseShortcuts_CaseInsensitiveKeys(t *testing.T) {
 	require.NoError(t, err, "should parse shortcuts with all-lowercase keys")
 	require.Len(t, shortcuts, 1)
 	assert.Equal(t, "Case Test Game", shortcuts[0].AppName)
-	assert.Equal(t, "/path/to/game", shortcuts[0].Exe)
-	assert.Equal(t, "/path/to", shortcuts[0].StartDir)
+	assert.Equal(t, testExe, shortcuts[0].Exe)
+	assert.Equal(t, testStartDir, shortcuts[0].StartDir)
 }
 
 func TestParseShortcuts_MixedCaseKeys(t *testing.T) {
@@ -562,6 +592,6 @@ func TestParseShortcuts_MixedCaseKeys(t *testing.T) {
 	require.NoError(t, err, "should parse shortcuts with unusual mixed-case keys")
 	require.Len(t, shortcuts, 1)
 	assert.Equal(t, "Case Test Game", shortcuts[0].AppName)
-	assert.Equal(t, "/path/to/game", shortcuts[0].Exe)
-	assert.Equal(t, "/path/to", shortcuts[0].StartDir)
+	assert.Equal(t, testExe, shortcuts[0].Exe)
+	assert.Equal(t, testStartDir, shortcuts[0].StartDir)
 }

--- a/internal/vdfbinary/shortcuts_test.go
+++ b/internal/vdfbinary/shortcuts_test.go
@@ -3,6 +3,8 @@ package vdfbinary_test
 import (
 	"bytes"
 	_ "embed"
+	"encoding/binary"
+	"strconv"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/internal/vdfbinary"
@@ -314,28 +316,90 @@ func TestParseShortcuts_CorruptedFile(t *testing.T) {
 func TestParseShortcuts_NonSequentialIndex(t *testing.T) {
 	t.Parallel()
 
-	// shortcuts { 1 { ... } } - starts at 1 instead of 0
+	// shortcuts { 1 { ... } } - starts at 1 instead of 0. Third-party tools can
+	// leave non-zero starting indices; this should parse rather than error.
 	var buf bytes.Buffer
 	buf.WriteByte(0x00)          //nolint:revive // never fails
 	buf.WriteString("shortcuts") //nolint:revive // never fails
 	buf.WriteByte(0x00)          //nolint:revive // never fails
+	writeEntry(&buf, "1", 0x04030201, "Only Game")
+	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end root)
 
-	buf.WriteByte(0x00)  //nolint:revive // never fails
-	buf.WriteString("1") //nolint:revive // never fails
-	buf.WriteByte(0x00)  //nolint:revive // never fails
+	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, shortcuts, 1)
+	assert.Equal(t, uint32(0x04030201), shortcuts[0].AppID)
+	assert.Equal(t, "Only Game", shortcuts[0].AppName)
+}
 
-	buf.WriteByte(0x02)                       //nolint:revive // never fails
-	buf.WriteString("appid")                  //nolint:revive // never fails
-	buf.WriteByte(0x00)                       //nolint:revive // never fails
-	buf.Write([]byte{0x01, 0x00, 0x00, 0x00}) //nolint:revive // never fails
+func TestParseShortcuts_GappedIndices(t *testing.T) {
+	t.Parallel()
 
-	buf.WriteByte(0x08) //nolint:revive // never fails
-	buf.WriteByte(0x08) //nolint:revive // never fails
-	buf.WriteByte(0x08) //nolint:revive // never fails
+	// shortcuts { 0 {...} 2 {...} } - a gap where index 1 was deleted. Both
+	// present entries should parse, in ascending index order.
+	var buf bytes.Buffer
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	buf.WriteString("shortcuts") //nolint:revive // never fails
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	writeEntry(&buf, "0", 100, "First")
+	writeEntry(&buf, "2", 300, "Third")
+	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end root)
 
-	_, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "index")
+	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, shortcuts, 2)
+	assert.Equal(t, "First", shortcuts[0].AppName)
+	assert.Equal(t, "Third", shortcuts[1].AppName)
+}
+
+func TestParseShortcuts_NonNumericKeySkipped(t *testing.T) {
+	t.Parallel()
+
+	// shortcuts { 0 {...} junk {...} } - a non-numeric key should be skipped,
+	// not fail the whole file.
+	var buf bytes.Buffer
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	buf.WriteString("shortcuts") //nolint:revive // never fails
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	writeEntry(&buf, "0", 100, "Real")
+	writeEntry(&buf, "junk", 999, "Ignored")
+	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end root)
+
+	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.Len(t, shortcuts, 1)
+	assert.Equal(t, "Real", shortcuts[0].AppName)
+}
+
+// TestParseShortcuts_NumberAcrossBufferBoundary is the regression test for the
+// intermittent, size-dependent parse failures: a 4-byte number value whose bytes
+// straddle a 4096-byte bufio refill boundary previously caused a short read and
+// failed the whole file ("number did not have the required amount of bytes").
+func TestParseShortcuts_NumberAcrossBufferBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Straddle positions for the 4096 and 8192 boundaries: a value starting at
+	// these offsets crosses the boundary part-way through its 4 bytes.
+	for _, valueStart := range []int{4093, 4094, 4095, 8189, 8190, 8191} {
+		t.Run(strconv.Itoa(valueStart), func(t *testing.T) {
+			t.Parallel()
+
+			data := buildVDFWithAppIDAt(valueStart, 0xDEADBEEF)
+
+			// Sanity-check the construction actually straddles a boundary.
+			require.NotEqual(t, valueStart/4096, (valueStart+3)/4096,
+				"test fixture should straddle a 4096 boundary")
+
+			shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(data))
+			require.NoError(t, err)
+			require.Len(t, shortcuts, 1)
+			assert.Equal(t, uint32(0xDEADBEEF), shortcuts[0].AppID)
+			assert.Equal(t, "Boundary Game", shortcuts[0].AppName)
+		})
+	}
 }
 
 func TestParseShortcuts_EmptyShortcutsMap(t *testing.T) {
@@ -352,6 +416,77 @@ func TestParseShortcuts_EmptyShortcutsMap(t *testing.T) {
 	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(buf.Bytes()))
 	require.NoError(t, err)
 	assert.Empty(t, shortcuts)
+}
+
+// writeStr writes a string field (marker 0x01, null-terminated key and value).
+func writeStr(buf *bytes.Buffer, key, val string) {
+	buf.WriteByte(0x01)  //nolint:revive // never fails
+	buf.WriteString(key) //nolint:revive // never fails
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+	buf.WriteString(val) //nolint:revive // never fails
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+}
+
+// writeEntry writes one shortcut entry map (appid, AppName, Exe, StartDir) keyed
+// by the given index string.
+func writeEntry(buf *bytes.Buffer, key string, appID uint32, name string) {
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+	buf.WriteString(key) //nolint:revive // never fails
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+
+	buf.WriteByte(0x02)      //nolint:revive // never fails
+	buf.WriteString("appid") //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
+	idb := make([]byte, 4)
+	binary.LittleEndian.PutUint32(idb, appID)
+	buf.Write(idb) //nolint:revive // never fails
+
+	writeStr(buf, "AppName", name)
+	writeStr(buf, "Exe", "/path/to/game")
+	writeStr(buf, "StartDir", "/path/to")
+
+	buf.WriteByte(0x08) //nolint:revive // never fails (end entry)
+}
+
+// buildVDFWithAppIDAt builds a single-shortcut binary VDF where the appid's
+// 4-byte value begins exactly at file offset valueStart, by padding a filler
+// string field. Used to place a number value across a bufio refill boundary.
+func buildVDFWithAppIDAt(valueStart int, appID uint32) []byte {
+	var buf bytes.Buffer
+
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+	buf.WriteString("shortcuts") //nolint:revive // never fails
+	buf.WriteByte(0x00)          //nolint:revive // never fails
+
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+	buf.WriteString("0") //nolint:revive // never fails
+	buf.WriteByte(0x00)  //nolint:revive // never fails
+
+	// filler string field sized so the appid value lands at valueStart.
+	// bytes before value = 11 (header) + 3 (entry) + (9 + pad) (filler) + 7 (appid field)
+	pad := valueStart - 30
+	buf.WriteByte(0x01)                       //nolint:revive // never fails
+	buf.WriteString("filler")                 //nolint:revive // never fails
+	buf.WriteByte(0x00)                       //nolint:revive // never fails
+	buf.Write(bytes.Repeat([]byte{'A'}, pad)) //nolint:revive // never fails
+	buf.WriteByte(0x00)                       //nolint:revive // never fails
+
+	buf.WriteByte(0x02)      //nolint:revive // never fails
+	buf.WriteString("appid") //nolint:revive // never fails
+	buf.WriteByte(0x00)      //nolint:revive // never fails
+	idb := make([]byte, 4)
+	binary.LittleEndian.PutUint32(idb, appID)
+	buf.Write(idb) //nolint:revive // never fails
+
+	writeStr(&buf, "AppName", "Boundary Game")
+	writeStr(&buf, "Exe", "/path/to/game")
+	writeStr(&buf, "StartDir", "/path/to")
+
+	buf.WriteByte(0x08) //nolint:revive // never fails (end entry)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end shortcuts)
+	buf.WriteByte(0x08) //nolint:revive // never fails (end root)
+
+	return buf.Bytes()
 }
 
 // buildShortcutVDF builds a binary VDF with a single shortcut using the given key names.

--- a/internal/vdfbinary/vdf.go
+++ b/internal/vdfbinary/vdf.go
@@ -85,13 +85,14 @@ func parseMap(buf *bufio.Reader) (vdfValue, error) {
 func parseNumber(buf *bufio.Reader) (vdfValue, error) {
 	bf := make([]byte, 4)
 
-	l, err := buf.Read(bf)
-	if err != nil {
+	// io.ReadFull, not buf.Read: bufio.Reader.Read returns only the bytes
+	// currently buffered, so a 4-byte number straddling a buffer-refill
+	// boundary would otherwise produce a short read and fail parsing.
+	if _, err := io.ReadFull(buf, bf); err != nil {
+		if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) {
+			return vdfValue{}, ErrCorruptedVDF
+		}
 		return vdfValue{}, fmt.Errorf("read number error: %w", err)
-	}
-
-	if l != len(bf) {
-		return vdfValue{}, errors.New("number did not have the required amount of bytes")
 	}
 
 	number := binary.LittleEndian.Uint32(bf)


### PR DESCRIPTION
- Fix intermittent `shortcuts.vdf` parse failures: `parseNumber` read 4-byte integers with `bufio.Reader.Read`, which returns only the currently-buffered bytes, so a number value straddling a 4096-byte buffer-refill boundary caused a short read that failed the entire file. Switched to `io.ReadFull`, which reads exactly 4 bytes across refills.
- This is why the failure looked size/count dependent but wasn't a real limit — whether a number field lands on a boundary depends on the exact byte layout, which shifts as non-Steam games are added, removed, or renamed.
- Harden `ParseShortcuts` to iterate the shortcut indices actually present (sorted) and skip non-numeric keys, instead of assuming a contiguous `0..N-1` sequence that third-party tools (EmuDeck/Lutris) can break.
- Add a boundary-straddle regression test (verified to fail without the fix) plus tests for gapped indices and non-numeric keys.

Refs #725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortcut parsing to handle non-sequential, gapped indices while returning results in ascending index order.
  * Non-numeric shortcut keys are now safely ignored instead of causing parse failures.
  * Improved VDF number parsing to reliably read 4-byte values across buffer boundaries, with clearer corruption handling on unexpected EOF.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->