### PR TITLE
fix(api): decode percent-encoded paths with parentheses in REST run endpoint

### DIFF
--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -154,6 +154,34 @@ func TestHandleRunRestDecodesPath(t *testing.T) {
 	}
 }
 
+func TestHandleRunRestRejectsMalformedEscapedPath(t *testing.T) {
+	t.Parallel()
+
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+	st, _ := state.NewState(platform, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	tokenQueue := make(chan tokens.Token, 1)
+	handler := HandleRunRest(&config.Instance{}, st, tokenQueue)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/run/invalid", http.NoBody)
+	req.URL.RawPath = "/run/%ZZ"
+
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("*", "%ZZ")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	select {
+	case token := <-tokenQueue:
+		t.Fatalf("REST run handler queued malformed token: %q", token.Text)
+	default:
+	}
+}
+
 func TestHandleRunReturnsWhenRequestContextCancelled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -78,22 +78,16 @@ func TestHandleRunRestReturnsWhenServiceContextCancelled(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 }
 
-// TestHandleRunRestDecodesPathWithParentheses is a regression test for
-// https://github.com/ZaparooProject/zaparoo-core/issues/1099 — filenames
-// containing parentheses (e.g. "Youjyuden (JP).mra") were failing to load
-// via the REST /run endpoint. Go's net/http populates r.URL.RawPath only
-// when its default re-escaping of r.URL.Path would not reproduce the
-// original request target exactly; a percent-escaped space combined with
-// literal parentheses is one such case. chi.URLParam(r, "*") returns the
-// wildcard segment from RawPath when present, so the token text ended up
-// still percent-encoded (e.g. "Youjyuden%20(JP).mra") instead of decoded
-// (e.g. "Youjyuden (JP).mra"), which broke file lookups downstream.
-func TestHandleRunRestDecodesPathWithParentheses(t *testing.T) {
+// Literal parentheses make net/url preserve RawPath, so chi returns an
+// encoded wildcard even though URL.Path is already decoded.
+func TestHandleRunRestDecodesPath(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name        string
 		requestPath string
+		remoteAddr  string
+		allowRun    string
 		wantText    string
 	}{
 		{
@@ -106,6 +100,18 @@ func TestHandleRunRestDecodesPathWithParentheses(t *testing.T) {
 			requestPath: "/run/_Arcade/Youjyuden%20(JP).mra",
 			wantText:    "_Arcade/Youjyuden (JP).mra",
 		},
+		{
+			name:        "literal percent escape is not decoded twice",
+			requestPath: "/run/_Arcade/Percent%2520Name.mra",
+			wantText:    "_Arcade/Percent%20Name.mra",
+		},
+		{
+			name:        "decoded path is used for remote authorization",
+			requestPath: "/run/_Arcade/Youjyuden%20(JP).mra",
+			remoteAddr:  "192.0.2.1:1234",
+			allowRun:    "[service]\nallow_run = ['\\*\\*launch:_Arcade/Youjyuden \\(JP\\)\\.mra']",
+			wantText:    "_Arcade/Youjyuden (JP).mra",
+		},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +119,10 @@ func TestHandleRunRestDecodesPathWithParentheses(t *testing.T) {
 			t.Parallel()
 
 			cfg := &config.Instance{}
+			if tt.allowRun != "" {
+				require.NoError(t, cfg.LoadTOML(tt.allowRun))
+			}
+
 			platform := mocks.NewMockPlatform()
 			platform.SetupBasicMock()
 			st, _ := state.NewState(platform, "test-boot-uuid")
@@ -125,26 +135,20 @@ func TestHandleRunRestDecodesPathWithParentheses(t *testing.T) {
 			req := httptest.NewRequestWithContext(
 				context.Background(), http.MethodGet, tt.requestPath, http.NoBody,
 			)
-			req.RemoteAddr = "127.0.0.1:1234"
+			req.RemoteAddr = tt.remoteAddr
+			if req.RemoteAddr == "" {
+				req.RemoteAddr = "127.0.0.1:1234"
+			}
 			recorder := httptest.NewRecorder()
 
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-				router.ServeHTTP(recorder, req)
-			}()
+			router.ServeHTTP(recorder, req)
 
+			require.Equal(t, http.StatusOK, recorder.Code)
 			select {
 			case token := <-tokenQueue:
 				assert.Equal(t, tt.wantText, token.Text)
-			case <-time.After(time.Second):
+			default:
 				t.Fatal("REST run handler did not send token to queue")
-			}
-
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-				t.Fatal("REST run handler did not return")
 			}
 		})
 	}

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -78,6 +78,78 @@ func TestHandleRunRestReturnsWhenServiceContextCancelled(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
 }
 
+// TestHandleRunRestDecodesPathWithParentheses is a regression test for
+// https://github.com/ZaparooProject/zaparoo-core/issues/1099 — filenames
+// containing parentheses (e.g. "Youjyuden (JP).mra") were failing to load
+// via the REST /run endpoint. Go's net/http populates r.URL.RawPath only
+// when its default re-escaping of r.URL.Path would not reproduce the
+// original request target exactly; a percent-escaped space combined with
+// literal parentheses is one such case. chi.URLParam(r, "*") returns the
+// wildcard segment from RawPath when present, so the token text ended up
+// still percent-encoded (e.g. "Youjyuden%20(JP).mra") instead of decoded
+// (e.g. "Youjyuden (JP).mra"), which broke file lookups downstream.
+func TestHandleRunRestDecodesPathWithParentheses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		requestPath string
+		wantText    string
+	}{
+		{
+			name:        "plain path with encoded space",
+			requestPath: "/run/SNES/Super%20Metroid.sfc",
+			wantText:    "SNES/Super Metroid.sfc",
+		},
+		{
+			name:        "path with parentheses and encoded space",
+			requestPath: "/run/_Arcade/Youjyuden%20(JP).mra",
+			wantText:    "_Arcade/Youjyuden (JP).mra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Instance{}
+			platform := mocks.NewMockPlatform()
+			platform.SetupBasicMock()
+			st, _ := state.NewState(platform, "test-boot-uuid")
+			t.Cleanup(st.StopService)
+
+			tokenQueue := make(chan tokens.Token, 1)
+			router := chi.NewRouter()
+			router.Get("/run/*", HandleRunRest(cfg, st, tokenQueue))
+
+			req := httptest.NewRequestWithContext(
+				context.Background(), http.MethodGet, tt.requestPath, http.NoBody,
+			)
+			req.RemoteAddr = "127.0.0.1:1234"
+			recorder := httptest.NewRecorder()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				router.ServeHTTP(recorder, req)
+			}()
+
+			select {
+			case token := <-tokenQueue:
+				assert.Equal(t, tt.wantText, token.Text)
+			case <-time.After(time.Second):
+				t.Fatal("REST run handler did not send token to queue")
+			}
+
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("REST run handler did not return")
+			}
+		})
+	}
+}
+
 func TestHandleRunReturnsWhenRequestContextCancelled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -146,7 +146,9 @@ func HandleRunRest(
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Info().Msg("received REST run request")
 
-		text := chi.URLParam(r, "*")
+		routeCtx := chi.RouteContext(r.Context())
+		prefix := strings.TrimSuffix(routeCtx.RoutePattern(), "*")
+		text := strings.TrimPrefix(r.URL.Path, prefix)
 
 		if !isLocalRequest(r) && !cfg.IsRunAllowed(text) {
 			log.Warn().Msg("REST run not allowed")

--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -146,9 +147,15 @@ func HandleRunRest(
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Info().Msg("received REST run request")
 
-		routeCtx := chi.RouteContext(r.Context())
-		prefix := strings.TrimSuffix(routeCtx.RoutePattern(), "*")
-		text := strings.TrimPrefix(r.URL.Path, prefix)
+		text := chi.URLParam(r, "*")
+		if r.URL.RawPath != "" {
+			var err error
+			text, err = url.PathUnescape(text)
+			if err != nil {
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+		}
 
 		if !isLocalRequest(r) && !cfg.IsRunAllowed(text) {
 			log.Warn().Msg("REST run not allowed")


### PR DESCRIPTION
I had copilot debug #1099 and this solves the problem I'm having but would appreciate another look

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved REST run handling by correctly URL-decoding wildcard path segments (e.g., encoded spaces and parentheses) before authorization and execution.
  * Prevents accidental double-decoding of percent-escaped sequences.
  * Returns **400 Bad Request** for malformed escape sequences in the request path.
* **Tests**
  * Added regression coverage for correct decoding (including “double-escaped” cases) and for rejecting malformed encoded paths, including authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->