### PR TITLE
test(database): canonicalize reapply user data path lookup

### DIFF
--- a/pkg/database/mediascanner/reapply_user_data_test.go
+++ b/pkg/database/mediascanner/reapply_user_data_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,7 +130,7 @@ func mediaDBIDForPath(
 	t.Helper()
 	system, err := db.FindSystemBySystemID(systemID)
 	require.NoError(t, err)
-	media, err := db.FindMediaBySystemAndPath(ctx, system.DBID, path)
+	media, err := db.FindMediaBySystemAndPath(ctx, system.DBID, pathutil.CanonicalMediaPath(path))
 	require.NoError(t, err)
 	require.NotNil(t, media)
 	return media.DBID


### PR DESCRIPTION
## Summary
- canonicalize the reapply user-data test media lookup path before querying media.db
- fixes the Windows-only path separator failure after #1007

## Validation
- go test -run TestReapplyMediaUserData ./pkg/database/mediascanner
- go test ./pkg/database/mediascanner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to reflect consistent path handling for media lookups.
  * Added validation for matching media entries using a standardized path format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->