### PR TITLE
fix(api): add media browse root contents view

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -743,6 +743,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | path       | string                                | Yes      | The browsed directory path. Empty string when listing roots.             |
 | entries    | [BrowseEntry](#browse-entry-object)[] | Yes      | Array of entries in the current path.                                    |
 | totalFiles | number                                | Yes      | Total count of media files in the current directory (respects `tags` and `letter` filters). |
+| totalDirs  | number                                | Yes      | Total count of immediate child directories in the current directory.     |
 | pagination | [Pagination](#browse-pagination-object) | No     | Pagination info. Omitted when there are no file results.                 |
 
 ##### Browse entry object
@@ -856,6 +857,10 @@ With SNES media under `/configured/SNES` and `/roms/SNES`, this view displays th
         "hasCover": true
       }
     ],
+    "pagination": {
+      "hasNextPage": false,
+      "pageSize": 100
+    },
     "totalDirs": 1,
     "totalFiles": 1
   }

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -716,6 +716,8 @@ Browse indexed media content by directory, similar to navigating a file manager.
 
 When called without a `path` parameter (or with an empty path), returns top-level root entries including filesystem roots and virtual scheme roots. When `systems` is provided without `path`, returns populated launcher routes for those systems only. Pass the same `systems` filter when browsing a returned route to keep shared paths scoped to the selected systems.
 
+Set `rootView` to `contents` with exactly one system to replace its filesystem routes with a one-level view of their immediate contents. This is display-only: entries retain physical paths, and browsing a returned directory uses ordinary single-path behavior. Root priority follows platform order (first root wins); exact, case-sensitive filesystem basenames define collisions. Virtual URI routes remain separate.
+
 Tags filter direct media files in the current path. Directories remain visible for navigation with unfiltered `fileCount` values, while `totalFiles`, file pagination, and cursors reflect only matching files. Tagged directory entries remain plain directories rather than being promoted to logical single-game aliases.
 
 #### Parameters
@@ -727,6 +729,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | path       | string | No       | Directory path to browse. Omit or set empty to list root entries. Supports filesystem paths and virtual URI schemes (e.g. `mame-arcade://`). |
 | systems    | string[] | No     | Case-sensitive list of system IDs to restrict route discovery and browse results to. A missing key or empty list preserves unfiltered behavior. |
 | fuzzySystem | boolean | No     | Enable fuzzy matching for system IDs in the `systems` array (e.g., `"snes"` matches `"SNES"`). |
+| rootView   | string | No       | Pathless system-root presentation: `routes` (default) returns separate populated routes; `contents` returns one-level immediate contents and requires exactly one system. Ignored when `path` is non-empty. Repeat with cursor requests. |
 | maxResults | number | No       | Maximum results per page. Default is 100, maximum is 1000.                                                 |
 | cursor     | string | No       | Opaque pagination cursor from a previous response's `nextCursor`. Omit for first page. Cursors are valid only with the same path, systems, tags, letter, and sort parameters. |
 | tags       | string[] | No     | Filter direct media files by tags. Syntax and AND/NOT/OR operators match `media.search`. Directories remain unfiltered. |
@@ -755,7 +758,7 @@ All parameters are optional. When called with no parameters, returns root entrie
 | systemId     | string   | No       | System ID for the media or single-system filtered route (e.g. `SNES`). Present on `media` entries and filtered `root` entries when exactly one system applies. |
 | systemIds    | string[] | No       | System IDs represented by a filtered `root` or `directory` entry.                                |
 | zapScript    | string   | No       | ZapScript command to launch this media. Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
-| relativePath | string   | No       | Relative path from root directory. Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
+| relativePath | string   | No       | Launcher-relative convenience path (for example `SNES/Game.sfc`) when portable conversion succeeds. Present on media and logical single-game container entries; omitted for unmatched absolute paths and virtual URIs. Not a stable media identity. |
 | tags         | object[] | No       | Tags attached to the media. Each object has `tag` (string) and `type` (string). Present on `media` entries and logical single-game container `directory` entries on zip-as-directory platforms. |
 | disambiguatingTags | object[] | No | Subset of `tags` whose values differ across same-named siblings of this title, ordered by display importance. Same object shape as `tags`. Omitted when the title has nothing to disambiguate. |
 | hasCover     | boolean  | Yes      | Whether media-level or title-level image properties are available. Meaningful for media-capable entries; clients can skip image requests when false. |
@@ -807,6 +810,60 @@ All parameters are optional. When called with no parameters, returns root entrie
 }
 ```
 
+#### Root contents example
+
+With SNES media under `/configured/SNES` and `/roms/SNES`, this view displays their immediate children together. If both roots contain the same basename, `/configured/SNES` wins because it appears first in platform root order.
+
+##### Request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "media.browse",
+  "params": {
+    "systems": ["SNES"],
+    "rootView": "contents"
+  }
+}
+```
+
+##### Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "path": "",
+    "entries": [
+      {
+        "name": "RPGs",
+        "path": "/configured/SNES/RPGs",
+        "type": "directory",
+        "fileCount": 42,
+        "systemIds": ["SNES"],
+        "hasCover": false
+      },
+      {
+        "mediaId": 42,
+        "name": "Super Mario World",
+        "path": "/roms/SNES/Super Mario World.sfc",
+        "type": "media",
+        "systemId": "SNES",
+        "zapScript": "@SNES/Super Mario World",
+        "relativePath": "SNES/Super Mario World.sfc",
+        "hasCover": true
+      }
+    ],
+    "totalDirs": 1,
+    "totalFiles": 1
+  }
+}
+```
+
+Selecting `RPGs` browses only `/configured/SNES/RPGs`; `rootView` does not merge lower levels.
+
 #### Browse path example
 
 ##### Request
@@ -847,7 +904,7 @@ All parameters are optional. When called with no parameters, returns root entrie
         "systemId": "SNES",
         "hasCover": true,
         "zapScript": "@SNES/Super Mario World",
-        "relativePath": "Super Mario World.sfc",
+        "relativePath": "SNES/Super Mario World.sfc",
         "tags": [
           {"tag": "1990", "type": "year"},
           {"tag": "2", "type": "players"}
@@ -861,7 +918,7 @@ All parameters are optional. When called with no parameters, returns root entrie
         "systemId": "SNES",
         "hasCover": false,
         "zapScript": "@SNES/The Legend of Zelda - A Link to the Past",
-        "relativePath": "The Legend of Zelda - A Link to the Past.sfc",
+        "relativePath": "SNES/The Legend of Zelda - A Link to the Past.sfc",
         "tags": [
           {"tag": "1991", "type": "year"},
           {"tag": "1", "type": "players"}

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	sortpkg "sort"
 	"strings"
 	"time"
 
@@ -46,6 +47,9 @@ import (
 const (
 	browsePhaseDirs  = "dirs"
 	browsePhaseFiles = "files"
+
+	browseRootViewRoutes   = "routes"
+	browseRootViewContents = "contents"
 )
 
 // browseCursorData is the JSON-serializable keyset cursor for browse pagination.
@@ -58,6 +62,7 @@ type browseCursorData struct {
 	SortMode   string `json:"sortMode,omitempty"`
 	Phase      string `json:"phase,omitempty"`
 	DirName    string `json:"dirName,omitempty"`
+	RootView   string `json:"rootView,omitempty"`
 	LastID     int64  `json:"lastId"`
 	TotalFiles int    `json:"totalFiles,omitempty"`
 	TotalDirs  int    `json:"totalDirs,omitempty"`
@@ -79,45 +84,70 @@ func encodeBrowseCursor(lastID int64, sortValue string, totalFiles ...int) (stri
 	return encodeCursorData(&data)
 }
 
-func encodeBrowseCursorWithMode(lastID int64, sortValue, sortMode string, totalFiles int) (string, error) {
+func encodeBrowseCursorWithMode(
+	lastID int64,
+	sortValue, sortMode string,
+	totalFiles int,
+	rootViews ...string,
+) (string, error) {
 	data := browseCursorData{LastID: lastID, SortValue: sortValue, SortMode: sortMode}
 	if totalFiles > 0 {
 		data.TotalFiles = totalFiles
+	}
+	if len(rootViews) > 0 {
+		data.RootView = rootViews[0]
 	}
 	return encodeCursorData(&data)
 }
 
 // encodeDirCursor builds a dirs-phase cursor positioned after dirName.
-func encodeDirCursor(dirName string, totalFiles, totalDirs int) (string, error) {
-	return encodeCursorData(&browseCursorData{
+func encodeDirCursor(dirName string, totalFiles, totalDirs int, rootViews ...string) (string, error) {
+	data := &browseCursorData{
 		Phase:      browsePhaseDirs,
 		DirName:    dirName,
 		TotalFiles: totalFiles,
 		TotalDirs:  totalDirs,
-	})
+	}
+	if len(rootViews) > 0 {
+		data.RootView = rootViews[0]
+	}
+	return encodeCursorData(data)
 }
 
 // encodeFileCursor builds a files-phase cursor from the last file's keyset.
-func encodeFileCursor(lastID int64, sortValue, sortMode string, totalFiles, totalDirs int) (string, error) {
-	return encodeCursorData(&browseCursorData{
+func encodeFileCursor(
+	lastID int64,
+	sortValue, sortMode string,
+	totalFiles, totalDirs int,
+	rootViews ...string,
+) (string, error) {
+	data := &browseCursorData{
 		Phase:      browsePhaseFiles,
 		SortValue:  sortValue,
 		SortMode:   sortMode,
 		LastID:     lastID,
 		TotalFiles: totalFiles,
 		TotalDirs:  totalDirs,
-	})
+	}
+	if len(rootViews) > 0 {
+		data.RootView = rootViews[0]
+	}
+	return encodeCursorData(data)
 }
 
 // encodeFilesStartCursor builds a files-phase cursor with no keyset (LastID 0),
 // marking the transition from the dirs phase so the next page starts files from
 // the beginning.
-func encodeFilesStartCursor(totalFiles, totalDirs int) (string, error) {
-	return encodeCursorData(&browseCursorData{
+func encodeFilesStartCursor(totalFiles, totalDirs int, rootViews ...string) (string, error) {
+	data := &browseCursorData{
 		Phase:      browsePhaseFiles,
 		TotalFiles: totalFiles,
 		TotalDirs:  totalDirs,
-	})
+	}
+	if len(rootViews) > 0 {
+		data.RootView = rootViews[0]
+	}
+	return encodeCursorData(data)
 }
 
 func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
@@ -147,6 +177,7 @@ func decodeBrowseCursor(cursor string) (*database.BrowseCursor, error) {
 		SortMode:   data.SortMode,
 		Phase:      data.Phase,
 		DirName:    data.DirName,
+		RootView:   data.RootView,
 		TotalFiles: data.TotalFiles,
 		TotalDirs:  data.TotalDirs,
 	}, nil
@@ -241,8 +272,26 @@ func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 		}
 	}
 
-	// No path → return root entries
+	// No path → return root entries or an opt-in one-level contents overlay.
 	if params.Path == nil || *params.Path == "" {
+		rootView := browseRootViewRoutes
+		if params.RootView != nil {
+			rootView = *params.RootView
+		}
+		if cursor != nil && cursor.RootView != "" && cursor.RootView != rootView {
+			return nil, models.ClientErrf("cursor does not match rootView %s", rootView)
+		}
+		if rootView == browseRootViewContents {
+			if len(systems) != 1 {
+				return nil, models.ClientErrf("rootView contents requires exactly one system")
+			}
+			if cursor != nil && cursor.RootView != browseRootViewContents {
+				return nil, models.ClientErrf("cursor does not match rootView contents")
+			}
+			return browseSystemRootContents(
+				&env, systems, cursor, maxResults, params.Letter, sort, tagFilters,
+			)
+		}
 		if len(systems) > 0 {
 			return browseSystemRoots(&env, systems)
 		}
@@ -250,6 +299,9 @@ func browseMedia(env requests.RequestEnv) (any, error) { //nolint:gocritic // si
 	}
 
 	path := *params.Path
+	if cursor != nil && cursor.RootView != "" {
+		return nil, models.ClientErrf("rootView contents cursor does not match path browse")
+	}
 
 	// Virtual path (contains ://)
 	if strings.Contains(path, "://") {
@@ -322,6 +374,17 @@ func browseRoots(env *requests.RequestEnv) (any, error) {
 }
 
 func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (any, error) {
+	entries, err := resolveSystemRootEntries(env, systems)
+	if err != nil {
+		return nil, err
+	}
+	return models.BrowseResults{Entries: entries}, nil
+}
+
+func resolveSystemRootEntries(
+	env *requests.RequestEnv,
+	systems []systemdefs.System,
+) ([]models.BrowseEntry, error) {
 	started := time.Now()
 	routes, err := buildSystemBrowseRouteCandidates(env, systems)
 	if err != nil {
@@ -387,7 +450,245 @@ func browseSystemRoots(env *requests.RequestEnv, systems []systemdefs.System) (a
 
 	entries = dedupeSystemRootEntries(entries)
 
-	return models.BrowseResults{Entries: entries}, nil
+	return entries, nil
+}
+
+func systemRootContentsSources(
+	env *requests.RequestEnv,
+	entries []models.BrowseEntry,
+) ([]database.BrowseSource, []models.BrowseEntry) {
+	physical := make([]models.BrowseEntry, 0, len(entries))
+	virtual := make([]models.BrowseEntry, 0)
+	for i := range entries {
+		if strings.Contains(entries[i].Path, "://") {
+			virtual = append(virtual, entries[i])
+			continue
+		}
+		physical = append(physical, entries[i])
+	}
+
+	var rootDirs []string
+	if env.Platform != nil {
+		rootDirs = env.Platform.RootDirs(env.Config)
+	}
+	rootPriority := func(path string) int {
+		for i, root := range rootDirs {
+			if helpers.PathHasPrefix(path, root) {
+				return i
+			}
+		}
+		return len(rootDirs)
+	}
+	sortpkg.SliceStable(physical, func(i, j int) bool {
+		return rootPriority(physical[i].Path) < rootPriority(physical[j].Path)
+	})
+
+	sources := make([]database.BrowseSource, 0, len(physical))
+	for i := range physical {
+		includeDirs := true
+		for j := range physical {
+			if i != j && isStrictFilesystemDescendant(physical[j].Path, physical[i].Path) {
+				includeDirs = false
+				break
+			}
+		}
+		prefix := filepath.ToSlash(filepath.Clean(physical[i].Path))
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+		sources = append(sources, database.BrowseSource{
+			PathPrefix:  prefix,
+			IncludeDirs: includeDirs,
+		})
+	}
+	return sources, virtual
+}
+
+func browseSystemRootContents(
+	env *requests.RequestEnv,
+	systems []systemdefs.System,
+	cursor *database.BrowseCursor,
+	maxResults int,
+	letter *string,
+	sortOrder string,
+	tags []zapscript.TagFilter,
+) (any, error) {
+	rootEntries, err := resolveSystemRootEntries(env, systems)
+	if err != nil {
+		return nil, err
+	}
+	sources, virtualEntries := systemRootContentsSources(env, rootEntries)
+	overlay := &database.BrowseOverlay{Sources: sources}
+	if cursor != nil {
+		virtualEntries = nil
+	}
+	if len(sources) == 0 {
+		return models.BrowseResults{Entries: virtualEntries}, nil
+	}
+
+	var totalDirs, totalFiles int
+	if cursor != nil {
+		totalDirs = cursor.TotalDirs
+		totalFiles = cursor.TotalFiles
+	}
+	inDirsPhase := letter == nil && (cursor == nil || cursor.Phase == browsePhaseDirs)
+	if inDirsPhase {
+		afterName := ""
+		if cursor != nil {
+			afterName = cursor.DirName
+		}
+		dirs, dirsErr := env.Database.MediaDB.BrowseDirectories(env.Context, database.BrowseDirectoriesOptions{
+			Overlay:   overlay,
+			AfterName: afterName,
+			Systems:   systems,
+			Limit:     maxResults + 1,
+		})
+		if dirsErr != nil {
+			return nil, fmt.Errorf("error browsing system root contents directories: %w", dirsErr)
+		}
+		if cursor == nil {
+			totalDirs, err = env.Database.MediaDB.BrowseDirCount(env.Context, database.BrowseDirCountOptions{
+				Overlay: overlay,
+				Systems: systems,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("error counting system root contents directories: %w", err)
+			}
+			totalFiles, err = browseRootContentsFileCount(env, sources, letter, systems, tags)
+			if err != nil {
+				return nil, err
+			}
+		}
+		hasMoreDirs := len(dirs) > maxResults
+		if hasMoreDirs {
+			dirs = dirs[:maxResults]
+			next, encErr := encodeDirCursor(
+				dirs[len(dirs)-1].Name, totalFiles, totalDirs, browseRootViewContents,
+			)
+			if encErr != nil {
+				return nil, fmt.Errorf("failed to encode root contents cursor: %w", encErr)
+			}
+			return buildRootContentsResponse(
+				env, dirs, nil, virtualEntries, maxResults, totalFiles, totalDirs, &next, true, systems, tags,
+			)
+		}
+
+		remaining := maxResults - len(dirs)
+		if remaining <= 0 {
+			var next *string
+			hasNext := totalFiles > 0
+			if hasNext {
+				encoded, encErr := encodeFilesStartCursor(totalFiles, totalDirs, browseRootViewContents)
+				if encErr != nil {
+					return nil, fmt.Errorf("failed to encode root contents cursor: %w", encErr)
+				}
+				next = &encoded
+			}
+			return buildRootContentsResponse(
+				env, dirs, nil, virtualEntries, maxResults, totalFiles, totalDirs, next, hasNext, systems, tags,
+			)
+		}
+		files, filesErr := env.Database.MediaDB.BrowseFiles(env.Context, &database.BrowseFilesOptions{
+			Overlay: overlay,
+			Limit:   remaining + 1,
+			Sort:    sortOrder,
+			Systems: systems,
+			Tags:    tags,
+		})
+		if filesErr != nil {
+			return nil, fmt.Errorf("error browsing system root contents files: %w", filesErr)
+		}
+		files, next, pageErr := paginateFiles(
+			files, remaining, totalFiles, totalDirs, sortOrder, browseRootViewContents,
+		)
+		if pageErr != nil {
+			return nil, pageErr
+		}
+		return buildRootContentsResponse(
+			env, dirs, files, virtualEntries, maxResults, totalFiles, totalDirs, next, next != nil, systems, tags,
+		)
+	}
+
+	fileCursor := cursor
+	if cursor != nil && cursor.Phase == browsePhaseFiles && cursor.LastID == 0 {
+		fileCursor = nil
+	}
+	files, filesErr := env.Database.MediaDB.BrowseFiles(env.Context, &database.BrowseFilesOptions{
+		Overlay: overlay,
+		Cursor:  fileCursor,
+		Limit:   maxResults + 1,
+		Letter:  letter,
+		Sort:    sortOrder,
+		Systems: systems,
+		Tags:    tags,
+	})
+	if filesErr != nil {
+		return nil, fmt.Errorf("error browsing system root contents files: %w", filesErr)
+	}
+	if totalFiles == 0 && (len(files) > 0 || cursor != nil) {
+		totalFiles, err = browseRootContentsFileCount(env, sources, letter, systems, tags)
+		if err != nil {
+			return nil, err
+		}
+	}
+	files, next, pageErr := paginateFiles(
+		files, maxResults, totalFiles, totalDirs, sortOrder, browseRootViewContents,
+	)
+	if pageErr != nil {
+		return nil, pageErr
+	}
+	return buildRootContentsResponse(
+		env, nil, files, virtualEntries, maxResults, totalFiles, totalDirs, next, next != nil, systems, tags,
+	)
+}
+
+func browseRootContentsFileCount(
+	env *requests.RequestEnv,
+	sources []database.BrowseSource,
+	letter *string,
+	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
+) (int, error) {
+	count, err := env.Database.MediaDB.BrowseFileCount(env.Context, database.BrowseFileCountOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Letter:  letter,
+		Systems: systems,
+		Tags:    tags,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("error counting system root contents files: %w", err)
+	}
+	return count, nil
+}
+
+func buildRootContentsResponse(
+	env *requests.RequestEnv,
+	dirs []database.BrowseDirectoryResult,
+	files []database.SearchResultWithCursor,
+	virtualEntries []models.BrowseEntry,
+	maxResults, totalFiles, totalDirs int,
+	nextCursor *string,
+	hasNextPage bool,
+	systems []systemdefs.System,
+	tags []zapscript.TagFilter,
+) (any, error) {
+	result, err := buildBrowseResponse(
+		env, "", dirs, files, maxResults, totalFiles, totalDirs, nextCursor, hasNextPage, systems, tags,
+	)
+	if err != nil {
+		return nil, err
+	}
+	browseResult, ok := result.(models.BrowseResults)
+	if !ok {
+		return nil, fmt.Errorf("unexpected root contents response type %T", result)
+	}
+	if len(virtualEntries) > 0 {
+		entries := make([]models.BrowseEntry, 0, len(virtualEntries)+len(browseResult.Entries))
+		entries = append(entries, virtualEntries...)
+		entries = append(entries, browseResult.Entries...)
+		browseResult.Entries = entries
+	}
+	return browseResult, nil
 }
 
 func dedupeSystemRootEntries(entries []models.BrowseEntry) []models.BrowseEntry {
@@ -834,6 +1135,7 @@ func paginateFiles(
 	limit int,
 	totalFiles, totalDirs int,
 	sort string,
+	rootViews ...string,
 ) (page []database.SearchResultWithCursor, next *string, err error) {
 	if len(files) <= limit {
 		return files, nil, nil
@@ -849,7 +1151,9 @@ func paginateFiles(
 			sortValue = last.Name
 		}
 	}
-	encoded, encErr := encodeFileCursor(last.MediaID, sortValue, last.SortMode, totalFiles, totalDirs)
+	encoded, encErr := encodeFileCursor(
+		last.MediaID, sortValue, last.SortMode, totalFiles, totalDirs, rootViews...,
+	)
 	if encErr != nil {
 		return nil, nil, fmt.Errorf("failed to encode cursor: %w", encErr)
 	}
@@ -931,11 +1235,6 @@ func buildBrowseResponse(
 		tags = tagSets[0]
 	}
 
-	var rootDirs []string
-	if env.LauncherCache != nil && env.Platform != nil {
-		rootDirs = env.Platform.RootDirs(env.Config)
-	}
-
 	var singletonAliases map[string]database.SingletonContainerAlias
 	if len(tags) == 0 {
 		singletonAliases = resolveDirSingletonAliases(env, path, dirs, systems)
@@ -943,7 +1242,10 @@ func buildBrowseResponse(
 
 	entries := make([]models.BrowseEntry, 0, len(dirs)+len(files))
 	for _, dir := range dirs {
-		dirPath := filepath.ToSlash(filepath.Join(path, dir.Name))
+		dirPath := dir.Path
+		if dirPath == "" {
+			dirPath = filepath.ToSlash(filepath.Join(path, dir.Name))
+		}
 		entry := models.BrowseEntry{
 			Name:      dir.Name,
 			Path:      dirPath,
@@ -951,7 +1253,7 @@ func buildBrowseResponse(
 			FileCount: &dir.FileCount,
 			SystemIDs: dir.SystemIDs,
 		}
-		if alias, ok := singletonAliases[dirPath+"/"]; ok {
+		if alias, ok := singletonAliases[strings.TrimSuffix(dirPath, "/")+"/"]; ok {
 			result := database.SearchResultWithCursor{
 				MediaID:       alias.Row.DBID,
 				SystemID:      alias.Row.System.SystemID,
@@ -961,7 +1263,7 @@ func buildBrowseResponse(
 				ZapScriptTags: alias.ZapScriptTags,
 				HasCover:      alias.HasCover,
 			}
-			mediaEntry := buildMediaEntry(&result, env, rootDirs)
+			mediaEntry := buildMediaEntry(&result, env)
 			entry.Name = mediaEntry.Name
 			entry.MediaID = mediaEntry.MediaID
 			entry.SystemID = mediaEntry.SystemID
@@ -975,7 +1277,7 @@ func buildBrowseResponse(
 	}
 
 	for i := range files {
-		entry := buildMediaEntry(&files[i], env, rootDirs)
+		entry := buildMediaEntry(&files[i], env)
 		entries = append(entries, entry)
 	}
 
@@ -1041,8 +1343,12 @@ func resolveDirSingletonAliases(
 		if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
 			continue
 		}
+		childDir := dir.Path
+		if childDir == "" {
+			childDir = filepath.ToSlash(filepath.Join(path, dir.Name))
+		}
 		candidates = append(candidates, database.SingletonAliasCandidate{
-			ChildDir:  filepath.ToSlash(filepath.Join(path, dir.Name)) + "/",
+			ChildDir:  strings.TrimSuffix(filepath.ToSlash(childDir), "/") + "/",
 			FileCount: dir.FileCount,
 		})
 	}
@@ -1101,7 +1407,6 @@ func browseMediaDisplayName(path, sortName, titleName string) string {
 func buildMediaEntry(
 	result *database.SearchResultWithCursor,
 	env *requests.RequestEnv,
-	rootDirs []string,
 ) models.BrowseEntry {
 	entry := models.BrowseEntry{
 		MediaID:            result.MediaID,
@@ -1116,10 +1421,7 @@ func buildMediaEntry(
 	zapScript := result.ZapScript()
 	entry.ZapScript = &zapScript
 
-	if env.LauncherCache != nil {
-		relPath := env.LauncherCache.ToRelativePath(rootDirs, result.SystemID, result.Path)
-		entry.RelPath = &relPath
-	}
+	entry.RelPath = mediaResponseRelativePath(env, result.SystemID, result.Path)
 
 	return entry
 }

--- a/pkg/api/methods/media_browse_index.go
+++ b/pkg/api/methods/media_browse_index.go
@@ -127,9 +127,40 @@ func browseMediaIndex(env requests.RequestEnv) (any, error) { //nolint:gocritic 
 		}
 	}
 
-	// No path → root listing. A letter rail is not meaningful for roots.
+	// No path normally means route listing, where a letter rail is not
+	// meaningful. The contents root view is an immediate media listing and uses
+	// the same ordered physical sources as media.browse.
 	if params.Path == nil || *params.Path == "" {
-		return emptyBrowseIndex(), nil
+		rootView := browseRootViewRoutes
+		if params.RootView != nil {
+			rootView = *params.RootView
+		}
+		if rootView != browseRootViewContents {
+			return emptyBrowseIndex(), nil
+		}
+		if len(systems) != 1 {
+			return nil, models.ClientErrf("rootView contents requires exactly one system")
+		}
+		rootEntries, rootErr := resolveSystemRootEntries(&env, systems)
+		if rootErr != nil {
+			return nil, rootErr
+		}
+		sources, _ := systemRootContentsSources(&env, rootEntries)
+		if len(sources) == 0 {
+			return emptyBrowseIndex(), nil
+		}
+		started := time.Now()
+		result, indexErr := env.Database.MediaDB.BrowseIndex(env.Context, database.BrowseIndexOptions{
+			Overlay: &database.BrowseOverlay{Sources: sources},
+			Sort:    sortOrder,
+			Systems: systems,
+			Tags:    tagFilters,
+		})
+		logBrowseTiming("root_contents_index", "", started, len(result.Buckets))
+		if indexErr != nil {
+			return nil, fmt.Errorf("error building root contents browse index: %w", indexErr)
+		}
+		return buildBrowseIndexResponse(result, browseRootViewContents)
 	}
 
 	prefix, err := resolveBrowseIndexPrefix(&env, *params.Path)
@@ -190,14 +221,17 @@ func emptyBrowseIndex() models.BrowseIndexResults {
 	}
 }
 
-func buildBrowseIndexResponse(result database.BrowseIndexResult) (any, error) {
+func buildBrowseIndexResponse(
+	result database.BrowseIndexResult,
+	rootViews ...string,
+) (any, error) {
 	groups := make([]models.BrowseIndexGroup, 0, len(result.Buckets))
 	for i := range result.Buckets {
 		bucket := &result.Buckets[i]
 		var cursor string
 		if !bucket.AtStart {
 			encoded, err := encodeBrowseCursorWithMode(
-				bucket.LastID, bucket.SortValue, result.SortMode, result.TotalFiles,
+				bucket.LastID, bucket.SortValue, result.SortMode, result.TotalFiles, rootViews...,
 			)
 			if err != nil {
 				return nil, fmt.Errorf("failed to encode browse index cursor: %w", err)

--- a/pkg/api/methods/media_browse_index_test.go
+++ b/pkg/api/methods/media_browse_index_test.go
@@ -163,6 +163,67 @@ func TestHandleMediaBrowseIndex_VirtualPath(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowseIndex_RootContentsUsesOverlayScope(t *testing.T) {
+	t.Parallel()
+
+	root1 := browseTestAbsPath("configured")
+	root2 := browseTestAbsPath("default")
+	route1 := filepath.ToSlash(filepath.Join(root1, "SNES"))
+	route2 := filepath.ToSlash(filepath.Join(root2, "SNES"))
+	wantSources := []database.BrowseSource{
+		{PathPrefix: route1 + "/", IncludeDirs: true},
+		{PathPrefix: route2 + "/", IncludeDirs: true},
+	}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root1, root2})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
+	})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseSystemRootCandidates", mock.Anything, mock.Anything).
+		Return(database.BrowseSystemRootCandidates{}, true, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything, mock.Anything).
+		Return(map[string]database.BrowseRouteCount{
+			route1: {Path: route1, FileCount: 1, SystemIDs: []string{"SNES"}},
+			route2: {Path: route2, FileCount: 1, SystemIDs: []string{"SNES"}},
+		}, nil)
+	mockMediaDB.On("BrowseIndex", mock.Anything, mock.MatchedBy(func(opts database.BrowseIndexOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, wantSources, opts.Overlay.Sources) &&
+			len(opts.Systems) == 1 && opts.Systems[0].ID == "SNES"
+	})).Return(database.BrowseIndexResult{
+		Scheme:     "latin",
+		SortMode:   "name-asc",
+		TotalFiles: 2,
+		Buckets: []database.BrowseIndexBucket{
+			{Key: "A", AtStart: true, Count: 1},
+			{Key: "B", SortValue: "Beta", LastID: 7, Count: 1, Offset: 1},
+		},
+	}, nil)
+
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Systems:  &systems,
+		RootView: stringPtr(browseRootViewContents),
+	})
+	result, err := HandleMediaBrowseIndex(env)
+	require.NoError(t, err)
+	res, ok := result.(models.BrowseIndexResults)
+	require.True(t, ok)
+	require.Len(t, res.Groups, 2)
+
+	cursor, err := decodeBrowseCursor(res.Groups[1].Cursor)
+	require.NoError(t, err)
+	require.NotNil(t, cursor)
+	assert.Equal(t, browseRootViewContents, cursor.RootView)
+	assert.Equal(t, int64(7), cursor.LastID)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowseIndex_RootReturnsNoRail(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -318,6 +318,139 @@ func TestHandleMediaBrowse_RootContentsUsesOrderedPhysicalSources(t *testing.T) 
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_RootContentsPaginatesDirectories(t *testing.T) {
+	t.Parallel()
+
+	root := browseTestAbsPath("roms")
+	route := filepath.ToSlash(filepath.Join(root, "SNES"))
+	source := database.BrowseSource{PathPrefix: route + "/", IncludeDirs: true}
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
+	})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseSystemRootCandidates", mock.Anything, mock.Anything).
+		Return(database.BrowseSystemRootCandidates{}, true, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything, mock.Anything).
+		Return(map[string]database.BrowseRouteCount{
+			route: {Path: route, FileCount: 3, SystemIDs: []string{"SNES"}},
+		}, nil)
+	directoryOpts := mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, []database.BrowseSource{source}, opts.Overlay.Sources) &&
+			opts.Limit == 2
+	})
+	mockMediaDB.On("BrowseDirectories", mock.Anything, directoryOpts).Return([]database.BrowseDirectoryResult{
+		{Name: "Action", Path: route + "/Action", FileCount: 100, SystemIDs: []string{"SNES"}},
+		{Name: "RPG", Path: route + "/RPG", FileCount: 100, SystemIDs: []string{"SNES"}},
+	}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, mock.Anything).Return(2, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, mock.Anything).Return(1, nil)
+
+	systems := []string{"SNES"}
+	maxResults := 1
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Systems:    &systems,
+		RootView:   stringPtr(browseRootViewContents),
+		MaxResults: &maxResults,
+	})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+	res, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, res.Entries, 1)
+	require.NotNil(t, res.Pagination)
+	assert.True(t, res.Pagination.HasNextPage)
+	require.NotNil(t, res.Pagination.NextCursor)
+
+	cursor, err := decodeBrowseCursor(*res.Pagination.NextCursor)
+	require.NoError(t, err)
+	require.NotNil(t, cursor)
+	assert.Equal(t, browsePhaseDirs, cursor.Phase)
+	assert.Equal(t, "Action", cursor.DirName)
+	assert.Equal(t, browseRootViewContents, cursor.RootView)
+	assert.Equal(t, 2, cursor.TotalDirs)
+	assert.Equal(t, 1, cursor.TotalFiles)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaBrowse_RootContentsTransitionsFromDirectoriesToFiles(t *testing.T) {
+	t.Parallel()
+
+	root := browseTestAbsPath("roms")
+	route := filepath.ToSlash(filepath.Join(root, "SNES"))
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
+	})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseSystemRootCandidates", mock.Anything, mock.Anything).
+		Return(database.BrowseSystemRootCandidates{}, true, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything, mock.Anything).
+		Return(map[string]database.BrowseRouteCount{
+			route: {Path: route, FileCount: 2, SystemIDs: []string{"SNES"}},
+		}, nil)
+	mockMediaDB.On("BrowseDirectories", mock.Anything, mock.Anything).
+		Return([]database.BrowseDirectoryResult{
+			{Name: "Action", Path: route + "/Action", FileCount: 100, SystemIDs: []string{"SNES"}},
+		}, nil).Once()
+	mockMediaDB.On("BrowseDirCount", mock.Anything, mock.Anything).Return(1, nil).Once()
+	mockMediaDB.On("BrowseFileCount", mock.Anything, mock.Anything).Return(1, nil).Once()
+	mockMediaDB.On("BrowseFiles", mock.Anything, mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+		return opts.Cursor == nil && opts.Limit == 2 && opts.Overlay != nil
+	})).Return([]database.SearchResultWithCursor{
+		{MediaID: 9, SystemID: "SNES", Name: "Game", Path: route + "/Game.sfc"},
+	}, nil).Once()
+
+	systems := []string{"SNES"}
+	maxResults := 1
+	firstEnv := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Systems:    &systems,
+		RootView:   stringPtr(browseRootViewContents),
+		MaxResults: &maxResults,
+	})
+	firstResult, err := HandleMediaBrowse(firstEnv)
+	require.NoError(t, err)
+	firstPage, ok := firstResult.(models.BrowseResults)
+	require.True(t, ok)
+	require.NotNil(t, firstPage.Pagination)
+	require.NotNil(t, firstPage.Pagination.NextCursor)
+
+	transitionCursor, err := decodeBrowseCursor(*firstPage.Pagination.NextCursor)
+	require.NoError(t, err)
+	require.NotNil(t, transitionCursor)
+	assert.Equal(t, browsePhaseFiles, transitionCursor.Phase)
+	assert.Zero(t, transitionCursor.LastID)
+	assert.Equal(t, browseRootViewContents, transitionCursor.RootView)
+
+	secondEnv := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Systems:    &systems,
+		RootView:   stringPtr(browseRootViewContents),
+		MaxResults: &maxResults,
+		Cursor:     firstPage.Pagination.NextCursor,
+	})
+	secondResult, err := HandleMediaBrowse(secondEnv)
+	require.NoError(t, err)
+	secondPage, ok := secondResult.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, secondPage.Entries, 1)
+	assert.Equal(t, "Game", secondPage.Entries[0].Name)
+	assert.Equal(t, 1, secondPage.TotalDirs)
+	assert.Equal(t, 1, secondPage.TotalFiles)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -197,6 +197,127 @@ func TestHandleMediaBrowse_RootLevel(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestHandleMediaBrowse_RootContentsRequiresOneSystem(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+	mockMediaDB := helpers.NewMockMediaDBI()
+
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, map[string]any{"rootView": "contents"})
+	_, err := HandleMediaBrowse(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires exactly one system")
+}
+
+func TestHandleMediaBrowse_RejectsRootContentsCursorOutsideContentsView(t *testing.T) {
+	t.Parallel()
+
+	cursor, err := encodeDirCursor("RPGs", 10, 2, browseRootViewContents)
+	require.NoError(t, err)
+
+	tests := []struct {
+		params map[string]any
+		name   string
+	}{
+		{
+			name: "pathless default routes",
+			params: map[string]any{
+				"cursor":  cursor,
+				"systems": []string{"SNES"},
+			},
+		},
+		{
+			name: "filesystem path",
+			params: map[string]any{
+				"cursor": cursor,
+				"path":   browseTestAbsPath("roms", "SNES"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockPlatform := mocks.NewMockPlatform()
+			mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
+			env := newBrowseEnv(t, helpers.NewMockMediaDBI(), mockPlatform, tt.params)
+
+			_, browseErr := HandleMediaBrowse(env)
+			require.Error(t, browseErr)
+			assert.Contains(t, browseErr.Error(), "cursor does not match")
+		})
+	}
+}
+
+func TestHandleMediaBrowse_RootContentsUsesOrderedPhysicalSources(t *testing.T) {
+	t.Parallel()
+
+	root1 := browseTestAbsPath("configured")
+	root2 := browseTestAbsPath("default")
+	route1 := filepath.ToSlash(filepath.Join(root1, "SNES"))
+	route2 := filepath.ToSlash(filepath.Join(root2, "SNES"))
+	prefix1 := route1 + "/"
+	prefix2 := route2 + "/"
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("SupportedReaders", mock.Anything).Return(nil)
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{root1, root2})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{ID: "SNES", SystemID: "SNES", Folders: []string{"SNES"}},
+	})
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockMediaDB.On("BrowseSystemRootCandidates", mock.Anything, mock.Anything).
+		Return(database.BrowseSystemRootCandidates{}, true, nil)
+	mockMediaDB.On("BrowseVirtualSchemes", mock.Anything, browseVirtualSchemesSystemOpts(t, "SNES")).
+		Return([]database.BrowseVirtualScheme{}, nil)
+	mockMediaDB.On("BrowseRouteCounts", mock.Anything, mock.Anything).
+		Return(map[string]database.BrowseRouteCount{
+			route1: {Path: route1, FileCount: 2, SystemIDs: []string{"SNES"}},
+			route2: {Path: route2, FileCount: 2, SystemIDs: []string{"SNES"}},
+		}, nil)
+
+	wantSources := []database.BrowseSource{
+		{PathPrefix: prefix1, IncludeDirs: true},
+		{PathPrefix: prefix2, IncludeDirs: true},
+	}
+	directoryOpts := mock.MatchedBy(func(opts database.BrowseDirectoriesOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, wantSources, opts.Overlay.Sources) &&
+			opts.Limit == defaultMaxResults+1
+	})
+	mockMediaDB.On("BrowseDirectories", mock.Anything, directoryOpts).Return([]database.BrowseDirectoryResult{{
+		Name: "RPGs", Path: route1 + "/RPGs", FileCount: 100, SystemIDs: []string{"SNES"},
+	}}, nil)
+	mockMediaDB.On("BrowseDirCount", mock.Anything, mock.MatchedBy(func(opts database.BrowseDirCountOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, wantSources, opts.Overlay.Sources)
+	})).Return(1, nil)
+	mockMediaDB.On("BrowseFileCount", mock.Anything, mock.MatchedBy(func(opts database.BrowseFileCountOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, wantSources, opts.Overlay.Sources)
+	})).Return(1, nil)
+	mockMediaDB.On("BrowseFiles", mock.Anything, mock.MatchedBy(func(opts *database.BrowseFilesOptions) bool {
+		return opts.Overlay != nil && assert.Equal(t, wantSources, opts.Overlay.Sources)
+	})).Return([]database.SearchResultWithCursor{{
+		MediaID: 7, SystemID: "SNES", Name: "Game", Path: route2 + "/Game.sfc",
+	}}, nil)
+
+	systems := []string{"SNES"}
+	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
+		Systems:  &systems,
+		RootView: stringPtr(browseRootViewContents),
+	})
+	result, err := HandleMediaBrowse(env)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+	assert.Equal(t, route1+"/RPGs", browseResults.Entries[0].Path)
+	assert.Equal(t, route2+"/Game.sfc", browseResults.Entries[1].Path)
+	assert.Equal(t, 1, browseResults.TotalDirs)
+	assert.Equal(t, 1, browseResults.TotalFiles)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestHandleMediaBrowse_SystemRootRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -513,6 +634,70 @@ func TestHandleMediaBrowse_SystemRootRoutesUsesCachedCandidates(t *testing.T) {
 	mockMediaDB.AssertExpectations(t)
 }
 
+func TestBuildMediaEntry_RelativePathSemantics(t *testing.T) {
+	t.Parallel()
+
+	root1 := browseTestAbsPath("root1")
+	root2 := browseTestAbsPath("root2")
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).
+		Return([]string{root1, root2}).Times(3)
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "primary", SystemID: "SNES", Folders: []string{"SNES"}},
+		{ID: "alternate", SystemID: "SNES", Folders: []string{"AltSNES"}},
+	})
+	baseEnv := &requests.RequestEnv{
+		Platform:      mockPlatform,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
+	}
+
+	tests := []struct {
+		env     *requests.RequestEnv
+		wantRel *string
+		name    string
+		path    string
+	}{
+		{
+			name:    "second root and launcher folder converts",
+			env:     baseEnv,
+			path:    filepath.Join(root2, "AltSNES", "Game.sfc"),
+			wantRel: stringPtr("SNES/Game.sfc"),
+		},
+		{name: "unmatched absolute path omitted", env: baseEnv, path: browseTestAbsPath("other", "Game.sfc")},
+		{name: "virtual URI omitted", env: baseEnv, path: "steam://123"},
+		{
+			name: "missing platform omitted",
+			env:  &requests.RequestEnv{LauncherCache: launcherCache},
+			path: filepath.Join(root1, "SNES", "Game.sfc"),
+		},
+		{
+			name: "missing launcher cache omitted",
+			env:  &requests.RequestEnv{Platform: mockPlatform, Config: &config.Instance{}},
+			path: filepath.Join(root1, "SNES", "Game.sfc"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := database.SearchResultWithCursor{
+				MediaID: 1, SystemID: "SNES", Name: "Game", Path: tt.path,
+			}
+			entry := buildMediaEntry(&result, tt.env)
+			assert.Equal(t, tt.path, entry.Path)
+			require.NotNil(t, entry.ZapScript)
+			if tt.wantRel == nil {
+				assert.Nil(t, entry.RelPath)
+			} else {
+				require.NotNil(t, entry.RelPath)
+				assert.Equal(t, *tt.wantRel, *entry.RelPath)
+			}
+		})
+	}
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -542,15 +727,22 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	mockMediaDB := helpers.NewMockMediaDBI()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Once()
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{"roms"}).Once()
 	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
 	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
 		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
 		Return(alias, nil).Once()
 
+	launcherCache := &phelpers.LauncherCache{}
+	launcherCache.InitializeFromSlice([]platforms.Launcher{{
+		ID: "NES", SystemID: "NES", Folders: []string{"NES"},
+	}})
 	env := &requests.RequestEnv{
-		Context:  context.Background(),
-		Database: &database.Database{MediaDB: mockMediaDB},
-		Platform: mockPlatform,
+		Context:       context.Background(),
+		Database:      &database.Database{MediaDB: mockMediaDB},
+		Platform:      mockPlatform,
+		Config:        &config.Instance{},
+		LauncherCache: launcherCache,
 	}
 	result, err := buildBrowseResponse(env, path,
 		[]database.BrowseDirectoryResult{{Name: dirName, FileCount: 1, SystemIDs: []string{"NES"}}},
@@ -566,6 +758,8 @@ func TestBuildBrowseResponse_SingletonAnnotation_WhenZipsAsDirsEnabled(t *testin
 	assert.Equal(t, "NES", *entry.SystemID)
 	require.NotNil(t, entry.ZapScript)
 	assert.NotEmpty(t, *entry.ZapScript)
+	require.NotNil(t, entry.RelPath)
+	assert.Equal(t, "NES/Game.zip/Game.nes", *entry.RelPath)
 	assert.Equal(t, tags, entry.Tags)
 	assert.True(t, entry.HasCover)
 	mockMediaDB.AssertExpectations(t)

--- a/pkg/api/models/params.go
+++ b/pkg/api/models/params.go
@@ -42,6 +42,7 @@ type BrowseParams struct {
 	Systems     *[]string `json:"systems" validate:"omitempty,dive,min=1"`
 	FuzzySystem *bool     `json:"fuzzySystem,omitempty"`
 	Path        *string   `json:"path,omitempty"`
+	RootView    *string   `json:"rootView,omitempty" validate:"omitempty,oneof=routes contents"`
 	MaxResults  *int      `json:"maxResults,omitempty" validate:"omitempty,gt=0,max=1000"`
 	Cursor      *string   `json:"cursor,omitempty"`
 	Tags        *[]string `json:"tags,omitempty" validate:"omitempty,dive,min=1"`

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -389,6 +389,7 @@ func GroupTagFiltersByOperator(filters []zapscript.TagFilter) (and, not, or []za
 // BrowseDirectoryResult represents a subdirectory found during browse navigation.
 type BrowseDirectoryResult struct {
 	Name      string
+	Path      string
 	SystemIDs []string
 	FileCount int
 }
@@ -421,6 +422,7 @@ type SingletonAliasCandidate struct {
 // directories returned; 0 means no limit (full listing).
 type BrowseDirectoriesOptions struct {
 	PathPrefix string
+	Overlay    *BrowseOverlay
 	AfterName  string
 	Systems    []systemdefs.System
 	Limit      int
@@ -429,6 +431,7 @@ type BrowseDirectoriesOptions struct {
 // BrowseDirCountOptions contains parameters for the BrowseDirCount query.
 type BrowseDirCountOptions struct {
 	PathPrefix string
+	Overlay    *BrowseOverlay
 	Systems    []systemdefs.System
 }
 
@@ -444,16 +447,30 @@ type BrowseCursor struct {
 	SortMode   string
 	Phase      string
 	DirName    string
+	RootView   string
 	LastID     int64
 	TotalFiles int
 	TotalDirs  int
 }
 
 // BrowseFilesOptions contains parameters for the BrowseFiles query.
+// BrowseSource is one ordered physical directory contributing to a pathless
+// system-root contents view. Earlier sources have higher overlay priority.
+// IncludeDirs is false for an ancestor route retained only for direct media.
+type BrowseSource struct {
+	PathPrefix  string
+	IncludeDirs bool
+}
+
+type BrowseOverlay struct {
+	Sources []BrowseSource
+}
+
 type BrowseFilesOptions struct {
 	Cursor     *BrowseCursor
 	Letter     *string
 	PathPrefix string
+	Overlay    *BrowseOverlay
 	Sort       string
 	Systems    []systemdefs.System
 	Tags       []zapscript.TagFilter
@@ -464,6 +481,7 @@ type BrowseFilesOptions struct {
 type BrowseFileCountOptions struct {
 	Letter     *string
 	PathPrefix string
+	Overlay    *BrowseOverlay
 	Systems    []systemdefs.System
 	Tags       []zapscript.TagFilter
 }
@@ -473,6 +491,7 @@ type BrowseFileCountOptions struct {
 // exact list a media.browse call would return.
 type BrowseIndexOptions struct {
 	PathPrefix string
+	Overlay    *BrowseOverlay
 	Sort       string
 	Systems    []systemdefs.System
 	Tags       []zapscript.TagFilter

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -453,7 +453,6 @@ type BrowseCursor struct {
 	TotalDirs  int
 }
 
-// BrowseFilesOptions contains parameters for the BrowseFiles query.
 // BrowseSource is one ordered physical directory contributing to a pathless
 // system-root contents view. Earlier sources have higher overlay priority.
 // IncludeDirs is false for an ancestor route retained only for direct media.
@@ -466,6 +465,7 @@ type BrowseOverlay struct {
 	Sources []BrowseSource
 }
 
+// BrowseFilesOptions contains parameters for the BrowseFiles query.
 type BrowseFilesOptions struct {
 	Cursor     *BrowseCursor
 	Letter     *string

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2449,7 +2449,8 @@ func (db *MediaDB) GetMediaCoverStatus(
 
 // BrowseFileCount returns the total number of immediate child files under a path prefix.
 func (db *MediaDB) BrowseFileCount(
-	ctx context.Context, opts database.BrowseFileCountOptions,
+	ctx context.Context,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // interface keeps browse option values consistent
 ) (int, error) {
 	if db.sql.Load() == nil {
 		return 0, ErrNullSQL

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -546,11 +546,22 @@ func splitBrowseSystemIDs(ids string) []string {
 	return uniqueBrowseSystemIDs(strings.Split(ids, ","))
 }
 
+func browseOverlaySources(overlay *database.BrowseOverlay) []database.BrowseSource {
+	if overlay == nil {
+		return nil
+	}
+	return overlay.Sources
+}
+
 func sqlBrowseDirectories(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
+	if len(browseOverlaySources(opts.Overlay)) > 0 {
+		return sqlBrowseOverlayDirectories(ctx, db, opts)
+	}
+
 	ready, err := sqlBrowseCacheReady(ctx, db)
 	if err != nil {
 		return nil, err
@@ -575,6 +586,103 @@ func sqlBrowseDirectories(
 		return fallback, nil
 	}
 	return sqlBrowseDirectoriesFromMediaFallback(ctx, db, opts)
+}
+
+func sqlBrowseOverlayDirectories(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
+	sources := browseOverlaySources(opts.Overlay)
+	values := make([]string, len(sources))
+	args := make([]any, 0, len(sources)+16)
+	for i := range sources {
+		values[i] = "(?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
+	}
+
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+		matched_dirs AS (
+			SELECT sources.parent_dir,
+				sources.priority,
+				substr(m.Path, length(sources.parent_dir) + 1) AS rest,
+				s.SystemID
+			FROM sources
+			INNER JOIN Media m
+				ON m.Path >= sources.parent_dir
+				AND m.Path < sources.parent_dir || char(1114111)
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE sources.include_dirs = 1 AND m.IsMissing = 0`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += `
+		), directory_candidates AS (
+			SELECT parent_dir,
+				priority,
+				substr(rest, 1, instr(rest, '/') - 1) AS name,
+				COUNT(*) AS file_count,
+				GROUP_CONCAT(DISTINCT SystemID) AS system_ids
+			FROM matched_dirs
+			WHERE instr(rest, '/') > 0
+			GROUP BY parent_dir, priority, name
+		), direct_files AS (
+			SELECT sources.priority,
+				substr(m.Path, length(m.ParentDir) + 1) AS name
+			FROM sources
+			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE m.IsMissing = 0`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += `
+		), ranked AS (
+			SELECT directory_candidates.*,
+				ROW_NUMBER() OVER (PARTITION BY name ORDER BY priority ASC) AS source_rank
+			FROM directory_candidates
+			WHERE NOT EXISTS (
+				SELECT 1 FROM direct_files
+				WHERE direct_files.priority < directory_candidates.priority
+					AND direct_files.name = directory_candidates.name
+			)
+		)
+		SELECT name, file_count, system_ids, parent_dir || name
+		FROM ranked
+		WHERE source_rank = 1`
+	if opts.AfterName != "" {
+		query += ` AND name > ?`
+		args = append(args, opts.AfterName)
+	}
+	query += ` ORDER BY name ASC`
+	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
+		query += limitClause
+		args = append(args, limitArgs...)
+	}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse overlay directories query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.BrowseDirectoryResult
+	for rows.Next() {
+		var result database.BrowseDirectoryResult
+		var systemIDs string
+		if scanErr := rows.Scan(&result.Name, &result.FileCount, &systemIDs, &result.Path); scanErr != nil {
+			return nil, fmt.Errorf("browse overlay directories scan: %w", scanErr)
+		}
+		result.SystemIDs = splitBrowseSystemIDs(systemIDs)
+		results = append(results, result)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse overlay directories rows: %w", rowsErr)
+	}
+	return results, nil
 }
 
 func sqlBrowseDirectoriesFromMediaFallback(
@@ -822,18 +930,23 @@ func browsePathPrefixCondition(column, pathPrefix string) (condition string, arg
 	return column + ` LIKE ? || '%'`, []any{pathPrefix}
 }
 
-func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
+func browseFilesFilterCondition(
+	opts *database.BrowseFilesOptions,
+	includeParent bool,
+) (where string, args []any) {
 	letterClauses, letterArgs := BuildLetterFilterSQL(opts.Letter, "m.SortName")
 	// Most browse scopes are bounded enough for correlated candidate probes.
 	// Required favorites are exceptionally sparse in production, so drive from
 	// that reverse-index set and probe any remaining filters per candidate.
 	tagClauses, tagArgs := buildBrowseTagFilterSQL(opts.Tags, "m")
 	conditions := make([]string, 0, 3+len(letterClauses)+len(tagClauses))
-	conditions = append(conditions, `m.ParentDir = ?`, `m.IsMissing = 0`)
+	if includeParent {
+		conditions = append(conditions, `m.ParentDir = ?`)
+		args = append(args, opts.PathPrefix)
+	}
+	conditions = append(conditions, `m.IsMissing = 0`)
 	conditions = append(conditions, letterClauses...)
 
-	args = make([]any, 0, 1+len(letterArgs)+len(tagArgs))
-	args = append(args, opts.PathPrefix)
 	args = append(args, letterArgs...)
 	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
 		conditions = append(conditions, systemClause)
@@ -843,6 +956,10 @@ func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, 
 	args = append(args, tagArgs...)
 
 	return strings.Join(conditions, " AND "), args
+}
+
+func browseFilesBaseCondition(opts *database.BrowseFilesOptions) (where string, args []any) {
+	return browseFilesFilterCondition(opts, true)
 }
 
 func browseFilenameExpr() string {
@@ -1017,7 +1134,121 @@ func sqlBrowseFiles(
 	db sqlQueryable,
 	opts *database.BrowseFilesOptions,
 ) ([]database.SearchResultWithCursor, error) {
+	if len(browseOverlaySources(opts.Overlay)) > 0 {
+		return sqlBrowseOverlayFilesFromMedia(ctx, db, opts)
+	}
 	return sqlBrowseFilesFromMedia(ctx, db, opts)
+}
+
+const overlayHigherPriorityDirectoryCondition = `NOT EXISTS (
+	SELECT 1
+	FROM sources higher
+	INNER JOIN Media descendant ON descendant.IsMissing = 0
+	WHERE higher.priority < sources.priority
+		AND higher.include_dirs = 1
+		AND descendant.ParentDir >= higher.parent_dir || substr(m.Path, length(m.ParentDir) + 1) || '/'
+		AND descendant.ParentDir < higher.parent_dir || substr(m.Path, length(m.ParentDir) + 1) || '/' || char(1114111)
+)`
+
+func sqlBrowseOverlayFilesFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts *database.BrowseFilesOptions,
+) ([]database.SearchResultWithCursor, error) {
+	sources := browseOverlaySources(opts.Overlay)
+	values := make([]string, len(sources))
+	args := make([]any, 0, len(sources)+16)
+	for i := range sources {
+		values[i] = "(?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
+	}
+
+	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		winnerConditions = append(winnerConditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+		 ranked AS (
+			SELECT m.DBID,
+				ROW_NUMBER() OVER (
+					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
+					ORDER BY sources.priority ASC, m.DBID ASC
+				) AS source_rank
+			FROM sources
+			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE ` + strings.Join(winnerConditions, " AND ") + `
+		)`
+
+	filterOpts := *opts
+	filterOpts.Systems = nil
+	where, filterArgs := browseFilesFilterCondition(&filterOpts, false)
+	args = append(args, filterArgs...)
+	sortMode := opts.Sort
+	sortExpr := "m.SortName"
+	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
+		sortExpr = browseFilenameExpr()
+	}
+	query += ` SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+		mt.DisambiguationTypes, ` + sortExpr + ` AS SortValue
+		FROM ranked
+		INNER JOIN Media m ON m.DBID = ranked.DBID
+		INNER JOIN Systems s ON m.SystemDBID = s.DBID
+		INNER JOIN MediaTitles mt ON mt.DBID = m.MediaTitleDBID
+		WHERE ranked.source_rank = 1 AND ` + where
+	if opts.Cursor != nil {
+		op := ">"
+		if opts.Sort == "name-desc" || opts.Sort == "filename-desc" {
+			op = "<"
+		}
+		query += ` AND (` + sortExpr + `, m.DBID) ` + op + ` (?, ?)`
+		args = append(args, opts.Cursor.SortValue, opts.Cursor.LastID)
+	}
+	direction := "ASC"
+	if opts.Sort == "name-desc" || opts.Sort == "filename-desc" {
+		direction = "DESC"
+	}
+	query += ` ORDER BY ` + sortExpr + ` ` + direction + `, m.DBID ` + direction + ` LIMIT ?`
+	args = append(args, opts.Limit)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("browse overlay files query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []database.SearchResultWithCursor
+	for rows.Next() {
+		var r database.SearchResultWithCursor
+		if scanErr := rows.Scan(
+			&r.SystemID, &r.Name, &r.Path, &r.MediaID, &r.MediaTitleID, &r.DisambiguationTypes, &r.SortValue,
+		); scanErr != nil {
+			return nil, fmt.Errorf("browse overlay files scan: %w", scanErr)
+		}
+		if r.Name == "" {
+			base := filepath.Base(r.Path)
+			if ext := filepath.Ext(base); ext != "" {
+				base = base[:len(base)-len(ext)]
+			}
+			r.Name = base
+		}
+		r.SortMode = sortMode
+		results = append(results, r)
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return nil, fmt.Errorf("browse overlay files rows: %w", rowsErr)
+	}
+	if err = fetchAndAttachUtilityTags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse overlay files tags: %w", err)
+	}
+	if err = fetchAndAttachCoverFlags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse overlay files cover flags: %w", err)
+	}
+	if err = attachZapScriptTags(ctx, db, results); err != nil {
+		return nil, fmt.Errorf("browse overlay files disambiguation: %w", err)
+	}
+	return results, nil
 }
 
 func sqlBrowseFilesFromMedia(
@@ -1550,8 +1781,12 @@ func fetchAndAttachUtilityTags(
 func sqlBrowseFileCount(
 	ctx context.Context,
 	db sqlQueryable,
-	opts database.BrowseFileCountOptions,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
 ) (int, error) {
+	if len(browseOverlaySources(opts.Overlay)) > 0 {
+		return sqlBrowseOverlayFileCount(ctx, db, opts)
+	}
+
 	// Letter and tag scopes need row-level predicates absent from compact cache.
 	// Unfiltered directory totals can use v3's parent=self direct-file rows.
 	if opts.Letter == nil && len(opts.Tags) == 0 && browseRouteCacheKey(opts.PathPrefix) != "/" {
@@ -1569,10 +1804,56 @@ func sqlBrowseFileCount(
 	return sqlBrowseFileCountFromMedia(ctx, db, opts)
 }
 
+func sqlBrowseOverlayFileCount(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
+) (int, error) {
+	sources := browseOverlaySources(opts.Overlay)
+	values := make([]string, len(sources))
+	args := make([]any, 0, len(sources)+16)
+	for i := range sources {
+		values[i] = "(?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
+	}
+	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		winnerConditions = append(winnerConditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+	filterOpts := &database.BrowseFilesOptions{
+		Letter: opts.Letter,
+		Tags:   opts.Tags,
+	}
+	where, filterArgs := browseFilesFilterCondition(filterOpts, false)
+	args = append(args, filterArgs...)
+	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+		ranked AS (
+			SELECT m.DBID,
+				ROW_NUMBER() OVER (
+					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
+					ORDER BY sources.priority ASC, m.DBID ASC
+				) AS source_rank
+			FROM sources
+			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE ` + strings.Join(winnerConditions, " AND ") + `
+		)
+		SELECT COUNT(*)
+		FROM ranked
+		INNER JOIN Media m ON m.DBID = ranked.DBID
+		WHERE ranked.source_rank = 1 AND ` + where
+	var count int
+	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("browse overlay file count: %w", err)
+	}
+	return count, nil
+}
+
 func sqlBrowseDirectFileCountFromCache(
 	ctx context.Context,
 	db sqlQueryable,
-	opts database.BrowseFileCountOptions,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
 ) (count int, cacheUsable bool, err error) {
 	covered, err := sqlBrowseCacheCoversSystems(ctx, db, opts.Systems)
 	if err != nil || !covered {
@@ -1639,7 +1920,7 @@ func sqlBrowseCacheCoversSystems(
 func sqlBrowseFileCountFromMedia(
 	ctx context.Context,
 	db sqlQueryable,
-	opts database.BrowseFileCountOptions,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
 ) (int, error) {
 	where, args := browseFilesBaseCondition(&database.BrowseFilesOptions{
 		PathPrefix: opts.PathPrefix,
@@ -1667,6 +1948,14 @@ func sqlBrowseDirCount(
 	db sqlQueryable,
 	opts database.BrowseDirCountOptions,
 ) (int, error) {
+	if len(browseOverlaySources(opts.Overlay)) > 0 {
+		dirs, overlayErr := sqlBrowseOverlayDirectories(ctx, db, database.BrowseDirectoriesOptions{
+			Overlay: opts.Overlay,
+			Systems: opts.Systems,
+		})
+		return len(dirs), overlayErr
+	}
+
 	ready, err := sqlBrowseCacheReady(ctx, db)
 	if err != nil {
 		return 0, err
@@ -1784,6 +2073,10 @@ func sqlBrowseIndex(
 	db sqlQueryable,
 	opts *database.BrowseIndexOptions,
 ) (database.BrowseIndexResult, error) {
+	if len(browseOverlaySources(opts.Overlay)) > 0 {
+		return sqlBrowseOverlayIndex(ctx, db, opts)
+	}
+
 	filesOpts := &database.BrowseFilesOptions{
 		PathPrefix: opts.PathPrefix,
 		Sort:       opts.Sort,
@@ -1875,6 +2168,111 @@ func sqlBrowseIndex(
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
 		return database.BrowseIndexResult{}, fmt.Errorf("browse index rows: %w", rowsErr)
+	}
+	return result, nil
+}
+
+func sqlBrowseOverlayIndex(
+	ctx context.Context,
+	db sqlQueryable,
+	opts *database.BrowseIndexOptions,
+) (database.BrowseIndexResult, error) {
+	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
+		total, err := sqlBrowseOverlayFileCount(ctx, db, database.BrowseFileCountOptions{
+			Overlay: opts.Overlay,
+			Systems: opts.Systems,
+			Tags:    opts.Tags,
+		})
+		if err != nil {
+			return database.BrowseIndexResult{}, err
+		}
+		return database.BrowseIndexResult{
+			Scheme:     browseIndexSchemeNone,
+			SortMode:   opts.Sort,
+			TotalFiles: total,
+		}, nil
+	}
+
+	sources := browseOverlaySources(opts.Overlay)
+	values := make([]string, len(sources))
+	args := make([]any, 0, len(sources)+16)
+	for i := range sources {
+		values[i] = "(?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
+	}
+	winnerConditions := []string{"m.IsMissing = 0", overlayHigherPriorityDirectoryCondition}
+	if systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems); systemClause != "" {
+		winnerConditions = append(winnerConditions, systemClause)
+		args = append(args, systemArgs...)
+	}
+	filterOpts := &database.BrowseFilesOptions{Tags: opts.Tags}
+	where, filterArgs := browseFilesFilterCondition(filterOpts, false)
+	args = append(args, filterArgs...)
+	desc := opts.Sort == "name-desc"
+	direction := "ASC"
+	if desc {
+		direction = "DESC"
+	}
+	bucketExpr := browseBucketKeyExpr("m.SortName")
+	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+		ranked AS (
+			SELECT m.DBID,
+				ROW_NUMBER() OVER (
+					PARTITION BY substr(m.Path, length(m.ParentDir) + 1)
+					ORDER BY sources.priority ASC, m.DBID ASC
+				) AS source_rank
+			FROM sources
+			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE ` + strings.Join(winnerConditions, " AND ") + `
+		), ordered AS (
+			SELECT ` + bucketExpr + ` AS bucket,
+				m.SortName AS sortValue,
+				m.DBID AS dbid,
+				ROW_NUMBER() OVER (ORDER BY m.SortName ` + direction + `, m.DBID ` + direction + `) AS rn
+			FROM ranked
+			INNER JOIN Media m ON m.DBID = ranked.DBID
+			WHERE ranked.source_rank = 1 AND ` + where + `
+		), counts AS (
+			SELECT bucket, COUNT(*) AS n, MIN(rn) AS first_rn FROM ordered GROUP BY bucket
+		)
+		SELECT o.bucket, o.sortValue, o.dbid, c.n, c.first_rn
+		FROM ordered o
+		INNER JOIN counts c ON c.bucket = o.bucket AND c.first_rn = o.rn
+		ORDER BY o.rn`
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return database.BrowseIndexResult{}, fmt.Errorf("browse overlay index query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := database.BrowseIndexResult{
+		Scheme:   browseIndexSchemeLatin,
+		SortMode: opts.Sort,
+	}
+	for rows.Next() {
+		var bucket, sortValue string
+		var dbid, firstRN int64
+		var count int
+		if scanErr := rows.Scan(&bucket, &sortValue, &dbid, &count, &firstRN); scanErr != nil {
+			return database.BrowseIndexResult{}, fmt.Errorf("browse overlay index scan: %w", scanErr)
+		}
+		cursorID := dbid - 1
+		if desc {
+			cursorID = dbid + 1
+		}
+		result.Buckets = append(result.Buckets, database.BrowseIndexBucket{
+			Key:       bucket,
+			SortValue: sortValue,
+			LastID:    cursorID,
+			Count:     count,
+			Offset:    int(firstRN - 1),
+			AtStart:   len(result.Buckets) == 0,
+		})
+		result.TotalFiles += count
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return database.BrowseIndexResult{}, fmt.Errorf("browse overlay index rows: %w", rowsErr)
 	}
 	return result, nil
 }

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -1590,6 +1590,23 @@ func TestBrowseOverlayFiles_FirstRootWinsByFilesystemName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 3, count)
 
+	dirCount, err := mediaDB.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, dirCount)
+
+	filenameIndex, err := mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Sort:    "filename-asc",
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, browseIndexSchemeNone, filenameIndex.Scheme)
+	assert.Equal(t, 3, filenameIndex.TotalFiles)
+	assert.Empty(t, filenameIndex.Buckets)
+
 	index, err := mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
 		Overlay: &database.BrowseOverlay{Sources: sources},
 		Systems: []systemdefs.System{*nesSystem},

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -24,6 +24,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,6 +39,24 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type queryCountingDB struct {
+	sqlQueryable
+	queryCalls int
+}
+
+func (db *queryCountingDB) QueryContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (*sql.Rows, error) {
+	db.queryCalls++
+	rows, err := db.sqlQueryable.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("counted query: %w", err)
+	}
+	return rows, nil
+}
 
 func browseTestPath(parts ...string) string {
 	return filepath.ToSlash(filepath.Join(append([]string{string(filepath.Separator)}, parts...)...))
@@ -1460,4 +1479,126 @@ func TestBrowseFiles_SortNameFallback_Integration(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, "mygame", results[0].Name,
 		"SortName='' should fall back to filename-without-extension")
+}
+
+func TestBrowseOverlayFiles_FirstRootWinsByFilesystemName(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	root1 := browseTestDir("configured", "NES")
+	root2 := browseTestDir("default", "NES")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insert := func(name, path string) database.Media {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+path),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		row, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           path,
+			ParentDir:      filepath.ToSlash(filepath.Dir(path)) + "/",
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+		return row
+	}
+	winner := insert("Configured Copy", root1+"Game.nes")
+	insert("Default Copy", root2+"Game.nes")
+	insert("Inside Folder", root1+"Folder/Inside.nes")
+	insert("Hidden By Folder", root2+"Folder")
+	shadowFile := insert("Shadow File", root1+"Shadow")
+	insert("Hidden Directory Media", root2+"Shadow/Inside.nes")
+	insert("Visible Directory Media", root2+"Visible/Inside.nes")
+	unique := insert("Unique", root2+"Unique.nes")
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	sources := []database.BrowseSource{
+		{PathPrefix: root1, IncludeDirs: true},
+		{PathPrefix: root2, IncludeDirs: true},
+	}
+	results, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+		Limit:   10,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t,
+		[]int64{winner.DBID, shadowFile.DBID, unique.DBID},
+		[]int64{results[0].MediaID, results[1].MediaID, results[2].MediaID},
+	)
+
+	secondPage, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+		Cursor: &database.BrowseCursor{
+			SortValue: results[1].SortValue,
+			LastID:    results[1].MediaID,
+		},
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
+	assert.Equal(t, unique.DBID, secondPage[0].MediaID)
+
+	dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	require.Len(t, dirs, 2)
+	assert.Equal(t, []string{"Folder", "Visible"}, []string{dirs[0].Name, dirs[1].Name})
+	assert.Equal(t, root1+"Folder", dirs[0].Path)
+	assert.Equal(t, root2+"Visible", dirs[1].Path)
+
+	queryCounter := &queryCountingDB{sqlQueryable: mediaDB.sql.Load()}
+	firstDirPage, err := sqlBrowseOverlayDirectories(ctx, queryCounter, database.BrowseDirectoriesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+		Limit:   1,
+	})
+	require.NoError(t, err)
+	require.Len(t, firstDirPage, 1)
+	assert.Equal(t, "Folder", firstDirPage[0].Name)
+	assert.Equal(t, 1, queryCounter.queryCalls)
+
+	secondDirPage, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		Overlay:   &database.BrowseOverlay{Sources: sources},
+		Systems:   []systemdefs.System{*nesSystem},
+		AfterName: firstDirPage[0].Name,
+		Limit:     1,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondDirPage, 1)
+	assert.Equal(t, "Visible", secondDirPage[0].Name)
+
+	count, err := mediaDB.BrowseFileCount(ctx, database.BrowseFileCountOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	index, err := mediaDB.BrowseIndex(ctx, database.BrowseIndexOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: []systemdefs.System{*nesSystem},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, browseIndexSchemeLatin, index.Scheme)
+	assert.Equal(t, 3, index.TotalFiles)
+	require.Len(t, index.Buckets, 3)
+	assert.Equal(t, []string{"C", "S", "U"}, []string{
+		index.Buckets[0].Key, index.Buckets[1].Key, index.Buckets[2].Key,
+	})
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -523,7 +523,9 @@ type Platform interface {
 	ScanHook(*tokens.Token) error
 	// SupportedReaders returns a list of supported reader modules for platform.
 	SupportedReaders(*config.Instance) []readers.Reader
-	// RootDirs returns a list of root folders to scan for media files.
+	// RootDirs returns root folders to scan for media files, ordered from
+	// highest to lowest priority. Consumers resolving duplicate relative names
+	// must prefer the first matching root.
 	RootDirs(*config.Instance) []string
 	// StopActiveLauncher kills/exits the currently running launcher process
 	// and clears the active media if it was successful.

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2737,7 +2737,8 @@ func (m *MockMediaDBI) GetMediaCoverStatus(
 }
 
 func (m *MockMediaDBI) BrowseFileCount(
-	ctx context.Context, opts database.BrowseFileCountOptions,
+	ctx context.Context,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // interface keeps browse option values consistent
 ) (int, error) {
 	args := m.Called(ctx, opts)
 	if count, ok := args.Get(0).(int); ok {


### PR DESCRIPTION
## Summary

- align `media.browse.relativePath` with shared media response semantics
- add opt-in, one-level `rootView: "contents"` overlays with first-root precedence
- support matching pagination, counts, browse indexes, cursor validation, and API documentation

Closes #1289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `rootView` setting for browsing system contents directly.
  * Added a unified contents view for single-system, pathless browsing across ordered filesystem roots.
  * Added pagination, filtering, sorting, directory counts, and index support for the contents view.
  * Updated `relativePath` to provide launcher-relative convenience paths when available.
* **Documentation**
  * Added guidance and examples for root views, duplicate handling, counts, and path behavior.
* **Bug Fixes**
  * Improved path handling for physical files and virtual entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->