### PR TITLE
fix(database): checkpoint disambiguation backfill and stamp fresh databases

### DIFF
--- a/pkg/database/mediadb/concurrent_operations_test.go
+++ b/pkg/database/mediadb/concurrent_operations_test.go
@@ -56,8 +56,8 @@ func TestConcurrentOptimizationPrevention(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "completed").
@@ -282,8 +282,8 @@ func TestAtomicOptimizationFlag(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "completed").
@@ -342,7 +342,6 @@ func TestOptimizationInterruption(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -437,14 +436,15 @@ func TestRaceConditionBetweenStatusAndOptimization(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// Steps run in order: resume read → temporary_repair_parent_dirs → browse_cache
-	// → pragma_optimize → page_prefetch → wal_checkpoint. All must be mocked so the
+	// → pragma_optimize → disambiguation_backfill → page_prefetch → wal_checkpoint.
+	// All must be mocked so the
 	// concurrent status reads race against the real workflow rather than steps that
 	// silently error on unmatched expectations.
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -208,6 +208,199 @@ func TestDisambiguationBackfill_EmptyDatabaseStampsWithoutWork(t *testing.T) {
 		"the empty-database check must stamp so later titles indexed under the current algorithm stay stamped")
 }
 
+// TestDisambiguationBackfill_ResumesFromCheckpoint verifies an interrupted
+// backfill does not restart from the first system: systems at or below the
+// persisted cursor are skipped, and completion stamps the version and clears
+// the cursor. Restart-from-scratch is what wedged devices with short power
+// sessions in an endless minutes-per-system walk.
+func TestDisambiguationBackfill_ResumesFromCheckpoint(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	firstSystemDBID, firstTitleDBID, _ := setupDisambTitle(t, mediaDB, "NES", "Sonic", []disambTitleMedia{
+		{path: browseTestPath("roms", "nes", "sonic-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "sonic-eur.nes"), tags: map[string]string{"release": "Europe"}},
+	})
+	_, secondTitleDBID, _ := setupDisambTitle(t, mediaDB, "SNES", "Mario", []disambTitleMedia{
+		{path: browseTestPath("roms", "snes", "mario-usa.sfc"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "snes", "mario-jpn.sfc"), tags: map[string]string{"release": "Japan"}},
+	})
+
+	// Simulate a previous walk interrupted after the first system committed.
+	require.NoError(t, sqlSetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load(), firstSystemDBID))
+
+	require.NoError(t, mediaDB.runDisambiguationBackfill(ctx, nil))
+
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, firstTitleDBID),
+		"systems at or below the checkpoint must not be recomputed again")
+	assert.Equal(t, "release", titleDisambiguationTypes(t, mediaDB, secondTitleDBID),
+		"systems past the checkpoint must be recomputed")
+
+	pending, err := mediaDB.disambiguationBackfillPending(ctx)
+	require.NoError(t, err)
+	assert.False(t, pending, "a resumed walk that reaches the end must stamp the version")
+
+	cursor, err := sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Zero(t, cursor, "completion must clear the checkpoint")
+}
+
+// TestDisambiguationBackfill_InterruptionPersistsProgress is the regression
+// test for devices wedged in an endless backfill: an interruption mid-walk
+// must leave a durable checkpoint for the completed system, and the next run
+// must resume past it instead of restarting from the first system.
+//
+// Not parallel: it mutates the package-level disambiguationBackfillAfterSystem
+// test seam. Sequential tests run while parallel tests are paused, so the
+// mutation cannot race their reads.
+func TestDisambiguationBackfill_InterruptionPersistsProgress(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	firstSystemDBID, firstTitleDBID, _ := setupDisambTitle(t, mediaDB, "NES", "Sonic", []disambTitleMedia{
+		{path: browseTestPath("roms", "nes", "sonic-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "sonic-eur.nes"), tags: map[string]string{"release": "Europe"}},
+	})
+	secondSystemDBID, secondTitleDBID, _ := setupDisambTitle(t, mediaDB, "SNES", "Mario", []disambTitleMedia{
+		{path: browseTestPath("roms", "snes", "mario-usa.sfc"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "snes", "mario-jpn.sfc"), tags: map[string]string{"release": "Japan"}},
+	})
+	require.Less(t, firstSystemDBID, secondSystemDBID,
+		"the walk visits systems in DBID order; the test relies on NES running first")
+
+	// Cancel as soon as the first system commits, as a power-off would.
+	interruptCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	disambiguationBackfillAfterSystem = func(int64) { cancel() }
+	defer func() { disambiguationBackfillAfterSystem = nil }()
+
+	ctx := context.Background()
+	require.Error(t, mediaDB.runDisambiguationBackfill(interruptCtx, nil),
+		"an interrupted walk must report the cancellation")
+
+	cursor, err := sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Equal(t, firstSystemDBID, cursor, "the completed system must be checkpointed durably")
+	assert.Equal(t, "release", titleDisambiguationTypes(t, mediaDB, firstTitleDBID),
+		"the system completed before the interruption keeps its recomputed value")
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, secondTitleDBID),
+		"the interrupted walk must not have reached the second system")
+
+	pending, err := mediaDB.disambiguationBackfillPending(ctx)
+	require.NoError(t, err)
+	assert.True(t, pending, "an interrupted walk must not stamp the version")
+
+	// Blank the first system's value: the resumed walk must skip it, so the
+	// blank surviving the resume proves it was not recomputed again.
+	_, err = mediaDB.sql.Load().ExecContext(ctx,
+		"UPDATE MediaTitles SET DisambiguationTypes = '' WHERE DBID = ?", firstTitleDBID)
+	require.NoError(t, err)
+
+	disambiguationBackfillAfterSystem = nil
+	require.NoError(t, mediaDB.runDisambiguationBackfill(ctx, nil))
+
+	assert.Empty(t, titleDisambiguationTypes(t, mediaDB, firstTitleDBID),
+		"resume must skip the checkpointed system instead of restarting from the first")
+	assert.Equal(t, "release", titleDisambiguationTypes(t, mediaDB, secondTitleDBID),
+		"resume must recompute the remaining systems")
+
+	pending, err = mediaDB.disambiguationBackfillPending(ctx)
+	require.NoError(t, err)
+	assert.False(t, pending, "the resumed walk must stamp the version on completion")
+
+	cursor, err = sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Zero(t, cursor, "completion must clear the checkpoint")
+}
+
+func TestDisambiguationBackfillCursor_Roundtrip(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	cursor, err := sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Zero(t, cursor, "missing cursor reads as zero")
+
+	require.NoError(t, sqlSetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load(), 42))
+	cursor, err = sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), cursor)
+
+	require.NoError(t, sqlClearDisambiguationBackfillCursor(ctx, mediaDB.sql.Load()))
+	cursor, err = sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Zero(t, cursor, "cleared cursor reads as zero")
+}
+
+// TestDisambiguationBackfillCursor_IgnoresOtherAlgoVersions verifies a cursor
+// persisted by a different algorithm version never truncates the current
+// walk: a new algorithm must revisit every system.
+func TestDisambiguationBackfillCursor_IgnoresOtherAlgoVersions(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, raw := range []string{"0:42", "999:42", "garbage", "1:notanumber"} {
+		_, err := mediaDB.sql.Load().ExecContext(ctx,
+			"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+			DBConfigDisambiguationBackfillCursor, raw,
+		)
+		require.NoError(t, err)
+
+		cursor, err := sqlGetDisambiguationBackfillCursor(ctx, mediaDB.sql.Load())
+		require.NoError(t, err)
+		assert.Zero(t, cursor, "cursor %q must be ignored", raw)
+	}
+}
+
+// TestMigrateUp_StampsEmptyDatabase verifies the boot path stamps a database
+// with no titles before the first index writes any. Without this, the stamp
+// check first runs during post-index optimization — after titles exist — and
+// a fresh install pays a full pointless backfill over values the index just
+// computed.
+func TestMigrateUp_StampsEmptyDatabase(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, mediaDB.MigrateUp())
+
+	var version string
+	err := mediaDB.sql.Load().QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigDisambiguationVersion,
+	).Scan(&version)
+	require.NoError(t, err)
+	assert.Equal(t, disambiguationAlgoVersion, version)
+}
+
+// TestMigrateUp_LegacyDatabaseStaysPending verifies the boot-time stamp check
+// never stamps a database that already holds titles: those may carry values
+// from an older algorithm and must keep the backfill pending.
+func TestMigrateUp_LegacyDatabaseStaysPending(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	setupDisambTitle(t, mediaDB, "NES", "Sonic", []disambTitleMedia{
+		{path: browseTestPath("roms", "nes", "sonic-usa.nes"), tags: map[string]string{"release": "USA"}},
+		{path: browseTestPath("roms", "nes", "sonic-eur.nes"), tags: map[string]string{"release": "Europe"}},
+	})
+
+	require.NoError(t, mediaDB.MigrateUp())
+
+	pending, err := mediaDB.disambiguationBackfillPending(ctx)
+	require.NoError(t, err)
+	assert.True(t, pending, "a database with titles must not be stamped by the boot check")
+}
+
 func TestRecomputeSystemDisambiguation_IdenticalTagsDoNotDisambiguate(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := setupTempMediaDB(t)

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1183,6 +1183,14 @@ func (db *MediaDB) MigrateUp() error {
 	if err := sqlSeedPlannerStats(db.ctx, db.sql.Load()); err != nil {
 		log.Warn().Err(err).Msg("failed to seed planner statistics")
 	}
+	// Best-effort: stamp the disambiguation version on a database with no
+	// titles before the first index writes any. The pending check performs the
+	// stamp as a side effect; without this, the check first runs during
+	// post-index optimization — after titles exist — and a fresh install pays
+	// a full backfill over values the index just computed.
+	if _, err := db.disambiguationBackfillPending(db.ctx); err != nil {
+		log.Warn().Err(err).Msg("failed to check disambiguation backfill state after migration")
+	}
 	return nil
 }
 
@@ -3448,8 +3456,8 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	// page_prefetch so the user-visible browse fix lands before the expensive
 	// planner/buffer housekeeping and survives interruption of those later steps.
 	// disambiguation_backfill is a one-time stamp-gated repair (a no-op once
-	// current) and only affects display/ZapScript hints, so it yields to the
-	// browse fix but still lands before the housekeeping steps. WAL checkpoint
+	// current) whose per-system recompute leans heavily on the query planner, so
+	// it runs after pragma_optimize has refreshed statistics. WAL checkpoint
 	// follows as non-critical housekeeping.
 	db.needsIndexRebuild.Store(false)
 
@@ -3467,14 +3475,14 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			maxRetries: 0, retryDelay: rd,
 		},
 		optimizationStep{
+			name: "pragma_optimize", fn: db.AnalyzeApproximate,
+			maxRetries: 2, retryDelay: rd,
+		},
+		optimizationStep{
 			name: "disambiguation_backfill", fn: func() error {
 				return db.runDisambiguationBackfill(db.ctx, pauser)
 			},
 			maxRetries: 0, retryDelay: rd,
-		},
-		optimizationStep{
-			name: "pragma_optimize", fn: db.AnalyzeApproximate,
-			maxRetries: 2, retryDelay: rd,
 		},
 		optimizationStep{
 			name: "page_prefetch", fn: func() error {

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -322,15 +322,15 @@ func TestRunBackgroundOptimization_Success(t *testing.T) {
 	mediaDB.sql.Store(db)
 
 	// Steps run in order: temporary_repair_parent_dirs → browse_cache →
-	// pragma_optimize → page_prefetch → wal_checkpoint.
+	// pragma_optimize → disambiguation_backfill → page_prefetch → wal_checkpoint.
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "running").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "completed").
@@ -367,7 +367,6 @@ func TestRunBackgroundOptimization_FailureHandling(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -409,8 +408,8 @@ func TestRunBackgroundOptimization_PagePrefetchCancellationAborts(t *testing.T) 
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "page_prefetch").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -450,8 +449,8 @@ func TestConcurrentOptimization(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "completed").
@@ -551,8 +550,8 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 		expectOptimizationResumeRead(mock)
 		expectTemporaryParentDirRepairStepNoop(mock)
 		expectBrowseCacheStep(mock)
-		expectDisambiguationBackfillStepNoop(mock)
 		expectAnalyzeStep(mock)
+		expectDisambiguationBackfillStepNoop(mock)
 		expectPostAnalyzeSteps(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "completed").
@@ -608,7 +607,6 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 		expectOptimizationResumeRead(mock)
 		expectTemporaryParentDirRepairStepNoop(mock)
 		expectBrowseCacheStep(mock)
-		expectDisambiguationBackfillStepNoop(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStep, "pragma_optimize").
 			WillReturnResult(sqlmock.NewResult(1, 1))
@@ -670,8 +668,8 @@ func TestOptimizationNotificationCallbacks(t *testing.T) {
 		expectOptimizationResumeRead(mock)
 		expectTemporaryParentDirRepairStepNoop(mock)
 		expectBrowseCacheStep(mock)
-		expectDisambiguationBackfillStepNoop(mock)
 		expectAnalyzeStep(mock)
+		expectDisambiguationBackfillStepNoop(mock)
 		expectPostAnalyzeSteps(mock)
 		mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 			WithArgs(DBConfigOptimizationStatus, "completed").
@@ -755,8 +753,8 @@ func TestRunBackgroundOptimization_PausesAndResumes(t *testing.T) {
 	expectOptimizationResumeRead(mock)
 	expectTemporaryParentDirRepairStepNoop(mock)
 	expectBrowseCacheStep(mock)
-	expectDisambiguationBackfillStepNoop(mock)
 	expectAnalyzeStep(mock)
+	expectDisambiguationBackfillStepNoop(mock)
 	expectPostAnalyzeSteps(mock)
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStatus, "completed").

--- a/pkg/database/mediadb/sql_config.go
+++ b/pkg/database/mediadb/sql_config.go
@@ -49,6 +49,7 @@ const (
 	DBConfigIndexResumeAttempts             = "IndexResumeAttempts"
 	DBConfigIndexResumeCheckpoint           = "IndexResumeCheckpoint"
 	DBConfigDisambiguationVersion           = "DisambiguationVersion"
+	DBConfigDisambiguationBackfillCursor    = "DisambiguationBackfillCursor"
 
 	temporaryRepairParentDirVersion = "1"
 

--- a/pkg/database/mediadb/sql_disambiguation_backfill.go
+++ b/pkg/database/mediadb/sql_disambiguation_backfill.go
@@ -24,6 +24,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -93,6 +95,63 @@ func sqlAllSystemDBIDs(ctx context.Context, db sqlQueryable) ([]int64, error) {
 	return ids, nil
 }
 
+// disambiguationBackfillAfterSystem is a test seam invoked after each system's
+// recompute and checkpoint have committed, so tests can interrupt the walk at
+// an exact system boundary. Production leaves it nil.
+var disambiguationBackfillAfterSystem func(systemDBID int64)
+
+// The backfill checkpoint records the last system whose recompute committed,
+// qualified by algorithm version so a cursor left by an older algorithm's
+// interrupted walk never truncates a newer one. Each system's recompute can
+// take minutes on slow storage, and short power sessions would otherwise
+// restart the walk from the first system on every boot.
+
+func sqlGetDisambiguationBackfillCursor(ctx context.Context, db sqlQueryable) (int64, error) {
+	var raw string
+	err := db.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = ?",
+		DBConfigDisambiguationBackfillCursor,
+	).Scan(&raw)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("failed to read disambiguation backfill cursor: %w", err)
+	}
+	version, dbidRaw, found := strings.Cut(raw, ":")
+	if !found || version != disambiguationAlgoVersion {
+		return 0, nil
+	}
+	dbid, parseErr := strconv.ParseInt(dbidRaw, 10, 64)
+	if parseErr != nil {
+		// A malformed cursor only costs re-walking already-committed systems.
+		log.Warn().Str("cursor", raw).Msg("ignoring malformed disambiguation backfill cursor")
+		dbid = 0
+	}
+	return dbid, nil
+}
+
+func sqlSetDisambiguationBackfillCursor(ctx context.Context, db sqlQueryable, systemDBID int64) error {
+	if _, err := db.ExecContext(ctx,
+		"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+		DBConfigDisambiguationBackfillCursor,
+		disambiguationAlgoVersion+":"+strconv.FormatInt(systemDBID, 10),
+	); err != nil {
+		return fmt.Errorf("failed to set disambiguation backfill cursor: %w", err)
+	}
+	return nil
+}
+
+func sqlClearDisambiguationBackfillCursor(ctx context.Context, db sqlQueryable) error {
+	if _, err := db.ExecContext(ctx,
+		"DELETE FROM DBConfig WHERE Name = ?",
+		DBConfigDisambiguationBackfillCursor,
+	); err != nil {
+		return fmt.Errorf("failed to clear disambiguation backfill cursor: %w", err)
+	}
+	return nil
+}
+
 // disambiguationBackfillPending reports whether stored DisambiguationTypes were
 // computed by an older algorithm and need a one-time recompute. An empty database
 // has nothing to backfill, so it is stamped current immediately — the first index
@@ -122,7 +181,9 @@ func (db *MediaDB) disambiguationBackfillPending(ctx context.Context) (bool, err
 // the stored values predate the current algorithm, then stamps the version. It
 // walks systems one at a time — the same granularity indexing used when it
 // recomputed per system on every run — so each write transaction stays short and
-// the pauser can interleave while a game is running.
+// the pauser can interleave while a game is running. Progress is checkpointed
+// per system, so an interrupted walk resumes where it stopped instead of
+// restarting from the first system.
 func (db *MediaDB) runDisambiguationBackfill(ctx context.Context, pauser *syncutil.Pauser) error {
 	pending, err := db.disambiguationBackfillPending(ctx)
 	if err != nil {
@@ -138,10 +199,28 @@ func (db *MediaDB) runDisambiguationBackfill(ctx context.Context, pauser *syncut
 		return err
 	}
 
+	cursor, err := sqlGetDisambiguationBackfillCursor(ctx, db.sql.Load())
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to read disambiguation backfill checkpoint; starting from the first system")
+		cursor = 0
+	}
+
 	started := time.Now()
-	log.Info().Int("systems", len(systemDBIDs)).Msg("disambiguation backfill started")
+	remaining := 0
+	for _, systemDBID := range systemDBIDs {
+		if systemDBID > cursor {
+			remaining++
+		}
+	}
+	log.Info().Int("systems", len(systemDBIDs)).Int("remaining", remaining).Int64("cursor", cursor).
+		Msg("disambiguation backfill started")
 
 	for _, systemDBID := range systemDBIDs {
+		// sqlAllSystemDBIDs orders by DBID, so everything at or below the
+		// checkpoint already committed in a previous walk.
+		if systemDBID <= cursor {
+			continue
+		}
 		if waitErr := pauser.Wait(ctx); waitErr != nil {
 			return fmt.Errorf("disambiguation backfill paused: %w", waitErr)
 		}
@@ -150,14 +229,26 @@ func (db *MediaDB) runDisambiguationBackfill(ctx context.Context, pauser *syncut
 		); recomputeErr != nil {
 			return fmt.Errorf("disambiguation backfill for system %d: %w", systemDBID, recomputeErr)
 		}
+		if checkpointErr := sqlSetDisambiguationBackfillCursor(ctx, db.sql.Load(), systemDBID); checkpointErr != nil {
+			// Progress durability only; the walk itself can continue.
+			log.Warn().Err(checkpointErr).Int64("systemDBID", systemDBID).
+				Msg("failed to checkpoint disambiguation backfill progress")
+		}
+		if disambiguationBackfillAfterSystem != nil {
+			disambiguationBackfillAfterSystem(systemDBID)
+		}
 	}
 
 	if err := sqlMarkDisambiguationVersionCurrent(ctx, db.sql.Load()); err != nil {
 		return err
 	}
+	if err := sqlClearDisambiguationBackfillCursor(ctx, db.sql.Load()); err != nil {
+		log.Warn().Err(err).Msg("failed to clear disambiguation backfill cursor after completion")
+	}
 
 	log.Info().
 		Int("systems", len(systemDBIDs)).
+		Int("processed", remaining).
 		Dur("elapsed", time.Since(started)).
 		Msg("disambiguation backfill completed")
 	return nil


### PR DESCRIPTION
- Devices with large libraries on slow storage could report a media database update indefinitely: the one-time disambiguation backfill takes minutes per system there, only stamps its done-marker after every system completes, and restarted from the first system on each boot after a power-off, so short power sessions never let it finish.
- Fresh installs always ran the full backfill pointlessly. The empty-database version stamp only ran during post-index optimization, after the first index had inserted titles, so the pending check found an unstamped database with titles and recomputed values the index had just written. MigrateUp now stamps the version when no titles exist yet, before the first index.
- Backfill progress is now checkpointed per system in DBConfig, qualified by algorithm version so a cursor from an older algorithm never truncates a newer walk. Interrupted walks resume past completed systems; completion stamps the version and clears the cursor.
- The disambiguation_backfill optimization step now runs after pragma_optimize so its recompute query plans against fresh statistics.
- Adds a regression test that interrupts the walk at a system boundary via a test seam, asserts durable checkpoint state, and verifies the resumed walk skips the completed system and finishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disambiguation backfills can now resume from saved progress after interruption.
  * Backfill progress is tracked by algorithm version and cleared when complete.
  * Empty databases are now marked as up to date during migration.

* **Bug Fixes**
  * Database optimization now refreshes statistics before running disambiguation backfills.
  * Backfill checkpoint failures are handled without aborting the operation.

* **Tests**
  * Added coverage for resuming, interruption recovery, cursor handling, and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->