### PR TITLE
fix(config): keep default remote URLs implicit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,12 +153,8 @@ var BaseDefaults = Values{
 	},
 	Backup: Backup{
 		Remote: BackupRemote{
-			BaseURL:  DefaultBackupRemoteBaseURL,
 			Schedule: DefaultBackupRemoteSchedule,
 		},
-	},
-	Playtime: Playtime{
-		BaseURL: DefaultPlaytimeBaseURL,
 	},
 	Readers: Readers{
 		AutoDetect: true,
@@ -345,6 +341,15 @@ func (c *Instance) LoadTOML(data string) error {
 func (c *Instance) applyTOML(data string) error {
 	if err := toml.Unmarshal([]byte(data), &c.vals); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// Older releases persisted runtime fallbacks as though they were user
+	// overrides. Treat only those exact legacy values as unset so future saves omit them.
+	if c.vals.Backup.Remote.BaseURL == DefaultBackupRemoteBaseURL {
+		c.vals.Backup.Remote.BaseURL = ""
+	}
+	if c.vals.Playtime.BaseURL == DefaultPlaytimeBaseURL {
+		c.vals.Playtime.BaseURL = ""
 	}
 
 	c.vals.Launchers.Custom = validateCustomLaunchers(

--- a/pkg/config/configbackup_test.go
+++ b/pkg/config/configbackup_test.go
@@ -20,8 +20,12 @@
 package config
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,9 +37,43 @@ func TestBackupDefaults(t *testing.T) {
 
 	assert.Empty(t, cfg.BackupLocalDir())
 	assert.False(t, cfg.BackupRemoteEnabled())
+	assert.Empty(t, BaseDefaults.Backup.Remote.BaseURL)
+	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
+	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
 	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 	assert.Equal(t, DefaultBackupRemoteSchedule, cfg.BackupRemoteSchedule())
 	assert.Equal(t, BackupScopePlatform, cfg.BackupScope())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
+	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
+	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
+}
+
+func TestBackupRemoteBaseURLMigratesLegacyDefault(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	configDir := t.TempDir()
+	require.NoError(t, fs.MkdirAll(configDir, 0o750))
+	legacyConfig := fmt.Sprintf(`config_schema = %d
+
+[backup.remote]
+base_url = %q
+`, SchemaVersion, DefaultBackupRemoteBaseURL)
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, CfgFile), []byte(legacyConfig), 0o600))
+
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, fs)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
+	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
+	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
+	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 }
 
 func TestBackupScope(t *testing.T) {
@@ -105,4 +143,20 @@ func TestSetBackupRemoteBaseURLNormalizes(t *testing.T) {
 
 	require.NoError(t, cfg.SetBackupRemoteBaseURL("https://example.com/backups/"))
 	assert.Equal(t, "https://example.com/backups", cfg.BackupRemoteBaseURL())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Equal(t, "https://example.com/backups", cfg.vals.Backup.Remote.BaseURL)
+	assert.Equal(t, "https://example.com/backups", readPersistedBackupBaseURL(t, cfg))
+	assert.Equal(t, "https://example.com/backups", cfg.BackupRemoteBaseURL())
+}
+
+func readPersistedBackupBaseURL(t *testing.T, cfg *Instance) string {
+	t.Helper()
+
+	data, err := afero.ReadFile(cfg.getFs(), cfg.cfgPath)
+	require.NoError(t, err)
+	var values Values
+	require.NoError(t, toml.Unmarshal(data, &values))
+	return values.Backup.Remote.BaseURL
 }

--- a/pkg/config/configbackup_test.go
+++ b/pkg/config/configbackup_test.go
@@ -32,14 +32,17 @@ import (
 
 func TestBackupDefaults(t *testing.T) {
 	t.Parallel()
-	cfg, err := NewConfig(t.TempDir(), BaseDefaults)
+
+	fs := afero.NewMemMapFs()
+	cfg, err := NewConfigWithFs(t.TempDir(), BaseDefaults, fs)
 	require.NoError(t, err)
 
 	assert.Empty(t, cfg.BackupLocalDir())
 	assert.False(t, cfg.BackupRemoteEnabled())
 	assert.Empty(t, BaseDefaults.Backup.Remote.BaseURL)
 	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
-	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
+	_, exists := readPersistedBackupBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 	assert.Equal(t, DefaultBackupRemoteSchedule, cfg.BackupRemoteSchedule())
 	assert.Equal(t, BackupScopePlatform, cfg.BackupScope())
@@ -47,7 +50,8 @@ func TestBackupDefaults(t *testing.T) {
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
-	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
+	_, exists = readPersistedBackupBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 }
 
@@ -72,7 +76,8 @@ base_url = %q
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Empty(t, cfg.vals.Backup.Remote.BaseURL)
-	assert.Empty(t, readPersistedBackupBaseURL(t, cfg))
+	_, exists := readPersistedBackupBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultBackupRemoteBaseURL, cfg.BackupRemoteBaseURL())
 }
 
@@ -147,16 +152,32 @@ func TestSetBackupRemoteBaseURLNormalizes(t *testing.T) {
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Equal(t, "https://example.com/backups", cfg.vals.Backup.Remote.BaseURL)
-	assert.Equal(t, "https://example.com/backups", readPersistedBackupBaseURL(t, cfg))
+	persistedBaseURL, exists := readPersistedBackupBaseURL(t, cfg)
+	assert.True(t, exists)
+	assert.Equal(t, "https://example.com/backups", persistedBaseURL)
 	assert.Equal(t, "https://example.com/backups", cfg.BackupRemoteBaseURL())
 }
 
-func readPersistedBackupBaseURL(t *testing.T, cfg *Instance) string {
+func readPersistedBackupBaseURL(t *testing.T, cfg *Instance) (string, bool) {
 	t.Helper()
 
 	data, err := afero.ReadFile(cfg.getFs(), cfg.cfgPath)
 	require.NoError(t, err)
-	var values Values
+	var values map[string]any
 	require.NoError(t, toml.Unmarshal(data, &values))
-	return values.Backup.Remote.BaseURL
+	backup, ok := values["backup"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	remote, ok := backup["remote"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	rawBaseURL, exists := remote["base_url"]
+	if !exists {
+		return "", false
+	}
+	baseURL, ok := rawBaseURL.(string)
+	require.True(t, ok)
+	return baseURL, true
 }

--- a/pkg/config/configplaytime_test.go
+++ b/pkg/config/configplaytime_test.go
@@ -54,13 +54,15 @@ func TestPlaytimeBaseURLDefaultPersistence(t *testing.T) {
 
 	assert.Empty(t, BaseDefaults.Playtime.BaseURL)
 	assert.Empty(t, cfg.vals.Playtime.BaseURL)
-	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	_, exists := readPersistedPlaytimeBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
 
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Empty(t, cfg.vals.Playtime.BaseURL)
-	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	_, exists = readPersistedPlaytimeBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
 }
 
@@ -85,7 +87,8 @@ base_url = %q
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Empty(t, cfg.vals.Playtime.BaseURL)
-	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	_, exists := readPersistedPlaytimeBaseURL(t, cfg)
+	assert.False(t, exists)
 	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
 }
 
@@ -104,18 +107,30 @@ func TestSetPlaytimeBaseURL(t *testing.T) {
 	require.NoError(t, cfg.Save())
 	require.NoError(t, cfg.Load())
 	assert.Equal(t, "https://playtime.example.com/api", cfg.vals.Playtime.BaseURL)
-	assert.Equal(t, "https://playtime.example.com/api", readPersistedPlaytimeBaseURL(t, cfg))
+	persistedBaseURL, exists := readPersistedPlaytimeBaseURL(t, cfg)
+	assert.True(t, exists)
+	assert.Equal(t, "https://playtime.example.com/api", persistedBaseURL)
 	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
 }
 
-func readPersistedPlaytimeBaseURL(t *testing.T, cfg *Instance) string {
+func readPersistedPlaytimeBaseURL(t *testing.T, cfg *Instance) (string, bool) {
 	t.Helper()
 
 	data, err := afero.ReadFile(cfg.getFs(), cfg.cfgPath)
 	require.NoError(t, err)
-	var values Values
+	var values map[string]any
 	require.NoError(t, toml.Unmarshal(data, &values))
-	return values.Playtime.BaseURL
+	playtime, ok := values["playtime"].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	rawBaseURL, exists := playtime["base_url"]
+	if !exists {
+		return "", false
+	}
+	baseURL, ok := rawBaseURL.(string)
+	require.True(t, ok)
+	return baseURL, true
 }
 
 func TestPlaytimeSyncEnabled(t *testing.T) {

--- a/pkg/config/configplaytime_test.go
+++ b/pkg/config/configplaytime_test.go
@@ -20,9 +20,13 @@
 package config
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
+	toml "github.com/pelletier/go-toml/v2"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,22 +35,87 @@ func TestPlaytimeBaseURL(t *testing.T) {
 	t.Parallel()
 
 	cfg := &Instance{}
+	assert.Empty(t, cfg.vals.Playtime.BaseURL)
 	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
 
 	require.NoError(t, cfg.LoadTOML(`[playtime]
 base_url = "https://playtime.example.com/api"
 `))
+	assert.Equal(t, "https://playtime.example.com/api", cfg.vals.Playtime.BaseURL)
 	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+}
+
+func TestPlaytimeBaseURLDefaultPersistence(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	cfg, err := NewConfigWithFs(t.TempDir(), BaseDefaults, fs)
+	require.NoError(t, err)
+
+	assert.Empty(t, BaseDefaults.Playtime.BaseURL)
+	assert.Empty(t, cfg.vals.Playtime.BaseURL)
+	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Empty(t, cfg.vals.Playtime.BaseURL)
+	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
+}
+
+func TestPlaytimeBaseURLMigratesLegacyDefault(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	configDir := t.TempDir()
+	require.NoError(t, fs.MkdirAll(configDir, 0o750))
+	legacyConfig := fmt.Sprintf(`config_schema = %d
+
+[playtime]
+base_url = %q
+`, SchemaVersion, DefaultPlaytimeBaseURL)
+	require.NoError(t, afero.WriteFile(fs, filepath.Join(configDir, CfgFile), []byte(legacyConfig), 0o600))
+
+	cfg, err := NewConfigWithFs(configDir, BaseDefaults, fs)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.vals.Playtime.BaseURL)
+	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Empty(t, cfg.vals.Playtime.BaseURL)
+	assert.Empty(t, readPersistedPlaytimeBaseURL(t, cfg))
+	assert.Equal(t, DefaultPlaytimeBaseURL, cfg.PlaytimeBaseURL())
 }
 
 func TestSetPlaytimeBaseURL(t *testing.T) {
 	t.Parallel()
 
-	cfg := &Instance{}
+	fs := afero.NewMemMapFs()
+	cfg, err := NewConfigWithFs(t.TempDir(), BaseDefaults, fs)
+	require.NoError(t, err)
+
 	require.NoError(t, cfg.SetPlaytimeBaseURL("https://playtime.example.com/api/"))
 	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
 	require.Error(t, cfg.SetPlaytimeBaseURL("http://example.com"))
 	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+
+	require.NoError(t, cfg.Save())
+	require.NoError(t, cfg.Load())
+	assert.Equal(t, "https://playtime.example.com/api", cfg.vals.Playtime.BaseURL)
+	assert.Equal(t, "https://playtime.example.com/api", readPersistedPlaytimeBaseURL(t, cfg))
+	assert.Equal(t, "https://playtime.example.com/api", cfg.PlaytimeBaseURL())
+}
+
+func readPersistedPlaytimeBaseURL(t *testing.T, cfg *Instance) string {
+	t.Helper()
+
+	data, err := afero.ReadFile(cfg.getFs(), cfg.cfgPath)
+	require.NoError(t, err)
+	var values Values
+	require.NoError(t, toml.Unmarshal(data, &values))
+	return values.Playtime.BaseURL
 }
 
 func TestPlaytimeSyncEnabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- keep backup and playtime base URL overrides blank unless explicitly configured
- resolve blank values to built-in runtime defaults
- normalize legacy persisted defaults while preserving custom URLs
- cover generation, migration, and save/reload behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default backup and playtime service URLs are no longer unnecessarily written to configuration files.
  * Existing configuration files containing legacy default URLs are automatically cleaned up when saved.
  * Custom remote URLs continue to be normalized and preserved across save and load operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->