### PR TITLE
feat(updater): preflight disk space and platform support before installing

### DIFF
--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -169,6 +169,10 @@ func HandleUpdateApply(
 		// part the user can act on.
 		return nil, models.ClientErrf("%s", err.Error())
 	}
+	if errors.Is(err, updater.ErrPlatformUnsupported) {
+		// The error already says what to do instead.
+		return nil, models.ClientErrf("%s", err.Error())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("update apply failed: %w", err)
 	}

--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -164,6 +164,11 @@ func HandleUpdateApply(
 	if errors.Is(err, updater.ErrUpdateInProgress) {
 		return nil, models.ClientErrf("update already in progress")
 	}
+	if errors.Is(err, updater.ErrInsufficientSpace) {
+		// The error names the directory and the shortfall, which is the only
+		// part the user can act on.
+		return nil, models.ClientErrf("%s", err.Error())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("update apply failed: %w", err)
 	}

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -319,6 +319,27 @@ func TestHandleUpdateApply_InsufficientSpace(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestHandleUpdateApply_PlatformUnsupported(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+	}
+	applyFn := func(context.Context, updater.Options) (string, error) {
+		return "", fmt.Errorf("%w: use the Windows installer instead", updater.ErrPlatformUnsupported)
+	}
+
+	result, err := HandleUpdateApply(env, applyFn, func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "this platform cannot install updates in place")
+	assert.Contains(t, err.Error(), "use the Windows installer instead")
+	assert.Nil(t, result)
+}
+
 func TestHandleUpdateApply_ActiveMedia(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -22,6 +22,7 @@ package methods
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -291,6 +292,30 @@ func TestHandleUpdateApply_UpdateInProgress(t *testing.T) {
 	result, err := HandleUpdateApply(env, applyFn, func() {})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "update already in progress")
+	assert.Nil(t, result)
+}
+
+// A full disk is the user's problem to fix, so the directory and the shortfall
+// have to survive into the client error rather than being wrapped away.
+func TestHandleUpdateApply_InsufficientSpace(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+	}
+	applyFn := func(context.Context, updater.Options) (string, error) {
+		return "", fmt.Errorf("%w: /media/fat has 12 MB free, need at least 90 MB",
+			updater.ErrInsufficientSpace)
+	}
+
+	result, err := HandleUpdateApply(env, applyFn, func() {})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "insufficient disk space for the update")
+	assert.Contains(t, err.Error(), "/media/fat has 12 MB free, need at least 90 MB")
 	assert.Nil(t, result)
 }
 

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -281,7 +281,7 @@ func prepareInstallCandidate(
 
 	// Probe again after copying because staging and the live install can be on
 	// different filesystems with different execution and permission semantics.
-	probe := &stager{platformID: platformID, probeTimeout: probeTimeout}
+	probe := newProbeStager(platformID)
 	if err := probe.probeBinary(ctx, candidatePath, version); err != nil {
 		_ = os.Remove(candidatePath)
 		return fmt.Errorf("probing the install candidate on the target filesystem: %w", err)

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -102,11 +102,7 @@ func (f *installStagedFixture) blockStateDir(t *testing.T) {
 	t.Helper()
 	dir := stateDirFor(f.dataDir)
 	require.NoError(t, os.MkdirAll(dir, stateDirPerm))
-	//nolint:gosec // an unwritable-but-readable directory is the failure under test
-	require.NoError(t, os.Chmod(dir, 0o500))
-	t.Cleanup(func() {
-		_ = os.Chmod(dir, stateDirPerm)
-	})
+	makeDirUnwritable(t, dir)
 }
 
 // assertInstallUndone checks that a failed install left the machine exactly as
@@ -424,9 +420,7 @@ func TestInstallStaged_RefusesWhenTheMarkerIsUnreadable(t *testing.T) {
 // binary is swapped. If it cannot be written the install must undo itself
 // completely instead of running a new binary nothing is watching.
 func TestInstallStaged_UndoesEverythingWhenTheMarkerCannotBeArmed(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("permission bits are not enforced for root")
-	}
+	skipUnlessDirPermsEnforced(t)
 
 	f := newInstallStagedFixture(t)
 	f.blockStateDir(t)
@@ -446,9 +440,7 @@ func TestInstallStaged_UndoesEverythingWhenTheMarkerCannotBeArmed(t *testing.T) 
 // so that failure has to reach the caller alongside the install failure rather
 // than being lost behind it.
 func TestInstallStaged_ReportsAFailedDatabaseReopen(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("permission bits are not enforced for root")
-	}
+	skipUnlessDirPermsEnforced(t)
 
 	f := newInstallStagedFixture(t)
 	f.blockStateDir(t)

--- a/pkg/service/updater/integration_test.go
+++ b/pkg/service/updater/integration_test.go
@@ -1,0 +1,430 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	selfupdate "github.com/creativeprojects/go-selfupdate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The unit tests in this package each hold one stage still and drive it with
+// stand-ins. These drive the whole chain — signed manifest, real archive over
+// HTTP, real binary swap, real SQLite user database — because the failures worth
+// catching here live in the seams: a snapshot taken of the wrong file, a
+// rollback that restores a binary but not the database it has to open, a
+// database migrated past what the restored binary understands. None of those are
+// visible from inside a single stage.
+
+const (
+	// otaManifestGeneration is any value above zero; the watermark itself is
+	// covered by the source tests.
+	otaManifestGeneration = 7
+
+	// otaOutgoingBinary stands in for the running executable. It is deliberately
+	// not the fake release binary: after a rollback the target has to be shown to
+	// be the old file and not the new one, and two identical files cannot show
+	// that. Nothing in the chain executes the outgoing binary — only the staged
+	// candidate is probed — so its contents are free.
+	otaOutgoingBinary = "outgoing zaparoo build 2.10.1"
+
+	otaSeedKey   = "integration-seed"
+	otaSeedValue = "written before the update"
+)
+
+// otaHarness is one device: a data directory holding the user database, the
+// updater's state and the backups, an install directory holding the binary, and
+// the two servers a release arrives from.
+type otaHarness struct {
+	userDB     *userdb.UserDB
+	ms         *manifestServer
+	archive    *otameta.Asset
+	dataDir    string
+	targetPath string
+}
+
+func newOTAHarness(t *testing.T) *otaHarness {
+	t.Helper()
+
+	// The data directory is the platform's, so the user database, the updater
+	// state directory and the backup directory sit where production puts them
+	// relative to each other.
+	dataDir := t.TempDir()
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{DataDir: dataDir})
+
+	db, err := userdb.OpenUserDB(t.Context(), pl)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.Equal(t, filepath.Join(dataDir, config.UserDbFile), db.GetDBPath(),
+		"the harness only proves anything if the updater and the database agree on the data directory")
+	require.NoError(t, db.SetDeviceState(otaSeedKey, otaSeedValue))
+
+	targetPath := filepath.Join(t.TempDir(), testBinaryName("zaparoo"))
+	//nolint:gosec // an executable stand-in owned by this test
+	require.NoError(t, os.WriteFile(targetPath, []byte(otaOutgoingBinary), 0o755))
+
+	archive := servedAsset(t, testArchiveName(testStageVersion, otameta.ArchiveExtTarGz),
+		releaseArchive(t, otameta.ArchiveExtTarGz, testBinaryName("zaparoo"), fakeBinaryBytes(t)))
+
+	return &otaHarness{
+		dataDir:    dataDir,
+		targetPath: targetPath,
+		userDB:     db,
+		archive:    archive,
+		ms:         newManifestServer(t, otaReleaseManifest(otaManifestGeneration, archive)),
+	}
+}
+
+// otaReleaseManifest is the document the CDN serves: one stable release whose
+// archive lives on another host entirely, which is how the published manifest
+// refers to release assets.
+func otaReleaseManifest(generation int64, archive *otameta.Asset) string {
+	return fmt.Sprintf(`manifest_version: 1
+generation: %d
+issued_at: 2026-08-17T02:00:00Z
+key_id: test1
+last_release_id: 1
+last_asset_id: 3
+releases:
+  - id: 1
+    name: v%[2]s
+    tag_name: v%[2]s
+    channel: stable
+    published_at: 2026-08-10T00:00:00Z
+    release_notes: integration release
+    assets:
+      - id: 1
+        name: %[3]s
+        size: %[4]d
+        sha256: %[5]s
+        url: %[6]s
+      - id: 2
+        name: checksums.txt
+        url: checksums.txt
+      - id: 3
+        name: checksums.txt.sig
+        url: checksums.txt.sig
+`, generation, testStageVersion, archive.Name, archive.Size, archive.SHA256, archive.URL)
+}
+
+// detect runs the same detection Apply runs: list the signed manifest through
+// go-selfupdate, then take the release back out of the manifest rather than
+// trusting what go-selfupdate handed back.
+func (h *otaHarness) detect(t *testing.T) (*verifiedSource, *otameta.Release) {
+	t.Helper()
+
+	src := h.ms.source(stateDirFor(h.dataDir), testStagePlatform, testStageArch)
+	up, err := selfupdate.NewUpdater(selfupdate.Config{
+		Source:    src,
+		Validator: newSignedChecksumValidator(src.key),
+		Filters:   []string{assetFilter(testStagePlatform, testStageArch)},
+	})
+	require.NoError(t, err)
+
+	release, found, err := up.DetectLatest(t.Context(), testRepo())
+	require.NoError(t, err)
+	require.True(t, found, "the manifest offers a release for this platform")
+	require.Equal(t, testStageVersion, release.Version())
+
+	manifestRelease, err := src.releaseForVersion(release.Version())
+	require.NoError(t, err)
+	return src, manifestRelease
+}
+
+// install runs detection, staging and the install, leaving the watchdog armed
+// exactly as a real apply does just before the service restarts.
+func (h *otaHarness) install(t *testing.T) *StagedUpdate {
+	t.Helper()
+
+	src, manifestRelease := h.detect(t)
+	staged, err := stageRelease(t.Context(), &StageOptions{
+		Release:        manifestRelease,
+		PlatformID:     testStagePlatform,
+		Arch:           testStageArch,
+		OS:             "linux",
+		TargetPath:     h.targetPath,
+		StagingRoot:    stagingRootFor(h.dataDir),
+		CurrentVersion: testCurrentVersion,
+	}, testAssetFetcher(t))
+	require.NoError(t, err)
+	require.Equal(t, testStageVersion, staged.Version)
+
+	require.NoError(t, installStaged(t.Context(), &installOptions{
+		Staged:             staged,
+		UserDB:             h.userDB,
+		TargetPath:         h.targetPath,
+		DataDir:            h.dataDir,
+		PreviousVersion:    testCurrentVersion,
+		PlatformID:         testStagePlatform,
+		ManifestGeneration: src.manifestGeneration(),
+		Trigger:            triggerManual,
+	}))
+	return staged
+}
+
+// marker reads what is on disk rather than what a call returned, because the
+// marker is the only thing the next boot gets to see.
+func (h *otaHarness) marker(t *testing.T) *pendingMarker {
+	t.Helper()
+
+	m, err := loadMarker(stateDirFor(h.dataDir))
+	require.NoError(t, err)
+	return m
+}
+
+func (h *otaHarness) result(t *testing.T) *updateResult {
+	t.Helper()
+
+	res := peekUpdateResult(stateDirFor(h.dataDir))
+	require.NotNil(t, res, "a finished update has to leave something for the next boot to report")
+	return res
+}
+
+// reopenUserDB opens the database the way a booting binary does, migrations and
+// all, so a schema the restored build cannot handle fails here rather than
+// silently passing.
+func (h *otaHarness) reopenUserDB(t *testing.T) *userdb.UserDB {
+	t.Helper()
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{DataDir: h.dataDir})
+	db, err := userdb.OpenUserDB(t.Context(), pl)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func assertSeedIntact(t *testing.T, db *userdb.UserDB) {
+	t.Helper()
+
+	value, found, err := db.GetDeviceState(otaSeedKey)
+	require.NoError(t, err)
+	require.True(t, found, "the row written before the update has to survive")
+	assert.Equal(t, otaSeedValue, value)
+}
+
+// openRawUserDB opens the database file directly. The updater closes the live
+// pool for the snapshot and does not reopen it, so anything acting as the newly
+// installed version has to bring its own connection.
+func openRawUserDB(t *testing.T, dataDir string) *sql.DB {
+	t.Helper()
+
+	raw, err := sql.Open("sqlite3", filepath.Join(dataDir, config.UserDbFile))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+	return raw
+}
+
+// TestOTA_InstallsAVerifiedReleaseAndConfirmsIt walks a release from a signed
+// manifest onto the target path and through the confirmation the next boot
+// performs, then checks that nothing the update needed is still on disk.
+func TestOTA_InstallsAVerifiedReleaseAndConfirmsIt(t *testing.T) {
+	t.Parallel()
+
+	h := newOTAHarness(t)
+	staged := h.install(t)
+
+	installed, err := os.ReadFile(h.targetPath) //nolint:gosec // path owned by this test
+	require.NoError(t, err)
+	assert.Equal(t, fakeBinaryBytes(t), installed, "the target has to be the staged release binary")
+
+	armed := h.marker(t)
+	require.NotNil(t, armed, "the install has to arm the watchdog before the service restarts")
+	assert.Equal(t, markerInstalled, armed.State)
+	assert.Equal(t, testCurrentVersion, armed.PreviousVersion)
+	assert.Equal(t, testStageVersion, armed.TargetVersion)
+	assert.Equal(t, int64(otaManifestGeneration), armed.ManifestGeneration)
+	assert.FileExists(t, armed.BackupPath, "rollback needs the outgoing binary kept")
+	assert.FileExists(t, armed.UserDBSnapshotPath, "rollback needs the pre-update database kept")
+
+	// First boot of the new version.
+	require.NoError(t, RunStartupWatchdog(t.Context(), h.dataDir, testStageVersion))
+	assert.Equal(t, markerConfirming, h.marker(t).State)
+
+	confirmed, err := Confirm(t.Context(), h.dataDir, testStageVersion)
+	require.NoError(t, err)
+	assert.Equal(t, testStageVersion, confirmed)
+
+	assert.Nil(t, h.marker(t), "a confirmed update leaves no marker for the next boot")
+	assert.NoFileExists(t, armed.BackupPath)
+	assert.NoFileExists(t, armed.UserDBSnapshotPath)
+	assert.NoFileExists(t, installSidecarPath(h.targetPath, installCandidateSuffix))
+	assert.NoDirExists(t, staged.Dir, "the staged payload is dead weight once the update is confirmed")
+
+	res := h.result(t)
+	assert.Equal(t, outcomeSucceeded, res.Outcome)
+	assert.Equal(t, testCurrentVersion, res.FromVersion)
+	assert.Equal(t, testStageVersion, res.ToVersion)
+
+	assertSeedIntact(t, h.reopenUserDB(t))
+}
+
+// TestOTA_RollsBackAVersionThatNeverConfirms is the failure the whole mechanism
+// exists for: the new binary starts, writes to the database, and then never
+// survives startup. Both the binary and the database have to go back.
+func TestOTA_RollsBackAVersionThatNeverConfirms(t *testing.T) {
+	t.Parallel()
+
+	h := newOTAHarness(t)
+	staged := h.install(t)
+	armed := h.marker(t)
+	require.NotNil(t, armed)
+
+	// First boot of the new version: it gets as far as confirming.
+	require.NoError(t, RunStartupWatchdog(t.Context(), h.dataDir, testStageVersion))
+
+	// ...and then writes something before dying, which the rollback must undo
+	// along with the binary.
+	newVersionDB := h.reopenUserDB(t)
+	require.NoError(t, newVersionDB.SetDeviceState("written-by-the-new-version", "1"))
+	require.NoError(t, newVersionDB.Close())
+
+	// Second boot: still the new version, still unconfirmed.
+	err := RunStartupWatchdog(t.Context(), h.dataDir, testStageVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	restartInto, ok := RollbackTargetPath(err)
+	require.True(t, ok, "the caller has to be told which binary to re-exec")
+	assert.Equal(t, h.targetPath, restartInto)
+
+	assert.Equal(t, otaOutgoingBinary, readFileString(t, h.targetPath),
+		"the target has to be the outgoing binary again, byte for byte")
+	assert.Nil(t, h.marker(t))
+	assert.NoFileExists(t, armed.BackupPath)
+	assert.NoFileExists(t, armed.UserDBSnapshotPath)
+	assert.NoDirExists(t, staged.Dir)
+
+	res := h.result(t)
+	assert.Equal(t, outcomeRolledBack, res.Outcome)
+	assert.Equal(t, testStageVersion, res.ToVersion)
+	assert.Equal(t, testCurrentVersion, res.FromVersion)
+
+	restored := h.reopenUserDB(t)
+	assertSeedIntact(t, restored)
+	_, found, err := restored.GetDeviceState("written-by-the-new-version")
+	require.NoError(t, err)
+	assert.False(t, found, "writes made by the version being rolled back must not survive it")
+}
+
+// TestOTA_RollsBackAcrossASchemaMigration is the case that decides whether a
+// rollback is worth having at all. A new version that migrates the user database
+// and then fails leaves a schema the restored binary refuses to open, and a
+// device with no supervisor cannot recover from that by itself. The snapshot is
+// the only thing standing between the two.
+func TestOTA_RollsBackAcrossASchemaMigration(t *testing.T) {
+	t.Parallel()
+
+	h := newOTAHarness(t)
+	h.install(t)
+	require.NoError(t, RunStartupWatchdog(t.Context(), h.dataDir, testStageVersion))
+
+	// Stand in for a migration the incoming release carries and this build does
+	// not: goose records nothing but the version, so a row above the highest
+	// embedded migration is exactly what a newer binary leaves behind.
+	raw := openRawUserDB(t, h.dataDir)
+	var applied int64
+	require.NoError(t, raw.QueryRowContext(t.Context(),
+		"SELECT MAX(version_id) FROM goose_db_version").Scan(&applied))
+	_, err := raw.ExecContext(t.Context(),
+		"INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, 1)", applied+1)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	// The premise, asserted rather than assumed: without the rollback this
+	// database is one the outgoing build will not open.
+	crossed := h.reopenUserDB(t)
+	require.ErrorIs(t, crossed.MigrateUp(), database.ErrSchemaAhead,
+		"the test only means something if the crossed schema really does lock this build out")
+	require.NoError(t, crossed.Close())
+
+	require.ErrorIs(t, RunStartupWatchdog(t.Context(), h.dataDir, testStageVersion), ErrRolledBack)
+
+	restored := h.reopenUserDB(t)
+	require.NoError(t, restored.MigrateUp(),
+		"the restored snapshot has to be a database the outgoing build can migrate and open")
+	assertSeedIntact(t, restored)
+}
+
+// TestOTA_ReopensTheUserDatabaseWhenTheInstallFails covers the one thing a
+// stand-in backupper cannot: BackupForUpdate closes the live connection pool,
+// and an install that fails after that point owes the running service a working
+// database back.
+func TestOTA_ReopensTheUserDatabaseWhenTheInstallFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+	t.Parallel()
+
+	h := newOTAHarness(t)
+	src, manifestRelease := h.detect(t)
+	staged, err := stageRelease(t.Context(), &StageOptions{
+		Release:        manifestRelease,
+		PlatformID:     testStagePlatform,
+		Arch:           testStageArch,
+		OS:             "linux",
+		TargetPath:     h.targetPath,
+		StagingRoot:    stagingRootFor(h.dataDir),
+		CurrentVersion: testCurrentVersion,
+	}, testAssetFetcher(t))
+	require.NoError(t, err)
+
+	// Readable so the install still gets as far as taking the snapshot, and
+	// unwritable so arming the marker is what fails.
+	stateDir := stateDirFor(h.dataDir)
+	require.NoError(t, os.MkdirAll(stateDir, stateDirPerm))
+	//nolint:gosec // an unwritable-but-readable directory is the failure under test
+	require.NoError(t, os.Chmod(stateDir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(stateDir, stateDirPerm) })
+
+	installErr := installStaged(t.Context(), &installOptions{
+		Staged:             staged,
+		UserDB:             h.userDB,
+		TargetPath:         h.targetPath,
+		DataDir:            h.dataDir,
+		PreviousVersion:    testCurrentVersion,
+		PlatformID:         testStagePlatform,
+		ManifestGeneration: src.manifestGeneration(),
+		Trigger:            triggerManual,
+	})
+	require.Error(t, installErr)
+	assert.NotContains(t, installErr.Error(), "reopening user database",
+		"the install failed, but reopening the database it closed must not have")
+
+	assert.Equal(t, otaOutgoingBinary, readFileString(t, h.targetPath),
+		"a failed install leaves the running binary exactly where it was")
+	assert.NoFileExists(t, installSidecarPath(h.targetPath, installBackupSuffix))
+	assert.NoFileExists(t, installSidecarPath(h.targetPath, installCandidateSuffix))
+
+	require.NoError(t, h.userDB.SetDeviceState("after-the-failed-install", "1"),
+		"the service carries on running, so its database has to be usable again")
+	assertSeedIntact(t, h.userDB)
+}

--- a/pkg/service/updater/integration_test.go
+++ b/pkg/service/updater/integration_test.go
@@ -379,9 +379,7 @@ func TestOTA_RollsBackAcrossASchemaMigration(t *testing.T) {
 // and an install that fails after that point owes the running service a working
 // database back.
 func TestOTA_ReopensTheUserDatabaseWhenTheInstallFails(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("permission bits are not enforced for root")
-	}
+	skipUnlessDirPermsEnforced(t)
 	t.Parallel()
 
 	h := newOTAHarness(t)
@@ -401,9 +399,7 @@ func TestOTA_ReopensTheUserDatabaseWhenTheInstallFails(t *testing.T) {
 	// unwritable so arming the marker is what fails.
 	stateDir := stateDirFor(h.dataDir)
 	require.NoError(t, os.MkdirAll(stateDir, stateDirPerm))
-	//nolint:gosec // an unwritable-but-readable directory is the failure under test
-	require.NoError(t, os.Chmod(stateDir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(stateDir, stateDirPerm) })
+	makeDirUnwritable(t, stateDir)
 
 	installErr := installStaged(t.Context(), &installOptions{
 		Staged:             staged,

--- a/pkg/service/updater/platform.go
+++ b/pkg/service/updater/platform.go
@@ -1,0 +1,48 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrPlatformUnsupported is returned when this build cannot finish an install
+// no matter how the release turns out.
+var ErrPlatformUnsupported = errors.New("this platform cannot install updates in place")
+
+// preflightPlatform refuses an install this build cannot complete.
+//
+// Windows locks the running image, so MoveFileEx cannot replace the executable
+// from inside the process being replaced. Without the exit-time helper the
+// install runs all the way to the replacement and fails there, which is after
+// the archive has been downloaded and after the user database has been
+// snapshotted and quiesced. The failure unwinds safely, but it costs the user
+// a download and a restart-shaped scare to learn something knowable up front.
+func preflightPlatform(goos string) error {
+	if goos == "windows" {
+		return fmt.Errorf(
+			"%w: replacing a running Windows executable needs a helper Core does not ship yet, "+
+				"so install this release with the Windows installer instead",
+			ErrPlatformUnsupported,
+		)
+	}
+	return nil
+}

--- a/pkg/service/updater/platform_test.go
+++ b/pkg/service/updater/platform_test.go
@@ -1,0 +1,46 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Windows fails at the replacement, which is after the download and after the
+// database snapshot, so the guard has to answer before any of that is spent.
+func TestPreflightPlatform_RefusesWindows(t *testing.T) {
+	t.Parallel()
+
+	err := preflightPlatform("windows")
+	require.ErrorIs(t, err, ErrPlatformUnsupported)
+	assert.Contains(t, err.Error(), "Windows installer",
+		"the message has to say what to do instead")
+}
+
+func TestPreflightPlatform_AllowsPlatformsThatReplaceTheirOwnBinary(t *testing.T) {
+	t.Parallel()
+
+	for _, goos := range []string{"linux", "darwin", "freebsd"} {
+		assert.NoError(t, preflightPlatform(goos), goos)
+	}
+}

--- a/pkg/service/updater/preflight.go
+++ b/pkg/service/updater/preflight.go
@@ -1,0 +1,150 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/rs/zerolog/log"
+)
+
+// ErrInsufficientSpace is returned before anything is downloaded, so a full
+// disk costs a manifest fetch rather than an archive.
+var ErrInsufficientSpace = errors.New("insufficient disk space for the update")
+
+const bytesPerMB = 1024 * 1024
+
+// spaceNeeds is what an install is about to write, and where.
+type spaceNeeds struct {
+	// free defaults to helpers.FreeDiskSpace. Injected so the check can be
+	// tested without filling a disk.
+	free        func(string) (uint64, error)
+	targetPath  string
+	stagingRoot string
+	userDBPath  string
+	archiveSize int64
+}
+
+// required totals every byte the install adds while the old binary and the old
+// database are still on disk, which is the peak: nothing is reclaimed until the
+// update is confirmed.
+//
+// The archive is counted twice because the manifest carries no uncompressed
+// size, so the compressed size stands in for the payload it expands into. Our
+// archives hold one compressed binary, so that underestimates the payload by
+// roughly the compression ratio, and the two binary-sized sidecars below absorb
+// the difference. The binary is counted twice for the staged candidate and the
+// rollback copy of the running binary, and the database once for the update
+// snapshot, which VACUUM INTO can only make smaller than its source.
+func (n *spaceNeeds) required() int64 {
+	binarySize := fileSizeOrZero(n.targetPath)
+	return 2*n.archiveSize + 2*binarySize + fileSizeOrZero(n.userDBPath)
+}
+
+// checkFreeSpace charges the whole requirement to every directory the install
+// writes to. On MiSTer they are all one volume and that is exact; where they are
+// separate volumes it is over-strict by the size of the parts that live
+// elsewhere, which is tens of megabytes on hardware with gigabytes free. There
+// is no portable way to tell two paths are the same filesystem, and refusing an
+// update that would have fit is a much cheaper mistake than starting one that
+// does not.
+func checkFreeSpace(n *spaceNeeds) error {
+	// A manifest with no size is rejected by the download for the same reason;
+	// there is nothing to check against here.
+	if n.archiveSize <= 0 {
+		return nil
+	}
+	required := n.required()
+	if required <= 0 {
+		return nil
+	}
+	//nolint:gosec // required is positive above
+	need := uint64(required)
+
+	free := n.free
+	if free == nil {
+		free = helpers.FreeDiskSpace
+	}
+
+	checked := make(map[string]struct{}, 3)
+	for _, path := range []string{
+		n.stagingRoot,
+		filepath.Dir(n.targetPath),
+		filepath.Dir(n.userDBPath),
+	} {
+		if path == "" {
+			continue
+		}
+		dir := nearestExistingDir(path)
+		if _, seen := checked[dir]; seen {
+			continue
+		}
+		checked[dir] = struct{}{}
+
+		available, err := free(dir)
+		if err != nil {
+			// A filesystem that will not report its free space must not make
+			// updating impossible; the install still fails safely on ENOSPC.
+			log.Warn().Err(err).Str("dir", dir).
+				Msg("could not check free space before updating")
+			continue
+		}
+		if available < need {
+			return fmt.Errorf("%w: %s has %d MB free, need at least %d MB",
+				ErrInsufficientSpace, dir, available/bytesPerMB, need/bytesPerMB)
+		}
+	}
+	return nil
+}
+
+// nearestExistingDir walks up until it finds a directory that exists. Free space
+// is a property of the filesystem rather than the leaf, and both the staging
+// root and the snapshot directory are created later in the install.
+func nearestExistingDir(path string) string {
+	for {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			return path
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return path
+		}
+		path = parent
+	}
+}
+
+// fileSizeOrZero leaves a missing or unreadable file out of the requirement
+// rather than failing the update over it.
+func fileSizeOrZero(path string) int64 {
+	if path == "" {
+		return 0
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Debug().Err(err).Str("path", path).
+			Msg("update space check could not size a file")
+		return 0
+	}
+	return info.Size()
+}

--- a/pkg/service/updater/preflight_test.go
+++ b/pkg/service/updater/preflight_test.go
@@ -1,0 +1,203 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updater
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testArchiveSize = 4 * bytesPerMB
+	testBinarySize  = 6 * bytesPerMB
+	testDBSize      = 2 * bytesPerMB
+)
+
+// testRequiredSpace is the formula spelled out independently of the
+// implementation, so a change to either has to be deliberate.
+const testRequiredSpace = 2*testArchiveSize + 2*testBinarySize + testDBSize
+
+type spaceFixture struct {
+	err   error
+	needs *spaceNeeds
+	dirs  []string
+	free  uint64
+}
+
+// newSpaceFixture lays out a target binary and a user database on one volume,
+// with the staging root under the data directory the way a real install has it.
+func newSpaceFixture(t *testing.T) *spaceFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	f := &spaceFixture{free: testRequiredSpace}
+	f.needs = &spaceNeeds{
+		archiveSize: testArchiveSize,
+		targetPath:  writeSizedFile(t, filepath.Join(dir, "zaparoo"), testBinarySize),
+		userDBPath:  writeSizedFile(t, filepath.Join(dir, "user.db"), testDBSize),
+		stagingRoot: filepath.Join(dir, "updater", "staging"),
+		free: func(path string) (uint64, error) {
+			f.dirs = append(f.dirs, path)
+			return f.free, f.err
+		},
+	}
+	return f
+}
+
+func writeSizedFile(t *testing.T, path string, size int64) string {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte{'x'}, int(size)), 0o600))
+	return path
+}
+
+func TestCheckFreeSpace_AcceptsExactlyEnough(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	f.free = testRequiredSpace
+
+	require.NoError(t, checkFreeSpace(f.needs))
+}
+
+// One byte short is the interesting boundary: it proves the requirement is the
+// sum of every part, not just the download.
+func TestCheckFreeSpace_RejectsOneByteShort(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	f.free = testRequiredSpace - 1
+
+	err := checkFreeSpace(f.needs)
+	require.ErrorIs(t, err, ErrInsufficientSpace)
+	assert.Contains(t, err.Error(), filepath.Dir(f.needs.targetPath),
+		"the message has to name the directory that is full")
+	assert.Contains(t, err.Error(), "need at least 22 MB")
+}
+
+func TestCheckFreeSpace_LeavesMissingFilesOutOfTheRequirement(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	require.NoError(t, os.Remove(f.needs.targetPath))
+	require.NoError(t, os.Remove(f.needs.userDBPath))
+	f.free = 2 * testArchiveSize
+
+	require.NoError(t, checkFreeSpace(f.needs),
+		"a first install has no binary or database to preserve")
+}
+
+// The three paths are one filesystem on MiSTer, where the data directory sits
+// beside the install target. Charging the requirement to it three times would
+// still be correct, but asking the kernel three times would not be.
+func TestCheckFreeSpace_ChecksOneVolumeOnce(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+
+	require.NoError(t, checkFreeSpace(f.needs))
+	assert.Equal(t, []string{filepath.Dir(f.needs.targetPath)}, f.dirs)
+}
+
+func TestCheckFreeSpace_ChecksEverySeparateVolume(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	elsewhere := t.TempDir()
+	f.needs.stagingRoot = elsewhere
+
+	require.NoError(t, checkFreeSpace(f.needs))
+	assert.ElementsMatch(t, []string{elsewhere, filepath.Dir(f.needs.targetPath)}, f.dirs)
+}
+
+// The staging root does not exist until Stage creates it, and neither does the
+// snapshot directory, so the check has to ask about an ancestor that does.
+func TestCheckFreeSpace_WalksUpToAnExistingDirectory(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	require.NoDirExists(t, f.needs.stagingRoot)
+
+	require.NoError(t, checkFreeSpace(f.needs))
+	require.Len(t, f.dirs, 1)
+	assert.Equal(t, filepath.Dir(f.needs.targetPath), f.dirs[0])
+}
+
+// vfat and exFAT already make us fall back on directory fsync. A filesystem that
+// will not report its free space must not be the reason a device can never
+// update; ENOSPC during the install is still handled safely.
+func TestCheckFreeSpace_UnknownFreeSpaceDoesNotBlock(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	f.err = errors.New("statfs is not supported here")
+	f.free = 0
+
+	require.NoError(t, checkFreeSpace(f.needs))
+	assert.NotEmpty(t, f.dirs)
+}
+
+func TestCheckFreeSpace_SkipsWhenTheManifestDeclaresNoSize(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	f.needs.archiveSize = 0
+	f.free = 0
+
+	require.NoError(t, checkFreeSpace(f.needs),
+		"downloadArchive rejects a sizeless asset with a better error")
+	assert.Empty(t, f.dirs)
+}
+
+func TestNearestExistingDir_StopsAtTheRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	assert.Equal(t, dir, nearestExistingDir(filepath.Join(dir, "a", "b", "c")))
+}
+
+// A release with nothing for this device is Stage's error to report, with the
+// platform and architecture in it. Reporting it here too would surface the
+// wrong one first.
+func TestPreflightSpace_LeavesAssetSelectionToStage(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	release := testRelease("v99.0.0", &otameta.Asset{
+		Name: "zaparoo-somethingelse_mips-99.0.0.zip",
+		Size: 1,
+	})
+
+	err := preflightSpace(
+		&Options{PlatformID: testStagePlatform, DataDir: dir},
+		release,
+		filepath.Join(dir, "zaparoo"),
+		filepath.Join(dir, "updater", "staging"),
+	)
+	require.NoError(t, err)
+}

--- a/pkg/service/updater/source_test.go
+++ b/pkg/service/updater/source_test.go
@@ -653,15 +653,11 @@ func TestVerifiedSource_ReleaseForVersionRejectsUnknownVersions(t *testing.T) {
 // media. Bookkeeping the check could not persist must not fail the check.
 func TestVerifiedSource_ReadOnlyStateDirStillChecks(t *testing.T) {
 	t.Parallel()
-	if os.Geteuid() == 0 {
-		t.Skip("permission bits are not enforced for root")
-	}
+	skipUnlessDirPermsEnforced(t)
 
 	ms := newManifestServer(t, twoReleaseManifest(412))
 	dir := t.TempDir()
-	//nolint:gosec // an unwritable-but-readable directory is the failure under test
-	require.NoError(t, os.Chmod(dir, 0o500))
-	t.Cleanup(func() { _ = os.Chmod(dir, stateDirPerm) })
+	makeDirUnwritable(t, dir)
 	src := ms.source(dir, "linux", "amd64")
 
 	releases, err := src.ListReleases(t.Context(), testRepo())

--- a/pkg/service/updater/stage.go
+++ b/pkg/service/updater/stage.go
@@ -34,6 +34,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -86,6 +87,17 @@ const (
 	// pipes would block the probe past its timeout, which would strand the whole
 	// update rather than fail it.
 	probeWaitDelay = 2 * time.Second
+
+	// probeBusyAttempts and probeBusyDelay wait out an ETXTBSY instead of
+	// reporting it as a failed probe. This process writes the staged binary and
+	// then executes it, so any child it forks in between inherits the still-open
+	// write descriptor and holds the exec off until that child execs or exits.
+	// Core spawns processes to launch media, so the window is real on a device,
+	// and the kernel is saying the file is busy rather than anything about
+	// whether the release runs. Four retries at a tenth of a second each is far
+	// longer than a fork-to-exec window and far shorter than probeTimeout.
+	probeBusyAttempts = 5
+	probeBusyDelay    = 100 * time.Millisecond
 
 	// probeOutputLimit caps how much of the staged binary's output the probe
 	// keeps. The probe runs a binary that arrived over the network moments ago,
@@ -223,16 +235,33 @@ type stager struct {
 	fetch            assetFetcher
 	release          *otameta.Release
 	chmod            func(string, os.FileMode) error
-	stagingRoot      string
-	goarch           string
-	binaryName       string
+	runProbe         probeFn
 	goos             string
+	binaryName       string
+	goarch           string
 	current          string
 	platformID       string
+	stagingRoot      string
 	maxFileBytes     int64
 	maxInflatedBytes int64
 	stallTimeout     time.Duration
 	probeTimeout     time.Duration
+	probeBusyDelay   time.Duration
+}
+
+// probeFn runs a binary's version flag and reports what it printed.
+type probeFn func(ctx context.Context, binaryPath string) (stdout, stderr string, err error)
+
+// newProbeStager builds the minimal stager the install candidate probe needs.
+// The install probes a second time, on the live install's filesystem rather
+// than staging's, and has no archive or download settings to carry.
+func newProbeStager(platformID string) *stager {
+	return &stager{
+		platformID:     platformID,
+		probeTimeout:   probeTimeout,
+		probeBusyDelay: probeBusyDelay,
+		runProbe:       runVersionProbe,
+	}
 }
 
 // stagingRootFor returns where staged versions live for a data directory.
@@ -307,6 +336,8 @@ func newStager(opts *StageOptions, fetch assetFetcher) (*stager, error) {
 		maxInflatedBytes: maxArchiveInflatedBytes,
 		stallTimeout:     downloadStallTimeout,
 		probeTimeout:     probeTimeout,
+		probeBusyDelay:   probeBusyDelay,
+		runProbe:         runVersionProbe,
 		chmod:            os.Chmod,
 	}
 	if s.goos == "" {
@@ -651,17 +682,27 @@ func (s *stager) probeBinary(ctx context.Context, binaryPath, version string) er
 	probeCtx, cancel := context.WithTimeout(ctx, s.probeTimeout)
 	defer cancel()
 
-	//nolint:gosec // the path is a file this process just created inside its own staging directory
-	cmd := exec.CommandContext(probeCtx, binaryPath, "-"+config.VersionFlagName)
-	var stdout, stderr cappedBuilder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	// Killing the process is not enough to unblock Wait if it left a child
-	// holding these pipes. This runs a binary that was downloaded seconds ago,
-	// so the timeout has to bound the call and not just the process.
-	cmd.WaitDelay = probeWaitDelay
+	var (
+		stdout, stderr string
+		runErr         error
+	)
+attempts:
+	for attempt := range probeBusyAttempts {
+		if attempt > 0 {
+			log.Debug().Str("binary", binaryPath).
+				Msg("staged binary is still held open for writing, retrying its version probe")
+			select {
+			case <-probeCtx.Done():
+				break attempts
+			case <-time.After(s.probeBusyDelay):
+			}
+		}
+		stdout, stderr, runErr = s.runProbe(probeCtx, binaryPath)
+		if !errors.Is(runErr, syscall.ETXTBSY) {
+			break attempts
+		}
+	}
 
-	runErr := cmd.Run()
 	if runErr != nil {
 		switch {
 		case ctx.Err() != nil:
@@ -671,7 +712,7 @@ func (s *stager) probeBinary(ctx context.Context, binaryPath, version string) er
 		case errors.Is(probeCtx.Err(), context.DeadlineExceeded):
 			return fmt.Errorf("%w: no answer within %s", ErrProbeFailed, s.probeTimeout)
 		default:
-			return fmt.Errorf("%w: %w (stderr: %s)", ErrProbeFailed, runErr, clip(stderr.String(), 256))
+			return fmt.Errorf("%w: %w (stderr: %s)", ErrProbeFailed, runErr, clip(stderr, 256))
 		}
 	}
 
@@ -680,13 +721,30 @@ func (s *stager) probeBinary(ctx context.Context, binaryPath, version string) er
 	// shipped, so a future release that prints something extra alongside its
 	// version must not be judged unrunnable for it.
 	want := config.VersionLine(version, s.platformID)
-	if !hasLine(stdout.String(), want) {
+	if !hasLine(stdout, want) {
 		return fmt.Errorf("%w: printed %q, expected a line reading %q",
-			ErrProbeFailed, clip(stdout.String(), 256), want)
+			ErrProbeFailed, clip(stdout, 256), want)
 	}
 
 	log.Debug().Str("binary", binaryPath).Msg("staged binary answered its version probe")
 	return nil
+}
+
+// runVersionProbe executes a binary's version flag and returns what it wrote to
+// each stream, both capped.
+func runVersionProbe(ctx context.Context, binaryPath string) (stdoutText, stderrText string, err error) {
+	//nolint:gosec // the path is a file this process just created inside its own staging directory
+	cmd := exec.CommandContext(ctx, binaryPath, "-"+config.VersionFlagName)
+	var stdout, stderr cappedBuilder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Killing the process is not enough to unblock Wait if it left a child
+	// holding these pipes. This runs a binary that was downloaded seconds ago,
+	// so the timeout has to bound the call and not just the process.
+	cmd.WaitDelay = probeWaitDelay
+
+	err = cmd.Run()
+	return stdout.String(), stderr.String(), err
 }
 
 // assetFetcherFor returns a fetcher backed by an HTTP transport.

--- a/pkg/service/updater/stage_test.go
+++ b/pkg/service/updater/stage_test.go
@@ -134,6 +134,31 @@ func buildFakeBinary(dir string) (string, error) {
 	return out, nil
 }
 
+// skipUnlessDirPermsEnforced skips a test whose failure under test is a write
+// into a directory that will not accept one. Root ignores the permission bits,
+// and on Windows os.Chmod only toggles the read-only attribute, which does not
+// stop a file being created inside a directory. On both, the setup silently
+// succeeds and the test asserts against an install that worked.
+func skipUnlessDirPermsEnforced(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no directory permission bit that blocks creating a file")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("permission bits are not enforced for root")
+	}
+}
+
+// makeDirUnwritable stages that failure, and restores the directory afterwards
+// so the test's own cleanup can still remove it.
+func makeDirUnwritable(t *testing.T, dir string) {
+	t.Helper()
+	skipUnlessDirPermsEnforced(t)
+	//nolint:gosec // an unwritable-but-readable directory is the failure under test
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, stateDirPerm) })
+}
+
 // testBinaryName adds the extension Windows needs. Without it exec cannot find
 // the staged file at all, because Windows resolves even an absolute path
 // through PATHEXT.

--- a/pkg/service/updater/stage_test.go
+++ b/pkg/service/updater/stage_test.go
@@ -35,6 +35,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1126,6 +1127,70 @@ func TestProbeBinary_CallerCancellationIsNotAProbeFailure(t *testing.T) {
 	require.Error(t, err)
 	require.NotErrorIs(t, err, ErrProbeFailed)
 	assert.Contains(t, err.Error(), "cancelled")
+}
+
+// TestProbeBinary_WaitsOutABinaryStillHeldOpenForWriting covers the race between
+// writing the staged binary and executing it. Any child this process forks in
+// between inherits the open write descriptor and the exec fails with ETXTBSY,
+// which says nothing about whether the release runs.
+func TestProbeBinary_WaitsOutABinaryStillHeldOpenForWriting(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		probeErr  error
+		name      string
+		busyUntil int
+		wantCalls int
+		wantOK    bool
+	}{
+		{
+			name:      "clears while the descriptor is still open",
+			busyUntil: 2,
+			wantCalls: 3,
+			wantOK:    true,
+		},
+		{
+			name:      "gives up on a binary that never clears",
+			busyUntil: probeBusyAttempts,
+			wantCalls: probeBusyAttempts,
+		},
+		{
+			name:      "does not retry a binary that will not run",
+			probeErr:  errors.New("exec format error"),
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := testStageOptions(t, testRelease("v"+testStageVersion), "zaparoo")
+			s, err := newStager(opts, unusedFetcher)
+			require.NoError(t, err)
+			s.probeBusyDelay = time.Millisecond
+
+			calls := 0
+			s.runProbe = func(context.Context, string) (string, string, error) {
+				calls++
+				if calls <= tt.busyUntil {
+					return "", "", fmt.Errorf("fork/exec: %w", syscall.ETXTBSY)
+				}
+				if tt.probeErr != nil {
+					return "", "", tt.probeErr
+				}
+				return config.VersionLine(testStageVersion, testStagePlatform), "", nil
+			}
+
+			err = s.probeBinary(context.Background(), "staged-binary", testStageVersion)
+			if tt.wantOK {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, ErrProbeFailed)
+			}
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
 }
 
 // executableCopy puts the fake release binary somewhere named stem, which is how

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sync/atomic"
@@ -192,13 +193,17 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolving the binary to update: %w", err)
 	}
+	stagingRoot := stagingRootFor(opts.DataDir)
+	if spaceErr := preflightSpace(&opts, manifestRelease, targetPath, stagingRoot); spaceErr != nil {
+		return "", spaceErr
+	}
 	staged, err := Stage(ctx, &StageOptions{
 		Release:        manifestRelease,
 		PlatformID:     opts.PlatformID,
 		Arch:           runtime.GOARCH,
 		OS:             runtime.GOOS,
 		TargetPath:     targetPath,
-		StagingRoot:    stagingRootFor(opts.DataDir),
+		StagingRoot:    stagingRoot,
 		CurrentVersion: config.AppVersion,
 	})
 	if err != nil {
@@ -219,6 +224,23 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 	}
 
 	return staged.Version, nil
+}
+
+// preflightSpace sizes the update from the verified manifest and refuses one
+// that cannot fit. The asset lookup here is a size lookup only: Stage repeats it
+// along with the version and upgrade-floor checks, so a selection failure is
+// left for Stage to report with its own error rather than reported twice.
+func preflightSpace(opts *Options, release *otameta.Release, targetPath, stagingRoot string) error {
+	asset, err := otameta.SelectAsset(release, opts.PlatformID, runtime.GOARCH)
+	if err != nil {
+		return nil //nolint:nilerr // Stage reports this properly a moment later
+	}
+	return checkFreeSpace(&spaceNeeds{
+		archiveSize: asset.Size,
+		targetPath:  targetPath,
+		stagingRoot: stagingRoot,
+		userDBPath:  filepath.Join(opts.DataDir, config.UserDbFile),
+	})
 }
 
 func ensureNoPendingUpdate(dataDir string) error {

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -185,6 +185,14 @@ func Apply(ctx context.Context, opts Options) (string, error) {
 		return "", fmt.Errorf("%w: running %s", ErrNotAnUpgrade, config.AppVersion)
 	}
 
+	// Checked here rather than at the top of Apply so that a device already on
+	// the newest version is told that, instead of being told its platform is
+	// unsupported. Everything below this point costs the user something the
+	// install can never spend well.
+	if platformErr := preflightPlatform(runtime.GOOS); platformErr != nil {
+		return "", platformErr
+	}
+
 	manifestRelease, err := s.source.releaseForVersion(release.Version())
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Four changes on top of #1280, all in the install path.

## Refuse an update that cannot fit on disk

An install writes the archive, the payload it expands into, a staged candidate binary, a rollback copy of the running binary and a snapshot of the user database, and none of it is reclaimed until the update is confirmed. Previously the first sign of a full disk was a failure partway through, after the download.

`Apply` now sizes the update from the verified manifest and refuses it before staging. The requirement is twice the archive size, twice the current binary and the size of the user database. The manifest carries no uncompressed size, so the compressed archive stands in for the payload it expands into; our archives hold one compressed binary, so the two binary-sized sidecar terms absorb the difference.

The requirement is charged in full to the staging root, the directory holding the install target and the user database's directory, each resolved up to its nearest existing ancestor because neither the staging root nor the snapshot directory exists yet. Those are one filesystem on MiSTer and separate ones elsewhere, and there is no portable way to tell, so charging each the whole requirement is over-strict by tens of megabytes on hardware with gigabytes free. A filesystem that will not report its free space is logged and allowed through: an unsupported `statfs` must not be the reason a device can never update.

`ErrInsufficientSpace` carries the directory and the shortfall, and maps to a client error in `update.apply`.

## Integration coverage for install and rollback

The install pipeline was covered a stage at a time. The property that matters most spans all of them: a version that migrates the user database and then fails to start has to leave a device running the old binary against a database the old binary can still open. Unit tests around a stand-in backupper cannot show that, because the schema rollback is real SQLite work.

Four tests drive a signed manifest, a real archive over HTTP, a real binary swap and a real `user.db` through the chain `Apply` runs — `verifiedSource`, `DetectLatest`, `releaseForVersion`, `stageRelease`, `installStaged`, then `RunStartupWatchdog` or `Confirm`:

- Install and confirm: the target holds the staged release binary, the marker is armed with the previous and target versions and the manifest generation, and the backup and snapshot are on disk; the first boot confirms and every one of those artifacts is gone, with the seed rows intact.
- Rollback when the new version never confirms: the new version boots, writes a device-state row, and dies. The second boot returns `ErrRolledBack` carrying the path to re-exec, the target is the outgoing binary byte for byte, and the row the rolled-back version wrote is gone with it.
- Rollback across a schema migration: a goose version row above the highest embedded migration stands in for a migration the incoming release carries and this build does not. The test first asserts its own premise — that the crossed schema really does lock this build out with `ErrSchemaAhead` — and then that the restored snapshot is a database the outgoing build can migrate and open.
- A failed install reopens the user database, so a device that refused an update is not left with its connection pool closed behind it.

The harness reuses the existing unit-test fixtures and adds no production seams.

## Refuse an in-place update on Windows

`replaceFile` on Windows is `MoveFileEx` with `REPLACE_EXISTING` and `WRITE_THROUGH` against the running `.exe`, and Windows refuses it: the running image is locked. The install unwinds safely from there, but it fails at the replacement — after the archive has been downloaded and after the user database has been snapshotted and quiesced.

`preflightPlatform` returns `ErrPlatformUnsupported` on Windows, wrapped with what to do instead, and `HandleUpdateApply` maps it to a client error. It runs after the upgrade check rather than at the top of `Apply`, so a Windows device already on the newest version is told that instead of being told its platform is unsupported.

This is the guard, not the exit-time helper. When the helper lands, the guard is what it replaces.

## Wait out a staged binary still open for writing

The version probe runs a binary this process wrote moments earlier. If anything forks in between, the child inherits the still-open write descriptor and the exec fails with `ETXTBSY` until that child execs or exits. Core spawns processes to launch media, so the window is real on a device, not only under a parallel test run. The probe treated it as the release failing to run: the staged binary was deleted and the update refused, on a build that was never actually judged.

The probe now retries an `ETXTBSY` four more times, 100 ms apart, which is far longer than a fork-to-exec window and far shorter than the ten-second probe timeout it still runs inside. Any other exec error is reported first time, unchanged.

Found by an intermittent failure in the new integration test, which reproduced once in eight runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform compatibility checks before applying updates.
  * Added disk-space validation to prevent updates when storage is insufficient.
  * Improved reliability when checking temporarily busy update binaries.
  * Added safeguards for installation confirmation, rollback, database recovery, and schema migrations.

* **Bug Fixes**
  * Unsupported-platform and insufficient-space errors now provide actionable messages.
  * Improved recovery when installation fails after closing the user database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->