### PR TITLE
fix(mediadb): serialize media write operations

### DIFF
--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -508,7 +508,7 @@ func GenerateMediaDB(
 	db *database.Database,
 	pauser *syncutil.Pauser,
 ) error {
-	return startMediaDBGeneration(ctx, pl, cfg, ns, systems, db, pauser, false)
+	return startMediaDBGeneration(ctx, pl, cfg, ns, systems, db, pauser, false, nil)
 }
 
 // GenerateMediaDBRebuild is GenerateMediaDB with a fresh start: the media
@@ -524,7 +524,48 @@ func GenerateMediaDBRebuild(
 	db *database.Database,
 	pauser *syncutil.Pauser,
 ) error {
-	return startMediaDBGeneration(ctx, pl, cfg, ns, systems, db, pauser, true)
+	return startMediaDBGeneration(ctx, pl, cfg, ns, systems, db, pauser, true, nil)
+}
+
+// GenerateMediaDBWithLease starts indexing with ownership atomically handed off
+// by another MediaDB operation, such as corruption recovery.
+func GenerateMediaDBWithLease(
+	ctx context.Context,
+	pl platforms.Platform,
+	cfg *config.Instance,
+	ns chan<- models.Notification,
+	systems []systemdefs.System,
+	db *database.Database,
+	pauser *syncutil.Pauser,
+	lease *database.MediaWriteLease,
+) error {
+	return startMediaDBGeneration(ctx, pl, cfg, ns, systems, db, pauser, false, lease)
+}
+
+func startPostIndexOptimization(
+	mediaDB database.MediaDBI,
+	lease *database.MediaWriteLease,
+	statusCallback func(optimizing bool),
+	pauser *syncutil.Pauser,
+) error {
+	coordinator, err := database.GetMediaDBWriteCoordinator(mediaDB)
+	if err != nil {
+		return fmt.Errorf("get media database write coordinator for optimization handoff: %w", err)
+	}
+	if err := lease.Handoff(database.MediaWriteOperationOptimization); err != nil {
+		return fmt.Errorf("handoff indexing to optimization: %w", err)
+	}
+
+	// Track wrapper before starting goroutine so Close cannot return before
+	// RunBackgroundOptimizationWithLease registers its internal work.
+	mediaDB.TrackBackgroundOperation()
+	go func() {
+		defer mediaDB.BackgroundOperationDone()
+		if err := coordinator.RunBackgroundOptimizationWithLease(statusCallback, pauser, lease); err != nil {
+			log.Error().Err(err).Msg("post-index background optimization failed")
+		}
+	}()
+	return nil
 }
 
 func startMediaDBGeneration(
@@ -536,10 +577,29 @@ func startMediaDBGeneration(
 	db *database.Database,
 	pauser *syncutil.Pauser,
 	rebuild bool,
+	lease *database.MediaWriteLease,
 ) error {
-	if err := startIndexingIfNoScrape(); err != nil {
-		return err
+	var err error
+	if lease == nil {
+		lease, err = startIndexing(db.MediaDB)
+		if err != nil {
+			return err
+		}
+	} else {
+		if !lease.ValidFor(database.MediaWriteOperationIndexing) {
+			return database.ErrMediaWriteLease
+		}
+		if !statusInstance.startIfNotRunning() {
+			lease.Release()
+			return models.ClientErrf("indexing already in progress")
+		}
 	}
+	leaseOwned := true
+	defer func() {
+		if leaseOwned {
+			lease.Release()
+		}
+	}()
 
 	notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 		Exists:             mediaDBHasUsableData(db.MediaDB),
@@ -591,7 +651,14 @@ func startMediaDBGeneration(
 	log.Info().Msg("generating media db")
 
 	db.MediaDB.TrackBackgroundOperation()
+	leaseOwned = false
 	go func() {
+		leaseTransferred := false
+		defer func() {
+			if !leaseTransferred {
+				lease.Release()
+			}
+		}()
 		defer db.MediaDB.BackgroundOperationDone()
 		defer debug.FreeOSMemory()
 
@@ -766,25 +833,21 @@ func startMediaDBGeneration(
 		runtime.GC()
 		debug.FreeOSMemory()
 
-		// Start background optimization with notification callback
-		// Index rebuilds, cache population, ANALYZE, and WAL checkpoint
-		// run as background steps so launches/searches aren't blocked.
-		// Track the optimization operation BEFORE starting the goroutine to prevent a race
-		// where Close() → Wait() could return between this goroutine's Done() and
-		// RunBackgroundOptimization's internal Add(). The wrapper ensures Done() is called
-		// even if RunBackgroundOptimization skips (e.g., already optimizing).
-		db.MediaDB.TrackBackgroundOperation()
-		go func() {
-			defer db.MediaDB.BackgroundOperationDone()
-			db.MediaDB.RunBackgroundOptimization(func(optimizing bool) {
-				notifications.MediaIndexing(ns, models.IndexingStatusResponse{
-					Exists:     true,
-					Indexing:   false,
-					Optimizing: optimizing,
-					TotalFiles: &total,
-				})
-			}, pauser)
-		}()
+		// Atomically hand indexing ownership to optimization so scraping cannot
+		// enter between completed indexing and post-index maintenance.
+		if handoffErr := startPostIndexOptimization(db.MediaDB, lease, func(optimizing bool) {
+			notifications.MediaIndexing(ns, models.IndexingStatusResponse{
+				Exists:     true,
+				Indexing:   false,
+				Optimizing: optimizing,
+				TotalFiles: &total,
+			})
+		}, pauser); handoffErr != nil {
+			log.Error().Err(handoffErr).Msg("failed to hand off indexing to background optimization")
+			statusInstance.clear()
+			return
+		}
+		leaseTransferred = true
 
 		statusInstance.clear()
 		log.Info().Msgf("finished generating media db in %v", time.Since(startTime))
@@ -840,23 +903,10 @@ func HandleGenerateMedia(env requests.RequestEnv) (any, error) {
 		systems = systemdefs.AllSystems()
 	}
 
-	// Additional validation for selective indexing
-	if isSelectiveIndexing {
-		// Check if optimization is running - this would conflict with selective indexing
-		optimizationStatus, err := env.Database.MediaDB.GetOptimizationStatus()
-		if err != nil {
-			return nil, fmt.Errorf("unable to verify optimization status for selective indexing: %w", err)
-		}
-		if optimizationStatus == "running" {
-			return nil, models.ClientErrf(
-				"selective indexing cannot be performed while database optimization is running",
-			)
-		}
-
-		// Ensure at least one system is specified for selective indexing
-		if len(systems) == 0 {
-			return nil, models.ClientErrf("at least one system must be specified for selective indexing")
-		}
+	// Ensure at least one resolved system is specified for selective indexing.
+	// Process-local lease ownership, not persisted optimization status, decides conflicts.
+	if isSelectiveIndexing && len(systems) == 0 {
+		return nil, models.ClientErrf("at least one system must be specified for selective indexing")
 	}
 
 	// Reconcile with current primary-media state before reporting initial

--- a/pkg/api/methods/media_clean_orphans.go
+++ b/pkg/api/methods/media_clean_orphans.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/rs/zerolog/log"
 )
@@ -37,7 +38,8 @@ func HandleMediaCleanOrphans(env requests.RequestEnv) (any, error) { //nolint:go
 
 	deleted, err := env.Database.MediaDB.CleanMediaOrphans(env.Context)
 	if err != nil {
-		if errors.Is(err, mediadb.ErrIndexingInProgress) ||
+		if errors.Is(err, database.ErrMediaWriteConflict) ||
+			errors.Is(err, mediadb.ErrIndexingInProgress) ||
 			errors.Is(err, mediadb.ErrOptimizationInProgress) ||
 			errors.Is(err, mediadb.ErrTransactionActive) {
 			return nil, models.ClientErrf("%w", err)

--- a/pkg/api/methods/media_operation_guard.go
+++ b/pkg/api/methods/media_operation_guard.go
@@ -20,34 +20,73 @@
 package methods
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
-	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 )
 
-var mediaOperationMu syncutil.Mutex
-
-func startIndexingIfNoScrape() error {
-	mediaOperationMu.Lock()
-	defer mediaOperationMu.Unlock()
-
-	if scrapingStatusInstance.isRunning() {
-		return models.ClientErrf("scraping is in progress")
-	}
-	if !statusInstance.startIfNotRunning() {
-		return models.ClientErrf("indexing already in progress")
-	}
-	return nil
+type mediaWriteClientConflictError struct {
+	cause   error
+	message string
 }
 
-func startScrapingIfNoIndex(scraperID string, force bool) error {
-	mediaOperationMu.Lock()
-	defer mediaOperationMu.Unlock()
+func (e *mediaWriteClientConflictError) Error() string { return e.message }
+func (e *mediaWriteClientConflictError) Unwrap() error { return e.cause }
 
-	if statusInstance.isRunning() {
-		return models.ClientErrf("media indexing is in progress")
+func mediaWriteClientError(err error, requested database.MediaWriteOperation) error {
+	var conflict *database.MediaWriteConflictError
+	if !errors.As(err, &conflict) {
+		return err
+	}
+
+	message := "media database maintenance in progress"
+	switch {
+	case conflict.Active == database.MediaWriteOperationIndexing && requested == database.MediaWriteOperationIndexing:
+		message = "indexing already in progress"
+	case conflict.Active == database.MediaWriteOperationIndexing:
+		message = "media indexing is in progress"
+	case conflict.Active == database.MediaWriteOperationScraping && requested == database.MediaWriteOperationScraping:
+		message = "scraping already in progress"
+	case conflict.Active == database.MediaWriteOperationScraping:
+		message = "scraping is in progress"
+	case conflict.Active == database.MediaWriteOperationOptimization:
+		message = "database optimization in progress"
+	}
+	return models.ClientErr(&mediaWriteClientConflictError{cause: err, message: message})
+}
+
+func startIndexing(mediaDB database.MediaDBI) (*database.MediaWriteLease, error) {
+	coordinator, err := database.GetMediaDBWriteCoordinator(mediaDB)
+	if err != nil {
+		return nil, fmt.Errorf("get media database write coordinator for indexing: %w", err)
+	}
+	lease, err := coordinator.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	if err != nil {
+		return nil, mediaWriteClientError(err, database.MediaWriteOperationIndexing)
+	}
+	if !statusInstance.startIfNotRunning() {
+		lease.Release()
+		return nil, models.ClientErrf("indexing already in progress")
+	}
+	return lease, nil
+}
+
+func startScraping(
+	mediaDB database.MediaDBI, scraperID string, force bool,
+) (*database.MediaWriteLease, error) {
+	coordinator, err := database.GetMediaDBWriteCoordinator(mediaDB)
+	if err != nil {
+		return nil, fmt.Errorf("get media database write coordinator for scraping: %w", err)
+	}
+	lease, err := coordinator.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	if err != nil {
+		return nil, mediaWriteClientError(err, database.MediaWriteOperationScraping)
 	}
 	if !scrapingStatusInstance.startIfNotRunning(scraperID, force) {
-		return models.ClientErrf("scraping already in progress")
+		lease.Release()
+		return nil, models.ClientErrf("scraping already in progress")
 	}
-	return nil
+	return lease, nil
 }

--- a/pkg/api/methods/media_operation_guard_test.go
+++ b/pkg/api/methods/media_operation_guard_test.go
@@ -20,6 +20,7 @@
 package methods
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -31,6 +32,87 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type mediaDBWithoutWriteCoordinator struct {
+	database.MediaDBI
+}
+
+func TestMediaWriteClientErrorMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		active    database.MediaWriteOperation
+		requested database.MediaWriteOperation
+		expected  string
+	}{
+		{
+			name:      "duplicate indexing",
+			active:    database.MediaWriteOperationIndexing,
+			requested: database.MediaWriteOperationIndexing,
+			expected:  "indexing already in progress",
+		},
+		{
+			name:      "indexing blocks scrape",
+			active:    database.MediaWriteOperationIndexing,
+			requested: database.MediaWriteOperationScraping,
+			expected:  "media indexing is in progress",
+		},
+		{
+			name:      "duplicate scraping",
+			active:    database.MediaWriteOperationScraping,
+			requested: database.MediaWriteOperationScraping,
+			expected:  "scraping already in progress",
+		},
+		{
+			name:      "scraping blocks index",
+			active:    database.MediaWriteOperationScraping,
+			requested: database.MediaWriteOperationIndexing,
+			expected:  "scraping is in progress",
+		},
+		{
+			name:      "optimization",
+			active:    database.MediaWriteOperationOptimization,
+			requested: database.MediaWriteOperationScraping,
+			expected:  "database optimization in progress",
+		},
+		{
+			name:      "maintenance fallback",
+			active:    database.MediaWriteOperationMaintenance,
+			requested: database.MediaWriteOperationIndexing,
+			expected:  "media database maintenance in progress",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conflict := &database.MediaWriteConflictError{Active: tt.active, Requested: tt.requested}
+			err := mediaWriteClientError(conflict, tt.requested)
+
+			assert.Equal(t, tt.expected, err.Error())
+			require.ErrorIs(t, err, database.ErrMediaWriteConflict)
+			var clientErr *models.ClientError
+			require.ErrorAs(t, err, &clientErr)
+		})
+	}
+
+	original := errors.New("coordinator failed")
+	assert.Same(t, original, mediaWriteClientError(original, database.MediaWriteOperationIndexing))
+}
+
+func TestMediaOperationGuardRequiresWriteCoordinator(t *testing.T) {
+	ClearIndexingStatus()
+	ClearScrapingStatus()
+	t.Cleanup(ClearIndexingStatus)
+	t.Cleanup(ClearScrapingStatus)
+
+	db := &mediaDBWithoutWriteCoordinator{}
+	lease, err := startIndexing(db)
+	assert.Nil(t, lease)
+	require.ErrorIs(t, err, database.ErrMediaWriteCoordinatorUnavailable)
+
+	lease, err = startScraping(db, "test-scraper", false)
+	assert.Nil(t, lease)
+	require.ErrorIs(t, err, database.ErrMediaWriteCoordinatorUnavailable)
+}
 
 func TestMediaOperationGuardOptimizationConflictsAreClientErrors(t *testing.T) {
 	// Shared API status instances make these tests intentionally non-parallel.
@@ -76,6 +158,47 @@ func TestMediaOperationGuardOptimizationConflictsAreClientErrors(t *testing.T) {
 			assert.Equal(t, tt.expectedMsg, err.Error())
 		})
 	}
+}
+
+func TestPostIndexOptimizationRequiresCoordinator(t *testing.T) {
+	mockDB := testhelpers.NewMockMediaDBI()
+	indexLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+	defer indexLease.Release()
+
+	err = startPostIndexOptimization(
+		&mediaDBWithoutWriteCoordinator{MediaDBI: mockDB}, indexLease, nil, nil,
+	)
+	require.ErrorIs(t, err, database.ErrMediaWriteCoordinatorUnavailable)
+	assert.True(t, indexLease.ValidFor(database.MediaWriteOperationIndexing))
+}
+
+func TestPostIndexOptimizationRejectsReleasedLease(t *testing.T) {
+	mockDB := testhelpers.NewMockMediaDBI()
+	indexLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+	indexLease.Release()
+
+	err = startPostIndexOptimization(mockDB, indexLease, nil, nil)
+	require.ErrorIs(t, err, database.ErrMediaWriteLease)
+	mockDB.AssertNotCalled(t, "TrackBackgroundOperation")
+}
+
+func TestGenerateMediaDBWithLeaseRejectsWrongOwner(t *testing.T) {
+	ClearIndexingStatus()
+	t.Cleanup(ClearIndexingStatus)
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	recoveryLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationRecovery)
+	require.NoError(t, err)
+	defer recoveryLease.Release()
+
+	err = GenerateMediaDBWithLease(
+		context.Background(), nil, nil, nil, nil,
+		&database.Database{MediaDB: mockDB}, nil, recoveryLease,
+	)
+	require.ErrorIs(t, err, database.ErrMediaWriteLease)
+	assert.True(t, recoveryLease.ValidFor(database.MediaWriteOperationRecovery))
 }
 
 func TestPostIndexOptimizationHandoffBlocksScraping(t *testing.T) {

--- a/pkg/api/methods/media_operation_guard_test.go
+++ b/pkg/api/methods/media_operation_guard_test.go
@@ -1,0 +1,151 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package methods
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaOperationGuardOptimizationConflictsAreClientErrors(t *testing.T) {
+	// Shared API status instances make these tests intentionally non-parallel.
+	ClearIndexingStatus()
+	ClearScrapingStatus()
+	t.Cleanup(ClearIndexingStatus)
+	t.Cleanup(ClearScrapingStatus)
+
+	tests := []struct {
+		start       func(database.MediaDBI) (*database.MediaWriteLease, error)
+		name        string
+		expectedMsg string
+	}{
+		{
+			name:        "indexing",
+			expectedMsg: "database optimization in progress",
+			start:       startIndexing,
+		},
+		{
+			name:        "scraping",
+			expectedMsg: "database optimization in progress",
+			start: func(db database.MediaDBI) (*database.MediaWriteLease, error) {
+				return startScraping(db, "test-scraper", false)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ClearIndexingStatus()
+			ClearScrapingStatus()
+			mockDB := testhelpers.NewMockMediaDBI()
+			optimizationLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+			require.NoError(t, err)
+			defer optimizationLease.Release()
+
+			lease, err := tt.start(mockDB)
+			assert.Nil(t, lease)
+			require.Error(t, err)
+			var clientErr *models.ClientError
+			require.ErrorAs(t, err, &clientErr)
+			require.ErrorIs(t, err, database.ErrMediaWriteConflict)
+			assert.Equal(t, tt.expectedMsg, err.Error())
+		})
+	}
+}
+
+func TestPostIndexOptimizationHandoffBlocksScraping(t *testing.T) {
+	mockDB := testhelpers.NewMockMediaDBI()
+	indexLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+
+	unblockOptimization := make(chan struct{})
+	optimizationDone := make(chan struct{})
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, indexLease).
+		Run(func(mock.Arguments) { <-unblockOptimization }).Return(nil).Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) { close(optimizationDone) }).Return().Once()
+
+	require.NoError(t, startPostIndexOptimization(mockDB, indexLease, nil, nil))
+	assert.Equal(t, database.MediaWriteOperationOptimization, mockDB.ActiveMediaWriteOperation())
+
+	scrapeLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	assert.Nil(t, scrapeLease)
+	require.ErrorIs(t, err, database.ErrMediaWriteConflict)
+
+	close(unblockOptimization)
+	select {
+	case <-optimizationDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-index optimization did not release ownership")
+	}
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
+	mockDB.AssertExpectations(t)
+}
+
+func TestPostIndexOptimizationFailedStartReleasesLease(t *testing.T) {
+	mockDB := testhelpers.NewMockMediaDBI()
+	indexLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+
+	optimizationDone := make(chan struct{})
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, indexLease).
+		Return(errors.New("injected optimization startup failure")).Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) { close(optimizationDone) }).Return().Once()
+
+	require.NoError(t, startPostIndexOptimization(mockDB, indexLease, nil, nil))
+	select {
+	case <-optimizationDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("failed post-index optimization did not finish")
+	}
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
+	mockDB.AssertExpectations(t)
+}
+
+func TestMediaOperationGuardReleasesLeaseWhenStatusClaimFails(t *testing.T) {
+	ClearIndexingStatus()
+	ClearScrapingStatus()
+	t.Cleanup(ClearIndexingStatus)
+	t.Cleanup(ClearScrapingStatus)
+
+	mockDB := testhelpers.NewMockMediaDBI()
+	statusInstance.setRunning(true)
+	lease, err := startIndexing(mockDB)
+	assert.Nil(t, lease)
+	require.Error(t, err)
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
+
+	statusInstance.clear()
+	scrapingStatusInstance.startIfNotRunning("test-scraper", false)
+	lease, err = startScraping(mockDB, "test-scraper", false)
+	assert.Nil(t, lease)
+	require.Error(t, err)
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
+	assert.NotErrorIs(t, err, database.ErrMediaWriteConflict)
+}

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -472,9 +472,16 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 		return nil, fmt.Errorf("scraper %q has no Scrape function", s.ID)
 	}
 
-	if err := startScrapingIfNoIndex(params.ScraperID, params.Force); err != nil {
+	lease, err := startScraping(env.Database.MediaDB, params.ScraperID, params.Force)
+	if err != nil {
 		return nil, err
 	}
+	leaseOwned := true
+	defer func() {
+		if leaseOwned {
+			lease.Release()
+		}
+	}()
 
 	ns := env.State.Notifications
 	db := env.Database
@@ -564,7 +571,9 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 
 	scraperID := params.ScraperID
 	db.MediaDB.TrackBackgroundOperation()
+	leaseOwned = false
 	go func() {
+		defer lease.Release()
 		defer scrapingStatusInstance.clearIfOwner(scraperID)
 		defer cancelFunc()
 		defer db.MediaDB.BackgroundOperationDone()

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -163,6 +163,9 @@ func TestHandleMediaScrape_IndexingInProgress(t *testing.T) {
 	defer statusInstance.clear()
 
 	mockDB := testhelpers.NewMockMediaDBI()
+	lease, acquireErr := mockDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, acquireErr)
+	defer lease.Release()
 	env := makeScrapeEnv(t,
 		map[string]platforms.Scraper{"test-scraper": emptyPlatformScraper("test-scraper", "Test Scraper")},
 		mockDB,
@@ -988,6 +991,7 @@ func TestHandleMediaScrape_PersistStatusErrorClearsRunning(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to persist scraping status")
 	assert.False(t, IsScrapingRunning())
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
 	mockDB.AssertExpectations(t)
 }
 
@@ -1009,6 +1013,7 @@ func TestHandleMediaScrape_PersistOperationErrorClearsRunning(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to persist scraping operation")
 	assert.False(t, IsScrapingRunning())
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
 	mockDB.AssertExpectations(t)
 }
 
@@ -1034,6 +1039,7 @@ func TestHandleMediaScrape_ScraperInitError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to start scraper")
 
 	assert.False(t, IsScrapingRunning(), "scraping status must be cleared after error")
+	assert.Equal(t, database.MediaWriteOperationNone, mockDB.ActiveMediaWriteOperation())
 	mockDB.AssertExpectations(t)
 }
 

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
@@ -710,10 +711,11 @@ func TestValidateUpdateMappingParams(t *testing.T) {
 
 func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 	tests := []struct {
-		name          string
-		params        string
-		errorContains string
-		wantError     bool
+		name               string
+		params             string
+		errorContains      string
+		optimizationStatus string
+		wantError          bool
 	}{
 		{
 			name:      "no parameters - all systems",
@@ -731,9 +733,10 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			wantError: false,
 		},
 		{
-			name:      "single valid system",
-			params:    `{"systems": ["NES"]}`,
-			wantError: false,
+			name:               "single valid system with stale optimization status",
+			params:             `{"systems": ["NES"]}`,
+			optimizationStatus: mediadb.IndexingStatusRunning,
+			wantError:          false,
 		},
 		{
 			name:      "multiple valid systems",
@@ -766,8 +769,8 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			mockUserDB := &helpers.MockUserDBI{}
 			mockMediaDB := helpers.NewMockMediaDBI()
 
-			// Mock optimization status check
-			mockMediaDB.On("GetOptimizationStatus").Return("", nil)
+			// Persisted optimization state is restart intent, not process ownership.
+			mockMediaDB.On("GetOptimizationStatus").Return(tt.optimizationStatus, nil)
 			mockMediaDB.On("SetOptimizationStatus", mock.Anything).Return(nil).Maybe()
 
 			// Mock additional methods that might be called

--- a/pkg/database/media_write.go
+++ b/pkg/database/media_write.go
@@ -1,0 +1,172 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+)
+
+// MediaWriteOperation identifies one process-local MediaDB write owner.
+type MediaWriteOperation string
+
+const (
+	MediaWriteOperationNone         MediaWriteOperation = ""
+	MediaWriteOperationIndexing     MediaWriteOperation = "indexing"
+	MediaWriteOperationScraping     MediaWriteOperation = "scraping"
+	MediaWriteOperationOptimization MediaWriteOperation = "optimization"
+	MediaWriteOperationMaintenance  MediaWriteOperation = "maintenance"
+	MediaWriteOperationRecovery     MediaWriteOperation = "recovery"
+)
+
+var (
+	ErrMediaWriteConflict               = errors.New("media database write operation conflict")
+	ErrMediaWriteLease                  = errors.New("invalid media database write lease")
+	ErrMediaWriteCoordinatorUnavailable = errors.New("media database write coordinator unavailable")
+)
+
+// MediaDBWriteCoordinator is optional process-local write arbitration layered
+// over MediaDBI without expanding that compatibility-sensitive interface.
+type MediaDBWriteCoordinator interface {
+	AcquireMediaWrite(operation MediaWriteOperation) (*MediaWriteLease, error)
+	ActiveMediaWriteOperation() MediaWriteOperation
+	RunBackgroundOptimizationWithLease(
+		statusCallback func(optimizing bool), pauser *syncutil.Pauser, lease *MediaWriteLease,
+	) error
+}
+
+// GetMediaDBWriteCoordinator returns write arbitration supported by current MediaDB implementations.
+func GetMediaDBWriteCoordinator(mediaDB MediaDBI) (MediaDBWriteCoordinator, error) {
+	coordinator, ok := mediaDB.(MediaDBWriteCoordinator)
+	if !ok {
+		return nil, ErrMediaWriteCoordinatorUnavailable
+	}
+	return coordinator, nil
+}
+
+// MediaWriteConflictError reports which process-local owner blocked a request.
+type MediaWriteConflictError struct {
+	Requested MediaWriteOperation
+	Active    MediaWriteOperation
+}
+
+func (e *MediaWriteConflictError) Error() string {
+	return fmt.Sprintf("media database %s is in progress", e.Active)
+}
+
+func (*MediaWriteConflictError) Unwrap() error {
+	return ErrMediaWriteConflict
+}
+
+// MediaWriteArbiter serializes process-local MediaDB mutations. Its zero value is ready to use.
+type MediaWriteArbiter struct {
+	active   MediaWriteOperation
+	mu       syncutil.Mutex
+	nextID   uint64
+	activeID uint64
+}
+
+// MediaWriteLease is exclusive ownership of one MediaDB write-operation slot.
+// Release is idempotent. Handoff changes operation type without an unowned gap.
+type MediaWriteLease struct {
+	arbiter  *MediaWriteArbiter
+	id       uint64
+	released atomic.Bool
+}
+
+// TryAcquire atomically claims the write slot.
+func (a *MediaWriteArbiter) TryAcquire(operation MediaWriteOperation) (*MediaWriteLease, error) {
+	if operation == MediaWriteOperationNone {
+		return nil, fmt.Errorf("%w: operation is empty", ErrMediaWriteLease)
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.active != MediaWriteOperationNone {
+		return nil, &MediaWriteConflictError{Requested: operation, Active: a.active}
+	}
+
+	a.nextID++
+	if a.nextID == 0 {
+		a.nextID++
+	}
+	a.activeID = a.nextID
+	a.active = operation
+	return &MediaWriteLease{arbiter: a, id: a.activeID}, nil
+}
+
+// Active reports current process-local owner, or MediaWriteOperationNone.
+func (a *MediaWriteArbiter) Active() MediaWriteOperation {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.active
+}
+
+// Operation reports operation currently owned by this lease.
+func (l *MediaWriteLease) Operation() MediaWriteOperation {
+	if l == nil || l.arbiter == nil || l.released.Load() {
+		return MediaWriteOperationNone
+	}
+
+	l.arbiter.mu.Lock()
+	defer l.arbiter.mu.Unlock()
+	if l.arbiter.activeID != l.id {
+		return MediaWriteOperationNone
+	}
+	return l.arbiter.active
+}
+
+// ValidFor reports whether lease still owns operation.
+func (l *MediaWriteLease) ValidFor(operation MediaWriteOperation) bool {
+	return l.Operation() == operation
+}
+
+// Handoff atomically transfers ownership to another operation type.
+func (l *MediaWriteLease) Handoff(operation MediaWriteOperation) error {
+	if l == nil || l.arbiter == nil || operation == MediaWriteOperationNone || l.released.Load() {
+		return ErrMediaWriteLease
+	}
+
+	l.arbiter.mu.Lock()
+	defer l.arbiter.mu.Unlock()
+	if l.released.Load() || l.arbiter.activeID != l.id || l.arbiter.active == MediaWriteOperationNone {
+		return ErrMediaWriteLease
+	}
+	l.arbiter.active = operation
+	return nil
+}
+
+// Release relinquishes ownership exactly once. Duplicate calls are no-ops.
+func (l *MediaWriteLease) Release() {
+	if l == nil || l.arbiter == nil || !l.released.CompareAndSwap(false, true) {
+		return
+	}
+
+	l.arbiter.mu.Lock()
+	defer l.arbiter.mu.Unlock()
+	if l.arbiter.activeID != l.id {
+		return
+	}
+	l.arbiter.activeID = 0
+	l.arbiter.active = MediaWriteOperationNone
+}

--- a/pkg/database/media_write_test.go
+++ b/pkg/database/media_write_test.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,4 +142,60 @@ func TestMediaWriteArbiterRejectsEmptyOperation(t *testing.T) {
 	assert.Nil(t, lease)
 	require.ErrorIs(t, err, ErrMediaWriteLease)
 	assert.NotErrorIs(t, err, ErrMediaWriteConflict)
+}
+
+type mediaDBWithWriteCoordinator struct {
+	MediaDBI
+	MediaDBWriteCoordinator
+}
+
+type mediaDBWithoutWriteCoordinator struct {
+	MediaDBI
+}
+
+func TestGetMediaDBWriteCoordinator(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	coordinatedDB := &mediaDBWithWriteCoordinator{
+		MediaDBWriteCoordinator: &testMediaWriteCoordinator{arbiter: &arbiter},
+	}
+
+	coordinator, err := GetMediaDBWriteCoordinator(coordinatedDB)
+	require.NoError(t, err)
+	assert.Same(t, coordinatedDB, coordinator)
+
+	coordinator, err = GetMediaDBWriteCoordinator(&mediaDBWithoutWriteCoordinator{})
+	assert.Nil(t, coordinator)
+	require.ErrorIs(t, err, ErrMediaWriteCoordinatorUnavailable)
+}
+
+func TestMediaWriteConflictErrorDescribesAndWrapsConflict(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	lease, err := arbiter.TryAcquire(MediaWriteOperationIndexing)
+	require.NoError(t, err)
+	defer lease.Release()
+
+	_, err = arbiter.TryAcquire(MediaWriteOperationScraping)
+	require.Error(t, err)
+	assert.Equal(t, "media database indexing is in progress", err.Error())
+	require.ErrorIs(t, err, ErrMediaWriteConflict)
+}
+
+type testMediaWriteCoordinator struct {
+	arbiter *MediaWriteArbiter
+}
+
+func (c *testMediaWriteCoordinator) AcquireMediaWrite(
+	operation MediaWriteOperation,
+) (*MediaWriteLease, error) {
+	return c.arbiter.TryAcquire(operation)
+}
+
+func (c *testMediaWriteCoordinator) ActiveMediaWriteOperation() MediaWriteOperation {
+	return c.arbiter.Active()
+}
+
+func (*testMediaWriteCoordinator) RunBackgroundOptimizationWithLease(
+	func(bool), *syncutil.Pauser, *MediaWriteLease,
+) error {
+	return nil
 }

--- a/pkg/database/media_write_test.go
+++ b/pkg/database/media_write_test.go
@@ -1,0 +1,144 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaWriteArbiterPairwiseConflicts(t *testing.T) {
+	operations := []MediaWriteOperation{
+		MediaWriteOperationIndexing,
+		MediaWriteOperationScraping,
+		MediaWriteOperationOptimization,
+	}
+
+	for _, active := range operations {
+		for _, requested := range operations {
+			t.Run(string(active)+"_blocks_"+string(requested), func(t *testing.T) {
+				var arbiter MediaWriteArbiter
+				lease, err := arbiter.TryAcquire(active)
+				require.NoError(t, err)
+
+				blockedLease, err := arbiter.TryAcquire(requested)
+				require.ErrorIs(t, err, ErrMediaWriteConflict)
+				assert.Nil(t, blockedLease)
+				var conflict *MediaWriteConflictError
+				require.ErrorAs(t, err, &conflict)
+				assert.Equal(t, active, conflict.Active)
+				assert.Equal(t, requested, conflict.Requested)
+
+				lease.Release()
+				next, err := arbiter.TryAcquire(requested)
+				require.NoError(t, err)
+				next.Release()
+			})
+		}
+	}
+}
+
+func TestMediaWriteArbiterSimultaneousStartsChooseOneOwner(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	const attempts = 64
+	start := make(chan struct{})
+	release := make(chan struct{})
+	var attempted sync.WaitGroup
+	var finished sync.WaitGroup
+	var acquired atomic.Int32
+	attempted.Add(attempts)
+	finished.Add(attempts)
+
+	for range attempts {
+		go func() {
+			defer finished.Done()
+			<-start
+			lease, err := arbiter.TryAcquire(MediaWriteOperationIndexing)
+			if err != nil {
+				attempted.Done()
+				return
+			}
+			acquired.Add(1)
+			attempted.Done()
+			<-release
+			lease.Release()
+		}()
+	}
+
+	close(start)
+	attempted.Wait()
+	assert.Equal(t, int32(1), acquired.Load())
+	close(release)
+	finished.Wait()
+	assert.Equal(t, MediaWriteOperationNone, arbiter.Active())
+}
+
+func TestMediaWriteLeaseHandoffHasNoUnownedGap(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	lease, err := arbiter.TryAcquire(MediaWriteOperationIndexing)
+	require.NoError(t, err)
+
+	require.NoError(t, lease.Handoff(MediaWriteOperationOptimization))
+	assert.True(t, lease.ValidFor(MediaWriteOperationOptimization))
+	assert.Equal(t, MediaWriteOperationOptimization, arbiter.Active())
+
+	blocked, err := arbiter.TryAcquire(MediaWriteOperationScraping)
+	require.ErrorIs(t, err, ErrMediaWriteConflict)
+	assert.Nil(t, blocked)
+
+	lease.Release()
+	scrapeLease, err := arbiter.TryAcquire(MediaWriteOperationScraping)
+	require.NoError(t, err)
+	scrapeLease.Release()
+}
+
+func TestMediaWriteLeaseDuplicateAndConcurrentRelease(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	lease, err := arbiter.TryAcquire(MediaWriteOperationScraping)
+	require.NoError(t, err)
+
+	const releases = 32
+	var wg sync.WaitGroup
+	wg.Add(releases)
+	for range releases {
+		go func() {
+			defer wg.Done()
+			lease.Release()
+		}()
+	}
+	wg.Wait()
+	lease.Release()
+
+	assert.Equal(t, MediaWriteOperationNone, arbiter.Active())
+	assert.Equal(t, MediaWriteOperationNone, lease.Operation())
+	require.ErrorIs(t, lease.Handoff(MediaWriteOperationOptimization), ErrMediaWriteLease)
+}
+
+func TestMediaWriteArbiterRejectsEmptyOperation(t *testing.T) {
+	var arbiter MediaWriteArbiter
+	lease, err := arbiter.TryAcquire(MediaWriteOperationNone)
+	assert.Nil(t, lease)
+	require.ErrorIs(t, err, ErrMediaWriteLease)
+	assert.NotErrorIs(t, err, ErrMediaWriteConflict)
+}

--- a/pkg/database/mediadb/concurrent_operations_test.go
+++ b/pkg/database/mediadb/concurrent_operations_test.go
@@ -28,11 +28,39 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCleanMediaOrphansPreservesConflictErrors(t *testing.T) {
+	tests := []struct {
+		legacyErr error
+		operation database.MediaWriteOperation
+	}{
+		{operation: database.MediaWriteOperationIndexing, legacyErr: ErrIndexingInProgress},
+		{operation: database.MediaWriteOperationOptimization, legacyErr: ErrOptimizationInProgress},
+		{operation: database.MediaWriteOperationScraping},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.operation), func(t *testing.T) {
+			mediaDB := &MediaDB{}
+			lease, err := mediaDB.AcquireMediaWrite(tt.operation)
+			require.NoError(t, err)
+			defer lease.Release()
+
+			deleted, err := mediaDB.CleanMediaOrphans(context.Background())
+			assert.Zero(t, deleted)
+			require.ErrorIs(t, err, database.ErrMediaWriteConflict)
+			if tt.legacyErr != nil {
+				require.ErrorIs(t, err, tt.legacyErr)
+			}
+		})
+	}
+}
 
 func TestConcurrentOptimizationPrevention(t *testing.T) {
 	db, mock, err := sqlmock.New()

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -167,6 +167,7 @@ type MediaDB struct {
 	stmtInsertTagType       *sql.Stmt
 	batchInsertMediaTag     *BatchInserter
 	inMemoryTagCache        atomic.Pointer[tagCache]
+	mediaWriteArbiter       atomic.Pointer[database.MediaWriteArbiter]
 	batchInsertTag          *BatchInserter
 	mediaSearchBounds       map[int64]mediaDBIDBounds
 	mediaSearchBoundsLoads  map[int64]*mediaSearchBoundsLoad
@@ -989,6 +990,29 @@ func (db *MediaDB) GetOptimizationStatus() (string, error) {
 // overlapping) a full optimization, and writing the persisted status from both
 // would race two operations over who owns "running". Being process-local also
 // means a crash simply drops the flag rather than wedging a persisted status.
+func (db *MediaDB) getMediaWriteArbiter() *database.MediaWriteArbiter {
+	if arbiter := db.mediaWriteArbiter.Load(); arbiter != nil {
+		return arbiter
+	}
+	arbiter := &database.MediaWriteArbiter{}
+	if db.mediaWriteArbiter.CompareAndSwap(nil, arbiter) {
+		return arbiter
+	}
+	return db.mediaWriteArbiter.Load()
+}
+
+func (db *MediaDB) AcquireMediaWrite(operation database.MediaWriteOperation) (*database.MediaWriteLease, error) {
+	lease, err := db.getMediaWriteArbiter().TryAcquire(operation)
+	if err != nil {
+		return nil, fmt.Errorf("acquire media database write operation: %w", err)
+	}
+	return lease, nil
+}
+
+func (db *MediaDB) ActiveMediaWriteOperation() database.MediaWriteOperation {
+	return db.getMediaWriteArbiter().Active()
+}
+
 func (db *MediaDB) IsOptimizing() bool {
 	return db.isOptimizing.Load() || db.browseCacheRebuilding.Load()
 }
@@ -1533,6 +1557,22 @@ func (db *MediaDB) Vacuum() error {
 // (status running or pending), while a batch transaction is open, or while
 // background optimisation is active, returning a sentinel error in each case.
 func (db *MediaDB) CleanMediaOrphans(ctx context.Context) (int64, error) {
+	lease, err := db.AcquireMediaWrite(database.MediaWriteOperationMaintenance)
+	if err != nil {
+		var conflict *database.MediaWriteConflictError
+		if errors.As(err, &conflict) {
+			switch conflict.Active {
+			case database.MediaWriteOperationIndexing:
+				return 0, fmt.Errorf("%w: %w", ErrIndexingInProgress, err)
+			case database.MediaWriteOperationOptimization:
+				return 0, fmt.Errorf("%w: %w", ErrOptimizationInProgress, err)
+			default:
+			}
+		}
+		return 0, err
+	}
+	defer lease.Release()
+
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()
 
@@ -3783,35 +3823,65 @@ func (db *MediaDB) GetMediaBySystemID(systemID string) ([]database.MediaWithFull
 // RunBackgroundOptimization performs database optimization operations in the background.
 // This includes creating indexes, running ANALYZE, and vacuuming the database.
 // It can be safely interrupted and resumed later.
-func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool), pauser *syncutil.Pauser) {
-	if !db.isOptimizing.CompareAndSwap(false, true) {
-		log.Info().Msg("background optimization is already running, skipping")
+func (db *MediaDB) RunBackgroundOptimization(
+	statusCallback func(optimizing bool), pauser *syncutil.Pauser,
+) {
+	lease, err := db.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+	if err != nil {
+		log.Info().Err(err).Msg("background optimization deferred")
 		return
 	}
+	if err := db.RunBackgroundOptimizationWithLease(statusCallback, pauser, lease); err != nil {
+		log.Error().Err(err).Msg("background optimization failed")
+	}
+}
+
+// RunBackgroundOptimizationWithLease runs optimization using ownership handed
+// off by another operation, such as successful indexing. It always releases lease.
+func notifyOptimizationStatus(statusCallback func(optimizing bool), optimizing bool) {
+	if statusCallback == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Interface("panic", r).Msg("panic recovered in optimization status callback")
+		}
+	}()
+	statusCallback(optimizing)
+}
+
+func (db *MediaDB) RunBackgroundOptimizationWithLease(
+	statusCallback func(optimizing bool), pauser *syncutil.Pauser, lease *database.MediaWriteLease,
+) (runErr error) {
+	if !lease.ValidFor(database.MediaWriteOperationOptimization) {
+		lease.Release()
+		return database.ErrMediaWriteLease
+	}
+
+	db.isOptimizing.Store(true)
 	db.backgroundOps.Add(1)
 	defer func() {
-		// Recover from any panics to prevent crashing the entire service
+		// Recover from any panics to prevent crashing the entire service.
 		if r := recover(); r != nil {
 			log.Error().Interface("panic", r).Msg("panic recovered in background optimization")
-			if statusCallback != nil {
-				statusCallback(false)
-			}
-			// Try to mark optimization as failed so it can be retried
+			// Try to mark optimization as failed so it can be retried.
 			if db.sql.Load() != nil {
 				_ = db.SetOptimizationStatus(IndexingStatusFailed)
 			}
+			runErr = fmt.Errorf("background optimization panic: %v", r)
+			notifyOptimizationStatus(statusCallback, false)
 		}
 		db.isOptimizing.Store(false)
 		db.backgroundOps.Done()
+		lease.Release()
 	}()
 
 	if db.sql.Load() == nil {
 		log.Error().Msg("cannot run background optimization: database not connected")
-		// Notify that optimization has failed
 		if statusCallback != nil {
 			statusCallback(false)
 		}
-		return
+		return ErrNullSQL
 	}
 
 	log.Info().Msg("starting background database optimization")
@@ -3819,11 +3889,10 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	// Set status to running
 	if err := db.SetOptimizationStatus(IndexingStatusRunning); err != nil {
 		log.Error().Err(err).Msg("failed to set optimization status to running")
-		// Notify that optimization has failed to start
 		if statusCallback != nil {
 			statusCallback(false)
 		}
-		return
+		return fmt.Errorf("failed to set optimization status to running: %w", err)
 	}
 
 	// Notify that optimization has started
@@ -3948,7 +4017,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			if statusCallback != nil {
 				statusCallback(false)
 			}
-			return
+			return fmt.Errorf("wait to run background optimization: %w", err)
 		}
 
 		log.Info().Msgf("running optimization step: %s", step.name)
@@ -4012,7 +4081,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 			if statusCallback != nil {
 				statusCallback(false)
 			}
-			return
+			return stepErr
 		}
 
 		stepMetricsEnd := stepRecorder.Capture(db.ctx, true)
@@ -4025,7 +4094,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	// Mark as completed
 	if err := db.SetOptimizationStatus(IndexingStatusCompleted); err != nil {
 		log.Error().Err(err).Msg("failed to set optimization status to completed")
-		return
+		return fmt.Errorf("failed to set optimization status to completed: %w", err)
 	}
 	// Clear optimization step on completion
 	if err := db.SetOptimizationStep(""); err != nil {
@@ -4038,6 +4107,7 @@ func (db *MediaDB) RunBackgroundOptimization(statusCallback func(optimizing bool
 	}
 
 	log.Info().Msg("background database optimization completed")
+	return nil
 }
 
 // WaitForBackgroundOperations waits for all background operations to complete.

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -285,14 +286,46 @@ func TestRunBackgroundOptimization_AlreadyRunning(t *testing.T) {
 	}
 	mediaDB.sql.Store(db)
 
-	// Set optimization as already running
-	mediaDB.isOptimizing.Store(true)
+	// Claim optimization as already running.
+	lease, acquireErr := mediaDB.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+	require.NoError(t, acquireErr)
+	defer lease.Release()
 
-	// This should return immediately without doing anything
+	// A second start returns immediately without changing ownership.
 	mediaDB.RunBackgroundOptimization(nil, nil)
+	assert.Equal(t, database.MediaWriteOperationOptimization, mediaDB.ActiveMediaWriteOperation())
+}
 
-	// Verify it's still marked as running
-	assert.True(t, mediaDB.isOptimizing.Load())
+func TestRunBackgroundOptimizationWithLease_InvalidOperationReleasesLease(t *testing.T) {
+	mediaDB := &MediaDB{}
+	lease, err := mediaDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+
+	err = mediaDB.RunBackgroundOptimizationWithLease(nil, nil, lease)
+	require.ErrorIs(t, err, database.ErrMediaWriteLease)
+	assert.Equal(t, database.MediaWriteOperationNone, mediaDB.ActiveMediaWriteOperation())
+}
+
+func TestRunBackgroundOptimization_PanicReleasesLease(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	mediaDB := &MediaDB{ctx: context.Background(), clock: clockwork.NewFakeClock()}
+	mediaDB.sql.Store(sqlDB)
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigOptimizationStatus, IndexingStatusRunning).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
+		WithArgs(DBConfigOptimizationStatus, IndexingStatusFailed).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mediaDB.RunBackgroundOptimization(func(bool) {
+		panic("injected callback panic")
+	}, nil)
+	assert.Equal(t, database.MediaWriteOperationNone, mediaDB.ActiveMediaWriteOperation())
+	assert.False(t, mediaDB.IsOptimizing())
+	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestRunBackgroundOptimization_NilDatabase(t *testing.T) {
@@ -428,6 +461,7 @@ func TestRunBackgroundOptimization_PagePrefetchCancellationAborts(t *testing.T) 
 	mediaDB.RunBackgroundOptimization(nil, nil)
 
 	assert.False(t, mediaDB.isOptimizing.Load())
+	assert.Equal(t, database.MediaWriteOperationNone, mediaDB.ActiveMediaWriteOperation())
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -296,6 +296,17 @@ func TestRunBackgroundOptimization_AlreadyRunning(t *testing.T) {
 	assert.Equal(t, database.MediaWriteOperationOptimization, mediaDB.ActiveMediaWriteOperation())
 }
 
+func TestBrowseCacheRebuildReportsOptimizing(t *testing.T) {
+	mediaDB := &MediaDB{}
+	assert.False(t, mediaDB.IsOptimizing())
+
+	mediaDB.BeginBrowseCacheRebuild()
+	assert.True(t, mediaDB.IsOptimizing())
+
+	mediaDB.EndBrowseCacheRebuild()
+	assert.False(t, mediaDB.IsOptimizing())
+}
+
 func TestRunBackgroundOptimizationWithLease_InvalidOperationReleasesLease(t *testing.T) {
 	mediaDB := &MediaDB{}
 	lease, err := mediaDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)

--- a/pkg/service/browse_cache_heal_test.go
+++ b/pkg/service/browse_cache_heal_test.go
@@ -43,6 +43,8 @@ import (
 func runBrowseCacheHealOptimizingCycle(t *testing.T, populateErr error) {
 	t.Helper()
 
+	pendingMediaWriteRetries.Store(0)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
 	mockDB := helpers.NewMockMediaDBI()
 	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil)
 	mockDB.On("GetTotalMediaCount").Return(1000, nil)
@@ -103,6 +105,9 @@ func TestCheckAndHealBrowseCache_RebuildsWhenStale(t *testing.T) {
 
 func TestCheckAndHealBrowseCache_ClearsOptimizingOnRebuildFailure(t *testing.T) {
 	runBrowseCacheHealOptimizingCycle(t, errors.New("rebuild boom"))
+	if pendingMediaWriteRetries.Load()&mediaWriteRetryBrowseCacheHeal != 0 {
+		t.Error("expected non-conflict rebuild failure not to schedule an immediate retry")
+	}
 }
 
 func TestCheckAndHealBrowseCache_SkipsWhenFresh(t *testing.T) {

--- a/pkg/service/index_resume.go
+++ b/pkg/service/index_resume.go
@@ -67,6 +67,29 @@ var mediaDBRecoveryAttempts atomic.Int32
 
 var mediaDBRecoveryLimitReported atomic.Bool
 
+const (
+	mediaWriteRetryIndexing uint32 = 1 << iota
+	mediaWriteRetryScraping
+	mediaWriteRetryOptimization
+	mediaWriteRetryMaintenance
+	mediaWriteRetryBrowseCacheHeal
+)
+
+var pendingMediaWriteRetries atomic.Uint32
+
+func deferMediaWriteRetry(operations uint32) {
+	for {
+		pending := pendingMediaWriteRetries.Load()
+		if pendingMediaWriteRetries.CompareAndSwap(pending, pending|operations) {
+			return
+		}
+	}
+}
+
+func claimMediaWriteRetries() uint32 {
+	return pendingMediaWriteRetries.Swap(0)
+}
+
 func claimMediaDBRecoveryAttempt() (int32, bool) {
 	for {
 		attempts := mediaDBRecoveryAttempts.Load()
@@ -165,6 +188,10 @@ func checkAndResumeIndexing(
 	if indexingStatus == mediadb.IndexingStatusFailed {
 		log.Warn().Msg("media indexing failed with an empty database; retrying automatically")
 	}
+	if activeMediaWriteOperation(db.MediaDB) != database.MediaWriteOperationNone {
+		deferMediaWriteRetry(mediaWriteRetryIndexing)
+		return false
+	}
 
 	// Bound only stalled resumes. A full reindex on a large library can span many
 	// user power cycles; those should resume indefinitely as long as completed
@@ -232,6 +259,9 @@ func checkAndResumeIndexing(
 	// GenerateMediaDB spawns its own goroutine and returns immediately
 	err = methods.GenerateMediaDB(st.GetContext(), pl, cfg, st.Notifications, systems, db, pauser)
 	if err != nil {
+		if errors.Is(err, database.ErrMediaWriteConflict) {
+			deferMediaWriteRetry(mediaWriteRetryIndexing)
+		}
 		// An expected operational state (e.g. indexing/scraping already running)
 		// means auto-resume isn't needed — not a failure worth reporting.
 		var clientErr *models.ClientError
@@ -253,6 +283,7 @@ type mediaDBGenerateFunc func(
 	[]systemdefs.System,
 	*database.Database,
 	*syncutil.Pauser,
+	*database.MediaWriteLease,
 ) error
 
 // checkAndRecoverCorruptMediaDB rebuilds the media database from scratch when corruption
@@ -267,7 +298,7 @@ func checkAndRecoverCorruptMediaDB(
 	st *state.State,
 	pauser *syncutil.Pauser,
 ) {
-	checkAndRecoverCorruptMediaDBWithGenerator(pl, cfg, db, st, pauser, methods.GenerateMediaDB)
+	checkAndRecoverCorruptMediaDBWithGenerator(pl, cfg, db, st, pauser, methods.GenerateMediaDBWithLease)
 }
 
 func checkAndRecoverCorruptMediaDBWithGenerator(
@@ -307,6 +338,23 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 		log.Warn().Msg("media database flagged corrupt but background work is in flight; deferring recovery")
 		return
 	}
+
+	coordinator, err := database.GetMediaDBWriteCoordinator(db.MediaDB)
+	if err != nil {
+		log.Error().Err(err).Msg("media database recovery cannot get write coordinator")
+		return
+	}
+	lease, err := coordinator.AcquireMediaWrite(database.MediaWriteOperationRecovery)
+	if err != nil {
+		log.Warn().Err(err).Msg("media database flagged corrupt but write operation owns database; deferring recovery")
+		return
+	}
+	leaseTransferred := false
+	defer func() {
+		if !leaseTransferred {
+			lease.Release()
+		}
+	}()
 
 	if st != nil {
 		st.SetMediaDBRecoveryActive(true)
@@ -386,8 +434,13 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 			Msg("media database recreated but service state is unavailable for reindex")
 		return
 	}
+	if handoffErr := lease.Handoff(database.MediaWriteOperationIndexing); handoffErr != nil {
+		log.Error().Err(handoffErr).Msg("failed to hand off media database recovery to reindex")
+		finishMediaDBRecoveryNotification(st, db.MediaDB)
+		return
+	}
 	if err := generate(st.GetContext(), pl, cfg, st.Notifications,
-		systemdefs.AllSystems(), db, pauser); err != nil {
+		systemdefs.AllSystems(), db, pauser, lease); err != nil {
 		var clientErr *models.ClientError
 		if errors.As(err, &clientErr) {
 			log.Warn().Err(err).Int32("recovery_attempt", attempt).Str("recovery_outcome", "reindex_skipped").
@@ -400,7 +453,9 @@ func checkAndRecoverCorruptMediaDBWithGenerator(
 			"Restart Zaparoo after checking available storage space.",
 			inboxservice.CategoryMediaDBCorruptionRecoveryFailure)
 		finishMediaDBRecoveryNotification(st, db.MediaDB)
+		return
 	}
+	leaseTransferred = true
 }
 
 func finishMediaDBRecoveryNotification(st *state.State, mediaDB database.MediaDBI) {
@@ -434,7 +489,18 @@ func addMediaDBRecoveryFailureInbox(st *state.State, body, category string) {
 	}
 }
 
+func activeMediaWriteOperation(mediaDB database.MediaDBI) database.MediaWriteOperation {
+	coordinator, err := database.GetMediaDBWriteCoordinator(mediaDB)
+	if err != nil {
+		return database.MediaWriteOperationNone
+	}
+	return coordinator.ActiveMediaWriteOperation()
+}
+
 func mediaDBCorruptionRecoveryBlocked(mediaDB database.MediaDBI) bool {
+	if activeMediaWriteOperation(mediaDB) != database.MediaWriteOperationNone {
+		return true
+	}
 	if !mediaDB.HasBackgroundOperations() {
 		return false
 	}
@@ -459,10 +525,11 @@ func watchForCorruptMediaDBRecovery(
 	cfg *config.Instance,
 	db *database.Database,
 	st *state.State,
-	pauser *syncutil.Pauser,
+	indexPauser *syncutil.Pauser,
+	scrapePauser *syncutil.Pauser,
 ) {
 	watchForCorruptMediaDBRecoveryAtInterval(
-		ctx, b, pl, cfg, db, st, pauser, mediaDBRecoveryPollInterval,
+		ctx, b, pl, cfg, db, st, indexPauser, scrapePauser, mediaDBRecoveryPollInterval,
 	)
 }
 
@@ -473,7 +540,8 @@ func watchForCorruptMediaDBRecoveryAtInterval(
 	cfg *config.Instance,
 	db *database.Database,
 	st *state.State,
-	pauser *syncutil.Pauser,
+	indexPauser *syncutil.Pauser,
+	scrapePauser *syncutil.Pauser,
 	pollInterval time.Duration,
 ) {
 	notifChan, subID := b.Subscribe(32, models.NotificationMediaIndexing)
@@ -489,10 +557,67 @@ func watchForCorruptMediaDBRecoveryAtInterval(
 			if !ok {
 				return
 			}
-			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, pauser)
+			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+			retryDurableMediaWriteOperations(ctx, pl, cfg, db, st, indexPauser, scrapePauser)
 		case <-ticker.C:
-			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, pauser)
+			checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+			retryDurableMediaWriteOperations(ctx, pl, cfg, db, st, indexPauser, scrapePauser)
 		}
+	}
+}
+
+// retryDurableMediaWriteOperations retries persisted work explicitly deferred by
+// a process-local lease conflict. Persisted statuses remain restart state, never locks.
+func retryDurableMediaWriteOperations(
+	ctx context.Context,
+	pl platforms.Platform,
+	cfg *config.Instance,
+	db *database.Database,
+	st *state.State,
+	indexPauser *syncutil.Pauser,
+	scrapePauser *syncutil.Pauser,
+) {
+	if db == nil || db.MediaDB == nil {
+		return
+	}
+
+	if ctx.Err() != nil || pl == nil || st == nil ||
+		activeMediaWriteOperation(db.MediaDB) != database.MediaWriteOperationNone {
+		return
+	}
+	pending := claimMediaWriteRetries()
+	if pending&mediaWriteRetryIndexing != 0 {
+		if checkAndResumeIndexing(pl, cfg, db, st, indexPauser) {
+			deferMediaWriteRetry(pending &^ mediaWriteRetryIndexing)
+			return
+		}
+	}
+	if pending&mediaWriteRetryScraping != 0 {
+		checkAndResumeScraping(pl, cfg, db, st, scrapePauser)
+		if activeMediaWriteOperation(db.MediaDB) != database.MediaWriteOperationNone {
+			deferMediaWriteRetry(pending &^ (mediaWriteRetryIndexing | mediaWriteRetryScraping))
+			return
+		}
+	}
+	if pending&mediaWriteRetryOptimization != 0 {
+		db.MediaDB.TrackBackgroundOperation()
+		go func() {
+			corrupt := checkAndResumeOptimization(db, st.Notifications, indexPauser)
+			db.MediaDB.BackgroundOperationDone()
+			if corrupt {
+				checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
+			}
+		}()
+	}
+	if pending&mediaWriteRetryMaintenance != 0 {
+		db.MediaDB.TrackBackgroundOperation()
+		go func() {
+			defer db.MediaDB.BackgroundOperationDone()
+			runMediaDBStartupMaintenanceWork(ctx, db.MediaDB, indexPauser, true)
+		}()
+	}
+	if pending&mediaWriteRetryBrowseCacheHeal != 0 {
+		checkAndHealBrowseCache(ctx, db, st.Notifications, indexPauser)
 	}
 }
 
@@ -569,6 +694,24 @@ func checkAndHealBrowseCache(
 			log.Debug().Msg("skipping browse cache self-heal; optimization started while paused")
 			return
 		}
+		coordinator, coordinatorErr := database.GetMediaDBWriteCoordinator(db.MediaDB)
+		if coordinatorErr != nil {
+			log.Error().Err(coordinatorErr).Msg("browse cache self-heal cannot get media database write coordinator")
+			return
+		}
+		lease, acquireErr := coordinator.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+		if acquireErr != nil {
+			if errors.Is(acquireErr, database.ErrMediaWriteConflict) {
+				deferMediaWriteRetry(mediaWriteRetryBrowseCacheHeal)
+				log.Debug().Err(acquireErr).
+					Msg("deferring browse cache self-heal; media database write operation active")
+				return
+			}
+			log.Error().Err(acquireErr).Msg("failed to acquire browse cache self-heal lease")
+			return
+		}
+		defer lease.Release()
+
 		// Surface the rebuild as an optimizing operation so the client can show a
 		// "preparing library" indicator instead of the user staring at slow or
 		// empty browse results. The push updates clients already connected; the
@@ -621,6 +764,10 @@ func checkAndResumeScraping(
 		log.Debug().Msgf("scraping status is '%s', no auto-resume needed", status)
 		return
 	}
+	if activeMediaWriteOperation(db.MediaDB) != database.MediaWriteOperationNone {
+		deferMediaWriteRetry(mediaWriteRetryScraping)
+		return
+	}
 
 	operation, found, err := db.MediaDB.GetScrapingOperation()
 	if err != nil {
@@ -659,6 +806,12 @@ func checkAndResumeScraping(
 	}
 	err = methods.ResumeMediaScrape(&env, operation)
 	if err != nil {
+		if errors.Is(err, database.ErrMediaWriteConflict) {
+			deferMediaWriteRetry(mediaWriteRetryScraping)
+			log.Info().Err(err).Str("scraper", operation.ScraperID).
+				Msg("media scraping auto-resume deferred; media database write operation active")
+			return
+		}
 		if setErr := db.MediaDB.SetScrapingStatus(mediadb.IndexingStatusFailed); setErr != nil {
 			log.Warn().Err(setErr).Msg("failed to persist scraping auto-resume failure status")
 		}
@@ -684,6 +837,10 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 	if status == mediadb.IndexingStatusPending ||
 		status == mediadb.IndexingStatusRunning ||
 		status == mediadb.IndexingStatusFailed {
+		if activeMediaWriteOperation(db.MediaDB) != database.MediaWriteOperationNone {
+			deferMediaWriteRetry(mediaWriteRetryOptimization)
+			return false
+		}
 		// A failed optimization is often the symptom of a corrupt database — e.g. a
 		// PRAGMA optimize that hit a malformed page. Resuming would just fail again
 		// on every boot, so confirm integrity first and route confirmed corruption
@@ -702,14 +859,33 @@ func checkAndResumeOptimization(db *database.Database, ns chan<- models.Notifica
 				return true
 			}
 		}
+		coordinator, coordinatorErr := database.GetMediaDBWriteCoordinator(db.MediaDB)
+		if coordinatorErr != nil {
+			log.Error().Err(coordinatorErr).Msg("optimization auto-resume cannot get write coordinator")
+			return false
+		}
+		lease, acquireErr := coordinator.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+		if acquireErr != nil {
+			if errors.Is(acquireErr, database.ErrMediaWriteConflict) {
+				deferMediaWriteRetry(mediaWriteRetryOptimization)
+				log.Info().Err(acquireErr).Msg("optimization auto-resume deferred; media database write active")
+				return false
+			}
+			log.Error().Err(acquireErr).Msg("failed to acquire optimization auto-resume lease")
+			return false
+		}
+
 		log.Info().Msgf("detected incomplete optimization (status: %s), automatically resuming", status)
-		db.MediaDB.RunBackgroundOptimization(func(optimizing bool) {
+		runErr := coordinator.RunBackgroundOptimizationWithLease(func(optimizing bool) {
 			notifications.MediaIndexing(ns, models.IndexingStatusResponse{
 				Exists:     true,
 				Indexing:   false,
 				Optimizing: optimizing,
 			})
-		}, pauser)
+		}, pauser, lease)
+		if runErr != nil {
+			log.Error().Err(runErr).Msg("optimization auto-resume failed")
+		}
 	} else {
 		log.Debug().Msgf("optimization status is '%s', no auto-resume needed", status)
 	}

--- a/pkg/service/media_recovery_test.go
+++ b/pkg/service/media_recovery_test.go
@@ -154,7 +154,7 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 	generateCalled := false
 	checkAndRecoverCorruptMediaDBWithGenerator(nil, nil, &database.Database{MediaDB: mockDB}, st, nil,
 		func(context.Context, platforms.Platform, *config.Instance, chan<- models.Notification,
-			[]systemdefs.System, *database.Database, *syncutil.Pauser,
+			[]systemdefs.System, *database.Database, *syncutil.Pauser, *database.MediaWriteLease,
 		) error {
 			generateCalled = true
 			return errors.New("injected reindex failure")
@@ -171,6 +171,40 @@ func TestCheckAndRecoverCorruptMediaDB_ReindexFailureFinishesNotification(t *tes
 	assert.Equal(t, "Recovering media database", *startedStatus.CurrentStepDisplay)
 	assert.False(t, finishedStatus.Indexing)
 	assert.False(t, finishedStatus.Exists)
+	mockDB.AssertExpectations(t)
+}
+
+func TestCheckAndRecoverCorruptMediaDB_TransfersRecoveryLeaseToReindex(t *testing.T) {
+	mediaDBRecoveryAttempts.Store(0)
+	mediaDBRecoveryLimitReported.Store(false)
+	t.Cleanup(func() {
+		mediaDBRecoveryAttempts.Store(0)
+		mediaDBRecoveryLimitReported.Store(false)
+	})
+
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("IsMarkedCorrupt").Return(true)
+	mockDB.On("HasBackgroundOperations").Return(false)
+	mockDB.On("BeginRecovery").Return()
+	mockDB.On("EndRecovery").Return()
+	mockDB.On("IntegrityReport").Return([]string{"Page 4: malformed"})
+	mockDB.On("Recreate", mock.Anything).Return(nil)
+
+	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	var transferred *database.MediaWriteLease
+	checkAndRecoverCorruptMediaDBWithGenerator(nil, nil, &database.Database{MediaDB: mockDB}, st, nil,
+		func(_ context.Context, _ platforms.Platform, _ *config.Instance, _ chan<- models.Notification,
+			_ []systemdefs.System, _ *database.Database, _ *syncutil.Pauser, lease *database.MediaWriteLease,
+		) error {
+			transferred = lease
+			return nil
+		})
+
+	require.NotNil(t, transferred)
+	assert.True(t, transferred.ValidFor(database.MediaWriteOperationIndexing))
+	assert.Equal(t, database.MediaWriteOperationIndexing, mockDB.ActiveMediaWriteOperation())
+	transferred.Release()
 	mockDB.AssertExpectations(t)
 }
 
@@ -215,7 +249,9 @@ func TestCheckAndRecoverCorruptMediaDB_ReleasesGateBeforeReindex(t *testing.T) {
 		checkAndRecoverCorruptMediaDBWithGenerator(nil, nil, db, st, syncutil.NewPauser(),
 			func(_ context.Context, _ platforms.Platform, _ *config.Instance, _ chan<- models.Notification,
 				_ []systemdefs.System, targetDB *database.Database, _ *syncutil.Pauser,
+				lease *database.MediaWriteLease,
 			) error {
+				assert.True(t, lease.ValidFor(database.MediaWriteOperationIndexing))
 				targetDB.MediaDB.TrackBackgroundOperation()
 				targetDB.MediaDB.BackgroundOperationDone()
 				close(reindexRegistered)
@@ -298,7 +334,7 @@ func TestCheckAndResumeOptimization_FailedCorruptMarksAndSkips(t *testing.T) {
 	assert.True(t, flaggedCorrupt, "must report corruption so the caller can trigger recovery")
 	mockDB.AssertCalled(t, "MarkCorrupt", "quick_check failed before optimization resume")
 	mockDB.AssertCalled(t, "SetIndexingStatus", mediadb.IndexingStatusCorrupt)
-	mockDB.AssertNotCalled(t, "RunBackgroundOptimization")
+	mockDB.AssertNotCalled(t, "RunBackgroundOptimizationWithLease")
 }
 
 // TestCheckAndResumeOptimization_HealthyResumes verifies that a recoverable interrupted
@@ -306,13 +342,14 @@ func TestCheckAndResumeOptimization_FailedCorruptMarksAndSkips(t *testing.T) {
 func TestCheckAndResumeOptimization_HealthyResumes(t *testing.T) {
 	mockDB := helpers.NewMockMediaDBI()
 	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusPending, nil)
-	mockDB.On("RunBackgroundOptimization", mock.Anything, mock.Anything).Return()
+	mockDB.On("RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
 
 	ns := make(chan models.Notification, 10)
 	flaggedCorrupt := checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
 
 	assert.False(t, flaggedCorrupt)
-	mockDB.AssertCalled(t, "RunBackgroundOptimization", mock.Anything, mock.Anything)
+	mockDB.AssertCalled(t, "RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything)
 	mockDB.AssertNotCalled(t, "MarkCorrupt", mock.Anything)
 }
 
@@ -326,7 +363,7 @@ func TestCheckAndResumeOptimization_NoResumeNeeded(t *testing.T) {
 	flaggedCorrupt := checkAndResumeOptimization(&database.Database{MediaDB: mockDB}, ns, syncutil.NewPauser())
 
 	assert.False(t, flaggedCorrupt)
-	mockDB.AssertNotCalled(t, "RunBackgroundOptimization", mock.Anything, mock.Anything)
+	mockDB.AssertNotCalled(t, "RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything)
 }
 
 // TestCheckAndRecoverCorruptMediaDB_DefersWhenScrapingInFlight covers the scraping guard:
@@ -362,6 +399,16 @@ func TestCheckAndRecoverCorruptMediaDB_StatusBackstopWithoutMarker(t *testing.T)
 
 // TestWatchForCorruptMediaDBRecovery verifies the watcher runs a recovery check when a
 // media-indexing notification arrives and shuts down cleanly on context cancellation.
+func TestMediaDBCorruptionRecoveryBlocked_UsesOptimizationLease(t *testing.T) {
+	mockDB := helpers.NewMockMediaDBI()
+	lease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+	require.NoError(t, err)
+	defer lease.Release()
+
+	assert.True(t, mediaDBCorruptionRecoveryBlocked(mockDB))
+	mockDB.AssertNotCalled(t, "HasBackgroundOperations")
+}
+
 func TestMediaDBCorruptionRecoveryBlocked_IgnoresStalePersistedStatus(t *testing.T) {
 	mockDB := helpers.NewMockMediaDBI()
 	mockDB.On("HasBackgroundOperations").Return(false)
@@ -401,7 +448,7 @@ func TestWatchForCorruptMediaDBRecovery_PollsForegroundMarker(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		watchForCorruptMediaDBRecoveryAtInterval(
-			ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil, 10*time.Millisecond,
+			ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil, nil, 10*time.Millisecond,
 		)
 		close(done)
 	}()
@@ -439,7 +486,7 @@ func TestWatchForCorruptMediaDBRecovery(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		watchForCorruptMediaDBRecovery(ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil)
+		watchForCorruptMediaDBRecovery(ctx, b, nil, nil, &database.Database{MediaDB: mockDB}, nil, nil, nil)
 		close(done)
 	}()
 

--- a/pkg/service/media_write_retry_test.go
+++ b/pkg/service/media_write_retry_test.go
@@ -1,0 +1,319 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	testmocks "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryDurableMediaWriteOperationsIdleDoesNotTouchDurableState(t *testing.T) {
+	pendingMediaWriteRetries.Store(0)
+	mockDB := helpers.NewMockMediaDBI()
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, nil, nil,
+	)
+
+	mockDB.AssertNotCalled(t, "GetIndexingStatus")
+	mockDB.AssertNotCalled(t, "ResetIndexResumeAttempts")
+	mockDB.AssertNotCalled(t, "GetScrapingStatus")
+	mockDB.AssertNotCalled(t, "GetOptimizationStatus")
+	mockDB.AssertNotCalled(t, "TemporaryRepairJobsPending", mock.Anything)
+}
+
+func TestRetryDurableMediaWriteOperationsDefersThenResumesOptimizationOnce(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryOptimization)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	optimizationStarted := make(chan struct{})
+	releaseOptimization := make(chan struct{})
+	optimizationDone := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusPending, nil).Once()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		close(optimizationDone)
+	}).Return().Once()
+	mockDB.On("RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(mock.Arguments) {
+			close(optimizationStarted)
+			<-releaseOptimization
+		}).Return(nil).Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	db := &database.Database{MediaDB: mockDB}
+
+	scrapeLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	require.NoError(t, err)
+	retryDurableMediaWriteOperations(context.Background(), pl, nil, db, st, nil, nil)
+	mockDB.AssertNotCalled(
+		t, "RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything,
+	)
+
+	scrapeLease.Release()
+	retryDurableMediaWriteOperations(context.Background(), pl, nil, db, st, nil, nil)
+	select {
+	case <-optimizationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("deferred optimization did not start")
+	}
+	// Watcher call returned even though optimization remains blocked in background.
+	retryDurableMediaWriteOperations(context.Background(), pl, nil, db, st, nil, nil)
+	close(releaseOptimization)
+	select {
+	case <-optimizationDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred optimization did not finish")
+	}
+	mockDB.AssertNumberOfCalls(t, "RunBackgroundOptimizationWithLease", 1)
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsDropsOptimizationRetryAfterStatusError(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryOptimization)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	optimizationDone := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("GetOptimizationStatus").Return("", errors.New("temporary status read failure")).Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		close(optimizationDone)
+	}).Return().Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, syncutil.NewPauser(), nil,
+	)
+
+	select {
+	case <-optimizationDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred optimization status check did not finish")
+	}
+	require.Zero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryOptimization)
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsDropsOptimizationRetryAfterRunError(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryOptimization)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	optimizationDone := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusPending, nil).Once()
+	mockDB.On("RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything).
+		Return(errors.New("hard optimization failure")).Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		close(optimizationDone)
+	}).Return().Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, syncutil.NewPauser(), nil,
+	)
+
+	select {
+	case <-optimizationDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred optimization did not finish after hard failure")
+	}
+	require.Zero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryOptimization)
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsDropsBrowseHealRetryAfterCountError(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryBrowseCacheHeal)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockDB.On("GetTotalMediaCount").Return(0, errors.New("temporary count failure")).Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, syncutil.NewPauser(), nil,
+	)
+
+	require.Zero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryBrowseCacheHeal)
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsTracksMaintenanceOnce(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryMaintenance)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	maintenanceDone := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockDB.On("TemporaryRepairJobsPending", mock.Anything).Return(false, nil).Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		close(maintenanceDone)
+	}).Return().Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, syncutil.NewPauser(), nil,
+	)
+
+	select {
+	case <-maintenanceDone:
+	case <-time.After(time.Second):
+		t.Fatal("deferred startup maintenance did not finish")
+	}
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsEndsTrackingBeforeCorruptionRecovery(t *testing.T) {
+	pendingMediaWriteRetries.Store(mediaWriteRetryOptimization)
+	mediaDBRecoveryAttempts.Store(0)
+	t.Cleanup(func() {
+		pendingMediaWriteRetries.Store(0)
+		mediaDBRecoveryAttempts.Store(0)
+	})
+
+	backgroundDone := make(chan struct{})
+	recoveryOrdering := make(chan bool, 1)
+	recoveryDone := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("TrackBackgroundOperation").Return().Once()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		close(backgroundDone)
+	}).Return().Once()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusFailed, nil).Once()
+	mockDB.On("QuickCheck").Return(false, nil).Once()
+	mockDB.On("IntegrityReport").Return([]string{"Page 42: corrupt"})
+	mockDB.On("MarkCorrupt", "quick_check failed before optimization resume").Return().Once()
+	mockDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil).Once()
+	mockDB.On("IsMarkedCorrupt").Return(true).Once()
+	mockDB.On("HasBackgroundOperations").Return(false).Once()
+	mockDB.On("BeginRecovery").Run(func(mock.Arguments) {
+		select {
+		case <-backgroundDone:
+			recoveryOrdering <- true
+		default:
+			recoveryOrdering <- false
+		}
+	}).Return().Once()
+	mockDB.On("Recreate", mock.Anything).Return(errors.New("stop after recovery ordering check")).Once()
+	mockDB.On("EndRecovery").Run(func(mock.Arguments) {
+		close(recoveryDone)
+	}).Return().Once()
+	mockDB.On("GetLastGenerated").Return(time.Now(), nil).Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	retryDurableMediaWriteOperations(
+		context.Background(), pl, nil, &database.Database{MediaDB: mockDB}, st, syncutil.NewPauser(), nil,
+	)
+
+	select {
+	case ordered := <-recoveryOrdering:
+		require.True(t, ordered, "recovery began before retry background tracking ended")
+	case <-time.After(time.Second):
+		t.Fatal("deferred optimization did not enter corruption recovery")
+	}
+	select {
+	case <-recoveryDone:
+	case <-time.After(time.Second):
+		t.Fatal("corruption recovery did not finish")
+	}
+	mockDB.AssertExpectations(t)
+}
+
+func TestRetryDurableMediaWriteOperationsResumesBrowseCacheHealAfterConflict(t *testing.T) {
+	pendingMediaWriteRetries.Store(0)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	healDone := make(chan struct{}, 2)
+	populateCalled := make(chan struct{})
+	mockDB := helpers.NewMockMediaDBI()
+	mockDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil).Times(4)
+	mockDB.On("GetTotalMediaCount").Return(1000, nil).Twice()
+	mockDB.On("BrowseCacheNeedsRebuild", mock.Anything).Return(true, nil).Twice()
+	mockDB.On("TrackBackgroundOperation").Return().Twice()
+	mockDB.On("BackgroundOperationDone").Run(func(mock.Arguments) {
+		healDone <- struct{}{}
+	}).Return().Twice()
+	mockDB.On("PopulateBrowseCache", mock.Anything).Run(func(mock.Arguments) {
+		close(populateCalled)
+	}).Return(nil).Once()
+
+	pl := testmocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	db := &database.Database{MediaDB: mockDB}
+	pauser := syncutil.NewPauser()
+
+	scrapeLease, err := mockDB.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	require.NoError(t, err)
+	checkAndHealBrowseCache(context.Background(), db, st.Notifications, pauser)
+	select {
+	case <-healDone:
+	case <-time.After(time.Second):
+		t.Fatal("browse cache heal did not finish after write conflict")
+	}
+	require.NotZero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryBrowseCacheHeal)
+	mockDB.AssertNotCalled(t, "PopulateBrowseCache", mock.Anything)
+
+	scrapeLease.Release()
+	retryDurableMediaWriteOperations(context.Background(), pl, nil, db, st, pauser, nil)
+	select {
+	case <-populateCalled:
+	case <-time.After(time.Second):
+		t.Fatal("deferred browse cache heal did not retry")
+	}
+	select {
+	case <-healDone:
+	case <-time.After(time.Second):
+		t.Fatal("retried browse cache heal did not finish")
+	}
+
+	require.Zero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryBrowseCacheHeal)
+	mockDB.AssertExpectations(t)
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -665,7 +665,9 @@ func startService(
 			}
 
 			runMediaDBStartupMaintenance(st.GetContext(), db.MediaDB, indexPauser, tagCacheLoaded)
-			if !resumeStarted && checkAndResumeOptimization(db, st.Notifications, indexPauser) {
+			if resumeStarted {
+				deferMediaWriteRetry(mediaWriteRetryOptimization)
+			} else if checkAndResumeOptimization(db, st.Notifications, indexPauser) {
 				// A failed optimization revealed a corrupt database; rebuild it now
 				// rather than waiting for the next startup.
 				checkAndRecoverCorruptMediaDB(pl, cfg, db, st, indexPauser)
@@ -731,7 +733,9 @@ func startService(
 	go watchGameForIndexPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, indexPauser)
 	go watchGameForScrapePause(st.GetContext(), notifBroker, st, cfg, st.Notifications, scrapePauser)
 	go watchGameForBackupPause(st.GetContext(), notifBroker, st, cfg, st.Notifications, backupPauser)
-	go watchForCorruptMediaDBRecovery(st.GetContext(), notifBroker, pl, cfg, db, st, indexPauser)
+	go watchForCorruptMediaDBRecovery(
+		st.GetContext(), notifBroker, pl, cfg, db, st, indexPauser, scrapePauser,
+	)
 
 	log.Info().Msg("starting publishers")
 	publisherNotifications, _ := notifBroker.Subscribe(100)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1335,6 +1335,31 @@ func TestRecordIndexResumeCheckpoint_ProgressMovedResetsAttempts(t *testing.T) {
 	assert.Equal(t, indexResumeCheckpointPrefix+"SNES", checkpoint)
 }
 
+func TestCheckAndResumeIndexing_LeaseConflictDoesNotConsumeResumeBudget(t *testing.T) {
+	pendingMediaWriteRetries.Store(0)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	scrapeLease, err := mockMediaDB.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	require.NoError(t, err)
+	defer scrapeLease.Release()
+
+	pl := mocks.NewMockPlatform()
+	st, _ := state.NewState(pl, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+
+	started := checkAndResumeIndexing(
+		pl, nil, &database.Database{MediaDB: mockMediaDB}, st, nil,
+	)
+
+	assert.False(t, started)
+	mockMediaDB.AssertNotCalled(t, "GetLastIndexedSystem")
+	mockMediaDB.AssertNotCalled(t, "IncrementIndexResumeAttempts")
+	assert.NotZero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryIndexing)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestCheckAndResumeIndexing_ResetsAttemptsOnCleanState(t *testing.T) {
 	// Note: Not using t.Parallel() due to global statusInstance usage in GenerateMediaDB
 	methods.ClearIndexingStatus()
@@ -1426,6 +1451,28 @@ func TestCheckAndResumeScraping_UnavailableScraperMarksFailed(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestCheckAndResumeScraping_WriteConflictPreservesDurableOperation(t *testing.T) {
+	pendingMediaWriteRetries.Store(0)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetScrapingStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
+	indexLease, err := mockMediaDB.AcquireMediaWrite(database.MediaWriteOperationIndexing)
+	require.NoError(t, err)
+	defer indexLease.Release()
+
+	checkAndResumeScraping(
+		mocks.NewMockPlatform(), nil, &database.Database{MediaDB: mockMediaDB}, nil, nil,
+	)
+
+	mockMediaDB.AssertNotCalled(t, "GetScrapingOperation")
+	mockMediaDB.AssertNotCalled(t, "SetScrapingStatus", mediadb.IndexingStatusFailed)
+	mockMediaDB.AssertNotCalled(t, "ClearScrapingOperation")
+	assert.Equal(t, database.MediaWriteOperationIndexing, mockMediaDB.ActiveMediaWriteOperation())
+	assert.NotZero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryScraping)
+	mockMediaDB.AssertExpectations(t)
+}
+
 func TestCheckAndResumeScraping_StartFailurePersistsTerminalState(t *testing.T) {
 	// Not parallel — manipulates shared scrapingStatusInstance.
 	methods.ClearScrapingStatus()
@@ -1472,11 +1519,12 @@ func TestCheckAndResumeOptimization_RunningStatus(t *testing.T) {
 	pauser := syncutil.NewPauser()
 	notifChan := make(chan models.Notification, 1)
 	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusRunning, nil).Once()
-	mockMediaDB.On("RunBackgroundOptimization", mock.Anything, pauser).Run(func(args mock.Arguments) {
-		callback, ok := args.Get(0).(func(bool))
-		require.True(t, ok)
-		callback(true)
-	}).Once()
+	mockMediaDB.On("RunBackgroundOptimizationWithLease", mock.Anything, pauser, mock.Anything).
+		Run(func(args mock.Arguments) {
+			callback, ok := args.Get(0).(func(bool))
+			require.True(t, ok)
+			callback(true)
+		}).Return(nil).Once()
 
 	checkAndResumeOptimization(db, notifChan, pauser)
 
@@ -1499,7 +1547,9 @@ func TestCheckAndResumeOptimization_CompletedStatus(t *testing.T) {
 	checkAndResumeOptimization(db, make(chan models.Notification, 1), nil)
 
 	mockMediaDB.AssertExpectations(t)
-	mockMediaDB.AssertNotCalled(t, "RunBackgroundOptimization", mock.Anything, mock.Anything)
+	mockMediaDB.AssertNotCalled(
+		t, "RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything,
+	)
 }
 
 func TestStartPublishers_NoPublishers(t *testing.T) {
@@ -1577,11 +1627,36 @@ func TestRunMediaDBStartupMaintenance_PassesPauserToTemporaryRepairOptimization(
 	mockMediaDB.On("TemporaryRepairJobsPending", ctx).Return(true, nil).Once()
 	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Twice()
 	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
-	mockMediaDB.On("RunBackgroundOptimization", mock.Anything, pauser).Once()
+	mockMediaDB.On("RunBackgroundOptimizationWithLease", mock.Anything, pauser, mock.Anything).
+		Return(nil).Once()
 	mockMediaDB.On("BackgroundOperationDone").Once()
 
 	runMediaDBStartupMaintenance(ctx, mockMediaDB, pauser, false)
 
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestRunMediaDBStartupMaintenance_LeaseConflictDefersTemporaryRepair(t *testing.T) {
+	pendingMediaWriteRetries.Store(0)
+	t.Cleanup(func() { pendingMediaWriteRetries.Store(0) })
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	ctx := context.Background()
+	mockMediaDB.On("TrackBackgroundOperation").Once()
+	mockMediaDB.On("TemporaryRepairJobsPending", ctx).Return(true, nil).Once()
+	mockMediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil).Twice()
+	mockMediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil).Once()
+	mockMediaDB.On("BackgroundOperationDone").Once()
+	scrapeLease, err := mockMediaDB.AcquireMediaWrite(database.MediaWriteOperationScraping)
+	require.NoError(t, err)
+	defer scrapeLease.Release()
+
+	runMediaDBStartupMaintenance(ctx, mockMediaDB, nil, true)
+
+	mockMediaDB.AssertNotCalled(
+		t, "RunBackgroundOptimizationWithLease", mock.Anything, mock.Anything, mock.Anything,
+	)
+	assert.NotZero(t, pendingMediaWriteRetries.Load()&mediaWriteRetryMaintenance)
 	mockMediaDB.AssertExpectations(t)
 }
 

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -495,7 +495,12 @@ func runMediaDBStartupMaintenance(
 
 	db.TrackBackgroundOperation()
 	defer db.BackgroundOperationDone()
+	runMediaDBStartupMaintenanceWork(ctx, db, pauser, tagCacheLoaded)
+}
 
+func runMediaDBStartupMaintenanceWork(
+	ctx context.Context, db database.MediaDBI, pauser *syncutil.Pauser, tagCacheLoaded bool,
+) {
 	// Boot here intentionally does NOT issue PRAGMA optimize or
 	// wal_checkpoint(TRUNCATE). SQLite's auto-checkpoint runs PASSIVE
 	// inline with COMMITs and keeps the WAL bounded without blocking
@@ -568,6 +573,24 @@ func runMediaDBStartupMaintenance(
 		return
 	}
 
+	coordinator, coordinatorErr := database.GetMediaDBWriteCoordinator(db)
+	if coordinatorErr != nil {
+		log.Error().Err(coordinatorErr).Msg("temporary media repair cannot get write coordinator")
+		return
+	}
+	lease, acquireErr := coordinator.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+	if acquireErr != nil {
+		if errors.Is(acquireErr, database.ErrMediaWriteConflict) {
+			deferMediaWriteRetry(mediaWriteRetryMaintenance)
+			log.Info().Err(acquireErr).Msg("temporary media repair deferred; media database write active")
+			return
+		}
+		log.Error().Err(acquireErr).Msg("failed to acquire temporary media repair lease")
+		return
+	}
+
 	log.Info().Msg("temporary media repair jobs pending; starting background optimization")
-	db.RunBackgroundOptimization(nil, pauser)
+	if runErr := coordinator.RunBackgroundOptimizationWithLease(nil, pauser, lease); runErr != nil {
+		log.Error().Err(runErr).Msg("temporary media repair optimization failed")
+	}
 }

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -51,6 +51,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -984,6 +985,7 @@ func (m *MockUserDBI) RecoverFromCorruption() (database.RestoreInfo, error) {
 // MockMediaDBI is a mock implementation of the MediaDBI interface using testify/mock
 type MockMediaDBI struct {
 	mock.Mock
+	mediaWriteArbiter     atomic.Pointer[database.MediaWriteArbiter]
 	ScrapeImageSystems    []string
 	TransactionCount      int
 	OperationsOutsideTxn  int
@@ -1919,6 +1921,31 @@ func (m *MockMediaDBI) GetOptimizationStep() (string, error) {
 // the media status query don't each need to stub it. Tests that care about a
 // full RunBackgroundOptimization pass set Optimizing directly; tests exercising
 // the browse-cache self-heal use BeginBrowseCacheRebuild/EndBrowseCacheRebuild.
+func (m *MockMediaDBI) getMediaWriteArbiter() *database.MediaWriteArbiter {
+	if arbiter := m.mediaWriteArbiter.Load(); arbiter != nil {
+		return arbiter
+	}
+	arbiter := &database.MediaWriteArbiter{}
+	if m.mediaWriteArbiter.CompareAndSwap(nil, arbiter) {
+		return arbiter
+	}
+	return m.mediaWriteArbiter.Load()
+}
+
+func (m *MockMediaDBI) AcquireMediaWrite(
+	operation database.MediaWriteOperation,
+) (*database.MediaWriteLease, error) {
+	lease, err := m.getMediaWriteArbiter().TryAcquire(operation)
+	if err != nil {
+		return nil, fmt.Errorf("mock acquire media database write operation: %w", err)
+	}
+	return lease, nil
+}
+
+func (m *MockMediaDBI) ActiveMediaWriteOperation() database.MediaWriteOperation {
+	return m.getMediaWriteArbiter().Active()
+}
+
 func (m *MockMediaDBI) IsOptimizing() bool {
 	return m.Optimizing || m.BrowseCacheRebuilding
 }
@@ -1931,8 +1958,33 @@ func (m *MockMediaDBI) EndBrowseCacheRebuild() {
 	m.BrowseCacheRebuilding = false
 }
 
-func (m *MockMediaDBI) RunBackgroundOptimization(statusCallback func(optimizing bool), pauser *syncutil.Pauser) {
+func (m *MockMediaDBI) RunBackgroundOptimization(
+	statusCallback func(optimizing bool), pauser *syncutil.Pauser,
+) {
+	lease, err := m.AcquireMediaWrite(database.MediaWriteOperationOptimization)
+	if err != nil {
+		return
+	}
+	defer lease.Release()
 	m.Called(statusCallback, pauser)
+}
+
+func (m *MockMediaDBI) RunBackgroundOptimizationWithLease(
+	statusCallback func(optimizing bool), pauser *syncutil.Pauser, lease *database.MediaWriteLease,
+) error {
+	if !lease.ValidFor(database.MediaWriteOperationOptimization) {
+		lease.Release()
+		return database.ErrMediaWriteLease
+	}
+	defer lease.Release()
+	args := m.Called(statusCallback, pauser, lease)
+	if len(args) == 0 {
+		return nil
+	}
+	if err := args.Error(0); err != nil {
+		return fmt.Errorf("mock background optimization with lease failed: %w", err)
+	}
+	return nil
 }
 
 func (m *MockMediaDBI) TemporaryRepairJobsPending(ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Summary

- serialize indexing, scraping, optimization, recovery, and maintenance through a process-local MediaDB write coordinator
- hand write ownership between recovery, indexing, and post-index optimization while deferring durable startup work on conflicts
- preserve shutdown and corruption-recovery ordering with focused race and deadlock regression coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added coordinated handling for media indexing, scraping, optimization, maintenance, and recovery operations.
  - Conflicting media operations now defer safely and retry automatically when the active operation completes.
  - Recovery and post-index optimization now transfer operation ownership without interruption.

- **Bug Fixes**
  - Improved cleanup after failed operations, preventing stale activity from blocking future work.
  - Media write conflicts now produce clear client-facing errors.
  - Resolved issues with stale optimization status affecting selective indexing and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->