### PR TITLE
fix(service): bind hold exit to launch token

### DIFF
--- a/docs/scan-behavior.md
+++ b/docs/scan-behavior.md
@@ -22,7 +22,8 @@ When `readers.scan.mode='tap'` (default setting) and a game is launched using a 
 
 When `readers.scan.mode='hold'` with `readers.scan.exit_delay=0.0` and a game is launched using a card:
 
-- [ ] Removing the card from the reader will immediately close the game.
+- [ ] Removing the card from the reader will immediately close the game, including when removal happens before launch initialization finishes.
+- [ ] Scanning and removing a command card will execute the command without closing the game; only the launch card owns Hold mode exit.
 - [ ] Exiting the game manually while the card is still on the reader will not cause the game to relaunch when returning to the menu.
 - [ ] Exiting the game manually via the internal menu and then removing the card won't trigger a core menu reload.
 
@@ -35,7 +36,7 @@ When `readers.scan.mode='hold'` with `readers.scan.exit_delay=N` and a game is l
 - [ ] Removing the card from the reader will close the game after **N seconds**.
 - [ ] Removing the card and reinserting it before the N-second countdown ends will not interrupt the ongoing game.
 - [ ] Removing the card and tapping a different game card will immediately launch the other game.
-- [ ] Removing the card and tapping a command card will execute the command and reset the countdown timer. You can repeatedly tap various command cards without changing the game, resetting the timer each time, and then reinsert the original game card to continue the session.
+- [ ] Removing the launch card and tapping a command card will execute the command without resetting or transferring the countdown. Removing the command card will not trigger another exit.
 - [ ] Exiting the game manually while the card is still on the reader will not cause the game to relaunch when returning to the menu.
 - [ ] Exiting the game manually via the internal menu and then removing the card won't trigger a core menu reload.
 - [ ] Exiting the game manually during the N-second countdown cancels the countdown and returns to the menu.

--- a/pkg/service/playlists/playlists.go
+++ b/pkg/service/playlists/playlists.go
@@ -19,7 +19,10 @@
 
 package playlists
 
-import "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
+import (
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+)
 
 type PlaylistItem struct {
 	ZapScript string
@@ -27,19 +30,23 @@ type PlaylistItem struct {
 }
 
 type Playlist struct {
-	ID      string
-	Name    string
-	Slot    string
-	Items   []PlaylistItem
-	Index   int
-	Playing bool
-	Clear   bool // signals the queue handler to remove the active playlist for this slot
-	// Loop and LoopOne control end-of-playlist behaviour set at load time.
+	// HoldToken is internal runtime ownership for primary hold-mode playback.
+	// It is not part of playlist persistence or API responses.
+	HoldToken *tokens.Token
+	ID        string
+	Name      string
+	Slot      string
+	Items     []PlaylistItem
+	Index     int
+	Playing   bool
+	// Clear signals the queue handler to remove the active playlist for this slot.
+	Clear bool
+	// Loop and LoopOne control end-of-playlist behavior set at load time.
 	// Loop wraps back to the start; LoopOne repeats the current track.
 	Loop    bool
 	LoopOne bool
-	// ForceRelaunch bypasses the playlistNeedsUpdate dedup so the same track can be
-	// relaunched (needed for LoopOne and single-item Loop).
+	// ForceRelaunch bypasses playlistNeedsUpdate dedup so the same track can be
+	// relaunched for LoopOne and single-item Loop.
 	ForceRelaunch bool
 }
 
@@ -60,14 +67,15 @@ func Next(p Playlist) *Playlist { //nolint:gocritic // value copy preserves immu
 		idx = 0
 	}
 	return &Playlist{
-		ID:      p.ID,
-		Name:    p.Name,
-		Slot:    p.Slot,
-		Items:   p.Items,
-		Index:   idx,
-		Playing: p.Playing,
-		Loop:    p.Loop,
-		LoopOne: p.LoopOne,
+		ID:        p.ID,
+		Name:      p.Name,
+		Slot:      p.Slot,
+		Items:     p.Items,
+		Index:     idx,
+		Playing:   p.Playing,
+		Loop:      p.Loop,
+		LoopOne:   p.LoopOne,
+		HoldToken: p.HoldToken,
 	}
 }
 
@@ -77,14 +85,15 @@ func Previous(p Playlist) *Playlist { //nolint:gocritic // value copy preserves 
 		idx = len(p.Items) - 1
 	}
 	return &Playlist{
-		ID:      p.ID,
-		Name:    p.Name,
-		Slot:    p.Slot,
-		Items:   p.Items,
-		Index:   idx,
-		Playing: p.Playing,
-		Loop:    p.Loop,
-		LoopOne: p.LoopOne,
+		ID:        p.ID,
+		Name:      p.Name,
+		Slot:      p.Slot,
+		Items:     p.Items,
+		Index:     idx,
+		Playing:   p.Playing,
+		Loop:      p.Loop,
+		LoopOne:   p.LoopOne,
+		HoldToken: p.HoldToken,
 	}
 }
 
@@ -99,40 +108,43 @@ func Goto(p Playlist, idx int) *Playlist { //nolint:gocritic // value copy prese
 		idx = 0
 	}
 	return &Playlist{
-		ID:      p.ID,
-		Name:    p.Name,
-		Slot:    p.Slot,
-		Items:   p.Items,
-		Index:   idx,
-		Playing: p.Playing,
-		Loop:    p.Loop,
-		LoopOne: p.LoopOne,
+		ID:        p.ID,
+		Name:      p.Name,
+		Slot:      p.Slot,
+		Items:     p.Items,
+		Index:     idx,
+		Playing:   p.Playing,
+		Loop:      p.Loop,
+		LoopOne:   p.LoopOne,
+		HoldToken: p.HoldToken,
 	}
 }
 
 func Play(p Playlist) *Playlist { //nolint:gocritic // value copy preserves immutable-style playlist updates
 	return &Playlist{
-		ID:      p.ID,
-		Name:    p.Name,
-		Slot:    p.Slot,
-		Items:   p.Items,
-		Index:   p.Index,
-		Playing: true,
-		Loop:    p.Loop,
-		LoopOne: p.LoopOne,
+		ID:        p.ID,
+		Name:      p.Name,
+		Slot:      p.Slot,
+		Items:     p.Items,
+		Index:     p.Index,
+		Playing:   true,
+		Loop:      p.Loop,
+		LoopOne:   p.LoopOne,
+		HoldToken: p.HoldToken,
 	}
 }
 
 func Pause(p Playlist) *Playlist { //nolint:gocritic // value copy preserves immutable-style playlist updates
 	return &Playlist{
-		ID:      p.ID,
-		Name:    p.Name,
-		Slot:    p.Slot,
-		Items:   p.Items,
-		Index:   p.Index,
-		Playing: false,
-		Loop:    p.Loop,
-		LoopOne: p.LoopOne,
+		ID:        p.ID,
+		Name:      p.Name,
+		Slot:      p.Slot,
+		Items:     p.Items,
+		Index:     p.Index,
+		Playing:   false,
+		Loop:      p.Loop,
+		LoopOne:   p.LoopOne,
+		HoldToken: p.HoldToken,
 	}
 }
 
@@ -156,5 +168,6 @@ type PlaylistController struct {
 	Active     *Playlist
 	Background *Playlist
 	Current    *Playlist
+	HoldToken  *tokens.Token
 	Queue      chan<- *Playlist
 }

--- a/pkg/service/playlists/playlists_test.go
+++ b/pkg/service/playlists/playlists_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -66,4 +67,18 @@ func TestTransitions_PreserveSlot(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, mediaslot.Background, playlists.Pause(*p).Slot)
 	})
+}
+
+func TestTransitions_PreserveHoldToken(t *testing.T) {
+	t.Parallel()
+
+	owner := &tokens.Token{UID: "playlist-card", Text: "**playlist.next"}
+	p := playlists.NewPlaylist("id", "name", []playlists.PlaylistItem{{ZapScript: "a"}, {ZapScript: "b"}})
+	p.HoldToken = owner
+
+	assert.Same(t, owner, playlists.Next(*p).HoldToken)
+	assert.Same(t, owner, playlists.Previous(*p).HoldToken)
+	assert.Same(t, owner, playlists.Goto(*p, 1).HoldToken)
+	assert.Same(t, owner, playlists.Play(*p).HoldToken)
+	assert.Same(t, owner, playlists.Pause(*p).HoldToken)
 }

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -110,6 +110,7 @@ func runTokenZapScript(
 		return nil
 	}
 
+	originToken := token
 	mappedValue, hasMapping := getMapping(svc.Config, svc.DB, svc.Platform, token)
 	if hasMapping {
 		log.Info().Msgf("found mapping: %s", mappedValue)
@@ -129,6 +130,15 @@ func runTokenZapScript(
 	currentPlaylist := plsc.Current
 	if currentPlaylist == nil {
 		currentPlaylist = currentPrimary
+	}
+
+	switch {
+	case originToken.ReaderID != "":
+		plsc.HoldToken = &originToken
+	case token.Source == tokens.SourcePlaylist && currentPrimary != nil:
+		plsc.HoldToken = currentPrimary.HoldToken
+	default:
+		plsc.HoldToken = nil
 	}
 
 	cmds := script.Cmds
@@ -187,6 +197,7 @@ func runTokenZapScript(
 				Active:     currentPrimary,
 				Background: currentBackground,
 				Current:    currentPlaylist,
+				HoldToken:  plsc.HoldToken,
 				Queue:      plsc.Queue,
 			},
 			token,
@@ -222,14 +233,21 @@ func runTokenZapScript(
 			}
 		}
 
-		if primaryMediaChanged && token.ReaderID != "" {
-			r, ok := svc.State.GetReader(token.ReaderID)
-			if ok && readers.HasCapability(r, readers.CapabilityRemovable) {
-				log.Debug().Any("token", token).Msg("media changed, updating software token")
-				select {
-				case svc.LaunchSoftwareQueue <- &token:
-				case <-svc.State.GetContext().Done():
-					return errors.New("service shutting down")
+		if primaryMediaChanged {
+			holdToken := &originToken
+			if token.Source == tokens.SourcePlaylist {
+				holdToken = plsc.HoldToken
+			}
+			if holdToken != nil && holdToken.ReaderID != "" {
+				r, ok := svc.State.GetReader(holdToken.ReaderID)
+				if ok && readers.HasCapability(r, readers.CapabilityRemovable) {
+					softwareToken := *holdToken
+					log.Debug().Msg("media changed, updating hold owner")
+					select {
+					case svc.LaunchSoftwareQueue <- &softwareToken:
+					case <-svc.State.GetContext().Done():
+						return errors.New("service shutting down")
+					}
 				}
 			}
 		}
@@ -384,6 +402,7 @@ func launchPlaylistMedia(
 		Active:     svc.State.GetActivePlaylist(),
 		Background: svc.State.GetBackgroundPlaylist(),
 		Current:    pls,
+		HoldToken:  pls.HoldToken,
 		Queue:      svc.PlaylistQueue,
 	}
 	if pls.Slot == mediaslot.Background {

--- a/pkg/service/queues_playlist_test.go
+++ b/pkg/service/queues_playlist_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
@@ -506,6 +507,82 @@ func TestRunTokenZapScript_BackgroundLaunchSkipsSoftwareToken(t *testing.T) {
 	default:
 	}
 	mockPlatform.AssertNumberOfCalls(t, "LaunchMedia", 1)
+}
+
+func TestRunTokenZapScript_PhysicalPlaylistCommandTransfersHoldOwner(t *testing.T) {
+	t.Parallel()
+
+	svc := setupPlaylistTestEnv(t)
+	active := makeServicePlaylist()
+	active.Playing = true
+	plq := make(chan *playlists.Playlist, 1)
+	owner := tokens.Token{
+		UID:      "playlist-card",
+		Text:     "**playlist.next",
+		Source:   tokens.SourceReader,
+		ReaderID: "mock-removable-reader",
+		ScanTime: time.Now(),
+	}
+
+	err := runTokenZapScript(svc, owner, playlists.PlaylistController{
+		Active:  active,
+		Current: active,
+		Queue:   plq,
+	}, nil, false)
+	require.NoError(t, err)
+
+	updated := <-plq
+	require.NotNil(t, updated.HoldToken)
+	assert.True(t, helpers.TokensEqual(&owner, updated.HoldToken))
+	assert.Equal(t, owner.ReaderID, updated.HoldToken.ReaderID)
+}
+
+func TestRunTokenZapScript_PrimaryPlaylistLaunchPublishesPhysicalOwner(t *testing.T) {
+	t.Parallel()
+
+	svc := setupPlaylistTestEnv(t)
+	mockPlatform, ok := svc.Platform.(*mocks.MockPlatform)
+	require.True(t, ok)
+
+	const readerID = "mock-removable-reader"
+	mockReader := mocks.NewMockReader()
+	mockReader.On("Metadata").Return(readers.DriverMetadata{ID: "mock-reader"}).Maybe()
+	mockReader.On("Path").Return(filepath.Join(string(filepath.Separator), "dev", "mock-device")).Maybe()
+	mockReader.On("Capabilities").Return([]readers.Capability{readers.CapabilityRemovable}).Maybe()
+	mockReader.On("ReaderID").Return(readerID).Maybe()
+	svc.State.SetReader(mockReader)
+
+	owner := &tokens.Token{
+		UID:      "playlist-card",
+		Text:     "**playlist.play:games",
+		Source:   tokens.SourceReader,
+		ReaderID: readerID,
+		ScanTime: time.Now(),
+	}
+	active := makeServicePlaylist()
+	active.Playing = true
+	active.HoldToken = owner
+
+	path := filepath.Join(t.TempDir(), "game.rom")
+	mockPlatform.On("LaunchMedia", svc.Config, path, (*platforms.Launcher)(nil), svc.DB,
+		mock.Anything).Return(nil).Once()
+
+	err := runTokenZapScript(svc, tokens.Token{
+		Text:     "**launch:" + path,
+		Source:   tokens.SourcePlaylist,
+		ScanTime: time.Now(),
+	}, playlists.PlaylistController{
+		Active:    active,
+		Current:   active,
+		HoldToken: owner,
+		Queue:     make(chan *playlists.Playlist, 1),
+	}, nil, false)
+	require.NoError(t, err)
+
+	softwareToken := <-svc.LaunchSoftwareQueue
+	require.NotNil(t, softwareToken)
+	assert.True(t, helpers.TokensEqual(owner, softwareToken))
+	assert.Equal(t, owner.ReaderID, softwareToken.ReaderID)
 }
 
 // statefulPlaybackStub tracks per-slot playing state so tests can observe the

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -22,6 +22,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
@@ -48,6 +49,32 @@ var ErrNoStagedToken = errors.New("no staged token to confirm")
 type toConnectDevice struct {
 	connectionString string
 	device           config.ReadersConnect
+}
+
+const maxPendingHoldRemovals = 32
+
+type holdTokenKey struct {
+	uid      string
+	text     string
+	pathRoot string
+}
+
+func newHoldTokenKey(token *tokens.Token) holdTokenKey {
+	return holdTokenKey{
+		uid:      token.UID,
+		text:     token.Text,
+		pathRoot: token.PathRoot,
+	}
+}
+
+func recordPendingHoldRemoval(pending map[holdTokenKey]tokens.Token, token *tokens.Token) {
+	if len(pending) >= maxPendingHoldRemovals {
+		for key := range pending {
+			delete(pending, key)
+			break
+		}
+	}
+	pending[newHoldTokenKey(token)] = *token
 }
 
 // isPathConnected checks if any connected reader is using the given path.
@@ -209,16 +236,20 @@ func runBeforeExitHook(
 	}
 }
 
+func cancelTimedExit(exitTimer clockwork.Timer, exitGeneration *atomic.Uint64) bool {
+	exitGeneration.Add(1)
+	return exitTimer != nil && exitTimer.Stop()
+}
+
 func timedExit(
 	svc *ServiceContext,
 	clock clockwork.Clock,
 	exitTimer clockwork.Timer,
+	exitGeneration *atomic.Uint64,
+	owner *tokens.Token,
 ) clockwork.Timer {
-	if exitTimer != nil {
-		stopped := exitTimer.Stop()
-		if stopped {
-			log.Debug().Msg("cancelling previous exit timer")
-		}
+	if cancelTimedExit(exitTimer, exitGeneration) {
+		log.Debug().Msg("cancelling previous exit timer")
 	}
 
 	if !svc.Config.HoldModeEnabled() {
@@ -226,37 +257,53 @@ func timedExit(
 		return exitTimer
 	}
 
-	// Only hardware readers support hold mode exit
-	lastToken := svc.State.GetLastScanned()
-	if lastToken.Source != tokens.SourceReader {
-		log.Debug().Str("source", lastToken.Source).Msg("skipping exit timer for non-reader source")
+	if owner.Source != tokens.SourceReader {
+		log.Debug().Str("source", owner.Source).Msg("skipping exit timer for non-reader source")
 		return exitTimer
 	}
 
-	// Check if the reader supports removal detection
-	r, ok := svc.State.GetReader(lastToken.ReaderID)
+	// Only hardware readers that report removal can own hold-mode media.
+	r, ok := svc.State.GetReader(owner.ReaderID)
 	if !ok {
-		log.Debug().Str("readerID", lastToken.ReaderID).Msg("reader not found in state, skipping exit timer")
+		log.Debug().Str("readerID", owner.ReaderID).Msg("reader not found in state, skipping exit timer")
 		return exitTimer
 	}
 	if !readers.HasCapability(r, readers.CapabilityRemovable) {
-		log.Debug().Str("readerID", lastToken.ReaderID).Msg("reader lacks removable capability, skipping exit timer")
+		log.Debug().Str("readerID", owner.ReaderID).Msg("reader lacks removable capability, skipping exit timer")
 		return exitTimer
 	}
 
+	ownerCopy := *owner
 	timerLen := time.Duration(float64(svc.Config.ReadersScan().ExitDelay) * float64(time.Second))
 	log.Debug().Msgf("exit timer set to: %s seconds", timerLen)
 	exitTimer = clock.NewTimer(timerLen)
+	timer := exitTimer
+	generation := exitGeneration.Add(1)
 
 	go func() {
 		select {
-		case <-exitTimer.Chan():
+		case <-timer.Chan():
 		case <-svc.State.GetContext().Done():
 			return
 		}
 
+		if exitGeneration.Load() != generation {
+			log.Debug().Msg("stale exit timer expired, cancelling exit")
+			return
+		}
 		if !svc.Config.HoldModeEnabled() {
 			log.Debug().Msg("exit timer expired, but hold mode disabled")
+			return
+		}
+
+		softwareToken := svc.State.GetSoftwareToken()
+		if !helpers.TokensEqual(&ownerCopy, softwareToken) {
+			log.Debug().Msg("hold owner changed, cancelling exit")
+			return
+		}
+		activeCard := svc.State.GetActiveCard()
+		if helpers.TokensEqual(&ownerCopy, &activeCard) {
+			log.Debug().Msg("hold owner reinserted, cancelling exit")
 			return
 		}
 
@@ -265,17 +312,14 @@ func timedExit(
 			log.Debug().Msg("no active media, cancelling exit")
 			return
 		}
-
-		if svc.State.GetSoftwareToken() == nil {
-			log.Debug().Msg("no active software token, cancelling exit")
-			return
-		}
-
 		if svc.Config.IsHoldModeIgnoredSystem(activeMedia.SystemID) {
 			log.Debug().Msg("active system ignored in config, cancelling exit")
 			return
 		}
 
+		if exitGeneration.Load() != generation {
+			return
+		}
 		runBeforeExitHook(svc, *activeMedia)
 
 		log.Info().Msg("exiting media")
@@ -284,6 +328,13 @@ func timedExit(
 			log.Warn().Msgf("error killing launcher: %s", err)
 		}
 
+		if svc.PlaylistQueue != nil {
+			select {
+			case svc.PlaylistQueue <- nil:
+			case <-svc.State.GetContext().Done():
+				return
+			}
+		}
 		select {
 		case svc.LaunchSoftwareQueue <- nil:
 		case <-svc.State.GetContext().Done():
@@ -319,7 +370,9 @@ func readerManager(
 
 	proc := &scanPreprocessor{}
 	connectScanSeen := make(map[string]bool)
+	pendingRemovals := make(map[holdTokenKey]tokens.Token)
 	var exitTimer clockwork.Timer
+	var exitGeneration atomic.Uint64
 
 	var stagedToken *tokens.Token
 	var guardUI *uievents.Handle
@@ -486,14 +539,22 @@ preprocessing:
 			scanSource = t.Source
 			scanProperties = t.Properties
 		case stoken := <-svc.LaunchSoftwareQueue:
-			// a token has been launched that starts software, used for managing exits
+			// A token has launched primary software and now owns hold-mode exit.
 			log.Debug().Msgf("new software token: %v", stoken)
-			if exitTimer != nil && !helpers.TokensEqual(stoken, svc.State.GetSoftwareToken()) {
-				if stopped := exitTimer.Stop(); stopped {
-					log.Info().Msg("different software token inserted, cancelling exit")
+			currentSoftwareToken := svc.State.GetSoftwareToken()
+			if stoken == nil || !helpers.TokensEqual(stoken, currentSoftwareToken) {
+				if cancelTimedExit(exitTimer, &exitGeneration) {
+					log.Info().Msg("software token changed, cancelling exit")
 				}
 			}
 			svc.State.SetSoftwareToken(stoken)
+			if stoken != nil {
+				key := newHoldTokenKey(stoken)
+				if removedToken, ok := pendingRemovals[key]; ok && helpers.TokensEqual(stoken, &removedToken) {
+					delete(pendingRemovals, key)
+					exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, stoken)
+				}
+			}
 			continue preprocessing
 		case result := <-svc.ConfirmQueue:
 			// Legacy API confirm remains launch-guard-specific and bypasses delay.
@@ -620,6 +681,14 @@ preprocessing:
 			}
 		}
 
+		var removedToken *tokens.Token
+		if scan == nil && !readerError {
+			if previous := proc.PrevToken(); previous != nil {
+				previousCopy := *previous
+				removedToken = &previousCopy
+			}
+		}
+
 		switch proc.Process(scan, readerError) {
 		case scanSkipDuplicate:
 			log.Debug().
@@ -629,6 +698,8 @@ preprocessing:
 			continue preprocessing
 
 		case scanNewToken:
+			delete(pendingRemovals, newHoldTokenKey(scan))
+
 			// Suppress the first scan from each newly-connected reader when ignore_on_connect is enabled
 			if svc.Config.ScanIgnoreOnConnect() && scan.ReaderID != "" && !connectScanSeen[scan.ReaderID] {
 				connectScanSeen[scan.ReaderID] = true
@@ -658,16 +729,11 @@ preprocessing:
 
 			svc.State.SetActiveCard(*scan)
 
-			if exitTimer != nil {
-				stopped := exitTimer.Stop()
-				stoken := svc.State.GetSoftwareToken()
-				if stopped && helpers.TokensEqual(scan, stoken) {
-					log.Info().Msg("same token reinserted, cancelling exit")
-					continue preprocessing
-				} else if stopped {
-					log.Info().Msg("new token inserted, restarting exit timer")
-					exitTimer = timedExit(svc, clock, exitTimer)
+			if exitTimer != nil && helpers.TokensEqual(scan, svc.State.GetSoftwareToken()) {
+				if cancelTimedExit(exitTimer, &exitGeneration) {
+					log.Info().Msg("hold owner reinserted, cancelling exit")
 				}
+				continue preprocessing
 			}
 
 			// avoid launching a token that was just written by a reader
@@ -767,20 +833,19 @@ preprocessing:
 			if pt := proc.PrevToken(); pt != nil && pt.ReaderID != "" {
 				delete(connectScanSeen, pt.ReaderID)
 			}
-			if exitTimer != nil {
-				if stopped := exitTimer.Stop(); stopped {
-					log.Debug().Msg("cancelled exit timer due to reader error")
-				}
+			if cancelTimedExit(exitTimer, &exitGeneration) {
+				log.Debug().Msg("cancelled exit timer due to reader error")
 			}
 			svc.State.SetActiveCard(tokens.Token{})
 
 		case scanNormalRemoval:
 			log.Info().Msg("token was removed")
 
-			// Clear ActiveCard before hook to prevent blocked removals from affecting new scans
+			// Clear ActiveCard before hook to prevent blocked removals from affecting new scans.
 			svc.State.SetActiveCard(tokens.Token{})
 
-			// Run on_remove hook; errors skip exit timer but card state is already cleared
+			// Run on_remove hook for every normal removal. A blocked removal must not
+			// become a deferred hold exit when its launch completes later.
 			onRemoveScript := svc.Config.ReadersScan().OnRemove
 			if svc.Config.HoldModeEnabled() && onRemoveScript != "" {
 				if err := runHook(svc, "on_remove", onRemoveScript, nil, nil); err != nil {
@@ -789,7 +854,18 @@ preprocessing:
 				}
 			}
 
-			exitTimer = timedExit(svc, clock, exitTimer)
+			if removedToken == nil {
+				continue preprocessing
+			}
+			key := newHoldTokenKey(removedToken)
+			recordPendingHoldRemoval(pendingRemovals, removedToken)
+			softwareToken := svc.State.GetSoftwareToken()
+			if !helpers.TokensEqual(removedToken, softwareToken) {
+				log.Debug().Msg("removed token does not own active media, skipping exit timer")
+				continue preprocessing
+			}
+			delete(pendingRemovals, key)
+			exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, removedToken)
 		}
 	}
 

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -322,6 +322,12 @@ func timedExit(
 		}
 		runBeforeExitHook(svc, *activeMedia)
 
+		softwareToken = svc.State.GetSoftwareToken()
+		if exitGeneration.Load() != generation || !helpers.TokensEqual(&ownerCopy, softwareToken) {
+			log.Debug().Msg("hold owner changed during before_exit, cancelling exit")
+			return
+		}
+
 		log.Info().Msg("exiting media")
 		err := svc.Platform.StopActiveLauncher(platforms.StopForMenu)
 		if err != nil {

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -596,6 +598,95 @@ func TestTimedExitConditions_ReaderIDRequired(t *testing.T) {
 				"%s: sourceIsReader=%v, readerExists=%v, hasRemovableCap=%v",
 				tt.expectedReason, sourceIsReader, readerExists, hasRemovableCap)
 		})
+	}
+}
+
+func TestTimedExit_RevalidatesOwnerAfterBeforeExit(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	cfg.SetScanMode(config.ScanModeHold)
+	cfg.SetScanExitDelay(0.001)
+	cfg.SetSystemDefaults([]config.SystemsDefault{{
+		System:     "NES",
+		BeforeExit: "**input.keyboard:{f2}",
+	}})
+	require.NoError(t, cfg.LoadTOML(`[zapscript.input]
+mode = "unrestricted"`))
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("mock-platform")
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{{
+		ID:       "test-launcher",
+		SystemID: "NES",
+	}}).Maybe()
+	mockPlatform.On("LookupMapping", mock.Anything).Return("", false).Maybe()
+
+	st, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	readerID := "pn532-1234567890abcdef"
+	mockReader := mocks.NewMockReader()
+	mockReader.On("ReaderID").Return(readerID)
+	mockReader.On("Path").Return("test-reader")
+	mockReader.On("Metadata").Return(readers.DriverMetadata{ID: "mock-reader"})
+	mockReader.On("Capabilities").Return([]readers.Capability{readers.CapabilityRemovable})
+	mockReader.On("Connected").Return(true)
+	mockReader.On("OnMediaChange", mock.Anything).Return(nil)
+	st.SetReader(mockReader)
+
+	owner := tokens.Token{
+		UID:      "game-card",
+		Text:     "game.nes",
+		Source:   tokens.SourceReader,
+		ReaderID: readerID,
+		ScanTime: time.Now(),
+	}
+	st.SetSoftwareToken(&owner)
+	st.SetActiveMedia(models.NewActiveMedia("test-launcher", "NES", "game.nes", "Game", "test-launcher"))
+
+	replacement := tokens.Token{
+		UID:      "replacement-card",
+		Text:     "other.nes",
+		Source:   tokens.SourceReader,
+		ReaderID: readerID,
+		ScanTime: time.Now(),
+	}
+	hookRan := make(chan struct{})
+	mockPlatform.On("KeyboardPress", "{f2}").Run(func(_ mock.Arguments) {
+		st.SetSoftwareToken(&replacement)
+		close(hookRan)
+	}).Return(nil).Once()
+	stopCalled := make(chan struct{}, 1)
+	mockPlatform.On("StopActiveLauncher", platforms.StopForMenu).Run(func(_ mock.Arguments) {
+		stopCalled <- struct{}{}
+	}).Return(nil).Maybe()
+
+	mockUserDB := testhelpers.NewMockUserDBI()
+	mockUserDB.On("GetEnabledMappings").Return([]database.Mapping{}, nil).Maybe()
+	mockUserDB.On("GetSupportedZapLinkHosts").Return([]string{}, nil).Maybe()
+	svc := &ServiceContext{
+		Platform:            mockPlatform,
+		Config:              cfg,
+		State:               st,
+		DB:                  &database.Database{UserDB: mockUserDB},
+		LaunchSoftwareQueue: make(chan *tokens.Token, 1),
+		PlaylistQueue:       make(chan *playlists.Playlist, 1),
+	}
+
+	clock := clockwork.NewFakeClock()
+	var exitGeneration atomic.Uint64
+	timedExit(svc, clock, nil, &exitGeneration, &owner)
+	clock.Advance(time.Millisecond)
+
+	select {
+	case <-hookRan:
+	case <-time.After(time.Second):
+		t.Fatal("before_exit hook did not run")
+	}
+	select {
+	case <-stopCalled:
+		t.Fatal("stale hold owner stopped active media after before_exit hook")
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -621,14 +622,14 @@ func TestTimedExitReturnsWhenLaunchQueueBlockedAndContextCancelled(t *testing.T)
 	mockReader.On("Capabilities").Return([]readers.Capability{readers.CapabilityRemovable})
 	st.SetReader(mockReader)
 
-	st.SetActiveCard(tokens.Token{
+	owner := tokens.Token{
 		UID:      "abc123",
 		Text:     "**launch.system:nes",
 		Source:   tokens.SourceReader,
 		ReaderID: readerID,
 		ScanTime: time.Now(),
-	})
-	st.SetSoftwareToken(&tokens.Token{Text: "NES/Super Mario Bros.nes"})
+	}
+	st.SetSoftwareToken(&owner)
 	st.SetActiveMedia(models.NewActiveMedia("nes", "NES", "game.nes", "Game", "launcher"))
 
 	stopCalled := make(chan struct{})
@@ -648,7 +649,8 @@ func TestTimedExitReturnsWhenLaunchQueueBlockedAndContextCancelled(t *testing.T)
 	}
 	clock := clockwork.NewFakeClock()
 
-	exitTimer := timedExit(svc, clock, nil)
+	var exitGeneration atomic.Uint64
+	exitTimer := timedExit(svc, clock, nil, &exitGeneration, &owner)
 	require.NotNil(t, exitTimer)
 	clock.Advance(time.Millisecond)
 

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -307,14 +307,20 @@ func (env *scanBehaviorEnv) waitForKeyboard(t *testing.T) string {
 // token back through lsq and readerManager has set it in state.
 func (env *scanBehaviorEnv) waitForSoftwareToken(t *testing.T) {
 	t.Helper()
+	env.waitForSoftwareTokenUID(t, "")
+}
+
+func (env *scanBehaviorEnv) waitForSoftwareTokenUID(t *testing.T, uid string) {
+	t.Helper()
 	deadline := time.After(behaviorTimeout)
 	for {
-		if env.st.GetSoftwareToken() != nil {
+		softwareToken := env.st.GetSoftwareToken()
+		if softwareToken != nil && (uid == "" || softwareToken.UID == uid) {
 			return
 		}
 		select {
 		case <-deadline:
-			t.Fatal("timed out waiting for software token to be set")
+			t.Fatalf("timed out waiting for software token UID=%q", uid)
 		case <-time.After(5 * time.Millisecond):
 		}
 	}
@@ -354,6 +360,21 @@ func (env *scanBehaviorEnv) waitForTimerStopped(t *testing.T) {
 		select {
 		case <-deadline:
 			t.Fatal("timed out waiting for exit timer to be stopped")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func (env *scanBehaviorEnv) waitForPlaylistCleared(t *testing.T) {
+	t.Helper()
+	deadline := time.After(behaviorTimeout)
+	for {
+		if env.st.GetActivePlaylist() == nil {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for active playlist to clear")
 		case <-time.After(time.Millisecond):
 		}
 	}
@@ -476,12 +497,53 @@ func TestScanBehavior_HoldImmediate_RemovalClosesGame(t *testing.T) {
 
 	env.sendGameScan("game1", env.gamePath("game.rom"))
 	env.waitForLaunch(t)
-	// Wait for the software token roundtrip through lsq before removal,
-	// otherwise the 0s timer fires before software token is set.
 	env.waitForSoftwareToken(t)
 
 	env.sendRemoval()
 	env.waitForStop(t)
+}
+
+func TestScanBehavior_HoldImmediate_FastRemovalClosesAfterLaunchOwnershipArrives(t *testing.T) {
+	t.Parallel()
+	env := setupScanBehavior(t, config.ScanModeHold, 0)
+
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForLaunch(t)
+	env.sendRemoval()
+
+	env.waitForStop(t)
+}
+
+func TestScanBehavior_HoldImmediate_UtilityRemovalDoesNotCloseGame(t *testing.T) {
+	t.Parallel()
+	env := setupScanBehavior(t, config.ScanModeHold, 0)
+
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForLaunch(t)
+	env.waitForSoftwareTokenUID(t, "game1")
+
+	env.sendCommandScan("keyboard", "**input.keyboard:coin")
+	env.waitForKeyboard(t)
+	env.sendRemoval()
+
+	env.expectNoStop(t)
+	env.waitForSoftwareTokenUID(t, "game1")
+}
+
+func TestScanBehavior_HoldImmediate_OwnerRemovalClearsPrimaryPlaylist(t *testing.T) {
+	t.Parallel()
+	env := setupScanBehavior(t, config.ScanModeHold, 0)
+
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForLaunch(t)
+	env.waitForSoftwareTokenUID(t, "game1")
+	playlist := playlists.NewPlaylist("playlist", "Playlist", []playlists.PlaylistItem{{ZapScript: "game"}})
+	playlist.Playing = true
+	env.st.SetActivePlaylist(playlist)
+
+	env.sendRemoval()
+	env.waitForStop(t)
+	env.waitForPlaylistCleared(t)
 }
 
 func TestScanBehavior_HoldImmediate_ManualExitNoRelaunch(t *testing.T) {
@@ -553,14 +615,18 @@ func TestScanBehavior_HoldDelayed_DifferentCardLaunchesImmediately(t *testing.T)
 
 	env.sendGameScan("gameA", env.gamePath("gameA.rom"))
 	require.Equal(t, env.gamePath("gameA.rom"), env.waitForLaunch(t))
-	env.waitForSoftwareToken(t)
+	env.waitForSoftwareTokenUID(t, "gameA")
 
 	env.sendRemoval()
 	env.sendGameScan("gameB", env.gamePath("gameB.rom"))
 	require.Equal(t, env.gamePath("gameB.rom"), env.waitForLaunch(t))
+	env.waitForSoftwareTokenUID(t, "gameB")
+
+	env.clock.Advance(10 * time.Second)
+	env.expectNoStop(t)
 }
 
-func TestScanBehavior_HoldDelayed_CommandResetsCountdown(t *testing.T) {
+func TestScanBehavior_HoldDelayed_CommandDoesNotResetCountdown(t *testing.T) {
 	t.Parallel()
 	env := setupScanBehavior(t, config.ScanModeHold, 5)
 
@@ -570,31 +636,15 @@ func TestScanBehavior_HoldDelayed_CommandResetsCountdown(t *testing.T) {
 
 	env.sendRemoval()
 
-	// First command card resets the 5s countdown.
 	env.sendCommandScan("cmd1", "**input.keyboard:coin")
 	env.waitForKeyboard(t)
-
-	// Advance 4s (< 5s exit_delay). If the timer was reset by the command,
-	// there's 1s remaining. If it wasn't, 4s > original timer and it would fire.
 	env.clock.Advance(4 * time.Second)
+	env.expectNoStop(t)
 
-	// Second command card resets the countdown again.
 	env.sendCommandScan("cmd2", "**input.keyboard:start")
 	env.waitForKeyboard(t)
-
-	// Advance another 4s (total 8s > 5s). Only passes if the second command
-	// truly reset the timer — otherwise the first command's timer (1s remaining)
-	// would have fired.
-	env.clock.Advance(4 * time.Second)
-	env.expectNoStop(t)
-
-	// Reinsert original game card — cancels timer, session continues.
-	env.sendGameScan("game1", env.gamePath("game.rom"))
-	env.waitForActiveCard(t, "game1")
-	env.waitForTimerStopped(t)
-
-	env.clock.Advance(10 * time.Second)
-	env.expectNoStop(t)
+	env.clock.Advance(time.Second)
+	env.waitForStop(t)
 }
 
 func TestScanBehavior_HoldDelayed_ManualExitNoRelaunch(t *testing.T) {

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -522,7 +522,7 @@ func TestScanBehavior_HoldImmediate_UtilityRemovalDoesNotCloseGame(t *testing.T)
 	env.waitForLaunch(t)
 	env.waitForSoftwareTokenUID(t, "game1")
 
-	env.sendCommandScan("keyboard", "**input.keyboard:coin")
+	env.sendCommandScan("keyboard", "**input.keyboard:{f2}")
 	env.waitForKeyboard(t)
 	env.sendRemoval()
 
@@ -636,12 +636,12 @@ func TestScanBehavior_HoldDelayed_CommandDoesNotResetCountdown(t *testing.T) {
 
 	env.sendRemoval()
 
-	env.sendCommandScan("cmd1", "**input.keyboard:coin")
+	env.sendCommandScan("cmd1", "**input.keyboard:{f2}")
 	env.waitForKeyboard(t)
 	env.clock.Advance(4 * time.Second)
 	env.expectNoStop(t)
 
-	env.sendCommandScan("cmd2", "**input.keyboard:start")
+	env.sendCommandScan("cmd2", "**input.keyboard:{f3}")
 	env.waitForKeyboard(t)
 	env.clock.Advance(time.Second)
 	env.waitForStop(t)

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -183,6 +183,12 @@ func queuePlaylistUpdate(env *platforms.CmdEnv, pls *playlists.Playlist) error {
 	}
 	if pls != nil {
 		pls.Slot = slot
+		if slot == mediaslot.Primary && env.Playlist.HoldToken != nil {
+			holdToken := *env.Playlist.HoldToken
+			pls.HoldToken = &holdToken
+		} else {
+			pls.HoldToken = nil
+		}
 	}
 	if env.LauncherCtx == nil && env.ServiceCtx == nil {
 		env.Playlist.Queue <- pls

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -141,6 +141,7 @@ func TestQueuePlaylistUpdate_HoldTokenAssignment(t *testing.T) {
 			assert.NotSame(t, owner, queued.HoldToken)
 			assert.True(t, helpers.TokensEqual(owner, queued.HoldToken))
 			assert.Equal(t, owner.ReaderID, queued.HoldToken.ReaderID)
+			assert.Equal(t, owner.Source, queued.HoldToken.Source)
 		})
 	}
 }

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -97,6 +97,54 @@ func TestQueuePlaylistUpdateReturnsWhenServiceContextCancelled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestQueuePlaylistUpdate_HoldTokenAssignment(t *testing.T) {
+	t.Parallel()
+
+	owner := &tokens.Token{
+		UID:      "playlist-card",
+		Text:     "**playlist.next",
+		Source:   tokens.SourceReader,
+		ReaderID: "reader-1",
+	}
+	staleOwner := &tokens.Token{UID: "stale-card"}
+
+	tests := []struct {
+		owner       *tokens.Token
+		name        string
+		slot        string
+		expectOwner bool
+	}{
+		{name: "primary copies owner", slot: mediaslot.Primary, owner: owner, expectOwner: true},
+		{name: "background clears owner", slot: mediaslot.Background, owner: owner},
+		{name: "primary without owner stays clear", slot: mediaslot.Primary},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			queue := make(chan *playlists.Playlist, 1)
+			playlist := &playlists.Playlist{Slot: tt.slot, HoldToken: staleOwner}
+			env := platforms.CmdEnv{
+				Playlist: playlists.PlaylistController{HoldToken: tt.owner, Queue: queue},
+			}
+
+			err := queuePlaylistUpdate(&env, playlist)
+			require.NoError(t, err)
+			queued := <-queue
+
+			if !tt.expectOwner {
+				assert.Nil(t, queued.HoldToken)
+				return
+			}
+			require.NotNil(t, queued.HoldToken)
+			assert.NotSame(t, owner, queued.HoldToken)
+			assert.True(t, helpers.TokensEqual(owner, queued.HoldToken))
+			assert.Equal(t, owner.ReaderID, queued.HoldToken.ReaderID)
+		})
+	}
+}
+
 func TestReadPlsFile(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- bind hold-mode exit timers to the physical token that launched primary media
- preserve launch ownership across primary playlist playback while ignoring utility and background tokens
- handle immediate card removal before launch ownership arrives and prevent stale timers from stopping replacement media
- update scan behavior documentation and regression coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hold-mode exit handling when launch cards are removed, including during launch initialization.
  * Command cards now execute without prematurely closing the game or resetting the existing exit countdown.
  * Exit timers now respect token ownership and ignore stale or unrelated removals.
  * Playlist transitions and launches now preserve ownership correctly, preventing unintended shutdowns or token changes.
  * Improved playlist updates when ownership changes between primary and background playback.

* **Documentation**
  * Clarified immediate- and delayed-exit behavior for hold mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->