### PR TITLE
feat(mister): coordinate console launchers and render sizing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -304,6 +304,9 @@ func (c *Instance) applyTOML(data string) error {
 		nil,
 		"config.toml",
 	)
+	if err := validateLauncherDefaults(c.vals.Launchers.Default); err != nil {
+		return fmt.Errorf("invalid launcher defaults: %w", err)
+	}
 
 	// prepare allow files regexes
 	c.vals.Launchers.allowFileRe = make([]*regexp.Regexp, len(c.vals.Launchers.AllowFile))

--- a/pkg/config/configlaunchers.go
+++ b/pkg/config/configlaunchers.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
@@ -47,9 +48,11 @@ type Launchers struct {
 }
 
 type LaunchersDefault struct {
-	Launcher   string `toml:"launcher"`
-	InstallDir string `toml:"install_dir,omitempty"`
-	ServerURL  string `toml:"server_url,omitempty"`
+	RenderScale      *int   `toml:"render_scale,omitempty"`
+	Launcher         string `toml:"launcher"`
+	InstallDir       string `toml:"install_dir,omitempty"`
+	ServerURL        string `toml:"server_url,omitempty"`
+	RenderResolution string `toml:"render_resolution,omitempty"`
 	// Action specifies the default launch action. Common values:
 	// - "" or "run": Default behavior (launch/play the media)
 	// - "details": Show media details/info page instead of launching
@@ -165,6 +168,15 @@ func (c *Instance) LookupLauncherDefaults(launcherID string, groups []string) La
 			if entry.LoadPath != "" {
 				result.LoadPath = entry.LoadPath
 			}
+			if entry.RenderScale != nil {
+				renderScale := *entry.RenderScale
+				result.RenderScale = &renderScale
+				result.RenderResolution = ""
+			}
+			if entry.RenderResolution != "" {
+				result.RenderScale = nil
+				result.RenderResolution = entry.RenderResolution
+			}
 		}
 	}
 
@@ -177,6 +189,38 @@ func (c *Instance) LookupLauncherDefaults(launcherID string, groups []string) La
 		Msg("LookupLauncherDefaults: resolution complete")
 
 	return result
+}
+
+// ValidateRenderResolution validates and parses a positive WIDTHxHEIGHT render target.
+func ValidateRenderResolution(value string) (width, height int, err error) {
+	widthText, heightText, ok := strings.Cut(strings.ToLower(value), "x")
+	if !ok || widthText == "" || heightText == "" || strings.Contains(heightText, "x") {
+		return 0, 0, fmt.Errorf("render resolution must use WIDTHxHEIGHT, got %q", value)
+	}
+	width, widthErr := strconv.Atoi(widthText)
+	height, heightErr := strconv.Atoi(heightText)
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return 0, 0, fmt.Errorf("render resolution must use positive dimensions, got %q", value)
+	}
+	return width, height, nil
+}
+
+func validateLauncherDefaults(defaults []LaunchersDefault) error {
+	for i := range defaults {
+		entry := &defaults[i]
+		if entry.RenderScale != nil && entry.RenderResolution != "" {
+			return fmt.Errorf("launcher default %d cannot set both render_scale and render_resolution", i)
+		}
+		if entry.RenderScale != nil && *entry.RenderScale <= 0 {
+			return fmt.Errorf("launcher default %d render_scale must be positive", i)
+		}
+		if entry.RenderResolution != "" {
+			if _, _, err := ValidateRenderResolution(entry.RenderResolution); err != nil {
+				return fmt.Errorf("launcher default %d: %w", i, err)
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Instance) LoadCustomLaunchers(launchersDir string) error {

--- a/pkg/config/configlaunchers_test.go
+++ b/pkg/config/configlaunchers_test.go
@@ -153,6 +153,54 @@ allow_execute = ["^test.*", "^echo$"]`))
 	assert.False(t, cfg.IsExecuteAllowed("rm -rf"))
 }
 
+func TestLauncherRenderDefaultsValidation(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		`[[launchers.default]]
+launcher = "GenericVideo"
+render_scale = 33`,
+		`[[launchers.default]]
+launcher = "ScummVM"
+render_resolution = "640x480"`,
+	}
+	for _, input := range valid {
+		cfg := &Instance{}
+		require.NoError(t, cfg.LoadTOML(input))
+	}
+
+	invalid := []string{
+		`[[launchers.default]]
+launcher = "GenericVideo"
+render_scale = 0`,
+		`[[launchers.default]]
+launcher = "ScummVM"
+render_resolution = "640-480"`,
+		`[[launchers.default]]
+launcher = "ScummVM"
+render_scale = 50
+render_resolution = "640x480"`,
+	}
+	for _, input := range invalid {
+		cfg := &Instance{}
+		require.Error(t, cfg.LoadTOML(input))
+	}
+}
+
+func TestLookupLauncherDefaults_RenderSettingsOverrideEachOther(t *testing.T) {
+	t.Parallel()
+
+	renderScale := 50
+	cfg := &Instance{vals: Values{Launchers: Launchers{Default: []LaunchersDefault{
+		{Launcher: "MiSTer", RenderScale: &renderScale},
+		{Launcher: "GenericVideo", RenderResolution: "640x360"},
+	}}}}
+
+	result := cfg.LookupLauncherDefaults("GenericVideo", []string{"MiSTer"})
+	assert.Nil(t, result.RenderScale)
+	assert.Equal(t, "640x360", result.RenderResolution)
+}
+
 func TestLookupLauncherDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/launch.go
+++ b/pkg/platforms/launch.go
@@ -21,6 +21,7 @@ package platforms
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -124,6 +125,22 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 	}
 	if params.Options.Action == "" {
 		params.Options.Action = action
+	}
+	if params.Config != nil && params.Options.RenderScale == nil && params.Options.RenderResolution == "" {
+		defaults := params.Config.LookupLauncherDefaults(params.Launcher.ID, params.Launcher.Groups)
+		params.Options.RenderScale = defaults.RenderScale
+		params.Options.RenderResolution = defaults.RenderResolution
+	}
+	if params.Options.RenderScale != nil && params.Options.RenderResolution != "" {
+		return errors.New("render_scale and render_resolution are mutually exclusive")
+	}
+	if params.Options.RenderScale != nil && *params.Options.RenderScale <= 0 {
+		return errors.New("render_scale must be positive")
+	}
+	if params.Options.RenderResolution != "" {
+		if _, _, renderErr := config.ValidateRenderResolution(params.Options.RenderResolution); renderErr != nil {
+			return fmt.Errorf("validate render_resolution: %w", renderErr)
+		}
 	}
 
 	slot, slotErr := mediaslot.Normalize(params.Options.Slot)

--- a/pkg/platforms/launch_test.go
+++ b/pkg/platforms/launch_test.go
@@ -269,6 +269,43 @@ func TestDoLaunch_RunningInstanceLauncher(t *testing.T) {
 	}
 }
 
+func TestDoLaunch_AppliesRenderDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`[[launchers.default]]
+launcher = "test-launcher"
+render_scale = 33`))
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("StopActiveLauncher", platforms.StopForPreemption).Return(nil).Once()
+	mockPlatform.On("SetTrackedProcess", mock.AnythingOfType("*os.Process")).Return().Once()
+	var captured *platforms.LaunchOptions
+	launcher := &platforms.Launcher{
+		ID:        "test-launcher",
+		SystemID:  "test-system",
+		Lifecycle: platforms.LifecycleTracked,
+		Launch: func(_ *config.Instance, _ string, opts *platforms.LaunchOptions) (*os.Process, error) {
+			captured = opts
+			return &os.Process{Pid: os.Getpid()}, nil
+		},
+	}
+
+	err := platforms.DoLaunch(&platforms.LaunchParams{
+		Platform:       mockPlatform,
+		Config:         cfg,
+		SetActiveMedia: func(*models.ActiveMedia) {},
+		Launcher:       launcher,
+		Path:           filepath.Join("test", "game.rom"),
+	}, filepath.Base)
+	require.NoError(t, err)
+	require.NotNil(t, captured)
+	require.NotNil(t, captured.RenderScale)
+	assert.Equal(t, 33, *captured.RenderScale)
+	assert.Empty(t, captured.RenderResolution)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestDoLaunch_LifecycleModes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/config/config.go
+++ b/pkg/platforms/mister/config/config.go
@@ -3,9 +3,7 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 )
@@ -21,11 +19,6 @@ const (
 	ScriptsDir         = SDRootDir + "/Scripts"
 	CmdInterface       = "/dev/MiSTer_cmd"
 	LinuxDir           = SDRootDir + "/linux"
-	MainPickerDir      = "/tmp/PICKERITEMS"
-	MainPickerSelected = "/tmp/PICKERSELECTED"
-	MainFeaturesFile   = "/tmp/MAINFEATURES"
-	MainFeaturePicker  = "PICKER"
-	MainFeatureNotice  = "NOTICE"
 	ScreenshotsDir     = SDRootDir + "/screenshots"
 	WallpapersDir      = SDRootDir + "/wallpapers"
 	MenuCore           = "MENU"
@@ -44,27 +37,6 @@ const (
 )
 
 var UpdateAllDownloaderCACert = filepath.Join(ScriptsDir, ".config", "downloader", "cacert.pem")
-
-func MainHasFeature(feature string) bool {
-	if _, err := os.Stat(MainFeaturesFile); os.IsNotExist(err) {
-		return false
-	}
-
-	contents, err := os.ReadFile(MainFeaturesFile)
-	if err != nil {
-		return false
-	}
-
-	features := strings.Split(string(contents), ",")
-
-	for _, f := range features {
-		if strings.EqualFold(f, feature) {
-			return true
-		}
-	}
-
-	return false
-}
 
 var GamesFolders = []string{
 	"/media/usb0/games",

--- a/pkg/platforms/mister/console_launcher.go
+++ b/pkg/platforms/mister/console_launcher.go
@@ -24,6 +24,7 @@ package mister
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,9 +55,10 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 		}
 	}
 
-	// Get console manager
-	cm := pl.ConsoleManager()
+	return setupConsoleManager(ctx, pl.ConsoleManager())
+}
 
+func setupConsoleManager(ctx context.Context, cm platforms.ConsoleManager) (platforms.ConsoleManager, error) {
 	// Switch to console mode (F9 + chvt to launcher VT)
 	if err := cm.Open(ctx, armLauncherVT); err != nil {
 		return nil, fmt.Errorf("failed to open console: %w", err)
@@ -70,7 +72,11 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 
 	// Clean launcher console (tty3) - where content actually displays
 	if err := cm.Clean(armLauncherVT); err != nil {
-		return nil, fmt.Errorf("failed to clean launcher console: %w", err)
+		cleanErr := fmt.Errorf("failed to clean launcher console: %w", err)
+		if closeErr := cm.Close(); closeErr != nil {
+			return nil, errors.Join(cleanErr, fmt.Errorf("close console after clean failure: %w", closeErr))
+		}
+		return nil, cleanErr
 	}
 
 	return cm, nil

--- a/pkg/platforms/mister/console_launcher.go
+++ b/pkg/platforms/mister/console_launcher.go
@@ -37,7 +37,7 @@ import (
 // This includes:
 //   - Checking if FPGA core is active and returning to menu if needed
 //   - Opening the console (switching to launcher VT)
-//   - Cleaning both F9 console (tty1) and launcher console (tty7)
+//   - Cleaning both F9 console (tty1) and launcher console (tty3)
 //
 // The provided context can be used to cancel console operations if the launcher is superseded.
 //
@@ -58,7 +58,7 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 	cm := pl.ConsoleManager()
 
 	// Switch to console mode (F9 + chvt to launcher VT)
-	if err := cm.Open(ctx, launcherConsoleVT); err != nil {
+	if err := cm.Open(ctx, armLauncherVT); err != nil {
 		return nil, fmt.Errorf("failed to open console: %w", err)
 	}
 
@@ -68,8 +68,8 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 		log.Debug().Err(err).Msg("failed to clean f9 console")
 	}
 
-	// Clean launcher console (tty7) - where content actually displays
-	if err := cm.Clean(launcherConsoleVT); err != nil {
+	// Clean launcher console (tty3) - where content actually displays
+	if err := cm.Clean(armLauncherVT); err != nil {
 		return nil, fmt.Errorf("failed to clean launcher console: %w", err)
 	}
 
@@ -78,10 +78,7 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 
 // createConsoleRestoreFunc builds a standard console cleanup function for console-based launchers.
 // The returned function handles:
-//   - Launching the MiSTer menu core
-//   - Restoring cursor state on both F9 and launcher consoles
-//   - Pressing F12 to exit console mode
-//   - Clearing the console active flag
+//   - Closing the console through a Main lease or stock F12 fallback
 //   - Grace period for transitions to complete
 //
 // This cleanup function should be called when:
@@ -92,32 +89,14 @@ func setupConsoleEnvironment(ctx context.Context, pl *Platform) (platforms.Conso
 // new launcher will handle console setup.
 //
 // This function is reusable for any console-based launcher.
-func createConsoleRestoreFunc(pl *Platform, cm platforms.ConsoleManager) func() {
+func createConsoleRestoreFunc(cm platforms.ConsoleManager) func() {
 	return func() {
-		// Exit console mode FIRST before loading menu
-		// If we call LaunchMenu() while in console mode, MiSTer Main switches to tty2
-		if err := pl.KeyboardPress("{f12}"); err != nil {
-			log.Error().Err(err).Msg("error pressing F12 to exit console")
+		// Exit console mode before loading menu. Close uses the explicit Main
+		// console lease when available and retains the stock F12 fallback.
+		if err := cm.Close(); err != nil {
+			log.Error().Err(err).Msg("error closing console")
 		}
 		time.Sleep(100 * time.Millisecond)
-
-		// Restore cursor state on F9 console (tty1) and launcher console (tty7)
-		if err := cm.Restore(f9ConsoleVT); err != nil {
-			log.Warn().Err(err).Msg("error restoring tty1 cursor")
-		}
-		if err := cm.Restore(launcherConsoleVT); err != nil {
-			log.Warn().Err(err).Msgf("error restoring tty%s cursor", launcherConsoleVT)
-		}
-
-		// NOW load menu core after exiting console mode
-		if err := pl.ReturnToMenu(); err != nil {
-			log.Error().Err(err).Msg("error launching menu")
-		}
-
-		// Clear console active flag
-		pl.consoleManager.mu.Lock()
-		pl.consoleManager.active = false
-		pl.consoleManager.mu.Unlock()
 
 		time.Sleep(200 * time.Millisecond)
 	}

--- a/pkg/platforms/mister/console_launcher.go
+++ b/pkg/platforms/mister/console_launcher.go
@@ -173,8 +173,9 @@ func runTrackedProcess(
 		return nil, fmt.Errorf("failed to start %s: %w", logPrefix, err)
 	}
 
-	// Track process and completion channel together BEFORE cleanup goroutine starts
-	pl.setTrackedProcessWithCleanup(cmd.Process, done)
+	// Track process and completion channel together BEFORE cleanup goroutine starts.
+	processGroup := cmd.SysProcAttr != nil && (cmd.SysProcAttr.Setsid || cmd.SysProcAttr.Setpgid)
+	pl.setTrackedProcessWithCleanup(cmd.Process, done, processGroup)
 
 	// Cleanup in goroutine (non-blocking)
 	go func() {
@@ -182,6 +183,7 @@ func runTrackedProcess(
 		defer close(done)
 
 		waitErr := cmd.Wait()
+		killRemainingProcessGroup(cmd.Process, processGroup)
 		log.Debug().Msgf("%s: process exited, waitErr=%v", logPrefix, waitErr)
 
 		// Handle different exit scenarios
@@ -199,7 +201,7 @@ func runTrackedProcess(
 		restoreFunc()
 
 		// Clear tracked process after cleanup completes
-		pl.clearTrackedProcess()
+		pl.clearTrackedProcess(cmd.Process)
 	}()
 
 	return cmd.Process, nil

--- a/pkg/platforms/mister/console_launcher_test.go
+++ b/pkg/platforms/mister/console_launcher_test.go
@@ -35,19 +35,23 @@ import (
 
 // testConsoleManager is a simple mock console manager for testing
 type testConsoleManager struct {
-	openErr    error
-	closeErr   error
-	cleanErr   error
-	restoreErr error
-	openCalled bool
+	openErr     error
+	closeErr    error
+	cleanErr    error
+	restoreErr  error
+	openVT      string
+	openCalled  bool
+	closeCalled bool
 }
 
-func (m *testConsoleManager) Open(_ context.Context, _ string) error {
+func (m *testConsoleManager) Open(_ context.Context, vt string) error {
 	m.openCalled = true
+	m.openVT = vt
 	return m.openErr
 }
 
 func (m *testConsoleManager) Close() error {
+	m.closeCalled = true
 	return m.closeErr
 }
 

--- a/pkg/platforms/mister/console_launcher_test.go
+++ b/pkg/platforms/mister/console_launcher_test.go
@@ -196,6 +196,53 @@ func TestSetupConsoleEnvironment_CancelledContext(t *testing.T) {
 	assert.Nil(t, cm)
 }
 
+func TestSetupConsoleManager_UsesArmVTAndCentralizedClose(t *testing.T) {
+	t.Parallel()
+
+	cm := &testConsoleManager{}
+	configured, err := setupConsoleManager(context.Background(), cm)
+	require.NoError(t, err)
+	assert.Same(t, cm, configured)
+	assert.Equal(t, armLauncherVT, cm.openVT)
+
+	restore := createConsoleRestoreFunc(cm)
+	restore()
+	assert.True(t, cm.closeCalled)
+}
+
+func TestSetupConsoleManager_OpenFailure(t *testing.T) {
+	t.Parallel()
+
+	cm := &testConsoleManager{openErr: assert.AnError}
+	configured, err := setupConsoleManager(context.Background(), cm)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Nil(t, configured)
+	assert.False(t, cm.closeCalled)
+}
+
+func TestSetupConsoleManager_CleanFailureClosesConsole(t *testing.T) {
+	t.Parallel()
+
+	cm := &testConsoleManager{cleanErr: assert.AnError}
+	configured, err := setupConsoleManager(context.Background(), cm)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Nil(t, configured)
+	assert.True(t, cm.closeCalled)
+}
+
+func TestSetupConsoleManager_CleanAndCloseFailuresAreJoined(t *testing.T) {
+	t.Parallel()
+
+	cleanErr := errors.New("clean failed")
+	closeErr := errors.New("close failed")
+	cm := &testConsoleManager{cleanErr: cleanErr, closeErr: closeErr}
+	configured, err := setupConsoleManager(context.Background(), cm)
+	require.ErrorIs(t, err, cleanErr)
+	require.ErrorIs(t, err, closeErr)
+	assert.Nil(t, configured)
+	assert.True(t, cm.closeCalled)
+}
+
 func TestConsoleManager_ErrorPropagation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/console_lease.go
+++ b/pkg/platforms/mister/console_lease.go
@@ -1,0 +1,148 @@
+//go:build linux
+
+package mister
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+)
+
+const (
+	consoleLeaseStatePath = "/tmp/zaparoo_console_state"
+	consoleLeaseVersion   = "1"
+)
+
+type consoleLeaseController interface {
+	Available() bool
+	Acquire(ctx context.Context, vt string) (string, error)
+	Release(ctx context.Context, nonce string) error
+}
+
+type mainConsoleLeaseController struct {
+	statePath    string
+	commandPath  string
+	pollInterval time.Duration
+}
+
+type consoleLeaseState struct {
+	version string
+	state   string
+	nonce   string
+	pid     int
+}
+
+func newMainConsoleLeaseController() *mainConsoleLeaseController {
+	return &mainConsoleLeaseController{
+		statePath:    consoleLeaseStatePath,
+		commandPath:  misterconfig.CmdInterface,
+		pollInterval: 20 * time.Millisecond,
+	}
+}
+
+func (c *mainConsoleLeaseController) Available() bool {
+	state, err := c.readState()
+	if err != nil || state.version != consoleLeaseVersion || state.pid <= 0 {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(string(filepath.Separator), "proc", strconv.Itoa(state.pid)))
+	return err == nil
+}
+
+func (c *mainConsoleLeaseController) Acquire(ctx context.Context, vt string) (string, error) {
+	nonce, err := newConsoleLeaseNonce()
+	if err != nil {
+		return "", err
+	}
+	if err := c.writeCommand(fmt.Sprintf("zaparoo_console acquire %s %s\n", nonce, vt)); err != nil {
+		return "", err
+	}
+	if err := c.waitForState(ctx, "acquired", nonce); err != nil {
+		return "", fmt.Errorf("acquire Main console lease: %w", err)
+	}
+	return nonce, nil
+}
+
+func (c *mainConsoleLeaseController) Release(ctx context.Context, nonce string) error {
+	if err := c.writeCommand(fmt.Sprintf("zaparoo_console release %s\n", nonce)); err != nil {
+		return err
+	}
+	if err := c.waitForState(ctx, "released", nonce); err != nil {
+		return fmt.Errorf("release Main console lease: %w", err)
+	}
+	return nil
+}
+
+func (c *mainConsoleLeaseController) writeCommand(command string) error {
+	cmd, err := os.OpenFile(c.commandPath, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open Main command interface: %w", err)
+	}
+	defer func() { _ = cmd.Close() }()
+
+	if _, err := cmd.WriteString(command); err != nil {
+		return fmt.Errorf("write Main command: %w", err)
+	}
+	return nil
+}
+
+func (c *mainConsoleLeaseController) waitForState(ctx context.Context, expected, nonce string) error {
+	ticker := time.NewTicker(c.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		state, err := c.readState()
+		if err == nil && state.nonce == nonce {
+			switch state.state {
+			case expected:
+				return nil
+			case "busy", "failed":
+				return fmt.Errorf("main reported console lease state %q", state.state)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *mainConsoleLeaseController) readState() (consoleLeaseState, error) {
+	contents, err := os.ReadFile(c.statePath)
+	if err != nil {
+		return consoleLeaseState{}, fmt.Errorf("read Main console state: %w", err)
+	}
+	fields := strings.Fields(string(contents))
+	if len(fields) != 4 {
+		return consoleLeaseState{}, errors.New("invalid Main console state")
+	}
+	pid, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return consoleLeaseState{}, fmt.Errorf("invalid Main console PID: %w", err)
+	}
+	return consoleLeaseState{
+		version: fields[0],
+		pid:     pid,
+		state:   fields[2],
+		nonce:   fields[3],
+	}, nil
+}
+
+func newConsoleLeaseNonce() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", fmt.Errorf("generate console lease nonce: %w", err)
+	}
+	return hex.EncodeToString(value[:]), nil
+}

--- a/pkg/platforms/mister/console_lease.go
+++ b/pkg/platforms/mister/console_lease.go
@@ -15,12 +15,12 @@ import (
 	"time"
 
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/spf13/afero"
 )
 
-const (
-	consoleLeaseStatePath = "/tmp/zaparoo_console_state"
-	consoleLeaseVersion   = "1"
-)
+const consoleLeaseVersion = "1"
+
+var consoleLeaseStatePath = filepath.Join(string(filepath.Separator), "tmp", "zaparoo_console_state")
 
 type consoleLeaseController interface {
 	Available() bool
@@ -29,9 +29,11 @@ type consoleLeaseController interface {
 }
 
 type mainConsoleLeaseController struct {
-	statePath    string
-	commandPath  string
-	pollInterval time.Duration
+	fs             afero.Fs
+	statePath      string
+	commandPath    string
+	pollInterval   time.Duration
+	cleanupTimeout time.Duration
 }
 
 type consoleLeaseState struct {
@@ -41,11 +43,13 @@ type consoleLeaseState struct {
 	pid     int
 }
 
-func newMainConsoleLeaseController() *mainConsoleLeaseController {
+func newMainConsoleLeaseController(fs afero.Fs) *mainConsoleLeaseController {
 	return &mainConsoleLeaseController{
-		statePath:    consoleLeaseStatePath,
-		commandPath:  misterconfig.CmdInterface,
-		pollInterval: 20 * time.Millisecond,
+		fs:             fs,
+		statePath:      consoleLeaseStatePath,
+		commandPath:    misterconfig.CmdInterface,
+		pollInterval:   20 * time.Millisecond,
+		cleanupTimeout: 3 * time.Second,
 	}
 }
 
@@ -54,7 +58,7 @@ func (c *mainConsoleLeaseController) Available() bool {
 	if err != nil || state.version != consoleLeaseVersion || state.pid <= 0 {
 		return false
 	}
-	_, err = os.Stat(filepath.Join(string(filepath.Separator), "proc", strconv.Itoa(state.pid)))
+	_, err = c.fs.Stat(filepath.Join(string(filepath.Separator), "proc", strconv.Itoa(state.pid)))
 	return err == nil
 }
 
@@ -67,7 +71,14 @@ func (c *mainConsoleLeaseController) Acquire(ctx context.Context, vt string) (st
 		return "", err
 	}
 	if err := c.waitForState(ctx, "acquired", nonce); err != nil {
-		return "", fmt.Errorf("acquire Main console lease: %w", err)
+		acquireErr := fmt.Errorf("acquire Main console lease: %w", err)
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), c.cleanupTimeout)
+		releaseErr := c.Release(releaseCtx, nonce)
+		releaseCancel()
+		if releaseErr != nil {
+			return "", errors.Join(acquireErr, fmt.Errorf("clean up uncertain Main console lease: %w", releaseErr))
+		}
+		return "", acquireErr
 	}
 	return nonce, nil
 }
@@ -83,7 +94,7 @@ func (c *mainConsoleLeaseController) Release(ctx context.Context, nonce string) 
 }
 
 func (c *mainConsoleLeaseController) writeCommand(command string) error {
-	cmd, err := os.OpenFile(c.commandPath, os.O_RDWR, 0)
+	cmd, err := c.fs.OpenFile(c.commandPath, os.O_RDWR, 0)
 	if err != nil {
 		return fmt.Errorf("open Main command interface: %w", err)
 	}
@@ -119,7 +130,7 @@ func (c *mainConsoleLeaseController) waitForState(ctx context.Context, expected,
 }
 
 func (c *mainConsoleLeaseController) readState() (consoleLeaseState, error) {
-	contents, err := os.ReadFile(c.statePath)
+	contents, err := afero.ReadFile(c.fs, c.statePath)
 	if err != nil {
 		return consoleLeaseState{}, fmt.Errorf("read Main console state: %w", err)
 	}

--- a/pkg/platforms/mister/console_lease_test.go
+++ b/pkg/platforms/mister/console_lease_test.go
@@ -7,62 +7,184 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func newTestConsoleLeaseController(t *testing.T) (*mainConsoleLeaseController, afero.Fs) {
+	t.Helper()
+
+	fs := afero.NewMemMapFs()
+	statePath := filepath.Join(string(filepath.Separator), "tmp", "console-state")
+	commandPath := filepath.Join(string(filepath.Separator), "dev", "MiSTer_cmd")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(statePath), 0o755))
+	require.NoError(t, fs.MkdirAll(filepath.Dir(commandPath), 0o755))
+	require.NoError(t, fs.MkdirAll(
+		filepath.Join(string(filepath.Separator), "proc", strconv.Itoa(os.Getpid())), 0o755,
+	))
+	require.NoError(t, afero.WriteFile(fs, commandPath, nil, 0o600))
+
+	return &mainConsoleLeaseController{
+		fs:             fs,
+		statePath:      statePath,
+		commandPath:    commandPath,
+		pollInterval:   time.Millisecond,
+		cleanupTimeout: 20 * time.Millisecond,
+	}, fs
+}
+
+func writeConsoleLeaseState(fs afero.Fs, path, state, nonce string) error {
+	if err := afero.WriteFile(
+		fs, path, []byte(fmt.Sprintf("1 %d %s %s\n", os.Getpid(), state, nonce)), 0o600,
+	); err != nil {
+		return fmt.Errorf("write console lease state: %w", err)
+	}
+	return nil
+}
+
+func waitForLeaseCommand(fs afero.Fs, path, action string) []string {
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		contents, err := afero.ReadFile(fs, path)
+		if err == nil {
+			fields := strings.Fields(string(contents))
+			if len(fields) >= 3 && fields[0] == "zaparoo_console" && fields[1] == action {
+				return fields
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return nil
+}
+
 func TestMainConsoleLeaseController_Available(t *testing.T) {
 	t.Parallel()
 
-	statePath := filepath.Join(t.TempDir(), "console-state")
-	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d ready -\n", os.Getpid())), 0o600))
-
-	controller := &mainConsoleLeaseController{statePath: statePath}
+	controller, fs := newTestConsoleLeaseController(t)
+	require.NoError(t, writeConsoleLeaseState(fs, controller.statePath, "ready", "-"))
 	assert.True(t, controller.Available())
 }
 
 func TestMainConsoleLeaseController_AvailableRejectsStalePID(t *testing.T) {
 	t.Parallel()
 
-	statePath := filepath.Join(t.TempDir(), "console-state")
-	require.NoError(t, os.WriteFile(statePath, []byte("1 2147483647 ready -\n"), 0o600))
-
-	controller := &mainConsoleLeaseController{statePath: statePath}
+	controller, fs := newTestConsoleLeaseController(t)
+	require.NoError(t, afero.WriteFile(
+		fs, controller.statePath, []byte("1 2147483647 ready -\n"), 0o600,
+	))
 	assert.False(t, controller.Available())
 }
 
-func TestMainConsoleLeaseController_WaitForState(t *testing.T) {
+func TestMainConsoleLeaseController_Acquire(t *testing.T) {
 	t.Parallel()
 
-	statePath := filepath.Join(t.TempDir(), "console-state")
-	controller := &mainConsoleLeaseController{
-		statePath:    statePath,
-		pollInterval: time.Millisecond,
-	}
-	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d ready -\n", os.Getpid())), 0o600))
-
+	controller, fs := newTestConsoleLeaseController(t)
 	go func() {
-		time.Sleep(5 * time.Millisecond)
-		_ = os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d acquired test-nonce\n", os.Getpid())), 0o600)
+		fields := waitForLeaseCommand(fs, controller.commandPath, "acquire")
+		if len(fields) >= 3 {
+			_ = writeConsoleLeaseState(fs, controller.statePath, "acquired", fields[2])
+		}
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	require.NoError(t, controller.waitForState(ctx, "acquired", "test-nonce"))
+	nonce, err := controller.Acquire(ctx, "3")
+	require.NoError(t, err)
+	assert.NotEmpty(t, nonce)
+}
+
+func TestMainConsoleLeaseController_AcquireCleansDelayedLeaseAfterContextFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, fs := newTestConsoleLeaseController(t)
+	controller.cleanupTimeout = time.Second
+	go func() {
+		fields := waitForLeaseCommand(fs, controller.commandPath, "acquire")
+		if len(fields) < 3 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+		_ = writeConsoleLeaseState(fs, controller.statePath, "acquired", fields[2])
+		if len(waitForLeaseCommand(fs, controller.commandPath, "release")) >= 3 {
+			_ = writeConsoleLeaseState(fs, controller.statePath, "released", fields[2])
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	_, err := controller.Acquire(ctx, "3")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	state, stateErr := controller.readState()
+	require.NoError(t, stateErr)
+	assert.Equal(t, "released", state.state)
+}
+
+func TestMainConsoleLeaseController_AcquireReportsCleanupFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, _ := newTestConsoleLeaseController(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := controller.Acquire(ctx, "3")
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Contains(t, err.Error(), "clean up uncertain Main console lease")
+}
+
+func TestMainConsoleLeaseController_Release(t *testing.T) {
+	t.Parallel()
+
+	controller, fs := newTestConsoleLeaseController(t)
+	go func() {
+		fields := waitForLeaseCommand(fs, controller.commandPath, "release")
+		if len(fields) >= 3 {
+			_ = writeConsoleLeaseState(fs, controller.statePath, "released", fields[2])
+		}
+	}()
+
+	require.NoError(t, controller.Release(context.Background(), "test-nonce"))
+}
+
+func TestMainConsoleLeaseController_WriteCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, _ := newTestConsoleLeaseController(t)
+	controller.commandPath = filepath.Join(string(filepath.Separator), "missing", "MiSTer_cmd")
+
+	err := controller.writeCommand("zaparoo_console release test-nonce\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open Main command interface")
+}
+
+func TestMainConsoleLeaseController_ReleaseStateFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, fs := newTestConsoleLeaseController(t)
+	go func() {
+		fields := waitForLeaseCommand(fs, controller.commandPath, "release")
+		if len(fields) >= 3 {
+			_ = writeConsoleLeaseState(fs, controller.statePath, "failed", fields[2])
+		}
+	}()
+
+	err := controller.Release(context.Background(), "test-nonce")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed")
 }
 
 func TestMainConsoleLeaseController_WaitForFailure(t *testing.T) {
 	t.Parallel()
 
-	statePath := filepath.Join(t.TempDir(), "console-state")
-	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d busy test-nonce\n", os.Getpid())), 0o600))
-	controller := &mainConsoleLeaseController{
-		statePath:    statePath,
-		pollInterval: time.Millisecond,
-	}
+	controller, fs := newTestConsoleLeaseController(t)
+	require.NoError(t, writeConsoleLeaseState(fs, controller.statePath, "busy", "test-nonce"))
 
 	err := controller.waitForState(context.Background(), "acquired", "test-nonce")
 	require.Error(t, err)

--- a/pkg/platforms/mister/console_lease_test.go
+++ b/pkg/platforms/mister/console_lease_test.go
@@ -153,6 +153,28 @@ func TestMainConsoleLeaseController_Release(t *testing.T) {
 	require.NoError(t, controller.Release(context.Background(), "test-nonce"))
 }
 
+func TestMainConsoleLeaseController_AcquireCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, _ := newTestConsoleLeaseController(t)
+	controller.commandPath = filepath.Join(string(filepath.Separator), "missing", "MiSTer_cmd")
+
+	_, err := controller.Acquire(context.Background(), "3")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open Main command interface")
+}
+
+func TestMainConsoleLeaseController_ReleaseCommandFailure(t *testing.T) {
+	t.Parallel()
+
+	controller, _ := newTestConsoleLeaseController(t)
+	controller.commandPath = filepath.Join(string(filepath.Separator), "missing", "MiSTer_cmd")
+
+	err := controller.Release(context.Background(), "test-nonce")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open Main command interface")
+}
+
 func TestMainConsoleLeaseController_WriteCommandFailure(t *testing.T) {
 	t.Parallel()
 
@@ -178,6 +200,21 @@ func TestMainConsoleLeaseController_ReleaseStateFailure(t *testing.T) {
 	err := controller.Release(context.Background(), "test-nonce")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed")
+}
+
+func TestMainConsoleLeaseController_ReadStateValidation(t *testing.T) {
+	t.Parallel()
+
+	controller, fs := newTestConsoleLeaseController(t)
+	require.NoError(t, afero.WriteFile(fs, controller.statePath, []byte("invalid\n"), 0o600))
+	_, err := controller.readState()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Main console state")
+
+	require.NoError(t, afero.WriteFile(fs, controller.statePath, []byte("1 bad ready -\n"), 0o600))
+	_, err = controller.readState()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid Main console PID")
 }
 
 func TestMainConsoleLeaseController_WaitForFailure(t *testing.T) {

--- a/pkg/platforms/mister/console_lease_test.go
+++ b/pkg/platforms/mister/console_lease_test.go
@@ -1,0 +1,70 @@
+//go:build linux
+
+package mister
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainConsoleLeaseController_Available(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "console-state")
+	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d ready -\n", os.Getpid())), 0o600))
+
+	controller := &mainConsoleLeaseController{statePath: statePath}
+	assert.True(t, controller.Available())
+}
+
+func TestMainConsoleLeaseController_AvailableRejectsStalePID(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "console-state")
+	require.NoError(t, os.WriteFile(statePath, []byte("1 2147483647 ready -\n"), 0o600))
+
+	controller := &mainConsoleLeaseController{statePath: statePath}
+	assert.False(t, controller.Available())
+}
+
+func TestMainConsoleLeaseController_WaitForState(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "console-state")
+	controller := &mainConsoleLeaseController{
+		statePath:    statePath,
+		pollInterval: time.Millisecond,
+	}
+	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d ready -\n", os.Getpid())), 0o600))
+
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d acquired test-nonce\n", os.Getpid())), 0o600)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, controller.waitForState(ctx, "acquired", "test-nonce"))
+}
+
+func TestMainConsoleLeaseController_WaitForFailure(t *testing.T) {
+	t.Parallel()
+
+	statePath := filepath.Join(t.TempDir(), "console-state")
+	require.NoError(t, os.WriteFile(statePath, []byte(fmt.Sprintf("1 %d busy test-nonce\n", os.Getpid())), 0o600))
+	controller := &mainConsoleLeaseController{
+		statePath:    statePath,
+		pollInterval: time.Millisecond,
+	}
+
+	err := controller.waitForState(context.Background(), "acquired", "test-nonce")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "busy")
+}

--- a/pkg/platforms/mister/console_manager.go
+++ b/pkg/platforms/mister/console_manager.go
@@ -14,6 +14,7 @@ import (
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mistermain"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 // TTYReader provides an interface for reading the active TTY.
@@ -25,6 +26,13 @@ type TTYReader interface {
 type FramebufferChecker interface {
 	IsReady() bool
 }
+
+type consoleHardware interface {
+	Clean(vt string) error
+	Restore(vt string) error
+}
+
+type realConsoleHardware struct{}
 
 // CoreNameGetter provides an interface for getting the active core name.
 type CoreNameGetter interface {
@@ -73,11 +81,13 @@ type MiSTerConsoleManager struct {
 	ttyReader       TTYReader
 	fbChecker       FramebufferChecker
 	coreNameGetter  CoreNameGetter
+	hardware        consoleHardware
 	leaseController consoleLeaseController
 	executor        command.Executor
 	platform        *Platform
 	activeVT        string
 	leaseNonce      string
+	framebufferWait time.Duration
 	mu              syncutil.RWMutex
 	active          bool
 }
@@ -88,8 +98,10 @@ func newConsoleManager(p *Platform) *MiSTerConsoleManager {
 		ttyReader:       realTTYReader{},
 		fbChecker:       realFramebufferChecker{},
 		coreNameGetter:  realCoreNameGetter{},
-		leaseController: newMainConsoleLeaseController(),
+		hardware:        realConsoleHardware{},
+		leaseController: newMainConsoleLeaseController(afero.NewOsFs()),
 		executor:        &command.RealExecutor{},
+		framebufferWait: 2 * time.Second,
 	}
 }
 
@@ -119,18 +131,31 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 		if err != nil {
 			return fmt.Errorf("failed to acquire Main console lease: %w", err)
 		}
-		if err := m.waitForFramebuffer(2 * time.Second); err != nil {
-			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
-			_ = m.leaseController.Release(releaseCtx, nonce)
-			releaseCancel()
-			return err
-		}
 
 		m.mu.Lock()
 		m.active = true
 		m.activeVT = vt
 		m.leaseNonce = nonce
 		m.mu.Unlock()
+
+		if framebufferErr := m.waitForFramebuffer(m.framebufferWait); framebufferErr != nil {
+			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			releaseErr := m.leaseController.Release(releaseCtx, nonce)
+			releaseCancel()
+			if releaseErr != nil {
+				wrappedReleaseErr := fmt.Errorf(
+					"release Main console lease after framebuffer failure: %w", releaseErr,
+				)
+				return errors.Join(framebufferErr, wrappedReleaseErr)
+			}
+
+			m.mu.Lock()
+			m.active = false
+			m.activeVT = ""
+			m.leaseNonce = ""
+			m.mu.Unlock()
+			return framebufferErr
+		}
 		log.Debug().Str("vt", vt).Msg("Main console lease acquired")
 		return nil
 	}
@@ -273,7 +298,14 @@ func (m *MiSTerConsoleManager) Close() error {
 
 // Clean prepares a console for use (clears screen, hides cursor).
 // This is public to allow launchers to clean specific TTYs.
-func (*MiSTerConsoleManager) Clean(vt string) error {
+func (m *MiSTerConsoleManager) Clean(vt string) error {
+	if err := m.hardware.Clean(vt); err != nil {
+		return fmt.Errorf("clean console tty%s: %w", vt, err)
+	}
+	return nil
+}
+
+func (realConsoleHardware) Clean(vt string) error {
 	// Clear screen and reset
 	err := writeTty(vt, "\033[2J\033[H")
 	if err != nil {
@@ -292,7 +324,14 @@ func (*MiSTerConsoleManager) Clean(vt string) error {
 
 // Restore restores console cursor state.
 // This is public to allow launchers to restore specific TTYs.
-func (*MiSTerConsoleManager) Restore(vt string) error {
+func (m *MiSTerConsoleManager) Restore(vt string) error {
+	if err := m.hardware.Restore(vt); err != nil {
+		return fmt.Errorf("restore console tty%s: %w", vt, err)
+	}
+	return nil
+}
+
+func (realConsoleHardware) Restore(vt string) error {
 	err := writeTty(vt, "\033[?25h")
 	if err != nil {
 		return err

--- a/pkg/platforms/mister/console_manager.go
+++ b/pkg/platforms/mister/console_manager.go
@@ -124,39 +124,11 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 		return nil
 	}
 
-	if m.leaseController.Available() {
-		leaseCtx, leaseCancel := context.WithTimeout(ctx, 3*time.Second)
-		nonce, err := m.leaseController.Acquire(leaseCtx, vt)
-		leaseCancel()
-		if err != nil {
-			return fmt.Errorf("failed to acquire Main console lease: %w", err)
-		}
-
-		m.mu.Lock()
-		m.active = true
-		m.activeVT = vt
-		m.leaseNonce = nonce
-		m.mu.Unlock()
-
-		if framebufferErr := m.waitForFramebuffer(m.framebufferWait); framebufferErr != nil {
-			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
-			releaseErr := m.leaseController.Release(releaseCtx, nonce)
-			releaseCancel()
-			if releaseErr != nil {
-				wrappedReleaseErr := fmt.Errorf(
-					"release Main console lease after framebuffer failure: %w", releaseErr,
-				)
-				return errors.Join(framebufferErr, wrappedReleaseErr)
-			}
-
-			m.mu.Lock()
-			m.active = false
-			m.activeVT = ""
-			m.leaseNonce = ""
-			m.mu.Unlock()
-			return framebufferErr
-		}
-		log.Debug().Str("vt", vt).Msg("Main console lease acquired")
+	acquired, err := m.tryAcquireLease(ctx, vt)
+	if err != nil {
+		return err
+	}
+	if acquired {
 		return nil
 	}
 
@@ -189,6 +161,16 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 	maxBackoff := 500 * time.Millisecond
 
 	for time.Now().Before(deadline) {
+		// Main may restart and publish its lease capability while returning
+		// from an FPGA core to the menu. Prefer that protocol once available.
+		acquired, err := m.tryAcquireLease(ctx, vt)
+		if err != nil {
+			return err
+		}
+		if acquired {
+			return nil
+		}
+
 		// Check if launcher context was cancelled
 		if ctx.Err() != nil {
 			log.Debug().Err(ctx.Err()).Msg("launcher context cancelled during F9 loop")
@@ -196,7 +178,7 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 		}
 
 		// Press F9 to signal MiSTer_Main to release framebuffer
-		err := m.platform.KeyboardPress("{f9}")
+		err = m.platform.KeyboardPress("{f9}")
 		if err != nil {
 			return fmt.Errorf("failed to press F9 key: %w", err)
 		}
@@ -246,6 +228,46 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 		Str("targetVT", vt).Str("core", coreName).
 		Msg("timeout waiting for console switch")
 	return errors.New("timeout waiting for console switch after 5s")
+}
+
+func (m *MiSTerConsoleManager) tryAcquireLease(ctx context.Context, vt string) (bool, error) {
+	if !m.leaseController.Available() {
+		return false, nil
+	}
+
+	leaseCtx, leaseCancel := context.WithTimeout(ctx, 3*time.Second)
+	nonce, err := m.leaseController.Acquire(leaseCtx, vt)
+	leaseCancel()
+	if err != nil {
+		return false, fmt.Errorf("failed to acquire Main console lease: %w", err)
+	}
+
+	m.mu.Lock()
+	m.active = true
+	m.activeVT = vt
+	m.leaseNonce = nonce
+	m.mu.Unlock()
+
+	if framebufferErr := m.waitForFramebuffer(m.framebufferWait); framebufferErr != nil {
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		releaseErr := m.leaseController.Release(releaseCtx, nonce)
+		releaseCancel()
+		if releaseErr != nil {
+			wrappedReleaseErr := fmt.Errorf(
+				"release Main console lease after framebuffer failure: %w", releaseErr,
+			)
+			return false, errors.Join(framebufferErr, wrappedReleaseErr)
+		}
+
+		m.mu.Lock()
+		m.active = false
+		m.activeVT = ""
+		m.leaseNonce = ""
+		m.mu.Unlock()
+		return false, framebufferErr
+	}
+	log.Debug().Str("vt", vt).Msg("Main console lease acquired")
+	return true, nil
 }
 
 // Close exits console mode and returns to normal display.

--- a/pkg/platforms/mister/console_manager.go
+++ b/pkg/platforms/mister/console_manager.go
@@ -70,22 +70,26 @@ func (realFramebufferChecker) IsReady() bool {
 
 // MiSTerConsoleManager manages console/TTY switching for MiSTer platform.
 type MiSTerConsoleManager struct {
-	ttyReader      TTYReader
-	fbChecker      FramebufferChecker
-	coreNameGetter CoreNameGetter
-	executor       command.Executor
-	platform       *Platform
-	mu             syncutil.RWMutex
-	active         bool
+	ttyReader       TTYReader
+	fbChecker       FramebufferChecker
+	coreNameGetter  CoreNameGetter
+	leaseController consoleLeaseController
+	executor        command.Executor
+	platform        *Platform
+	activeVT        string
+	leaseNonce      string
+	mu              syncutil.RWMutex
+	active          bool
 }
 
 func newConsoleManager(p *Platform) *MiSTerConsoleManager {
 	return &MiSTerConsoleManager{
-		platform:       p,
-		ttyReader:      realTTYReader{},
-		fbChecker:      realFramebufferChecker{},
-		coreNameGetter: realCoreNameGetter{},
-		executor:       &command.RealExecutor{},
+		platform:        p,
+		ttyReader:       realTTYReader{},
+		fbChecker:       realFramebufferChecker{},
+		coreNameGetter:  realCoreNameGetter{},
+		leaseController: newMainConsoleLeaseController(),
+		executor:        &command.RealExecutor{},
 	}
 }
 
@@ -105,6 +109,29 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 
 	if isActive {
 		log.Debug().Msg("console already active, skipping F9 sequence")
+		return nil
+	}
+
+	if m.leaseController.Available() {
+		leaseCtx, leaseCancel := context.WithTimeout(ctx, 3*time.Second)
+		nonce, err := m.leaseController.Acquire(leaseCtx, vt)
+		leaseCancel()
+		if err != nil {
+			return fmt.Errorf("failed to acquire Main console lease: %w", err)
+		}
+		if err := m.waitForFramebuffer(2 * time.Second); err != nil {
+			releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
+			_ = m.leaseController.Release(releaseCtx, nonce)
+			releaseCancel()
+			return err
+		}
+
+		m.mu.Lock()
+		m.active = true
+		m.activeVT = vt
+		m.leaseNonce = nonce
+		m.mu.Unlock()
+		log.Debug().Str("vt", vt).Msg("Main console lease acquired")
 		return nil
 	}
 
@@ -181,6 +208,7 @@ func (m *MiSTerConsoleManager) Open(ctx context.Context, vt string) error {
 			// Set console active flag
 			m.mu.Lock()
 			m.active = true
+			m.activeVT = vt
 			m.mu.Unlock()
 
 			return nil
@@ -207,22 +235,36 @@ func (m *MiSTerConsoleManager) Close() error {
 		return nil
 	}
 
+	m.mu.RLock()
+	activeVT := m.activeVT
+	leaseNonce := m.leaseNonce
+	m.mu.RUnlock()
+
 	// Restore console cursor state on both TTYs
 	if err := m.Restore(f9ConsoleVT); err != nil {
 		log.Debug().Err(err).Msg("failed to restore tty1 state")
 	}
-	if err := m.Restore(launcherConsoleVT); err != nil {
-		log.Debug().Err(err).Msgf("failed to restore tty%s state", launcherConsoleVT)
+	if activeVT != "" && activeVT != f9ConsoleVT {
+		if err := m.Restore(activeVT); err != nil {
+			log.Debug().Err(err).Msgf("failed to restore tty%s state", activeVT)
+		}
 	}
 
-	// Press F12 to return to FPGA framebuffer
-	if err := m.platform.KeyboardPress("{f12}"); err != nil {
+	if leaseNonce != "" {
+		releaseCtx, releaseCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		err := m.leaseController.Release(releaseCtx, leaseNonce)
+		releaseCancel()
+		if err != nil {
+			return fmt.Errorf("failed to release Main console lease: %w", err)
+		}
+	} else if err := m.platform.KeyboardPress("{f12}"); err != nil {
 		return fmt.Errorf("failed to press F12 key: %w", err)
 	}
 
-	// Clear console active flag
 	m.mu.Lock()
 	m.active = false
+	m.activeVT = ""
+	m.leaseNonce = ""
 	m.mu.Unlock()
 
 	log.Debug().Msg("console closed, returned to FPGA mode")

--- a/pkg/platforms/mister/console_manager_test.go
+++ b/pkg/platforms/mister/console_manager_test.go
@@ -65,6 +65,28 @@ func (m *mockCoreNameGetter) GetCoreName() string {
 	return m.coreName
 }
 
+type mockConsoleLeaseController struct {
+	acquireErr  error
+	releaseErr  error
+	acquiredVT  string
+	releasedKey string
+	available   bool
+}
+
+func (m *mockConsoleLeaseController) Available() bool {
+	return m.available
+}
+
+func (m *mockConsoleLeaseController) Acquire(_ context.Context, vt string) (string, error) {
+	m.acquiredVT = vt
+	return "test-nonce", m.acquireErr
+}
+
+func (m *mockConsoleLeaseController) Release(_ context.Context, nonce string) error {
+	m.releasedKey = nonce
+	return m.releaseErr
+}
+
 func TestMiSTerConsoleManager_Open_CancelledContext(t *testing.T) {
 	t.Parallel()
 
@@ -135,6 +157,41 @@ func TestMiSTerConsoleManager_Open_AlreadyActive(t *testing.T) {
 	cm.mu.RLock()
 	assert.True(t, cm.active)
 	cm.mu.RUnlock()
+}
+
+func TestMiSTerConsoleManager_Open_UsesMainConsoleLease(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.fbChecker = &mockFramebufferChecker{ready: true}
+
+	err := cm.Open(context.Background(), "3")
+	require.NoError(t, err)
+	assert.Equal(t, "3", lease.acquiredVT)
+	assert.Equal(t, "test-nonce", cm.leaseNonce)
+	assert.Equal(t, "3", cm.activeVT)
+	assert.True(t, cm.active)
+}
+
+func TestMiSTerConsoleManager_Close_ReleasesMainConsoleLease(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.active = true
+	cm.activeVT = "3"
+	cm.leaseNonce = "test-nonce"
+
+	// Avoid real TTY writes while testing lease release behavior.
+	cm.activeVT = ""
+	err := cm.Close()
+	require.NoError(t, err)
+	assert.Equal(t, "test-nonce", lease.releasedKey)
+	assert.False(t, cm.active)
+	assert.Empty(t, cm.leaseNonce)
 }
 
 func TestMiSTerConsoleManager_Open_ChvtAfterTty1Confirmed(t *testing.T) {
@@ -307,6 +364,7 @@ func TestNewConsoleManager_DefaultDependencies(t *testing.T) {
 	assert.NotNil(t, cm.ttyReader)
 	assert.NotNil(t, cm.fbChecker)
 	assert.NotNil(t, cm.coreNameGetter)
+	assert.NotNil(t, cm.leaseController)
 	assert.NotNil(t, cm.executor)
 
 	// Verify they're the real implementations

--- a/pkg/platforms/mister/console_manager_test.go
+++ b/pkg/platforms/mister/console_manager_test.go
@@ -294,6 +294,29 @@ func TestMiSTerConsoleManager_Close_ReleaseFailurePreservesRetryState(t *testing
 	assert.Equal(t, "test-nonce", lease.releasedKey)
 }
 
+func TestMiSTerConsoleManager_CleanAndRestoreUseHardwareBoundary(t *testing.T) {
+	t.Parallel()
+
+	hardware := &mockConsoleHardware{}
+	cm := newConsoleManager(&Platform{})
+	cm.hardware = hardware
+
+	require.NoError(t, cm.Clean("3"))
+	require.NoError(t, cm.Restore("3"))
+	assert.Equal(t, []string{"3"}, hardware.cleanedVTs)
+	assert.Equal(t, []string{"3"}, hardware.restoredVTs)
+}
+
+func TestMiSTerConsoleManager_CleanAndRestoreWrapHardwareErrors(t *testing.T) {
+	t.Parallel()
+
+	cm := newConsoleManager(&Platform{})
+	cm.hardware = &mockConsoleHardware{cleanErr: assert.AnError, restoreErr: assert.AnError}
+
+	require.ErrorIs(t, cm.Clean("3"), assert.AnError)
+	require.ErrorIs(t, cm.Restore("3"), assert.AnError)
+}
+
 func TestMiSTerConsoleManager_Open_ChvtAfterTty1Confirmed(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/console_manager_test.go
+++ b/pkg/platforms/mister/console_manager_test.go
@@ -66,15 +66,18 @@ func (m *mockCoreNameGetter) GetCoreName() string {
 }
 
 type mockConsoleLeaseController struct {
-	acquireErr  error
-	releaseErr  error
-	acquiredVT  string
-	releasedKey string
-	available   bool
+	acquireErr     error
+	releaseErr     error
+	acquiredVT     string
+	releasedKey    string
+	available      bool
+	availableAfter int
+	availableCalls int
 }
 
 func (m *mockConsoleLeaseController) Available() bool {
-	return m.available
+	m.availableCalls++
+	return m.available || (m.availableAfter > 0 && m.availableCalls >= m.availableAfter)
 }
 
 func (m *mockConsoleLeaseController) Acquire(_ context.Context, vt string) (string, error) {
@@ -190,6 +193,22 @@ func TestMiSTerConsoleManager_Open_UsesMainConsoleLease(t *testing.T) {
 	assert.Equal(t, "test-nonce", cm.leaseNonce)
 	assert.Equal(t, "3", cm.activeVT)
 	assert.True(t, cm.active)
+}
+
+func TestMiSTerConsoleManager_Open_UsesLeasePublishedAfterMenuTransition(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{availableAfter: 2}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.coreNameGetter = &mockCoreNameGetter{coreName: "GAMEBOY"}
+	cm.fbChecker = &mockFramebufferChecker{ready: true}
+
+	err := cm.Open(context.Background(), "3")
+	require.NoError(t, err)
+	assert.Equal(t, 2, lease.availableCalls)
+	assert.Equal(t, "3", lease.acquiredVT)
+	assert.Equal(t, "test-nonce", cm.leaseNonce)
 }
 
 func TestMiSTerConsoleManager_Open_LeaseFailure(t *testing.T) {

--- a/pkg/platforms/mister/console_manager_test.go
+++ b/pkg/platforms/mister/console_manager_test.go
@@ -87,6 +87,23 @@ func (m *mockConsoleLeaseController) Release(_ context.Context, nonce string) er
 	return m.releaseErr
 }
 
+type mockConsoleHardware struct {
+	cleanErr    error
+	restoreErr  error
+	cleanedVTs  []string
+	restoredVTs []string
+}
+
+func (m *mockConsoleHardware) Clean(vt string) error {
+	m.cleanedVTs = append(m.cleanedVTs, vt)
+	return m.cleanErr
+}
+
+func (m *mockConsoleHardware) Restore(vt string) error {
+	m.restoredVTs = append(m.restoredVTs, vt)
+	return m.restoreErr
+}
+
 func TestMiSTerConsoleManager_Open_CancelledContext(t *testing.T) {
 	t.Parallel()
 
@@ -175,23 +192,106 @@ func TestMiSTerConsoleManager_Open_UsesMainConsoleLease(t *testing.T) {
 	assert.True(t, cm.active)
 }
 
-func TestMiSTerConsoleManager_Close_ReleasesMainConsoleLease(t *testing.T) {
+func TestMiSTerConsoleManager_Open_LeaseFailure(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true, acquireErr: assert.AnError}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+
+	err := cm.Open(context.Background(), "3")
+	require.ErrorIs(t, err, assert.AnError)
+	assert.False(t, cm.active)
+	assert.Empty(t, cm.leaseNonce)
+	assert.Empty(t, lease.releasedKey)
+}
+
+func TestMiSTerConsoleManager_Open_LeaseContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true, acquireErr: context.Canceled}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+
+	err := cm.Open(context.Background(), "3")
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, cm.active)
+	assert.Empty(t, cm.leaseNonce)
+}
+
+func TestMiSTerConsoleManager_Open_FramebufferFailureReleasesLease(t *testing.T) {
 	t.Parallel()
 
 	lease := &mockConsoleLeaseController{available: true}
 	cm := newConsoleManager(&Platform{})
 	cm.leaseController = lease
+	cm.fbChecker = &mockFramebufferChecker{ready: false}
+	cm.framebufferWait = time.Millisecond
+
+	err := cm.Open(context.Background(), "3")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "framebuffer not ready")
+	assert.Equal(t, "test-nonce", lease.releasedKey)
+	assert.False(t, cm.active)
+	assert.Empty(t, cm.leaseNonce)
+}
+
+func TestMiSTerConsoleManager_Open_FramebufferAndReleaseFailurePreservesLease(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true, releaseErr: assert.AnError}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.fbChecker = &mockFramebufferChecker{ready: false}
+	cm.framebufferWait = time.Millisecond
+
+	err := cm.Open(context.Background(), "3")
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "framebuffer not ready")
+	assert.True(t, cm.active)
+	assert.Equal(t, "3", cm.activeVT)
+	assert.Equal(t, "test-nonce", cm.leaseNonce)
+	assert.Equal(t, "test-nonce", lease.releasedKey)
+}
+
+func TestMiSTerConsoleManager_Close_ReleasesMainConsoleLease(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true}
+	hardware := &mockConsoleHardware{}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.hardware = hardware
 	cm.active = true
 	cm.activeVT = "3"
 	cm.leaseNonce = "test-nonce"
 
-	// Avoid real TTY writes while testing lease release behavior.
-	cm.activeVT = ""
 	err := cm.Close()
 	require.NoError(t, err)
+	assert.Equal(t, []string{"1", "3"}, hardware.restoredVTs)
 	assert.Equal(t, "test-nonce", lease.releasedKey)
 	assert.False(t, cm.active)
+	assert.Empty(t, cm.activeVT)
 	assert.Empty(t, cm.leaseNonce)
+}
+
+func TestMiSTerConsoleManager_Close_ReleaseFailurePreservesRetryState(t *testing.T) {
+	t.Parallel()
+
+	lease := &mockConsoleLeaseController{available: true, releaseErr: assert.AnError}
+	cm := newConsoleManager(&Platform{})
+	cm.leaseController = lease
+	cm.hardware = &mockConsoleHardware{}
+	cm.active = true
+	cm.activeVT = "3"
+	cm.leaseNonce = "test-nonce"
+
+	err := cm.Close()
+	require.ErrorIs(t, err, assert.AnError)
+	assert.True(t, cm.active)
+	assert.Equal(t, "3", cm.activeVT)
+	assert.Equal(t, "test-nonce", cm.leaseNonce)
+	assert.Equal(t, "test-nonce", lease.releasedKey)
 }
 
 func TestMiSTerConsoleManager_Open_ChvtAfterTty1Confirmed(t *testing.T) {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	f9ConsoleVT       = "1"
-	launcherConsoleVT = "7"
-	scriptConsoleVT   = "3"
+	f9ConsoleVT     = "1"
+	armLauncherVT   = "3"
+	scriptConsoleVT = "2"
 )
 
 var mglIndexingSkippedLaunchers = map[string]struct{}{
@@ -746,7 +746,7 @@ func launchVideo(pl *Platform) func(*config.Instance, string, *platforms.LaunchO
 		cmd := buildFvpCommand(launcherCtx, path)
 
 		// Build cleanup function that will be called on completion/crash
-		restoreFunc := createConsoleRestoreFunc(pl, cm)
+		restoreFunc := createConsoleRestoreFunc(cm)
 
 		// Start process and manage lifecycle
 		return runTrackedProcess(pl, cmd, restoreFunc, "fvp")
@@ -830,7 +830,7 @@ func launchScummVM(pl *Platform) func(*config.Instance, string, *platforms.Launc
 		cmd := buildScummVMCommand(launcherCtx, scummvmBinary, targetID)
 
 		// Build cleanup function that will be called on completion/crash
-		restoreFunc := createConsoleRestoreFunc(pl, cm)
+		restoreFunc := createConsoleRestoreFunc(cm)
 
 		// Wrap restore to also stop MIDI if we started it
 		restoreWithMIDI := func() {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
@@ -28,9 +27,10 @@ import (
 )
 
 const (
-	f9ConsoleVT     = "1"
-	armLauncherVT   = "3"
-	scriptConsoleVT = "2"
+	f9ConsoleVT       = "1"
+	armLauncherVT     = "3"
+	scriptConsoleVT   = "2"
+	frontendConsoleVT = "7"
 )
 
 var mglIndexingSkippedLaunchers = map[string]struct{}{
@@ -765,6 +765,7 @@ func buildScummVMCommand(ctx context.Context, scummvmBinary, targetID string) *e
 	)
 
 	// Set environment variables
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Env = append(os.Environ(),
 		"HOME="+scummvmBaseDir,
 		"LD_LIBRARY_PATH="+filepath.Join(scummvmBaseDir, "arm-linux-gnueabihf")+":"+
@@ -855,42 +856,13 @@ func createScummVMLauncher(pl *Platform) platforms.Launcher {
 		Lifecycle:          platforms.LifecycleTracked,
 		Scanner:            scanScummVMGames,
 		Launch:             launchScummVM(pl),
-		// Kill uses keyboard input instead of signals to avoid VT lock issues.
-		// ScummVM's VT management doesn't handle SIGKILL properly and causes
-		// kernel-level VT locks requiring a reboot. Ctrl+q triggers clean exit.
-		// This function blocks until ScummVM exits (up to 5 seconds) to prevent
-		// new launches from starting during VT cleanup.
+		// ScummVM needs a keyboard-triggered graceful exit to avoid VT locks.
+		// Shared process lifecycle code owns waiting and timeout escalation.
 		Kill: func(_ *config.Instance) error {
-			// Send Ctrl+q to trigger ScummVM's clean exit
 			if err := pl.KeyboardPress("{ctrl+q}"); err != nil {
 				return fmt.Errorf("failed to send ctrl+q: %w", err)
 			}
-
-			// Wait for process to exit cleanly (up to 5 seconds)
-			pl.processMu.Lock()
-			proc := pl.trackedProcess
-			pl.processMu.Unlock()
-
-			if proc == nil {
-				// No tracked process, nothing to wait for
-				return nil
-			}
-
-			// Wait for process exit with timeout
-			done := make(chan error, 1)
-			go func() {
-				_, err := proc.Wait()
-				done <- err
-			}()
-
-			select {
-			case <-done:
-				log.Debug().Msg("ScummVM exited cleanly after ctrl+q")
-				return nil
-			case <-time.After(5 * time.Second):
-				log.Warn().Msg("ScummVM did not exit within 5 seconds")
-				return errors.New("timeout waiting for ScummVM to exit")
-			}
+			return nil
 		},
 	}
 }

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -821,7 +821,9 @@ func buildScummVMCommand(ctx context.Context, scummvmBinary, targetID string) *e
 	)
 
 	// ScummVM's SDL VT backend requires the inherited session. Unlike FVP,
-	// starting it in a new session causes an immediate SIGHUP on MiSTer.
+	// starting it in a new session causes an immediate SIGHUP on MiSTer. A
+	// separate process group preserves that session while allowing descendant cleanup.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Env = append(os.Environ(),
 		"HOME="+scummvmBaseDir,
 		"LD_LIBRARY_PATH="+filepath.Join(scummvmBaseDir, "arm-linux-gnueabihf")+":"+

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -27,11 +27,19 @@ import (
 )
 
 const (
-	f9ConsoleVT       = "1"
-	armLauncherVT     = "3"
-	scriptConsoleVT   = "2"
-	frontendConsoleVT = "7"
+	f9ConsoleVT             = "1"
+	armLauncherVT           = "3"
+	scriptConsoleVT         = "2"
+	frontendConsoleVT       = "7"
+	videoRenderScale        = 33
+	scummVMRenderResolution = "640x480"
 )
+
+type framebufferMode struct {
+	width   int
+	height  int
+	divisor int
+}
 
 var mglIndexingSkippedLaunchers = map[string]struct{}{
 	"GenericVideo": {},
@@ -690,6 +698,59 @@ func launchAtari2600AltCore(
 	}
 }
 
+func resolveFramebufferMode(
+	opts *platforms.LaunchOptions,
+	defaultScale int,
+	defaultResolution string,
+) (framebufferMode, error) {
+	var renderScale *int
+	renderResolution := ""
+	if opts != nil {
+		renderScale = opts.RenderScale
+		renderResolution = opts.RenderResolution
+	}
+	if renderScale != nil && renderResolution != "" {
+		return framebufferMode{}, errors.New("render_scale and render_resolution are mutually exclusive")
+	}
+	if renderScale == nil && renderResolution == "" {
+		if defaultScale > 0 {
+			renderScale = &defaultScale
+		} else {
+			renderResolution = defaultResolution
+		}
+	}
+
+	if renderScale != nil {
+		divisors := map[int]int{100: 1, 50: 2, 33: 3, 25: 4}
+		divisor, ok := divisors[*renderScale]
+		if !ok {
+			return framebufferMode{}, fmt.Errorf(
+				"unsupported MiSTer render_scale %d: use 25, 33, 50, or 100", *renderScale,
+			)
+		}
+		return framebufferMode{divisor: divisor}, nil
+	}
+
+	width, height, err := config.ValidateRenderResolution(renderResolution)
+	if err != nil {
+		return framebufferMode{}, fmt.Errorf("validate MiSTer render_resolution: %w", err)
+	}
+	return framebufferMode{width: width, height: height}, nil
+}
+
+func applyFramebufferMode(mode framebufferMode, format string) error {
+	if mode.divisor > 0 {
+		if err := mistermain.SetFramebufferScaled(mode.divisor, format); err != nil {
+			return fmt.Errorf("set scaled framebuffer: %w", err)
+		}
+		return nil
+	}
+	if err := mistermain.SetFramebufferExact(mode.width, mode.height, format); err != nil {
+		return fmt.Errorf("set exact framebuffer: %w", err)
+	}
+	return nil
+}
+
 // buildFvpCommand constructs the command for launching fvp video player.
 func buildFvpCommand(ctx context.Context, path string) *exec.Cmd {
 	fvpBinary := filepath.Join(misterconfig.LinuxDir, "fvp")
@@ -710,21 +771,17 @@ func buildFvpCommand(ctx context.Context, path string) *exec.Cmd {
 }
 
 func launchVideo(pl *Platform) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-	return func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
-		// videoDivisor controls the framebuffer resolution divisor for video playback.
-		// Using fb_cmd0 (scaled mode):
-		//   - divisor 3: ~640x360 on 1920x1080, ~853x480 on 2560x1440
-		//   - Scales to fill entire screen (no borders)
-		const videoDivisor = 3
-
+	return func(_ *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		if path == "" {
 			return nil, errors.New("no path specified")
 		}
 
-		log.Info().
-			Int("divisor", videoDivisor).
-			Str("path", path).
-			Msg("video playback starting")
+		framebuffer, err := resolveFramebufferMode(opts, videoRenderScale, "")
+		if err != nil {
+			return nil, fmt.Errorf("resolve video render size: %w", err)
+		}
+
+		log.Info().Str("path", path).Msg("video playback starting")
 
 		// Capture launcher context for staleness detection and cancellation
 		launcherCtx := pl.launcherManager.GetContext()
@@ -735,10 +792,9 @@ func launchVideo(pl *Platform) func(*config.Instance, string, *platforms.LaunchO
 			return nil, err
 		}
 
-		// Set scaled video mode for video playback
-		if modeErr := mistermain.SetVideoModeScaled(videoDivisor); modeErr != nil {
-			return nil, fmt.Errorf("failed to set scaled video mode (divisor %d): %w",
-				videoDivisor, modeErr)
+		if modeErr := applyFramebufferMode(framebuffer, mistermain.VideoModeFormatRGB32); modeErr != nil {
+			_ = cm.Close()
+			return nil, fmt.Errorf("failed to set video render size: %w", modeErr)
 		}
 
 		log.Info().Str("path", path).Msg("launching video with fvp")
@@ -780,7 +836,7 @@ func buildScummVMCommand(ctx context.Context, scummvmBinary, targetID string) *e
 
 // launchScummVM returns a launcher function for ScummVM games on MiSTer.
 func launchScummVM(pl *Platform) func(*config.Instance, string, *platforms.LaunchOptions) (*os.Process, error) {
-	return func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+	return func(_ *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
 		if path == "" {
 			return nil, errors.New("no path specified")
 		}
@@ -793,6 +849,11 @@ func launchScummVM(pl *Platform) func(*config.Instance, string, *platforms.Launc
 
 		if targetID == "" {
 			return nil, errors.New("no ScummVM target ID specified in path")
+		}
+
+		framebuffer, err := resolveFramebufferMode(opts, 0, scummVMRenderResolution)
+		if err != nil {
+			return nil, fmt.Errorf("resolve ScummVM render size: %w", err)
 		}
 
 		log.Info().Str("target", targetID).Msg("ScummVM game launching")
@@ -812,10 +873,9 @@ func launchScummVM(pl *Platform) func(*config.Instance, string, *platforms.Launc
 			return nil, err
 		}
 
-		// Set video mode for ScummVM (640x480 RGB16)
-		// Matches original MiSTer_ScummVM: vmode -r 640 480 rgb16
-		if err := mistermain.SetVideoModeExact(640, 480, mistermain.VideoModeFormatRGB16); err != nil {
-			return nil, fmt.Errorf("failed to set video mode: %w", err)
+		if modeErr := applyFramebufferMode(framebuffer, mistermain.VideoModeFormatRGB16); modeErr != nil {
+			_ = cm.Close()
+			return nil, fmt.Errorf("failed to set ScummVM render size: %w", modeErr)
 		}
 
 		// Start MIDIMeister if available

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -764,8 +764,8 @@ func buildScummVMCommand(ctx context.Context, scummvmBinary, targetID string) *e
 		targetID,
 	)
 
-	// Set environment variables
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// ScummVM's SDL VT backend requires the inherited session. Unlike FVP,
+	// starting it in a new session causes an immediate SIGHUP on MiSTer.
 	cmd.Env = append(os.Environ(),
 		"HOME="+scummvmBaseDir,
 		"LD_LIBRARY_PATH="+filepath.Join(scummvmBaseDir, "arm-linux-gnueabihf")+":"+

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -846,6 +846,15 @@ func launchScummVM(pl *Platform) func(*config.Instance, string, *platforms.Launc
 	}
 }
 
+func scummVMKill(keyboardPress func(string) error) func(*config.Instance) error {
+	return func(_ *config.Instance) error {
+		if err := keyboardPress("{ctrl+q}"); err != nil {
+			return fmt.Errorf("failed to send ctrl+q: %w", err)
+		}
+		return nil
+	}
+}
+
 // createScummVMLauncher creates a Launcher definition for ScummVM games.
 func createScummVMLauncher(pl *Platform) platforms.Launcher {
 	return platforms.Launcher{
@@ -858,12 +867,7 @@ func createScummVMLauncher(pl *Platform) platforms.Launcher {
 		Launch:             launchScummVM(pl),
 		// ScummVM needs a keyboard-triggered graceful exit to avoid VT locks.
 		// Shared process lifecycle code owns waiting and timeout escalation.
-		Kill: func(_ *config.Instance) error {
-			if err := pl.KeyboardPress("{ctrl+q}"); err != nil {
-				return fmt.Errorf("failed to send ctrl+q: %w", err)
-			}
-			return nil
-		},
+		Kill: scummVMKill(pl.KeyboardPress),
 	}
 }
 

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -28,7 +28,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
@@ -366,6 +368,36 @@ func TestBuildFvpCommand_DifferentPaths(t *testing.T) {
 			assert.Contains(t, cmd.Args, tt.path, "path should be in args")
 		})
 	}
+}
+
+func TestScummVMKill_SendsCtrlQWithoutWaiting(t *testing.T) {
+	t.Parallel()
+
+	pressed := make(chan string, 1)
+	kill := scummVMKill(func(keys string) error {
+		pressed <- keys
+		return nil
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- kill(&config.Instance{}) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("ScummVM Kill waited for process termination")
+	}
+	assert.Equal(t, "{ctrl+q}", <-pressed)
+}
+
+func TestScummVMKill_PropagatesKeyboardError(t *testing.T) {
+	t.Parallel()
+
+	kill := scummVMKill(func(string) error { return assert.AnError })
+	err := kill(&config.Instance{})
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "failed to send ctrl+q")
 }
 
 func TestBuildScummVMCommand(t *testing.T) {

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -472,9 +472,11 @@ func TestBuildScummVMCommand(t *testing.T) {
 	assert.Contains(t, cmd.Args, "--opl-driver=db")
 	assert.Contains(t, cmd.Args, "--output-rate=48000")
 
-	// Verify working directory and inherited session required by SDL VT handling.
+	// Verify process-group tracking without creating a new session.
 	assert.Equal(t, scummvmBaseDir, cmd.Dir)
-	assert.Nil(t, cmd.SysProcAttr)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setpgid)
+	assert.False(t, cmd.SysProcAttr.Setsid)
 
 	// Verify environment variables - check that our custom ones are set
 	hasCustomHome := false

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
@@ -379,16 +378,15 @@ func TestScummVMKill_SendsCtrlQWithoutWaiting(t *testing.T) {
 		return nil
 	})
 
-	done := make(chan error, 1)
-	go func() { done <- kill(&config.Instance{}) }()
+	err := kill(&config.Instance{})
+	require.NoError(t, err)
 
 	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("ScummVM Kill waited for process termination")
+	case keys := <-pressed:
+		assert.Equal(t, "{ctrl+q}", keys)
+	default:
+		t.Fatal("ScummVM Kill did not send ctrl+q")
 	}
-	assert.Equal(t, "{ctrl+q}", <-pressed)
 }
 
 func TestScummVMKill_PropagatesKeyboardError(t *testing.T) {
@@ -421,10 +419,9 @@ func TestBuildScummVMCommand(t *testing.T) {
 	assert.Contains(t, cmd.Args, "--opl-driver=db")
 	assert.Contains(t, cmd.Args, "--output-rate=48000")
 
-	// Verify working directory and isolated process group.
+	// Verify working directory and inherited session required by SDL VT handling.
 	assert.Equal(t, scummvmBaseDir, cmd.Dir)
-	require.NotNil(t, cmd.SysProcAttr)
-	assert.True(t, cmd.SysProcAttr.Setsid)
+	assert.Nil(t, cmd.SysProcAttr)
 
 	// Verify environment variables - check that our custom ones are set
 	hasCustomHome := false

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -389,8 +389,10 @@ func TestBuildScummVMCommand(t *testing.T) {
 	assert.Contains(t, cmd.Args, "--opl-driver=db")
 	assert.Contains(t, cmd.Args, "--output-rate=48000")
 
-	// Verify working directory
+	// Verify working directory and isolated process group.
 	assert.Equal(t, scummvmBaseDir, cmd.Dir)
+	require.NotNil(t, cmd.SysProcAttr)
+	assert.True(t, cmd.SysProcAttr.Setsid)
 
 	// Verify environment variables - check that our custom ones are set
 	hasCustomHome := false

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -308,6 +308,59 @@ func TestLaunchScummVM_InvalidPath_NoTargetID(t *testing.T) {
 	}
 }
 
+func TestResolveFramebufferMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		renderResolution  string
+		defaultResolution string
+		renderScale       int
+		defaultScale      int
+		expect            framebufferMode
+		expectError       bool
+	}{
+		{name: "video default", defaultScale: 33, expect: framebufferMode{divisor: 3}},
+		{name: "ScummVM default", defaultResolution: "640x480", expect: framebufferMode{width: 640, height: 480}},
+		{name: "half scale", renderScale: 50, expect: framebufferMode{divisor: 2}},
+		{name: "exact override", renderResolution: "800x600", expect: framebufferMode{width: 800, height: 600}},
+		{name: "unsupported scale", renderScale: 75, expectError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var opts *platforms.LaunchOptions
+			if tt.renderScale != 0 || tt.renderResolution != "" {
+				opts = &platforms.LaunchOptions{RenderResolution: tt.renderResolution}
+				if tt.renderScale != 0 {
+					renderScale := tt.renderScale
+					opts.RenderScale = &renderScale
+				}
+			}
+			mode, err := resolveFramebufferMode(opts, tt.defaultScale, tt.defaultResolution)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expect, mode)
+		})
+	}
+}
+
+func TestResolveFramebufferMode_RejectsConflictingOptions(t *testing.T) {
+	t.Parallel()
+
+	renderScale := 50
+	_, err := resolveFramebufferMode(&platforms.LaunchOptions{
+		RenderScale:      &renderScale,
+		RenderResolution: "640x480",
+	}, videoRenderScale, "")
+	require.Error(t, err)
+}
+
 func TestBuildFvpCommand(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/mistermain/vmode.go
+++ b/pkg/platforms/mister/mistermain/vmode.go
@@ -24,6 +24,7 @@ package mistermain
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 )
@@ -43,15 +44,30 @@ const (
 //   - Integer-scales to fit display
 //   - Centers with borders
 
-// SetVideoModeScaled sets a scaled video mode that fills the entire screen.
-// divisor controls resolution: 1=full, 2=half, 3=third, 4=quarter
-func SetVideoModeScaled(divisor int) error {
+func parseFramebufferFormat(format string) (pixelFormat string, rb int, err error) {
+	if len(format) < 2 {
+		return "", 0, fmt.Errorf("invalid framebuffer format %q", format)
+	}
+	rb, err = strconv.Atoi(format[:1])
+	if err != nil || (rb != 0 && rb != 1) {
+		return "", 0, fmt.Errorf("invalid framebuffer format %q", format)
+	}
+	return format[1:], rb, nil
+}
+
+// SetFramebufferScaled sets a framebuffer size relative to current display output.
+// divisor controls size: 1=full, 2=half, 3=third, 4=quarter.
+func SetFramebufferScaled(divisor int, format string) error {
 	if divisor < 1 || divisor > 4 {
 		return fmt.Errorf("divisor must be 1-4, got %d", divisor)
 	}
+	pixelFormat, rb, err := parseFramebufferFormat(format)
+	if err != nil {
+		return fmt.Errorf("parse scaled framebuffer format: %w", err)
+	}
 
-	if _, err := os.Stat(misterconfig.CmdInterface); err != nil {
-		return fmt.Errorf("command interface not accessible: %w", err)
+	if _, statErr := os.Stat(misterconfig.CmdInterface); statErr != nil {
+		return fmt.Errorf("command interface not accessible: %w", statErr)
 	}
 
 	cmd, err := os.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
@@ -65,8 +81,8 @@ func SetVideoModeScaled(divisor int) error {
 	// fb_cmd0 format: "fb_cmd0 format rb divisor"
 	cmdStr := fmt.Sprintf(
 		"fb_cmd0 %s %d %d",
-		VideoModeFormatRGB32[1:], // "8888"
-		VideoModeFormatRGB32[0],  // Rune '1' as int (49)
+		pixelFormat,
+		rb,
 		divisor,
 	)
 
@@ -78,15 +94,18 @@ func SetVideoModeScaled(divisor int) error {
 	return nil
 }
 
-// SetVideoModeExact sets an exact video mode with specific width and height.
-// The framebuffer is created at the exact dimensions and integer-scaled to fit the display.
-func SetVideoModeExact(width, height int, format string) error {
+// SetFramebufferExact sets exact framebuffer dimensions, integer-scaled to fit display output.
+func SetFramebufferExact(width, height int, format string) error {
 	if width < 1 || height < 1 {
 		return fmt.Errorf("width and height must be positive, got %dx%d", width, height)
 	}
+	pixelFormat, rb, err := parseFramebufferFormat(format)
+	if err != nil {
+		return fmt.Errorf("parse exact framebuffer format: %w", err)
+	}
 
-	if _, err := os.Stat(misterconfig.CmdInterface); err != nil {
-		return fmt.Errorf("command interface not accessible: %w", err)
+	if _, statErr := os.Stat(misterconfig.CmdInterface); statErr != nil {
+		return fmt.Errorf("command interface not accessible: %w", statErr)
 	}
 
 	cmd, err := os.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
@@ -102,8 +121,8 @@ func SetVideoModeExact(width, height int, format string) error {
 	// rb is '1' for RGBA order
 	cmdStr := fmt.Sprintf(
 		"fb_cmd1 %s %d %d %d",
-		format[1:], // "8888"
-		format[0],  // Rune '1' as int (49)
+		pixelFormat,
+		rb,
 		width,
 		height,
 	)

--- a/pkg/platforms/mister/mistermain/vmode_test.go
+++ b/pkg/platforms/mister/mistermain/vmode_test.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package mistermain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFramebufferFormat(t *testing.T) {
+	t.Parallel()
+
+	pixelFormat, rb, err := parseFramebufferFormat(VideoModeFormatRGB16)
+	require.NoError(t, err)
+	assert.Equal(t, "565", pixelFormat)
+	assert.Equal(t, 1, rb)
+}
+
+func TestParseFramebufferFormatRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := parseFramebufferFormat("rgb16")
+	require.Error(t, err)
+}

--- a/pkg/platforms/mister/mistermain/vmode_test.go
+++ b/pkg/platforms/mister/mistermain/vmode_test.go
@@ -12,15 +12,31 @@ import (
 func TestParseFramebufferFormat(t *testing.T) {
 	t.Parallel()
 
-	pixelFormat, rb, err := parseFramebufferFormat(VideoModeFormatRGB16)
-	require.NoError(t, err)
-	assert.Equal(t, "565", pixelFormat)
-	assert.Equal(t, 1, rb)
-}
+	tests := []struct {
+		name        string
+		input       string
+		wantFormat  string
+		wantRB      int
+		expectError bool
+	}{
+		{name: "rb disabled", input: "08888", wantFormat: "8888", wantRB: 0},
+		{name: "rb enabled", input: VideoModeFormatRGB16, wantFormat: "565", wantRB: 1},
+		{name: "too short", input: "1", expectError: true},
+		{name: "invalid rb", input: "28888", expectError: true},
+	}
 
-func TestParseFramebufferFormatRejectsInvalidValue(t *testing.T) {
-	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, _, err := parseFramebufferFormat("rgb16")
-	require.Error(t, err)
+			pixelFormat, rb, err := parseFramebufferFormat(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFormat, pixelFormat)
+			assert.Equal(t, tt.wantRB, rb)
+		})
+	}
 }

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -239,27 +239,9 @@ func (p *Platform) StartPre(cfg *config.Instance) error {
 	p.stopMappingsWatcher = closeMappingsWatcher
 	p.platformMu.Unlock()
 
-	go p.deferredStartPre()
-
 	log.Info().Int64("duration_ms", time.Since(startPreStart).Milliseconds()).
 		Msg("StartPre finished")
 	return nil
-}
-
-// deferredStartPre runs the StartPre work that does not need to complete
-// before the JSON-RPC API binds: only the picker directory bootstrap.
-// Runs once per process; failures are logged and tolerated. The initial
-// CSV mappings load and the mappings watcher both start synchronously
-// in StartPre so LookupMapping never sees nil maps and Stop() can never
-// race the watcher's stopper assignment.
-func (*Platform) deferredStartPre() {
-	if misterconfig.MainHasFeature(misterconfig.MainFeaturePicker) {
-		if err := os.MkdirAll(misterconfig.MainPickerDir, 0o750); err != nil {
-			log.Error().Err(err).Msg("failed to create picker directory")
-		} else if err := os.WriteFile(misterconfig.MainPickerSelected, []byte(""), 0o600); err != nil {
-			log.Error().Err(err).Msg("failed to write picker selected file")
-		}
-	}
 }
 
 var configureTLSDefaults = tlsroots.ConfigureDefaults
@@ -617,9 +599,9 @@ func (p *Platform) ReturnToMenu() error {
 	if err := p.consoleManager.Restore(f9ConsoleVT); err != nil {
 		log.Warn().Err(err).Msg("failed to restore tty1 cursor")
 	}
-	if launcherConsoleVT != f9ConsoleVT {
-		if err := p.consoleManager.Restore(launcherConsoleVT); err != nil {
-			log.Warn().Err(err).Msgf("failed to restore tty%s cursor", launcherConsoleVT)
+	if armLauncherVT != f9ConsoleVT {
+		if err := p.consoleManager.Restore(armLauncherVT); err != nil {
+			log.Warn().Err(err).Msgf("failed to restore tty%s cursor", armLauncherVT)
 		}
 	}
 
@@ -1395,8 +1377,7 @@ func (p *Platform) ShowNotice(
 	args widgetmodels.NoticeArgs,
 ) (func() error, time.Duration, error) {
 	p.platformMu.Lock()
-	needsDelay := time.Since(p.lastUIHidden) < 2*time.Second &&
-		!misterconfig.MainHasFeature(misterconfig.MainFeatureNotice)
+	needsDelay := time.Since(p.lastUIHidden) < 2*time.Second
 	p.platformMu.Unlock()
 
 	if needsDelay {
@@ -1422,8 +1403,7 @@ func (p *Platform) ShowLoader(
 	args widgetmodels.NoticeArgs,
 ) (func() error, error) {
 	p.platformMu.Lock()
-	needsDelay := time.Since(p.lastUIHidden) < 2*time.Second &&
-		!misterconfig.MainHasFeature(misterconfig.MainFeatureNotice)
+	needsDelay := time.Since(p.lastUIHidden) < 2*time.Second
 	p.platformMu.Unlock()
 
 	if needsDelay {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -640,6 +640,13 @@ func (p *Platform) StopActiveLauncher(intent platforms.StopIntent) error {
 }
 
 func (p *Platform) ReturnToMenu() error {
+	p.processMu.Lock()
+	hasTrackedProcess := p.trackedProcess != nil
+	p.processMu.Unlock()
+	if hasTrackedProcess {
+		return p.StopActiveLauncher(platforms.StopForMenu)
+	}
+
 	// Restore console cursor state on both TTYs
 	if err := p.consoleManager.Restore(f9ConsoleVT); err != nil {
 		log.Warn().Err(err).Msg("failed to restore tty1 cursor")

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -91,6 +92,7 @@ type arcadeCardLaunchCache struct {
 type Platform struct {
 	shared.LinuxInput
 	ctx                 context.Context
+	fs                  afero.Fs
 	dbLoadTime          time.Time
 	lastUIHidden        time.Time
 	launcherManager     platforms.LauncherContextManager
@@ -111,6 +113,7 @@ type Platform struct {
 	lastLauncher        platforms.Launcher
 	arcadeCardLaunch    arcadeCardLaunchCache
 	stopIntent          platforms.StopIntent
+	trackedProcessGroup bool
 	processMu           syncutil.RWMutex
 	platformMu          syncutil.Mutex
 }
@@ -118,6 +121,7 @@ type Platform struct {
 func NewPlatform() *Platform {
 	p := &Platform{
 		platformMu:      syncutil.Mutex{},
+		fs:              afero.NewOsFs(),
 		launchShortCore: mgls.LaunchShortCore,
 	}
 	p.consoleManager = newConsoleManager(p)
@@ -393,23 +397,32 @@ func (p *Platform) Stop() error {
 func (p *Platform) SetTrackedProcess(proc *os.Process) {
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
+	if p.trackedProcess != proc {
+		p.processDone = nil
+		p.trackedProcessGroup = false
+	}
 	p.trackedProcess = proc
 }
 
-// setTrackedProcessWithCleanup sets the tracked process and its cleanup completion channel
-func (p *Platform) setTrackedProcessWithCleanup(proc *os.Process, done chan struct{}) {
+// setTrackedProcessWithCleanup sets tracked process lifecycle state.
+func (p *Platform) setTrackedProcessWithCleanup(proc *os.Process, done chan struct{}, processGroup bool) {
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
 	p.trackedProcess = proc
 	p.processDone = done
+	p.trackedProcessGroup = processGroup
 }
 
-// clearTrackedProcess clears both the tracked process and its cleanup channel
-func (p *Platform) clearTrackedProcess() {
+// clearTrackedProcess clears lifecycle state when proc is still current.
+func (p *Platform) clearTrackedProcess(proc *os.Process) {
 	p.processMu.Lock()
 	defer p.processMu.Unlock()
+	if p.trackedProcess != proc {
+		return
+	}
 	p.trackedProcess = nil
 	p.processDone = nil
+	p.trackedProcessGroup = false
 }
 
 func (p *Platform) ScanHook(token *tokens.Token) error {
@@ -445,6 +458,13 @@ func (*Platform) RootDirs(cfg *config.Instance) []string {
 	return misterconfig.RootDirs(cfg)
 }
 
+func (p *Platform) filesystem() afero.Fs {
+	if p.fs != nil {
+		return p.fs
+	}
+	return afero.NewOsFs()
+}
+
 func (*Platform) Settings() platforms.Settings {
 	return platforms.Settings{
 		DataDir:    misterconfig.DataDir,
@@ -455,28 +475,130 @@ func (*Platform) Settings() platforms.Settings {
 	}
 }
 
+func signalTrackedProcess(proc *os.Process, processGroup bool, signal syscall.Signal) error {
+	if processGroup {
+		if err := syscall.Kill(-proc.Pid, signal); err != nil {
+			return fmt.Errorf("signal process group: %w", err)
+		}
+		return nil
+	}
+	if err := proc.Signal(signal); err != nil {
+		return fmt.Errorf("signal process: %w", err)
+	}
+	return nil
+}
+
+func trackedProcessGroupAlive(proc *os.Process, processGroup bool) bool {
+	if !processGroup {
+		return false
+	}
+	return !errors.Is(syscall.Kill(-proc.Pid, 0), syscall.ESRCH)
+}
+
+func killRemainingProcessGroup(proc *os.Process, processGroup bool) {
+	if !trackedProcessGroupAlive(proc, processGroup) {
+		return
+	}
+
+	log.Warn().Msg("tracked process group still alive after leader exit, sending SIGKILL")
+	if err := signalTrackedProcess(proc, true, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		log.Warn().Err(err).Msg("failed to SIGKILL remaining process group")
+		return
+	}
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for trackedProcessGroupAlive(proc, true) && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForTrackedProcess(proc *os.Process, done chan struct{}) chan struct{} {
+	if done != nil {
+		return done
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		_, _ = proc.Wait()
+		close(waitDone)
+	}()
+	return waitDone
+}
+
+func stopTrackedProcess(proc *os.Process, done chan struct{}, processGroup bool, gracefulStop func() error) {
+	const (
+		gracefulTimeout = 5 * time.Second
+		termTimeout     = 2 * time.Second
+		killTimeout     = 500 * time.Millisecond
+	)
+
+	waitDone := waitForTrackedProcess(proc, done)
+	gracefulSent := false
+	if gracefulStop != nil {
+		log.Debug().Msg("using custom Kill function for launcher")
+		if err := gracefulStop(); err != nil {
+			log.Warn().Err(err).Msg("custom Kill function failed, falling back to SIGTERM")
+		} else {
+			gracefulSent = true
+		}
+	}
+	if !gracefulSent {
+		log.Debug().Msg("sending SIGTERM to tracked process")
+		if err := signalTrackedProcess(proc, processGroup, syscall.SIGTERM); err != nil &&
+			!errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+			log.Warn().Err(err).Msg("failed to SIGTERM tracked process")
+		}
+	}
+
+	stopped := false
+	select {
+	case <-waitDone:
+		stopped = true
+		log.Debug().Msg("tracked process cleanup completed")
+	case <-time.After(gracefulTimeout):
+	}
+
+	if !stopped && gracefulSent {
+		log.Warn().Msg("custom graceful stop timed out, sending SIGTERM")
+		if err := signalTrackedProcess(proc, processGroup, syscall.SIGTERM); err != nil &&
+			!errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+			log.Warn().Err(err).Msg("failed to SIGTERM tracked process")
+		}
+		select {
+		case <-waitDone:
+			stopped = true
+			log.Debug().Msg("tracked process cleanup completed after SIGTERM")
+		case <-time.After(termTimeout):
+		}
+	}
+
+	if !stopped {
+		log.Warn().Msg("tracked process stop timed out, sending SIGKILL")
+		if err := signalTrackedProcess(proc, processGroup, syscall.SIGKILL); err != nil &&
+			!errors.Is(err, os.ErrProcessDone) && !errors.Is(err, syscall.ESRCH) {
+			log.Warn().Err(err).Msg("failed to SIGKILL tracked process")
+		}
+		select {
+		case <-waitDone:
+			log.Debug().Msg("tracked process cleanup completed after SIGKILL")
+		case <-time.After(killTimeout):
+			log.Warn().Msg("tracked process cleanup timed out after SIGKILL")
+		}
+	}
+
+	killRemainingProcessGroup(proc, processGroup)
+}
+
 func (p *Platform) StopActiveLauncher(intent platforms.StopIntent) error {
-	// Store intent before cancelling context so cleanup goroutine can read it
 	p.processMu.Lock()
 	p.stopIntent = intent
+	proc := p.trackedProcess
+	done := p.processDone
+	processGroup := p.trackedProcessGroup
 	p.processMu.Unlock()
 
-	// Check if we have a tracked process before attempting to stop it
-	p.processMu.Lock()
-	hadTrackedProcess := p.trackedProcess != nil
-	p.processMu.Unlock()
-
-	// Invalidate old launcher context ONLY for preemption (new launcher starting)
-	// EXCEPT for console launchers which need cleanup goroutine to run
-	// For StopForMenu and StopForConsoleReset, we need cleanup to run to unlock VT
-	cancelContextNow := intent == platforms.StopForPreemption && !hadTrackedProcess
-
-	// Console launchers (video/ScummVM): delay context cancellation until after cleanup
-
-	if cancelContextNow {
-		if p.launcherManager != nil {
-			p.launcherManager.NewContext()
-		}
+	if proc == nil && intent == platforms.StopForPreemption && p.launcherManager != nil {
+		p.launcherManager.NewContext()
 	}
 
 	// Check if launcher has custom Kill function
@@ -484,111 +606,30 @@ func (p *Platform) StopActiveLauncher(intent platforms.StopIntent) error {
 	customKill := p.lastLauncher.Kill
 	p.platformMu.Unlock()
 
-	// Use custom Kill if defined (e.g., keyboard input for ScummVM)
-	if customKill != nil {
-		log.Debug().Msg("using custom Kill function for launcher")
-		if err := customKill(&config.Instance{}); err != nil {
-			log.Warn().Err(err).Msg("custom Kill function failed")
-		}
-		// Custom Kill function used - skip signal-based termination entirely
-		// The process will exit on its own via the custom method
-	} else {
-		// Stop tracked process if it exists using signal-based termination
-		p.processMu.Lock()
-		if p.trackedProcess != nil {
-			proc := p.trackedProcess
-
-			// Staged termination approach:
-			// 1. Try SIGTERM first (allows SDL cleanup to run)
-			// 2. Wait 5 seconds
-			// 3. If still running, force kill with SIGKILL
-			// 4. After process dies, deallocate the VT to reset all state
-			log.Debug().Msg("sending SIGTERM to tracked process for graceful shutdown")
-			if err := proc.Signal(syscall.SIGTERM); err != nil {
-				log.Warn().Err(err).Msg("failed to send SIGTERM to tracked process")
-				p.trackedProcess = nil
-				p.processMu.Unlock()
-			} else {
-				p.trackedProcess = nil
-				p.processMu.Unlock()
-
-				// Wait for graceful exit with timeout
-				done := make(chan error, 1)
-				go func() {
-					_, err := proc.Wait()
-					done <- err
-				}()
-
-				select {
-				case err := <-done:
-					if err != nil {
-						log.Debug().Err(err).Msg("process exited after SIGTERM")
-					} else {
-						log.Debug().Msg("process exited gracefully after SIGTERM")
-					}
-				case <-time.After(5 * time.Second):
-					// SIGTERM didn't work within 5 seconds - force kill
-					log.Debug().Msg("SIGTERM timeout - sending SIGKILL")
-					if err := proc.Kill(); err != nil {
-						log.Warn().Err(err).Msg("failed to SIGKILL process")
-					} else {
-						// Wait for SIGKILL to complete (should be fast)
-						select {
-						case <-done:
-							log.Debug().Msg("process killed with SIGKILL")
-						case <-time.After(500 * time.Millisecond):
-							log.Warn().Msg("SIGKILL took too long")
-						}
-					}
-				}
+	if proc != nil {
+		var gracefulStop func() error
+		if customKill != nil {
+			gracefulStop = func() error {
+				return customKill(&config.Instance{})
 			}
-		} else {
-			p.processMu.Unlock()
+		}
+		stopTrackedProcess(proc, done, processGroup, gracefulStop)
+		if done == nil {
+			p.clearTrackedProcess(proc)
 		}
 	}
 
-	// Clear active media
 	p.setActiveMedia(nil)
 
-	// Return to menu if needed - but ONLY for launchers without tracked processes
-	// Console launchers (video/ScummVM) have cleanup goroutines that call ReturnToMenu
-	// FPGA/MGL launchers have no cleanup goroutine, so we must call it here
-	if intent == platforms.StopForMenu || intent == platforms.StopForConsoleReset {
-		if !hadTrackedProcess {
-			// No cleanup goroutine will run - we must call ReturnToMenu ourselves
-			log.Debug().Msg("no tracked process - calling ReturnToMenu directly")
-			if err := p.ReturnToMenu(); err != nil {
-				log.Warn().Err(err).Msg("failed to return to menu after stopping launcher")
-			}
-		} else {
-			log.Debug().Msg("tracked process existed - cleanup goroutine will call ReturnToMenu")
+	if proc == nil && (intent == platforms.StopForMenu || intent == platforms.StopForConsoleReset) {
+		log.Debug().Msg("no tracked process - calling ReturnToMenu directly")
+		if err := p.ReturnToMenu(); err != nil {
+			log.Warn().Err(err).Msg("failed to return to menu after stopping launcher")
 		}
 	}
 
-	// For console launchers during preemption, wait for cleanup to complete
-	// before cancelling context. This ensures console state (VT, cursor, video mode)
-	// is properly cleaned up before the new launcher starts.
-	if intent == platforms.StopForPreemption && hadTrackedProcess {
-		// Get the cleanup completion channel
-		p.processMu.Lock()
-		done := p.processDone
-		p.processMu.Unlock()
-
-		if done != nil {
-			log.Debug().Msg("waiting for console launcher cleanup to complete")
-			select {
-			case <-done:
-				log.Debug().Msg("console launcher cleanup completed")
-			case <-time.After(2 * time.Second):
-				// Safety valve: don't hang if process becomes a zombie
-				log.Warn().Msg("timeout waiting for console cleanup (2s)")
-			}
-		}
-
-		// Now invalidate the launcher context to prevent any further operations
-		if p.launcherManager != nil {
-			p.launcherManager.NewContext()
-		}
+	if intent == platforms.StopForPreemption && proc != nil && p.launcherManager != nil {
+		p.launcherManager.NewContext()
 	}
 
 	return nil
@@ -1394,7 +1435,7 @@ func (p *Platform) ShowNotice(
 		p.platformMu.Lock()
 		defer p.platformMu.Unlock()
 		p.lastUIHidden = time.Now()
-		return hideNotice(completePath)
+		return hideNotice(p.filesystem(), completePath)
 	}, preNoticeTime(), nil
 }
 
@@ -1420,7 +1461,7 @@ func (p *Platform) ShowLoader(
 		p.platformMu.Lock()
 		defer p.platformMu.Unlock()
 		p.lastUIHidden = time.Now()
-		return hideNotice(completePath)
+		return hideNotice(p.filesystem(), completePath)
 	}, nil
 }
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -601,9 +601,13 @@ func (p *Platform) StopActiveLauncher(intent platforms.StopIntent) error {
 		p.launcherManager.NewContext()
 	}
 
-	// Check if launcher has custom Kill function
+	// Capture the current launcher cleanup before clearing it. Script-tracked
+	// processes do not set lastLauncher and must not inherit a stale Kill hook.
 	p.platformMu.Lock()
 	customKill := p.lastLauncher.Kill
+	if proc != nil {
+		p.lastLauncher = platforms.Launcher{}
+	}
 	p.platformMu.Unlock()
 
 	if proc != nil {

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -356,6 +356,29 @@ func TestStopActiveLauncher_WaitsForCleanup(t *testing.T) {
 	}
 }
 
+func TestReturnToMenu_StopsTrackedConsoleProcess(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "sleep", "10")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	p := NewPlatform()
+	p.setActiveMedia = func(_ *models.ActiveMedia) {}
+	restoreDone := make(chan struct{})
+	proc, err := runTrackedProcess(p, cmd, func() { close(restoreDone) }, "return-to-menu-test")
+	require.NoError(t, err)
+
+	require.NoError(t, p.ReturnToMenu())
+	select {
+	case <-restoreDone:
+	case <-time.After(time.Second):
+		t.Fatal("console cleanup did not complete before ReturnToMenu returned")
+	}
+	require.Eventually(t, func() bool {
+		return errors.Is(syscall.Kill(proc.Pid, 0), syscall.ESRCH)
+	}, time.Second, 10*time.Millisecond, "tracked console process survived ReturnToMenu")
+}
+
 func TestStopActiveLauncher_KillsProcessGroupBeforeCleanup(t *testing.T) {
 	pidPath := filepath.Join(t.TempDir(), "child.pid")
 	cmd := exec.CommandContext( //nolint:gosec // Fixed test shell; only temp path is variable.
@@ -391,8 +414,9 @@ func TestStopActiveLauncher_KillsProcessGroupBeforeCleanup(t *testing.T) {
 		t.Fatal("console cleanup did not complete before stop returned")
 	}
 
-	assert.ErrorIs(t, syscall.Kill(childPID, 0), syscall.ESRCH,
-		"descendant process survived console cleanup")
+	require.Eventually(t, func() bool {
+		return errors.Is(syscall.Kill(childPID, 0), syscall.ESRCH)
+	}, time.Second, 10*time.Millisecond, "descendant process survived console cleanup")
 }
 
 func TestArcadeCardLaunchCache(t *testing.T) {

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -266,6 +266,34 @@ func TestStopActiveLauncher_CustomKill(t *testing.T) {
 	}
 }
 
+func TestStopActiveLauncher_DoesNotReuseStaleKillForScript(t *testing.T) {
+	t.Parallel()
+
+	p := NewPlatform()
+	p.setActiveMedia = func(_ *models.ActiveMedia) {}
+	killCalls := 0
+	launcher := platforms.Launcher{Kill: func(*config.Instance) error {
+		killCalls++
+		p.processMu.Lock()
+		proc := p.trackedProcess
+		p.processMu.Unlock()
+		return proc.Signal(syscall.SIGTERM)
+	}}
+	p.setLastLauncher(&launcher)
+
+	first := exec.CommandContext(context.Background(), "sleep", "10")
+	require.NoError(t, first.Start())
+	p.SetTrackedProcess(first.Process)
+	require.NoError(t, p.StopActiveLauncher(platforms.StopForMenu))
+	assert.Equal(t, 1, killCalls)
+
+	second := exec.CommandContext(context.Background(), "sleep", "10")
+	require.NoError(t, second.Start())
+	p.SetTrackedProcess(second.Process)
+	require.NoError(t, p.StopActiveLauncher(platforms.StopForMenu))
+	assert.Equal(t, 1, killCalls, "script stop reused stale launcher Kill hook")
+}
+
 func TestScummVMLauncher_HasCustomKill(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -27,6 +27,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -221,7 +224,16 @@ func TestStopActiveLauncher_CustomKill(t *testing.T) {
 			if tt.customKillFunc != nil {
 				launcher.Kill = func(cfg *config.Instance) error {
 					killCalled = true
-					return tt.customKillFunc(cfg)
+					err := tt.customKillFunc(cfg)
+					if err == nil {
+						p.processMu.Lock()
+						proc := p.trackedProcess
+						p.processMu.Unlock()
+						if proc != nil {
+							_ = proc.Signal(syscall.SIGTERM)
+						}
+					}
+					return err
 				}
 			}
 			p.setLastLauncher(&launcher)
@@ -314,6 +326,45 @@ func TestStopActiveLauncher_WaitsForCleanup(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("StopActiveLauncher did not return after cleanup completed")
 	}
+}
+
+func TestStopActiveLauncher_KillsProcessGroupBeforeCleanup(t *testing.T) {
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	cmd := exec.CommandContext( //nolint:gosec // Fixed test shell; only temp path is variable.
+		context.Background(),
+		"sh",
+		"-c",
+		`trap 'exit 0' TERM; sh -c 'trap "" TERM; while :; do sleep 1; done' & echo $! > "$1"; wait`,
+		"sh",
+		pidPath,
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	p := NewPlatform()
+	p.setActiveMedia = func(_ *models.ActiveMedia) {}
+	restoreDone := make(chan struct{})
+	_, err := runTrackedProcess(p, cmd, func() { close(restoreDone) }, "group-test")
+	require.NoError(t, err)
+
+	var childPID int
+	require.Eventually(t, func() bool {
+		contents, readErr := os.ReadFile(pidPath) //nolint:gosec // Test-owned temporary file.
+		if readErr != nil {
+			return false
+		}
+		childPID, readErr = strconv.Atoi(strings.TrimSpace(string(contents)))
+		return readErr == nil
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, p.StopActiveLauncher(platforms.StopForMenu))
+	select {
+	case <-restoreDone:
+	case <-time.After(time.Second):
+		t.Fatal("console cleanup did not complete before stop returned")
+	}
+
+	assert.ErrorIs(t, syscall.Kill(childPID, 0), syscall.ESRCH,
+		"descendant process survived console cleanup")
 }
 
 func TestArcadeCardLaunchCache(t *testing.T) {

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -27,6 +27,15 @@ const (
 	misterWidgetRunFlag     = "2"
 )
 
+var (
+	getScriptConsoleManager = func(pl *Platform) platforms.ConsoleManager { return pl.ConsoleManager() }
+	runScriptChvt           = func(ctx context.Context, vt string) error {
+		return exec.CommandContext(ctx, "chvt", vt).Run() //nolint:gosec // Fixed executable; VT is internal.
+	}
+	writeScriptLauncher = os.WriteFile
+	startScriptCommand  = func(cmd *exec.Cmd) error { return cmd.Start() }
+)
+
 func scriptIsActive() bool {
 	cmd := exec.CommandContext(context.Background(), "bash", "-c", misterScriptGrepCommand)
 	output, err := cmd.Output()
@@ -110,22 +119,31 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 		// to avoid the active script check (widgets handle this)
 		log.Debug().Msg("widget launched, changing params")
 		scriptPath = misterWidgetScriptPath
-		vt = armLauncherVT
+		vt = frontendConsoleVT
 	}
 
 	// Run it on-screen like a regular script. Use a background context with
 	// timeout since scripts are not launcher operations.
 	scriptCtx, scriptCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer scriptCancel()
-	err := pl.ConsoleManager().Open(scriptCtx, vt)
+	cm := getScriptConsoleManager(pl)
+	err := cm.Open(scriptCtx, vt)
 	if err != nil {
 		return fmt.Errorf("failed to open console for script: %w", err)
 	}
+	consoleOwned := true
+	defer func() {
+		if consoleOwned {
+			if closeErr := cm.Close(); closeErr != nil {
+				log.Warn().Err(closeErr).Msg("failed to close script console after setup error")
+			}
+		}
+	}()
 
 	// this is just to follow mister's convention, which reserves
 	// tty2 for scripts
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	err = exec.CommandContext(ctx, "chvt", vt).Run()
+	err = runScriptChvt(ctx, vt)
 	cancel()
 	if err != nil {
 		return fmt.Errorf("failed to switch to tty %s: %w", vt, err)
@@ -141,16 +159,13 @@ cd $(dirname "%s")
 %s
 `, runScript, bin, bin+" "+args)
 
-	err = os.WriteFile(scriptPath, []byte(launcher), 0o750) //nolint:gosec // Script file needs execute permissions
+	err = writeScriptLauncher(scriptPath, []byte(launcher), 0o750)
 	if err != nil {
 		return fmt.Errorf("failed to write script file: %w", err)
 	}
 
-	launcherCtx := pl.launcherManager.GetContext()
-
 	cmd := exec.CommandContext(
 		context.Background(),
-		"setsid",
 		"/sbin/agetty",
 		"-a",
 		"root",
@@ -161,6 +176,7 @@ cd $(dirname "%s")
 		"tty"+vt,
 		"linux",
 	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 	exit := func() {
 		if pl.activeMedia() != nil {
@@ -172,58 +188,27 @@ cd $(dirname "%s")
 	}
 
 	// Start script non-blocking
-	if err := cmd.Start(); err != nil {
+	if err := startScriptCommand(cmd); err != nil {
 		return fmt.Errorf("failed to start script: %w", err)
 	}
 
-	// Track process so it can be killed by StopActiveLauncher
-	pl.SetTrackedProcess(cmd.Process)
+	done := make(chan struct{})
+	pl.setTrackedProcessWithCleanup(cmd.Process, done, true)
 
-	// Cleanup in goroutine (non-blocking)
+	// This goroutine exclusively owns cmd.Wait and console cleanup.
 	go func() {
+		defer close(done)
 		waitErr := cmd.Wait()
-
-		// Check if script was superseded by new launcher
-		if launcherCtx.Err() != nil {
-			log.Debug().Msg("script cleanup cancelled - launcher superseded")
-			return
-		}
-
-		// Handle different exit scenarios
+		killRemainingProcessGroup(cmd.Process, true)
 		if waitErr != nil {
-			// Check if process was killed by signal
-			isKilled := false
-			exitErr := &exec.ExitError{}
-			if errors.As(waitErr, &exitErr) {
-				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
-					sig := status.Signal()
-					if status.Signaled() && (sig == syscall.SIGKILL || sig == syscall.SIGTERM) {
-						isKilled = true
-					}
-				}
-			}
-
-			if isKilled {
-				// Process was killed (likely by StopActiveLauncher for new media)
-				log.Debug().Msg("script stopped by new media launch")
-				pl.SetTrackedProcess(nil)
-				return
-			}
-
-			// agetty exits with code 2 when it can't find the specified TTY,
-			// which can happen during shutdown or preemption
-			var exitError *exec.ExitError
-			if !errors.As(waitErr, &exitError) || exitError.ExitCode() != 2 {
-				log.Debug().Err(waitErr).Msg("script exited with error")
-				pl.SetTrackedProcess(nil)
-				exit()
-			}
+			log.Debug().Err(waitErr).Msg("script exited")
 		} else {
 			log.Debug().Msg("script completed normally")
-			pl.SetTrackedProcess(nil)
-			exit()
 		}
+		exit()
+		pl.clearTrackedProcess(cmd.Process)
 	}()
+	consoleOwned = false
 
 	return nil
 }

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -100,18 +100,9 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 		}
 	}
 
-	// run it on-screen like a regular script
-	// Use background context with timeout since scripts are not launcher operations
-	scriptCtx, scriptCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer scriptCancel()
-	err := pl.ConsoleManager().Open(scriptCtx, scriptConsoleVT)
-	if err != nil {
-		return fmt.Errorf("failed to open console for script: %w", err)
-	}
-
 	scriptPath := misterScriptPath
 	runScript, widgetScript := scriptRunMode(bin, args)
-	vt := "2"
+	vt := scriptConsoleVT
 	log.Debug().Msgf("bin: %s", bin)
 	log.Debug().Msgf("args: %s", args)
 	if widgetScript {
@@ -119,7 +110,16 @@ func runScript(pl *Platform, bin, args string, hidden bool) error {
 		// to avoid the active script check (widgets handle this)
 		log.Debug().Msg("widget launched, changing params")
 		scriptPath = misterWidgetScriptPath
-		vt = launcherConsoleVT
+		vt = armLauncherVT
+	}
+
+	// Run it on-screen like a regular script. Use a background context with
+	// timeout since scripts are not launcher operations.
+	scriptCtx, scriptCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer scriptCancel()
+	err := pl.ConsoleManager().Open(scriptCtx, vt)
+	if err != nil {
+		return fmt.Errorf("failed to open console for script: %w", err)
 	}
 
 	// this is just to follow mister's convention, which reserves
@@ -166,16 +166,9 @@ cd $(dirname "%s")
 		if pl.activeMedia() != nil {
 			return
 		}
-		// exit console
-		err = pl.KeyboardPress("{f12}")
-		if err != nil {
-			return
+		if closeErr := pl.ConsoleManager().Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close script console")
 		}
-
-		// Clear console active flag
-		pl.consoleManager.mu.Lock()
-		pl.consoleManager.active = false
-		pl.consoleManager.mu.Unlock()
 	}
 
 	// Start script non-blocking

--- a/pkg/platforms/mister/scripts_test.go
+++ b/pkg/platforms/mister/scripts_test.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package mister
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func restoreScriptTestHooks(t *testing.T) {
+	t.Helper()
+
+	oldGetConsoleManager := getScriptConsoleManager
+	oldRunChvt := runScriptChvt
+	oldWriteLauncher := writeScriptLauncher
+	oldStartCommand := startScriptCommand
+	t.Cleanup(func() {
+		getScriptConsoleManager = oldGetConsoleManager
+		runScriptChvt = oldRunChvt
+		writeScriptLauncher = oldWriteLauncher
+		startScriptCommand = oldStartCommand
+	})
+}
+
+func newTestScript(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\n"), 0o700)) //nolint:gosec // Test executable.
+	return path
+}
+
+func newTestScriptPlatform() *Platform {
+	return &Platform{activeMedia: func() *models.ActiveMedia { return nil }}
+}
+
+func TestRunScript_WidgetUsesFrontendTTYAndCleansUpSetupFailure(t *testing.T) {
+	restoreScriptTestHooks(t)
+
+	cm := &testConsoleManager{}
+	getScriptConsoleManager = func(*Platform) platforms.ConsoleManager { return cm }
+	runScriptChvt = func(context.Context, string) error { return assert.AnError }
+
+	err := runScript(newTestScriptPlatform(), newTestScript(t, "zaparoo.sh"), "'-show-picker' 'args.json'", false)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, frontendConsoleVT, cm.openVT)
+	assert.True(t, cm.closeCalled)
+}
+
+func TestRunScript_CleansUpLauncherWriteFailure(t *testing.T) {
+	restoreScriptTestHooks(t)
+
+	cm := &testConsoleManager{}
+	getScriptConsoleManager = func(*Platform) platforms.ConsoleManager { return cm }
+	runScriptChvt = func(context.Context, string) error { return nil }
+	writeScriptLauncher = func(string, []byte, os.FileMode) error { return assert.AnError }
+
+	err := runScript(newTestScriptPlatform(), newTestScript(t, "test.sh"), "", false)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.True(t, cm.closeCalled)
+}
+
+func TestRunScript_CleansUpCommandStartFailure(t *testing.T) {
+	restoreScriptTestHooks(t)
+
+	cm := &testConsoleManager{}
+	getScriptConsoleManager = func(*Platform) platforms.ConsoleManager { return cm }
+	runScriptChvt = func(context.Context, string) error { return nil }
+	writeScriptLauncher = func(string, []byte, os.FileMode) error { return nil }
+	startScriptCommand = func(*exec.Cmd) error { return assert.AnError }
+
+	err := runScript(newTestScriptPlatform(), newTestScript(t, "test.sh"), "", false)
+	require.ErrorIs(t, err, assert.AnError)
+	assert.True(t, cm.closeCalled)
+}
+
+func TestRunScript_DoesNotCloseWhenOpenFails(t *testing.T) {
+	restoreScriptTestHooks(t)
+
+	cm := &testConsoleManager{openErr: errors.New("open failed")}
+	getScriptConsoleManager = func(*Platform) platforms.ConsoleManager { return cm }
+
+	err := runScript(newTestScriptPlatform(), newTestScript(t, "test.sh"), "", false)
+	require.Error(t, err)
+	assert.False(t, cm.closeCalled)
+}

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/client"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -454,42 +453,6 @@ func loadRecent(filename string) error {
 	return nil
 }
 
-func (tr *Tracker) runPickerSelection(name string) {
-	contents, err := os.ReadFile(name) //nolint:gosec // Internal picker selection file
-	switch {
-	case err != nil:
-		log.Error().Msgf("error reading main picker selected: %s", err)
-	case len(contents) == 0:
-		log.Error().Msgf("main picker selected is empty")
-	default:
-		path := strings.TrimSpace(string(contents))
-		path = misterconfig.SDRootDir + "/" + path
-		log.Info().Msgf("main picker selected path: %s", path)
-
-		pickerContents, err := os.ReadFile(path) //nolint:gosec // Internal picker content path
-		if err != nil {
-			log.Error().Msgf("error reading main picker selected path: %s", err)
-		} else {
-			_, err = client.LocalClient(context.Background(), tr.cfg, models.MethodRun, string(pickerContents))
-			if err != nil {
-				log.Error().Err(err).Msg("error running local client")
-			}
-		}
-
-		files, err := os.ReadDir(misterconfig.MainPickerDir)
-		if err != nil {
-			log.Error().Msgf("error reading picker items dir: %s", err)
-		} else {
-			for _, file := range files {
-				err := os.Remove(filepath.Join(misterconfig.MainPickerDir, file.Name()))
-				if err != nil {
-					log.Error().Msgf("error deleting file %s: %s", file.Name(), err)
-				}
-			}
-		}
-	}
-}
-
 // StartFileWatch Start thread for monitoring changes to all files relating to core/game launches.
 func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 	log.Info().Msg("starting file watcher")
@@ -522,9 +485,6 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 								log.Error().Msgf("error loading recent file: %s", err)
 							}
 						}
-					case event.Name == misterconfig.MainPickerSelected:
-						log.Info().Msgf("main picker selected: %s", event.Name)
-						tr.runPickerSelection(event.Name)
 					}
 				}
 			case watchErr, ok := <-watcher.Errors:
@@ -594,16 +554,6 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 	err = watcher.Add(misterconfig.CurrentPathFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to watch current path file (%s): %w", misterconfig.CurrentPathFile, err)
-	}
-
-	_, pickerExists := os.Stat(misterconfig.MainPickerSelected)
-	if pickerExists == nil && misterconfig.MainHasFeature(misterconfig.MainFeaturePicker) {
-		log.Debug().Msgf("adding watcher for picker selected file: %s", misterconfig.MainPickerSelected)
-		err = watcher.Add(misterconfig.MainPickerSelected)
-		if err != nil {
-			return nil, fmt.Errorf("failed to watch picker selected file (%s): %w",
-				misterconfig.MainPickerSelected, err)
-		}
 	}
 
 	elapsed := time.Since(startTime)

--- a/pkg/platforms/mister/ui.go
+++ b/pkg/platforms/mister/ui.go
@@ -5,7 +5,6 @@ package mister
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 func preNoticeTime() time.Duration {
@@ -42,12 +42,8 @@ func showNotice(
 		Text:     text,
 		Complete: completePath,
 	}
-	argsJSON, err := json.Marshal(args)
-	if err != nil {
-		return "", fmt.Errorf("error marshalling notice args: %w", err)
-	}
-	if err = os.WriteFile(argsPath, argsJSON, 0o600); err != nil {
-		return "", fmt.Errorf("error writing notice args: %w", err)
+	if writeErr := writeNoticeArgs(pl.filesystem(), argsPath, args); writeErr != nil {
+		return "", writeErr
 	}
 
 	scriptPath := filepath.Join(misterconfig.ScriptsDir, "zaparoo.sh")
@@ -63,11 +59,22 @@ func showNotice(
 	return argsPath, nil
 }
 
-func hideNotice(argsPath string) error {
-	if err := os.Remove(argsPath); err != nil {
+func writeNoticeArgs(fs afero.Fs, argsPath string, args widgetmodels.NoticeArgs) error {
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("error marshalling notice args: %w", err)
+	}
+	if err = afero.WriteFile(fs, argsPath, argsJSON, 0o600); err != nil {
+		return fmt.Errorf("error writing notice args: %w", err)
+	}
+	return nil
+}
+
+func hideNotice(fs afero.Fs, argsPath string) error {
+	if err := fs.Remove(argsPath); err != nil {
 		return fmt.Errorf("error removing notice args: %w", err)
 	}
-	if err := os.WriteFile(argsPath+".complete", []byte{}, 0o600); err != nil {
+	if err := afero.WriteFile(fs, argsPath+".complete", []byte{}, 0o600); err != nil {
 		return fmt.Errorf("error writing notice complete: %w", err)
 	}
 	return nil
@@ -83,7 +90,7 @@ func showPicker(
 	if err != nil {
 		return fmt.Errorf("failed to marshal picker args: %w", err)
 	}
-	err = os.WriteFile(argsPath, argsJSON, 0o600)
+	err = afero.WriteFile(pl.filesystem(), argsPath, argsJSON, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write picker args file: %w", err)
 	}

--- a/pkg/platforms/mister/ui.go
+++ b/pkg/platforms/mister/ui.go
@@ -7,21 +7,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mistermain"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/rs/zerolog/log"
 )
 
 func preNoticeTime() time.Duration {
-	if misterconfig.MainHasFeature(misterconfig.MainFeatureNotice) {
-		return 3 * time.Second
-	}
-	// accounting for the time it takes to boot up the console
+	// Account for time needed to open the script console.
 	return 5 * time.Second
 }
 
@@ -42,99 +37,39 @@ func showNotice(
 	argsPath := filepath.Join(pl.Settings().TempDir, argsName)
 	completePath := argsPath + ".complete"
 
-	if misterconfig.MainHasFeature(misterconfig.MainFeatureNotice) {
-		err := mistermain.RunDevCmd("show_notice", text)
-		if err != nil {
-			return "", fmt.Errorf("error running dev cmd: %w", err)
-		}
-	} else {
-		log.Debug().Msg("launching script notice")
-		// fall back on script
-		args := widgetmodels.NoticeArgs{
-			Text:     text,
-			Complete: completePath,
-		}
-		argsJSON, err := json.Marshal(args)
-		if err != nil {
-			return "", fmt.Errorf("error marshalling notice args: %w", err)
-		}
-		err = os.WriteFile(argsPath, argsJSON, 0o600)
-		if err != nil {
-			return "", fmt.Errorf("error writing notice args: %w", err)
-		}
+	log.Debug().Msg("launching script notice")
+	args := widgetmodels.NoticeArgs{
+		Text:     text,
+		Complete: completePath,
+	}
+	argsJSON, err := json.Marshal(args)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling notice args: %w", err)
+	}
+	if err = os.WriteFile(argsPath, argsJSON, 0o600); err != nil {
+		return "", fmt.Errorf("error writing notice args: %w", err)
+	}
 
-		scriptPath := filepath.Join(misterconfig.ScriptsDir, "zaparoo.sh")
-		scriptArg := "'-show-notice' '" + argsPath + "'"
-		if loader {
-			scriptArg = "'-show-loader' '" + argsPath + "'"
-		}
-		log.Debug().Msgf("running script notice: %s %s", scriptPath, scriptArg)
-		err = runScript(pl, scriptPath, scriptArg, false)
-		if err != nil {
-			return "", fmt.Errorf("error running notice script: %w", err)
-		}
+	scriptPath := filepath.Join(misterconfig.ScriptsDir, "zaparoo.sh")
+	scriptArg := "'-show-notice' '" + argsPath + "'"
+	if loader {
+		scriptArg = "'-show-loader' '" + argsPath + "'"
+	}
+	log.Debug().Msgf("running script notice: %s %s", scriptPath, scriptArg)
+	if err = runScript(pl, scriptPath, scriptArg, false); err != nil {
+		return "", fmt.Errorf("error running notice script: %w", err)
 	}
 
 	return argsPath, nil
 }
 
 func hideNotice(argsPath string) error {
-	if !misterconfig.MainHasFeature(misterconfig.MainFeatureNotice) {
-		err := os.Remove(argsPath)
-		if err != nil {
-			return fmt.Errorf("error removing notice args: %w", err)
-		}
-		err = os.WriteFile(argsPath+".complete", []byte{}, 0o600)
-		if err != nil {
-			return fmt.Errorf("error writing notice complete: %w", err)
-		}
+	if err := os.Remove(argsPath); err != nil {
+		return fmt.Errorf("error removing notice args: %w", err)
 	}
-	return nil
-}
-
-func misterSetupMainPicker(args widgetmodels.PickerArgs) error {
-	// remove existing items
-	files, err := os.ReadDir(misterconfig.MainPickerDir)
-	if err != nil {
-		log.Error().Msgf("error reading picker items dir: %s", err)
-	} else {
-		for _, file := range files {
-			removeErr := os.Remove(filepath.Join(misterconfig.MainPickerDir, file.Name()))
-			if removeErr != nil {
-				log.Error().Msgf("error deleting file %s: %s", file.Name(), removeErr)
-			}
-		}
+	if err := os.WriteFile(argsPath+".complete", []byte{}, 0o600); err != nil {
+		return fmt.Errorf("error writing notice complete: %w", err)
 	}
-
-	// write items to dir
-	for _, item := range args.Items {
-		name := item.Name
-		if strings.TrimSpace(item.Name) == "" {
-			name = item.ZapScript
-		}
-
-		if len(name) > 25 {
-			name = name[:25] + "..."
-		}
-
-		contents, marshalErr := json.Marshal(item)
-		if marshalErr != nil {
-			return fmt.Errorf("failed to marshal picker item: %w", marshalErr)
-		}
-
-		path := filepath.Join(misterconfig.MainPickerDir, name+".txt")
-		err = os.WriteFile(path, contents, 0o600)
-		if err != nil {
-			return fmt.Errorf("failed to write picker item file: %w", err)
-		}
-	}
-
-	// launch
-	err = os.WriteFile(misterconfig.CmdInterface, []byte("show_picker\n"), 0o600)
-	if err != nil {
-		return fmt.Errorf("failed to write show_picker command: %w", err)
-	}
-
 	return nil
 }
 
@@ -142,16 +77,7 @@ func showPicker(
 	pl *Platform,
 	args widgetmodels.PickerArgs,
 ) error {
-	// use custom main ui if available
-	if misterconfig.MainHasFeature(misterconfig.MainFeaturePicker) {
-		err := misterSetupMainPicker(args)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	// fall back to launching script menu
+	// Launch picker through the script UI.
 	argsPath := filepath.Join(pl.Settings().TempDir, "picker.json")
 	argsJSON, err := json.Marshal(args)
 	if err != nil {

--- a/pkg/platforms/mister/ui_test.go
+++ b/pkg/platforms/mister/ui_test.go
@@ -37,8 +37,12 @@ func TestNoticeArgsLifecycleUsesInjectedFilesystem(t *testing.T) {
 func TestNoticeArgsLifecycleReportsFilesystemErrors(t *testing.T) {
 	t.Parallel()
 
-	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+	baseFS := afero.NewMemMapFs()
 	argsPath := filepath.Join("tmp", "zaparoo", "notice.json")
+	require.NoError(t, baseFS.MkdirAll(filepath.Dir(argsPath), 0o755))
+	require.NoError(t, afero.WriteFile(baseFS, argsPath, []byte("existing"), 0o600))
+	fs := afero.NewReadOnlyFs(baseFS)
+
 	err := writeNoticeArgs(fs, argsPath, widgetmodels.NoticeArgs{Text: "Loading"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "error writing notice args")

--- a/pkg/platforms/mister/ui_test.go
+++ b/pkg/platforms/mister/ui_test.go
@@ -33,3 +33,17 @@ func TestNoticeArgsLifecycleUsesInjectedFilesystem(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 }
+
+func TestNoticeArgsLifecycleReportsFilesystemErrors(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+	argsPath := filepath.Join("tmp", "zaparoo", "notice.json")
+	err := writeNoticeArgs(fs, argsPath, widgetmodels.NoticeArgs{Text: "Loading"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error writing notice args")
+
+	err = hideNotice(fs, argsPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error removing notice args")
+}

--- a/pkg/platforms/mister/ui_test.go
+++ b/pkg/platforms/mister/ui_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package mister
+
+import (
+	"path/filepath"
+	"testing"
+
+	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoticeArgsLifecycleUsesInjectedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	argsPath := filepath.Join("tmp", "zaparoo", "notice.json")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(argsPath), 0o755))
+
+	err := writeNoticeArgs(fs, argsPath, widgetmodels.NoticeArgs{Text: "Loading"})
+	require.NoError(t, err)
+	exists, err := afero.Exists(fs, argsPath)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	require.NoError(t, hideNotice(fs, argsPath))
+	exists, err = afero.Exists(fs, argsPath)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	exists, err = afero.Exists(fs, argsPath+".complete")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -206,10 +206,16 @@ type ScanResult struct {
 
 // LaunchOptions contains optional parameters that can be passed to launchers.
 type LaunchOptions struct {
+	// RenderScale is the preferred internal rendering size as a percentage of
+	// available output dimensions. It does not change physical display mode.
+	RenderScale *int
 	// Action specifies the launch action. Common values:
 	// - "" or "run": Default behavior (launch/play the media)
 	// - "details": Show media details/info page instead of launching
 	Action string
+	// RenderResolution is the preferred fixed internal rendering size in
+	// WIDTHxHEIGHT form. It is mutually exclusive with RenderScale.
+	RenderResolution string
 	// SetName specifies a platform-defined launch profile/core name override.
 	// On MiSTer this maps to the MGL <setname> tag.
 	SetName string


### PR DESCRIPTION
Ref #1061

## Summary

- coordinate framebuffer ownership with nonce-backed Main console leases while retaining stock/older Main F9 fallback behavior
- reserve tty2 for scripts, tty3 for ARM launchers, and tty7 for frontend widgets; remove deprecated MAINFEATURES picker and notice integration
- harden FVP, ScummVM, and visible-script lifecycle with one process waiter, bounded shutdown escalation, process-group cleanup, and frontend restoration after cleanup
- handle hardware-tested transition cases: `**stop` now terminates tracked console launchers, delayed Main lease publication works after leaving FPGA cores, and ScummVM retains its SDL-required inherited session
- add generic launcher `render_scale` and `render_resolution` defaults, mapped on MiSTer to relative or exact framebuffer sizing without changing physical output mode
- expand lease, manager, process, script, UI, configuration, and render-sizing coverage

Example launcher overrides:

```toml
[[launchers.default]]
launcher = "GenericVideo"
render_scale = 33

[[launchers.default]]
launcher = "ScummVM"
render_resolution = "640x480"
```

`render_scale` and `render_resolution` are mutually exclusive. Existing behavior remains unchanged by default: GenericVideo uses one-third output dimensions and ScummVM uses an exact 640x480 RGB16 framebuffer.

Core remains backward-compatible with stock and older Main builds. Lease handling activates only when compatible Main capability state is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added main-console leasing to coordinate console access and reduce launch conflicts.
- **Bug Fixes**
  - Improved console VT targeting/restore across launcher and script flows, including ARM VT handling.
  - Hardened shutdown: releases the main-console lease and terminates remaining process groups during cleanup.
  - Improved launcher rendering behavior using validated render scale/resolution options (with safe defaults).
- **UI Improvements**
  - Standardized notice and picker UI behavior with consistent args/marker lifecycle (via zaparoo.sh).
- **Tests**
  - Expanded coverage for console leasing/manager behavior, script cleanup, and process-group termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->