### PR TITLE
perf(backup): reduce cloud pack memory usage

### DIFF
--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -1216,8 +1216,8 @@ func remotePackFixtureFile(tb testing.TB, size int) FileRef {
 		sourceIdentity: &sourceIdentity{info: info},
 		SourceRoot:     root,
 		SourceRel:      "save.dat",
-		ArchivePath:    path.Join(filesRoot, CategorySaves, "save.dat"),
-		RestorePath:    "saves/save.dat",
+		ArchivePath:    filepath.ToSlash(filepath.Join(filesRoot, CategorySaves, "save.dat")),
+		RestorePath:    filepath.ToSlash(filepath.Join(CategorySaves, "save.dat")),
 		Size:           int64(size),
 		SHA256:         hex.EncodeToString(sum[:]),
 	}
@@ -1242,27 +1242,104 @@ func TestBuildRemotePackStreamsIntoFinalBuffer(t *testing.T) {
 	assert.Equal(t, packFooterEntry{Hash: file.SHA256, Offset: 0, Length: file.Size}, footer[0])
 }
 
-func BenchmarkRemoteBackup_BuildPack(b *testing.B) {
-	for _, size := range []int{8 << 20, 32 << 20} {
-		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
-			file := remotePackFixtureFile(b, size)
-			expectedSize, err := remotePackEncodedSize([]FileRef{file})
-			require.NoError(b, err)
-			b.ReportAllocs()
-			b.SetBytes(int64(size))
-			b.ResetTimer()
-			for b.Loop() {
-				body, _, buildErr := buildRemotePack(context.Background(), []FileRef{file}, nil)
-				if buildErr != nil {
-					b.Fatal(buildErr)
-				}
-				if int64(len(body)) != expectedSize {
-					b.Fatalf("unexpected pack size: got %d, want %d", len(body), expectedSize)
-				}
-				runtime.KeepAlive(body)
-			}
+func TestBuildRemotePackRejectsChangedSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mutate func(testing.TB, string, int)
+		name   string
+	}{
+		{
+			name: "same size with different content",
+			mutate: func(tb testing.TB, filePath string, size int) {
+				require.NoError(tb, os.WriteFile(filePath, bytes.Repeat([]byte{0x42}, size), 0o600))
+			},
+		},
+		{
+			name: "grew after hashing",
+			mutate: func(tb testing.TB, filePath string, size int) {
+				data := append(bytes.Repeat([]byte{0x5a}, size), 0x01)
+				require.NoError(tb, os.WriteFile(filePath, data, 0o600))
+			},
+		},
+		{
+			name: "shrank after hashing",
+			mutate: func(tb testing.TB, filePath string, size int) {
+				require.NoError(tb, os.WriteFile(filePath, bytes.Repeat([]byte{0x5a}, size-1), 0o600))
+			},
+		},
+		{
+			name: "replaced after hashing",
+			mutate: func(tb testing.TB, filePath string, size int) {
+				require.NoError(tb, os.Remove(filePath))
+				require.NoError(tb, os.WriteFile(filePath, bytes.Repeat([]byte{0x5a}, size), 0o600))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			const size = 1024
+			file := remotePackFixtureFile(t, size)
+			tt.mutate(t, filepath.Join(file.SourceRoot, file.SourceRel), size)
+
+			_, _, err := buildRemotePack(context.Background(), []FileRef{file}, nil)
+			require.ErrorIs(t, err, errRemoteIntegrityRetry)
 		})
 	}
+}
+
+func TestBuildRemotePackRejectsInvalidEncodedSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		wantErr string
+		size    int64
+	}{
+		{name: "negative", size: -1, wantErr: "size overflow"},
+		{name: "over maximum", size: remoteMaxPackBytes, wantErr: "exceeds maximum size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			file := FileRef{SHA256: strings.Repeat("a", 64), Size: tt.size}
+
+			_, _, err := buildRemotePack(context.Background(), []FileRef{file}, nil)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func BenchmarkRemoteBackup_BuildPack_8MiB(b *testing.B) {
+	benchmarkRemoteBackupBuildPack(b, 8<<20)
+}
+
+func BenchmarkRemoteBackup_BuildPack_32MiB(b *testing.B) {
+	benchmarkRemoteBackupBuildPack(b, 32<<20)
+}
+
+func benchmarkRemoteBackupBuildPack(b *testing.B, size int) {
+	b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+		file := remotePackFixtureFile(b, size)
+		expectedSize, err := remotePackEncodedSize([]FileRef{file})
+		require.NoError(b, err)
+		b.ReportAllocs()
+		b.SetBytes(int64(size))
+		b.ResetTimer()
+		for b.Loop() {
+			body, _, buildErr := buildRemotePack(context.Background(), []FileRef{file}, nil)
+			if buildErr != nil {
+				b.Fatal(buildErr)
+			}
+			if int64(len(body)) != expectedSize {
+				b.Fatalf("unexpected pack size: got %d, want %d", len(body), expectedSize)
+			}
+			runtime.KeepAlive(body)
+		}
+	})
 }
 
 func TestRemoteSourceProcessingHonorsCancellation(t *testing.T) {

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -1203,6 +1203,68 @@ func TestValidateFilesRejectsUnsafeAndDuplicatePaths(t *testing.T) {
 	}))
 }
 
+func remotePackFixtureFile(tb testing.TB, size int) FileRef {
+	tb.Helper()
+	root := tb.TempDir()
+	data := bytes.Repeat([]byte{0x5a}, size)
+	filePath := filepath.Join(root, "save.dat")
+	require.NoError(tb, os.WriteFile(filePath, data, 0o600))
+	info, err := os.Stat(filePath)
+	require.NoError(tb, err)
+	sum := sha256.Sum256(data)
+	return FileRef{
+		sourceIdentity: &sourceIdentity{info: info},
+		SourceRoot:     root,
+		SourceRel:      "save.dat",
+		ArchivePath:    path.Join(filesRoot, CategorySaves, "save.dat"),
+		RestorePath:    "saves/save.dat",
+		Size:           int64(size),
+		SHA256:         hex.EncodeToString(sum[:]),
+	}
+}
+
+func TestBuildRemotePackStreamsIntoFinalBuffer(t *testing.T) {
+	t.Parallel()
+	file := remotePackFixtureFile(t, 2<<20)
+
+	body, packHash, err := buildRemotePack(context.Background(), []FileRef{file, file}, nil)
+	require.NoError(t, err)
+	expectedSize, err := remotePackEncodedSize([]FileRef{file})
+	require.NoError(t, err)
+	assert.Len(t, body, int(expectedSize))
+	assert.Equal(t, sha256Hex(body), packHash)
+
+	footerLength := int(binary.BigEndian.Uint32(body[len(body)-remotePackFooterTrailerSize:]))
+	footerStart := len(body) - remotePackFooterTrailerSize - footerLength
+	var footer []packFooterEntry
+	require.NoError(t, json.Unmarshal(body[footerStart:len(body)-remotePackFooterTrailerSize], &footer))
+	require.Len(t, footer, 1)
+	assert.Equal(t, packFooterEntry{Hash: file.SHA256, Offset: 0, Length: file.Size}, footer[0])
+}
+
+func BenchmarkRemoteBackup_BuildPack(b *testing.B) {
+	for _, size := range []int{8 << 20, 32 << 20} {
+		b.Run(fmt.Sprintf("%dMiB", size>>20), func(b *testing.B) {
+			file := remotePackFixtureFile(b, size)
+			expectedSize, err := remotePackEncodedSize([]FileRef{file})
+			require.NoError(b, err)
+			b.ReportAllocs()
+			b.SetBytes(int64(size))
+			b.ResetTimer()
+			for b.Loop() {
+				body, _, buildErr := buildRemotePack(context.Background(), []FileRef{file}, nil)
+				if buildErr != nil {
+					b.Fatal(buildErr)
+				}
+				if int64(len(body)) != expectedSize {
+					b.Fatalf("unexpected pack size: got %d, want %d", len(body), expectedSize)
+				}
+				runtime.KeepAlive(body)
+			}
+		})
+	}
+}
+
 func TestRemoteSourceProcessingHonorsCancellation(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -968,7 +968,7 @@ func TestOpenSourceRejectsSensitiveFileIdentity(t *testing.T) {
 	info, err := os.Stat(authPath)
 	require.NoError(t, err)
 	file := FileRef{
-		sourceIdentity: &sourceIdentity{info: info, excludedIdentities: []os.FileInfo{info}},
+		sourceIdentity: newSourceIdentity(info, []os.FileInfo{info}),
 		SourceRoot:     root, SourceRel: config.AuthFile, RestorePath: "mappings/leak.toml",
 	}
 
@@ -1213,7 +1213,7 @@ func remotePackFixtureFile(tb testing.TB, size int) FileRef {
 	require.NoError(tb, err)
 	sum := sha256.Sum256(data)
 	return FileRef{
-		sourceIdentity: &sourceIdentity{info: info},
+		sourceIdentity: newSourceIdentity(info, nil),
 		SourceRoot:     root,
 		SourceRel:      "save.dat",
 		ArchivePath:    filepath.ToSlash(filepath.Join(filesRoot, CategorySaves, "save.dat")),
@@ -1271,8 +1271,14 @@ func TestBuildRemotePackRejectsChangedSource(t *testing.T) {
 		{
 			name: "replaced after hashing",
 			mutate: func(tb testing.TB, filePath string, size int) {
-				require.NoError(tb, os.Remove(filePath))
-				require.NoError(tb, os.WriteFile(filePath, bytes.Repeat([]byte{0x5a}, size), 0o600))
+				// Rename a second file over the source rather than deleting and
+				// rewriting in place: the replacement is allocated while the
+				// original still exists, so it is guaranteed a distinct
+				// identity. Deleting first lets the filesystem hand the freed
+				// inode straight back, leaving the two indistinguishable.
+				replacement := filePath + ".replacement"
+				require.NoError(tb, os.WriteFile(replacement, bytes.Repeat([]byte{0x5a}, size), 0o600))
+				require.NoError(tb, os.Rename(replacement, filePath))
 			},
 		},
 	}
@@ -1350,7 +1356,7 @@ func TestRemoteSourceProcessingHonorsCancellation(t *testing.T) {
 	info, err := os.Stat(filePath)
 	require.NoError(t, err)
 	file := FileRef{
-		sourceIdentity: &sourceIdentity{info: info},
+		sourceIdentity: newSourceIdentity(info, nil),
 		SourceRoot:     root, SourceRel: "save.dat", Size: info.Size(), SHA256: strings.Repeat("0", 64),
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/service/backup/collector.go
+++ b/pkg/service/backup/collector.go
@@ -256,7 +256,7 @@ func sourceIdentities(paths map[string]struct{}) ([]os.FileInfo, error) {
 			return nil, fmt.Errorf("stating sensitive backup source: %w", err)
 		}
 		if info.Mode().IsRegular() {
-			identities = append(identities, info)
+			identities = append(identities, pinSourceIdentity(info))
 		}
 	}
 	return identities, nil
@@ -455,6 +455,22 @@ func trustedSource(target string, roots []string) (root, rel string, ok bool) {
 	return "", "", false
 }
 
+// pinSourceIdentity resolves the identity of a stat result so it stays bound to
+// the file that was stat'd. On Windows os.Stat records only the path and defers
+// the volume/file-index lookup to the first os.SameFile call, which re-opens
+// that path — so an unpinned identity silently follows whatever file later
+// occupies the path, and a swapped source compares equal. Comparing the info
+// against itself performs the lookup now. It is a no-op on other platforms,
+// where the device and inode are already captured.
+func pinSourceIdentity(info os.FileInfo) os.FileInfo {
+	_ = os.SameFile(info, info)
+	return info
+}
+
+func newSourceIdentity(info os.FileInfo, excluded []os.FileInfo) *sourceIdentity {
+	return &sourceIdentity{info: pinSourceIdentity(info), excludedIdentities: excluded}
+}
+
 func matchesSourceIdentity(info os.FileInfo, identities []os.FileInfo) bool {
 	for _, identity := range identities {
 		if os.SameFile(info, identity) {
@@ -501,7 +517,7 @@ func (c *sourceCollector) add(
 		return
 	}
 	c.appendFile(&FileRef{
-		sourceIdentity: &sourceIdentity{info: info, excludedIdentities: c.excludedIdentities},
+		sourceIdentity: newSourceIdentity(info, c.excludedIdentities),
 		SourceRoot:     sourceRoot,
 		SourceRel:      sourceRel,
 		ArchivePath:    filepath.ToSlash(spec.archive(restorePath)),
@@ -531,7 +547,7 @@ func (c *sourceCollector) addTrustedFile(
 	}
 	root := filepath.Dir(resolved)
 	c.appendFile(&FileRef{
-		sourceIdentity: &sourceIdentity{info: info},
+		sourceIdentity: newSourceIdentity(info, nil),
 		SourceRoot:     root,
 		SourceRel:      filepath.Base(resolved),
 		ArchivePath:    filepath.ToSlash(archivePath),

--- a/pkg/service/backup/remote.go
+++ b/pkg/service/backup/remote.go
@@ -2093,17 +2093,31 @@ func buildRemotePack(
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, "", fmt.Errorf("building remote backup pack: %w", ctxErr)
 	}
-	var buf bytes.Buffer
-	footer := make([]packFooterEntry, 0, len(files))
+	uniqueFiles := make([]FileRef, 0, len(files))
 	seen := make(map[string]struct{}, len(files))
 	for _, file := range files {
-		if waitErr := pauser.Wait(ctx); waitErr != nil {
-			return nil, "", fmt.Errorf("building remote backup pack: %w", waitErr)
-		}
 		if _, ok := seen[file.SHA256]; ok {
 			continue
 		}
 		seen[file.SHA256] = struct{}{}
+		uniqueFiles = append(uniqueFiles, file)
+	}
+	encodedSize, sizeErr := remotePackEncodedSize(uniqueFiles)
+	if sizeErr != nil {
+		return nil, "", sizeErr
+	}
+	if encodedSize > remoteMaxPackBytes {
+		return nil, "", fmt.Errorf("remote backup pack exceeds maximum size: %d bytes", encodedSize)
+	}
+	// Preallocate the final pack and stream sources into it so a large
+	// pack-of-one never creates a second full-file copy in memory.
+	var buf bytes.Buffer
+	buf.Grow(int(encodedSize))
+	footer := make([]packFooterEntry, 0, len(uniqueFiles))
+	for _, file := range uniqueFiles {
+		if waitErr := pauser.Wait(ctx); waitErr != nil {
+			return nil, "", fmt.Errorf("building remote backup pack: %w", waitErr)
+		}
 		opened, openErr := openSourceContext(ctx, &file)
 		if openErr != nil {
 			if errors.Is(openErr, errSourceIdentityChanged) {
@@ -2111,24 +2125,34 @@ func buildRemotePack(
 			}
 			return nil, "", openErr
 		}
-		payload, readErr := io.ReadAll(io.LimitReader(
-			&contextReader{ctx: ctx, reader: opened}, file.Size+1,
-		))
+
+		offset := int64(buf.Len())
+		hasher := sha256.New()
+		reader := &contextReader{ctx: ctx, reader: opened}
+		limited := &io.LimitedReader{R: reader, N: file.Size}
+		written, copyErr := io.Copy(io.MultiWriter(&buf, hasher), limited)
+		var extra [1]byte
+		var extraSize int
+		var extraErr error
+		if copyErr == nil && written == file.Size {
+			extraSize, extraErr = reader.Read(extra[:])
+		}
 		closeErr := opened.Close()
-		if readErr != nil {
-			return nil, "", fmt.Errorf("reading %s: %w", file.RestorePath, readErr)
+		if copyErr != nil {
+			return nil, "", fmt.Errorf("reading %s: %w", file.RestorePath, copyErr)
+		}
+		if extraErr != nil && !errors.Is(extraErr, io.EOF) {
+			return nil, "", fmt.Errorf("checking %s size: %w", file.RestorePath, extraErr)
 		}
 		if closeErr != nil {
 			return nil, "", fmt.Errorf("closing %s: %w", file.RestorePath, closeErr)
 		}
-		payloadHash := sha256.Sum256(payload)
-		if int64(len(payload)) != file.Size || hex.EncodeToString(payloadHash[:]) != file.SHA256 {
+		if written != file.Size || extraSize != 0 || hex.EncodeToString(hasher.Sum(nil)) != file.SHA256 {
 			return nil, "", fmt.Errorf("%w: source changed for %s", errRemoteIntegrityRetry, file.RestorePath)
 		}
 		footer = append(footer, packFooterEntry{
-			Hash: file.SHA256, Offset: int64(buf.Len()), Length: int64(len(payload)),
+			Hash: file.SHA256, Offset: offset, Length: written,
 		})
-		_, _ = buf.Write(payload)
 	}
 	footerData, err := json.Marshal(footer)
 	if err != nil {
@@ -2143,6 +2167,9 @@ func buildRemotePack(
 	binary.BigEndian.PutUint32(trailer[:], uint32(len(footerData)))
 	_, _ = buf.Write(trailer[:])
 	body = buf.Bytes()
+	if int64(len(body)) != encodedSize {
+		return nil, "", errors.New("remote backup pack size changed while building")
+	}
 	sum := sha256.Sum256(body)
 	return body, hex.EncodeToString(sum[:]), nil
 }

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -1385,6 +1385,8 @@ func showRemoteBackupRestoreConfirm(
 		"safety backup is created first.\n\n" +
 		"Core restarts after restore."
 	backupID := backup.ID
+	restoredLabel := "Restored backup from " + sourceName + ".\n" +
+		"Snapshot: " + formatBackupTime(backup.CreatedAt)
 	ShowConfirmModal(
 		pages, app,
 		message,
@@ -1399,10 +1401,10 @@ func showRemoteBackupRestoreConfirm(
 					if err := svc.RestoreRemoteBackup(ctx, backupID); err != nil {
 						return "", fmt.Errorf("restore cloud backup: %w", err)
 					}
-					return backupID, nil
+					return restoredLabel, nil
 				},
-				func(restoredLabel string) {
-					ShowInfoModal(pages, app, "Cloud backup restored", restoredLabel, func() {
+				func(label string) {
+					ShowInfoModal(pages, app, "Cloud backup restored", label, func() {
 						waitForCoreRestart(svc, pages, app, onRestored)
 					})
 				},

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -1640,6 +1640,9 @@ func TestRemoteBackupRestoreConfirm_WordingAndRestore_Integration(t *testing.T) 
 	// Confirm ("Yes" is focused first).
 	runner.SimulateEnter()
 	require.True(t, runner.WaitForText("Cloud backup restored", 2*time.Second))
+	assert.True(t, runner.ContainsText("Restored backup from Old MiSTer (unlinked)."))
+	assert.True(t, runner.ContainsText("Snapshot: 2026-07-10 12:00:00 UTC"))
+	assert.False(t, runner.ContainsText("backup-7"))
 	mockSvc.AssertCalled(t, "RestoreRemoteBackup", mock.Anything, "backup-7")
 }
 


### PR DESCRIPTION
## Summary

- stream cloud backup files directly into a preallocated final pack buffer
- validate encoded pack size and add allocation benchmarks
- replace internal restore IDs with source device and snapshot time in TUI feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cloud backup restoration messages to show the restored backup name and snapshot date.

* **Bug Fixes**
  * Cloud backup packs now handle duplicate files efficiently and verify content integrity during creation.
  * Restore confirmations no longer display an internal backup identifier.

* **Tests**
  * Added coverage and benchmarks for remote backup pack creation and restore confirmation messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->