### PR TITLE
feat(database): store favourites and launcher overrides in user.db

### DIFF
--- a/pkg/api/methods/media_meta_update.go
+++ b/pkg/api/methods/media_meta_update.go
@@ -76,7 +76,13 @@ func HandleMediaMetaUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 
 	row := resolved[0].Row
 	if patch.LauncherOverrideSet {
+		// Write the durable truth (UserDB) before the media.db projection. If the
+		// projection write fails the truth is still saved and the next reindex
+		// re-materializes it.
 		if patch.LauncherOverride == nil {
+			if udErr := setMediaUserLauncherOverride(&env, row.System.SystemID, row.Path, ""); udErr != nil {
+				return nil, udErr
+			}
 			if err := clearMediaLauncherOverride(&env, row.DBID); err != nil {
 				return nil, err
 			}
@@ -84,6 +90,9 @@ func HandleMediaMetaUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 			launcherID, err := resolveLauncherOverrideID(&env, row.System.SystemID, *patch.LauncherOverride)
 			if err != nil {
 				return nil, err
+			}
+			if udErr := setMediaUserLauncherOverride(&env, row.System.SystemID, row.Path, launcherID); udErr != nil {
+				return nil, udErr
 			}
 			if err := setMediaLauncherOverride(&env, row.DBID, launcherID); err != nil {
 				return nil, err

--- a/pkg/api/methods/media_meta_update_test.go
+++ b/pkg/api/methods/media_meta_update_test.go
@@ -37,15 +37,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMediaMetaUpdateEnv(mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+func makeMediaMetaUpdateEnv(t *testing.T, mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+	t.Helper()
 	launcherCache := &phelpers.LauncherCache{}
 	launcherCache.InitializeFromSlice([]platforms.Launcher{
 		{ID: "RetroArch", SystemID: "NES"},
 		{ID: "OtherSystem", SystemID: "SNES"},
 	})
+	userDB, cleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(cleanup)
 	return requests.RequestEnv{
 		Context:       context.Background(),
-		Database:      &database.Database{MediaDB: mockMediaDB},
+		Database:      &database.Database{MediaDB: mockMediaDB, UserDB: userDB},
 		LauncherCache: launcherCache,
 		Params:        []byte(params),
 	}
@@ -103,7 +106,7 @@ func TestHandleMediaMetaUpdate_SetsLauncherOverride(t *testing.T) {
 	}})
 
 	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`,
+		t, mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`,
 	))
 	require.NoError(t, err)
 
@@ -140,7 +143,7 @@ func TestHandleMediaMetaUpdate_SetsLauncherOverrideFromPlatformWhenCacheMissing(
 		TypeTag: launcherOverridePropertyTypeTag(),
 		Text:    "RetroArch",
 	}})
-	env := makeMediaMetaUpdateEnv(mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`)
+	env := makeMediaMetaUpdateEnv(t, mockDB, `{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`)
 	env.LauncherCache = nil
 	env.Platform = mockPlatform
 
@@ -170,7 +173,7 @@ func TestHandleMediaMetaUpdate_ClearsLauncherOverride(t *testing.T) {
 	expectMediaMetaUpdateResponse(mockDB, &row, nil)
 
 	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
+		t, mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
 	))
 	require.NoError(t, err)
 
@@ -189,7 +192,7 @@ func TestHandleMediaMetaUpdate_RejectsWrongSystemLauncher(t *testing.T) {
 		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
 
 	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"launcherOverride":"OtherSystem"}}`,
+		t, mockDB, `{"mediaId":1,"media":{"launcherOverride":"OtherSystem"}}`,
 	))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not support system")
@@ -205,7 +208,7 @@ func TestHandleMediaMetaUpdate_RejectsUnknownLauncher(t *testing.T) {
 		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
 
 	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"launcherOverride":"Missing"}}`,
+		t, mockDB, `{"mediaId":1,"media":{"launcherOverride":"Missing"}}`,
 	))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "launcher not found")
@@ -224,7 +227,7 @@ func TestHandleMediaMetaUpdate_ClearIgnoresMissingPropertyTag(t *testing.T) {
 	expectMediaMetaUpdateResponse(mockDB, &row, nil)
 
 	result, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
+		t, mockDB, `{"mediaId":1,"media":{"launcherOverride":null}}`,
 	))
 	require.NoError(t, err)
 
@@ -255,7 +258,7 @@ func TestHandleMediaMetaUpdate_RejectsMissingOrInvalidMediaPatch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockDB := testhelpers.NewMockMediaDBI()
-			_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(mockDB, tt.params))
+			_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(t, mockDB, tt.params))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 			mockDB.AssertExpectations(t)
@@ -268,7 +271,7 @@ func TestHandleMediaMetaUpdate_RejectsUnsupportedMediaField(t *testing.T) {
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	_, err := HandleMediaMetaUpdate(makeMediaMetaUpdateEnv(
-		mockDB, `{"mediaId":1,"media":{"unknown":"value"}}`,
+		t, mockDB, `{"mediaId":1,"media":{"unknown":"value"}}`,
 	))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported media field")

--- a/pkg/api/methods/media_tags_update.go
+++ b/pkg/api/methods/media_tags_update.go
@@ -80,6 +80,16 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 
 	row := resolved[0].Row
 	resolveDuration := time.Since(resolveStarted)
+
+	// Write the durable truth (UserDB) before the media.db projection. add/remove
+	// are restricted to user:favorite, and media.db applies removes before adds,
+	// so the net favourite state is "any add present". If the projection write
+	// below fails the truth is still saved and the next reindex re-materializes it.
+	favorite := len(add) > 0
+	if udErr := setMediaUserFavorite(&env, row.System.SystemID, row.Path, favorite); udErr != nil {
+		return nil, udErr
+	}
+
 	updateStarted := time.Now()
 	if updateErr := updateMediaUserTags(env.Database.MediaDB, row.DBID, remove, add); updateErr != nil {
 		return nil, updateErr

--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -39,10 +39,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMediaTagsUpdateEnv(mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+func makeMediaTagsUpdateEnv(t *testing.T, mockMediaDB *testhelpers.MockMediaDBI, params string) requests.RequestEnv {
+	t.Helper()
+	userDB, cleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(cleanup)
 	return requests.RequestEnv{
 		Context:  context.Background(),
-		Database: &database.Database{MediaDB: mockMediaDB},
+		Database: &database.Database{MediaDB: mockMediaDB, UserDB: userDB},
 		Params:   []byte(params),
 	}
 }
@@ -76,7 +79,7 @@ func TestHandleMediaTagsUpdate_AddsFavoriteTag(t *testing.T) {
 	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
 		Return([]database.TagInfo{}, nil).Once()
 
-	result, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	result, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
 	require.NoError(t, err)
 
 	resp, ok := result.(models.TagsResponse)
@@ -89,7 +92,7 @@ func TestHandleMediaTagsUpdate_RejectsSearchOperators(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["~user:favorite"]}`))
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["~user:favorite"]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tag operators are not allowed")
 	mockDB.AssertExpectations(t)
@@ -99,7 +102,7 @@ func TestHandleMediaTagsUpdate_RejectsEmptyTags(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":[" "]}`))
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":[" "]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "tag cannot be empty")
 	mockDB.AssertExpectations(t)
@@ -109,7 +112,7 @@ func TestHandleMediaTagsUpdate_RejectsUnsupportedTags(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["genre:platform"]}`))
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["genre:platform"]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only user:favorite can be mutated")
 	mockDB.AssertExpectations(t)
@@ -126,7 +129,7 @@ func TestHandleMediaTagsUpdate_RollsBackWhenAddFails(t *testing.T) {
 		Return(database.TagType{}, errors.New("tag type insert failed")).Once()
 	mockDB.On("RollbackTransaction").Return(nil).Once()
 
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to find or insert tag type")
 	mockDB.AssertExpectations(t)
@@ -149,7 +152,7 @@ func TestHandleMediaTagsUpdate_RollsBackWhenCommitFails(t *testing.T) {
 	mockDB.On("CommitTransactionWithOptions", commitOptions).Return(errors.New("commit failed")).Once()
 	mockDB.On("RollbackTransaction").Return(nil).Once()
 
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
+	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to commit media tag update transaction")
 	mockDB.AssertExpectations(t)
@@ -168,9 +171,11 @@ func TestHandleMediaTagsUpdate_RealMediaDBFavoriteFlow(t *testing.T) {
 	favoriteID := mediaIDs[0]
 	otherID := mediaIDs[1]
 
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
 	baseEnv := requests.RequestEnv{
 		Context:  ctx,
-		Database: &database.Database{MediaDB: mediaDB},
+		Database: &database.Database{MediaDB: mediaDB, UserDB: userDB},
 	}
 
 	addParams := fmt.Sprintf(`{"mediaId":%d,"add":["user:favorite"]}`, favoriteID)

--- a/pkg/api/methods/media_user_data.go
+++ b/pkg/api/methods/media_user_data.go
@@ -1,0 +1,47 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+)
+
+// setMediaUserFavorite records the favourite intent for a media path in UserDB,
+// the source of truth; callers then materialize the media.db projection. The
+// write is column-scoped and atomic so it cannot clobber a concurrent launcher
+// override edit on the same path.
+func setMediaUserFavorite(env *requests.RequestEnv, systemID, path string, favorite bool) error {
+	if err := env.Database.UserDB.SetMediaUserFavorite(systemID, path, favorite); err != nil {
+		return fmt.Errorf("failed to set media user favorite: %w", err)
+	}
+	return nil
+}
+
+// setMediaUserLauncherOverride records the launcher-override intent for a media
+// path in UserDB. An empty launcherID clears the override. See
+// setMediaUserFavorite for the concurrency guarantee.
+func setMediaUserLauncherOverride(env *requests.RequestEnv, systemID, path, launcherID string) error {
+	if err := env.Database.UserDB.SetMediaUserLauncherOverride(systemID, path, launcherID); err != nil {
+		return fmt.Errorf("failed to set media user launcher override: %w", err)
+	}
+	return nil
+}

--- a/pkg/api/methods/media_user_data_test.go
+++ b/pkg/api/methods/media_user_data_test.go
@@ -1,0 +1,153 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// favouriteRow is a resolved media row carrying the (SystemID, Path) key the
+// UserDB write needs.
+func favouriteRow(path string) database.MediaFullRow {
+	return database.MediaFullRow{
+		Media:  database.Media{DBID: 1, Path: path},
+		Title:  database.MediaTitle{DBID: 10},
+		System: database.System{DBID: 100, SystemID: "NES", Name: "NES"},
+	}
+}
+
+// TestMediaTagsUpdate_PersistsUserDBTruthWhenProjectionFails proves the truth-first
+// ordering: the UserDB favourite is saved even though the media.db projection write
+// then fails, so the next reindex can re-materialize it.
+func TestMediaTagsUpdate_PersistsUserDBTruthWhenProjectionFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	userDB, cleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(cleanup)
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: favouriteRow(path)}, nil).Once()
+	mockDB.On("BeginTransaction", false).Return(errors.New("projection boom")).Once()
+
+	env := requests.RequestEnv{
+		Context:  ctx,
+		Database: &database.Database{MediaDB: mockDB, UserDB: userDB},
+		Params:   []byte(`{"mediaId":1,"add":["user:favorite"]}`),
+	}
+	_, err := HandleMediaTagsUpdate(env)
+	require.Error(t, err)
+
+	data, found, getErr := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, getErr)
+	require.True(t, found, "UserDB truth must persist despite projection failure")
+	assert.True(t, data.IsFavorite)
+	mockDB.AssertExpectations(t)
+}
+
+// TestMediaMetaUpdate_PersistsUserDBTruthWhenProjectionFails proves the same for the
+// launcher-override path.
+func TestMediaMetaUpdate_PersistsUserDBTruthWhenProjectionFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	userDB, cleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(cleanup)
+
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{{ID: "RetroArch", SystemID: "NES"}})
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
+		Return(map[int64]database.MediaFullRow{1: favouriteRow(path)}, nil).Once()
+	mockDB.On("FindOrInsertTagType", database.TagType{
+		Type:        string(tags.TagTypeProperty),
+		IsExclusive: false,
+	}).Return(database.TagType{}, errors.New("projection boom")).Once()
+
+	env := requests.RequestEnv{
+		Context:       ctx,
+		Database:      &database.Database{MediaDB: mockDB, UserDB: userDB},
+		LauncherCache: launcherCache,
+		Params:        []byte(`{"mediaId":1,"media":{"launcherOverride":"retroarch"}}`),
+	}
+	_, err := HandleMediaMetaUpdate(env)
+	require.Error(t, err)
+
+	data, found, getErr := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, getErr)
+	require.True(t, found, "UserDB truth must persist despite projection failure")
+	assert.Equal(t, "RetroArch", data.LauncherOverride)
+	mockDB.AssertExpectations(t)
+}
+
+// TestMediaTagsUpdate_UserDBTruthAddThenRemove verifies the favourite truth is
+// written on add and deleted on remove, exercised against real databases.
+func TestMediaTagsUpdate_UserDBTruthAddThenRemove(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	gamePath := filepath.Join("roms", "NES", "Favorite Game.nes")
+	mediaIDs := addTestMediaPaths(t, mediaDB, gamePath)
+
+	baseEnv := requests.RequestEnv{
+		Context:  ctx,
+		Database: &database.Database{MediaDB: mediaDB, UserDB: userDB},
+	}
+
+	_, err := HandleMediaTagsUpdate(withParams(&baseEnv,
+		fmt.Sprintf(`{"mediaId":%d,"add":["user:favorite"]}`, mediaIDs[0])))
+	require.NoError(t, err)
+
+	data, found, err := userDB.GetMediaUserData("NES", gamePath)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, data.IsFavorite)
+
+	_, err = HandleMediaTagsUpdate(withParams(&baseEnv,
+		fmt.Sprintf(`{"mediaId":%d,"remove":["user:favorite"]}`, mediaIDs[0])))
+	require.NoError(t, err)
+
+	_, found, err = userDB.GetMediaUserData("NES", gamePath)
+	require.NoError(t, err)
+	assert.False(t, found, "row with no favourite and no override is deleted")
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -172,6 +172,23 @@ type MediaFullRow struct {
 	Title MediaTitle
 }
 
+// MediaUserData is the source-of-truth record for user-authored data about a
+// single media path: whether it is a favourite and any per-game launcher
+// override. It lives in UserDB (durable, power-loss safe) and is materialized
+// into media.db's MediaTags/MediaProperties projection both on edit and on
+// reindex. Keyed by (SystemID, Path) because a Media row's DBID is not stable
+// across a full media.db rebuild. A row with IsFavorite false and an empty
+// LauncherOverride carries no user intent and should be deleted rather than kept.
+type MediaUserData struct {
+	SystemID         string
+	Path             string
+	LauncherOverride string
+	DBID             int64
+	CreatedAt        int64
+	UpdatedAt        int64
+	IsFavorite       bool
+}
+
 // MediaPathID identifies a Media row by its system ID and path, used for batch
 // media-ID resolution of API responses.
 type MediaPathID struct {
@@ -696,6 +713,12 @@ type UserDBI interface {
 	UpdateMapping(id int64, m *Mapping) error
 	GetAllMappings() ([]Mapping, error)
 	GetEnabledMappings() ([]Mapping, error)
+	GetMediaUserData(systemID, path string) (MediaUserData, bool, error)
+	SetMediaUserFavorite(systemID, path string, favorite bool) error
+	SetMediaUserLauncherOverride(systemID, path, launcherID string) error
+	UpsertMediaUserData(data *MediaUserData) error
+	DeleteMediaUserData(systemID, path string) error
+	ListMediaUserData() ([]MediaUserData, error)
 	UpdateZapLinkHost(host string, zapscript int) error
 	GetZapLinkHost(host string) (bool, bool, error)
 	GetSupportedZapLinkHosts() ([]string, error)
@@ -909,6 +932,9 @@ type MediaDBI interface {
 	GetAllMedia() ([]Media, error)
 	GetAllTags() ([]Tag, error)
 	GetAllTagTypes() ([]TagType, error)
+	// GetExistingMediaUserData returns user-authored data (favourites, launcher
+	// overrides) already stored in media.db, for the one-time UserDB backfill.
+	GetExistingMediaUserData(ctx context.Context) ([]MediaUserData, error)
 
 	// Optimized JOIN query methods for populating scan state
 	GetTitlesWithSystems() ([]TitleWithSystem, error)

--- a/pkg/database/mediadb/media_user_data.go
+++ b/pkg/database/mediadb/media_user_data.go
@@ -1,0 +1,147 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/rs/zerolog/log"
+)
+
+type mediaUserDataKey struct {
+	systemID string
+	path     string
+}
+
+// GetExistingMediaUserData reads user-authored data already materialized in
+// media.db — favourites (user:favorite MediaTags) and launcher overrides
+// (launcher-override MediaProperties) — and returns it as MediaUserData rows
+// keyed by (SystemID, Path). It exists so a one-time startup backfill can seed
+// UserDB from versions that wrote this data only to media.db. A row carries
+// whichever of IsFavorite / LauncherOverride applies; both may be set.
+func (db *MediaDB) GetExistingMediaUserData(ctx context.Context) ([]database.MediaUserData, error) {
+	conn := db.sql.Load()
+	if conn == nil {
+		return nil, ErrNullSQL
+	}
+
+	merged := make(map[mediaUserDataKey]*database.MediaUserData)
+	if err := scanExistingFavorites(ctx, conn, merged); err != nil {
+		return nil, err
+	}
+	if err := scanExistingLauncherOverrides(ctx, conn, merged); err != nil {
+		return nil, err
+	}
+
+	result := make([]database.MediaUserData, 0, len(merged))
+	for _, entry := range merged {
+		result = append(result, *entry)
+	}
+	return result, nil
+}
+
+func mergedEntry(merged map[mediaUserDataKey]*database.MediaUserData, k mediaUserDataKey) *database.MediaUserData {
+	entry := merged[k]
+	if entry == nil {
+		entry = &database.MediaUserData{SystemID: k.systemID, Path: k.path}
+		merged[k] = entry
+	}
+	return entry
+}
+
+func scanExistingFavorites(
+	ctx context.Context, conn *sql.DB, merged map[mediaUserDataKey]*database.MediaUserData,
+) error {
+	// Tags are stored in their padded form (see sql_tags.go), so match that.
+	favTag := tags.PadTagValue(string(tags.TagUserFavorite))
+	rows, err := conn.QueryContext(ctx, `
+		SELECT s.SystemID, m.Path
+		FROM MediaTags mt
+		JOIN Tags t ON mt.TagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		JOIN Media m ON mt.MediaDBID = m.DBID
+		JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE tt.Type = ? AND t.Tag = ?
+	`, string(tags.TagTypeUser), favTag)
+	if err != nil {
+		return fmt.Errorf("failed to query existing favourites: %w", err)
+	}
+	defer closeRows(rows)
+
+	for rows.Next() {
+		var k mediaUserDataKey
+		if scanErr := rows.Scan(&k.systemID, &k.path); scanErr != nil {
+			return fmt.Errorf("failed to scan existing favourite: %w", scanErr)
+		}
+		mergedEntry(merged, k).IsFavorite = true
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return fmt.Errorf("failed to iterate existing favourites: %w", rowsErr)
+	}
+	return nil
+}
+
+func scanExistingLauncherOverrides(
+	ctx context.Context, conn *sql.DB, merged map[mediaUserDataKey]*database.MediaUserData,
+) error {
+	// Tags are stored in their padded form (see sql_tags.go), so match that.
+	overrideTag := tags.PadTagValue(string(tags.TagPropertyLauncherOverride))
+	rows, err := conn.QueryContext(ctx, `
+		SELECT s.SystemID, m.Path, mp.Text
+		FROM MediaProperties mp
+		JOIN Tags t ON mp.TypeTagDBID = t.DBID
+		JOIN TagTypes tt ON t.TypeDBID = tt.DBID
+		JOIN Media m ON mp.MediaDBID = m.DBID
+		JOIN Systems s ON m.SystemDBID = s.DBID
+		WHERE tt.Type = ? AND t.Tag = ?
+	`, string(tags.TagTypeProperty), overrideTag)
+	if err != nil {
+		return fmt.Errorf("failed to query existing launcher overrides: %w", err)
+	}
+	defer closeRows(rows)
+
+	for rows.Next() {
+		var (
+			k    mediaUserDataKey
+			text string
+		)
+		if scanErr := rows.Scan(&k.systemID, &k.path, &text); scanErr != nil {
+			return fmt.Errorf("failed to scan existing launcher override: %w", scanErr)
+		}
+		if text == "" {
+			continue
+		}
+		mergedEntry(merged, k).LauncherOverride = text
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return fmt.Errorf("failed to iterate existing launcher overrides: %w", rowsErr)
+	}
+	return nil
+}
+
+func closeRows(rows *sql.Rows) {
+	if closeErr := rows.Close(); closeErr != nil {
+		log.Warn().Err(closeErr).Msg("failed to close sql rows")
+	}
+}

--- a/pkg/database/mediadb/media_user_data_test.go
+++ b/pkg/database/mediadb/media_user_data_test.go
@@ -1,0 +1,113 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetExistingMediaUserData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	favPath := filepath.Join("roms", "NES", "Fav.nes")
+	overridePath := filepath.Join("roms", "NES", "Override.nes")
+	plainPath := filepath.Join("roms", "NES", "Plain.nes")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	system, err := mediaDB.InsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{SystemDBID: system.DBID, Slug: "t", Name: "T"})
+	require.NoError(t, err)
+
+	insertMedia := func(path string) database.Media {
+		m, insErr := mediaDB.InsertMedia(database.Media{
+			MediaTitleDBID: title.DBID, SystemDBID: system.DBID, Path: path,
+		})
+		require.NoError(t, insErr)
+		return m
+	}
+	favMedia := insertMedia(favPath)
+	overrideMedia := insertMedia(overridePath)
+	insertMedia(plainPath)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Favourite on favMedia.
+	userType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type: string(tags.TagTypeUser), IsExclusive: tags.IsExclusiveType(tags.TagTypeUser),
+	})
+	require.NoError(t, err)
+	favTag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: userType.DBID, Tag: string(tags.TagUserFavorite)})
+	require.NoError(t, err)
+	_, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{MediaDBID: favMedia.DBID, TagDBID: favTag.DBID})
+	require.NoError(t, err)
+
+	// Launcher override on overrideMedia.
+	propType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type: string(tags.TagTypeProperty), IsExclusive: tags.IsExclusiveType(tags.TagTypeProperty),
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.FindOrInsertTag(database.Tag{
+		TypeDBID: propType.DBID, Tag: string(tags.TagPropertyLauncherOverride),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, overrideMedia.DBID, []database.MediaProperty{{
+		TypeTag: tags.PropertyTypeTag(tags.TagPropertyLauncherOverride),
+		Text:    "RetroArch",
+	}}))
+
+	result, err := mediaDB.GetExistingMediaUserData(ctx)
+	require.NoError(t, err)
+
+	got := make(map[string]database.MediaUserData, len(result))
+	for _, r := range result {
+		got[r.Path] = r
+	}
+	require.Len(t, got, 2, "only favourited/overridden media are returned")
+
+	assert.True(t, got[favPath].IsFavorite)
+	assert.Empty(t, got[favPath].LauncherOverride)
+	assert.Equal(t, "NES", got[favPath].SystemID)
+
+	assert.False(t, got[overridePath].IsFavorite)
+	assert.Equal(t, "RetroArch", got[overridePath].LauncherOverride)
+
+	_, plainPresent := got[plainPath]
+	assert.False(t, plainPresent, "media with no user data is not returned")
+}
+
+func TestGetExistingMediaUserDataEmpty(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	result, err := mediaDB.GetExistingMediaUserData(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -1402,6 +1402,18 @@ func NewNamesIndex(
 	}
 	logPhaseMetrics("update_last_generated")
 
+	// Re-materialize user-owned data (favourites, launcher overrides) from UserDB
+	// onto the freshly built media.db, before the caches below are populated so
+	// they reflect it. Best-effort: a failure here only means the projection is
+	// stale until the next reindex; the truth in UserDB is unaffected.
+	t0 = time.Now()
+	if applied, reapplyErr := reapplyMediaUserData(ctx, db, fdb.UserDB); reapplyErr != nil {
+		log.Error().Err(reapplyErr).Msg("failed to re-apply media user data")
+	} else {
+		log.Info().Dur("elapsed", time.Since(t0)).Int("applied", applied).Msg("re-apply media user data complete")
+	}
+	logPhaseMetrics("reapply_media_user_data")
+
 	status.Phase = PhaseBuildingCaches
 	update(status)
 

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -407,6 +407,7 @@ func TestNewNamesIndex_SuccessfulResume(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock basic database operations - no Truncate() for successful resume
@@ -698,6 +699,7 @@ func TestNewNamesIndex_ResumeSystemNotFound(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock basic database operations - no special fallback in this scenario
@@ -866,6 +868,7 @@ func TestNewNamesIndex_FailedIndexingRecovery(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock basic database operations - fallback to fresh start
@@ -960,6 +963,7 @@ func TestNewNamesIndex_DatabaseErrorDuringResume(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock indexing state methods with database error
@@ -1033,6 +1037,7 @@ func TestSelectiveIndexing_ResumeWithDifferentSystems(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock basic database operations - should fall back to fresh start when systems differ
@@ -1143,6 +1148,7 @@ func TestSelectiveIndexing_EmptySystemsList(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	mockMediaDB.On("TruncateSystems", []string{}).Return(nil).Maybe()
@@ -1226,6 +1232,7 @@ func TestNewNamesIndex_TransactionCoverage(t *testing.T) {
 
 	// Setup database mocks
 	mockUserDB := &testhelpers.MockUserDBI{}
+	mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
 	mockMediaDB := &testhelpers.MockMediaDBI{}
 
 	// Mock basic database operations

--- a/pkg/database/mediascanner/reapply_user_data.go
+++ b/pkg/database/mediascanner/reapply_user_data.go
@@ -1,0 +1,159 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/rs/zerolog/log"
+)
+
+// reapplyMediaUserData re-materializes the media.db projection (favourite tags
+// and launcher-override properties) from the UserDB source of truth after the
+// media rows have been (re)built. UserDB owns this data so that a wiped or
+// rebuilt media.db can be reconstructed; on an incremental reindex the rows
+// already exist and the writes are idempotent no-ops.
+//
+// Writes use the same media.db primitives as the live edit handlers, so the
+// projection is identical. It is add-only: live edits keep media.db in sync when
+// a favourite/override is removed, so re-apply never needs to delete. Rows whose
+// system or path is not currently indexed are harmless orphans and are skipped.
+func reapplyMediaUserData(
+	ctx context.Context, db database.MediaDBI, userDB database.UserDBI,
+) (int, error) {
+	rows, err := userDB.ListMediaUserData()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list media user data: %w", err)
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+
+	favTagDBID, err := ensureFavoriteTag(db)
+	if err != nil {
+		return 0, err
+	}
+	if err := ensureLauncherOverrideTag(db); err != nil {
+		return 0, err
+	}
+	overrideTypeTag := tags.PropertyTypeTag(tags.TagPropertyLauncherOverride)
+
+	bySystem := make(map[string][]database.MediaUserData)
+	for _, row := range rows {
+		bySystem[row.SystemID] = append(bySystem[row.SystemID], row)
+	}
+
+	applied := 0
+	for systemID, items := range bySystem {
+		system, sysErr := db.FindSystemBySystemID(systemID)
+		if errors.Is(sysErr, sql.ErrNoRows) {
+			continue // system not indexed; harmless orphans
+		}
+		if sysErr != nil {
+			return applied, fmt.Errorf("failed to resolve system %q: %w", systemID, sysErr)
+		}
+
+		paths := make([]string, 0, len(items))
+		for i := range items {
+			paths = append(paths, items[i].Path)
+		}
+		mediaByPath, mErr := db.FindMediaBySystemAndPaths(ctx, system.DBID, paths)
+		if mErr != nil {
+			return applied, fmt.Errorf("failed to look up media for system %q: %w", systemID, mErr)
+		}
+
+		for i := range items {
+			item := items[i]
+			media, ok := mediaByPath[item.Path]
+			if !ok {
+				continue // path not indexed; harmless orphan
+			}
+			wrote := false
+			if item.IsFavorite {
+				if _, fErr := db.FindOrInsertMediaTag(database.MediaTag{
+					MediaDBID: media.DBID,
+					TagDBID:   favTagDBID,
+				}); fErr != nil {
+					return applied, fmt.Errorf("failed to re-apply favourite for %q: %w", item.Path, fErr)
+				}
+				wrote = true
+			}
+			if item.LauncherOverride != "" {
+				if pErr := db.UpsertMediaProperties(ctx, media.DBID, []database.MediaProperty{{
+					TypeTag: overrideTypeTag,
+					Text:    item.LauncherOverride,
+				}}); pErr != nil {
+					return applied, fmt.Errorf("failed to re-apply launcher override for %q: %w", item.Path, pErr)
+				}
+				wrote = true
+			}
+			if wrote {
+				applied++
+			}
+		}
+	}
+
+	log.Debug().Int("rows", len(rows)).Int("applied", applied).Msg("re-applied media user data")
+	return applied, nil
+}
+
+// ensureFavoriteTag finds or inserts the canonical user:favorite tag and returns
+// its DBID so per-media favourite tags can be written.
+func ensureFavoriteTag(db database.MediaDBI) (int64, error) {
+	tagType, err := db.FindOrInsertTagType(database.TagType{
+		Type:        string(tags.TagTypeUser),
+		IsExclusive: tags.IsExclusiveType(tags.TagTypeUser),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to find or insert user tag type: %w", err)
+	}
+	tagRow, err := db.FindOrInsertTag(database.Tag{
+		TypeDBID: tagType.DBID,
+		Tag:      string(tags.TagUserFavorite),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to find or insert favourite tag: %w", err)
+	}
+	return tagRow.DBID, nil
+}
+
+// ensureLauncherOverrideTag finds or inserts the canonical
+// property:launcher-override tag so UpsertMediaProperties can resolve it.
+func ensureLauncherOverrideTag(db database.MediaDBI) error {
+	tagType, err := db.FindOrInsertTagType(database.TagType{
+		Type:        string(tags.TagTypeProperty),
+		IsExclusive: tags.IsExclusiveType(tags.TagTypeProperty),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to find or insert property tag type: %w", err)
+	}
+	if _, err := db.FindOrInsertTag(database.Tag{
+		TypeDBID: tagType.DBID,
+		Tag:      string(tags.TagPropertyLauncherOverride),
+	}); err != nil {
+		return fmt.Errorf("failed to find or insert launcher override tag: %w", err)
+	}
+	return nil
+}

--- a/pkg/database/mediascanner/reapply_user_data_test.go
+++ b/pkg/database/mediascanner/reapply_user_data_test.go
@@ -1,0 +1,161 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func reapplyScanState() *database.ScanState {
+	return &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+}
+
+func TestReapplyMediaUserData(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	favPath := filepath.Join("roms", "NES", "Fav.nes")
+	overridePath := filepath.Join("roms", "NES", "Override.nes")
+	bothPath := filepath.Join("roms", "NES", "Both.nes")
+	plainPath := filepath.Join("roms", "NES", "Plain.nes")
+
+	// Build a freshly indexed media.db with no user data yet.
+	state := reapplyScanState()
+	require.NoError(t, SeedCanonicalTags(mediaDB, state))
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	for _, p := range []string{favPath, overridePath, bothPath, plainPath} {
+		_, _, err := AddMediaPath(mediaDB, state, "NES", p, "", false, false, nil, "")
+		require.NoError(t, err)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Seed UserDB truth, including orphans whose path/system is not indexed.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: favPath, IsFavorite: true,
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: overridePath, LauncherOverride: "RetroArch",
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: bothPath, IsFavorite: true, LauncherOverride: "RetroArch",
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: filepath.Join("roms", "NES", "Ghost.nes"), IsFavorite: true,
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "SNES", Path: filepath.Join("roms", "SNES", "Ghost.sfc"), IsFavorite: true,
+	}))
+
+	applied, err := reapplyMediaUserData(ctx, mediaDB, userDB)
+	require.NoError(t, err)
+	assert.Equal(t, 3, applied, "only indexed rows are materialized; orphans are skipped")
+
+	assert.True(t, mediaHasFavorite(ctx, t, mediaDB, "NES", favPath))
+	assert.Empty(t, mediaLauncherOverride(ctx, t, mediaDB, "NES", favPath))
+
+	assert.False(t, mediaHasFavorite(ctx, t, mediaDB, "NES", overridePath))
+	assert.Equal(t, "RetroArch", mediaLauncherOverride(ctx, t, mediaDB, "NES", overridePath))
+
+	assert.True(t, mediaHasFavorite(ctx, t, mediaDB, "NES", bothPath))
+	assert.Equal(t, "RetroArch", mediaLauncherOverride(ctx, t, mediaDB, "NES", bothPath))
+
+	assert.False(t, mediaHasFavorite(ctx, t, mediaDB, "NES", plainPath))
+	assert.Empty(t, mediaLauncherOverride(ctx, t, mediaDB, "NES", plainPath))
+
+	// Re-running is idempotent: no duplicate tags, no error.
+	applied2, err := reapplyMediaUserData(ctx, mediaDB, userDB)
+	require.NoError(t, err)
+	assert.Equal(t, 3, applied2)
+	assert.True(t, mediaHasFavorite(ctx, t, mediaDB, "NES", favPath))
+	assert.Equal(t, "RetroArch", mediaLauncherOverride(ctx, t, mediaDB, "NES", bothPath))
+}
+
+func TestReapplyMediaUserDataEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	applied, err := reapplyMediaUserData(ctx, mediaDB, userDB)
+	require.NoError(t, err)
+	assert.Equal(t, 0, applied)
+}
+
+func mediaDBIDForPath(
+	ctx context.Context, t *testing.T, db database.MediaDBI, systemID, path string,
+) int64 {
+	t.Helper()
+	system, err := db.FindSystemBySystemID(systemID)
+	require.NoError(t, err)
+	media, err := db.FindMediaBySystemAndPath(ctx, system.DBID, path)
+	require.NoError(t, err)
+	require.NotNil(t, media)
+	return media.DBID
+}
+
+func mediaHasFavorite(ctx context.Context, t *testing.T, db database.MediaDBI, systemID, path string) bool {
+	t.Helper()
+	tagInfos, err := db.GetMediaTagsByMediaDBID(ctx, mediaDBIDForPath(ctx, t, db, systemID, path))
+	require.NoError(t, err)
+	for _, ti := range tagInfos {
+		if ti.Type == string(tags.TagTypeUser) && ti.Tag == string(tags.TagUserFavorite) {
+			return true
+		}
+	}
+	return false
+}
+
+func mediaLauncherOverride(ctx context.Context, t *testing.T, db database.MediaDBI, systemID, path string) string {
+	t.Helper()
+	props, err := db.GetMediaPropertyMetadata(ctx, mediaDBIDForPath(ctx, t, db, systemID, path))
+	require.NoError(t, err)
+	want := tags.PropertyTypeTag(tags.TagPropertyLauncherOverride)
+	for _, p := range props {
+		if p.TypeTag == want {
+			return p.Text
+		}
+	}
+	return ""
+}

--- a/pkg/database/userdb/media_user_data.go
+++ b/pkg/database/userdb/media_user_data.go
@@ -1,0 +1,257 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
+)
+
+// GetMediaUserData returns the user-data row for a media path. The bool is false
+// when no row exists for the (systemID, path) key, in which case the media has no
+// favourite or launcher-override intent recorded.
+func (db *UserDB) GetMediaUserData(systemID, path string) (database.MediaUserData, bool, error) {
+	return sqlGetMediaUserData(db.ctx, db.sql.Load(), systemID, path)
+}
+
+// UpsertMediaUserData inserts or updates the user-data row for (SystemID, Path).
+// CreatedAt is set on insert only; UpdatedAt is set on every write.
+func (db *UserDB) UpsertMediaUserData(data *database.MediaUserData) error {
+	return sqlUpsertMediaUserData(db.ctx, db.sql.Load(), data, time.Now().Unix())
+}
+
+// SetMediaUserFavorite records (or clears) the favourite intent for a media
+// path without disturbing any launcher override on the same row. The write is a
+// column-scoped upsert plus a conditional delete, run in one transaction so two
+// concurrent edits to the same path (e.g. a favourite toggle and a launcher
+// override) cannot read-modify-write over each other.
+func (db *UserDB) SetMediaUserFavorite(systemID, path string, favorite bool) error {
+	return sqlSetMediaUserFavorite(db.ctx, db.sql.Load(), systemID, path, favorite, time.Now().Unix())
+}
+
+// SetMediaUserLauncherOverride records (or clears, when launcherID is empty) the
+// launcher-override intent for a media path without disturbing the favourite
+// flag on the same row. See SetMediaUserFavorite for the concurrency guarantee.
+func (db *UserDB) SetMediaUserLauncherOverride(systemID, path, launcherID string) error {
+	return sqlSetMediaUserLauncherOverride(db.ctx, db.sql.Load(), systemID, path, launcherID, time.Now().Unix())
+}
+
+// DeleteMediaUserData removes the user-data row for (SystemID, Path). Deleting a
+// row that does not exist is not an error.
+func (db *UserDB) DeleteMediaUserData(systemID, path string) error {
+	return sqlDeleteMediaUserData(db.ctx, db.sql.Load(), systemID, path)
+}
+
+// ListMediaUserData returns every user-data row, used by the reindex re-apply
+// step to re-materialize the media.db projection.
+func (db *UserDB) ListMediaUserData() ([]database.MediaUserData, error) {
+	return sqlListMediaUserData(db.ctx, db.sql.Load())
+}
+
+func sqlGetMediaUserData(
+	ctx context.Context, db *sql.DB, systemID, path string,
+) (database.MediaUserData, bool, error) {
+	var row database.MediaUserData
+	q, err := db.PrepareContext(ctx, `
+		select
+		DBID, SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		from MediaUserData
+		where SystemID = ? and Path = ?;
+	`)
+	if err != nil {
+		return row, false, fmt.Errorf("failed to prepare media user data select statement: %w", err)
+	}
+	defer func() {
+		if closeErr := q.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+	err = q.QueryRowContext(ctx, systemID, path).Scan(
+		&row.DBID,
+		&row.SystemID,
+		&row.Path,
+		&row.IsFavorite,
+		&row.LauncherOverride,
+		&row.CreatedAt,
+		&row.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return database.MediaUserData{}, false, nil
+	}
+	if err != nil {
+		return row, false, fmt.Errorf("failed to scan media user data row: %w", err)
+	}
+	return row, true, nil
+}
+
+func sqlUpsertMediaUserData(
+	ctx context.Context, db *sql.DB, data *database.MediaUserData, now int64,
+) error {
+	stmt, err := db.PrepareContext(ctx, `
+		insert into MediaUserData(
+			SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		) values (?, ?, ?, ?, ?, ?)
+		on conflict(SystemID, Path) do update set
+			IsFavorite = excluded.IsFavorite,
+			LauncherOverride = excluded.LauncherOverride,
+			UpdatedAt = excluded.UpdatedAt;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to prepare media user data upsert statement: %w", err)
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+	_, err = stmt.ExecContext(ctx,
+		data.SystemID,
+		data.Path,
+		data.IsFavorite,
+		data.LauncherOverride,
+		now,
+		now,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to execute media user data upsert: %w", err)
+	}
+	return nil
+}
+
+func sqlSetMediaUserFavorite(
+	ctx context.Context, db *sql.DB, systemID, path string, favorite bool, now int64,
+) error {
+	return mediaUserDataColumnWrite(ctx, db, `
+		insert into MediaUserData(
+			SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		) values (?, ?, ?, '', ?, ?)
+		on conflict(SystemID, Path) do update set
+			IsFavorite = excluded.IsFavorite,
+			UpdatedAt = excluded.UpdatedAt;
+	`, systemID, path, favorite, now)
+}
+
+func sqlSetMediaUserLauncherOverride(
+	ctx context.Context, db *sql.DB, systemID, path, launcherID string, now int64,
+) error {
+	return mediaUserDataColumnWrite(ctx, db, `
+		insert into MediaUserData(
+			SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		) values (?, ?, 0, ?, ?, ?)
+		on conflict(SystemID, Path) do update set
+			LauncherOverride = excluded.LauncherOverride,
+			UpdatedAt = excluded.UpdatedAt;
+	`, systemID, path, launcherID, now)
+}
+
+// mediaUserDataColumnWrite applies a single-column upsert and then deletes the
+// row if no user intent remains (not a favourite and no launcher override),
+// both inside one transaction so the pair is atomic against concurrent writers.
+// value is the column-specific bind (favourite bool or launcher ID string).
+func mediaUserDataColumnWrite(
+	ctx context.Context, db *sql.DB, upsert, systemID, path string, value any, now int64,
+) (err error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin media user data transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, upsert, systemID, path, value, now, now); err != nil {
+		return fmt.Errorf("failed to upsert media user data column: %w", err)
+	}
+	if _, err = tx.ExecContext(ctx, `
+		delete from MediaUserData
+		where SystemID = ? and Path = ? and IsFavorite = 0 and LauncherOverride = '';
+	`, systemID, path); err != nil {
+		return fmt.Errorf("failed to prune empty media user data row: %w", err)
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit media user data transaction: %w", err)
+	}
+	return nil
+}
+
+func sqlDeleteMediaUserData(ctx context.Context, db *sql.DB, systemID, path string) error {
+	_, err := db.ExecContext(ctx,
+		`delete from MediaUserData where SystemID = ? and Path = ?;`, systemID, path)
+	if err != nil {
+		return fmt.Errorf("failed to execute media user data delete: %w", err)
+	}
+	return nil
+}
+
+func sqlListMediaUserData(ctx context.Context, db *sql.DB) ([]database.MediaUserData, error) {
+	list := make([]database.MediaUserData, 0)
+
+	q, err := db.PrepareContext(ctx, `
+		select
+		DBID, SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		from MediaUserData;
+	`)
+	if err != nil {
+		return list, fmt.Errorf("failed to prepare list media user data statement: %w", err)
+	}
+	defer func() {
+		if closeErr := q.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+
+	rows, err := q.QueryContext(ctx)
+	if err != nil {
+		return list, fmt.Errorf("failed to execute list media user data query: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql rows")
+		}
+	}()
+	for rows.Next() {
+		row := database.MediaUserData{}
+		scanErr := rows.Scan(
+			&row.DBID,
+			&row.SystemID,
+			&row.Path,
+			&row.IsFavorite,
+			&row.LauncherOverride,
+			&row.CreatedAt,
+			&row.UpdatedAt,
+		)
+		if scanErr != nil {
+			return list, fmt.Errorf("failed to scan media user data row: %w", scanErr)
+		}
+		list = append(list, row)
+	}
+	if err = rows.Err(); err != nil {
+		return list, fmt.Errorf("failed to iterate over media user data rows: %w", err)
+	}
+	return list, nil
+}

--- a/pkg/database/userdb/media_user_data.go
+++ b/pkg/database/userdb/media_user_data.go
@@ -38,9 +38,15 @@ func (db *UserDB) GetMediaUserData(systemID, path string) (database.MediaUserDat
 }
 
 // UpsertMediaUserData inserts or updates the user-data row for (SystemID, Path).
-// CreatedAt is set on insert only; UpdatedAt is set on every write.
+// CreatedAt is set on insert only; UpdatedAt is set on every write. A row with no
+// favourite and no launcher override carries no user intent, so it is deleted
+// rather than persisted (keeping ListMediaUserData and the backfill guard honest).
 func (db *UserDB) UpsertMediaUserData(data *database.MediaUserData) error {
-	return sqlUpsertMediaUserData(db.ctx, db.sql.Load(), data, time.Now().Unix())
+	conn := db.sql.Load()
+	if !data.IsFavorite && data.LauncherOverride == "" {
+		return sqlDeleteMediaUserData(db.ctx, conn, data.SystemID, data.Path)
+	}
+	return sqlUpsertMediaUserData(db.ctx, conn, data, time.Now().Unix())
 }
 
 // SetMediaUserFavorite records (or clears) the favourite intent for a media

--- a/pkg/database/userdb/media_user_data_test.go
+++ b/pkg/database/userdb/media_user_data_test.go
@@ -1,0 +1,199 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaUserDataCRUD(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+
+	// Missing row reports not found.
+	_, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	// Insert.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID:   "NES",
+		Path:       path,
+		IsFavorite: true,
+	}))
+	got, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, got.IsFavorite)
+	assert.Empty(t, got.LauncherOverride)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
+	createdAt := got.CreatedAt
+
+	// Upsert overwrites fields by (SystemID, Path) and preserves CreatedAt.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID:         "NES",
+		Path:             path,
+		IsFavorite:       false,
+		LauncherOverride: "RetroArch",
+	}))
+	got, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.False(t, got.IsFavorite)
+	assert.Equal(t, "RetroArch", got.LauncherOverride)
+	assert.Equal(t, createdAt, got.CreatedAt, "CreatedAt must be preserved across upserts")
+
+	// Delete.
+	require.NoError(t, userDB.DeleteMediaUserData("NES", path))
+	_, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	// Deleting a missing row is not an error.
+	require.NoError(t, userDB.DeleteMediaUserData("NES", path))
+}
+
+func TestMediaUserDataUniquePerSystemAndPath(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+	// Same path under two systems are distinct rows.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: path, IsFavorite: true,
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "SNES", Path: path, LauncherOverride: "RetroArch",
+	}))
+
+	nes, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, nes.IsFavorite)
+
+	snes, found, err := userDB.GetMediaUserData("SNES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "RetroArch", snes.LauncherOverride)
+}
+
+func TestSetMediaUserFavoriteColumnScoped(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+
+	// Favouriting an absent path creates the row.
+	require.NoError(t, userDB.SetMediaUserFavorite("NES", path, true))
+	got, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, got.IsFavorite)
+
+	// An override on the same row must survive a favourite toggle...
+	require.NoError(t, userDB.SetMediaUserLauncherOverride("NES", path, "RetroArch"))
+	require.NoError(t, userDB.SetMediaUserFavorite("NES", path, false))
+	got, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found, "row with an override survives clearing the favourite")
+	assert.False(t, got.IsFavorite)
+	assert.Equal(t, "RetroArch", got.LauncherOverride)
+
+	// ...and the favourite must survive clearing the override.
+	require.NoError(t, userDB.SetMediaUserFavorite("NES", path, true))
+	require.NoError(t, userDB.SetMediaUserLauncherOverride("NES", path, ""))
+	got, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found, "row with a favourite survives clearing the override")
+	assert.True(t, got.IsFavorite)
+	assert.Empty(t, got.LauncherOverride)
+
+	// Clearing both intents deletes the row.
+	require.NoError(t, userDB.SetMediaUserFavorite("NES", path, false))
+	_, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	assert.False(t, found, "row with no favourite and no override is pruned")
+}
+
+// TestSetMediaUserDataConcurrentColumnsDoNotClobber runs a favourite write and a
+// launcher-override write against the same path concurrently. Because each write
+// is column-scoped, the final row must carry BOTH intents — a read-modify-write
+// implementation would lose one. Run under -race to catch interleaving bugs.
+func TestSetMediaUserDataConcurrentColumnsDoNotClobber(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	for i := range 50 {
+		path := filepath.Join("roms", "NES", "Game.nes")
+		require.NoError(t, userDB.DeleteMediaUserData("NES", path))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		var favErr, ovrErr error
+		go func() {
+			defer wg.Done()
+			favErr = userDB.SetMediaUserFavorite("NES", path, true)
+		}()
+		go func() {
+			defer wg.Done()
+			ovrErr = userDB.SetMediaUserLauncherOverride("NES", path, "RetroArch")
+		}()
+		wg.Wait()
+		require.NoError(t, favErr)
+		require.NoError(t, ovrErr)
+
+		got, found, err := userDB.GetMediaUserData("NES", path)
+		require.NoError(t, err)
+		require.True(t, found, "iteration %d: row must exist", i)
+		assert.True(t, got.IsFavorite, "iteration %d: favourite must survive concurrent override write", i)
+		assert.Equal(t, "RetroArch", got.LauncherOverride,
+			"iteration %d: override must survive concurrent favourite write", i)
+	}
+}
+
+func TestListMediaUserData(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	empty, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	for _, name := range []string{"A.nes", "B.nes", "C.nes"} {
+		require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+			SystemID:   "NES",
+			Path:       filepath.Join("roms", "NES", name),
+			IsFavorite: true,
+		}))
+	}
+
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}

--- a/pkg/database/userdb/media_user_data_test.go
+++ b/pkg/database/userdb/media_user_data_test.go
@@ -79,6 +79,36 @@ func TestMediaUserDataCRUD(t *testing.T) {
 	require.NoError(t, userDB.DeleteMediaUserData("NES", path))
 }
 
+func TestUpsertMediaUserDataEmptyIntentDeletes(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+
+	// Upserting an empty-intent row persists nothing.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: path,
+	}))
+	_, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	assert.False(t, found, "empty-intent upsert must not persist a row")
+
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Empty(t, all, "ListMediaUserData stays empty so the backfill guard is not blocked")
+
+	// Upserting an empty-intent row also removes an existing row for the key.
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: path, IsFavorite: true,
+	}))
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "NES", Path: path,
+	}))
+	_, found, err = userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	assert.False(t, found, "empty-intent upsert must delete the pre-existing row")
+}
+
 func TestMediaUserDataUniquePerSystemAndPath(t *testing.T) {
 	userDB, cleanup := setupTempUserDB(t)
 	defer cleanup()

--- a/pkg/database/userdb/migrations/20260624120000_media_user_data.sql
+++ b/pkg/database/userdb/migrations/20260624120000_media_user_data.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create table MediaUserData
+(
+    DBID             INTEGER PRIMARY KEY AUTOINCREMENT,
+    SystemID         text    not null,
+    Path             text    not null,
+    IsFavorite       integer not null default 0,
+    LauncherOverride text    not null default '',
+    CreatedAt        integer not null,
+    UpdatedAt        integer not null,
+    unique (SystemID, Path)
+);
+
+create index mediauserdata_system_idx on MediaUserData (SystemID);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+drop table MediaUserData;
+-- +goose StatementEnd

--- a/pkg/service/media_user_data_backfill_test.go
+++ b/pkg/service/media_user_data_backfill_test.go
@@ -1,0 +1,133 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedMediaUserData inserts one favourited and one launcher-overridden media into
+// media.db, mimicking a database written by a version that stored this data only
+// there. Returns the two paths.
+func seedMediaUserData(ctx context.Context, t *testing.T, mediaDB *mediadb.MediaDB) (favPath, overridePath string) {
+	t.Helper()
+	favPath = filepath.Join("roms", "NES", "Fav.nes")
+	overridePath = filepath.Join("roms", "NES", "Override.nes")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	system, err := mediaDB.InsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{SystemDBID: system.DBID, Slug: "t", Name: "T"})
+	require.NoError(t, err)
+	favMedia, err := mediaDB.InsertMedia(database.Media{
+		MediaTitleDBID: title.DBID, SystemDBID: system.DBID, Path: favPath,
+	})
+	require.NoError(t, err)
+	overrideMedia, err := mediaDB.InsertMedia(database.Media{
+		MediaTitleDBID: title.DBID, SystemDBID: system.DBID, Path: overridePath,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	userType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type: string(tags.TagTypeUser), IsExclusive: tags.IsExclusiveType(tags.TagTypeUser),
+	})
+	require.NoError(t, err)
+	favTag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: userType.DBID, Tag: string(tags.TagUserFavorite)})
+	require.NoError(t, err)
+	_, err = mediaDB.FindOrInsertMediaTag(database.MediaTag{MediaDBID: favMedia.DBID, TagDBID: favTag.DBID})
+	require.NoError(t, err)
+
+	propType, err := mediaDB.FindOrInsertTagType(database.TagType{
+		Type: string(tags.TagTypeProperty), IsExclusive: tags.IsExclusiveType(tags.TagTypeProperty),
+	})
+	require.NoError(t, err)
+	_, err = mediaDB.FindOrInsertTag(database.Tag{
+		TypeDBID: propType.DBID, Tag: string(tags.TagPropertyLauncherOverride),
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpsertMediaProperties(ctx, overrideMedia.DBID, []database.MediaProperty{{
+		TypeTag: tags.PropertyTypeTag(tags.TagPropertyLauncherOverride),
+		Text:    "RetroArch",
+	}}))
+
+	return favPath, overridePath
+}
+
+func TestBackfillMediaUserData(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	favPath, overridePath := seedMediaUserData(ctx, t, mediaDB)
+	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
+
+	backfillMediaUserData(ctx, db)
+
+	fav, found, err := userDB.GetMediaUserData("NES", favPath)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.True(t, fav.IsFavorite)
+
+	override, found, err := userDB.GetMediaUserData("NES", overridePath)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "RetroArch", override.LauncherOverride)
+}
+
+func TestBackfillMediaUserDataGuardSkipsWhenPopulated(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	// UserDB already has a row, so the one-time backfill must not run — even though
+	// media.db has favourites/overrides that aren't in UserDB.
+	manualPath := filepath.Join("roms", "SNES", "Manual.sfc")
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "SNES", Path: manualPath, IsFavorite: true,
+	}))
+	favPath, _ := seedMediaUserData(ctx, t, mediaDB)
+
+	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
+	backfillMediaUserData(ctx, db)
+
+	_, found, err := userDB.GetMediaUserData("NES", favPath)
+	require.NoError(t, err)
+	assert.False(t, found, "guard must skip backfill when UserDB already has data")
+
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Len(t, all, 1, "only the pre-existing row remains")
+}

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -114,8 +114,56 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		log.Error().Err(err).Msg("error migrating old boltdb mappings")
 	}
 
+	// One-time import of favourites/launcher overrides that older versions wrote
+	// only to media.db, so they live in UserDB (the source of truth) and survive a
+	// future media.db rebuild.
+	backfillMediaUserData(ctx, db)
+
 	success = true
 	return db, nil
+}
+
+// backfillMediaUserData seeds UserDB from favourites/launcher overrides that older
+// versions stored only in media.db. It runs only while UserDB has no media user
+// data yet: once any row exists, UserDB is authoritative and media.db's copy is
+// never re-read (re-reading could resurrect a favourite the user removed if a prior
+// projection write had failed). Best-effort: failures are logged, not fatal.
+func backfillMediaUserData(ctx context.Context, db *database.Database) {
+	if db == nil || db.UserDB == nil || db.MediaDB == nil {
+		return
+	}
+
+	existing, err := db.UserDB.ListMediaUserData()
+	if err != nil {
+		log.Warn().Err(err).Msg("skipping media user data backfill: failed to read user database")
+		return
+	}
+	if len(existing) > 0 {
+		return
+	}
+
+	rows, err := db.MediaDB.GetExistingMediaUserData(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to read existing media user data for backfill")
+		return
+	}
+	if len(rows) == 0 {
+		return
+	}
+
+	migrated := 0
+	for i := range rows {
+		row := rows[i]
+		if upErr := db.UserDB.UpsertMediaUserData(&row); upErr != nil {
+			log.Warn().Err(upErr).
+				Str("system", row.SystemID).Str("path", row.Path).
+				Msg("failed to backfill media user data row")
+			continue
+		}
+		migrated++
+	}
+	log.Info().Int("migrated", migrated).Int("found", len(rows)).
+		Msg("backfilled media user data into user database")
 }
 
 func openAndRecoverUserDB(ctx context.Context, pl platforms.Platform) (*userdb.UserDB, error) {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -228,6 +228,65 @@ func (m *MockUserDBI) GetEnabledMappings() ([]database.Mapping, error) {
 	return nil, nil
 }
 
+func (m *MockUserDBI) GetMediaUserData(systemID, path string) (database.MediaUserData, bool, error) {
+	args := m.Called(systemID, path)
+	data, ok := args.Get(0).(database.MediaUserData)
+	if !ok {
+		data = database.MediaUserData{}
+	}
+	found := args.Bool(1)
+	if err := args.Error(2); err != nil {
+		return data, found, fmt.Errorf("mock UserDBI get media user data failed: %w", err)
+	}
+	return data, found, nil
+}
+
+func (m *MockUserDBI) SetMediaUserFavorite(systemID, path string, favorite bool) error {
+	args := m.Called(systemID, path, favorite)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI set media user favorite failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) SetMediaUserLauncherOverride(systemID, path, launcherID string) error {
+	args := m.Called(systemID, path, launcherID)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI set media user launcher override failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) UpsertMediaUserData(data *database.MediaUserData) error {
+	args := m.Called(data)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI upsert media user data failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) DeleteMediaUserData(systemID, path string) error {
+	args := m.Called(systemID, path)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI delete media user data failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) ListMediaUserData() ([]database.MediaUserData, error) {
+	args := m.Called()
+	if data, ok := args.Get(0).([]database.MediaUserData); ok {
+		if err := args.Error(1); err != nil {
+			return data, fmt.Errorf("mock UserDBI list media user data failed: %w", err)
+		}
+		return data, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock UserDBI list media user data failed: %w", err)
+	}
+	return nil, nil
+}
+
 func (m *MockUserDBI) UpdateZapLinkHost(host string, isZapScript int) error {
 	args := m.Called(host, isZapScript)
 	if err := args.Error(0); err != nil {
@@ -1828,6 +1887,20 @@ func (m *MockMediaDBI) GetAllTagTypes() ([]database.TagType, error) {
 	return []database.TagType{}, nil
 }
 
+func (m *MockMediaDBI) GetExistingMediaUserData(ctx context.Context) ([]database.MediaUserData, error) {
+	args := m.Called(ctx)
+	if data, ok := args.Get(0).([]database.MediaUserData); ok {
+		if err := args.Error(1); err != nil {
+			return data, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return data, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return []database.MediaUserData{}, nil
+}
+
 // GetTitlesWithSystems mock method for optimized JOIN query
 func (m *MockMediaDBI) GetTitlesWithSystems() ([]database.TitleWithSystem, error) {
 	args := m.Called()
@@ -2337,7 +2410,12 @@ func ExpectTransactionRollback(mockDB sqlmock.Sqlmock) {
 //		userDB.AssertExpectations(t)
 //	}
 func NewMockUserDBI() *MockUserDBI {
-	return &MockUserDBI{}
+	m := &MockUserDBI{}
+	// A reindex always lists media user data to re-materialize the media.db
+	// projection. Default to an empty list so tests exercising NewNamesIndex
+	// don't each need to stub it; tests can override with their own expectation.
+	m.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
+	return m
 }
 
 // NewMockMediaDBI creates a new mock MediaDBI interface for testing.


### PR DESCRIPTION
- Favourites (`user:favorite` tags) and per-game launcher overrides (`launcher-override` properties) previously lived only in media.db, a rebuildable cache that corruption recovery or a full rebuild wipes. UserDB is now the source of truth and media.db carries a materialized projection (dual-write); read paths are unchanged.
- New UserDB `MediaUserData` table keyed `(SystemID, Path)`, since `MediaDBID` is not stable across a rebuild.
- Edit handlers write the UserDB truth first, then the media.db projection; a projection failure surfaces the error but the truth is kept and the next reindex reconciles it.
- Favourite and override writes are column-scoped atomic UserDB operations (upsert plus conditional delete in one transaction), so concurrent edits to the same path cannot clobber each other.
- A reindex re-applies UserDB data onto the freshly built media.db, add-only and idempotent.
- A one-time startup backfill seeds UserDB from media.db for users who already have favourites/overrides, guarded on UserDB being empty so a removed favourite is never resurrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User favorites and launcher overrides are now persisted in a durable user store and automatically restored during startup and media reindexing.
  * Existing favorites/launcher overrides are backfilled into the durable store so they remain available after rebuilds.

* **Bug Fixes**
  * Favorite and launcher-override updates now persist user intent first, so changes aren’t lost if the media projection update fails.
  * Clearing or changing a launcher override now updates the saved preference consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->