### PR TITLE
fix(mister): detect stale RBF cache entries

### DIFF
--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -37,12 +37,10 @@ import (
 //
 // On-disk persistence: when SetPersistPath has been called, the first
 // Refresh of the process tries to load `<path>` instead of scanning the
-// SD. If the loaded file's directory-mtime snapshot still matches the
-// live filesystem, no scan runs at all. If mtimes have drifted, the
-// loaded data is still installed for serving and NeedsRescan() returns
-// true so the caller can schedule a background rescan via the idle
-// scheduler. Subsequent Refresh calls noop when mtimes still match
-// (cheap stat-only check) and rescan when they don't.
+// SD. If its shallow RBF manifest matches the live filesystem, no scan runs.
+// If the manifest differs, the loaded data is installed for serving and
+// NeedsRescan returns true so the caller can schedule a background rescan.
+// Subsequent Refresh calls use directory mtimes as a cheap runtime check.
 type RBFCache struct {
 	bySystemID    map[string]RBFInfo
 	byShortName   map[string][]RBFInfo
@@ -93,10 +91,9 @@ func (c *RBFCache) SetPersistPath(path string) {
 }
 
 // NeedsRescan reports whether the most recent first-call Refresh loaded a
-// persisted cache whose directory-mtime snapshot didn't match the live
-// filesystem. The caller (typically a platform's StartPost) is expected
-// to schedule a background Refresh when this is true. The flag is reset
-// once a fresh scan completes.
+// persisted cache whose RBF manifest did not match the live filesystem.
+// The caller (typically a platform's StartPost) is expected to schedule a
+// background Refresh when this is true. The flag resets after a fresh scan.
 func (c *RBFCache) NeedsRescan() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -106,13 +103,12 @@ func (c *RBFCache) NeedsRescan() bool {
 // Refresh ensures the cache reflects the current filesystem. Behaviour:
 //
 //   - First call after process start, with a configured persist path: try
-//     to load the persisted cache. If loaded and the directory-mtime
-//     snapshot matches the live filesystem, install the data and return
-//     without scanning. If loaded but mtimes drifted, install the data,
-//     set NeedsRescan, and return without scanning. If the file is
-//     missing, corrupt, or version-mismatched, fall through to a scan.
-//   - Subsequent calls: stat the snapshot directories; if all mtimes
-//     still match, noop. Otherwise, scan and persist.
+//     to load the persisted cache. If loaded and its shallow RBF manifest
+//     matches the filesystem, install the data and return without scanning.
+//     If the manifest differs, install the data, set NeedsRescan, and return.
+//     Missing, corrupt, or version-mismatched files fall through to a scan.
+//   - Subsequent calls: stat snapshot directories and compare root RBF names;
+//     if all still match, noop. Otherwise, scan and persist.
 //
 // The cheap-stat fast path means callers like Platform.Launchers (which
 // is invoked from many hot paths) pay only a handful of stats per call
@@ -126,7 +122,7 @@ func (c *RBFCache) Refresh() {
 		if c.tryLoadFromDiskLocked() {
 			return
 		}
-	} else if dirMtimesMatch(c.lastDirMtimes) && rootRBFsMatch(c.lastRootRBFs) {
+	} else if !c.needsRescan && dirMtimesMatch(c.lastDirMtimes) && rootRBFsMatch(c.lastRootRBFs) {
 		return
 	}
 
@@ -134,8 +130,8 @@ func (c *RBFCache) Refresh() {
 }
 
 // tryLoadFromDiskLocked attempts to populate the cache from the persisted
-// file. Returns true if a usable file was loaded (the cache is now
-// populated even if mtimes drifted; needsRescan tracks that case).
+// file. Returns true if a usable file was loaded. The cache is populated
+// even if its manifest drifted; needsRescan tracks that case.
 func (c *RBFCache) tryLoadFromDiskLocked() bool {
 	if c.persistPath == "" {
 		return false
@@ -149,12 +145,11 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 		return false
 	}
 
+	liveManifest, manifestErr := snapshotRBFManifest()
 	c.BuildFromRBFs(stored.Files)
-	c.lastDirMtimes = stored.DirMtimes
-	c.lastRootRBFs = stored.RootRBFs
-	mtimesOK := dirMtimesMatch(stored.DirMtimes)
-	rootOK := rootRBFsMatch(stored.RootRBFs)
-	if mtimesOK && rootOK {
+	c.lastDirMtimes, _ = snapshotDirMtimes()
+	c.lastRootRBFs, _ = snapshotRootRBFs()
+	if manifestErr == nil && rbfManifestsMatch(stored.Manifest, liveManifest) {
 		log.Info().
 			Int("rbf_files", len(stored.Files)).
 			Int("systems_mapped", len(c.bySystemID)).
@@ -162,15 +157,14 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 			Msg("RBF cache loaded from disk")
 		c.needsRescan = false
 	} else {
-		drifted := diffDirMtimes(stored.DirMtimes)
-		rootDiff := diffRootRBFs(stored.RootRBFs)
-		log.Info().
+		event := log.Info().
 			Str("path", c.persistPath).
-			Int("drifted_count", len(drifted)).
-			Interface("drifted", drifted).
-			Strs("added_root_rbfs", rootDiff.Added).
-			Strs("removed_root_rbfs", rootDiff.Removed).
-			Msg("RBF cache loaded but state drifted; rescan needed")
+			Int("cached_rbf_files", len(stored.Manifest)).
+			Int("current_rbf_files", len(liveManifest))
+		if manifestErr != nil {
+			event = event.Err(manifestErr)
+		}
+		event.Msg("RBF cache loaded but manifest check failed or drifted; rescan needed")
 		c.needsRescan = true
 	}
 	return true
@@ -207,9 +201,14 @@ func (c *RBFCache) scanLocked() {
 		log.Warn().Err(rootErr).Msg("RBF cache: failed to snapshot root RBFs, skipping persist")
 		return
 	}
+	manifest, manifestErr := snapshotRBFManifest()
+	if manifestErr != nil {
+		log.Warn().Err(manifestErr).Msg("RBF cache: failed to snapshot RBF manifest, skipping persist")
+		return
+	}
 	c.lastDirMtimes = snapshot
 	c.lastRootRBFs = rootRBFs
-	if writeErr := writePersistedRBFCache(c.persistPath, rbfFiles, snapshot, rootRBFs); writeErr != nil {
+	if writeErr := writePersistedRBFCache(c.persistPath, rbfFiles, manifest); writeErr != nil {
 		log.Warn().Err(writeErr).Str("path", c.persistPath).Msg("RBF cache: failed to persist")
 		return
 	}

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/rs/zerolog/log"
 )
 
@@ -42,11 +43,12 @@ import (
 // NeedsRescan returns true so the caller can schedule a background rescan.
 // Subsequent Refresh calls use directory mtimes as a cheap runtime check.
 type RBFCache struct {
+	persistPath   string
+	sdRoot        string
 	bySystemID    map[string]RBFInfo
 	byShortName   map[string][]RBFInfo
 	byLauncherID  map[string][]string
 	lastDirMtimes map[string]int64
-	persistPath   string
 	lastRootRBFs  []string
 	mu            syncutil.RWMutex
 	initialized   bool
@@ -145,11 +147,14 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 		return false
 	}
 
-	liveManifest, manifestErr := snapshotRBFManifest()
+	beforeManifest, beforeErr := c.snapshotRBFManifest()
 	c.BuildFromRBFs(stored.Files)
-	c.lastDirMtimes, _ = snapshotDirMtimes()
-	c.lastRootRBFs, _ = snapshotRootRBFs()
-	if manifestErr == nil && rbfManifestsMatch(stored.Manifest, liveManifest) {
+	afterManifest, afterErr := c.snapshotRBFManifest()
+	c.lastDirMtimes, _ = c.snapshotDirMtimes()
+	c.lastRootRBFs, _ = c.snapshotRootRBFs()
+	manifestStable := beforeErr == nil && afterErr == nil &&
+		rbfManifestsMatch(beforeManifest, afterManifest)
+	if manifestStable && rbfManifestsMatch(stored.Manifest, beforeManifest) {
 		log.Info().
 			Int("rbf_files", len(stored.Files)).
 			Int("systems_mapped", len(c.bySystemID)).
@@ -160,9 +165,11 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 		event := log.Info().
 			Str("path", c.persistPath).
 			Int("cached_rbf_files", len(stored.Manifest)).
-			Int("current_rbf_files", len(liveManifest))
-		if manifestErr != nil {
-			event = event.Err(manifestErr)
+			Int("current_rbf_files", len(afterManifest))
+		if beforeErr != nil {
+			event = event.Err(beforeErr)
+		} else if afterErr != nil {
+			event = event.Err(afterErr)
 		}
 		event.Msg("RBF cache loaded but manifest check failed or drifted; rescan needed")
 		c.needsRescan = true
@@ -174,36 +181,45 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 // and (when persistence is configured) writes the result to disk. Caller
 // must hold c.mu.
 func (c *RBFCache) scanLocked() {
-	rbfFiles, err := shallowScanRBF()
-	if err != nil {
-		log.Warn().Err(err).Msg("RBF cache: scan failed, using empty cache")
-		c.BuildFromRBFs(nil)
-		c.needsRescan = false
-		return
+	const maxScanAttempts = 2
+	var rbfFiles []RBFInfo
+	var manifest []string
+	stable := false
+	for range maxScanAttempts {
+		beforeManifest, beforeErr := c.snapshotRBFManifest()
+		files, err := shallowScanRBF()
+		if err != nil {
+			log.Warn().Err(err).Msg("RBF cache: scan failed, using empty cache")
+			c.BuildFromRBFs(nil)
+			c.needsRescan = true
+			return
+		}
+		rbfFiles = files
+		afterManifest, afterErr := c.snapshotRBFManifest()
+		if beforeErr == nil && afterErr == nil && rbfManifestsMatch(beforeManifest, afterManifest) {
+			manifest = afterManifest
+			stable = true
+			break
+		}
 	}
 	c.BuildFromRBFs(rbfFiles)
-	c.needsRescan = false
+	c.needsRescan = !stable
 	log.Info().
 		Int("rbf_files", len(rbfFiles)).
 		Int("systems_mapped", len(c.bySystemID)).
 		Msg("RBF cache initialized")
 
-	if c.persistPath == "" {
+	if c.persistPath == "" || !stable {
 		return
 	}
-	snapshot, snapErr := snapshotDirMtimes()
+	snapshot, snapErr := c.snapshotDirMtimes()
 	if snapErr != nil {
 		log.Warn().Err(snapErr).Msg("RBF cache: failed to snapshot directory mtimes, skipping persist")
 		return
 	}
-	rootRBFs, rootErr := snapshotRootRBFs()
+	rootRBFs, rootErr := c.snapshotRootRBFs()
 	if rootErr != nil {
 		log.Warn().Err(rootErr).Msg("RBF cache: failed to snapshot root RBFs, skipping persist")
-		return
-	}
-	manifest, manifestErr := snapshotRBFManifest()
-	if manifestErr != nil {
-		log.Warn().Err(manifestErr).Msg("RBF cache: failed to snapshot RBF manifest, skipping persist")
 		return
 	}
 	c.lastDirMtimes = snapshot
@@ -216,6 +232,25 @@ func (c *RBFCache) scanLocked() {
 		Int("rbf_files", len(rbfFiles)).
 		Str("path", c.persistPath).
 		Msg("RBF cache persisted to disk")
+}
+
+func (c *RBFCache) root() string {
+	if c.sdRoot != "" {
+		return c.sdRoot
+	}
+	return misterconfig.SDRootDir
+}
+
+func (c *RBFCache) snapshotRBFManifest() ([]string, error) {
+	return snapshotRBFManifestAt(c.root())
+}
+
+func (c *RBFCache) snapshotDirMtimes() (map[string]int64, error) {
+	return snapshotDirMtimesAt(c.root())
+}
+
+func (c *RBFCache) snapshotRootRBFs() ([]string, error) {
+	return snapshotRootRBFsAt(c.root())
 }
 
 // BuildFromRBFs deterministically rebuilds bySystemID and byShortName from a

--- a/pkg/platforms/mister/cores/rbf_persist.go
+++ b/pkg/platforms/mister/cores/rbf_persist.go
@@ -41,7 +41,7 @@ const RBFCacheFileName = "rbf_cache.gob"
 
 const (
 	rbfCacheFileMagic   = "zrbf"
-	rbfCacheFileVersion = 3
+	rbfCacheFileVersion = 4
 )
 
 // rbfCacheMaxBytes caps gob input at load time. ~200 RBFs × ~256 B per
@@ -50,28 +50,102 @@ const (
 // lower it to exercise the oversize-fallback path.
 var rbfCacheMaxBytes int64 = 2 << 20
 
-// persistedRBFCache is the on-disk shape. DirMtimes maps each scanned
-// `_*` subdirectory to its ModTime().UnixNano() at scan time; drift
-// signals a core was added or removed under that subdir. RootRBFs is the
-// sorted list of `.rbf` filenames placed directly at SD root — used in
-// place of an `/media/fat` mtime check, which proved too noisy because
-// boot scripts and other writes touch the SD root unrelated to RBFs.
+// persistedRBFCache is the on-disk shape. Manifest contains every RBF path
+// covered by shallowScanRBF, plus symlink targets. Comparing it at startup
+// avoids trusting directory mtimes on filesystems where they may not change
+// when a core is added, removed, or replaced.
 type persistedRBFCache struct {
-	DirMtimes map[string]int64
-	Magic     string
-	Files     []RBFInfo
-	RootRBFs  []string
-	Version   int
+	Magic    string
+	Files    []RBFInfo
+	Manifest []string
+	Version  int
 }
 
 // snapshotDirMtimes captures the current mtime for each `_*` subdirectory
-// of the SD root. Those are the only directories whose mtime tracks core
-// presence: any add/remove/rename of an RBF inside `_Console` (etc.)
-// mutates the dir mtime. The SD root itself is intentionally excluded —
+// and the Light Gun directory. These are directories whose mtime can cheaply
+// signal runtime core changes. The SD root itself is intentionally excluded —
 // its mtime drifts from boot scripts and other unrelated writes — and
 // root-level RBFs are tracked separately via snapshotRootRBFs.
 func snapshotDirMtimes() (map[string]int64, error) {
 	return snapshotDirMtimesAt(config.SDRootDir)
+}
+
+// snapshotRBFManifest returns sorted shallow RBF paths relative to the SD root.
+// It scans root files, immediate files in every `_*` and Light Gun directory,
+// and immediate files in _RA_Cores/Cores. It never walks recursively.
+func snapshotRBFManifest() ([]string, error) {
+	return snapshotRBFManifestAt(config.SDRootDir)
+}
+
+func snapshotRBFManifestAt(root string) ([]string, error) {
+	rootFiles, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("readdir SD root for RBF manifest: %w", err)
+	}
+
+	manifest := make([]string, 0)
+	addRBF := func(dir, relativeDir string, entry os.DirEntry) error {
+		if entry.IsDir() || filepath.Ext(strings.ToLower(entry.Name())) != ".rbf" {
+			return nil
+		}
+		relativePath := filepath.Join(relativeDir, entry.Name())
+		if entry.Type()&os.ModeSymlink != 0 {
+			target, linkErr := os.Readlink(filepath.Join(dir, entry.Name()))
+			if linkErr != nil {
+				return fmt.Errorf("read RBF symlink %s: %w", relativePath, linkErr)
+			}
+			relativePath += " -> " + target
+		}
+		manifest = append(manifest, relativePath)
+		return nil
+	}
+	addRBFs := func(dir, relativeDir string) error {
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			return fmt.Errorf("readdir %s: %w", dir, readErr)
+		}
+		for _, entry := range entries {
+			if addErr := addRBF(dir, relativeDir, entry); addErr != nil {
+				return addErr
+			}
+		}
+		return nil
+	}
+
+	for _, entry := range rootFiles {
+		switch {
+		case entry.IsDir() && (strings.HasPrefix(entry.Name(), "_") || strings.EqualFold(entry.Name(), "Light Gun")):
+			dir := filepath.Join(root, entry.Name())
+			if addErr := addRBFs(dir, entry.Name()); addErr != nil {
+				return nil, fmt.Errorf("readdir RBF directory %s: %w", dir, addErr)
+			}
+		default:
+			if addErr := addRBF(root, "", entry); addErr != nil {
+				return nil, addErr
+			}
+		}
+	}
+
+	raRelativeDir := filepath.Join("_RA_Cores", "Cores")
+	raCoreDir := filepath.Join(root, raRelativeDir)
+	if addErr := addRBFs(raCoreDir, raRelativeDir); addErr != nil && !errors.Is(addErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("readdir RBF directory %s: %w", raCoreDir, addErr)
+	}
+
+	sort.Strings(manifest)
+	return manifest, nil
+}
+
+func rbfManifestsMatch(stored, current []string) bool {
+	if len(stored) != len(current) {
+		return false
+	}
+	for i := range stored {
+		if stored[i] != current[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func snapshotDirMtimesAt(root string) (map[string]int64, error) {
@@ -82,7 +156,7 @@ func snapshotDirMtimesAt(root string) (map[string]int64, error) {
 		return nil, fmt.Errorf("readdir SD root: %w", err)
 	}
 	for _, f := range files {
-		if !f.IsDir() || !strings.HasPrefix(f.Name(), "_") {
+		if !f.IsDir() || (!strings.HasPrefix(f.Name(), "_") && !strings.EqualFold(f.Name(), "Light Gun")) {
 			continue
 		}
 		sub := filepath.Join(root, f.Name())
@@ -106,9 +180,8 @@ func snapshotDirMtimesAt(root string) (map[string]int64, error) {
 //
 // Only direct SD-root files are captured here; RBFs nested under `_*`
 // directories are tracked transitively via snapshotDirMtimes. This matches
-// MiSTer's convention that cores live at SD root or under top-level `_*`
-// folders — a `.rbf` placed inside a brand-new non-`_*` top-level
-// directory would not be detected.
+// MiSTer's convention that cores live at SD root, under top-level `_*`
+// folders, or in Light Gun. Other top-level directories are not scanned.
 func snapshotRootRBFs() ([]string, error) {
 	return snapshotRootRBFsAt(config.SDRootDir)
 }
@@ -146,14 +219,6 @@ type dirMtimeDiff struct {
 	DeltaMs         int64
 }
 
-// rootRBFsDiff describes the divergence between a stored sorted list of
-// root-level RBF filenames and the live state. Either or both slices may
-// be empty when there is no divergence in that direction.
-type rootRBFsDiff struct {
-	Added   []string
-	Removed []string
-}
-
 // rootRBFsMatch reports whether the stored sorted list of root-level RBF
 // filenames is identical to the live filesystem state. A read failure on
 // the SD root is treated as a mismatch.
@@ -175,41 +240,6 @@ func rootRBFsMatchAt(root string, stored []string) bool {
 		}
 	}
 	return true
-}
-
-// diffRootRBFs returns the names added to and removed from the live
-// filesystem relative to the stored snapshot. Returns an empty diff when
-// the live filesystem can't be read, so the caller can still log the
-// stale state without crashing on the diagnostic path.
-func diffRootRBFs(stored []string) rootRBFsDiff {
-	return diffRootRBFsAt(config.SDRootDir, stored)
-}
-
-func diffRootRBFsAt(root string, stored []string) rootRBFsDiff {
-	current, err := snapshotRootRBFsAt(root)
-	if err != nil {
-		return rootRBFsDiff{}
-	}
-	storedSet := make(map[string]struct{}, len(stored))
-	for _, n := range stored {
-		storedSet[n] = struct{}{}
-	}
-	currentSet := make(map[string]struct{}, len(current))
-	for _, n := range current {
-		currentSet[n] = struct{}{}
-	}
-	var diff rootRBFsDiff
-	for _, n := range current {
-		if _, ok := storedSet[n]; !ok {
-			diff.Added = append(diff.Added, n)
-		}
-	}
-	for _, n := range stored {
-		if _, ok := currentSet[n]; !ok {
-			diff.Removed = append(diff.Removed, n)
-		}
-	}
-	return diff
 }
 
 // diffDirMtimes returns the per-path differences between snapshot and the
@@ -242,7 +272,7 @@ func diffDirMtimes(snapshot map[string]int64) []dirMtimeDiff {
 	files, err := os.ReadDir(config.SDRootDir)
 	if err == nil {
 		for _, f := range files {
-			if !f.IsDir() || !strings.HasPrefix(f.Name(), "_") {
+			if !f.IsDir() || (!strings.HasPrefix(f.Name(), "_") && !strings.EqualFold(f.Name(), "Light Gun")) {
 				continue
 			}
 			sub := filepath.Join(config.SDRootDir, f.Name())
@@ -266,8 +296,8 @@ func diffDirMtimes(snapshot map[string]int64) []dirMtimeDiff {
 // dirMtimesMatch reports whether the live filesystem state matches the
 // snapshot. Any of these makes the cache stale: a snapshotted dir is gone
 // or has a different mtime; a new `_*` dir exists that wasn't in the
-// snapshot. An empty snapshot is always considered stale so we don't trust
-// a half-written file.
+// snapshot. Light Gun is treated like a `_*` directory. An empty snapshot
+// is always considered stale so we don't trust incomplete runtime state.
 func dirMtimesMatch(snapshot map[string]int64) bool {
 	if len(snapshot) == 0 {
 		return false
@@ -286,7 +316,7 @@ func dirMtimesMatch(snapshot map[string]int64) bool {
 		return false
 	}
 	for _, f := range files {
-		if !f.IsDir() || !strings.HasPrefix(f.Name(), "_") {
+		if !f.IsDir() || (!strings.HasPrefix(f.Name(), "_") && !strings.EqualFold(f.Name(), "Light Gun")) {
 			continue
 		}
 		sub := filepath.Join(config.SDRootDir, f.Name())
@@ -339,9 +369,7 @@ func loadPersistedRBFCache(path string) (*persistedRBFCache, bool, error) {
 // fsynced, so a hard power-off between rename and the next sync can lose
 // the file. Recovery is automatic: a missing or truncated file falls back
 // to a scan on the next boot.
-func writePersistedRBFCache(
-	path string, files []RBFInfo, dirMtimes map[string]int64, rootRBFs []string,
-) error {
+func writePersistedRBFCache(path string, files []RBFInfo, manifest []string) error {
 	if path == "" {
 		return nil
 	}
@@ -357,11 +385,10 @@ func writePersistedRBFCache(
 	cleanup := func() { _ = os.Remove(tmpPath) }
 
 	payload := persistedRBFCache{
-		Magic:     rbfCacheFileMagic,
-		Version:   rbfCacheFileVersion,
-		Files:     files,
-		DirMtimes: dirMtimes,
-		RootRBFs:  rootRBFs,
+		Magic:    rbfCacheFileMagic,
+		Version:  rbfCacheFileVersion,
+		Files:    files,
+		Manifest: manifest,
 	}
 	if encErr := gob.NewEncoder(tmp).Encode(&payload); encErr != nil {
 		_ = tmp.Close()

--- a/pkg/platforms/mister/cores/rbf_persist.go
+++ b/pkg/platforms/mister/cores/rbf_persist.go
@@ -66,17 +66,9 @@ type persistedRBFCache struct {
 // signal runtime core changes. The SD root itself is intentionally excluded —
 // its mtime drifts from boot scripts and other unrelated writes — and
 // root-level RBFs are tracked separately via snapshotRootRBFs.
-func snapshotDirMtimes() (map[string]int64, error) {
-	return snapshotDirMtimesAt(config.SDRootDir)
-}
-
 // snapshotRBFManifest returns sorted shallow RBF paths relative to the SD root.
 // It scans root files, immediate files in every `_*` and Light Gun directory,
 // and immediate files in _RA_Cores/Cores. It never walks recursively.
-func snapshotRBFManifest() ([]string, error) {
-	return snapshotRBFManifestAt(config.SDRootDir)
-}
-
 func snapshotRBFManifestAt(root string) ([]string, error) {
 	rootFiles, err := os.ReadDir(root)
 	if err != nil {
@@ -182,10 +174,6 @@ func snapshotDirMtimesAt(root string) (map[string]int64, error) {
 // directories are tracked transitively via snapshotDirMtimes. This matches
 // MiSTer's convention that cores live at SD root, under top-level `_*`
 // folders, or in Light Gun. Other top-level directories are not scanned.
-func snapshotRootRBFs() ([]string, error) {
-	return snapshotRootRBFsAt(config.SDRootDir)
-}
-
 func snapshotRootRBFsAt(root string) ([]string, error) {
 	files, err := os.ReadDir(root)
 	if err != nil {

--- a/pkg/platforms/mister/cores/rbf_persist_test.go
+++ b/pkg/platforms/mister/cores/rbf_persist_test.go
@@ -54,13 +54,13 @@ func TestPersistedRBFCache_RoundTrip(t *testing.T) {
 	path := filepath.Join(dir, RBFCacheFileName)
 
 	rbfs := sampleRBFs()
-	mtimes := map[string]int64{
-		"/media/fat/_Console":  1234567891,
-		"/media/fat/_Computer": 1234567892,
+	manifest := []string{
+		"_Console/NES_20240101.rbf",
+		"_Console/SNES_20240101.rbf",
+		"MyCustomCore.rbf",
 	}
-	rootRBFs := []string{"MyCustomCore.rbf", "Userport.rbf"}
 
-	require.NoError(t, writePersistedRBFCache(path, rbfs, mtimes, rootRBFs))
+	require.NoError(t, writePersistedRBFCache(path, rbfs, manifest))
 
 	loaded, ok, err := loadPersistedRBFCache(path)
 	require.NoError(t, err)
@@ -69,8 +69,7 @@ func TestPersistedRBFCache_RoundTrip(t *testing.T) {
 	assert.Equal(t, rbfCacheFileMagic, loaded.Magic)
 	assert.Equal(t, rbfCacheFileVersion, loaded.Version)
 	assert.Equal(t, rbfs, loaded.Files)
-	assert.Equal(t, mtimes, loaded.DirMtimes)
-	assert.Equal(t, rootRBFs, loaded.RootRBFs)
+	assert.Equal(t, manifest, loaded.Manifest)
 }
 
 func TestPersistedRBFCache_MissingFile(t *testing.T) {
@@ -129,9 +128,10 @@ func TestPersistedRBFCache_TruncatedFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, RBFCacheFileName)
 
-	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), map[string]int64{
-		"/media/fat/_Console": 1,
-	}, nil))
+	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), []string{
+		"_Console/NES_20240101.rbf",
+		"_Console/SNES_20240101.rbf",
+	}))
 
 	info, err := os.Stat(path)
 	require.NoError(t, err)
@@ -149,9 +149,10 @@ func TestPersistedRBFCache_OversizedFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, RBFCacheFileName)
 
-	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), map[string]int64{
-		"/media/fat/_Console": 1,
-	}, nil))
+	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), []string{
+		"_Console/NES_20240101.rbf",
+		"_Console/SNES_20240101.rbf",
+	}))
 
 	originalCap := rbfCacheMaxBytes
 	rbfCacheMaxBytes = 16
@@ -168,23 +169,18 @@ func TestPersistedRBFCache_AtomicRenameOverwrites(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, RBFCacheFileName)
 
-	require.NoError(t, writePersistedRBFCache(path, sampleRBFs()[:1], map[string]int64{
-		"/media/fat/_Console": 1,
-	}, []string{"first.rbf"}))
+	require.NoError(t, writePersistedRBFCache(path, sampleRBFs()[:1], []string{"first.rbf"}))
 	loaded, ok, err := loadPersistedRBFCache(path)
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Len(t, loaded.Files, 1)
 
-	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), map[string]int64{
-		"/media/fat/_Console": 2,
-	}, []string{"second.rbf"}))
+	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), []string{"second.rbf"}))
 	loaded, ok, err = loadPersistedRBFCache(path)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Len(t, loaded.Files, 2, "second write should overwrite first")
-	assert.Equal(t, int64(2), loaded.DirMtimes["/media/fat/_Console"])
-	assert.Equal(t, []string{"second.rbf"}, loaded.RootRBFs)
+	assert.Equal(t, []string{"second.rbf"}, loaded.Manifest)
 }
 
 func TestDirMtimesMatch_EmptySnapshot(t *testing.T) {
@@ -245,16 +241,80 @@ func TestDiffDirMtimes_MissingPath(t *testing.T) {
 	assert.Zero(t, diffs[0].CurrentMtimeNs)
 }
 
-func TestSnapshotDirMtimes_IncludesRetroAchievementsCoreDir(t *testing.T) {
+func TestSnapshotDirMtimes_IncludesSpecialCoreDirs(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	lightGunDir := filepath.Join(root, "Light Gun")
 	require.NoError(t, os.MkdirAll(raCoreDir, 0o750))
+	require.NoError(t, os.MkdirAll(lightGunDir, 0o750))
 
 	snapshot, err := snapshotDirMtimesAt(root)
 	require.NoError(t, err)
 	assert.Contains(t, snapshot, raCoreDir)
+	assert.Contains(t, snapshot, lightGunDir)
+}
+
+func TestSnapshotRBFManifest_ShallowScanScope(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	consoleDir := filepath.Join(root, "_Console")
+	customDir := filepath.Join(root, "_Custom")
+	lightGunDir := filepath.Join(root, "Light Gun")
+	raCoreDir := filepath.Join(root, "_RA_Cores", "Cores")
+	ignoredDir := filepath.Join(root, "Games")
+	for _, dir := range []string{consoleDir, customDir, lightGunDir, raCoreDir, ignoredDir} {
+		require.NoError(t, os.MkdirAll(dir, 0o750))
+	}
+
+	writeRBF := func(path string) {
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+	}
+	writeRBF(filepath.Join(root, "Arcade.rbf"))
+	writeRBF(filepath.Join(consoleDir, "Saturn_20251003.rbf"))
+	writeRBF(filepath.Join(customDir, "Custom.rbf"))
+	writeRBF(filepath.Join(lightGunDir, "Sinden.rbf"))
+	writeRBF(filepath.Join(raCoreDir, "RASNES.rbf"))
+	writeRBF(filepath.Join(ignoredDir, "Ignored.rbf"))
+	require.NoError(t, os.MkdirAll(filepath.Join(consoleDir, "Nested"), 0o750))
+	writeRBF(filepath.Join(consoleDir, "Nested", "TooDeep.rbf"))
+	require.NoError(t, os.WriteFile(filepath.Join(consoleDir, "readme.txt"), nil, 0o600))
+
+	manifest, err := snapshotRBFManifestAt(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"Arcade.rbf",
+		filepath.Join("Light Gun", "Sinden.rbf"),
+		filepath.Join("_Console", "Saturn_20251003.rbf"),
+		filepath.Join("_Custom", "Custom.rbf"),
+		filepath.Join("_RA_Cores", "Cores", "RASNES.rbf"),
+	}, manifest)
+}
+
+func TestSnapshotRBFManifest_TracksSymlinkTarget(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	consoleDir := filepath.Join(root, "_Console")
+	require.NoError(t, os.MkdirAll(consoleDir, 0o750))
+	require.NoError(t, os.Symlink("Saturn_20251003.rbf", filepath.Join(consoleDir, "Saturn.rbf")))
+
+	manifest, err := snapshotRBFManifestAt(root)
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		filepath.Join("_Console", "Saturn.rbf") + " -> Saturn_20251003.rbf",
+	}, manifest)
+}
+
+func TestRBFManifestsMatch(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, rbfManifestsMatch(nil, nil))
+	assert.True(t, rbfManifestsMatch([]string{"_Console/Saturn.rbf"}, []string{"_Console/Saturn.rbf"}))
+	assert.False(t, rbfManifestsMatch([]string{"_Console/Saturn_old.rbf"}, []string{"_Console/Saturn_new.rbf"}))
+	assert.False(t, rbfManifestsMatch(nil, []string{"_Console/Saturn.rbf"}))
 }
 
 func TestRootRBFsMatch_NoFilesEqualsEmptySnapshot(t *testing.T) {
@@ -285,17 +345,6 @@ func TestRootRBFsMatch_IgnoresNonRBFRootFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "boot.log"), []byte{}, 0o600))
 	assert.True(t, rootRBFsMatchAt(root, nil),
 		"unrelated files at SD root must not invalidate the cache")
-}
-
-func TestDiffRootRBFs_AddedAndRemoved(t *testing.T) {
-	t.Parallel()
-	root := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(root, "Kept.rbf"), []byte{}, 0o600))
-	require.NoError(t, os.WriteFile(filepath.Join(root, "Added.rbf"), []byte{}, 0o600))
-
-	diff := diffRootRBFsAt(root, []string{"Kept.rbf", "Removed.rbf"})
-	assert.Equal(t, []string{"Added.rbf"}, diff.Added)
-	assert.Equal(t, []string{"Removed.rbf"}, diff.Removed)
 }
 
 // TestRBFCache_NoPersistPath_ScanFlowsThrough verifies that with no persist
@@ -333,9 +382,7 @@ func TestRBFCache_LoadFromDisk_PopulatesMaps(t *testing.T) {
 	path := filepath.Join(dir, RBFCacheFileName)
 
 	rbfs := sampleRBFs()
-	require.NoError(t, writePersistedRBFCache(path, rbfs, map[string]int64{
-		"/this/path/does/not/exist": 1, // forces dirMtimesMatch=false → needsRescan=true
-	}, nil))
+	require.NoError(t, writePersistedRBFCache(path, rbfs, []string{"missing.rbf"}))
 
 	cache := &RBFCache{}
 	cache.SetPersistPath(path)
@@ -344,11 +391,11 @@ func TestRBFCache_LoadFromDisk_PopulatesMaps(t *testing.T) {
 	// We don't assert specific systems — that depends on the Systems table
 	// containing entries with RBF "_Console/SNES" or "_Console/NES". What we
 	// CAN assert is that byShortName was populated from the persisted file
-	// and that the drift was detected.
+	// and that the unavailable live manifest was treated as stale.
 	rbf, ok := cache.GetByShortName("snes")
 	assert.True(t, ok, "SNES should be loaded from the persisted file")
 	assert.Equal(t, "_Console/SNES", rbf.MglName)
 
 	assert.True(t, cache.NeedsRescan(),
-		"bogus snapshot path must mark needsRescan=true")
+		"unavailable or mismatched live manifest must mark needsRescan=true")
 }

--- a/pkg/platforms/mister/cores/rbf_persist_test.go
+++ b/pkg/platforms/mister/cores/rbf_persist_test.go
@@ -34,16 +34,16 @@ import (
 func sampleRBFs() []RBFInfo {
 	return []RBFInfo{
 		{
-			Path:      "/media/fat/_Console/SNES_20240101.rbf",
+			Path:      filepath.Join(string(filepath.Separator), "media", "fat", "_Console", "SNES_20240101.rbf"),
 			Filename:  "SNES_20240101.rbf",
 			ShortName: "SNES",
-			MglName:   "_Console/SNES",
+			MglName:   filepath.Join("_Console", "SNES"),
 		},
 		{
-			Path:      "/media/fat/_Console/NES_20240101.rbf",
+			Path:      filepath.Join(string(filepath.Separator), "media", "fat", "_Console", "NES_20240101.rbf"),
 			Filename:  "NES_20240101.rbf",
 			ShortName: "NES",
-			MglName:   "_Console/NES",
+			MglName:   filepath.Join("_Console", "NES"),
 		},
 	}
 }
@@ -55,8 +55,8 @@ func TestPersistedRBFCache_RoundTrip(t *testing.T) {
 
 	rbfs := sampleRBFs()
 	manifest := []string{
-		"_Console/NES_20240101.rbf",
-		"_Console/SNES_20240101.rbf",
+		filepath.Join("_Console", "NES_20240101.rbf"),
+		filepath.Join("_Console", "SNES_20240101.rbf"),
 		"MyCustomCore.rbf",
 	}
 
@@ -129,8 +129,8 @@ func TestPersistedRBFCache_TruncatedFile(t *testing.T) {
 	path := filepath.Join(dir, RBFCacheFileName)
 
 	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), []string{
-		"_Console/NES_20240101.rbf",
-		"_Console/SNES_20240101.rbf",
+		filepath.Join("_Console", "NES_20240101.rbf"),
+		filepath.Join("_Console", "SNES_20240101.rbf"),
 	}))
 
 	info, err := os.Stat(path)
@@ -150,8 +150,8 @@ func TestPersistedRBFCache_OversizedFile(t *testing.T) {
 	path := filepath.Join(dir, RBFCacheFileName)
 
 	require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), []string{
-		"_Console/NES_20240101.rbf",
-		"_Console/SNES_20240101.rbf",
+		filepath.Join("_Console", "NES_20240101.rbf"),
+		filepath.Join("_Console", "SNES_20240101.rbf"),
 	}))
 
 	originalCap := rbfCacheMaxBytes
@@ -312,9 +312,13 @@ func TestRBFManifestsMatch(t *testing.T) {
 	t.Parallel()
 
 	assert.True(t, rbfManifestsMatch(nil, nil))
-	assert.True(t, rbfManifestsMatch([]string{"_Console/Saturn.rbf"}, []string{"_Console/Saturn.rbf"}))
-	assert.False(t, rbfManifestsMatch([]string{"_Console/Saturn_old.rbf"}, []string{"_Console/Saturn_new.rbf"}))
-	assert.False(t, rbfManifestsMatch(nil, []string{"_Console/Saturn.rbf"}))
+	saturn := filepath.Join("_Console", "Saturn.rbf")
+	assert.True(t, rbfManifestsMatch([]string{saturn}, []string{saturn}))
+	assert.False(t, rbfManifestsMatch(
+		[]string{filepath.Join("_Console", "Saturn_old.rbf")},
+		[]string{filepath.Join("_Console", "Saturn_new.rbf")},
+	))
+	assert.False(t, rbfManifestsMatch(nil, []string{saturn}))
 }
 
 func TestRootRBFsMatch_NoFilesEqualsEmptySnapshot(t *testing.T) {
@@ -358,7 +362,7 @@ func TestRBFCache_NoPersistPath_ScanFlowsThrough(t *testing.T) {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
 	assert.True(t, cache.initialized, "Refresh must mark cache initialized")
-	assert.False(t, cache.needsRescan, "scan path resets needsRescan")
+	assert.True(t, cache.needsRescan, "unavailable manifest keeps scan marked stale")
 	assert.Empty(t, cache.persistPath, "no persist path was configured")
 }
 
@@ -374,28 +378,41 @@ func TestRBFCache_SetPersistPath(t *testing.T) {
 	assert.Equal(t, "/tmp/example.gob", got)
 }
 
-// TestRBFCache_LoadFromDisk_PopulatesMaps verifies that a persisted file is
-// decoded and BuildFromRBFs is run, populating bySystemID for known systems.
 func TestRBFCache_LoadFromDisk_PopulatesMaps(t *testing.T) {
 	t.Parallel()
-	dir := t.TempDir()
-	path := filepath.Join(dir, RBFCacheFileName)
+	tests := []struct {
+		name        string
+		rootExists  bool
+		storedMatch bool
+		needsRescan bool
+	}{
+		{name: "matching manifest", rootExists: true, storedMatch: true},
+		{name: "mismatching manifest", rootExists: true, needsRescan: true},
+		{name: "snapshot error", needsRescan: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			root := filepath.Join(dir, "sd")
+			manifest := []string(nil)
+			if tt.rootExists {
+				require.NoError(t, os.MkdirAll(root, 0o750))
+				if !tt.storedMatch {
+					manifest = []string{"missing.rbf"}
+				}
+			}
+			path := filepath.Join(dir, RBFCacheFileName)
+			require.NoError(t, writePersistedRBFCache(path, sampleRBFs(), manifest))
 
-	rbfs := sampleRBFs()
-	require.NoError(t, writePersistedRBFCache(path, rbfs, []string{"missing.rbf"}))
+			cache := &RBFCache{sdRoot: root}
+			cache.SetPersistPath(path)
+			cache.Refresh()
 
-	cache := &RBFCache{}
-	cache.SetPersistPath(path)
-	cache.Refresh()
-
-	// We don't assert specific systems — that depends on the Systems table
-	// containing entries with RBF "_Console/SNES" or "_Console/NES". What we
-	// CAN assert is that byShortName was populated from the persisted file
-	// and that the unavailable live manifest was treated as stale.
-	rbf, ok := cache.GetByShortName("snes")
-	assert.True(t, ok, "SNES should be loaded from the persisted file")
-	assert.Equal(t, "_Console/SNES", rbf.MglName)
-
-	assert.True(t, cache.NeedsRescan(),
-		"unavailable or mismatched live manifest must mark needsRescan=true")
+			rbf, ok := cache.GetByShortName("snes")
+			require.True(t, ok)
+			assert.Equal(t, filepath.Join("_Console", "SNES"), rbf.MglName)
+			assert.Equal(t, tt.needsRescan, cache.NeedsRescan())
+		})
+	}
 }

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -365,7 +365,7 @@ func (p *Platform) StartPost(
 		log.Debug().Msg("no idle scheduler; skipping arcade DB update")
 	}
 
-	// If the RBF cache loaded from disk but its directory mtimes drifted,
+	// If the RBF cache loaded from disk but its shallow manifest drifted,
 	// the persisted entries are still serving requests but a rescan is
 	// needed to pick up any added/removed cores. Defer the rescan to the
 	// idle scheduler so it doesn't compete with the launcher's first


### PR DESCRIPTION
## Summary

- validate persisted MiSTer RBF caches against a shallow manifest instead of directory mtimes alone
- cover root cores, top-level underscore folders, Light Gun, and `_RA_Cores/Cores` without recursive scanning
- preserve cheap runtime mtime checks and schedule an idle rescan when startup manifest differs
- track symlink target changes and invalidate older persisted cache formats

Closes #1038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MiSTer core cache validation using a shallow manifest that detects changes to RBF files, directory contents, and symlink targets.
  * Cache now resyncs more accurately when manifest snapshotting indicates drift, including cases where manifests can’t be captured.
  * Treated the “Light Gun” directory consistently with other special core directories during validation.
* **Compatibility**
  * Updated the on-disk persisted cache format (version bump) to store and verify the manifest instead of directory mtimes and root RBF snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->