### PR TITLE
fix: refine TUI launch policy and API docs

### DIFF
--- a/cmd/batocera/main.go
+++ b/cmd/batocera/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/daemon"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/tui"
+	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
 )
 
@@ -162,17 +163,14 @@ func run() error {
 	}
 
 	// start the tui
-	app, err := tui.BuildMain(
-		cfg, pl,
-		isRunning,
-		path.Join(helpers.DataDir(pl), config.LogFile),
-		"storage")
-	if err != nil {
-		log.Error().Msgf("error setting up UI: %s", err)
-		return fmt.Errorf("error setting up UI: %w", err)
-	}
-
-	err = app.Run()
+	err = tui.BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
+		return tui.BuildMain(
+			cfg, pl,
+			isRunning,
+			path.Join(helpers.DataDir(pl), config.LogFile),
+			"storage",
+		)
+	})
 	if err != nil {
 		log.Error().Msgf("error running UI: %s", err)
 		return fmt.Errorf("error running UI: %w", err)

--- a/cmd/libreelec/main.go
+++ b/cmd/libreelec/main.go
@@ -99,7 +99,7 @@ func run() error {
 	}
 
 	// display main info gui
-	err = tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
+	err = tui.BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
 		logDestinationPath := path.Join("/storage", config.LogFile)
 		isRunning := func() bool {
 			running, runningErr := svc.Running()

--- a/cmd/mister/gui.go
+++ b/cmd/mister/gui.go
@@ -100,7 +100,7 @@ func tryAddStartup() error {
 	}
 
 	if !startup.Exists("mrext/" + config.AppName) {
-		err := tui.BuildAndRetry(nil, buildTheInstallRequestApp)
+		err := tui.BuildAndRetry(nil, nil, buildTheInstallRequestApp)
 		if err != nil {
 			return fmt.Errorf("failed to show startup prompt: %w", err)
 		}
@@ -111,7 +111,7 @@ func tryAddStartup() error {
 
 func displayServiceInfo(pl platforms.Platform, cfg *config.Instance, service *daemon.Service) error {
 	// Asturur > Wizzo
-	err := tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
+	err := tui.BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
 		logDestinationPath := path.Join(misterconfig.DataDir, config.LogFile)
 		isRunning := func() bool {
 			running, err := service.Running()

--- a/cmd/replayos/main.go
+++ b/cmd/replayos/main.go
@@ -152,7 +152,7 @@ func runTUI(pl *replayos.Platform, cfg *config.Instance) error {
 	}
 	defer stopDaemon()
 
-	err = tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
+	err = tui.BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
 		logDestPath := filepath.Join(helpers.DataDir(pl), config.LogFile)
 		return tui.BuildMain(
 			cfg, pl,

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -228,7 +228,15 @@ An example request: `GET http://10.0.0.123:7497/run/**launch.system:snes`
 
 This would act as though a token with the text `**launch.system:snes` had been scanned.
 
-Requests from the local device are allowed without restriction. Remote requests must be explicitly allowed using the `allow_launch` config file setting.
+URL-encode media paths used in the endpoint. Core decodes the path once before running it, including encoded spaces and parentheses:
+
+```http
+GET http://10.0.0.123:7497/run/_Arcade/Youjyuden%20%28JP%29.mra
+```
+
+This runs `_Arcade/Youjyuden (JP).mra`.
+
+Requests from the local device are allowed without restriction. Remote requests must be explicitly allowed using the `allow_run` config setting.
 
 ## Methods
 

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2553,7 +2553,7 @@ An object:
 
 ### settings.auth.unlink
 
-Remove the device's online account credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured remote backup server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup state is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups. Removal is local only: the server has no revoke endpoint and invalidates the old token when the device links again.
+Remove the device's online account credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured remote backup server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup state is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups.
 
 Requires a localhost client or a paired admin client.
 

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2300,9 +2300,9 @@ None.
 | profilesRequireForLaunch  | boolean                                   | Yes      | Whether media launches are blocked while no personal profile is active. |
 | profilesSwapData          | boolean                                   | Yes      | Whether profile switches also swap profile-scoped data (saves, save states) on supported platforms. Defaults to true. |
 | backupRemoteEnabled       | boolean                                   | No       | Whether automatic remote backup scheduling is enabled. Only returned to localhost and paired admin clients. |
-| playtimeSyncEnabled       | boolean                                   | No       | Whether play history sync is enabled. Defaults to false. Only returned to localhost and paired admin clients. |
+| playtimeSyncEnabled       | boolean                                   | No       | Whether the user explicitly enabled play history sync. Defaults to false. Only returned to localhost and paired admin clients. |
 | backupRemoteSchedule      | string                                    | No       | Remote backup schedule: `daily`, `weekly`, or `manual`. Only returned to localhost and paired admin clients. |
-| backupRemoteBaseUrl       | string                                    | No       | Configured backup remote server base URL (read-only). Only returned to localhost and paired admin clients. |
+| backupRemoteBaseUrl       | string                                    | No       | Configured remote backup server base URL (read-only). Only returned to localhost and paired admin clients. |
 
 ##### Reader connection object
 
@@ -2386,7 +2386,7 @@ An object containing any of the following optional keys:
 | profilesRequireForLaunch  | boolean                                   | No       | Whether media launches are blocked while no personal profile is active. |
 | profilesSwapData          | boolean                                   | No       | Whether profile switches also swap profile-scoped data. Turning it off converges data back to the shared state immediately. |
 | backupRemoteEnabled       | boolean                                   | No       | Enable automatic remote backup scheduling. Requires a localhost or paired admin client. |
-| playtimeSyncEnabled       | boolean                                   | No       | Enable play history sync. Requires a localhost or paired admin client. |
+| playtimeSyncEnabled       | boolean                                   | No       | Explicitly enable or disable play history sync. The first enabled sync uploads retained local history. Disabling stops future uploads. Requires a localhost or paired admin client. |
 | backupRemoteSchedule      | string                                    | No       | Remote backup schedule: `daily`, `weekly`, or `manual`. Requires a localhost or paired admin client. |
 
 #### Result
@@ -2508,7 +2508,7 @@ An object:
 
 Report whether Core holds a stored bearer credential for an auth server URL. The check is local only: the token is never validated against the server and no token material is returned.
 
-Status probes are only answered for official Zaparoo API hosts over HTTPS and for the configured backup remote base URL. Any other URL returns `linked: false` without revealing whether a credential exists.
+Status probes are only answered for official Zaparoo API hosts over HTTPS and for the configured remote backup base URL. Any other URL returns `linked: false` without revealing whether a credential exists.
 
 #### Parameters
 
@@ -2553,7 +2553,7 @@ An object:
 
 ### settings.auth.unlink
 
-Remove the device's online account credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured backup remote server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups. Removal is local only: the server has no revoke endpoint and invalidates the old token when the device links again.
+Remove the device's online account credentials — the inverse of `settings.auth.link`. The claim/link flow tags every credential it stores with the root domain that created it (`linked_via` in `auth.toml`), so unlink removes the configured remote backup server's entry plus every entry tagged with it, whatever domains the server's trusted list contained at link time. Credentials for other domains, hand-written basic-auth entries, and API keys are untouched. Remote backup state is marked unlinked so the status UI prompts a re-link and the scheduler stops attempting remote backups. Removal is local only: the server has no revoke endpoint and invalidates the old token when the device links again.
 
 Requires a localhost client or a paired admin client.
 
@@ -2764,23 +2764,23 @@ None.
 
 ### Device backup methods
 
-Backup methods operate on portable full-device ZIP snapshots. Authentication credentials are excluded from local and cloud snapshots. Restoring a snapshot restarts Core and requires clients to pair again. Mutating, listing, inspecting, and restoring methods require a localhost client or a paired admin client. Restore is refused while media is active.
+Backup methods operate on portable full-device ZIP snapshots. Authentication credentials are excluded from local and remote backups. Restoring a backup restarts Core while preserving the destination device's identity, encryption setting, paired clients, and stored authentication credentials. Mutating, listing, inspecting, and restoring methods require a localhost client or a paired admin client. Restore is refused while media is active.
 
 | Method | Parameters | Result |
 | :----- | :--------- | :----- |
-| `settings.backup` | None | Creates a bounded local ZIP and returns backup metadata. `integrity` is `valid` after creation. |
+| `settings.backup` | None | Creates a local ZIP and returns backup metadata. `integrity` is `valid` after creation. |
 | `settings.backup.list` | None | Lists local ZIP metadata without reading manifests. |
 | `settings.backup.inspect` | `{ "name": string }` | Reads manifest metadata. Payload `integrity` is `unchecked`; restore verifies every payload before mutation. |
 | `settings.backup.delete` | `{ "name": string }` | Deletes local ZIP and returns `null`. |
 | `settings.backup.restore` | `{ "name": string }` | Transactionally restores local ZIP, returns restore metadata, then restarts Core after response is written. |
-| `settings.backup.status` | None | Returns local/remote status, partial warnings, active operation, link state, linked device identity (`deviceName`, `linkedAt`), and Warp availability. A stale availability value triggers a background refresh; the response never blocks on the cloud API. |
-| `settings.backup.remote.run` | None | Creates manual cloud snapshot and returns upload/dedup metadata. |
-| `settings.backup.remote.list` | None | Lists cloud snapshots. Backup and device IDs are opaque strings. |
-| `settings.backup.remote.restore` | `{ "id": string }` | Transactionally restores cloud snapshot, reports completion, then restarts Core. |
+| `settings.backup.status` | None | Returns local and remote status, partial warnings, active operation, link state, linked device identity (`deviceName`, `linkedAt`), and Warp availability. Remote status distinguishes the latest successful run (`lastSuccessAt`) from the last stored content change (`lastSnapshotCreatedAt`); `lastRunNoChanges` identifies a successful unchanged run. A stale availability value triggers a background refresh, and the response never blocks on the remote API. |
+| `settings.backup.remote.run` | None | Creates a manual remote backup and returns uploaded/deduplicated file and pack counts, bytes, quota usage, warnings, skipped-file count, and `noChanges` when the server already holds an identical backup. |
+| `settings.backup.remote.list` | None | Lists remote backups. Backup and device IDs are opaque strings. |
+| `settings.backup.remote.restore` | `{ "id": string }` | Transactionally restores a remote backup, reports completion, then restarts Core. |
 
-`backup.remote.enabled` enables automatic scheduling only. Linked devices may manually upload, list, and restore while scheduling is disabled. Warp availability gates upload and scheduling; listing and restoring existing snapshots remain available. A cloud API `401` immediately marks device unlinked until a fresh link succeeds.
+`backup.remote.enabled` enables automatic scheduling only. Linked devices may manually upload, list, and restore while scheduling is disabled. Warp availability gates upload and scheduling; listing and restoring existing backups remain available. A remote API `401` immediately marks the device unlinked until a fresh link succeeds.
 
-Archives use known categories (`zaparoo`, `settings`, `inputs`, `saves`, and `savestates`), exact platform matching, SHA-256 payload verification, and configured size limits. `partial` status means snapshot completed but one or more unsafe or unavailable source paths were skipped; inspect/status responses include structured `warnings`. Archives that fail ZIP header, manifest, or platform-policy validation return an RPC error without backup metadata. Successful inspection reports `unchecked` because payload hashes are verified during restore.
+Archives use known categories (`zaparoo`, `settings`, `inputs`, `saves`, and `savestates`), exact platform matching, SHA-256 payload verification, and fixed entry, path, and manifest limits. Local and remote restores stage and verify every payload before device mutation. Remote files that cannot fit in a 64 MiB transfer pack are skipped and reported; server quota is checked before upload. `partial` status means a backup completed but one or more unsafe, unavailable, or oversized source files were skipped. Structured `warnings` describe unsafe or unavailable paths, while `skippedFiles` also counts oversized remote files. Archives that fail ZIP header, manifest, or platform-policy validation return an RPC error without backup metadata. Successful inspection reports `unchecked` because payload hashes are verified during restore.
 
 ## Playtime
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -288,7 +288,7 @@ func RunApp(pl platforms.Platform, cfg *config.Instance, daemonMode bool) (retur
 			return fmt.Errorf("error getting user home directory: %w", err)
 		}
 
-		err = tui.BuildAndRetry(cfg, func() (*tview.Application, error) {
+		err = tui.BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
 			return tui.BuildMain(
 				cfg, pl,
 				func() bool { return client.IsServiceRunning(cfg) },

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -296,11 +296,12 @@ func (p *Platform) getESConfig() *ESSystemConfig {
 
 func (*Platform) Settings() platforms.Settings {
 	return platforms.Settings{
-		DataDir:    DataDir,
-		ConfigDir:  ConfigDir,
-		TempDir:    filepath.Join(os.TempDir(), config.AppName),
-		LogDir:     LogDir,
-		ZipsAsDirs: false,
+		DataDir:               DataDir,
+		ConfigDir:             ConfigDir,
+		TempDir:               filepath.Join(os.TempDir(), config.AppName),
+		LogDir:                LogDir,
+		ZipsAsDirs:            false,
+		DisableZapScriptInTUI: true,
 	}
 }
 

--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSettings_DisablesZapScriptWhileTUIOpen(t *testing.T) {
+	t.Parallel()
+	assert.True(t, (&Platform{}).Settings().DisableZapScriptInTUI)
+}
+
 func TestPresentUIForwardsPassiveEvents(t *testing.T) {
 	// MockESAPIServer binds to hardcoded port 1234.
 	mockESAPI := helpers.NewMockESAPIServer(t)

--- a/pkg/platforms/libreelec/platform_test.go
+++ b/pkg/platforms/libreelec/platform_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSettings_AllowsZapScriptAlongsideTUI(t *testing.T) {
+	t.Parallel()
+	assert.False(t, (&Platform{}).Settings().DisableZapScriptInTUI)
+}
+
 // TestLibreELECHasKodiLaunchers tests that LibreELEC includes all Kodi launchers
 func TestLibreELECHasKodiLaunchers(t *testing.T) {
 	t.Parallel()

--- a/pkg/platforms/linux/platform_test.go
+++ b/pkg/platforms/linux/platform_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSettings_AllowsZapScriptAlongsideTUI(t *testing.T) {
+	t.Parallel()
+	assert.False(t, (&Platform{}).Settings().DisableZapScriptInTUI)
+}
+
 func TestLinuxHasKodiLocalLauncher(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -478,11 +478,12 @@ func (p *Platform) filesystem() afero.Fs {
 
 func (*Platform) Settings() platforms.Settings {
 	return platforms.Settings{
-		DataDir:    misterconfig.DataDir,
-		ConfigDir:  misterconfig.DataDir,
-		TempDir:    misterconfig.TempDir,
-		LogDir:     misterconfig.TempDir,
-		ZipsAsDirs: true,
+		DataDir:               misterconfig.DataDir,
+		ConfigDir:             misterconfig.DataDir,
+		TempDir:               misterconfig.TempDir,
+		LogDir:                misterconfig.TempDir,
+		ZipsAsDirs:            true,
+		DisableZapScriptInTUI: true,
 	}
 }
 

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -44,6 +44,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSettings_DisablesZapScriptWhileTUIOpen(t *testing.T) {
+	t.Parallel()
+	assert.True(t, (&Platform{}).Settings().DisableZapScriptInTUI)
+}
+
 // mockLauncherManager is a minimal mock for testing
 type mockLauncherManager struct{}
 

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -374,6 +374,10 @@ type Settings struct {
 	// ZipsAsDir returns true if this platform treats .zip files as if they
 	// were directories for the purpose of launching media.
 	ZipsAsDirs bool
+	// DisableZapScriptInTUI prevents token scans from launching media while
+	// the TUI occupies the platform's primary display. Leave false when the
+	// TUI and launched media can run alongside each other.
+	DisableZapScriptInTUI bool
 }
 
 // ScraperCustomOption is a single user-configurable option for a scraper.

--- a/pkg/platforms/replayos/platform_test.go
+++ b/pkg/platforms/replayos/platform_test.go
@@ -286,6 +286,7 @@ func TestSettings(t *testing.T) {
 	assert.Equal(t, installDir, s.ConfigDir)
 	assert.Equal(t, installDir+"/logs", s.LogDir)
 	assert.NotEmpty(t, s.TempDir)
+	assert.False(t, s.DisableZapScriptInTUI)
 }
 
 func TestWriteAutostart(t *testing.T) {

--- a/pkg/ui/tui/utils.go
+++ b/pkg/ui/tui/utils.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/client"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
@@ -480,16 +481,21 @@ type PrimitiveWithSetBorder interface {
 	SetBorder(arg bool) *tview.Box
 }
 
+func shouldDisableZapScriptInTUI(cfg *config.Instance, pl platforms.Platform) bool {
+	return cfg != nil && pl != nil && pl.Settings().DisableZapScriptInTUI
+}
+
 // BuildAndRetry attempts to build and display a TUI dialog, retrying with
 // alternate settings on error.
 // It's used to work around issues on MiSTer, which has an unusual setup for
-// showing TUI applications.
-// When cfg is non-nil, ZapScript execution is disabled while the TUI is open.
+// showing TUI applications. ZapScript is disabled only on platforms whose TUI
+// occupies the primary display and cannot run alongside launched media.
 func BuildAndRetry(
 	cfg *config.Instance,
+	pl platforms.Platform,
 	builder func() (*tview.Application, error),
 ) error {
-	if cfg != nil {
+	if shouldDisableZapScriptInTUI(cfg, pl) {
 		enableZapScript := client.DisableZapScript(cfg)
 		defer enableZapScript()
 	}

--- a/pkg/ui/tui/utils.go
+++ b/pkg/ui/tui/utils.go
@@ -39,6 +39,8 @@ const TUIRequestTimeout = 5 * time.Second
 // This is longer than TUIRequestTimeout to give users time to physically tap a tag.
 const TagReadTimeout = 30 * time.Second
 
+var disableZapScript = client.DisableZapScript
+
 // tuiContext creates a context with the TUI request timeout.
 // Use this for API calls from the TUI to avoid long hangs.
 func tuiContext() (context.Context, context.CancelFunc) {
@@ -496,7 +498,7 @@ func BuildAndRetry(
 	builder func() (*tview.Application, error),
 ) error {
 	if shouldDisableZapScriptInTUI(cfg, pl) {
-		enableZapScript := client.DisableZapScript(cfg)
+		enableZapScript := disableZapScript(cfg)
 		defer enableZapScript()
 	}
 

--- a/pkg/ui/tui/utils_test.go
+++ b/pkg/ui/tui/utils_test.go
@@ -21,6 +21,8 @@ package tui
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -62,6 +64,43 @@ func TestShouldDisableZapScriptInTUI(t *testing.T) {
 		pl.On("Settings").Return(platforms.Settings{DisableZapScriptInTUI: true})
 		assert.True(t, shouldDisableZapScriptInTUI(cfg, pl))
 	})
+}
+
+func TestBuildAndRetry_AppliesPlatformZapScriptPolicy(t *testing.T) {
+	originalDisableZapScript := disableZapScript
+	t.Cleanup(func() {
+		disableZapScript = originalDisableZapScript
+	})
+
+	buildErr := errors.New("build failed")
+	for _, shouldDisable := range []bool{false, true} {
+		t.Run(fmt.Sprintf("disable=%t", shouldDisable), func(t *testing.T) {
+			cfg := &config.Instance{}
+			pl := testingmocks.NewMockPlatform()
+			pl.On("Settings").Return(platforms.Settings{
+				DisableZapScriptInTUI: shouldDisable,
+			}).Once()
+
+			disabled := false
+			restored := false
+			disableZapScript = func(gotCfg *config.Instance) func() {
+				assert.Same(t, cfg, gotCfg)
+				disabled = true
+				return func() {
+					restored = true
+				}
+			}
+
+			err := BuildAndRetry(cfg, pl, func() (*tview.Application, error) {
+				assert.Equal(t, shouldDisable, disabled)
+				return nil, buildErr
+			})
+			require.ErrorIs(t, err, buildErr)
+			assert.Equal(t, shouldDisable, disabled)
+			assert.Equal(t, shouldDisable, restored)
+			pl.AssertExpectations(t)
+		})
+	}
 }
 
 func TestCenterWidget(t *testing.T) {

--- a/pkg/ui/tui/utils_test.go
+++ b/pkg/ui/tui/utils_test.go
@@ -24,11 +24,45 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testingmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestShouldDisableZapScriptInTUI(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+
+	t.Run("nil config", func(t *testing.T) {
+		t.Parallel()
+		pl := testingmocks.NewMockPlatform()
+		assert.False(t, shouldDisableZapScriptInTUI(nil, pl))
+	})
+
+	t.Run("nil platform", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, shouldDisableZapScriptInTUI(cfg, nil))
+	})
+
+	t.Run("concurrent TUI", func(t *testing.T) {
+		t.Parallel()
+		pl := testingmocks.NewMockPlatform()
+		pl.On("Settings").Return(platforms.Settings{})
+		assert.False(t, shouldDisableZapScriptInTUI(cfg, pl))
+	})
+
+	t.Run("exclusive TUI", func(t *testing.T) {
+		t.Parallel()
+		pl := testingmocks.NewMockPlatform()
+		pl.On("Settings").Return(platforms.Settings{DisableZapScriptInTUI: true})
+		assert.True(t, shouldDisableZapScriptInTUI(cfg, pl))
+	})
+}
 
 func TestCenterWidget(t *testing.T) {
 	t.Parallel()

--- a/pkg/ui/widgets/widgets.go
+++ b/pkg/ui/widgets/widgets.go
@@ -367,7 +367,7 @@ func NoticeUI(cfg *config.Instance, pl platforms.Platform, argsPath string, load
 		}()
 	}
 
-	err := tui.BuildAndRetry(nil, func() (*tview.Application, error) {
+	err := tui.BuildAndRetry(nil, nil, func() (*tview.Application, error) {
 		return NoticeUIBuilder(cfg, pl, argsPath, loader)
 	})
 	log.Debug().Msg("exiting notice widget")
@@ -604,7 +604,7 @@ func PickerUI(cfg *config.Instance, pl platforms.Platform, argsPath string) erro
 		}()
 	}
 
-	err := tui.BuildAndRetry(nil, func() (*tview.Application, error) {
+	err := tui.BuildAndRetry(nil, nil, func() (*tview.Application, error) {
 		return PickerUIBuilder(cfg, pl, argsPath)
 	})
 	log.Debug().Msg("exiting picker widget")

--- a/pkg/ui/widgets/widgets.go
+++ b/pkg/ui/widgets/widgets.go
@@ -54,6 +54,12 @@ const (
 
 type localClientFunc func(context.Context, *config.Instance, string, string) (string, error)
 
+type buildAndRetryFunc func(
+	*config.Instance,
+	platforms.Platform,
+	func() (*tview.Application, error),
+) error
+
 func runningFromZapScript() bool {
 	return os.Getenv("ZAPAROO_RUN_SCRIPT") == "2"
 }
@@ -327,6 +333,16 @@ func buildNoticeUI(
 
 // NoticeUI displays a message with an optional loading spinner.
 func NoticeUI(cfg *config.Instance, pl platforms.Platform, argsPath string, loader bool) error {
+	return runNoticeUI(cfg, pl, argsPath, loader, tui.BuildAndRetry)
+}
+
+func runNoticeUI(
+	cfg *config.Instance,
+	pl platforms.Platform,
+	argsPath string,
+	loader bool,
+	buildAndRetry buildAndRetryFunc,
+) error {
 	log.Info().Str("args", argsPath).Msg("showing notice")
 
 	pidFileCreated := false
@@ -367,7 +383,7 @@ func NoticeUI(cfg *config.Instance, pl platforms.Platform, argsPath string, load
 		}()
 	}
 
-	err := tui.BuildAndRetry(nil, nil, func() (*tview.Application, error) {
+	err := buildAndRetry(cfg, pl, func() (*tview.Application, error) {
 		return NoticeUIBuilder(cfg, pl, argsPath, loader)
 	})
 	log.Debug().Msg("exiting notice widget")
@@ -564,6 +580,15 @@ func buildPickerUI(
 
 // PickerUI displays a list picker of ZapScript commands to run.
 func PickerUI(cfg *config.Instance, pl platforms.Platform, argsPath string) error {
+	return runPickerUI(cfg, pl, argsPath, tui.BuildAndRetry)
+}
+
+func runPickerUI(
+	cfg *config.Instance,
+	pl platforms.Platform,
+	argsPath string,
+	buildAndRetry buildAndRetryFunc,
+) error {
 	log.Info().Str("args", argsPath).Msg("showing picker")
 
 	pidFileCreated := false
@@ -604,7 +629,7 @@ func PickerUI(cfg *config.Instance, pl platforms.Platform, argsPath string) erro
 		}()
 	}
 
-	err := tui.BuildAndRetry(nil, nil, func() (*tview.Application, error) {
+	err := buildAndRetry(cfg, pl, func() (*tview.Application, error) {
 		return PickerUIBuilder(cfg, pl, argsPath)
 	})
 	log.Debug().Msg("exiting picker widget")

--- a/pkg/ui/widgets/widgets_test.go
+++ b/pkg/ui/widgets/widgets_test.go
@@ -30,7 +30,9 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	testingmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -76,6 +78,59 @@ func waitForWidgetExit(t *testing.T, done <-chan error) {
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("widget did not stop")
+	}
+}
+
+func TestWidgetUIPassesPlatformPolicyToBuildAndRetry(t *testing.T) {
+	t.Setenv("ZAPAROO_RUN_SCRIPT", "")
+
+	cfg := &config.Instance{}
+	widgets := []struct {
+		run  func(*config.Instance, platforms.Platform, buildAndRetryFunc) error
+		name string
+	}{
+		{
+			name: "notice",
+			run: func(cfg *config.Instance, pl platforms.Platform, buildAndRetry buildAndRetryFunc) error {
+				return runNoticeUI(cfg, pl, "unused", false, buildAndRetry)
+			},
+		},
+		{
+			name: "picker",
+			run: func(cfg *config.Instance, pl platforms.Platform, buildAndRetry buildAndRetryFunc) error {
+				return runPickerUI(cfg, pl, "unused", buildAndRetry)
+			},
+		},
+	}
+
+	for _, widget := range widgets {
+		for _, disableZapScript := range []bool{false, true} {
+			name := fmt.Sprintf("%s/disable=%t", widget.name, disableZapScript)
+			t.Run(name, func(t *testing.T) {
+				pl := testingmocks.NewMockPlatform()
+				pl.On("Settings").Return(platforms.Settings{
+					DisableZapScriptInTUI: disableZapScript,
+				}).Once()
+
+				called := false
+				buildAndRetry := func(
+					gotCfg *config.Instance,
+					gotPl platforms.Platform,
+					builder func() (*tview.Application, error),
+				) error {
+					called = true
+					assert.Same(t, cfg, gotCfg)
+					assert.Same(t, pl, gotPl)
+					assert.Equal(t, disableZapScript, gotPl.Settings().DisableZapScriptInTUI)
+					assert.NotNil(t, builder)
+					return nil
+				}
+
+				require.NoError(t, widget.run(cfg, pl, buildAndRetry))
+				assert.True(t, called)
+				pl.AssertExpectations(t)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep ZapScript active while concurrent TUIs are open, disabling it only for MiSTer and Batocera
- route Batocera through shared TUI retry and suppression policy with platform coverage
- clarify URL-encoded `/run` paths, playtime sync settings, and remote backup API behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware TUI startup now gates media-launch behavior according to each platform’s policy, with ZapScript availability controlled while the TUI is active.
* **Documentation**
  * Launch endpoint docs now require URL-encoding for media paths (with decoding clarification).
  * Remote launch permission renamed from `allow_launch` to `allow_run`.
  * Settings/auth and device backup/restore documentation updated and expanded.
* **Bug Fixes**
  * Improved TUI build/retry behavior and consolidated error handling for TUI startup failures.
* **Tests**
  * Added/updated tests covering platform ZapScript gating and widget/TUI integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->