### PR TITLE
fix(database): paginate directory entries in media.browse

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -38,12 +38,35 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// Browse pagination phases. A cursor in the dirs phase pages through
+// directories (keyed by Name); the files phase pages through files. Directories
+// always fully precede files, so a cursor only ever resumes one stream.
+const (
+	browsePhaseDirs  = "dirs"
+	browsePhaseFiles = "files"
+)
+
 // browseCursorData is the JSON-serializable keyset cursor for browse pagination.
+// Phase selects the stream the cursor resumes ("dirs" or "files"; absent means a
+// legacy file-only cursor). DirName is the dirs-phase keyset; SortValue/SortMode/
+// LastID are the files-phase keyset. TotalFiles/TotalDirs carry the first-page
+// counts forward so cursor pages do not rerun the count queries.
 type browseCursorData struct {
 	SortValue  string `json:"sortValue"`
 	SortMode   string `json:"sortMode,omitempty"`
+	Phase      string `json:"phase,omitempty"`
+	DirName    string `json:"dirName,omitempty"`
 	LastID     int64  `json:"lastId"`
 	TotalFiles int    `json:"totalFiles,omitempty"`
+	TotalDirs  int    `json:"totalDirs,omitempty"`
+}
+
+func encodeCursorData(data *browseCursorData) (string, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal browse cursor: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(b), nil
 }
 
 func encodeBrowseCursor(lastID int64, sortValue string, totalFiles ...int) (string, error) {
@@ -51,11 +74,7 @@ func encodeBrowseCursor(lastID int64, sortValue string, totalFiles ...int) (stri
 	if len(totalFiles) > 0 && totalFiles[0] > 0 {
 		data.TotalFiles = totalFiles[0]
 	}
-	b, err := json.Marshal(data)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal browse cursor: %w", err)
-	}
-	return base64.StdEncoding.EncodeToString(b), nil
+	return encodeCursorData(&data)
 }
 
 func encodeBrowseCursorWithMode(lastID int64, sortValue, sortMode string, totalFiles int) (string, error) {
@@ -63,11 +82,40 @@ func encodeBrowseCursorWithMode(lastID int64, sortValue, sortMode string, totalF
 	if totalFiles > 0 {
 		data.TotalFiles = totalFiles
 	}
-	b, err := json.Marshal(data)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal browse cursor: %w", err)
-	}
-	return base64.StdEncoding.EncodeToString(b), nil
+	return encodeCursorData(&data)
+}
+
+// encodeDirCursor builds a dirs-phase cursor positioned after dirName.
+func encodeDirCursor(dirName string, totalFiles, totalDirs int) (string, error) {
+	return encodeCursorData(&browseCursorData{
+		Phase:      browsePhaseDirs,
+		DirName:    dirName,
+		TotalFiles: totalFiles,
+		TotalDirs:  totalDirs,
+	})
+}
+
+// encodeFileCursor builds a files-phase cursor from the last file's keyset.
+func encodeFileCursor(lastID int64, sortValue, sortMode string, totalFiles, totalDirs int) (string, error) {
+	return encodeCursorData(&browseCursorData{
+		Phase:      browsePhaseFiles,
+		SortValue:  sortValue,
+		SortMode:   sortMode,
+		LastID:     lastID,
+		TotalFiles: totalFiles,
+		TotalDirs:  totalDirs,
+	})
+}
+
+// encodeFilesStartCursor builds a files-phase cursor with no keyset (LastID 0),
+// marking the transition from the dirs phase so the next page starts files from
+// the beginning.
+func encodeFilesStartCursor(totalFiles, totalDirs int) (string, error) {
+	return encodeCursorData(&browseCursorData{
+		Phase:      browsePhaseFiles,
+		TotalFiles: totalFiles,
+		TotalDirs:  totalDirs,
+	})
 }
 
 func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
@@ -89,7 +137,10 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 		LastID:     data.LastID,
 		SortValue:  data.SortValue,
 		SortMode:   data.SortMode,
+		Phase:      data.Phase,
+		DirName:    data.DirName,
 		TotalFiles: data.TotalFiles,
+		TotalDirs:  data.TotalDirs,
 	}, nil
 }
 
@@ -562,32 +613,128 @@ func browseFilesystem(
 
 	ctx := env.Context
 
-	// Get subdirectories (only on first page)
-	var dirs []database.BrowseDirectoryResult
-	if cursor == nil {
-		var err error
+	// Counts are computed once on the first page and carried forward in the
+	// cursor so paging through a large directory does not rerun them.
+	var totalDirs, totalFiles int
+	if cursor != nil {
+		totalDirs = cursor.TotalDirs
+		totalFiles = cursor.TotalFiles
+	}
+
+	// Directory phase: directories are paginated by name and always precede
+	// files, so a cursor only ever resumes one stream. The letter filter targets
+	// files, so a letter query skips directories entirely.
+	inDirsPhase := letter == nil && (cursor == nil || cursor.Phase == browsePhaseDirs)
+	if inDirsPhase {
+		afterName := ""
+		if cursor != nil {
+			afterName = cursor.DirName
+		}
 		started := time.Now()
-		dirs, err = env.Database.MediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		dirs, err := env.Database.MediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
 			PathPrefix: prefix,
+			AfterName:  afterName,
 			Systems:    systems,
+			Limit:      maxResults + 1,
 		})
 		logBrowseTiming("directories", prefix, started, len(dirs))
 		if err != nil {
 			return nil, fmt.Errorf("error browsing directories: %w", err)
 		}
+
+		if cursor == nil {
+			started = time.Now()
+			totalDirs, err = env.Database.MediaDB.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+				PathPrefix: prefix,
+				Systems:    systems,
+			})
+			logBrowseTiming("dir_count", prefix, started, totalDirs)
+			if err != nil {
+				return nil, fmt.Errorf("error getting directory count: %w", err)
+			}
+		}
+
+		hasMoreDirs := len(dirs) > maxResults
+		if hasMoreDirs {
+			dirs = dirs[:maxResults]
+		}
+
+		// More directories remain: emit a directory-only page keyed by name.
+		if hasMoreDirs {
+			if cursor == nil {
+				totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems)
+				if err != nil {
+					return nil, err
+				}
+			}
+			next, encErr := encodeDirCursor(dirs[len(dirs)-1].Name, totalFiles, totalDirs)
+			if encErr != nil {
+				return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
+			}
+			return buildBrowseResponse(env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, &next, true, systems)
+		}
+
+		// Directories are exhausted. Fill the rest of the page with the first
+		// files so small folders return in a single round-trip (mixed boundary
+		// page), then continue paging files from there.
+		if cursor == nil {
+			totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems)
+			if err != nil {
+				return nil, err
+			}
+		}
+		remaining := maxResults - len(dirs)
+		if remaining <= 0 {
+			// The page is already full of directories; transition to the files
+			// phase on the next page if any files exist.
+			var next *string
+			hasNext := totalFiles > 0
+			if hasNext {
+				encoded, encErr := encodeFilesStartCursor(totalFiles, totalDirs)
+				if encErr != nil {
+					return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
+				}
+				next = &encoded
+			}
+			return buildBrowseResponse(
+				env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, next, hasNext, systems)
+		}
+
+		started = time.Now()
+		files, err := env.Database.MediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+			PathPrefix: prefix,
+			Limit:      remaining + 1,
+			Sort:       sort,
+			Systems:    systems,
+		})
+		logBrowseTiming("files", prefix, started, len(files))
+		if err != nil {
+			return nil, fmt.Errorf("error browsing files: %w", err)
+		}
+		files, next, encErr := paginateFiles(files, remaining, totalFiles, totalDirs, sort)
+		if encErr != nil {
+			return nil, encErr
+		}
+		return buildBrowseResponse(
+			env, cleaned, dirs, files, maxResults, totalFiles, totalDirs, next, next != nil, systems)
 	}
 
-	// Get files
-	opts := &database.BrowseFilesOptions{
+	// Files phase. A files-phase cursor with no keyset (LastID == 0) marks the
+	// transition out of the dirs phase, so files start from the beginning.
+	fileCursor := cursor
+	if cursor != nil && cursor.Phase == browsePhaseFiles && cursor.LastID == 0 {
+		fileCursor = nil
+	}
+
+	started := time.Now()
+	files, err := env.Database.MediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
 		PathPrefix: prefix,
-		Cursor:     cursor,
+		Cursor:     fileCursor,
 		Limit:      maxResults + 1,
 		Letter:     letter,
 		Sort:       sort,
 		Systems:    systems,
-	}
-	started := time.Now()
-	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
+	})
 	logBrowseTiming("files", prefix, started, len(files))
 	if err != nil {
 		return nil, fmt.Errorf("error browsing files: %w", err)
@@ -595,23 +742,69 @@ func browseFilesystem(
 
 	// Get total file count. First-page cursors carry this forward so loading
 	// additional pages in large directories does not repeat the same count query.
-	var totalFiles int
-	if cursor != nil && cursor.TotalFiles > 0 {
-		totalFiles = cursor.TotalFiles
-	} else if len(files) > 0 || cursor != nil {
-		started = time.Now()
-		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
-			PathPrefix: prefix,
-			Letter:     letter,
-			Systems:    systems,
-		})
-		logBrowseTiming("file_count", prefix, started, totalFiles)
+	if totalFiles == 0 && (len(files) > 0 || cursor != nil) {
+		totalFiles, err = browseTotalFileCount(ctx, env, prefix, letter, systems)
 		if err != nil {
-			return nil, fmt.Errorf("error getting file count: %w", err)
+			return nil, err
 		}
 	}
 
-	return buildBrowseResponse(env, cleaned, dirs, files, maxResults, totalFiles, sort, systems)
+	files, next, encErr := paginateFiles(files, maxResults, totalFiles, totalDirs, sort)
+	if encErr != nil {
+		return nil, encErr
+	}
+	return buildBrowseResponse(env, cleaned, nil, files, maxResults, totalFiles, totalDirs, next, next != nil, systems)
+}
+
+// browseTotalFileCount returns the direct-child file count for a path prefix,
+// logging the query timing.
+func browseTotalFileCount(
+	ctx context.Context,
+	env *requests.RequestEnv,
+	prefix string,
+	letter *string,
+	systems []systemdefs.System,
+) (int, error) {
+	started := time.Now()
+	count, err := env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		PathPrefix: prefix,
+		Letter:     letter,
+		Systems:    systems,
+	})
+	logBrowseTiming("file_count", prefix, started, count)
+	if err != nil {
+		return 0, fmt.Errorf("error getting file count: %w", err)
+	}
+	return count, nil
+}
+
+// paginateFiles trims an over-fetched file slice to the page limit and, when
+// more rows remain, encodes the keyset cursor for the next page.
+func paginateFiles(
+	files []database.SearchResultWithCursor,
+	limit int,
+	totalFiles, totalDirs int,
+	sort string,
+) (page []database.SearchResultWithCursor, next *string, err error) {
+	if len(files) <= limit {
+		return files, nil, nil
+	}
+	files = files[:limit]
+	last := files[len(files)-1]
+	sortValue := last.SortValue
+	if sortValue == "" {
+		switch sort {
+		case "filename-asc", "filename-desc":
+			sortValue = last.Path
+		default:
+			sortValue = last.Name
+		}
+	}
+	encoded, encErr := encodeFileCursor(last.MediaID, sortValue, last.SortMode, totalFiles, totalDirs)
+	if encErr != nil {
+		return nil, nil, fmt.Errorf("failed to encode cursor: %w", encErr)
+	}
+	return files, &encoded, nil
 }
 
 // browseVirtual lists all indexed media entries under a virtual URI scheme.
@@ -650,22 +843,24 @@ func browseVirtual(
 	if cursor != nil && cursor.TotalFiles > 0 {
 		totalFiles = cursor.TotalFiles
 	} else {
-		started = time.Now()
-		totalFiles, err = env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
-			PathPrefix: schemePath,
-			Letter:     letter,
-			Systems:    systems,
-		})
-		logBrowseTiming("virtual_file_count", schemePath, started, totalFiles)
+		totalFiles, err = browseTotalFileCount(ctx, env, schemePath, letter, systems)
 		if err != nil {
-			return nil, fmt.Errorf("error getting virtual file count: %w", err)
+			return nil, err
 		}
 	}
 
-	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, sort, systems)
+	files, next, encErr := paginateFiles(files, maxResults, totalFiles, 0, sort)
+	if encErr != nil {
+		return nil, encErr
+	}
+	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, 0, next, next != nil, systems)
 }
 
-// buildBrowseResponse assembles the BrowseResults from directories, files, and pagination info.
+// buildBrowseResponse assembles a BrowseResults page from directory and file
+// entries plus precomputed pagination. Directory entries are singleton-alias
+// enriched; pagination is attached whenever the page has entries so the caller's
+// next cursor (directory keyset, files-phase transition, or file keyset) is
+// surfaced.
 func buildBrowseResponse(
 	env *requests.RequestEnv,
 	path string,
@@ -673,92 +868,19 @@ func buildBrowseResponse(
 	files []database.SearchResultWithCursor,
 	maxResults int,
 	totalFiles int,
-	sort string,
+	totalDirs int,
+	nextCursor *string,
+	hasNextPage bool,
 	systems []systemdefs.System,
 ) (any, error) {
-	hasNextPage := len(files) > maxResults
-	if hasNextPage {
-		files = files[:maxResults]
-	}
-
-	entries := make([]models.BrowseEntry, 0, len(dirs)+len(files))
-
 	var rootDirs []string
 	if env.LauncherCache != nil && env.Platform != nil {
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
 
-	// Batch-resolve singleton container aliases for the page's candidate
-	// directories when browsing a single system. Only small dirs (recursive
-	// FileCount <= maxSingletonAliasCandidateFiles) are considered, so large
-	// trees like MiSTer's _Arcade/_alternatives are never scanned.
-	var singletonAliases map[string]database.SingletonContainerAlias
-	if len(dirs) > 0 && env.Database != nil && env.Database.MediaDB != nil {
-		// Determine which system to resolve against. Use the explicit filter if
-		// exactly one system was requested; otherwise infer from the directory
-		// entries (all dirs with media must belong to the same single system).
-		var systemID string
-		if len(systems) == 1 {
-			systemID = systems[0].ID
-		} else if len(systems) == 0 {
-			for _, dir := range dirs {
-				if len(dir.SystemIDs) == 0 {
-					continue
-				}
-				if len(dir.SystemIDs) > 1 || (systemID != "" && systemID != dir.SystemIDs[0]) {
-					systemID = ""
-					break
-				}
-				systemID = dir.SystemIDs[0]
-			}
-		}
-		var candidates []database.SingletonAliasCandidate
-		if systemID != "" {
-			prefix := path
-			if !strings.HasSuffix(prefix, "/") {
-				prefix += "/"
-			}
-			for _, dir := range dirs {
-				if !isSingletonDirectoryAliasCandidate(dir.FileCount) {
-					continue
-				}
-				if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
-					continue
-				}
-				candidates = append(candidates, database.SingletonAliasCandidate{
-					ChildDir:  prefix + dir.Name + "/",
-					FileCount: dir.FileCount,
-				})
-			}
-		}
-		if len(candidates) > 0 && singletonMediaAliasesEnabled(env) {
-			started := time.Now()
-			system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
-			if sysErr == nil {
-				aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
-					env.Context, system.DBID, candidates,
-				)
-				if aliasErr == nil && len(aliases) > 0 {
-					singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
-					for i := range aliases {
-						singletonAliases[aliases[i].ChildDir] = aliases[i]
-					}
-				} else if aliasErr != nil {
-					log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
-				}
-			} else {
-				log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
-			}
-			log.Debug().
-				Str("path", path).
-				Int("candidates", len(candidates)).
-				Int("aliases", len(singletonAliases)).
-				Dur("duration", time.Since(started)).
-				Msg("browse singleton alias resolution timing")
-		}
-	}
+	singletonAliases := resolveDirSingletonAliases(env, path, dirs, systems)
 
-	// Add directory entries
+	entries := make([]models.BrowseEntry, 0, len(dirs)+len(files))
 	for _, dir := range dirs {
 		dirPath := filepath.ToSlash(filepath.Join(path, dir.Name))
 		entry := models.BrowseEntry{
@@ -791,35 +913,13 @@ func buildBrowseResponse(
 		entries = append(entries, entry)
 	}
 
-	// Build file entries
 	for i := range files {
 		entry := buildMediaEntry(&files[i], env, rootDirs)
 		entries = append(entries, entry)
 	}
 
-	// Build pagination
 	var pagination *models.PaginationInfo
-	if len(files) > 0 {
-		var nextCursor *string
-		if hasNextPage {
-			lastResult := files[len(files)-1]
-			sortValue := lastResult.SortValue
-			if sortValue == "" {
-				switch sort {
-				case "filename-asc", "filename-desc":
-					sortValue = lastResult.Path
-				default:
-					sortValue = lastResult.Name
-				}
-			}
-			encoded, encErr := encodeBrowseCursorWithMode(
-				lastResult.MediaID, sortValue, lastResult.SortMode, totalFiles,
-			)
-			if encErr != nil {
-				return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
-			}
-			nextCursor = &encoded
-		}
+	if len(entries) > 0 {
 		pagination = &models.PaginationInfo{
 			NextCursor:  nextCursor,
 			HasNextPage: hasNextPage,
@@ -832,7 +932,94 @@ func buildBrowseResponse(
 		Entries:    entries,
 		Pagination: pagination,
 		TotalFiles: totalFiles,
+		TotalDirs:  totalDirs,
 	}, nil
+}
+
+// resolveDirSingletonAliases batch-resolves singleton container aliases for the
+// page's candidate directories when browsing a single system. Only small dirs
+// (recursive FileCount <= maxSingletonAliasCandidateFiles) are considered, so
+// large trees like MiSTer's _Arcade/_alternatives are never scanned.
+func resolveDirSingletonAliases(
+	env *requests.RequestEnv,
+	path string,
+	dirs []database.BrowseDirectoryResult,
+	systems []systemdefs.System,
+) map[string]database.SingletonContainerAlias {
+	if len(dirs) == 0 || env.Database == nil || env.Database.MediaDB == nil {
+		return nil
+	}
+
+	// Determine which system to resolve against. Use the explicit filter if
+	// exactly one system was requested; otherwise infer from the directory
+	// entries (all dirs with media must belong to the same single system).
+	var systemID string
+	if len(systems) == 1 {
+		systemID = systems[0].ID
+	} else if len(systems) == 0 {
+		for _, dir := range dirs {
+			if len(dir.SystemIDs) == 0 {
+				continue
+			}
+			if len(dir.SystemIDs) > 1 || (systemID != "" && systemID != dir.SystemIDs[0]) {
+				systemID = ""
+				break
+			}
+			systemID = dir.SystemIDs[0]
+		}
+	}
+	if systemID == "" {
+		return nil
+	}
+
+	var candidates []database.SingletonAliasCandidate
+	prefix := path
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	for _, dir := range dirs {
+		if !isSingletonDirectoryAliasCandidate(dir.FileCount) {
+			continue
+		}
+		if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
+			continue
+		}
+		candidates = append(candidates, database.SingletonAliasCandidate{
+			ChildDir:  prefix + dir.Name + "/",
+			FileCount: dir.FileCount,
+		})
+	}
+	if len(candidates) == 0 || !singletonMediaAliasesEnabled(env) {
+		return nil
+	}
+
+	started := time.Now()
+	system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
+	if sysErr != nil {
+		log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
+		return nil
+	}
+	aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
+		env.Context, system.DBID, candidates,
+	)
+	if aliasErr != nil {
+		log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
+		return nil
+	}
+	var singletonAliases map[string]database.SingletonContainerAlias
+	if len(aliases) > 0 {
+		singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
+		for i := range aliases {
+			singletonAliases[aliases[i].ChildDir] = aliases[i]
+		}
+	}
+	log.Debug().
+		Str("path", path).
+		Int("candidates", len(candidates)).
+		Int("aliases", len(singletonAliases)).
+		Dur("duration", time.Since(started)).
+		Msg("browse singleton alias resolution timing")
+	return singletonAliases
 }
 
 func browseMediaDisplayName(path, sortName, titleName string) string {

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -133,6 +133,12 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 		return nil, models.ClientErrf("invalid cursor data: %w", err)
 	}
 
+	switch data.Phase {
+	case "", browsePhaseDirs, browsePhaseFiles:
+	default:
+		return nil, models.ClientErrf("invalid cursor phase: %q", data.Phase)
+	}
+
 	return &database.BrowseCursor{
 		LastID:     data.LastID,
 		SortValue:  data.SortValue,
@@ -973,10 +979,6 @@ func resolveDirSingletonAliases(
 	}
 
 	var candidates []database.SingletonAliasCandidate
-	prefix := path
-	if !strings.HasSuffix(prefix, "/") {
-		prefix += "/"
-	}
 	for _, dir := range dirs {
 		if !isSingletonDirectoryAliasCandidate(dir.FileCount) {
 			continue
@@ -985,7 +987,7 @@ func resolveDirSingletonAliases(
 			continue
 		}
 		candidates = append(candidates, database.SingletonAliasCandidate{
-			ChildDir:  prefix + dir.Name + "/",
+			ChildDir:  filepath.ToSlash(filepath.Join(path, dir.Name)) + "/",
 			FileCount: dir.FileCount,
 		})
 	}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -77,9 +77,10 @@ func browseDirectoriesOpts(pathPrefix string) any {
 	})
 }
 
-func browseDirectoriesAfterOpts(pathPrefix, afterName string) any {
+func browseDirectoriesAfterOpts(pathPrefix, afterName string, limit int) any {
 	return mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
-		return opts.PathPrefix == pathPrefix && opts.AfterName == afterName && len(opts.Systems) == 0
+		return opts.PathPrefix == pathPrefix && opts.AfterName == afterName &&
+			opts.Limit == limit && len(opts.Systems) == 0
 	})
 }
 
@@ -1365,17 +1366,19 @@ func TestHandleMediaBrowse_DirPaginationCursorAdvance(t *testing.T) {
 	cursorStr, err := encodeDirCursor("Beta", 5, 10)
 	require.NoError(t, err)
 
+	path := "/roms/SNES"
+	maxResults := 2
+
 	mockMediaDB := helpers.NewMockMediaDBI()
-	// The next page is fetched with AfterName="Beta"; still more dirs remain.
-	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesAfterOpts("/roms/SNES/", "Beta")).
+	// The next page is fetched with AfterName="Beta" and the overfetch limit
+	// (maxResults+1) to detect whether more dirs remain.
+	mockMediaDB.On("BrowseDirectories", mock.Anything,
+		browseDirectoriesAfterOpts("/roms/SNES/", "Beta", maxResults+1)).
 		Return([]database.BrowseDirectoryResult{
 			{Name: "Delta", FileCount: 1},
 			{Name: "Epsilon", FileCount: 1},
 			{Name: "Zeta", FileCount: 1},
 		}, nil)
-
-	path := "/roms/SNES"
-	maxResults := 2
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
 		Path:       &path,
 		MaxResults: &maxResults,
@@ -1519,6 +1522,33 @@ func TestHandleMediaBrowse_CursorRoundTrip(t *testing.T) {
 	assert.False(t, browseResults.Pagination.HasNextPage)
 
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestDecodeBrowseCursor_RejectsInvalidPhase(t *testing.T) {
+	t.Parallel()
+
+	bogus, err := encodeCursorData(&browseCursorData{Phase: "bogus"})
+	require.NoError(t, err)
+
+	cursor, decErr := decodeBrowseCursor(bogus)
+	require.Error(t, decErr)
+	assert.Nil(t, cursor)
+	var clientErr *models.ClientError
+	assert.ErrorAs(t, decErr, &clientErr, "expected a client error for an invalid phase")
+}
+
+func TestDecodeBrowseCursor_AcceptsValidPhases(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []string{"", browsePhaseDirs, browsePhaseFiles} {
+		encoded, err := encodeCursorData(&browseCursorData{Phase: phase})
+		require.NoError(t, err)
+
+		cursor, decErr := decodeBrowseCursor(encoded)
+		require.NoError(t, decErr)
+		require.NotNil(t, cursor)
+		assert.Equal(t, phase, cursor.Phase)
+	}
 }
 
 func TestHandleMediaBrowse_CursorTotalFilesSkipsCountQuery(t *testing.T) {

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -77,6 +77,12 @@ func browseDirectoriesOpts(pathPrefix string) any {
 	})
 }
 
+func browseDirectoriesAfterOpts(pathPrefix, afterName string) any {
+	return mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
+		return opts.PathPrefix == pathPrefix && opts.AfterName == afterName && len(opts.Systems) == 0
+	})
+}
+
 func browseFileCountOpts(pathPrefix string, letter *string) any {
 	return mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
 		if opts.PathPrefix != pathPrefix || len(opts.Systems) != 0 {
@@ -103,6 +109,18 @@ func browseFilesSystemOpts(pathPrefix, systemID string) any {
 
 func browseFileCountSystemOpts(pathPrefix, systemID string) any {
 	return mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
+	})
+}
+
+func browseDirCountOpts(pathPrefix string) any {
+	return mock.MatchedBy(func(opts database.BrowseDirCountOptions) bool {
+		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 0
+	})
+}
+
+func browseDirCountSystemOpts(pathPrefix, systemID string) any {
+	return mock.MatchedBy(func(opts database.BrowseDirCountOptions) bool {
 		return opts.PathPrefix == pathPrefix && len(opts.Systems) == 1 && opts.Systems[0].ID == systemID
 	})
 }
@@ -473,7 +491,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -566,7 +584,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_UsesMediaDisplayNameFallbacks(t
 			}
 			result, err := buildBrowseResponse(env, path,
 				[]database.BrowseDirectoryResult{{Name: tt.dirName, FileCount: 1, SystemIDs: []string{"PSX"}}},
-				nil, defaultMaxResults, 0, "", systems)
+				nil, defaultMaxResults, 0, 0, nil, false, systems)
 			require.NoError(t, err)
 			browseResults, ok := result.(models.BrowseResults)
 			require.True(t, ok)
@@ -624,7 +642,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *tes
 	// No systems filter passed — inferred from dir.SystemIDs.
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
-		nil, defaultMaxResults, 0, "", nil)
+		nil, defaultMaxResults, 0, 0, nil, false, nil)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -657,7 +675,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_SkipsLookupForMixedDirSystems(t
 			{Name: "NES", FileCount: 1, SystemIDs: []string{"NES"}},
 			{Name: "SNES", FileCount: 1, SystemIDs: []string{"SNES"}},
 		},
-		nil, defaultMaxResults, 0, "", nil)
+		nil, defaultMaxResults, 0, 0, nil, false, nil)
 	require.NoError(t, err)
 
 	browseResults, ok := result.(models.BrowseResults)
@@ -689,7 +707,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsDisabledSkipsLook
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "Game.zip", FileCount: 1, SystemIDs: []string{"NES"}}},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -741,7 +759,7 @@ func TestBuildBrowseResponse_AnnotatesLogicalBinCueDirectory(t *testing.T) {
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "Game", FileCount: 2, SystemIDs: []string{"PSX"}}},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -779,7 +797,7 @@ func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "Collection", FileCount: 1, SystemIDs: []string{"NES"}}},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -811,7 +829,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirSkipsLookup(t *test
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: "_alternatives", FileCount: 5000, SystemIDs: []string{"Arcade"}}},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -867,7 +885,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirExcludedFromCandida
 			{Name: "Game", FileCount: 1, SystemIDs: []string{"NES"}},
 			{Name: "Collection", FileCount: 500, SystemIDs: []string{"NES"}},
 		},
-		nil, defaultMaxResults, 0, "", systems)
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
 	require.True(t, ok)
@@ -931,7 +949,7 @@ func TestBuildBrowseResponse_SingletonAnnotation_HasCoverPropagated(t *testing.T
 			}
 			result, err := buildBrowseResponse(env, path,
 				[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
-				nil, defaultMaxResults, 0, "", systems)
+				nil, defaultMaxResults, 0, 0, nil, false, systems)
 			require.NoError(t, err)
 			browseResults, ok := result.(models.BrowseResults)
 			require.True(t, ok)
@@ -1072,11 +1090,13 @@ func TestHandleMediaBrowse_FilesystemDirectory(t *testing.T) {
 			{Name: "NES", FileCount: 100},
 			{Name: "SNES", FileCount: 200},
 		}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts(romsAPIPath+"/")).
+		Return(2, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{}, nil)
-	// BrowseFileCount is skipped when BrowseFiles returns empty and no cursor
+	// The directory page also reports the total file count as the denominator.
 	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts(romsAPIPath+"/", nil)).
-		Return(0, nil).Maybe()
+		Return(0, nil)
 
 	path := romsAPIPath
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
@@ -1114,6 +1134,8 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(0, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
 			{
@@ -1169,6 +1191,8 @@ func TestHandleMediaBrowse_FilesystemFiltersBySystem(t *testing.T) {
 		Return([]database.BrowseDirectoryResult{
 			{Name: "RPG", FileCount: 3, SystemIDs: []string{"SNES"}},
 		}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountSystemOpts(sharedPrefix, "SNES")).
+		Return(1, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, browseFilesSystemOpts(sharedPrefix, "SNES")).
 		Return([]database.SearchResultWithCursor{
 			{
@@ -1217,6 +1241,8 @@ func TestHandleMediaBrowse_Pagination(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(0, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
 			{SystemID: "snes", Name: "Alpha", Path: "/roms/SNES/Alpha.sfc", MediaID: 1},
@@ -1258,6 +1284,187 @@ func TestHandleMediaBrowse_Pagination(t *testing.T) {
 	assert.Equal(t, int64(2), cursor.LastID)
 	assert.Equal(t, "Beta", cursor.SortValue)
 
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_DirPaginationPureDirPage(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	// maxResults=2 but 3 dirs are returned (limit maxResults+1=3), so more
+	// directories remain and the page is directory-only.
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
+		Return([]database.BrowseDirectoryResult{
+			{Name: "Alpha", FileCount: 1},
+			{Name: "Beta", FileCount: 1},
+			{Name: "Gamma", FileCount: 1},
+		}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(10, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
+		Return(5, nil)
+
+	path := "/roms/SNES"
+	maxResults := 2
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:       &path,
+		MaxResults: &maxResults,
+	})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	// Only the directory page (2 dirs) is returned; files are not fetched yet.
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, "directory", browseResults.Entries[0].Type)
+	assert.Equal(t, "Alpha", browseResults.Entries[0].Name)
+	assert.Equal(t, "directory", browseResults.Entries[1].Type)
+	assert.Equal(t, "Beta", browseResults.Entries[1].Name)
+	assert.Equal(t, 10, browseResults.TotalDirs)
+	assert.Equal(t, 5, browseResults.TotalFiles)
+
+	require.NotNil(t, browseResults.Pagination)
+	assert.True(t, browseResults.Pagination.HasNextPage)
+	require.NotNil(t, browseResults.Pagination.NextCursor)
+
+	// The cursor resumes the directory stream after the last returned dir.
+	cursor, decErr := decodeBrowseCursor(*browseResults.Pagination.NextCursor)
+	require.NoError(t, decErr)
+	require.NotNil(t, cursor)
+	assert.Equal(t, browsePhaseDirs, cursor.Phase)
+	assert.Equal(t, "Beta", cursor.DirName)
+	assert.Equal(t, 10, cursor.TotalDirs)
+	assert.Equal(t, 5, cursor.TotalFiles)
+
+	// Files are not queried while directories remain.
+	mockMediaDB.AssertNotCalled(t, "BrowseFiles", mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_DirPaginationCursorAdvance(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	// A dirs-phase cursor positioned after "Beta" carrying the first-page counts.
+	cursorStr, err := encodeDirCursor("Beta", 5, 10)
+	require.NoError(t, err)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	// The next page is fetched with AfterName="Beta"; still more dirs remain.
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesAfterOpts("/roms/SNES/", "Beta")).
+		Return([]database.BrowseDirectoryResult{
+			{Name: "Delta", FileCount: 1},
+			{Name: "Epsilon", FileCount: 1},
+			{Name: "Zeta", FileCount: 1},
+		}, nil)
+
+	path := "/roms/SNES"
+	maxResults := 2
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:       &path,
+		MaxResults: &maxResults,
+		Cursor:     &cursorStr,
+	})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, "Delta", browseResults.Entries[0].Name)
+	assert.Equal(t, "Epsilon", browseResults.Entries[1].Name)
+	// Counts are carried forward from the cursor, not recomputed.
+	assert.Equal(t, 10, browseResults.TotalDirs)
+	assert.Equal(t, 5, browseResults.TotalFiles)
+
+	require.NotNil(t, browseResults.Pagination)
+	assert.True(t, browseResults.Pagination.HasNextPage)
+	cursor, decErr := decodeBrowseCursor(*browseResults.Pagination.NextCursor)
+	require.NoError(t, decErr)
+	require.NotNil(t, cursor)
+	assert.Equal(t, browsePhaseDirs, cursor.Phase)
+	assert.Equal(t, "Epsilon", cursor.DirName)
+
+	// Cursor pages do not rerun the count queries.
+	mockMediaDB.AssertNotCalled(t, "BrowseDirCount", mock.Anything, mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "BrowseFileCount", mock.Anything, mock.Anything)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_DirToFileTransition(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	// Exactly maxResults dirs are returned (no extra row), so directories are
+	// exhausted but fill the whole page, leaving no room for files this page.
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
+		Return([]database.BrowseDirectoryResult{
+			{Name: "Alpha", FileCount: 1},
+			{Name: "Beta", FileCount: 1},
+		}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(2, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountOpts("/roms/SNES/", nil)).
+		Return(5, nil)
+
+	path := "/roms/SNES"
+	maxResults := 2
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path:       &path,
+		MaxResults: &maxResults,
+	})
+
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, "directory", browseResults.Entries[0].Type)
+	assert.Equal(t, "directory", browseResults.Entries[1].Type)
+	assert.Equal(t, 2, browseResults.TotalDirs)
+	assert.Equal(t, 5, browseResults.TotalFiles)
+
+	// More files remain, so the next cursor switches to the files phase from
+	// the beginning (no keyset).
+	require.NotNil(t, browseResults.Pagination)
+	assert.True(t, browseResults.Pagination.HasNextPage)
+	cursor, decErr := decodeBrowseCursor(*browseResults.Pagination.NextCursor)
+	require.NoError(t, decErr)
+	require.NotNil(t, cursor)
+	assert.Equal(t, browsePhaseFiles, cursor.Phase)
+	assert.Equal(t, int64(0), cursor.LastID)
+	assert.Equal(t, 5, cursor.TotalFiles)
+	assert.Equal(t, 2, cursor.TotalDirs)
+
+	// Files are not fetched on the boundary page (the page is full of dirs).
+	mockMediaDB.AssertNotCalled(t, "BrowseFiles", mock.Anything, mock.Anything)
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -1410,6 +1617,8 @@ func TestHandleMediaBrowse_FilenameSortCursor(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(0, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
 			{SystemID: "snes", Name: "Alpha", Path: "/roms/SNES/alpha.sfc", MediaID: 1},
@@ -1461,6 +1670,8 @@ func TestHandleMediaBrowse_NameDescSort(t *testing.T) {
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
 		Return([]database.BrowseDirectoryResult{}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(0, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
 			{SystemID: "snes", Name: "Zelda", Path: "/roms/SNES/Zelda.sfc", MediaID: 3},
@@ -1724,8 +1935,8 @@ func TestHandleMediaBrowse_WithLetterFilter(t *testing.T) {
 
 	letterM := "M"
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
-		Return([]database.BrowseDirectoryResult{}, nil)
+	// A letter filter browses files only — the directory phase is skipped,
+	// so BrowseDirectories/BrowseDirCount are never called.
 	mockMediaDB.On("BrowseFiles", mock.Anything, mock.Anything).
 		Return([]database.SearchResultWithCursor{
 			{

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -76,6 +76,7 @@ type BrowseResults struct {
 	Path       string          `json:"path"`
 	Entries    []BrowseEntry   `json:"entries"`
 	TotalFiles int             `json:"totalFiles"`
+	TotalDirs  int             `json:"totalDirs"`
 }
 
 // BrowseIndexGroup is one first-character section of a browse list. Key is the

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -346,20 +346,38 @@ type SingletonAliasCandidate struct {
 }
 
 // BrowseDirectoriesOptions contains parameters for the BrowseDirectories query.
+// AfterName is the keyset cursor for directory pagination: only directories
+// whose Name sorts strictly after it are returned (directory names are unique
+// within a parent, so Name alone is a stable keyset). Limit caps the number of
+// directories returned; 0 means no limit (full listing).
 type BrowseDirectoriesOptions struct {
+	PathPrefix string
+	AfterName  string
+	Systems    []systemdefs.System
+	Limit      int
+}
+
+// BrowseDirCountOptions contains parameters for the BrowseDirCount query.
+type BrowseDirCountOptions struct {
 	PathPrefix string
 	Systems    []systemdefs.System
 }
 
 // BrowseCursor holds the keyset pagination state for browse queries.
-// SortValue is the value of the sort column (Name or Path) from the last
-// result, LastID is the DBID tiebreaker, and TotalFiles carries the first-page
-// count so cursor pages do not need to rerun the same count query.
+//
+// media.browse pages directories first (ordered by Name), then files, under a
+// single cursor. Phase selects which stream the cursor resumes: "dirs" uses
+// DirName as the keyset, "files" (or empty, for legacy file-only cursors) uses
+// SortValue/SortMode/LastID. TotalFiles and TotalDirs carry the first-page
+// counts so cursor pages do not rerun the count queries.
 type BrowseCursor struct {
 	SortValue  string
 	SortMode   string
+	Phase      string
+	DirName    string
 	LastID     int64
 	TotalFiles int
+	TotalDirs  int
 }
 
 // BrowseFilesOptions contains parameters for the BrowseFiles query.
@@ -852,6 +870,7 @@ type MediaDBI interface {
 
 	// Browse methods for directory-style navigation of indexed content
 	BrowseDirectories(ctx context.Context, opts BrowseDirectoriesOptions) ([]BrowseDirectoryResult, error)
+	BrowseDirCount(ctx context.Context, opts BrowseDirCountOptions) (int, error)
 	BrowseFiles(ctx context.Context, opts *BrowseFilesOptions) ([]SearchResultWithCursor, error)
 	BrowseFileCount(ctx context.Context, opts BrowseFileCountOptions) (int, error)
 	BrowseIndex(ctx context.Context, opts BrowseIndexOptions) (BrowseIndexResult, error)

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1668,6 +1668,12 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
+	// spawns a goroutine + channel per rows.Next() call. A directory with
+	// thousands of children returns one row per child, so that per-row overhead
+	// dominates the scan on weak hardware (MiSTer). This is a bounded indexed
+	// read, so dropping mid-iteration cancellation is safe.
+	ctx = context.WithoutCancel(ctx)
 	results, err := sqlBrowseDirectories(ctx, db.sql.Load(), opts)
 	db.NoteCorruption(err)
 	return results, err

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1668,12 +1668,6 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
-	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
-	// spawns a goroutine + channel per rows.Next() call. A directory with
-	// thousands of children returns one row per child, so that per-row overhead
-	// dominates the scan on weak hardware (MiSTer). This is a bounded indexed
-	// read, so dropping mid-iteration cancellation is safe.
-	ctx = context.WithoutCancel(ctx)
 	results, err := sqlBrowseDirectories(ctx, db.sql.Load(), opts)
 	db.NoteCorruption(err)
 	return results, err
@@ -1701,6 +1695,18 @@ func (db *MediaDB) BrowseFileCount(
 		return 0, ErrNullSQL
 	}
 	return sqlBrowseFileCount(ctx, db.sql.Load(), opts)
+}
+
+// BrowseDirCount returns the total number of immediate child directories under a path prefix.
+func (db *MediaDB) BrowseDirCount(
+	ctx context.Context, opts database.BrowseDirCountOptions,
+) (int, error) {
+	if db.sql.Load() == nil {
+		return 0, ErrNullSQL
+	}
+	count, err := sqlBrowseDirCount(ctx, db.sql.Load(), opts)
+	db.NoteCorruption(err)
+	return count, err
 }
 
 // BrowseIndex returns the ordered first-character buckets for a browse scope,

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -381,7 +381,16 @@ func sqlBrowseDirectoriesFromMediaFallback(
 	if len(opts.Systems) > 0 {
 		return sqlBrowseDirectoriesForSystemsFromMedia(ctx, db, opts)
 	}
-	return sqlBrowseDirectoriesFromMedia(ctx, db, opts.PathPrefix)
+	return sqlBrowseDirectoriesFromMedia(ctx, db, opts)
+}
+
+// browseDirLimitClause returns a trailing LIMIT clause and its args for a
+// directory listing. A limit of 0 means no limit (full listing).
+func browseDirLimitClause(limit int) (clause string, args []any) {
+	if limit > 0 {
+		return " LIMIT ?", []any{limit}
+	}
+	return "", nil
 }
 
 func browseSystemIDsForLog(systems []systemdefs.System) []string {
@@ -408,7 +417,7 @@ func sqlBrowseDirectoriesFromCache(
 		return nil, false, nil
 	}
 	if len(opts.Systems) == 1 {
-		results, cacheErr := sqlBrowseDirectoriesFromCacheForSingleSystem(ctx, db, parentID, opts.Systems[0].ID)
+		results, cacheErr := sqlBrowseDirectoriesFromCacheForSingleSystem(ctx, db, parentID, opts)
 		return results, true, cacheErr
 	}
 
@@ -423,7 +432,15 @@ func sqlBrowseDirectoriesFromCache(
 		query += ` AND ` + systemClause
 		args = append(args, systemArgs...)
 	}
+	if opts.AfterName != "" {
+		query += ` AND d.Name > ?`
+		args = append(args, opts.AfterName)
+	}
 	query += ` GROUP BY d.DBID, d.Name ORDER BY d.Name ASC`
+	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
+		query += limitClause
+		args = append(args, limitArgs...)
+	}
 
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -451,17 +468,29 @@ func sqlBrowseDirectoriesFromCacheForSingleSystem(
 	ctx context.Context,
 	db sqlQueryable,
 	parentID int64,
-	systemID string,
+	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
-	rows, err := db.QueryContext(ctx, `SELECT d.Name, c.FileCount
+	systemID := opts.Systems[0].ID
+	args := []any{parentID, systemID}
+	query := `SELECT d.Name, c.FileCount
 		FROM BrowseDirCounts c
 		INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
 		INNER JOIN Systems s ON c.SystemDBID = s.DBID
 		WHERE c.ParentDirDBID = ?
 			AND c.ChildDirDBID != c.ParentDirDBID
 			AND d.IsVirtual = 0
-			AND s.SystemID = ?
-		ORDER BY d.Name ASC`, parentID, systemID)
+			AND s.SystemID = ?`
+	if opts.AfterName != "" {
+		query += ` AND d.Name > ?`
+		args = append(args, opts.AfterName)
+	}
+	query += ` ORDER BY d.Name ASC`
+	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
+		query += limitClause
+		args = append(args, limitArgs...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("browse cache single-system directories query: %w", err)
 	}
@@ -485,24 +514,30 @@ func sqlBrowseDirectoriesFromCacheForSingleSystem(
 func sqlBrowseDirectoriesFromMedia(
 	ctx context.Context,
 	db sqlQueryable,
-	pathPrefix string,
+	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
-	pathCondition, pathArgs := browsePathPrefixCondition("Path", pathPrefix)
-	args := append([]any{pathPrefix}, pathArgs...)
-	rows, err := db.QueryContext(ctx,
-		`WITH matched AS (
+	pathCondition, pathArgs := browsePathPrefixCondition("Path", opts.PathPrefix)
+	args := append([]any{opts.PathPrefix}, pathArgs...)
+	query := `WITH matched AS (
 			 SELECT substr(Path, length(?) + 1) AS Rest
 			 FROM Media
-			 WHERE IsMissing = 0 AND `+pathCondition+`
+			 WHERE IsMissing = 0 AND ` + pathCondition + `
 		 )
 		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
 			COUNT(*) AS FileCount
 		 FROM matched
 		 WHERE instr(Rest, '/') > 0
-		 GROUP BY Name
-		 ORDER BY Name ASC`,
-		args...,
-	)
+		 GROUP BY Name`
+	if opts.AfterName != "" {
+		query += ` HAVING Name > ?`
+		args = append(args, opts.AfterName)
+	}
+	query += ` ORDER BY Name ASC`
+	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
+		query += limitClause
+		args = append(args, limitArgs...)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("browse directories media query: %w", err)
 	}
@@ -533,22 +568,28 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 	args = append(args, opts.PathPrefix)
 	args = append(args, pathArgs...)
 	args = append(args, systemArgs...)
-	rows, err := db.QueryContext(ctx,
-		`WITH matched AS (
+	query := `WITH matched AS (
 			 SELECT substr(m.Path, length(?) + 1) AS Rest, s.SystemID
 			 FROM Media m
 			 INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			 WHERE m.IsMissing = 0 AND `+pathCondition+` AND `+systemClause+`
+			 WHERE m.IsMissing = 0 AND ` + pathCondition + ` AND ` + systemClause + `
 		 )
 		 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name,
 			COUNT(*) AS FileCount,
 			GROUP_CONCAT(DISTINCT SystemID)
 		 FROM matched
 		 WHERE instr(Rest, '/') > 0
-		 GROUP BY Name
-		 ORDER BY Name ASC`,
-		args...,
-	)
+		 GROUP BY Name`
+	if opts.AfterName != "" {
+		query += ` HAVING Name > ?`
+		args = append(args, opts.AfterName)
+	}
+	query += ` ORDER BY Name ASC`
+	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
+		query += limitClause
+		args = append(args, limitArgs...)
+	}
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("browse directories by system media query: %w", err)
 	}
@@ -1031,6 +1072,112 @@ func sqlBrowseFileCountFromMedia(
 	var count int
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("browse file count: %w", err)
+	}
+	return count, nil
+}
+
+// sqlBrowseDirCount returns the total number of immediate child directories
+// under a path prefix, routed the same way as the directory listing (cache when
+// ready and the parent is present, media otherwise) so the count matches what
+// the listing pages through.
+func sqlBrowseDirCount(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirCountOptions,
+) (int, error) {
+	ready, err := sqlBrowseCacheReady(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	if ready {
+		count, parentFound, cacheErr := sqlBrowseDirCountFromCache(ctx, db, opts)
+		if cacheErr != nil || parentFound {
+			return count, cacheErr
+		}
+	}
+	return sqlBrowseDirCountFromMedia(ctx, db, opts)
+}
+
+func sqlBrowseDirCountFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirCountOptions,
+) (count int, parentFound bool, err error) {
+	parentID, ok, err := sqlBrowseDirID(ctx, db, opts.PathPrefix)
+	if err != nil {
+		return 0, false, err
+	}
+	if !ok {
+		return 0, false, nil
+	}
+
+	args := []any{parentID}
+	base := `FROM BrowseDirCounts c
+		INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID
+		INNER JOIN Systems s ON c.SystemDBID = s.DBID
+		WHERE c.ParentDirDBID = ? AND c.ChildDirDBID != c.ParentDirDBID AND d.IsVirtual = 0`
+	if len(opts.Systems) == 1 {
+		base += ` AND s.SystemID = ?`
+		args = append(args, opts.Systems[0].ID)
+		if scanErr := db.QueryRowContext(ctx, `SELECT COUNT(*) `+base, args...).Scan(&count); scanErr != nil {
+			return 0, true, fmt.Errorf("browse cache single-system dir count: %w", scanErr)
+		}
+		return count, true, nil
+	}
+
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	if systemClause != "" {
+		base += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	if scanErr := db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT d.DBID) `+base, args...).Scan(&count); scanErr != nil {
+		return 0, true, fmt.Errorf("browse cache dir count: %w", scanErr)
+	}
+	return count, true, nil
+}
+
+func sqlBrowseDirCountFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirCountOptions,
+) (int, error) {
+	var (
+		inner string
+		args  []any
+	)
+	if len(opts.Systems) > 0 {
+		systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+		pathCondition, pathArgs := browsePathPrefixCondition("m.Path", opts.PathPrefix)
+		args = append(args, opts.PathPrefix)
+		args = append(args, pathArgs...)
+		args = append(args, systemArgs...)
+		inner = `WITH matched AS (
+				 SELECT substr(m.Path, length(?) + 1) AS Rest
+				 FROM Media m
+				 INNER JOIN Systems s ON m.SystemDBID = s.DBID
+				 WHERE m.IsMissing = 0 AND ` + pathCondition + ` AND ` + systemClause + `
+			 )
+			 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name
+			 FROM matched
+			 WHERE instr(Rest, '/') > 0
+			 GROUP BY Name`
+	} else {
+		pathCondition, pathArgs := browsePathPrefixCondition("Path", opts.PathPrefix)
+		args = append(args, opts.PathPrefix)
+		args = append(args, pathArgs...)
+		inner = `WITH matched AS (
+				 SELECT substr(Path, length(?) + 1) AS Rest
+				 FROM Media
+				 WHERE IsMissing = 0 AND ` + pathCondition + `
+			 )
+			 SELECT substr(Rest, 1, instr(Rest, '/') - 1) AS Name
+			 FROM matched
+			 WHERE instr(Rest, '/') > 0
+			 GROUP BY Name`
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (`+inner+`)`, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("browse dir count from media: %w", err)
 	}
 	return count, nil
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -229,6 +229,123 @@ func TestSqlBrowseDirectories_FallsBackWhenReadyCacheParentMissing(t *testing.T)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseDirectoriesFromCache_SingleSystemPaginates(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	gamesDir := browseTestDir("media", "fat", "games")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(gamesDir).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	// Keyset (AfterName) and overfetch (Limit) are bound after the system filter.
+	mock.ExpectQuery("SELECT d.Name, c.FileCount").
+		WithArgs(int64(10), "SNES", "Beta", 3).
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}).
+			AddRow("Delta", 1).AddRow("Epsilon", 1))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: gamesDir,
+		Systems:    []systemdefs.System{{ID: "SNES"}},
+		AfterName:  "Beta",
+		Limit:      3,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "Delta", results[0].Name)
+	assert.Equal(t, "Epsilon", results[1].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectoriesFromCache_MultiSystemPaginates(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	gamesDir := browseTestDir("media", "fat", "games")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(gamesDir).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	// System filter args precede the keyset and overfetch limit.
+	mock.ExpectQuery("SELECT d.Name, SUM").
+		WithArgs(int64(10), "NES", "SNES", "Beta", 3).
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+			AddRow("Delta", 1, "SNES").AddRow("Epsilon", 1, "NES"))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: gamesDir,
+		Systems:    []systemdefs.System{{ID: "NES"}, {ID: "SNES"}},
+		AfterName:  "Beta",
+		Limit:      3,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "Delta", results[0].Name)
+	assert.Equal(t, "Epsilon", results[1].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectories_MediaFallbackPaginates(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigBrowseIndexVersion).
+		WillReturnError(sql.ErrNoRows)
+	romsDir := browseTestDir("roms")
+	// HAVING keyset and LIMIT are bound after the path-prefix args.
+	mock.ExpectQuery("WITH matched AS").
+		WithArgs(romsDir, romsDir, stringPrefixUpperBound(romsDir), "Beta", 3).
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount"}).
+			AddRow("Delta", 2).AddRow("Epsilon", 2))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: romsDir,
+		AfterName:  "Beta",
+		Limit:      3,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "Delta", results[0].Name)
+	assert.Equal(t, "Epsilon", results[1].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirectoriesForSystems_MediaFallbackPaginates(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigBrowseIndexVersion).
+		WillReturnError(sql.ErrNoRows)
+	psxDir := browseTestDir("media", "fat", "games", "PSX")
+	// Path-prefix args, then system filter, then keyset and limit.
+	mock.ExpectQuery("WITH matched AS").
+		WithArgs(psxDir, psxDir, stringPrefixUpperBound(psxDir), "PSX", "Beta", 3).
+		WillReturnRows(sqlmock.NewRows([]string{"Name", "FileCount", "SystemIDs"}).
+			AddRow("USA", 273, "PSX").AddRow("World", 10, "PSX"))
+
+	results, err := sqlBrowseDirectories(context.Background(), db, database.BrowseDirectoriesOptions{
+		PathPrefix: psxDir,
+		Systems:    []systemdefs.System{{ID: "PSX"}},
+		AfterName:  "Beta",
+		Limit:      3,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "USA", results[0].Name)
+	assert.Equal(t, "World", results[1].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseDirCount_CacheSingleSystem(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -229,6 +229,99 @@ func TestSqlBrowseDirectories_FallsBackWhenReadyCacheParentMissing(t *testing.T)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseDirCount_CacheSingleSystem(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	gamesDir := browseTestDir("media", "fat", "games")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(gamesDir).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM BrowseDirCounts").
+		WithArgs(int64(10), "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
+
+	count, err := sqlBrowseDirCount(context.Background(), db, database.BrowseDirCountOptions{
+		PathPrefix: gamesDir,
+		Systems:    []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 7, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirCount_CacheNoSystemUsesDistinct(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	gamesDir := browseTestDir("media", "fat", "games")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(gamesDir).
+		WillReturnRows(sqlmock.NewRows([]string{"DBID"}).AddRow(10))
+	mock.ExpectQuery("SELECT COUNT\\(DISTINCT d.DBID\\) FROM BrowseDirCounts").
+		WithArgs(int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(13))
+
+	count, err := sqlBrowseDirCount(context.Background(), db, database.BrowseDirCountOptions{
+		PathPrefix: gamesDir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 13, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirCount_FallsBackToMediaWhenParentMissing(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	expectBrowseCacheReady(mock)
+	romsDir := browseTestDir("roms")
+	mock.ExpectQuery("SELECT DBID FROM BrowseDirs WHERE Path = ").
+		WithArgs(romsDir).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM \\(WITH matched AS").
+		WithArgs(romsDir, romsDir, stringPrefixUpperBound(romsDir)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(4))
+
+	count, err := sqlBrowseDirCount(context.Background(), db, database.BrowseDirCountOptions{
+		PathPrefix: romsDir,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 4, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlBrowseDirCount_FallsBackToMediaWhenCacheNotReady(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT Value FROM DBConfig WHERE Name = ").
+		WithArgs(DBConfigBrowseIndexVersion).
+		WillReturnError(sql.ErrNoRows)
+	romsDir := browseTestDir("roms")
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM \\(WITH matched AS").
+		WithArgs(romsDir, romsDir, stringPrefixUpperBound(romsDir), "SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(9))
+
+	count, err := sqlBrowseDirCount(context.Background(), db, database.BrowseDirCountOptions{
+		PathPrefix: romsDir,
+		Systems:    []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 9, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlBrowseVirtualSchemesFromCache_ReturnsEmptyWithoutMediaFallback(t *testing.T) {
 	t.Parallel()
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -3106,14 +3106,6 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
 	}
 
-	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
-	// spawns a goroutine + channel per rows.Next() call. This function runs five
-	// bulk reads that each return up to one row per candidate directory, so on a
-	// large folder (thousands of singleton containers) that per-row overhead
-	// dominates on weak hardware (MiSTer). These are bounded indexed reads, so
-	// dropping mid-iteration cancellation is safe.
-	ctx = context.WithoutCancel(ctx)
-
 	// Per-step timing, emitted once at debug level so the on-device breakdown of
 	// a slow resolution is visible without changing behaviour.
 	var inScanDur, fullRowsDur, tagsDur, zapDur, coverDur time.Duration

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -3106,6 +3106,30 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 		return nil, nil //nolint:nilnil // empty result is the "no aliases" sentinel, not an error
 	}
 
+	// Non-cancellable context: with a cancellable context, mattn/go-sqlite3
+	// spawns a goroutine + channel per rows.Next() call. This function runs five
+	// bulk reads that each return up to one row per candidate directory, so on a
+	// large folder (thousands of singleton containers) that per-row overhead
+	// dominates on weak hardware (MiSTer). These are bounded indexed reads, so
+	// dropping mid-iteration cancellation is safe.
+	ctx = context.WithoutCancel(ctx)
+
+	// Per-step timing, emitted once at debug level so the on-device breakdown of
+	// a slow resolution is visible without changing behaviour.
+	var inScanDur, fullRowsDur, tagsDur, zapDur, coverDur time.Duration
+	var inScanRows int
+	defer func() {
+		log.Debug().
+			Int("candidates", len(dirCandidates)).
+			Int("inScanRows", inScanRows).
+			Dur("inScanDuration", inScanDur).
+			Dur("fullRowsDuration", fullRowsDur).
+			Dur("tagsDuration", tagsDur).
+			Dur("zapScriptDuration", zapDur).
+			Dur("coverFlagsDuration", coverDur).
+			Msg("resolve singleton aliases step timing")
+	}()
+
 	expectedCounts := make(map[string]int, len(dirCandidates))
 	args := make([]any, 0, 1+len(dirCandidates))
 	args = append(args, systemDBID)
@@ -3120,6 +3144,7 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 
 	// One query for the direct media rows of all candidate dirs, served by
 	// idx_media_parentdir_system.
+	inScanStart := time.Now()
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
 	rows, err := db.sql.Load().QueryContext(ctx, `
 		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
@@ -3144,10 +3169,12 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 			return nil, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
 		}
 		childDirRows[m.ParentDir] = append(childDirRows[m.ParentDir], m)
+		inScanRows++
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
 		return nil, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
 	}
+	inScanDur = time.Since(inScanStart)
 
 	// For each candidate dir: skip if the recursive FileCount exceeds the
 	// direct rows (media in nested subdirectories). Otherwise apply
@@ -3177,14 +3204,18 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	for _, c := range candidates {
 		mediaDBIDs = append(mediaDBIDs, c.media.DBID)
 	}
+	fullRowsStart := time.Now()
 	fullRows, err := db.GetMediaWithTitleAndSystemByIDs(ctx, mediaDBIDs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases full rows: %w", err)
 	}
+	fullRowsDur = time.Since(fullRowsStart)
+	tagsStart := time.Now()
 	tagsMap, err := db.GetMediaTagsByMediaDBIDs(ctx, mediaDBIDs)
 	if err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases tags: %w", err)
 	}
+	tagsDur = time.Since(tagsStart)
 
 	// Build the alias list and a parallel synthetic results slice carrying each
 	// title's stored DisambiguationTypes, which attachZapScriptTags reads to
@@ -3215,18 +3246,22 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	}
 
 	// Populate ZapScriptTags from each title's precomputed disambiguating types.
+	zapStart := time.Now()
 	if err := attachZapScriptTags(ctx, db.sql.Load(), synthetic); err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases disambiguation: %w", err)
 	}
+	zapDur = time.Since(zapStart)
 	for i := range aliases {
 		aliases[i].ZapScriptTags = synthetic[i].ZapScriptTags
 	}
 
 	// Batch cover-flag check: one indexed UNION ALL query for all alias media.
 	// Populates HasCover so aliased directory entries show art in the grid.
+	coverStart := time.Now()
 	if err := fetchAndAttachCoverFlags(ctx, db.sql.Load(), synthetic); err != nil {
 		return nil, fmt.Errorf("resolve singleton aliases cover flags: %w", err)
 	}
+	coverDur = time.Since(coverStart)
 	for i := range aliases {
 		aliases[i].HasCover = synthetic[i].HasCover
 	}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2570,6 +2570,22 @@ func (m *MockMediaDBI) BrowseDirectories(
 	return []database.BrowseDirectoryResult{}, nil
 }
 
+func (m *MockMediaDBI) BrowseDirCount(
+	ctx context.Context, opts database.BrowseDirCountOptions,
+) (int, error) {
+	args := m.Called(ctx, opts)
+	if count, ok := args.Get(0).(int); ok {
+		if err := args.Error(1); err != nil {
+			return count, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return count, nil
+	}
+	if err := args.Error(1); err != nil {
+		return 0, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return 0, nil
+}
+
 func (m *MockMediaDBI) BrowseFiles(
 	ctx context.Context, opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {


### PR DESCRIPTION
## Problem

`media.browse` ignored `max_results` for directory entries. `browseFilesystem` fetched the entire directory listing whenever the cursor was nil — pagination was file-only. For a folder whose children are all game directories (`ZipsAsDirs` platforms, e.g. a MiSTer console folder with 2613 entries), Core returned every directory on page 1 and resolved singleton-container aliases for all of them.

On-device that single oversized page took ~16s, holding the single SQLite connection (`SetMaxOpenConns(1)`) long enough for concurrent `media.image`/`media.meta` requests to exceed the 30s `APIRequestTimeout`, drop the WebSocket, and reconnect into the same loop (#1022).

## Change

- Honor `max_results` for directories. The browse cursor gains a phase discriminator (`dirs`/`files`) and a directory keyset; directories page first by name, then files, under one cursor.
- Mixed boundary pages: when directories do not fill a page, the remaining slots are filled with the first files, so small folders still return in one round-trip. Pure-directory pages occur only when more directories remain than the page holds.
- Each page resolves singleton aliases for only its page of directories instead of the whole folder.
- Add `TotalDirs` to `BrowseResults`, backed by a new `BrowseDirCount` query that uses the existing browse cache with a `Media`-table fallback, so clients can size the scroll range without loading every entry.

No schema change and no reindex required: the new queries read existing cache tables and fall back to the `Media` table.

## Supersedes #1029

The per-row goroutine overhead that #1029 worked around with `context.WithoutCancel` is now bounded by pagination (~`page_size` rows per read), so the bulk reads in `ResolveSingletonContainerAliases` and `BrowseDirectories` use the request context directly and keep the request deadline — resolving the two CodeRabbit findings on that PR. The per-step timing instrumentation from #1029 is retained.

## Coordination

Paired with the launcher change (ZaparooProject/zaparoo-frontend) that consumes `totalDirs` and accepts paginated directory pages. Each side is backward compatible on its own (old launcher ignores the new field and extra pages; new launcher defaults `total_dirs` to 0 against old Core), but the freeze is only fully resolved when both are updated.

Refs #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Browse responses now return `totalDirs` alongside existing totals.
  - Directory browsing supports keyset-style `AfterName` pagination with an optional limit.
  - Directory and file browsing paginate together via a phase-aware cursor, including seamless transition from directories to files.

- **Bug Fixes**
  - Letter-based filtering now skips the directory phase entirely.
  - Browse pagination more reliably preserves position, and directory/file totals are carried forward to reduce inconsistent count recalculations.

- **Tests**
  - Expanded coverage for cursor validation, pagination boundaries, and directory count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->