### PR TITLE
fix(database): drain queries before swapping user database files

### DIFF
--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -44,6 +44,12 @@ const (
 	autoBackupKeep           = 3
 	databaseRenameAttempts   = 100
 	databaseRenameRetryDelay = 50 * time.Millisecond
+	// restoreRollbackSuffix names the copy of the live database kept while a
+	// replacement is installed, so an interrupted restore can be undone.
+	restoreRollbackSuffix = ".restore-rollback"
+	// restoreStagePattern matches the temporary files a restore stages the
+	// replacement into before installing it.
+	restoreStagePattern = ".userdb-restore-*"
 )
 
 func (db *UserDB) backupDir() string {
@@ -401,7 +407,7 @@ func renameDatabaseFileWithRetry(
 
 func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err error) {
 	dbDir := filepath.Dir(dbPath)
-	tmp, err := afero.TempFile(fs, dbDir, ".userdb-restore-*")
+	tmp, err := afero.TempFile(fs, dbDir, restoreStagePattern)
 	if err != nil {
 		return fmt.Errorf("failed to create staged restore file: %w", err)
 	}
@@ -416,7 +422,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 		return fmt.Errorf("failed to stage user database backup: %w", err)
 	}
 
-	rollbackPath := dbPath + ".restore-rollback"
+	rollbackPath := dbPath + restoreRollbackSuffix
 	_ = fs.Remove(rollbackPath)
 	if err = renameDatabaseFile(fs, dbPath, rollbackPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to preserve user database before restore: %w", err)
@@ -462,6 +468,64 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 		}
 	}
 	return nil
+}
+
+// recoverInterruptedRestore repairs the on-disk state left behind when the
+// process dies partway through replaceDatabaseFromBackup. That function renames
+// the live database aside before installing the replacement, and its error paths
+// are the only thing that ever puts it back — a crash in between leaves no
+// database at all, with the real data sitting under a name nothing else looks
+// for. Run this before opening, or a fresh empty database gets allocated over
+// the top and the user's mappings and history look lost.
+//
+// A rollback file alongside a database means the replacement was installed and
+// the rollback simply outlived its purpose; the pre-restore backup covers that
+// data, so it is dropped. A rollback file with no database means the restore
+// never completed, so the original goes back.
+func recoverInterruptedRestore(fs afero.Fs, dbPath string) {
+	dbDir := filepath.Dir(dbPath)
+	defer removeStagedRestoreFiles(fs, dbDir)
+
+	rollbackPath := dbPath + restoreRollbackSuffix
+	if _, err := fs.Stat(rollbackPath); err != nil {
+		return
+	}
+	if _, err := fs.Stat(dbPath); err == nil {
+		if removeErr := fs.Remove(rollbackPath); removeErr != nil {
+			log.Warn().Err(removeErr).Str("path", rollbackPath).
+				Msg("failed to remove stale user database rollback")
+		}
+		return
+	}
+
+	// The rollback still holds the live database from before the restore, and
+	// its sidecars were removed with it checkpointed, so it stands alone.
+	if err := renameDatabaseFile(fs, rollbackPath, dbPath); err != nil {
+		log.Error().Err(err).Str("path", rollbackPath).
+			Msg("failed to recover user database from interrupted restore")
+		return
+	}
+	if err := syncAferoDirectory(fs, dbDir); err != nil {
+		log.Warn().Err(err).Msg("failed to sync recovered user database")
+	}
+	log.Warn().Str("path", dbPath).Msg("recovered user database from interrupted restore")
+}
+
+// removeStagedRestoreFiles clears staging files an interrupted restore left
+// behind. They are complete copies of a backup, so they waste as much space as
+// the database itself until something removes them.
+func removeStagedRestoreFiles(fs afero.Fs, dbDir string) {
+	staged, err := afero.Glob(fs, filepath.Join(dbDir, restoreStagePattern))
+	if err != nil {
+		log.Warn().Err(err).Str("dir", dbDir).Msg("failed to list staged user database restores")
+		return
+	}
+	for _, path := range staged {
+		if removeErr := fs.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			log.Warn().Err(removeErr).Str("path", path).
+				Msg("failed to remove staged user database restore")
+		}
+	}
 }
 
 func restoreDatabaseRollback(fs afero.Fs, rollbackPath, dbPath string) error {
@@ -518,7 +582,13 @@ func (db *UserDB) RestoreBackup(name string) (database.RestoreInfo, error) {
 		}
 	}
 
-	if closeErr := db.Close(); closeErr != nil {
+	if closeErr := db.closeAndDrain(); closeErr != nil {
+		// Nothing on disk has been touched yet, so the restore can be refused
+		// outright. Put the connection back so the caller keeps a usable
+		// database rather than losing it to a restore that never started.
+		if openErr := db.Open(); openErr != nil {
+			log.Error().Err(openErr).Msg("failed to reopen user database after abandoned restore")
+		}
 		return database.RestoreInfo{}, closeErr
 	}
 	if err = replaceDatabaseFromBackup(afero.NewOsFs(), backupPath, db.GetDBPath()); err != nil {
@@ -566,7 +636,10 @@ func preserveCorruptFile(path string) {
 }
 
 func (db *UserDB) RecoverFromCorruption() (database.RestoreInfo, error) {
-	if err := db.Close(); err != nil {
+	// Recovery renames the database and its sidecars aside, so in-flight
+	// queries have to finish first. A drain failure is only logged: the
+	// database is already known bad and leaving it in place helps no one.
+	if err := db.closeAndDrain(); err != nil {
 		log.Warn().Err(err).Msg("error closing corrupt user database before recovery")
 	}
 	for _, path := range []string{db.GetDBPath(), db.GetDBPath() + "-wal", db.GetDBPath() + "-shm"} {

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -482,33 +482,37 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 // the rollback simply outlived its purpose; the pre-restore backup covers that
 // data, so it is dropped. A rollback file with no database means the restore
 // never completed, so the original goes back.
-func recoverInterruptedRestore(fs afero.Fs, dbPath string) {
+//
+// An error is returned only when that last case fails, because the rollback is
+// then the sole copy of the data and the caller must not carry on as if the
+// database were merely absent. Cleanup failures are logged instead: they cost
+// disk space, not data.
+func recoverInterruptedRestore(fs afero.Fs, dbPath string) error {
 	dbDir := filepath.Dir(dbPath)
 	defer removeStagedRestoreFiles(fs, dbDir)
 
 	rollbackPath := dbPath + restoreRollbackSuffix
 	if _, err := fs.Stat(rollbackPath); err != nil {
-		return
+		return nil
 	}
 	if _, err := fs.Stat(dbPath); err == nil {
 		if removeErr := fs.Remove(rollbackPath); removeErr != nil {
 			log.Warn().Err(removeErr).Str("path", rollbackPath).
 				Msg("failed to remove stale user database rollback")
 		}
-		return
+		return nil
 	}
 
 	// The rollback still holds the live database from before the restore, and
 	// its sidecars were removed with it checkpointed, so it stands alone.
 	if err := renameDatabaseFile(fs, rollbackPath, dbPath); err != nil {
-		log.Error().Err(err).Str("path", rollbackPath).
-			Msg("failed to recover user database from interrupted restore")
-		return
+		return fmt.Errorf("failed to recover user database from interrupted restore: %w", err)
 	}
 	if err := syncAferoDirectory(fs, dbDir); err != nil {
 		log.Warn().Err(err).Msg("failed to sync recovered user database")
 	}
 	log.Warn().Str("path", dbPath).Msg("recovered user database from interrupted restore")
+	return nil
 }
 
 // removeStagedRestoreFiles clears staging files an interrupted restore left
@@ -588,6 +592,13 @@ func (db *UserDB) RestoreBackup(name string) (database.RestoreInfo, error) {
 		// database rather than losing it to a restore that never started.
 		if openErr := db.Open(); openErr != nil {
 			log.Error().Err(openErr).Msg("failed to reopen user database after abandoned restore")
+			// Joined rather than dropped: a refused restore leaves the database
+			// working, but one that also failed to reopen does not, and the
+			// caller has to be able to tell those apart.
+			return database.RestoreInfo{}, errors.Join(
+				closeErr,
+				fmt.Errorf("failed to reopen user database after abandoned restore: %w", openErr),
+			)
 		}
 		return database.RestoreInfo{}, closeErr
 	}

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,13 @@ type transientRenameFs struct {
 	attempts int
 }
 
+// failRemoveFs refuses to unlink one named file, standing in for a file that
+// cannot be removed because of permissions or an open handle on Windows.
+type failRemoveFs struct {
+	afero.Fs
+	failBase string
+}
+
 func (fs *transientRenameFs) Rename(oldPath, newPath string) error {
 	fs.attempts++
 	if fs.attempts <= fs.failures {
@@ -106,6 +114,16 @@ func (fs failStagedInstallFs) Rename(oldPath, newPath string) error {
 	}
 	if err := fs.Fs.Rename(oldPath, newPath); err != nil {
 		return fmt.Errorf("rename test path: %w", err)
+	}
+	return nil
+}
+
+func (fs failRemoveFs) Remove(name string) error {
+	if filepath.Base(name) == fs.failBase {
+		return errors.New("injected remove failure")
+	}
+	if err := fs.Fs.Remove(name); err != nil {
+		return fmt.Errorf("remove test path: %w", err)
 	}
 	return nil
 }
@@ -646,6 +664,31 @@ func TestUserDBCloseAndDrainSucceedsWhenIdle(t *testing.T) {
 	require.NoError(t, userDB.Open())
 }
 
+// A UserDB whose Open failed before a connection was stored still reaches
+// closeAndDrain through RecoverFromCorruption, so there is nothing to drain and
+// nothing to dereference.
+func TestUserDBCloseAndDrainWithoutConnection(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, (&UserDB{}).closeAndDrain())
+}
+
+// A pool that will not close leaves the connection state unknown, so the caller
+// has to see the failure rather than go on to swap the files underneath it.
+func TestUserDBCloseAndDrainReportsCloseFailure(t *testing.T) {
+	t.Parallel()
+
+	sqlDB, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	closeErr := errors.New("driver refused to close")
+	mock.ExpectClose().WillReturnError(closeErr)
+
+	userDB := &UserDB{}
+	userDB.sql.Store(sqlDB)
+
+	require.ErrorIs(t, userDB.closeAndDrain(), closeErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestRecoverInterruptedRestore(t *testing.T) {
 	t.Parallel()
 
@@ -695,7 +738,7 @@ func TestRecoverInterruptedRestore(t *testing.T) {
 				))
 			}
 
-			recoverInterruptedRestore(fs, dbPath)
+			require.NoError(t, recoverInterruptedRestore(fs, dbPath))
 
 			got, err := afero.ReadFile(fs, dbPath)
 			require.NoError(t, err)
@@ -717,7 +760,7 @@ func TestRecoverInterruptedRestoreRemovesStagedFiles(t *testing.T) {
 	staged := filepath.Join(dbDir, ".userdb-restore-123456")
 	require.NoError(t, afero.WriteFile(fs, staged, []byte("staged"), 0o600))
 
-	recoverInterruptedRestore(fs, dbPath)
+	require.NoError(t, recoverInterruptedRestore(fs, dbPath))
 
 	exists, err := afero.Exists(fs, staged)
 	require.NoError(t, err)
@@ -725,6 +768,101 @@ func TestRecoverInterruptedRestoreRemovesStagedFiles(t *testing.T) {
 	dbExists, err := afero.Exists(fs, dbPath)
 	require.NoError(t, err)
 	assert.True(t, dbExists, "database must survive staged cleanup")
+}
+
+// TestRecoverInterruptedRestoreRetainsRollbackWhenRenameFails covers what
+// happens when recovery itself cannot complete. The rollback is the only copy
+// of the user's data at that point, so it has to be left where it is and the
+// failure reported, rather than the caller carrying on as if the database were
+// simply absent.
+func TestRecoverInterruptedRestoreRetainsRollbackWhenRenameFails(t *testing.T) {
+	t.Parallel()
+
+	base := afero.NewMemMapFs()
+	dbDir := filepath.Join("data", "zaparoo")
+	require.NoError(t, base.MkdirAll(dbDir, 0o750))
+	dbPath := filepath.Join(dbDir, "user.db")
+	rollbackPath := dbPath + restoreRollbackSuffix
+	require.NoError(t, afero.WriteFile(base, rollbackPath, []byte("original"), 0o600))
+
+	fs := failStagedInstallFs{Fs: base, dbPath: dbPath, failRollback: true}
+	err := recoverInterruptedRestore(fs, dbPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to recover user database from interrupted restore")
+
+	contents, err := afero.ReadFile(fs, rollbackPath)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(contents), "rollback must survive so recovery can be retried")
+	dbExists, err := afero.Exists(fs, dbPath)
+	require.NoError(t, err)
+	assert.False(t, dbExists, "no half-recovered database should be left behind")
+}
+
+// TestRecoverInterruptedRestoreKeepsDatabaseWhenStaleRollbackRemoveFails checks
+// the other direction: the restore did finish, so the rollback is only clutter.
+// Failing to delete it must not disturb the installed database.
+func TestRecoverInterruptedRestoreKeepsDatabaseWhenStaleRollbackRemoveFails(t *testing.T) {
+	t.Parallel()
+
+	base := afero.NewMemMapFs()
+	dbDir := filepath.Join("data", "zaparoo")
+	require.NoError(t, base.MkdirAll(dbDir, 0o750))
+	dbPath := filepath.Join(dbDir, "user.db")
+	rollbackPath := dbPath + restoreRollbackSuffix
+	require.NoError(t, afero.WriteFile(base, dbPath, []byte("installed"), 0o600))
+	require.NoError(t, afero.WriteFile(base, rollbackPath, []byte("original"), 0o600))
+
+	fs := failRemoveFs{Fs: base, failBase: filepath.Base(rollbackPath)}
+	require.NoError(t, recoverInterruptedRestore(fs, dbPath))
+
+	contents, err := afero.ReadFile(fs, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, "installed", string(contents))
+}
+
+// TestRecoverInterruptedRestoreKeepsDatabaseWhenSyncFails pins the ordering:
+// the rename is what recovers the data and the directory sync only makes it
+// durable, so a sync failure is reported but must not cost the recovery.
+func TestRecoverInterruptedRestoreKeepsDatabaseWhenSyncFails(t *testing.T) {
+	t.Parallel()
+
+	base := afero.NewMemMapFs()
+	dbDir := filepath.Join("data", "zaparoo")
+	require.NoError(t, base.MkdirAll(dbDir, 0o750))
+	dbPath := filepath.Join(dbDir, "user.db")
+	require.NoError(t, afero.WriteFile(base, dbPath+restoreRollbackSuffix, []byte("original"), 0o600))
+
+	fs := &failDirectorySyncFs{Fs: base, dir: dbDir, failAt: 1}
+	require.NoError(t, recoverInterruptedRestore(fs, dbPath))
+
+	contents, err := afero.ReadFile(fs, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, "original", string(contents))
+}
+
+// TestRemoveStagedRestoreFilesContinuesAfterFailure guards the loop: staged
+// files are full copies of the database, so one that cannot be removed must not
+// leave the rest sitting on disk consuming space.
+func TestRemoveStagedRestoreFilesContinuesAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	base := afero.NewMemMapFs()
+	dbDir := filepath.Join("data", "zaparoo")
+	require.NoError(t, base.MkdirAll(dbDir, 0o750))
+	stuck := filepath.Join(dbDir, ".userdb-restore-stuck")
+	other := filepath.Join(dbDir, ".userdb-restore-other")
+	require.NoError(t, afero.WriteFile(base, stuck, []byte("staged"), 0o600))
+	require.NoError(t, afero.WriteFile(base, other, []byte("staged"), 0o600))
+
+	fs := failRemoveFs{Fs: base, failBase: filepath.Base(stuck)}
+	removeStagedRestoreFiles(fs, dbDir)
+
+	stuckExists, err := afero.Exists(fs, stuck)
+	require.NoError(t, err)
+	assert.True(t, stuckExists)
+	otherExists, err := afero.Exists(fs, other)
+	require.NoError(t, err)
+	assert.False(t, otherExists, "a file that cannot be removed must not stop the rest")
 }
 
 // TestUserDBOpenRecoversInterruptedRestore is the failure this protects against:
@@ -757,4 +895,42 @@ func TestUserDBOpenRecoversInterruptedRestore(t *testing.T) {
 	require.Len(t, mappings, 1)
 	assert.Equal(t, "Survivor", mappings[0].Label)
 	assert.NoFileExists(t, dbPath+restoreRollbackSuffix)
+}
+
+// TestUserDBOpenRefusesWhenRecoveryFails closes the loop on the worst outcome.
+// Allocating a fresh schema when recovery fails does not just lose this open:
+// the empty database sitting beside the rollback makes the next open read the
+// state as a finished restore, and the rollback — still the only copy of the
+// data — gets deleted as leftovers. Failing the open keeps it recoverable.
+func TestUserDBOpenRefusesWhenRecoveryFails(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	require.NoError(t, userDB.AddMapping(&database.Mapping{
+		Label:    "Survivor",
+		Enabled:  true,
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "survivor-token",
+		Override: "**launch.system:n64",
+	}))
+
+	dbPath := userDB.GetDBPath()
+	require.NoError(t, userDB.closeAndDrain())
+	require.NoError(t, os.Rename(dbPath, dbPath+restoreRollbackSuffix))
+	userDB.fs = failStagedInstallFs{Fs: afero.NewOsFs(), dbPath: dbPath, failRollback: true}
+
+	err := userDB.Open()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to recover user database from interrupted restore")
+	assert.NoFileExists(t, dbPath, "a fresh database would strand the rollback")
+	assert.FileExists(t, dbPath+restoreRollbackSuffix)
+
+	// With the fault removed the data comes back, which is what refusing bought.
+	userDB.fs = nil
+	require.NoError(t, userDB.Open())
+	mappings, err := userDB.GetAllMappings()
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, "Survivor", mappings[0].Label)
 }

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -593,3 +593,168 @@ func TestUserDBRestoreConcurrentReaders(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, mappings, 1)
 }
+
+// TestUserDBRestoreRefusesWhileQueriesInFlight covers the crash that motivated
+// closeAndDrain: sql.DB.Close leaves a checked-out connection running, and
+// replacing the database files under it faults the process rather than failing
+// the query. The restore must refuse instead, leaving disk and connection intact.
+func TestUserDBRestoreRefusesWhileQueriesInFlight(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+	userDB.drainTimeout = 50 * time.Millisecond
+
+	require.NoError(t, userDB.AddMapping(&database.Mapping{
+		Label:    "Original",
+		Enabled:  true,
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "original-token",
+		Override: "**launch.system:n64",
+	}))
+	backup, err := userDB.Backup("test", true)
+	require.NoError(t, err)
+
+	// An open transaction holds a connection checked out, which is what an
+	// in-flight query looks like to the pool.
+	tx, err := userDB.sql.Load().BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	_, restoreErr := userDB.RestoreBackup(backup.Name)
+	require.ErrorIs(t, restoreErr, ErrConnDrainTimeout)
+
+	require.NoError(t, tx.Rollback())
+
+	// No file was touched, so nothing needs rolling back.
+	dbPath := userDB.GetDBPath()
+	assert.NoFileExists(t, dbPath+restoreRollbackSuffix)
+	assert.FileExists(t, dbPath)
+
+	// The connection was put back, so the database is still usable.
+	mappings, err := userDB.GetAllMappings()
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, "Original", mappings[0].Label)
+}
+
+func TestUserDBCloseAndDrainSucceedsWhenIdle(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	_, err := userDB.GetAllMappings()
+	require.NoError(t, err)
+	require.NoError(t, userDB.closeAndDrain())
+	require.NoError(t, userDB.Open())
+}
+
+func TestRecoverInterruptedRestore(t *testing.T) {
+	t.Parallel()
+
+	const (
+		originalData  = "original-database"
+		installedData = "installed-database"
+	)
+
+	tests := []struct {
+		name          string
+		dbContent     string
+		rollback      string
+		wantDBContent string
+		wantRollback  bool
+	}{
+		{
+			name:          "rollback without database restores original",
+			rollback:      originalData,
+			wantDBContent: originalData,
+		},
+		{
+			name:          "rollback beside database is discarded",
+			dbContent:     installedData,
+			rollback:      originalData,
+			wantDBContent: installedData,
+		},
+		{
+			name:          "database without rollback is left alone",
+			dbContent:     installedData,
+			wantDBContent: installedData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fs := afero.NewMemMapFs()
+			dbDir := filepath.Join("data", "zaparoo")
+			require.NoError(t, fs.MkdirAll(dbDir, 0o750))
+			dbPath := filepath.Join(dbDir, "user.db")
+			if tt.dbContent != "" {
+				require.NoError(t, afero.WriteFile(fs, dbPath, []byte(tt.dbContent), 0o600))
+			}
+			if tt.rollback != "" {
+				require.NoError(t, afero.WriteFile(
+					fs, dbPath+restoreRollbackSuffix, []byte(tt.rollback), 0o600,
+				))
+			}
+
+			recoverInterruptedRestore(fs, dbPath)
+
+			got, err := afero.ReadFile(fs, dbPath)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDBContent, string(got))
+			exists, err := afero.Exists(fs, dbPath+restoreRollbackSuffix)
+			require.NoError(t, err)
+			assert.False(t, exists, "rollback file should not survive recovery")
+		})
+	}
+}
+
+func TestRecoverInterruptedRestoreRemovesStagedFiles(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	dbDir := filepath.Join("data", "zaparoo")
+	require.NoError(t, fs.MkdirAll(dbDir, 0o750))
+	dbPath := filepath.Join(dbDir, "user.db")
+	require.NoError(t, afero.WriteFile(fs, dbPath, []byte("db"), 0o600))
+	staged := filepath.Join(dbDir, ".userdb-restore-123456")
+	require.NoError(t, afero.WriteFile(fs, staged, []byte("staged"), 0o600))
+
+	recoverInterruptedRestore(fs, dbPath)
+
+	exists, err := afero.Exists(fs, staged)
+	require.NoError(t, err)
+	assert.False(t, exists, "staged restore file should be removed")
+	dbExists, err := afero.Exists(fs, dbPath)
+	require.NoError(t, err)
+	assert.True(t, dbExists, "database must survive staged cleanup")
+}
+
+// TestUserDBOpenRecoversInterruptedRestore is the failure this protects against:
+// without recovery, Open sees no database file and allocates an empty one, so a
+// crash mid-restore reads to the user as a wiped database.
+func TestUserDBOpenRecoversInterruptedRestore(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	require.NoError(t, userDB.AddMapping(&database.Mapping{
+		Label:    "Survivor",
+		Enabled:  true,
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "survivor-token",
+		Override: "**launch.system:n64",
+	}))
+
+	dbPath := userDB.GetDBPath()
+	require.NoError(t, userDB.closeAndDrain())
+	// The state a crash between preserving the original and installing the
+	// replacement leaves behind.
+	require.NoError(t, os.Rename(dbPath, dbPath+restoreRollbackSuffix))
+	require.NoFileExists(t, dbPath)
+
+	require.NoError(t, userDB.Open())
+
+	mappings, err := userDB.GetAllMappings()
+	require.NoError(t, err)
+	require.Len(t, mappings, 1)
+	assert.Equal(t, "Survivor", mappings[0].Label)
+	assert.NoFileExists(t, dbPath+restoreRollbackSuffix)
+}

--- a/pkg/database/userdb/userdb.go
+++ b/pkg/database/userdb/userdb.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 var ErrNullSQL = errors.New("UserDB is not connected")
@@ -41,11 +42,25 @@ var ErrNullSQL = errors.New("UserDB is not connected")
 const sqliteConnParams = "?_journal_mode=WAL&_synchronous=FULL&_busy_timeout=5000" +
 	"&_cache_size=-512&_mmap_size=0"
 
+const (
+	// connDrainTimeout bounds the wait for in-flight queries before an
+	// operation that replaces the database files gives up.
+	connDrainTimeout = 10 * time.Second
+	connDrainPoll    = 2 * time.Millisecond
+)
+
+// ErrConnDrainTimeout is returned when queries are still running after the
+// connection pool has been closed and the drain deadline has passed.
+var ErrConnDrainTimeout = errors.New("timed out waiting for user database queries to finish")
+
 type UserDB struct {
 	pl     platforms.Platform
 	ctx    context.Context
 	sql    database.Conn
 	dbPath string
+	// drainTimeout overrides how long closeAndDrain waits; zero uses
+	// connDrainTimeout. Set only by tests to avoid multi-second waits.
+	drainTimeout time.Duration
 }
 
 func OpenUserDB(ctx context.Context, pl platforms.Platform) (*UserDB, error) {
@@ -58,6 +73,9 @@ func (db *UserDB) Open() error {
 	exists := true
 	dbPath := db.GetDBPath()
 	db.dbPath = dbPath
+	// Must run before the existence check below, which decides whether to
+	// allocate a fresh schema over the top of a recoverable database.
+	recoverInterruptedRestore(afero.NewOsFs(), dbPath)
 	log.Debug().Str("path", dbPath).Msg("checking if database file exists")
 
 	_, err := os.Stat(dbPath)
@@ -158,6 +176,44 @@ func (db *UserDB) Close() error {
 		return fmt.Errorf("failed to close database: %w", err)
 	}
 	return nil
+}
+
+// closeAndDrain closes the connection pool and waits for queries that had
+// already started to finish.
+//
+// sql.DB.Close only closes the connections sitting idle in the pool: one
+// checked out by a running query is closed when it is returned, and Close does
+// not wait for that. Anything that then replaces or unlinks the database files
+// would be pulling them out from under a live sqlite3_step. SQLite memory-maps
+// the WAL index regardless of _mmap_size, and faulting on a mapping that is no
+// longer backed raises SIGBUS, killing the process instead of failing the
+// query — so this must complete before any file is touched.
+//
+// The pool is closed first so no further queries can start. On timeout the
+// caller is expected to reopen; the database is left closed.
+func (db *UserDB) closeAndDrain() error {
+	sqlInstance := db.sql.Load()
+	if sqlInstance == nil {
+		return nil
+	}
+	if err := sqlInstance.Close(); err != nil {
+		return fmt.Errorf("failed to close database: %w", err)
+	}
+	timeout := db.drainTimeout
+	if timeout <= 0 {
+		timeout = connDrainTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		inUse := sqlInstance.Stats().InUse
+		if inUse == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%w: %d still running", ErrConnDrainTimeout, inUse)
+		}
+		time.Sleep(connDrainPoll)
+	}
 }
 
 // SetSQLForTesting allows injection of a sql.DB instance for testing purposes.

--- a/pkg/database/userdb/userdb.go
+++ b/pkg/database/userdb/userdb.go
@@ -54,13 +54,23 @@ const (
 var ErrConnDrainTimeout = errors.New("timed out waiting for user database queries to finish")
 
 type UserDB struct {
-	pl     platforms.Platform
-	ctx    context.Context
+	pl  platforms.Platform
+	ctx context.Context
+	// fs overrides the filesystem used to recover an interrupted restore; nil
+	// uses the OS filesystem. Set only by tests to inject failures.
+	fs     afero.Fs
 	sql    database.Conn
 	dbPath string
 	// drainTimeout overrides how long closeAndDrain waits; zero uses
 	// connDrainTimeout. Set only by tests to avoid multi-second waits.
 	drainTimeout time.Duration
+}
+
+func (db *UserDB) recoveryFs() afero.Fs {
+	if db.fs != nil {
+		return db.fs
+	}
+	return afero.NewOsFs()
 }
 
 func OpenUserDB(ctx context.Context, pl platforms.Platform) (*UserDB, error) {
@@ -74,8 +84,13 @@ func (db *UserDB) Open() error {
 	dbPath := db.GetDBPath()
 	db.dbPath = dbPath
 	// Must run before the existence check below, which decides whether to
-	// allocate a fresh schema over the top of a recoverable database.
-	recoverInterruptedRestore(afero.NewOsFs(), dbPath)
+	// allocate a fresh schema over the top of a recoverable database. Refusing
+	// to open is the safe outcome when recovery fails: the rollback file still
+	// holds the only copy of the data, and a fresh database beside it would
+	// look like a completed restore to the next open, which discards it.
+	if err := recoverInterruptedRestore(db.recoveryFs(), dbPath); err != nil {
+		return err
+	}
 	log.Debug().Str("path", dbPath).Msg("checking if database file exists")
 
 	_, err := os.Stat(dbPath)


### PR DESCRIPTION
Fixes the `SIGBUS` crash that killed the test binary on macOS CI in [run 30442786230](https://github.com/ZaparooProject/zaparoo-core/actions/runs/30442786230/job/90545807381), and the data-loss window behind it.

## The crash

`RestoreBackup` and `RecoverFromCorruption` both call `Close`, then rename the database aside and unlink its sidecars. `sql.DB.Close` only closes the connections sitting idle in `db.freeConn` — one checked out by a running query is closed when it is returned to the pool, and `Close` returns without waiting. UserDB has no query-serializing lock (`GetAllMappings` is `db.sql.Load()` plus a query), so nothing stopped SQLite from reading files that were being moved out from under it.

That does not surface as a query error. SQLite memory-maps the WAL index regardless of `_mmap_size=0`, and faulting on a mapping that is no longer backed raises `SIGBUS`, taking the process down:

```
SIGBUS: bus error
signal arrived during cgo execution

github.com/mattn/go-sqlite3._Cfunc__sqlite3_step_row_internal(...)
userdb.sqlAddMediaHistory(...)  pkg/database/userdb/media_history.go:174
userdb.TestUserDBRestoreConcurrentReaders.func1()  pkg/database/userdb/backup_test.go:573
```

`closeAndDrain` closes the pool so no further query can start, then waits for the checked-out connections to come back before any file is touched. A restore that cannot drain within the timeout is refused while disk is still untouched, and the connection is reopened so the caller keeps a usable database. Corruption recovery only logs a drain failure — that database is already known bad.

## The data loss

The crash is worse than a crash because of where it lands. `replaceDatabaseFromBackup` renames `user.db` to `.restore-rollback`, fsyncs the directory, removes the sidecars, then renames the staged copy into place. The rollback is only ever consulted by that function's own error paths — nothing looks for it at startup. A hard crash in that window therefore left no `user.db`, the real data under a name nothing reads, and a leftover staging copy whose cleanup `defer` never ran. The next open saw no database, allocated a fresh schema, and the user's mappings and history read as wiped.

`Open` now runs `recoverInterruptedRestore` first, before the existence check that drives schema allocation:

- rollback present, no database — the restore never completed, so the original goes back
- rollback present alongside a database — the replacement was installed, so the rollback is dropped (the pre-restore backup covers that data)
- staged `.userdb-restore-*` files are cleared either way

Restoring the rollback is safe because the drain now guarantees the pool closed cleanly first, which checkpoints the WAL into the main database.

## Notes

`RemoveSidecars` entered the restore path in #1091, which is unreleased — this has not shipped in a stable build. The underlying no-drain hazard has been present since v2.15.0.

I could not execute the macOS tests locally, so the SIGBUS itself is not something I can reproduce on this machine; the reasoning above is from the crash stack and the Go and SQLite source. The new tests cover the drain refusal and the rollback recovery on all platforms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database restore reliability after crashes and interrupted operations, including automatic cleanup of incomplete staged restore files and stale rollback artifacts.
  * Restores and corruption recovery now “close-and-drain” active database usage; if queries are still running, restore is refused with `ErrConnDrainTimeout` and the database remains usable.
  * Added clearer recovery behavior to ensure the correct database state is reinstated during interrupted restore scenarios.
* **Tests**
  * Expanded coverage for interrupted restore recovery, drain timeout refusal, and staged/rollback cleanup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->