### PR TITLE
fix(backup): support backups without platform files

### DIFF
--- a/pkg/api/methods/backup.go
+++ b/pkg/api/methods/backup.go
@@ -50,9 +50,6 @@ func requireBackupRuntime(env *requests.RequestEnv) error {
 }
 
 func backupMethodError(action string, err error) error {
-	if errors.Is(err, backupsvc.ErrPlatformBackupUnsupported) {
-		return models.ClientErrf("full-device backup is not supported on this platform")
-	}
 	if errors.Is(err, backupsvc.ErrRestoreMediaActive) {
 		return models.ClientErrf("cannot restore backup while media is active")
 	}

--- a/pkg/api/methods/backup_test.go
+++ b/pkg/api/methods/backup_test.go
@@ -99,15 +99,21 @@ func newBackupTestEnv(t *testing.T) requests.RequestEnv {
 	}
 }
 
-func TestHandleBackup_RejectsPlatformWithoutFullDeviceProvider(t *testing.T) {
+func TestHandleBackup_SucceedsWithoutPlatformBackupProvider(t *testing.T) {
 	env := newBackupTestEnv(t)
 	platformWithBackup, ok := env.Platform.(*backupCapableTestPlatform)
 	require.True(t, ok)
 	env.Platform = platformWithBackup.MockPlatform
 
-	_, err := HandleBackup(env)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not supported on this platform")
+	result, err := HandleBackup(env)
+	require.NoError(t, err)
+	info, ok := result.(backupsvc.Info)
+	require.True(t, ok)
+	assert.NotZero(t, info.Categories[backupsvc.CategoryZaparoo].Files)
+	assert.Zero(t, info.Categories[backupsvc.CategorySettings].Files)
+	assert.Zero(t, info.Categories[backupsvc.CategoryInputs].Files)
+	assert.Zero(t, info.Categories[backupsvc.CategorySaves].Files)
+	assert.Zero(t, info.Categories[backupsvc.CategorySavestates].Files)
 }
 
 func TestHandleBackup_Success(t *testing.T) {
@@ -309,7 +315,6 @@ func TestBackupMethodErrorMapsExpectedConditions(t *testing.T) {
 		err      error
 		contains string
 	}{
-		{err: backupsvc.ErrPlatformBackupUnsupported, contains: "not supported on this platform"},
 		{err: backupsvc.ErrRestoreMediaActive, contains: "while media is active"},
 		{err: backupsvc.ErrRestoreLaunchInProgress, contains: "media is launching or restart is pending"},
 		{err: &backupsvc.BusyError{Kind: backupsvc.OperationRemoteUpload}, contains: "busy with remote-upload"},

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -48,10 +48,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var (
-	ErrPlatformBackupUnsupported = errors.New("platform does not support full-device backup")
-	statusMu                     syncutil.RWMutex
-)
+var statusMu syncutil.RWMutex
 
 const (
 	CategoryZaparoo    = "zaparoo"
@@ -709,11 +706,7 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 	dataDir := helpers.DataDir(m.pl)
 	configDir := helpers.ConfigDir(m.pl)
 	var platformPlan platforms.BackupPlan
-	if scope == config.BackupScopePlatform {
-		provider, ok := m.pl.(platforms.BackupProvider)
-		if !ok {
-			return fileCollection{}, ErrPlatformBackupUnsupported
-		}
+	if provider, ok := m.pl.(platforms.BackupProvider); scope == config.BackupScopePlatform && ok {
 		platformPlan = platforms.BackupPlan{Definitions: provider.BackupDefinitions()}
 		if planner, planning := m.pl.(platforms.BackupPlanningProvider); planning {
 			platformPlan = planner.BackupPlan()

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -641,7 +641,7 @@ func TestManagerPreRestoreBackupIgnoresZaparooScope(t *testing.T) {
 	assert.Positive(t, pre.Categories[CategorySavestates].Files)
 }
 
-func TestManagerCreateUnsupportedPlatformScopes(t *testing.T) {
+func TestManagerCreateWithoutPlatformBackupProvider(t *testing.T) {
 	t.Parallel()
 	rootDir := t.TempDir()
 	dataDir := filepath.Join(rootDir, "zaparoo")
@@ -667,17 +667,115 @@ func TestManagerCreateUnsupportedPlatformScopes(t *testing.T) {
 	}, func() error { return nil }, nil)
 	mgr := NewManager(cfg, mockPlatform, &database.Database{UserDB: userDB})
 
-	// Platform scope still requires a backup provider.
-	_, err = mgr.Create(context.Background())
-	require.ErrorIs(t, err, ErrPlatformBackupUnsupported)
-
-	// Zaparoo scope backs up Core data on any platform, and pre-restore
-	// collection degrades to it when no provider exists.
-	assert.Equal(t, config.BackupScopeZaparoo, mgr.preRestoreScope())
-	cfg.SetBackupScope(config.BackupScopeZaparoo)
+	// Default platform scope degrades to Zaparoo-only when this platform
+	// has no platform backup definitions.
 	info, err := mgr.Create(context.Background())
 	require.NoError(t, err)
 	assert.Positive(t, info.Categories[CategoryZaparoo].Files)
+	assert.Zero(t, info.Categories[CategorySettings].Files)
+	assert.Zero(t, info.Categories[CategoryInputs].Files)
+	assert.Zero(t, info.Categories[CategorySaves].Files)
+	assert.Zero(t, info.Categories[CategorySavestates].Files)
+
+	// Pre-restore safety backups use the same supported Zaparoo-only scope.
+	assert.Equal(t, config.BackupScopeZaparoo, mgr.preRestoreScope())
+}
+
+func removeBackupProvider(t *testing.T, manager *Manager) {
+	t.Helper()
+	platformWithBackup, ok := manager.pl.(backupPlatform)
+	require.True(t, ok)
+	manager.pl = platformWithBackup.MockPlatform
+}
+
+func TestManagerRestoreWithoutPlatformBackupProvider(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Linux)
+	removeBackupProvider(t, env.Manager)
+
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	frontendPath := filepath.Join(env.DataDir, "frontend.toml")
+	require.NoError(t, os.Remove(frontendPath))
+
+	_, err = env.Manager.Restore(context.Background(), info.Name)
+	require.NoError(t, err)
+	restored, err := os.ReadFile(frontendPath) // #nosec G304 -- path belongs to test temp dir.
+	require.NoError(t, err)
+	assert.Equal(t, "enabled = true\n", string(restored))
+}
+
+func TestManagerRunRemoteWithoutPlatformBackupProvider(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Linux)
+	removeBackupProvider(t, env.Manager)
+	var committed remoteSnapshotRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/heartbeat":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/me":
+			writeJSON(t, w, remoteDeviceMeResponse{ID: "device-1", BackupActive: true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/check":
+			writeJSON(t, w, remoteCheckResponse{})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups":
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&committed)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, testCommittedRemoteResponse(t, "backup-linux", platformids.Linux, &committed))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	info, err := env.Manager.RunRemote(context.Background(), RemoteBackupTypeManual)
+	require.NoError(t, err)
+	assert.Equal(t, "backup-linux", info.Backup.ID)
+	require.NotEmpty(t, committed.Categories[CategoryZaparoo])
+	assert.NotContains(t, committed.Categories, CategorySettings)
+	assert.NotContains(t, committed.Categories, CategoryInputs)
+	assert.NotContains(t, committed.Categories, CategorySaves)
+	assert.NotContains(t, committed.Categories, CategorySavestates)
+}
+
+func TestManagerRestoreRemoteWithoutPlatformBackupProvider(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Linux)
+	removeBackupProvider(t, env.Manager)
+	manifestData, manifestHash, err := canonicalRemoteManifest(map[string][]remoteManifestEntry{
+		CategoryZaparoo: {{Path: config.UserDbFile, SHA256: remoteEmptyContentSHA256, Size: 0}},
+	})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/backup-linux":
+			writeJSON(t, w, remoteBackupResponse{
+				ID: "backup-linux", BackupType: RemoteBackupTypeManual, SchemaVersion: remoteSchemaVersion,
+				Platform:     testStringPointer(platformids.Linux),
+				ManifestHash: manifestHash,
+				Categories: map[string]remoteCategorySummary{
+					CategoryZaparoo: {Files: 1},
+				},
+				Manifest: manifestData, CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups/backup-linux/restore-complete":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	restore, err := env.Manager.RestoreRemote(context.Background(), "backup-linux")
+	require.NoError(t, err)
+	assert.Equal(t, "backup-linux", restore.RestoredFrom.ID)
+	env.UserDB.AssertCalled(t, "RestoreBackup", testifymock.AnythingOfType("string"))
 }
 
 func TestManagerTrackScheduleStale(t *testing.T) {

--- a/pkg/ui/tui/mock_api_client_test.go
+++ b/pkg/ui/tui/mock_api_client_test.go
@@ -144,13 +144,16 @@ func (m *MockSettingsService) GetBackupStatus(ctx context.Context) (*models.Back
 	return status, args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
 }
 
-func (m *MockSettingsService) RunRemoteBackup(ctx context.Context) (string, error) {
+func (m *MockSettingsService) RunRemoteBackup(ctx context.Context) (*RemoteBackupRun, error) {
 	args := m.Called(ctx)
-	id, ok := args.Get(0).(string)
-	if !ok {
-		return "", args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
 	}
-	return id, args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
+	run, ok := args.Get(0).(*RemoteBackupRun)
+	if !ok {
+		return nil, args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
+	}
+	return run, args.Error(1) //nolint:wrapcheck // mock returns test-provided errors
 }
 
 func (m *MockSettingsService) ListRemoteBackups(ctx context.Context) ([]RemoteBackupItem, error) {

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -624,7 +624,7 @@ func addCloudBackupItems(
 				return remoteBackupRunLabel(run), nil
 			},
 			func(label string) {
-				ShowInfoModal(pages, app, "Cloud backup created", label, rebuild)
+				ShowInfoModal(pages, app, "Cloud backup", label, rebuild)
 			},
 		)
 	})

--- a/pkg/ui/tui/settings.go
+++ b/pkg/ui/tui/settings.go
@@ -617,11 +617,11 @@ func addCloudBackupItems(
 			"Creating cloud backup",
 			"Uploading backup to the cloud...",
 			func(ctx context.Context) (string, error) {
-				id, backupErr := svc.RunRemoteBackup(ctx)
+				run, backupErr := svc.RunRemoteBackup(ctx)
 				if backupErr != nil {
 					return "", fmt.Errorf("create cloud backup: %w", backupErr)
 				}
-				return "Cloud backup " + id, nil
+				return remoteBackupRunLabel(run), nil
 			},
 			func(label string) {
 				ShowInfoModal(pages, app, "Cloud backup created", label, rebuild)
@@ -657,8 +657,6 @@ func backupActionErrorText(title string, err error) string {
 	case strings.Contains(message, "cannot restore backup while media is launching") ||
 		strings.Contains(message, "media launch is in progress"):
 		guidance = "Wait for media launch to finish, then try restoring again."
-	case strings.Contains(message, "full-device backup is not supported on this platform"):
-		guidance = "Full-device backup is not available on this platform."
 	case strings.Contains(message, "remote backup is not available for this account"):
 		guidance = "Cloud backup requires an active Zaparoo Warp subscription."
 	case strings.Contains(message, "backup restore rollback requires recovery") ||
@@ -1347,6 +1345,17 @@ func remoteBackupTypeLabel(backupType string) string {
 	default:
 		return "Backup"
 	}
+}
+
+func remoteBackupRunLabel(run *RemoteBackupRun) string {
+	label := "Backed up this device."
+	if run.NoChanges {
+		label = "This device is already backed up."
+	}
+	if !run.Backup.CreatedAt.IsZero() {
+		label += "\nSnapshot: " + formatBackupTime(run.Backup.CreatedAt)
+	}
+	return label
 }
 
 // remoteBackupOverwriteSummary names the categories a restore replaces on

--- a/pkg/ui/tui/settings_api_test.go
+++ b/pkg/ui/tui/settings_api_test.go
@@ -204,7 +204,7 @@ func TestDefaultSettingsService_RemoteBackupAPIContracts(t *testing.T) {
 	mockClient := mocks.NewMockAPIClient()
 	mockClient.On("Call", testifymock.Anything, models.MethodSettingsBackupRemoteRun, "").Return(
 		`{"backup":{"id":"save/a%b ?\u96ea","createdAt":"2026-07-10T12:00:00Z",`+
-			`"backupType":"manual","sizeBytes":42},"noChanges":false}`, nil,
+			`"backupType":"manual","sizeBytes":42},"noChanges":true}`, nil,
 	).Once()
 	mockClient.On("Call", testifymock.Anything, models.MethodSettingsBackupRemoteList, "").Return(
 		`{"items":[{"id":"save/a%b ?\u96ea","createdAt":"2026-07-10T12:00:00Z",`+
@@ -222,7 +222,7 @@ func TestDefaultSettingsService_RemoteBackupAPIContracts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, backupID, run.Backup.ID)
 	assert.Equal(t, time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC), run.Backup.CreatedAt)
-	assert.False(t, run.NoChanges)
+	assert.True(t, run.NoChanges)
 
 	backups, err := svc.ListRemoteBackups(ctx)
 	require.NoError(t, err)

--- a/pkg/ui/tui/settings_api_test.go
+++ b/pkg/ui/tui/settings_api_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/client"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -202,7 +203,8 @@ func TestDefaultSettingsService_RemoteBackupAPIContracts(t *testing.T) {
 	ctx := context.Background()
 	mockClient := mocks.NewMockAPIClient()
 	mockClient.On("Call", testifymock.Anything, models.MethodSettingsBackupRemoteRun, "").Return(
-		`{"backup":{"id":"save/a%b ?\u96ea"}}`, nil,
+		`{"backup":{"id":"save/a%b ?\u96ea","createdAt":"2026-07-10T12:00:00Z",`+
+			`"backupType":"manual","sizeBytes":42},"noChanges":false}`, nil,
 	).Once()
 	mockClient.On("Call", testifymock.Anything, models.MethodSettingsBackupRemoteList, "").Return(
 		`{"items":[{"id":"save/a%b ?\u96ea","createdAt":"2026-07-10T12:00:00Z",`+
@@ -216,9 +218,11 @@ func TestDefaultSettingsService_RemoteBackupAPIContracts(t *testing.T) {
 	).Return(`{}`, nil).Once()
 
 	svc := NewSettingsService(mockClient)
-	id, err := svc.RunRemoteBackup(ctx)
+	run, err := svc.RunRemoteBackup(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, backupID, id)
+	assert.Equal(t, backupID, run.Backup.ID)
+	assert.Equal(t, time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC), run.Backup.CreatedAt)
+	assert.False(t, run.NoChanges)
 
 	backups, err := svc.ListRemoteBackups(ctx)
 	require.NoError(t, err)

--- a/pkg/ui/tui/settings_service.go
+++ b/pkg/ui/tui/settings_service.go
@@ -59,6 +59,12 @@ type RemoteBackupItem struct {
 	Incompatible bool                            `json:"incompatible"`
 }
 
+// RemoteBackupRun describes one completed cloud backup operation.
+type RemoteBackupRun struct {
+	Backup    RemoteBackupItem `json:"backup"`
+	NoChanges bool             `json:"noChanges"`
+}
+
 // SettingsService handles settings API operations.
 type SettingsService interface {
 	// GetSettings fetches current settings from the API.
@@ -89,7 +95,7 @@ type SettingsService interface {
 	GetBackupStatus(ctx context.Context) (*models.BackupStatusResponse, error)
 
 	// RunRemoteBackup uploads a backup to the configured remote provider.
-	RunRemoteBackup(ctx context.Context) (string, error)
+	RunRemoteBackup(ctx context.Context) (*RemoteBackupRun, error)
 
 	// ListRemoteBackups fetches the account's cloud backup snapshots.
 	ListRemoteBackups(ctx context.Context) ([]RemoteBackupItem, error)
@@ -167,14 +173,6 @@ type SettingsService interface {
 // DefaultSettingsService implements SettingsService using an APIClient.
 type DefaultSettingsService struct {
 	apiClient client.APIClient
-}
-
-type remoteBackupRunRaw struct {
-	Backup remoteBackupIDRaw `json:"backup"`
-}
-
-type remoteBackupIDRaw struct {
-	ID string `json:"id"`
 }
 
 // NewSettingsService creates a SettingsService that uses the given APIClient.
@@ -299,16 +297,16 @@ func (s *DefaultSettingsService) GetBackupStatus(ctx context.Context) (*models.B
 	return &status, nil
 }
 
-func (s *DefaultSettingsService) RunRemoteBackup(ctx context.Context) (string, error) {
+func (s *DefaultSettingsService) RunRemoteBackup(ctx context.Context) (*RemoteBackupRun, error) {
 	resp, err := s.apiClient.Call(ctx, models.MethodSettingsBackupRemoteRun, "")
 	if err != nil {
-		return "", fmt.Errorf("failed to run remote backup: %w", err)
+		return nil, fmt.Errorf("failed to run remote backup: %w", err)
 	}
-	var raw remoteBackupRunRaw
-	if err := json.Unmarshal([]byte(resp), &raw); err != nil {
-		return "", fmt.Errorf("failed to parse remote backup result: %w", err)
+	var run RemoteBackupRun
+	if err := json.Unmarshal([]byte(resp), &run); err != nil {
+		return nil, fmt.Errorf("failed to parse remote backup result: %w", err)
 	}
-	return raw.Backup.ID, nil
+	return &run, nil
 }
 
 func (s *DefaultSettingsService) ListRemoteBackups(ctx context.Context) ([]RemoteBackupItem, error) {

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -992,6 +992,7 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 		Backup: RemoteBackupItem{
 			ID: "backup-42", CreatedAt: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
 		},
+		NoChanges: true,
 	}, nil)
 
 	runner.Start(pages)
@@ -1007,8 +1008,9 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Cloud backup created", 500*time.Millisecond))
-	assert.True(t, runner.ContainsText("Backed up this device."))
+	require.True(t, runner.WaitForText("This device is already backed up.", 500*time.Millisecond))
+	assert.True(t, runner.ContainsText("Cloud backup"))
+	assert.False(t, runner.ContainsText("Cloud backup created"))
 	assert.True(t, runner.ContainsText("Snapshot: 2026-07-10 12:00:00 UTC"))
 	assert.False(t, runner.ContainsText("backup-42"))
 	mockSvc.AssertCalled(t, "RunRemoteBackup", mock.Anything)

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -718,10 +718,6 @@ func TestBackupActionErrorTextMapsSafeGuidance(t *testing.T) {
 			expected: "Wait for media launch to finish",
 		},
 		{
-			name: "unsupported platform", err: errors.New("full-device backup is not supported on this platform"),
-			expected: "Full-device backup is not available on this platform",
-		},
-		{
 			name: "warp", err: errors.New("remote backup is not available for this account"),
 			expected: "requires an active Zaparoo Warp subscription",
 		},
@@ -909,7 +905,7 @@ func TestBuildBackupSettingsMenu_UnavailableWarpStillAttemptsUpload_Integration(
 	mockSvc.SetupGetBackupStatus(status)
 	mockSvc.SetupUpdateSettingsSuccess()
 	mockSvc.On("RunRemoteBackup", mock.Anything).
-		Return("", errors.New("remote backup is not available for this account"))
+		Return(nil, errors.New("remote backup is not available for this account"))
 
 	runner.Start(pages)
 	runner.QueueUpdateDraw(func() {
@@ -992,7 +988,11 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 	mockSvc := NewMockSettingsService()
 	mockSvc.SetupGetBackupStatus(backupTestStatus(true))
 	mockSvc.SetupUpdateSettingsSuccess()
-	mockSvc.On("RunRemoteBackup", mock.Anything).Return("backup-42", nil)
+	mockSvc.On("RunRemoteBackup", mock.Anything).Return(&RemoteBackupRun{
+		Backup: RemoteBackupItem{
+			ID: "backup-42", CreatedAt: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+		},
+	}, nil)
 
 	runner.Start(pages)
 	runner.QueueUpdateDraw(func() {
@@ -1008,7 +1008,9 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
 	require.True(t, runner.WaitForText("Cloud backup created", 500*time.Millisecond))
-	require.True(t, runner.WaitForText("Cloud backup backup-42", 100*time.Millisecond))
+	assert.True(t, runner.ContainsText("Backed up this device."))
+	assert.True(t, runner.ContainsText("Snapshot: 2026-07-10 12:00:00 UTC"))
+	assert.False(t, runner.ContainsText("backup-42"))
 	mockSvc.AssertCalled(t, "RunRemoteBackup", mock.Anything)
 }
 
@@ -1579,6 +1581,19 @@ func TestRemoteBackupSnapshotsPage_ShowsTypeAndSize_Integration(t *testing.T) {
 	assert.True(t, runner.ContainsText("Manual"))
 	assert.True(t, runner.ContainsText("Scheduled"))
 	assert.True(t, runner.ContainsText("4 MB"))
+}
+
+func TestRemoteBackupRunLabel_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	label := remoteBackupRunLabel(&RemoteBackupRun{
+		Backup: RemoteBackupItem{
+			CreatedAt: time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC),
+		},
+		NoChanges: true,
+	})
+
+	assert.Equal(t, "This device is already backed up.\nSnapshot: 2026-07-10 12:00:00 UTC", label)
 }
 
 func TestRemoteBackupSnapshotsPage_IncompatibleCannotRestore_Integration(t *testing.T) {


### PR DESCRIPTION
## Summary

- show friendly cloud backup completion details instead of internal snapshot IDs
- fall back to Zaparoo-only backup collection when platform backup definitions are unavailable
- cover local and cloud backup and restore behavior on platforms without backup providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud backups now succeed on platforms without full-device backup support by saving available application data.
  * Backup status displays whether a snapshot was created, no changes were needed, and when the snapshot was created.

* **Bug Fixes**
  * Improved local and remote backup and restore behavior for platforms without full-device backup providers.
  * Removed misleading unsupported-platform error messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->