### PR TITLE
fix: invalidate media thumb cache on scrape completion

### DIFF
--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -228,9 +228,9 @@ func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, da
 // stale or cross-contaminated entries do not accumulate.
 func (c *mediaThumbCache) wipe() {
 	if err := c.fs.RemoveAll(c.dir); err != nil {
-		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache after reindex")
+		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache")
 	} else {
-		log.Info().Str("dir", c.dir).Msg("media.image: thumb cache wiped after reindex")
+		log.Info().Str("dir", c.dir).Msg("media.image: thumb cache wiped")
 	}
 	c.resolvedMu.Lock()
 	c.resolvedTypes = make(map[string]string)

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -78,8 +78,9 @@ var (
 // mediaThumbCache persists resized cover images to disk so that the expensive
 // decode+bilinear-resize+transparency-scan is only performed once per unique
 // (identity, imageType, maxSize) triple. The cache survives core restarts and
-// reboots; it is wiped entirely when a full media reindex completes (because
-// MediaDB row IDs change and file-backed image paths may have moved).
+// reboots; it is wiped entirely when a scrape completes (scraping replaces
+// image sources under a stable cache key) and when a media reindex completes
+// (insurance against id:DBID-keyed entries colliding if the MediaDB is reset).
 //
 // Keys are SHA-256 hashes of the logical identity string; values are stored as
 // <hash>.jpg or <hash>.png to encode the content-type implicitly.
@@ -142,8 +143,9 @@ func (c *mediaThumbCache) setResolvedTypeTag(ref mediaRefParam, prefs []string, 
 
 // thumbKey returns the cache key string for a resize request. The key encodes
 // the stable identity (media-ID or system+path) plus the resolved image-type tag
-// and target size. Media IDs change on reindex, but the whole cache is wiped
-// then, so they are safe to use here.
+// and target size. Media IDs are reused across an in-place reindex, but could be
+// reassigned if the MediaDB is reset; the reindex wipe covers that case, so they
+// are safe to use here.
 func thumbKey(ref mediaRefParam, typeTag string, maxSize int) string {
 	var identity string
 	if ref.MediaID != nil {
@@ -222,8 +224,8 @@ func (c *mediaThumbCache) set(ref mediaRefParam, typeTag string, maxSize int, da
 }
 
 // wipe removes the entire thumbnail cache directory and clears the in-memory
-// resolved-type memo. Called after a successful full media reindex so stale
-// entries do not accumulate.
+// resolved-type memo. Called after a successful scrape or media reindex so
+// stale or cross-contaminated entries do not accumulate.
 func (c *mediaThumbCache) wipe() {
 	if err := c.fs.RemoveAll(c.dir); err != nil {
 		log.Warn().Err(err).Str("dir", c.dir).Msg("media.image: failed to wipe thumb cache after reindex")
@@ -244,7 +246,8 @@ func InitMediaThumbCache(pl platforms.Platform) {
 }
 
 // WipeMediaThumbCache removes all cached thumbnails. Called after a successful
-// full reindex so the cache does not serve stale art.
+// scrape (image sources may have changed) or media reindex so the cache does
+// not serve stale art.
 func WipeMediaThumbCache() {
 	if old := mediaThumbCachePointer.Load(); old != nil {
 		mediaThumbCachePointer.Store(old.nextGeneration())

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -542,6 +542,7 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 			if update.Done {
 				populateScrapedMediaCountExact(env.State.GetContext(), db, &status)
 				mediaImageNoImages.clear()
+				WipeMediaThumbCache()
 			} else {
 				populateScrapedMediaCountCached(env.State.GetContext(), db, &status)
 			}
@@ -566,6 +567,7 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 			terminalStatus.State = scrapeStateCompleted
 			populateScrapedMediaCountExact(env.State.GetContext(), db, &terminalStatus)
 			mediaImageNoImages.clear()
+			WipeMediaThumbCache()
 			publishScrapingStatus(ns, &terminalStatus)
 		}
 		if err := db.MediaDB.SetScrapingStatus(finalStatus); err != nil {

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -287,6 +289,106 @@ func TestHandleMediaScrape_HappyPath(t *testing.T) {
 	assert.True(t, status.Done)
 
 	mockDB.AssertExpectations(t)
+}
+
+// doneUpdatePlatformScraper returns a scraper that emits a single Done=true
+// update then closes the channel.
+func doneUpdatePlatformScraper(id, name string) platforms.Scraper {
+	return platforms.Scraper{
+		ID:   id,
+		Name: name,
+		Scrape: func(
+			_ context.Context, _ *config.Instance, _ platforms.Platform,
+			_ afero.Fs, _ *database.Database, _ scraper.ScrapeOptions,
+			_ platforms.ScraperCustomOptions, ch chan<- scraper.ScrapeUpdate,
+		) error {
+			go func() {
+				ch <- scraper.ScrapeUpdate{Done: true}
+				close(ch)
+			}()
+			return nil
+		},
+	}
+}
+
+// TestHandleMediaScrape_WipesThumbCacheOnCompletion verifies that finishing a
+// scrape invalidates the resized-thumbnail disk cache (issue #967): a re-scrape
+// can change image sources under a stable cache key, so the cache must be
+// wiped or it keeps serving stale art.
+func TestHandleMediaScrape_WipesThumbCacheOnCompletion(t *testing.T) {
+	// Not parallel — manipulates shared scrapingStatusInstance and the
+	// process-wide thumb cache pointer.
+	ClearScrapingStatus()
+	statusInstance.clear()
+
+	fs := afero.NewMemMapFs()
+	oldCache := &mediaThumbCache{
+		fs:            fs,
+		dir:           filepath.Join("cache", "thumbs", "current"),
+		resolvedTypes: make(map[string]string),
+	}
+	mediaID := int64(1)
+	oldCache.set(mediaRefParam{MediaID: &mediaID}, "property:image-boxart", 100, []byte("png-data"), "image/png")
+	mediaThumbCachePointer.Store(oldCache)
+	t.Cleanup(func() { mediaThumbCachePointer.Store(nil) })
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+	mockDB.On("ClearScrapingOperation").Return(nil).Once()
+	mockDB.On("WALCheckpoint").Return(nil).Once()
+	mockDB.On("TrackBackgroundOperation").Return()
+	mockDB.On("BackgroundOperationDone").Return()
+	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(0, nil)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
+		"test-scraper": doneUpdatePlatformScraper("test-scraper", "Test Scraper"),
+	})
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	t.Cleanup(st.StopService)
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: pl,
+		State:    st,
+		Database: &database.Database{MediaDB: mockDB},
+		Params:   json.RawMessage(`{"scraperId":"test-scraper"}`),
+	}
+
+	result, err := HandleMediaScrape(env)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	var gotDone bool
+	timeout := time.After(2 * time.Second)
+	for !gotDone {
+		select {
+		case n := <-ns:
+			if n.Method != models.NotificationMediaScraping {
+				continue
+			}
+			var payload models.ScrapingStatusResponse
+			require.NoError(t, json.Unmarshal(n.Params, &payload))
+			if payload.Done {
+				gotDone = true
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for done=true notification")
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		return !IsScrapingRunning()
+	}, 2*time.Second, 10*time.Millisecond, "scraping status should clear after goroutine completes")
+
+	newCache := mediaThumbCachePointer.Load()
+	require.NotNil(t, newCache)
+	assert.NotEqual(t, oldCache.dir, newCache.dir, "thumb cache generation should swap on scrape completion")
+	_, statErr := fs.Stat(oldCache.dir)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "old thumb cache dir should be removed")
 }
 
 func TestHandleMediaScrape_ResumesStalePauseForBackgroundMedia(t *testing.T) {

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -314,81 +314,102 @@ func doneUpdatePlatformScraper(id, name string) platforms.Scraper {
 // TestHandleMediaScrape_WipesThumbCacheOnCompletion verifies that finishing a
 // scrape invalidates the resized-thumbnail disk cache (issue #967): a re-scrape
 // can change image sources under a stable cache key, so the cache must be
-// wiped or it keeps serving stale art.
+// wiped or it keeps serving stale art. Both completion paths are covered: the
+// in-loop wipe on an explicit Done=true update, and the synthesized-done wipe
+// when the scraper closes the channel without ever emitting a Done update.
 func TestHandleMediaScrape_WipesThumbCacheOnCompletion(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance and the
 	// process-wide thumb cache pointer.
-	ClearScrapingStatus()
-	statusInstance.clear()
-
-	fs := afero.NewMemMapFs()
-	oldCache := &mediaThumbCache{
-		fs:            fs,
-		dir:           filepath.Join("cache", "thumbs", "current"),
-		resolvedTypes: make(map[string]string),
+	tests := []struct {
+		name    string
+		scraper platforms.Scraper
+	}{
+		{
+			name:    "explicit done update",
+			scraper: doneUpdatePlatformScraper("test-scraper", "Test Scraper"),
+		},
+		{
+			name:    "synthesized done on channel close",
+			scraper: emptyPlatformScraper("test-scraper", "Test Scraper"),
+		},
 	}
-	mediaID := int64(1)
-	oldCache.set(mediaRefParam{MediaID: &mediaID}, "property:image-boxart", 100, []byte("png-data"), "image/png")
-	mediaThumbCachePointer.Store(oldCache)
-	t.Cleanup(func() { mediaThumbCachePointer.Store(nil) })
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ClearScrapingStatus()
+			statusInstance.clear()
 
-	mockDB := testhelpers.NewMockMediaDBI()
-	mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).Return(nil).Once()
-	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
-	mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
-	mockDB.On("ClearScrapingOperation").Return(nil).Once()
-	mockDB.On("WALCheckpoint").Return(nil).Once()
-	mockDB.On("TrackBackgroundOperation").Return()
-	mockDB.On("BackgroundOperationDone").Return()
-	mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(0, nil)
-
-	pl := mocks.NewMockPlatform()
-	pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
-		"test-scraper": doneUpdatePlatformScraper("test-scraper", "Test Scraper"),
-	})
-	pl.SetupBasicMock()
-	st, ns := state.NewState(pl, "test")
-	t.Cleanup(st.StopService)
-
-	env := requests.RequestEnv{
-		Context:  context.Background(),
-		Platform: pl,
-		State:    st,
-		Database: &database.Database{MediaDB: mockDB},
-		Params:   json.RawMessage(`{"scraperId":"test-scraper"}`),
-	}
-
-	result, err := HandleMediaScrape(env)
-	require.NoError(t, err)
-	assert.Nil(t, result)
-
-	var gotDone bool
-	timeout := time.After(2 * time.Second)
-	for !gotDone {
-		select {
-		case n := <-ns:
-			if n.Method != models.NotificationMediaScraping {
-				continue
+			fs := afero.NewMemMapFs()
+			oldCache := &mediaThumbCache{
+				fs:            fs,
+				dir:           filepath.Join("cache", "thumbs", "current"),
+				resolvedTypes: make(map[string]string),
 			}
-			var payload models.ScrapingStatusResponse
-			require.NoError(t, json.Unmarshal(n.Params, &payload))
-			if payload.Done {
-				gotDone = true
+			mediaID := int64(1)
+			oldCache.set(
+				mediaRefParam{MediaID: &mediaID}, "property:image-boxart", 100, []byte("png-data"), "image/png",
+			)
+			mediaThumbCachePointer.Store(oldCache)
+			t.Cleanup(func() { mediaThumbCachePointer.Store(nil) })
+
+			mockDB := testhelpers.NewMockMediaDBI()
+			mockDB.On("SetScrapingOperation", database.ScrapingOperation{ScraperID: "test-scraper"}).Return(nil).Once()
+			mockDB.On("SetScrapingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
+			mockDB.On("SetScrapingStatus", mediadb.IndexingStatusCompleted).Return(nil).Once()
+			mockDB.On("ClearScrapingOperation").Return(nil).Once()
+			mockDB.On("WALCheckpoint").Return(nil).Once()
+			mockDB.On("TrackBackgroundOperation").Return()
+			mockDB.On("BackgroundOperationDone").Return()
+			mockDB.On("GetScrapedMediaCount", assertmock.Anything, "test-scraper").Return(0, nil)
+
+			pl := mocks.NewMockPlatform()
+			pl.On("Scrapers", assertmock.Anything).Return(map[string]platforms.Scraper{
+				"test-scraper": tt.scraper,
+			})
+			pl.SetupBasicMock()
+			st, ns := state.NewState(pl, "test")
+			t.Cleanup(st.StopService)
+
+			env := requests.RequestEnv{
+				Context:  context.Background(),
+				Platform: pl,
+				State:    st,
+				Database: &database.Database{MediaDB: mockDB},
+				Params:   json.RawMessage(`{"scraperId":"test-scraper"}`),
 			}
-		case <-timeout:
-			t.Fatal("timed out waiting for done=true notification")
-		}
+
+			result, err := HandleMediaScrape(env)
+			require.NoError(t, err)
+			assert.Nil(t, result)
+
+			var gotDone bool
+			timeout := time.After(2 * time.Second)
+			for !gotDone {
+				select {
+				case n := <-ns:
+					if n.Method != models.NotificationMediaScraping {
+						continue
+					}
+					var payload models.ScrapingStatusResponse
+					require.NoError(t, json.Unmarshal(n.Params, &payload))
+					if payload.Done {
+						gotDone = true
+					}
+				case <-timeout:
+					t.Fatal("timed out waiting for done=true notification")
+				}
+			}
+
+			require.Eventually(t, func() bool {
+				return !IsScrapingRunning()
+			}, 2*time.Second, 10*time.Millisecond, "scraping status should clear after goroutine completes")
+
+			newCache := mediaThumbCachePointer.Load()
+			require.NotNil(t, newCache)
+			assert.NotEqual(t, oldCache.dir, newCache.dir, "thumb cache generation should swap on scrape completion")
+			_, statErr := fs.Stat(oldCache.dir)
+			assert.ErrorIs(t, statErr, os.ErrNotExist, "old thumb cache dir should be removed")
+		})
 	}
-
-	require.Eventually(t, func() bool {
-		return !IsScrapingRunning()
-	}, 2*time.Second, 10*time.Millisecond, "scraping status should clear after goroutine completes")
-
-	newCache := mediaThumbCachePointer.Load()
-	require.NotNil(t, newCache)
-	assert.NotEqual(t, oldCache.dir, newCache.dir, "thumb cache generation should swap on scrape completion")
-	_, statErr := fs.Stat(oldCache.dir)
-	assert.ErrorIs(t, statErr, os.ErrNotExist, "old thumb cache dir should be removed")
 }
 
 func TestHandleMediaScrape_ResumesStalePauseForBackgroundMedia(t *testing.T) {


### PR DESCRIPTION
- Wipe the resized-thumbnail disk cache when a scrape completes, alongside the existing negative "no image" cache clear at both scrape-completion sites in `media_scrape.go`. Scraping replaces image sources under a stable thumb-cache key, so the cache previously kept serving the old thumbnail after a re-scrape.
- Correct the thumb-cache lifecycle comments in `media_image.go`: a normal in-place reindex reuses DBIDs and soft-flags missing media (no hard deletes), so the reindex wipe is insurance against `id:DBID` key collisions on a MediaDB reset rather than protection for deleted media.
- Add `TestHandleMediaScrape_WipesThumbCacheOnCompletion` verifying the cache generation swaps when a scrape finishes.

Closes #967

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed thumbnail cache cleanup on media scraping completion so cached thumbnails refresh reliably after scraping finishes (including when completion is signaled via channel close).
  * Improved thumbnail cache lifecycle handling around media reindex/reset scenarios.

* **Tests**
  * Added coverage to verify the thumbnail cache is wiped and the old cache directory is removed for both scrape completion paths.

* **Documentation**
  * Updated lifecycle documentation for the process-wide thumbnail disk cache to reflect broader wipe conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->