### PR TITLE
fix(audio): stop streaming playback starvation on low-power devices

### DIFF
--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"os"
 	"path/filepath"
@@ -41,8 +42,12 @@ import (
 )
 
 const (
-	targetSampleRate         = 48000
-	resampleQuality          = 4
+	targetSampleRate = 48000
+	resampleQuality  = 4
+	// lowPowerResampleQuality is used for streaming playback on platforms with
+	// very limited CPU (e.g. MiSTer, where the service shares one 800 MHz core
+	// with other processes), trading resampler quality for decode speed.
+	lowPowerResampleQuality  = 1
 	periodSizeInMilliseconds = 50
 	periodCount              = 4
 )
@@ -96,9 +101,11 @@ func (p *MalgoPlayer) playWAV(r io.ReadCloser) error {
 }
 
 // PlayBytes plays audio from a byte slice asynchronously, detecting format from
-// magic bytes. Supports WAV, OGG (Vorbis), MP3, and FLAC.
+// magic bytes. Supports WAV, OGG (Vorbis), MP3, and FLAC. Decoded+resampled PCM
+// is cached by content hash so repeated plays (e.g. the embedded default scan
+// feedback sounds) skip the decode work.
 func (p *MalgoPlayer) PlayBytes(data []byte) error {
-	samples, err := decodeBytesByMagic(data)
+	samples, err := p.loadPCMFromBytes(data)
 	if err != nil {
 		return err
 	}
@@ -148,6 +155,34 @@ func (p *MalgoPlayer) loadPCMFromFile(path string) ([][2]float64, error) {
 
 	p.pcmCacheMu.Lock()
 	p.pcmCache[path] = samples
+	p.pcmCacheMu.Unlock()
+
+	return samples, nil
+}
+
+// loadPCMFromBytes returns decoded+resampled stereo samples for the given
+// encoded audio buffer, cached by content hash. Without this, every play of an
+// embedded sound re-decodes and re-resamples it, which is a per-scan CPU spike
+// large enough to stall streaming playback on low-power devices.
+func (p *MalgoPlayer) loadPCMFromBytes(data []byte) ([][2]float64, error) {
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	key := fmt.Sprintf("bytes:%d:%x", len(data), h.Sum64())
+
+	p.pcmCacheMu.RLock()
+	if cached, ok := p.pcmCache[key]; ok {
+		p.pcmCacheMu.RUnlock()
+		return cached, nil
+	}
+	p.pcmCacheMu.RUnlock()
+
+	samples, err := decodeBytesByMagic(data)
+	if err != nil {
+		return nil, err
+	}
+
+	p.pcmCacheMu.Lock()
+	p.pcmCache[key] = samples
 	p.pcmCacheMu.Unlock()
 
 	return samples, nil

--- a/pkg/audio/audio_test.go
+++ b/pkg/audio/audio_test.go
@@ -399,6 +399,42 @@ func TestPCMCache_HitAndMiss(t *testing.T) {
 	}
 }
 
+func TestPCMCache_BytesCachedByContent(t *testing.T) {
+	t.Parallel()
+
+	p := NewMalgoPlayer()
+
+	// First decode populates the cache; second returns the cached samples.
+	samples1, err := p.loadPCMFromBytes(validWAVHeader())
+	require.NoError(t, err)
+	samples2, err := p.loadPCMFromBytes(validWAVHeader())
+	require.NoError(t, err)
+	assert.Equal(t, samples1, samples2)
+
+	p.pcmCacheMu.RLock()
+	entries := len(p.pcmCache)
+	p.pcmCacheMu.RUnlock()
+	assert.Equal(t, 1, entries, "identical bytes must share one cache entry")
+
+	// Different content gets its own entry.
+	_, err = p.loadPCMFromBytes(wavWithSamples(100))
+	require.NoError(t, err)
+
+	p.pcmCacheMu.RLock()
+	entries = len(p.pcmCache)
+	p.pcmCacheMu.RUnlock()
+	assert.Equal(t, 2, entries)
+
+	// Decode errors are not cached.
+	_, err = p.loadPCMFromBytes([]byte("not audio"))
+	require.Error(t, err)
+
+	p.pcmCacheMu.RLock()
+	entries = len(p.pcmCache)
+	p.pcmCacheMu.RUnlock()
+	assert.Equal(t, 2, entries)
+}
+
 func TestPCMCache_Clear(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/audio/device.go
+++ b/pkg/audio/device.go
@@ -211,7 +211,13 @@ func (d *sharedDevice) open() {
 	}
 	d.devMu.Unlock()
 
-	malgoCtx, err := malgo.InitContext(nil, malgo.ContextConfig{}, nil)
+	// Realtime priority puts the audio callback thread on SCHED_FIFO (Linux),
+	// so playback keeps running when the rest of the process is busy (e.g.
+	// heavy API queries on a CPU-constrained device). The default "highest"
+	// priority is a no-op under SCHED_OTHER, which has no priority levels.
+	// miniaudio falls back to a normal thread if realtime is not permitted.
+	ctxConfig := malgo.ContextConfig{ThreadPriority: malgo.ThreadPriorityRealtime}
+	malgoCtx, err := malgo.InitContext(nil, ctxConfig, nil)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to initialize audio context")
 		d.failAllSources()

--- a/pkg/audio/device.go
+++ b/pkg/audio/device.go
@@ -48,17 +48,19 @@ type mixSource interface {
 //
 // Lock order: devMu → individual source locks.
 type sharedDevice struct {
-	malgoCtx *malgo.AllocatedContext
-	device   *malgo.Device
-	cancelFn context.CancelFunc
-	devDone  chan struct{}
-	prevDone <-chan struct{}
-	manageCh chan struct{}
-	sources  []mixSource
-	toRemove []mixSource
-	mixBuf   [][2]float64
-	devMu    syncutil.Mutex
-	opening  bool
+	// initContext overrides malgo.InitContext in tests; nil means the real one.
+	initContext func([]malgo.Backend, malgo.ContextConfig, malgo.LogProc) (*malgo.AllocatedContext, error)
+	malgoCtx    *malgo.AllocatedContext
+	device      *malgo.Device
+	cancelFn    context.CancelFunc
+	devDone     chan struct{}
+	prevDone    <-chan struct{}
+	manageCh    chan struct{}
+	sources     []mixSource
+	toRemove    []mixSource
+	mixBuf      [][2]float64
+	devMu       syncutil.Mutex
+	opening     bool
 }
 
 // globalDevice is the process-wide audio output device shared by all players.
@@ -217,7 +219,11 @@ func (d *sharedDevice) open() {
 	// priority is a no-op under SCHED_OTHER, which has no priority levels.
 	// miniaudio falls back to a normal thread if realtime is not permitted.
 	ctxConfig := malgo.ContextConfig{ThreadPriority: malgo.ThreadPriorityRealtime}
-	malgoCtx, err := malgo.InitContext(nil, ctxConfig, nil)
+	initContext := d.initContext
+	if initContext == nil {
+		initContext = malgo.InitContext
+	}
+	malgoCtx, err := initContext(nil, ctxConfig, nil)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to initialize audio context")
 		d.failAllSources()

--- a/pkg/audio/device_test.go
+++ b/pkg/audio/device_test.go
@@ -22,10 +22,12 @@ package audio
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"math"
 	"testing"
 	"time"
 
+	"github.com/gen2brain/malgo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -147,6 +149,29 @@ func TestSharedDeviceManageRemovesDrainedSourceAndNotifies(t *testing.T) {
 	require.Len(t, d.sources, 1)
 	assert.Same(t, keepSrc, d.sources[0])
 	assert.Empty(t, d.toRemove)
+}
+
+// TestSharedDeviceOpenRequestsRealtimeThreadPriority verifies open passes
+// realtime thread priority to the malgo context, so the audio callback runs
+// under SCHED_FIFO on Linux instead of competing with normal process threads.
+func TestSharedDeviceOpenRequestsRealtimeThreadPriority(t *testing.T) {
+	t.Parallel()
+
+	var got malgo.ContextConfig
+	stubInit := func(_ []malgo.Backend, cfg malgo.ContextConfig, _ malgo.LogProc) (*malgo.AllocatedContext, error) {
+		got = cfg
+		return nil, errors.New("stub: no real audio context in tests")
+	}
+	d := &sharedDevice{
+		manageCh:    make(chan struct{}, 1),
+		initContext: stubInit,
+	}
+	d.sources = append(d.sources, &testMixSource{active: true})
+
+	d.open()
+
+	assert.Equal(t, malgo.ThreadPriorityRealtime, got.ThreadPriority)
+	assert.Empty(t, d.sources, "init failure must clear all sources")
 }
 
 func TestClampF64(t *testing.T) {

--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -40,6 +40,12 @@ import (
 const (
 	// ringBufferFrames is the streaming ring buffer size (4 s × 48 kHz = 192 000 frames,
 	// ~3 MB per slot). This bounds memory use regardless of track length.
+	//
+	// If streaming still stutters under heavy load on low-power devices, the
+	// remaining untried options are: raising this to 8 s (~6 MB per slot),
+	// boosting the prefetch goroutine's thread priority (runtime.LockOSThread
+	// plus per-thread setpriority), and prioritizing decode file reads over
+	// database queries with ioprio_set.
 	ringBufferFrames = 4 * targetSampleRate
 	// decodeChunkFrames is the number of frames decoded per prefetch iteration (100 ms).
 	decodeChunkFrames = 100 * targetSampleRate / 1000
@@ -75,16 +81,23 @@ type PlaybackManager interface {
 // Each slot streams audio through the shared global output device via a ring-buffer
 // prefetch goroutine — no full-file decode into RAM.
 type LongformPlaybackManager struct {
-	primary        *streamingSource
-	background     *streamingSource
-	drainCallbacks map[string]func(natural bool)
-	mu             syncutil.Mutex
+	primary         *streamingSource
+	background      *streamingSource
+	drainCallbacks  map[string]func(natural bool)
+	resampleQuality int
+	mu              syncutil.Mutex
 }
 
-// NewLongformPlaybackManager creates a new LongformPlaybackManager.
-func NewLongformPlaybackManager() *LongformPlaybackManager {
+// NewLongformPlaybackManager creates a new LongformPlaybackManager. lowPowerAudio
+// selects a cheaper resampler for streaming decode on CPU-constrained platforms.
+func NewLongformPlaybackManager(lowPowerAudio bool) *LongformPlaybackManager {
+	quality := resampleQuality
+	if lowPowerAudio {
+		quality = lowPowerResampleQuality
+	}
 	return &LongformPlaybackManager{
-		drainCallbacks: make(map[string]func(natural bool)),
+		drainCallbacks:  make(map[string]func(natural bool)),
+		resampleQuality: quality,
 	}
 }
 
@@ -112,7 +125,7 @@ func (m *LongformPlaybackManager) Play(slot, path string, opts PlaybackOptions) 
 		volume = 1.0
 	}
 
-	src, err := newStreamingSource(path, volume)
+	src, err := newStreamingSource(path, volume, m.resampleQuality)
 	if err != nil {
 		return fmt.Errorf("open streaming source: %w", err)
 	}
@@ -282,6 +295,7 @@ type streamingSource struct {
 	volume       float64
 	totalFrames  int64
 	sourceRate   int
+	quality      int
 	seekSrcFrame int64
 	played       int64
 	filled       int
@@ -297,7 +311,7 @@ type streamingSource struct {
 // newStreamingSource opens path for streaming decode and returns a ready source.
 // The prefetch goroutine is NOT started yet — call startPrefetch after registering
 // with the device.
-func newStreamingSource(path string, volume float64) (*streamingSource, error) {
+func newStreamingSource(path string, volume float64, quality int) (*streamingSource, error) {
 	//nolint:gosec // G304: callers validate media paths before launching.
 	f, err := os.Open(path)
 	if err != nil {
@@ -332,7 +346,7 @@ func newStreamingSource(path string, volume float64) (*streamingSource, error) {
 		totalFrames = int64(float64(n) * float64(targetSampleRate) / float64(format.SampleRate))
 	}
 
-	resampler := beep.Resample(resampleQuality, format.SampleRate, beep.SampleRate(targetSampleRate), decoder)
+	resampler := beep.Resample(quality, format.SampleRate, beep.SampleRate(targetSampleRate), decoder)
 
 	return &streamingSource{
 		ring:        make([][2]float64, ringBufferFrames),
@@ -340,6 +354,7 @@ func newStreamingSource(path string, volume float64) (*streamingSource, error) {
 		volume:      volume,
 		totalFrames: totalFrames,
 		sourceRate:  int(format.SampleRate),
+		quality:     quality,
 		wakeCh:      make(chan struct{}, 1),
 		decoder:     decoder,
 		file:        f,
@@ -387,10 +402,7 @@ func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 			s.filled = 0
 			s.eof = false
 		}
-		paused := s.paused
 		stopped := s.stopped
-		eof := s.eof
-		space := len(s.ring) - s.filled
 		s.mu.Unlock()
 
 		if stopped {
@@ -400,11 +412,25 @@ func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 			if err := s.decoder.Seek(int(seekFrame)); err != nil {
 				log.Warn().Err(err).Str("path", s.path).Msg("seek audio decoder")
 			}
-			s.resampler = beep.Resample(resampleQuality, beep.SampleRate(s.sourceRate),
+			s.resampler = beep.Resample(s.quality, beep.SampleRate(s.sourceRate),
 				beep.SampleRate(targetSampleRate), s.decoder)
 		}
 
-		if !paused && !eof && space > 0 {
+		// Fill all available ring space before sleeping. Decoding a single chunk
+		// per wake caps sustained decode at 1x realtime, leaving no headroom to
+		// rebuild the cushion when the CPU is contended (audible dropouts on
+		// slow ARM devices); filling to capacity lets the ring absorb stalls.
+		for {
+			s.mu.Lock()
+			space := 0
+			if !s.paused && !s.eof && !s.stopped && !s.seekPending {
+				space = len(s.ring) - s.filled
+			}
+			s.mu.Unlock()
+			if space == 0 {
+				break
+			}
+
 			n := min(space, len(s.chunk))
 			written, ok := s.resampler.Stream(s.chunk[:n])
 			if written > 0 {
@@ -427,6 +453,7 @@ func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 				s.mu.Lock()
 				s.eof = true
 				s.mu.Unlock()
+				break
 			}
 		}
 

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -295,33 +295,51 @@ func wavWithSamples(n uint32) []byte {
 func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "audio.wav")
-	require.NoError(t, os.WriteFile(path, wavWithSamples(4410), 0o600)) // 0.1 s of audio
+	// Both qualities: the seek path rebuilds the resampler from the source's
+	// stored quality, which must work for low-power platforms too.
+	for _, tc := range []struct {
+		name    string
+		quality int
+	}{
+		{name: "default quality", quality: resampleQuality},
+		{name: "low power quality", quality: lowPowerResampleQuality},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	s, err := newStreamingSource(path, 1.0, resampleQuality)
-	require.NoError(t, err)
-	s.startPrefetch()
-	t.Cleanup(s.stopAndDeregister)
+			path := filepath.Join(t.TempDir(), "audio.wav")
+			require.NoError(t, os.WriteFile(path, wavWithSamples(4410), 0o600)) // 0.1 s of audio
 
-	// Wait for the prefetch goroutine to fully decode the file.
-	require.Eventually(t, func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return s.eof
-	}, 5*time.Second, 5*time.Millisecond, "prefetch should reach EOF")
+			s, err := newStreamingSource(path, 1.0, tc.quality)
+			require.NoError(t, err)
+			s.startPrefetch()
+			t.Cleanup(s.stopAndDeregister)
 
-	// Simulate the tail playing out, then seek back to the start. Before the
-	// parked-prefetch fix the goroutine had already exited and the flushed ring
-	// stayed empty forever, wedging the slot in silence.
-	buf := make([][2]float64, 64)
-	s.mixAdd(buf, len(buf))
-	s.seek(-time.Second)
+			// Wait for the prefetch goroutine to fully decode the file.
+			require.Eventually(t, func() bool {
+				s.mu.Lock()
+				defer s.mu.Unlock()
+				return s.eof
+			}, 5*time.Second, 5*time.Millisecond, "prefetch should reach EOF")
 
-	require.Eventually(t, func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return s.filled > 0
-	}, 5*time.Second, 5*time.Millisecond, "seek after EOF should refill the ring")
+			// Simulate the tail playing out, then seek back to the start. Before the
+			// parked-prefetch fix the goroutine had already exited and the flushed ring
+			// stayed empty forever, wedging the slot in silence.
+			buf := make([][2]float64, 64)
+			s.mixAdd(buf, len(buf))
+			s.seek(-time.Second)
+
+			require.Eventually(t, func() bool {
+				s.mu.Lock()
+				defer s.mu.Unlock()
+				return s.filled > 0
+			}, 5*time.Second, 5*time.Millisecond, "seek after EOF should refill the ring")
+
+			s.mu.Lock()
+			assert.Equal(t, tc.quality, s.quality, "seek must preserve the source's resample quality")
+			s.mu.Unlock()
+		})
+	}
 }
 
 // TestStreamingSource_PrefetchFillsRingWithoutTickerPacing verifies the prefetch

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -250,14 +250,14 @@ func TestNewStreamingSource_UnsupportedExtension(t *testing.T) {
 	// The file must exist — the extension check happens after os.Open succeeds.
 	path := filepath.Join(t.TempDir(), "audio.xyz")
 	require.NoError(t, os.WriteFile(path, []byte("fake"), 0o600))
-	_, err := newStreamingSource(path, 1.0)
+	_, err := newStreamingSource(path, 1.0, resampleQuality)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported audio format")
 }
 
 func TestNewStreamingSource_FileNotFound(t *testing.T) {
 	t.Parallel()
-	_, err := newStreamingSource(filepath.Join(t.TempDir(), "missing.mp3"), 1.0)
+	_, err := newStreamingSource(filepath.Join(t.TempDir(), "missing.mp3"), 1.0, resampleQuality)
 	require.Error(t, err)
 }
 
@@ -267,7 +267,7 @@ func TestNewStreamingSource_WAVInitializesStreamingFields(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audio.wav")
 	require.NoError(t, os.WriteFile(path, validWAVHeader(), 0o600))
 
-	s, err := newStreamingSource(path, 0.75)
+	s, err := newStreamingSource(path, 0.75, resampleQuality)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, s.decoder.Close())
@@ -283,8 +283,8 @@ func TestNewStreamingSource_WAVInitializesStreamingFields(t *testing.T) {
 }
 
 // wavWithSamples builds a minimal mono 16-bit 44.1 kHz WAV containing n silent samples.
-func wavWithSamples(n uint16) []byte {
-	dataSize := uint32(n) * 2
+func wavWithSamples(n uint32) []byte {
+	dataSize := n * 2
 	header := validWAVHeader()
 	// Patch RIFF size and data chunk size for the sample payload.
 	binary.LittleEndian.PutUint32(header[4:8], 36+dataSize)
@@ -298,7 +298,7 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audio.wav")
 	require.NoError(t, os.WriteFile(path, wavWithSamples(4410), 0o600)) // 0.1 s of audio
 
-	s, err := newStreamingSource(path, 1.0)
+	s, err := newStreamingSource(path, 1.0, resampleQuality)
 	require.NoError(t, err)
 	s.startPrefetch()
 	t.Cleanup(s.stopAndDeregister)
@@ -324,13 +324,44 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 	}, 5*time.Second, 5*time.Millisecond, "seek after EOF should refill the ring")
 }
 
+// TestStreamingSource_PrefetchFillsRingWithoutTickerPacing verifies the prefetch
+// goroutine fills the entire ring in a burst rather than one chunk per 100 ms
+// tick. Per-tick pacing capped decode at 1x realtime, so the ring never built a
+// cushion and CPU contention produced period-sized dropouts (crackle) on slow
+// ARM devices. Filling the 4 s ring takes 40 chunks: burst-filling completes in
+// well under 2 s, while per-tick pacing needs at least 4 s.
+func TestStreamingSource_PrefetchFillsRingWithoutTickerPacing(t *testing.T) {
+	t.Parallel()
+
+	// 6 s of source audio at 44.1 kHz resamples to more than the 4 s ring holds.
+	path := filepath.Join(t.TempDir(), "audio.wav")
+	require.NoError(t, os.WriteFile(path, wavWithSamples(6*44100), 0o600))
+
+	s, err := newStreamingSource(path, 1.0, resampleQuality)
+	require.NoError(t, err)
+	s.startPrefetch()
+	t.Cleanup(s.stopAndDeregister)
+
+	require.Eventually(t, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.filled == len(s.ring)
+	}, 2*time.Second, 5*time.Millisecond, "prefetch should burst-fill the full ring")
+}
+
 func TestNewLongformPlaybackManager(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 	require.NotNil(t, m)
 	assert.NotNil(t, m.drainCallbacks)
 	assert.Nil(t, m.primary)
 	assert.Nil(t, m.background)
+}
+
+func TestNewLongformPlaybackManager_ResampleQuality(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, resampleQuality, NewLongformPlaybackManager(false).resampleQuality)
+	assert.Equal(t, lowPowerResampleQuality, NewLongformPlaybackManager(true).resampleQuality)
 }
 
 func TestLongformPlaybackManager_PlayReplacesSourceAndUsesDrainCallback(t *testing.T) {
@@ -345,7 +376,7 @@ func TestLongformPlaybackManager_PlayReplacesSourceAndUsesDrainCallback(t *testi
 	require.NoError(t, os.WriteFile(firstPath, validWAVHeader(), 0o600))
 	require.NoError(t, os.WriteFile(secondPath, validWAVHeader(), 0o600))
 
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 	drainCalls := 0
 	m.SetDrainCallback(mediaslot.Primary, func(_ bool) { drainCalls++ })
 
@@ -378,7 +409,7 @@ func TestLongformPlaybackManager_PlayReplacesSourceAndUsesDrainCallback(t *testi
 // an error when given a slot name that is neither primary nor background.
 func TestLongformPlaybackManager_InvalidSlot(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 
 	require.Error(t,
 		m.Play("badslot", filepath.Join("Music", "track.mp3"), PlaybackOptions{}),
@@ -395,7 +426,7 @@ func TestLongformPlaybackManager_InvalidSlot(t *testing.T) {
 // are all safe no-ops when no source has been registered for a slot.
 func TestLongformPlaybackManager_NoSourceOps(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 
 	slots := []string{"", mediaslot.Primary, mediaslot.Background}
 	for _, slot := range slots {
@@ -412,7 +443,7 @@ func TestLongformPlaybackManager_NoSourceOps(t *testing.T) {
 // on the primary slot when a source has been directly injected (no audio hardware needed).
 func TestLongformPlaybackManager_WithSourcePrimary(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 	s := newTestSource()
 	s.played = int64(targetSampleRate / 2) // 0.5 s in
 	m.mu.Lock()
@@ -457,7 +488,7 @@ func TestLongformPlaybackManager_WithSourcePrimary(t *testing.T) {
 // on the background slot.
 func TestLongformPlaybackManager_WithSourceBackground(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 	s := newTestSource()
 	m.mu.Lock()
 	m.background = s
@@ -493,7 +524,7 @@ func TestLongformPlaybackManager_WithSourceBackground(t *testing.T) {
 // the canonical name.
 func TestLongformPlaybackManager_SlotAliasesResolve(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 	s := newTestSource()
 	m.mu.Lock()
 	m.background = s
@@ -517,7 +548,7 @@ func TestLongformPlaybackManager_SlotAliasesResolve(t *testing.T) {
 // TestLongformPlaybackManager_SetDrainCallback verifies callbacks can be registered and invoked.
 func TestLongformPlaybackManager_SetDrainCallback(t *testing.T) {
 	t.Parallel()
-	m := NewLongformPlaybackManager()
+	m := NewLongformPlaybackManager(false)
 
 	var primaryCalled, backgroundCalled bool
 	m.SetDrainCallback(mediaslot.Primary, func(_ bool) { primaryCalled = true })

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -485,6 +485,7 @@ func (*Platform) Settings() platforms.Settings {
 		LogDir:                misterconfig.TempDir,
 		ZipsAsDirs:            true,
 		DisableZapScriptInTUI: true,
+		LowPowerAudio:         true,
 	}
 }
 

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -380,6 +380,10 @@ type Settings struct {
 	// the TUI occupies the platform's primary display. Leave false when the
 	// TUI and launched media can run alongside each other.
 	DisableZapScriptInTUI bool
+	// LowPowerAudio indicates the platform has very limited CPU available for
+	// audio decoding, so streaming playback trades resampler quality for
+	// decode speed.
+	LowPowerAudio bool
 }
 
 // ScraperCustomOption is a single user-configurable option for a scraper.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -230,7 +230,7 @@ func Start(
 
 	player := audio.NewMalgoPlayer()
 	player.SetVolume(float64(cfg.AudioVolume()) / 100.0)
-	playbackManager := audio.NewLongformPlaybackManager()
+	playbackManager := audio.NewLongformPlaybackManager(pl.Settings().LowPowerAudio)
 
 	// TODO: define the notifications chan here instead of in state
 	st, ns := state.NewState(pl, bootUUID) // global state, notification queue (source)


### PR DESCRIPTION
- Streaming prefetch now burst-fills all available ring space per wake instead of decoding one 100ms chunk per 100ms tick. The old pacing capped decode at 1x realtime, so the 4s ring never built a cushion and any CPU contention produced period-sized silence gaps, heard as persistent crackle on MiSTer.
- Adds a LowPowerAudio platform setting, enabled on MiSTer, which selects resample quality 1 instead of 4 for streaming decode.
- PlayBytes now caches decoded PCM by content hash, matching PlayFile. The embedded default scan feedback sounds were re-decoded and re-resampled on every scan, inline in the token processing path, which stalled streaming audio and slowed scans.
- The malgo context now requests realtime thread priority so the audio callback runs under SCHED_FIFO on Linux and keeps playing while the service is busy with API queries. The previous default priority is a no-op under SCHED_OTHER; miniaudio falls back to a normal thread where realtime is not permitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved audio playback by decoding PCM asynchronously and reusing previously decoded/resampled PCM for identical audio bytes.
  * Added lower-power streaming audio processing (selectable via a low-power setting) to reduce CPU use during streaming.
* **Bug Fixes**
  * Improved streaming ring-buffer refill behavior, including more reliable playback after seeking near/after end-of-stream.
* **Platform Support**
  * MiSTer now enables the low-power audio setting automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->