### PR TITLE
fix: improve online play history reliability

### DIFF
--- a/pkg/api/methods/auth.go
+++ b/pkg/api/methods/auth.go
@@ -287,7 +287,7 @@ func performClaim(
 		_, refreshErr := backupManager.RefreshRemoteAvailability(refreshCtx)
 		cancelRefresh()
 		if refreshErr != nil {
-			log.Debug().Err(refreshErr).Msg("remote backup availability not refreshed after link")
+			log.Warn().Err(refreshErr).Msg("remote backup availability not refreshed after link")
 		}
 		break
 	}

--- a/pkg/api/methods/auth_link.go
+++ b/pkg/api/methods/auth_link.go
@@ -336,6 +336,7 @@ func pollDeviceLink(
 ) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	consecutiveFailures := 0
 
 	for {
 		select {
@@ -343,6 +344,10 @@ func pollDeviceLink(
 			errMsg := "device linking stopped, start over to link this device"
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				errMsg = "link request expired, start over to link this device"
+				log.Warn().Err(ctx.Err()).Int("poll_failures", consecutiveFailures).
+					Msg("device link polling expired")
+			} else {
+				log.Debug().Err(ctx.Err()).Msg("device link polling stopped")
 			}
 			finishAuthLink(session, deps, models.AuthLinkStatusFailed, errMsg)
 			return
@@ -353,12 +358,19 @@ func pollDeviceLink(
 		if err != nil {
 			var terminal *authLinkTerminalError
 			if errors.As(err, &terminal) {
+				log.Warn().Err(err).Msg("device link polling failed permanently")
 				finishAuthLink(session, deps, models.AuthLinkStatusFailed, terminal.reason)
 				return
 			}
-			// Transient (network) errors: keep polling until expiry.
-			log.Debug().Err(err).Msg("device link poll failed, retrying")
+			// Transient errors remain retryable, but the first failure in each
+			// outage must be visible in normal support logs.
+			consecutiveFailures++
+			logDeviceLinkPollFailure(err, consecutiveFailures)
 			continue
+		}
+		if consecutiveFailures > 0 {
+			log.Info().Int("failures", consecutiveFailures).Msg("device link polling recovered")
+			consecutiveFailures = 0
 		}
 		if poll.Status != "approved" {
 			continue
@@ -377,6 +389,15 @@ func pollDeviceLink(
 		finishAuthLink(session, deps, models.AuthLinkStatusApproved, "")
 		return
 	}
+}
+
+func logDeviceLinkPollFailure(err error, consecutiveFailures int) {
+	if consecutiveFailures == 1 {
+		log.Warn().Err(err).Msg("device link poll failed, retrying")
+		return
+	}
+	log.Debug().Err(err).Int("consecutive_failures", consecutiveFailures).
+		Msg("device link poll still failing")
 }
 
 func pollDeviceLinkOnce(ctx context.Context, baseURL, deviceCode string) (*deviceLinkPollResponse, error) {

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -61,6 +61,35 @@ func TestLogDeviceLinkPollFailure(t *testing.T) {
 	assert.Contains(t, buf.String(), `"message":"device link poll still failing"`)
 }
 
+func TestPollDeviceLink_ContextDeadlineExpiresPendingSession(t *testing.T) {
+	// Not parallel: swaps package-level logger and link session state.
+	resetAuthLinkState(t)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	session := &authLinkSession{
+		cancel: cancel,
+		status: models.AuthLinkStatusResponse{Status: models.AuthLinkStatusPending},
+	}
+	authLinkMu.Lock()
+	activeAuthLink = session
+	authLinkMu.Unlock()
+
+	pollDeviceLink(ctx, session, &authLinkDeps{}, "", "", time.Hour)
+
+	assert.Equal(t, models.AuthLinkStatusFailed, session.status.Status)
+	assert.Equal(t, "link request expired, start over to link this device", session.status.Error)
+	assert.Contains(t, buf.String(), `"level":"warn"`)
+	assert.Contains(t, buf.String(), `"poll_failures":0`)
+	assert.Contains(t, buf.String(), `"message":"device link polling expired"`)
+}
+
 func TestPollDeviceLink_TransientFailuresRecoverAndReset(t *testing.T) {
 	// Not parallel: swaps package-level claimClient, logger, and link session state.
 	resetAuthLinkState(t)

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -36,10 +37,27 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLogDeviceLinkPollFailure(t *testing.T) {
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.InfoLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	logDeviceLinkPollFailure(assert.AnError, 1)
+	assert.Contains(t, buf.String(), `"level":"warn"`)
+	assert.Contains(t, buf.String(), `"message":"device link poll failed, retrying"`)
+
+	buf.Reset()
+	logDeviceLinkPollFailure(assert.AnError, 2)
+	assert.Empty(t, buf.String(), "repeated poll errors stay debug-level to avoid log flooding")
+}
 
 // resetAuthLinkState clears the package-level link session between tests.
 func resetAuthLinkState(t *testing.T) {

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -47,7 +47,7 @@ import (
 func TestLogDeviceLinkPollFailure(t *testing.T) {
 	var buf bytes.Buffer
 	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.InfoLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
 	t.Cleanup(func() { log.Logger = originalLogger })
 
 	logDeviceLinkPollFailure(assert.AnError, 1)
@@ -56,7 +56,60 @@ func TestLogDeviceLinkPollFailure(t *testing.T) {
 
 	buf.Reset()
 	logDeviceLinkPollFailure(assert.AnError, 2)
-	assert.Empty(t, buf.String(), "repeated poll errors stay debug-level to avoid log flooding")
+	assert.Contains(t, buf.String(), `"level":"debug"`)
+	assert.Contains(t, buf.String(), `"consecutive_failures":2`)
+	assert.Contains(t, buf.String(), `"message":"device link poll still failing"`)
+}
+
+func TestPollDeviceLink_TransientFailuresRecoverAndReset(t *testing.T) {
+	// Not parallel: swaps package-level claimClient, logger, and link session state.
+	resetAuthLinkState(t)
+
+	var polls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		switch polls.Add(1) {
+		case 1:
+			w.WriteHeader(http.StatusInternalServerError)
+		case 2:
+			w.WriteHeader(http.StatusTooManyRequests)
+		case 3:
+			_ = json.NewEncoder(w).Encode(deviceLinkPollResponse{Status: "pending"})
+		case 4:
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+
+	originalClient := claimClient
+	claimClient = server.Client()
+	t.Cleanup(func() { claimClient = originalClient })
+
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	session := &authLinkSession{status: models.AuthLinkStatusResponse{Status: models.AuthLinkStatusPending}}
+	authLinkMu.Lock()
+	activeAuthLink = session
+	authLinkMu.Unlock()
+
+	pollDeviceLink(context.Background(), session, &authLinkDeps{}, server.URL, "device-code", time.Millisecond)
+
+	assert.Equal(t, int32(5), polls.Load())
+	assert.Equal(t, models.AuthLinkStatusFailed, session.status.Status)
+	assert.Contains(t, session.status.Error, "expired")
+	logs := buf.Bytes()
+	assert.Equal(t, 2, bytes.Count(logs, []byte(`"message":"device link poll failed, retrying"`)),
+		"first failure after recovery must warn again")
+	assert.Contains(t, string(logs), `"level":"debug"`)
+	assert.Contains(t, string(logs), `"consecutive_failures":2`)
+	assert.Contains(t, string(logs), `"level":"info"`)
+	assert.Contains(t, string(logs), `"failures":2`)
+	assert.Contains(t, string(logs), `"message":"device link polling recovered"`)
+	assert.Contains(t, string(logs), `"message":"device link polling failed permanently"`)
 }
 
 // resetAuthLinkState clears the package-level link session between tests.

--- a/pkg/config/auth.go
+++ b/pkg/config/auth.go
@@ -79,6 +79,17 @@ func isValidAuthKey(key string) bool {
 	return key != "creds" && key != "auth" && key != "api_keys"
 }
 
+// validateAuthFileData rejects malformed TOML before callers replace the
+// active credential set or rewrite the file. Format-specific decoding remains
+// permissive so legacy and mixed layouts continue to work.
+func validateAuthFileData(data []byte) error {
+	var raw map[string]any
+	if err := toml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("failed to parse auth file: %w", err)
+	}
+	return nil
+}
+
 // LoadAuthFromData parses auth.toml data supporting all three formats.
 // Formats are merged, allowing users to mix formats in the same file.
 //

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -722,6 +722,46 @@ func readAPIKeysFromInstance(t *testing.T, cfg *Instance) []string {
 	return LoadAPIKeysFromData(data)
 }
 
+func TestReloadAuth_MalformedFileKeepsExistingValues(t *testing.T) {
+	originalAuth := authCfg.Load()
+	originalAPIKeys := apiKeys.Load()
+	t.Cleanup(func() {
+		if originalAuth != nil {
+			authCfg.Store(originalAuth)
+		} else {
+			authCfg.Store(map[string]CredentialEntry{})
+		}
+		if originalAPIKeys != nil {
+			apiKeys.Store(originalAPIKeys)
+		} else {
+			apiKeys.Store([]string{})
+		}
+	})
+
+	cfg := newTestConfigInstance(t)
+	existingCredentials := map[string]CredentialEntry{
+		"https://api.example.com": {Bearer: "existing-token"},
+	}
+	existingAPIKeys := []string{"existing-key"}
+	validData, err := marshalAuthFile(existingCredentials, existingAPIKeys)
+	require.NoError(t, err)
+	require.NoError(t, afero.WriteFile(cfg.getFs(), cfg.authPath, validData, 0o600))
+
+	cfg.mu.Lock()
+	cfg.reloadAuth()
+	cfg.mu.Unlock()
+	require.Equal(t, existingCredentials, GetAuthCfg())
+	require.Equal(t, existingAPIKeys, GetAPIKeys())
+
+	require.NoError(t, afero.WriteFile(cfg.getFs(), cfg.authPath, []byte("not valid toml [[["), 0o600))
+	cfg.mu.Lock()
+	cfg.reloadAuth()
+	cfg.mu.Unlock()
+
+	assert.Equal(t, existingCredentials, GetAuthCfg())
+	assert.Equal(t, existingAPIKeys, GetAPIKeys())
+}
+
 func TestSaveAuthEntry_CreateNewFile(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/auth_test.go
+++ b/pkg/config/auth_test.go
@@ -161,9 +161,12 @@ func TestLoadAuthFromData_EmptyData(t *testing.T) {
 func TestLoadAuthFromData_InvalidTOML(t *testing.T) {
 	t.Parallel()
 
-	// Invalid TOML should not panic, just return empty
-	result := LoadAuthFromData([]byte("this is not valid toml [[["))
+	data := []byte("this is not valid toml [[[")
+	// Low-level compatibility parser remains non-panicking; file-management
+	// callers validate first so malformed credentials are never discarded.
+	result := LoadAuthFromData(data)
 	assert.Empty(t, result)
+	require.Error(t, validateAuthFileData(data))
 }
 
 func TestNormalizeScheme(t *testing.T) {
@@ -734,6 +737,21 @@ func TestSaveAuthEntry_CreateNewFile(t *testing.T) {
 	assert.Equal(t, "test-token", creds["https://api.zaparoo.com"].Bearer)
 }
 
+func TestSaveAuthEntry_RejectsMalformedExistingFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfigInstance(t)
+	malformed := []byte("not valid toml [[[")
+	require.NoError(t, afero.WriteFile(cfg.getFs(), cfg.authPath, malformed, 0o600))
+
+	err := cfg.SaveAuthEntry("https://api.zaparoo.com", CredentialEntry{Bearer: "new-token"})
+	require.Error(t, err)
+
+	preserved, readErr := afero.ReadFile(cfg.getFs(), cfg.authPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, malformed, preserved)
+}
+
 func TestSaveAuthEntry_UpdateExisting(t *testing.T) {
 	t.Parallel()
 
@@ -816,6 +834,21 @@ func TestDeleteAuthEntries_RemovesOnlyTargetedDomains(t *testing.T) {
 	creds := readAuthFromInstance(t, cfg)
 	require.Len(t, creds, 1)
 	assert.Equal(t, "token3", creds["https://other.example.com"].Bearer)
+}
+
+func TestDeleteAuthEntries_RejectsMalformedExistingFile(t *testing.T) {
+	t.Parallel()
+
+	cfg := newTestConfigInstance(t)
+	malformed := []byte("not valid toml [[[")
+	require.NoError(t, afero.WriteFile(cfg.getFs(), cfg.authPath, malformed, 0o600))
+
+	err := cfg.DeleteAuthEntries([]string{"https://api.zaparoo.com"})
+	require.Error(t, err)
+
+	preserved, readErr := afero.ReadFile(cfg.getFs(), cfg.authPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, malformed, preserved)
 }
 
 func TestDeleteAuthEntries_MatchesCaseInsensitively(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -460,6 +460,9 @@ func (c *Instance) Save() error {
 func (c *Instance) reloadAuth() {
 	fs := c.getFs()
 	if _, err := fs.Stat(c.authPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Error().Err(err).Msg("failed to stat auth file")
+		}
 		return
 	}
 
@@ -467,6 +470,10 @@ func (c *Instance) reloadAuth() {
 	authData, err := afero.ReadFile(fs, c.authPath)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to read auth file")
+		return
+	}
+	if validateErr := validateAuthFileData(authData); validateErr != nil {
+		log.Error().Err(validateErr).Msg("auth file is invalid; keeping existing credentials")
 		return
 	}
 
@@ -488,12 +495,23 @@ func (c *Instance) SaveAuthEntry(domain string, entry CredentialEntry) error {
 
 	fs := c.getFs()
 
-	// Read existing auth file once, parse both credentials and API keys
+	// Read existing auth file once, parse both credentials and API keys.
+	// Never overwrite unreadable or malformed credentials as though the file
+	// were empty.
 	existing := make(map[string]CredentialEntry)
 	var existingKeys []string
-	if data, err := afero.ReadFile(fs, c.authPath); err == nil {
+	data, readErr := afero.ReadFile(fs, c.authPath)
+	switch {
+	case readErr == nil:
+		if validateErr := validateAuthFileData(data); validateErr != nil {
+			return validateErr
+		}
 		existing = LoadAuthFromData(data)
 		existingKeys = LoadAPIKeysFromData(data)
+	case errors.Is(readErr, os.ErrNotExist):
+		// First credential creates the file.
+	default:
+		return fmt.Errorf("failed to read auth file: %w", readErr)
 	}
 
 	// Upsert the entry
@@ -524,9 +542,15 @@ func (c *Instance) DeleteAuthEntries(domains []string) error {
 	fs := c.getFs()
 
 	data, err := afero.ReadFile(fs, c.authPath)
-	if err != nil {
+	if errors.Is(err, os.ErrNotExist) {
 		// No auth file means there is nothing to delete.
 		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read auth file: %w", err)
+	}
+	if validateErr := validateAuthFileData(data); validateErr != nil {
+		return validateErr
 	}
 	existing := LoadAuthFromData(data)
 	existingKeys := LoadAPIKeysFromData(data)

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -863,26 +863,31 @@ func guessLauncherFromCandidates(
 	}
 
 	if folderSystem, ok := folderTrailSystem(path); ok {
+		match := -1
 		for i := range candidates {
-			if strings.EqualFold(candidates[i].SystemID, folderSystem) {
-				return candidates[i], true
+			if !strings.EqualFold(candidates[i].SystemID, folderSystem) {
+				continue
 			}
+			if match != -1 {
+				return platforms.Launcher{}, false
+			}
+			match = i
+		}
+		if match != -1 {
+			return candidates[match], true
 		}
 		return platforms.Launcher{}, false
 	}
 
-	systemID := candidates[0].SystemID
-	for i := 1; i < len(candidates); i++ {
-		if !strings.EqualFold(candidates[i].SystemID, systemID) {
-			return platforms.Launcher{}, false
-		}
+	if len(candidates) != 1 {
+		return platforms.Launcher{}, false
 	}
 	return candidates[0], true
 }
 
 // GuessLauncherForPath conservatively infers a launcher when normal folder
-// matching fails. A recognized folder alias must agree with the extension;
-// without one, the extension must belong to exactly one system.
+// matching fails. A recognized folder alias must identify exactly one matching
+// launcher; without one, the extension must match exactly one launcher.
 func GuessLauncherForPath(path string) (platforms.Launcher, bool) {
 	launcher, ok := guessLauncherFromCandidates(path, GlobalLauncherCache.GetAllLaunchers())
 	if ok {

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -30,6 +30,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/pathutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	platformsshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
@@ -819,6 +820,81 @@ func launcherSpecificity(l *platforms.Launcher) int {
 	return score
 }
 
+func folderTrailSystem(path string) (string, bool) {
+	segments := strings.Split(filepath.ToSlash(filepath.Clean(filepath.Dir(path))), "/")
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := strings.TrimSpace(segments[i])
+		if segment == "" || segment == "." {
+			continue
+		}
+		system, err := systemdefs.LookupSystem(segment)
+		if err == nil {
+			return system.ID, true
+		}
+	}
+	return "", false
+}
+
+func launcherHasExtension(launcher *platforms.Launcher, ext string) bool {
+	for _, supported := range launcher.Extensions {
+		if strings.EqualFold(ext, supported) {
+			return true
+		}
+	}
+	return false
+}
+
+func guessLauncherFromCandidates(
+	path string, launchers []platforms.Launcher,
+) (platforms.Launcher, bool) {
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return platforms.Launcher{}, false
+	}
+
+	candidates := make([]platforms.Launcher, 0, len(launchers))
+	for i := range launchers {
+		if launchers[i].SystemID != "" && launcherHasExtension(&launchers[i], ext) {
+			candidates = append(candidates, launchers[i])
+		}
+	}
+	if len(candidates) == 0 {
+		return platforms.Launcher{}, false
+	}
+
+	if folderSystem, ok := folderTrailSystem(path); ok {
+		for i := range candidates {
+			if strings.EqualFold(candidates[i].SystemID, folderSystem) {
+				return candidates[i], true
+			}
+		}
+		return platforms.Launcher{}, false
+	}
+
+	systemID := candidates[0].SystemID
+	for i := 1; i < len(candidates); i++ {
+		if !strings.EqualFold(candidates[i].SystemID, systemID) {
+			return platforms.Launcher{}, false
+		}
+	}
+	return candidates[0], true
+}
+
+// GuessLauncherForPath conservatively infers a launcher when normal folder
+// matching fails. A recognized folder alias must agree with the extension;
+// without one, the extension must belong to exactly one system.
+func GuessLauncherForPath(path string) (platforms.Launcher, bool) {
+	launcher, ok := guessLauncherFromCandidates(path, GlobalLauncherCache.GetAllLaunchers())
+	if ok {
+		log.Info().
+			Str("path", path).
+			Str("launcher", launcher.ID).
+			Str("system", launcher.SystemID).
+			Msg("guessed launcher from folder trail and file extension")
+	}
+	return launcher, ok
+}
+
 // FindLauncher takes a path and tries to find the best possible match for a
 // launcher, taking into account specificity and allowlist restrictions.
 func FindLauncher(
@@ -827,30 +903,34 @@ func FindLauncher(
 	path string,
 ) (platforms.Launcher, error) {
 	launchers := PathToLaunchers(cfg, pl, path)
+	var launcher platforms.Launcher
 	if len(launchers) == 0 {
-		log.Debug().Str("path", path).Int("launchersChecked", len(GlobalLauncherCache.GetAllLaunchers())).
-			Msg("no launcher matched path")
-		return platforms.Launcher{}, errors.New("no launcher found for: " + path)
-	}
-
-	best := 0
-	bestScore := launcherSpecificity(&launchers[0])
-	for i := 1; i < len(launchers); i++ {
-		score := launcherSpecificity(&launchers[i])
-		if score > bestScore {
-			best = i
-			bestScore = score
+		var guessed bool
+		launcher, guessed = GuessLauncherForPath(path)
+		if !guessed {
+			log.Debug().Str("path", path).Int("launchersChecked", len(GlobalLauncherCache.GetAllLaunchers())).
+				Msg("no launcher matched path")
+			return platforms.Launcher{}, errors.New("no launcher found for: " + path)
 		}
+	} else {
+		best := 0
+		bestScore := launcherSpecificity(&launchers[0])
+		for i := 1; i < len(launchers); i++ {
+			score := launcherSpecificity(&launchers[i])
+			if score > bestScore {
+				best = i
+				bestScore = score
+			}
+		}
+
+		launcher = launchers[best]
+		log.Debug().
+			Str("path", path).
+			Str("launcher", launcher.ID).
+			Int("specificity", bestScore).
+			Int("candidates", len(launchers)).
+			Msg("selected launcher by specificity")
 	}
-
-	launcher := launchers[best]
-
-	log.Debug().
-		Str("path", path).
-		Str("launcher", launcher.ID).
-		Int("specificity", bestScore).
-		Int("candidates", len(launchers)).
-		Msg("selected launcher by specificity")
 
 	if launcher.AllowListOnly && !cfg.IsLauncherFileAllowed(path) {
 		return platforms.Launcher{}, errors.New("file not allowed: " + path)

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -85,6 +85,11 @@ func TestGuessLauncherForPath(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "folder alias does not resolve duplicate launchers",
+			path: filepath.Join(root, "media", "fat", "hacks", "PS2", "Game.iso"),
+			want: false,
+		},
+		{
 			name: "conflicting folder and extension",
 			path: filepath.Join(root, "media", "fat", "hacks", "SNES", "Game.gbc"),
 			want: false,
@@ -92,6 +97,11 @@ func TestGuessLauncherForPath(t *testing.T) {
 		{
 			name: "unsupported extension",
 			path: filepath.Join(root, "media", "fat", "hacks", "GBC", "notes.txt"),
+			want: false,
+		},
+		{
+			name: "missing extension",
+			path: filepath.Join(root, "media", "fat", "hacks", "GBC", "README"),
 			want: false,
 		},
 	}

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -35,6 +36,70 @@ import (
 
 // testLauncherCacheMutex protects GlobalLauncherCache modifications in tests
 var testLauncherCacheMutex syncutil.Mutex
+
+func TestGuessLauncherForPath(t *testing.T) {
+	t.Parallel()
+
+	launchers := []platforms.Launcher{
+		{ID: "GameboyColor", SystemID: systemdefs.SystemGameboyColor, Extensions: []string{".gbc"}},
+		{ID: "SNES", SystemID: systemdefs.SystemSNES, Extensions: []string{".sfc"}},
+		{ID: "PSX", SystemID: systemdefs.SystemPSX, Extensions: []string{".bin"}},
+		{ID: "MegaCD", SystemID: systemdefs.SystemMegaCD, Extensions: []string{".bin"}},
+	}
+	root := string(filepath.Separator)
+
+	tests := []struct {
+		name       string
+		path       string
+		wantSystem string
+		want       bool
+	}{
+		{
+			name:       "folder and extension agree",
+			path:       filepath.Join(root, "media", "fat", "hacks", "GBC", "Game.gbc"),
+			wantSystem: systemdefs.SystemGameboyColor,
+			want:       true,
+		},
+		{
+			name:       "unique extension without alias",
+			path:       filepath.Join(root, "media", "fat", "hacks", "Game.gbc"),
+			wantSystem: systemdefs.SystemGameboyColor,
+			want:       true,
+		},
+		{
+			name:       "folder disambiguates shared extension",
+			path:       filepath.Join(root, "media", "fat", "hacks", "PSX", "Game.bin"),
+			wantSystem: systemdefs.SystemPSX,
+			want:       true,
+		},
+		{
+			name: "shared extension without alias is ambiguous",
+			path: filepath.Join(root, "media", "fat", "hacks", "Game.bin"),
+			want: false,
+		},
+		{
+			name: "conflicting folder and extension",
+			path: filepath.Join(root, "media", "fat", "hacks", "SNES", "Game.gbc"),
+			want: false,
+		},
+		{
+			name: "unsupported extension",
+			path: filepath.Join(root, "media", "fat", "hacks", "GBC", "notes.txt"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			launcher, ok := guessLauncherFromCandidates(tt.path, launchers)
+			assert.Equal(t, tt.want, ok)
+			if tt.want {
+				assert.Equal(t, tt.wantSystem, launcher.SystemID)
+			}
+		})
+	}
+}
 
 func TestPathIsLauncher_AbsoluteFolderNoRootDirs(t *testing.T) {
 	t.Parallel()

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -45,6 +45,8 @@ func TestGuessLauncherForPath(t *testing.T) {
 		{ID: "SNES", SystemID: systemdefs.SystemSNES, Extensions: []string{".sfc"}},
 		{ID: "PSX", SystemID: systemdefs.SystemPSX, Extensions: []string{".bin"}},
 		{ID: "MegaCD", SystemID: systemdefs.SystemMegaCD, Extensions: []string{".bin"}},
+		{ID: "PCSX2", SystemID: systemdefs.SystemPS2, Extensions: []string{".iso"}},
+		{ID: "Play", SystemID: systemdefs.SystemPS2, Extensions: []string{".iso"}},
 	}
 	root := string(filepath.Separator)
 
@@ -75,6 +77,11 @@ func TestGuessLauncherForPath(t *testing.T) {
 		{
 			name: "shared extension without alias is ambiguous",
 			path: filepath.Join(root, "media", "fat", "hacks", "Game.bin"),
+			want: false,
+		},
+		{
+			name: "duplicate launchers for one system are ambiguous",
+			path: filepath.Join(root, "media", "fat", "hacks", "Game.iso"),
 			want: false,
 		},
 		{

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -32,11 +32,10 @@ import (
 )
 
 const (
-	ArcadeSystem            = "Arcade"
-	mediaLookupTimeout      = 2 * time.Second
-	trackerFileSettleDelay  = 50 * time.Millisecond
-	misterStorageDeviceFile = misterconfig.CoreConfigFolder + "/device.bin"
-	misterUSBRootCount      = 4
+	ArcadeSystem           = "Arcade"
+	mediaLookupTimeout     = 2 * time.Second
+	trackerFileSettleDelay = 50 * time.Millisecond
+	misterUSBRootCount     = 4
 )
 
 // platformWithArcadeCache is an optional interface for platforms that support arcade card launch caching.
@@ -434,7 +433,7 @@ func resolveRecentGamePath(path string, storageSelection []byte, exists func(str
 }
 
 // recentGamePath reads the newest launchable path from a MiSTer recent file.
-func recentGamePath(filename string) (string, error) {
+func recentGamePath(filename string, storageSelection []byte) (string, error) {
 	if !strings.Contains(filename, "_recent") {
 		return "", nil
 	}
@@ -450,7 +449,6 @@ func recentGamePath(filename string) (string, error) {
 	newest := recents[0]
 	if !strings.HasSuffix(filename, "cores_recent.cfg") {
 		path := filepath.Join(newest.Directory, newest.Name)
-		storageSelection, _ := os.ReadFile(misterStorageDeviceFile)
 		return resolveRecentGamePath(path, storageSelection, func(candidate string) bool {
 			_, statErr := os.Stat(candidate)
 			return statErr == nil
@@ -471,7 +469,8 @@ func recentGamePath(filename string) (string, error) {
 
 // loadRecent writes a recent file's newest launchable path to ACTIVEGAME.
 func loadRecent(filename string) error {
-	path, err := recentGamePath(filename)
+	storageSelection, _ := os.ReadFile(filepath.Join(misterconfig.CoreConfigFolder, "device.bin"))
+	path, err := recentGamePath(filename, storageSelection)
 	if err != nil {
 		return err
 	}
@@ -528,6 +527,18 @@ func trackerFileChanged(op fsnotify.Op) bool {
 	return op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0
 }
 
+func trackerRecentFileChanged(filename string) bool {
+	return filepath.Dir(filename) == filepath.Clean(misterconfig.CoreConfigFolder) &&
+		strings.Contains(filepath.Base(filename), "_recent")
+}
+
+func dispatchTrackerFileLoad(settled <-chan time.Time, load func()) {
+	go func() {
+		<-settled
+		load()
+	}()
+}
+
 // StartFileWatch Start thread for monitoring changes to all files relating to core/game launches.
 func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 	log.Info().Msg("starting file watcher")
@@ -555,21 +566,24 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 					tr.loadGame()
 				case event.Name == misterconfig.FileSelectFile:
 					// MakeFile truncates before writing the new status. Wait for
-					// FILESELECT and FULLPATH to contain the same selection.
-					time.Sleep(trackerFileSettleDelay)
-					loadFileSelection()
-				case strings.HasPrefix(event.Name, misterconfig.CoreConfigFolder):
+					// FILESELECT and FULLPATH to contain the same selection without
+					// blocking delivery of later watcher events.
+					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), loadFileSelection)
+				case trackerRecentFileChanged(event.Name):
 					// MiSTer truncates and rewrites binary recent files. Let the
-					// write settle before reading the first complete record.
-					time.Sleep(trackerFileSettleDelay)
-					recentErr := loadRecent(event.Name)
-					if recentErr != nil {
-						if errors.Is(recentErr, os.ErrNotExist) {
-							log.Debug().Err(recentErr).Msg("recent file was replaced before it could be read")
-						} else {
-							log.Error().Msgf("error loading recent file: %s", recentErr)
+					// write settle before reading the first complete record without
+					// blocking delivery of later watcher events.
+					filename := event.Name
+					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), func() {
+						recentErr := loadRecent(filename)
+						if recentErr != nil {
+							if errors.Is(recentErr, os.ErrNotExist) {
+								log.Debug().Err(recentErr).Msg("recent file was replaced before it could be read")
+							} else {
+								log.Error().Msgf("error loading recent file: %s", recentErr)
+							}
 						}
-					}
+					})
 				}
 			case watchErr, ok := <-watcher.Errors:
 				if !ok {

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -4,6 +4,7 @@ package tracker
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -31,8 +32,11 @@ import (
 )
 
 const (
-	ArcadeSystem       = "Arcade"
-	mediaLookupTimeout = 2 * time.Second
+	ArcadeSystem            = "Arcade"
+	mediaLookupTimeout      = 2 * time.Second
+	trackerFileSettleDelay  = 50 * time.Millisecond
+	misterStorageDeviceFile = misterconfig.CoreConfigFolder + "/device.bin"
+	misterUSBRootCount      = 4
 )
 
 // platformWithArcadeCache is an optional interface for platforms that support arcade card launch caching.
@@ -401,56 +405,119 @@ func (tr *Tracker) StopAll() {
 	tr.stopGame()
 }
 
-// Read a core's recent file and attempt to write the newest entry's
-// launch-able path to ACTIVEGAME.
-func loadRecent(filename string) error {
-	if !strings.Contains(filename, "_recent") {
-		return nil
+// resolveRecentGamePath mirrors MiSTer's relative-path root selection. Main
+// stores 0 for SD and nonzero for USB in config/device.bin; USB uses the first
+// available /media/usb0-3 root containing the recent file.
+func resolveRecentGamePath(path string, storageSelection []byte, exists func(string) bool) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
 	}
-
-	file, err := os.Open(filename) //nolint:gosec // Internal game file path
-	if err != nil {
-		return fmt.Errorf("error opening game file: %w", err)
-	}
-	defer func(file *os.File) {
-		closeErr := file.Close()
-		if closeErr != nil {
-			log.Error().Msgf("error closing file: %s", closeErr)
+	if len(storageSelection) >= 4 && binary.LittleEndian.Uint32(storageSelection[:4]) != 0 {
+		mediaRoot := filepath.Dir(misterconfig.SDRootDir)
+		for i := range misterUSBRootCount {
+			root := filepath.Join(mediaRoot, fmt.Sprintf("usb%d", i))
+			candidate := filepath.Join(root, path)
+			if exists(candidate) {
+				return candidate
+			}
 		}
-	}(file)
+	}
+	return filepath.Join(misterconfig.SDRootDir, path)
+}
+
+// recentGamePath reads the newest launchable path from a MiSTer recent file.
+func recentGamePath(filename string) (string, error) {
+	if !strings.Contains(filename, "_recent") {
+		return "", nil
+	}
 
 	recents, err := mistermain.ReadRecent(filename)
 	if err != nil {
-		return fmt.Errorf("error reading recent file: %w", err)
-	} else if len(recents) == 0 {
-		return nil
+		return "", fmt.Errorf("error reading recent file: %w", err)
+	}
+	if len(recents) == 0 {
+		return "", nil
 	}
 
 	newest := recents[0]
-
-	if strings.HasSuffix(filename, "cores_recent.cfg") {
-		// main menu's recent file, written when launching mgls
-		if strings.HasSuffix(strings.ToLower(newest.Name), ".mgl") {
-			mglPath := ResolvePath(filepath.Join(newest.Directory, newest.Name))
-			mgl, mglErr := mgls.ReadMgl(mglPath)
-			if mglErr != nil {
-				return fmt.Errorf("error reading mgl file: %w", mglErr)
-			}
-
-			err = activegame.SetActiveGame(mgl.File.Path)
-			if err != nil {
-				return fmt.Errorf("error setting active game: %w", err)
-			}
-		}
-	} else {
-		// individual core's recent file
-		err = activegame.SetActiveGame(filepath.Join(newest.Directory, newest.Name))
-		if err != nil {
-			return fmt.Errorf("error setting active game: %w", err)
-		}
+	if !strings.HasSuffix(filename, "cores_recent.cfg") {
+		path := filepath.Join(newest.Directory, newest.Name)
+		storageSelection, _ := os.ReadFile(misterStorageDeviceFile)
+		return resolveRecentGamePath(path, storageSelection, func(candidate string) bool {
+			_, statErr := os.Stat(candidate)
+			return statErr == nil
+		}), nil
 	}
 
+	// Main menu recents contain cores and MGLs; only MGLs identify a game.
+	if !strings.HasSuffix(strings.ToLower(newest.Name), ".mgl") {
+		return "", nil
+	}
+	mglPath := ResolvePath(filepath.Join(newest.Directory, newest.Name))
+	mgl, err := mgls.ReadMgl(mglPath)
+	if err != nil {
+		return "", fmt.Errorf("error reading mgl file: %w", err)
+	}
+	return mgl.File.Path, nil
+}
+
+// loadRecent writes a recent file's newest launchable path to ACTIVEGAME.
+func loadRecent(filename string) error {
+	path, err := recentGamePath(filename)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		return nil
+	}
+	if err = activegame.SetActiveGame(path); err != nil {
+		return fmt.Errorf("error setting active game: %w", err)
+	}
 	return nil
+}
+
+// selectedFullPath returns the selected file only after MiSTer publishes
+// FILESELECT=selected. FULLPATH also changes while the user browses, so it is
+// not a launch signal by itself.
+func selectedFullPath(statusData, pathData []byte) (string, error) {
+	if strings.TrimSpace(string(statusData)) != "selected" {
+		return "", nil
+	}
+	path := strings.TrimSpace(string(pathData))
+	if path == "" {
+		return "", errors.New("selected full path is empty")
+	}
+	return path, nil
+}
+
+func loadFileSelection() {
+	statusData, err := os.ReadFile(misterconfig.FileSelectFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to read MiSTer file selection status")
+		return
+	}
+	if strings.TrimSpace(string(statusData)) != "selected" {
+		return
+	}
+	pathData, err := os.ReadFile(misterconfig.FullPathFile)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to read selected MiSTer full path")
+		return
+	}
+	path, err := selectedFullPath(statusData, pathData)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to process MiSTer file selection")
+		return
+	}
+
+	log.Info().Str("path", path).Msg("manual MiSTer file launch detected")
+	if err = activegame.SetActiveGame(path); err != nil {
+		log.Error().Err(err).Str("path", path).Msg("failed to set selected active game")
+	}
+}
+
+func trackerFileChanged(op fsnotify.Op) bool {
+	return op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) != 0
 }
 
 // StartFileWatch Start thread for monitoring changes to all files relating to core/game launches.
@@ -470,20 +537,29 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 				if !ok {
 					return
 				}
-				if event.Op&fsnotify.Write == fsnotify.Write {
-					switch {
-					case event.Name == misterconfig.CoreNameFile:
-						tr.LoadCore()
-					case event.Name == misterconfig.ActiveGameFile:
-						tr.loadGame()
-					case strings.HasPrefix(event.Name, misterconfig.CoreConfigFolder):
-						err = loadRecent(event.Name)
-						if err != nil {
-							if errors.Is(err, os.ErrNotExist) {
-								log.Warn().Msgf("recent mgl file not found: %s", err)
-							} else {
-								log.Error().Msgf("error loading recent file: %s", err)
-							}
+				if !trackerFileChanged(event.Op) {
+					continue
+				}
+				switch {
+				case event.Name == misterconfig.CoreNameFile:
+					tr.LoadCore()
+				case event.Name == misterconfig.ActiveGameFile:
+					tr.loadGame()
+				case event.Name == misterconfig.FileSelectFile:
+					// MakeFile truncates before writing the new status. Wait for
+					// FILESELECT and FULLPATH to contain the same selection.
+					time.Sleep(trackerFileSettleDelay)
+					loadFileSelection()
+				case strings.HasPrefix(event.Name, misterconfig.CoreConfigFolder):
+					// MiSTer truncates and rewrites binary recent files. Let the
+					// write settle before reading the first complete record.
+					time.Sleep(trackerFileSettleDelay)
+					recentErr := loadRecent(event.Name)
+					if recentErr != nil {
+						if errors.Is(recentErr, os.ErrNotExist) {
+							log.Debug().Err(recentErr).Msg("recent file was replaced before it could be read")
+						} else {
+							log.Error().Msgf("error loading recent file: %s", recentErr)
 						}
 					}
 				}
@@ -541,19 +617,21 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 		return nil, fmt.Errorf("failed to watch active game file (%s): %w", misterconfig.ActiveGameFile, err)
 	}
 
-	if _, statPathErr := os.Stat(misterconfig.CurrentPathFile); os.IsNotExist(statPathErr) {
+	if _, statSelectErr := os.Stat(misterconfig.FileSelectFile); os.IsNotExist(statSelectErr) {
 		//nolint:gosec // MiSTer system file, needs to be readable by other apps
-		writePathErr := os.WriteFile(misterconfig.CurrentPathFile, []byte(""), 0o644)
-		if writePathErr != nil {
-			return nil, fmt.Errorf("failed to write current path file: %w", writePathErr)
+		writeSelectErr := os.WriteFile(misterconfig.FileSelectFile, []byte(""), 0o644)
+		if writeSelectErr != nil {
+			return nil, fmt.Errorf("failed to write file selection status: %w", writeSelectErr)
 		}
-		log.Info().Msgf("created current path file: %s", misterconfig.CurrentPathFile)
+		log.Info().Msgf("created file selection status: %s", misterconfig.FileSelectFile)
 	}
 
-	log.Debug().Msgf("adding watcher for current path file: %s", misterconfig.CurrentPathFile)
-	err = watcher.Add(misterconfig.CurrentPathFile)
+	// Watch the status file, not FULLPATH. MiSTer rewrites FULLPATH while the
+	// user browses and only FILESELECT=selected confirms a launch.
+	log.Debug().Msgf("adding watcher for file selection status: %s", misterconfig.FileSelectFile)
+	err = watcher.Add(misterconfig.FileSelectFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to watch current path file (%s): %w", misterconfig.CurrentPathFile, err)
+		return nil, fmt.Errorf("failed to watch file selection status (%s): %w", misterconfig.FileSelectFile, err)
 	}
 
 	elapsed := time.Since(startTime)

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -338,20 +338,28 @@ func (tr *Tracker) loadGame() {
 	}
 
 	launchers := helpers.PathToLaunchers(tr.cfg, tr.pl, path)
-	if len(launchers) == 0 {
-		log.Warn().Msgf("no launchers found for %s", path)
-		return
+	var launcher platforms.Launcher
+	switch {
+	case len(launchers) > 0:
+		launcher = launchers[0]
+	default:
+		var guessed bool
+		launcher, guessed = helpers.GuessLauncherForPath(path)
+		if !guessed {
+			log.Warn().Msgf("no launchers found for %s", path)
+			return
+		}
 	}
-	log.Debug().Msgf("tracker detected launchers: %v", launchers)
+	log.Debug().Msgf("tracker detected launcher: %v", launcher)
 
-	if launchers[0].SystemID == "" {
+	if launcher.SystemID == "" {
 		log.Warn().Str("path", path).Msg("launcher has empty system ID")
 		return
 	}
 
-	system, err := systemdefs.GetSystem(launchers[0].SystemID)
+	system, err := systemdefs.GetSystem(launcher.SystemID)
 	if err != nil {
-		log.Error().Err(err).Str("systemID", launchers[0].SystemID).Msg("error getting system")
+		log.Error().Err(err).Str("systemID", launcher.SystemID).Msg("error getting system")
 		return
 	}
 	log.Debug().Msgf("tracker detected system: %v", system)

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -15,21 +15,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func writeRecentEntry(t *testing.T, filename, directory, name string) {
+	t.Helper()
+	entry := make([]byte, 1024+256+256)
+	copy(entry[:1024], directory)
+	copy(entry[1024:1280], name)
+	copy(entry[1280:], name)
+	require.NoError(t, os.WriteFile(filename, entry, 0o600))
+}
+
 func TestSelectedFullPath(t *testing.T) {
 	t.Parallel()
 
+	selectedPath := filepath.Join(misterconfig.SDRootDir, "games", "SNES", "Game.sfc")
 	t.Run("selected", func(t *testing.T) {
 		path, err := selectedFullPath(
 			[]byte("selected\n"),
-			[]byte(" /media/fat/games/SNES/Game.sfc\n"),
+			[]byte(" "+selectedPath+"\n"),
 		)
 		require.NoError(t, err)
-		assert.Equal(t, "/media/fat/games/SNES/Game.sfc", path)
+		assert.Equal(t, selectedPath, path)
 	})
 
 	for _, status := range []string{"active", "cancelled", ""} {
 		t.Run("ignores "+status, func(t *testing.T) {
-			path, err := selectedFullPath([]byte(status), []byte("/media/fat/games/SNES/Game.sfc"))
+			path, err := selectedFullPath([]byte(status), []byte(selectedPath))
 			require.NoError(t, err)
 			assert.Empty(t, path)
 		})
@@ -70,15 +80,65 @@ func TestRecentGamePath(t *testing.T) {
 	tmpDir := t.TempDir()
 	gameDir := filepath.Join("games", "GBC")
 	recentFile := filepath.Join(tmpDir, "GBC_recent_0.cfg")
-	entry := make([]byte, 1024+256+256)
-	copy(entry[:1024], gameDir)
-	copy(entry[1024:1280], "Game.gbc")
-	copy(entry[1280:], "Game")
-	require.NoError(t, os.WriteFile(recentFile, entry, 0o600))
+	writeRecentEntry(t, recentFile, gameDir, "Game.gbc")
 
-	path, err := recentGamePath(recentFile)
+	path, err := recentGamePath(recentFile, []byte{0, 0, 0, 0})
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join(misterconfig.SDRootDir, gameDir, "Game.gbc"), path)
+}
+
+func TestRecentGamePath_CoreRecents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MGL resolves launched game", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		gamePath := filepath.Join(tmpDir, "games", "Game.rom")
+		mglPath := filepath.Join(tmpDir, "Game.MGL")
+		mglData := []byte(`<mistergamedescription><file path="` + gamePath + `"/></mistergamedescription>`)
+		require.NoError(t, os.WriteFile(mglPath, mglData, 0o600))
+		recentFile := filepath.Join(tmpDir, "cores_recent.cfg")
+		writeRecentEntry(t, recentFile, tmpDir, filepath.Base(mglPath))
+
+		path, err := recentGamePath(recentFile, nil)
+		require.NoError(t, err)
+		assert.Equal(t, gamePath, path)
+	})
+
+	t.Run("non-MGL core is ignored", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		recentFile := filepath.Join(tmpDir, "cores_recent.cfg")
+		writeRecentEntry(t, recentFile, tmpDir, "SNES.rbf")
+
+		path, err := recentGamePath(recentFile, nil)
+		require.NoError(t, err)
+		assert.Empty(t, path)
+	})
+
+	t.Run("malformed MGL returns error", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		mglPath := filepath.Join(tmpDir, "Broken.mgl")
+		require.NoError(t, os.WriteFile(mglPath, []byte(`<mistergamedescription>`), 0o600))
+		recentFile := filepath.Join(tmpDir, "cores_recent.cfg")
+		writeRecentEntry(t, recentFile, tmpDir, filepath.Base(mglPath))
+
+		_, err := recentGamePath(recentFile, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error reading mgl file")
+	})
+}
+
+func TestRecentGamePath_EmptyRecentFile(t *testing.T) {
+	t.Parallel()
+
+	recentFile := filepath.Join(t.TempDir(), "empty_recent.cfg")
+	require.NoError(t, os.WriteFile(recentFile, nil, 0o600))
+
+	path, err := recentGamePath(recentFile, nil)
+	require.NoError(t, err)
+	assert.Empty(t, path)
 }
 
 func TestTrackerFileChanged(t *testing.T) {
@@ -90,6 +150,44 @@ func TestTrackerFileChanged(t *testing.T) {
 	assert.True(t, trackerFileChanged(fsnotify.Write|fsnotify.Chmod))
 	assert.False(t, trackerFileChanged(fsnotify.Chmod))
 	assert.False(t, trackerFileChanged(fsnotify.Remove))
+}
+
+func TestTrackerRecentFileChanged(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, trackerRecentFileChanged(
+		filepath.Join(misterconfig.CoreConfigFolder, "GBC_recent_0.cfg"),
+	))
+	assert.True(t, trackerRecentFileChanged(
+		filepath.Join(misterconfig.CoreConfigFolder, "cores_recent.cfg"),
+	))
+	assert.False(t, trackerRecentFileChanged(
+		filepath.Join(misterconfig.CoreConfigFolder, "device.bin"),
+	))
+	assert.False(t, trackerRecentFileChanged(
+		filepath.Join(filepath.Dir(misterconfig.CoreConfigFolder), "config-backup", "GBC_recent_0.cfg"),
+	))
+}
+
+func TestDispatchTrackerFileLoad(t *testing.T) {
+	t.Parallel()
+
+	settled := make(chan time.Time)
+	loaded := make(chan struct{})
+	dispatchTrackerFileLoad(settled, func() { close(loaded) })
+
+	select {
+	case <-loaded:
+		t.Fatal("file load ran before settle signal")
+	default:
+	}
+
+	settled <- time.Now()
+	select {
+	case <-loaded:
+	case <-time.After(time.Second):
+		t.Fatal("file load did not run after settle signal")
+	}
 }
 
 func TestMediaLookupContextUsesServiceContext(t *testing.T) {

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -4,9 +4,93 @@ package tracker
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestSelectedFullPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("selected", func(t *testing.T) {
+		path, err := selectedFullPath(
+			[]byte("selected\n"),
+			[]byte(" /media/fat/games/SNES/Game.sfc\n"),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "/media/fat/games/SNES/Game.sfc", path)
+	})
+
+	for _, status := range []string{"active", "cancelled", ""} {
+		t.Run("ignores "+status, func(t *testing.T) {
+			path, err := selectedFullPath([]byte(status), []byte("/media/fat/games/SNES/Game.sfc"))
+			require.NoError(t, err)
+			assert.Empty(t, path)
+		})
+	}
+
+	t.Run("selected requires path", func(t *testing.T) {
+		_, err := selectedFullPath([]byte("selected"), nil)
+		require.Error(t, err)
+	})
+}
+
+func TestResolveRecentGamePath(t *testing.T) {
+	t.Parallel()
+
+	relativePath := filepath.Join("games", "GBC", "Game.gbc")
+	assert.Equal(t,
+		filepath.Join(misterconfig.SDRootDir, relativePath),
+		resolveRecentGamePath(relativePath, nil, func(string) bool { return false }),
+	)
+
+	usb1Path := filepath.Join(filepath.Dir(misterconfig.SDRootDir), "usb1", relativePath)
+	assert.Equal(t, usb1Path, resolveRecentGamePath(
+		relativePath,
+		[]byte{1, 0, 0, 0},
+		func(path string) bool { return path == usb1Path },
+	))
+
+	absolutePath := filepath.Join(string(filepath.Separator), "media", "network", "Game.gbc")
+	assert.Equal(t,
+		absolutePath,
+		resolveRecentGamePath(absolutePath, []byte{1, 0, 0, 0}, func(string) bool { return false }),
+	)
+}
+
+func TestRecentGamePath(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	gameDir := filepath.Join("games", "GBC")
+	recentFile := filepath.Join(tmpDir, "GBC_recent_0.cfg")
+	entry := make([]byte, 1024+256+256)
+	copy(entry[:1024], gameDir)
+	copy(entry[1024:1280], "Game.gbc")
+	copy(entry[1280:], "Game")
+	require.NoError(t, os.WriteFile(recentFile, entry, 0o600))
+
+	path, err := recentGamePath(recentFile)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(misterconfig.SDRootDir, gameDir, "Game.gbc"), path)
+}
+
+func TestTrackerFileChanged(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, trackerFileChanged(fsnotify.Write))
+	assert.True(t, trackerFileChanged(fsnotify.Create))
+	assert.True(t, trackerFileChanged(fsnotify.Rename))
+	assert.True(t, trackerFileChanged(fsnotify.Write|fsnotify.Chmod))
+	assert.False(t, trackerFileChanged(fsnotify.Chmod))
+	assert.False(t, trackerFileChanged(fsnotify.Remove))
+}
 
 func TestMediaLookupContextUsesServiceContext(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -264,22 +264,28 @@ func (m *Manager) Create(ctx context.Context) (Info, error) {
 		return Info{}, fmt.Errorf("creating backup: %w", err)
 	}
 	started := time.Now().UTC()
-	_ = m.writeLocalStatus(&statusEntry{LastRunAt: formatTime(started), LastStatus: StatusRunning})
+	if statusErr := m.writeLocalStatus(&statusEntry{
+		LastRunAt: formatTime(started), LastStatus: StatusRunning,
+	}); statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to persist running local backup status")
+	}
 
 	info, err := m.createBackup(ctx, false)
 	if err != nil {
-		_ = m.writeLocalStatus(&statusEntry{
+		if statusErr := m.writeLocalStatus(&statusEntry{
 			LastRunAt:  formatTime(started),
 			LastStatus: StatusFailed,
 			LastError:  safeStatusError(err),
-		})
+		}); statusErr != nil {
+			log.Warn().Err(statusErr).Msg("failed to persist failed local backup status")
+		}
 		return Info{}, err
 	}
 	lastStatus := StatusSuccess
 	if len(info.Warnings) > 0 {
 		lastStatus = StatusPartial
 	}
-	_ = m.writeLocalStatus(&statusEntry{
+	if statusErr := m.writeLocalStatus(&statusEntry{
 		LastRunAt:      formatTime(started),
 		LastSuccessAt:  formatTime(info.CreatedAt),
 		LastStatus:     lastStatus,
@@ -287,7 +293,9 @@ func (m *Manager) Create(ctx context.Context) (Info, error) {
 		Categories:     info.Categories,
 		Warnings:       info.Warnings,
 		SkippedFiles:   len(info.Warnings),
-	})
+	}); statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to persist successful local backup status")
+	}
 	return info, nil
 }
 
@@ -408,7 +416,7 @@ func (m *Manager) List() ([]ListInfo, error) {
 		}
 		info, infoErr := fastInfoFromDirEntry(m.backupDir(), entry)
 		if infoErr != nil {
-			log.Debug().Err(infoErr).Str("name", entry.Name()).Msg("failed to read backup ZIP metadata")
+			log.Warn().Err(infoErr).Str("name", entry.Name()).Msg("failed to read backup ZIP metadata")
 			continue
 		}
 		infos = append(infos, info)
@@ -1229,7 +1237,7 @@ func writeZipFile(ctx context.Context, zw *zip.Writer, file *FileRef) error {
 	}
 	defer func() {
 		if closeErr := in.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("path", file.RestorePath).Msg("failed to close backup source")
+			log.Warn().Err(closeErr).Str("path", file.RestorePath).Msg("failed to close backup source")
 		}
 	}()
 
@@ -1349,7 +1357,7 @@ func inspectZipManifest(zipPath string) (Info, error) {
 	}
 	defer func() {
 		if closeErr := zr.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
+			log.Warn().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
 		}
 	}()
 	entries, err := validateZipHeaders(zr.File)
@@ -1421,7 +1429,7 @@ func stageLocalArchive(
 	}
 	defer func() {
 		if closeErr := zr.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
+			log.Warn().Err(closeErr).Str("path", zipPath).Msg("failed to close backup ZIP")
 		}
 	}()
 	entries, err := validateZipHeaders(zr.File)
@@ -1455,7 +1463,7 @@ func stageLocalArchive(
 	staging := &restoreStaging{dir: dir}
 	cleanup := func() {
 		if removeErr := os.RemoveAll(dir); removeErr != nil {
-			log.Debug().Err(removeErr).Str("dir", dir).Msg("failed to remove local restore staging directory")
+			log.Warn().Err(removeErr).Str("dir", dir).Msg("failed to remove local restore staging directory")
 		}
 	}
 
@@ -1660,7 +1668,7 @@ func readZipEntryLimited(f *zip.File, limit int64) ([]byte, error) {
 	}
 	defer func() {
 		if closeErr := r.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("name", f.Name).Msg("failed to close ZIP entry")
+			log.Warn().Err(closeErr).Str("name", f.Name).Msg("failed to close ZIP entry")
 		}
 	}()
 	body, err := io.ReadAll(io.LimitReader(r, limit+1))

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -105,6 +105,13 @@ var (
 	errRemoteNewerSchema    = errors.New("backup requires a newer Core version")
 )
 
+// IsRemoteUnlinkedError reports expected inactivity when no usable online
+// credential exists. Background schedulers use this to avoid warning on
+// devices that have intentionally never linked or have since unlinked.
+func IsRemoteUnlinkedError(err error) bool {
+	return errors.Is(err, errRemoteUnlinked)
+}
+
 // RemoteRunInfo describes one completed remote backup run.
 //
 //nolint:govet // JSON response shape is grouped for API readability.
@@ -363,7 +370,11 @@ func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunIn
 	ctx = lease.Context()
 
 	started := time.Now().UTC()
-	_ = m.writeRemoteStatus(&statusEntry{LastRunAt: formatTime(started), LastStatus: StatusRunning})
+	if statusErr := m.writeRemoteStatus(&statusEntry{
+		LastRunAt: formatTime(started), LastStatus: StatusRunning,
+	}); statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to persist running remote backup status")
+	}
 
 	info, err := m.createRemoteSnapshot(ctx, backupType)
 	if errors.Is(err, errRemoteIntegrityRetry) {
@@ -382,7 +393,9 @@ func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunIn
 		if errors.Is(err, errRemoteUnlinked) {
 			failed.Unlinked = true
 		}
-		_ = m.writeRemoteStatus(failed)
+		if statusErr := m.writeRemoteStatus(failed); statusErr != nil {
+			log.Warn().Err(statusErr).Msg("failed to persist failed remote backup status")
+		}
 		m.notifyRemoteFailure(err)
 		return RemoteRunInfo{}, err
 	}
@@ -395,7 +408,7 @@ func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunIn
 	// with its original timestamp, and stamping that here would make a
 	// healthy daily schedule look like it stopped on the last content
 	// change (and eventually trip the false stale-backup notice).
-	_ = m.writeRemoteStatus(&statusEntry{
+	if statusErr := m.writeRemoteStatus(&statusEntry{
 		LastRunAt:             formatTime(started),
 		LastSuccessAt:         formatTime(time.Now().UTC()),
 		LastSnapshotCreatedAt: formatTime(info.Backup.CreatedAt),
@@ -405,7 +418,9 @@ func (m *Manager) RunRemote(ctx context.Context, backupType string) (RemoteRunIn
 		Categories:            remoteCategoriesToStatus(info.Categories),
 		Warnings:              info.Warnings,
 		SkippedFiles:          len(info.Warnings) + info.SkippedFiles,
-	})
+	}); statusErr != nil {
+		log.Warn().Err(statusErr).Msg("failed to persist successful remote backup status")
+	}
 	return info, nil
 }
 
@@ -638,7 +653,7 @@ func (m *Manager) stageRemotePayloads(
 	staging := &restoreStaging{dir: dir}
 	cleanup := func() {
 		if removeErr := os.RemoveAll(dir); removeErr != nil {
-			log.Debug().Err(removeErr).Str("dir", dir).Msg("failed to remove restore staging directory")
+			log.Warn().Err(removeErr).Str("dir", dir).Msg("failed to remove restore staging directory")
 		}
 	}
 
@@ -768,7 +783,7 @@ func (c *remoteClient) stagePackObjects(
 	}
 	defer func() {
 		if removeErr := os.Remove(packPath); removeErr != nil {
-			log.Debug().Err(removeErr).Str("path", packPath).Msg("failed to remove staged pack file")
+			log.Warn().Err(removeErr).Str("path", packPath).Msg("failed to remove staged pack file")
 		}
 	}()
 	return extractPackObjects(packPath, pack, staging)
@@ -843,7 +858,7 @@ func (c *remoteClient) downloadPackAttempt(
 	}
 	if rawErr != nil {
 		if removeErr := os.Remove(path); removeErr != nil {
-			log.Debug().Err(removeErr).Str("path", path).Msg("failed to remove failed pack download")
+			log.Warn().Err(removeErr).Str("path", path).Msg("failed to remove failed pack download")
 		}
 		return "", rawErr
 	}
@@ -861,7 +876,7 @@ func extractPackObjects(packPath string, pack *remotePackObjects, staging *resto
 	}
 	defer func() {
 		if closeErr := packFile.Close(); closeErr != nil {
-			log.Debug().Err(closeErr).Str("path", packPath).Msg("failed to close staged pack file")
+			log.Warn().Err(closeErr).Str("path", packPath).Msg("failed to close staged pack file")
 		}
 	}()
 	for i := range pack.Objects {
@@ -1025,7 +1040,7 @@ func (m *Manager) createRemoteSnapshot(ctx context.Context, backupType string) (
 	}
 	list, listErr := m.ListRemote(ctx)
 	if listErr != nil {
-		log.Debug().Err(listErr).Msg("failed to refresh remote backup quota after upload")
+		log.Warn().Err(listErr).Msg("failed to refresh remote backup quota after upload")
 	}
 	m.notifyRemoteWarnings(collection.Warnings)
 	uploadedFiles := 0
@@ -1335,7 +1350,11 @@ func (m *Manager) RefreshRemoteAvailabilityIfStaleAsync() {
 		ctx, cancel := context.WithTimeout(context.Background(), remoteRequestTimeout)
 		defer cancel()
 		if _, err := m.RefreshRemoteAvailability(ctx); err != nil {
-			log.Debug().Err(err).Msg("background remote availability refresh failed")
+			if errors.Is(err, context.Canceled) {
+				log.Debug().Err(err).Msg("background remote availability refresh stopped")
+			} else {
+				log.Warn().Err(err).Msg("background remote availability refresh failed")
+			}
 		}
 	}()
 }

--- a/pkg/service/backup/remote_playsync.go
+++ b/pkg/service/backup/remote_playsync.go
@@ -46,6 +46,13 @@ const (
 
 var errPlaySyncDisabled = errors.New("play history sync is disabled")
 
+// IsPlaySyncDisabledError reports an expected opt-out or mid-sync disable.
+// Background schedulers use this to keep intentional inactivity quiet while
+// surfacing real upload failures at warning level.
+func IsPlaySyncDisabledError(err error) bool {
+	return errors.Is(err, errPlaySyncDisabled)
+}
+
 // PlaySyncInfo summarizes one play-history sync pass.
 type PlaySyncInfo struct {
 	Uploaded int

--- a/pkg/service/backup/remote_playsync_test.go
+++ b/pkg/service/backup/remote_playsync_test.go
@@ -22,6 +22,7 @@ package backup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,6 +34,18 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOnlineErrorClassifiers(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsRemoteUnlinkedError(errRemoteUnlinked))
+	assert.True(t, IsRemoteUnlinkedError(errors.Join(errors.New("wrapped"), errRemoteUnlinked)))
+	assert.False(t, IsRemoteUnlinkedError(errors.New("network failure")))
+
+	assert.True(t, IsPlaySyncDisabledError(errPlaySyncDisabled))
+	assert.True(t, IsPlaySyncDisabledError(errors.Join(errors.New("wrapped"), errPlaySyncDisabled)))
+	assert.False(t, IsPlaySyncDisabledError(errors.New("upload failure")))
+}
 
 // playSyncTestEntry builds one closed, syncable MediaHistory row.
 func playSyncTestEntry(dbid int64, id, mediaName string, updatedAt time.Time) database.MediaHistoryEntry {

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -23,6 +23,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -113,6 +114,12 @@ func (s *remoteHeartbeatState) recordSuccess(now time.Time) {
 	s.backoff = remoteHeartbeatInitialBackoff
 }
 
+// onlineFailureRequiresWarning separates expected inactivity (disabled,
+// unlinked, or shutdown) from failures support logs must retain.
+func onlineFailureRequiresWarning(err error, expected bool) bool {
+	return err != nil && !expected && !errors.Is(err, context.Canceled)
+}
+
 func startRemoteBackupScheduler(
 	ctx context.Context,
 	cfg *config.Instance,
@@ -121,12 +128,13 @@ func startRemoteBackupScheduler(
 	st *state.State,
 	idleSched *idle.Scheduler,
 	pauser *syncutil.Pauser,
+	playSyncRequests <-chan struct{},
 	wg *sync.WaitGroup,
 ) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		remoteBackupSchedulerLoop(ctx, cfg, pl, db, st, idleSched, pauser, time.NewTicker)
+		remoteBackupSchedulerLoop(ctx, cfg, pl, db, st, idleSched, pauser, playSyncRequests, time.NewTicker)
 	}()
 }
 
@@ -138,6 +146,7 @@ func remoteBackupSchedulerLoop(
 	st *state.State,
 	idleSched *idle.Scheduler,
 	pauser *syncutil.Pauser,
+	playSyncRequests <-chan struct{},
 	newTicker func(time.Duration) *time.Ticker,
 ) {
 	// A run interrupted by power loss or a hard shutdown left "running" in
@@ -181,9 +190,15 @@ func remoteBackupSchedulerLoop(
 		}
 		mgr := backupsvc.NewManager(cfg, pl, db).WithCoordinator(st.BackupCoordinator())
 		if err := mgr.SendHeartbeat(ctx); err != nil {
-			// Not linked or unreachable: fine, heartbeats are best-effort.
 			heartbeatState.recordFailure(now)
-			log.Debug().Err(err).Msg("remote heartbeat not sent")
+			expected := backupsvc.IsRemoteUnlinkedError(err)
+			if onlineFailureRequiresWarning(err, expected) {
+				log.Warn().Err(err).
+					Dur("retry_in", heartbeatState.nextAttempt.Sub(now)).
+					Msg("remote heartbeat not sent")
+			} else {
+				log.Debug().Err(err).Msg("remote heartbeat not sent")
+			}
 			return
 		}
 		heartbeatState.recordSuccess(now)
@@ -201,25 +216,34 @@ func remoteBackupSchedulerLoop(
 	}
 
 	// Play-history sync reuses the heartbeat pacing state: interval on
-	// success, exponential backoff on failure. The first pass after linking
-	// is the bulk import of the whole local history.
+	// success, exponential backoff on failure. A completed session requests
+	// an immediate pass through this same serialized path. Requests coalesce,
+	// remain pending across failures, and never bypass retry backoff.
 	playSyncState := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
+	playSyncPending := false
 	tryPlaySync := func() {
 		now := time.Now()
-		if !playSyncDue(&playSyncState, now) {
+		if !playSyncDue(&playSyncState, now, playSyncPending) {
 			return
 		}
 		mgr := backupsvc.NewManager(cfg, pl, db).WithCoordinator(st.BackupCoordinator())
 		info, err := mgr.SyncPlayHistory(ctx)
 		if err != nil {
-			// Unlinked, disabled, or unreachable: sync is best-effort.
 			playSyncState.recordFailure(now)
-			log.Debug().Err(err).Msg("play history sync not run")
+			expected := backupsvc.IsRemoteUnlinkedError(err) || backupsvc.IsPlaySyncDisabledError(err)
+			if onlineFailureRequiresWarning(err, expected) {
+				log.Warn().Err(err).
+					Dur("retry_in", playSyncState.nextAttempt.Sub(now)).
+					Msg("play history sync failed")
+			} else {
+				log.Debug().Err(err).Msg("play history sync not run")
+			}
 			return
 		}
 		playSyncState.recordSuccess(now)
+		playSyncPending = false
 		if info.Uploaded > 0 {
-			log.Info().Int("sessions", info.Uploaded).Msg("scheduled play history sync completed")
+			log.Info().Int("sessions", info.Uploaded).Msg("play history sync completed")
 		}
 	}
 
@@ -236,16 +260,20 @@ func remoteBackupSchedulerLoop(
 			trySchedule()
 			tryStaleNotice()
 			tryPlaySync()
+		case <-playSyncRequests:
+			playSyncPending = true
+			tryPlaySync()
 		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-// playSyncDue reports whether a play-history sync pass should run now,
-// honoring the success interval and failure backoff.
-func playSyncDue(s *remoteHeartbeatState, now time.Time) bool {
-	if !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < playSyncInterval {
+// playSyncDue reports whether a play-history sync pass should run now.
+// A completed session bypasses the normal success interval, but never the
+// failure backoff.
+func playSyncDue(s *remoteHeartbeatState, now time.Time, pending bool) bool {
+	if !pending && !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < playSyncInterval {
 		return false
 	}
 	return s.nextAttempt.IsZero() || !now.Before(s.nextAttempt)
@@ -294,7 +322,11 @@ func runScheduledRemoteBackup(
 	}
 	availability, refreshErr := mgr.RefreshRemoteAvailability(ctx)
 	if refreshErr != nil {
-		log.Debug().Err(refreshErr).Msg("scheduled remote backup eligibility refresh failed")
+		if onlineFailureRequiresWarning(refreshErr, false) {
+			log.Warn().Err(refreshErr).Msg("scheduled remote backup eligibility refresh failed")
+		} else {
+			log.Debug().Err(refreshErr).Msg("scheduled remote backup eligibility refresh stopped")
+		}
 		return
 	}
 	if availability != backupsvc.RemoteAvailabilityAvailable {

--- a/pkg/service/backup_scheduler_test.go
+++ b/pkg/service/backup_scheduler_test.go
@@ -25,18 +25,25 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	backupsvc "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/backup"
+	stateservice "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,6 +186,103 @@ func TestPlaySyncDuePendingBypassesIntervalButHonorsBackoff(t *testing.T) {
 	s.nextAttempt = now.Add(time.Minute)
 	assert.False(t, playSyncDue(&s, now, true), "completed session must not bypass failure backoff")
 	assert.True(t, playSyncDue(&s, now.Add(time.Minute), true))
+}
+
+func TestRemoteBackupScheduler_PlaySyncRequestBypassesSuccessInterval(t *testing.T) {
+	rootDir := t.TempDir()
+	var watermarkRequests atomic.Int32
+	watermarkSeen := make(chan int32, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/heartbeat":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "device-1", "name": "test", "backup_active": false,
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/play-sessions/watermark":
+			count := watermarkRequests.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{"watermark": nil})
+			watermarkSeen <- count
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cfg, err := config.NewConfig(rootDir, config.BaseDefaults)
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetBackupRemoteBaseURL(server.URL))
+	require.NoError(t, cfg.SetPlaytimeBaseURL(server.URL))
+	cfg.SetBackupRemoteEnabled(false)
+	cfg.SetPlaytimeSync(true)
+	config.SetAuthCfgForTesting(map[string]config.CredentialEntry{
+		config.RemoteAuthLookupURL(server.URL): {Bearer: "test-token"},
+	})
+	t.Cleanup(config.ClearAuthCfgForTesting)
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+	mockPlatform.On("Settings").Return(platforms.Settings{
+		DataDir: rootDir, ConfigDir: rootDir,
+	}).Maybe()
+	st, _ := stateservice.NewState(mockPlatform, "test-boot")
+	t.Cleanup(st.StopService)
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	syncFinished := make(chan struct{}, 2)
+	mockUserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Twice()
+	mockUserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), mock.Anything).
+		Run(func(mock.Arguments) { syncFinished <- struct{}{} }).
+		Return([]database.MediaHistoryEntry{}, nil).Twice()
+	db := &database.Database{UserDB: mockUserDB}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	playSyncRequests := make(chan struct{}, 1)
+	done := make(chan struct{})
+	// Remote backup is disabled, so this loop exercises heartbeat and play
+	// sync only; the idle scheduler must never be reached.
+	go func() {
+		remoteBackupSchedulerLoop(
+			ctx, cfg, mockPlatform, db, st, nil, syncutil.NewPauser(), playSyncRequests,
+			func(time.Duration) *time.Ticker { return time.NewTicker(time.Hour) },
+		)
+		close(done)
+	}()
+
+	waitForWatermark := func(want int32) {
+		t.Helper()
+		select {
+		case got := <-watermarkSeen:
+			assert.Equal(t, want, got)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for play sync request %d", want)
+		}
+	}
+	waitForSync := func() {
+		t.Helper()
+		select {
+		case <-syncFinished:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for play sync to finish")
+		}
+	}
+	waitForWatermark(1)
+	waitForSync()
+	playSyncRequests <- struct{}{}
+	waitForWatermark(2)
+	waitForSync()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("backup scheduler did not stop after cancellation")
+	}
+	assert.Equal(t, int32(2), watermarkRequests.Load())
+	mockUserDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
 }
 
 func TestRemoteBackupScheduleInterval(t *testing.T) {

--- a/pkg/service/backup_scheduler_test.go
+++ b/pkg/service/backup_scheduler_test.go
@@ -24,6 +24,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -121,6 +122,31 @@ func TestRemoteBackupDueRetriesSoonerAfterFailure(t *testing.T) {
 		"success resets to the normal schedule interval")
 }
 
+func TestOnlineFailureRequiresWarning(t *testing.T) {
+	t.Parallel()
+
+	failure := errors.New("remote request failed")
+	tests := []struct {
+		err      error
+		name     string
+		expected bool
+		want     bool
+	}{
+		{name: "nil", want: false},
+		{name: "expected inactivity", err: failure, expected: true, want: false},
+		{name: "shutdown cancellation", err: context.Canceled, want: false},
+		{name: "wrapped shutdown cancellation", err: errors.Join(failure, context.Canceled), want: false},
+		{name: "actionable failure", err: failure, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, onlineFailureRequiresWarning(tt.err, tt.expected))
+		})
+	}
+}
+
 func TestRemoteHeartbeatStateBacksOffFailuresAndRecordsOnlySuccess(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
@@ -139,6 +165,20 @@ func TestRemoteHeartbeatStateBacksOffFailuresAndRecordsOnlySuccess(t *testing.T)
 	assert.False(t, state.due(succeededAt.Add(time.Hour)))
 	assert.True(t, state.due(succeededAt.Add(remoteHeartbeatInterval)))
 	assert.Equal(t, remoteHeartbeatInitialBackoff, state.backoff)
+}
+
+func TestPlaySyncDuePendingBypassesIntervalButHonorsBackoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	s := remoteHeartbeatState{lastSuccess: now.Add(-time.Minute)}
+
+	assert.False(t, playSyncDue(&s, now, false), "periodic sync must honor the success interval")
+	assert.True(t, playSyncDue(&s, now, true), "completed session must request an immediate sync")
+
+	s.nextAttempt = now.Add(time.Minute)
+	assert.False(t, playSyncDue(&s, now, true), "completed session must not bypass failure backoff")
+	assert.True(t, playSyncDue(&s, now.Add(time.Minute), true))
 }
 
 func TestRemoteBackupScheduleInterval(t *testing.T) {

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -44,6 +44,7 @@ type mediaHistoryTracker struct {
 	currentMediaStartTimeMono time.Time
 	st                        *state.State
 	db                        *database.Database
+	requestPlaySync           func()
 	currentHistoryDBID        int64
 	closingHistoryDBID        int64
 	mu                        syncutil.RWMutex
@@ -76,6 +77,8 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 				if closeErr := t.db.UserDB.CloseMediaHistory(prevDBID, endTime, playTime); closeErr != nil {
 					log.Error().Err(closeErr).Int64("dbid", prevDBID).
 						Msg("media history: failed to close orphaned entry")
+				} else if t.requestPlaySync != nil {
+					t.requestPlaySync()
 				}
 				t.mu.Lock()
 				if t.currentHistoryDBID == prevDBID {
@@ -197,6 +200,9 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					}
 					t.mu.Unlock()
 					log.Debug().Int64("dbid", dbid).Int("playTime", playTime).Msg("closed media history entry")
+					if t.requestPlaySync != nil {
+						t.requestPlaySync()
+					}
 				}
 			}
 		}

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -270,10 +270,12 @@ func TestMediaHistoryTracker_Listen_Stopped(t *testing.T) {
 	}
 
 	startTime := fakeClock.Now()
+	syncRequests := 0
 	tracker := &mediaHistoryTracker{
 		st:                    st,
 		db:                    db,
 		clock:                 fakeClock,
+		requestPlaySync:       func() { syncRequests++ },
 		currentHistoryDBID:    42,
 		currentMediaStartTime: startTime,
 	}
@@ -301,6 +303,7 @@ func TestMediaHistoryTracker_Listen_Stopped(t *testing.T) {
 	mockUserDB.AssertExpectations(t)
 	assert.Equal(t, int64(0), tracker.currentHistoryDBID)
 	assert.True(t, tracker.currentMediaStartTime.IsZero())
+	assert.Equal(t, 1, syncRequests)
 }
 
 func TestMediaHistoryTracker_Listen_Stopped_NoActiveHistory(t *testing.T) {
@@ -349,10 +352,12 @@ func TestMediaHistoryTracker_Listen_Stopped_DatabaseError(t *testing.T) {
 	}
 
 	startTime := fakeClock.Now()
+	syncRequests := 0
 	tracker := &mediaHistoryTracker{
 		st:                    st,
 		db:                    db,
 		clock:                 fakeClock,
+		requestPlaySync:       func() { syncRequests++ },
 		currentHistoryDBID:    42,
 		currentMediaStartTime: startTime,
 	}
@@ -378,6 +383,7 @@ func TestMediaHistoryTracker_Listen_Stopped_DatabaseError(t *testing.T) {
 	assert.Equal(t, int64(42), tracker.currentHistoryDBID)
 	assert.Equal(t, startTime, tracker.currentMediaStartTime)
 	assert.Equal(t, int64(0), tracker.closingHistoryDBID)
+	assert.Equal(t, 0, syncRequests)
 }
 
 func TestMediaHistoryTracker_Listen_MultipleNotifications(t *testing.T) {
@@ -734,10 +740,12 @@ func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
 	orphanStart := fakeClock.Now()
 
 	// Pre-set tracker state as if a game is currently tracked (orphaned open entry).
+	syncRequests := 0
 	tracker := &mediaHistoryTracker{
 		st:                    st,
 		db:                    db,
 		clock:                 fakeClock,
+		requestPlaySync:       func() { syncRequests++ },
 		currentHistoryDBID:    orphanedDBID,
 		currentMediaStartTime: orphanStart,
 	}
@@ -778,4 +786,5 @@ func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
 
 	mockUserDB.AssertExpectations(t)
 	assert.Equal(t, newDBID, tracker.currentHistoryDBID, "new DBID should be set after orphan close")
+	assert.Equal(t, 1, syncRequests)
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -544,7 +544,16 @@ func Start(
 			pruneExpiredZapLinkHosts(db)
 		},
 	)
-	startRemoteBackupScheduler(st.GetContext(), cfg, pl, db, st, idleSched, backupPauser, backgroundWG)
+	playSyncRequests := make(chan struct{}, 1)
+	requestPlaySync := func() {
+		select {
+		case playSyncRequests <- struct{}{}:
+		default:
+		}
+	}
+	startRemoteBackupScheduler(
+		st.GetContext(), cfg, pl, db, st, idleSched, backupPauser, playSyncRequests, backgroundWG,
+	)
 	go watchGameForIndexPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, indexPauser)
 	go watchGameForScrapePause(st.GetContext(), notifBroker, st, cfg, st.Notifications, scrapePauser)
 	go watchGameForBackupPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, backupPauser)
@@ -557,9 +566,10 @@ func Start(
 	// Start media history tracking
 	log.Info().Msg("starting media history listener")
 	historyTracker := &mediaHistoryTracker{
-		st:    st,
-		db:    db,
-		clock: clockwork.NewRealClock(),
+		st:              st,
+		db:              db,
+		clock:           clockwork.NewRealClock(),
+		requestPlaySync: requestPlaySync,
 	}
 	historyNotifications, _ := notifBroker.Subscribe(100, models.NotificationStarted, models.NotificationStopped)
 	historyListenDone := make(chan struct{})

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -827,19 +827,9 @@ func pollAuthLinkStatus(
 		ctx, cancel := tuiContext()
 		status, err := svc.GetAuthLinkStatus(ctx)
 		cancel()
+		consecutiveFailures = logAuthLinkStatusPollResult(err, consecutiveFailures)
 		if err != nil {
-			consecutiveFailures++
-			if consecutiveFailures == 1 {
-				log.Warn().Err(err).Msg("error polling device link status")
-			} else {
-				log.Debug().Err(err).Int("consecutive_failures", consecutiveFailures).
-					Msg("device link status polling still failing")
-			}
 			continue
-		}
-		if consecutiveFailures > 0 {
-			log.Info().Int("failures", consecutiveFailures).Msg("device link status polling recovered")
-			consecutiveFailures = 0
 		}
 		switch status.Status {
 		case models.AuthLinkStatusPending:
@@ -865,6 +855,23 @@ func pollAuthLinkStatus(
 			return
 		}
 	}
+}
+
+func logAuthLinkStatusPollResult(err error, consecutiveFailures int) int {
+	if err != nil {
+		consecutiveFailures++
+		if consecutiveFailures == 1 {
+			log.Warn().Err(err).Msg("error polling device link status")
+		} else {
+			log.Debug().Err(err).Int("consecutive_failures", consecutiveFailures).
+				Msg("device link status polling still failing")
+		}
+		return consecutiveFailures
+	}
+	if consecutiveFailures > 0 {
+		log.Info().Int("failures", consecutiveFailures).Msg("device link status polling recovered")
+	}
+	return 0
 }
 
 func buildBackupListPage(svc SettingsService, pages *tview.Pages, app *tview.Application, goBack func()) {

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -778,7 +778,7 @@ func startAuthLinkFlow(svc SettingsService, pages *tview.Pages, app *tview.Appli
 			cancelCtx, cancelCancel := tuiContext()
 			defer cancelCancel()
 			if cancelErr := svc.CancelAuthLink(cancelCtx); cancelErr != nil {
-				log.Debug().Err(cancelErr).Msg("error cancelling device link")
+				log.Warn().Err(cancelErr).Msg("error cancelling device link")
 			}
 			closeModal()
 			onDone()
@@ -816,6 +816,7 @@ func pollAuthLinkStatus(
 ) {
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()
+	consecutiveFailures := 0
 	for {
 		select {
 		case <-done:
@@ -827,8 +828,18 @@ func pollAuthLinkStatus(
 		status, err := svc.GetAuthLinkStatus(ctx)
 		cancel()
 		if err != nil {
-			log.Debug().Err(err).Msg("error polling device link status")
+			consecutiveFailures++
+			if consecutiveFailures == 1 {
+				log.Warn().Err(err).Msg("error polling device link status")
+			} else {
+				log.Debug().Err(err).Int("consecutive_failures", consecutiveFailures).
+					Msg("device link status polling still failing")
+			}
 			continue
+		}
+		if consecutiveFailures > 0 {
+			log.Info().Int("failures", consecutiveFailures).Msg("device link status polling recovered")
+			consecutiveFailures = 0
 		}
 		switch status.Status {
 		case models.AuthLinkStatusPending:

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -20,6 +20,7 @@
 package tui
 
 import (
+	"bytes"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -30,6 +31,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	testingmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/rivo/tview"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1638,6 +1641,33 @@ func TestRemoteBackupRestoreConfirm_WordingAndRestore_Integration(t *testing.T) 
 	runner.SimulateEnter()
 	require.True(t, runner.WaitForText("Cloud backup restored", 2*time.Second))
 	mockSvc.AssertCalled(t, "RestoreRemoteBackup", mock.Anything, "backup-7")
+}
+
+func TestLogAuthLinkStatusPollResult(t *testing.T) {
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+
+	consecutiveFailures := logAuthLinkStatusPollResult(assert.AnError, 0)
+	assert.Equal(t, 1, consecutiveFailures)
+	consecutiveFailures = logAuthLinkStatusPollResult(assert.AnError, consecutiveFailures)
+	assert.Equal(t, 2, consecutiveFailures)
+	consecutiveFailures = logAuthLinkStatusPollResult(nil, consecutiveFailures)
+	assert.Zero(t, consecutiveFailures)
+	consecutiveFailures = logAuthLinkStatusPollResult(assert.AnError, consecutiveFailures)
+	assert.Equal(t, 1, consecutiveFailures)
+
+	logs := buf.Bytes()
+	assert.Equal(t, 2, bytes.Count(logs, []byte(`"message":"error polling device link status"`)),
+		"first failure after recovery must warn again")
+	assert.Contains(t, string(logs), `"level":"warn"`)
+	assert.Contains(t, string(logs), `"level":"debug"`)
+	assert.Contains(t, string(logs), `"consecutive_failures":2`)
+	assert.Contains(t, string(logs), `"message":"device link status polling still failing"`)
+	assert.Contains(t, string(logs), `"level":"info"`)
+	assert.Contains(t, string(logs), `"failures":2`)
+	assert.Contains(t, string(logs), `"message":"device link status polling recovered"`)
 }
 
 func TestStartAuthLinkFlow_SuccessMentionsCloudBackups_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary
- surface actionable online backup, play-sync, and device-link failures while keeping expected inactive states quiet
- preserve existing credentials when `auth.toml` is malformed or unreadable
- sync completed play sessions immediately through serialized retries while retaining hourly fallback
- restore MiSTer OSD tracking through safe file-selection handling, robust recent-file events, and SD/USB-relative path resolution
- conservatively guess launchers outside configured media roots when folder aliases and extensions agree, or when an extension identifies one system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Play history can now request immediate remote sync after sessions end.
  * Improved MiSTer game detection with enhanced recent-path resolution and manual file selection handling.
  * Added fallback launcher inference for previously-unknown game paths.

* **Bug Fixes**
  * More robust auth file handling: validate TOML before loading and prevent malformed files from clobbering existing credentials.
  * Backup/restore and remote availability/polling now escalate key failures to warnings more consistently.

* **Improvements**
  * Reduced log noise via consecutive-failure counters, with clear “first retrying” and “recovered” signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->