### PR TITLE
feat(backup): improve remote backup reliability

### DIFF
--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -787,6 +787,7 @@ type BackupWarning struct {
 type BackupStatusEntry struct {
 	LastRunAt             *string                         `json:"lastRunAt,omitempty"`
 	LastSuccessAt         *string                         `json:"lastSuccessAt,omitempty"`
+	LastSnapshotCreatedAt *string                         `json:"lastSnapshotCreatedAt,omitempty"`
 	AvailabilityCheckedAt *string                         `json:"availabilityCheckedAt,omitempty"`
 	DeviceName            *string                         `json:"deviceName,omitempty"`
 	LinkedAt              *string                         `json:"linkedAt,omitempty"`
@@ -800,6 +801,11 @@ type BackupStatusEntry struct {
 	SkippedFiles          int                             `json:"skippedFiles,omitempty"`
 	Linked                bool                            `json:"linked,omitempty"`
 	Enabled               bool                            `json:"enabled"`
+	// LastRunNoChanges marks the most recent successful run as verified-
+	// unchanged: the server already held an identical snapshot, so nothing
+	// new was stored. LastSuccessAt still advances on such runs;
+	// LastSnapshotCreatedAt is when the stored content last changed.
+	LastRunNoChanges bool `json:"lastRunNoChanges,omitempty"`
 }
 
 type BackupStatusResponse struct {

--- a/pkg/config/configbackup.go
+++ b/pkg/config/configbackup.go
@@ -30,7 +30,6 @@ import (
 const (
 	DefaultBackupRemoteBaseURL  = "https://api.zaparoo.com"
 	DefaultBackupRemoteSchedule = "daily"
-	DefaultBackupMaxSizeBytes   = int64(5 << 30)
 )
 
 // OfficialAuthHosts are the hosts of the official Zaparoo Online API
@@ -57,10 +56,9 @@ const (
 )
 
 type Backup struct {
-	LocalDir     string       `toml:"local_dir,omitempty"`
-	Scope        string       `toml:"scope,omitempty"`
-	Remote       BackupRemote `toml:"remote,omitempty"`
-	MaxSizeBytes int64        `toml:"max_size_bytes,omitempty"`
+	LocalDir string       `toml:"local_dir,omitempty"`
+	Scope    string       `toml:"scope,omitempty"`
+	Remote   BackupRemote `toml:"remote,omitempty"`
 }
 
 type BackupRemote struct {
@@ -97,21 +95,6 @@ func (c *Instance) SetBackupScope(scope string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.vals.Backup.Scope = scope
-}
-
-func (c *Instance) BackupMaxSizeBytes() int64 {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.vals.Backup.MaxSizeBytes <= 0 {
-		return DefaultBackupMaxSizeBytes
-	}
-	return c.vals.Backup.MaxSizeBytes
-}
-
-func (c *Instance) SetBackupMaxSizeBytes(maxSize int64) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.vals.Backup.MaxSizeBytes = maxSize
 }
 
 func (c *Instance) BackupRemoteEnabled() bool {

--- a/pkg/config/configbackup_test.go
+++ b/pkg/config/configbackup_test.go
@@ -32,7 +32,6 @@ func TestBackupDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, cfg.BackupLocalDir())
-	assert.Equal(t, DefaultBackupMaxSizeBytes, cfg.BackupMaxSizeBytes())
 	assert.False(t, cfg.BackupRemoteEnabled())
 	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 	assert.Equal(t, DefaultBackupRemoteSchedule, cfg.BackupRemoteSchedule())
@@ -65,15 +64,6 @@ func TestSetBackupLocalDir(t *testing.T) {
 
 	cfg.SetBackupLocalDir("/media/usb/zaparoo-backups")
 	assert.Equal(t, "/media/usb/zaparoo-backups", cfg.BackupLocalDir())
-}
-
-func TestSetBackupMaxSizeBytes(t *testing.T) {
-	t.Parallel()
-	cfg, err := NewConfig(t.TempDir(), BaseDefaults)
-	require.NoError(t, err)
-
-	cfg.SetBackupMaxSizeBytes(1024)
-	assert.Equal(t, int64(1024), cfg.BackupMaxSizeBytes())
 }
 
 func TestValidateBackupRemoteBaseURL(t *testing.T) {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3293,7 +3293,7 @@ func TestMediaDB_BrowseRouteCountsDegradeOnSubTimeout_Integration(t *testing.T) 
 	// presence probe a real budget, so the route degrades to "present, unknown
 	// count" instead of erroring the whole browse.
 	origCount, origProbe := browseRouteCountSubTimeout, browseRouteProbeSubTimeout
-	browseRouteCountSubTimeout = time.Nanosecond
+	browseRouteCountSubTimeout = -time.Second
 	browseRouteProbeSubTimeout = 5 * time.Second
 	defer func() {
 		browseRouteCountSubTimeout = origCount

--- a/pkg/database/mediadb/query_methods_test.go
+++ b/pkg/database/mediadb/query_methods_test.go
@@ -100,7 +100,9 @@ func TestMediaDB_SearchMediaPathGlob_MultiSystemVariants(t *testing.T) {
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	gamePath := filepath.Join(string(filepath.Separator), "roms", "SNES", "Super Mario World.sfc")
+	gamePath := filepath.ToSlash(filepath.Join(
+		string(filepath.Separator), "roms", "SNES", "Super Mario World.sfc",
+	))
 	scantest.IndexMediaPaths(t, mediaDB, "SNES", gamePath)
 
 	snes, err := systemdefs.GetSystem("SNES")
@@ -121,7 +123,7 @@ func TestMediaDB_SearchMediaPathGlob_NoGlobPartsReturnsRandomGame(t *testing.T) 
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	gamePath := filepath.Join(string(filepath.Separator), "roms", "SNES", "Only Game.sfc")
+	gamePath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Only Game.sfc"))
 	scantest.IndexMediaPaths(t, mediaDB, "SNES", gamePath)
 
 	snes, err := systemdefs.GetSystem("SNES")
@@ -141,10 +143,11 @@ func TestMediaDB_BrowseDirCount_FromMediaFallback(t *testing.T) {
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	scantest.IndexMediaPaths(t, mediaDB, "SNES",
-		filepath.Join(string(filepath.Separator), "roms", "SNES", "USA", "Game.sfc"))
+	scantest.IndexMediaPaths(t, mediaDB, "SNES", filepath.ToSlash(filepath.Join(
+		string(filepath.Separator), "roms", "SNES", "USA", "Game.sfc",
+	)))
 
-	systemDir := filepath.Join(string(filepath.Separator), "roms", "SNES") + "/"
+	systemDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES")) + "/"
 	count, err := mediaDB.BrowseDirCount(context.Background(), database.BrowseDirCountOptions{
 		PathPrefix: systemDir,
 	})

--- a/pkg/database/mediadb/scan_reconcile_test.go
+++ b/pkg/database/mediadb/scan_reconcile_test.go
@@ -57,7 +57,9 @@ func TestReconcileStagedSystem_FullScanInsertsTitlesMediaAndTags(t *testing.T) {
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	gamePath := filepath.Join(string(filepath.Separator), "roms", "SNES", "Super Game (USA) (Rev 2).sfc")
+	gamePath := filepath.ToSlash(filepath.Join(
+		string(filepath.Separator), "roms", "SNES", "Super Game (USA) (Rev 2).sfc",
+	))
 	stats := scantest.IndexMediaPaths(t, mediaDB, "SNES", gamePath)
 
 	assert.True(t, stats.SystemKnown)
@@ -80,7 +82,7 @@ func TestReconcileStagedSystem_IdempotentRescanIsNoOp(t *testing.T) {
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	gamePath := filepath.Join(string(filepath.Separator), "roms", "Genesis", "Game.md")
+	gamePath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "Genesis", "Game.md"))
 	scantest.IndexMediaPaths(t, mediaDB, "Genesis", gamePath)
 
 	stats := scantest.IndexMediaPaths(t, mediaDB, "Genesis", gamePath)
@@ -99,8 +101,8 @@ func TestReconcileStagedSystem_IncompleteScanPreservesMissingState(t *testing.T)
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	fileA := filepath.Join(string(filepath.Separator), "roms", "SNES", "Game A.sfc")
-	fileB := filepath.Join(string(filepath.Separator), "roms", "SNES", "Game B.sfc")
+	fileA := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Game A.sfc"))
+	fileB := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Game B.sfc"))
 	scantest.IndexMediaPaths(t, mediaDB, "SNES", fileA, fileB)
 
 	stats := scantest.IndexMediaPathsWithOpts(

--- a/pkg/database/mediascanner/integration_test.go
+++ b/pkg/database/mediascanner/integration_test.go
@@ -362,7 +362,7 @@ func TestSlugGenerationPipeline(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, media, 1)
 			assert.Equal(t, titles[0].DBID, media[0].MediaTitleDBID, "Media should point to correct title")
-			assert.Equal(t, tt.path, media[0].Path, "Media path should match")
+			assert.Equal(t, filepath.ToSlash(tt.path), media[0].Path, "Media path should match")
 		})
 	}
 }

--- a/pkg/database/mediascanner/scan_reconcile_test.go
+++ b/pkg/database/mediascanner/scan_reconcile_test.go
@@ -55,14 +55,14 @@ func mediaTagStrings(t *testing.T, db *mediadb.MediaDB, mediaDBID int64) []strin
 	return got
 }
 
-// mediaBySystem returns the system's media rows keyed by path.
+// mediaBySystem returns system media keyed by platform-native path for test fixture lookups.
 func mediaBySystem(t *testing.T, db *mediadb.MediaDB, systemID string) map[string]database.MediaWithFullPath {
 	t.Helper()
 	rows, err := db.GetMediaBySystemID(systemID)
 	require.NoError(t, err)
 	byPath := make(map[string]database.MediaWithFullPath, len(rows))
 	for _, row := range rows {
-		byPath[row.Path] = row
+		byPath[filepath.FromSlash(row.Path)] = row
 	}
 	return byPath
 }

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -37,10 +38,12 @@ import (
 )
 
 const (
-	backupDirName  = "backups"
-	backupPrefix   = "backup-"
-	backupExt      = ".db"
-	autoBackupKeep = 3
+	backupDirName            = "backups"
+	backupPrefix             = "backup-"
+	backupExt                = ".db"
+	autoBackupKeep           = 3
+	databaseRenameAttempts   = 100
+	databaseRenameRetryDelay = 50 * time.Millisecond
 )
 
 func (db *UserDB) backupDir() string {
@@ -366,6 +369,36 @@ func copyFileSyncContext(ctx context.Context, src, dst string, mode os.FileMode)
 	return nil
 }
 
+func renameDatabaseFile(fs afero.Fs, oldPath, newPath string) error {
+	return renameDatabaseFileWithRetry(
+		fs,
+		oldPath,
+		newPath,
+		isRetryableDatabaseRenameError,
+		func() { time.Sleep(databaseRenameRetryDelay) },
+	)
+}
+
+func renameDatabaseFileWithRetry(
+	fs afero.Fs,
+	oldPath string,
+	newPath string,
+	retryable func(error) bool,
+	wait func(),
+) error {
+	for attempt := range databaseRenameAttempts {
+		err := fs.Rename(oldPath, newPath)
+		if err == nil {
+			return nil
+		}
+		if !retryable(err) || attempt == databaseRenameAttempts-1 {
+			return fmt.Errorf("rename database file: %w", err)
+		}
+		wait()
+	}
+	return errors.New("database rename attempts exhausted")
+}
+
 func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err error) {
 	dbDir := filepath.Dir(dbPath)
 	tmp, err := afero.TempFile(fs, dbDir, ".userdb-restore-*")
@@ -385,7 +418,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 
 	rollbackPath := dbPath + ".restore-rollback"
 	_ = fs.Remove(rollbackPath)
-	if err = fs.Rename(dbPath, rollbackPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err = renameDatabaseFile(fs, dbPath, rollbackPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to preserve user database before restore: %w", err)
 	}
 	originalPreserved := err == nil
@@ -400,7 +433,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 	}
 
 	database.RemoveSidecars(dbPath)
-	if err = fs.Rename(tmpPath, dbPath); err != nil {
+	if err = renameDatabaseFile(fs, tmpPath, dbPath); err != nil {
 		if originalPreserved {
 			rollbackErr := restoreDatabaseRollback(fs, rollbackPath, dbPath)
 			return errors.Join(
@@ -433,7 +466,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 
 func restoreDatabaseRollback(fs afero.Fs, rollbackPath, dbPath string) error {
 	_ = fs.Remove(dbPath)
-	if err := fs.Rename(rollbackPath, dbPath); err != nil {
+	if err := renameDatabaseFile(fs, rollbackPath, dbPath); err != nil {
 		return fmt.Errorf("failed to restore original user database: %w", err)
 	}
 	if err := syncAferoDirectory(fs, filepath.Dir(dbPath)); err != nil {
@@ -449,7 +482,8 @@ func syncAferoDirectory(fs afero.Fs, path string) error {
 	}
 	syncErr := dir.Sync()
 	closeErr := dir.Close()
-	if syncErr != nil {
+	// Windows does not support flushing directory handles through os.File.Sync.
+	if syncErr != nil && (runtime.GOOS != "windows" || !errors.Is(syncErr, os.ErrPermission)) {
 		return fmt.Errorf("failed to sync directory: %w", syncErr)
 	}
 	if closeErr != nil {

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -65,6 +65,24 @@ type failDirectorySyncFs struct {
 	failAt int
 }
 
+type transientRenameFs struct {
+	afero.Fs
+	err      error
+	failures int
+	attempts int
+}
+
+func (fs *transientRenameFs) Rename(oldPath, newPath string) error {
+	fs.attempts++
+	if fs.attempts <= fs.failures {
+		return fs.err
+	}
+	if err := fs.Fs.Rename(oldPath, newPath); err != nil {
+		return fmt.Errorf("rename transient test file: %w", err)
+	}
+	return nil
+}
+
 func (fs *failDirectorySyncFs) Open(name string) (afero.File, error) {
 	file, err := fs.Fs.Open(name)
 	if err != nil {
@@ -90,6 +108,51 @@ func (fs failStagedInstallFs) Rename(oldPath, newPath string) error {
 		return fmt.Errorf("rename test path: %w", err)
 	}
 	return nil
+}
+
+func TestRenameDatabaseFileWithRetry(t *testing.T) {
+	t.Parallel()
+
+	transientErr := errors.New("transient rename failure")
+	for _, tt := range []struct {
+		name             string
+		failures         int
+		expectedAttempts int
+		retryable        bool
+		expectError      bool
+	}{
+		{name: "retries transient error", retryable: true, failures: 2, expectedAttempts: 3},
+		{name: "stops on permanent error", failures: 2, expectedAttempts: 1, expectError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := &transientRenameFs{Fs: afero.NewMemMapFs(), err: transientErr, failures: tt.failures}
+			dir := "rename-test"
+			oldPath := filepath.Join(dir, "old.db")
+			newPath := filepath.Join(dir, "new.db")
+			require.NoError(t, fs.MkdirAll(dir, 0o750))
+			require.NoError(t, afero.WriteFile(fs, oldPath, []byte("database"), 0o600))
+
+			waits := 0
+			err := renameDatabaseFileWithRetry(
+				fs,
+				oldPath,
+				newPath,
+				func(err error) bool { return tt.retryable && errors.Is(err, transientErr) },
+				func() { waits++ },
+			)
+			if tt.expectError {
+				require.ErrorIs(t, err, transientErr)
+			} else {
+				require.NoError(t, err)
+				contents, readErr := afero.ReadFile(fs, newPath)
+				require.NoError(t, readErr)
+				assert.Equal(t, []byte("database"), contents)
+			}
+			assert.Equal(t, tt.expectedAttempts, fs.attempts)
+			assert.Equal(t, tt.expectedAttempts-1, waits)
+		})
+	}
 }
 
 func TestReplaceDatabaseFromBackup_RestoresOriginalAfterInstallFailure(t *testing.T) {

--- a/pkg/database/userdb/rename_retry_nonwindows.go
+++ b/pkg/database/userdb/rename_retry_nonwindows.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+func isRetryableDatabaseRenameError(_ error) bool {
+	return false
+}

--- a/pkg/database/userdb/rename_retry_windows.go
+++ b/pkg/database/userdb/rename_retry_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func isRetryableDatabaseRenameError(err error) bool {
+	return errors.Is(err, windows.ERROR_SHARING_VIOLATION) ||
+		errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -82,11 +82,13 @@ const (
 	maxArchiveEntries    = 100_000
 	maxArchivePathLen    = 512
 
-	manifestName  = "manifest.json"
-	filesRoot     = "files"
-	zaparooRoot   = "zaparoo"
-	platformRoot  = "platform"
-	backupDirName = "files"
+	manifestName               = "manifest.json"
+	filesRoot                  = "files"
+	zaparooRoot                = "zaparoo"
+	platformRoot               = "platform"
+	backupDirName              = "files"
+	localRestoreStagingPrefix  = "local-restore-"
+	remoteRestoreStagingPrefix = "remote-restore-"
 )
 
 type sourceOpener func(context.Context, *FileRef) (io.ReadCloser, error)
@@ -102,6 +104,9 @@ type Manager struct {
 	directorySync func(string) error
 	sourceOpener  sourceOpener
 	pauser        *syncutil.Pauser
+	// rateLimitWaits overrides the 429 retry wait bounds; nil uses the
+	// defaults. Set only by tests to avoid multi-second waits.
+	rateLimitWaits *rateLimitWaits
 }
 
 type sourceIdentity struct {
@@ -159,6 +164,17 @@ type zipReadResult struct {
 	Manifest Manifest
 }
 
+type localStagingOptions struct {
+	validatePolicy func(*Manifest) error
+	parent         string
+}
+
+type stagedLocalArchive struct {
+	result  *zipReadResult
+	staging *restoreStaging
+	cleanup func()
+}
+
 type fileCollection struct {
 	Cleanup  func() error
 	Files    []FileRef
@@ -174,6 +190,7 @@ type statusEntry struct {
 	Categories            map[string]models.BackupCategoryStatus `json:"categories,omitempty"`
 	LastRunAt             string                                 `json:"lastRunAt,omitempty"`
 	LastSuccessAt         string                                 `json:"lastSuccessAt,omitempty"`
+	LastSnapshotCreatedAt string                                 `json:"lastSnapshotCreatedAt,omitempty"`
 	AvailabilityCheckedAt string                                 `json:"availabilityCheckedAt,omitempty"`
 	ScheduleEnabledSince  string                                 `json:"scheduleEnabledSince,omitempty"`
 	LastError             string                                 `json:"lastError,omitempty"`
@@ -185,6 +202,7 @@ type statusEntry struct {
 	LastBackupSize        int64                                  `json:"lastBackupSize"`
 	SkippedFiles          int                                    `json:"skippedFiles,omitempty"`
 	Unlinked              bool                                   `json:"unlinked,omitempty"`
+	LastRunNoChanges      bool                                   `json:"lastRunNoChanges,omitempty"`
 }
 
 func NewManager(cfg *config.Instance, pl platforms.Platform, db *database.Database) *Manager {
@@ -320,7 +338,7 @@ func (m *Manager) createBackup(ctx context.Context, preRestore bool) (result Inf
 	if policyErr := m.validateManifestPolicy(&manifest); policyErr != nil {
 		return Info{}, fmt.Errorf("backup would fail restore policy: %w", policyErr)
 	}
-	if writeErr := writeZip(ctx, tmpPath, files, &manifest, m.cfg.BackupMaxSizeBytes()); writeErr != nil {
+	if writeErr := writeZip(ctx, tmpPath, files, &manifest); writeErr != nil {
 		_ = os.Remove(tmpPath)
 		return Info{}, writeErr
 	}
@@ -412,7 +430,7 @@ func (m *Manager) Inspect(ctx context.Context, name string) (Info, error) {
 	if validateErr := m.validateLocalArchiveManifest(backupPath); validateErr != nil {
 		return Info{}, validateErr
 	}
-	info, err := inspectZipManifest(backupPath, m.cfg.BackupMaxSizeBytes())
+	info, err := inspectZipManifest(backupPath)
 	if err != nil {
 		return Info{}, fmt.Errorf("inspecting backup ZIP: %w", err)
 	}
@@ -458,14 +476,14 @@ func (m *Manager) Restore(ctx context.Context, name string) (RestoreInfo, error)
 	if err != nil {
 		return RestoreInfo{}, err
 	}
-	if validateErr := m.validateLocalArchiveManifest(backupPath); validateErr != nil {
-		return RestoreInfo{}, validateErr
-	}
-	zipResult, err := readAndVerifyZipLimit(backupPath, m.cfg.BackupMaxSizeBytes())
+	staged, err := stageLocalArchive(ctx, backupPath, localStagingOptions{
+		parent: m.backupDir(), validatePolicy: m.validateManifestPolicy,
+	})
 	if err != nil {
 		return RestoreInfo{}, err
 	}
-	if validateErr := validateFiles(zipResult.Manifest.Files); validateErr != nil {
+	defer staged.cleanup()
+	if validateErr := validateFiles(staged.result.Manifest.Files); validateErr != nil {
 		return RestoreInfo{}, validateErr
 	}
 	pre, err := m.createBackup(ctx, true)
@@ -479,14 +497,16 @@ func (m *Manager) Restore(ctx context.Context, name string) (RestoreInfo, error)
 	if err != nil {
 		return RestoreInfo{}, err
 	}
-	if err = m.applyRestoreFromZip(ctx, backupPath, &zipResult.Manifest); err != nil {
+	if err = m.applyRestore(ctx, &staged.result.Manifest, func(file FileRef) (io.ReadCloser, error) {
+		return staged.staging.open(file.SHA256, file.Size)
+	}); err != nil {
 		return RestoreInfo{}, errors.Join(err, finishPlatformRestore(false))
 	}
 	if finishErr := finishPlatformRestore(true); finishErr != nil {
 		log.Warn().Err(finishErr).Msg("committed restore profile cleanup deferred until restart")
 	}
 	restoreSucceeded = true
-	return RestoreInfo{PreRestoreBackup: &pre, RestoredFrom: zipResult.Info}, nil
+	return RestoreInfo{PreRestoreBackup: &pre, RestoredFrom: staged.result.Info}, nil
 }
 
 func (m *Manager) Status() models.BackupStatusResponse {
@@ -709,7 +729,7 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 	if err != nil {
 		return fileCollection{}, errors.Join(err, cleanup())
 	}
-	collector := newSourceCollector(ctx, m.cfg.BackupMaxSizeBytes(), excludedSources)
+	collector := newSourceCollector(ctx, excludedSources)
 	collector.excludedIdentities = excludedIdentities
 	collector.pauser = m.pauser
 	if err = collector.addTrustedFile(
@@ -811,30 +831,6 @@ func (m *Manager) resolveBackupPath(name string) (string, error) {
 	return backupPath, nil
 }
 
-func (m *Manager) applyRestoreFromZip(ctx context.Context, zipPath string, manifest *Manifest) error {
-	zr, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return fmt.Errorf("opening backup ZIP: %w", err)
-	}
-	defer func() {
-		if closeErr := zr.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
-		}
-	}()
-	entries := zipEntriesByName(zr.File)
-	return m.applyRestore(ctx, manifest, func(file FileRef) (io.ReadCloser, error) {
-		entry, ok := entries[file.ArchivePath]
-		if !ok {
-			return nil, fmt.Errorf("backup ZIP missing payload for %s", file.ArchivePath)
-		}
-		opened, openErr := entry.Open()
-		if openErr != nil {
-			return nil, fmt.Errorf("opening backup ZIP payload %s: %w", file.ArchivePath, openErr)
-		}
-		return opened, nil
-	})
-}
-
 func readRestorePayload(
 	file *FileRef, openPayload func(FileRef) (io.ReadCloser, error), limit int64,
 ) (data []byte, err error) {
@@ -934,12 +930,22 @@ func installVerifiedPayload(
 	}
 
 	hash := sha256.New()
-	limited := &io.LimitedReader{R: &contextReader{ctx: ctx, reader: payload}, N: file.Size + 1}
+	reader := &contextReader{ctx: ctx, reader: payload}
+	limited := &io.LimitedReader{R: reader, N: file.Size}
 	written, copyErr := io.Copy(io.MultiWriter(tmp, hash), limited)
+	var extra [1]byte
+	var extraSize int
+	var extraErr error
+	if copyErr == nil && written == file.Size {
+		extraSize, extraErr = reader.Read(extra[:])
+	}
 	syncErr := tmp.Sync()
 	closeErr := tmp.Close()
 	if copyErr != nil {
 		return fmt.Errorf("staging restore payload %s: %w", file.RestorePath, copyErr)
+	}
+	if extraErr != nil && !errors.Is(extraErr, io.EOF) {
+		return fmt.Errorf("checking restore payload size %s: %w", file.RestorePath, extraErr)
 	}
 	if syncErr != nil {
 		return fmt.Errorf("syncing restore payload %s: %w", file.RestorePath, syncErr)
@@ -947,7 +953,7 @@ func installVerifiedPayload(
 	if closeErr != nil {
 		return fmt.Errorf("closing restore payload %s: %w", file.RestorePath, closeErr)
 	}
-	if written != file.Size {
+	if written != file.Size || extraSize != 0 {
 		return fmt.Errorf("restore payload size mismatch: %s", file.RestorePath)
 	}
 	if hex.EncodeToString(hash.Sum(nil)) != file.SHA256 {
@@ -1028,16 +1034,26 @@ func hashSourceFile(ctx context.Context, file *FileRef, opener sourceOpener) (st
 		return "", err
 	}
 	hash := sha256.New()
-	limited := &io.LimitedReader{R: &contextReader{ctx: ctx, reader: source}, N: file.Size + 1}
+	reader := &contextReader{ctx: ctx, reader: source}
+	limited := &io.LimitedReader{R: reader, N: file.Size}
 	size, readErr := io.Copy(hash, limited)
+	var extra [1]byte
+	var extraSize int
+	var extraErr error
+	if readErr == nil && size == file.Size {
+		extraSize, extraErr = reader.Read(extra[:])
+	}
 	closeErr := source.Close()
 	if readErr != nil {
 		return "", fmt.Errorf("reading backup source %s: %w", file.RestorePath, readErr)
 	}
+	if extraErr != nil && !errors.Is(extraErr, io.EOF) {
+		return "", fmt.Errorf("checking backup source size %s: %w", file.RestorePath, extraErr)
+	}
 	if closeErr != nil {
 		return "", fmt.Errorf("closing backup source %s: %w", file.RestorePath, closeErr)
 	}
-	if size != file.Size {
+	if size != file.Size || extraSize != 0 {
 		return "", fmt.Errorf("%w: source size changed for %s", errSourceIdentityChanged, file.RestorePath)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
@@ -1134,18 +1150,18 @@ func validateSlashPath(p string) error {
 }
 
 func writeZip(
-	ctx context.Context, zipPath string, files []FileRef, manifest *Manifest, maxLogicalSize int64,
+	ctx context.Context, zipPath string, files []FileRef, manifest *Manifest,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("writing backup archive: %w", err)
 	}
-	if err := validateManifestMetadata(manifest, maxLogicalSize); err != nil {
+	if err := validateManifestMetadata(manifest); err != nil {
 		return err
 	}
 	if len(files)+1 > maxArchiveEntries {
 		return fmt.Errorf("backup has too many entries: %d exceeds %d", len(files)+1, maxArchiveEntries)
 	}
-	expectedSize, err := validateLogicalSize(files, maxLogicalSize)
+	expectedSize, err := sumLogicalSize(files)
 	if err != nil {
 		return err
 	}
@@ -1164,15 +1180,12 @@ func writeZip(
 		return fmt.Errorf("creating backup ZIP: %w", err)
 	}
 	zw := zip.NewWriter(out)
-	written := int64(0)
 	for i := range files {
-		remaining := maxLogicalSize - written
-		if err = writeZipFile(ctx, zw, &files[i], remaining); err != nil {
+		if err = writeZipFile(ctx, zw, &files[i]); err != nil {
 			_ = zw.Close()
 			_ = out.Close()
 			return err
 		}
-		written += files[i].Size
 	}
 	manifest.Files = files
 	manifest.Categories = summarize(files)
@@ -1206,9 +1219,9 @@ func writeZip(
 	return nil
 }
 
-func writeZipFile(ctx context.Context, zw *zip.Writer, file *FileRef, remaining int64) error {
-	if remaining < 0 {
-		return errors.New("backup exceeds logical size limit")
+func writeZipFile(ctx context.Context, zw *zip.Writer, file *FileRef) error {
+	if file.Size < 0 {
+		return errors.New("backup source has negative size")
 	}
 	in, err := openSourceContext(ctx, file)
 	if err != nil {
@@ -1226,15 +1239,21 @@ func writeZipFile(ctx context.Context, zw *zip.Writer, file *FileRef, remaining 
 		return fmt.Errorf("creating ZIP entry %s: %w", file.ArchivePath, err)
 	}
 	hash := sha256.New()
-	limited := &io.LimitedReader{R: &contextReader{ctx: ctx, reader: in}, N: remaining + 1}
+	reader := &contextReader{ctx: ctx, reader: in}
+	limited := &io.LimitedReader{R: reader, N: file.Size}
 	size, err := io.Copy(io.MultiWriter(w, hash), limited)
 	if err != nil {
 		return fmt.Errorf("writing ZIP entry %s: %w", file.ArchivePath, err)
 	}
-	if size > remaining {
-		return fmt.Errorf("backup exceeds logical size limit while reading %s", file.RestorePath)
-	}
 	if file.Size != size {
+		return fmt.Errorf("backup source changed size while reading %s", file.RestorePath)
+	}
+	var extra [1]byte
+	extraSize, readErr := reader.Read(extra[:])
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return fmt.Errorf("checking ZIP entry source size %s: %w", file.ArchivePath, readErr)
+	}
+	if extraSize != 0 {
 		return fmt.Errorf("backup source changed size while reading %s", file.RestorePath)
 	}
 	actualHash := hex.EncodeToString(hash.Sum(nil))
@@ -1246,14 +1265,14 @@ func writeZipFile(ctx context.Context, zw *zip.Writer, file *FileRef, remaining 
 	return nil
 }
 
-func validateLogicalSize(files []FileRef, maxLogicalSize int64) (int64, error) {
-	if maxLogicalSize <= 0 || maxLogicalSize == math.MaxInt64 {
-		return 0, errors.New("backup logical size limit must be positive")
-	}
+func sumLogicalSize(files []FileRef) (int64, error) {
 	var total int64
 	for _, file := range files {
-		if file.Size < 0 || file.Size > maxLogicalSize-total {
-			return 0, fmt.Errorf("backup exceeds logical size limit of %d bytes", maxLogicalSize)
+		if file.Size < 0 {
+			return 0, errors.New("backup file has negative size")
+		}
+		if file.Size > math.MaxInt64-total {
+			return 0, errors.New("backup logical size overflow")
 		}
 		total += file.Size
 	}
@@ -1323,7 +1342,7 @@ func infoFromManifest(zipPath string, manifest *Manifest) (Info, error) {
 	}, nil
 }
 
-func inspectZipManifest(zipPath string, maxLogicalSize int64) (Info, error) {
+func inspectZipManifest(zipPath string) (Info, error) {
 	zr, openErr := zip.OpenReader(zipPath)
 	if openErr != nil {
 		return Info{}, fmt.Errorf("opening backup ZIP: %w", openErr)
@@ -1333,11 +1352,11 @@ func inspectZipManifest(zipPath string, maxLogicalSize int64) (Info, error) {
 			log.Debug().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
 		}
 	}()
-	entries, err := validateZipHeaders(zr.File, maxLogicalSize)
+	entries, err := validateZipHeaders(zr.File)
 	if err != nil {
 		return Info{}, err
 	}
-	manifest, err := readManifestFromZipLimit(zr.File, entries, maxLogicalSize)
+	manifest, err := readManifestFromZip(zr.File, entries)
 	if err != nil {
 		return Info{}, err
 	}
@@ -1355,21 +1374,20 @@ func (m *Manager) validateLocalArchiveManifest(zipPath string) error {
 		return fmt.Errorf("opening backup ZIP: %w", err)
 	}
 	defer func() { _ = zr.Close() }()
-	entries, err := validateZipHeaders(zr.File, m.cfg.BackupMaxSizeBytes())
+	entries, err := validateZipHeaders(zr.File)
 	if err != nil {
 		return err
 	}
-	manifest, err := readManifestFromZipLimit(zr.File, entries, m.cfg.BackupMaxSizeBytes())
+	manifest, err := readManifestFromZip(zr.File, entries)
 	if err != nil {
 		return err
 	}
 	return m.validateManifestPolicy(manifest)
 }
 
-func readManifestFromZipLimit(
+func readManifestFromZip(
 	files []*zip.File,
 	entries map[string]*zip.File,
-	maxLogicalSize int64,
 ) (*Manifest, error) {
 	manifestEntry, ok := entries[manifestName]
 	if !ok {
@@ -1386,13 +1404,17 @@ func readManifestFromZipLimit(
 	if manifest.Version != 1 {
 		return nil, fmt.Errorf("unsupported backup manifest version: %d", manifest.Version)
 	}
-	if validateErr := validateManifest(&manifest, files, entries, maxLogicalSize); validateErr != nil {
+	if validateErr := validateManifest(&manifest, files, entries); validateErr != nil {
 		return nil, validateErr
 	}
 	return &manifest, nil
 }
 
-func readAndVerifyZipLimit(zipPath string, maxLogicalSize int64) (*zipReadResult, error) {
+func stageLocalArchive(
+	ctx context.Context,
+	zipPath string,
+	options localStagingOptions,
+) (*stagedLocalArchive, error) {
 	zr, openErr := zip.OpenReader(zipPath)
 	if openErr != nil {
 		return nil, fmt.Errorf("opening backup ZIP: %w", openErr)
@@ -1402,33 +1424,100 @@ func readAndVerifyZipLimit(zipPath string, maxLogicalSize int64) (*zipReadResult
 			log.Debug().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
 		}
 	}()
-	entries, err := validateZipHeaders(zr.File, maxLogicalSize)
+	entries, err := validateZipHeaders(zr.File)
 	if err != nil {
 		return nil, err
 	}
-	manifest, err := readManifestFromZipLimit(zr.File, entries, maxLogicalSize)
+	manifest, err := readManifestFromZip(zr.File, entries)
 	if err != nil {
 		return nil, err
 	}
+	if options.validatePolicy != nil {
+		if policyErr := options.validatePolicy(manifest); policyErr != nil {
+			return nil, policyErr
+		}
+	}
+	required, err := uniquePayloadBytes(manifest.Files)
+	if err != nil {
+		return nil, err
+	}
+	free, err := helpers.FreeDiskSpace(options.parent)
+	if err != nil {
+		return nil, fmt.Errorf("checking local restore staging space: %w", err)
+	}
+	if uint64(required) > free { //nolint:gosec // uniquePayloadBytes rejects negative totals before conversion.
+		return nil, fmt.Errorf("insufficient disk space to stage local restore: need %d bytes", required)
+	}
+	dir, err := os.MkdirTemp(options.parent, localRestoreStagingPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("creating local restore staging directory: %w", err)
+	}
+	staging := &restoreStaging{dir: dir}
+	cleanup := func() {
+		if removeErr := os.RemoveAll(dir); removeErr != nil {
+			log.Debug().Err(removeErr).Str("dir", dir).Msg("failed to remove local restore staging directory")
+		}
+	}
+
+	seen := make(map[string]struct{}, len(manifest.Files))
 	for i := range manifest.Files {
+		if err = ctx.Err(); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("staging local restore: %w", err)
+		}
 		file := &manifest.Files[i]
+		if file.SHA256 == remoteEmptyContentSHA256 {
+			continue
+		}
+		if _, ok := seen[file.SHA256]; ok {
+			continue
+		}
+		seen[file.SHA256] = struct{}{}
 		entry := entries[file.ArchivePath]
-		if verifyErr := verifyZipEntry(entry, file); verifyErr != nil {
-			return nil, verifyErr
+		opened, openErr := entry.Open()
+		if openErr != nil {
+			cleanup()
+			return nil, fmt.Errorf("opening backup ZIP payload %s: %w", file.ArchivePath, openErr)
+		}
+		if installErr := installVerifiedPayload(ctx, staging.path(file.SHA256), file, opened); installErr != nil {
+			cleanup()
+			return nil, installErr
 		}
 	}
 	info, err := infoFromManifest(zipPath, manifest)
 	if err != nil {
+		cleanup()
 		return nil, err
 	}
 	info.Integrity = IntegrityValid
-	return &zipReadResult{Manifest: *manifest, Info: info}, nil
+	return &stagedLocalArchive{
+		result: &zipReadResult{Manifest: *manifest, Info: info}, staging: staging, cleanup: cleanup,
+	}, nil
 }
 
-func validateZipHeaders(files []*zip.File, maxLogicalSize int64) (map[string]*zip.File, error) {
-	if maxLogicalSize <= 0 || maxLogicalSize == math.MaxInt64 {
-		return nil, errors.New("backup logical size limit must be positive")
+func uniquePayloadBytes(files []FileRef) (int64, error) {
+	sizes := make(map[string]int64, len(files))
+	var total int64
+	for _, file := range files {
+		if size, ok := sizes[file.SHA256]; ok {
+			if size != file.Size {
+				return 0, fmt.Errorf("backup manifest has conflicting sizes for %s", file.SHA256)
+			}
+			continue
+		}
+		if file.Size < 0 {
+			return 0, errors.New("backup payload has negative size")
+		}
+		if file.Size > math.MaxInt64-total {
+			return 0, errors.New("backup payload staging size overflow")
+		}
+		sizes[file.SHA256] = file.Size
+		total += file.Size
 	}
+	return total, nil
+}
+
+func validateZipHeaders(files []*zip.File) (map[string]*zip.File, error) {
 	if len(files) > maxArchiveEntries {
 		return nil, fmt.Errorf("backup has too many entries: %d exceeds %d", len(files), maxArchiveEntries)
 	}
@@ -1455,19 +1544,19 @@ func validateZipHeaders(files []*zip.File, maxLogicalSize int64) (map[string]*zi
 		if file.Name == manifestName {
 			continue
 		}
-		if file.UncompressedSize64 > uint64(maxLogicalSize) {
-			return nil, fmt.Errorf("backup exceeds logical size limit of %d bytes", maxLogicalSize)
+		if file.UncompressedSize64 > math.MaxInt64 {
+			return nil, fmt.Errorf("ZIP entry size cannot be represented: %s", file.Name)
 		}
-		size := int64(file.UncompressedSize64) //nolint:gosec // bounded by positive maxLogicalSize above.
-		if size > maxLogicalSize-total {
-			return nil, fmt.Errorf("backup exceeds logical size limit of %d bytes", maxLogicalSize)
+		size := int64(file.UncompressedSize64) //nolint:gosec // bounded by math.MaxInt64 above.
+		if size > math.MaxInt64-total {
+			return nil, errors.New("backup logical size overflow")
 		}
 		total += size
 	}
 	return entries, nil
 }
 
-func validateManifestMetadata(manifest *Manifest, maxLogicalSize int64) error {
+func validateManifestMetadata(manifest *Manifest) error {
 	if manifest.Version != 1 {
 		return fmt.Errorf("unsupported backup manifest version: %d", manifest.Version)
 	}
@@ -1480,7 +1569,7 @@ func validateManifestMetadata(manifest *Manifest, maxLogicalSize int64) error {
 	if err := validateFiles(manifest.Files); err != nil {
 		return err
 	}
-	if _, err := validateLogicalSize(manifest.Files, maxLogicalSize); err != nil {
+	if _, err := sumLogicalSize(manifest.Files); err != nil {
 		return err
 	}
 	if !categorySummariesEqual(manifest.Categories, summarize(manifest.Files)) {
@@ -1499,9 +1588,8 @@ func validateManifest(
 	manifest *Manifest,
 	files []*zip.File,
 	entries map[string]*zip.File,
-	maxLogicalSize int64,
 ) error {
-	if err := validateManifestMetadata(manifest, maxLogicalSize); err != nil {
+	if err := validateManifestMetadata(manifest); err != nil {
 		return err
 	}
 	if len(manifest.Files)+1 != len(files) {
@@ -1552,28 +1640,6 @@ func categorySummariesEqual(
 		}
 	}
 	return true
-}
-
-func verifyZipEntry(entry *zip.File, file *FileRef) error {
-	r, err := entry.Open()
-	if err != nil {
-		return fmt.Errorf("opening ZIP entry %s: %w", entry.Name, err)
-	}
-	defer func() { _ = r.Close() }()
-
-	hash := sha256.New()
-	limited := &io.LimitedReader{R: r, N: file.Size + 1}
-	size, err := io.Copy(hash, limited)
-	if err != nil {
-		return fmt.Errorf("reading ZIP entry %s: %w", entry.Name, err)
-	}
-	if size != file.Size {
-		return fmt.Errorf("backup ZIP size mismatch: %s", entry.Name)
-	}
-	if hex.EncodeToString(hash.Sum(nil)) != file.SHA256 {
-		return fmt.Errorf("backup ZIP hash mismatch: %s", entry.Name)
-	}
-	return nil
 }
 
 func zipEntriesByName(files []*zip.File) map[string]*zip.File {
@@ -1637,6 +1703,8 @@ func toStatusEntry(st *statusEntry, enabled bool, schedule string) models.Backup
 	return models.BackupStatusEntry{
 		LastRunAt:             optionalString(st.LastRunAt),
 		LastSuccessAt:         optionalString(st.LastSuccessAt),
+		LastSnapshotCreatedAt: optionalString(st.LastSnapshotCreatedAt),
+		LastRunNoChanges:      st.LastRunNoChanges,
 		AvailabilityCheckedAt: optionalString(st.AvailabilityCheckedAt),
 		DeviceName:            optionalString(st.DeviceName),
 		LinkedAt:              optionalString(st.LinkedAt),

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -2521,6 +2521,146 @@ func TestRemotePackPlanReportsExactUploadBytes(t *testing.T) {
 	assert.Equal(t, expected, plan.uploadBytes)
 }
 
+func TestLocateRemotePacksRejectsInvalidServerResponses(t *testing.T) {
+	t.Parallel()
+
+	requestedHash := strings.Repeat("a", 64)
+	otherHash := strings.Repeat("b", 64)
+	packHash := strings.Repeat("c", 64)
+	validRef := remotePackObjectRef{Hash: requestedHash, Offset: 0, Length: 3}
+
+	tests := []struct {
+		name     string
+		wantErr  string
+		response remoteLocateResponse
+	}{
+		{
+			name:     "reported missing",
+			response: remoteLocateResponse{Missing: []string{requestedHash}},
+			wantErr:  "no longer available",
+		},
+		{
+			name: "conflicting pack sizes",
+			response: remoteLocateResponse{Packs: []remotePackObjects{
+				{PackHash: packHash, SizeBytes: 3, Objects: []remotePackObjectRef{validRef}},
+				{PackHash: packHash, SizeBytes: 4},
+			}},
+			wantErr: "conflicting sizes",
+		},
+		{
+			name: "invalid pack size",
+			response: remoteLocateResponse{Packs: []remotePackObjects{{
+				PackHash: packHash, SizeBytes: 0, Objects: []remotePackObjectRef{validRef},
+			}}},
+			wantErr: "invalid size",
+		},
+		{
+			name: "unrequested object",
+			response: remoteLocateResponse{Packs: []remotePackObjects{{
+				PackHash: packHash, SizeBytes: 3,
+				Objects: []remotePackObjectRef{{Hash: otherHash, Offset: 0, Length: 3}},
+			}}},
+			wantErr: "unrequested object",
+		},
+		{
+			name: "duplicate object",
+			response: remoteLocateResponse{Packs: []remotePackObjects{{
+				PackHash: packHash, SizeBytes: 6, Objects: []remotePackObjectRef{
+					validRef,
+					{Hash: requestedHash, Offset: 3, Length: 3},
+				},
+			}}},
+			wantErr: "located more than once",
+		},
+		{
+			name: "range outside pack",
+			response: remoteLocateResponse{Packs: []remotePackObjects{{
+				PackHash: packHash, SizeBytes: 3,
+				Objects: []remotePackObjectRef{{Hash: requestedHash, Offset: 1, Length: 3}},
+			}}},
+			wantErr: "inconsistent pack range",
+		},
+		{
+			name: "requested object omitted",
+			response: remoteLocateResponse{Packs: []remotePackObjects{{
+				PackHash: packHash, SizeBytes: 3,
+			}}},
+			wantErr: "response is missing 1 objects",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Equal(t, "/v1/device/backup-objects/locate", r.URL.Path)
+				writeJSON(t, w, tt.response)
+			}))
+			t.Cleanup(server.Close)
+			client := &remoteClient{httpClient: server.Client(), baseURL: server.URL}
+
+			_, err := locateRemotePacks(context.Background(), client, map[string]int64{requestedHash: 3})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestDownloadPackAttemptRejectsIntegrityMismatch(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("pack-data")
+	tests := []struct {
+		name     string
+		packHash string
+		wantErr  string
+		size     int64
+	}{
+		{name: "short body", packHash: sha256Hex(body), size: int64(len(body) + 1), wantErr: "size mismatch"},
+		{name: "extra body", packHash: sha256Hex(body), size: int64(len(body) - 1), wantErr: "size mismatch"},
+		{name: "wrong hash", packHash: strings.Repeat("0", 64), size: int64(len(body)), wantErr: "hash mismatch"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write(body)
+			}))
+			t.Cleanup(server.Close)
+			dir := t.TempDir()
+			client := &remoteClient{httpClient: server.Client(), baseURL: server.URL}
+
+			_, err := client.downloadPackAttempt(context.Background(), &remotePackObjects{
+				PackHash: tt.packHash, SizeBytes: tt.size,
+			}, dir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			entries, readErr := os.ReadDir(dir)
+			require.NoError(t, readErr)
+			assert.Empty(t, entries, "failed pack download must remove its staging file")
+		})
+	}
+}
+
+func TestExtractPackObjectRejectsHashMismatch(t *testing.T) {
+	t.Parallel()
+
+	packPath := filepath.Join(t.TempDir(), "pack")
+	require.NoError(t, os.WriteFile(packPath, []byte("payload"), 0o600))
+	// #nosec G304 -- packPath is created inside this test's temporary directory.
+	pack, err := os.Open(packPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pack.Close()) })
+
+	err = extractPackObject(pack, &remotePackObjectRef{
+		Hash: strings.Repeat("0", 64), Offset: 0, Length: int64(len("payload")),
+	}, filepath.Join(t.TempDir(), "object"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "staged pack object hash mismatch")
+}
+
 func TestEnsureRemoteUploadCapacity(t *testing.T) {
 	t.Parallel()
 	require.NoError(t, ensureRemoteUploadCapacity(100, 200, 100))

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -1489,7 +1489,9 @@ func TestApplyRestoreRollsBackWhenTargetDirectorySyncFails(t *testing.T) {
 		SHA256: sha256Hex(payload), Size: int64(len(payload)),
 	}}}
 
-	failPath := filepath.Join(env.RootDir, "saves")
+	physicalTargetPath, err := resolvePhysicalRestorePath(targetPath)
+	require.NoError(t, err)
+	failPath := filepath.Dir(physicalTargetPath)
 	failed := false
 	env.Manager.directorySync = func(path string) error {
 		if filepath.Clean(path) == filepath.Clean(failPath) && !failed {
@@ -1499,7 +1501,7 @@ func TestApplyRestoreRollsBackWhenTargetDirectorySyncFails(t *testing.T) {
 		return syncDirectory(path)
 	}
 
-	err := env.Manager.applyRestore(context.Background(), manifest, func(FileRef) (io.ReadCloser, error) {
+	err = env.Manager.applyRestore(context.Background(), manifest, func(FileRef) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(payload)), nil
 	})
 	require.Error(t, err)

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -208,10 +208,20 @@ func newBackupTestEnvWithClients(
 	}
 }
 
+func stageTestZip(t *testing.T, zipPath string) *zipReadResult {
+	t.Helper()
+	staged, err := stageLocalArchive(
+		context.Background(), zipPath, localStagingOptions{parent: filepath.Dir(zipPath)},
+	)
+	require.NoError(t, err)
+	t.Cleanup(staged.cleanup)
+	return staged.result
+}
+
 // collectPlatformFiles runs the source collector over platform definitions
 // without a Manager, for asserting collection results in isolation.
 func collectPlatformFiles(files []FileRef, definitions []platforms.BackupDefinition) []FileRef {
-	collector := newSourceCollector(context.Background(), config.DefaultBackupMaxSizeBytes, nil)
+	collector := newSourceCollector(context.Background(), nil)
 	for i := range files {
 		collector.appendFile(&files[i])
 	}
@@ -328,8 +338,7 @@ func TestManagerCreateBackupSkipsUnreadableSource(t *testing.T) {
 	status := env.Manager.Status()
 	assert.Equal(t, StatusPartial, status.Local.LastStatus)
 	assert.Equal(t, 1, status.Local.SkippedFiles)
-	result, err := readAndVerifyZipLimit(info.Path, env.Manager.cfg.BackupMaxSizeBytes())
-	require.NoError(t, err)
+	result := stageTestZip(t, info.Path)
 	for _, file := range result.Manifest.Files {
 		assert.NotEqual(t, filepath.ToSlash(filepath.Join("saves", "game.sav")), file.RestorePath)
 	}
@@ -352,7 +361,7 @@ func TestManagerCreateBackupSkipsNonportablePathAndSelfInspects(t *testing.T) {
 		Path:     "saves/literal%5Cname.sav",
 		Reason:   "source path is not portable",
 	})
-	inspected, err := inspectZipManifest(info.Path, env.Manager.cfg.BackupMaxSizeBytes())
+	inspected, err := inspectZipManifest(info.Path)
 	require.NoError(t, err)
 	assert.Equal(t, info.Warnings, inspected.Warnings)
 }
@@ -368,7 +377,7 @@ func TestWriteZipRejectsInvalidWarningBeforeCreatingArchive(t *testing.T) {
 		}},
 	}
 
-	err := writeZip(context.Background(), zipPath, nil, &manifest, config.DefaultBackupMaxSizeBytes)
+	err := writeZip(context.Background(), zipPath, nil, &manifest)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid warning metadata")
 	_, statErr := os.Stat(zipPath)
@@ -614,8 +623,7 @@ func TestManagerCreateZaparooScopeExcludesPlatformFiles(t *testing.T) {
 	assert.Zero(t, info.Categories[CategorySaves].Files)
 	assert.Zero(t, info.Categories[CategorySavestates].Files)
 
-	zipResult, err := readAndVerifyZipLimit(info.Path, config.DefaultBackupMaxSizeBytes)
-	require.NoError(t, err)
+	zipResult := stageTestZip(t, info.Path)
 	for _, file := range zipResult.Manifest.Files {
 		assert.Equal(t, CategoryZaparoo, file.Category, file.RestorePath)
 	}
@@ -1057,44 +1065,113 @@ func TestManagerRestoreRejectsWrongPlatformBeforePayloadVerification(t *testing.
 	assert.NotContains(t, err.Error(), "hash mismatch")
 }
 
-func TestManagerCreateEnforcesConfiguredLogicalLimit(t *testing.T) {
+func TestSourceCollectorAcceptsLargeLogicalTotal(t *testing.T) {
 	t.Parallel()
-	env := newBackupTestEnv(t, platformids.Mister)
-	env.Manager.cfg.SetBackupMaxSizeBytes(1)
+	collector := newSourceCollector(context.Background(), nil)
+	files := []FileRef{
+		{Category: CategoryZaparoo, ArchivePath: "files/zaparoo/one", RestorePath: "one", Size: 4 << 30},
+		{Category: CategoryZaparoo, ArchivePath: "files/zaparoo/two", RestorePath: "two", Size: 3 << 30},
+	}
+	for i := range files {
+		collector.appendFile(&files[i])
+	}
 
-	_, err := env.Manager.Create(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "logical size limit")
+	require.NoError(t, collector.err)
+	assert.Len(t, collector.files, 2)
+	assert.Equal(t, int64(7<<30), collector.logicalSize)
+}
+
+func TestSourceCollectorRejectsLogicalSizeOverflow(t *testing.T) {
+	t.Parallel()
+	collector := newSourceCollector(context.Background(), nil)
+	first := FileRef{
+		Category: CategoryZaparoo, ArchivePath: "files/zaparoo/one", RestorePath: "one", Size: math.MaxInt64,
+	}
+	second := FileRef{Category: CategoryZaparoo, ArchivePath: "files/zaparoo/two", RestorePath: "two", Size: 1}
+
+	collector.appendFile(&first)
+	collector.appendFile(&second)
+
+	require.Error(t, collector.err)
+	assert.Contains(t, collector.err.Error(), "overflow")
+	assert.Len(t, collector.files, 1)
 }
 
 func TestValidateZipHeadersRejectsArchiveLimits(t *testing.T) {
 	t.Parallel()
 
 	tooMany := make([]*zip.File, maxArchiveEntries+1)
-	_, err := validateZipHeaders(tooMany, config.DefaultBackupMaxSizeBytes)
+	_, err := validateZipHeaders(tooMany)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too many entries")
 
 	longPath := &zip.File{FileHeader: zip.FileHeader{Name: strings.Repeat("a", maxArchivePathLen+1)}}
-	_, err = validateZipHeaders([]*zip.File{longPath}, config.DefaultBackupMaxSizeBytes)
+	_, err = validateZipHeaders([]*zip.File{longPath})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path exceeds")
 
 	first := &zip.File{FileHeader: zip.FileHeader{Name: "files/zaparoo/user.db"}}
 	second := &zip.File{FileHeader: zip.FileHeader{Name: "files/zaparoo/user.db"}}
-	_, err = validateZipHeaders([]*zip.File{first, second}, config.DefaultBackupMaxSizeBytes)
+	_, err = validateZipHeaders([]*zip.File{first, second})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate ZIP entry")
 }
 
-func TestValidateLogicalSizeRejectsOverflowAndLimit(t *testing.T) {
+func TestValidateZipHeadersAcceptsLargeLogicalTotal(t *testing.T) {
 	t.Parallel()
-	_, err := validateLogicalSize([]FileRef{{Size: 7}, {Size: 4}}, 10)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "logical size limit")
+	files := []*zip.File{
+		{FileHeader: zip.FileHeader{Name: "files/zaparoo/one", UncompressedSize64: 4 << 30}},
+		{FileHeader: zip.FileHeader{Name: "files/zaparoo/two", UncompressedSize64: 3 << 30}},
+	}
 
-	_, err = validateLogicalSize([]FileRef{{Size: -1}}, 10)
+	_, err := validateZipHeaders(files)
+	require.NoError(t, err)
+
+	overflow := []*zip.File{
+		{FileHeader: zip.FileHeader{Name: "files/zaparoo/one", UncompressedSize64: math.MaxInt64}},
+		{FileHeader: zip.FileHeader{Name: "files/zaparoo/two", UncompressedSize64: 1}},
+	}
+	_, err = validateZipHeaders(overflow)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overflow")
+}
+
+func TestLogicalSizeAcceptsLargeTotalAndRejectsInvalidMetadata(t *testing.T) {
+	t.Parallel()
+	total, err := sumLogicalSize([]FileRef{{Size: 4 << 30}, {Size: 3 << 30}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(7<<30), total)
+
+	_, err = sumLogicalSize([]FileRef{{Size: -1}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "negative size")
+
+	_, err = sumLogicalSize([]FileRef{{Size: math.MaxInt64}, {Size: 1}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overflow")
+}
+
+func TestRemoteTransferTimeoutSaturates(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, remoteRequestTimeout, remoteTransferTimeout(0))
+	assert.Equal(t, time.Duration(math.MaxInt64), remoteTransferTimeout(math.MaxInt64))
+}
+
+func TestStageLocalArchiveHonorsCancellationAndCleansUp(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = stageLocalArchive(ctx, info.Path, localStagingOptions{
+		parent: env.Manager.backupDir(), validatePolicy: env.Manager.validateManifestPolicy,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	stagingDirs, err := filepath.Glob(filepath.Join(env.Manager.backupDir(), "local-restore-*"))
+	require.NoError(t, err)
+	assert.Empty(t, stagingDirs)
 }
 
 func TestReadAndVerifyZipRejectsUnsafeEntry(t *testing.T) {
@@ -1105,7 +1182,9 @@ func TestReadAndVerifyZipRejectsUnsafeEntry(t *testing.T) {
 		path.Join("..", "evil.txt"): "bad",
 	})
 
-	_, err := readAndVerifyZipLimit(zipPath, config.DefaultBackupMaxSizeBytes)
+	_, err := stageLocalArchive(
+		context.Background(), zipPath, localStagingOptions{parent: filepath.Dir(zipPath)},
+	)
 	require.Error(t, err)
 }
 
@@ -1152,7 +1231,7 @@ func TestSourceCollectorEnforcesFileBudgetDuringTraversal(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "one.sav"), "one")
 	writeTestFile(t, filepath.Join(root, "two.sav"), "two")
-	collector := newSourceCollector(context.Background(), 1<<20, nil)
+	collector := newSourceCollector(context.Background(), nil)
 	collector.maxFiles = 1
 	spec := collectorDefinition{
 		definition: platforms.BackupDefinition{
@@ -1173,7 +1252,7 @@ func TestSourceCollectorStopsWhenContextCanceled(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	collector := newSourceCollector(ctx, 1<<20, nil)
+	collector := newSourceCollector(ctx, nil)
 	collector.collect(&collectorDefinition{})
 	require.ErrorIs(t, collector.err, context.Canceled)
 	assert.Empty(t, collector.files)
@@ -1237,7 +1316,7 @@ func TestSourceCollectorMatchesBasenameGlobThroughTrustedDirectorySymlink(t *tes
 	writeTestFile(t, filepath.Join(target, "nested", "pad.map"), "nested map\n")
 	link := filepath.Join(root, "input-link")
 	require.NoError(t, os.Symlink(target, link))
-	collector := newSourceCollector(context.Background(), 1<<20, nil)
+	collector := newSourceCollector(context.Background(), nil)
 	collector.collect(&collectorDefinition{
 		definition: platforms.BackupDefinition{
 			Category: CategoryInputs, SourceRoot: link, RestoreRoot: filepath.Join("config", "inputs"),
@@ -1261,7 +1340,7 @@ func TestSourceCollectorRejectsDirectorySymlinkIntoExcludedPath(t *testing.T) {
 	root := t.TempDir()
 	writeTestFile(t, filepath.Join(root, "renamed", "pad.map"), "excluded map\n")
 	require.NoError(t, os.Symlink(filepath.Join(root, "renamed"), filepath.Join(root, "alias")))
-	collector := newSourceCollector(context.Background(), 1<<20, nil)
+	collector := newSourceCollector(context.Background(), nil)
 	collector.collect(&collectorDefinition{
 		definition: platforms.BackupDefinition{
 			Category: CategoryInputs, SourceRoot: root, RestoreRoot: filepath.Join("config", "inputs"),
@@ -1290,7 +1369,7 @@ func TestSourceCollectorEnforcesNonRecursivePhysicalSymlinkPolicy(t *testing.T) 
 	target := filepath.Join(root, "nested", "MiSTer.ini")
 	writeTestFile(t, target, "nested ini\n")
 	require.NoError(t, os.Symlink(target, filepath.Join(root, "MiSTer.ini")))
-	collector := newSourceCollector(context.Background(), 1<<20, nil)
+	collector := newSourceCollector(context.Background(), nil)
 	collector.collect(&collectorDefinition{
 		definition: platforms.BackupDefinition{
 			Category: CategorySettings, SourceRoot: root, NonRecursive: true,
@@ -1624,8 +1703,7 @@ func TestValidateRestoreJournalRejectsUnsafeOperationID(t *testing.T) {
 	env := newBackupTestEnv(t, platformids.Mister)
 
 	err := env.Manager.validateRestoreJournal(&restoreJournal{
-		OperationID:    "../../outside",
-		MaxLogicalSize: env.Manager.cfg.BackupMaxSizeBytes(),
+		OperationID: "../../outside",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "operation ID")
@@ -1839,6 +1917,34 @@ func TestApplyRestoreRollsBackUserDBAfterRestoreFailure(t *testing.T) {
 	assert.Contains(t, err.Error(), "injected database restore failure")
 	env.UserDB.AssertNumberOfCalls(t, "RestoreBackup", 2)
 	assert.NoDirExists(t, env.Manager.restoreTransactionPath())
+}
+
+func TestRecoverRestoreCleansStaleStagingDirectories(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	backupDir := env.Manager.backupDir()
+	localStaging := filepath.Join(backupDir, localRestoreStagingPrefix+"stale")
+	remoteStaging := filepath.Join(backupDir, remoteRestoreStagingPrefix+"stale")
+	unrelatedDir := filepath.Join(backupDir, "keep-me")
+	writeTestFile(t, filepath.Join(localStaging, "payload"), "local")
+	writeTestFile(t, filepath.Join(remoteStaging, "payload"), "remote")
+	writeTestFile(t, filepath.Join(unrelatedDir, "payload"), "keep")
+	reservedFile := filepath.Join(backupDir, localRestoreStagingPrefix+"not-a-directory")
+	writeTestFile(t, reservedFile, "keep")
+	stagingLink := filepath.Join(backupDir, remoteRestoreStagingPrefix+"symlink")
+	if runtime.GOOS != "windows" {
+		require.NoError(t, os.Symlink(unrelatedDir, stagingLink))
+	}
+
+	require.NoError(t, env.Manager.RecoverRestore(context.Background()))
+	assert.NoDirExists(t, localStaging)
+	assert.NoDirExists(t, remoteStaging)
+	assert.DirExists(t, unrelatedDir)
+	assert.FileExists(t, reservedFile)
+	if runtime.GOOS != "windows" {
+		_, err := os.Lstat(stagingLink)
+		require.NoError(t, err)
+	}
 }
 
 func TestRecoverRestoreRetainsTransactionOwnedUserDBRollbackAcrossRetries(t *testing.T) {
@@ -2236,7 +2342,7 @@ func TestManagerRunRemoteBackupUploadsPackedSnapshot(t *testing.T) {
 				t, "backup-1", platformids.Mister, &committed,
 			))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
-			writeJSON(t, w, remoteListResponse{StorageUsedBytes: 99, StorageQuotaBytes: 1000})
+			writeJSON(t, w, remoteListResponse{StorageUsedBytes: 99, StorageQuotaBytes: 1 << 30})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -2363,11 +2469,10 @@ func TestManagerRunRemoteBackupReportsQuotaExceeded(t *testing.T) {
 				return
 			}
 			writeJSON(t, w, remoteCheckResponse{Missing: req.Hashes})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
+			writeJSON(t, w, remoteListResponse{StorageUsedBytes: 0, StorageQuotaBytes: 1})
 		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/device/backup-packs/"):
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{
-				"error":{"code":"quota_exceeded","message":"Backup storage quota exceeded"}
-			}`))
+			t.Fatal("quota preflight must reject before uploading a pack")
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -2397,6 +2502,49 @@ func TestManagerRunRemoteBackupReportsQuotaExceeded(t *testing.T) {
 	default:
 		t.Fatal("expected inbox notification")
 	}
+}
+
+func TestRemotePackPlanReportsExactUploadBytes(t *testing.T) {
+	t.Parallel()
+	files := []FileRef{
+		{Category: CategorySaves, RestorePath: "saves/one", SHA256: strings.Repeat("1", 64), Size: 10},
+		{Category: CategorySaves, RestorePath: "saves/two", SHA256: strings.Repeat("2", 64), Size: 20},
+	}
+	missing := map[string]struct{}{files[0].SHA256: {}, files[1].SHA256: {}}
+
+	plan, err := planRemotePacks(files, missing)
+	require.NoError(t, err)
+	require.Len(t, plan.packs, 1)
+	expected, err := remotePackEncodedSize(plan.packs[0].files)
+	require.NoError(t, err)
+	assert.Equal(t, expected, plan.packs[0].size)
+	assert.Equal(t, expected, plan.uploadBytes)
+}
+
+func TestEnsureRemoteUploadCapacity(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, ensureRemoteUploadCapacity(100, 200, 100))
+	require.ErrorIs(t, ensureRemoteUploadCapacity(100, 200, 101), errRemoteQuotaExceeded)
+	require.ErrorIs(t, ensureRemoteUploadCapacity(201, 200, 0), errRemoteQuotaExceeded)
+	require.Error(t, ensureRemoteUploadCapacity(-1, 200, 1))
+}
+
+func TestRemoteUploadKeepsServerQuotaCheckAuthoritative(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPut, r.Method)
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"code":"quota_exceeded","message":"full"}}`))
+	}))
+	defer server.Close()
+	client := &remoteClient{
+		httpClient: server.Client(), baseURL: server.URL, bearer: "test-token", platform: "test",
+	}
+
+	err := client.doBytes(
+		context.Background(), http.MethodPut, "/v1/device/backup-packs/hash", []byte("pack"), nil,
+	)
+	require.ErrorIs(t, err, errRemoteQuotaExceeded)
 }
 
 func TestRemotePackFilesSortsByCategoryThenPath(t *testing.T) {
@@ -2488,7 +2636,7 @@ func TestManagerRestoreRemoteRejectsMissingUserDBBeforePreRestoreBackup(t *testi
 	env.UserDB.AssertNotCalled(t, "RestoreBackup", testifymock.Anything)
 }
 
-func TestManagerRestoreRemoteDownloadsObjects(t *testing.T) {
+func TestManagerRestoreRemoteStagesViaPacks(t *testing.T) {
 	env := newBackupTestEnv(t, platformids.Mister)
 	newSave := []byte("remote-save\n")
 	hash := sha256Hex(newSave)
@@ -2504,6 +2652,7 @@ func TestManagerRestoreRemoteDownloadsObjects(t *testing.T) {
 	require.NoError(t, err)
 	restoreComplete := false
 	var restoreCompleteID string
+	pack := newTestPackFixture(t, newSave, remoteConfig)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -2518,10 +2667,10 @@ func TestManagerRestoreRemoteDownloadsObjects(t *testing.T) {
 				},
 				Manifest: manifestData, CreatedAt: time.Now().UTC(),
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+hash:
-			_, _ = w.Write(newSave)
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+configHash:
-			_, _ = w.Write(remoteConfig)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			pack.handleLocate(t, w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-packs/"+pack.packHash:
+			_, _ = w.Write(pack.body)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups/7/restore-complete":
 			var complete remoteRestoreCompleteRequest
 			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&complete)) {
@@ -2599,6 +2748,81 @@ func parseTestPack(t *testing.T, body []byte) map[string][]byte {
 }
 
 func testStringPointer(value string) *string { return &value }
+
+// testPackFixture is one server-side pack over a set of payloads, in the
+// exact wire format the pack restore protocol serves: concatenated file
+// bytes + JSON footer + 4-byte footer-length trailer.
+type testPackFixture struct {
+	body     []byte
+	packHash string
+	objects  []remotePackObjectRef
+}
+
+func newTestPackFixture(t *testing.T, payloads ...[]byte) *testPackFixture {
+	t.Helper()
+	var buf bytes.Buffer
+	refs := make([]remotePackObjectRef, 0, len(payloads))
+	entries := make([]packFooterEntry, 0, len(payloads))
+	seen := make(map[string]struct{}, len(payloads))
+	for _, payload := range payloads {
+		hash := sha256Hex(payload)
+		if _, dup := seen[hash]; dup {
+			continue
+		}
+		seen[hash] = struct{}{}
+		offset := int64(buf.Len())
+		refs = append(refs, remotePackObjectRef{Hash: hash, Offset: offset, Length: int64(len(payload))})
+		entries = append(entries, packFooterEntry{Hash: hash, Offset: offset, Length: int64(len(payload))})
+		_, _ = buf.Write(payload)
+	}
+	footer, err := json.Marshal(entries)
+	require.NoError(t, err)
+	_, _ = buf.Write(footer)
+	var trailer [4]byte
+	//nolint:gosec // test footers are tiny, far below uint32 range.
+	binary.BigEndian.PutUint32(trailer[:], uint32(len(footer)))
+	_, _ = buf.Write(trailer[:])
+	return &testPackFixture{
+		body: buf.Bytes(), packHash: sha256Hex(buf.Bytes()), objects: refs,
+	}
+}
+
+// locateResponse resolves the requested hashes against this pack, listing
+// unknown hashes as missing — what a real locate endpoint would return for
+// a single-pack account.
+func (f *testPackFixture) locateResponse(hashes []string) remoteLocateResponse {
+	have := make(map[string]remotePackObjectRef, len(f.objects))
+	for _, ref := range f.objects {
+		have[ref.Hash] = ref
+	}
+	resp := remoteLocateResponse{Missing: []string{}}
+	pack := remotePackObjects{PackHash: f.packHash, SizeBytes: int64(len(f.body))}
+	for _, hash := range hashes {
+		if ref, ok := have[hash]; ok {
+			pack.Objects = append(pack.Objects, ref)
+		} else {
+			resp.Missing = append(resp.Missing, hash)
+		}
+	}
+	if len(pack.Objects) > 0 {
+		resp.Packs = append(resp.Packs, pack)
+	}
+	return resp
+}
+
+// handleLocate decodes a locate request and answers it from this pack.
+func (f *testPackFixture) handleLocate(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+	var req remoteLocateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Errorf("decoding locate request: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	assert.NotContains(t, req.Hashes, remoteEmptyContentSHA256,
+		"the empty-content hash must never be located")
+	writeJSON(t, w, f.locateResponse(req.Hashes))
+}
 
 func testCommittedRemoteResponse(
 	t *testing.T, id, platform string, request *remoteSnapshotRequest,
@@ -2826,6 +3050,8 @@ func TestManagerRestoreRemoteSynthesizesEmptyFiles(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	pack := newTestPackFixture(t, newSave)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/8":
@@ -2839,10 +3065,11 @@ func TestManagerRestoreRemoteSynthesizesEmptyFiles(t *testing.T) {
 				},
 				Manifest: manifestData, CreatedAt: time.Now().UTC(),
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+hash:
-			_, _ = w.Write(newSave)
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+remoteEmptyContentSHA256:
-			t.Error("the empty object must never be downloaded")
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			// handleLocate asserts the empty-content hash is never requested.
+			pack.handleLocate(t, w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-packs/"+pack.packHash:
+			_, _ = w.Write(pack.body)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups/8/restore-complete":
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -2867,12 +3094,14 @@ func TestManagerRestoreRemoteLeavesDeviceUntouchedOnDownloadFailure(t *testing.T
 	first := []byte("first-save\n")
 	second := []byte("second-save\n")
 	manifestData, manifestHash, err := canonicalRemoteManifest(map[string][]remoteManifestEntry{
+		CategoryZaparoo: {{Path: config.UserDbFile, SHA256: remoteEmptyContentSHA256, Size: 0}},
 		CategorySaves: {
 			{Path: "saves/a.sav", SHA256: sha256Hex(first), Size: int64(len(first))},
 			{Path: "saves/b.sav", SHA256: sha256Hex(second), Size: int64(len(second))},
 		},
 	})
 	require.NoError(t, err)
+	pack := newTestPackFixture(t, first, second)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -2882,15 +3111,16 @@ func TestManagerRestoreRemoteLeavesDeviceUntouchedOnDownloadFailure(t *testing.T
 				Platform:     testStringPointer(platformids.Mister),
 				ManifestHash: manifestHash, SizeBytes: int64(len(first) + len(second)),
 				Categories: map[string]remoteCategorySummary{
-					CategorySaves: {Files: 2, Bytes: int64(len(first) + len(second))},
+					CategoryZaparoo: {Files: 1, Bytes: 0},
+					CategorySaves:   {Files: 2, Bytes: int64(len(first) + len(second))},
 				},
 				Manifest: manifestData, CreatedAt: time.Now().UTC(),
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+sha256Hex(first):
-			_, _ = w.Write(first)
-		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-objects/"+sha256Hex(second):
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			pack.handleLocate(t, w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-packs/"+pack.packHash:
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"Object not found"}}`))
+			_, _ = w.Write([]byte(`{"error":{"code":"not_found","message":"Pack not found"}}`))
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -2909,6 +3139,45 @@ func TestManagerRestoreRemoteLeavesDeviceUntouchedOnDownloadFailure(t *testing.T
 	assert.Equal(t, []byte("old-a\n"), current)
 	_, err = os.Stat(filepath.Join(env.RootDir, "saves", "b.sav"))
 	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestManagerRestoreRemoteFailsWhenObjectsMissing(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Mister)
+	newSave := []byte("missing-object-save\n")
+	manifestData, manifestHash, err := canonicalRemoteManifest(map[string][]remoteManifestEntry{
+		CategoryZaparoo: {{Path: config.UserDbFile, SHA256: remoteEmptyContentSHA256, Size: 0}},
+		CategorySaves: {
+			{Path: "saves/game.sav", SHA256: sha256Hex(newSave), Size: int64(len(newSave))},
+		},
+	})
+	require.NoError(t, err)
+	// The fixture holds no payloads, so locate reports the hash missing.
+	pack := newTestPackFixture(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/9":
+			writeJSON(t, w, remoteBackupResponse{
+				ID: "9", BackupType: RemoteBackupTypeManual, SchemaVersion: remoteSchemaVersion,
+				Platform:     testStringPointer(platformids.Mister),
+				ManifestHash: manifestHash, SizeBytes: int64(len(newSave)),
+				Categories: map[string]remoteCategorySummary{
+					CategoryZaparoo: {Files: 1, Bytes: 0},
+					CategorySaves:   {Files: 1, Bytes: int64(len(newSave))},
+				},
+				Manifest: manifestData, CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			pack.handleLocate(t, w, r)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	_, err = env.Manager.RestoreRemote(context.Background(), "9")
+	require.ErrorContains(t, err, "no longer available")
 }
 
 func TestManagerRunRemoteRechecksDeduplicatedSourcesBeforeCommit(t *testing.T) {
@@ -3001,7 +3270,7 @@ func TestManagerRunRemoteRetriesOnceOnIntegrityMismatch(t *testing.T) {
 				t, "backup-2", platformids.Mister, &committed,
 			))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
-			writeJSON(t, w, remoteListResponse{})
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -3065,7 +3334,7 @@ func TestManagerRunRemoteRepairsMissingObjectsOnce(t *testing.T) {
 				t, "backup-repaired", platformids.Mister, &committed,
 			))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
-			writeJSON(t, w, remoteListResponse{})
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -3495,7 +3764,7 @@ func newRemoteBackupSuccessServer(t *testing.T, requests *atomic.Int32) *httptes
 			}
 			writeJSON(t, w, testCommittedRemoteResponse(t, "backup-1", platformids.Mister, &committed))
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
-			writeJSON(t, w, remoteListResponse{StorageUsedBytes: 1, StorageQuotaBytes: 1000})
+			writeJSON(t, w, remoteListResponse{StorageUsedBytes: 1, StorageQuotaBytes: 1 << 30})
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -3568,4 +3837,289 @@ func TestManagerRecoverInterruptedRunsSkipsActiveOperation(t *testing.T) {
 	status := env.Manager.Status()
 	assert.Equal(t, StatusFailed, status.Remote.LastStatus)
 	assert.Equal(t, statusErrorInterrupted, status.Remote.LastError)
+}
+
+func testRateLimitWaits() *rateLimitWaits {
+	return &rateLimitWaits{
+		minWait:     time.Millisecond,
+		defaultWait: time.Millisecond,
+		maxWait:     5 * time.Millisecond,
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 30*time.Second, parseRetryAfter("30"))
+	assert.Equal(t, 5*time.Second, parseRetryAfter(" 5 "))
+	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("-3"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("soon"))
+	// HTTP-date form is valid per spec but unused by the backup server;
+	// it degrades to the default wait rather than being parsed.
+	assert.Equal(t, time.Duration(0), parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT"))
+}
+
+func TestRemoteStatusErrorRateLimited(t *testing.T) {
+	t.Parallel()
+
+	t.Run("route-level plain-text 429 with Retry-After", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Retry-After": []string{"30"}},
+			Body:       io.NopCloser(strings.NewReader("Too Many Requests\n")),
+		}
+		err := remoteStatusError(resp)
+		require.ErrorIs(t, err, errRemoteRateLimited)
+		var rateLimited *remoteRateLimitedError
+		require.ErrorAs(t, err, &rateLimited)
+		assert.Equal(t, 30*time.Second, rateLimited.retryAfter)
+	})
+
+	t.Run("handler-level JSON rate_limited without header", func(t *testing.T) {
+		t.Parallel()
+		resp := &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{},
+			Body: io.NopCloser(strings.NewReader(
+				`{"error":{"code":"rate_limited","message":"Snapshot commit rate limit reached"}}`,
+			)),
+		}
+		err := remoteStatusError(resp)
+		require.ErrorIs(t, err, errRemoteRateLimited)
+		var rateLimited *remoteRateLimitedError
+		require.ErrorAs(t, err, &rateLimited)
+		assert.Equal(t, time.Duration(0), rateLimited.retryAfter)
+	})
+}
+
+func TestRemoteClientRetryRateLimited(t *testing.T) {
+	t.Parallel()
+	newClient := func() *remoteClient {
+		return &remoteClient{retryWaits: *testRateLimitWaits()}
+	}
+
+	t.Run("waits out rate limits and succeeds", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		err := newClient().retryRateLimited(context.Background(), func() error {
+			attempts++
+			if attempts < 3 {
+				return &remoteRateLimitedError{retryAfter: time.Millisecond}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 3, attempts)
+	})
+
+	t.Run("gives up after the attempt cap", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		err := newClient().retryRateLimited(context.Background(), func() error {
+			attempts++
+			return &remoteRateLimitedError{retryAfter: time.Millisecond}
+		})
+		require.ErrorIs(t, err, errRemoteRateLimited)
+		assert.Equal(t, remoteRateLimitMaxAttempts, attempts)
+	})
+
+	t.Run("other errors return immediately", func(t *testing.T) {
+		t.Parallel()
+		attempts := 0
+		err := newClient().retryRateLimited(context.Background(), func() error {
+			attempts++
+			return errRemoteQuotaExceeded
+		})
+		require.ErrorIs(t, err, errRemoteQuotaExceeded)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("context cancellation interrupts the wait", func(t *testing.T) {
+		t.Parallel()
+		client := &remoteClient{retryWaits: rateLimitWaits{
+			minWait: time.Hour, defaultWait: time.Hour, maxWait: time.Hour,
+		}}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		attempts := 0
+		err := client.retryRateLimited(ctx, func() error {
+			attempts++
+			return &remoteRateLimitedError{}
+		})
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.Equal(t, 1, attempts)
+	})
+}
+
+func TestManagerRestoreRemoteRetriesRateLimitedPackDownload(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Mister)
+	env.Manager.rateLimitWaits = testRateLimitWaits()
+	newSave := []byte("rate-limited-save\n")
+	manifestData, manifestHash, err := canonicalRemoteManifest(map[string][]remoteManifestEntry{
+		CategoryZaparoo: {{Path: config.UserDbFile, SHA256: remoteEmptyContentSHA256, Size: 0}},
+		CategorySaves: {
+			{Path: "saves/game.sav", SHA256: sha256Hex(newSave), Size: int64(len(newSave))},
+		},
+	})
+	require.NoError(t, err)
+	pack := newTestPackFixture(t, newSave)
+	packGets := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/11":
+			writeJSON(t, w, remoteBackupResponse{
+				ID: "11", BackupType: RemoteBackupTypeManual, SchemaVersion: remoteSchemaVersion,
+				Platform:     testStringPointer(platformids.Mister),
+				ManifestHash: manifestHash, SizeBytes: int64(len(newSave)),
+				Categories: map[string]remoteCategorySummary{
+					CategoryZaparoo: {Files: 1, Bytes: 0},
+					CategorySaves:   {Files: 1, Bytes: int64(len(newSave))},
+				},
+				Manifest: manifestData, CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			pack.handleLocate(t, w, r)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backup-packs/"+pack.packHash:
+			packGets++
+			if packGets <= 2 {
+				// Route-level rate limiter shape: plain text + Retry-After.
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte("Too Many Requests\n"))
+				return
+			}
+			_, _ = w.Write(pack.body)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups/11/restore-complete":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	_, err = env.Manager.RestoreRemote(context.Background(), "11")
+	require.NoError(t, err)
+	assert.Equal(t, 3, packGets, "two rate-limited responses are waited out and retried")
+	restored, err := os.ReadFile(filepath.Join(env.RootDir, "saves", "game.sav"))
+	require.NoError(t, err)
+	assert.Equal(t, newSave, restored)
+}
+
+func TestManagerRunRemoteRetriesRateLimitedPackUpload(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Mister)
+	env.Manager.rateLimitWaits = testRateLimitWaits()
+	putCalls := 0
+	var committed remoteSnapshotRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/heartbeat":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/me":
+			writeJSON(t, w, remoteDeviceMeResponse{ID: "device-1", BackupActive: true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/check":
+			var request remoteCheckRequest
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, remoteCheckResponse{Missing: request.Hashes})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/device/backup-packs/"):
+			putCalls++
+			if putCalls == 1 {
+				w.Header().Set("Retry-After", "1")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte("Too Many Requests\n"))
+				return
+			}
+			body, readErr := io.ReadAll(r.Body)
+			if !assert.NoError(t, readErr) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, remotePackResponse{PackHash: sha256Hex(body), CreatedAt: time.Now().UTC()})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups":
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&committed)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, testCommittedRemoteResponse(
+				t, "backup-rate-limited", platformids.Mister, &committed,
+			))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	info, err := env.Manager.RunRemote(context.Background(), RemoteBackupTypeManual)
+	require.NoError(t, err)
+	assert.Equal(t, "backup-rate-limited", info.Backup.ID)
+	assert.GreaterOrEqual(t, putCalls, 2, "the rate-limited pack upload is retried")
+}
+
+func TestManagerRunRemoteRecordsNoChangesOnDedupe(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Mister)
+	snapshotCreatedAt := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	verifiedAt := time.Now().UTC()
+	started := time.Now().UTC().Add(-time.Second)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/heartbeat":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/me":
+			writeJSON(t, w, remoteDeviceMeResponse{ID: "device-1", BackupActive: true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/check":
+			writeJSON(t, w, remoteCheckResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups":
+			var committed remoteSnapshotRequest
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&committed)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			// The server dedupe returns the EXISTING snapshot: an older
+			// created_at and, here, a different backup type than the
+			// manual run that committed — only deduplicated responses may
+			// mismatch the requested type.
+			response := testCommittedRemoteResponse(t, "backup-existing", platformids.Mister, &committed)
+			response.BackupType = RemoteBackupTypeScheduled
+			response.CreatedAt = snapshotCreatedAt
+			response.VerifiedAt = &verifiedAt
+			response.Deduplicated = true
+			writeJSON(t, w, response)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	info, err := env.Manager.RunRemote(context.Background(), RemoteBackupTypeManual)
+	require.NoError(t, err,
+		"a manual run deduplicating onto a scheduled snapshot must pass response validation")
+	assert.True(t, info.NoChanges)
+	assert.Equal(t, "backup-existing", info.Backup.ID)
+	assert.True(t, info.Backup.CreatedAt.Equal(snapshotCreatedAt))
+	require.NotNil(t, info.Backup.VerifiedAt)
+
+	remote := env.Manager.Status().Remote
+	assert.True(t, remote.LastRunNoChanges, "status records the run as verified-unchanged")
+	require.NotNil(t, remote.LastSuccessAt)
+	lastSuccess, err := time.Parse(time.RFC3339Nano, *remote.LastSuccessAt)
+	require.NoError(t, err)
+	assert.False(t, lastSuccess.Before(started),
+		"lastSuccessAt is the run's own time, not the deduped snapshot's created_at")
+	require.NotNil(t, remote.LastSnapshotCreatedAt)
+	assert.Equal(t, formatTime(snapshotCreatedAt), *remote.LastSnapshotCreatedAt,
+		"lastSnapshotCreatedAt preserves when the stored content last changed")
 }

--- a/pkg/service/backup/collector.go
+++ b/pkg/service/backup/collector.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -52,7 +53,6 @@ type sourceCollector struct {
 	files              []FileRef
 	warnings           []models.BackupWarning
 	logicalSize        int64
-	maxLogicalSize     int64
 	maxFiles           int
 	maxWarnings        int
 }
@@ -113,13 +113,13 @@ func (r *cancelableSource) Close() error {
 }
 
 func newSourceCollector(
-	ctx context.Context, maxLogicalSize int64, excludedSources map[string]struct{},
+	ctx context.Context, excludedSources map[string]struct{},
 ) *sourceCollector {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	return &sourceCollector{
-		ctx: ctx, maxLogicalSize: maxLogicalSize, excludedSources: excludedSources,
+		ctx: ctx, excludedSources: excludedSources,
 		maxFiles: maxArchiveEntries - 1, maxWarnings: maxArchiveEntries,
 	}
 }
@@ -477,8 +477,12 @@ func (c *sourceCollector) appendFile(file *FileRef) {
 		c.err = fmt.Errorf("backup has too many files: exceeds %d", c.maxFiles)
 		return
 	}
-	if file.Size < 0 || c.maxLogicalSize <= 0 || file.Size > c.maxLogicalSize-c.logicalSize {
-		c.err = fmt.Errorf("backup exceeds logical size limit of %d bytes", c.maxLogicalSize)
+	if file.Size < 0 {
+		c.err = errors.New("backup source has negative size")
+		return
+	}
+	if file.Size > math.MaxInt64-c.logicalSize {
+		c.err = errors.New("backup logical size overflow")
 		return
 	}
 	c.logicalSize += file.Size

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -308,6 +308,40 @@ type packFooterEntry struct {
 	Length int64  `json:"length"`
 }
 
+// uploadResult summarizes one upload pass: how many packs and bytes went
+// over the wire, and which files were skipped as unstorable.
+type uploadResult struct {
+	skipped       []FileRef
+	packs         int
+	bytesUploaded int64
+}
+
+type plannedRemotePack struct {
+	files []FileRef
+	size  int64
+}
+
+type remotePackPlan struct {
+	packs       []plannedRemotePack
+	skipped     []FileRef
+	uploadBytes int64
+}
+
+// remoteRateLimitedError is a 429 from the backup server. retryAfter is the
+// server-requested wait (zero when the header is absent). errors.Is matches
+// the errRemoteRateLimited sentinel.
+type remoteRateLimitedError struct {
+	retryAfter time.Duration
+}
+
+// rateLimitWaits bounds how long a rate-limited request waits before a
+// retry. Carried per client so tests can shrink the waits.
+type rateLimitWaits struct {
+	minWait     time.Duration
+	defaultWait time.Duration
+	maxWait     time.Duration
+}
+
 type remoteClient struct {
 	httpClient     *http.Client
 	onUnauthorized func()
@@ -1573,25 +1607,6 @@ func (m *Manager) uploadMissingWithQuotaPreflight(
 	return client.uploadPackPlan(ctx, &plan, m.pauser)
 }
 
-// uploadResult summarizes one upload pass: how many packs and bytes went
-// over the wire, and which files were skipped as unstorable.
-type uploadResult struct {
-	skipped       []FileRef
-	packs         int
-	bytesUploaded int64
-}
-
-type plannedRemotePack struct {
-	files []FileRef
-	size  int64
-}
-
-type remotePackPlan struct {
-	packs       []plannedRemotePack
-	skipped     []FileRef
-	uploadBytes int64
-}
-
 func planRemotePacks(files []FileRef, missing map[string]struct{}) (remotePackPlan, error) {
 	var plan remotePackPlan
 	if len(missing) == 0 {
@@ -1716,24 +1731,9 @@ func (c *remoteClient) uploadMissing(
 	return c.uploadPackPlan(ctx, &plan, pauser)
 }
 
-// remoteRateLimitedError is a 429 from the backup server. retryAfter is the
-// server-requested wait (zero when the header is absent). errors.Is matches
-// the errRemoteRateLimited sentinel.
-type remoteRateLimitedError struct {
-	retryAfter time.Duration
-}
-
 func (*remoteRateLimitedError) Error() string { return errRemoteRateLimited.Error() }
 
 func (*remoteRateLimitedError) Is(target error) bool { return errors.Is(errRemoteRateLimited, target) }
-
-// rateLimitWaits bounds how long a rate-limited request waits before a
-// retry. Carried per client so tests can shrink the waits.
-type rateLimitWaits struct {
-	minWait     time.Duration
-	defaultWait time.Duration
-	maxWait     time.Duration
-}
 
 var defaultRateLimitWaits = rateLimitWaits{
 	minWait:     remoteRateLimitMinWait,

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -36,6 +36,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -84,6 +85,14 @@ const (
 	// stuck behind a stale negative result.
 	remoteAvailabilityTTL      = 1 * time.Hour
 	remoteAvailabilityRetryTTL = 5 * time.Minute
+
+	// Rate-limited (429) responses are waited out and retried instead of
+	// failing the whole operation. The wait honors the server's Retry-After
+	// clamped to [min, max]; the default applies when no header is sent.
+	remoteRateLimitMaxAttempts = 10
+	remoteRateLimitMinWait     = 5 * time.Second
+	remoteRateLimitDefaultWait = 15 * time.Second
+	remoteRateLimitMaxWait     = 2 * time.Minute
 )
 
 var (
@@ -110,6 +119,10 @@ type RemoteRunInfo struct {
 	UploadedBytes     int64                            `json:"uploadedBytes"`
 	StorageUsedBytes  int64                            `json:"storageUsedBytes,omitempty"`
 	StorageQuotaBytes int64                            `json:"storageQuotaBytes,omitempty"`
+	// NoChanges marks a run whose manifest matched the server's existing
+	// snapshot: the run succeeded and the content is verified stored, but
+	// nothing new was uploaded and no new snapshot record was created.
+	NoChanges bool `json:"noChanges,omitempty"`
 }
 
 // RemoteRestoreInfo describes one completed remote restore.
@@ -135,6 +148,7 @@ type RemoteListInfo struct {
 type RemoteBackupInfo struct {
 	CoreVersion   *string                          `json:"coreVersion,omitempty"`
 	Platform      *string                          `json:"platform,omitempty"`
+	VerifiedAt    *time.Time                       `json:"verifiedAt,omitempty"`
 	RestoredAt    *time.Time                       `json:"restoredAt,omitempty"`
 	SourceDevice  *RemoteBackupSourceDevice        `json:"sourceDevice,omitempty"`
 	Categories    map[string]remoteCategorySummary `json:"categories"`
@@ -197,6 +211,31 @@ type remoteCheckResponse struct {
 	Missing []string `json:"missing"`
 }
 
+type remoteLocateRequest struct {
+	Hashes []string `json:"hashes"`
+}
+
+//nolint:tagliatelle // Remote API contract uses snake_case JSON fields.
+type remotePackObjectRef struct {
+	Hash   string `json:"hash"`
+	Offset int64  `json:"offset"`
+	Length int64  `json:"length"`
+}
+
+//nolint:tagliatelle,govet // Remote API contract uses snake_case JSON fields.
+type remotePackObjects struct {
+	PackHash  string                `json:"pack_hash"`
+	SizeBytes int64                 `json:"size_bytes"`
+	Objects   []remotePackObjectRef `json:"objects"`
+}
+
+// remoteLocateResponse maps requested content hashes to the live packs
+// holding their bytes; Missing lists hashes with no live object.
+type remoteLocateResponse struct {
+	Packs   []remotePackObjects `json:"packs"`
+	Missing []string            `json:"missing"`
+}
+
 //nolint:tagliatelle,govet // Remote API contract uses snake_case JSON fields.
 type remoteListResponse struct {
 	Items             []remoteBackupResponse `json:"items"`
@@ -208,6 +247,7 @@ type remoteListResponse struct {
 type remoteBackupResponse struct {
 	CoreVersion   *string                          `json:"core_version,omitempty"`
 	Platform      *string                          `json:"platform,omitempty"`
+	VerifiedAt    *time.Time                       `json:"verified_at,omitempty"`
 	RestoredAt    *time.Time                       `json:"restored_at,omitempty"`
 	SourceDevice  *remoteBackupSourceDevice        `json:"source_device,omitempty"`
 	Categories    map[string]remoteCategorySummary `json:"categories"`
@@ -218,6 +258,9 @@ type remoteBackupResponse struct {
 	ID            string                           `json:"id"`
 	SchemaVersion int                              `json:"schema_version"`
 	SizeBytes     int64                            `json:"size_bytes"`
+	// Deduplicated is set on commit responses whose manifest matched this
+	// existing snapshot: the run succeeded with no changes to store.
+	Deduplicated bool `json:"deduplicated,omitempty"`
 }
 
 //nolint:tagliatelle,govet // Remote API contract uses snake_case JSON fields.
@@ -271,6 +314,7 @@ type remoteClient struct {
 	baseURL        string
 	bearer         string
 	platform       string
+	retryWaits     rateLimitWaits
 }
 
 func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunInfo, error) {
@@ -312,14 +356,21 @@ func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunIn
 	if len(info.Warnings) > 0 || info.SkippedFiles > 0 {
 		lastStatus = StatusPartial
 	}
+	// LastSuccessAt is the run's own completion time, never the snapshot
+	// record's CreatedAt: a deduplicated run returns the existing snapshot
+	// with its original timestamp, and stamping that here would make a
+	// healthy daily schedule look like it stopped on the last content
+	// change (and eventually trip the false stale-backup notice).
 	_ = m.writeRemoteStatus(&statusEntry{
-		LastRunAt:      formatTime(started),
-		LastSuccessAt:  formatTime(info.Backup.CreatedAt),
-		LastStatus:     lastStatus,
-		LastBackupSize: info.Backup.SizeBytes,
-		Categories:     remoteCategoriesToStatus(info.Categories),
-		Warnings:       info.Warnings,
-		SkippedFiles:   len(info.Warnings) + info.SkippedFiles,
+		LastRunAt:             formatTime(started),
+		LastSuccessAt:         formatTime(time.Now().UTC()),
+		LastSnapshotCreatedAt: formatTime(info.Backup.CreatedAt),
+		LastRunNoChanges:      info.NoChanges,
+		LastStatus:            lastStatus,
+		LastBackupSize:        info.Backup.SizeBytes,
+		Categories:            remoteCategoriesToStatus(info.Categories),
+		Warnings:              info.Warnings,
+		SkippedFiles:          len(info.Warnings) + info.SkippedFiles,
 	})
 	return info, nil
 }
@@ -330,7 +381,10 @@ func (m *Manager) ListRemote(ctx context.Context) (RemoteListInfo, error) {
 		return RemoteListInfo{}, err
 	}
 	var resp remoteListResponse
-	if err := client.doJSON(ctx, http.MethodGet, "/v1/device/backups", nil, &resp); err != nil {
+	if err := client.retryRateLimited(ctx, func() error {
+		resp = remoteListResponse{}
+		return client.doJSON(ctx, http.MethodGet, "/v1/device/backups", nil, &resp)
+	}); err != nil {
 		return RemoteListInfo{}, err
 	}
 	items := make([]RemoteBackupInfo, 0, len(resp.Items))
@@ -389,7 +443,10 @@ func (m *Manager) RestoreRemote(ctx context.Context, id string) (RemoteRestoreIn
 	}
 	var resp remoteBackupResponse
 	backupPath := remoteBackupPath(id)
-	getErr := client.doJSONLimit(ctx, http.MethodGet, backupPath, nil, &resp, remoteManifestResponseLimit)
+	getErr := client.retryRateLimited(ctx, func() error {
+		resp = remoteBackupResponse{}
+		return client.doJSONLimit(ctx, http.MethodGet, backupPath, nil, &resp, remoteManifestResponseLimit)
+	})
 	if getErr != nil {
 		return RemoteRestoreInfo{}, getErr
 	}
@@ -415,7 +472,7 @@ func (m *Manager) RestoreRemote(ctx context.Context, id string) (RemoteRestoreIn
 	if len(files) > maxArchiveEntries-1 {
 		return RemoteRestoreInfo{}, fmt.Errorf("remote backup has too many files: %d", len(files))
 	}
-	if _, validateErr := validateLogicalSize(files, m.cfg.BackupMaxSizeBytes()); validateErr != nil {
+	if _, validateErr := sumLogicalSize(files); validateErr != nil {
 		return RemoteRestoreInfo{}, validateErr
 	}
 	for _, file := range files {
@@ -473,15 +530,15 @@ func (m *Manager) RestoreRemote(ctx context.Context, id string) (RemoteRestoreIn
 	return RemoteRestoreInfo{PreRestoreBackup: &preInfo, RestoredFrom: remoteBackupToInfo(&resp)}, nil
 }
 
-// remoteStaging holds downloaded, hash-verified payloads on disk, keyed by
-// content hash, so the apply phase never depends on the network.
-type remoteStaging struct {
+// restoreStaging holds hash-verified payloads on disk, keyed by content hash,
+// so restore application never depends on an archive or network stream.
+type restoreStaging struct {
 	dir string
 }
 
-func (s *remoteStaging) path(hash string) string { return filepath.Join(s.dir, hash) }
+func (s *restoreStaging) path(hash string) string { return filepath.Join(s.dir, hash) }
 
-func (s *remoteStaging) open(hash string, wantSize int64) (io.ReadCloser, error) {
+func (s *restoreStaging) open(hash string, wantSize int64) (io.ReadCloser, error) {
 	if hash == remoteEmptyContentSHA256 {
 		return io.NopCloser(strings.NewReader("")), nil
 	}
@@ -501,72 +558,314 @@ func (s *remoteStaging) open(hash string, wantSize int64) (io.ReadCloser, error)
 	return file, nil
 }
 
-// stageRemotePayloads downloads and verifies every unique non-empty object
-// referenced by files into a temporary directory under the backup dir. The
-// returned cleanup removes the staging directory; it is safe to call after a
-// partial failure.
+// stageRemotePayloads stages every unique non-empty object referenced by
+// files into a temporary directory under the backup dir, downloading whole
+// packs and slicing objects out by the server-reported offsets — one GET
+// per pack rather than one per object. The returned cleanup removes the
+// staging directory; it is safe to call after a partial failure.
 func (m *Manager) stageRemotePayloads(
 	ctx context.Context,
 	client *remoteClient,
 	files []FileRef,
-) (*remoteStaging, func(), error) {
+) (*restoreStaging, func(), error) {
 	if err := os.MkdirAll(m.backupDir(), 0o750); err != nil {
 		return nil, nil, fmt.Errorf("creating backup directory: %w", err)
 	}
-	var required int64
-	sizes := make(map[string]int64, len(files))
-	for _, file := range files {
-		if file.SHA256 == remoteEmptyContentSHA256 {
-			continue
-		}
-		if size, ok := sizes[file.SHA256]; ok {
-			if size != file.Size {
-				return nil, nil, fmt.Errorf("remote manifest has conflicting sizes for %s", file.SHA256)
-			}
-			continue
-		}
-		if file.Size < 0 || file.Size > m.cfg.BackupMaxSizeBytes()-required {
-			return nil, nil, errors.New("remote restore exceeds backup size limit")
-		}
-		sizes[file.SHA256] = file.Size
-		required += file.Size
+	sizes, required, err := uniqueRemotePayloadSizes(files)
+	if err != nil {
+		return nil, nil, err
 	}
+	packs, err := locateRemotePacks(ctx, client, sizes)
+	if err != nil {
+		return nil, nil, err
+	}
+	// One pack sits on disk while its objects are sliced out, so staging
+	// needs headroom for the largest pack on top of the payload bytes.
+	var largestPack int64
+	for i := range packs {
+		largestPack = max(largestPack, packs[i].SizeBytes)
+	}
+	if required > math.MaxInt64-largestPack {
+		return nil, nil, errors.New("remote restore staging size overflow")
+	}
+	required += largestPack
 	free, err := helpers.FreeDiskSpace(m.backupDir())
 	if err != nil {
 		return nil, nil, fmt.Errorf("checking remote restore staging space: %w", err)
 	}
+	//nolint:gosec // required is non-negative: summed from validated sizes with overflow checks.
 	if uint64(required) > free {
 		return nil, nil, fmt.Errorf("insufficient disk space to stage remote restore: need %d bytes", required)
 	}
-	dir, err := os.MkdirTemp(m.backupDir(), "remote-restore-")
+	dir, err := os.MkdirTemp(m.backupDir(), remoteRestoreStagingPrefix)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating restore staging directory: %w", err)
 	}
-	staging := &remoteStaging{dir: dir}
+	staging := &restoreStaging{dir: dir}
 	cleanup := func() {
 		if removeErr := os.RemoveAll(dir); removeErr != nil {
 			log.Debug().Err(removeErr).Str("dir", dir).Msg("failed to remove restore staging directory")
 		}
 	}
 
-	seen := make(map[string]struct{}, len(files))
+	for i := range packs {
+		if stageErr := client.stagePackObjects(ctx, &packs[i], staging); stageErr != nil {
+			cleanup()
+			return nil, nil, stageErr
+		}
+	}
+	return staging, cleanup, nil
+}
+
+// uniqueRemotePayloadSizes maps each unique non-empty content hash to its
+// size and totals the bytes restore staging needs on disk.
+func uniqueRemotePayloadSizes(files []FileRef) (sizes map[string]int64, required int64, err error) {
+	sizes = make(map[string]int64, len(files))
 	for _, file := range files {
 		if file.SHA256 == remoteEmptyContentSHA256 {
 			continue
 		}
-		if _, ok := seen[file.SHA256]; ok {
+		if size, ok := sizes[file.SHA256]; ok {
+			if size != file.Size {
+				return nil, 0, fmt.Errorf("remote manifest has conflicting sizes for %s", file.SHA256)
+			}
 			continue
 		}
-		seen[file.SHA256] = struct{}{}
-		downloadErr := client.downloadObject(
-			ctx, file.SHA256, file.Size, staging.path(file.SHA256),
-		)
-		if downloadErr != nil {
-			cleanup()
-			return nil, nil, downloadErr
+		if file.Size < 0 {
+			return nil, 0, errors.New("remote restore payload has negative size")
+		}
+		if file.Size > math.MaxInt64-required {
+			return nil, 0, errors.New("remote restore staging size overflow")
+		}
+		sizes[file.SHA256] = file.Size
+		required += file.Size
+	}
+	return sizes, required, nil
+}
+
+// locateRemotePacks resolves the needed content hashes to the live packs
+// holding their bytes and validates the response against the manifest:
+// every hash located exactly once, sizes matching, ranges inside the pack.
+// A live snapshot's packs are GC-protected, so any missing hash is a hard
+// error rather than something to work around.
+func locateRemotePacks(
+	ctx context.Context,
+	client *remoteClient,
+	sizes map[string]int64,
+) ([]remotePackObjects, error) {
+	if len(sizes) == 0 {
+		return nil, nil
+	}
+	hashes := make([]string, 0, len(sizes))
+	for hash := range sizes {
+		hashes = append(hashes, hash)
+	}
+	sort.Strings(hashes)
+
+	groups := make(map[string]*remotePackObjects)
+	missing := 0
+	for start := 0; start < len(hashes); start += remoteCheckBatchSize {
+		end := min(start+remoteCheckBatchSize, len(hashes))
+		var resp remoteLocateResponse
+		req := remoteLocateRequest{Hashes: hashes[start:end]}
+		if err := client.retryRateLimited(ctx, func() error {
+			resp = remoteLocateResponse{}
+			return client.doJSON(ctx, http.MethodPost, "/v1/device/backup-objects/locate", &req, &resp)
+		}); err != nil {
+			return nil, err
+		}
+		missing += len(resp.Missing)
+		for i := range resp.Packs {
+			pack := resp.Packs[i]
+			group, ok := groups[pack.PackHash]
+			if !ok {
+				groups[pack.PackHash] = &pack
+				continue
+			}
+			if group.SizeBytes != pack.SizeBytes {
+				return nil, fmt.Errorf("remote pack %s reported with conflicting sizes", pack.PackHash)
+			}
+			group.Objects = append(group.Objects, pack.Objects...)
 		}
 	}
-	return staging, cleanup, nil
+	if missing > 0 {
+		return nil, fmt.Errorf("remote backup objects are no longer available on the server: %d missing", missing)
+	}
+
+	located := make(map[string]struct{}, len(sizes))
+	packs := make([]remotePackObjects, 0, len(groups))
+	for _, group := range groups {
+		if group.SizeBytes <= 0 || group.SizeBytes > remoteMaxPackBytes {
+			return nil, fmt.Errorf("remote pack %s has invalid size %d", group.PackHash, group.SizeBytes)
+		}
+		for _, ref := range group.Objects {
+			want, needed := sizes[ref.Hash]
+			if !needed {
+				return nil, fmt.Errorf("remote locate returned unrequested object %s", ref.Hash)
+			}
+			if _, dup := located[ref.Hash]; dup {
+				return nil, fmt.Errorf("remote object %s located more than once", ref.Hash)
+			}
+			located[ref.Hash] = struct{}{}
+			if ref.Length != want || ref.Offset < 0 || ref.Offset > group.SizeBytes-ref.Length {
+				return nil, fmt.Errorf("remote object %s has an inconsistent pack range", ref.Hash)
+			}
+		}
+		packs = append(packs, *group)
+	}
+	if len(located) != len(sizes) {
+		return nil, fmt.Errorf("remote locate response is missing %d objects", len(sizes)-len(located))
+	}
+	sort.Slice(packs, func(i, j int) bool { return packs[i].PackHash < packs[j].PackHash })
+	return packs, nil
+}
+
+// stagePackObjects downloads one pack and slices its objects into the
+// staging directory, verifying the whole-pack hash and every slice's hash.
+// The transient pack file is removed once its objects are staged.
+func (c *remoteClient) stagePackObjects(
+	ctx context.Context,
+	pack *remotePackObjects,
+	staging *restoreStaging,
+) error {
+	packPath, err := c.downloadPack(ctx, pack, staging.dir)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if removeErr := os.Remove(packPath); removeErr != nil {
+			log.Debug().Err(removeErr).Str("path", packPath).Msg("failed to remove staged pack file")
+		}
+	}()
+	return extractPackObjects(packPath, pack, staging)
+}
+
+// downloadPack fetches a whole pack blob into a temporary file inside dir,
+// verifying its size and sha256 against the locate response. Rate-limited
+// responses are waited out; each attempt uses a fresh temporary file.
+func (c *remoteClient) downloadPack(
+	ctx context.Context,
+	pack *remotePackObjects,
+	dir string,
+) (string, error) {
+	var packPath string
+	err := c.retryRateLimited(ctx, func() error {
+		path, attemptErr := c.downloadPackAttempt(ctx, pack, dir)
+		if attemptErr != nil {
+			return attemptErr
+		}
+		packPath = path
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return packPath, nil
+}
+
+func (c *remoteClient) downloadPackAttempt(
+	ctx context.Context,
+	pack *remotePackObjects,
+	dir string,
+) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, remoteTransferTimeout(pack.SizeBytes))
+	defer cancel()
+	out, err := os.CreateTemp(dir, ".pack-*")
+	if err != nil {
+		return "", fmt.Errorf("creating pack staging file: %w", err)
+	}
+	path := out.Name()
+
+	downloadPath := "/v1/device/backup-packs/" + pack.PackHash
+	rawErr := c.doRaw(ctx, http.MethodGet, downloadPath, nil, "", func(resp *http.Response) error {
+		hasher := sha256.New()
+		limited := &io.LimitedReader{R: resp.Body, N: pack.SizeBytes}
+		written, copyErr := io.Copy(io.MultiWriter(out, hasher), limited)
+		if copyErr != nil {
+			return fmt.Errorf("reading remote backup pack: %w", copyErr)
+		}
+		if written != pack.SizeBytes {
+			return fmt.Errorf("remote backup pack size mismatch: %s", pack.PackHash)
+		}
+		var extra [1]byte
+		extraSize, readErr := resp.Body.Read(extra[:])
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return fmt.Errorf("checking remote backup pack size: %w", readErr)
+		}
+		if extraSize != 0 {
+			return fmt.Errorf("remote backup pack size mismatch: %s", pack.PackHash)
+		}
+		if hex.EncodeToString(hasher.Sum(nil)) != pack.PackHash {
+			return fmt.Errorf("remote backup pack hash mismatch: %s", pack.PackHash)
+		}
+		if syncErr := out.Sync(); syncErr != nil {
+			return fmt.Errorf("syncing pack staging file: %w", syncErr)
+		}
+		return nil
+	})
+	closeErr := out.Close()
+	if rawErr == nil && closeErr != nil {
+		rawErr = fmt.Errorf("closing pack staging file: %w", closeErr)
+	}
+	if rawErr != nil {
+		if removeErr := os.Remove(path); removeErr != nil {
+			log.Debug().Err(removeErr).Str("path", path).Msg("failed to remove failed pack download")
+		}
+		return "", rawErr
+	}
+	return path, nil
+}
+
+// extractPackObjects slices each located object out of a downloaded,
+// hash-verified pack file into its content-addressed staging file,
+// re-verifying every slice's sha256.
+func extractPackObjects(packPath string, pack *remotePackObjects, staging *restoreStaging) error {
+	// #nosec G304 -- packPath is a temp file created inside the private staging directory.
+	packFile, err := os.Open(packPath)
+	if err != nil {
+		return fmt.Errorf("opening staged pack file: %w", err)
+	}
+	defer func() {
+		if closeErr := packFile.Close(); closeErr != nil {
+			log.Debug().Err(closeErr).Str("path", packPath).Msg("failed to close staged pack file")
+		}
+	}()
+	for i := range pack.Objects {
+		if err := extractPackObject(packFile, &pack.Objects[i], staging.path(pack.Objects[i].Hash)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractPackObject(packFile *os.File, ref *remotePackObjectRef, destination string) (err error) {
+	// #nosec G304 -- destination is a validated hash inside a private staging directory.
+	out, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("creating remote restore staging file: %w", err)
+	}
+	defer func() {
+		if closeErr := out.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("closing remote restore staging file: %w", closeErr))
+		}
+	}()
+
+	hasher := sha256.New()
+	section := io.NewSectionReader(packFile, ref.Offset, ref.Length)
+	written, copyErr := io.Copy(io.MultiWriter(out, hasher), section)
+	if copyErr != nil {
+		return fmt.Errorf("reading staged pack object: %w", copyErr)
+	}
+	if written != ref.Length {
+		return fmt.Errorf("staged pack object size mismatch: %s", ref.Hash)
+	}
+	if hex.EncodeToString(hasher.Sum(nil)) != ref.Hash {
+		return fmt.Errorf("staged pack object hash mismatch: %s", ref.Hash)
+	}
+	if syncErr := out.Sync(); syncErr != nil {
+		return fmt.Errorf("syncing remote restore staging file: %w", syncErr)
+	}
+	return nil
 }
 
 func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (result RemoteRunInfo, err error) {
@@ -607,7 +906,7 @@ func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (
 			"backup has too many entries: %d exceeds %d", len(files), maxArchiveEntries-1,
 		)
 	}
-	if _, sizeErr := validateLogicalSize(files, m.cfg.BackupMaxSizeBytes()); sizeErr != nil {
+	if _, sizeErr := sumLogicalSize(files); sizeErr != nil {
 		return RemoteRunInfo{}, sizeErr
 	}
 	files, unreadableWarnings, err := prepareSourceFiles(ctx, files, m.sourceOpener, m.pauser)
@@ -626,7 +925,7 @@ func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (
 		return RemoteRunInfo{}, err
 	}
 	missingSet := stringSet(missing)
-	uploaded, err := client.uploadMissing(ctx, files, missingSet, m.pauser)
+	uploaded, err := m.uploadMissingWithQuotaPreflight(ctx, client, files, missingSet)
 	if err != nil {
 		return RemoteRunInfo{}, err
 	}
@@ -665,7 +964,7 @@ func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (
 			return RemoteRunInfo{}, checkErr
 		}
 		repairSet := stringSet(repairMissing)
-		repair, repairErr := client.uploadMissing(ctx, files, repairSet, m.pauser)
+		repair, repairErr := m.uploadMissingWithQuotaPreflight(ctx, client, files, repairSet)
 		if repairErr != nil {
 			return RemoteRunInfo{}, repairErr
 		}
@@ -715,6 +1014,7 @@ func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (
 		UploadedBytes:     uploaded.bytesUploaded,
 		StorageUsedBytes:  list.StorageUsedBytes,
 		StorageQuotaBytes: list.StorageQuotaBytes,
+		NoChanges:         backup.Deduplicated,
 	}, nil
 }
 
@@ -770,6 +1070,10 @@ func (m *Manager) newRemoteClient() (*remoteClient, error) {
 		return nil, errRemoteUnlinked
 	}
 	bearer := entry.Bearer
+	retryWaits := defaultRateLimitWaits
+	if m.rateLimitWaits != nil {
+		retryWaits = *m.rateLimitWaits
+	}
 	return &remoteClient{
 		// Timeouts are applied per request (scaled to transfer size for
 		// uploads/downloads), not on the client, so a large pack on a slow
@@ -778,9 +1082,10 @@ func (m *Manager) newRemoteClient() (*remoteClient, error) {
 		onUnauthorized: func() {
 			m.markRemoteUnlinkedIfCurrent(bearer)
 		},
-		baseURL:  baseURL,
-		bearer:   bearer,
-		platform: m.pl.ID(),
+		baseURL:    baseURL,
+		bearer:     bearer,
+		platform:   m.pl.ID(),
+		retryWaits: retryWaits,
 	}, nil
 }
 
@@ -788,11 +1093,15 @@ func (m *Manager) newRemoteClient() (*remoteClient, error) {
 // given size: the base request timeout plus time for the bytes at a
 // deliberately pessimistic throughput floor.
 func remoteTransferTimeout(sizeBytes int64) time.Duration {
-	timeout := remoteRequestTimeout
-	if sizeBytes > 0 {
-		timeout += time.Duration(sizeBytes/remoteTransferBytesPerSec) * time.Second
+	if sizeBytes <= 0 {
+		return remoteRequestTimeout
 	}
-	return timeout
+	transferSeconds := sizeBytes / remoteTransferBytesPerSec
+	maxTransferSeconds := int64((time.Duration(math.MaxInt64) - remoteRequestTimeout) / time.Second)
+	if transferSeconds > maxTransferSeconds {
+		return time.Duration(math.MaxInt64)
+	}
+	return remoteRequestTimeout + time.Duration(transferSeconds)*time.Second
 }
 
 func (m *Manager) notifyRemoteFailure(err error) {
@@ -1087,6 +1396,9 @@ func (m *Manager) writeRemoteStatus(remote *statusEntry) error {
 	if remote.LastSuccessAt == "" {
 		remote.LastSuccessAt = st.Remote.LastSuccessAt
 	}
+	if remote.LastSnapshotCreatedAt == "" {
+		remote.LastSnapshotCreatedAt = st.Remote.LastSnapshotCreatedAt
+	}
 	if remote.Availability == "" {
 		remote.Availability = st.Remote.Availability
 	}
@@ -1202,9 +1514,10 @@ func (c *remoteClient) checkMissing(ctx context.Context, hashes []string) ([]str
 		}
 		var resp remoteCheckResponse
 		req := remoteCheckRequest{Hashes: hashes[start:end]}
-		if err := c.doJSON(
-			ctx, http.MethodPost, "/v1/device/backup-objects/check", &req, &resp,
-		); err != nil {
+		if err := c.retryRateLimited(ctx, func() error {
+			resp = remoteCheckResponse{}
+			return c.doJSON(ctx, http.MethodPost, "/v1/device/backup-objects/check", &req, &resp)
+		}); err != nil {
 			return nil, err
 		}
 		missing = append(missing, resp.Missing...)
@@ -1212,23 +1525,77 @@ func (c *remoteClient) checkMissing(ctx context.Context, hashes []string) ([]str
 	return missing, nil
 }
 
-// uploadResult summarizes one uploadMissing pass: how many packs and bytes
-// went over the wire, and which files were skipped as unstorable.
+func (c *remoteClient) backupStorageUsage(ctx context.Context) (used, quota int64, err error) {
+	var resp remoteListResponse
+	if err := c.retryRateLimited(ctx, func() error {
+		resp = remoteListResponse{}
+		return c.doJSONLimit(
+			ctx, http.MethodGet, "/v1/device/backups", nil, &resp, remoteManifestResponseLimit,
+		)
+	}); err != nil {
+		return 0, 0, err
+	}
+	if resp.StorageUsedBytes < 0 || resp.StorageQuotaBytes < 0 {
+		return 0, 0, errors.New("remote backup storage response contains negative bytes")
+	}
+	return resp.StorageUsedBytes, resp.StorageQuotaBytes, nil
+}
+
+func ensureRemoteUploadCapacity(used, quota, required int64) error {
+	if used < 0 || quota < 0 || required < 0 {
+		return errors.New("remote backup capacity values must be nonnegative")
+	}
+	if used > quota || required > quota-used {
+		return errRemoteQuotaExceeded
+	}
+	return nil
+}
+
+func (m *Manager) uploadMissingWithQuotaPreflight(
+	ctx context.Context,
+	client *remoteClient,
+	files []FileRef,
+	missing map[string]struct{},
+) (uploadResult, error) {
+	plan, err := planRemotePacks(files, missing)
+	if err != nil {
+		return uploadResult{}, err
+	}
+	if plan.uploadBytes > 0 {
+		used, quota, usageErr := client.backupStorageUsage(ctx)
+		if usageErr != nil {
+			return uploadResult{}, usageErr
+		}
+		if capacityErr := ensureRemoteUploadCapacity(used, quota, plan.uploadBytes); capacityErr != nil {
+			return uploadResult{}, capacityErr
+		}
+	}
+	return client.uploadPackPlan(ctx, &plan, m.pauser)
+}
+
+// uploadResult summarizes one upload pass: how many packs and bytes went
+// over the wire, and which files were skipped as unstorable.
 type uploadResult struct {
 	skipped       []FileRef
 	packs         int
 	bytesUploaded int64
 }
 
-func (c *remoteClient) uploadMissing(
-	ctx context.Context,
-	files []FileRef,
-	missing map[string]struct{},
-	pauser *syncutil.Pauser,
-) (uploadResult, error) {
-	var result uploadResult
+type plannedRemotePack struct {
+	files []FileRef
+	size  int64
+}
+
+type remotePackPlan struct {
+	packs       []plannedRemotePack
+	skipped     []FileRef
+	uploadBytes int64
+}
+
+func planRemotePacks(files []FileRef, missing map[string]struct{}) (remotePackPlan, error) {
+	var plan remotePackPlan
 	if len(missing) == 0 {
-		return result, nil
+		return plan, nil
 	}
 	candidates := make([]FileRef, 0, len(files))
 	for _, file := range files {
@@ -1237,8 +1604,6 @@ func (c *remoteClient) uploadMissing(
 		}
 		// Empty files are never packed: a zero-length range cannot live in
 		// a pack, and the server treats the empty object as always-present.
-		// (A current server never reports it missing; this also covers one
-		// that predates that rule.)
 		if file.Size == 0 || file.SHA256 == remoteEmptyContentSHA256 {
 			continue
 		}
@@ -1262,23 +1627,18 @@ func (c *remoteClient) uploadMissing(
 		if len(current) == 0 {
 			return nil
 		}
-		if waitErr := pauser.Wait(ctx); waitErr != nil {
-			return fmt.Errorf("uploading remote backup pack: %w", waitErr)
+		size, err := remotePackEncodedSize(current)
+		if err != nil {
+			return err
 		}
-		body, packHash, buildErr := buildRemotePack(ctx, current, pauser)
-		if buildErr != nil {
-			return buildErr
+		if size > remoteMaxPackBytes {
+			return fmt.Errorf("remote backup pack exceeds maximum size: %d bytes", size)
 		}
-		if len(body) > remoteMaxPackBytes {
-			return fmt.Errorf("remote backup pack exceeds maximum size: %d bytes", len(body))
+		if size > math.MaxInt64-plan.uploadBytes {
+			return errors.New("remote backup upload size overflow")
 		}
-		var resp remotePackResponse
-		uploadPath := "/v1/device/backup-packs/" + packHash
-		if uploadErr := c.doBytes(ctx, http.MethodPut, uploadPath, body, &resp); uploadErr != nil {
-			return uploadErr
-		}
-		result.packs++
-		result.bytesUploaded += int64(len(body))
+		plan.packs = append(plan.packs, plannedRemotePack{files: current, size: size})
+		plan.uploadBytes += size
 		current = nil
 		currentBytes = 0
 		return nil
@@ -1287,68 +1647,126 @@ func (c *remoteClient) uploadMissing(
 	for i := range unique {
 		file := &unique[i]
 		if remoteSingleFilePackExceedsMax(file) {
-			// There is no way to store a file that cannot fit inside one
-			// pack: skip it and let the caller drop it from the manifest.
 			log.Warn().Str("path", file.RestorePath).Int64("size", file.Size).
 				Msg("skipping file too large for remote backup")
-			result.skipped = append(result.skipped, *file)
+			plan.skipped = append(plan.skipped, *file)
 			continue
 		}
 		categoryChanged := len(current) > 0 && current[0].Category != file.Category
 		packFull := len(current) > 0 && currentBytes+file.Size > remotePackTargetBytes
 		if categoryChanged || packFull {
 			if err := flush(); err != nil {
-				return result, err
+				return plan, err
 			}
 		}
 		current = append(current, *file)
 		currentBytes += file.Size
 	}
 	if err := flush(); err != nil {
-		return result, err
+		return plan, err
 	}
-	result.skipped = expandSkippedFiles(files, result.skipped)
+	plan.skipped = expandSkippedFiles(files, plan.skipped)
+	return plan, nil
+}
+
+func (c *remoteClient) uploadPackPlan(
+	ctx context.Context,
+	plan *remotePackPlan,
+	pauser *syncutil.Pauser,
+) (uploadResult, error) {
+	result := uploadResult{skipped: plan.skipped}
+	for i := range plan.packs {
+		if waitErr := pauser.Wait(ctx); waitErr != nil {
+			return result, fmt.Errorf("uploading remote backup pack: %w", waitErr)
+		}
+		pack := &plan.packs[i]
+		body, packHash, buildErr := buildRemotePack(ctx, pack.files, pauser)
+		if buildErr != nil {
+			return result, buildErr
+		}
+		if int64(len(body)) != pack.size {
+			return result, errors.New("remote backup pack size changed after planning")
+		}
+		var resp remotePackResponse
+		uploadPath := "/v1/device/backup-packs/" + packHash
+		// PUT-by-content-hash is idempotent, so a rate-limited upload is
+		// safe to wait out and retry.
+		if uploadErr := c.retryRateLimited(ctx, func() error {
+			resp = remotePackResponse{}
+			return c.doBytes(ctx, http.MethodPut, uploadPath, body, &resp)
+		}); uploadErr != nil {
+			return result, uploadErr
+		}
+		result.packs++
+		result.bytesUploaded += int64(len(body))
+	}
 	return result, nil
 }
 
-func (c *remoteClient) downloadObject(
+func (c *remoteClient) uploadMissing(
 	ctx context.Context,
-	hash string,
-	wantSize int64,
-	destination string,
-) error {
-	ctx, cancel := context.WithTimeout(ctx, remoteTransferTimeout(wantSize))
-	defer cancel()
-	downloadPath := "/v1/device/backup-objects/" + hash
-	return c.doRaw(ctx, http.MethodGet, downloadPath, nil, "", func(resp *http.Response) (err error) {
-		// #nosec G304 -- destination is a validated hash inside a private staging directory.
-		out, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
-		if err != nil {
-			return fmt.Errorf("creating remote restore staging file: %w", err)
-		}
-		defer func() {
-			if closeErr := out.Close(); closeErr != nil {
-				err = errors.Join(err, fmt.Errorf("closing remote restore staging file: %w", closeErr))
-			}
-		}()
+	files []FileRef,
+	missing map[string]struct{},
+	pauser *syncutil.Pauser,
+) (uploadResult, error) {
+	plan, err := planRemotePacks(files, missing)
+	if err != nil {
+		return uploadResult{}, err
+	}
+	return c.uploadPackPlan(ctx, &plan, pauser)
+}
 
-		hasher := sha256.New()
-		limited := &io.LimitedReader{R: resp.Body, N: wantSize + 1}
-		written, copyErr := io.Copy(io.MultiWriter(out, hasher), limited)
-		if copyErr != nil {
-			return fmt.Errorf("reading remote backup object: %w", copyErr)
+// remoteRateLimitedError is a 429 from the backup server. retryAfter is the
+// server-requested wait (zero when the header is absent). errors.Is matches
+// the errRemoteRateLimited sentinel.
+type remoteRateLimitedError struct {
+	retryAfter time.Duration
+}
+
+func (*remoteRateLimitedError) Error() string { return errRemoteRateLimited.Error() }
+
+func (*remoteRateLimitedError) Is(target error) bool { return errors.Is(errRemoteRateLimited, target) }
+
+// rateLimitWaits bounds how long a rate-limited request waits before a
+// retry. Carried per client so tests can shrink the waits.
+type rateLimitWaits struct {
+	minWait     time.Duration
+	defaultWait time.Duration
+	maxWait     time.Duration
+}
+
+var defaultRateLimitWaits = rateLimitWaits{
+	minWait:     remoteRateLimitMinWait,
+	defaultWait: remoteRateLimitDefaultWait,
+	maxWait:     remoteRateLimitMaxWait,
+}
+
+// retryRateLimited runs op, waiting out and retrying rate-limited (429)
+// responses instead of failing the operation. The wait honors the server's
+// Retry-After when sent, clamped to the client's wait bounds; other errors
+// and context cancellation return immediately.
+func (c *remoteClient) retryRateLimited(ctx context.Context, op func() error) error {
+	for attempt := 1; ; attempt++ {
+		err := op()
+		var rateLimited *remoteRateLimitedError
+		if err == nil || !errors.As(err, &rateLimited) || attempt >= remoteRateLimitMaxAttempts {
+			return err
 		}
-		if written != wantSize {
-			return fmt.Errorf("remote backup object size mismatch: %s", hash)
+		wait := rateLimited.retryAfter
+		if wait <= 0 {
+			wait = c.retryWaits.defaultWait
 		}
-		if hex.EncodeToString(hasher.Sum(nil)) != hash {
-			return fmt.Errorf("remote backup object hash mismatch: %s", hash)
+		wait = min(max(wait, c.retryWaits.minWait), c.retryWaits.maxWait)
+		log.Info().Dur("wait", wait).Int("attempt", attempt).
+			Msg("remote backup server rate limited request, waiting to retry")
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("waiting out remote backup rate limit: %w", ctx.Err())
+		case <-timer.C:
 		}
-		if syncErr := out.Sync(); syncErr != nil {
-			return fmt.Errorf("syncing remote restore staging file: %w", syncErr)
-		}
-		return nil
-	})
+	}
 }
 
 func (c *remoteClient) doJSON(ctx context.Context, method, path string, body, out any) error {
@@ -1480,6 +1898,12 @@ func remoteStatusError(resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, helpers.MaxResponseBodySize))
 	var apiErr remoteAPIError
 	_ = json.Unmarshal(body, &apiErr)
+	// Route-level 429s carry a plain-text body with a Retry-After header;
+	// handler-level ones carry the JSON rate_limited code. Both surface as
+	// a typed error so callers can wait the request out and retry.
+	if resp.StatusCode == http.StatusTooManyRequests || apiErr.Error.Code == "rate_limited" {
+		return &remoteRateLimitedError{retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
+	}
 	switch apiErr.Error.Code {
 	case "not_available":
 		return errRemoteNotAvailable
@@ -1487,8 +1911,6 @@ func remoteStatusError(resp *http.Response) error {
 		return errRemoteQuotaExceeded
 	case "payload_too_large":
 		return errors.New("remote backup payload too large")
-	case "rate_limited":
-		return errRemoteRateLimited
 	case "missing_objects":
 		return errRemoteMissingObjects
 	case "backup_too_large":
@@ -1511,6 +1933,16 @@ func remoteStatusError(resp *http.Response) error {
 		msg = resp.Status
 	}
 	return fmt.Errorf("remote backup server returned status %d: %s", resp.StatusCode, msg)
+}
+
+// parseRetryAfter reads a Retry-After header's delay-seconds form; absent
+// or malformed values yield zero and the caller applies its default wait.
+func parseRetryAfter(raw string) time.Duration {
+	seconds, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || seconds < 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 func hashRemoteFiles(ctx context.Context, files []FileRef, pauser *syncutil.Pauser) ([]FileRef, error) {
@@ -1593,12 +2025,32 @@ func remoteCategoryRank(category string) int {
 }
 
 func remoteSingleFilePackExceedsMax(file *FileRef) bool {
-	footer := []packFooterEntry{{Hash: file.SHA256, Offset: 0, Length: file.Size}}
+	size, err := remotePackEncodedSize([]FileRef{*file})
+	return err != nil || size > remoteMaxPackBytes
+}
+
+func remotePackEncodedSize(files []FileRef) (int64, error) {
+	footer := make([]packFooterEntry, 0, len(files))
+	var payloadBytes int64
+	for i := range files {
+		file := &files[i]
+		if file.Size < 0 || file.Size > math.MaxInt64-payloadBytes {
+			return 0, errors.New("remote backup pack size overflow")
+		}
+		footer = append(footer, packFooterEntry{
+			Hash: file.SHA256, Offset: payloadBytes, Length: file.Size,
+		})
+		payloadBytes += file.Size
+	}
 	footerData, err := json.Marshal(footer)
 	if err != nil {
-		return true
+		return 0, fmt.Errorf("encoding remote backup pack footer: %w", err)
 	}
-	return file.Size+int64(len(footerData))+remotePackFooterTrailerSize > remoteMaxPackBytes
+	overhead := int64(len(footerData)) + remotePackFooterTrailerSize
+	if overhead > math.MaxInt64-payloadBytes {
+		return 0, errors.New("remote backup pack size overflow")
+	}
+	return payloadBytes + overhead, nil
 }
 
 func buildRemotePack(
@@ -1742,6 +2194,7 @@ func remoteBackupToInfo(resp *remoteBackupResponse) RemoteBackupInfo {
 		Categories:    resp.Categories,
 		Manifest:      resp.Manifest,
 		CreatedAt:     resp.CreatedAt,
+		VerifiedAt:    resp.VerifiedAt,
 		RestoredAt:    resp.RestoredAt,
 	}
 	if resp.SourceDevice != nil {
@@ -1765,7 +2218,14 @@ func validateCommittedRemoteBackup(
 	if err != nil {
 		return err
 	}
-	if resp.ID == "" || resp.BackupType != expectedType || resp.SchemaVersion != remoteSchemaVersion {
+	if resp.ID == "" || resp.SchemaVersion != remoteSchemaVersion {
+		return errors.New("remote backup commit response metadata mismatch")
+	}
+	// A deduplicated commit returns the existing snapshot, which may have
+	// been created by a run of a different type (e.g. a manual run whose
+	// content matches the scheduled snapshot). Manifest equality is what
+	// matters; only fresh commits must echo the requested type.
+	if !resp.Deduplicated && resp.BackupType != expectedType {
 		return errors.New("remote backup commit response metadata mismatch")
 	}
 	actualFiles := remoteManifestFiles(manifest)

--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -92,7 +92,6 @@ type restoreJournal struct {
 	CreatedDirs       []restoreJournalDir      `json:"createdDirs,omitempty"`
 	Version           int                      `json:"version"`
 	Sequence          int                      `json:"sequence"`
-	MaxLogicalSize    int64                    `json:"maxLogicalSize"`
 	UserDBRestoreUsed bool                     `json:"userDbRestoreUsed,omitempty"`
 	UserDBStarted     bool                     `json:"userDbStarted,omitempty"`
 }
@@ -180,7 +179,36 @@ func (m *Manager) RecoverRestore(ctx context.Context) error {
 		return err
 	}
 	defer lease.Release()
-	return m.recoverRestoreLocked(lease.Context())
+	if recoveryErr := m.recoverRestoreLocked(lease.Context()); recoveryErr != nil {
+		return recoveryErr
+	}
+	return m.cleanupStaleRestoreStaging()
+}
+
+func (m *Manager) cleanupStaleRestoreStaging() error {
+	entries, err := os.ReadDir(m.backupDir())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("listing stale restore staging directories: %w", err)
+	}
+	var cleanupErr error
+	for _, entry := range entries {
+		if !entry.IsDir() ||
+			(!strings.HasPrefix(entry.Name(), localRestoreStagingPrefix) &&
+				!strings.HasPrefix(entry.Name(), remoteRestoreStagingPrefix)) {
+			continue
+		}
+		stalePath := filepath.Join(m.backupDir(), entry.Name())
+		if removeErr := os.RemoveAll(stalePath); removeErr != nil {
+			cleanupErr = errors.Join(
+				cleanupErr,
+				fmt.Errorf("removing stale restore staging directory %s: %w", entry.Name(), removeErr),
+			)
+		}
+	}
+	return cleanupErr
 }
 
 func (m *Manager) recoverRestoreLocked(ctx context.Context) error {
@@ -293,10 +321,9 @@ func (m *Manager) prepareRestoreJournal(
 		return restoreJournal{}, err
 	}
 	journal = restoreJournal{
-		Version:        restoreJournalVersion,
-		OperationID:    operationID,
-		Phase:          restorePhasePrepared,
-		MaxLogicalSize: m.cfg.BackupMaxSizeBytes(),
+		Version:     restoreJournalVersion,
+		OperationID: operationID,
+		Phase:       restorePhasePrepared,
 	}
 
 	if hasUserDBRestore(manifest.Files) {
@@ -358,13 +385,13 @@ func (m *Manager) prepareRestoreJournal(
 		if entryErr := inspectRollbackEntry(&entry, len(journal.Entries)); entryErr != nil {
 			return restoreJournal{}, entryErr
 		}
-		if entry.RollbackSize > m.cfg.BackupMaxSizeBytes()-rollbackBytes {
-			return restoreJournal{}, errors.New("restore rollback exceeds backup size limit")
+		if entry.RollbackSize < 0 || entry.RollbackSize > math.MaxInt64-rollbackBytes {
+			return restoreJournal{}, errors.New("restore rollback size overflow")
 		}
 		rollbackBytes += entry.RollbackSize
 		journal.Entries = append(journal.Entries, entry)
-		if file.Size > m.cfg.BackupMaxSizeBytes()-targetBytes[target.root] {
-			return restoreJournal{}, errors.New("restore target data exceeds backup size limit")
+		if file.Size > math.MaxInt64-targetBytes[target.root] {
+			return restoreJournal{}, errors.New("restore target data size overflow")
 		}
 		targetBytes[target.root] += file.Size
 
@@ -836,12 +863,22 @@ func installPayloadAtTarget(
 	}
 	defer func() { _ = root.Remove(tmpRel) }()
 	hash := sha256.New()
-	limited := &io.LimitedReader{R: &contextReader{ctx: ctx, reader: payload}, N: file.Size + 1}
+	reader := &contextReader{ctx: ctx, reader: payload}
+	limited := &io.LimitedReader{R: reader, N: file.Size}
 	written, copyErr := io.Copy(io.MultiWriter(tmp, hash), limited)
+	var extra [1]byte
+	var extraSize int
+	var extraErr error
+	if copyErr == nil && written == file.Size {
+		extraSize, extraErr = reader.Read(extra[:])
+	}
 	syncErr := tmp.Sync()
 	closeErr := tmp.Close()
 	if copyErr != nil {
 		return fmt.Errorf("staging restore payload %s: %w", file.RestorePath, copyErr)
+	}
+	if extraErr != nil && !errors.Is(extraErr, io.EOF) {
+		return fmt.Errorf("checking restore payload size %s: %w", file.RestorePath, extraErr)
 	}
 	if syncErr != nil {
 		return fmt.Errorf("syncing restore payload %s: %w", file.RestorePath, syncErr)
@@ -849,7 +886,7 @@ func installPayloadAtTarget(
 	if closeErr != nil {
 		return fmt.Errorf("closing restore payload %s: %w", file.RestorePath, closeErr)
 	}
-	if written != file.Size {
+	if written != file.Size || extraSize != 0 {
 		return fmt.Errorf("restore payload size mismatch: %s", file.RestorePath)
 	}
 	if hex.EncodeToString(hash.Sum(nil)) != file.SHA256 {
@@ -1593,15 +1630,12 @@ func (m *Manager) validateRestoreJournal(journal *restoreJournal) error {
 	if err != nil || len(operationID) != 12 {
 		return errors.New("restore journal has invalid operation ID")
 	}
-	if journal.MaxLogicalSize <= 0 || journal.MaxLogicalSize == math.MaxInt64 {
-		return errors.New("restore journal has invalid logical size limit")
-	}
 	if len(journal.Entries) > maxArchiveEntries-1 {
 		return errors.New("restore journal has too many entries")
 	}
 	files := make([]FileRef, 0, len(journal.Entries)+1)
 	entryTargets := make(map[string][]string, len(journal.Entries))
-	var total int64
+	var total, rollbackTotal int64
 	for i := range journal.Entries {
 		entry := &journal.Entries[i]
 		if entry.State != restoreEntryPending && entry.State != restoreEntryStarted &&
@@ -1615,9 +1649,8 @@ func (m *Manager) validateRestoreJournal(journal *restoreJournal) error {
 			return errors.New("committed restore journal contains incomplete entry")
 		}
 		files = append(files, entry.File)
-		if journal.MaxLogicalSize <= 0 || entry.File.Size < 0 ||
-			entry.File.Size > journal.MaxLogicalSize-total {
-			return errors.New("restore journal exceeds backup size limit")
+		if entry.File.Size < 0 || entry.File.Size > math.MaxInt64-total {
+			return errors.New("restore journal payload size overflow")
 		}
 		total += entry.File.Size
 		hash, err := hex.DecodeString(entry.File.SHA256)
@@ -1628,9 +1661,11 @@ func (m *Manager) validateRestoreJournal(journal *restoreJournal) error {
 			expectedRollback := filepath.Join(restoreRollbackDir, fmt.Sprintf("%06d", i))
 			rollbackHash, hashErr := hex.DecodeString(entry.RollbackSHA256)
 			if entry.RollbackPath != expectedRollback || entry.RollbackSize < 0 ||
+				entry.RollbackSize > math.MaxInt64-rollbackTotal ||
 				hashErr != nil || len(rollbackHash) != sha256.Size {
 				return errors.New("restore journal has invalid rollback metadata")
 			}
+			rollbackTotal += entry.RollbackSize
 		} else if entry.RollbackPath != "" || entry.RollbackSHA256 != "" || entry.RollbackSize != 0 {
 			return errors.New("restore journal has rollback metadata for a new file")
 		}
@@ -1647,7 +1682,7 @@ func (m *Manager) validateRestoreJournal(journal *restoreJournal) error {
 		artifactHash, artifactHashErr := hex.DecodeString(artifact.SHA256)
 		if journal.UserDBFile == nil ||
 			artifact.Path != filepath.Join(restoreRollbackDir, restoreUserDBRollbackName) ||
-			artifact.Size < 0 || artifact.Size > journal.MaxLogicalSize ||
+			artifact.Size < 0 || artifact.Size > math.MaxInt64-rollbackTotal ||
 			artifactHashErr != nil || len(artifactHash) != sha256.Size {
 			return errors.New("restore journal has invalid user database rollback metadata")
 		}
@@ -1659,7 +1694,7 @@ func (m *Manager) validateRestoreJournal(journal *restoreJournal) error {
 		hash, hashErr := hex.DecodeString(journal.UserDBFile.SHA256)
 		if journal.UserDBFile.Category != CategoryZaparoo ||
 			journal.UserDBFile.RestorePath != "user.db" || journal.UserDBFile.Size < 0 ||
-			journal.UserDBFile.Size > journal.MaxLogicalSize-total ||
+			journal.UserDBFile.Size > math.MaxInt64-total ||
 			hashErr != nil || len(hash) != sha256.Size {
 			return errors.New("restore journal has invalid user database payload metadata")
 		}

--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -32,6 +32,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -1706,7 +1707,8 @@ func syncDirectory(path string) error {
 	}
 	syncErr := dir.Sync()
 	closeErr := dir.Close()
-	if syncErr != nil {
+	// Windows does not support flushing directory handles through os.File.Sync.
+	if syncErr != nil && (runtime.GOOS != "windows" || !errors.Is(syncErr, os.ErrPermission)) {
 		return fmt.Errorf("syncing directory: %w", syncErr)
 	}
 	if closeErr != nil {

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -261,11 +261,19 @@ func runScheduledRemoteBackup(
 		log.Info().Str("availability", availability).Msg("skipping scheduled remote backup")
 		return
 	}
-	if _, err := mgr.RunRemote(ctx, backupsvc.RemoteBackupTypeScheduled); err != nil {
+	info, err := mgr.RunRemote(ctx, backupsvc.RemoteBackupTypeScheduled)
+	if err != nil {
 		log.Warn().Err(err).Msg("scheduled remote backup failed")
 		return
 	}
-	log.Info().Msg("scheduled remote backup completed")
+	log.Info().
+		Int("uploadedFiles", info.UploadedFiles).
+		Int("dedupedFiles", info.DedupedFiles).
+		Int64("uploadedBytes", info.UploadedBytes).
+		Bool("noChanges", info.NoChanges).
+		Str("backupID", info.Backup.ID).
+		Time("snapshotCreatedAt", info.Backup.CreatedAt).
+		Msg("scheduled remote backup completed")
 }
 
 func remoteBackupDue(now time.Time, status *models.BackupStatusEntry, schedule string) bool {


### PR DESCRIPTION
## Summary

- restore remote backups through verified pack downloads instead of per-object requests
- retry rate-limited requests, preflight upload quota, and harden transfer size and hash validation
- distinguish deduplicated runs from newly created snapshots so status timestamps remain accurate
- retry Windows database replacement when transient sharing violations keep files locked

Ref #1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup status now reports when the stored snapshot last changed and whether the latest run detected no new changes.
  * Remote backup/restore now uses pack-based transfers for more efficient syncing.

* **Bug Fixes**
  * Restore flow is more robust with retryable database rename handling and improved cleanup of stale staging data.
  * ZIP/archive and restore payload validation more reliably detects invalid sizes/incomplete data.
  * Remote transfers now better handle server rate limits (including bounded retries) and integrity checks.

* **Configuration**
  * Removed the configurable local max backup size setting; added default values for remote base URL and schedule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->