### PR TITLE
fix(database): scope cache updates to changed media tags

### DIFF
--- a/pkg/api/methods/media_tags_update.go
+++ b/pkg/api/methods/media_tags_update.go
@@ -20,13 +20,11 @@
 package methods
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
@@ -81,18 +79,19 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 	row := resolved[0].Row
 	resolveDuration := time.Since(resolveStarted)
 
-	// Write the durable truth (UserDB) before the media.db projection. add/remove
-	// are restricted to user:favorite, and media.db applies removes before adds,
-	// so the net favourite state is "any add present". If the projection write
-	// below fails the truth is still saved and the next reindex re-materializes it.
+	// Write the durable truth (UserDB) before the MediaDB projection. Since
+	// user:favorite is the only mutable tag, any add wins over a simultaneous
+	// remove. A failed projection remains repairable by the next reindex.
 	favorite := len(add) > 0
 	if udErr := setMediaUserFavorite(&env, row.System.SystemID, row.Path, favorite); udErr != nil {
 		return nil, udErr
 	}
 
 	updateStarted := time.Now()
-	if updateErr := updateMediaUserTags(env.Database.MediaDB, row.DBID, remove, add); updateErr != nil {
-		return nil, updateErr
+	if updateErr := env.Database.MediaDB.UpdateMediaTags(
+		env.Context, row.DBID, remove, add,
+	); updateErr != nil {
+		return nil, fmt.Errorf("failed to update media tag projection: %w", updateErr)
 	}
 	updateDuration := time.Since(updateStarted)
 
@@ -118,7 +117,7 @@ func HandleMediaTagsUpdate(env requests.RequestEnv) (any, error) { //nolint:gocr
 	return models.TagsResponse{Tags: append(fileTags, titleTags...)}, nil
 }
 
-func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
+func parseMutableUserTags(rawTags []string) ([]database.MediaTagRef, error) {
 	if len(rawTags) == 0 {
 		return nil, nil
 	}
@@ -136,99 +135,13 @@ func parseMutableUserTags(rawTags []string) ([]zapscript.TagFilter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse tag filters: %w", err)
 	}
+	refs := make([]database.MediaTagRef, 0, len(parsed))
 	for _, tag := range parsed {
 		if tag.Type != string(tags.TagTypeUser) || tag.Value != string(tags.TagUserFavorite) {
 			return nil, fmt.Errorf("only %s:%s can be mutated", tags.TagTypeUser, tags.TagUserFavorite)
 		}
+		refs = append(refs, database.MediaTagRef{Type: tag.Type, Tag: tag.Value})
 	}
 
-	return parsed, nil
-}
-
-func updateMediaUserTags(
-	mediaDB database.MediaDBI,
-	mediaDBID int64,
-	remove []zapscript.TagFilter,
-	add []zapscript.TagFilter,
-) error {
-	if err := mediaDB.BeginTransaction(false); err != nil {
-		return fmt.Errorf("failed to begin media tag update transaction: %w", err)
-	}
-
-	for _, tag := range remove {
-		if err := removeMediaUserTag(mediaDB, mediaDBID, tag); err != nil {
-			rollbackMediaTagUpdate(mediaDB)
-			return err
-		}
-	}
-	for _, tag := range add {
-		if err := addMediaUserTag(mediaDB, mediaDBID, tag); err != nil {
-			rollbackMediaTagUpdate(mediaDB)
-			return err
-		}
-	}
-
-	commitOptions := database.TransactionOptions{WALCheckpoint: database.WALCheckpointSkip}
-	if err := mediaDB.CommitTransactionWithOptions(commitOptions); err != nil {
-		rollbackMediaTagUpdate(mediaDB)
-		return fmt.Errorf("failed to commit media tag update transaction: %w", err)
-	}
-
-	return nil
-}
-
-func rollbackMediaTagUpdate(mediaDB database.MediaDBI) {
-	if rbErr := mediaDB.RollbackTransaction(); rbErr != nil {
-		log.Error().Err(rbErr).Msg("failed to rollback media tag update transaction")
-	}
-}
-
-func addMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.TagFilter) error {
-	tagType, err := mediaDB.FindOrInsertTagType(database.TagType{
-		Type:        tag.Type,
-		IsExclusive: tags.IsExclusiveType(tags.TagType(tag.Type)),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to find or insert tag type: %w", err)
-	}
-
-	tagRow, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: tagType.DBID, Tag: tag.Value})
-	if err != nil {
-		return fmt.Errorf("failed to find or insert tag: %w", err)
-	}
-
-	mediaTag := database.MediaTag{
-		MediaDBID: mediaDBID,
-		TagDBID:   tagRow.DBID,
-	}
-	if _, err = mediaDB.FindOrInsertMediaTag(mediaTag); err != nil {
-		return fmt.Errorf("failed to find or insert media tag: %w", err)
-	}
-
-	return nil
-}
-
-func removeMediaUserTag(mediaDB database.MediaDBI, mediaDBID int64, tag zapscript.TagFilter) error {
-	tagType, err := mediaDB.FindTagType(database.TagType{Type: tag.Type})
-	if err != nil {
-		return ignoreMissingTag(err)
-	}
-
-	tagRow, err := mediaDB.FindTag(database.Tag{TypeDBID: tagType.DBID, Tag: tag.Value})
-	if err != nil {
-		return ignoreMissingTag(err)
-	}
-
-	if err = mediaDB.DeleteMediaTag(mediaDBID, tagRow.DBID); err != nil {
-		return fmt.Errorf("failed to delete media tag: %w", err)
-	}
-
-	return nil
-}
-
-func ignoreMissingTag(err error) error {
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil
-	}
-	return err
+	return refs, nil
 }

--- a/pkg/api/methods/media_tags_update_test.go
+++ b/pkg/api/methods/media_tags_update_test.go
@@ -65,15 +65,13 @@ func TestHandleMediaTagsUpdate_AddsFavoriteTag(t *testing.T) {
 	}
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: row}, nil).Once()
-	mockDB.On("BeginTransaction", false).Return(nil).Once()
-	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
-		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeUser)}, nil).Once()
-	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagUserFavorite)}).
-		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagUserFavorite)}, nil).Once()
-	mockDB.On("FindOrInsertMediaTag", database.MediaTag{MediaDBID: 1, TagDBID: 12}).
-		Return(database.MediaTag{DBID: 13, MediaDBID: 1, TagDBID: 12}, nil).Once()
-	commitOptions := database.TransactionOptions{WALCheckpoint: database.WALCheckpointSkip}
-	mockDB.On("CommitTransactionWithOptions", commitOptions).Return(nil).Once()
+	mockDB.On(
+		"UpdateMediaTags",
+		mock.Anything,
+		int64(1),
+		[]database.MediaTagRef(nil),
+		[]database.MediaTagRef{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}},
+	).Return(nil).Once()
 	mockDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(1)).
 		Return([]database.TagInfo{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}}, nil).Once()
 	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
@@ -118,43 +116,49 @@ func TestHandleMediaTagsUpdate_RejectsUnsupportedTags(t *testing.T) {
 	mockDB.AssertExpectations(t)
 }
 
-func TestHandleMediaTagsUpdate_RollsBackWhenAddFails(t *testing.T) {
+func TestHandleMediaTagsUpdate_ReturnsProjectionError(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: mediaTagsUpdateRow()}, nil).Once()
-	mockDB.On("BeginTransaction", false).Return(nil).Once()
-	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
-		Return(database.TagType{}, errors.New("tag type insert failed")).Once()
-	mockDB.On("RollbackTransaction").Return(nil).Once()
+	mockDB.On(
+		"UpdateMediaTags",
+		mock.Anything,
+		int64(1),
+		[]database.MediaTagRef(nil),
+		[]database.MediaTagRef{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}},
+	).Return(errors.New("projection failed")).Once()
 
 	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to find or insert tag type")
+	assert.Contains(t, err.Error(), "failed to update media tag projection")
 	mockDB.AssertExpectations(t)
 }
 
-func TestHandleMediaTagsUpdate_RollsBackWhenCommitFails(t *testing.T) {
+func TestHandleMediaTagsUpdate_RemovesFavoriteTag(t *testing.T) {
 	t.Parallel()
 
 	mockDB := testhelpers.NewMockMediaDBI()
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: mediaTagsUpdateRow()}, nil).Once()
-	mockDB.On("BeginTransaction", false).Return(nil).Once()
-	mockDB.On("FindOrInsertTagType", database.TagType{Type: string(tags.TagTypeUser), IsExclusive: false}).
-		Return(database.TagType{DBID: 11, Type: string(tags.TagTypeUser)}, nil).Once()
-	mockDB.On("FindOrInsertTag", database.Tag{TypeDBID: 11, Tag: string(tags.TagUserFavorite)}).
-		Return(database.Tag{DBID: 12, TypeDBID: 11, Tag: string(tags.TagUserFavorite)}, nil).Once()
-	mockDB.On("FindOrInsertMediaTag", database.MediaTag{MediaDBID: 1, TagDBID: 12}).
-		Return(database.MediaTag{MediaDBID: 1, TagDBID: 12}, nil).Once()
-	commitOptions := database.TransactionOptions{WALCheckpoint: database.WALCheckpointSkip}
-	mockDB.On("CommitTransactionWithOptions", commitOptions).Return(errors.New("commit failed")).Once()
-	mockDB.On("RollbackTransaction").Return(nil).Once()
+	mockDB.On(
+		"UpdateMediaTags",
+		mock.Anything,
+		int64(1),
+		[]database.MediaTagRef{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}},
+		[]database.MediaTagRef(nil),
+	).Return(nil).Once()
+	mockDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(1)).
+		Return([]database.TagInfo{}, nil).Once()
+	mockDB.On("GetMediaTitleTagsByMediaTitleDBID", mock.Anything, int64(10)).
+		Return([]database.TagInfo{}, nil).Once()
 
-	_, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(t, mockDB, `{"mediaId":1,"add":["user:favorite"]}`))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to commit media tag update transaction")
+	result, err := HandleMediaTagsUpdate(makeMediaTagsUpdateEnv(
+		t, mockDB, `{"mediaId":1,"remove":["user:favorite"]}`,
+	))
+	require.NoError(t, err)
+	assertTagsDoNotContainFavorite(t, result)
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/media_user_data_test.go
+++ b/pkg/api/methods/media_user_data_test.go
@@ -88,7 +88,13 @@ func TestMediaTagsUpdate_PersistsUserDBTruthWhenProjectionFails(t *testing.T) {
 		Return([]database.SearchResult{}, nil).Maybe()
 	mockDB.On("GetMediaWithTitleAndSystemByIDs", mock.Anything, []int64{1}).
 		Return(map[int64]database.MediaFullRow{1: favouriteRow(path)}, nil).Once()
-	mockDB.On("BeginTransaction", false).Return(errors.New("projection boom")).Once()
+	mockDB.On(
+		"UpdateMediaTags",
+		mock.Anything,
+		int64(1),
+		[]database.MediaTagRef(nil),
+		[]database.MediaTagRef{{Type: string(tags.TagTypeUser), Tag: string(tags.TagUserFavorite)}},
+	).Return(errors.New("projection boom")).Once()
 
 	env := requests.RequestEnv{
 		Context:  ctx,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -300,6 +300,12 @@ type MediaTagLink struct {
 	TagDBID   int64
 }
 
+// MediaTagRef identifies a tag by its stable type and value.
+type MediaTagRef struct {
+	Type string
+	Tag  string
+}
+
 type SearchResult struct {
 	SystemID string
 	Name     string
@@ -1035,6 +1041,12 @@ type MediaDBI interface {
 	InsertMedia(row Media) (Media, error)
 	FindOrInsertMedia(row Media) (Media, error)
 	DeleteMediaTag(mediaDBID, tagDBID int64) error
+	UpdateMediaTags(
+		ctx context.Context,
+		mediaDBID int64,
+		remove []MediaTagRef,
+		add []MediaTagRef,
+	) error
 	TemporaryRepairJobsPending(ctx context.Context) (bool, error)
 
 	FindTagType(row TagType) (TagType, error)

--- a/pkg/database/mediadb/media_tag_mutation.go
+++ b/pkg/database/mediadb/media_tag_mutation.go
@@ -30,6 +30,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type resolvedMediaTag struct {
+	tagDBID     int64
+	tagTypeDBID int64
+	isExclusive bool
+}
+
 const refreshMediaTagCacheSQL = `
 	WITH tag_count AS (
 		SELECT
@@ -172,7 +178,7 @@ func removeMediaTags(
 	affectedTagDBIDs map[int64]struct{},
 ) error {
 	for _, ref := range refs {
-		tagDBID, found, err := findOrCreateMediaTag(ctx, tx, ref, false)
+		resolved, found, err := findOrCreateMediaTag(ctx, tx, ref, false)
 		if err != nil {
 			return fmt.Errorf("resolve media tag %s:%s for removal: %w", ref.Type, ref.Tag, err)
 		}
@@ -180,11 +186,11 @@ func removeMediaTags(
 			continue
 		}
 		if _, err = tx.ExecContext(ctx,
-			"DELETE FROM MediaTags WHERE MediaDBID = ? AND TagDBID = ?", mediaDBID, tagDBID,
+			"DELETE FROM MediaTags WHERE MediaDBID = ? AND TagDBID = ?", mediaDBID, resolved.tagDBID,
 		); err != nil {
 			return fmt.Errorf("remove media tag %s:%s: %w", ref.Type, ref.Tag, err)
 		}
-		affectedTagDBIDs[tagDBID] = struct{}{}
+		affectedTagDBIDs[resolved.tagDBID] = struct{}{}
 	}
 	return nil
 }
@@ -197,14 +203,51 @@ func addMediaTags(
 	affectedTagDBIDs map[int64]struct{},
 ) error {
 	for _, ref := range refs {
-		tagDBID, _, err := findOrCreateMediaTag(ctx, tx, ref, true)
+		resolved, _, err := findOrCreateMediaTag(ctx, tx, ref, true)
 		if err != nil {
 			return fmt.Errorf("resolve media tag %s:%s for addition: %w", ref.Type, ref.Tag, err)
 		}
-		if _, err = tx.ExecContext(ctx, insertMediaTagSQL, mediaDBID, tagDBID); err != nil {
+		if resolved.isExclusive {
+			if err = removeExclusiveMediaTags(
+				ctx, tx, mediaDBID, resolved.tagTypeDBID, affectedTagDBIDs,
+			); err != nil {
+				return fmt.Errorf("replace media tag type %s: %w", ref.Type, err)
+			}
+		}
+		if _, err = tx.ExecContext(ctx, insertMediaTagSQL, mediaDBID, resolved.tagDBID); err != nil {
 			return fmt.Errorf("add media tag %s:%s: %w", ref.Type, ref.Tag, err)
 		}
+		affectedTagDBIDs[resolved.tagDBID] = struct{}{}
+	}
+	return nil
+}
+
+func removeExclusiveMediaTags(
+	ctx context.Context,
+	tx *sql.Tx,
+	mediaDBID int64,
+	tagTypeDBID int64,
+	affectedTagDBIDs map[int64]struct{},
+) error {
+	rows, err := tx.QueryContext(ctx, `
+		DELETE FROM MediaTags
+		WHERE MediaDBID = ?
+		  AND TagDBID IN (SELECT DBID FROM Tags WHERE TypeDBID = ?)
+		RETURNING TagDBID`, mediaDBID, tagTypeDBID)
+	if err != nil {
+		return fmt.Errorf("delete existing exclusive media tags: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var tagDBID int64
+		if err = rows.Scan(&tagDBID); err != nil {
+			return fmt.Errorf("scan replaced exclusive media tag: %w", err)
+		}
 		affectedTagDBIDs[tagDBID] = struct{}{}
+	}
+	if err = rows.Err(); err != nil {
+		return fmt.Errorf("iterate replaced exclusive media tags: %w", err)
 	}
 	return nil
 }
@@ -214,28 +257,31 @@ func findOrCreateMediaTag(
 	tx *sql.Tx,
 	ref database.MediaTagRef,
 	create bool,
-) (tagDBID int64, found bool, err error) {
+) (resolvedMediaTag, bool, error) {
 	if ref.Type == "" || ref.Tag == "" {
-		return 0, false, errors.New("media tag type and value are required")
+		return resolvedMediaTag{}, false, errors.New("media tag type and value are required")
 	}
 
-	var tagTypeDBID int64
-	err = tx.QueryRowContext(ctx, "SELECT DBID FROM TagTypes WHERE Type = ?", ref.Type).Scan(&tagTypeDBID)
+	var resolved resolvedMediaTag
+	err := tx.QueryRowContext(ctx,
+		"SELECT DBID, IsExclusive FROM TagTypes WHERE Type = ?", ref.Type,
+	).Scan(&resolved.tagTypeDBID, &resolved.isExclusive)
 	if errors.Is(err, sql.ErrNoRows) {
 		if !create {
-			return 0, false, nil
+			return resolvedMediaTag{}, false, nil
 		}
+		resolved.isExclusive = tags.IsExclusiveType(tags.TagType(ref.Type))
 		result, insertErr := tx.ExecContext(ctx,
 			"INSERT INTO TagTypes (Type, IsExclusive) VALUES (?, ?)",
-			ref.Type, tags.IsExclusiveType(tags.TagType(ref.Type)),
+			ref.Type, resolved.isExclusive,
 		)
 		if insertErr != nil {
-			return 0, false, fmt.Errorf("insert tag type %q: %w", ref.Type, insertErr)
+			return resolvedMediaTag{}, false, fmt.Errorf("insert tag type %q: %w", ref.Type, insertErr)
 		}
-		tagTypeDBID, err = result.LastInsertId()
+		resolved.tagTypeDBID, err = result.LastInsertId()
 	}
 	if err != nil {
-		return 0, false, fmt.Errorf("find tag type %q: %w", ref.Type, err)
+		return resolvedMediaTag{}, false, fmt.Errorf("find tag type %q: %w", ref.Type, err)
 	}
 
 	paddedTag := tags.PadTagValue(ref.Tag)
@@ -244,24 +290,24 @@ func findOrCreateMediaTag(
 		FROM Tags
 		WHERE TypeDBID = ? AND (Tag = ? OR Tag = ?)
 		ORDER BY DBID
-		LIMIT 1`, tagTypeDBID, ref.Tag, paddedTag).Scan(&tagDBID)
+		LIMIT 1`, resolved.tagTypeDBID, ref.Tag, paddedTag).Scan(&resolved.tagDBID)
 	if errors.Is(err, sql.ErrNoRows) {
 		if !create {
-			return 0, false, nil
+			return resolvedMediaTag{}, false, nil
 		}
 		result, insertErr := tx.ExecContext(ctx,
 			"INSERT INTO Tags (TypeDBID, Tag, DisplayName) VALUES (?, ?, '')",
-			tagTypeDBID, paddedTag,
+			resolved.tagTypeDBID, paddedTag,
 		)
 		if insertErr != nil {
-			return 0, false, fmt.Errorf("insert tag %q: %w", ref.Tag, insertErr)
+			return resolvedMediaTag{}, false, fmt.Errorf("insert tag %q: %w", ref.Tag, insertErr)
 		}
-		tagDBID, err = result.LastInsertId()
+		resolved.tagDBID, err = result.LastInsertId()
 	}
 	if err != nil {
-		return 0, false, fmt.Errorf("find tag %q: %w", ref.Tag, err)
+		return resolvedMediaTag{}, false, fmt.Errorf("find tag %q: %w", ref.Tag, err)
 	}
-	return tagDBID, true, nil
+	return resolved, true, nil
 }
 
 func systemTagCacheReady(ctx context.Context, tx *sql.Tx, systemDBID int64) (bool, error) {

--- a/pkg/database/mediadb/media_tag_mutation.go
+++ b/pkg/database/mediadb/media_tag_mutation.go
@@ -1,0 +1,291 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/rs/zerolog/log"
+)
+
+const refreshMediaTagCacheSQL = `
+	WITH tag_count AS (
+		SELECT
+			(SELECT COUNT(*)
+			 FROM MediaTags mt
+			 JOIN Media m ON m.DBID = mt.MediaDBID
+			 WHERE mt.TagDBID = ? AND m.SystemDBID = ? AND m.IsMissing = 0)
+			+
+			(SELECT COUNT(*)
+			 FROM MediaTitleTags mtt
+			 JOIN MediaTitles mtl ON mtl.DBID = mtt.MediaTitleDBID
+			 WHERE mtt.TagDBID = ? AND mtl.SystemDBID = ?
+			   AND EXISTS (
+				   SELECT 1 FROM Media m
+				   WHERE m.MediaTitleDBID = mtl.DBID AND m.IsMissing = 0
+			   )) AS Count
+	)
+	INSERT INTO SystemTagsCache (SystemDBID, TagDBID, TagType, Tag, Count)
+	SELECT ?, t.DBID, tt.Type, t.Tag, tag_count.Count
+	FROM Tags t
+	JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+	CROSS JOIN tag_count
+	WHERE t.DBID = ? AND tag_count.Count > 0`
+
+// UpdateMediaTags mutates file-level tags and refreshes only affected cache
+// aggregates. Removals run before additions, so an addition wins when the same
+// tag appears in both lists.
+func (db *MediaDB) UpdateMediaTags(
+	ctx context.Context,
+	mediaDBID int64,
+	remove []database.MediaTagRef,
+	add []database.MediaTagRef,
+) error {
+	if len(remove) == 0 && len(add) == 0 {
+		return nil
+	}
+
+	systemID, cacheChanged, err := db.applyMediaTagMutations(ctx, mediaDBID, remove, add)
+	if err != nil {
+		return err
+	}
+	if !cacheChanged {
+		return nil
+	}
+
+	// SQL cache rows were updated transactionally. Drop process and persisted
+	// snapshots so no pre-mutation aggregate survives this generation.
+	db.inMemoryTagCache.Store(nil)
+	clearUtilityTagCache()
+	if persistErr := db.PersistTagCache(); persistErr != nil {
+		log.Warn().Err(persistErr).Str("system", systemID).
+			Msg("failed to remove stale persisted tag cache after media tag update")
+	}
+	return nil
+}
+
+func (db *MediaDB) applyMediaTagMutations(
+	ctx context.Context,
+	mediaDBID int64,
+	remove []database.MediaTagRef,
+	add []database.MediaTagRef,
+) (systemID string, cacheChanged bool, err error) {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
+		return "", false, ErrNullSQL
+	}
+	if db.inTransaction {
+		return "", false, ErrTransactionActive
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", false, ctxErr
+	}
+
+	tx, err := sqlDB.BeginTx(ctx, nil)
+	if err != nil {
+		return "", false, fmt.Errorf("begin media tag transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var systemDBID int64
+	if err = tx.QueryRowContext(ctx, `
+		SELECT m.SystemDBID, s.SystemID
+		FROM Media m
+		JOIN Systems s ON s.DBID = m.SystemDBID
+		WHERE m.DBID = ?`, mediaDBID).Scan(&systemDBID, &systemID); err != nil {
+		return "", false, fmt.Errorf("resolve media tag system: %w", err)
+	}
+
+	affectedTagDBIDs := make(map[int64]struct{}, len(remove)+len(add))
+	if removeErr := removeMediaTags(ctx, tx, mediaDBID, remove, affectedTagDBIDs); removeErr != nil {
+		return "", false, removeErr
+	}
+	if addErr := addMediaTags(ctx, tx, mediaDBID, add, affectedTagDBIDs); addErr != nil {
+		return "", false, addErr
+	}
+	if len(affectedTagDBIDs) == 0 {
+		return systemID, false, nil
+	}
+
+	cacheReady, cacheErr := systemTagCacheReady(ctx, tx, systemDBID)
+	if cacheErr != nil {
+		return "", false, cacheErr
+	}
+	if cacheReady {
+		for tagDBID := range affectedTagDBIDs {
+			if refreshErr := refreshMediaTagCache(ctx, tx, systemDBID, tagDBID); refreshErr != nil {
+				return "", false, refreshErr
+			}
+		}
+	}
+	if _, err = tx.ExecContext(ctx, "DELETE FROM MediaCountCache"); err != nil {
+		return "", false, fmt.Errorf("invalidate media count cache after tag update: %w", err)
+	}
+	if _, err = tx.ExecContext(ctx,
+		"DELETE FROM SlugResolutionCache WHERE SystemID = ?", systemID,
+	); err != nil {
+		return "", false, fmt.Errorf("invalidate slug cache after tag update: %w", err)
+	}
+
+	if err = tx.Commit(); err != nil {
+		return "", false, fmt.Errorf("commit media tag transaction: %w", err)
+	}
+	committed = true
+	return systemID, true, nil
+}
+
+func removeMediaTags(
+	ctx context.Context,
+	tx *sql.Tx,
+	mediaDBID int64,
+	refs []database.MediaTagRef,
+	affectedTagDBIDs map[int64]struct{},
+) error {
+	for _, ref := range refs {
+		tagDBID, found, err := findOrCreateMediaTag(ctx, tx, ref, false)
+		if err != nil {
+			return fmt.Errorf("resolve media tag %s:%s for removal: %w", ref.Type, ref.Tag, err)
+		}
+		if !found {
+			continue
+		}
+		if _, err = tx.ExecContext(ctx,
+			"DELETE FROM MediaTags WHERE MediaDBID = ? AND TagDBID = ?", mediaDBID, tagDBID,
+		); err != nil {
+			return fmt.Errorf("remove media tag %s:%s: %w", ref.Type, ref.Tag, err)
+		}
+		affectedTagDBIDs[tagDBID] = struct{}{}
+	}
+	return nil
+}
+
+func addMediaTags(
+	ctx context.Context,
+	tx *sql.Tx,
+	mediaDBID int64,
+	refs []database.MediaTagRef,
+	affectedTagDBIDs map[int64]struct{},
+) error {
+	for _, ref := range refs {
+		tagDBID, _, err := findOrCreateMediaTag(ctx, tx, ref, true)
+		if err != nil {
+			return fmt.Errorf("resolve media tag %s:%s for addition: %w", ref.Type, ref.Tag, err)
+		}
+		if _, err = tx.ExecContext(ctx, insertMediaTagSQL, mediaDBID, tagDBID); err != nil {
+			return fmt.Errorf("add media tag %s:%s: %w", ref.Type, ref.Tag, err)
+		}
+		affectedTagDBIDs[tagDBID] = struct{}{}
+	}
+	return nil
+}
+
+func findOrCreateMediaTag(
+	ctx context.Context,
+	tx *sql.Tx,
+	ref database.MediaTagRef,
+	create bool,
+) (tagDBID int64, found bool, err error) {
+	if ref.Type == "" || ref.Tag == "" {
+		return 0, false, errors.New("media tag type and value are required")
+	}
+
+	var tagTypeDBID int64
+	err = tx.QueryRowContext(ctx, "SELECT DBID FROM TagTypes WHERE Type = ?", ref.Type).Scan(&tagTypeDBID)
+	if errors.Is(err, sql.ErrNoRows) {
+		if !create {
+			return 0, false, nil
+		}
+		result, insertErr := tx.ExecContext(ctx,
+			"INSERT INTO TagTypes (Type, IsExclusive) VALUES (?, ?)",
+			ref.Type, tags.IsExclusiveType(tags.TagType(ref.Type)),
+		)
+		if insertErr != nil {
+			return 0, false, fmt.Errorf("insert tag type %q: %w", ref.Type, insertErr)
+		}
+		tagTypeDBID, err = result.LastInsertId()
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("find tag type %q: %w", ref.Type, err)
+	}
+
+	paddedTag := tags.PadTagValue(ref.Tag)
+	err = tx.QueryRowContext(ctx, `
+		SELECT DBID
+		FROM Tags
+		WHERE TypeDBID = ? AND (Tag = ? OR Tag = ?)
+		ORDER BY DBID
+		LIMIT 1`, tagTypeDBID, ref.Tag, paddedTag).Scan(&tagDBID)
+	if errors.Is(err, sql.ErrNoRows) {
+		if !create {
+			return 0, false, nil
+		}
+		result, insertErr := tx.ExecContext(ctx,
+			"INSERT INTO Tags (TypeDBID, Tag, DisplayName) VALUES (?, ?, '')",
+			tagTypeDBID, paddedTag,
+		)
+		if insertErr != nil {
+			return 0, false, fmt.Errorf("insert tag %q: %w", ref.Tag, insertErr)
+		}
+		tagDBID, err = result.LastInsertId()
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("find tag %q: %w", ref.Tag, err)
+	}
+	return tagDBID, true, nil
+}
+
+func systemTagCacheReady(ctx context.Context, tx *sql.Tx, systemDBID int64) (bool, error) {
+	var ready bool
+	if err := tx.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM SystemTagsCache WHERE SystemDBID = ?)", systemDBID,
+	).Scan(&ready); err != nil {
+		return false, fmt.Errorf("check system tag cache before media tag update: %w", err)
+	}
+	return ready, nil
+}
+
+func refreshMediaTagCache(ctx context.Context, tx *sql.Tx, systemDBID, tagDBID int64) error {
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM SystemTagsCache WHERE SystemDBID = ? AND TagDBID = ?", systemDBID, tagDBID,
+	); err != nil {
+		return fmt.Errorf("clear media tag cache entry: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, refreshMediaTagCacheSQL,
+		tagDBID, systemDBID,
+		tagDBID, systemDBID,
+		systemDBID, tagDBID,
+	); err != nil {
+		return fmt.Errorf("refresh media tag cache entry: %w", err)
+	}
+	return nil
+}

--- a/pkg/database/mediadb/media_tag_mutation_test.go
+++ b/pkg/database/mediadb/media_tag_mutation_test.go
@@ -113,6 +113,35 @@ func TestUpdateMediaTagsUpdatesOnlyAffectedCaches(t *testing.T) {
 	assertMediaHasTag(t, mediaDB, mediaDBID, customGenreRef, false)
 }
 
+func TestUpdateMediaTagsReplacesExclusiveType(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	mediaDBID := mediaRows[0].DBID
+	require.NoError(t, mediaDB.PopulateSystemTagsCache(ctx))
+
+	const exclusiveType = "custom-exclusive"
+	rawDB := mediaDB.UnsafeGetSQLDb()
+	_, err = rawDB.ExecContext(ctx,
+		"INSERT INTO TagTypes (Type, IsExclusive) VALUES (?, 1)", exclusiveType,
+	)
+	require.NoError(t, err)
+	firstRef := database.MediaTagRef{Type: exclusiveType, Tag: "first"}
+	secondRef := database.MediaTagRef{Type: exclusiveType, Tag: "second"}
+
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, nil, []database.MediaTagRef{firstRef}))
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, nil, []database.MediaTagRef{secondRef}))
+	assertMediaHasTag(t, mediaDB, mediaDBID, firstRef, false)
+	assertMediaHasTag(t, mediaDB, mediaDBID, secondRef, true)
+	assert.Zero(t, cachedTagCount(t, rawDB, "NES", firstRef.Type, firstRef.Tag))
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", secondRef.Type, secondRef.Tag))
+}
+
 func TestUpdateMediaTagsDoesNotCreatePartialSystemCache(t *testing.T) {
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()

--- a/pkg/database/mediadb/media_tag_mutation_test.go
+++ b/pkg/database/mediadb/media_tag_mutation_test.go
@@ -142,6 +142,74 @@ func TestUpdateMediaTagsReplacesExclusiveType(t *testing.T) {
 	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", secondRef.Type, secondRef.Tag))
 }
 
+func TestUpdateMediaTagsRollsBackExclusiveReplacementFailure(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	mediaDBID := mediaRows[0].DBID
+	require.NoError(t, mediaDB.PopulateSystemTagsCache(ctx))
+
+	const exclusiveType = "failing-exclusive"
+	rawDB := mediaDB.UnsafeGetSQLDb()
+	_, err = rawDB.ExecContext(ctx,
+		"INSERT INTO TagTypes (Type, IsExclusive) VALUES (?, 1)", exclusiveType,
+	)
+	require.NoError(t, err)
+	firstRef := database.MediaTagRef{Type: exclusiveType, Tag: "first"}
+	secondRef := database.MediaTagRef{Type: exclusiveType, Tag: "second"}
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, nil, []database.MediaTagRef{firstRef}))
+	_, err = rawDB.ExecContext(ctx, `
+		CREATE TRIGGER fail_exclusive_media_tag_delete
+		BEFORE DELETE ON MediaTags
+		BEGIN
+			SELECT RAISE(ABORT, 'injected exclusive replacement failure');
+		END`)
+	require.NoError(t, err)
+
+	err = mediaDB.UpdateMediaTags(ctx, mediaDBID, nil, []database.MediaTagRef{secondRef})
+	require.ErrorContains(t, err, "injected exclusive replacement failure")
+	assertMediaHasTag(t, mediaDB, mediaDBID, firstRef, true)
+	assertMediaHasTag(t, mediaDB, mediaDBID, secondRef, false)
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", firstRef.Type, firstRef.Tag))
+	assert.Zero(t, cachedTagCount(t, rawDB, "NES", secondRef.Type, secondRef.Tag))
+}
+
+func TestUpdateMediaTagsMissingRemovalDoesNotInvalidateCaches(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	require.NoError(t, mediaDB.PopulateSystemTagsCache(ctx))
+	require.NoError(t, mediaDB.RebuildTagCache())
+	initialCache := mediaDB.inMemoryTagCache.Load()
+	require.NotNil(t, initialCache)
+
+	rawDB := mediaDB.UnsafeGetSQLDb()
+	_, err = rawDB.ExecContext(ctx, `
+		INSERT INTO MediaCountCache (QueryHash, QueryParams, Count, MinDBID, MaxDBID, LastUpdated)
+		VALUES ('keep', '{}', 1, 1, 1, 1)`)
+	require.NoError(t, err)
+	remove := []database.MediaTagRef{
+		{Type: "missing-type", Tag: "missing"},
+		{Type: string(tags.TagTypeGenre), Tag: "missing"},
+	}
+
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaRows[0].DBID, remove, nil))
+	assert.Same(t, initialCache, mediaDB.inMemoryTagCache.Load())
+	var countCacheRows int
+	require.NoError(t, rawDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM MediaCountCache").Scan(&countCacheRows))
+	assert.Equal(t, 1, countCacheRows)
+}
+
 func TestUpdateMediaTagsDoesNotCreatePartialSystemCache(t *testing.T) {
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
@@ -190,6 +258,43 @@ func TestUpdateMediaTagsRollsBackWhenCacheRefreshFails(t *testing.T) {
 	err = mediaDB.UpdateMediaTags(ctx, mediaRows[0].DBID, nil, []database.MediaTagRef{favoriteRef})
 	require.ErrorContains(t, err, "injected cache refresh failure")
 	assertMediaHasTag(t, mediaDB, mediaRows[0].DBID, favoriteRef, false)
+}
+
+func TestUpdateMediaTagsRejectsInvalidTag(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	invalidRef := database.MediaTagRef{Type: string(tags.TagTypeUser)}
+
+	err = mediaDB.UpdateMediaTags(
+		context.Background(), mediaRows[0].DBID, nil, []database.MediaTagRef{invalidRef},
+	)
+	require.ErrorContains(t, err, "media tag type and value are required")
+}
+
+func TestUpdateMediaTagsRejectsActiveTransaction(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+
+	err = mediaDB.UpdateMediaTags(
+		context.Background(), mediaRows[0].DBID, nil, []database.MediaTagRef{favoriteRef},
+	)
+	require.ErrorIs(t, err, ErrTransactionActive)
+	require.NoError(t, mediaDB.RollbackTransaction())
 }
 
 func TestUpdateMediaTagsHonorsCanceledContext(t *testing.T) {

--- a/pkg/database/mediadb/media_tag_mutation_test.go
+++ b/pkg/database/mediadb/media_tag_mutation_test.go
@@ -1,0 +1,233 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateMediaTagsUpdatesOnlyAffectedCaches(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	mediaDBID := mediaRows[0].DBID
+	require.NoError(t, mediaDB.PopulateSystemTagsCache(ctx))
+
+	rawDB := mediaDB.UnsafeGetSQLDb()
+	utilityTagsBefore, err := resolveUtilityTagDBIDs(ctx, rawDB)
+	require.NoError(t, err)
+	require.Empty(t, utilityTagsBefore)
+	genreCountBefore := cachedTagCount(t, rawDB, "NES", string(tags.TagTypeGenre), "platform")
+	require.Positive(t, genreCountBefore)
+
+	_, err = rawDB.ExecContext(ctx, `
+		INSERT INTO MediaCountCache (QueryHash, QueryParams, Count, MinDBID, MaxDBID, LastUpdated)
+		VALUES ('stale', '{}', 1, 1, 1, 1)`)
+	require.NoError(t, err)
+	favoriteFilter := []zapscript.TagFilter{{
+		Type:  string(tags.TagTypeUser),
+		Value: string(tags.TagUserFavorite),
+	}}
+	require.NoError(t, mediaDB.SetCachedSlugResolution(
+		ctx, "NES", "favorite-game", favoriteFilter, mediaDBID, "test",
+	))
+	require.NoError(t, mediaDB.SetCachedSlugResolution(
+		ctx, "SNES", "other-game", favoriteFilter, mediaDBID, "test",
+	))
+
+	require.NoError(t, mediaDB.RebuildTagCache())
+	require.NotNil(t, mediaDB.inMemoryTagCache.Load())
+	require.NoError(t, mediaDB.PersistTagCache())
+	_, err = os.Stat(mediaDB.tagCachePath())
+	require.NoError(t, err)
+
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+	customGenreRef := database.MediaTagRef{Type: string(tags.TagTypeGenre), Tag: "custom"}
+	refs := []database.MediaTagRef{favoriteRef, customGenreRef}
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, nil, refs))
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", favoriteRef.Type, favoriteRef.Tag))
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", customGenreRef.Type, customGenreRef.Tag))
+	assert.Equal(t, genreCountBefore, cachedTagCount(t, rawDB, "NES", string(tags.TagTypeGenre), "platform"))
+	assertMediaHasTag(t, mediaDB, mediaDBID, favoriteRef, true)
+	assertMediaHasTag(t, mediaDB, mediaDBID, customGenreRef, true)
+	utilityTagsAfter, utilityErr := resolveUtilityTagDBIDs(ctx, rawDB)
+	require.NoError(t, utilityErr)
+	assert.Len(t, utilityTagsAfter, 1)
+	assert.Nil(t, mediaDB.inMemoryTagCache.Load())
+	_, err = os.Stat(mediaDB.tagCachePath())
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	var countCacheRows int
+	require.NoError(t, rawDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM MediaCountCache").Scan(&countCacheRows))
+	assert.Zero(t, countCacheRows)
+	_, _, found := mediaDB.GetCachedSlugResolution(ctx, "NES", "favorite-game", favoriteFilter)
+	assert.False(t, found)
+	_, _, found = mediaDB.GetCachedSlugResolution(ctx, "SNES", "other-game", favoriteFilter)
+	assert.True(t, found)
+
+	// Removals run before additions, so overlapping updates remain present and
+	// do not inflate aggregate counts.
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, refs, refs))
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", favoriteRef.Type, favoriteRef.Tag))
+	assert.Equal(t, int64(1), cachedTagCount(t, rawDB, "NES", customGenreRef.Type, customGenreRef.Tag))
+
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaDBID, refs, nil))
+	assert.Zero(t, cachedTagCount(t, rawDB, "NES", favoriteRef.Type, favoriteRef.Tag))
+	assert.Zero(t, cachedTagCount(t, rawDB, "NES", customGenreRef.Type, customGenreRef.Tag))
+	assert.Equal(t, genreCountBefore, cachedTagCount(t, rawDB, "NES", string(tags.TagTypeGenre), "platform"))
+	assertMediaHasTag(t, mediaDB, mediaDBID, favoriteRef, false)
+	assertMediaHasTag(t, mediaDB, mediaDBID, customGenreRef, false)
+}
+
+func TestUpdateMediaTagsDoesNotCreatePartialSystemCache(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, mediaRows[0].DBID, nil, []database.MediaTagRef{favoriteRef}))
+	var cacheRows int
+	require.NoError(t, mediaDB.UnsafeGetSQLDb().QueryRowContext(
+		ctx, "SELECT COUNT(*) FROM SystemTagsCache",
+	).Scan(&cacheRows))
+	assert.Zero(t, cacheRows)
+	assertMediaHasTag(t, mediaDB, mediaRows[0].DBID, favoriteRef, true)
+}
+
+func TestUpdateMediaTagsRollsBackWhenCacheRefreshFails(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	ctx := context.Background()
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	require.NoError(t, mediaDB.PopulateSystemTagsCache(ctx))
+	_, err = mediaDB.UnsafeGetSQLDb().ExecContext(ctx, `
+		CREATE TRIGGER fail_media_tag_cache_refresh
+		BEFORE INSERT ON SystemTagsCache
+		BEGIN
+			SELECT RAISE(ABORT, 'injected cache refresh failure');
+		END`)
+	require.NoError(t, err)
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+
+	err = mediaDB.UpdateMediaTags(ctx, mediaRows[0].DBID, nil, []database.MediaTagRef{favoriteRef})
+	require.ErrorContains(t, err, "injected cache refresh failure")
+	assertMediaHasTag(t, mediaDB, mediaRows[0].DBID, favoriteRef, false)
+}
+
+func TestUpdateMediaTagsHonorsCanceledContext(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	insertNESGameWithTag(t, mediaDB)
+
+	mediaRows, err := mediaDB.GetMediaBySystemID("NES")
+	require.NoError(t, err)
+	require.Len(t, mediaRows, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+
+	err = mediaDB.UpdateMediaTags(ctx, mediaRows[0].DBID, nil, []database.MediaTagRef{favoriteRef})
+	require.ErrorIs(t, err, context.Canceled)
+	assertMediaHasTag(t, mediaDB, mediaRows[0].DBID, favoriteRef, false)
+}
+
+func TestUpdateMediaTagsRejectsMissingMedia(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	favoriteRef := database.MediaTagRef{
+		Type: string(tags.TagTypeUser),
+		Tag:  string(tags.TagUserFavorite),
+	}
+
+	err := mediaDB.UpdateMediaTags(context.Background(), 999, nil, []database.MediaTagRef{favoriteRef})
+	require.Error(t, err)
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func cachedTagCount(t *testing.T, rawDB *sql.DB, systemID, tagType, tag string) int64 {
+	t.Helper()
+	var count int64
+	err := rawDB.QueryRowContext(context.Background(), `
+		SELECT COALESCE(SUM(stc.Count), 0)
+		FROM SystemTagsCache stc
+		JOIN Systems s ON s.DBID = stc.SystemDBID
+		WHERE s.SystemID = ? AND stc.TagType = ? AND stc.Tag = ?`,
+		systemID, tagType, tag,
+	).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+func assertMediaHasTag(
+	t *testing.T,
+	mediaDB *MediaDB,
+	mediaDBID int64,
+	ref database.MediaTagRef,
+	expected bool,
+) {
+	t.Helper()
+	tagList, err := mediaDB.GetMediaTagsByMediaDBID(context.Background(), mediaDBID)
+	require.NoError(t, err)
+	found := false
+	for _, tag := range tagList {
+		if tag.Type == ref.Type && tag.Tag == ref.Tag {
+			found = true
+			break
+		}
+	}
+	assert.Equal(t, expected, found)
+}
+
+var _ database.MediaDBI = (*MediaDB)(nil)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1609,6 +1609,19 @@ func (m *MockMediaDBI) DeleteMediaTag(mediaDBID, tagDBID int64) error {
 	return nil
 }
 
+func (m *MockMediaDBI) UpdateMediaTags(
+	ctx context.Context,
+	mediaDBID int64,
+	remove []database.MediaTagRef,
+	add []database.MediaTagRef,
+) error {
+	args := m.Called(ctx, mediaDBID, remove, add)
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil
+}
+
 // TagType CRUD methods
 func (m *MockMediaDBI) FindTagType(row database.TagType) (database.TagType, error) {
 	args := m.Called(row)


### PR DESCRIPTION
## Summary

- move media tag additions and removals into one generic, request-scoped MediaDB transaction
- refresh only affected `SystemTagsCache` aggregates and affected-system slug entries instead of clearing the full tag cache
- keep `user:favorite` durability in UserDB while making MediaDB mutation and cache handling tag-generic
- preserve remove-before-add semantics, idempotency, and atomic rollback on cache failures

On the supplied 45,661-row cache snapshot, the targeted favorite transaction completes in about 0.7 ms while preserving unrelated rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved adding, removing, and replacing media tags, including favorites.
  - Kept media counts, slugs, and cached tag information consistent after updates.
  - Added safer rollback behavior to prevent partial changes when updates fail.
  - Improved error handling for invalid, missing, or interrupted tag updates.

- **Tests**
  - Expanded coverage for tag updates, cache refreshes, failures, cancellations, and missing media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->