### PR TITLE
fix(windows): focus launched applications

### DIFF
--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -81,6 +81,7 @@ type Platform struct {
 	steamTracker            *steamtracker.WindowsPlatformIntegration
 	launcherManager         platforms.LauncherContextManager
 	windowFocuser           processWindowFocuser
+	windowFocusCancel       context.CancelFunc
 	lastLauncher            platforms.Launcher
 	processMu               syncutil.RWMutex
 	platformMappingsMu      syncutil.RWMutex
@@ -202,6 +203,10 @@ func (p *Platform) SetTrackedProcess(proc *os.Process) {
 		return
 	}
 
+	if p.windowFocusCancel != nil {
+		p.windowFocusCancel()
+		p.windowFocusCancel = nil
+	}
 	if p.trackedProcess != nil {
 		if err := p.trackedProcess.Kill(); err != nil && !isProcessFinishedError(err) {
 			log.Warn().Err(err).Msg("failed to kill previous tracked process")
@@ -211,20 +216,22 @@ func (p *Platform) SetTrackedProcess(proc *os.Process) {
 	p.trackedProcess = proc
 	p.completedTrackedProcess = nil
 	focuser := p.windowFocuser
-	launcherManager := p.launcherManager
-	p.processMu.Unlock()
-
-	log.Debug().Msgf("set tracked process: %v", proc)
 	if proc == nil || focuser == nil {
+		p.processMu.Unlock()
+		log.Debug().Msgf("set tracked process: %v", proc)
 		return
 	}
 
 	focusCtx := context.Background()
-	if launcherManager != nil {
-		if ctx := launcherManager.GetContext(); ctx != nil {
+	if p.launcherManager != nil {
+		if ctx := p.launcherManager.GetContext(); ctx != nil {
 			focusCtx = ctx
 		}
 	}
+	focusCtx, p.windowFocusCancel = context.WithCancel(focusCtx)
+	p.processMu.Unlock()
+
+	log.Debug().Msgf("set tracked process: %v", proc)
 	pid := uint32(proc.Pid) //nolint:gosec // Windows process IDs are 32-bit values
 	go func() {
 		if err := focuser.Focus(focusCtx, pid); err != nil && !errors.Is(err, context.Canceled) {

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/kodi"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/steam"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/steam/steamtracker"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/windows/windowfocus"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/acr122pcsc"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/externaldrive"
@@ -65,19 +66,28 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type processWindowFocuser interface {
+	Focus(context.Context, uint32) error
+}
+
 type Platform struct {
 	activeMedia             func() *models.ActiveMedia
 	setActiveMedia          func(*models.ActiveMedia)
 	customPlatformToSystem  map[string]string
 	systemToCustomPlatforms map[string][]string
 	trackedProcess          *os.Process
+	completedTrackedProcess *os.Process
 	launchBoxPipe           *LaunchBoxPipeServer
 	steamTracker            *steamtracker.WindowsPlatformIntegration
+	launcherManager         platforms.LauncherContextManager
+	windowFocuser           processWindowFocuser
 	lastLauncher            platforms.Launcher
 	processMu               syncutil.RWMutex
 	platformMappingsMu      syncutil.RWMutex
 	launchBoxPipeLock       syncutil.Mutex
 }
+
+const windowsErrorInvalidParameter syscall.Errno = 87
 
 var retroBatLaunchSettleDelay = 2 * time.Second
 
@@ -119,7 +129,7 @@ func (*Platform) StartPre(_ *config.Instance) error {
 func (p *Platform) StartPost(
 	_ context.Context,
 	cfg *config.Instance,
-	_ platforms.LauncherContextManager,
+	launcherManager platforms.LauncherContextManager,
 	activeMedia func() *models.ActiveMedia,
 	setActiveMedia func(*models.ActiveMedia),
 	_ *database.Database,
@@ -127,6 +137,8 @@ func (p *Platform) StartPost(
 ) error {
 	p.activeMedia = activeMedia
 	p.setActiveMedia = setActiveMedia
+	p.launcherManager = launcherManager
+	p.windowFocuser = windowfocus.New()
 
 	// Initialize LaunchBox pipe server if LaunchBox is installed
 	p.initLaunchBoxPipe(cfg)
@@ -145,6 +157,10 @@ func (p *Platform) StartPost(
 }
 
 func (p *Platform) Stop() error {
+	if p.launcherManager != nil {
+		p.launcherManager.NewContext()
+	}
+
 	// Stop Steam tracker
 	if p.steamTracker != nil {
 		p.steamTracker.Stop()
@@ -181,17 +197,77 @@ func (*Platform) Settings() platforms.Settings {
 
 func (p *Platform) SetTrackedProcess(proc *os.Process) {
 	p.processMu.Lock()
-	defer p.processMu.Unlock()
+	if p.trackedProcess != nil && proc != nil && p.trackedProcess.Pid == proc.Pid {
+		p.processMu.Unlock()
+		return
+	}
 
-	// Kill any existing tracked process before setting new one
 	if p.trackedProcess != nil {
-		if err := p.trackedProcess.Kill(); err != nil {
+		if err := p.trackedProcess.Kill(); err != nil && !isProcessFinishedError(err) {
 			log.Warn().Err(err).Msg("failed to kill previous tracked process")
 		}
 	}
 
 	p.trackedProcess = proc
+	p.completedTrackedProcess = nil
+	focuser := p.windowFocuser
+	launcherManager := p.launcherManager
+	p.processMu.Unlock()
+
 	log.Debug().Msgf("set tracked process: %v", proc)
+	if proc == nil || focuser == nil {
+		return
+	}
+
+	focusCtx := context.Background()
+	if launcherManager != nil {
+		if ctx := launcherManager.GetContext(); ctx != nil {
+			focusCtx = ctx
+		}
+	}
+	pid := uint32(proc.Pid) //nolint:gosec // Windows process IDs are 32-bit values
+	go func() {
+		if err := focuser.Focus(focusCtx, pid); err != nil && !errors.Is(err, context.Canceled) {
+			log.Debug().Err(err).Int("pid", proc.Pid).Msg("launched process window was not focused")
+		}
+	}()
+}
+
+func isProcessFinishedError(err error) bool {
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, windowsErrorInvalidParameter)
+}
+
+// WaitTrackedProcess waits for proc and removes its stale process handle when it exits.
+func (p *Platform) WaitTrackedProcess(proc *os.Process) error {
+	_, err := proc.Wait()
+
+	p.processMu.Lock()
+	if p.trackedProcess == proc {
+		p.trackedProcess = nil
+		p.completedTrackedProcess = proc
+	}
+	p.processMu.Unlock()
+
+	if err != nil {
+		return fmt.Errorf("wait for tracked process: %w", err)
+	}
+	return nil
+}
+
+// ClearTrackedProcessMedia clears active media only when proc is still the latest completed launch.
+func (p *Platform) ClearTrackedProcessMedia(proc *os.Process) bool {
+	p.processMu.Lock()
+	if p.completedTrackedProcess != proc || p.trackedProcess != nil {
+		p.processMu.Unlock()
+		return false
+	}
+	p.completedTrackedProcess = nil
+	p.processMu.Unlock()
+
+	if p.setActiveMedia != nil {
+		p.setActiveMedia(nil)
+	}
+	return true
 }
 
 func (p *Platform) setLastLauncher(l *platforms.Launcher) {
@@ -201,10 +277,15 @@ func (p *Platform) setLastLauncher(l *platforms.Launcher) {
 }
 
 func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
+	if p.launcherManager != nil {
+		p.launcherManager.NewContext()
+	}
+
 	p.processMu.Lock()
 
 	customKill := p.lastLauncher.Kill
 	p.lastLauncher = platforms.Launcher{}
+	p.completedTrackedProcess = nil
 
 	if customKill != nil {
 		p.trackedProcess = nil
@@ -216,7 +297,7 @@ func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
 	} else {
 		// Kill tracked process if exists
 		if p.trackedProcess != nil {
-			if err := p.trackedProcess.Kill(); err != nil {
+			if err := p.trackedProcess.Kill(); err != nil && !isProcessFinishedError(err) {
 				log.Warn().Err(err).Msg("failed to kill tracked process")
 			}
 			p.trackedProcess = nil
@@ -225,7 +306,9 @@ func (p *Platform) StopActiveLauncher(_ platforms.StopIntent) error {
 		p.processMu.Unlock()
 	}
 
-	p.setActiveMedia(nil)
+	if p.setActiveMedia != nil {
+		p.setActiveMedia(nil)
+	}
 	return nil
 }
 

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -87,7 +87,7 @@ type Platform struct {
 	launchBoxPipeLock       syncutil.Mutex
 }
 
-const windowsErrorInvalidParameter syscall.Errno = 87
+const errWindowsInvalidParameter syscall.Errno = 87
 
 var retroBatLaunchSettleDelay = 2 * time.Second
 
@@ -234,7 +234,7 @@ func (p *Platform) SetTrackedProcess(proc *os.Process) {
 }
 
 func isProcessFinishedError(err error) bool {
-	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, windowsErrorInvalidParameter)
+	return errors.Is(err, os.ErrProcessDone) || errors.Is(err, errWindowsInvalidParameter)
 }
 
 // WaitTrackedProcess waits for proc and removes its stale process handle when it exits.

--- a/pkg/platforms/windows/platform_test.go
+++ b/pkg/platforms/windows/platform_test.go
@@ -43,9 +43,21 @@ type recordingProcessFocuser struct {
 	pids chan uint32
 }
 
+type cancelingProcessFocuser struct {
+	started  chan uint32
+	canceled chan uint32
+}
+
 func (f *recordingProcessFocuser) Focus(_ context.Context, pid uint32) error {
 	f.pids <- pid
 	return nil
+}
+
+func (f *cancelingProcessFocuser) Focus(ctx context.Context, pid uint32) error {
+	f.started <- pid
+	<-ctx.Done()
+	f.canceled <- pid
+	return ctx.Err()
 }
 
 var (
@@ -178,6 +190,56 @@ func TestSetTrackedProcess_FocusesLaunchedProcess(t *testing.T) {
 	}
 
 	require.NoError(t, p.StopActiveLauncher(platforms.StopForPreemption))
+}
+
+func TestSetTrackedProcess_CancelsPreviousFocus(t *testing.T) {
+	t.Parallel()
+
+	oldCmd := exec.CommandContext(context.Background(), "cmd", "/C", "timeout", "/T", "10")
+	require.NoError(t, oldCmd.Start())
+	newCmd := exec.CommandContext(context.Background(), "cmd", "/C", "timeout", "/T", "10")
+	require.NoError(t, newCmd.Start())
+	t.Cleanup(func() {
+		_ = oldCmd.Process.Kill()
+		_, _ = oldCmd.Process.Wait()
+		_ = newCmd.Process.Kill()
+		_, _ = newCmd.Process.Wait()
+	})
+
+	focuser := &cancelingProcessFocuser{
+		started:  make(chan uint32, 2),
+		canceled: make(chan uint32, 2),
+	}
+	p := &Platform{windowFocuser: focuser}
+	p.SetTrackedProcess(oldCmd.Process)
+	select {
+	case pid := <-focuser.started:
+		assert.Equal(t, uint32(oldCmd.Process.Pid), pid) //nolint:gosec // Windows process IDs are 32-bit values
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first focus request")
+	}
+
+	p.SetTrackedProcess(newCmd.Process)
+	select {
+	case pid := <-focuser.canceled:
+		assert.Equal(t, uint32(oldCmd.Process.Pid), pid) //nolint:gosec // Windows process IDs are 32-bit values
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first focus cancellation")
+	}
+	select {
+	case pid := <-focuser.started:
+		assert.Equal(t, uint32(newCmd.Process.Pid), pid) //nolint:gosec // Windows process IDs are 32-bit values
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement focus request")
+	}
+
+	p.SetTrackedProcess(nil)
+	select {
+	case pid := <-focuser.canceled:
+		assert.Equal(t, uint32(newCmd.Process.Pid), pid) //nolint:gosec // Windows process IDs are 32-bit values
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for replacement focus cancellation")
+	}
 }
 
 func TestWaitTrackedProcess_ClearsCompletedProcess(t *testing.T) {

--- a/pkg/platforms/windows/platform_test.go
+++ b/pkg/platforms/windows/platform_test.go
@@ -39,6 +39,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type recordingProcessFocuser struct {
+	pids chan uint32
+}
+
+func (f *recordingProcessFocuser) Focus(_ context.Context, pid uint32) error {
+	f.pids <- pid
+	return nil
+}
+
+var (
+	_ platforms.TrackedProcessWaiter       = (*Platform)(nil)
+	_ platforms.TrackedProcessMediaClearer = (*Platform)(nil)
+)
+
 func TestWindowsHasKodiLocalLauncher(t *testing.T) {
 	t.Parallel()
 
@@ -137,6 +151,83 @@ func TestStopActiveLauncher_CustomKill(t *testing.T) {
 			assert.Equal(t, tt.customKillCalled, killCalled, "custom Kill called mismatch")
 		})
 	}
+}
+
+func TestSetTrackedProcess_FocusesLaunchedProcess(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "cmd", "/C", "timeout", "/T", "10")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	focuser := &recordingProcessFocuser{pids: make(chan uint32, 1)}
+	p := &Platform{
+		setActiveMedia: func(_ *models.ActiveMedia) {},
+		windowFocuser:  focuser,
+	}
+	p.SetTrackedProcess(cmd.Process)
+
+	select {
+	case pid := <-focuser.pids:
+		assert.Equal(t, uint32(cmd.Process.Pid), pid) //nolint:gosec // Windows process IDs are 32-bit values
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for process focus request")
+	}
+
+	require.NoError(t, p.StopActiveLauncher(platforms.StopForPreemption))
+}
+
+func TestWaitTrackedProcess_ClearsCompletedProcess(t *testing.T) {
+	t.Parallel()
+
+	cmd := exec.CommandContext(context.Background(), "cmd", "/C", "exit", "0")
+	require.NoError(t, cmd.Start())
+
+	mediaCleared := false
+	p := &Platform{setActiveMedia: func(media *models.ActiveMedia) {
+		if media == nil {
+			mediaCleared = true
+		}
+	}}
+	p.SetTrackedProcess(cmd.Process)
+
+	require.NoError(t, p.WaitTrackedProcess(cmd.Process))
+	p.processMu.RLock()
+	assert.Nil(t, p.trackedProcess)
+	assert.Same(t, cmd.Process, p.completedTrackedProcess)
+	p.processMu.RUnlock()
+
+	assert.True(t, p.ClearTrackedProcessMedia(cmd.Process))
+	assert.True(t, mediaCleared)
+	assert.False(t, p.ClearTrackedProcessMedia(cmd.Process))
+}
+
+func TestClearTrackedProcessMedia_DoesNotClearReplacement(t *testing.T) {
+	t.Parallel()
+
+	oldCmd := exec.CommandContext(context.Background(), "cmd", "/C", "exit", "0")
+	require.NoError(t, oldCmd.Start())
+	newCmd := exec.CommandContext(context.Background(), "cmd", "/C", "timeout", "/T", "10")
+	require.NoError(t, newCmd.Start())
+	t.Cleanup(func() {
+		_ = newCmd.Process.Kill()
+		_, _ = newCmd.Process.Wait()
+	})
+
+	mediaCleared := false
+	p := &Platform{setActiveMedia: func(_ *models.ActiveMedia) {
+		mediaCleared = true
+	}}
+	p.SetTrackedProcess(oldCmd.Process)
+	require.NoError(t, p.WaitTrackedProcess(oldCmd.Process))
+	p.SetTrackedProcess(newCmd.Process)
+
+	assert.False(t, p.ClearTrackedProcessMedia(oldCmd.Process))
+	assert.False(t, mediaCleared)
+	require.NoError(t, p.StopActiveLauncher(platforms.StopForPreemption))
 }
 
 func TestLaunchMedia_RetroBatStopsRunningGameBeforeLaunch(t *testing.T) {

--- a/pkg/platforms/windows/windowfocus/api_windows.go
+++ b/pkg/platforms/windows/windowfocus/api_windows.go
@@ -1,0 +1,167 @@
+//go:build windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package windowfocus
+
+import (
+	"runtime"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	focusPollInterval = 50 * time.Millisecond
+	focusTimeout      = 5 * time.Second
+	getWindowOwner    = 4
+	showRestore       = 9
+)
+
+var (
+	user32                       = windows.NewLazySystemDLL("user32.dll")
+	procAllowSetForegroundWindow = user32.NewProc("AllowSetForegroundWindow")
+	procAttachThreadInput        = user32.NewProc("AttachThreadInput")
+	procBringWindowToTop         = user32.NewProc("BringWindowToTop")
+	procEnumWindows              = user32.NewProc("EnumWindows")
+	procGetForegroundWindow      = user32.NewProc("GetForegroundWindow")
+	procGetWindow                = user32.NewProc("GetWindow")
+	procGetWindowThreadProcessID = user32.NewProc("GetWindowThreadProcessId")
+	procIsGUIThread              = user32.NewProc("IsGUIThread")
+	procIsIconic                 = user32.NewProc("IsIconic")
+	procIsWindowVisible          = user32.NewProc("IsWindowVisible")
+	procSetActiveWindow          = user32.NewProc("SetActiveWindow")
+	procSetFocus                 = user32.NewProc("SetFocus")
+	procSetForegroundWindow      = user32.NewProc("SetForegroundWindow")
+	procShowWindow               = user32.NewProc("ShowWindow")
+)
+
+type windowsAPI struct{}
+
+// New creates a Windows process-window focus manager.
+func New() *Manager {
+	return newManager(windowsAPI{}, focusPollInterval, focusTimeout)
+}
+
+func (windowsAPI) allowProcessForeground(pid uint32) {
+	_, _, _ = procAllowSetForegroundWindow.Call(uintptr(pid))
+}
+
+func (windowsAPI) findProcessWindow(pid uint32) (uintptr, bool) {
+	if hwnd, found := findWindowForPIDs(map[uint32]struct{}{pid: {}}); found {
+		return hwnd, true
+	}
+	return findWindowForPIDs(processTreePIDs(pid))
+}
+
+func findWindowForPIDs(pids map[uint32]struct{}) (uintptr, bool) {
+	var found uintptr
+	callback := syscall.NewCallback(func(hwnd, _ uintptr) uintptr {
+		if visible, _, _ := procIsWindowVisible.Call(hwnd); visible == 0 {
+			return 1
+		}
+		if owner, _, _ := procGetWindow.Call(hwnd, getWindowOwner); owner != 0 {
+			return 1
+		}
+
+		var windowPID uint32
+		_, _, _ = procGetWindowThreadProcessID.Call(hwnd, uintptr(unsafe.Pointer(&windowPID)))
+		if _, ok := pids[windowPID]; !ok {
+			return 1
+		}
+
+		found = hwnd
+		return 0
+	})
+	_, _, _ = procEnumWindows.Call(callback, 0)
+	return found, found != 0
+}
+
+func processTreePIDs(rootPID uint32) map[uint32]struct{} {
+	pids := map[uint32]struct{}{rootPID: {}}
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return pids
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err = windows.Process32First(snapshot, &entry); err != nil {
+		return pids
+	}
+
+	relations := make([]processRelation, 0, 64)
+	for {
+		relations = append(relations, processRelation{pid: entry.ProcessID, parentPID: entry.ParentProcessID})
+		if err = windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return processTree(rootPID, relations)
+}
+
+func (windowsAPI) activateWindow(hwnd uintptr) bool {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	foreground, _, _ := procGetForegroundWindow.Call()
+	if foreground == hwnd {
+		return true
+	}
+
+	_, _, _ = procIsGUIThread.Call(1)
+	currentThread := windows.GetCurrentThreadId()
+	foregroundThread := windowThreadID(foreground)
+	targetThread := windowThreadID(hwnd)
+
+	foregroundAttached := attachThreadInput(currentThread, foregroundThread)
+	if foregroundAttached {
+		defer detachThreadInput(currentThread, foregroundThread)
+	}
+	targetAttached := false
+	if targetThread != foregroundThread {
+		targetAttached = attachThreadInput(currentThread, targetThread)
+		if targetAttached {
+			defer detachThreadInput(currentThread, targetThread)
+		}
+	}
+
+	if iconic, _, _ := procIsIconic.Call(hwnd); iconic != 0 {
+		_, _, _ = procShowWindow.Call(hwnd, showRestore)
+	}
+	_, _, _ = procBringWindowToTop.Call(hwnd)
+	activated, _, _ := procSetForegroundWindow.Call(hwnd)
+	_, _, _ = procSetActiveWindow.Call(hwnd)
+	_, _, _ = procSetFocus.Call(hwnd)
+	if activated == 0 {
+		return false
+	}
+	foreground, _, _ = procGetForegroundWindow.Call()
+	return foreground == hwnd
+}
+
+func windowThreadID(hwnd uintptr) uint32 {
+	if hwnd == 0 {
+		return 0
+	}
+	threadID, _, _ := procGetWindowThreadProcessID.Call(hwnd, 0)
+	return uint32(threadID) //nolint:gosec // Win32 thread IDs are 32-bit values
+}
+
+func attachThreadInput(current, other uint32) bool {
+	if current == 0 || other == 0 || current == other {
+		return false
+	}
+	attached, _, _ := procAttachThreadInput.Call(uintptr(current), uintptr(other), 1)
+	return attached != 0
+}
+
+func detachThreadInput(current, other uint32) {
+	_, _, _ = procAttachThreadInput.Call(uintptr(current), uintptr(other), 0)
+}

--- a/pkg/platforms/windows/windowfocus/api_windows.go
+++ b/pkg/platforms/windows/windowfocus/api_windows.go
@@ -69,6 +69,7 @@ func findWindowForPIDs(pids map[uint32]struct{}) (uintptr, bool) {
 		}
 
 		var windowPID uint32
+		//nolint:gosec // Win32 API requires a pointer to receive the owning process ID.
 		_, _, _ = procGetWindowThreadProcessID.Call(hwnd, uintptr(unsafe.Pointer(&windowPID)))
 		if _, ok := pids[windowPID]; !ok {
 			return 1

--- a/pkg/platforms/windows/windowfocus/api_windows.go
+++ b/pkg/platforms/windows/windowfocus/api_windows.go
@@ -22,6 +22,13 @@ const (
 	showRestore       = 9
 )
 
+type windowSearchState struct {
+	pids  map[uint32]struct{}
+	found uintptr
+}
+
+type windowsAPI struct{}
+
 var (
 	user32                       = windows.NewLazySystemDLL("user32.dll")
 	procAllowSetForegroundWindow = user32.NewProc("AllowSetForegroundWindow")
@@ -38,9 +45,8 @@ var (
 	procSetFocus                 = user32.NewProc("SetFocus")
 	procSetForegroundWindow      = user32.NewProc("SetForegroundWindow")
 	procShowWindow               = user32.NewProc("ShowWindow")
+	enumWindowsCallback          = syscall.NewCallback(enumWindow)
 )
-
-type windowsAPI struct{}
 
 // New creates a Windows process-window focus manager.
 func New() *Manager {
@@ -58,28 +64,33 @@ func (windowsAPI) findProcessWindow(pid uint32) (uintptr, bool) {
 	return findWindowForPIDs(processTreePIDs(pid))
 }
 
+func enumWindow(hwnd, lparam uintptr) uintptr {
+	//nolint:gosec,govet // Win32 synchronously passes caller-owned state through uintptr lParam.
+	state := (*windowSearchState)(unsafe.Pointer(lparam))
+	if visible, _, _ := procIsWindowVisible.Call(hwnd); visible == 0 {
+		return 1
+	}
+	if owner, _, _ := procGetWindow.Call(hwnd, getWindowOwner); owner != 0 {
+		return 1
+	}
+
+	var windowPID uint32
+	//nolint:gosec // Win32 API requires a pointer to receive the owning process ID.
+	_, _, _ = procGetWindowThreadProcessID.Call(hwnd, uintptr(unsafe.Pointer(&windowPID)))
+	if _, ok := state.pids[windowPID]; !ok {
+		return 1
+	}
+
+	state.found = hwnd
+	return 0
+}
+
 func findWindowForPIDs(pids map[uint32]struct{}) (uintptr, bool) {
-	var found uintptr
-	callback := syscall.NewCallback(func(hwnd, _ uintptr) uintptr {
-		if visible, _, _ := procIsWindowVisible.Call(hwnd); visible == 0 {
-			return 1
-		}
-		if owner, _, _ := procGetWindow.Call(hwnd, getWindowOwner); owner != 0 {
-			return 1
-		}
-
-		var windowPID uint32
-		//nolint:gosec // Win32 API requires a pointer to receive the owning process ID.
-		_, _, _ = procGetWindowThreadProcessID.Call(hwnd, uintptr(unsafe.Pointer(&windowPID)))
-		if _, ok := pids[windowPID]; !ok {
-			return 1
-		}
-
-		found = hwnd
-		return 0
-	})
-	_, _, _ = procEnumWindows.Call(callback, 0)
-	return found, found != 0
+	state := windowSearchState{pids: pids}
+	//nolint:gosec // EnumWindows synchronously reads and updates state through lParam.
+	_, _, _ = procEnumWindows.Call(enumWindowsCallback, uintptr(unsafe.Pointer(&state)))
+	runtime.KeepAlive(&state)
+	return state.found, state.found != 0
 }
 
 func processTreePIDs(rootPID uint32) map[uint32]struct{} {

--- a/pkg/platforms/windows/windowfocus/focus.go
+++ b/pkg/platforms/windows/windowfocus/focus.go
@@ -1,0 +1,101 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package windowfocus activates windows created by launched Windows processes.
+package windowfocus
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var errFocusTimeout = errors.New("timed out waiting for process window")
+
+type processRelation struct {
+	pid       uint32
+	parentPID uint32
+}
+
+type nativeAPI interface {
+	allowProcessForeground(pid uint32)
+	findProcessWindow(pid uint32) (uintptr, bool)
+	activateWindow(hwnd uintptr) bool
+}
+
+func processTree(rootPID uint32, relations []processRelation) map[uint32]struct{} {
+	pids := map[uint32]struct{}{rootPID: {}}
+	for changed := true; changed; {
+		changed = false
+		for _, relation := range relations {
+			if _, known := pids[relation.pid]; known {
+				continue
+			}
+			if _, parentKnown := pids[relation.parentPID]; parentKnown {
+				pids[relation.pid] = struct{}{}
+				changed = true
+			}
+		}
+	}
+	return pids
+}
+
+// Manager waits for a launched process to create a top-level window and then
+// asks Windows to activate it.
+type Manager struct {
+	api          nativeAPI
+	pollInterval time.Duration
+	timeout      time.Duration
+}
+
+func newManager(api nativeAPI, pollInterval, timeout time.Duration) *Manager {
+	return &Manager{
+		api:          api,
+		pollInterval: pollInterval,
+		timeout:      timeout,
+	}
+}
+
+// Focus polls until the process owns a window that Windows accepts as foreground.
+func (m *Manager) Focus(ctx context.Context, pid uint32) error {
+	if m == nil || m.api == nil || pid == 0 {
+		return nil
+	}
+
+	m.api.allowProcessForeground(pid)
+
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(m.timeout)
+	defer timer.Stop()
+
+	for {
+		if hwnd, found := m.api.findProcessWindow(pid); found && m.api.activateWindow(hwnd) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+			return errFocusTimeout
+		case <-ticker.C:
+		}
+	}
+}

--- a/pkg/platforms/windows/windowfocus/focus_test.go
+++ b/pkg/platforms/windows/windowfocus/focus_test.go
@@ -1,0 +1,101 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package windowfocus
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAPI struct {
+	findAfter     int
+	activateAfter int
+	findCalls     int
+	activateCalls int
+}
+
+func (*fakeAPI) allowProcessForeground(_ uint32) {}
+
+func (f *fakeAPI) findProcessWindow(_ uint32) (uintptr, bool) {
+	f.findCalls++
+	return 42, f.findCalls >= f.findAfter
+}
+
+func (f *fakeAPI) activateWindow(_ uintptr) bool {
+	f.activateCalls++
+	return f.activateCalls >= f.activateAfter
+}
+
+func TestProcessTreeIncludesNestedChildren(t *testing.T) {
+	t.Parallel()
+
+	pids := processTree(10, []processRelation{
+		{pid: 30, parentPID: 20},
+		{pid: 20, parentPID: 10},
+		{pid: 40, parentPID: 99},
+	})
+
+	assert.Equal(t, map[uint32]struct{}{10: {}, 20: {}, 30: {}}, pids)
+}
+
+func TestManagerFocusWaitsForWindowAndActivation(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{findAfter: 2, activateAfter: 2}
+	manager := newManager(api, time.Millisecond, 100*time.Millisecond)
+
+	require.NoError(t, manager.Focus(context.Background(), 123))
+	assert.GreaterOrEqual(t, api.findCalls, 3)
+	assert.Equal(t, 2, api.activateCalls)
+}
+
+func TestManagerFocusStopsWhenCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	api := &fakeAPI{findAfter: 100, activateAfter: 1}
+	manager := newManager(api, time.Millisecond, time.Second)
+
+	err := manager.Focus(ctx, 123)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestManagerFocusTimesOut(t *testing.T) {
+	t.Parallel()
+
+	api := &fakeAPI{findAfter: 100, activateAfter: 1}
+	manager := newManager(api, time.Millisecond, 10*time.Millisecond)
+
+	err := manager.Focus(context.Background(), 123)
+	require.ErrorIs(t, err, errFocusTimeout)
+}
+
+func TestManagerFocusIgnoresInvalidRequests(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, (*Manager)(nil).Focus(context.Background(), 123))
+	assert.NoError(t, newManager(nil, time.Millisecond, time.Second).Focus(context.Background(), 123))
+	assert.NoError(t, newManager(&fakeAPI{}, time.Millisecond, time.Second).Focus(context.Background(), 0))
+}


### PR DESCRIPTION
## Summary

- locate top-level windows for launched processes or descendants, restore minimized windows, and retry foreground activation
- cancel superseded focus attempts and preserve active media when stale tracked processes exit
- tolerate expected already-finished process errors and cover focus orchestration plus tracked-process ownership

## Notes

- Foreground activation still requires validation on a real Windows system.

Closes #1130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows-launched games and processes now automatically focus their matching application window, with retrying and a timeout.
  - Enhanced launched-process tracking, including an explicit “wait for completion” step.
- **Bug Fixes**
  - Focus and completion tracking are now safer when replacing a tracked process or clearing to none (previous focus attempts are canceled).
  - Prevent stale completions from clearing media for newer launches; improved tolerance when processes exit during cleanup.
- **Tests**
  - Added unit coverage for tracked-process lifecycle and the Windows window-focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->