### PR TITLE
fix(updater): use Last-Modified for manifest conditional GET

### DIFF
--- a/.github/actions/ota-metadata/action.yml
+++ b/.github/actions/ota-metadata/action.yml
@@ -372,11 +372,15 @@ runs:
           rm -rf _verify
           mkdir -p _verify
 
+          # Deliberately the plain URL a device would request, with no
+          # cache-busting: the check is that the edge serves what we signed, so
+          # bypassing the cache would verify the origin and miss the case that
+          # matters. The purge above is what makes the edge current, and a
+          # mismatch here means the purge has not landed yet.
           fetched=true
           for f in $names; do
             if ! curl -fsS --retry 2 --retry-delay 2 --connect-timeout 15 --max-time 120 \
-                -H 'Cache-Control: no-cache' -H 'Pragma: no-cache' \
-                "$base/$f?cb=${GITHUB_RUN_ID}-${attempt}" -o "_verify/$f"; then
+                -D "_verify/$f.headers" "$base/$f" -o "_verify/$f"; then
               fetched=false
               break
             fi
@@ -397,10 +401,19 @@ runs:
           fi
 
           echo "Attempt $attempt: the edge is still serving older metadata, retrying"
+          for f in $names; do
+            # curl appends a header block per --retry attempt, so report the last.
+            state=$(grep -i '^cdn-cache:' "_verify/$f.headers" 2>/dev/null |
+              tail -n1 | tr -d '\r' || true)
+            echo "  $f: ${state:-cdn-cache: unreported}"
+          done
           sleep 15
         done
 
         if [ "$matched" != true ]; then
+          # A HIT in the states logged above means the purge did not take; a MISS
+          # means the origin itself is serving something other than what we
+          # uploaded. The two have completely different fixes.
           echo "::error::published metadata does not match what was signed after the purge"
           exit 1
         fi

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -171,9 +171,16 @@ Every publishing run does the same thing, in this order:
 6. Check the publish directory holds those four files and nothing else, and
    that no archive URL points anywhere but GitHub.
 7. Upload and purge the pull zone.
-8. Re-fetch all four files from the public URL, cache-busted, and require them
-   to be byte-identical to what was signed. Retries for a while, because purge
-   propagation is not instant. **A run that reaches this step and fails it has
+8. Re-fetch all four files from the public URL — the plain URL a device would
+   request, through the edge cache — and require them to be byte-identical to
+   what was signed. Cache-busting is deliberately not used: the thing being
+   checked is what the edge serves, and bypassing the cache would verify the
+   storage origin instead and miss the case that matters. Step 7's purge is what
+   makes the edge current, so a mismatch here means the purge has not landed
+   yet, and the step retries for a while because propagation is not instant.
+   Each failed attempt logs the `Cdn-Cache` header per file: a `HIT` means the
+   purge did not take, a `MISS` means the origin itself is serving something
+   other than what was uploaded. **A run that reaches this step and fails it has
    published something unverified** — investigate before dispatching anything
    else.
 

--- a/pkg/service/updater/otameta/manifest_test.go
+++ b/pkg/service/updater/otameta/manifest_test.go
@@ -377,9 +377,12 @@ func TestFindRelease(t *testing.T) {
 	assert.Nil(t, FindRelease(nil, "v2.16.1"))
 }
 
-// Guard against the manifest growing a field whose yaml name does not match
-// what go-selfupdate's HttpManifest expects, which would silently drop data for
-// deployed 2.x clients.
+// The channel names and the archive prefix are wire values: the publisher writes
+// them and the client matches on them, so a rename here is a fleet-wide break.
+// The separate guard that the manifest's yaml field names still decode into
+// go-selfupdate's HttpManifest is
+// TestRun_ProducedManifestDecodesInGoSelfupdate, which runs against a manifest
+// the generator actually produced.
 func TestManifest_ChannelNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/source.go
+++ b/pkg/service/updater/source.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
@@ -73,6 +74,23 @@ type verifiedSource struct {
 	stateDir   string
 	platformID string
 	goarch     string
+}
+
+// cacheValidators are the conditional-request tokens for a copy already on
+// disk. Both are sent when known: servers that offer an ETag prefer it, and the
+// ones that do not still answer If-Modified-Since.
+type cacheValidators struct {
+	etag         string
+	lastModified string
+}
+
+// httpResult is a size-capped response body, or the fact that the cached copy
+// is still current.
+type httpResult struct {
+	etag         string
+	lastModified string
+	body         []byte
+	notModified  bool
 }
 
 func (s *verifiedSource) ListReleases(
@@ -306,23 +324,6 @@ func (s *verifiedSource) DownloadReleaseAsset(
 	return res.Body, nil
 }
 
-// cacheValidators are the conditional-request tokens for a copy already on
-// disk. Both are sent when known: servers that offer an ETag prefer it, and the
-// ones that do not still answer If-Modified-Since.
-type cacheValidators struct {
-	etag         string
-	lastModified string
-}
-
-// httpResult is a size-capped response body, or the fact that the cached copy
-// is still current.
-type httpResult struct {
-	etag         string
-	lastModified string
-	body         []byte
-	notModified  bool
-}
-
 // get reads at most limit bytes from a URL. Accept-Encoding is deliberately
 // left to the transport so responses are transparently gzipped on the wire and
 // handed back as the original bytes the signature covers.
@@ -400,11 +401,11 @@ func resolveAssetURL(raw, base string) string {
 // isReleaseArchive reports whether a name looks like an installable archive
 // for any platform, as opposed to a metadata file published alongside them.
 func isReleaseArchive(name string) bool {
-	if len(name) < len("zaparoo-") || name[:len("zaparoo-")] != "zaparoo-" {
+	if !strings.HasPrefix(name, "zaparoo-") {
 		return false
 	}
 	for _, ext := range []string{".tar.gz", ".zip"} {
-		if len(name) > len(ext) && name[len(name)-len(ext):] == ext {
+		if strings.HasSuffix(name, ext) {
 			return true
 		}
 	}

--- a/pkg/service/updater/source.go
+++ b/pkg/service/updater/source.go
@@ -105,7 +105,7 @@ func (s *verifiedSource) ListReleases(
 // them, and enforces the generation watermark. The signature is always fetched
 // fresh; the manifest body is only re-downloaded when the CDN says it changed.
 func (s *verifiedSource) fetchManifest(ctx context.Context, base string) (*otameta.Manifest, error) {
-	sig, err := s.get(ctx, base+"/"+manifestSigFileName, "", ed25519.SignatureSize)
+	sig, err := s.get(ctx, base+"/"+manifestSigFileName, cacheValidators{}, ed25519.SignatureSize)
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest signature: %w", err)
 	}
@@ -119,12 +119,16 @@ func (s *verifiedSource) fetchManifest(ctx context.Context, base string) (*otame
 	st := loadState(s.stateDir)
 	cached := loadCachedManifest(s.stateDir)
 
-	etag := ""
+	// Only conditional when there are bytes on disk for a 304 to refer back to.
+	var validators cacheValidators
 	if len(cached) > 0 {
-		etag = st.ManifestETag
+		validators = cacheValidators{
+			etag:         st.ManifestETag,
+			lastModified: st.ManifestLastModified,
+		}
 	}
 
-	res, err := s.get(ctx, base+"/"+manifestFileName, etag, maxManifestBytes)
+	res, err := s.get(ctx, base+"/"+manifestFileName, validators, maxManifestBytes)
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest: %w", err)
 	}
@@ -162,11 +166,13 @@ func (s *verifiedSource) persist(st *updaterState, generation int64, res *httpRe
 	if !res.notModified {
 		if err := saveCachedManifest(s.stateDir, res.body); err != nil {
 			log.Warn().Err(err).Msg("could not cache verified update manifest")
-			// An ETag pointing at a manifest we failed to store would make the
-			// next check take a 304 with nothing to pair it with.
+			// Validators pointing at a manifest we failed to store would make
+			// the next check take a 304 with nothing to pair it with.
 			res.etag = ""
+			res.lastModified = ""
 		}
 		st.ManifestETag = res.etag
+		st.ManifestLastModified = res.lastModified
 	}
 
 	st.ManifestGeneration = generation
@@ -300,26 +306,40 @@ func (s *verifiedSource) DownloadReleaseAsset(
 	return res.Body, nil
 }
 
+// cacheValidators are the conditional-request tokens for a copy already on
+// disk. Both are sent when known: servers that offer an ETag prefer it, and the
+// ones that do not still answer If-Modified-Since.
+type cacheValidators struct {
+	etag         string
+	lastModified string
+}
+
 // httpResult is a size-capped response body, or the fact that the cached copy
 // is still current.
 type httpResult struct {
-	etag        string
-	body        []byte
-	notModified bool
+	etag         string
+	lastModified string
+	body         []byte
+	notModified  bool
 }
 
 // get reads at most limit bytes from a URL. Accept-Encoding is deliberately
 // left to the transport so responses are transparently gzipped on the wire and
 // handed back as the original bytes the signature covers.
-func (s *verifiedSource) get(ctx context.Context, target, etag string, limit int64) (*httpResult, error) {
+func (s *verifiedSource) get(
+	ctx context.Context, target string, validators cacheValidators, limit int64,
+) (*httpResult, error) {
 	client := &http.Client{Timeout: manifestFetchTimeout, Transport: s.transport}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	if etag != "" {
-		req.Header.Set("If-None-Match", etag)
+	if validators.etag != "" {
+		req.Header.Set("If-None-Match", validators.etag)
+	}
+	if validators.lastModified != "" {
+		req.Header.Set("If-Modified-Since", validators.lastModified)
 	}
 
 	res, err := client.Do(req)
@@ -333,7 +353,11 @@ func (s *verifiedSource) get(ctx context.Context, target, etag string, limit int
 	}()
 
 	if res.StatusCode == http.StatusNotModified {
-		return &httpResult{notModified: true, etag: etag}, nil
+		return &httpResult{
+			notModified:  true,
+			etag:         validators.etag,
+			lastModified: validators.lastModified,
+		}, nil
 	}
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("request failed with status %d", res.StatusCode)
@@ -349,7 +373,11 @@ func (s *verifiedSource) get(ctx context.Context, target, etag string, limit int
 		return nil, fmt.Errorf("response is larger than the %d byte limit", limit)
 	}
 
-	return &httpResult{body: body, etag: res.Header.Get("ETag")}, nil
+	return &httpResult{
+		body:         body,
+		etag:         res.Header.Get("ETag"),
+		lastModified: res.Header.Get("Last-Modified"),
+	}, nil
 }
 
 // resolveAssetURL turns the manifest's relative metadata URLs into absolute

--- a/pkg/service/updater/source_test.go
+++ b/pkg/service/updater/source_test.go
@@ -36,7 +36,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testRepoPath = "/ZaparooProject/zaparoo-core"
+const (
+	testRepoPath = "/ZaparooProject/zaparoo-core"
+	// testLastModified is a fixed HTTP-date; nothing under test reads a clock.
+	testLastModified = "Mon, 17 Aug 2026 01:26:54 GMT"
+)
 
 // manifestServer serves a signed manifest, counting how often each document was
 // actually fetched so conditional-GET behaviour is observable.
@@ -44,9 +48,11 @@ type manifestServer struct {
 	*httptest.Server
 	body         atomic.Pointer[[]byte]
 	etag         atomic.Pointer[string]
+	lastModified atomic.Pointer[string]
 	priv         ed25519.PrivateKey
 	pub          ed25519.PublicKey
 	manifestGets atomic.Int64
+	manifest304s atomic.Int64
 	sigGets      atomic.Int64
 	sigStatus    atomic.Int64
 }
@@ -59,6 +65,7 @@ func newManifestServer(t *testing.T, body string) *manifestServer {
 
 	ms := &manifestServer{pub: pub, priv: priv}
 	ms.setBody(body, `"v1"`)
+	ms.setLastModified(testLastModified)
 
 	ms.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data := *ms.body.Load()
@@ -73,10 +80,28 @@ func newManifestServer(t *testing.T, body string) *manifestServer {
 		case testRepoPath + "/" + manifestFileName:
 			ms.manifestGets.Add(1)
 			etag := *ms.etag.Load()
-			w.Header().Set("ETag", etag)
-			if r.Header.Get("If-None-Match") == etag {
-				w.WriteHeader(http.StatusNotModified)
-				return
+			lastMod := *ms.lastModified.Load()
+			if etag != "" {
+				w.Header().Set("ETag", etag)
+			}
+			if lastMod != "" {
+				w.Header().Set("Last-Modified", lastMod)
+			}
+			// RFC 7232 has a server that offers both prefer If-None-Match, so
+			// only one validator is consulted per request.
+			switch {
+			case etag != "":
+				if r.Header.Get("If-None-Match") == etag {
+					ms.manifest304s.Add(1)
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
+			case lastMod != "":
+				if r.Header.Get("If-Modified-Since") == lastMod {
+					ms.manifest304s.Add(1)
+					w.WriteHeader(http.StatusNotModified)
+					return
+				}
 			}
 			_, _ = w.Write(data)
 		default:
@@ -92,6 +117,10 @@ func (ms *manifestServer) setBody(body, etag string) {
 	data := []byte(body)
 	ms.body.Store(&data)
 	ms.etag.Store(&etag)
+}
+
+func (ms *manifestServer) setLastModified(lastModified string) {
+	ms.lastModified.Store(&lastModified)
 }
 
 // source returns a source pointed at this server, verifying against the key
@@ -288,6 +317,7 @@ func TestVerifiedSource_AdvancesWatermark(t *testing.T) {
 	st := loadState(dir)
 	assert.Equal(t, int64(412), st.ManifestGeneration)
 	assert.Equal(t, `"v1"`, st.ManifestETag)
+	assert.Equal(t, testLastModified, st.ManifestLastModified)
 	assert.False(t, st.ManifestSeenAt.IsZero())
 	assert.Equal(t, []byte(twoReleaseManifest(412)), loadCachedManifest(dir))
 }
@@ -346,6 +376,83 @@ func TestVerifiedSource_ConditionalGETUsesCache(t *testing.T) {
 
 	assert.Equal(t, int64(2), ms.manifestGets.Load())
 	assert.Equal(t, int64(2), ms.sigGets.Load(), "the signature must be fetched fresh every check")
+}
+
+// The production shape: Bunny never sends an ETag, because it only forwards one
+// the origin sends and Bunny Storage sends none. Last-Modified alone has to be
+// enough to reuse the cache, or every check re-downloads the whole manifest.
+func TestVerifiedSource_ConditionalGETWithoutETag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	ms.setBody(twoReleaseManifest(412), "")
+
+	_, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+
+	st := loadState(dir)
+	require.Empty(t, st.ManifestETag)
+	require.Equal(t, testLastModified, st.ManifestLastModified)
+
+	releases, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+	assert.Len(t, releases, 2)
+	assert.Equal(t, int64(1), ms.manifest304s.Load(),
+		"the second check should have been answered from cache via If-Modified-Since")
+	assert.Equal(t, int64(2), ms.sigGets.Load(), "the signature must be fetched fresh every check")
+}
+
+// A CDN caches the manifest and its signature as independent objects, so there
+// is a window after a republish where the two can disagree. The cached bytes
+// must lose to the fresh signature rather than being accepted: a check that
+// fails is recoverable on the next one, a mismatched pair being trusted is not.
+func TestVerifiedSource_RejectsCachedManifestAgainstNewerSignature(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	ms.setBody(twoReleaseManifest(412), "")
+
+	_, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+
+	// The body moves on, but Last-Modified does not, so the manifest is still
+	// answered 304 while the signature is re-fetched over the new bytes.
+	ms.setBody(twoReleaseManifest(413), "")
+
+	_, err = ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.ErrorIs(t, err, otameta.ErrBadSignature)
+	require.Equal(t, int64(1), ms.manifest304s.Load())
+
+	// The rejected fetch must leave the watermark and the cache as they were.
+	assert.Equal(t, int64(412), loadState(dir).ManifestGeneration)
+	assert.Equal(t, []byte(twoReleaseManifest(412)), loadCachedManifest(dir))
+}
+
+// A changed Last-Modified means the manifest moved, so the cache must not be
+// reused even though the request was conditional.
+func TestVerifiedSource_NewLastModifiedRefetches(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	ms.setBody(twoReleaseManifest(412), "")
+
+	_, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+
+	ms.setBody(twoReleaseManifest(413), "")
+	ms.setLastModified("Tue, 18 Aug 2026 09:00:00 GMT")
+
+	releases, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+	assert.Len(t, releases, 2)
+
+	st := loadState(dir)
+	assert.Equal(t, int64(413), st.ManifestGeneration, "the newer manifest must have been read")
+	assert.Equal(t, "Tue, 18 Aug 2026 09:00:00 GMT", st.ManifestLastModified)
+	assert.Equal(t, []byte(twoReleaseManifest(413)), loadCachedManifest(dir))
 }
 
 // An ETag with no cached bytes behind it must produce a full refetch, not a 304

--- a/pkg/service/updater/source_test.go
+++ b/pkg/service/updater/source_test.go
@@ -375,6 +375,8 @@ func TestVerifiedSource_ConditionalGETUsesCache(t *testing.T) {
 	require.Len(t, releases, 2)
 
 	assert.Equal(t, int64(2), ms.manifestGets.Load())
+	assert.Equal(t, int64(1), ms.manifest304s.Load(),
+		"the second check should have been answered from cache via If-None-Match")
 	assert.Equal(t, int64(2), ms.sigGets.Load(), "the signature must be fetched fresh every check")
 }
 
@@ -470,7 +472,8 @@ func TestVerifiedSource_MissingCacheRefetches(t *testing.T) {
 	releases, err := ms.source(dir, "linux", "amd64").ListReleases(t.Context(), testRepo())
 	require.NoError(t, err)
 	assert.Len(t, releases, 2)
-	assert.NotNil(t, loadCachedManifest(dir), "the cache should be rewritten")
+	assert.Equal(t, []byte(twoReleaseManifest(412)), loadCachedManifest(dir),
+		"the cache should be rewritten from the served bytes")
 }
 
 func TestVerifiedSource_RejectsOversizedManifest(t *testing.T) {

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -209,7 +209,19 @@ func writeFileAtomic(dir, name string, data []byte) error {
 	if err := os.Rename(tmpName, filepath.Join(dir, name)); err != nil {
 		return fmt.Errorf("replacing updater state file: %w", err)
 	}
-	return syncDir(dir)
+
+	// The rename has already happened, so the write succeeded whatever the
+	// directory sync does. Reporting a sync failure as a write failure would be
+	// actively harmful: callers respond by discarding what they just stored, so
+	// a filesystem that cannot flush a directory handle would permanently throw
+	// away the cache validators and the generation watermark. Not all of them
+	// can — vfat and exFAT are the ones these devices actually run on — and
+	// losing durability across a power cut is the smaller loss.
+	if err := syncDir(dir); err != nil {
+		log.Warn().Err(err).Str("file", name).
+			Msg("updater state was written but the directory could not be flushed")
+	}
+	return nil
 }
 
 func syncDir(dir string) error {
@@ -220,7 +232,8 @@ func syncDir(dir string) error {
 	syncErr := handle.Sync()
 	closeErr := handle.Close()
 
-	// Windows cannot flush a directory handle through os.File.Sync.
+	// Windows cannot flush a directory handle through os.File.Sync, so there is
+	// nothing to report there.
 	if syncErr != nil && (runtime.GOOS != "windows" || !errors.Is(syncErr, os.ErrPermission)) {
 		return fmt.Errorf("syncing updater state directory: %w", syncErr)
 	}

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -57,10 +57,17 @@ type updaterState struct {
 	// ManifestSeenAt records when the generation below was accepted. It is for
 	// operators reading the file; nothing in the verification path reads a clock.
 	ManifestSeenAt time.Time `json:"manifestSeenAt"`
-	// ManifestETag lets the next check ask the CDN for the manifest only if it
-	// changed. The cached bytes are re-verified on every use, so a tampered
-	// cache is caught rather than trusted.
-	ManifestETag string `json:"manifestETag"`
+	// ManifestETag and ManifestLastModified let the next check ask the CDN for
+	// the manifest only if it changed. The cached bytes are re-verified on every
+	// use, so a tampered cache is caught rather than trusted.
+	//
+	// Both are kept because which one fires depends on the origin. Bunny does
+	// not generate ETags; it only forwards one the origin sends, and Bunny
+	// Storage sends none, so in production Last-Modified is the validator that
+	// actually works. ETag is still honoured when present because it is the
+	// stronger of the two and servers that offer both prefer it.
+	ManifestETag         string `json:"manifestETag"`
+	ManifestLastModified string `json:"manifestLastModified"`
 	// ManifestGeneration is the highest generation this device has accepted.
 	ManifestGeneration int64 `json:"manifestGeneration"`
 	StateVersion       int   `json:"stateVersion"`
@@ -127,8 +134,9 @@ func saveState(dir string, st updaterState) error {
 	return writeFileAtomic(dir, stateFileName, data)
 }
 
-// loadCachedManifest returns the manifest bytes kept alongside the ETag. The
-// caller re-verifies them, so a caller receiving nil simply refetches.
+// loadCachedManifest returns the manifest bytes kept alongside the cache
+// validators. The caller re-verifies them, so a caller receiving nil simply
+// refetches.
 func loadCachedManifest(dir string) []byte {
 	if dir == "" {
 		return nil

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -44,14 +44,16 @@ func TestState_RoundTrip(t *testing.T) {
 	seen := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
 
 	require.NoError(t, saveState(dir, updaterState{
-		ManifestGeneration: 412,
-		ManifestETag:       `"abc123"`,
-		ManifestSeenAt:     seen,
+		ManifestGeneration:   412,
+		ManifestETag:         `"abc123"`,
+		ManifestLastModified: "Mon, 17 Aug 2026 01:26:54 GMT",
+		ManifestSeenAt:       seen,
 	}))
 
 	got := loadState(dir)
 	assert.Equal(t, int64(412), got.ManifestGeneration)
 	assert.Equal(t, `"abc123"`, got.ManifestETag)
+	assert.Equal(t, "Mon, 17 Aug 2026 01:26:54 GMT", got.ManifestLastModified)
 	assert.True(t, seen.Equal(got.ManifestSeenAt))
 	assert.Equal(t, currentStateVersion, got.StateVersion)
 }

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -59,7 +59,18 @@ type Result struct {
 	UpdateAvailable bool
 }
 
-func makeUpdater(opts Options) (*selfupdate.Updater, selfupdate.Repository, error) {
+// session is one update operation's updater and the transport backing it.
+type session struct {
+	updater *selfupdate.Updater
+	// close releases the transport's pooled connections. Callers must defer it:
+	// each operation builds a fresh transport, so without it the keep-alive
+	// connections and their goroutines outlive the operation until the idle
+	// timeout expires.
+	close func()
+	repo  selfupdate.Repository
+}
+
+func makeUpdater(opts Options) (*session, error) {
 	// tlsroots hands back a transport this updater owns outright, so setting the
 	// header timeout here does not affect anything else in the process.
 	transport := tlsroots.Transport(nil)
@@ -83,11 +94,15 @@ func makeUpdater(opts Options) (*selfupdate.Updater, selfupdate.Repository, erro
 		Prerelease: opts.Channel == config.UpdateChannelBeta,
 	})
 	if err != nil {
-		return nil, selfupdate.RepositorySlug{}, fmt.Errorf("creating updater: %w", err)
+		transport.CloseIdleConnections()
+		return nil, fmt.Errorf("creating updater: %w", err)
 	}
 
-	repo := selfupdate.NewRepositorySlug("ZaparooProject", "zaparoo-core")
-	return updater, repo, nil
+	return &session{
+		updater: updater,
+		repo:    selfupdate.NewRepositorySlug("ZaparooProject", "zaparoo-core"),
+		close:   transport.CloseIdleConnections,
+	}, nil
 }
 
 // assetFilter is the pattern go-selfupdate matches asset names against. The
@@ -104,12 +119,13 @@ func Check(ctx context.Context, opts Options) (*Result, error) {
 		return nil, ErrDevelopmentVersion
 	}
 
-	updater, repo, err := makeUpdater(opts)
+	s, err := makeUpdater(opts)
 	if err != nil {
 		return nil, err
 	}
+	defer s.close()
 
-	release, found, err := updater.DetectLatest(ctx, repo)
+	release, found, err := s.updater.DetectLatest(ctx, s.repo)
 	if err != nil {
 		return nil, fmt.Errorf("detecting latest release: %w", err)
 	}
@@ -132,19 +148,20 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 		return "", ErrDevelopmentVersion
 	}
 
-	u, repo, err := makeUpdater(opts)
+	s, err := makeUpdater(opts)
 	if err != nil {
 		return "", err
 	}
+	defer s.close()
 
 	// When running as a daemon subprocess, the binary is a temp copy and
 	// os.Executable() would point to it. ZAPAROO_APP holds the path to
 	// the original binary that should be updated instead.
 	var release *selfupdate.Release
 	if appPath := os.Getenv(config.AppEnv); appPath != "" {
-		release, err = u.UpdateCommand(ctx, appPath, config.AppVersion, repo)
+		release, err = s.updater.UpdateCommand(ctx, appPath, config.AppVersion, s.repo)
 	} else {
-		release, err = u.UpdateSelf(ctx, config.AppVersion, repo)
+		release, err = s.updater.UpdateSelf(ctx, config.AppVersion, s.repo)
 	}
 	if err != nil {
 		return "", fmt.Errorf("applying update: %w", err)


### PR DESCRIPTION
The manifest conditional GET never fired in production. The client sent only
`If-None-Match`, but Bunny does not generate ETags — it forwards one the origin
sends, and Bunny Storage sends none — so no file in the zone has an ETag and
every update check re-downloaded the full manifest.

## Client

`updaterState` gains `ManifestLastModified`, and `get()` takes a
`cacheValidators` pair instead of a bare etag string, sending `If-None-Match`
and `If-Modified-Since` when each is known. Both are kept because a server
offering both prefers the ETag, and it is the stronger validator.

Also adds a test for the case where the CDN's manifest and signature disagree.
They are independent edge objects, so a republish leaves a window the length of
their cache TTL where the two can be out of step. The fresh signature wins over
the cached bytes: the check fails with `ErrBadSignature` and leaves the
generation watermark and the cached manifest untouched. No retry — the stale
copy is on the edge, so refetching returns the same object, and the next
scheduled check recovers once the TTL lapses.

## CI

The post-publish verification step exists to confirm the edge serves what we
signed, but fetched with `?cb=` and `Cache-Control: no-cache`, which target the
origin instead. Both are inert: Bunny ignores request `no-cache`, and query
strings are not part of the cache key on this zone, so a novel `?cb=` returns a
`HIT`. The step was doing the right thing by accident. It now fetches the plain
URL a device requests, and logs each file's `Cdn-Cache` state on a mismatch so a
stale `HIT` (purge did not land) is distinguishable from a `MISS` (origin is
wrong).

## Server-side configuration

Done outside the repo, on the pull zone. `manifest.yaml` and `manifest.yaml.sig`
were not being edge-cached at all: Bunny's Smart Cache only caches a fixed
extension list, which includes `.txt` but not `.yaml` or `.sig`, so both were
treated as dynamic and passed through to origin on every request. An Edge Rule
with the **Override Cache Time** action (300s) plus a `Content-Type: text/plain`
response header now has them cached and compressed like `checksums.txt`.

Verified against `updates.zaparoo.org`: `Cdn-Cache: HIT`, `Content-Encoding:
gzip`, 19,932 bytes on the wire instead of 82,129, and both files return 304 to
`If-Modified-Since`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed OTA metadata manifests with key-based verification and platform-specific asset selection.
  * Added persistent metadata caching, validation, rollback protection, and conditional downloads.
  * Added update-manifest verification mode to validate all supported platform and architecture combinations before publishing.
  * Added support for staged signing-key rotation and revocation.

* **Bug Fixes**
  * Prevented ambiguous, missing, invalid, or incompatible update archives from being selected.
  * Improved CDN verification diagnostics, including cache-status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->