### PR TITLE
fix(kodi): resolve TV shows by durable identity

### DIFF
--- a/pkg/platforms/shared/kodi/client.go
+++ b/pkg/platforms/shared/kodi/client.go
@@ -302,7 +302,7 @@ func (c *Client) GetMovies(ctx context.Context) ([]Movie, error) {
 // GetTVShows retrieves all TV shows from Kodi's library
 func (c *Client) GetTVShows(ctx context.Context) ([]TVShow, error) {
 	params := VideoLibraryGetTVShowsParams{
-		Properties: []string{"title"},
+		Properties: []string{"title", "uniqueid"},
 	}
 
 	result, err := c.APIRequest(ctx, APIMethodVideoLibraryGetTVShows, params)
@@ -466,17 +466,20 @@ func (c *Client) LaunchArtist(path string) error {
 	return err
 }
 
-// LaunchTVShow launches a TV show by ID using playlist generation
+// LaunchTVShow resolves a durable show identity and launches its episodes as a playlist.
 func (c *Client) LaunchTVShow(path string) error {
-	// Parse show ID
-	idStr, err := virtualpath.ExtractSchemeID(path, shared.SchemeKodiShow)
+	reference, err := parseTVShowReference(path)
 	if err != nil {
-		return fmt.Errorf("failed to extract show ID from path: %w", err)
+		return err
 	}
 
-	showID, err := strconv.Atoi(idStr)
+	shows, err := c.GetTVShows(context.Background())
 	if err != nil {
-		return fmt.Errorf("failed to parse show ID %q: %w", idStr, err)
+		return fmt.Errorf("failed to resolve current Kodi TV show ID: %w", err)
+	}
+	showID, err := resolveTVShowID(reference, shows)
+	if err != nil {
+		return err
 	}
 
 	// Step 1: Clear video playlist (playlistid=1)

--- a/pkg/platforms/shared/kodi/client_test.go
+++ b/pkg/platforms/shared/kodi/client_test.go
@@ -543,6 +543,10 @@ func TestClient_GetTVShows_MakesCorrectAPICall(t *testing.T) {
 					map[string]any{
 						"tvshowid": 1,
 						"label":    "Breaking Bad",
+						"uniqueid": map[string]any{
+							"tvdb": "81189",
+							"imdb": "tt0903747",
+						},
 					},
 					map[string]any{
 						"tvshowid": 2,
@@ -568,6 +572,10 @@ func TestClient_GetTVShows_MakesCorrectAPICall(t *testing.T) {
 	// Verify first TV show
 	assert.Equal(t, 1, tvShows[0].ID)
 	assert.Equal(t, "Breaking Bad", tvShows[0].Label)
+	assert.Equal(t, map[string]string{
+		"tvdb": "81189",
+		"imdb": "tt0903747",
+	}, tvShows[0].UniqueIDs)
 
 	// Verify second TV show
 	assert.Equal(t, 2, tvShows[1].ID)
@@ -577,6 +585,11 @@ func TestClient_GetTVShows_MakesCorrectAPICall(t *testing.T) {
 	assert.Equal(t, "2.0", receivedPayload["jsonrpc"])
 	assert.Equal(t, "VideoLibrary.GetTVShows", receivedPayload["method"])
 	assert.NotNil(t, receivedPayload["id"])
+	params, ok := receivedPayload["params"].(map[string]any)
+	require.True(t, ok)
+	properties, ok := params["properties"].([]any)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []any{"title", "uniqueid"}, properties)
 }
 
 func TestClient_GetEpisodes_MakesCorrectAPICall(t *testing.T) {
@@ -1205,8 +1218,7 @@ func TestClient_LaunchArtist_MakesCorrectAPICall(t *testing.T) {
 func TestClient_LaunchTVShow_MakesCorrectAPICall(t *testing.T) {
 	t.Parallel()
 
-	// This test drives the implementation of LaunchTVShow to make playlist-based API requests
-	// It should: 1) Clear video playlist, 2) Get episodes for the show, 3) Add episodes to playlist, 4) Start playback
+	// Resolve the current Kodi ID before building and opening the show playlist.
 
 	var receivedPayloads []map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1224,6 +1236,22 @@ func TestClient_LaunchTVShow_MakesCorrectAPICall(t *testing.T) {
 		// Mock different responses based on method
 		var response map[string]any
 		switch method {
+		case "VideoLibrary.GetTVShows":
+			response = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      payload["id"],
+				"result": map[string]any{
+					"tvshows": []map[string]any{
+						{
+							"tvshowid": 456,
+							"label":    "Breaking Bad",
+							"uniqueid": map[string]any{
+								"tvdb": "81189",
+							},
+						},
+					},
+				},
+			}
 		case "Playlist.Clear":
 			response = map[string]any{
 				"jsonrpc": "2.0",
@@ -1280,28 +1308,31 @@ func TestClient_LaunchTVShow_MakesCorrectAPICall(t *testing.T) {
 	client.SetURL(server.URL)
 
 	// Test launching a TV show
-	showPath := "kodi-show://456/Breaking Bad"
+	showPath := "kodi-show://106/Breaking Bad?tvdb=81189"
 	err := client.LaunchTVShow(showPath)
 	require.NoError(t, err)
 
 	// Verify the correct sequence of API calls was made
-	require.Len(t, receivedPayloads, 4, "Should make 4 API calls: Clear, GetEpisodes, Add, Open")
+	require.Len(t, receivedPayloads, 5, "Should resolve the show, then clear, populate, and open its playlist")
 
-	// 1. Clear video playlist (playlistid=1)
-	assert.Equal(t, "Playlist.Clear", receivedPayloads[0]["method"])
-	clearParams, ok := receivedPayloads[0]["params"].(map[string]any)
+	// 1. Resolve the current Kodi TV show ID.
+	assert.Equal(t, "VideoLibrary.GetTVShows", receivedPayloads[0]["method"])
+
+	// 2. Clear video playlist (playlistid=1)
+	assert.Equal(t, "Playlist.Clear", receivedPayloads[1]["method"])
+	clearParams, ok := receivedPayloads[1]["params"].(map[string]any)
 	require.True(t, ok, "params should be a map[string]any")
 	assert.Equal(t, 1, int(clearParams["playlistid"].(float64)))
 
-	// 2. Get episodes for the show
-	assert.Equal(t, "VideoLibrary.GetEpisodes", receivedPayloads[1]["method"])
-	episodesParams, ok := receivedPayloads[1]["params"].(map[string]any)
+	// 3. Get episodes for the show
+	assert.Equal(t, "VideoLibrary.GetEpisodes", receivedPayloads[2]["method"])
+	episodesParams, ok := receivedPayloads[2]["params"].(map[string]any)
 	require.True(t, ok, "params should be a map[string]any")
 	assert.Equal(t, 456, int(episodesParams["tvshowid"].(float64)))
 
-	// 3. Add episodes to playlist
-	assert.Equal(t, "Playlist.Add", receivedPayloads[2]["method"])
-	addParams, ok := receivedPayloads[2]["params"].(map[string]any)
+	// 4. Add episodes to playlist
+	assert.Equal(t, "Playlist.Add", receivedPayloads[3]["method"])
+	addParams, ok := receivedPayloads[3]["params"].(map[string]any)
 	require.True(t, ok, "params should be a map[string]any")
 	assert.Equal(t, 1, int(addParams["playlistid"].(float64)))
 
@@ -1314,9 +1345,9 @@ func TestClient_LaunchTVShow_MakesCorrectAPICall(t *testing.T) {
 	require.True(t, ok, "first item should be a map[string]any")
 	assert.Equal(t, 123, int(firstItem["episodeid"].(float64)))
 
-	// 4. Start playbook with playlist
-	assert.Equal(t, "Player.Open", receivedPayloads[3]["method"])
-	openParams, ok := receivedPayloads[3]["params"].(map[string]any)
+	// 5. Start playback with playlist
+	assert.Equal(t, "Player.Open", receivedPayloads[4]["method"])
+	openParams, ok := receivedPayloads[4]["params"].(map[string]any)
 	require.True(t, ok, "params should be a map[string]any")
 	item, ok := openParams["item"].(map[string]any)
 	require.True(t, ok, "item should be a map[string]any")

--- a/pkg/platforms/shared/kodi/interface.go
+++ b/pkg/platforms/shared/kodi/interface.go
@@ -93,8 +93,8 @@ type KodiClient interface {
 	// Path format: "kodi-artist://[id]/[name]"
 	LaunchArtist(path string) error
 
-	// LaunchTVShow launches a TV show by ID using playlist generation
-	// Path format: "kodi-show://[id]/[name]"
+	// LaunchTVShow launches a TV show using its current Kodi ID or durable provider identity.
+	// Path format: "kodi-show://[id]/[name]?[provider]=[identity]"
 	LaunchTVShow(path string) error
 
 	// GetURL returns the current Kodi API URL

--- a/pkg/platforms/shared/kodi/scanner.go
+++ b/pkg/platforms/shared/kodi/scanner.go
@@ -184,7 +184,7 @@ func ScanTVShows(
 	for _, show := range shows {
 		results = append(results, platforms.ScanResult{
 			Name:  show.Label,
-			Path:  virtualpath.CreateVirtualPath(shared.SchemeKodiShow, strconv.Itoa(show.ID), show.Label),
+			Path:  createTVShowVirtualPath(show),
 			NoExt: true,
 		})
 	}

--- a/pkg/platforms/shared/kodi/scanner_test.go
+++ b/pkg/platforms/shared/kodi/scanner_test.go
@@ -426,9 +426,22 @@ func TestScanTVShows(t *testing.T) {
 
 	// Mock TV shows data
 	expectedTVShows := []TVShow{
-		{ID: 1, Label: "Breaking Bad"},
+		{
+			ID:    1,
+			Label: "Breaking Bad",
+			UniqueIDs: map[string]string{
+				"imdb": "tt0903747",
+				"tvdb": "81189",
+			},
+		},
 		{ID: 2, Label: "The Wire"},
-		{ID: 3, Label: "Better Call Saul"},
+		{
+			ID:    3,
+			Label: "Better Call Saul",
+			UniqueIDs: map[string]string{
+				"tmdb": "60059",
+			},
+		},
 	}
 
 	// Set up mock expectation
@@ -443,13 +456,13 @@ func TestScanTVShows(t *testing.T) {
 	assert.Len(t, results, 3)
 
 	assert.Equal(t, "Breaking Bad", results[0].Name)
-	assert.Equal(t, "kodi-show://1/Breaking%20Bad", results[0].Path)
+	assert.Equal(t, "kodi-show://1/Breaking%20Bad?tvdb=81189&imdb=tt0903747", results[0].Path)
 
 	assert.Equal(t, "The Wire", results[1].Name)
 	assert.Equal(t, "kodi-show://2/The%20Wire", results[1].Path)
 
 	assert.Equal(t, "Better Call Saul", results[2].Name)
-	assert.Equal(t, "kodi-show://3/Better%20Call%20Saul", results[2].Path)
+	assert.Equal(t, "kodi-show://3/Better%20Call%20Saul?tmdb=60059", results[2].Path)
 
 	// Verify mock was called
 	mockClient.AssertExpectations(t)

--- a/pkg/platforms/shared/kodi/tvshow_identity.go
+++ b/pkg/platforms/shared/kodi/tvshow_identity.go
@@ -1,0 +1,215 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package kodi
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/virtualpath"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
+)
+
+const (
+	tvShowProviderTVDB = "tvdb"
+	tvShowProviderTMDB = "tmdb"
+	tvShowProviderIMDb = "imdb"
+)
+
+var tvShowIdentityProviders = []string{
+	tvShowProviderTVDB,
+	tvShowProviderTMDB,
+	tvShowProviderIMDb,
+}
+
+type tvShowReference struct {
+	UniqueIDs map[string]string
+	Name      string
+	LegacyID  int
+}
+
+func createTVShowVirtualPath(show TVShow) string {
+	path := virtualpath.CreateVirtualPath(shared.SchemeKodiShow, strconv.Itoa(show.ID), show.Label)
+	query := make([]string, 0, len(tvShowIdentityProviders))
+	for _, provider := range tvShowIdentityProviders {
+		value, found := lookupTVShowUniqueID(show.UniqueIDs, provider)
+		if !found || strings.TrimSpace(value) == "" {
+			continue
+		}
+		query = append(query, provider+"="+url.QueryEscape(value))
+	}
+	if len(query) == 0 {
+		return path
+	}
+	return path + "?" + strings.Join(query, "&")
+}
+
+func parseTVShowReference(path string) (tvShowReference, error) {
+	parsed, err := virtualpath.ParseVirtualPathStr(path)
+	if err != nil {
+		return tvShowReference{}, fmt.Errorf("failed to parse TV show path: %w", err)
+	}
+	if !strings.EqualFold(parsed.Scheme, shared.SchemeKodiShow) {
+		return tvShowReference{}, fmt.Errorf(
+			"tv show path scheme mismatch: expected %s, got %s",
+			shared.SchemeKodiShow,
+			parsed.Scheme,
+		)
+	}
+
+	legacyID, err := strconv.Atoi(parsed.ID)
+	if err != nil {
+		return tvShowReference{}, fmt.Errorf("failed to parse show ID %q: %w", parsed.ID, err)
+	}
+
+	uniqueIDs, err := parseTVShowUniqueIDs(virtualpath.ParseURIComponents(path).Query)
+	if err != nil {
+		return tvShowReference{}, err
+	}
+
+	return tvShowReference{
+		UniqueIDs: uniqueIDs,
+		Name:      parsed.Name,
+		LegacyID:  legacyID,
+	}, nil
+}
+
+func parseTVShowUniqueIDs(rawQuery string) (map[string]string, error) {
+	if rawQuery == "" {
+		return map[string]string{}, nil
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse TV show identity query: %w", err)
+	}
+
+	uniqueIDs := make(map[string]string, len(tvShowIdentityProviders))
+	for _, provider := range tvShowIdentityProviders {
+		var providerValues []string
+		for key, queryValues := range values {
+			if strings.EqualFold(key, provider) {
+				providerValues = append(providerValues, queryValues...)
+			}
+		}
+
+		for _, value := range providerValues {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			if existing, found := uniqueIDs[provider]; found && !strings.EqualFold(existing, value) {
+				return nil, fmt.Errorf("conflicting %s TV show identities", provider)
+			}
+			uniqueIDs[provider] = value
+		}
+	}
+	return uniqueIDs, nil
+}
+
+func resolveTVShowID(reference tvShowReference, shows []TVShow) (int, error) {
+	if len(reference.UniqueIDs) > 0 {
+		identityMatches := matchingTVShowsByIdentity(reference.UniqueIDs, shows)
+		switch len(identityMatches) {
+		case 1:
+			return identityMatches[0].ID, nil
+		case 0:
+			// Provider metadata can be absent or corrected over time. Exact title
+			// matching below remains a safe fallback for uniquely named shows.
+		default:
+			titleMatches := matchingTVShowsByTitle(reference.Name, identityMatches)
+			if len(titleMatches) == 1 {
+				return titleMatches[0].ID, nil
+			}
+			return 0, errors.New("multiple Kodi TV shows match stored provider identities")
+		}
+	}
+
+	for _, show := range shows {
+		if show.ID != reference.LegacyID {
+			continue
+		}
+		if reference.Name == "" || equalTVShowTitle(show.Label, reference.Name) {
+			return show.ID, nil
+		}
+		break
+	}
+
+	titleMatches := matchingTVShowsByTitle(reference.Name, shows)
+	if len(titleMatches) == 1 {
+		return titleMatches[0].ID, nil
+	}
+	if len(titleMatches) > 1 {
+		return 0, fmt.Errorf("multiple Kodi TV shows match title %q", reference.Name)
+	}
+	return 0, fmt.Errorf("kodi TV show %q is no longer available", reference.Name)
+}
+
+func matchingTVShowsByIdentity(uniqueIDs map[string]string, shows []TVShow) []TVShow {
+	matches := make([]TVShow, 0, 1)
+	for _, show := range shows {
+		matched := false
+		conflicted := false
+		for provider, expected := range uniqueIDs {
+			actual, found := lookupTVShowUniqueID(show.UniqueIDs, provider)
+			if !found || strings.TrimSpace(actual) == "" {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(actual), strings.TrimSpace(expected)) {
+				matched = true
+			} else {
+				conflicted = true
+			}
+		}
+		if matched && !conflicted {
+			matches = append(matches, show)
+		}
+	}
+	return matches
+}
+
+func matchingTVShowsByTitle(name string, shows []TVShow) []TVShow {
+	if strings.TrimSpace(name) == "" {
+		return nil
+	}
+	matches := make([]TVShow, 0, 1)
+	for _, show := range shows {
+		if equalTVShowTitle(show.Label, name) {
+			matches = append(matches, show)
+		}
+	}
+	return matches
+}
+
+func lookupTVShowUniqueID(uniqueIDs map[string]string, provider string) (string, bool) {
+	for key, value := range uniqueIDs {
+		if strings.EqualFold(key, provider) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func equalTVShowTitle(first, second string) bool {
+	return strings.EqualFold(strings.TrimSpace(first), strings.TrimSpace(second))
+}

--- a/pkg/platforms/shared/kodi/tvshow_identity_test.go
+++ b/pkg/platforms/shared/kodi/tvshow_identity_test.go
@@ -1,0 +1,100 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package kodi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveTVShowID_UsesProviderIdentityAfterKodiIDChanges(t *testing.T) {
+	t.Parallel()
+
+	reference, err := parseTVShowReference(
+		"kodi-show://106/The%20Office?tvdb=73244&tmdb=2316&imdb=tt0386676",
+	)
+	require.NoError(t, err)
+
+	shows := []TVShow{
+		{
+			ID:    106,
+			Label: "One-Punch Man",
+			UniqueIDs: map[string]string{
+				"tvdb": "293088",
+			},
+		},
+		{
+			ID:    205,
+			Label: "The Office",
+			UniqueIDs: map[string]string{
+				"tvdb": "73244",
+				"tmdb": "2316",
+				"imdb": "tt0386676",
+			},
+		},
+	}
+
+	showID, err := resolveTVShowID(reference, shows)
+	require.NoError(t, err)
+	assert.Equal(t, 205, showID)
+}
+
+func TestResolveTVShowID_RepairsLegacyPathByExactTitle(t *testing.T) {
+	t.Parallel()
+
+	reference, err := parseTVShowReference("kodi-show://106/The%20Office")
+	require.NoError(t, err)
+
+	shows := []TVShow{
+		{ID: 106, Label: "One-Punch Man"},
+		{ID: 205, Label: "The Office"},
+	}
+
+	showID, err := resolveTVShowID(reference, shows)
+	require.NoError(t, err)
+	assert.Equal(t, 205, showID)
+}
+
+func TestResolveTVShowID_RejectsAmbiguousLegacyTitle(t *testing.T) {
+	t.Parallel()
+
+	reference, err := parseTVShowReference("kodi-show://106/The%20Office")
+	require.NoError(t, err)
+
+	shows := []TVShow{
+		{ID: 106, Label: "One-Punch Man"},
+		{ID: 205, Label: "The Office"},
+		{ID: 206, Label: "The Office"},
+	}
+
+	_, err = resolveTVShowID(reference, shows)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple Kodi TV shows")
+}
+
+func TestParseTVShowReference_RejectsConflictingProviderValues(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseTVShowReference("kodi-show://106/The%20Office?tvdb=73244&TVDB=99999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting tvdb")
+}

--- a/pkg/platforms/shared/kodi/types.go
+++ b/pkg/platforms/shared/kodi/types.go
@@ -38,8 +38,9 @@ type Movie struct {
 
 // TVShow represents a TV show in Kodi's library
 type TVShow struct {
-	Label string `json:"label"`
-	ID    int    `json:"tvshowid"`
+	UniqueIDs map[string]string `json:"uniqueid,omitempty"`
+	Label     string            `json:"label"`
+	ID        int               `json:"tvshowid"`
 }
 
 // Episode represents a TV episode in Kodi's library


### PR DESCRIPTION
## Summary

- include Kodi TVDB, TMDB, and IMDb identities in scanned `kodi-show` paths
- resolve current Kodi database IDs before launching TV show playlists
- preserve legacy direct cards by validating cached IDs and falling back to unique exact-title matches
- reject ambiguous matches instead of launching unrelated media

Kodi numeric TV show IDs can change after a library rebuild or Jellyfin account resync. Provider identities keep new direct cards stable while cached numeric ID and existing URI format retain backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TV show playback reliability when Kodi IDs change.
  * Preserved TV show links using provider identities and repaired compatible legacy links.
  * Prevented playback when show references are ambiguous or conflicting.

* **Improvements**
  * TV show results now include durable provider identity information, helping links remain valid across library updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->