### PR TITLE
fix(database): canonicalize media user data paths

### DIFF
--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -84,7 +84,11 @@ func startPriorityWSServer(t *testing.T, methodMap *MethodMap) (wsURL string, cl
 }
 
 func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) {
-	imageStarted := make(chan struct{}, wsLowConcurrency+1)
+	imageRequests := wsLowConcurrency + 1
+	queuedImageID := imageRequests
+	mutationID := imageRequests + 1
+	totalResponses := imageRequests + 1
+	imageStarted := make(chan struct{}, imageRequests)
 	releaseImages := make(chan struct{})
 
 	var methodMap MethodMap
@@ -107,7 +111,7 @@ func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) 
 	conn := dialWS(t, wsURL)
 	defer func() { _ = conn.Close() }()
 
-	for id := 1; id <= 3; id++ {
+	for id := 1; id <= imageRequests; id++ {
 		require.NoError(t, conn.WriteMessage(websocket.TextMessage,
 			[]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"media.image","id":%d}`, id))))
 	}
@@ -120,18 +124,21 @@ func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) 
 	}
 	select {
 	case <-imageStarted:
-		t.Fatal("third media.image ran before a low-priority worker was free")
+		t.Fatal("queued media.image ran before a low-priority worker was free")
 	default:
 	}
 
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
-		[]byte(`{"jsonrpc":"2.0","method":"media.tags.update","params":{"mediaId":1,"add":["user:favorite"]},"id":4}`)))
+		[]byte(fmt.Sprintf(
+			`{"jsonrpc":"2.0","method":"media.tags.update","params":{"mediaId":1,"add":["user:favorite"]},"id":%d}`,
+			mutationID,
+		))))
 	waitForMediaDBWriterPending(t)
 	close(releaseImages)
 
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
-	seen := make([]models.RPCID, 0, 4)
-	for range 4 {
+	seen := make([]models.RPCID, 0, totalResponses)
+	for range totalResponses {
 		_, msg, err := conn.ReadMessage()
 		require.NoError(t, err)
 		var resp models.ResponseObject
@@ -139,11 +146,11 @@ func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) 
 		seen = append(seen, resp.ID)
 	}
 
-	favoriteIndex := indexRPCID(seen, models.NewNumberID(4))
-	thirdImageIndex := indexRPCID(seen, models.NewNumberID(3))
+	favoriteIndex := indexRPCID(seen, models.NewNumberID(int64(mutationID)))
+	queuedImageIndex := indexRPCID(seen, models.NewNumberID(int64(queuedImageID)))
 	require.NotEqual(t, -1, favoriteIndex)
-	require.NotEqual(t, -1, thirdImageIndex)
-	assert.Less(t, favoriteIndex, thirdImageIndex, "mutation should bypass queued image work")
+	require.NotEqual(t, -1, queuedImageIndex)
+	assert.Less(t, favoriteIndex, queuedImageIndex, "mutation should bypass queued image work")
 }
 
 func waitForMediaDBWriterPending(t *testing.T) {

--- a/pkg/api/ws_dispatcher_test.go
+++ b/pkg/api/ws_dispatcher_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"testing"
 	"time"
 
@@ -83,12 +84,14 @@ func startPriorityWSServer(t *testing.T, methodMap *MethodMap) (wsURL string, cl
 }
 
 func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) {
-	t.Parallel()
+	imageStarted := make(chan struct{}, wsLowConcurrency+1)
+	releaseImages := make(chan struct{})
 
 	var methodMap MethodMap
 	require.NoError(t, methodMap.AddMethod(models.MethodMediaImage, func(env requests.RequestEnv) (any, error) {
+		imageStarted <- struct{}{}
 		select {
-		case <-time.After(250 * time.Millisecond):
+		case <-releaseImages:
 			return map[string]string{"kind": "image"}, nil
 		case <-env.Context.Done():
 			return nil, env.Context.Err()
@@ -108,8 +111,23 @@ func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) 
 		require.NoError(t, conn.WriteMessage(websocket.TextMessage,
 			[]byte(fmt.Sprintf(`{"jsonrpc":"2.0","method":"media.image","id":%d}`, id))))
 	}
+	for range wsLowConcurrency {
+		select {
+		case <-imageStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("media.image did not start")
+		}
+	}
+	select {
+	case <-imageStarted:
+		t.Fatal("third media.image ran before a low-priority worker was free")
+	default:
+	}
+
 	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
 		[]byte(`{"jsonrpc":"2.0","method":"media.tags.update","params":{"mediaId":1,"add":["user:favorite"]},"id":4}`)))
+	waitForMediaDBWriterPending(t)
+	close(releaseImages)
 
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
 	seen := make([]models.RPCID, 0, 4)
@@ -126,6 +144,25 @@ func TestWebSocketPriorityDispatcherHighPriorityBypassesSlowImage(t *testing.T) 
 	require.NotEqual(t, -1, favoriteIndex)
 	require.NotEqual(t, -1, thirdImageIndex)
 	assert.Less(t, favoriteIndex, thirdImageIndex, "mutation should bypass queued image work")
+}
+
+func waitForMediaDBWriterPending(t *testing.T) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if !wsMediaDBMu.TryRLock() {
+			return
+		}
+		wsMediaDBMu.RUnlock()
+
+		select {
+		case <-deadline:
+			t.Fatal("media.tags.update did not wait for the media DB write lock")
+		default:
+			runtime.Gosched()
+		}
+	}
 }
 
 func TestWebSocketPriorityDispatcherPreservesHighPriorityOrder(t *testing.T) {

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	platformsshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
@@ -1156,13 +1157,7 @@ func PopulateScanStateForSelectiveIndexing(
 func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 	f := MediaPathFragments{}
 
-	// don't clean the :// in custom scheme paths
-	if helpers.ReURI.MatchString(params.Path) {
-		f.Path = params.Path
-	} else {
-		// Clean and normalize to forward slashes for cross-platform consistency
-		f.Path = filepath.ToSlash(filepath.Clean(params.Path))
-	}
+	f.Path = pathutil.CanonicalMediaPath(params.Path)
 
 	// Use FilenameFromPath for virtual paths to get URL-decoded names
 	// For regular paths, extract basename manually

--- a/pkg/database/userdb/media_user_data.go
+++ b/pkg/database/userdb/media_user_data.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/rs/zerolog/log"
 )
 
@@ -34,7 +35,7 @@ import (
 // when no row exists for the (systemID, path) key, in which case the media has no
 // favourite or launcher-override intent recorded.
 func (db *UserDB) GetMediaUserData(systemID, path string) (database.MediaUserData, bool, error) {
-	return sqlGetMediaUserData(db.ctx, db.sql.Load(), systemID, path)
+	return sqlGetMediaUserData(db.ctx, db.sql.Load(), systemID, pathutil.CanonicalMediaPath(path))
 }
 
 // UpsertMediaUserData inserts or updates the user-data row for (SystemID, Path).
@@ -43,10 +44,12 @@ func (db *UserDB) GetMediaUserData(systemID, path string) (database.MediaUserDat
 // rather than persisted (keeping ListMediaUserData and the backfill guard honest).
 func (db *UserDB) UpsertMediaUserData(data *database.MediaUserData) error {
 	conn := db.sql.Load()
-	if !data.IsFavorite && data.LauncherOverride == "" {
-		return sqlDeleteMediaUserData(db.ctx, conn, data.SystemID, data.Path)
+	normalized := *data
+	normalized.Path = pathutil.CanonicalMediaPath(data.Path)
+	if !normalized.IsFavorite && normalized.LauncherOverride == "" {
+		return sqlDeleteMediaUserData(db.ctx, conn, normalized.SystemID, normalized.Path)
 	}
-	return sqlUpsertMediaUserData(db.ctx, conn, data, time.Now().Unix())
+	return sqlUpsertMediaUserData(db.ctx, conn, &normalized, time.Now().Unix())
 }
 
 // SetMediaUserFavorite records (or clears) the favourite intent for a media
@@ -55,20 +58,24 @@ func (db *UserDB) UpsertMediaUserData(data *database.MediaUserData) error {
 // concurrent edits to the same path (e.g. a favourite toggle and a launcher
 // override) cannot read-modify-write over each other.
 func (db *UserDB) SetMediaUserFavorite(systemID, path string, favorite bool) error {
-	return sqlSetMediaUserFavorite(db.ctx, db.sql.Load(), systemID, path, favorite, time.Now().Unix())
+	return sqlSetMediaUserFavorite(
+		db.ctx, db.sql.Load(), systemID, pathutil.CanonicalMediaPath(path), favorite, time.Now().Unix(),
+	)
 }
 
 // SetMediaUserLauncherOverride records (or clears, when launcherID is empty) the
 // launcher-override intent for a media path without disturbing the favourite
 // flag on the same row. See SetMediaUserFavorite for the concurrency guarantee.
 func (db *UserDB) SetMediaUserLauncherOverride(systemID, path, launcherID string) error {
-	return sqlSetMediaUserLauncherOverride(db.ctx, db.sql.Load(), systemID, path, launcherID, time.Now().Unix())
+	return sqlSetMediaUserLauncherOverride(
+		db.ctx, db.sql.Load(), systemID, pathutil.CanonicalMediaPath(path), launcherID, time.Now().Unix(),
+	)
 }
 
 // DeleteMediaUserData removes the user-data row for (SystemID, Path). Deleting a
 // row that does not exist is not an error.
 func (db *UserDB) DeleteMediaUserData(systemID, path string) error {
-	return sqlDeleteMediaUserData(db.ctx, db.sql.Load(), systemID, path)
+	return sqlDeleteMediaUserData(db.ctx, db.sql.Load(), systemID, pathutil.CanonicalMediaPath(path))
 }
 
 // ListMediaUserData returns every user-data row, used by the reindex re-apply
@@ -110,6 +117,7 @@ func sqlGetMediaUserData(
 	if err != nil {
 		return row, false, fmt.Errorf("failed to scan media user data row: %w", err)
 	}
+	row.Path = pathutil.CanonicalMediaPath(row.Path)
 	return row, true, nil
 }
 
@@ -254,6 +262,7 @@ func sqlListMediaUserData(ctx context.Context, db *sql.DB) ([]database.MediaUser
 		if scanErr != nil {
 			return list, fmt.Errorf("failed to scan media user data row: %w", scanErr)
 		}
+		row.Path = pathutil.CanonicalMediaPath(row.Path)
 		list = append(list, row)
 	}
 	if err = rows.Err(); err != nil {

--- a/pkg/database/userdb/media_user_data_test.go
+++ b/pkg/database/userdb/media_user_data_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,6 +78,29 @@ func TestMediaUserDataCRUD(t *testing.T) {
 
 	// Deleting a missing row is not an error.
 	require.NoError(t, userDB.DeleteMediaUserData("NES", path))
+}
+
+func TestMediaUserDataNormalizesNativePathSeparators(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "NES", "Game.nes")
+	canonicalPath := pathutil.CanonicalMediaPath(path)
+
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID:   "NES",
+		Path:       path,
+		IsFavorite: true,
+	}))
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, canonicalPath, all[0].Path)
+
+	got, found, err := userDB.GetMediaUserData("NES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, canonicalPath, got.Path)
 }
 
 func TestUpsertMediaUserDataEmptyIntentDeletes(t *testing.T) {

--- a/pkg/helpers/pathutil/pathutil.go
+++ b/pkg/helpers/pathutil/pathutil.go
@@ -25,7 +25,11 @@ package pathutil
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 )
+
+var mediaPathURI = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+.-]*)://(.+)$`)
 
 // ExeDir returns the directory containing the currently running executable.
 // Returns an empty string if the executable path cannot be determined.
@@ -35,6 +39,17 @@ func ExeDir() string {
 		return ""
 	}
 	return filepath.Dir(exe)
+}
+
+// CanonicalMediaPath normalizes a persisted media path to media.db's storage
+// format. Filesystem paths are cleaned and stored with forward slashes; URI
+// paths are kept unchanged.
+func CanonicalMediaPath(path string) string {
+	if path == "" || mediaPathURI.MatchString(path) {
+		return path
+	}
+	path = strings.ReplaceAll(path, `\`, string(filepath.Separator))
+	return filepath.ToSlash(filepath.Clean(path))
 }
 
 // ResolveRelativePath resolves a path relative to ExeDir if it is not

--- a/pkg/helpers/pathutil/pathutil_test.go
+++ b/pkg/helpers/pathutil/pathutil_test.go
@@ -37,7 +37,11 @@ func TestCanonicalMediaPath(t *testing.T) {
 		{name: "empty", path: "", expected: ""},
 		{name: "native path", path: filepath.Join("roms", "NES", "Game.nes"), expected: "roms/NES/Game.nes"},
 		{name: "backslash path", path: `roms\NES\Game.nes`, expected: "roms/NES/Game.nes"},
-		{name: "cleans filesystem path", path: filepath.Join("roms", "NES", "..", "SNES", "Game.sfc"), expected: "roms/SNES/Game.sfc"},
+		{
+			name:     "cleans filesystem path",
+			path:     filepath.Join("roms", "NES", "..", "SNES", "Game.sfc"),
+			expected: "roms/SNES/Game.sfc",
+		},
 		{name: "uri unchanged", path: "steam://12345", expected: "steam://12345"},
 	}
 

--- a/pkg/helpers/pathutil/pathutil_test.go
+++ b/pkg/helpers/pathutil/pathutil_test.go
@@ -26,6 +26,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestCanonicalMediaPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{name: "empty", path: "", expected: ""},
+		{name: "native path", path: filepath.Join("roms", "NES", "Game.nes"), expected: "roms/NES/Game.nes"},
+		{name: "backslash path", path: `roms\NES\Game.nes`, expected: "roms/NES/Game.nes"},
+		{name: "cleans filesystem path", path: filepath.Join("roms", "NES", "..", "SNES", "Game.sfc"), expected: "roms/SNES/Game.sfc"},
+		{name: "uri unchanged", path: "steam://12345", expected: "steam://12345"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, CanonicalMediaPath(tt.path))
+		})
+	}
+}
+
 func TestResolveRelativePath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- stabilize the WebSocket priority dispatcher test with deterministic worker barriers
- add shared media path canonicalization and use it for media.db indexing plus UserDB media user-data keys
- preserve URI paths while normalizing filesystem paths to slash-separated media.db form

Closes #998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media paths are now persisted and displayed in a consistent canonical format across the app.
  * URI-style media paths remain unchanged, while regular file paths are normalized more reliably.

* **Bug Fixes**
  * Fixed media entries and media-user-data operations (lookup, updates, favorites, launcher overrides, deletion) to consistently use the normalized path format.
  * Improved handling of mixed native separators and path cleanup for better cross-system consistency.

* **Tests**
  * Added and extended coverage for canonical media path behavior and media-user-data normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->