### PR TITLE
fix: preserve browse roots and expose indexable systems

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2087,17 +2087,21 @@ Native audio supports `toggle_pause`, `pause`, `resume`, `stop`, `fast_forward`,
 
 ### systems
 
-List all currently indexed systems.
+List systems currently indexed or supported by an available launcher on the running platform. Virtual systems are also included.
+
+Set `all` to include every system represented by the running platform's launcher definitions, even when its runtime dependency is currently unavailable. This is useful when selecting a specific system for its first media index.
 
 #### Parameters
 
-None.
+| Key | Type    | Required | Description                                                                                     |
+| :-- | :------ | :------- | :---------------------------------------------------------------------------------------------- |
+| all | boolean | No       | Include systems with unavailable launchers. Defaults to `false`. Indexed systems remain listed. |
 
 #### Result
 
-| Key     | Type                       | Required | Description                    |
-| :------ | :------------------------- | :------- | :----------------------------- |
-| systems | [System](#system-object)[] | Yes      | A list of all indexed systems. |
+| Key     | Type                       | Required | Description                                                        |
+| :------ | :------------------------- | :------- | :----------------------------------------------------------------- |
+| systems | [System](#system-object)[] | Yes      | Indexed, available, and optionally unavailable platform systems.   |
 
 See [System object](#system-object).
 
@@ -2109,7 +2113,10 @@ See [System object](#system-object).
 {
   "jsonrpc": "2.0",
   "id": "dbd312f3-7a5f-11ef-8f29-020304050607",
-  "method": "systems"
+  "method": "systems",
+  "params": {
+    "all": true
+  }
 }
 ```
 

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -22,9 +22,9 @@ package methods
 import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/rs/zerolog/log"
 )
@@ -32,9 +32,16 @@ import (
 func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Info().Msg("received systems request")
 
+	var params models.SystemsParams
+	if len(env.Params) > 0 {
+		if err := validation.ValidateAndUnmarshal(env.Params, &params); err != nil {
+			return nil, models.ClientErrf("invalid params: %w", err)
+		}
+	}
+
 	indexed, err := env.Database.MediaDB.IndexedSystems()
 	if err != nil {
-		log.Error().Err(err).Msgf("error getting indexed systems")
+		log.Error().Err(err).Msg("error getting indexed systems")
 		indexed = []string{}
 	}
 
@@ -42,22 +49,44 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 		log.Warn().Msg("no indexed systems found")
 	}
 
-	respSystems := make([]models.System, 0)
-
+	systemIDs := make([]string, 0, len(indexed))
+	seen := make(map[string]struct{}, len(indexed))
+	addSystemID := func(id string) {
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		systemIDs = append(systemIDs, id)
+	}
 	for _, id := range indexed {
-		system, err := systemdefs.GetSystem(id)
-		if err != nil {
-			log.Error().Err(err).Msgf("error getting system: %s", id)
+		addSystemID(id)
+	}
+
+	if env.LauncherCache != nil {
+		launchers := env.LauncherCache.GetAllLaunchers()
+		for i := range launchers {
+			if !params.All && !launchers[i].Available {
+				continue
+			}
+			addSystemID(launchers[i].SystemID)
+		}
+	}
+
+	respSystems := make([]models.System, 0, len(systemIDs))
+	for _, id := range systemIDs {
+		system, systemErr := systemdefs.GetSystem(id)
+		if systemErr != nil {
+			log.Error().Err(systemErr).Msgf("error getting system: %s", id)
 			continue
 		}
 
-		sr := models.System{
-			ID: system.ID,
-		}
-
-		sm, err := assets.GetSystemMetadata(id)
-		if err != nil {
-			log.Error().Err(err).Msgf("error getting system metadata: %s", id)
+		sr := models.System{ID: system.ID}
+		sm, metadataErr := assets.GetSystemMetadata(id)
+		if metadataErr != nil {
+			log.Error().Err(metadataErr).Msgf("error getting system metadata: %s", id)
 		} else {
 			sr.Name = sm.Name
 			sr.Category = sm.Category
@@ -68,20 +97,24 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 				sr.Manufacturer = &sm.Manufacturer
 			}
 		}
-
 		respSystems = append(respSystems, sr)
 	}
 
-	for _, system := range helpers.GlobalLauncherCache.GetLaunchableSystems() {
-		respSystems = append(respSystems, models.System{
-			ID:        launchables.EncodeID(system.ID),
-			Name:      system.Name,
-			Category:  system.Category,
-			ZapScript: system.ZapScript(),
-		})
+	if env.LauncherCache != nil {
+		for _, system := range env.LauncherCache.GetLaunchableSystems() {
+			id := launchables.EncodeID(system.ID)
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			respSystems = append(respSystems, models.System{
+				ID:        id,
+				Name:      system.Name,
+				Category:  system.Category,
+				ZapScript: system.ZapScript(),
+			})
+		}
 	}
 
-	return models.SystemsResponse{
-		Systems: respSystems,
-	}, nil
+	return models.SystemsResponse{Systems: respSystems}, nil
 }

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -46,7 +46,7 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 	}
 
 	if len(indexed) == 0 {
-		log.Warn().Msg("no indexed systems found")
+		log.Debug().Msg("no indexed systems found")
 	}
 
 	systemIDs := make([]string, 0, len(indexed))

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -1,0 +1,106 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleSystems_IncludesIndexedAndAvailableLauncherSystems(t *testing.T) {
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "indexed", SystemID: "NES"},
+		{ID: "available", SystemID: "SNES"},
+		{
+			ID:           "unavailable",
+			SystemID:     "Genesis",
+			Availability: func(*config.Instance) error { return errors.New("not installed") },
+		},
+	})
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
+	})
+	require.NoError(t, err)
+
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []string{"NES", "SNES"}, systemResponseIDs(response))
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleSystems_AllIncludesUnavailableLauncherSystems(t *testing.T) {
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "available", SystemID: "SNES"},
+		{
+			ID:           "unavailable",
+			SystemID:     "Genesis",
+			Availability: func(*config.Instance) error { return errors.New("not installed") },
+		},
+	})
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
+		Params:        json.RawMessage(`{"all":true}`),
+	})
+	require.NoError(t, err)
+
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []string{"NES", "SNES", "Genesis"}, systemResponseIDs(response))
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleSystems_RejectsInvalidParams(t *testing.T) {
+	result, err := HandleSystems(requests.RequestEnv{Params: json.RawMessage(`{"all":"yes"}`)})
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid params")
+}
+
+func systemResponseIDs(response models.SystemsResponse) []string {
+	ids := make([]string, len(response.Systems))
+	for i := range response.Systems {
+		ids[i] = response.Systems[i].ID
+	}
+	return ids
+}

--- a/pkg/api/methods/virtual_launchables_test.go
+++ b/pkg/api/methods/virtual_launchables_test.go
@@ -69,18 +69,14 @@ func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 		},
 	}
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
-	originalCache := corehelpers.GlobalLauncherCache
 	cache := &corehelpers.LauncherCache{}
 	cache.Initialize(mockPlatform, &config.Instance{})
-	corehelpers.GlobalLauncherCache = cache
-	t.Cleanup(func() {
-		corehelpers.GlobalLauncherCache = originalCache
-	})
 
 	result, err := HandleSystems(requests.RequestEnv{
-		Platform: mockPlatform,
-		Config:   &config.Instance{},
-		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		Config:        &config.Instance{},
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
 	})
 
 	require.NoError(t, err)

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -46,6 +46,10 @@ type BrowseParams struct {
 	Sort        *string   `json:"sort,omitempty" validate:"omitempty,oneof=name-asc name-desc filename-asc filename-desc"`
 }
 
+type SystemsParams struct {
+	All bool `json:"all,omitempty"`
+}
+
 type MediaIndexParams struct {
 	Systems     *[]string `json:"systems" validate:"omitempty,dive,min=1"`
 	FuzzySystem *bool     `json:"fuzzySystem,omitempty"`

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3323,23 +3323,27 @@ func TestMediaDB_BrowseRouteHasMediaProbe_Integration(t *testing.T) {
 	ctx := context.Background()
 	snesSystem, err := systemdefs.GetSystem("SNES")
 	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
 
 	populatedRoot := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes"))
 	insertSystemWithMedia(t, mediaDB, "SNES", "Probe Game",
 		filepath.ToSlash(filepath.Join(populatedRoot, "RPG", "game.sfc")))
 
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	_, err = mediaDB.FindOrInsertSystem(database.System{SystemID: nesSystem.ID, Name: nesSystem.ID})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
 	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", []systemdefs.System{*snesSystem})
-
-	has, err := sqlBrowseRouteHasMedia(ctx, mediaDB.sql.Load(),
-		browseRouteCacheKey(populatedRoot), systemClause, systemArgs)
+	has, err := sqlBrowseRouteHasMedia(ctx, mediaDB.sql.Load(), systemClause, systemArgs)
 	require.NoError(t, err)
-	assert.True(t, has, "probe finds media under a populated root")
+	assert.True(t, has, "probe finds media for a populated system")
 
-	emptyRoot := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "empty"))
-	has, err = sqlBrowseRouteHasMedia(ctx, mediaDB.sql.Load(),
-		browseRouteCacheKey(emptyRoot), systemClause, systemArgs)
+	systemClause, systemArgs = browseSystemFilterClause("s.SystemID", []systemdefs.System{*nesSystem})
+	has, err = sqlBrowseRouteHasMedia(ctx, mediaDB.sql.Load(), systemClause, systemArgs)
 	require.NoError(t, err)
-	assert.False(t, has, "probe reports no media under an empty root")
+	assert.False(t, has, "probe reports no media for an empty system")
 }
 
 func TestMediaDB_SearchMediaWithFilters_SelectiveIndexingKeepsUnchangedSystemsCacheEligible_Integration(t *testing.T) {

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -1701,10 +1701,12 @@ func sqlBrowseRouteCountsFromMedia(
 		}
 
 		// The exact COUNT timed out for this route. Degrade, don't die: probe
-		// cheaply whether the route has any media. If it does, include it with
-		// an unknown count so the root still browses; if the probe finds nothing
-		// (or itself times out), drop the route and keep browsing the rest.
-		hasMedia, probeErr := sqlBrowseRouteHasMedia(ctx, db, prefix, systemClause, systemArgs)
+		// cheaply whether the filtered systems have any media. Candidate routes
+		// come from those systems' configured and indexed roots, so a positive
+		// result keeps the route browsable without another path-prefix scan. If
+		// the probe finds nothing (or itself times out), drop the route and keep
+		// browsing the rest.
+		hasMedia, probeErr := sqlBrowseRouteHasMedia(ctx, db, systemClause, systemArgs)
 		if probeErr != nil {
 			log.Warn().Err(probeErr).Str("route", route).
 				Msg("browse route count timed out and presence probe failed; skipping route")
@@ -1733,29 +1735,28 @@ func sqlBrowseRouteCountsFromMedia(
 }
 
 // sqlBrowseRouteHasMedia is the cheap presence probe used when an exact route
-// COUNT(*) exceeds its sub-timeout. It stops at the first matching row, so for a
-// non-empty route it returns almost immediately even though the case-insensitive
-// LIKE cannot use an index. It has its own short sub-timeout so an empty route
-// (which forces a full partition scan) degrades to "unknown" rather than
-// blocking the whole browse.
+// COUNT(*) exceeds its sub-timeout. Candidate routes are already scoped to the
+// requested systems, so this probes those systems through Media.SystemDBID and
+// avoids the case-insensitive path LIKE scan that caused the exact count to time
+// out. It has its own short sub-timeout so a slow database still cannot block the
+// whole browse.
 func sqlBrowseRouteHasMedia(
 	ctx context.Context,
 	db sqlQueryable,
-	prefix, systemClause string,
+	systemClause string,
 	systemArgs []any,
 ) (bool, error) {
 	probeCtx, cancel := context.WithTimeout(ctx, browseRouteProbeSubTimeout)
 	defer cancel()
 
-	args := append([]any{prefix}, systemArgs...)
 	var one int
 	err := db.QueryRowContext(probeCtx,
 		`SELECT 1
 		 FROM Media m
 		 INNER JOIN Systems s ON m.SystemDBID = s.DBID
-		 WHERE m.IsMissing = 0 AND m.Path LIKE ? || '%' AND `+systemClause+`
+		 WHERE m.IsMissing = 0 AND `+systemClause+`
 		 LIMIT 1`,
-		args...,
+		systemArgs...,
 	).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -354,7 +354,10 @@ func getSystemPathsForLauncherCache(
 		default:
 		}
 
-		launchers := launcherCache.GetAvailableLaunchersBySystem(system.ID)
+		// Availability describes whether media can launch right now. Indexing
+		// still needs every platform launcher so users can discover media before
+		// installing or configuring its runtime dependency.
+		launchers := launcherCache.GetLaunchersBySystem(system.ID)
 
 		var folders []string
 		for j := range launchers {

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -122,6 +122,35 @@ func TestMultipleScannersForSameSystemID(t *testing.T) {
 	assert.True(t, scanner2Called, "Scanner 2 should have been called") // This will fail with the current bug
 }
 
+func TestGetSystemPathsIncludesUnavailableLaunchers(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	systemFolder := filepath.Join(root, "nes")
+	require.NoError(t, os.Mkdir(systemFolder, 0o750))
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{
+			ID:           "UnavailableLauncher",
+			SystemID:     systemdefs.SystemNES,
+			Folders:      []string{"nes"},
+			Availability: func(*config.Instance) error { return errors.New("runtime not installed") },
+		},
+	})
+
+	results := getSystemPathsForLauncherCache(
+		context.Background(),
+		[]string{root},
+		[]systemdefs.System{{ID: systemdefs.SystemNES}},
+		cache,
+	)
+
+	require.Len(t, results, 1)
+	assert.Equal(t, systemdefs.SystemNES, results[0].System.ID)
+	assert.Equal(t, systemFolder, results[0].Path)
+}
+
 func TestGetSystemPathsRespectsSkipFilesystemScan(t *testing.T) {
 	// Setup test launchers - one that skips filesystem scan, one that doesn't
 	skipLauncher := platforms.Launcher{


### PR DESCRIPTION
## Summary

- replace timeout fallback path scan with index-backed system presence probe so populated roots remain visible on large cold databases
- include indexed and runtime-available launcher systems in default `systems` responses, with `all: true` support for every platform launcher system
- let selective indexing discover folders even when launcher runtime dependency is unavailable
- document new API option and cover browse, systems, and scanner behavior with regression tests

Closes #1039
Ref ZaparooProject/zaparoo-app#182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The systems API now returns indexed systems plus systems supported by platform launchers, including virtual systems.
  - Added an optional `all` parameter to include systems even when runtime dependencies are unavailable.
- **Bug Fixes**
  - Improved browse route media detection during database timeouts so results stay accurate.
  - Media discovery now includes systems based on full platform launcher definitions, even if runtimes aren’t configured yet.
- **Documentation**
  - Updated systems API documentation and examples to reflect the expanded scope and `all` behavior.
- **Tests**
  - Added/updated coverage for `all`, virtual systems, and media discovery under unavailable runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->