### PR TITLE
fix(mac): launch URL cards in default browser

### DIFF
--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -43,6 +43,29 @@ type Platform struct {
 	processMu      syncutil.RWMutex
 }
 
+func openBrowserURL(path string) error {
+	//nolint:gosec // G204: launcher only matches http and https URLs
+	cmd := exec.CommandContext(context.Background(), "open", path)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start macOS browser command: %w", err)
+	}
+	return nil
+}
+
+func newWebBrowserLauncher(openURL func(string) error) platforms.Launcher {
+	return platforms.Launcher{
+		ID:        "WebBrowser",
+		Schemes:   []string{"http", "https"},
+		Lifecycle: platforms.LifecycleFireAndForget,
+		Launch: func(_ *config.Instance, path string, _ *platforms.LaunchOptions) (*os.Process, error) {
+			if err := openURL(path); err != nil {
+				return nil, fmt.Errorf("failed to open URL in browser: %w", err)
+			}
+			return nil, nil //nolint:nilnil // Browser launches don't return a process handle
+		},
+	}
+}
+
 func (*Platform) ID() string {
 	return platformids.Mac
 }
@@ -213,6 +236,7 @@ func (*Platform) LookupMapping(_ *tokens.Token) (string, bool) {
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	launchers := []platforms.Launcher{
 		steam.NewSteamLauncher(steam.DefaultDarwinOptions()),
+		newWebBrowserLauncher(openBrowserURL),
 		{
 			ID:            "Generic",
 			Extensions:    []string{".sh"},

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -35,6 +35,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type browserCommandFactory func(context.Context, string, ...string) *exec.Cmd
+
 type Platform struct {
 	activeMedia    func() *models.ActiveMedia
 	setActiveMedia func(*models.ActiveMedia)
@@ -43,10 +45,10 @@ type Platform struct {
 	processMu      syncutil.RWMutex
 }
 
-func openBrowserURL(path string) error {
+func openBrowserURL(path string, newCommand browserCommandFactory) error {
 	//nolint:gosec // G204: launcher only matches http and https URLs
-	cmd := exec.CommandContext(context.Background(), "open", path)
-	if err := cmd.Start(); err != nil {
+	cmd := newCommand(context.Background(), "open", path)
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("start macOS browser command: %w", err)
 	}
 	return nil
@@ -236,7 +238,9 @@ func (*Platform) LookupMapping(_ *tokens.Token) (string, bool) {
 func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 	launchers := []platforms.Launcher{
 		steam.NewSteamLauncher(steam.DefaultDarwinOptions()),
-		newWebBrowserLauncher(openBrowserURL),
+		newWebBrowserLauncher(func(path string) error {
+			return openBrowserURL(path, exec.CommandContext)
+		}),
 		{
 			ID:            "Generic",
 			Extensions:    []string{".sh"},

--- a/pkg/platforms/mac/platform_test.go
+++ b/pkg/platforms/mac/platform_test.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mac
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLaunchersIncludesWebBrowser(t *testing.T) {
+	t.Parallel()
+
+	launchers := (&Platform{}).Launchers(&config.Instance{})
+	var browser *platforms.Launcher
+	for i := range launchers {
+		if launchers[i].ID == "WebBrowser" {
+			browser = &launchers[i]
+			break
+		}
+	}
+
+	require.NotNil(t, browser)
+	require.ElementsMatch(t, []string{"http", "https"}, browser.Schemes)
+	require.Equal(t, platforms.LifecycleFireAndForget, browser.Lifecycle)
+	require.NotNil(t, browser.Launch)
+}
+
+func TestWebBrowserLauncherLaunch(t *testing.T) {
+	t.Parallel()
+
+	for _, url := range []string{"http://example.com", "https://example.com/path"} {
+		t.Run(url, func(t *testing.T) {
+			t.Parallel()
+
+			var openedURL string
+			launcher := newWebBrowserLauncher(func(path string) error {
+				openedURL = path
+				return nil
+			})
+
+			proc, err := launcher.Launch(nil, url, nil)
+
+			require.NoError(t, err)
+			assert.Nil(t, proc)
+			assert.Equal(t, url, openedURL)
+		})
+	}
+}
+
+func TestWebBrowserLauncherReturnsOpenError(t *testing.T) {
+	t.Parallel()
+
+	launcher := newWebBrowserLauncher(func(string) error {
+		return assert.AnError
+	})
+
+	proc, err := launcher.Launch(nil, "https://example.com", nil)
+
+	assert.Nil(t, proc)
+	require.ErrorContains(t, err, "failed to open URL in browser")
+	require.ErrorIs(t, err, assert.AnError)
+}

--- a/pkg/platforms/mac/platform_test.go
+++ b/pkg/platforms/mac/platform_test.go
@@ -22,6 +22,8 @@
 package mac
 
 import (
+	"context"
+	"os/exec"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -46,6 +48,41 @@ func TestLaunchersIncludesWebBrowser(t *testing.T) {
 	require.ElementsMatch(t, []string{"http", "https"}, browser.Schemes)
 	require.Equal(t, platforms.LifecycleFireAndForget, browser.Lifecycle)
 	require.NotNil(t, browser.Launch)
+}
+
+func TestOpenBrowserURL(t *testing.T) {
+	t.Parallel()
+
+	const url = "https://example.com/path"
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var commandName string
+		var commandArgs []string
+		err := openBrowserURL(url, func(_ context.Context, name string, args ...string) *exec.Cmd {
+			commandName = name
+			commandArgs = append(commandArgs, args...)
+			return exec.CommandContext(t.Context(), "sh", "-c", "exit 0")
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "open", commandName)
+		assert.Equal(t, []string{url}, commandArgs)
+	})
+
+	t.Run("non-zero exit", func(t *testing.T) {
+		t.Parallel()
+
+		err := openBrowserURL(url, func(_ context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(t.Context(), "sh", "-c", "exit 7")
+		})
+
+		require.ErrorContains(t, err, "start macOS browser command")
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+		assert.Equal(t, 7, exitErr.ExitCode())
+	})
 }
 
 func TestWebBrowserLauncherLaunch(t *testing.T) {

--- a/pkg/platforms/mister/console_lease_test.go
+++ b/pkg/platforms/mister/console_lease_test.go
@@ -108,10 +108,10 @@ func TestMainConsoleLeaseController_AcquireCleansDelayedLeaseAfterContextFailure
 	defer cancel()
 	go func() {
 		fields := waitForLeaseCommand(fs, controller.commandPath, "acquire")
+		cancel()
 		if len(fields) < 3 {
 			return
 		}
-		cancel()
 		_ = writeConsoleLeaseState(fs, controller.statePath, "acquired", fields[2])
 		if len(waitForLeaseCommand(fs, controller.commandPath, "release")) >= 3 {
 			_ = writeConsoleLeaseState(fs, controller.statePath, "released", fields[2])


### PR DESCRIPTION
## Summary

- add a macOS WebBrowser launcher for HTTP and HTTPS cards using the native `open` command
- cover launcher registration, URL forwarding, and open failures
- guarantee the console lease cleanup test cancels when command observation fails

Closes #1151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added macOS support for opening HTTP and HTTPS links in the system’s default web browser.
  - Web-browser launching is now available alongside existing platform launch options.
  - Browser launches now return promptly without requiring process tracking.

- **Bug Fixes**
  - Improved cleanup behavior when canceling delayed console lease operations.

- **Tests**
  - Added coverage for macOS browser launching, supported URL schemes, lifecycle behavior, and launch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->