### PR TITLE
feat(mister): group RetroAchievements launchers

### DIFF
--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -464,6 +464,15 @@ func retroAchievementsSetName(launcherID string) (string, bool) {
 	}
 }
 
+func applyRetroAchievementsLauncherGroup(launchers []platforms.Launcher) []platforms.Launcher {
+	for i := range launchers {
+		if _, ok := retroAchievementsSetName(launchers[i].ID); ok {
+			launchers[i].Groups = append(launchers[i].Groups, shared.LauncherGroupRetroAchievements)
+		}
+	}
+	return launchers
+}
+
 func launchRetroAchievementsCore(
 	launcherID string,
 	systemID string,
@@ -2356,5 +2365,5 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		},
 	}
 
-	return applyDefaultScanExcludes(enableMGLIndexing(launchers))
+	return applyDefaultScanExcludes(enableMGLIndexing(applyRetroAchievementsLauncherGroup(launchers)))
 }

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+	platformshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1077,6 +1078,7 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 			require.NotNil(t, found, "%s launcher should exist", tc.id)
 			assert.Equal(t, tc.systemID, found.SystemID,
 				"%s must inherit slots from %s", tc.id, tc.systemID)
+			assert.Contains(t, found.Groups, platformshared.LauncherGroupRetroAchievements)
 		})
 	}
 }

--- a/pkg/platforms/shared/launchers.go
+++ b/pkg/platforms/shared/launchers.go
@@ -33,10 +33,11 @@ const (
 
 // Launcher groups used as stable configuration references.
 const (
-	LauncherGroupNative    = "Native"
-	LauncherGroupEmuDeck   = "EmuDeck"
-	LauncherGroupRetroDECK = "RetroDECK"
-	LauncherGroupKodi      = "Kodi"
-	LauncherGroupKodiTV    = "KodiTV"
-	LauncherGroupKodiMusic = "KodiMusic"
+	LauncherGroupNative            = "Native"
+	LauncherGroupEmuDeck           = "EmuDeck"
+	LauncherGroupRetroDECK         = "RetroDECK"
+	LauncherGroupRetroAchievements = "RetroAchievements"
+	LauncherGroupKodi              = "Kodi"
+	LauncherGroupKodiTV            = "KodiTV"
+	LauncherGroupKodiMusic         = "KodiMusic"
 )


### PR DESCRIPTION
## Summary

- add a stable `RetroAchievements` launcher group configuration reference
- assign every mapped MiSTer RetroAchievements launcher to the shared group
- verify all expected RetroAchievements launchers expose the group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RetroAchievements launchers are now labeled with a dedicated group for easier discovery and organization.
* **Bug Fixes**
  * Improved launcher metadata so RetroAchievements entries are consistently categorized during creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->