### PR TITLE
fix(mister): clean AmigaVision display titles and update stale MediaTitle names on reindex

### DIFF
--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -138,6 +138,8 @@ Filesystem fallback searches known subdirectories under `<systemRootPath>/media/
 
 Only `<ROM root>/gamelist.xml` files are loaded. Nested files such as `<ROM root>/Japan/gamelist.xml` are not read by the current scraper.
 
+For systems that index virtual or non-file-backed entries (where the stored media path does not correspond to a real file), `<path>` must match the exact path the indexer stored for that media row.
+
 `gamelist.xml` deliberately does not scrape user-state fields such as favorite, hidden, or kidgame. It also does not overwrite filename-parser-owned fields such as disc and track.
 
 ## ZaparooCompanion Entries

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -827,6 +827,7 @@ type MediaDBI interface {
 	InsertMedia(row Media) (Media, error)
 	FindOrInsertMedia(row Media) (Media, error)
 	UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortName string) error
+	UpdateMediaTitleName(titleDBID int64, name string) error
 	UpdateMediaParentDir(mediaDBID int64, parentDir string) error
 	DeleteMediaTags(mediaDBID int64) error
 	DeleteMediaTag(mediaDBID, tagDBID int64) error

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2464,6 +2464,29 @@ func (db *MediaDB) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortName st
 	return err
 }
 
+func (db *MediaDB) UpdateMediaTitleName(titleDBID int64, name string) error {
+	if db.sql == nil {
+		return ErrNullSQL
+	}
+	if db.batchInsertMediaTitle != nil {
+		if err := db.batchInsertMediaTitle.Flush(); err != nil {
+			return fmt.Errorf("failed to flush media title batch before update: %w", err)
+		}
+	}
+
+	err := sqlUpdateMediaTitleName(db.ctx, db.conn(), titleDBID, name)
+	if err == nil && !db.inTransaction {
+		db.invalidateCaches(invalidationScope{AllSystems: true})
+		if invalidateErr := db.invalidateBrowseCacheForMediaChange(); invalidateErr != nil {
+			return invalidateErr
+		}
+	} else if err == nil {
+		db.markBrowseCacheDirty()
+	}
+
+	return err
+}
+
 func (db *MediaDB) UpdateMediaParentDir(mediaDBID int64, parentDir string) error {
 	if db.sql == nil {
 		return ErrNullSQL

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -4028,3 +4028,80 @@ func TestMediaDB_UpdateMediaTitle_FlushesBufferedTitle_Integration(t *testing.T)
 	assert.Equal(t, mediaPath, found.Path)
 	assert.Equal(t, int64(2), found.MediaTitleDBID)
 }
+
+func TestMediaDB_UpdateMediaTitleName_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Insert a system and a title with the raw AmigaVision listing line as Name.
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: "Amiga", Name: "Amiga"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "1001stolenideas",
+		Name:       "1001 Stolen Ideas (Airwalk)(AGA)",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// UpdateMediaTitleName must update MediaTitles.Name in place.
+	err = mediaDB.UpdateMediaTitleName(title.DBID, "1001 Stolen Ideas")
+	require.NoError(t, err)
+
+	titles, err := mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "1001 Stolen Ideas", titles[0].Name)
+	assert.Equal(t, "1001stolenideas", titles[0].Slug, "slug must not change when name is updated")
+}
+
+func TestMediaDB_UpdateMediaTitleName_FlushesPendingTitleBatch_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Insert the initial title outside a batch transaction.
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: "Amiga", Name: "Amiga"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "1869",
+		Name:       "1869 (AGA)[en]",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Buffer a second title inside an open batch transaction, then call
+	// UpdateMediaTitleName. The method must flush the batch before executing
+	// the UPDATE so the second title is persisted correctly.
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, err = mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: insertedSystem.DBID,
+		Slug:       "3dpool",
+		Name:       "3D Pool (OCS)[en]",
+	})
+	require.NoError(t, err)
+	err = mediaDB.UpdateMediaTitleName(title.DBID, "1869")
+	require.NoError(t, err, "update must flush the buffered title before executing")
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err := mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 2, "buffered title must have been flushed and persisted")
+
+	bySlug := make(map[string]string, len(titles))
+	for _, tt := range titles {
+		bySlug[tt.Slug] = tt.Name
+	}
+	assert.Equal(t, "1869", bySlug["1869"], "name must be updated to the cleaned title")
+	assert.Equal(t, "3D Pool (OCS)[en]", bySlug["3dpool"], "buffered title must be present")
+}

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -195,6 +195,17 @@ func sqlInsertMediaTitle(ctx context.Context, db *sql.DB, row *database.MediaTit
 	return *row, nil
 }
 
+func sqlUpdateMediaTitleName(ctx context.Context, db sqlQueryable, titleDBID int64, name string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE MediaTitles SET Name = ? WHERE DBID = ?`,
+		name, titleDBID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update media title name: %w", err)
+	}
+	return nil
+}
+
 func sqlGetAllMediaTitles(ctx context.Context, db *sql.DB) ([]database.MediaTitle, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT DBID, Slug, Name, SystemDBID, SlugLength, SlugWordCount, SecondarySlug

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -2143,6 +2143,37 @@ func TestSqlUpdateMediaTitle_ExecError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlUpdateMediaTitleName_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE MediaTitles SET Name = \? WHERE DBID = \?`).
+		WithArgs("1001 Stolen Ideas", int64(42)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = sqlUpdateMediaTitleName(context.Background(), db, 42, "1001 Stolen Ideas")
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlUpdateMediaTitleName_ExecError(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec(`UPDATE MediaTitles SET Name = \? WHERE DBID = \?`).
+		WithArgs("1001 Stolen Ideas", int64(42)).
+		WillReturnError(sql.ErrConnDone)
+
+	err = sqlUpdateMediaTitleName(context.Background(), db, 42, "1001 Stolen Ideas")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update media title name")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlGetMediaWithFullPath_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -193,6 +193,14 @@ func AddMediaPathWithPrefixPolicy(
 		}
 	} else {
 		titleIndex = foundTitleIndex
+		if ss.TitleNames != nil {
+			if existingName, ok := ss.TitleNames[titleIndex]; ok && existingName != canonicalTitleName {
+				if err := db.UpdateMediaTitleName(int64(titleIndex), canonicalTitleName); err != nil {
+					return 0, 0, fmt.Errorf("error updating media title name %s: %w", canonicalTitleName, err)
+				}
+				ss.TitleNames[titleIndex] = canonicalTitleName
+			}
+		}
 	}
 
 	mediaKey := database.MediaKey(systemID, pf.Path)

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -1801,3 +1801,91 @@ func TestAddMediaPath_ExistingTitleNameUpdatesOnReindex(t *testing.T) {
 	require.Len(t, titles, 1)
 	assert.Equal(t, "1001 Stolen Ideas", titles[0].Name)
 }
+
+// TestAddMediaPath_ExistingTitleNameUnchangedSkipsUpdate verifies that
+// reindexing a path whose derived title name is identical to the stored name
+// does not issue a redundant UPDATE. This exercises the equal-name branch in
+// AddMediaPathWithPrefixPolicy and documents that reindexing is idempotent.
+func TestAddMediaPath_ExistingTitleNameUnchangedSkipsUpdate(t *testing.T) {
+	t.Parallel()
+
+	const systemID = "Amiga"
+	gamePath := filepath.Join(
+		string(filepath.Separator), "media", "fat", "games", "Amiga", "Games", "1869 (AGA)[en]",
+	)
+
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	// First index: empty ProvidedName so the parser derives "1869".
+	initialState := newIndexingPipelineScanState()
+	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err := AddMediaPath(
+		mediaDB, initialState, systemID, gamePath,
+		"", true, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err := mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "1869", titles[0].Name)
+
+	// Second index: same path, same empty ProvidedName — derived name is still "1869".
+	// The equal-name check must skip UpdateMediaTitleName; the name must be unchanged.
+	reindexState := newIndexingPipelineScanState()
+	require.NoError(t, PopulateScanStateFromDB(context.Background(), mediaDB, reindexState))
+	require.NoError(t, PopulatePersistentScanStateForSystem(context.Background(), mediaDB, reindexState, systemID))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err = AddMediaPath(
+		mediaDB, reindexState, systemID, gamePath,
+		"", true, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err = mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "1869", titles[0].Name)
+}
+
+// TestAddMediaPath_TitleNameUpdateErrorPropagates verifies that a DB error
+// from UpdateMediaTitleName is propagated as a wrapped error. The scan state
+// is pre-seeded with an existing title whose stored name differs from the
+// newly derived name, so the update path is taken immediately.
+func TestAddMediaPath_TitleNameUpdateErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	const systemID = "Amiga"
+	gamePath := filepath.Join(
+		string(filepath.Separator), "media", "fat", "games", "Amiga", "Games", "1869 (AGA)[en]",
+	)
+
+	mockDB := &helpers.MockMediaDBI{}
+
+	// Pre-seed: system and title already exist in scan state.
+	// The stored name "1869 (AGA)[en]" differs from the derived "1869",
+	// so UpdateMediaTitleName will be called.
+	scanState := &database.ScanState{
+		SystemIDs:  map[string]int{systemID: 1},
+		TitleIDs:   map[string]int{database.TitleKey(systemID, "1869"): 5},
+		TitleNames: map[int]string{5: "1869 (AGA)[en]"},
+		MediaIDs:   make(map[string]int),
+		TagIDs:     make(map[string]int),
+		TagTypeIDs: make(map[string]int),
+	}
+
+	mockDB.On("UpdateMediaTitleName", int64(5), "1869").Return(assert.AnError).Once()
+
+	_, _, err := AddMediaPath(
+		mockDB, scanState, systemID, gamePath,
+		"", true, false, nil, slugs.MediaTypeGame,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error updating media title name")
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -1749,3 +1749,55 @@ func TestPopulateScanStateForSystem_TracksEmptySortNameInNeedsSortNameMap(t *tes
 	assert.Contains(t, ss.MediaNeedsSortName, populatedID,
 		"media with empty SortName must appear in MediaNeedsSortName")
 }
+
+// TestAddMediaPath_ExistingTitleNameUpdatesOnReindex verifies that when the
+// derived title name changes between index runs (e.g. after scanner starts
+// emitting empty ProvidedName so filename parsing cleans the title),
+// MediaTitles.Name is updated to the new cleaned name on the next reindex.
+// This covers the AmigaVision case: "1001 Stolen Ideas (Airwalk)(AGA)" →
+// "1001 Stolen Ideas" after ProvidedName is cleared in scanAmigaVisionListingFile.
+func TestAddMediaPath_ExistingTitleNameUpdatesOnReindex(t *testing.T) {
+	t.Parallel()
+
+	const systemID = "Amiga"
+	gamePath := filepath.Join(
+		string(filepath.Separator), "media", "fat", "games", "Amiga", "Demos", "1001 Stolen Ideas (Airwalk)(AGA)",
+	)
+
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	// First index: scanner provided the raw listing line as the name.
+	initialState := newIndexingPipelineScanState()
+	require.NoError(t, SeedCanonicalTags(mediaDB, initialState))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err := AddMediaPath(
+		mediaDB, initialState, systemID, gamePath,
+		"1001 Stolen Ideas (Airwalk)(AGA)", true, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err := mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "1001 Stolen Ideas (Airwalk)(AGA)", titles[0].Name)
+
+	// Second index: scanner now emits empty ProvidedName so the filename
+	// parser derives the cleaned title "1001 Stolen Ideas".
+	reindexState := newIndexingPipelineScanState()
+	require.NoError(t, PopulateScanStateFromDB(context.Background(), mediaDB, reindexState))
+	require.NoError(t, PopulatePersistentScanStateForSystem(context.Background(), mediaDB, reindexState, systemID))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, _, err = AddMediaPath(
+		mediaDB, reindexState, systemID, gamePath,
+		"", true, false, nil, slugs.MediaTypeGame,
+	)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	titles, err = mediaDB.GetAllMediaTitles()
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	assert.Equal(t, "1001 Stolen Ideas", titles[0].Name)
+}

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -2624,6 +2624,59 @@ func BenchmarkDetectNumberingPattern(b *testing.B) {
 	}
 }
 
+// TestParseTitleFromFilename_AmigaVision verifies that titles derived from
+// AmigaVision listing lines (the path basename) are cleaned correctly. The scanner
+// leaves ScanResult.Name empty so the indexer derives the title from the path,
+// which means the raw listing line — e.g. "1869 (AGA)[en]" — arrives as the
+// filename argument here.
+func TestParseTitleFromFilename_AmigaVision(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		filename  string
+		wantTitle string
+	}{
+		{
+			name:      "game with AGA chipset and single language",
+			filename:  "1869 (AGA)[en]",
+			wantTitle: "1869",
+		},
+		{
+			name:      "game with OCS chipset and single language",
+			filename:  "3D Pool (OCS)[en]",
+			wantTitle: "3D Pool",
+		},
+		{
+			name:      "game with OCS chipset and multi-language bracket",
+			filename:  "7 Colors (OCS)[en-de-fr-it-es]",
+			wantTitle: "7 Colors",
+		},
+		{
+			name:      "demo with group paren and AGA chipset",
+			filename:  "1001 Stolen Ideas (Airwalk)(AGA)",
+			wantTitle: "1001 Stolen Ideas",
+		},
+		{
+			name:      "demo with group paren and OCS chipset",
+			filename:  "9 Fingers (Spaceballs)(OCS)",
+			wantTitle: "9 Fingers",
+		},
+		{
+			name:      "game title with leading number preserved",
+			filename:  "1869 (OCS)[en]",
+			wantTitle: "1869",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantTitle, ParseTitleFromFilename(tt.filename, false))
+		})
+	}
+}
+
 func BenchmarkFilenameParser_ExtractSpecialPatterns(b *testing.B) {
 	filename := "Game Title (Disc 1 of 3) (Rev A) (v1.2) (1998) S02E05.zip"
 	b.ReportAllocs()

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -490,6 +490,7 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		// Nintendo
 		TagArcadeBoardNintendoVS, TagArcadeBoardNintendoNSS,
 	},
+
 	TagTypeCompatibility: {
 		// SEGA systems
 		TagCompatibilitySG1000, TagCompatibilitySG1000SC3000, TagCompatibilitySG1000Othello,

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -222,7 +222,7 @@ func TestAmigaScanner_IgnoresStaleListingRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	assert.Equal(t, filepath.Join(validPath, "Games", "Valid Game"), results[0].Path)
-	assert.Equal(t, "Valid Game", results[0].Name)
+	assert.Empty(t, results[0].Name)
 }
 
 func TestAmigaScanner_AddsGamesAndDemosSubfolders(t *testing.T) {
@@ -247,12 +247,10 @@ func TestAmigaScanner_AddsGamesAndDemosSubfolders(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, results, platforms.ScanResult{
 		Path:  filepath.Join(validPath, "Games", "Valid Game"),
-		Name:  "Valid Game",
 		NoExt: true,
 	})
 	assert.Contains(t, results, platforms.ScanResult{
 		Path:  filepath.Join(validPath, "Demos", "Valid Demo"),
-		Name:  "Valid Demo",
 		NoExt: true,
 	})
 }
@@ -280,7 +278,49 @@ func TestAmigaScanner_FiltersListingFiles(t *testing.T) {
 	assert.NotContains(t, results, platforms.ScanResult{Path: filepath.Join(validPath, "listings", "games.txt")})
 	assert.Contains(t, results, platforms.ScanResult{
 		Path:  filepath.Join(validPath, "Games", "Valid Game"),
-		Name:  "Valid Game",
+		NoExt: true,
+	})
+}
+
+func TestAmigaScanner_LeavesNameEmptyForIndexerTitleCleaning(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	validPath := filepath.Join(root, "games", "Amiga")
+
+	listingPath := filepath.Join(validPath, "listings")
+	require.NoError(t, os.MkdirAll(listingPath, 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(validPath, "shared"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(validPath, "AmigaVision.hdf"), []byte("test"), 0o600))
+	gamesContent := "1869 (AGA)[en]\n3D Pool (OCS)[en]\n7 Colors (OCS)[en-de-fr-it-es]\n"
+	demosContent := "1001 Stolen Ideas (Airwalk)(AGA)\n9 Fingers (Spaceballs)(OCS)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(listingPath, "games.txt"), []byte(gamesContent), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(listingPath, "demos.txt"), []byte(demosContent), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{filepath.Join(root, "games")},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(cfg))
+
+	results, err := amigaLauncher.Scanner(context.Background(), cfg, "Amiga", nil)
+	require.NoError(t, err)
+
+	for _, r := range results {
+		assert.Empty(t, r.Name, "ScanResult.Name must be empty so the indexer derives a cleaned title from the path")
+	}
+
+	// Paths still carry the raw listing line so launch validation can match exactly.
+	assert.Contains(t, results, platforms.ScanResult{
+		Path:  filepath.Join(validPath, "Games", "1869 (AGA)[en]"),
+		NoExt: true,
+	})
+	assert.Contains(t, results, platforms.ScanResult{
+		Path:  filepath.Join(validPath, "Demos", "1001 Stolen Ideas (Airwalk)(AGA)"),
 		NoExt: true,
 	})
 }

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1143,7 +1143,6 @@ func scanAmigaVisionListingFile(path, installPath string, listing amigaVisionLis
 		}
 		results = append(results, platforms.ScanResult{
 			Path:  filepath.Join(installPath, listing.BrowseDir, name),
-			Name:  name,
 			NoExt: true,
 		})
 	}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1089,6 +1089,15 @@ func (m *MockMediaDBI) UpdateMediaTitle(mediaDBID, mediaTitleDBID int64, sortNam
 	return nil
 }
 
+func (m *MockMediaDBI) UpdateMediaTitleName(titleDBID int64, name string) error {
+	m.trackDatabaseOperation()
+	args := m.Called(titleDBID, name)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) UpdateMediaParentDir(mediaDBID int64, parentDir string) error {
 	m.trackDatabaseOperation() // Track if called outside transaction
 	args := m.Called(mediaDBID, parentDir)
@@ -2191,6 +2200,7 @@ func NewMockMediaDBI() *MockMediaDBI {
 	mockMediaDB.On("BulkSetMediaMissing", mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("ResetMissingFlags", mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("UpdateMediaTitle", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockMediaDB.On("UpdateMediaTitleName", mock.Anything, mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("DeleteMediaTags", mock.Anything).Return(nil).Maybe()
 	// Disambiguation refresh runs per system at the end of indexing.
 	mockMediaDB.On("RecomputeSystemDisambiguation", mock.Anything, mock.Anything).Return(nil).Maybe()


### PR DESCRIPTION
## Summary

- AmigaVision `ScanResult.Name` is now left empty so the filename parser derives cleaned display titles from the path basename — `1869 (AGA)[en]` → `1869`, `1001 Stolen Ideas (Airwalk)(AGA)` → `1001 Stolen Ideas`. Paths stay raw so launch validation's exact-line matching is unaffected.
- When reindexing finds an existing title by slug, `AddMediaPathWithPrefixPolicy` now compares the stored `MediaTitles.Name` against the freshly derived name and updates it if they differ. This fixes stale names on existing databases without requiring a DB wipe.
- Chipset tokens (`AGA`, `OCS`, `ECS`, `CD32`, `CDTV`) and language brackets already mapped correctly to `TagTypeCompatibility` — no new tag type added.
- Added a `gamelist.xml` scraper note explaining that virtual/non-file-backed media paths must match what the indexer stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media titles are now automatically reconciled during reindexing when the derived display title changes, updating the stored title name as needed.
  * Ensures title rename operations succeed even when new titles are queued in the same batch.
* **Documentation**
  * Clarified that, for virtual or non-file-backed entries, the `<game><path>` value must match the exact indexed path stored.
* **Tests**
  * Added regression and integration coverage for title-name updates, no-op behavior when unchanged, and error propagation.
  * Updated AmigaVision/Amiga scanner expectations and added tests for standardized title cleaning and empty scan-result names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->