### PR TITLE
feat(mister): support latest RetroAchievements cores

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -408,12 +408,16 @@ func launchAltCoreWithSetNameSameDir(
 
 func retroAchievementsSetName(launcherID string) (string, bool) {
 	switch launcherID {
-	case "RAAtari2600":
+	case "RAAtari2600", "RAAtari7800":
 		return "RA_Atari7800", true
+	case "RAFDS":
+		return "RA_FDS", true
 	case "RAGameboy":
 		return "RA_Gameboy", true
 	case "RAGameboyColor":
 		return "RA_GBC", true
+	case "RAGameGear":
+		return "RA_GameGear", true
 	case "RASuperGameboy":
 		return "RA_SGB", true
 	case "RAGBA":
@@ -424,6 +428,8 @@ func retroAchievementsSetName(launcherID string) (string, bool) {
 		return "RA_MegaDrive", true
 	case "RANeoGeo":
 		return "RA_NeoGeo", true
+	case "RANeoGeoCD":
+		return "RA_NeoGeoCD", true
 	case "RANES":
 		return "RA_NES", true
 	case "RANintendo64":
@@ -436,8 +442,12 @@ func retroAchievementsSetName(launcherID string) (string, bool) {
 		return "RA_SMS", true
 	case "RASNES":
 		return "RA_SNES", true
+	case "RASaturn":
+		return "RA_Saturn", true
 	case "RATurboGrafx16":
 		return "RA_TurboGrafx16", true
+	case "RATurboGrafx16CD":
+		return "RA_TurboGrafx16CD", true
 	default:
 		return "", false
 	}
@@ -1081,6 +1091,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemAtari7800),
 		},
 		{
+			ID:       "RAAtari7800",
+			SystemID: systemdefs.SystemAtari7800,
+			Launch: launchRetroAchievementsCore(
+				"RAAtari7800", systemdefs.SystemAtari7800, "_RA_Cores/Cores/Atari7800",
+			),
+		},
+		{
 			ID:       "DB9Atari7800",
 			SystemID: systemdefs.SystemAtari7800,
 			Launch:   launchDB9Core("DB9Atari7800", systemdefs.SystemAtari7800, "Atari7800"),
@@ -1165,6 +1182,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemFDS),
 		},
 		{
+			ID:       "RAFDS",
+			SystemID: systemdefs.SystemFDS,
+			Launch: launchRetroAchievementsCoreNoSameDir(
+				"RAFDS", systemdefs.SystemFDS, "_RA_Cores/Cores/NES",
+			),
+		},
+		{
 			ID:         systemdefs.SystemGamate,
 			SystemID:   systemdefs.SystemGamate,
 			Folders:    []string{"Gamate"},
@@ -1227,6 +1251,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"SMS", "GameGear"},
 			Extensions: []string{".gg"},
 			Launch:     launch(pl, systemdefs.SystemGameGear),
+		},
+		{
+			ID:       "RAGameGear",
+			SystemID: systemdefs.SystemGameGear,
+			Launch: launchRetroAchievementsCoreNoSameDir(
+				"RAGameGear", systemdefs.SystemGameGear, "_RA_Cores/Cores/SMS",
+			),
 		},
 		{
 			ID:         systemdefs.SystemGameGear2P,
@@ -1451,6 +1482,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"NeoGeo-CD", "NEOGEO"},
 			Extensions: []string{".cue", ".chd"},
 			Launch:     launch(pl, systemdefs.SystemNeoGeoCD),
+		},
+		{
+			ID:       "RANeoGeoCD",
+			SystemID: systemdefs.SystemNeoGeoCD,
+			Launch: launchRetroAchievementsCoreNoSameDir(
+				"RANeoGeoCD", systemdefs.SystemNeoGeoCD, "_RA_Cores/Cores/NeoGeo",
+			),
 		},
 		{
 			ID:         systemdefs.SystemNeoGeoPocket,
@@ -1689,6 +1727,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Launch:     launch(pl, systemdefs.SystemSaturn),
 		},
 		{
+			ID:       "RASaturn",
+			SystemID: systemdefs.SystemSaturn,
+			Launch: launchRetroAchievementsCore(
+				"RASaturn", systemdefs.SystemSaturn, "_RA_Cores/Cores/Saturn",
+			),
+		},
+		{
 			ID:       "LLAPISaturn",
 			SystemID: systemdefs.SystemSaturn,
 			Launch:   launchAltCore("LLAPISaturn", systemdefs.SystemSaturn, "_LLAPI/Saturn_LLAPI"),
@@ -1789,6 +1834,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 			Folders:    []string{"TGFX16-CD"},
 			Extensions: []string{".cue", ".chd"},
 			Launch:     launch(pl, systemdefs.SystemTurboGrafx16CD),
+		},
+		{
+			ID:       "RATurboGrafx16CD",
+			SystemID: systemdefs.SystemTurboGrafx16CD,
+			Launch: launchRetroAchievementsCoreNoSameDir(
+				"RATurboGrafx16CD", systemdefs.SystemTurboGrafx16CD, "_RA_Cores/Cores/TurboGrafx16",
+			),
 		},
 		{
 			ID:         systemdefs.SystemVC4000,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -698,21 +698,27 @@ func TestRetroAchievementsSetNameMapping(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]string{
-		"RANES":          "RA_NES",
-		"RASNES":         "RA_SNES",
-		"RAGameboy":      "RA_Gameboy",
-		"RAGameboyColor": "RA_GBC",
-		"RASuperGameboy": "RA_SGB",
-		"RAGBA":          "RA_GBA",
-		"RANintendo64":   "RA_N64",
-		"RAPSX":          "RA_PSX",
-		"RAMegaDrive":    "RA_MegaDrive",
-		"RAMegaCD":       "RA_MegaCD",
-		"RASMS":          "RA_SMS",
-		"RANeoGeo":       "RA_NeoGeo",
-		"RATurboGrafx16": "RA_TurboGrafx16",
-		"RAAtari2600":    "RA_Atari7800",
-		"RAS32X":         "RA_S32X",
+		"RANES":            "RA_NES",
+		"RAFDS":            "RA_FDS",
+		"RASNES":           "RA_SNES",
+		"RAGameboy":        "RA_Gameboy",
+		"RAGameboyColor":   "RA_GBC",
+		"RAGameGear":       "RA_GameGear",
+		"RASuperGameboy":   "RA_SGB",
+		"RAGBA":            "RA_GBA",
+		"RANintendo64":     "RA_N64",
+		"RAPSX":            "RA_PSX",
+		"RAMegaDrive":      "RA_MegaDrive",
+		"RAMegaCD":         "RA_MegaCD",
+		"RASMS":            "RA_SMS",
+		"RANeoGeo":         "RA_NeoGeo",
+		"RANeoGeoCD":       "RA_NeoGeoCD",
+		"RATurboGrafx16":   "RA_TurboGrafx16",
+		"RATurboGrafx16CD": "RA_TurboGrafx16CD",
+		"RAAtari2600":      "RA_Atari7800",
+		"RAAtari7800":      "RA_Atari7800",
+		"RAS32X":           "RA_S32X",
+		"RASaturn":         "RA_Saturn",
 	}
 
 	for launcherID, want := range cases {
@@ -746,9 +752,15 @@ func TestRetroAchievementsSetNameSameDirRegression(t *testing.T) {
 		{launcherID: "RANeoGeo", wantSetName: "RA_NeoGeo", wantSameDir: true},
 		{launcherID: "RATurboGrafx16", wantSetName: "RA_TurboGrafx16", wantSameDir: true},
 		{launcherID: "RAAtari2600", wantSetName: "RA_Atari7800", wantSameDir: true},
+		{launcherID: "RAAtari7800", wantSetName: "RA_Atari7800", wantSameDir: true},
 		{launcherID: "RAS32X", wantSetName: "RA_S32X", wantSameDir: true},
+		{launcherID: "RASaturn", wantSetName: "RA_Saturn", wantSameDir: true},
+		{launcherID: "RAFDS", wantSetName: "RA_FDS", wantSameDir: false},
 		{launcherID: "RAGameboyColor", wantSetName: "RA_GBC", wantSameDir: false},
+		{launcherID: "RAGameGear", wantSetName: "RA_GameGear", wantSameDir: false},
+		{launcherID: "RANeoGeoCD", wantSetName: "RA_NeoGeoCD", wantSameDir: false},
 		{launcherID: "RASuperGameboy", wantSetName: "RA_SGB", wantSameDir: false},
+		{launcherID: "RATurboGrafx16CD", wantSetName: "RA_TurboGrafx16CD", wantSameDir: false},
 	}
 
 	for _, tc := range cases {
@@ -900,9 +912,11 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 		systemID string
 	}{
 		{"RANES", "NES"},
+		{"RAFDS", "FDS"},
 		{"RASNES", "SNES"},
 		{"RAGameboy", "Gameboy"},
 		{"RAGameboyColor", "GameboyColor"},
+		{"RAGameGear", "GameGear"},
 		{"RASuperGameboy", "SuperGameboy"},
 		{"RAGBA", "GBA"},
 		{"RANintendo64", "Nintendo64"},
@@ -911,9 +925,13 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 		{"RAMegaCD", "MegaCD"},
 		{"RASMS", "MasterSystem"},
 		{"RANeoGeo", "NeoGeo"},
+		{"RANeoGeoCD", "NeoGeoCD"},
 		{"RATurboGrafx16", "TurboGrafx16"},
+		{"RATurboGrafx16CD", "TurboGrafx16CD"},
 		{"RAAtari2600", "Atari2600"},
+		{"RAAtari7800", "Atari7800"},
 		{"RAS32X", "Sega32X"},
+		{"RASaturn", "Saturn"},
 	}
 
 	for _, tc := range cases {
@@ -1013,15 +1031,4 @@ func TestRetroAchievementsAtari2600RejectsInvalidSetName(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid set_name")
-}
-
-func TestRetroAchievementsAtari7800LauncherRemoved(t *testing.T) {
-	t.Parallel()
-
-	pl := NewPlatform()
-	launchers := CreateLaunchers(pl)
-
-	for i := range launchers {
-		assert.NotEqual(t, "RAAtari7800", launchers[i].ID)
-	}
 }


### PR DESCRIPTION
## Summary
- add MiSTer RetroAchievements launchers for newly supported Saturn and Atari 7800 cores
- support shared-core FDS, Game Gear, Neo Geo CD, and TurboGrafx-CD systems with dedicated set names
- preserve virtual-system ROM paths by disabling `same_dir` where no separate RBF exists
- extend launcher, set-name, and shared-directory regression coverage

Closes #1051
Closes #1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RetroAchievements launchers for Atari 7800, Famicom Disk System, Game Gear, Neo Geo CD, Sega Saturn, and TurboGrafx-16 CD.
  - Expanded support for identifying and grouping RetroAchievements game sets across these platforms.
  - Added platform-specific launch options to improve compatibility when launching supported titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->