### PR TITLE
fix(mister): preserve Neo Geo root folder indexing

### DIFF
--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -519,6 +519,103 @@ func TestNeoGeoScanner_AddsNestedRomsetEntries(t *testing.T) {
 	assert.Contains(t, results, platforms.ScanResult{Path: folderPath, Name: "King of Fighters '98", NoExt: true})
 }
 
+func TestNeoGeoScanner_AddsRootRomsetEntries(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	folderPath := filepath.Join(neoGeoPath, "MSLUG")
+	zipPath := filepath.Join(neoGeoPath, "kof98.zip")
+
+	require.NoError(t, os.MkdirAll(folderPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(folderPath, "crom0"), []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(`<?xml version="1.0"?>
+<romsets>
+  <romset name="mslug" altname="Metal Slug"/>
+  <romset name="kof98" altname="King of Fighters '98"/>
+</romsets>
+`), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+	results, err := neoGeoLauncher.Scanner(context.Background(), cfg, "NeoGeo", []platforms.ScanResult{
+		{Path: filepath.Join(folderPath, "crom0")},
+	})
+	require.NoError(t, err)
+
+	assert.NotContains(t, results, platforms.ScanResult{Path: filepath.Join(folderPath, "crom0")})
+	assert.Contains(t, results, platforms.ScanResult{Path: folderPath, Name: "Metal Slug", NoExt: true})
+	assert.Contains(t, results, platforms.ScanResult{Path: zipPath, Name: "King of Fighters '98", NoExt: true})
+}
+
+func TestNeoGeoScanner_AddsRootSymlinkedRomsetFolder(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	targetPath := filepath.Join(root, "romsets", "mslug")
+	linkPath := filepath.Join(neoGeoPath, "mslug")
+	require.NoError(t, os.MkdirAll(targetPath, 0o700))
+	require.NoError(t, os.MkdirAll(neoGeoPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(targetPath, "crom0"), []byte("test"), 0o600))
+	require.NoError(t, os.Symlink(targetPath, linkPath))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(`<?xml version="1.0"?>
+<romsets>
+  <romset name="mslug" altname="Metal Slug"/>
+</romsets>
+`), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+	results, err := neoGeoLauncher.Scanner(context.Background(), cfg, "NeoGeo", nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, results, platforms.ScanResult{Path: linkPath, Name: "Metal Slug", NoExt: true})
+}
+
+func TestNeoGeoScanner_HandlesMalformedRomsets(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	folderPath := filepath.Join(neoGeoPath, "mslug")
+	contentPath := filepath.Join(folderPath, "crom0")
+	require.NoError(t, os.MkdirAll(folderPath, 0o700))
+	require.NoError(t, os.WriteFile(contentPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte("<romsets>"), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+	results, err := neoGeoLauncher.Scanner(context.Background(), cfg, "NeoGeo", []platforms.ScanResult{
+		{Path: contentPath},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []platforms.ScanResult{{Path: contentPath}}, results)
+}
+
 func TestCollectNeoGeoRomsetEntries_DeduplicatesOverlappingRoots(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -866,15 +866,28 @@ func collectNeoGeoRomsetEntries(
 		}
 
 		base := info.Name()
-		if info.IsDir() {
+		isDirectory := info.IsDir()
+		if info.Mode()&os.ModeSymlink != 0 {
+			targetInfo, statErr := fs.Stat(path)
+			isDirectory = statErr == nil && targetInfo.IsDir()
+			log.Debug().Str("path", path).Bool("directory", isDirectory).
+				Msg("neogeo symlink candidate found")
+		}
+		if isDirectory {
 			if base == "__MACOSX" || strings.HasPrefix(base, ".") {
-				return filepath.SkipDir
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 
 			markerPath := filepath.Join(path, ".zaparooignore")
 			if _, statErr := fs.Stat(markerPath); statErr == nil {
 				log.Info().Str("path", path).Msg("skipping directory with .zaparooignore marker")
-				return filepath.SkipDir
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 		}
 
@@ -883,7 +896,7 @@ func collectNeoGeoRomsetEntries(
 		isZip := filepath.Ext(lowerBase) == ".zip"
 		if isZip {
 			candidateID = strings.TrimSuffix(lowerBase, filepath.Ext(lowerBase))
-		} else if !info.IsDir() {
+		} else if !isDirectory {
 			return nil
 		}
 
@@ -1268,6 +1281,10 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			}
 
 			log.Info().Msg("starting neogeo scan")
+			inputResultCount := len(results)
+			filteredResultCount := 0
+			addedResultCount := 0
+			romsetDefinitionCount := 0
 			romsetsFilename := "romsets.xml"
 			names := make(map[string]string)
 
@@ -1277,13 +1294,13 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			}
 
 			sfs := mediascanner.GetSystemPaths(ctx, cfg, p, p.RootDirs(cfg), []systemdefs.System{*s})
-			log.Debug().Int("paths", len(sfs)).Msg("neogeo scan paths found")
 
 			// Collect NEOGEO paths for filtering
 			neogeoPaths := make([]string, len(sfs))
 			for i, sf := range sfs {
 				neogeoPaths[i] = sf.Path
 			}
+			log.Debug().Int("paths", len(sfs)).Strs("roots", neogeoPaths).Msg("neogeo scan paths found")
 
 			// First pass: load all romsets from all directories
 			for _, sf := range sfs {
@@ -1293,28 +1310,40 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				default:
 				}
 
-				rsf, err := mediascanner.FindPath(ctx, filepath.Join(sf.Path, romsetsFilename))
-				if err == nil {
-					romsets, readErr := readRomsets(rsf)
-					if readErr != nil {
-						log.Warn().Err(readErr).Msg("unable to read romsets")
-						continue
-					}
+				expectedRomsetsPath := filepath.Join(sf.Path, romsetsFilename)
+				rsf, findErr := mediascanner.FindPath(ctx, expectedRomsetsPath)
+				if findErr != nil {
+					log.Debug().Err(findErr).Str("path", expectedRomsetsPath).Msg("neogeo romsets not found")
+					continue
+				}
 
-					for _, romset := range romsets {
-						// Handle comma-separated romset name aliases
-						for _, name := range strings.Split(romset.Name, ",") {
-							names[strings.ToLower(strings.TrimSpace(name))] = romset.AltName
-						}
+				romsets, readErr := readRomsets(rsf)
+				if readErr != nil {
+					log.Warn().Err(readErr).Str("path", rsf).Msg("unable to read neogeo romsets")
+					continue
+				}
+
+				romsetDefinitionCount += len(romsets)
+				for _, romset := range romsets {
+					// Handle comma-separated romset name aliases
+					for _, name := range strings.Split(romset.Name, ",") {
+						names[strings.ToLower(strings.TrimSpace(name))] = romset.AltName
 					}
 				}
+				log.Debug().Str("path", rsf).Int("romsets", len(romsets)).Int("totalAliases", len(names)).
+					Msg("neogeo romsets loaded")
 			}
 
+			resultsBeforeFilter := len(results)
 			if len(names) == 0 {
-				log.Warn().Msg("no valid romsets.xml found, applying fallback filter for zip contents")
+				log.Warn().Strs("roots", neogeoPaths).
+					Msg("no valid romsets.xml found, applying fallback filter for zip contents")
 				results = filterNeoGeoZipToNeoOnly(results)
 			} else {
 				results = filterNeoGeoGameContents(results, names, neogeoPaths)
+			}
+			if removed := resultsBeforeFilter - len(results); removed > 0 {
+				filteredResultCount = removed
 			}
 
 			// Second pass: read directories recursively and add launchable romset entries.
@@ -1339,10 +1368,16 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 						continue
 					}
 					results = append(results, entries...)
+					addedResultCount += len(entries)
+					log.Debug().Str("path", sf.Path).Int("matches", len(entries)).
+						Msg("neogeo romset root scanned")
 				}
 			}
 
-			log.Debug().Int("results", len(results)).Msg("neogeo scan completed")
+			log.Debug().Int("roots", len(sfs)).Int("romsets", romsetDefinitionCount).
+				Int("aliases", len(names)).Int("input", inputResultCount).Int("filtered", filteredResultCount).
+				Int("added", addedResultCount).Int("results", len(results)).
+				Msg("neogeo scan completed")
 
 			return results, nil
 		},


### PR DESCRIPTION
## Summary
- preserve root-level Neo Geo ROM-set folder discovery, including directory symlinks
- add focused diagnostics for ROM-set loading, filtering, and per-root matches
- cover root folders, ZIPs, symlinks, mixed case, and malformed XML with scanner regressions

Closes #1064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NeoGeo game scanning when romset definitions are located at the platform root.
  * Added support for NeoGeo romset folders accessed through symlinks.
  * Prevented malformed romset definitions from creating incorrect game entries.
  * Improved handling of ignored directories during scanning.

* **Improvements**
  * Enhanced scan reporting with clearer counts for detected, filtered, and added entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->