### PR TITLE
fix(service): select preferred property match

### DIFF
--- a/pkg/service/property_match.go
+++ b/pkg/service/property_match.go
@@ -21,6 +21,7 @@ package service
 
 import (
 	"context"
+	"strings"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -32,6 +33,28 @@ import (
 
 var dbMatchProperties = map[string]struct{}{
 	string(tags.TagPropertyGameID): {},
+}
+
+var deprioritizedPropertyMatchTags = map[database.MediaTagRef]struct{}{
+	{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedSample)}:         {},
+	{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedPreview)}:        {},
+	{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedPrerelease)}:     {},
+	{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedBootleg)}:        {},
+	{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedHack)}:           {},
+	{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedClone)}:          {},
+	{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedTranslation)}:    {},
+	{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedTranslationOld)}: {},
+	{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpHacked)}:                     {},
+	{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpModified)}:                   {},
+	{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpTranslated)}:                 {},
+	{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpBad)}:                        {},
+}
+
+var deprioritizedUnfinishedPrefixes = []string{
+	string(tags.TagUnfinishedAlpha),
+	string(tags.TagUnfinishedBeta),
+	string(tags.TagUnfinishedProto),
+	string(tags.TagUnfinishedDemo),
 }
 
 // resolveTokenProperties looks for a launch implied by properties a reader
@@ -81,18 +104,83 @@ func resolveTokenProperties(
 		return
 	}
 
-	switch len(matches) {
-	case 0:
+	if len(matches) == 0 {
 		log.Info().Any("properties", properties).Msg("no indexed media matched scanned properties")
-	case 1:
-		token.Text = gozapscript.Command{
-			Name: gozapscript.ZapScriptCmdLaunch,
-			Args: []string{matches[0].Path},
-		}.String()
-		log.Info().Str("system", matches[0].SystemID).Str("path", matches[0].Path).
-			Msg("resolved scan by property match")
-	default:
-		log.Warn().Any("properties", properties).Int("matches", len(matches)).
-			Msg("scan property matched multiple media")
+		return
 	}
+
+	selected := matches[0]
+	if len(matches) > 1 {
+		var preferredNonVariant bool
+		selected, preferredNonVariant = selectPreferredPropertyMatch(ctx, svc, matches)
+		selection := "first"
+		if preferredNonVariant {
+			selection = "non_variant"
+		}
+		log.Warn().Any("properties", properties).Int("matches", len(matches)).
+			Str("selection", selection).
+			Str("selected_path", selected.Path).
+			Msg("scan property matched multiple media; selecting preferred match")
+	}
+
+	token.Text = gozapscript.Command{
+		Name: gozapscript.ZapScriptCmdLaunch,
+		Args: []string{selected.Path},
+	}.String()
+	log.Info().Str("system", selected.SystemID).Str("path", selected.Path).
+		Msg("resolved scan by property match")
+}
+
+func selectPreferredPropertyMatch(
+	ctx context.Context,
+	svc *ServiceContext,
+	matches []database.SearchResult,
+) (database.SearchResult, bool) {
+	mediaIDs := make([]int64, len(matches))
+	for i := range matches {
+		mediaIDs[i] = matches[i].MediaID
+	}
+
+	mediaTags, err := svc.DB.MediaDB.GetMediaTagsByMediaDBIDs(ctx, mediaIDs)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to load media tags for property match ranking")
+		return matches[0], false
+	}
+
+	firstPreferred := -1
+	deprioritized := 0
+	for i := range matches {
+		if isDeprioritizedPropertyMatch(mediaTags[matches[i].MediaID]) {
+			deprioritized++
+			continue
+		}
+		if firstPreferred == -1 {
+			firstPreferred = i
+		}
+	}
+
+	if deprioritized > 0 && firstPreferred >= 0 {
+		return matches[firstPreferred], true
+	}
+	return matches[0], false
+}
+
+func isDeprioritizedPropertyMatch(mediaTags []database.TagInfo) bool {
+	for _, mediaTag := range mediaTags {
+		if _, ok := deprioritizedPropertyMatchTags[database.MediaTagRef{
+			Type: mediaTag.Type,
+			Tag:  mediaTag.Tag,
+		}]; ok {
+			return true
+		}
+		if mediaTag.Type != string(tags.TagTypeUnfinished) {
+			continue
+		}
+		for _, prefix := range deprioritizedUnfinishedPrefixes {
+			if strings.HasPrefix(mediaTag.Tag, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/service/property_match_test.go
+++ b/pkg/service/property_match_test.go
@@ -106,6 +106,7 @@ func TestResolveTokenProperties_AmbiguousMatchSelectsFirst(t *testing.T) {
 	}})
 
 	require.Equal(t, "**launch:"+firstPath, token.Text)
+	mediaDB.AssertExpectations(t)
 }
 
 func TestResolveTokenProperties_AmbiguousMatchPrefersNonVariant(t *testing.T) {
@@ -133,6 +134,7 @@ func TestResolveTokenProperties_AmbiguousMatchPrefersNonVariant(t *testing.T) {
 	}})
 
 	require.Equal(t, "**launch:"+officialPath, token.Text)
+	mediaDB.AssertExpectations(t)
 }
 
 func TestResolveTokenProperties_AmbiguousMatchAllVariantsSelectsFirst(t *testing.T) {
@@ -160,6 +162,7 @@ func TestResolveTokenProperties_AmbiguousMatchAllVariantsSelectsFirst(t *testing
 	}})
 
 	require.Equal(t, "**launch:"+firstPath, token.Text)
+	mediaDB.AssertExpectations(t)
 }
 
 func TestResolveTokenProperties_TagLookupErrorSelectsFirst(t *testing.T) {
@@ -184,6 +187,7 @@ func TestResolveTokenProperties_TagLookupErrorSelectsFirst(t *testing.T) {
 	}})
 
 	require.Equal(t, "**launch:"+firstPath, token.Text)
+	mediaDB.AssertExpectations(t)
 }
 
 func TestIsDeprioritizedPropertyMatch(t *testing.T) {
@@ -195,13 +199,72 @@ func TestIsDeprioritizedPropertyMatch(t *testing.T) {
 		want bool
 	}{
 		{
+			name: "sample",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedSample)},
+			want: true,
+		},
+		{
+			name: "preview",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedPreview)},
+			want: true,
+		},
+		{
+			name: "prerelease",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedPrerelease)},
+			want: true,
+		},
+		{
+			name: "bootleg",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedBootleg)},
+			want: true,
+		},
+		{
 			name: "hack",
 			tag:  database.TagInfo{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedHack)},
 			want: true,
 		},
 		{
+			name: "clone",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedClone)},
+			want: true,
+		},
+		{
+			name: "translation",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedTranslation)},
+			want: true,
+		},
+		{
+			name: "legacy translation",
+			tag: database.TagInfo{
+				Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedTranslationOld),
+			},
+			want: true,
+		},
+		{
+			name: "hacked dump",
+			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpHacked)},
+			want: true,
+		},
+		{
 			name: "modified dump",
 			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpModified)},
+			want: true,
+		},
+		{
+			name: "translated dump",
+			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpTranslated)},
+			want: true,
+		},
+		{
+			name: "bad dump",
+			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpBad)},
+			want: true,
+		},
+		{
+			name: "alpha prefix",
+			tag: database.TagInfo{
+				Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedAlpha) + ":1",
+			},
 			want: true,
 		},
 		{
@@ -212,6 +275,11 @@ func TestIsDeprioritizedPropertyMatch(t *testing.T) {
 		{
 			name: "prototype",
 			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedProto)},
+			want: true,
+		},
+		{
+			name: "numbered demo",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedDemo1)},
 			want: true,
 		},
 		{

--- a/pkg/service/property_match_test.go
+++ b/pkg/service/property_match_test.go
@@ -83,15 +83,45 @@ func TestResolveTokenProperties_ExistingMappingWins(t *testing.T) {
 	mediaDB.AssertNotCalled(t, "SearchMediaByProperty", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestResolveTokenProperties_AmbiguousMatchDoesNotLaunch(t *testing.T) {
+func TestResolveTokenProperties_AmbiguousMatchSelectsFirst(t *testing.T) {
 	t.Parallel()
 
+	firstPath := filepath.Join("games", "psx", "a.cue")
 	svc, mediaDB, platform := newPropertyMatchService(t, nil)
 	mediaDB.On(
 		"SearchMediaByProperty", mock.Anything, systemdefs.SystemPSX, string(tags.TagPropertyGameID), "SLUS-12345",
 	).Return([]database.SearchResult{
-		{SystemID: systemdefs.SystemPSX, Path: filepath.Join("games", "psx", "a.cue"), MediaID: 7},
+		{SystemID: systemdefs.SystemPSX, Path: firstPath, MediaID: 7},
 		{SystemID: systemdefs.SystemPSX, Path: filepath.Join("games", "psx", "b.cue"), MediaID: 8},
+	}, nil)
+	mediaDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, []int64{7, 8}).
+		Return(map[int64][]database.TagInfo{}, nil)
+	platform.On("LookupMapping", mock.Anything).Return("", false)
+
+	token := &tokens.Token{UID: "legacy-id", ScanTime: time.Now()}
+	resolveTokenProperties(context.Background(), svc, token, []readers.ScanProperty{{
+		System: systemdefs.SystemPSX,
+		Name:   string(tags.TagPropertyGameID),
+		Value:  "SLUS-12345",
+	}})
+
+	require.Equal(t, "**launch:"+firstPath, token.Text)
+}
+
+func TestResolveTokenProperties_AmbiguousMatchPrefersNonVariant(t *testing.T) {
+	t.Parallel()
+
+	hackPath := filepath.Join("games", "psx", "game-hack.cue")
+	officialPath := filepath.Join("games", "psx", "game.cue")
+	svc, mediaDB, platform := newPropertyMatchService(t, nil)
+	mediaDB.On(
+		"SearchMediaByProperty", mock.Anything, systemdefs.SystemPSX, string(tags.TagPropertyGameID), "SLUS-12345",
+	).Return([]database.SearchResult{
+		{SystemID: systemdefs.SystemPSX, Path: hackPath, MediaID: 7},
+		{SystemID: systemdefs.SystemPSX, Path: officialPath, MediaID: 8},
+	}, nil)
+	mediaDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, []int64{7, 8}).Return(map[int64][]database.TagInfo{
+		7: {{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedHack)}},
 	}, nil)
 	platform.On("LookupMapping", mock.Anything).Return("", false)
 
@@ -102,7 +132,106 @@ func TestResolveTokenProperties_AmbiguousMatchDoesNotLaunch(t *testing.T) {
 		Value:  "SLUS-12345",
 	}})
 
-	require.Empty(t, token.Text)
+	require.Equal(t, "**launch:"+officialPath, token.Text)
+}
+
+func TestResolveTokenProperties_AmbiguousMatchAllVariantsSelectsFirst(t *testing.T) {
+	t.Parallel()
+
+	firstPath := filepath.Join("games", "psx", "game-hack.cue")
+	svc, mediaDB, platform := newPropertyMatchService(t, nil)
+	mediaDB.On(
+		"SearchMediaByProperty", mock.Anything, systemdefs.SystemPSX, string(tags.TagPropertyGameID), "SLUS-12345",
+	).Return([]database.SearchResult{
+		{SystemID: systemdefs.SystemPSX, Path: firstPath, MediaID: 7},
+		{SystemID: systemdefs.SystemPSX, Path: filepath.Join("games", "psx", "game-translation.cue"), MediaID: 8},
+	}, nil)
+	mediaDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, []int64{7, 8}).Return(map[int64][]database.TagInfo{
+		7: {{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpModified)}},
+		8: {{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedTranslation)}},
+	}, nil)
+	platform.On("LookupMapping", mock.Anything).Return("", false)
+
+	token := &tokens.Token{UID: "legacy-id", ScanTime: time.Now()}
+	resolveTokenProperties(context.Background(), svc, token, []readers.ScanProperty{{
+		System: systemdefs.SystemPSX,
+		Name:   string(tags.TagPropertyGameID),
+		Value:  "SLUS-12345",
+	}})
+
+	require.Equal(t, "**launch:"+firstPath, token.Text)
+}
+
+func TestResolveTokenProperties_TagLookupErrorSelectsFirst(t *testing.T) {
+	t.Parallel()
+
+	firstPath := filepath.Join("games", "psx", "a.cue")
+	svc, mediaDB, platform := newPropertyMatchService(t, nil)
+	mediaDB.On(
+		"SearchMediaByProperty", mock.Anything, systemdefs.SystemPSX, string(tags.TagPropertyGameID), "SLUS-12345",
+	).Return([]database.SearchResult{
+		{SystemID: systemdefs.SystemPSX, Path: firstPath, MediaID: 7},
+		{SystemID: systemdefs.SystemPSX, Path: filepath.Join("games", "psx", "b.cue"), MediaID: 8},
+	}, nil)
+	mediaDB.On("GetMediaTagsByMediaDBIDs", mock.Anything, []int64{7, 8}).Return(nil, context.Canceled)
+	platform.On("LookupMapping", mock.Anything).Return("", false)
+
+	token := &tokens.Token{UID: "legacy-id", ScanTime: time.Now()}
+	resolveTokenProperties(context.Background(), svc, token, []readers.ScanProperty{{
+		System: systemdefs.SystemPSX,
+		Name:   string(tags.TagPropertyGameID),
+		Value:  "SLUS-12345",
+	}})
+
+	require.Equal(t, "**launch:"+firstPath, token.Text)
+}
+
+func TestIsDeprioritizedPropertyMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tag  database.TagInfo
+		want bool
+	}{
+		{
+			name: "hack",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnlicensed), Tag: string(tags.TagUnlicensedHack)},
+			want: true,
+		},
+		{
+			name: "modified dump",
+			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpModified)},
+			want: true,
+		},
+		{
+			name: "numbered beta",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedBeta2)},
+			want: true,
+		},
+		{
+			name: "prototype",
+			tag:  database.TagInfo{Type: string(tags.TagTypeUnfinished), Tag: string(tags.TagUnfinishedProto)},
+			want: true,
+		},
+		{
+			name: "verified dump",
+			tag:  database.TagInfo{Type: string(tags.TagTypeDump), Tag: string(tags.TagDumpVerified)},
+			want: false,
+		},
+		{
+			name: "region",
+			tag:  database.TagInfo{Type: string(tags.TagTypeRegion), Tag: string(tags.TagRegionUS)},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isDeprioritizedPropertyMatch([]database.TagInfo{tt.tag}))
+		})
+	}
 }
 
 func TestResolveTokenProperties_PathWithCommaRoundTrips(t *testing.T) {


### PR DESCRIPTION
## Summary

- resolve ambiguous property scans by selecting a deterministic media match
- prefer standard releases over demos, prototypes, hacks, translations, and modified or bad dumps
- fall back to the first result when all matches are variants or tag lookup fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property matching when multiple results are found.
  * Automatically prioritizes the most suitable non-variant match.
  * Deprioritizes matches with unfinished or explicitly excluded tags.
  * Falls back to the first available match when no preferred result can be identified or tag information is unavailable.
  * Resolving properties with no matches now exits cleanly without attempting to launch media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->