### PR TITLE
feat(playtime): add opt-in online history sync

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2300,6 +2300,7 @@ None.
 | profilesRequireForLaunch  | boolean                                   | Yes      | Whether media launches are blocked while no personal profile is active. |
 | profilesSwapData          | boolean                                   | Yes      | Whether profile switches also swap profile-scoped data (saves, save states) on supported platforms. Defaults to true. |
 | backupRemoteEnabled       | boolean                                   | No       | Whether automatic remote backup scheduling is enabled. Only returned to localhost and paired admin clients. |
+| playtimeSyncEnabled       | boolean                                   | No       | Whether play history sync is enabled. Defaults to false. Only returned to localhost and paired admin clients. |
 | backupRemoteSchedule      | string                                    | No       | Remote backup schedule: `daily`, `weekly`, or `manual`. Only returned to localhost and paired admin clients. |
 | backupRemoteBaseUrl       | string                                    | No       | Configured backup remote server base URL (read-only). Only returned to localhost and paired admin clients. |
 
@@ -2385,6 +2386,7 @@ An object containing any of the following optional keys:
 | profilesRequireForLaunch  | boolean                                   | No       | Whether media launches are blocked while no personal profile is active. |
 | profilesSwapData          | boolean                                   | No       | Whether profile switches also swap profile-scoped data. Turning it off converges data back to the shared state immediately. |
 | backupRemoteEnabled       | boolean                                   | No       | Enable automatic remote backup scheduling. Requires a localhost or paired admin client. |
+| playtimeSyncEnabled       | boolean                                   | No       | Enable play history sync. Requires a localhost or paired admin client. |
 | backupRemoteSchedule      | string                                    | No       | Remote backup schedule: `daily`, `weekly`, or `manual`. Requires a localhost or paired admin client. |
 
 #### Result
@@ -2551,7 +2553,7 @@ An object:
 
 ### settings.auth.unlink
 
-Remove the device's Zaparoo Online credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured backup remote server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups. Removal is local only: the server has no revoke endpoint and invalidates the old token when the device links again.
+Remove the device's online account credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured backup remote server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups. Removal is local only: the server has no revoke endpoint and invalidates the old token when the device links again.
 
 Requires a localhost client or a paired admin client.
 

--- a/pkg/api/methods/auth.go
+++ b/pkg/api/methods/auth.go
@@ -112,7 +112,7 @@ func authStatusProbeAllowed(rawURL, configuredBackupURL string) bool {
 	return strings.EqualFold(parsed.Scheme, configured.Scheme) && strings.EqualFold(parsed.Host, configured.Host)
 }
 
-// HandleSettingsAuthUnlink removes the device's Zaparoo Online credentials
+// HandleSettingsAuthUnlink removes the device's online account credentials
 // and marks remote backup unlinked. The claim/link flow tags every entry it
 // creates with the root domain that created it (linked_via), so unlink
 // removes the configured backup server's entry plus everything tagged with

--- a/pkg/api/methods/auth_link.go
+++ b/pkg/api/methods/auth_link.go
@@ -47,7 +47,7 @@ import (
 
 // Reverse device link flow (RFC 8628 device-authorization style): the device
 // starts a link request, displays a user code / QR URL, and polls until the
-// user approves it in Zaparoo Online. On approval, the poll returns a claim
+// user approves it in the account service. On approval, the poll returns a claim
 // token that goes through the same redemption pipeline as the forward flow.
 
 const (

--- a/pkg/api/methods/media_user_data.go
+++ b/pkg/api/methods/media_user_data.go
@@ -20,9 +20,13 @@
 package methods
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
 )
 
 // setMediaUserFavorite records the favourite intent for a media path in UserDB,
@@ -33,6 +37,7 @@ func setMediaUserFavorite(env *requests.RequestEnv, systemID, path string, favor
 	if err := env.Database.UserDB.SetMediaUserFavorite(systemID, path, favorite); err != nil {
 		return fmt.Errorf("failed to set media user favorite: %w", err)
 	}
+	snapshotMediaUserIdentity(env, systemID, path)
 	return nil
 }
 
@@ -43,5 +48,23 @@ func setMediaUserLauncherOverride(env *requests.RequestEnv, systemID, path, laun
 	if err := env.Database.UserDB.SetMediaUserLauncherOverride(systemID, path, launcherID); err != nil {
 		return fmt.Errorf("failed to set media user launcher override: %w", err)
 	}
+	snapshotMediaUserIdentity(env, systemID, path)
 	return nil
+}
+
+// snapshotMediaUserIdentity best-effort captures the scanner's identity
+// (display name + disambiguating tags) onto the user-data row just written.
+// MediaDB is disposable, so this is the only durable record of what the path
+// identified when the user marked it. Failures are logged, never surfaced:
+// user intent was already recorded.
+func snapshotMediaUserIdentity(env *requests.RequestEnv, systemID, path string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	identity, found := database.LookupMediaIdentity(ctx, env.Database.MediaDB, systemID, path)
+	if !found {
+		return
+	}
+	if err := env.Database.UserDB.SetMediaUserSnapshot(systemID, path, identity.Name, identity.Tags); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("failed to store media user identity snapshot")
+	}
 }

--- a/pkg/api/methods/media_user_data.go
+++ b/pkg/api/methods/media_user_data.go
@@ -58,7 +58,7 @@ func setMediaUserLauncherOverride(env *requests.RequestEnv, systemID, path, laun
 // identified when the user marked it. Failures are logged, never surfaced:
 // user intent was already recorded.
 func snapshotMediaUserIdentity(env *requests.RequestEnv, systemID, path string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(env.Context, 2*time.Second)
 	defer cancel()
 	identity, found := database.LookupMediaIdentity(ctx, env.Database.MediaDB, systemID, path)
 	if !found {

--- a/pkg/api/methods/media_user_data_test.go
+++ b/pkg/api/methods/media_user_data_test.go
@@ -59,6 +59,10 @@ func TestMediaTagsUpdate_PersistsUserDBTruthWhenProjectionFails(t *testing.T) {
 
 	path := filepath.Join("roms", "NES", "Game.nes")
 	mockDB := testhelpers.NewMockMediaDBI()
+	// The identity snapshot after a user-data write is best-effort; an empty
+	// search result means no snapshot and is not part of what these tests prove.
+	mockDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, mock.Anything).
+		Return([]database.SearchResult{}, nil).Maybe()
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: favouriteRow(path)}, nil).Once()
 	mockDB.On("BeginTransaction", false).Return(errors.New("projection boom")).Once()
@@ -92,6 +96,10 @@ func TestMediaMetaUpdate_PersistsUserDBTruthWhenProjectionFails(t *testing.T) {
 
 	path := filepath.Join("roms", "NES", "Game.nes")
 	mockDB := testhelpers.NewMockMediaDBI()
+	// The identity snapshot after a user-data write is best-effort; an empty
+	// search result means no snapshot and is not part of what these tests prove.
+	mockDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, mock.Anything).
+		Return([]database.SearchResult{}, nil).Maybe()
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: favouriteRow(path)}, nil).Once()
 	mockDB.On("FindOrInsertTagType", database.TagType{

--- a/pkg/api/methods/media_user_data_test.go
+++ b/pkg/api/methods/media_user_data_test.go
@@ -47,6 +47,29 @@ func favouriteRow(path string) database.MediaFullRow {
 	}
 }
 
+func TestSnapshotMediaUserIdentityUsesRequestContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	path := filepath.Join("roms", "NES", "Game.nes")
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On(
+		"SearchMediaPathExact",
+		mock.MatchedBy(func(got context.Context) bool { return errors.Is(got.Err(), context.Canceled) }),
+		mock.Anything,
+		path,
+	).Return([]database.SearchResult(nil), context.Canceled).Once()
+	env := requests.RequestEnv{
+		Context:  ctx,
+		Database: &database.Database{MediaDB: mockDB},
+	}
+
+	snapshotMediaUserIdentity(&env, "NES", path)
+
+	mockDB.AssertExpectations(t)
+}
+
 // TestMediaTagsUpdate_PersistsUserDBTruthWhenProjectionFails proves the truth-first
 // ordering: the UserDB favourite is saved even though the media.db projection write
 // then fails, so the next reindex can re-materialize it.

--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -85,9 +85,11 @@ func HandleSettings(env requests.RequestEnv) (any, error) { //nolint:gocritic //
 		backupRemoteEnabled := env.Config.BackupRemoteEnabled()
 		backupRemoteSchedule := env.Config.BackupRemoteSchedule()
 		backupRemoteBaseURL := env.Config.BackupRemoteBaseURL()
+		playtimeSyncEnabled := env.Config.PlaytimeSyncEnabled()
 		resp.BackupRemoteEnabled = &backupRemoteEnabled
 		resp.BackupRemoteSchedule = &backupRemoteSchedule
 		resp.BackupRemoteBaseURL = &backupRemoteBaseURL
+		resp.PlaytimeSyncEnabled = &playtimeSyncEnabled
 	}
 
 	return resp, nil
@@ -149,9 +151,10 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 		}
 	}
 
-	if params.BackupRemoteEnabled != nil || params.BackupRemoteSchedule != nil {
+	if params.BackupRemoteEnabled != nil || params.BackupRemoteSchedule != nil ||
+		params.PlaytimeSyncEnabled != nil {
 		if !isLocalOrAdmin(&env) {
-			return nil, models.ClientErrf("backup settings require a local or admin client")
+			return nil, models.ClientErrf("online settings require a local or admin client")
 		}
 	}
 
@@ -226,6 +229,11 @@ func HandleSettingsUpdate(env requests.RequestEnv) (any, error) {
 	if params.BackupRemoteSchedule != nil {
 		log.Debug().Str("backupRemoteSchedule", *params.BackupRemoteSchedule).Msg("updating setting")
 		env.Config.SetBackupRemoteSchedule(*params.BackupRemoteSchedule)
+	}
+
+	if params.PlaytimeSyncEnabled != nil {
+		log.Debug().Bool("playtimeSyncEnabled", *params.PlaytimeSyncEnabled).Msg("updating setting")
+		env.Config.SetPlaytimeSync(*params.PlaytimeSyncEnabled)
 	}
 
 	if params.ReadersScanMode != nil {

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -615,9 +615,11 @@ func TestHandleSettingsUpdate_NonLocalBackupSettingsRejectBeforeMutation(t *test
 
 	debugLogging := true
 	backupRemoteEnabled := true
+	playtimeSyncEnabled := true
 	params := models.UpdateSettingsParams{
 		DebugLogging:        &debugLogging,
 		BackupRemoteEnabled: &backupRemoteEnabled,
+		PlaytimeSyncEnabled: &playtimeSyncEnabled,
 	}
 	paramsJSON, err := json.Marshal(params)
 	require.NoError(t, err)
@@ -633,21 +635,24 @@ func TestHandleSettingsUpdate_NonLocalBackupSettingsRejectBeforeMutation(t *test
 
 	_, err = HandleSettingsUpdate(env)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "backup settings require a local or admin client")
+	assert.Contains(t, err.Error(), "online settings require a local or admin client")
 	assert.False(t, cfg.DebugLogging(), "non-local rejection must happen before any mutation")
 	assert.False(t, cfg.BackupRemoteEnabled())
+	assert.False(t, cfg.PlaytimeSyncEnabled(), "consent setting must not change on rejected request")
 
 	// A remote member client is rejected the same way.
 	env.ClientRole = string(permissions.RoleMember)
 	_, err = HandleSettingsUpdate(env)
 	require.Error(t, err)
 	assert.False(t, cfg.BackupRemoteEnabled())
+	assert.False(t, cfg.PlaytimeSyncEnabled())
 
 	// A paired admin client is as privileged as a local connection.
 	env.ClientRole = string(permissions.RoleAdmin)
 	_, err = HandleSettingsUpdate(env)
 	require.NoError(t, err)
 	assert.True(t, cfg.BackupRemoteEnabled())
+	assert.True(t, cfg.PlaytimeSyncEnabled())
 }
 
 func TestHandleSettings_ReaderConnectionsEnabled(t *testing.T) {
@@ -1303,10 +1308,13 @@ func TestHandleSettings_BackupRemoteBaseURLGatedToLocal(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, resp.BackupRemoteBaseURL)
 	assert.Equal(t, config.DefaultBackupRemoteBaseURL, *resp.BackupRemoteBaseURL)
+	require.NotNil(t, resp.PlaytimeSyncEnabled)
+	assert.False(t, *resp.PlaytimeSyncEnabled)
 
 	result, err = HandleSettings(requests.RequestEnv{Config: cfg, State: appState, IsLocal: false})
 	require.NoError(t, err)
 	resp, ok = result.(models.SettingsResponse)
 	require.True(t, ok)
 	assert.Nil(t, resp.BackupRemoteBaseURL)
+	assert.Nil(t, resp.PlaytimeSyncEnabled)
 }

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -165,6 +165,7 @@ type UpdateSettingsParams struct {
 	ErrorReporting            *bool               `json:"errorReporting"`
 	Encryption                *bool               `json:"encryption"`
 	BackupRemoteEnabled       *bool               `json:"backupRemoteEnabled"`
+	PlaytimeSyncEnabled       *bool               `json:"playtimeSyncEnabled"`
 	UpdateChannel             *string             `json:"updateChannel" validate:"omitempty,oneof=stable beta"`
 	BackupRemoteSchedule      *string             `json:"backupRemoteSchedule" validate:"omitempty,oneof=daily weekly manual"`
 	ReadersScanMode           *string             `json:"readersScanMode" validate:"omitempty,oneof=tap hold"`

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -138,6 +138,7 @@ type BrowseIndexResults struct {
 
 type SettingsResponse struct {
 	BackupRemoteEnabled       *bool              `json:"backupRemoteEnabled,omitempty"`
+	PlaytimeSyncEnabled       *bool              `json:"playtimeSyncEnabled,omitempty"`
 	BackupRemoteSchedule      *string            `json:"backupRemoteSchedule,omitempty"`
 	BackupRemoteBaseURL       *string            `json:"backupRemoteBaseUrl,omitempty"`
 	UpdateChannel             string             `json:"updateChannel"`

--- a/pkg/config/configbackup.go
+++ b/pkg/config/configbackup.go
@@ -32,7 +32,7 @@ const (
 	DefaultBackupRemoteSchedule = "daily"
 )
 
-// OfficialAuthHosts are the hosts of the official Zaparoo Online API
+// OfficialAuthHosts are the hosts of the official hosted API
 // services. settings.auth.status only answers link probes for these hosts
 // (over HTTPS) and the configured backup server; other URLs report
 // linked=false without revealing whether a credential exists. The claim

--- a/pkg/config/configplaytime.go
+++ b/pkg/config/configplaytime.go
@@ -29,6 +29,7 @@ import (
 // Playtime configures play time tracking and limits.
 type Playtime struct {
 	Retention *int           `toml:"retention,omitempty"`
+	Sync      *bool          `toml:"sync,omitempty"`
 	Limits    PlaytimeLimits `toml:"limits,omitempty"`
 }
 
@@ -50,6 +51,22 @@ func (c *Instance) PlaytimeRetention() int {
 		return 365 // Default: keep 365 days (1 year) of play time history
 	}
 	return *c.vals.Playtime.Retention
+}
+
+// PlaytimeSyncEnabled reports whether the user explicitly consented to
+// upload play history to the linked online account. Unset defaults to false:
+// account linking alone never grants play-history upload consent.
+func (c *Instance) PlaytimeSyncEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.vals.Playtime.Sync != nil && *c.vals.Playtime.Sync
+}
+
+// SetPlaytimeSync enables or disables play-history sync.
+func (c *Instance) SetPlaytimeSync(enabled bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Playtime.Sync = &enabled
 }
 
 // PlaytimeLimitsEnabled returns true if play time limits are enabled.

--- a/pkg/config/configplaytime_test.go
+++ b/pkg/config/configplaytime_test.go
@@ -27,6 +27,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPlaytimeSyncEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sync *bool
+		name string
+		want bool
+	}{
+		{name: "unset defaults disabled", sync: nil, want: false},
+		{name: "explicitly disabled", sync: boolPtr(false), want: false},
+		{name: "explicitly enabled", sync: boolPtr(true), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			inst := &Instance{vals: Values{Playtime: Playtime{Sync: tt.sync}}}
+			assert.Equal(t, tt.want, inst.PlaytimeSyncEnabled())
+		})
+	}
+}
+
 func TestPlaytimeLimitsEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -83,6 +83,7 @@ type MediaHistoryEntry struct {
 	SystemName     string     `json:"systemName"`
 	MediaPath      string     `json:"mediaPath"`
 	MediaName      string     `json:"mediaName"`
+	Tags           []string   `json:"tags,omitempty"`
 	DBID           int64      `db:"DBID" json:"id"`
 	WallDuration   int        `json:"wallDuration"`
 	DurationSec    int        `json:"durationSec"`
@@ -91,6 +92,13 @@ type MediaHistoryEntry struct {
 	TimeSkewFlag   bool       `json:"timeSkewFlag"`
 	ClockReliable  bool       `json:"clockReliable"`
 	IsDeleted      bool       `json:"isDeleted,omitempty"`
+}
+
+// MediaHistorySyncRef identifies the exact local version acknowledged by a
+// play-history upload. UpdatedAt is a monotonic per-row version watermark.
+type MediaHistorySyncRef struct {
+	UpdatedAt time.Time
+	DBID      int64
 }
 
 type MediaHistoryTopEntry struct {
@@ -211,10 +219,16 @@ type MediaUserData struct {
 	SystemID         string
 	Path             string
 	LauncherOverride string
-	DBID             int64
-	CreatedAt        int64
-	UpdatedAt        int64
-	IsFavorite       bool
+	// MediaName and Tags snapshot the scanner's identity for this path at
+	// write time (display name + disambiguating type:value tags), so the
+	// row stays matchable to a canonical game after MediaDB is rebuilt or
+	// the file disappears. Empty when no scanner entry existed.
+	MediaName  string
+	Tags       []string
+	DBID       int64
+	CreatedAt  int64
+	UpdatedAt  int64
+	IsFavorite bool
 }
 
 // MediaPathID identifies a Media row by its system ID and path, used for batch
@@ -793,7 +807,11 @@ type UserDBI interface {
 	GetLatestMediaHistory() (MediaHistoryEntry, bool, error)
 	GetMediaHistoryTop(systemIDs []string, since *time.Time, limit int) ([]MediaHistoryTopEntry, error)
 	CloseHangingMediaHistory() error
-	CleanupMediaHistory(retentionDays int) (int64, error)
+	CleanupMediaHistory(retentionDays int, requireSynced bool) (int64, error)
+	BackfillMediaHistoryUUIDs() (int64, error)
+	ResetMediaHistorySyncAfter(watermark *time.Time) error
+	GetMediaHistorySyncBatch(after time.Time, afterDBID int64, limit int) ([]MediaHistoryEntry, error)
+	MarkMediaHistorySynced(refs []MediaHistorySyncRef, syncedAt time.Time) error
 	HealTimestamps(bootUUID string, trueBootTime time.Time) (int64, error)
 	SumMediaPlayTimeForDay(dayStart time.Time) (int64, error)
 	SumMediaPlayTimeForDayByProfile(dayStart time.Time, profileID string) (int64, error)
@@ -806,6 +824,7 @@ type UserDBI interface {
 	GetMediaUserData(systemID, path string) (MediaUserData, bool, error)
 	SetMediaUserFavorite(systemID, path string, favorite bool) error
 	SetMediaUserLauncherOverride(systemID, path, launcherID string) error
+	SetMediaUserSnapshot(systemID, path, mediaName string, tags []string) error
 	UpsertMediaUserData(data *MediaUserData) error
 	DeleteMediaUserData(systemID, path string) error
 	ListMediaUserData() ([]MediaUserData, error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -802,7 +802,7 @@ type UserDBI interface {
 	CleanupHistory(retentionDays int) (int64, error)
 	AddMediaHistory(entry *MediaHistoryEntry) (int64, error)
 	UpdateMediaHistoryTime(dbid int64, playTime int) error
-	UpdateMediaHistoryTags(dbid int64, tags []string) error
+	UpdateMediaHistoryIdentity(dbid int64, identity MediaIdentity) error
 	CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error
 	GetMediaHistory(systemIDs []string, lastID int64, limit int) ([]MediaHistoryEntry, error)
 	GetLatestMediaHistory() (MediaHistoryEntry, bool, error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -802,6 +802,7 @@ type UserDBI interface {
 	CleanupHistory(retentionDays int) (int64, error)
 	AddMediaHistory(entry *MediaHistoryEntry) (int64, error)
 	UpdateMediaHistoryTime(dbid int64, playTime int) error
+	UpdateMediaHistoryTags(dbid int64, tags []string) error
 	CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error
 	GetMediaHistory(systemIDs []string, lastID int64, limit int) ([]MediaHistoryEntry, error)
 	GetLatestMediaHistory() (MediaHistoryEntry, bool, error)

--- a/pkg/database/media_identity.go
+++ b/pkg/database/media_identity.go
@@ -1,0 +1,109 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	mediatags "github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/rs/zerolog/log"
+)
+
+// Media identity snapshots: the scanner's parsed filename tags (typed
+// "type:value" pairs like "region:us") are captured onto durable userdb rows
+// (MediaHistory, MediaUserData) at record time, because MediaDB is
+// disposable and re-deriving tags later means re-parsing filenames outside
+// the scanner. Tags are stored as a JSON string array; the empty string
+// means no snapshot was possible.
+
+// EncodeTagStrings serializes tags for a userdb TEXT column. Nil or empty
+// input encodes to the empty string.
+func EncodeTagStrings(tags []string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(tags)
+	if err != nil {
+		// A []string cannot fail to marshal; guard anyway.
+		log.Warn().Err(err).Msg("failed to encode media tags")
+		return ""
+	}
+	return string(encoded)
+}
+
+// DecodeTagStrings parses a userdb tags column value. Empty or malformed
+// input decodes to nil (a snapshot is best-effort data, never a hard error).
+func DecodeTagStrings(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(raw), &tags); err != nil {
+		log.Warn().Err(err).Msg("failed to decode media tags")
+		return nil
+	}
+	return tags
+}
+
+// MediaIdentity is the scanner-derived identity snapshot for a media path.
+type MediaIdentity struct {
+	Name string
+	Tags []string
+}
+
+// LookupMediaIdentity resolves a media path to its scanner identity: the
+// indexed display name and the disambiguating "type:value" tags. The bool
+// reports a complete successful lookup, including a valid zero-tag result.
+// A media item launched outside the index has no snapshot; lookup failures
+// log at debug and return false so callers preserve any earlier snapshot.
+func LookupMediaIdentity(
+	ctx context.Context, mediaDB MediaDBI, systemID, path string,
+) (MediaIdentity, bool) {
+	if mediaDB == nil || path == "" {
+		return MediaIdentity{}, false
+	}
+	var systems []systemdefs.System
+	if system, err := systemdefs.GetSystem(systemID); err == nil {
+		systems = []systemdefs.System{*system}
+	}
+	results, err := mediaDB.SearchMediaPathExact(ctx, systems, path)
+	if err != nil || len(results) == 0 {
+		log.Debug().Err(err).Str("path", path).Msg("no media identity for path")
+		return MediaIdentity{}, false
+	}
+	identity := MediaIdentity{Name: results[0].Name}
+	tagInfos, err := mediaDB.GetMediaTagsByMediaDBID(ctx, results[0].MediaID)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).Msg("failed to load media tags for identity")
+		return MediaIdentity{}, false
+	}
+	tags := make([]string, 0, len(tagInfos))
+	for i := range tagInfos {
+		if tagInfos[i].Type == "" || tagInfos[i].Tag == "" ||
+			mediatags.IsUserOwnedType(mediatags.TagType(tagInfos[i].Type)) {
+			continue
+		}
+		tags = append(tags, tagInfos[i].Type+":"+tagInfos[i].Tag)
+	}
+	identity.Tags = tags
+	return identity, true
+}

--- a/pkg/database/media_identity_test.go
+++ b/pkg/database/media_identity_test.go
@@ -1,0 +1,86 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLookupMediaIdentity_ExcludesUserOwnedTags(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("games", "snes", "Game.sfc")
+	mediaDB := testhelpers.NewMockMediaDBI()
+	mediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, path).
+		Return([]database.SearchResult{{
+			SystemID: systemdefs.SystemSNES,
+			Name:     "Game",
+			Path:     path,
+			MediaID:  42,
+		}}, nil).Once()
+	mediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(42)).
+		Return([]database.TagInfo{
+			{Type: "extension", Tag: "sfc"},
+			{Type: "region", Tag: "us"},
+			{Type: "user", Tag: "favorite"},
+		}, nil).Once()
+
+	identity, found := database.LookupMediaIdentity(
+		context.Background(), mediaDB, systemdefs.SystemSNES, path,
+	)
+
+	assert.True(t, found)
+	assert.Equal(t, "Game", identity.Name)
+	assert.Equal(t, []string{"extension:sfc", "region:us"}, identity.Tags)
+	mediaDB.AssertExpectations(t)
+}
+
+func TestLookupMediaIdentity_ReportsSuccessfulEmptyTags(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("games", "snes", "Untagged.sfc")
+	mediaDB := testhelpers.NewMockMediaDBI()
+	mediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, path).
+		Return([]database.SearchResult{{
+			SystemID: systemdefs.SystemSNES,
+			Name:     "Untagged",
+			Path:     path,
+			MediaID:  43,
+		}}, nil).Once()
+	mediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(43)).
+		Return([]database.TagInfo{}, nil).Once()
+
+	identity, found := database.LookupMediaIdentity(
+		context.Background(), mediaDB, systemdefs.SystemSNES, path,
+	)
+
+	assert.True(t, found)
+	assert.Equal(t, "Untagged", identity.Name)
+	assert.Empty(t, identity.Tags)
+	mediaDB.AssertExpectations(t)
+}

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -48,6 +48,14 @@ func (db *UserDB) UpdateMediaHistoryTime(dbid int64, playTime int) error {
 	return sqlUpdateMediaHistoryTime(db.ctx, db.sql.Load(), dbid, playTime)
 }
 
+// UpdateMediaHistoryTags stores the scanner-derived identity tags for a history entry.
+func (db *UserDB) UpdateMediaHistoryTags(dbid int64, tags []string) error {
+	if db.sql.Load() == nil {
+		return ErrNullSQL
+	}
+	return sqlUpdateMediaHistoryTags(db.ctx, db.sql.Load(), dbid, tags)
+}
+
 // CloseMediaHistory finalizes a media history entry with end time and final play time.
 func (db *UserDB) CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error {
 	if db.sql.Load() == nil {
@@ -220,6 +228,18 @@ func sqlUpdateMediaHistoryTime(ctx context.Context, db *sql.DB, dbid int64, play
 	return nil
 }
 
+func sqlUpdateMediaHistoryTags(ctx context.Context, db *sql.DB, dbid int64, tags []string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE MediaHistory
+		SET Tags = ?, UpdatedAt = MAX(?, UpdatedAt + 1), SyncedAt = NULL
+		WHERE DBID = ?;
+	`, database.EncodeTagStrings(tags), time.Now().Unix(), dbid)
+	if err != nil {
+		return fmt.Errorf("failed to execute media history tags update: %w", err)
+	}
+	return nil
+}
+
 func sqlCloseMediaHistory(ctx context.Context, db *sql.DB, dbid int64, endTime time.Time, playTime int) error {
 	stmt, err := db.PrepareContext(ctx, `
 		UPDATE MediaHistory
@@ -296,7 +316,7 @@ func sqlGetMediaHistory(
 			DBID, ID, StartTime, EndTime, SystemID, SystemName,
 			MediaPath, MediaName, LauncherID, PlayTime,
 			BootUUID, MonotonicStart, DurationSec, WallDuration, TimeSkewFlag,
-			ClockReliable, ClockSource, CreatedAt, UpdatedAt, DeviceID, ProfileID
+			ClockReliable, ClockSource, CreatedAt, UpdatedAt, DeviceID, ProfileID, Tags
 		FROM MediaHistory
 		WHERE %s
 		ORDER BY DBID DESC
@@ -330,6 +350,7 @@ func sqlGetMediaHistory(
 		var createdAtUnix, updatedAtUnix int64
 		var id, clockSource sql.NullString
 		var deviceID, rowProfileID sql.NullString
+		var rawTags string
 
 		err = rows.Scan(
 			&entry.DBID,
@@ -353,6 +374,7 @@ func sqlGetMediaHistory(
 			&updatedAtUnix,
 			&deviceID,
 			&rowProfileID,
+			&rawTags,
 		)
 		if err != nil {
 			return list, fmt.Errorf("failed to scan media history row: %w", err)
@@ -372,6 +394,7 @@ func sqlGetMediaHistory(
 			profileStr := rowProfileID.String
 			entry.ProfileID = &profileStr
 		}
+		entry.Tags = database.DecodeTagStrings(rawTags)
 
 		entry.StartTime = time.Unix(startTimeUnix, 0)
 		if endTimeUnix.Valid {

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -93,11 +93,12 @@ func (db *UserDB) CloseHangingMediaHistory() error {
 }
 
 // CleanupMediaHistory removes media history older than the retention period.
-func (db *UserDB) CleanupMediaHistory(retentionDays int) (int64, error) {
+// When requireSynced is true, only server-acknowledged versions are removed.
+func (db *UserDB) CleanupMediaHistory(retentionDays int, requireSynced bool) (int64, error) {
 	if db.sql.Load() == nil {
 		return 0, ErrNullSQL
 	}
-	return sqlCleanupMediaHistory(db.ctx, db.sql.Load(), retentionDays)
+	return sqlCleanupMediaHistory(db.ctx, db.sql.Load(), retentionDays, requireSynced)
 }
 
 // HealTimestamps corrects timestamps for records created with unreliable clocks (MiSTer boot without NTP).
@@ -141,8 +142,8 @@ func sqlAddMediaHistory(ctx context.Context, db *sql.DB, entry *database.MediaHi
 		INSERT INTO MediaHistory(
 			ID, StartTime, SystemID, SystemName, MediaPath, MediaName, LauncherID, PlayTime,
 			BootUUID, MonotonicStart, DurationSec, WallDuration, TimeSkewFlag,
-			ClockReliable, ClockSource, CreatedAt, UpdatedAt, DeviceID, ProfileID
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+			ClockReliable, ClockSource, CreatedAt, UpdatedAt, DeviceID, ProfileID, Tags
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to prepare media history insert statement: %w", err)
@@ -182,6 +183,7 @@ func sqlAddMediaHistory(ctx context.Context, db *sql.DB, entry *database.MediaHi
 		entry.UpdatedAt.Unix(),
 		deviceID,
 		profileID,
+		database.EncodeTagStrings(entry.Tags),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to execute media history insert: %w", err)
@@ -198,7 +200,7 @@ func sqlAddMediaHistory(ctx context.Context, db *sql.DB, entry *database.MediaHi
 func sqlUpdateMediaHistoryTime(ctx context.Context, db *sql.DB, dbid int64, playTime int) error {
 	stmt, err := db.PrepareContext(ctx, `
 		UPDATE MediaHistory
-		SET PlayTime = ?, DurationSec = ?, UpdatedAt = ?
+		SET PlayTime = ?, DurationSec = ?, UpdatedAt = MAX(?, UpdatedAt + 1), SyncedAt = NULL
 		WHERE DBID = ?;
 	`)
 	if err != nil {
@@ -221,8 +223,8 @@ func sqlUpdateMediaHistoryTime(ctx context.Context, db *sql.DB, dbid int64, play
 func sqlCloseMediaHistory(ctx context.Context, db *sql.DB, dbid int64, endTime time.Time, playTime int) error {
 	stmt, err := db.PrepareContext(ctx, `
 		UPDATE MediaHistory
-		SET EndTime = ?, PlayTime = ?, DurationSec = ?, UpdatedAt = ?,
-		    WallDuration = (? - StartTime)
+		SET EndTime = ?, PlayTime = ?, DurationSec = ?, UpdatedAt = MAX(?, UpdatedAt + 1),
+		    WallDuration = (? - StartTime), SyncedAt = NULL
 		WHERE DBID = ?;
 	`)
 	if err != nil {
@@ -234,7 +236,9 @@ func sqlCloseMediaHistory(ctx context.Context, db *sql.DB, dbid int64, endTime t
 		}
 	}()
 
-	// Use endTime as UpdatedAt: both represent the moment the session ended.
+	// Use endTime as the wall-clock candidate. SQL advances UpdatedAt by at
+	// least one second so concurrent sync acknowledgements can compare exact
+	// local versions even when two changes happen in the same second.
 	endUnix := endTime.Unix()
 	_, err = stmt.ExecContext(ctx, endUnix, playTime, playTime, endUnix, endUnix, dbid)
 	if err != nil {
@@ -439,7 +443,8 @@ func sqlCloseHangingMediaHistory(ctx context.Context, db *sql.DB) error {
 		SET EndTime = StartTime + PlayTime,
 		    DurationSec = PlayTime,
 		    WallDuration = PlayTime,
-		    UpdatedAt = unixepoch()
+		    UpdatedAt = MAX(unixepoch(), UpdatedAt + 1),
+		    SyncedAt = NULL
 		WHERE EndTime IS NULL;
 	`)
 	if err != nil {
@@ -464,10 +469,16 @@ func sqlCloseHangingMediaHistory(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func sqlCleanupMediaHistory(ctx context.Context, db *sql.DB, retentionDays int) (int64, error) {
+func sqlCleanupMediaHistory(
+	ctx context.Context, db *sql.DB, retentionDays int, requireSynced bool,
+) (int64, error) {
 	cutoffTime := time.Now().AddDate(0, 0, -retentionDays).Unix()
 
-	stmt, err := db.PrepareContext(ctx, `DELETE FROM MediaHistory WHERE StartTime < ?;`)
+	query := `DELETE FROM MediaHistory WHERE StartTime < ?;`
+	if requireSynced {
+		query = `DELETE FROM MediaHistory WHERE StartTime < ? AND SyncedAt IS NOT NULL;`
+	}
+	stmt, err := db.PrepareContext(ctx, query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to prepare media history cleanup statement: %w", err)
 	}
@@ -547,7 +558,8 @@ func sqlHealTimestamps(ctx context.Context, db *sql.DB, bootUUID string, trueBoo
 		    END,
 		    ClockReliable = 1,
 		    ClockSource = 'healed',
-		    UpdatedAt = unixepoch()
+		    UpdatedAt = MAX(unixepoch(), UpdatedAt + 1),
+		    SyncedAt = NULL
 		WHERE BootUUID = ? AND ClockReliable = 0 AND MonotonicStart > 0;
 	`)
 	if err != nil {

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -48,12 +48,12 @@ func (db *UserDB) UpdateMediaHistoryTime(dbid int64, playTime int) error {
 	return sqlUpdateMediaHistoryTime(db.ctx, db.sql.Load(), dbid, playTime)
 }
 
-// UpdateMediaHistoryTags stores the scanner-derived identity tags for a history entry.
-func (db *UserDB) UpdateMediaHistoryTags(dbid int64, tags []string) error {
+// UpdateMediaHistoryIdentity stores the scanner-derived name and tags for a history entry.
+func (db *UserDB) UpdateMediaHistoryIdentity(dbid int64, identity database.MediaIdentity) error {
 	if db.sql.Load() == nil {
 		return ErrNullSQL
 	}
-	return sqlUpdateMediaHistoryTags(db.ctx, db.sql.Load(), dbid, tags)
+	return sqlUpdateMediaHistoryIdentity(db.ctx, db.sql.Load(), dbid, identity)
 }
 
 // CloseMediaHistory finalizes a media history entry with end time and final play time.
@@ -228,14 +228,16 @@ func sqlUpdateMediaHistoryTime(ctx context.Context, db *sql.DB, dbid int64, play
 	return nil
 }
 
-func sqlUpdateMediaHistoryTags(ctx context.Context, db *sql.DB, dbid int64, tags []string) error {
+func sqlUpdateMediaHistoryIdentity(
+	ctx context.Context, db *sql.DB, dbid int64, identity database.MediaIdentity,
+) error {
 	_, err := db.ExecContext(ctx, `
 		UPDATE MediaHistory
-		SET Tags = ?, UpdatedAt = MAX(?, UpdatedAt + 1), SyncedAt = NULL
+		SET MediaName = ?, Tags = ?, UpdatedAt = MAX(?, UpdatedAt + 1), SyncedAt = NULL
 		WHERE DBID = ?;
-	`, database.EncodeTagStrings(tags), time.Now().Unix(), dbid)
+	`, identity.Name, database.EncodeTagStrings(identity.Tags), time.Now().Unix(), dbid)
 	if err != nil {
-		return fmt.Errorf("failed to execute media history tags update: %w", err)
+		return fmt.Errorf("failed to execute media history identity update: %w", err)
 	}
 	return nil
 }

--- a/pkg/database/userdb/media_history_property_test.go
+++ b/pkg/database/userdb/media_history_property_test.go
@@ -237,7 +237,8 @@ func TestPropertyGetMediaHistoryLimitClamping(t *testing.T) {
 			MediaPath TEXT, MediaName TEXT, LauncherID TEXT, PlayTime INTEGER,
 			BootUUID TEXT, MonotonicStart INTEGER, DurationSec INTEGER, WallDuration INTEGER,
 			TimeSkewFlag INTEGER, ClockReliable INTEGER, ClockSource TEXT,
-			CreatedAt INTEGER, UpdatedAt INTEGER, DeviceID TEXT, ProfileID TEXT
+			CreatedAt INTEGER, UpdatedAt INTEGER, DeviceID TEXT, ProfileID TEXT,
+			Tags TEXT NOT NULL DEFAULT ''
 		)
 	`)
 	require.NoError(t, err)
@@ -274,7 +275,8 @@ func TestPropertyGetMediaHistoryLastIDPagination(t *testing.T) {
 			MediaPath TEXT, MediaName TEXT, LauncherID TEXT, PlayTime INTEGER,
 			BootUUID TEXT, MonotonicStart INTEGER, DurationSec INTEGER, WallDuration INTEGER,
 			TimeSkewFlag INTEGER, ClockReliable INTEGER, ClockSource TEXT,
-			CreatedAt INTEGER, UpdatedAt INTEGER, DeviceID TEXT, ProfileID TEXT
+			CreatedAt INTEGER, UpdatedAt INTEGER, DeviceID TEXT, ProfileID TEXT,
+			Tags TEXT NOT NULL DEFAULT ''
 		)
 	`)
 	require.NoError(t, err)

--- a/pkg/database/userdb/media_history_sync.go
+++ b/pkg/database/userdb/media_history_sync.go
@@ -1,0 +1,308 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// Play-history sync support: MediaHistory rows are uploaded to the Zaparoo
+// API keyed by their session UUID, cursored on (UpdatedAt, DBID) so healed
+// timestamps, play-time updates, close-outs, and tombstones re-sync
+// naturally. SyncedAt records acknowledgement of an exact local version;
+// the server-side timestamp watermark is the cross-install resume cursor.
+
+// One synced-at argument plus two arguments per exact-version reference must
+// stay within SQLite's common 999-variable limit.
+const mediaHistorySyncMarkChunkSize = 499
+
+// BackfillMediaHistoryUUIDs assigns stable session UUIDs to legacy
+// MediaHistory rows written before UUIDs existed. Existing timestamps remain
+// unchanged.
+func (db *UserDB) BackfillMediaHistoryUUIDs() (int64, error) {
+	return sqlBackfillMediaHistoryUUIDs(db.ctx, db.sql.Load())
+}
+
+// ResetMediaHistorySyncAfter clears local acknowledgements newer than the
+// server watermark so restored or reset server state is uploaded again. A nil
+// watermark means the server has no sessions and resets every local row.
+func (db *UserDB) ResetMediaHistorySyncAfter(watermark *time.Time) error {
+	return sqlResetMediaHistorySyncAfter(db.ctx, db.sql.Load(), watermark)
+}
+
+// GetMediaHistorySyncBatch returns unsynced rows after the local
+// (after, afterDBID) cursor in (UpdatedAt, DBID) order. Mutations clear
+// SyncedAt, so acknowledged rows do not repeat and unreliable-clock rows
+// remain eligible regardless of the server's timestamp watermark. Rows
+// without a session UUID are excluded; startup backfills legacy rows first.
+func (db *UserDB) GetMediaHistorySyncBatch(
+	after time.Time, afterDBID int64, limit int,
+) ([]database.MediaHistoryEntry, error) {
+	return sqlGetMediaHistorySyncBatch(db.ctx, db.sql.Load(), after, afterDBID, limit)
+}
+
+// MarkMediaHistorySynced stamps SyncedAt only when each row still matches the
+// uploaded version. Concurrent mutations advance UpdatedAt and remain unsynced.
+func (db *UserDB) MarkMediaHistorySynced(refs []database.MediaHistorySyncRef, syncedAt time.Time) error {
+	return sqlMarkMediaHistorySynced(db.ctx, db.sql.Load(), refs, syncedAt)
+}
+
+func sqlBackfillMediaHistoryUUIDs(ctx context.Context, db *sql.DB) (backfilled int64, err error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin media history UUID backfill transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	dbids, err := func() (ids []int64, resultErr error) {
+		rows, queryErr := tx.QueryContext(ctx, `
+			SELECT DBID FROM MediaHistory WHERE ID IS NULL OR ID = '';
+		`)
+		if queryErr != nil {
+			return nil, fmt.Errorf("failed to query media history rows missing UUIDs: %w", queryErr)
+		}
+		defer func() {
+			if closeErr := rows.Close(); closeErr != nil && resultErr == nil {
+				resultErr = fmt.Errorf("failed to close media history UUID backfill rows: %w", closeErr)
+			}
+		}()
+
+		for rows.Next() {
+			var dbid int64
+			if scanErr := rows.Scan(&dbid); scanErr != nil {
+				return nil, fmt.Errorf("failed to scan media history DBID: %w", scanErr)
+			}
+			ids = append(ids, dbid)
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			return nil, fmt.Errorf("error iterating media history rows missing UUIDs: %w", rowsErr)
+		}
+		return ids, nil
+	}()
+	if err != nil {
+		return 0, err
+	}
+
+	if len(dbids) > 0 {
+		backfilled, err = func() (count int64, resultErr error) {
+			stmt, prepareErr := tx.PrepareContext(ctx, `
+				UPDATE MediaHistory SET ID = ? WHERE DBID = ? AND (ID IS NULL OR ID = '');
+			`)
+			if prepareErr != nil {
+				return 0, fmt.Errorf("failed to prepare media history UUID backfill statement: %w", prepareErr)
+			}
+			defer func() {
+				if closeErr := stmt.Close(); closeErr != nil && resultErr == nil {
+					resultErr = fmt.Errorf("failed to close media history UUID backfill statement: %w", closeErr)
+				}
+			}()
+
+			for _, dbid := range dbids {
+				result, execErr := stmt.ExecContext(ctx, uuid.New().String(), dbid)
+				if execErr != nil {
+					return 0, fmt.Errorf("failed to backfill media history UUID: %w", execErr)
+				}
+				affected, rowsErr := result.RowsAffected()
+				if rowsErr != nil {
+					return 0, fmt.Errorf("failed to count backfilled media history UUIDs: %w", rowsErr)
+				}
+				count += affected
+			}
+			return count, nil
+		}()
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if commitErr := tx.Commit(); commitErr != nil {
+		return 0, fmt.Errorf("failed to commit media history UUID backfill: %w", commitErr)
+	}
+	return backfilled, nil
+}
+
+func sqlResetMediaHistorySyncAfter(ctx context.Context, db *sql.DB, watermark *time.Time) error {
+	query := `UPDATE MediaHistory SET SyncedAt = NULL;`
+	var args []any
+	if watermark != nil {
+		query = `UPDATE MediaHistory SET SyncedAt = NULL WHERE UpdatedAt > ?;`
+		args = append(args, watermark.Unix())
+	}
+	if _, err := db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to reset media history sync state: %w", err)
+	}
+	return nil
+}
+
+func sqlGetMediaHistorySyncBatch(
+	ctx context.Context, db *sql.DB, after time.Time, afterDBID int64, limit int,
+) ([]database.MediaHistoryEntry, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	stmt, err := db.PrepareContext(ctx, `
+		SELECT
+			DBID, ID, StartTime, EndTime, SystemID, SystemName,
+			MediaPath, MediaName, LauncherID, PlayTime,
+			BootUUID, MonotonicStart, DurationSec, WallDuration, TimeSkewFlag,
+			ClockReliable, ClockSource, CreatedAt, UpdatedAt, DeviceID, ProfileID,
+			COALESCE(IsDeleted, 0), SyncedAt, Tags
+		FROM MediaHistory
+		WHERE SyncedAt IS NULL
+		  AND (UpdatedAt > ? OR (UpdatedAt = ? AND DBID > ?))
+		  AND ID IS NOT NULL AND ID != ''
+		ORDER BY UpdatedAt ASC, DBID ASC
+		LIMIT ?;
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare media history sync batch statement: %w", err)
+	}
+	defer func() {
+		if closeErr := stmt.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close sql statement")
+		}
+	}()
+
+	afterUnix := after.Unix()
+	rows, err := stmt.QueryContext(ctx, afterUnix, afterUnix, afterDBID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query media history sync batch: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	list := make([]database.MediaHistoryEntry, 0, limit)
+	for rows.Next() {
+		var entry database.MediaHistoryEntry
+		var startTimeUnix int64
+		var endTimeUnix sql.NullInt64
+		var createdAtUnix, updatedAtUnix int64
+		var id, clockSource sql.NullString
+		var deviceID, rowProfileID sql.NullString
+		var isDeleted int64
+		var syncedAtUnix sql.NullInt64
+		var rawTags string
+
+		err = rows.Scan(
+			&entry.DBID,
+			&id,
+			&startTimeUnix,
+			&endTimeUnix,
+			&entry.SystemID,
+			&entry.SystemName,
+			&entry.MediaPath,
+			&entry.MediaName,
+			&entry.LauncherID,
+			&entry.PlayTime,
+			&entry.BootUUID,
+			&entry.MonotonicStart,
+			&entry.DurationSec,
+			&entry.WallDuration,
+			&entry.TimeSkewFlag,
+			&entry.ClockReliable,
+			&clockSource,
+			&createdAtUnix,
+			&updatedAtUnix,
+			&deviceID,
+			&rowProfileID,
+			&isDeleted,
+			&syncedAtUnix,
+			&rawTags,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan media history sync row: %w", err)
+		}
+
+		if id.Valid {
+			entry.ID = id.String
+		}
+		if clockSource.Valid {
+			entry.ClockSource = clockSource.String
+		}
+		if deviceID.Valid {
+			deviceStr := deviceID.String
+			entry.DeviceID = &deviceStr
+		}
+		if rowProfileID.Valid {
+			profileStr := rowProfileID.String
+			entry.ProfileID = &profileStr
+		}
+		entry.StartTime = time.Unix(startTimeUnix, 0)
+		if endTimeUnix.Valid {
+			endTime := time.Unix(endTimeUnix.Int64, 0)
+			entry.EndTime = &endTime
+		}
+		entry.CreatedAt = time.Unix(createdAtUnix, 0)
+		entry.UpdatedAt = time.Unix(updatedAtUnix, 0)
+		entry.IsDeleted = isDeleted != 0
+		if syncedAtUnix.Valid {
+			syncedAt := time.Unix(syncedAtUnix.Int64, 0)
+			entry.SyncedAt = &syncedAt
+		}
+		entry.Tags = database.DecodeTagStrings(rawTags)
+
+		list = append(list, entry)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating media history sync rows: %w", err)
+	}
+	return list, nil
+}
+
+func sqlMarkMediaHistorySynced(
+	ctx context.Context, db *sql.DB, refs []database.MediaHistorySyncRef, syncedAt time.Time,
+) error {
+	for start := 0; start < len(refs); start += mediaHistorySyncMarkChunkSize {
+		end := min(start+mediaHistorySyncMarkChunkSize, len(refs))
+		chunk := refs[start:end]
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, 1+(len(chunk)*2))
+		args = append(args, syncedAt.Unix())
+		for i := range chunk {
+			placeholders[i] = "(?, ?)"
+			args = append(args, chunk[i].DBID, chunk[i].UpdatedAt.Unix())
+		}
+		//nolint:gosec // placeholders are hardcoded "?" markers, not user input
+		query := fmt.Sprintf(
+			`UPDATE MediaHistory SET SyncedAt = ? WHERE (DBID, UpdatedAt) IN (%s);`,
+			strings.Join(placeholders, ", "),
+		)
+		if _, err := db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to mark media history synced: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/database/userdb/media_history_sync_integration_test.go
+++ b/pkg/database/userdb/media_history_sync_integration_test.go
@@ -1,0 +1,241 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// addSyncTestEntry inserts one closed session with the given UUID (may be
+// empty to simulate legacy rows) and UpdatedAt.
+func addSyncTestEntry(t *testing.T, db *UserDB, id, mediaName string, updatedAt time.Time) int64 {
+	t.Helper()
+	startTime := updatedAt.Add(-30 * time.Minute)
+	endTime := updatedAt
+	dbid, err := db.AddMediaHistory(&database.MediaHistoryEntry{
+		ID:            id,
+		StartTime:     startTime,
+		SystemID:      "snes",
+		SystemName:    "Super Nintendo",
+		MediaPath:     "/games/" + mediaName + ".sfc",
+		MediaName:     mediaName,
+		LauncherID:    "test",
+		PlayTime:      1800,
+		BootUUID:      "boot-1",
+		ClockReliable: true,
+		ClockSource:   "system",
+		Tags:          []string{"region:us", "rev:1"},
+		CreatedAt:     startTime,
+		UpdatedAt:     updatedAt.Add(-time.Second),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.CloseMediaHistory(dbid, endTime, 1800))
+	return dbid
+}
+
+func TestBackfillMediaHistoryUUIDs_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	base := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	legacyID := addSyncTestEntry(t, userDB, "", "Legacy Game", base)
+	addSyncTestEntry(t, userDB, "11111111-1111-4111-8111-111111111111", "Modern Game", base.Add(time.Hour))
+
+	backfilled, err := userDB.BackfillMediaHistoryUUIDs()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), backfilled, "only the legacy row needs a UUID")
+
+	// Idempotent
+	backfilled, err = userDB.BackfillMediaHistoryUUIDs()
+	require.NoError(t, err)
+	assert.Zero(t, backfilled)
+
+	// The legacy row now appears in sync batches with a UUID
+	batch, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 2)
+	for _, entry := range batch {
+		assert.NotEmpty(t, entry.ID)
+		if entry.DBID == legacyID {
+			assert.NotEmpty(t, entry.ID)
+		}
+	}
+}
+
+func TestGetMediaHistorySyncBatch_CursorWalk_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	base := time.Now().Add(-48 * time.Hour).Truncate(time.Second)
+	addSyncTestEntry(t, userDB, "11111111-1111-4111-8111-111111111111", "Game A", base)
+	addSyncTestEntry(t, userDB, "22222222-2222-4222-8222-222222222222", "Game B", base.Add(time.Hour))
+	// Same UpdatedAt as Game B: DBID breaks the tie
+	addSyncTestEntry(t, userDB, "33333333-3333-4333-8333-333333333333", "Game C", base.Add(time.Hour))
+	// A row without a UUID never syncs
+	addSyncTestEntry(t, userDB, "", "No UUID", base.Add(2*time.Hour))
+
+	// Full walk from zero, one row at a time, ordered (UpdatedAt, DBID)
+	var seen []string
+	cursor, cursorDBID := time.Time{}, int64(0)
+	for {
+		batch, err := userDB.GetMediaHistorySyncBatch(cursor, cursorDBID, 1)
+		require.NoError(t, err)
+		if len(batch) == 0 {
+			break
+		}
+		seen = append(seen, batch[0].MediaName)
+		cursor = batch[0].UpdatedAt
+		cursorDBID = batch[0].DBID
+	}
+	assert.Equal(t, []string{"Game A", "Game B", "Game C"}, seen)
+
+	// Resuming from a mid-tie cursor returns only rows after it
+	batch, err := userDB.GetMediaHistorySyncBatch(base.Add(time.Hour), 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 2, "both rows sharing the cursor timestamp re-send")
+	assert.Equal(t, "Game B", batch[0].MediaName)
+	assert.Equal(t, "Game C", batch[1].MediaName)
+	assert.Equal(t, []string{"region:us", "rev:1"}, batch[0].Tags,
+		"snapshotted tags round-trip through the sync batch")
+}
+
+func TestSyncedWatermarkRows_RequeueOnlyAfterMutation_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	updatedAt := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	dbid := addSyncTestEntry(
+		t, userDB, "11111111-1111-4111-8111-111111111111", "Game A", updatedAt,
+	)
+	ref := database.MediaHistorySyncRef{DBID: dbid, UpdatedAt: updatedAt}
+	require.NoError(t, userDB.MarkMediaHistorySynced(
+		[]database.MediaHistorySyncRef{ref}, time.Now().Truncate(time.Second),
+	))
+
+	batch, err := userDB.GetMediaHistorySyncBatch(updatedAt, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, batch, "acknowledged rows at the server watermark must not repeat")
+
+	// A same-second update advances UpdatedAt and clears SyncedAt. A stale
+	// acknowledgement arriving afterward must not mark the newer version.
+	require.NoError(t, userDB.CloseMediaHistory(dbid, updatedAt, 1900))
+	require.NoError(t, userDB.MarkMediaHistorySynced(
+		[]database.MediaHistorySyncRef{ref}, time.Now().Truncate(time.Second),
+	))
+	batch, err = userDB.GetMediaHistorySyncBatch(updatedAt, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, dbid, batch[0].DBID)
+	assert.Equal(t, 1900, batch[0].PlayTime)
+	assert.True(t, batch[0].UpdatedAt.After(updatedAt))
+	assert.Nil(t, batch[0].SyncedAt)
+}
+
+func TestGetMediaHistorySyncBatch_IncludesUnsyncedBeforeServerWatermark_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	unreliableTime := time.Unix(60, 0)
+	dbid := addSyncTestEntry(
+		t, userDB, "11111111-1111-4111-8111-111111111111", "Epoch Game", unreliableTime,
+	)
+	serverWatermark := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, userDB.ResetMediaHistorySyncAfter(&serverWatermark))
+
+	batch, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, dbid, batch[0].DBID)
+	assert.True(t, batch[0].UpdatedAt.Before(serverWatermark))
+}
+
+func TestResetMediaHistorySyncAfter_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	base := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	dbidA := addSyncTestEntry(t, userDB, "11111111-1111-4111-8111-111111111111", "Game A", base)
+	dbidB := addSyncTestEntry(
+		t, userDB, "22222222-2222-4222-8222-222222222222", "Game B", base.Add(time.Hour),
+	)
+	refs := []database.MediaHistorySyncRef{
+		{DBID: dbidA, UpdatedAt: base},
+		{DBID: dbidB, UpdatedAt: base.Add(time.Hour)},
+	}
+	require.NoError(t, userDB.MarkMediaHistorySynced(refs, time.Now().Truncate(time.Second)))
+
+	watermark := base
+	require.NoError(t, userDB.ResetMediaHistorySyncAfter(&watermark))
+	batch, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, dbidB, batch[0].DBID, "rows newer than server state must requeue")
+
+	require.NoError(t, userDB.ResetMediaHistorySyncAfter(nil))
+	batch, err = userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 2, "nil server watermark must requeue every local row")
+}
+
+func TestMarkMediaHistorySynced_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	base := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	dbidA := addSyncTestEntry(t, userDB, "11111111-1111-4111-8111-111111111111", "Game A", base)
+	addSyncTestEntry(t, userDB, "22222222-2222-4222-8222-222222222222", "Game B", base.Add(time.Hour))
+
+	// No-op on empty input
+	require.NoError(t, userDB.MarkMediaHistorySynced(nil, time.Now()))
+
+	syncedAt := time.Now().Truncate(time.Second)
+	require.NoError(t, userDB.MarkMediaHistorySynced([]database.MediaHistorySyncRef{
+		{DBID: dbidA, UpdatedAt: base},
+	}, syncedAt))
+
+	batch, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Equal(t, "Game B", batch[0].MediaName)
+	assert.NotEqual(t, dbidA, batch[0].DBID, "acknowledged exact version must be excluded")
+}

--- a/pkg/database/userdb/media_history_sync_test.go
+++ b/pkg/database/userdb/media_history_sync_test.go
@@ -1,0 +1,54 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package userdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLMarkMediaHistorySynced_ChunksFullUploadBatch(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	updatedAt := time.Now().Truncate(time.Second)
+	refs := make([]database.MediaHistorySyncRef, 500)
+	for i := range refs {
+		refs[i] = database.MediaHistorySyncRef{DBID: int64(i + 1), UpdatedAt: updatedAt}
+	}
+
+	mock.ExpectExec(`UPDATE MediaHistory SET SyncedAt.*WHERE \(DBID, UpdatedAt\) IN`).
+		WillReturnResult(sqlmock.NewResult(0, mediaHistorySyncMarkChunkSize))
+	mock.ExpectExec(`UPDATE MediaHistory SET SyncedAt.*WHERE \(DBID, UpdatedAt\) IN`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = sqlMarkMediaHistorySynced(t.Context(), db, refs, updatedAt.Add(time.Second))
+	require.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -84,6 +84,7 @@ func TestSqlAddMediaHistory_Success(t *testing.T) {
 			entry.UpdatedAt.Unix(),
 			nil,
 			nil,
+			database.EncodeTagStrings(entry.Tags),
 		).
 		WillReturnResult(sqlmock.NewResult(expectedDBID, 1))
 
@@ -142,6 +143,7 @@ func TestSqlAddMediaHistory_DatabaseError(t *testing.T) {
 			entry.UpdatedAt.Unix(),
 			nil,
 			nil,
+			database.EncodeTagStrings(entry.Tags),
 		).
 		WillReturnError(sqlmock.ErrCancelled)
 
@@ -629,7 +631,27 @@ func TestSqlCleanupMediaHistory_Success(t *testing.T) {
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, rowsDeleted))
 
-	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays)
+	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays, false)
+	require.NoError(t, err)
+	assert.Equal(t, rowsDeleted, rowsAffected)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlCleanupMediaHistory_RequiresSyncedRows(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	retentionDays := 365
+	rowsDeleted := int64(4)
+
+	mock.ExpectPrepare(`DELETE FROM MediaHistory WHERE StartTime.*SyncedAt IS NOT NULL`).
+		ExpectExec().
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, rowsDeleted))
+
+	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays, true)
 	require.NoError(t, err)
 	assert.Equal(t, rowsDeleted, rowsAffected)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -648,7 +670,7 @@ func TestSqlCleanupMediaHistory_NoRowsToDelete(t *testing.T) {
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 
-	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays)
+	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays, false)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), rowsAffected)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -667,7 +689,7 @@ func TestSqlCleanupMediaHistory_DeleteError(t *testing.T) {
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnError(sqlmock.ErrCancelled)
 
-	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays)
+	rowsAffected, err := sqlCleanupMediaHistory(context.Background(), db, retentionDays, false)
 	require.Error(t, err)
 	assert.Equal(t, int64(0), rowsAffected)
 	assert.Contains(t, err.Error(), "failed to execute media history cleanup")

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -193,6 +193,45 @@ func TestSqlUpdateMediaHistoryTime_DatabaseError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlUpdateMediaHistoryTags(t *testing.T) {
+	t.Parallel()
+
+	tags := []string{"region:us", "year:1990"}
+	tests := []struct {
+		execErr error
+		name    string
+	}{
+		{name: "success"},
+		{name: "database error", execErr: sqlmock.ErrCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db, mockDB, err := testsqlmock.NewSQLMock()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			expectation := mockDB.ExpectExec(`UPDATE MediaHistory SET Tags`).
+				WithArgs(database.EncodeTagStrings(tags), sqlmock.AnyArg(), int64(42))
+			if tt.execErr != nil {
+				expectation.WillReturnError(tt.execErr)
+			} else {
+				expectation.WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+
+			err = sqlUpdateMediaHistoryTags(context.Background(), db, 42, tags)
+			if tt.execErr != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to execute media history tags update")
+			} else {
+				require.NoError(t, err)
+			}
+			assert.NoError(t, mockDB.ExpectationsWereMet())
+		})
+	}
+}
+
 func TestSqlCloseMediaHistory_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -250,19 +289,19 @@ func TestSqlGetMediaHistory_Success(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "nes", "Nintendo Entertainment System",
 			"/games/mario.nes", "Super Mario Bros.", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, `["region:us"]`,
 		).
 		AddRow(
 			int64(2), "uuid-2", startTime, endTime, "snes", "Super Nintendo",
 			"/games/zelda.sfc", "The Legend of Zelda", "retroarch", 7200,
 			"boot-1", int64(2000), 7200, 7200, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, "",
 		)
 
 	mock.ExpectPrepare(`SELECT.*FROM MediaHistory.*ORDER BY DBID DESC LIMIT`).
@@ -276,6 +315,7 @@ func TestSqlGetMediaHistory_Success(t *testing.T) {
 	assert.Equal(t, int64(1), entries[0].DBID)
 	assert.Equal(t, "Super Mario Bros.", entries[0].MediaName)
 	assert.Equal(t, 3600, entries[0].PlayTime)
+	assert.Equal(t, []string{"region:us"}, entries[0].Tags)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -292,7 +332,7 @@ func TestSqlGetMediaHistory_EmptyResult(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	})
 
 	mock.ExpectPrepare(`SELECT.*FROM MediaHistory.*ORDER BY DBID DESC LIMIT`).
@@ -406,7 +446,7 @@ func TestSqlGetMediaHistory_SentinelUsesMaxInt64(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	})
 
 	// Verify that lastID=0 uses math.MaxInt64 as sentinel, not the old MaxInt32
@@ -435,12 +475,12 @@ func TestSqlGetMediaHistory_LargeLastID(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).AddRow(
 		int64(math.MaxInt32)+50, "uuid-1", time.Now().Unix(), nil, "nes", "NES",
 		"/games/mario.nes", "Mario", "retroarch", 100,
 		"boot-1", int64(1000), 100, 100, false,
-		true, "system", time.Now().Unix(), time.Now().Unix(), nil, nil,
+		true, "system", time.Now().Unix(), time.Now().Unix(), nil, nil, "",
 	)
 
 	mock.ExpectPrepare(`SELECT.*FROM MediaHistory.*ORDER BY DBID DESC LIMIT`).
@@ -469,13 +509,13 @@ func TestSqlGetMediaHistory_SingleSystemFilter(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "SNES", "Super Nintendo",
 			"/games/zelda.sfc", "The Legend of Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, `["region:jp"]`,
 		)
 
 	mock.ExpectPrepare(`SELECT.*FROM MediaHistory.*WHERE DBID < \? AND SystemID = \?.*ORDER BY DBID DESC LIMIT`).
@@ -487,6 +527,7 @@ func TestSqlGetMediaHistory_SingleSystemFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
 	assert.Equal(t, "SNES", entries[0].SystemID)
+	assert.Equal(t, []string{"region:jp"}, entries[0].Tags)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -504,19 +545,19 @@ func TestSqlGetMediaHistory_MultipleSystemIDs(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).
 		AddRow(
 			int64(2), "uuid-2", startTime, endTime, "SNES", "Super Nintendo",
 			"/games/zelda.sfc", "Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, "",
 		).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "NES", "NES",
 			"/games/mario.nes", "Mario", "retroarch", 1800,
 			"boot-1", int64(2000), 1800, 1800, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, "",
 		)
 
 	mock.ExpectPrepare(
@@ -548,13 +589,13 @@ func TestSqlGetMediaHistory_SystemFilterWithPagination(t *testing.T) {
 		"DBID", "ID", "StartTime", "EndTime", "SystemID", "SystemName",
 		"MediaPath", "MediaName", "LauncherID", "PlayTime",
 		"BootUUID", "MonotonicStart", "DurationSec", "WallDuration", "TimeSkewFlag",
-		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID",
+		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).
 		AddRow(
 			int64(8), "uuid-8", startTime, endTime, "SNES", "Super Nintendo",
 			"/games/zelda.sfc", "Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
-			true, "system", startTime, startTime, nil, nil,
+			true, "system", startTime, startTime, nil, nil, "",
 		)
 
 	// lastID=10 + SystemID filter — both conditions in WHERE clause

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -193,10 +193,13 @@ func TestSqlUpdateMediaHistoryTime_DatabaseError(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSqlUpdateMediaHistoryTags(t *testing.T) {
+func TestSqlUpdateMediaHistoryIdentity(t *testing.T) {
 	t.Parallel()
 
-	tags := []string{"region:us", "year:1990"}
+	identity := database.MediaIdentity{
+		Name: "Indexed Name",
+		Tags: []string{"region:us", "year:1990"},
+	}
 	tests := []struct {
 		execErr error
 		name    string
@@ -212,18 +215,20 @@ func TestSqlUpdateMediaHistoryTags(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = db.Close() }()
 
-			expectation := mockDB.ExpectExec(`UPDATE MediaHistory SET Tags`).
-				WithArgs(database.EncodeTagStrings(tags), sqlmock.AnyArg(), int64(42))
+			expectation := mockDB.ExpectExec(
+				`UPDATE MediaHistory SET MediaName = \?, Tags = \?, `+
+					`UpdatedAt = MAX\(\?, UpdatedAt \+ 1\), SyncedAt = NULL WHERE DBID = \?;`,
+			).WithArgs(identity.Name, database.EncodeTagStrings(identity.Tags), sqlmock.AnyArg(), int64(42))
 			if tt.execErr != nil {
 				expectation.WillReturnError(tt.execErr)
 			} else {
 				expectation.WillReturnResult(sqlmock.NewResult(0, 1))
 			}
 
-			err = sqlUpdateMediaHistoryTags(context.Background(), db, 42, tags)
+			err = sqlUpdateMediaHistoryIdentity(context.Background(), db, 42, identity)
 			if tt.execErr != nil {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), "failed to execute media history tags update")
+				assert.Contains(t, err.Error(), "failed to execute media history identity update")
 			} else {
 				require.NoError(t, err)
 			}
@@ -293,13 +298,15 @@ func TestSqlGetMediaHistory_Success(t *testing.T) {
 	}).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "nes", "Nintendo Entertainment System",
-			"/games/mario.nes", "Super Mario Bros.", "retroarch", 3600,
+			filepath.Join(string(filepath.Separator), "games", "mario.nes"),
+			"Super Mario Bros.", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
 			true, "system", startTime, startTime, nil, nil, `["region:us"]`,
 		).
 		AddRow(
 			int64(2), "uuid-2", startTime, endTime, "snes", "Super Nintendo",
-			"/games/zelda.sfc", "The Legend of Zelda", "retroarch", 7200,
+			filepath.Join(string(filepath.Separator), "games", "zelda.sfc"),
+			"The Legend of Zelda", "retroarch", 7200,
 			"boot-1", int64(2000), 7200, 7200, false,
 			true, "system", startTime, startTime, nil, nil, "",
 		)
@@ -478,7 +485,7 @@ func TestSqlGetMediaHistory_LargeLastID(t *testing.T) {
 		"ClockReliable", "ClockSource", "CreatedAt", "UpdatedAt", "DeviceID", "ProfileID", "Tags",
 	}).AddRow(
 		int64(math.MaxInt32)+50, "uuid-1", time.Now().Unix(), nil, "nes", "NES",
-		"/games/mario.nes", "Mario", "retroarch", 100,
+		filepath.Join(string(filepath.Separator), "games", "mario.nes"), "Mario", "retroarch", 100,
 		"boot-1", int64(1000), 100, 100, false,
 		true, "system", time.Now().Unix(), time.Now().Unix(), nil, nil, "",
 	)
@@ -513,7 +520,8 @@ func TestSqlGetMediaHistory_SingleSystemFilter(t *testing.T) {
 	}).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "SNES", "Super Nintendo",
-			"/games/zelda.sfc", "The Legend of Zelda", "retroarch", 3600,
+			filepath.Join(string(filepath.Separator), "games", "zelda.sfc"),
+			"The Legend of Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
 			true, "system", startTime, startTime, nil, nil, `["region:jp"]`,
 		)
@@ -549,13 +557,13 @@ func TestSqlGetMediaHistory_MultipleSystemIDs(t *testing.T) {
 	}).
 		AddRow(
 			int64(2), "uuid-2", startTime, endTime, "SNES", "Super Nintendo",
-			"/games/zelda.sfc", "Zelda", "retroarch", 3600,
+			filepath.Join(string(filepath.Separator), "games", "zelda.sfc"), "Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
 			true, "system", startTime, startTime, nil, nil, "",
 		).
 		AddRow(
 			int64(1), "uuid-1", startTime, endTime, "NES", "NES",
-			"/games/mario.nes", "Mario", "retroarch", 1800,
+			filepath.Join(string(filepath.Separator), "games", "mario.nes"), "Mario", "retroarch", 1800,
 			"boot-1", int64(2000), 1800, 1800, false,
 			true, "system", startTime, startTime, nil, nil, "",
 		)
@@ -593,7 +601,7 @@ func TestSqlGetMediaHistory_SystemFilterWithPagination(t *testing.T) {
 	}).
 		AddRow(
 			int64(8), "uuid-8", startTime, endTime, "SNES", "Super Nintendo",
-			"/games/zelda.sfc", "Zelda", "retroarch", 3600,
+			filepath.Join(string(filepath.Separator), "games", "zelda.sfc"), "Zelda", "retroarch", 3600,
 			"boot-1", int64(1000), 3600, 3600, false,
 			true, "system", startTime, startTime, nil, nil, "",
 		)
@@ -751,9 +759,11 @@ func TestSqlGetMediaHistoryTop_MultipleSessionsAggregated(t *testing.T) {
 		"SystemName", "MediaPath",
 	}).
 		AddRow("SNES", "Super Mario World", 7200, 12, now.Unix(),
-			"Super Nintendo Entertainment System", "/games/snes/smw.sfc").
+			"Super Nintendo Entertainment System",
+			filepath.Join(string(filepath.Separator), "games", "snes", "smw.sfc")).
 		AddRow("NES", "Super Mario Bros", 3600, 5, now.Add(-time.Hour).Unix(),
-			"Nintendo Entertainment System", "/games/nes/smb.nes")
+			"Nintendo Entertainment System",
+			filepath.Join(string(filepath.Separator), "games", "nes", "smb.nes"))
 
 	mock.ExpectPrepare(`SELECT.*sub\.SystemID.*FROM.*GROUP BY SystemID, MediaName.*ORDER BY sub\.TotalPlayTime DESC`).
 		ExpectQuery().
@@ -768,7 +778,8 @@ func TestSqlGetMediaHistoryTop_MultipleSessionsAggregated(t *testing.T) {
 	assert.Equal(t, 7200, entries[0].TotalPlayTime)
 	assert.Equal(t, 12, entries[0].SessionCount)
 	assert.Equal(t, "Super Nintendo Entertainment System", entries[0].SystemName)
-	assert.Equal(t, "/games/snes/smw.sfc", entries[0].MediaPath)
+	assert.Equal(t,
+		filepath.Join(string(filepath.Separator), "games", "snes", "smw.sfc"), entries[0].MediaPath)
 
 	assert.Equal(t, "NES", entries[1].SystemID)
 	assert.Equal(t, 3600, entries[1].TotalPlayTime)
@@ -791,7 +802,8 @@ func TestSqlGetMediaHistoryTop_SystemFilter(t *testing.T) {
 		"SystemName", "MediaPath",
 	}).
 		AddRow("SNES", "Super Mario World", 7200, 12, now.Unix(),
-			"Super Nintendo Entertainment System", "/games/snes/smw.sfc")
+			"Super Nintendo Entertainment System",
+			filepath.Join(string(filepath.Separator), "games", "snes", "smw.sfc"))
 
 	mock.ExpectPrepare(`SELECT.*WHERE SystemID = \?.*GROUP BY`).
 		ExpectQuery().
@@ -911,7 +923,7 @@ func TestSqlGetMediaHistoryTop_BothFilters(t *testing.T) {
 		"SystemName", "MediaPath",
 	}).
 		AddRow("Genesis", "Sonic", 1800, 3, now.Unix(),
-			"Sega Genesis", "/games/gen/sonic.md")
+			"Sega Genesis", filepath.Join(string(filepath.Separator), "games", "gen", "sonic.md"))
 
 	mock.ExpectPrepare(`SELECT.*WHERE SystemID = \? AND StartTime >= \?.*GROUP BY`).
 		ExpectQuery().
@@ -940,9 +952,11 @@ func TestSqlGetMediaHistoryTop_MultipleSystemIDs(t *testing.T) {
 		"SystemName", "MediaPath",
 	}).
 		AddRow("SNES", "Super Mario World", 7200, 12, now.Unix(),
-			"Super Nintendo Entertainment System", "/games/snes/smw.sfc").
+			"Super Nintendo Entertainment System",
+			filepath.Join(string(filepath.Separator), "games", "snes", "smw.sfc")).
 		AddRow("NES", "Super Mario Bros", 3600, 5, now.Add(-time.Hour).Unix(),
-			"Nintendo Entertainment System", "/games/nes/smb.nes")
+			"Nintendo Entertainment System",
+			filepath.Join(string(filepath.Separator), "games", "nes", "smb.nes"))
 
 	mock.ExpectPrepare(`SELECT.*WHERE SystemID IN \(\?, \?\).*GROUP BY`).
 		ExpectQuery().

--- a/pkg/database/userdb/media_user_data.go
+++ b/pkg/database/userdb/media_user_data.go
@@ -72,6 +72,17 @@ func (db *UserDB) SetMediaUserLauncherOverride(systemID, path, launcherID string
 	)
 }
 
+// SetMediaUserSnapshot records a successfully resolved scanner identity
+// snapshot on an existing user-data row. It never inserts: a snapshot without
+// user intent (favourite/override) is meaningless. Empty tags are significant
+// and replace stale tags; callers must skip this method when lookup fails.
+func (db *UserDB) SetMediaUserSnapshot(systemID, path, mediaName string, tags []string) error {
+	return sqlSetMediaUserSnapshot(
+		db.ctx, db.sql.Load(), systemID, pathutil.CanonicalMediaPath(path),
+		mediaName, database.EncodeTagStrings(tags),
+	)
+}
+
 // DeleteMediaUserData removes the user-data row for (SystemID, Path). Deleting a
 // row that does not exist is not an error.
 func (db *UserDB) DeleteMediaUserData(systemID, path string) error {
@@ -88,9 +99,10 @@ func sqlGetMediaUserData(
 	ctx context.Context, db *sql.DB, systemID, path string,
 ) (database.MediaUserData, bool, error) {
 	var row database.MediaUserData
+	var rawTags string
 	q, err := db.PrepareContext(ctx, `
 		select
-		DBID, SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		DBID, SystemID, Path, IsFavorite, LauncherOverride, MediaName, Tags, CreatedAt, UpdatedAt
 		from MediaUserData
 		where SystemID = ? and Path = ?;
 	`)
@@ -108,6 +120,8 @@ func sqlGetMediaUserData(
 		&row.Path,
 		&row.IsFavorite,
 		&row.LauncherOverride,
+		&row.MediaName,
+		&rawTags,
 		&row.CreatedAt,
 		&row.UpdatedAt,
 	)
@@ -118,6 +132,7 @@ func sqlGetMediaUserData(
 		return row, false, fmt.Errorf("failed to scan media user data row: %w", err)
 	}
 	row.Path = pathutil.CanonicalMediaPath(row.Path)
+	row.Tags = database.DecodeTagStrings(rawTags)
 	return row, true, nil
 }
 
@@ -126,11 +141,13 @@ func sqlUpsertMediaUserData(
 ) error {
 	stmt, err := db.PrepareContext(ctx, `
 		insert into MediaUserData(
-			SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
-		) values (?, ?, ?, ?, ?, ?)
+			SystemID, Path, IsFavorite, LauncherOverride, MediaName, Tags, CreatedAt, UpdatedAt
+		) values (?, ?, ?, ?, ?, ?, ?, ?)
 		on conflict(SystemID, Path) do update set
 			IsFavorite = excluded.IsFavorite,
 			LauncherOverride = excluded.LauncherOverride,
+			MediaName = case when excluded.MediaName != '' then excluded.MediaName else MediaUserData.MediaName end,
+			Tags = case when excluded.Tags != '' then excluded.Tags else MediaUserData.Tags end,
 			UpdatedAt = excluded.UpdatedAt;
 	`)
 	if err != nil {
@@ -146,6 +163,8 @@ func sqlUpsertMediaUserData(
 		data.Path,
 		data.IsFavorite,
 		data.LauncherOverride,
+		data.MediaName,
+		database.EncodeTagStrings(data.Tags),
 		now,
 		now,
 	)
@@ -179,6 +198,19 @@ func sqlSetMediaUserLauncherOverride(
 			LauncherOverride = excluded.LauncherOverride,
 			UpdatedAt = excluded.UpdatedAt;
 	`, systemID, path, launcherID, now)
+}
+
+func sqlSetMediaUserSnapshot(
+	ctx context.Context, db *sql.DB, systemID, path, mediaName, encodedTags string,
+) error {
+	_, err := db.ExecContext(ctx, `
+		update MediaUserData set MediaName = ?, Tags = ?
+		where SystemID = ? and Path = ?;
+	`, mediaName, encodedTags, systemID, path)
+	if err != nil {
+		return fmt.Errorf("failed to update media user data snapshot: %w", err)
+	}
+	return nil
 }
 
 // mediaUserDataColumnWrite applies a single-column upsert and then deletes the
@@ -227,7 +259,7 @@ func sqlListMediaUserData(ctx context.Context, db *sql.DB) ([]database.MediaUser
 
 	q, err := db.PrepareContext(ctx, `
 		select
-		DBID, SystemID, Path, IsFavorite, LauncherOverride, CreatedAt, UpdatedAt
+		DBID, SystemID, Path, IsFavorite, LauncherOverride, MediaName, Tags, CreatedAt, UpdatedAt
 		from MediaUserData;
 	`)
 	if err != nil {
@@ -250,12 +282,15 @@ func sqlListMediaUserData(ctx context.Context, db *sql.DB) ([]database.MediaUser
 	}()
 	for rows.Next() {
 		row := database.MediaUserData{}
+		var rawTags string
 		scanErr := rows.Scan(
 			&row.DBID,
 			&row.SystemID,
 			&row.Path,
 			&row.IsFavorite,
 			&row.LauncherOverride,
+			&row.MediaName,
+			&rawTags,
 			&row.CreatedAt,
 			&row.UpdatedAt,
 		)
@@ -263,6 +298,7 @@ func sqlListMediaUserData(ctx context.Context, db *sql.DB) ([]database.MediaUser
 			return list, fmt.Errorf("failed to scan media user data row: %w", scanErr)
 		}
 		row.Path = pathutil.CanonicalMediaPath(row.Path)
+		row.Tags = database.DecodeTagStrings(rawTags)
 		list = append(list, row)
 	}
 	if err = rows.Err(); err != nil {

--- a/pkg/database/userdb/media_user_data_test.go
+++ b/pkg/database/userdb/media_user_data_test.go
@@ -251,3 +251,43 @@ func TestListMediaUserData(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, all, 3)
 }
+
+func TestSetMediaUserSnapshot(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	path := filepath.Join("roms", "SNES", "Super Metroid (USA).sfc")
+
+	// Snapshot on a missing row is a no-op: identity without user intent
+	// is meaningless.
+	require.NoError(t, userDB.SetMediaUserSnapshot("SNES", path, "Super Metroid", []string{"region:us"}))
+	_, found, err := userDB.GetMediaUserData("SNES", path)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	// Favourite first, then snapshot the scanner identity onto the row.
+	require.NoError(t, userDB.SetMediaUserFavorite("SNES", path, true))
+	require.NoError(t, userDB.SetMediaUserSnapshot(
+		"SNES", path, "Super Metroid", []string{"region:us", "rev:1"}))
+	got, found, err := userDB.GetMediaUserData("SNES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "Super Metroid", got.MediaName)
+	assert.Equal(t, []string{"region:us", "rev:1"}, got.Tags)
+
+	// A successful lookup with no tags clears stale disambiguation while
+	// retaining the current scanner name.
+	require.NoError(t, userDB.SetMediaUserSnapshot("SNES", path, "Super Metroid", nil))
+	got, found, err = userDB.GetMediaUserData("SNES", path)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "Super Metroid", got.MediaName)
+	assert.Empty(t, got.Tags)
+
+	// The snapshot survives in listings too.
+	list, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, "Super Metroid", list[0].MediaName)
+	assert.Empty(t, list[0].Tags)
+}

--- a/pkg/database/userdb/migrations/20260723150000_media_identity_tags.sql
+++ b/pkg/database/userdb/migrations/20260723150000_media_identity_tags.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Snapshot disambiguating filename tags (type:value pairs from the media
+-- scanner, e.g. "region:us", "rev:1") onto the durable game-identity rows.
+-- MediaDB is disposable (rebuilt by rescan, never backed up), so tags for
+-- played/favorited items must be captured at record time or they are lost
+-- when the MediaDB entry disappears. Stored as a JSON string array; '' means
+-- no snapshot was possible (no scanner entry at record time).
+ALTER TABLE MediaHistory ADD COLUMN Tags TEXT NOT NULL DEFAULT '';
+
+-- MediaUserData additionally snapshots the display name: favorites store
+-- only the raw path today, which leaves future favorites sync re-parsing
+-- filenames server-side for names too.
+ALTER TABLE MediaUserData ADD COLUMN MediaName TEXT NOT NULL DEFAULT '';
+ALTER TABLE MediaUserData ADD COLUMN Tags TEXT NOT NULL DEFAULT '';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE MediaUserData DROP COLUMN Tags;
+ALTER TABLE MediaUserData DROP COLUMN MediaName;
+ALTER TABLE MediaHistory DROP COLUMN Tags;
+-- +goose StatementEnd

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -1158,7 +1158,7 @@ func (m *Manager) notifyRemoteFailure(err error) {
 	case errors.Is(err, errRemoteUnlinked):
 		title = "Remote backup needs relinking"
 		body = "Remote backup could not run because this device is not linked. " +
-			"Relink Zaparoo Online to resume remote backups."
+			"Relink your online account to resume remote backups."
 		category = inboxservice.CategoryBackupRemoteUnlinked
 	case errors.As(err, &busy):
 		// Not a failure worth an inbox message: another run is in flight.

--- a/pkg/service/backup/remote_playsync.go
+++ b/pkg/service/backup/remote_playsync.go
@@ -1,0 +1,219 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
+)
+
+// Play-history sync uploads MediaHistory sessions to the Zaparoo API over
+// the device token, cursored on the server-side watermark (the newest
+// core_updated_at it has stored). The server upserts by session UUID, so
+// bulk first import, steady state, retries, and retroactive timestamp
+// healing all share this one idempotent path. See the API repo's
+// docs/plans/zaparoo-open-api.md.
+const (
+	playSyncBatchSize = 500
+	// playSyncMaxBatches bounds one sync pass as a runaway backstop; a full
+	// year of heavy play is far below this many sessions. Anything left
+	// syncs on the next pass.
+	playSyncMaxBatches = 200
+)
+
+var errPlaySyncDisabled = errors.New("play history sync is disabled")
+
+// PlaySyncInfo summarizes one play-history sync pass.
+type PlaySyncInfo struct {
+	Uploaded int
+	Batches  int
+}
+
+//nolint:tagliatelle,govet // Remote API contract uses snake_case JSON fields.
+type remotePlaySessionItem struct {
+	ProfileID     *string    `json:"profile_id,omitempty"`
+	EndedAt       *time.Time `json:"ended_at,omitempty"`
+	SessionUUID   string     `json:"session_uuid"`
+	SystemID      string     `json:"system_id"`
+	SystemName    string     `json:"system_name"`
+	LauncherID    string     `json:"launcher_id"`
+	MediaPath     string     `json:"media_path"`
+	MediaName     string     `json:"media_name"`
+	ClockSource   string     `json:"clock_source"`
+	Tags          []string   `json:"tags,omitempty"`
+	StartedAt     time.Time  `json:"started_at"`
+	CoreUpdatedAt time.Time  `json:"core_updated_at"`
+	PlayTimeSecs  int        `json:"play_time_secs"`
+	ClockReliable bool       `json:"clock_reliable"`
+	IsDeleted     bool       `json:"is_deleted"`
+}
+
+type remotePlaySessionRequest struct {
+	Sessions []remotePlaySessionItem `json:"sessions"`
+}
+
+type remotePlaySessionResponse struct {
+	Watermark *time.Time `json:"watermark"`
+	Accepted  int64      `json:"accepted"`
+}
+
+type remotePlayWatermarkResponse struct {
+	Watermark *time.Time `json:"watermark"`
+}
+
+// mediaHistoryToRemote converts a local MediaHistory row to its wire shape.
+func mediaHistoryToRemote(entry *database.MediaHistoryEntry) remotePlaySessionItem {
+	return remotePlaySessionItem{
+		SessionUUID:   entry.ID,
+		ProfileID:     entry.ProfileID,
+		SystemID:      entry.SystemID,
+		SystemName:    entry.SystemName,
+		LauncherID:    entry.LauncherID,
+		MediaPath:     entry.MediaPath,
+		MediaName:     entry.MediaName,
+		StartedAt:     entry.StartTime.UTC(),
+		EndedAt:       entry.EndTime,
+		PlayTimeSecs:  entry.PlayTime,
+		ClockSource:   entry.ClockSource,
+		ClockReliable: entry.ClockReliable,
+		Tags:          entry.Tags,
+		IsDeleted:     entry.IsDeleted,
+		CoreUpdatedAt: entry.UpdatedAt.UTC(),
+	}
+}
+
+func (c *remoteClient) playSessionWatermark(ctx context.Context) (*time.Time, error) {
+	var resp remotePlayWatermarkResponse
+	if err := c.retryRateLimited(ctx, func() error {
+		resp = remotePlayWatermarkResponse{}
+		return c.doJSON(ctx, http.MethodGet, "/v1/device/play-sessions/watermark", nil, &resp)
+	}); err != nil {
+		return nil, err
+	}
+	return resp.Watermark, nil
+}
+
+func (c *remoteClient) uploadPlaySessions(
+	ctx context.Context, sessions []remotePlaySessionItem,
+) (remotePlaySessionResponse, error) {
+	var resp remotePlaySessionResponse
+	req := remotePlaySessionRequest{Sessions: sessions}
+	if err := c.retryRateLimited(ctx, func() error {
+		resp = remotePlaySessionResponse{}
+		return c.doJSON(ctx, http.MethodPost, "/v1/device/play-sessions", &req, &resp)
+	}); err != nil {
+		return remotePlaySessionResponse{}, err
+	}
+	return resp, nil
+}
+
+// SyncPlayHistory uploads every session updated since the server's
+// watermark. The first call after linking is the bulk import of the whole
+// local history; afterwards each pass sends only what changed. A pass is
+// cheap when nothing changed: one watermark GET and one empty local query.
+func (m *Manager) SyncPlayHistory(ctx context.Context) (PlaySyncInfo, error) {
+	if !m.cfg.PlaytimeSyncEnabled() {
+		return PlaySyncInfo{}, errPlaySyncDisabled
+	}
+	client, err := m.newRemoteClient()
+	if err != nil {
+		return PlaySyncInfo{}, err
+	}
+
+	watermark, err := client.playSessionWatermark(ctx)
+	if err != nil {
+		return PlaySyncInfo{}, err
+	}
+	// Clear local acknowledgements beyond server state (or all of them for a
+	// fresh server-side device). Batch selection then walks every unsynced row
+	// from the local beginning, including unreliable-clock rows older than the
+	// server watermark.
+	if resetErr := m.database.UserDB.ResetMediaHistorySyncAfter(watermark); resetErr != nil {
+		return PlaySyncInfo{}, fmt.Errorf("resetting media history sync state: %w", resetErr)
+	}
+	cursor := time.Time{}
+	var cursorDBID int64
+
+	info := PlaySyncInfo{}
+	for range playSyncMaxBatches {
+		if !m.cfg.PlaytimeSyncEnabled() {
+			return info, errPlaySyncDisabled
+		}
+		batch, batchErr := m.database.UserDB.GetMediaHistorySyncBatch(cursor, cursorDBID, playSyncBatchSize)
+		if batchErr != nil {
+			return info, fmt.Errorf("reading media history sync batch: %w", batchErr)
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		items := make([]remotePlaySessionItem, 0, len(batch))
+		refs := make([]database.MediaHistorySyncRef, 0, len(batch))
+		for i := range batch {
+			items = append(items, mediaHistoryToRemote(&batch[i]))
+			refs = append(refs, database.MediaHistorySyncRef{
+				DBID: batch[i].DBID, UpdatedAt: batch[i].UpdatedAt,
+			})
+		}
+		if !m.cfg.PlaytimeSyncEnabled() {
+			return info, errPlaySyncDisabled
+		}
+		resp, uploadErr := client.uploadPlaySessions(ctx, items)
+		if uploadErr != nil {
+			return info, uploadErr
+		}
+
+		if markErr := m.database.UserDB.MarkMediaHistorySynced(refs, time.Now().UTC()); markErr != nil {
+			// Batch selection depends on local acknowledgement state. Stop this
+			// pass rather than uploading the same unmarked rows repeatedly; the
+			// next pass safely retries the idempotent server upsert.
+			return info, fmt.Errorf("marking media history rows synced: %w", markErr)
+		}
+
+		info.Uploaded += len(batch)
+		info.Batches++
+		last := &batch[len(batch)-1]
+		cursor = last.UpdatedAt
+		cursorDBID = last.DBID
+		log.Debug().
+			Int("batch", len(batch)).
+			Int64("accepted", resp.Accepted).
+			Time("cursor", cursor).
+			Msg("play history batch synced")
+
+		if len(batch) < playSyncBatchSize {
+			break
+		}
+	}
+
+	if info.Uploaded > 0 {
+		log.Info().
+			Int("sessions", info.Uploaded).
+			Int("batches", info.Batches).
+			Msg("play history sync completed")
+	}
+	return info, nil
+}

--- a/pkg/service/backup/remote_playsync_test.go
+++ b/pkg/service/backup/remote_playsync_test.go
@@ -1,0 +1,237 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// playSyncTestEntry builds one closed, syncable MediaHistory row.
+func playSyncTestEntry(dbid int64, id, mediaName string, updatedAt time.Time) database.MediaHistoryEntry {
+	endTime := updatedAt
+	return database.MediaHistoryEntry{
+		DBID:          dbid,
+		ID:            id,
+		StartTime:     updatedAt.Add(-30 * time.Minute),
+		EndTime:       &endTime,
+		SystemID:      "snes",
+		SystemName:    "Super Nintendo",
+		MediaPath:     "/games/" + mediaName + ".sfc",
+		MediaName:     mediaName,
+		LauncherID:    "test",
+		PlayTime:      1800,
+		ClockReliable: true,
+		ClockSource:   "system",
+		Tags:          []string{"region:us", "ext:sfc"},
+		UpdatedAt:     updatedAt,
+	}
+}
+
+// playSyncTestServer serves the watermark and ingestion endpoints, recording
+// every uploaded batch.
+func playSyncTestServer(t *testing.T, watermark *time.Time) (*httptest.Server, *[][]remotePlaySessionItem) {
+	t.Helper()
+	var batches [][]remotePlaySessionItem
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/play-sessions/watermark":
+			assert.NoError(t, json.NewEncoder(w).Encode(remotePlayWatermarkResponse{Watermark: watermark}))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/play-sessions":
+			var req remotePlaySessionRequest
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			batches = append(batches, req.Sessions)
+			newest := req.Sessions[len(req.Sessions)-1].CoreUpdatedAt
+			assert.NoError(t, json.NewEncoder(w).Encode(remotePlaySessionResponse{
+				Accepted:  int64(len(req.Sessions)),
+				Watermark: &newest,
+			}))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &batches
+}
+
+func TestSyncPlayHistory_BulkImport(t *testing.T) {
+	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
+
+	server, batches := playSyncTestServer(t, nil)
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	first := playSyncTestEntry(1, "11111111-1111-4111-8111-111111111111", "Game A", base)
+	second := playSyncTestEntry(2, "22222222-2222-4222-8222-222222222222", "Game B", base.Add(time.Hour))
+
+	env.UserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Once()
+	// Never synced: the cursor starts at zero and the whole history uploads.
+	env.UserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), playSyncBatchSize).
+		Return([]database.MediaHistoryEntry{first, second}, nil).Once()
+	env.UserDB.On("MarkMediaHistorySynced", []database.MediaHistorySyncRef{
+		{DBID: first.DBID, UpdatedAt: first.UpdatedAt},
+		{DBID: second.DBID, UpdatedAt: second.UpdatedAt},
+	}, testifymock.AnythingOfType("time.Time")).Return(nil).Once()
+
+	info, err := env.Manager.SyncPlayHistory(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, info.Uploaded)
+	assert.Equal(t, 1, info.Batches)
+
+	require.Len(t, *batches, 1)
+	uploaded := (*batches)[0]
+	require.Len(t, uploaded, 2)
+	assert.Equal(t, first.ID, uploaded[0].SessionUUID)
+	assert.Equal(t, "Game A", uploaded[0].MediaName)
+	assert.Equal(t, 1800, uploaded[0].PlayTimeSecs)
+	assert.True(t, first.UpdatedAt.Equal(uploaded[0].CoreUpdatedAt))
+	assert.True(t, uploaded[0].ClockReliable)
+	assert.Equal(t, []string{"region:us", "ext:sfc"}, uploaded[0].Tags,
+		"disambiguating tags travel with the session")
+}
+
+func TestSyncPlayHistory_ResumesFromServerWatermark(t *testing.T) {
+	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	watermark := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Hour)
+
+	server, batches := playSyncTestServer(t, &watermark)
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	env.UserDB.On(
+		"ResetMediaHistorySyncAfter",
+		testifymock.MatchedBy(func(got *time.Time) bool {
+			return got != nil && watermark.Equal(*got)
+		}),
+	).Return(nil).Once()
+	// Local acknowledgement state suppresses unchanged rows; selection always
+	// starts at zero so old unreliable-clock rows remain eligible.
+	env.UserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), playSyncBatchSize).
+		Return([]database.MediaHistoryEntry{}, nil).Once()
+
+	info, err := env.Manager.SyncPlayHistory(context.Background())
+	require.NoError(t, err)
+	assert.Zero(t, info.Uploaded)
+	assert.Empty(t, *batches, "nothing new: no upload requests")
+}
+
+func TestSyncPlayHistory_PaginatesFullBatches(t *testing.T) {
+	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
+
+	server, batches := playSyncTestServer(t, nil)
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	// A full first batch forces a second query cursored after its last row.
+	full := make([]database.MediaHistoryEntry, 0, playSyncBatchSize)
+	refs := make([]database.MediaHistorySyncRef, 0, playSyncBatchSize)
+	for i := range playSyncBatchSize {
+		entry := playSyncTestEntry(
+			int64(i+1), "11111111-1111-4111-8111-111111111111", "Game", base.Add(time.Duration(i)*time.Second),
+		)
+		full = append(full, entry)
+		refs = append(refs, database.MediaHistorySyncRef{DBID: entry.DBID, UpdatedAt: entry.UpdatedAt})
+	}
+	last := full[len(full)-1]
+
+	env.UserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Once()
+	env.UserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), playSyncBatchSize).
+		Return(full, nil).Once()
+	env.UserDB.On(
+		"GetMediaHistorySyncBatch",
+		testifymock.MatchedBy(func(after time.Time) bool { return last.UpdatedAt.Equal(after) }),
+		last.DBID, playSyncBatchSize,
+	).Return([]database.MediaHistoryEntry{}, nil).Once()
+	env.UserDB.On("MarkMediaHistorySynced", refs, testifymock.AnythingOfType("time.Time")).
+		Return(nil).Once()
+
+	info, err := env.Manager.SyncPlayHistory(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, playSyncBatchSize, info.Uploaded)
+	assert.Equal(t, 1, info.Batches)
+	require.Len(t, *batches, 1)
+}
+
+func TestSyncPlayHistory_StopsWhenConsentRevokedDuringPass(t *testing.T) {
+	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
+	server, batches := playSyncTestServer(t, nil)
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+	entry := playSyncTestEntry(1, "11111111-1111-4111-8111-111111111111", "Game A", base)
+
+	env.UserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Once()
+	env.UserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), playSyncBatchSize).
+		Run(func(_ testifymock.Arguments) { env.Manager.cfg.SetPlaytimeSync(false) }).
+		Return([]database.MediaHistoryEntry{entry}, nil).Once()
+
+	info, err := env.Manager.SyncPlayHistory(context.Background())
+	require.ErrorIs(t, err, errPlaySyncDisabled)
+	assert.Zero(t, info.Uploaded)
+	assert.Empty(t, *batches, "revoked consent must stop before the next upload")
+	env.UserDB.AssertNotCalled(t, "MarkMediaHistorySynced", testifymock.Anything, testifymock.Anything)
+}
+
+func TestSyncPlayHistory_UnsetConsentIsDisabled(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, "mister")
+
+	assert.False(t, env.Manager.cfg.PlaytimeSyncEnabled())
+	_, err := env.Manager.SyncPlayHistory(context.Background())
+	require.ErrorIs(t, err, errPlaySyncDisabled)
+}
+
+func TestSyncPlayHistory_DisabledByConfig(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(false)
+
+	_, err := env.Manager.SyncPlayHistory(context.Background())
+	require.ErrorIs(t, err, errPlaySyncDisabled)
+}
+
+func TestSyncPlayHistory_Unlinked(t *testing.T) {
+	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	// No credential configured: sync must report unlinked, not upload.
+
+	_, err := env.Manager.SyncPlayHistory(context.Background())
+	require.ErrorIs(t, err, errRemoteUnlinked)
+}

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -58,6 +58,12 @@ const (
 	remoteHeartbeatInterval       = 24 * time.Hour
 	remoteHeartbeatInitialBackoff = 1 * time.Minute
 	remoteHeartbeatMaxBackoff     = 1 * time.Hour
+	// playSyncInterval paces play-history uploads to the remote API. Like
+	// heartbeats, sync runs for any linked device (it is not gated on
+	// remote backup being enabled or available); a pass with no new
+	// sessions is one GET and one empty local query. Failures back off on
+	// the shared heartbeat backoff schedule.
+	playSyncInterval = 1 * time.Hour
 	// remoteBackupStaleAfter is how long scheduling may go without a
 	// successful run before the user is told via the inbox. The inbox
 	// message wording assumes roughly a week.
@@ -194,9 +200,33 @@ func remoteBackupSchedulerLoop(
 		}
 	}
 
+	// Play-history sync reuses the heartbeat pacing state: interval on
+	// success, exponential backoff on failure. The first pass after linking
+	// is the bulk import of the whole local history.
+	playSyncState := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
+	tryPlaySync := func() {
+		now := time.Now()
+		if !playSyncDue(&playSyncState, now) {
+			return
+		}
+		mgr := backupsvc.NewManager(cfg, pl, db).WithCoordinator(st.BackupCoordinator())
+		info, err := mgr.SyncPlayHistory(ctx)
+		if err != nil {
+			// Unlinked, disabled, or unreachable: sync is best-effort.
+			playSyncState.recordFailure(now)
+			log.Debug().Err(err).Msg("play history sync not run")
+			return
+		}
+		playSyncState.recordSuccess(now)
+		if info.Uploaded > 0 {
+			log.Info().Int("sessions", info.Uploaded).Msg("scheduled play history sync completed")
+		}
+	}
+
 	tryHeartbeat()
 	trySchedule()
 	tryStaleNotice()
+	tryPlaySync()
 	ticker := newTicker(remoteBackupSchedulerCheckInterval)
 	defer ticker.Stop()
 	for {
@@ -205,10 +235,20 @@ func remoteBackupSchedulerLoop(
 			tryHeartbeat()
 			trySchedule()
 			tryStaleNotice()
+			tryPlaySync()
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// playSyncDue reports whether a play-history sync pass should run now,
+// honoring the success interval and failure backoff.
+func playSyncDue(s *remoteHeartbeatState, now time.Time) bool {
+	if !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < playSyncInterval {
+		return false
+	}
+	return s.nextAttempt.IsZero() || !now.Before(s.nextAttempt)
 }
 
 func scheduledRemoteBackupDue(

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -134,6 +134,11 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					profileID := activeProfile.ProfileID
 					entry.ProfileID = &profileID
 				}
+				// Snapshot the scanner's disambiguating tags now: MediaDB
+				// is disposable, so tags not captured at record time are
+				// lost to this row forever (rescan, deleted file,
+				// re-imaged card).
+				entry.Tags = t.lookupMediaTags(activeMedia.SystemID, activeMedia.Path)
 				dbid, addErr := t.db.UserDB.AddMediaHistory(entry)
 				if addErr != nil {
 					log.Error().Err(addErr).Msg("failed to add media history entry")
@@ -201,6 +206,19 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 // updatePlayTime periodically updates the PlayTime for the currently active media
 // history entry every 15 seconds. This limits crash-loss to at most 15 seconds of
 // playtime and keeps the history accurate for users who care about tracking.
+// lookupMediaTags snapshots the scanner's disambiguating tags for the
+// launched media. Best effort with a short timeout: a launch outside the
+// index simply records no tags.
+func (t *mediaHistoryTracker) lookupMediaTags(systemID, path string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	identity, found := database.LookupMediaIdentity(ctx, t.db.MediaDB, systemID, path)
+	if !found {
+		return nil
+	}
+	return identity.Tags
+}
+
 func (t *mediaHistoryTracker) updatePlayTime(ctx context.Context) {
 	ticker := t.clock.NewTicker(15 * time.Second)
 	defer ticker.Stop()

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -145,10 +145,10 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					t.mu.Unlock()
 					log.Debug().Int64("dbid", dbid).Msg("created media history entry")
 
-					// MediaDB lookup may block behind indexing. Capture launch identity
-					// now, then enrich the durable history row off the notification path.
+					// MediaDB lookup may block behind indexing. Capture lookup keys now,
+					// then enrich the durable history row off the notification path.
 					systemID, mediaPath := entry.SystemID, entry.MediaPath
-					go t.snapshotMediaHistoryTags(dbid, systemID, mediaPath)
+					go t.snapshotMediaHistoryIdentity(dbid, systemID, mediaPath)
 				}
 			}
 
@@ -203,27 +203,22 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 	}
 }
 
-// lookupMediaTags snapshots the scanner's disambiguating tags for the
-// launched media. Best effort with a short timeout: a launch outside the
-// index simply records no tags.
-func (t *mediaHistoryTracker) lookupMediaTags(systemID, path string) []string {
+// lookupMediaIdentity snapshots scanner-derived identity for launched media.
+// Best effort with a short timeout: a launch outside the index has no snapshot.
+func (t *mediaHistoryTracker) lookupMediaIdentity(systemID, path string) (database.MediaIdentity, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	identity, found := database.LookupMediaIdentity(ctx, t.db.MediaDB, systemID, path)
-	if !found {
-		return nil
-	}
-	return identity.Tags
+	return database.LookupMediaIdentity(ctx, t.db.MediaDB, systemID, path)
 }
 
-// snapshotMediaHistoryTags enriches a persisted entry without blocking notifications.
-func (t *mediaHistoryTracker) snapshotMediaHistoryTags(dbid int64, systemID, path string) {
-	tags := t.lookupMediaTags(systemID, path)
-	if len(tags) == 0 {
+// snapshotMediaHistoryIdentity enriches a persisted entry without blocking notifications.
+func (t *mediaHistoryTracker) snapshotMediaHistoryIdentity(dbid int64, systemID, path string) {
+	identity, found := t.lookupMediaIdentity(systemID, path)
+	if !found {
 		return
 	}
-	if err := t.db.UserDB.UpdateMediaHistoryTags(dbid, tags); err != nil {
-		log.Warn().Err(err).Int64("dbid", dbid).Msg("failed to store media history tags")
+	if err := t.db.UserDB.UpdateMediaHistoryIdentity(dbid, identity); err != nil {
+		log.Warn().Err(err).Int64("dbid", dbid).Msg("failed to store media history identity")
 	}
 }
 

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -134,11 +134,6 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					profileID := activeProfile.ProfileID
 					entry.ProfileID = &profileID
 				}
-				// Snapshot the scanner's disambiguating tags now: MediaDB
-				// is disposable, so tags not captured at record time are
-				// lost to this row forever (rescan, deleted file,
-				// re-imaged card).
-				entry.Tags = t.lookupMediaTags(activeMedia.SystemID, activeMedia.Path)
 				dbid, addErr := t.db.UserDB.AddMediaHistory(entry)
 				if addErr != nil {
 					log.Error().Err(addErr).Msg("failed to add media history entry")
@@ -149,6 +144,11 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					t.currentMediaStartTimeMono = nowMono
 					t.mu.Unlock()
 					log.Debug().Int64("dbid", dbid).Msg("created media history entry")
+
+					// MediaDB lookup may block behind indexing. Capture launch identity
+					// now, then enrich the durable history row off the notification path.
+					systemID, mediaPath := entry.SystemID, entry.MediaPath
+					go t.snapshotMediaHistoryTags(dbid, systemID, mediaPath)
 				}
 			}
 
@@ -203,9 +203,6 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 	}
 }
 
-// updatePlayTime periodically updates the PlayTime for the currently active media
-// history entry every 15 seconds. This limits crash-loss to at most 15 seconds of
-// playtime and keeps the history accurate for users who care about tracking.
 // lookupMediaTags snapshots the scanner's disambiguating tags for the
 // launched media. Best effort with a short timeout: a launch outside the
 // index simply records no tags.
@@ -219,6 +216,18 @@ func (t *mediaHistoryTracker) lookupMediaTags(systemID, path string) []string {
 	return identity.Tags
 }
 
+// snapshotMediaHistoryTags enriches a persisted entry without blocking notifications.
+func (t *mediaHistoryTracker) snapshotMediaHistoryTags(dbid int64, systemID, path string) {
+	tags := t.lookupMediaTags(systemID, path)
+	if len(tags) == 0 {
+		return
+	}
+	if err := t.db.UserDB.UpdateMediaHistoryTags(dbid, tags); err != nil {
+		log.Warn().Err(err).Int64("dbid", dbid).Msg("failed to store media history tags")
+	}
+}
+
+// updatePlayTime periodically updates the current entry, limiting crash-loss to 15 seconds.
 func (t *mediaHistoryTracker) updatePlayTime(ctx context.Context) {
 	ticker := t.clock.NewTicker(15 * time.Second)
 	defer ticker.Stop()

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -98,6 +98,78 @@ func TestMediaHistoryTracker_Listen_Started(t *testing.T) {
 	assert.Equal(t, startTime, tracker.currentMediaStartTime)
 }
 
+func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := &testhelpers.MockUserDBI{}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	tracker := &mediaHistoryTracker{
+		st:    st,
+		db:    &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		clock: clockwork.NewFakeClock(),
+	}
+	activeMedia := &models.ActiveMedia{
+		Started: tracker.clock.Now(), SystemID: "NES", SystemName: "Nintendo Entertainment System",
+		Path: filepath.Join("roms", "NES", "Game.nes"), Name: "Game", LauncherID: "NES",
+	}
+	st.SetActiveMedia(activeMedia)
+
+	lookupStarted := make(chan struct{})
+	releaseLookup := make(chan struct{})
+	tagsUpdated := make(chan struct{})
+	mockUserDB.On("AddMediaHistory", mock.MatchedBy(func(entry *database.MediaHistoryEntry) bool {
+		return entry.SystemID == "NES" && entry.MediaPath == activeMedia.Path && len(entry.Tags) == 0
+	})).Return(int64(42), nil).Once()
+	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, activeMedia.Path).
+		Run(func(_ mock.Arguments) {
+			close(lookupStarted)
+			<-releaseLookup
+		}).
+		Return([]database.SearchResult{{MediaID: 7, Name: "Game"}}, nil).Once()
+	mockMediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(7)).
+		Return([]database.TagInfo{{Type: "region", Tag: "us"}}, nil).Once()
+	mockUserDB.On("UpdateMediaHistoryTags", int64(42), []string{"region:us"}).
+		Run(func(_ mock.Arguments) { close(tagsUpdated) }).Return(nil).Once()
+
+	notifChan := make(chan models.Notification, 1)
+	notifChan <- models.Notification{Method: models.NotificationStarted}
+	close(notifChan)
+	listenDone := make(chan struct{})
+	go func() {
+		tracker.listen(notifChan)
+		close(listenDone)
+	}()
+
+	select {
+	case <-lookupStarted:
+	case <-time.After(time.Second):
+		close(releaseLookup)
+		t.Fatal("tag lookup did not start")
+	}
+	select {
+	case <-listenDone:
+		// Notification processing must not wait for MediaDB lookup.
+	case <-time.After(time.Second):
+		close(releaseLookup)
+		<-listenDone
+		t.Fatal("notification processing blocked on tag lookup")
+	}
+
+	// Mutating current state cannot retarget the already captured launch identity.
+	activeMedia.SystemID = "SNES"
+	activeMedia.Path = filepath.Join("roms", "SNES", "Other.sfc")
+	close(releaseLookup)
+	select {
+	case <-tagsUpdated:
+	case <-time.After(time.Second):
+		t.Fatal("resolved tags were not persisted")
+	}
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestMediaHistoryTracker_Listen_Started_NoActiveMedia(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -98,7 +98,7 @@ func TestMediaHistoryTracker_Listen_Started(t *testing.T) {
 	assert.Equal(t, startTime, tracker.currentMediaStartTime)
 }
 
-func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing.T) {
+func TestMediaHistoryTracker_Listen_StartedResolvesIdentityAsynchronously(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
@@ -112,26 +112,30 @@ func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing
 	}
 	activeMedia := &models.ActiveMedia{
 		Started: tracker.clock.Now(), SystemID: "NES", SystemName: "Nintendo Entertainment System",
-		Path: filepath.Join("roms", "NES", "Game.nes"), Name: "Game", LauncherID: "NES",
+		Path: filepath.Join("roms", "NES", "Game.nes"), Name: "Launch Name", LauncherID: "NES",
 	}
 	st.SetActiveMedia(activeMedia)
 
 	lookupStarted := make(chan struct{})
 	releaseLookup := make(chan struct{})
-	tagsUpdated := make(chan struct{})
+	identityUpdated := make(chan struct{})
 	mockUserDB.On("AddMediaHistory", mock.MatchedBy(func(entry *database.MediaHistoryEntry) bool {
-		return entry.SystemID == "NES" && entry.MediaPath == activeMedia.Path && len(entry.Tags) == 0
+		return entry.SystemID == "NES" && entry.MediaPath == activeMedia.Path &&
+			entry.MediaName == "Launch Name" && len(entry.Tags) == 0
 	})).Return(int64(42), nil).Once()
 	mockMediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, activeMedia.Path).
 		Run(func(_ mock.Arguments) {
 			close(lookupStarted)
 			<-releaseLookup
 		}).
-		Return([]database.SearchResult{{MediaID: 7, Name: "Game"}}, nil).Once()
+		Return([]database.SearchResult{{MediaID: 7, Name: "Indexed Name"}}, nil).Once()
 	mockMediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(7)).
-		Return([]database.TagInfo{{Type: "region", Tag: "us"}}, nil).Once()
-	mockUserDB.On("UpdateMediaHistoryTags", int64(42), []string{"region:us"}).
-		Run(func(_ mock.Arguments) { close(tagsUpdated) }).Return(nil).Once()
+		Return([]database.TagInfo(nil), nil).Once()
+	mockUserDB.On("UpdateMediaHistoryIdentity", int64(42), database.MediaIdentity{
+		Name: "Indexed Name",
+		Tags: []string{},
+	}).
+		Run(func(_ mock.Arguments) { close(identityUpdated) }).Return(nil).Once()
 
 	notifChan := make(chan models.Notification, 1)
 	notifChan <- models.Notification{Method: models.NotificationStarted}
@@ -146,7 +150,7 @@ func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing
 	case <-lookupStarted:
 	case <-time.After(time.Second):
 		close(releaseLookup)
-		t.Fatal("tag lookup did not start")
+		t.Fatal("identity lookup did not start")
 	}
 	select {
 	case <-listenDone:
@@ -154,7 +158,7 @@ func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing
 	case <-time.After(time.Second):
 		close(releaseLookup)
 		<-listenDone
-		t.Fatal("notification processing blocked on tag lookup")
+		t.Fatal("notification processing blocked on identity lookup")
 	}
 
 	// Mutating current state cannot retarget the already captured launch identity.
@@ -162,9 +166,9 @@ func TestMediaHistoryTracker_Listen_StartedResolvesTagsAsynchronously(t *testing
 	activeMedia.Path = filepath.Join("roms", "SNES", "Other.sfc")
 	close(releaseLookup)
 	select {
-	case <-tagsUpdated:
+	case <-identityUpdated:
 	case <-time.After(time.Second):
-		t.Fatal("resolved tags were not persisted")
+		t.Fatal("resolved identity was not persisted")
 	}
 	mockUserDB.AssertExpectations(t)
 	mockMediaDB.AssertExpectations(t)

--- a/pkg/service/media_user_data_backfill_test.go
+++ b/pkg/service/media_user_data_backfill_test.go
@@ -32,6 +32,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBackfillMediaHistoryUUIDsAtStartup(t *testing.T) {
+	t.Parallel()
+	userDB := testhelpers.NewMockUserDBI()
+	userDB.On("BackfillMediaHistoryUUIDs").Return(int64(3), nil).Once()
+
+	backfillMediaHistoryUUIDs(userDB)
+
+	userDB.AssertExpectations(t)
+}
+
 // seedMediaUserData inserts one favourited and one launcher-overridden media into
 // media.db, mimicking a database written by a version that stored this data only
 // there. Returns the two paths.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -533,7 +533,8 @@ func Start(
 		st.GetContext(), "history-retention-cleanup",
 		5*time.Second, 300*time.Second,
 		func(ctx context.Context) {
-			cleanupHistoryRetention(ctx, cfg, db)
+			remoteLinked := backupsvc.NewManager(cfg, pl, db).Status().Remote.Linked
+			cleanupHistoryRetention(ctx, cfg, db, cfg.PlaytimeSyncEnabled() && remoteLinked)
 		},
 	)
 	idleSched.Schedule(

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -199,9 +199,24 @@ scan_history = 7
 	mockUserDB := &testhelpers.MockUserDBI{}
 	db := &database.Database{UserDB: mockUserDB}
 	mockUserDB.On("CleanupHistory", 7).Return(int64(2), nil).Once()
-	mockUserDB.On("CleanupMediaHistory", 14).Return(int64(3), nil).Once()
+	mockUserDB.On("CleanupMediaHistory", 14, false).Return(int64(3), nil).Once()
 
-	cleanupHistoryRetention(context.Background(), cfg, db)
+	cleanupHistoryRetention(context.Background(), cfg, db, false)
+
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestCleanupHistoryRetention_ProtectsUnsyncedPlayHistory(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	cfg.SetPlaytimeRetention(14)
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+	mockUserDB.On("CleanupHistory", 30).Return(int64(0), nil).Once()
+	mockUserDB.On("CleanupMediaHistory", 14, true).Return(int64(2), nil).Once()
+
+	cleanupHistoryRetention(context.Background(), cfg, db, true)
 
 	mockUserDB.AssertExpectations(t)
 }
@@ -219,7 +234,7 @@ func TestCleanupHistoryRetention_CancelledBeforeMediaHistory(t *testing.T) {
 		cancel()
 	}).Return(int64(1), nil).Once()
 
-	cleanupHistoryRetention(ctx, cfg, db)
+	cleanupHistoryRetention(ctx, cfg, db, false)
 
 	mockUserDB.AssertExpectations(t)
 	mockUserDB.AssertNotCalled(t, "CleanupMediaHistory", mock.Anything)

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -107,6 +107,8 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		return db, err
 	}
 
+	backfillMediaHistoryUUIDs(userDB)
+
 	// migrate old boltdb mappings if required
 	log.Debug().Msg("checking for boltdb migration")
 	err = boltmigration.MaybeMigrate(pl, userDB)
@@ -121,6 +123,28 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 
 	success = true
 	return db, nil
+}
+
+// backfillMediaHistoryUUIDs assigns stable IDs to history written by older
+// versions. Best-effort and idempotent: failure is retried at next startup.
+func backfillMediaHistoryUUIDs(userDB database.UserDBI) {
+	if userDB == nil {
+		return
+	}
+
+	startedAt := time.Now()
+	backfilled, err := userDB.BackfillMediaHistoryUUIDs()
+	duration := time.Since(startedAt)
+	if err != nil {
+		log.Error().Err(err).Dur("duration", duration).Msg("failed to backfill media history UUIDs")
+		return
+	}
+	if backfilled > 0 {
+		log.Info().Int64("backfilled", backfilled).Dur("duration", duration).
+			Msg("backfilled media history UUIDs")
+		return
+	}
+	log.Debug().Dur("duration", duration).Msg("media history UUID backfill completed")
 }
 
 // backfillMediaUserData seeds UserDB from favourites/launcher overrides that older
@@ -238,7 +262,9 @@ func startupMaintenanceCancelled(ctx context.Context, message string) bool {
 	return false
 }
 
-func cleanupHistoryRetention(ctx context.Context, cfg *config.Instance, db *database.Database) {
+func cleanupHistoryRetention(
+	ctx context.Context, cfg *config.Instance, db *database.Database, protectUnsyncedPlayHistory bool,
+) {
 	if startupMaintenanceCancelled(ctx, "skipping history retention cleanup: startup maintenance cancelled") {
 		return
 	}
@@ -275,7 +301,7 @@ func cleanupHistoryRetention(ctx context.Context, cfg *config.Instance, db *data
 	playtimeRetention := cfg.PlaytimeRetention()
 	if playtimeRetention > 0 {
 		log.Info().Msgf("cleaning up media history older than %d days", playtimeRetention)
-		rowsDeleted, cleanupErr := db.UserDB.CleanupMediaHistory(playtimeRetention)
+		rowsDeleted, cleanupErr := db.UserDB.CleanupMediaHistory(playtimeRetention, protectUnsyncedPlayHistory)
 		switch {
 		case cleanupErr != nil:
 			log.Error().Err(cleanupErr).Msg("error cleaning up media history")

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -107,7 +107,8 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		return db, err
 	}
 
-	backfillMediaHistoryUUIDs(userDB)
+	// Best-effort, idempotent backfill must not delay database initialization.
+	go backfillMediaHistoryUUIDs(userDB)
 
 	// migrate old boltdb mappings if required
 	log.Debug().Msg("checking for boltdb migration")

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -359,6 +359,14 @@ func (m *MockUserDBI) UpdateMediaHistoryTime(dbid int64, playTime int) error {
 	return nil
 }
 
+func (m *MockUserDBI) UpdateMediaHistoryTags(dbid int64, tags []string) error {
+	args := m.Called(dbid, tags)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI update media history tags failed: %w", err)
+	}
+	return nil
+}
+
 func (m *MockUserDBI) CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error {
 	args := m.Called(dbid, endTime, playTime)
 	if err := args.Error(0); err != nil {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -359,10 +359,10 @@ func (m *MockUserDBI) UpdateMediaHistoryTime(dbid int64, playTime int) error {
 	return nil
 }
 
-func (m *MockUserDBI) UpdateMediaHistoryTags(dbid int64, tags []string) error {
-	args := m.Called(dbid, tags)
+func (m *MockUserDBI) UpdateMediaHistoryIdentity(dbid int64, identity database.MediaIdentity) error {
+	args := m.Called(dbid, identity)
 	if err := args.Error(0); err != nil {
-		return fmt.Errorf("mock UserDBI update media history tags failed: %w", err)
+		return fmt.Errorf("mock UserDBI update media history identity failed: %w", err)
 	}
 	return nil
 }

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -416,8 +416,8 @@ func (m *MockUserDBI) CloseHangingMediaHistory() error {
 	return nil
 }
 
-func (m *MockUserDBI) CleanupMediaHistory(retentionDays int) (int64, error) {
-	args := m.Called(retentionDays)
+func (m *MockUserDBI) CleanupMediaHistory(retentionDays int, requireSynced bool) (int64, error) {
+	args := m.Called(retentionDays, requireSynced)
 	rowsDeleted, ok := args.Get(0).(int64)
 	if !ok {
 		rowsDeleted = 0
@@ -426,6 +426,56 @@ func (m *MockUserDBI) CleanupMediaHistory(retentionDays int) (int64, error) {
 		return rowsDeleted, fmt.Errorf("mock UserDBI cleanup media history failed: %w", err)
 	}
 	return rowsDeleted, nil
+}
+
+func (m *MockUserDBI) SetMediaUserSnapshot(systemID, path, mediaName string, tags []string) error {
+	args := m.Called(systemID, path, mediaName, tags)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI set media user snapshot failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) BackfillMediaHistoryUUIDs() (int64, error) {
+	args := m.Called()
+	backfilled, ok := args.Get(0).(int64)
+	if !ok {
+		backfilled = 0
+	}
+	if err := args.Error(1); err != nil {
+		return backfilled, fmt.Errorf("mock UserDBI backfill media history uuids failed: %w", err)
+	}
+	return backfilled, nil
+}
+
+func (m *MockUserDBI) ResetMediaHistorySyncAfter(watermark *time.Time) error {
+	args := m.Called(watermark)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI reset media history sync state failed: %w", err)
+	}
+	return nil
+}
+
+func (m *MockUserDBI) GetMediaHistorySyncBatch(
+	after time.Time, afterDBID int64, limit int,
+) ([]database.MediaHistoryEntry, error) {
+	args := m.Called(after, afterDBID, limit)
+	entries, ok := args.Get(0).([]database.MediaHistoryEntry)
+	if !ok {
+		entries = nil
+	}
+	if err := args.Error(1); err != nil {
+		return entries, fmt.Errorf("mock UserDBI get media history sync batch failed: %w", err)
+	}
+	return entries, nil
+}
+
+func (m *MockUserDBI) MarkMediaHistorySynced(refs []database.MediaHistorySyncRef, syncedAt time.Time) error {
+	args := m.Called(refs, syncedAt)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock UserDBI mark media history synced failed: %w", err)
+	}
+	return nil
 }
 
 func (m *MockUserDBI) HealTimestamps(bootUUID string, trueBootTime time.Time) (int64, error) {

--- a/pkg/ui/tui/online.go
+++ b/pkg/ui/tui/online.go
@@ -120,6 +120,26 @@ func renderOnlineSettingsMenu(
 	}
 
 	menu.AddHeader("Features")
+	playtimeSyncEnabled := false
+	if data.settings != nil && data.settings.PlaytimeSyncEnabled != nil {
+		playtimeSyncEnabled = *data.settings.PlaytimeSyncEnabled
+	}
+	playtimeSyncDesc := "Upload play history to your linked Zaparoo Online account"
+	if !status.Remote.Linked {
+		playtimeSyncDesc = "Upload play history when this device is linked to Zaparoo Online"
+	}
+	menu.AddToggle("Play history sync", playtimeSyncDesc, &playtimeSyncEnabled, func(value bool) {
+		ctx, cancel := tuiContext()
+		defer cancel()
+		if err := svc.UpdateSettings(ctx, &models.UpdateSettingsParams{PlaytimeSyncEnabled: &value}); err != nil {
+			playtimeSyncEnabled = !value
+			menu.refreshAllItems(menu.GetCurrentItem())
+			log.Warn().Err(err).Msg("error updating play history sync setting")
+			ShowErrorModal(pages, app, "Failed to save play history sync setting", func() {
+				app.SetFocus(menu.List)
+			})
+		}
+	})
 	cloudDesc := "Create, restore, and schedule cloud backups of this device"
 	if !status.Remote.Linked {
 		cloudDesc = "Keep this device backed up to the cloud — included with Zaparoo Warp"

--- a/pkg/ui/tui/online_test.go
+++ b/pkg/ui/tui/online_test.go
@@ -32,7 +32,11 @@ import (
 )
 
 func onlineTestSettings(baseURL string) *models.SettingsResponse {
-	return &models.SettingsResponse{BackupRemoteBaseURL: &baseURL}
+	playtimeSyncEnabled := true
+	return &models.SettingsResponse{
+		BackupRemoteBaseURL: &baseURL,
+		PlaytimeSyncEnabled: &playtimeSyncEnabled,
+	}
 }
 
 func TestOnlineServerHost(t *testing.T) {
@@ -62,6 +66,7 @@ func TestBuildOnlineSettingsMenu_NotLinkedShowsLinkAction_Integration(t *testing
 
 	require.True(t, runner.WaitForText("Link account", 100*time.Millisecond))
 	assert.True(t, runner.ContainsText("Not linked"), "link status shows on the menu line")
+	assert.True(t, runner.ContainsText("Play history sync"), "sync consent is configurable before linking")
 	assert.True(t, runner.ContainsText("Cloud backup"), "features are discoverable while unlinked")
 	assert.False(t, runner.ContainsText("Unlink account"))
 	assert.False(t, runner.ContainsText("Warp:"), "Warp status is hidden until an account is linked")
@@ -86,9 +91,47 @@ func TestBuildOnlineSettingsMenu_LinkedShowsAccountControls_Integration(t *testi
 	require.True(t, runner.WaitForText("Account", 100*time.Millisecond))
 	assert.True(t, runner.ContainsText("Linked"), "link status shows on the menu line")
 	assert.True(t, runner.ContainsText("Warp"), "Warp subscription status shows on the menu line")
+	assert.True(t, runner.ContainsText("Play history sync"))
 	assert.True(t, runner.ContainsText("Cloud backup"))
 	assert.True(t, runner.ContainsText("Unlink account"))
 	assert.False(t, runner.ContainsText("Link account"))
+}
+
+func TestBuildOnlineSettingsMenu_PlayHistoryToggleUpdatesConsent_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+	pages := tview.NewPages()
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetBackupStatus(backupTestStatus(true))
+	mockSvc.SetupGetSettings(onlineTestSettings(config.DefaultBackupRemoteBaseURL))
+	mockSvc.SetupUpdateSettingsSuccess()
+
+	runner.Start(pages)
+	runner.QueueUpdateDraw(func() {
+		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
+	})
+	require.True(t, runner.WaitForText("Play history sync", 100*time.Millisecond))
+
+	// Account, Warp, Unlink account, then Play history sync.
+	runner.SimulateArrowDown()
+	runner.SimulateArrowDown()
+	runner.SimulateArrowDown()
+	runner.SimulateEnter()
+
+	require.True(t, runner.WaitForCondition(func() bool {
+		for _, call := range mockSvc.Calls {
+			if call.Method != "UpdateSettings" {
+				continue
+			}
+			params, ok := call.Arguments.Get(1).(*models.UpdateSettingsParams)
+			if ok && params.PlaytimeSyncEnabled != nil && !*params.PlaytimeSyncEnabled {
+				return true
+			}
+		}
+		return false
+	}, 100*time.Millisecond), "toggle should disable playtime sync consent")
 }
 
 func TestBuildOnlineSettingsMenu_LinkedShowsDeviceName_Integration(t *testing.T) {
@@ -185,7 +228,8 @@ func TestBuildOnlineSettingsMenu_CloudBackupNavigatesToBackupPage_Integration(t 
 	})
 	require.True(t, runner.WaitForText("Cloud backup", 100*time.Millisecond))
 
-	// Account row, Warp row, Unlink account, then Cloud backup in Features.
+	// Account, Warp, Unlink account, Play history sync, then Cloud backup.
+	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()


### PR DESCRIPTION
## Summary

- add explicit user consent for uploading play history to a linked online account
- derive stable media identities with disambiguating tags and persist sync metadata
- upload sessions incrementally using server watermarks and idempotent batches
- run sync through the existing online scheduler and expose its setting through the API and TUI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Play history sync** consent setting for eligible local/administrator sessions, with an online settings toggle and linked/unlinked guidance.
  * Play history sync runs on a schedule, uploads in batches, resumes using a server watermark, and stops immediately if consent is revoked.
  * Media favorites and launcher overrides now preserve scanner-derived **media name and tags** for more consistent identity.
* **Improvements**
  * History cleanup can protect unsynced play-history entries when sync is enabled.
  * Updated remote-backup relink messaging to reference the device’s online account credentials.
* **Documentation**
  * Updated API docs for `playtimeSyncEnabled` and clarified `settings.auth.unlink` wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->