### PR TITLE
fix(database): rebuild incomplete startup slug cache

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -914,10 +914,11 @@ type MediaDBI interface {
 	NoteCorruption(err error) bool
 	Recreate(keepBackup bool) error
 
-	// On-disk persistence for the rebuilt caches. Persist* writes the
-	// current in-memory cache atomically; LoadCached* reads it back at
-	// startup and returns (false, nil) on missing/stale/version-mismatch
-	// so the caller can fall through to a SQL rebuild.
+	// On-disk persistence for rebuilt caches. Persist* writes the current
+	// in-memory cache atomically; LoadCached* reads it back at startup and
+	// returns (false, nil) when a SQL rebuild is still required. A valid
+	// selective slug cache may be installed while returning false so covered
+	// systems remain searchable during the complete rebuild.
 	PersistTagCache() error
 	LoadCachedTagCache() (bool, error)
 	PersistSlugSearchCache() error

--- a/pkg/database/mediadb/slug_search_cache_persist.go
+++ b/pkg/database/mediadb/slug_search_cache_persist.go
@@ -94,9 +94,11 @@ func (db *MediaDB) slugSearchCachePath() string {
 // LoadCachedSlugSearchCache reads the persisted slug search cache from disk
 // and installs it into the atomic pointer. Verifies magic, version, and
 // index generation against the live DB before accepting the file. Returns
-// (false, nil) when the file is missing or stale, so the caller can fall
-// back to a SQL rebuild; (true, nil) when a usable cache was loaded;
-// (false, err) on unrecoverable I/O or decode errors.
+// (false, nil) when the file is missing, stale, or only covers selected
+// systems, so the caller can build a complete cache; (true, nil) when a
+// complete cache was loaded; (false, err) on unrecoverable I/O or decode
+// errors. A valid selective cache is still installed so its covered systems
+// remain searchable while the complete cache is built.
 func (db *MediaDB) LoadCachedSlugSearchCache() (bool, error) {
 	path := db.slugSearchCachePath()
 	if path == "" {
@@ -143,9 +145,10 @@ func (db *MediaDB) LoadCachedSlugSearchCache() (bool, error) {
 		Int("entries", cache.entryCount).
 		Int("systems", len(cache.systemRanges)).
 		Int64("generation", gen).
+		Bool("complete", cache.complete).
 		Str("path", path).
 		Msg("slug search cache loaded from disk")
-	return true, nil
+	return cache.complete, nil
 }
 
 // PersistSlugSearchCache writes the current in-memory slug search cache to

--- a/pkg/database/mediadb/slug_search_cache_persist_test.go
+++ b/pkg/database/mediadb/slug_search_cache_persist_test.go
@@ -110,6 +110,31 @@ func TestPersistAndLoadSlugSearchCache_RoundTrip(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestLoadCachedSlugSearchCache_IncompleteCacheRequestsRebuild(t *testing.T) {
+	t.Parallel()
+	mediaDB, mock, _ := newPersistTestDB(t)
+
+	selective := fakeSlugCache()
+	selective.complete = false
+	mediaDB.slugSearchCache.Store(selective)
+
+	expectIndexGenerationReadOnce(t, mock, 42)
+	require.NoError(t, mediaDB.PersistSlugSearchCache())
+
+	mediaDB.slugSearchCache.Store(nil)
+
+	expectIndexGenerationReadOnce(t, mock, 42)
+	complete, err := mediaDB.LoadCachedSlugSearchCache()
+	require.NoError(t, err)
+	assert.False(t, complete, "selective cache should request a complete startup rebuild")
+
+	loaded := mediaDB.slugSearchCache.Load()
+	require.NotNil(t, loaded, "selective cache should remain available during the rebuild")
+	assert.False(t, loaded.complete)
+	assert.True(t, loaded.CanServeSystems([]string{"nes"}))
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestLoadCachedSlugSearchCache_GenerationMismatch(t *testing.T) {
 	t.Parallel()
 	mediaDB, mock, _ := newPersistTestDB(t)


### PR DESCRIPTION
## Summary

- treat selectively persisted slug caches as requiring a complete startup rebuild
- keep covered systems searchable while the complete cache is rebuilt
- log cache completeness and cover incomplete-cache loading with a regression test

Closes #1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of selective slug-search caches during startup.
  * Selective caches remain available for supported searches while a complete cache rebuild is requested.
  * Cache loading now accurately reports whether the cache is complete.

* **Tests**
  * Added coverage to verify persistence and loading behavior for incomplete caches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->