### PR TITLE
test(tui): stabilize core restart test

### DIFF
--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -1027,7 +1027,7 @@ func TestWaitForCoreRestart_DownThenUp_Integration(t *testing.T) {
 	runner.Draw()
 
 	mockSvc := NewMockSettingsService()
-	releaseFirstPoll := make(chan struct{})
+	releaseFirstPoll := make(chan struct{}, 1)
 	defer close(releaseFirstPoll)
 	mockSvc.On("GetSettings", mock.Anything).
 		Run(func(mock.Arguments) { <-releaseFirstPoll }).

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -1027,7 +1027,12 @@ func TestWaitForCoreRestart_DownThenUp_Integration(t *testing.T) {
 	runner.Draw()
 
 	mockSvc := NewMockSettingsService()
-	mockSvc.On("GetSettings", mock.Anything).Return(nil, errors.New("connection refused")).Twice()
+	releaseFirstPoll := make(chan struct{})
+	defer close(releaseFirstPoll)
+	mockSvc.On("GetSettings", mock.Anything).
+		Run(func(mock.Arguments) { <-releaseFirstPoll }).
+		Return(nil, errors.New("connection refused")).Once()
+	mockSvc.On("GetSettings", mock.Anything).Return(nil, errors.New("connection refused")).Once()
 	mockSvc.On("GetSettings", mock.Anything).Return(&models.SettingsResponse{}, nil)
 
 	done := make(chan struct{})
@@ -1037,6 +1042,7 @@ func TestWaitForCoreRestart_DownThenUp_Integration(t *testing.T) {
 	})
 
 	require.True(t, runner.WaitForText("Core is restarting.", 100*time.Millisecond))
+	releaseFirstPoll <- struct{}{}
 	require.True(t, runner.WaitForText("Core restarted", time.Second))
 	assert.False(t, runner.ContainsText("Core is restarting."))
 	select {


### PR DESCRIPTION
## Summary

- gate first restart poll until initial modal assertion completes
- remove scheduler timing race causing intermittent Ubuntu CI failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved restart integration test synchronization.
  * Updated mock failure handling to make test behavior more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->