### PR TITLE
feat(readers): read token files from optical media

### DIFF
--- a/pkg/readers/opticaldrive/iso9660_identity.go
+++ b/pkg/readers/opticaldrive/iso9660_identity.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -122,6 +124,11 @@ func readISO9660IdentityContext(ctx context.Context, r contextReaderAt) (discIde
 
 		tokenFile, tokenErr := readISO9660TokenFileContext(ctx, r, buf)
 		if tokenErr != nil {
+			log.Debug().
+				Err(tokenErr).
+				Str("uuid", uuid).
+				Str("label", label).
+				Msg("failed to read ISO9660 token file")
 			tokenFile = discTokenFile{State: discTokenFileUnknown}
 		}
 		return discIdentity{UUID: uuid, Label: label, TokenFile: tokenFile}, true, nil
@@ -206,7 +213,7 @@ func readISO9660TokenFileRecord(
 }
 
 func parseISO9660DirectoryRecord(raw []byte) (iso9660DirectoryRecord, error) {
-	if len(raw) < 1 {
+	if len(raw) == 0 {
 		return iso9660DirectoryRecord{}, io.ErrUnexpectedEOF
 	}
 	recordLength := int(raw[0])

--- a/pkg/readers/opticaldrive/iso9660_identity.go
+++ b/pkg/readers/opticaldrive/iso9660_identity.go
@@ -21,6 +21,7 @@ package opticaldrive
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -36,18 +37,52 @@ const (
 	iso9660DescriptorTypePrimary = 0x01
 	iso9660DescriptorTypeEnd     = 0xff
 
-	iso9660VolumeIDOffset = 40
-	iso9660VolumeIDSize   = 32
-	iso9660CreatedOffset  = 813
-	iso9660ModifiedOffset = 830
-	iso9660DateSize       = 17
+	iso9660VolumeIDOffset            = 40
+	iso9660VolumeIDSize              = 32
+	iso9660RootDirectoryRecordOffset = 156
+	iso9660CreatedOffset             = 813
+	iso9660ModifiedOffset            = 830
+	iso9660DateSize                  = 17
+
+	iso9660DirectoryRecordMinSize     = 34
+	iso9660ExtentLocationOffset       = 2
+	iso9660DataLengthOffset           = 10
+	iso9660FileFlagsOffset            = 25
+	iso9660FileIdentifierLengthOffset = 32
+	iso9660FileIdentifierOffset       = 33
+	iso9660DirectoryFlag              = 0x02
+	iso9660MultiExtentFlag            = 0x80
+	iso9660MaxTokenFileSize           = 1 * 1024 * 1024
+	iso9660TokenFileName              = "zaparoo.txt" //nolint:gosec // Filename, not a credential.
+)
+
+type discTokenFileState uint8
+
+const (
+	discTokenFileUnknown discTokenFileState = iota
+	discTokenFileAbsent
+	discTokenFilePresent
 )
 
 var errISO9660IdentityNotFound = errors.New("iso9660 identity not found")
 
 type discIdentity struct {
-	UUID  string
-	Label string
+	UUID      string
+	Label     string
+	TokenFile discTokenFile
+}
+
+type discTokenFile struct {
+	Data  []byte
+	State discTokenFileState
+}
+
+type iso9660DirectoryRecord struct {
+	Identifier              []byte
+	ExtentLocation          uint32
+	DataLength              uint32
+	ExtendedAttributeLength uint8
+	Flags                   uint8
 }
 
 type contextReaderAt interface {
@@ -84,9 +119,124 @@ func readISO9660IdentityContext(ctx context.Context, r contextReaderAt) (discIde
 		if uuid == "" {
 			uuid = iso9660DateUUID(buf[iso9660CreatedOffset : iso9660CreatedOffset+iso9660DateSize])
 		}
-		return discIdentity{UUID: uuid, Label: label}, true, nil
+
+		tokenFile, tokenErr := readISO9660TokenFileContext(ctx, r, buf)
+		if tokenErr != nil {
+			tokenFile = discTokenFile{State: discTokenFileUnknown}
+		}
+		return discIdentity{UUID: uuid, Label: label, TokenFile: tokenFile}, true, nil
 	}
 	return discIdentity{}, false, nil
+}
+
+func readISO9660TokenFileContext(
+	ctx context.Context,
+	r contextReaderAt,
+	primaryVolumeDescriptor []byte,
+) (discTokenFile, error) {
+	rootRecord, err := parseISO9660DirectoryRecord(primaryVolumeDescriptor[iso9660RootDirectoryRecordOffset:])
+	if err != nil {
+		return discTokenFile{}, fmt.Errorf("parse iso9660 root directory record: %w", err)
+	}
+	if rootRecord.Flags&iso9660DirectoryFlag == 0 {
+		return discTokenFile{}, errors.New("iso9660 root directory record is not a directory")
+	}
+
+	rootOffset := iso9660RecordDataOffset(rootRecord)
+	remaining := int64(rootRecord.DataLength)
+	sector := make([]byte, iso9660SectorSize)
+	for directoryOffset := int64(0); remaining > 0; directoryOffset += iso9660SectorSize {
+		readSize := min(remaining, int64(len(sector)))
+		n, readErr := r.ReadAtContext(ctx, sector[:readSize], rootOffset+directoryOffset)
+		if readErr != nil {
+			return discTokenFile{}, fmt.Errorf("read iso9660 root directory: %w", readErr)
+		}
+		if int64(n) < readSize {
+			return discTokenFile{}, io.ErrUnexpectedEOF
+		}
+
+		for recordOffset := 0; recordOffset < n; {
+			recordLength := int(sector[recordOffset])
+			if recordLength == 0 {
+				break
+			}
+			if recordOffset+recordLength > n {
+				return discTokenFile{}, errors.New("iso9660 directory record crosses sector boundary")
+			}
+
+			record, parseErr := parseISO9660DirectoryRecord(sector[recordOffset : recordOffset+recordLength])
+			if parseErr != nil {
+				return discTokenFile{}, fmt.Errorf("parse iso9660 directory record: %w", parseErr)
+			}
+			if iso9660TokenFileIdentifier(record.Identifier) {
+				return readISO9660TokenFileRecord(ctx, r, record)
+			}
+			recordOffset += recordLength
+		}
+		remaining -= readSize
+	}
+
+	return discTokenFile{State: discTokenFileAbsent}, nil
+}
+
+func readISO9660TokenFileRecord(
+	ctx context.Context,
+	r contextReaderAt,
+	record iso9660DirectoryRecord,
+) (discTokenFile, error) {
+	if record.Flags&iso9660DirectoryFlag != 0 || record.Flags&iso9660MultiExtentFlag != 0 {
+		return discTokenFile{State: discTokenFilePresent}, nil
+	}
+	if record.DataLength > iso9660MaxTokenFileSize {
+		return discTokenFile{State: discTokenFilePresent}, nil
+	}
+	if record.DataLength == 0 {
+		return discTokenFile{State: discTokenFilePresent}, nil
+	}
+
+	contents := make([]byte, int(record.DataLength))
+	n, err := r.ReadAtContext(ctx, contents, iso9660RecordDataOffset(record))
+	if err != nil {
+		return discTokenFile{}, fmt.Errorf("read iso9660 token file: %w", err)
+	}
+	if n < len(contents) {
+		return discTokenFile{}, io.ErrUnexpectedEOF
+	}
+	return discTokenFile{Data: contents, State: discTokenFilePresent}, nil
+}
+
+func parseISO9660DirectoryRecord(raw []byte) (iso9660DirectoryRecord, error) {
+	if len(raw) < 1 {
+		return iso9660DirectoryRecord{}, io.ErrUnexpectedEOF
+	}
+	recordLength := int(raw[0])
+	if recordLength < iso9660DirectoryRecordMinSize || recordLength > len(raw) {
+		return iso9660DirectoryRecord{}, errors.New("invalid iso9660 directory record length")
+	}
+
+	identifierLength := int(raw[iso9660FileIdentifierLengthOffset])
+	identifierEnd := iso9660FileIdentifierOffset + identifierLength
+	if identifierEnd > recordLength {
+		return iso9660DirectoryRecord{}, errors.New("invalid iso9660 file identifier length")
+	}
+
+	return iso9660DirectoryRecord{
+		Identifier:              raw[iso9660FileIdentifierOffset:identifierEnd],
+		ExtentLocation:          binary.LittleEndian.Uint32(raw[iso9660ExtentLocationOffset:]),
+		DataLength:              binary.LittleEndian.Uint32(raw[iso9660DataLengthOffset:]),
+		ExtendedAttributeLength: raw[1],
+		Flags:                   raw[iso9660FileFlagsOffset],
+	}, nil
+}
+
+func iso9660RecordDataOffset(record iso9660DirectoryRecord) int64 {
+	block := int64(record.ExtentLocation) + int64(record.ExtendedAttributeLength)
+	return block * iso9660SectorSize
+}
+
+func iso9660TokenFileIdentifier(identifier []byte) bool {
+	name := strings.TrimSuffix(string(identifier), ";1")
+	return strings.EqualFold(name, iso9660TokenFileName)
 }
 
 func trimISO9660String(raw []byte) string {

--- a/pkg/readers/opticaldrive/opticaldrive.go
+++ b/pkg/readers/opticaldrive/opticaldrive.go
@@ -20,7 +20,9 @@
 package opticaldrive
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -182,6 +184,34 @@ func scanPropertiesEqual(a, b []readers.ScanProperty) bool {
 	return true
 }
 
+func discTokenFilesEqual(a, b discTokenFile) bool {
+	return a.State == b.State && bytes.Equal(a.Data, b.Data)
+}
+
+func cloneDiscTokenFile(tokenFile discTokenFile) discTokenFile {
+	return discTokenFile{
+		Data:  bytes.Clone(tokenFile.Data),
+		State: tokenFile.State,
+	}
+}
+
+func effectiveDiscTokenFile(
+	current, previous discTokenFile,
+	hasProbed bool,
+	identityErr error,
+) discTokenFile {
+	if identityErr != nil {
+		return discTokenFile{State: discTokenFileAbsent}
+	}
+	if current.State == discTokenFileUnknown {
+		if hasProbed {
+			return cloneDiscTokenFile(previous)
+		}
+		return discTokenFile{State: discTokenFileAbsent}
+	}
+	return current
+}
+
 func (r *FileReader) Open(
 	device config.ReadersConnect,
 	iq chan<- readers.Scan,
@@ -218,6 +248,7 @@ func (r *FileReader) Open(
 		defer r.wg.Done()
 		var token *tokens.Token
 		var tokenProperties []readers.ScanProperty
+		var activeTokenFile, lastTokenFile discTokenFile
 		var lastUUID, lastLabel, lastIdentityErr string
 		hasProbed := false
 
@@ -242,6 +273,7 @@ func (r *FileReader) Open(
 					log.Warn().Err(err).Msg("optical drive device no longer exists - " +
 						"sending error signal to keep media running")
 					token = nil
+					activeTokenFile = discTokenFile{}
 					hasProbed = false
 					iq <- readers.Scan{
 						Source:      tokens.SourceReader,
@@ -260,15 +292,26 @@ func (r *FileReader) Open(
 			uuid := strings.TrimSpace(identity.UUID)
 			label := strings.TrimSpace(identity.Label)
 			identityErrStr := errString(identityErr)
+			probeTokenFile := effectiveDiscTokenFile(identity.TokenFile, lastTokenFile, hasProbed, identityErr)
 
-			probeChanged := !hasProbed || uuid != lastUUID || label != lastLabel || identityErrStr != lastIdentityErr
+			probeChanged := !hasProbed || uuid != lastUUID || label != lastLabel ||
+				identityErrStr != lastIdentityErr || !discTokenFilesEqual(probeTokenFile, lastTokenFile)
 			lastUUID, lastLabel, lastIdentityErr = uuid, label, identityErrStr
+			lastTokenFile = cloneDiscTokenFile(probeTokenFile)
 			hasProbed = true
 			if !probeChanged {
 				continue
 			}
 
 			id := resolveTokenID(uuid, label, r.device.IDSource)
+			tokenText := ""
+			tokenData := ""
+			if probeTokenFile.State == discTokenFilePresent {
+				tokenText = strings.TrimSpace(string(probeTokenFile.Data))
+				if tokenText != "" {
+					tokenData = hex.EncodeToString(probeTokenFile.Data)
+				}
+			}
 			scanProperties := r.gameIDProbe(r.path)
 			log.Debug().
 				Str("path", r.path).
@@ -278,19 +321,21 @@ func (r *FileReader) Open(
 				Int("properties", len(scanProperties)).
 				Msg("optical media identification probe changed")
 
-			if token != nil && len(scanProperties) > 0 && scanPropertiesEqual(scanProperties, tokenProperties) {
+			if token != nil && len(scanProperties) > 0 && scanPropertiesEqual(scanProperties, tokenProperties) &&
+				(identityErr != nil || discTokenFilesEqual(probeTokenFile, activeTokenFile)) {
 				if id == "" || token.UID == "" || token.UID == id {
 					continue
 				}
 			}
 
-			if id == "" && len(scanProperties) == 0 {
+			if id == "" && len(scanProperties) == 0 && tokenText == "" {
 				if token != nil {
 					log.Debug().
 						Err(identityErr).
 						Msg("error identifying optical media, removing token")
 					token = nil
 					tokenProperties = nil
+					activeTokenFile = discTokenFile{}
 					iq <- readers.Scan{
 						Source:   tokens.SourceReader,
 						ReaderID: r.ReaderID(),
@@ -300,7 +345,8 @@ func (r *FileReader) Open(
 				continue
 			}
 
-			if token != nil && token.UID == id && scanPropertiesEqual(scanProperties, tokenProperties) {
+			if token != nil && token.UID == id && scanPropertiesEqual(scanProperties, tokenProperties) &&
+				discTokenFilesEqual(probeTokenFile, activeTokenFile) {
 				continue
 			}
 
@@ -308,10 +354,13 @@ func (r *FileReader) Open(
 				Type:     TokenType,
 				ScanTime: time.Now(),
 				UID:      id,
+				Text:     tokenText,
+				Data:     tokenData,
 				Source:   tokens.SourceReader,
 				ReaderID: r.ReaderID(),
 			}
 			tokenProperties = append(tokenProperties[:0], scanProperties...)
+			activeTokenFile = cloneDiscTokenFile(probeTokenFile)
 
 			log.Debug().Msgf("new token: %s", token.UID)
 			iq <- readers.Scan{

--- a/pkg/readers/opticaldrive/opticaldrive.go
+++ b/pkg/readers/opticaldrive/opticaldrive.go
@@ -318,6 +318,8 @@ func (r *FileReader) Open(
 				Str("uuid", uuid).
 				Str("label", label).
 				Str("identityErr", identityErrStr).
+				Uint8("tokenFileState", uint8(probeTokenFile.State)).
+				Int("tokenFileBytes", len(probeTokenFile.Data)).
 				Int("properties", len(scanProperties)).
 				Msg("optical media identification probe changed")
 

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -46,9 +46,8 @@ import (
 )
 
 const (
-	testISO9660RootExtent      = 20
-	testISO9660TokenExtent     = 21
-	testISO9660RootEntriesSize = 68
+	testISO9660RootExtent  = 20
+	testISO9660TokenExtent = 21
 )
 
 func TestNewReader(t *testing.T) {
@@ -287,7 +286,7 @@ func TestConstants(t *testing.T) {
 func TestReadISO9660Identity(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("SCES-01420", "1998102813221100", "1998010100000000")
+	image, _ := newTestISO9660Image("SCES-01420", "1998102813221100", "1998010100000000")
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
 	require.NoError(t, err)
@@ -300,9 +299,10 @@ func TestReadISO9660Identity(t *testing.T) {
 func TestReadISO9660Identity_TokenFile(t *testing.T) {
 	t.Parallel()
 
-	contents := []byte("  **launch.system:nes\n")
-	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
-	addTestISO9660TokenFile(image, "zaparoo.txt", contents, testISO9660DataLength(contents))
+	const fixtureContents = "  **launch.system:nes\n"
+	contents := []byte(fixtureContents)
+	image, rootEntriesSize := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, rootEntriesSize, "zaparoo.txt", contents, uint32(len(fixtureContents)))
 
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
@@ -319,8 +319,8 @@ func TestReadISO9660Identity_TokenFileNameVariants(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
-			addTestISO9660TokenFile(image, name, []byte("launch"), uint32(len("launch")))
+			image, rootEntriesSize := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+			addTestISO9660TokenFile(image, rootEntriesSize, name, []byte("launch"), uint32(len("launch")))
 
 			identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
@@ -335,8 +335,8 @@ func TestReadISO9660Identity_TokenFileNameVariants(t *testing.T) {
 func TestReadISO9660Identity_EmptyTokenFile(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
-	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, 0)
+	image, rootEntriesSize := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, rootEntriesSize, "zaparoo.txt;1", nil, 0)
 
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
@@ -349,8 +349,8 @@ func TestReadISO9660Identity_EmptyTokenFile(t *testing.T) {
 func TestReadISO9660Identity_OversizedTokenFile(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
-	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, iso9660MaxTokenFileSize+1)
+	image, rootEntriesSize := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, rootEntriesSize, "zaparoo.txt;1", nil, iso9660MaxTokenFileSize+1)
 
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
@@ -363,9 +363,9 @@ func TestReadISO9660Identity_OversizedTokenFile(t *testing.T) {
 func TestReadISO9660Identity_MalformedTokenDirectoryPreservesIdentity(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
+	image, rootEntriesSize := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
 	root := image[testISO9660RootExtent*iso9660SectorSize:]
-	root[testISO9660RootEntriesSize] = 10
+	root[rootEntriesSize] = 10
 
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
@@ -379,8 +379,8 @@ func TestReadISO9660Identity_MalformedTokenDirectoryPreservesIdentity(t *testing
 func TestReadISO9660Identity_TruncatedTokenFilePreservesIdentity(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
-	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, 32)
+	image, rootEntriesSize := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
+	addTestISO9660TokenFile(image, rootEntriesSize, "zaparoo.txt;1", nil, 32)
 	image = image[:testISO9660TokenExtent*iso9660SectorSize]
 
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
@@ -395,7 +395,7 @@ func TestReadISO9660Identity_TruncatedTokenFilePreservesIdentity(t *testing.T) {
 func TestReadISO9660Identity_FallsBackToCreatedDate(t *testing.T) {
 	t.Parallel()
 
-	image := newTestISO9660Image("SCES-01420", "0000000000000000", "1998010100000000")
+	image, _ := newTestISO9660Image("SCES-01420", "0000000000000000", "1998010100000000")
 	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
 
 	require.NoError(t, err)
@@ -446,8 +446,8 @@ func readTestISO9660Identity(reader *bytes.Reader) (discIdentity, bool, error) {
 	return readISO9660IdentityContext(context.Background(), testReaderAtContextAdapter{reader: reader})
 }
 
-func newTestISO9660Image(label, modified, created string) []byte {
-	image := make([]byte, (testISO9660TokenExtent+1)*iso9660SectorSize)
+func newTestISO9660Image(label, modified, created string) (image []byte, rootEntriesSize int) {
+	image = make([]byte, (testISO9660TokenExtent+1)*iso9660SectorSize)
 	desc := image[iso9660SuperblockOffset:]
 	desc[0] = iso9660DescriptorTypePrimary
 	copy(desc[1:6], "CD001")
@@ -465,27 +465,33 @@ func newTestISO9660Image(label, modified, created string) []byte {
 	)
 
 	root := image[testISO9660RootExtent*iso9660SectorSize:]
-	offset := writeTestISO9660DirectoryRecord(
+	rootEntriesSize = writeTestISO9660DirectoryRecord(
 		root,
 		testISO9660RootExtent,
 		iso9660SectorSize,
 		iso9660DirectoryFlag,
 		[]byte{0},
 	)
-	writeTestISO9660DirectoryRecord(
-		root[offset:],
+	rootEntriesSize += writeTestISO9660DirectoryRecord(
+		root[rootEntriesSize:],
 		testISO9660RootExtent,
 		iso9660SectorSize,
 		iso9660DirectoryFlag,
 		[]byte{1},
 	)
-	return image
+	return image, rootEntriesSize
 }
 
-func addTestISO9660TokenFile(image []byte, name string, contents []byte, declaredSize uint32) {
+func addTestISO9660TokenFile(
+	image []byte,
+	rootEntriesSize int,
+	name string,
+	contents []byte,
+	declaredSize uint32,
+) {
 	root := image[testISO9660RootExtent*iso9660SectorSize:]
 	writeTestISO9660DirectoryRecord(
-		root[testISO9660RootEntriesSize:],
+		root[rootEntriesSize:],
 		testISO9660TokenExtent,
 		declaredSize,
 		0,
@@ -501,15 +507,19 @@ func writeTestISO9660DirectoryRecord(
 	flags uint8,
 	identifier []byte,
 ) int {
-	identifierLength := byte(0)
-	for range identifier {
-		identifierLength++
+	if len(identifier) > int(^uint8(0)) {
+		panic("test ISO9660 identifier exceeds byte-sized field")
 	}
-	recordLengthByte := byte(iso9660FileIdentifierOffset) + identifierLength
-	if recordLengthByte%2 != 0 {
-		recordLengthByte++
+	identifierLength := byte(len(identifier)) //nolint:gosec // Length is bounds-checked above.
+
+	recordLength := iso9660FileIdentifierOffset + len(identifier)
+	if recordLength%2 != 0 {
+		recordLength++
 	}
-	recordLength := int(recordLengthByte)
+	if recordLength > int(^uint8(0)) {
+		panic("test ISO9660 directory record exceeds byte-sized field")
+	}
+	recordLengthByte := byte(recordLength)
 
 	record := destination[:recordLength]
 	record[0] = recordLengthByte
@@ -523,14 +533,6 @@ func writeTestISO9660DirectoryRecord(
 	record[iso9660FileIdentifierLengthOffset] = identifierLength
 	copy(record[iso9660FileIdentifierOffset:], identifier)
 	return recordLength
-}
-
-func testISO9660DataLength(data []byte) uint32 {
-	var length uint32
-	for range data {
-		length++
-	}
-	return length
 }
 
 type mockFSChecker struct {

--- a/pkg/readers/opticaldrive/opticaldrive_test.go
+++ b/pkg/readers/opticaldrive/opticaldrive_test.go
@@ -24,6 +24,8 @@ package opticaldrive
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -37,9 +39,16 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
+)
+
+const (
+	testISO9660RootExtent      = 20
+	testISO9660TokenExtent     = 21
+	testISO9660RootEntriesSize = 68
 )
 
 func TestNewReader(t *testing.T) {
@@ -285,6 +294,102 @@ func TestReadISO9660Identity(t *testing.T) {
 	require.True(t, found)
 	assert.Equal(t, "SCES-01420", identity.Label)
 	assert.Equal(t, "1998-10-28-13-22-11-00", identity.UUID)
+	assert.Equal(t, discTokenFileAbsent, identity.TokenFile.State)
+}
+
+func TestReadISO9660Identity_TokenFile(t *testing.T) {
+	t.Parallel()
+
+	contents := []byte("  **launch.system:nes\n")
+	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, "zaparoo.txt", contents, testISO9660DataLength(contents))
+
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, discTokenFilePresent, identity.TokenFile.State)
+	assert.Equal(t, contents, identity.TokenFile.Data)
+}
+
+func TestReadISO9660Identity_TokenFileNameVariants(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"ZAPAROO.TXT", "ZaPaRoO.TxT;1"} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+			addTestISO9660TokenFile(image, name, []byte("launch"), uint32(len("launch")))
+
+			identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, discTokenFilePresent, identity.TokenFile.State)
+			assert.Equal(t, []byte("launch"), identity.TokenFile.Data)
+		})
+	}
+}
+
+func TestReadISO9660Identity_EmptyTokenFile(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, 0)
+
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, discTokenFilePresent, identity.TokenFile.State)
+	assert.Empty(t, identity.TokenFile.Data)
+}
+
+func TestReadISO9660Identity_OversizedTokenFile(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("DATA", "2026010100000000", "2026010100000000")
+	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, iso9660MaxTokenFileSize+1)
+
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, discTokenFilePresent, identity.TokenFile.State)
+	assert.Empty(t, identity.TokenFile.Data)
+}
+
+func TestReadISO9660Identity_MalformedTokenDirectoryPreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
+	root := image[testISO9660RootExtent*iso9660SectorSize:]
+	root[testISO9660RootEntriesSize] = 10
+
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "LEGACY", identity.Label)
+	assert.Equal(t, "1998-01-01-00-00-00-00", identity.UUID)
+	assert.Equal(t, discTokenFileUnknown, identity.TokenFile.State)
+}
+
+func TestReadISO9660Identity_TruncatedTokenFilePreservesIdentity(t *testing.T) {
+	t.Parallel()
+
+	image := newTestISO9660Image("LEGACY", "1998010100000000", "1998010100000000")
+	addTestISO9660TokenFile(image, "zaparoo.txt;1", nil, 32)
+	image = image[:testISO9660TokenExtent*iso9660SectorSize]
+
+	identity, found, err := readTestISO9660Identity(bytes.NewReader(image))
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "LEGACY", identity.Label)
+	assert.Equal(t, "1998-01-01-00-00-00-00", identity.UUID)
+	assert.Equal(t, discTokenFileUnknown, identity.TokenFile.State)
 }
 
 func TestReadISO9660Identity_FallsBackToCreatedDate(t *testing.T) {
@@ -342,7 +447,7 @@ func readTestISO9660Identity(reader *bytes.Reader) (discIdentity, bool, error) {
 }
 
 func newTestISO9660Image(label, modified, created string) []byte {
-	image := make([]byte, iso9660SuperblockOffset+iso9660SectorSize)
+	image := make([]byte, (testISO9660TokenExtent+1)*iso9660SectorSize)
 	desc := image[iso9660SuperblockOffset:]
 	desc[0] = iso9660DescriptorTypePrimary
 	copy(desc[1:6], "CD001")
@@ -351,7 +456,81 @@ func newTestISO9660Image(label, modified, created string) []byte {
 	copy(desc[iso9660VolumeIDOffset:iso9660VolumeIDOffset+iso9660VolumeIDSize], label)
 	copy(desc[iso9660ModifiedOffset:iso9660ModifiedOffset+16], modified)
 	copy(desc[iso9660CreatedOffset:iso9660CreatedOffset+16], created)
+	writeTestISO9660DirectoryRecord(
+		desc[iso9660RootDirectoryRecordOffset:],
+		testISO9660RootExtent,
+		iso9660SectorSize,
+		iso9660DirectoryFlag,
+		[]byte{0},
+	)
+
+	root := image[testISO9660RootExtent*iso9660SectorSize:]
+	offset := writeTestISO9660DirectoryRecord(
+		root,
+		testISO9660RootExtent,
+		iso9660SectorSize,
+		iso9660DirectoryFlag,
+		[]byte{0},
+	)
+	writeTestISO9660DirectoryRecord(
+		root[offset:],
+		testISO9660RootExtent,
+		iso9660SectorSize,
+		iso9660DirectoryFlag,
+		[]byte{1},
+	)
 	return image
+}
+
+func addTestISO9660TokenFile(image []byte, name string, contents []byte, declaredSize uint32) {
+	root := image[testISO9660RootExtent*iso9660SectorSize:]
+	writeTestISO9660DirectoryRecord(
+		root[testISO9660RootEntriesSize:],
+		testISO9660TokenExtent,
+		declaredSize,
+		0,
+		[]byte(name),
+	)
+	copy(image[testISO9660TokenExtent*iso9660SectorSize:], contents)
+}
+
+func writeTestISO9660DirectoryRecord(
+	destination []byte,
+	extentLocation uint32,
+	dataLength uint32,
+	flags uint8,
+	identifier []byte,
+) int {
+	identifierLength := byte(0)
+	for range identifier {
+		identifierLength++
+	}
+	recordLengthByte := byte(iso9660FileIdentifierOffset) + identifierLength
+	if recordLengthByte%2 != 0 {
+		recordLengthByte++
+	}
+	recordLength := int(recordLengthByte)
+
+	record := destination[:recordLength]
+	record[0] = recordLengthByte
+	binary.LittleEndian.PutUint32(record[2:6], extentLocation)
+	binary.BigEndian.PutUint32(record[6:10], extentLocation)
+	binary.LittleEndian.PutUint32(record[10:14], dataLength)
+	binary.BigEndian.PutUint32(record[14:18], dataLength)
+	record[iso9660FileFlagsOffset] = flags
+	binary.LittleEndian.PutUint16(record[28:30], 1)
+	binary.BigEndian.PutUint16(record[30:32], 1)
+	record[iso9660FileIdentifierLengthOffset] = identifierLength
+	copy(record[iso9660FileIdentifierOffset:], identifier)
+	return recordLength
+}
+
+func testISO9660DataLength(data []byte) uint32 {
+	var length uint32
+	for range data {
+		length++
+	}
+	return length
 }
 
 type mockFSChecker struct {
@@ -636,6 +815,186 @@ func TestOpen_SuccessfulDiscDetection(t *testing.T) {
 	// Clean up
 	err = reader.Close()
 	require.NoError(t, err)
+}
+
+func TestOpen_TokenFileContent(t *testing.T) {
+	t.Parallel()
+
+	contents := []byte("  **launch.system:nes\n")
+	reader := newTestReader(&config.Instance{})
+	reader.fsChecker = &mockFSChecker{}
+	reader.discIdentifier = &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{
+				UUID:  "test-uuid",
+				Label: "test-label",
+				TokenFile: discTokenFile{
+					Data:  contents,
+					State: discTokenFilePresent,
+				},
+			}, nil
+		},
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, scan.Token)
+	assert.Equal(t, "disc", scan.Token.Type)
+	assert.Equal(t, "test-uuid/test-label", scan.Token.UID)
+	assert.Equal(t, "**launch.system:nes", scan.Token.Text)
+	assert.Equal(t, hex.EncodeToString(contents), scan.Token.Data)
+	assert.Equal(t, tokens.SourceReader, scan.Token.Source)
+	assert.NotEmpty(t, scan.Token.ReaderID)
+	assert.Empty(t, scan.Token.PathRoot)
+
+	require.NoError(t, reader.Close())
+}
+
+func TestOpen_InitialTokenParseErrorPreservesLegacyIdentity(t *testing.T) {
+	t.Parallel()
+
+	reader := newTestReader(&config.Instance{})
+	reader.fsChecker = &mockFSChecker{}
+	reader.discIdentifier = &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			return discIdentity{
+				UUID:      "legacy-uuid",
+				Label:     "legacy-label",
+				TokenFile: discTokenFile{State: discTokenFileUnknown},
+			}, nil
+		},
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, scan.Token)
+	assert.Equal(t, "legacy-uuid/legacy-label", scan.Token.UID)
+	assert.Empty(t, scan.Token.Text)
+	assert.Empty(t, scan.Token.Data)
+	testutils.AssertNoScan(t, scanQueue, 1500*time.Millisecond)
+
+	require.NoError(t, reader.Close())
+}
+
+func TestOpen_TokenParseErrorDoesNotRemoveActiveToken(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	reader := newTestReader(&config.Instance{})
+	reader.fsChecker = &mockFSChecker{}
+	reader.discIdentifier = &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			identity := discIdentity{UUID: "test-uuid", Label: "test-label"}
+			if callCount.Add(1) == 1 {
+				identity.TokenFile = discTokenFile{Data: []byte("launch"), State: discTokenFilePresent}
+			} else {
+				identity.TokenFile = discTokenFile{State: discTokenFileUnknown}
+			}
+			return identity, nil
+		},
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	scan := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, scan.Token)
+	assert.Equal(t, "launch", scan.Token.Text)
+	testutils.AssertNoScan(t, scanQueue, 2500*time.Millisecond)
+
+	require.NoError(t, reader.Close())
+}
+
+func TestOpen_TokenContentChangeEmitsOneUpdatedScan(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	reader := newTestReader(&config.Instance{})
+	reader.fsChecker = &mockFSChecker{}
+	reader.discIdentifier = &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			contents := []byte("second")
+			if callCount.Add(1) == 1 {
+				contents = []byte("first")
+			}
+			return discIdentity{
+				UUID:      "test-uuid",
+				Label:     "test-label",
+				TokenFile: discTokenFile{Data: contents, State: discTokenFilePresent},
+			}, nil
+		},
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	first := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, first.Token)
+	assert.Equal(t, "first", first.Token.Text)
+
+	second := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, second.Token)
+	assert.Equal(t, "second", second.Token.Text)
+	testutils.AssertNoScan(t, scanQueue, 1500*time.Millisecond)
+
+	require.NoError(t, reader.Close())
+}
+
+func TestOpen_DiscRemovalAfterTokenFileEmitsRemoval(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	reader := newTestReader(&config.Instance{})
+	reader.fsChecker = &mockFSChecker{}
+	reader.discIdentifier = &mockDiscIdentifier{
+		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
+			if callCount.Add(1) == 1 {
+				return discIdentity{
+					UUID:      "test-uuid",
+					Label:     "test-label",
+					TokenFile: discTokenFile{Data: []byte("launch"), State: discTokenFilePresent},
+				}, nil
+			}
+			return discIdentity{}, errISO9660IdentityNotFound
+		},
+	}
+	scanQueue := testutils.CreateTestScanChannel(t)
+
+	err := reader.Open(config.ReadersConnect{
+		Driver: "optical_drive",
+		Path:   "/dev/sr0",
+	}, scanQueue, readers.OpenOpts{})
+	require.NoError(t, err)
+
+	inserted := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	require.NotNil(t, inserted.Token)
+	assert.Equal(t, "launch", inserted.Token.Text)
+
+	removed := testutils.AssertScanReceived(t, scanQueue, 2*time.Second)
+	assert.Nil(t, removed.Token)
+	assert.False(t, removed.ReaderError)
+
+	require.NoError(t, reader.Close())
 }
 
 func TestOpen_DeviceDisappearsWithActiveToken(t *testing.T) {
@@ -1079,7 +1438,11 @@ func TestOpen_KeepsExistingTokenWhenStableIDTemporarilyUnavailable(t *testing.T)
 		identifyFunc: func(_ context.Context, _ string) (discIdentity, error) {
 			call := callCount.Add(1)
 			if call == 1 {
-				return discIdentity{UUID: "1998-10-28-13-22-11-00", Label: "SCES-01420"}, nil
+				return discIdentity{
+					UUID:      "1998-10-28-13-22-11-00",
+					Label:     "SCES-01420",
+					TokenFile: discTokenFile{Data: []byte("launch"), State: discTokenFilePresent},
+				}, nil
 			}
 			return discIdentity{}, errors.New("disc identity unavailable")
 		},
@@ -1104,6 +1467,7 @@ func TestOpen_KeepsExistingTokenWhenStableIDTemporarilyUnavailable(t *testing.T)
 	scan := testutils.AssertScanReceived(t, scanQueue, 1500*time.Millisecond)
 	require.NotNil(t, scan.Token)
 	assert.Equal(t, "1998-10-28-13-22-11-00/SCES-01420", scan.Token.UID)
+	assert.Equal(t, "launch", scan.Token.Text)
 	require.Len(t, scan.Properties, 1)
 
 	testutils.AssertNoScan(t, scanQueue, 2500*time.Millisecond)


### PR DESCRIPTION
## Summary

- read root-level `zaparoo.txt` directly from ISO9660 optical media without mounting it
- preserve legacy optical identity and active tokens when optional token-file parsing fails
- include token-file presence and content in media change detection, with raw-image and polling regressions

Closes #1227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optical drives now detect token files stored on ISO9660 discs.
  * Token-file content is included in scan data and updates when the content changes.
  * Token files are recognized across supported filename variants.

* **Bug Fixes**
  * Disc identity and active token data are preserved during temporary read or parsing failures.
  * Invalid, oversized, truncated, malformed, or empty token files are handled safely.
  * Disc removal correctly clears associated token information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->