### PR TITLE
fix(tui): paginate media search results

### DIFF
--- a/pkg/ui/tui/searchmedia.go
+++ b/pkg/ui/tui/searchmedia.go
@@ -244,58 +244,70 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 		} else {
 			frame.SetHelpText("Searching...")
 		}
+		// Search state and widgets stay confined to the tview event loop. The
+		// worker only performs the blocking request and queues its result here.
 		searching = true
 		app.ForceDraw()
-		defer func() {
-			searching = false
+
+		go func() {
+			searchCtx, searchCancel := context.WithTimeout(context.Background(), config.APIRequestTimeout)
+			results, err := svc.SearchMedia(searchCtx, params)
+			searchCancel()
+			if err != nil {
+				log.Warn().Err(err).Msg("error executing search query")
+			}
+
+			app.QueueUpdateDraw(func() {
+				if err != nil {
+					searching = false
+					if appendPage {
+						frame.SetHelpText("Error loading more results")
+					} else {
+						nextCursor = nil
+						activeSearchName = ""
+						activeSearchSystem = ""
+						frame.SetHelpText("An error occurred during search")
+					}
+					return
+				}
+
+				selectedIndex := mediaList.GetCurrentItem()
+				if !appendPage {
+					activeSearchName = searchName
+					activeSearchSystem = searchSystem
+					mediaList.Clear()
+					resultPaths = nil
+					selectedIndex = 0
+				}
+				appendResults(results.Results)
+
+				nextCursor = nil
+				if results.Pagination != nil &&
+					results.Pagination.HasNextPage && results.Pagination.NextCursor != nil {
+					nextCursor = results.Pagination.NextCursor
+				}
+
+				if len(resultPaths) > 0 {
+					if selectedIndex >= len(resultPaths) {
+						selectedIndex = len(resultPaths) - 1
+					}
+					mediaList.SetCurrentItem(selectedIndex)
+					frame.SetInfoText(fmt.Sprintf(
+						"[%s]%s[-]", CurrentTheme().SecondaryColor, resultPaths[selectedIndex]))
+					app.SetFocus(mediaList)
+				} else {
+					frame.SetInfoText("")
+				}
+
+				resultWord := "results"
+				if len(resultPaths) == 1 {
+					resultWord = "result"
+				}
+				frame.SetHelpText(fmt.Sprintf(
+					"Loaded %d %s. Select to write token", len(resultPaths), resultWord))
+				searching = false
+			})
 		}()
-
-		searchCtx, searchCancel := context.WithTimeout(context.Background(), config.APIRequestTimeout)
-		results, err := svc.SearchMedia(searchCtx, params)
-		searchCancel()
-		if err != nil {
-			log.Warn().Err(err).Msg("error executing search query")
-			if appendPage {
-				frame.SetHelpText("Error loading more results")
-			} else {
-				frame.SetHelpText("An error occurred during search")
-			}
-			return
-		}
-
-		selectedIndex := mediaList.GetCurrentItem()
-		if !appendPage {
-			activeSearchName = searchName
-			activeSearchSystem = searchSystem
-			mediaList.Clear()
-			resultPaths = nil
-			selectedIndex = 0
-		}
-		appendResults(results.Results)
-
-		nextCursor = nil
-		if results.Pagination != nil && results.Pagination.HasNextPage && results.Pagination.NextCursor != nil {
-			nextCursor = results.Pagination.NextCursor
-		}
-
-		if len(resultPaths) > 0 {
-			if selectedIndex >= len(resultPaths) {
-				selectedIndex = len(resultPaths) - 1
-			}
-			mediaList.SetCurrentItem(selectedIndex)
-			frame.SetInfoText(fmt.Sprintf(
-				"[%s]%s[-]", CurrentTheme().SecondaryColor, resultPaths[selectedIndex]))
-			app.SetFocus(mediaList)
-		} else {
-			frame.SetInfoText("")
-		}
-
-		resultWord := "results"
-		if len(resultPaths) == 1 {
-			resultWord = "result"
-		}
-		frame.SetHelpText(fmt.Sprintf(
-			"Loaded %d %s. Select to write token", len(resultPaths), resultWord))
 	}
 
 	loadNextPage = func() {

--- a/pkg/ui/tui/searchmedia.go
+++ b/pkg/ui/tui/searchmedia.go
@@ -34,6 +34,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const mediaSearchPrefetchThreshold = 10
+
 // writeTagForMedia is a helper for writing media search results to tags.
 func writeTagForMedia(
 	pages *tview.Pages,
@@ -87,6 +89,9 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 
 	searching := false
 	var resultPaths []string
+	var nextCursor *string
+	var activeSearchName, activeSearchSystem string
+	var loadNextPage func()
 
 	scrollList := NewScrollIndicatorList()
 	mediaList := scrollList.GetList()
@@ -96,6 +101,9 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 			frame.SetInfoText(fmt.Sprintf("[%s]%s[-]", CurrentTheme().SecondaryColor, resultPaths[index]))
 		} else {
 			frame.SetInfoText("")
+		}
+		if nextCursor != nil && loadNextPage != nil && index >= len(resultPaths)-mediaSearchPrefetchThreshold {
+			loadNextPage()
 		}
 	})
 
@@ -173,45 +181,13 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 		app.SetFocus(selector)
 	}
 
-	search := func() {
-		if searching {
-			return
-		}
+	var executeSearch func(cursor *string, appendPage bool)
 
-		searchName := session.GetSearchMediaName()
-		params := models.SearchParams{
-			Query: &searchName,
-		}
-
-		searchSystem := session.GetSearchMediaSystem()
-		if searchSystem != "" {
-			systemsFilter := []string{searchSystem}
-			params.Systems = &systemsFilter
-		}
-
-		frame.SetHelpText("Searching...")
-		searching = true
-		app.ForceDraw()
-		defer func() {
-			searching = false
-		}()
-
-		searchCtx, searchCancel := context.WithTimeout(context.Background(), config.APIRequestTimeout)
-		results, err := svc.SearchMedia(searchCtx, params)
-		searchCancel()
-		if err != nil {
-			log.Warn().Err(err).Msg("error executing search query")
-			frame.SetHelpText("An error occurred during search")
-			return
-		}
-
-		mediaList.Clear()
-		mediaList.SetCurrentItem(0)
-		resultPaths = make([]string, len(results.Results))
+	appendResults := func(results []models.SearchResultMedia) {
 		tuiCfg := config.GetTUIConfig()
-		for i := range results.Results {
-			result := &results.Results[i]
-			resultPaths[i] = result.Path
+		for i := range results {
+			result := &results[i]
+			resultPaths = append(resultPaths, result.Path)
 			var displayName, writeValue string
 			if tuiCfg.WriteFormat == "path" {
 				// Check if path is a virtual path (contains ://)
@@ -240,21 +216,98 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 				writeTagForMedia(pages, app, svc, value, mediaList)
 			})
 		}
-		// Update info text for first result
+	}
+
+	executeSearch = func(cursor *string, appendPage bool) {
+		if searching {
+			return
+		}
+
+		searchName := session.GetSearchMediaName()
+		searchSystem := session.GetSearchMediaSystem()
+		if appendPage {
+			searchName = activeSearchName
+			searchSystem = activeSearchSystem
+		}
+		params := models.SearchParams{
+			Query:  &searchName,
+			Cursor: cursor,
+		}
+
+		if searchSystem != "" {
+			systemsFilter := []string{searchSystem}
+			params.Systems = &systemsFilter
+		}
+
+		if appendPage {
+			frame.SetHelpText("Loading more results...")
+		} else {
+			frame.SetHelpText("Searching...")
+		}
+		searching = true
+		app.ForceDraw()
+		defer func() {
+			searching = false
+		}()
+
+		searchCtx, searchCancel := context.WithTimeout(context.Background(), config.APIRequestTimeout)
+		results, err := svc.SearchMedia(searchCtx, params)
+		searchCancel()
+		if err != nil {
+			log.Warn().Err(err).Msg("error executing search query")
+			if appendPage {
+				frame.SetHelpText("Error loading more results")
+			} else {
+				frame.SetHelpText("An error occurred during search")
+			}
+			return
+		}
+
+		selectedIndex := mediaList.GetCurrentItem()
+		if !appendPage {
+			activeSearchName = searchName
+			activeSearchSystem = searchSystem
+			mediaList.Clear()
+			resultPaths = nil
+			selectedIndex = 0
+		}
+		appendResults(results.Results)
+
+		nextCursor = nil
+		if results.Pagination != nil && results.Pagination.HasNextPage && results.Pagination.NextCursor != nil {
+			nextCursor = results.Pagination.NextCursor
+		}
+
 		if len(resultPaths) > 0 {
-			frame.SetInfoText(fmt.Sprintf("[%s]%s[-]", CurrentTheme().SecondaryColor, resultPaths[0]))
+			if selectedIndex >= len(resultPaths) {
+				selectedIndex = len(resultPaths) - 1
+			}
+			mediaList.SetCurrentItem(selectedIndex)
+			frame.SetInfoText(fmt.Sprintf(
+				"[%s]%s[-]", CurrentTheme().SecondaryColor, resultPaths[selectedIndex]))
+			app.SetFocus(mediaList)
 		} else {
 			frame.SetInfoText("")
 		}
 
 		resultWord := "results"
-		if len(results.Results) == 1 {
+		if len(resultPaths) == 1 {
 			resultWord = "result"
 		}
-		frame.SetHelpText(fmt.Sprintf("Found %d %s. Select to write token", len(results.Results), resultWord))
-		if results.Total > 0 {
-			app.SetFocus(mediaList)
+		frame.SetHelpText(fmt.Sprintf(
+			"Loaded %d %s. Select to write token", len(resultPaths), resultWord))
+	}
+
+	loadNextPage = func() {
+		if nextCursor == nil {
+			return
 		}
+		cursor := *nextCursor
+		executeSearch(&cursor, true)
+	}
+
+	search := func() {
+		executeSearch(nil, false)
 	}
 
 	var lastLeftFocus tview.Primitive = searchInput
@@ -356,6 +409,9 @@ func BuildSearchMedia(svc SettingsService, pages *tview.Pages, app *tview.Applic
 		systemButton.SetLabel(truncateSystemName("All"))
 		mediaList.Clear()
 		resultPaths = nil
+		nextCursor = nil
+		activeSearchName = ""
+		activeSearchSystem = ""
 		frame.SetInfoText("")
 		frame.SetHelpText("Type query in Name and press Search")
 		app.SetFocus(searchInput)

--- a/pkg/ui/tui/searchmedia_test.go
+++ b/pkg/ui/tui/searchmedia_test.go
@@ -135,6 +135,31 @@ func TestTruncateSystemName(t *testing.T) {
 	}
 }
 
+func psxFirstPageResult(nextCursor string) *models.SearchResults {
+	return &models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game One",
+				Path:      "game-one.chd",
+				ZapScript: "@PlayStation/Game One",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+			{
+				Name:      "Game Two",
+				Path:      "game-two.chd",
+				ZapScript: "@PlayStation/Game Two",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 2,
+		Pagination: &models.PaginationInfo{
+			NextCursor:  &nextCursor,
+			HasNextPage: true,
+			PageSize:    2,
+		},
+	}
+}
+
 func TestBuildSearchMedia_Integration(t *testing.T) {
 	t.Parallel()
 
@@ -249,28 +274,7 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 	nextCursor := "next-page"
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor == nil
-	})).Return(&models.SearchResults{
-		Results: []models.SearchResultMedia{
-			{
-				Name:      "Game One",
-				Path:      "game-one.chd",
-				ZapScript: "@PlayStation/Game One",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-			{
-				Name:      "Game Two",
-				Path:      "game-two.chd",
-				ZapScript: "@PlayStation/Game Two",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-		},
-		Total: 2,
-		Pagination: &models.PaginationInfo{
-			NextCursor:  &nextCursor,
-			HasNextPage: true,
-			PageSize:    2,
-		},
-	}, nil).Once()
+	})).Return(psxFirstPageResult(nextCursor), nil).Once()
 	releaseNextPage := make(chan time.Time)
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor != nil && *params.Cursor == nextCursor &&
@@ -347,28 +351,7 @@ func TestBuildSearchMedia_AutoloadErrorCanRetry_Integration(t *testing.T) {
 	nextCursor := "next-page"
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor == nil
-	})).Return(&models.SearchResults{
-		Results: []models.SearchResultMedia{
-			{
-				Name:      "Game One",
-				Path:      "game-one.chd",
-				ZapScript: "@PlayStation/Game One",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-			{
-				Name:      "Game Two",
-				Path:      "game-two.chd",
-				ZapScript: "@PlayStation/Game Two",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-		},
-		Total: 2,
-		Pagination: &models.PaginationInfo{
-			NextCursor:  &nextCursor,
-			HasNextPage: true,
-			PageSize:    2,
-		},
-	}, nil).Once()
+	})).Return(psxFirstPageResult(nextCursor), nil).Once()
 	moreParams := mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor != nil && *params.Cursor == nextCursor
 	})
@@ -430,28 +413,7 @@ func TestBuildSearchMedia_FreshSearchErrorClearsPagination_Integration(t *testin
 	nextCursor := "stale-cursor"
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor == nil && params.Query != nil && *params.Query == ""
-	})).Return(&models.SearchResults{
-		Results: []models.SearchResultMedia{
-			{
-				Name:      "Game One",
-				Path:      "game-one.chd",
-				ZapScript: "@PlayStation/Game One",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-			{
-				Name:      "Game Two",
-				Path:      "game-two.chd",
-				ZapScript: "@PlayStation/Game Two",
-				System:    models.System{ID: "psx", Name: "PlayStation"},
-			},
-		},
-		Total: 2,
-		Pagination: &models.PaginationInfo{
-			NextCursor:  &nextCursor,
-			HasNextPage: true,
-			PageSize:    2,
-		},
-	}, nil).Once()
+	})).Return(psxFirstPageResult(nextCursor), nil).Once()
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor == nil && params.Query != nil && *params.Query == "new query"
 	})).Return(nil, errors.New("fresh search failed")).Once()

--- a/pkg/ui/tui/searchmedia_test.go
+++ b/pkg/ui/tui/searchmedia_test.go
@@ -271,6 +271,7 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 			PageSize:    2,
 		},
 	}, nil).Once()
+	releaseNextPage := make(chan time.Time)
 	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
 		return params.Cursor != nil && *params.Cursor == nextCursor &&
 			params.Query != nil && *params.Query == ""
@@ -288,7 +289,7 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 			HasNextPage: false,
 			PageSize:    2,
 		},
-	}, nil).Once()
+	}, nil).WaitUntil(releaseNextPage).Once()
 
 	runner.Start(pages)
 	runner.Draw()
@@ -302,12 +303,26 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 	runner.SimulateTab()
 	runner.SimulateEnter()
 	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
 	assert.Equal(t, 1, mockSvc.SearchMediaCallCount(), "initial selection should not immediately prefetch")
 
 	// Editing the input must not combine the previous page's cursor with a new query.
 	session.SetSearchMediaName("different query")
-	runner.SimulateArrowDown()
+	scrollDone := make(chan struct{})
+	go func() {
+		runner.SimulateArrowDown()
+		close(scrollDone)
+	}()
+	select {
+	case <-scrollDone:
+	case <-time.After(100 * time.Millisecond):
+		close(releaseNextPage)
+		<-scrollDone
+		t.Fatal("scrolling blocked while the next page loaded")
+	}
 	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Loading more results", 100*time.Millisecond))
+	close(releaseNextPage)
 
 	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
 	assert.True(t, runner.ContainsText("Game One"), "first page should remain visible")
@@ -386,6 +401,7 @@ func TestBuildSearchMedia_AutoloadErrorCanRetry_Integration(t *testing.T) {
 	runner.SimulateTab()
 	runner.SimulateEnter()
 	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
 	runner.SimulateArrowDown()
 	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
 
@@ -396,6 +412,78 @@ func TestBuildSearchMedia_AutoloadErrorCanRetry_Integration(t *testing.T) {
 	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
 	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
 	assert.True(t, runner.ContainsText("Game One"), "retry should preserve first page")
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBuildSearchMedia_FreshSearchErrorClearsPagination_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+
+	pages := tview.NewPages()
+	pages.AddPage(PageMain, tview.NewTextView().SetText("Main"), true, false)
+
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetSystems([]models.System{{ID: "psx", Name: "PlayStation"}})
+
+	nextCursor := "stale-cursor"
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor == nil && params.Query != nil && *params.Query == ""
+	})).Return(&models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game One",
+				Path:      "game-one.chd",
+				ZapScript: "@PlayStation/Game One",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+			{
+				Name:      "Game Two",
+				Path:      "game-two.chd",
+				ZapScript: "@PlayStation/Game Two",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 2,
+		Pagination: &models.PaginationInfo{
+			NextCursor:  &nextCursor,
+			HasNextPage: true,
+			PageSize:    2,
+		},
+	}, nil).Once()
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor == nil && params.Query != nil && *params.Query == "new query"
+	})).Return(nil, errors.New("fresh search failed")).Once()
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor != nil && *params.Cursor == nextCursor
+	})).Return(&models.SearchResults{}, nil).Maybe()
+
+	runner.Start(pages)
+	runner.Draw()
+
+	session := NewSession()
+	runner.QueueUpdateDraw(func() {
+		BuildSearchMedia(mockSvc, pages, runner.App(), session)
+	})
+	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+
+	runner.SimulateTab()
+	runner.SimulateEnter()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
+
+	runner.SimulateArrowLeft()
+	session.SetSearchMediaName("new query")
+	runner.SimulateEnter()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForText("An error occurred during search", 100*time.Millisecond))
+
+	runner.SimulateTab()
+	runner.SimulateArrowDown()
+	assert.Never(t, func() bool {
+		return mockSvc.SearchMediaCallCount() > 2
+	}, 50*time.Millisecond, 5*time.Millisecond, "failed fresh search should discard the old cursor")
 	mockSvc.AssertExpectations(t)
 }
 

--- a/pkg/ui/tui/searchmedia_test.go
+++ b/pkg/ui/tui/searchmedia_test.go
@@ -20,6 +20,7 @@
 package tui
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -230,6 +232,171 @@ func TestBuildSearchMedia_SearchWithResults_Integration(t *testing.T) {
 	// Wait for SearchMedia to be called using the mock's signal channel
 	called := mockSvc.SearchMediaCalled()
 	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond), "SearchMedia should be called")
+}
+
+func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+
+	pages := tview.NewPages()
+	pages.AddPage(PageMain, tview.NewTextView().SetText("Main"), true, false)
+
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetSystems([]models.System{{ID: "psx", Name: "PlayStation"}})
+
+	nextCursor := "next-page"
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor == nil
+	})).Return(&models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game One",
+				Path:      "game-one.chd",
+				ZapScript: "@PlayStation/Game One",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+			{
+				Name:      "Game Two",
+				Path:      "game-two.chd",
+				ZapScript: "@PlayStation/Game Two",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 2,
+		Pagination: &models.PaginationInfo{
+			NextCursor:  &nextCursor,
+			HasNextPage: true,
+			PageSize:    2,
+		},
+	}, nil).Once()
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor != nil && *params.Cursor == nextCursor &&
+			params.Query != nil && *params.Query == ""
+	})).Return(&models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game Three",
+				Path:      "game-three.chd",
+				ZapScript: "@PlayStation/Game Three",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 1,
+		Pagination: &models.PaginationInfo{
+			HasNextPage: false,
+			PageSize:    2,
+		},
+	}, nil).Once()
+
+	runner.Start(pages)
+	runner.Draw()
+
+	session := NewSession()
+	runner.QueueUpdateDraw(func() {
+		BuildSearchMedia(mockSvc, pages, runner.App(), session)
+	})
+	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+
+	runner.SimulateTab()
+	runner.SimulateEnter()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	assert.Equal(t, 1, mockSvc.SearchMediaCallCount(), "initial selection should not immediately prefetch")
+
+	// Editing the input must not combine the previous page's cursor with a new query.
+	session.SetSearchMediaName("different query")
+	runner.SimulateArrowDown()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+
+	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
+	assert.True(t, runner.ContainsText("Game One"), "first page should remain visible")
+	assert.True(t, runner.ContainsText("game-two.chd"), "prefetch should preserve current selection")
+	assert.False(t, runner.ContainsText("Load more results"), "pagination should not add a list row")
+	assert.True(t, runner.ContainsText("Loaded 3 results"))
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBuildSearchMedia_AutoloadErrorCanRetry_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+
+	pages := tview.NewPages()
+	pages.AddPage(PageMain, tview.NewTextView().SetText("Main"), true, false)
+
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetSystems([]models.System{{ID: "psx", Name: "PlayStation"}})
+
+	nextCursor := "next-page"
+	mockSvc.On("SearchMedia", mock.Anything, mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor == nil
+	})).Return(&models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game One",
+				Path:      "game-one.chd",
+				ZapScript: "@PlayStation/Game One",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+			{
+				Name:      "Game Two",
+				Path:      "game-two.chd",
+				ZapScript: "@PlayStation/Game Two",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 2,
+		Pagination: &models.PaginationInfo{
+			NextCursor:  &nextCursor,
+			HasNextPage: true,
+			PageSize:    2,
+		},
+	}, nil).Once()
+	moreParams := mock.MatchedBy(func(params models.SearchParams) bool {
+		return params.Cursor != nil && *params.Cursor == nextCursor
+	})
+	mockSvc.On("SearchMedia", mock.Anything, moreParams).
+		Return(nil, errors.New("temporary search failure")).Once()
+	mockSvc.On("SearchMedia", mock.Anything, moreParams).Return(&models.SearchResults{
+		Results: []models.SearchResultMedia{
+			{
+				Name:      "Game Three",
+				Path:      "game-three.chd",
+				ZapScript: "@PlayStation/Game Three",
+				System:    models.System{ID: "psx", Name: "PlayStation"},
+			},
+		},
+		Total: 1,
+		Pagination: &models.PaginationInfo{
+			HasNextPage: false,
+			PageSize:    1,
+		},
+	}, nil).Once()
+
+	runner.Start(pages)
+	runner.Draw()
+
+	runner.QueueUpdateDraw(func() {
+		BuildSearchMedia(mockSvc, pages, runner.App(), NewSession())
+	})
+	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+
+	runner.SimulateTab()
+	runner.SimulateEnter()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	runner.SimulateArrowDown()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+
+	assert.True(t, runner.WaitForText("Error loading more results", 100*time.Millisecond))
+	assert.False(t, runner.ContainsText("Load more results"), "failed load should not add a list row")
+
+	runner.SimulateArrowUp()
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
+	assert.True(t, runner.ContainsText("Game One"), "retry should preserve first page")
+	mockSvc.AssertExpectations(t)
 }
 
 func TestBuildSearchMedia_DisambiguatingTags_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary

- follow media.search cursors instead of stopping after first 100 results
- prefetch and append next page near end of TUI result list without moving selection
- preserve active search filters across pages and surface loading or retry status in help text
- cover automatic pagination and transient failure recovery

Closes #1023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now automatically load additional pages as you near the end of the list.
  * Existing results remain visible while more items are fetched.
  * Result counts and status update during incremental loading.

* **Bug Fixes**
  * Improved “load more” failure handling with clear messaging and a subsequent retry that preserves prior results.
  * Fresh searches and Clear/reset actions now properly reset pagination to prevent reuse of stale cursors.

* **Tests**
  * Added integration coverage for incremental autoloading, autoload error/retry behavior, and pagination reset after a fresh search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->