### PR TITLE
feat(updater): add Batocera payloads and automatic scheduling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,6 +268,8 @@ jobs:
         with:
           sparse-checkout: |
             scripts/
+            pkg/platforms/batocera/payload.go
+            pkg/platforms/updatepayload/
             go.mod
           sparse-checkout-cone-mode: false
       - name: Set up Go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,6 +271,7 @@ jobs:
             pkg/platforms/batocera/payload.go
             pkg/platforms/updatepayload/
             go.mod
+            go.sum
           sparse-checkout-cone-mode: false
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,7 @@ jobs:
             cp "_signed/${arch}/Zaparoo.exe" "_dist/${arch}/Zaparoo.exe"
 
             # Create distribution ZIP
-            go run scripts/tasks/utils/makezip/main.go \
+            go run ./scripts/tasks/utils/makezip \
               windows "_dist/${arch}" Zaparoo.exe \
               "zaparoo-windows_${arch}-${VERSION}.zip"
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -148,6 +148,7 @@ tasks:
           "FuzzGetPathDir ./pkg/helpers"
           "FuzzSplitCommand ./pkg/helpers"
           "FuzzParseVirtualPathStr ./pkg/helpers/virtualpath"
+          "FuzzPayloadMemberPath ./pkg/platforms/updatepayload"
           "FuzzFindPath ./pkg/database/mediascanner"
           "FuzzProcessRequestObject ./pkg/api"
           "FuzzEstablishSession ./pkg/api/middleware"

--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -99,6 +99,9 @@ func updaterOptions(env *requests.RequestEnv, mode updater.Mode) updater.Options
 		Managed:    env.Platform.ManagedByPackageManager(),
 		Mode:       mode,
 	}
+	if provider, ok := env.Platform.(platforms.UpdatePayloadProvider); ok {
+		opts.Payload = provider.UpdatePayload()
+	}
 	if env.Database != nil {
 		opts.UserDB = env.Database.UserDB
 	}

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/power"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	backupcoordinator "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/backup/coordinator"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
@@ -46,6 +47,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type updatePayloadPlatform struct {
+	platforms.Platform
+	payload []updatepayload.File
+}
+
+func (p updatePayloadPlatform) UpdatePayload() []updatepayload.File {
+	return p.payload
+}
 
 func TestHandleUpdateCheck_DevelopmentVersion(t *testing.T) {
 	devVersions := []string{"DEVELOPMENT", "abc1234-dev"}
@@ -125,12 +135,16 @@ func TestHandleUpdateCheck_BetaChannel(t *testing.T) {
 
 	cfg := &config.Instance{}
 	cfg.SetUpdateChannel(config.UpdateChannelBeta)
+	payload := []updatepayload.File{{ArchivePath: "scripts/helper.sh"}}
 
 	env := requests.RequestEnv{
-		Context:  t.Context(),
-		Platform: mockPlatform,
-		Config:   cfg,
-		IsLocal:  true,
+		Context: t.Context(),
+		Platform: updatePayloadPlatform{
+			Platform: mockPlatform,
+			payload:  payload,
+		},
+		Config:  cfg,
+		IsLocal: true,
 	}
 
 	var received updater.Options
@@ -149,6 +163,7 @@ func TestHandleUpdateCheck_BetaChannel(t *testing.T) {
 	// An empty PlatformID selects no archive at all, so it has to arrive too.
 	assert.Equal(t, "mock-platform", received.PlatformID)
 	assert.Equal(t, dataDir, received.DataDir)
+	assert.Equal(t, payload, received.Payload)
 }
 
 func TestHandleUpdateCheck_NoUpdateAvailable(t *testing.T) {

--- a/pkg/platforms/batocera/payload.go
+++ b/pkg/platforms/batocera/payload.go
@@ -1,0 +1,76 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package batocera
+
+import (
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+)
+
+var updatePayload = []updatepayload.File{
+	{
+		SourcePath: filepath.Join("cmd", "batocera", "scripts", "configs", "emulationstation", "scripts",
+			"game-selected", "zaparoo_game_select.sh"),
+		ArchivePath: "scripts/configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+		InstallPath: "configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "configs", "multimedia_keys.conf"),
+		ArchivePath: "scripts/configs/multimedia_keys.conf",
+		InstallPath: "configs/multimedia_keys.conf",
+		Mode:        0o644,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "content_downloader.png"),
+		ArchivePath: "scripts/content_downloader.png",
+		InstallPath: "content_downloader.png",
+		Mode:        0o644,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "ports", "Zaparoo.sh"),
+		ArchivePath: "scripts/ports/Zaparoo.sh",
+		InstallPath: "../roms/ports/Zaparoo.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
+		ArchivePath: "scripts/services/zaparoo_service",
+		InstallPath: "services/zaparoo_service",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_wrapper.sh"),
+		ArchivePath: "scripts/zaparoo_wrapper.sh",
+		InstallPath: "zaparoo_wrapper.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_write_game.sh"),
+		ArchivePath: "scripts/zaparoo_write_game.sh",
+		InstallPath: "zaparoo_write_game.sh",
+		Mode:        0o755,
+	},
+}
+
+func UpdatePayload() []updatepayload.File {
+	return append([]updatepayload.File(nil), updatePayload...)
+}

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -43,52 +43,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-var updatePayload = []updatepayload.File{
-	{
-		SourcePath: filepath.Join("cmd", "batocera", "scripts", "configs", "emulationstation", "scripts",
-			"game-selected", "zaparoo_game_select.sh"),
-		ArchivePath: "scripts/configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
-		InstallPath: "configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
-		Mode:        0o755,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "configs", "multimedia_keys.conf"),
-		ArchivePath: "scripts/configs/multimedia_keys.conf",
-		InstallPath: "configs/multimedia_keys.conf",
-		Mode:        0o644,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "content_downloader.png"),
-		ArchivePath: "scripts/content_downloader.png",
-		InstallPath: "content_downloader.png",
-		Mode:        0o644,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "ports", "Zaparoo.sh"),
-		ArchivePath: "scripts/ports/Zaparoo.sh",
-		InstallPath: "../roms/ports/Zaparoo.sh",
-		Mode:        0o755,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
-		ArchivePath: "scripts/services/zaparoo_service",
-		InstallPath: "services/zaparoo_service",
-		Mode:        0o755,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_wrapper.sh"),
-		ArchivePath: "scripts/zaparoo_wrapper.sh",
-		InstallPath: "zaparoo_wrapper.sh",
-		Mode:        0o755,
-	},
-	{
-		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_write_game.sh"),
-		ArchivePath: "scripts/zaparoo_write_game.sh",
-		InstallPath: "zaparoo_write_game.sh",
-		Mode:        0o755,
-	},
-}
-
 const (
 	// HomeDir is hardcoded because home in env is not set at the point which
 	// the service file is called to start.
@@ -342,7 +296,7 @@ func (p *Platform) getESConfig() *ESSystemConfig {
 }
 
 func (*Platform) UpdatePayload() []updatepayload.File {
-	return append([]updatepayload.File(nil), updatePayload...)
+	return UpdatePayload()
 }
 
 func (*Platform) Settings() platforms.Settings {

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esde"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/kodi"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/externaldrive"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/file"
@@ -41,6 +42,52 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/rs/zerolog/log"
 )
+
+var updatePayload = []updatepayload.File{
+	{
+		SourcePath: filepath.Join("cmd", "batocera", "scripts", "configs", "emulationstation", "scripts",
+			"game-selected", "zaparoo_game_select.sh"),
+		ArchivePath: "scripts/configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+		InstallPath: "configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "configs", "multimedia_keys.conf"),
+		ArchivePath: "scripts/configs/multimedia_keys.conf",
+		InstallPath: "configs/multimedia_keys.conf",
+		Mode:        0o644,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "content_downloader.png"),
+		ArchivePath: "scripts/content_downloader.png",
+		InstallPath: "content_downloader.png",
+		Mode:        0o644,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "ports", "Zaparoo.sh"),
+		ArchivePath: "scripts/ports/Zaparoo.sh",
+		InstallPath: "../roms/ports/Zaparoo.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
+		ArchivePath: "scripts/services/zaparoo_service",
+		InstallPath: "services/zaparoo_service",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_wrapper.sh"),
+		ArchivePath: "scripts/zaparoo_wrapper.sh",
+		InstallPath: "zaparoo_wrapper.sh",
+		Mode:        0o755,
+	},
+	{
+		SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_write_game.sh"),
+		ArchivePath: "scripts/zaparoo_write_game.sh",
+		InstallPath: "zaparoo_write_game.sh",
+		Mode:        0o755,
+	},
+}
 
 const (
 	// HomeDir is hardcoded because home in env is not set at the point which
@@ -292,6 +339,10 @@ func (p *Platform) getESConfig() *ESSystemConfig {
 
 	p.esConfigCache = esCfg
 	return esCfg
+}
+
+func (*Platform) UpdatePayload() []updatepayload.File {
+	return append([]updatepayload.File(nil), updatePayload...)
 }
 
 func (*Platform) Settings() platforms.Settings {

--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -40,12 +40,84 @@ func TestSettings_UpdatePayload(t *testing.T) {
 	for _, file := range files {
 		byArchivePath[file.ArchivePath] = file
 	}
-	assert.Equal(t, filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
-		byArchivePath["scripts/services/zaparoo_service"].SourcePath)
-	assert.Equal(t, "services/zaparoo_service",
-		byArchivePath["scripts/services/zaparoo_service"].InstallPath)
-	assert.Equal(t, "../roms/ports/Zaparoo.sh",
-		byArchivePath["scripts/ports/Zaparoo.sh"].InstallPath)
+
+	tests := []struct {
+		name string
+		want updatepayload.File
+	}{
+		{
+			name: "game selected hook",
+			want: updatepayload.File{
+				SourcePath: filepath.Join("cmd", "batocera", "scripts", "configs", "emulationstation", "scripts",
+					"game-selected", "zaparoo_game_select.sh"),
+				ArchivePath: "scripts/configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+				InstallPath: "configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+				Mode:        0o755,
+			},
+		},
+		{
+			name: "multimedia keys",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "configs", "multimedia_keys.conf"),
+				ArchivePath: "scripts/configs/multimedia_keys.conf",
+				InstallPath: "configs/multimedia_keys.conf",
+				Mode:        0o644,
+			},
+		},
+		{
+			name: "content downloader image",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "content_downloader.png"),
+				ArchivePath: "scripts/content_downloader.png",
+				InstallPath: "content_downloader.png",
+				Mode:        0o644,
+			},
+		},
+		{
+			name: "ports launcher",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "ports", "Zaparoo.sh"),
+				ArchivePath: "scripts/ports/Zaparoo.sh",
+				InstallPath: "../roms/ports/Zaparoo.sh",
+				Mode:        0o755,
+			},
+		},
+		{
+			name: "service",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
+				ArchivePath: "scripts/services/zaparoo_service",
+				InstallPath: "services/zaparoo_service",
+				Mode:        0o755,
+			},
+		},
+		{
+			name: "wrapper",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_wrapper.sh"),
+				ArchivePath: "scripts/zaparoo_wrapper.sh",
+				InstallPath: "zaparoo_wrapper.sh",
+				Mode:        0o755,
+			},
+		},
+		{
+			name: "write game",
+			want: updatepayload.File{
+				SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_write_game.sh"),
+				ArchivePath: "scripts/zaparoo_write_game.sh",
+				InstallPath: "zaparoo_write_game.sh",
+				Mode:        0o755,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := byArchivePath[tt.want.ArchivePath]
+			require.True(t, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestPresentUIForwardsPassiveEvents(t *testing.T) {

--- a/pkg/platforms/batocera/platform_test.go
+++ b/pkg/platforms/batocera/platform_test.go
@@ -9,6 +9,7 @@ package batocera
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -27,6 +29,23 @@ import (
 func TestSettings_DisablesZapScriptWhileTUIOpen(t *testing.T) {
 	t.Parallel()
 	assert.True(t, (&Platform{}).Settings().DisableZapScriptInTUI)
+}
+
+func TestSettings_UpdatePayload(t *testing.T) {
+	t.Parallel()
+
+	files := (&Platform{}).UpdatePayload()
+	require.Len(t, files, 7)
+	byArchivePath := make(map[string]updatepayload.File, len(files))
+	for _, file := range files {
+		byArchivePath[file.ArchivePath] = file
+	}
+	assert.Equal(t, filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
+		byArchivePath["scripts/services/zaparoo_service"].SourcePath)
+	assert.Equal(t, "services/zaparoo_service",
+		byArchivePath["scripts/services/zaparoo_service"].InstallPath)
+	assert.Equal(t, "../roms/ports/Zaparoo.sh",
+		byArchivePath["scripts/ports/Zaparoo.sh"].InstallPath)
 }
 
 func TestPresentUIForwardsPassiveEvents(t *testing.T) {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -382,6 +383,10 @@ type BackupPlan struct {
 
 type BackupProvider interface {
 	BackupDefinitions() []BackupDefinition
+}
+
+type UpdatePayloadProvider interface {
+	UpdatePayload() []updatepayload.File
 }
 
 type BackupPlanningProvider interface {

--- a/pkg/platforms/shared/linuxbase/base_test.go
+++ b/pkg/platforms/shared/linuxbase/base_test.go
@@ -34,12 +34,39 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+//nolint:govet // Test helper groups embedded clock before recorded state.
+type recordingClock struct {
+	clockwork.Clock
+	mu             syncutil.Mutex
+	afterDurations []time.Duration
+}
+
+func (c *recordingClock) After(d time.Duration) <-chan time.Time {
+	c.mu.Lock()
+	c.afterDurations = append(c.afterDurations, d)
+	c.mu.Unlock()
+	return c.Clock.After(d)
+}
+
+func (c *recordingClock) afterCount(d time.Duration) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	count := 0
+	for _, recorded := range c.afterDurations {
+		if recorded == d {
+			count++
+		}
+	}
+	return count
+}
 
 // mockLauncherManager implements platforms.LauncherContextManager for testing.
 type mockLauncherManager struct {
@@ -355,16 +382,20 @@ func TestStopActiveLauncher(t *testing.T) {
 		require.NoError(t, cmd.Start())
 
 		base := NewBase("test")
+		clock := &recordingClock{Clock: clockwork.NewRealClock()}
+		base.SetClock(clock)
 		base.SetTrackedProcess(cmd.Process)
 		base.setActiveMedia = func(_ *models.ActiveMedia) {}
 		base.lastLauncher = platforms.Launcher{
 			Kill: func(_ *config.Instance) error { return assert.AnError },
 		}
 
-		start := time.Now()
 		require.NoError(t, base.StopActiveLauncher(platforms.StopForMenu))
 
-		assert.Less(t, time.Since(start), CustomKillTimeout)
+		// SIGKILLTimeout has the same duration and always creates the final
+		// cleanup timer. A second timer would mean the failed custom kill also
+		// waited out CustomKillTimeout instead of falling back immediately.
+		assert.Equal(t, 1, clock.afterCount(CustomKillTimeout))
 		assert.Nil(t, base.trackedProcess)
 	})
 

--- a/pkg/platforms/updatepayload/payload.go
+++ b/pkg/platforms/updatepayload/payload.go
@@ -22,68 +22,89 @@
 package updatepayload
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
-
-	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 )
 
-// Root maps a repository source directory to its top-level archive and install
-// directory. ArchiveRoot is always slash-separated.
-type Root struct {
-	SourceDir   string
-	ArchiveRoot string
+// File is one exact file in a platform update payload. SourcePath uses native
+// separators; archive and install paths are slash-separated descendants.
+type File struct {
+	SourcePath  string
+	ArchivePath string
+	InstallPath string
+	Mode        os.FileMode
 }
 
-var rootsByPlatform = map[string][]Root{
-	platformids.Batocera: {
-		{SourceDir: "cmd/batocera/scripts", ArchiveRoot: "scripts"},
-	},
-}
-
-// Roots returns a copy of the payload roots configured for platformID.
-func Roots(platformID string) []Root {
-	roots := rootsByPlatform[platformID]
-	return append([]Root(nil), roots...)
-}
-
-// RelativeMember returns a clean path below root for an archive member. Archive
-// names are slash paths on every host; native separators and path traversal are
-// rejected before callers convert the result to a filesystem path.
-func RelativeMember(root Root, member string) (string, bool) {
-	if root.ArchiveRoot == "" || member == "" || strings.Contains(member, `\`) || path.IsAbs(member) {
+// RelativeArchivePath validates member and returns its path below archiveRoot.
+func RelativeArchivePath(archiveRoot, member string) (string, bool) {
+	if !validDescendant(archiveRoot) || member == "" ||
+		strings.Contains(member, `\`) || path.IsAbs(member) || path.Clean(member) != member {
 		return "", false
 	}
-	if path.Clean(root.ArchiveRoot) != root.ArchiveRoot || strings.Contains(root.ArchiveRoot, "/") {
-		return "", false
-	}
-	if path.Clean(member) != member {
-		return "", false
-	}
-	prefix := root.ArchiveRoot + "/"
+	prefix := archiveRoot + "/"
 	if !strings.HasPrefix(member, prefix) {
 		return "", false
 	}
-	rel := strings.TrimPrefix(member, prefix)
-	if rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+	relative := strings.TrimPrefix(member, prefix)
+	if !validDescendant(relative) {
 		return "", false
 	}
-	for component := range strings.SplitSeq(rel, "/") {
-		if component == "" || component == "." || component == ".." {
-			return "", false
-		}
-	}
-	return rel, true
+	return relative, true
 }
 
-// IncludeSource reports whether a source-tree entry belongs in a release
-// payload. Finder metadata is never part of the runtime payload.
-func IncludeSource(relative string) bool {
-	if relative == "" {
+// MatchArchiveFile returns the exact configured file represented by member.
+func MatchArchiveFile(files []File, member string) (File, bool) {
+	for _, file := range files {
+		archiveRoot, _, ok := strings.Cut(file.ArchivePath, "/")
+		if !ok || file.ArchivePath != member {
+			continue
+		}
+		if _, ok := RelativeArchivePath(archiveRoot, member); ok && validInstallPath(file.InstallPath) &&
+			validMode(file.Mode) {
+			return file, true
+		}
+	}
+	return File{}, false
+}
+
+// InvalidArchiveMember reports malformed names that claim a configured payload root.
+func InvalidArchiveMember(files []File, member string) bool {
+	for _, file := range files {
+		archiveRoot, _, ok := strings.Cut(file.ArchivePath, "/")
+		if !ok || (!strings.HasPrefix(member, archiveRoot+"/") &&
+			!strings.HasPrefix(member, archiveRoot+`\`)) {
+			continue
+		}
+		_, valid := RelativeArchivePath(archiveRoot, member)
+		return !valid
+	}
+	return false
+}
+
+// ResolveInstallPath resolves a configured path relative to the binary directory.
+func ResolveInstallPath(binaryPath, installPath string) (string, bool) {
+	if binaryPath == "" || !validInstallPath(installPath) {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(binaryPath), filepath.FromSlash(installPath))), true
+}
+
+func validMode(mode os.FileMode) bool {
+	return mode.Perm() == 0o644 || mode.Perm() == 0o755
+}
+
+func validInstallPath(value string) bool {
+	return value != "" && !strings.Contains(value, `\`) && !path.IsAbs(value) && path.Clean(value) == value
+}
+
+func validDescendant(value string) bool {
+	if value == "" || strings.Contains(value, `\`) || path.IsAbs(value) || path.Clean(value) != value {
 		return false
 	}
-	for component := range strings.SplitSeq(strings.ReplaceAll(relative, `\`, "/"), "/") {
-		if component == ".DS_Store" {
+	for component := range strings.SplitSeq(value, "/") {
+		if component == "" || component == "." || component == ".." {
 			return false
 		}
 	}

--- a/pkg/platforms/updatepayload/payload.go
+++ b/pkg/platforms/updatepayload/payload.go
@@ -1,0 +1,91 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package updatepayload describes platform files shipped beside the Core binary
+// that must stay in sync when an unmanaged install updates itself.
+package updatepayload
+
+import (
+	"path"
+	"strings"
+
+	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+)
+
+// Root maps a repository source directory to its top-level archive and install
+// directory. ArchiveRoot is always slash-separated.
+type Root struct {
+	SourceDir   string
+	ArchiveRoot string
+}
+
+var rootsByPlatform = map[string][]Root{
+	platformids.Batocera: {
+		{SourceDir: "cmd/batocera/scripts", ArchiveRoot: "scripts"},
+	},
+}
+
+// Roots returns a copy of the payload roots configured for platformID.
+func Roots(platformID string) []Root {
+	roots := rootsByPlatform[platformID]
+	return append([]Root(nil), roots...)
+}
+
+// RelativeMember returns a clean path below root for an archive member. Archive
+// names are slash paths on every host; native separators and path traversal are
+// rejected before callers convert the result to a filesystem path.
+func RelativeMember(root Root, member string) (string, bool) {
+	if root.ArchiveRoot == "" || member == "" || strings.Contains(member, `\`) || path.IsAbs(member) {
+		return "", false
+	}
+	if path.Clean(root.ArchiveRoot) != root.ArchiveRoot || strings.Contains(root.ArchiveRoot, "/") {
+		return "", false
+	}
+	if path.Clean(member) != member {
+		return "", false
+	}
+	prefix := root.ArchiveRoot + "/"
+	if !strings.HasPrefix(member, prefix) {
+		return "", false
+	}
+	rel := strings.TrimPrefix(member, prefix)
+	if rel == "" || rel == "." || rel == ".." || strings.HasPrefix(rel, "../") {
+		return "", false
+	}
+	for component := range strings.SplitSeq(rel, "/") {
+		if component == "" || component == "." || component == ".." {
+			return "", false
+		}
+	}
+	return rel, true
+}
+
+// IncludeSource reports whether a source-tree entry belongs in a release
+// payload. Finder metadata is never part of the runtime payload.
+func IncludeSource(relative string) bool {
+	if relative == "" {
+		return false
+	}
+	for component := range strings.SplitSeq(strings.ReplaceAll(relative, `\`, "/"), "/") {
+		if component == ".DS_Store" {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/platforms/updatepayload/payload_test.go
+++ b/pkg/platforms/updatepayload/payload_test.go
@@ -1,0 +1,103 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package updatepayload
+
+import (
+	"testing"
+
+	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoots(t *testing.T) {
+	t.Parallel()
+
+	roots := Roots(platformids.Batocera)
+	assert.Equal(t, []Root{{SourceDir: "cmd/batocera/scripts", ArchiveRoot: "scripts"}}, roots)
+	assert.Empty(t, Roots(platformids.Linux))
+
+	roots[0].ArchiveRoot = "changed"
+	assert.Equal(t, "scripts", Roots(platformids.Batocera)[0].ArchiveRoot)
+}
+
+func TestRelativeMember(t *testing.T) {
+	t.Parallel()
+
+	root := Root{ArchiveRoot: "scripts"}
+	for _, tt := range []struct {
+		name   string
+		member string
+		want   string
+		ok     bool
+	}{
+		{name: "nested", member: "scripts/services/zaparoo_service", want: "services/zaparoo_service", ok: true},
+		{name: "root file", member: "scripts/zaparoo_write_game.sh", want: "zaparoo_write_game.sh", ok: true},
+		{name: "root directory", member: "scripts", ok: false},
+		{name: "other root", member: "other/file", ok: false},
+		{name: "absolute", member: "/scripts/file", ok: false},
+		{name: "parent", member: "scripts/../file", ok: false},
+		{name: "nested parent", member: "scripts/a/../../file", ok: false},
+		{name: "dot", member: "scripts/./file", ok: false},
+		{name: "empty component", member: "scripts//file", ok: false},
+		{name: "backslash", member: `scripts\..\file`, ok: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := RelativeMember(root, tt.member)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIncludeSource(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IncludeSource("services/zaparoo_service"))
+	assert.False(t, IncludeSource(".DS_Store"))
+	assert.False(t, IncludeSource("configs/.DS_Store"))
+	assert.False(t, IncludeSource(`configs\.DS_Store`))
+}
+
+func FuzzPayloadMemberPath(f *testing.F) {
+	root := Root{ArchiveRoot: "scripts"}
+	for _, seed := range []string{
+		"scripts/file",
+		"scripts/a/b",
+		"scripts/../file",
+		`scripts\..\file`,
+		"/scripts/file",
+		"scripts//file",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, member string) {
+		rel, ok := RelativeMember(root, member)
+		if !ok {
+			return
+		}
+		assert.NotEmpty(t, rel)
+		assert.NotContains(t, rel, `\`)
+		assert.NotContains(t, rel, "//")
+		assert.NotEqual(t, ".", rel)
+		assert.NotEqual(t, "..", rel)
+	})
+}

--- a/pkg/platforms/updatepayload/payload_test.go
+++ b/pkg/platforms/updatepayload/payload_test.go
@@ -20,27 +20,16 @@
 package updatepayload
 
 import (
+	"path/filepath"
 	"testing"
 
-	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestRoots(t *testing.T) {
+func TestRelativeArchivePath(t *testing.T) {
 	t.Parallel()
 
-	roots := Roots(platformids.Batocera)
-	assert.Equal(t, []Root{{SourceDir: "cmd/batocera/scripts", ArchiveRoot: "scripts"}}, roots)
-	assert.Empty(t, Roots(platformids.Linux))
-
-	roots[0].ArchiveRoot = "changed"
-	assert.Equal(t, "scripts", Roots(platformids.Batocera)[0].ArchiveRoot)
-}
-
-func TestRelativeMember(t *testing.T) {
-	t.Parallel()
-
-	root := Root{ArchiveRoot: "scripts"}
 	for _, tt := range []struct {
 		name   string
 		member string
@@ -49,35 +38,56 @@ func TestRelativeMember(t *testing.T) {
 	}{
 		{name: "nested", member: "scripts/services/zaparoo_service", want: "services/zaparoo_service", ok: true},
 		{name: "root file", member: "scripts/zaparoo_write_game.sh", want: "zaparoo_write_game.sh", ok: true},
-		{name: "root directory", member: "scripts", ok: false},
-		{name: "other root", member: "other/file", ok: false},
-		{name: "absolute", member: "/scripts/file", ok: false},
-		{name: "parent", member: "scripts/../file", ok: false},
-		{name: "nested parent", member: "scripts/a/../../file", ok: false},
-		{name: "dot", member: "scripts/./file", ok: false},
-		{name: "empty component", member: "scripts//file", ok: false},
-		{name: "backslash", member: `scripts\..\file`, ok: false},
+		{name: "root directory", member: "scripts"},
+		{name: "other root", member: "other/file"},
+		{name: "absolute", member: "/scripts/file"},
+		{name: "parent", member: "scripts/../file"},
+		{name: "nested parent", member: "scripts/a/../../file"},
+		{name: "dot", member: "scripts/./file"},
+		{name: "empty component", member: "scripts//file"},
+		{name: "backslash", member: `scripts\..\file`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, ok := RelativeMember(root, tt.member)
+			got, ok := RelativeArchivePath("scripts", tt.member)
 			assert.Equal(t, tt.ok, ok)
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestIncludeSource(t *testing.T) {
+func TestMatchArchiveFile(t *testing.T) {
 	t.Parallel()
 
-	assert.True(t, IncludeSource("services/zaparoo_service"))
-	assert.False(t, IncludeSource(".DS_Store"))
-	assert.False(t, IncludeSource("configs/.DS_Store"))
-	assert.False(t, IncludeSource(`configs\.DS_Store`))
+	files := []File{{
+		ArchivePath: "scripts/ports/Zaparoo.sh",
+		InstallPath: "../roms/ports/Zaparoo.sh",
+		Mode:        0o755,
+	}}
+	file, ok := MatchArchiveFile(files, "scripts/ports/Zaparoo.sh")
+	require.True(t, ok)
+	assert.Equal(t, "../roms/ports/Zaparoo.sh", file.InstallPath)
+	assert.Equal(t, 0o755, int(file.Mode))
+
+	_, ok = MatchArchiveFile(files, "scripts/unconfigured.sh")
+	assert.False(t, ok)
+	assert.True(t, InvalidArchiveMember(files, "scripts/../outside"))
+	assert.False(t, InvalidArchiveMember(files, "scripts/unconfigured.sh"))
+}
+
+func TestResolveInstallPath(t *testing.T) {
+	t.Parallel()
+
+	binary := filepath.Join("userdata", "system", "zaparoo")
+	got, ok := ResolveInstallPath(binary, "../roms/ports/Zaparoo.sh")
+	assert.True(t, ok)
+	assert.Equal(t, filepath.Join("userdata", "roms", "ports", "Zaparoo.sh"), got)
+
+	_, ok = ResolveInstallPath(binary, "/outside")
+	assert.False(t, ok)
 }
 
 func FuzzPayloadMemberPath(f *testing.F) {
-	root := Root{ArchiveRoot: "scripts"}
 	for _, seed := range []string{
 		"scripts/file",
 		"scripts/a/b",
@@ -90,7 +100,7 @@ func FuzzPayloadMemberPath(f *testing.F) {
 	}
 
 	f.Fuzz(func(t *testing.T, member string) {
-		rel, ok := RelativeMember(root, member)
+		rel, ok := RelativeArchivePath("scripts", member)
 		if !ok {
 			return
 		}

--- a/pkg/platforms/updatepayload/payload_test.go
+++ b/pkg/platforms/updatepayload/payload_test.go
@@ -38,14 +38,14 @@ func TestRelativeArchivePath(t *testing.T) {
 	}{
 		{name: "nested", member: "scripts/services/zaparoo_service", want: "services/zaparoo_service", ok: true},
 		{name: "root file", member: "scripts/zaparoo_write_game.sh", want: "zaparoo_write_game.sh", ok: true},
-		{name: "root directory", member: "scripts"},
-		{name: "other root", member: "other/file"},
-		{name: "absolute", member: "/scripts/file"},
-		{name: "parent", member: "scripts/../file"},
-		{name: "nested parent", member: "scripts/a/../../file"},
-		{name: "dot", member: "scripts/./file"},
-		{name: "empty component", member: "scripts//file"},
-		{name: "backslash", member: `scripts\..\file`},
+		{name: "root directory", member: "scripts", want: "", ok: false},
+		{name: "other root", member: "other/file", want: "", ok: false},
+		{name: "absolute", member: "/scripts/file", want: "", ok: false},
+		{name: "parent", member: "scripts/../file", want: "", ok: false},
+		{name: "nested parent", member: "scripts/a/../../file", want: "", ok: false},
+		{name: "dot", member: "scripts/./file", want: "", ok: false},
+		{name: "empty component", member: "scripts//file", want: "", ok: false},
+		{name: "backslash", member: `scripts\..\file`, want: "", ok: false},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/pkg/platforms/updatepayload/payload_test.go
+++ b/pkg/platforms/updatepayload/payload_test.go
@@ -75,6 +75,45 @@ func TestMatchArchiveFile(t *testing.T) {
 	assert.False(t, InvalidArchiveMember(files, "scripts/unconfigured.sh"))
 }
 
+func TestMatchArchiveFileRejectsInvalidDefinition(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		file File
+	}{
+		{
+			name: "archive path",
+			file: File{ArchivePath: "scripts/../helper.sh", InstallPath: "helper.sh", Mode: 0o755},
+		},
+		{
+			name: "install path",
+			file: File{ArchivePath: "scripts/helper.sh", InstallPath: "/helper.sh", Mode: 0o755},
+		},
+		{
+			name: "mode",
+			file: File{ArchivePath: "scripts/helper.sh", InstallPath: "helper.sh", Mode: 0o600},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := MatchArchiveFile([]File{tt.file}, tt.file.ArchivePath)
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestInvalidArchiveMemberChecksEveryConfiguredRoot(t *testing.T) {
+	t.Parallel()
+
+	files := []File{
+		{ArchivePath: "scripts/helper.sh"},
+		{ArchivePath: "assets/menu.png"},
+	}
+	assert.True(t, InvalidArchiveMember(files, "assets/../menu.png"))
+	assert.False(t, InvalidArchiveMember(files, "docs/../readme.md"))
+}
+
 func TestResolveInstallPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/backup_scheduler.go
+++ b/pkg/service/backup_scheduler.go
@@ -40,13 +40,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type remoteHeartbeatState struct {
-	lastSuccess time.Time
-	nextAttempt time.Time
-	backoff     time.Duration
-	idle        bool
-}
-
 type playSyncConfiguration struct {
 	bearer  string
 	enabled bool
@@ -99,29 +92,6 @@ func (s *staleNoticeState) shouldNotify(now time.Time, stale bool) bool {
 	return true
 }
 
-func (s *remoteHeartbeatState) due(now time.Time) bool {
-	if !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < remoteHeartbeatInterval {
-		return false
-	}
-	return s.nextAttempt.IsZero() || !now.Before(s.nextAttempt)
-}
-
-func (s *remoteHeartbeatState) recordFailure(now time.Time) {
-	s.idle = false
-	if s.backoff <= 0 {
-		s.backoff = remoteHeartbeatInitialBackoff
-	}
-	s.nextAttempt = now.Add(s.backoff)
-	s.backoff = min(s.backoff*2, remoteHeartbeatMaxBackoff)
-}
-
-func (s *remoteHeartbeatState) recordSuccess(now time.Time) {
-	s.idle = false
-	s.lastSuccess = now
-	s.nextAttempt = time.Time{}
-	s.backoff = remoteHeartbeatInitialBackoff
-}
-
 // onlineFailureRequiresWarning separates expected inactivity (disabled,
 // unlinked, or shutdown) from failures support logs must retain.
 func onlineFailureRequiresWarning(err error, expected bool) bool {
@@ -145,7 +115,7 @@ func (c playSyncConfiguration) eligible() bool {
 	return c.enabled && c.bearer != ""
 }
 
-func recordPlaySyncError(retryState *remoteHeartbeatState, now time.Time, err error) bool {
+func recordPlaySyncError(retryState *intervalState, now time.Time, err error) bool {
 	expected := backupsvc.IsRemoteUnlinkedError(err) || backupsvc.IsPlaySyncDisabledError(err)
 	if expected {
 		retryState.idle = true
@@ -153,7 +123,7 @@ func recordPlaySyncError(retryState *remoteHeartbeatState, now time.Time, err er
 		retryState.backoff = remoteHeartbeatInitialBackoff
 		return true
 	}
-	retryState.recordFailure(now)
+	retryState.recordFailure(now, remoteHeartbeatInitialBackoff, remoteHeartbeatMaxBackoff)
 	return false
 }
 
@@ -219,15 +189,15 @@ func remoteBackupSchedulerLoop(
 		)
 	}
 
-	heartbeatState := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
+	heartbeatState := intervalState{backoff: remoteHeartbeatInitialBackoff}
 	tryHeartbeat := func() {
 		now := time.Now()
-		if !heartbeatState.due(now) {
+		if !heartbeatState.due(now, remoteHeartbeatInterval) {
 			return
 		}
 		mgr := backupsvc.NewManager(cfg, pl, db).WithCoordinator(st.BackupCoordinator())
 		if err := mgr.SendHeartbeat(ctx); err != nil {
-			heartbeatState.recordFailure(now)
+			heartbeatState.recordFailure(now, remoteHeartbeatInitialBackoff, remoteHeartbeatMaxBackoff)
 			expected := backupsvc.IsRemoteUnlinkedError(err)
 			if onlineFailureRequiresWarning(err, expected) {
 				log.Warn().Err(err).
@@ -238,7 +208,7 @@ func remoteBackupSchedulerLoop(
 			}
 			return
 		}
-		heartbeatState.recordSuccess(now)
+		heartbeatState.recordSuccess(now, remoteHeartbeatInitialBackoff)
 	}
 
 	staleState := staleNoticeState{}
@@ -257,7 +227,7 @@ func remoteBackupSchedulerLoop(
 	// heartbeats, and completed sessions request immediate passes through this
 	// same serialized path. Requests coalesce, remain pending across failures,
 	// and never bypass retry backoff.
-	playSyncState := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
+	playSyncState := intervalState{backoff: remoteHeartbeatInitialBackoff}
 	playSyncPending := false
 	var idlePlaySyncConfiguration playSyncConfiguration
 	tryPlaySync := func() {
@@ -293,7 +263,7 @@ func remoteBackupSchedulerLoop(
 			}
 			return
 		}
-		playSyncState.recordSuccess(now)
+		playSyncState.recordSuccess(now, remoteHeartbeatInitialBackoff)
 		idlePlaySyncConfiguration = playSyncConfiguration{}
 		playSyncPending = false
 		if info.Uploaded > 0 {
@@ -326,7 +296,7 @@ func remoteBackupSchedulerLoop(
 // playSyncDue reports whether a play-history sync pass should run now.
 // A session lifecycle or active-heartbeat request bypasses the normal success
 // interval, but never the failure backoff.
-func playSyncDue(s *remoteHeartbeatState, now time.Time, pending bool) bool {
+func playSyncDue(s *intervalState, now time.Time, pending bool) bool {
 	if s.idle {
 		return false
 	}

--- a/pkg/service/backup_scheduler_test.go
+++ b/pkg/service/backup_scheduler_test.go
@@ -157,20 +157,20 @@ func TestOnlineFailureRequiresWarning(t *testing.T) {
 func TestRemoteHeartbeatStateBacksOffFailuresAndRecordsOnlySuccess(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
-	state := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
-	assert.True(t, state.due(now))
+	state := intervalState{backoff: remoteHeartbeatInitialBackoff}
+	assert.True(t, state.due(now, remoteHeartbeatInterval))
 
-	state.recordFailure(now)
+	state.recordFailure(now, remoteHeartbeatInitialBackoff, remoteHeartbeatMaxBackoff)
 	assert.True(t, state.lastSuccess.IsZero(), "failure must not advance heartbeat success time")
-	assert.False(t, state.due(now.Add(30*time.Second)))
-	assert.True(t, state.due(now.Add(remoteHeartbeatInitialBackoff)))
+	assert.False(t, state.due(now.Add(30*time.Second), remoteHeartbeatInterval))
+	assert.True(t, state.due(now.Add(remoteHeartbeatInitialBackoff), remoteHeartbeatInterval))
 	assert.Equal(t, 2*remoteHeartbeatInitialBackoff, state.backoff)
 
 	succeededAt := now.Add(remoteHeartbeatInitialBackoff)
-	state.recordSuccess(succeededAt)
+	state.recordSuccess(succeededAt, remoteHeartbeatInitialBackoff)
 	assert.Equal(t, succeededAt, state.lastSuccess)
-	assert.False(t, state.due(succeededAt.Add(time.Hour)))
-	assert.True(t, state.due(succeededAt.Add(remoteHeartbeatInterval)))
+	assert.False(t, state.due(succeededAt.Add(time.Hour), remoteHeartbeatInterval))
+	assert.True(t, state.due(succeededAt.Add(remoteHeartbeatInterval), remoteHeartbeatInterval))
 	assert.Equal(t, remoteHeartbeatInitialBackoff, state.backoff)
 }
 
@@ -178,7 +178,7 @@ func TestPlaySyncDuePendingBypassesIntervalButHonorsBackoff(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
-	s := remoteHeartbeatState{lastSuccess: now.Add(-time.Minute)}
+	s := intervalState{lastSuccess: now.Add(-time.Minute)}
 
 	assert.False(t, playSyncDue(&s, now, false), "periodic sync must honor the success interval")
 	assert.True(t, playSyncDue(&s, now, true), "completed session must request an immediate sync")
@@ -215,7 +215,7 @@ func TestRecordPlaySyncError_DoesNotBackoffExpectedInactivity(t *testing.T) {
 		{name: "unlinked", err: unlinkedErr},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			state := remoteHeartbeatState{
+			state := intervalState{
 				nextAttempt: now.Add(time.Hour),
 				backoff:     remoteHeartbeatMaxBackoff,
 			}
@@ -227,7 +227,7 @@ func TestRecordPlaySyncError_DoesNotBackoffExpectedInactivity(t *testing.T) {
 		})
 	}
 
-	state := remoteHeartbeatState{backoff: remoteHeartbeatInitialBackoff}
+	state := intervalState{backoff: remoteHeartbeatInitialBackoff}
 	networkErr := errors.New("network unavailable")
 	assert.False(t, recordPlaySyncError(&state, now, networkErr))
 	assert.False(t, state.idle)

--- a/pkg/service/scheduler_interval.go
+++ b/pkg/service/scheduler_interval.go
@@ -1,0 +1,59 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import "time"
+
+// intervalState paces recurring service work without making correctness depend
+// on persisted wall-clock time. Values captured by time.Now retain monotonic
+// readings for the life of the process.
+type intervalState struct {
+	lastSuccess time.Time
+	nextAttempt time.Time
+	backoff     time.Duration
+	idle        bool
+}
+
+func (s *intervalState) due(now time.Time, interval time.Duration) bool {
+	if !s.lastSuccess.IsZero() && now.Sub(s.lastSuccess) < interval {
+		return false
+	}
+	return s.nextAttempt.IsZero() || !now.Before(s.nextAttempt)
+}
+
+func (s *intervalState) recordFailure(
+	now time.Time,
+	initialBackoff time.Duration,
+	maxBackoff time.Duration,
+) {
+	s.idle = false
+	if s.backoff <= 0 {
+		s.backoff = initialBackoff
+	}
+	s.nextAttempt = now.Add(s.backoff)
+	s.backoff = min(s.backoff*2, maxBackoff)
+}
+
+func (s *intervalState) recordSuccess(now time.Time, initialBackoff time.Duration) {
+	s.idle = false
+	s.lastSuccess = now
+	s.nextAttempt = time.Time{}
+	s.backoff = initialBackoff
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -689,19 +689,6 @@ func startService(
 		},
 	)
 	idleSched.Schedule(
-		st.GetContext(), "updater-check",
-		5*time.Second, 300*time.Second,
-		func(ctx context.Context) {
-			updater.CheckAndNotify(
-				ctx, cfg,
-				updater.Options{PlatformID: pl.ID(), DataDir: helpers.DataDir(pl)},
-				st.Inbox(),
-				helpers.WaitForInternetContext, updater.Check,
-				pl.ManagedByPackageManager(),
-			)
-		},
-	)
-	idleSched.Schedule(
 		st.GetContext(), "history-retention-cleanup",
 		5*time.Second, 300*time.Second,
 		func(ctx context.Context) {
@@ -731,6 +718,7 @@ func startService(
 	startRemoteBackupScheduler(
 		st.GetContext(), cfg, pl, db, st, idleSched, backupPauser, playSyncRequests, backgroundWG,
 	)
+	startUpdaterScheduler(st.GetContext(), cfg, pl, db, st, idleSched, backgroundWG)
 	go watchGameForIndexPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, indexPauser)
 	go watchGameForScrapePause(st.GetContext(), notifBroker, st, cfg, st.Notifications, scrapePauser)
 	go watchGameForBackupPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, backupPauser)

--- a/pkg/service/updater/extract.go
+++ b/pkg/service/updater/extract.go
@@ -175,6 +175,7 @@ func verifyOpenArchive(ctx context.Context, f *os.File, want []byte) (int64, err
 
 type archiveMemberTarget struct {
 	destPath     string
+	archivePath  string
 	relativePath string
 	binary       bool
 	mode         os.FileMode
@@ -194,7 +195,7 @@ func (s *stager) memberTarget(name, binaryPath, payloadDir string) (archiveMembe
 		return archiveMemberTarget{}, false
 	}
 	return archiveMemberTarget{
-		destPath: destPath, relativePath: file.InstallPath, mode: file.Mode,
+		destPath: destPath, archivePath: file.ArchivePath, relativePath: file.InstallPath, mode: file.Mode,
 	}, true
 }
 
@@ -215,8 +216,8 @@ func (b *payloadBudget) admit(target archiveMemberTarget, declared int64) error 
 	if target.binary {
 		return nil
 	}
-	if _, duplicate := b.seen[target.relativePath]; duplicate {
-		return fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
+	if _, duplicate := b.seen[target.archivePath]; duplicate {
+		return fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.archivePath)
 	}
 	if declared > maxStagedPayloadBytes-b.bytes {
 		return fmt.Errorf("%w: payload files exceed the %d byte limit",
@@ -229,11 +230,20 @@ func (b *payloadBudget) record(target archiveMemberTarget, payload stagedPayload
 	if target.binary {
 		return nil
 	}
-	b.seen[target.relativePath] = struct{}{}
+	b.seen[target.archivePath] = struct{}{}
 	b.bytes += payload.Size
 	if b.bytes > maxStagedPayloadBytes {
 		return fmt.Errorf("%w: payload files exceed the %d byte limit",
 			ErrArchiveRejected, maxStagedPayloadBytes)
+	}
+	return nil
+}
+
+func (b *payloadBudget) requireAll(files []updatepayload.File) error {
+	for _, file := range files {
+		if _, ok := b.seen[file.ArchivePath]; !ok {
+			return fmt.Errorf("%w: required payload member %q is missing", ErrArchiveRejected, file.ArchivePath)
+		}
 	}
 	return nil
 }
@@ -352,6 +362,9 @@ func (s *stager) extractFromTarGz(
 	if !foundBinary {
 		return nil, fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
 	}
+	if err := budget.requireAll(s.payload); err != nil {
+		return nil, err
+	}
 	return payloads, nil
 }
 
@@ -416,6 +429,9 @@ func (s *stager) extractFromZip(
 	}
 	if !foundBinary {
 		return nil, fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
+	}
+	if err := budget.requireAll(s.payload); err != nil {
+		return nil, err
 	}
 	return payloads, nil
 }

--- a/pkg/service/updater/extract.go
+++ b/pkg/service/updater/extract.go
@@ -38,9 +38,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 )
 
@@ -95,36 +98,49 @@ func (w *errWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-// extractBinary opens the archive once, proves the bytes sitting on disk are
-// still the ones the signed manifest describes, and copies the executable out of
-// that same open file.
-func (s *stager) extractBinary(ctx context.Context, archivePath, ext string, want []byte, destPath string) error {
+// extractRelease opens the archive once, proves the bytes sitting on disk are
+// still the ones the signed manifest describes, and copies the executable and
+// configured platform payload out of that same open file.
+func (s *stager) extractRelease(
+	ctx context.Context,
+	archivePath, ext string,
+	want []byte,
+	binaryPath, payloadDir string,
+) ([]stagedPayloadFile, error) {
 	//nolint:gosec // the path is built by this package inside its own staging directory
 	f, err := os.Open(archivePath)
 	if err != nil {
-		return fmt.Errorf("opening the update archive: %w", err)
+		return nil, fmt.Errorf("opening the update archive: %w", err)
 	}
 	defer closeQuietly(f, "update archive")
 
 	size, err := verifyOpenArchive(ctx, f, want)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// Only the tar path reads sequentially; zip addresses the handle directly and
 	// does not care where the offset is. Rewinding both keeps that an
 	// implementation detail of the format rather than of this function.
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("rewinding the update archive: %w", err)
+		return nil, fmt.Errorf("rewinding the update archive: %w", err)
 	}
 
 	switch ext {
 	case otameta.ArchiveExtTarGz:
-		return s.extractFromTarGz(ctx, f, destPath)
+		return s.extractFromTarGz(ctx, f, binaryPath, payloadDir)
 	case otameta.ArchiveExtZip:
-		return s.extractFromZip(ctx, f, size, destPath)
+		return s.extractFromZip(ctx, f, size, binaryPath, payloadDir)
 	default:
-		return fmt.Errorf("%w: %q is not an archive type this build unpacks", ErrArchiveRejected, ext)
+		return nil, fmt.Errorf("%w: %q is not an archive type this build unpacks", ErrArchiveRejected, ext)
 	}
+}
+
+// extractBinary preserves the focused extraction seam used by binary-only
+// tests. Production staging uses extractRelease so configured payload files are
+// returned to the installer.
+func (s *stager) extractBinary(ctx context.Context, archivePath, ext string, want []byte, destPath string) error {
+	_, err := s.extractRelease(ctx, archivePath, ext, want, destPath, filepath.Dir(destPath))
+	return err
 }
 
 // verifyOpenArchive re-checks the archive against the manifest digest, reading
@@ -158,25 +174,106 @@ func verifyOpenArchive(ctx context.Context, f *os.File, want []byte) (int64, err
 	return size, nil
 }
 
-func (s *stager) extractFromTarGz(ctx context.Context, f *os.File, destPath string) error {
+type archiveMemberTarget struct {
+	destPath     string
+	relativePath string
+	binary       bool
+}
+
+func (s *stager) memberTarget(name, binaryPath, payloadDir string) (archiveMemberTarget, bool) {
+	if s.wantsMember(name) {
+		return archiveMemberTarget{destPath: binaryPath, binary: true}, true
+	}
+	for _, root := range s.payloadRoots {
+		relative, ok := updatepayload.RelativeMember(root, name)
+		if !ok || !updatepayload.IncludeSource(relative) {
+			continue
+		}
+		archivePath := path.Join(root.ArchiveRoot, relative)
+		destPath := filepath.Join(payloadDir, filepath.FromSlash(archivePath))
+		nativeRelative, err := filepath.Rel(payloadDir, destPath)
+		if err != nil || nativeRelative == ".." || strings.HasPrefix(nativeRelative, ".."+string(filepath.Separator)) {
+			return archiveMemberTarget{}, false
+		}
+		return archiveMemberTarget{destPath: destPath, relativePath: archivePath}, true
+	}
+	return archiveMemberTarget{}, false
+}
+
+func (s *stager) invalidPayloadMember(name string) bool {
+	for _, root := range s.payloadRoots {
+		if strings.HasPrefix(name, root.ArchiveRoot+"/") ||
+			strings.HasPrefix(name, root.ArchiveRoot+`\`) {
+			_, ok := updatepayload.RelativeMember(root, name)
+			return !ok
+		}
+	}
+	return false
+}
+
+func safePayloadMode(mode os.FileMode) os.FileMode {
+	if mode.Perm()&0o111 != 0 {
+		return 0o755
+	}
+	return 0o644
+}
+
+func (s *stager) copyArchiveMember(
+	ctx context.Context,
+	src io.Reader,
+	target archiveMemberTarget,
+	mode os.FileMode,
+) (stagedPayloadFile, error) {
+	if !target.binary {
+		//nolint:gosec // target is derived from a validated configured payload root
+		if err := os.MkdirAll(filepath.Dir(target.destPath), stateDirPerm); err != nil {
+			return stagedPayloadFile{}, fmt.Errorf("creating staged payload directory: %w", err)
+		}
+	}
+	if err := copyStagedFile(ctx, src, target.destPath, s.maxFileBytes); err != nil {
+		return stagedPayloadFile{}, err
+	}
+	if target.binary {
+		return stagedPayloadFile{}, nil
+	}
+	mode = safePayloadMode(mode)
+	if err := s.chmod(target.destPath, mode); err != nil {
+		return stagedPayloadFile{}, fmt.Errorf(
+			"setting staged payload permissions for %q: %w", target.relativePath, err)
+	}
+	info, err := os.Stat(target.destPath)
+	if err != nil {
+		return stagedPayloadFile{}, fmt.Errorf("reading staged payload %q: %w", target.relativePath, err)
+	}
+	return stagedPayloadFile{
+		Path:         target.destPath,
+		RelativePath: target.relativePath,
+		Mode:         mode,
+		Size:         info.Size(),
+	}, nil
+}
+
+func (s *stager) extractFromTarGz(
+	ctx context.Context,
+	f *os.File,
+	binaryPath, payloadDir string,
+) ([]stagedPayloadFile, error) {
 	gz, err := gzip.NewReader(&ctxReader{ctx: ctx, source: f})
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return fmt.Errorf("reading the update archive was cancelled: %w", ctxErr)
+			return nil, fmt.Errorf("reading the update archive was cancelled: %w", ctxErr)
 		}
-		return fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, err)
+		return nil, fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, err)
 	}
 	defer closeQuietly(gz, "update archive decompressor")
 
-	// The member count bounds how many entries the walk visits; this bounds how
-	// much content getting to them can cost. A skipped member still has to be
-	// inflated in full, because gzip cannot seek past one, so without a ceiling
-	// here a bomb ahead of the binary would run unbounded.
 	inflated := &io.LimitedReader{R: gz, N: s.maxInflatedBytes + 1}
 	overBudget := func() bool { return inflated.N <= 0 }
-
 	tr := tar.NewReader(inflated)
-	found := false
+	foundBinary := false
+	seenPayload := make(map[string]struct{})
+	var payloads []stagedPayloadFile
+	var payloadBytes int64
 	members := 0
 	for {
 		header, nextErr := tr.Next()
@@ -184,101 +281,144 @@ func (s *stager) extractFromTarGz(ctx context.Context, f *os.File, destPath stri
 			break
 		}
 		if nextErr != nil {
-			// Caller intent first. ErrArchiveRejected is a permanent verdict on the
-			// release, so returning it for what was really a shutdown would condemn
-			// a build nothing had actually found fault with.
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return fmt.Errorf("reading the update archive was cancelled: %w", ctxErr)
+				return nil, fmt.Errorf("reading the update archive was cancelled: %w", ctxErr)
 			}
 			if overBudget() {
-				return fmt.Errorf("%w: more than %d bytes of content in it",
+				return nil, fmt.Errorf("%w: more than %d bytes of content in it",
 					ErrArchiveRejected, s.maxInflatedBytes)
 			}
-			return fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, nextErr)
+			return nil, fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, nextErr)
 		}
-
 		members++
 		if members > maxArchiveMembers {
-			return fmt.Errorf("%w: more than %d members", ErrArchiveRejected, maxArchiveMembers)
+			return nil, fmt.Errorf("%w: more than %d members", ErrArchiveRejected, maxArchiveMembers)
 		}
-
-		// Regular files only. A symlink, hardlink, device node, fifo or
-		// directory entry is skipped rather than reasoned about.
-		if header.Typeflag != tar.TypeReg || !s.wantsMember(header.Name) {
+		if header.Typeflag != tar.TypeReg {
 			continue
 		}
-		if found {
-			return fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
+		if s.invalidPayloadMember(header.Name) {
+			return nil, fmt.Errorf("%w: invalid payload member %q", ErrArchiveRejected, header.Name)
+		}
+		target, wanted := s.memberTarget(header.Name, binaryPath, payloadDir)
+		if !wanted {
+			continue
+		}
+		if target.binary && foundBinary {
+			return nil, fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
+		}
+		if !target.binary {
+			if _, duplicate := seenPayload[target.relativePath]; duplicate {
+				return nil, fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
+			}
+			if header.Size > maxStagedPayloadBytes-payloadBytes {
+				return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
+					ErrArchiveRejected, maxStagedPayloadBytes)
+			}
 		}
 		if header.Size > s.maxFileBytes {
-			return fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
+			return nil, fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
 				ErrArchiveRejected, header.Name, header.Size, s.maxFileBytes)
 		}
-		if copyErr := copyStagedFile(ctx, tr, destPath, s.maxFileBytes); copyErr != nil {
-			// copyStagedFile already reports a cancellation as one, so only the
-			// budget needs separating out here.
+		payload, copyErr := s.copyArchiveMember(ctx, tr, target, header.FileInfo().Mode())
+		if copyErr != nil {
 			if ctx.Err() == nil && overBudget() {
-				return fmt.Errorf("%w: more than %d bytes of content in it",
+				return nil, fmt.Errorf("%w: more than %d bytes of content in it",
 					ErrArchiveRejected, s.maxInflatedBytes)
 			}
-			return copyErr
+			return nil, copyErr
 		}
-		found = true
-	}
-
-	if !found {
-		return fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
-	}
-	return nil
-}
-
-func (s *stager) extractFromZip(ctx context.Context, f *os.File, size int64, destPath string) error {
-	// No total-content ceiling here, unlike the tar walk: a zip member that is
-	// not wanted is never opened, so nothing but the binary is ever inflated and
-	// maxFileBytes already bounds that.
-	r, err := zip.NewReader(f, size)
-	if err != nil {
-		return fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, err)
-	}
-
-	if len(r.File) > maxArchiveMembers {
-		return fmt.Errorf("%w: more than %d members", ErrArchiveRejected, maxArchiveMembers)
-	}
-
-	found := false
-	for _, member := range r.File {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return fmt.Errorf("reading the update archive: %w", ctxErr)
-		}
-		// Regular files only, same as the tar walk: the mode bits are what
-		// carry a zip symlink, and a directory entry is not a file.
-		if !member.Mode().IsRegular() || !s.wantsMember(member.Name) {
+		if target.binary {
+			foundBinary = true
 			continue
 		}
-		if found {
-			return fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
+		seenPayload[target.relativePath] = struct{}{}
+		payloadBytes += payload.Size
+		if payloadBytes > maxStagedPayloadBytes {
+			return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
+				ErrArchiveRejected, maxStagedPayloadBytes)
+		}
+		payloads = append(payloads, payload)
+	}
+	if !foundBinary {
+		return nil, fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
+	}
+	return payloads, nil
+}
+
+func (s *stager) extractFromZip(
+	ctx context.Context,
+	f *os.File,
+	size int64,
+	binaryPath, payloadDir string,
+) ([]stagedPayloadFile, error) {
+	r, err := zip.NewReader(f, size)
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading the update archive: %w", ErrArchiveRejected, err)
+	}
+	if len(r.File) > maxArchiveMembers {
+		return nil, fmt.Errorf("%w: more than %d members", ErrArchiveRejected, maxArchiveMembers)
+	}
+
+	foundBinary := false
+	seenPayload := make(map[string]struct{})
+	var payloads []stagedPayloadFile
+	var payloadBytes int64
+	for _, member := range r.File {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("reading the update archive: %w", ctxErr)
+		}
+		if !member.Mode().IsRegular() {
+			continue
+		}
+		if s.invalidPayloadMember(member.Name) {
+			return nil, fmt.Errorf("%w: invalid payload member %q", ErrArchiveRejected, member.Name)
+		}
+		target, wanted := s.memberTarget(member.Name, binaryPath, payloadDir)
+		if !wanted {
+			continue
+		}
+		if target.binary && foundBinary {
+			return nil, fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
+		}
+		if !target.binary {
+			if _, duplicate := seenPayload[target.relativePath]; duplicate {
+				return nil, fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
+			}
+			if member.FileInfo().Size() > maxStagedPayloadBytes-payloadBytes {
+				return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
+					ErrArchiveRejected, maxStagedPayloadBytes)
+			}
 		}
 		if declared := member.FileInfo().Size(); declared > s.maxFileBytes {
-			return fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
+			return nil, fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
 				ErrArchiveRejected, member.Name, declared, s.maxFileBytes)
 		}
-
 		rc, openErr := member.Open()
 		if openErr != nil {
-			return fmt.Errorf("%w: reading %s: %w", ErrArchiveRejected, member.Name, openErr)
+			return nil, fmt.Errorf("%w: reading %s: %w", ErrArchiveRejected, member.Name, openErr)
 		}
-		copyErr := copyStagedFile(ctx, rc, destPath, s.maxFileBytes)
+		payload, copyErr := s.copyArchiveMember(ctx, rc, target, member.Mode())
 		closeQuietly(rc, "update archive member")
 		if copyErr != nil {
-			return copyErr
+			return nil, copyErr
 		}
-		found = true
+		if target.binary {
+			foundBinary = true
+			continue
+		}
+		seenPayload[target.relativePath] = struct{}{}
+		payloadBytes += payload.Size
+		if payloadBytes > maxStagedPayloadBytes {
+			return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
+				ErrArchiveRejected, maxStagedPayloadBytes)
+		}
+		payloads = append(payloads, payload)
 	}
-
-	if !found {
-		return fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
+	if !foundBinary {
+		return nil, fmt.Errorf("%w: no %s in it", ErrArchiveRejected, s.binaryName)
 	}
-	return nil
+	return payloads, nil
 }
 
 // wantsMember reports whether a member is the binary being staged. It has to be

--- a/pkg/service/updater/extract.go
+++ b/pkg/service/updater/extract.go
@@ -38,7 +38,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -178,51 +177,71 @@ type archiveMemberTarget struct {
 	destPath     string
 	relativePath string
 	binary       bool
+	mode         os.FileMode
 }
 
 func (s *stager) memberTarget(name, binaryPath, payloadDir string) (archiveMemberTarget, bool) {
 	if s.wantsMember(name) {
 		return archiveMemberTarget{destPath: binaryPath, binary: true}, true
 	}
-	for _, root := range s.payloadRoots {
-		relative, ok := updatepayload.RelativeMember(root, name)
-		if !ok || !updatepayload.IncludeSource(relative) {
-			continue
-		}
-		archivePath := path.Join(root.ArchiveRoot, relative)
-		destPath := filepath.Join(payloadDir, filepath.FromSlash(archivePath))
-		nativeRelative, err := filepath.Rel(payloadDir, destPath)
-		if err != nil || nativeRelative == ".." || strings.HasPrefix(nativeRelative, ".."+string(filepath.Separator)) {
-			return archiveMemberTarget{}, false
-		}
-		return archiveMemberTarget{destPath: destPath, relativePath: archivePath}, true
+	file, ok := updatepayload.MatchArchiveFile(s.payload, name)
+	if !ok {
+		return archiveMemberTarget{}, false
 	}
-	return archiveMemberTarget{}, false
+	destPath := filepath.Join(payloadDir, filepath.FromSlash(file.ArchivePath))
+	nativeRelative, err := filepath.Rel(payloadDir, destPath)
+	if err != nil || nativeRelative == ".." || strings.HasPrefix(nativeRelative, ".."+string(filepath.Separator)) {
+		return archiveMemberTarget{}, false
+	}
+	return archiveMemberTarget{
+		destPath: destPath, relativePath: file.InstallPath, mode: file.Mode,
+	}, true
 }
 
 func (s *stager) invalidPayloadMember(name string) bool {
-	for _, root := range s.payloadRoots {
-		if strings.HasPrefix(name, root.ArchiveRoot+"/") ||
-			strings.HasPrefix(name, root.ArchiveRoot+`\`) {
-			_, ok := updatepayload.RelativeMember(root, name)
-			return !ok
-		}
-	}
-	return false
+	return updatepayload.InvalidArchiveMember(s.payload, name)
 }
 
-func safePayloadMode(mode os.FileMode) os.FileMode {
-	if mode.Perm()&0o111 != 0 {
-		return 0o755
+type payloadBudget struct {
+	seen  map[string]struct{}
+	bytes int64
+}
+
+func newPayloadBudget() *payloadBudget {
+	return &payloadBudget{seen: make(map[string]struct{})}
+}
+
+func (b *payloadBudget) admit(target archiveMemberTarget, declared int64) error {
+	if target.binary {
+		return nil
 	}
-	return 0o644
+	if _, duplicate := b.seen[target.relativePath]; duplicate {
+		return fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
+	}
+	if declared > maxStagedPayloadBytes-b.bytes {
+		return fmt.Errorf("%w: payload files exceed the %d byte limit",
+			ErrArchiveRejected, maxStagedPayloadBytes)
+	}
+	return nil
+}
+
+func (b *payloadBudget) record(target archiveMemberTarget, payload stagedPayloadFile) error {
+	if target.binary {
+		return nil
+	}
+	b.seen[target.relativePath] = struct{}{}
+	b.bytes += payload.Size
+	if b.bytes > maxStagedPayloadBytes {
+		return fmt.Errorf("%w: payload files exceed the %d byte limit",
+			ErrArchiveRejected, maxStagedPayloadBytes)
+	}
+	return nil
 }
 
 func (s *stager) copyArchiveMember(
 	ctx context.Context,
 	src io.Reader,
 	target archiveMemberTarget,
-	mode os.FileMode,
 ) (stagedPayloadFile, error) {
 	if !target.binary {
 		//nolint:gosec // target is derived from a validated configured payload root
@@ -236,7 +255,7 @@ func (s *stager) copyArchiveMember(
 	if target.binary {
 		return stagedPayloadFile{}, nil
 	}
-	mode = safePayloadMode(mode)
+	mode := target.mode.Perm()
 	if err := s.chmod(target.destPath, mode); err != nil {
 		return stagedPayloadFile{}, fmt.Errorf(
 			"setting staged payload permissions for %q: %w", target.relativePath, err)
@@ -271,9 +290,8 @@ func (s *stager) extractFromTarGz(
 	overBudget := func() bool { return inflated.N <= 0 }
 	tr := tar.NewReader(inflated)
 	foundBinary := false
-	seenPayload := make(map[string]struct{})
+	budget := newPayloadBudget()
 	var payloads []stagedPayloadFile
-	var payloadBytes int64
 	members := 0
 	for {
 		header, nextErr := tr.Next()
@@ -307,20 +325,14 @@ func (s *stager) extractFromTarGz(
 		if target.binary && foundBinary {
 			return nil, fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
 		}
-		if !target.binary {
-			if _, duplicate := seenPayload[target.relativePath]; duplicate {
-				return nil, fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
-			}
-			if header.Size > maxStagedPayloadBytes-payloadBytes {
-				return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
-					ErrArchiveRejected, maxStagedPayloadBytes)
-			}
+		if err := budget.admit(target, header.Size); err != nil {
+			return nil, err
 		}
 		if header.Size > s.maxFileBytes {
 			return nil, fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
 				ErrArchiveRejected, header.Name, header.Size, s.maxFileBytes)
 		}
-		payload, copyErr := s.copyArchiveMember(ctx, tr, target, header.FileInfo().Mode())
+		payload, copyErr := s.copyArchiveMember(ctx, tr, target)
 		if copyErr != nil {
 			if ctx.Err() == nil && overBudget() {
 				return nil, fmt.Errorf("%w: more than %d bytes of content in it",
@@ -332,11 +344,8 @@ func (s *stager) extractFromTarGz(
 			foundBinary = true
 			continue
 		}
-		seenPayload[target.relativePath] = struct{}{}
-		payloadBytes += payload.Size
-		if payloadBytes > maxStagedPayloadBytes {
-			return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
-				ErrArchiveRejected, maxStagedPayloadBytes)
+		if err := budget.record(target, payload); err != nil {
+			return nil, err
 		}
 		payloads = append(payloads, payload)
 	}
@@ -361,9 +370,8 @@ func (s *stager) extractFromZip(
 	}
 
 	foundBinary := false
-	seenPayload := make(map[string]struct{})
+	budget := newPayloadBudget()
 	var payloads []stagedPayloadFile
-	var payloadBytes int64
 	for _, member := range r.File {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("reading the update archive: %w", ctxErr)
@@ -381,14 +389,8 @@ func (s *stager) extractFromZip(
 		if target.binary && foundBinary {
 			return nil, fmt.Errorf("%w: more than one %s", ErrArchiveRejected, s.binaryName)
 		}
-		if !target.binary {
-			if _, duplicate := seenPayload[target.relativePath]; duplicate {
-				return nil, fmt.Errorf("%w: duplicate payload member %q", ErrArchiveRejected, target.relativePath)
-			}
-			if member.FileInfo().Size() > maxStagedPayloadBytes-payloadBytes {
-				return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
-					ErrArchiveRejected, maxStagedPayloadBytes)
-			}
+		if err := budget.admit(target, member.FileInfo().Size()); err != nil {
+			return nil, err
 		}
 		if declared := member.FileInfo().Size(); declared > s.maxFileBytes {
 			return nil, fmt.Errorf("%w: %s declares %d bytes, over the %d byte limit",
@@ -398,7 +400,7 @@ func (s *stager) extractFromZip(
 		if openErr != nil {
 			return nil, fmt.Errorf("%w: reading %s: %w", ErrArchiveRejected, member.Name, openErr)
 		}
-		payload, copyErr := s.copyArchiveMember(ctx, rc, target, member.Mode())
+		payload, copyErr := s.copyArchiveMember(ctx, rc, target)
 		closeQuietly(rc, "update archive member")
 		if copyErr != nil {
 			return nil, copyErr
@@ -407,11 +409,8 @@ func (s *stager) extractFromZip(
 			foundBinary = true
 			continue
 		}
-		seenPayload[target.relativePath] = struct{}{}
-		payloadBytes += payload.Size
-		if payloadBytes > maxStagedPayloadBytes {
-			return nil, fmt.Errorf("%w: payload files exceed the %d byte limit",
-				ErrArchiveRejected, maxStagedPayloadBytes)
+		if err := budget.record(target, payload); err != nil {
+			return nil, err
 		}
 		payloads = append(payloads, payload)
 	}

--- a/pkg/service/updater/extract_test.go
+++ b/pkg/service/updater/extract_test.go
@@ -644,6 +644,35 @@ func TestExtractRelease_IncludesConfiguredPayload(t *testing.T) {
 	}
 }
 
+func TestExtractRelease_RejectsMissingConfiguredPayload(t *testing.T) {
+	t.Parallel()
+
+	for _, ext := range []string{otameta.ArchiveExtTarGz, otameta.ArchiveExtZip} {
+		t.Run(ext, func(t *testing.T) {
+			t.Parallel()
+			h := newExtractHarness(t, ext)
+			h.stager.payload = extractTestPayload()
+			h.stager.chmod = os.Chmod
+			switch ext {
+			case otameta.ArchiveExtTarGz:
+				writeTarGz(t, h.archivePath, []tarMember{
+					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+				})
+			case otameta.ArchiveExtZip:
+				writeZip(t, h.archivePath, []zipMember{
+					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+				})
+			}
+
+			err := h.extract(t, ext)
+			require.ErrorIs(t, err, ErrArchiveRejected)
+			assert.Contains(t, err.Error(), "scripts/configs/settings.conf")
+		})
+	}
+}
+
 func TestExtractRelease_RejectsDuplicateOrInvalidPayload(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/extract_test.go
+++ b/pkg/service/updater/extract_test.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 	"testing"
 
+	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	"github.com/stretchr/testify/assert"
@@ -126,6 +127,21 @@ func writeZip(t *testing.T, path string, members []zipMember) {
 // extractHarness lays a tree out so an escape is visible: the archive, the
 // payload directory extraction is allowed to write into, and a sibling holding
 // a file that must never change.
+func extractTestPayload() []updatepayload.File {
+	return []updatepayload.File{
+		{
+			ArchivePath: "scripts/services/zaparoo_service",
+			InstallPath: "services/zaparoo_service",
+			Mode:        0o755,
+		},
+		{
+			ArchivePath: "scripts/configs/settings.conf",
+			InstallPath: "configs/settings.conf",
+			Mode:        0o644,
+		},
+	}
+}
+
 type extractHarness struct {
 	stager      *stager
 	base        string
@@ -593,20 +609,21 @@ func TestExtractRelease_IncludesConfiguredPayload(t *testing.T) {
 		t.Run(ext, func(t *testing.T) {
 			t.Parallel()
 			h := newExtractHarness(t, ext)
-			h.stager.payloadRoots = []updatepayload.Root{{ArchiveRoot: "scripts"}}
+			h.stager.platformID = platformids.Batocera
+			h.stager.payload = extractTestPayload()
 			h.stager.chmod = os.Chmod
 			switch ext {
 			case otameta.ArchiveExtTarGz:
 				writeTarGz(t, h.archivePath, []tarMember{
 					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
-					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o644},
 					{name: "scripts/configs/settings.conf", body: []byte("config"), mode: 0o600},
 					{name: "scripts/.DS_Store", body: []byte("metadata")},
 				})
 			case otameta.ArchiveExtZip:
 				writeZip(t, h.archivePath, []zipMember{
 					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
-					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o644},
 					{name: "scripts/configs/settings.conf", body: []byte("config"), mode: 0o600},
 					{name: "scripts/.DS_Store", body: []byte("metadata")},
 				})
@@ -617,9 +634,9 @@ func TestExtractRelease_IncludesConfiguredPayload(t *testing.T) {
 			)
 			require.NoError(t, err)
 			require.Len(t, payloads, 2)
-			assert.Equal(t, "scripts/services/zaparoo_service", payloads[0].RelativePath)
+			assert.Equal(t, "services/zaparoo_service", payloads[0].RelativePath)
 			assert.Equal(t, os.FileMode(0o755), payloads[0].Mode)
-			assert.Equal(t, "scripts/configs/settings.conf", payloads[1].RelativePath)
+			assert.Equal(t, "configs/settings.conf", payloads[1].RelativePath)
 			assert.Equal(t, os.FileMode(0o644), payloads[1].Mode)
 			assert.FileExists(t, filepath.Join(h.payloadDir, "scripts", "services", "zaparoo_service"))
 			assert.NoFileExists(t, filepath.Join(h.payloadDir, "scripts", ".DS_Store"))
@@ -635,14 +652,15 @@ func TestExtractRelease_RejectsDuplicateOrInvalidPayload(t *testing.T) {
 		member string
 		dupe   bool
 	}{
-		{name: "duplicate", member: "scripts/file", dupe: true},
+		{name: "duplicate", member: "scripts/services/zaparoo_service", dupe: true},
 		{name: "parent traversal", member: "scripts/../file"},
 		{name: "backslash traversal", member: `scripts\..\file`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			h := newExtractHarness(t, otameta.ArchiveExtZip)
-			h.stager.payloadRoots = []updatepayload.Root{{ArchiveRoot: "scripts"}}
+			h.stager.platformID = platformids.Batocera
+			h.stager.payload = extractTestPayload()
 			h.stager.chmod = os.Chmod
 			members := []zipMember{
 				{name: "zaparoo", body: []byte("binary"), mode: 0o755},

--- a/pkg/service/updater/extract_test.go
+++ b/pkg/service/updater/extract_test.go
@@ -36,6 +36,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -489,13 +490,15 @@ func TestExtractWalk_StopsOnCancellation(t *testing.T) {
 		{
 			ext: otameta.ArchiveExtTarGz,
 			walk: func(h *extractHarness, ctx context.Context, f *os.File, _ int64) error {
-				return h.stager.extractFromTarGz(ctx, f, h.destPath)
+				_, err := h.stager.extractFromTarGz(ctx, f, h.destPath, h.payloadDir)
+				return err
 			},
 		},
 		{
 			ext: otameta.ArchiveExtZip,
 			walk: func(h *extractHarness, ctx context.Context, f *os.File, size int64) error {
-				return h.stager.extractFromZip(ctx, f, size, h.destPath)
+				_, err := h.stager.extractFromZip(ctx, f, size, h.destPath, h.payloadDir)
+				return err
 			},
 		},
 	}
@@ -580,6 +583,82 @@ func writeArchive(t *testing.T, path, ext, memberName string, binary []byte) {
 		writeZip(t, path, []zipMember{{name: memberName, body: binary, mode: 0o755}})
 	default:
 		t.Fatalf("unsupported archive extension %q", ext)
+	}
+}
+
+func TestExtractRelease_IncludesConfiguredPayload(t *testing.T) {
+	t.Parallel()
+
+	for _, ext := range []string{otameta.ArchiveExtTarGz, otameta.ArchiveExtZip} {
+		t.Run(ext, func(t *testing.T) {
+			t.Parallel()
+			h := newExtractHarness(t, ext)
+			h.stager.payloadRoots = []updatepayload.Root{{ArchiveRoot: "scripts"}}
+			h.stager.chmod = os.Chmod
+			switch ext {
+			case otameta.ArchiveExtTarGz:
+				writeTarGz(t, h.archivePath, []tarMember{
+					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+					{name: "scripts/configs/settings.conf", body: []byte("config"), mode: 0o600},
+					{name: "scripts/.DS_Store", body: []byte("metadata")},
+				})
+			case otameta.ArchiveExtZip:
+				writeZip(t, h.archivePath, []zipMember{
+					{name: "zaparoo", body: []byte("binary"), mode: 0o755},
+					{name: "scripts/services/zaparoo_service", body: []byte("service"), mode: 0o755},
+					{name: "scripts/configs/settings.conf", body: []byte("config"), mode: 0o600},
+					{name: "scripts/.DS_Store", body: []byte("metadata")},
+				})
+			}
+
+			payloads, err := h.stager.extractRelease(
+				context.Background(), h.archivePath, ext, archiveDigest(t, h.archivePath), h.destPath, h.payloadDir,
+			)
+			require.NoError(t, err)
+			require.Len(t, payloads, 2)
+			assert.Equal(t, "scripts/services/zaparoo_service", payloads[0].RelativePath)
+			assert.Equal(t, os.FileMode(0o755), payloads[0].Mode)
+			assert.Equal(t, "scripts/configs/settings.conf", payloads[1].RelativePath)
+			assert.Equal(t, os.FileMode(0o644), payloads[1].Mode)
+			assert.FileExists(t, filepath.Join(h.payloadDir, "scripts", "services", "zaparoo_service"))
+			assert.NoFileExists(t, filepath.Join(h.payloadDir, "scripts", ".DS_Store"))
+		})
+	}
+}
+
+func TestExtractRelease_RejectsDuplicateOrInvalidPayload(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		member string
+		dupe   bool
+	}{
+		{name: "duplicate", member: "scripts/file", dupe: true},
+		{name: "parent traversal", member: "scripts/../file"},
+		{name: "backslash traversal", member: `scripts\..\file`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newExtractHarness(t, otameta.ArchiveExtZip)
+			h.stager.payloadRoots = []updatepayload.Root{{ArchiveRoot: "scripts"}}
+			h.stager.chmod = os.Chmod
+			members := []zipMember{
+				{name: "zaparoo", body: []byte("binary"), mode: 0o755},
+				{name: tt.member, body: []byte("payload")},
+			}
+			if tt.dupe {
+				members = append(members, zipMember{name: tt.member, body: []byte("other")})
+			}
+			writeZip(t, h.archivePath, members)
+
+			_, err := h.stager.extractRelease(
+				context.Background(), h.archivePath, otameta.ArchiveExtZip,
+				archiveDigest(t, h.archivePath), h.destPath, h.payloadDir,
+			)
+			require.ErrorIs(t, err, ErrArchiveRejected)
+		})
 	}
 }
 

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
 )
 
 const (
@@ -43,6 +44,44 @@ const (
 // an update replaces the running binary.
 type UpdateBackupper interface {
 	BackupForUpdate(targetVersion string) (database.BackupInfo, func() error, error)
+}
+
+type payloadInstallOps struct {
+	fs            afero.Fs
+	replace       func(string, string) error
+	remove        func(string) error
+	stat          func(string) (os.FileInfo, error)
+	syncDirectory func(string) error
+}
+
+func defaultPayloadInstallOps() payloadInstallOps {
+	return payloadInstallOps{
+		fs:            afero.NewOsFs(),
+		replace:       replaceFile,
+		remove:        os.Remove,
+		stat:          os.Lstat,
+		syncDirectory: syncDir,
+	}
+}
+
+func (o payloadInstallOps) withDefaults() payloadInstallOps {
+	defaults := defaultPayloadInstallOps()
+	if o.fs == nil {
+		o.fs = defaults.fs
+	}
+	if o.replace == nil {
+		o.replace = defaults.replace
+	}
+	if o.remove == nil {
+		o.remove = defaults.remove
+	}
+	if o.stat == nil {
+		o.stat = defaults.stat
+	}
+	if o.syncDirectory == nil {
+		o.syncDirectory = defaults.syncDirectory
+	}
+	return o
 }
 
 type installOptions struct {
@@ -57,6 +96,7 @@ type installOptions struct {
 	// binary is how the install and its unwind move the executable around. The
 	// zero value does the real thing.
 	binary             installBinaryOps
+	payload            payloadInstallOps
 	TargetPath         string
 	DataDir            string
 	PreviousVersion    string
@@ -83,6 +123,7 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 	markerMu.Lock()
 	defer markerMu.Unlock()
 
+	payloadOps := opts.payload.withDefaults()
 	dir := stateDirFor(opts.DataDir)
 	pending, loadErr := loadMarker(dir)
 	if loadErr != nil {
@@ -124,12 +165,24 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 		return candidateErr
 	}
 
-	// Everything up to here can be abandoned by deleting two files. From the
+	payloadBackups, payloadErr := preparePayloadCandidates(opts.Staged, filepath.Dir(opts.TargetPath), payloadOps)
+	if payloadErr != nil {
+		_ = os.Remove(candidatePath)
+		removePreparedPayload(payloadBackups, payloadOps)
+		if cleanupErr := removeStagingDir(ctx, opts.Staged.Dir); cleanupErr != nil {
+			log.Warn().Err(cleanupErr).Str("dir", opts.Staged.Dir).
+				Msg("could not remove staging after payload preparation failed")
+		}
+		return payloadErr
+	}
+
+	// Everything up to here can be abandoned by deleting candidates and backups. From the
 	// snapshot on, the device is committed to either finishing or unwinding, so
 	// this is where a caller gets its last say.
 	if opts.PreQuiesce != nil {
 		if err := opts.PreQuiesce(ctx); err != nil {
 			_ = os.Remove(candidatePath)
+			removePreparedPayload(payloadBackups, payloadOps)
 			if cleanupErr := removeStagingDir(ctx, opts.Staged.Dir); cleanupErr != nil {
 				log.Warn().Err(cleanupErr).Str("dir", opts.Staged.Dir).
 					Msg("could not remove staging after the update was called off")
@@ -142,6 +195,7 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 	snapshot, resumeUserDB, err := opts.UserDB.BackupForUpdate(opts.Staged.Version)
 	if err != nil {
 		_ = os.Remove(candidatePath)
+		removePreparedPayload(payloadBackups, payloadOps)
 		if cleanupErr := removeStagingDir(ctx, opts.Staged.Dir); cleanupErr != nil {
 			log.Warn().Err(cleanupErr).Str("dir", opts.Staged.Dir).
 				Msg("could not remove staging after the update snapshot failed")
@@ -170,14 +224,26 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 		PlatformID:         opts.PlatformID,
 		UserDBSnapshotPath: snapshot.Path,
 		ManifestGeneration: opts.ManifestGeneration,
+		PayloadBackups:     payloadBackups,
 	}
 	if err := preserveCurrentBinary(opts.TargetPath, backupPath); err != nil {
-		removeInstallArtifacts(ctx, m, candidatePath, opts.binary)
+		removeInstallArtifacts(ctx, m, candidatePath, opts.binary, payloadOps)
 		return fmt.Errorf("preserving the current binary: %w", err)
 	}
 	if err := saveMarker(dir, m); err != nil {
-		removeInstallArtifacts(ctx, m, candidatePath, opts.binary)
+		removeInstallArtifacts(ctx, m, candidatePath, opts.binary, payloadOps)
 		return fmt.Errorf("recording the start of the update install: %w", err)
+	}
+
+	for _, payload := range m.PayloadBackups {
+		if err := payloadOps.replace(payload.CandidatePath, payload.TargetPath); err != nil {
+			return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
+				fmt.Errorf("installing payload file %q: %w", payload.TargetPath, err))
+		}
+		if err := payloadOps.syncDirectory(filepath.Dir(payload.TargetPath)); err != nil {
+			return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
+				fmt.Errorf("flushing installed payload file %q: %w", payload.TargetPath, err))
+		}
 	}
 
 	// Target holds the old executable until this swap and the verified new one
@@ -186,7 +252,7 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 	// to be vacated first the target name is briefly empty instead, and the
 	// marker written above is what tells the next boot to put the backup back.
 	if err := opts.binary.replace(candidatePath, opts.TargetPath); err != nil {
-		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath, opts.binary,
+		return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
 			fmt.Errorf("installing the staged binary: %w", err))
 	}
 	// From here the target name means the new binary, so an unwind has real work
@@ -194,13 +260,13 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 	// the unwind has to leave it alone.
 	m.BinaryReplaced = true
 	if err := syncDir(filepath.Dir(opts.TargetPath)); err != nil {
-		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath, opts.binary,
+		return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
 			fmt.Errorf("flushing the installed binary: %w", err))
 	}
 
 	m.State = markerInstalled
 	if err := saveMarker(dir, m); err != nil {
-		return abortInstallAfterError(ctx, opts.DataDir, m, candidatePath, opts.binary,
+		return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
 			fmt.Errorf("recording the completed update install: %w", err))
 	}
 
@@ -323,24 +389,174 @@ func prepareInstallCandidate(
 	return nil
 }
 
+func preparePayloadCandidates(
+	staged *StagedUpdate,
+	installRoot string,
+	ops payloadInstallOps,
+) ([]payloadBackup, error) {
+	if staged == nil || len(staged.payloadFiles) == 0 {
+		return nil, nil
+	}
+	ops = ops.withDefaults()
+	root := filepath.Clean(installRoot)
+	prepared := make([]payloadBackup, 0, len(staged.payloadFiles))
+	for _, file := range staged.payloadFiles {
+		relative := filepath.FromSlash(file.RelativePath)
+		targetPath := filepath.Join(root, relative)
+		relToRoot, err := filepath.Rel(root, targetPath)
+		if err != nil || relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+			return prepared, fmt.Errorf("payload target %q escapes install root", file.RelativePath)
+		}
+		entry := payloadBackup{
+			TargetPath:    targetPath,
+			BackupPath:    installSidecarPath(targetPath, installBackupSuffix),
+			CandidatePath: installSidecarPath(targetPath, installCandidateSuffix),
+		}
+		prepared = append(prepared, entry)
+		entryAt := &prepared[len(prepared)-1]
+
+		//nolint:gosec // target path is constrained beneath the resolved install root
+		if err := os.MkdirAll(filepath.Dir(targetPath), stateDirPerm); err != nil {
+			return prepared, fmt.Errorf("creating payload target directory: %w", err)
+		}
+		if err := ops.remove(entry.CandidatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return prepared, fmt.Errorf("removing stale payload candidate %q: %w", entry.CandidatePath, err)
+		}
+
+		targetInfo, statErr := ops.stat(targetPath)
+		switch {
+		case errors.Is(statErr, os.ErrNotExist):
+			entryAt.OriginalMissing = true
+			entryAt.BackupPath = ""
+		case statErr != nil:
+			return prepared, fmt.Errorf("reading payload target %q: %w", targetPath, statErr)
+		case !targetInfo.Mode().IsRegular():
+			return prepared, fmt.Errorf("payload target %q is not a regular file", targetPath)
+		}
+
+		if err := copyPayloadFile(file.Path, entry.CandidatePath, file.Mode); err != nil {
+			return prepared, fmt.Errorf("preparing payload candidate %q: %w", targetPath, err)
+		}
+		if err := ops.syncDirectory(filepath.Dir(targetPath)); err != nil {
+			return prepared, fmt.Errorf("flushing payload candidate %q: %w", targetPath, err)
+		}
+		if entryAt.OriginalMissing {
+			continue
+		}
+		if _, backupErr := ops.stat(entry.BackupPath); backupErr == nil {
+			if err := ops.remove(entry.BackupPath); err != nil {
+				return prepared, fmt.Errorf("removing orphaned payload backup %q: %w", entry.BackupPath, err)
+			}
+		} else if !errors.Is(backupErr, os.ErrNotExist) {
+			return prepared, fmt.Errorf("checking payload backup %q: %w", entry.BackupPath, backupErr)
+		}
+		if err := copyPayloadFile(targetPath, entry.BackupPath, targetInfo.Mode().Perm()); err != nil {
+			return prepared, fmt.Errorf("preserving payload target %q: %w", targetPath, err)
+		}
+		if err := ops.syncDirectory(filepath.Dir(targetPath)); err != nil {
+			return prepared, fmt.Errorf("flushing payload backup %q: %w", targetPath, err)
+		}
+	}
+	return prepared, nil
+}
+
+func copyPayloadFile(source, target string, mode os.FileMode) error {
+	//nolint:gosec // source and target are derived from verified staging and a controlled install root
+	src, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("opening payload source: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	//nolint:gosec // payload modes are normalized during staging
+	dst, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("creating payload sidecar: %w", err)
+	}
+	_, copyErr := io.Copy(dst, src)
+	chmodErr := dst.Chmod(mode.Perm())
+	syncErr := dst.Sync()
+	closeErr := dst.Close()
+	if copyErr != nil {
+		_ = os.Remove(target)
+		return fmt.Errorf("copying payload sidecar: %w", copyErr)
+	}
+	if chmodErr != nil {
+		_ = os.Remove(target)
+		return fmt.Errorf("setting payload sidecar permissions: %w", chmodErr)
+	}
+	if syncErr != nil {
+		_ = os.Remove(target)
+		return fmt.Errorf("flushing payload sidecar: %w", syncErr)
+	}
+	if closeErr != nil {
+		_ = os.Remove(target)
+		return fmt.Errorf("closing payload sidecar: %w", closeErr)
+	}
+	return nil
+}
+
+func removePreparedPayload(payloads []payloadBackup, ops payloadInstallOps) {
+	ops = ops.withDefaults()
+	for _, payload := range payloads {
+		for _, path := range []string{payload.CandidatePath, payload.BackupPath} {
+			if path == "" {
+				continue
+			}
+			if err := ops.remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+				log.Warn().Err(err).Str("path", path).Msg("could not remove unused payload sidecar")
+			}
+		}
+	}
+}
+
 func abortInstallAfterError(
 	ctx context.Context, dataDir string, m *pendingMarker, candidatePath string,
 	binary installBinaryOps, installErr error,
 ) error {
-	if abortErr := abortInstall(ctx, dataDir, m, candidatePath, binary); abortErr != nil {
+	return abortInstallAfterErrorWithOps(
+		ctx, dataDir, m, candidatePath, binary, defaultPayloadInstallOps(), installErr,
+	)
+}
+
+func abortInstallAfterErrorWithOps(
+	ctx context.Context, dataDir string, m *pendingMarker, candidatePath string,
+	binary installBinaryOps, payloadOps payloadInstallOps, installErr error,
+) error {
+	if abortErr := abortInstallWithOps(ctx, dataDir, m, candidatePath, binary, payloadOps); abortErr != nil {
 		return fmt.Errorf("%w; aborting the partial install also failed: %w", installErr, abortErr)
 	}
 	return installErr
 }
 
-// abortInstall restores only the binary. The new version has not run yet, so
-// restoring the UserDB snapshot would discard writes made while Apply was live.
-// Callers hold markerMu.
+// abortInstall restores payload files and the binary without restoring UserDB.
+// The incoming version has not run yet, so restoring its snapshot would discard
+// writes made while Apply was live. Callers hold markerMu.
 func abortInstall(
 	ctx context.Context, dataDir string, m *pendingMarker, candidatePath string, binary installBinaryOps,
 ) error {
+	return abortInstallWithOps(ctx, dataDir, m, candidatePath, binary, defaultPayloadInstallOps())
+}
+
+func abortInstallWithOps(
+	ctx context.Context,
+	dataDir string,
+	m *pendingMarker,
+	candidatePath string,
+	binary installBinaryOps,
+	payloadOps payloadInstallOps,
+) error {
 	if m == nil {
 		return nil
+	}
+	payloadOps = payloadOps.withDefaults()
+	fileOps := defaultWatchdogFileOps()
+	fileOps.fs = payloadOps.fs
+	fileOps.binary = binary
+	fileOps.replace = payloadOps.replace
+	fileOps.syncDirectory = payloadOps.syncDirectory
+	if err := restorePayloadFiles(stateDirFor(dataDir), m, fileOps); err != nil {
+		return err
 	}
 	if err := restoreBinaryAfterFailedInstall(m, binary); err != nil {
 		return err
@@ -349,7 +565,7 @@ func abortInstall(
 	if err := clearMarker(stateDirFor(dataDir)); err != nil {
 		return err
 	}
-	removeInstallArtifacts(ctx, m, candidatePath, binary)
+	removeInstallArtifacts(ctx, m, candidatePath, binary, payloadOps)
 	return nil
 }
 
@@ -395,8 +611,16 @@ func restoreBinaryAfterFailedInstall(m *pendingMarker, binary installBinaryOps) 
 }
 
 func removeInstallArtifacts(
-	ctx context.Context, m *pendingMarker, candidatePath string, binary installBinaryOps,
+	ctx context.Context,
+	m *pendingMarker,
+	candidatePath string,
+	binary installBinaryOps,
+	payloadOptions ...payloadInstallOps,
 ) {
+	payloadOps := defaultPayloadInstallOps()
+	if len(payloadOptions) > 0 {
+		payloadOps = payloadOptions[0].withDefaults()
+	}
 	if m != nil {
 		binary.sweep(m.TargetPath)
 	}
@@ -409,6 +633,9 @@ func removeInstallArtifacts(
 		if err := os.Remove(candidatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
 			log.Warn().Err(err).Str("path", candidatePath).Msg("could not remove update install candidate")
 		}
+	}
+	if m != nil {
+		removePreparedPayload(m.PayloadBackups, payloadOps)
 	}
 	if m != nil && m.UserDBSnapshotPath != "" {
 		if err := os.Remove(m.UserDBSnapshotPath); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -54,6 +54,7 @@ type payloadInstallOps struct {
 	stat          func(string) (os.FileInfo, error)
 	syncDirectory func(string) error
 	saveMarker    func(string, *pendingMarker) error
+	clearMarker   func(string) error
 }
 
 func defaultPayloadInstallOps() payloadInstallOps {
@@ -64,6 +65,7 @@ func defaultPayloadInstallOps() payloadInstallOps {
 		stat:          os.Lstat,
 		syncDirectory: syncDir,
 		saveMarker:    saveMarker,
+		clearMarker:   clearMarker,
 	}
 }
 
@@ -99,6 +101,9 @@ func (o payloadInstallOps) withDefaults() payloadInstallOps {
 	}
 	if o.saveMarker == nil {
 		o.saveMarker = defaults.saveMarker
+	}
+	if o.clearMarker == nil {
+		o.clearMarker = defaults.clearMarker
 	}
 	return o
 }
@@ -573,6 +578,7 @@ func abortInstallWithOps(
 	fileOps.replace = payloadOps.replace
 	fileOps.syncDirectory = payloadOps.syncDirectory
 	fileOps.marker.save = payloadOps.saveMarker
+	fileOps.marker.clear = payloadOps.clearMarker
 	if err := restorePayloadFiles(stateDirFor(dataDir), m, fileOps); err != nil {
 		return err
 	}
@@ -580,7 +586,7 @@ func abortInstallWithOps(
 		return err
 	}
 
-	if err := clearMarker(stateDirFor(dataDir)); err != nil {
+	if err := payloadOps.clearMarker(stateDirFor(dataDir)); err != nil {
 		return err
 	}
 	removeInstallArtifacts(ctx, m, candidatePath, binary, payloadOps)

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -572,7 +572,7 @@ func abortInstallWithOps(
 	fileOps.binary = binary
 	fileOps.replace = payloadOps.replace
 	fileOps.syncDirectory = payloadOps.syncDirectory
-	fileOps.saveMarker = payloadOps.saveMarker
+	fileOps.marker.save = payloadOps.saveMarker
 	if err := restorePayloadFiles(stateDirFor(dataDir), m, fileOps); err != nil {
 		return err
 	}

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 )
@@ -52,6 +53,7 @@ type payloadInstallOps struct {
 	remove        func(string) error
 	stat          func(string) (os.FileInfo, error)
 	syncDirectory func(string) error
+	saveMarker    func(string, *pendingMarker) error
 }
 
 func defaultPayloadInstallOps() payloadInstallOps {
@@ -61,6 +63,7 @@ func defaultPayloadInstallOps() payloadInstallOps {
 		remove:        os.Remove,
 		stat:          os.Lstat,
 		syncDirectory: syncDir,
+		saveMarker:    saveMarker,
 	}
 }
 
@@ -69,17 +72,33 @@ func (o payloadInstallOps) withDefaults() payloadInstallOps {
 	if o.fs == nil {
 		o.fs = defaults.fs
 	}
+	_, osBacked := o.fs.(*afero.OsFs)
 	if o.replace == nil {
-		o.replace = defaults.replace
+		if osBacked {
+			o.replace = defaults.replace
+		} else {
+			o.replace = o.fs.Rename
+		}
 	}
 	if o.remove == nil {
-		o.remove = defaults.remove
+		o.remove = o.fs.Remove
 	}
 	if o.stat == nil {
-		o.stat = defaults.stat
+		if osBacked {
+			o.stat = defaults.stat
+		} else {
+			o.stat = o.fs.Stat
+		}
 	}
 	if o.syncDirectory == nil {
-		o.syncDirectory = defaults.syncDirectory
+		if osBacked {
+			o.syncDirectory = defaults.syncDirectory
+		} else {
+			o.syncDirectory = func(string) error { return nil }
+		}
+	}
+	if o.saveMarker == nil {
+		o.saveMarker = defaults.saveMarker
 	}
 	return o
 }
@@ -165,7 +184,7 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 		return candidateErr
 	}
 
-	payloadBackups, payloadErr := preparePayloadCandidates(opts.Staged, filepath.Dir(opts.TargetPath), payloadOps)
+	payloadBackups, payloadErr := preparePayloadCandidates(opts.Staged, opts.TargetPath, payloadOps)
 	if payloadErr != nil {
 		_ = os.Remove(candidatePath)
 		removePreparedPayload(payloadBackups, payloadOps)
@@ -391,21 +410,18 @@ func prepareInstallCandidate(
 
 func preparePayloadCandidates(
 	staged *StagedUpdate,
-	installRoot string,
+	binaryPath string,
 	ops payloadInstallOps,
 ) ([]payloadBackup, error) {
 	if staged == nil || len(staged.payloadFiles) == 0 {
 		return nil, nil
 	}
 	ops = ops.withDefaults()
-	root := filepath.Clean(installRoot)
 	prepared := make([]payloadBackup, 0, len(staged.payloadFiles))
 	for _, file := range staged.payloadFiles {
-		relative := filepath.FromSlash(file.RelativePath)
-		targetPath := filepath.Join(root, relative)
-		relToRoot, err := filepath.Rel(root, targetPath)
-		if err != nil || relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
-			return prepared, fmt.Errorf("payload target %q escapes install root", file.RelativePath)
+		targetPath, ok := updatepayload.ResolveInstallPath(binaryPath, file.RelativePath)
+		if !ok {
+			return prepared, fmt.Errorf("payload target %q is not configured", file.RelativePath)
 		}
 		entry := payloadBackup{
 			TargetPath:    targetPath,
@@ -416,7 +432,7 @@ func preparePayloadCandidates(
 		entryAt := &prepared[len(prepared)-1]
 
 		//nolint:gosec // target path is constrained beneath the resolved install root
-		if err := os.MkdirAll(filepath.Dir(targetPath), stateDirPerm); err != nil {
+		if err := (afero.Afero{Fs: ops.fs}).MkdirAll(filepath.Dir(targetPath), stateDirPerm); err != nil {
 			return prepared, fmt.Errorf("creating payload target directory: %w", err)
 		}
 		if err := ops.remove(entry.CandidatePath); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -434,7 +450,7 @@ func preparePayloadCandidates(
 			return prepared, fmt.Errorf("payload target %q is not a regular file", targetPath)
 		}
 
-		if err := copyPayloadFile(file.Path, entry.CandidatePath, file.Mode); err != nil {
+		if err := copyPayloadFile(ops, file.Path, entry.CandidatePath, file.Mode); err != nil {
 			return prepared, fmt.Errorf("preparing payload candidate %q: %w", targetPath, err)
 		}
 		if err := ops.syncDirectory(filepath.Dir(targetPath)); err != nil {
@@ -450,7 +466,7 @@ func preparePayloadCandidates(
 		} else if !errors.Is(backupErr, os.ErrNotExist) {
 			return prepared, fmt.Errorf("checking payload backup %q: %w", entry.BackupPath, backupErr)
 		}
-		if err := copyPayloadFile(targetPath, entry.BackupPath, targetInfo.Mode().Perm()); err != nil {
+		if err := copyPayloadFile(ops, targetPath, entry.BackupPath, targetInfo.Mode().Perm()); err != nil {
 			return prepared, fmt.Errorf("preserving payload target %q: %w", targetPath, err)
 		}
 		if err := ops.syncDirectory(filepath.Dir(targetPath)); err != nil {
@@ -460,37 +476,38 @@ func preparePayloadCandidates(
 	return prepared, nil
 }
 
-func copyPayloadFile(source, target string, mode os.FileMode) error {
+func copyPayloadFile(ops payloadInstallOps, source, target string, mode os.FileMode) error {
+	ops = ops.withDefaults()
 	//nolint:gosec // source and target are derived from verified staging and a controlled install root
-	src, err := os.Open(source)
+	src, err := ops.fs.Open(source)
 	if err != nil {
 		return fmt.Errorf("opening payload source: %w", err)
 	}
 	defer func() { _ = src.Close() }()
 
 	//nolint:gosec // payload modes are normalized during staging
-	dst, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
+	dst, err := ops.fs.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode.Perm())
 	if err != nil {
 		return fmt.Errorf("creating payload sidecar: %w", err)
 	}
 	_, copyErr := io.Copy(dst, src)
-	chmodErr := dst.Chmod(mode.Perm())
+	chmodErr := ops.fs.Chmod(target, mode.Perm())
 	syncErr := dst.Sync()
 	closeErr := dst.Close()
 	if copyErr != nil {
-		_ = os.Remove(target)
+		_ = ops.remove(target)
 		return fmt.Errorf("copying payload sidecar: %w", copyErr)
 	}
 	if chmodErr != nil {
-		_ = os.Remove(target)
+		_ = ops.remove(target)
 		return fmt.Errorf("setting payload sidecar permissions: %w", chmodErr)
 	}
 	if syncErr != nil {
-		_ = os.Remove(target)
+		_ = ops.remove(target)
 		return fmt.Errorf("flushing payload sidecar: %w", syncErr)
 	}
 	if closeErr != nil {
-		_ = os.Remove(target)
+		_ = ops.remove(target)
 		return fmt.Errorf("closing payload sidecar: %w", closeErr)
 	}
 	return nil
@@ -555,6 +572,7 @@ func abortInstallWithOps(
 	fileOps.binary = binary
 	fileOps.replace = payloadOps.replace
 	fileOps.syncDirectory = payloadOps.syncDirectory
+	fileOps.saveMarker = payloadOps.saveMarker
 	if err := restorePayloadFiles(stateDirFor(dataDir), m, fileOps); err != nil {
 		return err
 	}

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -206,15 +206,21 @@ func TestPreparePayloadCandidates_UsesInjectedFilesystem(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
-	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll("/staging", 0o750))
-	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll("/userdata/system/services", 0o750))
-	require.NoError(t, afero.WriteFile(fs, "/staging/service", []byte("new"), 0o755))
-	require.NoError(t, afero.WriteFile(fs, "/userdata/system/services/service", []byte("old"), 0o700))
+	root := string(filepath.Separator)
+	stagingDir := filepath.Join(root, "staging")
+	serviceDir := filepath.Join(root, "userdata", "system", "services")
+	stagedPath := filepath.Join(stagingDir, "service")
+	targetPath := filepath.Join(serviceDir, "service")
+	binaryPath := filepath.Join(root, "userdata", "system", "zaparoo")
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(stagingDir, 0o750))
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(serviceDir, 0o750))
+	require.NoError(t, afero.WriteFile(fs, stagedPath, []byte("new"), 0o755))
+	require.NoError(t, afero.WriteFile(fs, targetPath, []byte("old"), 0o700))
 	staged := &StagedUpdate{payloadFiles: []stagedPayloadFile{{
-		Path: "/staging/service", RelativePath: "services/service", Mode: 0o755,
+		Path: stagedPath, RelativePath: "services/service", Mode: 0o755,
 	}}}
 
-	backups, err := preparePayloadCandidates(staged, "/userdata/system/zaparoo", payloadInstallOps{fs: fs})
+	backups, err := preparePayloadCandidates(staged, binaryPath, payloadInstallOps{fs: fs})
 	require.NoError(t, err)
 	require.Len(t, backups, 1)
 	assert.Equal(t, "new", readAferoFileString(t, fs, backups[0].CandidatePath))
@@ -232,17 +238,19 @@ func TestCopyPayloadFile_UsesInjectedFilesystem(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/staged-helper.sh", []byte("helper"), 0o600))
+	root := string(filepath.Separator)
+	stagedPath := filepath.Join(root, "staged-helper.sh")
+	targetPath := filepath.Join(root, "target-helper.sh")
+	require.NoError(t, afero.WriteFile(fs, stagedPath, []byte("helper"), 0o600))
 	ops := payloadInstallOps{fs: fs}
-	require.NoError(t, copyPayloadFile(ops, "/staged-helper.sh", "/target-helper.sh", 0o755))
+	require.NoError(t, copyPayloadFile(ops, stagedPath, targetPath, 0o755))
 
-	content, err := afero.ReadFile(fs, "/target-helper.sh")
+	content, err := afero.ReadFile(fs, targetPath)
 	require.NoError(t, err)
 	assert.Equal(t, "helper", string(content))
-	info, err := fs.Stat("/target-helper.sh")
+	info, err := fs.Stat(targetPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
-	assert.NoFileExists(t, "/target-helper.sh", "host filesystem must not receive injected writes")
 }
 
 func TestPreserveCurrentBinary_LeavesBootTargetPresent(t *testing.T) {

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -158,6 +158,48 @@ func TestInstallStaged_ArmsWatchdogBeforeRestart(t *testing.T) {
 	assert.Equal(t, int64(412), m.ManifestGeneration)
 }
 
+func TestInstallStaged_RestoresPayloadWhenIncomingVersionNeverRan(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	opts := f.options()
+	installRoot := filepath.Dir(f.targetPath)
+
+	existingStaged := filepath.Join(f.stagingDir, "scripts", "services", "zaparoo_service")
+	newStaged := filepath.Join(f.stagingDir, "scripts", "new-helper.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(existingStaged), 0o750))
+	//nolint:gosec // Executable payload fixtures.
+	require.NoError(t, os.WriteFile(existingStaged, []byte("new service"), 0o755))
+	//nolint:gosec // Executable payload fixtures.
+	require.NoError(t, os.WriteFile(newStaged, []byte("new helper"), 0o755))
+	existingTarget := filepath.Join(installRoot, "scripts", "services", "zaparoo_service")
+	newTarget := filepath.Join(installRoot, "scripts", "new-helper.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(existingTarget), 0o750))
+	//nolint:gosec // Executable payload fixture.
+	require.NoError(t, os.WriteFile(existingTarget, []byte("old service"), 0o700))
+	opts.Staged.payloadFiles = []stagedPayloadFile{
+		{Path: existingStaged, RelativePath: "scripts/services/zaparoo_service", Mode: 0o755},
+		{Path: newStaged, RelativePath: "scripts/new-helper.sh", Mode: 0o755},
+	}
+
+	require.NoError(t, installStaged(t.Context(), opts))
+	assert.Equal(t, "new service", readFileString(t, existingTarget))
+	assert.Equal(t, "new helper", readFileString(t, newTarget))
+	m, err := loadMarker(stateDirFor(f.dataDir))
+	require.NoError(t, err)
+	require.Len(t, m.PayloadBackups, 2)
+	assert.False(t, m.PayloadBackups[0].OriginalMissing)
+	assert.True(t, m.PayloadBackups[1].OriginalMissing)
+
+	// Seeing the outgoing version means the incoming binary never ran. Abort
+	// payload and binary changes without restoring UserDB.
+	require.NoError(t, runStartupWatchdogWithOps(
+		t.Context(), f.dataDir, testCurrentVersion, defaultWatchdogFileOps(),
+	))
+	assert.Equal(t, "old service", readFileString(t, existingTarget))
+	assert.NoFileExists(t, newTarget)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+}
+
 func TestPreserveCurrentBinary_LeavesBootTargetPresent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -170,14 +171,14 @@ func TestInstallStaged_RestoresPayloadWhenIncomingVersionNeverRan(t *testing.T) 
 	require.NoError(t, os.WriteFile(existingStaged, []byte("new service"), 0o755))
 	//nolint:gosec // Executable payload fixtures.
 	require.NoError(t, os.WriteFile(newStaged, []byte("new helper"), 0o755))
-	existingTarget := filepath.Join(installRoot, "scripts", "services", "zaparoo_service")
-	newTarget := filepath.Join(installRoot, "scripts", "new-helper.sh")
+	existingTarget := filepath.Join(installRoot, "services", "zaparoo_service")
+	newTarget := filepath.Join(installRoot, "new-helper.sh")
 	require.NoError(t, os.MkdirAll(filepath.Dir(existingTarget), 0o750))
 	//nolint:gosec // Executable payload fixture.
 	require.NoError(t, os.WriteFile(existingTarget, []byte("old service"), 0o700))
 	opts.Staged.payloadFiles = []stagedPayloadFile{
-		{Path: existingStaged, RelativePath: "scripts/services/zaparoo_service", Mode: 0o755},
-		{Path: newStaged, RelativePath: "scripts/new-helper.sh", Mode: 0o755},
+		{Path: existingStaged, RelativePath: "services/zaparoo_service", Mode: 0o755},
+		{Path: newStaged, RelativePath: "new-helper.sh", Mode: 0o755},
 	}
 
 	require.NoError(t, installStaged(t.Context(), opts))
@@ -198,6 +199,50 @@ func TestInstallStaged_RestoresPayloadWhenIncomingVersionNeverRan(t *testing.T) 
 	assert.NoFileExists(t, newTarget)
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+	assert.NoFileExists(t, f.snapshotPath, "abort discards the unused snapshot instead of restoring it")
+}
+
+func TestPreparePayloadCandidates_UsesInjectedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll("/staging", 0o750))
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll("/userdata/system/services", 0o750))
+	require.NoError(t, afero.WriteFile(fs, "/staging/service", []byte("new"), 0o755))
+	require.NoError(t, afero.WriteFile(fs, "/userdata/system/services/service", []byte("old"), 0o700))
+	staged := &StagedUpdate{payloadFiles: []stagedPayloadFile{{
+		Path: "/staging/service", RelativePath: "services/service", Mode: 0o755,
+	}}}
+
+	backups, err := preparePayloadCandidates(staged, "/userdata/system/zaparoo", payloadInstallOps{fs: fs})
+	require.NoError(t, err)
+	require.Len(t, backups, 1)
+	assert.Equal(t, "new", readAferoFileString(t, fs, backups[0].CandidatePath))
+	assert.Equal(t, "old", readAferoFileString(t, fs, backups[0].BackupPath))
+}
+
+func readAferoFileString(t *testing.T, fs afero.Fs, path string) string {
+	t.Helper()
+	content, err := afero.ReadFile(fs, path)
+	require.NoError(t, err)
+	return string(content)
+}
+
+func TestCopyPayloadFile_UsesInjectedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "/staged-helper.sh", []byte("helper"), 0o600))
+	ops := payloadInstallOps{fs: fs}
+	require.NoError(t, copyPayloadFile(ops, "/staged-helper.sh", "/target-helper.sh", 0o755))
+
+	content, err := afero.ReadFile(fs, "/target-helper.sh")
+	require.NoError(t, err)
+	assert.Equal(t, "helper", string(content))
+	info, err := fs.Stat("/target-helper.sh")
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	assert.NoFileExists(t, "/target-helper.sh", "host filesystem must not receive injected writes")
 }
 
 func TestPreserveCurrentBinary_LeavesBootTargetPresent(t *testing.T) {

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -216,6 +216,10 @@ func TestPreparePayloadCandidates_UsesInjectedFilesystem(t *testing.T) {
 	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(serviceDir, 0o750))
 	require.NoError(t, afero.WriteFile(fs, stagedPath, []byte("new"), 0o755))
 	require.NoError(t, afero.WriteFile(fs, targetPath, []byte("old"), 0o700))
+	candidatePath := installSidecarPath(targetPath, installCandidateSuffix)
+	backupPath := installSidecarPath(targetPath, installBackupSuffix)
+	require.NoError(t, afero.WriteFile(fs, candidatePath, []byte("stale candidate"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, backupPath, []byte("stale backup"), 0o600))
 	staged := &StagedUpdate{payloadFiles: []stagedPayloadFile{{
 		Path: stagedPath, RelativePath: "services/service", Mode: 0o755,
 	}}}
@@ -223,8 +227,36 @@ func TestPreparePayloadCandidates_UsesInjectedFilesystem(t *testing.T) {
 	backups, err := preparePayloadCandidates(staged, binaryPath, payloadInstallOps{fs: fs})
 	require.NoError(t, err)
 	require.Len(t, backups, 1)
-	assert.Equal(t, "new", readAferoFileString(t, fs, backups[0].CandidatePath))
-	assert.Equal(t, "old", readAferoFileString(t, fs, backups[0].BackupPath))
+	assert.Equal(t, candidatePath, backups[0].CandidatePath)
+	assert.Equal(t, backupPath, backups[0].BackupPath)
+	assert.Equal(t, "new", readAferoFileString(t, fs, candidatePath))
+	assert.Equal(t, "old", readAferoFileString(t, fs, backupPath))
+}
+
+func TestPreparePayloadCandidates_RejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	root := string(filepath.Separator)
+	stagedPath := filepath.Join(root, "staging", "service")
+	targetPath := filepath.Join(root, "userdata", "system", "services", "service")
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(filepath.Dir(stagedPath), 0o750))
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(targetPath, 0o750))
+	require.NoError(t, afero.WriteFile(fs, stagedPath, []byte("new"), 0o755))
+	staged := &StagedUpdate{payloadFiles: []stagedPayloadFile{{
+		Path: stagedPath, RelativePath: "services/service", Mode: 0o755,
+	}}}
+
+	backups, err := preparePayloadCandidates(
+		staged,
+		filepath.Join(root, "userdata", "system", "zaparoo"),
+		payloadInstallOps{fs: fs},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a regular file")
+	require.Len(t, backups, 1)
+	_, statErr := fs.Stat(backups[0].CandidatePath)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
 func readAferoFileString(t *testing.T, fs afero.Fs, path string) string {
@@ -234,13 +266,35 @@ func readAferoFileString(t *testing.T, fs afero.Fs, path string) string {
 	return string(content)
 }
 
-func TestCopyPayloadFile_UsesInjectedFilesystem(t *testing.T) {
+func TestRemovePreparedPayloadUsesInjectedFilesystem(t *testing.T) {
 	t.Parallel()
 
 	fs := afero.NewMemMapFs()
 	root := string(filepath.Separator)
-	stagedPath := filepath.Join(root, "staged-helper.sh")
-	targetPath := filepath.Join(root, "target-helper.sh")
+	candidatePath := filepath.Join(root, "service.zaparoo-update-new")
+	backupPath := filepath.Join(root, "service.zaparoo-update-backup")
+	require.NoError(t, afero.WriteFile(fs, candidatePath, []byte("candidate"), 0o600))
+	require.NoError(t, afero.WriteFile(fs, backupPath, []byte("backup"), 0o600))
+
+	removePreparedPayload([]payloadBackup{{
+		CandidatePath: candidatePath,
+		BackupPath:    backupPath,
+	}}, payloadInstallOps{fs: fs})
+
+	_, candidateErr := fs.Stat(candidatePath)
+	require.ErrorIs(t, candidateErr, os.ErrNotExist)
+	_, backupErr := fs.Stat(backupPath)
+	require.ErrorIs(t, backupErr, os.ErrNotExist)
+}
+
+func TestCopyPayloadFile_UsesInjectedFilesystem(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	hostRoot := t.TempDir()
+	stagedPath := filepath.Join(hostRoot, "staged-helper.sh")
+	targetPath := filepath.Join(hostRoot, "target-helper.sh")
+	require.NoError(t, (afero.Afero{Fs: fs}).MkdirAll(hostRoot, 0o750))
 	require.NoError(t, afero.WriteFile(fs, stagedPath, []byte("helper"), 0o600))
 	ops := payloadInstallOps{fs: fs}
 	require.NoError(t, copyPayloadFile(ops, stagedPath, targetPath, 0o755))
@@ -251,6 +305,7 @@ func TestCopyPayloadFile_UsesInjectedFilesystem(t *testing.T) {
 	info, err := fs.Stat(targetPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+	assert.NoFileExists(t, targetPath, "host filesystem must not receive injected writes")
 }
 
 func TestPreserveCurrentBinary_LeavesBootTargetPresent(t *testing.T) {

--- a/pkg/service/updater/marker.go
+++ b/pkg/service/updater/marker.go
@@ -110,8 +110,10 @@ var markerMu syncutil.Mutex
 // came from. Payload extras are not installed yet; the field exists from the
 // first version of the marker so adding them later is not a schema change.
 type payloadBackup struct {
-	TargetPath string `json:"targetPath"`
-	BackupPath string `json:"backupPath"`
+	TargetPath      string `json:"targetPath"`
+	BackupPath      string `json:"backupPath,omitempty"`
+	CandidatePath   string `json:"candidatePath,omitempty"`
+	OriginalMissing bool   `json:"originalMissing,omitempty"`
 }
 
 // pendingMarker is the record an update leaves behind for the boot that follows

--- a/pkg/service/updater/marker_test.go
+++ b/pkg/service/updater/marker_test.go
@@ -46,9 +46,12 @@ func TestMarker_RoundTrip(t *testing.T) {
 		TargetVersion:      "2.2.0",
 		PlatformID:         "mister",
 		UserDBSnapshotPath: filepath.Join("data", "backups", "backup-x-update.db"),
-		PayloadBackups: []payloadBackup{
-			{TargetPath: filepath.Join("opt", "extra"), BackupPath: filepath.Join("opt", ".extra.old")},
-		},
+		PayloadBackups: []payloadBackup{{
+			TargetPath:      filepath.Join("opt", "extra"),
+			BackupPath:      filepath.Join("opt", ".extra.old"),
+			CandidatePath:   filepath.Join("opt", ".extra.new"),
+			OriginalMissing: true,
+		}},
 		ManifestGeneration: 42,
 		Attempts:           1,
 	}))
@@ -67,6 +70,8 @@ func TestMarker_RoundTrip(t *testing.T) {
 	assert.Equal(t, currentMarkerVersion, got.MarkerVersion)
 	require.Len(t, got.PayloadBackups, 1)
 	assert.Equal(t, filepath.Join("opt", "extra"), got.PayloadBackups[0].TargetPath)
+	assert.Equal(t, filepath.Join("opt", ".extra.new"), got.PayloadBackups[0].CandidatePath)
+	assert.True(t, got.PayloadBackups[0].OriginalMissing)
 }
 
 func TestLoadMarker_AbsentIsNotAnError(t *testing.T) {

--- a/pkg/service/updater/preflight.go
+++ b/pkg/service/updater/preflight.go
@@ -39,11 +39,12 @@ const bytesPerMB = 1024 * 1024
 type spaceNeeds struct {
 	// free defaults to helpers.FreeDiskSpace. Injected so the check can be
 	// tested without filling a disk.
-	free        func(string) (uint64, error)
-	targetPath  string
-	stagingRoot string
-	userDBPath  string
-	archiveSize int64
+	free          func(string) (uint64, error)
+	targetPath    string
+	stagingRoot   string
+	userDBPath    string
+	archiveSize   int64
+	payloadCopies bool
 }
 
 // required totals every byte the install adds while the old binary and the old
@@ -59,7 +60,15 @@ type spaceNeeds struct {
 // snapshot, which VACUUM INTO can only make smaller than its source.
 func (n *spaceNeeds) required() int64 {
 	binarySize := fileSizeOrZero(n.targetPath)
-	return 2*n.archiveSize + 2*binarySize + fileSizeOrZero(n.userDBPath)
+	required := 2*n.archiveSize + 2*binarySize + fileSizeOrZero(n.userDBPath)
+	if n.payloadCopies {
+		// Payload files need a target-filesystem candidate and, where replacing
+		// existing files, a rollback copy. The signed manifest has no expanded
+		// payload size, so two archive-sized allowances conservatively bound the
+		// small Batocera scripts payload before download.
+		required += 2 * n.archiveSize
+	}
+	return required
 }
 
 // checkFreeSpace charges the whole requirement to every directory the install

--- a/pkg/service/updater/preflight.go
+++ b/pkg/service/updater/preflight.go
@@ -61,11 +61,11 @@ type spaceNeeds struct {
 func (n *spaceNeeds) required() int64 {
 	binarySize := fileSizeOrZero(n.targetPath)
 	required := 2*n.archiveSize + 2*binarySize + fileSizeOrZero(n.userDBPath)
-	// Payload files need a target-filesystem candidate and, where replacing
-	// existing files, a rollback copy. payloadSize is the extraction limit when
-	// preflight runs before download, so compression cannot make this estimate
-	// smaller than the bytes installation may retain.
-	required += 2 * n.payloadSize
+	// Payload files remain staged while installation creates a target-filesystem
+	// candidate and, where replacing existing files, a rollback copy. payloadSize
+	// is the extraction limit when preflight runs before download, so compression
+	// cannot make this estimate smaller than the bytes installation may retain.
+	required += 3 * n.payloadSize
 	return required
 }
 

--- a/pkg/service/updater/preflight.go
+++ b/pkg/service/updater/preflight.go
@@ -39,12 +39,12 @@ const bytesPerMB = 1024 * 1024
 type spaceNeeds struct {
 	// free defaults to helpers.FreeDiskSpace. Injected so the check can be
 	// tested without filling a disk.
-	free          func(string) (uint64, error)
-	targetPath    string
-	stagingRoot   string
-	userDBPath    string
-	archiveSize   int64
-	payloadCopies bool
+	free        func(string) (uint64, error)
+	targetPath  string
+	stagingRoot string
+	userDBPath  string
+	archiveSize int64
+	payloadSize int64
 }
 
 // required totals every byte the install adds while the old binary and the old
@@ -61,13 +61,11 @@ type spaceNeeds struct {
 func (n *spaceNeeds) required() int64 {
 	binarySize := fileSizeOrZero(n.targetPath)
 	required := 2*n.archiveSize + 2*binarySize + fileSizeOrZero(n.userDBPath)
-	if n.payloadCopies {
-		// Payload files need a target-filesystem candidate and, where replacing
-		// existing files, a rollback copy. The signed manifest has no expanded
-		// payload size, so two archive-sized allowances conservatively bound the
-		// small Batocera scripts payload before download.
-		required += 2 * n.archiveSize
-	}
+	// Payload files need a target-filesystem candidate and, where replacing
+	// existing files, a rollback copy. payloadSize is the extraction limit when
+	// preflight runs before download, so compression cannot make this estimate
+	// smaller than the bytes installation may retain.
+	required += 2 * n.payloadSize
 	return required
 }
 

--- a/pkg/service/updater/preflight_test.go
+++ b/pkg/service/updater/preflight_test.go
@@ -76,6 +76,14 @@ func writeSizedFile(t *testing.T, path string, size int64) string {
 	return path
 }
 
+func TestSpaceNeeds_IncludesPayloadCandidateAndBackupAllowance(t *testing.T) {
+	t.Parallel()
+
+	f := newSpaceFixture(t)
+	f.needs.payloadCopies = true
+	assert.Equal(t, int64(testRequiredSpace+2*testArchiveSize), f.needs.required())
+}
+
 func TestCheckFreeSpace_AcceptsExactlyEnough(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/updater/preflight_test.go
+++ b/pkg/service/updater/preflight_test.go
@@ -76,12 +76,12 @@ func writeSizedFile(t *testing.T, path string, size int64) string {
 	return path
 }
 
-func TestSpaceNeeds_IncludesExpandedPayloadCandidateAndBackupAllowance(t *testing.T) {
+func TestSpaceNeeds_IncludesStagedPayloadCandidateAndBackupAllowance(t *testing.T) {
 	t.Parallel()
 
 	f := newSpaceFixture(t)
 	f.needs.payloadSize = maxStagedPayloadBytes
-	assert.Equal(t, int64(testRequiredSpace+2*maxStagedPayloadBytes), f.needs.required())
+	assert.Equal(t, int64(testRequiredSpace+3*maxStagedPayloadBytes), f.needs.required())
 }
 
 func TestCheckFreeSpace_AcceptsExactlyEnough(t *testing.T) {

--- a/pkg/service/updater/preflight_test.go
+++ b/pkg/service/updater/preflight_test.go
@@ -76,12 +76,12 @@ func writeSizedFile(t *testing.T, path string, size int64) string {
 	return path
 }
 
-func TestSpaceNeeds_IncludesPayloadCandidateAndBackupAllowance(t *testing.T) {
+func TestSpaceNeeds_IncludesExpandedPayloadCandidateAndBackupAllowance(t *testing.T) {
 	t.Parallel()
 
 	f := newSpaceFixture(t)
-	f.needs.payloadCopies = true
-	assert.Equal(t, int64(testRequiredSpace+2*testArchiveSize), f.needs.required())
+	f.needs.payloadSize = maxStagedPayloadBytes
+	assert.Equal(t, int64(testRequiredSpace+2*maxStagedPayloadBytes), f.needs.required())
 }
 
 func TestCheckFreeSpace_AcceptsExactlyEnough(t *testing.T) {

--- a/pkg/service/updater/stage.go
+++ b/pkg/service/updater/stage.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	"github.com/rs/zerolog/log"
 )
@@ -65,6 +66,11 @@ const (
 	// caps the file that is kept; this caps what getting to it can be made to
 	// cost.
 	maxArchiveInflatedBytes = 384 << 20
+
+	// maxStagedPayloadBytes limits retained platform extras independently of the
+	// binary. Zip can seek past ignored members, so the archive-wide inflated
+	// limit alone cannot bound the sum of files selected from it.
+	maxStagedPayloadBytes = 256 << 20
 
 	// downloadStallTimeout is how long a transfer may make no progress at all
 	// before it is abandoned. It deliberately bounds silence rather than total
@@ -164,9 +170,12 @@ var (
 )
 
 // StageOptions describes one staging attempt.
+//
+//nolint:govet // Public option order groups related release and target fields.
 type StageOptions struct {
 	Release        *otameta.Release
 	progress       *progressReporter
+	payloadRoots   []updatepayload.Root
 	PlatformID     string
 	Arch           string
 	OS             string
@@ -178,6 +187,13 @@ type StageOptions struct {
 // StagedUpdate is a verified release unpacked into files this process named,
 // ready for the install stage to move into place. Nothing outside Dir has been
 // touched to produce it.
+type stagedPayloadFile struct {
+	Path         string
+	RelativePath string
+	Mode         os.FileMode
+	Size         int64
+}
+
 type StagedUpdate struct {
 	// Dir is the staging directory holding the archive and the payload.
 	// Removing it undoes the whole staging attempt.
@@ -190,7 +206,8 @@ type StagedUpdate struct {
 	// what it installed from.
 	ArchivePath string
 	// Version is the release version, without the tag's leading v.
-	Version string
+	Version      string
+	payloadFiles []stagedPayloadFile
 }
 
 // assetFetcher retrieves an asset URL. Production hands back the CDN response
@@ -232,6 +249,7 @@ type stager struct {
 	current          string
 	platformID       string
 	stagingRoot      string
+	payloadRoots     []updatepayload.Root
 	maxFileBytes     int64
 	maxInflatedBytes int64
 	stallTimeout     time.Duration
@@ -323,6 +341,7 @@ func newStager(opts *StageOptions, fetch assetFetcher) (*stager, error) {
 		binaryName:       binaryName,
 		stagingRoot:      opts.StagingRoot,
 		current:          opts.CurrentVersion,
+		payloadRoots:     append([]updatepayload.Root(nil), opts.payloadRoots...),
 		maxFileBytes:     maxStagedFileBytes,
 		maxInflatedBytes: maxArchiveInflatedBytes,
 		stallTimeout:     downloadStallTimeout,
@@ -452,9 +471,9 @@ func (s *stager) stageInto(
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrArchiveRejected, err)
 	}
-	wantDigest, err := assetDigest(asset)
-	if err != nil {
-		return nil, err
+	wantDigest, digestErr := assetDigest(asset)
+	if digestErr != nil {
+		return nil, digestErr
 	}
 
 	// The archive is written under a name built from the version and extension
@@ -474,8 +493,9 @@ func (s *stager) stageInto(
 
 	binaryPath := filepath.Join(payloadDir, s.binaryName)
 	s.progress.stage(ProgressVerifying)
-	if err := s.extractBinary(ctx, archivePath, ext, wantDigest, binaryPath); err != nil {
-		return nil, err
+	payloadFiles, extractErr := s.extractRelease(ctx, archivePath, ext, wantDigest, binaryPath, payloadDir)
+	if extractErr != nil {
+		return nil, extractErr
 	}
 
 	// Extraction is a long uninterruptible stretch on a slow device, so the probe
@@ -511,10 +531,11 @@ func (s *stager) stageInto(
 	}
 
 	return &StagedUpdate{
-		Dir:         dir,
-		BinaryPath:  binaryPath,
-		ArchivePath: archivePath,
-		Version:     version,
+		Dir:          dir,
+		BinaryPath:   binaryPath,
+		ArchivePath:  archivePath,
+		Version:      version,
+		payloadFiles: payloadFiles,
 	}, nil
 }
 

--- a/pkg/service/updater/stage.go
+++ b/pkg/service/updater/stage.go
@@ -175,7 +175,7 @@ var (
 type StageOptions struct {
 	Release        *otameta.Release
 	progress       *progressReporter
-	payloadRoots   []updatepayload.Root
+	payload        []updatepayload.File
 	PlatformID     string
 	Arch           string
 	OS             string
@@ -249,7 +249,7 @@ type stager struct {
 	current          string
 	platformID       string
 	stagingRoot      string
-	payloadRoots     []updatepayload.Root
+	payload          []updatepayload.File
 	maxFileBytes     int64
 	maxInflatedBytes int64
 	stallTimeout     time.Duration
@@ -331,6 +331,7 @@ func newStager(opts *StageOptions, fetch assetFetcher) (*stager, error) {
 		return nil, fmt.Errorf("staging an update needs the path of the binary to replace, got %q", opts.TargetPath)
 	}
 
+	payload := append([]updatepayload.File(nil), opts.payload...)
 	s := &stager{
 		fetch:            fetch,
 		release:          opts.Release,
@@ -341,7 +342,7 @@ func newStager(opts *StageOptions, fetch assetFetcher) (*stager, error) {
 		binaryName:       binaryName,
 		stagingRoot:      opts.StagingRoot,
 		current:          opts.CurrentVersion,
-		payloadRoots:     append([]updatepayload.Root(nil), opts.payloadRoots...),
+		payload:          payload,
 		maxFileBytes:     maxStagedFileBytes,
 		maxInflatedBytes: maxArchiveInflatedBytes,
 		stallTimeout:     downloadStallTimeout,

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -52,14 +52,20 @@ var stateMu syncutil.Mutex
 // purpose: the database is included in backups, so a watermark stored there
 // would roll backwards whenever an old backup was restored, which is a
 // self-inflicted downgrade window.
+//
+//nolint:govet // Field order keeps persisted state grouped by manifest, check, and outcome.
 type updaterState struct {
 	ManifestSeenAt       time.Time       `json:"manifestSeenAt"`
+	LastCheckAt          time.Time       `json:"lastCheckAt,omitempty"`
 	LastResult           *updateResult   `json:"lastResult,omitempty"`
 	Deferral             *updateDeferral `json:"deferral,omitempty"`
 	ManifestETag         string          `json:"manifestETag"`
 	ManifestLastModified string          `json:"manifestLastModified"`
+	LastOfferedVersion   string          `json:"lastOfferedVersion,omitempty"`
 	ManifestGeneration   int64           `json:"manifestGeneration"`
+	CheckFailures        int             `json:"checkFailures,omitempty"`
 	StateVersion         int             `json:"stateVersion"`
+	LastCheckOK          *bool           `json:"lastCheckOK,omitempty"` //nolint:tagliatelle // Established initialism.
 }
 
 // updateDeferral records that an automatic install has been putting a version
@@ -234,6 +240,57 @@ func writeFileAtomicWithSync(
 	}
 	if err := syncDirectory(dir); err != nil {
 		return fmt.Errorf("flushing updater state file %q: %w", name, err)
+	}
+	return nil
+}
+
+func recordScheduledCheck(dir string, succeeded bool) error {
+	if dir == "" {
+		return nil
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		return fmt.Errorf("loading updater state before recording scheduled check: %w", err)
+	}
+	st.LastCheckAt = time.Now().UTC()
+	st.LastCheckOK = &succeeded
+	if succeeded {
+		st.CheckFailures = 0
+	} else {
+		st.CheckFailures++
+	}
+	if err := saveState(dir, &st); err != nil {
+		return fmt.Errorf("recording scheduled update check: %w", err)
+	}
+	return nil
+}
+
+func lastOfferedVersion(dir string) string {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return loadState(dir).LastOfferedVersion
+}
+
+func recordOfferedVersion(dir, version string) error {
+	if dir == "" || version == "" {
+		return nil
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		return fmt.Errorf("loading updater state before recording offered version: %w", err)
+	}
+	if st.LastOfferedVersion == version {
+		return nil
+	}
+	st.LastOfferedVersion = version
+	if err := saveState(dir, &st); err != nil {
+		return fmt.Errorf("recording offered update version: %w", err)
 	}
 	return nil
 }

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -56,7 +56,7 @@ var stateMu syncutil.Mutex
 //nolint:govet // Field order keeps persisted state grouped by manifest, check, and outcome.
 type updaterState struct {
 	ManifestSeenAt       time.Time       `json:"manifestSeenAt"`
-	LastCheckAt          time.Time       `json:"lastCheckAt,omitempty"`
+	LastCheckAt          *time.Time      `json:"lastCheckAt,omitempty"`
 	LastResult           *updateResult   `json:"lastResult,omitempty"`
 	Deferral             *updateDeferral `json:"deferral,omitempty"`
 	ManifestETag         string          `json:"manifestETag"`
@@ -255,7 +255,8 @@ func recordScheduledCheck(dir string, succeeded bool) error {
 	if err != nil {
 		return fmt.Errorf("loading updater state before recording scheduled check: %w", err)
 	}
-	st.LastCheckAt = time.Now().UTC()
+	checkedAt := time.Now().UTC()
+	st.LastCheckAt = &checkedAt
 	st.LastCheckOK = &succeeded
 	if succeeded {
 		st.CheckFailures = 0
@@ -375,6 +376,10 @@ func sameUpdateResult(a, b *updateResult) bool {
 // that is what the deadline is measured from; a different version starts the
 // clock again.
 func recordDeferral(dir, version, reason string) error {
+	return recordDeferralAt(dir, version, reason, time.Now().UTC())
+}
+
+func recordDeferralAt(dir, version, reason string, now time.Time) error {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 
@@ -386,7 +391,7 @@ func recordDeferral(dir, version, reason string) error {
 		return nil
 	}
 
-	since := time.Now().UTC()
+	since := now.UTC()
 	if st.Deferral != nil && st.Deferral.Version == version && !st.Deferral.Since.IsZero() {
 		since = st.Deferral.Since
 	}

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -44,6 +44,7 @@ func TestScheduledCheckAndOfferedVersionState(t *testing.T) {
 	assert.False(t, *failed.LastCheckOK)
 	assert.Equal(t, 2, failed.CheckFailures)
 	assert.Equal(t, "2.11.0", failed.LastOfferedVersion)
+	require.NotNil(t, failed.LastCheckAt)
 	assert.False(t, failed.LastCheckAt.IsZero())
 
 	require.NoError(t, recordScheduledCheck(dir, true))
@@ -81,6 +82,11 @@ func TestState_RoundTrip(t *testing.T) {
 	assert.Equal(t, "Mon, 17 Aug 2026 01:26:54 GMT", got.ManifestLastModified)
 	assert.True(t, seen.Equal(got.ManifestSeenAt))
 	assert.Equal(t, currentStateVersion, got.StateVersion)
+	assert.Nil(t, got.LastCheckAt)
+
+	data, err := os.ReadFile(filepath.Join(dir, stateFileName)) //nolint:gosec // test temp dir
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "lastCheckAt")
 }
 
 // A device with no state yet accepts any generation, which is what makes a
@@ -335,6 +341,18 @@ func TestUpdateResult_NilIsNotRecorded(t *testing.T) {
 
 	assert.Nil(t, peekUpdateResult(dir))
 	assert.NoFileExists(t, filepath.Join(dir, stateFileName))
+}
+
+func TestRecordDeferralAt_UsesInjectedClock(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.FixedZone("device", 9*60*60))
+	require.NoError(t, recordDeferralAt(dir, "v2.5.0", ReasonActiveMedia, now))
+
+	deferral := peekDeferral(dir, "v2.5.0")
+	require.NotNil(t, deferral)
+	assert.Equal(t, now.UTC(), deferral.Since)
 }
 
 func TestRecordDeferral_KeepsSinceAcrossReasons(t *testing.T) {

--- a/pkg/service/updater/state_test.go
+++ b/pkg/service/updater/state_test.go
@@ -31,6 +31,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestScheduledCheckAndOfferedVersionState(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, recordScheduledCheck(dir, false))
+	require.NoError(t, recordScheduledCheck(dir, false))
+	require.NoError(t, recordOfferedVersion(dir, "2.11.0"))
+	failed, err := loadStateWithError(dir)
+	require.NoError(t, err)
+	require.NotNil(t, failed.LastCheckOK)
+	assert.False(t, *failed.LastCheckOK)
+	assert.Equal(t, 2, failed.CheckFailures)
+	assert.Equal(t, "2.11.0", failed.LastOfferedVersion)
+	assert.False(t, failed.LastCheckAt.IsZero())
+
+	require.NoError(t, recordScheduledCheck(dir, true))
+	succeeded, err := loadStateWithError(dir)
+	require.NoError(t, err)
+	require.NotNil(t, succeeded.LastCheckOK)
+	assert.True(t, *succeeded.LastCheckOK)
+	assert.Zero(t, succeeded.CheckFailures)
+	assert.Equal(t, "2.11.0", lastOfferedVersion(dir))
+}
+
 func TestStateDirFor(t *testing.T) {
 	t.Parallel()
 
@@ -98,6 +122,32 @@ func TestState_NewerVersionIsReadButNotOverwritten(t *testing.T) {
 	after, err := os.ReadFile(filepath.Join(dir, stateFileName)) //nolint:gosec // test temp dir
 	require.NoError(t, err)
 	assert.Equal(t, future, after)
+}
+
+func TestSchedulerStateWriters_DoNotOverwriteCorruptState(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		write func(string) error
+		name  string
+	}{
+		{name: "check", write: func(dir string) error { return recordScheduledCheck(dir, true) }},
+		{name: "offered", write: func(dir string) error { return recordOfferedVersion(dir, "2.11.0") }},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := filepath.Join(t.TempDir(), "updater")
+			require.NoError(t, os.MkdirAll(dir, stateDirPerm))
+			path := filepath.Join(dir, stateFileName)
+			corrupt := []byte("{not json")
+			require.NoError(t, os.WriteFile(path, corrupt, stateFilePerm))
+
+			require.Error(t, tt.write(dir))
+			after, err := os.ReadFile(path) //nolint:gosec // test-owned path
+			require.NoError(t, err)
+			assert.Equal(t, corrupt, after)
+		})
+	}
 }
 
 func TestRecordUpdateResult_DoesNotOverwriteCorruptState(t *testing.T) {

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -97,6 +97,8 @@ const (
 )
 
 // Options describes the device an update is being resolved for.
+//
+//nolint:govet // Field order groups updater dependencies and device settings.
 type Options struct {
 	UserDB UpdateBackupper
 	// Progress is called as the update moves through its stages, when the
@@ -108,6 +110,7 @@ type Options struct {
 	// Gate is what the device is busy with. A check uses it to report what
 	// would stop an update going ahead right now; nil reports nothing.
 	Gate       *GateDeps
+	Payload    []updatepayload.File
 	PlatformID string
 	Channel    string
 	DataDir    string
@@ -299,7 +302,11 @@ func noteGate(ctx context.Context, opts *Options, result *Result, stateDir, vers
 	if !decision.Expires {
 		return
 	}
-	if err := recordDeferral(stateDir, version, decision.Reason); err != nil {
+	now := time.Now().UTC()
+	if reporting.Now != nil {
+		now = reporting.Now().UTC()
+	}
+	if err := recordDeferralAt(stateDir, version, decision.Reason, now); err != nil {
 		log.Warn().Err(err).Msg("could not record why an update is waiting")
 	}
 }
@@ -481,7 +488,7 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 		CurrentVersion: config.AppVersion,
 		progress:       report,
 	}
-	stageOpts.payloadRoots = updatePayloadRoots(&opts)
+	stageOpts.payload = updatePayloadFiles(&opts)
 	staged, err := Stage(ctx, stageOpts)
 	if err != nil {
 		return fail(fmt.Errorf("staging update: %w", err))
@@ -516,11 +523,11 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 // that cannot fit. The asset lookup here is a size lookup only: Stage repeats it
 // along with the version and upgrade-floor checks, so a selection failure is
 // left for Stage to report with its own error rather than reported twice.
-func updatePayloadRoots(opts *Options) []updatepayload.Root {
+func updatePayloadFiles(opts *Options) []updatepayload.File {
 	if opts == nil || opts.Managed {
 		return nil
 	}
-	return updatepayload.Roots(opts.PlatformID)
+	return append([]updatepayload.File(nil), opts.Payload...)
 }
 
 func preflightSpace(opts *Options, release *otameta.Release, targetPath, stagingRoot string) error {
@@ -528,12 +535,16 @@ func preflightSpace(opts *Options, release *otameta.Release, targetPath, staging
 	if err != nil {
 		return nil //nolint:nilerr // Stage reports this properly a moment later
 	}
+	payloadSize := int64(0)
+	if len(updatePayloadFiles(opts)) > 0 {
+		payloadSize = maxStagedPayloadBytes
+	}
 	return checkFreeSpace(&spaceNeeds{
-		archiveSize:   asset.Size,
-		targetPath:    targetPath,
-		stagingRoot:   stagingRoot,
-		userDBPath:    filepath.Join(opts.DataDir, config.UserDbFile),
-		payloadCopies: len(updatePayloadRoots(opts)) > 0,
+		archiveSize: asset.Size,
+		payloadSize: payloadSize,
+		targetPath:  targetPath,
+		stagingRoot: stagingRoot,
+		userDBPath:  filepath.Join(opts.DataDir, config.UserDbFile),
 	})
 }
 

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/tlsroots"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/restart"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
@@ -49,11 +50,12 @@ const (
 )
 
 var (
-	ErrDevelopmentVersion = errors.New("update check skipped for development version")
-	ErrUpdateInProgress   = errors.New("update already in progress")
-	applyMu               syncutil.Mutex
-	applyInProgress       atomic.Bool
-	eligibilityPreflight  platformPreflightCache
+	ErrDevelopmentVersion    = errors.New("update check skipped for development version")
+	ErrUpdateInProgress      = errors.New("update already in progress")
+	errAutoInstallIneligible = errors.New("automatic update install is not eligible")
+	applyMu                  syncutil.Mutex
+	applyInProgress          atomic.Bool
+	eligibilityPreflight     platformPreflightCache
 )
 
 type platformPreflightCache struct {
@@ -352,6 +354,19 @@ func currentBinaryPath() string {
 // rolloutHeld reports whether the selected release's staged rollout has not
 // reached this device yet. Using the selected release matters when channels
 // contain semver-equal tags with different rollout percentages.
+func autoInstallReleaseAllowed(opts *Options, release *otameta.Release) error {
+	if opts == nil || opts.Mode != ModeAuto {
+		return nil
+	}
+	if opts.Managed {
+		return fmt.Errorf("%w: install is managed by a package manager", errAutoInstallIneligible)
+	}
+	if rolloutHeld(opts.DeviceID, release) {
+		return fmt.Errorf("%w: release is not rolled out to this device", errAutoInstallIneligible)
+	}
+	return nil
+}
+
 func rolloutHeld(deviceID string, release *otameta.Release) bool {
 	if release == nil {
 		return false
@@ -436,6 +451,9 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 	if !upgrade {
 		return fail(fmt.Errorf("%w: running %s", ErrNotAnUpgrade, config.AppVersion))
 	}
+	if eligibilityErr := autoInstallReleaseAllowed(&opts, manifestRelease); eligibilityErr != nil {
+		return fail(eligibilityErr)
+	}
 	report.setVersion(version)
 
 	targetPath, err := restart.BinaryPath()
@@ -453,7 +471,7 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 	if spaceErr := preflightSpace(&opts, manifestRelease, targetPath, stagingRoot); spaceErr != nil {
 		return fail(spaceErr)
 	}
-	staged, err := Stage(ctx, &StageOptions{
+	stageOpts := &StageOptions{
 		Release:        manifestRelease,
 		PlatformID:     opts.PlatformID,
 		Arch:           runtime.GOARCH,
@@ -462,7 +480,9 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 		StagingRoot:    stagingRoot,
 		CurrentVersion: config.AppVersion,
 		progress:       report,
-	})
+	}
+	stageOpts.payloadRoots = updatePayloadRoots(&opts)
+	staged, err := Stage(ctx, stageOpts)
 	if err != nil {
 		return fail(fmt.Errorf("staging update: %w", err))
 	}
@@ -496,16 +516,24 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 // that cannot fit. The asset lookup here is a size lookup only: Stage repeats it
 // along with the version and upgrade-floor checks, so a selection failure is
 // left for Stage to report with its own error rather than reported twice.
+func updatePayloadRoots(opts *Options) []updatepayload.Root {
+	if opts == nil || opts.Managed {
+		return nil
+	}
+	return updatepayload.Roots(opts.PlatformID)
+}
+
 func preflightSpace(opts *Options, release *otameta.Release, targetPath, stagingRoot string) error {
 	asset, err := otameta.SelectAsset(release, opts.PlatformID, runtime.GOARCH)
 	if err != nil {
 		return nil //nolint:nilerr // Stage reports this properly a moment later
 	}
 	return checkFreeSpace(&spaceNeeds{
-		archiveSize: asset.Size,
-		targetPath:  targetPath,
-		stagingRoot: stagingRoot,
-		userDBPath:  filepath.Join(opts.DataDir, config.UserDbFile),
+		archiveSize:   asset.Size,
+		targetPath:    targetPath,
+		stagingRoot:   stagingRoot,
+		userDBPath:    filepath.Join(opts.DataDir, config.UserDbFile),
+		payloadCopies: len(updatePayloadRoots(opts)) > 0,
 	})
 }
 
@@ -526,8 +554,8 @@ func ensureNoPendingUpdate(dataDir string) error {
 // CheckFn is the signature for a function that checks for updates.
 type CheckFn func(ctx context.Context, opts Options) (*Result, error)
 
-// CheckAndNotify checks for updates and posts an inbox message if one is
-// available. Intended to be called as a fire-and-forget goroutine on startup.
+// CheckAndNotify checks for updates and posts a version-deduplicated inbox
+// message when one is available. The service scheduler calls it periodically.
 func CheckAndNotify(
 	ctx context.Context,
 	cfg *config.Instance,
@@ -544,6 +572,9 @@ func CheckAndNotify(
 
 	if !waitFn(ctx, 30) {
 		log.Warn().Msg("no internet connectivity, skipping update check")
+		if err := recordScheduledCheck(stateDirFor(opts.DataDir), false); err != nil {
+			log.Warn().Err(err).Msg("could not record failed scheduled update check")
+		}
 		return
 	}
 	if ctx.Err() != nil {
@@ -560,7 +591,13 @@ func CheckAndNotify(
 	}
 	if err != nil {
 		log.Warn().Err(err).Msg("update check failed")
+		if stateErr := recordScheduledCheck(stateDirFor(opts.DataDir), false); stateErr != nil {
+			log.Warn().Err(stateErr).Msg("could not record failed scheduled update check")
+		}
 		return
+	}
+	if stateErr := recordScheduledCheck(stateDirFor(opts.DataDir), true); stateErr != nil {
+		log.Warn().Err(stateErr).Msg("could not record successful scheduled update check")
 	}
 
 	if !result.UpdateAvailable {
@@ -589,6 +626,10 @@ func CheckAndNotify(
 		Str("latest", result.LatestVersion).
 		Msg("update available")
 
+	stateDir := stateDirFor(opts.DataDir)
+	if lastOfferedVersion(stateDir) == result.LatestVersion {
+		return
+	}
 	title := fmt.Sprintf("Zaparoo %s is available", result.LatestVersion)
 	body := fmt.Sprintf(
 		"Currently on %s. %s",
@@ -603,5 +644,9 @@ func CheckAndNotify(
 		inbox.WithSeverity(inbox.SeverityInfo),
 	); err != nil {
 		log.Error().Err(err).Msg("failed to add update inbox message")
+		return
+	}
+	if err := recordOfferedVersion(stateDir, result.LatestVersion); err != nil {
+		log.Warn().Err(err).Msg("could not record offered update version")
 	}
 }

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -207,6 +207,31 @@ func TestCheckAndNotify_UpdateAvailable(t *testing.T) {
 	mockUserDB.AssertExpectations(t)
 }
 
+func TestCheckAndNotify_DeduplicatesOfferedVersion(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Instance{}
+	cfg.SetUpdateCheck(true)
+	mockUserDB := helpers.NewMockUserDBI()
+	mockUserDB.On("AddInboxMessage", mock.Anything).
+		Return(&database.InboxMessage{DBID: 1}, nil).Once()
+	inboxSvc := inbox.NewService(mockUserDB, make(chan models.Notification, 10))
+	opts := linuxOptions()
+	opts.DataDir = t.TempDir()
+	checkFn := func(context.Context, Options) (*Result, error) {
+		return &Result{
+			CurrentVersion: "2.9.0", LatestVersion: "2.10.0",
+			UpdateAvailable: true,
+		}, nil
+	}
+
+	CheckAndNotify(t.Context(), cfg, opts, inboxSvc, alwaysOnline, checkFn, false)
+	CheckAndNotify(t.Context(), cfg, opts, inboxSvc, alwaysOnline, checkFn, false)
+
+	mockUserDB.AssertExpectations(t)
+	assert.Equal(t, "2.10.0", lastOfferedVersion(stateDirFor(opts.DataDir)))
+}
+
 // A package-managed device still gets told a release exists, so the message has
 // to point at the thing that actually installs it there.
 func TestCheckAndNotify_ManagedInstallBodyNamesThePackageManager(t *testing.T) {
@@ -304,6 +329,29 @@ func TestCheck_CancelledContext(t *testing.T) {
 	result, err := Check(ctx, linuxOptions())
 	require.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestUpdatePayloadRootsOnlyForUnmanagedBatocera(t *testing.T) {
+	t.Parallel()
+
+	assert.NotEmpty(t, updatePayloadRoots(&Options{PlatformID: platformids.Batocera}))
+	assert.Empty(t, updatePayloadRoots(&Options{PlatformID: platformids.Batocera, Managed: true}))
+	assert.Empty(t, updatePayloadRoots(&Options{PlatformID: platformids.Linux}))
+}
+
+func TestAutoInstallReleaseAllowed(t *testing.T) {
+	t.Parallel()
+
+	held := &otameta.Release{TagName: "v2.10.0", Rollout: 0}
+	full := &otameta.Release{TagName: "v2.10.0", Rollout: 100}
+	require.NoError(t, autoInstallReleaseAllowed(&Options{Mode: ModeManual, Managed: true}, held))
+	require.ErrorIs(t,
+		autoInstallReleaseAllowed(&Options{Mode: ModeAuto, Managed: true}, full),
+		errAutoInstallIneligible)
+	require.ErrorIs(t,
+		autoInstallReleaseAllowed(&Options{Mode: ModeAuto, DeviceID: "device-1"}, held),
+		errAutoInstallIneligible)
+	assert.NoError(t, autoInstallReleaseAllowed(&Options{Mode: ModeAuto}, full))
 }
 
 func TestApply_UpdateInProgress(t *testing.T) {

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/inbox"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
@@ -331,12 +332,13 @@ func TestCheck_CancelledContext(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-func TestUpdatePayloadRootsOnlyForUnmanagedBatocera(t *testing.T) {
+func TestUpdatePayloadFilesOnlyForUnmanagedInstall(t *testing.T) {
 	t.Parallel()
 
-	assert.NotEmpty(t, updatePayloadRoots(&Options{PlatformID: platformids.Batocera}))
-	assert.Empty(t, updatePayloadRoots(&Options{PlatformID: platformids.Batocera, Managed: true}))
-	assert.Empty(t, updatePayloadRoots(&Options{PlatformID: platformids.Linux}))
+	payload := []updatepayload.File{{ArchivePath: "scripts/helper.sh"}}
+	assert.Equal(t, payload, updatePayloadFiles(&Options{Payload: payload}))
+	assert.Empty(t, updatePayloadFiles(&Options{Payload: payload, Managed: true}))
+	assert.Empty(t, updatePayloadFiles(&Options{}))
 }
 
 func TestAutoInstallReleaseAllowed(t *testing.T) {

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -325,6 +325,7 @@ func runStartupWatchdogWithOps(
 				stat:          fileOps.fs.Stat,
 				syncDirectory: fileOps.syncDirectory,
 				saveMarker:    fileOps.save,
+				clearMarker:   fileOps.clear,
 			})
 
 	case actionFinalize:

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -663,36 +663,7 @@ func restorePayloadFile(
 		return nil
 	}
 
-	if payload.BackupPath == "" || payload.TargetPath == "" {
-		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
-	}
-	_, statErr := fileOps.fs.Stat(payload.BackupPath)
-	if statErr != nil {
-		if errors.Is(statErr, os.ErrNotExist) && m.RestoringPath == payload.TargetPath {
-			if _, targetErr := fileOps.fs.Stat(payload.TargetPath); targetErr != nil {
-				return fmt.Errorf("restored backup and target are both unavailable for %q: %w",
-					payload.TargetPath, targetErr)
-			}
-			return nil
-		}
-		if errors.Is(statErr, os.ErrNotExist) {
-			return fmt.Errorf("%w: backup of %q: %w", errRollbackPrerequisite, payload.TargetPath, statErr)
-		}
-		return fmt.Errorf("reading the backup of %q: %w", payload.TargetPath, statErr)
-	}
-	if m.RestoringPath != payload.TargetPath {
-		m.RestoringPath = payload.TargetPath
-		if err := fileOps.save(dir, m); err != nil {
-			return fmt.Errorf("recording the payload being restored: %w", err)
-		}
-	}
-	if err := fileOps.replace(payload.BackupPath, payload.TargetPath); err != nil {
-		return fmt.Errorf("restoring %q: %w", payload.TargetPath, err)
-	}
-	if err := fileOps.syncDirectory(filepath.Dir(payload.TargetPath)); err != nil {
-		return fmt.Errorf("flushing restored file %q: %w", payload.TargetPath, err)
-	}
-	return nil
+	return restoreReplacedFileState(dir, m, payload.BackupPath, payload.TargetPath, fileOps, false)
 }
 
 // restoreReplacedFiles renames what the install displaced back over what it
@@ -717,6 +688,16 @@ func restoreReplacedFiles(dir string, m *pendingMarker, fileOps watchdogFileOps)
 func restoreReplacedFile(
 	dir string, m *pendingMarker, backupPath, targetPath string, fileOps watchdogFileOps,
 ) error {
+	return restoreReplacedFileState(dir, m, backupPath, targetPath, fileOps, true)
+}
+
+func restoreReplacedFileState(
+	dir string,
+	m *pendingMarker,
+	backupPath, targetPath string,
+	fileOps watchdogFileOps,
+	clearRestoringPath bool,
+) error {
 	if backupPath == "" || targetPath == "" {
 		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
 	}
@@ -727,9 +708,11 @@ func restoreReplacedFile(
 			if _, targetErr := fileOps.fs.Stat(targetPath); targetErr != nil {
 				return fmt.Errorf("restored backup and target are both unavailable for %q: %w", targetPath, targetErr)
 			}
-			m.RestoringPath = ""
-			if saveErr := fileOps.save(dir, m); saveErr != nil {
-				return fmt.Errorf("recording the completed file restore: %w", saveErr)
+			if clearRestoringPath {
+				m.RestoringPath = ""
+				if saveErr := fileOps.save(dir, m); saveErr != nil {
+					return fmt.Errorf("recording the completed file restore: %w", saveErr)
+				}
 			}
 			return nil
 		}
@@ -752,9 +735,11 @@ func restoreReplacedFile(
 	if err := fileOps.syncDirectory(filepath.Dir(targetPath)); err != nil {
 		return fmt.Errorf("flushing restored file %q: %w", targetPath, err)
 	}
-	m.RestoringPath = ""
-	if err := fileOps.save(dir, m); err != nil {
-		return fmt.Errorf("recording the completed file restore: %w", err)
+	if clearRestoringPath {
+		m.RestoringPath = ""
+		if err := fileOps.save(dir, m); err != nil {
+			return fmt.Errorf("recording the completed file restore: %w", err)
+		}
 	}
 	return nil
 }

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -114,6 +114,13 @@ func (e *rolledBackError) Unwrap() []error {
 	return []error{ErrRolledBack, e.cause}
 }
 
+func (o watchdogFileOps) save(dir string, marker *pendingMarker) error {
+	if o.saveMarker == nil {
+		return saveMarker(dir, marker)
+	}
+	return o.saveMarker(dir, marker)
+}
+
 func defaultWatchdogFileOps() watchdogFileOps {
 	return watchdogFileOps{
 		fs:              afero.NewOsFs(),
@@ -276,8 +283,15 @@ func runStartupWatchdogWithOps(
 		return nil
 
 	case actionAbortInstall:
-		return abortInstall(ctx, dataDir, m,
-			installSidecarPath(m.TargetPath, installCandidateSuffix), fileOps.binary)
+		return abortInstallWithOps(ctx, dataDir, m,
+			installSidecarPath(m.TargetPath, installCandidateSuffix), fileOps.binary,
+			payloadInstallOps{
+				fs:            fileOps.fs,
+				replace:       fileOps.replace,
+				remove:        fileOps.fs.Remove,
+				stat:          fileOps.fs.Stat,
+				syncDirectory: fileOps.syncDirectory,
+			})
 
 	case actionFinalize:
 		return finalizeTerminalUpdate(ctx, dataDir, m, fileOps)
@@ -582,14 +596,48 @@ func restoreUserDB(
 	return nil
 }
 
+func restorePayloadFiles(dir string, m *pendingMarker, fileOps watchdogFileOps) error {
+	for _, payload := range m.PayloadBackups {
+		if !payload.OriginalMissing {
+			if err := restoreReplacedFile(dir, m, payload.BackupPath, payload.TargetPath, fileOps); err != nil {
+				return err
+			}
+			continue
+		}
+
+		_, statErr := fileOps.fs.Stat(payload.TargetPath)
+		if errors.Is(statErr, os.ErrNotExist) {
+			continue
+		}
+		if statErr != nil {
+			return fmt.Errorf("reading newly installed payload %q: %w", payload.TargetPath, statErr)
+		}
+		if m.RestoringPath != payload.TargetPath {
+			m.RestoringPath = payload.TargetPath
+			if err := fileOps.save(dir, m); err != nil {
+				return fmt.Errorf("recording the payload being removed: %w", err)
+			}
+		}
+		if err := fileOps.fs.Remove(payload.TargetPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("removing newly installed payload %q: %w", payload.TargetPath, err)
+		}
+		if err := fileOps.syncDirectory(filepath.Dir(payload.TargetPath)); err != nil {
+			return fmt.Errorf("flushing removed payload %q: %w", payload.TargetPath, err)
+		}
+		m.RestoringPath = ""
+		if err := fileOps.save(dir, m); err != nil {
+			return fmt.Errorf("recording the removed payload: %w", err)
+		}
+	}
+	return nil
+}
+
 // restoreReplacedFiles renames what the install displaced back over what it
 // installed. The binary goes last so that a failure part way through leaves the
 // new one in place, which is the state blockRollback is willing to run in.
 func restoreReplacedFiles(dir string, m *pendingMarker, fileOps watchdogFileOps) error {
-	for _, p := range m.PayloadBackups {
-		if err := restoreReplacedFile(dir, m, p.BackupPath, p.TargetPath, fileOps); err != nil {
-			return err
-		}
+	if err := restorePayloadFiles(dir, m, fileOps); err != nil {
+		return err
 	}
 	// The binary is the one file the rollback may have to put back underneath a
 	// process that is running from it, so it does not go through the plain
@@ -617,7 +665,7 @@ func restoreReplacedFile(
 				return fmt.Errorf("restored backup and target are both unavailable for %q: %w", targetPath, targetErr)
 			}
 			m.RestoringPath = ""
-			if saveErr := saveMarker(dir, m); saveErr != nil {
+			if saveErr := fileOps.save(dir, m); saveErr != nil {
 				return fmt.Errorf("recording the completed file restore: %w", saveErr)
 			}
 			return nil
@@ -630,7 +678,7 @@ func restoreReplacedFile(
 
 	if m.RestoringPath != targetPath {
 		m.RestoringPath = targetPath
-		if err := saveMarker(dir, m); err != nil {
+		if err := fileOps.save(dir, m); err != nil {
 			return fmt.Errorf("recording the file being restored: %w", err)
 		}
 	}
@@ -642,7 +690,7 @@ func restoreReplacedFile(
 		return fmt.Errorf("flushing restored file %q: %w", targetPath, err)
 	}
 	m.RestoringPath = ""
-	if err := saveMarker(dir, m); err != nil {
+	if err := fileOps.save(dir, m); err != nil {
 		return fmt.Errorf("recording the completed file restore: %w", err)
 	}
 	return nil

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -291,6 +291,7 @@ func runStartupWatchdogWithOps(
 				remove:        fileOps.fs.Remove,
 				stat:          fileOps.fs.Stat,
 				syncDirectory: fileOps.syncDirectory,
+				saveMarker:    fileOps.save,
 			})
 
 	case actionFinalize:
@@ -486,7 +487,7 @@ func rollBack(
 	dir := stateDirFor(dataDir)
 	m.State = markerRollingBack
 	m.RollbackAttempts++
-	if err := fileOps.saveMarker(dir, m); err != nil {
+	if err := fileOps.save(dir, m); err != nil {
 		// Nothing has been moved yet, and without this on disk an interrupted
 		// rollback would not know to resume, nor how many times it already has.
 		// Stop here rather than start a swap that cannot be finished.
@@ -495,15 +496,15 @@ func rollBack(
 
 	if !m.UserDBRestored {
 		if err := restoreUserDB(ctx, dataDir, m, fileOps); err != nil {
-			return handleRollbackFailure(dir, m, err)
+			return handleRollbackFailure(dir, m, fileOps, err)
 		}
 		// Recorded before the binary moves, because a rollback that fails after
 		// this point resumes on the next boot with the device having been in
 		// use in between. Writing the snapshot again then would throw those
 		// writes away.
 		m.UserDBRestored = true
-		if err := fileOps.saveMarker(dir, m); err != nil {
-			failureErr := handleRollbackFailure(dir, m,
+		if err := fileOps.save(dir, m); err != nil {
+			failureErr := handleRollbackFailure(dir, m, fileOps,
 				fmt.Errorf("recording the restored user database: %w", err))
 			if failureErr == nil {
 				return nil
@@ -512,12 +513,12 @@ func rollBack(
 		}
 	}
 	if err := restoreReplacedFiles(dir, m, fileOps); err != nil {
-		return handleRollbackFailure(dir, m, err)
+		return handleRollbackFailure(dir, m, fileOps, err)
 	}
 
 	m.Outcome = outcomeRolledBack
 	m.OutcomeAt = time.Now().UTC()
-	if err := saveMarker(dir, m); err != nil {
+	if err := fileOps.save(dir, m); err != nil {
 		return newRolledBackError(m.TargetPath,
 			fmt.Errorf("recording the completed rollback: %w", err))
 	}
@@ -533,12 +534,14 @@ func rollBack(
 	return newRolledBackError(m.TargetPath, nil)
 }
 
-func handleRollbackFailure(dir string, m *pendingMarker, cause error) error {
+func handleRollbackFailure(
+	dir string, m *pendingMarker, fileOps watchdogFileOps, cause error,
+) error {
 	if errors.Is(cause, errRollbackPrerequisite) {
-		return blockRollback(dir, m, cause)
+		return blockRollback(dir, m, fileOps, cause)
 	}
 	if m.RollbackAttempts >= rollbackAttemptLimit {
-		return blockRollback(dir, m, fmt.Errorf(
+		return blockRollback(dir, m, fileOps, fmt.Errorf(
 			"rollback failed on %d attempts: %w", m.RollbackAttempts, cause))
 	}
 	log.Error().Err(cause).
@@ -551,7 +554,7 @@ func handleRollbackFailure(dir string, m *pendingMarker, cause error) error {
 
 // blockRollback gives up on a rollback only when a prerequisite is permanently
 // missing or corrupt. Retryable I/O errors leave markerRollingBack intact.
-func blockRollback(dir string, m *pendingMarker, cause error) error {
+func blockRollback(dir string, m *pendingMarker, fileOps watchdogFileOps, cause error) error {
 	log.Error().Err(cause).
 		Str("failed", m.TargetVersion).
 		Str("wanted", m.PreviousVersion).
@@ -560,7 +563,7 @@ func blockRollback(dir string, m *pendingMarker, cause error) error {
 	m.Outcome = outcomeRollbackBlocked
 	m.OutcomeAt = time.Now().UTC()
 	m.OutcomeDetail = cause.Error()
-	if err := saveMarker(dir, m); err != nil {
+	if err := fileOps.save(dir, m); err != nil {
 		return fmt.Errorf("recording that rollback was abandoned: %w", err)
 	}
 	if err := recordMarkerResult(dir, m); err != nil {
@@ -597,17 +600,50 @@ func restoreUserDB(
 }
 
 func restorePayloadFiles(dir string, m *pendingMarker, fileOps watchdogFileOps) error {
-	for _, payload := range m.PayloadBackups {
-		if !payload.OriginalMissing {
-			if err := restoreReplacedFile(dir, m, payload.BackupPath, payload.TargetPath, fileOps); err != nil {
-				return err
-			}
-			continue
+	for len(m.PayloadBackups) > 0 {
+		payload := m.PayloadBackups[0]
+		if err := restorePayloadFile(dir, m, payload, fileOps); err != nil {
+			return err
+		}
+		if err := removePayloadCandidate(payload, fileOps); err != nil {
+			return err
 		}
 
+		// Remove each completed entry durably before moving to the next file.
+		// Its backup may have been consumed by rename, so retaining the entry
+		// would make a later boot mistake completed work for a missing prerequisite.
+		m.PayloadBackups = m.PayloadBackups[1:]
+		m.RestoringPath = ""
+		if err := fileOps.save(dir, m); err != nil {
+			return fmt.Errorf("recording the completed payload restore: %w", err)
+		}
+	}
+	return nil
+}
+
+func removePayloadCandidate(payload payloadBackup, fileOps watchdogFileOps) error {
+	if payload.CandidatePath == "" {
+		return nil
+	}
+	if err := fileOps.fs.Remove(payload.CandidatePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("removing unused payload candidate %q: %w", payload.CandidatePath, err)
+	}
+	if err := fileOps.syncDirectory(filepath.Dir(payload.CandidatePath)); err != nil {
+		return fmt.Errorf("flushing removed payload candidate %q: %w", payload.CandidatePath, err)
+	}
+	return nil
+}
+
+func restorePayloadFile(
+	dir string, m *pendingMarker, payload payloadBackup, fileOps watchdogFileOps,
+) error {
+	if payload.OriginalMissing {
 		_, statErr := fileOps.fs.Stat(payload.TargetPath)
 		if errors.Is(statErr, os.ErrNotExist) {
-			continue
+			return nil
 		}
 		if statErr != nil {
 			return fmt.Errorf("reading newly installed payload %q: %w", payload.TargetPath, statErr)
@@ -624,10 +660,37 @@ func restorePayloadFiles(dir string, m *pendingMarker, fileOps watchdogFileOps) 
 		if err := fileOps.syncDirectory(filepath.Dir(payload.TargetPath)); err != nil {
 			return fmt.Errorf("flushing removed payload %q: %w", payload.TargetPath, err)
 		}
-		m.RestoringPath = ""
-		if err := fileOps.save(dir, m); err != nil {
-			return fmt.Errorf("recording the removed payload: %w", err)
+		return nil
+	}
+
+	if payload.BackupPath == "" || payload.TargetPath == "" {
+		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
+	}
+	_, statErr := fileOps.fs.Stat(payload.BackupPath)
+	if statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) && m.RestoringPath == payload.TargetPath {
+			if _, targetErr := fileOps.fs.Stat(payload.TargetPath); targetErr != nil {
+				return fmt.Errorf("restored backup and target are both unavailable for %q: %w",
+					payload.TargetPath, targetErr)
+			}
+			return nil
 		}
+		if errors.Is(statErr, os.ErrNotExist) {
+			return fmt.Errorf("%w: backup of %q: %w", errRollbackPrerequisite, payload.TargetPath, statErr)
+		}
+		return fmt.Errorf("reading the backup of %q: %w", payload.TargetPath, statErr)
+	}
+	if m.RestoringPath != payload.TargetPath {
+		m.RestoringPath = payload.TargetPath
+		if err := fileOps.save(dir, m); err != nil {
+			return fmt.Errorf("recording the payload being restored: %w", err)
+		}
+	}
+	if err := fileOps.replace(payload.BackupPath, payload.TargetPath); err != nil {
+		return fmt.Errorf("restoring %q: %w", payload.TargetPath, err)
+	}
+	if err := fileOps.syncDirectory(filepath.Dir(payload.TargetPath)); err != nil {
+		return fmt.Errorf("flushing restored file %q: %w", payload.TargetPath, err)
 	}
 	return nil
 }

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -68,10 +68,17 @@ const (
 	actionRollBack
 )
 
+type watchdogMarkerOps struct {
+	load   func(string) (*pendingMarker, error)
+	save   func(string, *pendingMarker) error
+	clear  func(string) error
+	record func(string, *pendingMarker) error
+}
+
 type watchdogFileOps struct {
-	fs         afero.Fs
-	replace    func(string, string) error
-	saveMarker func(string, *pendingMarker) error
+	fs      afero.Fs
+	replace func(string, string) error
+	marker  *watchdogMarkerOps
 	// binary puts back a file that may be the image this process is running
 	// from, which not every platform will let a plain replacement touch, and
 	// clears whatever an earlier swap had to leave behind to do it.
@@ -114,18 +121,44 @@ func (e *rolledBackError) Unwrap() []error {
 	return []error{ErrRolledBack, e.cause}
 }
 
+func (o watchdogFileOps) load(dir string) (*pendingMarker, error) {
+	if o.marker == nil || o.marker.load == nil {
+		return loadMarker(dir)
+	}
+	return o.marker.load(dir)
+}
+
 func (o watchdogFileOps) save(dir string, marker *pendingMarker) error {
-	if o.saveMarker == nil {
+	if o.marker == nil || o.marker.save == nil {
 		return saveMarker(dir, marker)
 	}
-	return o.saveMarker(dir, marker)
+	return o.marker.save(dir, marker)
+}
+
+func (o watchdogFileOps) clear(dir string) error {
+	if o.marker == nil || o.marker.clear == nil {
+		return clearMarker(dir)
+	}
+	return o.marker.clear(dir)
+}
+
+func (o watchdogFileOps) record(dir string, marker *pendingMarker) error {
+	if o.marker == nil || o.marker.record == nil {
+		return recordMarkerResult(dir, marker)
+	}
+	return o.marker.record(dir, marker)
 }
 
 func defaultWatchdogFileOps() watchdogFileOps {
 	return watchdogFileOps{
-		fs:              afero.NewOsFs(),
-		replace:         replaceFile,
-		saveMarker:      saveMarker,
+		fs:      afero.NewOsFs(),
+		replace: replaceFile,
+		marker: &watchdogMarkerOps{
+			load:   loadMarker,
+			save:   saveMarker,
+			clear:  clearMarker,
+			record: recordMarkerResult,
+		},
 		binary:          defaultInstallBinaryOps(),
 		syncDirectory:   syncDir,
 		removeStaging:   removeStagingDir,
@@ -231,7 +264,7 @@ func runStartupWatchdogWithOps(
 	defer markerMu.Unlock()
 
 	dir := stateDirFor(dataDir)
-	m, err := loadMarker(dir)
+	m, err := fileOps.load(dir)
 	if err != nil {
 		// A newer or unusable marker cannot safely direct this build. Leave it and
 		// every update snapshot alone so a compatible build or operator still has
@@ -248,7 +281,7 @@ func runStartupWatchdogWithOps(
 	switch decideWatchdogAction(m, currentVersion) {
 	case actionNone:
 		if m != nil && m.Outcome == outcomeRollbackBlocked {
-			if err := recordMarkerResult(dir, m); err != nil {
+			if err := fileOps.record(dir, m); err != nil {
 				log.Warn().Err(err).Msg("could not retain the blocked rollback result")
 			}
 		}
@@ -260,7 +293,7 @@ func runStartupWatchdogWithOps(
 			Str("markerVersion", m.TargetVersion).
 			Str("running", currentVersion).
 			Msg("discarding an update marker that does not describe this version")
-		if err := clearMarker(dir); err != nil {
+		if err := fileOps.clear(dir); err != nil {
 			return err
 		}
 		sweepUpdateSnapshotsFS(fileOps.fs, dataDir, "")
@@ -269,7 +302,7 @@ func runStartupWatchdogWithOps(
 	case actionConfirm:
 		m.State = markerConfirming
 		m.Attempts++
-		if err := saveMarker(dir, m); err != nil {
+		if err := fileOps.save(dir, m); err != nil {
 			// Without confirming on disk a failed startup looks like a first
 			// boot to the next one, so it would try to confirm again instead of
 			// rolling back. Report it; the next boot re-runs this same step.
@@ -566,7 +599,7 @@ func blockRollback(dir string, m *pendingMarker, fileOps watchdogFileOps, cause 
 	if err := fileOps.save(dir, m); err != nil {
 		return fmt.Errorf("recording that rollback was abandoned: %w", err)
 	}
-	if err := recordMarkerResult(dir, m); err != nil {
+	if err := fileOps.record(dir, m); err != nil {
 		log.Warn().Err(err).Msg("could not record the blocked rollback result")
 	}
 	return nil
@@ -751,7 +784,7 @@ func finalizeTerminalUpdate(
 		return errors.New("finalizing an update needs a completed outcome")
 	}
 	dir := stateDirFor(dataDir)
-	if err := recordMarkerResult(dir, m); err != nil {
+	if err := fileOps.record(dir, m); err != nil {
 		return err
 	}
 
@@ -774,7 +807,7 @@ func finalizeTerminalUpdate(
 	// line.
 	fileOps.binary.sweep(m.TargetPath)
 	sweepUpdateSnapshotsFS(fileOps.fs, dataDir, "")
-	if err := clearMarker(dir); err != nil {
+	if err := fileOps.clear(dir); err != nil {
 		return fmt.Errorf("clearing the completed update marker: %w", err)
 	}
 	return nil

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -895,8 +895,7 @@ func TestRunStartupWatchdog_MarkerWithoutASnapshotBlocksRollback(t *testing.T) {
 	assert.Equal(t, outcomeRollbackBlocked, blocked.Outcome)
 }
 
-// Payload extras have no producer yet, but the rollback already restores them,
-// and the binary has to go last: a failure part way through then leaves the new
+// Payload extras restore before the binary: a failure part way through leaves the new
 // binary in place, which is the state a blocked rollback can live with.
 func TestRunStartupWatchdog_RestoresPayloadFilesBeforeTheBinary(t *testing.T) {
 	t.Parallel()
@@ -933,6 +932,24 @@ func TestRunStartupWatchdog_RestoresPayloadFilesBeforeTheBinary(t *testing.T) {
 	assert.Equal(t, "old asset", readFileString(t, assetPath))
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 	assert.NoFileExists(t, assetBackup, "a restored backup is not left behind")
+}
+
+func TestRunStartupWatchdog_RemovesNewPayloadFileBeforeTheBinary(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	assetPath := filepath.Join(t.TempDir(), "new-helper.sh")
+	//nolint:gosec // Executable payload fixture.
+	require.NoError(t, os.WriteFile(assetPath, []byte("new asset"), 0o755))
+	m := f.marker(markerConfirming)
+	m.PayloadBackups = []payloadBackup{{TargetPath: assetPath, OriginalMissing: true}}
+	require.NoError(t, saveMarker(dir, m))
+
+	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, defaultWatchdogFileOps())
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.NoFileExists(t, assetPath)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 }
 
 // A payload entry with no backup recorded cannot be restored, and guessing is

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -338,25 +338,78 @@ func TestRunStartupWatchdog_ResumesInterruptedRollback(t *testing.T) {
 func TestRunStartupWatchdog_ResumesInterruptedPayloadRestore(t *testing.T) {
 	t.Parallel()
 
-	f := newInstallFixture(t)
-	dir := stateDirFor(f.dataDir)
-	assetDir := t.TempDir()
+	fs := afero.NewMemMapFs()
+	dataDir := filepath.Join("data", "zaparoo")
+	binDir := filepath.Join("system", "bin")
+	assetDir := filepath.Join("system", "assets")
+	targetPath := filepath.Join(binDir, "zaparoo")
+	backupPath := filepath.Join(binDir, ".zaparoo.zap-old")
 	assetPath := filepath.Join(assetDir, "menu.png")
 	assetBackup := filepath.Join(assetDir, ".menu.png.zap-old")
-	require.NoError(t, os.WriteFile(assetPath, []byte("new asset"), 0o600))
-	require.NoError(t, os.WriteFile(assetBackup, []byte("old asset"), 0o600))
+	stagingDir := filepath.Join(dataDir, "updater", "staging", testTargetVersion)
+	for _, dir := range []string{binDir, assetDir, stagingDir} {
+		require.NoError(t, fs.MkdirAll(dir, 0o750))
+	}
+	for path, content := range map[string]string{
+		targetPath: "new binary", backupPath: "old binary",
+		assetPath: "new asset", assetBackup: "old asset",
+	} {
+		require.NoError(t, afero.WriteFile(fs, path, []byte(content), 0o600))
+	}
 
-	m := f.marker(markerRollingBack)
-	m.RestoringPath = assetPath
-	m.PayloadBackups = []payloadBackup{{TargetPath: assetPath, BackupPath: assetBackup}}
-	require.NoError(t, saveMarker(dir, m))
-	require.NoError(t, replaceFile(assetBackup, assetPath))
+	marker := &pendingMarker{
+		State: markerRollingBack, TargetPath: targetPath, BackupPath: backupPath,
+		StagingDir: stagingDir, PreviousVersion: testPrevVersion, TargetVersion: testTargetVersion,
+		BinaryReplaced: true, UserDBRestored: true, RestoringPath: assetPath,
+		PayloadBackups: []payloadBackup{{TargetPath: assetPath, BackupPath: assetBackup}},
+	}
+	require.NoError(t, fs.Rename(assetBackup, assetPath))
+	recorded := false
+	fileOps := watchdogFileOps{
+		fs: fs,
+		marker: &watchdogMarkerOps{
+			load: func(string) (*pendingMarker, error) {
+				return marker, nil
+			},
+			save: func(_ string, saved *pendingMarker) error {
+				marker = saved
+				return nil
+			},
+			clear: func(string) error {
+				marker = nil
+				return nil
+			},
+			record: func(_ string, saved *pendingMarker) error {
+				recorded = true
+				assert.Equal(t, outcomeRolledBack, saved.Outcome)
+				return nil
+			},
+		},
+		replace: fs.Rename,
+		binary: installBinaryOps{
+			replaceRunning:  fs.Rename,
+			sweepSuperseded: func(string) {},
+		},
+		syncDirectory: func(string) error { return nil },
+		removeStaging: func(_ context.Context, path string) error {
+			return fs.RemoveAll(path)
+		},
+		restoreDatabase: func(context.Context, afero.Fs, string, string) error {
+			t.Fatal("database was restored twice")
+			return nil
+		},
+	}
 
-	err := RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	err := runStartupWatchdogWithOps(t.Context(), dataDir, testTargetVersion, fileOps)
 	require.ErrorIs(t, err, ErrRolledBack)
-	assert.Equal(t, "old asset", readFileString(t, assetPath))
-	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
-	assert.NoFileExists(t, markerPath(dir))
+	asset, readErr := afero.ReadFile(fs, assetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old asset", string(asset))
+	binary, readErr := afero.ReadFile(fs, targetPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, "old binary", string(binary))
+	assert.True(t, recorded)
+	assert.Nil(t, marker)
 }
 
 // The same missing backup on a rollback that has not started yet is a real
@@ -1143,9 +1196,9 @@ func TestRunStartupWatchdog_StopsStartupWhenRestoredDatabaseCannotBeRecorded(t *
 
 	saveErr := errors.New("marker storage unavailable")
 	ops := defaultWatchdogFileOps()
-	realSaveMarker := ops.saveMarker
+	realSaveMarker := ops.marker.save
 	saveCalls := 0
-	ops.saveMarker = func(gotDir string, m *pendingMarker) error {
+	ops.marker.save = func(gotDir string, m *pendingMarker) error {
 		saveCalls++
 		if saveCalls == 2 {
 			return saveErr

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -43,6 +43,19 @@ const (
 	testTargetVersion = "2.2.0"
 )
 
+type recordingRemoveFS struct {
+	afero.Fs
+	record func(string)
+}
+
+func (f *recordingRemoveFS) Remove(name string) error {
+	f.record(name)
+	if err := f.Fs.Remove(name); err != nil {
+		return fmt.Errorf("removing %q: %w", name, err)
+	}
+	return nil
+}
+
 func TestDecideWatchdogAction(t *testing.T) {
 	t.Parallel()
 
@@ -946,9 +959,94 @@ func TestRunStartupWatchdog_RemovesNewPayloadFileBeforeTheBinary(t *testing.T) {
 	m.PayloadBackups = []payloadBackup{{TargetPath: assetPath, OriginalMissing: true}}
 	require.NoError(t, saveMarker(dir, m))
 
-	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, defaultWatchdogFileOps())
+	ops := defaultWatchdogFileOps()
+	var restored []string
+	osFS := ops.fs
+	ops.fs = &recordingRemoveFS{Fs: osFS, record: func(path string) {
+		if path == assetPath {
+			restored = append(restored, path)
+		}
+	}}
+	ops.restoreDatabase = func(ctx context.Context, _ afero.Fs, source, target string) error {
+		return userdb.RestoreFileTo(ctx, osFS, source, target)
+	}
+	originalReplace := ops.binary.replaceRunning
+	ops.binary.replaceRunning = func(source, target string) error {
+		restored = append(restored, target)
+		return originalReplace(source, target)
+	}
+
+	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
 	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, []string{assetPath, f.targetPath}, restored)
 	assert.NoFileExists(t, assetPath)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+}
+
+func TestRestorePayloadFiles_RemovesUnusedCandidate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	candidatePath := filepath.Join(dir, "helper.zaparoo-update-new.sh")
+	require.NoError(t, os.WriteFile(candidatePath, []byte("candidate"), 0o600))
+	m := &pendingMarker{PayloadBackups: []payloadBackup{{
+		TargetPath: filepath.Join(dir, "helper.sh"), CandidatePath: candidatePath, OriginalMissing: true,
+	}}}
+
+	require.NoError(t, restorePayloadFiles(dir, m, defaultWatchdogFileOps()))
+	assert.NoFileExists(t, candidatePath)
+	assert.Empty(t, m.PayloadBackups)
+}
+
+func TestRunStartupWatchdog_ResumesAfterAnEarlierPayloadWasRestored(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	assetDir := t.TempDir()
+	firstPath := filepath.Join(assetDir, "first.sh")
+	firstBackup := filepath.Join(assetDir, ".first.sh.old")
+	secondPath := filepath.Join(assetDir, "second.sh")
+	secondBackup := filepath.Join(assetDir, ".second.sh.old")
+	for path, content := range map[string]string{
+		firstPath: "new first", firstBackup: "old first",
+		secondPath: "new second", secondBackup: "old second",
+	} {
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	m := f.marker(markerConfirming)
+	m.PayloadBackups = []payloadBackup{
+		{TargetPath: firstPath, BackupPath: firstBackup},
+		{TargetPath: secondPath, BackupPath: secondBackup},
+	}
+	require.NoError(t, saveMarker(dir, m))
+
+	errSecond := errors.New("second payload is busy")
+	firstOps := defaultWatchdogFileOps()
+	originalReplace := firstOps.replace
+	firstOps.replace = func(source, target string) error {
+		if target == secondPath {
+			return errSecond
+		}
+		return originalReplace(source, target)
+	}
+	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, firstOps)
+	require.ErrorIs(t, err, errSecond)
+	assert.Equal(t, "old first", readFileString(t, firstPath))
+	assert.Equal(t, "new second", readFileString(t, secondPath))
+	assert.NoFileExists(t, firstBackup)
+
+	pending, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, pending)
+	require.Len(t, pending.PayloadBackups, 1)
+	assert.Equal(t, secondPath, pending.PayloadBackups[0].TargetPath)
+
+	err = runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, defaultWatchdogFileOps())
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old first", readFileString(t, firstPath))
+	assert.Equal(t, "old second", readFileString(t, secondPath))
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 }
 
@@ -1137,6 +1235,7 @@ func TestRestoreReplacedFiles_RestoresTheBinaryThroughTheRunningImageSwap(t *tes
 			BackupPath: filepath.Join(dir, "extra.backup.dll"),
 		}},
 	}
+	payloadTarget := m.PayloadBackups[0].TargetPath
 	for _, path := range []string{m.BackupPath, m.PayloadBackups[0].BackupPath} {
 		require.NoError(t, afero.WriteFile(fs, path, []byte("old"), 0o600))
 	}
@@ -1152,7 +1251,7 @@ func TestRestoreReplacedFiles_RestoresTheBinaryThroughTheRunningImageSwap(t *tes
 	}
 
 	require.NoError(t, restoreReplacedFiles(dir, m, fileOps))
-	assert.Equal(t, []string{m.PayloadBackups[0].TargetPath}, plain)
+	assert.Equal(t, []string{payloadTarget}, plain)
 	assert.Equal(t, []string{m.TargetPath}, running)
 }
 

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -335,6 +335,30 @@ func TestRunStartupWatchdog_ResumesInterruptedRollback(t *testing.T) {
 	assert.NoFileExists(t, markerPath(dir))
 }
 
+func TestRunStartupWatchdog_ResumesInterruptedPayloadRestore(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	assetDir := t.TempDir()
+	assetPath := filepath.Join(assetDir, "menu.png")
+	assetBackup := filepath.Join(assetDir, ".menu.png.zap-old")
+	require.NoError(t, os.WriteFile(assetPath, []byte("new asset"), 0o600))
+	require.NoError(t, os.WriteFile(assetBackup, []byte("old asset"), 0o600))
+
+	m := f.marker(markerRollingBack)
+	m.RestoringPath = assetPath
+	m.PayloadBackups = []payloadBackup{{TargetPath: assetPath, BackupPath: assetBackup}}
+	require.NoError(t, saveMarker(dir, m))
+	require.NoError(t, replaceFile(assetBackup, assetPath))
+
+	err := RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old asset", readFileString(t, assetPath))
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, markerPath(dir))
+}
+
 // The same missing backup on a rollback that has not started yet is a real
 // failure: reporting success would strand the device on the broken version.
 func TestRunStartupWatchdog_MissingBinaryBackupBlocksRollback(t *testing.T) {

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -711,7 +711,6 @@ func TestRunStartupWatchdog_AbortsInterruptedInstallWithoutRestoringDB(t *testin
 	t.Parallel()
 
 	f := newInstallFixture(t)
-	dir := stateDirFor(f.dataDir)
 	// The swap never took the target name: the outgoing binary is still in
 	// place, so abort must not replace it from the backup.
 	//nolint:gosec // executable stand-in owned by this test
@@ -720,13 +719,19 @@ func TestRunStartupWatchdog_AbortsInterruptedInstallWithoutRestoringDB(t *testin
 	require.NoError(t, os.WriteFile(f.backupPath, []byte("backup binary"), 0o755))
 	m := f.marker(markerInstalling)
 	m.BinaryReplaced = false
-	require.NoError(t, saveMarker(dir, m))
+	cleared := false
+	ops := defaultWatchdogFileOps()
+	ops.marker.load = func(string) (*pendingMarker, error) { return m, nil }
+	ops.marker.clear = func(string) error {
+		cleared = true
+		return nil
+	}
 
-	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testPrevVersion))
+	require.NoError(t, runStartupWatchdogWithOps(t.Context(), f.dataDir, testPrevVersion, ops))
 
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 	assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath))
-	assert.NoFileExists(t, markerPath(dir))
+	assert.True(t, cleared)
 	assert.NoFileExists(t, f.snapshotPath)
 	assert.NoDirExists(t, f.stagingDir)
 }

--- a/pkg/service/updater_scheduler.go
+++ b/pkg/service/updater_scheduler.go
@@ -1,0 +1,375 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/notifications"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/power"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	updaterSchedulerTickInterval  = time.Minute
+	updaterCheckInterval          = 12 * time.Hour
+	updaterFailureInitialBackoff  = 5 * time.Minute
+	updaterFailureMaxBackoff      = 6 * time.Hour
+	updaterCheckIdleQuietWindow   = 5 * time.Second
+	updaterCheckIdleMaxWait       = 300 * time.Second
+	updaterInstallIdleQuietWindow = 60 * time.Second
+	updaterInstallIdleMaxWait     = 900 * time.Second
+)
+
+//nolint:govet // Field groups separate dependencies, state, and concurrency controls.
+type updaterScheduler struct {
+	cfg          *config.Instance
+	platform     platforms.Platform
+	db           *database.Database
+	state        *state.State
+	idle         *idle.Scheduler
+	clock        clockwork.Clock
+	waitInternet func(context.Context, int) bool
+	check        updater.CheckFn
+	apply        func(context.Context, updater.Options) (string, error)
+
+	pending          atomic.Pointer[updater.Result]
+	checkScheduled   atomic.Bool
+	installScheduled atomic.Bool
+	checkState       intervalState
+	installState     intervalState
+	mu               syncutil.Mutex
+}
+
+func startUpdaterScheduler(
+	ctx context.Context,
+	cfg *config.Instance,
+	pl platforms.Platform,
+	db *database.Database,
+	st *state.State,
+	idleSched *idle.Scheduler,
+	wg *sync.WaitGroup,
+) {
+	scheduler := newUpdaterScheduler(cfg, pl, db, st, idleSched)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scheduler.loop(ctx)
+	}()
+}
+
+func newUpdaterScheduler(
+	cfg *config.Instance,
+	pl platforms.Platform,
+	db *database.Database,
+	st *state.State,
+	idleSched *idle.Scheduler,
+) *updaterScheduler {
+	return &updaterScheduler{
+		cfg:          cfg,
+		platform:     pl,
+		db:           db,
+		state:        st,
+		idle:         idleSched,
+		clock:        clockwork.NewRealClock(),
+		waitInternet: helpers.WaitForInternetContext,
+		check:        updater.Check,
+		apply:        updater.Apply,
+	}
+}
+
+func (s *updaterScheduler) loop(ctx context.Context) {
+	s.tryCheck(ctx)
+	ticker := s.clock.NewTicker(updaterSchedulerTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.Chan():
+			s.tryCheck(ctx)
+			s.tryInstall(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func updaterInterval(deviceID string) time.Duration {
+	if deviceID == "" {
+		return updaterCheckInterval
+	}
+	sum := sha256.Sum256([]byte(deviceID))
+	// Map uniformly onto [-10%, +10%], inclusive. The result is stable for a
+	// device and does not require wall-clock time.
+	spread := int64(updaterCheckInterval / 5)
+	offset := int64(binary.BigEndian.Uint64(sum[:8])%uint64(spread+1)) - spread/2 //nolint:gosec // bounded modulo
+	return updaterCheckInterval + time.Duration(offset)
+}
+
+func (s *updaterScheduler) checkDue(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.checkState.due(now, updaterInterval(s.cfg.DeviceID()))
+}
+
+func (s *updaterScheduler) recordCheck(now time.Time, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil {
+		s.checkState.recordSuccess(now, updaterFailureInitialBackoff)
+		return
+	}
+	s.checkState.recordFailure(now, updaterFailureInitialBackoff, updaterFailureMaxBackoff)
+}
+
+func (s *updaterScheduler) installDue(now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.installState.due(now, 0)
+}
+
+func (s *updaterScheduler) recordInstall(now time.Time, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err == nil {
+		s.installState.recordSuccess(now, updaterFailureInitialBackoff)
+		return
+	}
+	s.installState.recordFailure(now, updaterFailureInitialBackoff, updaterFailureMaxBackoff)
+}
+
+func (s *updaterScheduler) tryCheck(ctx context.Context) {
+	if s.cfg == nil || !s.cfg.UpdateCheck() || s.installScheduled.Load() ||
+		s.checkScheduled.Load() || !s.checkDue(s.clock.Now()) {
+		return
+	}
+	if !s.checkScheduled.CompareAndSwap(false, true) {
+		return
+	}
+	s.idle.Schedule(ctx, "updater-check", updaterCheckIdleQuietWindow, updaterCheckIdleMaxWait,
+		func(taskCtx context.Context) {
+			defer s.checkScheduled.Store(false)
+			if !s.cfg.UpdateCheck() {
+				return
+			}
+			online := false
+			var result *updater.Result
+			var checkErr error
+			capture := func(checkCtx context.Context, opts updater.Options) (*updater.Result, error) {
+				result, checkErr = s.check(checkCtx, opts)
+				return result, checkErr
+			}
+			updater.CheckAndNotify(
+				taskCtx,
+				s.cfg,
+				serviceUpdaterOptions(s.cfg, s.platform, s.db, updater.ModeAuto),
+				s.state.Inbox(),
+				func(waitCtx context.Context, _ int) bool {
+					online = s.waitInternet(waitCtx, 3)
+					return online
+				},
+				capture,
+				s.platform.ManagedByPackageManager(),
+			)
+			if taskCtx.Err() != nil {
+				return
+			}
+			if !online {
+				checkErr = errors.New("internet unavailable")
+			}
+			if errors.Is(checkErr, updater.ErrDevelopmentVersion) {
+				checkErr = nil
+			}
+			if checkErr != nil || result == nil {
+				s.pending.Store(nil)
+				s.recordCheck(s.clock.Now(), checkErr)
+				return
+			}
+			s.pending.Store(result)
+			s.recordCheck(s.clock.Now(), nil)
+			s.tryInstall(taskCtx)
+		})
+}
+
+func autoInstallable(result *updater.Result) bool {
+	return result != nil && result.UpdateAvailable && !result.RolloutHeld &&
+		result.Eligibility == updater.EligibilityEligible
+}
+
+func (s *updaterScheduler) tryInstall(ctx context.Context) {
+	if s.cfg == nil || !s.cfg.UpdateCheck() || !s.cfg.UpdateInstall() ||
+		s.installScheduled.Load() || !s.installDue(s.clock.Now()) || !autoInstallable(s.pending.Load()) {
+		return
+	}
+
+	reporting := serviceUpdaterGateDeps(s.platform, s.db, s.state)
+	decision, err := updater.CanApplyUpdate(ctx, reporting, updater.ModeAuto, false)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not evaluate automatic update gate")
+		return
+	}
+	decision.Release()
+	if !decision.OK {
+		return
+	}
+	if !s.installScheduled.CompareAndSwap(false, true) {
+		return
+	}
+	s.idle.Schedule(ctx, "updater-install", updaterInstallIdleQuietWindow, updaterInstallIdleMaxWait,
+		func(taskCtx context.Context) {
+			defer s.installScheduled.Store(false)
+			s.runInstall(taskCtx)
+		})
+}
+
+func (s *updaterScheduler) runInstall(ctx context.Context) {
+	if !s.cfg.UpdateCheck() || !s.cfg.UpdateInstall() {
+		return
+	}
+	opts := serviceUpdaterOptions(s.cfg, s.platform, s.db, updater.ModeAuto)
+	fresh, err := s.check(ctx, opts)
+	if err != nil || !autoInstallable(fresh) {
+		if err != nil && !errors.Is(err, context.Canceled) {
+			log.Warn().Err(err).Msg("automatic update recheck failed")
+			s.recordInstall(s.clock.Now(), err)
+		}
+		if fresh != nil {
+			s.pending.Store(fresh)
+		} else {
+			s.pending.Store(nil)
+		}
+		return
+	}
+	s.pending.Store(fresh)
+
+	deps := serviceUpdaterGateDeps(s.platform, s.db, s.state)
+	deps.AcquireRestore = s.state.TryAcquireRestoreAccess
+	deps.AcquireMediaGate = s.state.AcquireUpdateMediaGate
+	decision, err := updater.CanApplyUpdate(ctx, deps, updater.ModeAuto, false)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.Warn().Err(err).Msg("automatic update gate failed")
+		}
+		s.recordInstall(s.clock.Now(), err)
+		return
+	}
+	if !decision.OK {
+		decision.Release()
+		return
+	}
+	defer decision.Release()
+
+	opts.Progress = serviceUpdaterProgress(s.state)
+	opts.PreQuiesce = func(context.Context) error {
+		powered := updater.PowerReady(deps, updater.ModeAuto, false)
+		return powered.Err()
+	}
+	previousVersion := config.AppVersion
+	newVersion, err := s.apply(ctx, opts)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			log.Warn().Err(err).Msg("automatic update install failed")
+		}
+		s.recordInstall(s.clock.Now(), err)
+		return
+	}
+	s.recordInstall(s.clock.Now(), nil)
+	log.Info().Str("previous", previousVersion).Str("new", newVersion).
+		Msg("automatic update applied, restarting service")
+	s.state.RestartService()
+}
+
+func serviceUpdaterOptions(
+	cfg *config.Instance,
+	pl platforms.Platform,
+	db *database.Database,
+	mode updater.Mode,
+) updater.Options {
+	opts := updater.Options{
+		PlatformID: pl.ID(),
+		Channel:    cfg.UpdateChannel(),
+		DataDir:    helpers.DataDir(pl),
+		DeviceID:   cfg.DeviceID(),
+		Managed:    pl.ManagedByPackageManager(),
+		Mode:       mode,
+	}
+	if db != nil {
+		opts.UserDB = db.UserDB
+	}
+	return opts
+}
+
+func serviceUpdaterGateDeps(
+	pl platforms.Platform,
+	db *database.Database,
+	st *state.State,
+) *updater.GateDeps {
+	deps := &updater.GateDeps{Power: func() power.Status { return platforms.PowerStatus(pl) }}
+	if db != nil && db.MediaDB != nil {
+		deps.IndexingStatus = db.MediaDB.GetIndexingStatus
+		deps.OptimizationStatus = db.MediaDB.GetOptimizationStatus
+		deps.ScrapingStatus = db.MediaDB.GetScrapingStatus
+	}
+	if st == nil {
+		return deps
+	}
+	if coordinator := st.BackupCoordinator(); coordinator != nil {
+		deps.BackupActive = func() bool {
+			_, _, active := coordinator.Active()
+			return active
+		}
+	}
+	deps.ReaderWriteActive = st.AnyReaderWriteActive
+	deps.ActiveMedia = func() bool { return st.ActiveMedia() != nil }
+	deps.BackgroundMedia = func() bool { return st.BackgroundMedia() != nil }
+	deps.ActivePlaylist = func() bool { return st.GetActivePlaylist() != nil }
+	return deps
+}
+
+func serviceUpdaterProgress(st *state.State) updater.ProgressFn {
+	if st == nil || st.Notifications == nil {
+		return nil
+	}
+	return func(progress updater.Progress) {
+		notifications.UpdateState(st.Notifications, models.UpdateStateNotification{
+			Stage:           string(progress.Stage),
+			Version:         progress.Version,
+			Trigger:         progress.Trigger,
+			Error:           progress.Error,
+			BytesDownloaded: progress.BytesDownloaded,
+			BytesTotal:      progress.BytesTotal,
+		})
+	}
+}

--- a/pkg/service/updater_scheduler.go
+++ b/pkg/service/updater_scheduler.go
@@ -187,6 +187,8 @@ func (s *updaterScheduler) tryCheck(ctx context.Context) {
 			online := false
 			var result *updater.Result
 			var checkErr error
+			opts := serviceUpdaterOptions(s.cfg, s.platform, s.db, updater.ModeAuto)
+			opts.Gate = s.gateDeps(nil)
 			capture := func(checkCtx context.Context, opts updater.Options) (*updater.Result, error) {
 				result, checkErr = s.check(checkCtx, opts)
 				return result, checkErr
@@ -194,7 +196,7 @@ func (s *updaterScheduler) tryCheck(ctx context.Context) {
 			updater.CheckAndNotify(
 				taskCtx,
 				s.cfg,
-				serviceUpdaterOptions(s.cfg, s.platform, s.db, updater.ModeAuto),
+				opts,
 				s.state.Inbox(),
 				func(waitCtx context.Context, _ int) bool {
 					online = s.waitInternet(waitCtx, 3)
@@ -229,12 +231,13 @@ func autoInstallable(result *updater.Result) bool {
 }
 
 func (s *updaterScheduler) tryInstall(ctx context.Context) {
+	result := s.pending.Load()
 	if s.cfg == nil || !s.cfg.UpdateCheck() || !s.cfg.UpdateInstall() ||
-		s.installScheduled.Load() || !s.installDue(s.clock.Now()) || !autoInstallable(s.pending.Load()) {
+		s.installScheduled.Load() || !s.installDue(s.clock.Now()) || !autoInstallable(result) {
 		return
 	}
 
-	reporting := serviceUpdaterGateDeps(s.platform, s.db, s.state)
+	reporting := s.gateDeps(result)
 	decision, err := updater.CanApplyUpdate(ctx, reporting, updater.ModeAuto, false)
 	if err != nil {
 		log.Warn().Err(err).Msg("could not evaluate automatic update gate")
@@ -259,6 +262,7 @@ func (s *updaterScheduler) runInstall(ctx context.Context) {
 		return
 	}
 	opts := serviceUpdaterOptions(s.cfg, s.platform, s.db, updater.ModeAuto)
+	opts.Gate = s.gateDeps(s.pending.Load())
 	fresh, err := s.check(ctx, opts)
 	if err != nil || !autoInstallable(fresh) {
 		if err != nil && !errors.Is(err, context.Canceled) {
@@ -274,7 +278,7 @@ func (s *updaterScheduler) runInstall(ctx context.Context) {
 	}
 	s.pending.Store(fresh)
 
-	deps := serviceUpdaterGateDeps(s.platform, s.db, s.state)
+	deps := s.gateDeps(fresh)
 	deps.AcquireRestore = s.state.TryAcquireRestoreAccess
 	deps.AcquireMediaGate = s.state.AcquireUpdateMediaGate
 	decision, err := updater.CanApplyUpdate(ctx, deps, updater.ModeAuto, false)
@@ -311,6 +315,18 @@ func (s *updaterScheduler) runInstall(ctx context.Context) {
 	s.state.RestartService()
 }
 
+func (s *updaterScheduler) gateDeps(result *updater.Result) *updater.GateDeps {
+	deps := serviceUpdaterGateDeps(s.platform, s.db, s.state)
+	deps.Now = s.clock.Now
+	deps.DeferredSince = func() time.Time {
+		if result == nil {
+			return time.Time{}
+		}
+		return result.DeferredSince
+	}
+	return deps
+}
+
 func serviceUpdaterOptions(
 	cfg *config.Instance,
 	pl platforms.Platform,
@@ -324,6 +340,9 @@ func serviceUpdaterOptions(
 		DeviceID:   cfg.DeviceID(),
 		Managed:    pl.ManagedByPackageManager(),
 		Mode:       mode,
+	}
+	if provider, ok := pl.(platforms.UpdatePayloadProvider); ok {
+		opts.Payload = provider.UpdatePayload()
 	}
 	if db != nil {
 		opts.UserDB = db.UserDB

--- a/pkg/service/updater_scheduler_test.go
+++ b/pkg/service/updater_scheduler_test.go
@@ -85,7 +85,10 @@ func TestUpdaterSchedulerEagerCheckHonorsSuccessInterval(t *testing.T) {
 	scheduler.clock = clock
 	scheduler.waitInternet = func(context.Context, int) bool { return true }
 	checked := make(chan struct{}, 2)
-	scheduler.check = func(context.Context, updater.Options) (*updater.Result, error) {
+	scheduler.check = func(_ context.Context, opts updater.Options) (*updater.Result, error) {
+		require.NotNil(t, opts.Gate)
+		require.NotNil(t, opts.Gate.Now)
+		assert.Equal(t, clock.Now(), opts.Gate.Now())
 		checked <- struct{}{}
 		return &updater.Result{
 			CurrentVersion: "2.9.0", LatestVersion: "2.9.0",
@@ -133,6 +136,7 @@ func TestUpdaterSchedulerRunInstallRechecksAndRestarts(t *testing.T) {
 	}
 	scheduler.check = func(_ context.Context, opts updater.Options) (*updater.Result, error) {
 		assert.Equal(t, updater.ModeAuto, opts.Mode)
+		require.NotNil(t, opts.Gate)
 		return fresh, nil
 	}
 	applied := false
@@ -149,6 +153,30 @@ func TestUpdaterSchedulerRunInstallRechecksAndRestarts(t *testing.T) {
 	assert.True(t, applied)
 	assert.True(t, st.RestartRequested())
 	pl.AssertExpectations(t)
+}
+
+func TestUpdaterSchedulerGateExpiresPersistedSoftDeferral(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(now)
+	scheduler := &updaterScheduler{clock: clock}
+	result := &updater.Result{DeferredSince: now.Add(-24*time.Hour + time.Minute)}
+	deps := scheduler.gateDeps(result)
+	deps.Power = nil
+	deps.ActiveMedia = func() bool { return true }
+
+	decision, err := updater.CanApplyUpdate(t.Context(), deps, updater.ModeAuto, false)
+	require.NoError(t, err)
+	assert.False(t, decision.OK)
+	assert.Equal(t, updater.ReasonActiveMedia, decision.Reason)
+	decision.Release()
+
+	clock.Advance(time.Minute)
+	decision, err = updater.CanApplyUpdate(t.Context(), deps, updater.ModeAuto, false)
+	require.NoError(t, err)
+	assert.True(t, decision.OK)
+	decision.Release()
 }
 
 func TestAutoInstallable(t *testing.T) {

--- a/pkg/service/updater_scheduler_test.go
+++ b/pkg/service/updater_scheduler_test.go
@@ -1,0 +1,169 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
+	stateservice "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdaterIntervalJitter(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, updaterCheckInterval, updaterInterval(""))
+	first := updaterInterval("device-1")
+	assert.Equal(t, first, updaterInterval("device-1"))
+	assert.GreaterOrEqual(t, first, updaterCheckInterval-updaterCheckInterval/10)
+	assert.LessOrEqual(t, first, updaterCheckInterval+updaterCheckInterval/10)
+	assert.NotEqual(t, first, updaterInterval("device-2"))
+}
+
+func TestIntervalStateBackoffAndReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC)
+	var state intervalState
+	assert.True(t, state.due(now, updaterCheckInterval))
+	state.recordFailure(now, updaterFailureInitialBackoff, updaterFailureMaxBackoff)
+	assert.False(t, state.due(now.Add(time.Minute), updaterCheckInterval))
+	assert.True(t, state.due(now.Add(updaterFailureInitialBackoff), updaterCheckInterval))
+	assert.Equal(t, 2*updaterFailureInitialBackoff, state.backoff)
+
+	state.backoff = updaterFailureMaxBackoff
+	state.recordFailure(now, updaterFailureInitialBackoff, updaterFailureMaxBackoff)
+	assert.Equal(t, updaterFailureMaxBackoff, state.backoff)
+
+	state.recordSuccess(now, updaterFailureInitialBackoff)
+	assert.False(t, state.due(now.Add(time.Hour), updaterCheckInterval))
+	assert.True(t, state.due(now.Add(updaterCheckInterval), updaterCheckInterval))
+	assert.Equal(t, updaterFailureInitialBackoff, state.backoff)
+}
+
+func TestUpdaterSchedulerEagerCheckHonorsSuccessInterval(t *testing.T) {
+	root := t.TempDir()
+	cfg, err := config.NewConfig(root, config.BaseDefaults)
+	require.NoError(t, err)
+	cfg.SetUpdateCheck(true)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("ID").Return("mock-platform")
+	pl.On("Settings").Return(platforms.Settings{DataDir: root})
+	pl.On("ManagedByPackageManager").Return(false)
+	st, _ := stateservice.NewState(pl, "test-boot")
+	t.Cleanup(st.StopService)
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC))
+	idleSched := idle.NewWithClock(clock)
+	scheduler := newUpdaterScheduler(cfg, pl, nil, st, idleSched)
+	scheduler.clock = clock
+	scheduler.waitInternet = func(context.Context, int) bool { return true }
+	checked := make(chan struct{}, 2)
+	scheduler.check = func(context.Context, updater.Options) (*updater.Result, error) {
+		checked <- struct{}{}
+		return &updater.Result{
+			CurrentVersion: "2.9.0", LatestVersion: "2.9.0",
+			Eligibility: updater.EligibilityEligible,
+		}, nil
+	}
+
+	scheduler.tryCheck(t.Context())
+	require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+	clock.Advance(updaterCheckIdleQuietWindow)
+	select {
+	case <-checked:
+	case <-time.After(time.Second):
+		t.Fatal("eager updater check did not run")
+	}
+	require.Eventually(t, func() bool { return !scheduler.checkScheduled.Load() }, time.Second, time.Millisecond)
+
+	scheduler.tryCheck(t.Context())
+	select {
+	case <-checked:
+		t.Fatal("updater checked again before its interval")
+	default:
+	}
+	idleSched.Wait()
+	pl.AssertExpectations(t)
+}
+
+func TestUpdaterSchedulerRunInstallRechecksAndRestarts(t *testing.T) {
+	root := t.TempDir()
+	cfg, err := config.NewConfig(root, config.BaseDefaults)
+	require.NoError(t, err)
+	cfg.SetUpdateCheck(true)
+	cfg.SetUpdateInstall(true)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("ID").Return("mock-platform")
+	pl.On("Settings").Return(platforms.Settings{DataDir: root})
+	pl.On("ManagedByPackageManager").Return(false)
+	st, _ := stateservice.NewState(pl, "test-boot")
+	t.Cleanup(st.StopService)
+	scheduler := newUpdaterScheduler(cfg, pl, nil, st, idle.New())
+	fresh := &updater.Result{
+		CurrentVersion: "2.9.0", LatestVersion: "2.10.0",
+		UpdateAvailable: true, Eligibility: updater.EligibilityEligible,
+	}
+	scheduler.check = func(_ context.Context, opts updater.Options) (*updater.Result, error) {
+		assert.Equal(t, updater.ModeAuto, opts.Mode)
+		return fresh, nil
+	}
+	applied := false
+	scheduler.apply = func(ctx context.Context, opts updater.Options) (string, error) {
+		applied = true
+		assert.Equal(t, updater.ModeAuto, opts.Mode)
+		require.NotNil(t, opts.PreQuiesce)
+		require.NoError(t, opts.PreQuiesce(ctx))
+		return "2.10.0", nil
+	}
+
+	scheduler.runInstall(t.Context())
+
+	assert.True(t, applied)
+	assert.True(t, st.RestartRequested())
+	pl.AssertExpectations(t)
+}
+
+func TestAutoInstallable(t *testing.T) {
+	t.Parallel()
+
+	eligible := &updater.Result{UpdateAvailable: true, Eligibility: updater.EligibilityEligible}
+	assert.True(t, autoInstallable(eligible))
+	copyResult := *eligible
+	copyResult.RolloutHeld = true
+	assert.False(t, autoInstallable(&copyResult))
+	copyResult = *eligible
+	copyResult.Eligibility = updater.EligibilityManaged
+	assert.False(t, autoInstallable(&copyResult))
+	copyResult = *eligible
+	copyResult.UpdateAvailable = false
+	assert.False(t, autoInstallable(&copyResult))
+	assert.False(t, autoInstallable(nil))
+}

--- a/pkg/service/updater_scheduler_test.go
+++ b/pkg/service/updater_scheduler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	stateservice "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
@@ -34,6 +35,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type schedulerPayloadPlatform struct {
+	platforms.Platform
+	payload []updatepayload.File
+}
+
+func (p schedulerPayloadPlatform) UpdatePayload() []updatepayload.File {
+	return p.payload
+}
 
 func TestUpdaterIntervalJitter(t *testing.T) {
 	t.Parallel()
@@ -65,6 +75,24 @@ func TestIntervalStateBackoffAndReset(t *testing.T) {
 	assert.False(t, state.due(now.Add(time.Hour), updaterCheckInterval))
 	assert.True(t, state.due(now.Add(updaterCheckInterval), updaterCheckInterval))
 	assert.Equal(t, updaterFailureInitialBackoff, state.backoff)
+}
+
+func TestServiceUpdaterOptionsIncludesPlatformPayload(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	cfg, err := config.NewConfig(root, config.BaseDefaults)
+	require.NoError(t, err)
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("mock-platform")
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: root})
+	mockPlatform.On("ManagedByPackageManager").Return(false)
+	payload := []updatepayload.File{{ArchivePath: "scripts/helper.sh"}}
+	pl := schedulerPayloadPlatform{Platform: mockPlatform, payload: payload}
+
+	opts := serviceUpdaterOptions(cfg, pl, nil, updater.ModeAuto)
+	assert.Equal(t, payload, opts.Payload)
+	mockPlatform.AssertExpectations(t)
 }
 
 func TestUpdaterSchedulerEagerCheckHonorsSuccessInterval(t *testing.T) {
@@ -116,6 +144,51 @@ func TestUpdaterSchedulerEagerCheckHonorsSuccessInterval(t *testing.T) {
 	pl.AssertExpectations(t)
 }
 
+func TestUpdaterSchedulerTryInstallSchedulesEligibleUpdate(t *testing.T) {
+	root := t.TempDir()
+	cfg, err := config.NewConfig(root, config.BaseDefaults)
+	require.NoError(t, err)
+	cfg.SetUpdateCheck(true)
+	cfg.SetUpdateInstall(true)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("ID").Return("mock-platform")
+	pl.On("Settings").Return(platforms.Settings{DataDir: root})
+	pl.On("ManagedByPackageManager").Return(false)
+	st, _ := stateservice.NewState(pl, "test-boot")
+	t.Cleanup(st.StopService)
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 8, 20, 10, 0, 0, 0, time.UTC))
+	idleSched := idle.NewWithClock(clock)
+	scheduler := newUpdaterScheduler(cfg, pl, nil, st, idleSched)
+	scheduler.clock = clock
+	fresh := &updater.Result{
+		CurrentVersion: "2.9.0", LatestVersion: "2.10.0",
+		UpdateAvailable: true, Eligibility: updater.EligibilityEligible,
+	}
+	scheduler.pending.Store(fresh)
+	scheduler.check = func(context.Context, updater.Options) (*updater.Result, error) {
+		return fresh, nil
+	}
+	applied := make(chan struct{}, 1)
+	scheduler.apply = func(context.Context, updater.Options) (string, error) {
+		applied <- struct{}{}
+		return "2.10.0", nil
+	}
+
+	scheduler.tryInstall(t.Context())
+	require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+	clock.Advance(updaterInstallIdleQuietWindow)
+	select {
+	case <-applied:
+	case <-time.After(time.Second):
+		t.Fatal("eligible automatic update was not installed")
+	}
+	require.Eventually(t, func() bool { return !scheduler.installScheduled.Load() }, time.Second, time.Millisecond)
+	assert.True(t, st.RestartRequested())
+	idleSched.Wait()
+	pl.AssertExpectations(t)
+}
+
 func TestUpdaterSchedulerRunInstallRechecksAndRestarts(t *testing.T) {
 	root := t.TempDir()
 	cfg, err := config.NewConfig(root, config.BaseDefaults)
@@ -152,6 +225,44 @@ func TestUpdaterSchedulerRunInstallRechecksAndRestarts(t *testing.T) {
 
 	assert.True(t, applied)
 	assert.True(t, st.RestartRequested())
+	pl.AssertExpectations(t)
+}
+
+func TestUpdaterSchedulerRunInstallStopsWhenRecheckIsNoLongerEligible(t *testing.T) {
+	root := t.TempDir()
+	cfg, err := config.NewConfig(root, config.BaseDefaults)
+	require.NoError(t, err)
+	cfg.SetUpdateCheck(true)
+	cfg.SetUpdateInstall(true)
+
+	pl := mocks.NewMockPlatform()
+	pl.On("ID").Return("mock-platform")
+	pl.On("Settings").Return(platforms.Settings{DataDir: root})
+	pl.On("ManagedByPackageManager").Return(false)
+	st, _ := stateservice.NewState(pl, "test-boot")
+	t.Cleanup(st.StopService)
+	scheduler := newUpdaterScheduler(cfg, pl, nil, st, idle.New())
+	stale := &updater.Result{
+		CurrentVersion: "2.9.0", LatestVersion: "2.10.0",
+		UpdateAvailable: true, Eligibility: updater.EligibilityEligible,
+	}
+	fresh := &updater.Result{
+		CurrentVersion: "2.10.0", LatestVersion: "2.10.0",
+		Eligibility: updater.EligibilityEligible,
+	}
+	scheduler.pending.Store(stale)
+	scheduler.check = func(context.Context, updater.Options) (*updater.Result, error) {
+		return fresh, nil
+	}
+	scheduler.apply = func(context.Context, updater.Options) (string, error) {
+		t.Fatal("update was applied after recheck reported no update")
+		return "", nil
+	}
+
+	scheduler.runInstall(t.Context())
+
+	assert.Same(t, fresh, scheduler.pending.Load())
+	assert.False(t, st.RestartRequested())
 	pl.AssertExpectations(t)
 }
 

--- a/scripts/tasks/docker.yml
+++ b/scripts/tasks/docker.yml
@@ -51,7 +51,7 @@ tasks:
           APP_VERSION:
             sh: echo -n "${APP_VERSION:-$(git rev-parse --short HEAD)-dev}"
       - >-
-        go run scripts/tasks/utils/makezip/main.go
+        go run ./scripts/tasks/utils/makezip
         {{.PLATFORM}} {{.BUILD_DIR}} {{.APP_BIN}}
         "zaparoo-{{.PLATFORM}}_{{default ARCH .BUILD_ARCH}}-${APP_VERSION}.{{.ARCHIVE_EXT}}"
 

--- a/scripts/tasks/utils/makezip/main.go
+++ b/scripts/tasks/utils/makezip/main.go
@@ -348,11 +348,25 @@ func createZipFile(zipPath, appPath, licensePath, readmePath, platform, _ string
 	return addPayloadToZip(zipWriter, payloadFiles(platform))
 }
 
-func addPayloadToZip(zipWriter *zip.Writer, files []updatepayload.File) error {
+func validatePayloadFiles(files []updatepayload.File) error {
+	seen := make(map[string]struct{}, len(files))
 	for _, file := range files {
-		if _, ok := updatepayload.MatchArchiveFile(files, file.ArchivePath); !ok {
+		if _, duplicate := seen[file.ArchivePath]; duplicate {
+			return fmt.Errorf("duplicate payload archive path %q", file.ArchivePath)
+		}
+		seen[file.ArchivePath] = struct{}{}
+		if _, ok := updatepayload.MatchArchiveFile([]updatepayload.File{file}, file.ArchivePath); !ok {
 			return fmt.Errorf("payload archive path %q is invalid", file.ArchivePath)
 		}
+	}
+	return nil
+}
+
+func addPayloadToZip(zipWriter *zip.Writer, files []updatepayload.File) error {
+	if err := validatePayloadFiles(files); err != nil {
+		return err
+	}
+	for _, file := range files {
 		info, err := os.Lstat(file.SourcePath)
 		if err != nil {
 			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)
@@ -464,10 +478,10 @@ func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, _ st
 }
 
 func addPayloadToTar(tarWriter *tar.Writer, files []updatepayload.File) error {
+	if err := validatePayloadFiles(files); err != nil {
+		return err
+	}
 	for _, file := range files {
-		if _, ok := updatepayload.MatchArchiveFile(files, file.ArchivePath); !ok {
-			return fmt.Errorf("payload archive path %q is invalid", file.ArchivePath)
-		}
 		info, err := os.Lstat(file.SourcePath)
 		if err != nil {
 			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)

--- a/scripts/tasks/utils/makezip/main.go
+++ b/scripts/tasks/utils/makezip/main.go
@@ -28,7 +28,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	archivepath "path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -125,9 +124,13 @@ func expandRelativeLinks(content, _ string) string {
 		linkPath = strings.TrimSuffix(linkPath, ".mdx")
 		linkPath = strings.TrimSuffix(linkPath, ".md")
 
-		// Remove trailing /index since zaparoo.org doesn't need it in URLs
-		linkPath = strings.TrimSuffix(linkPath, "/index")
-		linkPath = strings.TrimSuffix(linkPath, "index")
+		// Remove a path-final index segment since zaparoo.org doesn't need
+		// it in URLs. A filename such as platform-index is not an index page.
+		if linkPath == "index" {
+			linkPath = ""
+		} else {
+			linkPath = strings.TrimSuffix(linkPath, "/index")
+		}
 
 		// Build the absolute URL based on how many levels up we go
 		// Source docs are at docs/platforms/{platform}/, so:
@@ -342,26 +345,33 @@ func createZipFile(zipPath, appPath, licensePath, readmePath, platform, _ string
 		}
 	}
 
-	return addPayloadToZip(zipWriter, updatepayload.Roots(platform))
+	return addPayloadToZip(zipWriter, payloadFiles(platform))
 }
 
-func addPayloadToZip(zipWriter *zip.Writer, roots []updatepayload.Root) error {
-	for _, root := range roots {
-		info, err := os.Stat(root.SourceDir)
+func addPayloadToZip(zipWriter *zip.Writer, files []updatepayload.File) error {
+	for _, file := range files {
+		if _, ok := updatepayload.MatchArchiveFile(files, file.ArchivePath); !ok {
+			return fmt.Errorf("payload archive path %q is invalid", file.ArchivePath)
+		}
+		info, err := os.Lstat(file.SourcePath)
 		if err != nil {
-			return fmt.Errorf("reading payload source %q: %w", root.SourceDir, err)
+			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)
 		}
-		if !info.IsDir() {
-			return fmt.Errorf("payload source %q is not a directory", root.SourceDir)
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("payload source %q is not a regular file", file.SourcePath)
 		}
-		if err := addDirToZip(zipWriter, root.SourceDir, root.ArchiveRoot); err != nil {
-			return fmt.Errorf("adding payload source %q to zip: %w", root.SourceDir, err)
+		if err := addFileToZipMode(zipWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
+			return fmt.Errorf("adding payload source %q to zip: %w", file.SourcePath, err)
 		}
 	}
 	return nil
 }
 
 func addFileToZip(zipWriter *zip.Writer, filePath, arcname string) error {
+	return addFileToZipMode(zipWriter, filePath, arcname, 0)
+}
+
+func addFileToZipMode(zipWriter *zip.Writer, filePath, arcname string, mode os.FileMode) error {
 	//nolint:gosec // Safe: opens files in build script with controlled paths
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -382,6 +392,9 @@ func addFileToZip(zipWriter *zip.Writer, filePath, arcname string) error {
 	}
 	header.Name = arcname
 	header.Method = zip.Deflate
+	if mode != 0 {
+		header.SetMode(mode.Perm())
+	}
 
 	writer, err := zipWriter.CreateHeader(header)
 	if err != nil {
@@ -391,29 +404,6 @@ func addFileToZip(zipWriter *zip.Writer, filePath, arcname string) error {
 	_, err = io.Copy(writer, file)
 	if err != nil {
 		return fmt.Errorf("failed to copy file content to zip: %w", err)
-	}
-	return nil
-}
-
-func addDirToZip(zipWriter *zip.Writer, dirPath, archiveRoot string) error {
-	if err := filepath.Walk(dirPath, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-
-		relPath, err := filepath.Rel(dirPath, filePath)
-		if err != nil {
-			return fmt.Errorf("failed to get relative path: %w", err)
-		}
-		if !updatepayload.IncludeSource(relPath) {
-			return nil
-		}
-		return addFileToZip(zipWriter, filePath, archivepath.Join(archiveRoot, filepath.ToSlash(relPath)))
-	}); err != nil {
-		return fmt.Errorf("failed to walk directory %s: %w", dirPath, err)
 	}
 	return nil
 }
@@ -470,26 +460,33 @@ func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, _ st
 		}
 	}
 
-	return addPayloadToTar(tarWriter, updatepayload.Roots(platform))
+	return addPayloadToTar(tarWriter, payloadFiles(platform))
 }
 
-func addPayloadToTar(tarWriter *tar.Writer, roots []updatepayload.Root) error {
-	for _, root := range roots {
-		info, err := os.Stat(root.SourceDir)
+func addPayloadToTar(tarWriter *tar.Writer, files []updatepayload.File) error {
+	for _, file := range files {
+		if _, ok := updatepayload.MatchArchiveFile(files, file.ArchivePath); !ok {
+			return fmt.Errorf("payload archive path %q is invalid", file.ArchivePath)
+		}
+		info, err := os.Lstat(file.SourcePath)
 		if err != nil {
-			return fmt.Errorf("reading payload source %q: %w", root.SourceDir, err)
+			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)
 		}
-		if !info.IsDir() {
-			return fmt.Errorf("payload source %q is not a directory", root.SourceDir)
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("payload source %q is not a regular file", file.SourcePath)
 		}
-		if err := addDirToTar(tarWriter, root.SourceDir, root.ArchiveRoot); err != nil {
-			return fmt.Errorf("adding payload source %q to tar: %w", root.SourceDir, err)
+		if err := addFileToTarMode(tarWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
+			return fmt.Errorf("adding payload source %q to tar: %w", file.SourcePath, err)
 		}
 	}
 	return nil
 }
 
 func addFileToTar(tarWriter *tar.Writer, filePath, arcname string) error {
+	return addFileToTarMode(tarWriter, filePath, arcname, 0)
+}
+
+func addFileToTarMode(tarWriter *tar.Writer, filePath, arcname string, mode os.FileMode) error {
 	//nolint:gosec // Safe: opens files in build script with controlled paths
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -509,6 +506,9 @@ func addFileToTar(tarWriter *tar.Writer, filePath, arcname string) error {
 		return fmt.Errorf("operation failed: %w", err)
 	}
 	header.Name = arcname
+	if mode != 0 {
+		header.Mode = int64(mode.Perm())
+	}
 
 	err = tarWriter.WriteHeader(header)
 	if err != nil {
@@ -518,29 +518,6 @@ func addFileToTar(tarWriter *tar.Writer, filePath, arcname string) error {
 	_, err = io.Copy(tarWriter, file)
 	if err != nil {
 		return fmt.Errorf("failed to copy file content to tar: %w", err)
-	}
-	return nil
-}
-
-func addDirToTar(tarWriter *tar.Writer, dirPath, archiveRoot string) error {
-	if err := filepath.Walk(dirPath, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-
-		relPath, err := filepath.Rel(dirPath, filePath)
-		if err != nil {
-			return fmt.Errorf("failed to get relative path: %w", err)
-		}
-		if !updatepayload.IncludeSource(relPath) {
-			return nil
-		}
-		return addFileToTar(tarWriter, filePath, archivepath.Join(archiveRoot, filepath.ToSlash(relPath)))
-	}); err != nil {
-		return fmt.Errorf("failed to walk directory %s: %w", dirPath, err)
 	}
 	return nil
 }

--- a/scripts/tasks/utils/makezip/main.go
+++ b/scripts/tasks/utils/makezip/main.go
@@ -28,10 +28,13 @@ import (
 	"io"
 	"net/http"
 	"os"
+	archivepath "path"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 )
 
 const baseURL = "https://github.com/ZaparooProject/zaparoo.org/raw/refs/heads/main/docs/platforms/"
@@ -69,10 +72,6 @@ var platformURLs = map[string]string{
 	"windows":   "https://zaparoo.org/docs/platforms/windows/",
 	// Interim packaging fallback until dedicated ZapOS docs are published.
 	"zapos": "https://zaparoo.org/docs/platforms/linux/",
-}
-
-var extraItems = map[string][]string{
-	"batocera": {"cmd/batocera/scripts"},
 }
 
 func stripFrontmatter(content string) string {
@@ -114,21 +113,21 @@ func expandRelativeLinks(content, _ string) string {
 
 		// Count and strip leading ../ sequences
 		upLevels := 0
-		path := fullPath
-		for strings.HasPrefix(path, "../") {
+		linkPath := fullPath
+		for strings.HasPrefix(linkPath, "../") {
 			upLevels++
-			path = strings.TrimPrefix(path, "../")
+			linkPath = strings.TrimPrefix(linkPath, "../")
 		}
 		// Also handle ./ prefix (same directory)
-		path = strings.TrimPrefix(path, "./")
+		linkPath = strings.TrimPrefix(linkPath, "./")
 
 		// Remove .md or .mdx extension
-		path = strings.TrimSuffix(path, ".mdx")
-		path = strings.TrimSuffix(path, ".md")
+		linkPath = strings.TrimSuffix(linkPath, ".mdx")
+		linkPath = strings.TrimSuffix(linkPath, ".md")
 
 		// Remove trailing /index since zaparoo.org doesn't need it in URLs
-		path = strings.TrimSuffix(path, "/index")
-		path = strings.TrimSuffix(path, "index")
+		linkPath = strings.TrimSuffix(linkPath, "/index")
+		linkPath = strings.TrimSuffix(linkPath, "index")
 
 		// Build the absolute URL based on how many levels up we go
 		// Source docs are at docs/platforms/{platform}/, so:
@@ -138,10 +137,10 @@ func expandRelativeLinks(content, _ string) string {
 		var absURL string
 		if upLevels == 0 {
 			// Same directory or subdirectory - relative to platforms
-			absURL = baseDocsURL + "platforms/" + path
+			absURL = baseDocsURL + "platforms/" + linkPath
 		} else {
 			// Going up from platforms directory - resolve to docs base
-			absURL = baseDocsURL + path
+			absURL = baseDocsURL + linkPath
 		}
 
 		// Ensure URL ends with / and clean up any double slashes
@@ -310,7 +309,7 @@ func main() {
 	}
 }
 
-func createZipFile(zipPath, appPath, licensePath, readmePath, platform, buildDir string) error {
+func createZipFile(zipPath, appPath, licensePath, readmePath, platform, _ string) error {
 	//nolint:gosec // Safe: creates zip files in build script with controlled paths
 	zipFile, err := os.Create(zipPath)
 	if err != nil {
@@ -343,25 +342,22 @@ func createZipFile(zipPath, appPath, licensePath, readmePath, platform, buildDir
 		}
 	}
 
-	if items, ok := extraItems[platform]; ok {
-		for _, item := range items {
-			if info, err := os.Stat(item); err == nil {
-				if info.IsDir() {
-					err = addDirToZip(zipWriter, item, buildDir)
-				} else {
-					destPath := filepath.Join(buildDir, filepath.Base(item))
-					if copyErr := copyFile(item, destPath); copyErr != nil {
-						return fmt.Errorf("error copying extra file: %w", copyErr)
-					}
-					err = addFileToZip(zipWriter, destPath, filepath.Base(item))
-				}
-				if err != nil {
-					return fmt.Errorf("error adding extra item to zip: %w", err)
-				}
-			}
+	return addPayloadToZip(zipWriter, updatepayload.Roots(platform))
+}
+
+func addPayloadToZip(zipWriter *zip.Writer, roots []updatepayload.Root) error {
+	for _, root := range roots {
+		info, err := os.Stat(root.SourceDir)
+		if err != nil {
+			return fmt.Errorf("reading payload source %q: %w", root.SourceDir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("payload source %q is not a directory", root.SourceDir)
+		}
+		if err := addDirToZip(zipWriter, root.SourceDir, root.ArchiveRoot); err != nil {
+			return fmt.Errorf("adding payload source %q to zip: %w", root.SourceDir, err)
 		}
 	}
-
 	return nil
 }
 
@@ -399,31 +395,23 @@ func addFileToZip(zipWriter *zip.Writer, filePath, arcname string) error {
 	return nil
 }
 
-func addDirToZip(zipWriter *zip.Writer, dirPath, buildDir string) error {
-	if err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+func addDirToZip(zipWriter *zip.Writer, dirPath, archiveRoot string) error {
+	if err := filepath.Walk(dirPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-
-		if !info.IsDir() {
-			relPath, err := filepath.Rel(dirPath, path)
-			if err != nil {
-				return fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			destPath := filepath.Join(buildDir, filepath.Base(dirPath), relPath)
-			//nolint:gosec // G703: paths from internal walk, not user input
-			if err := os.MkdirAll(filepath.Dir(destPath), 0o750); err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-
-			if err := copyFile(path, destPath); err != nil {
-				return err
-			}
-
-			return addFileToZip(zipWriter, destPath, filepath.Join(filepath.Base(dirPath), relPath))
+		if !info.Mode().IsRegular() {
+			return nil
 		}
-		return nil
+
+		relPath, err := filepath.Rel(dirPath, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+		if !updatepayload.IncludeSource(relPath) {
+			return nil
+		}
+		return addFileToZip(zipWriter, filePath, archivepath.Join(archiveRoot, filepath.ToSlash(relPath)))
 	}); err != nil {
 		return fmt.Errorf("failed to walk directory %s: %w", dirPath, err)
 	}
@@ -442,7 +430,7 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, buildDir string) error {
+func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, _ string) error {
 	//nolint:gosec // Safe: creates tar.gz files in build script with controlled paths
 	tarGzFile, err := os.Create(tarGzPath)
 	if err != nil {
@@ -482,25 +470,22 @@ func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, buil
 		}
 	}
 
-	if items, ok := extraItems[platform]; ok {
-		for _, item := range items {
-			if info, err := os.Stat(item); err == nil {
-				if info.IsDir() {
-					err = addDirToTar(tarWriter, item, buildDir)
-				} else {
-					destPath := filepath.Join(buildDir, filepath.Base(item))
-					if copyErr := copyFile(item, destPath); copyErr != nil {
-						return fmt.Errorf("error copying extra file: %w", copyErr)
-					}
-					err = addFileToTar(tarWriter, destPath, filepath.Base(item))
-				}
-				if err != nil {
-					return fmt.Errorf("error adding extra item to tar: %w", err)
-				}
-			}
+	return addPayloadToTar(tarWriter, updatepayload.Roots(platform))
+}
+
+func addPayloadToTar(tarWriter *tar.Writer, roots []updatepayload.Root) error {
+	for _, root := range roots {
+		info, err := os.Stat(root.SourceDir)
+		if err != nil {
+			return fmt.Errorf("reading payload source %q: %w", root.SourceDir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("payload source %q is not a directory", root.SourceDir)
+		}
+		if err := addDirToTar(tarWriter, root.SourceDir, root.ArchiveRoot); err != nil {
+			return fmt.Errorf("adding payload source %q to tar: %w", root.SourceDir, err)
 		}
 	}
-
 	return nil
 }
 
@@ -537,31 +522,23 @@ func addFileToTar(tarWriter *tar.Writer, filePath, arcname string) error {
 	return nil
 }
 
-func addDirToTar(tarWriter *tar.Writer, dirPath, buildDir string) error {
-	if err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
+func addDirToTar(tarWriter *tar.Writer, dirPath, archiveRoot string) error {
+	if err := filepath.Walk(dirPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-
-		if !info.IsDir() {
-			relPath, err := filepath.Rel(dirPath, path)
-			if err != nil {
-				return fmt.Errorf("failed to get relative path: %w", err)
-			}
-
-			destPath := filepath.Join(buildDir, filepath.Base(dirPath), relPath)
-			//nolint:gosec // G703: paths from internal walk, not user input
-			if err := os.MkdirAll(filepath.Dir(destPath), 0o750); err != nil {
-				return fmt.Errorf("failed to create directory: %w", err)
-			}
-
-			if err := copyFile(path, destPath); err != nil {
-				return err
-			}
-
-			return addFileToTar(tarWriter, destPath, filepath.Join(filepath.Base(dirPath), relPath))
+		if !info.Mode().IsRegular() {
+			return nil
 		}
-		return nil
+
+		relPath, err := filepath.Rel(dirPath, filePath)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+		if !updatepayload.IncludeSource(relPath) {
+			return nil
+		}
+		return addFileToTar(tarWriter, filePath, archivepath.Join(archiveRoot, filepath.ToSlash(relPath)))
 	}); err != nil {
 		return fmt.Errorf("failed to walk directory %s: %w", dirPath, err)
 	}

--- a/scripts/tasks/utils/makezip/main.go
+++ b/scripts/tasks/utils/makezip/main.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+	"github.com/spf13/afero"
 )
 
 const baseURL = "https://github.com/ZaparooProject/zaparoo.org/raw/refs/heads/main/docs/platforms/"
@@ -299,11 +300,12 @@ func main() {
 	}
 
 	// Determine format based on file extension
+	fs := afero.NewOsFs()
 	var err error
 	if strings.HasSuffix(archiveName, ".tar.gz") {
-		err = createTarGzFile(archivePath, appPath, licensePath, readmePath, platform, buildDir)
+		err = createTarGzFile(fs, archivePath, appPath, licensePath, readmePath, platform, buildDir)
 	} else {
-		err = createZipFile(archivePath, appPath, licensePath, readmePath, platform, buildDir)
+		err = createZipFile(fs, archivePath, appPath, licensePath, readmePath, platform, buildDir)
 	}
 
 	if err != nil {
@@ -312,7 +314,7 @@ func main() {
 	}
 }
 
-func createZipFile(zipPath, appPath, licensePath, readmePath, platform, _ string) error {
+func createZipFile(fs afero.Fs, zipPath, appPath, licensePath, readmePath, platform, _ string) error {
 	//nolint:gosec // Safe: creates zip files in build script with controlled paths
 	zipFile, err := os.Create(zipPath)
 	if err != nil {
@@ -339,13 +341,13 @@ func createZipFile(zipPath, appPath, licensePath, readmePath, platform, _ string
 	}
 
 	for _, file := range filesToAdd {
-		err := addFileToZip(zipWriter, file.path, file.arcname)
+		err := addFileToZip(fs, zipWriter, file.path, file.arcname)
 		if err != nil {
 			return fmt.Errorf("error adding file to zip: %w", err)
 		}
 	}
 
-	return addPayloadToZip(zipWriter, payloadFiles(platform))
+	return addPayloadToZip(fs, zipWriter, payloadFiles(platform))
 }
 
 func validatePayloadFiles(files []updatepayload.File) error {
@@ -362,36 +364,50 @@ func validatePayloadFiles(files []updatepayload.File) error {
 	return nil
 }
 
-func addPayloadToZip(zipWriter *zip.Writer, files []updatepayload.File) error {
+func payloadSourceInfo(fs afero.Fs, path string) (os.FileInfo, error) {
+	if lstater, ok := fs.(afero.Lstater); ok {
+		info, _, err := lstater.LstatIfPossible(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading payload source info: %w", err)
+		}
+		return info, nil
+	}
+	info, err := fs.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading payload source info: %w", err)
+	}
+	return info, nil
+}
+
+func addPayloadToZip(fs afero.Fs, zipWriter *zip.Writer, files []updatepayload.File) error {
 	if err := validatePayloadFiles(files); err != nil {
 		return err
 	}
 	for _, file := range files {
-		info, err := os.Lstat(file.SourcePath)
+		info, err := payloadSourceInfo(fs, file.SourcePath)
 		if err != nil {
 			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("payload source %q is not a regular file", file.SourcePath)
 		}
-		if err := addFileToZipMode(zipWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
+		if err := addFileToZipMode(fs, zipWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
 			return fmt.Errorf("adding payload source %q to zip: %w", file.SourcePath, err)
 		}
 	}
 	return nil
 }
 
-func addFileToZip(zipWriter *zip.Writer, filePath, arcname string) error {
-	return addFileToZipMode(zipWriter, filePath, arcname, 0)
+func addFileToZip(fs afero.Fs, zipWriter *zip.Writer, filePath, arcname string) error {
+	return addFileToZipMode(fs, zipWriter, filePath, arcname, 0)
 }
 
-func addFileToZipMode(zipWriter *zip.Writer, filePath, arcname string, mode os.FileMode) error {
-	//nolint:gosec // Safe: opens files in build script with controlled paths
-	file, err := os.Open(filePath)
+func addFileToZipMode(fs afero.Fs, zipWriter *zip.Writer, filePath, arcname string, mode os.FileMode) error {
+	file, err := fs.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", filePath, err)
 	}
-	defer func(file *os.File) {
+	defer func(file afero.File) {
 		_ = file.Close()
 	}(file)
 
@@ -434,7 +450,7 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, _ string) error {
+func createTarGzFile(fs afero.Fs, tarGzPath, appPath, licensePath, readmePath, platform, _ string) error {
 	//nolint:gosec // Safe: creates tar.gz files in build script with controlled paths
 	tarGzFile, err := os.Create(tarGzPath)
 	if err != nil {
@@ -468,45 +484,44 @@ func createTarGzFile(tarGzPath, appPath, licensePath, readmePath, platform, _ st
 	}
 
 	for _, file := range filesToAdd {
-		err := addFileToTar(tarWriter, file.path, file.arcname)
+		err := addFileToTar(fs, tarWriter, file.path, file.arcname)
 		if err != nil {
 			return fmt.Errorf("error adding file to tar: %w", err)
 		}
 	}
 
-	return addPayloadToTar(tarWriter, payloadFiles(platform))
+	return addPayloadToTar(fs, tarWriter, payloadFiles(platform))
 }
 
-func addPayloadToTar(tarWriter *tar.Writer, files []updatepayload.File) error {
+func addPayloadToTar(fs afero.Fs, tarWriter *tar.Writer, files []updatepayload.File) error {
 	if err := validatePayloadFiles(files); err != nil {
 		return err
 	}
 	for _, file := range files {
-		info, err := os.Lstat(file.SourcePath)
+		info, err := payloadSourceInfo(fs, file.SourcePath)
 		if err != nil {
 			return fmt.Errorf("reading payload source %q: %w", file.SourcePath, err)
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("payload source %q is not a regular file", file.SourcePath)
 		}
-		if err := addFileToTarMode(tarWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
+		if err := addFileToTarMode(fs, tarWriter, file.SourcePath, file.ArchivePath, file.Mode); err != nil {
 			return fmt.Errorf("adding payload source %q to tar: %w", file.SourcePath, err)
 		}
 	}
 	return nil
 }
 
-func addFileToTar(tarWriter *tar.Writer, filePath, arcname string) error {
-	return addFileToTarMode(tarWriter, filePath, arcname, 0)
+func addFileToTar(fs afero.Fs, tarWriter *tar.Writer, filePath, arcname string) error {
+	return addFileToTarMode(fs, tarWriter, filePath, arcname, 0)
 }
 
-func addFileToTarMode(tarWriter *tar.Writer, filePath, arcname string, mode os.FileMode) error {
-	//nolint:gosec // Safe: opens files in build script with controlled paths
-	file, err := os.Open(filePath)
+func addFileToTarMode(fs afero.Fs, tarWriter *tar.Writer, filePath, arcname string, mode os.FileMode) error {
+	file, err := fs.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", filePath, err)
 	}
-	defer func(file *os.File) {
+	defer func(file afero.File) {
 		_ = file.Close()
 	}(file)
 

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -38,6 +38,59 @@ import (
 	"github.com/spf13/afero"
 )
 
+func assertBatoceraPayloadFiles(t *testing.T) {
+	t.Helper()
+
+	want := []updatepayload.File{
+		{
+			SourcePath: filepath.Join("cmd", "batocera", "scripts", "configs", "emulationstation", "scripts",
+				"game-selected", "zaparoo_game_select.sh"),
+			ArchivePath: "scripts/configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+			InstallPath: "configs/emulationstation/scripts/game-selected/zaparoo_game_select.sh",
+			Mode:        0o755,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "configs", "multimedia_keys.conf"),
+			ArchivePath: "scripts/configs/multimedia_keys.conf",
+			InstallPath: "configs/multimedia_keys.conf",
+			Mode:        0o644,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "content_downloader.png"),
+			ArchivePath: "scripts/content_downloader.png",
+			InstallPath: "content_downloader.png",
+			Mode:        0o644,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "ports", "Zaparoo.sh"),
+			ArchivePath: "scripts/ports/Zaparoo.sh",
+			InstallPath: "../roms/ports/Zaparoo.sh",
+			Mode:        0o755,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "services", "zaparoo_service"),
+			ArchivePath: "scripts/services/zaparoo_service",
+			InstallPath: "services/zaparoo_service",
+			Mode:        0o755,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_wrapper.sh"),
+			ArchivePath: "scripts/zaparoo_wrapper.sh",
+			InstallPath: "zaparoo_wrapper.sh",
+			Mode:        0o755,
+		},
+		{
+			SourcePath:  filepath.Join("cmd", "batocera", "scripts", "zaparoo_write_game.sh"),
+			ArchivePath: "scripts/zaparoo_write_game.sh",
+			InstallPath: "zaparoo_write_game.sh",
+			Mode:        0o755,
+		},
+	}
+	if got := payloadFiles("batocera"); !slices.Equal(got, want) {
+		t.Fatalf("batocera payload files = %#v, want %#v", got, want)
+	}
+}
+
 func TestStripFrontmatter(t *testing.T) {
 	t.Parallel()
 
@@ -549,6 +602,29 @@ func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
 	var tarBuf bytes.Buffer
 	if err := addPayloadToTar(fs, tar.NewWriter(&tarBuf), files); err == nil {
 		t.Fatal("addPayloadToTar unexpectedly accepted a missing source")
+	}
+}
+
+func TestAddPayloadToArchives_DirectorySourceFails(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	if err := fs.MkdirAll("payload-dir", 0o750); err != nil {
+		t.Fatal(err)
+	}
+	files := []updatepayload.File{{
+		SourcePath: "payload-dir", ArchivePath: "scripts/payload-dir",
+		InstallPath: "payload-dir", Mode: 0o755,
+	}}
+	var zipBuf bytes.Buffer
+	err := addPayloadToZip(fs, zip.NewWriter(&zipBuf), files)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("addPayloadToZip directory source error = %v", err)
+	}
+	var tarBuf bytes.Buffer
+	err = addPayloadToTar(fs, tar.NewWriter(&tarBuf), files)
+	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("addPayloadToTar directory source error = %v", err)
 	}
 }
 

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -547,6 +547,25 @@ func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
 	}
 }
 
+func TestAddPayloadToArchives_DuplicateArchivePathFails(t *testing.T) {
+	t.Parallel()
+
+	files := []updatepayload.File{
+		{ArchivePath: "scripts/helper.sh", InstallPath: "helper.sh", Mode: 0o755},
+		{ArchivePath: "scripts/helper.sh", InstallPath: "other-helper.sh", Mode: 0o755},
+	}
+	var zipBuf bytes.Buffer
+	zipWriter := zip.NewWriter(&zipBuf)
+	if err := addPayloadToZip(zipWriter, files); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("addPayloadToZip duplicate error = %v", err)
+	}
+	var tarBuf bytes.Buffer
+	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil ||
+		!strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("addPayloadToTar duplicate error = %v", err)
+	}
+}
+
 func TestCopyFile(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -20,15 +20,21 @@
 package main
 
 import (
+	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
 )
 
 func TestStripFrontmatter(t *testing.T) {
@@ -418,6 +424,84 @@ func TestCreateTarGzFile(t *testing.T) {
 			t.Error("tar.gz file was not created")
 		}
 	})
+}
+
+func TestAddPayloadToArchives(t *testing.T) {
+	t.Parallel()
+
+	source := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(source, "services"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	//nolint:gosec // Executable archive fixture.
+	if err := os.WriteFile(filepath.Join(source, "services", "zaparoo_service"), []byte("service"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, ".DS_Store"), []byte("metadata"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	roots := []updatepayload.Root{{SourceDir: source, ArchiveRoot: "scripts"}}
+
+	var zipBuf bytes.Buffer
+	zipWriter := zip.NewWriter(&zipBuf)
+	if err := addPayloadToZip(zipWriter, roots); err != nil {
+		t.Fatalf("addPayloadToZip failed: %v", err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	zipReader, err := zip.NewReader(bytes.NewReader(zipBuf.Bytes()), int64(zipBuf.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	zipNames := make([]string, 0, len(zipReader.File))
+	for _, file := range zipReader.File {
+		zipNames = append(zipNames, file.Name)
+	}
+
+	var tarBuf bytes.Buffer
+	tarWriter := tar.NewWriter(&tarBuf)
+	if err := addPayloadToTar(tarWriter, roots); err != nil {
+		t.Fatalf("addPayloadToTar failed: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var tarNames []string
+	tarReader := tar.NewReader(bytes.NewReader(tarBuf.Bytes()))
+	for {
+		header, nextErr := tarReader.Next()
+		if nextErr == io.EOF {
+			break
+		}
+		if nextErr != nil {
+			t.Fatal(nextErr)
+		}
+		tarNames = append(tarNames, header.Name)
+	}
+
+	want := []string{"scripts/services/zaparoo_service"}
+	if !slices.Equal(zipNames, want) {
+		t.Fatalf("zip payload names = %v, want %v", zipNames, want)
+	}
+	if !slices.Equal(tarNames, want) {
+		t.Fatalf("tar payload names = %v, want %v", tarNames, want)
+	}
+}
+
+func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
+	t.Parallel()
+
+	roots := []updatepayload.Root{{SourceDir: filepath.Join(t.TempDir(), "missing"), ArchiveRoot: "scripts"}}
+	var zipBuf bytes.Buffer
+	zipWriter := zip.NewWriter(&zipBuf)
+	if err := addPayloadToZip(zipWriter, roots); err == nil {
+		t.Fatal("addPayloadToZip unexpectedly accepted a missing source")
+	}
+	var tarBuf bytes.Buffer
+	if err := addPayloadToTar(tar.NewWriter(&tarBuf), roots); err == nil {
+		t.Fatal("addPayloadToTar unexpectedly accepted a missing source")
+	}
 }
 
 func TestCopyFile(t *testing.T) {

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -566,6 +566,24 @@ func TestAddPayloadToArchives_DuplicateArchivePathFails(t *testing.T) {
 	}
 }
 
+func TestAddPayloadToArchives_InvalidDefinitionFails(t *testing.T) {
+	t.Parallel()
+
+	files := []updatepayload.File{{
+		ArchivePath: "scripts/helper.sh", InstallPath: "/outside/helper.sh", Mode: 0o755,
+	}}
+	var zipBuf bytes.Buffer
+	if err := addPayloadToZip(zip.NewWriter(&zipBuf), files); err == nil ||
+		!strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("addPayloadToZip invalid definition error = %v", err)
+	}
+	var tarBuf bytes.Buffer
+	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil ||
+		!strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("addPayloadToTar invalid definition error = %v", err)
+	}
+}
+
 func TestCopyFile(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+	"github.com/spf13/afero"
 )
 
 func TestStripFrontmatter(t *testing.T) {
@@ -380,7 +381,7 @@ func TestCreateZipFile(t *testing.T) {
 			t.Fatalf("failed to write readme file: %v", err)
 		}
 
-		err := createZipFile(zipPath, appPath, licensePath, readmePath, "testplatform", tmpDir)
+		err := createZipFile(afero.NewOsFs(), zipPath, appPath, licensePath, readmePath, "testplatform", tmpDir)
 		if err != nil {
 			t.Fatalf("createZipFile failed: %v", err)
 		}
@@ -420,7 +421,9 @@ func TestCreateTarGzFile(t *testing.T) {
 			t.Fatalf("failed to write readme file: %v", err)
 		}
 
-		err := createTarGzFile(tarGzPath, appPath, licensePath, readmePath, "testplatform", tmpDir)
+		err := createTarGzFile(
+			afero.NewOsFs(), tarGzPath, appPath, licensePath, readmePath, "testplatform", tmpDir,
+		)
 		if err != nil {
 			t.Fatalf("createTarGzFile failed: %v", err)
 		}
@@ -435,13 +438,14 @@ func TestCreateTarGzFile(t *testing.T) {
 func TestAddPayloadToArchives(t *testing.T) {
 	t.Parallel()
 
-	source := t.TempDir()
-	payloadPath := filepath.Join(source, "zaparoo_service")
-	payloadContent := []byte("service")
-	if err := os.WriteFile(payloadPath, payloadContent, 0o600); err != nil {
+	fs := afero.NewMemMapFs()
+	source := "payload"
+	if err := fs.MkdirAll(source, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(source, ".DS_Store"), []byte("metadata"), 0o600); err != nil {
+	payloadPath := filepath.Join(source, "zaparoo_service")
+	payloadContent := []byte("service")
+	if err := afero.WriteFile(fs, payloadPath, payloadContent, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	files := []updatepayload.File{{
@@ -451,7 +455,7 @@ func TestAddPayloadToArchives(t *testing.T) {
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	if err := addPayloadToZip(zipWriter, files); err != nil {
+	if err := addPayloadToZip(fs, zipWriter, files); err != nil {
 		t.Fatalf("addPayloadToZip failed: %v", err)
 	}
 	if err := zipWriter.Close(); err != nil {
@@ -486,7 +490,7 @@ func TestAddPayloadToArchives(t *testing.T) {
 
 	var tarBuf bytes.Buffer
 	tarWriter := tar.NewWriter(&tarBuf)
-	if err := addPayloadToTar(tarWriter, files); err != nil {
+	if err := addPayloadToTar(fs, tarWriter, files); err != nil {
 		t.Fatalf("addPayloadToTar failed: %v", err)
 	}
 	if err := tarWriter.Close(); err != nil {
@@ -530,19 +534,20 @@ func TestAddPayloadToArchives(t *testing.T) {
 func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
 	t.Parallel()
 
+	fs := afero.NewMemMapFs()
 	files := []updatepayload.File{{
-		SourcePath:  filepath.Join(t.TempDir(), "missing"),
+		SourcePath:  "missing",
 		ArchivePath: "scripts/missing",
 		InstallPath: "missing",
 		Mode:        0o644,
 	}}
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	if err := addPayloadToZip(zipWriter, files); err == nil {
+	if err := addPayloadToZip(fs, zipWriter, files); err == nil {
 		t.Fatal("addPayloadToZip unexpectedly accepted a missing source")
 	}
 	var tarBuf bytes.Buffer
-	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil {
+	if err := addPayloadToTar(fs, tar.NewWriter(&tarBuf), files); err == nil {
 		t.Fatal("addPayloadToTar unexpectedly accepted a missing source")
 	}
 }
@@ -550,17 +555,18 @@ func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
 func TestAddPayloadToArchives_DuplicateArchivePathFails(t *testing.T) {
 	t.Parallel()
 
+	fs := afero.NewMemMapFs()
 	files := []updatepayload.File{
 		{ArchivePath: "scripts/helper.sh", InstallPath: "helper.sh", Mode: 0o755},
 		{ArchivePath: "scripts/helper.sh", InstallPath: "other-helper.sh", Mode: 0o755},
 	}
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	if err := addPayloadToZip(zipWriter, files); err == nil || !strings.Contains(err.Error(), "duplicate") {
+	if err := addPayloadToZip(fs, zipWriter, files); err == nil || !strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("addPayloadToZip duplicate error = %v", err)
 	}
 	var tarBuf bytes.Buffer
-	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil ||
+	if err := addPayloadToTar(fs, tar.NewWriter(&tarBuf), files); err == nil ||
 		!strings.Contains(err.Error(), "duplicate") {
 		t.Fatalf("addPayloadToTar duplicate error = %v", err)
 	}
@@ -569,16 +575,17 @@ func TestAddPayloadToArchives_DuplicateArchivePathFails(t *testing.T) {
 func TestAddPayloadToArchives_InvalidDefinitionFails(t *testing.T) {
 	t.Parallel()
 
+	fs := afero.NewMemMapFs()
 	files := []updatepayload.File{{
 		ArchivePath: "scripts/helper.sh", InstallPath: "/outside/helper.sh", Mode: 0o755,
 	}}
 	var zipBuf bytes.Buffer
-	if err := addPayloadToZip(zip.NewWriter(&zipBuf), files); err == nil ||
+	if err := addPayloadToZip(fs, zip.NewWriter(&zipBuf), files); err == nil ||
 		!strings.Contains(err.Error(), "invalid") {
 		t.Fatalf("addPayloadToZip invalid definition error = %v", err)
 	}
 	var tarBuf bytes.Buffer
-	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil ||
+	if err := addPayloadToTar(fs, tar.NewWriter(&tarBuf), files); err == nil ||
 		!strings.Contains(err.Error(), "invalid") {
 		t.Fatalf("addPayloadToTar invalid definition error = %v", err)
 	}

--- a/scripts/tasks/utils/makezip/main_test.go
+++ b/scripts/tasks/utils/makezip/main_test.go
@@ -187,6 +187,12 @@ func TestExpandRelativeLinks(t *testing.T) {
 			platformID: "linux",
 			expected:   "[Home](https://zaparoo.org/docs/platforms/)",
 		},
+		{
+			name:       "filename ending in index",
+			content:    "[Platforms](platform-index.md)",
+			platformID: "linux",
+			expected:   "[Platforms](https://zaparoo.org/docs/platforms/platform-index/)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -430,38 +436,57 @@ func TestAddPayloadToArchives(t *testing.T) {
 	t.Parallel()
 
 	source := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(source, "services"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	//nolint:gosec // Executable archive fixture.
-	if err := os.WriteFile(filepath.Join(source, "services", "zaparoo_service"), []byte("service"), 0o755); err != nil {
+	payloadPath := filepath.Join(source, "zaparoo_service")
+	payloadContent := []byte("service")
+	if err := os.WriteFile(payloadPath, payloadContent, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(source, ".DS_Store"), []byte("metadata"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	roots := []updatepayload.Root{{SourceDir: source, ArchiveRoot: "scripts"}}
+	files := []updatepayload.File{{
+		SourcePath: payloadPath, ArchivePath: "scripts/services/zaparoo_service",
+		InstallPath: "services/zaparoo_service", Mode: 0o755,
+	}}
 
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	if err := addPayloadToZip(zipWriter, roots); err != nil {
+	if err := addPayloadToZip(zipWriter, files); err != nil {
 		t.Fatalf("addPayloadToZip failed: %v", err)
 	}
 	if err := zipWriter.Close(); err != nil {
 		t.Fatal(err)
 	}
-	zipReader, err := zip.NewReader(bytes.NewReader(zipBuf.Bytes()), int64(zipBuf.Len()))
-	if err != nil {
-		t.Fatal(err)
+	zipReader, zipErr := zip.NewReader(bytes.NewReader(zipBuf.Bytes()), int64(zipBuf.Len()))
+	if zipErr != nil {
+		t.Fatal(zipErr)
 	}
 	zipNames := make([]string, 0, len(zipReader.File))
 	for _, file := range zipReader.File {
 		zipNames = append(zipNames, file.Name)
+		if file.Name != "scripts/services/zaparoo_service" {
+			continue
+		}
+		if file.Mode().Perm() != 0o755 {
+			t.Fatalf("zip payload mode = %o, want 755", file.Mode().Perm())
+		}
+		reader, openErr := file.Open()
+		if openErr != nil {
+			t.Fatal(openErr)
+		}
+		content, readErr := io.ReadAll(reader)
+		_ = reader.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !bytes.Equal(content, payloadContent) {
+			t.Fatalf("zip payload content = %q, want %q", content, payloadContent)
+		}
 	}
 
 	var tarBuf bytes.Buffer
 	tarWriter := tar.NewWriter(&tarBuf)
-	if err := addPayloadToTar(tarWriter, roots); err != nil {
+	if err := addPayloadToTar(tarWriter, files); err != nil {
 		t.Fatalf("addPayloadToTar failed: %v", err)
 	}
 	if err := tarWriter.Close(); err != nil {
@@ -478,6 +503,19 @@ func TestAddPayloadToArchives(t *testing.T) {
 			t.Fatal(nextErr)
 		}
 		tarNames = append(tarNames, header.Name)
+		if header.Name != "scripts/services/zaparoo_service" {
+			continue
+		}
+		if header.FileInfo().Mode().Perm() != 0o755 {
+			t.Fatalf("tar payload mode = %o, want 755", header.Mode)
+		}
+		content, readErr := io.ReadAll(tarReader)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !bytes.Equal(content, payloadContent) {
+			t.Fatalf("tar payload content = %q, want %q", content, payloadContent)
+		}
 	}
 
 	want := []string{"scripts/services/zaparoo_service"}
@@ -492,14 +530,19 @@ func TestAddPayloadToArchives(t *testing.T) {
 func TestAddPayloadToArchives_MissingSourceFails(t *testing.T) {
 	t.Parallel()
 
-	roots := []updatepayload.Root{{SourceDir: filepath.Join(t.TempDir(), "missing"), ArchiveRoot: "scripts"}}
+	files := []updatepayload.File{{
+		SourcePath:  filepath.Join(t.TempDir(), "missing"),
+		ArchivePath: "scripts/missing",
+		InstallPath: "missing",
+		Mode:        0o644,
+	}}
 	var zipBuf bytes.Buffer
 	zipWriter := zip.NewWriter(&zipBuf)
-	if err := addPayloadToZip(zipWriter, roots); err == nil {
+	if err := addPayloadToZip(zipWriter, files); err == nil {
 		t.Fatal("addPayloadToZip unexpectedly accepted a missing source")
 	}
 	var tarBuf bytes.Buffer
-	if err := addPayloadToTar(tar.NewWriter(&tarBuf), roots); err == nil {
+	if err := addPayloadToTar(tar.NewWriter(&tarBuf), files); err == nil {
 		t.Fatal("addPayloadToTar unexpectedly accepted a missing source")
 	}
 }

--- a/scripts/tasks/utils/makezip/payload_linux.go
+++ b/scripts/tasks/utils/makezip/payload_linux.go
@@ -15,5 +15,5 @@ func payloadFiles(platform string) []updatepayload.File {
 	if platform != "batocera" {
 		return nil
 	}
-	return (&batocera.Platform{}).UpdatePayload()
+	return batocera.UpdatePayload()
 }

--- a/scripts/tasks/utils/makezip/payload_linux.go
+++ b/scripts/tasks/utils/makezip/payload_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import (
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/batocera"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+)
+
+func payloadFiles(platform string) []updatepayload.File {
+	if platform != "batocera" {
+		return nil
+	}
+	return (&batocera.Platform{}).UpdatePayload()
+}

--- a/scripts/tasks/utils/makezip/payload_linux_test.go
+++ b/scripts/tasks/utils/makezip/payload_linux_test.go
@@ -26,9 +26,7 @@ import "testing"
 func TestPayloadFilesLinux(t *testing.T) {
 	t.Parallel()
 
-	if got := len(payloadFiles("batocera")); got != 7 {
-		t.Fatalf("batocera payload file count = %d, want 7", got)
-	}
+	assertBatoceraPayloadFiles(t)
 	if got := payloadFiles("linux"); got != nil {
 		t.Fatalf("linux payload files = %v, want nil", got)
 	}

--- a/scripts/tasks/utils/makezip/payload_linux_test.go
+++ b/scripts/tasks/utils/makezip/payload_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "testing"
+
+func TestPayloadFilesLinux(t *testing.T) {
+	t.Parallel()
+
+	if got := len(payloadFiles("batocera")); got != 7 {
+		t.Fatalf("batocera payload file count = %d, want 7", got)
+	}
+	if got := payloadFiles("linux"); got != nil {
+		t.Fatalf("linux payload files = %v, want nil", got)
+	}
+}

--- a/scripts/tasks/utils/makezip/payload_other.go
+++ b/scripts/tasks/utils/makezip/payload_other.go
@@ -6,8 +6,14 @@
 
 package main
 
-import "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+import (
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/batocera"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+)
 
-func payloadFiles(string) []updatepayload.File {
-	return nil
+func payloadFiles(platform string) []updatepayload.File {
+	if platform != "batocera" {
+		return nil
+	}
+	return batocera.UpdatePayload()
 }

--- a/scripts/tasks/utils/makezip/payload_other.go
+++ b/scripts/tasks/utils/makezip/payload_other.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package main
+
+import "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/updatepayload"
+
+func payloadFiles(string) []updatepayload.File {
+	return nil
+}

--- a/scripts/tasks/utils/makezip/payload_other_test.go
+++ b/scripts/tasks/utils/makezip/payload_other_test.go
@@ -26,9 +26,7 @@ import "testing"
 func TestPayloadFilesOther(t *testing.T) {
 	t.Parallel()
 
-	if got := len(payloadFiles("batocera")); got != 7 {
-		t.Fatalf("batocera payload file count = %d, want 7", got)
-	}
+	assertBatoceraPayloadFiles(t)
 	if got := payloadFiles("windows"); got != nil {
 		t.Fatalf("windows payload files = %v, want nil", got)
 	}

--- a/scripts/tasks/utils/makezip/payload_other_test.go
+++ b/scripts/tasks/utils/makezip/payload_other_test.go
@@ -1,0 +1,35 @@
+//go:build !linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "testing"
+
+func TestPayloadFilesOther(t *testing.T) {
+	t.Parallel()
+
+	if got := len(payloadFiles("batocera")); got != 7 {
+		t.Fatalf("batocera payload file count = %d, want 7", got)
+	}
+	if got := payloadFiles("windows"); got != nil {
+		t.Fatalf("windows payload files = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

- package and transactionally install Batocera script payloads alongside OTA binaries, including rollback and recovery handling
- replace one-shot update checks with periodic check/install scheduling, deterministic jitter, backoff, and guarded automatic installs
- persist scheduler diagnostics and deduplicate update notifications

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Batocera script payloads to OTA packages and installs, and replaces the one-shot update check with an automatic scheduler. Previously we updated only the binary and checked once per idle window; now we validate, stage, install, and roll back platform payloads with the binary, and pace checks/installs with jitter, backoff, and deduplicated notifications. Also clears stray abort markers to avoid false rollbacks.

- Payloads: define metadata/validation in `pkg/platforms/updatepayload`; Batocera implements `platforms.UpdatePayloadProvider` and `UpdatePayload()`; the API includes these in `updater.Options`.
- Extraction/install: extract binary + payload in one pass; cap staged payload bytes and include in preflight; isolate payload file ops for safer rollback; restore payloads before the binary on abort/rollback; resume interrupted payload restores at startup; reject unsafe archive paths.
- Scheduler: `pkg/service/updater_scheduler.go` persists `lastCheckAt`, `checkFailures`, and `lastOfferedVersion`, applies deterministic jitter and exponential backoff, and deduplicates “update available” by offered version; shared `intervalState` replaces bespoke pacing in the backup scheduler; service startup wires the new updater scheduler and removes the previous idle “updater-check” job.
- Packaging: `scripts/tasks/utils/makezip` embeds Batocera payload files in zip/tar.gz and is invoked as `go run ./scripts/tasks/utils/makezip`; CI sparse-checkout includes `pkg/platforms/updatepayload/` and Batocera payload.
- Tests: add coverage for payload update/rollback/resume, scheduled check state and dedupe, extraction limits, and fuzz `FuzzPayloadMemberPath`.

<sup>Written for commit f6beb575939fbecfd11b61baa5cee77485976d3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-core/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for delivering platform-specific files alongside application updates on eligible unmanaged Batocera installations.
  * Added automatic update checks and installs with idle-state, power, backup, and rollout safeguards.
  * Update notifications are now deduplicated by offered version.
  * Packaged payload files preserve configured install locations and permissions.
* **Bug Fixes**
  * Improved update rollback to restore replaced files and remove newly added files when installation fails.
  * Unsafe, duplicate, or malformed archive paths are rejected.
  * Failed custom termination now falls back immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->