### PR TITLE
fix(mister): load Atari5200 carts via file slot

### DIFF
--- a/pkg/platforms/mister/cores/cores.go
+++ b/pkg/platforms/mister/cores/cores.go
@@ -176,7 +176,7 @@ var Systems = map[string]Core{
 				Exts:  []string{".car", ".a52", ".bin", ".rom"},
 				Mgl: &MGLParams{
 					Delay:  1,
-					Method: "s",
+					Method: "f",
 					Index:  1,
 				},
 			},

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -221,6 +221,16 @@ func TestLaunchCoreRejectsControlCharacters(t *testing.T) {
 func TestGenerateMgl(t *testing.T) {
 	t.Parallel()
 
+	atari5200Path := filepath.Join(
+		string(filepath.Separator),
+		"media", "fat", "cifs", "games", "ATARI5200", "Activision Decathlon, The (USA).car",
+	)
+	atari5200MGLPath := filepath.ToSlash(filepath.Join(
+		"..", "..", "..", "..", "..", "media", "fat", "cifs", "games", "ATARI5200",
+		"Activision Decathlon, The (USA).car",
+	))
+	atari5200Core := cores.Systems["Atari5200"]
+
 	tests := []struct {
 		name     string
 		core     *cores.Core
@@ -323,6 +333,14 @@ func TestGenerateMgl(t *testing.T) {
 	<rbf>_Console/NES</rbf>
 	<file delay="2" type="f" index="1" path="../../../../../media/fat/games/NES/Mario.nes"/>
 </mistergamedescription>`,
+		},
+		{
+			name: "Atari5200 car uses load-file slot",
+			core: &atari5200Core,
+			path: atari5200Path,
+			want: "<mistergamedescription>\n\t<rbf>_Console/Atari5200</rbf>\n" +
+				"\t<file delay=\"1\" type=\"f\" index=\"1\" path=\"" + atari5200MGLPath + "\"/>\n" +
+				"</mistergamedescription>",
 		},
 		{
 			name: "game launch with reset tag (Jaguar)",


### PR DESCRIPTION
Summary:
- Load Atari5200 carts through MiSTer MGL file slot F1 instead of mount slot S1.
- Add regression coverage for generated Atari5200 .car MGL output.

Verification:
- go test ./pkg/platforms/mister/cores ./pkg/platforms/mister/mgls

Closes #1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Atari 5200 file handling so compatible files are matched and loaded more reliably.
  * Added coverage for an additional Atari 5200 cartridge scenario to help prevent regressions in MGL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->