### PR TITLE
fix(audio): preserve native playlist playback state

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -415,8 +415,9 @@ None.
 | systemName       | string   | Yes      | Display name of the system.                |
 | mediaPath        | string   | Yes      | Path to the media file.                    |
 | relativePath     | string   | No       | Launcher-relative convenience path, when it can be derived. Not a stable media identity. |
-| positionMs       | number   | No       | Current playback position in milliseconds for native audio media. |
-| durationMs       | number   | No       | Total playback duration in milliseconds for native audio media. |
+| positionMs       | number   | No       | Current playback position in milliseconds when reported by the launcher. Currently available for native audio. |
+| durationMs       | number   | No       | Total playback duration in milliseconds when reported by the launcher. Currently available for native audio. |
+| playbackState    | string   | No       | Launcher-reported playback state: `playing`, `paused`, or `stopped`. Currently available for native audio; omitted when unavailable. |
 | mediaName        | string   | Yes      | Display name of the media.                 |
 | slot             | string   | No       | Media slot for the item. Omitted or `primary` is foreground media; `background` is background audio. |
 | started          | string   | Yes      | Timestamp when media started in RFC3339 format. |

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -1097,7 +1097,7 @@ func HandleMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 			Slot:             mediaslot.Primary,
 			LauncherControls: activeMedia.LauncherControls,
 		}
-		enrichPlaybackPosition(&env, &primaryEntry, mediaslot.Primary)
+		enrichPlaybackState(&env, &primaryEntry, mediaslot.Primary)
 		resp.Active = append(resp.Active, models.ActiveMediaResponse{
 			ActiveMedia: primaryEntry,
 			ZapScript:   zapScript,
@@ -1117,7 +1117,7 @@ func HandleMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 			Slot:             mediaslot.Background,
 			LauncherControls: backgroundMedia.LauncherControls,
 		}
-		enrichPlaybackPosition(&env, &bgEntry, mediaslot.Background)
+		enrichPlaybackState(&env, &bgEntry, mediaslot.Background)
 		resp.Active = append(resp.Active, models.ActiveMediaResponse{
 			ActiveMedia: bgEntry,
 			ZapScript:   database.BuildTitleZapScript(backgroundMedia.SystemID, backgroundMedia.Name, nil),
@@ -1328,7 +1328,7 @@ func HandleActiveMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		entry.MediaID = mediaIDs[ref]
 	}
 
-	enrichPlaybackPosition(&env, &entry, slot)
+	enrichPlaybackState(&env, &entry, slot)
 
 	return models.ActiveMediaResponse{
 		ActiveMedia: entry,

--- a/pkg/api/methods/media_active_test.go
+++ b/pkg/api/methods/media_active_test.go
@@ -479,6 +479,10 @@ func TestHandleMedia_WithBackgroundMedia(t *testing.T) {
 	relPath := "music/song.mp3"
 	background.RelPath = &relPath
 	st.SetBackgroundMedia(background)
+	st.SetBackgroundPlaylist(&playlists.Playlist{
+		Slot:    mediaslot.Background,
+		Playing: true,
+	})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetOptimizationStatus").Return("", nil)
@@ -490,6 +494,11 @@ func TestHandleMedia_WithBackgroundMedia(t *testing.T) {
 		Context:  context.Background(),
 		State:    st,
 		Database: &database.Database{MediaDB: mockMediaDB},
+		PlaybackManager: newStubPlaybackManager(mediaslot.Background, audio.PlaybackState{
+			Position: 20 * time.Second,
+			Duration: 3 * time.Minute,
+			Paused:   true,
+		}),
 	}
 
 	result, err := HandleMedia(env)
@@ -504,6 +513,9 @@ func TestHandleMedia_WithBackgroundMedia(t *testing.T) {
 	assert.Equal(t, "song.mp3", resp.Active[0].Path)
 	assert.Equal(t, "Song", resp.Active[0].Name)
 	assert.Equal(t, "@Audio/Song", resp.Active[0].ZapScript)
+	assert.Equal(t, models.MediaPlaybackStatePaused, resp.Active[0].PlaybackState)
+	require.Len(t, resp.Playlists, 1)
+	assert.True(t, resp.Playlists[0].Playing, "playlist scheduler remains active while audio is auto-paused")
 
 	mockMediaDB.AssertExpectations(t)
 }
@@ -563,6 +575,9 @@ func TestHandleActiveMedia_BackgroundSlotParam(t *testing.T) {
 		State:    st,
 		Database: &database.Database{MediaDB: helpers.NewMockMediaDBI()},
 		Params:   json.RawMessage(params),
+		PlaybackManager: newStubPlaybackManager(mediaslot.Background, audio.PlaybackState{
+			Paused: true,
+		}),
 	}
 
 	result, err := HandleActiveMedia(env)
@@ -574,6 +589,7 @@ func TestHandleActiveMedia_BackgroundSlotParam(t *testing.T) {
 	assert.Equal(t, mediaslot.Background, resp.Slot)
 	assert.Equal(t, "song.mp3", resp.Path)
 	assert.Equal(t, "Song", resp.Name)
+	assert.Equal(t, models.MediaPlaybackStatePaused, resp.PlaybackState)
 }
 
 // TestHandleActiveMedia_BackgroundSlotReturnsNilWhenNoneActive verifies that
@@ -600,9 +616,9 @@ func TestHandleActiveMedia_BackgroundSlotReturnsNilWhenNoneActive(t *testing.T) 
 	assert.Nil(t, result)
 }
 
-// TestHandleActiveMedia_NativeAudioCarriesPosition verifies that
-// positionMs/durationMs are populated for native-audio entries.
-func TestHandleActiveMedia_NativeAudioCarriesPosition(t *testing.T) {
+// TestHandleActiveMedia_NativeAudioCarriesPlaybackState verifies that
+// playback details are populated for native-audio entries.
+func TestHandleActiveMedia_NativeAudioCarriesPlaybackState(t *testing.T) {
 	t.Parallel()
 
 	pl := mocks.NewMockPlatform()
@@ -616,6 +632,7 @@ func TestHandleActiveMedia_NativeAudioCarriesPosition(t *testing.T) {
 	mgr := newStubPlaybackManager(mediaslot.Primary, audio.PlaybackState{
 		Position: 30 * time.Second,
 		Duration: 3 * time.Minute,
+		Playing:  true,
 	})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
@@ -641,11 +658,12 @@ func TestHandleActiveMedia_NativeAudioCarriesPosition(t *testing.T) {
 	require.NotNil(t, resp.DurationMs)
 	assert.Equal(t, (30 * time.Second).Milliseconds(), *resp.PositionMs)
 	assert.Equal(t, (3 * time.Minute).Milliseconds(), *resp.DurationMs)
+	assert.Equal(t, models.MediaPlaybackStatePlaying, resp.PlaybackState)
 }
 
-// TestHandleActiveMedia_NonNativeLauncherOmitsPosition verifies that
-// positionMs/durationMs are absent for non-native-audio launchers.
-func TestHandleActiveMedia_NonNativeLauncherOmitsPosition(t *testing.T) {
+// TestHandleActiveMedia_NonNativeLauncherOmitsPlaybackState verifies that
+// playback details are absent for non-native-audio launchers.
+func TestHandleActiveMedia_NonNativeLauncherOmitsPlaybackState(t *testing.T) {
 	t.Parallel()
 
 	pl := mocks.NewMockPlatform()
@@ -683,6 +701,7 @@ func TestHandleActiveMedia_NonNativeLauncherOmitsPosition(t *testing.T) {
 	require.True(t, ok)
 	assert.Nil(t, resp.PositionMs, "non-native-audio launcher must not expose position")
 	assert.Nil(t, resp.DurationMs, "non-native-audio launcher must not expose duration")
+	assert.Empty(t, resp.PlaybackState, "non-native-audio launcher must not expose playback state")
 }
 
 // TestHandleMedia_PlaylistsIncludedInResponse verifies that active playlists for
@@ -788,9 +807,9 @@ func TestHandleMedia_EmptyPlaylistsOmittedFromResponse(t *testing.T) {
 	assert.Empty(t, resp.Playlists)
 }
 
-// TestHandleMedia_NativeAudioActiveEntryCarriesPosition verifies that the active[]
-// entry for native-audio primary media includes positionMs/durationMs.
-func TestHandleMedia_NativeAudioActiveEntryCarriesPosition(t *testing.T) {
+// TestHandleMedia_NativeAudioActiveEntryCarriesPlaybackState verifies that the active[]
+// entry for native-audio primary media includes playback details.
+func TestHandleMedia_NativeAudioActiveEntryCarriesPlaybackState(t *testing.T) {
 	t.Parallel()
 
 	pl := mocks.NewMockPlatform()
@@ -804,6 +823,7 @@ func TestHandleMedia_NativeAudioActiveEntryCarriesPosition(t *testing.T) {
 	mgr := newStubPlaybackManager(mediaslot.Primary, audio.PlaybackState{
 		Position: 15 * time.Second,
 		Duration: 4 * time.Minute,
+		Playing:  true,
 	})
 
 	mockMediaDB := helpers.NewMockMediaDBI()
@@ -833,6 +853,7 @@ func TestHandleMedia_NativeAudioActiveEntryCarriesPosition(t *testing.T) {
 	require.NotNil(t, resp.Active[0].DurationMs)
 	assert.Equal(t, (15 * time.Second).Milliseconds(), *resp.Active[0].PositionMs)
 	assert.Equal(t, (4 * time.Minute).Milliseconds(), *resp.Active[0].DurationMs)
+	assert.Equal(t, models.MediaPlaybackStatePlaying, resp.Active[0].PlaybackState)
 }
 
 func TestHandleUpdateActiveMedia_ClearMedia(t *testing.T) {

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -68,10 +68,10 @@ func optionalDBEnrichmentContext(parent context.Context) (context.Context, conte
 	return context.WithTimeout(parent, optionalDBEnrichmentTimeout)
 }
 
-// enrichPlaybackPosition fills PositionMs and DurationMs on an ActiveMedia entry
-// when the entry belongs to the native-audio launcher and a PlaybackManager is available.
-// slot is the normalized slot string ("primary" or "background").
-func enrichPlaybackPosition(env *requests.RequestEnv, entry *models.ActiveMedia, slot string) {
+// enrichPlaybackState fills playback details on an ActiveMedia entry when the entry
+// belongs to the native-audio launcher and a PlaybackManager is available. slot is
+// the normalized slot string ("primary" or "background").
+func enrichPlaybackState(env *requests.RequestEnv, entry *models.ActiveMedia, slot string) {
 	if env.PlaybackManager == nil {
 		return
 	}
@@ -83,6 +83,14 @@ func enrichPlaybackPosition(env *requests.RequestEnv, entry *models.ActiveMedia,
 	durMs := state.Duration.Milliseconds()
 	entry.PositionMs = &posMs
 	entry.DurationMs = &durMs
+	switch {
+	case state.Paused:
+		entry.PlaybackState = models.MediaPlaybackStatePaused
+	case state.Playing:
+		entry.PlaybackState = models.MediaPlaybackStatePlaying
+	default:
+		entry.PlaybackState = models.MediaPlaybackStateStopped
+	}
 }
 
 // toPlaylistState converts the internal Playlist representation to the API model.

--- a/pkg/api/methods/media_response_helpers_test.go
+++ b/pkg/api/methods/media_response_helpers_test.go
@@ -140,62 +140,88 @@ func TestToPlaylistState_EmptyItems(t *testing.T) {
 	assert.Equal(t, 0, state.Total)
 }
 
-// ----- enrichPlaybackPosition tests -----
+// ----- enrichPlaybackState tests -----
 
-func TestEnrichPlaybackPosition_NilManagerLeavesFieldsNil(t *testing.T) {
+func TestEnrichPlaybackState_NilManagerLeavesFieldsNil(t *testing.T) {
 	t.Parallel()
 	env := &requests.RequestEnv{PlaybackManager: nil}
 	entry := &models.ActiveMedia{LauncherID: platforms.NativeAudioLauncherID}
-	enrichPlaybackPosition(env, entry, mediaslot.Primary)
+	enrichPlaybackState(env, entry, mediaslot.Primary)
 	assert.Nil(t, entry.PositionMs)
 	assert.Nil(t, entry.DurationMs)
+	assert.Empty(t, entry.PlaybackState)
 }
 
-func TestEnrichPlaybackPosition_NonNativeLauncherLeavesFieldsNil(t *testing.T) {
+func TestEnrichPlaybackState_NonNativeLauncherLeavesFieldsNil(t *testing.T) {
 	t.Parallel()
 	mgr := newStubPlaybackManager(mediaslot.Primary, audio.PlaybackState{
 		Position: 30 * time.Second,
 		Duration: 3 * time.Minute,
+		Playing:  true,
 	})
 	env := &requests.RequestEnv{PlaybackManager: mgr}
 	entry := &models.ActiveMedia{LauncherID: "mister"}
-	enrichPlaybackPosition(env, entry, mediaslot.Primary)
+	enrichPlaybackState(env, entry, mediaslot.Primary)
 	assert.Nil(t, entry.PositionMs)
 	assert.Nil(t, entry.DurationMs)
+	assert.Empty(t, entry.PlaybackState)
 }
 
-func TestEnrichPlaybackPosition_NativeAudioFillsPositionAndDuration(t *testing.T) {
+func TestEnrichPlaybackState_NativeAudioFillsPlayingState(t *testing.T) {
 	t.Parallel()
 	pos := 45 * time.Second
 	dur := 3 * time.Minute
 	mgr := newStubPlaybackManager(mediaslot.Primary, audio.PlaybackState{
 		Position: pos,
 		Duration: dur,
+		Playing:  true,
 	})
 	env := &requests.RequestEnv{PlaybackManager: mgr}
 	entry := &models.ActiveMedia{LauncherID: platforms.NativeAudioLauncherID}
-	enrichPlaybackPosition(env, entry, mediaslot.Primary)
+	enrichPlaybackState(env, entry, mediaslot.Primary)
 	require.NotNil(t, entry.PositionMs)
 	require.NotNil(t, entry.DurationMs)
 	assert.Equal(t, pos.Milliseconds(), *entry.PositionMs)
 	assert.Equal(t, dur.Milliseconds(), *entry.DurationMs)
+	assert.Equal(t, models.MediaPlaybackStatePlaying, entry.PlaybackState)
 }
 
-func TestEnrichPlaybackPosition_BackgroundSlotUsesBackgroundState(t *testing.T) {
+func TestEnrichPlaybackState_BackgroundSlotUsesPausedState(t *testing.T) {
 	t.Parallel()
 	bgPos := 10 * time.Second
 	bgDur := 2 * time.Minute
 	mgr := &stubPlaybackManager{states: map[string]audio.PlaybackState{
-		mediaslot.Primary:    {Position: 999 * time.Second, Duration: 999 * time.Second},
-		mediaslot.Background: {Position: bgPos, Duration: bgDur},
+		mediaslot.Primary: {
+			Position: 999 * time.Second,
+			Duration: 999 * time.Second,
+			Playing:  true,
+		},
+		mediaslot.Background: {
+			Position: bgPos,
+			Duration: bgDur,
+			Paused:   true,
+		},
 	}}
 	env := &requests.RequestEnv{PlaybackManager: mgr}
 	entry := &models.ActiveMedia{LauncherID: platforms.NativeAudioLauncherID}
-	enrichPlaybackPosition(env, entry, mediaslot.Background)
+	enrichPlaybackState(env, entry, mediaslot.Background)
 	require.NotNil(t, entry.PositionMs)
 	require.NotNil(t, entry.DurationMs)
 	assert.Equal(t, bgPos.Milliseconds(), *entry.PositionMs)
 	assert.Equal(t, bgDur.Milliseconds(), *entry.DurationMs)
+	assert.Equal(t, models.MediaPlaybackStatePaused, entry.PlaybackState)
+}
+
+func TestEnrichPlaybackState_StoppedState(t *testing.T) {
+	t.Parallel()
+
+	mgr := newStubPlaybackManager(mediaslot.Primary, audio.PlaybackState{})
+	env := &requests.RequestEnv{PlaybackManager: mgr}
+	entry := &models.ActiveMedia{LauncherID: platforms.NativeAudioLauncherID}
+
+	enrichPlaybackState(env, entry, mediaslot.Primary)
+
+	assert.Equal(t, models.MediaPlaybackStateStopped, entry.PlaybackState)
 }
 
 func TestMediaIDsByPath_IgnoresRowsForUnrequestedSystems(t *testing.T) {

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -453,19 +453,28 @@ type ScrapersResponse struct {
 	Scrapers []ScraperInfo `json:"scrapers"`
 }
 
+type MediaPlaybackState string
+
+const (
+	MediaPlaybackStatePlaying MediaPlaybackState = "playing"
+	MediaPlaybackStatePaused  MediaPlaybackState = "paused"
+	MediaPlaybackStateStopped MediaPlaybackState = "stopped"
+)
+
 type ActiveMedia struct {
-	Started          time.Time `json:"started"`
-	RelPath          *string   `json:"relativePath,omitempty"`
-	PositionMs       *int64    `json:"positionMs,omitempty"`
-	DurationMs       *int64    `json:"durationMs,omitempty"`
-	LauncherID       string    `json:"launcherId"`
-	SystemID         string    `json:"systemId"`
-	SystemName       string    `json:"systemName"`
-	Path             string    `json:"mediaPath"`
-	Name             string    `json:"mediaName"`
-	Slot             string    `json:"slot,omitempty"`
-	LauncherControls []string  `json:"launcherControls,omitempty"`
-	MediaID          int64     `json:"mediaId,omitempty"`
+	Started          time.Time          `json:"started"`
+	RelPath          *string            `json:"relativePath,omitempty"`
+	PositionMs       *int64             `json:"positionMs,omitempty"`
+	DurationMs       *int64             `json:"durationMs,omitempty"`
+	PlaybackState    MediaPlaybackState `json:"playbackState,omitempty"`
+	LauncherID       string             `json:"launcherId"`
+	SystemID         string             `json:"systemId"`
+	SystemName       string             `json:"systemName"`
+	Path             string             `json:"mediaPath"`
+	Name             string             `json:"mediaName"`
+	Slot             string             `json:"slot,omitempty"`
+	LauncherControls []string           `json:"launcherControls,omitempty"`
+	MediaID          int64              `json:"mediaId,omitempty"`
 }
 
 // NewActiveMedia creates a new ActiveMedia with the current timestamp.

--- a/pkg/api/models/responses_test.go
+++ b/pkg/api/models/responses_test.go
@@ -236,6 +236,23 @@ func TestActiveMedia_Equal(t *testing.T) {
 	}
 }
 
+func TestActiveMedia_PlaybackStateJSON(t *testing.T) {
+	t.Parallel()
+
+	raw, err := json.Marshal(ActiveMedia{PlaybackState: MediaPlaybackStatePaused})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, "paused", got["playbackState"])
+
+	raw, err = json.Marshal(ActiveMedia{})
+	require.NoError(t, err)
+	got = nil
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.NotContains(t, got, "playbackState")
+}
+
 // TestPairedClient_JSONShape pins the wire shape of the PairedClient
 // type returned by the `clients` RPC method. This test exists to catch a
 // future regression where someone embeds *database.Client (which contains

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -321,8 +321,7 @@ func stopNativePlaybackBeforePrimaryCommand(
 		return nil
 	}
 	stopsPrimaryMedia := cmd.Name == gozapscript.ZapScriptCmdStop ||
-		cmd.Name == gozapscript.ZapScriptCmdPlaylistStop ||
-		cmd.Name == gozapscript.ZapScriptCmdPlaylistPause
+		cmd.Name == gozapscript.ZapScriptCmdPlaylistStop
 	if !zapscript.IsMediaLaunchingCommand(cmd.Name) && !stopsPrimaryMedia {
 		return nil
 	}
@@ -534,12 +533,14 @@ func handlePlaylist(
 			svc.State.SetActivePlaylist(pls)
 		}
 		if pls.Playing {
-			if slot == mediaslot.Background && !activePlaylist.Playing && pls.Current() == activePlaylist.Current() &&
-				svc.PlaybackManager != nil && svc.PlaybackManager.State(mediaslot.Background).Path != "" {
-				log.Info().Any("pls", playlistForLog(pls)).Msg("resuming background playlist playback")
-				svc.State.SetBackgroundAutoPaused(false)
-				if err := svc.PlaybackManager.Resume(mediaslot.Background); err != nil {
-					log.Warn().Err(err).Msg("failed to resume background playlist playback")
+			if !activePlaylist.Playing && pls.Current() == activePlaylist.Current() &&
+				svc.PlaybackManager != nil && svc.PlaybackManager.State(slot).Path != "" {
+				log.Info().Any("pls", playlistForLog(pls)).Str("slot", slot).Msg("resuming playlist playback")
+				if slot == mediaslot.Background {
+					svc.State.SetBackgroundAutoPaused(false)
+				}
+				if err := svc.PlaybackManager.Resume(slot); err != nil {
+					log.Warn().Err(err).Str("slot", slot).Msg("failed to resume playlist playback")
 				}
 				return
 			}
@@ -557,9 +558,9 @@ func handlePlaylist(
 				launchPlaylistMedia(svc, pls, player)
 			}()
 		} else {
-			if slot == mediaslot.Background && svc.PlaybackManager != nil {
-				if err := svc.PlaybackManager.Pause(mediaslot.Background); err != nil {
-					log.Warn().Err(err).Msg("failed to pause background playlist playback")
+			if svc.PlaybackManager != nil && svc.PlaybackManager.State(slot).Path != "" {
+				if err := svc.PlaybackManager.Pause(slot); err != nil {
+					log.Warn().Err(err).Str("slot", slot).Msg("failed to pause playlist playback")
 				}
 			}
 			log.Info().Any("pls", playlistForLog(pls)).Msg("updating playlist")

--- a/pkg/service/queues_playlist_test.go
+++ b/pkg/service/queues_playlist_test.go
@@ -301,7 +301,9 @@ func TestHandlePlaylist_BackgroundPausePausesPlayback(t *testing.T) {
 	t.Parallel()
 
 	svc := setupPlaylistTestEnv(t)
-	recorder := &servicePlaybackRecorder{}
+	recorder := &servicePlaybackRecorder{states: map[string]audio.PlaybackState{
+		mediaslot.Background: {Path: "track.mp3", Playing: true},
+	}}
 	svc.PlaybackManager = recorder
 	background := makeServicePlaylist()
 	background.Slot = mediaslot.Background
@@ -313,6 +315,25 @@ func TestHandlePlaylist_BackgroundPausePausesPlayback(t *testing.T) {
 
 	assert.Equal(t, []string{mediaslot.Background}, recorder.paused)
 	assert.False(t, svc.State.GetBackgroundPlaylist().Playing)
+}
+
+func TestHandlePlaylist_PrimaryPausePausesPlayback(t *testing.T) {
+	t.Parallel()
+
+	svc := setupPlaylistTestEnv(t)
+	recorder := &servicePlaybackRecorder{states: map[string]audio.PlaybackState{
+		mediaslot.Primary: {Path: "track.mp3", Playing: true},
+	}}
+	svc.PlaybackManager = recorder
+	primary := makeServicePlaylist()
+	primary.Playing = true
+	svc.State.SetActivePlaylist(primary)
+
+	paused := playlists.Pause(*primary)
+	handlePlaylist(svc, paused, nil)
+
+	assert.Equal(t, []string{mediaslot.Primary}, recorder.paused)
+	assert.False(t, svc.State.GetActivePlaylist().Playing)
 }
 
 func TestHandlePlaylist_BackgroundPlayResumesPausedPlayback(t *testing.T) {
@@ -334,6 +355,26 @@ func TestHandlePlaylist_BackgroundPlayResumesPausedPlayback(t *testing.T) {
 	assert.Equal(t, []string{mediaslot.Background}, recorder.resumed)
 	assert.Empty(t, recorder.played)
 	assert.True(t, svc.State.GetBackgroundPlaylist().Playing)
+}
+
+func TestHandlePlaylist_PrimaryPlayResumesPausedPlayback(t *testing.T) {
+	t.Parallel()
+
+	svc := setupPlaylistTestEnv(t)
+	recorder := &servicePlaybackRecorder{states: map[string]audio.PlaybackState{
+		mediaslot.Primary: {Path: "track.mp3", Paused: true},
+	}}
+	svc.PlaybackManager = recorder
+	primary := makeServicePlaylist()
+	primary.Playing = false
+	svc.State.SetActivePlaylist(primary)
+
+	playing := playlists.Play(*primary)
+	handlePlaylist(svc, playing, nil)
+
+	assert.Equal(t, []string{mediaslot.Primary}, recorder.resumed)
+	assert.Empty(t, recorder.played)
+	assert.True(t, svc.State.GetActivePlaylist().Playing)
 }
 
 func TestHandlePlaylist_BackgroundPlayRelaunchesWhenNoPlaybackSource(t *testing.T) {
@@ -371,6 +412,25 @@ func TestStopNativePlaybackBeforePrimaryCommandStopsAndClearsPrimaryNativeAudio(
 	require.NoError(t, err)
 	assert.Equal(t, []string{mediaslot.Primary}, recorder.stopped)
 	assert.Nil(t, svc.State.ActiveMedia())
+}
+
+func TestStopNativePlaybackBeforePrimaryCommandPreservesPrimaryPlaylistPause(t *testing.T) {
+	t.Parallel()
+
+	svc := setupPlaylistTestEnv(t)
+	recorder := &servicePlaybackRecorder{}
+	svc.PlaybackManager = recorder
+	svc.State.SetActiveMedia(models.NewActiveMedia(
+		"Audio", "Audio", "track.mp3", "Track", platforms.NativeAudioLauncherID,
+	))
+
+	err := stopNativePlaybackBeforePrimaryCommand(svc, gozapscript.Command{
+		Name: gozapscript.ZapScriptCmdPlaylistPause,
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Empty(t, recorder.stopped)
+	assert.NotNil(t, svc.State.ActiveMedia())
 }
 
 func TestStopNativePlaybackBeforePrimaryCommandStopsPrimaryPlaylistStop(t *testing.T) {

--- a/pkg/zapscript/playlist.go
+++ b/pkg/zapscript/playlist.go
@@ -796,7 +796,8 @@ func cmdPlaylistPause(pl platforms.Platform, env platforms.CmdEnv) (platforms.Cm
 		return platforms.CmdResult{}, err
 	}
 
-	if slot == mediaslot.Background {
+	if slot == mediaslot.Background ||
+		(env.PlaybackManager != nil && env.PlaybackManager.State(slot).Path != "") {
 		return platforms.CmdResult{
 			PlaylistChanged: true,
 			Playlist:        pls,

--- a/pkg/zapscript/playlist_test.go
+++ b/pkg/zapscript/playlist_test.go
@@ -999,6 +999,46 @@ func TestCmdPlaylistPause_BackgroundSlot(t *testing.T) {
 	<-queue
 }
 
+func TestCmdPlaylistPause_PrimaryNativeAudioPreservesLauncher(t *testing.T) {
+	t.Parallel()
+
+	// StopActiveLauncher is NOT mocked — a call to it would panic the test.
+	mp := newPlaylistTestPlatform()
+	playback := &playlistPlaybackStub{state: audio.PlaybackState{
+		Path:    "track.mp3",
+		Playing: true,
+	}}
+	pls, queue := makePlaylistEnv()
+	pls.Playing = true
+
+	result, err := cmdPlaylistPause(mp, platforms.CmdEnv{
+		PlaybackManager: playback,
+		Playlist:        playlists.PlaylistController{Active: pls, Queue: queue},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.PlaylistChanged)
+	require.NotNil(t, result.Playlist)
+	assert.False(t, result.Playlist.Playing)
+	<-queue
+}
+
+func TestCmdPlaylistPause_PrimaryNonAudioStopsLauncher(t *testing.T) {
+	t.Parallel()
+
+	mp := newPlaylistTestPlatform()
+	mp.On("StopActiveLauncher", platforms.StopForMenu).Return(nil).Once()
+	pls, queue := makePlaylistEnv()
+	pls.Playing = true
+
+	result, err := cmdPlaylistPause(mp, platforms.CmdEnv{
+		Playlist: playlists.PlaylistController{Active: pls, Queue: queue},
+	})
+	require.NoError(t, err)
+	assert.True(t, result.PlaylistChanged)
+	<-queue
+	mp.AssertExpectations(t)
+}
+
 // initTestLauncherCache seeds GlobalLauncherCache with a launcher that accepts
 // the given extensions (no folder restriction) and cleans up after the test.
 // Call from non-parallel tests only, since the cache is global.


### PR DESCRIPTION
## Summary

- pause and resume primary native-audio playlists without relaunching the current track
- expose launcher-reported `playbackState` for native audio in `media` and `media.active` responses
- keep playlist scheduler state distinct from slot playback state and document the API fields

Closes #1172
Closes #1173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active media responses now report playback state as playing, paused, or stopped when supported.
  * Playback timing information remains available alongside the new state.
* **Bug Fixes**
  * Pausing playlists now preserves active native audio instead of stopping and clearing it.
  * Playlist pause and resume behavior now works consistently for primary and background playback.
* **Documentation**
  * Updated API documentation to describe playback state and launcher-reported timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->