### PR TITLE
feat(scraper): resolve ES media-folder artwork across roots

### DIFF
--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -54,7 +54,7 @@ import (
 // root path and the DB identifiers of the matched MediaTitle and one of its
 // Media rows (used as the sentinel write target).
 type GamelistRecord struct {
-	AvailableMediaDirs  map[string]string
+	MediaDirsByRoot     []map[string]string
 	SystemRootPath      string
 	MatchKind           gamelistMatchKind
 	Game                esapi.Game
@@ -304,10 +304,9 @@ func resolveSystemsFromPlatform(
 }
 
 type parsedGamelistFile struct {
-	RootPath           string
-	GamelistPath       string
-	AvailableMediaDirs map[string]string
-	Games              []esapi.Game
+	RootPath     string
+	GamelistPath string
+	Games        []esapi.Game
 }
 
 type parsedGamelistSystem struct {
@@ -343,10 +342,9 @@ func (g *GamelistXMLScraper) loadParsedGamelistSystem(
 			Int("entries", len(gl.Games)).
 			Msg("gamelistxml: loaded gamelist.xml")
 		parsed.Files = append(parsed.Files, parsedGamelistFile{
-			RootPath:           rootPath,
-			GamelistPath:       gamelistPath,
-			AvailableMediaDirs: statMediaDirsFS(g.filesystem(), rootPath),
-			Games:              gl.Games,
+			RootPath:     rootPath,
+			GamelistPath: gamelistPath,
+			Games:        gl.Games,
 		})
 	}
 	return parsed, nil
@@ -375,6 +373,7 @@ func (g *GamelistXMLScraper) loadRecordsFromParsed(
 	parsed parsedGamelistSystem,
 ) ([]*GamelistRecord, error) {
 	var records []*GamelistRecord
+	mediaDirsByRoot := g.orderedMediaDirsForSystem(system)
 	candidateMedia := len(indexes.MediaByPathFold)
 	candidateTitles := len(indexes.TitlesBySlug)
 	var gamelistFiles, gamelistEntries, companionEntriesSkipped, invalidPaths int
@@ -422,7 +421,7 @@ outer:
 					slugPathSelections++
 					records = append(records, &GamelistRecord{
 						SystemRootPath:      file.RootPath,
-						AvailableMediaDirs:  file.AvailableMediaDirs,
+						MediaDirsByRoot:     mediaDirsByRoot,
 						Game:                *game,
 						MatchKind:           gamelistMatchSlugPath,
 						MatchedTitleDBID:    title.DBID,
@@ -457,7 +456,7 @@ outer:
 				}
 				records = append(records, &GamelistRecord{
 					SystemRootPath:      file.RootPath,
-					AvailableMediaDirs:  file.AvailableMediaDirs,
+					MediaDirsByRoot:     mediaDirsByRoot,
 					Game:                *game,
 					MatchKind:           selection.matchKind,
 					MatchedTitleDBID:    title.DBID,
@@ -478,7 +477,7 @@ outer:
 					Msg("gamelistxml: path-only fallback matched record")
 				records = append(records, &GamelistRecord{
 					SystemRootPath:      file.RootPath,
-					AvailableMediaDirs:  file.AvailableMediaDirs,
+					MediaDirsByRoot:     mediaDirsByRoot,
 					Game:                *game,
 					MatchKind:           gamelistMatchPathOnly,
 					MatchedTitleDBID:    pathMedia.MediaTitleDBID,
@@ -1087,9 +1086,9 @@ func (g *GamelistXMLScraper) MapToDB(record *GamelistRecord) scraper.MapResult {
 		key := propType + ":" + string(propValue)
 		p := pathProp(key, xmlPath, root, g.externalAssetRoots)
 		if p == nil {
-			p = findMediaFilePropFS(
+			p = findMediaFilePropAcrossRootsFS(
 				g.filesystem(), key, fallbackNames,
-				esmedia.ArtworkDirCandidates[string(propValue)], record.AvailableMediaDirs,
+				esmedia.ArtworkDirCandidates[string(propValue)], record.MediaDirsByRoot,
 			)
 		}
 		if p != nil {
@@ -1298,6 +1297,18 @@ func statMediaDirsFS(fs afero.Fs, rootPath string) map[string]string {
 	return esmedia.StatMediaDirsFS(fs, rootPath)
 }
 
+// orderedMediaDirsForSystem returns the media/ subdirectories of every ROM root
+// for the system, in RootDirs order (system.ROMPaths order). The filesystem
+// fallback searches these in order so artwork can live on a different root than
+// the rom; the first root with a match wins.
+func (g *GamelistXMLScraper) orderedMediaDirsForSystem(system scraper.ScrapeSystem) []map[string]string {
+	dirs := make([]map[string]string, 0, len(system.ROMPaths))
+	for _, root := range system.ROMPaths {
+		dirs = append(dirs, statMediaDirsFS(g.filesystem(), root))
+	}
+	return dirs
+}
+
 // findMediaFileProp searches for <stem>.png inside the first candidate
 // directory (from candidates) that appears in availableDirs. Returns a
 // MediaProperty for the file when found, nil otherwise.
@@ -1328,6 +1339,27 @@ func findMediaFilePropFS(
 	availableDirs map[string]string,
 ) *database.MediaProperty {
 	file := esmedia.FindFileFS(fs, fallbackNames, candidates, availableDirs)
+	if file == nil {
+		return nil
+	}
+	return &database.MediaProperty{
+		TypeTag:     typeTag,
+		Text:        file.Path,
+		ContentType: file.ContentType,
+	}
+}
+
+// findMediaFilePropAcrossRootsFS searches each root's media directories in
+// RootDirs order and returns a property for the first match. This lets artwork
+// live on a different root than the rom.
+func findMediaFilePropAcrossRootsFS(
+	fs afero.Fs,
+	typeTag string,
+	fallbackNames []string,
+	candidates []string,
+	mediaDirsByRoot []map[string]string,
+) *database.MediaProperty {
+	file := esmedia.FindFileAcrossRootsFS(fs, fallbackNames, candidates, mediaDirsByRoot)
 	if file == nil {
 		return nil
 	}
@@ -1625,10 +1657,9 @@ func isCompanionGame(game *esapi.Game) bool {
 // Parent records carry full metadata but no ROM path; they represent the canonical game
 // title shared by multiple regional ROM releases.
 type companionParent struct {
-	AvailableMediaDirs map[string]string
-	SystemRootPath     string
-	GameID             string
-	Game               esapi.Game
+	SystemRootPath string
+	GameID         string
+	Game           esapi.Game
 }
 
 // companionChild holds a ZaparooCompanion ROM child record parsed from a gamelist.xml.
@@ -1683,10 +1714,9 @@ func companionEntriesFromParsed(
 			switch {
 			case game.ScreenScraperIDAttr != "" && game.Path == "":
 				parents = append(parents, companionParent{
-					Game:               game,
-					SystemRootPath:     file.RootPath,
-					AvailableMediaDirs: file.AvailableMediaDirs,
-					GameID:             game.ScreenScraperIDAttr,
+					Game:           game,
+					SystemRootPath: file.RootPath,
+					GameID:         game.ScreenScraperIDAttr,
 				})
 			case game.ParentIDAttr != "" && game.Path != "":
 				resolved := esmedia.ResolvePath(game.Path, file.RootPath)
@@ -1717,13 +1747,13 @@ func companionEntriesFromParsed(
 }
 
 // mapCompanionParentToResult builds the tag and property writes for a companion parent
-// record. MapToDB is safe with an empty Game.Path; the stem becomes "." which is
-// rejected by findMediaFilePropFS, so filesystem fallbacks are skipped cleanly.
+// record. Parent records carry no ROM path, so the filesystem artwork fallback is
+// skipped cleanly (the stem becomes "." and no fallback names are produced); media
+// dirs are therefore not needed here.
 func (g *GamelistXMLScraper) mapCompanionParentToResult(p *companionParent) scraper.MapResult {
 	result := g.MapToDB(&GamelistRecord{
-		SystemRootPath:     p.SystemRootPath,
-		AvailableMediaDirs: p.AvailableMediaDirs,
-		Game:               p.Game,
+		SystemRootPath: p.SystemRootPath,
+		Game:           p.Game,
 	})
 	result.TitleProps = append(result.TitleProps, result.MediaProps...)
 	result.MediaProps = nil

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -337,7 +337,7 @@ func TestLoadRecords_PathMatch(t *testing.T) {
 	assert.Equal(t, "Mario", records[0].Game.Name)
 	assert.Equal(t, int64(11), records[0].MatchedMediaDBID)
 	assert.Equal(t, int64(22), records[0].MatchedTitleDBID)
-	assert.Equal(t, filepath.Join(root, "media", "image"), records[0].AvailableMediaDirs["image"])
+	assert.Equal(t, filepath.Join(root, "media", "image"), records[0].MediaDirsByRoot[0]["image"])
 }
 
 func TestLoadRecords_SubfolderPathMatch(t *testing.T) {
@@ -1472,8 +1472,8 @@ func TestMapToDB_FilesystemFallback_Image(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(imgDir, "mario.png"), []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"image": imgDir},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"image": imgDir}},
 		Game: esapi.Game{
 			Path:  "./roms/mario.nes",
 			Image: "", // no XML path → filesystem fallback
@@ -1504,8 +1504,8 @@ func TestMapToDB_FilesystemFallback_NestedGamePath(t *testing.T) {
 	require.NoError(t, os.WriteFile(imgPath, []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"images": imgDir},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"images": imgDir}},
 		Game: esapi.Game{
 			Path: "./Japan/Game.nes",
 		},
@@ -1524,6 +1524,65 @@ func TestMapToDB_FilesystemFallback_NestedGamePath(t *testing.T) {
 	assert.True(t, found, "nested filesystem fallback image property missing")
 }
 
+func TestMapToDB_FilesystemFallback_CrossRoot(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	romRoot := filepath.Join(base, "cifs", "nes")
+	artRoot := filepath.Join(base, "fat", "nes")
+	imgDir := filepath.Join(artRoot, "media", "images")
+	require.NoError(t, os.MkdirAll(imgDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(imgDir, "Game.png"), []byte{}, 0o600))
+
+	// The gamelist.xml lives on romRoot; artwork lives on a different root.
+	rec := GamelistRecord{
+		SystemRootPath:  romRoot,
+		MediaDirsByRoot: []map[string]string{{}, {"images": imgDir}},
+		Game:            esapi.Game{Path: "./Game.nes"},
+	}
+
+	result := (&GamelistXMLScraper{}).MapToDB(&rec)
+
+	propKey := string(tags.TagTypeProperty) + ":" + string(tags.TagPropertyImageImage)
+	var found bool
+	for _, p := range result.MediaProps {
+		if p.TypeTag == propKey {
+			found = true
+			assert.Equal(t, filepath.ToSlash(filepath.Join(imgDir, "Game.png")), p.Text)
+		}
+	}
+	assert.True(t, found, "cross-root filesystem fallback image property missing")
+}
+
+func TestMapToDB_FilesystemFallback_PrefersEarlierRootInOrder(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	romRoot := filepath.Join(base, "cifs", "nes")
+	firstArtDir := filepath.Join(base, "usb0", "nes", "media", "images")
+	secondArtDir := filepath.Join(base, "fat", "nes", "media", "images")
+	require.NoError(t, os.MkdirAll(firstArtDir, 0o750))
+	require.NoError(t, os.MkdirAll(secondArtDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(firstArtDir, "Game.png"), []byte{}, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(secondArtDir, "Game.png"), []byte{}, 0o600))
+
+	rec := GamelistRecord{
+		SystemRootPath:  romRoot,
+		MediaDirsByRoot: []map[string]string{{"images": firstArtDir}, {"images": secondArtDir}},
+		Game:            esapi.Game{Path: "./Game.nes"},
+	}
+
+	result := (&GamelistXMLScraper{}).MapToDB(&rec)
+
+	propKey := string(tags.TagTypeProperty) + ":" + string(tags.TagPropertyImageImage)
+	var found bool
+	for _, p := range result.MediaProps {
+		if p.TypeTag == propKey {
+			found = true
+			assert.Equal(t, filepath.ToSlash(filepath.Join(firstArtDir, "Game.png")), p.Text)
+		}
+	}
+	assert.True(t, found, "cross-root filesystem fallback image property missing")
+}
+
 func TestMapToDB_FilesystemFallback_NestedWinsBeforeFlat(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -1536,9 +1595,9 @@ func TestMapToDB_FilesystemFallback_NestedWinsBeforeFlat(t *testing.T) {
 	require.NoError(t, os.WriteFile(flatPath, []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"images": imgDir},
-		Game:               esapi.Game{Path: "./Japan/Game.nes"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"images": imgDir}},
+		Game:            esapi.Game{Path: "./Japan/Game.nes"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1564,9 +1623,9 @@ func TestMapToDB_FilesystemFallback_ThumbnailBox2DFrontAlias(t *testing.T) {
 	require.NoError(t, os.WriteFile(thumbPath, []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"box2dfront": thumbDir},
-		Game:               esapi.Game{Path: "./Game.nes"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"box2dfront": thumbDir}},
+		Game:            esapi.Game{Path: "./Game.nes"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1591,9 +1650,9 @@ func TestMapToDB_FilesystemFallback_Boxart(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(boxartDir, "sonic.png"), []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"boxart": boxartDir},
-		Game:               esapi.Game{Path: "./roms/sonic.md"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"boxart": boxartDir}},
+		Game:            esapi.Game{Path: "./roms/sonic.md"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1623,11 +1682,11 @@ func TestMapToDB_FallbackFindsBox2DLogoTitleScreenDirs(t *testing.T) {
 
 	rec := GamelistRecord{
 		SystemRootPath: root,
-		AvailableMediaDirs: map[string]string{
+		MediaDirsByRoot: []map[string]string{{
 			"box2d":       box2DDir,
 			"logo":        logoDir,
 			"titlescreen": titleScreenDir,
-		},
+		}},
 		Game: esapi.Game{Path: "./Game.nes"},
 	}
 
@@ -1662,9 +1721,9 @@ func TestMapToDB_FallbackFindsJPGMediaFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(imgPath, []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"images": imgDir},
-		Game:               esapi.Game{Path: "./Game.nes"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"images": imgDir}},
+		Game:            esapi.Game{Path: "./Game.nes"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1696,8 +1755,8 @@ func TestMapToDB_FilesystemFallback_XMLWins(t *testing.T) {
 	require.NoError(t, os.WriteFile(fsImg, []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"image": filepath.Join(root, "media", "image")},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"image": filepath.Join(root, "media", "image")}},
 		Game: esapi.Game{
 			Path:  "./roms/mario.nes",
 			Image: "./media/images/mario.png", // XML path present → must win
@@ -1720,7 +1779,7 @@ func TestMapToDB_FilesystemFallback_XMLWins(t *testing.T) {
 func TestMapToDB_FilesystemFallback_NoMediaDir(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
-	// No media/ directory, no AvailableMediaDirs — should produce no image props.
+	// No media/ directory, no MediaDirsByRoot — should produce no image props.
 	rec := GamelistRecord{
 		SystemRootPath: root,
 		Game:           esapi.Game{Path: "./roms/mario.nes"},
@@ -1808,9 +1867,9 @@ func TestMapToDB_FilesystemFallback_Boxart3D(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sonic.png"), []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"boxart3d": dir},
-		Game:               esapi.Game{Path: "./roms/sonic.md"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"boxart3d": dir}},
+		Game:            esapi.Game{Path: "./roms/sonic.md"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1835,9 +1894,9 @@ func TestMapToDB_FilesystemFallback_BoxartSide(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sonic.png"), []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"boxart2dside": dir},
-		Game:               esapi.Game{Path: "./roms/sonic.md"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"boxart2dside": dir}},
+		Game:            esapi.Game{Path: "./roms/sonic.md"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)
@@ -1862,9 +1921,9 @@ func TestMapToDB_FilesystemFallback_BoxartBack(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sonic.png"), []byte{}, 0o600))
 
 	rec := GamelistRecord{
-		SystemRootPath:     root,
-		AvailableMediaDirs: map[string]string{"boxart2dback": dir},
-		Game:               esapi.Game{Path: "./roms/sonic.md"},
+		SystemRootPath:  root,
+		MediaDirsByRoot: []map[string]string{{"boxart2dback": dir}},
+		Game:            esapi.Game{Path: "./roms/sonic.md"},
 	}
 
 	result := (&GamelistXMLScraper{}).MapToDB(&rec)

--- a/pkg/database/scraper/localmedia/scraper.go
+++ b/pkg/database/scraper/localmedia/scraper.go
@@ -293,31 +293,42 @@ func (s *scraperImpl) mediaPropsForPath(
 	roots []string,
 	availableDirs map[string]map[string]string,
 ) []database.MediaProperty {
-	props := make([]database.MediaProperty, 0)
+	// Artwork filenames are derived from the root that actually contains the
+	// game (its home root); the same relative names are then searched under
+	// every root's media/ dir so art can live on a different drive than the rom.
+	var fallbackNames []string
 	for _, root := range roots {
-		fallbackNames := esmedia.ArtworkFallbackNames(path, root)
-		if len(fallbackNames) == 0 {
+		if names := esmedia.ArtworkFallbackNames(path, root); len(names) > 0 {
+			fallbackNames = names
+			break
+		}
+	}
+	if len(fallbackNames) == 0 {
+		return nil
+	}
+
+	// roots is in RootDirs order, so the first root with a match wins.
+	orderedDirs := make([]map[string]string, 0, len(roots))
+	for _, root := range roots {
+		orderedDirs = append(orderedDirs, availableDirs[root])
+	}
+
+	props := make([]database.MediaProperty, 0)
+	for _, propValue := range artworkPropertyOrder {
+		file := esmedia.FindFileAcrossRootsFS(
+			s.fs,
+			fallbackNames,
+			esmedia.ArtworkDirCandidates[string(propValue)],
+			orderedDirs,
+		)
+		if file == nil {
 			continue
 		}
-		for _, propValue := range artworkPropertyOrder {
-			file := esmedia.FindFileFS(
-				s.fs,
-				fallbackNames,
-				esmedia.ArtworkDirCandidates[string(propValue)],
-				availableDirs[root],
-			)
-			if file == nil {
-				continue
-			}
-			props = append(props, database.MediaProperty{
-				TypeTag:     tags.PropertyTypeTag(propValue),
-				Text:        filepath.ToSlash(file.Path),
-				ContentType: file.ContentType,
-			})
-		}
-		if len(props) > 0 {
-			return props
-		}
+		props = append(props, database.MediaProperty{
+			TypeTag:     tags.PropertyTypeTag(propValue),
+			Text:        filepath.ToSlash(file.Path),
+			ContentType: file.ContentType,
+		})
 	}
 	return props
 }
@@ -365,12 +376,21 @@ func isLocalMediaPropForPath(prop *database.MediaProperty, mediaPath string, roo
 		return false
 	}
 
+	// Derive artwork names from the game's home root, then match the prop path
+	// against the media/ convention under any root (art may live cross-drive).
+	var fallbackNames []string
+	for _, root := range roots {
+		if names := esmedia.ArtworkFallbackNames(mediaPath, root); len(names) > 0 {
+			fallbackNames = names
+			break
+		}
+	}
+	if len(fallbackNames) == 0 {
+		return false
+	}
+
 	propPath := filepath.Clean(filepath.FromSlash(prop.Text))
 	for _, root := range roots {
-		fallbackNames := esmedia.ArtworkFallbackNames(mediaPath, root)
-		if len(fallbackNames) == 0 {
-			continue
-		}
 		for _, dir := range candidates {
 			for _, name := range fallbackNames {
 				candidate := filepath.Clean(filepath.Join(root, "media", dir, name))

--- a/pkg/database/scraper/localmedia/scraper_test.go
+++ b/pkg/database/scraper/localmedia/scraper_test.go
@@ -279,3 +279,100 @@ func TestMediaPropsForPath_UsesFlatFallbackAfterMirroredPath(t *testing.T) {
 	assert.Equal(t, filepath.ToSlash(flatCoverPath), props[0].Text)
 	assert.Equal(t, "image/webp", props[0].ContentType)
 }
+
+func TestMediaPropsForPath_FindsArtworkOnDifferentRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	romRoot := filepath.Join(base, "cifs", "nes")
+	artRoot := filepath.Join(base, "fat", "nes")
+	romPath := filepath.Join(romRoot, "Game.nes")
+	boxartPath := filepath.Join(artRoot, "media", "boxart", "Game.png")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(filepath.Join(romRoot, "media"), 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(boxartPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, boxartPath, []byte("boxart"), 0o600))
+
+	roots := []string{romRoot, artRoot}
+	s := &scraperImpl{fs: fs}
+	props := s.mediaPropsForPath(romPath, roots, s.availableDirsByRoot(roots))
+
+	require.Len(t, props, 1)
+	assert.Equal(t, tags.PropertyTypeTag(tags.TagPropertyImageBoxart), props[0].TypeTag)
+	assert.Equal(t, filepath.ToSlash(boxartPath), props[0].Text)
+}
+
+func TestMediaPropsForPath_PrefersEarlierRootInOrder(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	firstRoot := filepath.Join(base, "usb0", "nes")
+	secondRoot := filepath.Join(base, "cifs", "nes")
+	romPath := filepath.Join(secondRoot, "Game.nes")
+	firstBoxart := filepath.Join(firstRoot, "media", "boxart", "Game.png")
+	secondBoxart := filepath.Join(secondRoot, "media", "boxart", "Game.png")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(filepath.Dir(firstBoxart), 0o750))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(secondBoxart), 0o750))
+	require.NoError(t, afero.WriteFile(fs, firstBoxart, []byte("first"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, secondBoxart, []byte("second"), 0o600))
+
+	roots := []string{firstRoot, secondRoot}
+	s := &scraperImpl{fs: fs}
+	props := s.mediaPropsForPath(romPath, roots, s.availableDirsByRoot(roots))
+
+	require.Len(t, props, 1)
+	assert.Equal(t, filepath.ToSlash(firstBoxart), props[0].Text)
+}
+
+func TestMediaPropsForPath_MirroredSubfolderCrossRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	romRoot := filepath.Join(base, "cifs", "nes")
+	artRoot := filepath.Join(base, "fat", "nes")
+	romPath := filepath.Join(romRoot, "Japan", "Game.nes")
+	mirroredPath := filepath.Join(artRoot, "media", "images", "Japan", "Game.png")
+	flatPath := filepath.Join(artRoot, "media", "images", "Game.png")
+	fs := afero.NewMemMapFs()
+	require.NoError(t, fs.MkdirAll(filepath.Dir(mirroredPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, mirroredPath, []byte("mirror"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, flatPath, []byte("flat"), 0o600))
+
+	roots := []string{romRoot, artRoot}
+	s := &scraperImpl{fs: fs}
+	props := s.mediaPropsForPath(romPath, roots, s.availableDirsByRoot(roots))
+
+	require.Len(t, props, 1)
+	assert.Equal(t, tags.PropertyTypeTag(tags.TagPropertyImageImage), props[0].TypeTag)
+	assert.Equal(t, filepath.ToSlash(mirroredPath), props[0].Text)
+}
+
+func TestDeleteStaleLocalMediaProps_DeletesStaleCrossRootProp(t *testing.T) {
+	t.Parallel()
+
+	romRoot := filepath.Join(t.TempDir(), "cifs", "nes")
+	artRoot := filepath.Join(t.TempDir(), "fat", "nes")
+	mediaPath := filepath.Join(romRoot, "Game.nes")
+	staleCrossRootPath := filepath.Join(artRoot, "media", "boxart", "Game.png")
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaPropertyMetadata", mock.Anything, int64(11)).Return([]database.MediaProperty{
+		{
+			TypeTag:     tags.PropertyTypeTag(tags.TagPropertyImageBoxart),
+			TypeTagDBID: 101,
+			Text:        filepath.ToSlash(staleCrossRootPath),
+		},
+	}, nil)
+	mockDB.On("DeleteMediaProperty", mock.Anything, int64(11), int64(101)).Return(nil).Once()
+
+	s := &scraperImpl{db: mockDB, fs: afero.NewMemMapFs()}
+	media := &database.MediaWithFullPath{DBID: 11, MediaTitleDBID: 101, Path: mediaPath, SystemID: "NES"}
+	deleted, err := s.deleteStaleLocalMediaProps(
+		context.Background(), media, []string{romRoot, artRoot}, nil,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/database/scraper/localmedia/scraper_test.go
+++ b/pkg/database/scraper/localmedia/scraper_test.go
@@ -351,8 +351,9 @@ func TestMediaPropsForPath_MirroredSubfolderCrossRoot(t *testing.T) {
 func TestDeleteStaleLocalMediaProps_DeletesStaleCrossRootProp(t *testing.T) {
 	t.Parallel()
 
-	romRoot := filepath.Join(t.TempDir(), "cifs", "nes")
-	artRoot := filepath.Join(t.TempDir(), "fat", "nes")
+	base := t.TempDir()
+	romRoot := filepath.Join(base, "cifs", "nes")
+	artRoot := filepath.Join(base, "fat", "nes")
 	mediaPath := filepath.Join(romRoot, "Game.nes")
 	staleCrossRootPath := filepath.Join(artRoot, "media", "boxart", "Game.png")
 

--- a/pkg/platforms/shared/esmedia/artwork.go
+++ b/pkg/platforms/shared/esmedia/artwork.go
@@ -168,6 +168,24 @@ func FindFileFS(
 	return nil
 }
 
+// FindFileAcrossRootsFS searches each root's media directories in order and
+// returns the first matching file. orderedAvailableDirs must be in priority
+// order (RootDirs order); the first root with a hit wins. Within a root the
+// existing candidate-directory order applies.
+func FindFileAcrossRootsFS(
+	fs afero.Fs,
+	fallbackNames []string,
+	candidates []string,
+	orderedAvailableDirs []map[string]string,
+) *File {
+	for _, availableDirs := range orderedAvailableDirs {
+		if file := FindFileFS(fs, fallbackNames, candidates, availableDirs); file != nil {
+			return file
+		}
+	}
+	return nil
+}
+
 // MimeFromExt returns a MIME type based on file extension.
 func MimeFromExt(path string) string {
 	ext := strings.ToLower(filepath.Ext(path))

--- a/pkg/platforms/shared/esmedia/artwork_test.go
+++ b/pkg/platforms/shared/esmedia/artwork_test.go
@@ -146,6 +146,75 @@ func TestFindFileFS_RejectsTraversalNames(t *testing.T) {
 	assert.Equal(t, filepath.ToSlash(filepath.Join(dir, "Game.png")), file.Path)
 }
 
+func TestFindFileAcrossRootsFS_FirstRootInOrderWins(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	rootA := filepath.Join("media", "usb0", "nes")
+	rootB := filepath.Join("media", "fat", "nes")
+	boxartA := filepath.Join(rootA, "media", "boxart")
+	boxartB := filepath.Join(rootB, "media", "boxart")
+	require.NoError(t, fs.MkdirAll(boxartA, 0o750))
+	require.NoError(t, fs.MkdirAll(boxartB, 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(boxartA, "Game.png"), []byte("a"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(boxartB, "Game.png"), []byte("b"), 0o600))
+
+	file := FindFileAcrossRootsFS(
+		fs,
+		[]string{"Game.png"},
+		[]string{"boxart"},
+		[]map[string]string{
+			{"boxart": boxartA},
+			{"boxart": boxartB},
+		},
+	)
+
+	require.NotNil(t, file)
+	assert.Equal(t, filepath.ToSlash(filepath.Join(boxartA, "Game.png")), file.Path)
+}
+
+func TestFindFileAcrossRootsFS_FallsThroughToLaterRoot(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	romRoot := filepath.Join("media", "fat", "cifs", "nes")
+	artRoot := filepath.Join("media", "fat", "nes")
+	boxartArt := filepath.Join(artRoot, "media", "boxart")
+	require.NoError(t, fs.MkdirAll(filepath.Join(romRoot, "media"), 0o750))
+	require.NoError(t, fs.MkdirAll(boxartArt, 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(boxartArt, "Game.png"), []byte("art"), 0o600))
+
+	file := FindFileAcrossRootsFS(
+		fs,
+		[]string{"Game.png"},
+		[]string{"boxart"},
+		[]map[string]string{
+			StatMediaDirsFS(fs, romRoot),
+			StatMediaDirsFS(fs, artRoot),
+		},
+	)
+
+	require.NotNil(t, file)
+	assert.Equal(t, filepath.ToSlash(filepath.Join(boxartArt, "Game.png")), file.Path)
+}
+
+func TestFindFileAcrossRootsFS_NotFound(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	boxart := filepath.Join("media", "fat", "nes", "media", "boxart")
+	require.NoError(t, fs.MkdirAll(boxart, 0o750))
+
+	file := FindFileAcrossRootsFS(
+		fs,
+		[]string{"Missing.png"},
+		[]string{"boxart"},
+		[]map[string]string{{"boxart": boxart}},
+	)
+
+	assert.Nil(t, file)
+}
+
 func TestResolvePath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The `media-folder` and `gamelist.xml` filesystem fallbacks only searched the root containing the rom, so EmulationStation `media/` folder artwork had to live on the same drive as the games. People with roms on one root (e.g. a CIFS/network share) and artwork on another (e.g. the SD card) could not use the `media/` folder convention to keep large art files on faster local storage.

## Change

Search every root's `media/` directory in `RootDirs(cfg)` order, deriving the artwork filenames from the rom's home root, so a mirrored `media/` folder on any root resolves. First root with a match wins.

- **`esmedia.FindFileAcrossRootsFS`** — shared ordered-root lookup used by both scrapers.
- **`media-folder`** — `mediaPropsForPath` and the force re-scrape stale-cleanup matcher now search all roots. Resolution is now per-property first-match-by-root-order instead of all-from-the-first-root-with-any-art (single-root layouts produce identical results).
- **`gamelist.xml`** — media dirs are gathered once per system (RootDirs order) and carried on each record; the filesystem fallback searches them all. Explicit absolute asset paths already resolved cross-root and are unchanged.

The resulting layout now works on MiSTer with no config and no absolute paths:
- roms: `/media/fat/cifs/SNES/Game.sfc`
- art: `/media/fat/SNES/media/images/Game.png` (found automatically)

## Performance

For single-root systems (the common case) there is no meaningful change — `ROMPaths` contains only roots where the system folder exists, so the search is identical. Added cost applies only when the same system folder exists on multiple roots: extra `media/` stat probes bounded by the number of mirrored roots, with early-exit on first match and ~0 cost for roots without a `media/` dir.

## Tests

- `esmedia`: `FindFileAcrossRootsFS` first-match-in-order and not-found.
- `media-folder`: cross-root resolution, RootDirs-order priority, mirrored-subfolder cross-root, single-root regression, cross-root stale-prop cleanup.
- `gamelist.xml`: filesystem fallback resolves from a mirrored `media/` folder on a different root, with root-order priority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media/artwork path resolution now supports discovering files across multiple configured storage roots.
  * When multiple roots match, the earlier root in the configured order is preferred.
  * Gamelist record media directory mapping has been updated to carry per-root directory information for improved fallback behavior.

* **Tests**
  * Expanded coverage for cross-root artwork discovery, root precedence, mirrored subfolder behavior, and stale local media cleanup.
  * Added tests for the new cross-roots artwork lookup helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->