### PR TITLE
fix(tui): suppress intentional WebSocket closure warnings

### DIFF
--- a/pkg/api/client/client.go
+++ b/pkg/api/client/client.go
@@ -33,6 +33,8 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -382,12 +384,47 @@ func WaitForAPI(cfg *config.Instance, maxWaitTime, checkInterval time.Duration) 
 	return false
 }
 
+func waitNotificationsReadLogLevel(ctx context.Context, callerClosing bool, err error) zerolog.Level {
+	if callerClosing || ctx.Err() != nil {
+		return zerolog.TraceLevel
+	}
+	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+		return zerolog.DebugLevel
+	}
+	if errors.Is(err, net.ErrClosed) || websocket.IsCloseError(err,
+		websocket.CloseNoStatusReceived,
+		websocket.CloseAbnormalClosure,
+	) {
+		return zerolog.WarnLevel
+	}
+	return zerolog.ErrorLevel
+}
+
+func logWaitNotificationsReadError(ctx context.Context, callerClosing bool, err error) {
+	level := waitNotificationsReadLogLevel(ctx, callerClosing, err)
+	message := "websocket closed"
+	if level == zerolog.ErrorLevel {
+		message = "error reading message"
+	}
+	log.WithLevel(level).Err(err).Msg(message)
+}
+
 // WaitNotifications waits for any of the specified notification types on a single
 // WebSocket connection. Returns the notification method that matched and its params.
 func WaitNotifications(
 	ctx context.Context,
 	timeout time.Duration,
 	cfg *config.Instance,
+	ids ...string,
+) (method, params string, err error) {
+	return waitNotificationsWithClock(ctx, timeout, cfg, clockwork.NewRealClock(), ids...)
+}
+
+func waitNotificationsWithClock(
+	ctx context.Context,
+	timeout time.Duration,
+	cfg *config.Instance,
+	clock clockwork.Clock,
 	ids ...string,
 ) (method, params string, err error) {
 	u := url.URL{
@@ -416,12 +453,18 @@ func WaitNotifications(
 	if err != nil {
 		return "", "", fmt.Errorf("failed to dial websocket: %w", err)
 	}
-	defer func(c *websocket.Conn) {
+	connectionClosed := false
+	closeConnection := func() {
+		if connectionClosed {
+			return
+		}
+		connectionClosed = true
 		closeErr := c.Close()
-		if closeErr != nil {
+		if closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
 			log.Warn().Err(closeErr).Msg("error closing websocket")
 		}
-	}(c)
+	}
+	defer closeConnection()
 
 	idSet := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
@@ -429,6 +472,7 @@ func WaitNotifications(
 	}
 
 	done := make(chan struct{})
+	callerClosing := make(chan struct{})
 	var resp *models.RequestObject
 
 	go func() {
@@ -436,10 +480,11 @@ func WaitNotifications(
 		for {
 			_, message, readErr := c.ReadMessage()
 			if readErr != nil {
-				if isExpectedWebsocketClose(readErr) {
-					log.Warn().Err(readErr).Msg("websocket closed")
-				} else {
-					log.Error().Err(readErr).Msg("error reading message")
+				select {
+				case <-callerClosing:
+					logWaitNotificationsReadError(ctx, true, readErr)
+				default:
+					logWaitNotificationsReadError(ctx, false, readErr)
 				}
 				return
 			}
@@ -468,28 +513,40 @@ func WaitNotifications(
 		}
 	}()
 
+	var timer clockwork.Timer
 	var timerChan <-chan time.Time
 	if timeout == 0 {
 		effectiveTimeout := config.APIRequestTimeout
 		if deadline, ok := ctx.Deadline(); ok {
-			remaining := time.Until(deadline)
+			remaining := clock.Until(deadline)
 			if remaining < effectiveTimeout {
 				effectiveTimeout = remaining
 			}
 		}
-		timer := time.NewTimer(effectiveTimeout)
-		timerChan = timer.C
+		timer = clock.NewTimer(effectiveTimeout)
+		timerChan = timer.Chan()
 	} else if timeout > 0 {
-		timer := time.NewTimer(timeout)
-		timerChan = timer.C
+		timer = clock.NewTimer(timeout)
+		timerChan = timer.Chan()
+	}
+	if timer != nil {
+		defer timer.Stop()
+	}
+
+	shutdownReader := func() {
+		close(callerClosing)
+		closeConnection()
+		<-done
 	}
 
 	select {
 	case <-done:
 
 	case <-timerChan:
+		shutdownReader()
 		return "", "", ErrRequestTimeout
 	case <-ctx.Done():
+		shutdownReader()
 		return "", "", ErrRequestCancelled
 	}
 

--- a/pkg/api/client/client_test.go
+++ b/pkg/api/client/client_test.go
@@ -20,6 +20,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -35,7 +36,10 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/gorilla/websocket"
+	"github.com/jonboulle/clockwork"
 	"github.com/olahol/melody"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -75,6 +79,32 @@ func waitForWebSocketSession(server *helpers.WebSocketTestServer, timeout time.D
 		time.Sleep(time.Millisecond)
 	}
 	return false
+}
+
+type recordingTimer struct {
+	clockwork.Timer
+	stopped bool
+}
+
+func (t *recordingTimer) Stop() bool {
+	t.stopped = true
+	return t.Timer.Stop()
+}
+
+type recordingClock struct {
+	clockwork.Clock
+	timer *recordingTimer
+}
+
+func (c *recordingClock) NewTimer(d time.Duration) clockwork.Timer {
+	c.timer = &recordingTimer{Timer: c.Clock.NewTimer(d)}
+	return c.timer
+}
+
+type waitNotificationsResult struct {
+	err    error
+	method string
+	params string
 }
 
 func TestLocalClient_ValidRequest(t *testing.T) {
@@ -649,6 +679,189 @@ func TestWaitNotifications_Timeout(t *testing.T) {
 	assert.ErrorIs(t, err, ErrRequestTimeout)
 }
 
+func TestWaitNotifications_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	server := helpers.NewWebSocketTestServer(t, nil)
+	defer server.Close()
+
+	port := parseServerPort(t, server.Server)
+	cfg := testConfigWithPort(t, port)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan waitNotificationsResult, 1)
+
+	go func() {
+		method, params, err := WaitNotifications(ctx, -1, cfg, "tokens.added")
+		resultCh <- waitNotificationsResult{method: method, params: params, err: err}
+	}()
+
+	require.True(t, waitForWebSocketSession(server, time.Second))
+	cancel()
+
+	select {
+	case result := <-resultCh:
+		require.ErrorIs(t, result.err, ErrRequestCancelled)
+		assert.Empty(t, result.method)
+		assert.Empty(t, result.params)
+	case <-time.After(time.Second):
+		t.Fatal("WaitNotifications did not complete after cancellation")
+	}
+}
+
+func TestWaitNotifications_IntentionalCloseIsJoinedAndTraceLogged(t *testing.T) {
+	server := helpers.NewWebSocketTestServer(t, nil)
+	defer server.Close()
+
+	port := parseServerPort(t, server.Server)
+	cfg := testConfigWithPort(t, port)
+	var logs bytes.Buffer
+	originalLogger := zlog.Logger
+	zlog.Logger = zerolog.New(&logs).Level(zerolog.TraceLevel)
+	t.Cleanup(func() { zlog.Logger = originalLogger })
+
+	_, _, err := WaitNotifications(context.Background(), 20*time.Millisecond, cfg, "tokens.added")
+	require.ErrorIs(t, err, ErrRequestTimeout)
+
+	lines := bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n"))
+	require.Len(t, lines, 1, "reader must finish logging before WaitNotifications returns")
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(lines[0], &event))
+	assert.Equal(t, "trace", event[zerolog.LevelFieldName])
+	assert.Equal(t, "websocket closed", event[zerolog.MessageFieldName])
+}
+
+func TestWaitNotifications_StopsTimer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		expectedErr error
+		trigger     func(
+			t *testing.T,
+			fakeClock *clockwork.FakeClock,
+			server *helpers.WebSocketTestServer,
+			cancel context.CancelFunc,
+		)
+		name string
+	}{
+		{
+			name: "timeout",
+			trigger: func(
+				_ *testing.T,
+				fakeClock *clockwork.FakeClock,
+				_ *helpers.WebSocketTestServer,
+				_ context.CancelFunc,
+			) {
+				fakeClock.Advance(time.Second)
+			},
+			expectedErr: ErrRequestTimeout,
+		},
+		{
+			name: "cancellation",
+			trigger: func(
+				_ *testing.T,
+				_ *clockwork.FakeClock,
+				_ *helpers.WebSocketTestServer,
+				cancel context.CancelFunc,
+			) {
+				cancel()
+			},
+			expectedErr: ErrRequestCancelled,
+		},
+		{
+			name: "notification success",
+			trigger: func(
+				t *testing.T,
+				_ *clockwork.FakeClock,
+				server *helpers.WebSocketTestServer,
+				_ context.CancelFunc,
+			) {
+				notification := []byte(`{"jsonrpc":"2.0","method":"tokens.added","params":{"token":"123"}}`)
+				require.NoError(t, server.Melody.Broadcast(notification))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := helpers.NewWebSocketTestServer(t, nil)
+			defer server.Close()
+			port := parseServerPort(t, server.Server)
+			cfg := testConfigWithPort(t, port)
+			fakeClock := clockwork.NewFakeClock()
+			clock := &recordingClock{Clock: fakeClock}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			resultCh := make(chan waitNotificationsResult, 1)
+
+			go func() {
+				method, params, err := waitNotificationsWithClock(ctx, time.Second, cfg, clock, "tokens.added")
+				resultCh <- waitNotificationsResult{method: method, params: params, err: err}
+			}()
+
+			waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+			defer waitCancel()
+			require.NoError(t, fakeClock.BlockUntilContext(waitCtx, 1))
+			require.True(t, waitForWebSocketSession(server, time.Second))
+			tt.trigger(t, fakeClock, server, cancel)
+
+			select {
+			case result := <-resultCh:
+				if tt.expectedErr != nil {
+					require.ErrorIs(t, result.err, tt.expectedErr)
+				} else {
+					require.NoError(t, result.err)
+					assert.Equal(t, "tokens.added", result.method)
+					assert.JSONEq(t, `{"token":"123"}`, result.params)
+				}
+				require.NotNil(t, clock.timer)
+				assert.True(t, clock.timer.stopped)
+			case <-time.After(time.Second):
+				t.Fatal("WaitNotifications did not complete")
+			}
+		})
+	}
+}
+
+func TestWaitNotifications_ConcurrentCallerAndPeerClose(t *testing.T) {
+	t.Parallel()
+
+	server := helpers.NewWebSocketTestServer(t, nil)
+	defer server.Close()
+	port := parseServerPort(t, server.Server)
+	cfg := testConfigWithPort(t, port)
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+
+	go func() {
+		_, _, err := WaitNotifications(ctx, -1, cfg, "tokens.added")
+		resultCh <- err
+	}()
+
+	require.True(t, waitForWebSocketSession(server, time.Second))
+	start := make(chan struct{})
+	peerClosed := make(chan struct{})
+	go func() {
+		<-start
+		_ = server.Melody.CloseWithMsg(melody.FormatCloseMessage(websocket.CloseAbnormalClosure, "peer closed"))
+		close(peerClosed)
+	}()
+	close(start)
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		assert.True(t,
+			errors.Is(err, ErrRequestCancelled) || errors.Is(err, ErrRequestTimeout),
+			"unexpected concurrent-close result: %v", err,
+		)
+	case <-time.After(time.Second):
+		t.Fatal("concurrent close deadlocked WaitNotifications")
+	}
+	<-peerClosed
+}
+
 func TestLocalAPIClient_Call(t *testing.T) {
 	t.Parallel()
 
@@ -895,6 +1108,83 @@ func TestWaitForAPI_Timeout(t *testing.T) {
 
 	assert.False(t, result)
 	assert.GreaterOrEqual(t, elapsed, 200*time.Millisecond)
+}
+
+func TestWaitNotificationsReadLogLevel(t *testing.T) {
+	t.Parallel()
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		err           error
+		ctx           context.Context
+		name          string
+		expected      zerolog.Level
+		callerClosing bool
+	}{
+		{
+			name:          "intentional local close",
+			ctx:           context.Background(),
+			callerClosing: true,
+			err:           net.ErrClosed,
+			expected:      zerolog.TraceLevel,
+		},
+		{
+			name:     "ended request context",
+			ctx:      cancelledCtx,
+			err:      &websocket.CloseError{Code: websocket.CloseAbnormalClosure},
+			expected: zerolog.TraceLevel,
+		},
+		{
+			name:     "normal peer close",
+			ctx:      context.Background(),
+			err:      &websocket.CloseError{Code: websocket.CloseNormalClosure},
+			expected: zerolog.DebugLevel,
+		},
+		{
+			name:     "peer going away",
+			ctx:      context.Background(),
+			err:      &websocket.CloseError{Code: websocket.CloseGoingAway},
+			expected: zerolog.DebugLevel,
+		},
+		{
+			name:     "abnormal peer close",
+			ctx:      context.Background(),
+			err:      &websocket.CloseError{Code: websocket.CloseAbnormalClosure},
+			expected: zerolog.WarnLevel,
+		},
+		{
+			name:     "peer close without status",
+			ctx:      context.Background(),
+			err:      &websocket.CloseError{Code: websocket.CloseNoStatusReceived},
+			expected: zerolog.WarnLevel,
+		},
+		{
+			name:     "unmarked network close",
+			ctx:      context.Background(),
+			err:      net.ErrClosed,
+			expected: zerolog.WarnLevel,
+		},
+		{
+			name:     "protocol failure",
+			ctx:      context.Background(),
+			err:      &websocket.CloseError{Code: websocket.CloseProtocolError},
+			expected: zerolog.ErrorLevel,
+		},
+		{
+			name:     "unexpected read failure",
+			ctx:      context.Background(),
+			err:      errors.New("read failed"),
+			expected: zerolog.ErrorLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, waitNotificationsReadLogLevel(tt.ctx, tt.callerClosing, tt.err))
+		})
+	}
 }
 
 // TestIsExpectedWebsocketClose verifies that expected disconnects (including the


### PR DESCRIPTION
## Summary

- distinguish caller-initiated WebSocket shutdown from peer and network closure
- close and join notification readers on timeout or cancellation, and stop timers on every return path
- preserve warning/error visibility for abnormal closures and unexpected read failures
- add deterministic lifecycle, logging, timer, and concurrent-close coverage

Closes #1273

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses warnings from intentional WebSocket closures and makes `WaitNotifications` shutdown deterministic to prevent leaks. Previously, timeouts/cancellations or local closes often logged at warn/error; now expected closures are downgraded while abnormal closures remain visible.

- Logging changes for read failures: caller-initiated or cancelled -> trace; normal/going-away peer close -> debug; abnormal/no-status or `net.ErrClosed` -> warn; everything else -> error. Uses `zerolog` and `github.com/gorilla/websocket` helpers.
- Deterministic lifecycle: on timeout or cancellation, signal reader, close the connection, join the goroutine, and stop timers on every return path to avoid leaks and deadlocks on concurrent caller/peer closes.
- Maintains public API; adds internal `waitNotificationsWithClock` using `github.com/jonboulle/clockwork` for deterministic timer behavior in tests.
- Tests cover cancellation, intentional close logging, timer stop, and concurrent close scenarios.

<sup>Written for commit c0e9218e96f509d47697f6dbc1d733b7a7ced523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-core/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification waiting behavior during cancellation, timeouts, and successful completion.
  * Ensured connections close safely when both the caller and remote endpoint close concurrently.
  * Improved handling and classification of WebSocket read errors.
  * Prevented unnecessary timers from continuing after a wait operation finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->