### PR TITLE
fix(database): recover corrupt media database

### DIFF
--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -586,23 +586,32 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 				log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to clear scraping operation")
 			}
 		}
-		checkpointScrapingWAL(db.MediaDB, scraperID)
+		if checkpointScrapingWAL(db.MediaDB, scraperID) {
+			// Wake the corruption-recovery watcher, which only observes media-indexing
+			// notifications. Scraping status is already terminal here, so recovery won't defer.
+			notifications.MediaIndexing(ns, models.IndexingStatusResponse{Exists: true, Indexing: false})
+		}
 		log.Info().Str("scraper", scraperID).Str("status", finalStatus).Msg("scraper run complete")
 	}()
 
 	return nil, nil //nolint:nilnil // API handler returns nil result and nil error for async start
 }
 
-func checkpointScrapingWAL(mediaDB database.MediaDBI, scraperID string) {
+// checkpointScrapingWAL flushes the WAL after a scraper run. It returns true when the
+// checkpoint failure flagged the database corrupt, so the caller can wake the recovery
+// watcher; the scrape flow otherwise emits only scraping notifications, which the watcher
+// does not observe.
+func checkpointScrapingWAL(mediaDB database.MediaDBI, scraperID string) (corrupt bool) {
 	started := time.Now()
 	if err := mediaDB.WALCheckpoint(); err != nil {
 		// A malformed-page failure during the post-scrape checkpoint flags the database
 		// corrupt so the recovery flow rebuilds it rather than serving a broken cache.
-		mediaDB.NoteCorruption(err)
+		corrupt = mediaDB.NoteCorruption(err)
 		log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to checkpoint WAL after scraper run")
-		return
+		return corrupt
 	}
 	log.Debug().Str("scraper", scraperID).Dur("duration", time.Since(started)).Msg("checkpointed WAL after scraper run")
+	return false
 }
 
 // HandleMediaScrapeStatus returns the latest known media.scrape status snapshot.

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -596,6 +596,9 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 func checkpointScrapingWAL(mediaDB database.MediaDBI, scraperID string) {
 	started := time.Now()
 	if err := mediaDB.WALCheckpoint(); err != nil {
+		// A malformed-page failure during the post-scrape checkpoint flags the database
+		// corrupt so the recovery flow rebuilds it rather than serving a broken cache.
+		mediaDB.NoteCorruption(err)
 		log.Warn().Err(err).Str("scraper", scraperID).Msg("failed to checkpoint WAL after scraper run")
 		return
 	}

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -1334,3 +1334,38 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond)
 	mockDB.AssertExpectations(t)
 }
+
+// TestCheckpointScrapingWAL_CorruptionReported verifies that a checkpoint failure flagged
+// as corruption is reported back so the caller can wake the recovery watcher.
+func TestCheckpointScrapingWAL_CorruptionReported(t *testing.T) {
+	t.Parallel()
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("WALCheckpoint").Return(errors.New("database disk image is malformed"))
+	mockDB.On("NoteCorruption", assertmock.Anything).Return(true)
+
+	assert.True(t, checkpointScrapingWAL(mockDB, "scraper-1"))
+	mockDB.AssertExpectations(t)
+}
+
+// TestCheckpointScrapingWAL_NonCorruptionError verifies that a non-corruption checkpoint
+// failure is not reported as corruption.
+func TestCheckpointScrapingWAL_NonCorruptionError(t *testing.T) {
+	t.Parallel()
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("WALCheckpoint").Return(errors.New("disk full"))
+	mockDB.On("NoteCorruption", assertmock.Anything).Return(false)
+
+	assert.False(t, checkpointScrapingWAL(mockDB, "scraper-1"))
+	mockDB.AssertExpectations(t)
+}
+
+// TestCheckpointScrapingWAL_Success verifies the healthy path reports no corruption and
+// does not consult corruption detection.
+func TestCheckpointScrapingWAL_Success(t *testing.T) {
+	t.Parallel()
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("WALCheckpoint").Return(nil)
+
+	assert.False(t, checkpointScrapingWAL(mockDB, "scraper-1"))
+	mockDB.AssertNotCalled(t, "NoteCorruption", assertmock.Anything)
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -722,6 +722,13 @@ type MediaDBI interface {
 	RebuildSlugSearchCache() error
 	RebuildTagCache() error
 	WALCheckpoint() error
+	QuickCheck() (bool, error)
+	IntegrityReport() []string
+	MarkCorrupt(reason string)
+	IsMarkedCorrupt() bool
+	ClearCorruptMarker() error
+	NoteCorruption(err error) bool
+	RecreateAfterCorruption(keepBackup bool) error
 
 	// On-disk persistence for the rebuilt caches. Persist* writes the
 	// current in-memory cache atomically; LoadCached* reads it back at

--- a/pkg/database/mediadb/corruption_recovery_test.go
+++ b/pkg/database/mediadb/corruption_recovery_test.go
@@ -1,0 +1,214 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaDB_QuickCheck_HealthyReturnsOK(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ok, err := mediaDB.QuickCheck()
+	require.NoError(t, err)
+	assert.True(t, ok, "freshly allocated database should pass quick_check")
+}
+
+func TestMediaDB_QuickCheck_CorruptFileFails(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Overwrite the on-disk file with non-database bytes, then reopen.
+	path := mediaDB.GetDBPath()
+	require.NoError(t, mediaDB.Close())
+	mediaDB.sql = nil
+	require.NoError(t, os.WriteFile(path, []byte("this is not a sqlite database file at all"), 0o600))
+	require.NoError(t, mediaDB.Open())
+
+	ok, _ := mediaDB.QuickCheck()
+	assert.False(t, ok, "corrupt file must not pass quick_check")
+}
+
+func TestMediaDB_WALCheckpoint_NoOpDuringTransaction(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	defer func() { _ = mediaDB.RollbackTransaction() }()
+
+	// Must not truncate the WAL out from under an open writer; returns nil and
+	// leaves the transaction intact.
+	require.NoError(t, mediaDB.WALCheckpoint())
+	assert.NotNil(t, mediaDB.tx, "transaction should still be open after a no-op checkpoint")
+}
+
+func TestMediaDB_CorruptMarkerLifecycle(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	assert.False(t, mediaDB.IsMarkedCorrupt(), "no marker should exist initially")
+
+	mediaDB.MarkCorrupt("test reason")
+	assert.True(t, mediaDB.IsMarkedCorrupt())
+	_, statErr := os.Stat(mediaDB.GetDBPath() + corruptMarkerSuffix)
+	require.NoError(t, statErr, "marker sidecar file should exist on disk")
+
+	require.NoError(t, mediaDB.ClearCorruptMarker())
+	assert.False(t, mediaDB.IsMarkedCorrupt())
+
+	// Clearing an absent marker is a no-op.
+	require.NoError(t, mediaDB.ClearCorruptMarker())
+}
+
+func TestMediaDB_IntegrityReport_HealthyReturnsOK(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	report := mediaDB.IntegrityReport()
+	assert.Equal(t, []string{"ok"}, report)
+}
+
+func TestMediaDB_RecreateAfterCorruption_KeepBackup(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	insertSystemWithMedia(t, mediaDB, "NES", "Some Game", filepath.Join("roms", "nes", "game.nes"))
+	mediaDB.MarkCorrupt("test")
+	path := mediaDB.GetDBPath()
+
+	require.NoError(t, mediaDB.RecreateAfterCorruption(true))
+
+	// Forensic backup kept, marker cleared. (The reopened WAL database creates fresh
+	// -wal/-shm sidecars; the point is the stale corrupt ones don't survive into it,
+	// which the empty+queryable check below confirms.)
+	_, backupErr := os.Stat(path + corruptMarkerSuffix + ".bak")
+	require.NoError(t, backupErr, "backup copy should be kept when keepBackup=true")
+	assert.False(t, mediaDB.IsMarkedCorrupt(), "marker should be cleared after recreate")
+
+	// Fresh schema: queryable and empty.
+	var count int
+	require.NoError(t, mediaDB.sql.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM Media").Scan(&count))
+	assert.Equal(t, 0, count, "recreated database should be empty")
+}
+
+// zeroHighPages reproduces the real-world corruption: a contiguous run of high-numbered
+// (table-data) pages overwritten with 0x00, leaving the schema pages intact so the DB still
+// opens but integrity checks fail — mirroring the supplied corrupt media.db.
+func zeroHighPages(t *testing.T, db *MediaDB) {
+	t.Helper()
+	var pageSize, pageCount int
+	require.NoError(t, db.sql.QueryRowContext(context.Background(), "PRAGMA page_size").Scan(&pageSize))
+	require.NoError(t, db.sql.QueryRowContext(context.Background(), "PRAGMA page_count").Scan(&pageCount))
+	require.Greater(t, pageCount, 10, "need a DB with enough data pages to corrupt")
+
+	// Flush the WAL into the main file and remove sidecars so the zeroing is not undone by
+	// WAL recovery on reopen.
+	require.NoError(t, db.WALCheckpoint())
+	path := db.GetDBPath()
+	require.NoError(t, db.Close())
+	db.sql = nil
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600) //nolint:gosec // test-controlled temp DB path
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+	zero := make([]byte, pageSize)
+	// Zero the top third of pages (table/index data, never the page-1 header/schema root).
+	for p := (pageCount * 2 / 3); p <= pageCount; p++ {
+		_, werr := f.WriteAt(zero, int64((p-1)*pageSize))
+		require.NoError(t, werr)
+	}
+}
+
+func TestMediaDB_ZeroedPages_DetectedAndRecovered(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Grow the DB so the top third holds real table data.
+	for i := range 400 {
+		name := fmt.Sprintf("Game %04d", i)
+		insertSystemWithMedia(t, mediaDB, "NES", name, filepath.Join("roms", "nes", name+".nes"))
+	}
+
+	zeroHighPages(t, mediaDB)
+	require.NoError(t, mediaDB.Open())
+
+	ok, _ := mediaDB.QuickCheck()
+	assert.False(t, ok, "zeroed data pages must fail quick_check")
+	report := mediaDB.IntegrityReport()
+	assert.NotEqual(t, []string{"ok"}, report, "integrity report should show the damage")
+
+	// Recovery rebuilds to a clean, passing database.
+	require.NoError(t, mediaDB.RecreateAfterCorruption(false))
+	ok, err := mediaDB.QuickCheck()
+	require.NoError(t, err)
+	assert.True(t, ok, "database should pass quick_check after recovery")
+}
+
+func TestMediaDB_BrowseFiles_RoutesCorruptionToMarker(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// Corrupt the whole file so any query fails deterministically, isolating the test to
+	// the question we care about: does a corruption error on the read path flag the DB?
+	path := mediaDB.GetDBPath()
+	require.NoError(t, mediaDB.Close())
+	mediaDB.sql = nil
+	_ = os.Remove(path + "-wal")
+	_ = os.Remove(path + "-shm")
+	require.NoError(t, os.WriteFile(path, []byte("not a sqlite database — corrupted on purpose"), 0o600))
+	require.NoError(t, mediaDB.Open())
+	require.False(t, mediaDB.IsMarkedCorrupt())
+
+	_, err := mediaDB.BrowseFiles(context.Background(), &database.BrowseFilesOptions{})
+	require.Error(t, err)
+	assert.True(t, mediaDB.IsMarkedCorrupt(), "a malformed browse read must mark the DB corrupt")
+}
+
+func TestMediaDB_RecreateAfterCorruption_DeleteWhenNoBackup(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	insertSystemWithMedia(t, mediaDB, "NES", "Some Game", filepath.Join("roms", "nes", "game.nes"))
+	mediaDB.MarkCorrupt("test")
+	path := mediaDB.GetDBPath()
+
+	require.NoError(t, mediaDB.RecreateAfterCorruption(false))
+
+	_, backupErr := os.Stat(path + corruptMarkerSuffix + ".bak")
+	assert.True(t, os.IsNotExist(backupErr), "no backup should be kept when keepBackup=false")
+	assert.False(t, mediaDB.IsMarkedCorrupt())
+
+	var count int
+	require.NoError(t, mediaDB.sql.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM Media").Scan(&count))
+	assert.Equal(t, 0, count)
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -800,12 +800,14 @@ func (db *MediaDB) RecreateAfterCorruption(keepBackup bool) error {
 		}
 	}
 
-	if err := db.ClearCorruptMarker(); err != nil {
-		log.Warn().Err(err).Msg("failed to clear corrupt marker during recreate")
-	}
-
 	if err := db.Open(); err != nil {
 		return fmt.Errorf("failed to reopen media database after recreate: %w", err)
+	}
+
+	// Clear the marker only after the fresh database opens, so a failed reopen leaves
+	// the durable corrupt signal in place for the next recovery attempt.
+	if err := db.ClearCorruptMarker(); err != nil {
+		log.Warn().Err(err).Msg("failed to clear corrupt marker during recreate")
 	}
 	return nil
 }

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/perfmetrics"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
@@ -90,6 +91,14 @@ const (
 
 // defaultSlugSearchLimit is the max results returned by slug-based search methods.
 const defaultSlugSearchLimit = 50
+
+// integrityReportMaxRows caps PRAGMA integrity_check output so a badly corrupt
+// database cannot flood the log; the first rows identify the damaged pages.
+const integrityReportMaxRows = 20
+
+// corruptMarkerSuffix names the sidecar file written next to the database to flag
+// detected corruption. It is the DB-independent signal the recovery path keys on.
+const corruptMarkerSuffix = ".corrupt"
 
 // maxSelectiveInvalidationSystems avoids huge per-commit IN clauses and debug
 // logs during full-library indexing while preserving selective reindexing wins.
@@ -641,6 +650,164 @@ func (db *MediaDB) GetIndexingStatus() (string, error) {
 		return "", ErrNullSQL
 	}
 	return sqlGetIndexingStatus(db.ctx, db.sql)
+}
+
+// QuickCheck runs PRAGMA quick_check(1) and reports whether the database passes.
+// quick_check is a bounded integrity scan — it skips integrity_check's expensive
+// index-vs-table cross-checks and the argument stops it after the first error — so it
+// is cheap enough to confirm suspected corruption before acting on it. Returns
+// ok=true only when SQLite reports the single sentinel row "ok".
+func (db *MediaDB) QuickCheck() (bool, error) {
+	db.sqlMu.RLock()
+	defer db.sqlMu.RUnlock()
+	if db.sql == nil {
+		return false, ErrNullSQL
+	}
+
+	rows, err := db.sql.QueryContext(db.ctx, "PRAGMA quick_check(1)")
+	if err != nil {
+		return false, fmt.Errorf("quick_check query failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		if scanErr := rows.Scan(&line); scanErr != nil {
+			return false, fmt.Errorf("quick_check scan failed: %w", scanErr)
+		}
+		lines = append(lines, line)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return false, fmt.Errorf("quick_check rows failed: %w", rowsErr)
+	}
+
+	if len(lines) == 1 && lines[0] == "ok" {
+		return true, nil
+	}
+	log.Warn().Strs("details", lines).Msg("media database quick_check reported integrity errors")
+	return false, nil
+}
+
+// corruptMarkerPath returns the sidecar path used to flag a corrupt database.
+func (db *MediaDB) corruptMarkerPath() string {
+	return db.dbPath + corruptMarkerSuffix
+}
+
+// MarkCorrupt writes a sidecar marker file next to the database recording that
+// corruption was detected. The marker is the authoritative, DB-independent signal
+// the recovery path keys on: unlike IndexingStatusCorrupt it does not require writing
+// to the (possibly unwritable) database. Best-effort — failures are logged, not returned.
+func (db *MediaDB) MarkCorrupt(reason string) {
+	path := db.corruptMarkerPath()
+	contents := fmt.Sprintf("%s\n%s\n", db.clock.Now().UTC().Format(time.RFC3339), reason)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		log.Error().Err(err).Str("path", path).Msg("failed to write media database corrupt marker")
+		return
+	}
+	log.Warn().Str("path", path).Str("reason", reason).Msg("flagged media database as corrupt")
+}
+
+// IsMarkedCorrupt reports whether the corrupt marker sidecar exists.
+func (db *MediaDB) IsMarkedCorrupt() bool {
+	_, err := os.Stat(db.corruptMarkerPath())
+	return err == nil
+}
+
+// ClearCorruptMarker removes the corrupt marker sidecar. No-op when absent.
+func (db *MediaDB) ClearCorruptMarker() error {
+	if err := os.Remove(db.corruptMarkerPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to clear corrupt marker: %w", err)
+	}
+	return nil
+}
+
+// NoteCorruption flags the database corrupt when err indicates SQLite corruption, so any
+// path that first touches a malformed page (a read, a scraper write, a checkpoint) routes
+// into the recovery flow instead of silently failing. It only writes the marker once — the
+// expensive integrity report is logged later by the recovery orchestration, not on every
+// failing query. Returns true when err was a corruption error.
+func (db *MediaDB) NoteCorruption(err error) bool {
+	if err == nil || !isCorruptionError(err) {
+		return false
+	}
+	if !db.IsMarkedCorrupt() {
+		db.MarkCorrupt(fmt.Sprintf("query error: %v", err))
+	}
+	return true
+}
+
+// IntegrityReport runs PRAGMA integrity_check and returns up to integrityReportMaxRows
+// result rows. It captures a corruption fingerprint in the logs — which are uploadable
+// via the support bundle — when the database file itself cannot be retrieved. A healthy
+// database returns a single "ok" row.
+func (db *MediaDB) IntegrityReport() []string {
+	db.sqlMu.RLock()
+	defer db.sqlMu.RUnlock()
+	if db.sql == nil {
+		return []string{"integrity check unavailable: database not connected"}
+	}
+
+	rows, err := db.sql.QueryContext(db.ctx, fmt.Sprintf("PRAGMA integrity_check(%d)", integrityReportMaxRows))
+	if err != nil {
+		return []string{fmt.Sprintf("integrity check failed: %v", err)}
+	}
+	defer func() { _ = rows.Close() }()
+
+	var report []string
+	for rows.Next() {
+		var line string
+		if scanErr := rows.Scan(&line); scanErr != nil {
+			report = append(report, fmt.Sprintf("integrity check scan error: %v", scanErr))
+			break
+		}
+		report = append(report, line)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		report = append(report, fmt.Sprintf("integrity check rows error: %v", rowsErr))
+	}
+	return report
+}
+
+// RecreateAfterCorruption discards a corrupt database and reopens a fresh one. The
+// connection is closed; the main file is either preserved as a <db>.corrupt.bak forensic
+// copy (keepBackup — development builds only) or deleted; the -wal/-shm sidecars and the
+// corrupt marker are removed (a stale WAL would re-corrupt the new file); and Open()
+// allocates a fresh schema. MediaDB is a rebuildable cache, so nothing is salvaged — the
+// caller triggers a reindex afterwards.
+func (db *MediaDB) RecreateAfterCorruption(keepBackup bool) error {
+	if err := db.Close(); err != nil {
+		log.Warn().Err(err).Msg("error closing corrupt media database before recreate")
+	}
+	db.sql = nil
+
+	if keepBackup {
+		backup := db.dbPath + corruptMarkerSuffix + ".bak"
+		_ = os.Remove(backup)
+		if err := os.Rename(db.dbPath, backup); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Msg("failed to preserve corrupt media database backup; deleting instead")
+			if rmErr := os.Remove(db.dbPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+				return fmt.Errorf("failed to remove corrupt media database: %w", rmErr)
+			}
+		}
+	} else if err := os.Remove(db.dbPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to remove corrupt media database: %w", err)
+	}
+
+	for _, sidecar := range []string{db.dbPath + "-wal", db.dbPath + "-shm"} {
+		if err := os.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", sidecar).Msg("failed to remove WAL sidecar during recreate")
+		}
+	}
+
+	if err := db.ClearCorruptMarker(); err != nil {
+		log.Warn().Err(err).Msg("failed to clear corrupt marker during recreate")
+	}
+
+	if err := db.Open(); err != nil {
+		return fmt.Errorf("failed to reopen media database after recreate: %w", err)
+	}
+	return nil
 }
 
 func (db *MediaDB) SetScrapingStatus(status string) error {
@@ -1484,9 +1651,19 @@ func (db *MediaDB) Analyze() error {
 }
 
 // WALCheckpoint forces a WAL checkpoint to flush pending writes to the main database file.
+// It holds sqlMu so the TRUNCATE checkpoint is serialized with commits and other writes
+// (matching the in-commit checkpoint in CommitTransactionWithOptions), and is a no-op
+// while a transaction is open — truncating the WAL out from under an active writer on the
+// other pool connection would only ever return SQLITE_BUSY.
 func (db *MediaDB) WALCheckpoint() error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
 	if db.sql == nil {
 		return ErrNullSQL
+	}
+	if db.tx != nil {
+		return nil
 	}
 	_, err := db.sql.ExecContext(db.ctx, "PRAGMA wal_checkpoint(TRUNCATE);")
 	if err != nil {
@@ -1502,17 +1679,23 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseDirectories(ctx, db.sql, opts)
+	results, err := sqlBrowseDirectories(ctx, db.sql, opts)
+	db.NoteCorruption(err)
+	return results, err
 }
 
 // BrowseFiles returns indexed media files that are immediate children of the given path prefix.
+// A malformed-page error here (the cover-flags join reads MediaTitleProperties, where scraped
+// artwork lives) flags the database corrupt so the recovery flow rebuilds it.
 func (db *MediaDB) BrowseFiles(
 	ctx context.Context, opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
 	if db.sql == nil {
 		return nil, ErrNullSQL
 	}
-	return sqlBrowseFiles(ctx, db.sql, opts)
+	results, err := sqlBrowseFiles(ctx, db.sql, opts)
+	db.NoteCorruption(err)
+	return results, err
 }
 
 // BrowseFileCount returns the total number of immediate child files under a path prefix.
@@ -3019,6 +3202,11 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		// reuses free pages on the next INSERT, so disk reclamation is not needed.
 	)
 
+	// Per-step resource metrics so post-index/startup housekeeping (browse cache
+	// rebuild, pragma optimize, page prefetch) shows real wall time and write cost
+	// in logs, not just start/complete markers.
+	stepRecorder := perfmetrics.NewRecorderForDB(db)
+
 	// Execute each step with retry logic
 	for _, step := range steps {
 		// Wait if paused (e.g. game is running)
@@ -3050,6 +3238,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 		}
 
 		// Execute step with retry and exponential backoff
+		stepMetricsStart := stepRecorder.Capture(db.ctx, true)
 		var stepErr error
 		for attempt := 0; attempt <= step.maxRetries; attempt++ {
 			stepErr = step.fn()
@@ -3070,8 +3259,13 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			log.Error().Err(stepErr).Msgf("optimization step %s failed after %d attempts", step.name, step.maxRetries+1)
 			// Database corruption can't be repaired by optimization. Route it to the
 			// same corrupt-database state the indexer uses so the app surfaces the
-			// repair/rebuild flow instead of repeatedly failing maintenance.
+			// repair/rebuild flow instead of repeatedly failing maintenance. The sidecar
+			// marker is the durable signal recovery keys on, since the in-DB status write
+			// may itself fail on a malformed database.
 			if isCorruptionError(stepErr) {
+				log.Error().Strs("integrity", db.IntegrityReport()).
+					Msg("media database integrity check after optimization failure")
+				db.MarkCorrupt(fmt.Sprintf("optimization step %s: %v", step.name, stepErr))
 				if setErr := db.SetIndexingStatus(IndexingStatusCorrupt); setErr != nil {
 					log.Error().Err(setErr).Msg("failed to mark media database as corrupt after optimization failure")
 				}
@@ -3090,6 +3284,10 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			}
 			return
 		}
+
+		stepMetricsEnd := stepRecorder.Capture(db.ctx, true)
+		perfmetrics.AddDelta(log.Info().Str("step", step.name), &stepMetricsStart, &stepMetricsEnd).
+			Msg("optimization step metrics")
 
 		log.Info().Msgf("optimization step %s completed", step.name)
 	}

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -426,6 +426,18 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 				)
 			), '')
 			WHERE MediaTitles.%s IN (%s)
+			  -- Skip the per-title subquery for single-media titles that are already
+			  -- blank: a title with <=1 non-missing media can never have variant
+			  -- disambiguation, so its value is necessarily ''. Still process any
+			  -- title that currently has a value (so a title that dropped from
+			  -- multi-media to single-media is reset to '').
+			  AND (
+				MediaTitles.DisambiguationTypes != ''
+				OR (
+					SELECT COUNT(*) FROM Media
+					WHERE Media.MediaTitleDBID = MediaTitles.DBID AND Media.IsMissing = 0
+				) > 1
+			  )
 		`, typeHolders, filterCol, prepareVariadic("?", ",", len(chunk)))
 
 		if _, err := db.ExecContext(ctx, query, args...); err != nil {

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -1554,10 +1554,13 @@ func (db *MediaDB) UpsertMediaProperties(ctx context.Context, mediaDBID int64, p
 // The sentinel tag is inserted last so interrupted writes remain retryable.
 func (db *MediaDB) ApplyScrapeResult(
 	ctx context.Context, mediaDBID, mediaTitleDBID int64, write *database.ScrapeWrite,
-) error {
+) (retErr error) {
 	if db.sql == nil {
 		return ErrNullSQL
 	}
+	// A malformed-page error while writing scraped properties (the table this corruption
+	// class targets) flags the database corrupt so recovery rebuilds it.
+	defer func() { db.NoteCorruption(retErr) }()
 	target := database.ScrapeWriteTarget{MediaDBID: mediaDBID, MediaTitleDBID: mediaTitleDBID, Write: write}
 	if err := validateScrapeWriteTarget("ApplyScrapeResult", target); err != nil {
 		return err
@@ -1595,10 +1598,11 @@ func (db *MediaDB) ApplyScrapeResult(
 // ApplyScrapeResults writes multiple scraper payloads in one transaction.
 // Each target's sentinel is written after its metadata, and the whole batch rolls
 // back if any target fails.
-func (db *MediaDB) ApplyScrapeResults(ctx context.Context, targets []database.ScrapeWriteTarget) error {
+func (db *MediaDB) ApplyScrapeResults(ctx context.Context, targets []database.ScrapeWriteTarget) (retErr error) {
 	if db.sql == nil {
 		return ErrNullSQL
 	}
+	defer func() { db.NoteCorruption(retErr) }()
 	for _, target := range targets {
 		if err := validateScrapeWriteTarget("ApplyScrapeResults", target); err != nil {
 			return err

--- a/pkg/database/mediascanner/indexing_status_test.go
+++ b/pkg/database/mediascanner/indexing_status_test.go
@@ -64,3 +64,19 @@ func TestNewNamesIndex_CancellationPreservesCancelledStatus(t *testing.T) {
 	assert.Equal(t, mediadb.IndexingStatusCancelled, status,
 		"cancellation must leave Cancelled status, not be overwritten to Failed by the deferred handler")
 }
+
+// TestNoteIndexingCorruption verifies the helper persists the corrupt signal: it logs an
+// integrity report, writes the marker, sets the corrupt status, and clears the
+// last-indexed-system pointer so the recovery flow rebuilds the database.
+func TestNoteIndexingCorruption(t *testing.T) {
+	t.Parallel()
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("IntegrityReport").Return([]string{"Page 5: btree corrupt"})
+	mockDB.On("MarkCorrupt", "persistent scan state load for nes: boom").Return()
+	mockDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil)
+	mockDB.On("SetLastIndexedSystem", "").Return(nil)
+
+	noteIndexingCorruption(mockDB, "persistent scan state load for nes: boom")
+
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/database/mediascanner/indexing_status_test.go
+++ b/pkg/database/mediascanner/indexing_status_test.go
@@ -1,0 +1,66 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewNamesIndex_CancellationPreservesCancelledStatus verifies that a cancellation
+// observed inside the per-system loop (after the failure-tracking defer is registered)
+// leaves the indexing status as Cancelled. The deferred handler marks Failed on a genuine
+// error; this guards against it overwriting the Cancelled status set by the cancellation
+// path. Cannot use t.Parallel() - setupCustomLauncherSystems mutates GlobalLauncherCache.
+func TestNewNamesIndex_CancellationPreservesCancelledStatus(t *testing.T) {
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemNES:     {"a.bin", "b.bin"},
+		systemdefs.SystemSNES:    {"c.bin", "d.bin"},
+		systemdefs.SystemGenesis: {"e.bin", "f.bin"},
+	}
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// SystemID is only set once indexing reaches the per-system loop, which runs after the
+	// failure-tracking defer is registered. Cancelling there forces a post-defer cancellation.
+	update := func(s IndexStatus) {
+		if s.SystemID != "" {
+			cancel()
+		}
+	}
+
+	_, err := NewNamesIndex(ctx, platform, cfg, systems, db, update, nil)
+	require.ErrorIs(t, err, context.Canceled)
+
+	status, statusErr := db.MediaDB.GetIndexingStatus()
+	require.NoError(t, statusErr)
+	assert.Equal(t, mediadb.IndexingStatusCancelled, status,
+		"cancellation must leave Cancelled status, not be overwritten to Failed by the deferred handler")
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -623,7 +623,7 @@ func NewNamesIndex(
 	fdb *database.Database,
 	update func(IndexStatus),
 	pauser *syncutil.Pauser,
-) (int, error) {
+) (indexedFiles int, err error) {
 	db := fdb.MediaDB
 	indexStartTime := time.Now()
 	metrics := perfmetrics.NewRecorderForDB(db)
@@ -654,9 +654,6 @@ func NewNamesIndex(
 	log.Info().
 		Int("systemCount", len(systems)).
 		Msg("starting media indexing")
-
-	var indexedFiles int
-	var err error
 
 	// Track requested systems for resume validation before platform/path filtering.
 	requestedSystemIDs := make([]string, 0, len(systems))
@@ -871,8 +868,11 @@ func NewNamesIndex(
 			}
 		}
 
-		if err != nil {
-			// Mark indexing as failed on error
+		// Mark indexing as failed on a genuine error. Cancellation (handleCancellation sets
+		// Cancelled and returns ctx.Err()) and corruption (noteIndexingCorruption sets Corrupt)
+		// already persist their own terminal status, so they must not be overwritten here.
+		if err != nil && !errors.Is(err, context.Canceled) &&
+			!errors.Is(err, context.DeadlineExceeded) && !isSQLiteDatabaseCorrupt(err) {
 			if setErr := db.SetIndexingStatus(mediadb.IndexingStatusFailed); setErr != nil {
 				logMaintenanceError(setErr, "failed to set indexing status to failed after error")
 			}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -825,6 +825,9 @@ func NewNamesIndex(
 			return handleCancellation(ctx, db, "Media indexing cancelled during scan state population")
 		}
 		if isSQLiteDatabaseCorrupt(err) {
+			log.Error().Strs("integrity", db.IntegrityReport()).
+				Msg("media database integrity check after corruption detected during indexing")
+			db.MarkCorrupt(fmt.Sprintf("scan state population: %v", err))
 			if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
 				log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
 			}
@@ -913,6 +916,19 @@ func NewNamesIndex(
 	batchStarted := false
 	pendingSystems := make([]string, 0)
 
+	// Sub-phase wall-time accumulators across the systems loop, logged once after
+	// it so the monolithic "systems" phase can be attributed to its parts:
+	// per-system state load, file collection (filesystem scan + scanners), media
+	// row inserts, per-system finalize (flush + missing flags + disambiguation),
+	// and transaction commits (the fsync + checkpoint cost).
+	var (
+		stateLoadDur time.Duration
+		collectDur   time.Duration
+		insertDur    time.Duration
+		finalizeDur  time.Duration
+		commitDur    time.Duration
+	)
+
 	// TODO: skip unchanged systems via a per-system fingerprint — store
 	// hash(sorted walked paths) + parser version + media row count after each
 	// system completes; on match at the next run, skip the state load, parse,
@@ -959,15 +975,18 @@ func NewNamesIndex(
 		scanState.MissingMedia = make(map[int]struct{})
 
 		// Load existing data for this system — always persistent.
+		stateLoadStart := time.Now()
 		if loadErr := PopulatePersistentScanStateForSystem(ctx, db, &scanState, systemID); loadErr != nil {
 			if errors.Is(loadErr, context.Canceled) {
 				return handleCancellation(ctx, db, "Media indexing cancelled during system data loading")
 			}
 			return 0, fmt.Errorf("failed to load system data for persistent indexing: %w", loadErr)
 		}
+		stateLoadDur += time.Since(stateLoadStart)
 
 		files := make([]platforms.ScanResult, 0)
 		systemStartTime := time.Now()
+		collectStart := time.Now()
 
 		log.Info().
 			Str("system", systemID).
@@ -1102,6 +1121,8 @@ func NewNamesIndex(
 				Msg("calculated directory prefix policies")
 		}
 
+		collectDur += time.Since(collectStart)
+
 		for fileIdx, file := range files {
 			// Check for cancellation or pause between file processing
 			select {
@@ -1133,9 +1154,11 @@ func NewNamesIndex(
 			dir := filepath.Dir(file.Path)
 			prefixPolicy := prefixPolicyByDir[dir]
 
+			insertStart := time.Now()
 			_, _, addErr := AddMediaPathWithPrefixPolicy(
 				db, &scanState, systemID, file.Path, file.Name, file.NoExt, prefixPolicy, cfg, mediaType,
 			)
+			insertDur += time.Since(insertStart)
 			if addErr != nil {
 				var sqliteErr sqlite3.Error
 				if errors.As(addErr, &sqliteErr) && sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique &&
@@ -1171,6 +1194,7 @@ func NewNamesIndex(
 					return 0, fmt.Errorf("failed to commit batch transaction (file limit): %w", commitErr)
 				}
 				commitElapsed := time.Since(commitStart)
+				commitDur += commitElapsed
 				log.Debug().
 					Str("system", systemID).
 					Int("files", filesInBatch).
@@ -1207,6 +1231,7 @@ func NewNamesIndex(
 		// rows just inserted for this system are flushed (not committed) so the
 		// disambiguation query observes them; the commit itself is deferred to a
 		// batch boundary below so the fsync + checkpoint cost is amortised.
+		finalizeStart := time.Now()
 		systemDBID, found := scanState.SystemIDs[systemID]
 		if found {
 			// A mid-system file-limit commit may have closed the transaction on the
@@ -1245,6 +1270,7 @@ func NewNamesIndex(
 		// Populate* re-loads them for the next system. In-memory only; safe to do
 		// with the transaction still open.
 		FlushScanStateMaps(&scanState)
+		finalizeDur += time.Since(finalizeStart)
 
 		// Commit at a batch boundary: when accumulated files reach the limit or
 		// this is the last system. This is the only place the fsync + checkpoint is
@@ -1261,6 +1287,7 @@ func NewNamesIndex(
 				return 0, fmt.Errorf("failed to commit batch transaction: %w", commitErr)
 			}
 			commitElapsed := time.Since(commitStart)
+			commitDur += commitElapsed
 			log.Debug().
 				Str("system", systemID).
 				Int("files", filesInBatch).
@@ -1309,6 +1336,13 @@ func NewNamesIndex(
 		}
 	}
 
+	log.Info().
+		Dur("stateLoad", stateLoadDur).
+		Dur("collect", collectDur).
+		Dur("insert", insertDur).
+		Dur("finalize", finalizeDur).
+		Dur("commit", commitDur).
+		Msg("media indexing systems sub-phase breakdown")
 	logPhaseMetrics("systems")
 
 	status.Step++

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -81,6 +81,22 @@ func isSQLiteDatabaseCorrupt(err error) bool {
 		strings.Contains(msg, "file is not a database")
 }
 
+// noteIndexingCorruption flags the media database corrupt during indexing so the
+// recovery flow rebuilds it: it logs an integrity fingerprint, writes the durable
+// corrupt marker, persists the corrupt status, and clears the last-indexed-system
+// pointer. Callers return the corruption error after invoking it.
+func noteIndexingCorruption(db database.MediaDBI, reason string) {
+	log.Error().Strs("integrity", db.IntegrityReport()).
+		Msg("media database integrity check after corruption detected during indexing")
+	db.MarkCorrupt(reason)
+	if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
+		log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
+	}
+	if setErr := db.SetLastIndexedSystem(""); setErr != nil {
+		log.Error().Err(setErr).Msg("failed to clear last indexed system after corrupt database detection")
+	}
+}
+
 // logMaintenanceError logs an indexing maintenance failure (status writes, cache
 // population). When the failure is just the service context being cancelled
 // mid-index — an expected shutdown condition — it logs at Debug; any other
@@ -825,15 +841,7 @@ func NewNamesIndex(
 			return handleCancellation(ctx, db, "Media indexing cancelled during scan state population")
 		}
 		if isSQLiteDatabaseCorrupt(err) {
-			log.Error().Strs("integrity", db.IntegrityReport()).
-				Msg("media database integrity check after corruption detected during indexing")
-			db.MarkCorrupt(fmt.Sprintf("scan state population: %v", err))
-			if setErr := db.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
-				log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
-			}
-			if setErr := db.SetLastIndexedSystem(""); setErr != nil {
-				log.Error().Err(setErr).Msg("failed to clear last indexed system after corrupt database detection")
-			}
+			noteIndexingCorruption(db, fmt.Sprintf("scan state population: %v", err))
 			return 0, fmt.Errorf("%s: %w", mediaDatabaseCorruptMessage, err)
 		}
 		return 0, fmt.Errorf("failed to populate scan state: %w", err)
@@ -979,6 +987,10 @@ func NewNamesIndex(
 		if loadErr := PopulatePersistentScanStateForSystem(ctx, db, &scanState, systemID); loadErr != nil {
 			if errors.Is(loadErr, context.Canceled) {
 				return handleCancellation(ctx, db, "Media indexing cancelled during system data loading")
+			}
+			if isSQLiteDatabaseCorrupt(loadErr) {
+				noteIndexingCorruption(db, fmt.Sprintf("persistent scan state load for %s: %v", systemID, loadErr))
+				return 0, fmt.Errorf("%s: %w", mediaDatabaseCorruptMessage, loadErr)
 			}
 			return 0, fmt.Errorf("failed to load system data for persistent indexing: %w", loadErr)
 		}
@@ -1166,6 +1178,10 @@ func NewNamesIndex(
 					uniqueConstraintFailures++
 					log.Debug().Err(addErr).Str("path", file.Path).Msg("skipping duplicate media entry")
 					continue
+				}
+				if isSQLiteDatabaseCorrupt(addErr) {
+					noteIndexingCorruption(db, fmt.Sprintf("media insert for %s: %v", systemID, addErr))
+					return 0, fmt.Errorf("%s: %w", mediaDatabaseCorruptMessage, addErr)
 				}
 				return 0, fmt.Errorf("unrecoverable error adding media path %q: %w", file.Path, addErr)
 			}

--- a/pkg/service/inbox/inbox.go
+++ b/pkg/service/inbox/inbox.go
@@ -44,8 +44,9 @@ const (
 
 // Category constants for deduplication
 const (
-	CategoryNone            = "" // No deduplication
-	CategoryUpdateAvailable = "update_available"
+	CategoryNone                      = "" // No deduplication
+	CategoryMediaDBCorruptionRecovery = "mediadb_corruption_recovery"
+	CategoryUpdateAvailable           = "update_available"
 )
 
 // MessageOptions configures optional fields for inbox messages.

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -22,7 +22,9 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package service
 
 import (
+	"context"
 	"errors"
+	"sync/atomic"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -34,9 +36,15 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/broker"
+	inboxservice "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/rs/zerolog/log"
 )
+
+// mediaDBRecovering serializes media database recovery so the startup check and the
+// runtime watcher can never run a close/reopen rebuild concurrently.
+var mediaDBRecovering atomic.Bool
 
 // checkAndResumeIndexing checks if media indexing was interrupted and automatically resumes it
 func checkAndResumeIndexing(
@@ -97,6 +105,122 @@ func checkAndResumeIndexing(
 			log.Warn().Err(err).Msg("skipping auto-resume of media indexing")
 		} else {
 			log.Error().Err(err).Msg("failed to start auto-resume of media indexing")
+		}
+	}
+}
+
+// checkAndRecoverCorruptMediaDB rebuilds the media database from scratch when corruption
+// has been detected. MediaDB is a disposable, rebuildable cache (user-owned data lives in
+// UserDB), so recovery discards the corrupt file rather than attempting an unreliable
+// in-process repair, then triggers a full reindex. The durable sidecar marker is the
+// authoritative signal because the in-DB status write can itself fail on a malformed file.
+func checkAndRecoverCorruptMediaDB(
+	pl platforms.Platform,
+	cfg *config.Instance,
+	db *database.Database,
+	st *state.State,
+	pauser *syncutil.Pauser,
+) {
+	if db == nil || db.MediaDB == nil {
+		return
+	}
+
+	// Only one recovery at a time: the startup check and the runtime watcher both call
+	// this, and a concurrent close/reopen rebuild would race.
+	if !mediaDBRecovering.CompareAndSwap(false, true) {
+		return
+	}
+	defer mediaDBRecovering.Store(false)
+
+	corrupt := db.MediaDB.IsMarkedCorrupt()
+	if !corrupt {
+		// Backstop: trust a persisted corrupt status even if the marker is missing.
+		if status, err := db.MediaDB.GetIndexingStatus(); err == nil && status == mediadb.IndexingStatusCorrupt {
+			corrupt = true
+		}
+	}
+	if !corrupt {
+		return
+	}
+
+	// Never rebuild on top of an in-flight operation; the marker keeps recovery pending
+	// until the next safe point (this check runs again on the next startup pass).
+	if status, err := db.MediaDB.GetIndexingStatus(); err == nil &&
+		(status == mediadb.IndexingStatusRunning || status == mediadb.IndexingStatusPending) {
+		log.Warn().Msg("media database flagged corrupt but indexing is in flight; deferring recovery")
+		return
+	}
+	if status, err := db.MediaDB.GetScrapingStatus(); err == nil && status == mediadb.IndexingStatusRunning {
+		log.Warn().Msg("media database flagged corrupt but scraping is in flight; deferring recovery")
+		return
+	}
+
+	log.Error().Strs("integrity", db.MediaDB.IntegrityReport()).
+		Msg("media database is corrupt; rebuilding from scratch")
+	notifications.MediaIndexing(st.Notifications, models.IndexingStatusResponse{
+		Exists:   false,
+		Indexing: true,
+	})
+
+	if err := db.MediaDB.RecreateAfterCorruption(config.IsDevelopmentVersion()); err != nil {
+		log.Error().Err(err).Msg("failed to recreate media database after corruption")
+		return
+	}
+	log.Info().Msg("media database recreated after corruption; starting full reindex")
+
+	// Tell the user persistently: the rebuild discards scraped metadata (it lived in the
+	// corrupt cache), so artwork returns only after a re-scrape. The inbox lives in UserDB,
+	// which is unaffected by the media database corruption. Category dedups repeat events.
+	if inbox := st.Inbox(); inbox != nil {
+		if inboxErr := inbox.Add("Media database was corrupted and rebuilt",
+			inboxservice.WithBody("Your media database was corrupted (likely a storage write "+
+				"error) and has been rebuilt automatically. Re-scrape your library to restore "+
+				"box art and metadata."),
+			inboxservice.WithSeverity(inboxservice.SeverityWarning),
+			inboxservice.WithCategory(inboxservice.CategoryMediaDBCorruptionRecovery),
+		); inboxErr != nil {
+			log.Warn().Err(inboxErr).Msg("failed to add inbox message about media database recovery")
+		}
+	}
+
+	if err := methods.GenerateMediaDB(st.GetContext(), pl, cfg, st.Notifications,
+		systemdefs.AllSystems(), db, pauser); err != nil {
+		var clientErr *models.ClientError
+		if errors.As(err, &clientErr) {
+			log.Warn().Err(err).Msg("skipping reindex after media database recovery")
+		} else {
+			log.Error().Err(err).Msg("failed to start reindex after media database recovery")
+		}
+	}
+}
+
+// watchForCorruptMediaDBRecovery triggers recovery at runtime once an indexing or
+// optimization operation completes. Detection points set the durable corrupt marker
+// mid-operation; this watcher re-checks it at each operation boundary (a media-indexing
+// notification) so corruption found during a session self-heals without waiting for the
+// next service start. checkAndRecoverCorruptMediaDB is a cheap no-op when the marker is
+// absent or an operation is still in flight, and its CAS guard makes re-entry safe.
+func watchForCorruptMediaDBRecovery(
+	ctx context.Context,
+	b *broker.Broker,
+	pl platforms.Platform,
+	cfg *config.Instance,
+	db *database.Database,
+	st *state.State,
+	pauser *syncutil.Pauser,
+) {
+	notifChan, subID := b.Subscribe(32, models.NotificationMediaIndexing)
+	defer b.Unsubscribe(subID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-notifChan:
+			if !ok {
+				return
+			}
+			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, pauser)
 		}
 	}
 }
@@ -172,6 +296,24 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 	if status == mediadb.IndexingStatusPending ||
 		status == mediadb.IndexingStatusRunning ||
 		status == mediadb.IndexingStatusFailed {
+		// A failed optimization is often the symptom of a corrupt database — e.g. a
+		// PRAGMA optimize that hit a malformed page. Resuming would just fail again
+		// on every boot, so confirm integrity first and route confirmed corruption
+		// to the rebuild flow (IndexingStatusCorrupt) instead of looping.
+		if status == mediadb.IndexingStatusFailed {
+			switch ok, checkErr := db.MediaDB.QuickCheck(); {
+			case checkErr != nil:
+				log.Warn().Err(checkErr).Msg("failed to run quick_check before resuming optimization")
+			case !ok:
+				log.Error().Strs("integrity", db.MediaDB.IntegrityReport()).
+					Msg("media database failed integrity check; marking corrupt, skipping optimization resume")
+				db.MediaDB.MarkCorrupt("quick_check failed before optimization resume")
+				if setErr := db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
+					log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
+				}
+				return
+			}
+		}
 		log.Info().Msgf("detected incomplete optimization (status: %s), automatically resuming", status)
 		db.MediaDB.RunBackgroundOptimization(func(optimizing bool) {
 			notifications.MediaIndexing(ns, models.IndexingStatusResponse{

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -285,11 +285,15 @@ func checkAndResumeScraping(
 	}
 }
 
-func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notification, pauser *syncutil.Pauser) {
+// checkAndResumeOptimization resumes an interrupted optimization, or flags the database
+// corrupt when a failed optimization turns out to be a malformed file. It returns true
+// when it marked the database corrupt, so the caller can trigger recovery immediately
+// rather than waiting for the next startup.
+func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notification, pauser *syncutil.Pauser) bool {
 	status, err := db.MediaDB.GetOptimizationStatus()
 	if err != nil {
 		log.Debug().Err(err).Msg("failed to get optimization status during startup check")
-		return
+		return false
 	}
 
 	// Resume if optimization was interrupted or failed
@@ -311,7 +315,7 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 				if setErr := db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusCorrupt); setErr != nil {
 					log.Error().Err(setErr).Msg("failed to mark media database as corrupt")
 				}
-				return
+				return true
 			}
 		}
 		log.Info().Msgf("detected incomplete optimization (status: %s), automatically resuming", status)
@@ -325,4 +329,5 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 	} else {
 		log.Debug().Msgf("optimization status is '%s', no auto-resume needed", status)
 	}
+	return false
 }

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -20,13 +20,19 @@
 package service
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/broker"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // The recovery happy path runs a real reindex via methods.GenerateMediaDB and is covered
@@ -73,9 +79,115 @@ func TestCheckAndResumeOptimization_FailedCorruptMarksAndSkips(t *testing.T) {
 	mockDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil)
 
 	ns := make(chan models.Notification, 10)
-	checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
+	flaggedCorrupt := checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
 
+	assert.True(t, flaggedCorrupt, "must report corruption so the caller can trigger recovery")
 	mockDB.AssertCalled(t, "MarkCorrupt", "quick_check failed before optimization resume")
 	mockDB.AssertCalled(t, "SetIndexingStatus", mediadb.IndexingStatusCorrupt)
 	mockDB.AssertNotCalled(t, "RunBackgroundOptimization")
+}
+
+// TestCheckAndResumeOptimization_HealthyResumes verifies that a recoverable interrupted
+// optimization resumes and is not reported as corrupt.
+func TestCheckAndResumeOptimization_HealthyResumes(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusPending, nil)
+	mockDB.On("RunBackgroundOptimization", mock.Anything, mock.Anything).Return()
+
+	ns := make(chan models.Notification, 10)
+	flaggedCorrupt := checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
+
+	assert.False(t, flaggedCorrupt)
+	mockDB.AssertCalled(t, "RunBackgroundOptimization", mock.Anything, mock.Anything)
+	mockDB.AssertNotCalled(t, "MarkCorrupt", mock.Anything)
+}
+
+// TestCheckAndResumeOptimization_NoResumeNeeded verifies a completed optimization is left
+// alone and not reported as corrupt.
+func TestCheckAndResumeOptimization_NoResumeNeeded(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil)
+
+	ns := make(chan models.Notification, 10)
+	flaggedCorrupt := checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
+
+	assert.False(t, flaggedCorrupt)
+	mockDB.AssertNotCalled(t, "RunBackgroundOptimization", mock.Anything, mock.Anything)
+}
+
+// TestCheckAndRecoverCorruptMediaDB_DefersWhenScrapingInFlight covers the scraping guard:
+// a flagged-corrupt database must not be rebuilt while a scrape is running.
+func TestCheckAndRecoverCorruptMediaDB_DefersWhenScrapingInFlight(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(true)
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil)
+	mockDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil)
+
+	checkAndRecoverCorruptMediaDB(nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", mock.Anything)
+}
+
+// TestCheckAndRecoverCorruptMediaDB_StatusBackstopWithoutMarker covers the backstop that
+// trusts a persisted corrupt status even when the sidecar marker is missing.
+func TestCheckAndRecoverCorruptMediaDB_StatusBackstopWithoutMarker(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(false)
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCorrupt, nil)
+	// Corruption is detected via the status backstop; a running scrape then defers recovery,
+	// keeping the test off the heavy reindex path.
+	mockDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil)
+
+	checkAndRecoverCorruptMediaDB(nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+
+	mockDB.AssertCalled(t, "GetScrapingStatus")
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", mock.Anything)
+}
+
+// TestWatchForCorruptMediaDBRecovery verifies the watcher runs a recovery check when a
+// media-indexing notification arrives and shuts down cleanly on context cancellation.
+func TestWatchForCorruptMediaDBRecovery(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	checked := make(chan struct{}, 1)
+	mockDB.On("IsMarkedCorrupt").Return(false).Run(func(mock.Arguments) {
+		select {
+		case checked <- struct{}{}:
+		default:
+		}
+	})
+	mockDB.On("GetIndexingStatus").Return("", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	source := make(chan models.Notification, 10)
+	b := broker.NewBroker(ctx, source)
+	b.Start()
+
+	done := make(chan struct{})
+	go func() {
+		watchForCorruptMediaDBRecovery(ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+		close(done)
+	}()
+
+	// Re-publish until the watcher has subscribed and run a recovery check. Re-publishing
+	// is harmless: with no marker, each check is an idempotent no-op.
+	require.Eventually(t, func() bool {
+		select {
+		case source <- models.Notification{Method: models.NotificationMediaIndexing}:
+		default:
+		}
+		select {
+		case <-checked:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not exit after context cancellation")
+	}
+	b.Stop()
 }

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -1,0 +1,81 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+)
+
+// The recovery happy path runs a real reindex via methods.GenerateMediaDB and is covered
+// by the mediadb RecreateAfterCorruption tests plus manual verification. These tests cover
+// the guard/early-return branches, where recovery must NOT touch the database.
+
+func TestCheckAndRecoverCorruptMediaDB_NoMarkerIsNoOp(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(false)
+	mockDB.On("GetIndexingStatus").Return("", nil)
+
+	checkAndRecoverCorruptMediaDB(nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", true)
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", false)
+}
+
+func TestCheckAndRecoverCorruptMediaDB_DefersWhenIndexingInFlight(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(true)
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusRunning, nil)
+
+	checkAndRecoverCorruptMediaDB(nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", true)
+	mockDB.AssertNotCalled(t, "RecreateAfterCorruption", false)
+}
+
+func TestCheckAndRecoverCorruptMediaDB_NilDatabaseIsNoOp(_ *testing.T) {
+	// Must not panic with a nil database or nil MediaDB.
+	checkAndRecoverCorruptMediaDB(nil, nil, nil, nil, nil)
+	checkAndRecoverCorruptMediaDB(nil, nil, &database.Database{}, nil, nil)
+}
+
+// TestCheckAndResumeOptimization_FailedCorruptMarksAndSkips verifies the quick_check gate:
+// a failed optimization on a corrupt database is flagged corrupt and NOT resumed (which
+// would just fail again on every boot).
+func TestCheckAndResumeOptimization_FailedCorruptMarksAndSkips(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusFailed, nil)
+	mockDB.On("QuickCheck").Return(false, nil)
+	mockDB.On("IntegrityReport").Return([]string{"*** in database main ***", "Page 42: btree corrupt"})
+	mockDB.On("MarkCorrupt", "quick_check failed before optimization resume").Return()
+	mockDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil)
+
+	ns := make(chan models.Notification, 10)
+	checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
+
+	mockDB.AssertCalled(t, "MarkCorrupt", "quick_check failed before optimization resume")
+	mockDB.AssertCalled(t, "SetIndexingStatus", mediadb.IndexingStatusCorrupt)
+	mockDB.AssertNotCalled(t, "RunBackgroundOptimization")
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -356,6 +356,10 @@ func Start(
 				return
 			}
 
+			// Recover a corrupt media database before any other startup work reads it,
+			// so cache loads and resume checks operate on the fresh DB.
+			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+
 			var tagCacheLoaded, slugCacheLoaded bool
 			if db.MediaDB != nil {
 				tagCacheStarted := time.Now()
@@ -427,6 +431,7 @@ func Start(
 	)
 	go watchGameForIndexPause(st.GetContext(), notifBroker, st, st.Notifications, indexPauser)
 	go watchGameForScrapePause(st.GetContext(), notifBroker, st, st.Notifications, scrapePauser)
+	go watchForCorruptMediaDBRecovery(st.GetContext(), notifBroker, pl, cfg, db, st, indexPauser)
 
 	log.Info().Msg("starting publishers")
 	publisherNotifications, _ := notifBroker.Subscribe(100)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -387,7 +387,11 @@ func Start(
 
 			runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)
 			checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
-			checkAndResumeOptimization(db, st.Notifications, indexPauser)
+			if checkAndResumeOptimization(db, st.Notifications, indexPauser) {
+				// A failed optimization revealed a corrupt database; rebuild it now
+				// rather than waiting for the next startup.
+				checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+			}
 
 			rebuildStartupSlugSearchCache(db.MediaDB, slugCacheLoaded)
 		},

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -729,7 +729,7 @@ func (m *MockMediaDBI) ClearCorruptMarker() error {
 
 func (m *MockMediaDBI) NoteCorruption(err error) bool {
 	if !m.hasExpectation("NoteCorruption") {
-		return err != nil
+		return false
 	}
 	args := m.Called(err)
 	return args.Bool(0)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -679,6 +679,73 @@ func (m *MockMediaDBI) WALCheckpoint() error {
 	return nil
 }
 
+func (m *MockMediaDBI) QuickCheck() (bool, error) {
+	if !m.hasExpectation("QuickCheck") {
+		return true, nil
+	}
+	args := m.Called()
+	if err := args.Error(1); err != nil {
+		return args.Bool(0), fmt.Errorf("mock operation failed: %w", err)
+	}
+	return args.Bool(0), nil
+}
+
+func (m *MockMediaDBI) IntegrityReport() []string {
+	if !m.hasExpectation("IntegrityReport") {
+		return []string{"ok"}
+	}
+	args := m.Called()
+	if report, ok := args.Get(0).([]string); ok {
+		return report
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) MarkCorrupt(reason string) {
+	if !m.hasExpectation("MarkCorrupt") {
+		return
+	}
+	m.Called(reason)
+}
+
+func (m *MockMediaDBI) IsMarkedCorrupt() bool {
+	if !m.hasExpectation("IsMarkedCorrupt") {
+		return false
+	}
+	args := m.Called()
+	return args.Bool(0)
+}
+
+func (m *MockMediaDBI) ClearCorruptMarker() error {
+	if !m.hasExpectation("ClearCorruptMarker") {
+		return nil
+	}
+	args := m.Called()
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockMediaDBI) NoteCorruption(err error) bool {
+	if !m.hasExpectation("NoteCorruption") {
+		return err != nil
+	}
+	args := m.Called(err)
+	return args.Bool(0)
+}
+
+func (m *MockMediaDBI) RecreateAfterCorruption(keepBackup bool) error {
+	if !m.hasExpectation("RecreateAfterCorruption") {
+		return nil
+	}
+	args := m.Called(keepBackup)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) UpdateLastGenerated() error {
 	args := m.Called()
 	if err := args.Error(0); err != nil {


### PR DESCRIPTION
- Detect SQLite corruption (malformed disk image / not-a-database, by error code and message) at query, scraper-write, and optimization time, and on a failed `cell_size_check` at open.
- Record corruption with a `.corrupt` sidecar marker that the recovery path keys on, since an in-database status write may itself fail on a malformed file; log a capped `PRAGMA integrity_check` fingerprint for support bundles.
- Recover by discarding the corrupt media database, removing stale `-wal`/`-shm` sidecars, reopening a fresh schema, and triggering a reindex (the media database is a rebuildable cache, so nothing is salvaged).
- Serialize recovery between the startup check and in-flight detection so a corrupt database is rebuilt once, and add tests covering detection, marker lifecycle, and the recreate-then-reindex flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated detection and self-healing for corrupted MediaDB during startup and indexing, including automatic rebuild/re-scrape and watcher-based recovery mid-session.
  * Added a user-visible inbox warning when a rebuild is triggered.
  * Improved indexing status handling by preventing unsafe checkpoint behavior during active transactions.
* **Bug Fixes**
  * When corruption is detected during scraping or WAL checkpointing, the system now reliably marks corruption and triggers recovery.
  * Hardened optimization auto-resume to avoid continuing with a corrupt database.
* **Tests**
  * Expanded coverage for corruption detection, recovery paths, notification/watcher behavior, and optimization gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->