### PR TITLE
fix(config): make mapping reloads idempotent

### DIFF
--- a/pkg/api/methods/settings_test.go
+++ b/pkg/api/methods/settings_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -969,6 +970,43 @@ func TestHandleSettingsReload_DoesNotRefreshLaunchers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, NoContent{}, result)
 	assert.Zero(t, refreshable.refreshCalls)
+
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestHandleSettingsReload_DoesNotDuplicateMappings(t *testing.T) {
+	t.Parallel()
+
+	memFS := helpers.NewMemoryFS()
+	dataDir := "data"
+	configDir := "config"
+	mappingsDir := filepath.Join(dataDir, config.MappingsDir)
+	require.NoError(t, memFS.WriteFile(filepath.Join(mappingsDir, "test.toml"), []byte(`
+[[mappings.entry]]
+match_pattern = "file-pattern"
+zapscript = "**launch:file"
+`), 0o600))
+
+	cfg, err := helpers.NewTestConfig(memFS, configDir)
+	require.NoError(t, err)
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform").Maybe()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: dataDir}).Maybe()
+
+	env := requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		Config:   cfg,
+	}
+
+	for range 2 {
+		result, reloadErr := HandleSettingsReload(env)
+		require.NoError(t, reloadErr)
+		assert.Equal(t, NoContent{}, result)
+		require.Len(t, cfg.Mappings(), 1)
+	}
 
 	mockPlatform.AssertExpectations(t)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,6 +174,7 @@ type Instance struct {
 	cfgPath                 string
 	authPath                string
 	customLaunchersExternal []LaunchersCustom
+	mappingsExternal        []MappingsEntry
 	vals                    Values
 	defaults                Values
 	mu                      syncutil.RWMutex

--- a/pkg/config/configmappings.go
+++ b/pkg/config/configmappings.go
@@ -20,6 +20,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,7 +86,7 @@ func (c *Instance) LoadMappings(mappingsDir string) error {
 	}
 
 	filesCounts := 0
-	mappingsCount := 0
+	loadedMappings := make([]MappingsEntry, 0)
 
 	for _, mapPath := range mapFiles {
 		log.Debug().Msgf("loading mapping file: %s", mapPath)
@@ -103,13 +104,17 @@ func (c *Instance) LoadMappings(mappingsDir string) error {
 			continue
 		}
 
-		c.vals.Mappings.Entry = append(c.vals.Mappings.Entry, newVals.Mappings.Entry...)
-
+		loadedMappings = append(loadedMappings, newVals.Mappings.Entry...)
 		filesCounts++
-		mappingsCount += len(newVals.Mappings.Entry)
 	}
 
-	log.Info().Int("files", filesCounts).Int("mappings", mappingsCount).Msg("loaded mapping files")
+	if len(mapFiles) > 0 && filesCounts == 0 {
+		return errors.New("failed to parse any mapping files")
+	}
+
+	c.mappingsExternal = append([]MappingsEntry(nil), loadedMappings...)
+
+	log.Info().Int("files", filesCounts).Int("mappings", len(loadedMappings)).Msg("loaded mapping files")
 
 	return nil
 }
@@ -117,5 +122,9 @@ func (c *Instance) LoadMappings(mappingsDir string) error {
 func (c *Instance) Mappings() []MappingsEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.vals.Mappings.Entry
+
+	entries := make([]MappingsEntry, 0, len(c.vals.Mappings.Entry)+len(c.mappingsExternal))
+	entries = append(entries, c.vals.Mappings.Entry...)
+	entries = append(entries, c.mappingsExternal...)
+	return entries
 }

--- a/pkg/config/configmappings_test.go
+++ b/pkg/config/configmappings_test.go
@@ -81,6 +81,74 @@ zapscript = "**launch:nes/{match}"
 	assert.Equal(t, "*.nes", mappings[1].MatchPattern)
 }
 
+func TestLoadMappings_ReplacesExternalSnapshot(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	mappingsDir := filepath.Join("data", "mappings")
+	mappingPath := filepath.Join(mappingsDir, "test.toml")
+	require.NoError(t, fs.MkdirAll(mappingsDir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, mappingPath, []byte(`
+[[mappings.entry]]
+match_pattern = "external-original"
+zapscript = "**launch:original"
+`), 0o600))
+
+	cfg := &Instance{fs: fs}
+	require.NoError(t, cfg.LoadTOML(`
+[[mappings.entry]]
+match_pattern = "inline"
+zapscript = "**launch:inline"
+`))
+
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+	assert.Equal(t, []MappingsEntry{
+		{MatchPattern: "inline", ZapScript: "**launch:inline"},
+		{MatchPattern: "external-original", ZapScript: "**launch:original"},
+	}, cfg.Mappings(), "unchanged reload must not append duplicate mappings")
+
+	require.NoError(t, afero.WriteFile(fs, mappingPath, []byte(`
+[[mappings.entry]]
+match_pattern = "external-edited"
+zapscript = "**launch:edited"
+`), 0o600))
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+	assert.Equal(t, []MappingsEntry{
+		{MatchPattern: "inline", ZapScript: "**launch:inline"},
+		{MatchPattern: "external-edited", ZapScript: "**launch:edited"},
+	}, cfg.Mappings(), "edited mapping must replace previous external snapshot")
+
+	require.NoError(t, fs.Remove(mappingPath))
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+	assert.Equal(t, []MappingsEntry{
+		{MatchPattern: "inline", ZapScript: "**launch:inline"},
+	}, cfg.Mappings(), "deleted external mappings must be removed without clearing inline mappings")
+}
+
+func TestLoadMappings_RetainsSnapshotWhenAllFilesFail(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	mappingsDir := filepath.Join("data", "mappings")
+	mappingPath := filepath.Join(mappingsDir, "test.toml")
+	require.NoError(t, fs.MkdirAll(mappingsDir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, mappingPath, []byte(`
+[[mappings.entry]]
+match_pattern = "working"
+zapscript = "**launch:working"
+`), 0o600))
+
+	cfg := &Instance{fs: fs}
+	require.NoError(t, cfg.LoadMappings(mappingsDir))
+
+	require.NoError(t, afero.WriteFile(fs, mappingPath, []byte(`invalid {{{`), 0o600))
+	require.Error(t, cfg.LoadMappings(mappingsDir))
+	assert.Equal(t, []MappingsEntry{
+		{MatchPattern: "working", ZapScript: "**launch:working"},
+	}, cfg.Mappings())
+}
+
 func TestLoadMappings_MultipleFiles(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- track file mappings separately from inline config mappings
- atomically replace file mapping snapshots so reloads reflect edits and deletions without duplicates
- retain last valid snapshot when every mapping file fails to parse
- cover both direct and settings reload regressions

Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mapping reloads so entries are not duplicated.
  * External mappings now correctly update when files are edited or removed.
  * Preserved previously valid mappings when a reload encounters invalid configuration files.

* **Tests**
  * Added coverage for repeated reloads, mapping replacement, file deletion, and failed reload recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->