### PR TITLE
fix(service): cancel delayed removal hook on reinsert

### DIFF
--- a/docs/scan-behavior.md
+++ b/docs/scan-behavior.md
@@ -22,7 +22,7 @@ When `readers.scan.mode='tap'` (default setting) and a game is launched using a 
 
 When `readers.scan.mode='hold'` with `readers.scan.exit_delay=0.0` and a game is launched using a card:
 
-- [ ] Removing the card from the reader will immediately close the game, including when removal happens before launch initialization finishes.
+- [ ] Removing the card from the reader will close the game immediately after `on_remove` completes, including when removal happens before launch initialization finishes. If `on_remove` contains a delay, that hook delay completes before the zero-delay hold exit starts.
 - [ ] Scanning and removing a command card will execute the command without closing the game; only the launch card owns Hold mode exit.
 - [ ] Exiting the game manually while the card is still on the reader will not cause the game to relaunch when returning to the menu.
 - [ ] Exiting the game manually via the internal menu and then removing the card won't trigger a core menu reload.
@@ -33,7 +33,7 @@ When `readers.scan.mode='hold'` with `readers.scan.exit_delay=0.0` and a game is
 
 When `readers.scan.mode='hold'` with `readers.scan.exit_delay=N` and a game is launched using a card:
 
-- [ ] Removing the card from the reader will close the game after **N seconds**.
+- [ ] Removing the card from the reader runs `on_remove` first, then starts the **N-second** hold-exit countdown after the hook completes. Any hook delay therefore precedes `exit_delay` rather than overlapping it.
 - [ ] Removing the card and reinserting it before the N-second countdown ends will not interrupt the ongoing game.
 - [ ] When `on_remove` contains a `delay` command, reinserting the removed card during that delay cancels the remaining hook commands without relaunching the game.
 - [ ] Removing the card and tapping a different game card will immediately launch the other game.

--- a/docs/scan-behavior.md
+++ b/docs/scan-behavior.md
@@ -35,6 +35,7 @@ When `readers.scan.mode='hold'` with `readers.scan.exit_delay=N` and a game is l
 
 - [ ] Removing the card from the reader will close the game after **N seconds**.
 - [ ] Removing the card and reinserting it before the N-second countdown ends will not interrupt the ongoing game.
+- [ ] When `on_remove` contains a `delay` command, reinserting the removed card during that delay cancels the remaining hook commands without relaunching the game.
 - [ ] Removing the card and tapping a different game card will immediately launch the other game.
 - [ ] Removing the launch card and tapping a command card will execute the command without resetting or transferring the countdown. Removing the command card will not trigger another exit.
 - [ ] Exiting the game manually while the card is still on the reader will not cause the game to relaunch when returning to the menu.

--- a/pkg/service/hooks.go
+++ b/pkg/service/hooks.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"context"
 	"time"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
@@ -33,6 +34,17 @@ import (
 // Returns error if the script fails (for blocking hooks) or nil on success.
 // The scanned/launching params provide optional context for the expression env.
 func runHook(
+	svc *ServiceContext,
+	hookName string,
+	script string,
+	scanned *gozapscript.ExprEnvScanned,
+	launching *gozapscript.ExprEnvLaunching,
+) error {
+	return runHookWithContext(svc.State.GetContext(), svc, hookName, script, scanned, launching)
+}
+
+func runHookWithContext(
+	ctx context.Context,
 	svc *ServiceContext,
 	hookName string,
 	script string,
@@ -53,5 +65,5 @@ func runHook(
 	}
 
 	hookEnv := zapscript.GetExprEnv(svc.Platform, svc.Config, svc.State, scanned, launching)
-	return runTokenZapScript(svc, t, plsc, &hookEnv, true)
+	return runTokenZapScriptWithContext(ctx, svc, t, plsc, &hookEnv, true)
 }

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -105,6 +105,24 @@ func runTokenZapScript(
 	exprEnv *gozapscript.ArgExprEnv,
 	inHookContext bool,
 ) error {
+	return runTokenZapScriptWithContext(
+		svc.State.GetContext(),
+		svc,
+		token,
+		plsc,
+		exprEnv,
+		inHookContext,
+	)
+}
+
+func runTokenZapScriptWithContext(
+	runCtx context.Context,
+	svc *ServiceContext,
+	token tokens.Token, //nolint:gocritic // single-use parameter in service function
+	plsc playlists.PlaylistController,
+	exprEnv *gozapscript.ArgExprEnv,
+	inHookContext bool,
+) error {
 	if !svc.State.RunZapScriptEnabled() {
 		log.Warn().Msg("ignoring ZapScript, run ZapScript is disabled")
 		return nil
@@ -161,7 +179,7 @@ func runTokenZapScript(
 			}
 			launching := buildLaunchingContext(cmd)
 			hookEnv := zapscript.GetExprEnv(svc.Platform, svc.Config, svc.State, nil, launching)
-			hookErr := runTokenZapScript(svc, hookToken, hookPlsc, &hookEnv, true)
+			hookErr := runTokenZapScriptWithContext(runCtx, svc, hookToken, hookPlsc, &hookEnv, true)
 			if hookErr != nil {
 				return fmt.Errorf("before_media_start hook blocked launch: %w", hookErr)
 			}
@@ -191,7 +209,7 @@ func runTokenZapScript(
 		}
 
 		result, err := zapscript.RunCommand(
-			svc.State.GetContext(),
+			runCtx,
 			svc.Platform, svc.Config,
 			playlists.PlaylistController{
 				Active:     currentPrimary,

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -104,6 +104,39 @@ func hookHasDelayCommand(scriptText string) bool {
 	return false
 }
 
+func startDelayedRemovalHook(
+	ctx context.Context,
+	svc *ServiceContext,
+	script string,
+	token *tokens.Token,
+	generation uint64,
+	results chan<- removalHookResult,
+) *pendingRemovalHook {
+	tokenCopy := *token
+	cancelReady := make(chan context.CancelFunc, 1)
+	go func() {
+		hookCtx, hookCancel := context.WithCancel(ctx)
+		defer hookCancel()
+		cancelReady <- hookCancel
+
+		err := runHookWithContext(hookCtx, svc, "on_remove", script, nil, nil)
+		select {
+		case results <- removalHookResult{
+			err:        err,
+			token:      tokenCopy,
+			generation: generation,
+		}:
+		case <-ctx.Done():
+		}
+	}()
+
+	return &pendingRemovalHook{
+		cancel:     <-cancelReady,
+		token:      tokenCopy,
+		generation: generation,
+	}
+}
+
 // isPathConnected checks if any connected reader is using the given path.
 func isPathConnected(rs []readers.Reader, path string) bool {
 	for _, r := range rs {
@@ -943,28 +976,14 @@ preprocessing:
 						activeRemovalHook.cancel()
 					}
 					removalHookGeneration++
-					// Cancellation is retained by activeRemovalHook; goroutine also guarantees cleanup.
-					//nolint:gosec // G118 cannot track stored cancel funcs.
-					hookCtx, hookCancel := context.WithCancel(svc.State.GetContext())
-					tokenCopy := *removedToken
-					generation := removalHookGeneration
-					activeRemovalHook = &pendingRemovalHook{
-						cancel:     hookCancel,
-						token:      tokenCopy,
-						generation: generation,
-					}
-					go func() {
-						defer hookCancel()
-						err := runHookWithContext(hookCtx, svc, "on_remove", onRemoveScript, nil, nil)
-						select {
-						case removalHookResults <- removalHookResult{
-							err:        err,
-							token:      tokenCopy,
-							generation: generation,
-						}:
-						case <-svc.State.GetContext().Done():
-						}
-					}()
+					activeRemovalHook = startDelayedRemovalHook(
+						svc.State.GetContext(),
+						svc,
+						onRemoveScript,
+						removedToken,
+						removalHookGeneration,
+						removalHookResults,
+					)
 					continue preprocessing
 				}
 				if err := runHook(svc, "on_remove", onRemoveScript, nil, nil); err != nil {
@@ -977,6 +996,12 @@ preprocessing:
 				scheduleHoldRemoval(removedToken)
 			}
 		}
+	}
+
+	if activeRemovalHook != nil {
+		activeRemovalHook.cancel()
+		activeRemovalHook = nil
+		log.Debug().Msg("cancelled delayed on_remove hook during reader manager shutdown")
 	}
 
 	// daemon shutdown

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -59,6 +60,18 @@ type holdTokenKey struct {
 	pathRoot string
 }
 
+type pendingRemovalHook struct {
+	cancel     context.CancelFunc
+	token      tokens.Token
+	generation uint64
+}
+
+type removalHookResult struct {
+	err        error
+	token      tokens.Token
+	generation uint64
+}
+
 func newHoldTokenKey(token *tokens.Token) holdTokenKey {
 	return holdTokenKey{
 		uid:      token.UID,
@@ -75,6 +88,20 @@ func recordPendingHoldRemoval(pending map[holdTokenKey]tokens.Token, token *toke
 		}
 	}
 	pending[newHoldTokenKey(token)] = *token
+}
+
+func hookHasDelayCommand(scriptText string) bool {
+	parser := gozapscript.NewParser(scriptText)
+	script, err := parser.ParseScript()
+	if err != nil {
+		return false
+	}
+	for _, cmd := range script.Cmds {
+		if cmd.Name == gozapscript.ZapScriptCmdDelay {
+			return true
+		}
+	}
+	return false
 }
 
 // isPathConnected checks if any connected reader is using the given path.
@@ -377,8 +404,23 @@ func readerManager(
 	proc := &scanPreprocessor{}
 	connectScanSeen := make(map[string]bool)
 	pendingRemovals := make(map[holdTokenKey]tokens.Token)
+	removalHookResults := make(chan removalHookResult, 1)
 	var exitTimer clockwork.Timer
 	var exitGeneration atomic.Uint64
+	var removalHookGeneration uint64
+	var activeRemovalHook *pendingRemovalHook
+
+	scheduleHoldRemoval := func(removedToken *tokens.Token) {
+		key := newHoldTokenKey(removedToken)
+		recordPendingHoldRemoval(pendingRemovals, removedToken)
+		softwareToken := svc.State.GetSoftwareToken()
+		if !helpers.TokensEqual(removedToken, softwareToken) {
+			log.Debug().Msg("removed token does not own active media, skipping exit timer")
+			return
+		}
+		delete(pendingRemovals, key)
+		exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, removedToken)
+	}
 
 	var stagedToken *tokens.Token
 	var guardUI *uievents.Handle
@@ -526,6 +568,7 @@ preprocessing:
 		var readerError bool
 		var scanSource string
 		var scanProperties []readers.ScanProperty
+		var reinsertedDuringRemovalHook bool
 
 		select {
 		case <-svc.State.GetContext().Done():
@@ -544,9 +587,31 @@ preprocessing:
 			readerError = t.ReaderError
 			scanSource = t.Source
 			scanProperties = t.Properties
+		case hookResult := <-removalHookResults:
+			if activeRemovalHook == nil || hookResult.generation != activeRemovalHook.generation {
+				continue preprocessing
+			}
+			activeRemovalHook.cancel()
+			activeRemovalHook = nil
+			if hookResult.err != nil {
+				if errors.Is(hookResult.err, context.Canceled) {
+					log.Debug().Msg("on_remove hook cancelled")
+				} else {
+					log.Warn().Err(hookResult.err).Msg("on_remove hook blocked exit, media will keep running")
+				}
+				continue preprocessing
+			}
+			scheduleHoldRemoval(&hookResult.token)
+			continue preprocessing
 		case stoken := <-svc.LaunchSoftwareQueue:
 			// A token has launched primary software and now owns hold-mode exit.
 			log.Debug().Msgf("new software token: %v", stoken)
+			if activeRemovalHook != nil && !helpers.TokensEqual(stoken, &activeRemovalHook.token) {
+				activeRemovalHook.cancel()
+				activeRemovalHook = nil
+				removalHookGeneration++
+				log.Debug().Msg("software token changed, cancelling delayed on_remove hook")
+			}
 			currentSoftwareToken := svc.State.GetSoftwareToken()
 			if stoken == nil || !helpers.TokensEqual(stoken, currentSoftwareToken) {
 				if cancelTimedExit(exitTimer, &exitGeneration) {
@@ -622,6 +687,15 @@ preprocessing:
 			continue preprocessing
 		}
 
+		if scan != nil && activeRemovalHook != nil &&
+			helpers.TokensEqual(scan, &activeRemovalHook.token) {
+			activeRemovalHook.cancel()
+			activeRemovalHook = nil
+			removalHookGeneration++
+			reinsertedDuringRemovalHook = true
+			log.Info().Msg("removed token reinserted, cancelling delayed on_remove hook")
+		}
+
 		// If a scan races a terminal UI result, process resolution first. This
 		// prevents a re-tap from confirming a token whose Core timeout won.
 		if stagedToken != nil && guardResults != nil {
@@ -649,7 +723,7 @@ preprocessing:
 		// a re-scan of the staged token is not eaten as a duplicate. This is
 		// needed for barcode scanners which don't send removal events between
 		// scans — the preprocessor would see the re-scan as a duplicate.
-		if scan != nil && stagedToken != nil &&
+		if scan != nil && !reinsertedDuringRemovalHook && stagedToken != nil &&
 			svc.Config.LaunchGuardEnabled() && !svc.Config.LaunchGuardRequireConfirm() {
 			if helpers.TokensEqual(scan, stagedToken) && svc.State.ActiveMedia() != nil {
 				if !delayExpired {
@@ -735,6 +809,10 @@ preprocessing:
 
 			svc.State.SetActiveCard(*scan)
 
+			if reinsertedDuringRemovalHook {
+				continue preprocessing
+			}
+
 			if exitTimer != nil && helpers.TokensEqual(scan, svc.State.GetSoftwareToken()) {
 				if cancelTimedExit(exitTimer, &exitGeneration) {
 					log.Info().Msg("hold owner reinserted, cancelling exit")
@@ -761,7 +839,7 @@ preprocessing:
 			// Launch guard: when enabled and media is playing, stage tokens that
 			// would disrupt the current media (launches, playlist changes, stop).
 			// Utility commands (coin, keyboard, execute, etc.) pass through.
-			if svc.Config.LaunchGuardEnabled() && svc.State.ActiveMedia() != nil {
+			if !reinsertedDuringRemovalHook && svc.Config.LaunchGuardEnabled() && svc.State.ActiveMedia() != nil {
 				mappedValue, hasMapping := getMapping(svc.Config, svc.DB, svc.Platform, *scan)
 				scriptText := scan.Text
 				if hasMapping {
@@ -839,6 +917,12 @@ preprocessing:
 			if pt := proc.PrevToken(); pt != nil && pt.ReaderID != "" {
 				delete(connectScanSeen, pt.ReaderID)
 			}
+			if activeRemovalHook != nil {
+				activeRemovalHook.cancel()
+				activeRemovalHook = nil
+				removalHookGeneration++
+				log.Debug().Msg("cancelled delayed on_remove hook due to reader error")
+			}
 			if cancelTimedExit(exitTimer, &exitGeneration) {
 				log.Debug().Msg("cancelled exit timer due to reader error")
 			}
@@ -850,28 +934,48 @@ preprocessing:
 			// Clear ActiveCard before hook to prevent blocked removals from affecting new scans.
 			svc.State.SetActiveCard(tokens.Token{})
 
-			// Run on_remove hook for every normal removal. A blocked removal must not
-			// become a deferred hold exit when its launch completes later.
+			// Run on_remove hook for every normal removal. Delayed hooks run outside
+			// the reader loop so reinserting the removed token can cancel them.
 			onRemoveScript := svc.Config.ReadersScan().OnRemove
 			if svc.Config.HoldModeEnabled() && onRemoveScript != "" {
+				if removedToken != nil && hookHasDelayCommand(onRemoveScript) {
+					if activeRemovalHook != nil {
+						activeRemovalHook.cancel()
+					}
+					removalHookGeneration++
+					// Cancellation is retained by activeRemovalHook; goroutine also guarantees cleanup.
+					//nolint:gosec // G118 cannot track stored cancel funcs.
+					hookCtx, hookCancel := context.WithCancel(svc.State.GetContext())
+					tokenCopy := *removedToken
+					generation := removalHookGeneration
+					activeRemovalHook = &pendingRemovalHook{
+						cancel:     hookCancel,
+						token:      tokenCopy,
+						generation: generation,
+					}
+					go func() {
+						defer hookCancel()
+						err := runHookWithContext(hookCtx, svc, "on_remove", onRemoveScript, nil, nil)
+						select {
+						case removalHookResults <- removalHookResult{
+							err:        err,
+							token:      tokenCopy,
+							generation: generation,
+						}:
+						case <-svc.State.GetContext().Done():
+						}
+					}()
+					continue preprocessing
+				}
 				if err := runHook(svc, "on_remove", onRemoveScript, nil, nil); err != nil {
 					log.Warn().Err(err).Msg("on_remove hook blocked exit, media will keep running")
 					continue preprocessing
 				}
 			}
 
-			if removedToken == nil {
-				continue preprocessing
+			if removedToken != nil {
+				scheduleHoldRemoval(removedToken)
 			}
-			key := newHoldTokenKey(removedToken)
-			recordPendingHoldRemoval(pendingRemovals, removedToken)
-			softwareToken := svc.State.GetSoftwareToken()
-			if !helpers.TokensEqual(removedToken, softwareToken) {
-				log.Debug().Msg("removed token does not own active media, skipping exit timer")
-				continue preprocessing
-			}
-			delete(pendingRemovals, key)
-			exitTimer = timedExit(svc, clock, exitTimer, &exitGeneration, removedToken)
 		}
 	}
 

--- a/pkg/service/scan_behavior_test.go
+++ b/pkg/service/scan_behavior_test.go
@@ -576,6 +576,46 @@ func TestScanBehavior_HoldImmediate_ManualExitThenRemoveNoReload(t *testing.T) {
 // Hold mode delayed tests
 // ============================================================================
 
+func TestScanBehavior_HoldDelayedOnRemove_ReinsertCancelsHookWithoutRelaunch(t *testing.T) {
+	t.Parallel()
+	env := setupScanBehavior(t, config.ScanModeHold, 0)
+	require.NoError(t, env.cfg.LoadTOML(`[readers.scan]
+mode = "hold"
+on_remove = '**delay:10s||**input.keyboard:{escape}'`))
+
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForLaunch(t)
+	env.waitForSoftwareToken(t)
+
+	env.sendRemoval()
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForActiveCard(t, "game1")
+
+	env.expectNoLaunch(t)
+	env.expectNoStop(t)
+	select {
+	case key := <-env.keyboardCh:
+		t.Fatalf("unexpected delayed on_remove keyboard command: %s", key)
+	case <-time.After(noEventWait):
+	}
+}
+
+func TestScanBehavior_HoldDelayedOnRemove_AbsentTokenCompletesHookAndExit(t *testing.T) {
+	t.Parallel()
+	env := setupScanBehavior(t, config.ScanModeHold, 0)
+	require.NoError(t, env.cfg.LoadTOML(`[readers.scan]
+mode = "hold"
+on_remove = '**delay:10||**input.keyboard:{escape}'`))
+
+	env.sendGameScan("game1", env.gamePath("game.rom"))
+	env.waitForLaunch(t)
+	env.waitForSoftwareToken(t)
+
+	env.sendRemoval()
+	require.Equal(t, "{escape}", env.waitForKeyboard(t))
+	env.waitForStop(t)
+}
+
 func TestScanBehavior_HoldDelayed_RemovalClosesAfterDelay(t *testing.T) {
 	t.Parallel()
 	env := setupScanBehavior(t, config.ScanModeHold, 5)

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -557,6 +557,8 @@ func RunCommand(
 	res, err := cmdFn(pl, env)
 	if err != nil {
 		switch {
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			log.Debug().Err(err).Msgf("command cancelled: %s", logCmd)
 		case errors.Is(err, ErrFileNotFound),
 			errors.Is(err, titles.ErrNoMatch),
 			errors.Is(err, ErrNoControlCapabilities),

--- a/pkg/zapscript/utils.go
+++ b/pkg/zapscript/utils.go
@@ -83,6 +83,9 @@ func waitForDelay(ctx context.Context, delay time.Duration) error {
 
 	select {
 	case <-timer.C:
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/zapscript/utils.go
+++ b/pkg/zapscript/utils.go
@@ -73,6 +73,22 @@ func parseMacroDuration(s string) (time.Duration, error) {
 	return d, nil
 }
 
+func waitForDelay(ctx context.Context, delay time.Duration) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 //nolint:gocritic // single-use parameter in command handler
 func cmdDelay(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, error) {
 	if len(env.Cmd.Args) == 0 {
@@ -82,7 +98,9 @@ func cmdDelay(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, 
 	amount, err := strconv.Atoi(env.Cmd.Args[0])
 	if err == nil {
 		log.Info().Msgf("delaying for: %d", amount)
-		time.Sleep(time.Duration(amount) * time.Millisecond)
+		if waitErr := waitForDelay(env.ServiceCtx, time.Duration(amount)*time.Millisecond); waitErr != nil {
+			return platforms.CmdResult{}, waitErr
+		}
 		return platforms.CmdResult{}, nil
 	}
 
@@ -108,7 +126,9 @@ func cmdDelay(_ platforms.Platform, env platforms.CmdEnv) (platforms.CmdResult, 
 			return platforms.CmdResult{}, fmt.Errorf("invalid delay target %q: %w", env.Cmd.Args[0], durErr)
 		}
 		log.Info().Msgf("delaying for: %v", d)
-		time.Sleep(d)
+		if waitErr := waitForDelay(env.ServiceCtx, d); waitErr != nil {
+			return platforms.CmdResult{}, waitErr
+		}
 		return platforms.CmdResult{}, nil
 	}
 }

--- a/pkg/zapscript/utils_test.go
+++ b/pkg/zapscript/utils_test.go
@@ -365,7 +365,7 @@ func TestCmdDelay_GoDuration(t *testing.T) {
 func TestCmdDelay_ContextCancellation(t *testing.T) {
 	t.Parallel()
 
-	for _, delay := range []string{"10000", "10s"} {
+	for _, delay := range []string{"0", "0s", "10000", "10s"} {
 		t.Run(delay, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/zapscript/utils_test.go
+++ b/pkg/zapscript/utils_test.go
@@ -362,6 +362,29 @@ func TestCmdDelay_GoDuration(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, time.Millisecond)
 }
 
+func TestCmdDelay_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	for _, delay := range []string{"10000", "10s"} {
+		t.Run(delay, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			env := platforms.CmdEnv{
+				Cmd: zapscript.Command{
+					Name: "delay",
+					Args: []string{delay},
+				},
+				ServiceCtx: ctx,
+			}
+
+			_, err := cmdDelay(nil, env)
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
 func TestCmdDelay_MediaReady(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- run delayed `on_remove` hooks outside reader loop so scans remain responsive
- cancel remaining hook commands when removed token is reinserted, without relaunching active game
- make ZapScript delays context-aware and document/test resulting hold-mode behavior

Closes #1182

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Delayed removal actions now support cancellation when a card is reinserted, ownership changes, a reader error occurs, or a newer removal begins.
  - Successfully completed removal actions now finish the hold-mode flow automatically.
  - Removal hooks run before the exit countdown, including for zero-delay exits.

- **Bug Fixes**
  - Reinserting a removed card no longer relaunches or continues canceled actions.
  - Delay commands stop promptly when canceled.

- **Documentation**
  - Documented updated hold-mode removal and reinsertion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->