### PR TITLE
fix(mister): route AmigaVision virtual MGL launches

### DIFF
--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -388,12 +388,14 @@ func TestResolveAmigaVisionVirtualMGLPath(t *testing.T) {
 
 	missingMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga 500.mgl")
 	nonMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Readme.txt")
+	mglWithoutAmigaVision := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga.mgl")
 
 	assert.Equal(t, realMGL, resolveAmigaVisionVirtualMGLPath(virtualMGL))
 	assert.Equal(t, realVirtualMGL, resolveAmigaVisionVirtualMGLPath(realVirtualMGL))
 	assert.Equal(t, missingMGL, resolveAmigaVisionVirtualMGLPath(missingMGL))
 	assert.Equal(t, nonMGL, resolveAmigaVisionVirtualMGLPath(nonMGL))
 	assert.True(t, isAmigaVisionVirtualMGLPath(routedVirtualMGL))
+	assert.False(t, isAmigaVisionVirtualMGLPath(mglWithoutAmigaVision))
 
 	p := NewPlatform()
 	amigaLauncher := findAmigaLauncher(t, p.Launchers(&config.Instance{}))

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -381,6 +381,11 @@ func TestResolveAmigaVisionVirtualMGLPath(t *testing.T) {
 	amigaVisionMGLPaths = []string{realMGL}
 	t.Cleanup(func() { amigaVisionMGLPaths = oldPaths })
 
+	installPath := filepath.Join(t.TempDir(), "games", "Amiga")
+	routedVirtualMGL := filepath.Join(installPath, "Amiga.mgl")
+	require.NoError(t, os.MkdirAll(installPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(installPath, "AmigaVision.hdf"), []byte("test"), 0o600))
+
 	missingMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Amiga 500.mgl")
 	nonMGL := filepath.Join(t.TempDir(), "games", "Amiga", "Readme.txt")
 
@@ -388,6 +393,11 @@ func TestResolveAmigaVisionVirtualMGLPath(t *testing.T) {
 	assert.Equal(t, realVirtualMGL, resolveAmigaVisionVirtualMGLPath(realVirtualMGL))
 	assert.Equal(t, missingMGL, resolveAmigaVisionVirtualMGLPath(missingMGL))
 	assert.Equal(t, nonMGL, resolveAmigaVisionVirtualMGLPath(nonMGL))
+	assert.True(t, isAmigaVisionVirtualMGLPath(routedVirtualMGL))
+
+	p := NewPlatform()
+	amigaLauncher := findAmigaLauncher(t, p.Launchers(&config.Instance{}))
+	assert.True(t, amigaLauncher.Test(nil, routedVirtualMGL))
 }
 
 func TestAmigaLauncher_TestRequiresAmigaVisionVirtualPath(t *testing.T) {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -140,6 +140,9 @@ func resolveAmigaVisionVirtualMGLPath(path string) string {
 }
 
 func isAmigaVisionVirtualMGLPath(path string) bool {
+	if filepath.Ext(strings.ToLower(path)) != ".mgl" {
+		return false
+	}
 	if !hasAmigaVisionImage(filepath.Dir(path)) {
 		return false
 	}

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -139,6 +139,13 @@ func resolveAmigaVisionVirtualMGLPath(path string) string {
 	return path
 }
 
+func isAmigaVisionVirtualMGLPath(path string) bool {
+	if !hasAmigaVisionImage(filepath.Dir(path)) {
+		return false
+	}
+	return resolveAmigaVisionVirtualMGLPath(path) != path
+}
+
 func launchAmiga(pl platforms.Platform) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
 	genericLaunch := launch(pl, systemdefs.SystemAmiga)
 	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1194,7 +1194,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		Folders:    []string{"Amiga"},
 		Extensions: []string{".adf"},
 		Test: func(_ *config.Instance, path string) bool {
-			if isAmigaVisionListingFile(path) {
+			if isAmigaVisionListingFile(path) || isAmigaVisionVirtualMGLPath(path) {
 				return true
 			}
 


### PR DESCRIPTION
## Summary

- recognize indexed AmigaVision virtual MGL paths in the Amiga launcher
- route them through the existing resolver instead of sending nonexistent paths through the generic MGL launcher
- cover virtual MGL launcher matching with a regression test

Closes #1052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AmigaVision game detection on MiSTer.
  * AmigaVision virtual MGL paths are now recognized and launched correctly, including routed virtual paths (and AmigaVision virtual listings continue to be supported).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->