### PR TITLE
feat(api): add media.browse.index letter index method

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -232,7 +232,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods are used to execute actions and request data back from the API. The current API provides **60 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
+Methods are used to execute actions and request data back from the API. The current API provides **61 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
 
 | ID                              | Description                                                                           |
 | :------------------------------ | :------------------------------------------------------------------------------------ |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -253,6 +253,7 @@ Methods are used to execute actions and request data back from the API. The curr
 | media.generate.resume           | Resume paused media database indexing.                                                |
 | media.index                     | **Deprecated.** Alias for `media.generate`.                                           |
 | media.browse                    | Browse indexed media in a directory-style hierarchy.                                  |
+| media.browse.index              | Return first-character jump-to-letter buckets and seek cursors for a browse scope.    |
 | media.lookup                    | Resolve a game name and system to a media database match.                             |
 | media.meta                      | Return metadata for a specific indexed media row.                                     |
 | media.image                     | Return the best matching image for a specific indexed media row.                      |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -704,6 +704,78 @@ All parameters are optional. When called with no parameters, returns root entrie
 }
 ```
 
+### media.browse.index
+
+Return the ordered first-character "jump to letter" buckets for a browse scope. Each bucket carries a count and a ready-to-use cursor that seeks `media.browse` to the start of that bucket, so a single round trip gives a client everything it needs to draw a section rail _and_ jump into the full ordered list. This avoids paging from the top to reach a distant section, which matters on constrained clients (e.g. MiSTer).
+
+The scope parameters mirror `media.browse` so the index describes the exact list `media.browse` would return for the same scope. The per-bucket `cursor` is an ordinary browse cursor: pass it to `media.browse` with the same `path`/`systems`/`sort` to get a normal page that begins at the bucket and continues into the next bucket as the user scrolls.
+
+#### Parameters
+
+All parameters are optional.
+
+| Key         | Type     | Required | Description                                                                                       |
+| :---------- | :------- | :------- | :------------------------------------------------------------------------------------------------ |
+| path        | string   | No       | Directory or virtual scheme to index, same as `media.browse`. Omit or set empty for a root listing (no rail applies). |
+| systems     | string[] | No       | Case-sensitive system IDs to scope the index to, same as `media.browse`.                          |
+| fuzzySystem | boolean  | No       | Enable fuzzy matching for system IDs in `systems`.                                                |
+| sort        | string   | No       | Sort order, must match the `media.browse` sort the rail is for. One of `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. |
+
+#### Result
+
+| Key        | Type                                          | Required | Description                                                                 |
+| :--------- | :-------------------------------------------- | :------- | :-------------------------------------------------------------------------- |
+| scheme     | string                                        | Yes      | Collation used to derive the buckets. `latin` for first-character bucketing; `none` when no rail applies (a root listing, or a directory whose effective sort is not alphabetical, e.g. a ranked/date-prefixed collection folder), in which case `groups` is empty. |
+| totalFiles | number                                        | Yes      | Total media files in the scope.                                             |
+| groups     | [BrowseIndexGroup](#browse-index-group-object)[] | Yes   | Only non-empty buckets, ordered to match `sort`.                            |
+
+##### Browse index group object
+
+| Key    | Type   | Required | Description                                                                                       |
+| :----- | :----- | :------- | :------------------------------------------------------------------------------------------------ |
+| key    | string | Yes      | Stable bucket identifier (`A`–`Z`, `0-9`, `#`). Treat as opaque.                                  |
+| label  | string | Yes      | Display text for the bucket. Equal to `key` for the `latin` scheme.                               |
+| count  | number | Yes      | Number of media files in the bucket.                                                              |
+| cursor | string | Yes      | Opaque `media.browse` cursor positioned just before the bucket's first row. Empty string for the bucket that begins the list (call `media.browse` with no cursor for the first page). |
+
+Clients should render `groups` exactly as received, in order, without assuming a particular alphabet: `scheme` and `key` are opaque so a future locale-aware scheme (e.g. pinyin/kana/hangul buckets) requires no client change.
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "media.browse.index",
+  "params": {
+    "path": "/roms/SNES",
+    "sort": "name-asc"
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "scheme": "latin",
+    "totalFiles": 150,
+    "groups": [
+      { "key": "#", "label": "#", "count": 3, "cursor": "" },
+      { "key": "0-9", "label": "0-9", "count": 7, "cursor": "eyJzb3J0VmFsdWUiOiIjV29sZiIsImxhc3RJZCI6MTAyfQ==" },
+      { "key": "A", "label": "A", "count": 12, "cursor": "eyJzb3J0VmFsdWUiOiI5IExpdmVzIiwibGFzdElkIjoxMTV9" }
+    ]
+  }
+}
+```
+
+To jump to "A", the client calls `media.browse` with that group's `cursor` and the same `path`/`sort`; the returned page begins at the first "A" title and continues into "B" as the user keeps scrolling.
+
 ### media.tags
 
 Query the media database and return available tags for filtering.

--- a/pkg/api/methods/media_browse_index.go
+++ b/pkg/api/methods/media_browse_index.go
@@ -1,0 +1,214 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/rs/zerolog/log"
+)
+
+// Future work for media.browse.index (Phase 1 is what ships here):
+//
+// Phase 1 (current): buckets are derived from the first character of
+// Media.SortName via the shared bucketer (BrowseNameFirstChar /
+// browseBucketKeyExpr), giving Latin/numeric buckets A-Z, 0-9, #. SortName has
+// no phonetic normalization, so CJK titles all land in '#' — identical to how
+// media.browse already orders them, so no regression. The response reports
+// scheme "latin".
+//
+// Phase 2 (later, Core-side, no client change): populate a normalized,
+// case-folded sort key at index time and bucket/sort on it instead of SortName.
+// This is the same change for two problems:
+//   - Latin: SortName is BINARY-collated, so lowercase-initial titles sort after
+//     'Z' and would strand under the wrong bucket. A case-folded key fixes the
+//     ordering wrinkle.
+//   - CJK: bucket by pinyin initial (Chinese), kana row (Japanese), or hangul
+//     initial (Korean). Korean is computable from the codepoint; Chinese needs a
+//     Han->pinyin table; Japanese needs reading (yomi) data and is the hardest.
+// The vehicle is a *stored* column populated in Go at index time (a generated
+// column cannot run the phonetic transforms), indexed like SortName. Swapping it
+// in touches only the one shared bucketer; the facet, the letter filter, and the
+// seek cursor follow automatically. No data backfill — it fills on the next
+// manual reindex; pre-reindex rows fall back to SortName bucketing. The response
+// then reports scheme "pinyin"/"kana"/"hangul"/"mixed".
+//
+// Forward-compatibility is already baked in so Phase 2 needs no client change:
+// scheme and key are opaque, label is separate from key, and jumping is done via
+// the opaque per-bucket cursor (never the letter filter), so CJK bucket keys
+// never have to widen the A-Z/0-9/# letter-filter vocabulary.
+//
+// Performance notes (measured on MiSTer, ARM32): the facet is a covering-index
+// scan over one ParentDir partition plus a transient btree for the folded-bucket
+// GROUP BY, ~0.3-0.6s for ~1k-1.4k direct files. The first call into a folder
+// also pays resolveBrowseSortMode's prefix-policy path scan (shared with
+// media.browse, cached after). If genuinely large *flat* partitions appear, the
+// lever is a per-(path,systems,sort) cache tied to the media DB generation
+// (DBConfigBrowseIndexVersion), invalidated on reindex — deliberately not added
+// yet since real catalogs fold large collections into letter subdirectories.
+
+// HandleMediaBrowseIndex handles the media.browse.index API method. It returns
+// the ordered first-character buckets for a browse scope, each with a count and
+// a ready-to-use seek cursor, so a client can draw a "jump to letter" rail and
+// jump into the full ordered list in one round trip. media.browse itself is
+// unchanged: the per-bucket cursor is a normal browse cursor.
+func HandleMediaBrowseIndex(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use API param
+	log.Debug().Msg("received media browse index request")
+
+	result, err := browseMediaIndex(env)
+	if err != nil && errors.Is(err, context.Canceled) {
+		// The client navigated away mid-request. Expected and high-volume, so
+		// keep it out of Sentry (mirrors HandleMediaBrowse).
+		return nil, fmt.Errorf("%w", models.QuietClientErr(err))
+	}
+	return result, err
+}
+
+func browseMediaIndex(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
+	select {
+	case browseSem <- struct{}{}:
+		defer func() { <-browseSem }()
+	case <-env.Context.Done():
+		return nil, env.Context.Err()
+	}
+
+	var params models.BrowseParams
+	if len(env.Params) > 0 {
+		if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+			log.Warn().Err(err).Msg("invalid browse index params")
+			return nil, models.ClientErrf("invalid params: %w", err)
+		}
+	}
+
+	var sortOrder string
+	if params.Sort != nil {
+		sortOrder = *params.Sort
+	}
+
+	var systems []systemdefs.System
+	if params.Systems != nil && len(*params.Systems) > 0 {
+		fuzzy := params.FuzzySystem != nil && *params.FuzzySystem
+		var resolveErr error
+		systems, resolveErr = resolveSystems(*params.Systems, fuzzy)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+	}
+
+	// No path → root listing. A letter rail is not meaningful for roots.
+	if params.Path == nil || *params.Path == "" {
+		return emptyBrowseIndex(), nil
+	}
+
+	prefix, err := resolveBrowseIndexPrefix(&env, *params.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	started := time.Now()
+	result, err := env.Database.MediaDB.BrowseIndex(env.Context, database.BrowseIndexOptions{
+		PathPrefix: prefix,
+		Sort:       sortOrder,
+		Systems:    systems,
+	})
+	logBrowseTiming("index", prefix, started, len(result.Buckets))
+	if err != nil {
+		return nil, fmt.Errorf("error building browse index: %w", err)
+	}
+
+	return buildBrowseIndexResponse(result)
+}
+
+// resolveBrowseIndexPrefix validates the requested path and returns the DB path
+// prefix to scope the facet by, mirroring the security checks in
+// browseFilesystem/browseVirtual.
+func resolveBrowseIndexPrefix(env *requests.RequestEnv, path string) (string, error) {
+	if strings.Contains(path, "://") {
+		if !isKnownVirtualScheme(env, path) {
+			return "", models.ClientErrf("unknown virtual scheme: %s", path)
+		}
+		return path, nil
+	}
+
+	cleaned := filepath.ToSlash(filepath.Clean(path))
+	if cleaned != filepath.ToSlash(path) && cleaned+"/" != filepath.ToSlash(path) {
+		return "", models.ClientErrf("invalid path: contains disallowed components")
+	}
+
+	var rootDirs []string
+	if env.Platform != nil {
+		rootDirs = env.Platform.RootDirs(env.Config)
+	}
+	if !isPathUnderRoots(cleaned, rootDirs) {
+		return "", models.ClientErrf("path is not within an allowed root directory")
+	}
+
+	prefix := cleaned
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return prefix, nil
+}
+
+func emptyBrowseIndex() models.BrowseIndexResults {
+	return models.BrowseIndexResults{
+		Scheme: "none",
+		Groups: []models.BrowseIndexGroup{},
+	}
+}
+
+func buildBrowseIndexResponse(result database.BrowseIndexResult) (any, error) {
+	groups := make([]models.BrowseIndexGroup, 0, len(result.Buckets))
+	for i := range result.Buckets {
+		bucket := &result.Buckets[i]
+		var cursor string
+		if !bucket.AtStart {
+			encoded, err := encodeBrowseCursorWithMode(
+				bucket.LastID, bucket.SortValue, result.SortMode, result.TotalFiles,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to encode browse index cursor: %w", err)
+			}
+			cursor = encoded
+		}
+		groups = append(groups, models.BrowseIndexGroup{
+			Key:    bucket.Key,
+			Label:  bucket.Key,
+			Cursor: cursor,
+			Count:  bucket.Count,
+		})
+	}
+
+	return models.BrowseIndexResults{
+		Scheme:     result.Scheme,
+		Groups:     groups,
+		TotalFiles: result.TotalFiles,
+	}, nil
+}

--- a/pkg/api/methods/media_browse_index_test.go
+++ b/pkg/api/methods/media_browse_index_test.go
@@ -33,9 +33,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func browseIndexOpts(pathPrefix string) any {
+func browseIndexOpts(pathPrefix, sort string) any {
 	return mock.MatchedBy(func(opts database.BrowseIndexOptions) bool {
-		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 0
+		return opts.PathPrefix == pathPrefix && opts.Sort == sort && len(opts.Systems) == 0
 	})
 }
 
@@ -60,10 +60,10 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 
 	mockPlatform := newBrowseIndexPlatform(t, []string{romsRoot})
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts(prefix)).
+	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts(prefix, "name-desc")).
 		Return(database.BrowseIndexResult{
 			Scheme:     "latin",
-			SortMode:   "name-asc",
+			SortMode:   "name-desc",
 			TotalFiles: 3,
 			Buckets: []database.BrowseIndexBucket{
 				{Key: "A", AtStart: true},
@@ -71,7 +71,8 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 			},
 		}, nil)
 
-	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &snesPath})
+	sortOrder := "name-desc"
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &snesPath, Sort: &sortOrder})
 	result, err := HandleMediaBrowseIndex(env)
 	require.NoError(t, err)
 
@@ -94,7 +95,7 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 	require.NotNil(t, cursor)
 	assert.Equal(t, "Apex", cursor.SortValue)
 	assert.Equal(t, int64(7), cursor.LastID)
-	assert.Equal(t, "name-asc", cursor.SortMode)
+	assert.Equal(t, "name-desc", cursor.SortMode)
 	assert.Equal(t, 3, cursor.TotalFiles)
 
 	mockMediaDB.AssertExpectations(t)
@@ -105,7 +106,7 @@ func TestHandleMediaBrowseIndex_VirtualPath(t *testing.T) {
 
 	mockPlatform := newBrowseIndexPlatform(t, []string{browseTestAbsPath("roms")})
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts("steam://")).
+	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts("steam://", "")).
 		Return(database.BrowseIndexResult{
 			Scheme:     "latin",
 			SortMode:   "name-asc",

--- a/pkg/api/methods/media_browse_index_test.go
+++ b/pkg/api/methods/media_browse_index_test.go
@@ -1,0 +1,170 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func browseIndexOpts(pathPrefix string) any {
+	return mock.MatchedBy(func(opts database.BrowseIndexOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 0
+	})
+}
+
+func newBrowseIndexPlatform(t *testing.T, rootDirs []string) *mocks.MockPlatform {
+	t.Helper()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return(rootDirs)
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "Steam", SystemID: "pc", Schemes: []string{"steam"}},
+		})
+	return mockPlatform
+}
+
+func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
+	t.Parallel()
+
+	romsRoot := browseTestAbsPath("roms")
+	snesPath := filepath.Join(romsRoot, "SNES")
+	prefix := filepath.ToSlash(snesPath) + "/"
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{romsRoot})
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts(prefix)).
+		Return(database.BrowseIndexResult{
+			Scheme:     "latin",
+			SortMode:   "name-asc",
+			TotalFiles: 3,
+			Buckets: []database.BrowseIndexBucket{
+				{Key: "A", AtStart: true},
+				{Key: "B", SortValue: "Apex", LastID: 7, Count: 2},
+			},
+		}, nil)
+
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &snesPath})
+	result, err := HandleMediaBrowseIndex(env)
+	require.NoError(t, err)
+
+	res, ok := result.(models.BrowseIndexResults)
+	require.True(t, ok)
+	assert.Equal(t, "latin", res.Scheme)
+	assert.Equal(t, 3, res.TotalFiles)
+	require.Len(t, res.Groups, 2)
+
+	// The leading bucket has no preceding row, so its cursor is empty (page 1).
+	assert.Equal(t, "A", res.Groups[0].Key)
+	assert.Equal(t, "A", res.Groups[0].Label)
+	assert.Empty(t, res.Groups[0].Cursor)
+
+	// The second bucket carries a real seek cursor that decodes to its keyset.
+	assert.Equal(t, "B", res.Groups[1].Key)
+	require.NotEmpty(t, res.Groups[1].Cursor)
+	cursor, err := decodeBrowseCursor(res.Groups[1].Cursor)
+	require.NoError(t, err)
+	require.NotNil(t, cursor)
+	assert.Equal(t, "Apex", cursor.SortValue)
+	assert.Equal(t, int64(7), cursor.LastID)
+	assert.Equal(t, "name-asc", cursor.SortMode)
+	assert.Equal(t, 3, cursor.TotalFiles)
+
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowseIndex_VirtualPath(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{browseTestAbsPath("roms")})
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseIndex", mock.Anything, browseIndexOpts("steam://")).
+		Return(database.BrowseIndexResult{
+			Scheme:     "latin",
+			SortMode:   "name-asc",
+			TotalFiles: 1,
+			Buckets:    []database.BrowseIndexBucket{{Key: "A", AtStart: true, Count: 1}},
+		}, nil)
+
+	steamPath := "steam://"
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &steamPath})
+	result, err := HandleMediaBrowseIndex(env)
+	require.NoError(t, err)
+
+	res, ok := result.(models.BrowseIndexResults)
+	require.True(t, ok)
+	require.Len(t, res.Groups, 1)
+	assert.Equal(t, "A", res.Groups[0].Key)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowseIndex_RootReturnsNoRail(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{browseTestAbsPath("roms")})
+	mockMediaDB := helpers.NewMockMediaDBI()
+
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, nil)
+	result, err := HandleMediaBrowseIndex(env)
+	require.NoError(t, err)
+
+	res, ok := result.(models.BrowseIndexResults)
+	require.True(t, ok)
+	assert.Equal(t, "none", res.Scheme)
+	assert.Empty(t, res.Groups)
+	// No DB call for a root listing.
+	mockMediaDB.AssertNotCalled(t, "BrowseIndex", mock.Anything, mock.Anything)
+}
+
+func TestHandleMediaBrowseIndex_UnknownVirtualScheme(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{browseTestAbsPath("roms")})
+	mockMediaDB := helpers.NewMockMediaDBI()
+
+	bogus := "bogus://"
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &bogus})
+	_, err := HandleMediaBrowseIndex(env)
+	require.Error(t, err)
+	mockMediaDB.AssertNotCalled(t, "BrowseIndex", mock.Anything, mock.Anything)
+}
+
+func TestHandleMediaBrowseIndex_OutsideRootRejected(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{browseTestAbsPath("roms")})
+	mockMediaDB := helpers.NewMockMediaDBI()
+
+	outside := browseTestAbsPath("etc", "secrets")
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &outside})
+	_, err := HandleMediaBrowseIndex(env)
+	require.Error(t, err)
+	mockMediaDB.AssertNotCalled(t, "BrowseIndex", mock.Anything, mock.Anything)
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -75,6 +75,7 @@ const (
 	MethodMediaScrapeCancel    = "media.scrape.cancel"
 	MethodMediaScrapeResume    = "media.scrape.resume"
 	MethodMediaBrowse          = "media.browse"
+	MethodMediaBrowseIndex     = "media.browse.index"
 	MethodMediaControl         = "media.control"
 	MethodMediaActiveUpdate    = "media.active.update"
 	MethodMediaCleanOrphans    = "media.clean.orphans"

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -78,6 +78,31 @@ type BrowseResults struct {
 	TotalFiles int             `json:"totalFiles"`
 }
 
+// BrowseIndexGroup is one first-character section of a browse list. Key is the
+// stable bucket identifier and Label is what to display (equal for the Latin
+// scheme; separated so a future locale scheme can show a glyph differing from
+// the key). Cursor is an opaque media.browse cursor positioned just before the
+// bucket's first row: passing it to media.browse with the same scope returns a
+// continuous page that begins at the bucket. Clients must treat Key and Cursor
+// as opaque.
+type BrowseIndexGroup struct {
+	Key    string `json:"key"`
+	Label  string `json:"label"`
+	Cursor string `json:"cursor"`
+	Count  int    `json:"count"`
+}
+
+// BrowseIndexResults is the response for media.browse.index. Scheme reports the
+// collation used to derive buckets ("latin"), or "none" when no letter rail
+// applies to the scope (non-alphabetical sort, or a root listing); Groups is
+// then empty. Groups is authoritative and already ordered for the active sort;
+// clients render it as-is without assuming any alphabet.
+type BrowseIndexResults struct {
+	Scheme     string             `json:"scheme"`
+	Groups     []BrowseIndexGroup `json:"groups"`
+	TotalFiles int                `json:"totalFiles"`
+}
+
 type SettingsResponse struct {
 	UpdateChannel             string             `json:"updateChannel"`
 	ReadersScanMode           string             `json:"readersScanMode"`

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -250,6 +250,7 @@ func NewMethodMap() *MethodMap {
 		models.MethodMediaIndex:          methods.HandleGenerateMedia,
 		models.MethodMediaSearch:         methods.HandleMediaSearch,
 		models.MethodMediaBrowse:         methods.HandleMediaBrowse,
+		models.MethodMediaBrowseIndex:    methods.HandleMediaBrowseIndex,
 		models.MethodMediaTags:           methods.HandleMediaTags,
 		models.MethodMediaTagsUpdate:     methods.HandleMediaTagsUpdate,
 		models.MethodMediaMetaUpdate:     methods.HandleMediaMetaUpdate,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -346,6 +346,42 @@ type BrowseFileCountOptions struct {
 	Systems    []systemdefs.System
 }
 
+// BrowseIndexOptions contains parameters for the BrowseIndex facet query. It
+// mirrors the scoping fields of BrowseFilesOptions so the index describes the
+// exact list a media.browse call would return.
+type BrowseIndexOptions struct {
+	PathPrefix string
+	Sort       string
+	Systems    []systemdefs.System
+}
+
+// BrowseIndexBucket is one first-character bucket of a browse scope. SortValue
+// and LastID are the keyset of the row immediately before the bucket's first
+// row, so a media.browse cursor built from them lands a page on the bucket's
+// first item. AtStart is true for the bucket that begins the list (no preceding
+// row), in which case the caller should produce an empty cursor.
+type BrowseIndexBucket struct {
+	Key       string
+	SortValue string
+	LastID    int64
+	Count     int
+	AtStart   bool
+}
+
+// BrowseIndexResult is the ordered set of first-character buckets for a browse
+// scope. Buckets are ordered to match the active sort. Scheme reports the
+// collation used to derive the buckets ("latin"); it is "none" when the
+// directory's effective sort is not alphabetical, in which case Buckets is
+// empty and no rail applies. SortMode is the resolved browse sort mode the
+// buckets were computed under and must be embedded into the seek cursors so the
+// subsequent media.browse page continues in the same order.
+type BrowseIndexResult struct {
+	Scheme     string
+	SortMode   string
+	Buckets    []BrowseIndexBucket
+	TotalFiles int
+}
+
 // BrowseVirtualScheme represents a virtual URI scheme with indexed content.
 type BrowseVirtualScheme struct {
 	Scheme    string
@@ -757,6 +793,7 @@ type MediaDBI interface {
 	BrowseDirectories(ctx context.Context, opts BrowseDirectoriesOptions) ([]BrowseDirectoryResult, error)
 	BrowseFiles(ctx context.Context, opts *BrowseFilesOptions) ([]SearchResultWithCursor, error)
 	BrowseFileCount(ctx context.Context, opts BrowseFileCountOptions) (int, error)
+	BrowseIndex(ctx context.Context, opts BrowseIndexOptions) (BrowseIndexResult, error)
 	BrowseVirtualSchemes(ctx context.Context, opts BrowseVirtualSchemesOptions) ([]BrowseVirtualScheme, error)
 	BrowseRootCounts(ctx context.Context, rootDirs []string) (map[string]*int, error)
 	BrowseRouteCounts(ctx context.Context, opts BrowseRouteCountsOptions) (map[string]BrowseRouteCount, error)

--- a/pkg/database/mediadb/letterfilter.go
+++ b/pkg/database/mediadb/letterfilter.go
@@ -23,6 +23,31 @@ import "strings"
 
 const browseNameSymbolBucket = "#"
 
+// browseBucketExpr returns the SQL expression that derives a first-character
+// bucket from the given column. It is the single source of truth for the bucket
+// vocabulary on the SQL side: BuildLetterFilterSQL and the media.browse.index
+// facet both go through it so the filter, the facet, and the seek can never
+// disagree about which bucket a title belongs to. When the sort key changes
+// (e.g. a future normalized SortKey column), only this expression and
+// BrowseNameFirstChar need to move together.
+func browseBucketExpr(column string) string {
+	return "UPPER(SUBSTR(" + column + ", 1, 1))"
+}
+
+// browseBucketKeyExpr returns the SQL expression that folds the first character
+// of column into the canonical browse bucket key ("A".."Z", "0-9", "#"). It is
+// the SQL twin of BrowseNameFirstChar: the media.browse.index facet groups by
+// this expression, so the two must stay in lockstep or the facet and the letter
+// filter would disagree about bucket membership. UPPER leaves digits unchanged,
+// so the numeric test works on the upper-cased character.
+func browseBucketKeyExpr(column string) string {
+	c := browseBucketExpr(column)
+	return "CASE" +
+		" WHEN " + c + " BETWEEN 'A' AND 'Z' THEN " + c +
+		" WHEN " + c + " BETWEEN '0' AND '9' THEN '0-9'" +
+		" ELSE '" + browseNameSymbolBucket + "' END"
+}
+
 // BrowseNameFirstChar returns the indexed first-character bucket used by
 // media.browse letter filters.
 func BrowseNameFirstChar(name string) string {
@@ -54,7 +79,7 @@ func BuildLetterFilterSQL(letter *string, column string) (clauses []string, args
 	}
 
 	letterValue := strings.ToUpper(*letter)
-	upper := "UPPER(SUBSTR(" + column + ", 1, 1))"
+	upper := browseBucketExpr(column)
 
 	switch {
 	case letterValue == "0-9":

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1491,6 +1491,18 @@ func (db *MediaDB) BrowseFileCount(
 	return sqlBrowseFileCount(ctx, db.sql, opts)
 }
 
+// BrowseIndex returns the ordered first-character buckets for a browse scope,
+// each with a count and the keyset needed to seek a media.browse page to the
+// bucket's first item.
+func (db *MediaDB) BrowseIndex(
+	ctx context.Context, opts database.BrowseIndexOptions,
+) (database.BrowseIndexResult, error) {
+	if db.sql == nil {
+		return database.BrowseIndexResult{}, ErrNullSQL
+	}
+	return sqlBrowseIndex(ctx, db.sql, opts)
+}
+
 // BrowseVirtualSchemes returns distinct URI schemes present in indexed media.
 func (db *MediaDB) BrowseVirtualSchemes(
 	ctx context.Context, opts database.BrowseVirtualSchemesOptions,

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -916,6 +916,116 @@ func sqlBrowseFileCountFromMedia(
 	return count, nil
 }
 
+const (
+	browseIndexSchemeLatin = "latin"
+	browseIndexSchemeNone  = "none"
+)
+
+// sqlBrowseIndex computes the first-character bucket facet for a browse scope:
+// per-bucket counts plus each bucket's first-row keyset, from which a seek
+// cursor is derived so a media.browse page lands on the bucket's first item.
+// Buckets are returned in the active sort order (matching scroll order), not a
+// hard-coded alphabet.
+//
+// The rail is only meaningful when rows are ordered alphabetically by SortName.
+// When resolveBrowseSortMode picks a filename / rank-prefix / date-prefix
+// ordering, the first-character mapping would not match the displayed order, so
+// the result reports scheme "none" with no buckets.
+func sqlBrowseIndex(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseIndexOptions,
+) (database.BrowseIndexResult, error) {
+	filesOpts := &database.BrowseFilesOptions{
+		PathPrefix: opts.PathPrefix,
+		Sort:       opts.Sort,
+		Systems:    opts.Systems,
+	}
+	sortMode := resolveBrowseSortMode(ctx, db, filesOpts)
+	if browseSortExpr(sortMode) != "m.SortName" {
+		total, err := sqlBrowseFileCount(ctx, db, database.BrowseFileCountOptions{
+			PathPrefix: opts.PathPrefix,
+			Systems:    opts.Systems,
+		})
+		if err != nil {
+			return database.BrowseIndexResult{}, err
+		}
+		return database.BrowseIndexResult{
+			Scheme:     browseIndexSchemeNone,
+			SortMode:   sortMode,
+			TotalFiles: total,
+		}, nil
+	}
+
+	where, args := browseFilesBaseCondition(filesOpts)
+	// Only join Systems when a system filter is active; browseFilesBaseCondition
+	// references s.SystemID solely for that filter, so an unfiltered facet would
+	// otherwise pay one PK lookup per row for nothing.
+	join := ""
+	if len(opts.Systems) > 0 {
+		join = " INNER JOIN Systems s ON m.SystemDBID = s.DBID"
+	}
+	bucketExpr := browseBucketKeyExpr("m.SortName")
+	// The window orders by the browse sort expression, which idx_media_browse_sort
+	// already provides (ParentDir, IsMissing equality then SortName, DBID), so the
+	// window needs no sort; only the GROUP BY (folded bucket, not index order) uses
+	// a transient btree. rn gives each row's position so MIN(rn) per bucket finds
+	// the bucket's first row, joined back for its keyset.
+	desc := sortMode == "name-desc"
+
+	query := `WITH ordered AS (
+		SELECT ` + bucketExpr + ` AS bucket,
+			m.SortName AS sortValue,
+			m.DBID AS dbid,
+			ROW_NUMBER() OVER (ORDER BY ` + browseSortClause(sortMode) + `) AS rn
+		FROM Media m` + join + `
+		WHERE ` + where + `
+	), counts AS (
+		SELECT bucket, COUNT(*) AS n, MIN(rn) AS first_rn FROM ordered GROUP BY bucket
+	)
+	SELECT o.bucket, o.sortValue, o.dbid, c.n
+	FROM ordered o
+	INNER JOIN counts c ON c.bucket = o.bucket AND c.first_rn = o.rn
+	ORDER BY o.rn`
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return database.BrowseIndexResult{}, fmt.Errorf("browse index query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := database.BrowseIndexResult{Scheme: browseIndexSchemeLatin, SortMode: sortMode}
+	for rows.Next() {
+		var (
+			bucket    string
+			sortValue string
+			dbid      int64
+			count     int
+		)
+		if scanErr := rows.Scan(&bucket, &sortValue, &dbid, &count); scanErr != nil {
+			return database.BrowseIndexResult{}, fmt.Errorf("browse index scan: %w", scanErr)
+		}
+		// Nudge the tiebreaker so the strict keyset comparison includes this row:
+		// ascending uses (>) so subtract one; descending uses (<) so add one.
+		cursorID := dbid - 1
+		if desc {
+			cursorID = dbid + 1
+		}
+		result.Buckets = append(result.Buckets, database.BrowseIndexBucket{
+			Key:       bucket,
+			SortValue: sortValue,
+			LastID:    cursorID,
+			Count:     count,
+			AtStart:   len(result.Buckets) == 0,
+		})
+		result.TotalFiles += count
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return database.BrowseIndexResult{}, fmt.Errorf("browse index rows: %w", rowsErr)
+	}
+	return result, nil
+}
+
 func sqlBrowseVirtualSchemes(
 	ctx context.Context,
 	db sqlQueryable,

--- a/pkg/database/mediadb/sql_browse_index_test.go
+++ b/pkg/database/mediadb/sql_browse_index_test.go
@@ -79,6 +79,8 @@ func firstBrowsedBucketForCursor(
 }
 
 func TestBrowseIndex_BucketsCountsAndSeek(t *testing.T) {
+	t.Parallel()
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 
@@ -120,6 +122,8 @@ func TestBrowseIndex_BucketsCountsAndSeek(t *testing.T) {
 }
 
 func TestBrowseIndex_DescOrder(t *testing.T) {
+	t.Parallel()
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 
@@ -148,6 +152,8 @@ func TestBrowseIndex_DescOrder(t *testing.T) {
 }
 
 func TestBrowseIndex_SystemScoping(t *testing.T) {
+	t.Parallel()
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 
@@ -170,6 +176,8 @@ func TestBrowseIndex_SystemScoping(t *testing.T) {
 }
 
 func TestBrowseIndex_NonAlphabeticalSortReturnsNone(t *testing.T) {
+	t.Parallel()
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 
@@ -189,6 +197,8 @@ func TestBrowseIndex_NonAlphabeticalSortReturnsNone(t *testing.T) {
 }
 
 func TestBrowseIndex_EmptyDirectory(t *testing.T) {
+	t.Parallel()
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 

--- a/pkg/database/mediadb/sql_browse_index_test.go
+++ b/pkg/database/mediadb/sql_browse_index_test.go
@@ -1,0 +1,204 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// browseIndexTestDir is the ParentDir/PathPrefix the index test media live
+// under, matching how insertSystemMedia derives ParentDir from the media path.
+const browseIndexTestDir = "roms/nes/"
+
+func seedBrowseIndexMedia(t *testing.T, mediaDB *MediaDB, systemID string, titles []string) {
+	t.Helper()
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: systemID, Name: systemID})
+	require.NoError(t, err)
+	for _, title := range titles {
+		insertSystemMedia(t, mediaDB, system, title, filepath.Join("roms", "nes", title+".nes"))
+	}
+}
+
+func browseIndexTestSystems(t *testing.T, systemIDs ...string) []systemdefs.System {
+	t.Helper()
+	systems := make([]systemdefs.System, 0, len(systemIDs))
+	for _, id := range systemIDs {
+		sys, err := systemdefs.GetSystem(id)
+		require.NoError(t, err)
+		systems = append(systems, *sys)
+	}
+	return systems
+}
+
+// firstBrowsedBucketForCursor seeks media.browse to the bucket's cursor and
+// returns the canonical bucket of the first row of the resulting page.
+func firstBrowsedBucketForCursor(
+	t *testing.T, mediaDB *MediaDB, bucket database.BrowseIndexBucket, sortMode string,
+) string {
+	t.Helper()
+	opts := &database.BrowseFilesOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       sortMode,
+		Limit:      100,
+	}
+	if !bucket.AtStart {
+		opts.Cursor = &database.BrowseCursor{
+			SortValue: bucket.SortValue,
+			LastID:    bucket.LastID,
+			SortMode:  sortMode,
+		}
+	}
+	files, err := mediaDB.BrowseFiles(context.Background(), opts)
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "expected a page for bucket %q", bucket.Key)
+	return BrowseNameFirstChar(files[0].Name)
+}
+
+func TestBrowseIndex_BucketsCountsAndSeek(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Binary ascending order: '#'(35) < '3'(51) < 'A'(65) < 'B' < 'Z'.
+	seedBrowseIndexMedia(t, mediaDB, "NES", []string{
+		"#Hash", "3D World", "Alpha", "Apex", "Bravo", "Zelda",
+	})
+
+	result, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "name-asc",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "latin", result.Scheme)
+	assert.Equal(t, "name-asc", result.SortMode)
+	assert.Equal(t, 6, result.TotalFiles)
+
+	keys := make([]string, len(result.Buckets))
+	counts := make(map[string]int, len(result.Buckets))
+	for i, b := range result.Buckets {
+		keys[i] = b.Key
+		counts[b.Key] = b.Count
+	}
+	assert.Equal(t, []string{"#", "0-9", "A", "B", "Z"}, keys, "buckets in scroll order")
+	assert.Equal(t, map[string]int{"#": 1, "0-9": 1, "A": 2, "B": 1, "Z": 1}, counts)
+
+	// The first bucket in the list begins the list (no preceding row).
+	require.True(t, result.Buckets[0].AtStart)
+	for _, b := range result.Buckets[1:] {
+		assert.False(t, b.AtStart, "non-leading bucket %q should carry a cursor", b.Key)
+	}
+
+	// Each bucket's cursor must seek a media.browse page to that bucket's first row.
+	for _, b := range result.Buckets {
+		assert.Equalf(t, b.Key, firstBrowsedBucketForCursor(t, mediaDB, b, result.SortMode),
+			"cursor for bucket %q should land on bucket %q", b.Key, b.Key)
+	}
+}
+
+func TestBrowseIndex_DescOrder(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	seedBrowseIndexMedia(t, mediaDB, "NES", []string{
+		"#Hash", "3D World", "Alpha", "Apex", "Bravo", "Zelda",
+	})
+
+	result, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "name-desc",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "latin", result.Scheme)
+	keys := make([]string, len(result.Buckets))
+	for i, b := range result.Buckets {
+		keys[i] = b.Key
+	}
+	assert.Equal(t, []string{"Z", "B", "A", "0-9", "#"}, keys, "reversed for name-desc")
+	require.True(t, result.Buckets[0].AtStart, "Z begins a descending list")
+
+	for _, b := range result.Buckets {
+		assert.Equalf(t, b.Key, firstBrowsedBucketForCursor(t, mediaDB, b, result.SortMode),
+			"desc cursor for bucket %q should land on bucket %q", b.Key, b.Key)
+	}
+}
+
+func TestBrowseIndex_SystemScoping(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	seedBrowseIndexMedia(t, mediaDB, "NES", []string{"Alpha", "Bravo"})
+	seedBrowseIndexMedia(t, mediaDB, "SNES", []string{"Charlie", "Delta", "Echo"})
+
+	result, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "name-asc",
+		Systems:    browseIndexTestSystems(t, "SNES"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.TotalFiles, "only SNES media counted")
+	keys := make([]string, len(result.Buckets))
+	for i, b := range result.Buckets {
+		keys[i] = b.Key
+	}
+	assert.Equal(t, []string{"C", "D", "E"}, keys)
+}
+
+func TestBrowseIndex_NonAlphabeticalSortReturnsNone(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	seedBrowseIndexMedia(t, mediaDB, "NES", []string{"Alpha", "Bravo", "Charlie"})
+
+	// filename-asc resolves to a non-SortName ordering, so a first-character rail
+	// would not match the displayed order: the method reports scheme "none".
+	result, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "filename-asc",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "none", result.Scheme)
+	assert.Empty(t, result.Buckets)
+	assert.Equal(t, 3, result.TotalFiles, "total still reported for the scope")
+}
+
+func TestBrowseIndex_EmptyDirectory(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	result, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: "roms/empty/",
+		Sort:       "name-asc",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "latin", result.Scheme)
+	assert.Empty(t, result.Buckets)
+	assert.Equal(t, 0, result.TotalFiles)
+}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2334,6 +2334,22 @@ func (m *MockMediaDBI) BrowseFileCount(
 	return 0, nil
 }
 
+func (m *MockMediaDBI) BrowseIndex(
+	ctx context.Context, opts database.BrowseIndexOptions,
+) (database.BrowseIndexResult, error) {
+	args := m.Called(ctx, opts)
+	if result, ok := args.Get(0).(database.BrowseIndexResult); ok {
+		if err := args.Error(1); err != nil {
+			return result, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return result, nil
+	}
+	if err := args.Error(1); err != nil {
+		return database.BrowseIndexResult{}, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return database.BrowseIndexResult{}, nil
+}
+
 func (m *MockMediaDBI) BrowseVirtualSchemes(
 	ctx context.Context, opts database.BrowseVirtualSchemesOptions,
 ) ([]database.BrowseVirtualScheme, error) {


### PR DESCRIPTION
- Add `media.browse.index`, returning the ordered first-character buckets (`A`–`Z`, `0-9`, `#`) for a browse scope, each with a count and an opaque `media.browse` cursor that seeks to the start of that bucket — letting clients draw a jump-to-letter rail and seek into the full ordered list in one round trip.
- The facet reuses the existing browse base condition, sort resolution, and bucket vocabulary (`BrowseNameFirstChar` / `BuildLetterFilterSQL`) through a shared SQL bucket expression, so the filter, facet, and seek cursor can never disagree.
- Runs as a covering-index scan over one `ParentDir` partition; reports `scheme: "none"` (empty rail) for root listings and non-alphabetical sorts (filename, ranked/date-prefixed folders) where a first-character rail would not match display order.
- Response uses an opaque `scheme` plus separate `key`/`label` and seeks via the cursor (never the letter filter), so a future locale-aware scheme (pinyin/kana/hangul) needs no client change; the Phase 2 plan is documented in a comment in `media_browse_index.go`.
- Adds the `media.browse.index` reference to `docs/api/methods.md` and the method list, plus DB and API tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `media.browse.index` for alphabetical “jump-to-letter” browse buckets, including per-bucket counts and seek cursors to quickly paginate large collections. Supports browse-scope parameters and system filtering, and reports a no-bucket mode when an alphabetical scheme isn’t applicable.
* **Documentation**
  * Updated Core API documentation to include the new `media.browse.index` method and response shape.
* **Tests**
  * Added API and database coverage for bucket ordering, cursor correctness, virtual/invalid path handling, and system-scoped results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->