### PR TITLE
feat(systemdefs): add GenesisPlus (MD+) system and enrich MSU aliases

### DIFF
--- a/pkg/assets/systems/GenesisPlus.json
+++ b/pkg/assets/systems/GenesisPlus.json
@@ -1,0 +1,7 @@
+{
+  "id": "GenesisPlus",
+  "name": "Genesis/Mega Drive+",
+  "category": "Console",
+  "releaseDate": "",
+  "manufacturer": "Community"
+}

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -276,6 +276,7 @@ const (
 	SystemGBA2P             = "GBA2P"
 	SystemGenesis           = "Genesis"
 	SystemGenesisMSU        = "GenesisMSU"
+	SystemGenesisPlus       = "GenesisPlus"
 	SystemIntellivision     = "Intellivision"
 	SystemJaguar            = "Jaguar"
 	SystemJaguarCD          = "JaguarCD"
@@ -596,6 +597,11 @@ var Systems = map[string]System{
 		Aliases:   []string{"MegaDriveMSU", "MSU-MD"},
 		Fallbacks: []string{SystemGenesis},
 	},
+	SystemGenesisPlus: {
+		ID:        SystemGenesisPlus,
+		Aliases:   []string{"MDPlus", "MegaDrivePlus"},
+		Fallbacks: []string{SystemGenesis},
+	},
 	SystemIntellivision: {
 		ID:    SystemIntellivision,
 		Slugs: []string{"mattelintellivision", "intv"},
@@ -759,11 +765,12 @@ var Systems = map[string]System{
 	},
 	SystemSNESMSU1: {
 		ID:        SystemSNESMSU1,
-		Aliases:   []string{"MSU1", "MSU-1"},
+		Aliases:   []string{"MSU1", "MSU-1", "SNES-MSU1"},
 		Fallbacks: []string{SystemSNES},
 	},
 	SystemSGBMSU1: {
 		ID:        SystemSGBMSU1,
+		Aliases:   []string{"SGB-MSU1", "SuperGameboyMSU1"},
 		Fallbacks: []string{SystemSuperGameboy},
 	},
 	SystemSNESMusic: {

--- a/pkg/database/systemdefs/systemdefs_test.go
+++ b/pkg/database/systemdefs/systemdefs_test.go
@@ -291,6 +291,14 @@ func TestLookupSystemAliases(t *testing.T) {
 		{"GB alias", "GB", "Gameboy"},
 		{"GBA alias", "GameboyAdvance", "GBA"},
 		{"MAME alias", "MAME", "Arcade"},
+		// MSU/enhanced Genesis aliases
+		{"GenesisPlus by ID", "GenesisPlus", "GenesisPlus"},
+		{"GenesisPlus MDPlus alias", "MDPlus", "GenesisPlus"},
+		{"GenesisPlus MegaDrivePlus alias", "MegaDrivePlus", "GenesisPlus"},
+		// MSU-1 / SGB-MSU1 aliases
+		{"SNESMSU1 SNES-MSU1 alias", "SNES-MSU1", "SNESMSU1"},
+		{"SGBMSU1 SGB-MSU1 alias", "SGB-MSU1", "SGBMSU1"},
+		{"SGBMSU1 SuperGameboyMSU1 alias", "SuperGameboyMSU1", "SGBMSU1"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #979.

Four of the five systems requested in the issue already exist in systemdefs (`SNESMSU1`, `SGBMSU1`, `GenesisMSU`/MSU-MD, `FDS`). This PR adds the missing one and improves discoverability of the existing entries.

## Changes

- Add `SystemGenesisPlus` ("GenesisPlus") for the MD+ format, with aliases `MDPlus`/`MegaDrivePlus` and fallback → Genesis
- Add metadata file `pkg/assets/systems/GenesisPlus.json`
- Add alias `SNES-MSU1` to `SystemSNESMSU1` (hyphenated form)
- Add aliases `SGB-MSU1` and `SuperGameboyMSU1` to `SystemSGBMSU1` (previously had no aliases)
- Add tests covering all new and enriched alias lookups

Note: `"MD+"` typed as a lookup resolves to Genesis (not GenesisPlus) because `+` is stripped during slugification, colliding with Genesis's existing `md` slug. Users should use `MDPlus` or `MegaDrivePlus` to target this system explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Genesis/Mega Drive+ console system as a community-driven variant with multiple naming aliases for improved discovery.
  * Expanded SNES MSU and Super Game Boy MSU enhanced system aliases for enhanced compatibility and recognition.

* **Tests**
  * Extended test coverage for console system alias lookup functionality to verify new variants and system enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->