### PR TITLE
fix(database): speed up negative tag filters

### DIFF
--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -753,6 +753,89 @@ func TestMediaDB_RandomGameWithQuery_PathPrefixIntegration(t *testing.T) {
 	assert.Equal(t, matchingMediaID, result.MediaID)
 }
 
+func TestMediaDB_RandomGameWithQuery_NegativeTagIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	regionTagType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "region"})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	insertedSystem, err := mediaDB.InsertSystem(database.System{SystemID: nesSystem.ID, Name: "NES"})
+	require.NoError(t, err)
+
+	europeFilePath := filepath.Join("roms", "nes", "europe-file.nes")
+	europeTitlePath := filepath.Join("roms", "nes", "europe-title.nes")
+	untaggedPath := filepath.Join("roms", "nes", "untagged.nes")
+	var europeTitleID int64
+	for i, game := range []struct {
+		path           string
+		europeFileTag  bool
+		europeTitleTag bool
+	}{
+		{path: europeFilePath, europeFileTag: true},
+		{path: europeTitlePath, europeTitleTag: true},
+		{path: untaggedPath},
+	} {
+		name := fmt.Sprintf("Game %d", i+1)
+		insertedTitle, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(slugs.MediaTypeGame, name),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		insertedMedia, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           game.path,
+		})
+		require.NoError(t, mediaErr)
+		if game.europeTitleTag {
+			europeTitleID = insertedTitle.DBID
+		}
+		if !game.europeFileTag {
+			continue
+		}
+		europeTag, tagErr := mediaDB.FindOrInsertTag(database.Tag{
+			TypeDBID: regionTagType.DBID,
+			Tag:      "eu",
+		})
+		require.NoError(t, tagErr)
+		_, tagErr = mediaDB.InsertMediaTag(database.MediaTag{
+			MediaDBID: insertedMedia.DBID,
+			TagDBID:   europeTag.DBID,
+		})
+		require.NoError(t, tagErr)
+	}
+
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(context.Background(), europeTitleID, []database.TagInfo{{
+		Type: "region",
+		Tag:  "eu",
+	}}))
+
+	result, err := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+		Systems: []string{nesSystem.ID},
+		Tags: []zapscript.TagFilter{{
+			Type:     "region",
+			Value:    "eu",
+			Operator: zapscript.TagOperatorNOT,
+		}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, nesSystem.ID, result.SystemID)
+	assert.Equal(t, untaggedPath, result.Path)
+}
+
 func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/tagfilter.go
+++ b/pkg/database/mediadb/tagfilter.go
@@ -75,7 +75,7 @@ func expandCreditFilters(filters []zapscript.TagFilter) []zapscript.TagFilter {
 // BuildTagFilterSQL constructs SQL WHERE clauses and arguments for tag filtering
 // using a hybrid strategy optimized for SQLite performance:
 //   - AND filters: INTERSECT pattern
-//   - NOT filters: NOT EXISTS pattern
+//   - NOT filters: forward NOT IN anti-set
 //   - OR filters: EXISTS with OR conditions
 //
 // Returns a slice of WHERE clause strings and corresponding arguments.
@@ -161,22 +161,22 @@ func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []
 		args = append(args, val, devType, pubType, credType, val, devType, pubType, credType)
 	}
 
-	// Build NOT EXISTS clauses for NOT filters
-	// Each NOT filter excludes media that has the specified tag at either level
+	// Build forward anti-set clauses for NOT filters. Resolving matching media IDs
+	// once lets SQLite use the reverse tag indexes instead of repeating correlated
+	// tag joins for every candidate media row.
 	for _, f := range notFilters {
 		typ, val := resolveFilter(f.Type, f.Value)
-		clause := `NOT EXISTS (
-			SELECT 1 FROM MediaTags
+		clause := `Media.DBID NOT IN (
+			SELECT MediaDBID FROM MediaTags
 			JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-			WHERE MediaTags.MediaDBID = Media.DBID
-			AND TagTypes.Type = ? AND Tags.Tag = ?
-		) AND NOT EXISTS (
-			SELECT 1 FROM MediaTitleTags
-			JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
+			WHERE TagTypes.Type = ? AND Tags.Tag = ?
+			UNION ALL
+			SELECT m.DBID AS MediaDBID FROM Media m
+			JOIN MediaTitleTags mtt ON m.MediaTitleDBID = mtt.MediaTitleDBID
+			JOIN Tags ON mtt.TagDBID = Tags.DBID
 			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-			WHERE MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
-			AND TagTypes.Type = ? AND Tags.Tag = ?
+			WHERE TagTypes.Type = ? AND Tags.Tag = ?
 		)`
 		clauses = append(clauses, clause)
 		args = append(args, typ, val, typ, val)

--- a/pkg/database/mediadb/tagfilter_test.go
+++ b/pkg/database/mediadb/tagfilter_test.go
@@ -103,10 +103,13 @@ func TestBuildTagFilterSQL_NOTOnly(t *testing.T) {
 		require.Len(t, clauses, 1)
 		require.Len(t, args, 4) // 1 filter * 4 args (MediaTags + MediaTitleTags)
 
-		// Should use NOT EXISTS pattern for both tag sources
-		assert.Contains(t, clauses[0], "NOT EXISTS (")
-		assert.Contains(t, clauses[0], "MediaTags.MediaDBID = Media.DBID")
-		assert.Contains(t, clauses[0], "MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID")
+		// Should build one indexed anti-set across both tag sources.
+		assert.Contains(t, clauses[0], "Media.DBID NOT IN (")
+		assert.Contains(t, clauses[0], "SELECT MediaDBID FROM MediaTags")
+		assert.Contains(t, clauses[0], "SELECT m.DBID AS MediaDBID FROM Media m")
+		assert.Contains(t, clauses[0], "JOIN MediaTitleTags")
+		assert.Contains(t, clauses[0], "UNION ALL")
+		assert.NotContains(t, clauses[0], "NOT EXISTS")
 		assert.Equal(t, "unfinished", args[0])
 		assert.Equal(t, "demo", args[1])
 		assert.Equal(t, "unfinished", args[2])
@@ -123,9 +126,9 @@ func TestBuildTagFilterSQL_NOTOnly(t *testing.T) {
 		require.Len(t, clauses, 2) // Each NOT filter gets its own clause
 		require.Len(t, args, 8)    // 2 filters * 4 args each
 
-		// Both should use NOT EXISTS for both tag sources
-		assert.Contains(t, clauses[0], "NOT EXISTS")
-		assert.Contains(t, clauses[1], "NOT EXISTS")
+		// Both should build independent anti-sets across both tag sources.
+		assert.Contains(t, clauses[0], "Media.DBID NOT IN (")
+		assert.Contains(t, clauses[1], "Media.DBID NOT IN (")
 	})
 }
 
@@ -176,8 +179,8 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		// First clause should be INTERSECT (or IN for single)
 		assert.Contains(t, clauses[0], "Media.DBID IN (")
 
-		// Second clause should be NOT EXISTS
-		assert.Contains(t, clauses[1], "NOT EXISTS")
+		// Second clause should be a forward anti-set.
+		assert.Contains(t, clauses[1], "Media.DBID NOT IN (")
 	})
 
 	t.Run("AND + OR", func(t *testing.T) {
@@ -209,8 +212,8 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		require.Len(t, clauses, 2) // One for NOT, one for OR group
 		require.Len(t, args, 12)   // 1 NOT*4 + 2 OR*4
 
-		// First clause should be NOT EXISTS
-		assert.Contains(t, clauses[0], "NOT EXISTS")
+		// First clause should be a forward anti-set.
+		assert.Contains(t, clauses[0], "Media.DBID NOT IN (")
 
 		// Second clause should be EXISTS with OR
 		assert.Contains(t, clauses[1], "EXISTS (")
@@ -234,9 +237,9 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		assert.Contains(t, clauses[0], "Media.DBID IN (")
 		assert.Contains(t, clauses[0], "INTERSECT")
 
-		// Next two clauses: NOT EXISTS
-		assert.Contains(t, clauses[1], "NOT EXISTS")
-		assert.Contains(t, clauses[2], "NOT EXISTS")
+		// Next two clauses: forward anti-sets.
+		assert.Contains(t, clauses[1], "Media.DBID NOT IN (")
+		assert.Contains(t, clauses[2], "Media.DBID NOT IN (")
 
 		// Last clause: EXISTS with OR
 		assert.Contains(t, clauses[3], "EXISTS (")
@@ -537,7 +540,7 @@ func TestBuildTagFilterSQL_SQLStructure(t *testing.T) {
 		assert.Contains(t, clauses[0], "MediaTitleTags")
 	})
 
-	t.Run("NOT filters use NOT EXISTS pattern with both tag sources", func(t *testing.T) {
+	t.Run("NOT filters use indexed anti-set with both tag sources", func(t *testing.T) {
 		filters := []zapscript.TagFilter{
 			{Type: "unfinished", Value: "demo", Operator: zapscript.TagOperatorNOT},
 		}
@@ -545,10 +548,10 @@ func TestBuildTagFilterSQL_SQLStructure(t *testing.T) {
 		clauses, _ := BuildTagFilterSQL(filters)
 		require.Len(t, clauses, 1)
 
-		// Should contain NOT EXISTS for both MediaTags and MediaTitleTags
-		assert.Contains(t, clauses[0], "NOT EXISTS")
-		assert.Contains(t, clauses[0], "MediaTags.MediaDBID = Media.DBID")
-		assert.Contains(t, clauses[0], "MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID")
+		assert.Contains(t, clauses[0], "Media.DBID NOT IN (")
+		assert.Contains(t, clauses[0], "SELECT MediaDBID FROM MediaTags")
+		assert.Contains(t, clauses[0], "JOIN MediaTitleTags")
+		assert.NotContains(t, clauses[0], "NOT EXISTS")
 	})
 
 	t.Run("OR filters use EXISTS with OR pattern for both tag sources", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- replace correlated negative-tag checks with indexed anti-set lookups
- preserve filtering across file-level and title-level tags, including untagged media
- add random-launch regression coverage for excluded region tags

Closes #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved negative tag filtering so queries excluding tags return the correct results across file- and title-level tags.
  * Enhanced filtering behavior for single, multiple, and mixed tag conditions.

* **Tests**
  * Added integration coverage for negative tag filtering.
  * Expanded validation of tag-filter query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->