### PR TITLE
feat(readers): resolve external-drive relative paths

### DIFF
--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -589,6 +589,55 @@ func TestFindLauncher_FolderSystemOverSystemOnly(t *testing.T) {
 	assert.Equal(t, "FolderAndSystem", launcher.ID, "folder+system launcher should beat system-only")
 }
 
+func TestFindLauncher_GenericOutsideRootsBeatsFallbackCandidates(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	root := t.TempDir()
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+
+	genericLauncher := platforms.Launcher{
+		ID:         "Generic",
+		Extensions: []string{".mgl"},
+	}
+	snesLauncher := platforms.Launcher{
+		ID:         "SNES",
+		SystemID:   systemdefs.SystemSNES,
+		Folders:    []string{"SNES"},
+		Extensions: []string{".mgl"},
+	}
+	psxLauncher := platforms.Launcher{
+		ID:         "PSX",
+		SystemID:   systemdefs.SystemPSX,
+		Folders:    []string{"PSX"},
+		Extensions: []string{".mgl"},
+	}
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return(
+		[]platforms.Launcher{genericLauncher, snesLauncher, psxLauncher})
+
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	externalPath := filepath.Join(t.TempDir(), "Game.mgl")
+	launcher, err := FindLauncher(cfg, mockPlatform, externalPath)
+	require.NoError(t, err)
+	assert.Equal(t, "Generic", launcher.ID)
+
+	systemPath := filepath.Join(root, "SNES", "Game.mgl")
+	launcher, err = FindLauncher(cfg, mockPlatform, systemPath)
+	require.NoError(t, err)
+	assert.Equal(t, "SNES", launcher.ID)
+}
+
 func TestFindLauncher_GenericAloneStillWorks(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	mockPlatform := mocks.NewMockPlatform()

--- a/pkg/helpers/utils.go
+++ b/pkg/helpers/utils.go
@@ -57,7 +57,7 @@ func TokensEqual(a, b *tokens.Token) bool {
 		return false
 	}
 
-	return a.UID == b.UID && a.Text == b.Text
+	return a.UID == b.UID && a.Text == b.Text && a.PathRoot == b.PathRoot
 }
 
 func GetMd5Hash(filePath string) (string, error) {

--- a/pkg/helpers/utils_test.go
+++ b/pkg/helpers/utils_test.go
@@ -22,6 +22,7 @@ package helpers
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -132,6 +133,34 @@ func TestTokensEqual(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "same_path_root",
+			a: &tokens.Token{
+				UID:      "123456",
+				Text:     "Mario Bros",
+				PathRoot: filepath.Join("media", "usb-a"),
+			},
+			b: &tokens.Token{
+				UID:      "123456",
+				Text:     "Mario Bros",
+				PathRoot: filepath.Join("media", "usb-a"),
+			},
+			expected: true,
+		},
+		{
+			name: "different_path_root",
+			a: &tokens.Token{
+				UID:      "123456",
+				Text:     "Mario Bros",
+				PathRoot: filepath.Join("media", "usb-a"),
+			},
+			b: &tokens.Token{
+				UID:      "123456",
+				Text:     "Mario Bros",
+				PathRoot: filepath.Join("media", "usb-b"),
+			},
+			expected: false,
+		},
+		{
 			name: "empty_uid_and_text",
 			a: &tokens.Token{
 				UID:  "",
@@ -165,7 +194,7 @@ func TestTokensEqual(t *testing.T) {
 				ReaderID: "pn532-abc123",          // Different ReaderID
 				Unsafe:   true,                    // Different Unsafe
 			},
-			expected: true, // Only UID and Text matter
+			expected: true, // Only UID, Text, and PathRoot matter
 		},
 		{
 			name: "empty_vs_space_text",

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -159,10 +159,12 @@ type CmdEnv struct {
 	Database           *database.Database
 	ExprEnv            *zapscript.ArgExprEnv
 	Source             string
-	Cmd                zapscript.Command
-	TotalCommands      int
-	CurrentIndex       int
-	Unsafe             bool
+	// PathRoot is an optional per-token root for resolving relative filesystem paths.
+	PathRoot      string
+	Cmd           zapscript.Command
+	TotalCommands int
+	CurrentIndex  int
+	Unsafe        bool
 }
 
 // ProfileSwitchRequest asks the script runner to change the device's

--- a/pkg/readers/externaldrive/externaldrive.go
+++ b/pkg/readers/externaldrive/externaldrive.go
@@ -494,6 +494,7 @@ func (r *Reader) handleMountEvent(event *MountEvent) {
 		ScanTime: time.Now(),
 		Source:   tokens.SourceReader,
 		ReaderID: r.ReaderID(),
+		PathRoot: filepath.Clean(foundMount),
 	}
 
 	// Before adding token, verify device is still mounted (race condition protection)

--- a/pkg/readers/externaldrive/externaldrive_test.go
+++ b/pkg/readers/externaldrive/externaldrive_test.go
@@ -21,6 +21,7 @@ package externaldrive
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"os"
 	"path/filepath"
@@ -396,7 +397,9 @@ func TestProcessEvents_MountEvent(t *testing.T) {
 	case scan := <-scanChan:
 		assert.NotNil(t, scan.Token, "Should receive token from mount event")
 		assert.Equal(t, TokenType, scan.Token.Type)
-		assert.Contains(t, scan.Token.Text, tokenContents)
+		assert.Equal(t, tokenContents, scan.Token.Text)
+		assert.Equal(t, hex.EncodeToString([]byte(tokenContents)), scan.Token.Data)
+		assert.Equal(t, filepath.Clean(tempDir), scan.Token.PathRoot)
 		assert.NotEmpty(t, scan.Token.ReaderID, "ReaderID must be set on tokens from hardware readers")
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for scan event")
@@ -534,7 +537,9 @@ func TestHandleMountEvent_WithValidToken(t *testing.T) {
 	case scan := <-scanChan:
 		assert.NotNil(t, scan.Token)
 		assert.Equal(t, TokenType, scan.Token.Type)
-		assert.Contains(t, scan.Token.Text, "**launch.system:nes")
+		assert.Equal(t, tokenContents, scan.Token.Text)
+		assert.Equal(t, hex.EncodeToString([]byte(tokenContents)), scan.Token.Data)
+		assert.Equal(t, filepath.Clean(tempDir), scan.Token.PathRoot)
 		assert.NotEmpty(t, scan.Token.ReaderID, "ReaderID must be set on tokens from hardware readers")
 	case <-ctx.Done():
 		t.Fatal("Timeout waiting for scan event")

--- a/pkg/service/tokens/tokens.go
+++ b/pkg/service/tokens/tokens.go
@@ -51,5 +51,8 @@ type Token struct {
 	Data     string
 	Source   string
 	ReaderID string // Deterministic ID of the source reader
+	// PathRoot is an optional filesystem root used to resolve relative paths
+	// originating from source-backed tokens such as external drives.
+	PathRoot string
 	Unsafe   bool
 }

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -305,11 +305,10 @@ func pathLookupRoots(platformRoots []string, pathRoots ...string) []string {
 		if requireAbsolute && !filepath.IsAbs(cleanRoot) {
 			return
 		}
-		normalized := helpers.NormalizePathForComparison(cleanRoot)
-		if _, ok := seen[normalized]; ok {
+		if _, ok := seen[cleanRoot]; ok {
 			return
 		}
-		seen[normalized] = struct{}{}
+		seen[cleanRoot] = struct{}{}
 		roots = append(roots, cleanRoot)
 	}
 

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -293,8 +293,43 @@ func virtualStatPath(lookupPath string, parts []string, end int) string {
 	return filepath.Join(parts[:end]...)
 }
 
+func pathLookupRoots(platformRoots []string, pathRoots ...string) []string {
+	roots := make([]string, 0, len(platformRoots)+len(pathRoots))
+	seen := make(map[string]struct{}, len(platformRoots)+len(pathRoots))
+
+	addRoot := func(root string, requireAbsolute bool) {
+		if root == "" {
+			return
+		}
+		cleanRoot := filepath.Clean(root)
+		if requireAbsolute && !filepath.IsAbs(cleanRoot) {
+			return
+		}
+		normalized := helpers.NormalizePathForComparison(cleanRoot)
+		if _, ok := seen[normalized]; ok {
+			return
+		}
+		seen[normalized] = struct{}{}
+		roots = append(roots, cleanRoot)
+	}
+
+	for _, root := range pathRoots {
+		addRoot(root, true)
+	}
+	for _, root := range platformRoots {
+		addRoot(root, false)
+	}
+	return roots
+}
+
 // Check all games folders for a relative path to a file
-func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path string) (string, error) {
+func findFile(
+	fs afero.Fs,
+	pl platforms.Platform,
+	cfg *config.Instance,
+	path string,
+	pathRoots ...string,
+) (string, error) {
 	lookupPath := normalizeVirtualLookupPath(path)
 	ps := strings.Split(lookupPath, string(filepath.Separator))
 	statPath := lookupPath
@@ -316,7 +351,7 @@ func findFile(fs afero.Fs, pl platforms.Platform, cfg *config.Instance, path str
 
 	candidates := []string{statPath}
 	if !filepath.IsAbs(statPath) {
-		rootDirs := pl.RootDirs(cfg)
+		rootDirs := pathLookupRoots(pl.RootDirs(cfg), pathRoots...)
 		candidates = make([]string, 0, len(rootDirs))
 		for _, gf := range rootDirs {
 			candidates = append(candidates, filepath.Join(gf, statPath))
@@ -481,6 +516,7 @@ func RunCommand(
 		UI:                 opts.UI,
 		Playlist:           plsc,
 		Source:             token.Source,
+		PathRoot:           token.PathRoot,
 		TotalCommands:      totalCmds,
 		CurrentIndex:       currentIndex,
 		Unsafe:             unsafe,

--- a/pkg/zapscript/commands_test.go
+++ b/pkg/zapscript/commands_test.go
@@ -20,6 +20,8 @@
 package zapscript
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -618,6 +620,97 @@ func TestGetExprEnv_NoActiveMedia(t *testing.T) {
 	assert.Empty(t, env.ActiveMedia.Path)
 }
 
+func TestPathLookupRootsPrependsAndDeduplicatesRoot(t *testing.T) {
+	t.Parallel()
+
+	pathRoot := t.TempDir()
+	normalRoot := t.TempDir()
+	platformRoots := []string{normalRoot, filepath.Join(pathRoot, ".")}
+
+	roots := pathLookupRoots(platformRoots, filepath.Join("relative", "root"), pathRoot)
+
+	assert.Equal(t, []string{filepath.Clean(pathRoot), filepath.Clean(normalRoot)}, roots)
+	assert.Equal(t, []string{normalRoot, filepath.Join(pathRoot, ".")}, platformRoots)
+}
+
+func TestRunCommandResolvesPathRootBeforePlatformRoots(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		scriptText      string
+		createDriveFile bool
+		wantDriveFile   bool
+	}{
+		{
+			name:            "plain path prefers external root",
+			scriptText:      "Game.mgl",
+			createDriveFile: true,
+			wantDriveFile:   true,
+		},
+		{
+			name:          "explicit launch falls back to platform root",
+			scriptText:    "**launch:Game.mgl",
+			wantDriveFile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pathRoot := t.TempDir()
+			normalRoot := t.TempDir()
+			drivePath := filepath.Join(pathRoot, "Game.mgl")
+			normalPath := filepath.Join(normalRoot, "Game.mgl")
+			require.NoError(t, os.WriteFile(normalPath, []byte("normal"), 0o600))
+			if tt.createDriveFile {
+				require.NoError(t, os.WriteFile(drivePath, []byte("drive"), 0o600))
+			}
+
+			wantPath := normalPath
+			if tt.wantDriveFile {
+				wantPath = drivePath
+			}
+
+			cfg := &config.Instance{}
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("RootDirs", cfg).Return([]string{normalRoot}).Once()
+			mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{}).Twice()
+			mockPlatform.On(
+				"LaunchMedia",
+				cfg,
+				wantPath,
+				(*platforms.Launcher)(nil),
+				(*database.Database)(nil),
+				(*platforms.LaunchOptions)(nil),
+			).Return(nil).Once()
+
+			script, err := zapscript.NewParser(tt.scriptText).ParseScript()
+			require.NoError(t, err)
+			require.Len(t, script.Cmds, 1)
+
+			result, err := RunCommand(
+				t.Context(),
+				mockPlatform,
+				cfg,
+				playlists.PlaylistController{},
+				tokens.Token{PathRoot: pathRoot},
+				script.Cmds[0],
+				1,
+				0,
+				nil,
+				RunCommandOptions{LauncherManager: state.NewLauncherManager()},
+				&zapscript.ArgExprEnv{},
+			)
+
+			require.NoError(t, err)
+			assert.True(t, result.MediaChanged)
+			mockPlatform.AssertExpectations(t)
+		})
+	}
+}
+
 func TestRunCommandInjectsUIService(t *testing.T) {
 	t.Parallel()
 
@@ -644,6 +737,33 @@ func TestRunCommandInjectsUIService(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Same(t, ui, receivedUI)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestRunCommandInjectsTokenPathRoot(t *testing.T) {
+	t.Parallel()
+
+	pathRoot := t.TempDir()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ForwardCmd", mock.MatchedBy(func(env *platforms.CmdEnv) bool {
+		return env.PathRoot == pathRoot
+	})).Return(platforms.CmdResult{}, nil).Once()
+
+	_, err := RunCommand(
+		t.Context(),
+		mockPlatform,
+		&config.Instance{},
+		playlists.PlaylistController{},
+		tokens.Token{PathRoot: pathRoot},
+		zapscript.Command{Name: zapscript.ZapScriptCmdMisterINI},
+		1,
+		0,
+		nil,
+		RunCommandOptions{},
+		&zapscript.ArgExprEnv{},
+	)
+
+	require.NoError(t, err)
 	mockPlatform.AssertExpectations(t)
 }
 

--- a/pkg/zapscript/commands_test.go
+++ b/pkg/zapscript/commands_test.go
@@ -625,12 +625,20 @@ func TestPathLookupRootsPrependsAndDeduplicatesRoot(t *testing.T) {
 
 	pathRoot := t.TempDir()
 	normalRoot := t.TempDir()
-	platformRoots := []string{normalRoot, filepath.Join(pathRoot, ".")}
+	caseParent := t.TempDir()
+	upperRoot := filepath.Join(caseParent, "USB")
+	lowerRoot := filepath.Join(caseParent, "usb")
+	platformRoots := []string{normalRoot, filepath.Join(pathRoot, "."), upperRoot, lowerRoot}
 
 	roots := pathLookupRoots(platformRoots, filepath.Join("relative", "root"), pathRoot)
 
-	assert.Equal(t, []string{filepath.Clean(pathRoot), filepath.Clean(normalRoot)}, roots)
-	assert.Equal(t, []string{normalRoot, filepath.Join(pathRoot, ".")}, platformRoots)
+	assert.Equal(t, []string{
+		filepath.Clean(pathRoot),
+		filepath.Clean(normalRoot),
+		upperRoot,
+		lowerRoot,
+	}, roots)
+	assert.Equal(t, []string{normalRoot, filepath.Join(pathRoot, "."), upperRoot, lowerRoot}, platformRoots)
 }
 
 func TestRunCommandResolvesPathRootBeforePlatformRoots(t *testing.T) {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -693,6 +693,11 @@ func isValidRemoteFileURL(s string) (func(installer.DownloaderArgs) error, bool)
 
 //nolint:gocritic // single-use parameter in command handler
 func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	return cmdLaunchWithFS(afero.NewOsFs(), pl, env)
+}
+
+//nolint:gocritic // single-use parameter in command handler
+func cmdLaunchWithFS(fs afero.Fs, pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 	if len(env.Cmd.Args) == 0 {
 		return platforms.CmdResult{}, ErrArgCount
 	}
@@ -757,7 +762,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// this always takes precedence over the system/path format (but is not totally cross platform)
 	var findErr error
 	var p string
-	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path, env.PathRoot); findErr == nil {
+	if p, findErr = findFile(fs, pl, env.Cfg, path, env.PathRoot); findErr == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -818,7 +823,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		log.Debug().Msgf("checking system path: %s", systemPath)
 		var systemFindErr error
 		var fp string
-		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath, env.PathRoot); systemFindErr == nil {
+		if fp, systemFindErr = findFile(fs, pl, env.Cfg, systemPath, env.PathRoot); systemFindErr == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -999,6 +1004,11 @@ func getUniqueRecentMedia(
 
 //nolint:gocritic // single-use parameter in command handler
 func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
+	return cmdLaunchLastWithFS(afero.NewOsFs(), pl, env)
+}
+
+//nolint:gocritic // single-use parameter in command handler
+func cmdLaunchLastWithFS(fs afero.Fs, pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 	offset := 1
 	if len(env.Cmd.Args) > 0 && env.Cmd.Args[0] != "" {
 		n, err := strconv.Atoi(env.Cmd.Args[0])
@@ -1021,7 +1031,7 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 		return platforms.CmdResult{}, err
 	}
 
-	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, entry.MediaPath, env.PathRoot)
+	path, err := findFile(fs, pl, env.Cfg, entry.MediaPath, env.PathRoot)
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -757,7 +757,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 	// this always takes precedence over the system/path format (but is not totally cross platform)
 	var findErr error
 	var p string
-	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path); findErr == nil {
+	if p, findErr = findFile(afero.NewOsFs(), pl, env.Cfg, path, env.PathRoot); findErr == nil {
 		log.Debug().Msgf("launching found relative path: %s", p)
 		return platforms.CmdResult{
 			MediaChanged: true,
@@ -818,7 +818,7 @@ func cmdLaunch(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult
 		log.Debug().Msgf("checking system path: %s", systemPath)
 		var systemFindErr error
 		var fp string
-		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath); systemFindErr == nil {
+		if fp, systemFindErr = findFile(afero.NewOsFs(), pl, env.Cfg, systemPath, env.PathRoot); systemFindErr == nil {
 			log.Debug().Msgf("launching found system path: %s", fp)
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -1021,7 +1021,7 @@ func cmdLaunchLast(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdRe
 		return platforms.CmdResult{}, err
 	}
 
-	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, entry.MediaPath)
+	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, entry.MediaPath, env.PathRoot)
 	if err != nil {
 		return platforms.CmdResult{}, err
 	}

--- a/pkg/zapscript/launch_last_test.go
+++ b/pkg/zapscript/launch_last_test.go
@@ -94,6 +94,48 @@ func TestCmdLaunchLast_DefaultOffset(t *testing.T) {
 	mockUserDB.AssertExpectations(t)
 }
 
+func TestCmdLaunchLast_RelativePathUsesPathRoot(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := helpers.NewMockUserDBI()
+	cfg := &config.Instance{}
+	pathRoot := t.TempDir()
+	normalRoot := t.TempDir()
+	relativePath := filepath.Join("SNES", "Mario.sfc")
+	drivePath := createTestFile(t, pathRoot, relativePath)
+	_ = createTestFile(t, normalRoot, relativePath)
+
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 10).
+		Return([]database.MediaHistoryEntry{
+			makeHistoryEntry(relativePath, "Mario", "snes"),
+		}, nil)
+
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+	mockPlatform.On("RootDirs", cfg).Return([]string{normalRoot})
+	mockPlatform.On("LaunchMedia", cfg, drivePath,
+		(*platforms.Launcher)(nil),
+		mock.AnythingOfType("*database.Database"),
+		(*platforms.LaunchOptions)(nil)).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name:    "launch.last",
+			AdvArgs: zapscript.NewAdvArgs(nil),
+		},
+		Cfg:      cfg,
+		Database: &database.Database{UserDB: mockUserDB},
+		PathRoot: pathRoot,
+	}
+
+	result, err := cmdLaunchLast(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+	mockUserDB.AssertExpectations(t)
+}
+
 func TestCmdLaunchLast_Offset3(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_last_test.go
+++ b/pkg/zapscript/launch_last_test.go
@@ -99,12 +99,15 @@ func TestCmdLaunchLast_RelativePathUsesPathRoot(t *testing.T) {
 
 	mockPlatform := mocks.NewMockPlatform()
 	mockUserDB := helpers.NewMockUserDBI()
+	fs := helpers.NewMemoryFS()
 	cfg := &config.Instance{}
-	pathRoot := t.TempDir()
-	normalRoot := t.TempDir()
+	pathRoot := launchTestAbsPath("path-root")
+	normalRoot := launchTestAbsPath("normal-root")
 	relativePath := filepath.Join("SNES", "Mario.sfc")
-	drivePath := createTestFile(t, pathRoot, relativePath)
-	_ = createTestFile(t, normalRoot, relativePath)
+	drivePath := filepath.Join(pathRoot, relativePath)
+	normalPath := filepath.Join(normalRoot, relativePath)
+	require.NoError(t, fs.WriteFile(drivePath, []byte("test"), 0o600))
+	require.NoError(t, fs.WriteFile(normalPath, []byte("test"), 0o600))
 
 	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 10).
 		Return([]database.MediaHistoryEntry{
@@ -128,7 +131,7 @@ func TestCmdLaunchLast_RelativePathUsesPathRoot(t *testing.T) {
 		PathRoot: pathRoot,
 	}
 
-	result, err := cmdLaunchLast(mockPlatform, env)
+	result, err := cmdLaunchLastWithFS(fs.Fs, mockPlatform, env)
 
 	require.NoError(t, err)
 	assert.True(t, result.MediaChanged)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -934,6 +934,77 @@ launcher = "snes-retroarch"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdLaunch_SystemPathUsesPathRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		createDirectPath bool
+	}{
+		{
+			name:             "direct relative path keeps precedence",
+			createDirectPath: true,
+		},
+		{
+			name: "launcher folder resolves from path root",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pathRoot := t.TempDir()
+			directPath := filepath.Join(pathRoot, "snes", "game.sfc")
+			launcherPath := filepath.Join(pathRoot, "Console", "SNES", "game.sfc")
+			require.NoError(t, os.MkdirAll(filepath.Dir(launcherPath), 0o750))
+			require.NoError(t, os.WriteFile(launcherPath, []byte("launcher"), 0o600))
+
+			wantPath := launcherPath
+			if tt.createDirectPath {
+				require.NoError(t, os.MkdirAll(filepath.Dir(directPath), 0o750))
+				require.NoError(t, os.WriteFile(directPath, []byte("direct"), 0o600))
+				wantPath = directPath
+			}
+
+			cfg := &config.Instance{}
+			launcher := platforms.Launcher{
+				ID:         "snes",
+				SystemID:   "SNES",
+				Folders:    []string{filepath.Join("Console", "SNES")},
+				Extensions: []string{".sfc"},
+			}
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{launcher})
+			mockPlatform.On("RootDirs", cfg).Return([]string{})
+			mockPlatform.On("Settings").Return(platforms.Settings{DataDir: t.TempDir()}).Maybe()
+			mockPlatform.On(
+				"LaunchMedia",
+				cfg,
+				wantPath,
+				(*platforms.Launcher)(nil),
+				(*database.Database)(nil),
+				(*platforms.LaunchOptions)(nil),
+			).Return(nil).Once()
+
+			env := platforms.CmdEnv{
+				Cmd: zapscript.Command{
+					Name: "launch",
+					Args: []string{"snes" + "/" + "game.sfc"},
+				},
+				Cfg:      cfg,
+				PathRoot: pathRoot,
+			}
+
+			result, err := cmdLaunch(mockPlatform, env)
+
+			require.NoError(t, err)
+			assert.True(t, result.MediaChanged)
+			mockPlatform.AssertExpectations(t)
+		})
+	}
+}
+
 func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -954,16 +954,15 @@ func TestCmdLaunch_SystemPathUsesPathRoot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			pathRoot := t.TempDir()
+			fs := helpers.NewMemoryFS()
+			pathRoot := launchTestAbsPath("path-root")
 			directPath := filepath.Join(pathRoot, "snes", "game.sfc")
 			launcherPath := filepath.Join(pathRoot, "Console", "SNES", "game.sfc")
-			require.NoError(t, os.MkdirAll(filepath.Dir(launcherPath), 0o750))
-			require.NoError(t, os.WriteFile(launcherPath, []byte("launcher"), 0o600))
+			require.NoError(t, fs.WriteFile(launcherPath, []byte("launcher"), 0o600))
 
 			wantPath := launcherPath
 			if tt.createDirectPath {
-				require.NoError(t, os.MkdirAll(filepath.Dir(directPath), 0o750))
-				require.NoError(t, os.WriteFile(directPath, []byte("direct"), 0o600))
+				require.NoError(t, fs.WriteFile(directPath, []byte("direct"), 0o600))
 				wantPath = directPath
 			}
 
@@ -977,7 +976,7 @@ func TestCmdLaunch_SystemPathUsesPathRoot(t *testing.T) {
 			mockPlatform := mocks.NewMockPlatform()
 			mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{launcher})
 			mockPlatform.On("RootDirs", cfg).Return([]string{})
-			mockPlatform.On("Settings").Return(platforms.Settings{DataDir: t.TempDir()}).Maybe()
+			mockPlatform.On("Settings").Return(platforms.Settings{DataDir: launchTestAbsPath("data")}).Maybe()
 			mockPlatform.On(
 				"LaunchMedia",
 				cfg,
@@ -990,13 +989,13 @@ func TestCmdLaunch_SystemPathUsesPathRoot(t *testing.T) {
 			env := platforms.CmdEnv{
 				Cmd: zapscript.Command{
 					Name: "launch",
-					Args: []string{"snes" + "/" + "game.sfc"},
+					Args: []string{filepath.ToSlash(filepath.Join("snes", "game.sfc"))},
 				},
 				Cfg:      cfg,
 				PathRoot: pathRoot,
 			}
 
-			result, err := cmdLaunch(mockPlatform, env)
+			result, err := cmdLaunchWithFS(fs.Fs, mockPlatform, env)
 
 			require.NoError(t, err)
 			assert.True(t, result.MediaChanged)

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -430,7 +430,7 @@ func loadPlaylist(pl platforms.Platform, env platforms.CmdEnv) (*playlists.Playl
 		return pls, nil
 	}
 
-	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, env.Cmd.Args[0])
+	path, err := findFile(afero.NewOsFs(), pl, env.Cfg, env.Cmd.Args[0], env.PathRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	uievents "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/events"
 	"github.com/jonboulle/clockwork"
@@ -461,6 +462,49 @@ func TestRunPickerResult_DismissExecutesNothing(t *testing.T) {
 		t.Fatal("dismissed picker executed an action")
 	default:
 	}
+}
+
+func TestRunCommandLoadsPlaylistFromPathRoot(t *testing.T) {
+	t.Parallel()
+
+	pathRoot := t.TempDir()
+	normalRoot := t.TempDir()
+	gamePath := filepath.Join(pathRoot, "Game.mgl")
+	playlistPath := filepath.Join(pathRoot, "portable.pls")
+	require.NoError(t, os.WriteFile(gamePath, []byte("game"), 0o600))
+	require.NoError(t, os.WriteFile(playlistPath, []byte(`[playlist]
+File1=Game.mgl
+Title1=Portable Game`), 0o600))
+
+	cfg := &config.Instance{}
+	mockPlatform := newPlaylistTestPlatform()
+	mockPlatform.On("RootDirs", cfg).Return([]string{normalRoot}).Once()
+	queue := make(chan *playlists.Playlist, 1)
+
+	result, err := RunCommand(
+		t.Context(),
+		mockPlatform,
+		cfg,
+		playlists.PlaylistController{Queue: queue},
+		tokens.Token{PathRoot: pathRoot},
+		zapscript.Command{
+			Name: zapscript.ZapScriptCmdPlaylistLoad,
+			Args: []string{"portable.pls"},
+		},
+		1,
+		0,
+		nil,
+		RunCommandOptions{},
+		&zapscript.ArgExprEnv{},
+	)
+
+	require.NoError(t, err)
+	assert.True(t, result.PlaylistChanged)
+	require.NotNil(t, result.Playlist)
+	require.Len(t, result.Playlist.Items, 1)
+	assert.Equal(t, gamePath, result.Playlist.Items[0].ZapScript)
+	assert.Same(t, result.Playlist, <-queue)
+	mockPlatform.AssertExpectations(t)
 }
 
 // TestCmdPlaylistOpen_PreservesPosition tests that position is preserved when reopening active playlist


### PR DESCRIPTION
## Summary

- preserve external-drive mount roots on scanned tokens
- resolve relative launch and playlist paths against inserted drives before configured roots
- retain generic launcher, allowlist, and conservative fallback behavior

Closes #1152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced resolution of scripts, media, launchers, and playlists using a token’s source root, including recent-history paths and system/folder launcher layouts.
  * Added smarter path lookup roots handling with normalization and deduplication to improve file discovery.

* **Bug Fixes**
  * Improved token comparison so matches require identical source-root context, preventing incorrect equivalence.
  * Improved launcher selection for paths outside configured system roots.
  * External-drive mount handling now validates tokens more strictly, using exact field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->