### PR TITLE
chore: clean up stale TODO comments

### DIFF
--- a/pkg/config/migrate/iniconfig/user.go
+++ b/pkg/config/migrate/iniconfig/user.go
@@ -54,13 +54,12 @@ type TapToConfig struct {
 }
 
 type SystemsConfig struct {
-	GamesFolder []string `ini:"games_folder,omitempty,allowshadow"` // TODO: rename root_folder?
-	SetCore     []string `ini:"set_core,omitempty,allowshadow"`     // TODO: deprecated? change to set_launcher
+	GamesFolder []string `ini:"games_folder,omitempty,allowshadow"`
+	SetCore     []string `ini:"set_core,omitempty,allowshadow"`
 }
 
 type LaunchersConfig struct {
 	AllowFile []string `ini:"allow_file,omitempty,allowshadow"`
-	// TODO: allow_shell - contents of shell command
 }
 
 type APIConfig struct {
@@ -195,7 +194,6 @@ func (c *UserConfig) IsFileAllowed(path string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	for _, allowed := range c.Launchers.AllowFile {
-		// TODO: case insensitive on mister? platform option?
 		if runtime.GOOS == "windows" {
 			// do a case-insensitive comparison on windows
 			allowed = strings.ToLower(allowed)

--- a/pkg/database/mediadb/slug_metadata_test.go
+++ b/pkg/database/mediadb/slug_metadata_test.go
@@ -294,15 +294,14 @@ func TestGenerateSlugWithMetadata_DifferentMediaTypes(t *testing.T) {
 			expectedSecondary: "firstbattles01e05", // Secondary is reordered: "First Battle s01e05"
 			description:       "TV episode with S01E05 format and subtitle",
 		},
-		// TODO: Re-enable when ParseMovie is implemented
-		// {
-		// 	name:              "movie_with_year_no_secondary",
-		// 	mediaType:         slugs.MediaTypeMovie,
-		// 	input:             "The Matrix (1999)",
-		// 	expectedSlug:      "matrix",
-		// 	expectedSecondary: "",
-		// 	description:       "Movie with year in parentheses (stripped), no secondary title",
-		// },
+		{
+			name:              "movie_with_year_no_secondary",
+			mediaType:         slugs.MediaTypeMovie,
+			input:             "The Matrix (1999)",
+			expectedSlug:      "matrix",
+			expectedSecondary: "",
+			description:       "Movie with year in parentheses (stripped), no secondary title",
+		},
 		{
 			name:              "game_episode_like_with_dash",
 			mediaType:         slugs.MediaTypeGame,
@@ -311,15 +310,14 @@ func TestGenerateSlugWithMetadata_DifferentMediaTypes(t *testing.T) {
 			expectedSecondary: "s01e01", // After dash
 			description:       "Game with dash separator, episode-like title not normalized for Game type",
 		},
-		// TODO: Re-enable when ParseMusic is implemented
-		// {
-		// 	name:              "music_with_dash_separator",
-		// 	mediaType:         slugs.MediaTypeMusic,
-		// 	input:             "The Beatles - Hey Jude",
-		// 	expectedSlug:      "beatlesheyjude",
-		// 	expectedSecondary: "heyjude", // After dash
-		// 	description:       "Music title with dash separator between artist and song",
-		// },
+		{
+			name:              "music_with_dash_separator",
+			mediaType:         slugs.MediaTypeMusic,
+			input:             "The Beatles - Hey Jude",
+			expectedSlug:      "beatlesheyjude",
+			expectedSecondary: "heyjude", // After dash
+			description:       "Music title with dash separator between artist and song",
+		},
 		{
 			name:              "tvshow_vs_game_same_episode_title",
 			mediaType:         slugs.MediaTypeGame,

--- a/pkg/database/slugs/media_parsing.go
+++ b/pkg/database/slugs/media_parsing.go
@@ -26,7 +26,8 @@ package slugs
 // Media-specific parsers are implemented in separate files:
 //   - ParseTVShow → media_parsing_tv.go
 //   - ParseGame → media_parsing_game.go
-//   - ParseMovie, ParseMusic, etc. → TODO (return unchanged for now)
+//   - ParseMovie → media_parsing_movie.go
+//   - ParseMusic → media_parsing_music.go
 func ParseWithMediaType(mediaType MediaType, title string) string {
 	switch mediaType {
 	case MediaTypeTVShow:

--- a/pkg/database/slugs/media_parsing_movie.go
+++ b/pkg/database/slugs/media_parsing_movie.go
@@ -71,8 +71,8 @@ var (
 // Note: Years like (1999) are extracted as tags (year:1999) by the tag parser,
 // allowing users to filter by year when needed: launch.title Movie/Matrix (+year:1999)
 //
-// TODO: Scene releases use bare years without parentheses (Movie.Name.1999.1080p),
-// but we can't safely strip them without breaking movies with years in their titles
+// Scene releases use bare years without parentheses (Movie.Name.1999.1080p),
+// but we intentionally keep them to avoid breaking movies with years in their titles
 // (e.g., "2001: A Space Odyssey", "1917", "1984"). For now, we only strip years in
 // parentheses/brackets. This means scene releases will include the year in the slug
 // (e.g., "Matrix 1999" vs "Matrix" from standard naming). Cross-format matching happens

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -393,7 +393,7 @@ func (p *Platform) ReturnToMenu() error {
 }
 
 func (p *Platform) LaunchSystem(_ *config.Instance, systemID string) error {
-	if strings.EqualFold(systemID, "menu") {
+	if strings.EqualFold(systemID, platforms.SystemMenu) {
 		return p.ReturnToMenu()
 	}
 

--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -815,6 +815,23 @@ func TestReturnToMenu_CallsStopActiveLauncherWithStopForMenu(t *testing.T) {
 	assert.NoError(t, err, "ReturnToMenu should handle no active media gracefully")
 }
 
+func TestLaunchSystem_MenuUsesReturnToMenu(t *testing.T) {
+	// Note: Not using t.Parallel() because MockESAPIServer binds to hardcoded port 1234
+	mockESAPI := helpers.NewMockESAPIServer(t)
+	mockESAPI.WithNoRunningGame()
+
+	fs := helpers.NewMemoryFS()
+	cfg, err := helpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := &Platform{cfg: cfg}
+	platform.activeMedia = func() *models.ActiveMedia { return nil }
+	platform.setActiveMedia = func(_ *models.ActiveMedia) {}
+
+	err = platform.LaunchSystem(cfg, "Menu")
+	assert.NoError(t, err)
+}
+
 // TestStartPost_ESAPIUnavailable tests that StartPost handles ES API unavailability gracefully
 func TestStartPost_ESAPIUnavailable(t *testing.T) {
 	// Note: Not using t.Parallel() because we need to ensure no MockESAPIServer is running

--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -89,11 +89,7 @@ func PathToMGLDef(system *Core, path string) (*MGLParams, error) {
 	return mglDef, fmt.Errorf("system has no matching mgl args: %s, %s", system.ID, path)
 }
 
-// FIXME: launch game > launch new game same system > not working? should it?
-// TODO: alternate cores (user core override)
 // TODO: alternate arcade folders
-// TODO: custom scan function
-// TODO: custom launch function
 // TODO: support globbing on extensions
 
 var Systems = map[string]Core{
@@ -583,8 +579,6 @@ var Systems = map[string]Core{
 		RBF: "_Console/NeoGeo",
 		Slots: []Slot{
 			{
-				// TODO: This also has some special handling re: zip files (darksoft pack).
-				// Exts: []strings{".*"}
 				Label: "ROM set",
 				Exts:  []string{".neo"},
 				Mgl: &MGLParams{

--- a/pkg/platforms/mister/cores/rbfs.go
+++ b/pkg/platforms/mister/cores/rbfs.go
@@ -152,7 +152,6 @@ func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 }
 
 func SystemsWithRBF() map[string]RBFInfo {
-	// TODO: include alt rbfs somehow?
 	results := make(map[string]RBFInfo)
 
 	rbfFiles, err := shallowScanRBF()

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -651,7 +651,7 @@ func (*Platform) isFPGAActive() bool {
 
 func (p *Platform) LaunchSystem(cfg *config.Instance, id string) error {
 	// Handle menu specially - launch menu core directly
-	if strings.EqualFold(id, "menu") {
+	if strings.EqualFold(id, platforms.SystemMenu) {
 		if err := mistermain.LaunchMenu(); err != nil {
 			return fmt.Errorf("failed to launch menu: %w", err)
 		}

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -123,7 +123,7 @@ func TestScriptRunMode(t *testing.T) {
 	assert.True(t, widget)
 }
 
-func TestLaunchSystem_MenuUsesReturnToMenu(t *testing.T) {
+func TestLaunchSystem_MenuUsesLaunchMenu(t *testing.T) {
 	t.Parallel()
 
 	p := &Platform{}

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -103,6 +103,23 @@ func restoreTLSRootFallbackHooks(t *testing.T) {
 	})
 }
 
+func TestIsWidgetScript(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isWidgetScript("/media/fat/Scripts/test.sh", ""))
+	assert.False(t, isWidgetScript("/media/fat/Scripts/zaparoo.sh", "-show-text"))
+	assert.True(t, isWidgetScript("/media/fat/Scripts/zaparoo.sh", "'-show-text'"))
+}
+
+func TestLaunchSystem_MenuUsesReturnToMenu(t *testing.T) {
+	t.Parallel()
+
+	p := &Platform{}
+	err := p.LaunchSystem(&config.Instance{}, "Menu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to launch menu")
+}
+
 func TestStopActiveLauncher_CustomKill(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -111,6 +111,18 @@ func TestIsWidgetScript(t *testing.T) {
 	assert.True(t, isWidgetScript("/media/fat/Scripts/zaparoo.sh", "'-show-text'"))
 }
 
+func TestScriptRunMode(t *testing.T) {
+	t.Parallel()
+
+	runScript, widget := scriptRunMode("/media/fat/Scripts/test.sh", "")
+	assert.Equal(t, misterScriptRunFlag, runScript)
+	assert.False(t, widget)
+
+	runScript, widget = scriptRunMode("/media/fat/Scripts/zaparoo.sh", "'-show-text'")
+	assert.Equal(t, misterWidgetRunFlag, runScript)
+	assert.True(t, widget)
+}
+
 func TestLaunchSystem_MenuUsesReturnToMenu(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -121,6 +122,34 @@ func TestScriptRunMode(t *testing.T) {
 	runScript, widget = scriptRunMode("/media/fat/Scripts/zaparoo.sh", "'-show-text'")
 	assert.Equal(t, misterWidgetRunFlag, runScript)
 	assert.True(t, widget)
+}
+
+func TestRunScript_HiddenSetsMiSTerEnvironment(t *testing.T) {
+	t.Parallel()
+
+	if scriptIsActive() {
+		t.Skip("MiSTer script already active")
+	}
+
+	tmpDir := t.TempDir()
+	flagPath := filepath.Join(tmpDir, "run_flag")
+	argPath := filepath.Join(tmpDir, "arg")
+	scriptPath := filepath.Join(tmpDir, "script.sh")
+	script := "#!/bin/sh\n" +
+		"printf '%s' \"$ZAPAROO_RUN_SCRIPT\" > run_flag\n" +
+		"printf '%s' \"$1\" > arg\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o700)) //nolint:gosec // test script must be executable
+
+	err := runScript(nil, scriptPath, "hello", true)
+	require.NoError(t, err)
+
+	flag, err := os.ReadFile(flagPath) //nolint:gosec // test reads from its temp dir
+	require.NoError(t, err)
+	assert.Equal(t, misterScriptRunFlag, string(flag))
+
+	arg, err := os.ReadFile(argPath) //nolint:gosec // test reads from its temp dir
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(arg))
 }
 
 func TestLaunchSystem_MenuUsesLaunchMenu(t *testing.T) {

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -19,8 +19,20 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	misterScriptPath       = "/tmp/script"
+	misterWidgetScriptPath = "/tmp/widget_script"
+	misterScriptRunFlag    = "1"
+	misterWidgetRunFlag    = "2"
+)
+
 func scriptIsActive() bool {
-	cmd := exec.CommandContext(context.Background(), "bash", "-c", "ps ax | grep [/]tmp/script")
+	cmd := exec.CommandContext(
+		context.Background(),
+		"bash",
+		"-c",
+		"ps ax | grep [/]"+strings.TrimPrefix(misterScriptPath, "/"),
+	)
 	output, err := cmd.Output()
 	if err != nil {
 		// grep returns an error code if there was no result
@@ -44,7 +56,7 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 		cmd := exec.CommandContext(context.Background(), bin, args) //nolint:gosec // G204: script runner's purpose
 		cmd.Env = os.Environ()
 		cmd.Env = append(cmd.Env, "LC_ALL=en_US.UTF-8", "HOME=/root",
-			"LESSKEY=/media/fat/linux/lesskey", "ZAPAROO_RUN_SCRIPT=1")
+			"LESSKEY=/media/fat/linux/lesskey", "ZAPAROO_RUN_SCRIPT="+misterScriptRunFlag)
 		cmd.Dir = filepath.Dir(bin)
 		err := cmd.Run()
 		if err != nil {
@@ -90,19 +102,18 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 		return fmt.Errorf("failed to open console for script: %w", err)
 	}
 
-	scriptPath := "/tmp/script"
+	scriptPath := misterScriptPath
 	vt := "2"
-	runScript := "1"
-	// TODO: these shouldn't be hardcoded
+	runScript := misterScriptRunFlag
 	log.Debug().Msgf("bin: %s", bin)
 	log.Debug().Msgf("args: %s", args)
 	if strings.HasSuffix(bin, "/zaparoo.sh") && strings.HasPrefix(args, "'-show-") {
 		// launching widgets, so we'll use a different tty and script name
 		// to avoid the active script check (widgets handle this)
 		log.Debug().Msg("widget launched, changing params")
-		scriptPath = "/tmp/widget_script"
+		scriptPath = misterWidgetScriptPath
 		vt = launcherConsoleVT
-		runScript = "2"
+		runScript = misterWidgetRunFlag
 	}
 
 	// this is just to follow mister's convention, which reserves

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -41,6 +41,13 @@ func isWidgetScript(bin, args string) bool {
 	return strings.HasSuffix(bin, "/zaparoo.sh") && strings.HasPrefix(args, "'-show-")
 }
 
+func scriptRunMode(bin, args string) (runScript string, widget bool) {
+	if isWidgetScript(bin, args) {
+		return misterWidgetRunFlag, true
+	}
+	return misterScriptRunFlag, false
+}
+
 func runScript(pl *Platform, bin, args string, hidden bool) error {
 	if _, err := os.Stat(bin); err != nil {
 		return fmt.Errorf("failed to stat script file: %w", err)
@@ -103,17 +110,16 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 	}
 
 	scriptPath := misterScriptPath
+	runScript, widgetScript := scriptRunMode(bin, args)
 	vt := "2"
-	runScript := misterScriptRunFlag
 	log.Debug().Msgf("bin: %s", bin)
 	log.Debug().Msgf("args: %s", args)
-	if isWidgetScript(bin, args) {
+	if widgetScript {
 		// launching widgets, so we'll use a different tty and script name
 		// to avoid the active script check (widgets handle this)
 		log.Debug().Msg("widget launched, changing params")
 		scriptPath = misterWidgetScriptPath
 		vt = launcherConsoleVT
-		runScript = misterWidgetRunFlag
 	}
 
 	// this is just to follow mister's convention, which reserves

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -20,19 +20,15 @@ import (
 )
 
 const (
-	misterScriptPath       = "/tmp/script"
-	misterWidgetScriptPath = "/tmp/widget_script"
-	misterScriptRunFlag    = "1"
-	misterWidgetRunFlag    = "2"
+	misterScriptPath        = "/tmp/script"
+	misterScriptGrepCommand = "ps ax | grep [/]tmp/script"
+	misterWidgetScriptPath  = "/tmp/widget_script"
+	misterScriptRunFlag     = "1"
+	misterWidgetRunFlag     = "2"
 )
 
 func scriptIsActive() bool {
-	cmd := exec.CommandContext(
-		context.Background(),
-		"bash",
-		"-c",
-		"ps ax | grep [/]"+strings.TrimPrefix(misterScriptPath, "/"),
-	)
+	cmd := exec.CommandContext(context.Background(), "bash", "-c", misterScriptGrepCommand)
 	output, err := cmd.Output()
 	if err != nil {
 		// grep returns an error code if there was no result

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -37,6 +37,10 @@ func scriptIsActive() bool {
 	return strings.TrimSpace(string(output)) != ""
 }
 
+func isWidgetScript(bin, args string) bool {
+	return strings.HasSuffix(bin, "/zaparoo.sh") && strings.HasPrefix(args, "'-show-")
+}
+
 func runScript(pl *Platform, bin, args string, hidden bool) error {
 	if _, err := os.Stat(bin); err != nil {
 		return fmt.Errorf("failed to stat script file: %w", err)
@@ -103,7 +107,7 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 	runScript := misterScriptRunFlag
 	log.Debug().Msgf("bin: %s", bin)
 	log.Debug().Msgf("args: %s", args)
-	if strings.HasSuffix(bin, "/zaparoo.sh") && strings.HasPrefix(args, "'-show-") {
+	if isWidgetScript(bin, args) {
 		// launching widgets, so we'll use a different tty and script name
 		// to avoid the active script check (widgets handle this)
 		log.Debug().Msg("widget launched, changing params")

--- a/pkg/platforms/mister/startup/startup.go
+++ b/pkg/platforms/mister/startup/startup.go
@@ -31,9 +31,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 )
 
-// TODO: delete entry from startup
-// TODO: enable/disable entry in startup
-
 type Startup struct {
 	Entries []Entry
 }

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -45,7 +45,7 @@ type platformWithArcadeCache interface {
 type NameMapping struct {
 	CoreName   string
 	System     string
-	Name       string // TODO: use names.txt
+	Name       string
 	ArcadeName string
 }
 

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -293,7 +293,7 @@ func (p *Platform) ActiveGamePath() string {
 
 func (p *Platform) LaunchSystem(cfg *config.Instance, id string) error {
 	// Handle menu specially - launch menu core directly
-	if strings.EqualFold(id, "menu") {
+	if strings.EqualFold(id, platforms.SystemMenu) {
 		if err := LaunchMenu(); err != nil {
 			return fmt.Errorf("failed to launch menu: %w", err)
 		}

--- a/pkg/platforms/mistex/platform_test.go
+++ b/pkg/platforms/mistex/platform_test.go
@@ -24,9 +24,19 @@ package mistex
 import (
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLaunchSystem_MenuUsesLaunchMenu(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	err := platform.LaunchSystem(&config.Instance{}, "Menu")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to launch menu")
+}
 
 // TestGamepadPress_DisabledReturnsError tests that GamepadPress returns an error
 // when the virtual gamepad is disabled (gpd.Device is nil).

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -95,6 +95,12 @@ const (
 	StopForConsoleReset
 )
 
+// System identifiers for platform-level targets.
+const (
+	// SystemMenu identifies the platform's main menu/frontend target.
+	SystemMenu = "menu"
+)
+
 // Running instance identifiers for launchers that communicate with persistent applications.
 // Used in Launcher.UsesRunningInstance to indicate which app instance the launcher targets.
 const (

--- a/pkg/platforms/shared/installer/installer.go
+++ b/pkg/platforms/shared/installer/installer.go
@@ -123,7 +123,6 @@ func findInstallDir(
 	// TODO: this would be better if it could auto-detect the existing preferred
 	//       platform games folder, but there's currently no shared mechanism to
 	//       work out the correct root folder for a platform
-	// TODO: config override to set explicit fallback/default media folder
 
 	localPath := filepath.Clean(filepath.Join(fallbackDir, names.filename))
 

--- a/pkg/readers/acr122pcsc/acr122pcsc.go
+++ b/pkg/readers/acr122pcsc/acr122pcsc.go
@@ -359,8 +359,8 @@ func (r *ACR122PCSC) Close() error {
 	return nil
 }
 
-// TODO: this is a hack workaround to stop some log spam, probably the Detect
-// functions on readers should actually return an error instead of ""
+// PCSC reader listing can fail repeatedly when the service or hardware is absent.
+// Detect returns an empty string for "no reader", so log the first failure only.
 var detectErrorOnce sync.Once
 
 func (r *ACR122PCSC) Detect(connected []string) string {

--- a/pkg/readers/pn532/pn532.go
+++ b/pkg/readers/pn532/pn532.go
@@ -613,9 +613,9 @@ func (*Reader) Detect(connected []string) string {
 	// Track which enumerated ports were NOT detected as PN532 devices.
 	// Store the device file's ModTime so we can detect device swaps at
 	// the same path (the file is recreated with a new ModTime on replug).
-	// TODO: this re-enumerates serial ports redundantly since DetectAll
-	// already does so internally. Could be eliminated if DetectAll
-	// returned the full list of candidate paths it tried.
+	// DetectAll currently does not expose candidate paths it tried; see
+	// https://github.com/ZaparooProject/go-pn532/issues/94. Until then,
+	// enumerate serial ports here to infer failed probe paths.
 	currentPorts, enumErr := helpers.GetSerialDeviceList()
 	if enumErr == nil {
 		detectedPaths := make(map[string]bool, len(devices))

--- a/pkg/testing/helpers/kodi_server_test.go
+++ b/pkg/testing/helpers/kodi_server_test.go
@@ -21,7 +21,6 @@ package helpers_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -70,8 +69,7 @@ func TestMockKodiServer_HandlesPlayerGetActivePlayersRequest(t *testing.T) {
 	require.NoError(t, err)
 
 	// Make actual HTTP POST request to the server
-	// TODO: Accept context from parent test for better test control and timeout handling
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewBuffer(jsonData))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -111,9 +109,8 @@ func TestMockKodiServer_WithActivePlayers(t *testing.T) {
 	jsonData, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	// TODO: Accept context from parent test for better test control and timeout handling
 	req, err := http.NewRequestWithContext(
-		context.Background(),
+		t.Context(),
 		http.MethodPost,
 		server.GetURLForConfig(),
 		bytes.NewBuffer(jsonData),

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -263,10 +263,9 @@ func cmdSystem(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 	systemID := env.Cmd.Args[0]
 
-	// For menu, use ReturnToMenu() instead of LaunchSystem
-	// This ensures proper handling across all platforms (stops active launcher and returns to main menu)
-	// TODO: move "menu" to a const somewhere else
-	if strings.EqualFold(systemID, "menu") {
+	// For menu, use ReturnToMenu() instead of LaunchSystem.
+	// This ensures proper handling across all platforms (stops active launcher and returns to main menu).
+	if strings.EqualFold(systemID, platforms.SystemMenu) {
 		if err := pl.ReturnToMenu(); err != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,

--- a/scripts/taptui/taptui.sh
+++ b/scripts/taptui/taptui.sh
@@ -1763,7 +1763,6 @@ _readTag() {
     _yesno "Tag not read" --yes-label "Retry" && _readTag
     return 1
   fi
-  #TODO determin if we need a message here saying the scan was successful
   [[ -n "${currentScan}" ]] && echo "${currentScan}"
 }
 


### PR DESCRIPTION
Summary:
- Clean up stale or misleading TODO comments from the triage pass.
- Add a shared platform menu system constant and use it in menu launch checks.
- Re-enable movie/music slug metadata cases now that parsers exist.
- Replace MiSTer script magic values with named constants.

Verified with:
- go test ./pkg/testing/helpers/ ./pkg/database/mediadb/ ./pkg/platforms/mister/ ./pkg/platforms/batocera/ ./pkg/platforms/mistex/ ./pkg/zapscript/
- golangci-lint run --fix pkg/platforms/mister/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved “Menu” system detection across platforms to be consistent regardless of casing.

* **Improvements**
  * Enhanced Mister script launching by centralizing script settings and correctly setting the run flag for hidden/widget scripts.
  * Added a retry prompt in taptui when tag reading fails.

* **Tests**
  * Re-enabled additional slug-generation test cases and added/updated platform and Kodi test coverage.

* **Documentation / Chores**
  * Refreshed media and reader documentation plus minor cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->