### PR TITLE
fix(readers): disable optical drive autodetection by default

### DIFF
--- a/pkg/platforms/shared/linuxbase/readers.go
+++ b/pkg/platforms/shared/linuxbase/readers.go
@@ -49,7 +49,7 @@ func SupportedReaders(cfg *config.Instance, p platforms.Platform) []readers.Read
 		libnfc.NewACR122Reader(cfg),
 		libnfc.NewLegacyUARTReader(cfg),
 		libnfc.NewLegacyI2CReader(cfg),
-		opticaldrive.NewReaderWithDefaults(cfg, false, true),
+		opticaldrive.NewReaderWithDefaults(cfg, false, false),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
 	}

--- a/pkg/readers/opticaldrive/opticaldrive.go
+++ b/pkg/readers/opticaldrive/opticaldrive.go
@@ -122,7 +122,7 @@ type FileReader struct {
 }
 
 func NewReader(cfg *config.Instance) *FileReader {
-	return NewReaderWithDefaults(cfg, true, true)
+	return NewReaderWithDefaults(cfg, true, false)
 }
 
 func NewReaderWithDefaults(cfg *config.Instance, defaultEnabled, defaultAutoDetect bool) *FileReader {

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -61,7 +61,7 @@ func TestMetadata(t *testing.T) {
 	assert.Equal(t, "opticaldrive", metadata.ID)
 	assert.Equal(t, "Optical drive CD/DVD reader", metadata.Description)
 	assert.True(t, metadata.DefaultEnabled)
-	assert.True(t, metadata.DefaultAutoDetect)
+	assert.False(t, metadata.DefaultAutoDetect)
 }
 
 func TestIDs(t *testing.T) {


### PR DESCRIPTION
## Summary

- disable optical drive autodetection by default on MiSTer and other supported platforms
- preserve manual configuration and explicit per-driver autodetection opt-in
- update optical reader metadata coverage