### PR TITLE
feat: expose client capabilities and link mobile app

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -302,6 +302,7 @@ Methods are used to execute actions and request data back from the API. These AP
 | inbox.delete                    | Delete a specific inbox message by ID.                                                |
 | inbox.clear                     | Delete all inbox messages.                                                            |
 | clients                         | List paired API clients.                                                              |
+| clients.current                 | Return current connection role and effective capabilities.                            |
 | clients.delete                  | Delete a paired API client.                                                           |
 | input.keyboard                  | Send a keyboard input sequence.                                                       |
 | input.gamepad                   | Send a gamepad input sequence.                                                        |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -240,7 +240,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods are used to execute actions and request data back from the API. These API docs cover **64 methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
+Methods are used to execute actions and request data back from the API. These API docs cover **65 methods** across core functionality areas, including deprecated aliases. See the [API Methods](./methods) page for detailed definitions and examples of each method.
 
 | ID                              | Description                                                                           |
 | :------------------------------ | :------------------------------------------------------------------------------------ |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -3842,6 +3842,52 @@ Returns `null` on success.
 }
 ```
 
+## Clients
+
+### clients.current
+
+Return pairing status, authenticated role, and effective capabilities for the current connection. This method is available to every connection accepted by the API transport.
+
+`role` is `admin` or `member` for paired connections and `null` otherwise. Unpaired plaintext connections retain their legacy effective capabilities. Clients should use capability presence for corresponding UI gates and treat role as display-only. Capability names currently include `profiles.manage` and `settings.write`; the array does not enumerate every callable RPC method.
+
+#### Parameters
+
+None.
+
+#### Result
+
+| Key          | Type               | Description                                                    |
+| :----------- | :----------------- | :------------------------------------------------------------- |
+| paired       | boolean            | Whether connection carries an authenticated paired identity.   |
+| role         | string or `null`   | Paired client role, or `null` for an unpaired connection.       |
+| capabilities | array of strings   | Effective named capabilities granted to current connection.     |
+
+#### Example
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1f9a258e-2f86-4bc9-a31b-ec842eb79a42",
+  "method": "clients.current"
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1f9a258e-2f86-4bc9-a31b-ec842eb79a42",
+  "result": {
+    "paired": true,
+    "role": "member",
+    "capabilities": []
+  }
+}
+```
+
 ## Input
 
 Direct platform input control for remote control use cases. These methods bypass the token pipeline entirely: no hooks, history, or sound effects are triggered.

--- a/pkg/api/methods/clients.go
+++ b/pkg/api/methods/clients.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/permissions"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/rs/zerolog/log"
 )
@@ -59,6 +60,32 @@ func HandleClients(env requests.RequestEnv) (any, error) {
 			CreatedAt:  c.CreatedAt,
 			LastSeenAt: c.LastSeenAt,
 		}
+	}
+	return resp, nil
+}
+
+// HandleClientsCurrent returns the current connection's paired role and
+// effective capabilities. It is available to every accepted API connection.
+//
+//nolint:gocritic // API dispatch requires RequestEnv by value.
+func HandleClientsCurrent(env requests.RequestEnv) (any, error) {
+	grant := requestGrant(&env)
+	granted := grant.Capabilities()
+	capabilities := make([]string, len(granted))
+	for i, capability := range granted {
+		capabilities[i] = string(capability)
+	}
+
+	resp := models.ClientsCurrentResponse{
+		Capabilities: capabilities,
+		Paired:       env.ClientRole != "",
+	}
+	if resp.Paired {
+		role := env.ClientRole
+		if !permissions.ValidRole(role) {
+			role = string(permissions.RoleMember)
+		}
+		resp.Role = &role
 	}
 	return resp, nil
 }

--- a/pkg/api/methods/clients_test.go
+++ b/pkg/api/methods/clients_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/permissions"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
@@ -111,6 +112,85 @@ func TestHandleClients_RemoteRejected(t *testing.T) {
 	_, err := HandleClients(env)
 	require.ErrorIs(t, err, ErrLocalhostOnly)
 	mockUserDB.AssertNotCalled(t, "ListClients")
+}
+
+func TestHandleClientsCurrent(t *testing.T) {
+	t.Parallel()
+
+	adminCapabilities := []string{
+		string(permissions.CapProfilesManage),
+		string(permissions.CapSettingsWrite),
+	}
+	tests := []struct {
+		name             string
+		clientRole       string
+		wantRole         string
+		wantCapabilities []string
+		isLocal          bool
+		wantPaired       bool
+	}{
+		{
+			name:             "remote paired member",
+			clientRole:       string(permissions.RoleMember),
+			wantRole:         string(permissions.RoleMember),
+			wantCapabilities: []string{},
+			wantPaired:       true,
+		},
+		{
+			name:             "remote paired admin",
+			clientRole:       string(permissions.RoleAdmin),
+			wantRole:         string(permissions.RoleAdmin),
+			wantCapabilities: adminCapabilities,
+			wantPaired:       true,
+		},
+		{
+			name:             "remote unpaired keeps legacy grant",
+			wantCapabilities: adminCapabilities,
+		},
+		{
+			name:             "local unpaired gets local grant",
+			wantCapabilities: adminCapabilities,
+			isLocal:          true,
+		},
+		{
+			name:             "local paired member gets local grant",
+			clientRole:       string(permissions.RoleMember),
+			wantRole:         string(permissions.RoleMember),
+			wantCapabilities: adminCapabilities,
+			isLocal:          true,
+			wantPaired:       true,
+		},
+		{
+			name:             "unknown paired role degrades to member",
+			clientRole:       "superuser",
+			wantRole:         string(permissions.RoleMember),
+			wantCapabilities: []string{},
+			wantPaired:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := HandleClientsCurrent(requests.RequestEnv{
+				ClientRole: tt.clientRole,
+				IsLocal:    tt.isLocal,
+			})
+			require.NoError(t, err)
+			resp, ok := result.(models.ClientsCurrentResponse)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantPaired, resp.Paired)
+			assert.Equal(t, tt.wantCapabilities, resp.Capabilities)
+			assert.NotNil(t, resp.Capabilities)
+			if tt.wantPaired {
+				require.NotNil(t, resp.Role)
+				assert.Equal(t, tt.wantRole, *resp.Role)
+			} else {
+				assert.Nil(t, resp.Role)
+			}
+		})
+	}
 }
 
 // Note on revocation semantics: HandleClientsDelete is forward-only —

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -141,6 +141,7 @@ const (
 	MethodPlaytimeLimitsUpdate        = "settings.playtime.limits.update"
 	MethodPlaytime                    = "playtime"
 	MethodClients                     = "clients"
+	MethodClientsCurrent              = "clients.current"
 	MethodClientsDelete               = "clients.delete"
 	MethodClientsPairStart            = "clients.pair.start"
 	MethodClientsPairCancel           = "clients.pair.cancel"

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -653,6 +653,15 @@ type ClientsResponse struct {
 	Clients []PairedClient `json:"clients"`
 }
 
+// ClientsCurrentResponse describes the current connection's paired identity
+// and effective role capabilities. Role is null when the connection has no
+// paired identity; capabilities remain populated from its legacy grant.
+type ClientsCurrentResponse struct {
+	Role         *string  `json:"role"`
+	Capabilities []string `json:"capabilities"`
+	Paired       bool     `json:"paired"`
+}
+
 // ClientsDeleteParams is the parameters object for the clients.delete RPC method.
 type ClientsDeleteParams struct {
 	ClientID string `json:"clientId"`

--- a/pkg/api/models/responses_test.go
+++ b/pkg/api/models/responses_test.go
@@ -311,6 +311,38 @@ func TestClientsResponse_JSONShape(t *testing.T) {
 	assert.Len(t, clients, 2)
 }
 
+func TestClientsCurrentResponse_JSONShape(t *testing.T) {
+	t.Parallel()
+
+	t.Run("paired", func(t *testing.T) {
+		t.Parallel()
+
+		role := "member"
+		resp := ClientsCurrentResponse{
+			Role:         &role,
+			Capabilities: []string{},
+			Paired:       true,
+		}
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"role":"member","capabilities":[],"paired":true}`, string(raw))
+	})
+
+	t.Run("unpaired", func(t *testing.T) {
+		t.Parallel()
+
+		resp := ClientsCurrentResponse{
+			Capabilities: []string{"profiles.manage", "settings.write"},
+		}
+		raw, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"role":null,"capabilities":["profiles.manage","settings.write"],"paired":false}`,
+			string(raw),
+		)
+	})
+}
+
 // TestClientsDeleteParams_JSONShape pins the wire shape of the
 // `clients.delete` RPC parameters object.
 func TestClientsDeleteParams_JSONShape(t *testing.T) {

--- a/pkg/api/permissions/permissions.go
+++ b/pkg/api/permissions/permissions.go
@@ -42,6 +42,8 @@
 // paired, which is what makes member restrictions enforceable.
 package permissions
 
+import "slices"
+
 // Role is a paired client's permission level.
 type Role string
 
@@ -120,4 +122,18 @@ func (g Grant) EffectiveRole() Role {
 // Has reports whether the request may perform the given capability.
 func (g Grant) Has(capability Capability) bool {
 	return roleCapabilities[g.EffectiveRole()][capability]
+}
+
+// Capabilities returns the effective grant's enabled capabilities in stable
+// lexical order. The returned slice is always non-nil.
+func (g Grant) Capabilities() []Capability {
+	roleGrants := roleCapabilities[g.EffectiveRole()]
+	capabilities := make([]Capability, 0, len(roleGrants))
+	for capability, enabled := range roleGrants {
+		if enabled {
+			capabilities = append(capabilities, capability)
+		}
+	}
+	slices.Sort(capabilities)
+	return capabilities
 }

--- a/pkg/api/permissions/permissions_test.go
+++ b/pkg/api/permissions/permissions_test.go
@@ -70,6 +70,56 @@ func TestGrant_Has(t *testing.T) {
 	assert.False(t, member.Has(CapSettingsWrite))
 }
 
+func TestGrant_Capabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		grant Grant
+		want  []Capability
+	}{
+		{
+			name:  "paired admin is sorted",
+			grant: Grant{Role: RoleAdmin},
+			want:  []Capability{CapProfilesManage, CapSettingsWrite},
+		},
+		{
+			name:  "paired member is empty",
+			grant: Grant{Role: RoleMember},
+			want:  []Capability{},
+		},
+		{
+			name:  "unpaired remote keeps legacy capabilities",
+			grant: Grant{},
+			want:  []Capability{CapProfilesManage, CapSettingsWrite},
+		},
+		{
+			name:  "local member gets local capabilities",
+			grant: Grant{Role: RoleMember, IsLocal: true},
+			want:  []Capability{CapProfilesManage, CapSettingsWrite},
+		},
+		{
+			name:  "unknown role degrades to member",
+			grant: Grant{Role: "superuser"},
+			want:  []Capability{},
+		},
+		{
+			name:  "session downgrade removes capabilities",
+			grant: Grant{Role: RoleAdmin, SessionRole: RoleMember},
+			want:  []Capability{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.grant.Capabilities()
+			assert.NotNil(t, got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestValidRole(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -333,8 +333,9 @@ func NewMethodMap() *MethodMap {
 		models.MethodInboxDelete: methods.HandleInboxDelete,
 		models.MethodInboxClear:  methods.HandleInboxClear,
 		// clients (paired API clients)
-		models.MethodClients:       methods.HandleClients,
-		models.MethodClientsDelete: methods.HandleClientsDelete,
+		models.MethodClients:        methods.HandleClients,
+		models.MethodClientsCurrent: methods.HandleClientsCurrent,
+		models.MethodClientsDelete:  methods.HandleClientsDelete,
 
 		models.MethodProfiles:       methods.HandleProfiles,
 		models.MethodProfilesNew:    methods.HandleProfilesNew,

--- a/pkg/api/server_post_test.go
+++ b/pkg/api/server_post_test.go
@@ -239,6 +239,31 @@ func TestHandlePostRequest_ValidRequest(t *testing.T) {
 		"RequestStarted and RequestEnded must balance")
 }
 
+func TestHandlePostRequest_ClientsCurrentUnpairedRemote(t *testing.T) {
+	t.Parallel()
+
+	handler, _, _ := createTestPostHandler(t)
+	reqBody := `{"jsonrpc":"2.0","id":"current-client","method":"clients.current"}`
+	//nolint:noctx // test helper, no context needed
+	req := httptest.NewRequest(http.MethodPost, "/api", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	recorder := httptest.NewRecorder()
+
+	handler(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	assert.JSONEq(t, `{
+		"jsonrpc":"2.0",
+		"id":"current-client",
+		"result":{
+			"paired":false,
+			"role":null,
+			"capabilities":["profiles.manage","settings.write"]
+		}
+	}`, recorder.Body.String())
+}
+
 // TestHandlePostRequest_InvalidJSON tests that malformed JSON returns HTTP 200 with JSON-RPC parse error.
 func TestHandlePostRequest_InvalidJSON(t *testing.T) {
 	t.Parallel()

--- a/pkg/ui/tui/main.go
+++ b/pkg/ui/tui/main.go
@@ -37,6 +37,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const mainAppFooterText = "Connect with the Zaparoo App (iOS/Android): " +
+	"[::bu:https://zaparoo.app/]https://zaparoo.app/[::BU:-]"
+
 const (
 	PageMain                  = "main"
 	PageSettingsMain          = "settings_main"
@@ -519,7 +522,7 @@ func BuildMainPage(
 	t := CurrentTheme()
 
 	introText := tview.NewTextView().
-		SetText("Visit [::bu:https://zaparoo.org]zaparoo.org[::-:-] for guides and support.\n").
+		SetText("Visit [::bu:https://zaparoo.org]zaparoo.org[::BU:-] for guides and support.\n").
 		SetDynamicColors(true).
 		SetWordWrap(true)
 
@@ -747,9 +750,15 @@ func BuildMainPage(
 	focusRow, focusCol := session.GetMainMenuFocus()
 	buttonGrid.SetFocus(focusRow, focusCol)
 
+	appFooterText := tview.NewTextView().
+		SetText(mainAppFooterText).
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter)
+
 	main.AddItem(contentFlex, 0, 1, false)
 	main.AddItem(helpText, 1, 0, false)
 	main.AddItem(buttonGrid, 2, 0, true)
+	main.AddItem(appFooterText, 1, 0, false)
 
 	wrappedMain := NewMainFrame(main)
 	pageDefaults(PageMain, pages, wrappedMain)

--- a/pkg/ui/tui/main_test.go
+++ b/pkg/ui/tui/main_test.go
@@ -20,15 +20,64 @@
 package tui
 
 import (
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	testingmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBuildMainPage_ShowsAppFooter(t *testing.T) {
+	mainPageNotifyState.Cancel()
+	t.Cleanup(mainPageNotifyState.Cancel)
+
+	runner := NewTestAppRunner(t, 75, 15)
+	defer runner.Stop()
+
+	platform := testingmocks.NewMockPlatform()
+	platform.On("ID").Return("test")
+	pages := tview.NewPages()
+	BuildMainPage(
+		&config.Instance{}, pages, runner.App(), platform,
+		func() bool { return false }, "", "", nil,
+	)
+
+	runner.Start(pages)
+
+	require.True(t, runner.WaitForText(
+		"Connect with the Zaparoo App (iOS/Android): https://zaparoo.app/",
+		100*time.Millisecond,
+	))
+
+	var introY, visitX, supportX int
+	foundIntro := false
+	for y, line := range strings.Split(runner.GetScreenText(), "\n") {
+		visitX = strings.Index(line, "Visit")
+		supportX = strings.Index(line, "for guides")
+		if visitX >= 0 && supportX >= 0 {
+			introY = y
+			foundIntro = true
+			break
+		}
+	}
+	require.True(t, foundIntro)
+	visitStyle := runner.Screen().GetCellStyle(visitX, introY)
+	supportStyle := runner.Screen().GetCellStyle(supportX, introY)
+	visitForeground, visitBackground, visitAttributes := visitStyle.Decompose()
+	supportForeground, supportBackground, supportAttributes := supportStyle.Decompose()
+	assert.Equal(t, visitForeground, supportForeground)
+	assert.Equal(t, visitBackground, supportBackground)
+	assert.Equal(t, visitAttributes, supportAttributes)
+	assert.Equal(t, visitStyle.GetUnderlineStyle(), supportStyle.GetUnderlineStyle())
+
+	platform.AssertExpectations(t)
+}
 
 func TestMainPageState_SetCancel(t *testing.T) {
 	t.Parallel()

--- a/pkg/ui/tui/main_test.go
+++ b/pkg/ui/tui/main_test.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -50,14 +51,27 @@ func TestBuildMainPage_ShowsAppFooter(t *testing.T) {
 
 	runner.Start(pages)
 
+	const expectedFooterText = "Connect with the Zaparoo App (iOS/Android): https://zaparoo.app/"
 	require.True(t, runner.WaitForText(
-		"Connect with the Zaparoo App (iOS/Android): https://zaparoo.app/",
-		100*time.Millisecond,
+		expectedFooterText,
+		500*time.Millisecond,
 	))
+
+	screenLines := strings.Split(runner.GetScreenText(), "\n")
+	footerX := -1
+	for _, line := range screenLines {
+		if byteIndex := strings.Index(line, expectedFooterText); byteIndex >= 0 {
+			footerX = utf8.RuneCountInString(line[:byteIndex])
+			break
+		}
+	}
+	require.GreaterOrEqual(t, footerX, 0)
+	_, screenWidth, _ := runner.Screen().GetContents()
+	assert.Equal(t, (screenWidth-utf8.RuneCountInString(expectedFooterText))/2, footerX)
 
 	var introY, visitX, supportX int
 	foundIntro := false
-	for y, line := range strings.Split(runner.GetScreenText(), "\n") {
+	for y, line := range screenLines {
 		visitX = strings.Index(line, "Visit")
 		supportX = strings.Index(line, "for guides")
 		if visitX >= 0 && supportX >= 0 {


### PR DESCRIPTION
## Summary

- add `clients.current` for every accepted API connection, with paired role and deterministic effective capabilities
- preserve legacy plaintext grants and document the response contract
- add a compact TUI footer linking to the iOS and Android app
- fix TUI hyperlink style cleanup so text after `zaparoo.org` retains its original style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `clients.current` API method to report connection pairing status, role (when paired), and effective capabilities.
  - Updated the terminal interface with an application footer including support/help guidance.

- **Documentation**
  - Documented `clients.current`, including availability, response fields, and request/response examples.

- **Style**
  - Refined terminal link formatting and enhanced footer rendering to improve consistency and visual styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->