### PR TITLE
feat(updater): add rollback-safe OTA installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,226 +1,76 @@
-# AGENTS.md - Zaparoo Core
+# Agent Instructions
 
-Hardware-agnostic game launcher bridging physical tokens (NFC, barcodes, RFID) with digital media across 12 gaming platforms. Built in Go with WebSocket/JSON-RPC API, dual SQLite databases, and a custom ZapScript command language.
+## Repository purpose
 
-**Tech Stack**: Go 1.25.7+, SQLite (UserDB + MediaDB), WebSocket/HTTP JSON-RPC 2.0, malgo+beep/v2 (audio), testify/mock, sqlmock, afero
-
-For architecture details, API reference, and key concepts: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-
-## Safety & Permissions
-
-**Allowed without asking**: Read files, run file-scoped tests (`go test ./pkg/specific/`), run `task lint-fix`, package-level linting, `gofumpt`, `actionlint`, view git history.
-
-**Ask before**: Installing dependencies, `git push`/`git commit`, deleting files, changing DB schema/migrations, modifying config schema, adding platform support, breaking API changes.
-
-## Rules
-
-- Write tests for all new code — see [TESTING.md](TESTING.md) and `pkg/testing/README.md`
-- Use `task lint-fix` to resolve all linting and formatting issues
-- Keep diffs small and focused — one concern per change
-- Use file-scoped commands for faster feedback over full-suite runs
-- Reference existing patterns before writing new code
-- Define Go types and consts near the top of the file, before functions and methods
-- Use `filepath.Join` for path construction everywhere, including test files — never hardcode POSIX-style paths like `"/roms/snes/game.sfc"` as string literals
-- Use afero for filesystem operations in testable code
-- NEVER use `sync.Mutex`/`sync.RWMutex` — use `syncutil.Mutex`/`syncutil.RWMutex` (forbidigo linter enforces this)
-- NEVER use standard `log` or `fmt.Println` — use zerolog (depguard enforces this)
-- NEVER run builds, lints, or tests for another OS (e.g., `GOOS=windows`) — CGO dependencies. Rely on CI
-- NEVER amend commits — always create new commits
-- NEVER add dependencies without discussion
-
-## Testing
-
-Full guide: [TESTING.md](TESTING.md) | Quick reference: `pkg/testing/README.md`
-
-The goal is useful tests, not coverage metrics. Mock at interface boundaries — all hardware interactions must be mocked. Use existing mocks/fixtures from `pkg/testing/` instead of creating new ones.
-
-**Mock setup pattern**:
-
-```go
-import (
-    "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
-    "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
-    "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/fixtures"
-)
-
-mockPlatform := mocks.NewMockPlatform()
-mockReader := mocks.NewMockReader()
-mockUserDB := helpers.NewMockUserDBI()
-mockMediaDB := helpers.NewMockMediaDBI()
-```
+- Go daemon that turns physical token scans into cross-platform game and media actions through ZapScript.
+- Public interfaces include JSON-RPC over WebSocket/HTTP, configuration schemas, UserDB and MediaDB schemas, reader and platform interfaces, and update metadata.
+- Use the Go version declared in `go.mod`. Read `docs/ARCHITECTURE.md` when a task crosses subsystem boundaries.
 
 ## Commands
 
-```bash
-# File-scoped (preferred for speed)
-go test ./pkg/service/tokens/             # Test a package
-go test -run TestSpecificFunc ./pkg/api/  # Test by name
-go test -race ./pkg/service/tokens/       # Race detection
-gofumpt -w pkg/config/config.go           # Format a file
-golangci-lint run --fix pkg/service/      # Package-level lint
+- Build current platform: `task build`
+- Targeted tests: `task test -- ./pkg/path/...`
+- Full tests with race detection: `task test`
+- Non-mutating lint: `task lint`
+- Apply lint and formatting fixes deliberately: `task lint-fix`
+- Supported cross-platform lint: `task cross-lint:all`
+- Vulnerabilities: `task vulncheck`
+- Nil analysis: `task nilcheck`
+- Deadlock detection: `task deadlock`
+- Fuzz targets: `task fuzz`
+- Benchmarks: `task bench`, `task bench-db`, `task bench-compare`
 
-# Project-wide
-task test              # Full test suite with race detection
-task lint-fix          # Full lint with auto-fixes
-task cross-lint:all    # Cross-OS lint via repository zigcc Docker task
-task hooks:install     # Install local pre-push hook in .git/hooks
-task build             # Build binary
-task fuzz              # Run fuzz tests
-task vulncheck         # Security vulnerability scan
-task nilcheck          # Nil-pointer analysis
-task deadlock          # Detect lock ordering violations
+Use targeted package tests while iterating, then `task test` and `task lint` before finishing normal Go changes. Do not use `task lint-fix` as a read-only check because it can rewrite unrelated files.
 
-# DON'T use file-level golangci-lint (not well supported)
-# golangci-lint run pkg/config/config.go  # BAD
+Do not run ad hoc `GOOS=...` builds, tests, or lints. Core has CGO and platform-native dependencies; use `task cross-lint:all` for supported cross-platform analysis and leave native execution to CI.
 
-# Find total index duration from MCP logs:
-# grep "media indexing completed" <log-file>
+## Testing
 
-# GitHub Actions workflow linting (use when editing .github/workflows/*.yml)
-actionlint .github/workflows/fuzz.yml    # Lint a specific workflow
-actionlint                                # Lint all workflows
-```
+- Read `TESTING.md` and `pkg/testing/README.md` before adding substantial test infrastructure.
+- Add or update tests for behavior changes and bug fixes. Prefer a regression test that fails before a bug fix.
+- Mock hardware, network, process, and platform boundaries. Tests must not require a physical reader or target device.
+- Reuse mocks, fixtures, database helpers, and examples under `pkg/testing/` instead of creating parallel infrastructure.
+- Use afero for testable filesystem code and fake clocks for time-dependent behavior. Avoid sleeps when deterministic synchronization is possible.
+- Use `filepath.Join` for filesystem paths, including tests. Do not encode host-OS separators into production path logic.
+- Treat useful behavior coverage as the goal; do not weaken assertions merely to make a test pass.
 
-## Project Structure
+## Code and compatibility rules
 
-```
-zaparoo-core/
-├── cmd/{platform}/        # Platform entry points (12 platforms)
-├── pkg/
-│   ├── api/               # WebSocket/HTTP JSON-RPC server
-│   │   ├── methods/       # RPC method handlers
-│   │   └── models/        # API data models
-│   ├── assets/            # Embedded static files (App web build)
-│   ├── audio/             # Cross-platform audio playback
-│   ├── cli/               # CLI interface
-│   ├── config/            # Configuration management (TOML)
-│   ├── database/          # Dual database system
-│   │   ├── userdb/        # User mappings, history, playlists
-│   │   ├── mediadb/       # Indexed media content
-│   │   └── mediascanner/  # Media indexing engine
-│   ├── groovyproxy/       # Groovy scripting proxy
-│   ├── helpers/           # Utilities (syncutil, etc.)
-│   ├── platforms/         # 12 platform implementations
-│   ├── readers/           # 11 reader type drivers
-│   ├── service/           # Core business logic
-│   │   ├── broker/        # Event brokering
-│   │   ├── daemon/        # Background service management
-│   │   ├── discovery/     # mDNS service discovery
-│   │   ├── inbox/         # Message inbox
-│   │   ├── playlists/     # Playlist management
-│   │   ├── playtime/      # Play time tracking
-│   │   ├── publishers/    # Event publishing
-│   │   ├── state/         # Application state
-│   │   └── tokens/        # Token processing
-│   ├── testing/           # Testing infrastructure
-│   │   ├── README.md      # Quick reference
-│   │   ├── mocks/         # Pre-built mocks
-│   │   ├── helpers/       # Testing utilities (DB, FS, API)
-│   │   ├── fixtures/      # Sample test data
-│   │   └── examples/      # Example test patterns
-│   ├── ui/                # UI components (systray, TUI)
-│   └── zapscript/         # ZapScript language + advargs parser
-├── docs/                  # Architecture, API docs, plans
-├── scripts/               # Build and platform scripts
-├── TESTING.md             # Testing guide
-└── Taskfile.dist.yml      # Build and development tasks
-```
+- Use `syncutil.Mutex` and `syncutil.RWMutex`, never the standard mutex types. Deadlock instrumentation depends on these wrappers.
+- Use zerolog, not the standard `log` package or direct print statements.
+- Preserve backward compatibility for JSON-RPC methods, notifications, API models, configuration files, mappings, launchers, and persisted database data unless a breaking change is explicitly approved.
+- Keep UserDB and MediaDB access behind their interfaces. Existing applied migrations in `pkg/database/{userdb,mediadb}/migrations/` are immutable; add a new migration instead.
+- Configuration schema changes need migration and compatibility handling for existing installations.
+- Treat token contents, NDEF records, barcodes, MQTT messages, ZapScript, API requests, archives, and update metadata as untrusted input.
+- Do not hand-edit generated files such as `pkg/database/mediadb/stat1_seed_data.go`; use their documented generator.
+- Do not add dependencies, platforms, readers, launchers, or public API surface without discussion.
 
-## Reference Files
+## High-risk areas
 
-Copy these patterns for new code:
+- Authentication and authorization: `pkg/api/middleware/`, `pkg/config/auth.go`, client pairing, encryption, and profile permissions.
+- Parsing and execution: `pkg/readers/shared/ndef/`, `pkg/zapscript/`, command execution, archive extraction, and launcher handling.
+- Durable state: database migrations, backups, config migration, and profile data swapping.
+- Updates: `pkg/service/updater/`, `pkg/service/updater/otameta/`, `.github/workflows/ota-*.yml`, `.github/actions/ota-metadata/`, and `scripts/generate-update-manifest/`.
 
-- **Tests**: `pkg/testing/examples/` — 7 example files covering services, mocks, API, DB, filesystem, state, and ZapScript patterns
-- **API**: `pkg/api/methods/` — JSON-RPC method handler pattern
-- **Config**: `pkg/config/config.go` — Thread-safe config with RWMutex
-- **Database**: `pkg/database/userdb/` and `pkg/database/mediadb/` — Database interface pattern
-- **Platform**: `pkg/platforms/linux/platform.go` — Platform implementation pattern
-- **Service**: `pkg/service/tokens/tokens.go` — Service layer pattern
+For updater, signing, promotion, rollout, withdrawal, or key changes, read `docs/ota-runbook.md` first. Never publish OTA metadata, alter a rollout, rotate trust keys, tag a release, or run deployment workflows without explicit approval. Preserve signature verification, monotonic manifest generations, asset digests, rollback protections, and fail-closed install behavior.
 
-## Git & Commits
+Do not read, print, or commit `.env`, API keys, private signing material, local databases, logs containing user data, or generated runtime state.
 
-Zaparoo uses **Conventional Commits**: `<type>[scope]: <description>`
+## Specialized validation
 
-Types: `feat` (minor bump), `fix` (patch), `docs`, `refactor`, `style`, `perf`, `test`, `build`, `ci`, `chore`. Breaking changes: add `!` after type (`feat!:`) or `BREAKING CHANGE:` footer.
+- Concurrency, lifecycle, or lock changes: `task deadlock` and relevant race tests.
+- Untrusted parsers or protocol changes: run the relevant fuzz target; use `task fuzz` when the scope warrants the full set.
+- Dependency or security-sensitive changes: `task vulncheck`.
+- Performance work: read `docs/optimization-targets.md`, use allocation-reporting benchmarks with `b.Loop()`, and include `task bench-compare` evidence. Do not replace committed baselines without approval.
+- Workflow changes: run `actionlint` on the changed workflow or all workflows.
+- Before pushing cross-platform changes: `task cross-lint:all` and the repository's normal test/lint checks.
 
-```bash
-# Good:
-git commit -m "feat: add support for new NFC reader type"
-git commit -m "fix(api): resolve websocket reconnection issue"
-git commit -m "feat(database)!: change migration format"
+## Git and pull requests
 
-# Bad:
-git commit -m "Fixed bug"           # Missing type
-git commit -m "add reader support"  # Missing type prefix
-```
+- PR titles use Conventional Commit types enforced by `.github/workflows/pr-title.yml`.
+- PR descriptions must not include a test-plan section.
+- Do not commit, push, rewrite history, update benchmark baselines, or modify release state unless explicitly asked.
 
-Before committing: run `task lint-fix` then `task test`.
-Before pushing: run `task lint-fix`, `task test`, and `task cross-lint:all`; install the local pre-push hook with `task hooks:install`.
+## Completion
 
-Pull requests should NOT include a test plan section.
-
-## Benchmarks
-
-Naming convention: `Benchmark{Component}_{Operation}_{Scale}` (e.g., `BenchmarkSlugSearchCache_Search_500k`)
-
-All benchmarks must:
-- Call `b.ReportAllocs()` for allocation tracking
-- Use `b.Run()` subtests for scale tiers or variants
-- Set up data before `b.ResetTimer()`
-- Use `for b.Loop()` iteration pattern
-
-```bash
-task bench              # Run all benchmarks
-task bench-db           # Run database benchmarks only
-task bench-baseline     # Generate baseline (commit the output)
-task bench-compare      # Compare current vs baseline via benchstat
-```
-
-Optimization targets and thresholds: [docs/optimization-targets.md](docs/optimization-targets.md)
-
-## Background Agent Mode
-
-When running as a background agent (scheduled, headless, or autonomous):
-
-### Always Allowed
-- Run `task test`, `task lint`, `task vulncheck`, `task nilcheck`, `task deadlock`
-- Run `task bench` and `task bench-compare`
-- Read any file, run `go vet`, analyze code
-- Report findings as GitHub issues with `agent-finding` label
-- Run `task fuzz` with default time limits
-
-### Create PR with Evidence (Human Review Required)
-- Performance optimizations — must include before/after benchstat output in PR description
-- Refactoring that changes function signatures or public API
-- Adding new dependencies
-- Changes to security-sensitive files:
-  - `pkg/api/middleware/` (auth)
-  - `pkg/zapscript/utils.go` (command execution)
-  - `pkg/readers/shared/ndef/` (untrusted input parsing)
-  - `pkg/config/auth.go` (auth config)
-- Database schema changes or migrations
-
-### Never
-- Modify tests to make failing code pass (fix the code, not the test)
-- Remove or weaken linter rules
-- Add `nolint` directives without justification
-- Disable security checks (gosec, govulncheck)
-- Change the `forbidigo` rules for sync.Mutex/RWMutex
-- Modify CI workflow files
-- Push directly to main
-- Change benchmark baselines without human review
-
-### Reporting Format
-Title: `[agent:{type}] {summary}` — types: security, perf, quality
-Body: evidence, affected files, proposed fix, risk assessment
-Label: `agent-finding`
-For perf findings: include benchstat comparison
-
-## When Stuck
-
-Don't guess — ask for help or gather more information first.
-
-- **Ask clarifying questions** before coding
-- **Propose a plan first** — outline approach, then implement
-- **Reference existing patterns** — check similar code for consistency
-- **Look at git history** — `git log -p filename` shows how code evolved
+Report exactly which checks ran and any that were skipped. Do not claim completion while a relevant check is failing or the implementation is partial.

--- a/cmd/mac/main.go
+++ b/cmd/mac/main.go
@@ -115,9 +115,7 @@ func run() error {
 			// The previous version is back on disk, but this process is still the
 			// image that failed and nothing here would start the restored one.
 			if errors.Is(err, updater.ErrRolledBack) {
-				// Exec does not return on success: it replaces this process.
-				execErr := restart.Exec()
-				return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+				return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 			}
 
 			log.Error().Msgf("error starting service: %s", err)

--- a/cmd/mac/main.go
+++ b/cmd/mac/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mac"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/systray"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/tui"
 	"github.com/rs/zerolog/log"
@@ -111,6 +112,14 @@ func run() error {
 		var err error
 		svcResult, err = service.Start(pl, cfg)
 		if err != nil {
+			// The previous version is back on disk, but this process is still the
+			// image that failed and nothing here would start the restored one.
+			if errors.Is(err, updater.ErrRolledBack) {
+				// Exec does not return on success: it replaces this process.
+				execErr := restart.Exec()
+				return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			}
+
 			log.Error().Msgf("error starting service: %s", err)
 			return fmt.Errorf("error starting service: %w", err)
 		}

--- a/cmd/recalbox/main.go
+++ b/cmd/recalbox/main.go
@@ -103,9 +103,7 @@ func run() error {
 		// The previous version is back on disk, but this process is still the
 		// image that failed and nothing here would start the restored one.
 		if errors.Is(err, updater.ErrRolledBack) {
-			// Exec does not return on success: it replaces this process.
-			execErr := restart.Exec()
-			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 		}
 
 		log.Error().Err(err).Msg("error starting service")

--- a/cmd/recalbox/main.go
+++ b/cmd/recalbox/main.go
@@ -24,6 +24,7 @@ along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -38,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/recalbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -98,6 +100,14 @@ func run() error {
 
 	svcResult, err := service.Start(pl, cfg)
 	if err != nil {
+		// The previous version is back on disk, but this process is still the
+		// image that failed and nothing here would start the restored one.
+		if errors.Is(err, updater.ErrRolledBack) {
+			// Exec does not return on success: it replaces this process.
+			execErr := restart.Exec()
+			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+		}
+
 		log.Error().Err(err).Msg("error starting service")
 		return fmt.Errorf("error starting service: %w", err)
 	}

--- a/cmd/replayos/main.go
+++ b/cmd/replayos/main.go
@@ -128,9 +128,7 @@ func runDaemon(pl *replayos.Platform, cfg *config.Instance) error {
 		// The previous version is back on disk, but this process is still the
 		// image that failed and nothing here would start the restored one.
 		if errors.Is(err, updater.ErrRolledBack) {
-			// Exec does not return on success: it replaces this process.
-			execErr := restart.Exec()
-			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 		}
 
 		log.Error().Err(err).Msg("error starting service")

--- a/cmd/replayos/main.go
+++ b/cmd/replayos/main.go
@@ -25,6 +25,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -45,6 +46,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/daemon"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/tui"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog"
@@ -123,6 +125,14 @@ func runDaemon(pl *replayos.Platform, cfg *config.Instance) error {
 
 	svcResult, err := service.Start(pl, cfg)
 	if err != nil {
+		// The previous version is back on disk, but this process is still the
+		// image that failed and nothing here would start the restored one.
+		if errors.Is(err, updater.ErrRolledBack) {
+			// Exec does not return on success: it replaces this process.
+			execErr := restart.Exec()
+			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+		}
+
 		log.Error().Err(err).Msg("error starting service")
 		return fmt.Errorf("error starting service: %w", err)
 	}

--- a/cmd/retropie/main.go
+++ b/cmd/retropie/main.go
@@ -102,9 +102,7 @@ func run() error {
 		// The previous version is back on disk, but this process is still the
 		// image that failed and nothing here would start the restored one.
 		if errors.Is(err, updater.ErrRolledBack) {
-			// Exec does not return on success: it replaces this process.
-			execErr := restart.Exec()
-			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 		}
 
 		log.Error().Err(err).Msg("error starting service")

--- a/cmd/retropie/main.go
+++ b/cmd/retropie/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/retropie"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -98,6 +99,14 @@ func run() error {
 
 	svcResult, err := service.Start(pl, cfg)
 	if err != nil {
+		// The previous version is back on disk, but this process is still the
+		// image that failed and nothing here would start the restored one.
+		if errors.Is(err, updater.ErrRolledBack) {
+			// Exec does not return on success: it replaces this process.
+			execErr := restart.Exec()
+			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+		}
+
 		log.Error().Err(err).Msg("error starting service")
 		return fmt.Errorf("error starting service: %w", err)
 	}

--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/windows"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/systray"
 	"github.com/rs/zerolog/log"
 	syswindows "golang.org/x/sys/windows"
@@ -166,6 +167,14 @@ func run() error {
 
 	svcResult, err := service.Start(pl, cfg)
 	if err != nil {
+		// The previous version is back on disk, but this process is still the
+		// image that failed and nothing here would start the restored one.
+		if errors.Is(err, updater.ErrRolledBack) {
+			// Exec does not return on success: it replaces this process.
+			execErr := restart.Exec()
+			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+		}
+
 		log.Error().Msgf("error starting service: %s", err)
 		return fmt.Errorf("error starting service: %w", err)
 	}

--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -170,9 +170,7 @@ func run() error {
 		// The previous version is back on disk, but this process is still the
 		// image that failed and nothing here would start the restored one.
 		if errors.Is(err, updater.ErrRolledBack) {
-			// Exec does not return on success: it replaces this process.
-			execErr := restart.Exec()
-			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 		}
 
 		log.Error().Msgf("error starting service: %s", err)

--- a/cmd/zapos/main.go
+++ b/cmd/zapos/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/zapos"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -71,6 +72,14 @@ func run() error {
 
 	serviceResult, err := service.Start(platform, cfg)
 	if err != nil {
+		// The previous version is back on disk, but this process is still the
+		// image that failed and nothing here would start the restored one.
+		if errors.Is(err, updater.ErrRolledBack) {
+			// Exec does not return on success: it replaces this process.
+			execErr := restart.Exec()
+			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+		}
+
 		log.Error().Err(err).Msg("error starting service")
 		return fmt.Errorf("error starting service: %w", err)
 	}

--- a/cmd/zapos/main.go
+++ b/cmd/zapos/main.go
@@ -75,9 +75,7 @@ func run() error {
 		// The previous version is back on disk, but this process is still the
 		// image that failed and nothing here would start the restored one.
 		if errors.Is(err, updater.ErrRolledBack) {
-			// Exec does not return on success: it replaces this process.
-			execErr := restart.Exec()
-			return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 		}
 
 		log.Error().Err(err).Msg("error starting service")

--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -32,6 +34,56 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/rs/zerolog/log"
 )
+
+const updateAfterWriteFallbackDelay = 5 * time.Second
+
+type updateRestartGuard struct {
+	timer           *time.Timer
+	restart         func()
+	release         func()
+	previousVersion string
+	newVersion      string
+	once            sync.Once
+}
+
+func newUpdateRestartGuard(
+	delay time.Duration,
+	previousVersion, newVersion string,
+	restart, release func(),
+) *updateRestartGuard {
+	guard := &updateRestartGuard{
+		restart:         restart,
+		release:         release,
+		previousVersion: previousVersion,
+		newVersion:      newVersion,
+	}
+	guard.timer = time.AfterFunc(delay, func() {
+		guard.finish(true)
+	})
+	return guard
+}
+
+func (g *updateRestartGuard) afterWrite() {
+	g.timer.Stop()
+	g.finish(false)
+}
+
+func (g *updateRestartGuard) finish(fallback bool) {
+	g.once.Do(func() {
+		defer g.release()
+		event := log.Info()
+		message := "update applied, restarting service"
+		if fallback {
+			event = log.Warn()
+			message = "update response callback did not run, forcing service restart"
+		}
+		event.
+			Str("previous", g.previousVersion).
+			Str("new", g.newVersion).
+			Msg(message)
+		g.restart()
+	})
+}
 
 // updaterOptions describes the device to the updater.
 func updaterOptions(env *requests.RequestEnv) updater.Options {
@@ -116,19 +168,15 @@ func HandleUpdateApply(
 		return nil, fmt.Errorf("update apply failed: %w", err)
 	}
 
+	restartGuard := newUpdateRestartGuard(
+		updateAfterWriteFallbackDelay, previousVersion, newVersion, restartFn, releaseMediaGate,
+	)
 	releaseBeforeRestart = false
 	return models.ResponseWithCallback{
 		Result: models.UpdateApplyResponse{
 			PreviousVersion: previousVersion,
 			NewVersion:      newVersion,
 		},
-		AfterWrite: func() {
-			defer releaseMediaGate()
-			log.Info().
-				Str("previous", previousVersion).
-				Str("new", newVersion).
-				Msg("update applied, restarting service")
-			restartFn()
-		},
+		AfterWrite: restartGuard.afterWrite,
 	}, nil
 }

--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -35,11 +35,15 @@ import (
 
 // updaterOptions describes the device to the updater.
 func updaterOptions(env *requests.RequestEnv) updater.Options {
-	return updater.Options{
+	opts := updater.Options{
 		PlatformID: env.Platform.ID(),
 		Channel:    env.Config.UpdateChannel(),
 		DataDir:    helpers.DataDir(env.Platform),
 	}
+	if env.Database != nil {
+		opts.UserDB = env.Database.UserDB
+	}
+	return opts
 }
 
 func HandleUpdateCheck(
@@ -80,22 +84,46 @@ func HandleUpdateApply(
 		}
 	}
 
+	releaseMediaGate := func() {}
+	if env.State != nil {
+		release, err := env.State.AcquireUpdateMediaGate(env.Context)
+		if err != nil {
+			return nil, fmt.Errorf("waiting for media activity to settle before update: %w", err)
+		}
+		releaseMediaGate = release
+		if env.State.ActiveMedia() != nil {
+			releaseMediaGate()
+			return nil, models.ClientErrf("cannot apply update while media is active")
+		}
+	}
+	releaseBeforeRestart := true
+	defer func() {
+		if releaseBeforeRestart {
+			releaseMediaGate()
+		}
+	}()
+
 	previousVersion := config.AppVersion
 
 	newVersion, err := applyFn(env.Context, updaterOptions(&env))
 	if errors.Is(err, updater.ErrDevelopmentVersion) {
 		return nil, models.ClientErrf("cannot apply updates on development builds")
 	}
+	if errors.Is(err, updater.ErrUpdateInProgress) {
+		return nil, models.ClientErrf("update already in progress")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("update apply failed: %w", err)
 	}
 
+	releaseBeforeRestart = false
 	return models.ResponseWithCallback{
 		Result: models.UpdateApplyResponse{
 			PreviousVersion: previousVersion,
 			NewVersion:      newVersion,
 		},
 		AfterWrite: func() {
+			defer releaseMediaGate()
 			log.Info().
 				Str("previous", previousVersion).
 				Str("new", newVersion).

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -190,6 +191,38 @@ func TestHandleUpdateCheck_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "update check failed")
 	assert.Contains(t, err.Error(), "network timeout")
 	assert.Nil(t, result)
+}
+
+func TestUpdateRestartGuard_AfterWriteSupersedesFallback(t *testing.T) {
+	t.Parallel()
+
+	var restartCalls atomic.Int32
+	var releaseCalls atomic.Int32
+	guard := newUpdateRestartGuard(time.Hour, "2.9.0", "2.10.0",
+		func() { restartCalls.Add(1) }, func() { releaseCalls.Add(1) })
+
+	guard.afterWrite()
+	guard.afterWrite()
+
+	assert.Equal(t, int32(1), restartCalls.Load())
+	assert.Equal(t, int32(1), releaseCalls.Load())
+}
+
+func TestUpdateRestartGuard_FallbackSupersedesLateAfterWrite(t *testing.T) {
+	t.Parallel()
+
+	var restartCalls atomic.Int32
+	var releaseCalls atomic.Int32
+	guard := newUpdateRestartGuard(5*time.Millisecond, "2.9.0", "2.10.0",
+		func() { restartCalls.Add(1) }, func() { releaseCalls.Add(1) })
+
+	require.Eventually(t, func() bool {
+		return restartCalls.Load() == 1 && releaseCalls.Load() == 1
+	}, time.Second, 5*time.Millisecond)
+	guard.afterWrite()
+
+	assert.Equal(t, int32(1), restartCalls.Load())
+	assert.Equal(t, int32(1), releaseCalls.Load())
 }
 
 func TestHandleUpdateApply_DevelopmentVersion(t *testing.T) {

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -22,7 +22,9 @@ package methods
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -30,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
@@ -238,6 +241,100 @@ func TestHandleUpdateApply_Error(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestHandleUpdateApply_UpdateInProgress(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+	}
+	applyFn := func(context.Context, updater.Options) (string, error) {
+		return "", updater.ErrUpdateInProgress
+	}
+
+	result, err := HandleUpdateApply(env, applyFn, func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "update already in progress")
+	assert.Nil(t, result)
+}
+
+func TestHandleUpdateApply_ActiveMedia(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	st, _ := state.NewState(mockPlatform, "test-boot")
+	t.Cleanup(st.StopService)
+	st.SetActiveMedia(models.NewActiveMedia(
+		"SNES", "Super Nintendo", filepath.Join("roms", "game.sfc"), "Game", "test-launcher",
+	))
+
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		State:    st,
+	}
+	applyFn := func(context.Context, updater.Options) (string, error) {
+		t.Fatal("applyFn should not be called while media is active")
+		return "", nil
+	}
+
+	result, err := HandleUpdateApply(env, applyFn, func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "media is active")
+	assert.Nil(t, result)
+}
+
+func TestHandleUpdateApply_HoldsMediaGateUntilRestart(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	st, _ := state.NewState(mockPlatform, "test-boot")
+	t.Cleanup(st.StopService)
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		State:    st,
+	}
+	applyFn := func(context.Context, updater.Options) (string, error) {
+		return "2.10.0", nil
+	}
+
+	result, err := HandleUpdateApply(env, applyFn, st.RestartService)
+	require.NoError(t, err)
+	response, ok := result.(models.ResponseWithCallback)
+	require.True(t, ok)
+
+	launchErr := make(chan error, 1)
+	go func() {
+		release, acquireErr := st.AcquireMediaLaunch()
+		if release != nil {
+			release()
+		}
+		launchErr <- acquireErr
+	}()
+	select {
+	case err := <-launchErr:
+		require.NoError(t, err)
+		t.Fatal("media launch gate released before update restart")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	response.AfterWrite()
+	select {
+	case err := <-launchErr:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("queued media launch did not stop after update restart")
+	}
+}
+
 func TestHandleUpdateApply_IndexingInProgress(t *testing.T) {
 	t.Parallel()
 
@@ -286,15 +383,17 @@ func TestHandleUpdateApply_IndexingCompleted(t *testing.T) {
 
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil)
+	mockUserDB := helpers.NewMockUserDBI()
 
 	env := requests.RequestEnv{
 		Context:  t.Context(),
 		Platform: mockPlatform,
 		Config:   &config.Instance{},
-		Database: &database.Database{MediaDB: mockMediaDB},
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
 	}
 
-	applyFn := func(_ context.Context, _ updater.Options) (string, error) {
+	applyFn := func(_ context.Context, opts updater.Options) (string, error) {
+		assert.Same(t, mockUserDB, opts.UserDB)
 		return "2.10.0", nil
 	}
 

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -268,9 +268,7 @@ func RunApp(pl platforms.Platform, cfg *config.Instance, daemonMode bool) (retur
 			// The previous version is back on disk, but this process is still the
 			// image that failed and nothing here would start the restored one.
 			if errors.Is(err, updater.ErrRolledBack) {
-				// Exec does not return on success: it replaces this process.
-				execErr := restart.Exec()
-				return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+				return fmt.Errorf("restarting after update rollback: %w", restart.ExecAfterRollback(err))
 			}
 
 			log.Error().Msgf("error starting service: %s", err)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/daemon"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/tui"
 	"github.com/rivo/tview"
 	"github.com/rs/zerolog/log"
@@ -264,6 +265,14 @@ func RunApp(pl platforms.Platform, cfg *config.Instance, daemonMode bool) (retur
 		log.Info().Msg("starting service in daemon mode")
 		svcResult, err := service.Start(pl, cfg)
 		if err != nil {
+			// The previous version is back on disk, but this process is still the
+			// image that failed and nothing here would start the restored one.
+			if errors.Is(err, updater.ErrRolledBack) {
+				// Exec does not return on success: it replaces this process.
+				execErr := restart.Exec()
+				return fmt.Errorf("failed to re-exec after rolling back an update: %w", execErr)
+			}
+
 			log.Error().Msgf("error starting service: %s", err)
 			return fmt.Errorf("error starting service: %w", err)
 		}

--- a/pkg/database/corruption.go
+++ b/pkg/database/corruption.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 // CorruptMarkerSuffix names the sidecar file written next to a database to flag
@@ -91,7 +92,12 @@ func IsMarkedCorrupt(dbPath string) bool {
 
 // ClearCorruptMarker removes the corrupt marker sidecar for dbPath. No-op when absent.
 func ClearCorruptMarker(dbPath string) error {
-	if err := os.Remove(CorruptMarkerPath(dbPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
+	return ClearCorruptMarkerFS(afero.NewOsFs(), dbPath)
+}
+
+// ClearCorruptMarkerFS removes the corrupt marker through fs.
+func ClearCorruptMarkerFS(fs afero.Fs, dbPath string) error {
+	if err := fs.Remove(CorruptMarkerPath(dbPath)); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to clear corrupt marker: %w", err)
 	}
 	return nil
@@ -114,8 +120,13 @@ func NoteCorruption(dbPath string, err error, now time.Time) bool {
 // RemoveSidecars deletes the -wal and -shm sidecar files for dbPath. A stale WAL
 // left next to a freshly restored or recreated database would re-corrupt it.
 func RemoveSidecars(dbPath string) {
+	RemoveSidecarsFS(afero.NewOsFs(), dbPath)
+}
+
+// RemoveSidecarsFS deletes database sidecars through fs.
+func RemoveSidecarsFS(fs afero.Fs, dbPath string) {
 	for _, sidecar := range []string{dbPath + "-wal", dbPath + "-shm"} {
-		if err := os.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fs.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warn().Err(err).Str("path", sidecar).Msg("failed to remove database sidecar")
 		}
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -902,6 +902,7 @@ type UserDBI interface {
 	GetDeviceState(key string) (string, bool, error)
 	DeleteDeviceState(key string) error
 	Backup(reason string, manual bool) (BackupInfo, error)
+	BackupForUpdate(targetVersion string) (BackupInfo, func() error, error)
 	BackupForTransfer(ctx context.Context, reason string) (BackupInfo, func() error, error)
 	EnsureRecentBackup(maxAge time.Duration) (BackupInfo, bool, error)
 	ListBackups() ([]BackupInfo, error)

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -61,6 +61,8 @@ const (
 // survive until something deletes them deliberately.
 type backupKind string
 
+type restoreQuickCheck func(context.Context, afero.Fs, string) (bool, string, error)
+
 const (
 	backupKindAuto   backupKind = "auto"
 	backupKindManual backupKind = "manual"
@@ -314,7 +316,7 @@ func (db *UserDB) BackupForTransfer(
 	}
 
 	transferPath := filepath.Join(transferDir, "user.db")
-	if err = copyFileSyncContext(ctx, full.Path, transferPath, 0o600); err != nil {
+	if err = copyFileSyncContext(ctx, afero.NewOsFs(), full.Path, transferPath, 0o600); err != nil {
 		return fail(fmt.Errorf("failed to copy transfer backup: %w", err))
 	}
 	if err = sanitizeTransferBackup(ctx, transferPath); err != nil {
@@ -437,20 +439,18 @@ func (r *contextReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
-func copyFileSync(src, dst string, mode os.FileMode) error {
-	return copyFileSyncContext(context.Background(), src, dst, mode)
+func copyFileSync(fs afero.Fs, src, dst string, mode os.FileMode) error {
+	return copyFileSyncContext(context.Background(), fs, src, dst, mode)
 }
 
-func copyFileSyncContext(ctx context.Context, src, dst string, mode os.FileMode) error {
-	//nolint:gosec // src is selected by backup validation/recovery code, not raw user input.
-	in, err := os.Open(src)
+func copyFileSyncContext(ctx context.Context, fs afero.Fs, src, dst string, mode os.FileMode) error {
+	in, err := fs.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed to open source file: %w", err)
 	}
 	defer func() { _ = in.Close() }()
 
-	//nolint:gosec // dst is the known user database path controlled by this package.
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	out, err := fs.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return fmt.Errorf("failed to open destination file: %w", err)
 	}
@@ -512,7 +512,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 	}
 	defer func() { _ = fs.Remove(tmpPath) }()
 
-	if err = copyFileSync(backupPath, tmpPath, 0o600); err != nil {
+	if err = copyFileSync(fs, backupPath, tmpPath, 0o600); err != nil {
 		return fmt.Errorf("failed to stage user database backup: %w", err)
 	}
 
@@ -532,7 +532,7 @@ func replaceDatabaseFromBackup(fs afero.Fs, backupPath, dbPath string) (err erro
 		}
 	}
 
-	database.RemoveSidecars(dbPath)
+	database.RemoveSidecarsFS(fs, dbPath)
 	if err = renameDatabaseFile(fs, tmpPath, dbPath); err != nil {
 		if originalPreserved {
 			rollbackErr := restoreDatabaseRollback(fs, rollbackPath, dbPath)
@@ -667,7 +667,25 @@ func syncAferoDirectory(fs afero.Fs, path string) error {
 // crash partway through is repaired by recoverInterruptedRestore, which Open
 // already runs before anything else touches the file.
 func RestoreFileTo(ctx context.Context, fs afero.Fs, backupPath, dbPath string) error {
-	valid, check, err := quickCheckDBContext(ctx, backupPath)
+	return restoreFileToWithCheck(ctx, fs, backupPath, dbPath, quickCheckRestoreDBContext)
+}
+
+func quickCheckRestoreDBContext(
+	ctx context.Context, fs afero.Fs, path string,
+) (valid bool, result string, err error) {
+	if _, ok := fs.(*afero.OsFs); !ok {
+		return false, "", errors.New("user database quick_check requires an OS filesystem")
+	}
+	return quickCheckDBContext(ctx, path)
+}
+
+func restoreFileToWithCheck(
+	ctx context.Context,
+	fs afero.Fs,
+	backupPath, dbPath string,
+	quickCheck restoreQuickCheck,
+) error {
+	valid, check, err := quickCheck(ctx, fs, backupPath)
 	if err != nil {
 		if database.IsCorruptionError(err) {
 			return fmt.Errorf("%w: quick_check: %w", ErrInvalidBackup, err)
@@ -680,7 +698,7 @@ func RestoreFileTo(ctx context.Context, fs afero.Fs, backupPath, dbPath string) 
 	if err = replaceDatabaseFromBackup(fs, backupPath, dbPath); err != nil {
 		return fmt.Errorf("failed to restore user database backup: %w", err)
 	}
-	if err = database.ClearCorruptMarker(dbPath); err != nil {
+	if err = database.ClearCorruptMarkerFS(fs, dbPath); err != nil {
 		return fmt.Errorf("failed to clear user database corrupt marker after restore: %w", err)
 	}
 	return nil
@@ -791,7 +809,7 @@ func (db *UserDB) RecoverFromCorruption() (database.RestoreInfo, error) {
 		if !backup.Valid {
 			continue
 		}
-		if err = copyFileSync(backup.Path, db.GetDBPath(), 0o600); err != nil {
+		if err = copyFileSync(afero.NewOsFs(), backup.Path, db.GetDBPath(), 0o600); err != nil {
 			log.Warn().Err(err).Str("path", backup.Path).Msg("failed to restore user database backup")
 			continue
 		}

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -30,12 +30,15 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
+
+var ErrInvalidBackup = errors.New("user database backup is invalid")
 
 const (
 	backupDirName            = "backups"
@@ -52,15 +55,27 @@ const (
 	restoreStagePattern = ".userdb-restore-*"
 )
 
+// backupKind is the suffix a backup filename carries, and the only record on
+// disk of why it was taken. Retention reads it back rather than any metadata:
+// pruneAutoBackups reclaims backupKindAuto and nothing else, so the other kinds
+// survive until something deletes them deliberately.
+type backupKind string
+
+const (
+	backupKindAuto   backupKind = "auto"
+	backupKindManual backupKind = "manual"
+	// backupKindUpdate marks the snapshot taken before an update installs a new
+	// binary. Rolling that update back needs a database the previous version can
+	// still open, so retention must not reclaim it on a schedule; the updater
+	// deletes it once the update is confirmed or rolled back.
+	backupKindUpdate backupKind = "update"
+)
+
 func (db *UserDB) backupDir() string {
 	return filepath.Join(filepath.Dir(db.GetDBPath()), backupDirName)
 }
 
-func backupName(manual bool, now time.Time) string {
-	kind := "auto"
-	if manual {
-		kind = "manual"
-	}
+func backupName(kind backupKind, now time.Time) string {
 	return fmt.Sprintf("%s%s-%09d-%s%s",
 		backupPrefix,
 		now.UTC().Format("20060102-150405"),
@@ -70,9 +85,29 @@ func backupName(manual bool, now time.Time) string {
 	)
 }
 
-func isAutoBackupName(name string) bool {
+// hasBackupKind reports whether name is a backup filename of a given kind. The
+// suffix is built from the same constant backupName writes, so a new kind cannot
+// be added without retention and reporting agreeing on what it looks like.
+func hasBackupKind(name string, kind backupKind) bool {
 	return strings.HasPrefix(name, backupPrefix) &&
-		strings.HasSuffix(name, "-auto"+backupExt)
+		strings.HasSuffix(name, "-"+string(kind)+backupExt)
+}
+
+func isAutoBackupName(name string) bool {
+	return hasBackupKind(name, backupKindAuto)
+}
+
+// IsUpdateSnapshotName reports whether name is an update snapshot. The updater
+// needs this to reclaim snapshots whose update is long resolved, and it holds no
+// database handle when it runs.
+func IsUpdateSnapshotName(name string) bool {
+	return hasBackupKind(name, backupKindUpdate)
+}
+
+// BackupsDir returns the directory backups live in for a data directory, so a
+// caller with no open database can still find them.
+func BackupsDir(dataDir string) string {
+	return filepath.Join(dataDir, backupDirName)
 }
 
 func isBackupName(name string) bool {
@@ -93,7 +128,7 @@ func backupInfoContext(ctx context.Context, path string, quickCheck bool) (datab
 		Path:      path,
 		CreatedAt: info.ModTime(),
 		Size:      info.Size(),
-		Manual:    strings.HasSuffix(filepath.Base(path), "-manual"+backupExt),
+		Manual:    hasBackupKind(filepath.Base(path), backupKindManual),
 	}
 	if quickCheck {
 		valid, check, checkErr := quickCheckDBContext(ctx, path)
@@ -150,19 +185,78 @@ func (db *UserDB) pruneAutoBackups() error {
 }
 
 func (db *UserDB) Backup(reason string, manual bool) (database.BackupInfo, error) {
-	return db.createBackup(db.ctx, reason, manual)
+	kind := backupKindAuto
+	if manual {
+		kind = backupKindManual
+	}
+	return db.createBackup(db.ctx, reason, kind)
 }
 
-func (db *UserDB) createBackup(ctx context.Context, reason string, manual bool) (database.BackupInfo, error) {
+// BackupForUpdate drains and closes the live connection pool before taking the
+// snapshot. The pool remains closed until the caller invokes resume after an
+// aborted install; a successful install restarts the process instead. This
+// closes the window where acknowledged outgoing-version writes could land after
+// the rollback snapshot.
+func (db *UserDB) BackupForUpdate(
+	targetVersion string,
+) (database.BackupInfo, func() error, error) {
 	if db.sql.Load() == nil {
+		return database.BackupInfo{}, nil, ErrNullSQL
+	}
+	if err := db.closeAndDrain(); err != nil {
+		if openErr := db.Open(); openErr != nil {
+			return database.BackupInfo{}, nil, errors.Join(err,
+				fmt.Errorf("reopening user database after failed update drain: %w", openErr))
+		}
+		return database.BackupInfo{}, nil, err
+	}
+
+	resume := sync.OnceValue(func() error {
+		if err := db.Open(); err != nil {
+			return fmt.Errorf("reopening user database after aborted update: %w", err)
+		}
+		return nil
+	})
+	fail := func(cause error) (database.BackupInfo, func() error, error) {
+		return database.BackupInfo{}, nil, errors.Join(cause, resume())
+	}
+
+	snapshotDB, err := db.openSQLConnection(db.GetDBPath())
+	if err != nil {
+		return fail(fmt.Errorf("opening drained user database for update snapshot: %w", err))
+	}
+	snapshot, backupErr := db.createBackupWithSQL(
+		db.ctx, "update-"+targetVersion, backupKindUpdate, snapshotDB,
+	)
+	closeErr := snapshotDB.Close()
+	if backupErr != nil {
+		return fail(backupErr)
+	}
+	if closeErr != nil {
+		return fail(fmt.Errorf("closing update snapshot connection: %w", closeErr))
+	}
+	return snapshot, resume, nil
+}
+
+func (db *UserDB) createBackup(
+	ctx context.Context, reason string, kind backupKind,
+) (database.BackupInfo, error) {
+	sqlInstance := db.sql.Load()
+	if sqlInstance == nil {
 		return database.BackupInfo{}, ErrNullSQL
 	}
+	return db.createBackupWithSQL(ctx, reason, kind, sqlInstance)
+}
+
+func (db *UserDB) createBackupWithSQL(
+	ctx context.Context, reason string, kind backupKind, sqlInstance *sql.DB,
+) (database.BackupInfo, error) {
 	if err := os.MkdirAll(db.backupDir(), 0o750); err != nil {
 		return database.BackupInfo{}, fmt.Errorf("failed to create user database backup directory: %w", err)
 	}
 
-	backupPath := filepath.Join(db.backupDir(), backupName(manual, time.Now()))
-	if _, err := db.sql.Load().ExecContext(ctx, "VACUUM INTO ?", backupPath); err != nil {
+	backupPath := filepath.Join(db.backupDir(), backupName(kind, time.Now()))
+	if _, err := sqlInstance.ExecContext(ctx, "VACUUM INTO ?", backupPath); err != nil {
 		db.NoteCorruption(err)
 		return database.BackupInfo{}, fmt.Errorf("failed to back up user database: %w", err)
 	}
@@ -180,7 +274,7 @@ func (db *UserDB) createBackup(ctx context.Context, reason string, manual bool) 
 		_ = os.Remove(backupPath)
 		return info, fmt.Errorf("user database backup failed validation: %s", info.QuickCheck)
 	}
-	if !manual {
+	if kind == backupKindAuto {
 		if pruneErr := db.pruneAutoBackups(); pruneErr != nil {
 			return info, pruneErr
 		}
@@ -188,7 +282,7 @@ func (db *UserDB) createBackup(ctx context.Context, reason string, manual bool) 
 	log.Info().
 		Str("path", info.Path).
 		Int64("size", info.Size).
-		Bool("manual", manual).
+		Str("kind", string(kind)).
 		Str("reason", reason).
 		Msg("created user database backup")
 	return info, nil
@@ -200,7 +294,7 @@ func (db *UserDB) createBackup(ctx context.Context, reason string, manual bool) 
 func (db *UserDB) BackupForTransfer(
 	ctx context.Context, reason string,
 ) (database.BackupInfo, func() error, error) {
-	full, err := db.createBackup(ctx, reason, false)
+	full, err := db.createBackup(ctx, reason, backupKindAuto)
 	if err != nil {
 		return database.BackupInfo{}, nil, err
 	}
@@ -556,6 +650,38 @@ func syncAferoDirectory(fs afero.Fs, path string) error {
 	}
 	if closeErr != nil {
 		return fmt.Errorf("failed to close synced directory: %w", closeErr)
+	}
+	return nil
+}
+
+// RestoreFileTo installs a backup over a user database that nothing has open.
+//
+// RestoreBackup is the normal path and cannot be used here: it needs a live
+// *UserDB, and the only way to get one is OpenUserDB, which creates a fresh
+// empty schema when the file is missing. The update watchdog runs before any
+// database is opened — that is what lets it decide without consulting a schema
+// version — so it needs the swap on its own.
+//
+// The backup is quick_checked first, because installing a corrupt file over a
+// working database turns a recoverable situation into an unrecoverable one. A
+// crash partway through is repaired by recoverInterruptedRestore, which Open
+// already runs before anything else touches the file.
+func RestoreFileTo(ctx context.Context, fs afero.Fs, backupPath, dbPath string) error {
+	valid, check, err := quickCheckDBContext(ctx, backupPath)
+	if err != nil {
+		if database.IsCorruptionError(err) {
+			return fmt.Errorf("%w: quick_check: %w", ErrInvalidBackup, err)
+		}
+		return fmt.Errorf("failed to check user database backup: %w", err)
+	}
+	if !valid {
+		return fmt.Errorf("%w: quick_check: %s", ErrInvalidBackup, check)
+	}
+	if err = replaceDatabaseFromBackup(fs, backupPath, dbPath); err != nil {
+		return fmt.Errorf("failed to restore user database backup: %w", err)
+	}
+	if err = database.ClearCorruptMarker(dbPath); err != nil {
+		return fmt.Errorf("failed to clear user database corrupt marker after restore: %w", err)
 	}
 	return nil
 }

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -1126,3 +1126,142 @@ func TestBackupsDir(t *testing.T) {
 
 	assert.Equal(t, filepath.Join("data", backupDirName), BackupsDir("data"))
 }
+
+// quick_check runs through SQLite, which reads the real filesystem. Passing an
+// in-memory filesystem would have it check some other file — or nothing — so it
+// has to be refused rather than silently report a healthy backup.
+func TestRestoreFileTo_RequiresAnOSFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	dir := filepath.Join("data", "zaparoo")
+	require.NoError(t, fs.MkdirAll(dir, 0o750))
+	backupPath := filepath.Join(dir, "backup.db")
+	dbPath := filepath.Join(dir, "user.db")
+	require.NoError(t, afero.WriteFile(fs, backupPath, []byte("replacement"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, dbPath, []byte("original"), 0o600))
+
+	err := RestoreFileTo(t.Context(), fs, backupPath, dbPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OS filesystem")
+
+	contents, readErr := afero.ReadFile(fs, dbPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte("original"), contents, "the live database must be untouched")
+}
+
+// Whatever quick_check reports, a backup that is not known-good must never be
+// installed over a working database.
+func TestRestoreFileTo_LeavesTheDatabaseAloneWhenTheBackupIsNotKnownGood(t *testing.T) {
+	t.Parallel()
+
+	checkFailed := errors.New("could not open the backup")
+	tests := []struct {
+		check     restoreQuickCheck
+		wantIs    error
+		name      string
+		wantError string
+	}{
+		{
+			name: "quick_check reports damage",
+			check: func(context.Context, afero.Fs, string) (bool, string, error) {
+				return false, "*** in database main: page 3 is never used", nil
+			},
+			wantIs:    ErrInvalidBackup,
+			wantError: "page 3 is never used",
+		},
+		{
+			name: "quick_check finds corruption",
+			check: func(context.Context, afero.Fs, string) (bool, string, error) {
+				return false, "", errors.New("database disk image is malformed")
+			},
+			wantIs:    ErrInvalidBackup,
+			wantError: "quick_check",
+		},
+		{
+			name: "quick_check could not run",
+			check: func(context.Context, afero.Fs, string) (bool, string, error) {
+				return false, "", checkFailed
+			},
+			wantIs:    checkFailed,
+			wantError: "failed to check user database backup",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := afero.NewMemMapFs()
+			dir := filepath.Join("data", "zaparoo")
+			require.NoError(t, fs.MkdirAll(dir, 0o750))
+			backupPath := filepath.Join(dir, "backup.db")
+			dbPath := filepath.Join(dir, "user.db")
+			require.NoError(t, afero.WriteFile(fs, backupPath, []byte("replacement"), 0o600))
+			require.NoError(t, afero.WriteFile(fs, dbPath, []byte("original"), 0o600))
+
+			err := restoreFileToWithCheck(t.Context(), fs, backupPath, dbPath, tt.check)
+			require.ErrorIs(t, err, tt.wantIs)
+			assert.Contains(t, err.Error(), tt.wantError)
+
+			contents, readErr := afero.ReadFile(fs, dbPath)
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte("original"), contents, "the live database must be untouched")
+		})
+	}
+}
+
+// An update install asks for the snapshot before it touches anything. Without a
+// connection there is nothing to snapshot, and the install has to stop rather
+// than proceed with no rollback point.
+func TestUserDBBackupForUpdate_WithoutAConnection(t *testing.T) {
+	t.Parallel()
+
+	snapshot, resume, err := (&UserDB{}).BackupForUpdate("2.2.0")
+	require.ErrorIs(t, err, ErrNullSQL)
+	assert.Nil(t, resume)
+	assert.Empty(t, snapshot.Path)
+}
+
+// A drain that fails leaves writers still attached, so the snapshot cannot be
+// consistent. The install is told to stop, and the database is put back the way
+// it was found: the caller never closed it and has no way to reopen it.
+func TestUserDBBackupForUpdate_ReopensAfterAFailedDrain(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	require.NoError(t, userDB.sql.Load().Close())
+	sqlDB, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	closeErr := errors.New("driver refused to close")
+	mock.ExpectClose().WillReturnError(closeErr)
+	userDB.sql.Store(sqlDB)
+
+	snapshot, resume, err := userDB.BackupForUpdate("2.2.0")
+	require.ErrorIs(t, err, closeErr)
+	assert.Nil(t, resume)
+	assert.Empty(t, snapshot.Path)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	_, err = userDB.GetAllMappings()
+	require.NoError(t, err, "the database must be usable again after a refused drain")
+}
+
+// A snapshot that fails must not leave the connection pool drained: the install
+// is abandoned, but the service keeps running on the database it already had.
+func TestUserDBBackupForUpdate_ReopensWhenTheSnapshotFails(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	backupDir := userDB.backupDir()
+	require.NoError(t, os.RemoveAll(backupDir))
+	require.NoError(t, os.WriteFile(backupDir, []byte("not a directory"), 0o600))
+
+	snapshot, resume, err := userDB.BackupForUpdate("2.2.0")
+	require.Error(t, err)
+	assert.Nil(t, resume)
+	assert.Empty(t, snapshot.Path)
+
+	_, err = userDB.GetAllMappings()
+	require.NoError(t, err, "the database must be usable again after a failed snapshot")
+}

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -1022,6 +1022,40 @@ func TestUserDBBackupForUpdate_QuiescesWritersUntilResume(t *testing.T) {
 	}))
 }
 
+func TestRestoreFileTo_UsesSuppliedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	dir := filepath.Join("data", "zaparoo")
+	require.NoError(t, fs.MkdirAll(dir, 0o750))
+	backupPath := filepath.Join(dir, "backup.db")
+	dbPath := filepath.Join(dir, "user.db")
+	require.NoError(t, afero.WriteFile(fs, backupPath, []byte("replacement"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, dbPath, []byte("original"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, dbPath+"-wal", []byte("stale wal"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, database.CorruptMarkerPath(dbPath), []byte("corrupt"), 0o600))
+
+	checked := false
+	err := restoreFileToWithCheck(t.Context(), fs, backupPath, dbPath,
+		func(_ context.Context, gotFS afero.Fs, gotPath string) (bool, string, error) {
+			checked = true
+			assert.Same(t, fs, gotFS)
+			assert.Equal(t, backupPath, gotPath)
+			return true, "ok", nil
+		})
+	require.NoError(t, err)
+	assert.True(t, checked)
+
+	contents, err := afero.ReadFile(fs, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("replacement"), contents)
+	for _, removed := range []string{dbPath + "-wal", database.CorruptMarkerPath(dbPath)} {
+		exists, existsErr := afero.Exists(fs, removed)
+		require.NoError(t, existsErr)
+		assert.False(t, exists)
+	}
+}
+
 func TestRestoreFileTo_ReplacesTheLiveDatabase(t *testing.T) {
 	userDB, cleanup := setupTempUserDB(t)
 	defer cleanup()

--- a/pkg/database/userdb/backup_test.go
+++ b/pkg/database/userdb/backup_test.go
@@ -934,3 +934,161 @@ func TestUserDBOpenRefusesWhenRecoveryFails(t *testing.T) {
 	require.Len(t, mappings, 1)
 	assert.Equal(t, "Survivor", mappings[0].Label)
 }
+
+func TestBackupName_KindDecidesRetention(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 4, 30, 0, 1, time.UTC)
+
+	autoName := backupName(backupKindAuto, now)
+	manualName := backupName(backupKindManual, now)
+	updateName := backupName(backupKindUpdate, now)
+
+	assert.True(t, isBackupName(autoName))
+	assert.True(t, isBackupName(manualName))
+	assert.True(t, isBackupName(updateName), "an update snapshot is still restorable by name")
+
+	assert.True(t, isAutoBackupName(autoName))
+	assert.False(t, isAutoBackupName(manualName))
+	assert.False(t, isAutoBackupName(updateName), "retention must not reclaim update snapshots")
+
+	assert.False(t, IsUpdateSnapshotName(autoName))
+	assert.False(t, IsUpdateSnapshotName(manualName))
+	assert.True(t, IsUpdateSnapshotName(updateName))
+}
+
+// An update snapshot is not a manual backup, so it does not claim the exemption
+// the app shows for one, and it is not an auto backup, so retention leaves it
+// alone. The updater is what deletes it, once the update has been resolved.
+func TestUserDBBackupForUpdate_SurvivesPruningAndIsNotManual(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	snapshot, resume, err := userDB.BackupForUpdate("2.2.0")
+	require.NoError(t, err)
+	require.NoError(t, resume())
+	assert.False(t, snapshot.Manual)
+	assert.True(t, snapshot.Valid)
+	assert.True(t, IsUpdateSnapshotName(snapshot.Name))
+
+	for range autoBackupKeep + 2 {
+		_, backupErr := userDB.Backup("scheduled", false)
+		require.NoError(t, backupErr)
+	}
+
+	backups, err := userDB.ListBackups()
+	require.NoError(t, err)
+
+	autoCount := 0
+	snapshotPresent := false
+	for _, b := range backups {
+		if isAutoBackupName(b.Name) {
+			autoCount++
+		}
+		if b.Name == snapshot.Name {
+			snapshotPresent = true
+		}
+	}
+	assert.Equal(t, autoBackupKeep, autoCount, "auto backups pruned to retention limit")
+	assert.True(t, snapshotPresent, "update snapshot must survive pruning")
+	assert.FileExists(t, snapshot.Path)
+}
+
+func TestUserDBBackupForUpdate_QuiescesWritersUntilResume(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	_, resume, err := userDB.BackupForUpdate("2.2.0")
+	require.NoError(t, err)
+
+	err = userDB.AddMapping(&database.Mapping{
+		Label:    "too-late",
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "after-update-snapshot",
+		Override: "**launch.system:snes",
+		Enabled:  true,
+	})
+	require.Error(t, err, "writes after the update snapshot must remain quiesced")
+
+	require.NoError(t, resume())
+	require.NoError(t, userDB.AddMapping(&database.Mapping{
+		Label:    "after-resume",
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "after-aborted-update",
+		Override: "**launch.system:snes",
+		Enabled:  true,
+	}))
+}
+
+func TestRestoreFileTo_ReplacesTheLiveDatabase(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	require.NoError(t, userDB.AddMapping(&database.Mapping{
+		Label:    "restore-file-to",
+		Type:     MappingTypeID,
+		Match:    MatchTypeExact,
+		Pattern:  "restore-file-to-token",
+		Override: "**launch.system:snes",
+		Enabled:  true,
+	}))
+
+	snapshot, _, err := userDB.BackupForUpdate("2.2.0")
+	require.NoError(t, err)
+
+	dbPath := userDB.GetDBPath()
+	require.NoError(t, userDB.Close())
+
+	require.NoError(t, RestoreFileTo(context.Background(), afero.NewOsFs(), snapshot.Path, dbPath))
+
+	restored, err := sql.Open("sqlite3", dbPath+"?mode=ro&_query_only=ON")
+	require.NoError(t, err)
+	defer func() { _ = restored.Close() }()
+
+	var count int
+	require.NoError(t, restored.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM Mappings WHERE pattern = ?`, "restore-file-to-token",
+	).Scan(&count))
+	assert.Equal(t, 1, count)
+}
+
+// A backup that fails quick_check is not installed over a working database:
+// replacing a good file with a broken one is worse than refusing the restore.
+func TestRestoreFileTo_RejectsACorruptBackup(t *testing.T) {
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	snapshot, _, err := userDB.BackupForUpdate("2.2.0")
+	require.NoError(t, err)
+
+	dbPath := userDB.GetDBPath()
+	require.NoError(t, userDB.Close())
+
+	live, err := os.ReadFile(dbPath) // #nosec G304 -- test-owned path.
+	require.NoError(t, err)
+
+	corrupt, err := os.ReadFile(snapshot.Path) // #nosec G304 -- test-owned path.
+	require.NoError(t, err)
+	// Leave the header intact so it is opened as a database and then found bad,
+	// rather than rejected as some other kind of file.
+	for i := 100; i < len(corrupt) && i < 4096; i++ {
+		corrupt[i] = 0xFF
+	}
+	require.NoError(t, os.WriteFile(snapshot.Path, corrupt, 0o600)) // #nosec G703 -- test-owned path.
+
+	err = RestoreFileTo(context.Background(), afero.NewOsFs(), snapshot.Path, dbPath)
+	require.ErrorIs(t, err, ErrInvalidBackup)
+	assert.Contains(t, err.Error(), "quick_check", "the backup must be rejected by the integrity check")
+
+	after, err := os.ReadFile(dbPath) // #nosec G304 -- test-owned path.
+	require.NoError(t, err)
+	assert.Equal(t, live, after, "the live database must be untouched")
+}
+
+func TestBackupsDir(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, filepath.Join("data", backupDirName), BackupsDir("data"))
+}

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -861,8 +861,13 @@ func (s *Service) startService() {
 		// re-prepares the binary from the source path, which is where the
 		// rollback put it.
 		if errors.Is(err, updater.ErrRolledBack) {
-			execErr := s.restartServiceBinary()
-			log.Error().Err(execErr).Msg("failed to re-exec after rolling back an update")
+			targetPath, ok := updater.RollbackTargetPath(err)
+			if !ok {
+				log.Error().Err(err).Msg("rollback result did not include restored binary path")
+			} else {
+				execErr := s.restartServiceBinary(targetPath)
+				log.Error().Err(execErr).Msg("failed to re-exec after rolling back an update")
+			}
 		}
 
 		os.Exit(1)
@@ -888,7 +893,7 @@ func (s *Service) startService() {
 	}
 
 	if result.RestartRequested != nil && result.RestartRequested() {
-		execErr := s.restartServiceBinary()
+		execErr := s.restartServiceBinary("")
 		log.Error().Err(execErr).Msg("failed to re-exec for restart")
 		os.Exit(1)
 	}
@@ -896,8 +901,8 @@ func (s *Service) startService() {
 	os.Exit(0)
 }
 
-func (s *Service) restartServiceBinary() error {
-	cfg, err := s.restartExecConfig(os.Args, os.Environ())
+func (s *Service) restartServiceBinary(sourcePath string) error {
+	cfg, err := s.restartExecConfig(sourcePath, os.Args, os.Environ())
 	if err != nil {
 		return err
 	}
@@ -914,12 +919,17 @@ func (s *Service) restartServiceBinary() error {
 }
 
 func (s *Service) restartExecConfig(
+	sourcePath string,
 	args []string,
 	env []string,
 ) (restartExecConfig, error) {
-	binPath, err := serviceSourceBinaryPath()
-	if err != nil {
-		return restartExecConfig{}, err
+	binPath := sourcePath
+	if binPath == "" {
+		var err error
+		binPath, err = serviceSourceBinaryPath()
+		if err != nil {
+			return restartExecConfig{}, err
+		}
 	}
 	serviceBin, err := s.prepareBinary(binPath)
 	if err != nil {

--- a/pkg/service/daemon/daemon.go
+++ b/pkg/service/daemon/daemon.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/cespare/xxhash/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
@@ -850,9 +851,18 @@ func (s *Service) startService() {
 	if err != nil {
 		log.Error().Err(err).Msg("error starting service")
 
-		err = s.removePidFile()
-		if err != nil {
-			log.Error().Err(err).Msg("error removing pid file")
+		if pidErr := s.removePidFile(); pidErr != nil {
+			log.Error().Err(pidErr).Msg("error removing pid file")
+		}
+
+		// The previous version is back on disk but this process is still the
+		// image that failed, and on these platforms nothing would start the
+		// restored one. Re-exec instead of exiting: restartServiceBinary
+		// re-prepares the binary from the source path, which is where the
+		// rollback put it.
+		if errors.Is(err, updater.ErrRolledBack) {
+			execErr := s.restartServiceBinary()
+			log.Error().Err(execErr).Msg("failed to re-exec after rolling back an update")
 		}
 
 		os.Exit(1)

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -807,6 +807,7 @@ func TestRestartExecConfigUsesCachedServiceBinary(t *testing.T) {
 	t.Setenv(config.AppEnv, srcPath)
 
 	cfg, err := svc.restartExecConfig(
+		"",
 		[]string{"old-cache", "-service", "exec"},
 		[]string{"A=B", config.AppEnv + "=/old/path"},
 	)
@@ -818,6 +819,28 @@ func TestRestartExecConfigUsesCachedServiceBinary(t *testing.T) {
 	assert.FileExists(t, cfg.serviceBin)
 	assert.Equal(t, []string{cfg.serviceBin, "-service", "exec"}, cfg.args)
 	assert.Contains(t, cfg.env, config.AppEnv+"="+srcPath)
+}
+
+func TestRestartExecConfigUsesRollbackTargetWithoutAppEnv(t *testing.T) {
+	svc := newTestService(t)
+
+	srcDir := t.TempDir()
+	targetPath := filepath.Join(srcDir, "restored-zaparoo.sh")
+	require.NoError(t, os.WriteFile(targetPath, []byte("restored-binary"), 0o600))
+	t.Setenv(config.AppEnv, "")
+
+	cfg, err := svc.restartExecConfig(
+		targetPath,
+		[]string{"failed-cache", "-service", "exec"},
+		[]string{"A=B"},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, targetPath, cfg.binPath)
+	assert.Contains(t, cfg.env, config.AppEnv+"="+targetPath)
+	cached, err := os.ReadFile(cfg.serviceBin) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	assert.Equal(t, []byte("restored-binary"), cached)
 }
 
 func TestRunningRemovesStalePIDFile(t *testing.T) {

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -843,6 +843,25 @@ func TestRestartExecConfigUsesRollbackTargetWithoutAppEnv(t *testing.T) {
 	assert.Equal(t, []byte("restored-binary"), cached)
 }
 
+// A rollback that names a binary which is no longer there must fail loudly:
+// exec'ing whatever the stale cache happens to hold would silently undo the
+// rollback.
+func TestRestartExecConfigFailsWhenRollbackTargetIsMissing(t *testing.T) {
+	svc := newTestService(t)
+	t.Setenv(config.AppEnv, "")
+
+	missing := filepath.Join(t.TempDir(), "restored-zaparoo.sh")
+	cfg, err := svc.restartExecConfig(
+		missing,
+		[]string{"failed-cache", "-service", "exec"},
+		[]string{"A=B"},
+	)
+
+	require.ErrorIs(t, err, os.ErrNotExist)
+	assert.Empty(t, cfg.serviceBin)
+	assert.Empty(t, cfg.args)
+}
+
 func TestRunningRemovesStalePIDFile(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/inbox/inbox.go
+++ b/pkg/service/inbox/inbox.go
@@ -52,6 +52,7 @@ const (
 	CategoryMediaDBSchemaReset               = "mediadb_schema_reset"
 	CategoryMediaIndexResumeLimit            = "media_index_resume_limit"
 	CategoryUpdateAvailable                  = "update_available"
+	CategoryUpdateResult                     = "update_result"
 	CategoryBackupRemoteNotAvailable         = "backup_remote_not_available"
 	CategoryBackupRemoteQuotaExceeded        = "backup_remote_quota_exceeded"
 	CategoryBackupRemoteUnlinked             = "backup_remote_unlinked"

--- a/pkg/service/restart/restart.go
+++ b/pkg/service/restart/restart.go
@@ -20,6 +20,7 @@
 package restart
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -37,6 +38,22 @@ func ExecIfRequested(restartRequested func() bool) error {
 	}
 	log.Info().Msg("restart requested, re-executing binary")
 	return Exec()
+}
+
+// ExecAfterRollback re-execs the restored binary. A successful Exec never
+// returns, so every return preserves the rollback error for diagnosis.
+func ExecAfterRollback(rollbackErr error) error {
+	return execAfterRollbackWith(rollbackErr, Exec)
+}
+
+func execAfterRollbackWith(rollbackErr error, execFn func() error) error {
+	execErr := execFn()
+	if execErr == nil {
+		return fmt.Errorf("failed to re-exec after rolling back an update: restart returned unexpectedly: %w",
+			rollbackErr)
+	}
+	return fmt.Errorf("failed to re-exec after rolling back an update: %w",
+		errors.Join(rollbackErr, execErr))
 }
 
 // BinaryPath returns the path to the binary that should be exec'd on restart.

--- a/pkg/service/restart/restart_test.go
+++ b/pkg/service/restart/restart_test.go
@@ -20,6 +20,7 @@
 package restart
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -27,6 +28,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExecAfterRollback_PreservesExecFailure(t *testing.T) {
+	t.Parallel()
+
+	rollbackErr := errors.New("startup failed after rollback")
+	execErr := errors.New("exec denied")
+	err := execAfterRollbackWith(rollbackErr, func() error { return execErr })
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, rollbackErr)
+	require.ErrorIs(t, err, execErr)
+}
+
+func TestExecAfterRollback_HandlesUnexpectedNil(t *testing.T) {
+	t.Parallel()
+
+	rollbackErr := errors.New("startup failed after rollback")
+	err := execAfterRollbackWith(rollbackErr, func() error { return nil })
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, rollbackErr)
+	assert.Contains(t, err.Error(), "restart returned unexpectedly")
+}
 
 func TestBinaryPath_WithAppEnv(t *testing.T) {
 	t.Setenv(config.AppEnv, "/usr/bin/zaparoo")

--- a/pkg/service/restart/restart_unix.go
+++ b/pkg/service/restart/restart_unix.go
@@ -22,6 +22,7 @@
 package restart
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -44,6 +45,8 @@ func Exec() error {
 		Msg("re-executing binary for update restart")
 
 	//nolint:gosec // Safe: binPath is from os.Executable() or ZAPAROO_APP env var
-	err = syscall.Exec(binPath, os.Args, os.Environ())
-	return fmt.Errorf("exec failed: %w", err)
+	if err := syscall.Exec(binPath, os.Args, os.Environ()); err != nil {
+		return fmt.Errorf("exec failed: %w", err)
+	}
+	return errors.New("exec returned without replacing process")
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -23,6 +23,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -288,12 +289,60 @@ func resumeBackgroundAfterMediaStop(svc *ServiceContext) {
 	svc.State.SetBackgroundAutoPaused(false)
 }
 
+// updateConfirmDelay is how long an updated version has to stay up before its
+// update is committed. Long enough to catch a build that starts and then dies
+// on its first real work, short enough that the staged copy and the database
+// snapshot are not left sitting on a full SD card.
+const updateConfirmDelay = 30 * time.Second
+
+// Start brings the service up and resolves any update still waiting on this
+// boot to prove itself.
+//
+// The wrapper around startService exists for the failure path. Most of the platforms
+// this runs on have no supervisor, so a version that cannot start is not
+// restarted by anything: the device is simply gone until someone reflashes it.
+// Routing every way startService can fail through one deferred hook puts the previous
+// version back and reports ErrRolledBack, and the caller re-execs into it
+// rather than exiting.
 func Start(
 	pl platforms.Platform,
 	cfg *config.Instance,
-) (*StartResult, error) {
+) (res *StartResult, err error) {
 	log.Info().Msgf("version: %s", config.AppVersion)
 
+	dataDir := helpers.DataDir(pl)
+
+	// Deliberately before config, databases and network are touched: the
+	// failure this exists to catch is a binary that cannot reach any of them.
+	// It has its own context because st.GetContext does not exist yet.
+	if watchdogErr := updater.RunStartupWatchdog(
+		context.Background(), dataDir, config.AppVersion,
+	); watchdogErr != nil {
+		if errors.Is(watchdogErr, updater.ErrRolledBack) {
+			return nil, fmt.Errorf("resolving a pending update: %w", watchdogErr)
+		}
+		log.Error().Err(watchdogErr).Msg("could not resolve a pending update, continuing startup")
+	}
+
+	defer func() {
+		if err == nil {
+			return
+		}
+		// Only does anything when this boot is the first one after an update.
+		if rollbackErr := updater.RollBackFailedStart(
+			context.Background(), dataDir, config.AppVersion,
+		); rollbackErr != nil {
+			err = fmt.Errorf("%w: %w", rollbackErr, err)
+		}
+	}()
+
+	return startService(pl, cfg)
+}
+
+func startService(
+	pl platforms.Platform,
+	cfg *config.Instance,
+) (*StartResult, error) {
 	// A config file created outside Core can lack a device ID. The service
 	// daemon owns device identity (TUI/CLI processes only read it), so
 	// mint and persist one before anything reads it. Save generates a
@@ -736,6 +785,9 @@ func Start(
 	go func() {
 		<-st.GetContext().Done()
 		log.Info().Msg("service context cancelled, running cleanup")
+		if shutdownErr := updater.RecordCleanShutdown(helpers.DataDir(pl), config.AppVersion); shutdownErr != nil {
+			log.Warn().Err(shutdownErr).Msg("could not record clean shutdown during update confirmation")
+		}
 		if backupErr := waitForBackupShutdown(
 			st.BackupCoordinator(), backupShutdownWarningAfter, backupShutdownHardDeadline,
 		); backupErr != nil {
@@ -797,6 +849,19 @@ func Start(
 	}
 	log.Info().Msg("platform post start completed, service fully initialized")
 
+	// A rollback finishes before there is a database to post to and then
+	// re-execs, so this is the first point at which the user can be told about
+	// one. It is deliberately after StartPost: a boot that still fails after
+	// here rolls back and restores the database, which would take the message
+	// with it.
+	updater.ReportLastUpdate(helpers.DataDir(pl), st.Inbox())
+
+	backgroundWG.Add(1)
+	go func() {
+		defer backgroundWG.Done()
+		confirmPendingUpdate(st, helpers.DataDir(pl))
+	}()
+
 	if cfg.ServiceOnBoot() != "" || cfg.ServiceOnReady() != "" {
 		backgroundWG.Add(1)
 		go func() {
@@ -814,4 +879,25 @@ func Start(
 		Done:             doneCh,
 		RestartRequested: st.RestartRequested,
 	}, nil
+}
+
+// confirmPendingUpdate commits an update once the version it installed has run
+// for a while without falling over. Shutting down before then proves nothing, so
+// the marker stays and the next boot starts the wait again.
+func confirmPendingUpdate(st *state.State, dataDir string) {
+	select {
+	case <-time.After(updateConfirmDelay):
+	case <-st.GetContext().Done():
+		return
+	}
+
+	version, err := updater.Confirm(st.GetContext(), dataDir, config.AppVersion)
+	if err != nil {
+		log.Error().Err(err).Msg("could not confirm the installed update")
+		return
+	}
+	if version == "" {
+		return
+	}
+	updater.ReportLastUpdate(dataDir, st.Inbox())
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -65,6 +65,10 @@ const (
 	backupShutdownHardDeadline  = 2 * time.Minute
 	startupMediaIdleQuietWindow = 5 * time.Second
 	startupMediaIdleMaximumWait = 300 * time.Second
+	// updateConfirmDelay is how long an updated version has to stay up before its
+	// update is committed. Long enough to catch a build that starts and then dies
+	// on its first real work, short enough that recovery files do not fill storage.
+	updateConfirmDelay = 30 * time.Second
 )
 
 // StartResult holds the return values from Start.
@@ -288,12 +292,6 @@ func resumeBackgroundAfterMediaStop(svc *ServiceContext) {
 	}
 	svc.State.SetBackgroundAutoPaused(false)
 }
-
-// updateConfirmDelay is how long an updated version has to stay up before its
-// update is committed. Long enough to catch a build that starts and then dies
-// on its first real work, short enough that the staged copy and the database
-// snapshot are not left sitting on a full SD card.
-const updateConfirmDelay = 30 * time.Second
 
 // Start brings the service up and resolves any update still waiting on this
 // boot to prove itself.

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1796,3 +1796,35 @@ func TestCheckAndResumeIndexing_WaitGroupRace(t *testing.T) {
 		})
 	}
 }
+
+// An update is only committed once the version that installed it has stayed up
+// for a while. Shutting down before then proves nothing, so the wait must be
+// abandoned and the marker left for the next boot to judge.
+func TestConfirmPendingUpdate_ShutdownAbandonsTheWait(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	st, notifCh := state.NewState(mockPlatform, "test-boot-uuid")
+	t.Cleanup(func() {
+		st.StopService()
+		for len(notifCh) > 0 {
+			<-notifCh
+		}
+	})
+
+	dataDir := t.TempDir()
+	st.StopService()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		confirmPendingUpdate(st, dataDir)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(updateConfirmDelay):
+		t.Fatal("confirmPendingUpdate kept waiting after the service shut down")
+	}
+}

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -95,6 +95,7 @@ type State struct {
 	mediaRestoreMu        syncutil.RWMutex
 	mu                    syncutil.RWMutex
 	mediaLaunchMu         syncutil.RWMutex
+	activeMediaPublishMu  syncutil.RWMutex
 	activeMediaReady      bool
 	restartRequested      bool
 	restorePendingRestart bool
@@ -613,6 +614,11 @@ func (s *State) AcquireMediaLaunch() (func(), error) {
 	// side through Platform.LaunchMedia keeps stop requests behind platform
 	// launch settling and active-media readiness setup.
 	s.mediaLaunchMu.RLock()
+	if err := s.ctx.Err(); err != nil {
+		s.mediaLaunchMu.RUnlock()
+		releaseRestore()
+		return nil, err
+	}
 	s.mu.Lock()
 	s.mediaLaunchAccesses++
 	s.mu.Unlock()
@@ -628,6 +634,29 @@ func (s *State) AcquireMediaLaunch() (func(), error) {
 // AcquireMediaStop waits for in-flight media launches, then prevents another
 // launch from starting until the returned release function is called.
 func (s *State) AcquireMediaStop(ctx context.Context) (func(), error) {
+	return acquireExclusiveGate(ctx, &s.mediaLaunchMu)
+}
+
+// AcquireUpdateMediaGate waits for in-flight launches and ActiveMedia
+// publications, then prevents either from starting until release. The updater
+// holds this gate from its final safety check through restart cancellation.
+func (s *State) AcquireUpdateMediaGate(ctx context.Context) (func(), error) {
+	releaseLaunch, err := s.AcquireMediaStop(ctx)
+	if err != nil {
+		return nil, err
+	}
+	releasePublish, err := acquireExclusiveGate(ctx, &s.activeMediaPublishMu)
+	if err != nil {
+		releaseLaunch()
+		return nil, err
+	}
+	return func() {
+		releasePublish()
+		releaseLaunch()
+	}, nil
+}
+
+func acquireExclusiveGate(ctx context.Context, gate *syncutil.RWMutex) (func(), error) {
 	const retryInterval = 5 * time.Millisecond
 
 	retry := time.NewTicker(retryInterval)
@@ -640,9 +669,9 @@ func (s *State) AcquireMediaStop(ctx context.Context) (func(), error) {
 		}
 
 		// TryLock avoids registering a writer that would keep blocking new
-		// launches after this request is canceled.
-		if s.mediaLaunchMu.TryLock() {
-			return s.mediaLaunchMu.Unlock, nil
+		// readers after this request is canceled.
+		if gate.TryLock() {
+			return gate.Unlock, nil
 		}
 
 		select {
@@ -746,6 +775,16 @@ func (s *State) MarkActiveMediaReady(gen uint64) {
 
 func (s *State) SetActiveMedia(media *models.ActiveMedia) {
 	if media != nil {
+		// This gate is separate from mediaLaunchMu because normal launch code
+		// already holds that lock when it publishes ActiveMedia. External
+		// lifecycle trackers do not, so every publication takes this read side.
+		s.activeMediaPublishMu.RLock()
+		defer s.activeMediaPublishMu.RUnlock()
+		if err := s.ctx.Err(); err != nil {
+			log.Debug().Err(err).Msg("active media update rejected while service is stopping")
+			return
+		}
+
 		s.mu.RLock()
 		launchAccessHeld := s.mediaLaunchAccesses > 0
 		s.mu.RUnlock()

--- a/pkg/service/state/state_media_test.go
+++ b/pkg/service/state/state_media_test.go
@@ -152,6 +152,66 @@ func TestMediaStopGateWaitsForLaunchAndBlocksReplacement(t *testing.T) {
 	}
 }
 
+func TestUpdateMediaGateBlocksExternalPublicationThroughRestart(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(nil, "test-boot")
+	defer st.StopService()
+
+	releaseUpdate, err := st.AcquireUpdateMediaGate(context.Background())
+	require.NoError(t, err)
+
+	published := make(chan struct{})
+	go func() {
+		st.SetActiveMedia(&models.ActiveMedia{SystemID: "SNES", Name: "Game"})
+		close(published)
+	}()
+	select {
+	case <-published:
+		t.Fatal("external ActiveMedia publication bypassed update gate")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Nil(t, st.ActiveMedia())
+
+	st.RestartService()
+	releaseUpdate()
+	select {
+	case <-published:
+	case <-time.After(time.Second):
+		t.Fatal("external ActiveMedia publication did not stop after restart")
+	}
+	assert.Nil(t, st.ActiveMedia())
+}
+
+func TestUpdateMediaGateReleasesLaunchGateWhenPublicationWaitIsCanceled(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(nil, "test-boot")
+	defer st.StopService()
+
+	st.activeMediaPublishMu.RLock()
+	defer st.activeMediaPublishMu.RUnlock()
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		release, err := st.AcquireUpdateMediaGate(ctx)
+		if release != nil {
+			release()
+		}
+		result <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		if st.mediaLaunchMu.TryRLock() {
+			st.mediaLaunchMu.RUnlock()
+			return false
+		}
+		return true
+	}, time.Second, 5*time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-result, context.Canceled)
+	require.True(t, st.mediaLaunchMu.TryRLock(), "canceled update gate retained media launch lock")
+	st.mediaLaunchMu.RUnlock()
+}
+
 func TestMediaStopGateHonorsContextCancellation(t *testing.T) {
 	t.Parallel()
 	st, _ := NewState(nil, "test-boot")
@@ -273,6 +333,16 @@ func TestSuccessfulRestoreGateBlocksLaunchUntilRestart(t *testing.T) {
 	require.ErrorIs(t, err, ErrRestoreRestartRequired)
 	_, err = st.BeginRestoreGate()
 	require.ErrorIs(t, err, ErrRestoreRestartRequired)
+}
+
+func TestAcquireMediaLaunch_RejectsStoppedService(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(nil, "test-boot")
+	st.StopService()
+
+	release, err := st.AcquireMediaLaunch()
+	assert.Nil(t, release)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestSetRunZapScript(t *testing.T) {

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -1,0 +1,357 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	installBackupSuffix    = ".zaparoo-update-backup"
+	installCandidateSuffix = ".zaparoo-update-new"
+)
+
+// UpdateBackupper is the part of the live UserDB needed to arm rollback before
+// an update replaces the running binary.
+type UpdateBackupper interface {
+	BackupForUpdate(targetVersion string) (database.BackupInfo, func() error, error)
+}
+
+type installOptions struct {
+	UserDB             UpdateBackupper
+	Staged             *StagedUpdate
+	TargetPath         string
+	DataDir            string
+	PreviousVersion    string
+	PlatformID         string
+	Trigger            updateTrigger
+	ManifestGeneration int64
+}
+
+// installStaged copies the verified binary onto the target filesystem, snapshots
+// the live UserDB, records recovery metadata, then swaps the binary into place.
+// Every filesystem mutation after the marker is durable can be resumed or
+// undone by the startup watchdog.
+func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
+	if opts == nil || opts.Staged == nil {
+		return errors.New("installing an update needs a staged release")
+	}
+	if opts.UserDB == nil {
+		return errors.New("installing an update needs the user database")
+	}
+	if opts.TargetPath == "" || opts.DataDir == "" {
+		return errors.New("installing an update needs target and data paths")
+	}
+
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	dir := stateDirFor(opts.DataDir)
+	pending, loadErr := loadMarker(dir)
+	if loadErr != nil {
+		return fmt.Errorf("checking for an unresolved update: %w", loadErr)
+	}
+	if pending != nil {
+		return fmt.Errorf("an update to %s is still unresolved", pending.TargetVersion)
+	}
+
+	backupPath := installSidecarPath(opts.TargetPath, installBackupSuffix)
+	candidatePath := installSidecarPath(opts.TargetPath, installCandidateSuffix)
+	if _, statErr := os.Lstat(backupPath); statErr == nil {
+		if _, targetErr := os.Stat(opts.TargetPath); targetErr != nil {
+			return fmt.Errorf("orphaned binary backup exists but target is unavailable: %w", targetErr)
+		}
+		if removeErr := os.Remove(backupPath); removeErr != nil {
+			return fmt.Errorf("removing an orphaned binary backup: %w", removeErr)
+		}
+		if syncErr := syncDir(filepath.Dir(opts.TargetPath)); syncErr != nil {
+			return fmt.Errorf("flushing removal of an orphaned binary backup: %w", syncErr)
+		}
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("checking for an unresolved binary backup: %w", statErr)
+	}
+	if removeErr := os.Remove(candidatePath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		return fmt.Errorf("removing a stale install candidate: %w", removeErr)
+	}
+
+	if candidateErr := prepareInstallCandidate(ctx, opts.Staged.BinaryPath, candidatePath,
+		opts.Staged.Version, opts.PlatformID); candidateErr != nil {
+		if cleanupErr := removeStagingDir(ctx, opts.Staged.Dir); cleanupErr != nil {
+			log.Warn().Err(cleanupErr).Str("dir", opts.Staged.Dir).
+				Msg("could not remove staging after candidate preparation failed")
+		}
+		return candidateErr
+	}
+
+	snapshot, resumeUserDB, err := opts.UserDB.BackupForUpdate(opts.Staged.Version)
+	if err != nil {
+		_ = os.Remove(candidatePath)
+		if cleanupErr := removeStagingDir(ctx, opts.Staged.Dir); cleanupErr != nil {
+			log.Warn().Err(cleanupErr).Str("dir", opts.Staged.Dir).
+				Msg("could not remove staging after the update snapshot failed")
+		}
+		return fmt.Errorf("snapshotting the user database before update: %w", err)
+	}
+	resumeOnFailure := true
+	defer func() {
+		if resumeOnFailure && resumeUserDB != nil {
+			if resumeErr := resumeUserDB(); resumeErr != nil {
+				retErr = errors.Join(retErr,
+					fmt.Errorf("reopening user database after failed update install: %w", resumeErr))
+			}
+		}
+	}()
+
+	m := &pendingMarker{
+		InstalledAt:        time.Now().UTC(),
+		State:              markerInstalling,
+		Trigger:            opts.Trigger,
+		TargetPath:         opts.TargetPath,
+		BackupPath:         backupPath,
+		StagingDir:         opts.Staged.Dir,
+		PreviousVersion:    opts.PreviousVersion,
+		TargetVersion:      opts.Staged.Version,
+		PlatformID:         opts.PlatformID,
+		UserDBSnapshotPath: snapshot.Path,
+		ManifestGeneration: opts.ManifestGeneration,
+	}
+	if err := preserveCurrentBinary(opts.TargetPath, backupPath); err != nil {
+		removeInstallArtifacts(ctx, m, candidatePath)
+		return fmt.Errorf("preserving the current binary: %w", err)
+	}
+	if err := saveMarker(dir, m); err != nil {
+		removeInstallArtifacts(ctx, m, candidatePath)
+		return fmt.Errorf("recording the start of the update install: %w", err)
+	}
+
+	// Target remains the old executable until this single atomic replacement.
+	// A power cut before it leaves the old target intact; one after it leaves the
+	// verified target plus the durable old-binary copy and marker.
+	if err := replaceFile(candidatePath, opts.TargetPath); err != nil {
+		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath,
+			fmt.Errorf("installing the staged binary: %w", err))
+	}
+	if err := syncDir(filepath.Dir(opts.TargetPath)); err != nil {
+		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath,
+			fmt.Errorf("flushing the installed binary: %w", err))
+	}
+
+	m.State = markerInstalled
+	if err := saveMarker(dir, m); err != nil {
+		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath,
+			fmt.Errorf("recording the completed update install: %w", err))
+	}
+
+	resumeOnFailure = false
+	log.Info().
+		Str("from", opts.PreviousVersion).
+		Str("to", opts.Staged.Version).
+		Str("target", opts.TargetPath).
+		Msg("installed update and armed startup watchdog")
+	return nil
+}
+
+func preserveCurrentBinary(targetPath, backupPath string) error {
+	info, err := os.Stat(targetPath)
+	if err != nil {
+		return fmt.Errorf("reading current binary: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("current binary %q is not a regular file", targetPath)
+	}
+
+	src, err := os.Open(targetPath) //nolint:gosec // resolved executable path
+	if err != nil {
+		return fmt.Errorf("opening current binary: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	//nolint:gosec // backup must preserve executable mode for rollback
+	dst, err := os.OpenFile(backupPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("creating current binary backup: %w", err)
+	}
+	_, copyErr := io.Copy(dst, src)
+	// File.Sync must follow Chmod so executable-mode metadata reaches the same
+	// durability barrier as contents before the rollback marker is armed.
+	chmodErr := dst.Chmod(info.Mode().Perm())
+	syncErr := dst.Sync()
+	closeErr := dst.Close()
+	if copyErr != nil {
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("copying current binary backup: %w", copyErr)
+	}
+	if syncErr != nil {
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("flushing current binary backup: %w", syncErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(backupPath)
+		return fmt.Errorf("closing current binary backup: %w", closeErr)
+	}
+	if chmodErr != nil {
+		log.Warn().Err(chmodErr).Str("binary", backupPath).
+			Msg("could not preserve binary backup permissions; filesystem may derive them from mount options")
+	}
+	if runtime.GOOS != "windows" {
+		backupInfo, statErr := os.Stat(backupPath)
+		if statErr != nil {
+			return fmt.Errorf("checking binary backup permissions: %w", statErr)
+		}
+		if backupInfo.Mode().Perm()&0o111 == 0 {
+			return fmt.Errorf("binary backup %q is not executable on the target filesystem", backupPath)
+		}
+	}
+	if err := syncDir(filepath.Dir(targetPath)); err != nil {
+		return fmt.Errorf("flushing current binary backup directory: %w", err)
+	}
+	return nil
+}
+
+func prepareInstallCandidate(
+	ctx context.Context, stagedPath, candidatePath, version, platformID string,
+) error {
+	src, err := os.Open(stagedPath) //nolint:gosec // path comes from this package's verified staging result
+	if err != nil {
+		return fmt.Errorf("opening the staged binary: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	//nolint:gosec // executable candidate must be runnable; archive permissions are not trusted
+	dst, err := os.OpenFile(candidatePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, stagedBinaryPerm)
+	if err != nil {
+		return fmt.Errorf("creating the install candidate: %w", err)
+	}
+
+	_, copyErr := io.Copy(dst, src)
+	syncErr := dst.Sync()
+	closeErr := dst.Close()
+	if copyErr != nil {
+		_ = os.Remove(candidatePath)
+		return fmt.Errorf("copying the staged binary to the target filesystem: %w", copyErr)
+	}
+	if syncErr != nil {
+		_ = os.Remove(candidatePath)
+		return fmt.Errorf("flushing the install candidate: %w", syncErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(candidatePath)
+		return fmt.Errorf("closing the install candidate: %w", closeErr)
+	}
+	// A restrictive process umask may have removed execute bits from OpenFile's
+	// mode. Filesystems without mode bits can reject Chmod while still executing
+	// the file through mount options, so the probe below remains authoritative.
+	//nolint:gosec // an executable candidate must be executable
+	if err := os.Chmod(candidatePath, stagedBinaryPerm); err != nil {
+		log.Warn().Err(err).Str("binary", candidatePath).
+			Msg("could not set install candidate permissions; leaving the decision to the probe")
+	}
+	if err := syncDir(filepath.Dir(candidatePath)); err != nil {
+		_ = os.Remove(candidatePath)
+		return fmt.Errorf("flushing the install candidate directory: %w", err)
+	}
+
+	// Probe again after copying because staging and the live install can be on
+	// different filesystems with different execution and permission semantics.
+	probe := &stager{platformID: platformID, probeTimeout: probeTimeout}
+	if err := probe.probeBinary(ctx, candidatePath, version); err != nil {
+		_ = os.Remove(candidatePath)
+		return fmt.Errorf("probing the install candidate on the target filesystem: %w", err)
+	}
+	return nil
+}
+
+func abortInstallAfterError(
+	ctx context.Context, dataDir string, m *pendingMarker, candidatePath string, installErr error,
+) error {
+	if abortErr := abortInstall(ctx, dataDir, m, candidatePath); abortErr != nil {
+		return fmt.Errorf("%w; aborting the partial install also failed: %w", installErr, abortErr)
+	}
+	return installErr
+}
+
+// abortInstall restores only the binary. The new version has not run yet, so
+// restoring the UserDB snapshot would discard writes made while Apply was live.
+// Callers hold markerMu.
+func abortInstall(ctx context.Context, dataDir string, m *pendingMarker, candidatePath string) error {
+	if m == nil {
+		return nil
+	}
+	if _, backupErr := os.Stat(m.BackupPath); backupErr == nil {
+		if restoreErr := replaceFile(m.BackupPath, m.TargetPath); restoreErr != nil {
+			return fmt.Errorf("restoring the current binary after a failed install: %w", restoreErr)
+		}
+		if syncErr := syncDir(filepath.Dir(m.TargetPath)); syncErr != nil {
+			return fmt.Errorf("flushing the restored current binary: %w", syncErr)
+		}
+	} else if errors.Is(backupErr, os.ErrNotExist) {
+		if _, targetErr := os.Stat(m.TargetPath); targetErr != nil {
+			return fmt.Errorf("failed install has neither current binary nor backup: %w", targetErr)
+		}
+	} else {
+		return fmt.Errorf("checking the current binary backup after a failed install: %w", backupErr)
+	}
+
+	if err := clearMarker(stateDirFor(dataDir)); err != nil {
+		return err
+	}
+	removeInstallArtifacts(ctx, m, candidatePath)
+	return nil
+}
+
+func removeInstallArtifacts(ctx context.Context, m *pendingMarker, candidatePath string) {
+	if m != nil && m.BackupPath != "" {
+		if err := os.Remove(m.BackupPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", m.BackupPath).Msg("could not remove unused binary backup")
+		}
+	}
+	if candidatePath != "" {
+		if err := os.Remove(candidatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", candidatePath).Msg("could not remove update install candidate")
+		}
+	}
+	if m != nil && m.UserDBSnapshotPath != "" {
+		if err := os.Remove(m.UserDBSnapshotPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", m.UserDBSnapshotPath).Msg("could not remove unused update snapshot")
+		}
+	}
+	if m != nil && m.StagingDir != "" {
+		if err := removeStagingDir(ctx, m.StagingDir); err != nil {
+			log.Warn().Err(err).Str("dir", m.StagingDir).Msg("could not remove unused update staging directory")
+		}
+	}
+}
+
+func installSidecarPath(targetPath, suffix string) string {
+	ext := filepath.Ext(targetPath)
+	base := strings.TrimSuffix(targetPath, ext)
+	return base + suffix + ext
+}

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -20,6 +20,7 @@
 package updater
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,23 +31,42 @@ import (
 )
 
 type installTestBackupper struct {
-	version  string
-	snapshot database.BackupInfo
-	resumed  bool
+	err       error
+	resumeErr error
+	version   string
+	snapshot  database.BackupInfo
+	called    bool
+	resumed   bool
 }
 
 func (b *installTestBackupper) BackupForUpdate(
 	targetVersion string,
 ) (database.BackupInfo, func() error, error) {
+	b.called = true
 	b.version = targetVersion
+	if b.err != nil {
+		return database.BackupInfo{}, nil, b.err
+	}
 	return b.snapshot, func() error {
 		b.resumed = true
-		return nil
+		return b.resumeErr
 	}, nil
 }
 
-func TestInstallStaged_ArmsWatchdogBeforeRestart(t *testing.T) {
-	require.NoError(t, errFakeBinary)
+// installStagedFixture is a staged release sitting next to a live binary, laid
+// out the way stage.go leaves it just before an install starts.
+type installStagedFixture struct {
+	backupper    *installTestBackupper
+	dataDir      string
+	targetPath   string
+	stagedPath   string
+	stagingDir   string
+	snapshotPath string
+}
+
+func newInstallStagedFixture(t *testing.T) *installStagedFixture {
+	t.Helper()
+	require.NoError(t, errFakeBinary, "the fake release binary did not build")
 
 	dataDir := t.TempDir()
 	binDir := t.TempDir()
@@ -65,38 +85,78 @@ func TestInstallStaged_ArmsWatchdogBeforeRestart(t *testing.T) {
 	snapshotPath := filepath.Join(dataDir, "backups", "backup-20260818-043000-000000001-update.db")
 	require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o750))
 	require.NoError(t, os.WriteFile(snapshotPath, []byte("snapshot"), 0o600))
-	backupper := &installTestBackupper{snapshot: database.BackupInfo{Path: snapshotPath}}
 
-	err = installStaged(t.Context(), &installOptions{
+	return &installStagedFixture{
+		backupper:    &installTestBackupper{snapshot: database.BackupInfo{Path: snapshotPath}},
+		dataDir:      dataDir,
+		targetPath:   targetPath,
+		stagedPath:   stagedPath,
+		stagingDir:   stagingDir,
+		snapshotPath: snapshotPath,
+	}
+}
+
+// blockStateDir makes the updater state directory unwritable so the marker
+// cannot be armed, without disturbing anything the install reads first.
+func (f *installStagedFixture) blockStateDir(t *testing.T) {
+	t.Helper()
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	//nolint:gosec // an unwritable-but-readable directory is the failure under test
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, stateDirPerm)
+	})
+}
+
+// assertInstallUndone checks that a failed install left the machine exactly as
+// it found it: the old binary in place and no update artifacts behind.
+func (f *installStagedFixture) assertInstallUndone(t *testing.T) {
+	t.Helper()
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installBackupSuffix))
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installCandidateSuffix))
+	assert.NoFileExists(t, f.snapshotPath)
+	assert.NoDirExists(t, f.stagingDir)
+}
+
+func (f *installStagedFixture) options() *installOptions {
+	return &installOptions{
 		Staged: &StagedUpdate{
-			Dir:        stagingDir,
-			BinaryPath: stagedPath,
+			Dir:        f.stagingDir,
+			BinaryPath: f.stagedPath,
 			Version:    testStageVersion,
 		},
-		UserDB:             backupper,
-		TargetPath:         targetPath,
-		DataDir:            dataDir,
-		PreviousVersion:    testCurrentVersion,
-		PlatformID:         testStagePlatform,
-		ManifestGeneration: 412,
-		Trigger:            triggerManual,
-	})
-	require.NoError(t, err)
+		UserDB:          f.backupper,
+		TargetPath:      f.targetPath,
+		DataDir:         f.dataDir,
+		PreviousVersion: testCurrentVersion,
+		PlatformID:      testStagePlatform,
+		Trigger:         triggerManual,
+	}
+}
 
-	assert.Equal(t, testStageVersion, backupper.version)
-	assert.False(t, backupper.resumed, "successful install keeps UserDB quiesced until restart")
-	assert.Equal(t, "old binary", readFileString(t, installSidecarPath(targetPath, installBackupSuffix)))
-	assert.FileExists(t, targetPath)
-	assert.FileExists(t, snapshotPath)
-	assert.DirExists(t, stagingDir)
+func TestInstallStaged_ArmsWatchdogBeforeRestart(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	opts := f.options()
+	opts.ManifestGeneration = 412
 
-	m, err := loadMarker(stateDirFor(dataDir))
+	require.NoError(t, installStaged(t.Context(), opts))
+
+	assert.Equal(t, testStageVersion, f.backupper.version)
+	assert.False(t, f.backupper.resumed, "successful install keeps UserDB quiesced until restart")
+	assert.Equal(t, "old binary", readFileString(t, installSidecarPath(f.targetPath, installBackupSuffix)))
+	assert.FileExists(t, f.targetPath)
+	assert.FileExists(t, f.snapshotPath)
+	assert.DirExists(t, f.stagingDir)
+
+	m, err := loadMarker(stateDirFor(f.dataDir))
 	require.NoError(t, err)
 	require.NotNil(t, m)
 	assert.Equal(t, markerInstalled, m.State)
-	assert.Equal(t, targetPath, m.TargetPath)
-	assert.Equal(t, installSidecarPath(targetPath, installBackupSuffix), m.BackupPath)
-	assert.Equal(t, snapshotPath, m.UserDBSnapshotPath)
+	assert.Equal(t, f.targetPath, m.TargetPath)
+	assert.Equal(t, installSidecarPath(f.targetPath, installBackupSuffix), m.BackupPath)
+	assert.Equal(t, f.snapshotPath, m.UserDBSnapshotPath)
 	assert.Equal(t, testCurrentVersion, m.PreviousVersion)
 	assert.Equal(t, testStageVersion, m.TargetVersion)
 	assert.Equal(t, int64(412), m.ManifestGeneration)
@@ -159,4 +219,268 @@ func TestInstallSidecarPath_PreservesExecutableExtension(t *testing.T) {
 	assert.Equal(t,
 		filepath.Join("bin", "zaparoo"+installBackupSuffix),
 		installSidecarPath(filepath.Join("bin", "zaparoo"), installBackupSuffix))
+}
+
+func TestInstallStaged_RejectsIncompleteOptions(t *testing.T) {
+	t.Parallel()
+
+	staged := &StagedUpdate{Dir: "staging", BinaryPath: "staged", Version: testStageVersion}
+	backupper := &installTestBackupper{}
+
+	for name, opts := range map[string]*installOptions{
+		"nil options": nil,
+		"no staged release": {
+			UserDB: backupper, TargetPath: "target", DataDir: "data",
+		},
+		"no user database": {
+			Staged: staged, TargetPath: "target", DataDir: "data",
+		},
+		"no target path": {
+			Staged: staged, UserDB: backupper, DataDir: "data",
+		},
+		"no data directory": {
+			Staged: staged, UserDB: backupper, TargetPath: "target",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Error(t, installStaged(t.Context(), opts))
+			assert.Empty(t, backupper.version, "an incomplete install must not touch the user database")
+		})
+	}
+}
+
+// TestInstallStaged_RefusesWhileAnUpdateIsUnresolved keeps a second install from
+// overwriting the binary backup and marker the watchdog still needs to undo the
+// first one.
+func TestInstallStaged_RefusesWhileAnUpdateIsUnresolved(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, &pendingMarker{
+		State:         markerInstalled,
+		TargetPath:    f.targetPath,
+		TargetVersion: "9.9.9",
+	}))
+
+	err := installStaged(t.Context(), f.options())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "9.9.9")
+	assert.False(t, f.backupper.called, "a blocked install must not quiesce the user database")
+
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "9.9.9", m.TargetVersion, "the unresolved marker must survive untouched")
+}
+
+// TestInstallStaged_ClearsAnOrphanedBinaryBackup covers the retry after an
+// install that finished its cleanup incompletely: the previous backup is stale
+// once the target is present, and keeping it would make the next rollback
+// restore the wrong binary.
+func TestInstallStaged_ClearsAnOrphanedBinaryBackup(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	backupPath := installSidecarPath(f.targetPath, installBackupSuffix)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(backupPath, []byte("orphaned backup"), 0o755))
+
+	require.NoError(t, installStaged(t.Context(), f.options()))
+
+	assert.Equal(t, "old binary", readFileString(t, backupPath),
+		"the backup must describe the binary this install replaced, not the orphan")
+}
+
+func TestInstallStaged_RefusesWhenAnOrphanedBackupHasNoTarget(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	backupPath := installSidecarPath(f.targetPath, installBackupSuffix)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(backupPath, []byte("orphaned backup"), 0o755))
+	require.NoError(t, os.Remove(f.targetPath))
+
+	err := installStaged(t.Context(), f.options())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "orphaned binary backup")
+	assert.Equal(t, "orphaned backup", readFileString(t, backupPath),
+		"the only remaining copy of a binary must not be removed")
+	assert.False(t, f.backupper.called)
+}
+
+// TestInstallStaged_LeavesTheUserDBAloneWhenTheCandidateWillNotRun proves the
+// probe on the target filesystem runs before anything the old version depends
+// on is disturbed.
+func TestInstallStaged_LeavesTheUserDBAloneWhenTheCandidateWillNotRun(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	//nolint:gosec // deliberately not an executable
+	require.NoError(t, os.WriteFile(f.stagedPath, []byte("not a real binary"), 0o755))
+
+	err := installStaged(t.Context(), f.options())
+	require.Error(t, err)
+
+	assert.False(t, f.backupper.called, "the user database must stay open when the candidate fails")
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installCandidateSuffix))
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+	assert.NoDirExists(t, f.stagingDir, "a condemned release must not keep occupying the device")
+}
+
+// TestInstallStaged_CleansUpWhenTheSnapshotFails covers the window between a
+// verified candidate and an armed marker: without the snapshot there is nothing
+// to roll the database back to, so the install must not start.
+func TestInstallStaged_CleansUpWhenTheSnapshotFails(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	f.backupper.err = errors.New("database is busy")
+
+	err := installStaged(t.Context(), f.options())
+	require.Error(t, err)
+	require.ErrorIs(t, err, f.backupper.err)
+
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installCandidateSuffix))
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+	assert.NoDirExists(t, f.stagingDir)
+}
+
+func TestAbortInstall_RestoresTheCurrentBinary(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	binDir := t.TempDir()
+	targetPath := filepath.Join(binDir, testBinaryName("zaparoo"))
+	backupPath := installSidecarPath(targetPath, installBackupSuffix)
+	candidatePath := installSidecarPath(targetPath, installCandidateSuffix)
+	//nolint:gosec // executable stand-ins owned by this test
+	require.NoError(t, os.WriteFile(targetPath, []byte("half-installed binary"), 0o755))
+	//nolint:gosec // executable stand-ins owned by this test
+	require.NoError(t, os.WriteFile(backupPath, []byte("old binary"), 0o755))
+	//nolint:gosec // executable stand-ins owned by this test
+	require.NoError(t, os.WriteFile(candidatePath, []byte("candidate"), 0o755))
+
+	snapshotPath := filepath.Join(dataDir, "backups", "backup-20260818-043000-000000001-update.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o750))
+	require.NoError(t, os.WriteFile(snapshotPath, []byte("snapshot"), 0o600))
+	stagingDir := filepath.Join(stagingRootFor(dataDir), testStageVersion)
+	require.NoError(t, os.MkdirAll(stagingDir, stateDirPerm))
+
+	m := &pendingMarker{
+		State:              markerInstalling,
+		TargetPath:         targetPath,
+		BackupPath:         backupPath,
+		StagingDir:         stagingDir,
+		UserDBSnapshotPath: snapshotPath,
+		PreviousVersion:    testCurrentVersion,
+		TargetVersion:      testStageVersion,
+	}
+	require.NoError(t, saveMarker(stateDirFor(dataDir), m))
+
+	require.NoError(t, abortInstall(t.Context(), dataDir, m, candidatePath))
+
+	assert.Equal(t, "old binary", readFileString(t, targetPath))
+	assert.NoFileExists(t, backupPath)
+	assert.NoFileExists(t, candidatePath)
+	assert.NoFileExists(t, snapshotPath)
+	assert.NoDirExists(t, stagingDir)
+	assert.NoFileExists(t, markerPath(stateDirFor(dataDir)))
+}
+
+func TestAbortInstall_FailsWhenNeitherBinaryNorBackupExists(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	binDir := t.TempDir()
+	targetPath := filepath.Join(binDir, testBinaryName("zaparoo"))
+
+	err := abortInstall(t.Context(), dataDir, &pendingMarker{
+		State:      markerInstalling,
+		TargetPath: targetPath,
+		BackupPath: installSidecarPath(targetPath, installBackupSuffix),
+	}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "neither current binary nor backup")
+}
+
+func TestAbortInstall_WithoutAMarkerDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, abortInstall(t.Context(), t.TempDir(), nil, ""))
+}
+
+// A marker left unreadable by an earlier crash means an update may still be
+// unresolved. Starting a second install on top of it would lose the record of
+// the first, so the install has to refuse rather than assume nothing is pending.
+func TestInstallStaged_RefusesWhenTheMarkerIsUnreadable(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir), []byte("{not json"), 0o600))
+
+	err := installStaged(t.Context(), f.options())
+
+	require.ErrorContains(t, err, "checking for an unresolved update")
+	assert.False(t, f.backupper.called, "the database must not be quiesced for an install that cannot start")
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+}
+
+// The marker is what makes an install recoverable, so it is written before the
+// binary is swapped. If it cannot be written the install must undo itself
+// completely instead of running a new binary nothing is watching.
+func TestInstallStaged_UndoesEverythingWhenTheMarkerCannotBeArmed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+
+	f := newInstallStagedFixture(t)
+	f.blockStateDir(t)
+
+	err := installStaged(t.Context(), f.options())
+
+	require.ErrorContains(t, err, "recording the start of the update install")
+	assert.True(t, f.backupper.resumed, "the user database must be reopened after a failed install")
+	f.assertInstallUndone(t)
+
+	m, loadErr := loadMarker(stateDirFor(f.dataDir))
+	require.NoError(t, loadErr)
+	assert.Nil(t, m)
+}
+
+// A database that will not reopen leaves the service running without storage,
+// so that failure has to reach the caller alongside the install failure rather
+// than being lost behind it.
+func TestInstallStaged_ReportsAFailedDatabaseReopen(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+
+	f := newInstallStagedFixture(t)
+	f.blockStateDir(t)
+	reopenErr := errors.New("database is locked")
+	f.backupper.resumeErr = reopenErr
+
+	err := installStaged(t.Context(), f.options())
+
+	require.ErrorIs(t, err, reopenErr)
+	require.ErrorContains(t, err, "recording the start of the update install")
+	assert.ErrorContains(t, err, "reopening user database after failed update install")
+}
+
+// When an install fails and the undo fails too the machine is in the state the
+// operator most needs described, so neither failure may be dropped.
+func TestAbortInstallAfterError_ReportsBothFailures(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	backupPath := installSidecarPath(f.targetPath, installBackupSuffix)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(backupPath, []byte("old binary"), 0o755))
+
+	m := &pendingMarker{
+		State:      markerInstalling,
+		TargetPath: filepath.Join(f.dataDir, "gone", "zaparoo"),
+		BackupPath: backupPath,
+	}
+	installErr := errors.New("installing the staged binary")
+
+	err := abortInstallAfterError(t.Context(), f.dataDir, m, "", installErr)
+
+	require.ErrorIs(t, err, installErr)
+	require.ErrorContains(t, err, "aborting the partial install also failed")
+	require.ErrorContains(t, err, "restoring the current binary after a failed install")
+	assert.FileExists(t, backupPath, "a backup that could not be restored must be kept")
 }

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -1,0 +1,162 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type installTestBackupper struct {
+	version  string
+	snapshot database.BackupInfo
+	resumed  bool
+}
+
+func (b *installTestBackupper) BackupForUpdate(
+	targetVersion string,
+) (database.BackupInfo, func() error, error) {
+	b.version = targetVersion
+	return b.snapshot, func() error {
+		b.resumed = true
+		return nil
+	}, nil
+}
+
+func TestInstallStaged_ArmsWatchdogBeforeRestart(t *testing.T) {
+	require.NoError(t, errFakeBinary)
+
+	dataDir := t.TempDir()
+	binDir := t.TempDir()
+	targetPath := filepath.Join(binDir, testBinaryName("zaparoo"))
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(targetPath, []byte("old binary"), 0o755))
+
+	stagingDir := filepath.Join(stagingRootFor(dataDir), testStageVersion)
+	require.NoError(t, os.MkdirAll(stagingDir, stateDirPerm))
+	stagedPath := filepath.Join(stagingDir, testBinaryName("zaparoo"))
+	fakeBinary, err := os.ReadFile(fakeBinaryPath) //nolint:gosec // package test fixture
+	require.NoError(t, err)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(stagedPath, fakeBinary, 0o755))
+
+	snapshotPath := filepath.Join(dataDir, "backups", "backup-20260818-043000-000000001-update.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o750))
+	require.NoError(t, os.WriteFile(snapshotPath, []byte("snapshot"), 0o600))
+	backupper := &installTestBackupper{snapshot: database.BackupInfo{Path: snapshotPath}}
+
+	err = installStaged(t.Context(), &installOptions{
+		Staged: &StagedUpdate{
+			Dir:        stagingDir,
+			BinaryPath: stagedPath,
+			Version:    testStageVersion,
+		},
+		UserDB:             backupper,
+		TargetPath:         targetPath,
+		DataDir:            dataDir,
+		PreviousVersion:    testCurrentVersion,
+		PlatformID:         testStagePlatform,
+		ManifestGeneration: 412,
+		Trigger:            triggerManual,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, testStageVersion, backupper.version)
+	assert.False(t, backupper.resumed, "successful install keeps UserDB quiesced until restart")
+	assert.Equal(t, "old binary", readFileString(t, installSidecarPath(targetPath, installBackupSuffix)))
+	assert.FileExists(t, targetPath)
+	assert.FileExists(t, snapshotPath)
+	assert.DirExists(t, stagingDir)
+
+	m, err := loadMarker(stateDirFor(dataDir))
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, markerInstalled, m.State)
+	assert.Equal(t, targetPath, m.TargetPath)
+	assert.Equal(t, installSidecarPath(targetPath, installBackupSuffix), m.BackupPath)
+	assert.Equal(t, snapshotPath, m.UserDBSnapshotPath)
+	assert.Equal(t, testCurrentVersion, m.PreviousVersion)
+	assert.Equal(t, testStageVersion, m.TargetVersion)
+	assert.Equal(t, int64(412), m.ManifestGeneration)
+}
+
+func TestPreserveCurrentBinary_LeavesBootTargetPresent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "zaparoo")
+	backupPath := installSidecarPath(targetPath, installBackupSuffix)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(targetPath, []byte("old binary"), 0o755))
+
+	require.NoError(t, preserveCurrentBinary(targetPath, backupPath))
+
+	assert.Equal(t, "old binary", readFileString(t, targetPath))
+	assert.Equal(t, "old binary", readFileString(t, backupPath))
+}
+
+func TestInstallStaged_ReopensUserDBAfterInstallFailure(t *testing.T) {
+	require.NoError(t, errFakeBinary)
+
+	dataDir := t.TempDir()
+	binDir := t.TempDir()
+	targetPath := filepath.Join(binDir, testBinaryName("missing-target"))
+	stagingDir := filepath.Join(stagingRootFor(dataDir), testStageVersion)
+	require.NoError(t, os.MkdirAll(stagingDir, stateDirPerm))
+	stagedPath := filepath.Join(stagingDir, testBinaryName("zaparoo"))
+	fakeBinary, err := os.ReadFile(fakeBinaryPath) //nolint:gosec // package test fixture
+	require.NoError(t, err)
+	//nolint:gosec // executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(stagedPath, fakeBinary, 0o755))
+
+	snapshotPath := filepath.Join(dataDir, "backups", "backup-20260818-043000-000000001-update.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(snapshotPath), 0o750))
+	require.NoError(t, os.WriteFile(snapshotPath, []byte("snapshot"), 0o600))
+	backupper := &installTestBackupper{snapshot: database.BackupInfo{Path: snapshotPath}}
+
+	err = installStaged(t.Context(), &installOptions{
+		Staged:          &StagedUpdate{Dir: stagingDir, BinaryPath: stagedPath, Version: testStageVersion},
+		UserDB:          backupper,
+		TargetPath:      targetPath,
+		DataDir:         dataDir,
+		PreviousVersion: testCurrentVersion,
+		PlatformID:      testStagePlatform,
+		Trigger:         triggerManual,
+	})
+	require.Error(t, err)
+	assert.True(t, backupper.resumed)
+	assert.NoFileExists(t, markerPath(stateDirFor(dataDir)))
+}
+
+func TestInstallSidecarPath_PreservesExecutableExtension(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		filepath.Join("bin", "zaparoo"+installBackupSuffix+".exe"),
+		installSidecarPath(filepath.Join("bin", "zaparoo.exe"), installBackupSuffix))
+	assert.Equal(t,
+		filepath.Join("bin", "zaparoo"+installBackupSuffix),
+		installSidecarPath(filepath.Join("bin", "zaparoo"), installBackupSuffix))
+}

--- a/pkg/service/updater/install_unix_test.go
+++ b/pkg/service/updater/install_unix_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const restrictiveUmaskHelperEnv = "ZAPAROO_TEST_RESTRICTIVE_UPDATE_UMASK"
+
+func TestPreserveCurrentBinary_RestoresExecuteBitsAfterRestrictiveUmask(t *testing.T) {
+	if os.Getenv(restrictiveUmaskHelperEnv) == "1" {
+		dir := t.TempDir()
+		targetPath := filepath.Join(dir, "zaparoo")
+		backupPath := installSidecarPath(targetPath, installBackupSuffix)
+		//nolint:gosec // executable stand-in owned by this test
+		require.NoError(t, os.WriteFile(targetPath, []byte("old binary"), 0o755))
+
+		previousUmask := syscall.Umask(0o777)
+		defer syscall.Umask(previousUmask)
+
+		require.NoError(t, preserveCurrentBinary(targetPath, backupPath))
+		info, err := os.Stat(backupPath)
+		require.NoError(t, err)
+		require.NotZero(t, info.Mode().Perm()&0o111)
+		return
+	}
+
+	//nolint:gosec // controlled self-exec of current test binary with a fixed test selector
+	cmd := exec.CommandContext(t.Context(), os.Args[0],
+		"-test.run=^TestPreserveCurrentBinary_RestoresExecuteBitsAfterRestrictiveUmask$")
+	cmd.Env = append(os.Environ(), restrictiveUmaskHelperEnv+"=1")
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "restrictive-umask helper failed:\n%s", output)
+}

--- a/pkg/service/updater/marker.go
+++ b/pkg/service/updater/marker.go
@@ -1,0 +1,238 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// currentMarkerVersion is the schema of pending.json this build writes.
+	currentMarkerVersion = 1
+
+	markerFileName = "pending.json"
+	// markerBadSuffix names a marker this build could not parse. It is kept
+	// rather than deleted so the failure can be looked at afterwards; an update
+	// that went wrong is exactly when the evidence matters.
+	markerBadSuffix = ".bad"
+)
+
+// markerState is where an update has got to. It is the field the watchdog keys
+// its decision off, so the zero value is deliberately not one of them: an empty
+// state in a file that exists means the marker is unusable, not that the update
+// had not started.
+type markerState string
+
+const (
+	// markerInstalling is durable before the old binary is moved. A crash in the
+	// install swap can therefore restore the old binary instead of leaving no
+	// executable at the target path.
+	markerInstalling markerState = "installing"
+	// markerInstalled means the new binary is in place but has never run. The
+	// process that wrote this had not restarted yet.
+	markerInstalled markerState = "installed"
+	// markerConfirming means the new binary booted far enough to read its own
+	// marker. It has not yet proved it can stay up.
+	markerConfirming markerState = "confirming"
+	// markerRollingBack means a rollback started. It is written before anything
+	// is moved, so a rollback interrupted by a power cut resumes rather than
+	// leaving half the files swapped.
+	markerRollingBack markerState = "rollingBack"
+)
+
+// updateTrigger records who asked for the update, for the inbox message and for
+// operators reading the file. Nothing branches on it.
+type updateTrigger string
+
+const (
+	triggerManual updateTrigger = "manual"
+	triggerAuto   updateTrigger = "auto"
+)
+
+// updateOutcome is written once an update reaches a terminal state.
+type updateOutcome string
+
+const (
+	outcomeSucceeded  updateOutcome = "succeeded"
+	outcomeRolledBack updateOutcome = "rolledBack"
+	// outcomeRollbackBlocked means the binary was rolled back but the user
+	// database snapshot could not be restored, or the rollback could not be
+	// completed at all, and the new binary was left installed instead. A device
+	// running a suspect version beats one that will not boot.
+	outcomeRollbackBlocked updateOutcome = "rollbackBlocked"
+)
+
+var (
+	// errMarkerTooNew means the marker was written by a build with a newer schema.
+	// The only safe response is to leave it completely alone — including not
+	// deleting it — because a newer version that rolled back to this one must still
+	// find its own marker intact when it next runs.
+	errMarkerTooNew = errors.New("update marker was written by a newer version")
+	// errMarkerUnusable distinguishes a marker that exists but cannot direct
+	// recovery from a marker that is genuinely absent. Snapshot collection must
+	// never run in the former case.
+	errMarkerUnusable = errors.New("update marker exists but is unusable")
+)
+
+// markerMu serialises marker readers and writers within the process. The file is
+// replaced by rename so a reader never sees a torn write, but the confirmation
+// soak and a fresh apply can both be live at once.
+var markerMu syncutil.Mutex
+
+// payloadBackup pairs an installed payload file with the copy of what it
+// replaced, so a rollback can put the original back without re-deriving where it
+// came from. Payload extras are not installed yet; the field exists from the
+// first version of the marker so adding them later is not a schema change.
+type payloadBackup struct {
+	TargetPath string `json:"targetPath"`
+	BackupPath string `json:"backupPath"`
+}
+
+// pendingMarker is the record an update leaves behind for the boot that follows
+// it. It is deliberately self-contained: the watchdog reads it before any
+// config, database or network is available, because the failure it exists to
+// catch is precisely a binary that cannot get that far.
+type pendingMarker struct {
+	InstalledAt        time.Time       `json:"installedAt"`
+	OutcomeAt          time.Time       `json:"outcomeAt,omitempty"`
+	StagingDir         string          `json:"stagingDir"`
+	PreviousVersion    string          `json:"previousVersion"`
+	OutcomeDetail      string          `json:"outcomeDetail,omitempty"`
+	Trigger            updateTrigger   `json:"trigger"`
+	TargetPath         string          `json:"targetPath"`
+	BackupPath         string          `json:"backupPath"`
+	State              markerState     `json:"state"`
+	Outcome            updateOutcome   `json:"outcome,omitempty"`
+	TargetVersion      string          `json:"targetVersion"`
+	PlatformID         string          `json:"platformId"`
+	UserDBSnapshotPath string          `json:"userDbSnapshotPath"`
+	RestoringPath      string          `json:"restoringPath,omitempty"`
+	PayloadBackups     []payloadBackup `json:"payloadBackups,omitempty"`
+	ManifestGeneration int64           `json:"manifestGeneration"`
+	Attempts           int             `json:"attempts"`
+	MarkerVersion      int             `json:"markerVersion"`
+}
+
+// markerPath returns the marker file inside the updater's state directory.
+func markerPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, markerFileName)
+}
+
+// loadMarker reads pending.json.
+//
+// A missing marker is the ordinary case and yields (nil, nil): almost every boot
+// has no update to resolve. An unreadable or invalid marker returns
+// errMarkerUnusable and is quarantined when possible, so startup can continue
+// without mistaking it for confirmed absence and deleting its snapshots. A
+// marker from a newer schema returns errMarkerTooNew and is left exactly as it
+// was found.
+func loadMarker(dir string) (*pendingMarker, error) {
+	if dir == "" {
+		return nil, nil //nolint:nilnil // no state directory means no marker, which is not an error
+	}
+
+	path := markerPath(dir)
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from the platform data dir
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if _, badErr := os.Stat(path + markerBadSuffix); badErr == nil {
+				return nil, fmt.Errorf("%w: quarantined marker remains at %s", errMarkerUnusable, path+markerBadSuffix)
+			} else if !errors.Is(badErr, os.ErrNotExist) {
+				return nil, fmt.Errorf("%w: checking quarantined marker: %w", errMarkerUnusable, badErr)
+			}
+			return nil, nil //nolint:nilnil // confirmed absence is the ordinary case
+		}
+		log.Warn().Err(err).Str("path", path).Msg("could not read update marker")
+		return nil, fmt.Errorf("%w: reading %s: %w", errMarkerUnusable, path, err)
+	}
+
+	var m pendingMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		log.Error().Err(err).Str("path", path).Msg("update marker is corrupt, quarantining it")
+		quarantineMarker(path)
+		return nil, fmt.Errorf("%w: decoding %s: %w", errMarkerUnusable, path, err)
+	}
+
+	if m.MarkerVersion > currentMarkerVersion {
+		return nil, fmt.Errorf("%w: found %d, this build understands %d",
+			errMarkerTooNew, m.MarkerVersion, currentMarkerVersion)
+	}
+	switch m.State {
+	case markerInstalling, markerInstalled, markerConfirming, markerRollingBack:
+		return &m, nil
+	default:
+		log.Error().Str("path", path).Str("state", string(m.State)).
+			Msg("update marker has an unusable state, quarantining it")
+		quarantineMarker(path)
+		return nil, fmt.Errorf("%w: state %q", errMarkerUnusable, m.State)
+	}
+}
+
+// quarantineMarker moves an unusable marker aside for diagnosis. loadMarker
+// continues noticing the quarantined file on later boots so snapshots remain
+// protected until an operator resolves it. Failing to move it is logged; the
+// caller still refuses to treat the marker as absent.
+func quarantineMarker(path string) {
+	if err := os.Rename(path, path+markerBadSuffix); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("could not quarantine the update marker")
+	}
+}
+
+// saveMarker replaces pending.json atomically.
+func saveMarker(dir string, m *pendingMarker) error {
+	if dir == "" || m == nil {
+		return nil
+	}
+	if m.MarkerVersion > currentMarkerVersion {
+		return nil
+	}
+	m.MarkerVersion = currentMarkerVersion
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding update marker: %w", err)
+	}
+	return writeFileAtomic(dir, markerFileName, data)
+}
+
+// clearMarker removes pending.json once its update has reached a terminal state.
+func clearMarker(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if err := os.Remove(markerPath(dir)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing the update marker: %w", err)
+	}
+	if err := syncDir(dir); err != nil {
+		return fmt.Errorf("flushing the removed update marker: %w", err)
+	}
+	return nil
+}

--- a/pkg/service/updater/marker.go
+++ b/pkg/service/updater/marker.go
@@ -78,8 +78,9 @@ const (
 type updateOutcome string
 
 const (
-	outcomeSucceeded  updateOutcome = "succeeded"
-	outcomeRolledBack updateOutcome = "rolledBack"
+	outcomeSucceeded        updateOutcome = "succeeded"
+	outcomeRolledBack       updateOutcome = "rolledBack"
+	outcomeRecoveryRequired updateOutcome = "recoveryRequired"
 	// outcomeRollbackBlocked means the binary was rolled back but the user
 	// database snapshot could not be restored, or the rollback could not be
 	// completed at all, and the new binary was left installed instead. A device

--- a/pkg/service/updater/marker_test.go
+++ b/pkg/service/updater/marker_test.go
@@ -1,0 +1,152 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarker_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	installed := time.Date(2026, 8, 18, 4, 30, 0, 0, time.UTC)
+
+	require.NoError(t, saveMarker(dir, &pendingMarker{
+		InstalledAt:        installed,
+		State:              markerInstalled,
+		Trigger:            triggerManual,
+		TargetPath:         filepath.Join("opt", "zaparoo"),
+		BackupPath:         filepath.Join("opt", ".zaparoo.zap-old-2.1.0"),
+		StagingDir:         filepath.Join("data", "updater", "staging", "2.2.0"),
+		PreviousVersion:    "2.1.0",
+		TargetVersion:      "2.2.0",
+		PlatformID:         "mister",
+		UserDBSnapshotPath: filepath.Join("data", "backups", "backup-x-update.db"),
+		PayloadBackups: []payloadBackup{
+			{TargetPath: filepath.Join("opt", "extra"), BackupPath: filepath.Join("opt", ".extra.old")},
+		},
+		ManifestGeneration: 42,
+		Attempts:           1,
+	}))
+
+	got, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, installed.Equal(got.InstalledAt))
+	assert.Equal(t, markerInstalled, got.State)
+	assert.Equal(t, triggerManual, got.Trigger)
+	assert.Equal(t, "2.1.0", got.PreviousVersion)
+	assert.Equal(t, "2.2.0", got.TargetVersion)
+	assert.Equal(t, "mister", got.PlatformID)
+	assert.Equal(t, int64(42), got.ManifestGeneration)
+	assert.Equal(t, 1, got.Attempts)
+	assert.Equal(t, currentMarkerVersion, got.MarkerVersion)
+	require.Len(t, got.PayloadBackups, 1)
+	assert.Equal(t, filepath.Join("opt", "extra"), got.PayloadBackups[0].TargetPath)
+}
+
+func TestLoadMarker_AbsentIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	m, err := loadMarker(filepath.Join(t.TempDir(), "updater"))
+	require.NoError(t, err)
+	assert.Nil(t, m)
+
+	m, err = loadMarker("")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+}
+
+func TestLoadMarker_QuarantinesUnparseable(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir), []byte("{not json"), stateFilePerm))
+
+	m, err := loadMarker(dir)
+	require.ErrorIs(t, err, errMarkerUnusable)
+	assert.Nil(t, m)
+
+	_, statErr := os.Stat(markerPath(dir))
+	assert.True(t, os.IsNotExist(statErr), "unparseable marker should have been moved aside")
+	quarantined, readErr := os.ReadFile(markerPath(dir) + markerBadSuffix)
+	require.NoError(t, readErr)
+	assert.Equal(t, "{not json", string(quarantined))
+}
+
+func TestLoadMarker_QuarantinesStateless(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir),
+		[]byte(`{"markerVersion":1,"targetVersion":"2.2.0"}`), stateFilePerm))
+
+	m, err := loadMarker(dir)
+	require.ErrorIs(t, err, errMarkerUnusable)
+	assert.Nil(t, m)
+	assert.FileExists(t, markerPath(dir)+markerBadSuffix)
+}
+
+// A marker from a newer build has to survive this one completely intact: that
+// build may be rolled back to, run again and need to find its own marker.
+func TestLoadMarker_LeavesNewerSchemaAlone(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	raw := []byte(`{"markerVersion":99,"state":"installed","targetVersion":"9.0.0"}`)
+	require.NoError(t, os.WriteFile(markerPath(dir), raw, stateFilePerm))
+
+	m, err := loadMarker(dir)
+	require.ErrorIs(t, err, errMarkerTooNew)
+	assert.Nil(t, m)
+
+	onDisk, readErr := os.ReadFile(markerPath(dir))
+	require.NoError(t, readErr)
+	assert.Equal(t, raw, onDisk)
+	assert.NoFileExists(t, markerPath(dir)+markerBadSuffix)
+
+	// Saving over it is refused for the same reason.
+	require.NoError(t, saveMarker(dir, &pendingMarker{State: markerInstalled, MarkerVersion: 99}))
+	onDisk, readErr = os.ReadFile(markerPath(dir))
+	require.NoError(t, readErr)
+	assert.Equal(t, raw, onDisk)
+}
+
+func TestClearMarker_ToleratesAbsence(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, clearMarker(dir))
+
+	require.NoError(t, saveMarker(dir, &pendingMarker{State: markerConfirming, TargetVersion: "2.2.0"}))
+	require.NoError(t, clearMarker(dir))
+	assert.NoFileExists(t, markerPath(dir))
+}

--- a/pkg/service/updater/marker_test.go
+++ b/pkg/service/updater/marker_test.go
@@ -150,3 +150,35 @@ func TestClearMarker_ToleratesAbsence(t *testing.T) {
 	require.NoError(t, clearMarker(dir))
 	assert.NoFileExists(t, markerPath(dir))
 }
+
+// Platforms with no data directory get an empty state dir. Nothing there can be
+// persisted, and none of it may fail: the update path just has no marker.
+func TestMarker_NoStateDirIsInert(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, markerPath(""))
+
+	m, err := loadMarker("")
+	require.NoError(t, err)
+	assert.Nil(t, m)
+
+	require.NoError(t, saveMarker("", &pendingMarker{State: markerInstalled}))
+	require.NoError(t, clearMarker(""))
+}
+
+// A marker from a newer schema is left for the build that wrote it, so saving
+// over one must be refused rather than silently downgrade its contents.
+func TestSaveMarker_RefusesToDowngradeANewerSchema(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, saveMarker(dir, &pendingMarker{
+		MarkerVersion: currentMarkerVersion + 1,
+		State:         markerInstalled,
+		TargetVersion: testTargetVersion,
+	}))
+	assert.NoFileExists(t, markerPath(dir))
+
+	require.NoError(t, saveMarker(dir, nil))
+	assert.NoFileExists(t, markerPath(dir))
+}

--- a/pkg/service/updater/rename_state_unix.go
+++ b/pkg/service/updater/rename_state_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"fmt"
+	"os"
+)
+
+func replaceStateFile(source, target string) error {
+	if err := os.Rename(source, target); err != nil {
+		return fmt.Errorf("replacing state file %q with %q: %w", target, source, err)
+	}
+	return nil
+}

--- a/pkg/service/updater/rename_state_windows.go
+++ b/pkg/service/updater/rename_state_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceStateFile(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return fmt.Errorf("encoding state source path: %w", err)
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return fmt.Errorf("encoding state target path: %w", err)
+	}
+	if err := windows.MoveFileEx(from, to,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
+		return fmt.Errorf("replacing state file %q with %q: %w", target, source, err)
+	}
+	return nil
+}

--- a/pkg/service/updater/rename_state_windows.go
+++ b/pkg/service/updater/rename_state_windows.go
@@ -6,24 +6,6 @@
 
 package updater
 
-import (
-	"fmt"
-
-	"golang.org/x/sys/windows"
-)
-
 func replaceStateFile(source, target string) error {
-	from, err := windows.UTF16PtrFromString(source)
-	if err != nil {
-		return fmt.Errorf("encoding state source path: %w", err)
-	}
-	to, err := windows.UTF16PtrFromString(target)
-	if err != nil {
-		return fmt.Errorf("encoding state target path: %w", err)
-	}
-	if err := windows.MoveFileEx(from, to,
-		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
-		return fmt.Errorf("replacing state file %q with %q: %w", target, source, err)
-	}
-	return nil
+	return replaceFile(source, target)
 }

--- a/pkg/service/updater/replace_unix.go
+++ b/pkg/service/updater/replace_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"fmt"
+	"os"
+)
+
+func replaceFile(source, target string) error {
+	if err := os.Rename(source, target); err != nil {
+		return fmt.Errorf("replacing %q with %q: %w", target, source, err)
+	}
+	return nil
+}

--- a/pkg/service/updater/replace_windows.go
+++ b/pkg/service/updater/replace_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func replaceFile(source, target string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return fmt.Errorf("encoding replacement source path: %w", err)
+	}
+	to, err := windows.UTF16PtrFromString(target)
+	if err != nil {
+		return fmt.Errorf("encoding replacement target path: %w", err)
+	}
+	if err := windows.MoveFileEx(from, to,
+		windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH); err != nil {
+		return fmt.Errorf("replacing %q with %q: %w", target, source, err)
+	}
+	return nil
+}

--- a/pkg/service/updater/report_test.go
+++ b/pkg/service/updater/report_test.go
@@ -21,6 +21,7 @@ package updater
 
 import (
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -32,6 +33,39 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func TestReportLastUpdate_ReportsUnusableMarkerOnce(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	dir := stateDirFor(dataDir)
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir), []byte("{"), stateFilePerm))
+	require.NoError(t, RunStartupWatchdog(t.Context(), dataDir, testTargetVersion))
+	assert.FileExists(t, markerPath(dir)+markerBadSuffix)
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("AddInboxMessage", mock.MatchedBy(func(msg *database.InboxMessage) bool {
+		return msg.Title == "Update needs manual recovery" &&
+			msg.Severity == inbox.SeverityError &&
+			msg.Category == inbox.CategoryUpdateResult
+	})).Return(&database.InboxMessage{
+		DBID:     1,
+		Title:    "Update needs manual recovery",
+		Category: inbox.CategoryUpdateResult,
+	}, nil).Once()
+
+	ns := make(chan models.Notification, 2)
+	inboxSvc := inbox.NewService(mockUserDB, ns)
+	ReportLastUpdate(dataDir, inboxSvc)
+	assert.Nil(t, peekUpdateResult(dir))
+
+	// The quarantined marker remains install-blocking, but its stable result
+	// identity prevents the same warning being posted on every boot.
+	require.NoError(t, RunStartupWatchdog(t.Context(), dataDir, testTargetVersion))
+	ReportLastUpdate(dataDir, inboxSvc)
+	mockUserDB.AssertExpectations(t)
+}
 
 func TestReportLastUpdate_DescribesRollbackDirection(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/updater/report_test.go
+++ b/pkg/service/updater/report_test.go
@@ -1,0 +1,98 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportLastUpdate_DescribesRollbackDirection(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	dir := stateDirFor(dataDir)
+	require.NoError(t, recordUpdateResult(dir, &updateResult{
+		At:          time.Date(2026, 8, 18, 5, 0, 0, 0, time.UTC),
+		Outcome:     outcomeRolledBack,
+		FromVersion: testPrevVersion,
+		ToVersion:   testTargetVersion,
+	}))
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("AddInboxMessage", mock.MatchedBy(func(msg *database.InboxMessage) bool {
+		return msg.Title == "Update rolled back" &&
+			msg.Body == "Version 2.2.0 did not start, so version 2.1.0 was restored. "+
+				"Your data was restored from the snapshot taken before the update." &&
+			msg.Category == inbox.CategoryUpdateResult
+	})).Return(&database.InboxMessage{
+		DBID:     1,
+		Title:    "Update rolled back",
+		Category: inbox.CategoryUpdateResult,
+	}, nil).Once()
+
+	ns := make(chan models.Notification, 1)
+	ReportLastUpdate(dataDir, inbox.NewService(mockUserDB, ns))
+
+	assert.Nil(t, peekUpdateResult(dir))
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestReportLastUpdate_RetriesAfterInboxFailure(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	dir := stateDirFor(dataDir)
+	require.NoError(t, recordUpdateResult(dir, &updateResult{
+		At:          time.Date(2026, 8, 18, 5, 0, 0, 0, time.UTC),
+		Outcome:     outcomeRollbackBlocked,
+		FromVersion: testPrevVersion,
+		ToVersion:   testTargetVersion,
+		Detail:      "snapshot missing",
+	}))
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("AddInboxMessage", mock.Anything).
+		Return((*database.InboxMessage)(nil), errors.New("database busy")).Once()
+	mockUserDB.On("AddInboxMessage", mock.Anything).
+		Return(&database.InboxMessage{
+			DBID:     1,
+			Title:    "Update could not be rolled back",
+			Category: inbox.CategoryUpdateResult,
+		}, nil).Once()
+
+	ns := make(chan models.Notification, 2)
+	inboxSvc := inbox.NewService(mockUserDB, ns)
+	ReportLastUpdate(dataDir, inboxSvc)
+	assert.NotNil(t, peekUpdateResult(dir), "failed inbox write must remain pending")
+
+	ReportLastUpdate(dataDir, inboxSvc)
+	assert.Nil(t, peekUpdateResult(dir), "successful retry must acknowledge the result")
+	mockUserDB.AssertExpectations(t)
+}

--- a/pkg/service/updater/report_test.go
+++ b/pkg/service/updater/report_test.go
@@ -130,3 +130,79 @@ func TestReportLastUpdate_RetriesAfterInboxFailure(t *testing.T) {
 	assert.Nil(t, peekUpdateResult(dir), "successful retry must acknowledge the result")
 	mockUserDB.AssertExpectations(t)
 }
+
+func TestReportLastUpdate_MessagePerOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		outcome  updateOutcome
+		title    string
+		body     string
+		severity int
+	}{
+		{
+			outcome:  outcomeSucceeded,
+			severity: inbox.SeverityInfo,
+			title:    "Update installed",
+			body:     "Updated from version 2.1.0 to version 2.2.0.",
+		},
+		{
+			outcome:  outcomeRollbackBlocked,
+			severity: inbox.SeverityError,
+			title:    "Update could not be rolled back",
+			body: "Version 2.2.0 did not start and version 2.1.0 could not be restored " +
+				"automatically. The snapshot taken before the update is still in your " +
+				"backups and can be restored by hand.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.outcome), func(t *testing.T) {
+			t.Parallel()
+
+			dataDir := t.TempDir()
+			dir := stateDirFor(dataDir)
+			require.NoError(t, recordUpdateResult(dir, &updateResult{
+				At:          time.Date(2026, 8, 18, 5, 0, 0, 0, time.UTC),
+				Outcome:     tt.outcome,
+				FromVersion: testPrevVersion,
+				ToVersion:   testTargetVersion,
+				Detail:      "disk was full",
+			}))
+
+			mockUserDB := helpers.NewMockUserDBI()
+			mockUserDB.On("AddInboxMessage", mock.MatchedBy(func(msg *database.InboxMessage) bool {
+				return msg.Title == tt.title &&
+					msg.Severity == tt.severity &&
+					// A detail from the failure is appended so support has the
+					// reason, not just the outcome.
+					msg.Body == tt.body+"\n\ndisk was full" &&
+					msg.Category == inbox.CategoryUpdateResult
+			})).Return(&database.InboxMessage{
+				DBID:     1,
+				Title:    tt.title,
+				Category: inbox.CategoryUpdateResult,
+			}, nil).Once()
+
+			ns := make(chan models.Notification, 1)
+			ReportLastUpdate(dataDir, inbox.NewService(mockUserDB, ns))
+
+			assert.Nil(t, peekUpdateResult(dir), "a delivered result must not be shown again")
+			mockUserDB.AssertExpectations(t)
+		})
+	}
+}
+
+// Nothing to report and nowhere to report to are both ordinary: most boots have
+// no update result, and some platforms start without an inbox.
+func TestReportLastUpdate_QuietWithNothingToSay(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	ReportLastUpdate(dataDir, nil)
+
+	mockUserDB := helpers.NewMockUserDBI()
+	ns := make(chan models.Notification, 1)
+	ReportLastUpdate(dataDir, inbox.NewService(mockUserDB, ns))
+	mockUserDB.AssertNotCalled(t, "AddInboxMessage", mock.Anything)
+}

--- a/pkg/service/updater/source.go
+++ b/pkg/service/updater/source.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	selfupdate "github.com/creativeprojects/go-selfupdate"
 	"github.com/rs/zerolog/log"
@@ -65,15 +66,15 @@ var ErrGenerationRollback = errors.New("update manifest is older than one alread
 // unverified document, and hands back only the releases this device may
 // install, each reduced to the single archive that belongs to it.
 type verifiedSource struct {
-	transport *http.Transport
-	key       *keyRef
-	// verify is otameta.Verify in production; tests replace it so they can sign
-	// with a generated key pair.
-	verify     func(data, sig []byte) (*otameta.Manifest, error)
-	baseURL    string
-	stateDir   string
-	platformID string
-	goarch     string
+	transport    *http.Transport
+	key          *keyRef
+	verify       func(data, sig []byte) (*otameta.Manifest, error)
+	manifest     *otameta.Manifest
+	baseURL      string
+	stateDir     string
+	platformID   string
+	goarch       string
+	manifestBase string
 }
 
 // cacheValidators are the conditional-request tokens for a copy already on
@@ -115,8 +116,53 @@ func (s *verifiedSource) ListReleases(
 	// The checksum validator runs later in the same update and has to use the
 	// key the publisher actually signed with, not a build-time default.
 	s.key.set(manifest.KeyID)
+	s.manifest = manifest
+	s.manifestBase = base
 
 	return s.releasesFor(manifest, base), nil
+}
+
+// releaseForVersion returns the signed manifest release chosen by
+// go-selfupdate's channel/latest-version selection. Asset URLs are resolved the
+// same way releasesFor resolves them for go-selfupdate.
+func (s *verifiedSource) releaseForVersion(version string) (*otameta.Release, error) {
+	if s.manifest == nil {
+		return nil, errors.New("update manifest has not been loaded")
+	}
+	want, err := semver.NewVersion(version)
+	if err != nil {
+		return nil, fmt.Errorf("reading selected release version %q: %w", version, err)
+	}
+
+	for _, rel := range s.manifest.Releases {
+		if rel == nil {
+			continue
+		}
+		candidate, parseErr := semver.NewVersion(otameta.VersionFromTag(rel.TagName))
+		if parseErr != nil || !candidate.Equal(want) {
+			continue
+		}
+
+		resolved := *rel
+		resolved.Assets = make([]*otameta.Asset, 0, len(rel.Assets))
+		for _, asset := range rel.Assets {
+			if asset == nil {
+				continue
+			}
+			copyAsset := *asset
+			copyAsset.URL = resolveAssetURL(asset.URL, s.manifestBase)
+			resolved.Assets = append(resolved.Assets, &copyAsset)
+		}
+		return &resolved, nil
+	}
+	return nil, fmt.Errorf("selected release %s is missing from the verified manifest", version)
+}
+
+func (s *verifiedSource) manifestGeneration() int64 {
+	if s.manifest == nil {
+		return 0
+	}
+	return s.manifest.Generation
 }
 
 // fetchManifest retrieves the manifest and its detached signature, verifies
@@ -195,7 +241,7 @@ func (s *verifiedSource) persist(st *updaterState, generation int64, res *httpRe
 
 	st.ManifestGeneration = generation
 	st.ManifestSeenAt = time.Now().UTC()
-	if err := saveState(s.stateDir, *st); err != nil {
+	if err := saveState(s.stateDir, st); err != nil {
 		log.Warn().Err(err).Msg("could not record update manifest generation")
 	}
 }

--- a/pkg/service/updater/source.go
+++ b/pkg/service/updater/source.go
@@ -144,15 +144,7 @@ func (s *verifiedSource) releaseForVersion(version string) (*otameta.Release, er
 		}
 
 		resolved := *rel
-		resolved.Assets = make([]*otameta.Asset, 0, len(rel.Assets))
-		for _, asset := range rel.Assets {
-			if asset == nil {
-				continue
-			}
-			copyAsset := *asset
-			copyAsset.URL = resolveAssetURL(asset.URL, s.manifestBase)
-			resolved.Assets = append(resolved.Assets, &copyAsset)
-		}
+		resolved.Assets = resolvedAssetCopies(rel.Assets, s.manifestBase, nil)
 		return &resolved, nil
 	}
 	return nil, fmt.Errorf("selected release %s is missing from the verified manifest", version)
@@ -180,7 +172,11 @@ func (s *verifiedSource) fetchManifest(ctx context.Context, base string) (*otame
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
-	st := loadState(s.stateDir)
+	st, stateErr := loadStateWithError(s.stateDir)
+	if stateErr != nil {
+		log.Warn().Err(stateErr).Msg("could not load updater state, treating as unseen without overwriting it")
+		st = updaterState{}
+	}
 	cached := loadCachedManifest(s.stateDir)
 
 	// Only conditional when there are bytes on disk for a 304 to refer back to.
@@ -215,7 +211,9 @@ func (s *verifiedSource) fetchManifest(ctx context.Context, base string) (*otame
 			ErrGenerationRollback, manifest.Generation, st.ManifestGeneration)
 	}
 
-	s.persist(&st, manifest.Generation, res)
+	if stateErr == nil {
+		s.persist(&st, manifest.Generation, res)
+	}
 	return manifest, nil
 }
 
@@ -246,6 +244,23 @@ func (s *verifiedSource) persist(st *updaterState, generation int64, res *httpRe
 	}
 }
 
+func resolvedAssetCopies(
+	assets []*otameta.Asset,
+	base string,
+	include func(*otameta.Asset) bool,
+) []*otameta.Asset {
+	resolved := make([]*otameta.Asset, 0, len(assets))
+	for _, asset := range assets {
+		if asset == nil || (include != nil && !include(asset)) {
+			continue
+		}
+		copyAsset := *asset
+		copyAsset.URL = resolveAssetURL(asset.URL, base)
+		resolved = append(resolved, &copyAsset)
+	}
+	return resolved
+}
+
 // releasesFor reduces the manifest to what go-selfupdate should consider: the
 // releases that publish an archive for this device, each carrying that one
 // archive plus the metadata assets the validation chain needs.
@@ -270,22 +285,19 @@ func (s *verifiedSource) releasesFor(manifest *otameta.Manifest, base string) []
 			continue
 		}
 
-		assets := make([]*selfupdate.HttpAsset, 0, len(rel.Assets))
-		for _, a := range rel.Assets {
-			if a == nil {
-				continue
-			}
+		resolvedAssets := resolvedAssetCopies(rel.Assets, base, func(asset *otameta.Asset) bool {
 			// Everything that is not this device's archive is metadata: the
 			// checksums file and its signature. Other platforms' archives are
 			// dropped so nothing downstream can pick one by accident.
-			if a != archive && isReleaseArchive(a.Name) {
-				continue
-			}
+			return asset == archive || !isReleaseArchive(asset.Name)
+		})
+		assets := make([]*selfupdate.HttpAsset, 0, len(resolvedAssets))
+		for _, asset := range resolvedAssets {
 			assets = append(assets, &selfupdate.HttpAsset{
-				ID:   a.ID,
-				Name: a.Name,
-				Size: int(a.Size),
-				URL:  resolveAssetURL(a.URL, base),
+				ID:   asset.ID,
+				Name: asset.Name,
+				Size: int(asset.Size),
+				URL:  asset.URL,
 			})
 		}
 

--- a/pkg/service/updater/source_test.go
+++ b/pkg/service/updater/source_test.go
@@ -527,6 +527,23 @@ func TestVerifiedSource_SkipsAmbiguousRelease(t *testing.T) {
 	assert.Equal(t, "v2.15.1", releases[0].GetTagName())
 }
 
+func TestResolvedAssetCopies(t *testing.T) {
+	t.Parallel()
+
+	archive := &otameta.Asset{ID: 1, Name: "zaparoo-linux_amd64-2.2.0.tar.gz", URL: "assets/core.tar.gz"}
+	metadata := &otameta.Asset{ID: 2, Name: "checksums.txt", URL: "assets/checksums.txt"}
+	resolved := resolvedAssetCopies(
+		[]*otameta.Asset{nil, archive, metadata},
+		"https://updates.example/releases",
+		func(asset *otameta.Asset) bool { return asset == archive },
+	)
+
+	require.Len(t, resolved, 1)
+	assert.NotSame(t, archive, resolved[0])
+	assert.Equal(t, "https://updates.example/releases/assets/core.tar.gz", resolved[0].URL)
+	assert.Equal(t, "assets/core.tar.gz", archive.URL, "resolving must not mutate signed manifest assets")
+}
+
 func TestIsReleaseArchive(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/source_test.go
+++ b/pkg/service/updater/source_test.go
@@ -573,3 +573,109 @@ func assetNames(rel selfupdate.SourceRelease) []string {
 	}
 	return names
 }
+
+func TestVerifiedSource_ReleaseForVersionNeedsALoadedManifest(t *testing.T) {
+	t.Parallel()
+
+	src := newManifestServer(t, twoReleaseManifest(412)).source(t.TempDir(), "linux", "amd64")
+
+	_, err := src.releaseForVersion("2.16.1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has not been loaded")
+	assert.Equal(t, int64(0), src.manifestGeneration())
+}
+
+// TestVerifiedSource_ReleaseForVersion covers the second lookup an install does:
+// go-selfupdate picked a version, and the install has to re-find that release in
+// the manifest this process verified rather than trusting the detection result.
+func TestVerifiedSource_ReleaseForVersion(t *testing.T) {
+	t.Parallel()
+
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	src := ms.source(t.TempDir(), "linux", "amd64")
+	_, err := src.ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+	assert.Equal(t, int64(412), src.manifestGeneration())
+
+	rel, err := src.releaseForVersion("2.16.1")
+	require.NoError(t, err)
+	assert.Equal(t, "v2.16.1", rel.TagName)
+
+	// Unlike ListReleases this keeps every asset: the caller selects by name and
+	// still needs the checksum files alongside its own archive.
+	names := make([]string, 0, len(rel.Assets))
+	for _, asset := range rel.Assets {
+		names = append(names, asset.Name)
+	}
+	assert.Equal(t, []string{
+		"zaparoo-linux_amd64-2.16.1.tar.gz",
+		"zaparoo-zapos_arm64-2.16.1.tar.gz",
+		"checksums.txt",
+		"checksums.txt.sig",
+	}, names)
+
+	// Manifest-relative URLs resolve against the manifest, and the cached
+	// manifest keeps its original values so a second lookup resolves the same.
+	assert.Equal(t, ms.URL+testRepoPath+"/checksums.txt", rel.Assets[2].URL)
+	assert.Equal(t, "checksums.txt", src.manifest.Releases[0].Assets[2].URL,
+		"resolving asset URLs must not rewrite the verified manifest")
+
+	again, err := src.releaseForVersion("2.16.1")
+	require.NoError(t, err)
+	assert.Equal(t, ms.URL+testRepoPath+"/checksums.txt", again.Assets[2].URL)
+}
+
+// A version tag that is not in the manifest must fail the install rather than
+// fall through to some other release.
+func TestVerifiedSource_ReleaseForVersionRejectsUnknownVersions(t *testing.T) {
+	t.Parallel()
+
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	src := ms.source(t.TempDir(), "linux", "amd64")
+	_, err := src.ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+
+	for name, version := range map[string]string{
+		"absent from the manifest": "2.99.0",
+		"not a version at all":     "not-a-version",
+		"empty":                    "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := src.releaseForVersion(version)
+			require.Error(t, err)
+		})
+	}
+}
+
+// A data directory that cannot be written is ordinary on read-only install
+// media. Bookkeeping the check could not persist must not fail the check.
+func TestVerifiedSource_ReadOnlyStateDirStillChecks(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+
+	ms := newManifestServer(t, twoReleaseManifest(412))
+	dir := t.TempDir()
+	//nolint:gosec // an unwritable-but-readable directory is the failure under test
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, stateDirPerm) })
+	src := ms.source(dir, "linux", "amd64")
+
+	releases, err := src.ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+	require.Len(t, releases, 2)
+
+	// Nothing was stored, so the next check has to fetch the manifest in full
+	// rather than send validators it cannot pair with a cached body.
+	releases, err = src.ListReleases(t.Context(), testRepo())
+	require.NoError(t, err)
+	require.Len(t, releases, 2)
+	assert.Equal(t, int64(2), ms.manifestGets.Load())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
@@ -54,23 +53,23 @@ var stateMu syncutil.Mutex
 // would roll backwards whenever an old backup was restored, which is a
 // self-inflicted downgrade window.
 type updaterState struct {
-	// ManifestSeenAt records when the generation below was accepted. It is for
-	// operators reading the file; nothing in the verification path reads a clock.
-	ManifestSeenAt time.Time `json:"manifestSeenAt"`
-	// ManifestETag and ManifestLastModified let the next check ask the CDN for
-	// the manifest only if it changed. The cached bytes are re-verified on every
-	// use, so a tampered cache is caught rather than trusted.
-	//
-	// Both are kept because which one fires depends on the origin. Bunny does
-	// not generate ETags; it only forwards one the origin sends, and Bunny
-	// Storage sends none, so in production Last-Modified is the validator that
-	// actually works. ETag is still honoured when present because it is the
-	// stronger of the two and servers that offer both prefer it.
-	ManifestETag         string `json:"manifestETag"`
-	ManifestLastModified string `json:"manifestLastModified"`
-	// ManifestGeneration is the highest generation this device has accepted.
-	ManifestGeneration int64 `json:"manifestGeneration"`
-	StateVersion       int   `json:"stateVersion"`
+	ManifestSeenAt       time.Time     `json:"manifestSeenAt"`
+	LastResult           *updateResult `json:"lastResult,omitempty"`
+	ManifestETag         string        `json:"manifestETag"`
+	ManifestLastModified string        `json:"manifestLastModified"`
+	ManifestGeneration   int64         `json:"manifestGeneration"`
+	StateVersion         int           `json:"stateVersion"`
+}
+
+// updateResult records the terminal outcome of an update for the boot that
+// follows it.
+type updateResult struct {
+	At          time.Time     `json:"at"`
+	Outcome     updateOutcome `json:"outcome"`
+	FromVersion string        `json:"fromVersion"`
+	ToVersion   string        `json:"toVersion"`
+	Detail      string        `json:"detail,omitempty"`
+	Reported    bool          `json:"reported"`
 }
 
 // stateDirFor returns the updater's private directory inside the data dir.
@@ -118,7 +117,7 @@ func loadState(dir string) updaterState {
 }
 
 // saveState replaces state.json atomically.
-func saveState(dir string, st updaterState) error {
+func saveState(dir string, st *updaterState) error {
 	if dir == "" {
 		return nil
 	}
@@ -170,9 +169,15 @@ func saveCachedManifest(dir string, data []byte) error {
 
 // writeFileAtomic writes name inside dir via a temporary file and a rename, so
 // a reader either sees the previous contents or the new ones and never a
-// partial write. The directory is synced afterwards so the rename survives a
-// power cut, which these devices take regularly.
+// partial write. Success means both file contents and directory entry reached a
+// durability barrier; callers may delete rollback prerequisites afterwards.
 func writeFileAtomic(dir, name string, data []byte) error {
+	return writeFileAtomicWithSync(dir, name, data, syncDir)
+}
+
+func writeFileAtomicWithSync(
+	dir, name string, data []byte, syncDirectory func(string) error,
+) error {
 	if err := os.MkdirAll(dir, stateDirPerm); err != nil {
 		return fmt.Errorf("creating updater state directory: %w", err)
 	}
@@ -206,39 +211,80 @@ func writeFileAtomic(dir, name string, data []byte) error {
 		return fmt.Errorf("closing updater state file: %w", err)
 	}
 
-	if err := os.Rename(tmpName, filepath.Join(dir, name)); err != nil {
+	if err := replaceStateFile(tmpName, filepath.Join(dir, name)); err != nil {
 		return fmt.Errorf("replacing updater state file: %w", err)
 	}
-
-	// The rename has already happened, so the write succeeded whatever the
-	// directory sync does. Reporting a sync failure as a write failure would be
-	// actively harmful: callers respond by discarding what they just stored, so
-	// a filesystem that cannot flush a directory handle would permanently throw
-	// away the cache validators and the generation watermark. Not all of them
-	// can — vfat and exFAT are the ones these devices actually run on — and
-	// losing durability across a power cut is the smaller loss.
-	if err := syncDir(dir); err != nil {
-		log.Warn().Err(err).Str("file", name).
-			Msg("updater state was written but the directory could not be flushed")
+	if err := syncDirectory(dir); err != nil {
+		return fmt.Errorf("flushing updater state file %q: %w", name, err)
 	}
 	return nil
 }
 
-func syncDir(dir string) error {
-	handle, err := os.Open(dir) //nolint:gosec // path is derived from the platform data dir
-	if err != nil {
-		return fmt.Errorf("opening updater state directory for sync: %w", err)
+// recordUpdateResult stores how an update finished so the boot after it can say
+// so. Terminal cleanup keeps its marker until this succeeds, allowing a later
+// boot to retry result persistence without repeating rollback.
+//
+// Callers already holding markerMu take it before stateMu; nothing takes them
+// the other way round.
+func recordUpdateResult(dir string, res *updateResult) error {
+	if res == nil {
+		return nil
 	}
-	syncErr := handle.Sync()
-	closeErr := handle.Close()
 
-	// Windows cannot flush a directory handle through os.File.Sync, so there is
-	// nothing to report there.
-	if syncErr != nil && (runtime.GOOS != "windows" || !errors.Is(syncErr, os.ErrPermission)) {
-		return fmt.Errorf("syncing updater state directory: %w", syncErr)
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st := loadState(dir)
+	if sameUpdateResult(st.LastResult, res) {
+		return nil
 	}
-	if closeErr != nil {
-		return fmt.Errorf("closing updater state directory: %w", closeErr)
+	copyResult := *res
+	copyResult.Reported = false
+	st.LastResult = &copyResult
+	if err := saveState(dir, &st); err != nil {
+		return fmt.Errorf("recording the update result for the next boot: %w", err)
 	}
 	return nil
+}
+
+// peekUpdateResult returns an update result that has not been shown yet without
+// acknowledging it. Delivery acknowledges only after the inbox write succeeds.
+func peekUpdateResult(dir string) *updateResult {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st := loadState(dir)
+	if st.LastResult == nil || st.LastResult.Reported {
+		return nil
+	}
+	res := *st.LastResult
+	return &res
+}
+
+func markUpdateResultReported(dir string, res *updateResult) error {
+	if res == nil {
+		return nil
+	}
+
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st := loadState(dir)
+	if st.LastResult == nil || st.LastResult.Reported || !sameUpdateResult(st.LastResult, res) {
+		return nil
+	}
+	st.LastResult.Reported = true
+	if err := saveState(dir, &st); err != nil {
+		return fmt.Errorf("marking the update result as reported: %w", err)
+	}
+	return nil
+}
+
+func sameUpdateResult(a, b *updateResult) bool {
+	return a != nil && b != nil &&
+		a.At.Equal(b.At) &&
+		a.Outcome == b.Outcome &&
+		a.FromVersion == b.FromVersion &&
+		a.ToVersion == b.ToVersion &&
+		a.Detail == b.Detail
 }

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -80,28 +80,35 @@ func stateDirFor(dataDir string) string {
 	return filepath.Join(dataDir, "updater")
 }
 
-// loadState reads state.json. A missing, unreadable or corrupt file is not an
-// error: it yields a zero state, which accepts any generation. Failing closed
-// here would mean one bad write permanently stops a device updating, which is
-// a worse outcome than the replay the watermark exists to prevent.
+// loadState reads state.json for non-persisting callers. A missing, unreadable
+// or corrupt file yields a zero state so one bad bookkeeping file does not stop
+// update checks. Read-modify-write callers must use loadStateWithError instead.
 func loadState(dir string) updaterState {
-	if dir == "" {
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not load updater state, treating as unseen")
 		return updaterState{}
+	}
+	return st
+}
+
+func loadStateWithError(dir string) (updaterState, error) {
+	if dir == "" {
+		return updaterState{}, nil
 	}
 
 	//nolint:gosec // path is derived from the platform data dir
 	data, err := os.ReadFile(filepath.Join(dir, stateFileName))
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			log.Warn().Err(err).Msg("could not read updater state, treating as unseen")
+		if errors.Is(err, os.ErrNotExist) {
+			return updaterState{}, nil
 		}
-		return updaterState{}
+		return updaterState{}, fmt.Errorf("reading updater state: %w", err)
 	}
 
 	var st updaterState
 	if err := json.Unmarshal(data, &st); err != nil {
-		log.Warn().Err(err).Msg("updater state is corrupt, treating as unseen")
-		return updaterState{}
+		return updaterState{}, fmt.Errorf("decoding updater state: %w", err)
 	}
 
 	// A newer build may have written fields this one does not know about. The
@@ -113,7 +120,7 @@ func loadState(dir string) updaterState {
 			Int("understood", currentStateVersion).
 			Msg("updater state was written by a newer version, not updating it")
 	}
-	return st
+	return st, nil
 }
 
 // saveState replaces state.json atomically.
@@ -234,7 +241,10 @@ func recordUpdateResult(dir string, res *updateResult) error {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
-	st := loadState(dir)
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		return fmt.Errorf("loading updater state before recording result: %w", err)
+	}
 	if sameUpdateResult(st.LastResult, res) {
 		return nil
 	}
@@ -269,7 +279,10 @@ func markUpdateResultReported(dir string, res *updateResult) error {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
-	st := loadState(dir)
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		return fmt.Errorf("loading updater state before marking result reported: %w", err)
+	}
 	if st.LastResult == nil || st.LastResult.Reported || !sameUpdateResult(st.LastResult, res) {
 		return nil
 	}

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -20,6 +20,7 @@
 package updater
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +44,7 @@ func TestState_RoundTrip(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "updater")
 	seen := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
 
-	require.NoError(t, saveState(dir, updaterState{
+	require.NoError(t, saveState(dir, &updaterState{
 		ManifestGeneration:   412,
 		ManifestETag:         `"abc123"`,
 		ManifestLastModified: "Mon, 17 Aug 2026 01:26:54 GMT",
@@ -92,7 +93,7 @@ func TestState_NewerVersionIsReadButNotOverwritten(t *testing.T) {
 	assert.Equal(t, int64(500), got.ManifestGeneration)
 	assert.Equal(t, 99, got.StateVersion)
 
-	require.NoError(t, saveState(dir, got))
+	require.NoError(t, saveState(dir, &got))
 
 	after, err := os.ReadFile(filepath.Join(dir, stateFileName)) //nolint:gosec // test temp dir
 	require.NoError(t, err)
@@ -102,7 +103,7 @@ func TestState_NewerVersionIsReadButNotOverwritten(t *testing.T) {
 func TestSaveState_NoDir(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, saveState("", updaterState{ManifestGeneration: 1}))
+	require.NoError(t, saveState("", &updaterState{ManifestGeneration: 1}))
 }
 
 func TestCachedManifest_RoundTrip(t *testing.T) {
@@ -155,6 +156,21 @@ func TestWriteFileAtomic_ReplacesAndLeavesNoTemps(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
 	assert.Equal(t, "f", entries[0].Name())
+}
+
+func TestWriteFileAtomic_ReportsDirectorySyncFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	errSync := errors.New("directory sync failed")
+	err := writeFileAtomicWithSync(dir, markerFileName, []byte("{}"), func(string) error {
+		return errSync
+	})
+	require.ErrorIs(t, err, errSync)
+
+	// Rename may already be visible, but callers must retain rollback files
+	// because durability across reboot was not established.
+	assert.FileExists(t, filepath.Join(dir, markerFileName))
 }
 
 func TestWriteFileAtomic_FilePermissions(t *testing.T) {

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -225,3 +225,64 @@ func TestWriteFileAtomic_FilePermissions(t *testing.T) {
 	}
 	assert.Equal(t, os.FileMode(stateFilePerm), info.Mode().Perm())
 }
+
+// Delivery peeks a result, writes it to the inbox, then acknowledges it. If a
+// newer outcome is recorded in between, the acknowledgement must not swallow it.
+func TestMarkUpdateResultReported_OnlyAcknowledgesTheResultItWasGiven(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rolledBack := &updateResult{
+		At:          time.Date(2026, 8, 18, 4, 30, 0, 0, time.UTC),
+		Outcome:     outcomeRolledBack,
+		FromVersion: "2.1.0",
+		ToVersion:   "2.2.0",
+	}
+	require.NoError(t, recordUpdateResult(dir, rolledBack))
+	require.Equal(t, rolledBack.Outcome, peekUpdateResult(dir).Outcome)
+
+	succeeded := &updateResult{
+		At:          time.Date(2026, 8, 18, 5, 0, 0, 0, time.UTC),
+		Outcome:     outcomeSucceeded,
+		FromVersion: "2.1.0",
+		ToVersion:   "2.3.0",
+	}
+	require.NoError(t, recordUpdateResult(dir, succeeded))
+	require.NoError(t, markUpdateResultReported(dir, rolledBack))
+
+	pending := peekUpdateResult(dir)
+	require.NotNil(t, pending, "the newer result must still be waiting to be shown")
+	assert.Equal(t, outcomeSucceeded, pending.Outcome)
+	assert.Equal(t, "2.3.0", pending.ToVersion)
+}
+
+// Recording the same outcome again — the watchdog re-finalizing after an
+// interrupted boot — must not resurrect a result the user has already seen.
+func TestRecordUpdateResult_RepeatDoesNotUnreportADeliveredResult(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	res := &updateResult{
+		At:          time.Date(2026, 8, 18, 4, 30, 0, 0, time.UTC),
+		Outcome:     outcomeSucceeded,
+		FromVersion: "2.1.0",
+		ToVersion:   "2.2.0",
+	}
+	require.NoError(t, recordUpdateResult(dir, res))
+	require.NoError(t, markUpdateResultReported(dir, res))
+	require.Nil(t, peekUpdateResult(dir))
+
+	require.NoError(t, recordUpdateResult(dir, res))
+	assert.Nil(t, peekUpdateResult(dir))
+}
+
+func TestUpdateResult_NilIsNotRecorded(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, recordUpdateResult(dir, nil))
+	require.NoError(t, markUpdateResultReported(dir, nil))
+
+	assert.Nil(t, peekUpdateResult(dir))
+	assert.NoFileExists(t, filepath.Join(dir, stateFileName))
+}

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -100,6 +100,42 @@ func TestState_NewerVersionIsReadButNotOverwritten(t *testing.T) {
 	assert.Equal(t, future, after)
 }
 
+func TestRecordUpdateResult_DoesNotOverwriteCorruptState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateFileName)
+	corrupt := []byte("{not json")
+	require.NoError(t, os.WriteFile(path, corrupt, stateFilePerm))
+
+	err := recordUpdateResult(dir, &updateResult{
+		At:      time.Now().UTC(),
+		Outcome: outcomeSucceeded,
+	})
+	require.Error(t, err)
+	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned path
+	require.NoError(t, readErr)
+	assert.Equal(t, corrupt, after)
+}
+
+func TestMarkUpdateResultReported_DoesNotOverwriteCorruptState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, stateFileName)
+	corrupt := []byte("{not json")
+	require.NoError(t, os.WriteFile(path, corrupt, stateFilePerm))
+
+	err := markUpdateResultReported(dir, &updateResult{
+		At:      time.Now().UTC(),
+		Outcome: outcomeSucceeded,
+	})
+	require.Error(t, err)
+	after, readErr := os.ReadFile(path) //nolint:gosec // test-owned path
+	require.NoError(t, readErr)
+	assert.Equal(t, corrupt, after)
+}
+
 func TestSaveState_NoDir(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/syncdir_linux.go
+++ b/pkg/service/updater/syncdir_linux.go
@@ -15,8 +15,30 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type directorySyncHandle interface {
+	Sync() error
+	Close() error
+	Fd() uintptr
+}
+
+type linuxDirectorySyncOps struct {
+	open   func(string) (directorySyncHandle, error)
+	syncfs func(int) error
+}
+
+var defaultLinuxDirectorySyncOps = linuxDirectorySyncOps{
+	open: func(path string) (directorySyncHandle, error) {
+		return os.Open(path) //nolint:gosec // callers pass updater-owned or executable parent directories
+	},
+	syncfs: unix.Syncfs,
+}
+
 func syncDir(dir string) error {
-	handle, err := os.Open(dir) //nolint:gosec // callers pass updater-owned or executable parent directories
+	return syncDirWithOps(dir, defaultLinuxDirectorySyncOps)
+}
+
+func syncDirWithOps(dir string, ops linuxDirectorySyncOps) error {
+	handle, err := ops.open(dir)
 	if err != nil {
 		return fmt.Errorf("opening directory for sync: %w", err)
 	}
@@ -25,7 +47,7 @@ func syncDir(dir string) error {
 	if syncErr != nil && directorySyncUnsupported(syncErr) {
 		// vfat/exFAT may reject fsync on a directory handle. syncfs provides the
 		// filesystem-wide durability barrier needed before destructive cleanup.
-		syncErr = unix.Syncfs(int(handle.Fd()))
+		syncErr = ops.syncfs(int(handle.Fd()))
 	}
 	closeErr := handle.Close()
 	if syncErr != nil {

--- a/pkg/service/updater/syncdir_linux.go
+++ b/pkg/service/updater/syncdir_linux.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func syncDir(dir string) error {
+	handle, err := os.Open(dir) //nolint:gosec // callers pass updater-owned or executable parent directories
+	if err != nil {
+		return fmt.Errorf("opening directory for sync: %w", err)
+	}
+
+	syncErr := handle.Sync()
+	if syncErr != nil && directorySyncUnsupported(syncErr) {
+		// vfat/exFAT may reject fsync on a directory handle. syncfs provides the
+		// filesystem-wide durability barrier needed before destructive cleanup.
+		syncErr = unix.Syncfs(int(handle.Fd()))
+	}
+	closeErr := handle.Close()
+	if syncErr != nil {
+		return fmt.Errorf("syncing directory: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing synced directory: %w", closeErr)
+	}
+	return nil
+}
+
+func directorySyncUnsupported(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.EPERM) ||
+		errors.Is(err, syscall.EACCES) ||
+		errors.Is(err, syscall.EBADF) ||
+		errors.Is(err, syscall.ENOTSUP)
+}

--- a/pkg/service/updater/syncdir_linux_test.go
+++ b/pkg/service/updater/syncdir_linux_test.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeDirectorySyncHandle struct {
+	syncErr    error
+	closeErr   error
+	fd         uintptr
+	syncCalls  int
+	closeCalls int
+}
+
+func (h *fakeDirectorySyncHandle) Sync() error {
+	h.syncCalls++
+	return h.syncErr
+}
+
+func (h *fakeDirectorySyncHandle) Close() error {
+	h.closeCalls++
+	return h.closeErr
+}
+
+func (h *fakeDirectorySyncHandle) Fd() uintptr {
+	return h.fd
+}
+
+func TestSyncDirWithOps_SyncsAndClosesDirectory(t *testing.T) {
+	t.Parallel()
+
+	handle := &fakeDirectorySyncHandle{fd: 42}
+	syncfsCalls := 0
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open: func(path string) (directorySyncHandle, error) {
+			assert.Equal(t, "update-dir", path)
+			return handle, nil
+		},
+		syncfs: func(int) error {
+			syncfsCalls++
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, handle.syncCalls)
+	assert.Equal(t, 1, handle.closeCalls)
+	assert.Zero(t, syncfsCalls)
+}
+
+func TestDirectorySyncUnsupported(t *testing.T) {
+	t.Parallel()
+
+	for _, candidate := range []error{
+		syscall.EINVAL,
+		syscall.EPERM,
+		syscall.EACCES,
+		syscall.EBADF,
+		syscall.ENOTSUP,
+	} {
+		t.Run(candidate.Error(), func(t *testing.T) {
+			t.Parallel()
+			assert.True(t, directorySyncUnsupported(candidate))
+		})
+	}
+	assert.False(t, directorySyncUnsupported(syscall.EIO))
+}
+
+func TestSyncDirWithOps_PropagatesSyncfsFailure(t *testing.T) {
+	t.Parallel()
+
+	syncfsErr := errors.New("syncfs failed")
+	handle := &fakeDirectorySyncHandle{syncErr: syscall.ENOTSUP, fd: 42}
+	gotFD := -1
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open: func(string) (directorySyncHandle, error) { return handle, nil },
+		syncfs: func(fd int) error {
+			gotFD = fd
+			return syncfsErr
+		},
+	})
+
+	require.ErrorIs(t, err, syncfsErr)
+	assert.Equal(t, 42, gotFD)
+	assert.Equal(t, 1, handle.closeCalls)
+}

--- a/pkg/service/updater/syncdir_linux_test.go
+++ b/pkg/service/updater/syncdir_linux_test.go
@@ -95,3 +95,76 @@ func TestSyncDirWithOps_PropagatesSyncfsFailure(t *testing.T) {
 	assert.Equal(t, 42, gotFD)
 	assert.Equal(t, 1, handle.closeCalls)
 }
+
+func TestSyncDirWithOps_ReportsOpenFailure(t *testing.T) {
+	t.Parallel()
+
+	openErr := errors.New("no such directory")
+	syncfsCalls := 0
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open: func(string) (directorySyncHandle, error) { return nil, openErr },
+		syncfs: func(int) error {
+			syncfsCalls++
+			return nil
+		},
+	})
+
+	require.ErrorIs(t, err, openErr)
+	assert.Zero(t, syncfsCalls)
+}
+
+// A close failure after a successful sync still has to surface: on some
+// filesystems it is where a deferred write error is reported.
+func TestSyncDirWithOps_ReportsCloseFailure(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	handle := &fakeDirectorySyncHandle{closeErr: closeErr, fd: 42}
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open:   func(string) (directorySyncHandle, error) { return handle, nil },
+		syncfs: func(int) error { return nil },
+	})
+
+	require.ErrorIs(t, err, closeErr)
+	assert.Equal(t, 1, handle.syncCalls)
+}
+
+// syncfs recovering an unsupported directory fsync is the whole point of the
+// fallback: vfat and exFAT reject the fsync but the barrier still has to happen.
+func TestSyncDirWithOps_SyncfsRecoversUnsupportedFsync(t *testing.T) {
+	t.Parallel()
+
+	handle := &fakeDirectorySyncHandle{syncErr: syscall.EINVAL, fd: 7}
+	gotFD := -1
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open: func(string) (directorySyncHandle, error) { return handle, nil },
+		syncfs: func(fd int) error {
+			gotFD = fd
+			return nil
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 7, gotFD)
+	assert.Equal(t, 1, handle.closeCalls)
+}
+
+// An fsync failure that is not about support is a real durability failure and
+// must not be papered over by a filesystem-wide sync.
+func TestSyncDirWithOps_DoesNotFallBackOnRealSyncFailures(t *testing.T) {
+	t.Parallel()
+
+	handle := &fakeDirectorySyncHandle{syncErr: syscall.EIO, fd: 42}
+	syncfsCalls := 0
+	err := syncDirWithOps("update-dir", linuxDirectorySyncOps{
+		open: func(string) (directorySyncHandle, error) { return handle, nil },
+		syncfs: func(int) error {
+			syncfsCalls++
+			return nil
+		},
+	})
+
+	require.ErrorIs(t, err, syscall.EIO)
+	assert.Zero(t, syncfsCalls)
+	assert.Equal(t, 1, handle.closeCalls)
+}

--- a/pkg/service/updater/syncdir_other.go
+++ b/pkg/service/updater/syncdir_other.go
@@ -1,0 +1,28 @@
+//go:build !linux && !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDir(dir string) error {
+	handle, err := os.Open(dir) //nolint:gosec // callers pass updater-owned or executable parent directories
+	if err != nil {
+		return fmt.Errorf("opening directory for sync: %w", err)
+	}
+	syncErr := handle.Sync()
+	closeErr := handle.Close()
+	if syncErr != nil {
+		return fmt.Errorf("syncing directory: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing synced directory: %w", closeErr)
+	}
+	return nil
+}

--- a/pkg/service/updater/syncdir_windows.go
+++ b/pkg/service/updater/syncdir_windows.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
+	"golang.org/x/sys/windows"
 )
 
 func syncDir(dir string) error {
@@ -21,11 +23,17 @@ func syncDir(dir string) error {
 	closeErr := handle.Close()
 	// Windows does not expose directory fsync through os.File. Atomic replacement
 	// uses MoveFileEx; a permission result here means no stronger barrier exists.
-	if syncErr != nil && !errors.Is(syncErr, os.ErrPermission) {
+	if syncErr != nil && !windowsDirectorySyncUnsupported(syncErr) {
 		return fmt.Errorf("syncing directory: %w", syncErr)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("closing synced directory: %w", closeErr)
 	}
 	return nil
+}
+
+func windowsDirectorySyncUnsupported(err error) bool {
+	return errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, windows.ERROR_INVALID_FUNCTION) ||
+		errors.Is(err, windows.ERROR_NOT_SUPPORTED)
 }

--- a/pkg/service/updater/syncdir_windows.go
+++ b/pkg/service/updater/syncdir_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func syncDir(dir string) error {
+	handle, err := os.Open(dir) //nolint:gosec // callers pass updater-owned or executable parent directories
+	if err != nil {
+		return fmt.Errorf("opening directory for sync: %w", err)
+	}
+	syncErr := handle.Sync()
+	closeErr := handle.Close()
+	// Windows does not expose directory fsync through os.File. Atomic replacement
+	// uses MoveFileEx; a permission result here means no stronger barrier exists.
+	if syncErr != nil && !errors.Is(syncErr, os.ErrPermission) {
+		return fmt.Errorf("syncing directory: %w", syncErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing synced directory: %w", closeErr)
+	}
+	return nil
+}

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -23,13 +23,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"runtime"
+	"sync/atomic"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	selfupdate "github.com/creativeprojects/go-selfupdate"
 	"github.com/rs/zerolog/log"
@@ -37,19 +39,19 @@ import (
 
 const updateURL = "https://updates.zaparoo.org/"
 
-var ErrDevelopmentVersion = errors.New("update check skipped for development version")
+var (
+	ErrDevelopmentVersion = errors.New("update check skipped for development version")
+	ErrUpdateInProgress   = errors.New("update already in progress")
+	applyMu               syncutil.Mutex
+	applyInProgress       atomic.Bool
+)
 
 // Options describes the device an update is being resolved for.
 type Options struct {
-	// PlatformID is the platform half of the archive name.
+	UserDB     UpdateBackupper
 	PlatformID string
-	// Channel is stable or beta.
-	Channel string
-	// DataDir is the platform data directory. The generation watermark and the
-	// verified manifest cache live in a subdirectory of it. An empty value
-	// disables both: checks still work and are still verified, they just lose
-	// replay protection and re-download the manifest each time.
-	DataDir string
+	Channel    string
+	DataDir    string
 }
 
 type Result struct {
@@ -62,6 +64,7 @@ type Result struct {
 // session is one update operation's updater and the transport backing it.
 type session struct {
 	updater *selfupdate.Updater
+	source  *verifiedSource
 	// close releases the transport's pooled connections. Callers must defer it:
 	// each operation builds a fresh transport, so without it the keep-alive
 	// connections and their goroutines outlive the operation until the idle
@@ -100,6 +103,7 @@ func makeUpdater(opts Options) (*session, error) {
 
 	return &session{
 		updater: updater,
+		source:  source,
 		repo:    selfupdate.NewRepositorySlug("ZaparooProject", "zaparoo-core"),
 		close:   transport.CloseIdleConnections,
 	}, nil
@@ -147,6 +151,24 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 	if config.IsDevelopmentVersion() {
 		return "", ErrDevelopmentVersion
 	}
+	if !applyInProgress.CompareAndSwap(false, true) {
+		return "", ErrUpdateInProgress
+	}
+	defer applyInProgress.Store(false)
+
+	if opts.UserDB == nil {
+		return "", errors.New("applying an update needs the user database")
+	}
+	if opts.DataDir == "" {
+		return "", errors.New("applying an update needs the platform data directory")
+	}
+
+	applyMu.Lock()
+	defer applyMu.Unlock()
+
+	if err := ensureNoPendingUpdate(opts.DataDir); err != nil {
+		return "", err
+	}
 
 	s, err := makeUpdater(opts)
 	if err != nil {
@@ -154,20 +176,63 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 	}
 	defer s.close()
 
-	// When running as a daemon subprocess, the binary is a temp copy and
-	// os.Executable() would point to it. ZAPAROO_APP holds the path to
-	// the original binary that should be updated instead.
-	var release *selfupdate.Release
-	if appPath := os.Getenv(config.AppEnv); appPath != "" {
-		release, err = s.updater.UpdateCommand(ctx, appPath, config.AppVersion, s.repo)
-	} else {
-		release, err = s.updater.UpdateSelf(ctx, config.AppVersion, s.repo)
-	}
+	release, found, err := s.updater.DetectLatest(ctx, s.repo)
 	if err != nil {
-		return "", fmt.Errorf("applying update: %w", err)
+		return "", fmt.Errorf("detecting the release to apply: %w", err)
+	}
+	if !found || !release.GreaterThan(config.AppVersion) {
+		return "", fmt.Errorf("%w: running %s", ErrNotAnUpgrade, config.AppVersion)
 	}
 
-	return release.Version(), nil
+	manifestRelease, err := s.source.releaseForVersion(release.Version())
+	if err != nil {
+		return "", err
+	}
+	targetPath, err := restart.BinaryPath()
+	if err != nil {
+		return "", fmt.Errorf("resolving the binary to update: %w", err)
+	}
+	staged, err := Stage(ctx, &StageOptions{
+		Release:        manifestRelease,
+		PlatformID:     opts.PlatformID,
+		Arch:           runtime.GOARCH,
+		OS:             runtime.GOOS,
+		TargetPath:     targetPath,
+		StagingRoot:    stagingRootFor(opts.DataDir),
+		CurrentVersion: config.AppVersion,
+	})
+	if err != nil {
+		return "", fmt.Errorf("staging update: %w", err)
+	}
+
+	if err := installStaged(ctx, &installOptions{
+		Staged:             staged,
+		UserDB:             opts.UserDB,
+		TargetPath:         targetPath,
+		DataDir:            opts.DataDir,
+		PreviousVersion:    config.AppVersion,
+		PlatformID:         opts.PlatformID,
+		ManifestGeneration: s.source.manifestGeneration(),
+		Trigger:            triggerManual,
+	}); err != nil {
+		return "", fmt.Errorf("installing update: %w", err)
+	}
+
+	return staged.Version, nil
+}
+
+func ensureNoPendingUpdate(dataDir string) error {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	m, err := loadMarker(stateDirFor(dataDir))
+	if err != nil {
+		return fmt.Errorf("checking for an unresolved update: %w", err)
+	}
+	if m != nil {
+		return fmt.Errorf("an update to %s is still unresolved", m.TargetVersion)
+	}
+	return nil
 }
 
 // CheckFn is the signature for a function that checks for updates.

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -247,8 +247,60 @@ func TestApply_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	version, err := Apply(ctx, linuxOptions())
+	opts := linuxOptions()
+	opts.UserDB = &installTestBackupper{}
+	opts.DataDir = t.TempDir()
+
+	version, err := Apply(ctx, opts)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, version)
+}
+
+func TestApply_RejectsIncompleteOptions(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "1.0.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	withDataDir := linuxOptions()
+	withDataDir.DataDir = t.TempDir()
+
+	withUserDB := linuxOptions()
+	withUserDB.UserDB = &installTestBackupper{}
+
+	for name, opts := range map[string]Options{
+		"no user database":   withDataDir,
+		"no data directory":  withUserDB,
+		"neither of the two": linuxOptions(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			version, err := Apply(t.Context(), opts)
+			require.Error(t, err)
+			assert.Empty(t, version)
+		})
+	}
+}
+
+// An update that has not been confirmed or rolled back yet owns the binary
+// backup and the marker, so a second Apply must refuse before it reaches the
+// network rather than overwrite them.
+func TestApply_RefusesWhileAnUpdateIsUnresolved(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "1.0.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	dataDir := t.TempDir()
+	require.NoError(t, saveMarker(stateDirFor(dataDir), &pendingMarker{
+		State:         markerConfirming,
+		TargetVersion: "2.2.0",
+	}))
+
+	opts := linuxOptions()
+	opts.UserDB = &installTestBackupper{}
+	opts.DataDir = dataDir
+
+	version, err := Apply(t.Context(), opts)
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "2.2.0")
 	assert.Empty(t, version)
 }
 

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -227,6 +227,18 @@ func TestCheck_CancelledContext(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestApply_UpdateInProgress(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "1.0.0"
+	t.Cleanup(func() { config.AppVersion = original })
+	applyInProgress.Store(true)
+	t.Cleanup(func() { applyInProgress.Store(false) })
+
+	version, err := Apply(t.Context(), Options{})
+	require.ErrorIs(t, err, ErrUpdateInProgress)
+	assert.Empty(t, version)
+}
+
 func TestApply_CancelledContext(t *testing.T) {
 	original := config.AppVersion
 	config.AppVersion = "1.0.0"

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -1,0 +1,615 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+// watchdogAction is what the boot after an update has to do about it.
+type watchdogAction int
+
+const (
+	// actionNone means there is nothing to resolve and startup carries on.
+	actionNone watchdogAction = iota
+	// actionConfirm means the new version is running and now has to prove it
+	// stays up. The marker moves to confirming and startup carries on.
+	actionConfirm
+	// actionClear means the marker describes an update this process is not part
+	// of, so it is discarded and startup carries on.
+	actionClear
+	// actionAbortInstall means the outgoing version is still running after an
+	// interrupted binary swap, so only the old binary and unused artifacts need
+	// restoring; the live UserDB was never opened by the target version.
+	actionAbortInstall
+	// actionFinalize completes idempotent cleanup after a terminal outcome was
+	// durably recorded.
+	actionFinalize
+	// actionRollBack means the update did not work and the previous version has
+	// to be put back.
+	actionRollBack
+)
+
+// ErrRolledBack means an update was rolled back and the previous version is now
+// on disk. The process is still running the image that failed, so every caller
+// of Start has to re-exec rather than exit: on the platforms this matters for
+// there is no supervisor to start anything again.
+var (
+	ErrRolledBack           = errors.New("update rolled back, restart into the restored version")
+	errRollbackPrerequisite = errors.New("rollback prerequisite is unavailable")
+)
+
+// decideWatchdogAction maps a marker and the version actually running onto what
+// to do about it. It is separated from the work so the table can be tested
+// without a filesystem, which matters because getting a row wrong here either
+// bricks a device or undoes a good update.
+func decideWatchdogAction(m *pendingMarker, currentVersion string) watchdogAction {
+	if m == nil {
+		return actionNone
+	}
+	// A durable terminal outcome turns startup into idempotent cleanup, never
+	// another rollback. A blocked rollback deliberately retains its marker and
+	// snapshot for manual recovery.
+	switch m.Outcome {
+	case outcomeSucceeded, outcomeRolledBack:
+		return actionFinalize
+	case outcomeRollbackBlocked:
+		return actionNone
+	case "":
+		// Continue with the in-progress state below.
+	default:
+		return actionNone
+	}
+
+	switch m.State {
+	case markerInstalling:
+		if m.PreviousVersion == currentVersion {
+			return actionAbortInstall
+		}
+		return actionRollBack
+
+	case markerRollingBack:
+		// A rollback started and did not finish. Whatever is running now, the
+		// files are half swapped and the only way out is through.
+		return actionRollBack
+
+	case markerInstalled:
+		// The install completed and this is the first boot after it. Running the
+		// version the update aimed for means the binary at least starts.
+		if m.TargetVersion == currentVersion {
+			return actionConfirm
+		}
+		// If the outgoing version is still running, the target never opened the
+		// UserDB and the install can be aborted without restoring its snapshot.
+		if m.PreviousVersion == currentVersion {
+			return actionAbortInstall
+		}
+		return actionRollBack
+
+	case markerConfirming:
+		if m.TargetVersion == currentVersion {
+			// The previous boot got this far and then never confirmed, so the
+			// new version starts but does not survive startup.
+			return actionRollBack
+		}
+		// A different version is running, so this marker belongs to an update
+		// that was superseded or undone by other means.
+		return actionClear
+
+	default:
+		// Same schema version, unrecognised state: the file is damaged in a way
+		// parsing did not catch, and it cannot direct a rollback.
+		return actionClear
+	}
+}
+
+// RunStartupWatchdog resolves any update left pending by a previous boot. It
+// runs before configuration, the databases or the network are available,
+// because the failure it exists to catch is a binary that cannot get that far.
+//
+// It returns ErrRolledBack when the previous version has been put back and the
+// caller must re-exec into it. Every other error is advisory: startup continues,
+// because refusing to boot over a bookkeeping problem is the outcome this whole
+// mechanism exists to avoid.
+func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) error {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	dir := stateDirFor(dataDir)
+	m, err := loadMarker(dir)
+	if err != nil {
+		// A newer or unusable marker cannot safely direct this build. Leave it and
+		// every update snapshot alone so a compatible build or operator still has
+		// the evidence and recovery files.
+		log.Warn().Err(err).Msg("leaving an update marker this build cannot safely resolve")
+		return nil
+	}
+
+	switch decideWatchdogAction(m, currentVersion) {
+	case actionNone:
+		if m != nil && m.Outcome == outcomeRollbackBlocked {
+			if err := recordMarkerResult(dir, m); err != nil {
+				log.Warn().Err(err).Msg("could not retain the blocked rollback result")
+			}
+		}
+		sweepUpdateSnapshots(dataDir, snapshotToKeep(m))
+		return nil
+
+	case actionClear:
+		log.Info().
+			Str("markerVersion", m.TargetVersion).
+			Str("running", currentVersion).
+			Msg("discarding an update marker that does not describe this version")
+		if err := clearMarker(dir); err != nil {
+			return err
+		}
+		sweepUpdateSnapshots(dataDir, "")
+		return nil
+
+	case actionConfirm:
+		m.State = markerConfirming
+		m.Attempts++
+		if err := saveMarker(dir, m); err != nil {
+			// Without confirming on disk a failed startup looks like a first
+			// boot to the next one, so it would try to confirm again instead of
+			// rolling back. Report it; the next boot re-runs this same step.
+			return fmt.Errorf("recording that the updated version is being confirmed: %w", err)
+		}
+		log.Info().
+			Str("from", m.PreviousVersion).
+			Str("to", m.TargetVersion).
+			Int("attempts", m.Attempts).
+			Msg("confirming an updated version")
+		return nil
+
+	case actionAbortInstall:
+		return abortInstall(ctx, dataDir, m, installSidecarPath(m.TargetPath, installCandidateSuffix))
+
+	case actionFinalize:
+		return finalizeTerminalUpdate(ctx, dataDir, m)
+
+	case actionRollBack:
+		return rollBack(ctx, dataDir, m)
+
+	default:
+		return nil
+	}
+}
+
+// RollBackFailedStart is the same recovery driven by a startup that got past the
+// watchdog and then failed anyway. The watchdog only sees a process that never
+// started; this sees one that started and could not finish, which on a device
+// with no supervisor is just as fatal.
+func RollBackFailedStart(ctx context.Context, dataDir, currentVersion string) error {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	m, err := loadMarker(stateDirFor(dataDir))
+	if err != nil || m == nil {
+		return nil //nolint:nilerr // a marker this build cannot own is not ours to act on
+	}
+	if m.Outcome != "" || m.TargetVersion != currentVersion {
+		return nil
+	}
+	log.Error().
+		Str("from", m.PreviousVersion).
+		Str("to", m.TargetVersion).
+		Msg("the updated version failed to start, rolling back")
+	return rollBack(ctx, dataDir, m)
+}
+
+// RecordCleanShutdown resets a confirming marker so an orderly stop during the
+// soak window restarts confirmation on the next boot instead of looking like a
+// crash. A startup failure still rolls back through Start's deferred hook after
+// cleanup completes.
+func RecordCleanShutdown(dataDir, currentVersion string) error {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	dir := stateDirFor(dataDir)
+	m, err := loadMarker(dir)
+	if err != nil || m == nil {
+		return nil // an unreadable or foreign marker is not ours to change
+	}
+	if m.State != markerConfirming || m.Outcome != "" || m.TargetVersion != currentVersion {
+		return nil
+	}
+	m.State = markerInstalled
+	return saveMarker(dir, m)
+}
+
+// Confirm commits an update that has stayed up long enough to be trusted. The
+// terminal outcome is made durable before cleanup, so a crash at any cleanup
+// boundary resumes cleanup rather than attempting rollback without its files.
+func Confirm(ctx context.Context, dataDir, currentVersion string) (string, error) {
+	markerMu.Lock()
+	defer markerMu.Unlock()
+
+	dir := stateDirFor(dataDir)
+	m, err := loadMarker(dir)
+	if err != nil || m == nil {
+		return "", nil //nolint:nilerr // a marker this build cannot read is not ours to commit
+	}
+	if m.State != markerConfirming || m.Outcome != "" || m.TargetVersion != currentVersion {
+		return "", nil
+	}
+
+	m.Outcome = outcomeSucceeded
+	m.OutcomeAt = time.Now().UTC()
+	if err := saveMarker(dir, m); err != nil {
+		return "", fmt.Errorf("recording the confirmed update: %w", err)
+	}
+	if err := finalizeTerminalUpdate(ctx, dataDir, m); err != nil {
+		return m.TargetVersion, err
+	}
+
+	log.Info().
+		Str("from", m.PreviousVersion).
+		Str("to", m.TargetVersion).
+		Msg("update confirmed")
+	return m.TargetVersion, nil
+}
+
+// ReportLastUpdate posts the outcome of an update that finished before there was
+// an inbox to post it to. Rollbacks are exactly that case: they run before the
+// databases are open and then re-exec, so this is the only chance the user gets
+// to hear that the version they installed did not work.
+func ReportLastUpdate(dataDir string, inboxSvc *inbox.Service) {
+	if inboxSvc == nil {
+		return
+	}
+	dir := stateDirFor(dataDir)
+	res := peekUpdateResult(dir)
+	if res == nil {
+		return
+	}
+
+	var title, body string
+	severity := inbox.SeverityWarning
+	switch res.Outcome {
+	case outcomeRolledBack:
+		title = "Update rolled back"
+		body = fmt.Sprintf(
+			"Version %s did not start, so version %s was restored. "+
+				"Your data was restored from the snapshot taken before the update.",
+			res.ToVersion, res.FromVersion)
+	case outcomeRollbackBlocked:
+		severity = inbox.SeverityError
+		title = "Update could not be rolled back"
+		body = fmt.Sprintf(
+			"Version %s did not start and version %s could not be restored automatically. "+
+				"The snapshot taken before the update is still in your backups and can be "+
+				"restored by hand.",
+			res.ToVersion, res.FromVersion)
+	case outcomeSucceeded:
+		severity = inbox.SeverityInfo
+		title = "Update installed"
+		body = fmt.Sprintf("Updated from version %s to version %s.", res.FromVersion, res.ToVersion)
+	default:
+		return
+	}
+	if res.Detail != "" {
+		body += "\n\n" + res.Detail
+	}
+
+	if err := inboxSvc.Add(
+		title,
+		inbox.WithBody(body),
+		inbox.WithCategory(inbox.CategoryUpdateResult),
+		inbox.WithSeverity(severity),
+	); err != nil {
+		log.Error().Err(err).Msg("failed to add update result inbox message")
+		return
+	}
+	if err := markUpdateResultReported(dir, res); err != nil {
+		log.Warn().Err(err).Msg("update result was posted but could not be marked reported")
+	}
+}
+
+// rollBack puts the previous version back. Callers hold markerMu.
+//
+// The order is deliberate. The user database is restored first, because that is
+// the step with a way out: if it fails, nothing has moved and the device carries
+// on running the new version, which at worst is suspect. Restoring the binary
+// first and then failing on the database would leave an old binary in front of a
+// database migrated past what it can open, and that combination does not boot.
+func rollBack(ctx context.Context, dataDir string, m *pendingMarker) error {
+	dir := stateDirFor(dataDir)
+	if m.State != markerRollingBack {
+		m.State = markerRollingBack
+		if err := saveMarker(dir, m); err != nil {
+			// Nothing has been moved yet, and without this on disk an
+			// interrupted rollback would not know to resume. Stop here rather
+			// than start a swap that cannot be finished.
+			return fmt.Errorf("recording the start of the rollback: %w", err)
+		}
+	}
+
+	if err := restoreUserDB(ctx, dataDir, m); err != nil {
+		return handleRollbackFailure(dir, m, err)
+	}
+	if err := restoreReplacedFiles(dir, m); err != nil {
+		return handleRollbackFailure(dir, m, err)
+	}
+
+	m.Outcome = outcomeRolledBack
+	m.OutcomeAt = time.Now().UTC()
+	if err := saveMarker(dir, m); err != nil {
+		return fmt.Errorf("%w: recording the completed rollback: %w", ErrRolledBack, err)
+	}
+	if err := finalizeTerminalUpdate(ctx, dataDir, m); err != nil {
+		return fmt.Errorf("%w: finalizing the completed rollback: %w", ErrRolledBack, err)
+	}
+
+	log.Warn().
+		Str("failed", m.TargetVersion).
+		Str("restored", m.PreviousVersion).
+		Msg("update rolled back")
+	return ErrRolledBack
+}
+
+func handleRollbackFailure(dir string, m *pendingMarker, cause error) error {
+	if errors.Is(cause, errRollbackPrerequisite) {
+		return blockRollback(dir, m, cause)
+	}
+	log.Error().Err(cause).
+		Str("failed", m.TargetVersion).
+		Str("wanted", m.PreviousVersion).
+		Msg("rollback hit a retryable error; leaving it pending")
+	return fmt.Errorf("rollback remains pending after a retryable error: %w", cause)
+}
+
+// blockRollback gives up on a rollback only when a prerequisite is permanently
+// missing or corrupt. Retryable I/O errors leave markerRollingBack intact.
+func blockRollback(dir string, m *pendingMarker, cause error) error {
+	log.Error().Err(cause).
+		Str("failed", m.TargetVersion).
+		Str("wanted", m.PreviousVersion).
+		Msg("could not roll the update back, leaving the new version installed")
+
+	m.Outcome = outcomeRollbackBlocked
+	m.OutcomeAt = time.Now().UTC()
+	m.OutcomeDetail = cause.Error()
+	if err := saveMarker(dir, m); err != nil {
+		return fmt.Errorf("recording that rollback was abandoned: %w", err)
+	}
+	if err := recordMarkerResult(dir, m); err != nil {
+		log.Warn().Err(err).Msg("could not record the blocked rollback result")
+	}
+	return nil
+}
+
+// restoreUserDB puts the snapshot taken before the install back over the live
+// database. It runs on every rollback, including one that resumes: the snapshot
+// is still on disk, and writing it again costs a copy where guessing whether the
+// previous attempt got this far costs correctness.
+func restoreUserDB(ctx context.Context, dataDir string, m *pendingMarker) error {
+	if m.UserDBSnapshotPath == "" {
+		return fmt.Errorf("%w: the update recorded no user database snapshot", errRollbackPrerequisite)
+	}
+	if _, err := os.Stat(m.UserDBSnapshotPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%w: user database snapshot: %w", errRollbackPrerequisite, err)
+		}
+		return fmt.Errorf("reading the user database snapshot: %w", err)
+	}
+	dbPath := filepath.Join(dataDir, config.UserDbFile)
+	if err := userdb.RestoreFileTo(ctx, afero.NewOsFs(), m.UserDBSnapshotPath, dbPath); err != nil {
+		if errors.Is(err, userdb.ErrInvalidBackup) {
+			return fmt.Errorf("%w: %w", errRollbackPrerequisite, err)
+		}
+		return fmt.Errorf("restoring the user database snapshot: %w", err)
+	}
+	return nil
+}
+
+// restoreReplacedFiles renames what the install displaced back over what it
+// installed. The binary goes last so that a failure part way through leaves the
+// new one in place, which is the state blockRollback is willing to run in.
+func restoreReplacedFiles(dir string, m *pendingMarker) error {
+	for _, p := range m.PayloadBackups {
+		if err := restoreReplacedFile(dir, m, p.BackupPath, p.TargetPath); err != nil {
+			return err
+		}
+	}
+	return restoreReplacedFile(dir, m, m.BackupPath, m.TargetPath)
+}
+
+// restoreReplacedFile records the path about to move before renaming it. If a
+// power cut lands after the rename but before the marker can advance, a missing
+// backup is then proof that this exact move completed, not a guess based on the
+// rollback's coarse state.
+func restoreReplacedFile(dir string, m *pendingMarker, backupPath, targetPath string) error {
+	if backupPath == "" || targetPath == "" {
+		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
+	}
+
+	_, statErr := os.Stat(backupPath)
+	if statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) && m.RestoringPath == targetPath {
+			if _, targetErr := os.Stat(targetPath); targetErr != nil {
+				return fmt.Errorf("restored backup and target are both unavailable for %q: %w", targetPath, targetErr)
+			}
+			m.RestoringPath = ""
+			if saveErr := saveMarker(dir, m); saveErr != nil {
+				return fmt.Errorf("recording the completed file restore: %w", saveErr)
+			}
+			return nil
+		}
+		if errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("%w: backup of %q: %w", errRollbackPrerequisite, targetPath, statErr)
+		}
+		return fmt.Errorf("reading the backup of %q: %w", targetPath, statErr)
+	}
+
+	if m.RestoringPath != targetPath {
+		m.RestoringPath = targetPath
+		if err := saveMarker(dir, m); err != nil {
+			return fmt.Errorf("recording the file being restored: %w", err)
+		}
+	}
+
+	if err := replaceFile(backupPath, targetPath); err != nil {
+		return fmt.Errorf("restoring %q: %w", targetPath, err)
+	}
+	if err := syncDir(filepath.Dir(targetPath)); err != nil {
+		return fmt.Errorf("flushing restored file %q: %w", targetPath, err)
+	}
+	m.RestoringPath = ""
+	if err := saveMarker(dir, m); err != nil {
+		return fmt.Errorf("recording the completed file restore: %w", err)
+	}
+	return nil
+}
+
+func finalizeTerminalUpdate(ctx context.Context, dataDir string, m *pendingMarker) error {
+	if m == nil || (m.Outcome != outcomeSucceeded && m.Outcome != outcomeRolledBack) {
+		return errors.New("finalizing an update needs a completed outcome")
+	}
+	dir := stateDirFor(dataDir)
+	if err := recordMarkerResult(dir, m); err != nil {
+		return err
+	}
+
+	if m.Outcome == outcomeSucceeded {
+		if err := removeReplacedFiles(m); err != nil {
+			return err
+		}
+	}
+	if m.StagingDir != "" {
+		if err := removeStagingDir(ctx, m.StagingDir); err != nil {
+			log.Warn().Err(err).Str("dir", m.StagingDir).
+				Msg("could not remove the staging directory of a completed update")
+		}
+	}
+	sweepUpdateSnapshots(dataDir, "")
+	if err := clearMarker(dir); err != nil {
+		return fmt.Errorf("clearing the completed update marker: %w", err)
+	}
+	return nil
+}
+
+func recordMarkerResult(dir string, m *pendingMarker) error {
+	if m == nil || m.Outcome == "" {
+		return nil
+	}
+	at := m.OutcomeAt
+	if at.IsZero() {
+		at = m.InstalledAt
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	return recordUpdateResult(dir, &updateResult{
+		At:          at,
+		Outcome:     m.Outcome,
+		FromVersion: m.PreviousVersion,
+		ToVersion:   m.TargetVersion,
+		Detail:      m.OutcomeDetail,
+	})
+}
+
+// removeReplacedFiles deletes the copies of what an update displaced, once that
+// update is confirmed and they can no longer be needed.
+func removeReplacedFiles(m *pendingMarker) error {
+	paths := make([]string, 0, len(m.PayloadBackups)+1)
+	if m.BackupPath != "" {
+		paths = append(paths, m.BackupPath)
+	}
+	for _, p := range m.PayloadBackups {
+		if p.BackupPath != "" {
+			paths = append(paths, p.BackupPath)
+		}
+	}
+
+	var cleanupErr error
+	dirs := make(map[string]struct{}, len(paths))
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = errors.Join(cleanupErr,
+				fmt.Errorf("removing backup of replaced file %q: %w", path, err))
+			continue
+		}
+		dirs[filepath.Dir(path)] = struct{}{}
+	}
+	for dir := range dirs {
+		if err := syncDir(dir); err != nil {
+			cleanupErr = errors.Join(cleanupErr,
+				fmt.Errorf("flushing removed binary backups in %q: %w", dir, err))
+		}
+	}
+	if cleanupErr != nil {
+		return cleanupErr
+	}
+	return nil
+}
+
+// snapshotToKeep returns the snapshot a marker still depends on.
+//
+// A marker on disk always depends on its snapshot. The two outcomes that finish
+// an update delete their marker, so the only one that survives to be read again
+// is an abandoned rollback — and that is precisely the case where the snapshot
+// is the user's remaining way back, which the inbox message tells them to use.
+func snapshotToKeep(m *pendingMarker) string {
+	if m == nil {
+		return ""
+	}
+	return m.UserDBSnapshotPath
+}
+
+// sweepUpdateSnapshots deletes update snapshots no marker depends on any more.
+// Retention deliberately ignores them, so without this a device that updated a
+// dozen times would keep a dozen copies of its database forever.
+func sweepUpdateSnapshots(dataDir, keep string) {
+	dir := userdb.BackupsDir(dataDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// A device that has never taken a backup has no directory here.
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Debug().Err(err).Str("dir", dir).Msg("could not list backups to sweep update snapshots")
+		}
+		return
+	}
+
+	keep = filepath.Clean(keep)
+	for _, entry := range entries {
+		if entry.IsDir() || !userdb.IsUpdateSnapshotName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if keep != "." && filepath.Clean(path) == keep {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Warn().Err(err).Str("path", path).Msg("could not remove an unreferenced update snapshot")
+		}
+	}
+}

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -66,16 +66,6 @@ type watchdogFileOps struct {
 	restoreDatabase func(context.Context, afero.Fs, string, string) error
 }
 
-func defaultWatchdogFileOps() watchdogFileOps {
-	return watchdogFileOps{
-		fs:              afero.NewOsFs(),
-		replace:         replaceFile,
-		syncDirectory:   syncDir,
-		removeStaging:   removeStagingDir,
-		restoreDatabase: userdb.RestoreFileTo,
-	}
-}
-
 // ErrRolledBack means an update was rolled back and the previous version is now
 // on disk. The process is still running the image that failed, so every caller
 // of Start has to re-exec rather than exit: on the platforms this matters for
@@ -102,6 +92,16 @@ func (e *rolledBackError) Unwrap() []error {
 		return []error{ErrRolledBack}
 	}
 	return []error{ErrRolledBack, e.cause}
+}
+
+func defaultWatchdogFileOps() watchdogFileOps {
+	return watchdogFileOps{
+		fs:              afero.NewOsFs(),
+		replace:         replaceFile,
+		syncDirectory:   syncDir,
+		removeStaging:   removeStagingDir,
+		restoreDatabase: userdb.RestoreFileTo,
+	}
 }
 
 func newRolledBackError(targetPath string, cause error) error {

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -58,6 +58,24 @@ const (
 	actionRollBack
 )
 
+type watchdogFileOps struct {
+	fs              afero.Fs
+	replace         func(string, string) error
+	syncDirectory   func(string) error
+	removeStaging   func(context.Context, string) error
+	restoreDatabase func(context.Context, afero.Fs, string, string) error
+}
+
+func defaultWatchdogFileOps() watchdogFileOps {
+	return watchdogFileOps{
+		fs:              afero.NewOsFs(),
+		replace:         replaceFile,
+		syncDirectory:   syncDir,
+		removeStaging:   removeStagingDir,
+		restoreDatabase: userdb.RestoreFileTo,
+	}
+}
+
 // ErrRolledBack means an update was rolled back and the previous version is now
 // on disk. The process is still running the image that failed, so every caller
 // of Start has to re-exec rather than exit: on the platforms this matters for
@@ -66,6 +84,39 @@ var (
 	ErrRolledBack           = errors.New("update rolled back, restart into the restored version")
 	errRollbackPrerequisite = errors.New("rollback prerequisite is unavailable")
 )
+
+type rolledBackError struct {
+	cause      error
+	targetPath string
+}
+
+func (e *rolledBackError) Error() string {
+	if e.cause == nil {
+		return ErrRolledBack.Error()
+	}
+	return fmt.Sprintf("%s: %v", ErrRolledBack, e.cause)
+}
+
+func (e *rolledBackError) Unwrap() []error {
+	if e.cause == nil {
+		return []error{ErrRolledBack}
+	}
+	return []error{ErrRolledBack, e.cause}
+}
+
+func newRolledBackError(targetPath string, cause error) error {
+	return &rolledBackError{targetPath: targetPath, cause: cause}
+}
+
+// RollbackTargetPath returns the restored executable path carried by a rollback
+// result, allowing callers to re-exec that path rather than the failing image.
+func RollbackTargetPath(err error) (string, bool) {
+	var rollbackErr *rolledBackError
+	if !errors.As(err, &rollbackErr) || rollbackErr.targetPath == "" {
+		return "", false
+	}
+	return rollbackErr.targetPath, true
+}
 
 // decideWatchdogAction maps a marker and the version actually running onto what
 // to do about it. It is separated from the work so the table can be tested
@@ -140,6 +191,12 @@ func decideWatchdogAction(m *pendingMarker, currentVersion string) watchdogActio
 // because refusing to boot over a bookkeeping problem is the outcome this whole
 // mechanism exists to avoid.
 func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) error {
+	return runStartupWatchdogWithOps(ctx, dataDir, currentVersion, defaultWatchdogFileOps())
+}
+
+func runStartupWatchdogWithOps(
+	ctx context.Context, dataDir, currentVersion string, fileOps watchdogFileOps,
+) error {
 	markerMu.Lock()
 	defer markerMu.Unlock()
 
@@ -150,6 +207,11 @@ func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) err
 		// every update snapshot alone so a compatible build or operator still has
 		// the evidence and recovery files.
 		log.Warn().Err(err).Msg("leaving an update marker this build cannot safely resolve")
+		if errors.Is(err, errMarkerUnusable) {
+			if resultErr := recordUnusableMarkerResult(fileOps.fs, dir, currentVersion); resultErr != nil {
+				log.Warn().Err(resultErr).Msg("could not record unusable update marker for user notification")
+			}
+		}
 		return nil
 	}
 
@@ -160,7 +222,7 @@ func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) err
 				log.Warn().Err(err).Msg("could not retain the blocked rollback result")
 			}
 		}
-		sweepUpdateSnapshots(dataDir, snapshotToKeep(m))
+		sweepUpdateSnapshotsFS(fileOps.fs, dataDir, snapshotToKeep(m))
 		return nil
 
 	case actionClear:
@@ -171,7 +233,7 @@ func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) err
 		if err := clearMarker(dir); err != nil {
 			return err
 		}
-		sweepUpdateSnapshots(dataDir, "")
+		sweepUpdateSnapshotsFS(fileOps.fs, dataDir, "")
 		return nil
 
 	case actionConfirm:
@@ -194,10 +256,10 @@ func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) err
 		return abortInstall(ctx, dataDir, m, installSidecarPath(m.TargetPath, installCandidateSuffix))
 
 	case actionFinalize:
-		return finalizeTerminalUpdate(ctx, dataDir, m)
+		return finalizeTerminalUpdate(ctx, dataDir, m, fileOps)
 
 	case actionRollBack:
-		return rollBack(ctx, dataDir, m)
+		return rollBack(ctx, dataDir, m, fileOps)
 
 	default:
 		return nil
@@ -209,6 +271,12 @@ func RunStartupWatchdog(ctx context.Context, dataDir, currentVersion string) err
 // started; this sees one that started and could not finish, which on a device
 // with no supervisor is just as fatal.
 func RollBackFailedStart(ctx context.Context, dataDir, currentVersion string) error {
+	return rollBackFailedStartWithOps(ctx, dataDir, currentVersion, defaultWatchdogFileOps())
+}
+
+func rollBackFailedStartWithOps(
+	ctx context.Context, dataDir, currentVersion string, fileOps watchdogFileOps,
+) error {
 	markerMu.Lock()
 	defer markerMu.Unlock()
 
@@ -223,7 +291,7 @@ func RollBackFailedStart(ctx context.Context, dataDir, currentVersion string) er
 		Str("from", m.PreviousVersion).
 		Str("to", m.TargetVersion).
 		Msg("the updated version failed to start, rolling back")
-	return rollBack(ctx, dataDir, m)
+	return rollBack(ctx, dataDir, m, fileOps)
 }
 
 // RecordCleanShutdown resets a confirming marker so an orderly stop during the
@@ -250,6 +318,12 @@ func RecordCleanShutdown(dataDir, currentVersion string) error {
 // terminal outcome is made durable before cleanup, so a crash at any cleanup
 // boundary resumes cleanup rather than attempting rollback without its files.
 func Confirm(ctx context.Context, dataDir, currentVersion string) (string, error) {
+	return confirmWithOps(ctx, dataDir, currentVersion, defaultWatchdogFileOps())
+}
+
+func confirmWithOps(
+	ctx context.Context, dataDir, currentVersion string, fileOps watchdogFileOps,
+) (string, error) {
 	markerMu.Lock()
 	defer markerMu.Unlock()
 
@@ -267,7 +341,7 @@ func Confirm(ctx context.Context, dataDir, currentVersion string) (string, error
 	if err := saveMarker(dir, m); err != nil {
 		return "", fmt.Errorf("recording the confirmed update: %w", err)
 	}
-	if err := finalizeTerminalUpdate(ctx, dataDir, m); err != nil {
+	if err := finalizeTerminalUpdate(ctx, dataDir, m, fileOps); err != nil {
 		return m.TargetVersion, err
 	}
 
@@ -313,6 +387,12 @@ func ReportLastUpdate(dataDir string, inboxSvc *inbox.Service) {
 		severity = inbox.SeverityInfo
 		title = "Update installed"
 		body = fmt.Sprintf("Updated from version %s to version %s.", res.FromVersion, res.ToVersion)
+	case outcomeRecoveryRequired:
+		severity = inbox.SeverityError
+		title = "Update needs manual recovery"
+		body = "Core found update recovery data it cannot safely read. " +
+			"Automatic and manual updates remain blocked while the quarantined pending.json.bad marker remains. " +
+			"Preserve that marker and updater backups for support-assisted recovery."
 	default:
 		return
 	}
@@ -341,7 +421,24 @@ func ReportLastUpdate(dataDir string, inboxSvc *inbox.Service) {
 // on running the new version, which at worst is suspect. Restoring the binary
 // first and then failing on the database would leave an old binary in front of a
 // database migrated past what it can open, and that combination does not boot.
-func rollBack(ctx context.Context, dataDir string, m *pendingMarker) error {
+func recordUnusableMarkerResult(fs afero.Fs, dir, currentVersion string) error {
+	var at time.Time
+	for _, path := range []string{markerPath(dir) + markerBadSuffix, markerPath(dir)} {
+		if info, err := fs.Stat(path); err == nil {
+			at = info.ModTime().UTC()
+			break
+		}
+	}
+	return recordUpdateResult(dir, &updateResult{
+		At:        at,
+		Outcome:   outcomeRecoveryRequired,
+		ToVersion: currentVersion,
+	})
+}
+
+func rollBack(
+	ctx context.Context, dataDir string, m *pendingMarker, fileOps watchdogFileOps,
+) error {
 	dir := stateDirFor(dataDir)
 	if m.State != markerRollingBack {
 		m.State = markerRollingBack
@@ -353,27 +450,29 @@ func rollBack(ctx context.Context, dataDir string, m *pendingMarker) error {
 		}
 	}
 
-	if err := restoreUserDB(ctx, dataDir, m); err != nil {
+	if err := restoreUserDB(ctx, dataDir, m, fileOps); err != nil {
 		return handleRollbackFailure(dir, m, err)
 	}
-	if err := restoreReplacedFiles(dir, m); err != nil {
+	if err := restoreReplacedFiles(dir, m, fileOps); err != nil {
 		return handleRollbackFailure(dir, m, err)
 	}
 
 	m.Outcome = outcomeRolledBack
 	m.OutcomeAt = time.Now().UTC()
 	if err := saveMarker(dir, m); err != nil {
-		return fmt.Errorf("%w: recording the completed rollback: %w", ErrRolledBack, err)
+		return newRolledBackError(m.TargetPath,
+			fmt.Errorf("recording the completed rollback: %w", err))
 	}
-	if err := finalizeTerminalUpdate(ctx, dataDir, m); err != nil {
-		return fmt.Errorf("%w: finalizing the completed rollback: %w", ErrRolledBack, err)
+	if err := finalizeTerminalUpdate(ctx, dataDir, m, fileOps); err != nil {
+		return newRolledBackError(m.TargetPath,
+			fmt.Errorf("finalizing the completed rollback: %w", err))
 	}
 
 	log.Warn().
 		Str("failed", m.TargetVersion).
 		Str("restored", m.PreviousVersion).
 		Msg("update rolled back")
-	return ErrRolledBack
+	return newRolledBackError(m.TargetPath, nil)
 }
 
 func handleRollbackFailure(dir string, m *pendingMarker, cause error) error {
@@ -411,18 +510,20 @@ func blockRollback(dir string, m *pendingMarker, cause error) error {
 // database. It runs on every rollback, including one that resumes: the snapshot
 // is still on disk, and writing it again costs a copy where guessing whether the
 // previous attempt got this far costs correctness.
-func restoreUserDB(ctx context.Context, dataDir string, m *pendingMarker) error {
+func restoreUserDB(
+	ctx context.Context, dataDir string, m *pendingMarker, fileOps watchdogFileOps,
+) error {
 	if m.UserDBSnapshotPath == "" {
 		return fmt.Errorf("%w: the update recorded no user database snapshot", errRollbackPrerequisite)
 	}
-	if _, err := os.Stat(m.UserDBSnapshotPath); err != nil {
+	if _, err := fileOps.fs.Stat(m.UserDBSnapshotPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("%w: user database snapshot: %w", errRollbackPrerequisite, err)
 		}
 		return fmt.Errorf("reading the user database snapshot: %w", err)
 	}
 	dbPath := filepath.Join(dataDir, config.UserDbFile)
-	if err := userdb.RestoreFileTo(ctx, afero.NewOsFs(), m.UserDBSnapshotPath, dbPath); err != nil {
+	if err := fileOps.restoreDatabase(ctx, fileOps.fs, m.UserDBSnapshotPath, dbPath); err != nil {
 		if errors.Is(err, userdb.ErrInvalidBackup) {
 			return fmt.Errorf("%w: %w", errRollbackPrerequisite, err)
 		}
@@ -434,28 +535,30 @@ func restoreUserDB(ctx context.Context, dataDir string, m *pendingMarker) error 
 // restoreReplacedFiles renames what the install displaced back over what it
 // installed. The binary goes last so that a failure part way through leaves the
 // new one in place, which is the state blockRollback is willing to run in.
-func restoreReplacedFiles(dir string, m *pendingMarker) error {
+func restoreReplacedFiles(dir string, m *pendingMarker, fileOps watchdogFileOps) error {
 	for _, p := range m.PayloadBackups {
-		if err := restoreReplacedFile(dir, m, p.BackupPath, p.TargetPath); err != nil {
+		if err := restoreReplacedFile(dir, m, p.BackupPath, p.TargetPath, fileOps); err != nil {
 			return err
 		}
 	}
-	return restoreReplacedFile(dir, m, m.BackupPath, m.TargetPath)
+	return restoreReplacedFile(dir, m, m.BackupPath, m.TargetPath, fileOps)
 }
 
 // restoreReplacedFile records the path about to move before renaming it. If a
 // power cut lands after the rename but before the marker can advance, a missing
 // backup is then proof that this exact move completed, not a guess based on the
 // rollback's coarse state.
-func restoreReplacedFile(dir string, m *pendingMarker, backupPath, targetPath string) error {
+func restoreReplacedFile(
+	dir string, m *pendingMarker, backupPath, targetPath string, fileOps watchdogFileOps,
+) error {
 	if backupPath == "" || targetPath == "" {
 		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
 	}
 
-	_, statErr := os.Stat(backupPath)
+	_, statErr := fileOps.fs.Stat(backupPath)
 	if statErr != nil {
 		if errors.Is(statErr, os.ErrNotExist) && m.RestoringPath == targetPath {
-			if _, targetErr := os.Stat(targetPath); targetErr != nil {
+			if _, targetErr := fileOps.fs.Stat(targetPath); targetErr != nil {
 				return fmt.Errorf("restored backup and target are both unavailable for %q: %w", targetPath, targetErr)
 			}
 			m.RestoringPath = ""
@@ -477,10 +580,10 @@ func restoreReplacedFile(dir string, m *pendingMarker, backupPath, targetPath st
 		}
 	}
 
-	if err := replaceFile(backupPath, targetPath); err != nil {
+	if err := fileOps.replace(backupPath, targetPath); err != nil {
 		return fmt.Errorf("restoring %q: %w", targetPath, err)
 	}
-	if err := syncDir(filepath.Dir(targetPath)); err != nil {
+	if err := fileOps.syncDirectory(filepath.Dir(targetPath)); err != nil {
 		return fmt.Errorf("flushing restored file %q: %w", targetPath, err)
 	}
 	m.RestoringPath = ""
@@ -490,7 +593,9 @@ func restoreReplacedFile(dir string, m *pendingMarker, backupPath, targetPath st
 	return nil
 }
 
-func finalizeTerminalUpdate(ctx context.Context, dataDir string, m *pendingMarker) error {
+func finalizeTerminalUpdate(
+	ctx context.Context, dataDir string, m *pendingMarker, fileOps watchdogFileOps,
+) error {
 	if m == nil || (m.Outcome != outcomeSucceeded && m.Outcome != outcomeRolledBack) {
 		return errors.New("finalizing an update needs a completed outcome")
 	}
@@ -500,17 +605,17 @@ func finalizeTerminalUpdate(ctx context.Context, dataDir string, m *pendingMarke
 	}
 
 	if m.Outcome == outcomeSucceeded {
-		if err := removeReplacedFiles(m); err != nil {
+		if err := removeReplacedFiles(m, fileOps); err != nil {
 			return err
 		}
 	}
 	if m.StagingDir != "" {
-		if err := removeStagingDir(ctx, m.StagingDir); err != nil {
+		if err := fileOps.removeStaging(ctx, m.StagingDir); err != nil {
 			log.Warn().Err(err).Str("dir", m.StagingDir).
 				Msg("could not remove the staging directory of a completed update")
 		}
 	}
-	sweepUpdateSnapshots(dataDir, "")
+	sweepUpdateSnapshotsFS(fileOps.fs, dataDir, "")
 	if err := clearMarker(dir); err != nil {
 		return fmt.Errorf("clearing the completed update marker: %w", err)
 	}
@@ -539,7 +644,7 @@ func recordMarkerResult(dir string, m *pendingMarker) error {
 
 // removeReplacedFiles deletes the copies of what an update displaced, once that
 // update is confirmed and they can no longer be needed.
-func removeReplacedFiles(m *pendingMarker) error {
+func removeReplacedFiles(m *pendingMarker, fileOps watchdogFileOps) error {
 	paths := make([]string, 0, len(m.PayloadBackups)+1)
 	if m.BackupPath != "" {
 		paths = append(paths, m.BackupPath)
@@ -553,7 +658,7 @@ func removeReplacedFiles(m *pendingMarker) error {
 	var cleanupErr error
 	dirs := make(map[string]struct{}, len(paths))
 	for _, path := range paths {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fileOps.fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			cleanupErr = errors.Join(cleanupErr,
 				fmt.Errorf("removing backup of replaced file %q: %w", path, err))
 			continue
@@ -561,7 +666,7 @@ func removeReplacedFiles(m *pendingMarker) error {
 		dirs[filepath.Dir(path)] = struct{}{}
 	}
 	for dir := range dirs {
-		if err := syncDir(dir); err != nil {
+		if err := fileOps.syncDirectory(dir); err != nil {
 			cleanupErr = errors.Join(cleanupErr,
 				fmt.Errorf("flushing removed binary backups in %q: %w", dir, err))
 		}
@@ -589,8 +694,12 @@ func snapshotToKeep(m *pendingMarker) string {
 // Retention deliberately ignores them, so without this a device that updated a
 // dozen times would keep a dozen copies of its database forever.
 func sweepUpdateSnapshots(dataDir, keep string) {
+	sweepUpdateSnapshotsFS(afero.NewOsFs(), dataDir, keep)
+}
+
+func sweepUpdateSnapshotsFS(fs afero.Fs, dataDir, keep string) {
 	dir := userdb.BackupsDir(dataDir)
-	entries, err := os.ReadDir(dir)
+	entries, err := afero.ReadDir(fs, dir)
 	if err != nil {
 		// A device that has never taken a backup has no directory here.
 		if !errors.Is(err, os.ErrNotExist) {
@@ -608,7 +717,7 @@ func sweepUpdateSnapshots(dataDir, keep string) {
 		if keep != "." && filepath.Clean(path) == keep {
 			continue
 		}
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		if err := fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warn().Err(err).Str("path", path).Msg("could not remove an unreferenced update snapshot")
 		}
 	}

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -28,7 +28,9 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -276,6 +278,9 @@ func TestRunStartupWatchdog_RollsBackWhenConfirmationNeverHappened(t *testing.T)
 
 	err := RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion)
 	require.ErrorIs(t, err, ErrRolledBack)
+	rollbackTarget, ok := RollbackTargetPath(err)
+	require.True(t, ok)
+	assert.Equal(t, f.targetPath, rollbackTarget)
 
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 	assert.NoFileExists(t, f.backupPath)
@@ -613,6 +618,53 @@ func TestRunStartupWatchdog_AbortsInterruptedInstallWithoutRestoringDB(t *testin
 	assert.NoFileExists(t, markerPath(dir))
 	assert.NoFileExists(t, f.snapshotPath)
 	assert.NoDirExists(t, f.stagingDir)
+}
+
+func TestRestoreUserDB_UsesSuppliedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	dataDir := filepath.Join("data", "zaparoo")
+	snapshotPath := filepath.Join(dataDir, "backups", "snapshot-update.db")
+	require.NoError(t, fs.MkdirAll(filepath.Dir(snapshotPath), 0o750))
+	require.NoError(t, afero.WriteFile(fs, snapshotPath, []byte("snapshot"), 0o600))
+
+	restoreCalled := false
+	fileOps := watchdogFileOps{
+		fs: fs,
+		restoreDatabase: func(_ context.Context, gotFS afero.Fs, backupPath, dbPath string) error {
+			restoreCalled = true
+			assert.Same(t, fs, gotFS)
+			assert.Equal(t, snapshotPath, backupPath)
+			assert.Equal(t, filepath.Join(dataDir, config.UserDbFile), dbPath)
+			return nil
+		},
+	}
+	err := restoreUserDB(t.Context(), dataDir, &pendingMarker{UserDBSnapshotPath: snapshotPath}, fileOps)
+	require.NoError(t, err)
+	assert.True(t, restoreCalled)
+}
+
+func TestSweepUpdateSnapshots_UsesSuppliedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	dataDir := filepath.Join("data", "zaparoo")
+	backups := userdb.BackupsDir(dataDir)
+	require.NoError(t, fs.MkdirAll(backups, 0o750))
+	keep := filepath.Join(backups, "backup-20260818-043000-000000001-update.db")
+	stale := filepath.Join(backups, "backup-20260817-043000-000000001-update.db")
+	for _, path := range []string{keep, stale} {
+		require.NoError(t, afero.WriteFile(fs, path, []byte("db"), 0o600))
+	}
+
+	sweepUpdateSnapshotsFS(fs, dataDir, keep)
+	keepExists, err := afero.Exists(fs, keep)
+	require.NoError(t, err)
+	assert.True(t, keepExists)
+	staleExists, err := afero.Exists(fs, stale)
+	require.NoError(t, err)
+	assert.False(t, staleExists)
 }
 
 func TestSweepUpdateSnapshots(t *testing.T) {

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -22,6 +22,9 @@ package updater
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -693,4 +696,244 @@ func TestSweepUpdateSnapshots(t *testing.T) {
 	assert.NoFileExists(t, keep)
 	assert.FileExists(t, auto)
 	assert.FileExists(t, manual)
+}
+
+func TestRolledBackError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("re-exec is unavailable")
+	withCause := newRolledBackError("/usr/bin/zaparoo", cause)
+	require.ErrorIs(t, withCause, ErrRolledBack)
+	require.ErrorIs(t, withCause, cause)
+	assert.Equal(t, ErrRolledBack.Error()+": "+cause.Error(), withCause.Error())
+
+	// A rollback with no underlying cause still has to read as ErrRolledBack so
+	// callers re-exec instead of exiting into the version that failed.
+	bare := newRolledBackError("/usr/bin/zaparoo", nil)
+	require.ErrorIs(t, bare, ErrRolledBack)
+	assert.Equal(t, ErrRolledBack.Error(), bare.Error())
+}
+
+func TestRollbackTargetPath(t *testing.T) {
+	t.Parallel()
+
+	target, ok := RollbackTargetPath(newRolledBackError("/usr/bin/zaparoo", errors.New("boom")))
+	assert.True(t, ok)
+	assert.Equal(t, "/usr/bin/zaparoo", target)
+
+	// Without a target there is nothing to re-exec, so callers must not be told
+	// to try. Neither must an unrelated failure be mistaken for a rollback.
+	for name, err := range map[string]error{
+		"rollback without a target": newRolledBackError("", errors.New("boom")),
+		"unrelated failure":         errors.New("boom"),
+		"sentinel on its own":       ErrRolledBack,
+		"no error":                  nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			target, ok := RollbackTargetPath(err)
+			assert.False(t, ok)
+			assert.Empty(t, target)
+		})
+	}
+}
+
+// A marker written by a newer build must survive this one untouched: only the
+// build that understands it can decide what its update needs.
+func TestWatchdog_LeavesANewerSchemaMarkerAlone(t *testing.T) {
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerConfirming)
+	m.MarkerVersion = currentMarkerVersion + 1
+	raw, err := json.MarshalIndent(m, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir), raw, 0o600))
+	before := readFileString(t, markerPath(dir))
+
+	confirmed, err := Confirm(t.Context(), f.dataDir, testTargetVersion)
+	require.NoError(t, err)
+	assert.Empty(t, confirmed)
+	assert.Equal(t, before, readFileString(t, markerPath(dir)))
+
+	require.NoError(t, RecordCleanShutdown(f.dataDir, testTargetVersion))
+	assert.Equal(t, before, readFileString(t, markerPath(dir)),
+		"a marker this build cannot interpret must not be rewritten")
+	assert.NoFileExists(t, markerPath(dir)+markerBadSuffix,
+		"a newer schema is not corruption and must not be quarantined")
+}
+
+// RecordCleanShutdown runs on the way out of a boot that may have nothing to do
+// with the pending update, so it must only touch a marker awaiting this version.
+func TestRecordCleanShutdown_IgnoresAMarkerItDoesNotOwn(t *testing.T) {
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+
+	for name, m := range map[string]*pendingMarker{
+		"another version is confirming": func() *pendingMarker {
+			m := f.marker(markerConfirming)
+			m.TargetVersion = "9.9.9"
+			return m
+		}(),
+		"already resolved": func() *pendingMarker {
+			m := f.marker(markerConfirming)
+			m.Outcome = outcomeSucceeded
+			return m
+		}(),
+		"not confirming yet": f.marker(markerInstalled),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, saveMarker(dir, m))
+			before := readFileString(t, markerPath(dir))
+
+			require.NoError(t, RecordCleanShutdown(f.dataDir, testTargetVersion))
+			assert.Equal(t, before, readFileString(t, markerPath(dir)))
+		})
+	}
+}
+
+func TestRecordCleanShutdown_WithoutAMarkerDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	require.NoError(t, RecordCleanShutdown(dataDir, testTargetVersion))
+	assert.NoFileExists(t, markerPath(stateDirFor(dataDir)))
+}
+
+// finalizeTerminalUpdate deletes the binary backup and snapshot, so it must
+// refuse anything that has not actually reached an outcome.
+func TestFinalizeTerminalUpdate_RequiresAnOutcome(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	ops := defaultWatchdogFileOps()
+
+	require.Error(t, finalizeTerminalUpdate(t.Context(), f.dataDir, nil, ops))
+	require.Error(t, finalizeTerminalUpdate(t.Context(), f.dataDir, f.marker(markerConfirming), ops))
+
+	assert.FileExists(t, f.backupPath)
+	assert.FileExists(t, f.snapshotPath)
+}
+
+// A snapshot that fails its integrity check cannot be written over a working
+// database: that would turn a failed update into lost data. The rollback is
+// blocked instead, leaving the new binary and the snapshot for manual recovery.
+func TestRunStartupWatchdog_CorruptSnapshotBlocksRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	ops := defaultWatchdogFileOps()
+	restoreCalls := 0
+	ops.restoreDatabase = func(context.Context, afero.Fs, string, string) error {
+		restoreCalls++
+		return fmt.Errorf("%w: quick_check: page 3 is never used", userdb.ErrInvalidBackup)
+	}
+
+	require.NoError(t, runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, ops))
+	assert.Equal(t, 1, restoreCalls)
+
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.FileExists(t, f.backupPath)
+	assert.FileExists(t, f.snapshotPath, "the snapshot is the only remaining copy of the old data")
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, outcomeRollbackBlocked, m.Outcome)
+}
+
+// An install that never recorded a snapshot leaves nothing to roll the database
+// back to, so the binary must not be rolled back either: an old binary in front
+// of a migrated database is worse than the failed update.
+func TestRunStartupWatchdog_MarkerWithoutASnapshotBlocksRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerConfirming)
+	m.UserDBSnapshotPath = ""
+	require.NoError(t, saveMarker(dir, m))
+
+	ops := defaultWatchdogFileOps()
+	ops.restoreDatabase = func(context.Context, afero.Fs, string, string) error {
+		t.Fatal("a marker with no snapshot must not reach the database restore")
+		return nil
+	}
+
+	require.NoError(t, runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, ops))
+
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.FileExists(t, f.backupPath)
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+
+	blocked, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, blocked)
+	assert.Equal(t, outcomeRollbackBlocked, blocked.Outcome)
+}
+
+// Payload extras have no producer yet, but the rollback already restores them,
+// and the binary has to go last: a failure part way through then leaves the new
+// binary in place, which is the state a blocked rollback can live with.
+func TestRunStartupWatchdog_RestoresPayloadFilesBeforeTheBinary(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	assetDir := t.TempDir()
+	assetPath := filepath.Join(assetDir, "menu.png")
+	assetBackup := filepath.Join(assetDir, ".menu.png.zap-old")
+	require.NoError(t, os.WriteFile(assetPath, []byte("new asset"), 0o600))
+	require.NoError(t, os.WriteFile(assetBackup, []byte("old asset"), 0o600))
+
+	m := f.marker(markerConfirming)
+	m.PayloadBackups = []payloadBackup{{TargetPath: assetPath, BackupPath: assetBackup}}
+	require.NoError(t, saveMarker(dir, m))
+
+	ops := defaultWatchdogFileOps()
+	replace := ops.replace
+	var restored []string
+	ops.replace = func(src, dst string) error {
+		restored = append(restored, dst)
+		return replace(src, dst)
+	}
+
+	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
+	require.ErrorIs(t, err, ErrRolledBack)
+
+	assert.Equal(t, []string{assetPath, f.targetPath}, restored)
+	assert.Equal(t, "old asset", readFileString(t, assetPath))
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, assetBackup, "a restored backup is not left behind")
+}
+
+// A payload entry with no backup recorded cannot be restored, and guessing is
+// not an option: the rollback is blocked before anything moves.
+func TestRunStartupWatchdog_PayloadWithoutABackupBlocksRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerConfirming)
+	m.PayloadBackups = []payloadBackup{{TargetPath: filepath.Join(t.TempDir(), "menu.png")}}
+	require.NoError(t, saveMarker(dir, m))
+
+	require.NoError(t, runStartupWatchdogWithOps(
+		t.Context(), f.dataDir, testTargetVersion, defaultWatchdogFileOps()))
+
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.FileExists(t, f.backupPath)
+	// The database goes back first by design, so a blocked rollback leaves the
+	// new binary in front of the old data rather than the reverse.
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+
+	blocked, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, blocked)
+	assert.Equal(t, outcomeRollbackBlocked, blocked.Outcome)
 }

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -1,0 +1,644 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPrevVersion   = "2.1.0"
+	testTargetVersion = "2.2.0"
+)
+
+func TestDecideWatchdogAction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		marker  *pendingMarker
+		name    string
+		running string
+		want    watchdogAction
+	}{
+		{
+			name:    "no marker",
+			marker:  nil,
+			running: testTargetVersion,
+			want:    actionNone,
+		},
+		{
+			name: "interrupted install still running previous version",
+			marker: &pendingMarker{
+				State: markerInstalling, PreviousVersion: testPrevVersion, TargetVersion: testTargetVersion,
+			},
+			running: testPrevVersion,
+			want:    actionAbortInstall,
+		},
+		{
+			name: "interrupted install running target version",
+			marker: &pendingMarker{
+				State: markerInstalling, PreviousVersion: testPrevVersion, TargetVersion: testTargetVersion,
+			},
+			running: testTargetVersion,
+			want:    actionRollBack,
+		},
+		{
+			name:    "installed and running the target",
+			marker:  &pendingMarker{State: markerInstalled, TargetVersion: testTargetVersion},
+			running: testTargetVersion,
+			want:    actionConfirm,
+		},
+		{
+			name: "installed but still running previous version",
+			marker: &pendingMarker{
+				State: markerInstalled, PreviousVersion: testPrevVersion, TargetVersion: testTargetVersion,
+			},
+			running: testPrevVersion,
+			want:    actionAbortInstall,
+		},
+		{
+			name:    "installed but running something else",
+			marker:  &pendingMarker{State: markerInstalled, TargetVersion: testTargetVersion},
+			running: testPrevVersion,
+			want:    actionRollBack,
+		},
+		{
+			name:    "confirming the running version means the last boot never finished",
+			marker:  &pendingMarker{State: markerConfirming, TargetVersion: testTargetVersion},
+			running: testTargetVersion,
+			want:    actionRollBack,
+		},
+		{
+			name:    "confirming a version that is not running is stale",
+			marker:  &pendingMarker{State: markerConfirming, TargetVersion: testTargetVersion},
+			running: "2.3.0",
+			want:    actionClear,
+		},
+		{
+			name:    "an interrupted rollback resumes",
+			marker:  &pendingMarker{State: markerRollingBack, TargetVersion: testTargetVersion},
+			running: testTargetVersion,
+			want:    actionRollBack,
+		},
+		{
+			name: "a blocked outcome retains recovery files without retrying",
+			marker: &pendingMarker{
+				State: markerRollingBack, TargetVersion: testTargetVersion,
+				Outcome: outcomeRollbackBlocked,
+			},
+			running: testTargetVersion,
+			want:    actionNone,
+		},
+		{
+			name: "a succeeded outcome resumes terminal cleanup",
+			marker: &pendingMarker{
+				State: markerConfirming, TargetVersion: testTargetVersion,
+				Outcome: outcomeSucceeded,
+			},
+			running: testTargetVersion,
+			want:    actionFinalize,
+		},
+		{
+			name: "a rolled back outcome resumes terminal cleanup",
+			marker: &pendingMarker{
+				State: markerRollingBack, TargetVersion: testTargetVersion,
+				Outcome: outcomeRolledBack,
+			},
+			running: testPrevVersion,
+			want:    actionFinalize,
+		},
+		{
+			name:    "an unrecognised state cannot direct a rollback",
+			marker:  &pendingMarker{State: "sideways", TargetVersion: testTargetVersion},
+			running: testTargetVersion,
+			want:    actionClear,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, decideWatchdogAction(tt.marker, tt.running))
+		})
+	}
+}
+
+// installFixture is a device mid-update: the new binary installed over the old
+// one, the old one kept beside it, and a snapshot of the database as it was
+// before any of it happened.
+type installFixture struct {
+	dataDir      string
+	dbPath       string
+	targetPath   string
+	backupPath   string
+	snapshotPath string
+	stagingDir   string
+}
+
+func newInstallFixture(t *testing.T) *installFixture {
+	t.Helper()
+
+	dataDir := t.TempDir()
+	binDir := t.TempDir()
+
+	f := &installFixture{
+		dataDir:    dataDir,
+		dbPath:     filepath.Join(dataDir, config.UserDbFile),
+		targetPath: filepath.Join(binDir, "zaparoo"),
+		backupPath: filepath.Join(binDir, ".zaparoo.zap-old-"+testPrevVersion),
+		snapshotPath: filepath.Join(dataDir, "backups",
+			"backup-20260818-043000-000000001-update.db"),
+		stagingDir: filepath.Join(stagingRootFor(dataDir), testTargetVersion),
+	}
+
+	//nolint:gosec // stand-ins for an executable, which is what the mode is for
+	require.NoError(t, os.WriteFile(f.targetPath, []byte("new binary"), 0o755))
+	//nolint:gosec // stand-ins for an executable, which is what the mode is for
+	require.NoError(t, os.WriteFile(f.backupPath, []byte("old binary"), 0o755))
+	require.NoError(t, os.MkdirAll(f.stagingDir, stateDirPerm))
+
+	writeTestDB(t, f.dbPath, "after the update")
+	writeTestDB(t, f.snapshotPath, "before the update")
+	return f
+}
+
+// marker returns the record the install would have left, in the given state.
+func (f *installFixture) marker(state markerState) *pendingMarker {
+	return &pendingMarker{
+		State:              state,
+		Trigger:            triggerManual,
+		TargetPath:         f.targetPath,
+		BackupPath:         f.backupPath,
+		StagingDir:         f.stagingDir,
+		PreviousVersion:    testPrevVersion,
+		TargetVersion:      testTargetVersion,
+		PlatformID:         "mister",
+		UserDBSnapshotPath: f.snapshotPath,
+	}
+}
+
+func writeTestDB(t *testing.T, path, note string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := t.Context()
+	_, err = db.ExecContext(ctx, `CREATE TABLE note (text TEXT)`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO note (text) VALUES (?)`, note)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func readTestDBNote(t *testing.T, path string) string {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", path+"?mode=ro")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var note string
+	require.NoError(t, db.QueryRowContext(t.Context(), `SELECT text FROM note`).Scan(&note))
+	return note
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-owned path
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestRunStartupWatchdog_NoMarker(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), t.TempDir(), testTargetVersion))
+}
+
+func TestRunStartupWatchdog_ConfirmsFirstBoot(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerInstalled)))
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion))
+
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, markerConfirming, m.State)
+	assert.Equal(t, 1, m.Attempts)
+
+	// Nothing is reclaimed while the update is still being judged.
+	assert.FileExists(t, f.snapshotPath)
+	assert.FileExists(t, f.backupPath)
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+}
+
+func TestRunStartupWatchdog_RollsBackWhenConfirmationNeverHappened(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	err := RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, f.backupPath)
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoDirExists(t, f.stagingDir)
+	assert.NoFileExists(t, f.snapshotPath)
+
+	res := peekUpdateResult(dir)
+	require.NotNil(t, res)
+	assert.Equal(t, outcomeRolledBack, res.Outcome)
+	assert.Equal(t, testPrevVersion, res.FromVersion)
+	assert.Equal(t, testTargetVersion, res.ToVersion)
+}
+
+// A rollback interrupted after the binary was swapped but before the marker was
+// cleared has to finish, not start again from a backup that is no longer there.
+func TestRunStartupWatchdog_ResumesInterruptedRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerRollingBack)
+	m.RestoringPath = f.targetPath
+	require.NoError(t, saveMarker(dir, m))
+	require.NoError(t, replaceFile(f.backupPath, f.targetPath))
+
+	err := RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+	assert.NoFileExists(t, markerPath(dir))
+}
+
+// The same missing backup on a rollback that has not started yet is a real
+// failure: reporting success would strand the device on the broken version.
+func TestRunStartupWatchdog_MissingBinaryBackupBlocksRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+	require.NoError(t, os.Remove(f.backupPath))
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion))
+
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, outcomeRollbackBlocked, m.Outcome)
+
+	res := peekUpdateResult(dir)
+	require.NotNil(t, res)
+	assert.Equal(t, outcomeRollbackBlocked, res.Outcome)
+	assert.NotEmpty(t, res.Detail)
+}
+
+func TestRunStartupWatchdog_KeepsTheSnapshotOfAnAbandonedRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerRollingBack)
+	m.Outcome = outcomeRollbackBlocked
+	require.NoError(t, saveMarker(dir, m))
+
+	stale := filepath.Join(filepath.Dir(f.snapshotPath),
+		"backup-20260817-043000-000000009-update.db")
+	writeTestDB(t, stale, "some older update")
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion))
+
+	// The rollback was already given up on, so nothing may be retried: the
+	// marker, the new binary and the database all stay exactly as they were.
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+	got, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, outcomeRollbackBlocked, got.Outcome)
+
+	// The snapshot is the only way back the user has left, and the inbox message
+	// sends them to it, so the sweep must not take it. Snapshots nothing points
+	// at still go.
+	assert.FileExists(t, f.snapshotPath)
+	assert.NoFileExists(t, stale)
+}
+
+func TestRunStartupWatchdog_MissingSnapshotBlocksRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+	require.NoError(t, os.Remove(f.snapshotPath))
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion))
+
+	// Nothing moved: the database restore is the first step for exactly this
+	// reason, so an old binary is never left in front of a migrated database.
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.FileExists(t, f.backupPath)
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, outcomeRollbackBlocked, m.Outcome)
+
+	// A blocked rollback is terminal, so the next boot leaves it alone.
+	assert.Equal(t, actionNone, decideWatchdogAction(m, testTargetVersion))
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, testTargetVersion))
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+}
+
+func TestRunStartupWatchdog_ClearsMarkerForAnotherVersion(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	require.NoError(t, RunStartupWatchdog(context.Background(), f.dataDir, "2.4.0"))
+
+	assert.NoFileExists(t, markerPath(dir))
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, f.snapshotPath)
+}
+
+func TestConfirm(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	version, err := Confirm(context.Background(), f.dataDir, testTargetVersion)
+	require.NoError(t, err)
+	assert.Equal(t, testTargetVersion, version)
+
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.backupPath)
+	assert.NoFileExists(t, f.snapshotPath)
+	assert.NoDirExists(t, f.stagingDir)
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+
+	res := peekUpdateResult(dir)
+	require.NotNil(t, res)
+	assert.Equal(t, outcomeSucceeded, res.Outcome)
+	assert.Equal(t, testPrevVersion, res.FromVersion)
+	assert.Equal(t, testTargetVersion, res.ToVersion)
+}
+
+func TestConfirm_RetriesFailedBinaryBackupCleanup(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+	require.NoError(t, os.Remove(f.backupPath))
+	require.NoError(t, os.Mkdir(f.backupPath, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(f.backupPath, "locked"), []byte("x"), 0o600))
+
+	version, err := Confirm(t.Context(), f.dataDir, testTargetVersion)
+	require.Error(t, err)
+	assert.Equal(t, testTargetVersion, version)
+
+	m, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, m)
+	assert.Equal(t, outcomeSucceeded, m.Outcome)
+	assert.FileExists(t, f.snapshotPath)
+
+	require.NoError(t, os.RemoveAll(f.backupPath))
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.snapshotPath)
+}
+
+func TestConfirm_IgnoresAMarkerItDoesNotOwn(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerInstalled)))
+
+	// Still installed rather than confirming: the watchdog has not run.
+	version, err := Confirm(context.Background(), f.dataDir, testTargetVersion)
+	require.NoError(t, err)
+	assert.Empty(t, version)
+	assert.FileExists(t, markerPath(dir))
+
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+	version, err = Confirm(context.Background(), f.dataDir, "9.9.9")
+	require.NoError(t, err)
+	assert.Empty(t, version)
+	assert.FileExists(t, markerPath(dir))
+}
+
+func TestRollBackFailedStart(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	err := RollBackFailedStart(context.Background(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+}
+
+func TestRollBackFailedStart_NothingPending(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	require.NoError(t, RollBackFailedStart(context.Background(), f.dataDir, testTargetVersion))
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+
+	// A marker for a version this process is not running belongs to someone else.
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+	require.NoError(t, RollBackFailedStart(context.Background(), f.dataDir, "2.4.0"))
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+}
+
+func TestRecordCleanShutdown_RestartsConfirmationWithoutRollback(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	require.NoError(t, RecordCleanShutdown(f.dataDir, testTargetVersion))
+	m, err := loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, markerInstalled, m.State)
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	m, err = loadMarker(dir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, markerConfirming, m.State)
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+}
+
+func TestRunStartupWatchdog_RetriesTransientRestoreFailure(t *testing.T) {
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	require.NoError(t, os.Remove(f.snapshotPath))
+	require.NoError(t, os.Mkdir(f.snapshotPath, 0o750))
+
+	err := RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrRolledBack)
+
+	m, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, m)
+	assert.Equal(t, markerRollingBack, m.State)
+	assert.Empty(t, m.Outcome)
+	assert.FileExists(t, f.backupPath)
+
+	require.NoError(t, os.Remove(f.snapshotPath))
+	writeTestDB(t, f.snapshotPath, "before the update")
+
+	err = RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+}
+
+func TestRunStartupWatchdog_UnusableMarkerRetainsSnapshots(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+	require.NoError(t, os.WriteFile(markerPath(dir), []byte("{not json"), stateFilePerm))
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	assert.FileExists(t, f.snapshotPath)
+	assert.FileExists(t, markerPath(dir)+markerBadSuffix)
+
+	// A later boot still sees the quarantined evidence and must not treat the
+	// marker as confirmed absent.
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	assert.FileExists(t, f.snapshotPath)
+}
+
+func TestRunStartupWatchdog_FinalizesDurableSuccess(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	m := f.marker(markerConfirming)
+	m.Outcome = outcomeSucceeded
+	m.OutcomeAt = time.Date(2026, 8, 18, 5, 0, 0, 0, time.UTC)
+	require.NoError(t, saveMarker(dir, m))
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.backupPath)
+	assert.NoFileExists(t, f.snapshotPath)
+	assert.NoDirExists(t, f.stagingDir)
+	assert.Equal(t, "new binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+
+	res := peekUpdateResult(dir)
+	require.NotNil(t, res)
+	assert.Equal(t, outcomeSucceeded, res.Outcome)
+	assert.Equal(t, testPrevVersion, res.FromVersion)
+	assert.Equal(t, testTargetVersion, res.ToVersion)
+}
+
+func TestRunStartupWatchdog_AbortsInterruptedInstallWithoutRestoringDB(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerInstalling)))
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testPrevVersion))
+
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.snapshotPath)
+	assert.NoDirExists(t, f.stagingDir)
+}
+
+func TestSweepUpdateSnapshots(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	backups := filepath.Join(dataDir, "backups")
+	require.NoError(t, os.MkdirAll(backups, 0o750))
+
+	keep := filepath.Join(backups, "backup-20260818-043000-000000001-update.db")
+	stale := filepath.Join(backups, "backup-20260817-043000-000000001-update.db")
+	auto := filepath.Join(backups, "backup-20260817-043000-000000002-auto.db")
+	manual := filepath.Join(backups, "backup-20260817-043000-000000003-manual.db")
+	for _, path := range []string{keep, stale, auto, manual} {
+		require.NoError(t, os.WriteFile(path, []byte("db"), 0o600))
+	}
+
+	sweepUpdateSnapshots(dataDir, keep)
+
+	assert.FileExists(t, keep)
+	assert.NoFileExists(t, stale)
+	assert.FileExists(t, auto)
+	assert.FileExists(t, manual)
+
+	sweepUpdateSnapshots(dataDir, "")
+	assert.NoFileExists(t, keep)
+	assert.FileExists(t, auto)
+	assert.FileExists(t, manual)
+}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -785,6 +785,24 @@ func (m *MockUserDBI) Backup(reason string, manual bool) (database.BackupInfo, e
 	return info, nil
 }
 
+func (m *MockUserDBI) BackupForUpdate(
+	targetVersion string,
+) (database.BackupInfo, func() error, error) {
+	args := m.Called(targetVersion)
+	info, ok := args.Get(0).(database.BackupInfo)
+	if !ok {
+		return database.BackupInfo{}, nil, errors.New("mock UserDBI update backup returned invalid backup info")
+	}
+	resume, ok := args.Get(1).(func() error)
+	if !ok {
+		return info, nil, errors.New("mock UserDBI update backup returned invalid resume function")
+	}
+	if err := args.Error(2); err != nil {
+		return info, resume, fmt.Errorf("mock UserDBI update backup failed: %w", err)
+	}
+	return info, resume, nil
+}
+
 func (m *MockUserDBI) BackupForTransfer(
 	ctx context.Context, reason string,
 ) (database.BackupInfo, func() error, error) {


### PR DESCRIPTION
## Summary

- install verified update candidates with durable rollback binaries and atomic target replacement
- quiesce and snapshot UserDB before install, then confirm or roll back from an early startup watchdog
- persist update outcomes, retry interrupted cleanup, and report results without losing transient failures
- prevent concurrent applies and media activity from racing database quiescence

## Operational notes

Automatic installation remains disabled. Real-device migration-crossing rollback validation remains a release gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged application updates with verified releases, database snapshots, rollback protection, and startup recovery.
  * Updates now report status and confirm successful installations after healthy runtime.
  * Added safeguards against concurrent updates and updates while media is active.
  * Failed rollbacks can automatically restart the restored application.
* **Bug Fixes**
  * Improved recovery from interrupted or failed updates across supported platforms.
  * Enhanced backup retention, corruption detection, validation, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->