### PR TITLE
fix(zapscript): avoid random path lookup timeouts

### DIFF
--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -700,6 +700,59 @@ func TestMediaDB_RandomGame_Integration(t *testing.T) {
 	assert.NotZero(t, result2.MediaID)
 }
 
+func TestMediaDB_RandomGameWithQuery_PathPrefixIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	err := mediaDB.BeginTransaction(false)
+	require.NoError(t, err)
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: nesSystem.ID, Name: "NES"})
+	require.NoError(t, err)
+
+	matchingDir := filepath.Join("roms", "nes", "favorites")
+	matchingPath := filepath.Join(matchingDir, "target.nes")
+	outsidePath := filepath.Join("roms", "nes", "other", "outside.nes")
+	paths := []string{matchingPath, outsidePath}
+	var matchingMediaID int64
+	for i, path := range paths {
+		name := fmt.Sprintf("Game %d", i+1)
+		insertedTitle, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(slugs.MediaTypeGame, name),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		insertedMedia, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           path,
+		})
+		require.NoError(t, mediaErr)
+		if path == matchingPath {
+			matchingMediaID = insertedMedia.DBID
+		}
+	}
+
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	result, err := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+		PathPrefix: matchingDir + string(filepath.Separator),
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, nesSystem.ID, result.SystemID)
+	assert.Equal(t, matchingPath, result.Path)
+	assert.Equal(t, matchingMediaID, result.MediaID)
+}
+
 func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -1497,15 +1497,22 @@ func sqlRandomGameWithQueryAndStats(
 	// Use shared helper to build WHERE clause and arguments
 	whereClause, args := buildMediaQueryWhereClause(query)
 
+	// Path-prefix and tag filters reference Media directly. Avoid joining every
+	// matching row to metadata tables unless those tables supply a filter.
+	statsFrom := "FROM Media"
+	if len(query.Systems) > 0 || query.PathGlob != "" {
+		statsFrom = `FROM Media
+		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
+		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID`
+	}
+
 	// Step 1: Get count, min DBID, and max DBID for this query
-	//nolint:gosec // whereClause is built from safe conditions, no user input
+	//nolint:gosec // clauses are selected internally; whereClause contains placeholders
 	statsQuery := fmt.Sprintf(`
 		SELECT COUNT(*), COALESCE(MIN(Media.DBID), 0), COALESCE(MAX(Media.DBID), 0)
-		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
 		%s
-	`, whereClause)
+		%s
+	`, statsFrom, whereClause)
 
 	err := db.QueryRowContext(ctx, statsQuery, args...).Scan(&stats.Count, &stats.MinDBID, &stats.MaxDBID)
 	if err != nil {

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -754,7 +754,9 @@ func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) 
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	const pathPrefix = "/media/fat/_Arcade/_Organized/_Horizontal/"
+	pathPrefix := filepath.ToSlash(filepath.Join(
+		string(filepath.Separator), "media", "fat", "_Arcade", "_Organized", "_Horizontal",
+	)) + "/"
 	mock.ExpectQuery(
 		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), ` +
 			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE Media\.Path LIKE \? ` +

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -747,6 +747,39 @@ func TestSqlSearchMediaBySlugIn_AllEmptySlugs(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	const pathPrefix = "/media/fat/_Arcade/_Organized/_Horizontal/"
+	mock.ExpectQuery(
+		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), ` +
+			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE Media\.Path LIKE \? ` +
+			`AND Media\.IsMissing = 0`,
+	).WithArgs(pathPrefix + "%").WillReturnRows(
+		sqlmock.NewRows([]string{"count", "min", "max"}).AddRow(1, 42, 42),
+	)
+	mock.ExpectQuery(
+		`SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* `+
+			`WHERE Media\.Path LIKE \? AND Media\.IsMissing = 0 AND Media\.DBID >= \?`,
+	).WithArgs(pathPrefix+"%", int64(42)).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
+			AddRow("Arcade", pathPrefix+"game.mra", 42),
+	)
+
+	result, stats, err := sqlRandomGameWithQueryAndStats(context.Background(), db, &database.MediaQuery{
+		PathPrefix: pathPrefix,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, pathPrefix+"game.mra", result.Path)
+	assert.Equal(t, MediaStats{Count: 1, MinDBID: 42, MaxDBID: 42}, stats)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 // Disambiguation behavior is exercised end-to-end against a real database in
 // disambiguation_test.go (RecomputeSystemDisambiguation + attachZapScriptTags),
 // since the logic now lives in stored per-title types rather than in-memory

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -393,8 +393,8 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 			Tags:       tagFilters,
 		}
 		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
-		fallbackToFilesystem := errors.Is(searchErr, sql.ErrNoRows) ||
-			(len(tagFilters) == 0 && errors.Is(searchErr, context.DeadlineExceeded))
+		fallbackToFilesystem := len(tagFilters) == 0 &&
+			(errors.Is(searchErr, sql.ErrNoRows) || errors.Is(searchErr, context.DeadlineExceeded))
 		if fallbackToFilesystem {
 			// Slow indexed lookups should not block direct directory launches.
 			entries, readErr := afero.ReadDir(fs, cleanedPath)

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -331,6 +330,10 @@ func cmdSystem(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 
 //nolint:gocritic // single-use parameter in command handler
 func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	return cmdRandomWithFS(afero.NewOsFs(), pl, &env)
+}
+
+func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) (platforms.CmdResult, error) {
 	if len(env.Cmd.Args) == 0 {
 		return platforms.CmdResult{}, ErrArgCount
 	}
@@ -342,16 +345,16 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	}
 
 	var args zapscript.LaunchRandomArgs
-	if err := ParseAdvArgs(pl, &env, &args); err != nil {
+	if err := ParseAdvArgs(pl, env, &args); err != nil {
 		return platforms.CmdResult{}, fmt.Errorf("invalid advanced arguments: %w", err)
 	}
 
 	explicitLauncher := env.Cmd.AdvArgs.Get(zapscript.KeyLauncher) != ""
-	launch := getLaunchClosure(pl, &env, explicitLauncher)
+	launch := getLaunchClosure(pl, env, explicitLauncher)
 	tagFilters := args.Tags
 
 	gamesdb := env.Database.MediaDB
-	ctx, cancel := mediaDBLookupContext(&env)
+	ctx, cancel := mediaDBLookupContext(env)
 	defer cancel()
 
 	if strings.EqualFold(query, "all") {
@@ -394,7 +397,7 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			(len(tagFilters) == 0 && errors.Is(searchErr, context.DeadlineExceeded))
 		if fallbackToFilesystem {
 			// Slow indexed lookups should not block direct directory launches.
-			entries, readErr := os.ReadDir(cleanedPath)
+			entries, readErr := afero.ReadDir(fs, cleanedPath)
 			if readErr != nil {
 				return platforms.CmdResult{}, fmt.Errorf("failed to read path '%s': %w", cleanedPath, readErr)
 			}

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -390,8 +390,10 @@ func cmdRandom(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 			Tags:       tagFilters,
 		}
 		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
-		if errors.Is(searchErr, sql.ErrNoRows) {
-			// Fallback: pick random file directly from disk for unindexed paths
+		fallbackToFilesystem := errors.Is(searchErr, sql.ErrNoRows) ||
+			(len(tagFilters) == 0 && errors.Is(searchErr, context.DeadlineExceeded))
+		if fallbackToFilesystem {
+			// Slow indexed lookups should not block direct directory launches.
 			entries, readErr := os.ReadDir(cleanedPath)
 			if readErr != nil {
 				return platforms.CmdResult{}, fmt.Errorf("failed to read path '%s': %w", cleanedPath, readErr)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1881,9 +1881,11 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 func TestCmdRandom_AbsolutePathTimeoutFallsBackToFilesystem(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
+	fs := helpers.NewMemoryFS()
+	dir := launchTestAbsPath("games")
+	require.NoError(t, fs.Fs.MkdirAll(dir, 0o750))
 	romPath := filepath.Join(dir, "game.mra")
-	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
+	require.NoError(t, afero.WriteFile(fs.Fs, romPath, []byte("x"), 0o600))
 
 	mockPlatform := mocks.NewMockPlatform()
 	cfg := &config.Instance{}
@@ -1906,7 +1908,7 @@ func TestCmdRandom_AbsolutePathTimeoutFallsBackToFilesystem(t *testing.T) {
 		Database: &database.Database{MediaDB: mockMediaDB},
 	}
 
-	result, err := cmdRandom(mockPlatform, env)
+	result, err := cmdRandomWithFS(fs.Fs, mockPlatform, &env)
 
 	require.NoError(t, err)
 	assert.True(t, result.MediaChanged)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1916,35 +1916,49 @@ func TestCmdRandom_AbsolutePathTimeoutFallsBackToFilesystem(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
-func TestCmdRandom_AbsolutePathTimeoutWithTagsDoesNotFallback(t *testing.T) {
+func TestCmdRandom_AbsolutePathDatabaseMissWithTagsDoesNotFallback(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	mockPlatform := mocks.NewMockPlatform()
-	cfg := &config.Instance{}
-	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
-
-	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
-		Return(database.SearchResult{}, context.DeadlineExceeded)
-
-	env := platforms.CmdEnv{
-		Cmd: zapscript.Command{
-			Name: "launch.random",
-			Args: []string{dir},
-			AdvArgs: zapscript.NewAdvArgs(map[string]string{
-				string(zapscript.KeyTags): "genre:shmup",
-			}),
-		},
-		Cfg:      cfg,
-		Database: &database.Database{MediaDB: mockMediaDB},
+	tests := []struct {
+		searchErr error
+		name      string
+	}{
+		{name: "no rows", searchErr: sql.ErrNoRows},
+		{name: "timeout", searchErr: context.DeadlineExceeded},
 	}
 
-	_, err := cmdRandom(mockPlatform, env)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	mockMediaDB.AssertExpectations(t)
-	mockPlatform.AssertExpectations(t)
+			mockPlatform := mocks.NewMockPlatform()
+			cfg := &config.Instance{}
+			mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+			mockMediaDB := helpers.NewMockMediaDBI()
+			mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+				Return(database.SearchResult{}, tt.searchErr)
+			env := platforms.CmdEnv{
+				Cmd: zapscript.Command{
+					Name: "launch.random",
+					Args: []string{launchTestAbsPath("games")},
+					AdvArgs: zapscript.NewAdvArgs(map[string]string{
+						string(zapscript.KeyTags): "genre:shmup",
+					}),
+				},
+				Cfg:      cfg,
+				Database: &database.Database{MediaDB: mockMediaDB},
+			}
+
+			_, err := cmdRandom(mockPlatform, env)
+
+			require.ErrorIs(t, err, tt.searchErr)
+			mockPlatform.AssertNotCalled(t, "LaunchMedia", mock.Anything, mock.Anything,
+				mock.Anything, mock.Anything, mock.Anything)
+			mockMediaDB.AssertExpectations(t)
+			mockPlatform.AssertExpectations(t)
+		})
+	}
 }
 
 func TestCmdRandom_AbsolutePathFallback_NonExistentPath(t *testing.T) {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1878,6 +1878,73 @@ func TestCmdRandom_AbsolutePathFallbackToFilesystem(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdRandom_AbsolutePathTimeoutFallsBackToFilesystem(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	romPath := filepath.Join(dir, "game.mra")
+	require.NoError(t, os.WriteFile(romPath, []byte("x"), 0o600))
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Return(database.SearchResult{}, context.DeadlineExceeded)
+	mockPlatform.On(
+		"LaunchMedia", cfg, romPath, (*platforms.Launcher)(nil),
+		mock.Anything, (*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{dir},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AbsolutePathTimeoutWithTagsDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Return(database.SearchResult{}, context.DeadlineExceeded)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{dir},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				string(zapscript.KeyTags): "genre:shmup",
+			}),
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	_, err := cmdRandom(mockPlatform, env)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdRandom_AbsolutePathFallback_NonExistentPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- avoid unnecessary metadata joins when collecting random-media statistics for path-only queries
- fall back to direct filesystem selection when an untagged absolute-path lookup exceeds its database deadline
- preserve tagged-query semantics and cover both optimized SQL shape and timeout behavior

Closes #1122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved random media selection performance by avoiding unnecessary metadata joins when filtering by path prefix.
  - Absolute-path random launches now fall back to filesystem selection when the database times out and no tag filters are used.
  - Tag-filtered searches no longer fall back on timeout; timeout errors are retained.
- **Tests**
  - Added unit and integration coverage for path-prefix filtering in random selection.
  - Added regression tests for absolute-path timeout fallback behavior, including the no-fallback case when tag filters are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->