### PR TITLE
fix(launchers): reload custom launchers from the tray and validate launch overrides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -419,7 +419,7 @@ func (c *Instance) applyTOML(data string) error {
 
 		re, err := regexp.Compile(anchorPattern(allowFile))
 		if err != nil {
-			log.Warn().Msgf("invalid allow file regex: %s", allowFile)
+			log.Warn().Err(err).Msgf("invalid allow file regex: %s", allowFile)
 			continue
 		}
 		c.vals.Launchers.allowFileRe[i] = re
@@ -430,7 +430,7 @@ func (c *Instance) applyTOML(data string) error {
 	for i, allowExecute := range c.vals.ZapScript.AllowExecute {
 		re, err := regexp.Compile(anchorPattern(allowExecute))
 		if err != nil {
-			log.Warn().Msgf("invalid allow execute regex: %s", allowExecute)
+			log.Warn().Err(err).Msgf("invalid allow execute regex: %s", allowExecute)
 			continue
 		}
 		c.vals.ZapScript.allowExecuteRe[i] = re
@@ -441,7 +441,7 @@ func (c *Instance) applyTOML(data string) error {
 	for i, allowHTTP := range c.vals.ZapScript.AllowHTTP {
 		re, err := regexp.Compile(anchorPattern(allowHTTP))
 		if err != nil {
-			log.Warn().Msgf("invalid allow HTTP regex: %s", allowHTTP)
+			log.Warn().Err(err).Msgf("invalid allow HTTP regex: %s", allowHTTP)
 			continue
 		}
 		c.vals.ZapScript.allowHTTPRe[i] = re
@@ -452,7 +452,7 @@ func (c *Instance) applyTOML(data string) error {
 	for i, allowRun := range c.vals.Service.AllowRun {
 		re, err := regexp.Compile(anchorPattern(allowRun))
 		if err != nil {
-			log.Warn().Msgf("invalid allow run regex: %s", allowRun)
+			log.Warn().Err(err).Msgf("invalid allow run regex: %s", allowRun)
 			continue
 		}
 		c.vals.Service.allowRunRe[i] = re

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1713,3 +1713,26 @@ volume = 80
 	assert.True(t, cfg.DebugLogging())
 	assert.Equal(t, 80, cfg.AudioVolume())
 }
+
+func TestApplyTOML_InvalidAllowRegexes(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{vals: Values{}}
+	data := `
+[launchers]
+allow_file = ["["]
+
+[zapscript]
+allow_execute = ["["]
+allow_http = ["["]
+
+[service]
+allow_run = ["["]
+`
+
+	require.NoError(t, cfg.applyTOML(data))
+	assert.Equal(t, []*regexp.Regexp{nil}, cfg.vals.Launchers.allowFileRe)
+	assert.Equal(t, []*regexp.Regexp{nil}, cfg.vals.ZapScript.allowExecuteRe)
+	assert.Equal(t, []*regexp.Regexp{nil}, cfg.vals.ZapScript.allowHTTPRe)
+	assert.Equal(t, []*regexp.Regexp{nil}, cfg.vals.Service.allowRunRe)
+}

--- a/pkg/config/configcustomlaunchers.go
+++ b/pkg/config/configcustomlaunchers.go
@@ -165,6 +165,12 @@ func validateCustomLauncher(entry *LaunchersCustom) error {
 		}
 	}
 
+	// Write the resolved values back so consumers read canonical fields rather
+	// than re-deriving them. Omitting backend while setting execute is legal,
+	// and code that compared the raw field skipped those entries entirely.
+	entry.Kind = kind
+	entry.Backend = backend
+
 	return nil
 }
 

--- a/pkg/config/configcustomlaunchers_test.go
+++ b/pkg/config/configcustomlaunchers_test.go
@@ -41,6 +41,33 @@ func TestValidateCustomLauncher_MisterVirtualSystem(t *testing.T) {
 	assert.Equal(t, "Other", entry.Category)
 }
 
+func TestValidateCustomLauncher_NormalizesImpliedKindAndBackend(t *testing.T) {
+	entry := LaunchersCustom{
+		ID:      "Winamp_Main",
+		Kind:    CustomLauncherKindVirtualSystem,
+		Name:    "Winamp",
+		Execute: "winamp.exe",
+	}
+
+	require.NoError(t, validateCustomLauncher(&entry))
+	assert.Equal(t, CustomLauncherKindVirtualSystem, entry.Kind)
+	assert.Equal(t, CustomLauncherBackendCommand, entry.Backend)
+	assert.Equal(t, "Other", entry.Category)
+}
+
+func TestValidateCustomLauncher_NormalizesOmittedKind(t *testing.T) {
+	entry := LaunchersCustom{
+		ID:       "WinampMedia",
+		System:   "MusicTrack",
+		FileExts: []string{".m3u"},
+		Execute:  "winamp.exe \"[[media_path]]\"",
+	}
+
+	require.NoError(t, validateCustomLauncher(&entry))
+	assert.Equal(t, CustomLauncherKindLauncher, entry.Kind)
+	assert.Equal(t, CustomLauncherBackendCommand, entry.Backend)
+}
+
 func TestValidateCustomLauncher_RejectsInvalidCommonFields(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/launchables/launchables_test.go
+++ b/pkg/launchables/launchables_test.go
@@ -126,6 +126,31 @@ execute = "echo tools"
 	assert.Equal(t, uuid.NewSHA1(ZaparooLaunchableNamespace, []byte("command:tools")), entry.ID)
 }
 
+func TestLaunchablesReturnsCommandVirtualSystemWithImpliedBackend(t *testing.T) {
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[[launchers.custom]]
+id = "Winamp_Main"
+kind = "virtual_system"
+name = "Winamp"
+category = "Computer"
+execute = "winamp.exe"
+`))
+	platform := mocks.NewMockPlatform()
+	platform.On("Launchers", cfg).Return([]platforms.Launcher{{ID: "Winamp_Main", Launch: testLaunch()}})
+
+	defs := Launchables(cfg, platform)
+
+	require.Len(t, defs, 1)
+	entry, ok := defs[0].(VirtualSystem)
+	require.True(t, ok)
+	assert.Equal(t, "Winamp", entry.Name)
+	assert.Equal(t, "Computer", entry.Category)
+	// Identity matches the explicit-backend form, so both spellings of the same
+	// launcher keep the same app display settings and artwork.
+	assert.Equal(t, uuid.NewSHA1(ZaparooLaunchableNamespace, []byte("command:winamp_main")), entry.ID)
+}
+
 func TestLaunchablesReturnsNilForPlatformsWithoutDefinitions(t *testing.T) {
 	platform := mocks.NewMockPlatform()
 

--- a/pkg/service/next_actions.go
+++ b/pkg/service/next_actions.go
@@ -62,12 +62,20 @@ func handleNextActionPreflight(svc *ServiceContext, token *tokens.Token, script 
 			log.Warn().Err(err).Msg("failed to evaluate launch override")
 			return nextActionInvalid
 		}
+		resolvedLauncherID = strings.TrimSpace(resolvedLauncherID)
+		// Reject unknown IDs here rather than arming. Otherwise the error only
+		// surfaces on the next card scanned, blamed on that card instead of
+		// this one.
+		if !launcherIDExists(svc, resolvedLauncherID) {
+			log.Warn().Str("launcher", resolvedLauncherID).Msg("launch override launcher not found")
+			return nextActionInvalid
+		}
 		svc.State.SetPendingLaunchOverride(&state.PendingLaunchOverride{
-			LauncherID: strings.TrimSpace(resolvedLauncherID),
+			LauncherID: resolvedLauncherID,
 			Source:     *token,
 			CreatedAt:  time.Now(),
 		})
-		log.Info().Str("launcher", strings.TrimSpace(resolvedLauncherID)).Msg("armed one-shot launch override")
+		log.Info().Str("launcher", resolvedLauncherID).Msg("armed one-shot launch override")
 		return nextActionArmed
 	case gozapscript.ZapScriptCmdWrite:
 		if len(cmd.Args) != 1 || strings.TrimSpace(cmd.Args[0]) == "" || !cmd.AdvArgs.IsEmpty() {
@@ -88,6 +96,18 @@ func handleNextActionPreflight(svc *ServiceContext, token *tokens.Token, script 
 	default:
 		return nextActionNone
 	}
+}
+
+// launcherIDExists reports whether a launcher ID resolves, matching the
+// case-insensitive comparison the advanced argument validator uses when the
+// override is later applied to a launch command.
+func launcherIDExists(svc *ServiceContext, launcherID string) bool {
+	for _, id := range zapscript.GetLauncherIDs(svc.Platform, svc.Config) {
+		if strings.EqualFold(id, launcherID) {
+			return true
+		}
+	}
+	return false
 }
 
 func evalNextActionArg(svc *ServiceContext, value string) (string, error) {

--- a/pkg/service/next_actions.go
+++ b/pkg/service/next_actions.go
@@ -39,6 +39,11 @@ const (
 	nextActionInvalid
 )
 
+// launchOverrideTTL bounds how long an armed one-shot launcher override waits
+// for its next card. Without it, an override armed and then forgotten silently
+// rewrites a launch hours later.
+const launchOverrideTTL = 5 * time.Minute
+
 func handleNextActionPreflight(svc *ServiceContext, token *tokens.Token, script *gozapscript.Script) nextActionResult {
 	if !svc.State.RunZapScriptEnabled() {
 		return nextActionNone
@@ -130,6 +135,10 @@ func hasNonLauncherAdvArg(args gozapscript.AdvArgs) bool {
 		return true
 	})
 	return hasNonLauncher
+}
+
+func launchOverrideExpired(createdAt time.Time) bool {
+	return !createdAt.IsZero() && time.Since(createdAt) > launchOverrideTTL
 }
 
 func shouldApplyLaunchOverride(token *tokens.Token, inHookContext bool, cmdName string) bool {

--- a/pkg/service/next_actions_test.go
+++ b/pkg/service/next_actions_test.go
@@ -132,7 +132,9 @@ block_commands = ["write"]
 func TestHandleNextActionPreflight_ArmsLaunchOverride(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _ := setupNextActionTestEnv(t)
+	svc, mockPlatform, cfg := setupNextActionTestEnv(t)
+	mockPlatform.On("Launchers", cfg).
+		Return([]platforms.Launcher{{ID: "3do-dualram", SystemID: "3do"}})
 	parser := gozapscript.NewParser("**launch?launcher=3do-dualram")
 	script, err := parser.ParseScript()
 	require.NoError(t, err)
@@ -145,6 +147,42 @@ func TestHandleNextActionPreflight_ArmsLaunchOverride(t *testing.T) {
 	require.NotNil(t, pending)
 	assert.Equal(t, "3do-dualram", pending.LauncherID)
 	assert.Equal(t, "source", pending.Source.UID)
+}
+
+func TestHandleNextActionPreflight_ArmsLaunchOverrideCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	svc, mockPlatform, cfg := setupNextActionTestEnv(t)
+	mockPlatform.On("Launchers", cfg).
+		Return([]platforms.Launcher{{ID: "Winamp_Main", SystemID: ""}})
+	parser := gozapscript.NewParser("**launch?launcher=winamp_main")
+	script, err := parser.ParseScript()
+	require.NoError(t, err)
+	token := tokens.Token{UID: "source", Text: "**launch?launcher=winamp_main", ScanTime: time.Now()}
+
+	result := handleNextActionPreflight(svc, &token, &script)
+
+	require.Equal(t, nextActionArmed, result)
+	pending := svc.State.GetPendingLaunchOverride()
+	require.NotNil(t, pending)
+	assert.Equal(t, "winamp_main", pending.LauncherID)
+}
+
+func TestHandleNextActionPreflight_RejectsUnknownLaunchOverride(t *testing.T) {
+	t.Parallel()
+
+	svc, mockPlatform, cfg := setupNextActionTestEnv(t)
+	mockPlatform.On("Launchers", cfg).
+		Return([]platforms.Launcher{{ID: "3do-dualram", SystemID: "3do"}})
+	parser := gozapscript.NewParser("**launch?launcher=Winamp_Main")
+	script, err := parser.ParseScript()
+	require.NoError(t, err)
+	token := tokens.Token{UID: "source", Text: "**launch?launcher=Winamp_Main", ScanTime: time.Now()}
+
+	result := handleNextActionPreflight(svc, &token, &script)
+
+	require.Equal(t, nextActionInvalid, result)
+	assert.Nil(t, svc.State.GetPendingLaunchOverride())
 }
 
 func TestRunTokenZapScript_AppliesPendingLaunchOverride(t *testing.T) {

--- a/pkg/service/next_actions_test.go
+++ b/pkg/service/next_actions_test.go
@@ -217,6 +217,35 @@ func TestRunTokenZapScript_AppliesPendingLaunchOverride(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
+func TestRunTokenZapScript_DiscardsExpiredPendingLaunchOverride(t *testing.T) {
+	t.Parallel()
+
+	svc, mockPlatform, cfg := setupNextActionTestEnv(t)
+	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
+
+	path := filepath.Join(t.TempDir(), "game.chd")
+	mockPlatform.On("LaunchMedia", cfg, path,
+		(*platforms.Launcher)(nil),
+		svc.DB,
+		mock.MatchedBy(func(opts *platforms.LaunchOptions) bool {
+			return opts != nil && opts.ActiveMediaPublisher != nil
+		})).Return(nil).Once()
+
+	svc.State.SetPendingLaunchOverride(&state.PendingLaunchOverride{
+		LauncherID: "3do-dualram",
+		Source:     tokens.Token{UID: "source"},
+		CreatedAt:  time.Now().Add(-launchOverrideTTL - time.Minute),
+	})
+
+	plsc := playlists.PlaylistController{Queue: make(chan *playlists.Playlist, 1)}
+	token := tokens.Token{Text: "**launch:" + path, ScanTime: time.Now(), Source: tokens.SourceReader}
+	err := runTokenZapScript(svc, token, plsc, nil, false)
+
+	require.NoError(t, err)
+	assert.Nil(t, svc.State.GetPendingLaunchOverride())
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestRunTokenZapScript_PlaylistDoesNotConsumePendingOverride(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/queues.go
+++ b/pkg/service/queues.go
@@ -200,8 +200,13 @@ func runTokenZapScriptWithContext(
 
 		if shouldApplyLaunchOverride(&token, inHookContext, cmd.Name) {
 			if pending := svc.State.ConsumePendingLaunchOverride(); pending != nil {
-				log.Info().Str("launcher", pending.LauncherID).Msg("applying one-shot launch override")
-				cmd.AdvArgs = cmd.AdvArgs.With(gozapscript.KeyLauncher, pending.LauncherID)
+				if launchOverrideExpired(pending.CreatedAt) {
+					log.Warn().Str("launcher", pending.LauncherID).
+						Msg("discarding expired one-shot launch override")
+				} else {
+					log.Info().Str("launcher", pending.LauncherID).Msg("applying one-shot launch override")
+					cmd.AdvArgs = cmd.AdvArgs.With(gozapscript.KeyLauncher, pending.LauncherID)
+				}
 			}
 		}
 

--- a/pkg/ui/systray/systray.go
+++ b/pkg/ui/systray/systray.go
@@ -124,7 +124,7 @@ func systrayOnReady(
 						notify("Error opening launchers directory.")
 					}
 				case <-mReloadConfig.ClickedCh:
-					err := reloadCore(cfg)
+					err := reloadCore(cfg, client.LocalClient)
 					if err != nil {
 						log.Error().Err(err).Msg("failed to reload config")
 						notify("Error reloading Core config.")
@@ -156,12 +156,15 @@ func systrayOnReady(
 // files and rebuilds the launcher cache. Both calls are needed: settings.reload
 // does not read the launchers directory, so editing a custom launcher TOML has
 // no effect until launchers.refresh runs.
-func reloadCore(cfg *config.Instance) error {
+func reloadCore(
+	cfg *config.Instance,
+	localClient func(context.Context, *config.Instance, string, string) (string, error),
+) error {
 	ctx := context.Background()
-	if _, err := client.LocalClient(ctx, cfg, models.MethodSettingsReload, ""); err != nil {
+	if _, err := localClient(ctx, cfg, models.MethodSettingsReload, ""); err != nil {
 		return fmt.Errorf("reload settings: %w", err)
 	}
-	if _, err := client.LocalClient(ctx, cfg, models.MethodLaunchersRefresh, ""); err != nil {
+	if _, err := localClient(ctx, cfg, models.MethodLaunchersRefresh, ""); err != nil {
 		return fmt.Errorf("refresh launchers: %w", err)
 	}
 	return nil

--- a/pkg/ui/systray/systray.go
+++ b/pkg/ui/systray/systray.go
@@ -124,7 +124,7 @@ func systrayOnReady(
 						notify("Error opening launchers directory.")
 					}
 				case <-mReloadConfig.ClickedCh:
-					_, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsReload, "")
+					err := reloadCore(cfg)
 					if err != nil {
 						log.Error().Err(err).Msg("failed to reload config")
 						notify("Error reloading Core config.")
@@ -150,6 +150,21 @@ func systrayOnReady(
 			}
 		}()
 	}
+}
+
+// reloadCore reloads settings and mappings, then reloads the custom launcher
+// files and rebuilds the launcher cache. Both calls are needed: settings.reload
+// does not read the launchers directory, so editing a custom launcher TOML has
+// no effect until launchers.refresh runs.
+func reloadCore(cfg *config.Instance) error {
+	ctx := context.Background()
+	if _, err := client.LocalClient(ctx, cfg, models.MethodSettingsReload, ""); err != nil {
+		return fmt.Errorf("reload settings: %w", err)
+	}
+	if _, err := client.LocalClient(ctx, cfg, models.MethodLaunchersRefresh, ""); err != nil {
+		return fmt.Errorf("refresh launchers: %w", err)
+	}
+	return nil
 }
 
 func Run(

--- a/pkg/ui/systray/systray_test.go
+++ b/pkg/ui/systray/systray_test.go
@@ -1,6 +1,21 @@
 // Zaparoo Core
 // Copyright (c) 2026 The Zaparoo Project Contributors.
 // SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
 package systray
 
@@ -21,8 +36,8 @@ func TestReloadCore(t *testing.T) {
 	tests := []struct {
 		name            string
 		failedMethod    string
-		expectedMethods []string
 		expectedError   string
+		expectedMethods []string
 	}{
 		{
 			name: "reloads settings then launchers",

--- a/pkg/ui/systray/systray_test.go
+++ b/pkg/ui/systray/systray_test.go
@@ -1,0 +1,82 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package systray
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReloadCore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		failedMethod    string
+		expectedMethods []string
+		expectedError   string
+	}{
+		{
+			name: "reloads settings then launchers",
+			expectedMethods: []string{
+				models.MethodSettingsReload,
+				models.MethodLaunchersRefresh,
+			},
+		},
+		{
+			name:            "stops when settings reload fails",
+			failedMethod:    models.MethodSettingsReload,
+			expectedMethods: []string{models.MethodSettingsReload},
+			expectedError:   "reload settings: request failed",
+		},
+		{
+			name:         "reports launcher refresh failure",
+			failedMethod: models.MethodLaunchersRefresh,
+			expectedMethods: []string{
+				models.MethodSettingsReload,
+				models.MethodLaunchersRefresh,
+			},
+			expectedError: "refresh launchers: request failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Instance{}
+			var methods []string
+			localClient := func(
+				_ context.Context,
+				actualCfg *config.Instance,
+				method string,
+				params string,
+			) (string, error) {
+				require.Same(t, cfg, actualCfg)
+				assert.Empty(t, params)
+				methods = append(methods, method)
+				if method == tt.failedMethod {
+					return "", errors.New("request failed")
+				}
+				return "", nil
+			}
+
+			err := reloadCore(cfg, localClient)
+
+			assert.Equal(t, tt.expectedMethods, methods)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.expectedError)
+			}
+		})
+	}
+}

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -65,8 +65,8 @@ var (
 	errAmbiguousPath = errors.New("ambiguous case-insensitive path")
 )
 
-// getLauncherIDs extracts launcher IDs from the platform for validation context.
-func getLauncherIDs(pl platforms.Platform, cfg *config.Instance) []string {
+// GetLauncherIDs extracts launcher IDs from the platform for validation context.
+func GetLauncherIDs(pl platforms.Platform, cfg *config.Instance) []string {
 	launchers := pl.Launchers(cfg)
 	ids := make([]string, len(launchers))
 	for i := range launchers {
@@ -78,7 +78,7 @@ func getLauncherIDs(pl platforms.Platform, cfg *config.Instance) []string {
 // ParseAdvArgs parses and validates advanced arguments for a command.
 // Returns an error if parsing or validation fails.
 func ParseAdvArgs[T any](pl platforms.Platform, env *platforms.CmdEnv, dest *T) error {
-	ctx := advargs.NewParseContext(getLauncherIDs(pl, env.Cfg))
+	ctx := advargs.NewParseContext(GetLauncherIDs(pl, env.Cfg))
 	if err := advargs.Parse(env.Cmd.AdvArgs.Raw(), dest, ctx); err != nil {
 		return fmt.Errorf("failed to parse advanced args: %w", err)
 	}


### PR DESCRIPTION
Five independent fixes around custom launchers and one-shot launch overrides.

## Tray Reload no longer picks up custom launchers

`HandleSettingsReload` used to load custom launcher TOML files and refresh the
launcher cache. #1133 removed that so `settings.reload` would not block on
MiSTer's RBF scan, and moved the work to `launchers.refresh`, updating the TUI's
`ReloadCore` to call both methods. The system tray is the only other caller of
`settings.reload` and was not updated, so since then the tray **Reload** item has
had no effect on custom launcher files and a full restart has been required.

The tray now calls both methods, matching `DefaultSettingsService.ReloadCore`.

## Launch override armed with an unknown launcher

`**launch?launcher=X` arms a one-shot override for the next card without checking
that `X` resolves. A typo armed successfully, and the resulting
`launcher "X" not found` error surfaced on the next card scanned, blaming that
card instead. The preflight now resolves the ID against the platform launcher
list using the same case-insensitive comparison the advanced argument validator
applies later, and returns invalid — fail sound, failed history entry — when it
does not match.

## Pending launch override never expired

`PendingLaunchOverride.CreatedAt` was set but never read, so an override armed and
then forgotten silently rewrote a launch at any later point. It now expires after
five minutes, following the existing `pendingWriteTTL` pattern. An expired
override is consumed and discarded rather than left pending, so it cannot affect
a later scan.

## virtual_system with an implied backend produced no launchable

`validateCustomLauncher` accepts `kind = "virtual_system"` with `execute` and no
`backend`, because it validates through `effectiveCustomLauncherBackend`. It
normalised `category` but left `kind` and `backend` raw, while
`commandVirtualSystems` compares the raw `backend` field. Such an entry loaded and
logged as registered but never became a launchable, with no warning. Validation
now writes the resolved `kind` and `backend` back onto the entry. Entries in this
state produced no launchable before, so no existing launchable identity changes.

## Allow-list regex warnings did not say why

`invalid allow file regex` and its `allow_execute` / `allow_http` / `allow_run`
siblings logged the pattern without the compile error, leaving no way to tell what
was wrong with it. The error is now attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid launcher patterns now provide clearer error details.
  * Pending launch overrides expire after five minutes and are discarded safely.
  * Launcher matching is now case-insensitive, with unknown launchers rejected immediately.
  * Expired one-time overrides no longer affect media launches.

* **Improvements**
  * Custom launcher settings now apply sensible defaults when launcher type or backend is omitted.
  * Configuration reloads now refresh custom launchers and report errors consistently.
  * Command-backed virtual systems can now be recognized when the backend is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->