### PR TITLE
perf(database): fold per-system media-tag read into one query

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -521,7 +521,7 @@ type MediaWithFullPath struct {
 	TitleSlug      string
 	SystemID       string
 	SortName       string
-	TagIDs         []int64
+	TagIDs         []int
 	DBID           int64
 	MediaTitleDBID int64
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -511,13 +511,17 @@ type TitleWithSystem struct {
 	SystemDBID int64
 }
 
-// MediaWithFullPath represents a Media item with its associated title and system information
+// MediaWithFullPath represents a Media item with its associated title and system information.
+// TagIDs is transient and not a stored column: it is populated only by
+// GetMediaWithTagsBySystemID (when loadMediaTags is set) with the scanner-managed tag
+// DBIDs for the row, carrying tag links on the media row to avoid a second read.
 type MediaWithFullPath struct {
 	Path           string
 	ParentDir      string
 	TitleSlug      string
 	SystemID       string
 	SortName       string
+	TagIDs         []int64
 	DBID           int64
 	MediaTitleDBID int64
 }
@@ -842,6 +846,7 @@ type MediaDBI interface {
 	// Per-system query methods for lazy loading during resume
 	GetTitlesBySystemID(systemID string) ([]TitleWithSystem, error)
 	GetMediaBySystemID(systemID string) ([]MediaWithFullPath, error)
+	GetMediaWithTagsBySystemID(systemID string, loadMediaTags bool) ([]MediaWithFullPath, error)
 	GetMediaTagsBySystemID(systemID string) ([]MediaTagLink, error)
 	GetScannerMediaTagsBySystemID(systemID string) ([]MediaTagLink, error)
 

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2783,6 +2783,19 @@ func (db *MediaDB) GetMediaBySystemID(systemID string) ([]database.MediaWithFull
 	return sqlGetMediaBySystemID(context.WithoutCancel(db.ctx), db.sql, systemID)
 }
 
+// GetMediaWithTagsBySystemID retrieves media for a system and, when loadMediaTags is
+// set, the scanner-managed tag DBIDs for each row in a single pass (see
+// sqlGetMediaWithTagsBySystemID). Non-cancellable context: see GetTitlesBySystemID.
+func (db *MediaDB) GetMediaWithTagsBySystemID(
+	systemID string, loadMediaTags bool,
+) ([]database.MediaWithFullPath, error) {
+	if db.sql == nil {
+		return nil, ErrNullSQL
+	}
+
+	return sqlGetMediaWithTagsBySystemID(context.WithoutCancel(db.ctx), db.sql, systemID, loadMediaTags)
+}
+
 // GetMediaTagsBySystemID retrieves all media-tag links for a specific system.
 func (db *MediaDB) GetMediaTagsBySystemID(systemID string) ([]database.MediaTagLink, error) {
 	if db.sql == nil {

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -391,18 +391,20 @@ func sqlGetMediaWithTagsBySystemID(
 // parseScannerTagIDs parses a GROUP_CONCAT(TagDBID) string into a slice of tag DBIDs,
 // excluding user-owned tags. Returns nil for a NULL/empty input or when every tag was
 // user-owned, so media without scanner tags carry no slice allocation.
-func parseScannerTagIDs(tagIDs sql.NullString, userTagIDs map[int64]struct{}) ([]int64, error) {
+func parseScannerTagIDs(tagIDs sql.NullString, userTagIDs map[int64]struct{}) ([]int, error) {
 	if !tagIDs.Valid || tagIDs.String == "" {
 		return nil, nil
 	}
 	parts := strings.Split(tagIDs.String, ",")
-	result := make([]int64, 0, len(parts))
+	result := make([]int, 0, len(parts))
 	for _, part := range parts {
-		id, err := strconv.ParseInt(part, 10, 64)
+		// Atoi (not ParseInt+narrow) keeps tag DBIDs as int — the type ScanState's
+		// tag maps use — and errors rather than truncating an out-of-range value.
+		id, err := strconv.Atoi(part)
 		if err != nil {
 			return nil, fmt.Errorf("invalid tag DBID %q: %w", part, err)
 		}
-		if _, isUserTag := userTagIDs[id]; isUserTag {
+		if _, isUserTag := userTagIDs[int64(id)]; isUserTag {
 			continue
 		}
 		result = append(result, id)

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -24,9 +24,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	dbtags "github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/rs/zerolog/log"
 )
 
@@ -326,6 +328,89 @@ func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]
 		media = append(media, m)
 	}
 	return media, rows.Err()
+}
+
+// sqlGetMediaWithTagsBySystemID retrieves all media for a system and, when
+// loadMediaTags is set, the scanner-managed tag DBIDs for each row in a single
+// pass. Folding tag links into the media read avoids a second per-(media,tag)-link
+// scan of Media: GROUP_CONCAT aggregates the links on the C side so only one extra
+// string per media row crosses the cgo boundary. User-owned tags are filtered in Go
+// against a pre-fetched DBID set rather than joined in SQL, matching the rationale in
+// sqlGetScannerMediaTagsBySystemID. SystemID is filled from the argument.
+func sqlGetMediaWithTagsBySystemID(
+	ctx context.Context, db *sql.DB, systemID string, loadMediaTags bool,
+) ([]database.MediaWithFullPath, error) {
+	if !loadMediaTags {
+		return sqlGetMediaBySystemID(ctx, db, systemID)
+	}
+
+	userTagIDs, err := sqlGetTagDBIDsByType(ctx, db, string(dbtags.TagTypeUser))
+	if err != nil {
+		return nil, err
+	}
+
+	query := `
+		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName,
+			(SELECT GROUP_CONCAT(mt.TagDBID) FROM MediaTags mt WHERE mt.MediaDBID = m.DBID) AS TagIDs
+		FROM Media m INDEXED BY media_system_path_idx
+		WHERE m.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
+		ORDER BY m.Path
+	`
+	rows, err := db.QueryContext(ctx, query, systemID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query media with tags for system %s: %w", systemID, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	media := make([]database.MediaWithFullPath, 0)
+	for rows.Next() {
+		var (
+			m      database.MediaWithFullPath
+			tagIDs sql.NullString
+		)
+		if scanErr := rows.Scan(
+			&m.DBID, &m.Path, &m.ParentDir, &m.MediaTitleDBID, &m.SortName, &tagIDs,
+		); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan media with tags for system %s: %w", systemID, scanErr)
+		}
+		m.SystemID = systemID
+		parsed, parseErr := parseScannerTagIDs(tagIDs, userTagIDs)
+		if parseErr != nil {
+			return nil, fmt.Errorf("failed to parse tag IDs for media %d in system %s: %w", m.DBID, systemID, parseErr)
+		}
+		m.TagIDs = parsed
+		media = append(media, m)
+	}
+	return media, rows.Err()
+}
+
+// parseScannerTagIDs parses a GROUP_CONCAT(TagDBID) string into a slice of tag DBIDs,
+// excluding user-owned tags. Returns nil for a NULL/empty input or when every tag was
+// user-owned, so media without scanner tags carry no slice allocation.
+func parseScannerTagIDs(tagIDs sql.NullString, userTagIDs map[int64]struct{}) ([]int64, error) {
+	if !tagIDs.Valid || tagIDs.String == "" {
+		return nil, nil
+	}
+	parts := strings.Split(tagIDs.String, ",")
+	result := make([]int64, 0, len(parts))
+	for _, part := range parts {
+		id, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tag DBID %q: %w", part, err)
+		}
+		if _, isUserTag := userTagIDs[id]; isUserTag {
+			continue
+		}
+		result = append(result, id)
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
 }
 
 // sqlBulkSetMediaMissing marks media records as missing by DBID. Batches in chunks

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -301,14 +301,17 @@ func sqlGetTitlesWithSystemsExcluding(
 	return titles, rows.Err()
 }
 
-// sqlGetTitlesBySystemID retrieves all media titles for a specific system with their associated system information.
+// sqlGetTitlesBySystemID retrieves all media titles for a specific system.
 // This is used for lazy loading during resume to avoid loading ALL titles upfront.
+// SystemID is filled from the argument rather than joined from Systems: every row's
+// SystemID equals the filter argument, so the join only added a per-row probe and a
+// redundant string crossing (the top reindex allocator). SystemDBID is still selected
+// because other callers read it.
 func sqlGetTitlesBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.TitleWithSystem, error) {
 	query := `
-		SELECT t.DBID, t.Slug, t.Name, t.SystemDBID, s.SystemID
+		SELECT t.DBID, t.Slug, t.Name, t.SystemDBID
 		FROM MediaTitles t
-		JOIN Systems s ON t.SystemDBID = s.DBID
-		WHERE s.SystemID = ?
+		WHERE t.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
 	`
 	rows, err := db.QueryContext(ctx, query, systemID)
 	if err != nil {
@@ -323,9 +326,10 @@ func sqlGetTitlesBySystemID(ctx context.Context, db *sql.DB, systemID string) ([
 	titles := make([]database.TitleWithSystem, 0)
 	for rows.Next() {
 		var title database.TitleWithSystem
-		if err := rows.Scan(&title.DBID, &title.Slug, &title.Name, &title.SystemDBID, &title.SystemID); err != nil {
+		if err := rows.Scan(&title.DBID, &title.Slug, &title.Name, &title.SystemDBID); err != nil {
 			return nil, fmt.Errorf("failed to scan title for system %s: %w", systemID, err)
 		}
+		title.SystemID = systemID
 		titles = append(titles, title)
 	}
 	return titles, rows.Err()

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1789,10 +1789,10 @@ func TestSqlGetMediaWithTagsBySystemID_AggregatesAndFiltersTags(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, results, 4)
-	assert.Equal(t, []int64{10}, results[0].TagIDs)     // user tag 99 filtered out
-	assert.Nil(t, results[1].TagIDs)                    // NULL aggregate -> nil
-	assert.Equal(t, []int64{11, 12}, results[2].TagIDs) // no user tags
-	assert.Nil(t, results[3].TagIDs)                    // all-user -> nil
+	assert.Equal(t, []int{10}, results[0].TagIDs)     // user tag 99 filtered out
+	assert.Nil(t, results[1].TagIDs)                  // NULL aggregate -> nil
+	assert.Equal(t, []int{11, 12}, results[2].TagIDs) // no user tags
+	assert.Nil(t, results[3].TagIDs)                  // all-user -> nil
 	assert.Equal(t, "nes", results[0].SystemID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -1737,6 +1737,89 @@ func TestSqlGetMediaBySystemID_ScanError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+// mediaWithTagsBySystemIDQueryPattern matches the combined media + aggregated tag read.
+const mediaWithTagsBySystemIDQueryPattern = `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, m\.SortName,.*` +
+	`GROUP_CONCAT\(mt\.TagDBID\).*FROM Media m INDEXED BY media_system_path_idx.*` +
+	`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*ORDER BY m\.Path`
+
+func TestSqlGetMediaWithTagsBySystemID_LoadTagsFalse(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
+	marioPath := filepath.Join(gamesDir, "mario.nes")
+	rows := sqlmock.NewRows([]string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName"}).
+		AddRow(int64(1), marioPath, gamesDir, int64(10), "Super Mario Bros.")
+	// loadMediaTags=false must reuse the plain media query: no Tags lookup, no GROUP_CONCAT.
+	mock.ExpectQuery(mediaBySystemIDQueryPattern).WithArgs("nes").WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithTagsBySystemID(context.Background(), db, "nes", false)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, int64(1), results[0].DBID)
+	assert.Equal(t, "nes", results[0].SystemID)
+	assert.Nil(t, results[0].TagIDs)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithTagsBySystemID_AggregatesAndFiltersTags(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// User tag 99 must be excluded from every row's TagIDs.
+	mock.ExpectQuery(`SELECT t\.DBID.*FROM Tags t.*JOIN TagTypes tt.*WHERE tt\.Type = \?`).
+		WithArgs(string(dbtags.TagTypeUser)).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(int64(99)))
+
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "TagIDs"}
+	gamesDir := filepath.Join(string(filepath.Separator), "games")
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(1), filepath.Join(gamesDir, "mario.nes"), gamesDir, int64(10), "Mario", "10,99").
+		AddRow(int64(2), filepath.Join(gamesDir, "zelda.nes"), gamesDir, int64(11), "Zelda", nil).
+		AddRow(int64(3), filepath.Join(gamesDir, "metroid.nes"), gamesDir, int64(12), "Metroid", "11,12").
+		AddRow(int64(4), filepath.Join(gamesDir, "kirby.nes"), gamesDir, int64(13), "Kirby", "99")
+	mock.ExpectQuery(mediaWithTagsBySystemIDQueryPattern).WithArgs("nes").WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithTagsBySystemID(context.Background(), db, "nes", true)
+
+	require.NoError(t, err)
+	require.Len(t, results, 4)
+	assert.Equal(t, []int64{10}, results[0].TagIDs)     // user tag 99 filtered out
+	assert.Nil(t, results[1].TagIDs)                    // NULL aggregate -> nil
+	assert.Equal(t, []int64{11, 12}, results[2].TagIDs) // no user tags
+	assert.Nil(t, results[3].TagIDs)                    // all-user -> nil
+	assert.Equal(t, "nes", results[0].SystemID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlGetMediaWithTagsBySystemID_InvalidTagID(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT t\.DBID.*FROM Tags t.*JOIN TagTypes tt.*WHERE tt\.Type = \?`).
+		WithArgs(string(dbtags.TagTypeUser)).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}))
+	cols := []string{"DBID", "Path", "ParentDir", "MediaTitleDBID", "SortName", "TagIDs"}
+	marioPath := filepath.Join(string(filepath.Separator), "games", "mario.nes")
+	rows := sqlmock.NewRows(cols).
+		AddRow(int64(1), marioPath, "", int64(10), "Mario", "not-an-int")
+	mock.ExpectQuery(mediaWithTagsBySystemIDQueryPattern).WithArgs("nes").WillReturnRows(rows)
+
+	results, err := sqlGetMediaWithTagsBySystemID(context.Background(), db, "nes", true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse tag IDs")
+	assert.Nil(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlGetMediaTagsBySystemID_UsesSystemMediaIndex(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -1827,13 +1910,13 @@ func TestSqlGetTitlesBySystemID_Success(t *testing.T) {
 
 	systemID := "nes"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Slug", "Name", "SystemDBID", "SystemID"}).
-		AddRow(int64(1), "supermariobros", "Super Mario Bros", int64(100), "nes").
-		AddRow(int64(2), "legendofzelda", "The Legend of Zelda", int64(100), "nes").
-		AddRow(int64(3), "metroid", "Metroid", int64(100), "nes")
+	rows := sqlmock.NewRows([]string{"DBID", "Slug", "Name", "SystemDBID"}).
+		AddRow(int64(1), "supermariobros", "Super Mario Bros", int64(100)).
+		AddRow(int64(2), "legendofzelda", "The Legend of Zelda", int64(100)).
+		AddRow(int64(3), "metroid", "Metroid", int64(100))
 
-	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID, s\.SystemID.*` +
-		`FROM MediaTitles t.*WHERE s\.SystemID = \?`
+	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID.*` +
+		`FROM MediaTitles t.*WHERE t\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\)`
 	mock.ExpectQuery(titlesBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetTitlesBySystemID(context.Background(), db, systemID)
@@ -1869,10 +1952,10 @@ func TestSqlGetTitlesBySystemID_EmptyResult(t *testing.T) {
 
 	systemID := "nonexistent"
 
-	rows := sqlmock.NewRows([]string{"DBID", "Slug", "Name", "SystemDBID", "SystemID"})
+	rows := sqlmock.NewRows([]string{"DBID", "Slug", "Name", "SystemDBID"})
 
-	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID, s\.SystemID.*` +
-		`FROM MediaTitles t.*WHERE s\.SystemID = \?`
+	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID.*` +
+		`FROM MediaTitles t.*WHERE t\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\)`
 	mock.ExpectQuery(titlesBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetTitlesBySystemID(context.Background(), db, systemID)
@@ -1890,8 +1973,8 @@ func TestSqlGetTitlesBySystemID_QueryError(t *testing.T) {
 
 	systemID := "nes"
 
-	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID, s\.SystemID.*` +
-		`FROM MediaTitles t.*WHERE s\.SystemID = \?`
+	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID.*` +
+		`FROM MediaTitles t.*WHERE t\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\)`
 	mock.ExpectQuery(titlesBySystemQuery).WithArgs(systemID).WillReturnError(sql.ErrConnDone)
 
 	results, err := sqlGetTitlesBySystemID(context.Background(), db, systemID)
@@ -1914,8 +1997,8 @@ func TestSqlGetTitlesBySystemID_ScanError(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"DBID", "Slug"}).
 		AddRow(int64(1), "supermariobros")
 
-	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID, s\.SystemID.*` +
-		`FROM MediaTitles t.*WHERE s\.SystemID = \?`
+	titlesBySystemQuery := `SELECT t\.DBID, t\.Slug, t\.Name, t\.SystemDBID.*` +
+		`FROM MediaTitles t.*WHERE t\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\)`
 	mock.ExpectQuery(titlesBySystemQuery).WithArgs(systemID).WillReturnRows(rows)
 
 	results, err := sqlGetTitlesBySystemID(context.Background(), db, systemID)

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -919,7 +919,7 @@ func loadSystemStateData(
 // applyMediaTagIDs records the scanner-managed tag DBIDs for a media row into the
 // scan state's per-media tag set. No-op when tags are not being tracked or the row
 // has no scanner tags.
-func applyMediaTagIDs(ss *database.ScanState, mediaDBID int, tagIDs []int64) {
+func applyMediaTagIDs(ss *database.ScanState, mediaDBID int, tagIDs []int) {
 	if ss.MediaTagIDs == nil || len(tagIDs) == 0 {
 		return
 	}
@@ -929,7 +929,7 @@ func applyMediaTagIDs(ss *database.ScanState, mediaDBID int, tagIDs []int64) {
 		ss.MediaTagIDs[mediaDBID] = tagSet
 	}
 	for _, tagID := range tagIDs {
-		tagSet[int(tagID)] = struct{}{}
+		tagSet[tagID] = struct{}{}
 	}
 }
 

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -520,9 +520,10 @@ func insertMediaTagLink(db database.MediaDBI, mediaIndex, tagIndex int, tagStr s
 }
 
 type systemStateData struct {
-	titles    []database.TitleWithSystem
-	media     []database.MediaWithFullPath
-	mediaTags []database.MediaTagLink
+	titles []database.TitleWithSystem
+	// media carries each row's scanner-managed tag DBIDs in MediaWithFullPath.TagIDs
+	// when loaded with loadMediaTags set, so tag links ride on the media read.
+	media []database.MediaWithFullPath
 }
 
 func cloneMediaTagSet(tagIDs map[int]struct{}) map[int]struct{} {
@@ -860,16 +861,7 @@ func PopulateScanStateForSystem(
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
 		}
-	}
-
-	if ss.MediaTagIDs != nil {
-		for _, link := range stateData.mediaTags {
-			mediaDBID := int(link.MediaDBID)
-			if ss.MediaTagIDs[mediaDBID] == nil {
-				ss.MediaTagIDs[mediaDBID] = make(map[int]struct{})
-			}
-			ss.MediaTagIDs[mediaDBID][int(link.TagDBID)] = struct{}{}
-		}
+		applyMediaTagIDs(ss, int(m.DBID), m.TagIDs)
 	}
 
 	return nil
@@ -902,37 +894,43 @@ func loadSystemStateData(
 	default:
 	}
 
-	// Load media for this system
+	// Load media for this system, folding scanner-managed tag links into each row
+	// when requested so tags ride on the media read instead of a second scan.
 	mediaStart := time.Now()
-	media, err := db.GetMediaBySystemID(systemID)
+	media, err := db.GetMediaWithTagsBySystemID(systemID, loadMediaTags)
 	mediaElapsed := time.Since(mediaStart)
 	if err != nil {
 		return systemStateData{}, fmt.Errorf("failed to get media for system %s: %w", systemID, err)
-	}
-
-	mediaTags := []database.MediaTagLink(nil)
-	mediaTagsElapsed := time.Duration(0)
-	if loadMediaTags {
-		mediaTagsStart := time.Now()
-		mediaTags, err = db.GetScannerMediaTagsBySystemID(systemID)
-		mediaTagsElapsed = time.Since(mediaTagsStart)
-		if err != nil {
-			return systemStateData{}, fmt.Errorf("failed to get scanner media tags for system %s: %w", systemID, err)
-		}
 	}
 
 	log.Debug().
 		Str("system", systemID).
 		Int("titles", len(titles)).
 		Int("media", len(media)).
-		Int("mediaTags", len(mediaTags)).
+		Bool("mediaTags", loadMediaTags).
 		Dur("titlesDuration", titlesElapsed).
 		Dur("mediaDuration", mediaElapsed).
-		Dur("mediaTagsDuration", mediaTagsElapsed).
 		Dur("elapsed", time.Since(startTime)).
 		Msg("loaded existing data for system resume")
 
-	return systemStateData{titles: titles, media: media, mediaTags: mediaTags}, nil
+	return systemStateData{titles: titles, media: media}, nil
+}
+
+// applyMediaTagIDs records the scanner-managed tag DBIDs for a media row into the
+// scan state's per-media tag set. No-op when tags are not being tracked or the row
+// has no scanner tags.
+func applyMediaTagIDs(ss *database.ScanState, mediaDBID int, tagIDs []int64) {
+	if ss.MediaTagIDs == nil || len(tagIDs) == 0 {
+		return
+	}
+	tagSet := ss.MediaTagIDs[mediaDBID]
+	if tagSet == nil {
+		tagSet = make(map[int]struct{}, len(tagIDs))
+		ss.MediaTagIDs[mediaDBID] = tagSet
+	}
+	for _, tagID := range tagIDs {
+		tagSet[int(tagID)] = struct{}{}
+	}
 }
 
 // PopulatePersistentScanStateForSystem loads existing Media DBIDs for a system into
@@ -975,17 +973,8 @@ func PopulatePersistentScanStateForSystem(
 		if ss.MediaParentDirs != nil {
 			ss.MediaParentDirs[int(m.DBID)] = m.ParentDir
 		}
+		applyMediaTagIDs(ss, int(m.DBID), m.TagIDs)
 		ss.MissingMedia[int(m.DBID)] = struct{}{}
-	}
-
-	if ss.MediaTagIDs != nil {
-		for _, link := range stateData.mediaTags {
-			mediaDBID := int(link.MediaDBID)
-			if ss.MediaTagIDs[mediaDBID] == nil {
-				ss.MediaTagIDs[mediaDBID] = make(map[int]struct{})
-			}
-			ss.MediaTagIDs[mediaDBID][int(link.TagDBID)] = struct{}{}
-		}
 	}
 
 	log.Debug().

--- a/pkg/database/mediascanner/mediascanner_bench_test.go
+++ b/pkg/database/mediascanner/mediascanner_bench_test.go
@@ -20,12 +20,14 @@
 package mediascanner
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"runtime"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/mock"
 )
@@ -418,5 +420,120 @@ func BenchmarkGetPathFragments_PeakMemory(b *testing.B) {
 
 	if after.TotalAlloc > before.TotalAlloc {
 		b.ReportMetric(float64(after.TotalAlloc-before.TotalAlloc)/(1024*1024), "total-MB")
+	}
+}
+
+// newPersistentScanState mirrors the scan state initialized by the real reindex path
+// (mediascanner.go) so the per-system read-back populates every map, including tags.
+func newPersistentScanState() *database.ScanState {
+	return &database.ScanState{
+		SystemIDs:          make(map[string]int),
+		TitleIDs:           make(map[string]int),
+		TitleNames:         make(map[int]string),
+		MediaIDs:           make(map[string]int),
+		MediaTitleIDs:      make(map[int]int),
+		MediaNeedsSortName: make(map[int]struct{}),
+		MediaSortNames:     make(map[int]string),
+		MediaParentDirs:    make(map[int]string),
+		MediaTagIDs:        make(map[int]map[int]struct{}),
+		TagTypeIDs:         make(map[string]int),
+		TagIDs:             make(map[string]int),
+		MissingMedia:       make(map[int]struct{}),
+	}
+}
+
+// seedPersistentState populates a real DB with n media (and tagsPerItem scanner tags
+// each) for one system, so the read-back benchmark measures realistic row counts.
+func seedPersistentState(b *testing.B, db *mediadb.MediaDB, systemID string, n, tagsPerItem int) {
+	b.Helper()
+
+	ss := newScanState()
+	if err := SeedCanonicalTags(db, ss); err != nil {
+		b.Fatal(err)
+	}
+
+	filenames := buildSyntheticFilenames(n)
+	if err := db.BeginTransaction(true); err != nil {
+		b.Fatal(err)
+	}
+	for i, fn := range filenames {
+		if _, _, err := AddMediaPath(db, ss, systemID, fn, "", false, false, nil, ""); err != nil {
+			b.Fatalf("AddMediaPath(%d): %v", i, err)
+		}
+	}
+	if err := db.CommitTransaction(); err != nil {
+		b.Fatal(err)
+	}
+	if tagsPerItem == 0 {
+		return
+	}
+
+	tagType, err := db.FindOrInsertTagType(database.TagType{Type: "benchgenre"})
+	if err != nil {
+		b.Fatal(err)
+	}
+	tagDBIDs := make([]int64, tagsPerItem)
+	for i := range tagDBIDs {
+		tag, tagErr := db.FindOrInsertTag(database.Tag{
+			Tag:         fmt.Sprintf("benchtag%d", i),
+			DisplayName: fmt.Sprintf("Bench Tag %d", i),
+			TypeDBID:    tagType.DBID,
+		})
+		if tagErr != nil {
+			b.Fatal(tagErr)
+		}
+		tagDBIDs[i] = tag.DBID
+	}
+
+	media, err := db.GetMediaBySystemID(systemID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := db.BeginTransaction(true); err != nil {
+		b.Fatal(err)
+	}
+	for _, m := range media {
+		for _, tagDBID := range tagDBIDs {
+			if _, mtErr := db.InsertMediaTag(database.MediaTag{MediaDBID: m.DBID, TagDBID: tagDBID}); mtErr != nil {
+				b.Fatal(mtErr)
+			}
+		}
+	}
+	if err := db.CommitTransaction(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+// BenchmarkPopulatePersistentScanState_RealDB measures the per-system incremental
+// read-back (loadSystemStateData) against a real SQLite DB. The DB is seeded once
+// outside the timed loop; each iteration reads back into a fresh scan state. Varying
+// tagsPerItem exposes the tag-aggregation win (folding media-tag links into the media
+// read instead of a separate per-(media,tag)-link scan).
+func BenchmarkPopulatePersistentScanState_RealDB(b *testing.B) {
+	cases := []struct {
+		name        string
+		n           int
+		tagsPerItem int
+	}{
+		{name: "10k_0tags", n: 10_000, tagsPerItem: 0},
+		{name: "10k_4tags", n: 10_000, tagsPerItem: 4},
+		{name: "50k_4tags", n: 50_000, tagsPerItem: 4},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			db, cleanup := helpers.NewInMemoryMediaDB(b)
+			defer cleanup()
+			seedPersistentState(b, db, "nes", tc.n, tc.tagsPerItem)
+
+			b.ResetTimer()
+			for b.Loop() {
+				ss := newPersistentScanState()
+				if err := PopulatePersistentScanStateForSystem(context.Background(), db, ss, "nes"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -459,13 +459,11 @@ func TestNewNamesIndex_SuccessfulResume(t *testing.T) {
 	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
-	// Mock per-system loading (PopulatePersistentScanStateForSystem calls both)
+	// Mock per-system loading (PopulatePersistentScanStateForSystem reads titles + media/tags)
 	mockMediaDB.On("GetTitlesBySystemID", mock.AnythingOfType("string")).
 		Return([]database.TitleWithSystem{}, nil).Maybe()
-	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetMediaWithTagsBySystemID", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
 		Return([]database.MediaWithFullPath{}, nil).Maybe()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
-		Return([]database.MediaTagLink{}, nil).Maybe()
 	// Subsequent calls: normal operation (no truncate because resuming successfully)
 	mockMediaDB.On("SetIndexingStatus", "running").Return(nil).Once()
 	mockMediaDB.On("SetLastIndexedSystem", "genesis").Return(nil).Maybe() // Update progress during processing
@@ -578,10 +576,8 @@ func TestNewNamesIndex_ReportsSystemBeforeLoadingExistingData(t *testing.T) {
 	mockMediaDB.On("GetTitlesBySystemID", mock.AnythingOfType("string")).
 		Run(func(args mock.Arguments) { recordLoad(args.String(0)) }).
 		Return([]database.TitleWithSystem{}, nil).Twice()
-	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetMediaWithTagsBySystemID", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
 		Return([]database.MediaWithFullPath{}, nil).Twice()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
-		Return([]database.MediaTagLink{}, nil).Twice()
 	mockMediaDB.On("SetIndexingStatus", "completed").Return(nil).Once()
 	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
 	mockMediaDB.On("SetIndexingSystems", []string(nil)).Return(nil).Once()
@@ -758,10 +754,8 @@ func TestNewNamesIndex_ResumeSystemNotFound(t *testing.T) {
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Maybe()
 	mockMediaDB.On("GetTitlesBySystemID", mock.AnythingOfType("string")).
 		Return([]database.TitleWithSystem{}, nil).Maybe()
-	mockMediaDB.On("GetMediaBySystemID", mock.AnythingOfType("string")).
+	mockMediaDB.On("GetMediaWithTagsBySystemID", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).
 		Return([]database.MediaWithFullPath{}, nil).Maybe()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", mock.AnythingOfType("string")).
-		Return([]database.MediaTagLink{}, nil).Maybe()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Maybe()
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Maybe()
 	// Mock GetMax*ID methods for PopulateScanStateFromDB

--- a/pkg/database/mediascanner/persistence_regression_test.go
+++ b/pkg/database/mediascanner/persistence_regression_test.go
@@ -55,12 +55,13 @@ func TestPopulatePersistentScanStateForSystem_LoadsMediaOnce(t *testing.T) {
 		Slug:     "super-mario-bros",
 	}}, nil).Once()
 	nesPath := filepath.Join(string(filepath.Separator), "roms", "nes", "Super Mario Bros.nes")
-	mockDB.On("GetMediaBySystemID", "NES").Return([]database.MediaWithFullPath{{
-		DBID:      42,
-		SystemID:  "NES",
-		Path:      nesPath,
-		TitleSlug: "super-mario-bros",
-	}}, nil).Once()
+	mockDB.On("GetMediaWithTagsBySystemID", "NES", mock.AnythingOfType("bool")).
+		Return([]database.MediaWithFullPath{{
+			DBID:      42,
+			SystemID:  "NES",
+			Path:      nesPath,
+			TitleSlug: "super-mario-bros",
+		}}, nil).Once()
 
 	err := PopulatePersistentScanStateForSystem(context.Background(), mockDB, scanState, "NES")
 	require.NoError(t, err)
@@ -156,8 +157,8 @@ func TestNewNamesIndex_ResumeResetMissingFlagsSkipsCompletedSystems(t *testing.T
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{{DBID: 1, Type: "genre"}}, nil).Once()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
 	mockMediaDB.On("GetTitlesBySystemID", "snes").Return([]database.TitleWithSystem{}, nil).Once()
-	mockMediaDB.On("GetMediaBySystemID", "snes").Return([]database.MediaWithFullPath{}, nil).Once()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", "snes").Return([]database.MediaTagLink{}, nil).Once()
+	mockMediaDB.On("GetMediaWithTagsBySystemID", "snes", mock.AnythingOfType("bool")).
+		Return([]database.MediaWithFullPath{}, nil).Once()
 	mockMediaDB.On("ResetMissingFlags", []int{3}).Return(nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{
@@ -283,8 +284,8 @@ func TestNewNamesIndex_ResumeKeepsRequestedSystemsWhenSomeAreNotRunnable(t *test
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{{DBID: 1, Type: "genre"}}, nil).Once()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
 	mockMediaDB.On("GetTitlesBySystemID", "nes").Return([]database.TitleWithSystem{}, nil).Once()
-	mockMediaDB.On("GetMediaBySystemID", "nes").Return([]database.MediaWithFullPath{}, nil).Once()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
+	mockMediaDB.On("GetMediaWithTagsBySystemID", "nes", mock.AnythingOfType("bool")).
+		Return([]database.MediaWithFullPath{}, nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{
 		{ID: "nes"},
@@ -293,7 +294,7 @@ func TestNewNamesIndex_ResumeKeepsRequestedSystemsWhenSomeAreNotRunnable(t *test
 	require.NoError(t, err)
 	mockMediaDB.AssertNotCalled(t, "SetIndexingStatus", "")
 	mockMediaDB.AssertNotCalled(t, "GetTitlesBySystemID", "ps2")
-	mockMediaDB.AssertNotCalled(t, "GetMediaBySystemID", "ps2")
+	mockMediaDB.AssertNotCalled(t, "GetMediaWithTagsBySystemID", "ps2", mock.Anything)
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -361,7 +362,6 @@ func TestNewNamesIndex_DependencyFlushUniqueErrorAbortsIndexing(t *testing.T) {
 	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Twice()
 	mockMediaDB.On("GetAllTagTypes").Return([]database.TagType{}, nil).Once()
 	mockMediaDB.On("GetAllTags").Return([]database.Tag{}, nil).Once()
-	mockMediaDB.On("GetScannerMediaTagsBySystemID", "nes").Return([]database.MediaTagLink{}, nil).Once()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{{ID: "nes"}},
 		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, func(IndexStatus) {}, nil)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1789,6 +1789,32 @@ func (m *MockMediaDBI) GetMediaBySystemID(systemID string) ([]database.MediaWith
 	return []database.MediaWithFullPath{}, nil
 }
 
+// GetMediaWithTagsBySystemID mock method for the combined per-system media + tags read.
+func (m *MockMediaDBI) GetMediaWithTagsBySystemID(
+	systemID string, loadMediaTags bool,
+) ([]database.MediaWithFullPath, error) {
+	// Try to get mock expectations, but don't fail if none are set
+	if len(m.ExpectedCalls) > 0 {
+		for _, call := range m.ExpectedCalls {
+			if call.Method == "GetMediaWithTagsBySystemID" {
+				args := m.Called(systemID, loadMediaTags)
+				if media, ok := args.Get(0).([]database.MediaWithFullPath); ok {
+					if err := args.Error(1); err != nil {
+						return media, fmt.Errorf("mock operation failed: %w", err)
+					}
+					return media, nil
+				}
+				if err := args.Error(1); err != nil {
+					return nil, fmt.Errorf("mock operation failed: %w", err)
+				}
+				return []database.MediaWithFullPath{}, nil
+			}
+		}
+	}
+	// Default behavior when no expectations are set - return empty slice
+	return []database.MediaWithFullPath{}, nil
+}
+
 // GetMediaTagsBySystemID mock method for per-system lazy loading during resume.
 func (m *MockMediaDBI) GetMediaTagsBySystemID(systemID string) ([]database.MediaTagLink, error) {
 	args := m.Called(systemID)


### PR DESCRIPTION
Closes #968.

## Problem

Incremental reindex loads existing scan state per system in `loadSystemStateData` using three queries: media, a separate media-tag `CROSS JOIN` that re-scans `Media`, and titles. On-device CPU profiling (MiSTer, ARM) showed this read-back dominated reindex CPU, bound by per-row cgo crossings in SQLite — `cgocall` ~64% flat, with the tag-link scan and the media scan the two largest contributors.

## Change

- **Combine the media and tag reads** into `sqlGetMediaWithTagsBySystemID`. Tag DBIDs are aggregated per media row server-side with `GROUP_CONCAT` (using the `MediaTags` `PRIMARY KEY(MediaDBID, TagDBID)`), and user-owned tags are filtered in Go against a pre-fetched set — matching the existing `sqlGetScannerMediaTagsBySystemID` rationale. This removes the per-`(media, tag)`-link row explosion and the duplicate `Media` scan; three per-system queries become two.
- **Trim the titles query**: drop the `Systems` JOIN and the `SystemID` string column, filling `SystemID` from the argument (the pattern `sqlGetMediaBySystemID` already uses). `SystemDBID` is retained for the gamelistxml scraper.
- Read-path only; no schema change. The superseded `GetMediaBySystemID`/`GetScannerMediaTagsBySystemID` remain for their other callers (scraper path).

## Verification

- Full incremental reindex on a MiSTer (237,151 files, 114 systems, including a 66k-media scraped C64) completed successfully with no errors or warnings.
- Profiling confirms the new combined query is the live read path and the separate media-tag `CROSS JOIN` is gone.
- New `BenchmarkPopulatePersistentScanState_RealDB` exercises the per-system read-back against a real SQLite DB; existing resume/persistent-state pipeline tests guard correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved media scanning/indexing to load per-media tag information in a single step when enabled, reducing extra database reads and aligning resume behavior with the updated workflow.

* **New Features**
  * Added a new database retrieval option to fetch media along with tag identifiers on demand.

* **Tests**
  * Added/updated unit tests covering tag aggregation, filtering, and error handling, plus performance benchmarks for persistent scan state loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->