### PR TITLE
fix(mister): reject missing launch files

### DIFF
--- a/pkg/platforms/mister/console_lease.go
+++ b/pkg/platforms/mister/console_lease.go
@@ -112,6 +112,11 @@ func (c *mainConsoleLeaseController) waitForState(ctx context.Context, expected,
 
 	for {
 		state, err := c.readState()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		if err == nil && state.nonce == nonce {
 			switch state.state {
 			case expected:

--- a/pkg/platforms/mister/console_lease_test.go
+++ b/pkg/platforms/mister/console_lease_test.go
@@ -104,22 +104,22 @@ func TestMainConsoleLeaseController_AcquireCleansDelayedLeaseAfterContextFailure
 
 	controller, fs := newTestConsoleLeaseController(t)
 	controller.cleanupTimeout = time.Second
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		fields := waitForLeaseCommand(fs, controller.commandPath, "acquire")
 		if len(fields) < 3 {
 			return
 		}
-		time.Sleep(20 * time.Millisecond)
+		cancel()
 		_ = writeConsoleLeaseState(fs, controller.statePath, "acquired", fields[2])
 		if len(waitForLeaseCommand(fs, controller.commandPath, "release")) >= 3 {
 			_ = writeConsoleLeaseState(fs, controller.statePath, "released", fields[2])
 		}
 	}()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
 	_, err := controller.Acquire(ctx, "3")
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, context.Canceled)
 
 	state, stateErr := controller.readState()
 	require.NoError(t, stateErr)

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -26,6 +26,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	s "strings"
@@ -37,7 +38,10 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/tracker/activegame"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
+
+type commandInterfaceWriter struct{}
 
 // MRA represents the structure of a MiSTer Arcade ROM file.
 type MRA struct {
@@ -45,6 +49,24 @@ type MRA struct {
 	SetName string   `xml:"setname"`
 	Name    string   `xml:"name"`
 	Rbf     string   `xml:"rbf"`
+}
+
+func (commandInterfaceWriter) Write(p []byte) (int, error) {
+	cmd, err := os.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open command interface: %w", err)
+	}
+	defer func() {
+		if closeErr := cmd.Close(); closeErr != nil {
+			log.Error().Err(closeErr).Msg("failed to close command interface")
+		}
+	}()
+
+	n, err := cmd.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("write command interface: %w", err)
+	}
+	return n, nil
 }
 
 // ReadMRA parses an MRA file and returns the MRA struct with extracted metadata.
@@ -154,7 +176,11 @@ func validateLoadCorePath(path string) error {
 	return nil
 }
 
-func launchFile(path string) error {
+func launchFileWithDefaults(path string) error {
+	return launchFile(afero.NewOsFs(), commandInterfaceWriter{}, path)
+}
+
+func launchFile(fs afero.Fs, commandWriter io.Writer, path string) error {
 	validationErr := validateLoadCorePath(path)
 	if validationErr != nil {
 		return validationErr
@@ -165,7 +191,7 @@ func launchFile(path string) error {
 		return fmt.Errorf("not a valid launch file: %s", path)
 	}
 
-	if _, err := os.Stat(path); err != nil {
+	if _, err := fs.Stat(path); err != nil {
 		return fmt.Errorf("launch file not accessible: %w", err)
 	}
 
@@ -175,18 +201,8 @@ func launchFile(path string) error {
 	}
 
 	log.Debug().Str("file", path).Msg("sending to command interface")
-	cmd, err := os.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
-	if err != nil {
-		return fmt.Errorf("failed to open command interface: %w", err)
-	}
-	defer func() {
-		if err := cmd.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close command interface")
-		}
-	}()
-
 	command := "load_core " + path
-	if _, err := fmt.Fprintln(cmd, command); err != nil {
+	if _, err := fmt.Fprintln(commandWriter, command); err != nil {
 		return fmt.Errorf("failed to write to command interface: %w", err)
 	}
 	log.Info().Str("command", command).Msg("command interface launch request sent")
@@ -220,7 +236,7 @@ func launchTempMgl(cfg *config.Instance, system *cores.Core, path string) error 
 		return fmt.Errorf("failed to write temp file: %w", err)
 	}
 
-	return launchFile(tmpFile)
+	return launchFileWithDefaults(tmpFile)
 }
 
 // LaunchShortCore attempts to launch a core with a short path, as per what's
@@ -236,7 +252,7 @@ func LaunchShortCore(path string) error {
 		return fmt.Errorf("failed to write to command interface: %w", err)
 	}
 
-	return launchFile(tmpFile)
+	return launchFileWithDefaults(tmpFile)
 }
 
 // writeCurrentPath writes the CURRENTPATH, FULLPATH, and FILESELECT files
@@ -283,14 +299,14 @@ func LaunchGame(cfg *config.Instance, system *cores.Core, path string) error {
 
 	switch ext {
 	case ".mra":
-		err := launchFile(path)
+		err := launchFileWithDefaults(path)
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
 		writeCurrentPath(path)
 		log.Debug().Str("path", path).Msg("arcade game launched via MRA")
 	case ".mgl":
-		err := launchFile(path)
+		err := launchFileWithDefaults(path)
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
@@ -362,19 +378,19 @@ func LaunchBasicFile(path string) error {
 	ext := s.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".mra":
-		err = launchFile(path)
+		err = launchFileWithDefaults(path)
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
 		writeCurrentPath(path)
 	case ".mgl":
-		err = launchFile(path)
+		err = launchFileWithDefaults(path)
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}
 		isGame = true
 	case ".rbf":
-		err = launchFile(path)
+		err = launchFileWithDefaults(path)
 		if err != nil {
 			return fmt.Errorf("failed to write to command interface: %w", err)
 		}

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -41,7 +41,9 @@ import (
 	"github.com/spf13/afero"
 )
 
-type commandInterfaceWriter struct{}
+type commandInterfaceWriter struct {
+	open func() (io.WriteCloser, error)
+}
 
 // MRA represents the structure of a MiSTer Arcade ROM file.
 type MRA struct {
@@ -51,8 +53,16 @@ type MRA struct {
 	Rbf     string   `xml:"rbf"`
 }
 
-func (commandInterfaceWriter) Write(p []byte) (int, error) {
-	cmd, err := os.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
+func newCommandInterfaceWriter(fs afero.Fs) commandInterfaceWriter {
+	return commandInterfaceWriter{
+		open: func() (io.WriteCloser, error) {
+			return fs.OpenFile(misterconfig.CmdInterface, os.O_RDWR, 0)
+		},
+	}
+}
+
+func (w commandInterfaceWriter) Write(p []byte) (int, error) {
+	cmd, err := w.open()
 	if err != nil {
 		return 0, fmt.Errorf("failed to open command interface: %w", err)
 	}
@@ -177,7 +187,8 @@ func validateLoadCorePath(path string) error {
 }
 
 func launchFileWithDefaults(path string) error {
-	return launchFile(afero.NewOsFs(), commandInterfaceWriter{}, path)
+	fs := afero.NewOsFs()
+	return launchFile(fs, newCommandInterfaceWriter(fs), path)
 }
 
 func launchFile(fs afero.Fs, commandWriter io.Writer, path string) error {
@@ -193,11 +204,6 @@ func launchFile(fs afero.Fs, commandWriter io.Writer, path string) error {
 
 	if _, err := fs.Stat(path); err != nil {
 		return fmt.Errorf("launch file not accessible: %w", err)
-	}
-
-	_, err := os.Stat(misterconfig.CmdInterface)
-	if err != nil {
-		return fmt.Errorf("command interface not accessible: %w", err)
 	}
 
 	log.Debug().Str("file", path).Msg("sending to command interface")

--- a/pkg/platforms/mister/mgls/mgls.go
+++ b/pkg/platforms/mister/mgls/mgls.go
@@ -160,14 +160,18 @@ func launchFile(path string) error {
 		return validationErr
 	}
 
-	_, err := os.Stat(misterconfig.CmdInterface)
-	if err != nil {
-		return fmt.Errorf("command interface not accessible: %w", err)
-	}
-
 	lowerPath := s.ToLower(path)
 	if !s.HasSuffix(lowerPath, ".mgl") && !s.HasSuffix(lowerPath, ".mra") && !s.HasSuffix(lowerPath, ".rbf") {
 		return fmt.Errorf("not a valid launch file: %s", path)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("launch file not accessible: %w", err)
+	}
+
+	_, err := os.Stat(misterconfig.CmdInterface)
+	if err != nil {
+		return fmt.Errorf("command interface not accessible: %w", err)
 	}
 
 	log.Debug().Str("file", path).Msg("sending to command interface")

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -24,15 +24,29 @@ package mgls
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type errorWriteCloser struct {
+	err error
+}
+
+func (w errorWriteCloser) Write(_ []byte) (int, error) {
+	return 0, w.err
+}
+
+func (errorWriteCloser) Close() error {
+	return nil
+}
 
 func TestReadMRA(t *testing.T) {
 	t.Parallel()
@@ -204,15 +218,83 @@ func TestLaunchFileRejectsMissingTarget(t *testing.T) {
 		t.Run(ext, func(t *testing.T) {
 			t.Parallel()
 
-			path := filepath.Join(t.TempDir(), "missing"+ext)
+			path := filepath.Join("media", "fat", "missing"+ext)
 			var command bytes.Buffer
-			err := launchFile(afero.NewOsFs(), &command, path)
+			err := launchFile(afero.NewMemMapFs(), &command, path)
 
 			require.ErrorContains(t, err, "launch file not accessible")
 			require.ErrorIs(t, err, os.ErrNotExist)
 			require.Empty(t, command.String())
 		})
 	}
+}
+
+func TestLaunchFileWritesCommand(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	path := filepath.Join("media", "fat", "game.mgl")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, afero.WriteFile(fs, path, nil, 0o600))
+
+	var command bytes.Buffer
+	err := launchFile(fs, &command, path)
+
+	require.NoError(t, err)
+	require.Equal(t, "load_core "+path+"\n", command.String())
+}
+
+func TestCommandInterfaceWriter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("successful write", func(t *testing.T) {
+		t.Parallel()
+
+		fs := afero.NewMemMapFs()
+		require.NoError(t, fs.MkdirAll(filepath.Dir(misterconfig.CmdInterface), 0o755))
+		require.NoError(t, afero.WriteFile(fs, misterconfig.CmdInterface, nil, 0o600))
+		command := []byte("load_core " + filepath.Join("media", "fat", "game.mgl") + "\n")
+
+		n, err := newCommandInterfaceWriter(fs).Write(command)
+
+		require.NoError(t, err)
+		require.Equal(t, len(command), n)
+		got, err := afero.ReadFile(fs, misterconfig.CmdInterface)
+		require.NoError(t, err)
+		require.Equal(t, command, got)
+	})
+
+	t.Run("open failure", func(t *testing.T) {
+		t.Parallel()
+
+		writer := commandInterfaceWriter{
+			open: func() (io.WriteCloser, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		n, err := writer.Write([]byte("command"))
+
+		require.Zero(t, n)
+		require.ErrorContains(t, err, "failed to open command interface")
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("write failure", func(t *testing.T) {
+		t.Parallel()
+
+		writer := commandInterfaceWriter{
+			open: func() (io.WriteCloser, error) {
+				return errorWriteCloser{err: assert.AnError}, nil
+			},
+		}
+
+		n, err := writer.Write([]byte("command"))
+
+		require.Zero(t, n)
+		require.ErrorContains(t, err, "write command interface")
+		require.ErrorIs(t, err, assert.AnError)
+	})
 }
 
 func TestLaunchCoreRejectsControlCharacters(t *testing.T) {

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -194,6 +194,16 @@ func TestLaunchFileRejectsControlCharacters(t *testing.T) {
 	}
 }
 
+func TestLaunchFileRejectsMissingTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "missing.mra")
+	err := launchFile(path)
+
+	require.ErrorContains(t, err, "launch file not accessible")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestLaunchCoreRejectsControlCharacters(t *testing.T) {
 	oldCache := cores.GlobalRBFCache
 	t.Cleanup(func() {

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -22,12 +22,14 @@
 package mgls
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -188,7 +190,8 @@ func TestLaunchFileRejectsControlCharacters(t *testing.T) {
 		t.Run(path, func(t *testing.T) {
 			t.Parallel()
 
-			err := launchFile(path)
+			var command bytes.Buffer
+			err := launchFile(afero.NewMemMapFs(), &command, path)
 			require.EqualError(t, err, fmt.Sprintf("load_core path contains control character: %q", path))
 		})
 	}
@@ -197,11 +200,19 @@ func TestLaunchFileRejectsControlCharacters(t *testing.T) {
 func TestLaunchFileRejectsMissingTarget(t *testing.T) {
 	t.Parallel()
 
-	path := filepath.Join(t.TempDir(), "missing.mra")
-	err := launchFile(path)
+	for _, ext := range []string{".mra", ".mgl", ".rbf"} {
+		t.Run(ext, func(t *testing.T) {
+			t.Parallel()
 
-	require.ErrorContains(t, err, "launch file not accessible")
-	require.ErrorIs(t, err, os.ErrNotExist)
+			path := filepath.Join(t.TempDir(), "missing"+ext)
+			var command bytes.Buffer
+			err := launchFile(afero.NewOsFs(), &command, path)
+
+			require.ErrorContains(t, err, "launch file not accessible")
+			require.ErrorIs(t, err, os.ErrNotExist)
+			require.Empty(t, command.String())
+		})
+	}
 }
 
 func TestLaunchCoreRejectsControlCharacters(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject missing MRA, MGL, and RBF targets before writing to MiSTer command interface
- prevent failed launches from publishing false active-media state
- cover missing launch targets with regression test

Ref #1192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Launching missing MRA, MGL, and RBF files now returns a clear file-not-found accessibility error.
  * Missing launch files no longer produce command output.
  * Existing file-extension and command-interface validation remain supported.
  * Console lease acquisition now stops promptly when canceled, returning a cancellation error and releasing the lease correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->