### PR TITLE
feat(playtime): sync active sessions online

### DIFF
--- a/pkg/service/backup/remote_playsync_test.go
+++ b/pkg/service/backup/remote_playsync_test.go
@@ -147,6 +147,36 @@ func TestSyncPlayHistory_BulkImport(t *testing.T) {
 		"disambiguating tags travel with the session")
 }
 
+func TestSyncPlayHistory_UploadsActiveSession(t *testing.T) {
+	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
+	env := newBackupTestEnv(t, "mister")
+	env.Manager.cfg.SetPlaytimeSync(true)
+	updatedAt := time.Now().UTC().Truncate(time.Second)
+
+	server, batches := playSyncTestServer(t, nil)
+	configurePlaytimeTestAuth(t, env.Manager, server.URL)
+
+	active := playSyncTestEntry(
+		1, "11111111-1111-4111-8111-111111111111", "Now Playing", updatedAt,
+	)
+	active.EndTime = nil
+	active.PlayTime = 0
+	env.UserDB.On("ResetMediaHistorySyncAfter", (*time.Time)(nil)).Return(nil).Once()
+	env.UserDB.On("GetMediaHistorySyncBatch", time.Time{}, int64(0), playSyncBatchSize).
+		Return([]database.MediaHistoryEntry{active}, nil).Once()
+	env.UserDB.On("MarkMediaHistorySynced", []database.MediaHistorySyncRef{
+		{DBID: active.DBID, UpdatedAt: active.UpdatedAt},
+	}, testifymock.AnythingOfType("time.Time")).Return(nil).Once()
+
+	info, err := env.Manager.SyncPlayHistory(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, info.Uploaded)
+	require.Len(t, *batches, 1)
+	require.Len(t, (*batches)[0], 1)
+	assert.Nil(t, (*batches)[0][0].EndedAt)
+	assert.Zero(t, (*batches)[0][0].PlayTimeSecs)
+}
+
 func TestSyncPlayHistory_ResumesFromServerWatermark(t *testing.T) {
 	// No t.Parallel(): configurePlaytimeTestAuth mutates the global auth config.
 	env := newBackupTestEnv(t, "mister")

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -216,9 +216,10 @@ func remoteBackupSchedulerLoop(
 	}
 
 	// Play-history sync reuses the heartbeat pacing state: interval on
-	// success, exponential backoff on failure. A completed session requests
-	// an immediate pass through this same serialized path. Requests coalesce,
-	// remain pending across failures, and never bypass retry backoff.
+	// success, exponential backoff on failure. Session starts, active-session
+	// heartbeats, and completed sessions request immediate passes through this
+	// same serialized path. Requests coalesce, remain pending across failures,
+	// and never bypass retry backoff.
 	playSyncState := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
 	playSyncPending := false
 	tryPlaySync := func() {
@@ -270,8 +271,8 @@ func remoteBackupSchedulerLoop(
 }
 
 // playSyncDue reports whether a play-history sync pass should run now.
-// A completed session bypasses the normal success interval, but never the
-// failure backoff.
+// A session lifecycle or active-heartbeat request bypasses the normal success
+// interval, but never the failure backoff.
 func playSyncDue(s *remoteHeartbeatState, now time.Time, pending bool) bool {
 	if !pending && !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < playSyncInterval {
 		return false

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -36,12 +36,18 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const (
+	mediaHistoryUpdateInterval = 15 * time.Second
+	activePlaySyncInterval     = 5 * time.Minute
+)
+
 // mediaHistoryTracker encapsulates the state and logic for tracking media history.
 // It coordinates between the notification listener and the periodic PlayTime updater.
 type mediaHistoryTracker struct {
 	clock                     clockwork.Clock
 	currentMediaStartTime     time.Time
 	currentMediaStartTimeMono time.Time
+	lastPlaySyncRequestAt     time.Time
 	st                        *state.State
 	db                        *database.Database
 	requestPlaySync           func()
@@ -85,6 +91,7 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					t.currentHistoryDBID = 0
 					t.currentMediaStartTime = time.Time{}
 					t.currentMediaStartTimeMono = time.Time{}
+					t.lastPlaySyncRequestAt = time.Time{}
 				}
 				t.mu.Unlock()
 			}
@@ -147,6 +154,7 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 					t.currentMediaStartTimeMono = nowMono
 					t.mu.Unlock()
 					log.Debug().Int64("dbid", dbid).Msg("created media history entry")
+					t.requestActivePlaySyncIfDue(dbid, now, true)
 
 					// MediaDB lookup may block behind indexing. Capture lookup keys now,
 					// then enrich the durable history row off the notification path.
@@ -194,6 +202,7 @@ func (t *mediaHistoryTracker) listen(notificationChan <-chan models.Notification
 						t.currentHistoryDBID = 0
 						t.currentMediaStartTime = time.Time{}
 						t.currentMediaStartTimeMono = time.Time{}
+						t.lastPlaySyncRequestAt = time.Time{}
 					}
 					if t.closingHistoryDBID == dbid {
 						t.closingHistoryDBID = 0
@@ -228,9 +237,34 @@ func (t *mediaHistoryTracker) snapshotMediaHistoryIdentity(dbid int64, systemID,
 	}
 }
 
+// requestActivePlaySyncIfDue requests an immediate now-playing upload at
+// session start, then no more than once per activePlaySyncInterval. The DBID
+// check prevents a late updater tick from requesting a session already closing.
+func (t *mediaHistoryTracker) requestActivePlaySyncIfDue(dbid int64, now time.Time, force bool) {
+	if t.requestPlaySync == nil {
+		return
+	}
+
+	t.mu.Lock()
+	if t.currentHistoryDBID != dbid || t.closingHistoryDBID == dbid {
+		t.mu.Unlock()
+		return
+	}
+	elapsed := now.Sub(t.lastPlaySyncRequestAt)
+	if !force && !t.lastPlaySyncRequestAt.IsZero() && elapsed >= 0 && elapsed < activePlaySyncInterval {
+		t.mu.Unlock()
+		return
+	}
+	t.lastPlaySyncRequestAt = now
+	requestPlaySync := t.requestPlaySync
+	t.mu.Unlock()
+
+	requestPlaySync()
+}
+
 // updatePlayTime periodically updates the current entry, limiting crash-loss to 15 seconds.
 func (t *mediaHistoryTracker) updatePlayTime(ctx context.Context) {
-	ticker := t.clock.NewTicker(15 * time.Second)
+	ticker := t.clock.NewTicker(mediaHistoryUpdateInterval)
 	defer ticker.Stop()
 
 	for {
@@ -264,6 +298,7 @@ func (t *mediaHistoryTracker) updatePlayTime(ctx context.Context) {
 					log.Warn().Err(updateErr).Msg("failed to update media history play time")
 				} else {
 					log.Debug().Int64("dbid", dbid).Int("playTime", playTime).Msg("updated media history play time")
+					t.requestActivePlaySyncIfDue(dbid, t.clock.Now(), false)
 				}
 			}
 		case <-ctx.Done():

--- a/pkg/service/media_history_tracker.go
+++ b/pkg/service/media_history_tracker.go
@@ -250,8 +250,8 @@ func (t *mediaHistoryTracker) requestActivePlaySyncIfDue(dbid int64, now time.Ti
 		t.mu.Unlock()
 		return
 	}
-	elapsed := now.Sub(t.lastPlaySyncRequestAt)
-	if !force && !t.lastPlaySyncRequestAt.IsZero() && elapsed >= 0 && elapsed < activePlaySyncInterval {
+	if !force && !t.lastPlaySyncRequestAt.IsZero() &&
+		now.Before(t.lastPlaySyncRequestAt.Add(activePlaySyncInterval)) {
 		t.mu.Unlock()
 		return
 	}

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -98,6 +98,37 @@ func TestMediaHistoryTracker_Listen_Started(t *testing.T) {
 	assert.Equal(t, startTime, tracker.currentMediaStartTime)
 }
 
+func TestMediaHistoryTracker_Listen_StartedRequestsImmediatePlaySync(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := &testhelpers.MockUserDBI{}
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	fakeClock := clockwork.NewFakeClock()
+	syncRequests := 0
+	tracker := &mediaHistoryTracker{
+		st:              st,
+		db:              &database.Database{UserDB: mockUserDB},
+		clock:           fakeClock,
+		requestPlaySync: func() { syncRequests++ },
+	}
+	activeMedia := &models.ActiveMedia{
+		Started: fakeClock.Now(), SystemID: "nes", SystemName: "Nintendo Entertainment System",
+		Path: filepath.Join("games", "mario.nes"), Name: "Super Mario Bros.", LauncherID: "retroarch",
+	}
+	st.SetActiveMedia(activeMedia)
+	mockUserDB.On("AddMediaHistory", mock.Anything).Return(int64(42), nil).Once()
+
+	notifChan := make(chan models.Notification, 1)
+	notifChan <- models.Notification{Method: models.NotificationStarted}
+	close(notifChan)
+	tracker.listen(notifChan)
+
+	mockUserDB.AssertExpectations(t)
+	assert.Equal(t, 1, syncRequests)
+	assert.Equal(t, fakeClock.Now(), tracker.lastPlaySyncRequestAt)
+}
+
 func TestMediaHistoryTracker_Listen_StartedResolvesIdentityAsynchronously(t *testing.T) {
 	t.Parallel()
 
@@ -509,6 +540,70 @@ func TestMediaHistoryTracker_UpdatePlayTime(t *testing.T) {
 	mockUserDB.AssertExpectations(t)
 }
 
+func TestMediaHistoryTracker_UpdatePlayTimeRequestsActiveSyncEveryFiveMinutes(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := &testhelpers.MockUserDBI{}
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	fakeClock := clockwork.NewFakeClock()
+	startTime := fakeClock.Now()
+	syncRequested := make(chan struct{}, 1)
+	tracker := &mediaHistoryTracker{
+		st:                    st,
+		db:                    &database.Database{UserDB: mockUserDB},
+		clock:                 fakeClock,
+		requestPlaySync:       func() { syncRequested <- struct{}{} },
+		currentHistoryDBID:    42,
+		currentMediaStartTime: startTime,
+		lastPlaySyncRequestAt: startTime,
+	}
+	mockUserDB.On("UpdateMediaHistoryTime", int64(42), 300).Return(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		tracker.updatePlayTime(ctx)
+		close(done)
+	}()
+
+	require.NoError(t, fakeClock.BlockUntilContext(ctx, 1))
+	fakeClock.Advance(activePlaySyncInterval)
+	select {
+	case <-syncRequested:
+	case <-time.After(time.Second):
+		t.Fatal("active play sync was not requested after five minutes")
+	}
+	cancel()
+	<-done
+
+	mockUserDB.AssertExpectations(t)
+	assert.Equal(t, fakeClock.Now(), tracker.lastPlaySyncRequestAt)
+}
+
+func TestMediaHistoryTracker_RequestActivePlaySyncHonorsIntervalAndDBID(t *testing.T) {
+	t.Parallel()
+
+	startTime := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	syncRequests := 0
+	tracker := &mediaHistoryTracker{
+		requestPlaySync:       func() { syncRequests++ },
+		currentHistoryDBID:    42,
+		lastPlaySyncRequestAt: startTime,
+	}
+
+	tracker.requestActivePlaySyncIfDue(42, startTime.Add(activePlaySyncInterval-time.Second), false)
+	assert.Zero(t, syncRequests)
+
+	nextSync := startTime.Add(activePlaySyncInterval)
+	tracker.requestActivePlaySyncIfDue(42, nextSync, false)
+	assert.Equal(t, 1, syncRequests)
+	assert.Equal(t, nextSync, tracker.lastPlaySyncRequestAt)
+
+	tracker.requestActivePlaySyncIfDue(7, nextSync.Add(activePlaySyncInterval), true)
+	assert.Equal(t, 1, syncRequests, "a stale DBID must not request sync")
+}
+
 func TestMediaHistoryTracker_UpdatePlayTime_NoActiveMedia(t *testing.T) {
 	t.Parallel()
 
@@ -786,5 +881,5 @@ func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
 
 	mockUserDB.AssertExpectations(t)
 	assert.Equal(t, newDBID, tracker.currentHistoryDBID, "new DBID should be set after orphan close")
-	assert.Equal(t, 1, syncRequests)
+	assert.Equal(t, 2, syncRequests, "orphan close and new now-playing session both request sync")
 }

--- a/pkg/service/media_history_tracker_test.go
+++ b/pkg/service/media_history_tracker_test.go
@@ -309,6 +309,7 @@ func TestMediaHistoryTracker_Listen_Stopped(t *testing.T) {
 		requestPlaySync:       func() { syncRequests++ },
 		currentHistoryDBID:    42,
 		currentMediaStartTime: startTime,
+		lastPlaySyncRequestAt: startTime,
 	}
 
 	// Advance clock by 5 minutes
@@ -334,6 +335,7 @@ func TestMediaHistoryTracker_Listen_Stopped(t *testing.T) {
 	mockUserDB.AssertExpectations(t)
 	assert.Equal(t, int64(0), tracker.currentHistoryDBID)
 	assert.True(t, tracker.currentMediaStartTime.IsZero())
+	assert.True(t, tracker.lastPlaySyncRequestAt.IsZero())
 	assert.Equal(t, 1, syncRequests)
 }
 
@@ -594,6 +596,11 @@ func TestMediaHistoryTracker_RequestActivePlaySyncHonorsIntervalAndDBID(t *testi
 
 	tracker.requestActivePlaySyncIfDue(42, startTime.Add(activePlaySyncInterval-time.Second), false)
 	assert.Zero(t, syncRequests)
+	assert.Equal(t, startTime, tracker.lastPlaySyncRequestAt)
+
+	tracker.requestActivePlaySyncIfDue(42, startTime.Add(-time.Minute), false)
+	assert.Zero(t, syncRequests, "a backward clock jump must remain throttled")
+	assert.Equal(t, startTime, tracker.lastPlaySyncRequestAt)
 
 	nextSync := startTime.Add(activePlaySyncInterval)
 	tracker.requestActivePlaySyncIfDue(42, nextSync, false)
@@ -602,6 +609,12 @@ func TestMediaHistoryTracker_RequestActivePlaySyncHonorsIntervalAndDBID(t *testi
 
 	tracker.requestActivePlaySyncIfDue(7, nextSync.Add(activePlaySyncInterval), true)
 	assert.Equal(t, 1, syncRequests, "a stale DBID must not request sync")
+	assert.Equal(t, nextSync, tracker.lastPlaySyncRequestAt)
+
+	tracker.closingHistoryDBID = 42
+	tracker.requestActivePlaySyncIfDue(42, nextSync.Add(activePlaySyncInterval), true)
+	assert.Equal(t, 1, syncRequests, "a closing history row must not request sync")
+	assert.Equal(t, nextSync, tracker.lastPlaySyncRequestAt)
 }
 
 func TestMediaHistoryTracker_UpdatePlayTime_NoActiveMedia(t *testing.T) {
@@ -843,6 +856,7 @@ func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
 		requestPlaySync:       func() { syncRequests++ },
 		currentHistoryDBID:    orphanedDBID,
 		currentMediaStartTime: orphanStart,
+		lastPlaySyncRequestAt: orphanStart,
 	}
 
 	// Advance clock so the orphaned entry gets a non-zero play time.
@@ -881,5 +895,46 @@ func TestMediaHistoryTracker_Listen_OrphanedEntry(t *testing.T) {
 
 	mockUserDB.AssertExpectations(t)
 	assert.Equal(t, newDBID, tracker.currentHistoryDBID, "new DBID should be set after orphan close")
+	assert.Equal(t, fakeClock.Now(), tracker.lastPlaySyncRequestAt)
 	assert.Equal(t, 2, syncRequests, "orphan close and new now-playing session both request sync")
+}
+
+func TestMediaHistoryTracker_Listen_OrphanedEntryWithoutReplacementResetsSyncState(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockUserDB := &testhelpers.MockUserDBI{}
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	fakeClock := clockwork.NewFakeClock()
+	orphanStart := fakeClock.Now()
+	syncRequests := 0
+	tracker := &mediaHistoryTracker{
+		st:                    st,
+		db:                    &database.Database{UserDB: mockUserDB},
+		clock:                 fakeClock,
+		requestPlaySync:       func() { syncRequests++ },
+		currentHistoryDBID:    10,
+		currentMediaStartTime: orphanStart,
+		lastPlaySyncRequestAt: orphanStart,
+	}
+	fakeClock.Advance(30 * time.Second)
+	mockUserDB.On(
+		"CloseMediaHistory",
+		int64(10),
+		mock.AnythingOfType("time.Time"),
+		30,
+	).Return(nil).Once()
+
+	notifChan := make(chan models.Notification, 1)
+	notifChan <- models.Notification{Method: models.NotificationStarted}
+	close(notifChan)
+	tracker.listen(notifChan)
+
+	mockUserDB.AssertExpectations(t)
+	mockUserDB.AssertNotCalled(t, "AddMediaHistory", mock.Anything)
+	assert.Zero(t, tracker.currentHistoryDBID)
+	assert.True(t, tracker.currentMediaStartTime.IsZero())
+	assert.True(t, tracker.currentMediaStartTimeMono.IsZero())
+	assert.True(t, tracker.lastPlaySyncRequestAt.IsZero())
+	assert.Equal(t, 1, syncRequests)
 }


### PR DESCRIPTION
## Summary

- upload an open now-playing session immediately when media starts
- refresh active session playtime every five minutes through existing coalescing and backoff
- retain hourly reconciliation and immediate final sync when media stops
- cover active-session payloads, cadence, and lifecycle transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Active playback sessions now trigger remote sync immediately when they start.
  * Ongoing playback progress uploads continue periodically (about every five minutes), with throttling to avoid unnecessary requests.
  * Session start/stop and orphan cleanup refresh sync timing so active-state uploads remain accurate.
* **Tests**
  * Added coverage for active-session upload behavior and for throttling/reset logic around active play synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->