### PR TITLE
fix: Sentry issue sweep — downgrade expected-error noise, fix real bugs

### DIFF
--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -88,11 +88,20 @@ func isRunning() bool {
 		nil, false,
 		syswindows.StringToUTF16Ptr("MUTEX: Zaparoo Core"),
 	)
-	if err != nil {
-		log.Fatal().Err(err).Msg("error creating mutex")
+	// When another instance already holds the named mutex, CreateMutex reports
+	// ERROR_ALREADY_EXISTS. That is the "already running" signal we want — not a
+	// failure. Treating it as fatal crashed the second launch instead of exiting
+	// cleanly.
+	if errors.Is(err, syswindows.ERROR_ALREADY_EXISTS) {
+		return true
 	}
-	lastError := syswindows.GetLastError()
-	return errors.Is(lastError, syswindows.ERROR_ALREADY_EXISTS)
+	if err != nil {
+		// A genuine mutex-creation failure shouldn't prevent startup; log it and
+		// assume no other instance is running.
+		log.Error().Err(err).Msg("error creating single-instance mutex")
+		return false
+	}
+	return false
 }
 
 func main() {

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -262,7 +262,7 @@ func WaitNotification(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				if ctx.Err() != nil || errors.Is(readErr, net.ErrClosed) {
+				if ctx.Err() != nil || isExpectedWebsocketClose(readErr) {
 					log.Debug().Err(readErr).Msg("connection closed")
 				} else {
 					log.Error().Err(readErr).Msg("error reading message")

--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -44,6 +44,20 @@ var (
 
 const APIPath = "/api/v0.1"
 
+// isExpectedWebsocketClose reports whether a websocket read error is an expected
+// disconnect (the connection closed, the peer went away, or an abnormal closure
+// such as the service restarting) rather than a genuine protocol/read fault.
+// Expected disconnects are logged below Error level to keep them out of Sentry.
+func isExpectedWebsocketClose(err error) bool {
+	return errors.Is(err, net.ErrClosed) ||
+		websocket.IsCloseError(err,
+			websocket.CloseNormalClosure,
+			websocket.CloseGoingAway,
+			websocket.CloseNoStatusReceived,
+			websocket.CloseAbnormalClosure,
+		)
+}
+
 // DisableZapScript disables the service running any processed ZapScript from
 // tokens, and returns a function to re-enable it.
 // The returned function must be run even if there is an error so the service
@@ -134,7 +148,7 @@ func LocalClient(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				if ctx.Err() != nil || errors.Is(readErr, net.ErrClosed) {
+				if ctx.Err() != nil || isExpectedWebsocketClose(readErr) {
 					log.Debug().Err(readErr).Msg("connection closed")
 				} else {
 					log.Error().Err(readErr).Msg("error reading message")
@@ -405,12 +419,7 @@ func WaitNotifications(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				if errors.Is(readErr, net.ErrClosed) ||
-					websocket.IsCloseError(readErr,
-						websocket.CloseNormalClosure,
-						websocket.CloseGoingAway,
-						websocket.CloseNoStatusReceived,
-					) {
+				if isExpectedWebsocketClose(readErr) {
 					log.Warn().Err(readErr).Msg("websocket closed")
 				} else {
 					log.Error().Err(readErr).Msg("error reading message")

--- a/pkg/api/client/client_test.go
+++ b/pkg/api/client/client_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -856,4 +857,47 @@ func TestWaitForAPI_Timeout(t *testing.T) {
 
 	assert.False(t, result)
 	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond)
+}
+
+// TestIsExpectedWebsocketClose verifies that expected disconnects (including the
+// 1006 abnormal closure that was flooding Sentry) are classified for below-Error
+// logging, while genuine read faults are not.
+func TestIsExpectedWebsocketClose(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+	}{
+		{name: "net closed", err: net.ErrClosed, expected: true},
+		{
+			name:     "abnormal closure 1006",
+			err:      &websocket.CloseError{Code: websocket.CloseAbnormalClosure, Text: "unexpected EOF"},
+			expected: true,
+		},
+		{
+			name:     "normal closure",
+			err:      &websocket.CloseError{Code: websocket.CloseNormalClosure},
+			expected: true,
+		},
+		{
+			name:     "going away",
+			err:      &websocket.CloseError{Code: websocket.CloseGoingAway},
+			expected: true,
+		},
+		{
+			name:     "protocol error stays visible",
+			err:      &websocket.CloseError{Code: websocket.CloseProtocolError},
+			expected: false,
+		},
+		{name: "generic error", err: errors.New("boom"), expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isExpectedWebsocketClose(tt.err))
+		})
+	}
 }

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -20,8 +20,10 @@
 package methods
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -108,6 +110,18 @@ func logBrowseTiming(operation, path string, started time.Time, rows int) {
 func HandleMediaBrowse(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Debug().Msg("received media browse request")
 
+	result, err := browseMedia(env)
+	if err != nil && errors.Is(err, context.Canceled) {
+		// The client navigated away or cancelled the request mid-browse. This is
+		// expected and high-volume, so log at Debug to keep it out of Sentry.
+		// context.DeadlineExceeded is intentionally NOT downgraded here — a browse
+		// timeout may signal a real performance regression worth seeing.
+		return nil, fmt.Errorf("%w", models.QuietClientErr(err))
+	}
+	return result, err
+}
+
+func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	select {
 	case browseSem <- struct{}{}:
 		defer func() { <-browseSem }()

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -1844,3 +1844,28 @@ func TestSchemeDisplayName(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleMediaBrowseCancelledIsQuiet verifies that a browse request cancelled
+// by the client is returned as a QuietClientError (logged at Debug, kept out of
+// Sentry) rather than a plain error (logged at Error).
+func TestHandleMediaBrowseCancelledIsQuiet(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+	mockMediaDB := helpers.NewMockMediaDBI()
+
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	env.Context = ctx
+
+	result, err := HandleMediaBrowse(env)
+	assert.Nil(t, result)
+	require.Error(t, err)
+
+	var quietErr *models.QuietClientError
+	require.ErrorAs(t, err, &quietErr)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -1852,19 +1852,27 @@ func TestHandleMediaBrowseCancelledIsQuiet(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
+	romsRoot := browseTestAbsPath("roms")
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{})
+
+	// A DB query that fails because the request context was cancelled mid-browse
+	// (client navigated away) is the real-world source of these events.
 	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseRootCounts", mock.Anything, mock.Anything).
+		Return(map[string]*int(nil), context.Canceled)
 
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, nil)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	env.Context = ctx
 
 	result, err := HandleMediaBrowse(env)
 	assert.Nil(t, result)
 	require.Error(t, err)
 
+	// Cancellation is returned as a QuietClientError (logged at Debug, out of
+	// Sentry) and still unwraps to context.Canceled for the JSON-RPC response.
 	var quietErr *models.QuietClientError
 	require.ErrorAs(t, err, &quietErr)
 	assert.ErrorIs(t, err, context.Canceled)

--- a/pkg/api/methods/readers.go
+++ b/pkg/api/methods/readers.go
@@ -61,9 +61,14 @@ func HandleReaderWrite(
 
 	t, err := r.Write(p.Text)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		switch {
+		case errors.Is(err, context.Canceled):
 			log.Debug().Err(err).Msg("tag write cancelled")
-		} else {
+		case errors.Is(err, readers.ErrTagNotDetected), errors.Is(err, readers.ErrUnsupportedTagType):
+			// Expected user conditions (no tag presented, unsupported tag);
+			// keep these out of Sentry. Hardware write failures stay at Error.
+			log.Warn().Err(err).Msg("error writing to reader")
+		default:
 			log.Error().Err(err).Msg("error writing to reader")
 		}
 		return nil, errors.New("error writing to reader")

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -22,6 +22,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -126,6 +127,18 @@ func (f *Flags) Pre(pl platforms.Platform) {
 	}
 }
 
+// logClientCommandError logs a failure from a CLI local-client command. A
+// refused connection means the Zaparoo service isn't running — an expected user
+// situation already surfaced on stderr — so it logs at Warn to stay out of
+// Sentry; any other failure logs at Error.
+func logClientCommandError(err error, msg string) {
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		log.Warn().Err(err).Msg(msg)
+		return
+	}
+	log.Error().Err(err).Msg(msg)
+}
+
 func runFlag(cfg *config.Instance, value string) {
 	data, err := json.Marshal(&models.RunParams{
 		Text: &value,
@@ -137,7 +150,7 @@ func runFlag(cfg *config.Instance, value string) {
 
 	_, err = client.LocalClient(context.Background(), cfg, models.MethodRun, string(data))
 	if err != nil {
-		log.Error().Err(err).Msg("error running")
+		logClientCommandError(err, "error running")
 		_, _ = fmt.Fprintf(os.Stderr, "Error running: %v\n", err)
 		os.Exit(1)
 	}
@@ -175,7 +188,7 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 
 		_, err = client.LocalClient(context.Background(), cfg, models.MethodReadersWrite, string(data))
 		if err != nil {
-			log.Error().Err(err).Msg("error writing tag")
+			logClientCommandError(err, "error writing tag")
 			_, _ = fmt.Fprintf(os.Stderr, "Error writing tag: %v\n", err)
 			enableRun()
 			os.Exit(1)
@@ -201,7 +214,7 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 			cfg, models.NotificationTokensAdded,
 		)
 		if err != nil {
-			log.Error().Err(err).Msg("error waiting for notification")
+			logClientCommandError(err, "error waiting for notification")
 			_, _ = fmt.Fprintf(os.Stderr, "Error waiting for notification: %v\n", err)
 			close(sigs)
 			enableRun()
@@ -238,7 +251,7 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 
 		resp, err := client.LocalClient(context.Background(), cfg, method, params)
 		if err != nil {
-			log.Error().Err(err).Msg("error calling API")
+			logClientCommandError(err, "error calling API")
 			_, _ = fmt.Fprintf(os.Stderr, "Error calling API: %v\n", err)
 			os.Exit(1)
 		}
@@ -289,7 +302,7 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 	case *f.Reload:
 		_, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsReload, "")
 		if err != nil {
-			log.Error().Err(err).Msg("error reloading settings")
+			logClientCommandError(err, "error reloading settings")
 			_, _ = fmt.Fprintf(os.Stderr, "Error reloading: %v\n", err)
 			os.Exit(1)
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,72 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"syscall"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogClientCommandError(t *testing.T) {
+	tests := []struct {
+		err           error
+		name          string
+		expectedLevel string
+	}{
+		{
+			name:          "connection refused logs at warn",
+			err:           syscall.ECONNREFUSED,
+			expectedLevel: "warn",
+		},
+		{
+			name:          "wrapped connection refused logs at warn",
+			err:           fmt.Errorf("dial failed: %w", syscall.ECONNREFUSED),
+			expectedLevel: "warn",
+		},
+		{
+			name:          "other error logs at error",
+			err:           errors.New("something else broke"),
+			expectedLevel: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf).Level(zerolog.TraceLevel)
+			prevLogger := log.Logger
+			log.Logger = logger
+			t.Cleanup(func() { log.Logger = prevLogger })
+
+			logClientCommandError(tt.err, "error running")
+
+			output := buf.String()
+			assert.Contains(t, output, `"level":"`+tt.expectedLevel+`"`)
+			assert.Contains(t, output, "error running")
+		})
+	}
+}

--- a/pkg/database/mediadb/corruption_test.go
+++ b/pkg/database/mediadb/corruption_test.go
@@ -1,0 +1,83 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCorruptionError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err  error
+		name string
+		want bool
+	}{
+		{
+			name: "corrupt sqlite code",
+			err:  sqlite3.Error{Code: sqlite3.ErrCorrupt},
+			want: true,
+		},
+		{
+			name: "not a database sqlite code",
+			err:  sqlite3.Error{Code: sqlite3.ErrNotADB},
+			want: true,
+		},
+		{
+			name: "wrapped corrupt sqlite code",
+			err:  fmt.Errorf("during maintenance: %w", sqlite3.Error{Code: sqlite3.ErrCorrupt}),
+			want: true,
+		},
+		{
+			name: "malformed disk image message fallback",
+			err:  errors.New("database disk image is malformed"),
+			want: true,
+		},
+		{
+			name: "not a database message fallback",
+			err:  errors.New("file is not a database"),
+			want: true,
+		},
+		{
+			name: "other sqlite code",
+			err:  sqlite3.Error{Code: sqlite3.ErrBusy},
+			want: false,
+		},
+		{
+			name: "ordinary error",
+			err:  errors.New("temporary query failure"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isCorruptionError(tt.err))
+		})
+	}
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -45,9 +45,23 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/jonboulle/clockwork"
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
 )
+
+// isCorruptionError reports whether err indicates SQLite database corruption
+// (a malformed disk image or a non-database file). Mirrors the detection used by
+// the media scanner so corruption hit during background maintenance can be routed
+// to the same corrupt-database recovery path.
+func isCorruptionError(err error) bool {
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code == sqlite3.ErrCorrupt || sqliteErr.Code == sqlite3.ErrNotADB
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "database disk image is malformed") ||
+		strings.Contains(msg, "file is not a database")
+}
 
 var ErrNullSQL = errors.New("MediaDB is not connected")
 
@@ -2947,6 +2961,14 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		// Final check after all retries
 		if stepErr != nil {
 			log.Error().Err(stepErr).Msgf("optimization step %s failed after %d attempts", step.name, step.maxRetries+1)
+			// Database corruption can't be repaired by optimization. Route it to the
+			// same corrupt-database state the indexer uses so the app surfaces the
+			// repair/rebuild flow instead of repeatedly failing maintenance.
+			if isCorruptionError(stepErr) {
+				if setErr := db.SetIndexingStatus(IndexingStatusCorrupt); setErr != nil {
+					log.Error().Err(setErr).Msg("failed to mark media database as corrupt after optimization failure")
+				}
+			}
 			if setErr := db.SetOptimizationStatus(IndexingStatusFailed); setErr != nil {
 				log.Error().Err(setErr).Msg("failed to set optimization status to failed")
 			}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2904,7 +2904,11 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		if err := pauser.Wait(db.ctx); err != nil {
 			log.Info().Msg("background optimization cancelled while paused")
 			if setErr := db.SetOptimizationStatus(IndexingStatusFailed); setErr != nil {
-				log.Error().Err(setErr).Msg("failed to set optimization status to failed")
+				if errors.Is(setErr, context.Canceled) {
+					log.Debug().Err(setErr).Msg("set optimization status to failed skipped (cancelled)")
+				} else {
+					log.Error().Err(setErr).Msg("failed to set optimization status to failed")
+				}
 			}
 			if statusCallback != nil {
 				statusCallback(false)
@@ -2915,7 +2919,13 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		log.Info().Msgf("running optimization step: %s", step.name)
 
 		if err := db.SetOptimizationStep(step.name); err != nil {
-			log.Error().Err(err).Msgf("failed to set optimization step to %s", step.name)
+			// A cancelled context here just means the service is shutting down
+			// mid-optimization; that's expected, so keep it out of Sentry.
+			if errors.Is(err, context.Canceled) {
+				log.Debug().Err(err).Msgf("set optimization step to %s skipped (cancelled)", step.name)
+			} else {
+				log.Error().Err(err).Msgf("failed to set optimization step to %s", step.name)
+			}
 		}
 
 		// Execute step with retry and exponential backoff

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3985,3 +3985,46 @@ func TestMediaDB_BrowseFiles_UsesRankPrefixSortForNumberedCollections(t *testing
 	require.Len(t, nextPage, 1)
 	assert.Equal(t, "Contra", nextPage[0].Name)
 }
+
+// TestMediaDB_UpdateMediaTitle_FlushesBufferedTitle_Integration is a regression
+// test for the FOREIGN KEY constraint failure seen when re-pointing an existing
+// media row to a MediaTitle that is still buffered in the batch inserter (e.g. an
+// arcade .mra scanned once by filename and again by its arcade-database name).
+// UpdateMediaTitle must flush the pending MediaTitle batch before the UPDATE so
+// the referenced title exists.
+func TestMediaDB_UpdateMediaTitle_FlushesBufferedTitle_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Tx 1: persist a system, a title, and a media row referencing that title.
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	_, err := mediaDB.InsertSystem(database.System{DBID: 1, SystemID: "Arcade", Name: "Arcade"})
+	require.NoError(t, err)
+	_, err = mediaDB.InsertMediaTitle(&database.MediaTitle{DBID: 1, SystemDBID: 1, Slug: "imsorry", Name: "I'm Sorry"})
+	require.NoError(t, err)
+	mediaPath := filepath.Join("media", "fat", "_Arcade", "I'm Sorry (US, 315-5110).mra")
+	_, err = mediaDB.InsertMedia(database.Media{DBID: 1, SystemDBID: 1, MediaTitleDBID: 1, Path: mediaPath})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Tx 2: buffer a second title, then immediately re-point the existing media at
+	// it. Before the flush fix this failed with "FOREIGN KEY constraint failed".
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	_, err = mediaDB.InsertMediaTitle(&database.MediaTitle{
+		DBID: 2, SystemDBID: 1, Slug: "imsorryus3155110", Name: "I'm Sorry (US, 315-5110)",
+	})
+	require.NoError(t, err)
+	err = mediaDB.UpdateMediaTitle(1, 2, "I'm Sorry (US, 315-5110)")
+	require.NoError(t, err, "update must flush the buffered title to satisfy the foreign key")
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// The media row now references the second title.
+	found, err := mediaDB.FindMedia(database.Media{DBID: 1})
+	require.NoError(t, err)
+	assert.Equal(t, mediaPath, found.Path)
+	assert.Equal(t, int64(2), found.MediaTitleDBID)
+}

--- a/pkg/database/mediascanner/maintenance_log_test.go
+++ b/pkg/database/mediascanner/maintenance_log_test.go
@@ -1,0 +1,76 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+// Global zerolog state is mutated to capture output; must not be parallel.
+func TestLogMaintenanceError(t *testing.T) {
+	prevGlobalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(prevGlobalLevel) })
+
+	tests := []struct {
+		err           error
+		name          string
+		expectedLevel string
+	}{
+		{
+			name:          "context cancelled logs at debug",
+			err:           context.Canceled,
+			expectedLevel: "debug",
+		},
+		{
+			name:          "wrapped context cancelled logs at debug",
+			err:           fmt.Errorf("set status: %w", context.Canceled),
+			expectedLevel: "debug",
+		},
+		{
+			name:          "other error logs at error",
+			err:           errors.New("disk write failed"),
+			expectedLevel: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prevLogger := log.Logger
+			log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+			t.Cleanup(func() { log.Logger = prevLogger })
+
+			logMaintenanceError(tt.err, "failed to set indexing status")
+
+			output := buf.String()
+			assert.Contains(t, output, `"level":"`+tt.expectedLevel+`"`)
+			assert.Contains(t, output, "failed to set indexing status")
+		})
+	}
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -80,6 +80,18 @@ func isSQLiteDatabaseCorrupt(err error) bool {
 		strings.Contains(msg, "file is not a database")
 }
 
+// logMaintenanceError logs an indexing maintenance failure (status writes, cache
+// population). When the failure is just the service context being cancelled
+// mid-index — an expected shutdown condition — it logs at Debug; any other
+// failure logs at Error so genuine problems stay visible in Sentry.
+func logMaintenanceError(err error, msg string) {
+	if errors.Is(err, context.Canceled) {
+		log.Debug().Err(err).Msg(msg)
+		return
+	}
+	log.Error().Err(err).Msg(msg)
+}
+
 type PathResult struct {
 	Path   string
 	System systemdefs.System
@@ -534,7 +546,7 @@ func GetFiles(
 func handleCancellation(ctx context.Context, db database.MediaDBI, message string) (int, error) {
 	log.Info().Msg(message)
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCancelled); setErr != nil {
-		log.Error().Err(setErr).Msg("failed to set indexing status to cancelled")
+		logMaintenanceError(setErr, "failed to set indexing status to cancelled")
 	}
 	return 0, ctx.Err()
 }
@@ -546,7 +558,7 @@ func handleCancellationWithRollback(ctx context.Context, db database.MediaDBI, m
 		log.Error().Err(rbErr).Msg("failed to rollback transaction after cancellation")
 	}
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCancelled); setErr != nil {
-		log.Error().Err(setErr).Msg("failed to set indexing status to cancelled")
+		logMaintenanceError(setErr, "failed to set indexing status to cancelled")
 	}
 	return 0, ctx.Err()
 }
@@ -826,7 +838,7 @@ func NewNamesIndex(
 	logPhaseMetrics("initial_state_population")
 
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusRunning); setErr != nil {
-		log.Error().Err(setErr).Msg("failed to set indexing status to running")
+		logMaintenanceError(setErr, "failed to set indexing status to running")
 	}
 	if !shouldResume {
 		if setErr := db.SetLastIndexedSystem(""); setErr != nil {
@@ -850,7 +862,7 @@ func NewNamesIndex(
 		if err != nil {
 			// Mark indexing as failed on error
 			if setErr := db.SetIndexingStatus(mediadb.IndexingStatusFailed); setErr != nil {
-				log.Error().Err(setErr).Msg("failed to set indexing status to failed after error")
+				logMaintenanceError(setErr, "failed to set indexing status to failed after error")
 			}
 		}
 	}()
@@ -1331,7 +1343,7 @@ func NewNamesIndex(
 	t0 = time.Now()
 	if selectiveRun {
 		if cacheErr := db.PopulateSystemTagsCacheForSystems(ctx, indexedSystemDefs); cacheErr != nil {
-			log.Error().Err(cacheErr).Msg("failed to populate system tags cache for indexed systems")
+			logMaintenanceError(cacheErr, "failed to populate system tags cache for indexed systems")
 		}
 		log.Info().
 			Dur("elapsed", time.Since(t0)).
@@ -1348,7 +1360,7 @@ func NewNamesIndex(
 
 		t0 = time.Now()
 		if cacheErr := db.RefreshSlugSearchCacheForSystems(ctx, indexedSystems); cacheErr != nil {
-			log.Error().Err(cacheErr).Msg("failed to refresh slug search cache for indexed systems")
+			logMaintenanceError(cacheErr, "failed to refresh slug search cache for indexed systems")
 		}
 		log.Info().
 			Dur("elapsed", time.Since(t0)).
@@ -1357,7 +1369,7 @@ func NewNamesIndex(
 		logPhaseMetrics("refresh_slug_search_cache")
 	} else {
 		if cacheErr := db.PopulateSystemTagsCache(ctx); cacheErr != nil {
-			log.Error().Err(cacheErr).Msg("failed to populate system tags cache")
+			logMaintenanceError(cacheErr, "failed to populate system tags cache")
 		}
 		log.Info().Dur("elapsed", time.Since(t0)).Msg("PopulateSystemTagsCache complete")
 		logPhaseMetrics("populate_system_tags_cache")
@@ -1404,7 +1416,7 @@ func NewNamesIndex(
 
 	// Mark indexing as completed and clear indexing metadata
 	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCompleted); setErr != nil {
-		log.Error().Err(setErr).Msg("failed to set indexing status to completed")
+		logMaintenanceError(setErr, "failed to set indexing status to completed")
 	}
 	if setErr := db.SetLastIndexedSystem(""); setErr != nil {
 		log.Error().Err(setErr).Msg("failed to clear last indexed system on completion")

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -1020,6 +1021,12 @@ func NewNamesIndex(
 			if scanErr != nil {
 				if errors.Is(scanErr, context.Canceled) {
 					return handleCancellationWithRollback(ctx, db, "Media indexing cancelled during custom scanner")
+				}
+				if errors.Is(scanErr, syscall.ECONNREFUSED) {
+					// The scanner's backing service (e.g. Kodi) isn't running.
+					// Expected on devices without it; keep out of Sentry.
+					log.Warn().Err(scanErr).Msgf("skipping %s scanner: service unavailable", l.ID)
+					continue
 				}
 				log.Error().Err(scanErr).Msgf("error running %s scanner for system: %s", l.ID, systemID)
 				continue

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -20,6 +20,7 @@
 package systemdefs
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -27,6 +28,11 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 )
+
+// ErrUnknownSystem is returned when a system ID cannot be resolved. When this
+// originates from a user-supplied value (e.g. a system named in ZapScript), the
+// token-launch path logs it at Warn rather than Error.
+var ErrUnknownSystem = errors.New("unknown system")
 
 // The Systems list contains all the supported systems such as consoles,
 // computers and media types that are indexable by Zaparoo. This is the reference
@@ -100,7 +106,7 @@ func GetSystem(id string) (*System, error) {
 	if system, ok := Systems[id]; ok {
 		return &system, nil
 	}
-	return nil, fmt.Errorf("unknown system: %s", id)
+	return nil, fmt.Errorf("%w: %s", ErrUnknownSystem, id)
 }
 
 // buildLookupMap initializes the system lookup map with all possible lookup keys.
@@ -194,7 +200,7 @@ func LookupSystem(id string) (*System, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("unknown system: %s", id)
+	return nil, fmt.Errorf("%w: %s", ErrUnknownSystem, id)
 }
 
 func AllSystems() []System {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -53,8 +53,18 @@ func checkInZip(path string) string {
 	}
 
 	fileInfo, err := os.Stat(path)
-	if err != nil || fileInfo.IsDir() {
-		log.Error().Err(err).Msgf("failed to access the zip file at path: %s", path)
+	if err != nil {
+		// A token pointing to a zip that isn't present is a user/data condition,
+		// not a code fault; keep it out of Sentry. Other stat errors stay visible.
+		if os.IsNotExist(err) {
+			log.Warn().Err(err).Msgf("zip file not found at path: %s", path)
+		} else {
+			log.Error().Err(err).Msgf("failed to access the zip file at path: %s", path)
+		}
+		return path
+	}
+	if fileInfo.IsDir() {
+		log.Error().Msgf("expected a zip file but found a directory: %s", path)
 		return path
 	}
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -333,16 +333,15 @@ func (p *Platform) StartPost(
 		}
 
 		arcadeDbUpdated, err := arcadedb.UpdateArcadeDb(p)
-		if err != nil {
+		switch {
+		case err != nil:
 			// Non-fatal: an embedded arcade database is used as a fallback. Download
 			// failures are usually network/rate-limit issues, not code faults.
 			log.Warn().Msgf("failed to download arcade database: %s", err)
-		}
-
-		if arcadeDbUpdated {
+		case arcadeDbUpdated:
 			log.Info().Msg("arcade database updated")
 			tr.ReloadNameMap()
-		} else {
+		default:
 			log.Info().Msg("arcade database is up to date")
 		}
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -334,7 +334,9 @@ func (p *Platform) StartPost(
 
 		arcadeDbUpdated, err := arcadedb.UpdateArcadeDb(p)
 		if err != nil {
-			log.Error().Msgf("failed to download arcade database: %s", err)
+			// Non-fatal: an embedded arcade database is used as a fallback. Download
+			// failures are usually network/rate-limit issues, not code faults.
+			log.Warn().Msgf("failed to download arcade database: %s", err)
 		}
 
 		if arcadeDbUpdated {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -216,7 +216,9 @@ func (p *Platform) StartPre(cfg *config.Instance) error {
 	// path when nfc.csv is absent; <10ms parse otherwise).
 	uids, texts, err := LoadCsvMappings()
 	if err != nil {
-		log.Error().Msgf("error loading mappings: %s", err)
+		// A malformed nfc.csv is user-supplied data, not a code fault; log at
+		// Warn so it stays out of Sentry while remaining visible locally.
+		log.Warn().Msgf("error loading mappings: %s", err)
 	} else {
 		p.SetDB(uids, texts)
 		log.Info().Int("uid_count", len(uids)).Int("text_count", len(texts)).Msg("CSV mappings loaded")

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -4,6 +4,7 @@ package tracker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -207,7 +208,13 @@ func (tr *Tracker) LoadCore() {
 
 	data, err := os.ReadFile(misterconfig.CoreNameFile)
 	if err != nil {
-		log.Error().Msgf("error reading core name: %s", err)
+		// CORENAME is absent until MiSTer launches a core (e.g. right after boot).
+		// That's expected; other read errors (permissions, I/O) stay at Error.
+		if os.IsNotExist(err) {
+			log.Debug().Msgf("core name file not present yet: %s", err)
+		} else {
+			log.Error().Msgf("error reading core name: %s", err)
+		}
 		return
 	}
 
@@ -308,7 +315,13 @@ func (tr *Tracker) loadGame() {
 	if filepath.Ext(strings.ToLower(filename)) == ".mgl" {
 		mgl, mglErr := mgls.ReadMgl(path)
 		if mglErr != nil {
-			log.Error().Err(mglErr).Str("path", path).Msg("error reading mgl")
+			// A missing MGL (e.g. AmigaVision virtual paths, or a cleaned-up temp
+			// MGL) just means we can't track that game; not a fault worth Sentry.
+			if errors.Is(mglErr, os.ErrNotExist) {
+				log.Warn().Err(mglErr).Str("path", path).Msg("active game mgl file not found")
+			} else {
+				log.Error().Err(mglErr).Str("path", path).Msg("error reading mgl")
+			}
 		} else {
 			path = ResolvePath(mgl.File.Path)
 			log.Info().Msgf("mgl path: %s", path)
@@ -502,7 +515,11 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 					case strings.HasPrefix(event.Name, misterconfig.CoreConfigFolder):
 						err = loadRecent(event.Name)
 						if err != nil {
-							log.Error().Msgf("error loading recent file: %s", err)
+							if errors.Is(err, os.ErrNotExist) {
+								log.Warn().Msgf("recent mgl file not found: %s", err)
+							} else {
+								log.Error().Msgf("error loading recent file: %s", err)
+							}
 						}
 					case event.Name == misterconfig.MainPickerSelected:
 						log.Info().Msgf("main picker selected: %s", event.Name)

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -147,16 +147,15 @@ func (p *Platform) StartPost(
 		}
 
 		arcadeDbUpdated, err := arcadedb.UpdateArcadeDb(p)
-		if err != nil {
+		switch {
+		case err != nil:
 			// Non-fatal: an embedded arcade database is used as a fallback. Download
 			// failures are usually network/rate-limit issues, not code faults.
 			log.Warn().Msgf("failed to download arcade database: %s", err)
-		}
-
-		if arcadeDbUpdated {
+		case arcadeDbUpdated:
 			log.Info().Msg("arcade database updated")
 			tr.ReloadNameMap()
-		} else {
+		default:
 			log.Info().Msg("arcade database is up to date")
 		}
 

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -148,7 +148,9 @@ func (p *Platform) StartPost(
 
 		arcadeDbUpdated, err := arcadedb.UpdateArcadeDb(p)
 		if err != nil {
-			log.Error().Msgf("failed to download arcade database: %s", err)
+			// Non-fatal: an embedded arcade database is used as a fallback. Download
+			// failures are usually network/rate-limit issues, not code faults.
+			log.Warn().Msgf("failed to download arcade database: %s", err)
 		}
 
 		if arcadeDbUpdated {

--- a/pkg/platforms/shared/steam/scanner.go
+++ b/pkg/platforms/shared/steam/scanner.go
@@ -53,7 +53,13 @@ func ScanSteamApps(steamDir string) ([]platforms.ScanResult, error) {
 	//nolint:gosec // Safe: reads Steam config files for game library scanning
 	f, err := os.Open(filepath.Join(steamDir, "libraryfolders.vdf"))
 	if err != nil {
-		log.Error().Err(err).Msg("error opening libraryfolders.vdf")
+		// Steam not installed at this path (no library file) is expected on many
+		// devices; log at Debug to keep it out of Sentry. Mirror ScanSteamShortcuts.
+		if os.IsNotExist(err) {
+			log.Debug().Err(err).Msg("libraryfolders.vdf not found, skipping Steam app scan")
+		} else {
+			log.Warn().Err(err).Msg("error opening libraryfolders.vdf")
+		}
 		return results, nil
 	}
 	defer func() {

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -898,6 +898,7 @@ func (r *Reader) writeTag(req *WriteRequest) {
 	var count int
 	var target nfc.Target
 	var err error
+	var lastPollErr error
 	tries := defaultWriteTimeoutTries
 
 	for tries > 0 {
@@ -926,6 +927,7 @@ func (r *Reader) writeTag(req *WriteRequest) {
 
 		if err != nil && !errors.Is(err, nfc.Error(nfc.ETIMEOUT)) {
 			log.Warn().Msgf("could not poll: %s", err)
+			lastPollErr = err
 		}
 
 		if count > 0 {
@@ -936,6 +938,16 @@ func (r *Reader) writeTag(req *WriteRequest) {
 	}
 
 	if count == 0 {
+		// A timeout (or clean poll) with no tag is the expected "nothing
+		// presented" case. A non-timeout poll error means the reader actually
+		// failed, so surface it as a genuine fault rather than masking it as
+		// ErrTagNotDetected (which downstream treats as an expected condition).
+		if lastPollErr != nil {
+			req.Result <- WriteRequestResult{
+				Err: fmt.Errorf("failed to poll for tag: %w", lastPollErr),
+			}
+			return
+		}
 		log.Warn().Msgf("could not detect a tag")
 		req.Result <- WriteRequestResult{
 			Err: readers.ErrTagNotDetected,

--- a/pkg/readers/libnfc/libnfc.go
+++ b/pkg/readers/libnfc/libnfc.go
@@ -458,7 +458,13 @@ func (r *Reader) WriteTarget(ctx context.Context, text string, opts readers.Writ
 	if res.Cancelled {
 		return nil, ErrWriteCancelled
 	} else if res.Err != nil {
-		log.Error().Msgf("error writing to tag: %s", res.Err)
+		// Expected user conditions (no tag presented, unsupported tag) log at
+		// Warn; genuine hardware write failures stay at Error for Sentry.
+		if errors.Is(res.Err, readers.ErrTagNotDetected) || errors.Is(res.Err, readers.ErrUnsupportedTagType) {
+			log.Warn().Msgf("error writing to tag: %s", res.Err)
+		} else {
+			log.Error().Msgf("error writing to tag: %s", res.Err)
+		}
 		return nil, res.Err
 	}
 
@@ -932,7 +938,7 @@ func (r *Reader) writeTag(req *WriteRequest) {
 	if count == 0 {
 		log.Warn().Msgf("could not detect a tag")
 		req.Result <- WriteRequestResult{
-			Err: errors.New("could not detect a tag"),
+			Err: readers.ErrTagNotDetected,
 		}
 		return
 	}
@@ -975,9 +981,9 @@ func (r *Reader) writeTag(req *WriteRequest) {
 			return
 		}
 	default:
-		log.Error().Msgf("unsupported tag type: %s", cardType)
+		log.Warn().Msgf("unsupported tag type: %s", cardType)
 		req.Result <- WriteRequestResult{
-			Err: fmt.Errorf("unsupported tag type: %s", cardType),
+			Err: fmt.Errorf("%w: %s", readers.ErrUnsupportedTagType, cardType),
 		}
 		return
 	}

--- a/pkg/readers/readers.go
+++ b/pkg/readers/readers.go
@@ -21,11 +21,21 @@ package readers
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+)
+
+// ErrTagNotDetected and ErrUnsupportedTagType are expected user conditions
+// during a tag write (no tag was presented, or an unsupported tag was). Reader
+// drivers return these so the write path can log them at Warn rather than Error,
+// keeping them out of Sentry while genuine hardware failures remain at Error.
+var (
+	ErrTagNotDetected     = errors.New("could not detect a tag")
+	ErrUnsupportedTagType = errors.New("unsupported tag type")
 )
 
 type Capability string

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -22,6 +22,8 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package service
 
 import (
+	"errors"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -88,7 +90,14 @@ func checkAndResumeIndexing(
 	// GenerateMediaDB spawns its own goroutine and returns immediately
 	err = methods.GenerateMediaDB(st.GetContext(), pl, cfg, st.Notifications, systems, db, pauser)
 	if err != nil {
-		log.Error().Err(err).Msg("failed to start auto-resume of media indexing")
+		// An expected operational state (e.g. indexing/scraping already running)
+		// means auto-resume isn't needed — not a failure worth reporting.
+		var clientErr *models.ClientError
+		if errors.As(err, &clientErr) {
+			log.Warn().Err(err).Msg("skipping auto-resume of media indexing")
+		} else {
+			log.Error().Err(err).Msg("failed to start auto-resume of media indexing")
+		}
 	}
 }
 

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -31,12 +31,14 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playtime"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
 	"github.com/google/uuid"
@@ -82,6 +84,18 @@ func playlistForLog(pls *playlists.Playlist) any {
 		Truncated:     len(pls.Items) - showing,
 		Items:         pls.Items[:showing],
 	}
+}
+
+// isExpectedLaunchError reports whether a token-launch error is an expected
+// user/operational condition that should be logged at Warn rather than Error
+// (keeping it out of Sentry). These are not bugs: a missing file, a playlist
+// control command with nothing playing, a double-tap during an active launch,
+// or a user-supplied system that doesn't exist.
+func isExpectedLaunchError(err error) bool {
+	return errors.Is(err, zapscript.ErrFileNotFound) ||
+		errors.Is(err, zapscript.ErrNoPlaylistActive) ||
+		errors.Is(err, state.ErrLaunchInProgress) ||
+		errors.Is(err, systemdefs.ErrUnknownSystem)
 }
 
 func runTokenZapScript(
@@ -349,7 +363,11 @@ func launchPlaylistMedia(
 
 	err := runTokenZapScript(svc, t, plsc, nil, false)
 	if err != nil {
-		log.Error().Err(err).Msgf("error launching token")
+		if isExpectedLaunchError(err) {
+			log.Warn().Err(err).Msgf("error launching token")
+		} else {
+			log.Error().Err(err).Msgf("error launching token")
+		}
 		path, enabled := svc.Config.FailSoundPath(helpers.DataDir(svc.Platform))
 		helpers.PlayConfiguredSound(player, path, enabled, assets.FailSound, "fail")
 	}
@@ -635,7 +653,7 @@ func processTokenQueue(
 
 				err = runTokenZapScript(svc, t, plsc, nil, false)
 				if err != nil {
-					if errors.Is(err, zapscript.ErrFileNotFound) {
+					if isExpectedLaunchError(err) {
 						log.Warn().Err(err).Msgf("error launching token")
 					} else {
 						log.Error().Err(err).Msgf("error launching token")

--- a/pkg/service/queues_launcherror_test.go
+++ b/pkg/service/queues_launcherror_test.go
@@ -1,0 +1,68 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsExpectedLaunchError verifies that expected user/operational launch
+// failures are classified for Warn-level logging (kept out of Sentry) while
+// genuine errors are not, including when the sentinels are wrapped.
+func TestIsExpectedLaunchError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+	}{
+		{name: "file not found", err: zapscript.ErrFileNotFound, expected: true},
+		{name: "no playlist active", err: zapscript.ErrNoPlaylistActive, expected: true},
+		{name: "launch in progress", err: state.ErrLaunchInProgress, expected: true},
+		{name: "unknown system", err: systemdefs.ErrUnknownSystem, expected: true},
+		{
+			name:     "wrapped no playlist active",
+			err:      fmt.Errorf("failed to run zapscript command: %w", zapscript.ErrNoPlaylistActive),
+			expected: true,
+		},
+		{
+			name:     "wrapped unknown system",
+			err:      fmt.Errorf("%w: neo", systemdefs.ErrUnknownSystem),
+			expected: true,
+		},
+		{name: "generic error", err: errors.New("database disk image is malformed"), expected: false},
+		{name: "nil error", err: nil, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, isExpectedLaunchError(tt.err))
+		})
+	}
+}

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -53,6 +53,11 @@ func isPlsFile(path string) bool {
 	return filepath.Ext(strings.ToLower(path)) == ".pls"
 }
 
+// ErrNoPlaylistActive is returned by playlist control commands when no playlist
+// is active for the requested slot. This is an expected user condition (firing a
+// playlist command with nothing playing), so callers log it at Warn, not Error.
+var ErrNoPlaylistActive = errors.New("no playlist active")
+
 var (
 	plsFileRe  = regexp.MustCompile(`^File([1-9]\d*)\s*=\s*(.*)$`)
 	plsTitleRe = regexp.MustCompile(`^Title([1-9]\d*)\s*=\s*(.*)$`)
@@ -622,7 +627,7 @@ func cmdPlaylistNext(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdR
 	}
 	active := activePlaylistForSlot(&env, slot)
 	if active == nil {
-		return platforms.CmdResult{}, errors.New("no playlist active")
+		return platforms.CmdResult{}, ErrNoPlaylistActive
 	}
 
 	pls := playlists.Next(*active)
@@ -644,7 +649,7 @@ func cmdPlaylistPrevious(_ platforms.Platform, env platforms.CmdEnv) (platforms.
 	}
 	active := activePlaylistForSlot(&env, slot)
 	if active == nil {
-		return platforms.CmdResult{}, errors.New("no playlist active")
+		return platforms.CmdResult{}, ErrNoPlaylistActive
 	}
 	if restarted, restartErr := restartCurrentPlaylistTrack(&env, slot); restartErr != nil {
 		return platforms.CmdResult{}, restartErr
@@ -671,7 +676,7 @@ func cmdPlaylistGoto(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdR
 	}
 	active := activePlaylistForSlot(&env, slot)
 	if active == nil {
-		return platforms.CmdResult{}, errors.New("no playlist active")
+		return platforms.CmdResult{}, ErrNoPlaylistActive
 	}
 
 	if len(env.Cmd.Args) == 0 {
@@ -709,7 +714,7 @@ func cmdPlaylistStop(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 	}
 	active := activePlaylistForSlot(&env, slot)
 	if active == nil {
-		return platforms.CmdResult{}, errors.New("no playlist active")
+		return platforms.CmdResult{}, ErrNoPlaylistActive
 	}
 
 	if err := queuePlaylistUpdate(&env, &playlists.Playlist{Slot: slot, Clear: true}); err != nil {
@@ -742,7 +747,7 @@ func cmdPlaylistPause(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cm
 	}
 	active := activePlaylistForSlot(&env, slot)
 	if active == nil {
-		return platforms.CmdResult{}, errors.New("no playlist active")
+		return platforms.CmdResult{}, ErrNoPlaylistActive
 	}
 
 	pls := playlists.Pause(*active)

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -543,7 +543,7 @@ func cmdPlaylistOpen(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cmd
 	// If no args provided, use the currently active playlist
 	if len(env.Cmd.Args) == 0 {
 		if active == nil {
-			return platforms.CmdResult{}, errors.New("no active playlist to open")
+			return platforms.CmdResult{}, ErrNoPlaylistActive
 		}
 		log.Debug().Msg("opening active playlist (no args)")
 		// Use active playlist as-is (preserves current Index and state)

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -198,7 +198,7 @@ func TestCmdPlaylistOpen_NoArgs(t *testing.T) {
 		{
 			name:           "no args with no active playlist returns error",
 			activePlaylist: nil,
-			expectedError:  "no active playlist to open",
+			expectedError:  "no playlist active",
 		},
 	}
 


### PR DESCRIPTION
Goes through the unresolved zaparoo-core Sentry issues one by one: keeps genuine signal at Error, downgrades expected/user/environment conditions that carry no signal, and fixes the real bugs found. Telemetry exists primarily to catch real failures (notably NFC hardware), so hardware faults, crashes, and launch failures stay visible.

## Noise downgraded (no behaviour change, log level only)
- **ZapScript user errors → Warn**: `no playlist active` (the two highest-volume issues), launch-guard re-tap, `unknown system`, malformed nfc.csv, auto-resume "indexing already in progress".
- **Context cancellation → Debug**: browse cancelled by the client (now a QuietClientError) and indexer/optimization status writes during shutdown. `context deadline exceeded` on browse is kept at Error as a possible perf-regression signal.
- **Reader user actions → Warn**: only `unsupported tag type` and `could not detect a tag`. All real NFC hardware errors (InDataExchange timeouts, NTAG retries, InListPassiveTarget, SAM/no-ACK) stay at Error.
- **External services → Warn**: Kodi not running (connection refused), arcade-DB download rate-limits/timeouts (embedded fallback exists), CLI connect-refused, websocket abnormal closures. `service process is no longer running` kept at Error.
- **MiSTer env → Debug/Warn**: `/tmp/CORENAME` not-found, missing MGL referenced by the active game, token pointing to a missing zip. Other read errors stay at Error.
- **Steam → Debug**: missing `libraryfolders.vdf` (mirrors the existing ScanSteamShortcuts handling).

## Real bugs
- **FOREIGN KEY constraint on media title update**: already fixed in v2.12.0 (#775, UpdateMediaTitle flushes the buffered title batch first); remaining reports are un-upgraded v2.11.0 clients. Added a regression test.
- **DB corruption during PRAGMA optimize**: now routes to the existing `IndexingStatusCorrupt` recovery instead of only failing optimization.
- **Windows second-launch crash**: `isRunning` treated `ERROR_ALREADY_EXISTS` from `CreateMutex` as fatal, crashing the second instance instead of exiting cleanly.

## Deferred
- `timeout waiting for console switch` is left at Error and tracked separately — it needs MiSTer device investigation (F9 lands on tty2 when tty1 is expected).
- Sentry issues will be marked resolved after this merges and a release ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log noise by classifying expected vs unexpected websocket, launch, reader, and indexing errors, including better handling of cancellations.
  * Treated missing/optional files and unavailable scanner/services as warnings or non-fatal cases.
  * Improved SQLite corruption detection during media indexing and updated corruption state handling.
  * Refined single-instance detection on Windows to avoid fatal exits on expected “already running” cases.
* **New Features**
  * Added exported sentinel errors for expected NFC reader states, unknown systems, and “no playlist active”.
* **Tests**
  * Added/updated unit and integration tests covering the new error classification and cancellation/corruption behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->