### PR TITLE
feat: expand media system definitions

### DIFF
--- a/pkg/assets/systems/Application.json
+++ b/pkg/assets/systems/Application.json
@@ -1,0 +1,7 @@
+{
+  "id": "Application",
+  "name": "Applications",
+  "category": "Software",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/assets/systems/Audiobook.json
+++ b/pkg/assets/systems/Audiobook.json
@@ -1,0 +1,7 @@
+{
+  "id": "Audiobook",
+  "name": "Audiobook",
+  "category": "Media",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/assets/systems/MusicVideo.json
+++ b/pkg/assets/systems/MusicVideo.json
@@ -1,0 +1,7 @@
+{
+  "id": "MusicVideo",
+  "name": "Music Video",
+  "category": "Media",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/assets/systems/PodcastEpisode.json
+++ b/pkg/assets/systems/PodcastEpisode.json
@@ -1,0 +1,7 @@
+{
+  "id": "PodcastEpisode",
+  "name": "Podcast Episode",
+  "category": "Media",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/assets/systems/PodcastSeries.json
+++ b/pkg/assets/systems/PodcastSeries.json
@@ -1,0 +1,7 @@
+{
+  "id": "PodcastSeries",
+  "name": "Podcast Series",
+  "category": "Media",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/assets/systems/TVSeason.json
+++ b/pkg/assets/systems/TVSeason.json
@@ -1,0 +1,7 @@
+{
+  "id": "TVSeason",
+  "name": "TV Season",
+  "category": "Media",
+  "releaseDate": "",
+  "manufacturer": ""
+}

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -455,12 +455,18 @@ const (
 	SystemTIC80             = "TIC80"
 	SystemVideo             = "Video"
 	SystemAudio             = "Audio"
+	SystemApplication       = "Application"
 	SystemMovie             = "Movie"
 	SystemTVEpisode         = "TVEpisode"
+	SystemTVSeason          = "TVSeason"
 	SystemTVShow            = "TVShow"
 	SystemMusicTrack        = "MusicTrack"
 	SystemMusicArtist       = "MusicArtist"
 	SystemMusicAlbum        = "MusicAlbum"
+	SystemMusicVideo        = "MusicVideo"
+	SystemPodcastSeries     = "PodcastSeries"
+	SystemPodcastEpisode    = "PodcastEpisode"
+	SystemAudiobook         = "Audiobook"
 	SystemImage             = "Image"
 	SystemJ2ME              = "J2ME"
 	SystemGroovy            = "Groovy"
@@ -1203,6 +1209,11 @@ var Systems = map[string]System{
 		Slugs:     []string{"audiofile"},
 		MediaType: MediaTypeAudio,
 	},
+	SystemApplication: {
+		ID:        SystemApplication,
+		Aliases:   []string{"App", "Apps", "Software"},
+		MediaType: MediaTypeApplication,
+	},
 	SystemMovie: {
 		ID:        SystemMovie,
 		Slugs:     []string{"movies", "film", "cinema"},
@@ -1213,6 +1224,12 @@ var Systems = map[string]System{
 		ID:        SystemTVEpisode,
 		Aliases:   []string{"TV"},
 		Slugs:     []string{"television", "tvchannel"},
+		MediaType: MediaTypeTVShow,
+		Fallbacks: []string{SystemVideo},
+	},
+	SystemTVSeason: {
+		ID:        SystemTVSeason,
+		Slugs:     []string{"tvseasons", "televisionseason", "televisionseasons"},
 		MediaType: MediaTypeTVShow,
 		Fallbacks: []string{SystemVideo},
 	},
@@ -1239,6 +1256,30 @@ var Systems = map[string]System{
 		ID:        SystemMusicAlbum,
 		Slugs:     []string{"lp", "album", "albums"},
 		MediaType: MediaTypeMusic,
+		Fallbacks: []string{SystemAudio},
+	},
+	SystemMusicVideo: {
+		ID:        SystemMusicVideo,
+		Slugs:     []string{"musicvideos"},
+		MediaType: MediaTypeMusic,
+		Fallbacks: []string{SystemVideo},
+	},
+	SystemPodcastSeries: {
+		ID:        SystemPodcastSeries,
+		Slugs:     []string{"podcastshow", "podcastshows"},
+		MediaType: MediaTypeAudio,
+		Fallbacks: []string{SystemAudio},
+	},
+	SystemPodcastEpisode: {
+		ID:        SystemPodcastEpisode,
+		Slugs:     []string{"podcastepisodes"},
+		MediaType: MediaTypeAudio,
+		Fallbacks: []string{SystemAudio},
+	},
+	SystemAudiobook: {
+		ID:        SystemAudiobook,
+		Slugs:     []string{"audiobooks"},
+		MediaType: MediaTypeAudio,
 		Fallbacks: []string{SystemAudio},
 	},
 	SystemImage: {

--- a/pkg/database/systemdefs/systemdefs_test.go
+++ b/pkg/database/systemdefs/systemdefs_test.go
@@ -184,8 +184,9 @@ func TestAllSystemsHaveMetadataJSON(t *testing.T) {
 				"Other":    true,
 				"Media":    true,
 				"Handheld": true,
+				"Software": true,
 			}
-			expectedCategories := "Console, Computer, Arcade, Other, Media, Handheld"
+			expectedCategories := "Console, Computer, Arcade, Other, Media, Handheld, Software"
 			assert.True(t, validCategories[metadata.Category],
 				"System %s has invalid category '%s', expected one of: %s",
 				systemID, metadata.Category, expectedCategories)
@@ -690,16 +691,17 @@ func TestAllSystemsHaveMediaType(t *testing.T) {
 
 			// MediaType should be one of the defined constants
 			validTypes := map[MediaType]bool{
-				MediaTypeGame:   true,
-				MediaTypeMovie:  true,
-				MediaTypeTVShow: true,
-				MediaTypeMusic:  true,
-				MediaTypeImage:  true,
-				MediaTypeAudio:  true,
-				MediaTypeVideo:  true,
+				MediaTypeGame:        true,
+				MediaTypeMovie:       true,
+				MediaTypeTVShow:      true,
+				MediaTypeMusic:       true,
+				MediaTypeImage:       true,
+				MediaTypeAudio:       true,
+				MediaTypeVideo:       true,
+				MediaTypeApplication: true,
 			}
 			assert.True(t, validTypes[mediaType],
-				"System %s has invalid MediaType %q, must be one of: Game, Movie, TVShow, Music, Image, Audio, Video",
+				"System %s has invalid MediaType %q; expected a supported media type",
 				systemID, mediaType)
 		})
 	}
@@ -715,12 +717,18 @@ func TestMediaTypeSystems(t *testing.T) {
 	}{
 		{SystemVideo, MediaTypeVideo},
 		{SystemAudio, MediaTypeAudio},
+		{SystemApplication, MediaTypeApplication},
 		{SystemMovie, MediaTypeMovie},
 		{SystemTVEpisode, MediaTypeTVShow},
+		{SystemTVSeason, MediaTypeTVShow},
 		{SystemTVShow, MediaTypeTVShow},
 		{SystemMusicTrack, MediaTypeMusic},
 		{SystemMusicArtist, MediaTypeMusic},
 		{SystemMusicAlbum, MediaTypeMusic},
+		{SystemMusicVideo, MediaTypeMusic},
+		{SystemPodcastSeries, MediaTypeAudio},
+		{SystemPodcastEpisode, MediaTypeAudio},
+		{SystemAudiobook, MediaTypeAudio},
 		{SystemImage, MediaTypeImage},
 	}
 


### PR DESCRIPTION
## Summary
- add system definitions for applications, TV seasons, music videos, podcasts, and audiobooks
- add embedded metadata for each new system
- extend system definition tests for new categories and media types

## Verification
- `task lint-fix`
- `task test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional media types, including applications, TV seasons, music videos, podcast series and episodes, and audiobooks.
  * Expanded media categorization and metadata support for software and application content.
  * Added definitions for the newly supported content types, including names, categories, release dates, and manufacturers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->