### PR TITLE
feat(api): add offset field to media.browse.index buckets

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -232,7 +232,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods are used to execute actions and request data back from the API. The current API provides **61 registered methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
+Methods are used to execute actions and request data back from the API. These API docs cover **62 methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
 
 | ID                              | Description                                                                           |
 | :------------------------------ | :------------------------------------------------------------------------------------ |
@@ -256,6 +256,7 @@ Methods are used to execute actions and request data back from the API. The curr
 | media.browse.index              | Return first-character jump-to-letter buckets and seek cursors for a browse scope.    |
 | media.lookup                    | Resolve a game name and system to a media database match.                             |
 | media.meta                      | Return metadata for a specific indexed media row.                                     |
+| media.meta.update               | Update writable metadata fields for a specific indexed media row.                     |
 | media.image                     | Return the best matching image for a specific indexed media row.                      |
 | media.clean.orphans             | Remove orphaned media database rows.                                                  |
 | scrapers                        | List available metadata scrapers.                                                     |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -737,6 +737,7 @@ All parameters are optional.
 | label  | string | Yes      | Display text for the bucket. Equal to `key` for the `latin` scheme.                               |
 | count  | number | Yes      | Number of media files in the bucket.                                                              |
 | cursor | string | Yes      | Opaque `media.browse` cursor positioned just before the bucket's first row. Empty string for the bucket that begins the list (call `media.browse` with no cursor for the first page). |
+| offset | number | Yes      | 0-based position of the bucket's first item among the scope's media files, taken from its row number in the same ordered listing `media.browse` pages through (so it cannot drift from the browse order). Excludes any directory entries the listing shows before files; a client that jumps to a position in the full list adds its own leading-directory count. Use this to jump to the bucket's position rather than reloading from `cursor`. |
 
 Clients should render `groups` exactly as received, in order, without assuming a particular alphabet: `scheme` and `key` are opaque so a future locale-aware scheme (e.g. pinyin/kana/hangul buckets) requires no client change.
 
@@ -766,9 +767,9 @@ Clients should render `groups` exactly as received, in order, without assuming a
     "scheme": "latin",
     "totalFiles": 150,
     "groups": [
-      { "key": "#", "label": "#", "count": 3, "cursor": "" },
-      { "key": "0-9", "label": "0-9", "count": 7, "cursor": "eyJzb3J0VmFsdWUiOiIjV29sZiIsImxhc3RJZCI6MTAyfQ==" },
-      { "key": "A", "label": "A", "count": 12, "cursor": "eyJzb3J0VmFsdWUiOiI5IExpdmVzIiwibGFzdElkIjoxMTV9" }
+      { "key": "#", "label": "#", "count": 3, "cursor": "", "offset": 0 },
+      { "key": "0-9", "label": "0-9", "count": 7, "cursor": "eyJzb3J0VmFsdWUiOiIjV29sZiIsImxhc3RJZCI6MTAyfQ==", "offset": 3 },
+      { "key": "A", "label": "A", "count": 12, "cursor": "eyJzb3J0VmFsdWUiOiI5IExpdmVzIiwibGFzdElkIjoxMTV9", "offset": 10 }
     ]
   }
 }
@@ -1481,6 +1482,7 @@ Single requests return the existing single `media` response shape. Batch request
 | isMissing  | boolean                                 | Yes      | Whether the indexed file is currently missing.        |
 | tags       | [TagInfo](#taginfo-object)[]            | Yes      | ROM-level tags for this media row.                    |
 | properties | object                                  | Yes      | ROM-level properties keyed by canonical type tag.     |
+| launcherOverride | string                            | No       | Launcher ID stored for this media row, mirrored from `property:launcher-override` in `properties`. When present, Core uses it for title, search, path, random, and history launches unless ZapScript includes an explicit `launcher` argument. |
 | title      | [MediaMetaTitle](#media-meta-title-object) | Yes   | Shared title metadata for this media row.             |
 
 ##### Media meta title object
@@ -1538,7 +1540,13 @@ Property keys are canonical type tags such as `property:description`, `property:
       "tags": [
         {"type": "region", "tag": "usa"}
       ],
-      "properties": {},
+      "properties": {
+        "property:launcher-override": {
+          "text": "RetroArch",
+          "contentType": ""
+        }
+      },
+      "launcherOverride": "RetroArch",
       "title": {
         "slug": "super mario world",
         "name": "Super Mario World",
@@ -1576,6 +1584,77 @@ Property keys are canonical type tags such as `property:description`, `property:
       {"mediaId": 42},
       {"system": "SNES", "path": "/roms/snes/Super Metroid.sfc"}
     ]
+  }
+}
+```
+
+### media.meta.update
+
+Update writable metadata fields for one indexed media row, then return the same response shape as [`media.meta`](#mediameta).
+
+Use this to store a per-media launcher override. Core validates the launcher exists and supports the media row's system before saving it. Set `launcherOverride` to `null` to clear the override.
+
+Launcher selection order is:
+
+1. Explicit `launcher` advanced argument in ZapScript.
+2. Per-media `launcherOverride` stored with `media.meta.update`.
+3. System default launcher from configuration.
+4. Normal launcher matching.
+
+#### Parameters
+
+An object identifying the media row by `mediaId` or by `system` and canonical `path`.
+
+| Key     | Type   | Required | Description |
+| :------ | :----- | :------- | :---------- |
+| mediaId | number | No       | Opaque media database row ID from search, browse, or lookup. Cannot be mixed with `system`/`path`. |
+| system  | string | No       | System ID for the media row. Required when `mediaId` is omitted. |
+| path    | string | No       | Canonical indexed media path. Required when `mediaId` is omitted. |
+| media   | object | Yes      | Patch object. Currently supports only `launcherOverride`. |
+
+##### Media patch object
+
+| Key              | Type        | Required | Description |
+| :--------------- | :---------- | :------- | :---------- |
+| launcherOverride | string|null | Yes      | Launcher ID to use for this media row, matched case-insensitively and stored with canonical casing. Use `null` to clear it. Empty strings are rejected. |
+
+#### Result
+
+| Key   | Type                            | Required | Description                 |
+| :---- | :------------------------------ | :------- | :-------------------------- |
+| media | [MediaMeta](#media-meta-object) | Yes      | Updated metadata for row.   |
+
+#### Example
+
+##### Set override
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "media.meta.update",
+  "params": {
+    "mediaId": 42,
+    "media": {
+      "launcherOverride": "RetroArch"
+    }
+  }
+}
+```
+
+##### Clear override
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "media.meta.update",
+  "params": {
+    "system": "SNES",
+    "path": "/roms/snes/Super Mario World.sfc",
+    "media": {
+      "launcherOverride": null
+    }
   }
 }
 ```

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -1616,7 +1616,7 @@ An object identifying the media row by `mediaId` or by `system` and canonical `p
 
 | Key              | Type        | Required | Description |
 | :--------------- | :---------- | :------- | :---------- |
-| launcherOverride | string|null | Yes      | Launcher ID to use for this media row, matched case-insensitively and stored with canonical casing. Use `null` to clear it. Empty strings are rejected. |
+| launcherOverride | string\|null | Yes      | Launcher ID to use for this media row, matched case-insensitively and stored with canonical casing. Use `null` to clear it. Empty strings are rejected. |
 
 #### Result
 

--- a/pkg/api/methods/media_browse_index.go
+++ b/pkg/api/methods/media_browse_index.go
@@ -203,6 +203,7 @@ func buildBrowseIndexResponse(result database.BrowseIndexResult) (any, error) {
 			Label:  bucket.Key,
 			Cursor: cursor,
 			Count:  bucket.Count,
+			Offset: bucket.Offset,
 		})
 	}
 

--- a/pkg/api/methods/media_browse_index_test.go
+++ b/pkg/api/methods/media_browse_index_test.go
@@ -66,8 +66,8 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 			SortMode:   "name-desc",
 			TotalFiles: 3,
 			Buckets: []database.BrowseIndexBucket{
-				{Key: "A", AtStart: true},
-				{Key: "B", SortValue: "Apex", LastID: 7, Count: 2},
+				{Key: "A", AtStart: true, Count: 5, Offset: 0},
+				{Key: "B", SortValue: "Apex", LastID: 7, Count: 2, Offset: 5},
 			},
 		}, nil)
 
@@ -86,6 +86,8 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 	assert.Equal(t, "A", res.Groups[0].Key)
 	assert.Equal(t, "A", res.Groups[0].Label)
 	assert.Empty(t, res.Groups[0].Cursor)
+	assert.Equal(t, 0, res.Groups[0].Offset)
+	assert.Equal(t, 5, res.Groups[1].Offset)
 
 	// The second bucket carries a real seek cursor that decodes to its keyset.
 	assert.Equal(t, "B", res.Groups[1].Key)

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -84,12 +84,15 @@ type BrowseResults struct {
 // the key). Cursor is an opaque media.browse cursor positioned just before the
 // bucket's first row: passing it to media.browse with the same scope returns a
 // continuous page that begins at the bucket. Clients must treat Key and Cursor
-// as opaque.
+// as opaque. Offset is the 0-based position of the bucket's first item among
+// the scope's media files (excluding any leading directories), for clients that
+// jump to a position in the full list rather than reload from the cursor.
 type BrowseIndexGroup struct {
 	Key    string `json:"key"`
 	Label  string `json:"label"`
 	Cursor string `json:"cursor"`
 	Count  int    `json:"count"`
+	Offset int    `json:"offset"`
 }
 
 // BrowseIndexResults is the response for media.browse.index. Scheme reports the

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -358,13 +358,17 @@ type BrowseIndexOptions struct {
 // BrowseIndexBucket is one first-character bucket of a browse scope. SortValue
 // and LastID are the keyset of the row immediately before the bucket's first
 // row, so a media.browse cursor built from them lands a page on the bucket's
-// first item. AtStart is true for the bucket that begins the list (no preceding
-// row), in which case the caller should produce an empty cursor.
+// first item. Offset is the bucket's 0-based position among the scope's files
+// (its row number in the ordered query, so it can't drift from the browse
+// order); it excludes leading directories, which the caller adds. AtStart is
+// true for the bucket that begins the list (no preceding row), in which case
+// the caller should produce an empty cursor.
 type BrowseIndexBucket struct {
 	Key       string
 	SortValue string
 	LastID    int64
 	Count     int
+	Offset    int
 	AtStart   bool
 }
 

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -983,7 +983,7 @@ func sqlBrowseIndex(
 	), counts AS (
 		SELECT bucket, COUNT(*) AS n, MIN(rn) AS first_rn FROM ordered GROUP BY bucket
 	)
-	SELECT o.bucket, o.sortValue, o.dbid, c.n
+	SELECT o.bucket, o.sortValue, o.dbid, c.n, c.first_rn
 	FROM ordered o
 	INNER JOIN counts c ON c.bucket = o.bucket AND c.first_rn = o.rn
 	ORDER BY o.rn`
@@ -1001,8 +1001,9 @@ func sqlBrowseIndex(
 			sortValue string
 			dbid      int64
 			count     int
+			firstRN   int64
 		)
-		if scanErr := rows.Scan(&bucket, &sortValue, &dbid, &count); scanErr != nil {
+		if scanErr := rows.Scan(&bucket, &sortValue, &dbid, &count, &firstRN); scanErr != nil {
 			return database.BrowseIndexResult{}, fmt.Errorf("browse index scan: %w", scanErr)
 		}
 		// Nudge the tiebreaker so the strict keyset comparison includes this row:
@@ -1016,7 +1017,9 @@ func sqlBrowseIndex(
 			SortValue: sortValue,
 			LastID:    cursorID,
 			Count:     count,
-			AtStart:   len(result.Buckets) == 0,
+			// rn is 1-based; the bucket's first item is its 0-based file offset.
+			Offset:  int(firstRN - 1),
+			AtStart: len(result.Buckets) == 0,
 		})
 		result.TotalFiles += count
 	}

--- a/pkg/database/mediadb/sql_browse_index_test.go
+++ b/pkg/database/mediadb/sql_browse_index_test.go
@@ -101,12 +101,17 @@ func TestBrowseIndex_BucketsCountsAndSeek(t *testing.T) {
 
 	keys := make([]string, len(result.Buckets))
 	counts := make(map[string]int, len(result.Buckets))
+	offsets := make(map[string]int, len(result.Buckets))
 	for i, b := range result.Buckets {
 		keys[i] = b.Key
 		counts[b.Key] = b.Count
+		offsets[b.Key] = b.Offset
 	}
 	assert.Equal(t, []string{"#", "0-9", "A", "B", "Z"}, keys, "buckets in scroll order")
 	assert.Equal(t, map[string]int{"#": 1, "0-9": 1, "A": 2, "B": 1, "Z": 1}, counts)
+	// Offset is the bucket's 0-based file position = cumulative count of earlier
+	// buckets (#:0, 0-9:1, A:2, B:4, Z:5).
+	assert.Equal(t, map[string]int{"#": 0, "0-9": 1, "A": 2, "B": 4, "Z": 5}, offsets)
 
 	// The first bucket in the list begins the list (no preceding row).
 	require.True(t, result.Buckets[0].AtStart)
@@ -139,10 +144,15 @@ func TestBrowseIndex_DescOrder(t *testing.T) {
 
 	assert.Equal(t, "latin", result.Scheme)
 	keys := make([]string, len(result.Buckets))
+	offsets := make(map[string]int, len(result.Buckets))
 	for i, b := range result.Buckets {
 		keys[i] = b.Key
+		offsets[b.Key] = b.Offset
 	}
 	assert.Equal(t, []string{"Z", "B", "A", "0-9", "#"}, keys, "reversed for name-desc")
+	// Offset is the bucket's 0-based position in the descending listing =
+	// cumulative count of earlier buckets (Z:0, B:1, A:2, 0-9:4, #:5).
+	assert.Equal(t, map[string]int{"Z": 0, "B": 1, "A": 2, "0-9": 4, "#": 5}, offsets)
 	require.True(t, result.Buckets[0].AtStart, "Z begins a descending list")
 
 	for _, b := range result.Buckets {


### PR DESCRIPTION
- Thread a 0-based file offset through `media.browse.index`, derived from each bucket's first row number in the same ordered listing `media.browse` pages through, so clients can jump to a bucket's position without reloading from its cursor. The offset excludes leading directory entries.
- Document the existing `media.meta.update` method and the `launcherOverride` field on the `media.meta` response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `media.meta.update` RPC for updating writable media metadata (including `launcherOverride`).
  * Enhanced `media.meta` responses with optional `launcherOverride`.
  * Updated `media.browse.index` to include an `offset` per bucket for 0-based pagination within the ordered results.
* **Documentation**
  * Updated API documentation to reflect the new method and the updated method/response fields (now 62 registered methods).
* **Tests**
  * Extended browse-index tests to validate bucket `offset` values in both ascending and descending order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->