### PR TITLE
fix(zapscript): require HTTPS for public ZapLinks

### DIFF
--- a/pkg/config/configbackup.go
+++ b/pkg/config/configbackup.go
@@ -163,15 +163,7 @@ func validateRemoteBaseURL(rawURL, setting string) error {
 		return nil
 	}
 
-	host := parsed.Hostname()
-	if strings.EqualFold(host, "localhost") {
-		return nil
-	}
-	addr, err := netip.ParseAddr(host)
-	if err != nil {
-		return fmt.Errorf("http %s base URL must use localhost or a private IP literal", setting)
-	}
-	if isAllowedHTTPRemoteAddr(addr) {
+	if IsAllowedHTTPRemoteHost(parsed.Hostname()) {
 		return nil
 	}
 	return fmt.Errorf("http %s base URL must use localhost or a private IP literal", setting)
@@ -186,6 +178,17 @@ func normalizeRemoteBaseURL(rawURL string) string {
 	parsed.Fragment = ""
 	parsed.Path = strings.TrimRight(parsed.Path, "/")
 	return parsed.String()
+}
+
+// IsAllowedHTTPRemoteHost reports whether host may use plain HTTP for a
+// remote service. Hostnames other than localhost are rejected to avoid DNS
+// changes bypassing the local-network boundary.
+func IsAllowedHTTPRemoteHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	addr, err := netip.ParseAddr(host)
+	return err == nil && isAllowedHTTPRemoteAddr(addr)
 }
 
 func isAllowedHTTPRemoteAddr(addr netip.Addr) bool {

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -56,6 +56,7 @@ const (
 
 	preWarmMaxConcurrent = 5
 	preWarmTimeout       = 2 * time.Second
+	maxZapLinkRedirects  = 10
 )
 
 var AcceptedMimeTypes = []string{
@@ -92,15 +93,30 @@ var zapFetchTransport = &http.Transport{
 
 var zapFetchClientMu syncutil.RWMutex
 
-var zapFetchClient = newZapFetchClient(zapFetchTransport)
+var (
+	wellKnownFetchClient = newHTTPFetchClient(zapFetchTransport)
+	zapFetchClient       = newZapFetchClient(zapFetchTransport)
+)
 
-func newZapFetchClient(transport http.RoundTripper) *http.Client {
+func newHTTPFetchClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{
 		Transport: &installer.AuthTransport{
 			Base: transport,
 		},
 		Timeout: 10 * time.Second,
 	}
+}
+
+func newZapFetchClient(transport http.RoundTripper) *http.Client {
+	client := newHTTPFetchClient(transport)
+	client.CheckRedirect = checkZapLinkRedirect
+	return client
+}
+
+func currentWellKnownFetchClient() *http.Client {
+	zapFetchClientMu.RLock()
+	defer zapFetchClientMu.RUnlock()
+	return wellKnownFetchClient
 }
 
 func currentZapFetchClient() *http.Client {
@@ -114,6 +130,7 @@ func currentZapFetchClient() *http.Client {
 func ConfigureHTTPTransport() {
 	transport := tlsroots.Transport(zapFetchTransport)
 	zapFetchClientMu.Lock()
+	wellKnownFetchClient = newHTTPFetchClient(transport)
 	zapFetchClient = newZapFetchClient(transport)
 	zapFetchClientMu.Unlock()
 }
@@ -125,7 +142,7 @@ var ErrWellKnownNotFound = errors.New("well-known endpoint not found")
 // FetchWellKnown fetches and parses the .well-known/zaparoo file from a base URL.
 // Returns ErrWellKnownNotFound if the host returned 404.
 func FetchWellKnown(baseURL string) (*WellKnown, error) {
-	return doFetchWellKnown(baseURL, currentZapFetchClient())
+	return doFetchWellKnown(baseURL, currentWellKnownFetchClient())
 }
 
 func doFetchWellKnown(baseURL string, client httpDoer) (*WellKnown, error) {
@@ -173,6 +190,9 @@ func doFetchWellKnown(baseURL string, client httpDoer) (*WellKnown, error) {
 }
 
 func queryZapLinkSupport(u *url.URL) (int, error) {
+	if err := validateZapLinkURL(u); err != nil {
+		return 0, err
+	}
 	baseURL := u.Scheme + "://" + u.Host
 	wk, err := doFetchWellKnown(baseURL, currentZapFetchClient())
 	if errors.Is(err, ErrWellKnownNotFound) {
@@ -190,7 +210,7 @@ func isZapLink(link string, db *database.Database) bool {
 		return false
 	}
 
-	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+	if validationErr := validateZapLinkURL(u); validationErr != nil {
 		return false
 	}
 
@@ -232,6 +252,9 @@ func getRemoteZapScript(urlStr, platform string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for '%s': %w", urlStr, err)
+	}
+	if validationErr := validateZapLinkURL(req.URL); validationErr != nil {
+		return nil, validationErr
 	}
 	setZapLinkHeaders(req, platform)
 	req.Header.Set("Accept", strings.Join(AcceptedMimeTypes, ", "))
@@ -283,6 +306,45 @@ func getRemoteZapScript(urlStr, platform string) ([]byte, error) {
 	log.Debug().Int("size", len(body)).Msg("received zap link body")
 
 	return body, nil
+}
+
+// validateZapLinkURL enforces HTTPS except for localhost and literal
+// local-network addresses.
+func validateZapLinkURL(u *url.URL) error {
+	if u == nil || u.Host == "" || u.User != nil {
+		return errors.New("ZapLink URL must include a host and cannot include userinfo")
+	}
+
+	switch {
+	case strings.EqualFold(u.Scheme, "https"):
+		return nil
+	case strings.EqualFold(u.Scheme, "http") && config.IsAllowedHTTPRemoteHost(u.Hostname()):
+		return nil
+	case strings.EqualFold(u.Scheme, "http"):
+		return errors.New("public ZapLink URLs must use HTTPS")
+	default:
+		return errors.New("ZapLink URL must use HTTP or HTTPS")
+	}
+}
+
+func checkZapLinkRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxZapLinkRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxZapLinkRedirects)
+	}
+	if err := validateZapLinkURL(req.URL); err != nil {
+		return fmt.Errorf("invalid ZapLink redirect: %w", err)
+	}
+	if len(via) == 0 {
+		return nil
+	}
+
+	initial := via[0].URL
+	if strings.EqualFold(initial.Scheme, "https") &&
+		!config.IsAllowedHTTPRemoteHost(initial.Hostname()) &&
+		strings.EqualFold(req.URL.Scheme, "http") {
+		return errors.New("refusing ZapLink redirect downgrade from public HTTPS to HTTP")
+	}
+	return nil
 }
 
 // isOfflineError returns true if the error is some network connectivity
@@ -438,6 +500,11 @@ func PreWarmZapLinkHostsContext(
 
 // preWarmHost makes a HEAD request to a base URL's well-known endpoint to warm caches.
 func preWarmHost(ctx context.Context, baseURL string, db *database.Database, client httpDoer) {
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil || validateZapLinkURL(parsedBaseURL) != nil {
+		log.Debug().Msgf("skipping invalid zaplink host during pre-warm: %s", baseURL)
+		return
+	}
 	wellKnownURL := baseURL + WellKnownPath
 
 	ctx, cancel := context.WithTimeout(ctx, preWarmTimeout)

--- a/pkg/zapscript/zaplinks.go
+++ b/pkg/zapscript/zaplinks.go
@@ -94,21 +94,25 @@ var zapFetchTransport = &http.Transport{
 var zapFetchClientMu syncutil.RWMutex
 
 var (
-	wellKnownFetchClient = newHTTPFetchClient(zapFetchTransport)
+	wellKnownFetchClient = newWellKnownFetchClient(zapFetchTransport)
 	zapFetchClient       = newZapFetchClient(zapFetchTransport)
 )
 
 func newHTTPFetchClient(transport http.RoundTripper) *http.Client {
 	return &http.Client{
-		Transport: &installer.AuthTransport{
-			Base: transport,
-		},
-		Timeout: 10 * time.Second,
+		Transport: transport,
+		Timeout:   10 * time.Second,
 	}
 }
 
-func newZapFetchClient(transport http.RoundTripper) *http.Client {
+func newWellKnownFetchClient(transport http.RoundTripper) *http.Client {
 	client := newHTTPFetchClient(transport)
+	client.CheckRedirect = checkZapLinkRedirect
+	return client
+}
+
+func newZapFetchClient(transport http.RoundTripper) *http.Client {
+	client := newHTTPFetchClient(&installer.AuthTransport{Base: transport})
 	client.CheckRedirect = checkZapLinkRedirect
 	return client
 }
@@ -130,7 +134,7 @@ func currentZapFetchClient() *http.Client {
 func ConfigureHTTPTransport() {
 	transport := tlsroots.Transport(zapFetchTransport)
 	zapFetchClientMu.Lock()
-	wellKnownFetchClient = newHTTPFetchClient(transport)
+	wellKnownFetchClient = newWellKnownFetchClient(transport)
 	zapFetchClient = newZapFetchClient(transport)
 	zapFetchClientMu.Unlock()
 }
@@ -142,6 +146,13 @@ var ErrWellKnownNotFound = errors.New("well-known endpoint not found")
 // FetchWellKnown fetches and parses the .well-known/zaparoo file from a base URL.
 // Returns ErrWellKnownNotFound if the host returned 404.
 func FetchWellKnown(baseURL string) (*WellKnown, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid well-known base URL: %w", err)
+	}
+	if validationErr := validateZapLinkURL(u); validationErr != nil {
+		return nil, validationErr
+	}
 	return doFetchWellKnown(baseURL, currentWellKnownFetchClient())
 }
 
@@ -194,7 +205,7 @@ func queryZapLinkSupport(u *url.URL) (int, error) {
 		return 0, err
 	}
 	baseURL := u.Scheme + "://" + u.Host
-	wk, err := doFetchWellKnown(baseURL, currentZapFetchClient())
+	wk, err := doFetchWellKnown(baseURL, currentWellKnownFetchClient())
 	if errors.Is(err, ErrWellKnownNotFound) {
 		return 0, nil
 	}
@@ -490,7 +501,7 @@ func PreWarmZapLinkHostsContext(
 			}
 			defer func() { <-sem }()
 
-			preWarmHost(ctx, u, db, currentZapFetchClient())
+			preWarmHost(ctx, u, db, currentWellKnownFetchClient())
 		}(baseURL)
 	}
 

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -35,6 +35,7 @@ import (
 	"testing"
 
 	gozapscript "github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
@@ -299,11 +300,12 @@ func TestZapLinkRedirectPolicy(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		startURL  string
-		location  string
-		wantErr   string
-		wantCalls int
+		name           string
+		startURL       string
+		location       string
+		wantErr        string
+		wantCalls      int
+		repeatRedirect bool
 	}{
 		{
 			name:     "public HTTPS downgrade to public HTTP",
@@ -330,6 +332,14 @@ func TestZapLinkRedirectPolicy(t *testing.T) {
 			startURL: "https://example.com/start", location: "https://example.net/final",
 			wantCalls: 2,
 		},
+		{
+			name:           "redirect limit enforced",
+			startURL:       "https://example.com/start",
+			location:       "https://example.com/again",
+			wantErr:        "stopped after 10 redirects",
+			wantCalls:      10,
+			repeatRedirect: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,7 +348,7 @@ func TestZapLinkRedirectPolicy(t *testing.T) {
 			calls := 0
 			client := newZapFetchClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
 				calls++
-				if calls == 1 {
+				if tt.repeatRedirect || calls == 1 {
 					return &http.Response{
 						StatusCode: http.StatusFound,
 						Header:     http.Header{"Location": []string{tt.location}},
@@ -366,6 +376,49 @@ func TestZapLinkRedirectPolicy(t *testing.T) {
 			assert.Equal(t, tt.wantCalls, calls)
 		})
 	}
+}
+
+func TestZapFetchClientAuthenticationBoundary(t *testing.T) {
+	config.SetAuthCfgForTesting(map[string]config.CredentialEntry{
+		"https://example.com": {Bearer: "test-token"},
+	})
+	t.Cleanup(config.ClearAuthCfgForTesting)
+
+	var wellKnownAuth string
+	var payloadAuth string
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.Path {
+		case WellKnownPath:
+			wellKnownAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"zapscript":1}`)),
+				Request:    req,
+			}, nil
+		case "/token":
+			payloadAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       http.NoBody,
+				Request:    req,
+			}, nil
+		default:
+			return nil, errors.New("unexpected request path")
+		}
+	})
+
+	wk, err := doFetchWellKnown("https://example.com", newWellKnownFetchClient(transport))
+	require.NoError(t, err)
+	require.NotNil(t, wk)
+
+	resp, err := newZapFetchClient(transport).Get("https://example.com/token") //nolint:noctx // Local test transport.
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	assert.Empty(t, wellKnownAuth)
+	assert.Equal(t, "Bearer test-token", payloadAuth)
 }
 
 func TestPreWarmZapLinkHosts_NoInternet(t *testing.T) {
@@ -796,6 +849,51 @@ func TestCheckZapLinkFetchesSupportedRemoteScript(t *testing.T) {
 }
 
 // FetchWellKnown Tests
+
+func TestFetchWellKnownRejectsInvalidBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "public HTTP", baseURL: "http://example.com"},
+		{name: "official Edge HTTP", baseURL: "http://edge.zaparoo.com"},
+		{name: "unsupported scheme", baseURL: "ftp://example.com"},
+		{name: "missing host", baseURL: "https:///path"},
+		{name: "userinfo", baseURL: "https://user@example.com"},
+		{name: "malformed", baseURL: "https://%zz"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			wk, err := FetchWellKnown(tt.baseURL)
+			require.Error(t, err)
+			assert.Nil(t, wk)
+		})
+	}
+}
+
+func TestWellKnownRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	client := newWellKnownFetchClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		return &http.Response{
+			StatusCode: http.StatusFound,
+			Header:     http.Header{"Location": []string{"http://127.0.0.1/final"}},
+			Body:       http.NoBody,
+			Request:    req,
+		}, nil
+	}))
+
+	wk, err := doFetchWellKnown("https://example.com", client)
+	require.ErrorContains(t, err, "redirect downgrade")
+	assert.Nil(t, wk)
+	assert.Equal(t, 1, calls)
+}
 
 func TestFetchWellKnown_BasicZapScriptOnly(t *testing.T) {
 	t.Parallel()

--- a/pkg/zapscript/zaplinks_test.go
+++ b/pkg/zapscript/zaplinks_test.go
@@ -225,6 +225,149 @@ func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return resp, args.Error(1) //nolint:wrapcheck // test mock
 }
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestValidateZapLinkURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr bool
+	}{
+		{name: "public HTTPS hostname", rawURL: "https://example.com/token"},
+		{name: "public HTTPS IP", rawURL: "https://8.8.8.8/token"},
+		{name: "localhost HTTP", rawURL: "http://localhost:8080/token"},
+		{name: "case insensitive localhost HTTP", rawURL: "http://LOCALHOST:8080/token"},
+		{name: "IPv4 loopback HTTP", rawURL: "http://127.42.0.1:8080/token"},
+		{name: "IPv6 loopback HTTP", rawURL: "http://[::1]:8080/token"},
+		{name: "RFC1918 10 HTTP", rawURL: "http://10.0.0.1:8080/token"},
+		{name: "RFC1918 172 HTTP", rawURL: "http://172.16.0.1:8080/token"},
+		{name: "RFC1918 192 HTTP", rawURL: "http://192.168.0.1:8080/token"},
+		{name: "IPv4 link-local HTTP", rawURL: "http://169.254.1.1:8080/token"},
+		{name: "IPv6 ULA HTTP", rawURL: "http://[fd00::1]:8080/token"},
+		{name: "IPv6 link-local HTTP", rawURL: "http://[fe80::1]:8080/token"},
+		{name: "local HTTP query", rawURL: "http://192.168.1.2:8080/token?id=1"},
+		{name: "public HTTP hostname", rawURL: "http://example.com/token", wantErr: true},
+		{name: "public HTTP IP", rawURL: "http://8.8.8.8/token", wantErr: true},
+		{name: "LAN hostname HTTP", rawURL: "http://console.local/token", wantErr: true},
+		{name: "official Edge HTTP", rawURL: "http://edge.zaparoo.com/token", wantErr: true},
+		{name: "official short link HTTP", rawURL: "http://zpr.au/token", wantErr: true},
+		{name: "userinfo rejected", rawURL: "https://user@example.com/token", wantErr: true},
+		{name: "non-HTTP scheme", rawURL: "ftp://example.com/token", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			u, err := url.Parse(tt.rawURL)
+			require.NoError(t, err)
+			err = validateZapLinkURL(u)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPublicHTTPZapLinkRejectedBeforeNetworkAccess(t *testing.T) {
+	t.Parallel()
+
+	const publicURL = "http://edge.zaparoo.com/token"
+	u, err := url.Parse(publicURL)
+	require.NoError(t, err)
+
+	_, err = queryZapLinkSupport(u)
+	require.ErrorContains(t, err, "must use HTTPS")
+
+	_, err = getRemoteZapScript(publicURL, "test")
+	require.ErrorContains(t, err, "must use HTTPS")
+
+	mockClient := &mockHTTPClient{}
+	mockUserDB := &testhelpers.MockUserDBI{}
+	preWarmHost(t.Context(), "http://edge.zaparoo.com", &database.Database{UserDB: mockUserDB}, mockClient)
+	mockClient.AssertNotCalled(t, "Do")
+}
+
+func TestZapLinkRedirectPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		startURL  string
+		location  string
+		wantErr   string
+		wantCalls int
+	}{
+		{
+			name:     "public HTTPS downgrade to public HTTP",
+			startURL: "https://example.com/start", location: "http://example.net/final",
+			wantErr: "public ZapLink URLs must use HTTPS", wantCalls: 1,
+		},
+		{
+			name:     "public HTTPS downgrade to local HTTP",
+			startURL: "https://example.com/start", location: "http://127.0.0.1/final",
+			wantErr: "redirect downgrade", wantCalls: 1,
+		},
+		{
+			name:     "official HTTPS downgrade to local HTTP",
+			startURL: "https://edge.zaparoo.com/start", location: "http://192.168.1.2/final",
+			wantErr: "redirect downgrade", wantCalls: 1,
+		},
+		{
+			name:     "local HTTPS downgrade to local HTTP allowed",
+			startURL: "https://127.0.0.1/start", location: "http://127.0.0.1/final",
+			wantCalls: 2,
+		},
+		{
+			name:     "public HTTPS redirect allowed",
+			startURL: "https://example.com/start", location: "https://example.net/final",
+			wantCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			calls := 0
+			client := newZapFetchClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				calls++
+				if calls == 1 {
+					return &http.Response{
+						StatusCode: http.StatusFound,
+						Header:     http.Header{"Location": []string{tt.location}},
+						Body:       http.NoBody,
+						Request:    req,
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       http.NoBody,
+					Request:    req,
+				}, nil
+			}))
+
+			resp, err := client.Get(tt.startURL) //nolint:noctx // Test exercises redirect policy.
+			if resp != nil {
+				require.NoError(t, resp.Body.Close())
+			}
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
 func TestPreWarmZapLinkHosts_NoInternet(t *testing.T) {
 	t.Parallel()
 
@@ -518,6 +661,17 @@ func TestQueryZapLinkSupport_200WithZapScript1(t *testing.T) {
 
 // isZapLink Tests
 
+func TestIsZapLinkRejectsPublicHTTPBeforeCacheLookup(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := &testhelpers.MockUserDBI{}
+	db := &database.Database{UserDB: mockUserDB}
+
+	assert.False(t, isZapLink("http://edge.zaparoo.com/token", db))
+	mockUserDB.AssertNotCalled(t, "GetZapLinkHost")
+	mockUserDB.AssertNotCalled(t, "GetZapLinkCache")
+}
+
 func TestIsZapLink_TransientErrorNotCached(t *testing.T) {
 	t.Parallel()
 
@@ -667,10 +821,12 @@ func TestConfigureHTTPTransport_TrustsConfiguredTLSRoots(t *testing.T) {
 	}))
 	defer server.Close()
 
-	oldClient := currentZapFetchClient()
+	oldWellKnownClient := currentWellKnownFetchClient()
+	oldZapClient := currentZapFetchClient()
 	t.Cleanup(func() {
 		zapFetchClientMu.Lock()
-		zapFetchClient = oldClient
+		wellKnownFetchClient = oldWellKnownClient
+		zapFetchClient = oldZapClient
 		zapFetchClientMu.Unlock()
 	})
 


### PR DESCRIPTION
## Summary

- require HTTPS for public ZapLink discovery, payload fetches, and cache access
- preserve HTTP for localhost and literal private, loopback, and link-local addresses
- reject public HTTPS redirect downgrades while keeping account-claim transport behavior unchanged

Closes #1245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Improved remote-host validation to allow local and private addresses while rejecting unsafe public HTTP hosts.
  * Added URL validation, redirect limits, and HTTPS downgrade protection for ZapLink requests.
  * Prevented unsafe network access caused by DNS-based boundary bypasses.
* **Bug Fixes**
  * Improved separation and handling of well-known endpoint and authenticated script requests.
  * Invalid or unsupported pre-warming links are now skipped safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->