### PR TITLE
ci: bump codeql-action init and analyze to 4.37.1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: go
           build-mode: manual
@@ -39,6 +39,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           category: "/language:go"


### PR DESCRIPTION
Bumps `github/codeql-action/init` and `analyze` together to 4.37.1 (SHA `7188fc3`).

Dependabot split these into separate PRs (#1110, #1119), but `init` and `analyze` in `codeql.yml` must run the same version — bumping one alone fails with *"Loaded a configuration file for version '4.37.1', but running version '4.37.0'"*. Combining them is the only way either can pass CI. Supersedes #1110 and #1119 (Dependabot auto-closes them on merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security scanning workflow to use newer pinned CodeQL action revisions.
  * CodeQL analysis behavior and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->