### PR TITLE
feat(zapscript): guide path launches with system argument

### DIFF
--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -297,6 +297,43 @@ func launcherInferenceScore(l *platforms.Launcher) int {
 	return score
 }
 
+func inferLauncherForSystemPath(
+	pl platforms.Platform,
+	env *platforms.CmdEnv,
+	path string,
+	systemID string,
+) (platforms.Launcher, bool) {
+	ext := filepath.Ext(path)
+	if ext == "" {
+		return platforms.Launcher{}, false
+	}
+
+	launchers := pl.Launchers(env.Cfg)
+	match := -1
+	for i := range launchers {
+		if !strings.EqualFold(launchers[i].SystemID, systemID) {
+			continue
+		}
+		if launchers[i].Availability != nil && launchers[i].Availability(env.Cfg) != nil {
+			continue
+		}
+		for _, supported := range launchers[i].Extensions {
+			if !strings.EqualFold(ext, supported) {
+				continue
+			}
+			if match != -1 {
+				return platforms.Launcher{}, false
+			}
+			match = i
+			break
+		}
+	}
+	if match == -1 {
+		return platforms.Launcher{}, false
+	}
+	return launchers[match], true
+}
+
 //nolint:gocritic // single-use parameter in command handler
 func cmdSystem(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 	if len(env.Cmd.Args) != 1 {
@@ -607,10 +644,11 @@ func findLauncher(pl platforms.Platform, cfg *platforms.CmdEnv, launcherID strin
 }
 
 type launchTarget struct {
-	path               string
-	systemID           string
-	mediaID            int64
-	resolveMediaByPath bool
+	path                  string
+	systemID              string
+	mediaID               int64
+	resolveMediaByPath    bool
+	guideLauncherBySystem bool
 }
 
 func getLaunchClosure(
@@ -658,6 +696,18 @@ func getLaunchClosure(
 				return fmt.Errorf("launcher not found: %s", launcherID)
 			}
 			log.Info().Msgf("launching with launcher: %s", launcherID)
+		} else if target.guideLauncherBySystem {
+			inferred, found := inferLauncherForSystemPath(pl, env, target.path, target.systemID)
+			if found {
+				if inferred.AllowListOnly && !env.Cfg.IsLauncherFileAllowed(target.path) {
+					return errors.New("file not allowed: " + target.path)
+				}
+				launcher = &inferred
+				log.Info().
+					Str("system", target.systemID).
+					Str("launcher", inferred.ID).
+					Msg("selected launcher from system argument")
+			}
 		}
 
 		releaseLaunch := func() {}
@@ -741,13 +791,21 @@ func cmdLaunchWithFS(fs afero.Fs, pl platforms.Platform, env platforms.CmdEnv) (
 	}
 
 	launch := getLaunchClosure(pl, &env, explicitLauncher)
+	requestedPathTarget := func(resolvedPath string) launchTarget {
+		return launchTarget{
+			path:                  resolvedPath,
+			systemID:              requestedSystemID,
+			resolveMediaByPath:    true,
+			guideLauncherBySystem: requestedSystemID != "",
+		}
+	}
 
 	// if it's an absolute path, just try launch it
 	if filepath.IsAbs(path) {
 		log.Debug().Msgf("launching absolute path: %s", path)
 		return platforms.CmdResult{
 			MediaChanged: true,
-		}, launch(launchTarget{path: path, systemID: requestedSystemID, resolveMediaByPath: true})
+		}, launch(requestedPathTarget(path))
 	}
 
 	// match for uri style launch syntax
@@ -755,7 +813,7 @@ func cmdLaunchWithFS(fs afero.Fs, pl platforms.Platform, env platforms.CmdEnv) (
 		log.Debug().Msgf("launching uri: %s", path)
 		return platforms.CmdResult{
 			MediaChanged: true,
-		}, launch(launchTarget{path: path, systemID: requestedSystemID, resolveMediaByPath: true})
+		}, launch(requestedPathTarget(path))
 	}
 
 	// for relative paths, perform a basic check if the file exists in a games folder
@@ -766,7 +824,7 @@ func cmdLaunchWithFS(fs afero.Fs, pl platforms.Platform, env platforms.CmdEnv) (
 		log.Debug().Msgf("launching found relative path: %s", p)
 		return platforms.CmdResult{
 			MediaChanged: true,
-		}, launch(launchTarget{path: p, systemID: requestedSystemID, resolveMediaByPath: true})
+		}, launch(requestedPathTarget(p))
 	}
 	log.Debug().Err(findErr).Msgf("error finding file: %s", path)
 

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -699,15 +699,15 @@ func getLaunchClosure(
 		} else if target.guideLauncherBySystem {
 			inferred, found := inferLauncherForSystemPath(pl, env, target.path, target.systemID)
 			if found {
-				if inferred.AllowListOnly && !env.Cfg.IsLauncherFileAllowed(target.path) {
-					return errors.New("file not allowed: " + target.path)
-				}
 				launcher = &inferred
 				log.Info().
 					Str("system", target.systemID).
 					Str("launcher", inferred.ID).
 					Msg("selected launcher from system argument")
 			}
+		}
+		if launcher != nil && launcher.AllowListOnly && !env.Cfg.IsLauncherFileAllowed(target.path) {
+			return errors.New("file not allowed: " + target.path)
 		}
 
 		releaseLaunch := func() {}

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1078,6 +1078,50 @@ func TestInferLauncherForSystemPath_RejectsSameSystemAmbiguity(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdLaunch_SystemDefaultDoesNotBypassLauncherAllowlist(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[systems.default]]
+system = "genesis"
+launcher = "genesis-restricted"
+`))
+	path := launchTestAbsPath("external-drive", "SomeGame.bin")
+	launcher := platforms.Launcher{
+		ID:            "genesis-restricted",
+		SystemID:      systemdefs.SystemGenesis,
+		Extensions:    []string{".bin"},
+		AllowListOnly: true,
+	}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{launcher})
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: zapscript.ZapScriptCmdLaunch,
+			Args: []string{path},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				"system": systemdefs.SystemGenesis,
+			}),
+		},
+		Cfg: cfg,
+	}
+	_, err := cmdLaunch(mockPlatform, env)
+
+	require.ErrorContains(t, err, "file not allowed")
+	mockPlatform.AssertNotCalled(
+		t,
+		"LaunchMedia",
+		cfg,
+		path,
+		mock.Anything,
+		(*database.Database)(nil),
+		(*platforms.LaunchOptions)(nil),
+	)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdLaunch_SystemArgDoesNotBypassLauncherAllowlist(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1004,6 +1004,110 @@ func TestCmdLaunch_SystemPathUsesPathRoot(t *testing.T) {
 	}
 }
 
+func TestCmdLaunch_SystemArgGuidesExternalRelativePath(t *testing.T) {
+	t.Parallel()
+
+	fs := helpers.NewMemoryFS()
+	pathRoot := launchTestAbsPath("external-drive")
+	resolvedPath := filepath.Join(pathRoot, "SomeGame.bin")
+	require.NoError(t, fs.WriteFile(resolvedPath, []byte("game"), 0o600))
+
+	cfg := &config.Instance{}
+	genesisLauncher := platforms.Launcher{
+		ID:         systemdefs.SystemGenesis,
+		SystemID:   systemdefs.SystemGenesis,
+		Folders:    []string{"Genesis"},
+		Extensions: []string{".bin"},
+	}
+	psxLauncher := platforms.Launcher{
+		ID:         systemdefs.SystemPSX,
+		SystemID:   systemdefs.SystemPSX,
+		Folders:    []string{"PSX"},
+		Extensions: []string{".bin"},
+	}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{genesisLauncher, psxLauncher})
+	mockPlatform.On("RootDirs", cfg).Return([]string{})
+	mockPlatform.On(
+		"LaunchMedia",
+		cfg,
+		resolvedPath,
+		mock.MatchedBy(func(launcher *platforms.Launcher) bool {
+			return launcher != nil && launcher.ID == systemdefs.SystemGenesis
+		}),
+		(*database.Database)(nil),
+		(*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	reader := zapscript.NewParser("SomeGame.bin?system=Genesis")
+	script, err := reader.ParseScript()
+	require.NoError(t, err)
+	require.Len(t, script.Cmds, 1)
+
+	env := platforms.CmdEnv{
+		Cmd:      script.Cmds[0],
+		Cfg:      cfg,
+		PathRoot: pathRoot,
+	}
+	result, err := cmdLaunchWithFS(fs.Fs, mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestInferLauncherForSystemPath_RejectsSameSystemAmbiguity(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{
+		{ID: "GenesisOne", SystemID: systemdefs.SystemGenesis, Extensions: []string{".bin"}},
+		{ID: "GenesisTwo", SystemID: systemdefs.SystemGenesis, Extensions: []string{".bin"}},
+	})
+
+	launcher, found := inferLauncherForSystemPath(
+		mockPlatform,
+		&platforms.CmdEnv{Cfg: cfg},
+		filepath.Join("games", "SomeGame.bin"),
+		systemdefs.SystemGenesis,
+	)
+
+	assert.False(t, found)
+	assert.Empty(t, launcher.ID)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdLaunch_SystemArgDoesNotBypassLauncherAllowlist(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	path := launchTestAbsPath("external-drive", "SomeGame.bin")
+	launcher := platforms.Launcher{
+		ID:            systemdefs.SystemGenesis,
+		SystemID:      systemdefs.SystemGenesis,
+		Extensions:    []string{".bin"},
+		AllowListOnly: true,
+	}
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{launcher})
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: zapscript.ZapScriptCmdLaunch,
+			Args: []string{path},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				"system": systemdefs.SystemGenesis,
+			}),
+		},
+		Cfg: cfg,
+	}
+	_, err := cmdLaunch(mockPlatform, env)
+
+	require.ErrorContains(t, err, "file not allowed")
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestFindFile_ResolvesCaseInsensitiveVirtualZipPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- use the `system` advanced argument to disambiguate resolved path launchers by system and extension
- preserve conservative same-system ambiguity handling and launcher allowlist enforcement
- cover external-drive relative paths, ambiguity, and allowlist behavior with regression tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When launching an external path with a specified system, the app now automatically selects the matching system launcher (when unambiguous).
* **Bug Fixes**
  * Prevented automatic launcher selection when multiple launchers match the same system/extension.
  * Ensured launcher allowlist restrictions are still enforced even when a system is specified or defaults are used.
* **Tests**
  * Added coverage for system-guided path resolution, ambiguity behavior, and allowlist enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->