### PR TITLE
feat(api): add frontend media prerequisites

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -45,6 +45,8 @@ Returns `null` on success.
 
 Currently, it is not reported if the launched ZapScript encountered an error during launching, and the method will return before execution of ZapScript is complete.
 
+For ZapScript `launch.random`, Core selects uniformly from matching non-missing media rows after applying systems, tags, and path scope. Filesystem and virtual path targets recursively include subfolders. Tagged requests never use filesystem fallback because unindexed files have no tag metadata.
+
 #### Example
 
 ##### Request
@@ -520,7 +522,7 @@ None.
 
 Query the media database and return all matching indexed media.
 
-**Note:** This API now uses cursor-based pagination for all requests. The `total` field is deprecated and always returns -1. Use the `pagination` object to navigate through results. For subsequent pages, include the `nextCursor` value in the `cursor` parameter of your next request.
+**Note:** This API uses cursor-based pagination for all requests. The `total` field is deprecated and returns only the current response-page count; it is not the full match count. Use the `pagination` object to navigate through results. For subsequent pages, include the `nextCursor` value and repeat the same systems, query, tags, letter, and sort scope.
 
 #### Parameters
 
@@ -531,9 +533,10 @@ An object:
 | query      | string   | No       | Case-insensitive search by filename. By default, query is split by white space and results are found which contain every word. If omitted, all media is returned. |
 | systems    | string[] | No       | Case-sensitive list of system IDs to restrict search to. A missing key or empty list will search all systems.                  |
 | maxResults | number   | No       | Max number of results to return. Default is 100.                                                                               |
-| cursor     | string   | No       | Cursor for pagination. Omit for first page, use `nextCursor` from previous response for subsequent pages.                     |
-| tags       | string[] | No       | Filter results by tags. Maximum 50 tags, each up to 128 characters. Tags are case-sensitive and results must match all provided tags. Can be used without query or systems for tag-only searches. |
+| cursor     | string   | No       | Cursor for pagination. Omit for first page, use `nextCursor` from previous response for subsequent pages with the same scope and sort. |
+| tags       | string[] | No       | Filter results by case-sensitive tags. Maximum 50 tags, each up to 128 characters. Default and `+` filters require matches, `-` excludes matches, and `~` joins alternatives. Can be used without query or systems for tag-only searches. |
 | letter     | string   | No       | Filter results by first character of game name. Supports: A-Z (single letters), "0-9" (numbers), "#" (symbols). Case-insensitive. |
+| sort       | string   | No       | Explicit order: `name-asc`, `name-desc`, `filename-asc`, or `filename-desc`. Name uses the returned display name with SQLite's case-insensitive collation; filename uses full indexed path. Omitted preserves legacy database order. |
 | fuzzySystem | boolean | No       | Enable fuzzy matching for system IDs in the `systems` array (e.g., `"snes"` matches `"SNES"`). |
 
 #### Result
@@ -566,6 +569,7 @@ An object:
 | category     | string | No       | Category of system (e.g., "Console", "Computer"). Not yet formalised.    |
 | releaseDate  | string | No       | Release date of the system in ISO 8601 format (YYYY-MM-DD).              |
 | manufacturer | string | No       | Manufacturer of the system (e.g., "Nintendo", "Sega").                   |
+| mediaCount   | number | No       | Exact non-missing indexed media-row count for this system, or exact matching count when `systems.tags` is set. Zero means the system is supported but empty. Omitted by older Core versions or when counts are unavailable. |
 
 ##### Pagination object
 
@@ -706,6 +710,8 @@ Browse indexed media content by directory, similar to navigating a file manager.
 
 When called without a `path` parameter (or with an empty path), returns top-level root entries including filesystem roots and virtual scheme roots. When `systems` is provided without `path`, returns populated launcher routes for those systems only. Pass the same `systems` filter when browsing a returned route to keep shared paths scoped to the selected systems.
 
+Tags filter direct media files in the current path. Directories remain visible for navigation with unfiltered `fileCount` values, while `totalFiles`, file pagination, and cursors reflect only matching files. Tagged directory entries remain plain directories rather than being promoted to logical single-game aliases.
+
 #### Parameters
 
 All parameters are optional. When called with no parameters, returns root entries.
@@ -716,7 +722,8 @@ All parameters are optional. When called with no parameters, returns root entrie
 | systems    | string[] | No     | Case-sensitive list of system IDs to restrict route discovery and browse results to. A missing key or empty list preserves unfiltered behavior. |
 | fuzzySystem | boolean | No     | Enable fuzzy matching for system IDs in the `systems` array (e.g., `"snes"` matches `"SNES"`). |
 | maxResults | number | No       | Maximum results per page. Default is 100, maximum is 1000.                                                 |
-| cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page. Cursors are valid only with the same path, systems, letter, and sort parameters. |
+| cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page. Cursors are valid only with the same path, systems, tags, letter, and sort parameters. |
+| tags       | string[] | No     | Filter direct media files by tags. Syntax and AND/NOT/OR operators match `media.search`. Directories remain unfiltered. |
 | letter     | string | No       | Filter results to entries starting with this letter.                                                       |
 | sort       | string | No       | Sort order. One of: `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. Name sorting is prefix-aware for detected ranked/date collection folders. The `filename` variants sort by full file path. |
 
@@ -726,7 +733,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | :--------- | :------------------------------------ | :------- | :----------------------------------------------------------------------- |
 | path       | string                                | Yes      | The browsed directory path. Empty string when listing roots.             |
 | entries    | [BrowseEntry](#browse-entry-object)[] | Yes      | Array of entries in the current path.                                    |
-| totalFiles | number                                | Yes      | Total count of media files in the current directory (respects `letter` filter). |
+| totalFiles | number                                | Yes      | Total count of media files in the current directory (respects `tags` and `letter` filters). |
 | pagination | [Pagination](#browse-pagination-object) | No     | Pagination info. Omitted when there are no file results.                 |
 
 ##### Browse entry object
@@ -866,7 +873,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 
 Return the ordered first-character "jump to letter" buckets for a browse scope. Each bucket carries a count and a ready-to-use cursor that seeks `media.browse` to the start of that bucket, so a single round trip gives a client everything it needs to draw a section rail _and_ jump into the full ordered list. This avoids paging from the top to reach a distant section, which matters on constrained clients (e.g. MiSTer).
 
-The scope parameters mirror `media.browse` so the index describes the exact list `media.browse` would return for the same scope. The per-bucket `cursor` is an ordinary browse cursor: pass it to `media.browse` with the same `path`/`systems`/`sort` to get a normal page that begins at the bucket and continues into the next bucket as the user scrolls.
+The scope parameters mirror `media.browse` so the index describes the exact media-file list `media.browse` would return for the same scope. The per-bucket `cursor` is an ordinary browse cursor: pass it to `media.browse` with the same `path`/`systems`/`tags`/`sort` to get a normal page that begins at the bucket and continues into the next bucket as the user scrolls.
 
 #### Parameters
 
@@ -877,6 +884,7 @@ All parameters are optional.
 | path        | string   | No       | Directory or virtual scheme to index, same as `media.browse`. Omit or set empty for a root listing (no rail applies). |
 | systems     | string[] | No       | Case-sensitive system IDs to scope the index to, same as `media.browse`.                          |
 | fuzzySystem | boolean  | No       | Enable fuzzy matching for system IDs in `systems`.                                                |
+| tags        | string[] | No       | Filter indexed media by tags, using the same syntax and operators as `media.browse`.               |
 | sort        | string   | No       | Sort order, must match the `media.browse` sort the rail is for. One of `name-asc` (default), `name-desc`, `filename-asc`, `filename-desc`. |
 
 #### Result
@@ -884,7 +892,7 @@ All parameters are optional.
 | Key        | Type                                          | Required | Description                                                                 |
 | :--------- | :-------------------------------------------- | :------- | :-------------------------------------------------------------------------- |
 | scheme     | string                                        | Yes      | Collation used to derive the buckets. `latin` for first-character bucketing; `none` when no rail applies (a root listing, or a directory whose effective sort is not alphabetical, e.g. a ranked/date-prefixed collection folder), in which case `groups` is empty. |
-| totalFiles | number                                        | Yes      | Total media files in the scope.                                             |
+| totalFiles | number                                        | Yes      | Total media files matching the complete systems/path/tags scope.             |
 | groups     | [BrowseIndexGroup](#browse-index-group-object)[] | Yes   | Only non-empty buckets, ordered to match `sort`.                            |
 
 ##### Browse index group object
@@ -2387,17 +2395,22 @@ List systems currently indexed or supported by an available launcher on the runn
 
 Set `all` to include every system represented by the running platform's launcher definitions, even when its runtime dependency is currently unavailable. This is useful when selecting a specific system for its first media index.
 
+Responses include an exact non-missing `mediaCount` for each system when the media database count query succeeds. Supported systems with no indexed media have `mediaCount: 0`. The field is omitted if counts are unavailable, preserving compatibility with older clients and database-error fallback behavior.
+
+Set `tags` to return only systems containing matching non-missing media. Tagged responses use `mediaCount` for the exact matching count and omit zero-match systems. Tag syntax and AND/NOT/OR operators match `media.search`. Tags remain the final filter when combined with `all`, so launcher-only systems with no matching media are omitted.
+
 #### Parameters
 
-| Key | Type    | Required | Description                                                                                     |
-| :-- | :------ | :------- | :---------------------------------------------------------------------------------------------- |
-| all | boolean | No       | Include systems with unavailable launchers. Defaults to `false`. Indexed systems remain listed. |
+| Key  | Type     | Required | Description                                                                                     |
+| :--- | :------- | :------- | :---------------------------------------------------------------------------------------------- |
+| all  | boolean  | No       | Include systems with unavailable launchers. Defaults to `false`. Indexed systems remain listed. |
+| tags | string[] | No       | Return systems with matching media. Uses the same tag syntax and operators as `media.search`.    |
 
 #### Result
 
 | Key     | Type                       | Required | Description                                                        |
 | :------ | :------------------------- | :------- | :----------------------------------------------------------------- |
-| systems | [System](#system-object)[] | Yes      | Indexed, available, and optionally unavailable platform systems.   |
+| systems | [System](#system-object)[] | Yes      | Indexed, available, and optionally unavailable platform systems. Tagged requests include only positive-count systems. |
 
 See [System object](#system-object).
 
@@ -2429,14 +2442,16 @@ See [System object](#system-object).
         "name": "Gameboy Color",
         "category": "Handheld",
         "releaseDate": "1998-10-21",
-        "manufacturer": "Nintendo"
+        "manufacturer": "Nintendo",
+        "mediaCount": 842
       },
       {
         "id": "EDSAC",
         "name": "EDSAC",
         "category": "Computer",
         "releaseDate": "1949-05-06",
-        "manufacturer": "University of Cambridge"
+        "manufacturer": "University of Cambridge",
+        "mediaCount": 0
       }
     ]
   }

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -522,7 +522,7 @@ None.
 
 Query the media database and return all matching indexed media.
 
-**Note:** This API uses cursor-based pagination for all requests. The `total` field is deprecated and returns only the current response-page count; it is not the full match count. Use the `pagination` object to navigate through results. For subsequent pages, include the `nextCursor` value and repeat the same systems, query, tags, letter, and sort scope.
+**Note:** This API uses cursor-based pagination for all requests. The `total` field is deprecated and returns only the current response-page count; it is not the full match count. Use the `pagination` object to navigate through results. For subsequent pages, include the `nextCursor` value and repeat the same systems, pathPrefix, query, tags, letter, and sort scope.
 
 #### Parameters
 
@@ -532,6 +532,7 @@ An object:
 | :--------- | :------- | :------- | :----------------------------------------------------------------------------------------------------------------------------- |
 | query      | string   | No       | Case-insensitive search by filename. By default, query is split by white space and results are found which contain every word. If omitted, all media is returned. |
 | systems    | string[] | No       | Case-sensitive list of system IDs to restrict search to. A missing key or empty list will search all systems.                  |
+| pathPrefix | string   | No       | Recursively restrict results beneath a filesystem directory or virtual route. Matching respects path boundaries, so `/roms/SNES` does not include `/roms/SNES2`; `%` and `_` are literal path characters. |
 | maxResults | number   | No       | Max number of results to return. Default is 100.                                                                               |
 | cursor     | string   | No       | Cursor for pagination. Omit for first page, use `nextCursor` from previous response for subsequent pages with the same scope and sort. |
 | tags       | string[] | No       | Filter results by case-sensitive tags. Maximum 50 tags, each up to 128 characters. Default and `+` filters require matches, `-` excludes matches, and `~` joins alternatives. Can be used without query or systems for tag-only searches. |

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -570,7 +570,7 @@ An object:
 | category     | string | No       | Category of system (e.g., "Console", "Computer"). Not yet formalised.    |
 | releaseDate  | string | No       | Release date of the system in ISO 8601 format (YYYY-MM-DD).              |
 | manufacturer | string | No       | Manufacturer of the system (e.g., "Nintendo", "Sega").                   |
-| mediaCount   | number | No       | Exact non-missing indexed media-row count for this system, or exact matching count when `systems.tags` is set. Zero means the system is supported but empty. Omitted by older Core versions or when counts are unavailable. |
+| mediaCount   | number | No       | Populated only in `systems` responses; not included on System objects nested in `media.search` results. Exact non-missing indexed media-row count for this system, or exact matching count when `systems.tags` is set. Zero means the system is supported but empty. Omitted by older Core versions or when counts are unavailable. |
 
 ##### Pagination object
 

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -950,6 +950,10 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	if params.Query != nil {
 		query = *params.Query
 	}
+	var pathPrefix string
+	if params.PathPrefix != nil {
+		pathPrefix = *params.PathPrefix
+	}
 	tagParams := params.Tags
 
 	// Validate and parse tags parameter - requires type:value format
@@ -987,6 +991,7 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	searchFilters := database.SearchFilters{
 		Systems:    systems,
+		PathPrefix: pathPrefix,
 		Query:      query,
 		Sort:       sortOrder,
 		Tags:       tagFilters, // Will be empty if no tags provided

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/bgpriority"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/rs/zerolog/log"
@@ -163,12 +164,16 @@ func resolveSystems(ids []string, fuzzy bool) ([]systemdefs.System, error) {
 	return systems, nil
 }
 
+const sortedSearchCursorVersion = 2
+
 type cursorData struct {
-	LastID int64 `json:"lastId"`
+	SortValue string `json:"sortValue,omitempty"`
+	Sort      string `json:"sort,omitempty"`
+	Version   int    `json:"version,omitempty"`
+	LastID    int64  `json:"lastId"`
 }
 
-func encodeCursor(lastID int64) (string, error) {
-	data := cursorData{LastID: lastID}
+func encodeMediaSearchCursorData(data cursorData) (string, error) {
 	bytes, err := json.Marshal(data)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal cursor data: %w", err)
@@ -176,7 +181,28 @@ func encodeCursor(lastID int64) (string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
-func decodeCursor(cursor string) (*int64, error) {
+func encodeCursor(lastID int64) (string, error) {
+	return encodeMediaSearchCursorData(cursorData{LastID: lastID})
+}
+
+func encodeSortedSearchCursor(result *database.SearchResultWithCursor, sortOrder string) (string, error) {
+	sortValue := result.SortValue
+	if sortValue == "" {
+		if strings.HasPrefix(sortOrder, "filename-") {
+			sortValue = result.Path
+		} else {
+			sortValue = result.Name
+		}
+	}
+	return encodeMediaSearchCursorData(cursorData{
+		Version:   sortedSearchCursorVersion,
+		Sort:      sortOrder,
+		SortValue: sortValue,
+		LastID:    result.MediaID,
+	})
+}
+
+func decodeCursorData(cursor string) (*cursorData, error) {
 	if cursor == "" {
 		return nil, nil //nolint:nilnil // empty cursor is valid and should return nil
 	}
@@ -187,12 +213,44 @@ func decodeCursor(cursor string) (*int64, error) {
 	}
 
 	var data cursorData
-	err = json.Unmarshal(bytes, &data)
-	if err != nil {
+	if err = json.Unmarshal(bytes, &data); err != nil {
 		return nil, models.ClientErrf("invalid cursor data: %w", err)
 	}
+	return &data, nil
+}
 
+func decodeCursor(cursor string) (*int64, error) {
+	data, err := decodeCursorData(cursor)
+	if err != nil || data == nil {
+		return nil, err
+	}
+	if data.Version != 0 || data.Sort != "" || data.SortValue != "" {
+		return nil, models.ClientErrf("cursor requires matching search sort")
+	}
 	return &data.LastID, nil
+}
+
+func decodeMediaSearchCursor(
+	cursor string,
+	sortOrder string,
+) (*int64, *database.SearchCursor, error) {
+	if sortOrder == "" {
+		legacy, err := decodeCursor(cursor)
+		return legacy, nil, err
+	}
+
+	data, err := decodeCursorData(cursor)
+	if err != nil || data == nil {
+		return nil, nil, err
+	}
+	if data.Version != sortedSearchCursorVersion || data.Sort != sortOrder {
+		return nil, nil, models.ClientErrf("cursor does not match search sort %q", sortOrder)
+	}
+	return nil, &database.SearchCursor{
+		SortValue: data.SortValue,
+		Sort:      data.Sort,
+		LastID:    data.LastID,
+	}, nil
 }
 
 type indexingStatusVals struct {
@@ -814,6 +872,40 @@ func HandleGenerateMedia(env requests.RequestEnv) (any, error) {
 	return nil, err
 }
 
+func searchResultSystem(systemID string, launcherCache *helpers.LauncherCache) models.System {
+	result := models.System{ID: systemID, Name: systemID}
+	if system, err := systemdefs.GetSystem(systemID); err == nil {
+		result.ID = system.ID
+		metadata, metadataErr := assets.GetSystemMetadata(system.ID)
+		if metadataErr != nil {
+			log.Err(metadataErr).Str("systemID", system.ID).Msg("error getting system metadata")
+			return result
+		}
+		result.Name = metadata.Name
+		result.Category = metadata.Category
+		if metadata.ReleaseDate != "" {
+			result.ReleaseDate = &metadata.ReleaseDate
+		}
+		if metadata.Manufacturer != "" {
+			result.Manufacturer = &metadata.Manufacturer
+		}
+		return result
+	}
+
+	if launcherCache != nil {
+		for _, system := range launcherCache.GetLaunchableSystems() {
+			if launchables.EncodeID(system.ID) != systemID {
+				continue
+			}
+			result.Name = system.Name
+			result.Category = system.Category
+			result.ZapScript = system.ZapScript()
+			break
+		}
+	}
+	return result
+}
+
 func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	log.Info().Msg("received media search request")
 
@@ -837,12 +929,18 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 
 	ctx := env.Context
 
-	// Handle cursor-based pagination
+	var sortOrder string
+	if params.Sort != nil {
+		sortOrder = *params.Sort
+	}
+
+	// Handle cursor-based pagination. Legacy unsorted requests keep their
+	// DBID-only cursor; explicit sorts use a compound sort-value/DBID cursor.
 	var cursorStr string
 	if params.Cursor != nil {
 		cursorStr = *params.Cursor
 	}
-	cursor, err := decodeCursor(cursorStr)
+	cursor, sortCursor, err := decodeMediaSearchCursor(cursorStr, sortOrder)
 	if err != nil {
 		return nil, models.ClientErrf("invalid cursor: %w", err)
 	}
@@ -888,12 +986,14 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	}
 
 	searchFilters := database.SearchFilters{
-		Systems: systems,
-		Query:   query,
-		Tags:    tagFilters, // Will be empty if no tags provided
-		Letter:  validatedLetter,
-		Cursor:  cursor,
-		Limit:   limit,
+		Systems:    systems,
+		Query:      query,
+		Sort:       sortOrder,
+		Tags:       tagFilters, // Will be empty if no tags provided
+		Letter:     validatedLetter,
+		Cursor:     cursor,
+		SortCursor: sortCursor,
+		Limit:      limit,
 	}
 
 	searchResults, err = env.Database.MediaDB.SearchMediaWithFilters(ctx, &searchFilters)
@@ -915,30 +1015,7 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	results := make([]models.SearchResultMedia, 0, len(searchResults))
 	for i := range searchResults {
 		result := &searchResults[i]
-		system, err := systemdefs.GetSystem(result.SystemID)
-		if err != nil {
-			continue
-		}
-
-		resultSystem := models.System{
-			ID: system.ID,
-		}
-
-		metadata, err := assets.GetSystemMetadata(system.ID)
-		if err != nil {
-			resultSystem.Name = system.ID
-			log.Err(err).Msg("error getting system metadata")
-		} else {
-			resultSystem.Name = metadata.Name
-			resultSystem.Category = metadata.Category
-			if metadata.ReleaseDate != "" {
-				resultSystem.ReleaseDate = &metadata.ReleaseDate
-			}
-			if metadata.Manufacturer != "" {
-				resultSystem.Manufacturer = &metadata.Manufacturer
-			}
-		}
-
+		resultSystem := searchResultSystem(result.SystemID, env.LauncherCache)
 		zapScript := result.ZapScript()
 
 		var relPath *string
@@ -967,7 +1044,13 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 		var nextCursor *string
 		if hasNextPage {
 			lastResult := searchResults[len(searchResults)-1]
-			cursorStr, err := encodeCursor(lastResult.MediaID)
+			var cursorStr string
+			var err error
+			if sortOrder == "" {
+				cursorStr, err = encodeCursor(lastResult.MediaID)
+			} else {
+				cursorStr, err = encodeSortedSearchCursor(&lastResult, sortOrder)
+			}
 			if err != nil {
 				log.Error().Err(err).Msg("failed to encode next cursor")
 				return nil, fmt.Errorf("failed to generate next page cursor: %w", err)

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -872,7 +872,10 @@ func HandleGenerateMedia(env requests.RequestEnv) (any, error) {
 	return nil, err
 }
 
-func searchResultSystem(systemID string, launcherCache *helpers.LauncherCache) models.System {
+func searchResultSystem(
+	systemID string,
+	launchableSystems map[string]launchables.VirtualSystem,
+) models.System {
 	result := models.System{ID: systemID, Name: systemID}
 	if system, err := systemdefs.GetSystem(systemID); err == nil {
 		result.ID = system.ID
@@ -892,16 +895,10 @@ func searchResultSystem(systemID string, launcherCache *helpers.LauncherCache) m
 		return result
 	}
 
-	if launcherCache != nil {
-		for _, system := range launcherCache.GetLaunchableSystems() {
-			if launchables.EncodeID(system.ID) != systemID {
-				continue
-			}
-			result.Name = system.Name
-			result.Category = system.Category
-			result.ZapScript = system.ZapScript()
-			break
-		}
+	if system, ok := launchableSystems[systemID]; ok {
+		result.Name = system.Name
+		result.Category = system.Category
+		result.ZapScript = system.ZapScript()
 	}
 	return result
 }
@@ -1017,10 +1014,19 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	if env.LauncherCache != nil && env.Platform != nil {
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
+	var launchableSystems map[string]launchables.VirtualSystem
+	if env.LauncherCache != nil {
+		cachedSystems := env.LauncherCache.GetLaunchableSystems()
+		launchableSystems = make(map[string]launchables.VirtualSystem, len(cachedSystems))
+		for i := range cachedSystems {
+			launchableSystems[launchables.EncodeID(cachedSystems[i].ID)] = cachedSystems[i]
+		}
+	}
+
 	results := make([]models.SearchResultMedia, 0, len(searchResults))
 	for i := range searchResults {
 		result := &searchResults[i]
-		resultSystem := searchResultSystem(result.SystemID, env.LauncherCache)
+		resultSystem := searchResultSystem(result.SystemID, launchableSystems)
 		zapScript := result.ZapScript()
 
 		var relPath *string

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -29,10 +29,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/filters"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
@@ -178,6 +180,17 @@ func HandleMediaBrowse(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	return result, err
 }
 
+func parseBrowseTagFilters(rawTags *[]string) ([]zapscript.TagFilter, error) {
+	if rawTags == nil || len(*rawTags) == 0 {
+		return nil, nil
+	}
+	tagFilters, err := filters.ParseTagFilters(*rawTags)
+	if err != nil {
+		return nil, models.ClientErrf("failed to parse tag filters: %w", err)
+	}
+	return tagFilters, nil
+}
+
 func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // single-use parameter in API handler
 	select {
 	case browseSem <- struct{}{}:
@@ -192,6 +205,11 @@ func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 			log.Warn().Err(err).Msg("invalid browse params")
 			return nil, models.ClientErrf("invalid params: %w", err)
 		}
+	}
+
+	tagFilters, err := parseBrowseTagFilters(params.Tags)
+	if err != nil {
+		return nil, err
 	}
 
 	maxResults := defaultMaxResults
@@ -235,11 +253,11 @@ func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 
 	// Virtual path (contains ://)
 	if strings.Contains(path, "://") {
-		return browseVirtual(&env, path, cursor, maxResults, params.Letter, sort, systems)
+		return browseVirtual(&env, path, cursor, maxResults, params.Letter, sort, systems, tagFilters)
 	}
 
 	// Filesystem path
-	return browseFilesystem(&env, path, cursor, maxResults, params.Letter, sort, systems)
+	return browseFilesystem(&env, path, cursor, maxResults, params.Letter, sort, systems, tagFilters)
 }
 
 // browseRoots returns the top-level root entries: filesystem roots with indexed
@@ -601,6 +619,7 @@ func browseFilesystem(
 	letter *string,
 	sort string,
 	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
 ) (any, error) {
 	// Normalize the path
 	cleaned := filepath.ToSlash(filepath.Clean(path))
@@ -676,7 +695,7 @@ func browseFilesystem(
 		// More directories remain: emit a directory-only page keyed by name.
 		if hasMoreDirs {
 			if cursor == nil {
-				totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems)
+				totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems, tags)
 				if err != nil {
 					return nil, err
 				}
@@ -685,14 +704,15 @@ func browseFilesystem(
 			if encErr != nil {
 				return nil, fmt.Errorf("failed to encode cursor: %w", encErr)
 			}
-			return buildBrowseResponse(env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, &next, true, systems)
+			return buildBrowseResponse(
+				env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, &next, true, systems, tags)
 		}
 
 		// Directories are exhausted. Fill the rest of the page with the first
 		// files so small folders return in a single round-trip (mixed boundary
 		// page), then continue paging files from there.
 		if cursor == nil {
-			totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems)
+			totalFiles, err = browseTotalFileCount(ctx, env, prefix, nil, systems, tags)
 			if err != nil {
 				return nil, err
 			}
@@ -711,7 +731,7 @@ func browseFilesystem(
 				next = &encoded
 			}
 			return buildBrowseResponse(
-				env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, next, hasNext, systems)
+				env, cleaned, dirs, nil, maxResults, totalFiles, totalDirs, next, hasNext, systems, tags)
 		}
 
 		started = time.Now()
@@ -720,6 +740,7 @@ func browseFilesystem(
 			Limit:      remaining + 1,
 			Sort:       sort,
 			Systems:    systems,
+			Tags:       tags,
 		})
 		logBrowseTiming("files", prefix, started, len(files))
 		if err != nil {
@@ -730,7 +751,7 @@ func browseFilesystem(
 			return nil, encErr
 		}
 		return buildBrowseResponse(
-			env, cleaned, dirs, files, maxResults, totalFiles, totalDirs, next, next != nil, systems)
+			env, cleaned, dirs, files, maxResults, totalFiles, totalDirs, next, next != nil, systems, tags)
 	}
 
 	// Files phase. A files-phase cursor with no keyset (LastID == 0) marks the
@@ -748,6 +769,7 @@ func browseFilesystem(
 		Letter:     letter,
 		Sort:       sort,
 		Systems:    systems,
+		Tags:       tags,
 	})
 	logBrowseTiming("files", prefix, started, len(files))
 	if err != nil {
@@ -757,7 +779,7 @@ func browseFilesystem(
 	// Get total file count. First-page cursors carry this forward so loading
 	// additional pages in large directories does not repeat the same count query.
 	if totalFiles == 0 && (len(files) > 0 || cursor != nil) {
-		totalFiles, err = browseTotalFileCount(ctx, env, prefix, letter, systems)
+		totalFiles, err = browseTotalFileCount(ctx, env, prefix, letter, systems, tags)
 		if err != nil {
 			return nil, err
 		}
@@ -767,7 +789,8 @@ func browseFilesystem(
 	if encErr != nil {
 		return nil, encErr
 	}
-	return buildBrowseResponse(env, cleaned, nil, files, maxResults, totalFiles, totalDirs, next, next != nil, systems)
+	return buildBrowseResponse(
+		env, cleaned, nil, files, maxResults, totalFiles, totalDirs, next, next != nil, systems, tags)
 }
 
 // browseTotalFileCount returns the direct-child file count for a path prefix,
@@ -778,12 +801,14 @@ func browseTotalFileCount(
 	prefix string,
 	letter *string,
 	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
 ) (int, error) {
 	started := time.Now()
 	count, err := env.Database.MediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
 		PathPrefix: prefix,
 		Letter:     letter,
 		Systems:    systems,
+		Tags:       tags,
 	})
 	logBrowseTiming("file_count", prefix, started, count)
 	if err != nil {
@@ -830,6 +855,7 @@ func browseVirtual(
 	letter *string,
 	sort string,
 	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
 ) (any, error) {
 	// Validate scheme is known
 	if !isKnownVirtualScheme(env, schemePath) {
@@ -845,6 +871,7 @@ func browseVirtual(
 		Letter:     letter,
 		Sort:       sort,
 		Systems:    systems,
+		Tags:       tags,
 	}
 	started := time.Now()
 	files, err := env.Database.MediaDB.BrowseFiles(ctx, opts)
@@ -857,7 +884,7 @@ func browseVirtual(
 	if cursor != nil && cursor.TotalFiles > 0 {
 		totalFiles = cursor.TotalFiles
 	} else {
-		totalFiles, err = browseTotalFileCount(ctx, env, schemePath, letter, systems)
+		totalFiles, err = browseTotalFileCount(ctx, env, schemePath, letter, systems, tags)
 		if err != nil {
 			return nil, err
 		}
@@ -867,7 +894,8 @@ func browseVirtual(
 	if encErr != nil {
 		return nil, encErr
 	}
-	return buildBrowseResponse(env, schemePath, nil, files, maxResults, totalFiles, 0, next, next != nil, systems)
+	return buildBrowseResponse(
+		env, schemePath, nil, files, maxResults, totalFiles, 0, next, next != nil, systems, tags)
 }
 
 // buildBrowseResponse assembles a BrowseResults page from directory and file
@@ -886,13 +914,22 @@ func buildBrowseResponse(
 	nextCursor *string,
 	hasNextPage bool,
 	systems []systemdefs.System,
+	tagSets ...[]zapscript.TagFilter,
 ) (any, error) {
+	var tags []zapscript.TagFilter
+	if len(tagSets) > 0 {
+		tags = tagSets[0]
+	}
+
 	var rootDirs []string
 	if env.LauncherCache != nil && env.Platform != nil {
 		rootDirs = env.Platform.RootDirs(env.Config)
 	}
 
-	singletonAliases := resolveDirSingletonAliases(env, path, dirs, systems)
+	var singletonAliases map[string]database.SingletonContainerAlias
+	if len(tags) == 0 {
+		singletonAliases = resolveDirSingletonAliases(env, path, dirs, systems)
+	}
 
 	entries := make([]models.BrowseEntry, 0, len(dirs)+len(files))
 	for _, dir := range dirs {

--- a/pkg/api/methods/media_browse_index.go
+++ b/pkg/api/methods/media_browse_index.go
@@ -107,6 +107,11 @@ func browseMediaIndex(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		}
 	}
 
+	tagFilters, err := parseBrowseTagFilters(params.Tags)
+	if err != nil {
+		return nil, err
+	}
+
 	var sortOrder string
 	if params.Sort != nil {
 		sortOrder = *params.Sort
@@ -137,6 +142,7 @@ func browseMediaIndex(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		PathPrefix: prefix,
 		Sort:       sortOrder,
 		Systems:    systems,
+		Tags:       tagFilters,
 	})
 	logBrowseTiming("index", prefix, started, len(result.Buckets))
 	if err != nil {

--- a/pkg/api/methods/media_browse_index_test.go
+++ b/pkg/api/methods/media_browse_index_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -100,6 +101,40 @@ func TestHandleMediaBrowseIndex_FilesystemPath(t *testing.T) {
 	assert.Equal(t, "name-desc", cursor.SortMode)
 	assert.Equal(t, 3, cursor.TotalFiles)
 
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowseIndex_TagsReachDatabaseScope(t *testing.T) {
+	t.Parallel()
+
+	romsRoot := browseTestAbsPath("roms")
+	snesPath := filepath.Join(romsRoot, "SNES")
+	prefix := filepath.ToSlash(snesPath) + "/"
+	tags := []string{"user:favorite"}
+
+	mockPlatform := newBrowseIndexPlatform(t, []string{romsRoot})
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseIndex", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseIndexOptions) bool {
+			return opts.PathPrefix == prefix && len(opts.Tags) == 1 &&
+				opts.Tags[0].Type == "user" && opts.Tags[0].Value == "favorite" &&
+				opts.Tags[0].Operator == zapscript.TagOperatorAND
+		})).Return(database.BrowseIndexResult{
+		Scheme:     "latin",
+		SortMode:   "name-asc",
+		TotalFiles: 1,
+		Buckets:    []database.BrowseIndexBucket{{Key: "A", AtStart: true, Count: 1}},
+	}, nil)
+
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{Path: &snesPath, Tags: &tags})
+	result, err := HandleMediaBrowseIndex(env)
+	require.NoError(t, err)
+
+	res, ok := result.(models.BrowseIndexResults)
+	require.True(t, ok)
+	assert.Equal(t, 1, res.TotalFiles)
+	require.Len(t, res.Groups, 1)
+	assert.Equal(t, "A", res.Groups[0].Key)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -1237,10 +1237,14 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 func TestHandleMediaBrowse_FilesystemFiltersFilesByTags(t *testing.T) {
 	t.Parallel()
 
+	romsRoot := filepath.Join(browseTestAbsPath(), "roms")
+	snesPath := filepath.Join(romsRoot, "SNES")
+	dbSNESPrefix := filepath.ToSlash(snesPath) + "/"
+
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
 	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
-		Return([]string{"/roms"})
+		Return([]string{romsRoot})
 	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
 		Return([]platforms.Launcher{})
 
@@ -1248,25 +1252,25 @@ func TestHandleMediaBrowse_FilesystemFiltersFilesByTags(t *testing.T) {
 		return len(tags) == 1 && tags[0].Type == "user" && tags[0].Value == "favorite"
 	}
 	mockMediaDB := helpers.NewMockMediaDBI()
-	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts(dbSNESPrefix)).
 		Return([]database.BrowseDirectoryResult{{Name: "RPG", FileCount: 99}}, nil)
-	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts(dbSNESPrefix)).
 		Return(1, nil)
 	mockMediaDB.On("BrowseFiles", mock.Anything,
 		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
-			return opts.PathPrefix == "/roms/SNES/" && tagMatcher(opts.Tags)
+			return opts.PathPrefix == dbSNESPrefix && tagMatcher(opts.Tags)
 		})).Return([]database.SearchResultWithCursor{{
 		SystemID: "SNES",
 		Name:     "Chrono Trigger",
-		Path:     "/roms/SNES/Chrono Trigger.sfc",
+		Path:     filepath.ToSlash(filepath.Join(snesPath, "Chrono Trigger.sfc")),
 		MediaID:  7,
 	}}, nil)
 	mockMediaDB.On("BrowseFileCount", mock.Anything,
 		mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
-			return opts.PathPrefix == "/roms/SNES/" && tagMatcher(opts.Tags)
+			return opts.PathPrefix == dbSNESPrefix && tagMatcher(opts.Tags)
 		})).Return(1, nil)
 
-	path := "/roms/SNES"
+	path := snesPath
 	tags := []string{"user:favorite"}
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
 		Path: &path,
@@ -1895,6 +1899,55 @@ func TestHandleMediaBrowse_VirtualScheme(t *testing.T) {
 	assert.Equal(t, "media", browseResults.Entries[0].Type)
 	assert.Equal(t, "Team Fortress 2", browseResults.Entries[0].Name)
 
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_VirtualFiltersFilesByTags(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{browseTestAbsPath("roms")})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{
+			{ID: "Steam", SystemID: "Windows", Schemes: []string{"steam"}},
+		})
+
+	tagMatcher := func(tags []zapscript.TagFilter) bool {
+		return len(tags) == 1 &&
+			tags[0].Type == "user" &&
+			tags[0].Value == "favorite" &&
+			tags[0].Operator == zapscript.TagOperatorAND
+	}
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseFiles", mock.Anything,
+		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+			return opts.PathPrefix == "steam://" && tagMatcher(opts.Tags)
+		})).Return([]database.SearchResultWithCursor{{
+		SystemID: "Windows",
+		Name:     "Favorite Game",
+		Path:     "steam://440/favorite-game",
+		MediaID:  10,
+	}}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+			return opts.PathPrefix == "steam://" && tagMatcher(opts.Tags)
+		})).Return(1, nil)
+
+	path := "steam://"
+	tags := []string{"user:favorite"}
+	result, err := HandleMediaBrowse(newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path: &path,
+		Tags: &tags,
+	}))
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, 1, browseResults.TotalFiles)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Equal(t, "Favorite Game", browseResults.Entries[0].Name)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -1230,6 +1231,60 @@ func TestHandleMediaBrowse_FilesystemWithFiles(t *testing.T) {
 	assert.Equal(t, "snes", *browseResults.Entries[0].SystemID)
 	require.NotNil(t, browseResults.Entries[0].ZapScript)
 
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_FilesystemFiltersFilesByTags(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{"/roms"})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).
+		Return([]platforms.Launcher{})
+
+	tagMatcher := func(tags []zapscript.TagFilter) bool {
+		return len(tags) == 1 && tags[0].Type == "user" && tags[0].Value == "favorite"
+	}
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseDirectories", mock.Anything, browseDirectoriesOpts("/roms/SNES/")).
+		Return([]database.BrowseDirectoryResult{{Name: "RPG", FileCount: 99}}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, browseDirCountOpts("/roms/SNES/")).
+		Return(1, nil)
+	mockMediaDB.On("BrowseFiles", mock.Anything,
+		mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+			return opts.PathPrefix == "/roms/SNES/" && tagMatcher(opts.Tags)
+		})).Return([]database.SearchResultWithCursor{{
+		SystemID: "SNES",
+		Name:     "Chrono Trigger",
+		Path:     "/roms/SNES/Chrono Trigger.sfc",
+		MediaID:  7,
+	}}, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything,
+		mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+			return opts.PathPrefix == "/roms/SNES/" && tagMatcher(opts.Tags)
+		})).Return(1, nil)
+
+	path := "/roms/SNES"
+	tags := []string{"user:favorite"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Path: &path,
+		Tags: &tags,
+	})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	assert.Equal(t, 1, browseResults.TotalDirs)
+	assert.Equal(t, 1, browseResults.TotalFiles)
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, "directory", browseResults.Entries[0].Type)
+	assert.Equal(t, 99, *browseResults.Entries[0].FileCount)
+	assert.Zero(t, browseResults.Entries[0].MediaID, "tagged directories must not be promoted to media aliases")
+	assert.Equal(t, "media", browseResults.Entries[1].Type)
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases", mock.Anything, mock.Anything, mock.Anything)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -33,10 +33,12 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	phelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -113,6 +115,25 @@ func TestSearchResultSystem_UnknownSystemFallsBackToID(t *testing.T) {
 	result := searchResultSystem("virtual-system", nil)
 	assert.Equal(t, "virtual-system", result.ID)
 	assert.Equal(t, "virtual-system", result.Name)
+}
+
+func TestSearchResultSystem_UsesLaunchableSystemMap(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
+	encodedID := launchables.EncodeID(id)
+	result := searchResultSystem(encodedID, map[string]launchables.VirtualSystem{
+		encodedID: {
+			ID:       id,
+			Name:     "Chess",
+			Category: "Other",
+		},
+	})
+
+	assert.Equal(t, encodedID, result.ID)
+	assert.Equal(t, "Chess", result.Name)
+	assert.Equal(t, "Other", result.Category)
+	assert.Equal(t, "zaparoo://"+encodedID+"/Chess", result.ZapScript)
 }
 
 func TestDecodeCursor_InvalidInputs(t *testing.T) {

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -81,6 +81,40 @@ func TestCursorEncodeDecycle(t *testing.T) {
 	}
 }
 
+func TestSortedSearchCursorEncodeDecode(t *testing.T) {
+	t.Parallel()
+
+	encoded, err := encodeSortedSearchCursor(&database.SearchResultWithCursor{
+		SortValue: "Bravo",
+		MediaID:   42,
+	}, "name-asc")
+	require.NoError(t, err)
+
+	legacy, sorted, err := decodeMediaSearchCursor(encoded, "name-asc")
+	require.NoError(t, err)
+	assert.Nil(t, legacy)
+	require.NotNil(t, sorted)
+	assert.Equal(t, "name-asc", sorted.Sort)
+	assert.Equal(t, "Bravo", sorted.SortValue)
+	assert.Equal(t, int64(42), sorted.LastID)
+
+	_, _, err = decodeMediaSearchCursor(encoded, "name-desc")
+	require.Error(t, err)
+
+	legacyEncoded, err := encodeCursor(42)
+	require.NoError(t, err)
+	_, _, err = decodeMediaSearchCursor(legacyEncoded, "name-asc")
+	require.Error(t, err)
+}
+
+func TestSearchResultSystem_UnknownSystemFallsBackToID(t *testing.T) {
+	t.Parallel()
+
+	result := searchResultSystem("virtual-system", nil)
+	assert.Equal(t, "virtual-system", result.ID)
+	assert.Equal(t, "virtual-system", result.Name)
+}
+
 func TestDecodeCursor_InvalidInputs(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -199,6 +233,51 @@ func TestHandleMediaSearch_WithoutCursor(t *testing.T) {
 		assert.Equal(t, "Mario Bros", searchResults.Results[0].Name)
 		assert.Equal(t, "/games/mario.nes", searchResults.Results[0].Path)
 	}
+}
+
+func TestHandleMediaSearch_WithExplicitSort(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("SearchMediaWithFilters", mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.Sort == "name-asc" && filters.Cursor == nil &&
+				filters.SortCursor == nil && filters.Limit == 3
+		})).Return([]database.SearchResultWithCursor{
+		{SystemID: "NES", Name: "Alpha", Path: filepath.Join("games", "alpha.nes"), MediaID: 1, SortValue: "Alpha"},
+		{SystemID: "NES", Name: "Bravo", Path: filepath.Join("games", "bravo.nes"), MediaID: 2, SortValue: "Bravo"},
+		{
+			SystemID: "NES", Name: "Charlie", Path: filepath.Join("games", "charlie.nes"),
+			MediaID: 3, SortValue: "Charlie",
+		},
+	}, nil)
+
+	maxResults := 2
+	sortOrder := "name-asc"
+	paramsJSON, err := json.Marshal(models.SearchParams{MaxResults: &maxResults, Sort: &sortOrder})
+	require.NoError(t, err)
+
+	result, err := HandleMediaSearch(requests.RequestEnv{
+		Context: context.Background(),
+		Params:  paramsJSON,
+		Database: &database.Database{
+			MediaDB: mockMediaDB,
+		},
+	})
+	require.NoError(t, err)
+
+	searchResults, ok := result.(models.SearchResults)
+	require.True(t, ok)
+	require.Len(t, searchResults.Results, 2)
+	require.NotNil(t, searchResults.Pagination)
+	require.NotNil(t, searchResults.Pagination.NextCursor)
+	legacy, sorted, err := decodeMediaSearchCursor(*searchResults.Pagination.NextCursor, sortOrder)
+	require.NoError(t, err)
+	assert.Nil(t, legacy)
+	require.NotNil(t, sorted)
+	assert.Equal(t, "Bravo", sorted.SortValue)
+	assert.Equal(t, int64(2), sorted.LastID)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestHandleMediaSearch_WithCursor(t *testing.T) {

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -933,6 +933,42 @@ func TestResolveSystems_PreservesOrder(t *testing.T) {
 	assert.Equal(t, "Genesis", systems[2].ID)
 }
 
+func TestHandleMediaSearch_PassesPathPrefix(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	pathPrefix := "steam://44"
+	query := "target"
+
+	mockMediaDB.On("SearchMediaWithFilters",
+		mock.Anything,
+		mock.MatchedBy(func(filters *database.SearchFilters) bool {
+			return filters.PathPrefix == pathPrefix && filters.Query == query
+		}),
+	).Return([]database.SearchResultWithCursor{}, nil)
+
+	paramsJSON, err := json.Marshal(models.SearchParams{
+		PathPrefix: &pathPrefix,
+		Query:      &query,
+	})
+	require.NoError(t, err)
+
+	appState, _ := state.NewState(mockPlatform, "test-boot-uuid")
+	_, err = HandleMediaSearch(requests.RequestEnv{
+		Context: context.Background(),
+		Params:  paramsJSON,
+		Database: &database.Database{
+			MediaDB: mockMediaDB,
+		},
+		Platform: mockPlatform,
+		State:    appState,
+		Config:   &config.Instance{},
+	})
+	require.NoError(t, err)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaSearch_DeduplicatesSystems(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/systems.go
+++ b/pkg/api/methods/systems.go
@@ -20,10 +20,13 @@
 package methods
 
 import (
+	"fmt"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/filters"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/launchables"
 	"github.com/rs/zerolog/log"
@@ -39,10 +42,48 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 		}
 	}
 
-	indexed, err := env.Database.MediaDB.IndexedSystems()
-	if err != nil {
-		log.Error().Err(err).Msg("error getting indexed systems")
-		indexed = []string{}
+	tagged := params.Tags != nil && len(*params.Tags) > 0
+	mediaCounts := make(map[string]int)
+	mediaCountsAvailable := false
+	var indexed []string
+	if tagged {
+		tagFilters, err := filters.ParseTagFilters(*params.Tags)
+		if err != nil {
+			return nil, models.ClientErrf("failed to parse tag filters: %w", err)
+		}
+		counts, err := env.Database.MediaDB.SystemMediaCounts(env.Context, tagFilters)
+		if err != nil {
+			return nil, fmt.Errorf("error getting tagged system media counts: %w", err)
+		}
+		indexed = make([]string, 0, len(counts))
+		for _, count := range counts {
+			if count.SystemID == "" || count.Count <= 0 {
+				continue
+			}
+			indexed = append(indexed, count.SystemID)
+			mediaCounts[count.SystemID] = count.Count
+		}
+		mediaCountsAvailable = true
+	} else {
+		counts, err := env.Database.MediaDB.SystemMediaCounts(env.Context, nil)
+		if err == nil {
+			indexed = make([]string, 0, len(counts))
+			for _, count := range counts {
+				if count.SystemID == "" || count.Count <= 0 {
+					continue
+				}
+				indexed = append(indexed, count.SystemID)
+				mediaCounts[count.SystemID] = count.Count
+			}
+			mediaCountsAvailable = true
+		} else {
+			log.Error().Err(err).Msg("error getting system media counts")
+			indexed, err = env.Database.MediaDB.IndexedSystems()
+			if err != nil {
+				log.Error().Err(err).Msg("error getting indexed systems")
+				indexed = []string{}
+			}
+		}
 	}
 
 	if len(indexed) == 0 {
@@ -50,15 +91,20 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 	}
 
 	systemIDs := make([]string, 0, len(indexed))
-	seen := make(map[string]struct{}, len(indexed))
+	seenCandidates := make(map[string]struct{}, len(indexed))
 	addSystemID := func(id string) {
 		if id == "" {
 			return
 		}
-		if _, ok := seen[id]; ok {
+		if tagged {
+			if _, ok := mediaCounts[id]; !ok {
+				return
+			}
+		}
+		if _, ok := seenCandidates[id]; ok {
 			return
 		}
-		seen[id] = struct{}{}
+		seenCandidates[id] = struct{}{}
 		systemIDs = append(systemIDs, id)
 	}
 	for _, id := range indexed {
@@ -76,14 +122,19 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 	}
 
 	respSystems := make([]models.System, 0, len(systemIDs))
+	rendered := make(map[string]struct{}, len(systemIDs))
 	for _, id := range systemIDs {
 		system, systemErr := systemdefs.GetSystem(id)
 		if systemErr != nil {
-			log.Error().Err(systemErr).Msgf("error getting system: %s", id)
+			log.Debug().Err(systemErr).Msgf("system has no static definition: %s", id)
 			continue
 		}
 
 		sr := models.System{ID: system.ID}
+		if mediaCountsAvailable {
+			count := mediaCounts[id]
+			sr.MediaCount = &count
+		}
 		sm, metadataErr := assets.GetSystemMetadata(id)
 		if metadataErr != nil {
 			log.Error().Err(metadataErr).Msgf("error getting system metadata: %s", id)
@@ -98,20 +149,32 @@ func HandleSystems(env requests.RequestEnv) (any, error) { //nolint:gocritic // 
 			}
 		}
 		respSystems = append(respSystems, sr)
+		rendered[id] = struct{}{}
 	}
 
 	if env.LauncherCache != nil {
 		for _, system := range env.LauncherCache.GetLaunchableSystems() {
 			id := launchables.EncodeID(system.ID)
-			if _, ok := seen[id]; ok {
+			if _, ok := rendered[id]; ok {
 				continue
 			}
-			seen[id] = struct{}{}
+			var mediaCount *int
+			if tagged {
+				if _, ok := mediaCounts[id]; !ok {
+					continue
+				}
+			}
+			if mediaCountsAvailable {
+				count := mediaCounts[id]
+				mediaCount = &count
+			}
+			rendered[id] = struct{}{}
 			respSystems = append(respSystems, models.System{
-				ID:        id,
-				Name:      system.Name,
-				Category:  system.Category,
-				ZapScript: system.ZapScript(),
+				MediaCount: mediaCount,
+				ID:         id,
+				Name:       system.Name,
+				Category:   system.Category,
+				ZapScript:  system.ZapScript(),
 			})
 		}
 	}

--- a/pkg/api/methods/systems_test.go
+++ b/pkg/api/methods/systems_test.go
@@ -20,10 +20,12 @@
 package methods
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
 
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -32,12 +34,13 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHandleSystems_IncludesIndexedAndAvailableLauncherSystems(t *testing.T) {
 	mockMediaDB := testhelpers.NewMockMediaDBI()
-	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+	expectUntaggedSystemMediaCounts(mockMediaDB, []database.SystemMediaCount{{SystemID: "NES", Count: 12}}, nil)
 
 	cache := &helpers.LauncherCache{}
 	cache.InitializeFromSlice([]platforms.Launcher{
@@ -59,6 +62,8 @@ func TestHandleSystems_IncludesIndexedAndAvailableLauncherSystems(t *testing.T) 
 	response, ok := result.(models.SystemsResponse)
 	require.True(t, ok)
 	assert.Equal(t, []string{"NES", "SNES"}, systemResponseIDs(response))
+	assert.Equal(t, map[string]int{"NES": 12, "SNES": 0}, systemResponseMediaCounts(response))
+	mockMediaDB.AssertNotCalled(t, "IndexedSystems")
 	mockMediaDB.AssertExpectations(t)
 }
 
@@ -66,7 +71,7 @@ func TestHandleSystems_IncludesUnindexedAvailable3DO(t *testing.T) {
 	t.Parallel()
 
 	mockMediaDB := testhelpers.NewMockMediaDBI()
-	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
+	expectUntaggedSystemMediaCounts(mockMediaDB, []database.SystemMediaCount{}, nil)
 
 	cache := &helpers.LauncherCache{}
 	cache.InitializeFromSlice([]platforms.Launcher{{ID: "3DO", SystemID: "3DO"}})
@@ -80,12 +85,14 @@ func TestHandleSystems_IncludesUnindexedAvailable3DO(t *testing.T) {
 	response, ok := result.(models.SystemsResponse)
 	require.True(t, ok)
 	assert.Equal(t, []string{"3DO"}, systemResponseIDs(response))
+	assert.Equal(t, map[string]int{"3DO": 0}, systemResponseMediaCounts(response))
+	mockMediaDB.AssertNotCalled(t, "IndexedSystems")
 	mockMediaDB.AssertExpectations(t)
 }
 
 func TestHandleSystems_AllIncludesUnavailableLauncherSystems(t *testing.T) {
 	mockMediaDB := testhelpers.NewMockMediaDBI()
-	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+	expectUntaggedSystemMediaCounts(mockMediaDB, []database.SystemMediaCount{{SystemID: "NES", Count: 5}}, nil)
 
 	cache := &helpers.LauncherCache{}
 	cache.InitializeFromSlice([]platforms.Launcher{
@@ -107,7 +114,92 @@ func TestHandleSystems_AllIncludesUnavailableLauncherSystems(t *testing.T) {
 	response, ok := result.(models.SystemsResponse)
 	require.True(t, ok)
 	assert.Equal(t, []string{"NES", "SNES", "Genesis"}, systemResponseIDs(response))
+	assert.Equal(t, map[string]int{"NES": 5, "SNES": 0, "Genesis": 0}, systemResponseMediaCounts(response))
+	mockMediaDB.AssertNotCalled(t, "IndexedSystems")
 	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleSystems_CountFailureFallsBackWithoutMediaCount(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	expectUntaggedSystemMediaCounts(mockMediaDB, nil, errors.New("count failed"))
+	mockMediaDB.On("IndexedSystems").Return([]string{"NES"}, nil)
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{{ID: "snes", SystemID: "SNES"}})
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
+	})
+	require.NoError(t, err)
+
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []string{"NES", "SNES"}, systemResponseIDs(response))
+	assert.Empty(t, systemResponseMediaCounts(response))
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleSystems_TaggedReturnsMatchingCounts(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On(
+		"SystemMediaCounts",
+		mock.Anything,
+		mock.MatchedBy(func(tagFilters []zapscript.TagFilter) bool {
+			return len(tagFilters) == 1 &&
+				tagFilters[0].Type == "user" &&
+				tagFilters[0].Value == "favorite" &&
+				tagFilters[0].Operator == zapscript.TagOperatorAND
+		}),
+	).Return([]database.SystemMediaCount{
+		{SystemID: "NES", Count: 4},
+		{SystemID: "SNES", Count: 7},
+	}, nil)
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "nes", SystemID: "NES"},
+		{ID: "snes", SystemID: "SNES"},
+		{ID: "genesis", SystemID: "Genesis"},
+	})
+
+	result, err := HandleSystems(requests.RequestEnv{
+		Context:       context.Background(),
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		LauncherCache: cache,
+		Params:        json.RawMessage(`{"all":true,"tags":["user:favorite"]}`),
+	})
+	require.NoError(t, err)
+
+	response, ok := result.(models.SystemsResponse)
+	require.True(t, ok)
+	assert.Equal(t, []string{"NES", "SNES"}, systemResponseIDs(response))
+	require.Len(t, response.Systems, 2)
+	require.NotNil(t, response.Systems[0].MediaCount)
+	require.NotNil(t, response.Systems[1].MediaCount)
+	assert.Equal(t, 4, *response.Systems[0].MediaCount)
+	assert.Equal(t, 7, *response.Systems[1].MediaCount)
+	mockMediaDB.AssertNotCalled(t, "IndexedSystems")
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleSystems_TaggedRejectsInvalidTag(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	result, err := HandleSystems(requests.RequestEnv{
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Params:   json.RawMessage(`{"tags":["favorite"]}`),
+	})
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse tag filters")
+	mockMediaDB.AssertNotCalled(t, "SystemMediaCounts", mock.Anything, mock.Anything)
 }
 
 func TestHandleSystems_RejectsInvalidParams(t *testing.T) {
@@ -118,10 +210,32 @@ func TestHandleSystems_RejectsInvalidParams(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid params")
 }
 
+func expectUntaggedSystemMediaCounts(
+	mockMediaDB *testhelpers.MockMediaDBI,
+	counts []database.SystemMediaCount,
+	err error,
+) {
+	mockMediaDB.On(
+		"SystemMediaCounts",
+		mock.Anything,
+		mock.MatchedBy(func(tagFilters []zapscript.TagFilter) bool { return len(tagFilters) == 0 }),
+	).Return(counts, err)
+}
+
 func systemResponseIDs(response models.SystemsResponse) []string {
 	ids := make([]string, len(response.Systems))
 	for i := range response.Systems {
 		ids[i] = response.Systems[i].ID
 	}
 	return ids
+}
+
+func systemResponseMediaCounts(response models.SystemsResponse) map[string]int {
+	counts := make(map[string]int)
+	for i := range response.Systems {
+		if response.Systems[i].MediaCount != nil {
+			counts[response.Systems[i].ID] = *response.Systems[i].MediaCount
+		}
+	}
+	return counts
 }

--- a/pkg/api/methods/virtual_launchables_test.go
+++ b/pkg/api/methods/virtual_launchables_test.go
@@ -50,7 +50,7 @@ func (p *apiLaunchablePlatform) Launchables(*config.Instance) []launchables.Laun
 func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 	id := uuid.MustParse("01890f4a-33e8-4d44-d3a8-56824d352000")
 	mockMediaDB := testhelpers.NewMockMediaDBI()
-	mockMediaDB.On("IndexedSystems").Return([]string{}, nil)
+	expectUntaggedSystemMediaCounts(mockMediaDB, []database.SystemMediaCount{}, nil)
 	mockPlatform := &apiLaunchablePlatform{
 		MockPlatform: mocks.NewMockPlatform(),
 		defs: []launchables.Launchable{
@@ -87,5 +87,7 @@ func TestHandleSystems_IncludesVirtualSystems(t *testing.T) {
 	assert.Equal(t, "Chess", response.Systems[0].Name)
 	assert.Equal(t, "Other", response.Systems[0].Category)
 	assert.Equal(t, "zaparoo://"+launchables.EncodeID(id)+"/Chess", response.Systems[0].ZapScript)
+	require.NotNil(t, response.Systems[0].MediaCount)
+	assert.Zero(t, *response.Systems[0].MediaCount)
 	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -29,6 +29,7 @@ import (
 type SearchParams struct {
 	Systems     *[]string `json:"systems" validate:"omitempty,dive,min=1"`
 	FuzzySystem *bool     `json:"fuzzySystem,omitempty"`
+	PathPrefix  *string   `json:"pathPrefix,omitempty"`
 	MaxResults  *int      `json:"maxResults" validate:"omitempty,gt=0,max=1000"`
 	Cursor      *string   `json:"cursor,omitempty"`
 	Tags        *[]string `json:"tags,omitempty" validate:"omitempty,dive,min=1"`

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -33,6 +33,7 @@ type SearchParams struct {
 	Cursor      *string   `json:"cursor,omitempty"`
 	Tags        *[]string `json:"tags,omitempty" validate:"omitempty,dive,min=1"`
 	Letter      *string   `json:"letter,omitempty" validate:"omitempty,letter"`
+	Sort        *string   `json:"sort,omitempty" validate:"omitempty,oneof=name-asc name-desc filename-asc filename-desc"`
 	Query       *string   `json:"query"`
 }
 
@@ -42,12 +43,14 @@ type BrowseParams struct {
 	Path        *string   `json:"path,omitempty"`
 	MaxResults  *int      `json:"maxResults,omitempty" validate:"omitempty,gt=0,max=1000"`
 	Cursor      *string   `json:"cursor,omitempty"`
+	Tags        *[]string `json:"tags,omitempty" validate:"omitempty,dive,min=1"`
 	Letter      *string   `json:"letter,omitempty" validate:"omitempty,letter"`
 	Sort        *string   `json:"sort,omitempty" validate:"omitempty,oneof=name-asc name-desc filename-asc filename-desc"`
 }
 
 type SystemsParams struct {
-	All bool `json:"all,omitempty"`
+	Tags *[]string `json:"tags,omitempty" validate:"omitempty,dive,min=1"`
+	All  bool      `json:"all,omitempty"`
 }
 
 type MediaIndexParams struct {

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -187,6 +187,7 @@ type PlaytimeStatusResponse struct {
 type System struct {
 	ReleaseDate  *string `json:"releaseDate,omitempty"`
 	Manufacturer *string `json:"manufacturer,omitempty"`
+	MediaCount   *int    `json:"mediaCount,omitempty"`
 	ID           string  `json:"id,omitempty"`
 	Name         string  `json:"name,omitempty"`
 	Category     string  `json:"category,omitempty"`

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -322,6 +322,11 @@ type SearchResult struct {
 	MediaID  int64
 }
 
+type SystemMediaCount struct {
+	SystemID string
+	Count    int
+}
+
 type TagInfo struct {
 	Tag   string `json:"tag"`
 	Type  string `json:"type"`
@@ -444,6 +449,7 @@ type BrowseFilesOptions struct {
 	PathPrefix string
 	Sort       string
 	Systems    []systemdefs.System
+	Tags       []zapscript.TagFilter
 	Limit      int
 }
 
@@ -452,6 +458,7 @@ type BrowseFileCountOptions struct {
 	Letter     *string
 	PathPrefix string
 	Systems    []systemdefs.System
+	Tags       []zapscript.TagFilter
 }
 
 // BrowseIndexOptions contains parameters for the BrowseIndex facet query. It
@@ -461,6 +468,7 @@ type BrowseIndexOptions struct {
 	PathPrefix string
 	Sort       string
 	Systems    []systemdefs.System
+	Tags       []zapscript.TagFilter
 }
 
 // BrowseIndexBucket is one first-character bucket of a browse scope. SortValue
@@ -718,14 +726,22 @@ type MediaQuery struct {
 	Tags       []zapscript.TagFilter `json:"tags,omitempty"`
 }
 
+type SearchCursor struct {
+	SortValue string
+	Sort      string
+	LastID    int64
+}
+
 // SearchFilters represents parameters for filtered media search
 type SearchFilters struct {
-	Cursor  *int64                `json:"cursor,omitempty"`
-	Letter  *string               `json:"letter,omitempty"`
-	Query   string                `json:"query"`
-	Systems []systemdefs.System   `json:"systems,omitempty"`
-	Tags    []zapscript.TagFilter `json:"tags,omitempty"`
-	Limit   int                   `json:"limit"`
+	Cursor     *int64                `json:"cursor,omitempty"`
+	SortCursor *SearchCursor         `json:"-"`
+	Letter     *string               `json:"letter,omitempty"`
+	Query      string                `json:"query"`
+	Sort       string                `json:"sort,omitempty"`
+	Systems    []systemdefs.System   `json:"systems,omitempty"`
+	Tags       []zapscript.TagFilter `json:"tags,omitempty"`
+	Limit      int                   `json:"limit"`
 }
 
 // ScanStagedTag is one tag derived from a scanned file, staged for set-based
@@ -1032,6 +1048,7 @@ type MediaDBI interface {
 	BrowseCacheNeedsRebuild(ctx context.Context) (bool, error)
 
 	IndexedSystems() ([]string, error)
+	SystemMediaCounts(ctx context.Context, tags []zapscript.TagFilter) ([]SystemMediaCount, error)
 	SystemIndexed(system *systemdefs.System) bool
 	RandomGame(ctx context.Context, systems []systemdefs.System) (SearchResult, error)
 	RandomGameWithQuery(ctx context.Context, query *MediaQuery) (SearchResult, error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -737,6 +737,7 @@ type SearchFilters struct {
 	Cursor     *int64                `json:"cursor,omitempty"`
 	SortCursor *SearchCursor         `json:"-"`
 	Letter     *string               `json:"letter,omitempty"`
+	PathPrefix string                `json:"pathPrefix,omitempty"`
 	Query      string                `json:"query"`
 	Sort       string                `json:"sort,omitempty"`
 	Systems    []systemdefs.System   `json:"systems,omitempty"`

--- a/pkg/database/mediadb/frontend_prereq_bench_test.go
+++ b/pkg/database/mediadb/frontend_prereq_bench_test.go
@@ -1,0 +1,236 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkFrontendPrerequisites_Query_1k(b *testing.B) {
+	benchmarkFrontendPrerequisiteQueries(b, 1_000)
+}
+
+func BenchmarkFrontendPrerequisites_Query_50k(b *testing.B) {
+	benchmarkFrontendPrerequisiteQueries(b, 50_000)
+}
+
+func BenchmarkFrontendPrerequisites_Query_500k(b *testing.B) {
+	benchmarkFrontendPrerequisiteQueries(b, 500_000)
+}
+
+func benchmarkFrontendPrerequisiteQueries(b *testing.B, rows int) {
+	b.Helper()
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+	defer cleanup()
+	rootDir := seedRandomGameBenchmark(b, mediaDB, rows)
+	folderDir := mediaRecursivePathPrefix(filepath.ToSlash(filepath.Join(rootDir, "folder-000")))
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(b, err)
+	searchSystems := []systemdefs.System{*nesSystem}
+
+	favorite := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+	action := []zapscript.TagFilter{{Type: "genre", Value: "action"}}
+	andTags := []zapscript.TagFilter{
+		{Type: "user", Value: "favorite"},
+		{Type: "genre", Value: "action"},
+	}
+	orTags := []zapscript.TagFilter{
+		{Type: "user", Value: "favorite", Operator: zapscript.TagOperatorOR},
+		{Type: "genre", Value: "action", Operator: zapscript.TagOperatorOR},
+	}
+	notFavorite := []zapscript.TagFilter{{
+		Type: "user", Value: "favorite", Operator: zapscript.TagOperatorNOT,
+	}}
+	tagCases := []struct {
+		name string
+		tags []zapscript.TagFilter
+	}{
+		{name: "favorite-sparse", tags: favorite},
+		{name: "action-dense", tags: action},
+		{name: "favorite-and-action", tags: andTags},
+		{name: "favorite-or-action", tags: orTags},
+		{name: "not-favorite", tags: notFavorite},
+	}
+
+	b.Run("systems", func(b *testing.B) {
+		b.Run("all-media", func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				counts, err := mediaDB.SystemMediaCounts(ctx, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(counts) != 1 {
+					b.Fatalf("expected one system count, got %d", len(counts))
+				}
+			}
+		})
+
+		for i := range tagCases {
+			testCase := &tagCases[i]
+			b.Run(testCase.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					counts, err := mediaDB.SystemMediaCounts(ctx, testCase.tags)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if len(counts) != 1 {
+						b.Fatalf("expected one system count, got %d", len(counts))
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("browse-first-page", func(b *testing.B) {
+		for i := range tagCases {
+			testCase := &tagCases[i]
+			b.Run(testCase.name, func(b *testing.B) {
+				b.ReportAllocs()
+				opts := &database.BrowseFilesOptions{
+					PathPrefix: folderDir,
+					Sort:       "name",
+					Tags:       testCase.tags,
+					Limit:      100,
+				}
+				b.ResetTimer()
+				for b.Loop() {
+					_, err := mediaDB.BrowseFiles(ctx, opts)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("browse-cursor-page", func(b *testing.B) {
+		b.ReportAllocs()
+		firstPageOpts := &database.BrowseFilesOptions{
+			PathPrefix: folderDir,
+			Sort:       "name",
+			Tags:       action,
+			Limit:      25,
+		}
+		firstPage, err := mediaDB.BrowseFiles(ctx, firstPageOpts)
+		require.NoError(b, err)
+		require.Len(b, firstPage, 25)
+		last := firstPage[len(firstPage)-1]
+		cursorOpts := &database.BrowseFilesOptions{
+			PathPrefix: folderDir,
+			Sort:       "name",
+			Tags:       action,
+			Limit:      25,
+			Cursor: &database.BrowseCursor{
+				Phase:     "files",
+				SortMode:  last.SortMode,
+				SortValue: last.SortValue,
+				LastID:    last.MediaID,
+			},
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err = mediaDB.BrowseFiles(ctx, cursorOpts)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("browse-index", func(b *testing.B) {
+		for i := range tagCases {
+			testCase := &tagCases[i]
+			b.Run(testCase.name, func(b *testing.B) {
+				b.ReportAllocs()
+				opts := database.BrowseIndexOptions{
+					PathPrefix: folderDir,
+					Sort:       "name",
+					Tags:       testCase.tags,
+				}
+				b.ResetTimer()
+				for b.Loop() {
+					_, err := mediaDB.BrowseIndex(ctx, opts)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+
+	for _, sortOrder := range []string{"name-asc", "name-desc", "filename-asc", "filename-desc"} {
+		b.Run("search-"+sortOrder, func(b *testing.B) {
+			b.ReportAllocs()
+			filters := &database.SearchFilters{
+				Sort:    sortOrder,
+				Systems: searchSystems,
+				Tags:    favorite,
+				Limit:   100,
+			}
+			b.ResetTimer()
+			for b.Loop() {
+				_, err := mediaDB.SearchMediaWithFilters(ctx, filters)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+
+	b.Run("search-name-asc-cursor-page", func(b *testing.B) {
+		b.ReportAllocs()
+		firstPageFilters := &database.SearchFilters{
+			Sort: "name-asc", Systems: searchSystems, Tags: favorite, Limit: 5,
+		}
+		firstPage, err := mediaDB.SearchMediaWithFilters(ctx, firstPageFilters)
+		require.NoError(b, err)
+		require.Len(b, firstPage, 5)
+		last := firstPage[len(firstPage)-1]
+		cursorFilters := &database.SearchFilters{
+			Sort:    "name-asc",
+			Systems: searchSystems,
+			Tags:    favorite,
+			Limit:   5,
+			SortCursor: &database.SearchCursor{
+				Sort:      "name-asc",
+				SortValue: last.SortValue,
+				LastID:    last.MediaID,
+			},
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err = mediaDB.SearchMediaWithFilters(ctx, cursorFilters)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/pkg/database/mediadb/frontend_prereq_bench_test.go
+++ b/pkg/database/mediadb/frontend_prereq_bench_test.go
@@ -205,6 +205,42 @@ func benchmarkFrontendPrerequisiteQueries(b *testing.B, rows int) {
 		})
 	}
 
+	b.Run("search-name-asc-path-prefix", func(b *testing.B) {
+		b.ReportAllocs()
+		filters := &database.SearchFilters{
+			PathPrefix: folderDir,
+			Sort:       "name-asc",
+			Systems:    searchSystems,
+			Tags:       favorite,
+			Limit:      100,
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := mediaDB.SearchMediaWithFilters(ctx, filters)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("search-name-asc-path-prefix-query", func(b *testing.B) {
+		b.ReportAllocs()
+		filters := &database.SearchFilters{
+			PathPrefix: folderDir,
+			Query:      "Game",
+			Sort:       "name-asc",
+			Systems:    searchSystems,
+			Limit:      100,
+		}
+		b.ResetTimer()
+		for b.Loop() {
+			_, err := mediaDB.SearchMediaWithFilters(ctx, filters)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
 	b.Run("search-name-asc-cursor-page", func(b *testing.B) {
 		b.ReportAllocs()
 		firstPageFilters := &database.SearchFilters{

--- a/pkg/database/mediadb/frontend_prereq_plan_test.go
+++ b/pkg/database/mediadb/frontend_prereq_plan_test.go
@@ -1,0 +1,122 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+)
+
+func TestFrontendPrerequisiteQueryPlansUseExistingIndexes(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	rootDir := seedRandomGameBenchmark(t, mediaDB, 1_000)
+	folderDir := mediaRecursivePathPrefix(filepath.ToSlash(filepath.Join(rootDir, "folder-000")))
+	favorite := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+
+	t.Run("untagged system counts stream covering index", func(t *testing.T) {
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT Media.SystemDBID, COUNT(*)
+			FROM Media INDEXED BY media_system_present_path_idx
+			WHERE Media.IsMissing = 0
+			GROUP BY Media.SystemDBID`)
+		assertRandomPlanContains(t, plan, "media_system_present_path_idx")
+	})
+
+	t.Run("cached system counts use root and system indexes", func(t *testing.T) {
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT Systems.SystemID, SUM(BrowseDirCounts.FileCount)
+			FROM BrowseDirs
+			INNER JOIN BrowseDirCounts ON BrowseDirCounts.ParentDirDBID = BrowseDirs.DBID
+			INNER JOIN Systems ON Systems.DBID = BrowseDirCounts.SystemDBID
+			WHERE BrowseDirs.Path = '/'
+			GROUP BY BrowseDirCounts.SystemDBID, Systems.SystemID`)
+		assertRandomPlanContains(t, plan, "sqlite_autoindex_BrowseDirs_1")
+		assertRandomPlanContains(t, plan, "idx_browsedircounts_parent_system")
+	})
+
+	t.Run("tagged system facets use reverse tag indexes", func(t *testing.T) {
+		tagClauses, args := BuildTagFilterSQL(favorite)
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT Systems.SystemID, matched.Count
+			FROM (
+				SELECT Media.SystemDBID, COUNT(*) AS Count
+				FROM Media
+				WHERE Media.IsMissing = 0 AND `+strings.Join(tagClauses, " AND ")+`
+				GROUP BY Media.SystemDBID
+			) matched
+			INNER JOIN Systems ON Systems.DBID = matched.SystemDBID`, args...)
+		assertRandomPlanContains(t, plan, "mediatags_tag_media_idx")
+		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")
+	})
+
+	t.Run("negative system facets subtract reverse-index exclusions", func(t *testing.T) {
+		query, args := buildNegativeOnlySystemMediaCountsQuery([]zapscript.TagFilter{{
+			Type: "user", Value: "favorite", Operator: zapscript.TagOperatorNOT,
+		}})
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), query, args...)
+		assertRandomPlanContains(t, plan, "media_system_present_path_idx")
+		assertRandomPlanContains(t, plan, "mediatags_tag_media_idx")
+		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")
+	})
+
+	t.Run("favorite browse uses reverse tag indexes", func(t *testing.T) {
+		opts := &database.BrowseFilesOptions{
+			PathPrefix: folderDir,
+			Sort:       "name",
+			Tags:       favorite,
+			Limit:      100,
+		}
+		whereClause, args := browseFilesBaseCondition(opts)
+		args = append(args, opts.Limit)
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT m.DBID
+			FROM Media m
+			WHERE `+whereClause+`
+			ORDER BY m.SortName ASC, m.DBID ASC
+			LIMIT ?`, args...)
+		assertRandomPlanContains(t, plan, "mediatags_tag_media_idx")
+		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")
+	})
+
+	t.Run("sorted favorite search uses reverse tag indexes", func(t *testing.T) {
+		tagClauses, tagArgs := BuildTagFilterSQL(favorite)
+		args := append([]any{"NES"}, tagArgs...)
+		args = append(args, 100)
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT Systems.SystemID, MediaTitles.Name, Media.Path, Media.DBID
+			FROM Systems
+			INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
+			INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
+			WHERE Systems.SystemID = ?
+			AND Media.IsMissing = 0
+			AND `+strings.Join(tagClauses, " AND ")+`
+			ORDER BY MediaTitles.Name COLLATE NOCASE ASC, Media.DBID ASC
+			LIMIT ?`, args...)
+		assertRandomPlanContains(t, plan, "mediatags_tag_media_idx")
+		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")
+	})
+}

--- a/pkg/database/mediadb/frontend_prereq_plan_test.go
+++ b/pkg/database/mediadb/frontend_prereq_plan_test.go
@@ -83,6 +83,16 @@ func TestFrontendPrerequisiteQueryPlansUseExistingIndexes(t *testing.T) {
 		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")
 	})
 
+	t.Run("search path prefix uses media path index", func(t *testing.T) {
+		pathClause, args := browsePathPrefixCondition("Media.Path", folderDir)
+		plan := randomQueryPlan(t, mediaDB.sql.Load(), `
+			SELECT Media.DBID
+			FROM Media
+			WHERE Media.IsMissing = 0 AND `+pathClause+`
+			ORDER BY Media.Path`, args...)
+		assertRandomPlanContains(t, plan, "media_path_idx")
+	})
+
 	t.Run("favorite browse uses reverse tag indexes", func(t *testing.T) {
 		opts := &database.BrowseFilesOptions{
 			PathPrefix: folderDir,

--- a/pkg/database/mediadb/media_count_cache_test.go
+++ b/pkg/database/mediadb/media_count_cache_test.go
@@ -1,0 +1,66 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetCachedStats_PrunesOldestEntries(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	db := mediaDB.sql.Load()
+
+	for i := range mediaCountCacheMaxEntries {
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO MediaCountCache
+				(QueryHash, QueryParams, Count, MinDBID, MaxDBID, LastUpdated)
+			VALUES (?, '{}', 1, 1, 1, ?)`, fmt.Sprintf("seed-%04d", i), i)
+		require.NoError(t, err)
+	}
+
+	query := &database.MediaQuery{PathPrefix: filepath.Join("roms", "SNES")}
+	stats := MediaStats{Count: 4, MinDBID: 10, MaxDBID: 40}
+	require.NoError(t, mediaDB.SetCachedStats(ctx, query, stats))
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM MediaCountCache").Scan(&count))
+	assert.Equal(t, mediaCountCacheMaxEntries, count)
+
+	var oldestCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM MediaCountCache WHERE QueryHash = ?", "seed-0000",
+	).Scan(&oldestCount))
+	assert.Zero(t, oldestCount)
+
+	cached, found := mediaDB.GetCachedStats(ctx, query)
+	require.True(t, found)
+	assert.Equal(t, stats, cached)
+}

--- a/pkg/database/mediadb/media_search.go
+++ b/pkg/database/mediadb/media_search.go
@@ -22,6 +22,7 @@ package mediadb
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -69,29 +70,42 @@ func buildMediaSearchTypeGroups(
 	return groups
 }
 
-func mergeMediaSearchTypeGroupVariants(
-	groups []mediaSearchTypeGroup,
-	wordCount int,
-) ([][]string, bool) {
-	merged := make([][]string, wordCount)
-	seen := make([]map[string]struct{}, wordCount)
-	includeName := false
-	for i := range groups {
-		includeName = includeName || groups[i].includeName
-		for wordIndex, variants := range groups[i].variantGroups {
-			if seen[wordIndex] == nil {
-				seen[wordIndex] = make(map[string]struct{}, len(variants))
-			}
-			for _, variant := range variants {
-				if _, ok := seen[wordIndex][variant]; ok {
-					continue
-				}
-				seen[wordIndex][variant] = struct{}{}
-				merged[wordIndex] = append(merged[wordIndex], variant)
-			}
-		}
+func mediaSearchSystemsForPathPrefix(
+	ctx context.Context,
+	db sqlQueryable,
+	pathPrefix string,
+) ([]systemdefs.System, error) {
+	pathClause, args := browsePathPrefixCondition(
+		"Media.Path", mediaRecursivePathPrefix(pathPrefix))
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT Systems.SystemID
+		FROM Media
+		INNER JOIN Systems ON Systems.DBID = Media.SystemDBID
+		WHERE Media.IsMissing = 0 AND `+pathClause+`
+		ORDER BY Systems.SystemID`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query media search path systems: %w", err)
 	}
-	return merged, includeName
+	defer func() { _ = rows.Close() }()
+
+	systems := make([]systemdefs.System, 0, 4)
+	for rows.Next() {
+		var systemID string
+		if scanErr := rows.Scan(&systemID); scanErr != nil {
+			return nil, fmt.Errorf("scan media search path system: %w", scanErr)
+		}
+		system, lookupErr := systemdefs.GetSystem(systemID)
+		if lookupErr == nil {
+			systems = append(systems, *system)
+			continue
+		}
+		// Unregistered indexed systems use System's default game-title normalization.
+		systems = append(systems, systemdefs.System{ID: systemID})
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("media search path systems rows: %w", rowsErr)
+	}
+	return systems, nil
 }
 
 func mediaSearchTypeGroupsCacheable(groups []mediaSearchTypeGroup) bool {

--- a/pkg/database/mediadb/media_search.go
+++ b/pkg/database/mediadb/media_search.go
@@ -69,6 +69,31 @@ func buildMediaSearchTypeGroups(
 	return groups
 }
 
+func mergeMediaSearchTypeGroupVariants(
+	groups []mediaSearchTypeGroup,
+	wordCount int,
+) ([][]string, bool) {
+	merged := make([][]string, wordCount)
+	seen := make([]map[string]struct{}, wordCount)
+	includeName := false
+	for i := range groups {
+		includeName = includeName || groups[i].includeName
+		for wordIndex, variants := range groups[i].variantGroups {
+			if seen[wordIndex] == nil {
+				seen[wordIndex] = make(map[string]struct{}, len(variants))
+			}
+			for _, variant := range variants {
+				if _, ok := seen[wordIndex][variant]; ok {
+					continue
+				}
+				seen[wordIndex][variant] = struct{}{}
+				merged[wordIndex] = append(merged[wordIndex], variant)
+			}
+		}
+	}
+	return merged, includeName
+}
+
 func mediaSearchTypeGroupsCacheable(groups []mediaSearchTypeGroup) bool {
 	if len(groups) == 0 {
 		return false
@@ -158,8 +183,13 @@ func compareSearchResults(a, b *database.SearchResultWithCursor, sortOrder strin
 func titleDBIDQueryParamCount(candidateCount int, filters *database.SearchFilters) int {
 	_, tagArgs := buildCandidateTagFilterSQL(filters.Tags)
 	_, letterArgs := BuildLetterFilterSQL(filters.Letter, "MediaTitles.Name")
+	var pathArgs []any
+	if filters.PathPrefix != "" {
+		_, pathArgs = browsePathPrefixCondition(
+			"Media.Path", mediaRecursivePathPrefix(filters.PathPrefix))
+	}
 
-	count := candidateCount + len(tagArgs) + len(letterArgs) + 1 // LIMIT
+	count := candidateCount + len(pathArgs) + len(tagArgs) + len(letterArgs) + 1 // LIMIT
 	if filters.SortCursor != nil {
 		count += 2
 	} else if filters.Cursor != nil {
@@ -182,6 +212,7 @@ func (db *MediaDB) searchMediaTypeGroupsWithSQL(
 			groups[i].systems,
 			groups[i].variantGroups,
 			rawWords,
+			filters.PathPrefix,
 			filters.Tags,
 			filters.Letter,
 			filters.Cursor,

--- a/pkg/database/mediadb/media_search.go
+++ b/pkg/database/mediadb/media_search.go
@@ -118,12 +118,51 @@ func searchMediaTypeGroupsInCache(
 	return candidates
 }
 
+func sqliteNoCaseCompare(a, b string) int {
+	limit := min(len(a), len(b))
+	for i := range limit {
+		left := a[i]
+		right := b[i]
+		if left >= 'A' && left <= 'Z' {
+			left += 'a' - 'A'
+		}
+		if right >= 'A' && right <= 'Z' {
+			right += 'a' - 'A'
+		}
+		if order := cmp.Compare(left, right); order != 0 {
+			return order
+		}
+	}
+	return cmp.Compare(len(a), len(b))
+}
+
+func compareSearchResults(a, b *database.SearchResultWithCursor, sortOrder string) int {
+	var order int
+	switch sortOrder {
+	case "name-asc", "name-desc":
+		order = sqliteNoCaseCompare(a.SortValue, b.SortValue)
+	case "filename-asc", "filename-desc":
+		order = cmp.Compare(a.SortValue, b.SortValue)
+	default:
+		return cmp.Compare(a.MediaID, b.MediaID)
+	}
+	if order == 0 {
+		order = cmp.Compare(a.MediaID, b.MediaID)
+	}
+	if sortOrder == "name-desc" || sortOrder == "filename-desc" {
+		return -order
+	}
+	return order
+}
+
 func titleDBIDQueryParamCount(candidateCount int, filters *database.SearchFilters) int {
 	_, tagArgs := buildCandidateTagFilterSQL(filters.Tags)
 	_, letterArgs := BuildLetterFilterSQL(filters.Letter, "MediaTitles.Name")
 
 	count := candidateCount + len(tagArgs) + len(letterArgs) + 1 // LIMIT
-	if filters.Cursor != nil {
+	if filters.SortCursor != nil {
+		count += 2
+	} else if filters.Cursor != nil {
 		count++
 	}
 	return count
@@ -137,7 +176,7 @@ func (db *MediaDB) searchMediaTypeGroupsWithSQL(
 ) ([]database.SearchResultWithCursor, error) {
 	results := make([]database.SearchResultWithCursor, 0, filters.Limit)
 	for i := range groups {
-		groupResults, err := sqlSearchMediaWithFilters(
+		groupResults, err := sqlSearchMediaWithFiltersSorted(
 			ctx,
 			db.sql.Load(),
 			groups[i].systems,
@@ -146,6 +185,8 @@ func (db *MediaDB) searchMediaTypeGroupsWithSQL(
 			filters.Tags,
 			filters.Letter,
 			filters.Cursor,
+			filters.SortCursor,
+			filters.Sort,
 			filters.Limit,
 			groups[i].includeName,
 		)
@@ -156,7 +197,7 @@ func (db *MediaDB) searchMediaTypeGroupsWithSQL(
 	}
 
 	slices.SortFunc(results, func(a, b database.SearchResultWithCursor) int {
-		return cmp.Compare(a.MediaID, b.MediaID)
+		return compareSearchResults(&a, &b, filters.Sort)
 	})
 	results = slices.CompactFunc(results, func(a, b database.SearchResultWithCursor) bool {
 		return a.MediaID == b.MediaID

--- a/pkg/database/mediadb/media_search_path_test.go
+++ b/pkg/database/mediadb/media_search_path_test.go
@@ -123,6 +123,35 @@ func TestSearchMediaWithFilters_PathPrefixIncludesIndexedVirtualSystems(t *testi
 	assert.Equal(t, virtualPath, results[0].Path)
 }
 
+func TestSearchMediaWithFilters_VirtualPathKeepsMediaTypeVariantsScoped(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	nesSystem := insertSystemWithMedia(t, mediaDB, systemdefs.SystemNES, "Mario Kart", "steam://nes/mario-kart")
+	insertSystemMedia(t, mediaDB, nesSystem, "R-Type", "steam://nes/r-type")
+	insertSystemWithMedia(t, mediaDB, systemdefs.SystemMovie, "R-Type", "steam://movies/r-type")
+	mediaDB.slugSearchCache.Store(nil)
+
+	results, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems:    systemdefs.AllSystems(),
+		PathPrefix: "steam://",
+		Query:      "R-Type",
+		Sort:       "filename-asc",
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	resultSystems := []string{results[0].SystemID, results[1].SystemID}
+	assert.ElementsMatch(t, []string{systemdefs.SystemNES, systemdefs.SystemMovie}, resultSystems)
+	for i := range results {
+		assert.Equal(t, "R-Type", results[i].Name)
+	}
+}
+
 func TestSearchMediaWithFilters_PathPrefixComposesAcrossCacheAndSQL(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediadb/media_search_path_test.go
+++ b/pkg/database/mediadb/media_search_path_test.go
@@ -1,0 +1,191 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchMediaWithFilters_PathPrefixIsRecursiveAndBoundarySafe(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	root := filepath.Join("roms", "SNES")
+	insidePath := filepath.Join(root, "inside.sfc")
+	nestedPath := filepath.Join(root, "nested", "inside-too.sfc")
+	siblingPath := filepath.Join("roms", "SNES2", "outside.sfc")
+	literalRoot := filepath.Join("roms", "100%_Games")
+	literalPath := filepath.Join(literalRoot, "literal.sfc")
+	wildcardLookalikePath := filepath.Join("roms", "100XXGames", "outside.sfc")
+
+	system := insertSystemWithMedia(t, mediaDB, "SNES", "Inside", insidePath)
+	insertSystemMedia(t, mediaDB, system, "Nested", nestedPath)
+	insertSystemMedia(t, mediaDB, system, "Sibling", siblingPath)
+	insertSystemMedia(t, mediaDB, system, "Literal", literalPath)
+	insertSystemMedia(t, mediaDB, system, "Wildcard Lookalike", wildcardLookalikePath)
+	insertSystemMedia(t, mediaDB, system, "Steam Inside", "steam://44/inside")
+	insertSystemMedia(t, mediaDB, system, "Steam Sibling", "steam://440/outside")
+
+	snes, err := systemdefs.GetSystem(systemdefs.SystemSNES)
+	require.NoError(t, err)
+	search := func(pathPrefix string) []database.SearchResultWithCursor {
+		results, searchErr := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+			Systems:    []systemdefs.System{*snes},
+			PathPrefix: pathPrefix,
+			Sort:       "filename-asc",
+			Limit:      10,
+		})
+		require.NoError(t, searchErr)
+		return results
+	}
+
+	results := search(root)
+	require.Len(t, results, 2)
+	assert.Equal(t, []string{insidePath, nestedPath}, []string{results[0].Path, results[1].Path})
+
+	results = search(literalRoot)
+	require.Len(t, results, 1)
+	assert.Equal(t, literalPath, results[0].Path)
+
+	results = search("steam://44")
+	require.Len(t, results, 1)
+	assert.Equal(t, "steam://44/inside", results[0].Path)
+}
+
+func TestSearchMediaWithFilters_PathPrefixIncludesIndexedVirtualSystems(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	virtualSystem, err := mediaDB.FindOrInsertSystem(database.System{
+		SystemID: "virtual-system",
+		Name:     "Virtual System",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: virtualSystem.DBID,
+		Slug:       "virtualgame",
+		Name:       "Virtual Game",
+	})
+	require.NoError(t, err)
+	virtualPath := "zaparoo://virtual-system/virtual-game"
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     virtualSystem.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           virtualPath,
+		ParentDir:      "zaparoo://",
+		SortName:       "Virtual Game",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	results, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems:    systemdefs.AllSystems(),
+		PathPrefix: "zaparoo://virtual-system",
+		Query:      "Virtual Game",
+		Sort:       "name-asc",
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "virtual-system", results[0].SystemID)
+	assert.Equal(t, virtualPath, results[0].Path)
+}
+
+func TestSearchMediaWithFilters_PathPrefixComposesAcrossCacheAndSQL(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	root := filepath.Join("roms", "SNES", "favorites")
+	alphaPath := filepath.Join(root, "target-alpha.sfc")
+	betaPath := filepath.Join(root, "nested", "target-beta.sfc")
+	notFavoritePath := filepath.Join(root, "target-other.sfc")
+	outsidePath := filepath.Join("roms", "SNES", "outside", "target-outside.sfc")
+
+	system := insertSystemWithMedia(t, mediaDB, "SNES", "Target Alpha", alphaPath)
+	insertSystemMedia(t, mediaDB, system, "Target Beta", betaPath)
+	insertSystemMedia(t, mediaDB, system, "Target Other", notFavoritePath)
+	insertSystemMedia(t, mediaDB, system, "Target Outside", outsidePath)
+
+	for _, mediaPath := range []string{alphaPath, betaPath, outsidePath} {
+		media, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: mediaPath})
+		require.NoError(t, err)
+		require.NoError(t, mediaDB.UpdateMediaTags(ctx, media.DBID, nil, []database.MediaTagRef{{
+			Type: "user",
+			Tag:  "favorite",
+		}}))
+	}
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+
+	snes, err := systemdefs.GetSystem(systemdefs.SystemSNES)
+	require.NoError(t, err)
+	letter := "T"
+	filters := database.SearchFilters{
+		Systems:    []systemdefs.System{*snes},
+		PathPrefix: root,
+		Query:      "Target",
+		Sort:       "name-asc",
+		Tags: []zapscript.TagFilter{{
+			Type:  "user",
+			Value: "favorite",
+		}},
+		Letter: &letter,
+		Limit:  1,
+	}
+
+	firstPage, err := mediaDB.SearchMediaWithFilters(ctx, &filters)
+	require.NoError(t, err)
+	require.Len(t, firstPage, 1)
+	assert.Equal(t, "Target Alpha", firstPage[0].Name)
+
+	filters.SortCursor = &database.SearchCursor{
+		SortValue: firstPage[0].SortValue,
+		Sort:      firstPage[0].SortMode,
+		LastID:    firstPage[0].MediaID,
+	}
+	secondPage, err := mediaDB.SearchMediaWithFilters(ctx, &filters)
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
+	assert.Equal(t, "Target Beta", secondPage[0].Name)
+
+	mediaDB.slugSearchCache.Store(nil)
+	filters.SortCursor = nil
+	sqlResults, err := mediaDB.SearchMediaWithFilters(ctx, &filters)
+	require.NoError(t, err)
+	require.Len(t, sqlResults, 1)
+	assert.Equal(t, "Target Alpha", sqlResults[0].Name)
+}

--- a/pkg/database/mediadb/media_search_sort_test.go
+++ b/pkg/database/mediadb/media_search_sort_test.go
@@ -1,0 +1,134 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchMediaWithFilters_ExplicitSortPagination(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	system := insertSystemWithMedia(
+		t, mediaDB, "NES", "charlie", filepath.Join("roms", "nes", "a-charlie.nes"))
+	insertSystemMedia(t, mediaDB, system, "Alpha", filepath.Join("roms", "nes", "z-alpha.nes"))
+	insertSystemMedia(t, mediaDB, system, "bravo", filepath.Join("roms", "nes", "m-bravo.nes"))
+	insertSystemMedia(t, mediaDB, system, "alpha", filepath.Join("roms", "nes", "b-alpha-lower.nes"))
+
+	nes, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	firstPage, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Sort:    "name-asc",
+		Limit:   2,
+	})
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	assert.Equal(t, []string{"Alpha", "alpha"}, []string{firstPage[0].Name, firstPage[1].Name})
+	assert.Equal(t, "Alpha", firstPage[0].SortValue)
+	assert.Equal(t, "name-asc", firstPage[0].SortMode)
+
+	secondPage, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Sort:    "name-asc",
+		SortCursor: &database.SearchCursor{
+			Sort:      "name-asc",
+			SortValue: firstPage[1].SortValue,
+			LastID:    firstPage[1].MediaID,
+		},
+		Limit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondPage, 2)
+	assert.Equal(t, []string{"bravo", "charlie"}, []string{secondPage[0].Name, secondPage[1].Name})
+
+	descending, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Sort:    "name-desc",
+		Limit:   4,
+	})
+	require.NoError(t, err)
+	require.Len(t, descending, 4)
+	assert.Equal(t, []string{"charlie", "bravo", "alpha", "Alpha"}, []string{
+		descending[0].Name,
+		descending[1].Name,
+		descending[2].Name,
+		descending[3].Name,
+	})
+
+	byFilename, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Sort:    "filename-asc",
+		Limit:   4,
+	})
+	require.NoError(t, err)
+	require.Len(t, byFilename, 4)
+	assert.Equal(t, []string{"charlie", "alpha", "bravo", "Alpha"}, []string{
+		byFilename[0].Name,
+		byFilename[1].Name,
+		byFilename[2].Name,
+		byFilename[3].Name,
+	})
+}
+
+func TestSearchMediaWithFilters_CombinesTagLetterAndSort(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	bravoPath := filepath.Join("roms", "nes", "bravo.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Bravo", bravoPath)
+	insertSystemMedia(t, mediaDB, system, "Beta", filepath.Join("roms", "nes", "beta.nes"))
+	insertSystemMedia(t, mediaDB, system, "Alpha", filepath.Join("roms", "nes", "alpha.nes"))
+	bravo, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: bravoPath})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, bravo.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+
+	nes, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	letter := "B"
+	results, err := mediaDB.SearchMediaWithFilters(ctx, &database.SearchFilters{
+		Systems: []systemdefs.System{*nes},
+		Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
+		Letter:  &letter,
+		Sort:    "name-asc",
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Bravo", results[0].Name)
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2154,13 +2154,15 @@ func (db *MediaDB) BrowseDirCount(
 // BrowseIndex returns the ordered first-character buckets for a browse scope,
 // each with a count and the keyset needed to seek a media.browse page to the
 // bucket's first item.
+//
+//nolint:gocritic // Value options preserve the established MediaDBI method contract.
 func (db *MediaDB) BrowseIndex(
 	ctx context.Context, opts database.BrowseIndexOptions,
 ) (database.BrowseIndexResult, error) {
 	if db.sql.Load() == nil {
 		return database.BrowseIndexResult{}, ErrNullSQL
 	}
-	return sqlBrowseIndex(ctx, db.sql.Load(), opts)
+	return sqlBrowseIndex(ctx, db.sql.Load(), &opts)
 }
 
 // BrowseVirtualSchemes returns distinct URI schemes present in indexed media.
@@ -2301,9 +2303,9 @@ func (db *MediaDB) SearchMediaWithFilters(
 
 	qWords := strings.Fields(filters.Query)
 	if len(qWords) == 0 || len(filters.Systems) == 0 {
-		return sqlSearchMediaWithFilters(
+		return sqlSearchMediaWithFiltersSorted(
 			ctx, db.sql.Load(), filters.Systems, nil, qWords, filters.Tags,
-			filters.Letter, filters.Cursor, filters.Limit, false)
+			filters.Letter, filters.Cursor, filters.SortCursor, filters.Sort, filters.Limit, false)
 	}
 
 	groups := buildMediaSearchTypeGroups(filters.Systems, qWords)
@@ -2328,9 +2330,9 @@ func (db *MediaDB) SearchMediaWithFilters(
 				Int("mediaTypeGroups", len(groups)).
 				Int("candidates", len(candidateIDs)).
 				Msg("media search using in-memory slug cache")
-			return sqlSearchMediaByTitleDBIDs(
+			return sqlSearchMediaByTitleDBIDsSorted(
 				ctx, db.sql.Load(), candidateIDs, filters.Tags,
-				filters.Letter, filters.Cursor, filters.Limit)
+				filters.Letter, filters.Cursor, filters.SortCursor, filters.Sort, filters.Limit)
 		}
 
 		log.Debug().
@@ -2677,61 +2679,29 @@ func (db *MediaDB) IndexedSystems() ([]string, error) {
 	return sqlIndexedSystems(db.ctx, db.sql.Load())
 }
 
-// RandomGame returns a random game from specified systems.
-func (db *MediaDB) RandomGame(ctx context.Context, systems []systemdefs.System) (database.SearchResult, error) {
-	var result database.SearchResult
+func (db *MediaDB) SystemMediaCounts(
+	ctx context.Context,
+	tagFilters []zapscript.TagFilter,
+) ([]database.SystemMediaCount, error) {
 	if db.sql.Load() == nil {
-		return result, ErrNullSQL
+		return nil, ErrNullSQL
 	}
+	return sqlSystemMediaCounts(ctx, db.sql.Load(), tagFilters)
+}
 
-	if len(systems) > 0 {
-		cache := db.slugSearchCache.Load()
-		systemIDs := make([]string, len(systems))
-		for i, sys := range systems {
-			systemIDs[i] = sys.ID
-		}
-		if cache != nil && cache.CanServeSystems(systemIDs) {
-			// Resolve to only systems that have indexed content
-			systemDBIDs := cache.ResolveSystemDBIDs(systemIDs)
-			if len(systemDBIDs) == 0 {
-				return result, sql.ErrNoRows
-			}
-			// Pick a random system first to give equal weight per system
-			systemDBID, err := helpers.RandomElem(systemDBIDs)
-			if err != nil {
-				return result, fmt.Errorf("failed to select random system: %w", err)
-			}
-			titleDBID, ok := cache.RandomEntry([]int64{systemDBID})
-			if !ok {
-				return result, sql.ErrNoRows
-			}
-			return sqlGetRandomMediaForTitle(ctx, db.sql.Load(), titleDBID)
-		}
+// RandomGame returns a uniformly selected media row from the specified systems.
+func (db *MediaDB) RandomGame(ctx context.Context, systems []systemdefs.System) (database.SearchResult, error) {
+	if db.sql.Load() == nil {
+		return database.SearchResult{}, ErrNullSQL
 	}
-
-	// Filter to only systems that have indexed content
+	if len(systems) == 0 {
+		return database.SearchResult{}, sql.ErrNoRows
+	}
 	systemIDs := make([]string, len(systems))
-	for i, sys := range systems {
-		systemIDs[i] = sys.ID
+	for i := range systems {
+		systemIDs[i] = systems[i].ID
 	}
-	indexedIDs, err := sqlFilterIndexedSystems(ctx, db.sql.Load(), systemIDs)
-	if err != nil {
-		return result, fmt.Errorf("failed to filter indexed systems: %w", err)
-	}
-	if len(indexedIDs) == 0 {
-		return result, sql.ErrNoRows
-	}
-
-	systemID, err := helpers.RandomElem(indexedIDs)
-	if err != nil {
-		return result, fmt.Errorf("failed to select random system: %w", err)
-	}
-	sys, sysErr := systemdefs.GetSystem(systemID)
-	if sysErr != nil {
-		return result, fmt.Errorf("failed to get system definition: %w", sysErr)
-	}
-
-	return sqlRandomGame(ctx, db.sql.Load(), sys)
+	return db.RandomGameWithQuery(ctx, &database.MediaQuery{Systems: systemIDs})
 }
 
 // RandomGameWithQuery returns a random game matching the specified MediaQuery.
@@ -2741,48 +2711,9 @@ func (db *MediaDB) RandomGameWithQuery(ctx context.Context, query *database.Medi
 		return result, ErrNullSQL
 	}
 
-	// Systems-only queries can use the in-memory slug search cache
-	isSystemsOnly := query.PathPrefix == "" && query.PathGlob == "" && len(query.Tags) == 0 && len(query.Systems) > 0
-	if isSystemsOnly {
-		cache := db.slugSearchCache.Load()
-		if cache != nil && cache.CanServeSystems(query.Systems) {
-			// Resolve to only systems that have indexed content
-			systemDBIDs := cache.ResolveSystemDBIDs(query.Systems)
-			if len(systemDBIDs) == 0 {
-				return result, sql.ErrNoRows
-			}
-			// Pick a random system first to give equal weight per system
-			systemDBID, err := helpers.RandomElem(systemDBIDs)
-			if err != nil {
-				return result, fmt.Errorf("failed to select random system: %w", err)
-			}
-			titleDBID, ok := cache.RandomEntry([]int64{systemDBID})
-			if !ok {
-				return result, sql.ErrNoRows
-			}
-			return sqlGetRandomMediaForTitle(ctx, db.sql.Load(), titleDBID)
-		}
-	}
-
-	// For SQL fallback, filter to indexed systems and pick one for equal weight
-	if len(query.Systems) > 1 {
-		indexedSystems, filterErr := sqlFilterIndexedSystems(ctx, db.sql.Load(), query.Systems)
-		if filterErr != nil {
-			return result, fmt.Errorf("failed to filter indexed systems: %w", filterErr)
-		}
-		if len(indexedSystems) == 0 {
-			return result, sql.ErrNoRows
-		}
-		system, randErr := helpers.RandomElem(indexedSystems)
-		if randErr != nil {
-			return result, fmt.Errorf("failed to select random system: %w", randErr)
-		}
-		narrowed := *query
-		narrowed.Systems = []string{system}
-		query = &narrowed
-	}
-
-	// Check MediaCountCache for complex queries or when slug cache unavailable
+	// Use one full matching scope so systems are weighted by their matching
+	// media rows and tag filters cannot choose an empty system first.
+	// Check MediaCountCache before repeating the count query.
 	if stats, found := db.GetCachedStats(ctx, query); found {
 		if stats.Count == 0 {
 			return result, sql.ErrNoRows
@@ -2877,63 +2808,11 @@ func (db *MediaDB) GetCachedStats(ctx context.Context, query *database.MediaQuer
 	return stats, true
 }
 
-// randomGameWithStats generates a random game selection using cached statistics.
+// randomGameWithStats generates a uniform random media selection using cached statistics.
 func (db *MediaDB) randomGameWithStats(
 	ctx context.Context, query *database.MediaQuery, stats MediaStats,
 ) (database.SearchResult, error) {
-	var row database.SearchResult
-
-	// Generate random DBID within the range
-	randomOffset, err := helpers.RandomInt(int(stats.MaxDBID - stats.MinDBID + 1))
-	if err != nil {
-		return row, fmt.Errorf("failed to generate random DBID offset: %w", err)
-	}
-	targetDBID := stats.MinDBID + int64(randomOffset)
-
-	// Use shared helper to build WHERE clause and arguments
-	whereClause, args := buildMediaQueryWhereClause(query)
-
-	// Get the first media item with DBID >= targetDBID
-	//nolint:gosec // whereClause is built from safe conditions, no user input
-	selectQuery := fmt.Sprintf(`
-		SELECT Systems.SystemID, Media.Path, Media.DBID
-		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-		%s AND Media.DBID >= ?
-		ORDER BY Media.DBID ASC
-		LIMIT 1
-	`, whereClause)
-
-	args = append(args, targetDBID)
-	err = db.sql.Load().QueryRowContext(ctx, selectQuery, args...).Scan(
-		&row.SystemID,
-		&row.Path,
-		&row.MediaID,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
-		selectQuery = fmt.Sprintf(`
-			SELECT Systems.SystemID, Media.Path, Media.DBID
-			FROM Media
-			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-			%s AND Media.DBID < ?
-			ORDER BY Media.DBID DESC
-			LIMIT 1
-		`, whereClause)
-		args[len(args)-1] = targetDBID // Replace the last argument
-		err = db.sql.Load().QueryRowContext(ctx, selectQuery, args...).Scan(
-			&row.SystemID,
-			&row.Path,
-			&row.MediaID,
-		)
-	}
-	if err != nil {
-		return row, fmt.Errorf("failed to scan random game row using cached stats: %w", err)
-	}
-	row.Name = helpers.FilenameFromPath(row.Path)
-	return row, nil
+	return sqlSelectRandomGameWithStats(ctx, db.sql.Load(), query, stats)
 }
 
 // SetCachedStats stores statistics for the given media query in the cache.
@@ -2986,7 +2865,7 @@ func (*MediaDB) generateQueryHash(query *database.MediaQuery) (string, error) {
 	normalized := database.MediaQuery{
 		Systems:    make([]string, len(query.Systems)),
 		PathGlob:   strings.ToLower(strings.TrimSpace(query.PathGlob)),
-		PathPrefix: strings.ToLower(strings.TrimSpace(query.PathPrefix)),
+		PathPrefix: strings.TrimSpace(query.PathPrefix),
 		Tags:       make([]zapscript.TagFilter, len(query.Tags)),
 	}
 
@@ -3000,7 +2879,10 @@ func (*MediaDB) generateQueryHash(query *database.MediaQuery) (string, error) {
 		if normalized.Tags[i].Type != normalized.Tags[j].Type {
 			return normalized.Tags[i].Type < normalized.Tags[j].Type
 		}
-		return normalized.Tags[i].Value < normalized.Tags[j].Value
+		if normalized.Tags[i].Value != normalized.Tags[j].Value {
+			return normalized.Tags[i].Value < normalized.Tags[j].Value
+		}
+		return normalized.Tags[i].Operator < normalized.Tags[j].Operator
 	})
 
 	// Marshal to JSON with consistent ordering

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -86,7 +86,10 @@ const defaultSlugSearchLimit = 50
 // logs during full-library indexing while preserving selective reindexing wins.
 const maxSelectiveInvalidationSystems = 32
 
-const mediaStatsCacheWriteTimeout = 100 * time.Millisecond
+const (
+	mediaStatsCacheWriteTimeout = 100 * time.Millisecond
+	mediaCountCacheMaxEntries   = 256
+)
 
 // mediaWALCheckpointThreshold bounds WAL growth during indexing. A batch commit
 // checkpoints (TRUNCATE) once the WAL has grown past this size, so a long
@@ -2308,29 +2311,22 @@ func (db *MediaDB) SearchMediaWithFilters(
 			filters.Letter, filters.Cursor, filters.SortCursor, filters.Sort, filters.Limit, false)
 	}
 
-	groups := buildMediaSearchTypeGroups(filters.Systems, qWords)
+	searchSystems := filters.Systems
 	if strings.Contains(filters.PathPrefix, "://") && requestedAllSystems(filters.Systems) {
-		variantGroups, includeName := mergeMediaSearchTypeGroupVariants(groups, len(qWords))
-		return sqlSearchMediaWithFiltersSorted(
-			ctx,
-			db.sql.Load(),
-			filters.Systems,
-			variantGroups,
-			qWords,
-			filters.PathPrefix,
-			filters.Tags,
-			filters.Letter,
-			filters.Cursor,
-			filters.SortCursor,
-			filters.Sort,
-			filters.Limit,
-			includeName,
-		)
+		var err error
+		searchSystems, err = mediaSearchSystemsForPathPrefix(ctx, db.sql.Load(), filters.PathPrefix)
+		if err != nil {
+			return nil, err
+		}
+		if len(searchSystems) == 0 {
+			return []database.SearchResultWithCursor{}, nil
+		}
 	}
 
-	systemIDs := make([]string, len(filters.Systems))
-	for i := range filters.Systems {
-		systemIDs[i] = filters.Systems[i].ID
+	groups := buildMediaSearchTypeGroups(searchSystems, qWords)
+	systemIDs := make([]string, len(searchSystems))
+	for i := range searchSystems {
+		systemIDs[i] = searchSystems[i].ID
 	}
 
 	cache := db.slugSearchCache.Load()
@@ -2737,18 +2733,33 @@ func (db *MediaDB) RandomGameWithQuery(ctx context.Context, query *database.Medi
 		if stats.Count == 0 {
 			return result, sql.ErrNoRows
 		}
-		return db.randomGameWithStats(ctx, query, stats)
+		result, err := db.randomGameWithStats(ctx, query, stats)
+		if err == nil || !errors.Is(err, sql.ErrNoRows) {
+			return result, err
+		}
+
+		// A matching-row miss means cached count/range statistics are stale.
+		// Refresh once and retry through the uncached selector.
+		return db.randomGameWithFreshStats(ctx, query)
 	}
 
-	// Cache miss - use the full SQL implementation and cache the stats
+	return db.randomGameWithFreshStats(ctx, query)
+}
+
+func (db *MediaDB) randomGameWithFreshStats(
+	ctx context.Context,
+	query *database.MediaQuery,
+) (database.SearchResult, error) {
 	result, stats, err := sqlRandomGameWithQueryAndStats(ctx, db.sql.Load(), query)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			db.cacheMediaStats(ctx, query, stats)
+		}
 		return result, err
 	}
 
-	// Cache the stats for future use (best effort - don't fail if caching fails)
+	// Cache the stats for future use (best effort - don't fail if caching fails).
 	db.cacheMediaStats(ctx, query, stats)
-
 	return result, nil
 }
 
@@ -2859,6 +2870,25 @@ func (db *MediaDB) SetCachedStats(ctx context.Context, query *database.MediaQuer
 	`, queryHash, string(queryParams), stats.Count, stats.MinDBID, stats.MaxDBID, time.Now().Unix())
 	if err != nil {
 		return fmt.Errorf("failed to cache stats: %w", err)
+	}
+
+	_, err = db.sql.Load().ExecContext(ctx, `
+		DELETE FROM MediaCountCache
+		WHERE QueryHash IN (
+			SELECT QueryHash
+			FROM MediaCountCache
+			WHERE QueryHash <> ?
+			ORDER BY LastUpdated ASC, QueryHash ASC
+			LIMIT (
+				SELECT CASE
+					WHEN COUNT(*) > ? THEN COUNT(*) - ?
+					ELSE 0
+				END
+				FROM MediaCountCache
+			)
+		)`, queryHash, mediaCountCacheMaxEntries, mediaCountCacheMaxEntries)
+	if err != nil {
+		return fmt.Errorf("failed to prune media count cache: %w", err)
 	}
 
 	return nil

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2304,11 +2304,30 @@ func (db *MediaDB) SearchMediaWithFilters(
 	qWords := strings.Fields(filters.Query)
 	if len(qWords) == 0 || len(filters.Systems) == 0 {
 		return sqlSearchMediaWithFiltersSorted(
-			ctx, db.sql.Load(), filters.Systems, nil, qWords, filters.Tags,
+			ctx, db.sql.Load(), filters.Systems, nil, qWords, filters.PathPrefix, filters.Tags,
 			filters.Letter, filters.Cursor, filters.SortCursor, filters.Sort, filters.Limit, false)
 	}
 
 	groups := buildMediaSearchTypeGroups(filters.Systems, qWords)
+	if strings.Contains(filters.PathPrefix, "://") && requestedAllSystems(filters.Systems) {
+		variantGroups, includeName := mergeMediaSearchTypeGroupVariants(groups, len(qWords))
+		return sqlSearchMediaWithFiltersSorted(
+			ctx,
+			db.sql.Load(),
+			filters.Systems,
+			variantGroups,
+			qWords,
+			filters.PathPrefix,
+			filters.Tags,
+			filters.Letter,
+			filters.Cursor,
+			filters.SortCursor,
+			filters.Sort,
+			filters.Limit,
+			includeName,
+		)
+	}
+
 	systemIDs := make([]string, len(filters.Systems))
 	for i := range filters.Systems {
 		systemIDs[i] = filters.Systems[i].ID
@@ -2331,7 +2350,7 @@ func (db *MediaDB) SearchMediaWithFilters(
 				Int("candidates", len(candidateIDs)).
 				Msg("media search using in-memory slug cache")
 			return sqlSearchMediaByTitleDBIDsSorted(
-				ctx, db.sql.Load(), candidateIDs, filters.Tags,
+				ctx, db.sql.Load(), candidateIDs, filters.PathPrefix, filters.Tags,
 				filters.Letter, filters.Cursor, filters.SortCursor, filters.Sort, filters.Limit)
 		}
 

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -720,9 +720,10 @@ func TestMediaDB_RandomGameWithQuery_PathPrefixIntegration(t *testing.T) {
 
 	matchingDir := filepath.Join("roms", "nes", "favorites")
 	matchingPath := filepath.Join(matchingDir, "target.nes")
+	nestedPath := filepath.Join(matchingDir, "nested", "nested.nes")
+	siblingPrefixPath := filepath.Join("roms", "nes", "favorites-old", "sibling.nes")
 	outsidePath := filepath.Join("roms", "nes", "other", "outside.nes")
-	paths := []string{matchingPath, outsidePath}
-	var matchingMediaID int64
+	paths := []string{matchingPath, nestedPath, siblingPrefixPath, outsidePath}
 	for i, path := range paths {
 		name := fmt.Sprintf("Game %d", i+1)
 		insertedTitle, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
@@ -731,27 +732,24 @@ func TestMediaDB_RandomGameWithQuery_PathPrefixIntegration(t *testing.T) {
 			Name:       name,
 		})
 		require.NoError(t, titleErr)
-		insertedMedia, mediaErr := mediaDB.InsertMedia(database.Media{
+		_, mediaErr := mediaDB.InsertMedia(database.Media{
 			SystemDBID:     insertedSystem.DBID,
 			MediaTitleDBID: insertedTitle.DBID,
 			Path:           path,
+			ParentDir:      ParentDirForMediaPath(filepath.ToSlash(path)),
 		})
 		require.NoError(t, mediaErr)
-		if path == matchingPath {
-			matchingMediaID = insertedMedia.DBID
-		}
 	}
 
 	require.NoError(t, mediaDB.CommitTransaction())
 
 	result, err := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
-		PathPrefix: matchingDir + string(filepath.Separator),
+		PathPrefix: filepath.ToSlash(matchingDir),
 	})
 
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
-	assert.Equal(t, matchingPath, result.Path)
-	assert.Equal(t, matchingMediaID, result.MediaID)
+	assert.Contains(t, []string{matchingPath, nestedPath}, result.Path)
 }
 
 func TestMediaDB_RandomGameWithQuery_NegativeTagIntegration(t *testing.T) {
@@ -835,6 +833,67 @@ func TestMediaDB_RandomGameWithQuery_NegativeTagIntegration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, nesSystem.ID, result.SystemID)
 	assert.Equal(t, untaggedPath, result.Path)
+}
+
+func TestMediaDB_RandomGameWithQuery_TagsApplyBeforeSystems(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	favoriteType, err := mediaDB.FindOrInsertTagType(database.TagType{Type: "user"})
+	require.NoError(t, err)
+	favoriteTag, err := mediaDB.FindOrInsertTag(database.Tag{TypeDBID: favoriteType.DBID, Tag: "favorite"})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	var favoritePath string
+	for _, systemID := range []string{"NES", "SNES"} {
+		systemDef, systemErr := systemdefs.GetSystem(systemID)
+		require.NoError(t, systemErr)
+		insertedSystem, insertErr := mediaDB.InsertSystem(database.System{
+			SystemID: systemDef.ID,
+			Name:     systemID,
+		})
+		require.NoError(t, insertErr)
+		insertedTitle, insertErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: insertedSystem.DBID,
+			Slug:       slugs.Slugify(slugs.MediaTypeGame, systemID+" Game"),
+			Name:       systemID + " Game",
+		})
+		require.NoError(t, insertErr)
+		mediaPath := filepath.Join("roms", strings.ToLower(systemID), "game.rom")
+		insertedMedia, insertErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     insertedSystem.DBID,
+			MediaTitleDBID: insertedTitle.DBID,
+			Path:           mediaPath,
+		})
+		require.NoError(t, insertErr)
+		if systemID == "NES" {
+			favoritePath = mediaPath
+			_, insertErr = mediaDB.InsertMediaTag(database.MediaTag{
+				MediaDBID: insertedMedia.DBID,
+				TagDBID:   favoriteTag.DBID,
+			})
+			require.NoError(t, insertErr)
+		}
+	}
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	result, err := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{
+		Systems: []string{"NES", "SNES"},
+		Tags: []zapscript.TagFilter{{
+			Type:  "user",
+			Value: "favorite",
+		}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "NES", result.SystemID)
+	assert.Equal(t, favoritePath, result.Path)
 }
 
 func TestMediaDB_LookupsRespectCanceledContext(t *testing.T) {

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -677,17 +677,23 @@ func browsePathPrefixCondition(column, pathPrefix string) (condition string, arg
 
 func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
 	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "m.SortName")
-	conditions := make([]string, 0, 3+len(letterClauses))
+	// Most browse scopes are bounded enough for correlated candidate probes.
+	// Required favorites are exceptionally sparse in production, so drive from
+	// that reverse-index set and probe any remaining filters per candidate.
+	tagClauses, tagArgs := buildBrowseTagFilterSQL(opts.Tags, "m")
+	conditions := make([]string, 0, 3+len(letterClauses)+len(tagClauses))
 	conditions = append(conditions, `m.ParentDir = ?`, `m.IsMissing = 0`)
 	conditions = append(conditions, letterClauses...)
 
-	args = make([]any, 0, 1+len(letterArgs))
+	args = make([]any, 0, 1+len(letterArgs)+len(tagArgs))
 	args = append(args, opts.PathPrefix)
 	args = append(args, letterArgs...)
 	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
 		conditions = append(conditions, systemClause)
 		args = append(args, systemArgs...)
 	}
+	conditions = append(conditions, tagClauses...)
+	args = append(args, tagArgs...)
 
 	return strings.Join(conditions, " AND "), args
 }
@@ -1228,6 +1234,7 @@ func sqlBrowseFileCountFromMedia(
 		PathPrefix: opts.PathPrefix,
 		Letter:     opts.Letter,
 		Systems:    opts.Systems,
+		Tags:       opts.Tags,
 	})
 	query := `SELECT COUNT(*)
 		FROM Media m
@@ -1364,18 +1371,20 @@ const (
 func sqlBrowseIndex(
 	ctx context.Context,
 	db sqlQueryable,
-	opts database.BrowseIndexOptions,
+	opts *database.BrowseIndexOptions,
 ) (database.BrowseIndexResult, error) {
 	filesOpts := &database.BrowseFilesOptions{
 		PathPrefix: opts.PathPrefix,
 		Sort:       opts.Sort,
 		Systems:    opts.Systems,
+		Tags:       opts.Tags,
 	}
 	sortMode := resolveBrowseSortMode(ctx, db, filesOpts)
 	if browseSortExpr(sortMode) != "m.SortName" {
 		total, err := sqlBrowseFileCount(ctx, db, database.BrowseFileCountOptions{
 			PathPrefix: opts.PathPrefix,
 			Systems:    opts.Systems,
+			Tags:       opts.Tags,
 		})
 		if err != nil {
 			return database.BrowseIndexResult{}, err

--- a/pkg/database/mediadb/sql_browse_tags_test.go
+++ b/pkg/database/mediadb/sql_browse_tags_test.go
@@ -87,6 +87,16 @@ func TestBrowseTags_FilesCountAndIndexStayAligned(t *testing.T) {
 	assert.Equal(t, "A", index.Buckets[0].Key)
 	assert.Equal(t, 1, index.Buckets[0].Count)
 
+	filenameIndex, err := mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		PathPrefix: pathPrefix,
+		Sort:       "filename-desc",
+		Tags:       favoriteFilter,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "none", filenameIndex.Scheme)
+	assert.Empty(t, filenameIndex.Buckets)
+	assert.Equal(t, 1, filenameIndex.TotalFiles, "non-matching rows must not contribute to filename index totals")
+
 	titleFilter := []zapscript.TagFilter{{Type: "genre", Value: "rpg"}}
 	titleFiles, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
 		PathPrefix: pathPrefix,

--- a/pkg/database/mediadb/sql_browse_tags_test.go
+++ b/pkg/database/mediadb/sql_browse_tags_test.go
@@ -1,0 +1,166 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowseTags_FilesCountAndIndexStayAligned(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	alphaPath := filepath.Join("roms", "nes", "Alpha.nes")
+	bravoPath := filepath.Join("roms", "nes", "Bravo.nes")
+	charliePath := filepath.Join("roms", "nes", "Charlie.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Alpha", alphaPath)
+	insertSystemMedia(t, mediaDB, system, "Bravo", bravoPath)
+	insertSystemMedia(t, mediaDB, system, "Charlie", charliePath)
+
+	alpha, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: alphaPath})
+	require.NoError(t, err)
+	charlie, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: charliePath})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, alpha.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, charlie.MediaTitleDBID, []database.TagInfo{{
+		Type: "genre",
+		Tag:  "rpg",
+	}}))
+
+	pathPrefix := filepath.ToSlash(filepath.Dir(alphaPath)) + "/"
+	favoriteFilter := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+	files, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: pathPrefix,
+		Sort:       "name-asc",
+		Tags:       favoriteFilter,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "Alpha", files[0].Name)
+
+	count, err := mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		PathPrefix: pathPrefix,
+		Tags:       favoriteFilter,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	index, err := mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		PathPrefix: pathPrefix,
+		Sort:       "name-asc",
+		Tags:       favoriteFilter,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, index.TotalFiles)
+	require.Len(t, index.Buckets, 1)
+	assert.Equal(t, "A", index.Buckets[0].Key)
+	assert.Equal(t, 1, index.Buckets[0].Count)
+
+	titleFilter := []zapscript.TagFilter{{Type: "genre", Value: "rpg"}}
+	titleFiles, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: pathPrefix,
+		Tags:       titleFilter,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, titleFiles, 1)
+	assert.Equal(t, "Charlie", titleFiles[0].Name)
+}
+
+func TestHasRequiredFavoriteFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filter zapscript.TagFilter
+		name   string
+		want   bool
+	}{
+		{name: "default AND", filter: zapscript.TagFilter{Type: "user", Value: "favorite"}, want: true},
+		{name: "explicit AND", filter: zapscript.TagFilter{
+			Type: "user", Value: "favorite", Operator: zapscript.TagOperatorAND,
+		}, want: true},
+		{name: "OR", filter: zapscript.TagFilter{
+			Type: "user", Value: "favorite", Operator: zapscript.TagOperatorOR,
+		}},
+		{name: "NOT", filter: zapscript.TagFilter{
+			Type: "user", Value: "favorite", Operator: zapscript.TagOperatorNOT,
+		}},
+		{name: "other tag", filter: zapscript.TagFilter{Type: "genre", Value: "action"}},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, testCase.want, hasRequiredFavoriteFilter([]zapscript.TagFilter{testCase.filter}))
+		})
+	}
+}
+
+func TestBuildBrowseTagFilterSQL(t *testing.T) {
+	t.Parallel()
+
+	clauses, args := buildBrowseTagFilterSQL([]zapscript.TagFilter{
+		{Type: "user", Value: "favorite"},
+		{Type: "genre", Value: "action"},
+	}, "m")
+	require.Len(t, clauses, 2)
+	assert.Contains(t, clauses[0], "m.DBID IN")
+	assert.Contains(t, clauses[1], "EXISTS")
+	assert.Len(t, args, 8)
+
+	candidateClauses, _ := buildBrowseTagFilterSQL([]zapscript.TagFilter{{
+		Type: "genre", Value: "action",
+	}}, "m")
+	require.Len(t, candidateClauses, 1)
+	assert.Contains(t, candidateClauses[0], "EXISTS")
+	assert.NotContains(t, candidateClauses[0], "m.DBID IN")
+}
+
+func TestBuildTagFilterSQL_MediaAlias(t *testing.T) {
+	t.Parallel()
+
+	clauses, args := buildTagFilterSQLForRef([]zapscript.TagFilter{
+		{Type: "user", Value: "favorite"},
+		{Type: "region", Value: "eu", Operator: zapscript.TagOperatorNOT},
+		{Type: "lang", Value: "en", Operator: zapscript.TagOperatorOR},
+	}, "m")
+
+	require.NotEmpty(t, clauses)
+	assert.NotEmpty(t, args)
+	for _, clause := range clauses {
+		assert.NotContains(t, clause, "Media.DBID")
+		assert.NotContains(t, clause, "Media.MediaTitleDBID")
+	}
+	assert.Contains(t, clauses[0], "m.DBID")
+}

--- a/pkg/database/mediadb/sql_helpers.go
+++ b/pkg/database/mediadb/sql_helpers.go
@@ -40,6 +40,13 @@ func prepareVariadic(p, s string, c int) string {
 	return strings.Join(q, s)
 }
 
+func mediaRecursivePathPrefix(path string) string {
+	if path == "" || strings.HasSuffix(path, "/") {
+		return path
+	}
+	return path + "/"
+}
+
 // buildMediaQueryWhereClause creates WHERE clause and arguments for a MediaQuery.
 // Centralizes the logic to avoid duplication between different query functions.
 func buildMediaQueryWhereClause(query *database.MediaQuery) (whereClause string, args []any) {
@@ -56,10 +63,14 @@ func buildMediaQueryWhereClause(query *database.MediaQuery) (whereClause string,
 			fmt.Sprintf("Systems.SystemID IN (%s)", strings.Join(placeholders, ",")))
 	}
 
-	// Path prefix filtering (for absolute paths)
+	// Recursive paths use a boundary-delimited indexed range, so a scope such
+	// as /roms/SNES cannot include sibling /roms/SNES2 and wildcard characters
+	// in real path names stay literal.
 	if query.PathPrefix != "" {
-		whereConditions = append(whereConditions, "Media.Path LIKE ?")
-		args = append(args, query.PathPrefix+"%")
+		pathCondition, pathArgs := browsePathPrefixCondition(
+			"Media.Path", mediaRecursivePathPrefix(query.PathPrefix))
+		whereConditions = append(whereConditions, pathCondition)
+		args = append(args, pathArgs...)
 	}
 
 	// PathGlob - match against slugified titles for fuzzy search
@@ -119,4 +130,20 @@ func buildMediaQueryWhereClause(query *database.MediaQuery) (whereClause string,
 	}
 
 	return whereClause, args
+}
+
+// buildMediaCandidateQueryWhereClause uses correlated tag probes for a query
+// already narrowed to one candidate DBID. This avoids materializing a complete
+// tag result set for each dense-range rejection-sampling attempt.
+func buildMediaCandidateQueryWhereClause(
+	query *database.MediaQuery,
+) (whereClause string, args []any) {
+	candidateQuery := *query
+	candidateQuery.Tags = nil
+	whereClause, args = buildMediaQueryWhereClause(&candidateQuery)
+	tagClauses, tagArgs := buildCandidateTagFilterSQL(query.Tags)
+	if len(tagClauses) == 0 {
+		return whereClause, args
+	}
+	return whereClause + " AND " + strings.Join(tagClauses, " AND "), append(args, tagArgs...)
 }

--- a/pkg/database/mediadb/sql_random_bench_test.go
+++ b/pkg/database/mediadb/sql_random_bench_test.go
@@ -1,0 +1,226 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkRandomGame_Query_1k(b *testing.B) {
+	benchmarkRandomGameQuery(b, 1_000)
+}
+
+func BenchmarkRandomGame_Query_50k(b *testing.B) {
+	benchmarkRandomGameQuery(b, 50_000)
+}
+
+func BenchmarkRandomGame_Query_500k(b *testing.B) {
+	benchmarkRandomGameQuery(b, 500_000)
+}
+
+func benchmarkRandomGameQuery(b *testing.B, rows int) {
+	b.Helper()
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+	defer cleanup()
+	rootDir := seedRandomGameBenchmark(b, mediaDB, rows)
+
+	queries := []struct {
+		name  string
+		query database.MediaQuery
+		cold  bool
+	}{
+		{name: "all", query: database.MediaQuery{Systems: []string{"NES"}}},
+		{name: "all-cold", cold: true, query: database.MediaQuery{Systems: []string{"NES"}}},
+		{name: "favorite-sparse", query: database.MediaQuery{
+			Systems: []string{"NES"},
+			Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
+		}},
+		{name: "favorite-sparse-cold", cold: true, query: database.MediaQuery{
+			Systems: []string{"NES"},
+			Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
+		}},
+		{name: "action-dense", query: database.MediaQuery{
+			Systems: []string{"NES"},
+			Tags:    []zapscript.TagFilter{{Type: "genre", Value: "action"}},
+		}},
+		{name: "not-favorite-dense", query: database.MediaQuery{
+			Systems: []string{"NES"},
+			Tags: []zapscript.TagFilter{{
+				Type:     "user",
+				Value:    "favorite",
+				Operator: zapscript.TagOperatorNOT,
+			}},
+		}},
+		{name: "recursive-path", query: database.MediaQuery{PathPrefix: rootDir}},
+	}
+
+	for i := range queries {
+		testCase := &queries[i]
+		b.Run(testCase.name, func(b *testing.B) {
+			b.ReportAllocs()
+			_, err := mediaDB.RandomGameWithQuery(ctx, &testCase.query)
+			require.NoError(b, err)
+
+			b.ResetTimer()
+			for b.Loop() {
+				if testCase.cold {
+					if err = mediaDB.InvalidateCountCache(); err != nil {
+						b.Fatal(err)
+					}
+				}
+				_, err = mediaDB.RandomGameWithQuery(ctx, &testCase.query)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func seedRandomGameBenchmark(b testing.TB, mediaDB *MediaDB, rows int) string {
+	b.Helper()
+	ctx := context.Background()
+	rootDir := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "random-bench"))
+
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'NES', 'NES');
+		INSERT INTO TagTypes (DBID, Type, IsExclusive) VALUES
+			(1, 'user', 0),
+			(2, 'genre', 0);
+		INSERT INTO Tags (DBID, TypeDBID, Tag) VALUES
+			(1, 1, 'favorite'),
+			(2, 2, 'action');
+	`)
+	require.NoError(b, err)
+
+	titleStmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 1, ?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, titleStmt.Close()) }()
+	mediaStmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName)
+		VALUES (?, ?, 1, ?, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, mediaStmt.Close()) }()
+	tagStmt, err := tx.PrepareContext(ctx, `INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (?, ?)`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, tagStmt.Close()) }()
+
+	for i := 1; i <= rows; i++ {
+		mediaID := int64(i)
+		name := fmt.Sprintf("Random Game %06d", i)
+		folderNumber := (i - 1) / 100 % 100
+		folder := mediaRecursivePathPrefix(filepath.ToSlash(filepath.Join(
+			rootDir, fmt.Sprintf("folder-%03d", folderNumber))))
+		mediaPath := filepath.ToSlash(filepath.Join(folder, fmt.Sprintf("game-%06d.rom", i)))
+		_, err = titleStmt.ExecContext(ctx, mediaID, fmt.Sprintf("random-game-%06d", i), name)
+		require.NoError(b, err)
+		_, err = mediaStmt.ExecContext(ctx, mediaID, mediaID, mediaPath, folder, name)
+		require.NoError(b, err)
+		if i <= 5 || i%10_007 == 0 {
+			_, err = tagStmt.ExecContext(ctx, mediaID, int64(1))
+			require.NoError(b, err)
+		}
+		if i%5 != 0 {
+			_, err = tagStmt.ExecContext(ctx, mediaID, int64(2))
+			require.NoError(b, err)
+		}
+	}
+
+	require.NoError(b, tx.Commit())
+	_, err = mediaDB.sql.Load().ExecContext(ctx, "ANALYZE")
+	require.NoError(b, err)
+	return rootDir
+}
+
+func TestRandomGameQueryPlansUseExistingIndexes(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	rootDir := seedRandomGameBenchmark(t, mediaDB, 1_000)
+
+	pathWhere, pathArgs := buildMediaQueryWhereClause(&database.MediaQuery{PathPrefix: rootDir})
+	pathPlan := randomQueryPlan(t, mediaDB.sql.Load(),
+		"SELECT COUNT(*), MIN(Media.DBID), MAX(Media.DBID) FROM Media "+pathWhere, pathArgs...)
+	assertRandomPlanContains(t, pathPlan, "path_idx")
+
+	tagQuery := &database.MediaQuery{
+		Systems: []string{"NES"},
+		Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
+	}
+	tagWhere, tagArgs := buildMediaQueryWhereClause(tagQuery)
+	tagPlan := randomQueryPlan(t, mediaDB.sql.Load(), `
+		SELECT COUNT(*), MIN(Media.DBID), MAX(Media.DBID)
+		FROM Media
+		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
+		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
+	`+tagWhere, tagArgs...)
+	assertRandomPlanContains(t, tagPlan, "mediatags_tag_media_idx")
+	assertRandomPlanContains(t, tagPlan, "mediatitletags_tag_idx")
+
+	candidateWhere, candidateArgs := buildMediaCandidateQueryWhereClause(tagQuery)
+	candidateArgs = append(candidateArgs, int64(100))
+	candidatePlan := randomQueryPlan(t, mediaDB.sql.Load(), `
+		SELECT Systems.SystemID, Media.Path, Media.DBID
+		FROM Media
+		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
+		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
+	`+candidateWhere+" AND Media.DBID = ? LIMIT 1", candidateArgs...)
+	assertRandomPlanContains(t, candidatePlan, "SEARCH Media USING INTEGER PRIMARY KEY")
+}
+
+func randomQueryPlan(t testing.TB, db sqlQueryable, query string, args ...any) string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	plan := strings.Join(details, "\n")
+	t.Logf("query plan:\n%s", plan)
+	return plan
+}
+
+func assertRandomPlanContains(t testing.TB, plan, index string) {
+	t.Helper()
+	require.Contains(t, strings.ToLower(plan), strings.ToLower(index))
+}

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -787,7 +787,7 @@ func sqlSearchMediaWithFilters(
 	includeName bool,
 ) ([]database.SearchResultWithCursor, error) {
 	return sqlSearchMediaWithFiltersSorted(
-		ctx, db, systems, variantGroups, rawWords, tags, letter, cursor, nil, "", limit, includeName)
+		ctx, db, systems, variantGroups, rawWords, "", tags, letter, cursor, nil, "", limit, includeName)
 }
 
 func sqlSearchMediaWithFiltersSorted(
@@ -796,6 +796,7 @@ func sqlSearchMediaWithFiltersSorted(
 	systems []systemdefs.System,
 	variantGroups [][]string,
 	rawWords []string,
+	pathPrefix string,
 	tags []zapscript.TagFilter,
 	letter *string,
 	cursor *int64,
@@ -814,8 +815,8 @@ func sqlSearchMediaWithFiltersSorted(
 	// covers every defined system the SystemID IN (...) clause filters nothing,
 	// but its presence makes SQLite drive the join from Systems and scan every
 	// title instead of the handful of tag matches. Omit it in that case.
-	skipSystemFilter := len(variantGroups) == 0 && !includeName && len(tags) > 0 &&
-		requestedAllSystems(systems)
+	skipSystemFilter := requestedAllSystems(systems) && (pathPrefix != "" ||
+		(len(variantGroups) == 0 && !includeName && len(tags) > 0))
 
 	// Build system ID args
 	args := make([]any, 0)
@@ -881,6 +882,15 @@ func sqlSearchMediaWithFiltersSorted(
 		cursorArgs = []any{*cursor}
 	}
 
+	pathFilterCondition := ""
+	var pathFilterArgs []any
+	if pathPrefix != "" {
+		pathClause, pathArgs := browsePathPrefixCondition(
+			"Media.Path", mediaRecursivePathPrefix(pathPrefix))
+		pathFilterCondition = " AND " + pathClause
+		pathFilterArgs = pathArgs
+	}
+
 	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
 	tagFilterCondition := ""
 	if len(tagFilterClauses) > 0 {
@@ -921,6 +931,7 @@ func sqlSearchMediaWithFiltersSorted(
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
 		WHERE ` + systemCondition +
 		`Media.IsMissing = 0` +
+		pathFilterCondition +
 		variantCondition +
 		cursorCondition +
 		tagFilterCondition +
@@ -929,11 +940,12 @@ func sqlSearchMediaWithFiltersSorted(
 		` LIMIT ?`
 
 	// Assemble args in WHERE-clause order.
-	mediaArgs := append([]any(nil), args...)        // System IDs
-	mediaArgs = append(mediaArgs, variantArgs...)   // Query variants
-	mediaArgs = append(mediaArgs, cursorArgs...)    // Cursor keyset
-	mediaArgs = append(mediaArgs, tagFilterArgs...) // Tag filters
-	mediaArgs = append(mediaArgs, letterArgs...)    // Letter filters
+	mediaArgs := append([]any(nil), args...)         // System IDs
+	mediaArgs = append(mediaArgs, pathFilterArgs...) // Recursive path range
+	mediaArgs = append(mediaArgs, variantArgs...)    // Query variants
+	mediaArgs = append(mediaArgs, cursorArgs...)     // Cursor keyset
+	mediaArgs = append(mediaArgs, tagFilterArgs...)  // Tag filters
+	mediaArgs = append(mediaArgs, letterArgs...)     // Letter filters
 	mediaArgs = append(mediaArgs, limit)
 
 	queryStarted := time.Now()
@@ -998,6 +1010,7 @@ func sqlSearchMediaWithFiltersSorted(
 
 	log.Debug().
 		Int("systems", len(systems)).
+		Str("pathPrefix", pathPrefix).
 		Int("variantGroups", len(variantGroups)).
 		Int("tagFilters", len(tags)).
 		Str("sort", sortOrder).
@@ -1020,13 +1033,14 @@ func sqlSearchMediaByTitleDBIDs(
 	limit int,
 ) ([]database.SearchResultWithCursor, error) {
 	return sqlSearchMediaByTitleDBIDsSorted(
-		ctx, db, titleDBIDs, tags, letter, cursor, nil, "", limit)
+		ctx, db, titleDBIDs, "", tags, letter, cursor, nil, "", limit)
 }
 
 func sqlSearchMediaByTitleDBIDsSorted(
 	ctx context.Context,
 	db sqlQueryable,
 	titleDBIDs []int64,
+	pathPrefix string,
 	tags []zapscript.TagFilter,
 	letter *string,
 	cursor *int64,
@@ -1048,6 +1062,13 @@ func sqlSearchMediaByTitleDBIDsSorted(
 	// Build additional filter conditions
 	var extraConditions []string
 	var extraArgs []any
+
+	if pathPrefix != "" {
+		pathClause, pathArgs := browsePathPrefixCondition(
+			"Media.Path", mediaRecursivePathPrefix(pathPrefix))
+		extraConditions = append(extraConditions, pathClause)
+		extraArgs = append(extraArgs, pathArgs...)
+	}
 
 	switch {
 	case sortCursor != nil:

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -739,6 +739,41 @@ func requestedAllSystems(systems []systemdefs.System) bool {
 	return true
 }
 
+func searchSortExpr(sortOrder string) string {
+	switch sortOrder {
+	case "name-asc", "name-desc":
+		return "MediaTitles.Name COLLATE NOCASE"
+	case "filename-asc", "filename-desc":
+		return "Media.Path"
+	default:
+		return "Media.DBID"
+	}
+}
+
+func searchSortClause(sortOrder string) string {
+	expr := searchSortExpr(sortOrder)
+	switch sortOrder {
+	case "name-desc", "filename-desc":
+		return expr + " DESC, Media.DBID DESC"
+	default:
+		return expr + " ASC, Media.DBID ASC"
+	}
+}
+
+func searchCursorPredicate(sortOrder string) string {
+	expr := searchSortExpr(sortOrder)
+	switch sortOrder {
+	case "name-desc", "filename-desc":
+		return "(" + expr + ", Media.DBID) < (?, ?)"
+	default:
+		return "(" + expr + ", Media.DBID) > (?, ?)"
+	}
+}
+
+func searchCursorCondition(sortOrder string) string {
+	return " AND " + searchCursorPredicate(sortOrder) + " "
+}
+
 func sqlSearchMediaWithFilters(
 	ctx context.Context,
 	db sqlQueryable,
@@ -748,6 +783,24 @@ func sqlSearchMediaWithFilters(
 	tags []zapscript.TagFilter,
 	letter *string,
 	cursor *int64,
+	limit int,
+	includeName bool,
+) ([]database.SearchResultWithCursor, error) {
+	return sqlSearchMediaWithFiltersSorted(
+		ctx, db, systems, variantGroups, rawWords, tags, letter, cursor, nil, "", limit, includeName)
+}
+
+func sqlSearchMediaWithFiltersSorted(
+	ctx context.Context,
+	db sqlQueryable,
+	systems []systemdefs.System,
+	variantGroups [][]string,
+	rawWords []string,
+	tags []zapscript.TagFilter,
+	letter *string,
+	cursor *int64,
+	sortCursor *database.SearchCursor,
+	sortOrder string,
 	limit int,
 	includeName bool,
 ) ([]database.SearchResultWithCursor, error) {
@@ -809,11 +862,23 @@ func sqlSearchMediaWithFilters(
 		variantCondition = " AND " + strings.Join(groupClauses, " AND ")
 	}
 
-	// Add cursor condition if provided
+	// Add cursor condition if provided. Explicit sorts use their compound
+	// sort-value/DBID keyset; legacy requests retain the DBID-only cursor.
 	cursorCondition := ""
-	if cursor != nil {
+	var cursorArgs []any
+	switch {
+	case sortCursor != nil:
+		if sortOrder == "" || sortCursor.Sort != sortOrder {
+			return nil, errors.New("search cursor sort does not match request")
+		}
+		cursorCondition = searchCursorCondition(sortOrder)
+		cursorArgs = []any{sortCursor.SortValue, sortCursor.LastID}
+	case cursor != nil:
+		if sortOrder != "" {
+			return nil, errors.New("legacy search cursor cannot continue explicit sort")
+		}
 		cursorCondition = " AND Media.DBID > ? "
-		variantArgs = append(variantArgs, *cursor)
+		cursorArgs = []any{*cursor}
 	}
 
 	tagFilterClauses, tagFilterArgs := BuildTagFilterSQL(tags)
@@ -827,7 +892,6 @@ func sqlSearchMediaWithFilters(
 	letterClauses, letterArgs := BuildLetterFilterSQL(letter, "MediaTitles.Name")
 	if len(letterClauses) > 0 {
 		letterFilterCondition = " AND " + strings.Join(letterClauses, " AND ")
-		variantArgs = append(variantArgs, letterArgs...)
 	}
 
 	systemCondition := ""
@@ -836,9 +900,13 @@ func sqlSearchMediaWithFilters(
 			prepareVariadic("?", ",", len(systems)) + `) AND `
 	}
 
-	// Every query must use cursor order because media-type-scoped searches are
-	// merged in Go before applying the page limit.
-	orderCondition := ` ORDER BY Media.DBID ASC`
+	// Every query must use the requested cursor order because media-type-scoped
+	// searches are merged in Go before applying the page limit.
+	orderCondition := ` ORDER BY ` + searchSortClause(sortOrder)
+	sortValueSelect := ""
+	if sortOrder != "" {
+		sortValueSelect = `, ` + searchSortExpr(sortOrder) + ` AS SortValue`
+	}
 
 	//nolint:gosec // Safe: WHERE clause built from sanitized components, no direct user input interpolation
 	mediaQuery := `
@@ -847,7 +915,7 @@ func sqlSearchMediaWithFilters(
 			MediaTitles.Name,
 			Media.Path,
 			Media.DBID,
-			MediaTitles.DisambiguationTypes
+			MediaTitles.DisambiguationTypes` + sortValueSelect + `
 		FROM Systems
 		INNER JOIN MediaTitles ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
@@ -860,10 +928,12 @@ func sqlSearchMediaWithFilters(
 		orderCondition +
 		` LIMIT ?`
 
-	// Assemble final args: systems → variants → tag filters → limit
+	// Assemble args in WHERE-clause order.
 	mediaArgs := append([]any(nil), args...)        // System IDs
-	mediaArgs = append(mediaArgs, variantArgs...)   // Variant args (includes cursor, letter if present)
-	mediaArgs = append(mediaArgs, tagFilterArgs...) // Add tag filter args
+	mediaArgs = append(mediaArgs, variantArgs...)   // Query variants
+	mediaArgs = append(mediaArgs, cursorArgs...)    // Cursor keyset
+	mediaArgs = append(mediaArgs, tagFilterArgs...) // Tag filters
+	mediaArgs = append(mediaArgs, letterArgs...)    // Letter filters
 	mediaArgs = append(mediaArgs, limit)
 
 	queryStarted := time.Now()
@@ -890,11 +960,29 @@ func sqlSearchMediaWithFilters(
 	// Collect media items
 	for mediaRows.Next() {
 		result := database.SearchResultWithCursor{}
-		if scanErr := mediaRows.Scan(
-			&result.SystemID, &result.Name, &result.Path, &result.MediaID, &result.DisambiguationTypes,
-		); scanErr != nil {
+		var scanErr error
+		if sortOrder == "" {
+			scanErr = mediaRows.Scan(
+				&result.SystemID,
+				&result.Name,
+				&result.Path,
+				&result.MediaID,
+				&result.DisambiguationTypes,
+			)
+		} else {
+			scanErr = mediaRows.Scan(
+				&result.SystemID,
+				&result.Name,
+				&result.Path,
+				&result.MediaID,
+				&result.DisambiguationTypes,
+				&result.SortValue,
+			)
+		}
+		if scanErr != nil {
 			return results, fmt.Errorf("failed to scan media result: %w", scanErr)
 		}
+		result.SortMode = sortOrder
 		results = append(results, result)
 	}
 	if err = mediaRows.Err(); err != nil {
@@ -912,6 +1000,7 @@ func sqlSearchMediaWithFilters(
 		Int("systems", len(systems)).
 		Int("variantGroups", len(variantGroups)).
 		Int("tagFilters", len(tags)).
+		Str("sort", sortOrder).
 		Bool("tagDriven", skipSystemFilter).
 		Int("rows", len(results)).
 		Dur("queryDuration", queryElapsed).
@@ -930,6 +1019,21 @@ func sqlSearchMediaByTitleDBIDs(
 	cursor *int64,
 	limit int,
 ) ([]database.SearchResultWithCursor, error) {
+	return sqlSearchMediaByTitleDBIDsSorted(
+		ctx, db, titleDBIDs, tags, letter, cursor, nil, "", limit)
+}
+
+func sqlSearchMediaByTitleDBIDsSorted(
+	ctx context.Context,
+	db sqlQueryable,
+	titleDBIDs []int64,
+	tags []zapscript.TagFilter,
+	letter *string,
+	cursor *int64,
+	sortCursor *database.SearchCursor,
+	sortOrder string,
+	limit int,
+) ([]database.SearchResultWithCursor, error) {
 	if len(titleDBIDs) == 0 {
 		return []database.SearchResultWithCursor{}, nil
 	}
@@ -945,7 +1049,17 @@ func sqlSearchMediaByTitleDBIDs(
 	var extraConditions []string
 	var extraArgs []any
 
-	if cursor != nil {
+	switch {
+	case sortCursor != nil:
+		if sortOrder == "" || sortCursor.Sort != sortOrder {
+			return nil, errors.New("search cursor sort does not match request")
+		}
+		extraConditions = append(extraConditions, searchCursorPredicate(sortOrder))
+		extraArgs = append(extraArgs, sortCursor.SortValue, sortCursor.LastID)
+	case cursor != nil:
+		if sortOrder != "" {
+			return nil, errors.New("legacy search cursor cannot continue explicit sort")
+		}
 		extraConditions = append(extraConditions, "Media.DBID > ?")
 		extraArgs = append(extraArgs, *cursor)
 	}
@@ -963,6 +1077,11 @@ func sqlSearchMediaByTitleDBIDs(
 		whereExtra = " AND " + strings.Join(extraConditions, " AND ")
 	}
 
+	sortValueSelect := ""
+	if sortOrder != "" {
+		sortValueSelect = `, ` + searchSortExpr(sortOrder) + ` AS SortValue`
+	}
+
 	//nolint:gosec // Safe: WHERE clause built from sanitized components
 	query := `
 		SELECT
@@ -970,12 +1089,12 @@ func sqlSearchMediaByTitleDBIDs(
 			MediaTitles.Name,
 			Media.Path,
 			Media.DBID,
-			MediaTitles.DisambiguationTypes
+			MediaTitles.DisambiguationTypes` + sortValueSelect + `
 		FROM MediaTitles
 		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
 		INNER JOIN Media ON MediaTitles.DBID = Media.MediaTitleDBID
 		WHERE ` + titleCondition + ` AND Media.IsMissing = 0` + whereExtra + `
-		ORDER BY Media.DBID ASC
+		ORDER BY ` + searchSortClause(sortOrder) + `
 		LIMIT ?`
 
 	finalArgs := make([]any, 0, len(args)+len(extraArgs)+1)
@@ -993,11 +1112,29 @@ func sqlSearchMediaByTitleDBIDs(
 	results := make([]database.SearchResultWithCursor, 0, min(limit, 100))
 	for rows.Next() {
 		var r database.SearchResultWithCursor
-		if scanErr := rows.Scan(
-			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.DisambiguationTypes,
-		); scanErr != nil {
+		var scanErr error
+		if sortOrder == "" {
+			scanErr = rows.Scan(
+				&r.SystemID,
+				&r.Name,
+				&r.Path,
+				&r.MediaID,
+				&r.DisambiguationTypes,
+			)
+		} else {
+			scanErr = rows.Scan(
+				&r.SystemID,
+				&r.Name,
+				&r.Path,
+				&r.MediaID,
+				&r.DisambiguationTypes,
+				&r.SortValue,
+			)
+		}
+		if scanErr != nil {
 			return nil, fmt.Errorf("failed to scan result: %w", scanErr)
 		}
+		r.SortMode = sortOrder
 		results = append(results, r)
 	}
 	if err = rows.Err(); err != nil {
@@ -1013,6 +1150,7 @@ func sqlSearchMediaByTitleDBIDs(
 	log.Debug().
 		Int("titleDBIDs", len(titleDBIDs)).
 		Int("tagFilters", len(tags)).
+		Str("sort", sortOrder).
 		Int("rows", len(results)).
 		Dur("queryDuration", queryElapsed).
 		Dur("tagsDuration", time.Since(tagsStarted)).
@@ -1397,88 +1535,81 @@ func sqlSearchMediaBySlugIn(
 	return results, nil
 }
 
-// sqlGetRandomMediaForTitle returns a random media entry for the given title DBID.
-func sqlGetRandomMediaForTitle(ctx context.Context, db sqlQueryable, titleDBID int64) (database.SearchResult, error) {
-	var row database.SearchResult
-	err := db.QueryRowContext(ctx, `
-		SELECT Systems.SystemID, Media.Path, Media.DBID
-		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-		WHERE Media.MediaTitleDBID = ? AND Media.IsMissing = 0
-		ORDER BY RANDOM() LIMIT 1
-	`, titleDBID).Scan(&row.SystemID, &row.Path, &row.MediaID)
-	if err != nil {
-		return row, fmt.Errorf("failed to get random media for title %d: %w", titleDBID, err)
-	}
-	row.Name = helpers.FilenameFromPath(row.Path)
-	return row, nil
+const (
+	randomDenseRangeFactor   = 4
+	randomExactProbeAttempts = 8
+)
+
+func sqlSelectRandomGameWithStats(
+	ctx context.Context,
+	db sqlQueryable,
+	query *database.MediaQuery,
+	stats MediaStats,
+) (database.SearchResult, error) {
+	return sqlSelectRandomGameWithStatsUsing(ctx, db, query, stats, helpers.RandomInt)
 }
 
-func sqlRandomGame(ctx context.Context, db sqlQueryable, system *systemdefs.System) (database.SearchResult, error) {
+func sqlSelectRandomGameWithStatsUsing(
+	ctx context.Context,
+	db sqlQueryable,
+	query *database.MediaQuery,
+	stats MediaStats,
+	randomInt func(int) (int, error),
+) (database.SearchResult, error) {
 	var row database.SearchResult
-
-	// Step 1: Get count, min DBID, and max DBID for this system
-	statsQuery := `
-		SELECT COUNT(*), COALESCE(MIN(Media.DBID), 0), COALESCE(MAX(Media.DBID), 0)
-		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-		WHERE Systems.SystemID = ? AND Media.IsMissing = 0
-	`
-	var count int
-	var minDBID, maxDBID int64
-	err := db.QueryRowContext(ctx, statsQuery, system.ID).Scan(&count, &minDBID, &maxDBID)
-	if err != nil {
-		return row, fmt.Errorf("failed to get media stats for system: %w", err)
-	}
-
-	if count == 0 {
+	if stats.Count <= 0 {
 		return row, sql.ErrNoRows
 	}
 
-	// Step 2: Generate random DBID within the range
-	// This approach is O(log n) instead of O(n) for OFFSET
-	randomOffset, err := helpers.RandomInt(int(maxDBID - minDBID + 1))
-	if err != nil {
-		return row, fmt.Errorf("failed to generate random DBID offset: %w", err)
-	}
-	targetDBID := minDBID + int64(randomOffset)
-
-	// Step 3: Get the first media item with DBID >= targetDBID
-	selectQuery := `
+	whereClause, baseArgs := buildMediaQueryWhereClause(query)
+	const selectColumns = `
 		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
 		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-		WHERE Systems.SystemID = ? AND Media.IsMissing = 0 AND Media.DBID >= ?
-		ORDER BY Media.DBID ASC
-		LIMIT 1
-	`
-	err = db.QueryRowContext(ctx, selectQuery, system.ID, targetDBID).Scan(
-		&row.SystemID,
-		&row.Path,
-		&row.MediaID,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
-		selectQuery = `
-			SELECT Systems.SystemID, Media.Path, Media.DBID
-			FROM Media
-			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-			WHERE Systems.SystemID = ? AND Media.IsMissing = 0 AND Media.DBID < ?
-			ORDER BY Media.DBID DESC
-			LIMIT 1
-		`
-		err = db.QueryRowContext(ctx, selectQuery, system.ID, targetDBID).Scan(
-			&row.SystemID,
-			&row.Path,
-			&row.MediaID,
-		)
+		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID`
+
+	maxInt := int64(^uint(0) >> 1)
+	var rangeSize int64
+	if stats.MaxDBID >= stats.MinDBID {
+		delta := stats.MaxDBID - stats.MinDBID
+		if delta < maxInt {
+			rangeSize = delta + 1
+		}
 	}
+
+	// Exact rejection sampling is constant-time for dense DBID ranges and stays
+	// uniform because misses are discarded rather than assigned to the next row.
+	if rangeSize > 0 && rangeSize <= int64(stats.Count)*randomDenseRangeFactor {
+		candidateWhereClause, candidateArgs := buildMediaCandidateQueryWhereClause(query)
+		exactQuery := selectColumns + "\n" + candidateWhereClause + " AND Media.DBID = ? LIMIT 1"
+		for range randomExactProbeAttempts {
+			randomOffset, err := randomInt(int(rangeSize))
+			if err != nil {
+				return row, fmt.Errorf("failed to generate exact random DBID offset: %w", err)
+			}
+			args := append(append([]any(nil), candidateArgs...), stats.MinDBID+int64(randomOffset))
+			err = db.QueryRowContext(ctx, exactQuery, args...).Scan(&row.SystemID, &row.Path, &row.MediaID)
+			if err == nil {
+				row.Name = helpers.FilenameFromPath(row.Path)
+				return row, nil
+			}
+			if !errors.Is(err, sql.ErrNoRows) {
+				return row, fmt.Errorf("failed exact random media probe: %w", err)
+			}
+		}
+	}
+
+	// Sparse scopes use a uniform ordinal over the exact matching set. This
+	// scans only to the chosen matching row and avoids ORDER BY RANDOM's full
+	// random-key sort.
+	randomOrdinal, err := randomInt(stats.Count)
 	if err != nil {
-		return row, fmt.Errorf("failed to scan random game row using DBID approach: %w", err)
+		return row, fmt.Errorf("failed to generate random media ordinal: %w", err)
+	}
+	offsetQuery := selectColumns + "\n" + whereClause + " ORDER BY Media.DBID ASC LIMIT 1 OFFSET ?"
+	args := append(append([]any(nil), baseArgs...), randomOrdinal)
+	if err = db.QueryRowContext(ctx, offsetQuery, args...).Scan(&row.SystemID, &row.Path, &row.MediaID); err != nil {
+		return row, fmt.Errorf("failed to select random media ordinal: %w", err)
 	}
 	row.Name = helpers.FilenameFromPath(row.Path)
 	return row, nil
@@ -1520,52 +1651,9 @@ func sqlRandomGameWithQueryAndStats(
 		return row, stats, sql.ErrNoRows
 	}
 
-	// Step 2: Generate random DBID within the range
-	randomOffset, err := helpers.RandomInt(int(stats.MaxDBID - stats.MinDBID + 1))
+	row, err = sqlSelectRandomGameWithStats(ctx, db, query, stats)
 	if err != nil {
-		return row, stats, fmt.Errorf("failed to generate random DBID offset: %w", err)
+		return row, stats, err
 	}
-	targetDBID := stats.MinDBID + int64(randomOffset)
-
-	// Step 3: Get the first media item with DBID >= targetDBID
-	//nolint:gosec // whereClause is built from safe conditions, no user input
-	selectQuery := fmt.Sprintf(`
-		SELECT Systems.SystemID, Media.Path, Media.DBID
-		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-		%s AND Media.DBID >= ?
-		ORDER BY Media.DBID ASC
-		LIMIT 1
-	`, whereClause)
-
-	args = append(args, targetDBID)
-	err = db.QueryRowContext(ctx, selectQuery, args...).Scan(
-		&row.SystemID,
-		&row.Path,
-		&row.MediaID,
-	)
-	if errors.Is(err, sql.ErrNoRows) {
-		// If no row found >= targetDBID (gap in DBID sequence), try wrapping to beginning
-		selectQuery = fmt.Sprintf(`
-			SELECT Systems.SystemID, Media.Path, Media.DBID
-			FROM Media
-			INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-			INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID
-			%s AND Media.DBID < ?
-			ORDER BY Media.DBID DESC
-			LIMIT 1
-		`, whereClause)
-		args[len(args)-1] = targetDBID
-		err = db.QueryRowContext(ctx, selectQuery, args...).Scan(
-			&row.SystemID,
-			&row.Path,
-			&row.MediaID,
-		)
-	}
-	if err != nil {
-		return row, stats, fmt.Errorf("failed to scan random game row with query: %w", err)
-	}
-	row.Name = helpers.FilenameFromPath(row.Path)
 	return row, stats, nil
 }

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -794,6 +794,47 @@ func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) 
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestRandomGameWithQuery_RefreshesStaleCachedStatsOnce(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mediaDB := &MediaDB{inTransaction: true}
+	mediaDB.sql.Store(db)
+	mock.ExpectQuery(`SELECT Count, MinDBID, MaxDBID FROM MediaCountCache WHERE QueryHash = \?`).
+		WithArgs(sqlmock.AnyArg()).
+		WillReturnRows(sqlmock.NewRows([]string{"Count", "MinDBID", "MaxDBID"}).AddRow(1, 999, 999))
+
+	exactQuery := `SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* ` +
+		`WHERE Media\.IsMissing = 0 AND Media\.DBID = \? LIMIT 1`
+	for range randomExactProbeAttempts {
+		mock.ExpectQuery(exactQuery).WithArgs(int64(999)).
+			WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}))
+	}
+	mock.ExpectQuery(
+		`SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* ` +
+			`WHERE Media\.IsMissing = 0 ORDER BY Media\.DBID ASC LIMIT 1 OFFSET \?`,
+	).WithArgs(0).WillReturnRows(sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}))
+
+	mock.ExpectQuery(
+		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), ` +
+			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE Media\.IsMissing = 0`,
+	).WillReturnRows(sqlmock.NewRows([]string{"count", "min", "max"}).AddRow(1, 42, 42))
+	mediaPath := filepath.Join("roms", "nes", "refreshed.nes")
+	mock.ExpectQuery(exactQuery).WithArgs(int64(42)).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).AddRow("NES", mediaPath, 42),
+	)
+
+	result, err := mediaDB.RandomGameWithQuery(context.Background(), &database.MediaQuery{})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), result.MediaID)
+	assert.Equal(t, mediaPath, result.Path)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSQLSelectRandomGameWithStats_DenseGapRejectsMissingDBID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -34,6 +34,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGenerateQueryHash_PreservesPathCase(t *testing.T) {
+	t.Parallel()
+
+	mediaDB := &MediaDB{}
+	upperPrefix, err := mediaDB.generateQueryHash(&database.MediaQuery{PathPrefix: filepath.Join("roms", "SNES")})
+	require.NoError(t, err)
+	lowerPrefix, err := mediaDB.generateQueryHash(&database.MediaQuery{PathPrefix: filepath.Join("roms", "snes")})
+	require.NoError(t, err)
+	assert.NotEqual(t, upperPrefix, lowerPrefix)
+}
+
 func TestFetchAndAttachTags_EmptyResults(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()
@@ -758,16 +769,17 @@ func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) 
 		string(filepath.Separator), "media", "fat", "_Arcade", "_Organized", "_Horizontal",
 	)) + "/"
 	mock.ExpectQuery(
-		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), ` +
-			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE Media\.Path LIKE \? ` +
-			`AND Media\.IsMissing = 0`,
-	).WithArgs(pathPrefix + "%").WillReturnRows(
+		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), `+
+			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE Media\.Path >= \? `+
+			`AND Media\.Path < \? AND Media\.IsMissing = 0`,
+	).WithArgs(pathPrefix, stringPrefixUpperBound(pathPrefix)).WillReturnRows(
 		sqlmock.NewRows([]string{"count", "min", "max"}).AddRow(1, 42, 42),
 	)
 	mock.ExpectQuery(
 		`SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* `+
-			`WHERE Media\.Path LIKE \? AND Media\.IsMissing = 0 AND Media\.DBID >= \?`,
-	).WithArgs(pathPrefix+"%", int64(42)).WillReturnRows(
+			`WHERE Media\.Path >= \? AND Media\.Path < \? AND Media\.IsMissing = 0 `+
+			`AND Media\.DBID = \? LIMIT 1`,
+	).WithArgs(pathPrefix, stringPrefixUpperBound(pathPrefix), int64(42)).WillReturnRows(
 		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
 			AddRow("Arcade", pathPrefix+"game.mra", 42),
 	)
@@ -779,6 +791,70 @@ func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, pathPrefix+"game.mra", result.Path)
 	assert.Equal(t, MediaStats{Count: 1, MinDBID: 42, MaxDBID: 42}, stats)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSQLSelectRandomGameWithStats_DenseGapRejectsMissingDBID(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	exactQuery := `SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* ` +
+		`WHERE Media\.IsMissing = 0 AND Media\.DBID = \? LIMIT 1`
+	mock.ExpectQuery(exactQuery).WithArgs(int64(2)).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}),
+	)
+	mock.ExpectQuery(exactQuery).WithArgs(int64(4)).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
+			AddRow("NES", filepath.Join("roms", "nes", "four.nes"), int64(4)),
+	)
+
+	offsets := []int{1, 3}
+	result, err := sqlSelectRandomGameWithStatsUsing(
+		context.Background(), db, &database.MediaQuery{},
+		MediaStats{Count: 3, MinDBID: 1, MaxDBID: 4},
+		func(maxValue int) (int, error) {
+			require.Equal(t, 4, maxValue)
+			offset := offsets[0]
+			offsets = offsets[1:]
+			return offset, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), result.MediaID)
+	assert.Empty(t, offsets)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSQLSelectRandomGameWithStats_SparseUsesUniformOrdinal(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(
+		`SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media .* ` +
+			`WHERE Media\.IsMissing = 0 ORDER BY Media\.DBID ASC LIMIT 1 OFFSET \?`,
+	).WithArgs(1).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
+			AddRow("SNES", filepath.Join("roms", "snes", "hundred.sfc"), int64(100)),
+	)
+
+	result, err := sqlSelectRandomGameWithStatsUsing(
+		context.Background(), db, &database.MediaQuery{},
+		MediaStats{Count: 2, MinDBID: 1, MaxDBID: 100},
+		func(maxValue int) (int, error) {
+			require.Equal(t, 2, maxValue)
+			return 1, nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), result.MediaID)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediadb/sql_systems.go
+++ b/pkg/database/mediadb/sql_systems.go
@@ -24,7 +24,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/rs/zerolog/log"
@@ -223,6 +225,134 @@ func sqlIndexedSystems(ctx context.Context, db *sql.DB) ([]string, error) {
 	return list, err
 }
 
+func buildNegativeOnlySystemMediaCountsQuery(
+	tags []zapscript.TagFilter,
+) (query string, args []any) {
+	forbidden := make([]zapscript.TagFilter, len(tags))
+	for i := range tags {
+		forbidden[i] = tags[i]
+		forbidden[i].Operator = zapscript.TagOperatorOR
+	}
+	forbiddenClauses, args := BuildTagFilterSQL(forbidden)
+
+	query = `
+		WITH TotalCounts AS (
+			SELECT Media.SystemDBID, COUNT(*) AS Count
+			FROM Media INDEXED BY media_system_present_path_idx
+			WHERE Media.IsMissing = 0
+			GROUP BY Media.SystemDBID
+		), ExcludedCounts AS (
+			SELECT Media.SystemDBID, COUNT(*) AS Count
+			FROM Media
+			WHERE Media.IsMissing = 0
+			AND ` + strings.Join(forbiddenClauses, " AND ") + `
+			GROUP BY Media.SystemDBID
+		)
+		SELECT Systems.SystemID, TotalCounts.Count - COALESCE(ExcludedCounts.Count, 0)
+		FROM TotalCounts
+		INNER JOIN Systems ON Systems.DBID = TotalCounts.SystemDBID
+		LEFT JOIN ExcludedCounts ON ExcludedCounts.SystemDBID = TotalCounts.SystemDBID
+		WHERE TotalCounts.Count > COALESCE(ExcludedCounts.Count, 0)
+		ORDER BY Systems.SystemID`
+	return query, args
+}
+
+func querySystemMediaCounts(
+	ctx context.Context,
+	db sqlQueryable,
+	query string,
+	args ...any,
+) ([]database.SystemMediaCount, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query system media counts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make([]database.SystemMediaCount, 0)
+	for rows.Next() {
+		var count database.SystemMediaCount
+		if scanErr := rows.Scan(&count.SystemID, &count.Count); scanErr != nil {
+			return nil, fmt.Errorf("failed to scan system media count: %w", scanErr)
+		}
+		counts = append(counts, count)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("system media count rows: %w", err)
+	}
+	return counts, nil
+}
+
+func sqlSystemMediaCountsFromBrowseCache(
+	ctx context.Context,
+	db sqlQueryable,
+) ([]database.SystemMediaCount, error) {
+	return querySystemMediaCounts(ctx, db, `
+		SELECT Systems.SystemID, SUM(BrowseDirCounts.FileCount)
+		FROM BrowseDirs
+		INNER JOIN BrowseDirCounts ON BrowseDirCounts.ParentDirDBID = BrowseDirs.DBID
+		INNER JOIN Systems ON Systems.DBID = BrowseDirCounts.SystemDBID
+		WHERE BrowseDirs.Path = '/'
+		GROUP BY BrowseDirCounts.SystemDBID, Systems.SystemID
+		ORDER BY Systems.SystemID`)
+}
+
+func sqlSystemMediaCounts(
+	ctx context.Context,
+	db sqlQueryable,
+	tags []zapscript.TagFilter,
+) ([]database.SystemMediaCount, error) {
+	if len(tags) == 0 {
+		if state, err := sqlBrowseCacheStatus(ctx, db); err == nil && sqlBrowseCacheServeable(state) {
+			counts, cacheErr := sqlSystemMediaCountsFromBrowseCache(ctx, db)
+			if cacheErr == nil {
+				return counts, nil
+			}
+			log.Debug().Err(cacheErr).Msg("failed to read system media counts from browse cache")
+		} else if err != nil {
+			log.Debug().Err(err).Msg("failed to check browse cache for system media counts")
+		}
+
+		return querySystemMediaCounts(ctx, db, `
+			SELECT Systems.SystemID, matched.Count
+			FROM (
+				SELECT Media.SystemDBID, COUNT(*) AS Count
+				FROM Media INDEXED BY media_system_present_path_idx
+				WHERE Media.IsMissing = 0
+				GROUP BY Media.SystemDBID
+			) matched
+			INNER JOIN Systems ON Systems.DBID = matched.SystemDBID
+			ORDER BY Systems.SystemID`)
+	}
+
+	andFilters, notFilters, orFilters := database.GroupTagFiltersByOperator(tags)
+	negativeOnly := len(notFilters) > 0 && len(andFilters) == 0 && len(orFilters) == 0
+
+	var query string
+	var args []any
+	if negativeOnly {
+		query, args = buildNegativeOnlySystemMediaCountsQuery(tags)
+	} else {
+		tagClauses, tagArgs := BuildTagFilterSQL(tags)
+		conditions := make([]string, 1, 1+len(tagClauses))
+		conditions[0] = "Media.IsMissing = 0"
+		conditions = append(conditions, tagClauses...)
+		query = `
+			SELECT Systems.SystemID, matched.Count
+			FROM (
+				SELECT Media.SystemDBID, COUNT(*) AS Count
+				FROM Media
+				WHERE ` + strings.Join(conditions, " AND ") + `
+				GROUP BY Media.SystemDBID
+			) matched
+			INNER JOIN Systems ON Systems.DBID = matched.SystemDBID
+			ORDER BY Systems.SystemID`
+		args = tagArgs
+	}
+
+	return querySystemMediaCounts(ctx, db, query, args...)
+}
+
 func sqlIndexedSystemsFromBrowseCache(ctx context.Context, db sqlQueryable) ([]string, error) {
 	rows, err := db.QueryContext(ctx, `
 		SELECT s.SystemID
@@ -252,55 +382,6 @@ func sqlIndexedSystemsFromBrowseCache(ctx context.Context, db sqlQueryable) ([]s
 		return nil, err
 	}
 	return list, nil
-}
-
-// sqlFilterIndexedSystems returns only those systemIDs that exist in the Systems
-// table (i.e., have indexed content). Preserves input order.
-func sqlFilterIndexedSystems(ctx context.Context, db sqlQueryable, systemIDs []string) ([]string, error) {
-	if len(systemIDs) == 0 {
-		return []string{}, nil
-	}
-
-	args := make([]any, len(systemIDs))
-	for i, id := range systemIDs {
-		args[i] = id
-	}
-
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
-	rows, err := db.QueryContext(ctx,
-		"SELECT SystemID FROM Systems WHERE SystemID IN ("+
-			prepareVariadic("?", ",", len(systemIDs))+")",
-		args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to filter indexed systems: %w", err)
-	}
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close rows in sqlFilterIndexedSystems")
-		}
-	}()
-
-	indexed := make(map[string]struct{})
-	for rows.Next() {
-		var id string
-		if scanErr := rows.Scan(&id); scanErr != nil {
-			return nil, fmt.Errorf("failed to scan indexed system: %w", scanErr)
-		}
-		indexed[id] = struct{}{}
-	}
-	if err = rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating indexed systems: %w", err)
-	}
-
-	// Preserve input order, dedup by removing from map after first match
-	result := make([]string, 0, len(indexed))
-	for _, id := range systemIDs {
-		if _, ok := indexed[id]; ok {
-			result = append(result, id)
-			delete(indexed, id)
-		}
-	}
-	return result, nil
 }
 
 func sqlGetAllSystems(ctx context.Context, db *sql.DB) ([]database.System, error) {

--- a/pkg/database/mediadb/sql_systems_test.go
+++ b/pkg/database/mediadb/sql_systems_test.go
@@ -1,0 +1,194 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemMediaCounts_TagScopes(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	nesPath := filepath.Join("roms", "nes", "chrono-trigger.nes")
+	nesSystem := insertSystemWithMedia(t, mediaDB, "NES", "Chrono Trigger", nesPath)
+	nesMedia, err := mediaDB.FindMedia(database.Media{SystemDBID: nesSystem.DBID, Path: nesPath})
+	require.NoError(t, err)
+
+	variantPath := filepath.Join("roms", "nes", "chrono-trigger-rev-a.nes")
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	_, err = mediaDB.InsertMedia(database.Media{
+		SystemDBID:     nesSystem.DBID,
+		MediaTitleDBID: nesMedia.MediaTitleDBID,
+		Path:           variantPath,
+		ParentDir:      filepath.ToSlash(filepath.Dir(variantPath)) + "/",
+		SortName:       "Chrono Trigger",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	snesPath := filepath.Join("roms", "snes", "earthbound.sfc")
+	snesSystem := insertSystemWithMedia(t, mediaDB, "SNES", "EarthBound", snesPath)
+	snesMedia, err := mediaDB.FindMedia(database.Media{SystemDBID: snesSystem.DBID, Path: snesPath})
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, nesMedia.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, snesMedia.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, nesMedia.MediaTitleDBID, []database.TagInfo{{
+		Type: "genre",
+		Tag:  "rpg",
+	}}))
+
+	allCounts, err := mediaDB.SystemMediaCounts(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{
+		{SystemID: "NES", Count: 2},
+		{SystemID: "SNES", Count: 1},
+	}, allCounts)
+
+	favoriteCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{{
+		Type:  "user",
+		Value: "favorite",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{
+		{SystemID: "NES", Count: 1},
+		{SystemID: "SNES", Count: 1},
+	}, favoriteCounts)
+
+	titleCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{{
+		Type:  "genre",
+		Value: "rpg",
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{{SystemID: "NES", Count: 2}}, titleCounts)
+
+	combinedCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{
+		{Type: "genre", Value: "rpg"},
+		{Type: "user", Value: "favorite"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{{SystemID: "NES", Count: 1}}, combinedCounts)
+
+	orCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{
+		{Type: "genre", Value: "rpg", Operator: zapscript.TagOperatorOR},
+		{Type: "user", Value: "favorite", Operator: zapscript.TagOperatorOR},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{
+		{SystemID: "NES", Count: 2},
+		{SystemID: "SNES", Count: 1},
+	}, orCounts)
+
+	notFavoriteCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{{
+		Type: "user", Value: "favorite", Operator: zapscript.TagOperatorNOT,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{{SystemID: "NES", Count: 1}}, notFavoriteCounts)
+
+	notRPGCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{{
+		Type: "genre", Value: "rpg", Operator: zapscript.TagOperatorNOT,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{{SystemID: "SNES", Count: 1}}, notRPGCounts)
+
+	multipleNotCounts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{
+		{Type: "user", Value: "favorite", Operator: zapscript.TagOperatorNOT},
+		{Type: "genre", Value: "rpg", Operator: zapscript.TagOperatorNOT},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, multipleNotCounts)
+}
+
+func TestSystemMediaCounts_UsesBrowseCache(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.Join("roms", "nes", "game.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Game", mediaPath)
+	db := mediaDB.sql.Load()
+
+	_, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO BrowseDirs (Path, Name, IsVirtual) VALUES ('/', '/', 0)`)
+	require.NoError(t, err)
+	var rootDirDBID int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT DBID FROM BrowseDirs WHERE Path = '/'",
+	).Scan(&rootDirDBID))
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO BrowseDirCounts
+			(ParentDirDBID, ChildDirDBID, SystemDBID, FileCount)
+		VALUES (?, ?, ?, ?)`, rootDirDBID, rootDirDBID, system.DBID, 42)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)`,
+		DBConfigBrowseIndexVersion, browseCacheSchemaVersion)
+	require.NoError(t, err)
+
+	counts, err := mediaDB.SystemMediaCounts(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []database.SystemMediaCount{{SystemID: "NES", Count: 42}}, counts)
+}
+
+func TestSystemMediaCounts_ExcludesMissingMedia(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.Join("roms", "nes", "missing.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Missing", mediaPath)
+	media, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: mediaPath})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, media.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+
+	_, err = mediaDB.sql.Load().ExecContext(ctx, "UPDATE Media SET IsMissing = 1 WHERE DBID = ?", media.DBID)
+	require.NoError(t, err)
+
+	counts, err := mediaDB.SystemMediaCounts(ctx, []zapscript.TagFilter{{
+		Type:  "user",
+		Value: "favorite",
+	}})
+	require.NoError(t, err)
+	assert.Empty(t, counts)
+}

--- a/pkg/database/mediadb/tagfilter.go
+++ b/pkg/database/mediadb/tagfilter.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ZaparooProject/go-zapscript"
@@ -72,26 +73,74 @@ func expandCreditFilters(filters []zapscript.TagFilter) []zapscript.TagFilter {
 	return expanded
 }
 
-func candidateTagExistsSQL(condition string) string {
+func candidateTagExistsSQL(condition, mediaRef string) string {
 	return fmt.Sprintf(`(EXISTS (
 		SELECT 1 FROM MediaTags
 		JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-		WHERE MediaTags.MediaDBID = Media.DBID
+		WHERE MediaTags.MediaDBID = %s.DBID
 		AND %s
 	) OR EXISTS (
 		SELECT 1 FROM MediaTitleTags
 		JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
 		JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-		WHERE MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
+		WHERE MediaTitleTags.MediaTitleDBID = %s.MediaTitleDBID
 		AND %s
-	))`, condition, condition)
+	))`, mediaRef, condition, mediaRef, condition)
 }
 
 // buildCandidateTagFilterSQL builds correlated tag filters for a bounded set of
-// title candidates. Probing tag indexes for each candidate avoids materializing
+// media candidates. Probing tag indexes for each candidate avoids materializing
 // every media ID carrying a common tag across the full database.
+func isRequiredFavoriteFilter(filter zapscript.TagFilter) bool {
+	if filter.Operator == zapscript.TagOperatorNOT || filter.Operator == zapscript.TagOperatorOR {
+		return false
+	}
+	tagType, tagValue := resolveFilter(filter.Type, filter.Value)
+	return tagType == string(tags.TagTypeUser) && tagValue == string(tags.TagUserFavorite)
+}
+
+func hasRequiredFavoriteFilter(filters []zapscript.TagFilter) bool {
+	return slices.ContainsFunc(filters, isRequiredFavoriteFilter)
+}
+
+func buildBrowseTagFilterSQL(
+	filters []zapscript.TagFilter,
+	mediaRef string,
+) (clauses []string, args []any) {
+	if !hasRequiredFavoriteFilter(filters) {
+		return buildCandidateTagFilterSQLForRef(filters, mediaRef)
+	}
+
+	var favoriteFilter zapscript.TagFilter
+	remaining := make([]zapscript.TagFilter, 0, len(filters)-1)
+	for _, filter := range filters {
+		if favoriteFilter.Type == "" && isRequiredFavoriteFilter(filter) {
+			favoriteFilter = filter
+			continue
+		}
+		remaining = append(remaining, filter)
+	}
+
+	favoriteClauses, favoriteArgs := buildTagFilterSQLForRef([]zapscript.TagFilter{favoriteFilter}, mediaRef)
+	remainingClauses, remainingArgs := buildCandidateTagFilterSQLForRef(remaining, mediaRef)
+	clauses = make([]string, 0, len(favoriteClauses)+len(remainingClauses))
+	clauses = append(clauses, favoriteClauses...)
+	clauses = append(clauses, remainingClauses...)
+	args = make([]any, 0, len(favoriteArgs)+len(remainingArgs))
+	args = append(args, favoriteArgs...)
+	args = append(args, remainingArgs...)
+	return clauses, args
+}
+
 func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []any) {
+	return buildCandidateTagFilterSQLForRef(filters, "Media")
+}
+
+func buildCandidateTagFilterSQLForRef(
+	filters []zapscript.TagFilter,
+	mediaRef string,
+) (clauses []string, args []any) {
 	if len(filters) == 0 {
 		return nil, nil
 	}
@@ -105,7 +154,7 @@ func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string
 		if f.Type == string(tags.TagTypeCredit) {
 			_, val := resolveFilter(f.Type, f.Value)
 			condition := "Tags.Tag = ? AND TagTypes.Type IN (?, ?, ?)"
-			clauses = append(clauses, candidateTagExistsSQL(condition))
+			clauses = append(clauses, candidateTagExistsSQL(condition, mediaRef))
 			devType := string(tags.TagTypeDeveloper)
 			pubType := string(tags.TagTypePublisher)
 			credType := string(tags.TagTypeCredit)
@@ -114,13 +163,13 @@ func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string
 		}
 
 		typ, val := resolveFilter(f.Type, f.Value)
-		clauses = append(clauses, candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?"))
+		clauses = append(clauses, candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?", mediaRef))
 		args = append(args, typ, val, typ, val)
 	}
 
 	for _, f := range notFilters {
 		typ, val := resolveFilter(f.Type, f.Value)
-		clauses = append(clauses, "NOT "+candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?"))
+		clauses = append(clauses, "NOT "+candidateTagExistsSQL("TagTypes.Type = ? AND Tags.Tag = ?", mediaRef))
 		args = append(args, typ, val, typ, val)
 	}
 
@@ -138,7 +187,7 @@ func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string
 		for i := range orTypes {
 			args = append(args, orTypes[i], orValues[i])
 		}
-		clauses = append(clauses, candidateTagExistsSQL("("+strings.Join(orConditions, " OR ")+")"))
+		clauses = append(clauses, candidateTagExistsSQL("("+strings.Join(orConditions, " OR ")+")", mediaRef))
 	}
 
 	return clauses, args
@@ -153,6 +202,10 @@ func buildCandidateTagFilterSQL(filters []zapscript.TagFilter) (clauses []string
 // Returns a slice of WHERE clause strings and corresponding arguments.
 // Clauses should be joined with " AND " and appended to the main query's WHERE conditions.
 func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []any) {
+	return buildTagFilterSQLForRef(filters, "Media")
+}
+
+func buildTagFilterSQLForRef(filters []zapscript.TagFilter, mediaRef string) (clauses []string, args []any) {
 	if len(filters) == 0 {
 		return nil, nil
 	}
@@ -203,7 +256,7 @@ func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []
 			args = append(args, typ, val, typ, val)
 		}
 
-		intersectClause := fmt.Sprintf("Media.DBID IN (%s)", strings.Join(intersectSelects, " INTERSECT "))
+		intersectClause := fmt.Sprintf("%s.DBID IN (%s)", mediaRef, strings.Join(intersectSelects, " INTERSECT "))
 		clauses = append(clauses, intersectClause)
 	}
 
@@ -226,7 +279,7 @@ func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []
 	)`
 	for _, f := range andCreditFilters {
 		_, val := resolveFilter(f.Type, f.Value)
-		clauses = append(clauses, fmt.Sprintf("Media.DBID IN (%s)", andCreditSelect))
+		clauses = append(clauses, fmt.Sprintf("%s.DBID IN (%s)", mediaRef, andCreditSelect))
 		devType := string(tags.TagTypeDeveloper)
 		pubType := string(tags.TagTypePublisher)
 		credType := string(tags.TagTypeCredit)
@@ -238,7 +291,7 @@ func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []
 	// tag joins for every candidate media row.
 	for _, f := range notFilters {
 		typ, val := resolveFilter(f.Type, f.Value)
-		clause := `Media.DBID NOT IN (
+		clause := mediaRef + `.DBID NOT IN (
 			SELECT MediaDBID FROM MediaTags
 			JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
@@ -254,38 +307,37 @@ func BuildTagFilterSQL(filters []zapscript.TagFilter) (clauses []string, args []
 		args = append(args, typ, val, typ, val)
 	}
 
-	// Build a single EXISTS clause with OR for all OR filters
-	// Media must have at least ONE of the OR tags from either level
+	// Resolve all OR matches through reverse tag indexes once. Correlating OR
+	// probes against the outer Media scan makes even sparse unions O(all media)
+	// on MiSTer and can exceed the API timeout.
 	if len(orFilters) > 0 {
-		var orConditions []string
-		var orTyps, orVals []string
+		orConditions := make([]string, 0, len(orFilters))
+		orTypes := make([]string, 0, len(orFilters))
+		orValues := make([]string, 0, len(orFilters))
 		for _, f := range orFilters {
 			typ, val := resolveFilter(f.Type, f.Value)
-			orTyps = append(orTyps, typ)
-			orVals = append(orVals, val)
+			orTypes = append(orTypes, typ)
+			orValues = append(orValues, val)
 			orConditions = append(orConditions, "(TagTypes.Type = ? AND Tags.Tag = ?)")
 			args = append(args, typ, val)
 		}
 		orJoined := strings.Join(orConditions, " OR ")
-
-		// Duplicate args for the second EXISTS (MediaTitleTags)
-		for i := range orTyps {
-			args = append(args, orTyps[i], orVals[i])
+		for i := range orTypes {
+			args = append(args, orTypes[i], orValues[i])
 		}
 
-		orClause := fmt.Sprintf(`(EXISTS (
-			SELECT 1 FROM MediaTags
+		orClause := fmt.Sprintf(`%s.DBID IN (
+			SELECT MediaDBID FROM MediaTags
 			JOIN Tags ON MediaTags.TagDBID = Tags.DBID
 			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-			WHERE MediaTags.MediaDBID = Media.DBID
-			AND (%s)
-		) OR EXISTS (
-			SELECT 1 FROM MediaTitleTags
-			JOIN Tags ON MediaTitleTags.TagDBID = Tags.DBID
+			WHERE %s
+			UNION
+			SELECT m.DBID AS MediaDBID FROM Media m
+			JOIN MediaTitleTags mtt ON m.MediaTitleDBID = mtt.MediaTitleDBID
+			JOIN Tags ON mtt.TagDBID = Tags.DBID
 			JOIN TagTypes ON Tags.TypeDBID = TagTypes.DBID
-			WHERE MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID
-			AND (%s)
-		))`, orJoined, orJoined)
+			WHERE %s
+		)`, mediaRef, orJoined, orJoined)
 		clauses = append(clauses, orClause)
 	}
 

--- a/pkg/database/mediadb/tagfilter_test.go
+++ b/pkg/database/mediadb/tagfilter_test.go
@@ -142,10 +142,12 @@ func TestBuildTagFilterSQL_OROnly(t *testing.T) {
 		require.Len(t, clauses, 1)
 		require.Len(t, args, 4) // 1 filter * 4 args (MediaTags + MediaTitleTags)
 
-		// Should use EXISTS with single condition for both tag sources
-		assert.Contains(t, clauses[0], "EXISTS (")
-		assert.Contains(t, clauses[0], "MediaTags.MediaDBID = Media.DBID")
-		assert.Contains(t, clauses[0], "MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID")
+		// Should resolve one reverse-index union across both tag sources.
+		assert.Contains(t, clauses[0], "Media.DBID IN (")
+		assert.Contains(t, clauses[0], "SELECT MediaDBID FROM MediaTags")
+		assert.Contains(t, clauses[0], "JOIN MediaTitleTags")
+		assert.Contains(t, clauses[0], "UNION")
+		assert.NotContains(t, clauses[0], "EXISTS (")
 	})
 
 	t.Run("Multiple OR filters", func(t *testing.T) {
@@ -159,8 +161,10 @@ func TestBuildTagFilterSQL_OROnly(t *testing.T) {
 		require.Len(t, clauses, 1) // All OR filters grouped into one clause
 		require.Len(t, args, 12)   // 3 filters * 2 args * 2 sources
 
-		// Should use EXISTS with OR conditions for both tag sources
-		assert.Contains(t, clauses[0], "EXISTS (")
+		// Should use one reverse-index union with OR conditions for both sources.
+		assert.Contains(t, clauses[0], "Media.DBID IN (")
+		assert.Contains(t, clauses[0], "UNION")
+		assert.NotContains(t, clauses[0], "EXISTS (")
 		assert.Equal(t, 6, strings.Count(clauses[0], "TagTypes.Type = ?")) // 3 per source
 	})
 }
@@ -194,11 +198,9 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		require.Len(t, clauses, 2) // One for AND, one for OR group
 		require.Len(t, args, 12)   // 1 AND*4 + 2 OR*4
 
-		// First clause should be INTERSECT
 		assert.Contains(t, clauses[0], "Media.DBID IN (")
-
-		// Second clause should be EXISTS with OR
-		assert.Contains(t, clauses[1], "EXISTS (")
+		assert.Contains(t, clauses[1], "Media.DBID IN (")
+		assert.Contains(t, clauses[1], "UNION")
 	})
 
 	t.Run("NOT + OR", func(t *testing.T) {
@@ -212,11 +214,9 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		require.Len(t, clauses, 2) // One for NOT, one for OR group
 		require.Len(t, args, 12)   // 1 NOT*4 + 2 OR*4
 
-		// First clause should be a forward anti-set.
 		assert.Contains(t, clauses[0], "Media.DBID NOT IN (")
-
-		// Second clause should be EXISTS with OR
-		assert.Contains(t, clauses[1], "EXISTS (")
+		assert.Contains(t, clauses[1], "Media.DBID IN (")
+		assert.Contains(t, clauses[1], "UNION")
 	})
 
 	t.Run("AND + NOT + OR", func(t *testing.T) {
@@ -241,8 +241,9 @@ func TestBuildTagFilterSQL_MixedOperators(t *testing.T) {
 		assert.Contains(t, clauses[1], "Media.DBID NOT IN (")
 		assert.Contains(t, clauses[2], "Media.DBID NOT IN (")
 
-		// Last clause: EXISTS with OR
-		assert.Contains(t, clauses[3], "EXISTS (")
+		// Last clause: reverse-index OR union.
+		assert.Contains(t, clauses[3], "Media.DBID IN (")
+		assert.Contains(t, clauses[3], "UNION")
 	})
 }
 
@@ -554,7 +555,7 @@ func TestBuildTagFilterSQL_SQLStructure(t *testing.T) {
 		assert.NotContains(t, clauses[0], "NOT EXISTS")
 	})
 
-	t.Run("OR filters use EXISTS with OR pattern for both tag sources", func(t *testing.T) {
+	t.Run("OR filters use reverse-index union for both tag sources", func(t *testing.T) {
 		filters := []zapscript.TagFilter{
 			{Type: "lang", Value: "en", Operator: zapscript.TagOperatorOR},
 			{Type: "lang", Value: "es", Operator: zapscript.TagOperatorOR},
@@ -563,11 +564,12 @@ func TestBuildTagFilterSQL_SQLStructure(t *testing.T) {
 		clauses, _ := BuildTagFilterSQL(filters)
 		require.Len(t, clauses, 1)
 
-		// Should contain EXISTS with OR for both MediaTags and MediaTitleTags
-		assert.Contains(t, clauses[0], "EXISTS (")
+		assert.Contains(t, clauses[0], "Media.DBID IN (")
 		assert.Contains(t, clauses[0], " OR ")
-		assert.Contains(t, clauses[0], "MediaTags.MediaDBID = Media.DBID")
-		assert.Contains(t, clauses[0], "MediaTitleTags.MediaTitleDBID = Media.MediaTitleDBID")
+		assert.Contains(t, clauses[0], "SELECT MediaDBID FROM MediaTags")
+		assert.Contains(t, clauses[0], "JOIN MediaTitleTags")
+		assert.Contains(t, clauses[0], "UNION")
+		assert.NotContains(t, clauses[0], "EXISTS (")
 	})
 }
 
@@ -592,17 +594,18 @@ func TestBuildTagFilterSQL_Regression(t *testing.T) {
 			},
 		},
 		{
-			name: "Single OR filter uses EXISTS for both tag sources",
+			name: "Single OR filter uses reverse indexes for both tag sources",
 			filters: []zapscript.TagFilter{
 				{Type: "lang", Value: "en", Operator: zapscript.TagOperatorOR},
 			},
-			description: "Single OR filter uses EXISTS with both MediaTags and MediaTitleTags",
+			description: "Single OR filter unions MediaTags and MediaTitleTags matches",
 			validate: func(t *testing.T, clauses []string, _ []any) {
 				assert.Len(t, clauses, 1)
-				assert.Contains(t, clauses[0], "EXISTS (")
+				assert.Contains(t, clauses[0], "Media.DBID IN (")
 				assert.Contains(t, clauses[0], "MediaTags")
 				assert.Contains(t, clauses[0], "MediaTitleTags")
-				// Single OR condition appears in both EXISTS clauses (one per tag source)
+				assert.Contains(t, clauses[0], "UNION")
+				assert.NotContains(t, clauses[0], "EXISTS (")
 				assert.Equal(t, 2, strings.Count(clauses[0], "TagTypes.Type = ?"))
 			},
 		},

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1446,6 +1446,23 @@ func (m *MockMediaDBI) IndexedSystems() ([]string, error) {
 	return nil, nil
 }
 
+func (m *MockMediaDBI) SystemMediaCounts(
+	ctx context.Context,
+	tags []zapscript.TagFilter,
+) ([]database.SystemMediaCount, error) {
+	args := m.Called(ctx, tags)
+	if counts, ok := args.Get(0).([]database.SystemMediaCount); ok {
+		if err := args.Error(1); err != nil {
+			return counts, fmt.Errorf("mock operation failed: %w", err)
+		}
+		return counts, nil
+	}
+	if err := args.Error(1); err != nil {
+		return nil, fmt.Errorf("mock operation failed: %w", err)
+	}
+	return nil, nil
+}
+
 func (m *MockMediaDBI) SystemIndexed(system *systemdefs.System) bool {
 	args := m.Called(system)
 	return args.Bool(0)
@@ -2682,6 +2699,7 @@ func (m *MockMediaDBI) BrowseFileCount(
 	return 0, nil
 }
 
+//nolint:gocritic // Value options preserve the established MediaDBI method contract.
 func (m *MockMediaDBI) BrowseIndex(
 	ctx context.Context, opts database.BrowseIndexOptions,
 ) (database.BrowseIndexResult, error) {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -421,16 +421,21 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 		}, nil
 	}
 
-	// absolute path, use database query to find random media with this path prefix
-	// this includes virtual paths and zips as options
-	if filepath.IsAbs(query) {
-		cleanedPath := filepath.Clean(query)
+	isFilesystemPath := filepath.IsAbs(query)
+	isVirtualPath := strings.Contains(query, "://")
+
+	// Path queries use the media database so virtual entries and tags compose.
+	if isFilesystemPath || isVirtualPath {
+		cleanedPath := query
+		if isFilesystemPath {
+			cleanedPath = filepath.ToSlash(filepath.Clean(query))
+		}
 		mediaQuery := database.MediaQuery{
-			PathPrefix: filepath.ToSlash(cleanedPath),
+			PathPrefix: cleanedPath,
 			Tags:       tagFilters,
 		}
 		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
-		fallbackToFilesystem := len(tagFilters) == 0 &&
+		fallbackToFilesystem := isFilesystemPath && len(tagFilters) == 0 &&
 			(errors.Is(searchErr, sql.ErrNoRows) || errors.Is(searchErr, context.DeadlineExceeded))
 		if fallbackToFilesystem {
 			// Slow indexed lookups should not block direct directory launches.

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -422,7 +422,10 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 	}
 
 	isFilesystemPath := filepath.IsAbs(query)
-	isVirtualPath := strings.Contains(query, "://")
+	virtualMarker := strings.Index(query, "://")
+	firstPathSeparator := strings.IndexAny(query, `/\`)
+	isVirtualPath := virtualMarker >= 0 &&
+		(firstPathSeparator < 0 || virtualMarker < firstPathSeparator)
 
 	// Path queries use the media database so virtual entries and tags compose.
 	if isFilesystemPath || isVirtualPath {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1940,6 +1940,42 @@ launcher = "RA"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdRandom_QueryContainingVirtualMarkerUsesLegacySystemSearch(t *testing.T) {
+	t.Parallel()
+
+	const query = "NES/title://cutscene"
+	mediaPath := filepath.Join(launchTestAbsPath("games"), "NES", "Title Cutscene.nes")
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.MatchedBy(func(mediaQuery *database.MediaQuery) bool {
+		return mediaQuery.PathPrefix == "" &&
+			mediaQuery.PathGlob == "title://cutscene" &&
+			len(mediaQuery.Systems) == 1 &&
+			mediaQuery.Systems[0] == systemdefs.SystemNES
+	})).Return(database.SearchResult{
+		Path:     mediaPath,
+		SystemID: systemdefs.SystemNES,
+	}, nil)
+	mockPlatform.On(
+		"LaunchMedia", cfg, mediaPath, (*platforms.Launcher)(nil),
+		mock.Anything, (*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	result, err := cmdRandom(mockPlatform, platforms.CmdEnv{
+		Cmd:      zapscript.Command{Name: "launch.random", Args: []string{query}},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestCmdRandom_VirtualPathUsesRecursivePrefixWithTags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1940,6 +1940,47 @@ launcher = "RA"
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCmdRandom_VirtualPathUsesRecursivePrefixWithTags(t *testing.T) {
+	t.Parallel()
+
+	const virtualRoot = "steam://"
+	const mediaPath = "steam://123/favorite"
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.MatchedBy(func(query *database.MediaQuery) bool {
+		return query.PathPrefix == virtualRoot &&
+			len(query.Tags) == 1 &&
+			query.Tags[0].Type == "user" &&
+			query.Tags[0].Value == "favorite"
+	})).Return(database.SearchResult{Path: mediaPath, SystemID: "Steam"}, nil)
+	mockPlatform.On(
+		"LaunchMedia", cfg, mediaPath, (*platforms.Launcher)(nil),
+		mock.Anything, (*platforms.LaunchOptions)(nil),
+	).Return(nil)
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{virtualRoot},
+			AdvArgs: zapscript.NewAdvArgs(map[string]string{
+				string(zapscript.KeyTags): "user:favorite",
+			}),
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	}
+
+	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
 // TestCmdRandom_DoubleSlashPathCleaned verifies that a double-slash prefix
 // (e.g. from **launch.random://path) is normalized before querying the DB.
 // On Windows, //media/fat is a UNC path and filepath.Clean preserves the double


### PR DESCRIPTION
## Summary

- Add exact non-missing `mediaCount` values to ordinary `systems` responses, including zero for supported empty systems, and add exact tagged system facets.
- Add recursive boundary-safe `media.search.pathPrefix`, shared tag filtering for `media.browse` and `media.browse.index`, and explicit stable search sorting with sort-aware cursors.
- Make `launch.random` uniform per matching media row across systems, tags, recursive filesystem paths, and virtual paths.
- Preserve legacy behavior when new parameters are omitted; no schema, index, or dependency changes.

This supersedes the dedicated `systems.favorites` approach in #1178. Peter Brittain (@KindarConrath), who authored that initial work, is credited as a co-author on the commit.

Live MiSTer validation used 244,623 indexed media rows. Sparse OR system facets improved from a 30-second timeout to 0.11 seconds, broad OR to 0.35 seconds, and negative-only counts from 17.1 seconds to about 4.2 seconds. Recursive path search completed tagged/letter/sorted scopes in 0.17 seconds and a 100-row broad Arcade page in 0.64 seconds.

Closes #1224

Closes #1225

Supersedes #1178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tag filtering to media search, browsing, browse indexes, and system listings, including AND/OR/NOT combinations.
  - Added name and filename sorting with reliable, scope-aware cursor pagination.
  - System responses now include matching media counts.
  - Random media selection supports tagged and virtual-path searches more consistently.
  - Improved path-prefix filtering to avoid sibling-path matches.

- **Bug Fixes**
  - Corrected filtered totals and system matching across combined filters.
  - Improved handling of unknown systems and sparse media collections.

- **Documentation**
  - Updated API documentation and examples for filtering, sorting, pagination, and media counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->