### PR TITLE
fix(ci): stabilize cross-platform and fuzz checks

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,35 +52,78 @@ jobs:
         run: go mod download
 
       - name: Run fuzz tests
-        run: task fuzz
+        id: fuzz
+        run: |
+          set -o pipefail
+          task fuzz 2>&1 | tee fuzz.log
         env:
           FUZZ_TIME: ${{ inputs.fuzz-time || '2m' }}
 
-      - name: Upload crash corpus
-        if: failure()
+      - name: Classify fuzz failure
+        if: failure() && steps.fuzz.outcome == 'failure'
+        id: fuzz-failure
+        run: |
+          kind=failure
+          artifact_dir=fuzz-failure-artifact
+          mkdir -p "$artifact_dir"
+          cp fuzz.log "$artifact_dir/fuzz.log"
+
+          while IFS= read -r corpus; do
+            kind=crash
+            destination="$artifact_dir/$corpus"
+            mkdir -p "$(dirname "$destination")"
+            cp "$corpus" "$destination"
+          done < <(git ls-files --others --exclude-standard -- '**/testdata/fuzz/**')
+
+          failed_targets="$(grep -c 'FAIL: Fuzz.* in \./pkg/' fuzz.log || true)"
+          timeouts="$(grep -c 'context deadline exceeded' fuzz.log || true)"
+          if [[ "$kind" != "crash" && "$timeouts" -gt 0 && "$failed_targets" -eq "$timeouts" ]]; then
+            kind=timeout
+          fi
+          echo "kind=$kind" >> "$GITHUB_OUTPUT"
+
+      - name: Upload fuzz failure evidence
+        if: failure() && steps.fuzz.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: fuzz-crashes
-          path: "**/testdata/fuzz/**"
-          if-no-files-found: ignore
+          name: fuzz-${{ steps.fuzz-failure.outputs.kind }}
+          path: fuzz-failure-artifact
+          if-no-files-found: error
 
       - name: Create issue on failure
-        if: failure()
+        if: failure() && steps.fuzz.outcome == 'failure'
         env:
+          FAILURE_KIND: ${{ steps.fuzz-failure.outputs.kind }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          case "$FAILURE_KIND" in
+            crash)
+              title="Nightly fuzz: crash found ($(date -u +%Y-%m-%d))"
+              summary="The fuzz run produced a new failing corpus entry."
+              next_step="Download the artifact, place the corpus file in its matching testdata/fuzz/FuzzName directory, and run the target with go test -run FuzzName/corpus_filename ./pkg/path/to/package."
+              ;;
+            timeout)
+              title="Nightly fuzz: timeout ($(date -u +%Y-%m-%d))"
+              summary="The fuzz run ended with context deadline exceeded and produced no new corpus entry. This is a timeout, not a confirmed crash."
+              next_step="Review fuzz.log for the stalled target and rerun it before changing production code."
+              ;;
+            *)
+              title="Nightly fuzz: failure ($(date -u +%Y-%m-%d))"
+              summary="The fuzz command failed without a timeout signature or new corpus entry."
+              next_step="Review fuzz.log to identify the failing target."
+              ;;
+          esac
+
           gh issue create \
-            --title "Nightly fuzz: crash found ($(date -u +%Y-%m-%d))" \
+            --title "$title" \
             --label "bug" \
-            --body "$(cat <<'EOF'
-          The nightly fuzz run found a crash. The failing corpus entry is attached as an artifact on the workflow run.
+            --body "$(cat <<EOF
+          $summary
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          **Failure type:** $FAILURE_KIND
+          **Artifact:** fuzz-$FAILURE_KIND
 
-          Download the `fuzz-crashes` artifact from that run and place the corpus file into the appropriate `testdata/fuzz/FuzzName/` directory to reproduce locally:
-
-          ```
-          go test -run FuzzName/corpus_filename ./pkg/path/to/package
-          ```
+          $next_step
           EOF
           )"

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -345,12 +345,14 @@ jobs:
         run: |
           go test -v -race \
             ./pkg/api \
+            ./pkg/database/mediascanner \
             ./pkg/helpers \
             ./pkg/helpers/command \
             ./pkg/readers/externaldrive \
             ./pkg/platforms/shared/steam \
             ./pkg/platforms/shared/steam/steamtracker \
             ./pkg/service \
+            ./pkg/service/backup \
             ./pkg/service/restart \
             ./pkg/ui/systray
 
@@ -359,12 +361,14 @@ jobs:
         run: |
           go test -v -race \
             ./pkg/api \
+            ./pkg/database/mediascanner \
             ./pkg/helpers \
             ./pkg/helpers/command \
             ./pkg/readers/externaldrive \
             ./pkg/platforms/shared/steam \
             ./pkg/platforms/shared/steam/steamtracker \
             ./pkg/service \
+            ./pkg/service/backup \
             ./pkg/service/daemon \
             ./pkg/service/restart \
             ./pkg/ui/systray

--- a/pkg/database/mediascanner/scan_reconcile_test.go
+++ b/pkg/database/mediascanner/scan_reconcile_test.go
@@ -94,7 +94,7 @@ func TestReconcile_NewSystemInsertsTitlesMediaAndTags(t *testing.T) {
 	row := byPath[gamePath]
 	require.NotZero(t, row.DBID)
 	assert.False(t, row.IsMissing)
-	assert.Equal(t, mediadb.ParentDirForMediaPath(gamePath), row.ParentDir)
+	assert.Equal(t, mediadb.ParentDirForMediaPath(filepath.ToSlash(gamePath)), row.ParentDir)
 	assert.Equal(t, "Super Game", row.SortName)
 
 	got := mediaTagStrings(t, mediaDB, row.DBID)
@@ -437,7 +437,7 @@ func TestReconcile_RepairsParentDirAndSortName(t *testing.T) {
 	assert.Equal(t, int64(1), stats.MediaUpserted)
 
 	repaired := mediaBySystem(t, mediaDB, "SNES")[gamePath]
-	assert.Equal(t, mediadb.ParentDirForMediaPath(gamePath), repaired.ParentDir)
+	assert.Equal(t, mediadb.ParentDirForMediaPath(filepath.ToSlash(gamePath)), repaired.ParentDir)
 	assert.Equal(t, "Epsilon", repaired.SortName)
 }
 

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -2264,7 +2264,9 @@ func TestManagerWritesStatusAtomically(t *testing.T) {
 	assert.True(t, stored.Remote.Unlinked)
 	info, err := os.Stat(env.Manager.statusPath())
 	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 	entries, err := os.ReadDir(filepath.Dir(env.Manager.statusPath()))
 	require.NoError(t, err)
 	for _, entry := range entries {
@@ -3753,12 +3755,17 @@ func TestRemoteClientManifestResponsesExceedDefaultLimit(t *testing.T) {
 	manifest = append(manifest, []byte(`{"pad":"end"}]`)...)
 	require.Greater(t, len(manifest), int(helpers.MaxResponseBodySize))
 
+	response, err := json.Marshal(remoteBackupResponse{
+		ID: "backup-3", SchemaVersion: remoteSchemaVersion, Manifest: json.RawMessage(manifest),
+		CreatedAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/3" {
-			writeJSON(t, w, remoteBackupResponse{
-				ID: "backup-3", SchemaVersion: remoteSchemaVersion, Manifest: json.RawMessage(manifest),
-				CreatedAt: time.Now().UTC(),
-			})
+			w.Header().Set("Content-Type", "application/json")
+			// The size-limited request intentionally closes before reading the full response.
+			_, _ = w.Write(response)
 			return
 		}
 		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -3768,7 +3775,7 @@ func TestRemoteClientManifestResponsesExceedDefaultLimit(t *testing.T) {
 	client := &remoteClient{httpClient: server.Client(), baseURL: server.URL, bearer: "t", platform: "test"}
 
 	var small remoteBackupResponse
-	err := client.doJSON(context.Background(), http.MethodGet, "/v1/device/backups/3", nil, &small)
+	err = client.doJSON(context.Background(), http.MethodGet, "/v1/device/backups/3", nil, &small)
 	require.Error(t, err, "the default limit truncates manifest-bearing responses")
 
 	var full remoteBackupResponse

--- a/pkg/service/mappings_fuzz_test.go
+++ b/pkg/service/mappings_fuzz_test.go
@@ -24,8 +24,15 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 )
+
+func resetRegexCacheAfterFuzzCase(t *testing.T) {
+	t.Helper()
+	// Keep random one-off patterns from accumulating in the process-wide cache.
+	t.Cleanup(helpers.GlobalRegexCache.Clear)
+}
 
 // FuzzCheckMappingUID tests UID mapping matching with arbitrary patterns and
 // data, covering exact, partial, and regex match types.
@@ -47,6 +54,7 @@ func FuzzCheckMappingUID(f *testing.F) {
 		default:
 			return
 		}
+		resetRegexCacheAfterFuzzCase(t)
 
 		m := &database.Mapping{
 			Pattern: pattern,
@@ -90,6 +98,7 @@ func FuzzCheckMappingText(f *testing.F) {
 		default:
 			return
 		}
+		resetRegexCacheAfterFuzzCase(t)
 
 		m := &database.Mapping{
 			Pattern: pattern,
@@ -129,6 +138,7 @@ func FuzzCheckMappingData(f *testing.F) {
 		default:
 			return
 		}
+		resetRegexCacheAfterFuzzCase(t)
 
 		m := &database.Mapping{
 			Pattern: pattern,


### PR DESCRIPTION
## Summary

- correct platform-specific MediaScanner and backup test assumptions
- bound mapping fuzz cache growth and classify crash, timeout, and generic failures separately
- run MediaScanner and backup tests in native Windows and macOS PR checks

Closes #1150
Ref #1149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated fuzz-failure reporting by distinguishing crashes, timeouts, and general failures, with clearer evidence and reproduction guidance.
  * Prevented stale regex state from affecting successive fuzzing cases.

* **Tests**
  * Expanded native Windows and macOS test coverage for media scanning and backup services.
  * Improved cross-platform backup test reliability and media path verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->