### PR TITLE
perf(mediascanner): batch index commits across systems

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -703,6 +703,7 @@ type MediaDBI interface {
 	BeginTransaction(batchEnabled bool) error
 	CommitTransaction() error
 	CommitTransactionWithOptions(options TransactionOptions) error
+	FlushBatchInserters() error
 	RollbackTransaction() error
 	Exists() bool
 	UpdateLastGenerated() error

--- a/pkg/database/mediadb/flush_batch_inserters_test.go
+++ b/pkg/database/mediadb/flush_batch_inserters_test.go
@@ -1,0 +1,94 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func countMediaInTx(t *testing.T, db *MediaDB) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.tx.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM Media").Scan(&n))
+	return n
+}
+
+// TestMediaDB_FlushBatchInserters verifies the primitive that lets one indexing
+// transaction span multiple systems: flushing buffered batch inserts makes the
+// rows visible to reads on the same (still-open) transaction — which per-system
+// disambiguation relies on — while leaving the inserters usable for more rows.
+func TestMediaDB_FlushBatchInserters(t *testing.T) {
+	t.Run("no active transaction is a no-op", func(t *testing.T) {
+		mediaDB, cleanup := setupTempMediaDB(t)
+		defer cleanup()
+
+		require.NoError(t, mediaDB.FlushBatchInserters())
+	})
+
+	t.Run("flush exposes buffered rows in the transaction and keeps inserters open", func(t *testing.T) {
+		mediaDB, cleanup := setupTempMediaDB(t)
+		defer cleanup()
+
+		require.NoError(t, mediaDB.BeginTransaction(true))
+		defer func() { _ = mediaDB.RollbackTransaction() }()
+
+		_, err := mediaDB.InsertSystem(database.System{DBID: 1, SystemID: "NES", Name: "NES"})
+		require.NoError(t, err)
+		_, err = mediaDB.InsertMediaTitle(&database.MediaTitle{
+			DBID: 1, SystemDBID: 1, Slug: "game", Name: "Game", SlugLength: 4, SlugWordCount: 1,
+		})
+		require.NoError(t, err)
+		_, err = mediaDB.InsertMedia(database.Media{
+			DBID: 1, MediaTitleDBID: 1, SystemDBID: 1,
+			Path: filepath.Join("roms", "nes", "game.nes"), ParentDir: "roms/nes/", SortName: "Game",
+		})
+		require.NoError(t, err)
+
+		// Inserts are buffered in the batch inserters, not yet in the transaction.
+		assert.Equal(t, 0, countMediaInTx(t, mediaDB), "rows should be buffered before flush")
+
+		require.NoError(t, mediaDB.FlushBatchInserters())
+
+		// After flush they are visible to reads on the same transaction.
+		assert.Equal(t, 1, countMediaInTx(t, mediaDB), "rows should be visible after flush")
+
+		// The inserters remain usable: more rows can be added and flushed without
+		// committing, as happens when the next system is indexed in the same batch.
+		_, err = mediaDB.InsertMedia(database.Media{
+			DBID: 2, MediaTitleDBID: 1, SystemDBID: 1,
+			Path: filepath.Join("roms", "nes", "game2.nes"), ParentDir: "roms/nes/", SortName: "Game 2",
+		})
+		require.NoError(t, err)
+		require.NoError(t, mediaDB.FlushBatchInserters())
+		assert.Equal(t, 2, countMediaInTx(t, mediaDB), "second flush should expose the additional row")
+
+		require.NoError(t, mediaDB.CommitTransaction())
+
+		media, err := mediaDB.GetMediaBySystemID("NES")
+		require.NoError(t, err)
+		assert.Len(t, media, 2, "both media rows should persist after commit")
+	})
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1078,6 +1078,40 @@ func (db *MediaDB) closeAllBatchInserters() error {
 	return errors.Join(closeErrs...)
 }
 
+// FlushBatchInserters flushes all pending batch-insert buffers into the open
+// transaction without committing, so freshly inserted rows become visible to
+// reads on the same transaction (e.g. RecomputeSystemDisambiguation). Unlike
+// closeAllBatchInserters it leaves the inserters open for continued use, which
+// lets one transaction span multiple systems. No-op when no transaction or no
+// batch inserters are active. Each inserter's Flush already flushes its FK
+// dependencies first, so the iteration order only needs to be deterministic.
+func (db *MediaDB) FlushBatchInserters() error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
+	if db.tx == nil {
+		return nil
+	}
+
+	var flushErrs []error
+	for _, bi := range []*BatchInserter{
+		db.batchInsertSystem,
+		db.batchInsertMediaTitle,
+		db.batchInsertMedia,
+		db.batchInsertTag,
+		db.batchInsertTagType,
+		db.batchInsertMediaTag,
+	} {
+		if bi == nil {
+			continue
+		}
+		if flushErr := bi.Flush(); flushErr != nil {
+			flushErrs = append(flushErrs, flushErr)
+		}
+	}
+	return errors.Join(flushErrs...)
+}
+
 // RollbackTransaction rolls back the current transaction and cleans up resources
 func (db *MediaDB) RollbackTransaction() error {
 	db.sqlMu.Lock()

--- a/pkg/database/mediascanner/batched_commits_test.go
+++ b/pkg/database/mediascanner/batched_commits_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -204,9 +205,89 @@ func TestNewNamesIndex_BatchedReindexIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestNewNamesIndex_BatchedMissingMediaMarkedOnReindex verifies that media which
+// disappears between indexes is still flagged missing now that the missing-state
+// reconciliation runs inside the shared batch transaction rather than its own.
+func TestNewNamesIndex_BatchedMissingMediaMarkedOnReindex(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	dir := t.TempDir()
+	keep := filepath.Join(dir, "keep.bin")
+	gone := filepath.Join(dir, "gone.bin")
+	require.NoError(t, os.WriteFile(keep, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(gone, []byte("x"), 0o600))
+
+	launcher := platforms.Launcher{
+		ID:         "custom-nes",
+		SystemID:   systemdefs.SystemNES,
+		Folders:    []string{dir},
+		Extensions: []string{".bin"},
+	}
+	fsHelper := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fsHelper, t.TempDir())
+	require.NoError(t, err)
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	systems := []systemdefs.System{{ID: systemdefs.SystemNES}}
+
+	first, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, first)
+
+	// The file vanishes before the second index, so its row must be flagged missing.
+	require.NoError(t, os.Remove(gone))
+
+	_, err = NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	// GetAllMedia does not select IsMissing, so read the flag directly.
+	missingByBase := readMissingFlags(t, db)
+	assert.True(t, missingByBase["gone.bin"], "the removed file's media row should be flagged missing")
+	assert.False(t, missingByBase["keep.bin"], "the surviving file's media row should not be missing")
+}
+
+// readMissingFlags returns IsMissing for every Media row keyed by path basename.
+func readMissingFlags(t *testing.T, db *database.Database) map[string]bool {
+	t.Helper()
+	sqlDB := db.MediaDB.UnsafeGetSQLDb()
+	require.NotNil(t, sqlDB)
+	rows, err := sqlDB.QueryContext(context.Background(), "SELECT Path, IsMissing FROM Media")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	flags := make(map[string]bool)
+	for rows.Next() {
+		var path string
+		var missing bool
+		require.NoError(t, rows.Scan(&path, &missing))
+		flags[filepath.Base(path)] = missing
+	}
+	require.NoError(t, rows.Err())
+	return flags
+}
+
 // TestNewNamesIndex_LargeSystemCommitsMidBatch verifies that a single system
 // exceeding maxFilesPerTransaction still triggers an intermediate (memory-safety)
-// commit and indexes every file correctly.
+// commit and indexes every file correctly. A small system is batched ahead of the
+// large one (it sorts first: "Gameboy" < "NES"), so the mid-system commit fires
+// while the small system is already finalized — exercising the path that marks
+// previously-batched systems complete at a mid-system commit boundary.
 func TestNewNamesIndex_LargeSystemCommitsMidBatch(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache and log.Logger.
 	db, cleanup := testhelpers.NewTestDatabase(t)
@@ -214,7 +295,8 @@ func TestNewNamesIndex_LargeSystemCommitsMidBatch(t *testing.T) {
 
 	fileCount := maxFilesPerTransaction + 5
 	systemFiles := map[string][]string{
-		systemdefs.SystemNES: genFileNames("game", fileCount),
+		systemdefs.SystemGameboy: {"small1.bin", "small2.bin"},
+		systemdefs.SystemNES:     genFileNames("game", fileCount),
 	}
 	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
 
@@ -232,11 +314,17 @@ func TestNewNamesIndex_LargeSystemCommitsMidBatch(t *testing.T) {
 	zerolog.SetGlobalLevel(prevGlobal)
 	output := buf.String()
 
-	assert.Equal(t, fileCount, filesIndexed, "every file in the oversized system should be indexed")
+	assert.Equal(t, fileCount+2, filesIndexed, "every file in both systems should be indexed")
 
 	media, mErr := db.MediaDB.GetMediaBySystemID(systemdefs.SystemNES)
 	require.NoError(t, mErr)
-	assert.Len(t, media, fileCount, "all media rows should be present")
+	assert.Len(t, media, fileCount, "all media rows for the oversized system should be present")
+
+	// The small system was batched ahead of the large one; it must be committed
+	// (and queryable) even though the large system forced a mid-system commit.
+	smallMedia, sErr := db.MediaDB.GetMediaBySystemID(systemdefs.SystemGameboy)
+	require.NoError(t, sErr)
+	assert.Len(t, smallMedia, 2, "the small system batched ahead should be fully indexed")
 
 	fileLimitCommits := strings.Count(output, "committed batch (file limit)")
 	assert.GreaterOrEqual(t, fileLimitCommits, 1,

--- a/pkg/database/mediascanner/batched_commits_test.go
+++ b/pkg/database/mediascanner/batched_commits_test.go
@@ -1,0 +1,244 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// syncLogBuffer is a goroutine-safe buffer for capturing zerolog output, since
+// background optimization may keep logging after the indexing loop returns.
+type syncLogBuffer struct {
+	buf bytes.Buffer
+	mu  syncutil.Mutex
+}
+
+func (s *syncLogBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n, err := s.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("write to log buffer: %w", err)
+	}
+	return n, nil
+}
+
+func (s *syncLogBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+// setupCustomLauncherSystems writes the given files into a temp folder per
+// system and wires up a mock platform with one custom launcher per system. It
+// returns the platform and config ready to pass to NewNamesIndex. The caller is
+// responsible for restoring GlobalLauncherCache (handled here via t.Cleanup).
+func setupCustomLauncherSystems(
+	t *testing.T, systemFiles map[string][]string,
+) (platforms.Platform, *config.Instance, []systemdefs.System) {
+	t.Helper()
+
+	fsHelper := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fsHelper, t.TempDir())
+	require.NoError(t, err)
+
+	launchers := make([]platforms.Launcher, 0, len(systemFiles))
+	systems := make([]systemdefs.System, 0, len(systemFiles))
+	for systemID, files := range systemFiles {
+		dir := t.TempDir()
+		for _, name := range files {
+			require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600))
+		}
+		launchers = append(launchers, platforms.Launcher{
+			ID:         "custom-" + systemID,
+			SystemID:   systemID,
+			Folders:    []string{dir},
+			Extensions: []string{".bin"},
+		})
+		systems = append(systems, systemdefs.System{ID: systemID})
+	}
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(launchers)
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	t.Cleanup(func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	})
+
+	return platform, cfg, systems
+}
+
+func genFileNames(prefix string, n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("%s_%05d.bin", prefix, i)
+	}
+	return names
+}
+
+// TestNewNamesIndex_BatchesCommitsAcrossSmallSystems verifies that a run of many
+// small systems shares a single transaction commit instead of committing once
+// (or twice) per system. The fixed per-commit fsync+checkpoint cost dominates
+// indexing on slow storage, so collapsing N systems into one commit is the win.
+func TestNewNamesIndex_BatchesCommitsAcrossSmallSystems(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache and log.Logger.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemNES:          {"a.bin", "b.bin"},
+		systemdefs.SystemSNES:         {"c.bin", "d.bin"},
+		systemdefs.SystemGenesis:      {"e.bin", "f.bin"},
+		systemdefs.SystemGameboy:      {"g.bin", "h.bin"},
+		systemdefs.SystemGameboyColor: {"i.bin", "j.bin"},
+		systemdefs.SystemGBA:          {"k.bin", "l.bin"},
+	}
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+
+	buf := &syncLogBuffer{}
+	prevLogger := log.Logger
+	prevGlobal := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(buf).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = prevLogger; zerolog.SetGlobalLevel(prevGlobal) }()
+
+	filesIndexed, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	// Restore the logger before reading so background optimization can't race the read.
+	log.Logger = prevLogger
+	zerolog.SetGlobalLevel(prevGlobal)
+	output := buf.String()
+
+	assert.Equal(t, 12, filesIndexed, "all files across all systems should be indexed")
+
+	for systemID, files := range systemFiles {
+		media, mErr := db.MediaDB.GetMediaBySystemID(systemID)
+		require.NoError(t, mErr)
+		assert.Lenf(t, media, len(files), "system %s should have all its media", systemID)
+	}
+
+	// All files fit well under maxFilesPerTransaction, so there must be exactly one
+	// batch-boundary commit and no mid-system (file-limit) commits — proving the six
+	// systems shared a single transaction rather than committing per system.
+	boundaryCommits := strings.Count(output, `"message":"committing media indexing batch"`)
+	fileLimitCommits := strings.Count(output, "committed batch (file limit)")
+	assert.Equal(t, 1, boundaryCommits,
+		"six small systems should share exactly one batch commit (got log:\n%s)", output)
+	assert.Equal(t, 0, fileLimitCommits, "no mid-system commits expected for small systems")
+}
+
+// TestNewNamesIndex_BatchedReindexIsIdempotent verifies that re-indexing the same
+// media a second time (which exercises the persistent-state reload plus the
+// missing-state/disambiguation work now merged into the shared transaction)
+// produces identical results and does not duplicate or drop rows.
+func TestNewNamesIndex_BatchedReindexIsIdempotent(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemNES:     {"a.bin", "b.bin", "c.bin"},
+		systemdefs.SystemSNES:    {"d.bin", "e.bin"},
+		systemdefs.SystemGenesis: {"f.bin"},
+	}
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+
+	first, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 6, first)
+
+	second, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "re-indexing identical media must produce an identical count")
+
+	for systemID, files := range systemFiles {
+		media, mErr := db.MediaDB.GetMediaBySystemID(systemID)
+		require.NoError(t, mErr)
+		assert.Lenf(t, media, len(files), "system %s should still have exactly its media after reindex", systemID)
+	}
+}
+
+// TestNewNamesIndex_LargeSystemCommitsMidBatch verifies that a single system
+// exceeding maxFilesPerTransaction still triggers an intermediate (memory-safety)
+// commit and indexes every file correctly.
+func TestNewNamesIndex_LargeSystemCommitsMidBatch(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache and log.Logger.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	fileCount := maxFilesPerTransaction + 5
+	systemFiles := map[string][]string{
+		systemdefs.SystemNES: genFileNames("game", fileCount),
+	}
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+
+	buf := &syncLogBuffer{}
+	prevLogger := log.Logger
+	prevGlobal := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(buf).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = prevLogger; zerolog.SetGlobalLevel(prevGlobal) }()
+
+	filesIndexed, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	log.Logger = prevLogger
+	zerolog.SetGlobalLevel(prevGlobal)
+	output := buf.String()
+
+	assert.Equal(t, fileCount, filesIndexed, "every file in the oversized system should be indexed")
+
+	media, mErr := db.MediaDB.GetMediaBySystemID(systemdefs.SystemNES)
+	require.NoError(t, mErr)
+	assert.Len(t, media, fileCount, "all media rows should be present")
+
+	fileLimitCommits := strings.Count(output, "committed batch (file limit)")
+	assert.GreaterOrEqual(t, fileLimitCommits, 1,
+		"a system larger than maxFilesPerTransaction must commit mid-system at least once")
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -903,9 +903,15 @@ func NewNamesIndex(
 		}
 	}
 
-	// Batch tracking variables for adaptive transaction management
+	// Batch tracking variables for adaptive transaction management. One
+	// transaction can span multiple systems to amortise the fixed per-commit
+	// fsync + WAL-checkpoint cost on slow storage (each commit costs ~0.2-2.5s
+	// regardless of row count). pendingSystems holds systems whose inserts and
+	// missing-state are buffered in the open transaction but not yet committed,
+	// and therefore not yet durable for crash-resume.
 	filesInBatch := 0
 	batchStarted := false
+	pendingSystems := make([]string, 0)
 
 	// TODO: skip unchanged systems via a per-system fingerprint — store
 	// hash(sorted walked paths) + parser version + media row count after each
@@ -918,7 +924,7 @@ func NewNamesIndex(
 	// collected before the AddMediaPath phase. Populate* and FlushScanStateMaps
 	// are called for every system, fixing the stale-state gaps that existed in
 	// the previous loop 2 and loop 3.
-	for _, sys := range sortedSystems {
+	for sysIdx, sys := range sortedSystems {
 		// Check for cancellation or pause
 		select {
 		case <-ctx.Done():
@@ -1149,12 +1155,17 @@ func NewNamesIndex(
 					Msg("processed media paths")
 			}
 
-			// Commit if we hit file limit (memory safety - even mid-system)
+			// Commit if we hit file limit (memory safety - even mid-system). The
+			// current system is only partially processed here, so it is NOT marked
+			// complete; on resume the cursor points at it and it is re-indexed from
+			// scratch (idempotent). Systems fully processed earlier in this batch are
+			// now durable and marked complete.
 			if filesInBatch >= maxFilesPerTransaction {
 				log.Debug().
 					Str("system", systemID).
 					Int("files", filesInBatch).
-					Msg("committing media indexing batch")
+					Int("batchedSystems", len(pendingSystems)).
+					Msg("committing media indexing batch (file limit)")
 				commitStart := time.Now()
 				if commitErr := db.CommitTransaction(); commitErr != nil {
 					return 0, fmt.Errorf("failed to commit batch transaction (file limit): %w", commitErr)
@@ -1171,11 +1182,17 @@ func NewNamesIndex(
 						Dur("commitTime", commitElapsed).
 						Msg("database commit took longer than expected")
 				}
-				// Update progress after successful commit
+				// Resume cursor points at the in-progress system so it is redone;
+				// systems sorted before it (including the batched, fully-processed
+				// ones) are treated as complete on resume.
 				if setErr := db.SetLastIndexedSystem(systemID); setErr != nil {
 					log.Error().Err(setErr).Msgf(
 						"failed to set last indexed system to %s after file limit commit", systemID)
 				}
+				for _, s := range pendingSystems {
+					completedSystems[s] = true
+				}
+				pendingSystems = pendingSystems[:0]
 				// NOTE: Do not flush TitleIDs/MediaIDs here — we are still
 				// mid-system. Clearing them would break dedup for remaining
 				// files in this system (multi-disc titles, persistent-mode
@@ -1185,66 +1202,92 @@ func NewNamesIndex(
 			}
 		}
 
-		if batchStarted {
+		// Finalize this system's missing-state and disambiguation inside the
+		// currently open transaction, which is shared across batched systems. The
+		// rows just inserted for this system are flushed (not committed) so the
+		// disambiguation query observes them; the commit itself is deferred to a
+		// batch boundary below so the fsync + checkpoint cost is amortised.
+		systemDBID, found := scanState.SystemIDs[systemID]
+		if found {
+			// A mid-system file-limit commit may have closed the transaction on the
+			// final file; reopen one so the missing-state writes have a home.
+			if !batchStarted {
+				if beginErr := db.BeginTransaction(true); beginErr != nil {
+					return 0, fmt.Errorf("failed to begin transaction to finalize system %s: %w", systemID, beginErr)
+				}
+				batchStarted = true
+			}
+			if flushErr := db.FlushBatchInserters(); flushErr != nil {
+				return 0, fmt.Errorf("failed to flush batch inserts for system %s: %w", systemID, flushErr)
+			}
+			if resetErr := db.ResetMissingFlags([]int{systemDBID}); resetErr != nil {
+				return 0, fmt.Errorf("failed to reset missing flags for system %s: %w", systemID, resetErr)
+			}
+			if len(scanState.MissingMedia) > 0 {
+				if missErr := db.BulkSetMediaMissing(scanState.MissingMedia); missErr != nil {
+					return 0, fmt.Errorf("failed to mark missing media for system %s: %w", systemID, missErr)
+				}
+			}
+			// Refresh stored sibling disambiguation now the system's media, tags, and
+			// missing flags are final and flushed into the transaction. Non-fatal:
+			// stale disambiguation only affects display/ZapScript hints and is
+			// corrected on the next index.
+			if disErr := db.RecomputeSystemDisambiguation(ctx, []int64{int64(systemDBID)}); disErr != nil {
+				log.Warn().Err(disErr).Str("system", systemID).Msg("failed to recompute title disambiguation")
+			}
+			pendingSystems = append(pendingSystems, systemID)
+		} else {
+			// System produced no rows — nothing to commit for it.
+			completedSystems[systemID] = true
+		}
+
+		// Always flush between systems — TitleIDs/MediaIDs are system-scoped and
+		// Populate* re-loads them for the next system. In-memory only; safe to do
+		// with the transaction still open.
+		FlushScanStateMaps(&scanState)
+
+		// Commit at a batch boundary: when accumulated files reach the limit or
+		// this is the last system. This is the only place the fsync + checkpoint is
+		// paid, so a run of small systems shares a single commit.
+		isLastSystem := sysIdx == len(sortedSystems)-1
+		if batchStarted && (filesInBatch >= maxFilesPerTransaction || isLastSystem) {
 			log.Debug().
 				Str("system", systemID).
 				Int("files", filesInBatch).
-				Msg("committing media indexing system transaction")
+				Int("batchedSystems", len(pendingSystems)).
+				Msg("committing media indexing batch")
 			commitStart := time.Now()
 			if commitErr := db.CommitTransaction(); commitErr != nil {
-				return 0, fmt.Errorf("failed to commit system transaction: %w", commitErr)
+				return 0, fmt.Errorf("failed to commit batch transaction: %w", commitErr)
 			}
 			commitElapsed := time.Since(commitStart)
 			log.Debug().
 				Str("system", systemID).
 				Int("files", filesInBatch).
+				Int("batchedSystems", len(pendingSystems)).
 				Dur("commitTime", commitElapsed).
-				Msg("committed system transaction")
+				Msg("committed batch")
 			if commitElapsed > 5*time.Second {
 				log.Warn().
 					Int("files", filesInBatch).
 					Dur("commitTime", commitElapsed).
 					Msg("database commit took longer than expected")
 			}
+			// The cursor points at the last fully-finalized system; systems before
+			// it are complete and it is redone on resume (idempotent).
+			if len(pendingSystems) > 0 {
+				lastDone := pendingSystems[len(pendingSystems)-1]
+				if setErr := db.SetLastIndexedSystem(lastDone); setErr != nil {
+					log.Error().Err(setErr).Msgf("failed to set last indexed system to %s after batch commit", lastDone)
+				}
+				for _, s := range pendingSystems {
+					completedSystems[s] = true
+				}
+				pendingSystems = pendingSystems[:0]
+			}
 			filesInBatch = 0
 			batchStarted = false
 		}
-
-		systemDBID, found := scanState.SystemIDs[systemID]
-		if !found {
-			completedSystems[systemID] = true
-			FlushScanStateMaps(&scanState)
-			continue
-		}
-
-		if beginErr := db.BeginTransaction(false); beginErr != nil {
-			return 0, fmt.Errorf("failed to begin missing-state transaction: %w", beginErr)
-		}
-		if resetErr := db.ResetMissingFlags([]int{systemDBID}); resetErr != nil {
-			return 0, fmt.Errorf("failed to reset missing flags for system %s: %w", systemID, resetErr)
-		}
-		if len(scanState.MissingMedia) > 0 {
-			if missErr := db.BulkSetMediaMissing(scanState.MissingMedia); missErr != nil {
-				return 0, fmt.Errorf("failed to mark missing media for system %s: %w", systemID, missErr)
-			}
-		}
-		// Refresh stored sibling disambiguation now the system's media, tags, and
-		// missing flags are final. Runs in the same transaction so it observes the
-		// missing flags just written. Non-fatal: stale disambiguation only affects
-		// display/ZapScript hints and is corrected on the next index.
-		if disErr := db.RecomputeSystemDisambiguation(ctx, []int64{int64(systemDBID)}); disErr != nil {
-			log.Warn().Err(disErr).Str("system", systemID).Msg("failed to recompute title disambiguation")
-		}
-		if commitErr := db.CommitTransaction(); commitErr != nil {
-			return 0, fmt.Errorf("failed to commit missing-state transaction: %w", commitErr)
-		}
-
-		if setErr := db.SetLastIndexedSystem(systemID); setErr != nil {
-			log.Error().Err(setErr).Msgf("failed to set last indexed system to %s after system completion", systemID)
-		}
-
-		// Mark system as processed only after its missing-state finalization commits.
-		completedSystems[systemID] = true
 
 		systemElapsed := time.Since(systemStartTime)
 		systemMetricsEnd := metrics.Capture(ctx, false)
@@ -1264,10 +1307,6 @@ func NewNamesIndex(
 				Dur("elapsed", systemElapsed).
 				Msg("system indexing took longer than expected - check for slow storage or large directories")
 		}
-
-		// Always flush between systems — TitleIDs/MediaIDs are system-scoped and
-		// Populate* re-loads them for the next system.
-		FlushScanStateMaps(&scanState)
 	}
 
 	logPhaseMetrics("systems")

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -640,6 +640,19 @@ func (m *MockMediaDBI) CommitTransactionWithOptions(options database.Transaction
 	return nil
 }
 
+func (m *MockMediaDBI) FlushBatchInserters() error {
+	// Infrastructure call during indexing; treat as a no-op unless a test sets
+	// an explicit expectation, so callers don't have to wire it up everywhere.
+	if !m.hasExpectedCall("FlushBatchInserters") {
+		return nil
+	}
+	args := m.Called()
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) RollbackTransaction() error {
 	args := m.Called()
 	if err := args.Error(0); err != nil {


### PR DESCRIPTION
- Keep one SQLite transaction open across consecutive systems during media indexing, committing only when accumulated files reach `maxFilesPerTransaction` or at the end of the run, instead of committing once (or twice) per system.
- On slow storage (e.g. MiSTer SD card) each commit costs a fixed fsync + WAL checkpoint regardless of row count, so a library of many small systems previously paid that cost hundreds of times; this collapses it to roughly `total_files / maxFilesPerTransaction` commits.
- Durability is unchanged: `synchronous=FULL`, WAL journal mode, and the `wal_checkpoint(TRUNCATE)` after commit all remain; only the number of commits drops.
- Add `MediaDB.FlushBatchInserters` to flush buffered inserts into the open transaction without committing, so each system's disambiguation reads see its rows while inserts continue across systems.
- Merge each system's missing-state and disambiguation work into the shared transaction, removing the separate per-system commit.
- Advance the crash-resume cursor only at commit boundaries; a power loss mid-batch re-indexes that batch, which is safe because indexing is idempotent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved media library indexing with adaptive batching, reducing unnecessary mid-run commits and improving performance for large collections.
  * Reindexing behavior is more reliable: removed media are now correctly detected and flagged as missing without disrupting remaining files.

* **Tests**
  * Added integration coverage for batched commit behavior across multiple systems, idempotent reindexing, missing-media marking, and large-library mid-batch committing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->