### PR TITLE
perf(database): reuse browse presence probe

### DIFF
--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -1717,6 +1717,9 @@ func sqlBrowseRouteCountsFromMedia(
 			probeHasMedia, probeErr = sqlBrowseRouteHasMedia(ctx, db, systemClause, systemArgs)
 			probeAttempted = true
 		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("browse route counts media scan: %w", ctxErr)
+		}
 		if probeErr != nil {
 			log.Warn().Err(probeErr).Str("route", route).
 				Msg("browse route count timed out and presence probe failed; skipping route")

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -1659,6 +1659,13 @@ func sqlBrowseRouteCountsFromMedia(
 		return counts, nil
 	}
 	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	// The presence probe depends only on the system filter, so reuse its
+	// outcome across every route count that times out during this call.
+	var (
+		probeAttempted bool
+		probeHasMedia  bool
+		probeErr       error
+	)
 	for _, route := range opts.Routes {
 		prefix := browseRouteCacheKey(route)
 		args := append([]any{prefix}, systemArgs...)
@@ -1706,13 +1713,16 @@ func sqlBrowseRouteCountsFromMedia(
 		// result keeps the route browsable without another path-prefix scan. If
 		// the probe finds nothing (or itself times out), drop the route and keep
 		// browsing the rest.
-		hasMedia, probeErr := sqlBrowseRouteHasMedia(ctx, db, systemClause, systemArgs)
+		if !probeAttempted {
+			probeHasMedia, probeErr = sqlBrowseRouteHasMedia(ctx, db, systemClause, systemArgs)
+			probeAttempted = true
+		}
 		if probeErr != nil {
 			log.Warn().Err(probeErr).Str("route", route).
 				Msg("browse route count timed out and presence probe failed; skipping route")
 			continue
 		}
-		if !hasMedia {
+		if !probeHasMedia {
 			continue
 		}
 		log.Warn().Str("route", route).

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -24,7 +24,9 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -506,37 +508,141 @@ func TestSqlBrowseRouteCountsFromCache_UsesChildDirCounts(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// Not parallel: the route-context case mutates the package-level count timeout.
 func TestSqlBrowseRouteCountsFromMedia_ReusesPresenceProbeAcrossTimeouts(t *testing.T) {
+	tests := []struct {
+		probeErr            error
+		name                string
+		probeHasMedia       bool
+		routeContextTimeout bool
+		wantUnknownCounts   bool
+	}{
+		{
+			name:              "media present",
+			probeHasMedia:     true,
+			wantUnknownCounts: true,
+		},
+		{
+			name: "no rows",
+		},
+		{
+			name:     "probe timeout",
+			probeErr: context.DeadlineExceeded,
+		},
+		{
+			name:     "probe error",
+			probeErr: errors.New("probe failed"),
+		},
+		{
+			name:                "route context timeout",
+			probeHasMedia:       true,
+			routeContextTimeout: true,
+			wantUnknownCounts:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			probeQueries := 0
+			matcher := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+				if strings.Contains(actualSQL, "SELECT 1") {
+					probeQueries++
+				}
+				return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+			})
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			if tc.routeContextTimeout {
+				originalTimeout := browseRouteCountSubTimeout
+				browseRouteCountSubTimeout = 100 * time.Millisecond
+				t.Cleanup(func() { browseRouteCountSubTimeout = originalTimeout })
+			}
+
+			routeA := browseTestPath("roms", "a")
+			routeB := browseTestPath("roms", "b")
+			expectCountTimeout := func(route string) {
+				t.Helper()
+				expectation := mock.ExpectQuery("SELECT COUNT").
+					WithArgs(browseRouteCacheKey(route), "SNES")
+				if tc.routeContextTimeout {
+					expectation.WillDelayFor(time.Second).WillReturnError(errors.New("interrupted"))
+				} else {
+					expectation.WillReturnError(context.DeadlineExceeded)
+				}
+			}
+			expectCountTimeout(routeA)
+			probeExpectation := mock.ExpectQuery("SELECT 1").WithArgs("SNES")
+			if tc.probeErr != nil {
+				probeExpectation.WillReturnError(tc.probeErr)
+			} else {
+				probeRows := sqlmock.NewRows([]string{"one"})
+				if tc.probeHasMedia {
+					probeRows.AddRow(1)
+				}
+				probeExpectation.WillReturnRows(probeRows)
+			}
+			expectCountTimeout(routeB)
+			// Keep one query pending so the matcher sees an unexpected second probe.
+			mock.ExpectQuery("SELECT sentinel").
+				WillReturnRows(sqlmock.NewRows([]string{"one"}).AddRow(1))
+
+			counts, err := sqlBrowseRouteCountsFromMedia(context.Background(), db, database.BrowseRouteCountsOptions{
+				Routes:  []string{routeA, routeB},
+				Systems: []systemdefs.System{{ID: "SNES"}},
+			})
+			require.NoError(t, err)
+			if tc.wantUnknownCounts {
+				require.Len(t, counts, 2)
+				for _, route := range []string{routeA, routeB} {
+					assert.Equal(t, database.BrowseRouteCount{
+						Path:         route,
+						SystemIDs:    []string{"SNES"},
+						CountUnknown: true,
+					}, counts[route])
+				}
+			} else {
+				assert.Empty(t, counts)
+			}
+
+			var sentinel int
+			require.NoError(t, db.QueryRowContext(context.Background(), "SELECT sentinel").Scan(&sentinel))
+			assert.Equal(t, 1, probeQueries)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSqlBrowseRouteCountsFromMedia_PropagatesCancellationDuringProbe(t *testing.T) {
 	t.Parallel()
-	db, mock, err := sqlmock.New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	matcher := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		if strings.Contains(actualSQL, "SELECT 1") {
+			cancel()
+		}
+		return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(matcher))
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	routeA := browseTestPath("roms", "a")
-	routeB := browseTestPath("roms", "b")
+	route := browseTestPath("roms", "a")
 	mock.ExpectQuery("SELECT COUNT").
-		WithArgs(browseRouteCacheKey(routeA), "SNES").
+		WithArgs(browseRouteCacheKey(route), "SNES").
 		WillReturnError(context.DeadlineExceeded)
 	mock.ExpectQuery("SELECT 1").
 		WithArgs("SNES").
-		WillReturnRows(sqlmock.NewRows([]string{"one"}).AddRow(1))
-	mock.ExpectQuery("SELECT COUNT").
-		WithArgs(browseRouteCacheKey(routeB), "SNES").
-		WillReturnError(context.DeadlineExceeded)
+		WillReturnError(context.Canceled)
 
-	counts, err := sqlBrowseRouteCountsFromMedia(context.Background(), db, database.BrowseRouteCountsOptions{
-		Routes:  []string{routeA, routeB},
+	counts, err := sqlBrowseRouteCountsFromMedia(ctx, db, database.BrowseRouteCountsOptions{
+		Routes:  []string{route},
 		Systems: []systemdefs.System{{ID: "SNES"}},
 	})
-	require.NoError(t, err)
-	require.Len(t, counts, 2)
-	for _, route := range []string{routeA, routeB} {
-		assert.Equal(t, database.BrowseRouteCount{
-			Path:         route,
-			SystemIDs:    []string{"SNES"},
-			CountUnknown: true,
-		}, counts[route])
-	}
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, counts)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -506,6 +506,40 @@ func TestSqlBrowseRouteCountsFromCache_UsesChildDirCounts(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlBrowseRouteCountsFromMedia_ReusesPresenceProbeAcrossTimeouts(t *testing.T) {
+	t.Parallel()
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	routeA := browseTestPath("roms", "a")
+	routeB := browseTestPath("roms", "b")
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(browseRouteCacheKey(routeA), "SNES").
+		WillReturnError(context.DeadlineExceeded)
+	mock.ExpectQuery("SELECT 1").
+		WithArgs("SNES").
+		WillReturnRows(sqlmock.NewRows([]string{"one"}).AddRow(1))
+	mock.ExpectQuery("SELECT COUNT").
+		WithArgs(browseRouteCacheKey(routeB), "SNES").
+		WillReturnError(context.DeadlineExceeded)
+
+	counts, err := sqlBrowseRouteCountsFromMedia(context.Background(), db, database.BrowseRouteCountsOptions{
+		Routes:  []string{routeA, routeB},
+		Systems: []systemdefs.System{{ID: "SNES"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, counts, 2)
+	for _, route := range []string{routeA, routeB} {
+		assert.Equal(t, database.BrowseRouteCount{
+			Path:         route,
+			SystemIDs:    []string{"SNES"},
+			CountUnknown: true,
+		}, counts[route])
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBrowseCacheBuilder_NormalizesRelativeFilesystemDirs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- memoize system-scoped browse presence probe for each route-count fallback call
- reuse successful, empty, timeout, and error outcomes across timed-out routes
- verify two timed-out routes degrade using one presence probe

Closes #1147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browse results when per-route count lookups time out by reusing a single media-presence check for the request’s scope.
  * When the presence probe fails, remaining timed-out routes are skipped; when no media is reported, timed-out routes are dropped without degrading to unknown counts.

* **Tests**
  * Added unit tests ensuring the presence probe is issued only once across multiple timeouts.
  * Added coverage for proper cancellation propagation during the presence probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->