### PR TITLE
fix: validate OTA prerelease tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           is_nightly: ${{ inputs.is_nightly || 'false' }}
         run: |
           # Detect pre-release builds (nightly, alpha, beta, rc, etc.)
-          # Any tag with a hyphen after the version (e.g. v2.10.0-beta2) is pre-release
+          # Any tag with a hyphen after the version (e.g. v2.10.0-beta.2) is pre-release
           VERSION="${tag#v}"
           if [[ "$is_nightly" == "true" ]] || [[ "$tag" == *"nightly"* ]]; then
             PRERELEASE="--prerelease"

--- a/.github/workflows/ota-validate.yml
+++ b/.github/workflows/ota-validate.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   validate:
-    # Stable releases and non-nightly pre-releases are the ones that can be promoted.
+    # Stable, beta, and release-candidate tags are promotable; nightly and alpha are not.
     if: ${{ !github.event.release.prerelease || !contains(github.event.release.tag_name, 'nightly') }}
     name: Check ${{ github.event.release.tag_name }} is promotable
     runs-on: ubuntu-latest
@@ -35,6 +35,16 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+
+      - name: Validate OTA prerelease tag format
+        if: ${{ github.event.release.prerelease }}
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(beta|rc)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error title=Invalid OTA prerelease tag::Invalid tag '$TAG'. Use vX.Y.Z-beta.N or vX.Y.Z-rc.N. Alpha releases are not promotable to the beta OTA channel."
+            exit 1
+          fi
 
       - name: Download the release
         env:

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -45,6 +45,16 @@ and removes a cron as something that can silently fail.
 
 ### Promoting a release
 
+Prereleases promoted to the beta OTA channel must use `vX.Y.Z-beta.N` or
+`vX.Y.Z-rc.N`, where `N` is an unpadded numeric SemVer prerelease identifier,
+for example `v2.17.0-beta.10` or `v2.17.0-rc.1`. Do not use forms such as
+`-beta10` or `-rc01`: SemVer either sorts them incorrectly or rejects their
+numeric identifiers. Alpha remains a valid version stage for builds and GitHub
+releases, but alpha releases are not promotable to the beta OTA channel. OTA
+validate checks this policy before release assets, and the shared manifest
+generator enforces it during manual promotion. Nightly tags keep their existing
+convention.
+
 1. Wait for **OTA validate** to pass on the release. Its job summary lists the
    inputs to use. A failure here means the release is not promotable at all —
    usually a platform archive missing from the build matrix.

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -152,7 +152,7 @@ func TestHandleUpdateCheck_BetaChannel(t *testing.T) {
 		received = opts
 		return &updater.Result{
 			CurrentVersion:  "2.9.0",
-			LatestVersion:   "2.10.0-beta1",
+			LatestVersion:   "2.10.0-beta.1",
 			UpdateAvailable: true,
 		}, nil
 	}

--- a/pkg/service/updater/otameta/manifest_test.go
+++ b/pkg/service/updater/otameta/manifest_test.go
@@ -360,7 +360,7 @@ func TestVersionFromTag(t *testing.T) {
 
 	assert.Equal(t, "2.16.1", VersionFromTag("v2.16.1"))
 	assert.Equal(t, "2.16.1", VersionFromTag("2.16.1"))
-	assert.Equal(t, "2.17.0-beta1", VersionFromTag("v2.17.0-beta1"))
+	assert.Equal(t, "2.17.0-beta.1", VersionFromTag("v2.17.0-beta.1"))
 }
 
 func TestFindRelease(t *testing.T) {

--- a/pkg/service/updater/swap_test.go
+++ b/pkg/service/updater/swap_test.go
@@ -251,7 +251,7 @@ func TestReplaceRunningBinary_ReportsBothFailuresWhenTheOutgoingBinaryCannotGoBa
 	err := replaceRunningBinaryWith(f.source, f.target, ops)
 
 	require.ErrorIs(t, err, fatal)
-	assert.Contains(t, err.Error(), f.target,
+	assert.Contains(t, err.Error(), fmt.Sprintf("%q", f.target),
 		"the error has to name the binary that is no longer there")
 	assert.NoFileExists(t, f.target)
 	assert.FileExists(t, f.superseded, "the outgoing binary is still recoverable by hand")

--- a/scripts/generate-update-manifest/beta_tag_test.go
+++ b/scripts/generate-update-manifest/beta_tag_test.go
@@ -1,0 +1,131 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater/otameta"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCandidateTag_OTAPrerelease(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range []string{
+		"v2.17.0-beta.0",
+		"v2.17.0-beta.9",
+		"v2.17.0-beta.10",
+		"v2.17.0-rc.0",
+		"v2.17.0-rc.1",
+		"v2.17.0-rc.10",
+	} {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, validateCandidateTag(tag, channelBeta))
+		})
+	}
+}
+
+func TestValidateCandidateTag_RejectsUnsupportedOTAPrerelease(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range []string{
+		"v2.17.0-beta10",
+		"v2.17.0-beta.01",
+		"v2.17.0-rc1",
+		"v2.17.0-rc.01",
+		"v2.17.0-alpha.1",
+		"2.17.0-beta.10",
+		"v2.17-beta.10",
+	} {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+			err := validateCandidateTag(tag, channelBeta)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "use vX.Y.Z-beta.N or vX.Y.Z-rc.N")
+		})
+	}
+}
+
+func TestValidateCandidateTag_NonBetaChannelUnchanged(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateCandidateTag("v2.17.0", channelStable))
+	require.NoError(t, validateCandidateTag("v2.17.0-alpha.1", channelStable))
+}
+
+func TestApplyPromote_RejectsUnsupportedOTAPrereleaseBeforeArchives(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range []string{"v2.17.0-beta10", "v2.17.0-alpha.1"} {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+			_, err := applyPromote(afero.NewMemMapFs(), &manifest{}, &options{
+				tag:         tag,
+				channel:     channelBeta,
+				archivesDir: "missing",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "use vX.Y.Z-beta.N or vX.Y.Z-rc.N")
+		})
+	}
+}
+
+func TestCanonicalPrereleaseVersionOrdering(t *testing.T) {
+	t.Parallel()
+
+	ordered := []string{
+		"v2.17.0-alpha.1",
+		"v2.17.0-beta.9",
+		"v2.17.0-beta.10",
+		"v2.17.0-rc.1",
+		"v2.17.0",
+	}
+	for i := 1; i < len(ordered); i++ {
+		assert.True(t, newerRelease(
+			&otameta.Release{TagName: ordered[i]},
+			&otameta.Release{TagName: ordered[i-1]},
+		), "%s should sort above %s", ordered[i], ordered[i-1])
+	}
+}
+
+func TestApplyPromote_IgnoresMalformedHistoricalBetaTag(t *testing.T) {
+	t.Parallel()
+
+	fs := afero.NewMemMapFs()
+	writeFullMatrix(t, fs, testArchivesDir, "v2.17.0-beta.10")
+	m := &manifest{Releases: []*release{{
+		TagName: "v2.16.0-beta10",
+		Channel: channelBeta,
+	}}}
+
+	_, err := applyPromote(fs, m, &options{
+		tag:         "v2.17.0-beta.10",
+		channel:     channelBeta,
+		archivesDir: testArchivesDir,
+		rollout:     fullRollout,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, findRelease(m, "v2.16.0-beta10"))
+	assert.NotNil(t, findRelease(m, "v2.17.0-beta.10"))
+}

--- a/scripts/generate-update-manifest/main.go
+++ b/scripts/generate-update-manifest/main.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -207,7 +208,25 @@ func loadPublishedChecksums(fs afero.Fs, path string) ([]checksumEntry, error) {
 
 // applyPromote gathers the local archives, cross-checks them against the
 // GitHub release, and adds the release to the manifest.
+var canonicalOTAPrereleaseTag = regexp.MustCompile(
+	`^v\d+\.\d+\.\d+-(beta|rc)\.(0|[1-9]\d*)$`,
+)
+
+func validateCandidateTag(tag, channel string) error {
+	if channel == channelBeta && !canonicalOTAPrereleaseTag.MatchString(tag) {
+		return fmt.Errorf(
+			"invalid beta-channel tag %q: use vX.Y.Z-beta.N or vX.Y.Z-rc.N",
+			tag,
+		)
+	}
+	return nil
+}
+
 func applyPromote(fs afero.Fs, m *manifest, opts *options) (*release, error) {
+	if err := validateCandidateTag(opts.tag, opts.channel); err != nil {
+		return nil, err
+	}
+
 	archives, err := scanArchives(fs, opts.archivesDir)
 	if err != nil {
 		return nil, err

--- a/scripts/generate-update-manifest/main_test.go
+++ b/scripts/generate-update-manifest/main_test.go
@@ -145,22 +145,22 @@ func TestRun_PromoteCrossChecksGithub(t *testing.T) {
 	t.Parallel()
 
 	f := newPublishFixture(t, []string{"v2.16.0"}, []string{channelStable})
-	files := f.stageArchives(t, "v2.17.0-beta1")
-	writeGithubRelease(t, f.fs, "release.json", "v2.17.0-beta1", true, files)
+	files := f.stageArchives(t, "v2.17.0-beta.1")
+	writeGithubRelease(t, f.fs, "release.json", "v2.17.0-beta.1", true, files)
 
-	opts := f.promoteOpts("v2.17.0-beta1", channelBeta)
+	opts := f.promoteOpts("v2.17.0-beta.1", channelBeta)
 	opts.githubRelease = "release.json"
 
 	_, err := run(f.fs, opts, testNow)
 	require.NoError(t, err)
 
 	m, _ := f.published(t)
-	rel := findRelease(m, "v2.17.0-beta1")
+	rel := findRelease(m, "v2.17.0-beta.1")
 	require.NotNil(t, rel)
 	assert.Equal(t, channelBeta, rel.Channel)
 	assert.True(t, rel.Prerelease)
 	assert.Equal(t,
-		"https://github.com/ZaparooProject/zaparoo-core/releases/tag/v2.17.0-beta1",
+		"https://github.com/ZaparooProject/zaparoo-core/releases/tag/v2.17.0-beta.1",
 		rel.URL,
 	)
 	assert.Equal(t, time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC), rel.PublishedAt.UTC())
@@ -543,7 +543,7 @@ func TestRun_ProducedManifestDecodesInGoSelfupdate(t *testing.T) {
 	t.Parallel()
 
 	f := newPublishFixture(t,
-		[]string{"v2.16.0", "v2.17.0-beta1"},
+		[]string{"v2.16.0", "v2.17.0-beta.1"},
 		[]string{channelStable, channelBeta},
 	)
 	f.stageArchives(t, "v2.16.1")

--- a/scripts/generate-update-manifest/manifest_test.go
+++ b/scripts/generate-update-manifest/manifest_test.go
@@ -71,7 +71,7 @@ func TestNormalizeManifest_BackfillsLegacyFields(t *testing.T) {
 		LastAssetID:   3,
 		Releases: []*release{
 			{ID: 1, TagName: "v2.16.0", Prerelease: false},
-			{ID: 2, TagName: "v2.17.0-beta1", Prerelease: true},
+			{ID: 2, TagName: "v2.17.0-beta.1", Prerelease: true},
 		},
 	}
 
@@ -156,7 +156,7 @@ func TestManifestRoundTrip(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	path := filepath.Join("out", manifestName)
 
-	original := newTestManifest(t, []string{"v2.16.0", "v2.17.0-beta1"}, []string{channelStable, channelBeta})
+	original := newTestManifest(t, []string{"v2.16.0", "v2.17.0-beta.1"}, []string{channelStable, channelBeta})
 	stampManifest(original, 42, "k1", time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC))
 	require.NoError(t, writeManifest(fs, original, path))
 

--- a/scripts/generate-update-manifest/ops_test.go
+++ b/scripts/generate-update-manifest/ops_test.go
@@ -267,8 +267,8 @@ func TestApplyRetention_KeepsNewestPerChannel(t *testing.T) {
 	t.Parallel()
 
 	tags := []string{
-		"v2.10.0", "v2.11.0-beta1", "v2.11.0", "v2.12.0-beta1",
-		"v2.12.0", "v2.13.0-beta1", "v2.13.0",
+		"v2.10.0", "v2.11.0-beta.1", "v2.11.0", "v2.12.0-beta.1",
+		"v2.12.0", "v2.13.0-beta.1", "v2.13.0",
 	}
 	channels := []string{
 		channelStable, channelBeta, channelStable, channelBeta,
@@ -278,8 +278,8 @@ func TestApplyRetention_KeepsNewestPerChannel(t *testing.T) {
 
 	dropped := applyRetention(m, 2, 1, 0)
 
-	assert.Equal(t, []string{"v2.10.0", "v2.11.0", "v2.11.0-beta1", "v2.12.0-beta1"}, dropped)
-	assert.Equal(t, []string{"v2.12.0", "v2.13.0-beta1", "v2.13.0"}, tagsOf(m),
+	assert.Equal(t, []string{"v2.10.0", "v2.11.0", "v2.11.0-beta.1", "v2.12.0-beta.1"}, dropped)
+	assert.Equal(t, []string{"v2.12.0", "v2.13.0-beta.1", "v2.13.0"}, tagsOf(m),
 		"surviving releases keep their original order")
 }
 
@@ -287,7 +287,7 @@ func TestApplyRetention_TruncatesSupersededNotes(t *testing.T) {
 	t.Parallel()
 
 	m := newTestManifest(t,
-		[]string{"v2.16.0", "v2.16.1", "v2.17.0-beta1"},
+		[]string{"v2.16.0", "v2.16.1", "v2.17.0-beta.1"},
 		[]string{channelStable, channelStable, channelBeta},
 	)
 	long := strings.Repeat("a", 4000)
@@ -301,7 +301,7 @@ func TestApplyRetention_TruncatesSupersededNotes(t *testing.T) {
 	assert.Len(t, findRelease(m, "v2.16.0").ReleaseNotes, 100+len(notesTruncationMarker))
 	assert.Equal(t, long, findRelease(m, "v2.16.1").ReleaseNotes,
 		"the newest stable release keeps its full notes")
-	assert.Equal(t, long, findRelease(m, "v2.17.0-beta1").ReleaseNotes,
+	assert.Equal(t, long, findRelease(m, "v2.17.0-beta.1").ReleaseNotes,
 		"the newest beta release keeps its full notes")
 }
 

--- a/scripts/generate-update-manifest/targets_test.go
+++ b/scripts/generate-update-manifest/targets_test.go
@@ -157,7 +157,7 @@ func TestVersionFromTag(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, "2.16.1", versionFromTag("v2.16.1"))
-	assert.Equal(t, "2.17.0-beta1", versionFromTag("v2.17.0-beta1"))
+	assert.Equal(t, "2.17.0-beta.1", versionFromTag("v2.17.0-beta.1"))
 	assert.Equal(t, "2.16.1", versionFromTag("2.16.1"))
 }
 

--- a/scripts/tasks/batocera.yml
+++ b/scripts/tasks/batocera.yml
@@ -60,7 +60,7 @@ tasks:
     vars:
       BUILD_DIR: '{{.BUILD_DIR | default "_build/packages/batocera"}}'
       TEMPLATE_DIR: '{{.TEMPLATE_DIR | default "scripts/batocera/template"}}'
-      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta1 -> 2.8.0_beta1)
+      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta.1 -> 2.8.0_beta.1)
       PKG_VERSION: '{{.VERSION | replace "-" "_"}}'
       PACKAGE_NAME: zaparoo-core-{{.PKG_VERSION}}-1-{{.PKG_ARCH}}
       PACKAGE_DIR: "{{.BUILD_DIR}}/{{.PACKAGE_NAME}}"
@@ -110,7 +110,7 @@ tasks:
     vars:
       TEMPLATE_DIR: scripts/batocera/template
       BUILD_DIR: _build/packages/batocera
-      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta1 -> 2.8.0_beta1)
+      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta.1 -> 2.8.0_beta.1)
       PKG_VERSION: '{{.APP_VERSION | replace "-" "_"}}'
       PACKAGE_NAME: zaparoo-core-{{.PKG_VERSION}}-1-any
       PACKAGE_DIR: "{{.BUILD_DIR}}/{{.PACKAGE_NAME}}"
@@ -152,7 +152,7 @@ tasks:
     vars:
       TEMPLATE_DIR: scripts/batocera/template
       BUILD_DIR: _build/packages/batocera
-      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta1 -> 2.8.0_beta1)
+      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta.1 -> 2.8.0_beta.1)
       PKG_VERSION: '{{.APP_VERSION | replace "-" "_"}}'
       PACKAGE_NAME: zaparoo-core-{{.PKG_VERSION}}-1-any
       PACKAGE_DIR: "{{.BUILD_DIR}}/{{.PACKAGE_NAME}}"
@@ -205,7 +205,7 @@ tasks:
     desc: Build universal package and deploy to Batocera system
     vars:
       BATOCERA_HOST: '{{.BATOCERA_HOST | default "root@${BATOCERA_IP}"}}'
-      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta1 -> 2.8.0_beta1)
+      # Sanitize version for pacman: replace dashes with underscores (e.g., 2.8.0-beta.1 -> 2.8.0_beta.1)
       PKG_VERSION: '{{.APP_VERSION | replace "-" "_"}}'
     cmds:
       - task: package-any


### PR DESCRIPTION
## Summary

- require canonical dotted numeric identifiers for OTA prerelease tags
- allow beta and release-candidate tags on the beta OTA channel while keeping alpha versions valid but non-promotable
- align workflow validation, manifest generation, tests, examples, and OTA documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces canonical SemVer prerelease tags for OTA promotion. Previously we accepted tags like v2.17.0-beta1 and promoted any non-nightly prereleases; now only vX.Y.Z-beta.N or vX.Y.Z-rc.N are promotable, alpha stays non-promotable, and CI/tooling reject invalid tags.

- Validates prerelease tags in `ota-validate` and in `scripts/generate-update-manifest` before scanning archives; preserves historical malformed tags but enforces the new rule for new promotions; updates docs and tests to the dotted form.

**Required actions**
- Tag promotable prereleases as vX.Y.Z-beta.N or vX.Y.Z-rc.N when promoting to the beta OTA channel.
- Do not promote alpha releases.

<sup>Written for commit 446b72f11d379b8b4aa4f619f94777f8eba6cd04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ZaparooProject/zaparoo-core/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beta-channel promotions now require canonical `vX.Y.Z-beta.N` or `vX.Y.Z-rc.N` tags.
  * Unsupported formats, including alpha and nightly tags, are rejected for beta promotion.
* **Documentation**
  * Updated OTA promotion guidance with valid prerelease formats and validation rules.
* **Tests**
  * Expanded coverage for prerelease validation, ordering, malformed historical tags, and manifest compatibility.
  * Updated beta version examples to use the canonical dot-separated format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->