### PR TITLE
fix(database): re-resolve cover flag image tags when none are cached

### DIFF
--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -263,6 +263,16 @@ func resolveImagePropertyTagDBIDs(ctx context.Context, db sqlQueryable) ([]int64
 		return nil, fmt.Errorf("browse image property tags rows: %w", rowsErr)
 	}
 
+	// Never cache an empty result. The image-* property tags are seeded during
+	// indexing (SeedCanonicalTags), so a browse that runs before they exist would
+	// otherwise pin an empty set for the process lifetime — making every entry report
+	// HasCover=false until the process restarts, since the scrape/index-completion
+	// path does not invalidate this cache. Re-querying while empty is cheap; once the
+	// tags exist the non-empty result is cached normally.
+	if len(tagIDs) == 0 {
+		return tagIDs, nil
+	}
+
 	imagePropertyTagCacheMu.Lock()
 	if imagePropertyTagCacheMap == nil {
 		imagePropertyTagCacheMap = make(map[sqlQueryable][]int64)

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -780,6 +780,65 @@ func TestFetchAndAttachCoverFlags_Integration_TitleLevelProperty(t *testing.T) {
 	assert.True(t, results[1].HasCover, "media whose title has an image property should have HasCover=true")
 }
 
+// TestFetchAndAttachCoverFlags_Integration_TagsSeededAfterFirstBrowse reproduces the
+// regression where a browse that runs before the image-* property tags are seeded
+// (which happens inside the indexing pipeline) pins an empty tag set in the
+// process-lifetime cache, leaving every later browse reporting HasCover=false until
+// the process restarts. The scrape/index-completion path never invalidates this
+// cache, so the only recovery without this fix is a restart.
+func TestFetchAndAttachCoverFlags_Integration_TagsSeededAfterFirstBrowse(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Game With Cover"),
+		Name:       "Game With Cover",
+	})
+	require.NoError(t, err)
+	media, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "with_cover.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// First browse runs before any image-* property tag exists, mirroring a browse
+	// landing mid-reindex before SeedCanonicalTags. No covers can exist yet, so
+	// HasCover=false here is correct — but it must not be cached for the DB handle.
+	firstPass := []database.SearchResultWithCursor{
+		{MediaID: media.DBID, MediaTitleID: title.DBID, Name: "Game With Cover"},
+	}
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), firstPass))
+	require.False(t, firstPass[0].HasCover, "no image tags seeded yet, so HasCover must be false")
+
+	// Indexing then seeds the image-* tags and the scraper writes the cover property.
+	seedImagePropertyTags(t, mediaDB)
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, title.DBID, []database.MediaProperty{
+		{TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageBoxart), Text: filepath.Join("art", "with_cover.png")},
+	}))
+
+	// A subsequent browse on the same DB handle must now see the cover. Without the
+	// empty-result guard in resolveImagePropertyTagDBIDs, the first pass would have
+	// cached an empty tag set and this would still report false.
+	secondPass := []database.SearchResultWithCursor{
+		{MediaID: media.DBID, MediaTitleID: title.DBID, Name: "Game With Cover"},
+	}
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), secondPass))
+	assert.True(t, secondPass[0].HasCover,
+		"cover must be detected once image tags are seeded, even if an earlier browse ran first")
+}
+
 // Sibling disambiguation is exercised end-to-end in disambiguation_test.go: it
 // now reads stored per-title types (RecomputeSystemDisambiguation) instead of
 // grouping a page in memory, so it is correct across page boundaries.


### PR DESCRIPTION
Covers disappear in the frontend after upgrading, and a force rescrape does not bring them back — only a service restart does.

## Cause

`resolveImagePropertyTagDBIDs` (`pkg/database/mediadb/sql_browse.go`) caches its result keyed by the `*sql.DB` handle, including an empty slice. The `image-*` property tags are created during indexing by `SeedCanonicalTags`, so a browse that runs before they exist (mid-reindex, widened by slow storage) pins an empty tag set for the process lifetime.

`fetchAndAttachCoverFlags` then early-returns on the empty set, leaving every result `HasCover=false`. The API sends `hasCover` explicitly (no `omitempty`), and the frontend cover gate honours `false` by suppressing the `media.image` request — so every cover vanishes. Nothing in the scrape/index-completion path invalidates this cache (the scraper commits on its own transaction; index completion invalidates without `UtilityTagDBIDsChanged`), so a force rescrape does not recover it. Only a process restart, which clears the cache on DB open, does.

This surfaced only after the frontend added the `hasCover` gate; older builds requested covers for every entry and were unaffected by the flag.

## Fix

Skip caching when the resolved image-tag set is empty, so the small lookup re-runs until the tags exist and then caches the non-empty result as before. A non-empty cache is already self-correcting for later property writes, since the per-entry property lookup runs live each browse. No schema, migration, or API change.

## Tests

`TestFetchAndAttachCoverFlags_Integration_TagsSeededAfterFirstBrowse` browses before the image tags are seeded (caching the empty set), then seeds the tags and writes a cover property, and asserts the cover is detected on the next browse. It fails without the guard and passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cover-art availability could be reported incorrectly after an initial browse with no matching image tags.
  * Browsing now correctly updates cover status on later requests, even if image-related tags are added after the first lookup.

* **Tests**
  * Added coverage for browsing again after tags are created, ensuring cover flags refresh as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->