### PR TITLE
perf(audio): bypass resampling for 48 kHz sources

### DIFF
--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -286,7 +286,7 @@ func (*LongformPlaybackManager) slotKey(slot string) (string, error) {
 // background goroutine. This bounds memory use to ringBufferFrames regardless of
 // file length and keeps decoding off the malgo audio thread.
 type streamingSource struct {
-	resampler      beep.Streamer
+	streamer       beep.Streamer
 	decoder        beep.StreamSeekCloser
 	onDrain        func(natural bool)
 	file           *os.File
@@ -313,6 +313,13 @@ type streamingSource struct {
 	eof            atomic.Bool
 	stopped        atomic.Bool
 	paused         atomic.Bool
+}
+
+func streamerAtTargetSampleRate(source beep.Streamer, sourceRate beep.SampleRate, quality int) beep.Streamer {
+	if sourceRate == beep.SampleRate(targetSampleRate) {
+		return source
+	}
+	return beep.Resample(quality, sourceRate, beep.SampleRate(targetSampleRate), source)
 }
 
 // newStreamingSource opens path for streaming decode and returns a ready source.
@@ -352,7 +359,7 @@ func newStreamingSource(path string, volume float64, quality int) (*streamingSou
 		totalFrames = int64(float64(n) * float64(targetSampleRate) / float64(format.SampleRate))
 	}
 
-	resampler := beep.Resample(quality, format.SampleRate, beep.SampleRate(targetSampleRate), decoder)
+	streamer := streamerAtTargetSampleRate(decoder, format.SampleRate, quality)
 
 	return &streamingSource{
 		ring:        make([][2]float64, ringBufferFrames),
@@ -364,7 +371,7 @@ func newStreamingSource(path string, volume float64, quality int) (*streamingSou
 		wakeCh:      make(chan struct{}, 1),
 		decoder:     decoder,
 		file:        f,
-		resampler:   resampler,
+		streamer:    streamer,
 		chunk:       make([][2]float64, decodeChunkFrames),
 	}, nil
 }
@@ -410,8 +417,7 @@ prefetchLoop:
 			if err := s.decoder.Seek(int(seekFrame)); err != nil {
 				log.Warn().Err(err).Str("path", s.path).Msg("seek audio decoder")
 			}
-			s.resampler = beep.Resample(s.quality, beep.SampleRate(s.sourceRate),
-				beep.SampleRate(targetSampleRate), s.decoder)
+			s.streamer = streamerAtTargetSampleRate(s.decoder, beep.SampleRate(s.sourceRate), s.quality)
 			s.readPos.Store(0)
 			s.writePos.Store(0)
 			s.eof.Store(false)
@@ -445,7 +451,7 @@ prefetchLoop:
 
 			space := len(s.ring) - boundedFrameCount(buffered, len(s.ring))
 			n := min(space, len(s.chunk))
-			written, ok := s.resampler.Stream(s.chunk[:n])
+			written, ok := s.streamer.Stream(s.chunk[:n])
 			if s.seekPending.Load() {
 				continue prefetchLoop
 			}

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
+	"github.com/gopxl/beep/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -319,15 +320,37 @@ func TestNewStreamingSource_WAVInitializesStreamingFields(t *testing.T) {
 	assert.Len(t, s.ring, ringBufferFrames)
 	assert.Len(t, s.chunk, decodeChunkFrames)
 	assert.NotNil(t, s.wakeCh)
-	assert.NotNil(t, s.resampler)
+	assert.IsType(t, (*beep.Resampler)(nil), s.streamer)
+}
+
+func TestNewStreamingSource_TargetRateUsesDecoderDirectly(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "audio.wav")
+	require.NoError(t, os.WriteFile(path, wavWithSamplesAtRate(0, targetSampleRate), 0o600))
+
+	s, err := newStreamingSource(path, 1.0, resampleQuality)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, s.decoder.Close())
+	}()
+
+	assert.Equal(t, targetSampleRate, s.sourceRate)
+	assert.Same(t, s.decoder, s.streamer)
 }
 
 // wavWithSamples builds a minimal mono 16-bit 44.1 kHz WAV containing n silent samples.
 func wavWithSamples(n uint32) []byte {
+	return wavWithSamplesAtRate(n, 44100)
+}
+
+func wavWithSamplesAtRate(n, sampleRate uint32) []byte {
 	dataSize := n * 2
 	header := validWAVHeader()
-	// Patch RIFF size and data chunk size for the sample payload.
+	// Patch sample rate, byte rate, RIFF size, and data chunk size for the sample payload.
 	binary.LittleEndian.PutUint32(header[4:8], 36+dataSize)
+	binary.LittleEndian.PutUint32(header[24:28], sampleRate)
+	binary.LittleEndian.PutUint32(header[28:32], sampleRate*2)
 	binary.LittleEndian.PutUint32(header[40:44], dataSize)
 	return append(header, make([]byte, dataSize)...)
 }
@@ -335,25 +358,41 @@ func wavWithSamples(n uint32) []byte {
 func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 	t.Parallel()
 
-	// Both qualities: the seek path rebuilds the resampler from the source's
-	// stored quality, which must work for low-power platforms too.
+	// Both qualities and sample-rate paths: seek must preserve low-power
+	// resampling and continue bypassing resampling for target-rate sources.
 	for _, tc := range []struct {
-		name    string
-		quality int
+		name       string
+		quality    int
+		sourceRate uint32
+		direct     bool
 	}{
-		{name: "default quality", quality: resampleQuality},
-		{name: "low power quality", quality: lowPowerResampleQuality},
+		{name: "default quality resampled", quality: resampleQuality, sourceRate: 44100},
+		{name: "low power quality resampled", quality: lowPowerResampleQuality, sourceRate: 44100},
+		{
+			name: "default quality direct", quality: resampleQuality,
+			sourceRate: targetSampleRate, direct: true,
+		},
+		{
+			name: "low power quality direct", quality: lowPowerResampleQuality,
+			sourceRate: targetSampleRate, direct: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			path := filepath.Join(t.TempDir(), "audio.wav")
-			require.NoError(t, os.WriteFile(path, wavWithSamples(4410), 0o600)) // 0.1 s of audio
+			sampleCount := tc.sourceRate / 10
+			require.NoError(t, os.WriteFile(path, wavWithSamplesAtRate(sampleCount, tc.sourceRate), 0o600))
 
 			s, err := newStreamingSource(path, 1.0, tc.quality)
 			require.NoError(t, err)
 			s.startPrefetch()
-			t.Cleanup(s.stopAndDeregister)
+			stopped := false
+			t.Cleanup(func() {
+				if !stopped {
+					s.stopAndDeregister()
+				}
+			})
 
 			// Wait for the prefetch goroutine to fully decode the file.
 			require.Eventually(t, func() bool {
@@ -372,6 +411,13 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 			}, 5*time.Second, 5*time.Millisecond, "seek after EOF should refill the ring")
 
 			assert.Equal(t, tc.quality, s.quality, "seek must preserve the source's resample quality")
+			s.stopAndDeregister()
+			stopped = true
+			if tc.direct {
+				assert.Same(t, s.decoder, s.streamer)
+			} else {
+				assert.IsType(t, (*beep.Resampler)(nil), s.streamer)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- use decoded 48 kHz audio directly instead of running 1:1 interpolation
- retain resampling for differing rates during initial playback and seek rebuilds
- cover default and low-power streaming paths at 44.1 kHz and 48 kHz

Closes #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved audio playback for sources already using the target sample rate by avoiding unnecessary resampling.
  * Preserved configured resampling behavior for sources with different sample rates.
* **Bug Fixes**
  * Improved seeking and prefetch decoding across both direct playback and resampled audio.
  * Expanded coverage for seek-after-end playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->