### PR TITLE
fix(database): populate MediaTitleID on singleton container aliases

### DIFF
--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -868,6 +868,12 @@ func sqlBrowseFilesFromMedia(
 // DBIDs are resolved once per database handle, so every browse page can check
 // MediaProperties/MediaTitleProperties directly without joining Tags/TagTypes
 // or LIKE-scanning tag strings. Results with no image property get HasCover=false.
+//
+// The title-scope check keys off MediaTitleID. A caller that builds results
+// without populating it (e.g. a synthetic singleton container alias) would
+// otherwise silently skip title-scoped covers, blanking the grid for folder-based
+// systems. backfillMissingTitleIDs resolves any missing IDs first, so cover flags
+// are correct regardless of which fields the caller filled in.
 func fetchAndAttachCoverFlags(
 	ctx context.Context,
 	db sqlQueryable,
@@ -883,6 +889,10 @@ func fetchAndAttachCoverFlags(
 	}
 	if len(imageTagIDs) == 0 {
 		return nil
+	}
+
+	if err = backfillMissingTitleIDs(ctx, db, results); err != nil {
+		return fmt.Errorf("browse cover flags backfill title ids: %w", err)
 	}
 
 	mediaIDs := make([]int64, 0, len(results))
@@ -960,6 +970,59 @@ func fetchAndAttachCoverFlags(
 	}
 	if err = rows.Err(); err != nil {
 		return fmt.Errorf("browse cover flags rows: %w", err)
+	}
+	return nil
+}
+
+// backfillMissingTitleIDs populates MediaTitleID for any result that has a MediaID
+// but no MediaTitleID, resolving it from the Media row (Media.MediaTitleDBID is NOT
+// NULL). Callers that already set MediaTitleID — the file-browse path — pay nothing:
+// the function returns before querying when no result is missing a title ID. The
+// lookup is a single primary-key IN query, so it stays cheap for the alias path.
+func backfillMissingTitleIDs(
+	ctx context.Context,
+	db sqlQueryable,
+	results []database.SearchResultWithCursor,
+) error {
+	missing := make([]int64, 0)
+	byMediaID := make(map[int64][]int)
+	for i := range results {
+		if results[i].MediaTitleID != 0 || results[i].MediaID == 0 {
+			continue
+		}
+		if _, ok := byMediaID[results[i].MediaID]; !ok {
+			missing = append(missing, results[i].MediaID)
+		}
+		byMediaID[results[i].MediaID] = append(byMediaID[results[i].MediaID], i)
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	placeholders := prepareVariadic("?", ",", len(missing))
+	args := make([]any, len(missing))
+	for i, id := range missing {
+		args[i] = id
+	}
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
+	rows, err := db.QueryContext(ctx,
+		`SELECT DBID, MediaTitleDBID FROM Media WHERE DBID IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return fmt.Errorf("query media title ids: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var mediaID, titleID int64
+		if scanErr := rows.Scan(&mediaID, &titleID); scanErr != nil {
+			return fmt.Errorf("scan media title id: %w", scanErr)
+		}
+		for _, idx := range byMediaID[mediaID] {
+			results[idx].MediaTitleID = titleID
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("media title id rows: %w", err)
 	}
 	return nil
 }

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -62,6 +62,89 @@ func benchBrowseFilesTagAttach(b *testing.B, name string, withTags bool) {
 	})
 }
 
+// BenchmarkCoverFlags_Attach measures fetchAndAttachCoverFlags for a browse page
+// whose covers are title-scoped (the common case: scrapers store artwork at the
+// title level). Results carry MediaTitleID as the production callers populate it,
+// so this measures the cover query itself rather than the backfill fallback.
+func BenchmarkCoverFlags_Attach(b *testing.B) {
+	for _, page := range []int{100, 500} {
+		b.Run(fmt.Sprintf("title-scope-%d", page), func(b *testing.B) {
+			b.ReportAllocs()
+			ctx := context.Background()
+			mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+			defer cleanup()
+			mediaIDs := seedBenchCoverFlagsDB(b, mediaDB, page)
+
+			results := make([]database.SearchResultWithCursor, len(mediaIDs))
+			for i, id := range mediaIDs {
+				// One media per title in the seeder, so titleID == mediaID.
+				results[i] = database.SearchResultWithCursor{MediaID: id, MediaTitleID: id}
+			}
+			// Warm the per-handle image property tag cache so the benchmark
+			// measures the cover query, not the one-off tag lookup.
+			require.NoError(b, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), results))
+
+			b.ResetTimer()
+			for b.Loop() {
+				if err := fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), results); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// seedBenchCoverFlagsDB inserts `rows` titles, one media each, and a title-scope
+// image-boxart property per title. Returns the media DBIDs in insertion order.
+func seedBenchCoverFlagsDB(b *testing.B, mediaDB *MediaDB, rows int) []int64 {
+	b.Helper()
+	ctx := context.Background()
+	parentDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "cover")) + "/"
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'Bench', 'Bench');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES (900, 'property', 0);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES (901, 900, 'image-boxart');
+	`)
+	require.NoError(b, err)
+
+	titleStmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 1, ?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, titleStmt.Close()) }()
+
+	mediaStmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName) VALUES (?, ?, 1, ?, ?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, mediaStmt.Close()) }()
+
+	propStmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO MediaTitleProperties (MediaTitleDBID, TypeTagDBID, Text) VALUES (?, 901, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, propStmt.Close()) }()
+
+	mediaIDs := make([]int64, 0, rows)
+	for i := 1; i <= rows; i++ {
+		id := int64(i)
+		slug := fmt.Sprintf("cover-game-%05d", i)
+		name := fmt.Sprintf("Cover Game %05d", i)
+		path := filepath.ToSlash(filepath.Join(parentDir, fmt.Sprintf("cover-game-%05d", i), "game.chd"))
+		_, err = titleStmt.ExecContext(ctx, id, slug, name)
+		require.NoError(b, err)
+		_, err = mediaStmt.ExecContext(ctx, id, id, path, parentDir, name)
+		require.NoError(b, err)
+		_, err = propStmt.ExecContext(ctx, id, fmt.Sprintf("art/%05d.png", i))
+		require.NoError(b, err)
+		mediaIDs = append(mediaIDs, id)
+	}
+
+	require.NoError(b, tx.Commit())
+	return mediaIDs
+}
+
 func setupBrowseBenchMediaDB(b *testing.B) (mediaDB *MediaDB, cleanup func()) {
 	b.Helper()
 	tempDir, err := os.MkdirTemp("", "zaparoo-browse-bench-mediadb-*")

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -775,14 +775,16 @@ func TestFetchAndAttachCoverFlags_NoCoverEntries(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	results := []database.SearchResultWithCursor{
-		{MediaID: 1, Name: "NoCoverGame"},
-		{MediaID: 2, Name: "AnotherNoCoverGame"},
+		{MediaID: 1, MediaTitleID: 101, Name: "NoCoverGame"},
+		{MediaID: 2, MediaTitleID: 102, Name: "AnotherNoCoverGame"},
 	}
 
-	// Query returns no rows — neither media ID has any image property.
+	// Query returns no rows — neither media ID has any image property. Title IDs
+	// are populated so no backfill query runs; the media leg binds mediaIDs and
+	// the title leg binds titleIDs.
 	expectImagePropertyTagLookup(mock, 901)
 	mock.ExpectQuery(`SELECT 'media' AS Scope, mp\.MediaDBID AS ID`).
-		WithArgs(int64(1), int64(2), int64(901)).
+		WithArgs(int64(1), int64(2), int64(901), int64(101), int64(102), int64(901)).
 		WillReturnRows(sqlmock.NewRows([]string{"Scope", "ID"}))
 
 	err = fetchAndAttachCoverFlags(context.Background(), db, results)
@@ -799,14 +801,14 @@ func TestFetchAndAttachCoverFlags_MediaLevelCover(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	results := []database.SearchResultWithCursor{
-		{MediaID: 10, Name: "GameWithCover"},
-		{MediaID: 20, Name: "GameWithoutCover"},
+		{MediaID: 10, MediaTitleID: 110, Name: "GameWithCover"},
+		{MediaID: 20, MediaTitleID: 120, Name: "GameWithoutCover"},
 	}
 
 	// Query returns mediaID 10 as having a cover (media-level property).
 	expectImagePropertyTagLookup(mock, 901)
 	mock.ExpectQuery(`SELECT 'media' AS Scope, mp\.MediaDBID AS ID`).
-		WithArgs(int64(10), int64(20), int64(901)).
+		WithArgs(int64(10), int64(20), int64(901), int64(110), int64(120), int64(901)).
 		WillReturnRows(sqlmock.NewRows([]string{"Scope", "ID"}).AddRow("media", int64(10)))
 
 	err = fetchAndAttachCoverFlags(context.Background(), db, results)
@@ -849,12 +851,12 @@ func TestFetchAndAttachCoverFlags_QueryError(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	results := []database.SearchResultWithCursor{
-		{MediaID: 5, Name: "SomeGame"},
+		{MediaID: 5, MediaTitleID: 105, Name: "SomeGame"},
 	}
 
 	expectImagePropertyTagLookup(mock, 901)
 	mock.ExpectQuery(`SELECT 'media' AS Scope, mp\.MediaDBID AS ID`).
-		WithArgs(int64(5), int64(901)).
+		WithArgs(int64(5), int64(901), int64(105), int64(901)).
 		WillReturnError(errors.New("db unavailable"))
 
 	err = fetchAndAttachCoverFlags(context.Background(), db, results)
@@ -988,6 +990,53 @@ func TestFetchAndAttachCoverFlags_Integration_TitleLevelProperty(t *testing.T) {
 	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), results))
 	assert.True(t, results[0].HasCover, "media whose title has an image property should have HasCover=true")
 	assert.True(t, results[1].HasCover, "media whose title has an image property should have HasCover=true")
+}
+
+// TestFetchAndAttachCoverFlags_Integration_TitleCoverWithoutMediaTitleID verifies
+// that a title-scoped cover is detected even when the result omits MediaTitleID.
+// The cover query resolves the title through the Media row (Media.MediaTitleDBID is
+// NOT NULL), so callers that build results without populating MediaTitleID — such as
+// singleton container aliases — still get correct title-scope cover flags. This
+// guards against the regression where folder-based systems showed a blank grid.
+func TestFetchAndAttachCoverFlags_Integration_TitleCoverWithoutMediaTitleID(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	seedImagePropertyTags(t, mediaDB)
+
+	ctx := context.Background()
+
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Title Only Cover"),
+		Name:       "Title Only Cover",
+	})
+	require.NoError(t, err)
+	media, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "title_only.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	require.NoError(t, mediaDB.UpsertMediaTitleProperties(ctx, title.DBID, []database.MediaProperty{
+		{TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageBoxart), Text: filepath.Join("art", "title_only.png")},
+	}))
+
+	// MediaTitleID deliberately left zero, mirroring a synthetic result.
+	results := []database.SearchResultWithCursor{
+		{MediaID: media.DBID, Name: "Title Only Cover"},
+	}
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), results))
+	assert.True(t, results[0].HasCover,
+		"title-scope cover must resolve via the Media row even when MediaTitleID is omitted")
 }
 
 // TestFetchAndAttachCoverFlags_Integration_TagsSeededAfterFirstBrowse reproduces the

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -3232,6 +3232,7 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 			SystemID:            row.System.SystemID,
 			Name:                row.Title.Name,
 			MediaID:             row.DBID,
+			MediaTitleID:        row.Title.DBID,
 			Tags:                mediaTags,
 			DisambiguationTypes: row.Title.DisambiguationTypes,
 		})

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2548,3 +2548,60 @@ func TestResolveSingletonContainerAliases_HasCoverSet(t *testing.T) {
 	assert.True(t, byDir[coverDir].HasCover, "aliased dir with image property should have HasCover=true")
 	assert.False(t, byDir[noCoverDir].HasCover, "aliased dir without image property should have HasCover=false")
 }
+
+// TestResolveSingletonContainerAliases_HasCoverSetFromTitleProperty verifies that
+// HasCover is true when the cover art is title-scoped (MediaTitleProperties) rather
+// than media-scoped. Scrapers store artwork at the title level, so without the
+// alias's MediaTitleID populated the cover-flag lookup skips the title-scope branch
+// and folder-based systems (e.g. PSX) render a blank grid.
+func TestResolveSingletonContainerAliases_HasCoverSetFromTitleProperty(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed the minimal tag rows needed by fetchAndAttachCoverFlags.
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT OR IGNORE INTO TagTypes (DBID, Type, IsExclusive) VALUES (900, 'property', 0);
+		INSERT OR IGNORE INTO Tags    (DBID, TypeDBID, Tag)      VALUES (901, 900, 'image-boxart');
+	`)
+	require.NoError(t, err)
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+
+	// gameWithCover — title-level image property inserted below.
+	coverDir := aliasTestDir(parent, "WithCover")
+	coverPath := filepath.ToSlash(filepath.Join(parent, "WithCover", "cover.chd"))
+	// gameNoCover — no property.
+	noCoverDir := aliasTestDir(parent, "NoCover")
+	noCoverPath := filepath.ToSlash(filepath.Join(parent, "NoCover", "nocov.chd"))
+
+	_, err = mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES
+			(1, 2, 'with-cover', 'With Cover'),
+			(2, 2, 'no-cover',   'No Cover');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 2, 2, ?, ?);
+	`, coverPath, coverDir, noCoverPath, noCoverDir)
+	require.NoError(t, err)
+
+	// Title-scope property for MediaTitle DBID=1 (no media-scope property anywhere).
+	_, err = mediaDB.sql.Load().ExecContext(ctx,
+		`INSERT INTO MediaTitleProperties (MediaTitleDBID, TypeTagDBID, Text) VALUES (1, 901, 'cover.jpg')`)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: coverDir, FileCount: 1},
+		{ChildDir: noCoverDir, FileCount: 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 2)
+
+	byDir := make(map[string]database.SingletonContainerAlias, 2)
+	for _, a := range aliases {
+		byDir[a.ChildDir] = a
+	}
+	assert.True(t, byDir[coverDir].HasCover, "aliased dir with title-scope image property should have HasCover=true")
+	assert.False(t, byDir[noCoverDir].HasCover, "aliased dir without image property should have HasCover=false")
+}


### PR DESCRIPTION
## Problem

Since v2.15.0, browse-grid artwork stopped appearing for folder-based systems (e.g. PSX, and "most consoles" whose games are stored as directories). Rescraping and restarting did not help.

## Root cause

Singleton container aliases resolve a folder containing a single media to that media, so a directory entry behaves like a game. `ResolveSingletonContainerAliases` builds a synthetic set of results and passes them to `fetchAndAttachCoverFlags` to compute `HasCover`, but the synthetic struct omitted `MediaTitleID`.

`fetchAndAttachCoverFlags` skips its title-scope lookup when `MediaTitleID == 0`. Scrapers store artwork at the **title** level (`MediaTitleProperties`), so with `MediaTitleID` unset, every aliased directory entry got `HasCover=false`. The client then saw zero covers for the screen and never requested any art — a blank grid that survives rescrapes and restarts because it is a code defect, not a stale cache.

File-based systems (e.g. SNES inside a zip) were unaffected because their browse path (`sqlBrowseFilesFromMedia`) already populates `MediaTitleID`.

Introduced by #969 (title-global tag disambiguation). #1030 only added timing logs to this function.

## Fix

Two commits:

1. **Populate `MediaTitleID` on singleton aliases** — set it from the already-loaded `row.Title.DBID` on the synthetic result so the title-scope cover check runs. One field; no schema, API, or migration change. Existing `media.db` files already contain the correct title-scoped artwork, so no rescrape is needed.

2. **Derive missing title IDs in the cover-flag path (hardening)** — `fetchAndAttachCoverFlags` previously depended on every caller populating `MediaTitleID`; `== 0` was indistinguishable from "no title", which is exactly the trap #969 fell into. It now resolves any missing `MediaTitleID` from the `Media` row (`Media.MediaTitleDBID` is `NOT NULL`) before the cover query, so a future caller that omits the field can't silently reintroduce the blank grid.

   The backfill is a single primary-key `IN` lookup that runs **only** when a result is missing its title id — the file-browse path already populates it and queries nothing extra. The proven cover query is unchanged. A SQL-join alternative was prototyped and rejected: it regressed the cover query ~26× at 500 entries (SQLite plans `Media.DBID IN (...)` + join as O(n²)). The Go-side backfill keeps the path performance-neutral:

   | entries | before | after |
   |--------:|-------:|------:|
   | 100     | ~115µs | ~118µs |
   | 500     | ~552µs | ~552µs |

## Tests / benchmarks

- `TestResolveSingletonContainerAliases_HasCoverSetFromTitleProperty` — seeds a title-scope `image-boxart` property (no media-scope property) and asserts the alias gets `HasCover=true`. The pre-existing `HasCoverSet` test only exercised media-scope, which is why this regression shipped undetected.
- `TestFetchAndAttachCoverFlags_Integration_TitleCoverWithoutMediaTitleID` — asserts a title-scoped cover resolves when the result omits `MediaTitleID`, guarding the backfill path.
- `BenchmarkCoverFlags_Attach` — new benchmark for the cover-flag path (none existed), title-scope at 100/500 entries.

Verified fixed on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browse cover detection so artwork stored at the title level is correctly applied, including for singleton container aliasing.
  * Fixed cases where cover status wasn’t attached when title identifiers were missing, by reliably resolving them before checking artwork.
* **Tests**
  * Added unit and integration coverage for title-scoped cover flags with and without initially set title identifiers.
* **Benchmarks**
  * Introduced a benchmark to measure cover-flag attachment performance for title-scoped artwork pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->