### PR TITLE
fix(audio): make playback callbacks lock-free

### DIFF
--- a/pkg/audio/audio.go
+++ b/pkg/audio/audio.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/gopxl/beep/v2"
@@ -227,16 +228,13 @@ type oneshotSource struct {
 	samples [][2]float64
 	pos     int
 	volume  float64
-	mu      syncutil.Mutex
-	stopped bool
+	stopped atomic.Bool
 }
 
 // mixAdd sums up to n frames from the buffer into buf. Returns drained when exhausted.
-// Called on the malgo audio thread under devMu — must not block or alloc.
+// Called on the malgo realtime thread and performs no blocking synchronization.
 func (s *oneshotSource) mixAdd(buf [][2]float64, n int) (int, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.stopped {
+	if s.stopped.Load() {
 		return 0, true
 	}
 	written := 0
@@ -249,16 +247,14 @@ func (s *oneshotSource) mixAdd(buf [][2]float64, n int) (int, bool) {
 	return written, s.pos >= len(s.samples)
 }
 
-// isActive always returns true: one-shot sources are active until drained or cancelled.
-func (*oneshotSource) isActive() bool {
-	return true
+// isActive returns false once cancellation makes the source drain immediately.
+func (s *oneshotSource) isActive() bool {
+	return !s.stopped.Load()
 }
 
 // cancel marks the source as stopped so it drains immediately on the next callback.
 func (s *oneshotSource) cancel() {
-	s.mu.Lock()
-	s.stopped = true
-	s.mu.Unlock()
+	s.stopped.Store(true)
 }
 
 // onDrained implements the optional drainCallback interface used by the device manager.

--- a/pkg/audio/device.go
+++ b/pkg/audio/device.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/binary"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -41,38 +42,58 @@ type mixSource interface {
 	isActive() bool
 }
 
+type mixSourceEntry struct {
+	source  mixSource
+	drained atomic.Bool
+}
+
+type mixSourceList []*mixSourceEntry
+
 // sharedDevice is a single on-demand malgo output device shared by all audio sources.
 // It opens when the first source registers, mixes all sources in the audio callback,
 // and releases when all sources finish or are explicitly closed.
 // This prevents concurrent ALSA device opens, which crash miniaudio on MiSTer.
 //
-// Lock order: devMu → individual source locks.
+// Control paths serialize mutations with devMu, then publish an immutable source
+// snapshot. The realtime callback only reads that snapshot and never takes devMu.
 type sharedDevice struct {
-	// initContext overrides malgo.InitContext in tests; nil means the real one.
-	initContext func([]malgo.Backend, malgo.ContextConfig, malgo.LogProc) (*malgo.AllocatedContext, error)
-	malgoCtx    *malgo.AllocatedContext
-	device      *malgo.Device
-	cancelFn    context.CancelFunc
-	devDone     chan struct{}
-	prevDone    <-chan struct{}
-	manageCh    chan struct{}
-	sources     []mixSource
-	toRemove    []mixSource
-	mixBuf      [][2]float64
-	devMu       syncutil.Mutex
-	opening     bool
+	initContext  func([]malgo.Backend, malgo.ContextConfig, malgo.LogProc) (*malgo.AllocatedContext, error)
+	malgoCtx     *malgo.AllocatedContext
+	device       *malgo.Device
+	cancelFn     context.CancelFunc
+	devDone      chan struct{}
+	prevDone     <-chan struct{}
+	sourceView   atomic.Pointer[mixSourceList]
+	sources      []*mixSourceEntry
+	mixBuf       [][2]float64
+	devMu        syncutil.Mutex
+	drainPending atomic.Bool
+	opening      bool
+}
+
+func newSharedDevice() *sharedDevice {
+	d := &sharedDevice{}
+	d.publishSourcesLocked()
+	return d
+}
+
+// publishSourcesLocked replaces the callback's immutable source snapshot.
+// Caller must hold devMu unless the device has not yet been published.
+func (d *sharedDevice) publishSourcesLocked() {
+	view := make(mixSourceList, len(d.sources))
+	copy(view, d.sources)
+	d.sourceView.Store(&view)
 }
 
 // globalDevice is the process-wide audio output device shared by all players.
-var globalDevice = &sharedDevice{
-	manageCh: make(chan struct{}, 1),
-}
+var globalDevice = newSharedDevice()
 
 // register adds src and opens the device if not already open.
 // Safe to call concurrently.
 func (d *sharedDevice) register(src mixSource) {
 	d.devMu.Lock()
-	d.sources = append(d.sources, src)
+	d.sources = append(d.sources, &mixSourceEntry{source: src})
+	d.publishSourcesLocked()
 	needOpen := src.isActive() && !d.opening && d.device == nil
 	if needOpen {
 		d.opening = true
@@ -87,18 +108,24 @@ func (d *sharedDevice) register(src mixSource) {
 // deregister removes src and closes the device when no sources remain.
 func (d *sharedDevice) deregister(src mixSource) {
 	d.devMu.Lock()
-	for i, s := range d.sources {
-		if s == src {
-			d.sources = append(d.sources[:i], d.sources[i+1:]...)
-			break
-		}
-	}
+	removed := d.removeSourceLocked(src)
 	empty := len(d.sources) == 0
 	d.devMu.Unlock()
 
-	if empty {
+	if removed && empty {
 		d.closeDevice()
 	}
+}
+
+func (d *sharedDevice) removeSourceLocked(src mixSource) bool {
+	for i, candidate := range d.sources {
+		if candidate.source == src {
+			d.sources = append(d.sources[:i], d.sources[i+1:]...)
+			d.publishSourcesLocked()
+			return true
+		}
+	}
+	return false
 }
 
 // releaseIfAllPaused closes the device when no source is currently active.
@@ -109,8 +136,8 @@ func (d *sharedDevice) releaseIfAllPaused() {
 		d.devMu.Unlock()
 		return
 	}
-	for _, s := range d.sources {
-		if s.isActive() {
+	for _, entry := range d.sources {
+		if entry.source.isActive() {
 			d.devMu.Unlock()
 			return
 		}
@@ -119,9 +146,9 @@ func (d *sharedDevice) releaseIfAllPaused() {
 	d.closeDevice()
 }
 
-func hasActiveSource(sources []mixSource) bool {
-	for _, src := range sources {
-		if src.isActive() {
+func hasActiveSource(sources []*mixSourceEntry) bool {
+	for _, entry := range sources {
+		if entry.source.isActive() {
 			return true
 		}
 	}
@@ -168,8 +195,11 @@ func (d *sharedDevice) closeDevice() {
 func (d *sharedDevice) failAllSources() {
 	d.devMu.Lock()
 	srcs := make([]mixSource, len(d.sources))
-	copy(srcs, d.sources)
+	for i, entry := range d.sources {
+		srcs[i] = entry.source
+	}
 	d.sources = d.sources[:0]
+	d.publishSourcesLocked()
 	d.opening = false
 	d.devMu.Unlock()
 
@@ -249,7 +279,6 @@ func (d *sharedDevice) open() {
 	d.devDone = done
 	d.prevDone = done // next open waits for this one
 	d.mixBuf = mixBuf
-	d.toRemove = d.toRemove[:0]
 	d.devMu.Unlock()
 
 	// F32 format, stereo, fixed sample rate with MiSTer-tuned period settings.
@@ -291,8 +320,8 @@ func (d *sharedDevice) open() {
 	go d.manage(ctx, device, malgoCtx, done)
 }
 
-// manage runs while the device is open. It drains source-removal notifications from
-// the audio callback and shuts down the device when all sources finish or ctx is cancelled.
+// manage runs while the device is open. It removes sources marked drained by
+// the callback and shuts down the device when all sources finish or ctx is cancelled.
 func (d *sharedDevice) manage(
 	ctx context.Context,
 	device *malgo.Device,
@@ -300,32 +329,44 @@ func (d *sharedDevice) manage(
 	done chan struct{},
 ) {
 	defer d.cleanup(done, malgoCtx, device)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-d.manageCh:
-			d.devMu.Lock()
-			for _, s := range d.toRemove {
-				for i, src := range d.sources {
-					if src == s {
-						d.sources = append(d.sources[:i], d.sources[i+1:]...)
-						// Notify the source asynchronously so it can do blocking work.
-						go func(drainedSrc mixSource) {
-							if cb, ok := drainedSrc.(interface{ onDrained() }); ok {
-								cb.onDrained()
-							}
-						}(s)
-						break
-					}
-				}
+		case <-ticker.C:
+			if !d.drainPending.Swap(false) {
+				continue
 			}
-			d.toRemove = d.toRemove[:0]
+			d.devMu.Lock()
+			drained := make([]mixSource, 0, len(d.sources))
+			remaining := d.sources[:0]
+			for _, entry := range d.sources {
+				if entry.drained.Load() {
+					drained = append(drained, entry.source)
+					continue
+				}
+				remaining = append(remaining, entry)
+			}
+			if len(drained) > 0 {
+				d.sources = remaining
+				d.publishSourcesLocked()
+			}
 			empty := len(d.sources) == 0
 			d.devMu.Unlock()
 
-			if empty {
+			for _, src := range drained {
+				// Notify asynchronously because source cleanup may block on decoder I/O.
+				go func(drainedSrc mixSource) {
+					if cb, ok := drainedSrc.(interface{ onDrained() }); ok {
+						cb.onDrained()
+					}
+				}(src)
+			}
+
+			if len(drained) > 0 && empty {
 				return
 			}
 		}
@@ -373,9 +414,6 @@ func (d *sharedDevice) cleanup(
 // onSamples is the malgo audio callback. It mixes all registered sources into the output
 // buffer. Called on the malgo audio thread — must not block, allocate, or make syscalls.
 func (d *sharedDevice) onSamples(output, _ []byte, frameCount uint32) {
-	d.devMu.Lock()
-	defer d.devMu.Unlock()
-
 	n := int(frameCount)
 	if n > len(d.mixBuf) {
 		n = len(d.mixBuf)
@@ -386,10 +424,13 @@ func (d *sharedDevice) onSamples(output, _ []byte, frameCount uint32) {
 		d.mixBuf[i] = [2]float64{}
 	}
 
-	for _, src := range d.sources {
-		_, drained := src.mixAdd(d.mixBuf, n)
-		if drained {
-			d.toRemove = append(d.toRemove, src)
+	if view := d.sourceView.Load(); view != nil {
+		for _, entry := range *view {
+			_, drained := entry.source.mixAdd(d.mixBuf, n)
+			if drained {
+				entry.drained.Store(true)
+				d.drainPending.Store(true)
+			}
 		}
 	}
 
@@ -407,14 +448,6 @@ func (d *sharedDevice) onSamples(output, _ []byte, frameCount uint32) {
 	// Zero any trailing output bytes we didn't fill.
 	for i := offset; i < len(output); i++ {
 		output[i] = 0
-	}
-
-	// Wake the manager goroutine when sources have drained.
-	if len(d.toRemove) > 0 {
-		select {
-		case d.manageCh <- struct{}{}:
-		default:
-		}
 	}
 }
 

--- a/pkg/audio/device_test.go
+++ b/pkg/audio/device_test.go
@@ -58,6 +58,14 @@ func (s *testMixSource) onDrained() {
 	}
 }
 
+func setTestSources(d *sharedDevice, sources ...mixSource) {
+	d.sources = make([]*mixSourceEntry, len(sources))
+	for i, src := range sources {
+		d.sources[i] = &mixSourceEntry{source: src}
+	}
+	d.publishSourcesLocked()
+}
+
 func float32At(b []byte, frame, channel int) float32 {
 	offset := (frame*2 + channel) * 4
 	return math.Float32frombits(binary.LittleEndian.Uint32(b[offset:]))
@@ -73,11 +81,9 @@ func TestSharedDeviceOnSamplesMixesClampsAndQueuesDrainedSources(t *testing.T) {
 	activeSrc := &testMixSource{
 		frames: [][2]float64{{0.5, 0.25}},
 	}
-	d := &sharedDevice{
-		manageCh: make(chan struct{}, 1),
-		sources:  []mixSource{drainedSrc, activeSrc},
-		mixBuf:   make([][2]float64, 2),
-	}
+	d := newSharedDevice()
+	setTestSources(d, drainedSrc, activeSrc)
+	d.mixBuf = make([][2]float64, 2)
 	output := []byte("sentinel sentinel sentinel")
 
 	d.onSamples(output, nil, 3)
@@ -87,26 +93,62 @@ func TestSharedDeviceOnSamplesMixesClampsAndQueuesDrainedSources(t *testing.T) {
 	assert.InDelta(t, float32(0.25), float32At(output, 1, 0), 1e-6)
 	assert.InDelta(t, float32(0.5), float32At(output, 1, 1), 1e-6)
 	assert.Equal(t, make([]byte, len(output)-16), output[16:], "trailing output must be zeroed")
-	require.Len(t, d.toRemove, 1)
-	assert.Same(t, drainedSrc, d.toRemove[0])
+	view := d.sourceView.Load()
+	require.NotNil(t, view)
+	require.Len(t, *view, 2)
+	assert.True(t, (*view)[0].drained.Load(), "expected drained source to be marked")
+}
+
+func TestSharedDeviceOnSamplesDoesNotAllocate(t *testing.T) {
+	d := newSharedDevice()
+	setTestSources(d, &testMixSource{frames: [][2]float64{{0.25, 0.25}}})
+	d.mixBuf = make([][2]float64, 1)
+	output := make([]byte, 8)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		d.onSamples(output, nil, 1)
+	})
+	assert.Zero(t, allocs)
+}
+
+func TestSharedDeviceOnSamplesDoesNotWaitForControlLock(t *testing.T) {
+	t.Parallel()
+
+	d := newSharedDevice()
+	setTestSources(d, &testMixSource{frames: [][2]float64{{0.25, 0.25}}})
+	d.mixBuf = make([][2]float64, 1)
+	output := make([]byte, 8)
+
+	// Control operations may hold devMu while the realtime callback fires.
+	// Callback must use its immutable snapshot rather than wait on that lock.
+	d.devMu.Lock()
+	defer d.devMu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		d.onSamples(output, nil, 1)
+		close(done)
+	}()
+
 	select {
-	case <-d.manageCh:
-	default:
-		t.Fatal("expected manage wake after source drained")
+	case <-done:
+		assert.InDelta(t, float32(0.25), float32At(output, 0, 0), 1e-6)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("realtime callback blocked on device control lock")
 	}
 }
 
 func TestSharedDeviceOpenIfNeededRequiresActiveSource(t *testing.T) {
 	t.Parallel()
 
-	d := &sharedDevice{sources: []mixSource{&testMixSource{active: false}}}
+	d := newSharedDevice()
+	setTestSources(d, &testMixSource{active: false})
 	d.openIfNeeded()
 	d.devMu.Lock()
 	opening := d.opening
 	d.devMu.Unlock()
 	assert.False(t, opening)
 
-	d.sources = append(d.sources, &testMixSource{active: true})
+	setTestSources(d, d.sources[0].source, &testMixSource{active: true})
 	d.openIfNeeded()
 	// Read under devMu: failAllSources (called when ALSA is unavailable) also
 	// holds devMu when it clears d.opening, so the lock ensures we observe the
@@ -122,16 +164,13 @@ func TestSharedDeviceManageRemovesDrainedSourceAndNotifies(t *testing.T) {
 
 	keepSrc := &testMixSource{active: true}
 	drainedSrc := &testMixSource{onDrainedCh: make(chan struct{})}
-	d := &sharedDevice{
-		manageCh: make(chan struct{}, 1),
-		sources:  []mixSource{keepSrc, drainedSrc},
-		toRemove: []mixSource{drainedSrc},
-	}
+	d := newSharedDevice()
+	setTestSources(d, keepSrc, drainedSrc)
+	d.sources[1].drained.Store(true)
+	d.drainPending.Store(true)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go d.manage(ctx, nil, nil, done)
-
-	d.manageCh <- struct{}{}
 
 	select {
 	case <-drainedSrc.onDrainedCh:
@@ -147,8 +186,11 @@ func TestSharedDeviceManageRemovesDrainedSourceAndNotifies(t *testing.T) {
 	}
 
 	require.Len(t, d.sources, 1)
-	assert.Same(t, keepSrc, d.sources[0])
-	assert.Empty(t, d.toRemove)
+	assert.Same(t, keepSrc, d.sources[0].source)
+	view := d.sourceView.Load()
+	require.NotNil(t, view)
+	require.Len(t, *view, 1)
+	assert.Same(t, keepSrc, (*view)[0].source)
 }
 
 // TestSharedDeviceOpenRequestsRealtimeThreadPriority verifies open passes
@@ -162,11 +204,9 @@ func TestSharedDeviceOpenRequestsRealtimeThreadPriority(t *testing.T) {
 		got = cfg
 		return nil, errors.New("stub: no real audio context in tests")
 	}
-	d := &sharedDevice{
-		manageCh:    make(chan struct{}, 1),
-		initContext: stubInit,
-	}
-	d.sources = append(d.sources, &testMixSource{active: true})
+	d := newSharedDevice()
+	d.initContext = stubInit
+	setTestSources(d, &testMixSource{active: true})
 
 	d.open()
 

--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -550,6 +550,9 @@ func (s *streamingSource) mixAdd(buf [][2]float64, n int) (int, bool) {
 	}
 	// Re-read writePos after EOF so final producer frames cannot be skipped.
 	drained := s.writePos.Load() == readPos
+	if s.seekPending.Load() {
+		drained = false
+	}
 	s.consumerActive.Store(false)
 	return written, drained
 }
@@ -624,8 +627,12 @@ func (s *streamingSource) seek(offset time.Duration) {
 	// Gate new callback reads, then wait for any callback already consuming the
 	// ring to finish before replacing playback position and decoder state.
 	s.seekPending.Store(true)
-	for s.consumerActive.Load() {
+	deadline := time.Now().Add(3 * time.Second)
+	for s.consumerActive.Load() && time.Now().Before(deadline) {
 		time.Sleep(time.Millisecond)
+	}
+	if s.consumerActive.Load() {
+		log.Warn().Str("path", s.path).Msg("timeout waiting for audio consumer before seek")
 	}
 
 	newPlayed := s.played.Load() + int64(offset.Seconds()*targetSampleRate)

--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -21,10 +21,12 @@ package audio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -149,13 +151,15 @@ func (m *LongformPlaybackManager) Play(slot, path string, opts PlaybackOptions) 
 		}
 	}
 
-	// Stop and deregister the previous source for this slot.
+	// Start decoding before touching the current source or opening ALSA. Device
+	// startup and previous-source cleanup then provide time to build a cushion,
+	// so the first callback does not race an empty ring.
+	src.startPrefetch()
 	if old != nil {
 		old.stopAndDeregister()
 	}
 
 	globalDevice.register(src)
-	src.startPrefetch()
 	return nil
 }
 
@@ -282,35 +286,37 @@ func (*LongformPlaybackManager) slotKey(slot string) (string, error) {
 // background goroutine. This bounds memory use to ringBufferFrames regardless of
 // file length and keeps decoding off the malgo audio thread.
 type streamingSource struct {
-	resampler    beep.Streamer
-	decoder      beep.StreamSeekCloser
-	onDrain      func(natural bool)
-	file         *os.File
-	wakeCh       chan struct{}
-	doneCh       chan struct{}
-	cancelFn     context.CancelFunc
-	path         string
-	ring         [][2]float64
-	chunk        [][2]float64
-	volume       float64
-	totalFrames  int64
-	sourceRate   int
-	quality      int
-	seekSrcFrame int64
-	played       int64
-	filled       int
-	wpos         int
-	rpos         int
-	mu           syncutil.Mutex
-	seekPending  bool
-	eof          bool
-	stopped      bool
-	paused       bool
+	resampler      beep.Streamer
+	decoder        beep.StreamSeekCloser
+	onDrain        func(natural bool)
+	file           *os.File
+	wakeCh         chan struct{}
+	doneCh         chan struct{}
+	cancelFn       context.CancelFunc
+	path           string
+	ring           [][2]float64
+	chunk          [][2]float64
+	volume         float64
+	totalFrames    int64
+	sourceRate     int
+	quality        int
+	mu             syncutil.Mutex
+	seekMu         syncutil.Mutex
+	readPos        atomic.Uint64
+	writePos       atomic.Uint64
+	played         atomic.Int64
+	seekSrcFrame   atomic.Int64
+	underruns      atomic.Uint64
+	seekPending    atomic.Bool
+	consumerActive atomic.Bool
+	underrunActive atomic.Bool
+	eof            atomic.Bool
+	stopped        atomic.Bool
+	paused         atomic.Bool
 }
 
 // newStreamingSource opens path for streaming decode and returns a ready source.
-// The prefetch goroutine is NOT started yet — call startPrefetch after registering
-// with the device.
+// The prefetch goroutine is not started yet; start it before device registration.
 func newStreamingSource(path string, volume float64, quality int) (*streamingSource, error) {
 	//nolint:gosec // G304: callers validate media paths before launching.
 	f, err := os.Open(path)
@@ -364,7 +370,7 @@ func newStreamingSource(path string, volume float64, quality int) (*streamingSou
 }
 
 // startPrefetch launches the background goroutine that fills the ring buffer.
-// Must be called after the source is registered with the device.
+// Call before device registration so playback starts with buffered audio.
 func (s *streamingSource) startPrefetch() {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -375,89 +381,91 @@ func (s *streamingSource) startPrefetch() {
 	go s.prefetch(ctx, done)
 }
 
-// prefetch runs in a background goroutine, filling the ring buffer from the decoder.
+// prefetch runs in a background goroutine, filling the single-producer,
+// single-consumer ring buffer from the decoder.
 func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 	defer close(done)
 	defer func() {
 		if err := s.decoder.Close(); err != nil {
 			log.Warn().Err(err).Str("path", s.path).Msg("close audio decoder")
 		}
-		if err := s.file.Close(); err != nil {
+		if err := s.file.Close(); err != nil && !errors.Is(err, os.ErrClosed) {
 			log.Warn().Err(err).Str("path", s.path).Msg("close audio file")
 		}
 	}()
 
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
+	var reportedUnderruns uint64
 
+prefetchLoop:
 	for {
-		// Handle a pending seek: flush ring, reposition decoder, rebuild resampler.
-		s.mu.Lock()
-		seekPending := s.seekPending
-		seekFrame := s.seekSrcFrame
-		if seekPending {
-			s.seekPending = false
-			s.rpos = 0
-			s.wpos = 0
-			s.filled = 0
-			s.eof = false
-		}
-		stopped := s.stopped
-		s.mu.Unlock()
-
-		if stopped {
+		if s.stopped.Load() {
 			return
 		}
-		if seekPending {
+
+		if s.seekPending.Load() {
+			s.seekMu.Lock()
+			seekFrame := s.seekSrcFrame.Load()
 			if err := s.decoder.Seek(int(seekFrame)); err != nil {
 				log.Warn().Err(err).Str("path", s.path).Msg("seek audio decoder")
 			}
 			s.resampler = beep.Resample(s.quality, beep.SampleRate(s.sourceRate),
 				beep.SampleRate(targetSampleRate), s.decoder)
+			s.readPos.Store(0)
+			s.writePos.Store(0)
+			s.eof.Store(false)
+			s.underrunActive.Store(false)
+			s.seekPending.Store(false)
+			s.seekMu.Unlock()
 		}
 
-		// Fill all available ring space before sleeping. Decoding a single chunk
-		// per wake caps sustained decode at 1x realtime, leaving no headroom to
-		// rebuild the cushion when the CPU is contended (audible dropouts on
-		// slow ARM devices); filling to capacity lets the ring absorb stalls.
-		for {
-			s.mu.Lock()
-			space := 0
-			if !s.paused && !s.eof && !s.stopped && !s.seekPending {
-				space = len(s.ring) - s.filled
+		if count := s.underruns.Load(); count > reportedUnderruns {
+			log.Warn().
+				Str("path", s.path).
+				Uint64("underruns", count).
+				Int("bufferedFrames", s.bufferedFrames()).
+				Msg("audio stream buffer underrun")
+			reportedUnderruns = count
+		}
+
+		// Fill all available ring space before sleeping. The producer writes frame
+		// data before publishing writePos; the callback consumes published frames
+		// and advances readPos. Neither side takes a mutex.
+		for !s.paused.Load() && !s.eof.Load() && !s.stopped.Load() {
+			if s.seekPending.Load() {
+				continue prefetchLoop
 			}
-			s.mu.Unlock()
-			if space == 0 {
+			readPos := s.readPos.Load()
+			writePos := s.writePos.Load()
+			buffered := writePos - readPos
+			if buffered >= uint64(len(s.ring)) {
 				break
 			}
 
+			space := len(s.ring) - boundedFrameCount(buffered, len(s.ring))
 			n := min(space, len(s.chunk))
 			written, ok := s.resampler.Stream(s.chunk[:n])
+			if s.seekPending.Load() {
+				continue prefetchLoop
+			}
 			if written > 0 {
-				s.mu.Lock()
 				for i := range written {
-					s.ring[s.wpos] = s.chunk[i]
-					s.wpos = (s.wpos + 1) % len(s.ring)
+					s.ring[(writePos+uint64(i))%uint64(len(s.ring))] = s.chunk[i]
 				}
-				s.filled += written
-				s.mu.Unlock()
+				s.writePos.Store(writePos + uint64(written))
 			}
 			if !ok {
 				if err := s.decoder.Err(); err != nil {
 					log.Warn().Err(err).Str("path", s.path).Msg("audio decode error")
 				}
-				// Decoder exhausted or errored; let the ring drain naturally.
-				// Don't exit: a seek can still arrive while the tail plays out
-				// (it clears eof and repositions the decoder). The goroutine is
-				// cancelled on stop or when the drained source is deregistered.
-				s.mu.Lock()
-				s.eof = true
-				s.mu.Unlock()
+				// Publish EOF only after final frames. Loading EOF before writePos
+				// lets the consumer observe every frame before reporting drained.
+				s.eof.Store(true)
 				break
 			}
 		}
 
-		// Sleep until the ring needs refilling or a seek arrives.
 		select {
 		case <-ctx.Done():
 			return
@@ -467,54 +475,96 @@ func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 	}
 }
 
-// mixAdd implements mixSource. Called on the malgo audio thread; must not block or alloc.
-func (s *streamingSource) mixAdd(buf [][2]float64, n int) (int, bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+func boundedFrameCount(frames uint64, limit int) int {
+	if limit <= 0 || frames == 0 {
+		return 0
+	}
+	if frames >= uint64(limit) {
+		return limit
+	}
+	return int(frames) //nolint:gosec // frames is proven positive and below the platform-sized limit.
+}
 
-	if s.stopped {
+func (s *streamingSource) bufferedFrames() int {
+	if s.seekPending.Load() {
+		return 0
+	}
+	readPos := s.readPos.Load()
+	writePos := s.writePos.Load()
+	if writePos <= readPos {
+		return 0
+	}
+	buffered := writePos - readPos
+	return boundedFrameCount(buffered, len(s.ring))
+}
+
+func (s *streamingSource) wakePrefetch() {
+	select {
+	case s.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+// mixAdd implements mixSource. Called on the malgo realtime thread; this is the
+// single ring consumer and performs no blocking synchronization or allocation.
+func (s *streamingSource) mixAdd(buf [][2]float64, n int) (int, bool) {
+	if s.stopped.Load() {
 		return 0, true
 	}
-	if s.paused || s.filled == 0 {
-		// Drained only when the prefetch finished AND the ring is empty.
-		return 0, s.eof && s.filled == 0
+	if s.paused.Load() || s.seekPending.Load() {
+		return 0, false
 	}
 
-	written := 0
-	for written < n && s.filled > 0 {
-		buf[written][0] += s.ring[s.rpos][0] * s.volume
-		buf[written][1] += s.ring[s.rpos][1] * s.volume
-		s.rpos = (s.rpos + 1) % len(s.ring)
-		s.filled--
-		s.played++
-		written++
+	s.consumerActive.Store(true)
+	if s.seekPending.Load() {
+		s.consumerActive.Store(false)
+		return 0, false
 	}
 
-	// Kick the prefetch goroutine when the ring drops below 25 % capacity.
-	if s.filled < len(s.ring)/4 && !s.eof {
-		select {
-		case s.wakeCh <- struct{}{}:
-		default:
-		}
+	// Load EOF before writePos. When EOF is true, the producer's final writePos
+	// publication is guaranteed to be visible before deciding the source drained.
+	eof := s.eof.Load()
+	readPos := s.readPos.Load()
+	writePos := s.writePos.Load()
+	available := writePos - readPos
+	written := boundedFrameCount(available, n)
+	for i := range written {
+		sample := s.ring[(readPos+uint64(i))%uint64(len(s.ring))]
+		buf[i][0] += sample[0] * s.volume
+		buf[i][1] += sample[1] * s.volume
+	}
+	if written > 0 {
+		readPos += uint64(written)
+		s.readPos.Store(readPos)
+		s.played.Add(int64(written))
+		s.underrunActive.Store(false)
 	}
 
-	return written, s.eof && s.filled == 0
+	if written < n && !eof && s.underrunActive.CompareAndSwap(false, true) {
+		s.underruns.Add(1)
+	}
+
+	if !eof {
+		s.consumerActive.Store(false)
+		return written, false
+	}
+	// Re-read writePos after EOF so final producer frames cannot be skipped.
+	drained := s.writePos.Load() == readPos
+	s.consumerActive.Store(false)
+	return written, drained
 }
 
 // isActive returns false when paused (contributing silence) so the device can be
 // released when all sources are idle.
 func (s *streamingSource) isActive() bool {
-	s.mu.Lock()
-	active := !s.paused && !s.stopped
-	s.mu.Unlock()
-	return active
+	return !s.paused.Load() && !s.stopped.Load()
 }
 
 // fail cancels the prefetch goroutine and fires the drain callback, used when the
 // device fails to open. Does not block waiting for the goroutine to exit.
 func (s *streamingSource) fail() {
+	s.stopped.Store(true)
 	s.mu.Lock()
-	s.stopped = true
 	cancelFn := s.cancelFn
 	s.mu.Unlock()
 	if cancelFn != nil {
@@ -528,9 +578,8 @@ func (s *streamingSource) fail() {
 // (Stop/replace), then cancels the prefetch goroutine, which parks at EOF while
 // the ring tail plays out and would otherwise leak.
 func (s *streamingSource) onDrained() {
+	natural := !s.stopped.Swap(true)
 	s.mu.Lock()
-	natural := !s.stopped
-	s.stopped = true
 	cancelFn := s.cancelFn
 	s.mu.Unlock()
 
@@ -544,38 +593,42 @@ func (s *streamingSource) onDrained() {
 
 // setPaused sets the paused flag.
 func (s *streamingSource) setPaused(paused bool) {
-	s.mu.Lock()
-	s.paused = paused
-	s.mu.Unlock()
+	s.paused.Store(paused)
 	// Wake the prefetch goroutine on resume so it can refill the ring.
 	if !paused {
-		select {
-		case s.wakeCh <- struct{}{}:
-		default:
-		}
+		s.wakePrefetch()
 	}
 }
 
 // togglePause flips the paused state and returns the new value.
 func (s *streamingSource) togglePause() bool {
-	s.mu.Lock()
-	s.paused = !s.paused
-	nowPaused := s.paused
-	s.mu.Unlock()
-	if !nowPaused {
-		select {
-		case s.wakeCh <- struct{}{}:
-		default:
+	for {
+		wasPaused := s.paused.Load()
+		nowPaused := !wasPaused
+		if !s.paused.CompareAndSwap(wasPaused, nowPaused) {
+			continue
 		}
+		if !nowPaused {
+			s.wakePrefetch()
+		}
+		return nowPaused
 	}
-	return nowPaused
 }
 
 // seek schedules a seek to the given offset from the current position.
 // The ring buffer is flushed atomically; a brief silence occurs during the re-fill.
 func (s *streamingSource) seek(offset time.Duration) {
-	s.mu.Lock()
-	newPlayed := s.played + int64(offset.Seconds()*targetSampleRate)
+	s.seekMu.Lock()
+	defer s.seekMu.Unlock()
+
+	// Gate new callback reads, then wait for any callback already consuming the
+	// ring to finish before replacing playback position and decoder state.
+	s.seekPending.Store(true)
+	for s.consumerActive.Load() {
+		time.Sleep(time.Millisecond)
+	}
+
+	newPlayed := s.played.Load() + int64(offset.Seconds()*targetSampleRate)
 	if newPlayed < 0 {
 		newPlayed = 0
 	}
@@ -583,28 +636,17 @@ func (s *streamingSource) seek(offset time.Duration) {
 		newPlayed = s.totalFrames
 	}
 	srcFrame := int64(float64(newPlayed) / targetSampleRate * float64(s.sourceRate))
-	s.seekPending = true
-	s.seekSrcFrame = srcFrame
-	s.played = newPlayed
-	// Flush ring so the callback returns silence until the prefetch refills it.
-	s.rpos = 0
-	s.wpos = 0
-	s.filled = 0
-	s.eof = false
-	s.mu.Unlock()
-
-	// Wake the prefetch goroutine immediately to process the seek.
-	select {
-	case s.wakeCh <- struct{}{}:
-	default:
-	}
+	s.seekSrcFrame.Store(srcFrame)
+	s.played.Store(newPlayed)
+	s.eof.Store(false)
+	s.wakePrefetch()
 }
 
 // stopAndDeregister cancels the prefetch goroutine and removes this source from
 // the shared device. Blocks until the prefetch goroutine exits.
 func (s *streamingSource) stopAndDeregister() {
+	s.stopped.Store(true)
 	s.mu.Lock()
-	s.stopped = true
 	cancelFn := s.cancelFn
 	doneCh := s.doneCh
 	s.mu.Unlock()
@@ -625,14 +667,15 @@ func (s *streamingSource) stopAndDeregister() {
 
 // state returns a snapshot of the current playback state.
 func (s *streamingSource) state() PlaybackState {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	paused := s.paused.Load()
+	stopped := s.stopped.Load()
+	eof := s.eof.Load()
 	return PlaybackState{
 		Path:     s.path,
-		Position: sampleDuration(int(s.played)),
+		Position: sampleDuration(int(s.played.Load())),
 		Duration: sampleDuration(int(s.totalFrames)),
-		Playing:  !s.paused && !s.stopped && (!s.eof || s.filled != 0),
-		Paused:   s.paused,
+		Playing:  !paused && !stopped && (!eof || s.bufferedFrames() != 0),
+		Paused:   paused,
 	}
 }
 

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -40,6 +40,16 @@ func newTestSource() *streamingSource {
 	}
 }
 
+func TestBoundedFrameCount(t *testing.T) {
+	t.Parallel()
+
+	assert.Zero(t, boundedFrameCount(10, 0))
+	assert.Zero(t, boundedFrameCount(0, 10))
+	assert.Equal(t, 5, boundedFrameCount(5, 10))
+	assert.Equal(t, 10, boundedFrameCount(10, 10))
+	assert.Equal(t, 10, boundedFrameCount(^uint64(0), 10))
+}
+
 func TestSampleDuration(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, time.Duration(0), sampleDuration(0))
@@ -52,7 +62,7 @@ func TestStreamingSource_State_PlayingLogic(t *testing.T) {
 	t.Parallel()
 
 	s := newTestSource()
-	s.played = targetSampleRate / 2 // 0.5 s in
+	s.played.Store(targetSampleRate / 2) // 0.5 s in
 
 	// Default: not paused, not stopped, not eof → Playing
 	ps := s.state()
@@ -62,23 +72,22 @@ func TestStreamingSource_State_PlayingLogic(t *testing.T) {
 	assert.Equal(t, time.Second, ps.Duration)
 
 	// Paused → Playing=false
-	s.paused = true
+	s.paused.Store(true)
 	assert.False(t, s.state().Playing)
 	assert.True(t, s.state().Paused)
-	s.paused = false
+	s.paused.Store(false)
 
 	// Stopped → Playing=false
-	s.stopped = true
+	s.stopped.Store(true)
 	assert.False(t, s.state().Playing)
-	s.stopped = false
+	s.stopped.Store(false)
 
 	// EOF with ring drained → Playing=false
-	s.eof = true
-	s.filled = 0
+	s.eof.Store(true)
 	assert.False(t, s.state().Playing)
 
 	// EOF but ring still has frames → Playing=true (tail draining)
-	s.filled = 10
+	s.writePos.Store(10)
 	assert.True(t, s.state().Playing)
 }
 
@@ -87,10 +96,10 @@ func TestStreamingSource_IsActive(t *testing.T) {
 	s := newTestSource()
 
 	assert.True(t, s.isActive())
-	s.paused = true
+	s.paused.Store(true)
 	assert.False(t, s.isActive())
-	s.paused = false
-	s.stopped = true
+	s.paused.Store(false)
+	s.stopped.Store(true)
 	assert.False(t, s.isActive())
 }
 
@@ -105,14 +114,14 @@ func TestStreamingSource_OnDrained(t *testing.T) {
 	s.onDrain = func(natural bool) { gotNatural = &natural }
 
 	// stopped=false → natural drain
-	s.stopped = false
+	s.stopped.Store(false)
 	s.onDrained()
 	require.NotNil(t, gotNatural)
 	assert.True(t, *gotNatural)
 
 	// stopped=true → explicit stop
 	gotNatural = nil
-	s.stopped = true
+	s.stopped.Store(true)
 	s.onDrained()
 	require.NotNil(t, gotNatural)
 	assert.False(t, *gotNatural)
@@ -123,15 +132,11 @@ func TestStreamingSource_SetPaused(t *testing.T) {
 	s := newTestSource()
 
 	s.setPaused(true)
-	s.mu.Lock()
-	assert.True(t, s.paused)
-	s.mu.Unlock()
+	assert.True(t, s.paused.Load())
 
 	// Resume writes to wakeCh.
 	s.setPaused(false)
-	s.mu.Lock()
-	assert.False(t, s.paused)
-	s.mu.Unlock()
+	assert.False(t, s.paused.Load())
 
 	select {
 	case <-s.wakeCh:
@@ -146,15 +151,11 @@ func TestStreamingSource_TogglePause(t *testing.T) {
 
 	nowPaused := s.togglePause()
 	assert.True(t, nowPaused)
-	s.mu.Lock()
-	assert.True(t, s.paused)
-	s.mu.Unlock()
+	assert.True(t, s.paused.Load())
 
 	nowPaused = s.togglePause()
 	assert.False(t, nowPaused)
-	s.mu.Lock()
-	assert.False(t, s.paused)
-	s.mu.Unlock()
+	assert.False(t, s.paused.Load())
 
 	// Resume writes to wakeCh.
 	select {
@@ -167,19 +168,14 @@ func TestStreamingSource_TogglePause(t *testing.T) {
 func TestStreamingSource_Seek(t *testing.T) {
 	t.Parallel()
 	s := newTestSource()
-	// Pre-fill the ring to verify it is flushed on seek.
-	s.filled = 50
-	s.wpos = 50
-	s.played = int64(targetSampleRate) // 1 s
+	// Pre-fill the ring to verify it is hidden from the callback during seek.
+	s.writePos.Store(50)
+	s.played.Store(targetSampleRate) // 1 s
 
 	s.seek(0) // seek to current position (offset=0)
 
-	s.mu.Lock()
-	assert.True(t, s.seekPending, "seekPending must be set")
-	assert.Equal(t, 0, s.filled, "ring must be flushed")
-	assert.Equal(t, 0, s.wpos, "write pos must be reset")
-	assert.Equal(t, 0, s.rpos, "read pos must be reset")
-	s.mu.Unlock()
+	assert.True(t, s.seekPending.Load(), "seekPending must be set")
+	assert.Equal(t, 0, s.bufferedFrames(), "pending seek must hide stale ring frames")
 
 	select {
 	case <-s.wakeCh:
@@ -193,20 +189,17 @@ func TestStreamingSource_SeekClampsToTrackBounds(t *testing.T) {
 
 	s := newTestSource()
 	s.sourceRate = targetSampleRate
-	s.played = int64(targetSampleRate / 2)
+	s.played.Store(targetSampleRate / 2)
 	s.seek(-time.Second)
-	s.mu.Lock()
-	assert.Equal(t, int64(0), s.played)
-	assert.Equal(t, int64(0), s.seekSrcFrame)
-	s.mu.Unlock()
+	assert.Equal(t, int64(0), s.played.Load())
+	assert.Equal(t, int64(0), s.seekSrcFrame.Load())
 	<-s.wakeCh
 
-	s.played = int64(targetSampleRate)
+	s.seekPending.Store(false)
+	s.played.Store(targetSampleRate)
 	s.seek(time.Second)
-	s.mu.Lock()
-	assert.Equal(t, int64(targetSampleRate), s.played)
-	assert.Equal(t, int64(targetSampleRate), s.seekSrcFrame)
-	s.mu.Unlock()
+	assert.Equal(t, int64(targetSampleRate), s.played.Load())
+	assert.Equal(t, int64(targetSampleRate), s.seekSrcFrame.Load())
 }
 
 func TestStreamingSource_MixAdd(t *testing.T) {
@@ -218,8 +211,7 @@ func TestStreamingSource_MixAdd(t *testing.T) {
 	for i := range nFrames {
 		s.ring[i] = [2]float64{float64(i+1) * 0.1, float64(i+1) * 0.1}
 	}
-	s.wpos = nFrames
-	s.filled = nFrames
+	s.writePos.Store(nFrames)
 
 	buf := make([][2]float64, 20)
 	n, drained := s.mixAdd(buf, nFrames)
@@ -232,7 +224,7 @@ func TestStreamingSource_MixAdd(t *testing.T) {
 	}
 
 	// Now drained: eof=true, ring empty after mix.
-	s.eof = true
+	s.eof.Store(true)
 	buf2 := make([][2]float64, 5)
 	n2, drained2 := s.mixAdd(buf2, 5)
 	assert.Equal(t, 0, n2)
@@ -240,9 +232,57 @@ func TestStreamingSource_MixAdd(t *testing.T) {
 
 	// Stopped: drains immediately.
 	s2 := newTestSource()
-	s2.stopped = true
+	s2.stopped.Store(true)
 	_, stopped := s2.mixAdd(buf, 5)
 	assert.True(t, stopped)
+}
+
+func TestStreamingSource_MixAddDoesNotWaitForLifecycleLock(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSource()
+	s.ring[0] = [2]float64{0.5, 0.5}
+	s.writePos.Store(1)
+	buf := make([][2]float64, 1)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	done := make(chan struct{})
+	go func() {
+		s.mixAdd(buf, 1)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.InDelta(t, 0.5, buf[0][0], 1e-9)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("realtime source mix blocked on lifecycle lock")
+	}
+}
+
+func TestStreamingSource_UnderrunEpisodes(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSource()
+	buf := make([][2]float64, 4)
+
+	written, drained := s.mixAdd(buf, len(buf))
+	assert.Zero(t, written)
+	assert.False(t, drained)
+	assert.Equal(t, uint64(1), s.underruns.Load())
+
+	// Repeated empty callbacks belong to the same underrun episode.
+	s.mixAdd(buf, len(buf))
+	assert.Equal(t, uint64(1), s.underruns.Load())
+
+	// Consuming newly published audio ends the episode; another empty callback
+	// starts a new one.
+	s.ring[0] = [2]float64{0.25, 0.25}
+	s.writePos.Store(1)
+	s.mixAdd(buf, 1)
+	s.mixAdd(buf, len(buf))
+	assert.Equal(t, uint64(2), s.underruns.Load())
 }
 
 func TestNewStreamingSource_UnsupportedExtension(t *testing.T) {
@@ -317,9 +357,7 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 
 			// Wait for the prefetch goroutine to fully decode the file.
 			require.Eventually(t, func() bool {
-				s.mu.Lock()
-				defer s.mu.Unlock()
-				return s.eof
+				return s.eof.Load()
 			}, 5*time.Second, 5*time.Millisecond, "prefetch should reach EOF")
 
 			// Simulate the tail playing out, then seek back to the start. Before the
@@ -330,14 +368,10 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 			s.seek(-time.Second)
 
 			require.Eventually(t, func() bool {
-				s.mu.Lock()
-				defer s.mu.Unlock()
-				return s.filled > 0
+				return s.bufferedFrames() > 0
 			}, 5*time.Second, 5*time.Millisecond, "seek after EOF should refill the ring")
 
-			s.mu.Lock()
 			assert.Equal(t, tc.quality, s.quality, "seek must preserve the source's resample quality")
-			s.mu.Unlock()
 		})
 	}
 }
@@ -361,10 +395,45 @@ func TestStreamingSource_PrefetchFillsRingWithoutTickerPacing(t *testing.T) {
 	t.Cleanup(s.stopAndDeregister)
 
 	require.Eventually(t, func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return s.filled == len(s.ring)
+		return s.bufferedFrames() == len(s.ring)
 	}, 2*time.Second, 5*time.Millisecond, "prefetch should burst-fill the full ring")
+}
+
+func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "audio.wav")
+	require.NoError(t, os.WriteFile(path, wavWithSamples(10*44100), 0o600))
+
+	s, err := newStreamingSource(path, 1.0, lowPowerResampleQuality)
+	require.NoError(t, err)
+	s.startPrefetch()
+	t.Cleanup(s.stopAndDeregister)
+	require.Eventually(t, func() bool {
+		return s.bufferedFrames() == len(s.ring)
+	}, 2*time.Second, 5*time.Millisecond)
+
+	buf := make([][2]float64, 2048)
+	deadline := time.Now().Add(5 * time.Second)
+	total := 0
+	for time.Now().Before(deadline) {
+		for i := range buf {
+			buf[i] = [2]float64{}
+		}
+		written, drained := s.mixAdd(buf, len(buf))
+		total += written
+		if drained {
+			break
+		}
+		if written == 0 {
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	assert.Greater(t, total, ringBufferFrames)
+	assert.Equal(t, int64(total), s.played.Load())
+	assert.True(t, s.eof.Load())
+	assert.Zero(t, s.bufferedFrames())
 }
 
 func TestNewLongformPlaybackManager(t *testing.T) {
@@ -384,7 +453,8 @@ func TestNewLongformPlaybackManager_ResampleQuality(t *testing.T) {
 
 func TestLongformPlaybackManager_PlayReplacesSourceAndUsesDrainCallback(t *testing.T) {
 	oldDevice := globalDevice
-	testDevice := &sharedDevice{manageCh: make(chan struct{}, 1), opening: true}
+	testDevice := newSharedDevice()
+	testDevice.opening = true
 	globalDevice = testDevice
 	t.Cleanup(func() { globalDevice = oldDevice })
 
@@ -408,13 +478,11 @@ func TestLongformPlaybackManager_PlayReplacesSourceAndUsesDrainCallback(t *testi
 	require.NotNil(t, second)
 	assert.NotSame(t, first, second)
 	assert.InDelta(t, 0.25, second.volume, 1e-9)
-	first.mu.Lock()
-	assert.True(t, first.stopped, "replaced source must be stopped")
-	first.mu.Unlock()
+	assert.True(t, first.stopped.Load(), "replaced source must be stopped")
 
 	testDevice.devMu.Lock()
 	require.Len(t, testDevice.sources, 1)
-	assert.Same(t, second, testDevice.sources[0])
+	assert.Same(t, second, testDevice.sources[0].source)
 	testDevice.devMu.Unlock()
 
 	second.onDrained()
@@ -463,7 +531,7 @@ func TestLongformPlaybackManager_WithSourcePrimary(t *testing.T) {
 	t.Parallel()
 	m := NewLongformPlaybackManager(false)
 	s := newTestSource()
-	s.played = int64(targetSampleRate / 2) // 0.5 s in
+	s.played.Store(targetSampleRate / 2) // 0.5 s in
 	m.mu.Lock()
 	m.primary = s
 	m.mu.Unlock()
@@ -475,30 +543,22 @@ func TestLongformPlaybackManager_WithSourcePrimary(t *testing.T) {
 
 	// Seek schedules a seek.
 	require.NoError(t, m.Seek(mediaslot.Primary, 0))
-	s.mu.Lock()
-	assert.True(t, s.seekPending)
-	s.mu.Unlock()
+	assert.True(t, s.seekPending.Load())
 
 	// Pause sets the paused flag.
 	require.NoError(t, m.Pause(mediaslot.Primary))
-	s.mu.Lock()
-	assert.True(t, s.paused)
-	s.mu.Unlock()
+	assert.True(t, s.paused.Load())
 
 	// TogglePause unpauses.
 	require.NoError(t, m.TogglePause(mediaslot.Primary))
-	s.mu.Lock()
-	assert.False(t, s.paused)
-	s.mu.Unlock()
+	assert.False(t, s.paused.Load())
 
 	// Resume is a no-error call when already unpaused.
 	require.NoError(t, m.Resume(mediaslot.Primary))
 
 	// Stop sets stopped, clears the slot, and returns no error.
 	require.NoError(t, m.Stop(mediaslot.Primary))
-	s.mu.Lock()
-	assert.True(t, s.stopped)
-	s.mu.Unlock()
+	assert.True(t, s.stopped.Load())
 	assert.Equal(t, PlaybackState{}, m.State(mediaslot.Primary))
 }
 
@@ -518,22 +578,16 @@ func TestLongformPlaybackManager_WithSourceBackground(t *testing.T) {
 
 	// Pause/TogglePause/Resume cycle.
 	require.NoError(t, m.Pause(mediaslot.Background))
-	s.mu.Lock()
-	assert.True(t, s.paused)
-	s.mu.Unlock()
+	assert.True(t, s.paused.Load())
 
 	require.NoError(t, m.TogglePause(mediaslot.Background))
-	s.mu.Lock()
-	assert.False(t, s.paused)
-	s.mu.Unlock()
+	assert.False(t, s.paused.Load())
 
 	require.NoError(t, m.Resume(mediaslot.Background))
 
 	// Stop clears background slot.
 	require.NoError(t, m.Stop(mediaslot.Background))
-	s.mu.Lock()
-	assert.True(t, s.stopped)
-	s.mu.Unlock()
+	assert.True(t, s.stopped.Load())
 	assert.Equal(t, PlaybackState{}, m.State(mediaslot.Background))
 }
 
@@ -550,16 +604,12 @@ func TestLongformPlaybackManager_SlotAliasesResolve(t *testing.T) {
 
 	for _, alias := range []string{"bg", "Background", " background "} {
 		require.NoError(t, m.Pause(alias))
-		s.mu.Lock()
-		assert.True(t, s.paused, "alias %q must resolve to the background source", alias)
-		s.paused = false
-		s.mu.Unlock()
+		assert.True(t, s.paused.Load(), "alias %q must resolve to the background source", alias)
+		s.paused.Store(false)
 	}
 
 	require.NoError(t, m.Stop("bg"))
-	s.mu.Lock()
-	assert.True(t, s.stopped, "Stop via alias must stop the background source")
-	s.mu.Unlock()
+	assert.True(t, s.stopped.Load(), "Stop via alias must stop the background source")
 	assert.Equal(t, PlaybackState{}, m.State(mediaslot.Background))
 }
 

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -416,6 +416,7 @@ func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
 	buf := make([][2]float64, 2048)
 	deadline := time.Now().Add(5 * time.Second)
 	total := 0
+	didDrain := false
 	for time.Now().Before(deadline) {
 		for i := range buf {
 			buf[i] = [2]float64{}
@@ -423,6 +424,7 @@ func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
 		written, drained := s.mixAdd(buf, len(buf))
 		total += written
 		if drained {
+			didDrain = true
 			break
 		}
 		if written == 0 {
@@ -430,6 +432,7 @@ func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
 		}
 	}
 
+	require.True(t, didDrain, "stream did not drain before deadline")
 	assert.Greater(t, total, ringBufferFrames)
 	assert.Equal(t, int64(total), s.played.Load())
 	assert.True(t, s.eof.Load())


### PR DESCRIPTION
## Summary

- publish immutable source snapshots so malgo callbacks never wait on device-control locks
- feed streaming playback through a lock-free SPSC ring with atomic lifecycle and seek coordination
- prefetch earlier and handle draining and underruns without callback allocations, reducing MiSTer stutter and shutdown stalls

Validated with `task lint-fix` and `task test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved real-time audio mixing to reduce locking and maintain smoother playback under concurrent activity.
  * Improved buffering and prefetching to better handle streaming playback and bursts of audio data.

* **Reliability**
  * Improved pause, resume, seeking, stopping, and device shutdown behavior.
  * Added better handling for underruns, drained audio sources, and playback completion.

* **Testing**
  * Expanded coverage for concurrent playback, buffering limits, underruns, lock-free mixing, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->