### PR TITLE
fix(readers): show MiSTer arcade tty2oled pictures

### DIFF
--- a/pkg/platforms/mister/tty2oled.go
+++ b/pkg/platforms/mister/tty2oled.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
+	"github.com/rs/zerolog/log"
+)
+
+// TTY2OLEDPictureName returns MiSTer's arcade setname, matching upstream picture filenames.
+func (*Platform) TTY2OLEDPictureName(media *models.ActiveMedia) string {
+	if media == nil || media.SystemID != systemdefs.SystemArcade {
+		return ""
+	}
+
+	mediaPath := strings.TrimSpace(media.Path)
+	if mediaPath == "" {
+		return ""
+	}
+
+	if strings.EqualFold(filepath.Ext(mediaPath), ".mra") {
+		mra, err := mgls.ReadMRA(mediaPath)
+		if err != nil {
+			log.Debug().Err(err).Str("path", mediaPath).Msg("failed to read arcade setname for tty2oled")
+			return ""
+		}
+		return strings.TrimSpace(mra.SetName)
+	}
+
+	if filepath.Base(mediaPath) == mediaPath && filepath.Ext(mediaPath) == "" {
+		return mediaPath
+	}
+
+	return ""
+}

--- a/pkg/platforms/mister/tty2oled_test.go
+++ b/pkg/platforms/mister/tty2oled_test.go
@@ -1,0 +1,89 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTTY2OLEDPictureNameFromTrackedArcade(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	media := &models.ActiveMedia{
+		SystemID: systemdefs.SystemArcade,
+		Path:     "bubbles",
+		Name:     "Bubbles",
+	}
+
+	assert.Equal(t, "bubbles", platform.TTY2OLEDPictureName(media))
+}
+
+func TestTTY2OLEDPictureNameFromMRA(t *testing.T) {
+	t.Parallel()
+
+	mraPath := filepath.Join(t.TempDir(), "Street Fighter II.mra")
+	mra := []byte(`<misterromdescription>
+	<setname>sf2</setname>
+	<name>Street Fighter II - The World Warrior</name>
+</misterromdescription>`)
+	require.NoError(t, os.WriteFile(mraPath, mra, 0o600))
+	platform := &Platform{}
+	media := &models.ActiveMedia{
+		SystemID: systemdefs.SystemArcade,
+		Path:     mraPath,
+		Name:     "Street Fighter II - The World Warrior",
+	}
+
+	assert.Equal(t, "sf2", platform.TTY2OLEDPictureName(media))
+}
+
+func TestTTY2OLEDPictureNameIgnoresNonArcadeMedia(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	media := &models.ActiveMedia{
+		SystemID: systemdefs.SystemNES,
+		Path:     "bubbles",
+	}
+
+	assert.Empty(t, platform.TTY2OLEDPictureName(media))
+}
+
+func TestTTY2OLEDPictureNameRejectsArcadeFilePathWithoutSetname(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	media := &models.ActiveMedia{
+		SystemID: systemdefs.SystemArcade,
+		Path:     filepath.Join("media", "fat", "_Arcade", "Bubbles.mgl"),
+	}
+
+	assert.Empty(t, platform.TTY2OLEDPictureName(media))
+}

--- a/pkg/platforms/mister/tty2oled_test.go
+++ b/pkg/platforms/mister/tty2oled_test.go
@@ -76,6 +76,27 @@ func TestTTY2OLEDPictureNameIgnoresNonArcadeMedia(t *testing.T) {
 	assert.Empty(t, platform.TTY2OLEDPictureName(media))
 }
 
+func TestTTY2OLEDPictureNameReturnsEmptyForMissingMediaPath(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	media := &models.ActiveMedia{SystemID: systemdefs.SystemArcade}
+
+	assert.Empty(t, platform.TTY2OLEDPictureName(media))
+}
+
+func TestTTY2OLEDPictureNameReturnsEmptyWhenMRAIsUnreadable(t *testing.T) {
+	t.Parallel()
+
+	platform := &Platform{}
+	media := &models.ActiveMedia{
+		SystemID: systemdefs.SystemArcade,
+		Path:     filepath.Join(t.TempDir(), "missing.mra"),
+	}
+
+	assert.Empty(t, platform.TTY2OLEDPictureName(media))
+}
+
 func TestTTY2OLEDPictureNameRejectsArcadeFilePathWithoutSetname(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/readers/tty2oled/mappings.go
+++ b/pkg/readers/tty2oled/mappings.go
@@ -83,6 +83,7 @@ var systemToPicture = map[string]string{
 	"PC":              "AO486", // PC games run on AO486 core
 
 	// Additional mappings based on picture repository structure
+	"Arcade":        "Arcade",
 	"Arcadia":       "Arcadia",
 	"Astrocade":     "Astrocade",
 	"ColecoVision":  "ColecoVision",

--- a/pkg/readers/tty2oled/mappings_test.go
+++ b/pkg/readers/tty2oled/mappings_test.go
@@ -37,6 +37,7 @@ func TestMapSystemToPicture(t *testing.T) {
 		{"SNES", "SNES"},
 		{"PSX", "PSX"},
 		{"Dreamcast", "Dreamcast"},
+		{"Arcade", "Arcade"},
 		{"DOS", "AO486"},
 		{"PC", "AO486"},
 		{"AdventureVision", "AVision"},

--- a/pkg/readers/tty2oled/pictures.go
+++ b/pkg/readers/tty2oled/pictures.go
@@ -66,95 +66,98 @@ func (pm *PictureManager) GetPictureForSystem(systemID string) (string, error) {
 		return "", errors.New("empty system ID")
 	}
 
-	// Map system ID to picture name
 	pictureName := mapSystemToPicture(systemID)
 	if pictureName == "" {
 		return "", fmt.Errorf("no picture mapping available for system: %s", systemID)
 	}
 
-	// Select variant (base or alternative)
+	return pm.getPictureByName(pictureName)
+}
+
+func (pm *PictureManager) getPictureByName(pictureName string) (string, error) {
+	if err := validatePictureName(pictureName); err != nil {
+		return "", err
+	}
+
 	selectedVariant := selectPictureVariant(pictureName)
-
 	log.Debug().
-		Str("system", systemID).
-		Str("mapped_picture", pictureName).
+		Str("picture", pictureName).
 		Str("selected_variant", selectedVariant).
-		Msg("mapped system to picture")
+		Msg("selected tty2oled picture")
 
-	// Ensure cache directory exists
 	if err := pm.ensureCacheDir(); err != nil {
 		return "", fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	// Try to find picture in order of preference
 	for _, format := range PictureFormats {
 		picturePath, err := pm.findPicture(selectedVariant, format)
 		if err == nil && picturePath != "" {
-			// Verify file exists and is readable
 			if _, err := os.Stat(picturePath); err == nil {
 				log.Debug().
-					Str("system", systemID).
+					Str("picture", pictureName).
 					Str("variant", selectedVariant).
 					Str("format", format).
 					Str("path", picturePath).
-					Msg("found picture for system")
+					Msg("found tty2oled picture")
 				return picturePath, nil
 			}
 		}
 	}
 
-	// No picture found, try to download
-	return pm.downloadPictureForSystem(selectedVariant)
+	return pm.downloadPictureByName(selectedVariant)
 }
 
 // FindPictureOnDisk checks if a picture is immediately available on disk without downloading
 func (pm *PictureManager) FindPictureOnDisk(systemID string) (string, bool) {
-	log.Debug().Str("system", systemID).Msg("FindPictureOnDisk: starting")
-
 	if systemID == "" {
 		return "", false
 	}
 
-	// Map system ID to picture name
-	log.Debug().Str("system", systemID).Msg("FindPictureOnDisk: mapping system to picture")
 	pictureName := mapSystemToPicture(systemID)
-	log.Debug().Str("system", systemID).Str("picture", pictureName).Msg("FindPictureOnDisk: mapped to picture")
 	if pictureName == "" {
 		log.Debug().Str("system", systemID).Msg("no picture mapping available for system")
 		return "", false
 	}
 
-	// Select variant (base or alternative) - same selection logic as GetPictureForSystem
-	log.Debug().Str("system", systemID).Str("picture", pictureName).Msg("FindPictureOnDisk: selecting variant")
-	selectedVariant := selectPictureVariant(pictureName)
-	log.Debug().
-		Str("system", systemID).
-		Str("selected_variant", selectedVariant).
-		Msg("FindPictureOnDisk: variant selected")
+	return pm.findPictureByNameOnDisk(pictureName)
+}
 
-	// Ensure cache directory exists
+func (pm *PictureManager) findPictureByNameOnDisk(pictureName string) (string, bool) {
+	if err := validatePictureName(pictureName); err != nil {
+		return "", false
+	}
+
+	selectedVariant := selectPictureVariant(pictureName)
 	if err := pm.ensureCacheDir(); err != nil {
 		return "", false
 	}
 
-	// Try to find picture in order of preference
 	for _, format := range PictureFormats {
 		picturePath, err := pm.findPicture(selectedVariant, format)
 		if err == nil && picturePath != "" {
-			// Verify file exists and is readable
 			if _, err := os.Stat(picturePath); err == nil {
 				log.Debug().
-					Str("system", systemID).
+					Str("picture", pictureName).
 					Str("variant", selectedVariant).
 					Str("format", format).
 					Str("path", picturePath).
-					Msg("found picture on disk for system")
+					Msg("found tty2oled picture on disk")
 				return picturePath, true
 			}
 		}
 	}
 
 	return "", false
+}
+
+func validatePictureName(pictureName string) error {
+	if pictureName == "" {
+		return errors.New("empty picture name")
+	}
+	if pictureName == "." || pictureName == ".." || strings.ContainsAny(pictureName, `/\\`) {
+		return fmt.Errorf("invalid picture name: %q", pictureName)
+	}
+	return nil
 }
 
 // findPicture looks for a picture file in the cache directory
@@ -171,9 +174,8 @@ func (pm *PictureManager) findPicture(pictureName, format string) (string, error
 	return "", fmt.Errorf("picture not found: %s in format %s", pictureName, format)
 }
 
-// downloadPictureForSystem attempts to download a picture for the given picture name
-// Note: systemID is now the already-mapped picture name (e.g., "AO486", "Genesis", etc.)
-func (pm *PictureManager) downloadPictureForSystem(pictureName string) (string, error) {
+// downloadPictureByName attempts to download a picture with the exact upstream name.
+func (pm *PictureManager) downloadPictureByName(pictureName string) (string, error) {
 	log.Info().Str("picture", pictureName).Msg("attempting to download picture")
 
 	var lastErr error

--- a/pkg/readers/tty2oled/pictures_test.go
+++ b/pkg/readers/tty2oled/pictures_test.go
@@ -1,0 +1,71 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tty2oled
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindPictureByNameOnDisk(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	formatDir := filepath.Join(cacheDir, "GSC")
+	require.NoError(t, os.MkdirAll(formatDir, 0o750))
+	picturePath := filepath.Join(formatDir, "bubbles.gsc")
+	require.NoError(t, os.WriteFile(picturePath, []byte("picture"), 0o600))
+	manager := &PictureManager{cacheDir: cacheDir}
+
+	got, found := manager.findPictureByNameOnDisk("bubbles")
+
+	assert.True(t, found)
+	assert.Equal(t, picturePath, got)
+}
+
+func TestFindArcadeFallbackOnDisk(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	formatDir := filepath.Join(cacheDir, "GSC")
+	require.NoError(t, os.MkdirAll(formatDir, 0o750))
+	picturePath := filepath.Join(formatDir, "Arcade.gsc")
+	require.NoError(t, os.WriteFile(picturePath, []byte("picture"), 0o600))
+	manager := &PictureManager{cacheDir: cacheDir}
+
+	got, found := manager.FindPictureOnDisk("Arcade")
+
+	assert.True(t, found)
+	assert.Equal(t, picturePath, got)
+}
+
+func TestPictureNameRejectsPaths(t *testing.T) {
+	t.Parallel()
+
+	manager := &PictureManager{cacheDir: t.TempDir()}
+
+	_, found := manager.findPictureByNameOnDisk(filepath.Join("..", "bubbles"))
+
+	assert.False(t, found)
+}

--- a/pkg/readers/tty2oled/pictures_test.go
+++ b/pkg/readers/tty2oled/pictures_test.go
@@ -55,8 +55,11 @@ func TestFindArcadeFallbackOnDisk(t *testing.T) {
 	manager := &PictureManager{cacheDir: cacheDir}
 
 	got, found := manager.FindPictureOnDisk("Arcade")
-
 	assert.True(t, found)
+	assert.Equal(t, picturePath, got)
+
+	got, err := manager.GetPictureForSystem("Arcade")
+	require.NoError(t, err)
 	assert.Equal(t, picturePath, got)
 }
 
@@ -65,7 +68,25 @@ func TestPictureNameRejectsPaths(t *testing.T) {
 
 	manager := &PictureManager{cacheDir: t.TempDir()}
 
-	_, found := manager.findPictureByNameOnDisk(filepath.Join("..", "bubbles"))
-
+	invalidName := filepath.Join("..", "bubbles")
+	_, found := manager.findPictureByNameOnDisk(invalidName)
 	assert.False(t, found)
+
+	_, err := manager.getPictureByName(invalidName)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid picture name")
+}
+
+func TestGetPictureForSystemRejectsEmptyOrUnmappedSystem(t *testing.T) {
+	t.Parallel()
+
+	manager := &PictureManager{cacheDir: t.TempDir()}
+
+	_, err := manager.GetPictureForSystem("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty system ID")
+
+	_, err = manager.GetPictureForSystem("UnknownSystem")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no picture mapping")
 }

--- a/pkg/readers/tty2oled/tty2oled.go
+++ b/pkg/readers/tty2oled/tty2oled.go
@@ -49,6 +49,10 @@ type MediaOperation struct {
 	timestamp time.Time
 }
 
+type pictureNameProvider interface {
+	TTY2OLEDPictureName(*models.ActiveMedia) string
+}
+
 // Reader represents a tty2oled display reader
 type Reader struct {
 	port                  serial.Port
@@ -727,6 +731,26 @@ func (r *Reader) clearDisplay() error {
 	return r.sendCommand(CmdClearShow)
 }
 
+func (r *Reader) pictureNamesForMedia(media *models.ActiveMedia) []string {
+	if media == nil {
+		return nil
+	}
+
+	pictureNames := make([]string, 0, 2)
+	if provider, ok := r.platform.(pictureNameProvider); ok {
+		if pictureName := strings.TrimSpace(provider.TTY2OLEDPictureName(media)); pictureName != "" {
+			pictureNames = append(pictureNames, pictureName)
+		}
+	}
+
+	mappedPicture := mapSystemToPicture(media.SystemID)
+	if mappedPicture != "" && (len(pictureNames) == 0 || pictureNames[0] != mappedPicture) {
+		pictureNames = append(pictureNames, mappedPicture)
+	}
+
+	return pictureNames
+}
+
 func (r *Reader) displayMedia(media *models.ActiveMedia) error {
 	if media == nil || media.SystemID == "" {
 		return r.clearDisplay()
@@ -745,46 +769,61 @@ func (r *Reader) displayMedia(media *models.ActiveMedia) error {
 		r.mu.Unlock()
 	}()
 
-	// Check if picture is immediately available on disk (no download delay)
-	log.Debug().Str("system", media.SystemID).Msg("displayMedia: checking picture manager")
 	if r.pictureManager == nil {
 		return errors.New("picture manager is nil")
 	}
 
-	log.Debug().Str("system", media.SystemID).Msg("displayMedia: calling FindPictureOnDisk")
-	picturePath, foundOnDisk := r.pictureManager.FindPictureOnDisk(media.SystemID)
-	if foundOnDisk {
-		log.Debug().
-			Str("system", media.SystemID).
-			Str("path", picturePath).
-			Msg("picture found on disk, replacing text with image")
-		return r.displayPicture(picturePath)
+	pictureNames := r.pictureNamesForMedia(media)
+	fallbackPath := ""
+	fallbackIndex := -1
+	for i, pictureName := range pictureNames {
+		picturePath, foundOnDisk := r.pictureManager.findPictureByNameOnDisk(pictureName)
+		if !foundOnDisk {
+			continue
+		}
+		if i == 0 {
+			log.Debug().
+				Str("system", media.SystemID).
+				Str("picture", pictureName).
+				Str("path", picturePath).
+				Msg("preferred picture found on disk")
+			return r.displayPicture(picturePath)
+		}
+		fallbackPath = picturePath
+		fallbackIndex = i
+		break
 	}
 
-	// Show text immediately for instant feedback
-	if err := r.displaySystemName(media.SystemID); err != nil {
+	if fallbackPath != "" {
+		if err := r.displayPicture(fallbackPath); err != nil {
+			return err
+		}
+	} else if err := r.displaySystemName(media.SystemID); err != nil {
 		return fmt.Errorf("failed to display system name: %w", err)
 	}
 
-	// Try to download picture if not on disk
-	log.Debug().
-		Str("system", media.SystemID).
-		Msg("picture not on disk, attempting download")
-
-	picturePath, err := r.pictureManager.GetPictureForSystem(media.SystemID)
-	if err != nil {
-		log.Info().
+	downloadCount := len(pictureNames)
+	if fallbackIndex >= 0 {
+		downloadCount = fallbackIndex
+	}
+	for _, pictureName := range pictureNames[:downloadCount] {
+		picturePath, err := r.pictureManager.getPictureByName(pictureName)
+		if err != nil {
+			continue
+		}
+		log.Debug().
 			Str("system", media.SystemID).
-			Msg("picture download failed, keeping text display")
-		return nil // Text is already showing, no error
+			Str("picture", pictureName).
+			Str("path", picturePath).
+			Msg("picture downloaded successfully, replacing fallback")
+		return r.displayPicture(picturePath)
 	}
 
-	// Picture downloaded successfully, replace text with image
-	log.Debug().
+	log.Info().
 		Str("system", media.SystemID).
-		Str("path", picturePath).
-		Msg("picture downloaded successfully, replacing text with image")
-	return r.displayPicture(picturePath)
+		Strs("pictures", pictureNames).
+		Msg("picture download failed, keeping fallback display")
+	return nil
 }
 
 // displaySystemName shows the system name as text on the display

--- a/pkg/readers/tty2oled/tty2oled_test.go
+++ b/pkg/readers/tty2oled/tty2oled_test.go
@@ -20,19 +20,86 @@
 package tty2oled
 
 import (
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.bug.st/serial"
 )
+
+type recordingSerialPort struct {
+	*testutils.MockSerialPort
+	writes [][]byte
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newRecordingSerialPort() *recordingSerialPort {
+	return &recordingSerialPort{MockSerialPort: testutils.NewMockSerialPort()}
+}
+
+func (*recordingSerialPort) SetMode(*serial.Mode) error {
+	return nil
+}
+
+func (p *recordingSerialPort) Write(data []byte) (int, error) {
+	p.writes = append(p.writes, append([]byte(nil), data...))
+	return len(data), nil
+}
+
+func (*recordingSerialPort) Drain() error {
+	return nil
+}
+
+func (*recordingSerialPort) ResetInputBuffer() error {
+	return nil
+}
+
+func (*recordingSerialPort) ResetOutputBuffer() error {
+	return nil
+}
+
+func (*recordingSerialPort) SetDTR(bool) error {
+	return nil
+}
+
+func (*recordingSerialPort) SetRTS(bool) error {
+	return nil
+}
+
+func (*recordingSerialPort) GetModemStatusBits() (*serial.ModemStatusBits, error) {
+	return &serial.ModemStatusBits{}, nil
+}
+
+func (*recordingSerialPort) Break(time.Duration) error {
+	return nil
+}
+
+func testPictureContent() string {
+	return "//\n//\nconst unsigned char bits[] = {\n" + strings.Repeat("0X00,", 2048) + "\n};\n"
+}
+
+func writeTestPicture(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(testPictureContent()), 0o600))
+}
 
 type pictureNameMockPlatform struct {
 	*mocks.MockPlatform
@@ -87,6 +154,98 @@ func TestPictureNamesForMediaWithoutPlatformOverride(t *testing.T) {
 	pictureNames := reader.pictureNamesForMedia(&models.ActiveMedia{SystemID: "NES"})
 
 	assert.Equal(t, []string{"NES"}, pictureNames)
+}
+
+func TestDisplayMediaUsesPreferredPictureOnDisk(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	picturePath := filepath.Join(cacheDir, "GSC", "bubbles.gsc")
+	writeTestPicture(t, picturePath)
+	port := newRecordingSerialPort()
+	reader := &Reader{
+		platform: &pictureNameMockPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			pictureName:  "bubbles",
+		},
+		pictureManager: &PictureManager{cacheDir: cacheDir},
+		port:           port,
+	}
+
+	err := reader.displayMedia(&models.ActiveMedia{SystemID: "Arcade", Name: "Bubbles"})
+
+	require.NoError(t, err)
+	require.Len(t, port.writes, 2)
+	assert.Equal(t, CmdCore+",bubbles,"+DefaultTransition+CommandTerminator, string(port.writes[0]))
+	assert.Len(t, port.writes[1], 2048)
+	assert.False(t, reader.operationInProgress)
+}
+
+func TestDisplayMediaKeepsGenericPictureWhenPreferredDownloadFails(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	picturePath := filepath.Join(cacheDir, "GSC", "Arcade.gsc")
+	writeTestPicture(t, picturePath)
+	port := newRecordingSerialPort()
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	reader := &Reader{
+		platform: &pictureNameMockPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			pictureName:  "bubbles",
+		},
+		pictureManager: &PictureManager{cacheDir: cacheDir, httpClient: client},
+		port:           port,
+	}
+
+	err := reader.displayMedia(&models.ActiveMedia{SystemID: "Arcade", Name: "Bubbles"})
+
+	require.NoError(t, err)
+	require.Len(t, port.writes, 2)
+	assert.Equal(t, CmdCore+",Arcade,"+DefaultTransition+CommandTerminator, string(port.writes[0]))
+	assert.Len(t, port.writes[1], 2048)
+}
+
+func TestDisplayMediaDownloadsPreferredPictureAfterTextFallback(t *testing.T) {
+	t.Parallel()
+
+	cacheDir := t.TempDir()
+	port := newRecordingSerialPort()
+	requestedPath := ""
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requestedPath = req.URL.Path
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(testPictureContent())),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})}
+	reader := &Reader{
+		platform: &pictureNameMockPlatform{
+			MockPlatform: mocks.NewMockPlatform(),
+			pictureName:  "bubbles",
+		},
+		pictureManager: &PictureManager{cacheDir: cacheDir, httpClient: client},
+		port:           port,
+	}
+
+	err := reader.displayMedia(&models.ActiveMedia{SystemID: "Arcade", Name: "Bubbles"})
+
+	require.NoError(t, err)
+	require.Len(t, port.writes, 4)
+	assert.Equal(t, CmdClearShow+CommandTerminator, string(port.writes[0]))
+	assert.Equal(t, "Arcade"+CommandTerminator, string(port.writes[1]))
+	assert.Equal(t, CmdCore+",bubbles,"+DefaultTransition+CommandTerminator, string(port.writes[2]))
+	assert.Len(t, port.writes[3], 2048)
+	assert.True(t, strings.HasSuffix(requestedPath, "/Pictures/GSC_US/bubbles.gsc"))
 }
 
 func TestMetadata(t *testing.T) {

--- a/pkg/readers/tty2oled/tty2oled_test.go
+++ b/pkg/readers/tty2oled/tty2oled_test.go
@@ -34,6 +34,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type pictureNameMockPlatform struct {
+	*mocks.MockPlatform
+	pictureName string
+}
+
+func (p *pictureNameMockPlatform) TTY2OLEDPictureName(*models.ActiveMedia) string {
+	return p.pictureName
+}
+
 func TestNewReader(t *testing.T) {
 	t.Parallel()
 
@@ -52,6 +61,32 @@ func TestNewReader(t *testing.T) {
 	assert.NotNil(t, reader.pictureManager)
 	assert.NotNil(t, reader.operationQueue)
 	assert.Equal(t, StateDisconnected, reader.stateManager.GetState())
+}
+
+func TestPictureNamesForMedia(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	reader := &Reader{
+		platform: &pictureNameMockPlatform{
+			MockPlatform: mockPlatform,
+			pictureName:  "bubbles",
+		},
+	}
+
+	pictureNames := reader.pictureNamesForMedia(&models.ActiveMedia{SystemID: "Arcade"})
+
+	assert.Equal(t, []string{"bubbles", "Arcade"}, pictureNames)
+}
+
+func TestPictureNamesForMediaWithoutPlatformOverride(t *testing.T) {
+	t.Parallel()
+
+	reader := &Reader{}
+
+	pictureNames := reader.pictureNamesForMedia(&models.ActiveMedia{SystemID: "NES"})
+
+	assert.Equal(t, []string{"NES"}, pictureNames)
 }
 
 func TestMetadata(t *testing.T) {

--- a/pkg/readers/tty2oled/tty2oled_test.go
+++ b/pkg/readers/tty2oled/tty2oled_test.go
@@ -188,7 +188,11 @@ func TestDisplayMediaKeepsGenericPictureWhenPreferredDownloadFails(t *testing.T)
 	picturePath := filepath.Join(cacheDir, "GSC", "Arcade.gsc")
 	writeTestPicture(t, picturePath)
 	port := newRecordingSerialPort()
+	requestedPath := ""
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if requestedPath == "" {
+			requestedPath = req.URL.Path
+		}
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
 			Body:       io.NopCloser(strings.NewReader("")),
@@ -208,6 +212,7 @@ func TestDisplayMediaKeepsGenericPictureWhenPreferredDownloadFails(t *testing.T)
 	err := reader.displayMedia(&models.ActiveMedia{SystemID: "Arcade", Name: "Bubbles"})
 
 	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(requestedPath, "/Pictures/GSC_US/bubbles.gsc"))
 	require.Len(t, port.writes, 2)
 	assert.Equal(t, CmdCore+",Arcade,"+DefaultTransition+CommandTerminator, string(port.writes[0]))
 	assert.Len(t, port.writes[1], 2048)


### PR DESCRIPTION
## Summary
- resolve MiSTer arcade tty2oled pictures from tracked core and MRA setnames
- prefer upstream per-core artwork while retaining generic Arcade and text fallbacks
- validate direct picture names and add regression coverage for both launch paths

Closes #1171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Arcade artwork support for MiSTer media, including artwork identified from arcade set metadata.
  * Media can now use platform-specific artwork names, with system-based fallback when unavailable.
  * Added local artwork lookup and download support for named pictures.
  * Added validation to reject invalid artwork paths.

* **Bug Fixes**
  * Preserved fallback artwork display when downloads fail.
  * Improved handling of missing, unsupported, or invalid media metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->