### PR TITLE
fix(zapscript): honor insert-coin amount argument

### DIFF
--- a/pkg/zapscript/input.go
+++ b/pkg/zapscript/input.go
@@ -303,6 +303,8 @@ func insertCoin(
 	env platforms.CmdEnv,
 	key string,
 ) (platforms.CmdResult, error) {
+	const maxAmount = 99
+
 	var amount int
 
 	if len(env.Cmd.Args) == 0 || env.Cmd.Args[0] == "" {
@@ -312,6 +314,13 @@ func insertCoin(
 		amount, err = strconv.Atoi(env.Cmd.Args[0])
 		if err != nil {
 			return platforms.CmdResult{}, fmt.Errorf("invalid amount '%s': %w", env.Cmd.Args[0], err)
+		}
+		if amount < 0 || amount > maxAmount {
+			return platforms.CmdResult{}, fmt.Errorf(
+				"invalid amount '%s': must be between 0 and %d",
+				env.Cmd.Args[0],
+				maxAmount,
+			)
 		}
 	}
 

--- a/pkg/zapscript/input.go
+++ b/pkg/zapscript/input.go
@@ -305,7 +305,7 @@ func insertCoin(
 ) (platforms.CmdResult, error) {
 	var amount int
 
-	if len(env.Cmd.Args) == 0 || env.Cmd.Args[0] != "" {
+	if len(env.Cmd.Args) == 0 || env.Cmd.Args[0] == "" {
 		amount = 1
 	} else {
 		var err error

--- a/pkg/zapscript/input_test.go
+++ b/pkg/zapscript/input_test.go
@@ -369,9 +369,23 @@ func TestInsertCoinAmount(t *testing.T) {
 			wantKeys: []string{"5"},
 		},
 		{
+			name: "zero amount inserts no coins",
+			args: []string{"0"},
+		},
+		{
 			name:     "supplied amount is honored",
 			args:     []string{"2"},
 			wantKeys: []string{"5", "5"},
+		},
+		{
+			name:      "negative amount returns error",
+			args:      []string{"-1"},
+			wantError: "invalid amount '-1'",
+		},
+		{
+			name:      "amount above maximum returns error",
+			args:      []string{"100"},
+			wantError: "invalid amount '100'",
 		},
 		{
 			name:      "invalid amount returns error",

--- a/pkg/zapscript/input_test.go
+++ b/pkg/zapscript/input_test.go
@@ -350,6 +350,64 @@ func TestCmdCoinMultiplayerKeys(t *testing.T) {
 	}
 }
 
+func TestInsertCoinAmount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		wantError string
+		args      []string
+		wantKeys  []string
+	}{
+		{
+			name:     "omitted amount defaults to one",
+			wantKeys: []string{"5"},
+		},
+		{
+			name:     "empty amount defaults to one",
+			args:     []string{""},
+			wantKeys: []string{"5"},
+		},
+		{
+			name:     "supplied amount is honored",
+			args:     []string{"2"},
+			wantKeys: []string{"5", "5"},
+		},
+		{
+			name:      "invalid amount returns error",
+			args:      []string{"invalid"},
+			wantError: "invalid amount 'invalid'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockPlatform := mocks.NewMockPlatform()
+			if len(tt.wantKeys) > 0 {
+				mockPlatform.On("KeyboardPress", "5").Return(nil).Times(len(tt.wantKeys))
+			}
+
+			env := platforms.CmdEnv{
+				Cmd: gozapscript.Command{
+					Name: gozapscript.ZapScriptCmdInputCoinP1,
+					Args: tt.args,
+				},
+			}
+
+			_, err := insertCoin(mockPlatform, env, "5")
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantKeys, mockPlatform.GetKeyboardPresses())
+			mockPlatform.AssertExpectations(t)
+		})
+	}
+}
+
 func TestCmdKeyboard_CombosBlocksSingleChar(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- honor numeric amounts supplied to insert-coin commands
- preserve one-coin default for omitted or empty amounts
- add regression coverage for default, numeric, and invalid amounts

Closes #1292

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the `insert-coin` amount in `pkg/zapscript`: applies numeric amounts, defaults to one when omitted or empty, and enforces a 0–99 bound. Previously, non-empty amounts were ignored and empty amounts attempted to parse; now zero inserts no coins, invalid strings return "invalid amount 'X'", and negative or >99 amounts return an error.

- Review notes:
  - Condition fix and bounds check in `pkg/zapscript/input.go`.
  - Tests in `pkg/zapscript/input_test.go` cover default, zero, explicit, invalid, and out-of-range cases.

<sup>Written for commit 64ca341430fac678d51f9da7cd53b84cbfbba1c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-core/pull/1295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Coin insertion now defaults to one coin when no amount is provided.
  * Explicit coin amounts are limited to 0–99.
  * Invalid numeric input and out-of-range amounts now return validation errors.

* **Tests**
  * Added coverage for omitted, empty, zero, positive, negative, excessive, and nonnumeric amounts.
  * Verified coin insertion behavior, validation errors, and related interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->