### PR TITLE
fix(mister): canonicalize external arcade play sessions

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -888,6 +888,10 @@ type UserDBI interface {
 	AddMediaHistory(entry *MediaHistoryEntry) (int64, error)
 	UpdateMediaHistoryTime(dbid int64, playTime int) error
 	UpdateMediaHistoryIdentity(dbid int64, identity *MediaIdentity) (bool, error)
+	// UpdateMediaHistoryIdentityAndPath is UpdateMediaHistoryIdentity plus a
+	// MediaPath correction, for backfilling legacy rows recorded under a
+	// non-path external identifier (e.g. a MiSTer arcade set name).
+	UpdateMediaHistoryIdentityAndPath(dbid int64, path string, identity *MediaIdentity) (bool, error)
 	CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error
 	GetMediaHistory(systemIDs []string, lastID int64, limit int) ([]MediaHistoryEntry, error)
 	GetDistinctMediaHistory(

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -313,7 +313,8 @@ func sqlUpdateMediaHistoryIdentityAndPath(
 		WHERE DBID = ?
 		  AND (
 		    MediaIdentityPolicyVersion < ? OR
-		    (MediaIdentityPolicyVersion = ? AND MediaIdentity = '')
+		    (MediaIdentityPolicyVersion = ? AND MediaIdentity = '') OR
+		    MediaPath <> ?
 		  );
 	`,
 		path,
@@ -325,6 +326,7 @@ func sqlUpdateMediaHistoryIdentityAndPath(
 		dbid,
 		identity.PolicyVersion,
 		identity.PolicyVersion,
+		path,
 	)
 	if err != nil {
 		return false, fmt.Errorf("failed to execute media history identity and path update: %w", err)

--- a/pkg/database/userdb/media_history.go
+++ b/pkg/database/userdb/media_history.go
@@ -57,6 +57,18 @@ func (db *UserDB) UpdateMediaHistoryIdentity(dbid int64, identity *database.Medi
 	return sqlUpdateMediaHistoryIdentity(db.ctx, db.sql.Load(), dbid, identity)
 }
 
+// UpdateMediaHistoryIdentityAndPath is UpdateMediaHistoryIdentity plus a
+// MediaPath correction, for backfilling legacy rows recorded under a
+// non-path external identifier (e.g. a MiSTer arcade set name).
+func (db *UserDB) UpdateMediaHistoryIdentityAndPath(
+	dbid int64, path string, identity *database.MediaIdentity,
+) (bool, error) {
+	if db.sql.Load() == nil {
+		return false, ErrNullSQL
+	}
+	return sqlUpdateMediaHistoryIdentityAndPath(db.ctx, db.sql.Load(), dbid, path, identity)
+}
+
 // CloseMediaHistory finalizes a media history entry with end time and final play time.
 func (db *UserDB) CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error {
 	if db.sql.Load() == nil {
@@ -278,6 +290,48 @@ func sqlUpdateMediaHistoryIdentity(
 	rows, err := result.RowsAffected()
 	if err != nil {
 		return false, fmt.Errorf("failed to count media history identity update: %w", err)
+	}
+	return rows > 0, nil
+}
+
+// sqlUpdateMediaHistoryIdentityAndPath is sqlUpdateMediaHistoryIdentity plus
+// a MediaPath correction. DBID, ID (session UUID), StartTime/EndTime,
+// PlayTime, and ProfileID are untouched.
+func sqlUpdateMediaHistoryIdentityAndPath(
+	ctx context.Context, db *sql.DB, dbid int64, path string, identity *database.MediaIdentity,
+) (bool, error) {
+	if identity == nil {
+		return false, errors.New("media history identity is required")
+	}
+	if path == "" {
+		return false, errors.New("media history path is required")
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE MediaHistory
+		SET MediaPath = ?, MediaName = ?, Tags = ?, MediaIdentity = ?, MediaIdentityPolicyVersion = ?,
+		    UpdatedAt = MAX(?, UpdatedAt + 1), SyncedAt = NULL
+		WHERE DBID = ?
+		  AND (
+		    MediaIdentityPolicyVersion < ? OR
+		    (MediaIdentityPolicyVersion = ? AND MediaIdentity = '')
+		  );
+	`,
+		path,
+		identity.DisplayName,
+		database.EncodeTagStrings(identity.LegacyTags()),
+		database.EncodeMediaIdentity(identity),
+		identity.PolicyVersion,
+		time.Now().Unix(),
+		dbid,
+		identity.PolicyVersion,
+		identity.PolicyVersion,
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute media history identity and path update: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("failed to count media history identity and path update: %w", err)
 	}
 	return rows > 0, nil
 }

--- a/pkg/database/userdb/media_history_sync_integration_test.go
+++ b/pkg/database/userdb/media_history_sync_integration_test.go
@@ -238,6 +238,55 @@ func TestMediaHistoryIdentityMutation_RequeuesAfterStaleSyncAcknowledgement(t *t
 	assert.False(t, updated, "same-policy live/backfill races must be idempotent")
 }
 
+// A backfilled arcade set-name row (recorded under a bare set name like
+// "pooyan" because the launch wasn't Zaparoo-initiated) must resync under
+// its original session UUID with the corrected canonical path, not as a
+// second session - the server upserts by session_uuid, so this is what
+// keeps the enrichment from creating a duplicate remote session.
+func TestMediaHistoryIdentityAndPathMutation_RequeuesWithSameUUIDAndCanonicalPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	sessionUUID := "22222222-2222-4222-8222-222222222222"
+	base := time.Now().Add(-24 * time.Hour).Truncate(time.Second)
+	startTime := base.Add(-30 * time.Minute)
+	dbid, err := userDB.AddMediaHistory(&database.MediaHistoryEntry{
+		ID: sessionUUID, StartTime: startTime, SystemID: "Arcade", SystemName: "Arcade",
+		MediaPath: "pooyan", MediaName: "Arcade", LauncherID: "", PlayTime: 1800,
+		BootUUID: "boot-1", ClockReliable: true, ClockSource: "system",
+		CreatedAt: startTime, UpdatedAt: base.Add(-time.Second),
+	})
+	require.NoError(t, err)
+	require.NoError(t, userDB.CloseMediaHistory(dbid, base, 1800))
+
+	initial, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, initial, 1)
+	require.Equal(t, sessionUUID, initial[0].ID)
+	staleRef := database.MediaHistorySyncRef{DBID: dbid, UpdatedAt: initial[0].UpdatedAt}
+	require.NoError(t, userDB.MarkMediaHistorySynced(
+		[]database.MediaHistorySyncRef{staleRef}, time.Now().Truncate(time.Second),
+	))
+
+	canonicalPath := filepath.Join("_Arcade", "Pooyan.mra")
+	identity := mediaHistoryIdentityFixture("Pooyan", database.CurrentMediaIdentityPolicyVersion)
+	updated, err := userDB.UpdateMediaHistoryIdentityAndPath(dbid, canonicalPath, identity)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	batch, err := userDB.GetMediaHistorySyncBatch(time.Time{}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1, "the correction must requeue the existing row, not add a second one")
+	assert.Equal(t, sessionUUID, batch[0].ID, "resync must upsert the original session, not create a duplicate")
+	assert.Equal(t, canonicalPath, batch[0].MediaPath)
+	assert.Equal(t, identity, batch[0].MediaIdentity)
+	assert.Nil(t, batch[0].SyncedAt)
+	assert.True(t, batch[0].UpdatedAt.After(staleRef.UpdatedAt))
+}
+
 func TestMediaHistoryCloseAndIdentityEnrichment_PreserveBothUpdates(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/userdb/media_history_sync_integration_test.go
+++ b/pkg/database/userdb/media_history_sync_integration_test.go
@@ -287,6 +287,39 @@ func TestMediaHistoryIdentityAndPathMutation_RequeuesWithSameUUIDAndCanonicalPat
 	assert.True(t, batch[0].UpdatedAt.After(staleRef.UpdatedAt))
 }
 
+func TestMediaHistoryIdentityAndPathMutation_CorrectsPathWithCurrentIdentity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	userDB, cleanup := setupTempUserDB(t)
+	defer cleanup()
+
+	now := time.Now().Truncate(time.Second)
+	dbid, err := userDB.AddMediaHistory(&database.MediaHistoryEntry{
+		ID: "33333333-3333-4333-8333-333333333333", StartTime: now.Add(-time.Minute),
+		SystemID: "Arcade", SystemName: "Arcade", MediaPath: "pooyan", MediaName: "Pooyan",
+		BootUUID: "boot-1", ClockReliable: true, ClockSource: "system",
+		CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Second),
+	})
+	require.NoError(t, err)
+
+	identity := mediaHistoryIdentityFixture("Pooyan", database.CurrentMediaIdentityPolicyVersion)
+	updated, err := userDB.UpdateMediaHistoryIdentity(dbid, identity)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	canonicalPath := filepath.Join("_Arcade", "Pooyan.mra")
+	updated, err = userDB.UpdateMediaHistoryIdentityAndPath(dbid, canonicalPath, identity)
+	require.NoError(t, err)
+	require.True(t, updated, "canonical path correction must not be blocked by a current identity")
+
+	history, err := userDB.GetMediaHistory([]string{"Arcade"}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, canonicalPath, history[0].MediaPath)
+	assert.Equal(t, identity, history[0].MediaIdentity)
+}
+
 func TestMediaHistoryCloseAndIdentityEnrichment_PreserveBothUpdates(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -343,6 +343,7 @@ func TestSqlUpdateMediaHistoryIdentityAndPath(t *testing.T) {
 				int64(40),
 				identity.PolicyVersion,
 				identity.PolicyVersion,
+				canonicalPath,
 			)
 			if tt.execErr != nil {
 				expectation.WillReturnError(tt.execErr)

--- a/pkg/database/userdb/media_history_test.go
+++ b/pkg/database/userdb/media_history_test.go
@@ -299,6 +299,104 @@ func TestSqlUpdateMediaHistoryIdentity_ReportsUncountableUpdate(t *testing.T) {
 	assert.NoError(t, mockDB.ExpectationsWereMet())
 }
 
+func TestSqlUpdateMediaHistoryIdentityAndPath(t *testing.T) {
+	t.Parallel()
+
+	canonicalPath := filepath.Join("_Arcade", "Pooyan.mra")
+	identity := database.MediaIdentity{
+		MediaType:              "Arcade",
+		CanonicalSystemID:      "Arcade",
+		DisplayName:            "Pooyan",
+		CoreSlug:               "pooyan",
+		ObservationFingerprint: "sha256:test",
+		Tags: []database.MediaIdentityTag{
+			{Type: "region", Value: "us", Role: database.MediaIdentityTagRoleIdentity},
+		},
+		PolicyVersion: database.CurrentMediaIdentityPolicyVersion,
+	}
+	tests := []struct {
+		execErr error
+		name    string
+	}{
+		{name: "success"},
+		{name: "database error", execErr: sqlmock.ErrCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db, mockDB, err := testsqlmock.NewSQLMock()
+			require.NoError(t, err)
+			defer func() { _ = db.Close() }()
+
+			expectation := mockDB.ExpectExec(
+				`UPDATE MediaHistory SET MediaPath = \?, MediaName = \?, Tags = \?, MediaIdentity = \?, `+
+					`MediaIdentityPolicyVersion = \?, UpdatedAt = MAX\(\?, UpdatedAt \+ 1\), `+
+					`SyncedAt = NULL WHERE DBID = \?.*MediaIdentityPolicyVersion < \?`,
+			).WithArgs(
+				canonicalPath,
+				identity.DisplayName,
+				database.EncodeTagStrings(identity.LegacyTags()),
+				database.EncodeMediaIdentity(&identity),
+				identity.PolicyVersion,
+				sqlmock.AnyArg(),
+				int64(40),
+				identity.PolicyVersion,
+				identity.PolicyVersion,
+			)
+			if tt.execErr != nil {
+				expectation.WillReturnError(tt.execErr)
+			} else {
+				expectation.WillReturnResult(sqlmock.NewResult(0, 1))
+			}
+
+			updated, updateErr := sqlUpdateMediaHistoryIdentityAndPath(
+				context.Background(), db, 40, canonicalPath, &identity,
+			)
+			if tt.execErr != nil {
+				require.Error(t, updateErr)
+				assert.Contains(t, updateErr.Error(), "failed to execute media history identity and path update")
+				assert.False(t, updated)
+			} else {
+				require.NoError(t, updateErr)
+				assert.True(t, updated)
+			}
+			assert.NoError(t, mockDB.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSqlUpdateMediaHistoryIdentityAndPath_RejectsNilIdentity(t *testing.T) {
+	t.Parallel()
+	db, mockDB, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	updated, err := sqlUpdateMediaHistoryIdentityAndPath(context.Background(), db, 40, "path.mra", nil)
+	require.Error(t, err)
+	assert.False(t, updated)
+	assert.NoError(t, mockDB.ExpectationsWereMet(), "no statement may reach the database")
+}
+
+// An empty path would otherwise blank MediaPath on the row it is meant to
+// correct, leaving the enriched session unlaunchable and unidentifiable.
+func TestSqlUpdateMediaHistoryIdentityAndPath_RejectsEmptyPath(t *testing.T) {
+	t.Parallel()
+	db, mockDB, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	identity := database.MediaIdentity{
+		MediaType: "Arcade", CanonicalSystemID: "Arcade", DisplayName: "Pooyan",
+		CoreSlug: "pooyan", ObservationFingerprint: "sha256:test",
+		PolicyVersion: database.CurrentMediaIdentityPolicyVersion,
+	}
+	updated, err := sqlUpdateMediaHistoryIdentityAndPath(context.Background(), db, 40, "", &identity)
+	require.Error(t, err)
+	assert.False(t, updated)
+	assert.NoError(t, mockDB.ExpectationsWereMet(), "no statement may reach the database")
+}
+
 func TestSqlCloseMediaHistory_Success(t *testing.T) {
 	t.Parallel()
 	db, mock, err := testsqlmock.NewSQLMock()

--- a/pkg/platforms/launch.go
+++ b/pkg/platforms/launch.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/assets"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/rs/zerolog/log"
@@ -223,21 +224,21 @@ func DoLaunch(params *LaunchParams, getDisplayName func(string) string) error {
 		return nil
 	}
 
-	// Try to look up SystemID from MediaDB if launcher doesn't have one
+	// Look up the indexed display name from MediaDB. SearchMediaPathExact
+	// requires at least one system to search - a launcher without a
+	// SystemID has nothing to scope the search to, so displayName stays the
+	// filename-parsed fallback in that case, same as before.
 	systemID := params.Launcher.SystemID
 	displayName := tags.ParseTitleFromFilename(getDisplayName(params.Path), false)
 
-	if params.DB != nil && params.DB.MediaDB != nil {
+	if systemID != "" && params.DB != nil && params.DB.MediaDB != nil {
 		ctx, cancel := activeMediaLookupContext(params.Context)
-		results, searchErr := params.DB.MediaDB.SearchMediaPathExact(ctx, nil, params.Path)
+		results, searchErr := params.DB.MediaDB.SearchMediaPathExact(
+			ctx, []systemdefs.System{{ID: systemID}}, params.Path,
+		)
 		cancel()
-		if searchErr == nil && len(results) > 0 {
-			if systemID == "" && results[0].SystemID != "" {
-				systemID = results[0].SystemID
-			}
-			if results[0].Name != "" {
-				displayName = results[0].Name
-			}
+		if searchErr == nil && len(results) > 0 && results[0].Name != "" {
+			displayName = results[0].Name
 		}
 	}
 

--- a/pkg/platforms/mister/mistermain/recents.go
+++ b/pkg/platforms/mister/mistermain/recents.go
@@ -22,6 +22,7 @@
 package mistermain
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -47,11 +48,15 @@ func ReadRecent(path string) ([]RecentEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
+	defer func() { _ = file.Close() }()
 
 	for {
 		entry := make([]byte, 1024+256+256)
-		n, err := file.Read(entry)
-		if err == io.EOF || n == 0 {
+		_, err := io.ReadFull(file, entry)
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			// EOF: no more records. ErrUnexpectedEOF: a truncated final
+			// record from a write still in progress - discard it rather
+			// than treat partial bytes as a record.
 			break
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to read file: %w", err)

--- a/pkg/platforms/mister/mistermain/recents_test.go
+++ b/pkg/platforms/mister/mistermain/recents_test.go
@@ -1,0 +1,109 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mistermain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recentBinaryEntry builds one raw 1536-byte MiSTer recent-file record:
+// 1024 bytes directory, 256 bytes name, 256 bytes label, NUL-padded.
+func recentBinaryEntry(directory, name, label string) []byte {
+	entry := make([]byte, 1024+256+256)
+	copy(entry[:1024], directory)
+	copy(entry[1024:1280], name)
+	copy(entry[1280:1536], label)
+	return entry
+}
+
+func TestReadRecent_MultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "test_recent.cfg")
+	data := append(
+		recentBinaryEntry("games/NES", "Game1.nes", "Game 1"),
+		recentBinaryEntry("games/SNES", "Game2.sfc", "Game 2")...,
+	)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	entries, err := ReadRecent(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	assert.Equal(t, RecentEntry{Directory: "games/NES", Name: "Game1.nes", Label: "Game 1"}, entries[0])
+	assert.Equal(t, RecentEntry{Directory: "games/SNES", Name: "Game2.sfc", Label: "Game 2"}, entries[1])
+}
+
+func TestReadRecent_StopsAtZeroedRecord(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "test_recent.cfg")
+	data := append(
+		recentBinaryEntry("games/NES", "Game1.nes", "Game 1"),
+		make([]byte, 1024+256+256)...,
+	)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	entries, err := ReadRecent(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "a zeroed (cleared) slot must not be read as a record")
+}
+
+// A recent file caught mid-write by MiSTer (MakeFile truncates before
+// rewriting) can end with a partial final record. That must be silently
+// discarded, not returned as a garbage entry or treated as a read error.
+func TestReadRecent_DiscardsTruncatedFinalRecord(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "test_recent.cfg")
+	full := recentBinaryEntry("games/NES", "Game1.nes", "Game 1")
+	truncated := full[:900] // less than one full 1536-byte record
+	data := append(append([]byte{}, full...), truncated...)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	entries, err := ReadRecent(path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the truncated trailing record must be discarded, not returned")
+	assert.Equal(t, "Game1.nes", entries[0].Name)
+}
+
+func TestReadRecent_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReadRecent(filepath.Join(t.TempDir(), "missing.cfg"))
+	require.Error(t, err)
+}
+
+func TestReadRecent_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "empty.cfg")
+	require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+	entries, err := ReadRecent(path)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -367,6 +367,22 @@ func (p *Platform) StartPost(
 		log.Debug().Msg("no idle scheduler; skipping arcade DB update")
 	}
 
+	// One-time cleanup: resolve legacy MediaHistory rows recorded under a
+	// bare arcade set name (from before the tracker could canonicalize
+	// externally detected arcade launches) to their real .mra path and
+	// identity. Deferred to the idle scheduler for the same reason as the
+	// arcade DB update; the task itself retries internally until it
+	// succeeds, since Schedule only runs it once.
+	if scheduler != nil {
+		scheduler.Schedule(
+			ctx, "arcade-history-backfill",
+			5*time.Second, 300*time.Second,
+			func(ctx context.Context) { tracker.RunArcadeHistoryBackfill(ctx, db, tr) },
+		)
+	} else {
+		log.Debug().Msg("no idle scheduler; skipping arcade history backfill")
+	}
+
 	// If the RBF cache loaded from disk but its shallow manifest drifted,
 	// the persisted entries are still serving requests but a rescan is
 	// needed to pick up any added/removed cores. Defer the rescan to the

--- a/pkg/platforms/mister/tracker/arcade_history_backfill.go
+++ b/pkg/platforms/mister/tracker/arcade_history_backfill.go
@@ -1,0 +1,178 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// arcadeHistoryBackfillDeviceStateKey marks the one-time arcade history
+	// backfill complete. Versioned so a future change to the resolution
+	// policy can revisit rows a prior version left unresolved.
+	arcadeHistoryBackfillDeviceStateKey = "mister_arcade_history_backfill_v1"
+	// arcadeHistoryBackfillRetryInterval paces retries when a pass can't
+	// fully resolve every candidate row yet (MediaDB still indexing, or a
+	// transient write failure). Not urgent, no backoff needed - this isn't
+	// hitting an external service and the cost of a no-op pass is negligible.
+	arcadeHistoryBackfillRetryInterval = 5 * time.Minute
+	arcadeHistoryBackfillPageSize      = 100
+)
+
+// RunArcadeHistoryBackfill resolves every legacy MediaHistory row recorded
+// under a bare arcade set name (MediaPath = "pooyan", not a path - from a
+// launch the tracker detected externally, before ResolveArcadeSetName
+// existed) to its canonical .mra path and identity, then never runs again.
+// Intended to run once as an idle-scheduler task for the life of the
+// platform; blocks until fully done or ctx is cancelled.
+func RunArcadeHistoryBackfill(ctx context.Context, db *database.Database, tr *Tracker) {
+	runArcadeHistoryBackfillAtInterval(ctx, db, tr, arcadeHistoryBackfillRetryInterval)
+}
+
+func runArcadeHistoryBackfillAtInterval(
+	ctx context.Context, db *database.Database, tr *Tracker, retryInterval time.Duration,
+) {
+	if db == nil || db.UserDB == nil || db.MediaDB == nil || tr == nil {
+		return
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if _, found, _ := db.UserDB.GetDeviceState(arcadeHistoryBackfillDeviceStateKey); found {
+			return
+		}
+
+		if mediaDBReadyForArcadeBackfill(db.MediaDB) {
+			log.Debug().Msg("arcade history backfill: starting pass")
+			if runArcadeHistoryBackfillPass(ctx, db, tr) {
+				err := db.UserDB.SetDeviceState(arcadeHistoryBackfillDeviceStateKey, "done")
+				if err == nil {
+					log.Info().Msg("arcade history backfill complete")
+					return
+				}
+				log.Warn().Err(err).Msg("failed to record arcade history backfill completion")
+				// Not fatal: the next retry will simply redo a pass that
+				// finds nothing left to fix and try to mark done again.
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retryInterval):
+		}
+	}
+}
+
+// mediaDBReadyForArcadeBackfill reports whether MediaDB is idle enough to
+// read from: no indexing or optimization under way. Status read failures
+// count as unready, matching the general media history identity sweep's
+// caution (pkg/service/media_history_backfill.go).
+func mediaDBReadyForArcadeBackfill(mediaDB database.MediaDBI) bool {
+	indexingStatus, err := mediaDB.GetIndexingStatus()
+	if err != nil {
+		return false
+	}
+	if indexingStatus == mediadb.IndexingStatusRunning || indexingStatus == mediadb.IndexingStatusPending {
+		return false
+	}
+	optimizationStatus, err := mediaDB.GetOptimizationStatus()
+	if err != nil {
+		return false
+	}
+	return optimizationStatus != mediadb.IndexingStatusRunning && optimizationStatus != mediadb.IndexingStatusPending
+}
+
+// runArcadeHistoryBackfillPass walks every Arcade MediaHistory row once,
+// resolving what it can. Returns true only when every candidate row seen
+// this pass ended up resolved - the only condition under which the caller
+// marks the task permanently done.
+func runArcadeHistoryBackfillPass(ctx context.Context, db *database.Database, tr *Tracker) bool {
+	var cursor int64
+	clean := true
+	for {
+		if ctx.Err() != nil {
+			return false
+		}
+		batch, err := db.UserDB.GetMediaHistory([]string{ArcadeSystem}, cursor, arcadeHistoryBackfillPageSize)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to read arcade media history for backfill")
+			return false
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for i := range batch {
+			entry := &batch[i]
+			cursor = entry.DBID
+			if entry.MediaIdentity != nil || filepath.IsAbs(entry.MediaPath) {
+				continue // already resolved, or already a real path
+			}
+			if !resolveAndFixArcadeHistoryRow(ctx, db, tr, entry) {
+				clean = false
+			}
+		}
+		if len(batch) < arcadeHistoryBackfillPageSize {
+			break
+		}
+	}
+	return clean
+}
+
+// resolveAndFixArcadeHistoryRow resolves one row's set-name MediaPath to its
+// canonical .mra path and identity, then persists both atomically. Returns
+// false for any outcome that leaves the row unresolved - unconfirmed set
+// name, no matching indexed entry, or a write failure - so the caller
+// retries it on a later pass.
+func resolveAndFixArcadeHistoryRow(
+	ctx context.Context, db *database.Database, tr *Tracker, entry *database.MediaHistoryEntry,
+) bool {
+	rowCtx, cancel := context.WithTimeout(ctx, mediaLookupTimeout)
+	defer cancel()
+
+	path, ok := tr.ResolveExternalMediaPath(rowCtx, entry.SystemID, entry.MediaPath)
+	if !ok {
+		return false
+	}
+	identity, found, err := database.LookupMediaIdentity(rowCtx, db.MediaDB, entry.SystemID, path)
+	if err != nil || !found {
+		return false
+	}
+	updated, err := db.UserDB.UpdateMediaHistoryIdentityAndPath(entry.DBID, path, &identity)
+	if err != nil {
+		log.Warn().Err(err).Int64("dbid", entry.DBID).
+			Msg("failed to backfill arcade history identity and path")
+		return false
+	}
+	if !updated {
+		log.Debug().Int64("dbid", entry.DBID).Msg("arcade history row already had current identity")
+	}
+	return true
+}

--- a/pkg/platforms/mister/tracker/arcade_history_backfill_test.go
+++ b/pkg/platforms/mister/tracker/arcade_history_backfill_test.go
@@ -1,0 +1,310 @@
+//go:build linux
+
+package tracker
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	testinghelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// stubSettledMediaDB makes the mock report an idle, ready-to-read MediaDB.
+func stubSettledArcadeMediaDB(mediaDB *testinghelpers.MockMediaDBI) {
+	mediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusCompleted, nil)
+	mediaDB.On("GetOptimizationStatus").Return(mediadb.IndexingStatusCompleted, nil)
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_SkipsWhenAlreadyDone(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	userDB.On("GetDeviceState", arcadeHistoryBackfillDeviceStateKey).Return("done", true, nil)
+
+	runArcadeHistoryBackfillAtInterval(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{}, time.Millisecond,
+	)
+
+	userDB.AssertNotCalled(t, "GetMediaHistory", mock.Anything, mock.Anything, mock.Anything)
+	mediaDB.AssertNotCalled(t, "GetIndexingStatus")
+	userDB.AssertExpectations(t)
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_MarksDoneAfterCleanPass(t *testing.T) {
+	t.Parallel()
+
+	mraPath := filepath.Join(t.TempDir(), "Pooyan.mra")
+	writeTestMRA(t, mraPath, "pooyan", "Pooyan")
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	stubSettledArcadeMediaDB(mediaDB)
+	userDB.On("GetDeviceState", arcadeHistoryBackfillDeviceStateKey).Return("", false, nil).Once()
+	// A short page (fewer rows than the page size) already ends the walk, so
+	// no follow-up call with the advanced cursor is expected.
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 5, SystemID: ArcadeSystem, MediaPath: "pooyan"},
+		}, nil).Once()
+	mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+		Return([]database.SearchResultWithCursor{{Path: mraPath}}, nil)
+	mediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, mraPath).
+		Return([]database.SearchResult{{
+			SystemID: ArcadeSystem, Name: "Pooyan", Path: mraPath, Slug: "pooyan", MediaID: 9,
+		}}, nil)
+	mediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(9)).
+		Return([]database.TagInfo{}, nil)
+	userDB.On("UpdateMediaHistoryIdentityAndPath", int64(5), mraPath, mock.Anything).
+		Return(true, nil).Once()
+	userDB.On("SetDeviceState", arcadeHistoryBackfillDeviceStateKey, "done").Return(nil).Once()
+
+	tr := &Tracker{
+		db:      &database.Database{UserDB: userDB, MediaDB: mediaDB},
+		NameMap: []NameMapping{{CoreName: "pooyan", System: ArcadeSystem, ArcadeName: "Pooyan"}},
+	}
+	runArcadeHistoryBackfillAtInterval(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, tr, time.Millisecond,
+	)
+
+	userDB.AssertExpectations(t)
+	mediaDB.AssertExpectations(t)
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_RetriesCompletionMarkerWrite(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	stubSettledArcadeMediaDB(mediaDB)
+	userDB.On("GetDeviceState", arcadeHistoryBackfillDeviceStateKey).Return("", false, nil)
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry{}, nil)
+	userDB.On("SetDeviceState", arcadeHistoryBackfillDeviceStateKey, "done").Return(assert.AnError).Once()
+	userDB.On("SetDeviceState", arcadeHistoryBackfillDeviceStateKey, "done").Return(nil).Once()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	runArcadeHistoryBackfillAtInterval(
+		ctx, &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{}, time.Millisecond,
+	)
+
+	require.NoError(t, ctx.Err())
+	userDB.AssertExpectations(t)
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_RetriesWhileMediaDBUnsettled(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	userDB.On("GetDeviceState", arcadeHistoryBackfillDeviceStateKey).Return("", false, nil)
+	mediaDB.On("GetIndexingStatus").Return(mediadb.IndexingStatusRunning, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runArcadeHistoryBackfillAtInterval(
+			ctx, &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{}, 5*time.Millisecond,
+		)
+	}()
+
+	// Give it a couple of retry cycles to prove it never reads history while
+	// unsettled, then stop it.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("backfill did not stop after cancellation")
+	}
+
+	userDB.AssertNotCalled(t, "GetMediaHistory", mock.Anything, mock.Anything, mock.Anything)
+	userDB.AssertNotCalled(t, "SetDeviceState", mock.Anything, mock.Anything)
+	mediaDB.AssertNotCalled(t, "GetOptimizationStatus")
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_RetriesWhenRowUnresolved(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	stubSettledArcadeMediaDB(mediaDB)
+	userDB.On("GetDeviceState", arcadeHistoryBackfillDeviceStateKey).Return("", false, nil)
+	// No NameMap entry for "unknownset", so every pass leaves it unresolved.
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 7, SystemID: ArcadeSystem, MediaPath: "unknownset"},
+		}, nil)
+
+	tr := &Tracker{db: &database.Database{UserDB: userDB, MediaDB: mediaDB}}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runArcadeHistoryBackfillAtInterval(
+			ctx, &database.Database{UserDB: userDB, MediaDB: mediaDB}, tr, 5*time.Millisecond,
+		)
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("backfill did not stop after cancellation")
+	}
+
+	userDB.AssertNotCalled(t, "SetDeviceState", mock.Anything, mock.Anything)
+	userDB.AssertNotCalled(t, "UpdateMediaHistoryIdentityAndPath", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestRunArcadeHistoryBackfillAtInterval_NilDependenciesReturnImmediately(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+
+	// Each case is missing exactly one required dependency.
+	runArcadeHistoryBackfillAtInterval(context.Background(), nil, &Tracker{}, time.Millisecond)
+	runArcadeHistoryBackfillAtInterval(
+		context.Background(), &database.Database{MediaDB: mediaDB}, &Tracker{}, time.Millisecond,
+	)
+	runArcadeHistoryBackfillAtInterval(
+		context.Background(), &database.Database{UserDB: userDB}, &Tracker{}, time.Millisecond,
+	)
+	runArcadeHistoryBackfillAtInterval(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, nil, time.Millisecond,
+	)
+
+	userDB.AssertNotCalled(t, "GetDeviceState", mock.Anything)
+	mediaDB.AssertNotCalled(t, "GetIndexingStatus")
+}
+
+func TestRunArcadeHistoryBackfillPass_SkipsAlreadyResolvedRows(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	absPath, err := filepath.Abs(filepath.Join("_Arcade", "AlreadyReal.mra"))
+	require.NoError(t, err)
+
+	// A short page already ends the walk, so no follow-up call is expected.
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 1, SystemID: ArcadeSystem, MediaPath: "some.mra", MediaIdentity: &database.MediaIdentity{}},
+			{DBID: 2, SystemID: ArcadeSystem, MediaPath: absPath},
+		}, nil).Once()
+
+	clean := runArcadeHistoryBackfillPass(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{},
+	)
+
+	assert.True(t, clean, "rows already resolved or already a real path need no work")
+	userDB.AssertNotCalled(t, "UpdateMediaHistoryIdentityAndPath", mock.Anything, mock.Anything, mock.Anything)
+	userDB.AssertExpectations(t)
+}
+
+// A full page (== page size) does not by itself end the walk - only a page
+// shorter than the page size does. The next call must carry the last row's
+// DBID as its cursor.
+func TestRunArcadeHistoryBackfillPass_PaginatesFullPages(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+
+	fullPage := make([]database.MediaHistoryEntry, arcadeHistoryBackfillPageSize)
+	for i := range fullPage {
+		fullPage[i] = database.MediaHistoryEntry{
+			DBID: int64(i + 1), SystemID: ArcadeSystem,
+			MediaPath: "resolved.mra", MediaIdentity: &database.MediaIdentity{},
+		}
+	}
+	lastDBID := fullPage[len(fullPage)-1].DBID
+
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return(fullPage, nil).Once()
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, lastDBID, arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry{}, nil).Once()
+
+	clean := runArcadeHistoryBackfillPass(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{},
+	)
+
+	assert.True(t, clean)
+	userDB.AssertExpectations(t)
+}
+
+func TestRunArcadeHistoryBackfillPass_ReadFailureIsNotClean(t *testing.T) {
+	t.Parallel()
+
+	userDB := testinghelpers.NewMockUserDBI()
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	userDB.On("GetMediaHistory", []string{ArcadeSystem}, int64(0), arcadeHistoryBackfillPageSize).
+		Return([]database.MediaHistoryEntry(nil), assert.AnError).Once()
+
+	clean := runArcadeHistoryBackfillPass(
+		context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, &Tracker{},
+	)
+
+	assert.False(t, clean)
+}
+
+func TestResolveAndFixArcadeHistoryRow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unresolved set name", func(t *testing.T) {
+		t.Parallel()
+		userDB := testinghelpers.NewMockUserDBI()
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		tr := &Tracker{db: &database.Database{UserDB: userDB, MediaDB: mediaDB}}
+
+		ok := resolveAndFixArcadeHistoryRow(
+			context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, tr,
+			&database.MediaHistoryEntry{DBID: 1, SystemID: ArcadeSystem, MediaPath: "unknownset"},
+		)
+
+		assert.False(t, ok)
+		userDB.AssertNotCalled(t, "UpdateMediaHistoryIdentityAndPath", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("write failure leaves row unresolved", func(t *testing.T) {
+		t.Parallel()
+		mraPath := filepath.Join(t.TempDir(), "Pooyan.mra")
+		writeTestMRA(t, mraPath, "pooyan", "Pooyan")
+
+		userDB := testinghelpers.NewMockUserDBI()
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: mraPath}}, nil)
+		mediaDB.On("SearchMediaPathExact", mock.Anything, mock.Anything, mraPath).
+			Return([]database.SearchResult{{
+				SystemID: ArcadeSystem, Name: "Pooyan", Path: mraPath, Slug: "pooyan", MediaID: 3,
+			}}, nil)
+		mediaDB.On("GetMediaTagsByMediaDBID", mock.Anything, int64(3)).
+			Return([]database.TagInfo{}, nil)
+		userDB.On("UpdateMediaHistoryIdentityAndPath", int64(6), mraPath, mock.Anything).
+			Return(false, assert.AnError)
+
+		tr := &Tracker{
+			db:      &database.Database{UserDB: userDB, MediaDB: mediaDB},
+			NameMap: []NameMapping{{CoreName: "pooyan", System: ArcadeSystem, ArcadeName: "Pooyan"}},
+		}
+		ok := resolveAndFixArcadeHistoryRow(
+			context.Background(), &database.Database{UserDB: userDB, MediaDB: mediaDB}, tr,
+			&database.MediaHistoryEntry{DBID: 6, SystemID: ArcadeSystem, MediaPath: "pooyan"},
+		)
+
+		assert.False(t, ok)
+	})
+}

--- a/pkg/platforms/mister/tracker/arcaderesolve.go
+++ b/pkg/platforms/mister/tracker/arcaderesolve.go
@@ -1,0 +1,96 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
+	"github.com/rs/zerolog/log"
+)
+
+// ResolveArcadeSetName maps a MiSTer arcade core's set name (as reported by
+// /tmp/CORENAME) to the single indexed .mra file that owns it. arcadeName is
+// the pretty name from ArcadeDatabase.csv, used to narrow the MediaDB search
+// before each candidate is confirmed by parsing its own <setname>. Ambiguous
+// or unconfirmable set names report ok=false rather than guessing - callers
+// keep today's set-name-only behaviour in that case.
+func ResolveArcadeSetName(
+	ctx context.Context, mediaDB database.MediaDBI, setName, arcadeName string,
+) (path string, ok bool) {
+	if mediaDB == nil || setName == "" || arcadeName == "" {
+		return "", false
+	}
+
+	results, err := mediaDB.SearchMediaBySlug(ctx, ArcadeSystem, arcadeName, nil)
+	if err != nil {
+		log.Debug().Err(err).Str("setname", setName).Msg("failed to search media for arcade set name")
+		return "", false
+	}
+
+	candidates := dedupeMediaPaths(results)
+	if len(candidates) == 0 {
+		return "", false
+	}
+
+	var confirmed []string
+	unreadable := 0
+	for _, candidate := range candidates {
+		mra, mraErr := mgls.ReadMRA(candidate)
+		switch {
+		case mraErr != nil:
+			unreadable++
+		case strings.EqualFold(mra.SetName, setName):
+			confirmed = append(confirmed, candidate)
+		}
+	}
+
+	switch {
+	case len(confirmed) == 1:
+		return confirmed[0], true
+	case len(confirmed) == 0 && len(candidates) == 1 && unreadable == 1:
+		// The only slug candidate couldn't be confirmed (unreadable MRA),
+		// but it is still the best - and only - available match.
+		return candidates[0], true
+	default:
+		return "", false
+	}
+}
+
+func dedupeMediaPaths(results []database.SearchResultWithCursor) []string {
+	seen := make(map[string]struct{}, len(results))
+	paths := make([]string, 0, len(results))
+	for i := range results {
+		p := results[i].Path
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		paths = append(paths, p)
+	}
+	return paths
+}

--- a/pkg/platforms/mister/tracker/arcaderesolve_test.go
+++ b/pkg/platforms/mister/tracker/arcaderesolve_test.go
@@ -1,0 +1,174 @@
+//go:build linux
+
+package tracker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	testinghelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTestMRA(t *testing.T, path, setName, name string) {
+	t.Helper()
+	data := "<misterromdescription><setname>" + setName + "</setname><name>" + name + "</name></misterromdescription>"
+	require.NoError(t, os.WriteFile(path, []byte(data), 0o600))
+}
+
+func TestLookupArcadeSetPathRetriesFailure(t *testing.T) {
+	t.Parallel()
+
+	mraPath := filepath.Join(t.TempDir(), "Pooyan.mra")
+	writeTestMRA(t, mraPath, "pooyan", "Pooyan")
+
+	mediaDB := testinghelpers.NewMockMediaDBI()
+	mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+		Return([]database.SearchResultWithCursor{}, nil).Once()
+	mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+		Return([]database.SearchResultWithCursor{{Path: mraPath}}, nil).Once()
+
+	tr := &Tracker{db: &database.Database{MediaDB: mediaDB}}
+	_, ok := tr.lookupArcadeSetPath("pooyan", "Pooyan")
+	require.False(t, ok)
+
+	path, ok := tr.lookupArcadeSetPath("pooyan", "Pooyan")
+	require.True(t, ok)
+	assert.Equal(t, mraPath, path)
+	mediaDB.AssertExpectations(t)
+}
+
+func TestResolveArcadeSetName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unique confirmed match", func(t *testing.T) {
+		t.Parallel()
+		mraPath := filepath.Join(t.TempDir(), "Pooyan.mra")
+		writeTestMRA(t, mraPath, "pooyan", "Pooyan")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: mraPath}}, nil)
+
+		path, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		require.True(t, ok)
+		assert.Equal(t, mraPath, path)
+	})
+
+	t.Run("confirmed match picked out of unrelated candidates", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		wantPath := filepath.Join(dir, "Pooyan.mra")
+		otherPath := filepath.Join(dir, "Pooyan (alt).mra")
+		writeTestMRA(t, wantPath, "pooyan", "Pooyan")
+		writeTestMRA(t, otherPath, "pooyana", "Pooyan (alt)")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: wantPath}, {Path: otherPath}}, nil)
+
+		path, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		require.True(t, ok)
+		assert.Equal(t, wantPath, path)
+	})
+
+	t.Run("ambiguous confirmed matches are refused", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		altPath := filepath.Join(dir, "clone1.mra")
+		otherPath := filepath.Join(dir, "clone2.mra")
+		writeTestMRA(t, altPath, "pooyan", "Pooyan (clone 1)")
+		writeTestMRA(t, otherPath, "pooyan", "Pooyan (clone 2)")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: altPath}, {Path: otherPath}}, nil)
+
+		_, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		assert.False(t, ok)
+	})
+
+	t.Run("no candidate confirms the set name", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		altPath := filepath.Join(dir, "Pooyan (alt).mra")
+		otherPath := filepath.Join(dir, "Pooyan (bootleg).mra")
+		writeTestMRA(t, altPath, "pooyana", "Pooyan (alt)")
+		writeTestMRA(t, otherPath, "pooyanb", "Pooyan (bootleg)")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: altPath}, {Path: otherPath}}, nil)
+
+		_, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		assert.False(t, ok)
+	})
+
+	t.Run("no candidates", func(t *testing.T) {
+		t.Parallel()
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{}, nil)
+
+		_, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		assert.False(t, ok)
+	})
+
+	t.Run("duplicate paths from slug variants are deduplicated", func(t *testing.T) {
+		t.Parallel()
+		mraPath := filepath.Join(t.TempDir(), "Pooyan.mra")
+		writeTestMRA(t, mraPath, "pooyan", "Pooyan")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: mraPath}, {Path: mraPath}}, nil)
+
+		path, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		require.True(t, ok)
+		assert.Equal(t, mraPath, path)
+	})
+
+	t.Run("single unreadable candidate is still accepted", func(t *testing.T) {
+		t.Parallel()
+		missingPath := filepath.Join(t.TempDir(), "Missing.mra")
+
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor{{Path: missingPath}}, nil)
+
+		path, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		require.True(t, ok)
+		assert.Equal(t, missingPath, path)
+	})
+
+	t.Run("nil mediaDB refuses", func(t *testing.T) {
+		t.Parallel()
+		_, ok := ResolveArcadeSetName(context.Background(), nil, "pooyan", "Pooyan")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty setName or arcadeName refuses", func(t *testing.T) {
+		t.Parallel()
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		_, ok := ResolveArcadeSetName(context.Background(), mediaDB, "", "Pooyan")
+		assert.False(t, ok)
+		_, ok = ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "")
+		assert.False(t, ok)
+	})
+
+	t.Run("search error refuses", func(t *testing.T) {
+		t.Parallel()
+		mediaDB := testinghelpers.NewMockMediaDBI()
+		mediaDB.On("SearchMediaBySlug", mock.Anything, ArcadeSystem, "Pooyan", []zapscript.TagFilter(nil)).
+			Return([]database.SearchResultWithCursor(nil), assert.AnError)
+
+		_, ok := ResolveArcadeSetName(context.Background(), mediaDB, "pooyan", "Pooyan")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -51,6 +51,14 @@ type NameMapping struct {
 	ArcadeName string
 }
 
+// arcadeResolution caches one set name's resolution outcome so a core that
+// stays active (or is re-entered) doesn't re-run the MediaDB search and MRA
+// parses on every LoadCore call.
+type arcadeResolution struct {
+	path string
+	ok   bool
+}
+
 type Tracker struct {
 	pl               platforms.Platform
 	setActiveMedia   func(*models.ActiveMedia)
@@ -58,6 +66,7 @@ type Tracker struct {
 	serviceCtx       context.Context
 	activeMedia      func() *models.ActiveMedia
 	db               *database.Database
+	arcadeResolved   map[string]arcadeResolution
 	ActiveSystemName string
 	ActiveSystem     string
 	ActiveGameID     string
@@ -154,6 +163,9 @@ func (tr *Tracker) ReloadNameMap() {
 	nameMap := generateNameMap(tr.pl)
 	log.Info().Int("count", len(nameMap)).Msg("reloaded name mappings")
 	tr.NameMap = nameMap
+	// Set-name to MRA-path resolutions may change along with the name map
+	// (an ArcadeDatabase.csv update can add or rename entries).
+	tr.arcadeResolved = nil
 }
 
 func (tr *Tracker) LookupCoreName(name string) *NameMapping {
@@ -185,6 +197,27 @@ func (tr *Tracker) LookupCoreName(name string) *NameMapping {
 	}
 
 	return nil
+}
+
+// ResolveExternalMediaPath maps a legacy MediaHistory row's set-name-only
+// MediaPath back to its canonical indexed .mra path, for the arcade history
+// backfill task (arcade_history_backfill.go).
+func (tr *Tracker) ResolveExternalMediaPath(ctx context.Context, systemID, value string) (string, bool) {
+	if systemID != ArcadeSystem || value == "" {
+		return "", false
+	}
+	if tr.db == nil || tr.db.MediaDB == nil {
+		return "", false
+	}
+
+	tr.mu.Lock()
+	mapping := tr.LookupCoreName(value)
+	tr.mu.Unlock()
+	if mapping == nil || mapping.ArcadeName == "" {
+		return "", false
+	}
+
+	return ResolveArcadeSetName(ctx, tr.db.MediaDB, value, mapping.ArcadeName)
 }
 
 func (tr *Tracker) stopCore() bool {
@@ -248,16 +281,27 @@ func (tr *Tracker) LoadCore() {
 	// set arcade core details
 	if result := tr.LookupCoreName(coreName); result != nil && result.ArcadeName != "" {
 		log.Info().Str("arcade_game", result.ArcadeName).Str("setname", result.CoreName).Msg("arcade game detected")
-		err := activegame.SetActiveGame(result.CoreName)
+
+		mraPath, name := tr.resolveArcadeGame(result.CoreName, result.ArcadeName)
+		activeGamePath := result.CoreName
+		if mraPath != "" {
+			activeGamePath = mraPath
+		}
+		err := activegame.SetActiveGame(activeGamePath)
 		if err != nil {
 			log.Warn().Err(err).Msg("error setting active game")
 		}
 
-		tr.ActiveGameID = coreName
-		tr.ActiveGameName = result.ArcadeName
-		tr.ActiveGamePath = "" // no way to find mra path from CORENAME
+		tr.ActiveGameName = name
 		tr.ActiveSystem = ArcadeSystem
 		tr.ActiveSystemName = ArcadeSystem
+		if mraPath != "" {
+			tr.ActiveGameID = fmt.Sprintf("%s/%s", ArcadeSystem, filepath.Base(mraPath))
+			tr.ActiveGamePath = mraPath
+		} else {
+			tr.ActiveGameID = coreName
+			tr.ActiveGamePath = "" // no way to find mra path from CORENAME
+		}
 
 		// Check if this arcade game was recently launched via card scan
 		// If so, suppress duplicate notification
@@ -270,14 +314,71 @@ func (tr *Tracker) LoadCore() {
 			}
 		}
 
+		// Don't overwrite a more authoritative observation of the same game:
+		// a Zaparoo launch or a resolved FILESELECT event may already have
+		// published this canonical .mra path before CORENAME caught up.
+		if mraPath != "" {
+			if active := tr.activeMedia(); active != nil &&
+				active.SystemID == ArcadeSystem && active.Path == mraPath {
+				return
+			}
+		}
+
 		tr.setActiveMedia(models.NewActiveMedia(
 			tr.ActiveSystem,
 			tr.ActiveSystemName,
-			coreName,
+			activeGamePath,
 			tr.ActiveGameName,
 			"", // LauncherID unknown when tracking MiSTer core changes
 		))
 	}
+}
+
+// resolveArcadeGame resolves an externally detected arcade core's set name to
+// its canonical indexed .mra path and display name. On resolution or lookup
+// failure it falls back to the raw set name and the ArcadeDatabase.csv name,
+// matching prior behaviour.
+func (tr *Tracker) resolveArcadeGame(setName, arcadeName string) (mraPath, name string) {
+	name = arcadeName
+	path, ok := tr.lookupArcadeSetPath(setName, arcadeName)
+	if !ok {
+		return "", name
+	}
+
+	if tr.db != nil && tr.db.MediaDB != nil {
+		systems := []systemdefs.System{{ID: ArcadeSystem}}
+		ctx, cancel := tr.mediaLookupContext()
+		results, searchErr := tr.db.MediaDB.SearchMediaPathExact(ctx, systems, path)
+		cancel()
+		if searchErr == nil && len(results) > 0 && results[0].Name != "" {
+			name = results[0].Name
+		}
+	}
+	return path, name
+}
+
+// lookupArcadeSetPath resolves and caches setName's canonical .mra path for
+// the lifetime of the Tracker, or until ReloadNameMap clears the cache.
+// Failed resolutions are retried because MediaDB may still be indexing.
+func (tr *Tracker) lookupArcadeSetPath(setName, arcadeName string) (string, bool) {
+	if cached, found := tr.arcadeResolved[setName]; found {
+		return cached.path, cached.ok
+	}
+
+	var path string
+	var ok bool
+	if tr.db != nil && tr.db.MediaDB != nil {
+		ctx, cancel := tr.mediaLookupContext()
+		path, ok = ResolveArcadeSetName(ctx, tr.db.MediaDB, setName, arcadeName)
+		cancel()
+	}
+	if ok {
+		if tr.arcadeResolved == nil {
+			tr.arcadeResolved = make(map[string]arcadeResolution)
+		}
+		tr.arcadeResolved[setName] = arcadeResolution{path: path, ok: true}
+	}
+	return path, ok
 }
 
 func (tr *Tracker) stopGame() {
@@ -412,10 +513,12 @@ func (tr *Tracker) StopAll() {
 	tr.stopGame()
 }
 
-// resolveRecentGamePath mirrors MiSTer's relative-path root selection. Main
-// stores 0 for SD and nonzero for USB in config/device.bin; USB uses the first
-// available /media/usb0-3 root containing the recent file.
-func resolveRecentGamePath(path string, storageSelection []byte, exists func(string) bool) string {
+// resolveStorageRelativePath mirrors MiSTer's relative-path root selection.
+// Main stores 0 for SD and nonzero for USB in config/device.bin; USB uses the
+// first available /media/usb0-3 root containing the path. Used both for
+// recent-file entries and for the file selector's FULLPATH, which is
+// relative to the active storage root while browsing.
+func resolveStorageRelativePath(path string, storageSelection []byte, exists func(string) bool) string {
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path)
 	}
@@ -449,7 +552,7 @@ func recentGamePath(filename string, storageSelection []byte) (string, error) {
 	newest := recents[0]
 	if !strings.HasSuffix(filename, "cores_recent.cfg") {
 		path := filepath.Join(newest.Directory, newest.Name)
-		return resolveRecentGamePath(path, storageSelection, func(candidate string) bool {
+		return resolveStorageRelativePath(path, storageSelection, func(candidate string) bool {
 			_, statErr := os.Stat(candidate)
 			return statErr == nil
 		}), nil
@@ -483,37 +586,223 @@ func loadRecent(filename string) error {
 	return nil
 }
 
-// selectedFullPath returns the selected file only after MiSTer publishes
-// FILESELECT=selected. FULLPATH also changes while the user browses, so it is
-// not a launch signal by itself.
-func selectedFullPath(statusData, pathData []byte) (string, error) {
-	if strings.TrimSpace(string(statusData)) != "selected" {
-		return "", nil
-	}
-	path := strings.TrimSpace(string(pathData))
-	if path == "" {
-		return "", errors.New("selected full path is empty")
-	}
-	return path, nil
+// fileSelection is one settled MiSTer native file-selector event: the
+// FILESELECT/FULLPATH/CURRENTPATH trio read together after the selection has
+// stopped changing.
+type fileSelection struct {
+	Status      string
+	FullPath    string
+	CurrentPath string
 }
 
-func loadFileSelection() {
-	statusData, err := os.ReadFile(misterconfig.FileSelectFile)
+func trimTrackerFileContent(data []byte) string {
+	return strings.TrimSpace(strings.Trim(string(data), "\x00"))
+}
+
+// readFileSelectionFrom reads MiSTer's file-selector status trio. FULLPATH
+// and CURRENTPATH are only read once FILESELECT says "selected" - while
+// browsing they hold in-progress state, and MakeFile truncates before
+// writing, so reading them unconditionally risks catching a torn write.
+func readFileSelectionFrom(statusFile, fullPathFile, currentPathFile string) (fileSelection, error) {
+	statusData, err := os.ReadFile(statusFile) // #nosec G304 -- caller passes trusted MiSTer status file paths
 	if err != nil {
-		log.Warn().Err(err).Msg("failed to read MiSTer file selection status")
+		return fileSelection{}, fmt.Errorf("failed to read file selection status: %w", err)
+	}
+	sel := fileSelection{Status: trimTrackerFileContent(statusData)}
+	if sel.Status != "selected" {
+		return sel, nil
+	}
+
+	fullPathData, err := os.ReadFile(fullPathFile) // #nosec G304 -- caller passes trusted MiSTer status file paths
+	if err != nil {
+		return fileSelection{}, fmt.Errorf("failed to read selected full path: %w", err)
+	}
+	// #nosec G304 -- caller passes trusted MiSTer status file paths
+	currentPathData, err := os.ReadFile(currentPathFile)
+	if err != nil {
+		return fileSelection{}, fmt.Errorf("failed to read selected current path: %w", err)
+	}
+	sel.FullPath = trimTrackerFileContent(fullPathData)
+	sel.CurrentPath = trimTrackerFileContent(currentPathData)
+	return sel, nil
+}
+
+// stripExt mirrors the extension stripping MiSTer's get_display_name
+// (file_io.cpp) applies to CURRENTPATH for .mra/.mgl/.rbf files and cores
+// with a single declared extension.
+func stripExt(name string) string {
+	ext := filepath.Ext(name)
+	if ext == "" {
+		return name
+	}
+	return name[:len(name)-len(ext)]
+}
+
+// matchesSelectionName reports whether entryName is the file MiSTer recorded
+// as CURRENTPATH, either verbatim (MGL-driven launches write the full
+// basename) or with its extension stripped (the interactive file selector's
+// altname).
+func matchesSelectionName(entryName, current string) bool {
+	return strings.EqualFold(entryName, current) || strings.EqualFold(stripExt(entryName), current)
+}
+
+// resolveDirEntry finds the single directory entry matching current. An
+// extension-stripped match is only used when it is unambiguous - MiSTer's
+// altname can't otherwise be told apart from a same-named entry with a
+// different extension.
+func resolveDirEntry(entries []os.DirEntry, current string) (string, bool) {
+	for _, e := range entries {
+		if strings.EqualFold(e.Name(), current) {
+			return e.Name(), true
+		}
+	}
+	match, count := "", 0
+	for _, e := range entries {
+		if strings.EqualFold(stripExt(e.Name()), current) {
+			match = e.Name()
+			count++
+		}
+	}
+	if count == 1 {
+		return match, true
+	}
+	return "", false
+}
+
+// composeSelectedPath resolves one settled file-selection event to the
+// concrete path MiSTer launched. sel.FullPath is either an absolute file
+// path (MGL launches, Zaparoo's own writeCurrentPath) or, for the
+// interactive file selector, the browsed directory relative to the active
+// storage root; sel.CurrentPath is the selected entry's display name. A
+// selection this can't confidently resolve (ambiguous match, a name rewritten
+// by names.txt/NeoGeo translation tables, a stale mid-write read) reports
+// ok=false rather than guessing.
+func composeSelectedPath(
+	sel fileSelection,
+	storageSelection []byte,
+	stat func(string) (os.FileInfo, error),
+	readDir func(string) ([]os.DirEntry, error),
+) (path string, ok bool) {
+	if sel.Status != "selected" {
+		return "", false
+	}
+	current := sel.CurrentPath
+	if current == "" || current == ".." {
+		return "", false
+	}
+	if sel.FullPath == "" {
+		return "", false
+	}
+
+	base := resolveStorageRelativePath(sel.FullPath, storageSelection, func(candidate string) bool {
+		_, statErr := stat(candidate)
+		return statErr == nil
+	})
+
+	info, err := stat(base)
+	if err != nil {
+		return "", false
+	}
+	if !info.IsDir() {
+		if !matchesSelectionName(filepath.Base(base), current) {
+			return "", false
+		}
+		return base, true
+	}
+
+	entries, err := readDir(base)
+	if err != nil {
+		return "", false
+	}
+	name, found := resolveDirEntry(entries, current)
+	if !found {
+		return "", false
+	}
+	selected := filepath.Join(base, name)
+
+	selectedInfo, err := stat(selected)
+	if err != nil {
+		return "", false
+	}
+	if !selectedInfo.IsDir() {
+		return selected, true
+	}
+
+	// A disc-style folder holding exactly one file (MiSTer's
+	// MENU_GENERIC_FILE_SELECTED) launches that file directly; a folder with
+	// several files (e.g. a NeoGeo folder set) launches as the directory.
+	innerEntries, err := readDir(selected)
+	if err != nil {
+		return selected, true
+	}
+	onlyFile, fileCount := "", 0
+	for _, e := range innerEntries {
+		if e.IsDir() {
+			continue
+		}
+		fileCount++
+		onlyFile = e.Name()
+	}
+	if fileCount == 1 {
+		return filepath.Join(selected, onlyFile), true
+	}
+	return selected, true
+}
+
+// isSystemOrMenuPath rejects MiSTer's own configuration, script, and core
+// selections so they are never recorded as a launched game: Scripts/, the
+// config folder, linux/, and the file types MiSTer's menu itself opens
+// (cores, filters, presets, scripts, MiSTer.ini variants).
+func isSystemOrMenuPath(path string) bool {
+	if helpers.PathHasPrefix(path, misterconfig.ScriptsDir) ||
+		helpers.PathHasPrefix(path, misterconfig.CoreConfigFolder) ||
+		helpers.PathHasPrefix(path, misterconfig.LinuxDir) {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".rbf", ".ini", ".cfg", ".txt", ".sh":
+		return true
+	default:
+		return false
+	}
+}
+
+// hasSystemLauncher reports whether any launcher in the list identifies a
+// known system, i.e. is a real media launcher rather than MiSTer's generic
+// core/RBF catch-all (which has no SystemID).
+func hasSystemLauncher(launchers []platforms.Launcher) bool {
+	for i := range launchers {
+		if launchers[i].SystemID != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// loadFileSelection reads a settled native MiSTer file-selection event and,
+// if it resolves to a trackable game, records it the same way a Zaparoo
+// launch does.
+func (tr *Tracker) loadFileSelection() {
+	sel, err := readFileSelectionFrom(
+		misterconfig.FileSelectFile, misterconfig.FullPathFile, misterconfig.CurrentPathFile,
+	)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to read MiSTer file selection")
 		return
 	}
-	if strings.TrimSpace(string(statusData)) != "selected" {
+
+	storageSelection, _ := os.ReadFile(filepath.Join(misterconfig.CoreConfigFolder, "device.bin"))
+	path, ok := composeSelectedPath(sel, storageSelection, os.Stat, os.ReadDir)
+	if !ok {
 		return
 	}
-	pathData, err := os.ReadFile(misterconfig.FullPathFile)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to read selected MiSTer full path")
+
+	if isSystemOrMenuPath(path) {
+		log.Debug().Str("path", path).Msg("ignoring MiSTer system/menu file selection")
 		return
 	}
-	path, err := selectedFullPath(statusData, pathData)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to process MiSTer file selection")
+	if launchers := helpers.PathToLaunchers(tr.cfg, tr.pl, path); !hasSystemLauncher(launchers) {
+		log.Debug().Str("path", path).Msg("ignoring MiSTer file selection with no matching launcher")
 		return
 	}
 
@@ -566,9 +855,9 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 					tr.loadGame()
 				case event.Name == misterconfig.FileSelectFile:
 					// MakeFile truncates before writing the new status. Wait for
-					// FILESELECT and FULLPATH to contain the same selection without
-					// blocking delivery of later watcher events.
-					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), loadFileSelection)
+					// FILESELECT, FULLPATH, and CURRENTPATH to settle as one event
+					// without blocking delivery of later watcher events.
+					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), tr.loadFileSelection)
 				case trackerRecentFileChanged(event.Name):
 					// MiSTer truncates and rewrites binary recent files. Let the
 					// write settle before reading the first complete record without

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -9,11 +9,102 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeFileInfo/fakeDirEntry/fakeFS give composeSelectedPath a small
+// in-memory filesystem, so tests can exercise MiSTer's SD/USB root selection
+// and directory browsing without depending on real paths like /media/fat
+// existing on the test machine.
+type fakeFileInfo struct {
+	name  string
+	isDir bool
+}
+
+func (f fakeFileInfo) Name() string { return f.name }
+func (fakeFileInfo) Size() int64    { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode {
+	if f.isDir {
+		return os.ModeDir
+	}
+	return 0
+}
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool      { return f.isDir }
+func (fakeFileInfo) Sys() any           { return nil }
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (f fakeDirEntry) Name() string { return f.name }
+func (f fakeDirEntry) IsDir() bool  { return f.isDir }
+func (f fakeDirEntry) Type() os.FileMode {
+	if f.isDir {
+		return os.ModeDir
+	}
+	return 0
+}
+
+func (f fakeDirEntry) Info() (os.FileInfo, error) {
+	return fakeFileInfo(f), nil
+}
+
+func fakeFile(name string) fakeDirEntry { return fakeDirEntry{name: name} }
+func fakeDir(name string) fakeDirEntry  { return fakeDirEntry{name: name, isDir: true} }
+
+type fakeFS struct {
+	dirs  map[string][]fakeDirEntry
+	files map[string]bool
+}
+
+func newFakeFS() *fakeFS {
+	return &fakeFS{dirs: map[string][]fakeDirEntry{}, files: map[string]bool{}}
+}
+
+// addDir registers path as a directory containing entries. Any child
+// directory entries are registered too (as empty, unless later overridden by
+// their own addDir call).
+func (f *fakeFS) addDir(path string, entries ...fakeDirEntry) {
+	f.dirs[path] = entries
+	for _, e := range entries {
+		child := filepath.Join(path, e.name)
+		if e.isDir {
+			if _, ok := f.dirs[child]; !ok {
+				f.dirs[child] = nil
+			}
+		} else {
+			f.files[child] = true
+		}
+	}
+}
+
+func (f *fakeFS) stat(path string) (os.FileInfo, error) {
+	if _, ok := f.dirs[path]; ok {
+		return fakeFileInfo{name: filepath.Base(path), isDir: true}, nil
+	}
+	if f.files[path] {
+		return fakeFileInfo{name: filepath.Base(path), isDir: false}, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+func (f *fakeFS) readDir(path string) ([]os.DirEntry, error) {
+	entries, ok := f.dirs[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	out := make([]os.DirEntry, len(entries))
+	for i, e := range entries {
+		out[i] = e
+	}
+	return out, nil
+}
 
 func writeRecentEntry(t *testing.T, filename, directory, name string) {
 	t.Helper()
@@ -24,44 +115,17 @@ func writeRecentEntry(t *testing.T, filename, directory, name string) {
 	require.NoError(t, os.WriteFile(filename, entry, 0o600))
 }
 
-func TestSelectedFullPath(t *testing.T) {
-	t.Parallel()
-
-	selectedPath := filepath.Join(misterconfig.SDRootDir, "games", "SNES", "Game.sfc")
-	t.Run("selected", func(t *testing.T) {
-		path, err := selectedFullPath(
-			[]byte("selected\n"),
-			[]byte(" "+selectedPath+"\n"),
-		)
-		require.NoError(t, err)
-		assert.Equal(t, selectedPath, path)
-	})
-
-	for _, status := range []string{"active", "cancelled", ""} {
-		t.Run("ignores "+status, func(t *testing.T) {
-			path, err := selectedFullPath([]byte(status), []byte(selectedPath))
-			require.NoError(t, err)
-			assert.Empty(t, path)
-		})
-	}
-
-	t.Run("selected requires path", func(t *testing.T) {
-		_, err := selectedFullPath([]byte("selected"), nil)
-		require.Error(t, err)
-	})
-}
-
-func TestResolveRecentGamePath(t *testing.T) {
+func TestResolveStorageRelativePath(t *testing.T) {
 	t.Parallel()
 
 	relativePath := filepath.Join("games", "GBC", "Game.gbc")
 	assert.Equal(t,
 		filepath.Join(misterconfig.SDRootDir, relativePath),
-		resolveRecentGamePath(relativePath, nil, func(string) bool { return false }),
+		resolveStorageRelativePath(relativePath, nil, func(string) bool { return false }),
 	)
 
 	usb1Path := filepath.Join(filepath.Dir(misterconfig.SDRootDir), "usb1", relativePath)
-	assert.Equal(t, usb1Path, resolveRecentGamePath(
+	assert.Equal(t, usb1Path, resolveStorageRelativePath(
 		relativePath,
 		[]byte{1, 0, 0, 0},
 		func(path string) bool { return path == usb1Path },
@@ -70,8 +134,227 @@ func TestResolveRecentGamePath(t *testing.T) {
 	absolutePath := filepath.Join(string(filepath.Separator), "media", "network", "Game.gbc")
 	assert.Equal(t,
 		absolutePath,
-		resolveRecentGamePath(absolutePath, []byte{1, 0, 0, 0}, func(string) bool { return false }),
+		resolveStorageRelativePath(absolutePath, []byte{1, 0, 0, 0}, func(string) bool { return false }),
 	)
+}
+
+func TestReadFileSelectionFrom(t *testing.T) {
+	t.Parallel()
+
+	writeFiles := func(t *testing.T, status, fullPath, currentPath string) (string, string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		statusFile := filepath.Join(dir, "FILESELECT")
+		fullPathFile := filepath.Join(dir, "FULLPATH")
+		currentPathFile := filepath.Join(dir, "CURRENTPATH")
+		require.NoError(t, os.WriteFile(statusFile, []byte(status), 0o600))
+		require.NoError(t, os.WriteFile(fullPathFile, []byte(fullPath), 0o600))
+		require.NoError(t, os.WriteFile(currentPathFile, []byte(currentPath), 0o600))
+		return statusFile, fullPathFile, currentPathFile
+	}
+
+	t.Run("selected", func(t *testing.T) {
+		t.Parallel()
+		statusFile, fullPathFile, currentPathFile := writeFiles(
+			t, "selected", "/media/fat/_Arcade/Pooyan.mra\x00\x00", "Pooyan\x00",
+		)
+		sel, err := readFileSelectionFrom(statusFile, fullPathFile, currentPathFile)
+		require.NoError(t, err)
+		assert.Equal(t, fileSelection{
+			Status:      "selected",
+			FullPath:    "/media/fat/_Arcade/Pooyan.mra",
+			CurrentPath: "Pooyan",
+		}, sel)
+	})
+
+	for _, status := range []string{"active", "cancelled", ""} {
+		t.Run("does not read FULLPATH/CURRENTPATH when "+status, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			statusFile := filepath.Join(dir, "FILESELECT")
+			require.NoError(t, os.WriteFile(statusFile, []byte(status), 0o600))
+			// FULLPATH/CURRENTPATH don't exist; reading them would error.
+			sel, err := readFileSelectionFrom(
+				statusFile,
+				filepath.Join(dir, "FULLPATH"),
+				filepath.Join(dir, "CURRENTPATH"),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, status, sel.Status)
+			assert.Empty(t, sel.FullPath)
+			assert.Empty(t, sel.CurrentPath)
+		})
+	}
+
+	t.Run("missing status file errors", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		_, err := readFileSelectionFrom(
+			filepath.Join(dir, "FILESELECT"),
+			filepath.Join(dir, "FULLPATH"),
+			filepath.Join(dir, "CURRENTPATH"),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("missing FULLPATH errors once selected", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		statusFile := filepath.Join(dir, "FILESELECT")
+		require.NoError(t, os.WriteFile(statusFile, []byte("selected"), 0o600))
+		_, err := readFileSelectionFrom(
+			statusFile, filepath.Join(dir, "FULLPATH"), filepath.Join(dir, "CURRENTPATH"),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("missing CURRENTPATH errors once selected", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		statusFile, fullPathFile, currentPathFile := writeFiles(t, "selected", "/media/fat/game.rom", "")
+		require.NoError(t, os.Remove(currentPathFile))
+		_, err := readFileSelectionFrom(statusFile, fullPathFile, filepath.Join(dir, "CURRENTPATH"))
+		require.Error(t, err)
+	})
+}
+
+func TestComposeSelectedPath(t *testing.T) {
+	t.Parallel()
+
+	sdSNES := filepath.Join(misterconfig.SDRootDir, "games", "SNES")
+	sdArcade := filepath.Join(misterconfig.SDRootDir, "_Arcade")
+	sdPSX := filepath.Join(misterconfig.SDRootDir, "games", "PSX")
+	sdNeoGeo := filepath.Join(misterconfig.SDRootDir, "games", "NEOGEO")
+	sdRoot := misterconfig.SDRootDir
+	usbGBC := filepath.Join(filepath.Dir(misterconfig.SDRootDir), "usb1", "games", "GBC")
+
+	fs := newFakeFS()
+	fs.addDir(sdSNES, fakeFile("Game1.sfc"), fakeFile("Game2.sfc"))
+	fs.addDir(sdArcade,
+		fakeFile("Pooyan.mra"), fakeFile("Other.mgl"),
+		fakeFile("Game.a"), fakeFile("Game.b"),
+		fakeFile("SNES_20220101.rbf"),
+	)
+	fs.addDir(sdRoot, fakeDir("games"), fakeDir("_Arcade"))
+	fs.addDir(sdPSX, fakeDir("Game (Disc 1)"))
+	fs.addDir(filepath.Join(sdPSX, "Game (Disc 1)"), fakeFile("Game.cue"))
+	fs.addDir(sdNeoGeo, fakeDir("mslug"))
+	fs.addDir(filepath.Join(sdNeoGeo, "mslug"), fakeFile("046-p1.p1"), fakeFile("046-s1.s1"))
+	fs.addDir(usbGBC, fakeFile("Game.gbc"))
+
+	tests := []struct {
+		sel     fileSelection
+		name    string
+		want    string
+		storage []byte
+		wantOK  bool
+	}{
+		{
+			name: "not selected",
+			sel:  fileSelection{Status: "active", FullPath: sdSNES, CurrentPath: "Game1"},
+		},
+		{
+			name: "current path is parent reference",
+			sel:  fileSelection{Status: "selected", FullPath: sdSNES, CurrentPath: ".."},
+		},
+		{
+			name: "current path is empty",
+			sel:  fileSelection{Status: "selected", FullPath: sdSNES, CurrentPath: ""},
+		},
+		{
+			name:   "first of two games in the same folder",
+			sel:    fileSelection{Status: "selected", FullPath: sdSNES, CurrentPath: "Game1"},
+			wantOK: true,
+			want:   filepath.Join(sdSNES, "Game1.sfc"),
+		},
+		{
+			name:   "second of two games in the same folder",
+			sel:    fileSelection{Status: "selected", FullPath: sdSNES, CurrentPath: "Game2"},
+			wantOK: true,
+			want:   filepath.Join(sdSNES, "Game2.sfc"),
+		},
+		{
+			name:   "extension-stripped MRA selection",
+			sel:    fileSelection{Status: "selected", FullPath: sdArcade, CurrentPath: "Pooyan"},
+			wantOK: true,
+			want:   filepath.Join(sdArcade, "Pooyan.mra"),
+		},
+		{
+			name: "core datecode name is unrecoverable",
+			sel:  fileSelection{Status: "selected", FullPath: sdArcade, CurrentPath: "SNES"},
+		},
+		{
+			name: "ambiguous extension-stripped match is refused",
+			sel:  fileSelection{Status: "selected", FullPath: sdArcade, CurrentPath: "Game"},
+		},
+		{
+			name: "MGL-driven absolute path matches basename verbatim",
+			sel: fileSelection{
+				Status: "selected", FullPath: filepath.Join(sdArcade, "Pooyan.mra"), CurrentPath: "Pooyan.mra",
+			},
+			wantOK: true,
+			want:   filepath.Join(sdArcade, "Pooyan.mra"),
+		},
+		{
+			name: "stale FULLPATH basename mismatch is refused",
+			sel: fileSelection{
+				Status: "selected", FullPath: filepath.Join(sdArcade, "Pooyan.mra"), CurrentPath: "Other",
+			},
+		},
+		{
+			name:   "disc folder with one file resolves to the file",
+			sel:    fileSelection{Status: "selected", FullPath: sdPSX, CurrentPath: "Game (Disc 1)"},
+			wantOK: true,
+			want:   filepath.Join(sdPSX, "Game (Disc 1)", "Game.cue"),
+		},
+		{
+			name:   "multi-file folder set resolves to the folder",
+			sel:    fileSelection{Status: "selected", FullPath: sdNeoGeo, CurrentPath: "mslug"},
+			wantOK: true,
+			want:   filepath.Join(sdNeoGeo, "mslug"),
+		},
+		{
+			name:    "USB root resolution for relative FULLPATH",
+			sel:     fileSelection{Status: "selected", FullPath: filepath.Join("games", "GBC"), CurrentPath: "Game"},
+			storage: []byte{1, 0, 0, 0},
+			wantOK:  true,
+			want:    filepath.Join(usbGBC, "Game.gbc"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := composeSelectedPath(tt.sel, tt.storage, fs.stat, fs.readDir)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestIsSystemOrMenuPath(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.ScriptsDir, "update.sh")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.CoreConfigFolder, "SNES.ini")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.LinuxDir, "menu.rbf")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "_Arcade", "cores", "core.rbf")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "filters", "snes.ini")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "presets", "preset.cfg")))
+	assert.True(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "readme.txt")))
+
+	assert.False(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "games", "SNES", "Game.sfc")))
+	assert.False(t, isSystemOrMenuPath(filepath.Join(misterconfig.SDRootDir, "_Arcade", "Pooyan.mra")))
+}
+
+func TestHasSystemLauncher(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, hasSystemLauncher(nil))
+	assert.False(t, hasSystemLauncher([]platforms.Launcher{{ID: "Generic"}}))
+	assert.True(t, hasSystemLauncher([]platforms.Launcher{{ID: "Generic"}, {ID: "SNES", SystemID: "SNES"}}))
 }
 
 func TestRecentGamePath(t *testing.T) {

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -117,7 +117,7 @@ func (p *Platform) StartPost(
 	activeMedia func() *models.ActiveMedia,
 	setActiveMedia func(*models.ActiveMedia),
 	db *database.Database,
-	_ *idle.Scheduler,
+	scheduler *idle.Scheduler,
 ) error {
 	p.activeMedia = activeMedia
 	p.setActiveMedia = setActiveMedia
@@ -165,6 +165,21 @@ func (p *Platform) StartPost(
 			log.Info().Msgf("arcade database has %d entries", len(m))
 		}
 	}()
+
+	// One-time cleanup: resolve legacy MediaHistory rows recorded under a
+	// bare arcade set name (from before the tracker could canonicalize
+	// externally detected arcade launches) to their real .mra path and
+	// identity. Track the task through the idle scheduler so shutdown waits
+	// for cancellation before closing the databases.
+	if scheduler != nil {
+		scheduler.Schedule(
+			ctx, "arcade-history-backfill",
+			5*time.Second, 300*time.Second,
+			func(ctx context.Context) { tracker.RunArcadeHistoryBackfill(ctx, db, tr) },
+		)
+	} else {
+		log.Debug().Msg("no idle scheduler; skipping arcade history backfill")
+	}
 
 	return nil
 }

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -369,6 +369,17 @@ func (m *MockUserDBI) UpdateMediaHistoryIdentity(dbid int64, identity *database.
 	return updated, nil
 }
 
+func (m *MockUserDBI) UpdateMediaHistoryIdentityAndPath(
+	dbid int64, path string, identity *database.MediaIdentity,
+) (bool, error) {
+	args := m.Called(dbid, path, identity)
+	updated := args.Bool(0)
+	if err := args.Error(1); err != nil {
+		return updated, fmt.Errorf("mock UserDBI update media history identity and path failed: %w", err)
+	}
+	return updated, nil
+}
+
 func (m *MockUserDBI) CloseMediaHistory(dbid int64, endTime time.Time, playTime int) error {
 	args := m.Called(dbid, endTime, playTime)
 	if err := args.Error(0); err != nil {


### PR DESCRIPTION
## Summary

- resolve externally detected MiSTer arcade launches to canonical MRA paths and identities
- backfill legacy arcade history rows with retry-safe, shutdown-aware background work
- improve recent-file and file-selection tracking while preventing duplicate sessions

Validated with full race tests, deadlock analysis, and lint.

Closes #1291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery of legacy MiSTer arcade history, enriching entries with canonical paths and media details.
  * Improved MiSTer game selection across SD cards, USB storage, folders, disc images, and recent files.
  * Added safer arcade set identification to prevent ambiguous or incorrect matches.

* **Bug Fixes**
  * Prevented duplicate history sessions when arcade media is enriched.
  * Improved handling of incomplete recent-game records and invalid system or menu selections.
  * Restricted launcher media lookups to the appropriate system for more accurate results.

* **Tests**
  * Expanded coverage for arcade resolution, history recovery, recent files, and storage-path selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->