### PR TITLE
fix: make random launches reliable

### DIFF
--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2946,6 +2946,30 @@ func (db *MediaDB) RandomGameWithQuery(ctx context.Context, query *database.Medi
 		return result, ErrNullSQL
 	}
 
+	// Per-system counts preserve uniform media-row weighting while narrowing
+	// broad system scopes before random row selection touches the Media table.
+	if query.PathPrefix == "" && query.PathGlob == "" && len(query.Systems) > 1 {
+		started := time.Now()
+		counts, err := db.SystemMediaCounts(ctx, query.Tags)
+		if err != nil {
+			return result, fmt.Errorf("failed to get system media counts for random selection: %w", err)
+		}
+		selectedSystem, err := selectWeightedSystem(counts, query.Systems)
+		if err != nil {
+			return result, err
+		}
+		log.Debug().
+			Int("systems", len(query.Systems)).
+			Int("tagFilters", len(query.Tags)).
+			Str("selectedSystem", selectedSystem).
+			Dur("duration", time.Since(started)).
+			Msg("narrowed weighted random media scope")
+
+		narrowed := *query
+		narrowed.Systems = []string{selectedSystem}
+		return db.RandomGameWithQuery(ctx, &narrowed)
+	}
+
 	// Use one full matching scope so systems are weighted by their matching
 	// media rows and tag filters cannot choose an empty system first.
 	// Check MediaCountCache before repeating the count query.
@@ -2964,6 +2988,49 @@ func (db *MediaDB) RandomGameWithQuery(ctx context.Context, query *database.Medi
 	}
 
 	return db.randomGameWithFreshStats(ctx, query)
+}
+
+func selectWeightedSystem(
+	counts []database.SystemMediaCount,
+	systems []string,
+) (string, error) {
+	return selectWeightedSystemUsing(counts, systems, helpers.RandomInt)
+}
+
+func selectWeightedSystemUsing(
+	counts []database.SystemMediaCount,
+	systems []string,
+	randomInt func(int) (int, error),
+) (string, error) {
+	requested := make(map[string]struct{}, len(systems))
+	for _, systemID := range systems {
+		requested[systemID] = struct{}{}
+	}
+
+	eligible := make([]database.SystemMediaCount, 0, len(systems))
+	total := 0
+	for _, count := range counts {
+		if _, ok := requested[count.SystemID]; !ok || count.Count <= 0 {
+			continue
+		}
+		eligible = append(eligible, count)
+		total += count.Count
+	}
+	if total == 0 {
+		return "", sql.ErrNoRows
+	}
+
+	offset, err := randomInt(total)
+	if err != nil {
+		return "", fmt.Errorf("failed to select weighted random system: %w", err)
+	}
+	for _, count := range eligible {
+		if offset < count.Count {
+			return count.SystemID, nil
+		}
+		offset -= count.Count
+	}
+	return "", sql.ErrNoRows
 }
 
 func (db *MediaDB) randomGameWithFreshStats(

--- a/pkg/database/mediadb/sql_helpers.go
+++ b/pkg/database/mediadb/sql_helpers.go
@@ -54,15 +54,18 @@ func mediaRecursivePathPrefix(path string) string {
 func buildMediaQueryWhereClause(query *database.MediaQuery) (whereClause string, args []any) {
 	var whereConditions []string
 
-	// System filtering
+	// Filter through Media.SystemDBID so broad system scopes use the
+	// partial covering index instead of joining every Media row through titles.
 	if len(query.Systems) > 0 {
 		placeholders := make([]string, len(query.Systems))
 		for i, system := range query.Systems {
 			placeholders[i] = "?"
 			args = append(args, system)
 		}
-		whereConditions = append(whereConditions,
-			fmt.Sprintf("Systems.SystemID IN (%s)", strings.Join(placeholders, ",")))
+		whereConditions = append(whereConditions, fmt.Sprintf(
+			"Media.SystemDBID IN (SELECT Systems.DBID FROM Systems WHERE Systems.SystemID IN (%s))",
+			strings.Join(placeholders, ","),
+		))
 	}
 
 	// Recursive paths use a boundary-delimited indexed range, so a scope such

--- a/pkg/database/mediadb/sql_random_bench_test.go
+++ b/pkg/database/mediadb/sql_random_bench_test.go
@@ -49,6 +49,14 @@ func benchmarkRandomGameQuery(b *testing.B, rows int) {
 	mediaDB, cleanup := setupBrowseBenchMediaDB(b)
 	defer cleanup()
 	rootDir := seedRandomGameBenchmark(b, mediaDB, rows)
+	seedRandomGameBrowseCounts(b, mediaDB, rows)
+	broadSystems := []string{
+		"3DO", "AdventureVision", "AmigaCD32", "Arcadia", "Atari2600", "Atari5200", "Atari7800", "Astrocade",
+		"CasioPV1000", "CDI", "ChannelF", "ColecoVision", "FDS", "Genesis", "Sega32X", "Intellivision",
+		"Jaguar", "JaguarCD", "Odyssey2", "MasterSystem", "NeoGeo", "NeoGeoCD", "NES", "Nintendo64", "PSX",
+		"Saturn", "MegaCD", "SG1000", "SNES", "SuperGameboy", "SuperGrafx", "TurboGrafx16", "TurboGrafx16CD",
+		"VC4000", "Vectrex", "VirtualBoy", "CreatiVision",
+	}
 
 	queries := []struct {
 		name  string
@@ -57,6 +65,7 @@ func benchmarkRandomGameQuery(b *testing.B, rows int) {
 	}{
 		{name: "all", query: database.MediaQuery{Systems: []string{"NES"}}},
 		{name: "all-cold", cold: true, query: database.MediaQuery{Systems: []string{"NES"}}},
+		{name: "broad-systems-cold", cold: true, query: database.MediaQuery{Systems: broadSystems}},
 		{name: "favorite-sparse", query: database.MediaQuery{
 			Systems: []string{"NES"},
 			Tags:    []zapscript.TagFilter{{Type: "user", Value: "favorite"}},
@@ -164,6 +173,29 @@ func seedRandomGameBenchmark(b testing.TB, mediaDB *MediaDB, rows int) string {
 	return rootDir
 }
 
+func seedRandomGameBrowseCounts(b testing.TB, mediaDB *MediaDB, rows int) {
+	b.Helper()
+	ctx := context.Background()
+	db := mediaDB.sql.Load()
+
+	_, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO BrowseDirs (Path, Name, IsVirtual) VALUES ('/', '/', 0)`)
+	require.NoError(b, err)
+	var rootDirDBID int64
+	require.NoError(b, db.QueryRowContext(ctx,
+		"SELECT DBID FROM BrowseDirs WHERE Path = '/'",
+	).Scan(&rootDirDBID))
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO BrowseDirCounts
+			(ParentDirDBID, ChildDirDBID, SystemDBID, FileCount)
+		VALUES (?, ?, 1, ?)`, rootDirDBID, rootDirDBID, rows)
+	require.NoError(b, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)`,
+		DBConfigBrowseIndexVersion, browseCacheSchemaVersion)
+	require.NoError(b, err)
+}
+
 func TestRandomGameQueryPlansUseExistingIndexes(t *testing.T) {
 	t.Parallel()
 
@@ -175,6 +207,14 @@ func TestRandomGameQueryPlansUseExistingIndexes(t *testing.T) {
 	pathPlan := randomQueryPlan(t, mediaDB.sql.Load(),
 		"SELECT COUNT(*), MIN(Media.DBID), MAX(Media.DBID) FROM Media "+pathWhere, pathArgs...)
 	assertRandomPlanContains(t, pathPlan, "path_idx")
+
+	broadSystems := &database.MediaQuery{Systems: []string{
+		"NES", "SNES", "Genesis", "Saturn", "PSX", "Nintendo64", "Atari2600", "AmigaCD32",
+	}}
+	systemWhere, systemArgs := buildMediaQueryWhereClause(broadSystems)
+	systemPlan := randomQueryPlan(t, mediaDB.sql.Load(),
+		"SELECT COUNT(*), MIN(Media.DBID), MAX(Media.DBID) FROM Media "+systemWhere, systemArgs...)
+	assertRandomPlanContains(t, systemPlan, "media_system_present_path_idx")
 
 	tagQuery := &database.MediaQuery{
 		Systems: []string{"NES"},

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -1937,11 +1937,13 @@ func sqlSelectRandomGameWithStatsUsing(
 	}
 
 	whereClause, baseArgs := buildMediaQueryWhereClause(query)
-	const selectColumns = `
+	selectColumns := `
 		SELECT Systems.SystemID, Media.Path, Media.DBID
 		FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID`
+		INNER JOIN Systems ON Systems.DBID = Media.SystemDBID`
+	if query.PathGlob != "" {
+		selectColumns += "\n\t\tINNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID"
+	}
 
 	maxInt := int64(^uint(0) >> 1)
 	var rangeSize int64
@@ -2000,13 +2002,12 @@ func sqlRandomGameWithQueryAndStats(
 	// Use shared helper to build WHERE clause and arguments
 	whereClause, args := buildMediaQueryWhereClause(query)
 
-	// Path-prefix and tag filters reference Media directly. Avoid joining every
-	// matching row to metadata tables unless those tables supply a filter.
+	// System, path-prefix, and tag filters reference Media directly. Only title
+	// glob matching needs the title table during the full-scope statistics scan.
 	statsFrom := "FROM Media"
-	if len(query.Systems) > 0 || query.PathGlob != "" {
+	if query.PathGlob != "" {
 		statsFrom = `FROM Media
-		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID
-		INNER JOIN Systems ON Systems.DBID = MediaTitles.SystemDBID`
+		INNER JOIN MediaTitles ON MediaTitles.DBID = Media.MediaTitleDBID`
 	}
 
 	// Step 1: Get count, min DBID, and max DBID for this query

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -829,6 +830,96 @@ func TestSQLRandomGameWithQuery_PathPrefixStatsAvoidMetadataJoins(t *testing.T) 
 
 	require.NoError(t, err)
 	assert.Equal(t, pathPrefix+"game.mra", result.Path)
+	assert.Equal(t, MediaStats{Count: 1, MinDBID: 42, MaxDBID: 42}, stats)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSelectWeightedSystemUsing(t *testing.T) {
+	t.Parallel()
+
+	counts := []database.SystemMediaCount{
+		{SystemID: "NES", Count: 2},
+		{SystemID: "SNES", Count: 3},
+		{SystemID: "Genesis", Count: 100},
+		{SystemID: "Empty", Count: 0},
+	}
+	systems := []string{"NES", "SNES", "Empty"}
+
+	tests := []struct {
+		name   string
+		want   string
+		offset int
+	}{
+		{name: "first NES row", offset: 0, want: "NES"},
+		{name: "last NES row", offset: 1, want: "NES"},
+		{name: "first SNES row", offset: 2, want: "SNES"},
+		{name: "last SNES row", offset: 4, want: "SNES"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected, err := selectWeightedSystemUsing(
+				counts,
+				systems,
+				func(total int) (int, error) {
+					require.Equal(t, 5, total)
+					return tt.offset, nil
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, selected)
+		})
+	}
+}
+
+func TestSelectWeightedSystemUsing_NoMatchingMedia(t *testing.T) {
+	t.Parallel()
+
+	selected, err := selectWeightedSystemUsing(
+		[]database.SystemMediaCount{{SystemID: "NES", Count: 10}},
+		[]string{"SNES"},
+		func(int) (int, error) {
+			t.Fatal("random selection should not run without eligible media")
+			return 0, nil
+		},
+	)
+
+	assert.Empty(t, selected)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestSQLRandomGameWithQuery_SystemStatsAvoidTitleJoin(t *testing.T) {
+	t.Parallel()
+
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	systems := []string{"NES", "SNES", "Genesis"}
+	mock.ExpectQuery(
+		`SELECT COUNT\(\*\), COALESCE\(MIN\(Media\.DBID\), 0\), `+
+			`COALESCE\(MAX\(Media\.DBID\), 0\) FROM Media WHERE `+
+			`Media\.SystemDBID IN \(SELECT Systems\.DBID FROM Systems `+
+			`WHERE Systems\.SystemID IN \(\?,\?,\?\)\) AND Media\.IsMissing = 0`,
+	).WithArgs("NES", "SNES", "Genesis").WillReturnRows(
+		sqlmock.NewRows([]string{"count", "min", "max"}).AddRow(1, 42, 42),
+	)
+	mock.ExpectQuery(
+		`SELECT Systems\.SystemID, Media\.Path, Media\.DBID FROM Media `+
+			`INNER JOIN Systems ON Systems\.DBID = Media\.SystemDBID WHERE `+
+			`Media\.SystemDBID IN \(SELECT Systems\.DBID FROM Systems `+
+			`WHERE Systems\.SystemID IN \(\?,\?,\?\)\) AND Media\.IsMissing = 0 `+
+			`AND Media\.DBID = \? LIMIT 1`,
+	).WithArgs("NES", "SNES", "Genesis", int64(42)).WillReturnRows(
+		sqlmock.NewRows([]string{"SystemID", "Path", "DBID"}).
+			AddRow("SNES", filepath.Join("roms", "snes", "game.sfc"), 42),
+	)
+
+	result, stats, err := sqlRandomGameWithQueryAndStats(context.Background(), db, &database.MediaQuery{
+		Systems: systems,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "SNES", result.SystemID)
 	assert.Equal(t, MediaStats{Count: 1, MinDBID: 42, MaxDBID: 42}, stats)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -887,6 +887,22 @@ func TestSelectWeightedSystemUsing_NoMatchingMedia(t *testing.T) {
 	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
+func TestSelectWeightedSystemUsing_RandomError(t *testing.T) {
+	t.Parallel()
+
+	randomErr := errors.New("random selection failed")
+	selected, err := selectWeightedSystemUsing(
+		[]database.SystemMediaCount{{SystemID: "NES", Count: 10}},
+		[]string{"NES"},
+		func(int) (int, error) {
+			return 0, randomErr
+		},
+	)
+
+	assert.Empty(t, selected)
+	assert.ErrorIs(t, err, randomErr)
+}
+
 func TestSQLRandomGameWithQuery_SystemStatsAvoidTitleJoin(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/database/mediadb/sql_systems_test.go
+++ b/pkg/database/mediadb/sql_systems_test.go
@@ -166,6 +166,78 @@ func TestSystemMediaCounts_UsesBrowseCache(t *testing.T) {
 	assert.Equal(t, []database.SystemMediaCount{{SystemID: "NES", Count: 42}}, counts)
 }
 
+func TestRandomGameWithQuery_BroadSystemsUsesBrowseCounts(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.Join("roms", "nes", "game.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Game", mediaPath)
+	db := mediaDB.sql.Load()
+
+	_, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO BrowseDirs (Path, Name, IsVirtual) VALUES ('/', '/', 0)`)
+	require.NoError(t, err)
+	var rootDirDBID int64
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT DBID FROM BrowseDirs WHERE Path = '/'",
+	).Scan(&rootDirDBID))
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO BrowseDirCounts
+			(ParentDirDBID, ChildDirDBID, SystemDBID, FileCount)
+		VALUES (?, ?, ?, ?)`, rootDirDBID, rootDirDBID, system.DBID, 1)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)`,
+		DBConfigBrowseIndexVersion, browseCacheSchemaVersion)
+	require.NoError(t, err)
+
+	broadQuery := database.MediaQuery{Systems: []string{"NES", "SNES"}}
+	result, err := mediaDB.RandomGameWithQuery(ctx, &broadQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "NES", result.SystemID)
+	assert.Equal(t, mediaPath, result.Path)
+
+	_, broadCached := mediaDB.GetCachedStats(ctx, &broadQuery)
+	assert.False(t, broadCached)
+	_, narrowedCached := mediaDB.GetCachedStats(ctx, &database.MediaQuery{Systems: []string{"NES"}})
+	assert.True(t, narrowedCached)
+}
+
+func TestRandomGameWithQuery_BroadTaggedSystemsUsesTaggedCounts(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	mediaPath := filepath.Join("roms", "nes", "favorite.nes")
+	system := insertSystemWithMedia(t, mediaDB, "NES", "Favorite", mediaPath)
+	media, err := mediaDB.FindMedia(database.Media{SystemDBID: system.DBID, Path: mediaPath})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.UpdateMediaTags(ctx, media.DBID, nil, []database.MediaTagRef{{
+		Type: "user",
+		Tag:  "favorite",
+	}}))
+
+	favorite := []zapscript.TagFilter{{Type: "user", Value: "favorite"}}
+	broadQuery := database.MediaQuery{Systems: []string{"NES", "SNES"}, Tags: favorite}
+	result, err := mediaDB.RandomGameWithQuery(ctx, &broadQuery)
+	require.NoError(t, err)
+	assert.Equal(t, "NES", result.SystemID)
+	assert.Equal(t, mediaPath, result.Path)
+
+	_, broadCached := mediaDB.GetCachedStats(ctx, &broadQuery)
+	assert.False(t, broadCached)
+	_, narrowedCached := mediaDB.GetCachedStats(ctx, &database.MediaQuery{
+		Systems: []string{"NES"},
+		Tags:    favorite,
+	})
+	assert.True(t, narrowedCached)
+}
+
 func TestSystemMediaCounts_ExcludesMissingMedia(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -21,6 +21,7 @@ package helpers
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	stdpath "path"
 	"path/filepath"
@@ -36,6 +37,9 @@ import (
 	platformsshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/rs/zerolog/log"
 )
+
+// ErrNoLauncher indicates that no configured launcher can handle a media path.
+var ErrNoLauncher = errors.New("no launcher found")
 
 // NormalizePathForComparison normalizes a path for cross-platform case-insensitive comparison.
 // Converts to forward slashes and lowercases for consistent matching across all platforms.
@@ -615,7 +619,7 @@ func (m *LauncherMatcher) FindLauncher(path string) (platforms.Launcher, error) 
 	if len(launchers) == 0 {
 		log.Debug().Str("path", path).Int("launchersChecked", len(GlobalLauncherCache.GetAllLaunchers())).
 			Msg("no launcher matched path")
-		return platforms.Launcher{}, errors.New("no launcher found for: " + path)
+		return platforms.Launcher{}, fmt.Errorf("%w for: %s", ErrNoLauncher, path)
 	}
 
 	best := 0
@@ -915,7 +919,7 @@ func FindLauncher(
 		if !guessed {
 			log.Debug().Str("path", path).Int("launchersChecked", len(GlobalLauncherCache.GetAllLaunchers())).
 				Msg("no launcher matched path")
-			return platforms.Launcher{}, errors.New("no launcher found for: " + path)
+			return platforms.Launcher{}, fmt.Errorf("%w for: %s", ErrNoLauncher, path)
 		}
 	} else {
 		best := 0

--- a/pkg/helpers/paths_launcher_test.go
+++ b/pkg/helpers/paths_launcher_test.go
@@ -693,7 +693,8 @@ func TestFindLauncher_NoMatch(t *testing.T) {
 	}()
 
 	_, err := FindLauncher(cfg, mockPlatform, "/some/random/file.xyz")
-	assert.Error(t, err, "should return error when no launcher matches")
+	require.Error(t, err, "should return error when no launcher matches")
+	assert.ErrorIs(t, err, ErrNoLauncher)
 }
 
 func TestFindLauncher_AllowListBlocksAfterSpecificity(t *testing.T) {

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathHasPrefixNormalized(t *testing.T) {
@@ -155,6 +156,32 @@ func TestLauncherMatcher_NilPlatformDoesNotSynthesizeMediaPaths(t *testing.T) {
 
 	matcher := NewLauncherMatcher(cfg, nil)
 	assert.False(t, matcher.MatchSystemFile("NES", filepath.Join("media", "nes", "game.nes")))
+}
+
+func TestLauncherMatcher_FindLauncherNoMatch(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	launcher := platforms.Launcher{
+		ID:         "NESLauncher",
+		SystemID:   "NES",
+		Extensions: []string{".nes"},
+	}
+	cfg := &config.Instance{}
+
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.InitializeFromSlice([]platforms.Launcher{launcher})
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, nil)
+	_, err := matcher.FindLauncher(filepath.Join("media", "games", "gamelist.xml"))
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoLauncher)
 }
 
 func TestLauncherMatcher_MatchSystemFile(t *testing.T) {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -41,6 +41,8 @@ import (
 	"github.com/spf13/afero"
 )
 
+const randomLaunchSelectionAttempts = 16
+
 func launcherOverridePropertyTypeTag() string {
 	return tags.PropertyTypeTag(tags.TagPropertyLauncherOverride)
 }
@@ -391,7 +393,7 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 	tagFilters := args.Tags
 
 	gamesdb := env.Database.MediaDB
-	ctx, cancel := mediaDBLookupContext(env)
+	ctx, cancel := randomMediaDBLookupContext(env)
 	defer cancel()
 
 	if strings.EqualFold(query, "all") {
@@ -404,14 +406,20 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 			Systems: systemIDs,
 			Tags:    tagFilters,
 		}
-		game, gameErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+		selectGame := func() (database.SearchResult, error) {
+			return gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+		}
+		game, gameErr := selectGame()
 		if gameErr != nil {
 			return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", gameErr)
 		}
 
-		if launchErr := launch(launchTarget{
-			path: game.Path, systemID: game.SystemID, mediaID: game.MediaID,
-		}); launchErr != nil {
+		_, launchErr := launchRandomGameWithRetry(game, selectGame, func(candidate database.SearchResult) error {
+			return launch(launchTarget{
+				path: candidate.Path, systemID: candidate.SystemID, mediaID: candidate.MediaID,
+			})
+		})
+		if launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
 			}, fmt.Errorf("failed to launch random game: %w", launchErr)
@@ -437,7 +445,10 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 			PathPrefix: cleanedPath,
 			Tags:       tagFilters,
 		}
-		searchResult, searchErr := gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+		selectGame := func() (database.SearchResult, error) {
+			return gamesdb.RandomGameWithQuery(ctx, &mediaQuery)
+		}
+		searchResult, searchErr := selectGame()
 		fallbackToFilesystem := isFilesystemPath && len(tagFilters) == 0 &&
 			(errors.Is(searchErr, sql.ErrNoRows) || errors.Is(searchErr, context.DeadlineExceeded))
 		if fallbackToFilesystem {
@@ -455,14 +466,24 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 			if len(files) == 0 {
 				return platforms.CmdResult{}, fmt.Errorf("no files found in: %s", cleanedPath)
 			}
-			file, randomErr := helpers.RandomElem(files)
-			if randomErr != nil {
-				return platforms.CmdResult{}, fmt.Errorf("failed to select random file: %w", randomErr)
+			selectFile := func() (database.SearchResult, error) {
+				file, randomErr := helpers.RandomElem(files)
+				if randomErr != nil {
+					return database.SearchResult{}, fmt.Errorf("failed to select random file: %w", randomErr)
+				}
+				return database.SearchResult{Path: file}, nil
 			}
-			if launchErr := launch(launchTarget{path: file}); launchErr != nil {
+			file, randomErr := selectFile()
+			if randomErr != nil {
+				return platforms.CmdResult{}, randomErr
+			}
+			file, launchErr := launchRandomGameWithRetry(file, selectFile, func(candidate database.SearchResult) error {
+				return launch(launchTarget{path: candidate.Path})
+			})
+			if launchErr != nil {
 				return platforms.CmdResult{
 					MediaChanged: true,
-				}, fmt.Errorf("failed to launch file '%s': %w", file, launchErr)
+				}, fmt.Errorf("failed to launch file '%s': %w", file.Path, launchErr)
 			}
 			return platforms.CmdResult{
 				MediaChanged: true,
@@ -471,9 +492,16 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 			return platforms.CmdResult{}, fmt.Errorf("failed to find random media for path '%s': %w", query, searchErr)
 		}
 
-		if launchErr := launch(launchTarget{
-			path: searchResult.Path, systemID: searchResult.SystemID, mediaID: searchResult.MediaID,
-		}); launchErr != nil {
+		searchResult, launchErr := launchRandomGameWithRetry(
+			searchResult,
+			selectGame,
+			func(candidate database.SearchResult) error {
+				return launch(launchTarget{
+					path: candidate.Path, systemID: candidate.SystemID, mediaID: candidate.MediaID,
+				})
+			},
+		)
+		if launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
 			}, fmt.Errorf("failed to launch file '%s': %w", searchResult.Path, launchErr)
@@ -510,15 +538,21 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 		if searchQuery == "*" {
 			mediaQuery.PathGlob = ""
 		}
-		game, randomErr := randomGameBySystemTier(ctx, gamesdb, &mediaQuery, systemTiers)
+		selectGame := func() (database.SearchResult, error) {
+			return randomGameBySystemTier(ctx, gamesdb, &mediaQuery, systemTiers)
+		}
+		game, randomErr := selectGame()
 		if randomErr != nil {
 			return platforms.CmdResult{},
 				fmt.Errorf("failed to get random game matching '%s': %w", searchQuery, randomErr)
 		}
 
-		if launchErr := launch(launchTarget{
-			path: game.Path, systemID: game.SystemID, mediaID: game.MediaID,
-		}); launchErr != nil {
+		game, launchErr := launchRandomGameWithRetry(game, selectGame, func(candidate database.SearchResult) error {
+			return launch(launchTarget{
+				path: candidate.Path, systemID: candidate.SystemID, mediaID: candidate.MediaID,
+			})
+		})
+		if launchErr != nil {
 			return platforms.CmdResult{
 				MediaChanged: true,
 			}, fmt.Errorf("failed to launch game '%s': %w", game.Path, launchErr)
@@ -542,14 +576,21 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 	}
 
 	mediaQuery := database.MediaQuery{Tags: tagFilters}
-	game, err := randomGameBySystemTier(ctx, gamesdb, &mediaQuery, orderedSystemTiers(systems))
+	systemTiers := orderedSystemTiers(systems)
+	selectGame := func() (database.SearchResult, error) {
+		return randomGameBySystemTier(ctx, gamesdb, &mediaQuery, systemTiers)
+	}
+	game, err := selectGame()
 	if err != nil {
 		return platforms.CmdResult{}, fmt.Errorf("failed to get random game: %w", err)
 	}
 
-	if err := launch(launchTarget{
-		path: game.Path, systemID: game.SystemID, mediaID: game.MediaID,
-	}); err != nil {
+	game, err = launchRandomGameWithRetry(game, selectGame, func(candidate database.SearchResult) error {
+		return launch(launchTarget{
+			path: candidate.Path, systemID: candidate.SystemID, mediaID: candidate.MediaID,
+		})
+	})
+	if err != nil {
 		return platforms.CmdResult{
 			MediaChanged: true,
 		}, fmt.Errorf("failed to launch random game '%s': %w", game.Path, err)
@@ -557,6 +598,35 @@ func cmdRandomWithFS(fs afero.Fs, pl platforms.Platform, env *platforms.CmdEnv) 
 	return platforms.CmdResult{
 		MediaChanged: true,
 	}, nil
+}
+
+func launchRandomGameWithRetry(
+	game database.SearchResult,
+	selectGame func() (database.SearchResult, error),
+	launchGame func(database.SearchResult) error,
+) (database.SearchResult, error) {
+	var launchErr error
+	for attempt := range randomLaunchSelectionAttempts {
+		launchErr = launchGame(game)
+		if launchErr == nil || !errors.Is(launchErr, helpers.ErrNoLauncher) {
+			return game, launchErr
+		}
+		if attempt == randomLaunchSelectionAttempts-1 {
+			break
+		}
+
+		var selectErr error
+		game, selectErr = selectGame()
+		if selectErr != nil {
+			return game, fmt.Errorf("failed to select another random media entry: %w", selectErr)
+		}
+	}
+
+	return game, fmt.Errorf(
+		"no launchable random media found after %d selections: %w",
+		randomLaunchSelectionAttempts,
+		launchErr,
+	)
 }
 
 func orderedSystemTiers(systems []systemdefs.System) [][]systemdefs.System {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	pathhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	platformshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
@@ -1291,6 +1292,18 @@ func TestMediaDBLookupContext_UsesTimeoutWithoutServiceContext(t *testing.T) {
 	assert.WithinDuration(t, time.Now().Add(mediaDBLookupTimeout), deadline, 200*time.Millisecond)
 }
 
+func TestRandomMediaDBLookupContext_UsesExtendedTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := randomMediaDBLookupContext(&platforms.CmdEnv{})
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	assert.WithinDuration(t, time.Now().Add(randomMediaDBLookupTimeout), deadline, 200*time.Millisecond)
+	assert.Greater(t, randomMediaDBLookupTimeout, mediaDBLookupTimeout)
+}
+
 func TestMediaDBLookupContext_IgnoresCanceledLauncherContext(t *testing.T) {
 	t.Parallel()
 
@@ -1872,6 +1885,47 @@ launcher = "RA"
 	}
 
 	result, err := cmdRandom(mockPlatform, env)
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockMediaDB.AssertExpectations(t)
+	mockPlatform.AssertExpectations(t)
+}
+
+func TestCmdRandom_AbsolutePathRetriesUnlaunchableMedia(t *testing.T) {
+	t.Parallel()
+
+	queryPath := filepath.Join(launchTestAbsPath("games"), "SNES")
+	metadataPath := filepath.Join(queryPath, "gamelist.xml")
+	gamePath := filepath.Join(queryPath, "Super Mario World.sfc")
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Return(database.SearchResult{SystemID: systemdefs.SystemSNES, Path: metadataPath}, nil).Once()
+	mockMediaDB.On("RandomGameWithQuery", mock.Anything, mock.Anything).
+		Return(database.SearchResult{SystemID: systemdefs.SystemSNES, Path: gamePath}, nil).Once()
+
+	mockPlatform.On(
+		"LaunchMedia", cfg, metadataPath, (*platforms.Launcher)(nil),
+		mock.Anything, (*platforms.LaunchOptions)(nil),
+	).Return(pathhelpers.ErrNoLauncher).Once()
+	mockPlatform.On(
+		"LaunchMedia", cfg, gamePath, (*platforms.Launcher)(nil),
+		mock.Anything, (*platforms.LaunchOptions)(nil),
+	).Return(nil).Once()
+
+	result, err := cmdRandom(mockPlatform, platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "launch.random",
+			Args: []string{queryPath},
+		},
+		Cfg:      cfg,
+		Database: &database.Database{MediaDB: mockMediaDB},
+	})
 
 	require.NoError(t, err)
 	assert.True(t, result.MediaChanged)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -1631,6 +1631,68 @@ func TestSearchMediaBySystemTierReturnsDatabaseError(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestLaunchRandomGameWithRetry_StopContracts(t *testing.T) {
+	t.Parallel()
+
+	terminalErr := errors.New("terminal launch failure")
+	selectionErr := errors.New("reselection failure")
+	tests := []struct {
+		launchErr      error
+		selectErr      error
+		wantErr        error
+		name           string
+		wantLaunches   int
+		wantSelections int
+	}{
+		{
+			name:         "terminal launch error",
+			launchErr:    terminalErr,
+			wantErr:      terminalErr,
+			wantLaunches: 1,
+		},
+		{
+			name:           "reselection error",
+			launchErr:      pathhelpers.ErrNoLauncher,
+			selectErr:      selectionErr,
+			wantErr:        selectionErr,
+			wantLaunches:   1,
+			wantSelections: 1,
+		},
+		{
+			name:           "retry limit",
+			launchErr:      pathhelpers.ErrNoLauncher,
+			wantErr:        pathhelpers.ErrNoLauncher,
+			wantLaunches:   randomLaunchSelectionAttempts,
+			wantSelections: randomLaunchSelectionAttempts - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			launches := 0
+			selections := 0
+			_, err := launchRandomGameWithRetry(
+				database.SearchResult{Path: filepath.Join("games", "first.rom")},
+				func() (database.SearchResult, error) {
+					selections++
+					if tt.selectErr != nil {
+						return database.SearchResult{}, tt.selectErr
+					}
+					return database.SearchResult{Path: filepath.Join("games", "next.rom")}, nil
+				},
+				func(database.SearchResult) error {
+					launches++
+					return tt.launchErr
+				},
+			)
+
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantLaunches, launches)
+			assert.Equal(t, tt.wantSelections, selections)
+		})
+	}
+}
+
 func TestCmdRandomSystemWildcardUsesOrderedFallback(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/zapscript/media_context.go
+++ b/pkg/zapscript/media_context.go
@@ -26,13 +26,27 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 )
 
-const mediaDBLookupTimeout = 2 * time.Second
+const (
+	mediaDBLookupTimeout       = 2 * time.Second
+	randomMediaDBLookupTimeout = 5 * time.Second
+)
 
 func mediaDBLookupContext(env *platforms.CmdEnv) (context.Context, context.CancelFunc) {
+	return mediaDBLookupContextWithTimeout(env, mediaDBLookupTimeout)
+}
+
+func randomMediaDBLookupContext(env *platforms.CmdEnv) (context.Context, context.CancelFunc) {
+	return mediaDBLookupContextWithTimeout(env, randomMediaDBLookupTimeout)
+}
+
+func mediaDBLookupContextWithTimeout(
+	env *platforms.CmdEnv,
+	timeout time.Duration,
+) (context.Context, context.CancelFunc) {
 	parent := env.ServiceCtx
 	if parent == nil {
 		parent = context.Background()
 	}
 	//nolint:gosec // Caller owns and invokes returned cancel function.
-	return context.WithTimeout(parent, mediaDBLookupTimeout)
+	return context.WithTimeout(parent, timeout)
 }


### PR DESCRIPTION
## Summary

- retry random candidates that fail launcher resolution instead of abandoning the launch
- narrow broad system and tagged scopes with exact media-count weighting before random row selection
- use `Media.SystemDBID` indexes and avoid unnecessary title joins in random queries
- give random media lookups a MiSTer-suitable deadline

## Validation

- confirmed broad and tagged random launch behavior on MiSTer
- `task lint-fix`
- race-enabled media database and ZapScript tests

Closes #1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Random media selection now distributes results proportionally across matching systems.
  * Broad system and tagged-system searches use more appropriate browse and tag statistics.
  * Search performance improves by avoiding unnecessary title lookups when filtering by system.
  * Random launches retry unavailable or unlaunchable entries, improving the chance of starting playable media.
  * Random media lookups have an extended timeout for improved reliability.
  * Launcher-not-found errors are now clearly identifiable for better handling and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->