### PR TITLE
fix(database): disambiguate same-name media with comprehensive tag mapping

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -438,6 +438,13 @@ func GenerateMediaDB(
 				}
 			}
 
+			// Once cancellation is requested the scanner may fire one more status
+			// update before it observes the cancelled context. Skip it so the
+			// running flag isn't resurrected after cancel() cleared it.
+			if indexCtx.Err() != nil {
+				return
+			}
+
 			// Always update in-memory status for polling clients.
 			statusInstance.set(indexingStatusVals{
 				indexing:    true,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -506,15 +506,18 @@ type SearchResultWithCursor struct {
 // siblings, so a sole differentiator always survives truncation regardless of its rank.
 // Rank is the slice index.
 var TagTypeDisplayPriority = []string{
-	"unfinished", "unlicensed", "region", "disc", "edition", "rev", "builddate",
-	"lang", "distribution", "media", "release", "year",
-	"players", "developer", "publisher", "credit",
+	"unfinished", "unlicensed", "region", "video", "disc", "disctotal", "edition",
+	"rev", "arcadeboard", "cabinet", "protection", "set", "input", "dump", "alt", "compatibility", "builddate",
+	"lang", "distribution", "media", "addon", "release", "year",
+	"players", "developer", "publisher", "copyright", "credit",
+	"track",
 }
 
-// ZapScriptTagTypes defines which tag types are eligible for inclusion in ZapScript
-// title commands. Only these types are considered when checking for disambiguation. This
-// is the same set as TagTypeDisplayPriority; order is irrelevant here (used for SQL
-// membership), so it aliases the priority list to keep the two in sync.
+// ZapScriptTagTypes is the allowlist of tag types eligible for sibling disambiguation:
+// only these types are considered when deciding whether a title's media differ. It is the
+// same set as TagTypeDisplayPriority (order is irrelevant here, used only for SQL
+// membership), so it aliases the priority list to keep the two in sync. "unknown" is
+// deliberately absent — unclassified tokens never disambiguate.
 var ZapScriptTagTypes = TagTypeDisplayPriority
 
 // TagTypeDisplayRank returns the display-importance rank of a tag type (lower is more

--- a/pkg/database/mediadb/disambiguation_bench_test.go
+++ b/pkg/database/mediadb/disambiguation_bench_test.go
@@ -1,0 +1,100 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkRecomputeDisambiguation_System measures the system-scoped disambiguation
+// recompute — the single-pass set-based aggregation run once per system at index time —
+// over titles shaped like the arcade "Jackal" case: three siblings sharing one tag, with
+// two of them each carrying a distinct extra tag so presence/absence disambiguation fires.
+func BenchmarkRecomputeDisambiguation_System(b *testing.B) {
+	for _, titles := range []int{1000, 10000, 50000} {
+		b.Run(fmt.Sprintf("titles_%d", titles), func(b *testing.B) {
+			b.ReportAllocs()
+			mediaDB, cleanup := setupBenchDisambDB(b, titles)
+			defer cleanup()
+			ctx := context.Background()
+			for b.Loop() {
+				if err := mediaDB.RecomputeSystemDisambiguation(ctx, []int64{1}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// setupBenchDisambDB seeds a MediaDB with `titles` multi-media titles in one system. Each
+// title has three media: all share region:world, the second adds input:joystick:rotary,
+// the third adds unlicensed:bootleg — so every title disambiguates via presence/absence.
+func setupBenchDisambDB(b *testing.B, titles int) (mediaDB *MediaDB, cleanup func()) {
+	b.Helper()
+	tempDir, err := os.MkdirTemp("", "zaparoo-bench-disamb-*")
+	require.NoError(b, err)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
+
+	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
+	require.NoError(b, err)
+	cleanup = func() {
+		if mediaDB != nil {
+			_ = mediaDB.Close()
+		}
+		_ = os.RemoveAll(tempDir)
+	}
+
+	ctx := context.Background()
+	conn := mediaDB.sql.Load()
+
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'Bench', 'Bench');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES
+			(1, 'region', 0), (2, 'input', 0), (3, 'unlicensed', 0);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES
+			(1, 1, 'world'), (2, 2, 'joystick:rotary'), (3, 3, 'bootleg');
+	`)
+	require.NoError(b, err)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(`
+		WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM seq WHERE i < %d)
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name)
+			SELECT i, 1, 'game-' || i, 'Game ' || i FROM seq;
+		WITH RECURSIVE seq(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM seq WHERE i < %d)
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, IsMissing)
+			SELECT (i-1)*3 + j, i, 1, 'game-' || i || '-' || j, 0
+			FROM seq, (SELECT 1 AS j UNION SELECT 2 UNION SELECT 3);
+		INSERT INTO MediaTags (MediaDBID, TagDBID) SELECT DBID, 1 FROM Media;
+		INSERT INTO MediaTags (MediaDBID, TagDBID) SELECT DBID, 2 FROM Media WHERE (DBID %% 3) = 2;
+		INSERT INTO MediaTags (MediaDBID, TagDBID) SELECT DBID, 3 FROM Media WHERE (DBID %% 3) = 0;
+	`, titles, titles))
+	require.NoError(b, err)
+
+	return mediaDB, cleanup
+}

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -268,6 +268,89 @@ func TestRecomputeSystemDisambiguation_DifferingMultiValueSetsDisambiguate(t *te
 	assert.Equal(t, "region", titleDisambiguationTypes(t, mediaDB, titleDBID))
 }
 
+// TestRecomputeSystemDisambiguation_PresenceAbsenceDisambiguates covers the arcade
+// "Jackal" case: three siblings share region:world, but one adds an input tag
+// (Rotary) and another an unlicensed tag ([bl] → bootleg). Neither tag is shared, so
+// presence vs absence must distinguish them; region (identical on all) must not. The
+// tag values mirror what the filename parser actually emits for these names.
+func TestRecomputeSystemDisambiguation_PresenceAbsenceDisambiguates(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "Arcade", "Jackal", []disambTitleMedia{
+		{path: browseTestPath("roms", "arcade", "jackal-w.mra"), tags: map[string]string{"region": "world"}},
+		{
+			path: browseTestPath("roms", "arcade", "jackal-w-rotary.mra"),
+			tags: map[string]string{"region": "world", "input": "joystick:rotary"},
+		},
+		{
+			path: browseTestPath("roms", "arcade", "jackal-w-bl.mra"),
+			tags: map[string]string{"region": "world", "unlicensed": "bootleg"},
+		},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "input,unlicensed", titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], Name: "Jackal", SystemID: "Arcade", DisambiguationTypes: "input,unlicensed"},
+		{MediaID: mediaIDs[1], Name: "Jackal", SystemID: "Arcade", DisambiguationTypes: "input,unlicensed"},
+		{MediaID: mediaIDs[2], Name: "Jackal", SystemID: "Arcade", DisambiguationTypes: "input,unlicensed"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql.Load(), results))
+	assert.Empty(t, results[0].ZapScriptTags, "plain (W) sibling has no distinguishing tag")
+	require.Len(t, results[1].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "input", Tag: "joystick:rotary"}, results[1].ZapScriptTags[0])
+	require.Len(t, results[2].ZapScriptTags, 1)
+	assert.Equal(t, database.TagInfo{Type: "unlicensed", Tag: "bootleg"}, results[2].ZapScriptTags[0])
+}
+
+// TestRecomputeSystemDisambiguation_MultipleTitlesInOnePass verifies the single-pass
+// recompute handles several titles in one call: a title that disambiguates and one that
+// does not must both get the correct value from the same system-scoped recompute.
+func TestRecomputeSystemDisambiguation_MultipleTitlesInOnePass(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	sysA, titleA, _ := setupDisambTitle(t, mediaDB, "Arcade", "Contra", []disambTitleMedia{
+		{path: browseTestPath("roms", "arcade", "contra-w.mra"), tags: map[string]string{"region": "world"}},
+		{path: browseTestPath("roms", "arcade", "contra-jp.mra"), tags: map[string]string{"region": "jp"}},
+	})
+	sysB, titleB, _ := setupDisambTitle(t, mediaDB, "Arcade", "Gradius", []disambTitleMedia{
+		{path: browseTestPath("roms", "arcade", "gradius-1.mra"), tags: map[string]string{"region": "world"}},
+		{path: browseTestPath("roms", "arcade", "gradius-2.mra"), tags: map[string]string{"region": "world"}},
+	})
+	require.Equal(t, sysA, sysB, "both titles must share one system")
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{sysA}))
+	assert.Equal(t, "region", titleDisambiguationTypes(t, mediaDB, titleA), "differing region disambiguates")
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleB), "identical siblings do not disambiguate")
+}
+
+// TestRecomputeSystemDisambiguation_ClearsStaleValue verifies the reset step: a title
+// carrying a stale DisambiguationTypes whose media no longer disagree is cleared to ”.
+func TestRecomputeSystemDisambiguation_ClearsStaleValue(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	sysID, titleID, _ := setupDisambTitle(t, mediaDB, "Arcade", "Gradius", []disambTitleMedia{
+		{path: browseTestPath("roms", "arcade", "gradius-1.mra"), tags: map[string]string{"region": "world"}},
+		{path: browseTestPath("roms", "arcade", "gradius-2.mra"), tags: map[string]string{"region": "world"}},
+	})
+	_, err := mediaDB.sql.Load().ExecContext(
+		ctx, `UPDATE MediaTitles SET DisambiguationTypes = 'region' WHERE DBID = ?`, titleID)
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{sysID}))
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, titleID), "stale value must be cleared")
+}
+
 // TestRecomputeTitleDisambiguation_Success exercises the title-scoped entry point
 // (RecomputeTitleDisambiguation) directly, complementing the system-scoped tests.
 func TestRecomputeTitleDisambiguation_Success(t *testing.T) {

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -374,12 +374,14 @@ func sqlRecomputeDisambiguationForSystems(ctx context.Context, db sqlQueryable, 
 // MediaTitles.DBID (title-scoped) or MediaTitles.SystemDBID (system-scoped).
 // filterCol is a trusted constant, never user input.
 //
-// Each chunk executes as two statements (reset the in-scope titles to ”, then set the
-// qualifying ones). These are only atomic when db is a transaction; on a non-tx handle a
-// failure of the set statement after the reset committed leaves those titles blank until
-// the next recompute. That is a benign, self-healing display-hint degradation (callers
-// log-and-continue, MediaDB is rebuilt on reindex), and callers hold db.sqlMu exclusively
-// so no reader ever observes the intermediate reset-only state.
+// Each chunk executes as a single atomic UPDATE: a LEFT JOIN over the in-scope titles
+// COALESCEs a computed type list (or ” when a title no longer qualifies) so the reset and
+// set happen together. This matters because GetZapScriptTagsBySystemAndPath reads
+// DisambiguationTypes without holding db.sqlMu, and MediaDB caps the pool at one connection;
+// a two-statement reset-then-set would release the connection between them and let that
+// reader observe the transient blank state, writing a ZapScript tag with no disambiguation
+// suffix. One statement never releases the connection mid-update, so no reader sees a
+// partial result.
 func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol string, ids []int64) error {
 	if len(ids) == 0 {
 		return nil
@@ -407,25 +409,16 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 			chunkArgs[i] = id
 		}
 
-		// 1) Clear every in-scope title that currently carries a value, so titles
-		// that lost their last variant (or dropped below two media) are reset. The
-		// != '' guard skips the common already-blank rows.
-		//nolint:gosec // filterCol is a trusted constant; values are parameterized.
-		resetQuery := fmt.Sprintf(
-			`UPDATE MediaTitles SET DisambiguationTypes = '' WHERE %s IN (%s) AND DisambiguationTypes != ''`,
-			filterCol, holders)
-		if _, err := db.ExecContext(ctx, resetQuery, chunkArgs...); err != nil {
-			return fmt.Errorf("failed to reset disambiguation: %w", err)
-		}
-
-		// 2) Compute disambiguating types for the in-scope multi-media titles in one
+		// Compute disambiguating types for the in-scope multi-media titles in one
 		// set-based pass (a single global sort + aggregate, no per-title correlated
-		// subquery) and write them. A type disambiguates when its sibling media
-		// disagree: either two media carry different per-media value-sets
-		// (COUNT(DISTINCT vs) > 1), or some media carry the type and others lack it
-		// (mtc < the title's total non-missing media count) — the latter tells
-		// "Jackal (W)" apart from "Jackal (W) [bl]". Types are stored comma-joined in
-		// alphabetical order; read paths reorder them by display rank.
+		// subquery), then LEFT JOIN the full in-scope set back so titles that no longer
+		// qualify COALESCE to '' — the reset and the set land in one atomic UPDATE. A
+		// type disambiguates when its sibling media disagree: either two media carry
+		// different per-media value-sets (COUNT(DISTINCT vs) > 1), or some media carry
+		// the type and others lack it (mtc < the title's total non-missing media count)
+		// — the latter tells "Jackal (W)" apart from "Jackal (W) [bl]". Types are stored
+		// comma-joined in alphabetical order; read paths reorder them by display rank.
+		// The IS NOT guard skips rows already holding the computed value.
 		//nolint:gosec // filterCol is a trusted constant; values are parameterized.
 		setQuery := fmt.Sprintf(`
 			WITH scope AS (
@@ -462,13 +455,19 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 				FROM agg JOIN tot ON tot.tid = agg.tid
 				WHERE agg.dv > 1 OR agg.mtc < tot.tm
 			),
-			result AS (
+			grp AS (
 				SELECT tid, group_concat(typ, ',') AS types
 				FROM (SELECT tid, typ FROM qual ORDER BY tid, typ)
 				GROUP BY tid
+			),
+			result AS (
+				SELECT scope.tid AS tid, COALESCE(grp.types, '') AS types
+				FROM scope LEFT JOIN grp ON grp.tid = scope.tid
 			)
 			UPDATE MediaTitles SET DisambiguationTypes = result.types
-			FROM result WHERE MediaTitles.DBID = result.tid
+			FROM result
+			WHERE MediaTitles.DBID = result.tid
+			  AND MediaTitles.DisambiguationTypes IS NOT result.types
 		`, filterCol, holders, typeClause)
 
 		setArgs := make([]any, 0, len(chunkArgs)+len(typeArgs))

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -433,7 +433,7 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 				HAVING COUNT(*) > 1
 			),
 			mvs AS (
-				SELECT tid, typ, mid, group_concat(tag) AS vs
+				SELECT tid, typ, mid, group_concat(tag ORDER BY tag) AS vs
 				FROM (
 					SELECT DISTINCT m.MediaTitleDBID AS tid, tt.Type AS typ, m.DBID AS mid, t.Tag AS tag
 					FROM tot
@@ -442,7 +442,6 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 					JOIN Tags t ON t.DBID = x.TagDBID
 					JOIN TagTypes tt ON tt.DBID = t.TypeDBID
 					WHERE m.IsMissing = 0%s
-					ORDER BY m.MediaTitleDBID, tt.Type, m.DBID, t.Tag
 				)
 				GROUP BY tid, typ, mid
 			),
@@ -456,8 +455,8 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 				WHERE agg.dv > 1 OR agg.mtc < tot.tm
 			),
 			grp AS (
-				SELECT tid, group_concat(typ, ',') AS types
-				FROM (SELECT tid, typ FROM qual ORDER BY tid, typ)
+				SELECT tid, group_concat(typ, ',' ORDER BY typ) AS types
+				FROM qual
 				GROUP BY tid
 			),
 			result AS (

--- a/pkg/database/mediadb/sql_media_titles.go
+++ b/pkg/database/mediadb/sql_media_titles.go
@@ -347,13 +347,14 @@ func sqlGetTitlesBySystemID(ctx context.Context, db *sql.DB, systemID string) ([
 }
 
 // sqlRecomputeTitleDisambiguation recomputes MediaTitles.DisambiguationTypes for
-// the given titles. A tag type is disambiguating for a title when the title's
-// present (non-missing) media hold more than one distinct per-media value-set for
-// that type, restricted to database.ZapScriptTagTypes. Comparing per-media sets
-// (not values pooled across media) means a multi-valued type that is identical on
-// every sibling — e.g. every disc tagged (USA, Europe) — does not falsely
-// disambiguate. The result is stored as a sorted, comma-separated list of type
-// names (empty when nothing disambiguates).
+// the given titles. A tag type disambiguates a title when the title's present
+// (non-missing) sibling media disagree on it: either they hold more than one
+// distinct per-media value-set, or some media carry the type and others lack it
+// entirely. Only tag types in database.ZapScriptTagTypes (the eligibility allowlist)
+// are considered. Comparing per-media sets (not values pooled across media) means a
+// multi-valued type that is identical on every sibling — e.g. every disc tagged
+// (USA, Europe) — does not falsely disambiguate. The result is stored as a sorted,
+// comma-separated list of type names (empty when nothing disambiguates).
 //
 // This is the single source of truth for sibling disambiguation: read paths
 // filter each result's tags by the stored types instead of re-deriving across a
@@ -372,18 +373,27 @@ func sqlRecomputeDisambiguationForSystems(ctx context.Context, db sqlQueryable, 
 // sqlRecomputeDisambiguation runs the disambiguation UPDATE filtered by either
 // MediaTitles.DBID (title-scoped) or MediaTitles.SystemDBID (system-scoped).
 // filterCol is a trusted constant, never user input.
+//
+// Each chunk executes as two statements (reset the in-scope titles to ”, then set the
+// qualifying ones). These are only atomic when db is a transaction; on a non-tx handle a
+// failure of the set statement after the reset committed leaves those titles blank until
+// the next recompute. That is a benign, self-healing display-hint degradation (callers
+// log-and-continue, MediaDB is rebuilt on reindex), and callers hold db.sqlMu exclusively
+// so no reader ever observes the intermediate reset-only state.
 func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol string, ids []int64) error {
 	if len(ids) == 0 {
 		return nil
 	}
 
-	typeHolders := prepareVariadic("?", ",", len(database.ZapScriptTagTypes))
+	// Allowlist of tag types eligible for disambiguation, rendered as an IN clause.
 	typeArgs := make([]any, len(database.ZapScriptTagTypes))
 	for i, t := range database.ZapScriptTagTypes {
 		typeArgs[i] = t
 	}
+	typeClause := " AND tt.Type IN (" + prepareVariadic("?", ",", len(database.ZapScriptTagTypes)) + ")"
 
-	// Chunk IDs so total bound parameters stay under SQLite's limit.
+	// Chunk IDs so bound parameters stay under SQLite's limit; leave room for the
+	// type params the set statement appends.
 	chunkSize := sqliteMaxParams - len(database.ZapScriptTagTypes)
 	for start := 0; start < len(ids); start += chunkSize {
 		end := start + chunkSize
@@ -391,56 +401,80 @@ func sqlRecomputeDisambiguation(ctx context.Context, db sqlQueryable, filterCol 
 			end = len(ids)
 		}
 		chunk := ids[start:end]
-
-		args := make([]any, 0, len(typeArgs)+len(chunk))
-		args = append(args, typeArgs...)
-		for _, id := range chunk {
-			args = append(args, id)
+		holders := prepareVariadic("?", ",", len(chunk))
+		chunkArgs := make([]any, len(chunk))
+		for i, id := range chunk {
+			chunkArgs[i] = id
 		}
 
-		//nolint:gosec // filterCol is a trusted constant; placeholders are parameterized
-		query := fmt.Sprintf(`
-			UPDATE MediaTitles
-			SET DisambiguationTypes = COALESCE((
-				SELECT group_concat(Type, ',')
-				FROM (
-					SELECT Type
-					FROM (
-						SELECT Type, MediaDBID, group_concat(Tag) AS ValueSet
-						FROM (
-							SELECT DISTINCT tt.Type AS Type, m.DBID AS MediaDBID, t.Tag AS Tag
-							FROM Media m
-							JOIN MediaTags mt ON mt.MediaDBID = m.DBID
-							JOIN Tags t ON t.DBID = mt.TagDBID
-							JOIN TagTypes tt ON tt.DBID = t.TypeDBID
-							WHERE m.MediaTitleDBID = MediaTitles.DBID
-							  AND m.IsMissing = 0
-							  AND tt.Type IN (%s)
-							ORDER BY tt.Type, m.DBID, t.Tag
-						)
-						GROUP BY Type, MediaDBID
-					)
-					GROUP BY Type
-					HAVING COUNT(DISTINCT ValueSet) > 1
-					ORDER BY Type
-				)
-			), '')
-			WHERE MediaTitles.%s IN (%s)
-			  -- Skip the per-title subquery for single-media titles that are already
-			  -- blank: a title with <=1 non-missing media can never have variant
-			  -- disambiguation, so its value is necessarily ''. Still process any
-			  -- title that currently has a value (so a title that dropped from
-			  -- multi-media to single-media is reset to '').
-			  AND (
-				MediaTitles.DisambiguationTypes != ''
-				OR (
-					SELECT COUNT(*) FROM Media
-					WHERE Media.MediaTitleDBID = MediaTitles.DBID AND Media.IsMissing = 0
-				) > 1
-			  )
-		`, typeHolders, filterCol, prepareVariadic("?", ",", len(chunk)))
+		// 1) Clear every in-scope title that currently carries a value, so titles
+		// that lost their last variant (or dropped below two media) are reset. The
+		// != '' guard skips the common already-blank rows.
+		//nolint:gosec // filterCol is a trusted constant; values are parameterized.
+		resetQuery := fmt.Sprintf(
+			`UPDATE MediaTitles SET DisambiguationTypes = '' WHERE %s IN (%s) AND DisambiguationTypes != ''`,
+			filterCol, holders)
+		if _, err := db.ExecContext(ctx, resetQuery, chunkArgs...); err != nil {
+			return fmt.Errorf("failed to reset disambiguation: %w", err)
+		}
 
-		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		// 2) Compute disambiguating types for the in-scope multi-media titles in one
+		// set-based pass (a single global sort + aggregate, no per-title correlated
+		// subquery) and write them. A type disambiguates when its sibling media
+		// disagree: either two media carry different per-media value-sets
+		// (COUNT(DISTINCT vs) > 1), or some media carry the type and others lack it
+		// (mtc < the title's total non-missing media count) — the latter tells
+		// "Jackal (W)" apart from "Jackal (W) [bl]". Types are stored comma-joined in
+		// alphabetical order; read paths reorder them by display rank.
+		//nolint:gosec // filterCol is a trusted constant; values are parameterized.
+		setQuery := fmt.Sprintf(`
+			WITH scope AS (
+				SELECT DBID AS tid FROM MediaTitles WHERE %s IN (%s)
+			),
+			tot AS (
+				SELECT m.MediaTitleDBID AS tid, COUNT(*) AS tm
+				FROM Media m
+				JOIN scope ON scope.tid = m.MediaTitleDBID
+				WHERE m.IsMissing = 0
+				GROUP BY m.MediaTitleDBID
+				HAVING COUNT(*) > 1
+			),
+			mvs AS (
+				SELECT tid, typ, mid, group_concat(tag) AS vs
+				FROM (
+					SELECT DISTINCT m.MediaTitleDBID AS tid, tt.Type AS typ, m.DBID AS mid, t.Tag AS tag
+					FROM tot
+					JOIN Media m ON m.MediaTitleDBID = tot.tid
+					JOIN MediaTags x ON x.MediaDBID = m.DBID
+					JOIN Tags t ON t.DBID = x.TagDBID
+					JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+					WHERE m.IsMissing = 0%s
+					ORDER BY m.MediaTitleDBID, tt.Type, m.DBID, t.Tag
+				)
+				GROUP BY tid, typ, mid
+			),
+			agg AS (
+				SELECT tid, typ, COUNT(DISTINCT vs) AS dv, COUNT(*) AS mtc
+				FROM mvs GROUP BY tid, typ
+			),
+			qual AS (
+				SELECT agg.tid AS tid, agg.typ AS typ
+				FROM agg JOIN tot ON tot.tid = agg.tid
+				WHERE agg.dv > 1 OR agg.mtc < tot.tm
+			),
+			result AS (
+				SELECT tid, group_concat(typ, ',') AS types
+				FROM (SELECT tid, typ FROM qual ORDER BY tid, typ)
+				GROUP BY tid
+			)
+			UPDATE MediaTitles SET DisambiguationTypes = result.types
+			FROM result WHERE MediaTitles.DBID = result.tid
+		`, filterCol, holders, typeClause)
+
+		setArgs := make([]any, 0, len(chunkArgs)+len(typeArgs))
+		setArgs = append(setArgs, chunkArgs...)
+		setArgs = append(setArgs, typeArgs...)
+		if _, err := db.ExecContext(ctx, setQuery, setArgs...); err != nil {
 			return fmt.Errorf("failed to recompute disambiguation: %w", err)
 		}
 	}

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -341,6 +341,8 @@ func AddMediaPathWithPrefixPolicy(
 				dynType = string(tags.TagTypeCredit)
 			case strings.HasPrefix(tagStr, string(tags.TagTypeBuildDate)+":"):
 				dynType = string(tags.TagTypeBuildDate)
+			case strings.HasPrefix(tagStr, string(tags.TagTypeTrack)+":"):
+				dynType = string(tags.TagTypeTrack)
 			}
 			if dynType != "" {
 				tagValue := strings.TrimPrefix(tagStr, dynType+":")

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -545,6 +545,54 @@ func TestAddMediaPath_ArcadeBuildDateTagPersisted(t *testing.T) {
 	assert.Contains(t, got, "region:world")
 }
 
+func TestAddMediaPath_TrackTagPersisted(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	state := &database.ScanState{
+		SystemIDs:     make(map[string]int),
+		TitleIDs:      make(map[string]int),
+		MediaIDs:      make(map[string]int),
+		MediaTitleIDs: make(map[int]int),
+		MediaTagIDs:   make(map[int]map[int]struct{}),
+		TagTypeIDs:    make(map[string]int),
+		TagIDs:        make(map[string]int),
+		MissingMedia:  make(map[int]struct{}),
+	}
+	require.NoError(t, SeedCanonicalTags(mediaDB, state))
+
+	// A music library track number ([01]) becomes a track: tag whose type is created
+	// dynamically by the indexing pipeline (track is not a seeded canonical type).
+	path := filepath.Join("SNESMusic", "Star Fox [01].spc")
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	_, mediaID, err := AddMediaPath(mediaDB, state, "SNESMusic", path, "", false, false, nil, slugs.MediaTypeMusic)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+	rows, err := sqlDB.QueryContext(ctx, `
+		SELECT TagTypes.Type, Tags.Tag
+		FROM MediaTags
+		JOIN Tags ON Tags.DBID = MediaTags.TagDBID
+		JOIN TagTypes ON TagTypes.DBID = Tags.TypeDBID
+		WHERE MediaTags.MediaDBID = ?`, mediaID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var got []string
+	for rows.Next() {
+		var typ, val string
+		require.NoError(t, rows.Scan(&typ, &val))
+		got = append(got, typ+":"+tags.UnpadTagValue(val))
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Contains(t, got, "track:1", "track tag should persist through indexing")
+}
+
 func TestAddMediaPath_SkipsTitleAndTagWritesWhenExistingMetadataMatches(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/perfmetrics"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -100,6 +101,7 @@ type companionStats struct {
 	UniqueTitleWrites      int
 	DuplicateTitles        int
 	ConflictingTitleWrites int
+	ConflictingChildSlugs  int
 }
 
 type scrapeWriteStats struct {
@@ -1746,6 +1748,141 @@ func companionEntriesFromParsed(
 	return parents, children
 }
 
+// companionSlugStem returns the lowercased slug stem of a companion child whose path is a
+// "<slug>.slug" reference, matching the lookup key used by matchCompanionChildMedia. The
+// second return is false for children matched by a real path/filename instead.
+func companionSlugStem(resolvedPath string) (string, bool) {
+	base := filepath.Base(resolvedPath)
+	if !strings.EqualFold(filepath.Ext(base), ".slug") {
+		return "", false
+	}
+	return strings.ToLower(strings.TrimSuffix(base, filepath.Ext(base))), true
+}
+
+func companionSlugMediaType(systemID string) slugs.MediaType {
+	if system, err := systemdefs.GetSystem(systemID); err == nil {
+		return system.GetMediaType()
+	}
+	return slugs.MediaTypeGame
+}
+
+func isASCIIDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+// companionParentNameScore rates how consistent a parent's display name is with a child
+// slug stem. A ZaparooCompanion gamelist can erroneously list one slug under multiple
+// parents (e.g. "phantasystar4" under both "Phantasy Star 4" and "Phantasy Star 3"); the
+// score picks the parent whose name actually matches the slug. 2 = exact slug match, 1 =
+// one slug extends the other at a non-digit boundary (a subtitle or hack suffix), 0 = no
+// relation. The non-digit boundary stops "phantasystar1" from matching "phantasystar12".
+func companionParentNameScore(mediaType slugs.MediaType, childSlug, parentName string) int {
+	parentSlug := slugs.Slugify(mediaType, parentName)
+	switch {
+	case parentSlug == "" || childSlug == "":
+		return 0
+	case parentSlug == childSlug:
+		return 2
+	case strings.HasPrefix(parentSlug, childSlug) && !isASCIIDigit(parentSlug[len(childSlug)]):
+		return 1
+	case strings.HasPrefix(childSlug, parentSlug) && !isASCIIDigit(childSlug[len(parentSlug)]):
+		return 1
+	default:
+		return 0
+	}
+}
+
+// resolveCompanionSlugConflicts drops companion child records whose ".slug" stem is claimed
+// by more than one parent ID. The correct parent is chosen by name consistency
+// (companionParentNameScore); when no parent's name relates to the slug, every conflicting
+// child for that slug is dropped rather than risk writing the wrong parent's metadata onto a
+// title. Children matched by real path/filename, slugs claimed by a single parent, and
+// ambiguous ties between equally-named parents are left untouched (the latter preserves the
+// prior first-wins behavior, since equally-named parents carry equivalent metadata).
+func resolveCompanionSlugConflicts(
+	systemID string,
+	parents []companionParent,
+	children []companionChild,
+	stats *companionStats,
+) []companionChild {
+	parentIDsByStem := make(map[string]map[string]struct{})
+	for i := range children {
+		stem, ok := companionSlugStem(children[i].ResolvedPath)
+		if !ok {
+			continue
+		}
+		pids := parentIDsByStem[stem]
+		if pids == nil {
+			pids = make(map[string]struct{})
+			parentIDsByStem[stem] = pids
+		}
+		pids[children[i].ParentGameID] = struct{}{}
+	}
+
+	parentNameByID := make(map[string]string, len(parents))
+	for i := range parents {
+		parentNameByID[parents[i].GameID] = parents[i].Game.Name
+	}
+	mediaType := companionSlugMediaType(systemID)
+
+	type resolution struct {
+		winner string
+		drop   bool
+	}
+	conflicts := make(map[string]resolution)
+	for stem, pids := range parentIDsByStem {
+		if len(pids) < 2 {
+			continue
+		}
+		bestScore := -1
+		scores := make(map[string]int, len(pids))
+		for id := range pids {
+			s := companionParentNameScore(mediaType, stem, parentNameByID[id])
+			scores[id] = s
+			if s > bestScore {
+				bestScore = s
+			}
+		}
+		if bestScore <= 0 {
+			conflicts[stem] = resolution{drop: true}
+			continue
+		}
+		winner, winnerCount := "", 0
+		for id, s := range scores {
+			if s == bestScore {
+				winner, winnerCount = id, winnerCount+1
+			}
+		}
+		if winnerCount == 1 {
+			conflicts[stem] = resolution{winner: winner}
+		}
+		// winnerCount > 1: ambiguous tie among equally-named parents; leave unmanaged.
+	}
+	if len(conflicts) == 0 {
+		return children
+	}
+
+	filtered := children[:0]
+	for i := range children {
+		if stem, ok := companionSlugStem(children[i].ResolvedPath); ok {
+			if res, conflicted := conflicts[stem]; conflicted &&
+				(res.drop || children[i].ParentGameID != res.winner) {
+				if stats != nil {
+					stats.ConflictingChildSlugs++
+				}
+				log.Warn().
+					Str("system", systemID).
+					Str("slug", stem).
+					Str("parentGameID", children[i].ParentGameID).
+					Str("chosenParentGameID", res.winner).
+					Bool("dropped", res.drop).
+					Msg("gamelistxml: companion: conflicting child slug, skipping ambiguous parent mapping")
+				continue
+			}
+		}
+		filtered = append(filtered, children[i])
+	}
+	return filtered
+}
+
 // mapCompanionParentToResult builds the tag and property writes for a companion parent
 // record. Parent records carry no ROM path, so the filesystem artwork fallback is
 // skipped cleanly (the stem becomes "." and no fallback names are produced); media
@@ -1818,6 +1955,7 @@ func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
 
 	sentinel := scraper.SentinelTagInfo("gamelist.xml")
 	stats := companionStats{WriteStats: scrapeWriteStats{UniqueTitleDBIDs: make(map[int64]struct{})}}
+	children = resolveCompanionSlugConflicts(system.ID, parents, children, &stats)
 	lastProgress := time.Now().Add(-scrapeProgressInterval)
 	emitProgress := func(force bool) bool {
 		if ch == nil {
@@ -1858,6 +1996,7 @@ func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
 			Int("unique_title_writes", stats.UniqueTitleWrites).
 			Int("duplicate_title_writes", stats.DuplicateTitles).
 			Int("conflicting_title_writes", stats.ConflictingTitleWrites).
+			Int("conflicting_child_slugs", stats.ConflictingChildSlugs).
 			Bool("force", opts.Force).
 			Msg("gamelistxml: companion: finished entries")
 		logScrapeWriteStats("gamelistxml: companion write stats", system.ID, &stats.WriteStats)

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1795,8 +1795,9 @@ func companionParentNameScore(mediaType slugs.MediaType, childSlug, parentName s
 // (companionParentNameScore); when no parent's name relates to the slug, every conflicting
 // child for that slug is dropped rather than risk writing the wrong parent's metadata onto a
 // title. Children matched by real path/filename, slugs claimed by a single parent, and
-// ambiguous ties between equally-named parents are left untouched (the latter preserves the
-// prior first-wins behavior, since equally-named parents carry equivalent metadata).
+// ties between exactly-named parents are left untouched (the latter preserves the prior
+// first-wins behavior, since equally-named parents carry equivalent metadata). Ties among
+// prefix-only matches are dropped, because differently-named parents do not share metadata.
 func resolveCompanionSlugConflicts(
 	systemID string,
 	parents []companionParent,
@@ -1851,10 +1852,17 @@ func resolveCompanionSlugConflicts(
 				winner, winnerCount = id, winnerCount+1
 			}
 		}
-		if winnerCount == 1 {
+		switch {
+		case winnerCount == 1:
 			conflicts[stem] = resolution{winner: winner}
+		case bestScore == 1:
+			// Tie among prefix-only matches: the parents are differently named (e.g.
+			// "Mega" vs "Megaman X" both weakly matching "megaman"), so their metadata is
+			// not equivalent. Drop rather than risk writing the wrong parent's metadata.
+			conflicts[stem] = resolution{drop: true}
 		}
-		// winnerCount > 1: ambiguous tie among equally-named parents; leave unmanaged.
+		// winnerCount > 1 && bestScore == 2: tie among exact-name matches; leave unmanaged
+		// (equally-named parents carry equivalent metadata, preserving first-wins behavior).
 	}
 	if len(conflicts) == 0 {
 		return children

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -2656,6 +2656,8 @@ func TestResolveCompanionSlugConflicts(t *testing.T) {
 		{GameID: "2", Game: esapi.Game{Name: "Double Dragon"}},
 		{GameID: "8", Game: esapi.Game{Name: "Some Unrelated Game"}},
 		{GameID: "9", Game: esapi.Game{Name: "Another Unrelated Game"}},
+		{GameID: "50", Game: esapi.Game{Name: "Mega"}},      // prefix of "megaman" -> score 1
+		{GameID: "51", Game: esapi.Game{Name: "Megaman X"}}, // "megaman" prefix of it -> score 1
 	}
 	child := func(stem, parent string) companionChild {
 		return companionChild{ResolvedPath: filepath.Join(t.TempDir(), stem+".slug"), ParentGameID: parent}
@@ -2668,6 +2670,8 @@ func TestResolveCompanionSlugConflicts(t *testing.T) {
 		child("doubledragon", "2"),
 		child("mystery", "8"), // no parent name relates -> drop all
 		child("mystery", "9"),
+		child("megaman", "50"), // prefix-only tie between differently-named parents -> drop all
+		child("megaman", "51"),
 		{ResolvedPath: filepath.Join(t.TempDir(), "real.md"), ParentGameID: "30"}, // non-slug, untouched
 	}
 
@@ -2687,7 +2691,8 @@ func TestResolveCompanionSlugConflicts(t *testing.T) {
 	assert.Equal(t, []string{"77"}, parentFor("phantasystar3"), "single-parent slug untouched")
 	assert.ElementsMatch(t, []string{"1", "2"}, parentFor("doubledragon"), "equal-name tie left unmanaged")
 	assert.Empty(t, parentFor("mystery"), "no consistent parent -> all dropped")
-	assert.Equal(t, 3, stats.ConflictingChildSlugs, "1 phantasystar4 + 2 mystery dropped")
+	assert.Empty(t, parentFor("megaman"), "prefix-only tie -> all dropped")
+	assert.Equal(t, 5, stats.ConflictingChildSlugs, "1 phantasystar4 + 2 mystery + 2 megaman dropped")
 
 	var nonSlug int
 	for _, c := range got {

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -2606,6 +2606,98 @@ func TestProcessCompanionEntries_DuplicateSlugChildConsumesTitleMedia(t *testing
 	})
 }
 
+func TestProcessCompanionEntries_ConflictingChildSlugPrefersConsistentParent(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// The same "phantasystar4" slug is listed under two parents. The WRONG parent
+	// (Phantasy Star 3) is listed first to prove file order does not decide the winner;
+	// name consistency must route the slug to the Phantasy Star 4 parent (id 30).
+	require.NoError(t, os.WriteFile(filepath.Join(root, "gamelist.xml"), []byte(`<gameList>
+  <game id="30" source="ZaparooCompanion">
+    <name>Phantasy Star 4 - The End Of The Millennium</name>
+    <developer>Sega</developer>
+  </game>
+  <game id="77" source="ZaparooCompanion">
+    <name>Phantasy Star 3 - Generations Of Doom</name>
+    <developer>Sega</developer>
+  </game>
+  <game parentid="77" source="ZaparooCompanion"><path>./phantasystar4.slug</path></game>
+  <game parentid="30" source="ZaparooCompanion"><path>./phantasystar4.slug</path></game>
+</gameList>`), 0o600))
+
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("ApplyScrapeResult", mock.Anything, int64(40), int64(500),
+		companionWriteMatcher(
+			nil,
+			[]database.TagInfo{{Type: string(tags.TagTypeDeveloper), Tag: "sega", Label: "Sega"}},
+			companionXMLGameIDProps("30"),
+		)).Return(nil)
+
+	s := &GamelistXMLScraper{db: mockDB}
+	system := scraper.ScrapeSystem{ID: "Genesis", ROMPaths: []string{root}, DBID: 5}
+	indexes := mediaByPath(database.Media{
+		DBID: 40, MediaTitleDBID: 500, Path: filepath.Join(root, "Phantasy Star IV (USA).md"),
+	})
+	indexes.AllTitlesBySlug["phantasystar4"] = database.MediaTitle{DBID: 500, SystemDBID: 5, Slug: "phantasystar4"}
+
+	stats := s.processCompanionEntries(context.Background(), scraper.ScrapeOptions{}, system, mockDB, indexes, nil)
+
+	assert.Equal(t, 1, stats.ConflictingChildSlugs)
+	assertCompanionCounts(t, &stats, 1, 1, 0)
+	mockDB.AssertExpectations(t)
+}
+
+func TestResolveCompanionSlugConflicts(t *testing.T) {
+	t.Parallel()
+	parents := []companionParent{
+		{GameID: "30", Game: esapi.Game{Name: "Phantasy Star 4 - The End Of The Millennium"}},
+		{GameID: "77", Game: esapi.Game{Name: "Phantasy Star 3 - Generations Of Doom"}},
+		{GameID: "1", Game: esapi.Game{Name: "Double Dragon"}},
+		{GameID: "2", Game: esapi.Game{Name: "Double Dragon"}},
+		{GameID: "8", Game: esapi.Game{Name: "Some Unrelated Game"}},
+		{GameID: "9", Game: esapi.Game{Name: "Another Unrelated Game"}},
+	}
+	child := func(stem, parent string) companionChild {
+		return companionChild{ResolvedPath: filepath.Join(t.TempDir(), stem+".slug"), ParentGameID: parent}
+	}
+	children := []companionChild{
+		child("phantasystar4", "77"), // wrong parent first
+		child("phantasystar4", "30"), // consistent parent
+		child("phantasystar3", "77"), // single parent, untouched
+		child("doubledragon", "1"),   // tie: both parents equally named -> unmanaged
+		child("doubledragon", "2"),
+		child("mystery", "8"), // no parent name relates -> drop all
+		child("mystery", "9"),
+		{ResolvedPath: filepath.Join(t.TempDir(), "real.md"), ParentGameID: "30"}, // non-slug, untouched
+	}
+
+	var stats companionStats
+	got := resolveCompanionSlugConflicts("Genesis", parents, children, &stats)
+
+	parentFor := func(stem string) []string {
+		var ids []string
+		for _, c := range got {
+			if s, ok := companionSlugStem(c.ResolvedPath); ok && s == stem {
+				ids = append(ids, c.ParentGameID)
+			}
+		}
+		return ids
+	}
+	assert.Equal(t, []string{"30"}, parentFor("phantasystar4"), "consistent parent wins regardless of order")
+	assert.Equal(t, []string{"77"}, parentFor("phantasystar3"), "single-parent slug untouched")
+	assert.ElementsMatch(t, []string{"1", "2"}, parentFor("doubledragon"), "equal-name tie left unmanaged")
+	assert.Empty(t, parentFor("mystery"), "no consistent parent -> all dropped")
+	assert.Equal(t, 3, stats.ConflictingChildSlugs, "1 phantasystar4 + 2 mystery dropped")
+
+	var nonSlug int
+	for _, c := range got {
+		if _, ok := companionSlugStem(c.ResolvedPath); !ok {
+			nonSlug++
+		}
+	}
+	assert.Equal(t, 1, nonSlug, "non-slug child untouched")
+}
+
 func TestProcessCompanionEntries_RewritesAlreadyScraped(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -35,6 +35,15 @@ var (
 	// Special pattern extraction (complex patterns that still use regex)
 	reTransBracketed = regexp.MustCompile(`^T([+-]?)([A-Za-z]{2,3})(?:.*?v(\d+(?:\.\d+)*))?`)
 
+	// "side-N-of-M" — a disk side plus the total disk/side count.
+	reSideOf = regexp.MustCompile(`^side-(\d+)-of-(\d+)$`)
+
+	// Raw TOSEC/GoodTools dump-flag bracket grammar: a 1-2 letter flag, an optional numeric
+	// index ("f1", "a2"), and/or a whitespace-separated cracker/group name ("cr XOR",
+	// "h ASS", "t +2 XOR"). A hyphen after the flag is deliberately NOT accepted, so
+	// hyphenated words like "b-side"/"a-team" are never misread as flag+credit.
+	reDumpFlag = regexp.MustCompile(`^([a-z]{1,2})(\d+)?(?:\s+(\S.*))?$`)
+
 	// Scene release artifact patterns (for modern media: movies, TV shows)
 	// Note: These patterns match AFTER separator normalization, so hyphens have become spaces
 	reResolution = regexp.MustCompile(`(?i)\b(480p|720p|1080p|2160p|4K|8K|UHD)\b`)
@@ -270,9 +279,24 @@ func classifyUnmappedParen(normalized, _ string) ([]CanonicalTag, bool) {
 		}
 	}
 
-	// Version phrases — drop, no tag ("version" or its Romance-language equivalents)
-	for _, t := range tokens {
+	// "Side 1 of 2" → media side + disc total.
+	if sideTags, ok := parseSideOfToken(normalized); ok {
+		return sideTags, true
+	}
+
+	// Version phrases. "(System 16C version)" carries a meaningful board id before the
+	// "version" word — map the leading tokens if they resolve. Bare "(version)" or phrases
+	// whose leader doesn't map (e.g. "(final version)") drop with no tag.
+	for i, t := range tokens {
 		if t == "version" || t == "versione" || t == "versao" {
+			if i > 0 {
+				if mapped := mapFilenameTagToCanonical(strings.Join(tokens[:i], "-")); len(mapped) > 0 {
+					for j := range mapped {
+						mapped[j].Source = TagSourceBracketed
+					}
+					return mapped, true
+				}
+			}
 			return nil, true
 		}
 	}
@@ -1100,6 +1124,12 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 			}
 		}
 		if !matched {
+			if vTags, ok := parseVersionToken(normalized); ok {
+				results = append(results, vTags...)
+				matched = true
+			}
+		}
+		if !matched {
 			unmatched = append(unmatched, normalized)
 		}
 	}
@@ -1107,14 +1137,31 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 	// MiSTer Arcade also writes the region and date as separate comma-parts, e.g.
 	// "(EU, 961004)". A standalone 6-digit number is normally rejected as a date, but
 	// the presence of a region sibling makes it unambiguous, so accept it here.
+	consumed := make([]bool, len(unmatched))
 	if hasTagType(results, TagTypeRegion) {
-		for _, u := range unmatched {
+		for i, u := range unmatched {
 			if v, ok := parseBuildDate(u); ok {
 				results = append(results, CanonicalTag{
 					Type: TagTypeBuildDate, Value: TagValue(v), Source: TagSourceBracketed,
 				})
+				consumed[i] = true
 				break
 			}
+		}
+	}
+
+	// Any remaining unmatched comma-part is run through classifyUnmappedParen so a
+	// correctly-typed qualifier (set/edition/hack/crack/classics) is not silently dropped
+	// just because it sits after a comma — "(World, Set 1)" now yields set:1. The
+	// company-name→credit fallback is deliberately NOT applied here: a comma-part like
+	// "CPS Changer" is hardware, not a credit, and gets its correct type via an explicit
+	// mapping instead of being mislabeled.
+	for i, u := range unmatched {
+		if consumed[i] {
+			continue
+		}
+		if res, classified := classifyUnmappedParen(u, u); classified {
+			results = append(results, res...)
 		}
 	}
 
@@ -1123,6 +1170,33 @@ func parseCommaSeparatedTags(tag string) []CanonicalTag {
 	}
 	return nil
 }
+
+// parseVersionToken recognizes MAME/arcade software-version parens like "(ver. 100)" or
+// "(Ver. 1.01)" (normalized to "ver-100" / "ver-1-01") and maps them to a revision tag.
+// The value must start with a digit so it never matches word-shaped tokens. Returns the
+// rev tag(s) and true on a match.
+func parseVersionToken(normalized string) ([]CanonicalTag, bool) {
+	for _, prefix := range []string{"version-", "ver-"} {
+		rest, ok := strings.CutPrefix(normalized, prefix)
+		if !ok || rest == "" || !isASCIIDigit(rest[0]) {
+			continue
+		}
+		valid := true
+		for i := range len(rest) {
+			if !isASCIIDigit(rest[i]) && rest[i] != '-' {
+				valid = false
+				break
+			}
+		}
+		if valid {
+			return []CanonicalTag{{Type: TagTypeRev, Value: TagValue(rest), Source: TagSourceBracketed}}, true
+		}
+	}
+	return nil, false
+}
+
+// isASCIIDigit reports whether b is an ASCII digit.
+func isASCIIDigit(b byte) bool { return b >= '0' && b <= '9' }
 
 // parseRegionDateToken handles the MiSTer Arcade naming convention where a single
 // parenthetical packs a region word and a build date, space-separated (normalization
@@ -1227,8 +1301,138 @@ func disambiguateTag(ctx *ParseContext) []CanonicalTag {
 		return rdTags
 	}
 
+	// Arcade software version "(ver. 100)" → rev:100. Checked before the generic
+	// paren fallback so it is not mis-classified as a credit/company name.
+	if vTags, ok := parseVersionToken(normalized); ok {
+		return vTags
+	}
+
+	// Arcade protection chip "(FD1094 317-0154)" → protection:fd1094.
+	if pTags, ok := parseProtectionChip(normalized); ok {
+		return pTags
+	}
+
 	// For parentheses tags, use position and context
 	return mapParenthesisTag(normalized, ctx)
+}
+
+// parseProtectionChip recognizes an arcade protection-chip token — a chip family followed by
+// a serial ("fd1094-317-0060", "fd1089b-317-0018", "8751-317-0078") — and returns
+// protection:<family>, dropping the open-ended serial. Must run after explicit keyword
+// mappings. Returns the tag and true on a match.
+func parseProtectionChip(normalized string) ([]CanonicalTag, bool) {
+	var value TagValue
+	switch {
+	case strings.HasPrefix(normalized, "fd1094"):
+		value = TagProtectionFD1094
+	case strings.HasPrefix(normalized, "fd1089"):
+		value = TagProtectionFD1089
+	case strings.HasPrefix(normalized, "8751"):
+		value = TagProtection8751
+	case strings.HasPrefix(normalized, "mc-8123"), strings.HasPrefix(normalized, "mc8123"):
+		value = TagProtectionMC8123
+	default:
+		return nil, false
+	}
+	return []CanonicalTag{{Type: TagTypeProtection, Value: value, Source: TagSourceBracketed}}, true
+}
+
+// parseSideOfToken maps "side-N-of-M" (e.g. "Side 1 of 2") to a media side value plus the
+// disc/side total. Returns the tags and true on a match.
+func parseSideOfToken(normalized string) ([]CanonicalTag, bool) {
+	m := reSideOf.FindStringSubmatch(normalized)
+	if m == nil {
+		return nil, false
+	}
+	sides := map[string]TagValue{"1": TagMediaSideA, "2": TagMediaSideB, "3": TagMediaSideC, "4": TagMediaSideD}
+	side, ok := sides[m[1]]
+	if !ok {
+		return nil, false
+	}
+	result := []CanonicalTag{{Type: TagTypeMedia, Value: side, Source: TagSourceBracketed}}
+	totals := map[string]TagValue{
+		"2": TagDiscTotal2, "3": TagDiscTotal3, "4": TagDiscTotal4, "5": TagDiscTotal5, "6": TagDiscTotal6,
+	}
+	if total, ok := totals[m[2]]; ok {
+		result = append(result, CanonicalTag{Type: TagTypeDiscTotal, Value: total, Source: TagSourceBracketed})
+	}
+	return result, true
+}
+
+// dumpFlagValues maps a TOSEC/GoodTools bracket dump-flag letter to its canonical value.
+var dumpFlagValues = map[string]TagValue{
+	"a": TagDumpAlternate, "b": TagDumpBad, "cr": TagDumpCracked, "f": TagDumpFixed,
+	"h": TagDumpHacked, "m": TagDumpModified, "o": TagDumpOverdump, "p": TagDumpPirated,
+	"t": TagDumpTrained, "tr": TagDumpTranslated, "u": TagDumpUnderdump, "v": TagDumpVirus,
+}
+
+// parseDumpFlagBracket handles the TOSEC/GoodTools dump-flag bracket grammar: a flag letter
+// optionally followed by an index ("[f1]", "[a2]") and/or a whitespace-separated cracker/
+// group name ("[cr XOR]", "[h ASS]", "[t +2 XOR]"). The flag sets the dump status; a trailing
+// group name becomes a credit. It parses the RAW bracket tag (not the normalized form) so the
+// cracker convention's space separator is distinguishable from a plain hyphen — hyphenated
+// words like "b-side"/"a-team" must not be misread as flag+credit. Must run AFTER explicit
+// keyword mappings so tokens like "a000" (a load address) are not misread as flag "a".
+func parseDumpFlagBracket(rawTag string) ([]CanonicalTag, bool) {
+	m := reDumpFlag.FindStringSubmatch(strings.ToLower(strings.TrimSpace(rawTag)))
+	if m == nil {
+		return nil, false
+	}
+	value, ok := dumpFlagValues[m[1]]
+	if !ok {
+		return nil, false
+	}
+	result := []CanonicalTag{{Type: TagTypeDump, Value: value, Source: TagSourceBracketed}}
+	if m[3] != "" && looksLikeCompanyName(m[3]) {
+		result = append(result, CanonicalTag{
+			Type: TagTypeCredit, Value: NormalizeCompanyName(m[3]), Source: TagSourceBracketed,
+		})
+	}
+	return result, true
+}
+
+// parseTrackNumber recognizes a music track number token ("01", "12", "track-3") and returns
+// its leading-zero-stripped value.
+func parseTrackNumber(normalized string) (string, bool) {
+	s := normalized
+	if rest, ok := strings.CutPrefix(s, "track-"); ok {
+		s = rest
+	}
+	if s == "" || len(s) > 3 || !allDigits(s) {
+		return "", false
+	}
+	stripped := strings.TrimLeft(s, "0")
+	if stripped == "" {
+		stripped = "0"
+	}
+	return stripped, true
+}
+
+// mapMusicBracket maps the bracket conventions of SPC/NSF music libraries, where brackets
+// carry track numbers, alternate-sound sets, and composer/annotation text rather than dump
+// status. Returns nil if the token is not a recognized music bracket.
+func mapMusicBracket(normalized string) []CanonicalTag {
+	if n, ok := parseTrackNumber(normalized); ok {
+		return []CanonicalTag{{Type: TagTypeTrack, Value: TagValue(n), Source: TagSourceBracketed}}
+	}
+	// Alternate sound set "as1".."asN" → alt:N.
+	if rest, ok := strings.CutPrefix(normalized, "as"); ok && rest != "" && allDigits(rest) {
+		n := strings.TrimLeft(rest, "0")
+		if n == "" {
+			n = "0"
+		}
+		return []CanonicalTag{{Type: TagTypeAlt, Value: TagValue(n), Source: TagSourceBracketed}}
+	}
+	if normalized == "sfx" {
+		return []CanonicalTag{{Type: TagTypeAlt, Value: TagAlt, Source: TagSourceBracketed}}
+	}
+	// Composer / annotation free-text is a credit.
+	if looksLikeCompanyName(normalized) {
+		return []CanonicalTag{{
+			Type: TagTypeCredit, Value: NormalizeCompanyName(normalized), Source: TagSourceBracketed,
+		}}
+	}
+	return nil
 }
 
 // mapBracketTag maps tags from square brackets [].
@@ -1255,6 +1459,23 @@ func mapBracketTag(tag string, mediaType slugs.MediaType) []CanonicalTag {
 	// Normalize the tag for regular processing
 	normalized := cachedNormalizeTag(tag)
 
+	// A bracketed build date ("[2017-10-31]", "[1988-01]") is a date in any context. Only
+	// the dash-delimited forms are accepted here: bare 6-/8-digit tokens (e.g. "[010203]")
+	// are far more likely to be catalog numbers or ids than dates, so they stay dump info.
+	if strings.Contains(normalized, "-") {
+		if v, ok := parseBuildDate(normalized); ok {
+			return []CanonicalTag{{Type: TagTypeBuildDate, Value: TagValue(v), Source: TagSourceBracketed}}
+		}
+	}
+
+	// Music libraries use brackets for track numbers, alternate-sound sets, and composer
+	// text rather than dump status.
+	if mediaType == slugs.MediaTypeMusic {
+		if musicTags := mapMusicBracket(normalized); musicTags != nil {
+			return musicTags
+		}
+	}
+
 	if structuralTags, ok := parseStructuralSetTag(normalized, TagSourceBracketed); ok {
 		return structuralTags
 	}
@@ -1279,23 +1500,64 @@ func mapBracketTag(tag string, mediaType slugs.MediaType) []CanonicalTag {
 		return []CanonicalTag{{Type: TagTypeDump, Value: TagDumpCracked, Source: TagSourceBracketed}}
 	case "t":
 		return []CanonicalTag{{Type: TagTypeDump, Value: TagDumpTrained, Source: TagSourceBracketed}}
+	case "bl":
+		// MAME/arcade "[bl]" marks a bootleg romset.
+		return []CanonicalTag{{Type: TagTypeUnlicensed, Value: TagUnlicensedBootleg, Source: TagSourceBracketed}}
 	default:
-		// Try default mapping, filtering for known tag types
-		// Allow dump, unlicensed, language, and region tags through
+		// Try the keyword mapping and accept any concrete hardware/spec/status type it
+		// yields — memory ([128K]) → compatibility, [PAL] → video, board ids → arcadeboard,
+		// as well as the dump/unlicensed/lang/region markers. Only the company/person types
+		// (credit/publisher/developer) are excluded: those belong to parens, never brackets.
 		mapped := mapFilenameTagToCanonical(normalized)
 		var knownTags []CanonicalTag
 		for _, ct := range mapped {
-			if ct.Type == TagTypeDump || ct.Type == TagTypeUnlicensed ||
-				ct.Type == TagTypeLang || ct.Type == TagTypeRegion {
-				ct.Source = TagSourceBracketed
-				knownTags = append(knownTags, ct)
+			// Skip the company/person types — those belong to parens, never brackets.
+			if ct.Type == TagTypeUnknown || ct.Type == TagTypeCredit ||
+				ct.Type == TagTypePublisher || ct.Type == TagTypeDeveloper {
+				continue
 			}
+			ct.Source = TagSourceBracketed
+			knownTags = append(knownTags, ct)
 		}
 		if len(knownTags) > 0 {
 			return knownTags
 		}
+		// Arcade protection chip "[FD1094 317-0060]" → protection:fd1094 (before the dump-flag
+		// parser so it is not misread, and after explicit mappings).
+		if pTags, ok := parseProtectionChip(normalized); ok {
+			return pTags
+		}
+		// TOSEC dump flags with an index or cracker/group suffix: "[f1]", "[a2]", "[cr XOR]",
+		// "[h ASS]". Parses the raw tag (space vs hyphen) so hyphenated words are not misread.
+		if dumpTags, ok := parseDumpFlagBracket(tag); ok {
+			return dumpTags
+		}
+		// Structural qualifiers (set/edition/hack/crack/classics) can appear in brackets too.
+		if res, classified := classifyUnmappedParen(normalized, tag); classified && len(res) > 0 {
+			return res
+		}
+		// Unrecognized bracket token: traditional bracket semantics treat it as dump info.
 		return []CanonicalTag{{Type: TagTypeDump, Value: TagValue(normalized), Source: TagSourceBracketed}}
 	}
+}
+
+// classifyLooseParenToken classifies a paren/comma token that matched no keyword mapping,
+// using the shared No-Intro/TOSEC heuristics: structural/edition/hack/crack/set/translation
+// classification (classifyUnmappedParen), then the TOSEC year-position publisher rule, then a
+// company-name credit, else unknown. norm is the normalized token, raw the original text.
+// index and yearExtracted come from the paren's position context; comma-parts pass index 1
+// and false, since a comma-part is never at the TOSEC year position.
+func classifyLooseParenToken(norm, raw string, index int, yearExtracted bool) []CanonicalTag {
+	if result, classified := classifyUnmappedParen(norm, raw); classified {
+		return result
+	}
+	if index == 0 && yearExtracted {
+		return []CanonicalTag{{Type: TagTypePublisher, Value: NormalizeCompanyName(raw), Source: TagSourceBracketed}}
+	}
+	if looksLikeCompanyName(norm) {
+		return []CanonicalTag{{Type: TagTypeCredit, Value: NormalizeCompanyName(raw), Source: TagSourceBracketed}}
+	}
+	return []CanonicalTag{{Type: TagTypeUnknown, Value: TagValue(norm), Source: TagSourceBracketed}}
 }
 
 // mapParenthesisTag maps tags from parentheses ().
@@ -1428,31 +1690,7 @@ func mapParenthesisTag(tag string, ctx *ParseContext) []CanonicalTag {
 	// Try default mapping
 	mapped := mapFilenameTagToCanonical(tag)
 	if len(mapped) == 0 {
-		// Classify the unmatched group first: may produce edition:, release:, credit:,
-		// or nothing (nil means "drop silently").
-		result, classified := classifyUnmappedParen(tag, ctx.CurrentTag)
-		if classified {
-			return result
-		}
-		// TOSEC positional rule: Title (year)(publisher)[flags]
-		// extractSpecialPatterns removes the year paren before extractTags runs, so the
-		// TOSEC publisher lands at paren position 0. YearExtractedFromFile is set only by
-		// extractSpecialPatterns, so this check cannot fire from year tags from other sources.
-		if ctx.CurrentIndex == 0 && ctx.YearExtractedFromFile {
-			return []CanonicalTag{{
-				Type:   TagTypePublisher,
-				Value:  NormalizeCompanyName(ctx.CurrentTag),
-				Source: TagSourceBracketed,
-			}}
-		}
-		if looksLikeCompanyName(tag) {
-			return []CanonicalTag{{
-				Type:   TagTypeCredit,
-				Value:  NormalizeCompanyName(ctx.CurrentTag),
-				Source: TagSourceBracketed,
-			}}
-		}
-		return []CanonicalTag{{Type: TagTypeUnknown, Value: TagValue(tag), Source: TagSourceBracketed}}
+		return classifyLooseParenToken(tag, ctx.CurrentTag, ctx.CurrentIndex, ctx.YearExtractedFromFile)
 	}
 
 	// If multiple mappings, check if they're complementary (like region+language)

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -1474,10 +1474,14 @@ func TestParseFilenameToCanonicalTagsForMedia_CabinetAndProtection(t *testing.T)
 		wantTag  string
 	}{
 		{"Game (Cocktail).mra", "cabinet:cocktail"},
+		{"Game (Cabaret).mra", "cabinet:cabaret"},
 		{"Game (World, Upright).mra", "cabinet:upright"},
 		{"Cabinet (sitdown - upright).mra", "cabinet:sitdown"},
 		{"Cabinet (sitdown - upright).mra", "cabinet:upright"},
 		{"Alex Kidd (World, S16A) [No Protection].mra", "protection:no-protection"},
+		{"Game (Encrypted).mra", "protection:encrypted"},
+		{"Game (Decrypted).mra", "protection:decrypted"},
+		{"Game (MC-8123).mra", "protection:mc-8123"},
 		{"Ace Attacker (Japan, S16A) [FD1094 317-0060].mra", "protection:fd1094"},
 		{"Alien (World) (FD1094 317-0154).mra", "protection:fd1094"},
 		{"Altered Beast (set 8) (8751 317-0078).mra", "protection:8751"},
@@ -1547,6 +1551,7 @@ func TestParseFilenameToCanonicalTagsForMedia_FormatAndStructureTokens(t *testin
 		{"180 (1986)(Mastertronic)[cr XOR].atr", "dump:cracked"},
 		{"180 (1986)(Mastertronic)[cr XOR].atr", "credit:xor"},
 		{"007 (1987)(Domark)[k-file].atr", "media:k-file"},
+		{"Boulder Dash (1984)(First Star)[lnx].atr", "media:lnx"},
 		{"Prog (19xx)(-)[basic].rkr", "compatibility:basic"},
 		{"Game (8K).prg", "compatibility:memory:8k"},
 		{"Game (4K).prg", "compatibility:memory:4k"},

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -1336,6 +1336,241 @@ func TestParseFilenameToCanonicalTagsForMedia_GameSkipsTVButKeepsRomTranslationP
 	assert.Contains(t, gameStrings, "region:us")
 }
 
+// TestParseFilenameToCanonicalTagsForMedia_DumpFlagGrammar verifies the TOSEC dump-flag
+// bracket grammar accepts real flag/cracker forms but rejects hyphenated words, which must
+// not be misread as flag+credit (e.g. "[b-side]" is not "bad dump by side").
+func TestParseFilenameToCanonicalTagsForMedia_DumpFlagGrammar(t *testing.T) {
+	t.Parallel()
+
+	collect := func(fn string) []string {
+		got := ParseFilenameToCanonicalTagsForMedia(fn, slugs.MediaTypeGame)
+		strs := make([]string, len(got))
+		for i, ct := range got {
+			strs[i] = ct.String()
+		}
+		return strs
+	}
+
+	// Real dump-flag / cracker forms are recognized.
+	assert.Contains(t, collect("Game [cr XOR].d64"), "dump:cracked")
+	assert.Contains(t, collect("Game [cr XOR].d64"), "credit:xor")
+	assert.Contains(t, collect("Game [h ASS].d64"), "dump:hacked")
+	assert.Contains(t, collect("Game [f1].nes"), "dump:fixed")
+	assert.Contains(t, collect("Game [a2].nes"), "dump:alternate")
+
+	// Hyphenated words must NOT be misread as flag+credit.
+	bSide := collect("Game [b-side].nes")
+	assert.NotContains(t, bSide, "dump:bad")
+	assert.NotContains(t, bSide, "credit:side")
+	aTeam := collect("Game [a-team].nes")
+	assert.NotContains(t, aTeam, "dump:alternate")
+	assert.NotContains(t, aTeam, "credit:team")
+}
+
+func TestParseFilenameToCanonicalTagsForMedia_ArcadeInputControls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		{"Jackal (W, Rotary).mra", "input:joystick:rotary"},
+		{"Some Game (Trackball).mra", "input:trackball"},
+		{"Some Game (Paddle).mra", "input:paddle"},
+		{"Some Game (Twin Stick).mra", "input:stick:twin"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+}
+
+// TestParseFilenameToCanonicalTagsForMedia_ArcadeMetadataTokens covers the arcade
+// filename tokens that must map to their correct known types (not unknown): bootleg
+// bracket, Sega System board shorthand, software version, and memory config.
+func TestParseFilenameToCanonicalTagsForMedia_ArcadeMetadataTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		{"Jackal (W) [bl].mra", "unlicensed:bootleg"},
+		{"Action Fighter (World, S16A).mra", "arcadeboard:sega:system16a"},
+		{"Sonic (World, S16B).mra", "arcadeboard:sega:system16b"},
+		{"Body Slam (World, S16).mra", "arcadeboard:sega:system16"},
+		{"Demon Front (ver. 105).mra", "rev:105"},
+		{"Dragon World 2001 (ver. 100, Japan).mra", "rev:100"},
+		{"Caliber 50 (Ver. 1.01).mra", "rev:1-01"},
+		{"Some Game (48-128K).tap", "compatibility:memory:48k-128k"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+}
+
+// TestParseFilenameToCanonicalTagsForMedia_LooseTokenRouting covers the systematic
+// routing fixes: comma-parts and bracket tokens now reach the classifier instead of being
+// dropped, so recognized qualifiers get their correct type in every context. Also covers
+// the new keyword/date mappings.
+func TestParseFilenameToCanonicalTagsForMedia_LooseTokenRouting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		// set / board as a comma-part (previously dropped after the comma)
+		{"Finalizer (World, Set 2).mra", "set:2"},
+		{"Alex Kidd (World, System 16B).mra", "arcadeboard:sega:system16b"},
+		{"Game (World, CPS Changer).mra", "arcadeboard:capcom:cpschanger"},
+		// board id followed by a trailing "version" word (previously dropped as noise)
+		{"Fantasy Zone II (System 16C version).mra", "arcadeboard:sega:system16c"},
+		// memory as a bracket token (previously dropped as dump:<raw>)
+		{"Elite (1984)(Firebird)[128K].tap", "compatibility:memory:128k"},
+		{"180 (1986)(Mastertronic)[48-128K].atr", "compatibility:memory:48k-128k"},
+		// year-month build date (previously unknown)
+		{"720 (1988-01).nsf", "builddate:1988-01"},
+		// keyword mappings whose values already existed
+		{"Game (New Zealand).z64", "region:nz"},
+		{"Game (PAL60).md", "video:pal-60"},
+		{"Game [re-release].tap", "release:reissue"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+}
+
+// TestParseFilenameToCanonicalTagsForMedia_CabinetAndProtection covers the two arcade tag
+// types: cabinet orientation and copy-protection state (chip family only, serial dropped).
+func TestParseFilenameToCanonicalTagsForMedia_CabinetAndProtection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		{"Game (Cocktail).mra", "cabinet:cocktail"},
+		{"Game (World, Upright).mra", "cabinet:upright"},
+		{"Cabinet (sitdown - upright).mra", "cabinet:sitdown"},
+		{"Cabinet (sitdown - upright).mra", "cabinet:upright"},
+		{"Alex Kidd (World, S16A) [No Protection].mra", "protection:no-protection"},
+		{"Ace Attacker (Japan, S16A) [FD1094 317-0060].mra", "protection:fd1094"},
+		{"Alien (World) (FD1094 317-0154).mra", "protection:fd1094"},
+		{"Altered Beast (set 8) (8751 317-0078).mra", "protection:8751"},
+		{"Action Fighter (World, S16A) [FD1089B 317-0018].mra", "protection:fd1089"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename+"_"+tt.wantTag, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+
+	// The protection chip serial (e.g. "317-0060") is deliberately dropped — only the chip
+	// family is kept — so no resulting tag should carry the serial.
+	t.Run("serial_dropped", func(t *testing.T) {
+		t.Parallel()
+		for _, ct := range ParseFilenameToCanonicalTagsForMedia(
+			"Ace Attacker (Japan, S16A) [FD1094 317-0060].mra", slugs.MediaTypeGame,
+		) {
+			assert.NotContains(t, ct.String(), "317", "chip serial must not leak into a tag: %s", ct.String())
+		}
+	})
+}
+
+// TestParseFilenameToCanonicalTagsForMedia_MusicBrackets covers the media-aware bracket
+// handling for SPC/NSF music libraries: track numbers, alternate-sound sets, and composer text.
+func TestParseFilenameToCanonicalTagsForMedia_MusicBrackets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		{"Star Fox [01].spc", "track:1"},
+		{"Star Fox [12].spc", "track:12"},
+		{"Utopia [AS1].spc", "alt:1"},
+		{"Zelda [AS3].spc", "alt:3"},
+		{"Song [Hajime Hirasawa].spc", "credit:hajime-hirasawa"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeMusic)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+}
+
+// TestParseFilenameToCanonicalTagsForMedia_FormatAndStructureTokens covers the remaining
+// format/memory/structure/hardware tokens that previously dropped or fell to dump:<raw>.
+func TestParseFilenameToCanonicalTagsForMedia_FormatAndStructureTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename string
+		wantTag  string
+	}{
+		{"180 (1986)(Mastertronic)[cr XOR].atr", "dump:cracked"},
+		{"180 (1986)(Mastertronic)[cr XOR].atr", "credit:xor"},
+		{"007 (1987)(Domark)[k-file].atr", "media:k-file"},
+		{"Prog (19xx)(-)[basic].rkr", "compatibility:basic"},
+		{"Game (8K).prg", "compatibility:memory:8k"},
+		{"Game (4K).prg", "compatibility:memory:4k"},
+		{"Game (A000).prg", "compatibility:load:a000"},
+		{"Game [no boot].dsk", "dump:no-boot"},
+		{"Prog (type-in).prg", "distribution:type-in"},
+		{"Great Giana (Side 1 of 2).d64", "media:side-a"},
+		{"Great Giana (Side 1 of 2).d64", "disctotal:2"},
+		{"R-Type (World, M72 hardware).mra", "arcadeboard:irem:m72"},
+		{"Game [2017-10-31].hex", "builddate:2017-10-31"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.filename+"_"+tt.wantTag, func(t *testing.T) {
+			t.Parallel()
+			got := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			strs := make([]string, len(got))
+			for i, ct := range got {
+				strs[i] = ct.String()
+			}
+			assert.Contains(t, strs, tt.wantTag)
+		})
+	}
+}
+
 func TestParseFilenameToCanonicalTagsForMedia_NonGameSkipsRomTranslationLanguageTags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/tags/string_parsers.go
+++ b/pkg/database/tags/string_parsers.go
@@ -159,6 +159,15 @@ func parseBuildDate(s string) (string, bool) {
 			return "", false
 		}
 		return s, true
+	case len(s) == 7 && s[4] == '-':
+		// Year-month only, e.g. "1988-01" (common in NSF/SPC music build dates).
+		if !allDigits(s[0:4]) || !allDigits(s[5:7]) {
+			return "", false
+		}
+		if m := atoi2(s[5:7]); m < 1 || m > 12 {
+			return "", false
+		}
+		return s, true
 	case len(s) == 8 && allDigits(s):
 		if !validMonthDay(atoi2(s[4:6]), atoi2(s[6:8])) {
 			return "", false

--- a/pkg/database/tags/tag_mappings.go
+++ b/pkg/database/tags/tag_mappings.go
@@ -100,55 +100,56 @@ var allTagMappings = map[string][]CanonicalTag{
 	"cl": {{Type: TagTypeRegion, Value: TagRegionCL}, {Type: TagTypeLang, Value: TagLangES}}, // Chile
 	"cn": {{Type: TagTypeRegion, Value: TagRegionCN}, {Type: TagTypeLang, Value: TagLangZH}},
 	// Serbia, also Czech language
-	"cs": {{Type: TagTypeRegion, Value: TagRegionCS}, {Type: TagTypeLang, Value: TagLangCS}},
-	"cy": {{Type: TagTypeRegion, Value: TagRegionCY}},
-	"cz": {{Type: TagTypeRegion, Value: TagRegionCZ}, {Type: TagTypeLang, Value: TagLangCS}},
-	"de": {{Type: TagTypeRegion, Value: TagRegionDE}, {Type: TagTypeLang, Value: TagLangDE}},
-	"dk": {{Type: TagTypeRegion, Value: TagRegionDK}, {Type: TagTypeLang, Value: TagLangDA}},
-	"ee": {{Type: TagTypeRegion, Value: TagRegionEE}, {Type: TagTypeLang, Value: TagLangET}}, // Estonia
-	"eg": {{Type: TagTypeRegion, Value: TagRegionEG}, {Type: TagTypeLang, Value: TagLangAR}}, // Egypt
-	"es": {{Type: TagTypeRegion, Value: TagRegionES}, {Type: TagTypeLang, Value: TagLangES}},
-	"eu": {{Type: TagTypeRegion, Value: TagRegionEU}}, // Europe - multi-region
-	"fi": {{Type: TagTypeRegion, Value: TagRegionFI}, {Type: TagTypeLang, Value: TagLangFI}},
-	"fr": {{Type: TagTypeRegion, Value: TagRegionFR}, {Type: TagTypeLang, Value: TagLangFR}},
-	"gb": {{Type: TagTypeRegion, Value: TagRegionGB}, {Type: TagTypeLang, Value: TagLangEN}},
-	"gr": {{Type: TagTypeRegion, Value: TagRegionGR}, {Type: TagTypeLang, Value: TagLangEL}},
-	"hk": {{Type: TagTypeRegion, Value: TagRegionHK}}, // Hong Kong - multilingual (Chinese/English)
-	"hr": {{Type: TagTypeRegion, Value: TagRegionHR}, {Type: TagTypeLang, Value: TagLangHR}},
-	"hu": {{Type: TagTypeRegion, Value: TagRegionHU}, {Type: TagTypeLang, Value: TagLangHU}},
-	"id": {{Type: TagTypeRegion, Value: TagRegionID}},
-	"ie": {{Type: TagTypeRegion, Value: TagRegionIE}, {Type: TagTypeLang, Value: TagLangEN}},
-	"il": {{Type: TagTypeRegion, Value: TagRegionIL}, {Type: TagTypeLang, Value: TagLangHE}},
-	"in": {{Type: TagTypeRegion, Value: TagRegionIN}, {Type: TagTypeLang, Value: TagLangHI}},
-	"ir": {{Type: TagTypeRegion, Value: TagRegionIR}, {Type: TagTypeLang, Value: TagLangFA}},
-	"is": {{Type: TagTypeRegion, Value: TagRegionIS}, {Type: TagTypeLang, Value: TagLangIS}}, // Iceland
-	"it": {{Type: TagTypeRegion, Value: TagRegionIT}, {Type: TagTypeLang, Value: TagLangIT}},
-	"jo": {{Type: TagTypeRegion, Value: TagRegionJO}, {Type: TagTypeLang, Value: TagLangAR}}, // Jordan
-	"jp": {{Type: TagTypeRegion, Value: TagRegionJP}, {Type: TagTypeLang, Value: TagLangJA}},
-	"kr": {{Type: TagTypeRegion, Value: TagRegionKR}, {Type: TagTypeLang, Value: TagLangKO}},
-	"lt": {{Type: TagTypeRegion, Value: TagRegionLT}, {Type: TagTypeLang, Value: TagLangLT}},
-	"lu": {{Type: TagTypeRegion, Value: TagRegionLU}}, // Luxembourg - multilingual (Luxembourgish/French/German)
-	"lv": {{Type: TagTypeRegion, Value: TagRegionLV}, {Type: TagTypeLang, Value: TagLangLV}},
-	"mn": {{Type: TagTypeRegion, Value: TagRegionMN}},
-	"mx": {{Type: TagTypeRegion, Value: TagRegionMX}, {Type: TagTypeLang, Value: TagLangES}},
-	"my": {{Type: TagTypeRegion, Value: TagRegionMY}, {Type: TagTypeLang, Value: TagLangMS}},
-	"nl": {{Type: TagTypeRegion, Value: TagRegionNL}, {Type: TagTypeLang, Value: TagLangNL}},
-	"no": {{Type: TagTypeRegion, Value: TagRegionNO}, {Type: TagTypeLang, Value: TagLangNO}},
-	"np": {{Type: TagTypeRegion, Value: TagRegionNP}},
-	"nz": {{Type: TagTypeRegion, Value: TagRegionNZ}, {Type: TagTypeLang, Value: TagLangEN}}, // New Zealand
-	"om": {{Type: TagTypeRegion, Value: TagRegionOM}, {Type: TagTypeLang, Value: TagLangAR}}, // Oman
-	"pe": {{Type: TagTypeRegion, Value: TagRegionPE}, {Type: TagTypeLang, Value: TagLangES}}, // Peru
-	"ph": {{Type: TagTypeRegion, Value: TagRegionPH}},
-	"pl": {{Type: TagTypeRegion, Value: TagRegionPL}, {Type: TagTypeLang, Value: TagLangPL}},
-	"pt": {{Type: TagTypeRegion, Value: TagRegionPT}, {Type: TagTypeLang, Value: TagLangPT}},
-	"qa": {{Type: TagTypeRegion, Value: TagRegionQA}, {Type: TagTypeLang, Value: TagLangAR}}, // Qatar
-	"ro": {{Type: TagTypeRegion, Value: TagRegionRO}, {Type: TagTypeLang, Value: TagLangRO}},
-	"ru": {{Type: TagTypeRegion, Value: TagRegionRU}, {Type: TagTypeLang, Value: TagLangRU}},
-	"se": {{Type: TagTypeRegion, Value: TagRegionSE}, {Type: TagTypeLang, Value: TagLangSV}},
-	"sg": {{Type: TagTypeRegion, Value: TagRegionSG}}, // Singapore - multilingual (English/Malay/Chinese/Tamil)
-	"si": {{Type: TagTypeRegion, Value: TagRegionSI}, {Type: TagTypeLang, Value: TagLangSL}},
-	"sk": {{Type: TagTypeRegion, Value: TagRegionSK}, {Type: TagTypeLang, Value: TagLangSK}},
-	"th": {{Type: TagTypeRegion, Value: TagRegionTH}, {Type: TagTypeLang, Value: TagLangTH}},
+	"cs":          {{Type: TagTypeRegion, Value: TagRegionCS}, {Type: TagTypeLang, Value: TagLangCS}},
+	"cy":          {{Type: TagTypeRegion, Value: TagRegionCY}},
+	"cz":          {{Type: TagTypeRegion, Value: TagRegionCZ}, {Type: TagTypeLang, Value: TagLangCS}},
+	"de":          {{Type: TagTypeRegion, Value: TagRegionDE}, {Type: TagTypeLang, Value: TagLangDE}},
+	"dk":          {{Type: TagTypeRegion, Value: TagRegionDK}, {Type: TagTypeLang, Value: TagLangDA}},
+	"ee":          {{Type: TagTypeRegion, Value: TagRegionEE}, {Type: TagTypeLang, Value: TagLangET}}, // Estonia
+	"eg":          {{Type: TagTypeRegion, Value: TagRegionEG}, {Type: TagTypeLang, Value: TagLangAR}}, // Egypt
+	"es":          {{Type: TagTypeRegion, Value: TagRegionES}, {Type: TagTypeLang, Value: TagLangES}},
+	"eu":          {{Type: TagTypeRegion, Value: TagRegionEU}}, // Europe - multi-region
+	"fi":          {{Type: TagTypeRegion, Value: TagRegionFI}, {Type: TagTypeLang, Value: TagLangFI}},
+	"fr":          {{Type: TagTypeRegion, Value: TagRegionFR}, {Type: TagTypeLang, Value: TagLangFR}},
+	"gb":          {{Type: TagTypeRegion, Value: TagRegionGB}, {Type: TagTypeLang, Value: TagLangEN}},
+	"gr":          {{Type: TagTypeRegion, Value: TagRegionGR}, {Type: TagTypeLang, Value: TagLangEL}},
+	"hk":          {{Type: TagTypeRegion, Value: TagRegionHK}}, // Hong Kong - multilingual (Chinese/English)
+	"hr":          {{Type: TagTypeRegion, Value: TagRegionHR}, {Type: TagTypeLang, Value: TagLangHR}},
+	"hu":          {{Type: TagTypeRegion, Value: TagRegionHU}, {Type: TagTypeLang, Value: TagLangHU}},
+	"id":          {{Type: TagTypeRegion, Value: TagRegionID}},
+	"ie":          {{Type: TagTypeRegion, Value: TagRegionIE}, {Type: TagTypeLang, Value: TagLangEN}},
+	"il":          {{Type: TagTypeRegion, Value: TagRegionIL}, {Type: TagTypeLang, Value: TagLangHE}},
+	"in":          {{Type: TagTypeRegion, Value: TagRegionIN}, {Type: TagTypeLang, Value: TagLangHI}},
+	"ir":          {{Type: TagTypeRegion, Value: TagRegionIR}, {Type: TagTypeLang, Value: TagLangFA}},
+	"is":          {{Type: TagTypeRegion, Value: TagRegionIS}, {Type: TagTypeLang, Value: TagLangIS}}, // Iceland
+	"it":          {{Type: TagTypeRegion, Value: TagRegionIT}, {Type: TagTypeLang, Value: TagLangIT}},
+	"jo":          {{Type: TagTypeRegion, Value: TagRegionJO}, {Type: TagTypeLang, Value: TagLangAR}}, // Jordan
+	"jp":          {{Type: TagTypeRegion, Value: TagRegionJP}, {Type: TagTypeLang, Value: TagLangJA}},
+	"kr":          {{Type: TagTypeRegion, Value: TagRegionKR}, {Type: TagTypeLang, Value: TagLangKO}},
+	"lt":          {{Type: TagTypeRegion, Value: TagRegionLT}, {Type: TagTypeLang, Value: TagLangLT}},
+	"lu":          {{Type: TagTypeRegion, Value: TagRegionLU}}, // Luxembourg (multilingual)
+	"lv":          {{Type: TagTypeRegion, Value: TagRegionLV}, {Type: TagTypeLang, Value: TagLangLV}},
+	"mn":          {{Type: TagTypeRegion, Value: TagRegionMN}},
+	"mx":          {{Type: TagTypeRegion, Value: TagRegionMX}, {Type: TagTypeLang, Value: TagLangES}},
+	"my":          {{Type: TagTypeRegion, Value: TagRegionMY}, {Type: TagTypeLang, Value: TagLangMS}},
+	"nl":          {{Type: TagTypeRegion, Value: TagRegionNL}, {Type: TagTypeLang, Value: TagLangNL}},
+	"no":          {{Type: TagTypeRegion, Value: TagRegionNO}, {Type: TagTypeLang, Value: TagLangNO}},
+	"np":          {{Type: TagTypeRegion, Value: TagRegionNP}},
+	"nz":          {{Type: TagTypeRegion, Value: TagRegionNZ}, {Type: TagTypeLang, Value: TagLangEN}}, // New Zealand
+	"new-zealand": {{Type: TagTypeRegion, Value: TagRegionNZ}, {Type: TagTypeLang, Value: TagLangEN}}, // NZ full name
+	"om":          {{Type: TagTypeRegion, Value: TagRegionOM}, {Type: TagTypeLang, Value: TagLangAR}}, // Oman
+	"pe":          {{Type: TagTypeRegion, Value: TagRegionPE}, {Type: TagTypeLang, Value: TagLangES}}, // Peru
+	"ph":          {{Type: TagTypeRegion, Value: TagRegionPH}},
+	"pl":          {{Type: TagTypeRegion, Value: TagRegionPL}, {Type: TagTypeLang, Value: TagLangPL}},
+	"pt":          {{Type: TagTypeRegion, Value: TagRegionPT}, {Type: TagTypeLang, Value: TagLangPT}},
+	"qa":          {{Type: TagTypeRegion, Value: TagRegionQA}, {Type: TagTypeLang, Value: TagLangAR}}, // Qatar
+	"ro":          {{Type: TagTypeRegion, Value: TagRegionRO}, {Type: TagTypeLang, Value: TagLangRO}},
+	"ru":          {{Type: TagTypeRegion, Value: TagRegionRU}, {Type: TagTypeLang, Value: TagLangRU}},
+	"se":          {{Type: TagTypeRegion, Value: TagRegionSE}, {Type: TagTypeLang, Value: TagLangSV}},
+	"sg":          {{Type: TagTypeRegion, Value: TagRegionSG}}, // Singapore (multilingual)
+	"si":          {{Type: TagTypeRegion, Value: TagRegionSI}, {Type: TagTypeLang, Value: TagLangSL}},
+	"sk":          {{Type: TagTypeRegion, Value: TagRegionSK}, {Type: TagTypeLang, Value: TagLangSK}},
+	"th":          {{Type: TagTypeRegion, Value: TagRegionTH}, {Type: TagTypeLang, Value: TagLangTH}},
 	// Turkey - context-aware: ()=region/lang, []=translated (see filename_parser.go)
 	"tr": {{Type: TagTypeRegion, Value: TagRegionTR}},
 	"tw": {{Type: TagTypeRegion, Value: TagRegionTW}, {Type: TagTypeLang, Value: TagLangZH}}, // Taiwan
@@ -293,6 +294,7 @@ var allTagMappings = map[string][]CanonicalTag{
 	"ntsc-pal": {{Type: TagTypeVideo, Value: TagVideoNTSCPAL}},
 	"pal":      {{Type: TagTypeVideo, Value: TagVideoPAL}},
 	"pal-60":   {{Type: TagTypeVideo, Value: TagVideoPAL60}},
+	"pal60":    {{Type: TagTypeVideo, Value: TagVideoPAL60}}, // "PAL60" without separator
 	"pal-ntsc": {{Type: TagTypeVideo, Value: TagVideoPALNTSC}},
 	"svga":     {{Type: TagTypeVideo, Value: TagVideoSVGA}},
 	"vga":      {{Type: TagTypeVideo, Value: TagVideoVGA}},
@@ -364,9 +366,27 @@ var allTagMappings = map[string][]CanonicalTag{
 	"ii+": {{Type: TagTypeCompatibility, Value: TagCompatibilityApple2Plus}},
 	"iie": {{Type: TagTypeCompatibility, Value: TagCompatibilityApple2E}},
 	// Memory requirements
-	"16k":      {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory16K}},
-	"128k":     {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory128K}},
-	"48k-128k": {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory48K128K}},
+	"3k":        {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory3K}},
+	"4k":        {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory4K}},
+	"8k":        {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory8K}},
+	"16k":       {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory16K}},
+	"19k":       {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory19K}},
+	"64k":       {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory64K}},
+	"128k":      {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory128K}},
+	"48k-128k":  {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory48K128K}},
+	"48-128k":   {{Type: TagTypeCompatibility, Value: TagCompatibilityMemory48K128K}}, // ZX Spectrum "48-128K"
+	"a000":      {{Type: TagTypeCompatibility, Value: TagCompatibilityLoadA000}},      // VIC-20 load at $A000
+	"basic":     {{Type: TagTypeCompatibility, Value: TagCompatibilityBasic}},         // Requires BASIC
+	"pascal":    {{Type: TagTypeCompatibility, Value: TagCompatibilityPascal}},        // Requires Pascal
+	"cpm":       {{Type: TagTypeCompatibility, Value: TagCompatibilityCPM}},           // Requires CP/M
+	"rdos":      {{Type: TagTypeCompatibility, Value: TagCompatibilityRDOS}},          // Atari RDOS
+	"os-b":      {{Type: TagTypeCompatibility, Value: TagCompatibilityOSB}},           // Atari OS-B
+	"sedoric":   {{Type: TagTypeCompatibility, Value: TagCompatibilitySedoric}},       // Oric Sedoric
+	"lnx":       {{Type: TagTypeMedia, Value: TagMediaLNX}},                           // C64 Lynx archive
+	"k-file":    {{Type: TagTypeMedia, Value: TagMediaKFile}},                         // Atari K-File disk image
+	"no-boot":   {{Type: TagTypeDump, Value: TagDumpNoBoot}},                          // Non-bootable dump
+	"type-in":   {{Type: TagTypeDistribution, Value: TagDistributionTypeIn}},          // Magazine type-in
+	"multipart": {{Type: TagTypeMedia, Value: TagMediaPart}},                          // Multi-part file
 	// Amiga systems
 	"+2":                     {{Type: TagTypeCompatibility, Value: TagCompatibilityAmigaPlus2}},
 	"+2a":                    {{Type: TagTypeCompatibility, Value: TagCompatibilityAmigaPlus2A}},
@@ -427,12 +447,54 @@ var allTagMappings = map[string][]CanonicalTag{
 	"vs-unisystem":           {{Type: TagTypeCompatibility, Value: TagCompatibilityNintendoVSUnisystem}},
 
 	// ============================================================================
+	// INPUT / CONTROL MAPPINGS
+	// ============================================================================
+	// Control-scheme qualifiers used in arcade (.mra) filenames, e.g.
+	// "Jackal (W, Rotary)". Without these the control variant is dropped and
+	// sibling arcade entries become indistinguishable.
+	"rotary":     {{Type: TagTypeInput, Value: TagInputJoystickRotary}}, // rotary joystick
+	"trackball":  {{Type: TagTypeInput, Value: TagInputTrackball}},      // trackball
+	"paddle":     {{Type: TagTypeInput, Value: TagInputPaddle}},         // paddle
+	"twin-stick": {{Type: TagTypeInput, Value: TagInputStickTwin}},      // twin/dual stick
+
+	// ============================================================================
 	// ARCADE AND SPECIAL HARDWARE MAPPINGS
 	// ============================================================================
 	"vs":       {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardNintendoVS}},   // VS System arcade
 	"nss":      {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardNintendoNSS}},  // Nintendo Super System arcade
 	"megaplay": {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaMegaplay}}, // MegaPlay arcade
 	"mp":       {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaMegaplay}}, // MegaPlay (short form)
+	// Arcade cabinet orientation.
+	"upright":  {{Type: TagTypeCabinet, Value: TagCabinetUpright}},
+	"cocktail": {{Type: TagTypeCabinet, Value: TagCabinetCocktail}},
+	"cabaret":  {{Type: TagTypeCabinet, Value: TagCabinetCabaret}},
+	"sitdown":  {{Type: TagTypeCabinet, Value: TagCabinetSitdown}},
+	// Arcade copy-protection state (chip families handled by parseProtectionChip).
+	"no-protection": {{Type: TagTypeProtection, Value: TagProtectionNone}},
+	"encrypted":     {{Type: TagTypeProtection, Value: TagProtectionEncrypted}},
+	"decrypted":     {{Type: TagTypeProtection, Value: TagProtectionDecrypted}},
+	"mc-8123":       {{Type: TagTypeProtection, Value: TagProtectionMC8123}},
+	"mc8123":        {{Type: TagTypeProtection, Value: TagProtectionMC8123}},
+	// Sega System board shorthand used in MiSTer arcade MRA names, e.g. "(World, S16A)".
+	"s16":  {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16}},  // Sega System 16
+	"s16a": {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16A}}, // Sega System 16A
+	"s16b": {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16B}}, // Sega System 16B
+	"s16c": {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16C}}, // Sega System 16C
+	"s18":  {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem18}},  // Sega System 18
+	"s24":  {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem24}},  // Sega System 24
+	"s32":  {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem32}},  // Sega System 32
+	// Full-word forms of the same Sega System boards (e.g. "(World, System 16B)").
+	"system-16":    {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16}},
+	"system-16a":   {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16A}},
+	"system-16b":   {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16B}},
+	"system-16c":   {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem16C}},
+	"system-18":    {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem18}},
+	"system-24":    {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem24}},
+	"system-32":    {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardSegaSystem32}},
+	"cps-changer":  {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardCapcomCPSChanger}},
+	"m72":          {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardIremM72}}, // Irem M72
+	"m72-hardware": {{Type: TagTypeArcadeBoard, Value: TagArcadeBoardIremM72}}, // Irem M72 (full form)
+	"pc10":         {{Type: TagTypeCompatibility, Value: TagCompatibilityNintendoPlaychoice10}},
 	// "bs" is ambiguous: Bosnian language vs Satellaview - handled in filename_parser.go
 	"satellaview": {{Type: TagTypeAddon, Value: TagAddonOnlineSatellaview}}, // Satellaview online service
 	// "st" is ambiguous: Sufami Turbo vs other uses - handled in filename_parser.go
@@ -734,7 +796,9 @@ var allTagMappings = map[string][]CanonicalTag{
 
 	// Japanese release/edition descriptors
 	"reprint":            {{Type: TagTypeRelease, Value: TagReleaseReissue}},
+	"re-release":         {{Type: TagTypeRelease, Value: TagReleaseReissue}},
 	"fukkokuban":         {{Type: TagTypeRelease, Value: TagReleaseReissue}},
+	"hb":                 {{Type: TagTypeRelease, Value: TagReleaseHomebrew}},   // arcade "hb" = homebrew
 	"taikenban":          {{Type: TagTypeUnfinished, Value: TagUnfinishedDemo}}, // Demo/trial version
 	"shinsaku-taikenban": {{Type: TagTypeUnfinished, Value: TagUnfinishedDemo}}, // New demo/trial
 	"ura":                {{Type: TagTypeAlt, Value: TagAlt}},                   // Alternate/secret version

--- a/pkg/database/tags/tag_values.go
+++ b/pkg/database/tags/tag_values.go
@@ -762,6 +762,25 @@ const (
 	TagEmbeddedPocketsonar TagValue = "pocketsonar"
 )
 
+// Cabinet orientation tag values (arcade)
+const (
+	TagCabinetUpright  TagValue = "upright"
+	TagCabinetCocktail TagValue = "cocktail"
+	TagCabinetCabaret  TagValue = "cabaret"
+	TagCabinetSitdown  TagValue = "sitdown"
+)
+
+// Protection tag values (arcade copy-protection state; chip family only, no serial)
+const (
+	TagProtectionNone      TagValue = "no-protection"
+	TagProtectionFD1094    TagValue = "fd1094"
+	TagProtectionFD1089    TagValue = "fd1089"
+	TagProtection8751      TagValue = "8751"
+	TagProtectionMC8123    TagValue = "mc-8123"
+	TagProtectionEncrypted TagValue = "encrypted"
+	TagProtectionDecrypted TagValue = "decrypted"
+)
+
 // Arcade board tag values
 const (
 	// CAPCOM
@@ -1254,6 +1273,7 @@ const (
 	TagDumpBIOS             TagValue = "bios"                 // BIOS dump
 	TagDumpHackedFFE        TagValue = "hacked:ffe"           // Far East Copier hack
 	TagDumpHackedIntroRemov TagValue = "hacked:intro-removed" // Hacked intro removed
+	TagDumpNoBoot           TagValue = "no-boot"              // Dump does not boot
 )
 
 // Amiga compatibility combination tag values
@@ -1308,6 +1328,8 @@ const (
 	TagMediaFDS       TagValue = "fds"
 	TagMediaEReader   TagValue = "ereader"
 	TagMediaMultiboot TagValue = "multiboot"
+	TagMediaKFile     TagValue = "k-file" // Atari 8-bit K-File disk image
+	TagMediaLNX       TagValue = "lnx"    // C64 Lynx archive
 )
 
 // Multigame tag values (volume numbers and menu)
@@ -1490,6 +1512,7 @@ const (
 	TagDistributionClubNintendo   TagValue = "club-nintendo"
 	TagDistributionGBAEReader     TagValue = "gba-e-reader"
 	TagDistributionCompilation    TagValue = "compilation"
+	TagDistributionTypeIn         TagValue = "type-in" // Magazine type-in listing
 )
 
 // Apple II compatibility tag values
@@ -1500,9 +1523,21 @@ const (
 
 // Memory compatibility tag values
 const (
+	TagCompatibilityMemory3K      TagValue = "memory:3k"
+	TagCompatibilityMemory4K      TagValue = "memory:4k"
+	TagCompatibilityMemory8K      TagValue = "memory:8k"
 	TagCompatibilityMemory16K     TagValue = "memory:16k"
+	TagCompatibilityMemory19K     TagValue = "memory:19k"
+	TagCompatibilityMemory64K     TagValue = "memory:64k"
 	TagCompatibilityMemory128K    TagValue = "memory:128k"
 	TagCompatibilityMemory48K128K TagValue = "memory:48k-128k"
+	TagCompatibilityLoadA000      TagValue = "load:a000"  // VIC-20 8K block at $A000
+	TagCompatibilityBasic         TagValue = "basic"      // Requires a BASIC interpreter
+	TagCompatibilityPascal        TagValue = "pascal"     // Requires UCSD/Apple Pascal
+	TagCompatibilityCPM           TagValue = "os:cpm"     // Requires CP/M
+	TagCompatibilityRDOS          TagValue = "os:rdos"    // Atari RDOS
+	TagCompatibilityOSB           TagValue = "os:os-b"    // Atari OS-B
+	TagCompatibilitySedoric       TagValue = "os:sedoric" // Oric Sedoric DOS
 )
 
 // Property tag values — referenced by scrapers for static content properties.

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -97,6 +97,8 @@ const (
 	TagTypeEmbedded      TagType = "embedded"      // Embedded chips and internal hardware
 	TagTypeSave          TagType = "save"          // Save mechanism
 	TagTypeArcadeBoard   TagType = "arcadeboard"   // Arcade board types
+	TagTypeCabinet       TagType = "cabinet"       // Arcade cabinet orientation
+	TagTypeProtection    TagType = "protection"    // Arcade copy-protection state
 	TagTypeCompatibility TagType = "compatibility" // System compatibility tags
 	TagTypeSupplement    TagType = "supplement"    // Supplementary content (dlc, update, expansion, theme, avatar)
 	TagTypeDistribution  TagType = "distribution"  // Digital distribution platform (virtual-console, wiiware, xblig)
@@ -439,6 +441,17 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagSavePassword, // Password-based progression (no save memory)
 	},
 
+	TagTypeCabinet: {
+		// Arcade cabinet orientation
+		TagCabinetUpright, TagCabinetCocktail, TagCabinetCabaret, TagCabinetSitdown,
+	},
+
+	TagTypeProtection: {
+		// Arcade copy-protection state (chip family only)
+		TagProtectionNone, TagProtectionFD1094, TagProtectionFD1089, TagProtection8751,
+		TagProtectionMC8123, TagProtectionEncrypted, TagProtectionDecrypted,
+	},
+
 	TagTypeArcadeBoard: {
 		// Arcade system boards - specific hardware platforms for arcade games
 		// CAPCOM
@@ -544,7 +557,11 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		// Apple II
 		TagCompatibilityApple2Plus, TagCompatibilityApple2E,
 		// Memory requirements
-		TagCompatibilityMemory16K, TagCompatibilityMemory128K, TagCompatibilityMemory48K128K,
+		TagCompatibilityMemory3K, TagCompatibilityMemory4K, TagCompatibilityMemory8K,
+		TagCompatibilityMemory16K, TagCompatibilityMemory19K, TagCompatibilityMemory64K,
+		TagCompatibilityMemory128K, TagCompatibilityMemory48K128K,
+		TagCompatibilityLoadA000, TagCompatibilityBasic, TagCompatibilityPascal,
+		TagCompatibilityCPM, TagCompatibilityRDOS, TagCompatibilityOSB, TagCompatibilitySedoric,
 		// Other
 		TagCompatibilityIBMPCDoctorPCJr, TagCompatibilityOsbourneOsbourne1,
 		TagCompatibilityMiscOrch80, TagCompatibilityMiscPiano90,
@@ -562,7 +579,7 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagDistributionGameCube, TagDistributionSwitchOnline, TagDistributionDiskWriter, TagDistributionSteam,
 		TagDistributionSegaChannel, TagDistributionGenesisMini, TagDistributionSegaAges, TagDistributionSegaSmashPack,
 		TagDistributionWii, TagDistributionClubNintendo, TagDistributionGBAEReader,
-		TagDistributionCompilation,
+		TagDistributionCompilation, TagDistributionTypeIn,
 	},
 	TagTypeDisc: {
 		// Disc number for multi-disc games (which disc this file is)
@@ -852,7 +869,7 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagDumpVerified,   // Verified good dump
 		// Dump variants
 		TagDumpPending, TagDumpChecksumBad, TagDumpChecksumUnknown, TagDumpBIOS,
-		TagDumpHackedFFE, TagDumpHackedIntroRemov,
+		TagDumpHackedFFE, TagDumpHackedIntroRemov, TagDumpNoBoot,
 	},
 
 	TagTypeMedia: {
@@ -869,6 +886,12 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagMediaTape,  // Cassette tape
 		// Additional media types
 		TagMediaCart, TagMediaN64DD, TagMediaFDS, TagMediaEReader, TagMediaMultiboot,
+		TagMediaKFile, TagMediaLNX,
+	},
+
+	TagTypeTrack: {
+		// Music track numbers — values are open-ended (track:1, track:2, …) and created
+		// dynamically at index time, so no fixed values are enumerated here.
 	},
 
 	TagTypeExtension: {

--- a/pkg/database/tags/tagtypes.go
+++ b/pkg/database/tags/tagtypes.go
@@ -41,6 +41,7 @@ var CanonicalIsExclusive = map[TagType]bool{
 	TagTypeExtension:   true,
 	TagTypeMedia:       true,
 	TagTypeArcadeBoard: true,
+	TagTypeProtection:  true, // one copy-protection state per romset (cabinet stays additive)
 
 	// Sequential ordering types
 	TagTypeSeason:  true,


### PR DESCRIPTION
- Same-name media (e.g. three identical "Jackal" or "Finalizer" arcade entries) rendered without any distinguishing tags because their filename tokens were unparsed or ineligible for disambiguation; this maps every distinguishing token to a correctly-typed known tag (arcade boards, input devices, memory/compatibility, dump flags, protection chips, cabinet orientation, build dates, and more).
- Adds two tag types: cabinet (upright/cocktail/cabaret/sitdown) and protection (fd1094/fd1089/8751/mc-8123/encrypted/decrypted).
- Recomputes DisambiguationTypes over the full allowlist of eligible tag types so both value differences and presence/absence across siblings qualify, and rewrites the recompute as a single-pass set-based update (reset then set-qualifying via CTEs), parity-verified against the prior correlated-subquery form with added benchmark coverage.
- Resolves companion gamelist slug conflicts by selecting the name-consistent parent, fixing Phantasy Star IV showing Phantasy Star III metadata.
- Maps the spelled-out "(System 16C version)" arcade board id that was previously dropped as version noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded filename and metadata parsing for arcade, music, and archive formats, including cabinet orientation, protection states, input controls, track numbers, TOSEC-style dump flags, a new `YYYY-MM` build-date shape, and additional compatibility/distribution aliases.
  * Added smarter companion entry conflict resolution to route duplicate child slugs to the most consistent parent.
* **Bug Fixes**
  * Improved system title disambiguation recomputation, including clearing stale results and updating which tag types qualify and their ordering.
  * Prevented an extra indexing status update after cancellation.
  * Ensured dynamically generated `track:*` tags (including `track:`-prefixed filename tags) are correctly persisted after indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->