### PR TITLE
fix(playtime): use dedicated sync base URL

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -157,6 +157,9 @@ var BaseDefaults = Values{
 			Schedule: DefaultBackupRemoteSchedule,
 		},
 	},
+	Playtime: Playtime{
+		BaseURL: DefaultPlaytimeBaseURL,
+	},
 	Readers: Readers{
 		AutoDetect: true,
 		Scan: ReadersScan{

--- a/pkg/config/configbackup.go
+++ b/pkg/config/configbackup.go
@@ -20,7 +20,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"net/netip"
 	"net/url"
@@ -139,20 +138,26 @@ func (c *Instance) SetBackupRemoteBaseURL(rawURL string) error {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.vals.Backup.Remote.BaseURL = normalizeBackupBaseURL(rawURL)
+	c.vals.Backup.Remote.BaseURL = normalizeRemoteBaseURL(rawURL)
 	return nil
 }
 
 func ValidateBackupRemoteBaseURL(rawURL string) error {
+	return validateRemoteBaseURL(rawURL, "backup remote")
+}
+
+func validateRemoteBaseURL(rawURL, setting string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return fmt.Errorf("invalid backup remote base URL: %w", err)
+		return fmt.Errorf("invalid %s base URL: %w", setting, err)
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return errors.New("backup remote base URL must use http or https")
+		return fmt.Errorf("%s base URL must use http or https", setting)
 	}
 	if parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return errors.New("backup remote base URL must include only scheme, host, optional port, and optional path")
+		return fmt.Errorf(
+			"%s base URL must include only scheme, host, optional port, and optional path", setting,
+		)
 	}
 	if parsed.Scheme == "https" {
 		return nil
@@ -164,15 +169,15 @@ func ValidateBackupRemoteBaseURL(rawURL string) error {
 	}
 	addr, err := netip.ParseAddr(host)
 	if err != nil {
-		return errors.New("http backup remote base URL must use localhost or a private IP literal")
+		return fmt.Errorf("http %s base URL must use localhost or a private IP literal", setting)
 	}
-	if isAllowedHTTPBackupAddr(addr) {
+	if isAllowedHTTPRemoteAddr(addr) {
 		return nil
 	}
-	return errors.New("http backup remote base URL must use localhost or a private IP literal")
+	return fmt.Errorf("http %s base URL must use localhost or a private IP literal", setting)
 }
 
-func normalizeBackupBaseURL(rawURL string) string {
+func normalizeRemoteBaseURL(rawURL string) string {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL
@@ -183,7 +188,7 @@ func normalizeBackupBaseURL(rawURL string) string {
 	return parsed.String()
 }
 
-func isAllowedHTTPBackupAddr(addr netip.Addr) bool {
+func isAllowedHTTPRemoteAddr(addr netip.Addr) bool {
 	if addr.IsLoopback() || addr.IsLinkLocalUnicast() {
 		return true
 	}
@@ -209,6 +214,10 @@ func isAllowedHTTPBackupAddr(addr netip.Addr) bool {
 }
 
 func BackupAuthLookupURL(rawURL string) string {
+	return RemoteAuthLookupURL(rawURL)
+}
+
+func RemoteAuthLookupURL(rawURL string) string {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL

--- a/pkg/config/configplaytime.go
+++ b/pkg/config/configplaytime.go
@@ -26,10 +26,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const DefaultPlaytimeBaseURL = "https://api.zaparoo.com"
+
 // Playtime configures play time tracking and limits.
 type Playtime struct {
 	Retention *int           `toml:"retention,omitempty"`
 	Sync      *bool          `toml:"sync,omitempty"`
+	BaseURL   string         `toml:"base_url,omitempty"`
 	Limits    PlaytimeLimits `toml:"limits,omitempty"`
 }
 
@@ -51,6 +54,31 @@ func (c *Instance) PlaytimeRetention() int {
 		return 365 // Default: keep 365 days (1 year) of play time history
 	}
 	return *c.vals.Playtime.Retention
+}
+
+// PlaytimeBaseURL returns the API base URL used for play-history sync.
+func (c *Instance) PlaytimeBaseURL() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.vals.Playtime.BaseURL == "" {
+		return DefaultPlaytimeBaseURL
+	}
+	return c.vals.Playtime.BaseURL
+}
+
+// SetPlaytimeBaseURL validates, normalizes, and stores the play-history API base URL.
+func (c *Instance) SetPlaytimeBaseURL(rawURL string) error {
+	if err := ValidatePlaytimeBaseURL(rawURL); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.vals.Playtime.BaseURL = normalizeRemoteBaseURL(rawURL)
+	return nil
+}
+
+func ValidatePlaytimeBaseURL(rawURL string) error {
+	return validateRemoteBaseURL(rawURL, "playtime")
 }
 
 // PlaytimeSyncEnabled reports whether the user explicitly consented to

--- a/pkg/config/configplaytime_test.go
+++ b/pkg/config/configplaytime_test.go
@@ -27,6 +27,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPlaytimeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
+
+	require.NoError(t, cfg.LoadTOML(`[playtime]
+base_url = "https://playtime.example.com/api"
+`))
+	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+}
+
+func TestSetPlaytimeBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{}
+	require.NoError(t, cfg.SetPlaytimeBaseURL("https://playtime.example.com/api/"))
+	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+	require.Error(t, cfg.SetPlaytimeBaseURL("http://example.com"))
+	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+}
+
 func TestPlaytimeSyncEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -1097,8 +1097,19 @@ func (m *Manager) newRemoteClient() (*remoteClient, error) {
 		}
 		return nil, errRemoteUnlinked
 	}
-	baseURL := strings.TrimRight(m.cfg.BackupRemoteBaseURL(), "/")
-	lookupURL := config.BackupAuthLookupURL(baseURL)
+	return m.newAuthenticatedRemoteClient(m.cfg.BackupRemoteBaseURL(), m.markRemoteUnlinkedIfCurrent)
+}
+
+func (m *Manager) newPlaytimeRemoteClient() (*remoteClient, error) {
+	return m.newAuthenticatedRemoteClient(m.cfg.PlaytimeBaseURL(), nil)
+}
+
+func (m *Manager) newAuthenticatedRemoteClient(
+	rawBaseURL string,
+	onUnauthorized func(string),
+) (*remoteClient, error) {
+	baseURL := strings.TrimRight(rawBaseURL, "/")
+	lookupURL := config.RemoteAuthLookupURL(baseURL)
 	entry := config.LookupAuth(config.GetAuthCfg(), lookupURL)
 	if entry == nil || entry.Bearer == "" {
 		return nil, errRemoteUnlinked
@@ -1108,18 +1119,22 @@ func (m *Manager) newRemoteClient() (*remoteClient, error) {
 	if m.rateLimitWaits != nil {
 		retryWaits = *m.rateLimitWaits
 	}
+	var unauthorizedCallback func()
+	if onUnauthorized != nil {
+		unauthorizedCallback = func() {
+			onUnauthorized(bearer)
+		}
+	}
 	return &remoteClient{
 		// Timeouts are applied per request (scaled to transfer size for
 		// uploads/downloads), not on the client, so a large pack on a slow
 		// uplink is not killed at the base timeout.
-		httpClient: &http.Client{},
-		onUnauthorized: func() {
-			m.markRemoteUnlinkedIfCurrent(bearer)
-		},
-		baseURL:    baseURL,
-		bearer:     bearer,
-		platform:   m.pl.ID(),
-		retryWaits: retryWaits,
+		httpClient:     &http.Client{},
+		onUnauthorized: unauthorizedCallback,
+		baseURL:        baseURL,
+		bearer:         bearer,
+		platform:       m.pl.ID(),
+		retryWaits:     retryWaits,
 	}, nil
 }
 

--- a/pkg/service/backup/remote_playsync.go
+++ b/pkg/service/backup/remote_playsync.go
@@ -138,7 +138,7 @@ func (m *Manager) SyncPlayHistory(ctx context.Context) (PlaySyncInfo, error) {
 	if !m.cfg.PlaytimeSyncEnabled() {
 		return PlaySyncInfo{}, errPlaySyncDisabled
 	}
-	client, err := m.newRemoteClient()
+	client, err := m.newPlaytimeRemoteClient()
 	if err != nil {
 		return PlaySyncInfo{}, err
 	}

--- a/pkg/service/backup/remote_playsync_test.go
+++ b/pkg/service/backup/remote_playsync_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/stretchr/testify/assert"
 	testifymock "github.com/stretchr/testify/mock"
@@ -84,14 +85,25 @@ func playSyncTestServer(t *testing.T, watermark *time.Time) (*httptest.Server, *
 	return server, &batches
 }
 
+func configurePlaytimeTestAuth(t *testing.T, manager *Manager, baseURL string) {
+	t.Helper()
+	require.NoError(t, manager.cfg.SetPlaytimeBaseURL(baseURL))
+	config.SetAuthCfgForTesting(map[string]config.CredentialEntry{
+		config.RemoteAuthLookupURL(baseURL): {Bearer: "test-token"},
+	})
+	t.Cleanup(config.ClearAuthCfgForTesting)
+}
+
 func TestSyncPlayHistory_BulkImport(t *testing.T) {
-	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
 	env := newBackupTestEnv(t, "mister")
 	env.Manager.cfg.SetPlaytimeSync(true)
 	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
 
 	server, batches := playSyncTestServer(t, nil)
-	configureRemoteTestAuth(t, env.Manager, server.URL)
+	configurePlaytimeTestAuth(t, env.Manager, server.URL)
+	assert.Equal(t, config.DefaultBackupRemoteBaseURL, env.Manager.cfg.BackupRemoteBaseURL())
+	assert.Equal(t, server.URL, env.Manager.cfg.PlaytimeBaseURL())
 
 	first := playSyncTestEntry(1, "11111111-1111-4111-8111-111111111111", "Game A", base)
 	second := playSyncTestEntry(2, "22222222-2222-4222-8222-222222222222", "Game B", base.Add(time.Hour))
@@ -123,13 +135,13 @@ func TestSyncPlayHistory_BulkImport(t *testing.T) {
 }
 
 func TestSyncPlayHistory_ResumesFromServerWatermark(t *testing.T) {
-	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
 	env := newBackupTestEnv(t, "mister")
 	env.Manager.cfg.SetPlaytimeSync(true)
 	watermark := time.Now().UTC().Truncate(time.Second).Add(-2 * time.Hour)
 
 	server, batches := playSyncTestServer(t, &watermark)
-	configureRemoteTestAuth(t, env.Manager, server.URL)
+	configurePlaytimeTestAuth(t, env.Manager, server.URL)
 
 	env.UserDB.On(
 		"ResetMediaHistorySyncAfter",
@@ -149,13 +161,13 @@ func TestSyncPlayHistory_ResumesFromServerWatermark(t *testing.T) {
 }
 
 func TestSyncPlayHistory_PaginatesFullBatches(t *testing.T) {
-	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
 	env := newBackupTestEnv(t, "mister")
 	env.Manager.cfg.SetPlaytimeSync(true)
 	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
 
 	server, batches := playSyncTestServer(t, nil)
-	configureRemoteTestAuth(t, env.Manager, server.URL)
+	configurePlaytimeTestAuth(t, env.Manager, server.URL)
 
 	// A full first batch forces a second query cursored after its last row.
 	full := make([]database.MediaHistoryEntry, 0, playSyncBatchSize)
@@ -188,12 +200,12 @@ func TestSyncPlayHistory_PaginatesFullBatches(t *testing.T) {
 }
 
 func TestSyncPlayHistory_StopsWhenConsentRevokedDuringPass(t *testing.T) {
-	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
 	env := newBackupTestEnv(t, "mister")
 	env.Manager.cfg.SetPlaytimeSync(true)
 	base := time.Now().UTC().Truncate(time.Second).Add(-24 * time.Hour)
 	server, batches := playSyncTestServer(t, nil)
-	configureRemoteTestAuth(t, env.Manager, server.URL)
+	configurePlaytimeTestAuth(t, env.Manager, server.URL)
 	entry := playSyncTestEntry(1, "11111111-1111-4111-8111-111111111111", "Game A", base)
 
 	env.UserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Once()
@@ -227,7 +239,7 @@ func TestSyncPlayHistory_DisabledByConfig(t *testing.T) {
 }
 
 func TestSyncPlayHistory_Unlinked(t *testing.T) {
-	// No t.Parallel(): configureRemoteTestAuth mutates the global auth config.
+	// No t.Parallel(): other play-sync tests mutate the global auth config.
 	env := newBackupTestEnv(t, "mister")
 	env.Manager.cfg.SetPlaytimeSync(true)
 	// No credential configured: sync must report unlinked, not upload.


### PR DESCRIPTION
## Summary

- add an independent `[playtime].base_url` setting with the official API default and shared remote URL validation
- route play-history sync through the playtime endpoint without changing remote backup routing
- preserve linked backup credentials when the independent playtime endpoint returns unauthorized, with config and sync coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable play-history API connectivity with a default service URL.
  * Play-history synchronization now uses its dedicated API configuration.
  * Added support for normalized remote authentication URLs.

* **Bug Fixes**
  * Improved remote URL validation, including restrictions for unauthorized private or local addresses.
  * Invalid play-history URLs are rejected without overwriting the existing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->