### PR TITLE
fix(api): redact auth secrets from errors and logs

### DIFF
--- a/pkg/api/methods/auth.go
+++ b/pkg/api/methods/auth.go
@@ -215,14 +215,14 @@ func performClaim(
 	// Extract root domain (scheme + host) from the claim URL
 	claimURL, err := url.Parse(rawClaimURL)
 	if err != nil {
-		return nil, models.ClientErrf("invalid claim URL: %w", err)
+		return nil, models.ClientErr(remoteRequestError("invalid claim URL", err))
 	}
 	// HTTPS only, with the same private/localhost HTTP allowance the backup
 	// base URL gets — for developing against a locally-run API.
 	if claimURL.Scheme != "https" {
 		rootURL := claimURL.Scheme + "://" + claimURL.Host
 		if validateErr := config.ValidateBackupRemoteBaseURL(rootURL); validateErr != nil {
-			return nil, models.ClientErrf("claim URL must use HTTPS")
+			return nil, models.ClientErr(remoteRequestError("claim URL must use HTTPS", validateErr))
 		}
 	}
 	rootDomain := claimURL.Scheme + "://" + claimURL.Host
@@ -326,7 +326,7 @@ func redeemClaimToken(
 		ctx, http.MethodPost, claimURL, bytes.NewReader(body),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to create claim request: %w", err)
+		return "", remoteRequestError("failed to create claim request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(zapscript.HeaderZaparooOS, runtime.GOOS)

--- a/pkg/api/methods/auth.go
+++ b/pkg/api/methods/auth.go
@@ -74,6 +74,17 @@ type claimResponse struct {
 // wellKnownFetcher fetches and parses a .well-known/zaparoo file from a base URL.
 type wellKnownFetcher func(baseURL string) (*zapscript.WellKnown, error)
 
+// remoteRequestError strips net/http's URL wrapper before returning an error.
+// Claim and link URLs may contain short-lived credentials, so they must never
+// be copied into API errors or logs.
+func remoteRequestError(action string, err error) error {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		err = urlErr.Err
+	}
+	return fmt.Errorf("%s: %w", action, err)
+}
+
 // HandleSettingsAuthStatus reports whether Core has a local bearer for an allowed auth URL.
 // It does not validate the token remotely and never exposes token material or credential domains.
 //
@@ -327,7 +338,7 @@ func redeemClaimToken(
 
 	resp, err := claimClient.Do(req) //nolint:gosec // G107: claim URL from user input, validated as HTTPS
 	if err != nil {
-		return "", fmt.Errorf("failed to contact claim server: %w", err)
+		return "", remoteRequestError("failed to contact claim server", err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -336,11 +347,10 @@ func redeemClaimToken(
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, helpers.MaxResponseBodySize))
-		return "", fmt.Errorf(
-			"claim server returned status %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(body)),
-		)
+		// Drain a bounded amount for connection reuse, but never copy an
+		// untrusted server body into an API error: it may echo the claim token.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, helpers.MaxResponseBodySize))
+		return "", fmt.Errorf("claim server returned status %d", resp.StatusCode)
 	}
 
 	var claim claimResponse

--- a/pkg/api/methods/auth_link.go
+++ b/pkg/api/methods/auth_link.go
@@ -138,7 +138,7 @@ func HandleSettingsAuthLink(env requests.RequestEnv, fetchWK wellKnownFetcher) (
 		baseURL = deviceLinkDefaultBaseURL
 	}
 	if err := config.ValidateBackupRemoteBaseURL(baseURL); err != nil {
-		return nil, models.ClientErrf("invalid link URL: %w", err)
+		return nil, models.ClientErr(remoteRequestError("invalid link URL", err))
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
 
@@ -288,7 +288,7 @@ func createDeviceLinkRequest(
 		ctx, http.MethodPost, baseURL+deviceLinkCreatePath, http.NoBody,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create link request: %w", err)
+		return nil, remoteRequestError("failed to create link request", err)
 	}
 	req.Header.Set(zapscript.HeaderZaparooOS, runtime.GOOS)
 	req.Header.Set(zapscript.HeaderZaparooArch, runtime.GOARCH)
@@ -407,7 +407,7 @@ func pollDeviceLinkOnce(ctx context.Context, baseURL, deviceCode string) (*devic
 		ctx, http.MethodPost, baseURL+deviceLinkPollPath, bytes.NewReader(body),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create poll request: %w", err)
+		return nil, remoteRequestError("failed to create poll request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/api/methods/auth_link.go
+++ b/pkg/api/methods/auth_link.go
@@ -299,7 +299,7 @@ func createDeviceLinkRequest(
 
 	resp, err := claimClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to contact link server: %w", err)
+		return nil, remoteRequestError("failed to contact link server", err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -307,11 +307,9 @@ func createDeviceLinkRequest(
 		}
 	}()
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, helpers.MaxResponseBodySize))
-		return nil, fmt.Errorf(
-			"link server returned status %d: %s",
-			resp.StatusCode, strings.TrimSpace(string(body)),
-		)
+		// Never propagate an untrusted response body into API errors or logs.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, helpers.MaxResponseBodySize))
+		return nil, fmt.Errorf("link server returned status %d", resp.StatusCode)
 	}
 
 	var created deviceLinkCreateResponse
@@ -415,7 +413,7 @@ func pollDeviceLinkOnce(ctx context.Context, baseURL, deviceCode string) (*devic
 
 	resp, err := claimClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to contact link server: %w", err)
+		return nil, remoteRequestError("failed to contact link server", err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -44,6 +44,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	reflectedSecret  = "zpl1_reflected-device-code"       //nolint:gosec // Test fixture device code.
+	malformedLinkURL = "https://user:link-url-secret@%zz" //nolint:gosec // Test fixture credentials.
+)
+
 func TestLogDeviceLinkPollFailure(t *testing.T) {
 	var buf bytes.Buffer
 	originalLogger := log.Logger
@@ -283,7 +288,6 @@ func TestSettingsAuthLink_RejectsSecondPendingStart(t *testing.T) {
 
 func TestCreateDeviceLinkRequest_DoesNotReturnServerBody(t *testing.T) {
 	// Not parallel: swaps package-level claimClient.
-	const reflectedSecret = "zpl1_reflected-device-code" //nolint:gosec // test fixture device code
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte("invalid device code: " + reflectedSecret))
@@ -298,6 +302,43 @@ func TestCreateDeviceLinkRequest_DoesNotReturnServerBody(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
 	assert.NotContains(t, err.Error(), reflectedSecret)
+	assert.NotContains(t, err.Error(), "invalid device code: "+reflectedSecret)
+}
+
+func TestSettingsAuthLink_MalformedURLRedacted(t *testing.T) {
+	t.Parallel()
+
+	params, err := json.Marshal(models.SettingsAuthLinkParams{URL: malformedLinkURL})
+	require.NoError(t, err)
+	_, err = HandleSettingsAuthLink(requests.RequestEnv{IsLocal: true, Params: params}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid link URL")
+	assert.NotContains(t, err.Error(), malformedLinkURL)
+	assert.NotContains(t, err.Error(), "link-url-secret")
+}
+
+func TestDeviceLinkRequestErrorsRedactURL(t *testing.T) {
+	// Not parallel: captures package-level logger.
+	_, createErr := createDeviceLinkRequest(t.Context(), malformedLinkURL, "test", "")
+	require.Error(t, createErr)
+	assert.Contains(t, createErr.Error(), "failed to create link request")
+	assert.NotContains(t, createErr.Error(), malformedLinkURL)
+	assert.NotContains(t, createErr.Error(), "link-url-secret")
+
+	_, pollErr := pollDeviceLinkOnce(t.Context(), malformedLinkURL, "device-code")
+	require.Error(t, pollErr)
+	assert.Contains(t, pollErr.Error(), "failed to create poll request")
+	assert.NotContains(t, pollErr.Error(), malformedLinkURL)
+	assert.NotContains(t, pollErr.Error(), "link-url-secret")
+
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+	logDeviceLinkPollFailure(pollErr, 1)
+	assert.Contains(t, buf.String(), "failed to create poll request")
+	assert.NotContains(t, buf.String(), malformedLinkURL)
+	assert.NotContains(t, buf.String(), "link-url-secret")
 }
 
 func TestSettingsAuthLink_HappyPath(t *testing.T) {

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -45,8 +45,9 @@ import (
 )
 
 const (
-	reflectedSecret  = "zpl1_reflected-device-code"       //nolint:gosec // Test fixture device code.
-	malformedLinkURL = "https://user:link-url-secret@%zz" //nolint:gosec // Test fixture credentials.
+	reflectedSecret       = "zpl1_reflected-device-code" //nolint:gosec // Test fixture device code.
+	reflectedResponseBody = "invalid device code: " + reflectedSecret
+	malformedLinkURL      = "https://user:link-url-secret@%zz" //nolint:gosec // Test fixture credentials.
 )
 
 func TestLogDeviceLinkPollFailure(t *testing.T) {
@@ -290,7 +291,7 @@ func TestCreateDeviceLinkRequest_DoesNotReturnServerBody(t *testing.T) {
 	// Not parallel: swaps package-level claimClient.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte("invalid device code: " + reflectedSecret))
+		_, _ = w.Write([]byte(reflectedResponseBody))
 	}))
 	defer server.Close()
 
@@ -302,7 +303,26 @@ func TestCreateDeviceLinkRequest_DoesNotReturnServerBody(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "400")
 	assert.NotContains(t, err.Error(), reflectedSecret)
-	assert.NotContains(t, err.Error(), "invalid device code: "+reflectedSecret)
+	assert.NotContains(t, err.Error(), reflectedResponseBody)
+}
+
+func TestPollDeviceLinkOnce_DoesNotReturnServerBody(t *testing.T) {
+	// Not parallel: swaps package-level claimClient.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(reflectedResponseBody))
+	}))
+	defer server.Close()
+
+	originalClient := claimClient
+	claimClient = server.Client()
+	t.Cleanup(func() { claimClient = originalClient })
+
+	_, err := pollDeviceLinkOnce(t.Context(), server.URL, reflectedSecret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.NotContains(t, err.Error(), reflectedResponseBody)
+	assert.NotContains(t, err.Error(), reflectedSecret)
 }
 
 func TestSettingsAuthLink_MalformedURLRedacted(t *testing.T) {

--- a/pkg/api/methods/auth_link_test.go
+++ b/pkg/api/methods/auth_link_test.go
@@ -281,6 +281,25 @@ func TestSettingsAuthLink_RejectsSecondPendingStart(t *testing.T) {
 	assert.Contains(t, err.Error(), "already pending")
 }
 
+func TestCreateDeviceLinkRequest_DoesNotReturnServerBody(t *testing.T) {
+	// Not parallel: swaps package-level claimClient.
+	const reflectedSecret = "zpl1_reflected-device-code" //nolint:gosec // test fixture device code
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid device code: " + reflectedSecret))
+	}))
+	defer server.Close()
+
+	originalClient := claimClient
+	claimClient = server.Client()
+	t.Cleanup(func() { claimClient = originalClient })
+
+	_, err := createDeviceLinkRequest(t.Context(), server.URL, "test-platform", "test-device")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "400")
+	assert.NotContains(t, err.Error(), reflectedSecret)
+}
+
 func TestSettingsAuthLink_HappyPath(t *testing.T) {
 	// Not parallel: swaps package-level claimClient and link session state.
 	resetAuthLinkState(t)

--- a/pkg/api/methods/auth_test.go
+++ b/pkg/api/methods/auth_test.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -40,9 +41,18 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/zapscript"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	//nolint:gosec // Test fixture claim URL.
+	secretURL = "https://api.example.com/claim?token=zpc1_claim-secret"
+	//nolint:gosec // Test fixture credentials.
+	malformedClaimURL = "https://user:claim-url-secret@%zz"
 )
 
 func TestSettingsAuthStatus_RequiresURL(t *testing.T) {
@@ -144,12 +154,11 @@ func TestSettingsAuthClaim_RequiresHTTPS(t *testing.T) {
 	_, err = HandleSettingsAuthClaim(env, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "HTTPS")
+	assert.NotContains(t, err.Error(), params.ClaimURL)
 }
 
 func TestRemoteRequestError_StripsSensitiveURL(t *testing.T) {
-	t.Parallel()
-
-	const secretURL = "https://api.example.com/claim?token=zpc1_claim-secret" //nolint:gosec // test fixture claim URL
+	// Not parallel: swaps package-level logger.
 	err := remoteRequestError("failed to contact claim server", &url.Error{
 		Op:  http.MethodPost,
 		URL: secretURL,
@@ -159,6 +168,35 @@ func TestRemoteRequestError_StripsSensitiveURL(t *testing.T) {
 	assert.Contains(t, err.Error(), "connection refused")
 	assert.NotContains(t, err.Error(), secretURL)
 	assert.NotContains(t, err.Error(), "zpc1_claim-secret")
+
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = originalLogger })
+	log.Warn().Err(err).Msg("claim request failed")
+	assert.Contains(t, buf.String(), "failed to contact claim server")
+	assert.NotContains(t, buf.String(), secretURL)
+	assert.NotContains(t, buf.String(), "zpc1_claim-secret")
+}
+
+func TestPerformClaim_MalformedURLRedacted(t *testing.T) {
+	t.Parallel()
+
+	_, err := performClaim(t.Context(), nil, nil, nil, malformedClaimURL, "token", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid claim URL")
+	assert.NotContains(t, err.Error(), malformedClaimURL)
+	assert.NotContains(t, err.Error(), "claim-url-secret")
+}
+
+func TestRedeemClaimToken_RequestErrorRedactsURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := redeemClaimToken(t.Context(), malformedClaimURL, "token", "test", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create claim request")
+	assert.NotContains(t, err.Error(), malformedClaimURL)
+	assert.NotContains(t, err.Error(), "claim-url-secret")
 }
 
 func TestSettingsAuthClaim_ClaimTokenFailure(t *testing.T) {
@@ -208,6 +246,7 @@ func TestSettingsAuthClaim_ClaimTokenFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "401")
 	assert.NotContains(t, err.Error(), "bad-token")
+	assert.NotContains(t, err.Error(), "invalid token: bad-token")
 }
 
 func TestSettingsAuthClaim_RootMissingAuth(t *testing.T) {

--- a/pkg/api/methods/auth_test.go
+++ b/pkg/api/methods/auth_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -145,6 +146,21 @@ func TestSettingsAuthClaim_RequiresHTTPS(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTPS")
 }
 
+func TestRemoteRequestError_StripsSensitiveURL(t *testing.T) {
+	t.Parallel()
+
+	const secretURL = "https://api.example.com/claim?token=zpc1_claim-secret" //nolint:gosec // test fixture claim URL
+	err := remoteRequestError("failed to contact claim server", &url.Error{
+		Op:  http.MethodPost,
+		URL: secretURL,
+		Err: errors.New("connection refused"),
+	})
+
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.NotContains(t, err.Error(), secretURL)
+	assert.NotContains(t, err.Error(), "zpc1_claim-secret")
+}
+
 func TestSettingsAuthClaim_ClaimTokenFailure(t *testing.T) {
 	// Not parallel: swaps package-level claimClient
 
@@ -154,7 +170,7 @@ func TestSettingsAuthClaim_ClaimTokenFailure(t *testing.T) {
 		assert.Equal(t, runtime.GOARCH, r.Header.Get(zapscript.HeaderZaparooArch))
 		assert.Equal(t, "test-platform", r.Header.Get(zapscript.HeaderZaparooPlatform))
 		w.WriteHeader(http.StatusUnauthorized)
-		_, _ = w.Write([]byte("invalid token"))
+		_, _ = w.Write([]byte("invalid token: bad-token"))
 	}))
 	defer claimServer.Close()
 
@@ -191,6 +207,7 @@ func TestSettingsAuthClaim_ClaimTokenFailure(t *testing.T) {
 	_, err = HandleSettingsAuthClaim(env, mockFetchWK)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "401")
+	assert.NotContains(t, err.Error(), "bad-token")
 }
 
 func TestSettingsAuthClaim_RootMissingAuth(t *testing.T) {

--- a/pkg/api/server_logging_test.go
+++ b/pkg/api/server_logging_test.go
@@ -34,6 +34,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	claimSecret             = "zpc1_claim-secret" //nolint:gosec // Test fixture claim token.
+	userCode                = "ABCD-1234"
+	compactUserCode         = "ABCD1234"
+	authClaimURL            = "https://api.zaparoo.com/v1/device-claims/redeem"
+	authLinkVerificationURL = "https://online.zaparoo.com/link"
+)
+
 func TestLogSafeResponse(t *testing.T) {
 	tests := []struct {
 		result         any
@@ -316,7 +324,6 @@ func TestLogSafeRequest(t *testing.T) {
 }
 
 func TestLogSafeRequest_AuthClaimParamsRedacted(t *testing.T) {
-	const claimSecret = "zpc1_claim-secret" //nolint:gosec // test fixture claim token
 	var buf bytes.Buffer
 	originalLogger := log.Logger
 	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
@@ -326,18 +333,17 @@ func TestLogSafeRequest_AuthClaimParamsRedacted(t *testing.T) {
 		JSONRPC: "2.0",
 		ID:      models.NewStringID("claim-request"),
 		Method:  models.MethodSettingsAuthClaim,
-		Params:  []byte(`{"claimUrl":"https://api.zaparoo.com/v1/device-claims/redeem","token":"` + claimSecret + `"}`),
+		Params:  []byte(`{"claimUrl":"` + authClaimURL + `","token":"` + claimSecret + `"}`),
 	})
 
 	out := buf.String()
 	assert.Contains(t, out, models.MethodSettingsAuthClaim)
 	assert.NotContains(t, out, claimSecret)
+	assert.NotContains(t, out, authClaimURL)
 	assert.NotContains(t, out, "claimUrl")
 }
 
 func TestLogSafeResponse_AuthLinkCodesRedacted(t *testing.T) {
-	const userCode = "ABCD-1234"
-	const compactUserCode = "ABCD1234"
 	var buf bytes.Buffer
 	originalLogger := log.Logger
 	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
@@ -346,14 +352,15 @@ func TestLogSafeResponse_AuthLinkCodesRedacted(t *testing.T) {
 	logSafeResponse(models.AuthLinkStatusResponse{
 		Status:                  models.AuthLinkStatusPending,
 		UserCode:                userCode,
-		VerificationURL:         "https://online.zaparoo.com/link",
-		VerificationURLComplete: "https://online.zaparoo.com/link?code=" + compactUserCode,
+		VerificationURL:         authLinkVerificationURL,
+		VerificationURLComplete: authLinkVerificationURL + "?code=" + compactUserCode,
 	})
 
 	out := buf.String()
 	assert.Contains(t, out, "AuthLinkStatusResponse")
 	assert.NotContains(t, out, compactUserCode)
 	assert.NotContains(t, out, userCode)
+	assert.NotContains(t, out, authLinkVerificationURL)
 	assert.NotContains(t, out, "verificationUrlComplete")
 }
 

--- a/pkg/api/server_logging_test.go
+++ b/pkg/api/server_logging_test.go
@@ -315,6 +315,48 @@ func TestLogSafeRequest(t *testing.T) {
 	}
 }
 
+func TestLogSafeRequest_AuthClaimParamsRedacted(t *testing.T) {
+	const claimSecret = "zpc1_claim-secret" //nolint:gosec // test fixture claim token
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = originalLogger }()
+
+	logSafeRequest(&models.RequestObject{
+		JSONRPC: "2.0",
+		ID:      models.NewStringID("claim-request"),
+		Method:  models.MethodSettingsAuthClaim,
+		Params:  []byte(`{"claimUrl":"https://api.zaparoo.com/v1/device-claims/redeem","token":"` + claimSecret + `"}`),
+	})
+
+	out := buf.String()
+	assert.Contains(t, out, models.MethodSettingsAuthClaim)
+	assert.NotContains(t, out, claimSecret)
+	assert.NotContains(t, out, "claimUrl")
+}
+
+func TestLogSafeResponse_AuthLinkCodesRedacted(t *testing.T) {
+	const userCode = "ABCD-1234"
+	const compactUserCode = "ABCD1234"
+	var buf bytes.Buffer
+	originalLogger := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	defer func() { log.Logger = originalLogger }()
+
+	logSafeResponse(models.AuthLinkStatusResponse{
+		Status:                  models.AuthLinkStatusPending,
+		UserCode:                userCode,
+		VerificationURL:         "https://online.zaparoo.com/link",
+		VerificationURLComplete: "https://online.zaparoo.com/link?code=" + compactUserCode,
+	})
+
+	out := buf.String()
+	assert.Contains(t, out, "AuthLinkStatusResponse")
+	assert.NotContains(t, out, compactUserCode)
+	assert.NotContains(t, out, userCode)
+	assert.NotContains(t, out, "verificationUrlComplete")
+}
+
 func TestLogWSWriteError(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

- strip `net/http` URL wrappers before returning claim and device-link transport errors so credential-bearing URLs cannot reach API errors or logs
- omit untrusted claim and link server response bodies that may echo submitted secrets
- add regression coverage for claim parameters, reflected tokens, and device-link codes in debug logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented sensitive credentials, tokens, URLs, and server response content from appearing in authentication errors.
  * Preserved useful HTTP status and connection details while removing confidential information.
  * Improved safe logging by excluding authentication claim parameters and link codes.

* **Tests**
  * Added coverage to verify sensitive data is consistently omitted from returned errors and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->