### PR TITLE
fix(database): only cap stalled media index resumes

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -879,6 +879,8 @@ type MediaDBI interface {
 	GetIndexResumeAttempts() (int, error)
 	IncrementIndexResumeAttempts() (int, error)
 	ResetIndexResumeAttempts() error
+	GetIndexResumeCheckpoint() (string, error)
+	SetIndexResumeCheckpoint(checkpoint string) error
 	SetScrapingStatus(status string) error
 	GetScrapingStatus() (string, error)
 	SetScrapingOperation(operation ScrapingOperation) error

--- a/pkg/database/mediadb/index_resume_attempts_test.go
+++ b/pkg/database/mediadb/index_resume_attempts_test.go
@@ -27,18 +27,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestMediaDB_IndexResumeAttempts_RoundTrip exercises the persisted resume-attempt
-// counter that bounds automatic reindex resumes: a missing key reads as zero,
-// Increment returns and persists successive values, and Reset clears it.
+// TestMediaDB_IndexResumeAttempts_RoundTrip exercises the persisted no-progress
+// resume counter and checkpoint: missing keys read as zero/empty, Increment
+// persists successive values, checkpoint round-trips, and Reset clears both.
 func TestMediaDB_IndexResumeAttempts_RoundTrip(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 
-	// A fresh DB has no stored counter; it must default to zero rather than error.
+	// A fresh DB has no stored counter/checkpoint; both must default rather than error.
 	attempts, err := mediaDB.GetIndexResumeAttempts()
 	require.NoError(t, err)
 	assert.Equal(t, 0, attempts, "unset counter defaults to zero")
+	checkpoint, err := mediaDB.GetIndexResumeCheckpoint()
+	require.NoError(t, err)
+	assert.Empty(t, checkpoint, "unset checkpoint defaults to empty")
 
 	// Each increment returns the new value and persists it.
 	next, err := mediaDB.IncrementIndexResumeAttempts()
@@ -53,11 +56,20 @@ func TestMediaDB_IndexResumeAttempts_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, got, "incremented value survives a re-read")
 
-	// Reset returns the counter to zero.
+	// The durable progress checkpoint round-trips beside the counter.
+	require.NoError(t, mediaDB.SetIndexResumeCheckpoint("last_indexed_system=NES"))
+	checkpoint, err = mediaDB.GetIndexResumeCheckpoint()
+	require.NoError(t, err)
+	assert.Equal(t, "last_indexed_system=NES", checkpoint)
+
+	// Reset returns the counter to zero and clears the checkpoint.
 	require.NoError(t, mediaDB.ResetIndexResumeAttempts())
 	got, err = mediaDB.GetIndexResumeAttempts()
 	require.NoError(t, err)
 	assert.Equal(t, 0, got, "reset clears the counter")
+	checkpoint, err = mediaDB.GetIndexResumeCheckpoint()
+	require.NoError(t, err)
+	assert.Empty(t, checkpoint, "reset clears the checkpoint")
 
 	// Incrementing after a reset starts from one again, giving a future
 	// interruption a fresh resume budget.

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -742,13 +742,11 @@ func (db *MediaDB) IncrementIndexResumeAttempts() (int, error) {
 func (db *MediaDB) ResetIndexResumeAttempts() error {
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()
-	if db.sql.Load() == nil {
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
 		return ErrNullSQL
 	}
-	if err := sqlSetIndexResumeAttempts(db.ctx, db.conn(), 0); err != nil {
-		return err
-	}
-	return sqlSetIndexResumeCheckpoint(db.ctx, db.conn(), "")
+	return sqlResetIndexResumeState(db.ctx, sqlDB)
 }
 
 // GetIndexResumeCheckpoint returns the durable indexing checkpoint observed at

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -706,8 +706,8 @@ func (db *MediaDB) GetOptimizationStep() (string, error) {
 }
 
 // GetIndexResumeAttempts returns the number of consecutive automatic resume
-// attempts recorded for an interrupted media index. It resets to zero once
-// indexing reaches a clean (non-interrupted) state.
+// attempts that found no durable indexing progress since the previous resume.
+// It resets to zero once indexing reaches a clean state or the resume checkpoint moves.
 func (db *MediaDB) GetIndexResumeAttempts() (int, error) {
 	db.sqlMu.RLock()
 	defer db.sqlMu.RUnlock()
@@ -717,9 +717,9 @@ func (db *MediaDB) GetIndexResumeAttempts() (int, error) {
 	return sqlGetIndexResumeAttempts(db.ctx, db.sql.Load())
 }
 
-// IncrementIndexResumeAttempts bumps the consecutive resume-attempt counter and
-// returns the new value. It bounds how many times an interrupted index is
-// auto-resumed so a reindex that keeps getting interrupted cannot loop forever.
+// IncrementIndexResumeAttempts bumps the no-progress resume-attempt counter and
+// returns the new value. It bounds repeated resumes only when the durable
+// indexing checkpoint is not moving.
 func (db *MediaDB) IncrementIndexResumeAttempts() (int, error) {
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()
@@ -737,15 +737,40 @@ func (db *MediaDB) IncrementIndexResumeAttempts() (int, error) {
 	return next, nil
 }
 
-// ResetIndexResumeAttempts clears the consecutive resume-attempt counter,
-// giving a future interruption a fresh budget of automatic resumes.
+// ResetIndexResumeAttempts clears the no-progress resume-attempt counter and
+// checkpoint, giving a future interrupted index a fresh stall budget.
 func (db *MediaDB) ResetIndexResumeAttempts() error {
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()
 	if db.sql.Load() == nil {
 		return ErrNullSQL
 	}
-	return sqlSetIndexResumeAttempts(db.ctx, db.conn(), 0)
+	if err := sqlSetIndexResumeAttempts(db.ctx, db.conn(), 0); err != nil {
+		return err
+	}
+	return sqlSetIndexResumeCheckpoint(db.ctx, db.conn(), "")
+}
+
+// GetIndexResumeCheckpoint returns the durable indexing checkpoint observed at
+// the previous auto-resume. A changed checkpoint proves the index made progress.
+func (db *MediaDB) GetIndexResumeCheckpoint() (string, error) {
+	db.sqlMu.RLock()
+	defer db.sqlMu.RUnlock()
+	if db.sql.Load() == nil {
+		return "", ErrNullSQL
+	}
+	return sqlGetIndexResumeCheckpoint(db.ctx, db.sql.Load())
+}
+
+// SetIndexResumeCheckpoint stores the durable indexing checkpoint observed at
+// auto-resume time so the next boot can detect whether progress moved.
+func (db *MediaDB) SetIndexResumeCheckpoint(checkpoint string) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+	if db.sql.Load() == nil {
+		return ErrNullSQL
+	}
+	return sqlSetIndexResumeCheckpoint(db.ctx, db.conn(), checkpoint)
 }
 
 func (db *MediaDB) SetIndexingStatus(status string) error {

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -240,6 +240,31 @@ func sqlGetIndexResumeCheckpoint(ctx context.Context, db sqlQueryable) (string, 
 	return checkpoint, nil
 }
 
+func sqlResetIndexResumeState(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin index resume reset transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := sqlSetIndexResumeAttempts(ctx, tx, 0); err != nil {
+		return err
+	}
+	if err := sqlSetIndexResumeCheckpoint(ctx, tx, ""); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit index resume reset transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
 func sqlSetIndexingStatus(ctx context.Context, db sqlQueryable, status string) error {
 	_, err := db.ExecContext(ctx,
 		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -47,6 +47,7 @@ const (
 	DBConfigTemporaryRepairParentDirVersion = "TemporaryRepairParentDirVersion"
 	DBConfigIndexGeneration                 = "IndexGeneration"
 	DBConfigIndexResumeAttempts             = "IndexResumeAttempts"
+	DBConfigIndexResumeCheckpoint           = "IndexResumeCheckpoint"
 	DBConfigDisambiguationVersion           = "DisambiguationVersion"
 
 	temporaryRepairParentDirVersion = "1"
@@ -211,6 +212,32 @@ func sqlGetIndexResumeAttempts(ctx context.Context, db sqlQueryable) (int, error
 		return 0, fmt.Errorf("failed to parse index resume attempts: %w", err)
 	}
 	return attempts, nil
+}
+
+func sqlSetIndexResumeCheckpoint(ctx context.Context, db sqlQueryable, checkpoint string) error {
+	_, err := db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigIndexResumeCheckpoint,
+		checkpoint,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set index resume checkpoint: %w", err)
+	}
+	return nil
+}
+
+func sqlGetIndexResumeCheckpoint(ctx context.Context, db sqlQueryable) (string, error) {
+	var checkpoint string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigIndexResumeCheckpoint,
+	).Scan(&checkpoint)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	} else if err != nil {
+		return "", fmt.Errorf("failed to get index resume checkpoint: %w", err)
+	}
+	return checkpoint, nil
 }
 
 func sqlSetIndexingStatus(ctx context.Context, db sqlQueryable, status string) error {

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -75,6 +75,47 @@ func TestSqlGetLastGenerated_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlResetIndexResumeState_Success(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigIndexResumeAttempts, "0").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigIndexResumeCheckpoint, "").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err = sqlResetIndexResumeState(context.Background(), db)
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlResetIndexResumeState_CheckpointErrorRollsBack(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigIndexResumeAttempts, "0").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigIndexResumeCheckpoint, "").
+		WillReturnError(sql.ErrConnDone)
+	mock.ExpectRollback()
+
+	err = sqlResetIndexResumeState(context.Background(), db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to set index resume checkpoint")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlFindSystem_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -42,15 +42,51 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// maxIndexResumeAttempts bounds how many consecutive boots will auto-resume an
-// interrupted media index before giving up and leaving the library browsable
-// from cache. A large-library reindex can take hours; without this bound a device
-// that reboots mid-index would relaunch the reindex on every boot forever.
-const maxIndexResumeAttempts = 3
+// maxIndexNoProgressResumeAttempts bounds automatic resumes only when the
+// durable indexing checkpoint stops moving. Normal power-offs during a long
+// background index can resume forever as long as each completed system advances
+// the checkpoint.
+const maxIndexNoProgressResumeAttempts = 5
+
+const indexResumeCheckpointPrefix = "last_indexed_system="
 
 // mediaDBRecovering serializes media database recovery so the startup check and the
 // runtime watcher can never run a close/reopen rebuild concurrently.
 var mediaDBRecovering atomic.Bool
+
+func currentIndexResumeCheckpoint(mediaDB database.MediaDBI) (string, error) {
+	lastIndexedSystem, err := mediaDB.GetLastIndexedSystem()
+	if err != nil {
+		return "", err
+	}
+	return indexResumeCheckpointPrefix + lastIndexedSystem, nil
+}
+
+func recordIndexResumeCheckpoint(mediaDB database.MediaDBI) (int, bool, error) {
+	currentCheckpoint, err := currentIndexResumeCheckpoint(mediaDB)
+	if err != nil {
+		return 0, false, err
+	}
+	previousCheckpoint, err := mediaDB.GetIndexResumeCheckpoint()
+	if err != nil {
+		return 0, false, err
+	}
+	if previousCheckpoint != currentCheckpoint {
+		if resetErr := mediaDB.ResetIndexResumeAttempts(); resetErr != nil {
+			return 0, false, resetErr
+		}
+		if setErr := mediaDB.SetIndexResumeCheckpoint(currentCheckpoint); setErr != nil {
+			return 0, false, setErr
+		}
+		return 0, false, nil
+	}
+
+	attempts, err := mediaDB.IncrementIndexResumeAttempts()
+	if err != nil {
+		return 0, false, err
+	}
+	return attempts, attempts >= maxIndexNoProgressResumeAttempts, nil
+}
 
 // checkAndResumeIndexing checks if media indexing was interrupted and automatically resumes it.
 // It returns true when an index resume was started so callers can defer lower-priority
@@ -80,31 +116,31 @@ func checkAndResumeIndexing(
 		return false
 	}
 
-	// Bound automatic resumes. A full reindex on a large library can take hours;
-	// if the device keeps rebooting mid-index we would otherwise relaunch it every
-	// boot forever, and while indexing is "running" the browse-cache self-heal is
-	// suppressed. After enough consecutive interruptions, stop looping and mark the
-	// index cancelled so the library stays browsable from the (stale) cache instead.
-	attempts, err := db.MediaDB.GetIndexResumeAttempts()
+	// Bound only stalled resumes. A full reindex on a large library can span many
+	// user power cycles; those should resume indefinitely as long as completed
+	// systems move the durable checkpoint. If the same checkpoint is retried too
+	// many times, stop looping and mark the index cancelled so browse-cache repair
+	// and user-initiated indexing can recover.
+	noProgressAttempts, stalled, err := recordIndexResumeCheckpoint(db.MediaDB)
 	if err != nil {
-		// The persisted counter is the only thing bounding automatic resumes. If it
-		// can't be read we cannot prove we're under the limit, so fail closed and skip
-		// resuming rather than risk an unbounded reboot-resume loop; the library stays
-		// browsable from the (stale) cache.
-		log.Warn().Err(err).Msg("failed to read index resume attempt counter; skipping auto-resume")
+		// The persisted checkpoint/counter is the only thing bounding stalled
+		// automatic resumes. If it can't be updated, fail closed and keep cached
+		// library data browsable rather than risk an unbounded resume loop.
+		log.Warn().Err(err).Msg("failed to record index resume checkpoint; skipping auto-resume")
 		return false
 	}
-	if attempts >= maxIndexResumeAttempts {
-		log.Warn().Int("attempts", attempts).
-			Msg("interrupted media indexing exceeded automatic resume limit; leaving library browsable")
+	if stalled {
+		log.Warn().Int("noProgressAttempts", noProgressAttempts).
+			Int("limit", maxIndexNoProgressResumeAttempts).
+			Msg("interrupted media indexing made no durable progress across repeated resumes; leaving library browsable")
 		if setErr := db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusCancelled); setErr != nil {
-			log.Warn().Err(setErr).Msg("failed to mark wedged indexing as cancelled")
+			log.Warn().Err(setErr).Msg("failed to mark stalled indexing as cancelled")
 		}
 		if inbox := st.Inbox(); inbox != nil {
-			if inboxErr := inbox.Add("Media indexing paused after repeated interruptions",
-				inboxservice.WithBody("Media indexing was interrupted several times before it could "+
-					"finish, so it has been paused to keep your library browsable. Start indexing again "+
-					"from Settings when your device can stay on long enough to complete it."),
+			if inboxErr := inbox.Add("Media indexing paused after repeated stalls",
+				inboxservice.WithBody("Media indexing resumed several times without completing another system, "+
+					"so it has been paused to keep your library browsable. Start indexing again from "+
+					"Settings when your device can stay on long enough to make progress."),
 				inboxservice.WithSeverity(inboxservice.SeverityWarning),
 				inboxservice.WithCategory(inboxservice.CategoryMediaIndexResumeLimit),
 			); inboxErr != nil {
@@ -113,16 +149,8 @@ func checkAndResumeIndexing(
 		}
 		return false
 	}
-	newAttempts, incErr := db.MediaDB.IncrementIndexResumeAttempts()
-	if incErr != nil {
-		// A failed increment means the next boot reads the same count and resumes
-		// again — a persistent write failure would loop forever. Fail closed.
-		log.Warn().Err(incErr).Msg("failed to record index resume attempt; skipping auto-resume")
-		return false
-	}
-	attempts = newAttempts
 
-	log.Info().Int("attempt", attempts).Int("limit", maxIndexResumeAttempts).
+	log.Info().Int("noProgressAttempts", noProgressAttempts).Int("limit", maxIndexNoProgressResumeAttempts).
 		Msg("detected interrupted media indexing, automatically resuming")
 
 	// Get the systems that were being indexed from the database

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -24,6 +24,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
@@ -57,33 +58,33 @@ var mediaDBRecovering atomic.Bool
 func currentIndexResumeCheckpoint(mediaDB database.MediaDBI) (string, error) {
 	lastIndexedSystem, err := mediaDB.GetLastIndexedSystem()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get last indexed system: %w", err)
 	}
 	return indexResumeCheckpointPrefix + lastIndexedSystem, nil
 }
 
-func recordIndexResumeCheckpoint(mediaDB database.MediaDBI) (int, bool, error) {
+func recordIndexResumeCheckpoint(mediaDB database.MediaDBI) (attempts int, stalled bool, err error) {
 	currentCheckpoint, err := currentIndexResumeCheckpoint(mediaDB)
 	if err != nil {
 		return 0, false, err
 	}
 	previousCheckpoint, err := mediaDB.GetIndexResumeCheckpoint()
 	if err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("failed to get index resume checkpoint: %w", err)
 	}
 	if previousCheckpoint != currentCheckpoint {
 		if resetErr := mediaDB.ResetIndexResumeAttempts(); resetErr != nil {
-			return 0, false, resetErr
+			return 0, false, fmt.Errorf("failed to reset index resume attempts: %w", resetErr)
 		}
 		if setErr := mediaDB.SetIndexResumeCheckpoint(currentCheckpoint); setErr != nil {
-			return 0, false, setErr
+			return 0, false, fmt.Errorf("failed to set index resume checkpoint: %w", setErr)
 		}
 		return 0, false, nil
 	}
 
-	attempts, err := mediaDB.IncrementIndexResumeAttempts()
+	attempts, err = mediaDB.IncrementIndexResumeAttempts()
 	if err != nil {
-		return 0, false, err
+		return 0, false, fmt.Errorf("failed to increment index resume attempts: %w", err)
 	}
 	return attempts, attempts >= maxIndexNoProgressResumeAttempts, nil
 }
@@ -132,7 +133,7 @@ func checkAndResumeIndexing(
 	if stalled {
 		log.Warn().Int("noProgressAttempts", noProgressAttempts).
 			Int("limit", maxIndexNoProgressResumeAttempts).
-			Msg("interrupted media indexing made no durable progress across repeated resumes; leaving library browsable")
+			Msg("media indexing made no durable progress across repeated resumes; leaving library browsable")
 		if setErr := db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusCancelled); setErr != nil {
 			log.Warn().Err(setErr).Msg("failed to mark stalled indexing as cancelled")
 		}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -840,7 +840,7 @@ func TestCheckAndResumeIndexing_StopsAfterMaxNoProgressResumeAttempts(t *testing
 	require.NoError(t, db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusRunning))
 	require.NoError(t, db.MediaDB.SetLastIndexedSystem("NES"))
 	require.NoError(t, db.MediaDB.SetIndexResumeCheckpoint(indexResumeCheckpointPrefix+"NES"))
-	for i := 0; i < maxIndexNoProgressResumeAttempts-1; i++ {
+	for range maxIndexNoProgressResumeAttempts - 1 {
 		_, incErr := db.MediaDB.IncrementIndexResumeAttempts()
 		require.NoError(t, incErr)
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -814,7 +814,7 @@ func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {
 	mockMediaDB.AssertNotCalled(t, "GetOptimizationStatus")
 }
 
-func TestCheckAndResumeIndexing_StopsAfterMaxResumeAttempts(t *testing.T) {
+func TestCheckAndResumeIndexing_StopsAfterMaxNoProgressResumeAttempts(t *testing.T) {
 	// Note: Not using t.Parallel() due to global statusInstance usage in GenerateMediaDB
 	methods.ClearIndexingStatus()
 
@@ -827,7 +827,7 @@ func TestCheckAndResumeIndexing_StopsAfterMaxResumeAttempts(t *testing.T) {
 	defer cleanup()
 	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
 
-	// Wire an inbox so the resume-limit branch can surface a user-facing message.
+	// Wire an inbox so the stall-limit branch can surface a user-facing message.
 	mockUserDB := testhelpers.NewMockUserDBI()
 	mockUserDB.On("AddInboxMessage", mock.MatchedBy(func(m *database.InboxMessage) bool {
 		return m.Category == inboxservice.CategoryMediaIndexResumeLimit &&
@@ -835,10 +835,12 @@ func TestCheckAndResumeIndexing_StopsAfterMaxResumeAttempts(t *testing.T) {
 	})).Return(&database.InboxMessage{}, nil)
 	st.SetInbox(inboxservice.NewService(mockUserDB, st.Notifications))
 
-	// Simulate a reindex that keeps getting interrupted: status wedged at
-	// "running" with the resume-attempt counter already at the limit.
+	// Simulate a reindex that keeps getting interrupted at the same durable
+	// checkpoint. The next resume attempt reaches the no-progress stall limit.
 	require.NoError(t, db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusRunning))
-	for range maxIndexResumeAttempts {
+	require.NoError(t, db.MediaDB.SetLastIndexedSystem("NES"))
+	require.NoError(t, db.MediaDB.SetIndexResumeCheckpoint(indexResumeCheckpointPrefix+"NES"))
+	for i := 0; i < maxIndexNoProgressResumeAttempts-1; i++ {
 		_, incErr := db.MediaDB.IncrementIndexResumeAttempts()
 		require.NoError(t, incErr)
 	}
@@ -850,10 +852,33 @@ func TestCheckAndResumeIndexing_StopsAfterMaxResumeAttempts(t *testing.T) {
 	status, err := db.MediaDB.GetIndexingStatus()
 	require.NoError(t, err)
 	assert.Equal(t, mediadb.IndexingStatusCancelled, status)
-	assert.False(t, methods.IsIndexing(), "indexing must not be relaunched past the resume limit")
+	assert.False(t, methods.IsIndexing(), "indexing must not be relaunched past the no-progress limit")
 
 	// The user must be told why indexing stopped, via a resume-limit inbox message.
 	mockUserDB.AssertCalled(t, "AddInboxMessage", mock.Anything)
+}
+
+func TestRecordIndexResumeCheckpoint_ProgressMovedResetsAttempts(t *testing.T) {
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	require.NoError(t, db.MediaDB.SetLastIndexedSystem("SNES"))
+	require.NoError(t, db.MediaDB.SetIndexResumeCheckpoint(indexResumeCheckpointPrefix+"NES"))
+	_, incErr := db.MediaDB.IncrementIndexResumeAttempts()
+	require.NoError(t, incErr)
+
+	attempts, stalled, err := recordIndexResumeCheckpoint(db.MediaDB)
+	require.NoError(t, err)
+	assert.False(t, stalled)
+	assert.Equal(t, 0, attempts)
+
+	storedAttempts, err := db.MediaDB.GetIndexResumeAttempts()
+	require.NoError(t, err)
+	assert.Equal(t, 0, storedAttempts)
+
+	checkpoint, err := db.MediaDB.GetIndexResumeCheckpoint()
+	require.NoError(t, err)
+	assert.Equal(t, indexResumeCheckpointPrefix+"SNES", checkpoint)
 }
 
 func TestCheckAndResumeIndexing_ResetsAttemptsOnCleanState(t *testing.T) {
@@ -870,6 +895,7 @@ func TestCheckAndResumeIndexing_ResetsAttemptsOnCleanState(t *testing.T) {
 	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
 
 	require.NoError(t, db.MediaDB.SetIndexingStatus(mediadb.IndexingStatusCompleted))
+	require.NoError(t, db.MediaDB.SetIndexResumeCheckpoint(indexResumeCheckpointPrefix+"NES"))
 	_, incErr := db.MediaDB.IncrementIndexResumeAttempts()
 	require.NoError(t, incErr)
 
@@ -878,6 +904,9 @@ func TestCheckAndResumeIndexing_ResetsAttemptsOnCleanState(t *testing.T) {
 	attempts, err := db.MediaDB.GetIndexResumeAttempts()
 	require.NoError(t, err)
 	assert.Equal(t, 0, attempts, "a clean indexing state must reset the resume-attempt counter")
+	checkpoint, err := db.MediaDB.GetIndexResumeCheckpoint()
+	require.NoError(t, err)
+	assert.Empty(t, checkpoint, "a clean indexing state must clear the resume checkpoint")
 }
 
 func TestCheckAndResumeScraping_StatusErrorDoesNothing(t *testing.T) {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1670,6 +1670,19 @@ func (m *MockMediaDBI) ResetIndexResumeAttempts() error {
 	return nil
 }
 
+func (m *MockMediaDBI) GetIndexResumeCheckpoint() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockMediaDBI) SetIndexResumeCheckpoint(checkpoint string) error {
+	args := m.Called(checkpoint)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockMediaDBI) hasExpectation(method string) bool {
 	for _, call := range m.ExpectedCalls {
 		if call.Method == method {
@@ -2257,6 +2270,8 @@ func NewMockMediaDBI() *MockMediaDBI {
 	mockMediaDB.On("GetIndexResumeAttempts").Return(0, nil).Maybe()
 	mockMediaDB.On("IncrementIndexResumeAttempts").Return(1, nil).Maybe()
 	mockMediaDB.On("ResetIndexResumeAttempts").Return(nil).Maybe()
+	mockMediaDB.On("GetIndexResumeCheckpoint").Return("", nil).Maybe()
+	mockMediaDB.On("SetIndexResumeCheckpoint", mock.Anything).Return(nil).Maybe()
 	mockMediaDB.On("GetDBPath").Return("/tmp/mock-media.db").Maybe()
 	mockMediaDB.On("HasAnyMedia").Return(false, nil).Maybe()
 	mockMediaDB.On("DropSecondaryIndexes").Return(nil).Maybe()


### PR DESCRIPTION
Summary:
- Replace raw media index auto-resume cap with durable checkpoint stall detection
- Persist last resume checkpoint and reset stall count when indexing progress moves
- Keep cached library browsable by cancelling only repeated no-progress resumes

Verified: go test ./pkg/database/mediadb ./pkg/service; task lint-fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable indexing “no-progress” checkpoint tracking to improve detection of stalled progress and govern auto-resume retries.
* **Bug Fixes**
  * Resetting indexing resume state now clears both retry counts and the saved checkpoint.
  * Auto-resume now stops with clearer stall-limit warnings when progress doesn’t advance, and avoids retrying when checkpoint recording fails.
* **Tests**
  * Expanded unit/integration coverage for checkpoint persistence, round-trips, progress-based resets, and the updated no-progress stop conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->