### PR TITLE
feat: title-global tag disambiguation

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -399,8 +399,9 @@ An object:
 | name      | string                   | Yes      | A human-readable version of the result's filename without a file extension.                                 |
 | path      | string                   | Yes      | Canonical indexed media path. Use with `system.id` for `media.meta` and `media.image`. |
 | relativePath | string               | No       | Launcher-relative convenience path, when it can be derived. Not a stable media identity. |
-| zapScript | string                   | Yes      | ZapScript command to launch this media item.                                                                |
+| zapScript | string                   | Yes      | ZapScript command to launch this media item. Includes the disambiguating tags inline (e.g. `@Arcade/X-Men Vs. Street Fighter (region:eu) (builddate:1996-10-04)`) so the written command resolves back to this specific variant. |
 | tags      | [TagInfo](#taginfo-object)[] | Yes      | Array of tags associated with this media item.                                               |
+| disambiguatingTags | [TagInfo](#taginfo-object)[] | No | Subset of `tags` whose values differ across same-named siblings of this title, ordered by display importance. Omitted when the title has nothing to disambiguate. Clients can render these to tell variants apart. |
 
 ##### System object
 
@@ -587,6 +588,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | zapScript    | string   | No       | ZapScript command to launch this media. Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
 | relativePath | string   | No       | Relative path from root directory. Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
 | tags         | object[] | No       | Tags attached to the media. Each object has `tag` (string) and `type` (string). Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
+| disambiguatingTags | object[] | No | Subset of `tags` whose values differ across same-named siblings of this title, ordered by display importance. Same object shape as `tags`. Omitted when the title has nothing to disambiguate. |
 
 ##### Browse pagination object
 

--- a/docs/media-titles.md
+++ b/docs/media-titles.md
@@ -183,6 +183,7 @@ Examples:
 - First paren tag → region if it matches the known region list (USA, Europe, Japan, etc.)
 - Subsequent tags → language, version, dev status
 - Multi-value: `(En,Fr,De)` → `lang:en`, `lang:fr`, `lang:de`
+- MiSTer Arcade `(Region YYMMDD)` packs a region and romset build date in one group: `(World 931005)` → `region:world`, `builddate:1993-10-05`. The date is also accepted as `YYYYMMDD` or `YYYY-MM-DD`, and the region/date may be comma-separated (`(EU, 961004)`).
 
 **Step 4: Square bracket tags** — always dump info or modifications:
 - `[!]` → `dump:verified`, `[b]` → `dump:bad`, `[h]` → `hack:yes`, `[T+En]` → `translation:en`
@@ -195,6 +196,9 @@ Example:
 
 "Zelda (Europe) (En,Fr,De,Es,It).gba"
   → [region:eu, lang:en, lang:fr, lang:de, lang:es, lang:it]
+
+"X-Men Vs. Street Fighter (Europe 961004).mra"
+  → [region:eu, builddate:1996-10-04]
 ```
 
 ---

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -749,13 +749,14 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		}
 
 		results = append(results, models.SearchResultMedia{
-			MediaID:   result.MediaID,
-			RelPath:   relPath,
-			System:    resultSystem,
-			Name:      result.Name,
-			Path:      result.Path,
-			ZapScript: zapScript,
-			Tags:      result.Tags,
+			MediaID:            result.MediaID,
+			RelPath:            relPath,
+			System:             resultSystem,
+			Name:               result.Name,
+			Path:               result.Path,
+			ZapScript:          zapScript,
+			Tags:               result.Tags,
+			DisambiguatingTags: result.ZapScriptTags,
 		})
 	}
 

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -771,6 +771,7 @@ func buildBrowseResponse(
 			entry.RelPath = mediaEntry.RelPath
 			entry.ZapScript = mediaEntry.ZapScript
 			entry.Tags = mediaEntry.Tags
+			entry.DisambiguatingTags = mediaEntry.DisambiguatingTags
 			entry.HasCover = mediaEntry.HasCover
 		}
 		entries = append(entries, entry)
@@ -845,13 +846,14 @@ func buildMediaEntry(
 	rootDirs []string,
 ) models.BrowseEntry {
 	entry := models.BrowseEntry{
-		MediaID:  result.MediaID,
-		Name:     result.Name,
-		Path:     result.Path,
-		Type:     "media",
-		SystemID: &result.SystemID,
-		Tags:     result.Tags,
-		HasCover: result.HasCover,
+		MediaID:            result.MediaID,
+		Name:               result.Name,
+		Path:               result.Path,
+		Type:               "media",
+		SystemID:           &result.SystemID,
+		Tags:               result.Tags,
+		DisambiguatingTags: result.ZapScriptTags,
+		HasCover:           result.HasCover,
 	}
 	zapScript := result.ZapScript()
 	entry.ZapScript = &zapScript

--- a/pkg/api/methods/media_lookup.go
+++ b/pkg/api/methods/media_lookup.go
@@ -111,14 +111,15 @@ func HandleMediaLookup(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	return models.MediaLookupResponse{
 		Match: &models.MediaLookupMatch{
-			MediaID:    result.Result.MediaID,
-			RelPath:    relPath,
-			System:     resultSystem,
-			Name:       result.Result.Name,
-			Path:       result.Result.Path,
-			ZapScript:  zapScript,
-			Tags:       result.Result.Tags,
-			Confidence: result.Confidence,
+			MediaID:            result.Result.MediaID,
+			RelPath:            relPath,
+			System:             resultSystem,
+			Name:               result.Result.Name,
+			Path:               result.Result.Path,
+			ZapScript:          zapScript,
+			Tags:               result.Result.Tags,
+			DisambiguatingTags: result.Result.ZapScriptTags,
+			Confidence:         result.Confidence,
 		},
 	}, nil
 }

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -29,13 +29,14 @@ import (
 )
 
 type SearchResultMedia struct {
-	RelPath   *string            `json:"relativePath,omitempty"`
-	System    System             `json:"system"`
-	Name      string             `json:"name"`
-	Path      string             `json:"path"`
-	ZapScript string             `json:"zapScript"`
-	Tags      []database.TagInfo `json:"tags"`
-	MediaID   int64              `json:"mediaId,omitempty"`
+	RelPath            *string            `json:"relativePath,omitempty"`
+	System             System             `json:"system"`
+	Name               string             `json:"name"`
+	Path               string             `json:"path"`
+	ZapScript          string             `json:"zapScript"`
+	Tags               []database.TagInfo `json:"tags"`
+	DisambiguatingTags []database.TagInfo `json:"disambiguatingTags,omitempty"`
+	MediaID            int64              `json:"mediaId,omitempty"`
 }
 
 type PaginationInfo struct {
@@ -55,18 +56,19 @@ type TagsResponse struct {
 }
 
 type BrowseEntry struct {
-	SystemID  *string            `json:"systemId,omitempty"`
-	RelPath   *string            `json:"relativePath,omitempty"`
-	ZapScript *string            `json:"zapScript,omitempty"`
-	FileCount *int               `json:"fileCount,omitempty"`
-	Group     *string            `json:"group,omitempty"`
-	Path      string             `json:"path"`
-	Type      string             `json:"type"`
-	Name      string             `json:"name"`
-	SystemIDs []string           `json:"systemIds,omitempty"`
-	Tags      []database.TagInfo `json:"tags,omitempty"`
-	MediaID   int64              `json:"mediaId,omitempty"`
-	HasCover  bool               `json:"hasCover"`
+	SystemID           *string            `json:"systemId,omitempty"`
+	RelPath            *string            `json:"relativePath,omitempty"`
+	ZapScript          *string            `json:"zapScript,omitempty"`
+	FileCount          *int               `json:"fileCount,omitempty"`
+	Group              *string            `json:"group,omitempty"`
+	Path               string             `json:"path"`
+	Type               string             `json:"type"`
+	Name               string             `json:"name"`
+	SystemIDs          []string           `json:"systemIds,omitempty"`
+	Tags               []database.TagInfo `json:"tags,omitempty"`
+	DisambiguatingTags []database.TagInfo `json:"disambiguatingTags,omitempty"`
+	MediaID            int64              `json:"mediaId,omitempty"`
+	HasCover           bool               `json:"hasCover"`
 }
 
 type BrowseResults struct {
@@ -338,14 +340,15 @@ type ScrapingStatusResponse struct {
 }
 
 type MediaLookupMatch struct {
-	RelPath    *string            `json:"relativePath,omitempty"`
-	System     System             `json:"system"`
-	Name       string             `json:"name"`
-	Path       string             `json:"path"`
-	ZapScript  string             `json:"zapScript"`
-	Tags       []database.TagInfo `json:"tags"`
-	MediaID    int64              `json:"mediaId,omitempty"`
-	Confidence float64            `json:"confidence"`
+	RelPath            *string            `json:"relativePath,omitempty"`
+	System             System             `json:"system"`
+	Name               string             `json:"name"`
+	Path               string             `json:"path"`
+	ZapScript          string             `json:"zapScript"`
+	Tags               []database.TagInfo `json:"tags"`
+	DisambiguatingTags []database.TagInfo `json:"disambiguatingTags,omitempty"`
+	MediaID            int64              `json:"mediaId,omitempty"`
+	Confidence         float64            `json:"confidence"`
 }
 
 type MediaLookupResponse struct {

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -117,11 +117,12 @@ func TestServerStartupConcurrency(t *testing.T) {
 			platform := mocks.NewMockPlatform()
 			platform.SetupBasicMock()
 
-			// Use a specific port to avoid conflicts
-			testPort := 8000 + attempt
+			// Bind an OS-assigned free port (port 0) instead of a hard-coded
+			// port: parallel attempts sharing fixed ports — or any other
+			// process holding one — caused "address already in use" flakes.
 			fs := helpers.NewMemoryFS()
 			configDir := t.TempDir()
-			cfg, err := helpers.NewTestConfigWithPort(fs, configDir, testPort)
+			cfg, err := helpers.NewTestConfigWithPort(fs, configDir, 0)
 			require.NoError(t, err)
 
 			st, notifCh := state.NewState(platform, "test-boot-uuid")
@@ -137,11 +138,12 @@ func TestServerStartupConcurrency(t *testing.T) {
 			// Start server in a separate goroutine
 			serverDone := make(chan struct{})
 			serverErr := make(chan error, 1)
+			ready := make(chan error, 1)
 			go func() {
 				defer close(serverDone)
-				serverErr <- Start(
+				serverErr <- StartWithReady(
 					platform, cfg, st, tokenQueue, nil, db,
-					nil, notifBroker, "", nil, nil, nil, nil, nil,
+					nil, notifBroker, "", nil, nil, nil, nil, nil, ready,
 				)
 			}()
 			// Cleanup: stop service first, then wait for server goroutine to fully exit
@@ -151,6 +153,16 @@ func TestServerStartupConcurrency(t *testing.T) {
 				<-serverDone
 				require.NoError(t, <-serverErr)
 			}()
+
+			// Wait for the listener to bind before reading the resolved port:
+			// with port 0 the server writes the actual port back to cfg only
+			// after a successful bind.
+			select {
+			case bindErr := <-ready:
+				require.NoError(t, bindErr)
+			case <-time.After(2 * time.Second):
+				t.Fatal("server did not bind within timeout")
+			}
 
 			// Test that server becomes available and responds correctly
 			// The server should properly synchronize startup internally

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -415,7 +415,7 @@ type SearchResultWithCursor struct {
 // siblings, so a sole differentiator always survives truncation regardless of its rank.
 // Rank is the slice index.
 var TagTypeDisplayPriority = []string{
-	"unfinished", "unlicensed", "region", "disc", "edition", "rev",
+	"unfinished", "unlicensed", "region", "disc", "edition", "rev", "builddate",
 	"lang", "distribution", "media", "release", "year",
 	"players", "developer", "publisher", "credit",
 }
@@ -437,12 +437,26 @@ func TagTypeDisplayRank(tagType string) int {
 	return len(TagTypeDisplayPriority)
 }
 
+// isFourDigitYear reports whether s is exactly four ASCII digits, the only form
+// accepted for a year value in a ZapScript title command.
+func isFourDigitYear(s string) bool {
+	if len(s) != 4 {
+		return false
+	}
+	for i := range len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // BuildTitleZapScript builds a ZapScript title command string from a system ID,
 // media name, and disambiguating tags. Format: @SystemID/Name (year:YYYY) (type:value)
 // Multiple values of the same type are grouped into one parens as a comma-separated
 // shorthand: (region:eu, region:us). Types are emitted in the order they first appear in
 // the input (callers pass tags pre-sorted by display priority). Only non-empty tags are
-// included; year values must be 4 digits.
+// included; year values must be exactly 4 digits.
 func BuildTitleZapScript(systemID, name string, tags []TagInfo) string {
 	var sb strings.Builder
 	_, _ = sb.WriteString("@" + systemID + "/" + name)
@@ -453,7 +467,7 @@ func BuildTitleZapScript(systemID, name string, tags []TagInfo) string {
 		if tag.Tag == "" {
 			continue
 		}
-		if tag.Type == "year" && len(tag.Tag) != 4 {
+		if tag.Type == "year" && !isFourDigitYear(tag.Tag) {
 			continue
 		}
 		if _, seen := valuesByType[tag.Type]; !seen {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -407,27 +407,74 @@ type SearchResultWithCursor struct {
 	HasCover            bool
 }
 
+// TagTypeDisplayPriority orders the eligible disambiguation tag types from most to least
+// important for display. Clients render the emitted disambiguating tags left-to-right and
+// truncate when space runs out, so the most decisive distinctions come first: variant
+// flags (beta/proto/hack) before region, then the specific-variant markers, then extra
+// context. A tag type only appears on an entry when it actually differs across the title's
+// siblings, so a sole differentiator always survives truncation regardless of its rank.
+// Rank is the slice index.
+var TagTypeDisplayPriority = []string{
+	"unfinished", "unlicensed", "region", "disc", "edition", "rev",
+	"lang", "distribution", "media", "release", "year",
+	"players", "developer", "publisher", "credit",
+}
+
 // ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript
-// title commands. Only these types are considered when checking for disambiguation.
-var ZapScriptTagTypes = []string{"year", "players", "rev", "developer", "publisher", "credit", "edition", "release"}
+// title commands. Only these types are considered when checking for disambiguation. This
+// is the same set as TagTypeDisplayPriority; order is irrelevant here (used for SQL
+// membership), so it aliases the priority list to keep the two in sync.
+var ZapScriptTagTypes = TagTypeDisplayPriority
+
+// TagTypeDisplayRank returns the display-importance rank of a tag type (lower is more
+// important). Unknown types sort last. Used to order emitted disambiguating tags.
+func TagTypeDisplayRank(tagType string) int {
+	for i, t := range TagTypeDisplayPriority {
+		if t == tagType {
+			return i
+		}
+	}
+	return len(TagTypeDisplayPriority)
+}
 
 // BuildTitleZapScript builds a ZapScript title command string from a system ID,
 // media name, and disambiguating tags. Format: @SystemID/Name (year:YYYY) (type:value)
-// Only includes tags that are present in the provided slice.
+// Multiple values of the same type are grouped into one parens as a comma-separated
+// shorthand: (region:eu, region:us). Types are emitted in the order they first appear in
+// the input (callers pass tags pre-sorted by display priority). Only non-empty tags are
+// included; year values must be 4 digits.
 func BuildTitleZapScript(systemID, name string, tags []TagInfo) string {
 	var sb strings.Builder
 	_, _ = sb.WriteString("@" + systemID + "/" + name)
+
+	typeOrder := make([]string, 0, len(tags))
+	valuesByType := make(map[string][]string, len(tags))
 	for _, tag := range tags {
 		if tag.Tag == "" {
 			continue
 		}
-		if tag.Type == "year" {
-			if len(tag.Tag) == 4 {
-				_, _ = sb.WriteString(" (year:" + tag.Tag + ")")
-			}
+		if tag.Type == "year" && len(tag.Tag) != 4 {
 			continue
 		}
-		_, _ = sb.WriteString(" (" + tag.Type + ":" + tag.Tag + ")")
+		if _, seen := valuesByType[tag.Type]; !seen {
+			typeOrder = append(typeOrder, tag.Type)
+		}
+		valuesByType[tag.Type] = append(valuesByType[tag.Type], tag.Tag)
+	}
+
+	for _, tagType := range typeOrder {
+		values := valuesByType[tagType]
+		if len(values) == 0 {
+			continue
+		}
+		_, _ = sb.WriteString(" (")
+		for k, v := range values {
+			if k > 0 {
+				_, _ = sb.WriteString(", ")
+			}
+			_, _ = sb.WriteString(tagType + ":" + v)
+		}
+		_, _ = sb.WriteString(")")
 	}
 	return sb.String()
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -142,13 +142,16 @@ type System struct {
 }
 
 type MediaTitle struct {
-	Slug          string
-	Name          string
-	SecondarySlug sql.NullString
-	DBID          int64
-	SystemDBID    int64
-	SlugLength    int
-	SlugWordCount int
+	Slug string
+	Name string
+	// DisambiguationTypes is the title's stored comma-separated set of tag types
+	// whose values differ across its non-missing media (see RecomputeTitleDisambiguation).
+	DisambiguationTypes string
+	SecondarySlug       sql.NullString
+	DBID                int64
+	SystemDBID          int64
+	SlugLength          int
+	SlugWordCount       int
 }
 
 type Media struct {
@@ -388,16 +391,20 @@ type BrowseSystemRootCandidates struct {
 }
 
 type SearchResultWithCursor struct {
-	SystemID      string
-	Name          string
-	Path          string
-	SortValue     string
-	SortMode      string
-	Tags          []TagInfo
-	ZapScriptTags []TagInfo
-	MediaID       int64
-	MediaTitleID  int64 `json:"-"`
-	HasCover      bool
+	SystemID string
+	Name     string
+	Path     string
+	// DisambiguationTypes is the title's stored comma-separated set of tag types
+	// that distinguish its variants (see RecomputeTitleDisambiguation). Empty for
+	// titles with no variants, which lets the read path skip the tag lookup.
+	DisambiguationTypes string
+	SortValue           string
+	SortMode            string
+	Tags                []TagInfo
+	ZapScriptTags       []TagInfo
+	MediaID             int64
+	MediaTitleID        int64 `json:"-"`
+	HasCover            bool
 }
 
 // ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript
@@ -427,8 +434,9 @@ func BuildTitleZapScript(systemID, name string, tags []TagInfo) string {
 
 // ZapScript returns the ZapScript title command string for this search result.
 // Uses ZapScriptTags (disambiguating tags only). If ZapScriptTags has not been
-// computed (nil), no tags are emitted — callers that need disambiguation must
-// ensure ZapScriptTags is populated via computeZapScriptTags or equivalent.
+// populated (nil), no tags are emitted — callers that need disambiguation must
+// run the result through attachZapScriptTags, which reads the title's stored
+// DisambiguationTypes (see RecomputeTitleDisambiguation).
 func (r *SearchResultWithCursor) ZapScript() string {
 	return BuildTitleZapScript(r.SystemID, r.Name, r.ZapScriptTags)
 }
@@ -836,6 +844,15 @@ type MediaDBI interface {
 	// UpsertMediaTitleTags writes tags to MediaTitleTags for a specific MediaTitle row.
 	// Exclusive/additive behaviour is identical to UpsertMediaTags.
 	UpsertMediaTitleTags(ctx context.Context, mediaTitleDBID int64, tags []TagInfo) error
+
+	// RecomputeTitleDisambiguation recomputes the stored disambiguating tag types
+	// for the given MediaTitle DBIDs. Called after writes that change a title's
+	// media or tags so reads can rely on the stored, title-global value.
+	RecomputeTitleDisambiguation(ctx context.Context, titleDBIDs []int64) error
+
+	// RecomputeSystemDisambiguation recomputes the stored disambiguating tag types
+	// for every MediaTitle belonging to the given system DBIDs. Used at index time.
+	RecomputeSystemDisambiguation(ctx context.Context, systemDBIDs []int64) error
 
 	// UpsertMediaTitleProperties upserts properties into MediaTitleProperties.
 	// Conflicts on (MediaTitleDBID, TypeTagDBID) update data columns; DBID is preserved.

--- a/pkg/database/keys_test.go
+++ b/pkg/database/keys_test.go
@@ -288,6 +288,34 @@ func TestBuildTitleZapScript(t *testing.T) {
 			tags:     []TagInfo{{Tag: "", Type: "publisher"}, {Tag: "nintendo", Type: "publisher"}},
 			want:     "@SNES/Game (publisher:nintendo)",
 		},
+		{
+			name:     "multiple values of same type grouped into shorthand",
+			systemID: "Genesis",
+			gameName: "Sonic The Hedgehog",
+			tags:     []TagInfo{{Tag: "eu", Type: "region"}, {Tag: "us", Type: "region"}},
+			want:     "@Genesis/Sonic The Hedgehog (region:eu, region:us)",
+		},
+		{
+			name:     "different types each get their own parens in first-seen order",
+			systemID: "SNES",
+			gameName: "Game",
+			tags:     []TagInfo{{Tag: "us", Type: "region"}, {Tag: "a", Type: "rev"}},
+			want:     "@SNES/Game (region:us) (rev:a)",
+		},
+		{
+			name:     "non-consecutive same type grouped, value order preserved",
+			systemID: "SNES",
+			gameName: "Game",
+			tags:     []TagInfo{{Tag: "us", Type: "region"}, {Tag: "1", Type: "rev"}, {Tag: "eu", Type: "region"}},
+			want:     "@SNES/Game (region:us, region:eu) (rev:1)",
+		},
+		{
+			name:     "multi-value lang grouped",
+			systemID: "GBA",
+			gameName: "Game",
+			tags:     []TagInfo{{Tag: "en", Type: "lang"}, {Tag: "fr", Type: "lang"}, {Tag: "de", Type: "lang"}},
+			want:     "@GBA/Game (lang:en, lang:fr, lang:de)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/database/keys_test.go
+++ b/pkg/database/keys_test.go
@@ -226,6 +226,13 @@ func TestBuildTitleZapScript(t *testing.T) {
 			want:     "@SNES/Game",
 		},
 		{
+			name:     "year tag with non-digit chars skipped",
+			systemID: "SNES",
+			gameName: "Game",
+			tags:     []TagInfo{{Tag: "abcd", Type: "year"}},
+			want:     "@SNES/Game",
+		},
+		{
 			name:     "players tag",
 			systemID: "SNES",
 			gameName: "Game",

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -108,8 +108,8 @@ func TestRecomputeSystemDisambiguation_DifferingTagDisambiguates(t *testing.T) {
 	ctx := context.Background()
 
 	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "NES", "Sonic", []disambTitleMedia{
-		{path: "/roms/nes/sonic-usa.nes", tags: map[string]string{"release": "USA"}},
-		{path: "/roms/nes/sonic-eur.nes", tags: map[string]string{"release": "Europe"}},
+		{path: browseTestPath("roms", "nes", "sonic-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "sonic-eur.nes"), tags: map[string]string{"release": "Europe"}},
 	})
 
 	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
@@ -206,6 +206,91 @@ func TestRecomputeSystemDisambiguation_MissingMediaExcluded(t *testing.T) {
 
 	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
 	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+// addExtraTag attaches one more (type, value) tag to each of the given media,
+// used to build multi-valued tag sets the map-based setupDisambTitle helper can't
+// express (one value per type).
+func addExtraTag(t *testing.T, mediaDB *MediaDB, mediaIDs []int64, tagType, value string) {
+	t.Helper()
+	tt, err := mediaDB.FindOrInsertTagType(database.TagType{Type: tagType})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	tag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tt.DBID, Tag: value})
+	require.NoError(t, err)
+	for _, mid := range mediaIDs {
+		_, err = mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: mid, TagDBID: tag.DBID})
+		require.NoError(t, err)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+}
+
+// TestRecomputeSystemDisambiguation_IdenticalMultiValueSetsDoNotDisambiguate proves
+// that a multi-valued type identical on every sibling is not flagged: both discs
+// carry the same region set {us, eu}, so only the differing disc number
+// disambiguates. (Pooling distinct values across media would wrongly flag region.)
+func TestRecomputeSystemDisambiguation_IdenticalMultiValueSetsDoNotDisambiguate(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "PSX", "Final Fantasy VII", []disambTitleMedia{
+		{path: browseTestPath("roms", "psx", "ff7-disc1.chd"), tags: map[string]string{"region": "us", "disc": "1"}},
+		{path: browseTestPath("roms", "psx", "ff7-disc2.chd"), tags: map[string]string{"region": "us", "disc": "2"}},
+	})
+
+	// Give both discs the identical second region value so each holds the set {us, eu}.
+	addExtraTag(t, mediaDB, mediaIDs, "region", "eu")
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "disc", titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+// TestRecomputeSystemDisambiguation_DifferingMultiValueSetsDisambiguate is the
+// counterpart: when the per-media region sets differ ({us, eu} vs {us}), region
+// disambiguates.
+func TestRecomputeSystemDisambiguation_DifferingMultiValueSetsDisambiguate(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "SNES", "Secret of Mana", []disambTitleMedia{
+		{path: browseTestPath("roms", "snes", "som-multi.sfc"), tags: map[string]string{"region": "us"}},
+		{path: browseTestPath("roms", "snes", "som-us.sfc"), tags: map[string]string{"region": "us"}},
+	})
+
+	// Only the first media also carries region:eu → its set {us, eu} differs from {us}.
+	addExtraTag(t, mediaDB, mediaIDs[:1], "region", "eu")
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "region", titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+// TestRecomputeTitleDisambiguation_Success exercises the title-scoped entry point
+// (RecomputeTitleDisambiguation) directly, complementing the system-scoped tests.
+func TestRecomputeTitleDisambiguation_Success(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, titleDBID, _ := setupDisambTitle(t, mediaDB, "NES", "Contra", []disambTitleMedia{
+		{path: browseTestPath("roms", "nes", "contra-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "contra-jpn.nes"), tags: map[string]string{"release": "Japan"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeTitleDisambiguation(ctx, []int64{titleDBID}))
+	assert.Equal(t, "release", titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+// TestRecomputeTitleDisambiguation_NullSQL verifies the nil-DB guard.
+func TestRecomputeTitleDisambiguation_NullSQL(t *testing.T) {
+	t.Parallel()
+	db := &MediaDB{}
+	err := db.RecomputeTitleDisambiguation(context.Background(), []int64{1})
+	require.ErrorIs(t, err, ErrNullSQL)
 }
 
 // TestAttachZapScriptTags_TitleGlobalAcrossPages proves the page-independence fix:

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -251,3 +251,56 @@ func TestGetZapScriptTagsBySystemAndPath_Integration(t *testing.T) {
 	require.Len(t, got, 1, "only release differs across the two variants")
 	assert.Equal(t, database.TagInfo{Type: "release", Tag: "USA"}, got[0])
 }
+
+// TestRecomputeSystemDisambiguation_RegionDisambiguates exercises a newly eligible tag
+// type: region (us vs jp) now disambiguates same-named regional variants.
+func TestRecomputeSystemDisambiguation_RegionDisambiguates(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "Genesis", "Sonic The Hedgehog", []disambTitleMedia{
+		{path: "/roms/genesis/sonic-usa.md", tags: map[string]string{"region": "us"}},
+		{path: "/roms/genesis/sonic-jpn.md", tags: map[string]string{"region": "jp"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "region", titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Sonic The Hedgehog", SystemID: "Genesis", DisambiguationTypes: "region"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql, results))
+	require.Len(t, results[0].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "region", Tag: "us"}, results[0].ZapScriptTags[0])
+}
+
+// TestAttachZapScriptTags_OrdersByDisplayPriority verifies emitted tags come back in
+// display-importance order (unfinished › region › rev), not alphabetical, so clients can
+// render-and-truncate left to right.
+func TestAttachZapScriptTags_OrdersByDisplayPriority(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "Genesis", "Streets of Rage", []disambTitleMedia{
+		{path: "/roms/genesis/sor-a.md", tags: map[string]string{"region": "us", "unfinished": "beta", "rev": "a"}},
+		{path: "/roms/genesis/sor-b.md", tags: map[string]string{"region": "jp", "unfinished": "proto", "rev": "b"}},
+	})
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	stored := titleDisambiguationTypes(t, mediaDB, titleDBID)
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Streets of Rage", SystemID: "Genesis", DisambiguationTypes: stored},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql, results))
+	require.Len(t, results[0].ZapScriptTags, 3)
+	gotOrder := []string{
+		results[0].ZapScriptTags[0].Type,
+		results[0].ZapScriptTags[1].Type,
+		results[0].ZapScriptTags[2].Type,
+	}
+	assert.Equal(t, []string{"unfinished", "region", "rev"}, gotOrder)
+}

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -1,0 +1,253 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// disambTitleMedia describes one media row of a title for the test helper: its
+// path and the (type, value) tags to attach.
+type disambTitleMedia struct {
+	tags map[string]string
+	path string
+}
+
+// setupDisambTitle inserts a system, one title, and its media+tags, returning the
+// system DBID, title DBID, and the inserted media DBIDs in input order.
+func setupDisambTitle(
+	t *testing.T, mediaDB *MediaDB, systemID, titleName string, media []disambTitleMedia,
+) (systemDBID, titleDBID int64, mediaDBIDs []int64) {
+	t.Helper()
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: systemID, Name: systemID})
+	require.NoError(t, err)
+
+	// Tag types must exist before the write transaction (mirrors other tests).
+	typeDBIDs := make(map[string]int64)
+	for i := range media {
+		for tagType := range media[i].tags {
+			if _, ok := typeDBIDs[tagType]; ok {
+				continue
+			}
+			tt, ttErr := mediaDB.FindOrInsertTagType(database.TagType{Type: tagType})
+			require.NoError(t, ttErr)
+			typeDBIDs[tagType] = tt.DBID
+		}
+	}
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: system.DBID,
+		Slug:       slugs.Slugify(slugs.MediaTypeGame, titleName),
+		Name:       titleName,
+	})
+	require.NoError(t, err)
+
+	mediaDBIDs = make([]int64, len(media))
+	for i := range media {
+		row, mErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           media[i].path,
+			ParentDir:      ParentDirForMediaPath(media[i].path),
+			SortName:       titleName,
+		})
+		require.NoError(t, mErr)
+		mediaDBIDs[i] = row.DBID
+
+		for tagType, value := range media[i].tags {
+			tag, tErr := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: typeDBIDs[tagType], Tag: value})
+			require.NoError(t, tErr)
+			_, tErr = mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: row.DBID, TagDBID: tag.DBID})
+			require.NoError(t, tErr)
+		}
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	return system.DBID, title.DBID, mediaDBIDs
+}
+
+func titleDisambiguationTypes(t *testing.T, mediaDB *MediaDB, titleDBID int64) string {
+	t.Helper()
+	var types string
+	err := mediaDB.sql.QueryRowContext(
+		context.Background(), `SELECT DisambiguationTypes FROM MediaTitles WHERE DBID = ?`, titleDBID,
+	).Scan(&types)
+	require.NoError(t, err)
+	return types
+}
+
+func TestRecomputeSystemDisambiguation_DifferingTagDisambiguates(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "NES", "Sonic", []disambTitleMedia{
+		{path: "/roms/nes/sonic-usa.nes", tags: map[string]string{"release": "USA"}},
+		{path: "/roms/nes/sonic-eur.nes", tags: map[string]string{"release": "Europe"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "release", titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	// The main browse/search query supplies DisambiguationTypes; simulate that.
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Sonic", SystemID: "NES", DisambiguationTypes: "release"},
+		{MediaID: mediaIDs[1], Name: "Sonic", SystemID: "NES", DisambiguationTypes: "release"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql, results))
+	require.Len(t, results[0].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "release", Tag: "USA"}, results[0].ZapScriptTags[0])
+	require.Len(t, results[1].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "release", Tag: "Europe"}, results[1].ZapScriptTags[0])
+}
+
+func TestRecomputeSystemDisambiguation_IdenticalTagsDoNotDisambiguate(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "NES", "Tetris", []disambTitleMedia{
+		{path: "/roms/nes/tetris-a.nes", tags: map[string]string{"year": "1989"}},
+		{path: "/roms/nes/tetris-b.nes", tags: map[string]string{"year": "1989"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Tetris", SystemID: "NES"},
+		{MediaID: mediaIDs[1], Name: "Tetris", SystemID: "NES"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql, results))
+	assert.Empty(t, results[0].ZapScriptTags)
+	assert.NotNil(t, results[0].ZapScriptTags, "ZapScriptTags should be a non-nil empty slice")
+	assert.Empty(t, results[1].ZapScriptTags)
+}
+
+func TestRecomputeSystemDisambiguation_OnlyDifferingTypeSelected(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Same year, different players — only players disambiguates.
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "Arcade", "Street Fighter", []disambTitleMedia{
+		{path: "/roms/arcade/sf-2p.zip", tags: map[string]string{"year": "1992", "players": "2"}},
+		{path: "/roms/arcade/sf-4p.zip", tags: map[string]string{"year": "1992", "players": "4"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "players", titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Street Fighter", SystemID: "Arcade", DisambiguationTypes: "players"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql, results))
+	require.Len(t, results[0].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "players", Tag: "2"}, results[0].ZapScriptTags[0])
+}
+
+func TestRecomputeSystemDisambiguation_SingleMediaTitle(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, _ := setupDisambTitle(t, mediaDB, "NES", "Solo", []disambTitleMedia{
+		{path: "/roms/nes/solo.nes", tags: map[string]string{"release": "USA"}},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+func TestRecomputeSystemDisambiguation_MissingMediaExcluded(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "NES", "Castlevania", []disambTitleMedia{
+		{path: "/roms/nes/cv-usa.nes", tags: map[string]string{"release": "USA"}},
+		{path: "/roms/nes/cv-eur.nes", tags: map[string]string{"release": "Europe"}},
+	})
+
+	// Mark the Europe variant missing: only one present variant remains, so the
+	// title no longer disambiguates.
+	_, err := mediaDB.sql.ExecContext(ctx, `UPDATE Media SET IsMissing = 1 WHERE DBID = ?`, mediaIDs[1])
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleDBID))
+}
+
+// TestAttachZapScriptTags_TitleGlobalAcrossPages proves the page-independence fix:
+// a single result on its own page still receives its disambiguating tag because
+// the type set is stored per title, not derived from the current page.
+func TestAttachZapScriptTags_TitleGlobalAcrossPages(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parentDir := browseTestDir("roms", "nes")
+	systemDBID, _, _ := setupDisambTitle(t, mediaDB, "NES", "Double Dragon", []disambTitleMedia{
+		{path: browseTestPath("roms", "nes", "dd-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "dd-jpn.nes"), tags: map[string]string{"release": "Japan"}},
+	})
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+
+	// Limit 1 → only the first sibling is on this page; old page-scoped grouping
+	// would have found no sibling and emitted no disambiguating tag.
+	results, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{PathPrefix: parentDir, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Len(t, results[0].ZapScriptTags, 1, "lone sibling on a page must still be disambiguated")
+	assert.Equal(t, "release", results[0].ZapScriptTags[0].Type)
+}
+
+func TestGetZapScriptTagsBySystemAndPath_Integration(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	usaPath := "/roms/nes/contra-usa.nes"
+	systemDBID, _, _ := setupDisambTitle(t, mediaDB, "NES", "Contra", []disambTitleMedia{
+		{path: usaPath, tags: map[string]string{"release": "USA", "year": "1988"}},
+		{path: "/roms/nes/contra-jpn.nes", tags: map[string]string{"release": "Japan", "year": "1988"}},
+	})
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+
+	got, err := mediaDB.GetZapScriptTagsBySystemAndPath(ctx, "NES", usaPath)
+	require.NoError(t, err)
+	require.Len(t, got, 1, "only release differs across the two variants")
+	assert.Equal(t, database.TagInfo{Type: "release", Tag: "USA"}, got[0])
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -692,6 +692,31 @@ func (db *MediaDB) GetLastIndexedSystem() (string, error) {
 	return sqlGetLastIndexedSystem(db.ctx, db.sql)
 }
 
+// RecomputeTitleDisambiguation recomputes the stored disambiguating tag types
+// for the given MediaTitle DBIDs. Callers invoke this after any write that can
+// change a title's set of media or their tags (indexing, scraping, manual tag
+// edits) so reads can rely on the stored, title-global value.
+func (db *MediaDB) RecomputeTitleDisambiguation(ctx context.Context, titleDBIDs []int64) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	return sqlRecomputeTitleDisambiguation(ctx, db.conn(), titleDBIDs)
+}
+
+// RecomputeSystemDisambiguation recomputes the stored disambiguating tag types
+// for every MediaTitle belonging to the given system DBIDs. Called at index time
+// once a system is fully written so all of its titles are refreshed together.
+func (db *MediaDB) RecomputeSystemDisambiguation(ctx context.Context, systemDBIDs []int64) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	return sqlRecomputeDisambiguationForSystems(ctx, db.conn(), systemDBIDs)
+}
+
 // IndexGeneration returns the monotonic counter that's bumped on every
 // successful indexing run. Returns 0 if no indexing has completed yet.
 func (db *MediaDB) IndexGeneration() (int64, error) {

--- a/pkg/database/mediadb/migrations/20260615120000_title_disambiguation.sql
+++ b/pkg/database/mediadb/migrations/20260615120000_title_disambiguation.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE MediaTitles ADD COLUMN DisambiguationTypes TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE MediaTitles DROP COLUMN DisambiguationTypes;

--- a/pkg/database/mediadb/multi_variant_search_test.go
+++ b/pkg/database/mediadb/multi_variant_search_test.go
@@ -71,8 +71,8 @@ func TestSearchMediaWithFilters_MultipleSameMediaTypeSystems(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs("NES", "SNES", "%mario%", "%mario%", 10). // Should be 5 args, not 7
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Super Mario Bros", mediaPath, int64(1)))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("NES", "Super Mario Bros", mediaPath, int64(1), ""))
 
 	// Mock tags query
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -121,7 +121,7 @@ func TestSearchMediaWithFilters_DifferentMediaTypes(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs("PS2", "TVEpisode", "%losts01e05%", "%losts01e05%", 10).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}))
 
 	// No tags query mock needed - no results means fetchAndAttachTags returns early
 
@@ -182,8 +182,8 @@ func TestSearchMediaWithFilters_MultipleWordsMultipleSystems(t *testing.T) {
 			"%mario%", "%mario%", // Word 2: Slug LIKE, SecondarySlug LIKE
 			10, // Limit
 		). // Should be 8 args, not 16
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("SNES", "Super Mario World", mediaPath, int64(1)))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("SNES", "Super Mario World", mediaPath, int64(1), ""))
 
 	// Mock tags query
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").

--- a/pkg/database/mediadb/slug_cache.go
+++ b/pkg/database/mediadb/slug_cache.go
@@ -273,7 +273,8 @@ func (db *MediaDB) GetMediaByDBID(ctx context.Context, mediaDBID int64) (databas
 // GetZapScriptTagsBySystemAndPath retrieves disambiguating tags for a media item.
 // A tag is disambiguating when sibling media entries (same title) have different
 // values for that tag type (e.g., 2-player vs 4-player variants of the same game).
-// Returns only the target media's tags for tag types that differ across siblings.
+// Returns only the target media's tags for tag types listed in the title's
+// precomputed MediaTitles.DisambiguationTypes (see RecomputeTitleDisambiguation).
 // Returns empty slice if no disambiguating tags exist or media not found.
 func (db *MediaDB) GetZapScriptTagsBySystemAndPath(
 	ctx context.Context, systemID, path string,
@@ -282,69 +283,21 @@ func (db *MediaDB) GetZapScriptTagsBySystemAndPath(
 		return nil, ErrNullSQL
 	}
 
-	// Single query: find tag types where siblings under the same title have
-	// different values, then return only the target media's tags for those types.
-	// Checks both MediaTags (file-level) and MediaTitleTags (title-level) tags.
-	typePlaceholders := prepareVariadic("?", ",", len(database.ZapScriptTagTypes))
-	args := make([]any, 0, 2+len(database.ZapScriptTagTypes)*4)
-	args = append(args, systemID, path)
-	for range 4 {
-		for _, tagType := range database.ZapScriptTagTypes {
-			args = append(args, tagType)
-		}
-	}
-
-	rows, err := db.sql.QueryContext(ctx, fmt.Sprintf(`
-		WITH Target AS (
-			SELECT Media.DBID, Media.MediaTitleDBID
-			FROM Media
-			JOIN MediaTitles ON Media.MediaTitleDBID = MediaTitles.DBID
-			JOIN Systems ON MediaTitles.SystemDBID = Systems.DBID
-			WHERE Systems.SystemID = ? AND Media.Path = ? AND Media.IsMissing = 0
-		),
-		-- All eligible tags for the target (file-level + title-level)
-		TargetTags AS (
-			SELECT DISTINCT tt.DBID as TypeDBID, tt.Type, t.Tag
-			FROM Target
-			JOIN MediaTags mt ON Target.DBID = mt.MediaDBID
-			JOIN Tags t ON mt.TagDBID = t.DBID
-			JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-			WHERE tt.Type IN (%s)
-			UNION
-			SELECT DISTINCT tt.DBID as TypeDBID, tt.Type, t.Tag
-			FROM Target
-			JOIN MediaTitleTags mtt ON Target.MediaTitleDBID = mtt.MediaTitleDBID
-			JOIN Tags t ON mtt.TagDBID = t.DBID
-			JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-			WHERE tt.Type IN (%s)
-		),
-		-- All eligible tags across siblings (file-level + title-level)
-		SiblingTags AS (
-			SELECT DISTINCT t.Tag, t.TypeDBID
-			FROM Target
-			JOIN Media sibling ON sibling.MediaTitleDBID = Target.MediaTitleDBID
-			JOIN MediaTags smt ON sibling.DBID = smt.MediaDBID
-			JOIN Tags t ON smt.TagDBID = t.DBID
-			JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-			WHERE tt.Type IN (%s)
-			AND sibling.IsMissing = 0
-			UNION
-			SELECT DISTINCT t.Tag, t.TypeDBID
-			FROM Target
-			JOIN MediaTitleTags mtt ON Target.MediaTitleDBID = mtt.MediaTitleDBID
-			JOIN Tags t ON mtt.TagDBID = t.DBID
-			JOIN TagTypes tt ON t.TypeDBID = tt.DBID
-			WHERE tt.Type IN (%s)
-		)
-		SELECT tt.Type, tt.Tag
-		FROM TargetTags tt
-		WHERE (
-			SELECT COUNT(DISTINCT st.Tag)
-			FROM SiblingTags st
-			WHERE st.TypeDBID = tt.TypeDBID
-		) > 1
-		ORDER BY tt.Type, tt.Tag
-	`, typePlaceholders, typePlaceholders, typePlaceholders, typePlaceholders), args...)
+	// The disambiguating types are precomputed per title, so this is a single
+	// indexed lookup: return the target media's tags whose type is listed for its
+	// title. The comma-boundary membership test never matches a type prefix.
+	rows, err := db.sql.QueryContext(ctx, `
+		SELECT TagTypes.Type, Tags.Tag, Tags.DisplayName
+		FROM Media
+		JOIN MediaTitles ON Media.MediaTitleDBID = MediaTitles.DBID
+		JOIN Systems ON MediaTitles.SystemDBID = Systems.DBID
+		JOIN MediaTags ON MediaTags.MediaDBID = Media.DBID
+		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+		JOIN TagTypes ON TagTypes.DBID = Tags.TypeDBID
+		WHERE Systems.SystemID = ? AND Media.Path = ? AND Media.IsMissing = 0
+		  AND instr(',' || MediaTitles.DisambiguationTypes || ',', ',' || TagTypes.Type || ',') > 0
+		ORDER BY TagTypes.Type, Tags.Tag
+	`, systemID, path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get zapscript tags by system and path: %w", err)
 	}
@@ -357,7 +310,7 @@ func (db *MediaDB) GetZapScriptTagsBySystemAndPath(
 	resultTags := make([]database.TagInfo, 0)
 	for rows.Next() {
 		var tag database.TagInfo
-		if scanErr := rows.Scan(&tag.Type, &tag.Tag); scanErr != nil {
+		if scanErr := rows.Scan(&tag.Type, &tag.Tag, &tag.Label); scanErr != nil {
 			return nil, fmt.Errorf("failed to scan tag: %w", scanErr)
 		}
 		tag.Tag = tags.UnpadTagValue(tag.Tag)

--- a/pkg/database/mediadb/slug_cache.go
+++ b/pkg/database/mediadb/slug_cache.go
@@ -320,5 +320,15 @@ func (db *MediaDB) GetZapScriptTagsBySystemAndPath(
 		return nil, fmt.Errorf("rows iteration error: %w", err)
 	}
 
+	// Order by display importance so the written ZapScript matches the order shown to
+	// users (variant flags, region, ... credit last); sort by value within a type.
+	sort.SliceStable(resultTags, func(a, b int) bool {
+		ra, rb := database.TagTypeDisplayRank(resultTags[a].Type), database.TagTypeDisplayRank(resultTags[b].Type)
+		if ra != rb {
+			return ra < rb
+		}
+		return resultTags[a].Tag < resultTags[b].Tag
+	})
+
 	return resultTags, nil
 }

--- a/pkg/database/mediadb/slug_cache_test.go
+++ b/pkg/database/mediadb/slug_cache_test.go
@@ -886,6 +886,9 @@ func TestGetZapScriptTagsBySystemAndPath_WithYear_Integration(t *testing.T) {
 	err = mediaDB.CommitTransaction()
 	require.NoError(t, err)
 
+	// Disambiguating types are precomputed per title at index time; replicate that here.
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{insertedSystem.DBID}))
+
 	// Test GetZapScriptTagsBySystemAndPath - should return year since siblings differ
 	tags, err := mediaDB.GetZapScriptTagsBySystemAndPath(ctx, nesSystem.ID, "/roms/nes/mario.nes")
 	require.NoError(t, err)
@@ -950,6 +953,9 @@ func TestGetZapScriptTagsBySystemAndPath_UnpadsNumericTags_Integration(t *testin
 
 	err = mediaDB.CommitTransaction()
 	require.NoError(t, err)
+
+	// Disambiguating types are precomputed per title at index time; replicate that here.
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{insertedSystem.DBID}))
 
 	resultTags, err := mediaDB.GetZapScriptTagsBySystemAndPath(
 		ctx,

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -650,9 +650,11 @@ func sqlBrowseFilesFromMedia(
 	sortMode := resolveBrowseSortMode(ctx, db, opts)
 	sortModeElapsed := time.Since(sortModeStarted)
 	sortExpr := browseSortExpr(sortMode)
-	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, ` + sortExpr + ` AS SortValue
+	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, ` +
+		`mt.DisambiguationTypes, ` + sortExpr + ` AS SortValue
 		FROM Media m
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		INNER JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
 		WHERE ` + where
 	if opts.Cursor != nil {
 		query += browseCursorCondition(sortMode)
@@ -672,7 +674,7 @@ func sqlBrowseFilesFromMedia(
 	for rows.Next() {
 		var r database.SearchResultWithCursor
 		if scanErr := rows.Scan(
-			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID, &r.SortValue,
+			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID, &r.DisambiguationTypes, &r.SortValue,
 		); scanErr != nil {
 			return nil, fmt.Errorf("browse files scan: %w", scanErr)
 		}
@@ -705,12 +707,12 @@ func sqlBrowseFilesFromMedia(
 	}
 	coverFlagsElapsed := time.Since(coverFlagsStarted)
 
-	// Disambiguate sibling variants: same SystemID+Name within the page get
-	// ZapScriptTags populated so the tag-write path can produce unambiguous
-	// ZapScript strings. Zero extra queries when there are no siblings (typical).
+	// Populate ZapScriptTags from the title's precomputed disambiguating types
+	// (single indexed lookup). Title-global, so it is correct regardless of how
+	// siblings fall across pages or sort order.
 	siblingsStarted := time.Now()
-	if err := fetchAndDisambiguateSiblings(ctx, db, results); err != nil {
-		return nil, fmt.Errorf("browse files sibling disambiguation: %w", err)
+	if err := attachZapScriptTags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse files disambiguation: %w", err)
 	}
 
 	log.Debug().
@@ -724,66 +726,6 @@ func sqlBrowseFilesFromMedia(
 		Dur("siblingsDuration", time.Since(siblingsStarted)).
 		Msg("browse files step timing")
 	return results, nil
-}
-
-// fetchAndDisambiguateSiblings populates ZapScriptTags on results that share
-// the same SystemID+Name (disc variants, regional editions, etc.) so the
-// tag-write path can build an unambiguous ZapScript string. For pages with no
-// sibling groups — the common case — the function returns immediately after the
-// grouping check with no DB queries. When siblings are present, a single batch
-// tag fetch is issued only for the affected media IDs.
-func fetchAndDisambiguateSiblings(
-	ctx context.Context,
-	db sqlQueryable,
-	results []database.SearchResultWithCursor,
-) error {
-	if len(results) == 0 {
-		return nil
-	}
-
-	nameGroups := make(map[string][]int, len(results))
-	for i := range results {
-		key := results[i].SystemID + "\x00" + results[i].Name
-		nameGroups[key] = append(nameGroups[key], i)
-	}
-
-	var siblingIndices []int
-	for _, indices := range nameGroups {
-		if len(indices) >= 2 {
-			siblingIndices = append(siblingIndices, indices...)
-		}
-	}
-
-	if len(siblingIndices) == 0 {
-		for i := range results {
-			results[i].ZapScriptTags = []database.TagInfo{}
-		}
-		return nil
-	}
-
-	// Fetch full tags only for the sibling results (single batch query).
-	siblingResults := make([]database.SearchResultWithCursor, len(siblingIndices))
-	for i, idx := range siblingIndices {
-		siblingResults[i] = results[idx]
-	}
-	if err := fetchAndAttachTagsByResultIDs(ctx, db, siblingResults); err != nil {
-		return fmt.Errorf("sibling tag fetch: %w", err)
-	}
-	computeZapScriptTags(siblingResults)
-
-	// Write ZapScriptTags back; non-sibling entries get an empty slice.
-	siblingTagMap := make(map[int64][]database.TagInfo, len(siblingIndices))
-	for i, idx := range siblingIndices {
-		siblingTagMap[results[idx].MediaID] = siblingResults[i].ZapScriptTags
-	}
-	for i := range results {
-		if zapTags, ok := siblingTagMap[results[i].MediaID]; ok {
-			results[i].ZapScriptTags = zapTags
-		} else {
-			results[i].ZapScriptTags = []database.TagInfo{}
-		}
-	}
-	return nil
 }
 
 // fetchAndAttachCoverFlags sets HasCover on each result based on whether the

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -765,71 +765,9 @@ func TestFetchAndAttachCoverFlags_Integration_TitleLevelProperty(t *testing.T) {
 	assert.True(t, results[1].HasCover, "media whose title has an image property should have HasCover=true")
 }
 
-// TestFetchAndDisambiguateSiblings_NoSiblings verifies that when all entries on
-// the page have unique names, ZapScriptTags is set to an empty slice with no
-// DB queries.
-func TestFetchAndDisambiguateSiblings_NoSiblings(t *testing.T) {
-	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	results := []database.SearchResultWithCursor{
-		{MediaID: 1, MediaTitleID: 10, SystemID: "NES", Name: "Game A"},
-		{MediaID: 2, MediaTitleID: 11, SystemID: "NES", Name: "Game B"},
-		{MediaID: 3, MediaTitleID: 12, SystemID: "NES", Name: "Game C"},
-	}
-
-	// No DB queries should be issued — grouping is pure in-memory.
-	err = fetchAndDisambiguateSiblings(context.Background(), db, results)
-	require.NoError(t, err)
-	for i, r := range results {
-		assert.Equal(t, []database.TagInfo{}, r.ZapScriptTags, "entry %d should have empty ZapScriptTags", i)
-	}
-	assert.NoError(t, mock.ExpectationsWereMet(), "no DB queries expected")
-}
-
-// TestFetchAndDisambiguateSiblings_EmptyResults verifies the empty-input guard.
-func TestFetchAndDisambiguateSiblings_EmptyResults(t *testing.T) {
-	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	err = fetchAndDisambiguateSiblings(context.Background(), db, nil)
-	require.NoError(t, err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestFetchAndDisambiguateSiblings_DuplicateNamesFetchTags(t *testing.T) {
-	t.Parallel()
-	db, mock, err := testsqlmock.NewSQLMock()
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	results := []database.SearchResultWithCursor{
-		{MediaID: 1, MediaTitleID: 10, SystemID: "NES", Name: "Same Game"},
-		{MediaID: 2, MediaTitleID: 11, SystemID: "NES", Name: "Same Game"},
-	}
-
-	mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM MediaTags`).
-		WithArgs(int64(1), int64(2), int64(10), int64(11)).
-		WillReturnRows(sqlmock.NewRows([]string{"HasTags"}).AddRow(true))
-	mock.ExpectPrepare(`SELECT\s+0 as SourceKind`).
-		ExpectQuery().
-		WithArgs(int64(1), int64(2), int64(10), int64(11)).
-		WillReturnRows(sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "DisplayName", "Type"}).
-			AddRow(0, int64(1), "USA", "United States", "release").
-			AddRow(0, int64(2), "Japan", "Japan", "release"))
-
-	err = fetchAndDisambiguateSiblings(context.Background(), db, results)
-	require.NoError(t, err)
-	require.Len(t, results[0].ZapScriptTags, 1)
-	require.Len(t, results[1].ZapScriptTags, 1)
-	assert.Equal(t, database.TagInfo{Tag: "USA", Type: "release", Label: "United States"}, results[0].ZapScriptTags[0])
-	assert.Equal(t, database.TagInfo{Tag: "Japan", Type: "release", Label: "Japan"}, results[1].ZapScriptTags[0])
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
+// Sibling disambiguation is exercised end-to-end in disambiguation_test.go: it
+// now reads stored per-title types (RecomputeSystemDisambiguation) instead of
+// grouping a page in memory, so it is correct across page boundaries.
 
 // TestBrowseFiles_SortNameFallback_Integration verifies that a media row with
 // SortName=” (pre-migration) gets its display name derived from the file path

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -331,6 +331,84 @@ func sqlGetTitlesBySystemID(ctx context.Context, db *sql.DB, systemID string) ([
 	return titles, rows.Err()
 }
 
+// sqlRecomputeTitleDisambiguation recomputes MediaTitles.DisambiguationTypes for
+// the given titles. A tag type is disambiguating for a title when the title's
+// present (non-missing) media hold more than one distinct value for that type,
+// restricted to database.ZapScriptTagTypes. The result is stored as a sorted,
+// comma-separated list of type names (empty when nothing disambiguates).
+//
+// This is the single source of truth for sibling disambiguation: read paths
+// filter each result's tags by the stored types instead of re-deriving across a
+// page of results, which made disambiguation depend on pagination and sort order.
+func sqlRecomputeTitleDisambiguation(ctx context.Context, db sqlQueryable, titleDBIDs []int64) error {
+	return sqlRecomputeDisambiguation(ctx, db, "DBID", titleDBIDs)
+}
+
+// sqlRecomputeDisambiguationForSystems recomputes DisambiguationTypes for every
+// MediaTitle belonging to the given systems. Used at index time so titles whose
+// media set changed (including titles that lost variants) are all refreshed.
+func sqlRecomputeDisambiguationForSystems(ctx context.Context, db sqlQueryable, systemDBIDs []int64) error {
+	return sqlRecomputeDisambiguation(ctx, db, "SystemDBID", systemDBIDs)
+}
+
+// sqlRecomputeDisambiguation runs the disambiguation UPDATE filtered by either
+// MediaTitles.DBID (title-scoped) or MediaTitles.SystemDBID (system-scoped).
+// filterCol is a trusted constant, never user input.
+func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol string, ids []int64) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	typeHolders := prepareVariadic("?", ",", len(database.ZapScriptTagTypes))
+	typeArgs := make([]any, len(database.ZapScriptTagTypes))
+	for i, t := range database.ZapScriptTagTypes {
+		typeArgs[i] = t
+	}
+
+	// Chunk IDs so total bound parameters stay under SQLite's limit.
+	chunkSize := sqliteMaxParams - len(database.ZapScriptTagTypes)
+	for start := 0; start < len(ids); start += chunkSize {
+		end := start + chunkSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunk := ids[start:end]
+
+		args := make([]any, 0, len(typeArgs)+len(chunk))
+		args = append(args, typeArgs...)
+		for _, id := range chunk {
+			args = append(args, id)
+		}
+
+		//nolint:gosec // filterCol is a trusted constant; placeholders are parameterized
+		query := fmt.Sprintf(`
+			UPDATE MediaTitles
+			SET DisambiguationTypes = COALESCE((
+				SELECT group_concat(Type, ',')
+				FROM (
+					SELECT tt.Type AS Type
+					FROM Media m
+					JOIN MediaTags mt ON mt.MediaDBID = m.DBID
+					JOIN Tags t ON t.DBID = mt.TagDBID
+					JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+					WHERE m.MediaTitleDBID = MediaTitles.DBID
+					  AND m.IsMissing = 0
+					  AND tt.Type IN (%s)
+					GROUP BY tt.Type
+					HAVING COUNT(DISTINCT t.Tag) > 1
+					ORDER BY tt.Type
+				)
+			), '')
+			WHERE MediaTitles.%s IN (%s)
+		`, typeHolders, filterCol, prepareVariadic("?", ",", len(chunk)))
+
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to recompute disambiguation: %w", err)
+		}
+	}
+	return nil
+}
+
 // PreFilterQuery represents pre-filter parameters for efficient fuzzy matching candidate reduction.
 type PreFilterQuery struct {
 	MinLength    int

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -333,9 +333,12 @@ func sqlGetTitlesBySystemID(ctx context.Context, db *sql.DB, systemID string) ([
 
 // sqlRecomputeTitleDisambiguation recomputes MediaTitles.DisambiguationTypes for
 // the given titles. A tag type is disambiguating for a title when the title's
-// present (non-missing) media hold more than one distinct value for that type,
-// restricted to database.ZapScriptTagTypes. The result is stored as a sorted,
-// comma-separated list of type names (empty when nothing disambiguates).
+// present (non-missing) media hold more than one distinct per-media value-set for
+// that type, restricted to database.ZapScriptTagTypes. Comparing per-media sets
+// (not values pooled across media) means a multi-valued type that is identical on
+// every sibling — e.g. every disc tagged (USA, Europe) — does not falsely
+// disambiguate. The result is stored as a sorted, comma-separated list of type
+// names (empty when nothing disambiguates).
 //
 // This is the single source of truth for sibling disambiguation: read paths
 // filter each result's tags by the stored types instead of re-deriving across a
@@ -386,17 +389,25 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 			SET DisambiguationTypes = COALESCE((
 				SELECT group_concat(Type, ',')
 				FROM (
-					SELECT tt.Type AS Type
-					FROM Media m
-					JOIN MediaTags mt ON mt.MediaDBID = m.DBID
-					JOIN Tags t ON t.DBID = mt.TagDBID
-					JOIN TagTypes tt ON tt.DBID = t.TypeDBID
-					WHERE m.MediaTitleDBID = MediaTitles.DBID
-					  AND m.IsMissing = 0
-					  AND tt.Type IN (%s)
-					GROUP BY tt.Type
-					HAVING COUNT(DISTINCT t.Tag) > 1
-					ORDER BY tt.Type
+					SELECT Type
+					FROM (
+						SELECT Type, MediaDBID, group_concat(Tag) AS ValueSet
+						FROM (
+							SELECT DISTINCT tt.Type AS Type, m.DBID AS MediaDBID, t.Tag AS Tag
+							FROM Media m
+							JOIN MediaTags mt ON mt.MediaDBID = m.DBID
+							JOIN Tags t ON t.DBID = mt.TagDBID
+							JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+							WHERE m.MediaTitleDBID = MediaTitles.DBID
+							  AND m.IsMissing = 0
+							  AND tt.Type IN (%s)
+							ORDER BY tt.Type, m.DBID, t.Tag
+						)
+						GROUP BY Type, MediaDBID
+					)
+					GROUP BY Type
+					HAVING COUNT(DISTINCT ValueSet) > 1
+					ORDER BY Type
 				)
 			), '')
 			WHERE MediaTitles.%s IN (%s)

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -1583,6 +1583,12 @@ func (db *MediaDB) ApplyScrapeResult(
 		return fmt.Errorf("ApplyScrapeResult: commit: %w", err)
 	}
 	committed = true
+	// Scraped tags can change which tags distinguish a title's variants. Refresh
+	// after commit (the scrape ran on its own tx, not db.tx). Non-fatal.
+	if disErr := db.RecomputeTitleDisambiguation(ctx, []int64{mediaTitleDBID}); disErr != nil {
+		log.Warn().Err(disErr).Int64("titleID", mediaTitleDBID).
+			Msg("failed to recompute title disambiguation after scrape")
+	}
 	return nil
 }
 
@@ -1623,6 +1629,21 @@ func (db *MediaDB) ApplyScrapeResults(ctx context.Context, targets []database.Sc
 		return fmt.Errorf("ApplyScrapeResults: commit: %w", err)
 	}
 	committed = true
+	// Scraped tags can change which tags distinguish a title's variants. Refresh
+	// the affected titles after commit (the batch ran on its own tx). Non-fatal.
+	titleIDs := make([]int64, 0, len(targets))
+	seenTitles := make(map[int64]struct{}, len(targets))
+	for i := range targets {
+		id := targets[i].MediaTitleDBID
+		if _, ok := seenTitles[id]; ok {
+			continue
+		}
+		seenTitles[id] = struct{}{}
+		titleIDs = append(titleIDs, id)
+	}
+	if disErr := db.RecomputeTitleDisambiguation(ctx, titleIDs); disErr != nil {
+		log.Warn().Err(disErr).Msg("failed to recompute title disambiguation after scrape batch")
+	}
 	stats.Duration = stats.Duration.Round(time.Microsecond)
 	log.Debug().
 		Int("targets", stats.Targets).
@@ -2587,6 +2608,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 		SELECT
 			m.DBID, m.Path, m.ParentDir, m.SortName, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
 			mt.DBID, mt.Slug, mt.SecondarySlug, mt.Name, mt.SlugLength, mt.SlugWordCount, mt.SystemDBID,
+			mt.DisambiguationTypes,
 			s.DBID, s.SystemID, s.Name
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
@@ -2609,6 +2631,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 		&row.MediaTitleDBID, &row.SystemDBID,
 		&row.Title.DBID, &row.Title.Slug, &row.Title.SecondarySlug, &row.Title.Name,
 		&row.Title.SlugLength, &row.Title.SlugWordCount, &row.Title.SystemDBID,
+		&row.Title.DisambiguationTypes,
 		&row.System.DBID, &row.System.SystemID, &row.System.Name,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -2637,6 +2660,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 		SELECT
 			m.DBID, m.Path, m.ParentDir, m.SortName, m.IsMissing, m.MediaTitleDBID, m.SystemDBID,
 			mt.DBID, mt.Slug, mt.SecondarySlug, mt.Name, mt.SlugLength, mt.SlugWordCount, mt.SystemDBID,
+			mt.DisambiguationTypes,
 			s.DBID, s.SystemID, s.Name
 		FROM Media m
 		INNER JOIN MediaTitles mt ON m.MediaTitleDBID = mt.DBID
@@ -2659,6 +2683,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 			&row.MediaTitleDBID, &row.SystemDBID,
 			&row.Title.DBID, &row.Title.Slug, &row.Title.SecondarySlug, &row.Title.Name,
 			&row.Title.SlugLength, &row.Title.SlugWordCount, &row.Title.SystemDBID,
+			&row.Title.DisambiguationTypes,
 			&row.System.DBID, &row.System.SystemID, &row.System.Name,
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan GetMediaWithTitleAndSystemByIDs: %w", err)
@@ -3156,9 +3181,9 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		return nil, fmt.Errorf("resolve singleton aliases tags: %w", err)
 	}
 
-	// Build the alias list and a parallel synthetic results slice for in-memory
-	// ZapScript disambiguation (same approach as computeZapScriptTags in the
-	// search path — no extra DB queries).
+	// Build the alias list and a parallel synthetic results slice carrying each
+	// title's stored DisambiguationTypes, which attachZapScriptTags reads to
+	// populate ZapScriptTags (same path as the search/browse queries).
 	aliases := make([]database.SingletonContainerAlias, 0, len(candidates))
 	synthetic := make([]database.SearchResultWithCursor, 0, len(candidates))
 	for _, c := range candidates {
@@ -3176,15 +3201,18 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 			Tags:     mediaTags,
 		})
 		synthetic = append(synthetic, database.SearchResultWithCursor{
-			SystemID: row.System.SystemID,
-			Name:     row.Title.Name,
-			MediaID:  row.DBID,
-			Tags:     mediaTags,
+			SystemID:            row.System.SystemID,
+			Name:                row.Title.Name,
+			MediaID:             row.DBID,
+			Tags:                mediaTags,
+			DisambiguationTypes: row.Title.DisambiguationTypes,
 		})
 	}
 
-	// In-memory ZapScript disambiguation across the resolved set.
-	computeZapScriptTags(synthetic)
+	// Populate ZapScriptTags from each title's precomputed disambiguating types.
+	if err := attachZapScriptTags(ctx, db.sql, synthetic); err != nil {
+		return nil, fmt.Errorf("resolve singleton aliases disambiguation: %w", err)
+	}
 	for i := range aliases {
 		aliases[i].ZapScriptTags = synthetic[i].ZapScriptTags
 	}

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2351,6 +2351,35 @@ func TestResolveSingletonContainerAliases_TagsAttachedOnAlias(t *testing.T) {
 	assert.Equal(t, "favorite", aliases[0].Tags[0].Type)
 }
 
+// TestResolveSingletonContainerAliases_DisambiguatingTagsAttached verifies that a
+// singleton container alias whose title has sibling variants gets its disambiguating
+// ZapScriptTags populated. The aliased USA disc lives in its own directory while the
+// Japan variant of the same title lives elsewhere; the title therefore disambiguates
+// on "release" and the alias must surface release=USA.
+func TestResolveSingletonContainerAliases_DisambiguatingTagsAttached(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	usaPath := "roms/PSX/USA Disc/game.chd"
+	systemDBID, _, mediaIDs := setupDisambTitle(t, mediaDB, "PSX", "Game", []disambTitleMedia{
+		{path: usaPath, tags: map[string]string{"release": "USA"}},
+		{path: "roms/PSX/Game (Japan).chd", tags: map[string]string{"release": "Japan"}},
+	})
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+
+	aliasDir := ParentDirForMediaPath(usaPath)
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, systemDBID, []database.SingletonAliasCandidate{
+		{ChildDir: aliasDir, FileCount: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, mediaIDs[0], aliases[0].Row.DBID)
+	require.Len(t, aliases[0].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "release", Tag: "USA"}, aliases[0].ZapScriptTags[0])
+}
+
 func TestResolveSingletonContainerAliases_MultipleDirsInOneScan(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupAliasTestDB(t)

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2362,10 +2362,11 @@ func TestResolveSingletonContainerAliases_DisambiguatingTagsAttached(t *testing.
 	defer cleanup()
 	ctx := context.Background()
 
-	usaPath := "roms/PSX/USA Disc/game.chd"
+	usaPath := filepath.ToSlash(filepath.Join("roms", "PSX", "USA Disc", "game.chd"))
+	jpnPath := filepath.ToSlash(filepath.Join("roms", "PSX", "Game (Japan).chd"))
 	systemDBID, _, mediaIDs := setupDisambTitle(t, mediaDB, "PSX", "Game", []disambTitleMedia{
 		{path: usaPath, tags: map[string]string{"release": "USA"}},
-		{path: "roms/PSX/Game (Japan).chd", tags: map[string]string{"release": "Japan"}},
+		{path: jpnPath, tags: map[string]string{"release": "Japan"}},
 	})
 	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
 

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -417,94 +417,118 @@ func logFetchAndAttachTagsTiming(
 	tagPairs int,
 	unionStarted time.Time,
 ) {
-	unionElapsed := time.Since(unionStarted)
-	zsStarted := time.Now()
-	computeZapScriptTags(results)
-	zsElapsed := time.Since(zsStarted)
-
 	log.Debug().
 		Int("rows", len(results)).
 		Int("tagPairs", tagPairs).
-		Dur("unionDuration", unionElapsed).
-		Dur("zapscriptDuration", zsElapsed).
+		Dur("unionDuration", time.Since(unionStarted)).
 		Msg("fetch and attach tags timing")
 }
 
-// computeZapScriptTags determines which tags are disambiguating across sibling
-// variants (results with the same Name) and populates ZapScriptTags on each result.
-// A tag type is disambiguating when multiple results sharing the same Name have
-// different values for that tag type.
+// attachTagsAndDisambiguation attaches all tags to the results and then populates
+// ZapScriptTags from each title's precomputed disambiguating types. Search entry
+// points use this; fetchAndAttachTags itself stays a pure tag-attach step.
+func attachTagsAndDisambiguation(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+		return err
+	}
+	return attachZapScriptTags(ctx, db, results)
+}
+
+// attachZapScriptTags populates ZapScriptTags on each result with the tags that
+// disambiguate it from its same-title siblings. Disambiguation is precomputed and
+// stored per title in MediaTitles.DisambiguationTypes (see RecomputeTitleDisambiguation),
+// so this is a single indexed lookup keyed by media ID — it is title-global and
+// independent of pagination, sort order, or page-level grouping. A media's
+// ZapScriptTags are exactly its MediaTags whose type is listed for its title.
 //
-// KNOWN LIMITATION: This operates on a single page of results, so siblings split
-// across pages won't trigger disambiguation here. The app writes the ZapScript
-// string from search results directly to tags, so a bare @system/name could be
-// written when siblings exist on other pages. In practice this is rare — siblings
-// are adjacent in sort order — and the resolver handles bare commands via its
-// multi-strategy search. A proper fix would require a DB query per title group.
-func computeZapScriptTags(results []database.SearchResultWithCursor) {
-	if len(results) == 0 {
-		return
-	}
-
-	// Group results by SystemID+Name to find siblings (same title within a system)
-	nameGroups := make(map[string][]int) // "SystemID/Name" → indices into results
-	hasSiblings := false
+// Callers MUST populate each result's DisambiguationTypes from the title's stored
+// value (the main search/browse queries select it). An empty DisambiguationTypes is
+// treated as "title has no variants" and skips the lookup, so a result left empty by
+// mistake silently yields no ZapScriptTags.
+func attachZapScriptTags(ctx context.Context, db sqlQueryable, results []database.SearchResultWithCursor) error {
 	for i := range results {
-		key := results[i].SystemID + "/" + results[i].Name
-		nameGroups[key] = append(nameGroups[key], i)
-		if len(nameGroups[key]) > 1 {
-			hasSiblings = true
+		if results[i].ZapScriptTags == nil {
+			results[i].ZapScriptTags = []database.TagInfo{}
 		}
 	}
-	if !hasSiblings {
-		for i := range results {
-			if results[i].ZapScriptTags == nil {
-				results[i].ZapScriptTags = []database.TagInfo{}
-			}
-		}
-		return
+	if len(results) == 0 {
+		return nil
 	}
 
-	for _, indices := range nameGroups {
-		if len(indices) < 2 {
-			for _, idx := range indices {
-				if results[idx].ZapScriptTags == nil {
-					results[idx].ZapScriptTags = []database.TagInfo{}
-				}
-			}
+	// Only media whose title actually has variants need a lookup. Titles with no
+	// variants have an empty DisambiguationTypes, so the common page (no variants)
+	// issues zero queries.
+	mediaIDs := make([]int64, 0, len(results))
+	seen := make(map[int64]struct{}, len(results))
+	for i := range results {
+		id := results[i].MediaID
+		if id == 0 || results[i].DisambiguationTypes == "" {
 			continue
 		}
-		// For each eligible tag type, collect distinct values across siblings
-		disambiguating := make(map[string]bool) // tag types that need disambiguation
-
-		for _, tagType := range database.ZapScriptTagTypes {
-			values := make(map[string]bool)
-			for _, idx := range indices {
-				for _, tag := range results[idx].Tags {
-					if tag.Type == tagType {
-						values[tag.Tag] = true
-					}
-				}
-			}
-			if len(values) > 1 {
-				disambiguating[tagType] = true
-			}
+		if _, ok := seen[id]; ok {
+			continue
 		}
+		seen[id] = struct{}{}
+		mediaIDs = append(mediaIDs, id)
+	}
+	if len(mediaIDs) == 0 {
+		return nil
+	}
 
-		// Populate ZapScriptTags with only disambiguating tags for each result
-		for _, idx := range indices {
-			var zapTags []database.TagInfo
-			for _, tag := range results[idx].Tags {
-				if disambiguating[tag.Type] {
-					zapTags = append(zapTags, tag)
-				}
-			}
-			results[idx].ZapScriptTags = zapTags
-			if results[idx].ZapScriptTags == nil {
-				results[idx].ZapScriptTags = []database.TagInfo{}
-			}
+	placeholders := prepareVariadic("?", ",", len(mediaIDs))
+	args := make([]any, len(mediaIDs))
+	for i, id := range mediaIDs {
+		args[i] = id
+	}
+
+	// Comma-boundary membership test against the stored type list: a Type matches
+	// only when delimited by commas on both sides, so "rev" never matches "revision".
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	query := `
+		SELECT Media.DBID, TagTypes.Type, Tags.Tag, Tags.DisplayName
+		FROM Media
+		JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
+		JOIN MediaTags ON MediaTags.MediaDBID = Media.DBID
+		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+		JOIN TagTypes ON TagTypes.DBID = Tags.TypeDBID
+		WHERE Media.DBID IN (` + placeholders + `)
+		  AND instr(',' || MediaTitles.DisambiguationTypes || ',', ',' || TagTypes.Type || ',') > 0
+		ORDER BY Media.DBID, TagTypes.Type, Tags.Tag`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to query disambiguating tags: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close disambiguating tags rows")
+		}
+	}()
+
+	byMedia := make(map[int64][]database.TagInfo)
+	for rows.Next() {
+		var mediaID int64
+		var tag database.TagInfo
+		if scanErr := rows.Scan(&mediaID, &tag.Type, &tag.Tag, &tag.Label); scanErr != nil {
+			return fmt.Errorf("failed to scan disambiguating tag: %w", scanErr)
+		}
+		tag.Tag = dbtags.UnpadTagValue(tag.Tag)
+		byMedia[mediaID] = append(byMedia[mediaID], tag)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("disambiguating tags rows iteration error: %w", err)
+	}
+
+	for i := range results {
+		if zapTags, ok := byMedia[results[i].MediaID]; ok {
+			results[i].ZapScriptTags = zapTags
 		}
 	}
+	return nil
 }
 
 func sqlSearchMediaPathExact(
@@ -816,7 +840,8 @@ func sqlSearchMediaWithFilters(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID
+			Media.DBID,
+			MediaTitles.DisambiguationTypes
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -859,7 +884,9 @@ func sqlSearchMediaWithFilters(
 	// Collect media items
 	for mediaRows.Next() {
 		result := database.SearchResultWithCursor{}
-		if scanErr := mediaRows.Scan(&result.SystemID, &result.Name, &result.Path, &result.MediaID); scanErr != nil {
+		if scanErr := mediaRows.Scan(
+			&result.SystemID, &result.Name, &result.Path, &result.MediaID, &result.DisambiguationTypes,
+		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan media result: %w", scanErr)
 		}
 		results = append(results, result)
@@ -871,7 +898,7 @@ func sqlSearchMediaWithFilters(
 
 	// Fetch and attach tags for all results
 	tagsStarted := time.Now()
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return results, err
 	}
 
@@ -936,7 +963,8 @@ func sqlSearchMediaByTitleDBIDs(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID
+			Media.DBID,
+			MediaTitles.DisambiguationTypes
 		FROM MediaTitles
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -959,7 +987,9 @@ func sqlSearchMediaByTitleDBIDs(
 	results := make([]database.SearchResultWithCursor, 0, min(limit, 100))
 	for rows.Next() {
 		var r database.SearchResultWithCursor
-		if scanErr := rows.Scan(&r.SystemID, &r.Name, &r.Path, &r.MediaID); scanErr != nil {
+		if scanErr := rows.Scan(
+			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.DisambiguationTypes,
+		); scanErr != nil {
 			return nil, fmt.Errorf("failed to scan result: %w", scanErr)
 		}
 		results = append(results, r)
@@ -970,7 +1000,7 @@ func sqlSearchMediaByTitleDBIDs(
 	queryElapsed := time.Since(queryStarted)
 
 	tagsStarted := time.Now()
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return nil, err
 	}
 
@@ -1018,7 +1048,8 @@ func sqlSearchMediaBySlug(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID as MediaID
+			Media.DBID as MediaID,
+			MediaTitles.DisambiguationTypes
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -1052,6 +1083,7 @@ func sqlSearchMediaBySlug(
 			&result.Name,
 			&result.Path,
 			&result.MediaID,
+			&result.DisambiguationTypes,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -1063,7 +1095,7 @@ func sqlSearchMediaBySlug(
 	}
 
 	// Fetch and attach tags for all results
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return results, err
 	}
 
@@ -1108,7 +1140,8 @@ func sqlSearchMediaBySecondarySlug(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID as MediaID
+			Media.DBID as MediaID,
+			MediaTitles.DisambiguationTypes
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -1142,6 +1175,7 @@ func sqlSearchMediaBySecondarySlug(
 			&result.Name,
 			&result.Path,
 			&result.MediaID,
+			&result.DisambiguationTypes,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -1153,7 +1187,7 @@ func sqlSearchMediaBySecondarySlug(
 	}
 
 	// Fetch and attach tags for all results
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return results, err
 	}
 
@@ -1193,7 +1227,8 @@ func sqlSearchMediaBySlugPrefix(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID as MediaID
+			Media.DBID as MediaID,
+			MediaTitles.DisambiguationTypes
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -1227,6 +1262,7 @@ func sqlSearchMediaBySlugPrefix(
 			&result.Name,
 			&result.Path,
 			&result.MediaID,
+			&result.DisambiguationTypes,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -1238,7 +1274,7 @@ func sqlSearchMediaBySlugPrefix(
 	}
 
 	// Fetch and attach tags for all results
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return results, err
 	}
 
@@ -1301,7 +1337,8 @@ func sqlSearchMediaBySlugIn(
 			Systems.SystemID,
 			MediaTitles.Name,
 			Media.Path,
-			Media.DBID as MediaID
+			Media.DBID as MediaID,
+			MediaTitles.DisambiguationTypes
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -1335,6 +1372,7 @@ func sqlSearchMediaBySlugIn(
 			&result.Name,
 			&result.Path,
 			&result.MediaID,
+			&result.DisambiguationTypes,
 		); scanErr != nil {
 			return results, fmt.Errorf("failed to scan search result: %w", scanErr)
 		}
@@ -1346,7 +1384,7 @@ func sqlSearchMediaBySlugIn(
 	}
 
 	// Fetch and attach tags for all results
-	if err := fetchAndAttachTags(ctx, db, results); err != nil {
+	if err := attachTagsAndDisambiguation(ctx, db, results); err != nil {
 		return results, err
 	}
 

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -525,6 +525,15 @@ func attachZapScriptTags(ctx context.Context, db sqlQueryable, results []databas
 
 	for i := range results {
 		if zapTags, ok := byMedia[results[i].MediaID]; ok {
+			// Order by display importance (variant flags, region, ... credit last) so
+			// clients can render left-to-right and truncate. Within a type, sort by value.
+			sort.SliceStable(zapTags, func(a, b int) bool {
+				ra, rb := database.TagTypeDisplayRank(zapTags[a].Type), database.TagTypeDisplayRank(zapTags[b].Type)
+				if ra != rb {
+					return ra < rb
+				}
+				return zapTags[a].Tag < zapTags[b].Tag
+			})
 			results[i].ZapScriptTags = zapTags
 		}
 	}

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -357,8 +357,6 @@ func TestFetchAndAttachTags_ResultTitleIDsNoTagsSkipsFullFetch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, results[0].Tags)
 	assert.Empty(t, results[1].Tags)
-	assert.NotNil(t, results[0].ZapScriptTags)
-	assert.NotNil(t, results[1].ZapScriptTags)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -539,8 +537,8 @@ func TestSqlSearchMediaWithFilters_IntegrationWithTags(t *testing.T) {
 	includeName := false
 
 	// Mock the main media query
-	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1))
+	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1), "")
 
 	mock.ExpectPrepare(`SELECT.*FROM Systems.*WHERE Systems.SystemID IN`).
 		ExpectQuery().
@@ -577,8 +575,8 @@ func TestSqlSearchMediaBySlug_IntegrationWithTags(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	// Mock the main search query
-	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1))
+	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1), "")
 
 	mock.ExpectPrepare(`SELECT.*FROM Systems.*WHERE Systems.SystemID = \?.*AND MediaTitles.Slug = \?`).
 		ExpectQuery().
@@ -612,8 +610,8 @@ func TestSqlSearchMediaBySecondarySlug_IntegrationWithTags(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	// Mock the main search query
-	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-		AddRow("nes", "Super Mario Bros", "/games/smb.nes", int64(1))
+	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+		AddRow("nes", "Super Mario Bros", "/games/smb.nes", int64(1), "")
 
 	mock.ExpectPrepare(`SELECT.*FROM Systems.*WHERE Systems.SystemID = \?.*AND MediaTitles.SecondarySlug = \?`).
 		ExpectQuery().
@@ -647,9 +645,9 @@ func TestSqlSearchMediaBySlugPrefix_IntegrationWithTags(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	// Mock the main search query
-	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1)).
-		AddRow("nes", "Super Mario Bros 2", "/games/mario2.nes", int64(2))
+	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1), "").
+		AddRow("nes", "Super Mario Bros 2", "/games/mario2.nes", int64(2), "")
 
 	mock.ExpectPrepare(`SELECT.*FROM Systems.*WHERE Systems.SystemID = \?.*AND MediaTitles.Slug LIKE \?`).
 		ExpectQuery().
@@ -686,9 +684,9 @@ func TestSqlSearchMediaBySlugIn_IntegrationWithTags(t *testing.T) {
 	slugList := []string{"super-mario-bros", "the-legend-of-zelda"}
 
 	// Mock the main search query
-	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1)).
-		AddRow("nes", "The Legend of Zelda", "/games/zelda.nes", int64(2))
+	mediaRows := sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+		AddRow("nes", "Super Mario Bros", "/games/mario.nes", int64(1), "").
+		AddRow("nes", "The Legend of Zelda", "/games/zelda.nes", int64(2), "")
 
 	mock.ExpectPrepare(`SELECT.*FROM Systems.*WHERE Systems.SystemID = \?.*AND MediaTitles.Slug IN`).
 		ExpectQuery().
@@ -749,152 +747,7 @@ func TestSqlSearchMediaBySlugIn_AllEmptySlugs(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestComputeZapScriptTags_Empty(t *testing.T) {
-	t.Parallel()
-	results := []database.SearchResultWithCursor{}
-	computeZapScriptTags(results)
-	assert.Empty(t, results)
-}
-
-func TestComputeZapScriptTags_SingleResult(t *testing.T) {
-	t.Parallel()
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{
-				{Type: "year", Tag: "1989"},
-				{Type: "genre", Tag: "Puzzle"},
-			},
-		},
-	}
-	computeZapScriptTags(results)
-	assert.Empty(t, results[0].ZapScriptTags, "single result should have no disambiguating tags")
-	assert.NotNil(t, results[0].ZapScriptTags, "ZapScriptTags should be initialized, not nil")
-}
-
-func TestComputeZapScriptTags_SiblingsDifferentYear(t *testing.T) {
-	t.Parallel()
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{
-				{Type: "year", Tag: "1989"},
-				{Type: "genre", Tag: "Puzzle"},
-			},
-		},
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 2,
-			Tags: []database.TagInfo{
-				{Type: "year", Tag: "1990"},
-				{Type: "genre", Tag: "Puzzle"},
-			},
-		},
-	}
-	computeZapScriptTags(results)
-	require.Len(t, results[0].ZapScriptTags, 1)
-	assert.Equal(t, "year", results[0].ZapScriptTags[0].Type)
-	assert.Equal(t, "1989", results[0].ZapScriptTags[0].Tag)
-	require.Len(t, results[1].ZapScriptTags, 1)
-	assert.Equal(t, "year", results[1].ZapScriptTags[0].Type)
-	assert.Equal(t, "1990", results[1].ZapScriptTags[0].Tag)
-}
-
-func TestComputeZapScriptTags_SiblingsSameYear(t *testing.T) {
-	t.Parallel()
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1989"}},
-		},
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 2,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1989"}},
-		},
-	}
-	computeZapScriptTags(results)
-	assert.Empty(t, results[0].ZapScriptTags, "same year across siblings should not disambiguate")
-	assert.Empty(t, results[1].ZapScriptTags)
-}
-
-func TestComputeZapScriptTags_MixedDisambiguation(t *testing.T) {
-	t.Parallel()
-	// Same year but different players — only players should disambiguate
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Street Fighter", SystemID: "Arcade", MediaID: 1,
-			Tags: []database.TagInfo{
-				{Type: "year", Tag: "1992"},
-				{Type: "players", Tag: "2"},
-			},
-		},
-		{
-			Name: "Street Fighter", SystemID: "Arcade", MediaID: 2,
-			Tags: []database.TagInfo{
-				{Type: "year", Tag: "1992"},
-				{Type: "players", Tag: "4"},
-			},
-		},
-	}
-	computeZapScriptTags(results)
-	// Only players should be disambiguating (years are the same)
-	require.Len(t, results[0].ZapScriptTags, 1)
-	assert.Equal(t, "players", results[0].ZapScriptTags[0].Type)
-	assert.Equal(t, "2", results[0].ZapScriptTags[0].Tag)
-	require.Len(t, results[1].ZapScriptTags, 1)
-	assert.Equal(t, "players", results[1].ZapScriptTags[0].Type)
-	assert.Equal(t, "4", results[1].ZapScriptTags[0].Tag)
-}
-
-func TestComputeZapScriptTags_DifferentNamesNotGrouped(t *testing.T) {
-	t.Parallel()
-	// Different names should not be grouped as siblings
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1989"}},
-		},
-		{
-			Name: "Dr. Mario", SystemID: "NES", MediaID: 2,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1990"}},
-		},
-	}
-	computeZapScriptTags(results)
-	assert.Empty(t, results[0].ZapScriptTags, "different names should not trigger disambiguation")
-	assert.Empty(t, results[1].ZapScriptTags)
-}
-
-func TestComputeZapScriptTags_NonEligibleTagTypesIgnored(t *testing.T) {
-	t.Parallel()
-	// Genre differs across siblings but is not in ZapScriptTagTypes
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{{Type: "genre", Tag: "Puzzle"}},
-		},
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 2,
-			Tags: []database.TagInfo{{Type: "genre", Tag: "Action"}},
-		},
-	}
-	computeZapScriptTags(results)
-	assert.Empty(t, results[0].ZapScriptTags, "non-eligible tag types should not disambiguate")
-	assert.Empty(t, results[1].ZapScriptTags)
-}
-
-func TestComputeZapScriptTags_CrossSystemSameNameNotGrouped(t *testing.T) {
-	t.Parallel()
-	// Same name on different systems should NOT be grouped as siblings
-	results := []database.SearchResultWithCursor{
-		{
-			Name: "Tetris", SystemID: "NES", MediaID: 1,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1989"}},
-		},
-		{
-			Name: "Tetris", SystemID: "GB", MediaID: 2,
-			Tags: []database.TagInfo{{Type: "year", Tag: "1990"}},
-		},
-	}
-	computeZapScriptTags(results)
-	assert.Empty(t, results[0].ZapScriptTags, "cross-system same name should not trigger disambiguation")
-	assert.Empty(t, results[1].ZapScriptTags)
-}
+// Disambiguation behavior is exercised end-to-end against a real database in
+// disambiguation_test.go (RecomputeSystemDisambiguation + attachZapScriptTags),
+// since the logic now lives in stored per-title types rather than in-memory
+// page grouping.

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -593,8 +593,8 @@ func TestSqlSearchMediaWithFilters_WithTags(t *testing.T) {
 		ExpectQuery().
 		// Slug LIKE, SecondarySlug LIKE, tag args doubled for both tag sources
 		WithArgs("NES", "%mario%", "%mario%", "genre", "Action", "genre", "Action", 10).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Mario", "/games/mario.nes", 1))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("NES", "Mario", "/games/mario.nes", 1, ""))
 
 	// Mock second query: get tags for the media items
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -633,6 +633,8 @@ func expectSearchTagsQuery(mock sqlmock.Sqlmock, mediaID int64) {
 		ExpectQuery().
 		WithArgs(mediaID, mediaID).
 		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "DisplayName", "Type"}))
+	// No disambiguation lookup is expected: these fixtures return an empty
+	// DisambiguationTypes, so attachZapScriptTags skips the query entirely.
 }
 
 func TestSqlSearchMediaWithFilters_AllSystemsTagOnlySkipsSystemFilter(t *testing.T) {
@@ -648,8 +650,8 @@ func TestSqlSearchMediaWithFilters_AllSystemsTagOnlySkipsSystemFilter(t *testing
 	mock.ExpectPrepare("(?s)WHERE\\s+Media\\.IsMissing = 0.*ORDER BY Media\\.DBID ASC.*LIMIT \\?").
 		ExpectQuery().
 		WithArgs("user", "favorite", "user", "favorite", 10).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 7))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 7, ""))
 	expectSearchTagsQuery(mock, 7)
 
 	results, err := sqlSearchMediaWithFilters(
@@ -682,8 +684,8 @@ func TestSqlSearchMediaWithFilters_DuplicateSystemsMissingOneKeepsSystemFilter(t
 	mock.ExpectPrepare(searchSystemFilterPattern).
 		ExpectQuery().
 		WithArgs(args...).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow(allSystems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 8))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow(allSystems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 8, ""))
 	expectSearchTagsQuery(mock, 8)
 
 	results, err := sqlSearchMediaWithFilters(
@@ -714,8 +716,8 @@ func TestSqlSearchMediaWithFilters_NonTagDrivenKeepsSystemFilter(t *testing.T) {
 		mock.ExpectPrepare(searchSystemFilterPattern).
 			ExpectQuery().
 			WithArgs(args...).
-			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-				AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 9))
+			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+				AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), 9, ""))
 		expectSearchTagsQuery(mock, 9)
 
 		results, err := sqlSearchMediaWithFilters(
@@ -743,8 +745,8 @@ func TestSqlSearchMediaWithFilters_NonTagDrivenKeepsSystemFilter(t *testing.T) {
 		mock.ExpectPrepare(searchVariantSystemFilterPattern).
 			ExpectQuery().
 			WithArgs(args...).
-			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-				AddRow(systems[0].ID, "Mario", filepath.ToSlash(filepath.Join("roms", "mario.rom")), 10))
+			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+				AddRow(systems[0].ID, "Mario", filepath.ToSlash(filepath.Join("roms", "mario.rom")), 10, ""))
 		expectSearchTagsQuery(mock, 10)
 
 		results, err := sqlSearchMediaWithFilters(
@@ -1278,8 +1280,8 @@ func TestSqlSearchMediaBySlug_Success(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1, ""))
 
 	// Mock tags query (now always called even when no tag filters)
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1312,8 +1314,8 @@ func TestSqlSearchMediaBySlug_WithTags(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug, "region", "usa", "region", "usa", "genre", "platform", "genre", "platform").
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("snes", "Super Mario World", "/games/super-mario-world-usa.smc", 1))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("snes", "Super Mario World", "/games/super-mario-world-usa.smc", 1, ""))
 
 	// Mock tags query
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1354,9 +1356,9 @@ func TestSqlSearchMediaBySlug_MultipleResults(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("genesis", "Sonic the Hedgehog", "/games/sonic.bin", 1).
-			AddRow("genesis", "Sonic the Hedgehog 2", "/games/sonic2.bin", 2))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("genesis", "Sonic the Hedgehog", "/games/sonic.bin", 1, "").
+			AddRow("genesis", "Sonic the Hedgehog 2", "/games/sonic2.bin", 2, ""))
 
 	// Mock tags query (now always called even when no tag filters)
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1398,9 +1400,9 @@ func TestSqlSearchMediaBySlug_LoadsTagsWithoutFilters(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("snes", "Super Mario World (USA)", "/games/smw-usa.smc", 1).
-			AddRow("snes", "Super Mario World (Europe)", "/games/smw-eu.smc", 2))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("snes", "Super Mario World (USA)", "/games/smw-usa.smc", 1, "").
+			AddRow("snes", "Super Mario World (Europe)", "/games/smw-eu.smc", 2, ""))
 
 	// Mock tags query - returns tags for both ROMs
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1444,7 +1446,7 @@ func TestSqlSearchMediaBySlug_NoResults(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}))
 
 	results, err := sqlSearchMediaBySlug(context.Background(), db, systemID, slug, tags)
 
@@ -1467,7 +1469,7 @@ func TestSqlSearchMediaBySlug_WithTagsNoResults(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug, "region", "japan", "region", "japan").
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}))
 
 	results, err := sqlSearchMediaBySlug(context.Background(), db, systemID, slug, tags)
 
@@ -1514,8 +1516,8 @@ func TestSqlSearchMediaBySlug_TagsQueryError(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug, "region", "usa", "region", "usa").
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1, ""))
 
 	// Mock tags query error
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1577,8 +1579,8 @@ func TestSqlSearchMediaBySlug_TagsScanError(t *testing.T) {
 	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
 		ExpectQuery().
 		WithArgs(systemID, slug, "region", "usa", "region", "usa").
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID"}).
-			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "MediaID", "DisambiguationTypes"}).
+			AddRow("snes", "Super Mario World", "/games/super-mario-world.smc", 1, ""))
 
 	// Mock tags query with wrong column count (scan error)
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1953,9 +1955,9 @@ func TestSqlSearchMediaByTitleDBIDs_BasicLookup(t *testing.T) {
 
 	mock.ExpectQuery("SELECT .+ FROM MediaTitles").
 		WithArgs(int64(10), int64(20), 100).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Super Mario Bros", "/games/nes/smb.nes", 100).
-			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("NES", "Super Mario Bros", "/games/nes/smb.nes", 100, "").
+			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200, ""))
 
 	// Tag query (fetchAndAttachTags uses PrepareContext)
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
@@ -1988,8 +1990,8 @@ func TestSqlSearchMediaByTitleDBIDs_WithCursor(t *testing.T) {
 	cursor := int64(150)
 	mock.ExpectQuery("SELECT .+ FROM MediaTitles").
 		WithArgs(int64(10), cursor, 100).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("NES", "Zelda", "/games/nes/zelda.nes", 200, ""))
 
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().
@@ -2012,8 +2014,8 @@ func TestSqlSearchMediaByTitleDBIDs_WithLetter(t *testing.T) {
 	letter := "S"
 	mock.ExpectQuery("SELECT .+ FROM MediaTitles").
 		WithArgs(int64(10), letter, 100).
-		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID"}).
-			AddRow("NES", "Super Mario Bros", "/games/nes/smb.nes", 100))
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow("NES", "Super Mario Bros", "/games/nes/smb.nes", 100, ""))
 
 	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
 		ExpectQuery().

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -316,8 +316,9 @@ func AddMediaPathWithPrefixPolicy(
 			tagIndex = foundTagIndex
 		}
 
-		// Dynamically create open-ended string tags for rev, developer, publisher, and credit.
-		// These types allow arbitrary values (e.g. "rev:7-2502", "credit:nintendo-r-and-d1").
+		// Dynamically create open-ended string tags for rev, developer, publisher, credit,
+		// and builddate. These types allow arbitrary values (e.g. "rev:7-2502",
+		// "credit:nintendo-r-and-d1", "builddate:1993-10-05").
 		if tagIndex == 0 {
 			var dynType string
 			switch {
@@ -329,6 +330,8 @@ func AddMediaPathWithPrefixPolicy(
 				dynType = string(tags.TagTypePublisher)
 			case strings.HasPrefix(tagStr, string(tags.TagTypeCredit)+":"):
 				dynType = string(tags.TagTypeCredit)
+			case strings.HasPrefix(tagStr, string(tags.TagTypeBuildDate)+":"):
+				dynType = string(tags.TagTypeBuildDate)
 			}
 			if dynType != "" {
 				tagValue := strings.TrimPrefix(tagStr, dynType+":")

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -494,6 +494,57 @@ func TestAddMediaPath_ReindexesExistingMediaRefreshesDerivedMetadata(t *testing.
 	assert.Equal(t, 1, extensionTagCount)
 }
 
+// TestAddMediaPath_ArcadeBuildDateTagPersisted verifies the freeform builddate tag
+// produced from a MiSTer Arcade "(Region YYMMDD)" name survives indexing. builddate
+// is an open-ended value type, so the pipeline must create it dynamically (like rev/
+// credit) — otherwise it is dropped as "unknown".
+func TestAddMediaPath_ArcadeBuildDateTagPersisted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	state := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, state))
+
+	path := filepath.Join("_Arcade", "Super Street Fighter II The New Challengers (World 931005).mra")
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, mediaID, err := AddMediaPath(mediaDB, state, "Arcade", path, "", false, false, nil, slugs.MediaTypeGame)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT TagTypes.Type, Tags.Tag
+		FROM MediaTags
+		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+		JOIN TagTypes ON TagTypes.DBID = Tags.TypeDBID
+		WHERE MediaTags.MediaDBID = ?`, mediaID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var got []string
+	for rows.Next() {
+		var typ, val string
+		require.NoError(t, rows.Scan(&typ, &val))
+		got = append(got, typ+":"+tags.UnpadTagValue(val))
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Contains(t, got, "builddate:1993-10-05", "build date tag should persist through indexing")
+	assert.Contains(t, got, "region:world")
+}
+
 func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -1209,6 +1209,13 @@ func NewNamesIndex(
 				return 0, fmt.Errorf("failed to mark missing media for system %s: %w", systemID, missErr)
 			}
 		}
+		// Refresh stored sibling disambiguation now the system's media, tags, and
+		// missing flags are final. Runs in the same transaction so it observes the
+		// missing flags just written. Non-fatal: stale disambiguation only affects
+		// display/ZapScript hints and is corrected on the next index.
+		if disErr := db.RecomputeSystemDisambiguation(ctx, []int64{int64(systemDBID)}); disErr != nil {
+			log.Warn().Err(disErr).Str("system", systemID).Msg("failed to recompute title disambiguation")
+		}
 		if commitErr := db.CommitTransaction(); commitErr != nil {
 			return 0, fmt.Errorf("failed to commit missing-state transaction: %w", commitErr)
 		}

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -236,6 +236,40 @@ func classifyUnmappedParen(normalized, _ string) ([]CanonicalTag, bool) {
 		return []CanonicalTag{{Type: TagTypeRelease, Value: TagReleaseClassics, Source: TagSourceBracketed}}, true
 	}
 
+	// ROM hack with a title prefix: "smw-hack", "sa-1-smw-hack" → unlicensed:hack.
+	// (Bare "hack" already maps; the title prefix is what breaks the dash-split.)
+	if last == "hack" && len(tokens) >= 2 {
+		return []CanonicalTag{{Type: TagTypeUnlicensed, Value: TagUnlicensedHack, Source: TagSourceBracketed}}, true
+	}
+
+	// Cracked dump with a cracker credit: "4am-crack", "...-crack" → dump:cracked.
+	if last == "crack" && len(tokens) >= 2 {
+		return []CanonicalTag{{Type: TagTypeDump, Value: TagDumpCracked, Source: TagSourceBracketed}}, true
+	}
+
+	// Literal translation marker: "english-translation" → unlicensed:translation, plus the
+	// language tag when the prefix names a language.
+	if last == "translation" {
+		result := []CanonicalTag{{Type: TagTypeUnlicensed, Value: TagUnlicensedTranslation, Source: TagSourceBracketed}}
+		if len(tokens) >= 2 {
+			prefix := strings.Join(tokens[:len(tokens)-1], "-")
+			for _, lt := range mapFilenameTagToCanonical(prefix) {
+				if lt.Type == TagTypeLang {
+					lt.Source = TagSourceBracketed
+					result = append(result, lt)
+				}
+			}
+		}
+		return result, true
+	}
+
+	// Set number: "set-1", "set-2" → set:N (distinct from media-structure "disc-N").
+	if first == "set" && len(tokens) >= 2 {
+		if number, ok := normalizeStructuralNumber(tokens[1]); ok {
+			return []CanonicalTag{{Type: TagTypeSet, Value: TagValue(number), Source: TagSourceBracketed}}, true
+		}
+	}
+
 	// Version phrases — drop, no tag ("version" or its Romance-language equivalents)
 	for _, t := range tokens {
 		if t == "version" || t == "versione" || t == "versao" {
@@ -1036,6 +1070,7 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 	}
 
 	var results []CanonicalTag
+	var unmatched []string
 
 	for _, part := range parts {
 		// Clean up the part (remove leading/trailing whitespace and dashes)
@@ -1048,10 +1083,37 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 		normalized := cachedNormalizeTag(part)
 		mapped := mapFilenameTagToCanonical(normalized)
 
+		matched := false
 		for _, ct := range mapped {
 			if ct.Type != TagTypeUnknown {
 				ct.Source = TagSourceBracketed
 				results = append(results, ct)
+				matched = true
+			}
+		}
+		// A comma-part may itself be a "Region YYMMDD" pack, e.g. the "Japan 951020"
+		// half of "(CPS Changer, Japan 951020)".
+		if !matched {
+			if rdTags, ok := parseRegionDateToken(normalized); ok {
+				results = append(results, rdTags...)
+				matched = true
+			}
+		}
+		if !matched {
+			unmatched = append(unmatched, normalized)
+		}
+	}
+
+	// MiSTer Arcade also writes the region and date as separate comma-parts, e.g.
+	// "(EU, 961004)". A standalone 6-digit number is normally rejected as a date, but
+	// the presence of a region sibling makes it unambiguous, so accept it here.
+	if hasTagType(results, TagTypeRegion) {
+		for _, u := range unmatched {
+			if v, ok := parseBuildDate(u); ok {
+				results = append(results, CanonicalTag{
+					Type: TagTypeBuildDate, Value: TagValue(v), Source: TagSourceBracketed,
+				})
+				break
 			}
 		}
 	}
@@ -1060,6 +1122,42 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 		return results
 	}
 	return nil
+}
+
+// parseRegionDateToken handles the MiSTer Arcade naming convention where a single
+// parenthetical packs a region word and a build date, space-separated (normalization
+// turns the space into a dash): "World 931005" → "world-931005" →
+// region:world + builddate:1993-10-05. It also accepts a standalone build date
+// (YYYY-MM-DD or YYYYMMDD). A bare 6-digit number is deliberately NOT treated as a
+// date unless preceded by a region word, to avoid false positives on plain numbers.
+// Returns the canonical tags and true on a match.
+func parseRegionDateToken(normalized string) ([]CanonicalTag, bool) {
+	// Standalone date: YYYY-MM-DD (dashed) or YYYYMMDD (8 digits). Bare 6-digit is
+	// excluded here — it only counts as a date with a region prefix (below).
+	if strings.Contains(normalized, "-") || len(normalized) == 8 {
+		if v, ok := parseBuildDate(normalized); ok {
+			return []CanonicalTag{{Type: TagTypeBuildDate, Value: TagValue(v), Source: TagSourceBracketed}}, true
+		}
+	}
+
+	// Region word + trailing date. Split on the last dash so multi-word regions
+	// ("hong-kong", "united-kingdom") stay intact.
+	i := strings.LastIndex(normalized, "-")
+	if i <= 0 || i >= len(normalized)-1 {
+		return nil, false
+	}
+	prefix, last := normalized[:i], normalized[i+1:]
+	v, ok := parseBuildDate(last)
+	if !ok {
+		return nil, false
+	}
+	regionTags := mapFilenameTagToCanonical(prefix)
+	if !hasTagType(regionTags, TagTypeRegion) {
+		return nil, false
+	}
+	result := withSource(regionTags, TagSourceBracketed)
+	result = append(result, CanonicalTag{Type: TagTypeBuildDate, Value: TagValue(v), Source: TagSourceBracketed})
+	return result, true
 }
 
 // disambiguateTag uses context to determine the correct canonical tag(s) for an ambiguous raw tag.
@@ -1121,6 +1219,12 @@ func disambiguateTag(ctx *ParseContext) []CanonicalTag {
 	// Check if it's comma-separated mixed tags (JP, Rev B) or (USA, Europe)
 	if mixedTags := parseCommaSeparatedTags(normalized); mixedTags != nil {
 		return mixedTags
+	}
+
+	// MiSTer Arcade "Region YYMMDD" packs a region word and a build date in one
+	// parens (no comma): "World 931005" → region:world + builddate:1993-10-05.
+	if rdTags, ok := parseRegionDateToken(normalized); ok {
+		return rdTags
 	}
 
 	// For parentheses tags, use position and context

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -770,6 +770,155 @@ func TestParseFilenameToCanonicalTags_Integration(t *testing.T) {
 	}
 }
 
+func TestParseFilenameToCanonicalTags_ArcadeRegionBuildDate(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		wantTags []string
+	}{
+		{
+			name:     "World region with build date",
+			filename: "Super Street Fighter II The New Challengers (World 931005).mra",
+			wantTags: []string{"region:world", "builddate:1993-10-05"},
+		},
+		{
+			name:     "USA region with build date adds lang",
+			filename: "Some Arcade Game (USA 040202).mra",
+			wantTags: []string{"region:us", "lang:en", "builddate:2004-02-02"},
+		},
+		{
+			name:     "Europe region with build date no longer credit",
+			filename: "X-Men Vs. Street Fighter (Europe 961004).mra",
+			wantTags: []string{"region:eu", "builddate:1996-10-04"},
+		},
+		{
+			name:     "qualifier comma region with build date",
+			filename: "Street Fighter Zero (CPS Changer, Japan 951020).mra",
+			wantTags: []string{"region:jp", "lang:ja", "builddate:1995-10-20"},
+		},
+		{
+			name:     "standalone No-Intro build date",
+			filename: "Sonic The Hedgehog 2 (1992-09-21).bin",
+			wantTags: []string{"builddate:1992-09-21"},
+		},
+		{
+			name:     "comma-separated region and bare date",
+			filename: "X-Men Vs. Street Fighter (EU, 961004).mra",
+			wantTags: []string{"region:eu", "builddate:1996-10-04"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseFilenameToCanonicalTags(tt.filename)
+			gotStrings := make([]string, len(got))
+			for i, tag := range got {
+				gotStrings[i] = tag.String()
+			}
+			for _, want := range tt.wantTags {
+				assert.Contains(t, gotStrings, want, "expected %s in %v", want, gotStrings)
+			}
+			// No credit: fallback should survive for these region+date names.
+			for _, tagStr := range gotStrings {
+				assert.False(t, strings.HasPrefix(tagStr, "credit:"),
+					"region+date name should not produce credit: tag, got %q", tagStr)
+			}
+		})
+	}
+}
+
+func TestParseFilenameToCanonicalTags_CreditRemappings(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		wantTags []string
+		wantNot  []string // tag prefixes that must NOT appear
+	}{
+		{
+			name:     "title-prefixed hack is unlicensed not credit",
+			filename: "Super Mario World (SMW Hack).sfc",
+			wantTags: []string{"unlicensed:hack"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "multi-token hack",
+			filename: "Super Mario World (SA-1 SMW Hack).sfc",
+			wantTags: []string{"unlicensed:hack"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "cracker credit becomes dump cracked",
+			filename: "Pitfall (4am Crack).a26",
+			wantTags: []string{"dump:cracked"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "multi-token cracker",
+			filename: "Game (4am and SAN Inc Crack).dsk",
+			wantTags: []string{"dump:cracked"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "english translation maps to unlicensed plus lang",
+			filename: "Final Fantasy (English Translation).sfc",
+			wantTags: []string{"unlicensed:translation", "lang:en"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "set number maps to set tag",
+			filename: "Galaga (Set 1).mra",
+			wantTags: []string{"set:1"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "wip maps to unfinished",
+			filename: "Some Homebrew (WIP).bin",
+			wantTags: []string{"unfinished:wip"},
+			wantNot:  []string{"credit:"},
+		},
+		{
+			name:     "genuine company name stays credit",
+			filename: "Cracktro (Fairlight).d64",
+			wantTags: []string{"credit:fairlight"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseFilenameToCanonicalTags(tt.filename)
+			gotStrings := make([]string, len(got))
+			for i, tag := range got {
+				gotStrings[i] = tag.String()
+			}
+			for _, want := range tt.wantTags {
+				assert.Contains(t, gotStrings, want, "expected %s in %v", want, gotStrings)
+			}
+			for _, prefix := range tt.wantNot {
+				for _, tagStr := range gotStrings {
+					assert.False(t, strings.HasPrefix(tagStr, prefix),
+						"%q should not produce %s tag, got %q", tt.filename, prefix, tagStr)
+				}
+			}
+		})
+	}
+}
+
+func TestParseFilenameToCanonicalTags_BareNumberNotBuildDate(t *testing.T) {
+	// A bare 6-digit number with no region word must not be read as a build date,
+	// including as a comma-part with no region sibling.
+	for _, filename := range []string{
+		"Mystery Game (123456).rom",
+		"Mystery Game (931005).rom",
+		"Mystery Game (Foo, 961004).rom",
+	} {
+		got := ParseFilenameToCanonicalTags(filename)
+		for _, tag := range got {
+			assert.NotEqual(t, TagTypeBuildDate, tag.Type,
+				"bare number in %q should not produce a build date, got %s", filename, tag.String())
+		}
+	}
+}
+
 func TestParseFilenameToCanonicalTags_NoDuplicates(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/database/tags/string_parsers.go
+++ b/pkg/database/tags/string_parsers.go
@@ -121,6 +121,62 @@ func isBracketedYearValue(s string) bool {
 	return s[0] == '2' && s[1] == '0' // 2000-2099
 }
 
+// allDigits reports whether every byte of s is an ASCII digit (s must be non-empty).
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := range len(s) {
+		if !isDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// atoi2 converts a 2-digit ASCII string to its integer value (no validation).
+func atoi2(s string) int {
+	return int(s[0]-'0')*10 + int(s[1]-'0')
+}
+
+// validMonthDay reports whether m is 1–12 and d is 1–31 (calendar-agnostic bound).
+func validMonthDay(m, d int) bool {
+	return m >= 1 && m <= 12 && d >= 1 && d <= 31
+}
+
+// parseBuildDate normalizes a romset/build date to YYYY-MM-DD. It accepts MiSTer
+// arcade YYMMDD (6 digits; century pivot at 70, so 70–99→19xx and 00–69→20xx),
+// YYYYMMDD (8 digits), and No-Intro YYYY-MM-DD. Returns false for any other shape
+// or an out-of-range month/day. The 6-digit form is the arcade convention; callers
+// gate it on a preceding region word to avoid matching bare numbers.
+func parseBuildDate(s string) (string, bool) {
+	switch {
+	case len(s) == 10 && s[4] == '-' && s[7] == '-':
+		if !allDigits(s[0:4]) || !allDigits(s[5:7]) || !allDigits(s[8:10]) {
+			return "", false
+		}
+		if !validMonthDay(atoi2(s[5:7]), atoi2(s[8:10])) {
+			return "", false
+		}
+		return s, true
+	case len(s) == 8 && allDigits(s):
+		if !validMonthDay(atoi2(s[4:6]), atoi2(s[6:8])) {
+			return "", false
+		}
+		return s[0:4] + "-" + s[4:6] + "-" + s[6:8], true
+	case len(s) == 6 && allDigits(s):
+		if !validMonthDay(atoi2(s[2:4]), atoi2(s[4:6])) {
+			return "", false
+		}
+		century := "20"
+		if s[0] >= '7' { // first digit 7–9 ⇒ YY 70–99 ⇒ 1900s
+			century = "19"
+		}
+		return century + s[0:2] + "-" + s[2:4] + "-" + s[4:6], true
+	}
+	return "", false
+}
+
 // parseMatch holds the result of a string-based pattern match, replacing []int
 // from FindStringSubmatchIndex. Fields are indices into the original string.
 type parseMatch struct {

--- a/pkg/database/tags/string_parsers_test.go
+++ b/pkg/database/tags/string_parsers_test.go
@@ -74,6 +74,44 @@ func TestIsYearValue(t *testing.T) {
 	assert.False(t, isYearValue(""))
 }
 
+func TestParseBuildDate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		// arcade YYMMDD, century pivot at 70
+		{in: "931005", want: "1993-10-05", ok: true},
+		{in: "961004", want: "1996-10-04", ok: true},
+		{in: "040202", want: "2004-02-02", ok: true},
+		{in: "000101", want: "2000-01-01", ok: true},
+		{in: "691231", want: "2069-12-31", ok: true},
+		{in: "700101", want: "1970-01-01", ok: true},
+		// YYYYMMDD
+		{in: "19920921", want: "1992-09-21", ok: true},
+		// YYYY-MM-DD passthrough
+		{in: "1992-09-21", want: "1992-09-21", ok: true},
+		// invalid month/day
+		{in: "999999", want: "", ok: false},
+		{in: "931305", want: "", ok: false}, // month 13
+		{in: "930032", want: "", ok: false}, // day 32
+		{in: "1992-13-01", want: "", ok: false},
+		// wrong shapes
+		{in: "12345", want: "", ok: false},   // 5 digits
+		{in: "1234567", want: "", ok: false}, // 7 digits
+		{in: "world", want: "", ok: false},
+		{in: "world-931005", want: "", ok: false},
+		{in: "", want: "", ok: false},
+	}
+	for _, tt := range tests {
+		got, ok := parseBuildDate(tt.in)
+		assert.Equal(t, tt.ok, ok, "ok mismatch for %q", tt.in)
+		assert.Equal(t, tt.want, got, "value mismatch for %q", tt.in)
+	}
+}
+
 func TestFindBracketedYear(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/tags/tag_mappings.go
+++ b/pkg/database/tags/tag_mappings.go
@@ -216,6 +216,7 @@ var allTagMappings = map[string][]CanonicalTag{
 	"beta-5":               {{Type: TagTypeUnfinished, Value: TagUnfinishedBeta5}},
 	"preview":              {{Type: TagTypeUnfinished, Value: TagUnfinishedPreview}},
 	"pre-release":          {{Type: TagTypeUnfinished, Value: TagUnfinishedPrerelease}},
+	"wip":                  {{Type: TagTypeUnfinished, Value: TagUnfinishedWIP}},
 	"proto":                {{Type: TagTypeUnfinished, Value: TagUnfinishedProto}},
 	"prototype":            {{Type: TagTypeUnfinished, Value: TagUnfinishedProto}},
 	"engineering-sample":   {{Type: TagTypeUnfinished, Value: TagUnfinishedProto}},

--- a/pkg/database/tags/tag_values.go
+++ b/pkg/database/tags/tag_values.go
@@ -438,6 +438,7 @@ const (
 	TagUnfinishedPreview     TagValue = "preview"
 	TagUnfinishedPrerelease  TagValue = "prerelease"
 	TagUnfinishedFinal       TagValue = "final"
+	TagUnfinishedWIP         TagValue = "wip"
 )
 
 // Unlicensed tag values

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -117,6 +117,7 @@ const (
 	TagTypeMameParent    TagType = "mameparent"    // MAME parent ROM relationship
 	TagTypeRegion        TagType = "region"        // Release region
 	TagTypeYear          TagType = "year"          // Release year
+	TagTypeBuildDate     TagType = "builddate"     // Romset/build date (YYYY-MM-DD); MiSTer arcade YYMMDD
 	TagTypeSeason        TagType = "season"        // TV show season number
 	TagTypeEpisode       TagType = "episode"       // TV show episode number
 	TagTypeTrack         TagType = "track"         // Music track number
@@ -684,6 +685,7 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagUnfinishedPreview,     // Preview version (our addition)
 		TagUnfinishedPrerelease,  // Pre-release version (our addition)
 		TagUnfinishedFinal,       // Final release (TOSEC/demo-scene: completed version)
+		TagUnfinishedWIP,         // Work-in-progress build
 		// Demo variants
 		TagUnfinishedDemoPlayable, TagUnfinishedDemoRolling, TagUnfinishedDemoSlideshow,
 	},
@@ -759,6 +761,10 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 
 	TagTypeCredit: {
 		// Dynamic values - company credits where developer/publisher role is unspecified
+	},
+
+	TagTypeBuildDate: {
+		// Dynamic values - romset/build dates normalized to YYYY-MM-DD by the parser.
 	},
 
 	TagTypeRelease: {

--- a/pkg/database/tags/tagtypes.go
+++ b/pkg/database/tags/tagtypes.go
@@ -53,6 +53,9 @@ var CanonicalIsExclusive = map[TagType]bool{
 	TagTypeUnfinished: true,
 	TagTypeCopyright:  true,
 
+	// One build/romset date per file
+	TagTypeBuildDate: true,
+
 	// Game family/series — one authoritative value per title
 	TagTypeGameFamily: true,
 

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2166,6 +2166,9 @@ func NewMockMediaDBI() *MockMediaDBI {
 	mockMediaDB.On("ResetMissingFlags", mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("UpdateMediaTitle", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("DeleteMediaTags", mock.Anything).Return(nil).Maybe()
+	// Disambiguation refresh runs per system at the end of indexing.
+	mockMediaDB.On("RecomputeSystemDisambiguation", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockMediaDB.On("RecomputeTitleDisambiguation", mock.Anything, mock.Anything).Return(nil).Maybe()
 	return mockMediaDB
 }
 
@@ -2508,6 +2511,22 @@ func (m *MockMediaDBI) UpsertMediaTags(ctx context.Context, mediaDBID int64, tag
 
 func (m *MockMediaDBI) UpsertMediaTitleTags(ctx context.Context, mediaTitleDBID int64, tags []database.TagInfo) error {
 	args := m.Called(ctx, mediaTitleDBID, tags)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) RecomputeTitleDisambiguation(ctx context.Context, titleDBIDs []int64) error {
+	args := m.Called(ctx, titleDBIDs)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) RecomputeSystemDisambiguation(ctx context.Context, systemDBIDs []int64) error {
+	args := m.Called(ctx, systemDBIDs)
 	if err := args.Error(0); err != nil {
 		return fmt.Errorf("mock operation failed: %w", err)
 	}

--- a/pkg/zapscript/titles/selection.go
+++ b/pkg/zapscript/titles/selection.go
@@ -175,38 +175,52 @@ func FilterByTags(
 
 // HasAllTags checks if a result matches the specified tag filters
 // Respects operator logic: AND (must have), NOT (must not have), OR (at least one)
+// tagValueSets builds a lookup of a result's tags as type -> set of values. Multi-valued
+// types (e.g. region:us,eu or lang:en,fr,de) keep every value rather than collapsing to a
+// single last-write-wins value, so tag filters match against the full set.
+func tagValueSets(result *database.SearchResultWithCursor) map[string]map[string]struct{} {
+	sets := make(map[string]map[string]struct{}, len(result.Tags))
+	for _, tag := range result.Tags {
+		values, ok := sets[tag.Type]
+		if !ok {
+			values = make(map[string]struct{})
+			sets[tag.Type] = values
+		}
+		values[tag.Tag] = struct{}{}
+	}
+	return sets
+}
+
 func HasAllTags(result *database.SearchResultWithCursor, tagFilters []zapscript.TagFilter) bool {
 	if len(tagFilters) == 0 {
 		return true
 	}
 
-	// Create a map of result's tags for fast lookup
-	resultTags := make(map[string]string) // type -> value
-	for _, tag := range result.Tags {
-		resultTags[tag.Type] = tag.Tag
-	}
+	resultTags := tagValueSets(result)
 
 	// Group filters by operator using shared logic
 	andFilters, notFilters, orFilters := database.GroupTagFiltersByOperator(tagFilters)
 
-	// Check AND filters: must have ALL
+	// Check AND filters: the result's value set for the type must contain the value.
 	for _, requiredTag := range andFilters {
-		value, exists := resultTags[requiredTag.Type]
+		values, exists := resultTags[requiredTag.Type]
 		if !exists {
 			// Tag type not present on result — can't evaluate.
 			// Missing metadata is not a conflict, so skip rather
 			// than rejecting results that simply lack this tag type.
 			continue
 		}
-		if value != requiredTag.Value {
+		if _, ok := values[requiredTag.Value]; !ok {
 			return false
 		}
 	}
 
 	// Check NOT filters: must NOT have ANY
 	for _, excludedTag := range notFilters {
-		if value, exists := resultTags[excludedTag.Type]; exists && value == excludedTag.Value {
-			return false // Has a tag that should be excluded
+		if values, exists := resultTags[excludedTag.Type]; exists {
+			if _, ok := values[excludedTag.Value]; ok {
+				return false // Has a tag that should be excluded
+			}
 		}
 	}
 
@@ -214,9 +228,11 @@ func HasAllTags(result *database.SearchResultWithCursor, tagFilters []zapscript.
 	if len(orFilters) > 0 {
 		hasAtLeastOne := false
 		for _, orTag := range orFilters {
-			if value, exists := resultTags[orTag.Type]; exists && value == orTag.Value {
-				hasAtLeastOne = true
-				break
+			if values, exists := resultTags[orTag.Type]; exists {
+				if _, ok := values[orTag.Value]; ok {
+					hasAtLeastOne = true
+					break
+				}
 			}
 		}
 		if !hasAtLeastOne {
@@ -574,11 +590,8 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 		return 1.0
 	}
 
-	// Create a map of result's tags for fast lookup
-	resultTags := make(map[string]string) // type -> value
-	for _, tag := range result.Tags {
-		resultTags[tag.Type] = tag.Tag
-	}
+	// Build a lookup of the result's tags as type -> set of values.
+	resultTags := tagValueSets(result)
 
 	// If result has no tags at all, give moderate confidence (0.65)
 	// This handles database entries with incomplete tag information
@@ -596,13 +609,13 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 	// on the result. Missing metadata is not a conflict.
 	applicableAndFilters := 0
 	for _, requiredTag := range andFilters {
-		value, exists := resultTags[requiredTag.Type]
+		values, exists := resultTags[requiredTag.Type]
 		if !exists {
 			// Tag type not present — can't evaluate, skip.
 			continue
 		}
 		applicableAndFilters++
-		if value == requiredTag.Value {
+		if _, ok := values[requiredTag.Value]; ok {
 			matched++
 		} else {
 			conflicts++
@@ -611,7 +624,8 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 
 	// Check NOT filters
 	for _, excludedTag := range notFilters {
-		if value, exists := resultTags[excludedTag.Type]; exists && value == excludedTag.Value {
+		values, exists := resultTags[excludedTag.Type]
+		if _, has := values[excludedTag.Value]; exists && has {
 			// Has a tag that should be excluded - major penalty
 			conflicts += 2
 		} else {
@@ -624,10 +638,12 @@ func CalculateTagMatchConfidence(result *database.SearchResultWithCursor, tagFil
 	if len(orFilters) > 0 {
 		hasAtLeastOne := false
 		for _, orTag := range orFilters {
-			if value, exists := resultTags[orTag.Type]; exists && value == orTag.Value {
-				hasAtLeastOne = true
-				matched++
-				break
+			if values, exists := resultTags[orTag.Type]; exists {
+				if _, ok := values[orTag.Value]; ok {
+					hasAtLeastOne = true
+					matched++
+					break
+				}
 			}
 		}
 		if !hasAtLeastOne {

--- a/pkg/zapscript/titles/selection_test.go
+++ b/pkg/zapscript/titles/selection_test.go
@@ -300,6 +300,59 @@ func TestHasAllTagsOperators(t *testing.T) {
 			tagFilters: []zapscript.TagFilter{},
 			expected:   true,
 		},
+		{
+			name: "multi-value type - AND matches one value in the set",
+			result: database.SearchResultWithCursor{
+				Tags: []database.TagInfo{
+					{Type: "region", Tag: "us"},
+					{Type: "region", Tag: "eu"},
+				},
+			},
+			tagFilters: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+			},
+			expected: true,
+		},
+		{
+			name: "multi-value type - AND of two values both in the set",
+			result: database.SearchResultWithCursor{
+				Tags: []database.TagInfo{
+					{Type: "region", Tag: "us"},
+					{Type: "region", Tag: "eu"},
+				},
+			},
+			tagFilters: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+				{Type: "region", Value: "eu", Operator: zapscript.TagOperatorAND},
+			},
+			expected: true, // set-aware: collapsing to one value would fail this
+		},
+		{
+			name: "multi-value type - AND value not in the set",
+			result: database.SearchResultWithCursor{
+				Tags: []database.TagInfo{
+					{Type: "region", Tag: "us"},
+					{Type: "region", Tag: "eu"},
+				},
+			},
+			tagFilters: []zapscript.TagFilter{
+				{Type: "region", Value: "jp", Operator: zapscript.TagOperatorAND},
+			},
+			expected: false,
+		},
+		{
+			name: "multi-value lang - NOT matches a value in the set",
+			result: database.SearchResultWithCursor{
+				Tags: []database.TagInfo{
+					{Type: "lang", Tag: "en"},
+					{Type: "lang", Tag: "fr"},
+				},
+			},
+			tagFilters: []zapscript.TagFilter{
+				{Type: "lang", Value: "fr", Operator: zapscript.TagOperatorNOT},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/zapscript/titles/tags.go
+++ b/pkg/zapscript/titles/tags.go
@@ -39,6 +39,10 @@ var reCanonicalTag = regexp.MustCompile(`\(([+~-]?)([a-zA-Z][a-zA-Z0-9_-]*):([^)
 // Matches format: (operator?type:value) where operator is -, +, or ~ (optional, defaults to AND)
 // Examples: (-unfinished:beta), (+region:us), (year:1994), (~lang:en)
 //
+// Multiple tags may be comma-separated inside a single parens group as a shorthand,
+// space-optional: (region:us, region:ja), (region:us,rev:a). The gate on a type:value
+// colon means filename parens like (USA), (Disc 1) or (En,Fr,De) are left in the title.
+//
 // This is used to support operator-based tag filtering in media titles, separate from
 // filename metadata tags which don't support operators.
 //
@@ -51,24 +55,24 @@ func ExtractCanonicalTagsFromParens(input string) (tagFilters []zapscript.TagFil
 	matches := reCanonicalTag.FindAllStringSubmatch(input, -1)
 
 	for _, match := range matches {
-		fullMatch := match[0] // "(+region:us)"
-		operator := match[1]  // "+"
-		tagType := match[2]   // "region"
-		tagValue := match[3]  // "us"
+		fullMatch := match[0]   // "(region:us, region:ja)"
+		operator := match[1]    // leading operator, if any
+		tagType := match[2]     // first tag type
+		innerValues := match[3] // value plus any further comma-separated tags
 
-		// Construct tag string with operator for parsing
-		tagStr := operator + tagType + ":" + tagValue
-
-		// Parse using existing filter parser (handles normalization and validation)
-		parsedFilters, err := filters.ParseTagFilters([]string{tagStr})
+		// Reconstruct the full inner content and split into individual type:value
+		// entries. filters.ParseTagFilters trims each, applies per-entry operators,
+		// normalizes, validates, and deduplicates — no custom tag parsing here.
+		inner := operator + tagType + ":" + innerValues
+		parsedFilters, err := filters.ParseTagFilters(strings.Split(inner, ","))
 		if err != nil {
-			log.Warn().Err(err).Str("tag", tagStr).Msg("failed to parse canonical tag from parentheses")
+			log.Warn().Err(err).Str("tags", inner).Msg("failed to parse canonical tags from parentheses")
 			continue
 		}
 
 		if len(parsedFilters) > 0 {
-			extractedTags = append(extractedTags, parsedFilters[0])
-			// Remove this tag from the string
+			extractedTags = append(extractedTags, parsedFilters...)
+			// Remove this whole parens group from the string
 			remaining = strings.Replace(remaining, fullMatch, "", 1)
 		}
 	}

--- a/pkg/zapscript/titles/tags_test.go
+++ b/pkg/zapscript/titles/tags_test.go
@@ -321,6 +321,81 @@ func TestExtractCanonicalTagsFromParensEdgeCases(t *testing.T) {
 	}
 }
 
+func TestExtractCanonicalTagsFromParensCommaShorthand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		input             string
+		expectedRemaining string
+		expected          []zapscript.TagFilter
+	}{
+		{
+			name:              "two values same type with space",
+			input:             "Game (region:us, region:eu)",
+			expectedRemaining: "Game",
+			expected: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+				{Type: "region", Value: "eu", Operator: zapscript.TagOperatorAND},
+			},
+		},
+		{
+			name:              "two values same type no space",
+			input:             "Game (region:us,region:eu)",
+			expectedRemaining: "Game",
+			expected: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+				{Type: "region", Value: "eu", Operator: zapscript.TagOperatorAND},
+			},
+		},
+		{
+			name:              "extra whitespace around comma",
+			input:             "Game (region:us ,  region:eu)",
+			expectedRemaining: "Game",
+			expected: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+				{Type: "region", Value: "eu", Operator: zapscript.TagOperatorAND},
+			},
+		},
+		{
+			name:              "mixed types in one parens",
+			input:             "Game (region:us, rev:a)",
+			expectedRemaining: "Game",
+			expected: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+				{Type: "rev", Value: "a", Operator: zapscript.TagOperatorAND},
+			},
+		},
+		{
+			name:              "filename language list left untouched",
+			input:             "Game (En,Fr,De)",
+			expectedRemaining: "Game (En,Fr,De)",
+			expected:          nil,
+		},
+		{
+			name:              "filename disc paren left untouched",
+			input:             "Game (Disc 1)",
+			expectedRemaining: "Game (Disc 1)",
+			expected:          nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tagFilters, remaining := ExtractCanonicalTagsFromParens(tt.input)
+			assert.Equal(t, tt.expectedRemaining, remaining)
+			require.Len(t, tagFilters, len(tt.expected))
+			for i, want := range tt.expected {
+				assert.Equal(t, want.Type, tagFilters[i].Type, "type at %d", i)
+				assert.Equal(t, want.Value, tagFilters[i].Value, "value at %d", i)
+				assert.Equal(t, want.Operator, tagFilters[i].Operator, "operator at %d", i)
+			}
+		})
+	}
+}
+
 func TestExtractCanonicalTagsFromParensOperators(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Indexing strips filename metadata (region, revision, players, etc.) into structured tags and stores a clean display name. This declutters lists but means many entries share an identical clean name — regional variants, revisions, romhacks, multi-disc games. The image-grid console client shows only the clean name, so users see indistinguishable duplicate cards.

Disambiguation previously ran per page of results, which had a documented bug: siblings split across pages, or reordered by sort, failed to disambiguate. The same page-scoped logic also drove ZapScript title-command generation, so written tags carried the same bug.

## Change

Disambiguation is now a title-global property computed at index time and stored in `MediaTitles.DisambiguationTypes`. A tag type disambiguates a title when its non-missing media hold more than one distinct per-media value-set for that type. Read paths (search, browse, lookup, scraper aliases, single-item tag-writing) filter each result's tags by the stored types instead of re-deriving across a page, so results are correct regardless of pagination, sort, or filtering — and ZapScript title commands are unambiguous for the same reason.

Recompute runs at index time (per system) and after scraping.

### Eligible tag types

`year, players, rev, developer, publisher, credit, edition, release` (existing) plus `region, lang, unfinished, disc, unlicensed, media, distribution, builddate`.

### Multi-value support

`region` and `lang` are frequently multi-valued on one entry (`(USA, Europe)` → `us,eu`). These are emitted in full and written as comma-separated shorthand, e.g. `@Genesis/Sonic The Hedgehog (region:eu, region:us)`. The inline-parens title syntax accepts the same shorthand (`(region:us, region:ja)`, space-optional), reusing the existing tag-filter parser. The title resolver matches against the full value set per type rather than a single last-write-wins value. Disambiguation compares per-media value-sets, so a multi-valued tag that is identical across every sibling (e.g. every disc tagged `(USA, Europe)`) does not produce spurious badges.

### Display ordering

Emitted tags are ordered by display importance (`TagTypeDisplayPriority`): variant flags (`unfinished`, `unlicensed`) and `region` first, freeform `credit` last. Clients render left-to-right and truncate; a type only appears when it actually differs across siblings, so a sole differentiator always survives truncation.

### Arcade region and build dates

MiSTer Arcade names pack a region and romset build date into one parenthetical (`(World 931005)`, `(Europe 961004)`, comma form `(EU, 961004)`). The parser previously only split on commas, so region was dropped or dumped into the `credit` fallback. These are now parsed into `region` plus a new `builddate` tag (`YYMMDD`/`YYYYMMDD`/`YYYY-MM-DD`, normalized to `YYYY-MM-DD`), so same-region arcade variants are distinguished by build date.

### Credit-tag reclassification

Filename qualifiers that fell through to the `credit` fallback are reclassified to their correct types: `*-hack` → `unlicensed:hack`, `*-crack` → `dump:cracked`, `set-N` → `set:N`, `*-translation` → `unlicensed:translation`, and `wip` → `unfinished:wip` (new value). On a 241k-media MiSTer this moves ~5,000 media out of the meaningless `credit` bucket (13,406 → 8,810).

### API

Search, browse, and lookup responses gain a structured `disambiguatingTags` field (documented in `docs/api/methods.md`). Full `tags` is unchanged. The `DisambiguationTypes` column is added by migration and populates on the next reindex (empty until then — backwards compatible).

## Verified on device

Reindexed a MiSTer (241k media): region distinguishes US/EU/JP variants, multi-disc games show per-disc badges, multi-region entries emit comma shorthand, and a written `(region:eu, region:us)` ZapScript resolves back to the correct media. The 8 X-Men Vs. Street Fighter arcade variants — including two Europe and four Asia romsets that region alone cannot separate — are each uniquely badged by `region` + `builddate`.

## Out of scope

- Region/version inside Arcade MRA XML (the filename convention is parsed instead; XML is unnecessary).
- Identical dumps filed under multiple collection folders are byte-identical, launch identically, and have nothing to disambiguate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API responses for media search, browse, and lookup now return `disambiguatingTags` to help distinguish similar items.
  * Added support for additional tag types, including dynamic `builddate` parsing from Arcade-style filenames and `unfinished:wip`.

* **Improvements**
  * Tag handling now correctly supports multiple values per tag type.
  * Disambiguation is now persisted and used for consistent tagging and ordering (display-priority based).

* **Bug Fixes**
  * Reduced flakiness in concurrent server startup tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->