### PR TITLE
fix(zapos): write RetroArch log under the service log dir

### DIFF
--- a/pkg/platforms/zapos/platform.go
+++ b/pkg/platforms/zapos/platform.go
@@ -35,11 +35,10 @@ func NewPlatform() *Platform {
 
 // Settings returns appliance-specific persistent paths.
 func (*Platform) Settings() platforms.Settings {
-	dataDir := userdataPath("data", config.AppName)
 	return platforms.Settings{
 		ConfigDir: userdataPath("config", config.AppName),
-		DataDir:   dataDir,
-		LogDir:    filepath.Join(dataDir, config.LogsDir),
+		DataDir:   userdataPath("data", config.AppName),
+		LogDir:    logDir(),
 		TempDir:   filepath.Join(os.TempDir(), config.AppName),
 	}
 }
@@ -80,15 +79,21 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 func applianceRetroArchOptions() retroarch.Options {
 	pack := userdataPath("runtime", "retroarch")
 	return retroarch.Options{
-		Exec:           []string{filepath.Join(pack, "retroarch")},
-		VTWrap:         []string{"openvt", "-c", "2", "-s", "-w", "--"},
-		CoresDir:       filepath.Join(pack, "cores"),
-		ConfigPath:     filepath.Join(pack, "retroarch.cfg"),
-		LibDir:         filepath.Join(pack, "lib"),
-		Home:           userdataPath("home"),
-		ExtraArgs:      []string{"-v", "--log-file", userdataPath("ra.log")},
+		Exec:       []string{filepath.Join(pack, "retroarch")},
+		VTWrap:     []string{"openvt", "-c", "2", "-s", "-w", "--"},
+		CoresDir:   filepath.Join(pack, "cores"),
+		ConfigPath: filepath.Join(pack, "retroarch.cfg"),
+		LibDir:     filepath.Join(pack, "lib"),
+		Home:       userdataPath("home"),
+		// RetroArch runs as the service user, which cannot create files in the
+		// root-owned /userdata top level; log next to the service's own logs.
+		ExtraArgs:      []string{"-v", "--log-file", filepath.Join(logDir(), "retroarch.log")},
 		NetworkCmdAddr: retroArchNetworkAddr,
 	}
+}
+
+func logDir() string {
+	return filepath.Join(userdataPath("data", config.AppName), config.LogsDir)
 }
 
 func userdataPath(elements ...string) string {

--- a/pkg/platforms/zapos/platform_test.go
+++ b/pkg/platforms/zapos/platform_test.go
@@ -86,7 +86,8 @@ func TestApplianceRetroArchOptions(t *testing.T) {
 	assert.Equal(t, filepath.Join(pack, "retroarch.cfg"), opts.ConfigPath)
 	assert.Equal(t, filepath.Join(pack, "lib"), opts.LibDir)
 	assert.Equal(t, userdataPath("home"), opts.Home)
-	assert.Equal(t, []string{"-v", "--log-file", userdataPath("ra.log")}, opts.ExtraArgs)
+	logPath := filepath.Join(userdataPath("data", "zaparoo"), "logs", "retroarch.log")
+	assert.Equal(t, []string{"-v", "--log-file", logPath}, opts.ExtraArgs)
 	assert.Equal(t, retroArchNetworkAddr, opts.NetworkCmdAddr)
 }
 
@@ -103,7 +104,7 @@ func TestAppliancePSXCommand(t *testing.T) {
 	assert.Equal(t, []string{
 		"-c", "2", "-s", "-w", "--",
 		filepath.Join(pack, "retroarch"),
-		"-v", "--log-file", userdataPath("ra.log"),
+		"-v", "--log-file", filepath.Join(userdataPath("data", "zaparoo"), "logs", "retroarch.log"),
 		"--config", filepath.Join(pack, "retroarch.cfg"),
 		"-L", filepath.Join(pack, "cores", "pcsx_rearmed_libretro.so"),
 		mediaPath,


### PR DESCRIPTION
## Summary
- `--log-file /userdata/ra.log` fails on the appliance: RetroArch runs as the non-root service user and the `/userdata` top level is root-owned (0755), so the file can never be created. The path was carried over from the dev `run-game.sh` loop, which ran as root.
- Move it to the platform's `Settings().LogDir` → `/userdata/data/zaparoo/logs/retroarch.log`, which the OS init already creates/chowns for the service user and the diagnostics bundle already collects. No rotation needed — RetroArch truncates the log per launch.

Validated with `go test ./...` and `golangci-lint run ./...` (0 issues).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RetroArch logging to use the platform’s standard logs directory.
  * Improved consistency of configuration, data, and log directory paths across the platform.
* **Tests**
  * Updated platform checks to verify the corrected RetroArch log file location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->