### PR TITLE
fix(steamos): name Steam Runtime shortcut correctly

### DIFF
--- a/pkg/platforms/steamos/steamruntime/install.go
+++ b/pkg/platforms/steamos/steamruntime/install.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	runtimeExecutableName = "zaparoo-steam-runtime"
-	runtimeDisplayName    = "Zaparoo"
+	runtimeDisplayName    = "Zaparoo Runtime"
 	statusDuplicate       = "duplicate"
 	statusMissing         = "missing"
 	statusReady           = "ready"

--- a/pkg/platforms/steamos/steamruntime/install_test.go
+++ b/pkg/platforms/steamos/steamruntime/install_test.go
@@ -46,7 +46,7 @@ func TestInstallAddsSteamShortcut(t *testing.T) {
 	require.Equal(t, paths.Binary, target)
 	desktop, err := afero.ReadFile(fs, paths.Desktop)
 	require.NoError(t, err)
-	require.Contains(t, string(desktop), "Name=Zaparoo")
+	require.Contains(t, string(desktop), "Name="+runtimeDisplayName+"\n")
 	require.Contains(t, string(desktop), "Exec=\""+paths.Runtime+"\"")
 	executor.AssertExpectations(t)
 }

--- a/pkg/platforms/steamos/steamruntime/shortcut_test.go
+++ b/pkg/platforms/steamos/steamruntime/shortcut_test.go
@@ -18,7 +18,7 @@ import (
 
 func runtimeShortcutFixture(appID uint32, executable string) []byte {
 	return fixtures.BuildShortcutsVDF([]fixtures.TestShortcut{{
-		AppID: appID, AppName: "Zaparoo", Exe: `"` + executable + `"`, StartDir: filepath.Dir(executable),
+		AppID: appID, AppName: runtimeDisplayName, Exe: `"` + executable + `"`, StartDir: filepath.Dir(executable),
 	}})
 }
 


### PR DESCRIPTION
## Summary

- name the internal Steam shortcut `Zaparoo Runtime`
- align Core desktop metadata and test fixtures with Decky filtering

Closes #1242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Steam Runtime desktop and shortcut display name to **“Zaparoo Runtime.”**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->