### PR TITLE
feat(API): Add systems.favorites API endpoint

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -901,6 +901,14 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		return nil, fmt.Errorf("error searching media with filters: %w", err)
 	}
 
+	// Count the full result set for the query, ignoring cursor pagination.
+	countFilters := searchFilters
+	countFilters.Cursor = nil
+	fullTotal, err := env.Database.MediaDB.SearchMediaWithFiltersCount(ctx, &countFilters)
+	if err != nil {
+		return nil, fmt.Errorf("error counting search results: %w", err)
+	}
+
 	// Check if there are more results
 	hasNextPage := len(searchResults) > maxResults
 	if hasNextPage {
@@ -984,7 +992,7 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	return models.SearchResults{
 		Results:    results,
-		Total:      len(results), // Deprecated: returns count of results in response
+		Total:      fullTotal,
 		Pagination: pagination,
 	}, nil
 }

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -901,18 +901,25 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		return nil, fmt.Errorf("error searching media with filters: %w", err)
 	}
 
-	// Count the full result set for the query, ignoring cursor pagination.
-	countFilters := searchFilters
-	countFilters.Cursor = nil
-	fullTotal, err := env.Database.MediaDB.SearchMediaWithFiltersCount(ctx, &countFilters)
-	if err != nil {
-		return nil, fmt.Errorf("error counting search results: %w", err)
-	}
-
 	// Check if there are more results
 	hasNextPage := len(searchResults) > maxResults
 	if hasNextPage {
 		searchResults = searchResults[:maxResults]
+	}
+
+	// Count the full result set for the query, ignoring cursor pagination.
+	// If there is no cursor and the first page proves there are no more results,
+	// the total is already known and we can skip the extra COUNT query.
+	var fullTotal int
+	if cursor == nil && !hasNextPage {
+		fullTotal = len(searchResults)
+	} else {
+		countFilters := searchFilters
+		countFilters.Cursor = nil
+		fullTotal, err = env.Database.MediaDB.SearchMediaWithFiltersCount(ctx, &countFilters)
+		if err != nil {
+			return nil, fmt.Errorf("error counting search results: %w", err)
+		}
 	}
 
 	// Convert to API models

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -142,6 +142,12 @@ func TestHandleMediaSearch_WithoutCursor(t *testing.T) {
 				len(filters.Tags) == 0 // No tags for this test
 		}),
 	).Return(expectedResults, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "mario" && filters.Cursor == nil && len(filters.Tags) == 0
+		}),
+	).Return(len(expectedResults), nil)
 
 	// Create request without cursor (initial request)
 	query := "mario"
@@ -229,6 +235,12 @@ func TestHandleMediaSearch_WithCursor(t *testing.T) {
 				len(filters.Systems) > 0 // Should have systems
 		}),
 	).Return(expectedResults, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "mario" && filters.Cursor == nil && len(filters.Tags) == 0
+		}),
+	).Return(3, nil)
 
 	// Create request with cursor
 	cursorStr, err := encodeCursor(50)
@@ -267,8 +279,7 @@ func TestHandleMediaSearch_WithCursor(t *testing.T) {
 	require.True(t, ok, "Should return SearchResults")
 
 	assert.Len(t, searchResults.Results, 2, "Should return 2 results (maxResults)")
-	assert.Equal(t, len(searchResults.Results), searchResults.Total,
-		"Total should equal result count (deprecated field)")
+	assert.Equal(t, 3, searchResults.Total, "Total should report the full result count")
 	assert.NotNil(t, searchResults.Pagination, "Pagination should not be nil for cursor requests")
 
 	// Verify pagination info
@@ -432,9 +443,18 @@ func TestHandleMediaSearch_WithLetterFiltering(t *testing.T) {
 	// Test valid letter parameter
 	letter := "M"
 	query := "test"
-	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.MatchedBy(func(filters *database.SearchFilters) bool {
-		return filters.Letter != nil && *filters.Letter == letter
-	})).Return([]database.SearchResultWithCursor{}, nil).Once()
+	mockMediaDB.On("SearchMediaWithFilters",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Letter != nil && *filters.Letter == letter
+		}),
+	).Return([]database.SearchResultWithCursor{}, nil).Once()
+	mockMediaDB.On("SearchMediaWithFiltersCount",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Letter != nil && *filters.Letter == letter && filters.Cursor == nil
+		}),
+	).Return(0, nil).Once()
 
 	// Create test parameters
 	params := models.SearchParams{
@@ -488,6 +508,12 @@ func TestHandleMediaSearch_FullyBlankQuery(t *testing.T) {
 				filters.Limit == 101
 		}),
 	).Return(expectedResults, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "" && filters.Cursor == nil
+		}),
+	).Return(len(expectedResults), nil)
 
 	// Create request with fully blank parameters
 	params := models.SearchParams{
@@ -555,6 +581,12 @@ func TestHandleMediaSearch_TagsOnly(t *testing.T) {
 				len(filters.Systems) > 0 // Should have all systems
 		}),
 	).Return(expectedResults, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Query == "" && filters.Cursor == nil && len(filters.Tags) == 1
+		}),
+	).Return(len(expectedResults), nil)
 
 	// Create request with tags only (no query or systems)
 	tags := []string{"genre:RPG"}
@@ -615,6 +647,7 @@ func TestHandleMediaSearch_SystemMetadata(t *testing.T) {
 		mock.Anything, // context
 		mock.Anything, // filters
 	).Return(expectedResults, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount", mock.Anything, mock.Anything).Return(len(expectedResults), nil)
 
 	// Create request
 	query := "test"
@@ -725,6 +758,7 @@ func TestHandleMediaSearch_AcceptsFuzzySystem(t *testing.T) {
 			return len(filters.Systems) == 1 && filters.Systems[0].ID == "Genesis"
 		}),
 	).Return([]database.SearchResultWithCursor{}, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount", mock.Anything, mock.Anything).Return(0, nil)
 
 	query := "test"
 	fuzzyMatch := true
@@ -866,6 +900,7 @@ func TestHandleMediaSearch_DeduplicatesSystems(t *testing.T) {
 			return len(filters.Systems) == 1
 		}),
 	).Return([]database.SearchResultWithCursor{}, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount", mock.Anything, mock.Anything).Return(0, nil)
 
 	query := "test"
 	params := models.SearchParams{
@@ -1050,6 +1085,7 @@ func TestHandleMediaSearch_RelativePaths(t *testing.T) {
 	).Return([]database.SearchResultWithCursor{
 		{SystemID: "NES", Name: "Mario Bros", Path: mediaPath, MediaID: 1},
 	}, nil)
+	mockMediaDB.On("SearchMediaWithFiltersCount", mock.Anything, mock.Anything).Return(1, nil)
 
 	query := "mario"
 	params := models.SearchParams{Query: &query}

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -142,13 +142,6 @@ func TestHandleMediaSearch_WithoutCursor(t *testing.T) {
 				len(filters.Tags) == 0 // No tags for this test
 		}),
 	).Return(expectedResults, nil)
-	mockMediaDB.On("SearchMediaWithFiltersCount",
-		mock.Anything,
-		mock.MatchedBy(func(filters *database.SearchFilters) bool {
-			return filters.Query == "mario" && filters.Cursor == nil && len(filters.Tags) == 0
-		}),
-	).Return(len(expectedResults), nil)
-
 	// Create request without cursor (initial request)
 	query := "mario"
 	params := models.SearchParams{
@@ -177,8 +170,9 @@ func TestHandleMediaSearch_WithoutCursor(t *testing.T) {
 	result, err := HandleMediaSearch(env)
 	require.NoError(t, err)
 
-	// Check if mocks were called at all
-	t.Logf("Mock calls made: %v", mockMediaDB.Calls)
+	// Verify SearchMediaWithFiltersCount was not called because the first page
+	// proved there are no more results.
+	mockMediaDB.AssertNotCalled(t, "SearchMediaWithFiltersCount", mock.Anything, mock.Anything)
 
 	// Verify response format with cursor-based pagination
 	searchResults, ok := result.(models.SearchResults)

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -123,7 +123,8 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 	return models.SystemsResponse{Systems: respSystems}, nil
 }
 
-func HandleSystemFavorites(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
+//nolint:gocritic // single-use parameter in API handler
+func HandleSystemFavorites(env requests.RequestEnv) (any, error) {
 	log.Info().Msg("received system favorites request")
 
 	filters := &database.SearchFilters{
@@ -140,7 +141,8 @@ func HandleSystemFavorites(env requests.RequestEnv) (any, error) { //nolint:gocr
 	seen := make(map[string]struct{}, len(filters.Systems))
 	systemIDs := make([]string, 0, len(filters.Systems))
 
-	for _, result := range results {
+	for i := range results {
+		result := &results[i]
 		if result.SystemID == "" {
 			continue
 		}

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -130,30 +130,11 @@ func HandleSystemFavorites(env requests.RequestEnv) (any, error) {
 	filters := &database.SearchFilters{
 		Systems: systemdefs.AllSystems(),
 		Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
-		Limit:   0,
 	}
 
-	results, err := env.Database.MediaDB.SearchMediaWithFilters(env.Context, filters)
+	systemIDs, err := env.Database.MediaDB.SearchMediaWithFiltersSystemIDs(env.Context, filters)
 	if err != nil {
-		return nil, fmt.Errorf("error searching favorite media: %w", err)
-	}
-
-	seen := make(map[string]struct{}, len(filters.Systems))
-	systemIDs := make([]string, 0, len(filters.Systems))
-
-	for i := range results {
-		result := &results[i]
-		if result.SystemID == "" {
-			continue
-		}
-		if _, ok := seen[result.SystemID]; ok {
-			continue
-		}
-		seen[result.SystemID] = struct{}{}
-		systemIDs = append(systemIDs, result.SystemID)
-		if len(seen) == len(filters.Systems) {
-			break
-		}
+		return nil, fmt.Errorf("error searching favorite systems: %w", err)
 	}
 
 	respSystems := make([]models.System, 0, len(systemIDs))

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -20,10 +20,14 @@
 package methods
 
 import (
+	"fmt"
+
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/rs/zerolog/log"
@@ -114,6 +118,65 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 				ZapScript: system.ZapScript(),
 			})
 		}
+	}
+
+	return models.SystemsResponse{Systems: respSystems}, nil
+}
+
+func HandleSystemFavorites(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
+	log.Info().Msg("received system favorites request")
+
+	filters := &database.SearchFilters{
+		Systems: systemdefs.AllSystems(),
+		Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
+		Limit:   0,
+	}
+
+	results, err := env.Database.MediaDB.SearchMediaWithFilters(env.Context, filters)
+	if err != nil {
+		return nil, fmt.Errorf("error searching favorite media: %w", err)
+	}
+
+	seen := make(map[string]struct{}, len(filters.Systems))
+	systemIDs := make([]string, 0, len(filters.Systems))
+
+	for _, result := range results {
+		if result.SystemID == "" {
+			continue
+		}
+		if _, ok := seen[result.SystemID]; ok {
+			continue
+		}
+		seen[result.SystemID] = struct{}{}
+		systemIDs = append(systemIDs, result.SystemID)
+		if len(seen) == len(filters.Systems) {
+			break
+		}
+	}
+
+	respSystems := make([]models.System, 0, len(systemIDs))
+	for _, id := range systemIDs {
+		system, systemErr := systemdefs.GetSystem(id)
+		if systemErr != nil {
+			log.Error().Err(systemErr).Msgf("error getting system: %s", id)
+			continue
+		}
+
+		sr := models.System{ID: system.ID}
+		sm, metadataErr := assets.GetSystemMetadata(id)
+		if metadataErr != nil {
+			log.Error().Err(metadataErr).Msgf("error getting system metadata: %s", id)
+		} else {
+			sr.Name = sm.Name
+			sr.Category = sm.Category
+			if sm.ReleaseDate != "" {
+				sr.ReleaseDate = &sm.ReleaseDate
+			}
+			if sm.Manufacturer != "" {
+				sr.Manufacturer = &sm.Manufacturer
+			}
+		}
+		respSystems = append(respSystems, sr)
 	}
 
 	return models.SystemsResponse{Systems: respSystems}, nil

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -136,26 +135,19 @@ func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
 	mockMediaDB := testhelpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 
-	// Return duplicate results for NES and one for SNES; handler should
-	// deduplicate and return each system once.
-	results := []database.SearchResultWithCursor{
-		{SystemID: "NES", Name: "Game A", Path: filepath.Join("games", "a.nes"), MediaID: 1},
-		{SystemID: "NES", Name: "Game B", Path: filepath.Join("games", "b.nes"), MediaID: 2},
-		{SystemID: "SNES", Name: "Game C", Path: filepath.Join("games", "c.sfc"), MediaID: 3},
-	}
-
-	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.MatchedBy(func(filters *database.SearchFilters) bool {
-		if len(filters.Tags) != 1 {
-			return false
-		}
-		if filters.Tags[0].Type != "user" || filters.Tags[0].Value != "favorite" {
-			return false
-		}
-		if filters.Limit != 0 {
-			return false
-		}
-		return assert.Equal(t, systemdefs.AllSystems(), filters.Systems)
-	})).Return(results, nil)
+	mockMediaDB.On(
+		"SearchMediaWithFiltersSystemIDs",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			if len(filters.Tags) != 1 {
+				return false
+			}
+			if filters.Tags[0].Type != "user" || filters.Tags[0].Value != "favorite" {
+				return false
+			}
+			return assert.Equal(t, systemdefs.AllSystems(), filters.Systems)
+		}),
+	).Return([]string{"NES", "SNES"}, nil)
 
 	env := requests.RequestEnv{
 		Context: context.Background(),
@@ -199,10 +191,10 @@ func TestHandleSystemFavorites_NoFavoritesReturnsEmpty(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 
 	mockMediaDB.On(
-		"SearchMediaWithFilters",
+		"SearchMediaWithFiltersSystemIDs",
 		mock.Anything,
 		mock.Anything,
-	).Return([]database.SearchResultWithCursor{}, nil)
+	).Return([]string{}, nil)
 
 	env := requests.RequestEnv{
 		Context: context.Background(),

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -138,9 +139,9 @@ func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
 	// Return duplicate results for NES and one for SNES; handler should
 	// deduplicate and return each system once.
 	results := []database.SearchResultWithCursor{
-		{SystemID: "NES", Name: "Game A", Path: "/games/a.nes", MediaID: 1},
-		{SystemID: "NES", Name: "Game B", Path: "/games/b.nes", MediaID: 2},
-		{SystemID: "SNES", Name: "Game C", Path: "/games/c.sfc", MediaID: 3},
+		{SystemID: "NES", Name: "Game A", Path: filepath.Join("games", "a.nes"), MediaID: 1},
+		{SystemID: "NES", Name: "Game B", Path: filepath.Join("games", "b.nes"), MediaID: 2},
+		{SystemID: "SNES", Name: "Game C", Path: filepath.Join("games", "c.sfc"), MediaID: 3},
 	}
 
 	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.MatchedBy(func(filters *database.SearchFilters) bool {

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -147,7 +147,7 @@ func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
 			}
 			return assert.Equal(t, systemdefs.AllSystems(), filters.Systems)
 		}),
-	).Return([]string{"NES", "SNES"}, nil)
+	).Return([]string{"NES", "SNES", "UNKNOWN"}, nil)
 
 	env := requests.RequestEnv{
 		Context: context.Background(),
@@ -172,6 +172,8 @@ func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
 
 	assert.Contains(t, ids, "NES")
 	assert.Contains(t, ids, "SNES")
+	assert.NotContains(t, ids, "UNKNOWN")
+
 	// Ensure NES only appears once
 	countNES := 0
 	for _, s := range resp.Systems {

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -198,7 +198,11 @@ func TestHandleSystemFavorites_NoFavoritesReturnsEmpty(t *testing.T) {
 	mockMediaDB := testhelpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 
-	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.Anything).Return([]database.SearchResultWithCursor{}, nil)
+	mockMediaDB.On(
+		"SearchMediaWithFilters",
+		mock.Anything,
+		mock.Anything,
+	).Return([]database.SearchResultWithCursor{}, nil)
 
 	env := requests.RequestEnv{
 		Context: context.Background(),
@@ -214,7 +218,7 @@ func TestHandleSystemFavorites_NoFavoritesReturnsEmpty(t *testing.T) {
 
 	resp, ok := res.(models.SystemsResponse)
 	require.True(t, ok, "expected SystemsResponse")
-	assert.Len(t, resp.Systems, 0, "should return no systems when there are no favorites")
+	assert.Empty(t, resp.Systems, "should return no systems when there are no favorites")
 
 	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -31,7 +32,9 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,4 +127,86 @@ func systemResponseIDs(response models.SystemsResponse) []string {
 		ids[i] = response.Systems[i].ID
 	}
 	return ids
+}
+
+func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
+	mockUserDB := &testhelpers.MockUserDBI{}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+
+	// Return duplicate results for NES and one for SNES; handler should
+	// deduplicate and return each system once.
+	results := []database.SearchResultWithCursor{
+		{SystemID: "NES", Name: "Game A", Path: "/games/a.nes", MediaID: 1},
+		{SystemID: "NES", Name: "Game B", Path: "/games/b.nes", MediaID: 2},
+		{SystemID: "SNES", Name: "Game C", Path: "/games/c.sfc", MediaID: 3},
+	}
+
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.MatchedBy(func(filters *database.SearchFilters) bool {
+		if len(filters.Tags) != 1 {
+			return false
+		}
+		return filters.Tags[0].Type == "user" && filters.Tags[0].Value == "favorite"
+	})).Return(results, nil)
+
+	env := requests.RequestEnv{
+		Context: context.Background(),
+		Database: &database.Database{
+			UserDB:  mockUserDB,
+			MediaDB: mockMediaDB,
+		},
+		Platform: mockPlatform,
+	}
+
+	res, err := HandleSystemFavorites(env)
+	require.NoError(t, err)
+
+	resp, ok := res.(models.SystemsResponse)
+	require.True(t, ok, "expected SystemsResponse")
+
+	// Extract IDs for easy assertions
+	ids := make(map[string]struct{})
+	for _, s := range resp.Systems {
+		ids[s.ID] = struct{}{}
+	}
+
+	assert.Contains(t, ids, "NES")
+	assert.Contains(t, ids, "SNES")
+	// Ensure NES only appears once
+	countNES := 0
+	for _, s := range resp.Systems {
+		if s.ID == "NES" {
+			countNES++
+		}
+	}
+	assert.Equal(t, 1, countNES, "NES should appear only once")
+
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestHandleSystemFavorites_NoFavoritesReturnsEmpty(t *testing.T) {
+	mockUserDB := &testhelpers.MockUserDBI{}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything, mock.Anything).Return([]database.SearchResultWithCursor{}, nil)
+
+	env := requests.RequestEnv{
+		Context: context.Background(),
+		Database: &database.Database{
+			UserDB:  mockUserDB,
+			MediaDB: mockMediaDB,
+		},
+		Platform: mockPlatform,
+	}
+
+	res, err := HandleSystemFavorites(env)
+	require.NoError(t, err)
+
+	resp, ok := res.(models.SystemsResponse)
+	require.True(t, ok, "expected SystemsResponse")
+	assert.Len(t, resp.Systems, 0, "should return no systems when there are no favorites")
+
+	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -146,7 +147,13 @@ func TestHandleSystemFavorites_ReturnsFavoritedSystemsUnique(t *testing.T) {
 		if len(filters.Tags) != 1 {
 			return false
 		}
-		return filters.Tags[0].Type == "user" && filters.Tags[0].Value == "favorite"
+		if filters.Tags[0].Type != "user" || filters.Tags[0].Value != "favorite" {
+			return false
+		}
+		if filters.Limit != 0 {
+			return false
+		}
+		return assert.Equal(t, systemdefs.AllSystems(), filters.Systems)
 	})).Return(results, nil)
 
 	env := requests.RequestEnv{

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -153,6 +153,7 @@ const (
 	MethodProfilesSwitch              = "profiles.switch"
 	MethodProfilesVerify              = "profiles.verify"
 	MethodSystems                     = "systems"
+	MethodSystemsFavorites            = "systems.favorites"
 	MethodLaunchers                   = "launchers"
 	MethodLaunchersRefresh            = "launchers.refresh"
 	MethodHistory                     = "tokens.history"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -291,7 +291,8 @@ func NewMethodMap() *MethodMap {
 		models.MethodPlaytimeLimitsUpdate:        methods.HandlePlaytimeLimitsUpdate,
 		models.MethodPlaytime:                    methods.HandlePlaytime,
 		// systems
-		models.MethodSystems: methods.HandleSystems,
+		models.MethodSystems:          methods.HandleSystems,
+		models.MethodSystemsFavorites: methods.HandleSystemFavorites,
 		// launchers
 		models.MethodLaunchers:        methods.HandleLaunchers,
 		models.MethodLaunchersRefresh: methods.HandleLaunchersRefresh,

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -972,6 +972,7 @@ type MediaDBI interface {
 
 	SearchMediaPathExact(ctx context.Context, systems []systemdefs.System, query string) ([]SearchResult, error)
 	SearchMediaWithFilters(ctx context.Context, filters *SearchFilters) ([]SearchResultWithCursor, error)
+	SearchMediaWithFiltersCount(ctx context.Context, filters *SearchFilters) (int, error)
 	SearchMediaBySlug(
 		ctx context.Context, systemID string, slug string, tags []zapscript.TagFilter,
 	) ([]SearchResultWithCursor, error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -973,6 +973,7 @@ type MediaDBI interface {
 	SearchMediaPathExact(ctx context.Context, systems []systemdefs.System, query string) ([]SearchResult, error)
 	SearchMediaWithFilters(ctx context.Context, filters *SearchFilters) ([]SearchResultWithCursor, error)
 	SearchMediaWithFiltersCount(ctx context.Context, filters *SearchFilters) (int, error)
+	SearchMediaWithFiltersSystemIDs(ctx context.Context, filters *SearchFilters) ([]string, error)
 	SearchMediaBySlug(
 		ctx context.Context, systemID string, slug string, tags []zapscript.TagFilter,
 	) ([]SearchResultWithCursor, error)

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2278,9 +2278,7 @@ func (db *MediaDB) SearchMediaWithFilters(
 			variants = variants[:maxVariantsPerWord]
 		}
 
-		if len(variants) > 0 {
-			variantGroups = append(variantGroups, variants)
-		}
+		variantGroups = append(variantGroups, variants)
 	}
 
 	// Try in-memory cache path when we have slug variants and no Name fallback
@@ -2373,9 +2371,7 @@ func (db *MediaDB) SearchMediaWithFiltersCount(
 			variants = variants[:maxVariantsPerWord]
 		}
 
-		if len(variants) > 0 {
-			variantGroups = append(variantGroups, variants)
-		}
+		variantGroups = append(variantGroups, variants)
 	}
 
 	cache := db.slugSearchCache.Load()

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2332,6 +2332,99 @@ func (db *MediaDB) SearchMediaWithFilters(
 	return results, err
 }
 
+func (db *MediaDB) SearchMediaWithFiltersCount(
+	ctx context.Context,
+	filters *database.SearchFilters,
+) (int, error) {
+	if db.sql.Load() == nil {
+		return 0, ErrNullSQL
+	}
+
+	// Collect unique MediaTypes from the systems being searched
+	uniqueMediaTypes := make(map[slugs.MediaType]struct{})
+	for _, system := range filters.Systems {
+		uniqueMediaTypes[system.GetMediaType()] = struct{}{}
+	}
+
+	qWords := strings.Fields(filters.Query)
+	variantGroups := make([][]string, 0, len(qWords))
+	includeName := false
+
+	for _, word := range qWords {
+		seenVariants := make(map[string]struct{})
+		variants := make([]string, 0, len(uniqueMediaTypes))
+
+		for mediaType := range uniqueMediaTypes {
+			slugVariant := slugs.Slugify(mediaType, word)
+			if slugVariant != "" {
+				if _, exists := seenVariants[slugVariant]; !exists {
+					variants = append(variants, slugVariant)
+					seenVariants[slugVariant] = struct{}{}
+				}
+			}
+		}
+
+		if len(variants) == 0 && word != "" {
+			includeName = true
+		}
+
+		const maxVariantsPerWord = 8
+		if len(variants) > maxVariantsPerWord {
+			variants = variants[:maxVariantsPerWord]
+		}
+
+		if len(variants) > 0 {
+			variantGroups = append(variantGroups, variants)
+		}
+	}
+
+	cache := db.slugSearchCache.Load()
+	systemIDs := make([]string, len(filters.Systems))
+	for i, sys := range filters.Systems {
+		systemIDs[i] = sys.ID
+	}
+	cacheReady := cache != nil && cache.CanServeSystems(systemIDs)
+	var systemDBIDs []int64
+	if cacheReady {
+		systemDBIDs = cache.ResolveSystemDBIDs(systemIDs)
+	}
+	if cacheReady && len(variantGroups) > 0 && !includeName {
+		log.Debug().
+			Strs("systems", systemIDs).
+			Int("variantGroups", len(variantGroups)).
+			Bool("includeName", includeName).
+			Msg("media search count using in-memory slug cache")
+
+		candidateIDs := cache.Search(systemDBIDs, func() [][][]byte {
+			byteGroups := make([][][]byte, len(variantGroups))
+			for i, group := range variantGroups {
+				byteGroups[i] = make([][]byte, len(group))
+				for j, v := range group {
+					byteGroups[i][j] = []byte(v)
+				}
+			}
+			return byteGroups
+		}())
+		if len(candidateIDs) == 0 {
+			return 0, nil
+		}
+
+		return sqlSearchMediaByTitleDBIDsCount(ctx, db.sql.Load(), candidateIDs, filters.Tags, filters.Letter)
+	}
+
+	log.Debug().
+		Strs("systems", systemIDs).
+		Bool("cachePresent", cache != nil).
+		Bool("cacheReady", cacheReady).
+		Int("variantGroups", len(variantGroups)).
+		Bool("includeName", includeName).
+		Msg("media search count falling back to SQL LIKE path")
+
+	return sqlSearchMediaWithFiltersCount(
+		ctx, db.sql.Load(), filters.Systems, variantGroups, qWords, filters.Tags,
+		filters.Letter, includeName)
+}
+
 // slugCacheSearch is a shared helper for slug-based search methods that use the
 // in-memory cache. It handles slugification, system resolution, and SQL fallback.
 // Returns (results, true, nil) on cache hit, or (nil, false, nil) when the caller

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2425,6 +2425,18 @@ func (db *MediaDB) SearchMediaWithFiltersCount(
 		filters.Letter, includeName)
 }
 
+func (db *MediaDB) SearchMediaWithFiltersSystemIDs(
+	ctx context.Context,
+	filters *database.SearchFilters,
+) ([]string, error) {
+	if db.sql.Load() == nil {
+		return nil, ErrNullSQL
+	}
+
+	return sqlSearchMediaWithFiltersSystemIDs(
+		ctx, db.sql.Load(), filters.Systems, filters.Tags)
+}
+
 // slugCacheSearch is a shared helper for slug-based search methods that use the
 // in-memory cache. It handles slugification, system resolution, and SQL fallback.
 // Returns (results, true, nil) on cache hit, or (nil, false, nil) when the caller

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2310,6 +2310,28 @@ func (db *MediaDB) SearchMediaWithFilters(
 			return []database.SearchResultWithCursor{}, nil
 		}
 
+		_, tagFilterArgs := BuildTagFilterSQL(filters.Tags)
+		_, letterArgs := BuildLetterFilterSQL(filters.Letter, "MediaTitles.Name")
+		totalParams := len(candidateIDs) + len(tagFilterArgs) + len(letterArgs)
+		if filters.Cursor != nil {
+			totalParams++
+		}
+		if filters.Limit > 0 {
+			totalParams++
+		}
+		if totalParams > sqliteMaxParams {
+			log.Debug().
+				Int("candidateTitleDBIDs", len(candidateIDs)).
+				Int("tagArgs", len(tagFilterArgs)).
+				Int("letterArgs", len(letterArgs)).
+				Bool("hasCursor", filters.Cursor != nil).
+				Int("limit", filters.Limit).
+				Msg("slug-cache candidate set too large for titleDBIDs IN search; falling back to SQL LIKE search")
+			return sqlSearchMediaWithFilters(
+				ctx, db.sql.Load(), filters.Systems, variantGroups, qWords, filters.Tags,
+				filters.Letter, filters.Cursor, filters.Limit, includeName)
+		}
+
 		return sqlSearchMediaByTitleDBIDs(
 			ctx, db.sql.Load(), candidateIDs, filters.Tags,
 			filters.Letter, filters.Cursor, filters.Limit)
@@ -2403,6 +2425,20 @@ func (db *MediaDB) SearchMediaWithFiltersCount(
 		}())
 		if len(candidateIDs) == 0 {
 			return 0, nil
+		}
+
+		_, tagFilterArgs := BuildTagFilterSQL(filters.Tags)
+		_, letterArgs := BuildLetterFilterSQL(filters.Letter, "MediaTitles.Name")
+		totalParams := len(candidateIDs) + len(tagFilterArgs) + len(letterArgs)
+		if totalParams > sqliteMaxParams {
+			log.Debug().
+				Int("candidateTitleDBIDs", len(candidateIDs)).
+				Int("tagArgs", len(tagFilterArgs)).
+				Int("letterArgs", len(letterArgs)).
+				Msg("slug-cache candidate set too large for titleDBIDs IN count; falling back to SQL LIKE count")
+			return sqlSearchMediaWithFiltersCount(
+				ctx, db.sql.Load(), filters.Systems, variantGroups, qWords, filters.Tags,
+				filters.Letter, includeName)
 		}
 
 		return sqlSearchMediaByTitleDBIDsCount(ctx, db.sql.Load(), candidateIDs, filters.Tags, filters.Letter)

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -2754,6 +2754,49 @@ func TestMediaDB_RandomGameWithQuery_PartialSlugCacheFallsBackToSQL_Integration(
 	assert.True(t, seenSNES, "partial slug cache should not silently exclude uncached requested systems")
 }
 
+func TestMediaDB_SearchMediaWithFiltersCount_SlugCacheCandidateLimitFallsBackToSQL_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insertedSystem, err := mediaDB.FindOrInsertSystem(database.System{SystemID: nesSystem.ID, Name: nesSystem.ID})
+	require.NoError(t, err)
+
+	for i := range sqliteMaxParams + 2 {
+		titleName := fmt.Sprintf("Game %d", i)
+		insertedTitle, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), titleName),
+			Name:       titleName,
+		})
+		require.NoError(t, insertErr)
+		_, insertErr = mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           filepath.Join("roms", "nes", fmt.Sprintf("game-%d.nes", i)),
+		})
+		require.NoError(t, insertErr)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+
+	count, err := mediaDB.SearchMediaWithFiltersCount(context.Background(), &database.SearchFilters{
+		Query:   "game",
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, sqliteMaxParams+2, count)
+}
+
 func TestMediaDB_CacheMediaStats_CanceledContextIsNonFatal_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -997,7 +997,7 @@ func sqlSearchMediaWithFiltersSystemIDs(
 		results = append(results, systemID)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to iterate system IDs rows: %w", err)
 	}
 
 	return results, nil

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -838,6 +838,7 @@ func sqlSearchMediaWithFilters(
 
 	systemCondition := ""
 	if !skipSystemFilter {
+		//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 		systemCondition = `Systems.SystemID IN (` +
 			prepareVariadic("?", ",", len(systems)) + `) AND `
 	}

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -38,6 +38,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+const defaultSearchResultsCapacity = 16
+
 // fetchAndAttachTags fetches tags for a slice of search results and attaches them to the results.
 // This helper consolidates duplicated tag-fetching logic across multiple search functions.
 // Combines file-level (MediaTags) and title-level (MediaTitleTags) tags via UNION ALL
@@ -749,7 +751,11 @@ func sqlSearchMediaWithFilters(
 	limit int,
 	includeName bool,
 ) ([]database.SearchResultWithCursor, error) {
-	results := make([]database.SearchResultWithCursor, 0, limit)
+	initialCapacity := limit
+	if initialCapacity <= 0 {
+		initialCapacity = defaultSearchResultsCapacity
+	}
+	results := make([]database.SearchResultWithCursor, 0, initialCapacity)
 	if len(systems) == 0 {
 		return nil, errors.New("no systems provided for media search")
 	}
@@ -843,6 +849,11 @@ func sqlSearchMediaWithFilters(
 		orderCondition = ` ORDER BY Media.DBID ASC`
 	}
 
+	limitClause := " LIMIT ?"
+	if limit == 0 {
+		limitClause = ""
+	}
+
 	//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 	mediaQuery := `
 		SELECT
@@ -861,13 +872,15 @@ func sqlSearchMediaWithFilters(
 		tagFilterCondition +
 		letterFilterCondition +
 		orderCondition +
-		` LIMIT ?`
+		limitClause
 
 	// Assemble final args: systems → variants → tag filters → limit
 	mediaArgs := append([]any(nil), args...)        // System IDs
 	mediaArgs = append(mediaArgs, variantArgs...)   // Variant args (includes cursor, letter if present)
 	mediaArgs = append(mediaArgs, tagFilterArgs...) // Add tag filter args
-	mediaArgs = append(mediaArgs, limit)
+	if limit != 0 {
+		mediaArgs = append(mediaArgs, limit)
+	}
 
 	queryStarted := time.Now()
 	mediaStmt, err := db.PrepareContext(ctx, mediaQuery)
@@ -966,6 +979,11 @@ func sqlSearchMediaByTitleDBIDs(
 		whereExtra = " AND " + strings.Join(extraConditions, " AND ")
 	}
 
+	limitClause := "\n\t\tLIMIT ?"
+	if limit == 0 {
+		limitClause = ""
+	}
+
 	//nolint:gosec // Safe: WHERE clause built from sanitized components
 	query := `
 		SELECT
@@ -978,13 +996,14 @@ func sqlSearchMediaByTitleDBIDs(
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
 		WHERE ` + titleCondition + ` AND Media.IsMissing = 0` + whereExtra + `
-		ORDER BY Media.DBID ASC
-		LIMIT ?`
+		ORDER BY Media.DBID ASC` + limitClause
 
 	finalArgs := make([]any, 0, len(args)+len(extraArgs)+1)
 	finalArgs = append(finalArgs, args...)
 	finalArgs = append(finalArgs, extraArgs...)
-	finalArgs = append(finalArgs, limit)
+	if limit != 0 {
+		finalArgs = append(finalArgs, limit)
+	}
 
 	queryStarted := time.Now()
 	rows, err := db.QueryContext(ctx, query, finalArgs...)
@@ -993,7 +1012,11 @@ func sqlSearchMediaByTitleDBIDs(
 	}
 	defer func() { _ = rows.Close() }()
 
-	results := make([]database.SearchResultWithCursor, 0, min(limit, 100))
+	initialCapacity := min(limit, 100)
+	if initialCapacity <= 0 {
+		initialCapacity = defaultSearchResultsCapacity
+	}
+	results := make([]database.SearchResultWithCursor, 0, initialCapacity)
 	for rows.Next() {
 		var r database.SearchResultWithCursor
 		if scanErr := rows.Scan(

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -850,7 +850,7 @@ func sqlSearchMediaWithFilters(
 	}
 
 	limitClause := " LIMIT ?"
-	if limit == 0 {
+	if limit <= 0 {
 		limitClause = ""
 	}
 
@@ -878,7 +878,7 @@ func sqlSearchMediaWithFilters(
 	mediaArgs := append([]any(nil), args...)        // System IDs
 	mediaArgs = append(mediaArgs, variantArgs...)   // Variant args (includes cursor, letter if present)
 	mediaArgs = append(mediaArgs, tagFilterArgs...) // Add tag filter args
-	if limit != 0 {
+	if limit > 0 {
 		mediaArgs = append(mediaArgs, limit)
 	}
 
@@ -980,7 +980,7 @@ func sqlSearchMediaByTitleDBIDs(
 	}
 
 	limitClause := "\n\t\tLIMIT ?"
-	if limit == 0 {
+	if limit <= 0 {
 		limitClause = ""
 	}
 

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -937,6 +937,153 @@ func sqlSearchMediaWithFilters(
 	return results, nil
 }
 
+func sqlSearchMediaWithFiltersCount(
+	ctx context.Context,
+	db sqlQueryable,
+	systems []systemdefs.System,
+	variantGroups [][]string,
+	rawWords []string,
+	tags []zapscript.TagFilter,
+	letter *string,
+	includeName bool,
+) (int, error) {
+	if len(systems) == 0 {
+		return 0, errors.New("no systems provided for media search")
+	}
+
+	skipSystemFilter := len(variantGroups) == 0 && !includeName && len(tags) > 0 &&
+		requestedAllSystems(systems)
+
+	args := make([]any, 0)
+	if !skipSystemFilter {
+		for _, sys := range systems {
+			args = append(args, sys.ID)
+		}
+	}
+
+	groupClauses := make([]string, 0, len(variantGroups))
+	variantArgs := make([]any, 0, len(variantGroups)*4)
+
+	for wordIdx, variants := range variantGroups {
+		if len(variants) == 0 {
+			continue
+		}
+
+		orConditions := make([]string, 0, len(variants)*2+1)
+
+		for _, variant := range variants {
+			orConditions = append(orConditions, "MediaTitles.Slug LIKE ?")
+			variantArgs = append(variantArgs, "%"+variant+"%")
+			orConditions = append(orConditions, "MediaTitles.SecondarySlug LIKE ?")
+			variantArgs = append(variantArgs, "%"+variant+"%")
+		}
+
+		if includeName && wordIdx < len(rawWords) && rawWords[wordIdx] != "" {
+			orConditions = append(orConditions, "MediaTitles.Name LIKE ?")
+			variantArgs = append(variantArgs, "%"+rawWords[wordIdx]+"%")
+		}
+
+		groupClauses = append(groupClauses, "("+strings.Join(orConditions, " OR ")+")")
+	}
+
+	variantCondition := ""
+	if len(groupClauses) > 0 {
+		variantCondition = " AND " + strings.Join(groupClauses, " AND ")
+	}
+
+	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
+	tagFilterCondition := ""
+	if len(tagFilterClauses) > 0 {
+		tagFilterCondition = " AND " + strings.Join(tagFilterClauses, " AND ")
+	}
+
+	letterFilterCondition := ""
+	letterClauses, letterArgs := BuildLetterFilterSQL(letter, "MediaTitles.Name")
+	if len(letterClauses) > 0 {
+		letterFilterCondition = " AND " + strings.Join(letterClauses, " AND ")
+		variantArgs = append(variantArgs, letterArgs...)
+	}
+
+	systemCondition := ""
+	if !skipSystemFilter {
+		systemCondition = `Systems.SystemID IN (` + prepareVariadic("?", ",", len(systems)) + `) AND `
+	}
+
+	//nolint:gosec // Safe: WHERE clause is built from sanitized components and parameterized args.
+	query := `
+		SELECT COUNT(*)
+		FROM Systems
+		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
+		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
+		WHERE ` + systemCondition +
+		`Media.IsMissing = 0` +
+		variantCondition +
+		tagFilterCondition +
+		letterFilterCondition
+
+	finalArgs := append([]any(nil), args...)
+	finalArgs = append(finalArgs, variantArgs...)
+	finalArgs = append(finalArgs, tagFilterArgs...)
+
+	var count int
+	if err := db.QueryRowContext(ctx, query, finalArgs...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to execute media count query: %w", err)
+	}
+
+	return count, nil
+}
+
+func sqlSearchMediaByTitleDBIDsCount(
+	ctx context.Context,
+	db sqlQueryable,
+	titleDBIDs []int64,
+	tags []zapscript.TagFilter,
+	letter *string,
+) (int, error) {
+	if len(titleDBIDs) == 0 {
+		return 0, nil
+	}
+
+	args := make([]any, 0, len(titleDBIDs)+10)
+	for _, id := range titleDBIDs {
+		args = append(args, id)
+	}
+	titleCondition := "MediaTitles.DBID IN (" + prepareVariadic("?", ",", len(titleDBIDs)) + ")"
+
+	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
+	letterClauses, letterArgs := BuildLetterFilterSQL(letter, "MediaTitles.Name")
+	extraConditions := make([]string, 0, len(tagFilterClauses)+len(letterClauses))
+	extraArgs := make([]any, 0, len(tagFilterArgs)+len(letterArgs))
+	extraConditions = append(extraConditions, tagFilterClauses...)
+	extraArgs = append(extraArgs, tagFilterArgs...)
+	extraConditions = append(extraConditions, letterClauses...)
+	extraArgs = append(extraArgs, letterArgs...)
+
+	whereExtra := ""
+	if len(extraConditions) > 0 {
+		whereExtra = " AND " + strings.Join(extraConditions, " AND ")
+	}
+
+	//nolint:gosec // Safe: WHERE clause is built from sanitized components and parameterized args.
+	query := `
+		SELECT COUNT(*)
+		FROM MediaTitles
+		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
+		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
+		WHERE ` + titleCondition + ` AND Media.IsMissing = 0` + whereExtra
+
+	finalArgs := make([]any, 0, len(args)+len(extraArgs))
+	finalArgs = append(finalArgs, args...)
+	finalArgs = append(finalArgs, extraArgs...)
+
+	var count int
+	if err := db.QueryRowContext(ctx, query, finalArgs...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to execute title DBIDs count query: %w", err)
+	}
+
+	return count, nil
+}
+
 func sqlSearchMediaByTitleDBIDs(
 	ctx context.Context,
 	db sqlQueryable,

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -937,6 +937,74 @@ func sqlSearchMediaWithFilters(
 	return results, nil
 }
 
+func sqlSearchMediaWithFiltersSystemIDs(
+	ctx context.Context,
+	db sqlQueryable,
+	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
+) ([]string, error) {
+	if len(systems) == 0 {
+		return nil, errors.New("no systems provided for media search")
+	}
+
+	skipSystemFilter := requestedAllSystems(systems)
+
+	args := make([]any, 0)
+	if !skipSystemFilter {
+		for _, sys := range systems {
+			args = append(args, sys.ID)
+		}
+	}
+
+	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
+	tagFilterCondition := ""
+	if len(tagFilterClauses) > 0 {
+		tagFilterCondition = " AND " + strings.Join(tagFilterClauses, " AND ")
+	}
+
+	systemCondition := ""
+	if !skipSystemFilter {
+		systemCondition = `Systems.SystemID IN (` + prepareVariadic("?", ",", len(systems)) + `) AND `
+	}
+
+	query := `
+		SELECT DISTINCT Systems.SystemID
+		FROM Systems
+		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
+		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
+		WHERE ` + systemCondition +
+		`Media.IsMissing = 0` +
+		tagFilterCondition +
+		` ORDER BY Systems.SystemID ASC`
+
+	finalArgs := append([]any(nil), args...)
+	finalArgs = append(finalArgs, tagFilterArgs...)
+
+	rows, err := db.QueryContext(ctx, query, finalArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute system IDs query: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close system IDs rows")
+		}
+	}()
+
+	results := make([]string, 0)
+	for rows.Next() {
+		var systemID string
+		if scanErr := rows.Scan(&systemID); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan system ID: %w", scanErr)
+		}
+		results = append(results, systemID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
 func sqlSearchMediaWithFiltersCount(
 	ctx context.Context,
 	db sqlQueryable,
@@ -1148,7 +1216,7 @@ func sqlSearchMediaByTitleDBIDs(
 	finalArgs := make([]any, 0, len(args)+len(extraArgs)+1)
 	finalArgs = append(finalArgs, args...)
 	finalArgs = append(finalArgs, extraArgs...)
-	if limit != 0 {
+	if limit > 0 {
 		finalArgs = append(finalArgs, limit)
 	}
 

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -783,10 +783,6 @@ func sqlSearchMediaWithFilters(
 	variantArgs := make([]any, 0, len(variantGroups)*4) // Estimate: ~4 variants per word
 
 	for wordIdx, variants := range variantGroups {
-		if len(variants) == 0 {
-			continue
-		}
-
 		orConditions := make([]string, 0, len(variants)*2+1)
 
 		// Add OR conditions for each slug variant
@@ -968,6 +964,7 @@ func sqlSearchMediaWithFiltersSystemIDs(
 		systemCondition = `Systems.SystemID IN (` + prepareVariadic("?", ",", len(systems)) + `) AND `
 	}
 
+	//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 	query := `
 		SELECT DISTINCT Systems.SystemID
 		FROM Systems
@@ -1034,10 +1031,6 @@ func sqlSearchMediaWithFiltersCount(
 	variantArgs := make([]any, 0, len(variantGroups)*4)
 
 	for wordIdx, variants := range variantGroups {
-		if len(variants) == 0 {
-			continue
-		}
-
 		orConditions := make([]string, 0, len(variants)*2+1)
 
 		for _, variant := range variants {

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -706,6 +706,73 @@ func TestSqlSearchMediaWithFilters_AllSystemsTagOnlySkipsSystemFilter(t *testing
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSqlSearchMediaWithFilters_ZeroLimitOmitsLimitClause(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		limit int
+	}{
+		{name: "zero", limit: 0},
+		{name: "negative", limit: -1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db, mock, err := testsqlmock.NewSQLMock()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			systems := systemdefs.AllSystems()
+			require.NotEmpty(t, systems)
+			tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+
+			mock.ExpectPrepare("(?s).*Media\\.IsMissing = 0.*ORDER BY Media\\.DBID ASC\\s*$").
+				ExpectQuery().
+				WithArgs("user", "favorite", "user", "favorite").
+				WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+					AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), int64(7), ""))
+			expectSearchTagsQuery(mock, 7)
+
+			results, err := sqlSearchMediaWithFilters(
+				context.Background(), db, systems, nil, nil, tags, nil, nil, tt.limit, false,
+			)
+
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, systems[0].ID, results[0].SystemID)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSqlSearchMediaWithFilters_PositiveLimitIncludesLimitClause(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	systems := systemdefs.AllSystems()
+	require.NotEmpty(t, systems)
+	tags := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+	favoritePath := filepath.ToSlash(filepath.Join("roms", "favorite.rom"))
+
+	mock.ExpectPrepare("(?s).*Media\\.IsMissing = 0.*ORDER BY Media\\.DBID ASC.*LIMIT \\?").
+		ExpectQuery().
+		WithArgs("user", "favorite", "user", "favorite", 10).
+		WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
+			AddRow(systems[0].ID, "Favorite", favoritePath, 7, ""))
+	expectSearchTagsQuery(mock, 7)
+
+	results, err := sqlSearchMediaWithFilters(
+		context.Background(), db, systems, nil, nil, tags, nil, nil, 10, false,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, systems[0].ID, results[0].SystemID)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSqlSearchMediaWithFilters_DuplicateSystemsMissingOneKeepsSystemFilter(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -737,6 +737,7 @@ func TestSqlSearchMediaWithFilters_ZeroLimitOmitsLimitClause(t *testing.T) {
 						int64(7),
 						"",
 					))
+			expectSearchTagsQuery(mock, 7)
 
 			results, err := sqlSearchMediaWithFilters(
 				context.Background(), db, systems, nil, nil, tags, nil, nil, tt.limit, false,

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -730,8 +730,13 @@ func TestSqlSearchMediaWithFilters_ZeroLimitOmitsLimitClause(t *testing.T) {
 				ExpectQuery().
 				WithArgs("user", "favorite", "user", "favorite").
 				WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Name", "Path", "DBID", "DisambiguationTypes"}).
-					AddRow(systems[0].ID, "Favorite", filepath.ToSlash(filepath.Join("roms", "favorite.rom")), int64(7), ""))
-			expectSearchTagsQuery(mock, 7)
+					AddRow(
+						systems[0].ID,
+						"Favorite",
+						filepath.ToSlash(filepath.Join("roms", "favorite.rom")),
+						int64(7),
+						"",
+					))
 
 			results, err := sqlSearchMediaWithFilters(
 				context.Background(), db, systems, nil, nil, tags, nil, nil, tt.limit, false,

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1215,6 +1215,20 @@ func (m *MockMediaDBI) SearchMediaWithFilters(
 	return nil, nil
 }
 
+func (m *MockMediaDBI) SearchMediaWithFiltersCount(
+	ctx context.Context,
+	filters *database.SearchFilters,
+) (int, error) {
+	args := m.Called(ctx, filters)
+	if err := args.Error(1); err != nil {
+		return 0, fmt.Errorf("mock operation failed: %w", err)
+	}
+	if count, ok := args.Get(0).(int); ok {
+		return count, nil
+	}
+	return 0, nil
+}
+
 func (m *MockMediaDBI) SearchMediaBySlug(
 	ctx context.Context, systemID string, slug string, tags []zapscript.TagFilter,
 ) ([]database.SearchResultWithCursor, error) {

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1226,7 +1226,24 @@ func (m *MockMediaDBI) SearchMediaWithFiltersCount(
 	if count, ok := args.Get(0).(int); ok {
 		return count, nil
 	}
+	if count, ok := args.Get(0).(int64); ok {
+		return int(count), nil
+	}
 	return 0, nil
+}
+
+func (m *MockMediaDBI) SearchMediaWithFiltersSystemIDs(
+	ctx context.Context,
+	filters *database.SearchFilters,
+) ([]string, error) {
+	args := m.Called(ctx, filters)
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock operation failed: %w", err)
+	}
+	if results, ok := args.Get(0).([]string); ok {
+		return results, nil
+	}
+	return nil, nil
 }
 
 func (m *MockMediaDBI) SearchMediaBySlug(


### PR DESCRIPTION
* Add systems.favorites API endpoint specifically for the frontend favorites window to find what consoles should be shown based on what games are favorited.
* Update media.search endpoint to have the total be the total matching results instead of the total count on the page. This now matches the behaviour of media.browse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a systems favorites API endpoint that returns unique systems associated with favorited media.
  - Unknown or invalid systems are safely excluded from results.

- **Bug Fixes**
  - Improved search behavior for unlimited-result requests.
  - Prevented invalid result-capacity handling when no limit is specified.

- **Tests**
  - Added coverage for favorite filtering, deduplication, empty results, unlimited searches, and result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->