### PR TITLE
feat(mister): classify arcade hardware systems

### DIFF
--- a/pkg/assets/systems/CPS1.json
+++ b/pkg/assets/systems/CPS1.json
@@ -1,7 +1,7 @@
 {
   "id": "CPS1",
   "name": "Capcom Play System",
-  "category": "Other",
+  "category": "Arcade",
   "releaseDate": "",
   "manufacturer": ""
 }

--- a/pkg/assets/systems/CPS2.json
+++ b/pkg/assets/systems/CPS2.json
@@ -1,7 +1,7 @@
 {
   "id": "CPS2",
   "name": "Capcom Play System II",
-  "category": "Other",
+  "category": "Arcade",
   "releaseDate": "",
   "manufacturer": ""
 }

--- a/pkg/assets/systems/CPS3.json
+++ b/pkg/assets/systems/CPS3.json
@@ -1,7 +1,7 @@
 {
   "id": "CPS3",
   "name": "Capcom Play System III",
-  "category": "Other",
+  "category": "Arcade",
   "releaseDate": "",
   "manufacturer": ""
 }

--- a/pkg/assets/systems/IremM72.json
+++ b/pkg/assets/systems/IremM72.json
@@ -1,0 +1,7 @@
+{
+  "id": "IremM72",
+  "name": "Irem M72",
+  "category": "Arcade",
+  "releaseDate": "1987-01-01",
+  "manufacturer": "Irem"
+}

--- a/pkg/assets/systems/IremM92.json
+++ b/pkg/assets/systems/IremM92.json
@@ -1,0 +1,7 @@
+{
+  "id": "IremM92",
+  "name": "Irem M92",
+  "category": "Arcade",
+  "releaseDate": "1991-01-01",
+  "manufacturer": "Irem"
+}

--- a/pkg/assets/systems/JalecoMegaSystem1.json
+++ b/pkg/assets/systems/JalecoMegaSystem1.json
@@ -1,0 +1,7 @@
+{
+  "id": "JalecoMegaSystem1",
+  "name": "Jaleco Mega System 1",
+  "category": "Arcade",
+  "releaseDate": "1988-01-01",
+  "manufacturer": "Jaleco"
+}

--- a/pkg/assets/systems/NamcoSystem1.json
+++ b/pkg/assets/systems/NamcoSystem1.json
@@ -1,0 +1,7 @@
+{
+  "id": "NamcoSystem1",
+  "name": "Namco System 1",
+  "category": "Arcade",
+  "releaseDate": "1987-01-01",
+  "manufacturer": "Namco"
+}

--- a/pkg/assets/systems/PGM.json
+++ b/pkg/assets/systems/PGM.json
@@ -1,0 +1,7 @@
+{
+  "id": "PGM",
+  "name": "PolyGame Master",
+  "category": "Arcade",
+  "releaseDate": "1997-01-01",
+  "manufacturer": "IGS"
+}

--- a/pkg/assets/systems/SegaSTV.json
+++ b/pkg/assets/systems/SegaSTV.json
@@ -1,0 +1,7 @@
+{
+  "id": "SegaSTV",
+  "name": "Sega ST-V",
+  "category": "Arcade",
+  "releaseDate": "1994-01-01",
+  "manufacturer": "Sega"
+}

--- a/pkg/assets/systems/SegaSystem16.json
+++ b/pkg/assets/systems/SegaSystem16.json
@@ -1,0 +1,7 @@
+{
+  "id": "SegaSystem16",
+  "name": "Sega System 16",
+  "category": "Arcade",
+  "releaseDate": "1985-01-01",
+  "manufacturer": "Sega"
+}

--- a/pkg/assets/systems/SegaSystem18.json
+++ b/pkg/assets/systems/SegaSystem18.json
@@ -1,0 +1,7 @@
+{
+  "id": "SegaSystem18",
+  "name": "Sega System 18",
+  "category": "Arcade",
+  "releaseDate": "1989-01-01",
+  "manufacturer": "Sega"
+}

--- a/pkg/assets/systems/TaitoF2.json
+++ b/pkg/assets/systems/TaitoF2.json
@@ -1,0 +1,7 @@
+{
+  "id": "TaitoF2",
+  "name": "Taito F2 System",
+  "category": "Arcade",
+  "releaseDate": "1988-01-01",
+  "manufacturer": "Taito"
+}

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -418,45 +418,54 @@ const (
 
 // Other
 const (
-	SystemAndroid     = "Android"
-	SystemArcade      = "Arcade"
-	SystemAtomiswave  = "Atomiswave"
-	SystemArduboy     = "Arduboy"
-	SystemChip8       = "Chip8"
-	SystemCPS1        = "CPS1"
-	SystemCPS2        = "CPS2"
-	SystemCPS3        = "CPS3"
-	SystemDAPHNE      = "DAPHNE"
-	SystemDICE        = "DICE"
-	SystemSinge       = "Singe"
-	SystemModel1      = "Model1"
-	SystemModel2      = "Model2"
-	SystemNamco2X6    = "Namco2X6"
-	SystemNamco22     = "Namco22"
-	SystemTriforce    = "Triforce"
-	SystemLindbergh   = "Lindbergh"
-	SystemChihiro     = "Chihiro"
-	SystemGaelco      = "Gaelco"
-	SystemHikaru      = "Hikaru"
-	SystemIOS         = "iOS"
-	SystemModel3      = "Model3"
-	SystemNAOMI       = "NAOMI"
-	SystemNAOMI2      = "NAOMI2"
-	SystemPico8       = "Pico8"
-	SystemTIC80       = "TIC80"
-	SystemVideo       = "Video"
-	SystemAudio       = "Audio"
-	SystemMovie       = "Movie"
-	SystemTVEpisode   = "TVEpisode"
-	SystemTVShow      = "TVShow"
-	SystemMusicTrack  = "MusicTrack"
-	SystemMusicArtist = "MusicArtist"
-	SystemMusicAlbum  = "MusicAlbum"
-	SystemImage       = "Image"
-	SystemJ2ME        = "J2ME"
-	SystemGroovy      = "Groovy"
-	SystemPlugNPlay   = "PlugNPlay"
-	SystemDevErr      = "DevErr"
+	SystemAndroid           = "Android"
+	SystemArcade            = "Arcade"
+	SystemAtomiswave        = "Atomiswave"
+	SystemArduboy           = "Arduboy"
+	SystemChip8             = "Chip8"
+	SystemCPS1              = "CPS1"
+	SystemCPS2              = "CPS2"
+	SystemCPS3              = "CPS3"
+	SystemIremM72           = "IremM72"
+	SystemIremM92           = "IremM92"
+	SystemJalecoMegaSystem1 = "JalecoMegaSystem1"
+	SystemNamcoSystem1      = "NamcoSystem1"
+	SystemPGM               = "PGM"
+	SystemSegaSTV           = "SegaSTV"
+	SystemSegaSystem16      = "SegaSystem16"
+	SystemSegaSystem18      = "SegaSystem18"
+	SystemTaitoF2           = "TaitoF2"
+	SystemDAPHNE            = "DAPHNE"
+	SystemDICE              = "DICE"
+	SystemSinge             = "Singe"
+	SystemModel1            = "Model1"
+	SystemModel2            = "Model2"
+	SystemNamco2X6          = "Namco2X6"
+	SystemNamco22           = "Namco22"
+	SystemTriforce          = "Triforce"
+	SystemLindbergh         = "Lindbergh"
+	SystemChihiro           = "Chihiro"
+	SystemGaelco            = "Gaelco"
+	SystemHikaru            = "Hikaru"
+	SystemIOS               = "iOS"
+	SystemModel3            = "Model3"
+	SystemNAOMI             = "NAOMI"
+	SystemNAOMI2            = "NAOMI2"
+	SystemPico8             = "Pico8"
+	SystemTIC80             = "TIC80"
+	SystemVideo             = "Video"
+	SystemAudio             = "Audio"
+	SystemMovie             = "Movie"
+	SystemTVEpisode         = "TVEpisode"
+	SystemTVShow            = "TVShow"
+	SystemMusicTrack        = "MusicTrack"
+	SystemMusicArtist       = "MusicArtist"
+	SystemMusicAlbum        = "MusicAlbum"
+	SystemImage             = "Image"
+	SystemJ2ME              = "J2ME"
+	SystemGroovy            = "Groovy"
+	SystemPlugNPlay         = "PlugNPlay"
+	SystemDevErr            = "DevErr"
 )
 
 var Systems = map[string]System{
@@ -1242,16 +1251,59 @@ var Systems = map[string]System{
 		Slugs: []string{"javame", "javamobile", "mobilephone"},
 	},
 	SystemCPS1: {
-		ID:    SystemCPS1,
-		Slugs: []string{"cpsystem1", "capcomsystem1", "capcomplay1"},
+		ID:        SystemCPS1,
+		Slugs:     []string{"cpsystem1", "capcomsystem1", "capcomplay1"},
+		Fallbacks: []string{SystemArcade},
 	},
 	SystemCPS2: {
-		ID:    SystemCPS2,
-		Slugs: []string{"cpsystem2", "capcomsystem2", "capcomplay2"},
+		ID:        SystemCPS2,
+		Slugs:     []string{"cpsystem2", "capcomsystem2", "capcomplay2"},
+		Fallbacks: []string{SystemArcade},
 	},
 	SystemCPS3: {
-		ID:    SystemCPS3,
-		Slugs: []string{"cpsystem3", "capcomsystem3", "capcomplay3"},
+		ID:        SystemCPS3,
+		Slugs:     []string{"cpsystem3", "capcomsystem3", "capcomplay3"},
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemIremM72: {
+		ID:        SystemIremM72,
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemIremM92: {
+		ID:        SystemIremM92,
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemJalecoMegaSystem1: {
+		ID:        SystemJalecoMegaSystem1,
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemNamcoSystem1: {
+		ID:        SystemNamcoSystem1,
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemPGM: {
+		ID:        SystemPGM,
+		Slugs:     []string{"igs", "igspgm", "polygamemaster"},
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemSegaSTV: {
+		ID:        SystemSegaSTV,
+		Slugs:     []string{"stv"},
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemSegaSystem16: {
+		ID:        SystemSegaSystem16,
+		Slugs:     []string{"system16"},
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemSegaSystem18: {
+		ID:        SystemSegaSystem18,
+		Slugs:     []string{"system18"},
+		Fallbacks: []string{SystemArcade},
+	},
+	SystemTaitoF2: {
+		ID:        SystemTaitoF2,
+		Fallbacks: []string{SystemArcade},
 	},
 	SystemAtariST: {
 		ID:    SystemAtariST,

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -42,6 +42,7 @@ var misterArcadeSystemSpecs = []arcadeSystemSpec{
 type arcadeSystemCache struct {
 	platform        *Platform
 	scanArcadeFiles func(context.Context, *config.Instance) ([]platforms.ScanResult, error)
+	readArcadeDB    func(platforms.Platform) ([]arcadedb.ArcadeDbEntry, error)
 	results         map[string][]platforms.ScanResult
 	mu              syncutil.Mutex
 	loaded          bool
@@ -50,6 +51,7 @@ type arcadeSystemCache struct {
 func newArcadeSystemCache(platform *Platform) *arcadeSystemCache {
 	cache := &arcadeSystemCache{platform: platform}
 	cache.scanArcadeFiles = cache.scanFiles
+	cache.readArcadeDB = arcadedb.ReadArcadeDb
 	return cache
 }
 
@@ -105,7 +107,7 @@ func (c *arcadeSystemCache) load(
 		}
 	}
 
-	entries, err := arcadedb.ReadArcadeDb(c.platform)
+	entries, err := c.readArcadeDB(c.platform)
 	if err != nil {
 		log.Warn().Err(err).Msg("unable to classify MiSTer arcade systems")
 		c.loaded = true
@@ -211,21 +213,23 @@ func addNeoGeoMVSLauncher(
 	var cached []platforms.ScanResult
 	var loaded bool
 
-	updatedNeoGeo.Scanner = func(
+	scanAndCache := func(
 		ctx context.Context,
 		cfg *config.Instance,
 		systemID string,
 		results []platforms.ScanResult,
 	) ([]platforms.ScanResult, error) {
 		scanned, err := baseScanner(ctx, cfg, systemID, results)
-		if err == nil {
-			mu.Lock()
-			cached = append([]platforms.ScanResult(nil), scanned...)
-			loaded = true
-			mu.Unlock()
+		if err != nil {
+			return scanned, err
 		}
-		return scanned, err
+		mu.Lock()
+		cached = append([]platforms.ScanResult(nil), scanned...)
+		loaded = true
+		mu.Unlock()
+		return scanned, nil
 	}
+	updatedNeoGeo.Scanner = scanAndCache
 
 	neoGeoMVS = platforms.Launcher{
 		ID:         systemdefs.SystemNeoGeoMVS,
@@ -250,7 +254,7 @@ func addNeoGeoMVSLauncher(
 			if wasLoaded {
 				return results, nil
 			}
-			return baseScanner(ctx, cfg, systemdefs.SystemNeoGeo, nil)
+			return scanAndCache(ctx, cfg, systemdefs.SystemNeoGeo, nil)
 		},
 	}
 	return updatedNeoGeo, neoGeoMVS
@@ -261,18 +265,23 @@ func launchNeoGeoMVS(platform *Platform) func(
 ) (*os.Process, error) {
 	baseLaunch := launch(platform, systemdefs.SystemNeoGeo)
 	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
-		launchOpts := platforms.LaunchOptions{}
-		if opts != nil {
-			launchOpts = *opts
-		}
-		if launchOpts.SetName == "" {
-			launchOpts.SetName = systemdefs.SystemNeoGeoMVS
-		}
-		if launchOpts.SetNameSameDir == "" {
-			launchOpts.SetNameSameDir = "true"
-		}
+		launchOpts := neoGeoMVSLaunchOptions(opts)
 		return baseLaunch(cfg, path, &launchOpts)
 	}
+}
+
+func neoGeoMVSLaunchOptions(opts *platforms.LaunchOptions) platforms.LaunchOptions {
+	launchOpts := platforms.LaunchOptions{}
+	if opts != nil {
+		launchOpts = *opts
+	}
+	if launchOpts.SetName == "" {
+		launchOpts.SetName = systemdefs.SystemNeoGeoMVS
+	}
+	if launchOpts.SetNameSameDir == "" {
+		launchOpts.SetNameSameDir = "true"
+	}
+	return launchOpts
 }
 
 func addArcadeSystemLaunchers(platform *Platform, launchers []platforms.Launcher) []platforms.Launcher {

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -27,6 +27,7 @@ type arcadeSystemSpec struct {
 var misterArcadeSystemSpecs = []arcadeSystemSpec{
 	{systemID: systemdefs.SystemCPS1, platforms: []string{"Capcom CPS-1", "Capcom CPS-1.5"}},
 	{systemID: systemdefs.SystemCPS2, platforms: []string{"Capcom CPS-2"}},
+	{systemID: systemdefs.SystemCPS3, platforms: []string{"Capcom CPS-3"}},
 	{systemID: systemdefs.SystemIremM72, platforms: []string{"Irem M72"}},
 	{systemID: systemdefs.SystemIremM92, platforms: []string{"Irem M92"}},
 	{systemID: systemdefs.SystemJalecoMegaSystem1, platforms: []string{"Jaleco Mega System 1"}},
@@ -39,14 +40,17 @@ var misterArcadeSystemSpecs = []arcadeSystemSpec{
 }
 
 type arcadeSystemCache struct {
-	platform *Platform
-	results  map[string][]platforms.ScanResult
-	mu       syncutil.Mutex
-	loaded   bool
+	platform        *Platform
+	scanArcadeFiles func(context.Context, *config.Instance) ([]platforms.ScanResult, error)
+	results         map[string][]platforms.ScanResult
+	mu              syncutil.Mutex
+	loaded          bool
 }
 
 func newArcadeSystemCache(platform *Platform) *arcadeSystemCache {
-	return &arcadeSystemCache{platform: platform}
+	cache := &arcadeSystemCache{platform: platform}
+	cache.scanArcadeFiles = cache.scanFiles
+	return cache
 }
 
 func (c *arcadeSystemCache) captureScanner(
@@ -55,7 +59,9 @@ func (c *arcadeSystemCache) captureScanner(
 	_ string,
 	results []platforms.ScanResult,
 ) ([]platforms.ScanResult, error) {
-	c.load(ctx, cfg, results)
+	if err := c.load(ctx, cfg, results); err != nil {
+		return nil, err
+	}
 	return results, nil
 }
 
@@ -68,7 +74,9 @@ func (c *arcadeSystemCache) scanner(systemID string) func(
 		_ string,
 		_ []platforms.ScanResult,
 	) ([]platforms.ScanResult, error) {
-		c.load(ctx, cfg, nil)
+		if err := c.load(ctx, cfg, nil); err != nil {
+			return nil, err
+		}
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		return append([]platforms.ScanResult(nil), c.results[systemID]...), nil
@@ -79,28 +87,38 @@ func (c *arcadeSystemCache) load(
 	ctx context.Context,
 	cfg *config.Instance,
 	files []platforms.ScanResult,
-) {
+) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.loaded {
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	if len(files) == 0 {
-		files = c.scanArcadeFiles(ctx, cfg)
+		var err error
+		files, err = c.scanArcadeFiles(ctx, cfg)
+		if err != nil {
+			return err
+		}
 	}
 
 	entries, err := arcadedb.ReadArcadeDb(c.platform)
 	if err != nil {
 		log.Warn().Err(err).Msg("unable to classify MiSTer arcade systems")
 		c.loaded = true
-		return
+		return nil
 	}
 
 	setSystems := arcadeSetSystems(entries)
 
-	c.results = make(map[string][]platforms.ScanResult, len(misterArcadeSystemSpecs))
+	classified := make(map[string][]platforms.ScanResult, len(misterArcadeSystemSpecs))
 	for i := range files {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if !strings.EqualFold(filepath.Ext(files[i].Path), ".mra") {
 			continue
 		}
@@ -110,10 +128,12 @@ func (c *arcadeSystemCache) load(
 			continue
 		}
 		if systemID := setSystems[strings.ToLower(mra.SetName)]; systemID != "" {
-			c.results[systemID] = append(c.results[systemID], files[i])
+			classified[systemID] = append(classified[systemID], files[i])
 		}
 	}
+	c.results = classified
 	c.loaded = true
+	return nil
 }
 
 func arcadeSetSystems(entries []arcadedb.ArcadeDbEntry) map[string]string {
@@ -132,26 +152,32 @@ func arcadeSetSystems(entries []arcadedb.ArcadeDbEntry) map[string]string {
 	return setSystems
 }
 
-func (c *arcadeSystemCache) scanArcadeFiles(
+func (c *arcadeSystemCache) scanFiles(
 	ctx context.Context,
 	cfg *config.Instance,
-) []platforms.ScanResult {
+) ([]platforms.ScanResult, error) {
 	var results []platforms.ScanResult
 	for _, root := range c.platform.RootDirs(cfg) {
 		select {
 		case <-ctx.Done():
-			return results
+			return nil, ctx.Err()
 		default:
 		}
 
 		arcadePath, err := mediascanner.FindPath(ctx, filepath.Join(root, "_Arcade"))
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			continue
 		}
 		walkErr := afero.Walk(
 			c.platform.filesystem(),
 			arcadePath,
 			func(path string, info os.FileInfo, walkEntryErr error) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				if walkEntryErr != nil {
 					return walkEntryErr
 				}
@@ -166,10 +192,13 @@ func (c *arcadeSystemCache) scanArcadeFiles(
 			},
 		)
 		if walkErr != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			log.Warn().Err(walkErr).Str("path", arcadePath).Msg("unable to scan MiSTer arcade files for classification")
 		}
 	}
-	return results
+	return results, nil
 }
 
 func addNeoGeoMVSLauncher(

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -1,0 +1,270 @@
+//go:build linux
+
+package mister
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediascanner"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+type arcadeSystemSpec struct {
+	systemID  string
+	platforms []string
+}
+
+var misterArcadeSystemSpecs = []arcadeSystemSpec{
+	{systemID: systemdefs.SystemCPS1, platforms: []string{"Capcom CPS-1", "Capcom CPS-1.5"}},
+	{systemID: systemdefs.SystemCPS2, platforms: []string{"Capcom CPS-2"}},
+	{systemID: systemdefs.SystemIremM72, platforms: []string{"Irem M72"}},
+	{systemID: systemdefs.SystemIremM92, platforms: []string{"Irem M92"}},
+	{systemID: systemdefs.SystemJalecoMegaSystem1, platforms: []string{"Jaleco Mega System 1"}},
+	{systemID: systemdefs.SystemNamcoSystem1, platforms: []string{"Namco System-1"}},
+	{systemID: systemdefs.SystemPGM, platforms: []string{"IGS PGM"}},
+	{systemID: systemdefs.SystemSegaSTV, platforms: []string{"Sega ST-V"}},
+	{systemID: systemdefs.SystemSegaSystem16, platforms: []string{"Sega System 16"}},
+	{systemID: systemdefs.SystemSegaSystem18, platforms: []string{"Sega System 18"}},
+	{systemID: systemdefs.SystemTaitoF2, platforms: []string{"Taito F2 System"}},
+}
+
+type arcadeSystemCache struct {
+	platform *Platform
+	results  map[string][]platforms.ScanResult
+	mu       syncutil.Mutex
+	loaded   bool
+}
+
+func newArcadeSystemCache(platform *Platform) *arcadeSystemCache {
+	return &arcadeSystemCache{platform: platform}
+}
+
+func (c *arcadeSystemCache) captureScanner(
+	ctx context.Context,
+	cfg *config.Instance,
+	_ string,
+	results []platforms.ScanResult,
+) ([]platforms.ScanResult, error) {
+	c.load(ctx, cfg, results)
+	return results, nil
+}
+
+func (c *arcadeSystemCache) scanner(systemID string) func(
+	context.Context, *config.Instance, string, []platforms.ScanResult,
+) ([]platforms.ScanResult, error) {
+	return func(
+		ctx context.Context,
+		cfg *config.Instance,
+		_ string,
+		_ []platforms.ScanResult,
+	) ([]platforms.ScanResult, error) {
+		c.load(ctx, cfg, nil)
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return append([]platforms.ScanResult(nil), c.results[systemID]...), nil
+	}
+}
+
+func (c *arcadeSystemCache) load(
+	ctx context.Context,
+	cfg *config.Instance,
+	files []platforms.ScanResult,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.loaded {
+		return
+	}
+
+	if len(files) == 0 {
+		files = c.scanArcadeFiles(ctx, cfg)
+	}
+
+	entries, err := arcadedb.ReadArcadeDb(c.platform)
+	if err != nil {
+		log.Warn().Err(err).Msg("unable to classify MiSTer arcade systems")
+		c.loaded = true
+		return
+	}
+
+	setSystems := arcadeSetSystems(entries)
+
+	c.results = make(map[string][]platforms.ScanResult, len(misterArcadeSystemSpecs))
+	for i := range files {
+		if !strings.EqualFold(filepath.Ext(files[i].Path), ".mra") {
+			continue
+		}
+		mra, readErr := mgls.ReadMRA(files[i].Path)
+		if readErr != nil {
+			log.Debug().Err(readErr).Str("path", files[i].Path).Msg("unable to classify arcade MRA")
+			continue
+		}
+		if systemID := setSystems[strings.ToLower(mra.SetName)]; systemID != "" {
+			c.results[systemID] = append(c.results[systemID], files[i])
+		}
+	}
+	c.loaded = true
+}
+
+func arcadeSetSystems(entries []arcadedb.ArcadeDbEntry) map[string]string {
+	platformSystems := make(map[string]string)
+	for _, spec := range misterArcadeSystemSpecs {
+		for _, platformName := range spec.platforms {
+			platformSystems[platformName] = spec.systemID
+		}
+	}
+	setSystems := make(map[string]string, len(entries))
+	for i := range entries {
+		if systemID := platformSystems[entries[i].Platform]; systemID != "" {
+			setSystems[strings.ToLower(entries[i].Setname)] = systemID
+		}
+	}
+	return setSystems
+}
+
+func (c *arcadeSystemCache) scanArcadeFiles(
+	ctx context.Context,
+	cfg *config.Instance,
+) []platforms.ScanResult {
+	var results []platforms.ScanResult
+	for _, root := range c.platform.RootDirs(cfg) {
+		select {
+		case <-ctx.Done():
+			return results
+		default:
+		}
+
+		arcadePath, err := mediascanner.FindPath(ctx, filepath.Join(root, "_Arcade"))
+		if err != nil {
+			continue
+		}
+		walkErr := afero.Walk(
+			c.platform.filesystem(),
+			arcadePath,
+			func(path string, info os.FileInfo, walkEntryErr error) error {
+				if walkEntryErr != nil {
+					return walkEntryErr
+				}
+				if info.IsDir() {
+					return nil
+				}
+				ext := filepath.Ext(path)
+				if strings.EqualFold(ext, ".mra") || strings.EqualFold(ext, ".mgl") {
+					results = append(results, platforms.ScanResult{Path: path})
+				}
+				return nil
+			},
+		)
+		if walkErr != nil {
+			log.Warn().Err(walkErr).Str("path", arcadePath).Msg("unable to scan MiSTer arcade files for classification")
+		}
+	}
+	return results
+}
+
+func addNeoGeoMVSLauncher(
+	platform *Platform,
+	neoGeo *platforms.Launcher,
+) (updatedNeoGeo, neoGeoMVS platforms.Launcher) {
+	updatedNeoGeo = *neoGeo
+	baseScanner := updatedNeoGeo.Scanner
+	var mu syncutil.Mutex
+	var cached []platforms.ScanResult
+	var loaded bool
+
+	updatedNeoGeo.Scanner = func(
+		ctx context.Context,
+		cfg *config.Instance,
+		systemID string,
+		results []platforms.ScanResult,
+	) ([]platforms.ScanResult, error) {
+		scanned, err := baseScanner(ctx, cfg, systemID, results)
+		if err == nil {
+			mu.Lock()
+			cached = append([]platforms.ScanResult(nil), scanned...)
+			loaded = true
+			mu.Unlock()
+		}
+		return scanned, err
+	}
+
+	neoGeoMVS = platforms.Launcher{
+		ID:         systemdefs.SystemNeoGeoMVS,
+		SystemID:   systemdefs.SystemNeoGeoMVS,
+		Folders:    []string{"NEOGEO"},
+		Extensions: []string{".neo", ".zip"},
+		Test: func(_ *config.Instance, path string) bool {
+			return filepath.Ext(path) == ""
+		},
+		SkipFilesystemScan: true,
+		Launch:             launchNeoGeoMVS(platform),
+		Scanner: func(
+			ctx context.Context,
+			cfg *config.Instance,
+			_ string,
+			_ []platforms.ScanResult,
+		) ([]platforms.ScanResult, error) {
+			mu.Lock()
+			wasLoaded := loaded
+			results := append([]platforms.ScanResult(nil), cached...)
+			mu.Unlock()
+			if wasLoaded {
+				return results, nil
+			}
+			return baseScanner(ctx, cfg, systemdefs.SystemNeoGeo, nil)
+		},
+	}
+	return updatedNeoGeo, neoGeoMVS
+}
+
+func launchNeoGeoMVS(platform *Platform) func(
+	*config.Instance, string, *platforms.LaunchOptions,
+) (*os.Process, error) {
+	baseLaunch := launch(platform, systemdefs.SystemNeoGeo)
+	return func(cfg *config.Instance, path string, opts *platforms.LaunchOptions) (*os.Process, error) {
+		launchOpts := platforms.LaunchOptions{}
+		if opts != nil {
+			launchOpts = *opts
+		}
+		if launchOpts.SetName == "" {
+			launchOpts.SetName = systemdefs.SystemNeoGeoMVS
+		}
+		if launchOpts.SetNameSameDir == "" {
+			launchOpts.SetNameSameDir = "true"
+		}
+		return baseLaunch(cfg, path, &launchOpts)
+	}
+}
+
+func addArcadeSystemLaunchers(platform *Platform, launchers []platforms.Launcher) []platforms.Launcher {
+	cache := newArcadeSystemCache(platform)
+	for i := range launchers {
+		if launchers[i].ID == systemdefs.SystemArcade {
+			launchers[i].Scanner = cache.captureScanner
+			break
+		}
+	}
+
+	for _, spec := range misterArcadeSystemSpecs {
+		launchers = append(launchers, platforms.Launcher{
+			ID:                 spec.systemID,
+			SystemID:           spec.systemID,
+			Folders:            []string{"_Arcade"},
+			Extensions:         []string{".mra"},
+			SkipFilesystemScan: true,
+			Scanner:            cache.scanner(spec.systemID),
+			Launch:             launchArcade(platform, systemdefs.SystemArcade),
+		})
+	}
+	return launchers
+}

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -5,6 +5,9 @@ package mister
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -21,16 +24,78 @@ func TestArcadeSetSystemsMapsCuratedPlatforms(t *testing.T) {
 	setSystems := arcadeSetSystems([]arcadedb.ArcadeDbEntry{
 		{Setname: "CPS1GAME", Platform: "Capcom CPS-1"},
 		{Setname: "cps15game", Platform: "Capcom CPS-1.5"},
+		{Setname: "cps2game", Platform: "Capcom CPS-2"},
 		{Setname: "CPS3GAME", Platform: "Capcom CPS-3"},
+		{Setname: "m72game", Platform: "Irem M72"},
+		{Setname: "m92game", Platform: "Irem M92"},
+		{Setname: "jalecogame", Platform: "Jaleco Mega System 1"},
+		{Setname: "namcogame", Platform: "Namco System-1"},
 		{Setname: "pgmgame", Platform: "IGS PGM"},
+		{Setname: "stvgame", Platform: "Sega ST-V"},
+		{Setname: "system16game", Platform: "Sega System 16"},
+		{Setname: "system18game", Platform: "Sega System 18"},
+		{Setname: "taitogame", Platform: "Taito F2 System"},
 		{Setname: "unknown", Platform: "Unique hardware"},
 	})
 
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps1game"])
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps15game"])
+	assert.Equal(t, systemdefs.SystemCPS2, setSystems["cps2game"])
 	assert.Equal(t, systemdefs.SystemCPS3, setSystems["cps3game"])
+	assert.Equal(t, systemdefs.SystemIremM72, setSystems["m72game"])
+	assert.Equal(t, systemdefs.SystemIremM92, setSystems["m92game"])
+	assert.Equal(t, systemdefs.SystemJalecoMegaSystem1, setSystems["jalecogame"])
+	assert.Equal(t, systemdefs.SystemNamcoSystem1, setSystems["namcogame"])
 	assert.Equal(t, systemdefs.SystemPGM, setSystems["pgmgame"])
+	assert.Equal(t, systemdefs.SystemSegaSTV, setSystems["stvgame"])
+	assert.Equal(t, systemdefs.SystemSegaSystem16, setSystems["system16game"])
+	assert.Equal(t, systemdefs.SystemSegaSystem18, setSystems["system18game"])
+	assert.Equal(t, systemdefs.SystemTaitoF2, setSystems["taitogame"])
 	assert.NotContains(t, setSystems, "unknown")
+}
+
+func TestArcadeSystemCacheClassifiesProvidedMRAFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	classifiedPath := filepath.Join(dir, "game.mra")
+	require.NoError(t, os.WriteFile(classifiedPath, []byte(
+		"<misterromdescription><setname>CPS1GAME</setname></misterromdescription>",
+	), 0o600))
+	malformedPath := filepath.Join(dir, "malformed.mra")
+	require.NoError(t, os.WriteFile(malformedPath, []byte("<invalid>"), 0o600))
+	mglPath := filepath.Join(dir, "shortcut.mgl")
+	require.NoError(t, os.WriteFile(mglPath, []byte("ignored"), 0o600))
+
+	cache := newArcadeSystemCache(NewPlatform())
+	readCalls := 0
+	cache.readArcadeDB = func(platforms.Platform) ([]arcadedb.ArcadeDbEntry, error) {
+		readCalls++
+		return []arcadedb.ArcadeDbEntry{{Setname: "cps1game", Platform: "Capcom CPS-1"}}, nil
+	}
+	input := []platforms.ScanResult{
+		{Path: classifiedPath, Name: "Classified"},
+		{Path: malformedPath},
+		{Path: mglPath},
+	}
+
+	unchanged, err := cache.captureScanner(context.Background(), &config.Instance{}, systemdefs.SystemArcade, input)
+	require.NoError(t, err)
+	assert.Equal(t, input, unchanged)
+
+	results, err := cache.scanner(systemdefs.SystemCPS1)(
+		context.Background(), &config.Instance{}, systemdefs.SystemCPS1, nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []platforms.ScanResult{{Path: classifiedPath, Name: "Classified"}}, results)
+	assert.Equal(t, 1, readCalls)
+
+	results[0].Path = "mutated"
+	results, err = cache.scanner(systemdefs.SystemCPS1)(
+		context.Background(), &config.Instance{}, systemdefs.SystemCPS1, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, classifiedPath, results[0].Path)
 }
 
 func TestArcadeSystemCacheRetriesAfterCancelledScan(t *testing.T) {
@@ -63,6 +128,28 @@ func TestArcadeSystemCacheRetriesAfterCancelledScan(t *testing.T) {
 	assert.Equal(t, 2, calls)
 }
 
+func TestArcadeSystemCacheScanFilesFiltersSupportedExtensions(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	arcadeDir := filepath.Join(root, "_Arcade", "subdirectory")
+	require.NoError(t, os.MkdirAll(arcadeDir, 0o750))
+	mraPath := filepath.Join(arcadeDir, "game.mra")
+	mglPath := filepath.Join(arcadeDir, "shortcut.MGL")
+	txtPath := filepath.Join(arcadeDir, "notes.txt")
+	for _, path := range []string{mraPath, mglPath, txtPath} {
+		require.NoError(t, os.WriteFile(path, []byte("test"), 0o600))
+	}
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[launchers]\nindex_root = [%q]\n", root)))
+	cache := newArcadeSystemCache(NewPlatform())
+
+	results, err := cache.scanFiles(context.Background(), cfg)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []platforms.ScanResult{{Path: mraPath}, {Path: mglPath}}, results)
+}
+
 func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {
 	t.Parallel()
 
@@ -89,6 +176,35 @@ func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {
 		assert.Equal(t, 1, calls)
 	})
 
+	t.Run("MVS scan populates shared cache", func(t *testing.T) {
+		t.Parallel()
+
+		expected := []platforms.ScanResult{{Path: "kof98.neo", Name: "The King of Fighters '98"}}
+		calls := 0
+		neoGeo := platforms.Launcher{Scanner: func(
+			context.Context, *config.Instance, string, []platforms.ScanResult,
+		) ([]platforms.ScanResult, error) {
+			calls++
+			return expected, nil
+		}}
+
+		updated, mvs := addNeoGeoMVSLauncher(NewPlatform(), &neoGeo)
+		results, err := mvs.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeoMVS, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, results)
+		assert.Equal(t, 1, calls)
+
+		results, err = updated.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeo, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, results)
+		assert.Equal(t, 2, calls)
+
+		results, err = mvs.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeoMVS, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, results)
+		assert.Equal(t, 2, calls)
+	})
+
 	t.Run("scanner error is not cached", func(t *testing.T) {
 		t.Parallel()
 
@@ -108,6 +224,23 @@ func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {
 		require.ErrorIs(t, err, scanErr)
 		assert.Equal(t, 2, calls)
 	})
+}
+
+func TestNeoGeoMVSLaunchOptions(t *testing.T) {
+	t.Parallel()
+
+	defaults := neoGeoMVSLaunchOptions(nil)
+	assert.Equal(t, systemdefs.SystemNeoGeoMVS, defaults.SetName)
+	assert.Equal(t, "true", defaults.SetNameSameDir)
+
+	explicit := neoGeoMVSLaunchOptions(&platforms.LaunchOptions{
+		SetName:        "CustomMVS",
+		SetNameSameDir: "false",
+		Action:         "details",
+	})
+	assert.Equal(t, "CustomMVS", explicit.SetName)
+	assert.Equal(t, "false", explicit.SetNameSameDir)
+	assert.Equal(t, "details", explicit.Action)
 }
 
 func TestArcadeSystemLaunchersPreserveArcadeAndAddGranularSystems(t *testing.T) {

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -3,8 +3,11 @@
 package mister
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
@@ -18,14 +21,93 @@ func TestArcadeSetSystemsMapsCuratedPlatforms(t *testing.T) {
 	setSystems := arcadeSetSystems([]arcadedb.ArcadeDbEntry{
 		{Setname: "CPS1GAME", Platform: "Capcom CPS-1"},
 		{Setname: "cps15game", Platform: "Capcom CPS-1.5"},
+		{Setname: "CPS3GAME", Platform: "Capcom CPS-3"},
 		{Setname: "pgmgame", Platform: "IGS PGM"},
 		{Setname: "unknown", Platform: "Unique hardware"},
 	})
 
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps1game"])
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps15game"])
+	assert.Equal(t, systemdefs.SystemCPS3, setSystems["cps3game"])
 	assert.Equal(t, systemdefs.SystemPGM, setSystems["pgmgame"])
 	assert.NotContains(t, setSystems, "unknown")
+}
+
+func TestArcadeSystemCacheRetriesAfterCancelledScan(t *testing.T) {
+	t.Parallel()
+
+	cache := newArcadeSystemCache(NewPlatform())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := cache.scanFiles(ctx, &config.Instance{})
+	require.ErrorIs(t, err, context.Canceled)
+
+	calls := 0
+	cache.scanArcadeFiles = func(context.Context, *config.Instance) ([]platforms.ScanResult, error) {
+		calls++
+		if calls == 1 {
+			return []platforms.ScanResult{{Path: "partial.mra"}}, context.Canceled
+		}
+		return nil, nil
+	}
+
+	_, err = cache.captureScanner(context.Background(), &config.Instance{}, systemdefs.SystemArcade, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, cache.loaded)
+	assert.Empty(t, cache.results)
+
+	_, err = cache.scanner(systemdefs.SystemCPS1)(
+		context.Background(), &config.Instance{}, systemdefs.SystemCPS1, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful scan", func(t *testing.T) {
+		t.Parallel()
+
+		expected := []platforms.ScanResult{{Path: "mslug.neo", Name: "Metal Slug"}}
+		calls := 0
+		neoGeo := platforms.Launcher{Scanner: func(
+			context.Context, *config.Instance, string, []platforms.ScanResult,
+		) ([]platforms.ScanResult, error) {
+			calls++
+			return expected, nil
+		}}
+
+		updated, mvs := addNeoGeoMVSLauncher(NewPlatform(), &neoGeo)
+		results, err := updated.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeo, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, results)
+
+		results, err = mvs.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeoMVS, nil)
+		require.NoError(t, err)
+		assert.Equal(t, expected, results)
+		assert.Equal(t, 1, calls)
+	})
+
+	t.Run("scanner error is not cached", func(t *testing.T) {
+		t.Parallel()
+
+		scanErr := errors.New("scan failed")
+		calls := 0
+		neoGeo := platforms.Launcher{Scanner: func(
+			context.Context, *config.Instance, string, []platforms.ScanResult,
+		) ([]platforms.ScanResult, error) {
+			calls++
+			return nil, scanErr
+		}}
+
+		updated, mvs := addNeoGeoMVSLauncher(NewPlatform(), &neoGeo)
+		_, err := updated.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeo, nil)
+		require.ErrorIs(t, err, scanErr)
+		_, err = mvs.Scanner(context.Background(), &config.Instance{}, systemdefs.SystemNeoGeoMVS, nil)
+		require.ErrorIs(t, err, scanErr)
+		assert.Equal(t, 2, calls)
+	})
 }
 
 func TestArcadeSystemLaunchersPreserveArcadeAndAddGranularSystems(t *testing.T) {

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -1,0 +1,53 @@
+//go:build linux
+
+package mister
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArcadeSetSystemsMapsCuratedPlatforms(t *testing.T) {
+	t.Parallel()
+
+	setSystems := arcadeSetSystems([]arcadedb.ArcadeDbEntry{
+		{Setname: "CPS1GAME", Platform: "Capcom CPS-1"},
+		{Setname: "cps15game", Platform: "Capcom CPS-1.5"},
+		{Setname: "pgmgame", Platform: "IGS PGM"},
+		{Setname: "unknown", Platform: "Unique hardware"},
+	})
+
+	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps1game"])
+	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps15game"])
+	assert.Equal(t, systemdefs.SystemPGM, setSystems["pgmgame"])
+	assert.NotContains(t, setSystems, "unknown")
+}
+
+func TestArcadeSystemLaunchersPreserveArcadeAndAddGranularSystems(t *testing.T) {
+	t.Parallel()
+
+	launchers := addArcadeSystemLaunchers(NewPlatform(), CreateLaunchers(NewPlatform()))
+	byID := make(map[string]platforms.Launcher, len(launchers))
+	for i := range launchers {
+		byID[launchers[i].ID] = launchers[i]
+	}
+
+	arcade, ok := byID[systemdefs.SystemArcade]
+	require.True(t, ok)
+	assert.False(t, arcade.SkipFilesystemScan)
+	assert.NotNil(t, arcade.Scanner)
+
+	for _, spec := range misterArcadeSystemSpecs {
+		launcher, found := byID[spec.systemID]
+		require.True(t, found, spec.systemID)
+		assert.True(t, launcher.SkipFilesystemScan, spec.systemID)
+		assert.Equal(t, []string{"_Arcade"}, launcher.Folders, spec.systemID)
+		assert.NotNil(t, launcher.Scanner, spec.systemID)
+		assert.NotNil(t, launcher.Launch, spec.systemID)
+	}
+}

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -78,10 +78,11 @@ func TestArcadeSystemCacheClassifiesProvidedMRAFiles(t *testing.T) {
 		{Path: malformedPath},
 		{Path: mglPath},
 	}
+	inputBefore := append([]platforms.ScanResult(nil), input...)
 
 	unchanged, err := cache.captureScanner(context.Background(), &config.Instance{}, systemdefs.SystemArcade, input)
 	require.NoError(t, err)
-	assert.Equal(t, input, unchanged)
+	assert.Equal(t, inputBefore, unchanged)
 
 	results, err := cache.scanner(systemdefs.SystemCPS1)(
 		context.Background(), &config.Instance{}, systemdefs.SystemCPS1, nil,
@@ -246,7 +247,8 @@ func TestNeoGeoMVSLaunchOptions(t *testing.T) {
 func TestArcadeSystemLaunchersPreserveArcadeAndAddGranularSystems(t *testing.T) {
 	t.Parallel()
 
-	launchers := addArcadeSystemLaunchers(NewPlatform(), CreateLaunchers(NewPlatform()))
+	platform := NewPlatform()
+	launchers := addArcadeSystemLaunchers(platform, CreateLaunchers(platform))
 	byID := make(map[string]platforms.Launcher, len(launchers))
 	for i := range launchers {
 		byID[launchers[i].ID] = launchers[i]
@@ -255,7 +257,23 @@ func TestArcadeSystemLaunchersPreserveArcadeAndAddGranularSystems(t *testing.T) 
 	arcade, ok := byID[systemdefs.SystemArcade]
 	require.True(t, ok)
 	assert.False(t, arcade.SkipFilesystemScan)
-	assert.NotNil(t, arcade.Scanner)
+	require.NotNil(t, arcade.Scanner)
+
+	dir := t.TempDir()
+	classifiedPath := filepath.Join(dir, "classified.mra")
+	unclassifiedPath := filepath.Join(dir, "unclassified.mra")
+	require.NoError(t, os.WriteFile(classifiedPath, []byte(
+		"<misterromdescription><setname>1941</setname></misterromdescription>",
+	), 0o600))
+	require.NoError(t, os.WriteFile(unclassifiedPath, []byte(
+		"<misterromdescription><setname>unknown</setname></misterromdescription>",
+	), 0o600))
+	arcadeInput := []platforms.ScanResult{{Path: classifiedPath}, {Path: unclassifiedPath}}
+	arcadeResults, err := arcade.Scanner(
+		context.Background(), &config.Instance{}, systemdefs.SystemArcade, arcadeInput,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, arcadeInput, arcadeResults)
 
 	for _, spec := range misterArcadeSystemSpecs {
 		launcher, found := byID[spec.systemID]

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1417,8 +1417,12 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 		},
 	}
 
-	ls := CreateLaunchers(p)
-	ls = append(ls, amiga, neogeo, createVideoLauncher(p), createScummVMLauncher(p), createAudioScannerLauncher())
+	neogeo, neogeoMVS := addNeoGeoMVSLauncher(p, &neogeo)
+	ls := addArcadeSystemLaunchers(p, CreateLaunchers(p))
+	ls = append(
+		ls, amiga, neogeo, neogeoMVS,
+		createVideoLauncher(p), createScummVMLauncher(p), createAudioScannerLauncher(),
+	)
 
 	custom := helpers.ParseCustomLaunchers(p, cfg.CustomLaunchers())
 	return append(custom, ls...)

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -20,6 +20,7 @@
 package zapscript
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -439,9 +440,9 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	if len(ps) == 2 {
 		systemID, searchQuery := ps[0], ps[1]
 
-		var systems []systemdefs.System
+		var systemTiers [][]systemdefs.System
 		if strings.EqualFold(systemID, "all") {
-			systems = systemdefs.AllSystems()
+			systemTiers = [][]systemdefs.System{systemdefs.AllSystems()}
 		} else {
 			system, lookupErr := systemdefs.LookupSystem(systemID)
 			if lookupErr != nil {
@@ -449,46 +450,17 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			} else if system == nil {
 				return platforms.CmdResult{}, fmt.Errorf("system not found: %s", systemID)
 			}
-			systems = systemdefs.SystemsWithFallbacks([]systemdefs.System{*system})
+			systemTiers = orderedSystemTiers([]systemdefs.System{*system})
 		}
 
-		// Handle the special case of /* pattern - use RandomGameWithQuery
-		if searchQuery == "*" {
-			systemIDs := make([]string, len(systems))
-			for i, sys := range systems {
-				systemIDs[i] = sys.ID
-			}
-			mediaQuery := database.MediaQuery{
-				Systems: systemIDs,
-				Tags:    tagFilters,
-			}
-			game, randomErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
-			if randomErr != nil {
-				return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", randomErr)
-			}
-
-			if launchErr := launch(launchTarget{
-				path: game.Path, systemID: game.SystemID, mediaID: game.MediaID,
-			}); launchErr != nil {
-				return platforms.CmdResult{
-					MediaChanged: true,
-				}, fmt.Errorf("failed to launch random game '%s': %w", game.Path, launchErr)
-			}
-			return platforms.CmdResult{
-				MediaChanged: true,
-			}, nil
-		}
-
-		systemIDs := make([]string, len(systems))
-		for i, sys := range systems {
-			systemIDs[i] = sys.ID
-		}
 		mediaQuery := database.MediaQuery{
-			Systems:  systemIDs,
 			PathGlob: searchQuery,
 			Tags:     tagFilters,
 		}
-		game, randomErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+		if searchQuery == "*" {
+			mediaQuery.PathGlob = ""
+		}
+		game, randomErr := randomGameBySystemTier(ctx, gamesdb, &mediaQuery, systemTiers)
 		if randomErr != nil {
 			return platforms.CmdResult{},
 				fmt.Errorf("failed to get random game matching '%s': %w", searchQuery, randomErr)
@@ -519,17 +491,8 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		systems = append(systems, *system)
 	}
 
-	systems = systemdefs.SystemsWithFallbacks(systems)
-
-	systemIDs := make([]string, len(systems))
-	for i, sys := range systems {
-		systemIDs[i] = sys.ID
-	}
-	mediaQuery := database.MediaQuery{
-		Systems: systemIDs,
-		Tags:    tagFilters,
-	}
-	game, err := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+	mediaQuery := database.MediaQuery{Tags: tagFilters}
+	game, err := randomGameBySystemTier(ctx, gamesdb, &mediaQuery, orderedSystemTiers(systems))
 	if err != nil {
 		return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", err)
 	}
@@ -544,6 +507,85 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	return platforms.CmdResult{
 		MediaChanged: true,
 	}, nil
+}
+
+func orderedSystemTiers(systems []systemdefs.System) [][]systemdefs.System {
+	if len(systems) == 0 {
+		return nil
+	}
+
+	primary := make([]systemdefs.System, 0, len(systems))
+	seen := make(map[string]struct{}, len(systems)*2)
+	for i := range systems {
+		if _, ok := seen[systems[i].ID]; ok {
+			continue
+		}
+		seen[systems[i].ID] = struct{}{}
+		primary = append(primary, systems[i])
+	}
+	tiers := [][]systemdefs.System{primary}
+	for i := range primary {
+		for _, fallbackID := range primary[i].Fallbacks {
+			if _, ok := seen[fallbackID]; ok {
+				continue
+			}
+			fallback, err := systemdefs.GetSystem(fallbackID)
+			if err != nil {
+				continue
+			}
+			seen[fallbackID] = struct{}{}
+			tiers = append(tiers, []systemdefs.System{*fallback})
+		}
+	}
+	return tiers
+}
+
+func systemIDs(systems []systemdefs.System) []string {
+	ids := make([]string, len(systems))
+	for i := range systems {
+		ids[i] = systems[i].ID
+	}
+	return ids
+}
+
+func randomGameBySystemTier(
+	ctx context.Context,
+	gamesDB database.MediaDBI,
+	query *database.MediaQuery,
+	tiers [][]systemdefs.System,
+) (database.SearchResult, error) {
+	for i := range tiers {
+		tierQuery := *query
+		tierQuery.Systems = systemIDs(tiers[i])
+		result, err := gamesDB.RandomGameWithQuery(ctx, &tierQuery)
+		if err == nil {
+			return result, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return database.SearchResult{}, fmt.Errorf("failed to query random media tier: %w", err)
+		}
+	}
+	return database.SearchResult{}, sql.ErrNoRows
+}
+
+func searchMediaBySystemTier(
+	ctx context.Context,
+	gamesDB database.MediaDBI,
+	filters *database.SearchFilters,
+	tiers [][]systemdefs.System,
+) ([]database.SearchResultWithCursor, error) {
+	for i := range tiers {
+		tierFilters := *filters
+		tierFilters.Systems = tiers[i]
+		results, err := gamesDB.SearchMediaWithFilters(ctx, &tierFilters)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search media tier: %w", err)
+		}
+		if len(results) > 0 {
+			return results, nil
+		}
+	}
+	return nil, nil
 }
 
 func findLauncher(pl platforms.Platform, cfg *platforms.CmdEnv, launcherID string) *platforms.Launcher {
@@ -869,28 +911,30 @@ func cmdSearch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		return platforms.CmdResult{}, errors.New("no query specified")
 	}
 
-	var systems []systemdefs.System
+	var systemTiers [][]systemdefs.System
 
 	if strings.EqualFold(systemID, "all") {
-		systems = systemdefs.AllSystems()
+		systemTiers = [][]systemdefs.System{systemdefs.AllSystems()}
 	} else {
 		system, lookupErr := systemdefs.LookupSystem(systemID)
 		if lookupErr != nil {
 			return platforms.CmdResult{}, fmt.Errorf("failed to lookup system '%s': %w", systemID, lookupErr)
 		}
+		if system == nil {
+			return platforms.CmdResult{}, fmt.Errorf("system not found: %s", systemID)
+		}
 
-		systems = systemdefs.SystemsWithFallbacks([]systemdefs.System{*system})
+		systemTiers = orderedSystemTiers([]systemdefs.System{*system})
 	}
 
 	searchFilters := database.SearchFilters{
-		Systems: systems,
-		Query:   searchQuery,
-		Tags:    tagFilters,
-		Limit:   1,
+		Query: searchQuery,
+		Tags:  tagFilters,
+		Limit: 1,
 	}
 	ctx, cancel := mediaDBLookupContext(&env)
 	defer cancel()
-	res, searchErr := gamesdb.SearchMediaWithFilters(ctx, &searchFilters)
+	res, searchErr := searchMediaBySystemTier(ctx, gamesdb, &searchFilters, systemTiers)
 	if searchErr != nil {
 		return platforms.CmdResult{}, fmt.Errorf("failed to search systems for '%s': %w", searchQuery, searchErr)
 	}

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	platformshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
@@ -1248,6 +1249,62 @@ func TestCmdSearch_AppliesMediaLauncherOverride(t *testing.T) {
 	assert.True(t, result.MediaChanged)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
+}
+
+func TestRandomGameBySystemTier_TriesFallbackAfterPrimaryMiss(t *testing.T) {
+	t.Parallel()
+
+	primary, err := systemdefs.GetSystem(systemdefs.SystemAmigaCD32)
+	require.NoError(t, err)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything,
+		mock.MatchedBy(func(query *database.MediaQuery) bool {
+			return len(query.Systems) == 1 && query.Systems[0] == systemdefs.SystemAmigaCD32
+		}),
+	).Return(database.SearchResult{}, sql.ErrNoRows).Once()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything,
+		mock.MatchedBy(func(query *database.MediaQuery) bool {
+			return len(query.Systems) == 1 && query.Systems[0] == systemdefs.SystemAmiga
+		}),
+	).Return(database.SearchResult{SystemID: systemdefs.SystemAmiga, Path: "fallback.adf"}, nil).Once()
+
+	result, err := randomGameBySystemTier(
+		context.Background(), mockMediaDB, &database.MediaQuery{}, orderedSystemTiers([]systemdefs.System{*primary}),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, systemdefs.SystemAmiga, result.SystemID)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestSearchMediaBySystemTier_DoesNotCombineFallback(t *testing.T) {
+	t.Parallel()
+
+	primary, err := systemdefs.GetSystem(systemdefs.SystemAmigaCD32)
+	require.NoError(t, err)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmigaCD32
+		}),
+	).Return([]database.SearchResultWithCursor{{SystemID: systemdefs.SystemAmigaCD32, Path: "primary.iso"}}, nil).Once()
+
+	results, err := searchMediaBySystemTier(
+		context.Background(), mockMediaDB, &database.SearchFilters{Query: "primary"},
+		orderedSystemTiers([]systemdefs.System{*primary}),
+	)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, systemdefs.SystemAmigaCD32, results[0].SystemID)
+	mockMediaDB.AssertNotCalled(t, "SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmiga
+		}),
+	)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1251,6 +1251,23 @@ func TestCmdSearch_AppliesMediaLauncherOverride(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestOrderedSystemTiersPreservesFallbackOrder(t *testing.T) {
+	t.Parallel()
+
+	primary, err := systemdefs.GetSystem(systemdefs.SystemNeoGeoMVS)
+	require.NoError(t, err)
+
+	tiers := orderedSystemTiers([]systemdefs.System{*primary, *primary})
+	require.Len(t, tiers, 3)
+	require.Len(t, tiers[0], 1)
+	assert.Equal(t, systemdefs.SystemNeoGeoMVS, tiers[0][0].ID)
+	require.Len(t, tiers[1], 1)
+	assert.Equal(t, systemdefs.SystemNeoGeo, tiers[1][0].ID)
+	require.Len(t, tiers[2], 1)
+	assert.Equal(t, systemdefs.SystemNeoGeoAES, tiers[2][0].ID)
+	assert.Nil(t, orderedSystemTiers(nil))
+}
+
 func TestRandomGameBySystemTier_TriesFallbackAfterPrimaryMiss(t *testing.T) {
 	t.Parallel()
 
@@ -1275,6 +1292,29 @@ func TestRandomGameBySystemTier_TriesFallbackAfterPrimaryMiss(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, systemdefs.SystemAmiga, result.SystemID)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestRandomGameBySystemTierStopsOnDatabaseError(t *testing.T) {
+	t.Parallel()
+
+	primary, err := systemdefs.GetSystem(systemdefs.SystemAmigaCD32)
+	require.NoError(t, err)
+
+	dbErr := errors.New("database unavailable")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything,
+		mock.MatchedBy(func(query *database.MediaQuery) bool {
+			return len(query.Systems) == 1 && query.Systems[0] == systemdefs.SystemAmigaCD32
+		}),
+	).Return(database.SearchResult{}, dbErr).Once()
+
+	_, err = randomGameBySystemTier(
+		context.Background(), mockMediaDB, &database.MediaQuery{}, orderedSystemTiers([]systemdefs.System{*primary}),
+	)
+
+	require.ErrorIs(t, err, dbErr)
+	mockMediaDB.AssertNumberOfCalls(t, "RandomGameWithQuery", 1)
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -1306,6 +1346,112 @@ func TestSearchMediaBySystemTier_DoesNotCombineFallback(t *testing.T) {
 	assert.Equal(t, systemdefs.SystemAmiga, results[0].SystemID)
 	assert.Equal(t, "fallback.adf", results[0].Path)
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestSearchMediaBySystemTierReturnsDatabaseError(t *testing.T) {
+	t.Parallel()
+
+	primary, err := systemdefs.GetSystem(systemdefs.SystemAmigaCD32)
+	require.NoError(t, err)
+
+	dbErr := errors.New("database unavailable")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmigaCD32
+		}),
+	).Return(nil, dbErr).Once()
+
+	_, err = searchMediaBySystemTier(
+		context.Background(), mockMediaDB, &database.SearchFilters{Query: "game"},
+		orderedSystemTiers([]systemdefs.System{*primary}),
+	)
+
+	require.ErrorIs(t, err, dbErr)
+	mockMediaDB.AssertNumberOfCalls(t, "SearchMediaWithFilters", 1)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestCmdRandomSystemWildcardUsesOrderedFallback(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	amigaLauncher := platforms.Launcher{
+		ID: systemdefs.SystemAmiga, SystemID: systemdefs.SystemAmiga, Extensions: []string{".adf"},
+	}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{amigaLauncher})
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "Amiga", "Fallback.adf")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything,
+		mock.MatchedBy(func(query *database.MediaQuery) bool {
+			return len(query.Systems) == 1 && query.Systems[0] == systemdefs.SystemAmigaCD32 &&
+				query.PathGlob == ""
+		}),
+	).Return(database.SearchResult{}, sql.ErrNoRows).Once()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything,
+		mock.MatchedBy(func(query *database.MediaQuery) bool {
+			return len(query.Systems) == 1 && query.Systems[0] == systemdefs.SystemAmiga &&
+				query.PathGlob == ""
+		}),
+	).Return(database.SearchResult{SystemID: systemdefs.SystemAmiga, Path: romPath}, nil).Once()
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		(*platforms.Launcher)(nil),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	result, err := cmdRandom(mockPlatform, platforms.CmdEnv{
+		Cmd: zapscript.Command{Name: "launch.random", Args: []string{systemdefs.SystemAmigaCD32 + "/*"}},
+		Cfg: cfg, Database: &database.Database{MediaDB: mockMediaDB},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdSearchUsesOrderedFallback(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	amigaLauncher := platforms.Launcher{
+		ID: systemdefs.SystemAmiga, SystemID: systemdefs.SystemAmiga, Extensions: []string{".adf"},
+	}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{amigaLauncher})
+
+	romPath := filepath.Join(launchTestAbsPath("games"), "Amiga", "Fallback.adf")
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmigaCD32 &&
+				filters.Query == "fallback"
+		}),
+	).Return([]database.SearchResultWithCursor{}, nil).Once()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmiga &&
+				filters.Query == "fallback"
+		}),
+	).Return([]database.SearchResultWithCursor{{SystemID: systemdefs.SystemAmiga, Path: romPath}}, nil).Once()
+	mockPlatform.On("LaunchMedia", cfg, romPath,
+		(*platforms.Launcher)(nil),
+		mock.Anything,
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	result, err := cmdSearch(mockPlatform, platforms.CmdEnv{
+		Cmd: zapscript.Command{Name: "launch.search", Args: []string{systemdefs.SystemAmigaCD32 + "/fallback"}},
+		Cfg: cfg, Database: &database.Database{MediaDB: mockMediaDB},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
 }
 
 func TestCmdRandom_MediaDBLookupUsesServiceContext(t *testing.T) {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1289,21 +1289,22 @@ func TestSearchMediaBySystemTier_DoesNotCombineFallback(t *testing.T) {
 		mock.MatchedBy(func(filters *database.SearchFilters) bool {
 			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmigaCD32
 		}),
-	).Return([]database.SearchResultWithCursor{{SystemID: systemdefs.SystemAmigaCD32, Path: "primary.iso"}}, nil).Once()
+	).Return([]database.SearchResultWithCursor{}, nil).Once()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmiga
+		}),
+	).Return([]database.SearchResultWithCursor{{SystemID: systemdefs.SystemAmiga, Path: "fallback.adf"}}, nil).Once()
 
 	results, err := searchMediaBySystemTier(
-		context.Background(), mockMediaDB, &database.SearchFilters{Query: "primary"},
+		context.Background(), mockMediaDB, &database.SearchFilters{Query: "fallback"},
 		orderedSystemTiers([]systemdefs.System{*primary}),
 	)
 
 	require.NoError(t, err)
 	require.Len(t, results, 1)
-	assert.Equal(t, systemdefs.SystemAmigaCD32, results[0].SystemID)
-	mockMediaDB.AssertNotCalled(t, "SearchMediaWithFilters", mock.Anything,
-		mock.MatchedBy(func(filters *database.SearchFilters) bool {
-			return len(filters.Systems) == 1 && filters.Systems[0].ID == systemdefs.SystemAmiga
-		}),
-	)
+	assert.Equal(t, systemdefs.SystemAmiga, results[0].SystemID)
+	assert.Equal(t, "fallback.adf", results[0].Path)
 	mockMediaDB.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

- preserve complete MiSTer Arcade indexing while duplicating ArcadeDB-classified games into granular hardware systems
- add CPS, PGM, Sega, Taito, Namco, Irem, and Jaleco arcade system definitions with Arcade fallbacks
- duplicate Neo Geo media as NeoGeoMVS with an independent MiSTer setname configuration
- resolve fallback systems in order instead of combining primary and fallback result pools

Closes #1050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system metadata for additional arcade platforms and reclassified CPS1, CPS2, and CPS3 as **Arcade**.
  * Expanded MiSTer arcade support with curated platform detection, per-system launchers, and **NeoGeo MVS** launcher support.
* **Improvements**
  * Enhanced random launch and search to try the selected system tier first, then fall back tier-by-tier only when needed.
* **Tests**
  * Added coverage for tiered fallback behavior and MiSTer arcade scanner caching/retry semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->