### PR TITLE
feat(readers): add Epilogue Operator bridge support

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,4 +67,4 @@ Device profiles are named buckets of preferences and limits, with no passwords o
 
 ## Reader Auto-Detection
 
-10 reader types: acr122pcsc, externaldrive, file, libnfc, mqtt, opticaldrive, pn532, rs232barcode, simpleserial, tty2oled
+11 reader types: acr122pcsc, externaldrive, file, libnfc, mqtt, operator (MiSTer only), opticaldrive, pn532, rs232barcode, simpleserial, tty2oled

--- a/pkg/helpers/serial.go
+++ b/pkg/helpers/serial.go
@@ -58,6 +58,10 @@ var ignoreDevices = []serialDevice{
 	{Vid: "16d0", Pid: "109b"},
 	{Vid: "16d0", Pid: "109c"},
 	{Vid: "16d0", Pid: "109d"},
+	// Epilogue Operator
+	{Vid: "16d0", Pid: "123d"}, // GB Operator
+	{Vid: "16d0", Pid: "123e"}, // SN Operator
+	{Vid: "16d0", Pid: "134d"}, // 64 Operator
 }
 
 func ignoreSerialDevice(path string) bool {

--- a/pkg/helpers/serial_test.go
+++ b/pkg/helpers/serial_test.go
@@ -173,27 +173,21 @@ func TestSerialDevicePathValidation(t *testing.T) {
 func TestSerialDeviceIgnoreList(t *testing.T) {
 	t.Parallel()
 
-	// Test that the ignore list contains expected Sinden Lightgun entries
-	expectedIgnoreCount := 18 // Count from the actual ignoreDevices slice
-	assert.Len(t, ignoreDevices, expectedIgnoreCount, "Ignore list should contain expected number of devices")
+	assert.Len(t, ignoreDevices, 21, "ignore list should contain expected number of devices")
 
-	// Test specific known ignore entries
-	foundSinden16c0 := false
-	foundSinden16d0 := false
+	expectedDevices := []serialDevice{
+		{Vid: "16c0", Pid: "0f38"}, // Sinden Lightgun
+		{Vid: "16d0", Pid: "1094"}, // Sinden Lightgun
+		{Vid: "16d0", Pid: "123d"}, // GB Operator
+		{Vid: "16d0", Pid: "123e"}, // SN Operator
+		{Vid: "16d0", Pid: "134d"}, // 64 Operator
+	}
+	for _, device := range expectedDevices {
+		assert.Contains(t, ignoreDevices, device)
+	}
 
 	for _, device := range ignoreDevices {
-		if device.Vid == "16c0" && device.Pid == "0f38" {
-			foundSinden16c0 = true
-		}
-		if device.Vid == "16d0" && device.Pid == "1094" {
-			foundSinden16d0 = true
-		}
-
-		// All VID/PID pairs should be non-empty
 		assert.NotEmpty(t, device.Vid, "VID should not be empty")
 		assert.NotEmpty(t, device.Pid, "PID should not be empty")
 	}
-
-	assert.True(t, foundSinden16c0, "Should contain Sinden Lightgun 16c0:0f38 entry")
-	assert.True(t, foundSinden16d0, "Should contain Sinden Lightgun 16d0:1094 entry")
 }

--- a/pkg/platforms/mister/operator_reader.go
+++ b/pkg/platforms/mister/operator_reader.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/file"
+	"github.com/spf13/afero"
+)
+
+const operatorReaderID = "operator"
+
+var (
+	operatorEntryPath = filepath.Join(misterconfig.ScriptsDir, "Operator.sh")
+	operatorTokenPath = filepath.Join(string(filepath.Separator), "tmp", "zaparoo-operator.token")
+)
+
+func newOperatorReader(cfg *config.Instance, fs afero.Fs) *file.Reader {
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
+
+	return file.NewReaderWithOptions(cfg, &file.ReaderOptions{
+		Metadata: readers.DriverMetadata{
+			ID:                operatorReaderID,
+			DefaultEnabled:    true,
+			DefaultAutoDetect: true,
+			Description:       "Epilogue Operator cartridge bridge",
+		},
+		IDs:            []string{operatorReaderID},
+		AutoDetectPath: operatorTokenPath,
+		IsAvailable: func() bool {
+			info, err := fs.Stat(operatorEntryPath)
+			return err == nil && info.Mode().IsRegular()
+		},
+	})
+}

--- a/pkg/platforms/mister/operator_reader_test.go
+++ b/pkg/platforms/mister/operator_reader_test.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperatorReaderDetection(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	reader := newOperatorReader(&config.Instance{}, fs)
+
+	metadata := reader.Metadata()
+	assert.Equal(t, operatorReaderID, metadata.ID)
+	assert.Equal(t, "Epilogue Operator cartridge bridge", metadata.Description)
+	assert.True(t, metadata.DefaultEnabled)
+	assert.True(t, metadata.DefaultAutoDetect)
+	assert.Equal(t, []string{operatorReaderID}, reader.IDs())
+	assert.Empty(t, reader.Detect(nil), "missing Operator entry point must not activate reader")
+
+	require.NoError(t, fs.MkdirAll(filepath.Dir(operatorEntryPath), 0o755))
+	require.NoError(t, afero.WriteFile(fs, operatorEntryPath, nil, 0o644))
+	expectedConnection := operatorReaderID + ":" + operatorTokenPath
+	assert.Equal(t, expectedConnection, reader.Detect(nil))
+	assert.Empty(t, reader.Detect([]string{"file:" + operatorTokenPath}),
+		"connected token path must not be detected twice")
+
+	require.NoError(t, fs.Remove(operatorEntryPath))
+	require.NoError(t, fs.Mkdir(operatorEntryPath, 0o755))
+	assert.Empty(t, reader.Detect(nil), "directory at entry point path must not activate reader")
+}
+
+func TestSupportedReadersIncludesOperator(t *testing.T) {
+	t.Parallel()
+
+	platform := NewPlatform()
+	supportedReaders := platform.SupportedReaders(&config.Instance{})
+
+	var found bool
+	for _, reader := range supportedReaders {
+		if reader.Metadata().ID == operatorReaderID {
+			found = true
+		}
+		require.NoError(t, reader.Close())
+	}
+	assert.True(t, found)
+}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -185,6 +185,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		libnfc.NewLegacyUARTReader(cfg),
 		libnfc.NewLegacyI2CReader(cfg),
 		file.NewReader(cfg),
+		newOperatorReader(cfg, p.fs),
 		simpleserial.NewReader(cfg),
 		rs232barcode.NewReader(cfg),
 		opticaldrive.NewReader(cfg),

--- a/pkg/readers/file/file.go
+++ b/pkg/readers/file/file.go
@@ -40,22 +40,28 @@ import (
 
 const TokenType = "file"
 
+// ReaderOptions customizes a file-backed reader for a specific bridge.
+type ReaderOptions struct {
+	IsAvailable    func() bool
+	AutoDetectPath string
+	Metadata       readers.DriverMetadata
+	IDs            []string
+}
+
 type Reader struct {
-	cfg     *config.Instance
-	device  config.ReadersConnect
-	path    string
-	polling bool
-	mu      syncutil.RWMutex // protects polling
-	wg      sync.WaitGroup
+	cfg            *config.Instance
+	isAvailable    func() bool
+	device         config.ReadersConnect
+	path           string
+	autoDetectPath string
+	metadata       readers.DriverMetadata
+	ids            []string
+	wg             sync.WaitGroup
+	mu             syncutil.RWMutex
+	polling        bool
 }
 
-func NewReader(cfg *config.Instance) *Reader {
-	return &Reader{
-		cfg: cfg,
-	}
-}
-
-func (*Reader) Metadata() readers.DriverMetadata {
+func defaultMetadata() readers.DriverMetadata {
 	return readers.DriverMetadata{
 		ID:                "file",
 		DefaultEnabled:    true,
@@ -64,8 +70,36 @@ func (*Reader) Metadata() readers.DriverMetadata {
 	}
 }
 
-func (*Reader) IDs() []string {
-	return []string{"file"}
+func NewReader(cfg *config.Instance) *Reader {
+	return NewReaderWithOptions(cfg, &ReaderOptions{
+		Metadata: defaultMetadata(),
+		IDs:      []string{"file"},
+	})
+}
+
+// NewReaderWithOptions creates a file-backed reader with custom driver metadata and detection.
+func NewReaderWithOptions(cfg *config.Instance, options *ReaderOptions) *Reader {
+	return &Reader{
+		cfg:            cfg,
+		metadata:       options.Metadata,
+		ids:            append([]string(nil), options.IDs...),
+		autoDetectPath: options.AutoDetectPath,
+		isAvailable:    options.IsAvailable,
+	}
+}
+
+func (r *Reader) Metadata() readers.DriverMetadata {
+	if r.metadata.ID == "" {
+		return defaultMetadata()
+	}
+	return r.metadata
+}
+
+func (r *Reader) IDs() []string {
+	if len(r.ids) == 0 {
+		return []string{r.Metadata().ID}
+	}
+	return append([]string(nil), r.ids...)
 }
 
 func (r *Reader) Open(device config.ReadersConnect, iq chan<- readers.Scan, _ readers.OpenOpts) error {
@@ -198,8 +232,28 @@ func (r *Reader) Close() error {
 	return nil
 }
 
-func (*Reader) Detect(_ []string) string {
-	return ""
+func (r *Reader) Detect(excluded []string) string {
+	if r.autoDetectPath == "" || !r.available() || isPathExcluded(r.autoDetectPath, excluded) {
+		return ""
+	}
+	return r.Metadata().ID + ":" + r.autoDetectPath
+}
+
+func (r *Reader) available() bool {
+	return r.isAvailable == nil || r.isAvailable()
+}
+
+func isPathExcluded(path string, excluded []string) bool {
+	for _, connection := range excluded {
+		if connection == path {
+			return true
+		}
+		_, connectedPath, found := strings.Cut(connection, ":")
+		if found && connectedPath == path {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Reader) Path() string {
@@ -212,8 +266,9 @@ func (r *Reader) ReaderID() string {
 
 func (r *Reader) Connected() bool {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.polling
+	polling := r.polling
+	r.mu.RUnlock()
+	return polling && r.available()
 }
 
 func (r *Reader) Info() string {

--- a/pkg/readers/file/file_test.go
+++ b/pkg/readers/file/file_test.go
@@ -67,6 +67,7 @@ func TestNewReaderWithOptions(t *testing.T) {
 	assert.Equal(t, "operator", reader.Metadata().ID)
 	assert.Equal(t, []string{"operator"}, reader.IDs())
 	assert.Equal(t, "operator:"+tokenPath, reader.Detect(nil))
+	assert.Empty(t, reader.Detect([]string{tokenPath}))
 	assert.Empty(t, reader.Detect([]string{"file:" + tokenPath}))
 
 	reader.polling = true

--- a/pkg/readers/file/file_test.go
+++ b/pkg/readers/file/file_test.go
@@ -43,6 +43,39 @@ func TestNewReader(t *testing.T) {
 	assert.Equal(t, cfg, reader.cfg)
 }
 
+func TestNewReaderWithOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	tokenPath := filepath.Join(string(filepath.Separator), "tmp", "operator.token")
+	available := true
+	reader := NewReaderWithOptions(cfg, &ReaderOptions{
+		Metadata: readers.DriverMetadata{
+			ID:                "operator",
+			DefaultEnabled:    true,
+			DefaultAutoDetect: true,
+			Description:       "Operator bridge",
+		},
+		IDs:            []string{"operator"},
+		AutoDetectPath: tokenPath,
+		IsAvailable: func() bool {
+			return available
+		},
+	})
+
+	assert.Equal(t, cfg, reader.cfg)
+	assert.Equal(t, "operator", reader.Metadata().ID)
+	assert.Equal(t, []string{"operator"}, reader.IDs())
+	assert.Equal(t, "operator:"+tokenPath, reader.Detect(nil))
+	assert.Empty(t, reader.Detect([]string{"file:" + tokenPath}))
+
+	reader.polling = true
+	assert.True(t, reader.Connected())
+	available = false
+	assert.Empty(t, reader.Detect(nil))
+	assert.False(t, reader.Connected())
+}
+
 func TestMetadata(t *testing.T) {
 	t.Parallel()
 
@@ -262,6 +295,32 @@ func TestOpen_InitialFileContent_TokenDetected(t *testing.T) {
 	assert.Equal(t, TokenType, scan.Token.Type)
 	assert.NotEmpty(t, scan.Token.ReaderID, "ReaderID must be set on tokens from hardware readers")
 	assert.False(t, scan.ReaderError)
+}
+
+func TestOpen_CustomDriverUsesCustomReaderID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	reader := NewReaderWithOptions(cfg, &ReaderOptions{
+		Metadata: readers.DriverMetadata{ID: "operator"},
+		IDs:      []string{"operator"},
+	})
+	scanQueue := testutils.CreateTestScanChannel(t)
+	tokenFile := filepath.Join(t.TempDir(), "operator.token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("test-token"), 0o600))
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "operator",
+		Path:   tokenFile,
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, reader.Close())
+	}()
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 1*time.Second)
+	require.NotNil(t, scan.Token)
+	assert.Equal(t, readers.GenerateReaderID("operator", tokenFile), scan.Token.ReaderID)
 }
 
 func TestOpen_FileContentChange_NewToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- add MiSTer-only Operator reader that detects `/media/fat/Scripts/Operator.sh` and consumes `/tmp/zaparoo-operator.token` without rewriting config
- generalize file reader for bridge-specific metadata, auto-detection, and availability checks
- exclude GB, SN, and 64 Operator USB interfaces from generic serial auto-detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Epilogue Operator cartridge bridge reader for MiSTer, including autodetection support.
  * Introduced configurable options for file-based readers, including custom detection paths and reader IDs.
  * Updated documentation to reflect 11 supported reader types (including Operator for MiSTer).

* **Bug Fixes**
  * Extended the serial-device ignore list with additional Epilogue Operator VID/PID entries.
  * Improved file reader availability/connection detection and exclusion-based autodetection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->