### PR TITLE
fix(database): recover interrupted media database rebuilds

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -395,7 +395,7 @@ func mediaDBHasUsableData(mediaDB database.MediaDBI) bool {
 	if mediaDB == nil {
 		return false
 	}
-	if lastGenerated, err := mediaDB.GetLastGenerated(); err == nil && !time.Unix(0, 0).Equal(lastGenerated) {
+	if lastGenerated, err := mediaDB.GetLastGenerated(); err == nil && !lastGenerated.IsZero() {
 		return true
 	}
 	hasMedia, err := mediaDB.HasAnyMedia()

--- a/pkg/api/methods/media_optimization_test.go
+++ b/pkg/api/methods/media_optimization_test.go
@@ -139,7 +139,7 @@ func TestHandleMedia_OptimizationStatus(t *testing.T) {
 			// fallback) in every branch, including mid-index.
 			lastGenerated := time.Now()
 			if tt.dbEmpty {
-				lastGenerated = time.Unix(0, 0)
+				lastGenerated = time.Time{}
 			}
 			mockMediaDB.On("GetLastGenerated").Return(lastGenerated, nil).Maybe()
 			mockMediaDB.On("GetTotalMediaCount").Return(100, nil).Maybe()
@@ -186,7 +186,7 @@ func TestHandleMedia_IndexingAndOptimizationPriority(t *testing.T) {
 	// Both indexing and optimization are "running"
 	mockMediaDB.On("GetOptimizationStatus").Return("running", nil)
 	// Empty database: first index still running, nothing committed yet.
-	mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 
 	// Set indexing as active - use set() to avoid data race
 	statusInstance.set(indexingStatusVals{
@@ -270,7 +270,7 @@ func TestHandleMedia_IndexingPriorityOverBrowseCacheRebuild(t *testing.T) {
 	testState, _ := state.NewState(mockPlatform, "test-boot-uuid")
 
 	mockMediaDB.On("GetOptimizationStatus").Return("completed", nil)
-	mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 	mockMediaDB.BeginBrowseCacheRebuild()
 
 	statusInstance.set(indexingStatusVals{indexing: true, totalSteps: 10, currentStep: 5})
@@ -374,7 +374,7 @@ func TestHandleMedia_PersistedIndexingStatusShowsPreparingResume(t *testing.T) {
 	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusRunning, nil)
 	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusRunning, nil)
 	// Interrupted first index on an empty database awaiting resume.
-	mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 
 	db := &database.Database{MediaDB: mockMediaDB, UserDB: mockUserDB}
 	env := requests.RequestEnv{Context: context.Background(), Database: db, State: testState}
@@ -399,7 +399,7 @@ func TestGenerateMediaDB_NotifiesPreparingBeforeOptimizationPreflightFailure(t *
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.Optimizing = true
 	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
-	mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 	ns := make(chan models.Notification, 2)
 	db := &database.Database{MediaDB: mockMediaDB}
 

--- a/pkg/api/methods/media_rebuild_test.go
+++ b/pkg/api/methods/media_rebuild_test.go
@@ -165,7 +165,7 @@ func TestHandleGenerateMedia_RebuildRecreateFailureAbortsIndexing(t *testing.T) 
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("Recreate", false).Return(errors.New("disk on fire")).Once()
-	mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 
 	env := newRebuildTestEnv(t, mockMediaDB, `{"rebuild":true}`)
 	_, err := HandleGenerateMedia(env)

--- a/pkg/api/methods/media_total_count_test.go
+++ b/pkg/api/methods/media_total_count_test.go
@@ -207,6 +207,47 @@ func TestHandleMedia_MissingMediaCount(t *testing.T) {
 	}
 }
 
+func TestMediaDBHasUsableData(t *testing.T) {
+	tests := []struct {
+		lastGenerated    time.Time
+		lastGeneratedErr error
+		name             string
+		hasMedia         bool
+		expected         bool
+	}{
+		{
+			name: "fresh empty database",
+		},
+		{
+			name:     "partial index has media",
+			hasMedia: true,
+			expected: true,
+		},
+		{
+			name:          "completed empty index",
+			lastGenerated: time.Now(),
+			expected:      true,
+		},
+		{
+			name:             "timestamp read failure falls back to media",
+			lastGeneratedErr: assert.AnError,
+			hasMedia:         true,
+			expected:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMediaDB := &helpers.MockMediaDBI{}
+			mockMediaDB.On("GetLastGenerated").Return(tt.lastGenerated, tt.lastGeneratedErr)
+			mockMediaDB.On("HasAnyMedia").Return(tt.hasMedia, nil).Maybe()
+
+			assert.Equal(t, tt.expected, mediaDBHasUsableData(mockMediaDB))
+			mockMediaDB.AssertExpectations(t)
+		})
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -813,7 +813,7 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 
 			// Mock total media count
 			mockMediaDB.On("GetTotalMediaCount").Return(0, nil).Maybe()
-			mockMediaDB.On("GetLastGenerated").Return(time.Unix(0, 0), nil).Maybe()
+			mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Maybe()
 
 			// Mock optimized JOIN methods for PopulateScanStateFromDB
 			mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Maybe()

--- a/pkg/database/mediadb/corruption_recovery_test.go
+++ b/pkg/database/mediadb/corruption_recovery_test.go
@@ -213,6 +213,25 @@ func TestMediaDB_Recreate_RemovesPersistedCaches(t *testing.T) {
 	assert.False(t, loaded)
 }
 
+func TestMediaDB_Recreate_CacheRemovalFailureKeepsReindexPending(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	mediaDB.MarkCorrupt("test")
+	cachePath := mediaDB.slugSearchCachePath()
+	require.NoError(t, os.MkdirAll(cachePath, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(cachePath, "blocker"), []byte("stale"), 0o600))
+
+	err := mediaDB.Recreate(false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to clear caches")
+	status, statusErr := mediaDB.GetIndexingStatus()
+	require.NoError(t, statusErr)
+	assert.Equal(t, IndexingStatusPending, status)
+	assert.True(t, mediaDB.IsMarkedCorrupt(), "corrupt marker must survive cache cleanup failure")
+}
+
 // zeroHighPages reproduces the real-world corruption: a contiguous run of high-numbered
 // (table-data) pages overwritten with 0x00, leaving the schema pages intact so the DB still
 // opens but integrity checks fail — mirroring the supplied corrupt media.db.

--- a/pkg/database/mediadb/corruption_recovery_test.go
+++ b/pkg/database/mediadb/corruption_recovery_test.go
@@ -180,11 +180,37 @@ func TestMediaDB_Recreate_KeepBackup(t *testing.T) {
 	require.NoError(t, backupErr, "backup copy should be kept when keepBackup=true")
 	assert.False(t, mediaDB.IsMarkedCorrupt(), "marker should be cleared after recreate")
 
-	// Fresh schema: queryable and empty.
+	// Fresh schema: queryable and empty, with durable intent to rebuild it.
 	var count int
 	require.NoError(t, mediaDB.sql.Load().QueryRowContext(context.Background(),
 		"SELECT COUNT(*) FROM Media").Scan(&count))
 	assert.Equal(t, 0, count, "recreated database should be empty")
+	status, err := mediaDB.GetIndexingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, IndexingStatusPending, status)
+}
+
+func TestMediaDB_Recreate_RemovesPersistedCaches(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	insertSystemWithMedia(t, mediaDB, "NES", "Some Game", filepath.Join("roms", "nes", "game.nes"))
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	require.NoError(t, mediaDB.PersistSlugSearchCache())
+	require.FileExists(t, mediaDB.slugSearchCachePath())
+
+	// A stale tag cache must be removed even if its contents cannot be decoded.
+	require.NoError(t, os.MkdirAll(filepath.Dir(mediaDB.tagCachePath()), 0o750))
+	require.NoError(t, os.WriteFile(mediaDB.tagCachePath(), []byte("stale"), 0o600))
+	require.FileExists(t, mediaDB.tagCachePath())
+
+	require.NoError(t, mediaDB.Recreate(false))
+
+	assert.NoFileExists(t, mediaDB.slugSearchCachePath())
+	assert.NoFileExists(t, mediaDB.tagCachePath())
+	loaded, err := mediaDB.LoadCachedSlugSearchCache()
+	require.NoError(t, err)
+	assert.False(t, loaded)
 }
 
 // zeroHighPages reproduces the real-world corruption: a contiguous run of high-numbered

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -875,11 +875,12 @@ func (db *MediaDB) IntegrityReport() []string {
 
 // Recreate discards the database file and reopens a fresh one. The connection is
 // closed; the main file is either preserved as a <db>.corrupt.bak forensic copy
-// (keepBackup — development builds only) or deleted; the -wal/-shm sidecars and any
-// corrupt marker are removed (a stale WAL would re-corrupt the new file); and Open()
-// allocates a fresh schema. MediaDB is a rebuildable cache, so nothing is salvaged —
-// the caller triggers a reindex afterwards. Callers: corruption recovery and the
-// user-requested fresh-start rebuild (media.index with rebuild:true).
+// (keepBackup — development builds only) or deleted; the -wal/-shm sidecars are
+// removed (a stale WAL would re-corrupt the new file); and Open() allocates a fresh
+// schema. Before any corrupt marker is cleared, the fresh database is marked pending
+// for reindex and stale search caches are removed. This durable handoff lets startup
+// resume if the process exits before the caller starts indexing. Callers: corruption
+// recovery and the user-requested fresh-start rebuild (media.index with rebuild:true).
 func (db *MediaDB) Recreate(keepBackup bool) error {
 	// Serialize recreates: a user-triggered rebuild must never interleave its
 	// close/delete/reopen with corruption recovery's (or another rebuild's).
@@ -939,8 +940,28 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 		return errors.New("recreated media database failed quick_check")
 	}
 
-	// Clear the marker only after the fresh database opens and passes verification,
-	// so a failed replacement leaves the durable signal for the next recovery attempt.
+	// Persist reindex intent before clearing the corrupt marker. Path discovery and
+	// indexing start asynchronously after Recreate returns, so a power loss or startup
+	// failure in that window must not leave an empty database with no resume signal.
+	if err := db.SetIndexingStatus(IndexingStatusPending); err != nil {
+		return fmt.Errorf("failed to mark recreated media database pending reindex: %w", err)
+	}
+
+	// Persisted caches belong to the discarded database. A fresh DB starts with the
+	// same generation value, so leaving generation-zero files behind can make stale
+	// title candidates look valid even though their SQL rows no longer exist.
+	db.inMemoryTagCache.Store(nil)
+	db.slugSearchCache.Store(nil)
+	cacheErr := errors.Join(
+		removePersistedCacheFile(db.tagCachePath(), tagCacheKind),
+		removePersistedCacheFile(db.slugSearchCachePath(), slugSearchCacheKind),
+	)
+	if cacheErr != nil {
+		return fmt.Errorf("failed to clear caches after media database recreate: %w", cacheErr)
+	}
+
+	// Clear the marker only after the fresh database is verified and has durable
+	// reindex intent, so every failure before this point remains recoverable on boot.
 	if err := db.ClearCorruptMarker(); err != nil {
 		return fmt.Errorf("failed to clear corrupt marker after media database recreate: %w", err)
 	}

--- a/pkg/service/inbox/inbox.go
+++ b/pkg/service/inbox/inbox.go
@@ -48,6 +48,7 @@ const (
 	CategoryMediaDBCorruptionRecovery        = "mediadb_corruption_recovery"
 	CategoryMediaDBCorruptionRecoveryFailure = "mediadb_corruption_recovery_failure"
 	CategoryMediaDBCorruptionRecoveryLimit   = "mediadb_corruption_recovery_limit"
+	CategoryMediaDBInterruptedRebuild        = "mediadb_interrupted_rebuild"
 	CategoryMediaIndexResumeLimit            = "media_index_resume_limit"
 	CategoryUpdateAvailable                  = "update_available"
 	CategoryBackupRemoteNotAvailable         = "backup_remote_not_available"

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -113,7 +113,24 @@ func recordIndexResumeCheckpoint(mediaDB database.MediaDBI) (attempts int, stall
 	return attempts, attempts >= maxIndexNoProgressResumeAttempts, nil
 }
 
+func indexingStatusNeedsResume(status string, mediaDB database.MediaDBI) (bool, error) {
+	switch status {
+	case mediadb.IndexingStatusRunning, mediadb.IndexingStatusPending:
+		return true, nil
+	case mediadb.IndexingStatusFailed:
+		hasMedia, err := mediaDB.HasAnyMedia()
+		if err != nil {
+			return false, fmt.Errorf("failed to check media after indexing failure: %w", err)
+		}
+		return !hasMedia, nil
+	default:
+		return false, nil
+	}
+}
+
 // checkAndResumeIndexing checks if media indexing was interrupted and automatically resumes it.
+// It also retries a failed index when the database has no usable media, which prevents a
+// failed corruption-recovery reindex from permanently stranding a fresh empty database.
 // It returns true when an index resume was started so callers can defer lower-priority
 // media maintenance until indexing reaches a terminal state.
 func checkAndResumeIndexing(
@@ -130,8 +147,13 @@ func checkAndResumeIndexing(
 		return false
 	}
 
-	// Only resume if indexing was interrupted (running or pending states)
-	if indexingStatus != mediadb.IndexingStatusRunning && indexingStatus != mediadb.IndexingStatusPending {
+	resumeNeeded, resumeErr := indexingStatusNeedsResume(indexingStatus, db.MediaDB)
+	if resumeErr != nil {
+		log.Warn().Err(resumeErr).Str("status", indexingStatus).
+			Msg("failed to determine whether media indexing needs auto-resume")
+		return false
+	}
+	if !resumeNeeded {
 		log.Debug().Msgf("indexing status is '%s', no auto-resume needed", indexingStatus)
 		// A clean state means the previous index either completed or was never
 		// interrupted; give any future interruption a fresh resume budget.
@@ -139,6 +161,9 @@ func checkAndResumeIndexing(
 			log.Warn().Err(resetErr).Msg("failed to reset index resume attempt counter")
 		}
 		return false
+	}
+	if indexingStatus == mediadb.IndexingStatusFailed {
+		log.Warn().Msg("media indexing failed with an empty database; retrying automatically")
 	}
 
 	// Bound only stalled resumes. A full reindex on a large library can span many
@@ -284,9 +309,16 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 	}
 
 	// Close the race between the active-work check and Recreate: once this gate is
-	// held, new tracked work waits until the replacement database is ready.
+	// held, new tracked work waits until the replacement database is ready. Release
+	// it before starting the reindex: GenerateMediaDB registers that work through
+	// TrackBackgroundOperation, which needs the gate's read lock.
 	db.MediaDB.BeginRecovery()
-	defer db.MediaDB.EndRecovery()
+	recoveryGateHeld := true
+	defer func() {
+		if recoveryGateHeld {
+			db.MediaDB.EndRecovery()
+		}
+	}()
 
 	attempt, allowed := claimMediaDBRecoveryAttempt()
 	if !allowed {
@@ -315,11 +347,14 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 		addMediaDBRecoveryFailureInbox(st, "Automatic media database recovery failed. Safely shut down, "+
 			"check free space, and inspect or replace the storage device before trying again.",
 			inboxservice.CategoryMediaDBCorruptionRecoveryFailure)
-		finishMediaDBRecoveryNotification(st)
+		finishMediaDBRecoveryNotification(st, db.MediaDB)
 		return
 	}
 	log.Info().Int32("recovery_attempt", attempt).Str("recovery_outcome", "verified_recreate").
 		Msg("media database recreated and verified after corruption; starting full reindex")
+
+	db.MediaDB.EndRecovery()
+	recoveryGateHeld = false
 
 	// Tell the user persistently: the rebuild discards scraped metadata (it lived in the
 	// corrupt cache), so artwork returns only after a re-scrape. The inbox lives in UserDB,
@@ -356,16 +391,24 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 		addMediaDBRecoveryFailureInbox(st, "Media database was rebuilt, but reindexing could not start. "+
 			"Restart Zaparoo after checking available storage space.",
 			inboxservice.CategoryMediaDBCorruptionRecoveryFailure)
-		finishMediaDBRecoveryNotification(st)
+		finishMediaDBRecoveryNotification(st, db.MediaDB)
 	}
 }
 
-func finishMediaDBRecoveryNotification(st *state.State) {
+func finishMediaDBRecoveryNotification(st *state.State, mediaDB database.MediaDBI) {
 	if st == nil {
 		return
 	}
+	exists := false
+	if mediaDB != nil {
+		if lastGenerated, err := mediaDB.GetLastGenerated(); err == nil && !lastGenerated.IsZero() {
+			exists = true
+		} else if hasMedia, hasErr := mediaDB.HasAnyMedia(); hasErr == nil {
+			exists = hasMedia
+		}
+	}
 	notifications.MediaIndexing(st.Notifications, models.IndexingStatusResponse{
-		Exists:   true,
+		Exists:   exists,
 		Indexing: false,
 	})
 }

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -112,6 +112,8 @@ func TestCheckAndRecoverCorruptMediaDB_RecreateFailureFinishesNotification(t *te
 	mockDB.On("EndRecovery").Return()
 	mockDB.On("IntegrityReport").Return([]string{"Page 4: malformed"})
 	mockDB.On("Recreate", mock.Anything).Return(errors.New("storage unavailable"))
+	mockDB.On("GetLastGenerated").Return(time.Time{}, nil)
+	mockDB.On("HasAnyMedia").Return(false, nil)
 
 	st, ns := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
 	t.Cleanup(st.StopService)
@@ -124,6 +126,7 @@ func TestCheckAndRecoverCorruptMediaDB_RecreateFailureFinishesNotification(t *te
 	require.NoError(t, json.Unmarshal(finished.Params, &finishedStatus))
 	assert.True(t, startedStatus.Indexing)
 	assert.False(t, finishedStatus.Indexing)
+	assert.False(t, finishedStatus.Exists)
 }
 
 func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *testing.T) {
@@ -141,6 +144,8 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 	mockDB.On("EndRecovery").Return()
 	mockDB.On("IntegrityReport").Return([]string{"Page 4: malformed"})
 	mockDB.On("Recreate", mock.Anything).Return(nil)
+	mockDB.On("GetLastGenerated").Return(time.Time{}, nil)
+	mockDB.On("HasAnyMedia").Return(false, nil)
 
 	st, ns := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
 	t.Cleanup(st.StopService)
@@ -161,7 +166,50 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 	assert.True(t, generateCalled)
 	assert.True(t, startedStatus.Indexing)
 	assert.False(t, finishedStatus.Indexing)
+	assert.False(t, finishedStatus.Exists)
 	mockDB.AssertExpectations(t)
+}
+
+func TestCheckAndRecoverCorruptMediaDB_ReleasesGateBeforeReindex(t *testing.T) {
+	mediaDBRecoveryAttempts.Store(0)
+	mediaDBRecoveryLimitReported.Store(false)
+	t.Cleanup(func() {
+		mediaDBRecoveryAttempts.Store(0)
+		mediaDBRecoveryLimitReported.Store(false)
+	})
+
+	db, cleanup := helpers.NewTestDatabase(t)
+	defer cleanup()
+	db.MediaDB.MarkCorrupt("test recovery gate")
+
+	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	reindexRegistered := make(chan struct{})
+	recoveryDone := make(chan struct{})
+	go func() {
+		defer close(recoveryDone)
+		checkAndRecoverCorruptMediaDBWithGenerator(nil, nil, db, st, syncutil.NewPauser(),
+			func(_ context.Context, _ platforms.Platform, _ *config.Instance, _ chan<- models.Notification,
+				_ []systemdefs.System, targetDB *database.Database, _ *syncutil.Pauser,
+			) error {
+				targetDB.MediaDB.TrackBackgroundOperation()
+				targetDB.MediaDB.BackgroundOperationDone()
+				close(reindexRegistered)
+				return errors.New("stop after background registration")
+			})
+	}()
+
+	select {
+	case <-reindexRegistered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reindex blocked while registering its background operation")
+	}
+	select {
+	case <-recoveryDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("corruption recovery did not finish after reindex registration")
+	}
 }
 
 func TestCheckAndRecoverCorruptMediaDB_StopsRecoveryLoop(t *testing.T) {

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -170,6 +170,25 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 	mockDB.AssertExpectations(t)
 }
 
+func TestFinishMediaDBRecoveryNotification_ReportsCompletedDatabase(t *testing.T) {
+	t.Parallel()
+
+	mockDB := &helpers.MockMediaDBI{}
+	mockDB.On("GetLastGenerated").Return(time.Now(), nil).Once()
+	st, ns := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	finishMediaDBRecoveryNotification(st, mockDB)
+
+	notification := <-ns
+	var status models.IndexingStatusResponse
+	require.NoError(t, json.Unmarshal(notification.Params, &status))
+	assert.True(t, status.Exists)
+	assert.False(t, status.Indexing)
+	mockDB.AssertExpectations(t)
+	mockDB.AssertNotCalled(t, "HasAnyMedia")
+}
+
 func TestCheckAndRecoverCorruptMediaDB_ReleasesGateBeforeReindex(t *testing.T) {
 	mediaDBRecoveryAttempts.Store(0)
 	mediaDBRecoveryLimitReported.Store(false)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -127,6 +127,9 @@ func recoverInterruptedMediaDBRecreate(mediaDB database.MediaDBI, slugCacheLoade
 		return false
 	}
 
+	mediaDB.TrackBackgroundOperation()
+	defer mediaDB.BackgroundOperationDone()
+
 	if err := mediaDB.SetIndexingStatus(mediadb.IndexingStatusPending); err != nil {
 		log.Error().Err(err).Msg("failed to restore reindex intent for empty recreated media database")
 		return false

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -91,6 +91,56 @@ func waitForBackupShutdown(
 	return nil
 }
 
+// recoverInterruptedMediaDBRecreate repairs the 2.16 failure state where a
+// recreated database lost its reindex intent before indexing persisted a status.
+// A non-empty persisted slug cache plus a blank, never-generated, empty database
+// is durable evidence that an indexed database existed before it was replaced.
+func recoverInterruptedMediaDBRecreate(mediaDB database.MediaDBI, slugCacheLoaded bool) bool {
+	if mediaDB == nil || !slugCacheLoaded {
+		return false
+	}
+
+	status, err := mediaDB.GetIndexingStatus()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check indexing status for interrupted database recreation")
+		return false
+	}
+	if status != "" {
+		return false
+	}
+
+	lastGenerated, err := mediaDB.GetLastGenerated()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check generation time for interrupted database recreation")
+		return false
+	}
+	if !lastGenerated.IsZero() {
+		return false
+	}
+
+	hasMedia, err := mediaDB.HasAnyMedia()
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to check media rows for interrupted database recreation")
+		return false
+	}
+	if hasMedia {
+		return false
+	}
+
+	if err := mediaDB.SetIndexingStatus(mediadb.IndexingStatusPending); err != nil {
+		log.Error().Err(err).Msg("failed to restore reindex intent for empty recreated media database")
+		return false
+	}
+
+	log.Warn().Msg("detected empty media database with stale search cache; resuming interrupted rebuild")
+	if err := mediaDB.RebuildSlugSearchCache(); err != nil {
+		log.Warn().Err(err).Msg("failed to clear stale slug search cache after interrupted rebuild")
+	} else if err := mediaDB.PersistSlugSearchCache(); err != nil {
+		log.Warn().Err(err).Msg("failed to remove stale persisted slug search cache after interrupted rebuild")
+	}
+	return true
+}
+
 func rebuildStartupSlugSearchCache(mediaDB database.MediaDBI, slugCacheLoaded bool) {
 	if mediaDB == nil || slugCacheLoaded {
 		return
@@ -482,6 +532,20 @@ func Start(
 					Dur("duration", time.Since(slugCacheStarted)).
 					Msg("cached slug search cache load completed")
 				slugCacheLoaded = loaded
+			}
+
+			if recoverInterruptedMediaDBRecreate(db.MediaDB, slugCacheLoaded) {
+				slugCacheLoaded = false
+				if inboxSvc := st.Inbox(); inboxSvc != nil {
+					if inboxErr := inboxSvc.Add("Media database rebuild resumed",
+						inbox.WithBody("A previous media database rebuild was interrupted. Full media indexing "+
+							"will resume automatically; keep the device powered until it completes."),
+						inbox.WithSeverity(inbox.SeverityWarning),
+						inbox.WithCategory(inbox.CategoryMediaDBInterruptedRebuild),
+					); inboxErr != nil {
+						log.Warn().Err(inboxErr).Msg("failed to add inbox message about resumed media database rebuild")
+					}
+				}
 			}
 
 			runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -567,6 +567,48 @@ func TestAdvanceBackgroundPlaylist_NilPlaylistClearsBackgroundMedia(t *testing.T
 	}
 }
 
+func TestRecoverInterruptedMediaDBRecreate_RestoresPendingState(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Once()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Once()
+	mockMediaDB.On("HasAnyMedia").Return(false, nil).Once()
+	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusPending).Return(nil).Once()
+	mockMediaDB.On("RebuildSlugSearchCache").Return(nil).Once()
+	mockMediaDB.On("PersistSlugSearchCache").Return(nil).Once()
+
+	recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
+
+	assert.True(t, recovered)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestRecoverInterruptedMediaDBRecreate_IgnoresFirstInstall(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+
+	recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, false)
+
+	assert.False(t, recovered)
+	mockMediaDB.AssertNotCalled(t, "GetIndexingStatus")
+}
+
+func TestRecoverInterruptedMediaDBRecreate_IgnoresCompletedEmptyIndex(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Once()
+	mockMediaDB.On("GetLastGenerated").Return(time.Now(), nil).Once()
+
+	recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
+
+	assert.False(t, recovered)
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "SetIndexingStatus", mock.Anything)
+}
+
 func TestRebuildStartupSlugSearchCache_SkipsWhenLoaded(t *testing.T) {
 	t.Parallel()
 
@@ -633,6 +675,57 @@ func TestRebuildStartupSlugSearchCache_RebuildsWhenIdle(t *testing.T) {
 	rebuildStartupSlugSearchCache(mockMediaDB, false)
 
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestIndexingStatusNeedsResume(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    string
+		hasMedia  bool
+		expected  bool
+		checkRows bool
+	}{
+		{
+			name:     "pending",
+			status:   mediadb.IndexingStatusPending,
+			expected: true,
+		},
+		{
+			name:      "failed empty database",
+			status:    mediadb.IndexingStatusFailed,
+			expected:  true,
+			checkRows: true,
+		},
+		{
+			name:      "failed database with media",
+			status:    mediadb.IndexingStatusFailed,
+			hasMedia:  true,
+			checkRows: true,
+		},
+		{
+			name:   "cancelled",
+			status: mediadb.IndexingStatusCancelled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockMediaDB := &testhelpers.MockMediaDBI{}
+			if tt.checkRows {
+				mockMediaDB.On("HasAnyMedia").Return(tt.hasMedia, nil).Once()
+			}
+
+			actual, err := indexingStatusNeedsResume(tt.status, mockMediaDB)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+			mockMediaDB.AssertExpectations(t)
+		})
+	}
 }
 
 func TestCheckAndResumeIndexing_NoInterruption(t *testing.T) {
@@ -873,8 +966,9 @@ func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {
 	// Create mock state
 	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
 
-	// Mock database to return "failed" status (should not resume)
+	// A failed update over a still-usable database should not auto-resume.
 	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusFailed, nil)
+	mockMediaDB.On("HasAnyMedia").Return(true, nil)
 	// A non-interrupted state resets the resume-attempt counter.
 	mockMediaDB.On("ResetIndexResumeAttempts").Return(nil)
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -574,14 +574,34 @@ func TestRecoverInterruptedMediaDBRecreate_RestoresPendingState(t *testing.T) {
 	mockMediaDB.On("GetIndexingStatus").Return("", nil).Once()
 	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Once()
 	mockMediaDB.On("HasAnyMedia").Return(false, nil).Once()
+	mockMediaDB.On("TrackBackgroundOperation").Return().Once()
 	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusPending).Return(nil).Once()
 	mockMediaDB.On("RebuildSlugSearchCache").Return(nil).Once()
 	mockMediaDB.On("PersistSlugSearchCache").Return(nil).Once()
+	mockMediaDB.On("BackgroundOperationDone").Return().Once()
 
 	recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
 
 	assert.True(t, recovered)
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestRecoverInterruptedMediaDBRecreate_StatusErrorReleasesBackgroundOperation(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return("", nil).Once()
+	mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Once()
+	mockMediaDB.On("HasAnyMedia").Return(false, nil).Once()
+	mockMediaDB.On("TrackBackgroundOperation").Return().Once()
+	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusPending).Return(assert.AnError).Once()
+	mockMediaDB.On("BackgroundOperationDone").Return().Once()
+
+	recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
+
+	assert.False(t, recovered)
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "RebuildSlugSearchCache")
 }
 
 func TestRecoverInterruptedMediaDBRecreate_IgnoresFirstInstall(t *testing.T) {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -604,6 +604,115 @@ func TestRecoverInterruptedMediaDBRecreate_StatusErrorReleasesBackgroundOperatio
 	mockMediaDB.AssertNotCalled(t, "RebuildSlugSearchCache")
 }
 
+func TestRecoverInterruptedMediaDBRecreate_RejectsAmbiguousState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		statusErr        error
+		lastGeneratedErr error
+		hasMediaErr      error
+		name             string
+		status           string
+		hasMedia         bool
+		checkGenerated   bool
+		checkMedia       bool
+	}{
+		{
+			name:      "indexing status unavailable",
+			statusErr: assert.AnError,
+		},
+		{
+			name:   "index already pending",
+			status: mediadb.IndexingStatusPending,
+		},
+		{
+			name:             "last generation unavailable",
+			lastGeneratedErr: assert.AnError,
+			checkGenerated:   true,
+		},
+		{
+			name:           "media rows unavailable",
+			hasMediaErr:    assert.AnError,
+			checkGenerated: true,
+			checkMedia:     true,
+		},
+		{
+			name:           "database still has media",
+			hasMedia:       true,
+			checkGenerated: true,
+			checkMedia:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockMediaDB := &testhelpers.MockMediaDBI{}
+			mockMediaDB.On("GetIndexingStatus").Return(tt.status, tt.statusErr).Once()
+			if tt.checkGenerated {
+				mockMediaDB.On("GetLastGenerated").Return(time.Time{}, tt.lastGeneratedErr).Once()
+			}
+			if tt.checkMedia {
+				mockMediaDB.On("HasAnyMedia").Return(tt.hasMedia, tt.hasMediaErr).Once()
+			}
+
+			recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
+
+			assert.False(t, recovered)
+			mockMediaDB.AssertExpectations(t)
+			mockMediaDB.AssertNotCalled(t, "TrackBackgroundOperation")
+		})
+	}
+}
+
+func TestRecoverInterruptedMediaDBRecreate_CacheFailuresKeepRecoveryPending(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		rebuildErr  error
+		persistErr  error
+		name        string
+		callPersist bool
+	}{
+		{
+			name:       "cache rebuild fails",
+			rebuildErr: assert.AnError,
+		},
+		{
+			name:        "cache persistence fails",
+			persistErr:  assert.AnError,
+			callPersist: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockMediaDB := &testhelpers.MockMediaDBI{}
+			mockMediaDB.On("GetIndexingStatus").Return("", nil).Once()
+			mockMediaDB.On("GetLastGenerated").Return(time.Time{}, nil).Once()
+			mockMediaDB.On("HasAnyMedia").Return(false, nil).Once()
+			mockMediaDB.On("TrackBackgroundOperation").Return().Once()
+			mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusPending).Return(nil).Once()
+			mockMediaDB.On("RebuildSlugSearchCache").Return(tt.rebuildErr).Once()
+			if tt.callPersist {
+				mockMediaDB.On("PersistSlugSearchCache").Return(tt.persistErr).Once()
+			}
+			mockMediaDB.On("BackgroundOperationDone").Return().Once()
+
+			recovered := recoverInterruptedMediaDBRecreate(mockMediaDB, true)
+
+			assert.True(t, recovered)
+			mockMediaDB.AssertExpectations(t)
+			if !tt.callPersist {
+				mockMediaDB.AssertNotCalled(t, "PersistSlugSearchCache")
+			}
+		})
+	}
+}
+
 func TestRecoverInterruptedMediaDBRecreate_IgnoresFirstInstall(t *testing.T) {
 	t.Parallel()
 
@@ -701,11 +810,13 @@ func TestIndexingStatusNeedsResume(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		status    string
-		hasMedia  bool
-		expected  bool
-		checkRows bool
+		hasMediaErr error
+		name        string
+		status      string
+		hasMedia    bool
+		expected    bool
+		checkRows   bool
+		expectedErr bool
 	}{
 		{
 			name:     "pending",
@@ -725,6 +836,13 @@ func TestIndexingStatusNeedsResume(t *testing.T) {
 			checkRows: true,
 		},
 		{
+			name:        "failed media check",
+			status:      mediadb.IndexingStatusFailed,
+			hasMediaErr: assert.AnError,
+			checkRows:   true,
+			expectedErr: true,
+		},
+		{
 			name:   "cancelled",
 			status: mediadb.IndexingStatusCancelled,
 		},
@@ -736,12 +854,16 @@ func TestIndexingStatusNeedsResume(t *testing.T) {
 
 			mockMediaDB := &testhelpers.MockMediaDBI{}
 			if tt.checkRows {
-				mockMediaDB.On("HasAnyMedia").Return(tt.hasMedia, nil).Once()
+				mockMediaDB.On("HasAnyMedia").Return(tt.hasMedia, tt.hasMediaErr).Once()
 			}
 
 			actual, err := indexingStatusNeedsResume(tt.status, mockMediaDB)
 
-			require.NoError(t, err)
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			assert.Equal(t, tt.expected, actual)
 			mockMediaDB.AssertExpectations(t)
 		})
@@ -963,6 +1085,20 @@ func TestCheckAndResumeIndexing_DatabaseError(t *testing.T) {
 
 	// Verify that only GetIndexingStatus was called and no further operations
 	mockMediaDB.AssertNotCalled(t, "GetOptimizationStatus")
+}
+
+func TestCheckAndResumeIndexing_FailedStatusMediaCheckError(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := &testhelpers.MockMediaDBI{}
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusFailed, nil).Once()
+	mockMediaDB.On("HasAnyMedia").Return(false, assert.AnError).Once()
+
+	started := checkAndResumeIndexing(nil, nil, &database.Database{MediaDB: mockMediaDB}, nil, nil)
+
+	assert.False(t, started)
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "ResetIndexResumeAttempts")
 }
 
 func TestCheckAndResumeIndexing_FailedStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

- release corruption-recovery gate before reindex background registration, preventing a self-deadlock introduced in 2.16
- persist pending reindex intent and clear stale search caches before clearing corruption marker
- automatically repair already-stranded empty databases, retry failed empty indexes, and report database existence accurately

Validated with `task lint-fix` and full race-enabled `task test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after interrupted or corrupted media database rebuilds.
  * Automatically resumes indexing when an empty database requires recovery.
  * Clears stale caches and restores pending indexing status during database recreation.
  * Recovery notifications now accurately indicate whether media is available.
  * Prevented recovery processes from blocking background indexing operations.
* **Tests**
  * Added coverage for interrupted rebuilds, cache cleanup, indexing resumption, recovery failures, and empty database handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->