### PR TITLE
fix(mister): skip Arcade Organizer during indexing

### DIFF
--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -632,14 +632,27 @@ func GetFiles(
 		if d.Type()&os.ModeSymlink != 0 {
 			symlinksEncountered.Add(1)
 		}
-		if (d.IsDir() || d.Type()&os.ModeSymlink != 0) &&
-			matcher.ShouldSkipScanDirectory(system.ID, p) {
-			directoriesExcluded.Add(1)
-			log.Info().
-				Str("system", systemID).
-				Str("path", p).
-				Msg("skipping launcher-excluded scan directory")
-			return filepath.SkipDir
+		isSymlink := d.Type()&os.ModeSymlink != 0
+		if (d.IsDir() || isSymlink) && matcher.ShouldSkipScanDirectory(system.ID, p) {
+			isDirectory := d.IsDir()
+			if isSymlink {
+				targetInfo, statErr := statWithContext(ctx, p)
+				if statErr != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return ctxErr
+					}
+				} else {
+					isDirectory = targetInfo.IsDir()
+				}
+			}
+			if isDirectory {
+				directoriesExcluded.Add(1)
+				log.Info().
+					Str("system", systemID).
+					Str("path", p).
+					Msg("skipping launcher-excluded scan directory")
+				return filepath.SkipDir
+			}
 		}
 
 		if n%5000 == 0 {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -568,6 +568,28 @@ func filterRunnableSystems(
 	return filtered
 }
 
+// shouldSkipExcludedSymlink reports whether an excluded symlink must be kept
+// out of the walk. A timeout means its target type is unknown, but allowing
+// fastwalk to follow it would immediately repeat the blocking stat without a
+// timeout. Context cancellation takes precedence so callers can stop the walk.
+func shouldSkipExcludedSymlink(
+	ctx context.Context,
+	path string,
+	stat func(context.Context, string) (os.FileInfo, error),
+) (bool, error) {
+	targetInfo, err := stat(ctx, path)
+	if err == nil {
+		return targetInfo.IsDir(), nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, ctxErr
+	}
+	if errors.Is(err, ErrFsTimeout) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // GetFiles searches for all valid games in a given path and returns a list of
 // files. Uses fastwalk for parallel directory traversal with built-in symlink
 // cycle detection. Deep searches .zip files when ZipsAsDirs is enabled.
@@ -634,18 +656,15 @@ func GetFiles(
 		}
 		isSymlink := d.Type()&os.ModeSymlink != 0
 		if (d.IsDir() || isSymlink) && matcher.ShouldSkipScanDirectory(system.ID, p) {
-			isDirectory := d.IsDir()
+			shouldSkip := d.IsDir()
 			if isSymlink {
-				targetInfo, statErr := statWithContext(ctx, p)
-				if statErr != nil {
-					if ctxErr := ctx.Err(); ctxErr != nil {
-						return ctxErr
-					}
-				} else {
-					isDirectory = targetInfo.IsDir()
+				var skipErr error
+				shouldSkip, skipErr = shouldSkipExcludedSymlink(ctx, p, statWithContext)
+				if skipErr != nil {
+					return skipErr
 				}
 			}
-			if isDirectory {
+			if shouldSkip {
 				directoriesExcluded.Add(1)
 				log.Info().
 					Str("system", systemID).

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -585,6 +585,8 @@ func GetFiles(
 	}
 
 	var entriesScanned atomic.Int64
+	var symlinksEncountered atomic.Int64
+	var directoriesExcluded atomic.Int64
 	walkStartTime := time.Now()
 
 	var mu syncutil.Mutex
@@ -627,6 +629,19 @@ func GetFiles(
 		}
 
 		n := entriesScanned.Add(1)
+		if d.Type()&os.ModeSymlink != 0 {
+			symlinksEncountered.Add(1)
+		}
+		if (d.IsDir() || d.Type()&os.ModeSymlink != 0) &&
+			matcher.ShouldSkipScanDirectory(system.ID, p) {
+			directoriesExcluded.Add(1)
+			log.Info().
+				Str("system", systemID).
+				Str("path", p).
+				Msg("skipping launcher-excluded scan directory")
+			return filepath.SkipDir
+		}
+
 		if n%5000 == 0 {
 			log.Debug().
 				Str("system", systemID).
@@ -704,6 +719,8 @@ func GetFiles(
 		Str("system", systemID).
 		Str("path", path).
 		Int64("entriesScanned", scanned).
+		Int64("symlinksEncountered", symlinksEncountered.Load()).
+		Int64("directoriesExcluded", directoriesExcluded.Load()).
 		Int("filesFound", len(results)).
 		Dur("elapsed", walkElapsed).
 		Msg("completed directory walk")

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2150,20 +2150,26 @@ func TestGetFiles_SkipsLauncherExcludedDirectory(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	rootDir := t.TempDir()
 	arcadeDir := filepath.Join(rootDir, "_Arcade")
-	organizedDir := filepath.Join(arcadeDir, "_Organized", "_1 A-E")
-	require.NoError(t, os.MkdirAll(organizedDir, 0o750))
+	organizedTarget := filepath.Join(rootDir, "organized-target")
+	organizedTargetDir := filepath.Join(organizedTarget, "_1 A-E")
+	require.NoError(t, os.MkdirAll(arcadeDir, 0o750))
+	require.NoError(t, os.MkdirAll(organizedTargetDir, 0o750))
+	organizedLink := filepath.Join(arcadeDir, "_Organized")
+	require.NoError(t, os.Symlink(organizedTarget, organizedLink))
 
 	canonicalPath := filepath.Join(arcadeDir, "Pooyan.mra")
 	require.NoError(t, os.WriteFile(canonicalPath, []byte("<misterromdescription/>"), 0o600))
-	aliasPath := filepath.Join(organizedDir, "Pooyan.mra")
-	require.NoError(t, os.Symlink(canonicalPath, aliasPath))
+	aliasPath := filepath.Join(organizedLink, "_1 A-E", "Pooyan.mra")
+	require.NoError(t, os.Symlink(canonicalPath, filepath.Join(organizedTargetDir, "Pooyan.mra")))
+	fileAliasPath := filepath.Join(arcadeDir, "ExcludedFile.mra")
+	require.NoError(t, os.Symlink(canonicalPath, fileAliasPath))
 
 	launcher := platforms.Launcher{
 		ID:                    "arcade-launcher",
 		SystemID:              systemdefs.SystemArcade,
 		Folders:               []string{"_Arcade"},
 		Extensions:            []string{".mra"},
-		ScanDirectoryExcludes: []string{"_Organized"},
+		ScanDirectoryExcludes: []string{"_Organized", "ExcludedFile.mra"},
 	}
 
 	fs := testhelpers.NewMemoryFS()
@@ -2188,7 +2194,7 @@ func TestGetFiles_SkipsLauncherExcludedDirectory(t *testing.T) {
 
 	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemArcade, arcadeDir, nil)
 	require.NoError(t, err)
-	assert.Equal(t, []string{canonicalPath}, files)
+	assert.ElementsMatch(t, []string{canonicalPath, fileAliasPath}, files)
 
 	matcher := helpers.NewLauncherMatcher(cfg, platform)
 	assert.True(t, matcher.MatchSystemFile(systemdefs.SystemArcade, aliasPath),

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2146,6 +2146,32 @@ func TestGetFiles_ZipsAsDirs(t *testing.T) {
 	assert.False(t, foundFiles["readme.txt"])
 }
 
+func TestShouldSkipExcludedSymlink_FsTimeout(t *testing.T) {
+	t.Parallel()
+
+	stat := func(context.Context, string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("stale mount: %w", ErrFsTimeout)
+	}
+
+	shouldSkip, err := shouldSkipExcludedSymlink(context.Background(), "excluded-link", stat)
+	require.NoError(t, err)
+	assert.True(t, shouldSkip)
+}
+
+func TestShouldSkipExcludedSymlink_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stat := func(context.Context, string) (os.FileInfo, error) {
+		return nil, fmt.Errorf("stale mount: %w", ErrFsTimeout)
+	}
+
+	shouldSkip, err := shouldSkipExcludedSymlink(ctx, "excluded-link", stat)
+	assert.False(t, shouldSkip)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestGetFiles_SkipsLauncherExcludedDirectory(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	rootDir := t.TempDir()

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2146,6 +2146,55 @@ func TestGetFiles_ZipsAsDirs(t *testing.T) {
 	assert.False(t, foundFiles["readme.txt"])
 }
 
+func TestGetFiles_SkipsLauncherExcludedDirectory(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	arcadeDir := filepath.Join(rootDir, "_Arcade")
+	organizedDir := filepath.Join(arcadeDir, "_Organized", "_1 A-E")
+	require.NoError(t, os.MkdirAll(organizedDir, 0o750))
+
+	canonicalPath := filepath.Join(arcadeDir, "Pooyan.mra")
+	require.NoError(t, os.WriteFile(canonicalPath, []byte("<misterromdescription/>"), 0o600))
+	aliasPath := filepath.Join(organizedDir, "Pooyan.mra")
+	require.NoError(t, os.Symlink(canonicalPath, aliasPath))
+
+	launcher := platforms.Launcher{
+		ID:                    "arcade-launcher",
+		SystemID:              systemdefs.SystemArcade,
+		Folders:               []string{"_Arcade"},
+		Extensions:            []string{".mra"},
+		ScanDirectoryExcludes: []string{"_Organized"},
+	}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	defer func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemArcade, arcadeDir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{canonicalPath}, files)
+
+	matcher := helpers.NewLauncherMatcher(cfg, platform)
+	assert.True(t, matcher.MatchSystemFile(systemdefs.SystemArcade, aliasPath),
+		"excluded directory media must remain directly launchable")
+}
+
 func TestGetFiles_RespectsLauncherScanExcludes(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	rootDir := t.TempDir()

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -232,11 +232,12 @@ func pathHasPrefixNormalized(normPath, normRoot string) bool {
 // launcherPrecomp holds per-launcher precomputed values to eliminate repeated
 // string allocations inside the hot pathIsLauncher loop.
 type launcherPrecomp struct {
-	normMediaPath string   // normDataDir + "/media/" + lower(SystemID), empty when SystemID is ""
-	rootPairs     []string // normRoot + "/" + normFolder for every root × relative-folder combination
-	absFolders    []string // normalized absolute folder paths (already normalized from folderCache)
-	extensions    []string // pre-lowercased extensions
-	scanExcludes  []string // pre-normalized scan-only exclude patterns
+	normMediaPath         string   // normDataDir + "/media/" + lower(SystemID), empty when SystemID is ""
+	rootPairs             []string // normRoot + "/" + normFolder for every root × relative-folder combination
+	absFolders            []string // normalized absolute folder paths (already normalized from folderCache)
+	extensions            []string // pre-lowercased extensions
+	scanExcludes          []string // pre-normalized scan-only file exclude patterns
+	scanDirectoryExcludes []string // pre-normalized scan-only directory exclude patterns
 }
 
 // LauncherMatcher provides optimized path matching with pre-normalized paths.
@@ -326,6 +327,12 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 		for _, exclude := range l.ScanExcludes {
 			lp.scanExcludes = append(lp.scanExcludes, NormalizePathForComparison(exclude))
 		}
+		for _, exclude := range l.ScanDirectoryExcludes {
+			lp.scanDirectoryExcludes = append(
+				lp.scanDirectoryExcludes,
+				NormalizePathForComparison(exclude),
+			)
+		}
 
 		precomp[l.ID] = lp
 	}
@@ -396,6 +403,56 @@ func (m *LauncherMatcher) MatchSystemFileForScan(systemID, path string) bool {
 		Int("launchersChecked", len(launchers)).
 		Msg("no launcher matched file")
 
+	return false
+}
+
+// ShouldSkipScanDirectory reports whether every launcher scanning path for the
+// given system excludes that directory. Requiring agreement preserves files
+// needed by another launcher that shares the same scan root.
+func (m *LauncherMatcher) ShouldSkipScanDirectory(systemID, path string) bool {
+	normPath := NormalizePathForComparison(path)
+	launchers := GlobalLauncherCache.GetLaunchersBySystem(systemID)
+	matched := false
+
+	for i := range launchers {
+		launcher := &launchers[i]
+		lc := m.precomp[launcher.ID]
+		if lc == nil {
+			continue
+		}
+
+		for _, roots := range [][]string{lc.rootPairs, lc.absFolders} {
+			for _, root := range roots {
+				if !pathHasPrefixNormalized(normPath, root) {
+					continue
+				}
+				relPath := strings.TrimPrefix(normPath, root)
+				relPath = strings.TrimPrefix(relPath, "/")
+				if relPath == "" {
+					return false
+				}
+
+				matched = true
+				if !scanDirectoryExcludeMatches(relPath, lc.scanDirectoryExcludes) {
+					return false
+				}
+			}
+		}
+	}
+
+	return matched
+}
+
+func scanDirectoryExcludeMatches(relPath string, patterns []string) bool {
+	base := stdpath.Base(relPath)
+	for _, pattern := range patterns {
+		if pattern == "" || pattern == "." {
+			continue
+		}
+		if scanExcludePatternMatches(relPath, base, pattern) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -416,6 +416,9 @@ func (m *LauncherMatcher) ShouldSkipScanDirectory(systemID, path string) bool {
 
 	for i := range launchers {
 		launcher := &launchers[i]
+		if launcher.SkipFilesystemScan {
+			continue
+		}
 		lc := m.precomp[launcher.ID]
 		if lc == nil {
 			continue

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -290,6 +290,58 @@ func TestLauncherMatcher_MatchSystemFileForScanExcludes(t *testing.T) {
 	assert.True(t, matcher.MatchSystemFileForScan("NES", nonMatchingWildcardPath))
 }
 
+func TestLauncherMatcher_ShouldSkipScanDirectory(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{
+			ID:                    "Arcade",
+			SystemID:              "Arcade",
+			Folders:               []string{"_Arcade"},
+			Extensions:            []string{".mra"},
+			ScanDirectoryExcludes: []string{"_Organized"},
+		},
+		{
+			ID:                    "SharedFiltered",
+			SystemID:              "Shared",
+			Folders:               []string{"shared"},
+			ScanDirectoryExcludes: []string{"generated"},
+		},
+		{
+			ID:       "SharedUnfiltered",
+			SystemID: "Shared",
+			Folders:  []string{filepath.Join("shared", "generated")},
+		},
+	})
+
+	cfg := &config.Instance{}
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+	organized := filepath.Join(rootDir, "_Arcade", "_oRgAnIzEd")
+	assert.True(t, matcher.ShouldSkipScanDirectory("Arcade", organized))
+	assert.False(t, matcher.ShouldSkipScanDirectory("Arcade", filepath.Join(rootDir, "_Arcade")))
+	assert.False(t, matcher.ShouldSkipScanDirectory("Arcade", filepath.Join(rootDir, "_Arcade", "alternatives")))
+	assert.False(t, matcher.ShouldSkipScanDirectory("Arcade", filepath.Join(rootDir, "other", "_Organized")))
+	assert.False(t, matcher.ShouldSkipScanDirectory("Shared", filepath.Join(rootDir, "shared", "generated")),
+		"one launcher must not hide a directory needed by another launcher")
+
+	aliasPath := filepath.Join(organized, "Pooyan.mra")
+	assert.True(t, matcher.MatchSystemFile("Arcade", aliasPath),
+		"scan directory exclusions must not affect direct launches")
+}
+
 func TestLauncherMatcher_RootSlashAndDotFolder(t *testing.T) {
 	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
 	mockPlatform := mocks.NewMockPlatform()

--- a/pkg/helpers/paths_matcher_test.go
+++ b/pkg/helpers/paths_matcher_test.go
@@ -315,6 +315,18 @@ func TestLauncherMatcher_ShouldSkipScanDirectory(t *testing.T) {
 			SystemID: "Shared",
 			Folders:  []string{filepath.Join("shared", "generated")},
 		},
+		{
+			ID:                    "SharedSkippedFiltered",
+			SystemID:              "SharedSkipped",
+			Folders:               []string{"shared-skipped"},
+			ScanDirectoryExcludes: []string{"generated"},
+		},
+		{
+			ID:                 "SharedSkippedNonFilesystem",
+			SystemID:           "SharedSkipped",
+			Folders:            []string{"shared-skipped"},
+			SkipFilesystemScan: true,
+		},
 	})
 
 	cfg := &config.Instance{}
@@ -336,6 +348,9 @@ func TestLauncherMatcher_ShouldSkipScanDirectory(t *testing.T) {
 	assert.False(t, matcher.ShouldSkipScanDirectory("Arcade", filepath.Join(rootDir, "other", "_Organized")))
 	assert.False(t, matcher.ShouldSkipScanDirectory("Shared", filepath.Join(rootDir, "shared", "generated")),
 		"one launcher must not hide a directory needed by another launcher")
+	sharedSkipped := filepath.Join(rootDir, "shared-skipped", "generated")
+	assert.True(t, matcher.ShouldSkipScanDirectory("SharedSkipped", sharedSkipped),
+		"a non-filesystem launcher must not prevent a filesystem launcher from excluding a directory")
 
 	aliasPath := filepath.Join(organized, "Pooyan.mra")
 	assert.True(t, matcher.MatchSystemFile("Arcade", aliasPath),

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -266,6 +266,7 @@ func (c *arcadeSystemCache) scanFiles(
 	cfg *config.Instance,
 ) ([]platforms.ScanResult, error) {
 	var results []platforms.ScanResult
+	matcher := helpers.NewLauncherMatcher(cfg, c.platform)
 	for _, root := range c.platform.RootDirs(cfg) {
 		select {
 		case <-ctx.Done():
@@ -291,6 +292,10 @@ func (c *arcadeSystemCache) scanFiles(
 					return walkEntryErr
 				}
 				if info.IsDir() {
+					if matcher.ShouldSkipScanDirectory(systemdefs.SystemArcade, path) {
+						log.Info().Str("path", path).Msg("skipping launcher-excluded MiSTer arcade directory")
+						return filepath.SkipDir
+					}
 					return nil
 				}
 				ext := filepath.Ext(path)

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
@@ -302,25 +303,39 @@ func TestArcadeSystemCacheRecaptureInvalidatesClassification(t *testing.T) {
 }
 
 func TestArcadeSystemCacheScanFilesFiltersSupportedExtensions(t *testing.T) {
-	t.Parallel()
-
 	root := t.TempDir()
-	arcadeDir := filepath.Join(root, "_Arcade", "subdirectory")
+	arcadeRoot := filepath.Join(root, "_Arcade")
+	arcadeDir := filepath.Join(arcadeRoot, "subdirectory")
+	organizedDir := filepath.Join(arcadeRoot, "_Organized", "_1 A-E")
 	require.NoError(t, os.MkdirAll(arcadeDir, 0o750))
+	require.NoError(t, os.MkdirAll(organizedDir, 0o750))
 	mraPath := filepath.Join(arcadeDir, "game.mra")
 	mglPath := filepath.Join(arcadeDir, "shortcut.MGL")
 	txtPath := filepath.Join(arcadeDir, "notes.txt")
-	for _, path := range []string{mraPath, mglPath, txtPath} {
+	canonicalPath := filepath.Join(arcadeRoot, "Pooyan.mra")
+	for _, path := range []string{mraPath, mglPath, txtPath, canonicalPath} {
 		require.NoError(t, os.WriteFile(path, []byte("test"), 0o600))
 	}
+	aliasPath := filepath.Join(organizedDir, "Pooyan.mra")
+	require.NoError(t, os.Symlink(canonicalPath, aliasPath))
 
 	cfg := &config.Instance{}
 	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[launchers]\nindex_root = [%q]\n", root)))
-	cache := newArcadeSystemCache(NewPlatform())
+	platform := NewPlatform()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.InitializeFromSlice(platform.Launchers(cfg))
+	helpers.GlobalLauncherCache = testCache
+	t.Cleanup(func() { helpers.GlobalLauncherCache = originalCache })
+	cache := newArcadeSystemCache(platform)
 
 	results, err := cache.scanFiles(context.Background(), cfg)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []platforms.ScanResult{{Path: mraPath}, {Path: mglPath}}, results)
+	assert.ElementsMatch(t, []platforms.ScanResult{
+		{Path: mraPath},
+		{Path: mglPath},
+		{Path: canonicalPath},
+	}, results)
 }
 
 func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -2285,11 +2285,12 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		},
 		// Other
 		{
-			ID:         systemdefs.SystemArcade,
-			SystemID:   systemdefs.SystemArcade,
-			Folders:    []string{"_Arcade"},
-			Extensions: []string{".mra", ".mgl"},
-			Launch:     launchArcade(pl, systemdefs.SystemArcade),
+			ID:                    systemdefs.SystemArcade,
+			SystemID:              systemdefs.SystemArcade,
+			Folders:               []string{"_Arcade"},
+			Extensions:            []string{".mra", ".mgl"},
+			ScanDirectoryExcludes: []string{"_Organized"},
+			Launch:                launchArcade(pl, systemdefs.SystemArcade),
 		},
 		{
 			ID:         systemdefs.SystemArduboy,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -580,6 +580,7 @@ func TestArcadeLauncherExtensions(t *testing.T) {
 
 	require.NotNil(t, arcadeLauncher, "Arcade launcher should exist")
 	assert.Equal(t, []string{"_Arcade"}, arcadeLauncher.Folders)
+	assert.Equal(t, []string{"_Organized"}, arcadeLauncher.ScanDirectoryExcludes)
 	assert.Contains(t, arcadeLauncher.Extensions, ".mra")
 	assert.Contains(t, arcadeLauncher.Extensions, ".mgl")
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -336,6 +336,11 @@ type Launcher struct {
 	// the base filename; patterns with a slash can match any path suffix. They
 	// only affect media scanning; direct path launches can still match the launcher.
 	ScanExcludes []string
+	// ScanDirectoryExcludes are case-insensitive slash-normalized glob patterns
+	// relative to this launcher's Folders. Matching directories are not traversed.
+	// Patterns without a slash match a directory basename; patterns with a slash
+	// can match any relative path suffix. Direct path launches remain unaffected.
+	ScanDirectoryExcludes []string
 	// Folders to scan for files, relative to the root folders of the platform.
 	Folders []string
 	// Accepted schemes for URI-style launches.


### PR DESCRIPTION
## Summary

- add launcher-owned directory scan exclusions while preserving shared-root safety and direct launches
- skip MiSTer `_Arcade/_Organized` before traversing its symlink aliases
- reuse the exclusion policy for granular Arcade fallback scanning and expose walk diagnostics

## Validation

- `task test`
- `task lint`

Closes #1290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips MiSTer `_Arcade/_Organized` during indexing and hardens scan-time directory exclusion to prevent duplicate Arcade entries and walk stalls, without affecting direct launches. Previously we traversed `_Organized` symlink aliases and could re-stat timed-out symlinks; now we exclude that directory and treat timed-out excluded symlinks as directories to skip with shared-root safety.

- Adds `ScanDirectoryExcludes` to `platforms.Launcher` (case-insensitive, slash-normalized globs relative to `Folders`; patterns without a slash match a directory basename).
- Precomputes directory excludes and adds `ShouldSkipScanDirectory(systemID, path)` in `helpers.LauncherMatcher`; a directory is skipped only if every filesystem-scanning launcher for that system excludes it.
- Updates `pkg/database/mediascanner` GetFiles: treats excluded symlinked directories as directories when the target stat times out, honors context cancellation, logs skips, increments `symlinksEncountered` and `directoriesExcluded`, and uses `filepath.SkipDir`.
- Applies directory skipping in MiSTer Arcade traversal and updates the Arcade launcher to exclude `_Organized`; direct-path launches (including aliases) remain valid and launchers sharing the same scan root are preserved.

<sup>Written for commit c3a5be0ceef31d6cd16086a1d809df1dba5e6136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-core/pull/1294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media scanning to skip directories and symlinks excluded by launcher scan rules.
  * Prevented duplicate or organized media from being indexed while preserving direct launching.
  * Added case-insensitive directory exclusion support with correct handling of nested paths and overlapping launchers.
  * Arcade scanning now excludes the `_Organized` directory while continuing to detect supported files elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->