### PR TITLE
fix(mister): include shared profile data in backups

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -204,12 +204,22 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libasound2-dev \
+            libnfc-dev \
+            libpcsclite-dev
 
       - name: Verify runner prerequisites
         run: |

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -196,6 +196,29 @@ jobs:
           path: D:\go-mod-cache
           key: ${{ runner.os }}-gomod-${{ hashFiles('go.mod', 'go.sum') }}
 
+  mister-backup-mount-smoke:
+    name: MiSTer Backup Mount Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify runner prerequisites
+        run: |
+          command -v unshare
+          sudo -n true
+
+      - name: Run MiSTer backup mount smoke test
+        run: scripts/test-mister-backup-mounts.sh
+
   cross-lint:
     name: Cross Lint
     if: github.event_name == 'pull_request'

--- a/pkg/platforms/mister/backup_test.go
+++ b/pkg/platforms/mister/backup_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,6 +26,10 @@ func TestBackupDefinitions(t *testing.T) {
 	assert.Equal(t, "settings", definitions[0].Category)
 	assert.True(t, definitions[0].NonRecursive)
 	assert.Contains(t, definitions[0].Include, platforms.BackupPattern{Glob: "MiSTer.ini"})
+	assert.Contains(t, definitions[0].Include, platforms.BackupPattern{
+		Glob: filepath.Base(misterconfig.LegacyMappingsPath),
+	})
+	assert.Contains(t, definitions[0].Include, platforms.BackupPattern{Glob: misterNamesFile})
 	assert.NotContains(t, definitions[0].Include, platforms.BackupPattern{Glob: retroAchievementsConfigFile})
 	assert.Contains(t, definitions[0].Exclude, platforms.BackupPattern{Glob: "MiSTer_example.ini"})
 
@@ -46,6 +51,7 @@ func TestBackupDefinitions(t *testing.T) {
 	assert.Equal(t, profileRoot, definitions[5].SourceRoot)
 	assert.Equal(t, "saves", definitions[5].Category)
 	assert.Contains(t, definitions[5].Include, platforms.BackupPattern{Contains: "/saves/"})
+	assert.Contains(t, definitions[5].Include, platforms.BackupPattern{Glob: profileNameFile})
 	assert.NotContains(t, definitions[5].Include, platforms.BackupPattern{Glob: retroAchievementsConfigFile})
 	assert.Equal(t, profileRoot, definitions[6].SourceRoot)
 	assert.Equal(t, "savestates", definitions[6].Category)

--- a/pkg/platforms/mister/backup_test.go
+++ b/pkg/platforms/mister/backup_test.go
@@ -16,6 +16,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPlatformPrepareBackupWithoutProfileManager(t *testing.T) {
+	t.Parallel()
+	platform := &Platform{}
+
+	plan, cleanup, err := platform.PrepareBackup()
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	assert.Equal(t, BackupDefinitions(platform.Settings()), plan.Definitions)
+	assert.Empty(t, plan.Warnings)
+	require.NoError(t, cleanup())
+}
+
 func TestBackupDefinitions(t *testing.T) {
 	t.Parallel()
 	rootDir := t.TempDir()

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -54,6 +54,7 @@ import (
 )
 
 const (
+	misterNamesFile           = "names.txt"
 	amigaVisionGamesListing   = "listings/games.txt"
 	amigaVisionDemosListing   = "listings/demos.txt"
 	amigaVisionGamesBrowseDir = "Games"
@@ -607,12 +608,12 @@ func (p *Platform) BackupDefinitions() []platforms.BackupDefinition {
 	return BackupDefinitions(p.Settings())
 }
 
-func (p *Platform) BackupPlan() platforms.BackupPlan {
+func (p *Platform) PrepareBackup() (platforms.BackupPlan, func() error, error) {
 	definitions := BackupDefinitions(p.Settings())
 	if p.profileData == nil {
-		return platforms.BackupPlan{Definitions: definitions}
+		return platforms.BackupPlan{Definitions: definitions}, func() error { return nil }, nil
 	}
-	return p.profileData.backupPlan(p.Settings(), definitions)
+	return p.profileData.prepareBackup(p.Settings(), definitions)
 }
 
 func (p *Platform) PrepareBackupRestore() (func(bool) error, error) {
@@ -644,6 +645,8 @@ func BackupDefinitions(settings platforms.Settings) []platforms.BackupDefinition
 				{Glob: "MiSTer_*.ini"},
 				{Glob: "MiSTer.ini.*"},
 				{Glob: "downloader.ini"},
+				{Glob: filepath.Base(misterconfig.LegacyMappingsPath)},
+				{Glob: misterNamesFile},
 			},
 			Exclude: []platforms.BackupPattern{{Glob: "MiSTer_example.ini"}},
 		},
@@ -690,7 +693,10 @@ func BackupDefinitions(settings platforms.Settings) []platforms.BackupDefinition
 			Category:    "saves",
 			SourceRoot:  filepath.Join(root, "zaparoo", "profiles"),
 			RestoreRoot: filepath.Join("zaparoo", "profiles"),
-			Include:     []platforms.BackupPattern{{Contains: "/saves/"}},
+			Include: []platforms.BackupPattern{
+				{Contains: "/saves/"},
+				{Glob: profileNameFile},
+			},
 		},
 		{
 			Category:    "savestates",

--- a/pkg/platforms/mister/profiledata.go
+++ b/pkg/platforms/mister/profiledata.go
@@ -64,6 +64,7 @@ const (
 	profileDataItemSavestates        = "savestates"
 	profileDataItemRetroAchievements = "retroachievements"
 	retroAchievementsConfigFile      = "retroachievements.cfg"
+	profileNameFile                  = "name.txt"
 
 	// nasPoolDirName is the pool directory created inside a foreign mount
 	// (e.g. a NAS share bind-mounted over saves/ by cifs_mount.sh). The
@@ -453,7 +454,7 @@ func (d *profileDataManager) writeNameFile(profileDir string, ref platforms.Prof
 	if ref.Name == "" {
 		return
 	}
-	path := filepath.Join(profileDir, "name.txt")
+	path := filepath.Join(profileDir, profileNameFile)
 	if err := afero.WriteFile(d.fs, path, []byte(ref.Name+"\n"), 0o644); err != nil {
 		log.Warn().Err(err).Str("path", path).
 			Msg("profiles: failed to write profile name file")

--- a/pkg/platforms/mister/profiledata_backup.go
+++ b/pkg/platforms/mister/profiledata_backup.go
@@ -188,9 +188,10 @@ func (d *profileDataManager) prepareBackup(
 		}
 
 		alias := filepath.Join(aliasRoot, item)
-		if err = d.fs.MkdirAll(alias, 0o750); err == nil {
-			_, err = d.m.BindMount(target, alias)
-			if err == nil {
+		aliasErr := d.fs.MkdirAll(alias, 0o750)
+		if aliasErr == nil {
+			_, aliasErr = d.m.BindMount(target, alias)
+			if aliasErr == nil {
 				aliases = append(aliases, alias)
 			}
 		}
@@ -211,7 +212,7 @@ func (d *profileDataManager) prepareBackup(
 				cleanupAliases(),
 			)
 		}
-		if err != nil {
+		if aliasErr != nil {
 			plan.Definitions = append(plan.Definitions, originalDefinition)
 			plan.Warnings = append(plan.Warnings, platforms.BackupWarning{
 				Category: item, Path: item, Reason: "shared profile data unavailable during backup",

--- a/pkg/platforms/mister/profiledata_backup.go
+++ b/pkg/platforms/mister/profiledata_backup.go
@@ -22,18 +22,17 @@
 package mister
 
 // Backup-facing adaptation of profile data mounts. Active profile binds
-// hide the shared saves/savestates underneath them, so the backup plan
-// must describe what is actually visible (and warn about what is not),
-// and restore must temporarily remove Zaparoo's own binds so writes reach
-// real storage instead of a profile pool.
+// hide shared saves and savestates. Backup preparation creates private bind
+// aliases to that underlying data, then immediately restores active profile
+// mounts. Restore temporarily removes Zaparoo's binds so writes reach storage.
 
 import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/spf13/afero"
 )
 
 type profileRestoreMount struct {
@@ -57,16 +56,45 @@ func removeBackupDefinition(
 	return filtered
 }
 
-func profileBindUsesNAS(entry *mountLedgerEntry) bool {
-	root := filepath.ToSlash(entry.Root)
-	return strings.Contains(root, "/"+nasPoolDirName+"/")
+func profileBackupDefinitionsForRoot(
+	settings platforms.Settings, definitions []platforms.BackupDefinition, root string,
+) []platforms.BackupDefinition {
+	baseRoot := BackupRestoreRoot(settings)
+	if filepath.Clean(root) == filepath.Clean(baseRoot) {
+		return definitions
+	}
+	for _, item := range []string{profileDataItemSaves, profileDataItemSavestates} {
+		definitions = removeBackupDefinition(
+			definitions, filepath.Join(baseRoot, item), item, item,
+		)
+		definitions = removeBackupDefinition(
+			definitions, filepath.Join(baseRoot, "zaparoo", "profiles"),
+			filepath.Join("zaparoo", "profiles"), item,
+		)
+		profilePatterns := []platforms.BackupPattern{{Contains: "/" + item + "/"}}
+		if item == profileDataItemSaves {
+			profilePatterns = append(profilePatterns, platforms.BackupPattern{Glob: profileNameFile})
+		}
+		definitions = append(definitions,
+			platforms.BackupDefinition{
+				Category: item, SourceRoot: filepath.Join(root, item), RestoreRoot: item,
+				Include: []platforms.BackupPattern{{All: true}},
+			},
+			platforms.BackupDefinition{
+				Category: item, SourceRoot: filepath.Join(root, "zaparoo", "profiles"),
+				RestoreRoot: filepath.Join("zaparoo", "profiles"), Include: profilePatterns,
+			},
+		)
+	}
+	return definitions
 }
 
-func (d *profileDataManager) backupPlan(
+func (d *profileDataManager) prepareBackup(
 	settings platforms.Settings, definitions []platforms.BackupDefinition,
-) platforms.BackupPlan {
+) (platforms.BackupPlan, func() error, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
 	plan := platforms.BackupPlan{Definitions: definitions}
 	mounts, err := d.m.Mounts()
 	if err != nil {
@@ -78,7 +106,7 @@ func (d *profileDataManager) backupPlan(
 				Category: item, Path: item, Reason: "profile mount state unavailable",
 			})
 		}
-		return plan
+		return plan, func() error { return nil }, nil
 	}
 	d.ledger.prune(mounts)
 	root, err := d.resolveStorageRoot(mounts)
@@ -91,31 +119,43 @@ func (d *profileDataManager) backupPlan(
 				Category: item, Path: item, Reason: "profile storage root unavailable",
 			})
 		}
-		return plan
+		return plan, func() error { return nil }, nil
 	}
-	baseRoot := BackupRestoreRoot(settings)
-	if filepath.Clean(root) != filepath.Clean(baseRoot) {
-		for _, item := range []string{profileDataItemSaves, profileDataItemSavestates} {
-			plan.Definitions = removeBackupDefinition(
-				plan.Definitions, filepath.Join(baseRoot, item), item, item,
-			)
-			plan.Definitions = removeBackupDefinition(
-				plan.Definitions, filepath.Join(baseRoot, "zaparoo", "profiles"),
-				filepath.Join("zaparoo", "profiles"), item,
-			)
-			plan.Definitions = append(plan.Definitions,
-				platforms.BackupDefinition{
-					Category: item, SourceRoot: filepath.Join(root, item), RestoreRoot: item,
-					Include: []platforms.BackupPattern{{All: true}},
-				},
-				platforms.BackupDefinition{
-					Category: item, SourceRoot: filepath.Join(root, "zaparoo", "profiles"),
-					RestoreRoot: filepath.Join("zaparoo", "profiles"),
-					Include:     []platforms.BackupPattern{{Contains: "/" + item + "/"}},
-				},
-			)
+	plan.Definitions = profileBackupDefinitionsForRoot(settings, plan.Definitions, root)
+
+	hasActiveBind := false
+	for _, item := range []string{profileDataItemSaves, profileDataItemSavestates} {
+		stack := mountsAt(mounts, filepath.Join(root, item))
+		if len(stack) > 0 && d.ledger.find(&stack[len(stack)-1]) != nil {
+			hasActiveBind = true
+			break
 		}
 	}
+	if !hasActiveBind {
+		return plan, func() error { return nil }, nil
+	}
+
+	if err = d.fs.MkdirAll(settings.TempDir, 0o750); err != nil {
+		return platforms.BackupPlan{}, nil, fmt.Errorf("creating profile backup temp root: %w", err)
+	}
+	aliasRoot, err := afero.TempDir(d.fs, settings.TempDir, "profile-backup-")
+	if err != nil {
+		return platforms.BackupPlan{}, nil, fmt.Errorf("creating profile backup alias root: %w", err)
+	}
+	aliases := make([]string, 0, 2)
+	cleanupAliases := func() error {
+		var errs []error
+		for i := len(aliases) - 1; i >= 0; i-- {
+			if unmountErr := d.m.Unmount(aliases[i]); unmountErr != nil {
+				errs = append(errs, fmt.Errorf("unmounting profile backup alias %s: %w", aliases[i], unmountErr))
+			}
+		}
+		if removeErr := d.fs.RemoveAll(aliasRoot); removeErr != nil {
+			errs = append(errs, fmt.Errorf("removing profile backup alias root: %w", removeErr))
+		}
+		return errors.Join(errs...)
+	}
+
 	for _, item := range []string{profileDataItemSaves, profileDataItemSavestates} {
 		target := filepath.Join(root, item)
 		stack := mountsAt(mounts, target)
@@ -126,24 +166,74 @@ func (d *profileDataManager) backupPlan(
 		if entry == nil {
 			continue
 		}
+
+		originalDefinition := platforms.BackupDefinition{
+			Category: item, SourceRoot: target, RestoreRoot: item,
+			Include: []platforms.BackupPattern{{All: true}},
+		}
 		plan.Definitions = removeBackupDefinition(plan.Definitions, target, item, item)
-		if profileBindUsesNAS(entry) {
-			plan.Definitions = append(plan.Definitions, platforms.BackupDefinition{
-				Category: item, SourceRoot: target,
-				RestoreRoot:        filepath.Join(item, nasPoolDirName, entry.ProfileID, item),
-				SourceTrustedRoots: []string{target}, Include: []platforms.BackupPattern{{All: true}},
-			})
+		itemSpec, ok := findProfileDataItem(item)
+		if !ok {
+			return platforms.BackupPlan{}, nil, errors.Join(
+				fmt.Errorf("unknown backup profile data item %q", item), cleanupAliases(),
+			)
+		}
+		previous := platforms.ProfileRef{ID: entry.ProfileID}
+		if err = d.applyItem(&profileItemPlan{item: itemSpec, target: target}); err != nil {
+			plan.Definitions = append(plan.Definitions, originalDefinition)
 			plan.Warnings = append(plan.Warnings, platforms.BackupWarning{
-				Category: item, Path: filepath.ToSlash(filepath.Join(item, nasPoolDirName)),
-				Reason: "shared and inactive NAS profile data hidden by active profile mount",
+				Category: item, Path: item, Reason: "shared profile data unavailable during backup",
 			})
 			continue
 		}
-		plan.Warnings = append(plan.Warnings, platforms.BackupWarning{
-			Category: item, Path: item, Reason: "shared profile data hidden by active profile mount",
+
+		alias := filepath.Join(aliasRoot, item)
+		if err = d.fs.MkdirAll(alias, 0o750); err == nil {
+			_, err = d.m.BindMount(target, alias)
+			if err == nil {
+				aliases = append(aliases, alias)
+			}
+		}
+		restorePlan, restoreErr := d.prepareItem(root, itemSpec, previous)
+		if restoreErr == nil {
+			restoreErr = d.applyItem(&restorePlan)
+		}
+		if restoreErr != nil {
+			return platforms.BackupPlan{}, nil, errors.Join(
+				fmt.Errorf("restoring %s profile mount after preparing backup: %w", item, restoreErr),
+				cleanupAliases(),
+			)
+		}
+		mounts, restoreErr = d.m.Mounts()
+		if restoreErr != nil {
+			return platforms.BackupPlan{}, nil, errors.Join(
+				fmt.Errorf("refreshing profile mounts after preparing backup: %w", restoreErr),
+				cleanupAliases(),
+			)
+		}
+		if err != nil {
+			plan.Definitions = append(plan.Definitions, originalDefinition)
+			plan.Warnings = append(plan.Warnings, platforms.BackupWarning{
+				Category: item, Path: item, Reason: "shared profile data unavailable during backup",
+			})
+			continue
+		}
+		plan.Definitions = append(plan.Definitions, platforms.BackupDefinition{
+			Category: item, SourceRoot: alias, RestoreRoot: item,
+			SourceTrustedRoots: []string{alias}, Include: []platforms.BackupPattern{{All: true}},
 		})
 	}
-	return plan
+
+	cleaned := false
+	return plan, func() error {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		if cleaned {
+			return nil
+		}
+		cleaned = true
+		return cleanupAliases()
+	}, nil
 }
 
 func (d *profileDataManager) restoreProfileMounts(root string, mounts []profileRestoreMount) error {

--- a/pkg/platforms/mister/profiledata_backup_integration_test.go
+++ b/pkg/platforms/mister/profiledata_backup_integration_test.go
@@ -1,0 +1,98 @@
+//go:build linux && integration
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package mister
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
+	if os.Getenv("ZAPAROO_TEST_REAL_MOUNTS") != "1" {
+		t.Skip("set ZAPAROO_TEST_REAL_MOUNTS=1 in an isolated mount namespace")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("real bind-mount smoke test requires effective root inside mount namespace")
+	}
+
+	mounter := sysMounter{}
+	mounts, err := mounter.Mounts()
+	if err != nil {
+		t.Skipf("mount table unavailable: %v", err)
+	}
+	mediaMounts := mountsAt(mounts, mediaRootPath)
+	if len(mediaMounts) == 0 || mediaMounts[len(mediaMounts)-1].FSType != "tmpfs" {
+		t.Skip("/media is not backed by isolated tmpfs")
+	}
+	if len(mountsAt(mounts, misterconfig.SDRootDir)) != 0 {
+		t.Skip("MiSTer storage root already has a mount")
+	}
+
+	testRoot := t.TempDir()
+	storageRoot := misterconfig.SDRootDir
+	tempDir := filepath.Join(testRoot, "tmp")
+	settings := platforms.Settings{DataDir: filepath.Join(storageRoot, "zaparoo"), TempDir: tempDir}
+	fs := afero.NewOsFs()
+	require.NoError(t, os.MkdirAll(storageRoot, 0o750))
+	manager := &profileDataManager{
+		fs: fs, m: mounter, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
+	}
+	for _, item := range allItems() {
+		require.NoError(t, os.MkdirAll(filepath.Join(storageRoot, item), 0o750))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(storageRoot, item, "shared.txt"), []byte("shared-"+item), 0o600,
+		))
+	}
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	t.Cleanup(func() {
+		for _, item := range allItems() {
+			_ = manager.m.Unmount(filepath.Join(storageRoot, item))
+		}
+	})
+	for _, item := range allItems() {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(storageRoot, item, "personal.txt"), []byte("personal-"+item), 0o600,
+		))
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+	assert.Empty(t, plan.Warnings)
+	for _, item := range allItems() {
+		// #nosec G304 -- storageRoot is an isolated tmpfs created by the smoke-test runner.
+		personal, readErr := os.ReadFile(filepath.Join(storageRoot, item, "personal.txt"))
+		require.NoError(t, readErr)
+		assert.Equal(t, "personal-"+item, string(personal))
+		var alias string
+		for _, definition := range plan.Definitions {
+			if definition.Category == item && definition.RestoreRoot == item &&
+				len(definition.SourceTrustedRoots) == 1 {
+				alias = definition.SourceRoot
+				break
+			}
+		}
+		require.NotEmpty(t, alias)
+		// #nosec G304 -- alias is returned by the backup plan under the isolated test root.
+		shared, readErr := os.ReadFile(filepath.Join(alias, "shared.txt"))
+		require.NoError(t, readErr)
+		assert.Equal(t, "shared-"+item, string(shared))
+		_, statErr := os.Stat(filepath.Join(alias, "personal.txt"))
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	}
+	require.NoError(t, cleanup())
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}

--- a/pkg/platforms/mister/profiledata_backup_integration_test.go
+++ b/pkg/platforms/mister/profiledata_backup_integration_test.go
@@ -44,14 +44,14 @@ func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
 	tempDir := filepath.Join(testRoot, "tmp")
 	settings := platforms.Settings{DataDir: filepath.Join(storageRoot, "zaparoo"), TempDir: tempDir}
 	fs := afero.NewOsFs()
-	require.NoError(t, os.MkdirAll(storageRoot, 0o750))
+	require.NoError(t, fs.MkdirAll(storageRoot, 0o750))
 	manager := &profileDataManager{
 		fs: fs, m: mounter, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
 	}
 	for _, item := range allItems() {
-		require.NoError(t, os.MkdirAll(filepath.Join(storageRoot, item), 0o750))
-		require.NoError(t, os.WriteFile(
-			filepath.Join(storageRoot, item, "shared.txt"), []byte("shared-"+item), 0o600,
+		require.NoError(t, fs.MkdirAll(filepath.Join(storageRoot, item), 0o750))
+		require.NoError(t, afero.WriteFile(
+			fs, filepath.Join(storageRoot, item, "shared.txt"), []byte("shared-"+item), 0o600,
 		))
 	}
 	require.NoError(t, manager.apply(kidA(), allItems()))
@@ -61,8 +61,8 @@ func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
 		}
 	})
 	for _, item := range allItems() {
-		require.NoError(t, os.WriteFile(
-			filepath.Join(storageRoot, item, "personal.txt"), []byte("personal-"+item), 0o600,
+		require.NoError(t, afero.WriteFile(
+			fs, filepath.Join(storageRoot, item, "personal.txt"), []byte("personal-"+item), 0o600,
 		))
 	}
 
@@ -72,7 +72,7 @@ func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
 	assert.Empty(t, plan.Warnings)
 	for _, item := range allItems() {
 		// #nosec G304 -- storageRoot is an isolated tmpfs created by the smoke-test runner.
-		personal, readErr := os.ReadFile(filepath.Join(storageRoot, item, "personal.txt"))
+		personal, readErr := afero.ReadFile(fs, filepath.Join(storageRoot, item, "personal.txt"))
 		require.NoError(t, readErr)
 		assert.Equal(t, "personal-"+item, string(personal))
 		var alias string
@@ -85,14 +85,14 @@ func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
 		}
 		require.NotEmpty(t, alias)
 		// #nosec G304 -- alias is returned by the backup plan under the isolated test root.
-		shared, readErr := os.ReadFile(filepath.Join(alias, "shared.txt"))
+		shared, readErr := afero.ReadFile(fs, filepath.Join(alias, "shared.txt"))
 		require.NoError(t, readErr)
 		assert.Equal(t, "shared-"+item, string(shared))
-		_, statErr := os.Stat(filepath.Join(alias, "personal.txt"))
+		_, statErr := fs.Stat(filepath.Join(alias, "personal.txt"))
 		require.ErrorIs(t, statErr, os.ErrNotExist)
 	}
 	require.NoError(t, cleanup())
-	entries, err := os.ReadDir(tempDir)
+	entries, err := afero.ReadDir(fs, tempDir)
 	require.NoError(t, err)
 	assert.Empty(t, entries)
 }

--- a/pkg/platforms/mister/profiledata_backup_test.go
+++ b/pkg/platforms/mister/profiledata_backup_test.go
@@ -73,16 +73,24 @@ func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
 		t.Skip("real bind-mount smoke test requires effective root inside mount namespace")
 	}
 
+	mounter := sysMounter{}
+	mounts, err := mounter.Mounts()
+	if err != nil {
+		t.Skipf("mount table unavailable: %v", err)
+	}
+	mediaMounts := mountsAt(mounts, mediaRootPath)
+	if len(mediaMounts) == 0 || mediaMounts[len(mediaMounts)-1].FSType != "tmpfs" {
+		t.Skip("/media is not backed by isolated tmpfs")
+	}
+
 	testRoot := t.TempDir()
 	storageRoot := misterconfig.SDRootDir
 	tempDir := filepath.Join(testRoot, "tmp")
 	settings := platforms.Settings{DataDir: filepath.Join(storageRoot, "zaparoo"), TempDir: tempDir}
 	fs := afero.NewOsFs()
-	if err := os.MkdirAll(storageRoot, 0o750); err != nil {
-		t.Skipf("real MiSTer storage root unavailable: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(storageRoot, 0o750))
 	manager := &profileDataManager{
-		fs: fs, m: sysMounter{}, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
+		fs: fs, m: mounter, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
 	}
 	for _, item := range allItems() {
 		require.NoError(t, os.MkdirAll(filepath.Join(storageRoot, item), 0o750))
@@ -194,6 +202,46 @@ func TestPrepareBackupWarnsWhenMountStateIsUnavailable(t *testing.T) {
 	require.NoError(t, cleanup())
 }
 
+func TestPrepareBackupFailsWhenTempRootCannotBeCreated(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, _ := newTestManager(mounter)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+	manager.fs = failMkdirFS{Fs: manager.fs, path: settings.TempDir}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.ErrorContains(t, err, "creating profile backup temp root")
+	assert.Empty(t, plan)
+	assert.Nil(t, cleanup)
+	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
+}
+
+func TestPrepareBackupCleanupReportsUnmountFailure(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, fs := newTestManager(mounter)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+
+	_, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	mounter.unmountErr = errors.New("injected cleanup unmount failure")
+	err = cleanup()
+	require.ErrorContains(t, err, "unmounting profile backup alias")
+	require.NoError(t, cleanup(), "cleanup remains idempotent after reporting an error")
+	entries, readErr := afero.ReadDir(fs, settings.TempDir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries)
+}
+
 func TestPrepareBackupAliasesUnderlyingNASData(t *testing.T) {
 	t.Parallel()
 	savesTarget := filepath.Join(misterconfig.SDRootDir, profileDataItemSaves)
@@ -295,6 +343,32 @@ func TestPrepareBackupWarnsWhenSharedAliasCannotBeMounted(t *testing.T) {
 	})
 	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
 	require.NoError(t, cleanup())
+}
+
+func TestPrepareBackupFailsWhenProfileMountCannotBeRestored(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, fs := newTestManager(mounter)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+	mounter.bindErr = errors.New("injected restore bind failure")
+	mounter.failBindAtTry = mounter.bindAttempts + 2
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.Error(t, err)
+	assert.Empty(t, plan)
+	assert.Nil(t, cleanup)
+	require.ErrorContains(t, err, "restoring saves profile mount after preparing backup")
+	exists, existsErr := afero.Exists(fs, settings.TempDir)
+	require.NoError(t, existsErr)
+	if exists {
+		entries, readErr := afero.ReadDir(fs, settings.TempDir)
+		require.NoError(t, readErr)
+		assert.Empty(t, entries)
+	}
 }
 
 func TestPrepareBackupRestoreUnmountsAndRestoresProfileBinds(t *testing.T) {

--- a/pkg/platforms/mister/profiledata_backup_test.go
+++ b/pkg/platforms/mister/profiledata_backup_test.go
@@ -23,44 +23,160 @@ package mister
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestProfileBackupPlanOmitsLiveAliasAndIncludesProfilePools(t *testing.T) {
-	t.Parallel()
-	mounter := &fakeMounter{}
-	manager, _ := newTestManager(mounter)
-	require.NoError(t, manager.apply(kidA(), allItems()))
-	settings := platforms.Settings{DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo")}
-	plan := manager.backupPlan(settings, BackupDefinitions(settings))
-
-	for _, definition := range plan.Definitions {
-		assert.False(t, definition.Category == profileDataItemSaves &&
-			filepath.Clean(definition.SourceRoot) == filepath.Join(misterconfig.SDRootDir, "saves") &&
-			filepath.Clean(definition.RestoreRoot) == profileDataItemSaves)
+func assertActiveProfile(t *testing.T, manager *profileDataManager, mounter *fakeMounter, root string) {
+	t.Helper()
+	for _, item := range allItems() {
+		stack := mountsAt(mounter.mounts, filepath.Join(root, item))
+		require.NotEmpty(t, stack)
+		entry := manager.ledger.find(&stack[len(stack)-1])
+		require.NotNil(t, entry)
+		assert.Equal(t, kidA().ID, entry.ProfileID)
 	}
-	assert.Contains(t, plan.Warnings, platforms.BackupWarning{
-		Category: profileDataItemSaves, Path: profileDataItemSaves,
-		Reason: "shared profile data hidden by active profile mount",
-	})
-	assert.Contains(t, plan.Warnings, platforms.BackupWarning{
-		Category: profileDataItemSavestates, Path: profileDataItemSavestates,
-		Reason: "shared profile data hidden by active profile mount",
-	})
 }
 
-func TestProfileBackupPlanWarnsWhenMountStateIsUnavailable(t *testing.T) {
+func TestPrepareBackupWithoutActiveProfileUsesStaticLocations(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, fs := newTestManager(mounter)
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	assert.Empty(t, plan.Warnings)
+	assert.Equal(t, BackupDefinitions(settings), plan.Definitions)
+	assert.Empty(t, mounter.mounts)
+	exists, err := afero.Exists(fs, settings.TempDir)
+	require.NoError(t, err)
+	assert.False(t, exists)
+	require.NoError(t, cleanup())
+}
+
+func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
+	if os.Getenv("ZAPAROO_TEST_REAL_MOUNTS") != "1" {
+		t.Skip("set ZAPAROO_TEST_REAL_MOUNTS=1 in an isolated mount namespace")
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("real bind-mount smoke test requires effective root inside mount namespace")
+	}
+
+	testRoot := t.TempDir()
+	storageRoot := misterconfig.SDRootDir
+	tempDir := filepath.Join(testRoot, "tmp")
+	settings := platforms.Settings{DataDir: filepath.Join(storageRoot, "zaparoo"), TempDir: tempDir}
+	fs := afero.NewOsFs()
+	if err := os.MkdirAll(storageRoot, 0o750); err != nil {
+		t.Skipf("real MiSTer storage root unavailable: %v", err)
+	}
+	manager := &profileDataManager{
+		fs: fs, m: sysMounter{}, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
+	}
+	for _, item := range allItems() {
+		require.NoError(t, os.MkdirAll(filepath.Join(storageRoot, item), 0o750))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(storageRoot, item, "shared.txt"), []byte("shared-"+item), 0o600,
+		))
+	}
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	t.Cleanup(func() {
+		for _, item := range allItems() {
+			_ = manager.m.Unmount(filepath.Join(storageRoot, item))
+		}
+	})
+	for _, item := range allItems() {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(storageRoot, item, "personal.txt"), []byte("personal-"+item), 0o600,
+		))
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+	assert.Empty(t, plan.Warnings)
+	for _, item := range allItems() {
+		// #nosec G304 -- storageRoot is an isolated tmpfs created by the smoke-test runner.
+		personal, readErr := os.ReadFile(filepath.Join(storageRoot, item, "personal.txt"))
+		require.NoError(t, readErr)
+		assert.Equal(t, "personal-"+item, string(personal))
+		var alias string
+		for _, definition := range plan.Definitions {
+			if definition.Category == item && definition.RestoreRoot == item &&
+				len(definition.SourceTrustedRoots) == 1 {
+				alias = definition.SourceRoot
+				break
+			}
+		}
+		require.NotEmpty(t, alias)
+		// #nosec G304 -- alias is returned by the backup plan under the isolated test root.
+		shared, readErr := os.ReadFile(filepath.Join(alias, "shared.txt"))
+		require.NoError(t, readErr)
+		assert.Equal(t, "shared-"+item, string(shared))
+		_, statErr := os.Stat(filepath.Join(alias, "personal.txt"))
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	}
+	require.NoError(t, cleanup())
+	entries, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPrepareBackupAliasesSharedDataAndPreservesActiveProfile(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, fs := newTestManager(mounter)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	assert.Empty(t, plan.Warnings)
+	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
+
+	for _, item := range allItems() {
+		var alias string
+		for _, definition := range plan.Definitions {
+			if definition.Category == item && definition.RestoreRoot == item &&
+				filepath.Dir(definition.SourceRoot) != misterconfig.SDRootDir {
+				alias = definition.SourceRoot
+				break
+			}
+		}
+		require.NotEmpty(t, alias)
+		assert.Len(t, mountsAt(mounter.mounts, alias), 1)
+	}
+
+	require.NoError(t, cleanup())
+	require.NoError(t, cleanup())
+	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
+	entries, err := afero.ReadDir(fs, settings.TempDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPrepareBackupWarnsWhenMountStateIsUnavailable(t *testing.T) {
 	t.Parallel()
 	mounter := &fakeMounter{mountsErr: errors.New("mount table unavailable")}
 	manager, _ := newTestManager(mounter)
 	settings := platforms.Settings{DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo")}
-	plan := manager.backupPlan(settings, BackupDefinitions(settings))
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
 
 	for _, item := range allItems() {
 		assert.Contains(t, plan.Warnings, platforms.BackupWarning{
@@ -75,9 +191,10 @@ func TestProfileBackupPlanWarnsWhenMountStateIsUnavailable(t *testing.T) {
 			)
 		}
 	}
+	require.NoError(t, cleanup())
 }
 
-func TestProfileBackupPlanMapsActiveNASPoolToOwnedPath(t *testing.T) {
+func TestPrepareBackupAliasesUnderlyingNASData(t *testing.T) {
 	t.Parallel()
 	savesTarget := filepath.Join(misterconfig.SDRootDir, profileDataItemSaves)
 	statesTarget := filepath.Join(misterconfig.SDRootDir, profileDataItemSavestates)
@@ -87,18 +204,97 @@ func TestProfileBackupPlanMapsActiveNASPoolToOwnedPath(t *testing.T) {
 	}}
 	manager, _ := newTestManager(mounter)
 	require.NoError(t, manager.apply(kidA(), allItems()))
-	settings := platforms.Settings{DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo")}
-	plan := manager.backupPlan(settings, BackupDefinitions(settings))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
 
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	assert.Empty(t, plan.Warnings)
+	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
 	for _, item := range allItems() {
-		expectedRestoreRoot := filepath.Join(item, nasPoolDirName, kidA().ID, item)
+		var aliasDefinition platforms.BackupDefinition
+		for _, definition := range plan.Definitions {
+			if definition.Category == item && definition.RestoreRoot == item &&
+				filepath.Dir(definition.SourceRoot) != misterconfig.SDRootDir {
+				aliasDefinition = definition
+				break
+			}
+		}
+		require.NotEmpty(t, aliasDefinition.SourceRoot)
+		aliasMounts := mountsAt(mounter.mounts, aliasDefinition.SourceRoot)
+		require.Len(t, aliasMounts, 1)
+		assert.Equal(t, "cifs", aliasMounts[0].FSType)
+	}
+	require.NoError(t, cleanup())
+}
+
+func TestPrepareBackupUsesUSBStorageRoot(t *testing.T) {
+	t.Parallel()
+	usbRoot := filepath.Join(mediaRootPath, "usb1")
+	mounter := &fakeMounter{mounts: []mountEntry{
+		{Root: "/", Mountpoint: usbRoot, FSType: "vfat", Source: "/dev/sdb1"},
+	}}
+	manager, fs := newTestManager(mounter)
+	writeDeviceBin(t, fs, 1)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	assert.Empty(t, plan.Warnings)
+	assertActiveProfile(t, manager, mounter, usbRoot)
+	assert.Contains(t, plan.Definitions, platforms.BackupDefinition{
+		Category: profileDataItemSaves, SourceRoot: filepath.Join(usbRoot, "zaparoo", "profiles"),
+		RestoreRoot: filepath.Join("zaparoo", "profiles"),
+		Include: []platforms.BackupPattern{
+			{Contains: "/" + profileDataItemSaves + "/"},
+			{Glob: profileNameFile},
+		},
+	})
+	for _, item := range allItems() {
+		if item == profileDataItemSaves {
+			continue
+		}
 		assert.Contains(t, plan.Definitions, platforms.BackupDefinition{
-			Category: item, SourceRoot: filepath.Join(misterconfig.SDRootDir, item),
-			RestoreRoot:        expectedRestoreRoot,
-			SourceTrustedRoots: []string{filepath.Join(misterconfig.SDRootDir, item)},
-			Include:            []platforms.BackupPattern{{All: true}},
+			Category: item, SourceRoot: filepath.Join(usbRoot, "zaparoo", "profiles"),
+			RestoreRoot: filepath.Join("zaparoo", "profiles"),
+			Include:     []platforms.BackupPattern{{Contains: "/" + item + "/"}},
 		})
 	}
+	require.NoError(t, cleanup())
+}
+
+func TestPrepareBackupWarnsWhenSharedAliasCannotBeMounted(t *testing.T) {
+	t.Parallel()
+	mounter := &fakeMounter{}
+	manager, _ := newTestManager(mounter)
+	require.NoError(t, manager.apply(kidA(), allItems()))
+	mounter.bindErr = errors.New("injected alias bind failure")
+	mounter.failBindAtTry = mounter.bindAttempts + 1
+	settings := platforms.Settings{
+		DataDir: filepath.Join(misterconfig.SDRootDir, "zaparoo"),
+		TempDir: filepath.Join(string(filepath.Separator), "tmp", "zaparoo"),
+	}
+
+	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
+	require.NoError(t, err)
+	assert.Contains(t, plan.Warnings, platforms.BackupWarning{
+		Category: profileDataItemSaves, Path: profileDataItemSaves,
+		Reason: "shared profile data unavailable during backup",
+	})
+	assert.Contains(t, plan.Definitions, platforms.BackupDefinition{
+		Category:    profileDataItemSaves,
+		SourceRoot:  filepath.Join(misterconfig.SDRootDir, profileDataItemSaves),
+		RestoreRoot: profileDataItemSaves,
+		Include:     []platforms.BackupPattern{{All: true}},
+	})
+	assertActiveProfile(t, manager, mounter, misterconfig.SDRootDir)
+	require.NoError(t, cleanup())
 }
 
 func TestPrepareBackupRestoreUnmountsAndRestoresProfileBinds(t *testing.T) {

--- a/pkg/platforms/mister/profiledata_backup_test.go
+++ b/pkg/platforms/mister/profiledata_backup_test.go
@@ -23,7 +23,6 @@ package mister
 
 import (
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -63,82 +62,6 @@ func TestPrepareBackupWithoutActiveProfileUsesStaticLocations(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, exists)
 	require.NoError(t, cleanup())
-}
-
-func TestPrepareBackupRealBindMountSmoke(t *testing.T) {
-	if os.Getenv("ZAPAROO_TEST_REAL_MOUNTS") != "1" {
-		t.Skip("set ZAPAROO_TEST_REAL_MOUNTS=1 in an isolated mount namespace")
-	}
-	if os.Geteuid() != 0 {
-		t.Skip("real bind-mount smoke test requires effective root inside mount namespace")
-	}
-
-	mounter := sysMounter{}
-	mounts, err := mounter.Mounts()
-	if err != nil {
-		t.Skipf("mount table unavailable: %v", err)
-	}
-	mediaMounts := mountsAt(mounts, mediaRootPath)
-	if len(mediaMounts) == 0 || mediaMounts[len(mediaMounts)-1].FSType != "tmpfs" {
-		t.Skip("/media is not backed by isolated tmpfs")
-	}
-
-	testRoot := t.TempDir()
-	storageRoot := misterconfig.SDRootDir
-	tempDir := filepath.Join(testRoot, "tmp")
-	settings := platforms.Settings{DataDir: filepath.Join(storageRoot, "zaparoo"), TempDir: tempDir}
-	fs := afero.NewOsFs()
-	require.NoError(t, os.MkdirAll(storageRoot, 0o750))
-	manager := &profileDataManager{
-		fs: fs, m: mounter, ledger: loadMountLedger(fs, filepath.Join(testRoot, "mounts.json")),
-	}
-	for _, item := range allItems() {
-		require.NoError(t, os.MkdirAll(filepath.Join(storageRoot, item), 0o750))
-		require.NoError(t, os.WriteFile(
-			filepath.Join(storageRoot, item, "shared.txt"), []byte("shared-"+item), 0o600,
-		))
-	}
-	require.NoError(t, manager.apply(kidA(), allItems()))
-	t.Cleanup(func() {
-		for _, item := range allItems() {
-			_ = manager.m.Unmount(filepath.Join(storageRoot, item))
-		}
-	})
-	for _, item := range allItems() {
-		require.NoError(t, os.WriteFile(
-			filepath.Join(storageRoot, item, "personal.txt"), []byte("personal-"+item), 0o600,
-		))
-	}
-
-	plan, cleanup, err := manager.prepareBackup(settings, BackupDefinitions(settings))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = cleanup() })
-	assert.Empty(t, plan.Warnings)
-	for _, item := range allItems() {
-		// #nosec G304 -- storageRoot is an isolated tmpfs created by the smoke-test runner.
-		personal, readErr := os.ReadFile(filepath.Join(storageRoot, item, "personal.txt"))
-		require.NoError(t, readErr)
-		assert.Equal(t, "personal-"+item, string(personal))
-		var alias string
-		for _, definition := range plan.Definitions {
-			if definition.Category == item && definition.RestoreRoot == item &&
-				len(definition.SourceTrustedRoots) == 1 {
-				alias = definition.SourceRoot
-				break
-			}
-		}
-		require.NotEmpty(t, alias)
-		// #nosec G304 -- alias is returned by the backup plan under the isolated test root.
-		shared, readErr := os.ReadFile(filepath.Join(alias, "shared.txt"))
-		require.NoError(t, readErr)
-		assert.Equal(t, "shared-"+item, string(shared))
-		_, statErr := os.Stat(filepath.Join(alias, "personal.txt"))
-		require.ErrorIs(t, statErr, os.ErrNotExist)
-	}
-	require.NoError(t, cleanup())
-	entries, err := os.ReadDir(tempDir)
-	require.NoError(t, err)
-	assert.Empty(t, entries)
 }
 
 func TestPrepareBackupAliasesSharedDataAndPreservesActiveProfile(t *testing.T) {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -362,6 +362,10 @@ type BackupPlanningProvider interface {
 	BackupPlan() BackupPlan
 }
 
+type BackupPreparingProvider interface {
+	PrepareBackup() (BackupPlan, func() error, error)
+}
+
 type BackupRestoreRootProvider interface {
 	BackupRestoreRoot() string
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -363,6 +363,8 @@ type BackupPlanningProvider interface {
 }
 
 type BackupPreparingProvider interface {
+	// PrepareBackup returns a non-nil, idempotent cleanup callback on success.
+	// When it returns an error, cleanup is nil and must not be called.
 	PrepareBackup() (BackupPlan, func() error, error)
 }
 

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -803,6 +803,7 @@ func zaparooBackupDefinitions(configDir, dataDir string) []platforms.BackupDefin
 				{Glob: config.LimitSoundFilename},
 				{Glob: config.PendingSoundFilename},
 				{Glob: config.ReadySoundFilename},
+				{Glob: "*.ogg"},
 				{Glob: "*.wav"},
 				{Glob: "*.mp3"},
 				{Glob: "*.flac"},

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -351,10 +351,12 @@ func (m *Manager) createBackup(ctx context.Context, preRestore bool) (result Inf
 		_ = os.Remove(tmpPath)
 		return Info{}, fmt.Errorf("finalizing backup ZIP: %w", renameErr)
 	}
-	info, err := infoFromManifest(finalPath, &manifest)
-	if err != nil {
-		return Info{}, err
+	verified, verifyErr := m.verifyLocalArchive(ctx, finalPath)
+	if verifyErr != nil {
+		_ = os.Remove(finalPath)
+		return Info{}, fmt.Errorf("verifying completed backup ZIP: %w", verifyErr)
 	}
+	info := verified.Info
 	log.Info().Str("path", finalPath).Int64("size", info.Size).Msg("created local backup ZIP")
 	if preRestore {
 		// Never fail the backup that was just created over a prune error.
@@ -706,19 +708,32 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 	dataDir := helpers.DataDir(m.pl)
 	configDir := helpers.ConfigDir(m.pl)
 	var platformPlan platforms.BackupPlan
+	platformCleanup := func() error { return nil }
 	if provider, ok := m.pl.(platforms.BackupProvider); scope == config.BackupScopePlatform && ok {
 		platformPlan = platforms.BackupPlan{Definitions: provider.BackupDefinitions()}
-		if planner, planning := m.pl.(platforms.BackupPlanningProvider); planning {
-			platformPlan = planner.BackupPlan()
+		switch backupProvider := m.pl.(type) {
+		case platforms.BackupPreparingProvider:
+			var err error
+			platformPlan, platformCleanup, err = backupProvider.PrepareBackup()
+			if err != nil {
+				return fileCollection{}, fmt.Errorf("preparing platform profile data for backup: %w", err)
+			}
+		case platforms.BackupPlanningProvider:
+			platformPlan = backupProvider.BackupPlan()
 		}
 	}
 
 	if m.database == nil || m.database.UserDB == nil {
-		return fileCollection{}, errors.New("database is not available")
+		return fileCollection{}, errors.Join(errors.New("database is not available"), platformCleanup())
 	}
 	userBackup, cleanup, err := m.database.UserDB.BackupForTransfer(ctx, reason)
 	if err != nil {
-		return fileCollection{}, fmt.Errorf("snapshotting transfer user database: %w", err)
+		return fileCollection{}, errors.Join(
+			fmt.Errorf("snapshotting transfer user database: %w", err), platformCleanup(),
+		)
+	}
+	cleanupAll := func() error {
+		return errors.Join(cleanup(), platformCleanup())
 	}
 
 	canonicalConfigRoots := canonicalCategoryRoots([]string{configDir}, "")
@@ -728,7 +743,7 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 	}
 	excludedIdentities, err := sourceIdentities(excludedSources)
 	if err != nil {
-		return fileCollection{}, errors.Join(err, cleanup())
+		return fileCollection{}, errors.Join(err, cleanupAll())
 	}
 	collector := newSourceCollector(ctx, excludedSources)
 	collector.excludedIdentities = excludedIdentities
@@ -736,7 +751,7 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 	if err = collector.addTrustedFile(
 		userBackup.Path, CategoryZaparoo, zaparooArchive("user.db"), "user.db",
 	); err != nil {
-		return fileCollection{}, errors.Join(err, cleanup())
+		return fileCollection{}, errors.Join(err, cleanupAll())
 	}
 	zaparooDefs := zaparooBackupDefinitions(configDir, dataDir)
 	zaparooDefinitions := make([]collectorDefinition, 0, len(zaparooDefs))
@@ -758,9 +773,9 @@ func (m *Manager) collectFiles(ctx context.Context, reason, scope string) (fileC
 		collector.warn(warning.Category, warning.Path, warning.Reason)
 	}
 	if collector.err != nil {
-		return fileCollection{}, errors.Join(collector.err, cleanup())
+		return fileCollection{}, errors.Join(collector.err, cleanupAll())
 	}
-	return fileCollection{Files: collector.files, Warnings: collector.warnings, Cleanup: cleanup}, nil
+	return fileCollection{Files: collector.files, Warnings: collector.warnings, Cleanup: cleanupAll}, nil
 }
 
 // zaparooBackupDefinitions describes which Zaparoo-owned files backups
@@ -777,6 +792,21 @@ func zaparooBackupDefinitions(configDir, dataDir string) []platforms.BackupDefin
 		{
 			SourceRoot: dataDir, Category: CategoryZaparoo, NonRecursive: true,
 			Include: []platforms.BackupPattern{{Glob: "frontend.toml"}, {Glob: config.TUIFile}},
+		},
+		{
+			SourceRoot:  filepath.Join(dataDir, config.AssetsDir),
+			RestoreRoot: config.AssetsDir,
+			Category:    CategoryZaparoo,
+			Include: []platforms.BackupPattern{
+				{Glob: config.SuccessSoundFilename},
+				{Glob: config.FailSoundFilename},
+				{Glob: config.LimitSoundFilename},
+				{Glob: config.PendingSoundFilename},
+				{Glob: config.ReadySoundFilename},
+				{Glob: "*.wav"},
+				{Glob: "*.mp3"},
+				{Glob: "*.flac"},
+			},
 		},
 		{
 			SourceRoot:  filepath.Join(dataDir, config.LaunchersDir),
@@ -1367,6 +1397,70 @@ func inspectZipManifest(zipPath string) (Info, error) {
 	}
 	info.Integrity = IntegrityUnchecked
 	return info, nil
+}
+
+func (m *Manager) verifyLocalArchive(ctx context.Context, zipPath string) (*zipReadResult, error) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening backup ZIP: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+	entries, err := validateZipHeaders(zr.File)
+	if err != nil {
+		return nil, err
+	}
+	manifest, err := readManifestFromZip(zr.File, entries)
+	if err != nil {
+		return nil, err
+	}
+	policyErr := m.validateManifestPolicy(manifest)
+	if policyErr != nil {
+		return nil, policyErr
+	}
+	for i := range manifest.Files {
+		file := &manifest.Files[i]
+		entry := entries[file.ArchivePath]
+		payload, openErr := entry.Open()
+		if openErr != nil {
+			return nil, fmt.Errorf("opening backup ZIP payload %s: %w", file.ArchivePath, openErr)
+		}
+		verifyErr := verifyArchivePayload(ctx, file, payload)
+		closeErr := payload.Close()
+		if closeErr != nil {
+			closeErr = fmt.Errorf("closing backup ZIP payload %s: %w", file.ArchivePath, closeErr)
+		}
+		if verifyErr != nil || closeErr != nil {
+			return nil, errors.Join(verifyErr, closeErr)
+		}
+	}
+	info, err := infoFromManifest(zipPath, manifest)
+	if err != nil {
+		return nil, err
+	}
+	info.Integrity = IntegrityValid
+	return &zipReadResult{Manifest: *manifest, Info: info}, nil
+}
+
+func verifyArchivePayload(ctx context.Context, file *FileRef, payload io.Reader) error {
+	hash := sha256.New()
+	reader := &contextReader{ctx: ctx, reader: payload}
+	limited := &io.LimitedReader{R: reader, N: file.Size}
+	written, err := io.Copy(hash, limited)
+	if err != nil {
+		return fmt.Errorf("reading backup ZIP payload %s: %w", file.ArchivePath, err)
+	}
+	var extra [1]byte
+	extraSize, extraErr := reader.Read(extra[:])
+	if extraErr != nil && !errors.Is(extraErr, io.EOF) {
+		return fmt.Errorf("checking backup ZIP payload size %s: %w", file.ArchivePath, extraErr)
+	}
+	if written != file.Size || extraSize != 0 {
+		return fmt.Errorf("backup ZIP payload size mismatch: %s", file.ArchivePath)
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != file.SHA256 {
+		return fmt.Errorf("backup ZIP payload hash mismatch: %s", file.ArchivePath)
+	}
+	return nil
 }
 
 func (m *Manager) validateLocalArchiveManifest(zipPath string) error {

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -113,6 +113,13 @@ type backupPlanningTestPlatform struct {
 	plan platforms.BackupPlan
 }
 
+type backupPreparingTestPlatform struct {
+	prepared *bool
+	cleaned  *bool
+	plan     platforms.BackupPlan
+	backupPlatform
+}
+
 func (p backupPlatform) BackupDefinitions() []platforms.BackupDefinition {
 	return p.definitions
 }
@@ -123,6 +130,14 @@ func (p backupRestoreRootPlatform) BackupRestoreRoot() string {
 
 func (p *backupPlanningTestPlatform) BackupPlan() platforms.BackupPlan {
 	return p.plan
+}
+
+func (p *backupPreparingTestPlatform) PrepareBackup() (platforms.BackupPlan, func() error, error) {
+	*p.prepared = true
+	return p.plan, func() error {
+		*p.cleaned = true
+		return nil
+	}, nil
 }
 
 func (p *backupRestorePreparingPlatform) PrepareBackupRestore() (func(bool) error, error) {
@@ -154,10 +169,15 @@ func newBackupTestEnvWithClients(
 	writeTestFile(t, filepath.Join(configDir, config.CfgFile), "debug_logging = false\n")
 	writeTestFile(t, filepath.Join(dataDir, "frontend.toml"), "enabled = true\n")
 	writeTestFile(t, filepath.Join(dataDir, config.TUIFile), "theme = \"default\"\n")
+	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, config.SuccessSoundFilename), "success-audio\n")
+	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, "custom.wav"), "custom-audio\n")
+	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, "ArcadeDatabase.csv"), "generated-cache\n")
 	writeTestFile(t, filepath.Join(dataDir, config.LaunchersDir, "custom.toml"), "[[launchers]]\n")
 	writeTestFile(t, filepath.Join(dataDir, config.MappingsDir, "tokens.toml"), "[[mappings]]\n")
 
 	writeTestFile(t, filepath.Join(rootDir, "MiSTer.ini"), "video_mode=0\n")
+	writeTestFile(t, filepath.Join(rootDir, "nfc.csv"), "match_uid,text\n")
+	writeTestFile(t, filepath.Join(rootDir, "names.txt"), "NES=My Nintendo\n")
 	writeTestFile(t, filepath.Join(rootDir, "config", "core.cfg"), "setting=1\n")
 	writeTestFile(t, filepath.Join(rootDir, "config", "core_recent.cfg"), "recent=1\n")
 	writeTestFile(t, filepath.Join(rootDir, "config", "inputs", "pad.map"), "map\n")
@@ -246,6 +266,8 @@ func testPlatformDefinitions(rootDir string) []platforms.BackupDefinition {
 			NonRecursive: true,
 			Include: []platforms.BackupPattern{
 				{Glob: "MiSTer.ini"},
+				{Glob: "nfc.csv"},
+				{Glob: "names.txt"},
 			},
 		},
 		{
@@ -266,7 +288,10 @@ func testPlatformDefinitions(rootDir string) []platforms.BackupDefinition {
 			Category:    CategorySaves,
 			SourceRoot:  filepath.Join(rootDir, "zaparoo", "profiles"),
 			RestoreRoot: filepath.Join("zaparoo", "profiles"),
-			Include:     []platforms.BackupPattern{{Contains: "/saves/"}},
+			Include: []platforms.BackupPattern{
+				{Contains: "/saves/"},
+				{Glob: "name.txt"},
+			},
 		},
 		{
 			Category:    CategorySavestates,
@@ -287,6 +312,72 @@ func testPlatformDefinitions(rootDir string) []platforms.BackupDefinition {
 			Include:     []platforms.BackupPattern{{All: true}},
 		},
 	}
+}
+
+func TestManagerCreateIncludesManagedAudioAssets(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	result := stageTestZip(t, info.Path)
+	paths := make(map[string]struct{}, len(result.Manifest.Files))
+	for _, file := range result.Manifest.Files {
+		paths[file.RestorePath] = struct{}{}
+	}
+
+	assert.Contains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, config.SuccessSoundFilename)))
+	assert.Contains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, "custom.wav")))
+	assert.NotContains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, "ArcadeDatabase.csv")))
+}
+
+func TestManagerCreateUsesPreparedPlatformPlanAndCleansUp(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	prepared := false
+	cleaned := false
+	env.Manager.pl = &backupPreparingTestPlatform{
+		backupPlatform: basePlatform,
+		plan:           platforms.BackupPlan{Definitions: basePlatform.BackupDefinitions()},
+		prepared:       &prepared,
+		cleaned:        &cleaned,
+	}
+	defaultOpener := env.Manager.sourceOpener
+	env.Manager.sourceOpener = func(ctx context.Context, file *FileRef) (io.ReadCloser, error) {
+		assert.True(t, prepared)
+		assert.False(t, cleaned)
+		return defaultOpener(ctx, file)
+	}
+
+	_, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	assert.True(t, prepared)
+	assert.True(t, cleaned)
+}
+
+func TestManagerCreateCleansUpPreparedPlatformAfterFailure(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	prepared := false
+	cleaned := false
+	env.Manager.pl = &backupPreparingTestPlatform{
+		backupPlatform: basePlatform,
+		plan:           platforms.BackupPlan{Definitions: basePlatform.BackupDefinitions()},
+		prepared:       &prepared,
+		cleaned:        &cleaned,
+	}
+	env.Manager.sourceOpener = func(context.Context, *FileRef) (io.ReadCloser, error) {
+		return nil, errors.New("injected source failure")
+	}
+
+	_, err := env.Manager.Create(context.Background())
+	require.Error(t, err)
+	assert.True(t, prepared)
+	assert.True(t, cleaned)
 }
 
 func TestManagerCreateReportsPlatformPlanWarningsAsPartial(t *testing.T) {
@@ -315,6 +406,21 @@ func TestManagerCreateReportsPlatformPlanWarningsAsPartial(t *testing.T) {
 	status := env.Manager.Status()
 	assert.Equal(t, StatusPartial, status.Local.LastStatus)
 	assert.Equal(t, 1, status.Local.SkippedFiles)
+}
+
+func TestVerifyLocalArchiveRejectsCorruptCompletedPayload(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+
+	result := stageTestZip(t, info.Path)
+	require.NotEmpty(t, result.Manifest.Files)
+	corruptZipPayload(t, info.Path, result.Manifest.Files[0].ArchivePath, "corrupt payload")
+
+	_, err = env.Manager.verifyLocalArchive(context.Background(), info.Path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backup ZIP")
 }
 
 func TestManagerCreateBackupSkipsUnreadableSource(t *testing.T) {
@@ -494,6 +600,112 @@ func TestValidateManifestPolicyRequiresExactlyOneUserDB(t *testing.T) {
 	assert.Contains(t, err.Error(), "exactly one files/zaparoo/user.db payload")
 }
 
+func TestManagerCanonicalLocalBackupRoundTrip(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	profileID := "11111111-aaaa-bbbb-cccc-000000000001"
+	durable := map[string]string{
+		filepath.Join(env.ConfigDir, config.CfgFile):                                  "debug_logging = false\n",
+		filepath.Join(env.DataDir, "frontend.toml"):                                   "enabled = true\n",
+		filepath.Join(env.DataDir, config.TUIFile):                                    "theme = \"default\"\n",
+		filepath.Join(env.DataDir, config.AssetsDir, config.SuccessSoundFilename):     "success-audio\n",
+		filepath.Join(env.DataDir, config.AssetsDir, "custom.wav"):                    "custom-audio\n",
+		filepath.Join(env.DataDir, config.LaunchersDir, "custom.toml"):                "[[launchers]]\n",
+		filepath.Join(env.DataDir, config.MappingsDir, "tokens.toml"):                 "[[mappings]]\n",
+		filepath.Join(env.RootDir, "MiSTer.ini"):                                      "video_mode=0\n",
+		filepath.Join(env.RootDir, "nfc.csv"):                                         "match_uid,text\n",
+		filepath.Join(env.RootDir, "names.txt"):                                       "NES=My Nintendo\n",
+		filepath.Join(env.RootDir, "config", "core.cfg"):                              "setting=1\n",
+		filepath.Join(env.RootDir, "config", "inputs", "pad.map"):                     "map\n",
+		filepath.Join(env.RootDir, "saves", "game.sav"):                               "save-data\n",
+		filepath.Join(env.RootDir, "savestates", "game.ss"):                           "state-data\n",
+		filepath.Join(env.DataDir, "profiles", profileID, "name.txt"):                 "Kid A\n",
+		filepath.Join(env.DataDir, "profiles", profileID, "saves", "profile.sav"):     "profile-save\n",
+		filepath.Join(env.DataDir, "profiles", profileID, "savestates", "profile.ss"): "profile-state\n",
+	}
+	for filePath, contents := range durable {
+		writeTestFile(t, filePath, contents)
+	}
+	excluded := map[string]string{
+		filepath.Join(env.ConfigDir, config.AuthFile):                              "secret\n",
+		filepath.Join(env.DataDir, config.AssetsDir, "ArcadeDatabase.csv"):         "generated-cache\n",
+		filepath.Join(env.DataDir, "profiles", profileID, "retroachievements.cfg"): "password=secret\n",
+		filepath.Join(env.RootDir, "config", "core_recent.cfg"):                    "recent=1\n",
+		filepath.Join(env.RootDir, "games", "game.rom"):                            "rom\n",
+	}
+	for filePath, contents := range excluded {
+		writeTestFile(t, filePath, contents)
+	}
+
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, IntegrityValid, info.Integrity)
+	assert.Empty(t, info.Warnings)
+	result := stageTestZip(t, info.Path)
+	manifestPaths := make(map[string]struct{}, len(result.Manifest.Files))
+	for _, file := range result.Manifest.Files {
+		manifestPaths[file.RestorePath] = struct{}{}
+	}
+	for filePath := range durable {
+		rel, relErr := canonicalFixtureRestorePath(&env, filePath)
+		require.NoError(t, relErr)
+		assert.Contains(t, manifestPaths, filepath.ToSlash(rel))
+	}
+	for filePath := range excluded {
+		rel, relErr := canonicalFixtureRestorePath(&env, filePath)
+		require.NoError(t, relErr)
+		assert.NotContains(t, manifestPaths, filepath.ToSlash(rel))
+	}
+
+	for filePath := range durable {
+		writeTestFile(t, filePath, "changed\n")
+	}
+	for filePath := range excluded {
+		require.NoError(t, os.Remove(filePath))
+	}
+	_, err = env.Manager.Restore(context.Background(), info.Name)
+	require.NoError(t, err)
+	for filePath, contents := range durable {
+		// #nosec G304 -- paths belong to test-owned temporary directories.
+		data, readErr := os.ReadFile(filePath)
+		require.NoError(t, readErr, filePath)
+		if filePath == filepath.Join(env.ConfigDir, config.CfgFile) {
+			assert.Contains(t, string(data), contents, filePath)
+			continue
+		}
+		assert.Equal(t, contents, string(data), filePath)
+	}
+	for filePath := range excluded {
+		_, statErr := os.Stat(filePath)
+		assert.ErrorIs(t, statErr, os.ErrNotExist, filePath)
+	}
+}
+
+func canonicalFixtureRestorePath(env *backupTestEnv, sourcePath string) (string, error) {
+	profileRoot := filepath.Join(env.DataDir, "profiles")
+	if rel, err := filepath.Rel(profileRoot, sourcePath); err == nil &&
+		rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		restorePath, restoreErr := filepath.Rel(env.RootDir, sourcePath)
+		if restoreErr != nil {
+			return "", fmt.Errorf("resolving profile fixture restore path: %w", restoreErr)
+		}
+		return restorePath, nil
+	}
+	if rel, err := filepath.Rel(env.ConfigDir, sourcePath); err == nil &&
+		rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return rel, nil
+	}
+	if rel, err := filepath.Rel(env.DataDir, sourcePath); err == nil &&
+		rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return rel, nil
+	}
+	restorePath, err := filepath.Rel(env.RootDir, sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("resolving fixture restore path: %w", err)
+	}
+	return restorePath, nil
+}
+
 func TestManagerCreateListRestore(t *testing.T) {
 	t.Parallel()
 	env := newBackupTestEnv(t, platformids.Mister)
@@ -570,6 +782,10 @@ func TestZaparooRestorePolicyMirrorsCollector(t *testing.T) {
 	assert.True(t, allowed("Config.toml"))
 	assert.True(t, allowed("FRONTEND.TOML"))
 	assert.True(t, allowed("Tui.toml"))
+	assert.True(t, allowed("assets/SUCCESS.OGG"))
+	assert.True(t, allowed("assets/custom.WAV"))
+	assert.True(t, allowed("assets/custom.MP3"))
+	assert.True(t, allowed("assets/custom.FLAC"))
 	assert.True(t, allowed("mappings/group/CARDS.TOML"))
 	assert.True(t, allowed("launchers/Custom.toml"))
 	assert.True(t, allowed("mappings/deep/nested/dirs/file.toml"))
@@ -578,6 +794,8 @@ func TestZaparooRestorePolicyMirrorsCollector(t *testing.T) {
 	assert.False(t, allowed("USER.DB"))
 	assert.False(t, allowed("user.db"))
 	assert.False(t, allowed("mappings/notes.txt"))
+	assert.False(t, allowed("assets/ArcadeDatabase.csv"))
+	assert.False(t, allowed("assets/tty2oled_pics/NES.png"))
 	assert.False(t, allowed("other/file.toml"))
 	assert.False(t, allowed("auth.toml"))
 }
@@ -2537,6 +2755,121 @@ func TestStatusEntrySanitizesStoredError(t *testing.T) {
 
 	assert.Equal(t, "backup failed", entry.LastError)
 	assert.NotContains(t, entry.LastError, "/media/fat")
+}
+
+func TestManagerCanonicalRemoteBackupRoundTrip(t *testing.T) {
+	env := newBackupTestEnv(t, platformids.Mister)
+	objects := make(map[string][]byte)
+	var committed remoteBackupResponse
+	var committedRequest remoteSnapshotRequest
+	var restorePack *testPackFixture
+	restoreCompleted := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/heartbeat":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/me":
+			writeJSON(t, w, remoteDeviceMeResponse{ID: "device-1", BackupActive: true})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/check":
+			var req remoteCheckRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			missing := make([]string, 0, len(req.Hashes))
+			for _, hash := range req.Hashes {
+				if hash == remoteEmptyContentSHA256 {
+					continue
+				}
+				if _, ok := objects[hash]; !ok {
+					missing = append(missing, hash)
+				}
+			}
+			writeJSON(t, w, remoteCheckResponse{Missing: missing})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/device/backup-packs/"):
+			body, err := io.ReadAll(r.Body)
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			for hash, payload := range parseTestPack(t, body) {
+				objects[hash] = payload
+			}
+			writeJSON(t, w, remotePackResponse{
+				PackHash: sha256Hex(body), ObjectCount: len(objects), CreatedAt: time.Now().UTC(),
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups":
+			if err := json.NewDecoder(r.Body).Decode(&committedRequest); !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			committed = testCommittedRemoteResponse(t, "canonical", platformids.Mister, &committedRequest)
+			writeJSON(t, w, committed)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups":
+			writeJSON(t, w, remoteListResponse{StorageQuotaBytes: 1 << 30})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/device/backups/canonical":
+			writeJSON(t, w, committed)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backup-objects/locate":
+			var req remoteLocateRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			payloads := make([][]byte, 0, len(req.Hashes))
+			for _, hash := range req.Hashes {
+				payload, ok := objects[hash]
+				if !assert.True(t, ok, hash) {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				payloads = append(payloads, payload)
+			}
+			restorePack = newTestPackFixture(t, payloads...)
+			writeJSON(t, w, restorePack.locateResponse(req.Hashes))
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/device/backup-packs/"):
+			if !assert.NotNil(t, restorePack) {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			assert.Equal(t, "/v1/device/backup-packs/"+restorePack.packHash, r.URL.Path)
+			_, _ = w.Write(restorePack.body)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/device/backups/canonical/restore-complete":
+			restoreCompleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+	configureRemoteTestAuth(t, env.Manager, server.URL)
+
+	run, err := env.Manager.RunRemote(context.Background(), RemoteBackupTypeManual)
+	require.NoError(t, err)
+	assert.Equal(t, "canonical", run.Backup.ID)
+	assert.NotEmpty(t, committedRequest.Categories[CategoryZaparoo])
+	assert.NotEmpty(t, committedRequest.Categories[CategorySaves])
+	assert.NotEmpty(t, committedRequest.Categories[CategorySavestates])
+
+	changed := map[string]string{
+		filepath.Join(env.DataDir, config.AssetsDir, config.SuccessSoundFilename): "success-audio\n",
+		filepath.Join(env.RootDir, "nfc.csv"):                                     "match_uid,text\n",
+		filepath.Join(env.RootDir, "names.txt"):                                   "NES=My Nintendo\n",
+		filepath.Join(env.RootDir, "saves", "game.sav"):                           "save-data\n",
+		filepath.Join(env.RootDir, "savestates", "game.ss"):                       "state-data\n",
+	}
+	for filePath := range changed {
+		writeTestFile(t, filePath, "changed\n")
+	}
+	_, err = env.Manager.RestoreRemote(context.Background(), "canonical")
+	require.NoError(t, err)
+	assert.True(t, restoreCompleted)
+	for filePath, expected := range changed {
+		// #nosec G304 -- paths belong to test-owned temporary directories.
+		data, readErr := os.ReadFile(filePath)
+		require.NoError(t, readErr)
+		assert.Equal(t, expected, string(data), filePath)
+	}
 }
 
 func TestManagerRunRemoteBackupUploadsPackedSnapshot(t *testing.T) {

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -114,9 +114,10 @@ type backupPlanningTestPlatform struct {
 }
 
 type backupPreparingTestPlatform struct {
-	prepared *bool
-	cleaned  *bool
-	plan     platforms.BackupPlan
+	prepared   *bool
+	cleaned    *bool
+	prepareErr error
+	plan       platforms.BackupPlan
 	backupPlatform
 }
 
@@ -134,6 +135,9 @@ func (p *backupPlanningTestPlatform) BackupPlan() platforms.BackupPlan {
 
 func (p *backupPreparingTestPlatform) PrepareBackup() (platforms.BackupPlan, func() error, error) {
 	*p.prepared = true
+	if p.prepareErr != nil {
+		return platforms.BackupPlan{}, nil, p.prepareErr
+	}
 	return p.plan, func() error {
 		*p.cleaned = true
 		return nil
@@ -170,6 +174,7 @@ func newBackupTestEnvWithClients(
 	writeTestFile(t, filepath.Join(dataDir, "frontend.toml"), "enabled = true\n")
 	writeTestFile(t, filepath.Join(dataDir, config.TUIFile), "theme = \"default\"\n")
 	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, config.SuccessSoundFilename), "success-audio\n")
+	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, "custom.ogg"), "custom-ogg-audio\n")
 	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, "custom.wav"), "custom-audio\n")
 	writeTestFile(t, filepath.Join(dataDir, config.AssetsDir, "ArcadeDatabase.csv"), "generated-cache\n")
 	writeTestFile(t, filepath.Join(dataDir, config.LaunchersDir, "custom.toml"), "[[launchers]]\n")
@@ -327,6 +332,7 @@ func TestManagerCreateIncludesManagedAudioAssets(t *testing.T) {
 	}
 
 	assert.Contains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, config.SuccessSoundFilename)))
+	assert.Contains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, "custom.ogg")))
 	assert.Contains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, "custom.wav")))
 	assert.NotContains(t, paths, filepath.ToSlash(filepath.Join(config.AssetsDir, "ArcadeDatabase.csv")))
 }
@@ -380,6 +386,27 @@ func TestManagerCreateCleansUpPreparedPlatformAfterFailure(t *testing.T) {
 	assert.True(t, cleaned)
 }
 
+func TestManagerCreateFailsWhenPlatformPreparationFails(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.Mister)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	prepared := false
+	cleaned := false
+	env.Manager.pl = &backupPreparingTestPlatform{
+		backupPlatform: basePlatform,
+		prepared:       &prepared,
+		cleaned:        &cleaned,
+		prepareErr:     errors.New("injected preparation failure"),
+	}
+
+	_, err := env.Manager.Create(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "preparing platform profile data for backup")
+	assert.True(t, prepared)
+	assert.False(t, cleaned)
+}
+
 func TestManagerCreateReportsPlatformPlanWarningsAsPartial(t *testing.T) {
 	t.Parallel()
 	env := newBackupTestEnv(t, platformids.Mister)
@@ -420,7 +447,59 @@ func TestVerifyLocalArchiveRejectsCorruptCompletedPayload(t *testing.T) {
 
 	_, err = env.Manager.verifyLocalArchive(context.Background(), info.Path)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "backup ZIP")
+	assert.True(t,
+		strings.Contains(err.Error(), "hash mismatch") ||
+			strings.Contains(err.Error(), "size mismatch"),
+		err,
+	)
+}
+
+func TestVerifyArchivePayload(t *testing.T) {
+	t.Parallel()
+	contents := []byte("payload")
+	hash := sha256.Sum256(contents)
+	file := FileRef{
+		ArchivePath: "files/zaparoo/payload.bin",
+		Size:        int64(len(contents)),
+		SHA256:      hex.EncodeToString(hash[:]),
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, verifyArchivePayload(context.Background(), &file, bytes.NewReader(contents)))
+	})
+	t.Run("hash mismatch", func(t *testing.T) {
+		t.Parallel()
+		badHash := file
+		badHash.SHA256 = strings.Repeat("0", sha256.Size*2)
+		err := verifyArchivePayload(context.Background(), &badHash, bytes.NewReader(contents))
+		require.ErrorContains(t, err, "payload hash mismatch")
+	})
+	t.Run("short payload", func(t *testing.T) {
+		t.Parallel()
+		err := verifyArchivePayload(context.Background(), &file, bytes.NewReader(contents[:len(contents)-1]))
+		require.ErrorContains(t, err, "payload size mismatch")
+	})
+	t.Run("long payload", func(t *testing.T) {
+		t.Parallel()
+		err := verifyArchivePayload(context.Background(), &file, bytes.NewReader(append(contents, '!')))
+		require.ErrorContains(t, err, "payload size mismatch")
+	})
+	t.Run("canceled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := verifyArchivePayload(ctx, &file, bytes.NewReader(contents))
+		require.ErrorIs(t, err, context.Canceled)
+	})
+	t.Run("reader failure", func(t *testing.T) {
+		t.Parallel()
+		err := verifyArchivePayload(
+			context.Background(), &file,
+			io.MultiReader(bytes.NewReader(contents[:1]), &errorReader{err: errors.New("injected read failure")}),
+		)
+		require.ErrorContains(t, err, "reading backup ZIP payload")
+	})
 }
 
 func TestManagerCreateBackupSkipsUnreadableSource(t *testing.T) {
@@ -783,6 +862,7 @@ func TestZaparooRestorePolicyMirrorsCollector(t *testing.T) {
 	assert.True(t, allowed("FRONTEND.TOML"))
 	assert.True(t, allowed("Tui.toml"))
 	assert.True(t, allowed("assets/SUCCESS.OGG"))
+	assert.True(t, allowed("assets/custom.OGG"))
 	assert.True(t, allowed("assets/custom.WAV"))
 	assert.True(t, allowed("assets/custom.MP3"))
 	assert.True(t, allowed("assets/custom.FLAC"))

--- a/pkg/service/backup/mister_integration_test.go
+++ b/pkg/service/backup/mister_integration_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +20,8 @@ func TestMiSTerBackupDefinitionsCollectorExcludesPrivateAndGeneratedFiles(t *tes
 	t.Parallel()
 	rootDir := t.TempDir()
 	writeTestFile(t, filepath.Join(rootDir, "MiSTer.ini"), "user ini\n")
+	writeTestFile(t, filepath.Join(rootDir, filepath.Base(misterconfig.LegacyMappingsPath)), "match_uid,text\n")
+	writeTestFile(t, filepath.Join(rootDir, "names.txt"), "NES=My Nintendo\n")
 	writeTestFile(t, filepath.Join(rootDir, "MiSTer_example.ini"), "example ini\n")
 	writeTestFile(t, filepath.Join(rootDir, "config", "core.cfg"), "core settings\n")
 	writeTestFile(t, filepath.Join(rootDir, "config", "core_recent.cfg"), "recent\n")
@@ -41,6 +44,7 @@ func TestMiSTerBackupDefinitionsCollectorExcludesPrivateAndGeneratedFiles(t *tes
 	writeTestFile(t, filepath.Join(
 		rootDir, "zaparoo", "profiles", profileID, "retroachievements.cfg",
 	), "password=profile-secret\n")
+	writeTestFile(t, filepath.Join(rootDir, "zaparoo", "profiles", profileID, "name.txt"), "Kid A\n")
 	nasProfileID := "22222222-aaaa-bbbb-cccc-000000000002"
 	writeTestFile(t, filepath.Join(rootDir, "saves", ".zaparoo-profiles", nasProfileID, "saves", "nas.sav"),
 		"nas save\n")
@@ -53,6 +57,8 @@ func TestMiSTerBackupDefinitionsCollectorExcludesPrivateAndGeneratedFiles(t *tes
 	}
 
 	assert.Contains(t, byArchive, platformArchive("MiSTer.ini"))
+	assert.Contains(t, byArchive, platformArchive(filepath.Base(misterconfig.LegacyMappingsPath)))
+	assert.Contains(t, byArchive, platformArchive("names.txt"))
 	assert.Contains(t, byArchive, platformArchive(filepath.Join("config", "core.cfg")))
 	assert.Contains(t, byArchive, platformArchive(filepath.Join("config", "nested", "video.cfg")))
 	assert.Contains(t, byArchive, platformArchive(filepath.Join("config", "inputs", "nested", "arcade.map")))
@@ -63,6 +69,9 @@ func TestMiSTerBackupDefinitionsCollectorExcludesPrivateAndGeneratedFiles(t *tes
 	)))
 	assert.Contains(t, byArchive, platformArchive(filepath.Join(
 		"zaparoo", "profiles", profileID, "savestates", "game.ss",
+	)))
+	assert.Contains(t, byArchive, platformArchive(filepath.Join(
+		"zaparoo", "profiles", profileID, "name.txt",
 	)))
 	assert.Contains(t, byArchive, platformArchive(filepath.Join(
 		"saves", ".zaparoo-profiles", nasProfileID, "saves", "nas.sav",

--- a/scripts/test-mister-backup-mounts.sh
+++ b/scripts/test-mister-backup-mounts.sh
@@ -1,23 +1,41 @@
 #!/bin/sh
 set -eu
 
-for command in sudo unshare mount go; do
+for command in unshare mount go; do
 	if ! command -v "$command" >/dev/null 2>&1; then
 		echo "$command is required" >&2
 		exit 1
 	fi
 done
 
-run_smoke_test='\
+module_cache=$(go env GOMODCACHE)
+
+# Command expands only inside the isolated namespace.
+# shellcheck disable=SC2016
+run_smoke_test='
 	set -eu
 	mount --make-rprivate /
 	mount -t tmpfs tmpfs /media
 	mkdir -p /media/fat
-	ZAPAROO_TEST_REAL_MOUNTS=1 go test ./pkg/platforms/mister/ \
-		-run "^TestPrepareBackupRealBindMountSmoke$" -count=1 -v
+	cache_root=$(mktemp -d)
+	export GOCACHE="$cache_root/go-build"
+	export GOMODCACHE="$MODULE_CACHE"
+	export GOPATH="$cache_root/gopath"
+	if ZAPAROO_TEST_REAL_MOUNTS=1 go test ./pkg/platforms/mister/ \
+		-run "^TestPrepareBackupRealBindMountSmoke$" -count=1 -v; then
+		status=0
+	else
+		status=$?
+	fi
+	rm -rf "$cache_root"
+	exit "$status"
 '
 
-if [ "${CI:-}" = "true" ] || sudo -n true 2>/dev/null; then
+run_privileged() {
+	if ! command -v sudo >/dev/null 2>&1; then
+		echo "sudo is required for privileged execution" >&2
+		exit 1
+	fi
 	if ! sudo -n true 2>/dev/null; then
 		echo "CI runner must provide passwordless sudo" >&2
 		exit 1
@@ -25,10 +43,16 @@ if [ "${CI:-}" = "true" ] || sudo -n true 2>/dev/null; then
 	exec sudo -n env \
 		"PATH=$PATH" \
 		"HOME=$HOME" \
-		"GOCACHE=$(go env GOCACHE)" \
-		"GOMODCACHE=$(go env GOMODCACHE)" \
-		"GOPATH=$(go env GOPATH)" \
+		"MODULE_CACHE=$module_cache" \
 		unshare --mount sh -c "$run_smoke_test"
+}
+
+if [ "${CI:-}" = "true" ]; then
+	run_privileged
+fi
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+	run_privileged
 fi
 
-exec unshare --user --map-root-user --mount sh -c "$run_smoke_test"
+exec env "MODULE_CACHE=$module_cache" \
+	unshare --user --map-root-user --mount sh -c "$run_smoke_test"

--- a/scripts/test-mister-backup-mounts.sh
+++ b/scripts/test-mister-backup-mounts.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+for command in sudo unshare mount go; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		echo "$command is required" >&2
+		exit 1
+	fi
+done
+
+run_smoke_test='\
+	set -eu
+	mount --make-rprivate /
+	mount -t tmpfs tmpfs /media
+	mkdir -p /media/fat
+	ZAPAROO_TEST_REAL_MOUNTS=1 go test ./pkg/platforms/mister/ \
+		-run "^TestPrepareBackupRealBindMountSmoke$" -count=1 -v
+'
+
+if [ "${CI:-}" = "true" ] || sudo -n true 2>/dev/null; then
+	if ! sudo -n true 2>/dev/null; then
+		echo "CI runner must provide passwordless sudo" >&2
+		exit 1
+	fi
+	exec sudo -n env \
+		"PATH=$PATH" \
+		"HOME=$HOME" \
+		"GOCACHE=$(go env GOCACHE)" \
+		"GOMODCACHE=$(go env GOMODCACHE)" \
+		"GOPATH=$(go env GOPATH)" \
+		unshare --mount sh -c "$run_smoke_test"
+fi
+
+exec unshare --user --map-root-user --mount sh -c "$run_smoke_test"

--- a/scripts/test-mister-backup-mounts.sh
+++ b/scripts/test-mister-backup-mounts.sh
@@ -21,7 +21,7 @@ run_smoke_test='
 	export GOCACHE="$cache_root/go-build"
 	export GOMODCACHE="$MODULE_CACHE"
 	export GOPATH="$cache_root/gopath"
-	if ZAPAROO_TEST_REAL_MOUNTS=1 go test ./pkg/platforms/mister/ \
+	if ZAPAROO_TEST_REAL_MOUNTS=1 go test -tags=integration ./pkg/platforms/mister/ \
 		-run "^TestPrepareBackupRealBindMountSmoke$" -count=1 -v; then
 		status=0
 	else


### PR DESCRIPTION
## Summary
- include hidden Shared Profile saves and savestates while preserving active profile mounts
- expand MiSTer backup coverage for mappings, names, profile metadata, and managed audio assets
- verify finalized local ZIP payloads with SHA-256 and add local/remote restore roundtrip coverage
- run real bind-mount smoke coverage on an isolated Linux CI runner

Closes #1238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MiSTer backups now include legacy mappings, device names, and profile metadata.
  * Backups support profile data stored on NAS and USB locations while preserving active profiles.
  * Zaparoo backups now include configured audio assets.

* **Bug Fixes**
  * Completed backup archives are verified for manifest consistency, file sizes, and integrity.
  * Failed backups are automatically removed and temporary backup changes are cleaned up reliably.
  * Backup cleanup now runs reliably when collection or preparation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->