### PR TITLE
fix(database): constrain cached media search queries

### DIFF
--- a/pkg/database/mediadb/candidate_tagfilter_test.go
+++ b/pkg/database/mediadb/candidate_tagfilter_test.go
@@ -1,0 +1,237 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCandidateTagFilterSQL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("regular AND filters use candidate-correlated lookups", func(t *testing.T) {
+		t.Parallel()
+		filters := []zapscript.TagFilter{
+			{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND},
+			{Type: "lang", Value: "en", Operator: zapscript.TagOperatorAND},
+		}
+
+		clauses, args := buildCandidateTagFilterSQL(filters)
+
+		require.Len(t, clauses, 2)
+		require.Len(t, args, 8)
+		for _, clause := range clauses {
+			assert.Equal(t, 2, strings.Count(clause, "EXISTS ("))
+			assert.Contains(t, clause, "MediaTags.MediaDBID = Media.DBID")
+			assert.Contains(t, clause, "MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID")
+			assert.NotContains(t, clause, "Media.DBID IN (")
+		}
+		assert.Equal(t, []any{"region", "us", "region", "us", "lang", "en", "lang", "en"}, args)
+	})
+
+	t.Run("NOT filter checks both candidate tag sources", func(t *testing.T) {
+		t.Parallel()
+		filters := []zapscript.TagFilter{
+			{Type: "unfinished", Value: "demo", Operator: zapscript.TagOperatorNOT},
+		}
+
+		clauses, args := buildCandidateTagFilterSQL(filters)
+
+		require.Len(t, clauses, 1)
+		assert.Contains(t, clauses[0], "NOT (")
+		assert.Equal(t, 2, strings.Count(clauses[0], "EXISTS ("))
+		assert.NotContains(t, clauses[0], "NOT IN")
+		assert.Equal(t, []any{"unfinished", "demo", "unfinished", "demo"}, args)
+	})
+
+	t.Run("OR filters share candidate-correlated lookup", func(t *testing.T) {
+		t.Parallel()
+		filters := []zapscript.TagFilter{
+			{Type: "lang", Value: "en", Operator: zapscript.TagOperatorOR},
+			{Type: "lang", Value: "ja", Operator: zapscript.TagOperatorOR},
+		}
+
+		clauses, args := buildCandidateTagFilterSQL(filters)
+
+		require.Len(t, clauses, 1)
+		assert.Equal(t, 2, strings.Count(clauses[0], "EXISTS ("))
+		assert.Equal(t, 4, strings.Count(clauses[0], "TagTypes.Type = ?"))
+		assert.Equal(t, []any{"lang", "en", "lang", "ja", "lang", "en", "lang", "ja"}, args)
+	})
+
+	t.Run("AND credit searches all credit roles", func(t *testing.T) {
+		t.Parallel()
+		filters := []zapscript.TagFilter{
+			{Type: "credit", Value: "nintendo", Operator: zapscript.TagOperatorAND},
+		}
+
+		clauses, args := buildCandidateTagFilterSQL(filters)
+
+		require.Len(t, clauses, 1)
+		assert.Equal(t, 2, strings.Count(clauses[0], "TagTypes.Type IN (?, ?, ?)"))
+		assert.Equal(t, []any{
+			"nintendo", "developer", "publisher", "credit",
+			"nintendo", "developer", "publisher", "credit",
+		}, args)
+	})
+}
+
+func TestSqlSearchMediaByTitleDBIDs_UsesCandidateTagFilters(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`(?s)WHERE MediaTitles\.DBID IN \(\?\).*AND \(EXISTS \(.*`+
+		`MediaTags\.MediaDBID = Media\.DBID.*MediaTitleTags\.MediaTitleDBID = Media\.MediaTitleDBID`).
+		WithArgs(int64(10), "region", "us", "region", "us", 100).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"SystemID", "Name", "Path", "DBID", "DisambiguationTypes",
+		}))
+
+	results, err := sqlSearchMediaByTitleDBIDs(
+		context.Background(),
+		db,
+		[]int64{10},
+		[]zapscript.TagFilter{{Type: "region", Value: "us"}},
+		nil,
+		nil,
+		100,
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSqlSearchMediaByTitleDBIDs_CandidateTagFilterSemantics(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	regionType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "region"})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.BeginTransaction(false))
+
+	nes, err := systemdefs.GetSystem(systemdefs.SystemNES)
+	require.NoError(t, err)
+	system, err := mediaDB.InsertSystem(database.System{SystemID: nes.ID, Name: nes.ID})
+	require.NoError(t, err)
+
+	type fixture struct {
+		path    string
+		region  string
+		titleID int64
+		title   bool
+	}
+	fixtures := []fixture{
+		{path: filepath.Join("games", "us-file.nes"), region: "us"},
+		{path: filepath.Join("games", "us-title.nes"), region: "us", title: true},
+		{path: filepath.Join("games", "jp-file.nes"), region: "jp"},
+		{path: filepath.Join("games", "untagged.nes")},
+	}
+	for i := range fixtures {
+		title, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       "candidate" + fixtures[i].region,
+			Name:       fixtures[i].path,
+		})
+		require.NoError(t, insertErr)
+		fixtures[i].titleID = title.DBID
+		media, insertErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           fixtures[i].path,
+		})
+		require.NoError(t, insertErr)
+		if fixtures[i].region == "" || fixtures[i].title {
+			continue
+		}
+		tag, tagErr := mediaDB.FindOrInsertTag(database.Tag{
+			TypeDBID: regionType.DBID,
+			Tag:      fixtures[i].region,
+		})
+		require.NoError(t, tagErr)
+		_, tagErr = mediaDB.InsertMediaTag(database.MediaTag{MediaDBID: media.DBID, TagDBID: tag.DBID})
+		require.NoError(t, tagErr)
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(context.Background(), fixtures[1].titleID, []database.TagInfo{{
+		Type: "region",
+		Tag:  "us",
+	}}))
+
+	candidateIDs := make([]int64, len(fixtures))
+	for i := range fixtures {
+		candidateIDs[i] = fixtures[i].titleID
+	}
+	tests := []struct {
+		name      string
+		filters   []zapscript.TagFilter
+		wantPaths []string
+	}{
+		{
+			name:      "AND matches file and title tags",
+			filters:   []zapscript.TagFilter{{Type: "region", Value: "us"}},
+			wantPaths: []string{fixtures[0].path, fixtures[1].path},
+		},
+		{
+			name: "NOT excludes file and title tags",
+			filters: []zapscript.TagFilter{{
+				Type: "region", Value: "us", Operator: zapscript.TagOperatorNOT,
+			}},
+			wantPaths: []string{fixtures[2].path, fixtures[3].path},
+		},
+		{
+			name: "OR matches either value across both sources",
+			filters: []zapscript.TagFilter{
+				{Type: "region", Value: "us", Operator: zapscript.TagOperatorOR},
+				{Type: "region", Value: "jp", Operator: zapscript.TagOperatorOR},
+			},
+			wantPaths: []string{fixtures[0].path, fixtures[1].path, fixtures[2].path},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, searchErr := sqlSearchMediaByTitleDBIDs(
+				context.Background(), mediaDB.sql.Load(), candidateIDs, tt.filters, nil, nil, 10,
+			)
+			require.NoError(t, searchErr)
+			paths := make([]string, len(results))
+			for i := range results {
+				paths[i] = results[i].Path
+			}
+			assert.ElementsMatch(t, tt.wantPaths, paths)
+		})
+	}
+}

--- a/pkg/database/mediadb/candidate_tagfilter_test.go
+++ b/pkg/database/mediadb/candidate_tagfilter_test.go
@@ -34,6 +34,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fixture struct {
+	path    string
+	region  string
+	titleID int64
+	title   bool
+}
+
 func TestBuildCandidateTagFilterSQL(t *testing.T) {
 	t.Parallel()
 
@@ -148,12 +155,6 @@ func TestSqlSearchMediaByTitleDBIDs_CandidateTagFilterSemantics(t *testing.T) {
 	system, err := mediaDB.InsertSystem(database.System{SystemID: nes.ID, Name: nes.ID})
 	require.NoError(t, err)
 
-	type fixture struct {
-		path    string
-		region  string
-		titleID int64
-		title   bool
-	}
 	fixtures := []fixture{
 		{path: filepath.Join("games", "us-file.nes"), region: "us"},
 		{path: filepath.Join("games", "us-title.nes"), region: "us", title: true},

--- a/pkg/database/mediadb/media_search.go
+++ b/pkg/database/mediadb/media_search.go
@@ -1,0 +1,168 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"cmp"
+	"context"
+	"slices"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+)
+
+type mediaSearchTypeGroup struct {
+	systems       []systemdefs.System
+	variantGroups [][]string
+	includeName   bool
+}
+
+func buildMediaSearchTypeGroups(
+	systems []systemdefs.System,
+	queryWords []string,
+) []mediaSearchTypeGroup {
+	groups := make([]mediaSearchTypeGroup, 0, 8)
+	groupIndexes := make(map[slugs.MediaType]int, 8)
+
+	for i := range systems {
+		mediaType := systems[i].GetMediaType()
+		groupIndex, ok := groupIndexes[mediaType]
+		if !ok {
+			groupIndex = len(groups)
+			groupIndexes[mediaType] = groupIndex
+			groups = append(groups, mediaSearchTypeGroup{})
+		}
+		groups[groupIndex].systems = append(groups[groupIndex].systems, systems[i])
+	}
+
+	for i := range groups {
+		mediaType := groups[i].systems[0].GetMediaType()
+		groups[i].variantGroups = make([][]string, len(queryWords))
+		for wordIndex, word := range queryWords {
+			variant := slugs.Slugify(mediaType, word)
+			if variant == "" {
+				groups[i].includeName = true
+				continue
+			}
+			groups[i].variantGroups[wordIndex] = []string{variant}
+		}
+	}
+
+	return groups
+}
+
+func mediaSearchTypeGroupsCacheable(groups []mediaSearchTypeGroup) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	for i := range groups {
+		if groups[i].includeName || len(groups[i].variantGroups) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func searchMediaTypeGroupsInCache(
+	cache *SlugSearchCache,
+	groups []mediaSearchTypeGroup,
+) []int64 {
+	seen := make(map[int64]struct{})
+	candidates := make([]int64, 0, 1024)
+
+	for i := range groups {
+		systemIDs := make([]string, len(groups[i].systems))
+		for j := range groups[i].systems {
+			systemIDs[j] = groups[i].systems[j].ID
+		}
+		systemDBIDs := cache.ResolveSystemDBIDs(systemIDs)
+		if len(systemDBIDs) == 0 {
+			continue
+		}
+
+		byteGroups := make([][][]byte, len(groups[i].variantGroups))
+		for wordIndex, variants := range groups[i].variantGroups {
+			byteGroups[wordIndex] = make([][]byte, len(variants))
+			for variantIndex, variant := range variants {
+				byteGroups[wordIndex][variantIndex] = []byte(variant)
+			}
+		}
+
+		for _, candidate := range cache.Search(systemDBIDs, byteGroups) {
+			if _, ok := seen[candidate]; ok {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	return candidates
+}
+
+func titleDBIDQueryParamCount(candidateCount int, filters *database.SearchFilters) int {
+	_, tagArgs := buildCandidateTagFilterSQL(filters.Tags)
+	_, letterArgs := BuildLetterFilterSQL(filters.Letter, "MediaTitles.Name")
+
+	count := candidateCount + len(tagArgs) + len(letterArgs) + 1 // LIMIT
+	if filters.Cursor != nil {
+		count++
+	}
+	return count
+}
+
+func (db *MediaDB) searchMediaTypeGroupsWithSQL(
+	ctx context.Context,
+	groups []mediaSearchTypeGroup,
+	rawWords []string,
+	filters *database.SearchFilters,
+) ([]database.SearchResultWithCursor, error) {
+	results := make([]database.SearchResultWithCursor, 0, filters.Limit)
+	for i := range groups {
+		groupResults, err := sqlSearchMediaWithFilters(
+			ctx,
+			db.sql.Load(),
+			groups[i].systems,
+			groups[i].variantGroups,
+			rawWords,
+			filters.Tags,
+			filters.Letter,
+			filters.Cursor,
+			filters.Limit,
+			groups[i].includeName,
+		)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, groupResults...)
+	}
+
+	slices.SortFunc(results, func(a, b database.SearchResultWithCursor) int {
+		return cmp.Compare(a.MediaID, b.MediaID)
+	})
+	results = slices.CompactFunc(results, func(a, b database.SearchResultWithCursor) bool {
+		return a.MediaID == b.MediaID
+	})
+	if len(results) > filters.Limit {
+		results = results[:filters.Limit]
+	}
+	return results, nil
+}

--- a/pkg/database/mediadb/media_search_scope_test.go
+++ b/pkg/database/mediadb/media_search_scope_test.go
@@ -1,0 +1,212 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testsqlmock "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaDB_SearchMediaWithFilters_ScopesCachedVariantsByMediaType(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	nes, err := systemdefs.GetSystem(systemdefs.SystemNES)
+	require.NoError(t, err)
+	movie, err := systemdefs.GetSystem(systemdefs.SystemMovie)
+	require.NoError(t, err)
+
+	cache := buildTestCache([]struct {
+		slug       string
+		secSlug    string
+		titleDBID  int64
+		systemDBID int64
+	}{
+		{slug: "rtype", titleDBID: 10, systemDBID: 1},
+		{slug: "mariokart", titleDBID: 11, systemDBID: 1},
+		{slug: "r", titleDBID: 20, systemDBID: 2},
+	}, map[int64]string{1: nes.ID, 2: movie.ID})
+	cache.complete = true
+
+	mediaDB := &MediaDB{}
+	mediaDB.sql.Store(db)
+	mediaDB.slugSearchCache.Store(cache)
+
+	nesPath := filepath.Join("games", "nes", "rtype.nes")
+	moviePath := filepath.Join("movies", "rtype.mkv")
+	mock.ExpectQuery("SELECT .+ FROM MediaTitles").
+		WithArgs(int64(10), int64(20), 10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"SystemID", "Name", "Path", "DBID", "DisambiguationTypes",
+		}).
+			AddRow(nes.ID, "R-Type", nesPath, int64(100), "").
+			AddRow(movie.ID, "R-Type", moviePath, int64(200), ""))
+	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
+		ExpectQuery().
+		WithArgs(100, 200, 100, 200).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
+
+	results, err := mediaDB.SearchMediaWithFilters(context.Background(), &database.SearchFilters{
+		Systems: []systemdefs.System{*nes, *movie},
+		Query:   "R-Type",
+		Limit:   10,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, nesPath, results[0].Path)
+	assert.Equal(t, moviePath, results[1].Path)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSearchMediaTypeGroupsInCache_SkipsMissingSystemGroup(t *testing.T) {
+	t.Parallel()
+
+	nes, err := systemdefs.GetSystem(systemdefs.SystemNES)
+	require.NoError(t, err)
+	movie, err := systemdefs.GetSystem(systemdefs.SystemMovie)
+	require.NoError(t, err)
+
+	cache := buildTestCache([]struct {
+		slug       string
+		secSlug    string
+		titleDBID  int64
+		systemDBID int64
+	}{
+		{slug: "rtype", titleDBID: 10, systemDBID: 1},
+		{slug: "mariokart", titleDBID: 11, systemDBID: 1},
+	}, map[int64]string{1: nes.ID})
+	cache.complete = true
+
+	groups := buildMediaSearchTypeGroups([]systemdefs.System{*nes, *movie}, []string{"R-Type"})
+	candidates := searchMediaTypeGroupsInCache(cache, groups)
+
+	assert.Equal(t, []int64{10}, candidates)
+}
+
+func TestMediaDB_SearchMediaWithFilters_ScopesSQLVariantsByMediaType(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	nes, err := systemdefs.GetSystem(systemdefs.SystemNES)
+	require.NoError(t, err)
+	movie, err := systemdefs.GetSystem(systemdefs.SystemMovie)
+	require.NoError(t, err)
+
+	mediaDB := &MediaDB{}
+	mediaDB.sql.Store(db)
+
+	nesPath := filepath.Join("games", "nes", "rtype.nes")
+	moviePath := filepath.Join("movies", "rtype.mkv")
+	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
+		ExpectQuery().
+		WithArgs(nes.ID, "%rtype%", "%rtype%", 1).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"SystemID", "Name", "Path", "DBID", "DisambiguationTypes",
+		}).AddRow(nes.ID, "R-Type", nesPath, int64(300), ""))
+	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
+		ExpectQuery().
+		WithArgs(300, 300).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
+	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
+		ExpectQuery().
+		WithArgs(movie.ID, "%r%", "%r%", 1).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"SystemID", "Name", "Path", "DBID", "DisambiguationTypes",
+		}).AddRow(movie.ID, "R-Type", moviePath, int64(200), ""))
+	mock.ExpectPrepare("SELECT.*MediaDBID.*Tag.*Type FROM").
+		ExpectQuery().
+		WithArgs(200, 200).
+		WillReturnRows(sqlmock.NewRows([]string{"MediaDBID", "Tag", "Type"}))
+
+	results, err := mediaDB.SearchMediaWithFilters(context.Background(), &database.SearchFilters{
+		Systems: []systemdefs.System{*nes, *movie},
+		Query:   "R-Type",
+		Limit:   1,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, moviePath, results[0].Path)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestMediaDB_SearchMediaWithFilters_FallsBackBeforeSQLiteVariableLimit(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	nes, err := systemdefs.GetSystem(systemdefs.SystemNES)
+	require.NoError(t, err)
+
+	entries := make([]struct {
+		slug       string
+		secSlug    string
+		titleDBID  int64
+		systemDBID int64
+	}, sqliteMaxParams)
+	for i := range entries {
+		entries[i] = struct {
+			slug       string
+			secSlug    string
+			titleDBID  int64
+			systemDBID int64
+		}{slug: "rtype", titleDBID: int64(i + 1), systemDBID: 1}
+	}
+	cache := buildTestCache(entries, map[int64]string{1: nes.ID})
+	cache.complete = true
+
+	mediaDB := &MediaDB{}
+	mediaDB.sql.Store(db)
+	mediaDB.slugSearchCache.Store(cache)
+
+	mock.ExpectPrepare("SELECT.*Systems\\.SystemID.*MediaTitles\\.Name.*Media\\.Path.*Media\\.DBID.*").
+		ExpectQuery().
+		WithArgs(nes.ID, "%rtype%", "%rtype%", 10).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"SystemID", "Name", "Path", "DBID", "DisambiguationTypes",
+		}))
+
+	results, err := mediaDB.SearchMediaWithFilters(context.Background(), &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Query:   "R-Type",
+		Limit:   10,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2299,96 +2299,57 @@ func (db *MediaDB) SearchMediaWithFilters(
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
 
-	// Collect unique MediaTypes from the systems being searched
-	uniqueMediaTypes := make(map[slugs.MediaType]struct{})
-	for _, system := range filters.Systems {
-		uniqueMediaTypes[system.GetMediaType()] = struct{}{}
-	}
-
-	// Generate slug variants for each query word based on the MediaTypes we're actually searching
 	qWords := strings.Fields(filters.Query)
-	variantGroups := make([][]string, 0, len(qWords))
-	includeName := false
-
-	for _, word := range qWords {
-		seenVariants := make(map[string]struct{})
-		variants := make([]string, 0, len(uniqueMediaTypes))
-
-		// Generate a slug variant for each MediaType present in the search
-		for mediaType := range uniqueMediaTypes {
-			slugVariant := slugs.Slugify(mediaType, word)
-			if slugVariant != "" {
-				if _, exists := seenVariants[slugVariant]; !exists {
-					variants = append(variants, slugVariant)
-					seenVariants[slugVariant] = struct{}{}
-				}
-			}
-		}
-
-		// If no variants were generated (e.g. pure punctuation), fall back to Name search
-		if len(variants) == 0 && word != "" {
-			includeName = true
-		}
-
-		// Cap variants per word to avoid SQLite param limit issues (999 params total)
-		// With max 10 words * 8 media types = 80 params for variants, plus systems/tags/etc, we're safe
-		const maxVariantsPerWord = 8
-		if len(variants) > maxVariantsPerWord {
-			variants = variants[:maxVariantsPerWord]
-		}
-
-		if len(variants) > 0 {
-			variantGroups = append(variantGroups, variants)
-		}
+	if len(qWords) == 0 || len(filters.Systems) == 0 {
+		return sqlSearchMediaWithFilters(
+			ctx, db.sql.Load(), filters.Systems, nil, qWords, filters.Tags,
+			filters.Letter, filters.Cursor, filters.Limit, false)
 	}
 
-	// Try in-memory cache path when we have slug variants and no Name fallback
-	cache := db.slugSearchCache.Load()
+	groups := buildMediaSearchTypeGroups(filters.Systems, qWords)
 	systemIDs := make([]string, len(filters.Systems))
-	for i, sys := range filters.Systems {
-		systemIDs[i] = sys.ID
+	for i := range filters.Systems {
+		systemIDs[i] = filters.Systems[i].ID
 	}
+
+	cache := db.slugSearchCache.Load()
 	cacheReady := cache != nil && cache.CanServeSystems(systemIDs)
-	if cacheReady && len(variantGroups) > 0 && !includeName {
-		log.Debug().
-			Strs("systems", systemIDs).
-			Int("variantGroups", len(variantGroups)).
-			Bool("includeName", includeName).
-			Msg("media search using in-memory slug cache")
-		systemDBIDs := cache.ResolveSystemDBIDs(systemIDs)
-
-		// Convert string variant groups to byte variant groups
-		byteGroups := make([][][]byte, len(variantGroups))
-		for i, group := range variantGroups {
-			byteGroups[i] = make([][]byte, len(group))
-			for j, v := range group {
-				byteGroups[i][j] = []byte(v)
-			}
-		}
-
-		candidateIDs := cache.Search(systemDBIDs, byteGroups)
+	cacheableGroups := mediaSearchTypeGroupsCacheable(groups)
+	if cacheReady && cacheableGroups {
+		candidateIDs := searchMediaTypeGroupsInCache(cache, groups)
 		if len(candidateIDs) == 0 {
 			return []database.SearchResultWithCursor{}, nil
 		}
 
-		return sqlSearchMediaByTitleDBIDs(
-			ctx, db.sql.Load(), candidateIDs, filters.Tags,
-			filters.Letter, filters.Cursor, filters.Limit)
+		queryParams := titleDBIDQueryParamCount(len(candidateIDs), filters)
+		if queryParams <= sqliteMaxParams {
+			log.Debug().
+				Strs("systems", systemIDs).
+				Int("mediaTypeGroups", len(groups)).
+				Int("candidates", len(candidateIDs)).
+				Msg("media search using in-memory slug cache")
+			return sqlSearchMediaByTitleDBIDs(
+				ctx, db.sql.Load(), candidateIDs, filters.Tags,
+				filters.Letter, filters.Cursor, filters.Limit)
+		}
+
+		log.Debug().
+			Int("candidates", len(candidateIDs)).
+			Int("queryParams", queryParams).
+			Int("maxQueryParams", sqliteMaxParams).
+			Msg("media search cache candidates exceed SQLite parameter budget")
 	}
 
-	// Fallback: SQL LIKE path (no cache, non-Latin query, or browse-only)
+	// Search each media type separately so one type's normalization does not
+	// broaden matches in unrelated systems.
 	log.Debug().
 		Strs("systems", systemIDs).
 		Bool("cachePresent", cache != nil).
 		Bool("cacheReady", cacheReady).
-		Int("variantGroups", len(variantGroups)).
-		Bool("includeName", includeName).
-		Msg("media search falling back to SQL LIKE path")
-	results, err := sqlSearchMediaWithFilters(
-		ctx, db.sql.Load(), filters.Systems, variantGroups, qWords, filters.Tags,
-		filters.Letter, filters.Cursor, filters.Limit, includeName)
-
-	return results, err
+		Bool("cacheableGroups", cacheableGroups).
+		Int("mediaTypeGroups", len(groups)).
+		Msg("media search falling back to grouped SQL LIKE path")
+	return db.searchMediaTypeGroupsWithSQL(ctx, groups, qWords, filters)
 }
 
 // slugCacheSearch is a shared helper for slug-based search methods that use the

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -779,10 +779,6 @@ func sqlSearchMediaWithFilters(
 	variantArgs := make([]any, 0, len(variantGroups)*4) // Estimate: ~4 variants per word
 
 	for wordIdx, variants := range variantGroups {
-		if len(variants) == 0 {
-			continue
-		}
-
 		orConditions := make([]string, 0, len(variants)*2+1)
 
 		// Add OR conditions for each slug variant
@@ -801,8 +797,10 @@ func sqlSearchMediaWithFilters(
 			variantArgs = append(variantArgs, "%"+rawWords[wordIdx]+"%")
 		}
 
-		// Combine OR conditions for this word into a group
-		groupClauses = append(groupClauses, "("+strings.Join(orConditions, " OR ")+")")
+		if len(orConditions) > 0 {
+			// Combine OR conditions for this word into a group
+			groupClauses = append(groupClauses, "("+strings.Join(orConditions, " OR ")+")")
+		}
 	}
 
 	// If no variant groups (empty query), search for anything
@@ -838,12 +836,9 @@ func sqlSearchMediaWithFilters(
 			prepareVariadic("?", ",", len(systems)) + `) AND `
 	}
 
-	orderCondition := ""
-	if skipSystemFilter {
-		// The tag-driven plan iterates Media rowids from the IN-list; make the
-		// cursor pagination order explicit rather than relying on scan order.
-		orderCondition = ` ORDER BY Media.DBID ASC`
-	}
+	// Every query must use cursor order because media-type-scoped searches are
+	// merged in Go before applying the page limit.
+	orderCondition := ` ORDER BY Media.DBID ASC`
 
 	//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 	mediaQuery := `
@@ -955,7 +950,7 @@ func sqlSearchMediaByTitleDBIDs(
 		extraArgs = append(extraArgs, *cursor)
 	}
 
-	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
+	tagFilterClauses, tagFilterArgs := buildCandidateTagFilterSQL(tags)
 	extraConditions = append(extraConditions, tagFilterClauses...)
 	extraArgs = append(extraArgs, tagFilterArgs...)
 

--- a/pkg/database/mediadb/tagfilter.go
+++ b/pkg/database/mediadb/tagfilter.go
@@ -72,6 +72,78 @@ func expandCreditFilters(filters []zapscript.TagFilter) []zapscript.TagFilter {
 	return expanded
 }
 
+func candidateTagExistsSQL(condition string) string {
+	return fmt.Sprintf(`(EXISTS (
+		SELECT 1 FROM MediaTags
+		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTags.MediaDBID = Media.DBID
+		AND %s
+	) OR EXISTS (
+		SELECT 1 FROM MediaTitleTags
+		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
+		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
+		WHERE MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
+		AND %s
+	))`, condition, condition)
+}
+
+// buildCandidateTagFilterSQL builds correlated tag filters for a bounded set of
+// title candidates. Probing tag indexes for each candidate avoids materializing
+// every media ID carrying a common tag across the full database.
+func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []any) {
+	if len(filters) == 0 {
+		return nil, nil
+	}
+
+	filters = expandCreditFilters(filters)
+	andFilters, notFilters, orFilters := database.GroupTagFiltersByOperator(filters)
+	clauses = make([]string, 0, len(filters))
+	args = make([]any, 0, len(filters)*4)
+
+	for _, f := range andFilters {
+		if f.Type == string(tags.TagTypeCredit) {
+			_, val := resolveFilter(f.Type, f.Value)
+			condition := "Tags.Tag = ? AND TagTypes.Type IN (?, ?, ?)"
+			clauses = append(clauses, candidateTagExistsSQL(condition))
+			devType := string(tags.TagTypeDeveloper)
+			pubType := string(tags.TagTypePublisher)
+			credType := string(tags.TagTypeCredit)
+			args = append(args, val, devType, pubType, credType, val, devType, pubType, credType)
+			continue
+		}
+
+		typ, val := resolveFilter(f.Type, f.Value)
+		clauses = append(clauses, candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?"))
+		args = append(args, typ, val, typ, val)
+	}
+
+	for _, f := range notFilters {
+		typ, val := resolveFilter(f.Type, f.Value)
+		clauses = append(clauses, "NOT "+candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?"))
+		args = append(args, typ, val, typ, val)
+	}
+
+	if len(orFilters) > 0 {
+		orConditions := make([]string, 0, len(orFilters))
+		orTypes := make([]string, 0, len(orFilters))
+		orValues := make([]string, 0, len(orFilters))
+		for _, f := range orFilters {
+			typ, val := resolveFilter(f.Type, f.Value)
+			orConditions = append(orConditions, "(TagTypes.Type = ? AND Tags.Tag = ?)")
+			orTypes = append(orTypes, typ)
+			orValues = append(orValues, val)
+			args = append(args, typ, val)
+		}
+		for i := range orTypes {
+			args = append(args, orTypes[i], orValues[i])
+		}
+		clauses = append(clauses, candidateTagExistsSQL("("+strings.Join(orConditions, " OR ")+")"))
+	}
+
+	return clauses, args
+}
+
 // BuildTagFilterSQL constructs SQL WHERE clauses and arguments for tag filtering
 // using a hybrid strategy optimized for SQLite performance:
 //   - AND filters: INTERSECT pattern


### PR DESCRIPTION
## Summary
- scope cached slug variants to their matching media types so short cross-media variants cannot explode candidate sets
- fall back to grouped, cursor-ordered SQL before candidate IDs exceed SQLite parameter limits
- probe tags against bounded candidates instead of materializing every media ID carrying common tags

## Performance
On a 244,623-item MiSTer library, `R-Type` with `region:us` dropped from 6.26s to 189ms cold and 130ms warm in SQL. Live result IDs remained unchanged.

Closes #1194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved media search across different media types, including more reliable cached and database-backed searches.
  * Enhanced tag filtering for file-level and title-level tags, including AND, OR, NOT, and credit-based filters.
  * Search results are consistently ordered, deduplicated, and limited as requested.

* **Bug Fixes**
  * Improved fallback behavior for large searches and cases where cached results are unavailable.
  * Corrected title-based searches to apply candidate-specific tag filters accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->