### PR TITLE
fix(database): rebuild media database when its schema is newer

### DIFF
--- a/pkg/database/corruption.go
+++ b/pkg/database/corruption.go
@@ -64,6 +64,13 @@ func CorruptMarkerPath(dbPath string) string {
 	return dbPath + CorruptMarkerSuffix
 }
 
+// CorruptBackupPath returns where a database file is renamed aside when it is
+// replaced but worth keeping. Both databases do this, so the mapping lives here
+// rather than being spelled out at each site.
+func CorruptBackupPath(dbPath string) string {
+	return CorruptMarkerPath(dbPath) + ".bak"
+}
+
 // MarkCorrupt writes the corrupt marker sidecar next to dbPath recording that
 // corruption was detected. Best-effort — failures are logged, not returned.
 func MarkCorrupt(dbPath, reason string, now time.Time) {

--- a/pkg/database/corruption_test.go
+++ b/pkg/database/corruption_test.go
@@ -86,6 +86,34 @@ func TestCorruptMarkerLifecycle(t *testing.T) {
 	require.NoError(t, ClearCorruptMarker(dbPath))
 }
 
+// Both databases rename files aside to this path, so the mapping has to stay
+// distinct from the marker itself — otherwise keeping a copy would clear the flag
+// saying why it was kept.
+func TestCorruptBackupPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		dbPath string
+		want   string
+	}{
+		{name: "database file", dbPath: "media.db", want: "media.db" + CorruptMarkerSuffix + ".bak"},
+		{name: "sidecar file", dbPath: "media.db-wal", want: "media.db-wal" + CorruptMarkerSuffix + ".bak"},
+		{
+			name:   "nested path",
+			dbPath: filepath.Join("data", "user.db"),
+			want:   filepath.Join("data", "user.db") + CorruptMarkerSuffix + ".bak",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, CorruptBackupPath(tt.dbPath))
+			assert.NotEqual(t, CorruptMarkerPath(tt.dbPath), CorruptBackupPath(tt.dbPath),
+				"the kept copy must not collide with the marker")
+		})
+	}
+}
+
 func TestNoteCorruption(t *testing.T) {
 	t.Parallel()
 	dbPath := filepath.Join(t.TempDir(), "test.db")

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1036,7 +1036,7 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 	db.inTransaction = false
 
 	if keepBackup {
-		backup := database.CorruptMarkerPath(db.dbPath) + ".bak"
+		backup := database.CorruptBackupPath(db.dbPath)
 		_ = os.Remove(backup)
 		if err := os.Rename(db.dbPath, backup); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warn().Err(err).Msg("failed to preserve corrupt media database backup; deleting instead")

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -639,7 +639,7 @@ func preserveCorruptFile(path string) {
 		log.Warn().Err(err).Str("path", path).Msg("failed to stat corrupt user database file")
 		return
 	}
-	backup := path + database.CorruptMarkerSuffix + ".bak"
+	backup := database.CorruptBackupPath(path)
 	_ = os.Remove(backup)
 	if err := os.Rename(path, backup); err != nil {
 		log.Warn().Err(err).Str("path", path).Msg("failed to preserve corrupt user database file")

--- a/pkg/service/inbox/inbox.go
+++ b/pkg/service/inbox/inbox.go
@@ -49,6 +49,7 @@ const (
 	CategoryMediaDBCorruptionRecoveryFailure = "mediadb_corruption_recovery_failure"
 	CategoryMediaDBCorruptionRecoveryLimit   = "mediadb_corruption_recovery_limit"
 	CategoryMediaDBInterruptedRebuild        = "mediadb_interrupted_rebuild"
+	CategoryMediaDBSchemaReset               = "mediadb_schema_reset"
 	CategoryMediaIndexResumeLimit            = "media_index_resume_limit"
 	CategoryUpdateAvailable                  = "update_available"
 	CategoryBackupRemoteNotAvailable         = "backup_remote_not_available"

--- a/pkg/service/media_user_data_backfill_test.go
+++ b/pkg/service/media_user_data_backfill_test.go
@@ -21,6 +21,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -29,6 +30,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +46,7 @@ func TestBackfillMediaHistoryUUIDs(t *testing.T) {
 	userDB.AssertExpectations(t)
 }
 
-// seedMediaUserData inserts one favourited and one launcher-overridden media into
+// seedMediaUserData inserts one favorited and one launcher-overridden media into
 // media.db, mimicking a database written by a version that stored this data only
 // there. Returns the two paths.
 func seedMediaUserData(ctx context.Context, t *testing.T, mediaDB *mediadb.MediaDB) (favPath, overridePath string) {
@@ -103,7 +105,7 @@ func TestBackfillMediaUserData(t *testing.T) {
 	favPath, overridePath := seedMediaUserData(ctx, t, mediaDB)
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
 
-	backfillMediaUserData(ctx, db, nil)
+	require.NoError(t, backfillMediaUserData(ctx, db, nil))
 
 	fav, found, err := userDB.GetMediaUserData("NES", favPath)
 	require.NoError(t, err)
@@ -125,7 +127,7 @@ func TestBackfillMediaUserDataGuardSkipsWhenPopulated(t *testing.T) {
 	t.Cleanup(userCleanup)
 
 	// UserDB already has a row, so the one-time backfill must not run — even though
-	// media.db has favourites/overrides that aren't in UserDB.
+	// media.db has favorites/overrides that aren't in UserDB.
 	manualPath := filepath.Join("roms", "SNES", "Manual.sfc")
 	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
 		SystemID: "SNES", Path: manualPath, IsFavorite: true,
@@ -133,7 +135,7 @@ func TestBackfillMediaUserDataGuardSkipsWhenPopulated(t *testing.T) {
 	favPath, _ := seedMediaUserData(ctx, t, mediaDB)
 
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
-	backfillMediaUserData(ctx, db, nil)
+	require.NoError(t, backfillMediaUserData(ctx, db, nil))
 
 	_, found, err := userDB.GetMediaUserData("NES", favPath)
 	require.NoError(t, err)
@@ -163,7 +165,7 @@ func TestBackfillMediaUserDataUsesRescuedRows(t *testing.T) {
 	// An empty media database stands in for the rebuilt one: without the rescued
 	// rows there would be nothing to import.
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
-	backfillMediaUserData(ctx, db, rescued)
+	require.NoError(t, backfillMediaUserData(ctx, db, rescued))
 
 	row, found, err := userDB.GetMediaUserData("NES", rescuedPath)
 	require.NoError(t, err)
@@ -172,8 +174,10 @@ func TestBackfillMediaUserDataUsesRescuedRows(t *testing.T) {
 	assert.Equal(t, "RetroArch", row.LauncherOverride)
 }
 
-// A media database written by a newer build may not answer these queries at all.
-// Nothing comes back and startup carries on: the rows were only ever a bonus.
+// A media database written by a newer build may not answer these queries at all. The
+// caller cannot tell that from "there was nothing to rescue" — one means the file held
+// no favorites, the other means it may have held some that are about to be deleted
+// unread — so it is reported as an error.
 func TestRescueMediaUserDataOnUnreadableDatabase(t *testing.T) {
 	ctx := context.Background()
 
@@ -181,10 +185,14 @@ func TestRescueMediaUserDataOnUnreadableDatabase(t *testing.T) {
 	t.Cleanup(mediaCleanup)
 	require.NoError(t, mediaDB.Close())
 
-	assert.Empty(t, rescueMediaUserData(ctx, mediaDB))
+	rows, err := rescueMediaUserData(ctx, mediaDB)
+	require.Error(t, err)
+	assert.Empty(t, rows)
 }
 
-func TestBackfillMediaUserDataSurvivesUnreadableMediaDB(t *testing.T) {
+// The read failure is reported, but nothing was lost: media.db is still there to retry
+// from on the next boot, and startup is not stopped either way.
+func TestBackfillMediaUserDataReportsUnreadableMediaDB(t *testing.T) {
 	ctx := context.Background()
 
 	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
@@ -193,11 +201,50 @@ func TestBackfillMediaUserDataSurvivesUnreadableMediaDB(t *testing.T) {
 	t.Cleanup(userCleanup)
 	require.NoError(t, mediaDB.Close())
 
-	backfillMediaUserData(ctx, &database.Database{MediaDB: mediaDB, UserDB: userDB}, nil)
+	require.Error(t, backfillMediaUserData(ctx, &database.Database{MediaDB: mediaDB, UserDB: userDB}, nil))
 
 	all, err := userDB.ListMediaUserData()
 	require.NoError(t, err)
 	assert.Empty(t, all)
+}
+
+// A caller that is about to destroy the rows' only copy needs to know they did not all
+// land, so a failing upsert is reported rather than only logged — including when some
+// rows did make it, which is the case a count alone would hide.
+func TestBackfillMediaUserDataReportsFailedRescuedRows(t *testing.T) {
+	t.Parallel()
+	firstPath := filepath.Join("roms", "NES", "One.nes")
+	secondPath := filepath.Join("roms", "NES", "Two.nes")
+
+	// NewMockUserDBI already answers ListMediaUserData with no rows, which is the
+	// state the backfill runs in.
+	userDB := testhelpers.NewMockUserDBI()
+	userDB.On("UpsertMediaUserData", mock.MatchedBy(func(row *database.MediaUserData) bool {
+		return row.Path == firstPath
+	})).Return(nil).Once()
+	userDB.On("UpsertMediaUserData", mock.MatchedBy(func(row *database.MediaUserData) bool {
+		return row.Path == secondPath
+	})).Return(errors.New("no space left on device")).Once()
+
+	err := backfillMediaUserData(context.Background(),
+		&database.Database{UserDB: userDB},
+		[]database.MediaUserData{
+			{SystemID: "NES", Path: firstPath, IsFavorite: true},
+			{SystemID: "NES", Path: secondPath, IsFavorite: true},
+		})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "imported 1 of 2")
+
+	userDB.AssertExpectations(t)
+}
+
+// Rescued rows with nowhere to go is a failure too: reporting success would tell the
+// caller the rows are safe when they are about to be deleted.
+func TestBackfillMediaUserDataWithoutUserDBRejectsRescuedRows(t *testing.T) {
+	t.Parallel()
+	err := backfillMediaUserData(context.Background(), &database.Database{},
+		[]database.MediaUserData{{SystemID: "NES", Path: filepath.Join("roms", "NES", "One.nes")}})
+	require.Error(t, err)
 }
 
 // Nothing to read and nothing rescued means there is no work to do.
@@ -207,7 +254,7 @@ func TestBackfillMediaUserDataWithoutMediaDB(t *testing.T) {
 	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
 	t.Cleanup(userCleanup)
 
-	backfillMediaUserData(ctx, &database.Database{UserDB: userDB}, nil)
+	require.NoError(t, backfillMediaUserData(ctx, &database.Database{UserDB: userDB}, nil))
 
 	all, err := userDB.ListMediaUserData()
 	require.NoError(t, err)
@@ -231,9 +278,9 @@ func TestBackfillMediaUserDataIgnoresRescuedRowsWhenPopulated(t *testing.T) {
 
 	rescuedPath := filepath.Join("roms", "NES", "Rescued.nes")
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
-	backfillMediaUserData(ctx, db, []database.MediaUserData{{
+	require.NoError(t, backfillMediaUserData(ctx, db, []database.MediaUserData{{
 		SystemID: "NES", Path: rescuedPath, IsFavorite: true,
-	}})
+	}}))
 
 	_, found, err := userDB.GetMediaUserData("NES", rescuedPath)
 	require.NoError(t, err)

--- a/pkg/service/media_user_data_backfill_test.go
+++ b/pkg/service/media_user_data_backfill_test.go
@@ -103,7 +103,7 @@ func TestBackfillMediaUserData(t *testing.T) {
 	favPath, overridePath := seedMediaUserData(ctx, t, mediaDB)
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
 
-	backfillMediaUserData(ctx, db)
+	backfillMediaUserData(ctx, db, nil)
 
 	fav, found, err := userDB.GetMediaUserData("NES", favPath)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestBackfillMediaUserDataGuardSkipsWhenPopulated(t *testing.T) {
 	favPath, _ := seedMediaUserData(ctx, t, mediaDB)
 
 	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
-	backfillMediaUserData(ctx, db)
+	backfillMediaUserData(ctx, db, nil)
 
 	_, found, err := userDB.GetMediaUserData("NES", favPath)
 	require.NoError(t, err)
@@ -142,4 +142,100 @@ func TestBackfillMediaUserDataGuardSkipsWhenPopulated(t *testing.T) {
 	all, err := userDB.ListMediaUserData()
 	require.NoError(t, err)
 	assert.Len(t, all, 1, "only the pre-existing row remains")
+}
+
+// Rows rescued from a media database that has already been discarded are the only
+// copy left, so the backfill has to take them in place of a read it can no longer
+// do.
+func TestBackfillMediaUserDataUsesRescuedRows(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	rescuedPath := filepath.Join("roms", "NES", "Rescued.nes")
+	rescued := []database.MediaUserData{{
+		SystemID: "NES", Path: rescuedPath, IsFavorite: true, LauncherOverride: "RetroArch",
+	}}
+
+	// An empty media database stands in for the rebuilt one: without the rescued
+	// rows there would be nothing to import.
+	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
+	backfillMediaUserData(ctx, db, rescued)
+
+	row, found, err := userDB.GetMediaUserData("NES", rescuedPath)
+	require.NoError(t, err)
+	require.True(t, found, "rescued rows must be imported when UserDB is empty")
+	assert.True(t, row.IsFavorite)
+	assert.Equal(t, "RetroArch", row.LauncherOverride)
+}
+
+// A media database written by a newer build may not answer these queries at all.
+// Nothing comes back and startup carries on: the rows were only ever a bonus.
+func TestRescueMediaUserDataOnUnreadableDatabase(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	require.NoError(t, mediaDB.Close())
+
+	assert.Empty(t, rescueMediaUserData(ctx, mediaDB))
+}
+
+func TestBackfillMediaUserDataSurvivesUnreadableMediaDB(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+	require.NoError(t, mediaDB.Close())
+
+	backfillMediaUserData(ctx, &database.Database{MediaDB: mediaDB, UserDB: userDB}, nil)
+
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+// Nothing to read and nothing rescued means there is no work to do.
+func TestBackfillMediaUserDataWithoutMediaDB(t *testing.T) {
+	ctx := context.Background()
+
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	backfillMediaUserData(ctx, &database.Database{UserDB: userDB}, nil)
+
+	all, err := userDB.ListMediaUserData()
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+// The rescued rows are as stale as any other media.db copy, so the guard that makes
+// UserDB authoritative applies to them too.
+func TestBackfillMediaUserDataIgnoresRescuedRowsWhenPopulated(t *testing.T) {
+	ctx := context.Background()
+
+	mediaDB, mediaCleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(mediaCleanup)
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	t.Cleanup(userCleanup)
+
+	manualPath := filepath.Join("roms", "SNES", "Manual.sfc")
+	require.NoError(t, userDB.UpsertMediaUserData(&database.MediaUserData{
+		SystemID: "SNES", Path: manualPath, IsFavorite: true,
+	}))
+
+	rescuedPath := filepath.Join("roms", "NES", "Rescued.nes")
+	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
+	backfillMediaUserData(ctx, db, []database.MediaUserData{{
+		SystemID: "NES", Path: rescuedPath, IsFavorite: true,
+	}})
+
+	_, found, err := userDB.GetMediaUserData("NES", rescuedPath)
+	require.NoError(t, err)
+	assert.False(t, found, "guard must skip rescued rows when UserDB already has data")
 }

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -92,6 +92,17 @@ func markSchemaAhead(ctx context.Context, t *testing.T, dataDir, dbFile string) 
 	}
 }
 
+// dropMediaDBTable removes a table the rescue queries, standing in for a newer
+// build having reshaped it.
+func dropMediaDBTable(ctx context.Context, t *testing.T, dataDir, table string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", filepath.Join(dataDir, config.MediaDbFile))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+	_, err = conn.ExecContext(ctx, "DROP TABLE "+table)
+	require.NoError(t, err)
+}
+
 // mediaDBSchemaVersion reads the migration version straight out of the file, so
 // the assertion does not depend on the handle under test.
 func mediaDBSchemaVersion(ctx context.Context, t *testing.T, dataDir string) int64 {
@@ -115,7 +126,9 @@ func TestMakeDatabase_SchemaAheadRebuildsMediaDB(t *testing.T) {
 	db, mediaDBReset, err := makeDatabase(ctx, pl)
 	t.Cleanup(func() { closeDatabase(db) })
 	require.NoError(t, err, "a media database from a newer build must not stop startup")
-	assert.True(t, mediaDBReset, "the caller has to know the database was discarded")
+	require.NotNil(t, mediaDBReset, "the caller has to know the database was discarded")
+	assert.False(t, mediaDBReset.userDataLost,
+		"there were no favorites or overrides to lose, so the notice must not claim any")
 
 	_, err = db.MediaDB.FindSystemBySystemID(testSystemID)
 	require.Error(t, err, "the unreadable database's rows must not survive the rebuild")
@@ -138,7 +151,7 @@ func TestMakeDatabase_CompatibleMediaDBIsKept(t *testing.T) {
 	db, mediaDBReset, err := makeDatabase(ctx, pl)
 	t.Cleanup(func() { closeDatabase(db) })
 	require.NoError(t, err)
-	assert.False(t, mediaDBReset, "a readable database must not be reported as rebuilt")
+	assert.Nil(t, mediaDBReset, "a readable database must not be reported as rebuilt")
 
 	system, err := db.MediaDB.FindSystemBySystemID(testSystemID)
 	require.NoError(t, err, "a readable database must be left alone")
@@ -163,7 +176,7 @@ func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
 	db, mediaDBReset, err := makeDatabase(ctx, pl)
 	t.Cleanup(func() { closeDatabase(db) })
 	require.ErrorIs(t, err, database.ErrSchemaAhead)
-	assert.False(t, mediaDBReset)
+	assert.Nil(t, mediaDBReset)
 
 	// A downgrade usually leaves both databases ahead. Startup ends here either
 	// way, so the media index — expensive to rebuild, and holding scraped
@@ -176,7 +189,7 @@ func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
 	assert.Equal(t, "Test System", system.Name)
 }
 
-// Favourites and launcher overrides can still be sitting only in media.db when the
+// Favorites and launcher overrides can still be sitting only in media.db when the
 // rebuild happens, and a reindex cannot bring them back, so the rebuild has to hand
 // them to the backfill on its way out.
 func TestMakeDatabase_SchemaAheadPreservesMediaUserData(t *testing.T) {
@@ -194,17 +207,44 @@ func TestMakeDatabase_SchemaAheadPreservesMediaUserData(t *testing.T) {
 	db, mediaDBReset, err := makeDatabase(ctx, pl)
 	t.Cleanup(func() { closeDatabase(db) })
 	require.NoError(t, err)
-	require.True(t, mediaDBReset)
+	require.NotNil(t, mediaDBReset)
+	assert.False(t, mediaDBReset.userDataLost, "the rows were carried across, so nothing was lost")
 
 	fav, found, err := db.UserDB.GetMediaUserData("NES", favPath)
 	require.NoError(t, err)
-	require.True(t, found, "a favourite held only in the discarded database must survive")
+	require.True(t, found, "a favorite held only in the discarded database must survive")
 	assert.True(t, fav.IsFavorite)
 
 	override, found, err := db.UserDB.GetMediaUserData("NES", overridePath)
 	require.NoError(t, err)
 	require.True(t, found, "a launcher override held only in the discarded database must survive")
 	assert.Equal(t, "RetroArch", override.LauncherOverride)
+}
+
+// The rescue queries this build's tables against a file a newer build wrote, so they
+// can fail outright. Nothing later can say what was in there, so the rebuild has to
+// assume favorites and overrides were lost and pass that on to the notice.
+func TestMakeDatabase_SchemaAheadReportsUnreadableMediaUserData(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+	seedMigratedMediaDB(ctx, t, pl)
+
+	// A newer build having reshaped the tables the rescue reads is the realistic
+	// version of this; dropping one gets the same failure without a second schema.
+	dropMediaDBTable(ctx, t, dataDir, "MediaTags")
+	markSchemaAhead(ctx, t, dataDir, config.MediaDbFile)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err, "an unreadable rescue must not stop startup either")
+	require.NotNil(t, mediaDBReset)
+	assert.True(t, mediaDBReset.userDataLost,
+		"a rescue that could not read the rows must be reported as a loss")
+
+	status, err := db.MediaDB.GetIndexingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, mediadb.IndexingStatusPending, status,
+		"the rebuild still has to happen")
 }
 
 // Start posts the notice rather than makeDatabase, because the media database is
@@ -252,7 +292,7 @@ func TestStart_SchemaAheadPostsInboxMessage(t *testing.T) {
 	db, mediaDBReset, err := makeDatabase(ctx, mockPlatform)
 	t.Cleanup(func() { closeDatabase(db) })
 	require.NoError(t, err)
-	assert.False(t, mediaDBReset, "the database Start rebuilt must now be readable")
+	assert.Nil(t, mediaDBReset, "the database Start rebuilt must now be readable")
 
 	messages, err := db.UserDB.GetInboxMessages()
 	require.NoError(t, err)
@@ -261,25 +301,47 @@ func TestStart_SchemaAheadPostsInboxMessage(t *testing.T) {
 	assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
 }
 
+// A reindex restores the media list and (after a re-scrape) the artwork, so the notice
+// only has to explain that. Favorites and launcher overrides are different: nothing
+// can rebuild them, so when they did not make it across the notice has to say so.
 func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
-	ctx := context.Background()
-	pl, _ := newMediaDBPlatform(t)
+	tests := []struct {
+		name         string
+		userDataLost bool
+	}{
+		{name: "user data carried across", userDataLost: false},
+		{name: "user data lost", userDataLost: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			pl, _ := newMediaDBPlatform(t)
 
-	db, _, err := makeDatabase(ctx, pl)
-	t.Cleanup(func() { closeDatabase(db) })
-	require.NoError(t, err)
+			db, _, err := makeDatabase(ctx, pl)
+			t.Cleanup(func() { closeDatabase(db) })
+			require.NoError(t, err)
 
-	st, _ := state.NewState(pl, "test-boot-uuid")
-	t.Cleanup(st.StopService)
-	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
+			st, _ := state.NewState(pl, "test-boot-uuid")
+			t.Cleanup(st.StopService)
+			st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
 
-	notifyMediaDBSchemaReset(st)
+			notifyMediaDBSchemaReset(st, tt.userDataLost)
 
-	messages, err := db.UserDB.GetInboxMessages()
-	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
-	assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+			messages, err := db.UserDB.GetInboxMessages()
+			require.NoError(t, err)
+			require.Len(t, messages, 1)
+			assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
+			assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+			assert.Contains(t, messages[0].Body, "indexed again",
+				"the notice always explains the reindex")
+			if tt.userDataLost {
+				assert.Contains(t, messages[0].Body, "Favorites")
+			} else {
+				assert.NotContains(t, messages[0].Body, "Favorites",
+					"nothing was lost, so the notice must not say anything needs setting again")
+			}
+		})
+	}
 }
 
 // The notice is an explanation, not part of the rebuild, so a failed write is
@@ -293,15 +355,15 @@ func TestNotifyMediaDBSchemaReset_InboxWriteFailureIsNotFatal(t *testing.T) {
 	t.Cleanup(st.StopService)
 	st.SetInbox(inbox.NewService(userDB, st.Notifications))
 
-	notifyMediaDBSchemaReset(st)
+	notifyMediaDBSchemaReset(st, false)
 
 	userDB.AssertExpectations(t)
 }
 
 func TestNotifyMediaDBSchemaReset_WithoutInboxIsNoOp(_ *testing.T) {
 	// Must not panic before the inbox service exists, or with no state at all.
-	notifyMediaDBSchemaReset(nil)
+	notifyMediaDBSchemaReset(nil, false)
 	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
 	defer st.StopService()
-	notifyMediaDBSchemaReset(st)
+	notifyMediaDBSchemaReset(st, true)
 }

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -155,6 +155,8 @@ func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
 
 	db, _, err := makeDatabase(ctx, pl)
 	require.NoError(t, err)
+	_, err = db.MediaDB.InsertSystem(database.System{Name: "Test System", SystemID: testSystemID})
+	require.NoError(t, err)
 	closeDatabase(db)
 	markSchemaAhead(ctx, t, dataDir, config.UserDbFile)
 
@@ -162,6 +164,16 @@ func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
 	t.Cleanup(func() { closeDatabase(db) })
 	require.ErrorIs(t, err, database.ErrSchemaAhead)
 	assert.False(t, mediaDBReset)
+
+	// A downgrade usually leaves both databases ahead. Startup ends here either
+	// way, so the media index — expensive to rebuild, and holding scraped
+	// metadata — must still be there when the newer build is put back.
+	mediaDB, err := mediadb.OpenMediaDB(ctx, pl)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, mediaDB.Close()) })
+	system, err := mediaDB.FindSystemBySystemID(testSystemID)
+	require.NoError(t, err, "an unreadable user database must not cost the media index")
+	assert.Equal(t, "Test System", system.Name)
 }
 
 // Favourites and launcher overrides can still be sitting only in media.db when the

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,11 +32,14 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	testmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -160,6 +164,91 @@ func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
 	assert.False(t, mediaDBReset)
 }
 
+// Favourites and launcher overrides can still be sitting only in media.db when the
+// rebuild happens, and a reindex cannot bring them back, so the rebuild has to hand
+// them to the backfill on its way out.
+func TestMakeDatabase_SchemaAheadPreservesMediaUserData(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+
+	mediaDB, err := mediadb.OpenMediaDB(ctx, pl)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.MigrateUp())
+	favPath, overridePath := seedMediaUserData(ctx, t, mediaDB)
+	require.NoError(t, mediaDB.Close())
+
+	markSchemaAhead(ctx, t, dataDir, config.MediaDbFile)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err)
+	require.True(t, mediaDBReset)
+
+	fav, found, err := db.UserDB.GetMediaUserData("NES", favPath)
+	require.NoError(t, err)
+	require.True(t, found, "a favourite held only in the discarded database must survive")
+	assert.True(t, fav.IsFavorite)
+
+	override, found, err := db.UserDB.GetMediaUserData("NES", overridePath)
+	require.NoError(t, err)
+	require.True(t, found, "a launcher override held only in the discarded database must survive")
+	assert.Equal(t, "RetroArch", override.LauncherOverride)
+}
+
+// Start posts the notice rather than makeDatabase, because the media database is
+// discarded before the inbox service exists. Covering that wiring takes Start
+// itself, run as far as the API bind — occupied here — which is past the inbox
+// message and short of the reindex the rebuilt database is now due.
+func TestStart_SchemaAheadPostsInboxMessage(t *testing.T) {
+	ctx := context.Background()
+
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, listener.Close()) }()
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	require.True(t, ok)
+
+	testRoot := t.TempDir()
+	settings := platforms.Settings{
+		ConfigDir: testRoot,
+		DataDir:   testRoot,
+		LogDir:    testRoot,
+		TempDir:   testRoot,
+	}
+
+	cfg, err := testhelpers.NewTestConfigWithListenAndPort(nil, testRoot, "127.0.0.1", tcpAddr.Port)
+	require.NoError(t, err)
+	cfg.SetAutoUpdate(false)
+
+	mockPlatform := testmocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("mock-platform")
+	mockPlatform.On("Settings").Return(settings)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{testRoot})
+	mockPlatform.On("SupportedReaders", mock.AnythingOfType("*config.Instance")).Return([]readers.Reader{})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+	mockPlatform.On("ManagedByPackageManager").Return(false)
+	mockPlatform.On("StartPre", cfg).Return(nil)
+	mockPlatform.On("Stop").Return(nil).Maybe()
+
+	seedMigratedMediaDB(ctx, t, mockPlatform)
+	markSchemaAhead(ctx, t, testRoot, config.MediaDbFile)
+
+	svcResult, startErr := Start(mockPlatform, cfg)
+	require.Nil(t, svcResult)
+	require.Error(t, startErr, "the occupied API port is what stops this run, not the rebuild")
+
+	db, mediaDBReset, err := makeDatabase(ctx, mockPlatform)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err)
+	assert.False(t, mediaDBReset, "the database Start rebuilt must now be readable")
+
+	messages, err := db.UserDB.GetInboxMessages()
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
+	assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+}
+
 func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 	ctx := context.Background()
 	pl, _ := newMediaDBPlatform(t)
@@ -179,6 +268,22 @@ func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 	require.Len(t, messages, 1)
 	assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
 	assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+}
+
+// The notice is an explanation, not part of the rebuild, so a failed write is
+// logged and startup continues.
+func TestNotifyMediaDBSchemaReset_InboxWriteFailureIsNotFatal(t *testing.T) {
+	userDB := testhelpers.NewMockUserDBI()
+	userDB.On("AddInboxMessage", mock.Anything).
+		Return((*database.InboxMessage)(nil), errors.New("user database is unwritable"))
+
+	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	st.SetInbox(inbox.NewService(userDB, st.Notifications))
+
+	notifyMediaDBSchemaReset(st)
+
+	userDB.AssertExpectations(t)
 }
 
 func TestNotifyMediaDBSchemaReset_WithoutInboxIsNoOp(_ *testing.T) {

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -1,0 +1,190 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	testmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// schemaAheadVersion is higher than any migration this build embeds, so a
+// database carrying it looks like one a newer binary migrated.
+const schemaAheadVersion int64 = 99999999999999
+
+// testSystemID identifies the row used to tell a preserved database from a
+// rebuilt one.
+const testSystemID = "test"
+
+func newMediaDBPlatform(t *testing.T) (pl platforms.Platform, dataDir string) {
+	t.Helper()
+	dataDir = t.TempDir()
+	mockPlatform := testmocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: dataDir})
+	return mockPlatform, dataDir
+}
+
+// seedMigratedMediaDB creates a media database at this build's schema holding
+// one identifiable row.
+func seedMigratedMediaDB(ctx context.Context, t *testing.T, pl platforms.Platform) {
+	t.Helper()
+	db, err := mediadb.OpenMediaDB(ctx, pl)
+	require.NoError(t, err)
+	require.NoError(t, db.MigrateUp())
+	_, err = db.InsertSystem(database.System{Name: "Test System", SystemID: testSystemID})
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+// markSchemaAhead records a migration version no build of this binary knows
+// about, which is what a newer binary having run against the file looks like to
+// goose. The schema version sidecar is dropped so the version check is not
+// skipped: on a real downgrade the sidecar is present but records the newer
+// binary's version, which fails the fast path's strict equality test the same
+// way a missing sidecar does.
+func markSchemaAhead(ctx context.Context, t *testing.T, dataDir, dbFile string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", filepath.Join(dataDir, dbFile))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, 1)", schemaAheadVersion)
+	require.NoError(t, err)
+
+	sidecar := filepath.Join(dataDir, config.CacheDir, dbFile+".schema_version.json")
+	if err := os.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+		require.NoError(t, err)
+	}
+}
+
+// mediaDBSchemaVersion reads the migration version straight out of the file, so
+// the assertion does not depend on the handle under test.
+func mediaDBSchemaVersion(ctx context.Context, t *testing.T, dataDir string) int64 {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", filepath.Join(dataDir, config.MediaDbFile))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, conn.Close()) }()
+
+	var version int64
+	require.NoError(t, conn.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version").Scan(&version))
+	return version
+}
+
+func TestMakeDatabase_SchemaAheadRebuildsMediaDB(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+	seedMigratedMediaDB(ctx, t, pl)
+	markSchemaAhead(ctx, t, dataDir, config.MediaDbFile)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err, "a media database from a newer build must not stop startup")
+	assert.True(t, mediaDBReset, "the caller has to know the database was discarded")
+
+	_, err = db.MediaDB.FindSystemBySystemID(testSystemID)
+	require.Error(t, err, "the unreadable database's rows must not survive the rebuild")
+
+	status, err := db.MediaDB.GetIndexingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, mediadb.IndexingStatusPending, status,
+		"the rebuilt database must be left pending so startup reindexes it")
+
+	version := mediaDBSchemaVersion(ctx, t, dataDir)
+	assert.Less(t, version, schemaAheadVersion, "the newer build's migration version must be gone")
+	assert.Positive(t, version, "the rebuilt database must be migrated to this build's schema")
+}
+
+func TestMakeDatabase_CompatibleMediaDBIsKept(t *testing.T) {
+	ctx := context.Background()
+	pl, _ := newMediaDBPlatform(t)
+	seedMigratedMediaDB(ctx, t, pl)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err)
+	assert.False(t, mediaDBReset, "a readable database must not be reported as rebuilt")
+
+	system, err := db.MediaDB.FindSystemBySystemID(testSystemID)
+	require.NoError(t, err, "a readable database must be left alone")
+	assert.Equal(t, "Test System", system.Name)
+}
+
+// A user database from a newer build has to stay fatal: unlike the media
+// database, nothing can reconstruct what is in it, so starting up and writing
+// against a schema this build does not understand would lose data. The update
+// rollback path restores a snapshot instead.
+func TestMakeDatabase_SchemaAheadUserDBIsFatal(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+
+	db, _, err := makeDatabase(ctx, pl)
+	require.NoError(t, err)
+	closeDatabase(db)
+	markSchemaAhead(ctx, t, dataDir, config.UserDbFile)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.ErrorIs(t, err, database.ErrSchemaAhead)
+	assert.False(t, mediaDBReset)
+}
+
+func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
+	ctx := context.Background()
+	pl, _ := newMediaDBPlatform(t)
+
+	db, _, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err)
+
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
+
+	notifyMediaDBSchemaReset(st)
+
+	messages, err := db.UserDB.GetInboxMessages()
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
+	assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+}
+
+func TestNotifyMediaDBSchemaReset_WithoutInboxIsNoOp(_ *testing.T) {
+	// Must not panic before the inbox service exists, or with no state at all.
+	notifyMediaDBSchemaReset(nil)
+	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
+	defer st.StopService()
+	notifyMediaDBSchemaReset(st)
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -378,8 +378,8 @@ func Start(
 	log.Info().Msg("initializing inbox service")
 	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
 
-	if mediaDBReset {
-		notifyMediaDBSchemaReset(st)
+	if mediaDBReset != nil {
+		notifyMediaDBSchemaReset(st, mediaDBReset.userDataLost)
 	}
 
 	// Initialize profiles and restore the persisted active profile before

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -361,7 +361,7 @@ func Start(
 
 	log.Info().Msg("opening databases")
 	databaseStarted := time.Now()
-	db, err := makeDatabase(st.GetContext(), pl)
+	db, mediaDBReset, err := makeDatabase(st.GetContext(), pl)
 	if err != nil {
 		log.Error().Err(err).Msgf("error opening databases")
 		return nil, err
@@ -377,6 +377,10 @@ func Start(
 	// Initialize inbox service for system notifications
 	log.Info().Msg("initializing inbox service")
 	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
+
+	if mediaDBReset {
+		notifyMediaDBSchemaReset(st)
+	}
 
 	// Initialize profiles and restore the persisted active profile before
 	// the limits manager starts, so limit checks see the right profile.

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -90,6 +90,19 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		}
 	}()
 
+	// The user database goes first because it is the one that can end startup: if
+	// its schema is newer than this build understands there is nothing to be done
+	// about it, and the media database must not have been thrown away by then.
+	log.Debug().Msg("opening user database")
+	userDB, err := openAndRecoverUserDB(ctx, pl)
+	// Assign before the error check: openAndRecoverUserDB can return a non-nil
+	// handle alongside an error, and the deferred closeDatabase only closes what
+	// is stored on db. Assigning here ensures that handle is not leaked.
+	db.UserDB = userDB
+	if err != nil {
+		return db, false, err
+	}
+
 	log.Debug().Msg("opening media database")
 	mediaDB, err := mediadb.OpenMediaDB(ctx, pl)
 	if err != nil {
@@ -99,11 +112,6 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 
 	log.Debug().Msg("running media database migrations")
 	mediaDBReset := false
-	// Favourites and launcher overrides written before UserDB became their home
-	// exist only in the media database. If the backfill below has not managed to
-	// copy them across yet, discarding the file destroys the only copy, so they
-	// are read out first and handed to the backfill instead.
-	var rescuedUserData []database.MediaUserData
 	err = mediaDB.MigrateUp()
 	switch {
 	case errors.Is(err, database.ErrSchemaAhead):
@@ -116,23 +124,19 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		// No recovery gate is taken around the rebuild: nothing else has a handle
 		// on this database yet, so there is no background work to lock out.
 		log.Warn().Err(err).Msg("media database schema is newer than this build supports, rebuilding it")
-		rescuedUserData = rescueMediaUserData(ctx, mediaDB)
+		// Favourites and launcher overrides written before UserDB became their
+		// home exist only in this file. Import them now rather than carrying them
+		// to the backfill below: once the file is gone the rescue is the only copy
+		// there is, and anything that ends startup in between would take it.
+		if rescued := rescueMediaUserData(ctx, mediaDB); len(rescued) > 0 {
+			backfillMediaUserData(ctx, db, rescued)
+		}
 		if resetErr := resetMediaDBForNewerSchema(mediaDB); resetErr != nil {
 			return db, false, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
 		}
 		mediaDBReset = true
 	case err != nil:
 		return db, false, fmt.Errorf("error migrating mediadb: %w", err)
-	}
-
-	log.Debug().Msg("opening user database")
-	userDB, err := openAndRecoverUserDB(ctx, pl)
-	// Assign before the error check: openAndRecoverUserDB can return a non-nil
-	// handle alongside an error, and the deferred closeDatabase only closes what
-	// is stored on db. Assigning here ensures that handle is not leaked.
-	db.UserDB = userDB
-	if err != nil {
-		return db, false, err
 	}
 
 	// migrate old boltdb mappings if required
@@ -145,17 +149,17 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	// One-time import of favourites/launcher overrides that older versions wrote
 	// only to media.db, so they live in UserDB (the source of truth) and survive a
 	// future media.db rebuild.
-	backfillMediaUserData(ctx, db, rescuedUserData)
+	backfillMediaUserData(ctx, db, nil)
 
 	success = true
 	return db, mediaDBReset, nil
 }
 
 // rescueMediaUserData reads the favourites and launcher overrides out of a media
-// database that is about to be discarded. Best-effort by necessity: the file was
-// written by a newer build, so these queries may not fit its schema at all. A
-// failure here leaves the rebuild to go ahead without them, which is what would
-// have happened regardless.
+// database that is about to be discarded, for the caller to hand straight to the
+// backfill. Best-effort by necessity: the file was written by a newer build, so
+// these queries may not fit its schema at all. A failure here leaves the rebuild
+// to go ahead without them, which is what would have happened regardless.
 func rescueMediaUserData(ctx context.Context, mediaDB *mediadb.MediaDB) []database.MediaUserData {
 	rows, err := mediaDB.GetExistingMediaUserData(ctx)
 	if err != nil {

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -23,6 +23,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -35,6 +36,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
@@ -72,7 +75,10 @@ func setupEnvironmentFS(fs afero.Fs, pl platforms.Platform) error {
 	return nil
 }
 
-func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Database, error) {
+// makeDatabase opens both databases. The returned flag reports that the media
+// database was discarded because its schema was newer than this build supports,
+// so the caller can tell the user why a full reindex is starting.
+func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Database, bool, error) {
 	db := &database.Database{
 		MediaDB: nil,
 		UserDB:  nil,
@@ -87,14 +93,30 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	log.Debug().Msg("opening media database")
 	mediaDB, err := mediadb.OpenMediaDB(ctx, pl)
 	if err != nil {
-		return db, fmt.Errorf("failed to open media database: %w", err)
+		return db, false, fmt.Errorf("failed to open media database: %w", err)
 	}
 	db.MediaDB = mediaDB
 
 	log.Debug().Msg("running media database migrations")
+	mediaDBReset := false
 	err = mediaDB.MigrateUp()
-	if err != nil {
-		return db, fmt.Errorf("error migrating mediadb: %w", err)
+	switch {
+	case errors.Is(err, database.ErrSchemaAhead):
+		// A newer build migrated this file and the device has since gone back to
+		// an older one. Everything in the media database can be rebuilt by a
+		// reindex, so discarding it is better than refusing to start: a device
+		// that will not boot is a far worse outcome than a rebuild. The user
+		// database holds data nothing can reconstruct, so it stays fatal.
+		//
+		// No recovery gate is taken around the rebuild: nothing else has a handle
+		// on this database yet, so there is no background work to lock out.
+		log.Warn().Err(err).Msg("media database schema is newer than this build supports, rebuilding it")
+		if resetErr := resetMediaDBForNewerSchema(mediaDB); resetErr != nil {
+			return db, false, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
+		}
+		mediaDBReset = true
+	case err != nil:
+		return db, false, fmt.Errorf("error migrating mediadb: %w", err)
 	}
 
 	log.Debug().Msg("opening user database")
@@ -104,7 +126,7 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	// is stored on db. Assigning here ensures that handle is not leaked.
 	db.UserDB = userDB
 	if err != nil {
-		return db, err
+		return db, false, err
 	}
 
 	// migrate old boltdb mappings if required
@@ -120,7 +142,48 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	backfillMediaUserData(ctx, db)
 
 	success = true
-	return db, nil
+	return db, mediaDBReset, nil
+}
+
+// resetMediaDBForNewerSchema replaces a media database this build cannot read
+// with an empty one at this build's schema, left marked pending so the startup
+// resume check reindexes it. No forensic copy is kept: the cause is known, the
+// contents are reproducible, and the platforms most likely to hit this are the
+// ones with the least free space.
+func resetMediaDBForNewerSchema(mediaDB *mediadb.MediaDB) error {
+	if err := mediaDB.Recreate(false); err != nil {
+		return fmt.Errorf("recreating media database: %w", err)
+	}
+	// Recreate's reopen allocates the schema, but the extra work MigrateUp does
+	// on top of that — seeding planner statistics so the reindex about to start
+	// has sane query plans — only happens on this path.
+	if err := mediaDB.MigrateUp(); err != nil {
+		return fmt.Errorf("migrating recreated media database: %w", err)
+	}
+	return nil
+}
+
+// notifyMediaDBSchemaReset tells the user why their media is being indexed
+// again. makeDatabase discards the database before the inbox service exists, so
+// the message is posted from Start once it does.
+func notifyMediaDBSchemaReset(st *state.State) {
+	if st == nil {
+		return
+	}
+	inboxSvc := st.Inbox()
+	if inboxSvc == nil {
+		log.Warn().Msg("inbox unavailable, cannot report media database rebuild")
+		return
+	}
+	if err := inboxSvc.Add("Media database was rebuilt after a version change",
+		inbox.WithBody("This version of Zaparoo is older than the one that last ran and could not read "+
+			"the media database it left behind. The database has been rebuilt and your media is being "+
+			"indexed again. Re-scrape your library to restore box art and metadata."),
+		inbox.WithSeverity(inbox.SeverityWarning),
+		inbox.WithCategory(inbox.CategoryMediaDBSchemaReset),
+	); err != nil {
+		log.Warn().Err(err).Msg("failed to add inbox message about media database rebuild")
+	}
 }
 
 // backfillMediaHistoryUUIDs assigns stable IDs to history written by older

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -46,6 +46,16 @@ const zapLinkHostExpiration = 30 * 24 * time.Hour
 
 const userDBBackupMaxAge = 24 * time.Hour
 
+// mediaDBSchemaReset reports that the media database was discarded because its
+// schema was newer than this build supports.
+type mediaDBSchemaReset struct {
+	// userDataLost is set when favorites or launcher overrides that existed only in
+	// the discarded database could not be read out of it, or could not all be written
+	// to the user database. No reindex can rebuild them and nothing else holds a copy,
+	// so the user is told rather than left to notice on their own.
+	userDataLost bool
+}
+
 func setupEnvironment(pl platforms.Platform) error {
 	return setupEnvironmentFS(afero.NewOsFs(), pl)
 }
@@ -75,10 +85,12 @@ func setupEnvironmentFS(fs afero.Fs, pl platforms.Platform) error {
 	return nil
 }
 
-// makeDatabase opens both databases. The returned flag reports that the media
-// database was discarded because its schema was newer than this build supports,
-// so the caller can tell the user why a full reindex is starting.
-func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Database, bool, error) {
+// makeDatabase opens both databases. A non-nil reset reports that the media database
+// was discarded because its schema was newer than this build supports, so the caller
+// can tell the user why a full reindex is starting.
+func makeDatabase(
+	ctx context.Context, pl platforms.Platform,
+) (*database.Database, *mediaDBSchemaReset, error) {
 	db := &database.Database{
 		MediaDB: nil,
 		UserDB:  nil,
@@ -100,18 +112,18 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	// is stored on db. Assigning here ensures that handle is not leaked.
 	db.UserDB = userDB
 	if err != nil {
-		return db, false, err
+		return db, nil, err
 	}
 
 	log.Debug().Msg("opening media database")
 	mediaDB, err := mediadb.OpenMediaDB(ctx, pl)
 	if err != nil {
-		return db, false, fmt.Errorf("failed to open media database: %w", err)
+		return db, nil, fmt.Errorf("failed to open media database: %w", err)
 	}
 	db.MediaDB = mediaDB
 
 	log.Debug().Msg("running media database migrations")
-	mediaDBReset := false
+	var reset *mediaDBSchemaReset
 	err = mediaDB.MigrateUp()
 	switch {
 	case errors.Is(err, database.ErrSchemaAhead):
@@ -124,19 +136,30 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		// No recovery gate is taken around the rebuild: nothing else has a handle
 		// on this database yet, so there is no background work to lock out.
 		log.Warn().Err(err).Msg("media database schema is newer than this build supports, rebuilding it")
-		// Favourites and launcher overrides written before UserDB became their
+		reset = &mediaDBSchemaReset{userDataLost: false}
+		// Favorites and launcher overrides written before UserDB became their
 		// home exist only in this file. Import them now rather than carrying them
 		// to the backfill below: once the file is gone the rescue is the only copy
 		// there is, and anything that ends startup in between would take it.
-		if rescued := rescueMediaUserData(ctx, mediaDB); len(rescued) > 0 {
-			backfillMediaUserData(ctx, db, rescued)
+		rescued, rescueErr := rescueMediaUserData(ctx, mediaDB)
+		switch {
+		case rescueErr != nil:
+			// Nothing later can say what was in there, so assume the worst.
+			log.Error().Err(rescueErr).
+				Msg("could not read media user data out of the newer media database")
+			reset.userDataLost = true
+		case len(rescued) > 0:
+			if importErr := backfillMediaUserData(ctx, db, rescued); importErr != nil {
+				log.Error().Err(importErr).
+					Msg("could not import media user data rescued from the newer media database")
+				reset.userDataLost = true
+			}
 		}
 		if resetErr := resetMediaDBForNewerSchema(mediaDB); resetErr != nil {
-			return db, false, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
+			return db, nil, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
 		}
-		mediaDBReset = true
 	case err != nil:
-		return db, false, fmt.Errorf("error migrating mediadb: %w", err)
+		return db, nil, fmt.Errorf("error migrating mediadb: %w", err)
 	}
 
 	// migrate old boltdb mappings if required
@@ -146,31 +169,33 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		log.Error().Err(err).Msg("error migrating old boltdb mappings")
 	}
 
-	// One-time import of favourites/launcher overrides that older versions wrote
+	// One-time import of favorites/launcher overrides that older versions wrote
 	// only to media.db, so they live in UserDB (the source of truth) and survive a
-	// future media.db rebuild.
-	backfillMediaUserData(ctx, db, nil)
+	// future media.db rebuild. media.db is still there to retry from next boot, so a
+	// failure here is only logged.
+	if err := backfillMediaUserData(ctx, db, nil); err != nil {
+		log.Warn().Err(err).Msg("failed to backfill media user data into the user database")
+	}
 
 	success = true
-	return db, mediaDBReset, nil
+	return db, reset, nil
 }
 
-// rescueMediaUserData reads the favourites and launcher overrides out of a media
+// rescueMediaUserData reads the favorites and launcher overrides out of a media
 // database that is about to be discarded, for the caller to hand straight to the
-// backfill. Best-effort by necessity: the file was written by a newer build, so
-// these queries may not fit its schema at all. A failure here leaves the rebuild
-// to go ahead without them, which is what would have happened regardless.
-func rescueMediaUserData(ctx context.Context, mediaDB *mediadb.MediaDB) []database.MediaUserData {
+// backfill. The file was written by a newer build, so these queries may not fit its
+// schema at all; an error means the caller is about to delete rows it could not read
+// and cannot say what they were, which is worth telling the user about.
+func rescueMediaUserData(ctx context.Context, mediaDB *mediadb.MediaDB) ([]database.MediaUserData, error) {
 	rows, err := mediaDB.GetExistingMediaUserData(ctx)
 	if err != nil {
-		log.Warn().Err(err).Msg("could not read media user data out of the newer media database")
-		return nil
+		return nil, fmt.Errorf("reading media user data from the newer media database: %w", err)
 	}
 	if len(rows) > 0 {
 		log.Info().Int("found", len(rows)).
 			Msg("preserving media user data from the discarded media database")
 	}
-	return rows
+	return rows, nil
 }
 
 // resetMediaDBForNewerSchema replaces a media database this build cannot read
@@ -194,7 +219,7 @@ func resetMediaDBForNewerSchema(mediaDB *mediadb.MediaDB) error {
 // notifyMediaDBSchemaReset tells the user why their media is being indexed
 // again. makeDatabase discards the database before the inbox service exists, so
 // the message is posted from Start once it does.
-func notifyMediaDBSchemaReset(st *state.State) {
+func notifyMediaDBSchemaReset(st *state.State, userDataLost bool) {
 	if st == nil {
 		return
 	}
@@ -203,10 +228,19 @@ func notifyMediaDBSchemaReset(st *state.State) {
 		log.Warn().Msg("inbox unavailable, cannot report media database rebuild")
 		return
 	}
+	body := "This version of Zaparoo is older than the one that last ran and could not read " +
+		"the media database it left behind. The database has been rebuilt and your media is being " +
+		"indexed again. Re-scrape your library to restore box art and metadata."
+	if userDataLost {
+		// The rescue is the only thing that could have saved these, and it did not.
+		// A reindex will not bring them back, so say so plainly.
+		// A failed read cannot tell an empty database from one full of favorites, so
+		// this hedges rather than telling someone who had none that they lost some.
+		body += " Favorites and launcher overrides set before this device last updated may " +
+			"not have been carried across, and may need to be set again."
+	}
 	if err := inboxSvc.Add("Media database was rebuilt after a version change",
-		inbox.WithBody("This version of Zaparoo is older than the one that last ran and could not read "+
-			"the media database it left behind. The database has been rebuilt and your media is being "+
-			"indexed again. Re-scrape your library to restore box art and metadata."),
+		inbox.WithBody(body),
 		inbox.WithSeverity(inbox.SeverityWarning),
 		inbox.WithCategory(inbox.CategoryMediaDBSchemaReset),
 	); err != nil {
@@ -238,57 +272,70 @@ func backfillMediaHistoryUUIDs(userDB database.UserDBI) (int64, error) {
 	return 0, nil
 }
 
-// backfillMediaUserData seeds UserDB from favourites/launcher overrides that older
+// backfillMediaUserData seeds UserDB from favorites/launcher overrides that older
 // versions stored only in media.db. It runs only while UserDB has no media user
 // data yet: once any row exists, UserDB is authoritative and media.db's copy is
-// never re-read (re-reading could resurrect a favourite the user removed if a prior
-// projection write had failed). Best-effort: failures are logged, not fatal.
+// never re-read (re-reading could resurrect a favorite the user removed if a prior
+// projection write had failed).
 //
 // rescued carries rows read out of a media database that has since been discarded
 // for having a newer schema; when it is set, it stands in for the read that can no
 // longer happen. The same UserDB-is-authoritative guard applies to it.
-func backfillMediaUserData(ctx context.Context, db *database.Database, rescued []database.MediaUserData) {
+//
+// Never fatal — startup carries on either way. An error means at least one row did
+// not make it, which matters for rescued rows because nothing else holds them.
+// Having nothing to do is not an error.
+func backfillMediaUserData(ctx context.Context, db *database.Database, rescued []database.MediaUserData) error {
 	if db == nil || db.UserDB == nil {
-		return
+		if len(rescued) > 0 {
+			return errors.New("no user database to import media user data into")
+		}
+		return nil
 	}
 
 	existing, err := db.UserDB.ListMediaUserData()
 	if err != nil {
-		log.Warn().Err(err).Msg("skipping media user data backfill: failed to read user database")
-		return
+		return fmt.Errorf("reading media user data from user database: %w", err)
 	}
 	if len(existing) > 0 {
-		return
+		return nil
 	}
 
 	rows := rescued
 	if len(rows) == 0 {
 		if db.MediaDB == nil {
-			return
+			return nil
 		}
 		rows, err = db.MediaDB.GetExistingMediaUserData(ctx)
 		if err != nil {
-			log.Warn().Err(err).Msg("failed to read existing media user data for backfill")
-			return
+			return fmt.Errorf("reading media user data from media database: %w", err)
 		}
 	}
 	if len(rows) == 0 {
-		return
+		return nil
 	}
 
 	migrated := 0
+	var firstErr error
 	for i := range rows {
 		row := rows[i]
 		if upErr := db.UserDB.UpsertMediaUserData(&row); upErr != nil {
 			log.Warn().Err(upErr).
 				Str("system", row.SystemID).Str("path", row.Path).
 				Msg("failed to backfill media user data row")
+			if firstErr == nil {
+				firstErr = upErr
+			}
 			continue
 		}
 		migrated++
 	}
 	log.Info().Int("migrated", migrated).Int("found", len(rows)).
 		Msg("backfilled media user data into user database")
+	if firstErr != nil {
+		return fmt.Errorf("imported %d of %d media user data rows: %w", migrated, len(rows), firstErr)
+	}
+	return nil
 }
 
 func openAndRecoverUserDB(ctx context.Context, pl platforms.Platform) (*userdb.UserDB, error) {

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -99,6 +99,11 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 
 	log.Debug().Msg("running media database migrations")
 	mediaDBReset := false
+	// Favourites and launcher overrides written before UserDB became their home
+	// exist only in the media database. If the backfill below has not managed to
+	// copy them across yet, discarding the file destroys the only copy, so they
+	// are read out first and handed to the backfill instead.
+	var rescuedUserData []database.MediaUserData
 	err = mediaDB.MigrateUp()
 	switch {
 	case errors.Is(err, database.ErrSchemaAhead):
@@ -111,6 +116,7 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 		// No recovery gate is taken around the rebuild: nothing else has a handle
 		// on this database yet, so there is no background work to lock out.
 		log.Warn().Err(err).Msg("media database schema is newer than this build supports, rebuilding it")
+		rescuedUserData = rescueMediaUserData(ctx, mediaDB)
 		if resetErr := resetMediaDBForNewerSchema(mediaDB); resetErr != nil {
 			return db, false, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
 		}
@@ -139,10 +145,28 @@ func makeDatabase(ctx context.Context, pl platforms.Platform) (*database.Databas
 	// One-time import of favourites/launcher overrides that older versions wrote
 	// only to media.db, so they live in UserDB (the source of truth) and survive a
 	// future media.db rebuild.
-	backfillMediaUserData(ctx, db)
+	backfillMediaUserData(ctx, db, rescuedUserData)
 
 	success = true
 	return db, mediaDBReset, nil
+}
+
+// rescueMediaUserData reads the favourites and launcher overrides out of a media
+// database that is about to be discarded. Best-effort by necessity: the file was
+// written by a newer build, so these queries may not fit its schema at all. A
+// failure here leaves the rebuild to go ahead without them, which is what would
+// have happened regardless.
+func rescueMediaUserData(ctx context.Context, mediaDB *mediadb.MediaDB) []database.MediaUserData {
+	rows, err := mediaDB.GetExistingMediaUserData(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not read media user data out of the newer media database")
+		return nil
+	}
+	if len(rows) > 0 {
+		log.Info().Int("found", len(rows)).
+			Msg("preserving media user data from the discarded media database")
+	}
+	return rows
 }
 
 // resetMediaDBForNewerSchema replaces a media database this build cannot read
@@ -215,8 +239,12 @@ func backfillMediaHistoryUUIDs(userDB database.UserDBI) (int64, error) {
 // data yet: once any row exists, UserDB is authoritative and media.db's copy is
 // never re-read (re-reading could resurrect a favourite the user removed if a prior
 // projection write had failed). Best-effort: failures are logged, not fatal.
-func backfillMediaUserData(ctx context.Context, db *database.Database) {
-	if db == nil || db.UserDB == nil || db.MediaDB == nil {
+//
+// rescued carries rows read out of a media database that has since been discarded
+// for having a newer schema; when it is set, it stands in for the read that can no
+// longer happen. The same UserDB-is-authoritative guard applies to it.
+func backfillMediaUserData(ctx context.Context, db *database.Database, rescued []database.MediaUserData) {
+	if db == nil || db.UserDB == nil {
 		return
 	}
 
@@ -229,10 +257,16 @@ func backfillMediaUserData(ctx context.Context, db *database.Database) {
 		return
 	}
 
-	rows, err := db.MediaDB.GetExistingMediaUserData(ctx)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to read existing media user data for backfill")
-		return
+	rows := rescued
+	if len(rows) == 0 {
+		if db.MediaDB == nil {
+			return
+		}
+		rows, err = db.MediaDB.GetExistingMediaUserData(ctx)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to read existing media user data for backfill")
+			return
+		}
 	}
 	if len(rows) == 0 {
 		return


### PR DESCRIPTION
A media database migrated by a newer build stops an older build from starting: `CheckSchemaVersion` returns `ErrSchemaAhead` and `makeDatabase` treated that as fatal, so switching from beta to stable by hand leaves an unbootable device.

Everything in the media database can be rebuilt by a reindex, so discard it instead. `Recreate(false)` deletes the file and its `-wal`/`-shm` sidecars, reopens at this build's schema, and marks the fresh database pending — the intent the existing startup resume check already acts on. `MigrateUp` runs again afterwards so the new file gets the planner-stat seeding a fresh install gets. No `.corrupt.bak` copy is kept: the cause is known, the contents are reproducible, and the devices most likely to hit this have the least free space.

The user database keeps failing fatally. Nothing can reconstruct what is in it, so starting up against a schema this build does not understand would lose data.

The rebuild happens before the inbox service exists, so `makeDatabase` returns a flag and `Start` posts the message (new `mediadb_schema_reset` category) once the inbox is up.

Tests run against real SQLite files: schema-ahead rebuilds and leaves the database pending, migrated and empty of the old rows; a compatible database is untouched; a schema-ahead user database still fails startup; the inbox message carries the right category and severity; a nil state or missing inbox does not panic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media databases created by newer builds are automatically rebuilt.
  * Recoverable favourites and launcher overrides are preserved during rebuilding.
  * An inbox warning explains when a media database is reset and reindexing is required.
* **Bug Fixes**
  * Compatible media databases are preserved without unnecessary changes.
  * User data remains recoverable when a media database cannot be read.
  * Corrupt database backups are retained when data cannot be fully recovered.
  * Incompatible user databases continue to trigger a startup failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->