### PR TITLE
perf(database): avoid per-row goroutines resolving singleton aliases

### DIFF
--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1668,6 +1668,12 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
+	// spawns a goroutine + channel per rows.Next() call. A directory with
+	// thousands of children returns one row per child, so that per-row overhead
+	// dominates the scan on weak hardware (MiSTer). This is a bounded indexed
+	// read, so dropping mid-iteration cancellation is safe.
+	ctx = context.WithoutCancel(ctx)
 	results, err := sqlBrowseDirectories(ctx, db.sql.Load(), opts)
 	db.NoteCorruption(err)
 	return results, err

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -3106,6 +3106,30 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
 	}
 
+	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
+	// spawns a goroutine + channel per rows.Next() call. This function runs five
+	// bulk reads that each return up to one row per candidate directory, so on a
+	// large folder (thousands of singleton containers) that per-row overhead
+	// dominates on weak hardware (MiSTer). These are bounded indexed reads, so
+	// dropping mid-iteration cancellation is safe.
+	ctx = context.WithoutCancel(ctx)
+
+	// Per-step timing, emitted once at debug level so the on-device breakdown of
+	// a slow resolution is visible without changing behaviour.
+	var inScanDur, fullRowsDur, tagsDur, zapDur, coverDur time.Duration
+	var inScanRows int
+	defer func() {
+		log.Debug().
+			Int("candidates", len(dirCandidates)).
+			Int("inScanRows", inScanRows).
+			Dur("inScanDuration", inScanDur).
+			Dur("fullRowsDuration", fullRowsDur).
+			Dur("tagsDuration", tagsDur).
+			Dur("zapScriptDuration", zapDur).
+			Dur("coverFlagsDuration", coverDur).
+			Msg("resolve singleton aliases step timing")
+	}()
+
 	expectedCounts := make(map[string]int, len(dirCandidates))
 	args := make([]any, 0, 1+len(dirCandidates))
 	args = append(args, systemDBID)
@@ -3120,6 +3144,7 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 
 	// One query for the direct media rows of all candidate dirs, served by
 	// idx_media_parentdir_system.
+	inScanStart := time.Now()
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
 	rows, err := db.sql.Load().QueryContext(ctx, `
 		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
@@ -3144,10 +3169,12 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 			return nil, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
 		}
 		childDirRows[m.ParentDir] = append(childDirRows[m.ParentDir], m)
+		inScanRows++
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
 		return nil, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
 	}
+	inScanDur = time.Since(inScanStart)
 
 	// For each candidate dir: skip if the recursive FileCount exceeds the
 	// direct rows (media in nested subdirectories). Otherwise apply
@@ -3177,14 +3204,18 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	for _, c := range candidates {
 		mediaDBIDs = append(mediaDBIDs, c.media.DBID)
 	}
+	fullRowsStart := time.Now()
 	fullRows, err := db.GetMediaWithTitleAndSystemByIDs(ctx, mediaDBIDs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases full rows: %w", err)
 	}
+	fullRowsDur = time.Since(fullRowsStart)
+	tagsStart := time.Now()
 	tagsMap, err := db.GetMediaTagsByMediaDBIDs(ctx, mediaDBIDs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases tags: %w", err)
 	}
+	tagsDur = time.Since(tagsStart)
 
 	// Build the alias list and a parallel synthetic results slice carrying each
 	// title's stored DisambiguationTypes, which attachZapScriptTags reads to
@@ -3215,18 +3246,22 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	}
 
 	// Populate ZapScriptTags from each title's precomputed disambiguating types.
+	zapStart := time.Now()
 	if err := attachZapScriptTags(ctx, db.sql.Load(), synthetic); err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases disambiguation: %w", err)
 	}
+	zapDur = time.Since(zapStart)
 	for i := range aliases {
 		aliases[i].ZapScriptTags = synthetic[i].ZapScriptTags
 	}
 
 	// Batch cover-flag check: one indexed UNION ALL query for all alias media.
 	// Populates HasCover so aliased directory entries show art in the grid.
+	coverStart := time.Now()
 	if err := fetchAndAttachCoverFlags(ctx, db.sql.Load(), synthetic); err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases cover flags: %w", err)
 	}
+	coverDur = time.Since(coverStart)
 	for i := range aliases {
 		aliases[i].HasCover = synthetic[i].HasCover
 	}


### PR DESCRIPTION
## Problem

Browsing a folder with thousands of single-file children — a MiSTer console directory where each game is its own zip (`ZipsAsDirs`) — froze the app on "Loading Games..." and then "Reconnecting" (#1022).

From the user's logs, browsing `/media/fat/games/MegaDrive/Genesis ROMs/` (2613 entries):

```
"directories"                       rows:2613  duration:1055ms
"browse singleton alias resolution" candidates:2613 aliases:2613 duration:13101ms
"media.browse"                      duration:16311ms
```

The 16s browse holds the single SQLite connection; the app's concurrent `media.image`/`media.meta` requests then queue past the 30s `APIRequestTimeout` (`context deadline exceeded`), the WebSocket rate limiter closes the connection, and the app reconnects into the same loop.

## Cause

Both the directory listing and the singleton-alias resolution run their bulk reads under the cancellable request context. With a cancellable context, `mattn/go-sqlite3` spawns a goroutine + channel per `rows.Next()`. These reads return up to one row per child directory, so that per-row overhead scales with entry count and dominates on weak hardware.

Measured against the user's DB on a desktop (warm cache): the five resolution sub-queries total ~130ms with clean, fully-indexed query plans — no catastrophic plan. The on-device 13.1s is a ~100x gap, consistent with per-row overhead (the plain `directories` query alone was ~0.4ms/row on-device).

## Change

- `context.WithoutCancel` for the bulk reads in `ResolveSingletonContainerAliases` and `BrowseDirectories`, matching the existing scanner pattern in `mediadb.go`. These are bounded indexed reads, so dropping mid-iteration cancellation is safe.
- A debug-level per-step timing line in `ResolveSingletonContainerAliases` so the on-device breakdown (in-scan / full-rows / tags / zapscript / cover-flags) is visible.

Behavior is unchanged — only context cancellability and an added debug log. Existing `ResolveSingletonContainerAliases` and `media_browse` tests cover correctness.

## Note

This ships the leading-hypothesis fix together with the instrumentation. The new timing line lets us confirm on-device whether the goroutine overhead was the dominant cost; if the breakdown shows the cost is raw I/O or connection contention instead, the follow-up is to reduce hot-path work (directory pagination or index-time alias precompute) rather than just removing cancellation.

Refs #1022


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory browsing reliability for large folders by preventing scans from being interrupted mid-way.
  * Reduced overhead during media resolution, which may improve responsiveness when loading or disambiguating large libraries.
  * Added internal timing tracking to help diagnose slow media lookup and browsing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->