### PR TITLE
fix(readers): stabilize optical disc identity

### DIFF
--- a/pkg/readers/opticaldrive/disc_reader_linux.go
+++ b/pkg/readers/opticaldrive/disc_reader_linux.go
@@ -23,6 +23,7 @@ package opticaldrive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -30,7 +31,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const discReadRetryDelay = 10 * time.Millisecond
+var (
+	discReadRetryDelay = 10 * time.Millisecond
+	unixPread          = unix.Pread
+	unixClose          = unix.Close
+)
 
 type unixDiscDeviceReader struct {
 	fd int
@@ -53,7 +58,7 @@ func (r *unixDiscDeviceReader) ReadAtContext(ctx context.Context, p []byte, off 
 		default:
 		}
 
-		n, err := unix.Pread(r.fd, p[total:], off+int64(total))
+		n, err := unixPread(r.fd, p[total:], off+int64(total))
 		if n > 0 {
 			total += n
 		}
@@ -63,7 +68,7 @@ func (r *unixDiscDeviceReader) ReadAtContext(ctx context.Context, p []byte, off 
 			}
 			continue
 		}
-		if err == unix.EAGAIN || err == unix.EWOULDBLOCK || err == unix.EINTR {
+		if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EINTR) {
 			if waitDiscReadRetry(ctx) != nil {
 				return total, fmt.Errorf("wait for optical device read: %w", ctx.Err())
 			}
@@ -75,7 +80,7 @@ func (r *unixDiscDeviceReader) ReadAtContext(ctx context.Context, p []byte, off 
 }
 
 func (r *unixDiscDeviceReader) Close() error {
-	if err := unix.Close(r.fd); err != nil {
+	if err := unixClose(r.fd); err != nil {
 		return fmt.Errorf("close optical device: %w", err)
 	}
 	return nil

--- a/pkg/readers/opticaldrive/disc_reader_linux.go
+++ b/pkg/readers/opticaldrive/disc_reader_linux.go
@@ -1,0 +1,93 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package opticaldrive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const discReadRetryDelay = 10 * time.Millisecond
+
+type unixDiscDeviceReader struct {
+	fd int
+}
+
+func openDiscDevice(devicePath string) (contextReaderAtCloser, error) {
+	fd, err := unix.Open(devicePath, unix.O_RDONLY|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open optical device: %w", err)
+	}
+	return &unixDiscDeviceReader{fd: fd}, nil
+}
+
+func (r *unixDiscDeviceReader) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
+	total := 0
+	for total < len(p) {
+		select {
+		case <-ctx.Done():
+			return total, ctx.Err()
+		default:
+		}
+
+		n, err := unix.Pread(r.fd, p[total:], off+int64(total))
+		if n > 0 {
+			total += n
+		}
+		if err == nil {
+			if n == 0 {
+				return total, io.EOF
+			}
+			continue
+		}
+		if err == unix.EAGAIN || err == unix.EWOULDBLOCK || err == unix.EINTR {
+			if waitDiscReadRetry(ctx) != nil {
+				return total, fmt.Errorf("wait for optical device read: %w", ctx.Err())
+			}
+			continue
+		}
+		return total, fmt.Errorf("read optical device: %w", err)
+	}
+	return total, nil
+}
+
+func (r *unixDiscDeviceReader) Close() error {
+	if err := unix.Close(r.fd); err != nil {
+		return fmt.Errorf("close optical device: %w", err)
+	}
+	return nil
+}
+
+func waitDiscReadRetry(ctx context.Context) error {
+	timer := time.NewTimer(discReadRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/readers/opticaldrive/disc_reader_other.go
+++ b/pkg/readers/opticaldrive/disc_reader_other.go
@@ -1,0 +1,28 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package opticaldrive
+
+import "errors"
+
+func openDiscDevice(_ string) (contextReaderAtCloser, error) {
+	return nil, errors.New("optical disc identity probing is not implemented on this platform")
+}

--- a/pkg/readers/opticaldrive/iso9660_identity.go
+++ b/pkg/readers/opticaldrive/iso9660_identity.go
@@ -20,6 +20,7 @@
 package opticaldrive
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -49,12 +50,44 @@ type discIdentity struct {
 	Label string
 }
 
+type contextReaderAt interface {
+	ReadAtContext(context.Context, []byte, int64) (int, error)
+}
+
+type readerAtContextAdapter struct {
+	reader io.ReaderAt
+}
+
+func (r readerAtContextAdapter) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+	n, err := r.reader.ReadAt(p, off)
+	if err != nil {
+		return n, fmt.Errorf("read at: %w", err)
+	}
+	return n, nil
+}
+
 func readISO9660Identity(r io.ReaderAt) (discIdentity, bool, error) {
+	return readISO9660IdentityContext(context.Background(), readerAtContextAdapter{reader: r})
+}
+
+func readISO9660IdentityContext(ctx context.Context, r contextReaderAt) (discIdentity, bool, error) {
 	buf := make([]byte, iso9660DescriptorSize)
 	for i := range iso9660MaxDescriptors {
 		offset := int64(iso9660SuperblockOffset + i*iso9660SectorSize)
-		if _, err := r.ReadAt(buf, offset); err != nil {
+		n, err := r.ReadAtContext(ctx, buf, offset)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				return discIdentity{}, false, nil
+			}
 			return discIdentity{}, false, fmt.Errorf("read iso9660 descriptor: %w", err)
+		}
+		if n < len(buf) {
+			return discIdentity{}, false, nil
 		}
 
 		if string(buf[1:6]) != "CD001" {

--- a/pkg/readers/opticaldrive/iso9660_identity.go
+++ b/pkg/readers/opticaldrive/iso9660_identity.go
@@ -54,27 +54,6 @@ type contextReaderAt interface {
 	ReadAtContext(context.Context, []byte, int64) (int, error)
 }
 
-type readerAtContextAdapter struct {
-	reader io.ReaderAt
-}
-
-func (r readerAtContextAdapter) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
-	select {
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	default:
-	}
-	n, err := r.reader.ReadAt(p, off)
-	if err != nil {
-		return n, fmt.Errorf("read at: %w", err)
-	}
-	return n, nil
-}
-
-func readISO9660Identity(r io.ReaderAt) (discIdentity, bool, error) {
-	return readISO9660IdentityContext(context.Background(), readerAtContextAdapter{reader: r})
-}
-
 func readISO9660IdentityContext(ctx context.Context, r contextReaderAt) (discIdentity, bool, error) {
 	buf := make([]byte, iso9660DescriptorSize)
 	for i := range iso9660MaxDescriptors {

--- a/pkg/readers/opticaldrive/iso9660_identity.go
+++ b/pkg/readers/opticaldrive/iso9660_identity.go
@@ -1,0 +1,109 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package opticaldrive
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	iso9660SectorSize       = 0x800
+	iso9660SuperblockOffset = 0x8000
+	iso9660MaxDescriptors   = 16
+	iso9660DescriptorSize   = iso9660SectorSize
+
+	iso9660DescriptorTypePrimary = 0x01
+	iso9660DescriptorTypeEnd     = 0xff
+
+	iso9660VolumeIDOffset = 40
+	iso9660VolumeIDSize   = 32
+	iso9660CreatedOffset  = 813
+	iso9660ModifiedOffset = 830
+	iso9660DateSize       = 17
+)
+
+var errISO9660IdentityNotFound = errors.New("iso9660 identity not found")
+
+type discIdentity struct {
+	UUID  string
+	Label string
+}
+
+func readISO9660Identity(r io.ReaderAt) (discIdentity, bool, error) {
+	buf := make([]byte, iso9660DescriptorSize)
+	for i := range iso9660MaxDescriptors {
+		offset := int64(iso9660SuperblockOffset + i*iso9660SectorSize)
+		if _, err := r.ReadAt(buf, offset); err != nil {
+			return discIdentity{}, false, fmt.Errorf("read iso9660 descriptor: %w", err)
+		}
+
+		if string(buf[1:6]) != "CD001" {
+			continue
+		}
+		if buf[0] == iso9660DescriptorTypeEnd {
+			break
+		}
+		if buf[0] != iso9660DescriptorTypePrimary {
+			continue
+		}
+
+		label := trimISO9660String(buf[iso9660VolumeIDOffset : iso9660VolumeIDOffset+iso9660VolumeIDSize])
+		uuid := iso9660DateUUID(buf[iso9660ModifiedOffset : iso9660ModifiedOffset+iso9660DateSize])
+		if uuid == "" {
+			uuid = iso9660DateUUID(buf[iso9660CreatedOffset : iso9660CreatedOffset+iso9660DateSize])
+		}
+		return discIdentity{UUID: uuid, Label: label}, true, nil
+	}
+	return discIdentity{}, false, nil
+}
+
+func trimISO9660String(raw []byte) string {
+	return strings.TrimRight(string(raw), " \x00")
+}
+
+func iso9660DateUUID(raw []byte) string {
+	if len(raw) < iso9660DateSize {
+		return ""
+	}
+
+	zeros := 0
+	for _, b := range raw[:16] {
+		if b == '0' {
+			zeros++
+		}
+	}
+	if zeros == 16 && raw[16] == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"%c%c%c%c-%c%c-%c%c-%c%c-%c%c-%c%c-%c%c",
+		raw[0], raw[1], raw[2], raw[3],
+		raw[4], raw[5],
+		raw[6], raw[7],
+		raw[8], raw[9],
+		raw[10], raw[11],
+		raw[12], raw[13],
+		raw[14], raw[15],
+	)
+}

--- a/pkg/readers/opticaldrive/opticaldrive.go
+++ b/pkg/readers/opticaldrive/opticaldrive.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -55,9 +54,8 @@ type FSChecker interface {
 	ReadDir(path string) ([]os.DirEntry, error)
 }
 
-// CommandRunner runs external commands.
-type CommandRunner interface {
-	RunBlkid(ctx context.Context, valueType, devicePath string) ([]byte, error)
+type discIdentifier interface {
+	Identify(ctx context.Context, devicePath string) (discIdentity, error)
 }
 
 // DefaultFSChecker uses os.Stat for filesystem checks.
@@ -79,21 +77,45 @@ func (DefaultFSChecker) ReadDir(path string) ([]os.DirEntry, error) {
 	return entries, nil
 }
 
-// DefaultCommandRunner runs real blkid commands.
-type DefaultCommandRunner struct{}
+type defaultDiscIdentifier struct{}
 
-func (DefaultCommandRunner) RunBlkid(ctx context.Context, valueType, devicePath string) ([]byte, error) {
-	//nolint:gosec // G204: valueType and devicePath from OS, blkid reader's purpose
-	out, err := exec.CommandContext(ctx, "blkid", "-o", "value", "-s", valueType, devicePath).Output()
+func (defaultDiscIdentifier) Identify(ctx context.Context, devicePath string) (discIdentity, error) {
+	//nolint:gosec // Safe: devicePath is validated as an absolute /dev path before this call.
+	file, err := os.Open(devicePath)
 	if err != nil {
-		return nil, fmt.Errorf("blkid command failed: %w", err)
+		return discIdentity{}, fmt.Errorf("open optical device: %w", err)
 	}
-	return out, nil
+	defer func() {
+		_ = file.Close()
+	}()
+
+	doneCh := make(chan struct{}, 1)
+	var identity discIdentity
+	var found bool
+	var readErr error
+	go func() {
+		identity, found, readErr = readISO9660Identity(file)
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = file.Close()
+		return discIdentity{}, fmt.Errorf("identify optical media: %w", ctx.Err())
+	case <-doneCh:
+		if readErr != nil {
+			return discIdentity{}, readErr
+		}
+		if !found {
+			return discIdentity{}, errISO9660IdentityNotFound
+		}
+		return identity, nil
+	}
 }
 
 type FileReader struct {
 	fsChecker         FSChecker
-	commandRunner     CommandRunner
+	discIdentifier    discIdentifier
 	gameIDProbe       func(path string) []readers.ScanProperty
 	cfg               *config.Instance
 	device            config.ReadersConnect
@@ -117,7 +139,7 @@ func NewReaderWithDefaults(cfg *config.Instance, defaultEnabled, defaultAutoDete
 		defaultEnabled:    defaultEnabled,
 		defaultAutoDetect: defaultAutoDetect,
 		fsChecker:         DefaultFSChecker{},
-		commandRunner:     DefaultCommandRunner{},
+		discIdentifier:    defaultDiscIdentifier{},
 		gameIDProbe:       identifyGameIDProperties,
 		sysBlockPath:      filepath.Join(string(filepath.Separator), "sys", "block"),
 		devPath:           filepath.Join(string(filepath.Separator), "dev"),
@@ -135,6 +157,37 @@ func (r *FileReader) Metadata() readers.DriverMetadata {
 
 func (*FileReader) IDs() []string {
 	return []string{"opticaldrive", "optical_drive"}
+}
+
+func resolveTokenID(uuid, label, idSource string) string {
+	switch idSource {
+	case IDSourceUUID:
+		return uuid
+	case IDSourceLabel:
+		return label
+	case IDSourceMerged:
+		if uuid == "" || label == "" {
+			return ""
+		}
+		return uuid + MergedIDSeparator + label
+	default:
+		if uuid == "" || label == "" {
+			return ""
+		}
+		return uuid + MergedIDSeparator + label
+	}
+}
+
+func scanPropertiesEqual(a, b []readers.ScanProperty) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *FileReader) Open(
@@ -168,30 +221,12 @@ func (r *FileReader) Open(
 	r.polling = true
 	r.mu.Unlock()
 
-	getID := func(uuid string, label string) string {
-		if uuid == "" {
-			return label
-		} else if label == "" {
-			return uuid
-		}
-
-		switch r.device.IDSource {
-		case IDSourceUUID:
-			return uuid
-		case IDSourceLabel:
-			return label
-		case IDSourceMerged:
-			return uuid + MergedIDSeparator + label
-		default:
-			return uuid + MergedIDSeparator + label
-		}
-	}
-
 	r.wg.Add(1)
 	go func() {
 		defer r.wg.Done()
 		var token *tokens.Token
-		var lastUUID, lastLabel, lastUUIDErr, lastLabelErr string
+		var tokenProperties []readers.ScanProperty
+		var lastUUID, lastLabel, lastIdentityErr string
 		hasProbed := false
 
 		for {
@@ -226,45 +261,43 @@ func (r *FileReader) Open(
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			rawUUID, uuidErr := r.commandRunner.RunBlkid(ctx, "UUID", r.path)
+			identity, identityErr := r.discIdentifier.Identify(ctx, r.path)
 			cancel()
 
-			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-			rawLabel, labelErr := r.commandRunner.RunBlkid(ctx, "LABEL", r.path)
-			cancel()
+			uuid := strings.TrimSpace(identity.UUID)
+			label := strings.TrimSpace(identity.Label)
+			identityErrStr := errString(identityErr)
 
-			uuid := strings.TrimSpace(string(rawUUID))
-			label := strings.TrimSpace(string(rawLabel))
-			uuidErrStr, labelErrStr := errString(uuidErr), errString(labelErr)
-
-			probeChanged := !hasProbed || uuid != lastUUID || label != lastLabel ||
-				uuidErrStr != lastUUIDErr || labelErrStr != lastLabelErr
-			lastUUID, lastLabel, lastUUIDErr, lastLabelErr = uuid, label, uuidErrStr, labelErrStr
+			probeChanged := !hasProbed || uuid != lastUUID || label != lastLabel || identityErrStr != lastIdentityErr
+			lastUUID, lastLabel, lastIdentityErr = uuid, label, identityErrStr
 			hasProbed = true
 			if !probeChanged {
 				continue
 			}
 
-			id := getID(uuid, label)
+			id := resolveTokenID(uuid, label, r.device.IDSource)
 			scanProperties := r.gameIDProbe(r.path)
 			log.Debug().
 				Str("path", r.path).
 				Str("uuid", uuid).
 				Str("label", label).
-				Str("uuidErr", uuidErrStr).
-				Str("labelErr", labelErrStr).
+				Str("identityErr", identityErrStr).
 				Int("properties", len(scanProperties)).
 				Msg("optical media identification probe changed")
-			if id == "" && len(scanProperties) > 0 {
-				id = "gameid/" + scanProperties[0].System + "/" + scanProperties[0].Value
+
+			if token != nil && len(scanProperties) > 0 && scanPropertiesEqual(scanProperties, tokenProperties) {
+				if id == "" || token.UID == "" || token.UID == id {
+					continue
+				}
 			}
 
-			if id == "" {
+			if id == "" && len(scanProperties) == 0 {
 				if token != nil {
 					log.Debug().
-						Err(errors.Join(uuidErr, labelErr)).
+						Err(identityErr).
 						Msg("error identifying optical media, removing token")
 					token = nil
+					tokenProperties = nil
 					iq <- readers.Scan{
 						Source: tokens.SourceReader,
 						Token:  nil,
@@ -273,7 +306,7 @@ func (r *FileReader) Open(
 				continue
 			}
 
-			if token != nil && token.UID == id {
+			if token != nil && token.UID == id && scanPropertiesEqual(scanProperties, tokenProperties) {
 				continue
 			}
 
@@ -284,6 +317,7 @@ func (r *FileReader) Open(
 				Source:   tokens.SourceReader,
 				ReaderID: r.ReaderID(),
 			}
+			tokenProperties = append(tokenProperties[:0], scanProperties...)
 
 			log.Debug().Msgf("new token: %s", token.UID)
 			iq <- readers.Scan{

--- a/pkg/readers/opticaldrive/opticaldrive.go
+++ b/pkg/readers/opticaldrive/opticaldrive.go
@@ -77,40 +77,32 @@ func (DefaultFSChecker) ReadDir(path string) ([]os.DirEntry, error) {
 	return entries, nil
 }
 
+type contextReaderAtCloser interface {
+	contextReaderAt
+	Close() error
+}
+
 type defaultDiscIdentifier struct{}
 
+var openDiscDeviceReader = openDiscDevice
+
 func (defaultDiscIdentifier) Identify(ctx context.Context, devicePath string) (discIdentity, error) {
-	//nolint:gosec // Safe: devicePath is validated as an absolute /dev path before this call.
-	file, err := os.Open(devicePath)
+	reader, err := openDiscDeviceReader(devicePath)
 	if err != nil {
-		return discIdentity{}, fmt.Errorf("open optical device: %w", err)
+		return discIdentity{}, err
 	}
 	defer func() {
-		_ = file.Close()
+		_ = reader.Close()
 	}()
 
-	doneCh := make(chan struct{}, 1)
-	var identity discIdentity
-	var found bool
-	var readErr error
-	go func() {
-		identity, found, readErr = readISO9660Identity(file)
-		doneCh <- struct{}{}
-	}()
-
-	select {
-	case <-ctx.Done():
-		_ = file.Close()
-		return discIdentity{}, fmt.Errorf("identify optical media: %w", ctx.Err())
-	case <-doneCh:
-		if readErr != nil {
-			return discIdentity{}, readErr
-		}
-		if !found {
-			return discIdentity{}, errISO9660IdentityNotFound
-		}
-		return identity, nil
+	identity, found, err := readISO9660IdentityContext(ctx, reader)
+	if err != nil {
+		return discIdentity{}, err
 	}
+	if !found {
+		return discIdentity{}, errISO9660IdentityNotFound
+	}
+	return identity, nil
 }
 
 type FileReader struct {

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -306,6 +307,16 @@ func TestReadISO9660Identity_NotFound(t *testing.T) {
 	assert.Empty(t, identity)
 }
 
+func TestReadISO9660Identity_ShortReadIsMiss(t *testing.T) {
+	t.Parallel()
+
+	identity, found, err := readISO9660Identity(bytes.NewReader(make([]byte, iso9660SuperblockOffset+1)))
+
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, identity)
+}
+
 func newTestISO9660Image(label, modified, created string) []byte {
 	image := make([]byte, iso9660SuperblockOffset+iso9660SectorSize)
 	desc := image[iso9660SuperblockOffset:]
@@ -371,10 +382,50 @@ func (m *mockDiscIdentifier) Identify(ctx context.Context, devicePath string) (d
 	return discIdentity{}, nil
 }
 
+type blockingContextReader struct {
+	closed atomic.Bool
+	reads  atomic.Int32
+}
+
+func (r *blockingContextReader) ReadAtContext(ctx context.Context, _ []byte, _ int64) (int, error) {
+	r.reads.Add(1)
+	<-ctx.Done()
+	return 0, ctx.Err()
+}
+
+func (r *blockingContextReader) Close() error {
+	r.closed.Store(true)
+	return nil
+}
+
 func newTestReader(cfg *config.Instance) *FileReader {
 	reader := NewReader(cfg)
 	reader.gameIDProbe = func(string) []readers.ScanProperty { return nil }
 	return reader
+}
+
+func TestDefaultDiscIdentifierIdentify_TimeoutDoesNotLeakGoroutine(t *testing.T) {
+	reader := &blockingContextReader{}
+	oldOpen := openDiscDeviceReader
+	openDiscDeviceReader = func(string) (contextReaderAtCloser, error) {
+		return reader, nil
+	}
+	t.Cleanup(func() {
+		openDiscDeviceReader = oldOpen
+	})
+
+	before := runtime.NumGoroutine()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := defaultDiscIdentifier{}.Identify(ctx, "/dev/sr0")
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int32(1), reader.reads.Load())
+	assert.True(t, reader.closed.Load())
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= before+1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestOpen_InvalidPath_NotAbsolute(t *testing.T) {
@@ -516,7 +567,7 @@ func TestOpen_DeviceDisappearsWithActiveToken(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestOpen_BlkidFailsNormalDiscRemoval(t *testing.T) {
+func TestOpen_DiscIdentificationFailsNormalDiscRemoval(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -556,7 +607,7 @@ func TestOpen_BlkidFailsNormalDiscRemoval(t *testing.T) {
 	assert.Equal(t, "test-uuid/test-label", scan1.Token.UID)
 	assert.NotEmpty(t, scan1.Token.ReaderID, "ReaderID must be set on tokens from hardware readers")
 
-	// Second scan: disc removed (blkid fails but device exists)
+	// Second scan: disc removed (identification fails but device exists)
 	// This should be a normal removal, NOT a ReaderError
 	scan2 := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
 	assert.Nil(t, scan2.Token, "token should be nil on disc removal")

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -22,7 +22,9 @@
 package opticaldrive
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -174,7 +176,7 @@ func TestConnected(t *testing.T) {
 	}
 }
 
-func TestGetID(t *testing.T) {
+func TestResolveTokenID(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -185,49 +187,63 @@ func TestGetID(t *testing.T) {
 		expectedID string
 	}{
 		{
-			name:       "only uuid",
+			name:       "uuid source uses uuid",
 			uuid:       "abc123",
-			label:      "",
+			label:      "my-disc",
 			idSource:   IDSourceUUID,
 			expectedID: "abc123",
 		},
 		{
-			name:       "only label",
+			name:       "uuid source requires uuid",
 			uuid:       "",
 			label:      "my-disc",
-			idSource:   IDSourceLabel,
-			expectedID: "my-disc",
-		},
-		{
-			name:       "both uuid and label - uuid source",
-			uuid:       "abc123",
-			label:      "my-disc",
 			idSource:   IDSourceUUID,
-			expectedID: "abc123",
+			expectedID: "",
 		},
 		{
-			name:       "both uuid and label - label source",
+			name:       "label source uses label",
 			uuid:       "abc123",
 			label:      "my-disc",
 			idSource:   IDSourceLabel,
 			expectedID: "my-disc",
 		},
 		{
-			name:       "both uuid and label - merged source",
+			name:       "label source requires label",
+			uuid:       "abc123",
+			label:      "",
+			idSource:   IDSourceLabel,
+			expectedID: "",
+		},
+		{
+			name:       "merged source uses both",
 			uuid:       "abc123",
 			label:      "my-disc",
 			idSource:   IDSourceMerged,
 			expectedID: "abc123/my-disc",
 		},
 		{
-			name:       "both uuid and label - default (merged)",
+			name:       "merged source requires uuid",
+			uuid:       "",
+			label:      "my-disc",
+			idSource:   IDSourceMerged,
+			expectedID: "",
+		},
+		{
+			name:       "merged source requires label",
+			uuid:       "abc123",
+			label:      "",
+			idSource:   IDSourceMerged,
+			expectedID: "",
+		},
+		{
+			name:       "default source is strict merged",
 			uuid:       "abc123",
 			label:      "my-disc",
 			idSource:   "",
 			expectedID: "abc123/my-disc",
 		},
 		{
-			name:       "both uuid and label - unknown source (defaults to merged)",
+			name:       "unknown source is strict merged",
 			uuid:       "abc123",
 			label:      "my-disc",
 			idSource:   "unknown",
@@ -239,33 +255,7 @@ func TestGetID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			reader := &FileReader{
-				device: config.ReadersConnect{
-					IDSource: tt.idSource,
-				},
-			}
-
-			// Create the getID function as it appears in Open()
-			getID := func(uuid string, label string) string {
-				if uuid == "" {
-					return label
-				} else if label == "" {
-					return uuid
-				}
-
-				switch reader.device.IDSource {
-				case IDSourceUUID:
-					return uuid
-				case IDSourceLabel:
-					return label
-				case IDSourceMerged:
-					return uuid + MergedIDSeparator + label
-				default:
-					return uuid + MergedIDSeparator + label
-				}
-			}
-
-			result := getID(tt.uuid, tt.label)
+			result := resolveTokenID(tt.uuid, tt.label, tt.idSource)
 			assert.Equal(t, tt.expectedID, result)
 		})
 	}
@@ -279,6 +269,54 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, "label", IDSourceLabel)
 	assert.Equal(t, "merged", IDSourceMerged)
 	assert.Equal(t, "/", MergedIDSeparator)
+}
+
+func TestReadISO9660Identity(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("SCES-01420", "1998102813221100", "1998010100000000")
+	identity, found, err := readISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "SCES-01420", identity.Label)
+	assert.Equal(t, "1998-10-28-13-22-11-00", identity.UUID)
+}
+
+func TestReadISO9660Identity_FallsBackToCreatedDate(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("SCES-01420", "0000000000000000", "1998010100000000")
+	identity, found, err := readISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "1998-01-01-00-00-00-00", identity.UUID)
+}
+
+func TestReadISO9660Identity_NotFound(t *testing.T) {
+	t.Parallel()
+
+	identity, found, err := readISO9660Identity(
+		bytes.NewReader(make([]byte, iso9660SuperblockOffset+iso9660MaxDescriptors*iso9660SectorSize)),
+	)
+
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, identity)
+}
+
+func newTestISO9660Image(label, modified, created string) []byte {
+	image := make([]byte, iso9660SuperblockOffset+iso9660SectorSize)
+	desc := image[iso9660SuperblockOffset:]
+	desc[0] = iso9660DescriptorTypePrimary
+	copy(desc[1:6], "CD001")
+	desc[6] = 1
+	copy(desc[iso9660VolumeIDOffset:iso9660VolumeIDOffset+iso9660VolumeIDSize], "                                ")
+	copy(desc[iso9660VolumeIDOffset:iso9660VolumeIDOffset+iso9660VolumeIDSize], label)
+	copy(desc[iso9660ModifiedOffset:iso9660ModifiedOffset+16], modified)
+	copy(desc[iso9660CreatedOffset:iso9660CreatedOffset+16], created)
+	return image
 }
 
 type mockFSChecker struct {
@@ -322,16 +360,15 @@ func (*mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (*mockFileInfo) IsDir() bool        { return false }
 func (*mockFileInfo) Sys() any           { return nil }
 
-type mockCommandRunner struct {
-	blkidFunc func(ctx context.Context, valueType, devicePath string) ([]byte, error)
+type mockDiscIdentifier struct {
+	identifyFunc func(ctx context.Context, devicePath string) (discIdentity, error)
 }
 
-func (m *mockCommandRunner) RunBlkid(ctx context.Context, valueType, devicePath string) ([]byte, error) {
-	if m.blkidFunc != nil {
-		return m.blkidFunc(ctx, valueType, devicePath)
+func (m *mockDiscIdentifier) Identify(ctx context.Context, devicePath string) (discIdentity, error) {
+	if m.identifyFunc != nil {
+		return m.identifyFunc(ctx, devicePath)
 	}
-	// Default behavior for mock when no function is set
-	return []byte{}, nil
+	return discIdentity{}, nil
 }
 
 func newTestReader(cfg *config.Instance) *FileReader {
@@ -391,18 +428,15 @@ func TestOpen_SuccessfulDiscDetection(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
-			if valueType == "UUID" {
-				return []byte("abc-123-uuid\n"), nil
-			}
-			return []byte("My Disc\n"), nil
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{UUID: "abc-123-uuid", Label: "My Disc"}, nil
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -445,18 +479,15 @@ func TestOpen_DeviceDisappearsWithActiveToken(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
-			if valueType == "UUID" {
-				return []byte("test-uuid\n"), nil
-			}
-			return []byte("test-label\n"), nil
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{UUID: "test-uuid", Label: "test-label"}, nil
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -496,24 +527,19 @@ func TestOpen_BlkidFailsNormalDiscRemoval(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
 			callCount++
-			// First call: successful detection
-			if callCount == 1 || callCount == 2 {
-				if valueType == "UUID" {
-					return []byte("test-uuid\n"), nil
-				}
-				return []byte("test-label\n"), nil
+			if callCount == 1 {
+				return discIdentity{UUID: "test-uuid", Label: "test-label"}, nil
 			}
-			// Subsequent calls: blkid fails (disc removed normally)
-			return nil, assert.AnError
+			return discIdentity{}, assert.AnError
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -551,24 +577,19 @@ func TestOpen_EmptyUUIDAndLabel_RemovesToken(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
 			callCount++
-			// First poll: return valid UUID/LABEL
-			if callCount == 1 || callCount == 2 {
-				if valueType == "UUID" {
-					return []byte("test-uuid\n"), nil
-				}
-				return []byte("test-label\n"), nil
+			if callCount == 1 {
+				return discIdentity{UUID: "test-uuid", Label: "test-label"}, nil
 			}
-			// Second poll: return empty values
-			return []byte(""), nil
+			return discIdentity{}, nil
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -603,18 +624,15 @@ func TestOpen_IDSourceUUID(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
-			if valueType == "UUID" {
-				return []byte("my-uuid\n"), nil
-			}
-			return []byte("my-label\n"), nil
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{UUID: "my-uuid", Label: "my-label"}, nil
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -645,18 +663,15 @@ func TestOpen_IDSourceLabel(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, valueType string, _ string) ([]byte, error) {
-			if valueType == "UUID" {
-				return []byte("my-uuid\n"), nil
-			}
-			return []byte("my-label\n"), nil
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{UUID: "my-uuid", Label: "my-label"}, nil
 		},
 	}
 
 	reader := newTestReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	scanQueue := testutils.CreateTestScanChannel(t)
 
 	device := config.ReadersConnect{
@@ -752,16 +767,16 @@ func TestOpen_NoRepeatedGameIDProbeForUnchangedUnidentifiedDisc(t *testing.T) {
 		},
 	}
 
-	mockCmd := &mockCommandRunner{
-		blkidFunc: func(_ context.Context, _ string, _ string) ([]byte, error) {
-			return []byte(""), nil
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{}, nil
 		},
 	}
 
 	var probeCount atomic.Int32
 	reader := NewReader(&config.Instance{})
 	reader.fsChecker = mockFS
-	reader.commandRunner = mockCmd
+	reader.discIdentifier = mockIdentifier
 	reader.gameIDProbe = func(_ string) []readers.ScanProperty {
 		probeCount.Add(1)
 		return nil
@@ -781,6 +796,141 @@ func TestOpen_NoRepeatedGameIDProbeForUnchangedUnidentifiedDisc(t *testing.T) {
 
 	assert.Equal(t, int32(1), probeCount.Load(),
 		"gameid probe should only run once for an unchanged, unidentified disc")
+
+	err = reader.Close()
+	require.NoError(t, err)
+}
+
+func TestOpen_GameIDPropertyDoesNotBecomeTokenID(t *testing.T) {
+	t.Parallel()
+
+	mockFS := &mockFSChecker{
+		statFunc: func(_ string) (os.FileInfo, error) {
+			return &mockFileInfo{}, nil
+		},
+	}
+
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{}, errors.New("disc identity unavailable")
+		},
+	}
+
+	reader := NewReader(&config.Instance{})
+	reader.fsChecker = mockFS
+	reader.discIdentifier = mockIdentifier
+	reader.gameIDProbe = func(_ string) []readers.ScanProperty {
+		return []readers.ScanProperty{{System: "PSX", Name: "gameid", Value: "SCES-01420"}}
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	device := config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}
+
+	err := reader.Open(device, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 1500*time.Millisecond)
+	require.NotNil(t, scan.Token)
+	assert.Empty(t, scan.Token.UID)
+	require.Len(t, scan.Properties, 1)
+	assert.Equal(t, "SCES-01420", scan.Properties[0].Value)
+
+	err = reader.Close()
+	require.NoError(t, err)
+}
+
+func TestOpen_GameIDPropertyKeepsInitialTokenIDStable(t *testing.T) {
+	t.Parallel()
+
+	mockFS := &mockFSChecker{
+		statFunc: func(_ string) (os.FileInfo, error) {
+			return &mockFileInfo{}, nil
+		},
+	}
+
+	var callCount atomic.Int32
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			call := callCount.Add(1)
+			if call == 1 {
+				return discIdentity{}, errors.New("disc identity unavailable")
+			}
+			return discIdentity{UUID: "1998-10-28-13-22-11-00", Label: "SCES-01420"}, nil
+		},
+	}
+
+	reader := NewReader(&config.Instance{})
+	reader.fsChecker = mockFS
+	reader.discIdentifier = mockIdentifier
+	reader.gameIDProbe = func(_ string) []readers.ScanProperty {
+		return []readers.ScanProperty{{System: "PSX", Name: "gameid", Value: "SCES-01420"}}
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	device := config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}
+
+	err := reader.Open(device, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 1500*time.Millisecond)
+	require.NotNil(t, scan.Token)
+	assert.Empty(t, scan.Token.UID)
+	require.Len(t, scan.Properties, 1)
+
+	testutils.AssertNoScan(t, scanQueue, 2500*time.Millisecond)
+
+	err = reader.Close()
+	require.NoError(t, err)
+}
+
+func TestOpen_KeepsExistingTokenWhenStableIDTemporarilyUnavailable(t *testing.T) {
+	t.Parallel()
+
+	mockFS := &mockFSChecker{
+		statFunc: func(_ string) (os.FileInfo, error) {
+			return &mockFileInfo{}, nil
+		},
+	}
+
+	var callCount atomic.Int32
+	mockIdentifier := &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			call := callCount.Add(1)
+			if call == 1 {
+				return discIdentity{UUID: "1998-10-28-13-22-11-00", Label: "SCES-01420"}, nil
+			}
+			return discIdentity{}, errors.New("disc identity unavailable")
+		},
+	}
+
+	reader := NewReader(&config.Instance{})
+	reader.fsChecker = mockFS
+	reader.discIdentifier = mockIdentifier
+	reader.gameIDProbe = func(_ string) []readers.ScanProperty {
+		return []readers.ScanProperty{{System: "PSX", Name: "gameid", Value: "SCES-01420"}}
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	device := config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}
+
+	err := reader.Open(device, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 1500*time.Millisecond)
+	require.NotNil(t, scan.Token)
+	assert.Equal(t, "1998-10-28-13-22-11-00/SCES-01420", scan.Token.UID)
+	require.Len(t, scan.Properties, 1)
+
+	testutils.AssertNoScan(t, scanQueue, 2500*time.Millisecond)
 
 	err = reader.Close()
 	require.NoError(t, err)

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -25,6 +25,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"sync/atomic"
@@ -37,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 )
 
 func TestNewReader(t *testing.T) {
@@ -276,7 +279,7 @@ func TestReadISO9660Identity(t *testing.T) {
 	t.Parallel()
 
 	image := newTestISO9660Image("SCES-01420", "1998102813221100", "1998010100000000")
-	identity, found, err := readISO9660Identity(bytes.NewReader(image))
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
 	require.NoError(t, err)
 	require.True(t, found)
@@ -288,7 +291,7 @@ func TestReadISO9660Identity_FallsBackToCreatedDate(t *testing.T) {
 	t.Parallel()
 
 	image := newTestISO9660Image("SCES-01420", "0000000000000000", "1998010100000000")
-	identity, found, err := readISO9660Identity(bytes.NewReader(image))
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
 	require.NoError(t, err)
 	require.True(t, found)
@@ -298,7 +301,7 @@ func TestReadISO9660Identity_FallsBackToCreatedDate(t *testing.T) {
 func TestReadISO9660Identity_NotFound(t *testing.T) {
 	t.Parallel()
 
-	identity, found, err := readISO9660Identity(
+	identity, found, err := readTestISO9660Identity(
 		bytes.NewReader(make([]byte, iso9660SuperblockOffset+iso9660MaxDescriptors*iso9660SectorSize)),
 	)
 
@@ -310,11 +313,32 @@ func TestReadISO9660Identity_NotFound(t *testing.T) {
 func TestReadISO9660Identity_ShortReadIsMiss(t *testing.T) {
 	t.Parallel()
 
-	identity, found, err := readISO9660Identity(bytes.NewReader(make([]byte, iso9660SuperblockOffset+1)))
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(make([]byte, iso9660SuperblockOffset+1)))
 
 	require.NoError(t, err)
 	assert.False(t, found)
 	assert.Empty(t, identity)
+}
+
+type testReaderAtContextAdapter struct {
+	reader *bytes.Reader
+}
+
+func (r testReaderAtContextAdapter) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+	n, err := r.reader.ReadAt(p, off)
+	if err != nil {
+		return n, fmt.Errorf("read test data: %w", err)
+	}
+	return n, nil
+}
+
+func readTestISO9660Identity(reader *bytes.Reader) (discIdentity, bool, error) {
+	return readISO9660IdentityContext(context.Background(), testReaderAtContextAdapter{reader: reader})
 }
 
 func newTestISO9660Image(label, modified, created string) []byte {
@@ -402,6 +426,106 @@ func newTestReader(cfg *config.Instance) *FileReader {
 	reader := NewReader(cfg)
 	reader.gameIDProbe = func(string) []readers.ScanProperty { return nil }
 	return reader
+}
+
+func overrideUnixDiscIO(
+	t *testing.T,
+	pread func(int, []byte, int64) (int, error),
+	closeFn func(int) error,
+) {
+	t.Helper()
+	oldPread := unixPread
+	oldClose := unixClose
+	oldDelay := discReadRetryDelay
+	unixPread = pread
+	unixClose = closeFn
+	discReadRetryDelay = time.Millisecond
+	t.Cleanup(func() {
+		unixPread = oldPread
+		unixClose = oldClose
+		discReadRetryDelay = oldDelay
+	})
+}
+
+func TestUnixDiscDeviceReaderReadAtContext_PartialReads(t *testing.T) {
+	calls := 0
+	offsets := make([]int64, 0, 2)
+	overrideUnixDiscIO(t, func(_ int, p []byte, off int64) (int, error) {
+		calls++
+		offsets = append(offsets, off)
+		if calls == 1 {
+			return copy(p, "ab"), nil
+		}
+		return copy(p, "cd"), nil
+	}, unix.Close)
+
+	buf := make([]byte, 4)
+	n, err := (&unixDiscDeviceReader{fd: -1}).ReadAtContext(context.Background(), buf, 10)
+
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, "abcd", string(buf))
+	assert.Equal(t, []int64{10, 12}, offsets)
+}
+
+func TestUnixDiscDeviceReaderReadAtContext_RetriesTemporaryErrors(t *testing.T) {
+	calls := 0
+	overrideUnixDiscIO(t, func(_ int, p []byte, _ int64) (int, error) {
+		calls++
+		switch calls {
+		case 1:
+			return 0, unix.EAGAIN
+		case 2:
+			return 0, unix.EINTR
+		default:
+			return copy(p, "ok"), nil
+		}
+	}, unix.Close)
+
+	buf := make([]byte, 2)
+	n, err := (&unixDiscDeviceReader{fd: -1}).ReadAtContext(context.Background(), buf, 0)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "ok", string(buf))
+	assert.Equal(t, 3, calls)
+}
+
+func TestUnixDiscDeviceReaderReadAtContext_ZeroReadIsEOF(t *testing.T) {
+	overrideUnixDiscIO(t, func(_ int, _ []byte, _ int64) (int, error) {
+		return 0, nil
+	}, unix.Close)
+
+	n, err := (&unixDiscDeviceReader{fd: -1}).ReadAtContext(context.Background(), make([]byte, 1), 0)
+
+	assert.Equal(t, 0, n)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestUnixDiscDeviceReaderReadAtContext_CancelDuringRetry(t *testing.T) {
+	calls := 0
+	ctx, cancel := context.WithCancel(context.Background())
+	overrideUnixDiscIO(t, func(_ int, _ []byte, _ int64) (int, error) {
+		calls++
+		cancel()
+		return 0, unix.EAGAIN
+	}, unix.Close)
+
+	n, err := (&unixDiscDeviceReader{fd: -1}).ReadAtContext(ctx, make([]byte, 1), 0)
+
+	assert.Equal(t, 0, n)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls)
+}
+
+func TestUnixDiscDeviceReaderClose_ReturnsCloseError(t *testing.T) {
+	overrideUnixDiscIO(t, unix.Pread, func(int) error {
+		return unix.EBADF
+	})
+
+	err := (&unixDiscDeviceReader{fd: -1}).Close()
+
+	require.ErrorIs(t, err, unix.EBADF)
 }
 
 func TestDefaultDiscIdentifierIdentify_TimeoutDoesNotLeakGoroutine(t *testing.T) {


### PR DESCRIPTION
Summary
- Replace blkid UUID/LABEL calls with direct ISO9660 PVD identity parsing.
- Keep gameid as scan metadata only, never token UID, while preserving property-based launches.
- Add regressions for stable optical token IDs and ISO9660 parsing.

Verified
- go test ./pkg/readers/opticaldrive/ ./pkg/service/
- golangci-lint run pkg/readers/opticaldrive/ pkg/service/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved optical disc detection by reading ISO9660 volume information directly from the disc to generate a stable UUID and clean label.
  * Added a Linux-only disc device reader with context-aware timeouts and safe cancellation.

* **Bug Fixes**
  * Reduced token churn by updating tokens only when scan properties truly change.
  * Kept existing token IDs stable when disc identity is temporarily unavailable; avoided deriving token IDs from game-derived data when ISO identity can’t be read.
  * More robust handling of missing/short reads and accurate cleanup of label formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->