### PR TITLE
fix(media): resolve patched ROM variant selection

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -583,7 +583,7 @@ type SearchResultWithCursor struct {
 // siblings, so a sole differentiator always survives truncation regardless of its rank.
 // Rank is the slice index.
 var TagTypeDisplayPriority = []string{
-	"unfinished", "unlicensed", "region", "video", "disc", "disctotal", "edition",
+	"unfinished", "unlicensed", "patch", "region", "video", "disc", "disctotal", "edition",
 	"rev", "arcadeboard", "cabinet", "protection", "set", "input", "dump", "alt", "compatibility", "builddate",
 	"lang", "distribution", "media", "addon", "release", "year",
 	"players", "developer", "publisher", "copyright", "credit",

--- a/pkg/database/keys_test.go
+++ b/pkg/database/keys_test.go
@@ -303,6 +303,18 @@ func TestBuildTitleZapScript(t *testing.T) {
 			want:     "@Genesis/Sonic The Hedgehog (region:eu, region:us)",
 		},
 		{
+			name:     "multiple patch tags preserve hierarchical values",
+			systemID: "SNES",
+			gameName: "Super Castlevania IV",
+			tags: []TagInfo{
+				{Tag: "fastrom:1-1", Type: "patch"},
+				{Tag: "uncensored:2-1", Type: "patch"},
+				{Tag: "font:us", Type: "patch"},
+			},
+			want: "@SNES/Super Castlevania IV " +
+				"(patch:fastrom:1-1, patch:uncensored:2-1, patch:font:us)",
+		},
+		{
 			name:     "different types each get their own parens in first-seen order",
 			systemID: "SNES",
 			gameName: "Game",

--- a/pkg/database/mediadb/disambiguation_test.go
+++ b/pkg/database/mediadb/disambiguation_test.go
@@ -143,6 +143,32 @@ func TestRecomputeSystemDisambiguation_DifferingTagDisambiguates(t *testing.T) {
 	assert.Equal(t, results[1].ZapScriptTags, fetchedResults[1].ZapScriptTags)
 }
 
+func TestRecomputeSystemDisambiguation_PatchTagDisambiguates(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	systemDBID, titleDBID, mediaIDs := setupDisambTitle(t, mediaDB, "SNES", "Super Castlevania IV", []disambTitleMedia{
+		{
+			path: browseTestPath("roms", "snes", "castlevania-fastrom.sfc"),
+			tags: map[string]string{"patch": "fastrom:1-1"},
+		},
+		{path: browseTestPath("roms", "snes", "castlevania-vanilla.sfc")},
+	})
+
+	require.NoError(t, mediaDB.RecomputeSystemDisambiguation(ctx, []int64{systemDBID}))
+	assert.Equal(t, "patch", titleDisambiguationTypes(t, mediaDB, titleDBID))
+
+	results := []database.SearchResultWithCursor{
+		{MediaID: mediaIDs[0], DisambiguationTypes: "patch"},
+		{MediaID: mediaIDs[1], DisambiguationTypes: "patch"},
+	}
+	require.NoError(t, attachZapScriptTags(ctx, mediaDB.sql.Load(), results))
+	assert.Equal(t, []database.TagInfo{{Type: "patch", Tag: "fastrom:1-1"}}, results[0].ZapScriptTags)
+	assert.Empty(t, results[1].ZapScriptTags)
+}
+
 // TestDisambiguationBackfill_RecomputesStaleTitlesAndStamps covers the one-time
 // algorithm-version backfill: indexing only recomputes DisambiguationTypes for
 // titles whose data changed, so values written by an older algorithm are never

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2599,6 +2599,7 @@ func (db *MediaDB) slugCacheSearch(
 	ctx context.Context,
 	systemID string,
 	input string,
+	tagFilters []zapscript.TagFilter,
 	matchFn func(*SlugSearchCache, []int64, []byte) []int64,
 ) ([]database.SearchResultWithCursor, bool, error) {
 	cache := db.slugSearchCache.Load()
@@ -2625,10 +2626,10 @@ func (db *MediaDB) slugCacheSearch(
 	if len(candidates) == 0 {
 		return []database.SearchResultWithCursor{}, true, nil
 	}
-	// Skip SQL-level tag filters for cache path — the Go-side selection
-	// logic handles missing/conflicting tags gracefully, and the INTERSECT
-	// subqueries are the most expensive part of the query on slow storage.
-	results, err := sqlSearchMediaByTitleDBIDs(ctx, db.sql.Load(), candidates, nil, nil, nil, defaultSlugSearchLimit)
+	// Slug cache narrows title candidates only. Apply tag filters in the bounded
+	// media query so cache hits preserve SQL-fallback semantics before LIMIT.
+	results, err := sqlSearchMediaByTitleDBIDs(
+		ctx, db.sql.Load(), candidates, tagFilters, nil, nil, defaultSlugSearchLimit)
 	log.Debug().
 		Str("system", systemID).
 		Int("candidates", len(candidates)).
@@ -2642,13 +2643,10 @@ func (db *MediaDB) SearchMediaBySlug(
 	if db.sql.Load() == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, slug,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, slug, tagFilters,
 		(*SlugSearchCache).ExactSlugMatch); ok || err != nil {
 		return results, err
 	}
-	// SQL fallback (cache not ready) still applies tag filters in the query
-	// for performance. The cache path skips SQL tag filters — Go-side
-	// selection handles tag matching in both cases.
 	return sqlSearchMediaBySlug(ctx, db.sql.Load(), systemID, slug, tagFilters)
 }
 
@@ -2658,7 +2656,7 @@ func (db *MediaDB) SearchMediaBySecondarySlug(
 	if db.sql.Load() == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, secondarySlug,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, secondarySlug, tagFilters,
 		(*SlugSearchCache).ExactSecondarySlugMatch); ok || err != nil {
 		return results, err
 	}
@@ -2671,7 +2669,7 @@ func (db *MediaDB) SearchMediaBySlugPrefix(
 	if db.sql.Load() == nil {
 		return make([]database.SearchResultWithCursor, 0), ErrNullSQL
 	}
-	if results, ok, err := db.slugCacheSearch(ctx, systemID, slugPrefix,
+	if results, ok, err := db.slugCacheSearch(ctx, systemID, slugPrefix, tagFilters,
 		(*SlugSearchCache).PrefixSlugMatch); ok || err != nil {
 		return results, err
 	}

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -1452,8 +1452,10 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 			systemDBID:    insertedSNESSystem.DBID,
 			name:          "The Legend of Zelda: A Link to the Past",
 			secondarySlug: "zelda3",
-			path:          "/roms/snes/Zelda - A Link to the Past.smc",
-			tags:          []database.TagInfo{{Type: "region", Tag: "usa"}, {Type: "genre", Tag: "adventure"}},
+			path: filepath.Join(
+				string(filepath.Separator), "roms", "snes", "Zelda - A Link to the Past.smc",
+			),
+			tags: []database.TagInfo{{Type: "region", Tag: "usa"}, {Type: "genre", Tag: "adventure"}},
 		},
 		{
 			systemID:   nesSystem.ID,

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -1426,11 +1426,12 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 
 	// Create test media titles and media with various slug patterns
 	testGames := []struct {
-		systemID   string
-		name       string
-		path       string
-		tags       []database.TagInfo
-		systemDBID int64
+		systemID      string
+		name          string
+		secondarySlug string
+		path          string
+		tags          []database.TagInfo
+		systemDBID    int64
 	}{
 		{
 			systemID:   snesSystem.ID,
@@ -1447,11 +1448,12 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 			tags:       []database.TagInfo{{Type: "region", Tag: "usa"}, {Type: "genre", Tag: "platform"}},
 		},
 		{
-			systemID:   snesSystem.ID,
-			systemDBID: insertedSNESSystem.DBID,
-			name:       "The Legend of Zelda: A Link to the Past",
-			path:       "/roms/snes/Zelda - A Link to the Past.smc",
-			tags:       []database.TagInfo{{Type: "region", Tag: "usa"}, {Type: "genre", Tag: "adventure"}},
+			systemID:      snesSystem.ID,
+			systemDBID:    insertedSNESSystem.DBID,
+			name:          "The Legend of Zelda: A Link to the Past",
+			secondarySlug: "zelda3",
+			path:          "/roms/snes/Zelda - A Link to the Past.smc",
+			tags:          []database.TagInfo{{Type: "region", Tag: "usa"}, {Type: "genre", Tag: "adventure"}},
 		},
 		{
 			systemID:   nesSystem.ID,
@@ -1484,10 +1486,15 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 	}
 
 	for _, game := range testGames {
+		secondarySlug := sql.NullString{}
+		if game.secondarySlug != "" {
+			secondarySlug = sql.NullString{String: game.secondarySlug, Valid: true}
+		}
 		title := database.MediaTitle{
-			SystemDBID: game.systemDBID,
-			Slug:       slugs.Slugify(slugs.MediaTypeGame, game.name),
-			Name:       game.name,
+			SystemDBID:    game.systemDBID,
+			Slug:          slugs.Slugify(slugs.MediaTypeGame, game.name),
+			Name:          game.name,
+			SecondarySlug: secondarySlug,
 		}
 		insertedTitle, titleErr := mediaDB.InsertMediaTitle(&title)
 		require.NoError(t, titleErr)
@@ -1567,6 +1574,10 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 
 	// Cache hits must preserve the strict tag-filter behavior of the SQL fallback.
 	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	cache := mediaDB.slugSearchCache.Load()
+	require.NotNil(t, cache)
+	require.True(t, cache.CanServeSystems([]string{"SNES"}))
+
 	tags = []zapscript.TagFilter{{Type: "region", Value: "japan"}}
 	results, err = mediaDB.SearchMediaBySlug(ctx, "SNES", "supermarioworld", tags)
 	require.NoError(t, err)
@@ -1576,6 +1587,28 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 	results, err = mediaDB.SearchMediaBySlug(ctx, "SNES", "supermarioworld", tags)
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
+
+	tags = []zapscript.TagFilter{{Type: "region", Value: "japan"}}
+	results, err = mediaDB.SearchMediaBySecondarySlug(ctx, "SNES", "zelda3", tags)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	tags = []zapscript.TagFilter{{Type: "region", Value: "usa"}}
+	results, err = mediaDB.SearchMediaBySecondarySlug(ctx, "SNES", "zelda3", tags)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "The Legend of Zelda: A Link to the Past", results[0].Name)
+
+	tags = []zapscript.TagFilter{{Type: "region", Value: "japan"}}
+	results, err = mediaDB.SearchMediaBySlugPrefix(ctx, "SNES", "supermarioworld2", tags)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	tags = []zapscript.TagFilter{{Type: "region", Value: "usa"}}
+	results, err = mediaDB.SearchMediaBySlugPrefix(ctx, "SNES", "supermarioworld2", tags)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Super Mario World 2: Yoshi's Island", results[0].Name)
 
 	// Test 6: Slug search across different systems
 	results, err = mediaDB.SearchMediaBySlug(ctx, "NES", "supermariobrothers", nil)

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -1565,6 +1565,18 @@ func TestMediaDB_SearchMediaBySlug_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 1) // Only Super Mario World matches USA AND platform
 
+	// Cache hits must preserve the strict tag-filter behavior of the SQL fallback.
+	require.NoError(t, mediaDB.RebuildSlugSearchCache())
+	tags = []zapscript.TagFilter{{Type: "region", Value: "japan"}}
+	results, err = mediaDB.SearchMediaBySlug(ctx, "SNES", "supermarioworld", tags)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+
+	tags = []zapscript.TagFilter{{Type: "region", Value: "usa"}}
+	results, err = mediaDB.SearchMediaBySlug(ctx, "SNES", "supermarioworld", tags)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
 	// Test 6: Slug search across different systems
 	results, err = mediaDB.SearchMediaBySlug(ctx, "NES", "supermariobrothers", nil)
 	require.NoError(t, err)

--- a/pkg/database/mediadb/sql_scan_reconcile.go
+++ b/pkg/database/mediadb/sql_scan_reconcile.go
@@ -46,6 +46,7 @@ var scanDynamicTagTypes = []string{
 	string(tags.TagTypePublisher),
 	string(tags.TagTypeCredit),
 	string(tags.TagTypeBuildDate),
+	string(tags.TagTypePatch),
 	string(tags.TagTypeTrack),
 	string(tags.TagTypeExtension),
 }

--- a/pkg/database/mediascanner/indexing_pipeline.go
+++ b/pkg/database/mediascanner/indexing_pipeline.go
@@ -261,6 +261,17 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 		f.FileName, _ = strings.CutSuffix(fileBase, f.Ext)
 	}
 
+	// Use pre-resolved media type if provided, otherwise look up from system ID.
+	mediaType := params.MediaType
+	if mediaType == "" {
+		mediaType = slugs.MediaTypeGame // Default to Game
+		if params.SystemID != "" {
+			if system, err := systemdefs.GetSystem(params.SystemID); err == nil {
+				mediaType = system.GetMediaType()
+			}
+		}
+	}
+
 	fileNameForTitle := f.FileName
 	trimmedName := strings.TrimSpace(params.ProvidedName)
 	if trimmedName != "" {
@@ -274,22 +285,11 @@ func GetPathFragments(params *PathFragmentParams) MediaPathFragments {
 		if stripped, ok := browseprefix.StripWithPolicy(f.FileName, prefixPolicy); ok {
 			fileNameForTitle = stripped
 		}
-		f.Title = tags.ParseTitleFromFilename(fileNameForTitle, false)
-		f.DisplayTitle = tags.ParseDisplayTitleFromFilename(fileNameForTitle, false)
+		f.Title = tags.ParseTitleFromFilenameForMedia(fileNameForTitle, false, mediaType)
+		f.DisplayTitle = tags.ParseDisplayTitleFromFilenameForMedia(fileNameForTitle, false, mediaType)
 	}
 	if f.DisplayTitle == "" {
 		f.DisplayTitle = f.Title
-	}
-
-	// Use pre-resolved media type if provided, otherwise look up from system ID
-	mediaType := params.MediaType
-	if mediaType == "" {
-		mediaType = slugs.MediaTypeGame // Default to Game
-		if params.SystemID != "" {
-			if system, err := systemdefs.GetSystem(params.SystemID); err == nil {
-				mediaType = system.GetMediaType()
-			}
-		}
 	}
 
 	// SlugifyWithTokens computes both slug and tokens in a single pass,

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -435,6 +435,27 @@ func TestGetPathFragments_PreResolvedMediaType(t *testing.T) {
 	assert.Equal(t, result.Title, resultDefault.Title, "title extraction should be identical regardless of media type")
 }
 
+func TestGetPathFragments_HTGDBPatchSuffix(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(
+		string(filepath.Separator), "media", "fat", "games", "SNES",
+		"Super Castlevania IV (U) FastROM (Hack) v1.1 Vitor Vilela.sfc",
+	)
+	result := GetPathFragments(&PathFragmentParams{
+		Path:      path,
+		SystemID:  "SNES",
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	assert.Equal(t, "Super Castlevania IV", result.Title)
+	assert.Equal(t, "Super Castlevania IV", result.DisplayTitle)
+	assert.Equal(t, "supercastlevania4", result.Slug)
+	assert.Contains(t, result.Tags, "unlicensed:hack")
+	assert.Contains(t, result.Tags, "patch:fastrom:1-1")
+	assert.NotContains(t, result.Tags, "rev:1-1")
+}
+
 // TestGetPathFragments_ProvidedName verifies that a non-empty ProvidedName
 // overrides the title parsed from the filename. The slug derives from the
 // override, and tags are still extracted from the filename.

--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -454,6 +454,30 @@ func TestGetPathFragments_HTGDBPatchSuffix(t *testing.T) {
 	assert.Contains(t, result.Tags, "unlicensed:hack")
 	assert.Contains(t, result.Tags, "patch:fastrom:1-1")
 	assert.NotContains(t, result.Tags, "rev:1-1")
+
+	for _, test := range []struct {
+		mediaType slugs.MediaType
+		extension string
+	}{
+		{mediaType: slugs.MediaTypeMovie, extension: ".mkv"},
+		{mediaType: slugs.MediaTypeMusic, extension: ".flac"},
+	} {
+		t.Run(string(test.mediaType), func(t *testing.T) {
+			t.Parallel()
+			mediaPath := filepath.Join(
+				string(filepath.Separator), "media", "fat",
+				"Super Castlevania IV (U) FastROM (Hack) v1.1 Vitor Vilela"+test.extension,
+			)
+			mediaResult := GetPathFragments(&PathFragmentParams{
+				Path:      mediaPath,
+				MediaType: test.mediaType,
+			})
+
+			assert.Equal(t, "Super Castlevania IV FastROM v1.1 Vitor Vilela", mediaResult.Title)
+			assert.Equal(t, mediaResult.Title, mediaResult.DisplayTitle)
+			assert.NotContains(t, mediaResult.Tags, "patch:fastrom:1-1")
+		})
+	}
 }
 
 // TestGetPathFragments_ProvidedName verifies that a non-empty ProvidedName

--- a/pkg/database/mediascanner/scan_reconcile_test.go
+++ b/pkg/database/mediascanner/scan_reconcile_test.go
@@ -214,6 +214,9 @@ func TestReconcile_DynamicTagTypesPersisted(t *testing.T) {
 	require.NoError(t, SeedCanonicalTags(ctx, mediaDB))
 
 	arcadePath := filepath.Join("_Arcade", "Super Street Fighter II The New Challengers (World 931005).mra")
+	patchPath := filepath.Join(
+		"SNES", "Super Castlevania IV (U) FastROM (Hack) v1.1 Vitor Vilela.sfc",
+	)
 	trackPath := filepath.Join("SNESMusic", "Star Fox [01].spc")
 
 	require.NoError(t, mediaDB.BeginTransaction(true))
@@ -222,6 +225,11 @@ func TestReconcile_DynamicTagTypesPersisted(t *testing.T) {
 		DB: mediaDB, SystemID: "Arcade", Path: arcadePath, MediaType: slugs.MediaTypeGame,
 	}))
 	_, err := mediaDB.ReconcileStagedSystem(ctx, "Arcade", database.ScanReconcileOpts{})
+	require.NoError(t, err)
+	require.NoError(t, StageMediaPath(&StageMediaPathParams{
+		DB: mediaDB, SystemID: "SNES", Path: patchPath, MediaType: slugs.MediaTypeGame,
+	}))
+	_, err = mediaDB.ReconcileStagedSystem(ctx, "SNES", database.ScanReconcileOpts{})
 	require.NoError(t, err)
 	require.NoError(t, StageMediaPath(&StageMediaPathParams{
 		DB: mediaDB, SystemID: "SNESMusic", Path: trackPath, MediaType: slugs.MediaTypeMusic,
@@ -235,6 +243,11 @@ func TestReconcile_DynamicTagTypesPersisted(t *testing.T) {
 	got := mediaTagStrings(t, mediaDB, arcadeRows[arcadePath].DBID)
 	assert.Contains(t, got, "builddate:1993-10-05", "build date tag should persist through indexing")
 	assert.Contains(t, got, "region:world")
+
+	patchRows := mediaBySystem(t, mediaDB, "SNES")
+	require.Len(t, patchRows, 1)
+	got = mediaTagStrings(t, mediaDB, patchRows[patchPath].DBID)
+	assert.Contains(t, got, "patch:fastrom:1-1", "patch tag should persist through indexing")
 
 	musicRows := mediaBySystem(t, mediaDB, "SNESMusic")
 	require.Len(t, musicRows, 1)

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -2269,22 +2269,40 @@ func stripMetadataBracketsForDisplay(s string) string {
 // code duplication. However, it only applies transformations appropriate for display
 // titles (no Roman numeral conversion, edition stripping, etc.).
 func ParseTitleFromFilename(filename string, stripLeadingNumbers bool) string {
-	return parseFilenameTitle(filename, stripLeadingNumbers, false)
+	return ParseTitleFromFilenameForMedia(filename, stripLeadingNumbers, slugs.MediaTypeGame)
+}
+
+// ParseTitleFromFilenameForMedia extracts a canonical title using media-specific cleanup.
+func ParseTitleFromFilenameForMedia(
+	filename string, stripLeadingNumbers bool, mediaType slugs.MediaType,
+) string {
+	return parseFilenameTitle(filename, stripLeadingNumbers, false, mediaType)
 }
 
 // ParseDisplayTitleFromFilename extracts a per-file display title while preserving
 // structural set markers such as "(Disc 1)", "(Disk 2 of 4)", and "(File 3)".
 // The canonical title parser still strips those markers before slug generation.
 func ParseDisplayTitleFromFilename(filename string, stripLeadingNumbers bool) string {
-	return parseFilenameTitle(filename, stripLeadingNumbers, true)
+	return ParseDisplayTitleFromFilenameForMedia(filename, stripLeadingNumbers, slugs.MediaTypeGame)
 }
 
-func parseFilenameTitle(filename string, stripLeadingNumbers, preserveStructuralTags bool) string {
+// ParseDisplayTitleFromFilenameForMedia extracts a media-specific per-file display title.
+func ParseDisplayTitleFromFilenameForMedia(
+	filename string, stripLeadingNumbers bool, mediaType slugs.MediaType,
+) string {
+	return parseFilenameTitle(filename, stripLeadingNumbers, true, mediaType)
+}
+
+func parseFilenameTitle(
+	filename string, stripLeadingNumbers, preserveStructuralTags bool, mediaType slugs.MediaType,
+) string {
 	// Import the slugs package for shared normalization functions
 	// This eliminates code duplication while keeping display-appropriate behavior
 	title := filename
-	if _, withoutPatchSuffix, matched := parseHTGDBPatchSuffix(title); matched {
-		title = withoutPatchSuffix
+	if mediaType == "" || mediaType == slugs.MediaTypeGame {
+		if _, withoutPatchSuffix, matched := parseHTGDBPatchSuffix(title); matched {
+			title = withoutPatchSuffix
+		}
 	}
 
 	// Step 1: Remove file extension first (simplifies later processing)

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -33,7 +33,22 @@ import (
 // These are compiled once at initialization for optimal performance.
 var (
 	// Special pattern extraction (complex patterns that still use regex)
-	reTransBracketed = regexp.MustCompile(`^T([+-]?)([A-Za-z]{2,3})(?:.*?v(\d+(?:\.\d+)*))?`)
+	reTransBracketed    = regexp.MustCompile(`^T([+-]?)([A-Za-z]{2,3})(?:.*?v(\d+(?:\.\d+)*))?`)
+	reSquareBracket     = regexp.MustCompile(`\[([^\[\]]+)]`)
+	rePatchVersion      = regexp.MustCompile(`(?:^|-)v(\d+(?:-\d+)*)$`)
+	reFontPatch         = regexp.MustCompile(`^([a-z]{2})-font$`)
+	reHTGDBHackMarker   = regexp.MustCompile(`(?i)\((?:hack|patch)\)`)
+	reHTGDBPatchVersion = regexp.MustCompile(`(?i)(?:^|[\s_+\-])v(\d+(?:\.\d+)*)`)
+	reHTGDBPatchLabel   = regexp.MustCompile(`(?i)\b(?:` +
+		`(?:ted[\s_-]+)?woolsey[\s_-]+uncensored[\s_-]+edition|` +
+		`stereo\s*\+\s*bug[\s_-]*fix(?:es)?|gba[\s_-]+script[\s_-]+port|` +
+		`splash[\s_-]+screen[\s_-]+removed|quality[\s_-]+of[\s_-]+life|` +
+		`music[\s_-]+restore|sram[\s_-]+expansion|faster[\s_-]+rom|` +
+		`fast[\s_-]*rom|slow[\s_-]*rom|all[\s_-]+bugs[\s_-]+fix|` +
+		`bug[\s_-]*fix(?:es)?|uncensor(?:ed)?|relocalized|restoration|` +
+		`performance|retouch|overhaul|tweak|wide[\s_-]*screen|` +
+		`msu[\s_-]*1|sa[\s_-]*1|colori[sz](?:ation|ed)|redux|qol` +
+		`)\b`)
 
 	// "side-N-of-M" — a disk side plus the total disk/side count.
 	reSideOf = regexp.MustCompile(`^side-(\d+)-of-(\d+)$`)
@@ -72,6 +87,57 @@ var editionSuffixFallbacks = map[string]TagValue{
 	"remake":  TagEditionRemake,
 	"remix":   TagEditionRemix,
 	"cut":     TagEditionCut,
+}
+
+// patchLabelAliases contains patch labels observed in ROM-hack collections.
+// Unknown bracket labels remain available to the general filename parser.
+var patchLabelAliases = map[string]TagValue{
+	"all-bugs-fix":                   "bugfix",
+	"bug-fix":                        "bugfix",
+	"bug-fixes":                      "bugfix",
+	"bugfix":                         "bugfix",
+	"bugfixes":                       "bugfix",
+	"color":                          "color",
+	"colorisation":                   "color",
+	"colorised":                      "color",
+	"colorization":                   "color",
+	"colorized":                      "color",
+	"fast-rom":                       "fastrom",
+	"faster-rom":                     "fastrom",
+	"fastrom":                        "fastrom",
+	"fix":                            "fix",
+	"fixes":                          "fix",
+	"gba-script-port":                "script-port",
+	"hack":                           "hack",
+	"msu-1":                          "msu1",
+	"msu1":                           "msu1",
+	"music":                          "music",
+	"music-restore":                  "music",
+	"no-sram":                        "no-sram",
+	"overhaul":                       "overhaul",
+	"performance":                    "performance",
+	"quality-of-life":                "qol",
+	"qol":                            "qol",
+	"redux":                          "redux",
+	"relocalized":                    "relocalized",
+	"restoration":                    "restoration",
+	"retouch":                        "retouch",
+	"sa-1":                           "sa1",
+	"sa1":                            "sa1",
+	"script-port":                    "script-port",
+	"slow-rom":                       "slowrom",
+	"slowrom":                        "slowrom",
+	"splash-screen-removed":          "splash-screen-removed",
+	"sram":                           "sram",
+	"sram-expansion":                 "sram",
+	"stereo-bug-fixes":               "bugfix",
+	"tweak":                          "tweak",
+	"uncensor":                       "uncensored",
+	"uncensored":                     "uncensored",
+	"wide-screen":                    "widescreen",
+	"widescreen":                     "widescreen",
+	"woolsey-uncensored-edition":     "uncensored",
+	"ted-woolsey-uncensored-edition": "uncensored",
 }
 
 // editionQualifiers maps recognized qualifier strings (after stripping the suffix and "the-")
@@ -668,6 +734,208 @@ func extractSpecialPatterns(filename string) (tags []CanonicalTag, remaining str
 	return extractSpecialPatternsForMedia(filename, "")
 }
 
+// splitPatchVersion removes a trailing patch version such as "-v1-1".
+func splitPatchVersion(normalized string) (label, version string) {
+	match := rePatchVersion.FindStringSubmatchIndex(normalized)
+	if match == nil {
+		return normalized, ""
+	}
+	return strings.TrimRight(normalized[:match[0]], "-"), normalized[match[2]:match[3]]
+}
+
+func canonicalPatchLabel(label string) (TagValue, bool) {
+	value, ok := patchLabelAliases[label]
+	return value, ok
+}
+
+func versionedPatchValue(value TagValue, version string) TagValue {
+	if version == "" {
+		return value
+	}
+	return TagValue(string(value) + ":" + version)
+}
+
+// parsePatchBracket maps explicit patch naming conventions such as
+// "[FastROM hack by Author v1.1]", "[Performance by Author (v1.0)]",
+// "[FastROM]", and "[US font]" to stable, additive values. Unknown bracket
+// labels are not treated as patches. Credits are intentionally omitted because
+// patch identity and version select media without author-specific tag noise.
+func parsePatchBracket(content string) ([]CanonicalTag, bool) {
+	normalized := cachedNormalizeTag(content)
+
+	if match := reFontPatch.FindStringSubmatch(normalized); match != nil {
+		return []CanonicalTag{{
+			Type:   TagTypePatch,
+			Value:  TagValue("font:" + match[1]),
+			Source: TagSourceBracketed,
+		}}, true
+	}
+
+	label, version := splitPatchVersion(normalized)
+	patchValue, matched := canonicalPatchLabel(label)
+
+	if !matched {
+		if descriptor, _, found := strings.Cut(label, "-by-"); found {
+			patchValue, matched = canonicalPatchLabel(descriptor)
+		}
+	}
+
+	if !matched {
+		for _, marker := range []string{"-hack", "-patch"} {
+			markerIndex := strings.Index(label, marker)
+			if markerIndex <= 0 {
+				continue
+			}
+
+			suffix := label[markerIndex+len(marker):]
+			if suffix != "" && !strings.HasPrefix(suffix, "-by-") {
+				continue
+			}
+
+			patchName := strings.Trim(label[:markerIndex], "-")
+			if patchName == "" {
+				continue
+			}
+			if canonical, ok := canonicalPatchLabel(patchName); ok {
+				patchValue = canonical
+			} else {
+				patchValue = TagValue(patchName)
+			}
+			matched = true
+			break
+		}
+	}
+
+	if !matched {
+		return nil, false
+	}
+
+	return []CanonicalTag{
+		{Type: TagTypeUnlicensed, Value: TagUnlicensedHack, Source: TagSourceBracketed},
+		{
+			Type:   TagTypePatch,
+			Value:  versionedPatchValue(patchValue, version),
+			Source: TagSourceBracketed,
+		},
+	}, true
+}
+
+func hasHTGDBPatchMarker(filename string) bool {
+	for offset := 0; offset < len(filename); {
+		markerStart := strings.IndexByte(filename[offset:], '(')
+		if markerStart < 0 {
+			return false
+		}
+		markerStart += offset
+		remaining := filename[markerStart:]
+		if len(remaining) >= len("(hack)") && strings.EqualFold(remaining[:len("(hack)")], "(hack)") {
+			return true
+		}
+		if len(remaining) >= len("(patch)") && strings.EqualFold(remaining[:len("(patch)")], "(patch)") {
+			return true
+		}
+		offset = markerStart + 1
+	}
+	return false
+}
+
+func splitPatchFilenameExtension(filename string) (stem, extension string) {
+	lastSlash := strings.LastIndexAny(filename, `/\\`)
+	lastDot := strings.LastIndex(filename, ".")
+	if lastDot <= lastSlash {
+		return filename, ""
+	}
+
+	extensionBody := filename[lastDot+1:]
+	if len(extensionBody) < 2 || len(extensionBody) > 4 || strings.ContainsAny(extensionBody, " \t") {
+		return filename, ""
+	}
+	return filename[:lastDot], filename[lastDot:]
+}
+
+// parseHTGDBPatchSuffix handles HTGDB/SmokeMonster names such as
+// "Axelay (U) FastROM (Hack) v1.0 Vitor Vilela". Only researched patch
+// labels are recognized; arbitrary names containing "(Hack)" retain their
+// existing title and revision behavior.
+func parseHTGDBPatchSuffix(filename string) ([]CanonicalTag, string, bool) {
+	if !hasHTGDBPatchMarker(filename) {
+		return nil, filename, false
+	}
+
+	stem, extension := splitPatchFilenameExtension(filename)
+	markers := reHTGDBHackMarker.FindAllStringIndex(stem, -1)
+	if len(markers) == 0 {
+		return nil, filename, false
+	}
+
+	marker := markers[len(markers)-1]
+	prefix := stem[:marker[0]]
+	labelMatches := reHTGDBPatchLabel.FindAllStringIndex(prefix, -1)
+	if len(labelMatches) == 0 {
+		return nil, filename, false
+	}
+
+	stripStart := labelMatches[0][0]
+	version := ""
+	if match := reHTGDBPatchVersion.FindStringSubmatch(stem[stripStart:]); match != nil {
+		version = strings.ReplaceAll(match[1], ".", "-")
+	}
+
+	tags := []CanonicalTag{{
+		Type:   TagTypeUnlicensed,
+		Value:  TagUnlicensedHack,
+		Source: TagSourceBracketed,
+	}}
+	seen := make(map[TagValue]struct{}, len(labelMatches))
+	for _, match := range labelMatches {
+		normalized := cachedNormalizeTag(prefix[match[0]:match[1]])
+		patchValue, ok := canonicalPatchLabel(normalized)
+		if !ok {
+			continue
+		}
+		patchValue = versionedPatchValue(patchValue, version)
+		if _, exists := seen[patchValue]; exists {
+			continue
+		}
+		seen[patchValue] = struct{}{}
+		tags = append(tags, CanonicalTag{
+			Type:   TagTypePatch,
+			Value:  patchValue,
+			Source: TagSourceBracketed,
+		})
+	}
+	if len(tags) == 1 {
+		return nil, filename, false
+	}
+
+	remaining := strings.TrimRight(prefix[:stripStart], " \t-_+") + extension
+	return tags, remaining, true
+}
+
+// extractPatchBrackets removes recognized patch-only square brackets before generic
+// version extraction. This keeps patch versions attached to their patch identity instead
+// of misclassifying the first bracketed version as the base ROM revision.
+func extractPatchBrackets(filename string) (patchTags []CanonicalTag, remaining string) {
+	patchTags = make([]CanonicalTag, 0)
+	seen := make(map[string]struct{})
+	remaining = reSquareBracket.ReplaceAllStringFunc(filename, func(group string) string {
+		parsed, ok := parsePatchBracket(group[1 : len(group)-1])
+		if !ok {
+			return group
+		}
+		for _, tag := range parsed {
+			key := tag.String()
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			patchTags = append(patchTags, tag)
+		}
+		return " "
+	})
+	return patchTags, remaining
+}
+
 // extractSpecialPatternsForMedia is the media-type-aware variant of extractSpecialPatterns.
 // Patterns irrelevant to the given mediaType are skipped to reduce regex overhead.
 // Pass an empty mediaType to run all patterns (equivalent to extractSpecialPatterns).
@@ -682,6 +950,18 @@ func extractSpecialPatternsForMedia(
 	}
 
 	remaining = filename
+
+	if mediaType == "" || mediaType == slugs.MediaTypeGame {
+		patchTags, withoutPatchBrackets := extractPatchBrackets(remaining)
+		tags = append(tags, patchTags...)
+		remaining = withoutPatchBrackets
+
+		suffixTags, withoutPatchSuffix, matched := parseHTGDBPatchSuffix(remaining)
+		if matched {
+			tags = append(tags, suffixTags...)
+			remaining = withoutPatchSuffix
+		}
+	}
 
 	// Pattern 1: "Disc/Disk X of Y [Side A/B/C/D]" - most common multi-disc format
 	if m := findDiscPattern(remaining); m.ok {
@@ -2003,6 +2283,9 @@ func parseFilenameTitle(filename string, stripLeadingNumbers, preserveStructural
 	// Import the slugs package for shared normalization functions
 	// This eliminates code duplication while keeping display-appropriate behavior
 	title := filename
+	if _, withoutPatchSuffix, matched := parseHTGDBPatchSuffix(title); matched {
+		title = withoutPatchSuffix
+	}
 
 	// Step 1: Remove file extension first (simplifies later processing)
 	// Find the last dot that's likely an extension (after the last slash if any)

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -2043,6 +2043,7 @@ func TestParseFilenameToCanonicalTags_Patches(t *testing.T) {
 			},
 		},
 		{
+			// parseHTGDBPatchSuffix applies one captured version to every recognized suffix label.
 			name: "HTGDB composite suffix",
 			filename: "Final Fantasy V GBA Script Port+Ginger Battle Galuf+Bugfixes, Sprite Touch-Ups " +
 				"(Hack) v1.15 J121, v1.03 Chicken Knife.sfc",

--- a/pkg/database/tags/filename_parser_test.go
+++ b/pkg/database/tags/filename_parser_test.go
@@ -1986,6 +1986,253 @@ func TestParseBracesAndAngles_FullPipeline(t *testing.T) {
 	}
 }
 
+func TestParseFilenameToCanonicalTags_Patches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		filename        string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name: "issue 1237 multi-patch filename",
+			filename: "Super Castlevania IV (USA) [FastROM hack by Vitor Vilela v1.1] " +
+				"[Uncensored hack by ShadowOne333 v2.1] [US font].sfc",
+			wantContains: []string{
+				"region:us",
+				"unlicensed:hack",
+				"patch:fastrom:1-1",
+				"patch:uncensored:2-1",
+				"patch:font:us",
+			},
+			wantNotContains: []string{"rev:1-1", "rev:2-1"},
+		},
+		{
+			name:         "patch without version",
+			filename:     "Game [FastROM hack by Someone].sfc",
+			wantContains: []string{"unlicensed:hack", "patch:fastrom"},
+		},
+		{
+			name:         "HTGDB FastROM suffix",
+			filename:     "Super Castlevania IV (U) FastROM (Hack) v1.1 Vitor Vilela.sfc",
+			wantContains: []string{"region:us", "unlicensed:hack", "patch:fastrom:1-1"},
+			wantNotContains: []string{
+				"rev:1-1",
+			},
+		},
+		{
+			name:         "HTGDB uncensored suffix",
+			filename:     "Super Castlevania IV Uncensored (hack) v1 ShadowOne333.sfc",
+			wantContains: []string{"unlicensed:hack", "patch:uncensored:1"},
+			wantNotContains: []string{
+				"rev:1",
+			},
+		},
+		{
+			name:         "HTGDB versionless restoration suffix",
+			filename:     "Contra III - The Alien Wars Restoration (Hack) Final SCD.sfc",
+			wantContains: []string{"unlicensed:hack", "patch:restoration"},
+		},
+		{
+			name:         "HTGDB SA-1 suffix",
+			filename:     "Gradius III SA-1 Origin USA (Hack) v1.6 Vitor Vilela.sfc",
+			wantContains: []string{"unlicensed:hack", "patch:sa1:1-6"},
+			wantNotContains: []string{
+				"rev:1-6",
+			},
+		},
+		{
+			name: "HTGDB composite suffix",
+			filename: "Final Fantasy V GBA Script Port+Ginger Battle Galuf+Bugfixes, Sprite Touch-Ups " +
+				"(Hack) v1.15 J121, v1.03 Chicken Knife.sfc",
+			wantContains: []string{
+				"unlicensed:hack",
+				"patch:script-port:1-15",
+				"patch:bugfix:1-15",
+			},
+			wantNotContains: []string{"rev:1-15", "rev:1-03"},
+		},
+		{
+			name: "HTGDB version before marker",
+			filename: "Final Fantasy III Ted Woolsey Uncensored Edition v1.3 by Rodimus Primal " +
+				"(Hack).sfc",
+			wantContains: []string{"unlicensed:hack", "patch:uncensored:1-3"},
+			wantNotContains: []string{
+				"rev:1-3",
+			},
+		},
+		{
+			name: "standalone researched patch labels",
+			filename: "Game [FastROM] [SlowROM] [Uncensored] [Bugfixes] [Widescreen] [Relocalized] " +
+				"[Restoration] [Redux] [Performance] [Retouch] [Overhaul] [Tweak].sfc",
+			wantContains: []string{
+				"patch:fastrom",
+				"patch:slowrom",
+				"patch:uncensored",
+				"patch:bugfix",
+				"patch:widescreen",
+				"patch:relocalized",
+				"patch:restoration",
+				"patch:redux",
+				"patch:performance",
+				"patch:retouch",
+				"patch:overhaul",
+				"patch:tweak",
+			},
+		},
+		{
+			name: "standalone patch aliases",
+			filename: "Game [Fast-ROM v1.1] [Uncensor v2.0] [Bug Fixes] [All Bugs Fix] " +
+				"[Wide Screen] [Quality of Life].sfc",
+			wantContains: []string{
+				"patch:fastrom:1-1",
+				"patch:uncensored:2-0",
+				"patch:bugfix",
+				"patch:widescreen",
+				"patch:qol",
+			},
+			wantNotContains: []string{"rev:1-1", "rev:2-0"},
+		},
+		{
+			name: "curated patch categories with credits",
+			filename: "Game [Performance by kandowontu (v1.0)] [Fix by Someone (v0.9)] " +
+				"[Restoration by Group v2.0] [Retouch by Person] [Overhaul by Team] [Tweak by Author].sfc",
+			wantContains: []string{
+				"patch:performance:1-0",
+				"patch:fix:0-9",
+				"patch:restoration:2-0",
+				"patch:retouch",
+				"patch:overhaul",
+				"patch:tweak",
+			},
+			wantNotContains: []string{"rev:1-0", "rev:0-9", "rev:2-0"},
+		},
+		{
+			name: "generic explicit hack and patch labels",
+			filename: "Game [Hack by Author v1.2] [Alt Font & Controls Hack by Team v2.0] " +
+				"[Optional patch by Group v3.0].sfc",
+			wantContains: []string{
+				"patch:hack:1-2",
+				"patch:alt-font-controls:2-0",
+				"patch:optional:3-0",
+			},
+			wantNotContains: []string{"rev:1-2", "rev:2-0", "rev:3-0"},
+		},
+		{
+			name: "hardware and enhancement patch labels",
+			filename: "Game [MSU-1] [SA-1] [SRAM] [No SRAM] [Color] [Colorization] " +
+				"[Music] [Script Port] [Splash Screen Removed].sfc",
+			wantContains: []string{
+				"patch:msu1",
+				"patch:sa1",
+				"patch:sram",
+				"patch:no-sram",
+				"patch:color",
+				"patch:music",
+				"patch:script-port",
+				"patch:splash-screen-removed",
+			},
+		},
+		{
+			name:            "unknown bracket label remains non-patch metadata",
+			filename:        "Game [Player 1 Color] [Fan Label v1.0].sfc",
+			wantNotContains: []string{"patch:player-1-color", "patch:fan-label:1-0"},
+		},
+		{
+			name:            "ordinary dump hack marker remains dump metadata",
+			filename:        "Game [h].sfc",
+			wantContains:    []string{"dump:hacked"},
+			wantNotContains: []string{"unlicensed:hack", "patch:h"},
+		},
+		{
+			name:            "title containing hack is not patch metadata",
+			filename:        "Hackers (USA).sfc",
+			wantContains:    []string{"region:us"},
+			wantNotContains: []string{"unlicensed:hack"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			parsed := ParseFilenameToCanonicalTagsForMedia(tt.filename, slugs.MediaTypeGame)
+			got := make([]string, 0, len(parsed))
+			for _, tag := range parsed {
+				got = append(got, tag.String())
+			}
+			for _, expected := range tt.wantContains {
+				assert.Contains(t, got, expected)
+			}
+			for _, unexpected := range tt.wantNotContains {
+				assert.NotContains(t, got, unexpected)
+			}
+		})
+	}
+}
+
+func TestParseFilenameTitle_HTGDBPatchSuffixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "FastROM suffix",
+			filename: "Super Castlevania IV (U) FastROM (Hack) v1.1 Vitor Vilela.sfc",
+			want:     "Super Castlevania IV",
+		},
+		{
+			name:     "hyphenated FastROM suffix",
+			filename: "Arcana - Fastrom (Hack) v0.2 rainponcho.sfc",
+			want:     "Arcana",
+		},
+		{
+			name:     "uncensored suffix",
+			filename: "Super Castlevania IV Uncensored (hack) v1 ShadowOne333.sfc",
+			want:     "Super Castlevania IV",
+		},
+		{
+			name:     "versionless restoration suffix",
+			filename: "Contra III - The Alien Wars Restoration (Hack) Final SCD.sfc",
+			want:     "Contra III - The Alien Wars",
+		},
+		{
+			name:     "SA-1 suffix qualifiers",
+			filename: "Gradius III SA-1 Origin USA (Hack) v1.6 Vitor Vilela.sfc",
+			want:     "Gradius III",
+		},
+		{
+			name: "version before marker",
+			filename: "Final Fantasy III Ted Woolsey Uncensored Edition v1.3 by Rodimus Primal " +
+				"(Hack).sfc",
+			want: "Final Fantasy III",
+		},
+		{
+			name: "composite suffix",
+			filename: "Final Fantasy V GBA Script Port+Ginger Battle Galuf+Bugfixes, Sprite Touch-Ups " +
+				"(Hack) v1.15 J121, v1.03 Chicken Knife.sfc",
+			want: "Final Fantasy V",
+		},
+		{
+			name:     "unknown hack suffix",
+			filename: "Game Alternate Physics (Hack) v1.0 Author.sfc",
+			want:     "Game Alternate Physics v1.0 Author",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ParseTitleFromFilename(tt.filename, false))
+			assert.Equal(t, tt.want, ParseDisplayTitleFromFilename(tt.filename, false))
+		})
+	}
+}
+
 func TestExtractSpecialPatterns_EditionWords(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/database/tags/tags.go
+++ b/pkg/database/tags/tags.go
@@ -123,6 +123,7 @@ const (
 	TagTypeSet           TagType = "set"           // Set number
 	TagTypeAlt           TagType = "alt"           // Alternate version
 	TagTypeUnlicensed    TagType = "unlicensed"    // Unlicensed/bootleg/hacks
+	TagTypePatch         TagType = "patch"         // Applied ROM patches and modifications
 	TagTypeMameParent    TagType = "mameparent"    // MAME parent ROM relationship
 	TagTypeRegion        TagType = "region"        // Release region
 	TagTypeYear          TagType = "year"          // Release year
@@ -770,6 +771,11 @@ var CanonicalTagDefinitions = map[TagType][]TagValue{
 		TagUnlicensedAftermarket,    // Made after original market cycle ended
 		// Publisher-specific
 		TagUnlicensedSachen, // Sachen unlicensed (NES)
+	},
+
+	TagTypePatch: {
+		// Dynamic values identify applied patches and optional versions, such as
+		// patch:fastrom:1-1 or patch:uncensored:2-1.
 	},
 
 	TagTypeMameParent: {

--- a/pkg/database/tags/tags_test.go
+++ b/pkg/database/tags/tags_test.go
@@ -58,6 +58,7 @@ func TestTagTypeConstants(t *testing.T) {
 		{"Set", TagTypeSet, "set"},
 		{"Alt", TagTypeAlt, "alt"},
 		{"Unlicensed", TagTypeUnlicensed, "unlicensed"},
+		{"Patch", TagTypePatch, "patch"},
 		{"MameParent", TagTypeMameParent, "mameparent"},
 		{"Region", TagTypeRegion, "region"},
 		{"Year", TagTypeYear, "year"},
@@ -84,7 +85,7 @@ func TestTagTypeNaming(t *testing.T) {
 		TagTypeSave, TagTypeArcadeBoard, TagTypeCompatibility, TagTypeDisc, TagTypeDiscTotal,
 		TagTypeBased, TagTypeSearch, TagTypeMultigame, TagTypeReboxed, TagTypePort,
 		TagTypeLang, TagTypeUnfinished, TagTypeRerelease, TagTypeRev, TagTypeSet,
-		TagTypeAlt, TagTypeUnlicensed, TagTypeMameParent, TagTypeRegion, TagTypeYear,
+		TagTypeAlt, TagTypeUnlicensed, TagTypePatch, TagTypeMameParent, TagTypeRegion, TagTypeYear,
 		TagTypeVideo, TagTypeCopyright, TagTypeDump, TagTypeMedia, TagTypeExtension,
 		TagTypeUnknown, TagTypeUser,
 	}
@@ -139,7 +140,7 @@ func TestCanonicalTagDefinitionsCoverage(t *testing.T) {
 		TagTypeSave, TagTypeArcadeBoard, TagTypeCompatibility, TagTypeDisc, TagTypeDiscTotal,
 		TagTypeBased, TagTypeSearch, TagTypeMultigame, TagTypeReboxed, TagTypePort,
 		TagTypeLang, TagTypeUnfinished, TagTypeRerelease, TagTypeRev, TagTypeSet,
-		TagTypeAlt, TagTypeUnlicensed, TagTypeMameParent, TagTypeRegion, TagTypeYear,
+		TagTypeAlt, TagTypeUnlicensed, TagTypePatch, TagTypeMameParent, TagTypeRegion, TagTypeYear,
 		TagTypeVideo, TagTypeCopyright, TagTypeDump, TagTypeMedia,
 		// Note: Extension and Unknown are special and may not have predefined tags
 	}
@@ -149,8 +150,8 @@ func TestCanonicalTagDefinitionsCoverage(t *testing.T) {
 			tags, exists := CanonicalTagDefinitions[tagType]
 			assert.True(t, exists, "TagType %s must exist in CanonicalTagDefinitions", tagType)
 
-			// MameParent can be empty, but all others should have at least one tag
-			if tagType != TagTypeMameParent {
+			// MameParent and Patch use dynamic values, but all others should have predefined tags.
+			if tagType != TagTypeMameParent && tagType != TagTypePatch {
 				assert.NotEmpty(t, tags, "TagType %s should have at least one tag defined", tagType)
 			}
 		})
@@ -612,7 +613,7 @@ func TestNoTagTypeCollisions(t *testing.T) {
 		TagTypeSave, TagTypeArcadeBoard, TagTypeCompatibility, TagTypeDisc, TagTypeDiscTotal,
 		TagTypeBased, TagTypeSearch, TagTypeMultigame, TagTypeReboxed, TagTypePort,
 		TagTypeLang, TagTypeUnfinished, TagTypeRerelease, TagTypeRev, TagTypeSet,
-		TagTypeAlt, TagTypeUnlicensed, TagTypeMameParent, TagTypeRegion, TagTypeYear,
+		TagTypeAlt, TagTypeUnlicensed, TagTypePatch, TagTypeMameParent, TagTypeRegion, TagTypeYear,
 		TagTypeVideo, TagTypeCopyright, TagTypeDump, TagTypeMedia, TagTypeExtension,
 		TagTypeUnknown,
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -76,6 +76,7 @@ type StartResult struct {
 func resumeAndScheduleStartupMediaWork(
 	ctx context.Context,
 	scheduler *idle.Scheduler,
+	db *database.Database,
 	resumeIndexing func() bool,
 	runDeferred func(context.Context, bool),
 ) {
@@ -88,6 +89,10 @@ func resumeAndScheduleStartupMediaWork(
 		startupMediaIdleQuietWindow,
 		startupMediaIdleMaximumWait,
 		func(taskCtx context.Context) {
+			if db == nil || db.MediaDB == nil {
+				log.Warn().Msg("skipping deferred startup media work: media database is nil")
+				return
+			}
 			runDeferred(taskCtx, resumeStarted)
 		},
 	)
@@ -526,6 +531,7 @@ func Start(
 	resumeAndScheduleStartupMediaWork(
 		st.GetContext(),
 		idleSched,
+		db,
 		func() bool {
 			if db == nil || db.MediaDB == nil {
 				log.Warn().Msg("skipping startup index resume: database is nil")
@@ -534,8 +540,8 @@ func Start(
 			return checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
 		},
 		func(_ context.Context, resumeStarted bool) {
-			if db == nil {
-				log.Warn().Msg("skipping startup media work: database is nil")
+			if db == nil || db.MediaDB == nil {
+				log.Warn().Msg("skipping startup media work: media database is nil")
 				return
 			}
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -60,8 +60,10 @@ import (
 )
 
 const (
-	backupShutdownWarningAfter = 30 * time.Second
-	backupShutdownHardDeadline = 2 * time.Minute
+	backupShutdownWarningAfter  = 30 * time.Second
+	backupShutdownHardDeadline  = 2 * time.Minute
+	startupMediaIdleQuietWindow = 5 * time.Second
+	startupMediaIdleMaximumWait = 300 * time.Second
 )
 
 // StartResult holds the return values from Start.
@@ -69,6 +71,26 @@ type StartResult struct {
 	Stop             func() error
 	Done             <-chan struct{}
 	RestartRequested func() bool
+}
+
+func resumeAndScheduleStartupMediaWork(
+	ctx context.Context,
+	scheduler *idle.Scheduler,
+	resumeIndexing func() bool,
+	runDeferred func(context.Context, bool),
+) {
+	// Interrupted indexing is recovery work. Resume it synchronously; API
+	// activity must not postpone visible database progress.
+	resumeStarted := resumeIndexing()
+	scheduler.Schedule(
+		ctx,
+		"startup-media-work",
+		startupMediaIdleQuietWindow,
+		startupMediaIdleMaximumWait,
+		func(taskCtx context.Context) {
+			runDeferred(taskCtx, resumeStarted)
+		},
+	)
 }
 
 func waitForBackupShutdown(
@@ -499,10 +521,19 @@ func Start(
 	checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
 	checkAndResumeScraping(pl, cfg, db, st, scrapePauser)
 
-	idleSched.Schedule(
-		st.GetContext(), "startup-media-work",
-		5*time.Second, 300*time.Second,
-		func(_ context.Context) {
+	// Active gameplay pauses indexing through indexPauser independently of the
+	// API-idle scheduler used for lower-priority startup maintenance.
+	resumeAndScheduleStartupMediaWork(
+		st.GetContext(),
+		idleSched,
+		func() bool {
+			if db == nil || db.MediaDB == nil {
+				log.Warn().Msg("skipping startup index resume: database is nil")
+				return false
+			}
+			return checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
+		},
+		func(_ context.Context, resumeStarted bool) {
 			if db == nil {
 				log.Warn().Msg("skipping startup media work: database is nil")
 				return
@@ -549,11 +580,13 @@ func Start(
 						log.Warn().Err(inboxErr).Msg("failed to add inbox message about resumed media database rebuild")
 					}
 				}
+				// This legacy recovery path depends on loading the persisted slug cache,
+				// so it cannot be detected by the immediate startup check above.
+				resumeStarted = checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
 			}
 
 			runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)
-			indexResumeStarted := checkAndResumeIndexing(pl, cfg, db, st, indexPauser)
-			if !indexResumeStarted && checkAndResumeOptimization(db, st.Notifications, indexPauser) {
+			if !resumeStarted && checkAndResumeOptimization(db, st.Notifications, indexPauser) {
 				// A failed optimization revealed a corrupt database; rebuild it now
 				// rather than waiting for the next startup.
 				checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -69,6 +69,7 @@ func TestResumeAndScheduleStartupMediaWork_ResumeBypassesAPIIdleWait(t *testing.
 	resumeAndScheduleStartupMediaWork(
 		ctx,
 		scheduler,
+		&database.Database{MediaDB: testhelpers.NewMockMediaDBI()},
 		func() bool {
 			resumeCalls++
 			return true
@@ -92,6 +93,41 @@ func TestResumeAndScheduleStartupMediaWork_ResumeBypassesAPIIdleWait(t *testing.
 		assert.True(t, resumeStarted)
 	case <-time.After(2 * time.Second):
 		t.Fatal("deferred startup work did not run after maximum idle wait")
+	}
+}
+
+func TestResumeAndScheduleStartupMediaWork_SkipsDeferredWithNilMediaDB(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	scheduler := idle.NewWithClock(clock)
+	deferred := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resumeCalls := 0
+	resumeAndScheduleStartupMediaWork(
+		ctx,
+		scheduler,
+		&database.Database{},
+		func() bool {
+			resumeCalls++
+			return false
+		},
+		func(context.Context, bool) {
+			deferred <- struct{}{}
+		},
+	)
+
+	assert.Equal(t, 1, resumeCalls)
+	require.NoError(t, clock.BlockUntilContext(ctx, 1))
+	clock.Advance(startupMediaIdleQuietWindow + time.Second)
+	scheduler.Wait()
+
+	select {
+	case <-deferred:
+		t.Fatal("deferred startup work ran with nil media database")
+	default:
 	}
 }
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -40,16 +40,60 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	backupcoordinator "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/backup/coordinator"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	inboxservice "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/jonboulle/clockwork"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResumeAndScheduleStartupMediaWork_ResumeBypassesAPIIdleWait(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	scheduler := idle.NewWithClock(clock)
+	scheduler.RequestStarted()
+	deferred := make(chan bool, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer scheduler.Wait()
+	defer scheduler.RequestEnded()
+	defer cancel()
+
+	resumeCalls := 0
+	resumeAndScheduleStartupMediaWork(
+		ctx,
+		scheduler,
+		func() bool {
+			resumeCalls++
+			return true
+		},
+		func(_ context.Context, resumeStarted bool) {
+			deferred <- resumeStarted
+		},
+	)
+
+	assert.Equal(t, 1, resumeCalls, "index resume must run before waiting for API idle")
+	select {
+	case <-deferred:
+		t.Fatal("deferred startup work ran while API request was active")
+	default:
+	}
+
+	require.NoError(t, clock.BlockUntilContext(ctx, 1))
+	clock.Advance(startupMediaIdleMaximumWait + time.Second)
+	select {
+	case resumeStarted := <-deferred:
+		assert.True(t, resumeStarted)
+	case <-time.After(2 * time.Second):
+		t.Fatal("deferred startup work did not run after maximum idle wait")
+	}
+}
 
 func TestWaitForBackupShutdownDoesNotTearDownBeforeLeaseRelease(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- add canonical patch tags for bracketed and HTGDB/SmokeMonster ROM naming conventions
- persist patch tags through indexing and apply them during cached search, disambiguation, and ZapScript generation
- keep patch versions out of base-ROM revision tags and normalize patched variants to their canonical titles
- resume interrupted media indexing before API-idle startup maintenance

Validated against a reindexed MiSTer SNES library, including exact FastROM and uncensored tag filters.

Closes #1237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for patch tags in media metadata.
  * Recognizes patch information from bracketed and HTGDB-style filenames, including aliases, versions, credits, and language-specific patches.
  * Preserves patch details and ordering in generated titles.
  * Applies media-specific title parsing for games, movies, and music.
* **Bug Fixes**
  * Tag-filtered slug searches remain accurate when using cached results.
  * Interrupted startup indexing resumes promptly, including during API activity.
  * Patch tags correctly disambiguate media variants.
  * Deferred startup maintenance is skipped when the media database is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->