### PR TITLE
fix(api): serialize stop after media launch

### DIFF
--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -183,12 +184,41 @@ func HandleRunRest(
 	}
 }
 
+func waitForCurrentMediaReady(ctx context.Context, st *state.State) error {
+	for {
+		gen, active := st.ActiveMediaReadyGeneration()
+		if !active {
+			return nil
+		}
+
+		err := st.WaitForActiveMediaReady(ctx, gen)
+		switch {
+		case err == nil, errors.Is(err, state.ErrNoActiveMedia):
+			return nil
+		case errors.Is(err, state.ErrActiveMediaChanged):
+			continue
+		default:
+			return fmt.Errorf("wait for active media ready: %w", err)
+		}
+	}
+}
+
 func HandleStop(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Info().Msg("received stop request")
+
+	release, err := env.State.AcquireMediaStop(env.Context)
+	if err != nil {
+		return nil, fmt.Errorf("wait for in-flight media launch: %w", err)
+	}
+	defer release()
+
+	if err := waitForCurrentMediaReady(env.Context, env.State); err != nil {
+		return nil, err
+	}
+
 	// TODO: return an error when nothing is active, requires StopActiveLauncher
 	// to report whether anything was actually stopped
-	err := env.Platform.StopActiveLauncher(platforms.StopForMenu)
-	if err != nil {
+	if err := env.Platform.StopActiveLauncher(platforms.StopForMenu); err != nil {
 		return nil, fmt.Errorf("failed to stop active launcher: %w", err)
 	}
 	return NoContent{}, nil

--- a/pkg/api/methods/run_test.go
+++ b/pkg/api/methods/run_test.go
@@ -1,0 +1,112 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stopResult struct {
+	value any
+	err   error
+}
+
+func TestHandleStopWaitsForLaunchAndMediaReadiness(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("StopActiveLauncher", platforms.StopForMenu).Return(nil).Once()
+	st, _ := state.NewState(mockPlatform, "test-boot")
+	defer st.StopService()
+
+	releaseLaunch, err := st.AcquireMediaLaunch()
+	require.NoError(t, err)
+	st.SetActiveMedia(models.NewActiveMedia("snes", "SNES", "game.sfc", "Game", "RASNES"))
+	readyGen, active := st.ActiveMediaReadyGeneration()
+	require.True(t, active)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	resultCh := make(chan stopResult, 1)
+	go func() {
+		value, stopErr := HandleStop(requests.RequestEnv{
+			Context:  ctx,
+			Platform: mockPlatform,
+			State:    st,
+		})
+		resultCh <- stopResult{value: value, err: stopErr}
+	}()
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		t.Fatal("stop completed while media launch was in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+	mockPlatform.AssertNotCalled(t, "StopActiveLauncher", platforms.StopForMenu)
+
+	releaseLaunch()
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		t.Fatal("stop completed before active media became ready")
+	case <-time.After(50 * time.Millisecond):
+	}
+	mockPlatform.AssertNotCalled(t, "StopActiveLauncher", platforms.StopForMenu)
+
+	st.MarkActiveMediaReady(readyGen)
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		assert.Equal(t, NoContent{}, result.value)
+	case <-time.After(time.Second):
+		t.Fatal("stop did not complete after media became ready")
+	}
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestHandleStopWithoutActiveMedia(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("StopActiveLauncher", platforms.StopForMenu).Return(nil).Once()
+	st, _ := state.NewState(mockPlatform, "test-boot")
+	defer st.StopService()
+
+	value, err := HandleStop(requests.RequestEnv{
+		Context:  context.Background(),
+		Platform: mockPlatform,
+		State:    st,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, NoContent{}, value)
+	mockPlatform.AssertExpectations(t)
+}

--- a/pkg/api/methods/run_test.go
+++ b/pkg/api/methods/run_test.go
@@ -92,6 +92,30 @@ func TestHandleStopWaitsForLaunchAndMediaReadiness(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestHandleStopCanceledWhileLaunchInFlight(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	st, _ := state.NewState(mockPlatform, "test-boot")
+	defer st.StopService()
+
+	releaseLaunch, err := st.AcquireMediaLaunch()
+	require.NoError(t, err)
+	defer releaseLaunch()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	value, err := HandleStop(requests.RequestEnv{
+		Context:  ctx,
+		Platform: mockPlatform,
+		State:    st,
+	})
+
+	assert.Nil(t, value)
+	require.ErrorIs(t, err, context.Canceled)
+	mockPlatform.AssertNotCalled(t, "StopActiveLauncher", platforms.StopForMenu)
+}
+
 func TestHandleStopWithoutActiveMedia(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -525,23 +525,28 @@ func (s *State) AcquireMediaLaunch() (func(), error) {
 // AcquireMediaStop waits for in-flight media launches, then prevents another
 // launch from starting until the returned release function is called.
 func (s *State) AcquireMediaStop(ctx context.Context) (func(), error) {
-	acquired := make(chan struct{})
-	abandoned := make(chan struct{})
-	go func() {
-		s.mediaLaunchMu.Lock()
-		select {
-		case acquired <- struct{}{}:
-		case <-abandoned:
-			s.mediaLaunchMu.Unlock()
-		}
-	}()
+	const retryInterval = 5 * time.Millisecond
 
-	select {
-	case <-acquired:
-		return s.mediaLaunchMu.Unlock, nil
-	case <-ctx.Done():
-		close(abandoned)
-		return nil, ctx.Err()
+	retry := time.NewTicker(retryInterval)
+	defer retry.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// TryLock avoids registering a writer that would keep blocking new
+		// launches after this request is canceled.
+		if s.mediaLaunchMu.TryLock() {
+			return s.mediaLaunchMu.Unlock, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-retry.C:
+		}
 	}
 }
 

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -87,6 +87,7 @@ type State struct {
 	activeMediaReadyGen   uint64
 	mediaLaunchAccesses   int
 	mu                    syncutil.RWMutex
+	mediaLaunchMu         syncutil.RWMutex
 	mediaRestoreMu        syncutil.RWMutex
 	activeMediaReady      bool
 	stopService           bool
@@ -500,10 +501,15 @@ func (s *State) AcquireRestoreAccess() (func(), error) {
 }
 
 func (s *State) AcquireMediaLaunch() (func(), error) {
-	release, err := s.TryAcquireRestoreAccess()
+	releaseRestore, err := s.TryAcquireRestoreAccess()
 	if err != nil {
 		return nil, err
 	}
+
+	// Stop operations take the exclusive side of this gate. Holding the read
+	// side through Platform.LaunchMedia keeps stop requests behind platform
+	// launch settling and active-media readiness setup.
+	s.mediaLaunchMu.RLock()
 	s.mu.Lock()
 	s.mediaLaunchAccesses++
 	s.mu.Unlock()
@@ -511,8 +517,32 @@ func (s *State) AcquireMediaLaunch() (func(), error) {
 		s.mu.Lock()
 		s.mediaLaunchAccesses--
 		s.mu.Unlock()
-		release()
+		s.mediaLaunchMu.RUnlock()
+		releaseRestore()
 	}, nil
+}
+
+// AcquireMediaStop waits for in-flight media launches, then prevents another
+// launch from starting until the returned release function is called.
+func (s *State) AcquireMediaStop(ctx context.Context) (func(), error) {
+	acquired := make(chan struct{})
+	abandoned := make(chan struct{})
+	go func() {
+		s.mediaLaunchMu.Lock()
+		select {
+		case acquired <- struct{}{}:
+		case <-abandoned:
+			s.mediaLaunchMu.Unlock()
+		}
+	}()
+
+	select {
+	case <-acquired:
+		return s.mediaLaunchMu.Unlock, nil
+	case <-ctx.Done():
+		close(abandoned)
+		return nil, ctx.Err()
+	}
 }
 
 func (s *State) BeginRestoreGate() (func(bool), error) {

--- a/pkg/service/state/state_media_test.go
+++ b/pkg/service/state/state_media_test.go
@@ -82,6 +82,98 @@ func TestMediaRestoreGateMutualExclusion(t *testing.T) {
 	releaseLaunch()
 }
 
+func TestMediaStopGateWaitsForLaunchAndBlocksReplacement(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(nil, "test-boot")
+	defer st.StopService()
+
+	releaseLaunch, err := st.AcquireMediaLaunch()
+	require.NoError(t, err)
+
+	stopRelease := make(chan func(), 1)
+	stopErr := make(chan error, 1)
+	go func() {
+		release, acquireErr := st.AcquireMediaStop(context.Background())
+		if acquireErr != nil {
+			stopErr <- acquireErr
+			return
+		}
+		stopRelease <- release
+	}()
+
+	select {
+	case <-stopRelease:
+		t.Fatal("media stop gate acquired while launch was in flight")
+	case err := <-stopErr:
+		require.NoError(t, err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseLaunch()
+	var releaseStop func()
+	select {
+	case releaseStop = <-stopRelease:
+	case err := <-stopErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("media stop gate did not acquire after launch completed")
+	}
+
+	replacementResult := make(chan struct {
+		release func()
+		err     error
+	}, 1)
+	go func() {
+		release, acquireErr := st.AcquireMediaLaunch()
+		replacementResult <- struct {
+			release func()
+			err     error
+		}{release: release, err: acquireErr}
+	}()
+
+	select {
+	case result := <-replacementResult:
+		if result.release != nil {
+			result.release()
+		}
+		require.NoError(t, result.err)
+		t.Fatal("replacement launch started while media stop gate was held")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseStop()
+	select {
+	case result := <-replacementResult:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.release)
+		result.release()
+	case <-time.After(time.Second):
+		t.Fatal("replacement launch did not resume after media stop completed")
+	}
+}
+
+func TestMediaStopGateHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(nil, "test-boot")
+	defer st.StopService()
+
+	releaseLaunch, err := st.AcquireMediaLaunch()
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	releaseStop, err := st.AcquireMediaStop(ctx)
+	assert.Nil(t, releaseStop)
+	require.ErrorIs(t, err, context.Canceled)
+
+	releaseLaunch()
+	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
+	defer cleanupCancel()
+	releaseStop, err = st.AcquireMediaStop(cleanupCtx)
+	require.NoError(t, err, "canceled waiter must release the stop gate after the launch finishes")
+	releaseStop()
+}
+
 func TestExternalActiveMediaCancelsRestoreBeforeUpdatingState(t *testing.T) {
 	t.Parallel()
 	st, _ := NewState(nil, "test-boot")

--- a/pkg/service/state/state_media_test.go
+++ b/pkg/service/state/state_media_test.go
@@ -159,6 +159,11 @@ func TestMediaStopGateHonorsContextCancellation(t *testing.T) {
 
 	releaseLaunch, err := st.AcquireMediaLaunch()
 	require.NoError(t, err)
+	defer func() {
+		if releaseLaunch != nil {
+			releaseLaunch()
+		}
+	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -166,11 +171,33 @@ func TestMediaStopGateHonorsContextCancellation(t *testing.T) {
 	assert.Nil(t, releaseStop)
 	require.ErrorIs(t, err, context.Canceled)
 
+	replacementResult := make(chan struct {
+		release func()
+		err     error
+	}, 1)
+	go func() {
+		release, acquireErr := st.AcquireMediaLaunch()
+		replacementResult <- struct {
+			release func()
+			err     error
+		}{release: release, err: acquireErr}
+	}()
+
+	select {
+	case result := <-replacementResult:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.release)
+		result.release()
+	case <-time.After(time.Second):
+		t.Fatal("canceled media stop kept a replacement launch blocked")
+	}
+
 	releaseLaunch()
+	releaseLaunch = nil
 	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
 	defer cleanupCancel()
 	releaseStop, err = st.AcquireMediaStop(cleanupCtx)
-	require.NoError(t, err, "canceled waiter must release the stop gate after the launch finishes")
+	require.NoError(t, err)
 	releaseStop()
 }
 


### PR DESCRIPTION
## Summary

- wait for in-flight media launches and active-media readiness before handling API stop requests
- block replacement launches until stop processing completes
- add regression coverage for launch races, readiness, and cancellation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media stopping to wait for ongoing launches and media readiness to complete.
  * Prevented media replacement while a stop operation is in progress.
  * Added cancellation handling so interrupted stop requests exit safely.
  * Ensured stopping succeeds cleanly when no media is currently active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->