### PR TITLE
fix(mister): resolve Sinden launchers to the correct core

### DIFF
--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -46,7 +46,7 @@ import (
 type RBFCache struct {
 	bySystemID    map[string]RBFInfo
 	byShortName   map[string][]RBFInfo
-	byLauncherID  map[string]string
+	byLauncherID  map[string][]string
 	lastDirMtimes map[string]int64
 	persistPath   string
 	lastRootRBFs  []string
@@ -386,31 +386,40 @@ func isHexish(s string) bool {
 	return true
 }
 
-// RegisterAltCore registers an alt core's expected RBF path.
-// Called during launcher creation.
-func (c *RBFCache) RegisterAltCore(launcherID, rbfPath string) {
+// RegisterAltCore registers an alt core's expected RBF path(s).
+// Called during launcher creation. When multiple paths are given, they are
+// tried in order at resolution time and the first that matches a scanned RBF
+// wins, allowing a launcher to support more than one core location/naming
+// convention (e.g. Sinden cores in "Light Gun/" or legacy "_Sinden/").
+func (c *RBFCache) RegisterAltCore(launcherID string, rbfPaths ...string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.byLauncherID == nil {
-		c.byLauncherID = make(map[string]string)
+		c.byLauncherID = make(map[string][]string)
 	}
-	c.byLauncherID[launcherID] = rbfPath
+	c.byLauncherID[launcherID] = rbfPaths
 }
 
 // GetByLauncherID returns the resolved RBF path for an alt core launcher.
-// When the registered path includes a directory, the match is strict: a
-// directory mismatch returns (RBFInfo{}, false) rather than silently falling
-// back to a different directory's core.
+// Registered paths are tried in order; the first that resolves wins. When a
+// registered path includes a directory, the match is strict: a directory
+// mismatch is skipped rather than silently falling back to a different
+// directory's core.
 func (c *RBFCache) GetByLauncherID(launcherID string) (RBFInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	rbfPath, ok := c.byLauncherID[launcherID]
+	rbfPaths, ok := c.byLauncherID[launcherID]
 	if !ok {
 		return RBFInfo{}, false
 	}
 
-	return c.getByMglPathLocked(rbfPath)
+	for _, rbfPath := range rbfPaths {
+		if rbfInfo, found := c.getByMglPathLocked(rbfPath); found {
+			return rbfInfo, true
+		}
+	}
+	return RBFInfo{}, false
 }
 
 func (c *RBFCache) relatedCandidates(rbfPath string) []string {

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -173,11 +173,11 @@ func TestRegisterAltCore(t *testing.T) {
 
 	// Verify it was stored
 	cache.mu.RLock()
-	rbfPath, ok := cache.byLauncherID["2XPSX"]
+	rbfPaths, ok := cache.byLauncherID["2XPSX"]
 	cache.mu.RUnlock()
 
 	assert.True(t, ok, "launcher ID should be found")
-	assert.Equal(t, "_Other/PSX2XCPU", rbfPath)
+	assert.Equal(t, []string{"_Other/PSX2XCPU"}, rbfPaths)
 }
 
 func TestRegisterAltCore_MultipleRegistrations(t *testing.T) {
@@ -192,9 +192,9 @@ func TestRegisterAltCore_MultipleRegistrations(t *testing.T) {
 
 	cache.mu.RLock()
 	assert.Len(t, cache.byLauncherID, 3, "should have 3 registered launchers")
-	assert.Equal(t, "_Other/PSX2XCPU", cache.byLauncherID["2XPSX"])
-	assert.Equal(t, "_ConsolePWM/PSX_PWM", cache.byLauncherID["PWMPSX"])
-	assert.Equal(t, "_LLAPI/PSX_LLAPI", cache.byLauncherID["LLAPIPSX"])
+	assert.Equal(t, []string{"_Other/PSX2XCPU"}, cache.byLauncherID["2XPSX"])
+	assert.Equal(t, []string{"_ConsolePWM/PSX_PWM"}, cache.byLauncherID["PWMPSX"])
+	assert.Equal(t, []string{"_LLAPI/PSX_LLAPI"}, cache.byLauncherID["LLAPIPSX"])
 	cache.mu.RUnlock()
 }
 
@@ -268,6 +268,56 @@ func TestGetByLauncherID_ExtractsShortNameFromPath(t *testing.T) {
 	rbf, found := cache.GetByLauncherID("80MHzNintendo64")
 	assert.True(t, found, "should find RBF by extracted short name")
 	assert.Equal(t, "_Other/N64_80MHz", rbf.MglName)
+}
+
+// TestGetByLauncherID_MultipleCandidatesPrefersFirst verifies that when an alt
+// core registers more than one candidate path (e.g. Sinden cores in the modern
+// "Light Gun/" folder or the legacy "_Sinden/" folder), the first candidate
+// that resolves wins when both are installed.
+func TestGetByLauncherID_MultipleCandidatesPrefersFirst(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/Light Gun/NES-Sinden.rbf", ShortName: "NES-Sinden", MglName: "Light Gun/NES-Sinden"},
+		{Path: "/media/fat/_Sinden/NES_Sinden.rbf", ShortName: "NES_Sinden", MglName: "_Sinden/NES_Sinden"},
+	})
+	cache.RegisterAltCore("SindenNES", "Light Gun/NES-Sinden", "_Sinden/NES_Sinden")
+
+	rbf, found := cache.GetByLauncherID("SindenNES")
+	assert.True(t, found, "registered launcher should be found")
+	assert.Equal(t, "Light Gun/NES-Sinden", rbf.MglName, "should prefer the modern Light Gun path")
+}
+
+// TestGetByLauncherID_MultipleCandidatesFallsBack verifies that resolution falls
+// through to a later candidate when the preferred one is not installed.
+func TestGetByLauncherID_MultipleCandidatesFallsBack(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Sinden/NES_Sinden.rbf", ShortName: "NES_Sinden", MglName: "_Sinden/NES_Sinden"},
+	})
+	cache.RegisterAltCore("SindenNES", "Light Gun/NES-Sinden", "_Sinden/NES_Sinden")
+
+	rbf, found := cache.GetByLauncherID("SindenNES")
+	assert.True(t, found, "should fall back to the legacy candidate")
+	assert.Equal(t, "_Sinden/NES_Sinden", rbf.MglName)
+}
+
+// TestGetByLauncherID_MultipleCandidatesNoneInstalled verifies that no candidate
+// resolving returns not-found (Resolve then falls back to the base system core).
+func TestGetByLauncherID_MultipleCandidatesNoneInstalled(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/NES_20240101.rbf", ShortName: "NES", MglName: "_Console/NES"},
+	})
+	cache.RegisterAltCore("SindenNES", "Light Gun/NES-Sinden", "_Sinden/NES_Sinden")
+
+	_, found := cache.GetByLauncherID("SindenNES")
+	assert.False(t, found, "no Sinden candidate installed should not resolve")
 }
 
 // TestRegression_Issue477_AltCoreUsesWrongRBFPath is a regression test for GitHub issue #477.

--- a/pkg/platforms/mister/cores/rbfs.go
+++ b/pkg/platforms/mister/cores/rbfs.go
@@ -122,7 +122,9 @@ func shallowScanRBFAt(root string) ([]RBFInfo, error) {
 	}
 
 	for _, file := range files {
-		if file.IsDir() && strings.HasPrefix(file.Name(), "_") {
+		// Scan "_"-prefixed core menu folders plus the "Light Gun" folder
+		// used by modern MiSTer Sinden cores (which has no "_" prefix).
+		if file.IsDir() && (strings.HasPrefix(file.Name(), "_") || strings.EqualFold(file.Name(), "Light Gun")) {
 			subFiles, subErr := os.ReadDir(filepath.Join(root, file.Name()))
 			if subErr != nil {
 				continue

--- a/pkg/platforms/mister/cores/rbfs_test.go
+++ b/pkg/platforms/mister/cores/rbfs_test.go
@@ -115,3 +115,28 @@ func TestShallowScanRBF_IncludesRetroAchievementsCores(t *testing.T) {
 	assert.Equal(t, "NES", found.ShortName)
 	assert.Equal(t, "NES.rbf", found.Filename)
 }
+
+func TestShallowScanRBF_IncludesLightGunSindenCores(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	lightGunDir := filepath.Join(root, "Light Gun")
+	require.NoError(t, os.MkdirAll(lightGunDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(lightGunDir, "NES-Sinden.rbf"), []byte{}, 0o600))
+
+	rbfs, err := shallowScanRBFAt(root)
+	require.NoError(t, err)
+
+	expectedMglName := filepath.Join("Light Gun", "NES-Sinden")
+	var found *RBFInfo
+	for i := range rbfs {
+		if rbfs[i].MglName == expectedMglName {
+			found = &rbfs[i]
+			break
+		}
+	}
+
+	require.NotNil(t, found, "Light Gun Sinden core should be included in shallow RBF scan")
+	assert.Equal(t, "NES-Sinden", found.ShortName)
+	assert.Equal(t, "NES-Sinden.rbf", found.Filename)
+}

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -226,9 +226,18 @@ func launchArcade(
 }
 
 func launchSinden(
+	launcherID string,
 	systemID string,
 	rbfName string,
 ) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
+	// Modern setups (update_all / MrLightgun) deploy Sinden cores to
+	// "Light Gun/<Core>-Sinden", older ones to "_Sinden/<Core>_Sinden".
+	// Register both; the modern path is preferred when present.
+	newRBF := "Light Gun/" + rbfName + "-Sinden"
+	oldRBF := "_Sinden/" + rbfName + "_Sinden"
+	setName := rbfName + "_Sinden"
+	cores.GlobalRBFCache.RegisterAltCore(launcherID, newRBF, oldRBF)
+
 	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		s, err := cores.GetCore(systemID)
 		if err != nil {
@@ -237,28 +246,13 @@ func launchSinden(
 		path = checkInZip(path)
 
 		sn := *s
-
-		newRBF := "Light Gun/" + rbfName + "-Sinden"
-		oldRBF := "_Sinden/" + rbfName + "_Sinden"
-
-		newMatches, err := filepath.Glob(filepath.Join(misterconfig.SDRootDir, newRBF) + "*")
-		if err != nil {
-			log.Debug().Err(err).Msg("error checking for new Sinden RBF")
-		}
-		if len(newMatches) > 0 {
-			sn.RBF = newRBF
-		} else {
-			// just fallback on trying the old path
-			sn.RBF = oldRBF
-		}
-
-		sn.SetName = rbfName + "_Sinden"
-		sn.SetNameSameDir = true
-		if setNameErr := applySetNameOptions(&sn, opts); setNameErr != nil {
+		if setNameErr := configureAltCoreWithDefaultSetName(
+			&sn, launcherID, newRBF, setName, true, opts,
+		); setNameErr != nil {
 			return nil, setNameErr
 		}
 
-		log.Debug().Str("rbf", sn.RBF).Msgf("launching Sinden: %v", sn)
+		log.Debug().Str("rbf", sn.RBF).Str("launcher", launcherID).Msgf("launching Sinden: %v", sn)
 
 		err = mgls.LaunchGame(cfg, &sn, path)
 		if err != nil {
@@ -1261,12 +1255,12 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenGenesis",
 			SystemID: systemdefs.SystemGenesis,
-			Launch:   launchSinden(systemdefs.SystemGenesis, "Genesis"),
+			Launch:   launchSinden("SindenGenesis", systemdefs.SystemGenesis, "Genesis"),
 		},
 		{
 			ID:       "SindenMegaDrive",
 			SystemID: systemdefs.SystemGenesis,
-			Launch:   launchSinden(systemdefs.SystemGenesis, "MegaDrive"),
+			Launch:   launchSinden("SindenMegaDrive", systemdefs.SystemGenesis, "MegaDrive"),
 		},
 		{
 			ID:       "LLAPIMegaDrive",
@@ -1326,7 +1320,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenSMS",
 			SystemID: systemdefs.SystemMasterSystem,
-			Launch:   launchSinden(systemdefs.SystemMasterSystem, "SMS"),
+			Launch:   launchSinden("SindenSMS", systemdefs.SystemMasterSystem, "SMS"),
 		},
 		{
 			ID:       "LLAPISMS",
@@ -1355,7 +1349,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenMegaCD",
 			SystemID: systemdefs.SystemMegaCD,
-			Launch:   launchSinden(systemdefs.SystemMegaCD, "MegaCD"),
+			Launch:   launchSinden("SindenMegaCD", systemdefs.SystemMegaCD, "MegaCD"),
 		},
 		{
 			ID:       "LLAPIMegaCD",
@@ -1434,7 +1428,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenNES",
 			SystemID: systemdefs.SystemNES,
-			Launch:   launchSinden(systemdefs.SystemNES, "NES"),
+			Launch:   launchSinden("SindenNES", systemdefs.SystemNES, "NES"),
 		},
 		{
 			ID:         systemdefs.SystemNESMusic,
@@ -1540,7 +1534,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenPSX",
 			SystemID: systemdefs.SystemPSX,
-			Launch:   launchSinden(systemdefs.SystemPSX, "PSX"),
+			Launch:   launchSinden("SindenPSX", systemdefs.SystemPSX, "PSX"),
 		},
 		{
 			ID:       "2XPSX",
@@ -1696,7 +1690,7 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		{
 			ID:       "SindenSNES",
 			SystemID: systemdefs.SystemSNES,
-			Launch:   launchSinden(systemdefs.SystemSNES, "SNES"),
+			Launch:   launchSinden("SindenSNES", systemdefs.SystemSNES, "SNES"),
 		},
 		{
 			ID:         systemdefs.SystemSNESMusic,


### PR DESCRIPTION
- The Sinden RBF-loading path was dead for every system: `launchSinden` set `core.RBF`, but MGL resolution reads the RBF cache by `LauncherID` and falls back to the base system core when none is registered, so `SindenNES` and friends launched the plain base core instead of the lightgun core.
- Scan the `Light Gun/` folder in `shallowScanRBFAt` so modern Sinden cores (`Light Gun/<Core>-Sinden.rbf`, deployed by update_all/MrLightgun) are indexed; previously only `_`-prefixed folders were scanned.
- Support multiple ordered candidate paths per alt core in the RBF cache, with `GetByLauncherID` returning the first that resolves.
- Register Sinden launchers via the alt-core mechanism with both the modern `Light Gun/<Core>-Sinden` and legacy `_Sinden/<Core>_Sinden` paths and set `LauncherID` so resolution finds them, preferring the modern path.

Closes #991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Light Gun cores are now detected and scanned from the dedicated Light Gun folder.
  * Core resolution now supports multiple registered paths per launcher, allowing fallback to alternative cores.

* **Tests**
  * Added comprehensive tests for multi-candidate core resolution scenarios.
  * Added test coverage for Light Gun core detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->