### PR TITLE
fix(mister): support unstable RBF core names

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2420,7 +2420,7 @@ Returns `null` on success.
 
 ### settings.reload
 
-Reload settings from the configuration file.
+Reload settings and mappings from disk.
 
 #### Parameters
 
@@ -3591,7 +3591,7 @@ None.
 
 ### launchers.refresh
 
-Refresh the internal launcher cache, forcing a reload of launcher configurations.
+Refresh internal launcher cache, forcing reload of launcher configurations and supported platform launcher dependencies. On MiSTer, this forces an RBF filesystem rescan and rewrites the persisted RBF cache.
 
 #### Parameters
 

--- a/pkg/api/methods/launchers.go
+++ b/pkg/api/methods/launchers.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/rs/zerolog/log"
 )
 
@@ -73,6 +75,17 @@ func HandleLaunchers(env requests.RequestEnv) (any, error) { //nolint:gocritic /
 	return models.LaunchersResponse{Launchers: resp}, nil
 }
 
+func refreshLauncherDependencies(pl platforms.Platform) error {
+	refresher, ok := pl.(platforms.LauncherRefreshProvider)
+	if !ok {
+		return nil
+	}
+	if err := refresher.RefreshLauncherDependencies(); err != nil {
+		return fmt.Errorf("refresh platform launcher dependencies: %w", err)
+	}
+	return nil
+}
+
 func HandleLaunchersRefresh(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use
 	log.Info().Msg("received launchers refresh request")
 
@@ -89,6 +102,10 @@ func HandleLaunchersRefresh(env requests.RequestEnv) (any, error) { //nolint:goc
 		return nil, errors.New("error loading custom launchers")
 	}
 
+	if err = refreshLauncherDependencies(env.Platform); err != nil {
+		log.Error().Err(err).Msg("error refreshing launcher dependencies")
+		return nil, errors.New("error refreshing launcher dependencies")
+	}
 	env.LauncherCache.Refresh(env.Platform, env.Config)
 
 	log.Info().Msg("launcher cache refreshed")

--- a/pkg/api/methods/launchers_test.go
+++ b/pkg/api/methods/launchers_test.go
@@ -21,6 +21,8 @@ package methods
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -34,6 +36,17 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type refreshableMockPlatform struct {
+	*mocks.MockPlatform
+	refreshErr   error
+	refreshCalls int
+}
+
+func (p *refreshableMockPlatform) RefreshLauncherDependencies() error {
+	p.refreshCalls++
+	return p.refreshErr
+}
 
 // TestHandleLaunchersRefresh_ReloadsFromDisk tests that HandleLaunchersRefresh
 // reloads config and custom launcher files from disk before refreshing the cache.
@@ -81,6 +94,72 @@ func TestHandleLaunchersRefresh_ReloadsFromDisk(t *testing.T) {
 
 	// Verify Launchers was called (cache was refreshed)
 	mockPlatform.AssertCalled(t, "Launchers", mock.AnythingOfType("*config.Instance"))
+}
+
+func TestHandleLaunchersRefresh_ForcesPlatformDependencies(t *testing.T) {
+	t.Parallel()
+
+	memFS := helpers.NewMemoryFS()
+	dataDir := filepath.Join(string(filepath.Separator), "data")
+	configDir := filepath.Join(string(filepath.Separator), "config")
+	require.NoError(t, memFS.Fs.MkdirAll(configDir, 0o750))
+	require.NoError(t, memFS.Fs.MkdirAll(filepath.Join(dataDir, config.LaunchersDir), 0o750))
+
+	cfg, err := helpers.NewTestConfig(memFS, configDir)
+	require.NoError(t, err)
+
+	basePlatform := mocks.NewMockPlatform()
+	basePlatform.On("ID").Return("test-platform").Maybe()
+	basePlatform.On("Settings").Return(platforms.Settings{DataDir: dataDir}).Maybe()
+	basePlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "3DO", SystemID: "3DO"},
+	})
+	refreshable := &refreshableMockPlatform{MockPlatform: basePlatform}
+	cache := &corehelpers.LauncherCache{}
+
+	result, err := HandleLaunchersRefresh(requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      refreshable,
+		Config:        cfg,
+		LauncherCache: cache,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, result)
+	assert.Equal(t, 1, refreshable.refreshCalls)
+	require.Len(t, cache.GetAllLaunchers(), 1)
+}
+
+func TestHandleLaunchersRefresh_PropagatesPlatformRefreshError(t *testing.T) {
+	t.Parallel()
+
+	memFS := helpers.NewMemoryFS()
+	dataDir := filepath.Join(string(filepath.Separator), "data")
+	configDir := filepath.Join(string(filepath.Separator), "config")
+	require.NoError(t, memFS.Fs.MkdirAll(configDir, 0o750))
+	require.NoError(t, memFS.Fs.MkdirAll(filepath.Join(dataDir, config.LaunchersDir), 0o750))
+
+	cfg, err := helpers.NewTestConfig(memFS, configDir)
+	require.NoError(t, err)
+
+	basePlatform := mocks.NewMockPlatform()
+	basePlatform.On("ID").Return("test-platform").Maybe()
+	basePlatform.On("Settings").Return(platforms.Settings{DataDir: dataDir}).Maybe()
+	refreshable := &refreshableMockPlatform{
+		MockPlatform: basePlatform,
+		refreshErr:   errors.New("RBF scan failed"),
+	}
+	cache := &corehelpers.LauncherCache{}
+
+	result, err := HandleLaunchersRefresh(requests.RequestEnv{
+		Context:       context.Background(),
+		Platform:      refreshable,
+		Config:        cfg,
+		LauncherCache: cache,
+	})
+	require.ErrorContains(t, err, "error refreshing launcher dependencies")
+	assert.Nil(t, result)
+	assert.Equal(t, 1, refreshable.refreshCalls)
+	assert.Empty(t, cache.GetAllLaunchers())
 }
 
 // TestHandleLaunchersRefresh_CacheUpdatesOnSecondCall tests that the cache

--- a/pkg/api/methods/settings.go
+++ b/pkg/api/methods/settings.go
@@ -112,15 +112,6 @@ func HandleSettingsReload(env requests.RequestEnv) (any, error) {
 		return nil, errors.New("error loading mappings")
 	}
 
-	launchersDir := filepath.Join(helpers.DataDir(env.Platform), config.LaunchersDir)
-	err = env.Config.LoadCustomLaunchers(launchersDir)
-	if err != nil {
-		log.Error().Err(err).Msg("error loading custom launchers")
-		return nil, errors.New("error loading custom launchers")
-	}
-
-	env.LauncherCache.Refresh(env.Platform, env.Config)
-
 	if env.Player != nil {
 		env.Player.ClearFileCache()
 		env.Player.SetVolume(float64(env.Config.AudioVolume()) / 100.0)

--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -942,48 +942,33 @@ func TestHandleSettingsUpdate_AudioVolume(t *testing.T) {
 	mockPlayer.AssertCalled(t, "SetVolume", 0.5)
 }
 
-// TestHandleSettingsReload_RefreshesLauncherCache tests that HandleSettingsReload
-// refreshes the launcher cache after reloading config and custom launcher files.
-func TestHandleSettingsReload_RefreshesLauncherCache(t *testing.T) {
+func TestHandleSettingsReload_DoesNotRefreshLaunchers(t *testing.T) {
 	t.Parallel()
 
-	// Set up in-memory filesystem with required directories
 	memFS := helpers.NewMemoryFS()
 	dataDir := "/data"
 	configDir := "/config"
 	require.NoError(t, memFS.Fs.MkdirAll(configDir, 0o750))
 	require.NoError(t, memFS.Fs.MkdirAll(dataDir+"/"+config.MappingsDir, 0o750))
-	require.NoError(t, memFS.Fs.MkdirAll(dataDir+"/"+config.LaunchersDir, 0o750))
 
 	cfg, err := helpers.NewTestConfig(memFS, configDir)
 	require.NoError(t, err)
 
-	expectedLaunchers := []platforms.Launcher{
-		{ID: "test-launcher", SystemID: "NES"},
-	}
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test-platform").Maybe()
 	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: dataDir}).Maybe()
-	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(expectedLaunchers).Maybe()
-
-	testCache := &corehelpers.LauncherCache{}
-	assert.Empty(t, testCache.GetAllLaunchers())
+	refreshable := &refreshableMockPlatform{MockPlatform: mockPlatform}
 
 	env := requests.RequestEnv{
-		Context:       context.Background(),
-		Platform:      mockPlatform,
-		Config:        cfg,
-		LauncherCache: testCache,
+		Context:  context.Background(),
+		Platform: refreshable,
+		Config:   cfg,
 	}
 
 	result, err := HandleSettingsReload(env)
 	require.NoError(t, err)
 	assert.Equal(t, NoContent{}, result)
-
-	cached := testCache.GetAllLaunchers()
-	require.Len(t, cached, 1)
-	assert.Equal(t, "test-launcher", cached[0].ID)
-	assert.Equal(t, "NES", cached[0].SystemID)
+	assert.Zero(t, refreshable.refreshCalls)
 
 	mockPlatform.AssertExpectations(t)
 }

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -62,6 +62,27 @@ func TestHandleSystems_IncludesIndexedAndAvailableLauncherSystems(t *testing.T) 
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleSystems_IncludesUnindexedAvailable3DO(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{{ID: "3DO", SystemID: "3DO"}})
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
+	})
+	require.NoError(t, err)
+
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []string{"3DO"}, systemResponseIDs(response))
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleSystems_AllIncludesUnavailableLauncherSystems(t *testing.T) {
 	mockMediaDB := testhelpers.NewMockMediaDBI()
 	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -42,6 +42,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type reloadAPICaller func(
+	ctx context.Context,
+	cfg *config.Instance,
+	method string,
+	params string,
+) (string, error)
+
 type Flags struct {
 	Write                *string
 	Read                 *bool
@@ -103,7 +110,7 @@ func SetupFlags() *Flags {
 		Reload: flag.Bool(
 			"reload",
 			false,
-			"reload config and mappings from disk",
+			"reload config, mappings, launchers, and platform launcher data",
 		),
 		Pair: flag.Bool(
 			"pair",
@@ -174,6 +181,16 @@ func logClientCommandError(err error, msg string) {
 		return
 	}
 	log.Error().Err(err).Msg(msg)
+}
+
+func reloadCore(ctx context.Context, cfg *config.Instance, call reloadAPICaller) error {
+	if _, err := call(ctx, cfg, models.MethodSettingsReload, ""); err != nil {
+		return fmt.Errorf("reload settings: %w", err)
+	}
+	if _, err := call(ctx, cfg, models.MethodLaunchersRefresh, ""); err != nil {
+		return fmt.Errorf("refresh launchers: %w", err)
+	}
+	return nil
 }
 
 func runFlag(cfg *config.Instance, value string) {
@@ -373,9 +390,9 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 			sanitizeForOutput(*f.ProfileResetSwitchID), sanitizeForOutput(switchID))
 		os.Exit(0)
 	case *f.Reload:
-		_, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsReload, "")
+		err := reloadCore(context.Background(), cfg, client.LocalClient)
 		if err != nil {
-			logClientCommandError(err, "error reloading settings")
+			logClientCommandError(err, "error reloading Core")
 			_, _ = fmt.Fprintf(os.Stderr, "Error reloading: %v\n", err)
 			os.Exit(1)
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -21,15 +21,75 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"syscall"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestReloadCore(t *testing.T) {
+	t.Parallel()
+
+	var methods []string
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		methods = append(methods, method)
+		return "", nil
+	}
+
+	require.NoError(t, reloadCore(context.Background(), nil, call))
+	assert.Equal(t, []string{models.MethodSettingsReload, models.MethodLaunchersRefresh}, methods)
+}
+
+func TestReloadCore_StopsAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		failed      string
+		errContains string
+		expected    []string
+	}{
+		{
+			name:        "settings reload",
+			failed:      models.MethodSettingsReload,
+			expected:    []string{models.MethodSettingsReload},
+			errContains: "reload settings",
+		},
+		{
+			name:        "launcher refresh",
+			failed:      models.MethodLaunchersRefresh,
+			expected:    []string{models.MethodSettingsReload, models.MethodLaunchersRefresh},
+			errContains: "refresh launchers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var methods []string
+			call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+				methods = append(methods, method)
+				if method == tt.failed {
+					return "", errors.New("request failed")
+				}
+				return "", nil
+			}
+
+			err := reloadCore(context.Background(), nil, call)
+			require.ErrorContains(t, err, tt.errContains)
+			assert.Equal(t, tt.expected, methods)
+		})
+	}
+}
 
 func TestLogClientCommandError(t *testing.T) {
 	tests := []struct {

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -257,6 +257,15 @@ func (p *Platform) RootDirs(cfg *config.Instance) []string {
 	return result
 }
 
+// RefreshLauncherDependencies invalidates external EmulationStation config so
+// the following launcher rebuild reparses current system paths and extensions.
+func (p *Platform) RefreshLauncherDependencies() error {
+	p.esConfigMu.Lock()
+	defer p.esConfigMu.Unlock()
+	p.esConfigCache = nil
+	return nil
+}
+
 // getESConfig returns cached ES system config, parsing it on first access.
 func (p *Platform) getESConfig() *ESSystemConfig {
 	p.esConfigMu.RLock()

--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -1200,6 +1200,22 @@ func TestRootDirs_AlwaysIncludesDefaultPath(t *testing.T) {
 	assert.Contains(t, roots, "/userdata/roms", "default ROM path must always be included")
 }
 
+func TestRefreshLauncherDependencies_InvalidatesESConfig(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{
+		esConfigCache: &ESSystemConfig{Systems: map[string]ESSystem{
+			"nes": {Name: "nes"},
+		}},
+	}
+	var refresher platforms.LauncherRefreshProvider = platform
+
+	require.NoError(t, refresher.RefreshLauncherDependencies())
+	platform.esConfigMu.RLock()
+	defer platform.esConfigMu.RUnlock()
+	assert.Nil(t, platform.esConfigCache)
+}
+
 // TestRootDirs_IncludesESDiscoveredPaths verifies that paths from ES config
 // are included alongside the default path.
 func TestRootDirs_IncludesESDiscoveredPaths(t *testing.T) {

--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -132,7 +132,19 @@ func (c *RBFCache) Refresh() {
 		return
 	}
 
-	c.scanLocked()
+	if err := c.scanLocked(); err != nil {
+		log.Warn().Err(err).Msg("RBF cache: scan failed, keeping previous cache")
+	}
+}
+
+// ForceRefresh bypasses filesystem fast paths and immediately rebuilds the
+// cache from the live RBF files. A failed scan leaves existing entries intact.
+func (c *RBFCache) ForceRefresh() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.initialized = true
+	return c.scanLocked()
 }
 
 // tryLoadFromDiskLocked attempts to populate the cache from the persisted
@@ -183,59 +195,70 @@ func (c *RBFCache) tryLoadFromDiskLocked() bool {
 
 // scanLocked runs the synchronous SD scan, rebuilds the in-memory maps,
 // and (when persistence is configured) writes the result to disk. Caller
-// must hold c.mu.
-func (c *RBFCache) scanLocked() {
+// must hold c.mu. Failed or unstable scans leave existing entries intact.
+func (c *RBFCache) scanLocked() error {
 	const maxScanAttempts = 2
-	var rbfFiles []RBFInfo
-	var manifest []string
-	stable := false
+	var lastErr error
 	for range maxScanAttempts {
 		beforeManifest, beforeErr := c.snapshotRBFManifest()
-		files, err := shallowScanRBFWithFS(c.filesystem(), c.root())
-		if err != nil {
-			log.Warn().Err(err).Msg("RBF cache: scan failed, using empty cache")
-			c.BuildFromRBFs(nil)
-			c.needsRescan = true
-			return
+		if beforeErr != nil {
+			lastErr = fmt.Errorf("snapshot RBF manifest before scan: %w", beforeErr)
+			continue
 		}
-		rbfFiles = files
-		afterManifest, afterErr := c.snapshotRBFManifest()
-		if beforeErr == nil && afterErr == nil && rbfManifestsMatch(beforeManifest, afterManifest) {
-			manifest = afterManifest
-			stable = true
-			break
-		}
-	}
-	c.BuildFromRBFs(rbfFiles)
-	c.needsRescan = !stable
-	log.Info().
-		Int("rbf_files", len(rbfFiles)).
-		Int("systems_mapped", len(c.bySystemID)).
-		Msg("RBF cache initialized")
 
-	if c.persistPath == "" || !stable {
-		return
+		rbfFiles, err := shallowScanRBFWithFS(c.filesystem(), c.root())
+		if err != nil {
+			c.needsRescan = true
+			return fmt.Errorf("scan RBF files: %w", err)
+		}
+		afterManifest, afterErr := c.snapshotRBFManifest()
+		if afterErr != nil {
+			lastErr = fmt.Errorf("snapshot RBF manifest after scan: %w", afterErr)
+			continue
+		}
+		if !rbfManifestsMatch(beforeManifest, afterManifest) {
+			lastErr = errors.New("RBF manifest changed during scan")
+			continue
+		}
+
+		c.BuildFromRBFs(rbfFiles)
+		c.needsRescan = false
+		log.Info().
+			Int("rbf_files", len(rbfFiles)).
+			Int("systems_mapped", len(c.bySystemID)).
+			Msg("RBF cache initialized")
+
+		if c.persistPath == "" {
+			return nil
+		}
+		snapshot, snapErr := c.snapshotDirMtimes()
+		if snapErr != nil {
+			c.needsRescan = true
+			return fmt.Errorf("snapshot RBF directory mtimes: %w", snapErr)
+		}
+		rootRBFs, rootErr := c.snapshotRootRBFs()
+		if rootErr != nil {
+			c.needsRescan = true
+			return fmt.Errorf("snapshot root RBFs: %w", rootErr)
+		}
+		c.lastDirMtimes = snapshot
+		c.lastRootRBFs = rootRBFs
+		if writeErr := writePersistedRBFCache(c.persistPath, rbfFiles, afterManifest); writeErr != nil {
+			log.Warn().Err(writeErr).Str("path", c.persistPath).Msg("RBF cache: failed to persist")
+			return nil
+		}
+		log.Debug().
+			Int("rbf_files", len(rbfFiles)).
+			Str("path", c.persistPath).
+			Msg("RBF cache persisted to disk")
+		return nil
 	}
-	snapshot, snapErr := c.snapshotDirMtimes()
-	if snapErr != nil {
-		log.Warn().Err(snapErr).Msg("RBF cache: failed to snapshot directory mtimes, skipping persist")
-		return
+
+	c.needsRescan = true
+	if lastErr == nil {
+		lastErr = errors.New("RBF scan did not produce a stable manifest")
 	}
-	rootRBFs, rootErr := c.snapshotRootRBFs()
-	if rootErr != nil {
-		log.Warn().Err(rootErr).Msg("RBF cache: failed to snapshot root RBFs, skipping persist")
-		return
-	}
-	c.lastDirMtimes = snapshot
-	c.lastRootRBFs = rootRBFs
-	if writeErr := writePersistedRBFCache(c.persistPath, rbfFiles, manifest); writeErr != nil {
-		log.Warn().Err(writeErr).Str("path", c.persistPath).Msg("RBF cache: failed to persist")
-		return
-	}
-	log.Debug().
-		Int("rbf_files", len(rbfFiles)).
-		Str("path", c.persistPath).
-		Msg("RBF cache persisted to disk")
+	return lastErr
 }
 
 func (c *RBFCache) filesystem() afero.Fs {
@@ -275,16 +298,40 @@ func (c *RBFCache) snapshotRootRBFs() ([]string, error) {
 	return snapshotRootRBFsWithFS(c.filesystem(), c.root())
 }
 
+func unstableCoreBaseName(shortName string) (string, bool) {
+	const marker = "_unstable_"
+	markerIndex := strings.LastIndex(strings.ToLower(shortName), marker)
+	if markerIndex <= 0 {
+		return "", false
+	}
+
+	parts := strings.Split(shortName[markerIndex+len(marker):], "_")
+	if len(parts) != 2 || !isNDigits(parts[0], 8) || !isHexish(parts[1]) {
+		return "", false
+	}
+	return shortName[:markerIndex], true
+}
+
 // BuildFromRBFs deterministically rebuilds bySystemID and byShortName from a
-// scanned RBF list, preferring each system's canonical directory when multiple
-// RBFs share a short name. No filesystem access; safe to call in tests.
+// scanned RBF list. Exact core names take precedence over standardized
+// unstable-nightly fallbacks. No filesystem access; safe to call in tests.
 func (c *RBFCache) BuildFromRBFs(rbfFiles []RBFInfo) {
 	c.bySystemID = make(map[string]RBFInfo)
 	c.byShortName = make(map[string][]RBFInfo)
+	unstableByBase := make(map[string][]RBFInfo)
 
 	for _, rbf := range rbfFiles {
 		key := strings.ToLower(rbf.ShortName)
 		c.byShortName[key] = append(c.byShortName[key], rbf)
+		if baseName, ok := unstableCoreBaseName(rbf.ShortName); ok {
+			baseKey := strings.ToLower(baseName)
+			unstableByBase[baseKey] = append(unstableByBase[baseKey], rbf)
+		}
+	}
+	for key := range unstableByBase {
+		sort.SliceStable(unstableByBase[key], func(i, j int) bool {
+			return unstableByBase[key][i].ShortName > unstableByBase[key][j].ShortName
+		})
 	}
 
 	for _, system := range Systems {
@@ -292,8 +339,12 @@ func (c *RBFCache) BuildFromRBFs(rbfFiles []RBFInfo) {
 			continue
 		}
 		canonicalDir, shortName := splitRBFPath(system.RBF)
-		candidates := c.byShortName[strings.ToLower(shortName)]
-		if rbf, ok := selectByCanonicalDir(candidates, canonicalDir); ok {
+		key := strings.ToLower(shortName)
+		if rbf, ok := selectByCanonicalDir(c.byShortName[key], canonicalDir); ok {
+			c.bySystemID[system.ID] = rbf
+			continue
+		}
+		if rbf, ok := selectByCanonicalDir(unstableByBase[key], canonicalDir); ok {
 			c.bySystemID[system.ID] = rbf
 		}
 	}

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -605,6 +605,174 @@ func TestBuildFromRBFs_PrefersOriginalWhenForkAlsoExists(t *testing.T) {
 	assert.Equal(t, "_Console/GBA", rbf.MglName)
 }
 
+func TestUnstableCoreBaseName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		shortName string
+		wantBase  string
+		wantOK    bool
+	}{
+		{name: "3DO", shortName: "3DO_unstable_20260715_0995eb", wantBase: "3DO", wantOK: true},
+		{
+			name:      "base with underscore",
+			shortName: "Saturn_DualSDRAM_unstable_20260720_176386",
+			wantBase:  "Saturn_DualSDRAM",
+			wantOK:    true,
+		},
+		{
+			name:      "base with hyphen",
+			shortName: "ZX-Spectrum_unstable_20260713_0746f6",
+			wantBase:  "ZX-Spectrum",
+			wantOK:    true,
+		},
+		{name: "case insensitive marker", shortName: "NES_UNSTABLE_20260720_13773d", wantBase: "NES", wantOK: true},
+		{name: "missing base", shortName: "_unstable_20260715_0995eb"},
+		{name: "invalid date", shortName: "3DO_unstable_2026071_0995eb"},
+		{name: "invalid hash", shortName: "3DO_unstable_20260715_not-hex"},
+		{name: "missing hash", shortName: "3DO_unstable_20260715_"},
+		{name: "extra suffix", shortName: "3DO_unstable_20260715_0995eb_extra"},
+		{name: "different marker", shortName: "3DO_beta_20260715_0995eb"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base, ok := unstableCoreBaseName(tc.shortName)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantBase, base)
+		})
+	}
+}
+
+func TestBuildFromRBFs_UsesUnstableNightlyFallback(t *testing.T) {
+	t.Parallel()
+
+	unstablePath := filepath.Join("media", "fat", "_Unstable", "3DO_unstable_20260715_0995eb.rbf")
+	unstableMGL := filepath.Join("_Unstable", "3DO_unstable_20260715_0995eb")
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{{
+		Path:      unstablePath,
+		Filename:  filepath.Base(unstablePath),
+		ShortName: "3DO_unstable_20260715_0995eb",
+		MglName:   unstableMGL,
+	}})
+
+	got, err := cache.Resolve(nil, &Core{ID: "3DO", RBF: filepath.Join("_Console", "3DO")})
+	require.NoError(t, err)
+	assert.Equal(t, unstablePath, got.Path)
+	assert.Equal(t, unstableMGL, got.MglName)
+
+	_, exactFound := cache.GetByShortName("3DO")
+	assert.False(t, exactFound, "unstable fallback must not become an exact short-name alias")
+	_, rbfCount := cache.Count()
+	assert.Equal(t, 1, rbfCount)
+}
+
+func TestBuildFromRBFs_PrefersOfficialOverUnstable(t *testing.T) {
+	t.Parallel()
+
+	official := RBFInfo{
+		Path:      filepath.Join("media", "fat", "_Console", "3DO_20260717.rbf"),
+		Filename:  "3DO_20260717.rbf",
+		ShortName: "3DO",
+		MglName:   filepath.Join("_Console", "3DO"),
+	}
+	unstable := RBFInfo{
+		Path:      filepath.Join("media", "fat", "_Unstable", "3DO_unstable_20260715_0995eb.rbf"),
+		Filename:  "3DO_unstable_20260715_0995eb.rbf",
+		ShortName: "3DO_unstable_20260715_0995eb",
+		MglName:   filepath.Join("_Unstable", "3DO_unstable_20260715_0995eb"),
+	}
+
+	for _, files := range [][]RBFInfo{{unstable, official}, {official, unstable}} {
+		cache := &RBFCache{}
+		cache.BuildFromRBFs(files)
+		got, ok := cache.GetBySystemID("3DO")
+		require.True(t, ok)
+		assert.Equal(t, official.Path, got.Path)
+	}
+}
+
+func TestBuildFromRBFs_SelectsNewestUnstableNightly(t *testing.T) {
+	t.Parallel()
+
+	older := RBFInfo{
+		Path:      filepath.Join("media", "fat", "_Unstable", "3DO_unstable_20260714_ffffff.rbf"),
+		Filename:  "3DO_unstable_20260714_ffffff.rbf",
+		ShortName: "3DO_unstable_20260714_ffffff",
+		MglName:   filepath.Join("_Unstable", "3DO_unstable_20260714_ffffff"),
+	}
+	newer := RBFInfo{
+		Path:      filepath.Join("media", "fat", "_Unstable", "3DO_unstable_20260715_000001.rbf"),
+		Filename:  "3DO_unstable_20260715_000001.rbf",
+		ShortName: "3DO_unstable_20260715_000001",
+		MglName:   filepath.Join("_Unstable", "3DO_unstable_20260715_000001"),
+	}
+
+	for _, files := range [][]RBFInfo{{older, newer}, {newer, older}} {
+		cache := &RBFCache{}
+		cache.BuildFromRBFs(files)
+		got, ok := cache.GetBySystemID("3DO")
+		require.True(t, ok)
+		assert.Equal(t, newer.Path, got.Path)
+	}
+}
+
+func TestRBFCache_ForceRefreshBypassesFastPath(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := filepath.Join("media", "fat")
+	consoleDir := filepath.Join(root, "_Console")
+	require.NoError(t, fs.MkdirAll(consoleDir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(consoleDir, "NES_20260701.rbf"), nil, 0o600))
+
+	cache := &RBFCache{fs: fs, sdRoot: root}
+	cache.Refresh()
+	_, found := cache.GetBySystemID("NES")
+	require.True(t, found)
+
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(consoleDir, "3DO_20260717.rbf"), nil, 0o600))
+	var err error
+	cache.lastDirMtimes, err = snapshotDirMtimesWithFS(fs, root)
+	require.NoError(t, err)
+	cache.lastRootRBFs, err = snapshotRootRBFsWithFS(fs, root)
+	require.NoError(t, err)
+
+	cache.Refresh()
+	_, found = cache.GetBySystemID("3DO")
+	assert.False(t, found, "normal refresh should use unchanged-snapshot fast path")
+
+	require.NoError(t, cache.ForceRefresh())
+	got, found := cache.GetBySystemID("3DO")
+	require.True(t, found)
+	assert.Equal(t, filepath.Join("_Console", "3DO"), got.MglName)
+}
+
+func TestRBFCache_ForceRefreshFailurePreservesCache(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{
+		fs:     afero.NewMemMapFs(),
+		sdRoot: filepath.Join("missing", "root"),
+	}
+	existing := RBFInfo{
+		Path:      filepath.Join("media", "fat", "_Console", "NES_20260701.rbf"),
+		Filename:  "NES_20260701.rbf",
+		ShortName: "NES",
+		MglName:   filepath.Join("_Console", "NES"),
+	}
+	cache.BuildFromRBFs([]RBFInfo{existing})
+
+	require.Error(t, cache.ForceRefresh())
+	got, found := cache.GetBySystemID("NES")
+	require.True(t, found)
+	assert.Equal(t, existing, got)
+	assert.True(t, cache.NeedsRescan())
+}
+
 func TestGetByLauncherID_GlobRegisteredAltCore(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/cores/rbfs_test.go
+++ b/pkg/platforms/mister/cores/rbfs_test.go
@@ -48,6 +48,12 @@ func TestParseRBFPath_StripsOnlyOfficialDateSuffix(t *testing.T) {
 			wantMglName:   filepath.Join("_Console", "GBA"),
 		},
 		{
+			name:          "official 3DO release",
+			relPath:       filepath.Join("_Console", "3DO_20260717.rbf"),
+			wantShortName: "3DO",
+			wantMglName:   filepath.Join("_Console", "3DO"),
+		},
+		{
 			name:          "underscore core strips date only",
 			relPath:       filepath.Join("_Console", "Saturn_DS_20230410.rbf"),
 			wantShortName: "Saturn_DS",

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1328,6 +1328,15 @@ func amigaVisionMGLScanResults(installPath string, mglPaths []string) []platform
 	return results
 }
 
+func (p *Platform) RefreshLauncherDependencies() error {
+	cores.GlobalRBFCache.SetFilesystem(p.filesystem())
+	cores.GlobalRBFCache.SetPersistPath(filepath.Join(helpers.DataDir(p), config.CacheDir, cores.RBFCacheFileName))
+	if err := cores.GlobalRBFCache.ForceRefresh(); err != nil {
+		return fmt.Errorf("force refresh RBF cache: %w", err)
+	}
+	return nil
+}
+
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	// Launchers is invoked from many hot paths (token scans, RPC handlers,
 	// indexing). The Refresh fast path stats only the snapshot directories

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -71,6 +71,12 @@ type amigaVisionVirtualPath struct {
 	GameName    string
 }
 
+type launcherRBFCache interface {
+	SetFilesystem(afero.Fs)
+	SetPersistPath(string)
+	ForceRefresh() error
+}
+
 var (
 	amigaVisionListings = []amigaVisionListing{
 		{Path: amigaVisionGamesListing, BrowseDir: amigaVisionGamesBrowseDir},
@@ -112,6 +118,7 @@ type Platform struct {
 	launchShortCore     func(string) error
 	launchBasicFile     func(string) error
 	closeConsole        func() error
+	launcherRBFCache    launcherRBFCache
 	lastLauncher        platforms.Launcher
 	arcadeCardLaunch    arcadeCardLaunchCache
 	stopIntent          platforms.StopIntent
@@ -1329,9 +1336,13 @@ func amigaVisionMGLScanResults(installPath string, mglPaths []string) []platform
 }
 
 func (p *Platform) RefreshLauncherDependencies() error {
-	cores.GlobalRBFCache.SetFilesystem(p.filesystem())
-	cores.GlobalRBFCache.SetPersistPath(filepath.Join(helpers.DataDir(p), config.CacheDir, cores.RBFCacheFileName))
-	if err := cores.GlobalRBFCache.ForceRefresh(); err != nil {
+	cache := p.launcherRBFCache
+	if cache == nil {
+		cache = cores.GlobalRBFCache
+	}
+	cache.SetFilesystem(p.filesystem())
+	cache.SetPersistPath(filepath.Join(helpers.DataDir(p), config.CacheDir, cores.RBFCacheFileName))
+	if err := cache.ForceRefresh(); err != nil {
 		return fmt.Errorf("force refresh RBF cache: %w", err)
 	}
 	return nil

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -47,6 +47,8 @@ import (
 // mockLauncherManager is a minimal mock for testing
 type mockLauncherManager struct{}
 
+// recordingLauncherRBFCache stays local because shared test helpers have no
+// MiSTer RBF cache double with call-order recording and configurable refresh errors.
 type recordingLauncherRBFCache struct {
 	fs          afero.Fs
 	forceErr    error
@@ -78,7 +80,21 @@ func (*mockLauncherManager) NewContext() context.Context {
 }
 
 func TestRefreshLauncherDependencies(t *testing.T) {
-	t.Parallel()
+	t.Run("global cache fallback", func(t *testing.T) {
+		// Keep this subtest sequential while replacing the package singleton.
+		oldCache := cores.GlobalRBFCache
+		cache := &cores.RBFCache{}
+		cores.GlobalRBFCache = cache
+		defer func() { cores.GlobalRBFCache = oldCache }()
+
+		platform := &Platform{fs: afero.NewMemMapFs()}
+		require.Nil(t, platform.launcherRBFCache)
+		var refresher platforms.LauncherRefreshProvider = platform
+
+		err := refresher.RefreshLauncherDependencies()
+		require.ErrorIs(t, err, os.ErrNotExist)
+		assert.True(t, cache.NeedsRescan())
+	})
 
 	refreshErr := errors.New("refresh failed")
 	tests := []struct {

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -35,8 +35,11 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,12 +47,71 @@ import (
 // mockLauncherManager is a minimal mock for testing
 type mockLauncherManager struct{}
 
+type recordingLauncherRBFCache struct {
+	fs          afero.Fs
+	forceErr    error
+	persistPath string
+	calls       []string
+}
+
+func (c *recordingLauncherRBFCache) SetFilesystem(fs afero.Fs) {
+	c.calls = append(c.calls, "filesystem")
+	c.fs = fs
+}
+
+func (c *recordingLauncherRBFCache) SetPersistPath(path string) {
+	c.calls = append(c.calls, "persist")
+	c.persistPath = path
+}
+
+func (c *recordingLauncherRBFCache) ForceRefresh() error {
+	c.calls = append(c.calls, "refresh")
+	return c.forceErr
+}
+
 func (*mockLauncherManager) GetContext() context.Context {
 	return context.Background()
 }
 
 func (*mockLauncherManager) NewContext() context.Context {
 	return context.Background()
+}
+
+func TestRefreshLauncherDependencies(t *testing.T) {
+	t.Parallel()
+
+	refreshErr := errors.New("refresh failed")
+	tests := []struct {
+		forceErr error
+		name     string
+	}{
+		{name: "success"},
+		{name: "refresh error", forceErr: refreshErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := afero.NewMemMapFs()
+			cache := &recordingLauncherRBFCache{forceErr: tt.forceErr}
+			platform := &Platform{fs: fs, launcherRBFCache: cache}
+			var refresher platforms.LauncherRefreshProvider = platform
+
+			err := refresher.RefreshLauncherDependencies()
+			if tt.forceErr != nil {
+				require.ErrorIs(t, err, tt.forceErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Same(t, fs, cache.fs)
+			assert.Equal(t,
+				filepath.Join(helpers.DataDir(platform), config.CacheDir, cores.RBFCacheFileName),
+				cache.persistPath,
+			)
+			assert.Equal(t, []string{"filesystem", "persist", "refresh"}, cache.calls)
+		})
+	}
 }
 
 func TestConfigureTLSRootFallback_ConfiguresDefaultsAndCustomTransports(t *testing.T) {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -405,6 +405,12 @@ type Scraper struct {
 	SupportedSystemIDs []string
 }
 
+// LauncherRefreshProvider is optionally implemented by platforms that cache
+// runtime launcher dependencies and can force their rediscovery.
+type LauncherRefreshProvider interface {
+	RefreshLauncherDependencies() error
+}
+
 // TrackedProcessWaiter is optionally implemented by platforms that coordinate
 // process waiting with StopActiveLauncher. Exactly one caller must reap a process.
 type TrackedProcessWaiter interface {

--- a/pkg/ui/tui/mock_api_client_test.go
+++ b/pkg/ui/tui/mock_api_client_test.go
@@ -88,6 +88,11 @@ func (m *MockSettingsService) UpdateSettings(ctx context.Context, params *models
 	return args.Error(0) //nolint:wrapcheck // mock returns test-provided errors
 }
 
+func (m *MockSettingsService) ReloadCore(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0) //nolint:wrapcheck // mock returns test-provided errors
+}
+
 func (m *MockSettingsService) CreateBackup(ctx context.Context) (string, error) {
 	args := m.Called(ctx)
 	return args.String(0), args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
@@ -224,6 +229,10 @@ func (m *MockSettingsService) SetupUpdateSettingsSuccess() {
 // SetupUpdateSettingsError configures the mock to return an error on update.
 func (m *MockSettingsService) SetupUpdateSettingsError(err error) {
 	m.On("UpdateSettings", mock.Anything, mock.Anything).Return(err)
+}
+
+func (m *MockSettingsService) SetupReloadCore(err error) {
+	m.On("ReloadCore", mock.Anything).Return(err)
 }
 
 func (m *MockSettingsService) SetupGetBackupStatus(status *models.BackupStatusResponse) {

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -1655,6 +1655,23 @@ func buildAdvancedSettingsMenu(svc SettingsService, pages *tview.Pages, app *tvi
 		buildIgnoreSystemsPage(svc, pages, app)
 	})
 
+	menu.AddAction("Reload Core", "Reload settings, mappings, and launcher configuration", func() {
+		reloadCtx, reloadCancel := tuiContext()
+		err := svc.ReloadCore(reloadCtx)
+		reloadCancel()
+		if err != nil {
+			log.Warn().Err(err).Msg("error reloading Core")
+			ShowErrorModal(pages, app, "Failed to reload Core", func() {
+				app.SetFocus(menu.List)
+			})
+			return
+		}
+		ShowInfoModal(
+			pages, app, "Core reloaded", "Settings, mappings, and launcher configuration reloaded.",
+			func() { app.SetFocus(menu.List) },
+		)
+	})
+
 	menu.AddToggle("Debug logging", "Enable verbose debug output", &debugLogging, func(value bool) {
 		ctx, cancel := tuiContext()
 		defer cancel()

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -1657,19 +1657,23 @@ func buildAdvancedSettingsMenu(svc SettingsService, pages *tview.Pages, app *tvi
 
 	menu.AddAction("Reload Core", "Reload settings, mappings, and launcher configuration", func() {
 		reloadCtx, reloadCancel := tuiContext()
-		err := svc.ReloadCore(reloadCtx)
-		reloadCancel()
-		if err != nil {
-			log.Warn().Err(err).Msg("error reloading Core")
-			ShowErrorModal(pages, app, "Failed to reload Core", func() {
-				app.SetFocus(menu.List)
+		go func() {
+			err := svc.ReloadCore(reloadCtx)
+			reloadCancel()
+			app.QueueUpdateDraw(func() {
+				if err != nil {
+					log.Warn().Err(err).Msg("error reloading Core")
+					ShowErrorModal(pages, app, "Failed to reload Core", func() {
+						app.SetFocus(menu.List)
+					})
+					return
+				}
+				ShowInfoModal(
+					pages, app, "Core reloaded", "Settings, mappings, and launcher configuration reloaded.",
+					func() { app.SetFocus(menu.List) },
+				)
 			})
-			return
-		}
-		ShowInfoModal(
-			pages, app, "Core reloaded", "Settings, mappings, and launcher configuration reloaded.",
-			func() { app.SetFocus(menu.List) },
-		)
+		}()
 	})
 
 	menu.AddToggle("Debug logging", "Enable verbose debug output", &debugLogging, func(value bool) {

--- a/pkg/ui/tui/settings_api_test.go
+++ b/pkg/ui/tui/settings_api_test.go
@@ -110,6 +110,48 @@ func TestDefaultSettingsService_UpdateSettings_Error(t *testing.T) {
 	mockClient.AssertExpectations(t)
 }
 
+func TestDefaultSettingsService_ReloadCore(t *testing.T) {
+	t.Parallel()
+
+	mockClient := mocks.NewMockAPIClient()
+	settingsCall := mockClient.On("Call", testifymock.Anything, models.MethodSettingsReload, "").
+		Return(`{}`, nil).Once()
+	mockClient.On("Call", testifymock.Anything, models.MethodLaunchersRefresh, "").
+		Return(`{}`, nil).Once().NotBefore(settingsCall)
+
+	svc := NewSettingsService(mockClient)
+	require.NoError(t, svc.ReloadCore(context.Background()))
+	mockClient.AssertExpectations(t)
+}
+
+func TestDefaultSettingsService_ReloadCoreSettingsError(t *testing.T) {
+	t.Parallel()
+
+	mockClient := mocks.NewMockAPIClient()
+	mockClient.On("Call", testifymock.Anything, models.MethodSettingsReload, "").
+		Return("", errors.New("reload failed")).Once()
+
+	svc := NewSettingsService(mockClient)
+	err := svc.ReloadCore(context.Background())
+	require.ErrorContains(t, err, "failed to reload settings")
+	mockClient.AssertExpectations(t)
+}
+
+func TestDefaultSettingsService_ReloadCoreLaunchersError(t *testing.T) {
+	t.Parallel()
+
+	mockClient := mocks.NewMockAPIClient()
+	settingsCall := mockClient.On("Call", testifymock.Anything, models.MethodSettingsReload, "").
+		Return(`{}`, nil).Once()
+	mockClient.On("Call", testifymock.Anything, models.MethodLaunchersRefresh, "").
+		Return("", errors.New("refresh failed")).Once().NotBefore(settingsCall)
+
+	svc := NewSettingsService(mockClient)
+	err := svc.ReloadCore(context.Background())
+	require.ErrorContains(t, err, "failed to refresh launchers")
+	mockClient.AssertExpectations(t)
+}
+
 func TestDefaultSettingsService_LocalBackupAPIContracts(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/ui/tui/settings_service.go
+++ b/pkg/ui/tui/settings_service.go
@@ -67,6 +67,9 @@ type SettingsService interface {
 	// UpdateSettings sends a settings update to the API.
 	UpdateSettings(ctx context.Context, params *models.UpdateSettingsParams) error
 
+	// ReloadCore reloads settings, mappings, launchers, and platform launcher dependencies.
+	ReloadCore(ctx context.Context) error
+
 	// CreateBackup creates a local backup ZIP.
 	CreateBackup(ctx context.Context) (string, error)
 
@@ -201,6 +204,16 @@ func (s *DefaultSettingsService) UpdateSettings(ctx context.Context, params *mod
 	_, err = s.apiClient.Call(ctx, models.MethodSettingsUpdate, string(data))
 	if err != nil {
 		return fmt.Errorf("failed to update settings: %w", err)
+	}
+	return nil
+}
+
+func (s *DefaultSettingsService) ReloadCore(ctx context.Context) error {
+	if _, err := s.apiClient.Call(ctx, models.MethodSettingsReload, ""); err != nil {
+		return fmt.Errorf("failed to reload settings: %w", err)
+	}
+	if _, err := s.apiClient.Call(ctx, models.MethodLaunchersRefresh, ""); err != nil {
+		return fmt.Errorf("failed to refresh launchers: %w", err)
 	}
 	return nil
 }

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -400,10 +400,59 @@ func TestBuildAdvancedSettingsMenu_Integration(t *testing.T) {
 
 	// Verify menu items
 	assert.True(t, runner.ContainsText("Ignore systems"), "Ignore systems should be visible")
+	assert.True(t, runner.ContainsText("Reload Core"), "Reload Core should be visible")
 	assert.True(t, runner.ContainsText("Debug logging"), "Debug logging should be visible")
 
 	// Verify count indicator (2 systems selected)
 	assert.True(t, runner.ContainsText("2 selected"), "Should show 2 systems selected")
+}
+
+func TestBuildAdvancedSettingsMenu_ReloadCore_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+	pages := tview.NewPages()
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetSettings(defaultTestSettings())
+	mockSvc.SetupReloadCore(nil)
+
+	runner.Start(pages)
+	runner.Draw()
+	runner.QueueUpdateDraw(func() {
+		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
+	})
+	require.True(t, runner.WaitForText("Reload Core", 100*time.Millisecond))
+
+	runner.SimulateArrowDown()
+	runner.SimulateEnter()
+
+	require.True(t, runner.WaitForText("Core reloaded", 100*time.Millisecond))
+	mockSvc.AssertCalled(t, "ReloadCore", mock.Anything)
+}
+
+func TestBuildAdvancedSettingsMenu_ReloadCoreError_Integration(t *testing.T) {
+	t.Parallel()
+
+	runner := NewTestAppRunner(t, 80, 25)
+	defer runner.Stop()
+	pages := tview.NewPages()
+	mockSvc := NewMockSettingsService()
+	mockSvc.SetupGetSettings(defaultTestSettings())
+	mockSvc.SetupReloadCore(errors.New("reload failed"))
+
+	runner.Start(pages)
+	runner.Draw()
+	runner.QueueUpdateDraw(func() {
+		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
+	})
+	require.True(t, runner.WaitForText("Reload Core", 100*time.Millisecond))
+
+	runner.SimulateArrowDown()
+	runner.SimulateEnter()
+
+	require.True(t, runner.WaitForText("Failed to reload Core", 100*time.Millisecond))
+	mockSvc.AssertCalled(t, "ReloadCore", mock.Anything)
 }
 
 func TestBuildAdvancedSettingsMenu_ToggleDebugLogging_Integration(t *testing.T) {
@@ -429,7 +478,8 @@ func TestBuildAdvancedSettingsMenu_ToggleDebugLogging_Integration(t *testing.T) 
 
 	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
 
-	// Navigate to debug logging (second item)
+	// Navigate to debug logging (third item)
+	runner.Screen().InjectArrowDown()
 	runner.Screen().InjectArrowDown()
 	runner.Draw()
 
@@ -1193,7 +1243,8 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingShowsConfirmModal_Integration(t
 
 	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
 
-	// Navigate to error reporting (third item: ignore systems, debug logging, error reporting)
+	// Navigate to error reporting (fourth item)
+	runner.SimulateArrowDown() // to reload Core
 	runner.SimulateArrowDown() // to debug logging
 	runner.SimulateArrowDown() // to error reporting
 
@@ -1229,6 +1280,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingCancelDoesNotEnable_Integration
 	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
 
 	// Navigate to error reporting
+	runner.SimulateArrowDown() // to reload Core
 	runner.SimulateArrowDown() // to debug logging
 	runner.SimulateArrowDown() // to error reporting
 
@@ -1272,6 +1324,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingConfirmEnables_Integration(t *t
 	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
 
 	// Navigate to error reporting
+	runner.SimulateArrowDown() // to reload Core
 	runner.SimulateArrowDown() // to debug logging
 	runner.SimulateArrowDown() // to error reporting
 
@@ -1316,6 +1369,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingDisableNoConfirm_Integration(t 
 	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
 
 	// Navigate to error reporting
+	runner.SimulateArrowDown() // to reload Core
 	runner.SimulateArrowDown() // to debug logging
 	runner.SimulateArrowDown() // to error reporting
 

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -415,7 +415,20 @@ func TestBuildAdvancedSettingsMenu_ReloadCore_Integration(t *testing.T) {
 	pages := tview.NewPages()
 	mockSvc := NewMockSettingsService()
 	mockSvc.SetupGetSettings(defaultTestSettings())
-	mockSvc.SetupReloadCore(nil)
+	reloadStarted := make(chan struct{})
+	releaseReload := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseReload)
+		}
+	}()
+	mockSvc.On("ReloadCore", mock.Anything).
+		Run(func(_ mock.Arguments) {
+			close(reloadStarted)
+			<-releaseReload
+		}).
+		Return(nil)
 
 	runner.Start(pages)
 	runner.Draw()
@@ -425,7 +438,33 @@ func TestBuildAdvancedSettingsMenu_ReloadCore_Integration(t *testing.T) {
 	require.True(t, runner.WaitForText("Reload Core", 100*time.Millisecond))
 
 	runner.SimulateArrowDown()
-	runner.SimulateEnter()
+	enterDone := make(chan struct{})
+	go func() {
+		runner.SimulateEnter()
+		close(enterDone)
+	}()
+
+	select {
+	case <-reloadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("reload did not start")
+	}
+	uiResponsive := make(chan struct{})
+	go func() {
+		runner.QueueUpdateDraw(func() { close(uiResponsive) })
+	}()
+	select {
+	case <-uiResponsive:
+	case <-time.After(time.Second):
+		t.Fatal("reload blocked TUI event loop")
+	}
+	close(releaseReload)
+	released = true
+	select {
+	case <-enterDone:
+	case <-time.After(time.Second):
+		t.Fatal("reload action did not return")
+	}
 
 	require.True(t, runner.WaitForText("Core reloaded", 100*time.Millisecond))
 	mockSvc.AssertCalled(t, "ReloadCore", mock.Anything)


### PR DESCRIPTION
## Summary

- recognize standardized MiSTer unstable-nightly RBF names as fallback while preserving official-core and explicit launcher precedence
- make launcher refresh force supported platform dependency discovery, including MiSTer RBF and Batocera system caches
- expose combined settings and launcher reload through CLI and TUI while keeping API responsibilities separate

Closes #1127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Reload Core** to Advanced Settings, reloading settings/mappings and refreshing launcher dependencies with success/error notifications.
  * Platform-specific launcher refresh support added (e.g., Batocera re-detects current EmulationStation config).
* **Bug Fixes**
  * Settings reload no longer refreshes launcher configuration/cache from disk.
  * MiSTer launcher refresh now triggers an RBF rescan and updates the persisted RBF cache, with improved stable vs unstable nightly selection.
* **Documentation**
  * Updated API docs to reflect settings/mappings reload and the broader MiSTer launcher refresh behavior.
* **Tests**
  * Added/updated coverage for Reload Core, platform dependency refresh, and MiSTer RBF refresh semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->