### PR TITLE
perf(mediadb): reduce media indexing cost and verify applied pragmas

### DIFF
--- a/pkg/api/client/client_test.go
+++ b/pkg/api/client/client_test.go
@@ -81,6 +81,65 @@ func waitForWebSocketSession(server *helpers.WebSocketTestServer, timeout time.D
 	return false
 }
 
+// waitNotificationTimeout is the budget these tests hand to WaitNotification.
+//
+// It has to comfortably exceed a loopback dial rather than just the wait:
+// WaitNotification reuses the caller's timeout as its dial deadline
+// (dialTimeout = timeout), so a budget close to the dial cost surfaces a dial
+// i/o timeout instead of the timeout error under test. Under
+// `go test -race ./pkg/...` a loopback dial was observed past 100 ms, which is
+// what made the 100 ms variants of these tests flaky.
+const waitNotificationTimeout = 2 * time.Second
+
+type waitNotificationResult struct {
+	err    error
+	params string
+}
+
+// waitNotificationInBackground starts WaitNotification and hands back its
+// result, so the test body can wait for the client's session to register before
+// broadcasting. Melody delivers only to sessions that are already connected, so
+// a broadcast sent before the client arrives is dropped and the caller waits out
+// its whole timeout for a notification that no longer exists.
+func waitNotificationInBackground(
+	ctx context.Context, cfg *config.Instance, id string,
+) <-chan waitNotificationResult {
+	ch := make(chan waitNotificationResult, 1)
+	go func() {
+		params, err := WaitNotification(ctx, waitNotificationTimeout, cfg, id)
+		ch <- waitNotificationResult{params: params, err: err}
+	}()
+	return ch
+}
+
+// broadcastAfterSessionReady blocks until the client's websocket session is
+// registered, then broadcasts each payload in order.
+func broadcastAfterSessionReady(
+	t *testing.T, server *helpers.WebSocketTestServer, payloads ...map[string]any,
+) {
+	t.Helper()
+	require.True(t, waitForWebSocketSession(server, waitNotificationTimeout),
+		"websocket session never registered; a broadcast now would be dropped")
+	for _, payload := range payloads {
+		data, err := json.Marshal(payload)
+		require.NoError(t, err)
+		require.NoError(t, server.Melody.Broadcast(data))
+	}
+}
+
+// awaitNotification returns the background WaitNotification result, failing the
+// test rather than hanging if it never arrives.
+func awaitNotification(t *testing.T, resultCh <-chan waitNotificationResult) waitNotificationResult {
+	t.Helper()
+	select {
+	case result := <-resultCh:
+		return result
+	case <-time.After(waitNotificationTimeout):
+		t.Fatal("WaitNotification did not complete")
+		return waitNotificationResult{}
+	}
+}
+
 type recordingTimer struct {
 	clockwork.Timer
 	stopped bool
@@ -402,23 +461,18 @@ func TestWaitNotification_ReceivesNotification(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
-	// Send notification after connection is established
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		notification := map[string]any{
-			"jsonrpc": "2.0",
-			"method":  "tokens.added",
-			"params":  map[string]any{"token": "test123"},
-		}
-		data, _ := json.Marshal(notification)
-		_ = server.Melody.Broadcast(data)
-	}()
+	resultCh := waitNotificationInBackground(context.Background(), cfg, "tokens.added")
+	broadcastAfterSessionReady(t, server, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "tokens.added",
+		"params":  map[string]any{"token": "test123"},
+	})
 
-	result, err := WaitNotification(context.Background(), time.Second, cfg, "tokens.added")
-	require.NoError(t, err)
+	result := awaitNotification(t, resultCh)
+	require.NoError(t, result.err)
 
 	var params map[string]any
-	err = json.Unmarshal([]byte(result), &params)
+	err := json.Unmarshal([]byte(result.params), &params)
 	require.NoError(t, err)
 	assert.Equal(t, "test123", params["token"])
 }
@@ -432,33 +486,26 @@ func TestWaitNotification_IgnoresWrongMethod(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-
-		// Send wrong notification first
-		wrongNotification := map[string]any{
+	resultCh := waitNotificationInBackground(context.Background(), cfg, "tokens.added")
+	broadcastAfterSessionReady(t, server,
+		// Wrong notification first; it must be skipped.
+		map[string]any{
 			"jsonrpc": "2.0",
 			"method":  "tokens.removed",
 			"params":  map[string]any{"wrong": true},
-		}
-		wrongData, _ := json.Marshal(wrongNotification)
-		_ = server.Melody.Broadcast(wrongData)
-
-		// Then send correct notification
-		correctNotification := map[string]any{
+		},
+		map[string]any{
 			"jsonrpc": "2.0",
 			"method":  "tokens.added",
 			"params":  map[string]any{"correct": true},
-		}
-		correctData, _ := json.Marshal(correctNotification)
-		_ = server.Melody.Broadcast(correctData)
-	}()
+		},
+	)
 
-	result, err := WaitNotification(context.Background(), time.Second, cfg, "tokens.added")
-	require.NoError(t, err)
+	result := awaitNotification(t, resultCh)
+	require.NoError(t, result.err)
 
 	var params map[string]any
-	err = json.Unmarshal([]byte(result), &params)
+	err := json.Unmarshal([]byte(result.params), &params)
 	require.NoError(t, err)
 	assert.True(t, params["correct"].(bool))
 }
@@ -472,34 +519,27 @@ func TestWaitNotification_IgnoresRequestObjects(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-
-		// Send a request object (has ID) - should be ignored
-		request := map[string]any{
+	resultCh := waitNotificationInBackground(context.Background(), cfg, "tokens.added")
+	broadcastAfterSessionReady(t, server,
+		// A request object (it has an ID) must be ignored.
+		map[string]any{
 			"jsonrpc": "2.0",
 			"method":  "tokens.added",
 			"params":  map[string]any{"from_request": true},
 			"id":      "some-id",
-		}
-		requestData, _ := json.Marshal(request)
-		_ = server.Melody.Broadcast(requestData)
-
-		// Send a true notification (no ID)
-		notification := map[string]any{
+		},
+		map[string]any{
 			"jsonrpc": "2.0",
 			"method":  "tokens.added",
 			"params":  map[string]any{"from_notification": true},
-		}
-		notificationData, _ := json.Marshal(notification)
-		_ = server.Melody.Broadcast(notificationData)
-	}()
+		},
+	)
 
-	result, err := WaitNotification(context.Background(), time.Second, cfg, "tokens.added")
-	require.NoError(t, err)
+	result := awaitNotification(t, resultCh)
+	require.NoError(t, result.err)
 
 	var params map[string]any
-	err = json.Unmarshal([]byte(result), &params)
+	err := json.Unmarshal([]byte(result.params), &params)
 	require.NoError(t, err)
 	assert.True(t, params["from_notification"].(bool))
 }
@@ -513,8 +553,9 @@ func TestWaitNotification_Timeout(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
-	// Don't send any notification, let it timeout
-	_, err := WaitNotification(context.Background(), 100*time.Millisecond, cfg, "tokens.added")
+	// Don't send any notification, let it timeout. The budget must stay well
+	// above the dial cost — see waitNotificationTimeout.
+	_, err := WaitNotification(context.Background(), waitNotificationTimeout, cfg, "tokens.added")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrRequestTimeout)
 }
@@ -531,14 +572,17 @@ func TestWaitNotification_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		cancel()
-	}()
+	// Cancel only once the client is connected. Cancelling during the dial
+	// fails it instead, which reports a wrapped context error rather than
+	// ErrRequestCancelled.
+	resultCh := waitNotificationInBackground(ctx, cfg, "tokens.added")
+	require.True(t, waitForWebSocketSession(server, waitNotificationTimeout),
+		"websocket session never registered")
+	cancel()
 
-	_, err := WaitNotification(ctx, time.Second, cfg, "tokens.added")
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrRequestCancelled)
+	result := awaitNotification(t, resultCh)
+	require.Error(t, result.err)
+	assert.ErrorIs(t, result.err, ErrRequestCancelled)
 }
 
 func TestWaitNotifications_ReceivesAnyOfMultiple(t *testing.T) {
@@ -669,14 +713,29 @@ func TestWaitNotifications_Timeout(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
-	_, _, err := WaitNotifications(
-		context.Background(),
-		100*time.Millisecond,
-		cfg,
-		"tokens.added",
-	)
-	require.Error(t, err)
-	assert.ErrorIs(t, err, ErrRequestTimeout)
+	// Drive the timeout off a fake clock rather than a short real budget. The
+	// dial deadline is the same value the wait uses, so a budget small enough to
+	// keep the test quick was being consumed by the loopback dial instead,
+	// surfacing a dial i/o timeout rather than ErrRequestTimeout.
+	fakeClock := clockwork.NewFakeClock()
+	resultCh := make(chan waitNotificationsResult, 1)
+	go func() {
+		method, params, err := waitNotificationsWithClock(
+			context.Background(), waitNotificationTimeout, cfg, fakeClock, "tokens.added")
+		resultCh <- waitNotificationsResult{method: method, params: params, err: err}
+	}()
+
+	blockCtx, blockCancel := context.WithTimeout(context.Background(), waitNotificationTimeout)
+	defer blockCancel()
+	require.NoError(t, fakeClock.BlockUntilContext(blockCtx, 1), "timeout timer was never armed")
+	fakeClock.Advance(waitNotificationTimeout)
+
+	select {
+	case result := <-resultCh:
+		require.ErrorIs(t, result.err, ErrRequestTimeout)
+	case <-time.After(waitNotificationTimeout):
+		t.Fatal("WaitNotifications did not complete after the timeout fired")
+	}
 }
 
 func TestWaitNotifications_ContextCancellation(t *testing.T) {
@@ -719,7 +778,29 @@ func TestWaitNotifications_IntentionalCloseIsJoinedAndTraceLogged(t *testing.T) 
 	zlog.Logger = zerolog.New(&logs).Level(zerolog.TraceLevel)
 	t.Cleanup(func() { zlog.Logger = originalLogger })
 
-	_, _, err := WaitNotifications(context.Background(), 20*time.Millisecond, cfg, "tokens.added")
+	// Fake clock for the same reason as TestWaitNotifications_Timeout: a real
+	// budget short enough to keep this quick can be eaten by the dial, which
+	// fails before any of the close/log behaviour under test happens.
+	fakeClock := clockwork.NewFakeClock()
+	resultCh := make(chan waitNotificationsResult, 1)
+	go func() {
+		method, params, waitErr := waitNotificationsWithClock(
+			context.Background(), waitNotificationTimeout, cfg, fakeClock, "tokens.added")
+		resultCh <- waitNotificationsResult{method: method, params: params, err: waitErr}
+	}()
+
+	blockCtx, blockCancel := context.WithTimeout(context.Background(), waitNotificationTimeout)
+	defer blockCancel()
+	require.NoError(t, fakeClock.BlockUntilContext(blockCtx, 1), "timeout timer was never armed")
+	fakeClock.Advance(waitNotificationTimeout)
+
+	var err error
+	select {
+	case result := <-resultCh:
+		err = result.err
+	case <-time.After(waitNotificationTimeout):
+		t.Fatal("WaitNotifications did not complete after the timeout fired")
+	}
 	require.ErrorIs(t, err, ErrRequestTimeout)
 
 	lines := bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n"))
@@ -936,21 +1017,22 @@ func TestLocalAPIClient_WaitNotification(t *testing.T) {
 	port := parseServerPort(t, server.Server)
 	cfg := testConfigWithPort(t, port)
 
+	client := NewLocalAPIClient(cfg)
+	resultCh := make(chan waitNotificationResult, 1)
 	go func() {
-		time.Sleep(50 * time.Millisecond)
-		notification := map[string]any{
-			"jsonrpc": "2.0",
-			"method":  "tokens.added",
-			"params":  map[string]any{"token": "abc"},
-		}
-		data, _ := json.Marshal(notification)
-		_ = server.Melody.Broadcast(data)
+		params, err := client.WaitNotification(context.Background(), waitNotificationTimeout, "tokens.added")
+		resultCh <- waitNotificationResult{params: params, err: err}
 	}()
 
-	client := NewLocalAPIClient(cfg)
-	result, err := client.WaitNotification(context.Background(), time.Second, "tokens.added")
-	require.NoError(t, err)
-	assert.Contains(t, result, "abc")
+	broadcastAfterSessionReady(t, server, map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "tokens.added",
+		"params":  map[string]any{"token": "abc"},
+	})
+
+	result := awaitNotification(t, resultCh)
+	require.NoError(t, result.err)
+	assert.Contains(t, result.params, "abc")
 }
 
 func TestNewLocalAPIClient(t *testing.T) {

--- a/pkg/api/main_test.go
+++ b/pkg/api/main_test.go
@@ -20,12 +20,25 @@
 package api
 
 import (
+	"os"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"go.uber.org/goleak"
 )
 
+// testLogRedirector is installed as the global logger's writer for the whole
+// test binary, so tests capture output by pointing it somewhere rather than by
+// assigning log.Logger. See logRedirector for why that assignment was a race.
+var testLogRedirector = &logRedirector{fallback: os.Stderr, level: zerolog.TraceLevel}
+
 func TestMain(m *testing.M) {
+	// Install once, before any test runs, and leave it alone from here on.
+	// Everything reaches the writer; captureLogs applies the per-test level.
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	log.Logger = zerolog.New(testLogRedirector).With().Timestamp().Logger()
+
 	goleak.VerifyTestMain(m,
 		// melody's hub goroutine is managed by the library and Close() is async
 		goleak.IgnoreTopFunction("github.com/olahol/melody.(*hub).run"),

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -669,8 +669,22 @@ func startMediaDBGeneration(
 		// Widen the connection pool for the duration: the indexing writer
 		// holds a connection near-continuously, and foreground search +
 		// browse must not queue behind each other on the single remainder.
+		//
+		// The restore is released explicitly before optimization is handed off
+		// (see releaseConnBoost below); this defer only covers the paths that
+		// return before reaching that point. Leaving it to the defer alone
+		// raced optimization's own boost and broke it on three consecutive
+		// device runs — see #1279 and releaseConnBoost's comment.
+		connBoostReleased := false
+		releaseConnBoost := func() {
+			if connBoostReleased {
+				return
+			}
+			connBoostReleased = true
+			db.MediaDB.SetIndexingConnBoost(false)
+		}
 		db.MediaDB.SetIndexingConnBoost(true)
-		defer db.MediaDB.SetIndexingConnBoost(false)
+		defer releaseConnBoost()
 
 		if rebuild {
 			// Recreate closes the database, and Close waits for all tracked
@@ -832,6 +846,18 @@ func startMediaDBGeneration(
 		// the OS so idle RSS drops from peak.
 		runtime.GC()
 		debug.FreeOSMemory()
+
+		// Drop the indexing pool boost BEFORE optimization is spawned, not on
+		// the way out of this goroutine.
+		//
+		// Optimization re-applies its own boost as its first act, and that
+		// begins by draining every pooled connection. It sizes that drain from
+		// SetMaxOpenConns, so if this restore is still pending it reads the
+		// widened cap, tries to acquire one more connection than the pool will
+		// ever hand out once the restore lands, and deadlocks against its own
+		// held connections until the acquire deadline expires. Releasing here
+		// gives the two a happens-before edge without any waiting.
+		releaseConnBoost()
 
 		// Atomically hand indexing ownership to optimization so scraping cannot
 		// enter between completed indexing and post-index maintenance.

--- a/pkg/api/methods/media_rebuild_test.go
+++ b/pkg/api/methods/media_rebuild_test.go
@@ -71,9 +71,17 @@ func newRebuildTestEnv(t *testing.T, mockMediaDB *helpers.MockMediaDBI, params s
 
 // waitForIndexingFinished polls until the background indexing goroutine started
 // by HandleGenerateMedia has cleared the in-process indexing status.
+// indexingFinishedTimeout guards against a background goroutine that never
+// finishes; it is not a claim about how fast one should be. The work behind it
+// recreates a SQLite database and runs migrations, which under
+// `go test -race ./pkg/...` can take several seconds on a loaded machine — the
+// previous 5s deadline failed there while passing on its own. Polling returns as
+// soon as indexing clears, so a generous deadline costs a passing test nothing.
+const indexingFinishedTimeout = 30 * time.Second
+
 func waitForIndexingFinished(t *testing.T) {
 	t.Helper()
-	deadline := time.After(5 * time.Second)
+	deadline := time.After(indexingFinishedTimeout)
 	ticker := time.NewTicker(5 * time.Millisecond)
 	defer ticker.Stop()
 	for {

--- a/pkg/api/pairing_test.go
+++ b/pkg/api/pairing_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/schollz/pake/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -657,10 +656,7 @@ func TestHTTPHandlers_FullFlow(t *testing.T) {
 //
 // Not t.Parallel — mutates the global zerolog logger to capture output.
 func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
-	t.Cleanup(func() { log.Logger = originalLogger })
+	buf := captureLogs(t, zerolog.WarnLevel)
 
 	h := newPairingHarness(t)
 	pin, _, err := h.mgr.StartPairing("member")
@@ -735,10 +731,7 @@ func TestHandlePairFinish_AuditLogsHMACMismatch(t *testing.T) {
 //
 // Not t.Parallel — mutates the global zerolog logger.
 func TestHandlePairFinish_AuditLogsExhaustion(t *testing.T) {
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.WarnLevel)
-	t.Cleanup(func() { log.Logger = originalLogger })
+	buf := captureLogs(t, zerolog.WarnLevel)
 
 	h := newPairingHarness(t, WithPairingMaxAttempts(1))
 	pin, _, err := h.mgr.StartPairing("member")

--- a/pkg/api/server_logging_test.go
+++ b/pkg/api/server_logging_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/olahol/melody"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +66,80 @@ func (c *logCapture) String() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.buf.String()
+}
+
+// logRedirector is the writer behind the package's global logger. It is
+// installed once by TestMain and never replaced, so tests can capture log
+// output by swapping where it points instead of by assigning log.Logger.
+//
+// Assigning log.Logger is a data race and the race detector caught it: a
+// dispatcher goroutine belonging to another test was reading the global logger
+// in log.Debug() while TestHandlePairFinish_AuditLogsHMACMismatch wrote it.
+// Guarding the capture buffer, which this package already did, does not help —
+// the unguarded state is the Logger value itself. Websocket dispatcher
+// goroutines outlive the test that started them, so no amount of test ordering
+// removes the overlap.
+//
+// Implementing zerolog.LevelWriter keeps per-test level filtering exact without
+// parsing the JSON back out.
+type logRedirector struct {
+	target   *logCapture
+	fallback io.Writer
+	mu       syncutil.Mutex
+	level    zerolog.Level
+}
+
+func (r *logRedirector) Write(p []byte) (int, error) {
+	return r.WriteLevel(zerolog.NoLevel, p)
+}
+
+func (r *logRedirector) WriteLevel(level zerolog.Level, p []byte) (int, error) {
+	r.mu.Lock()
+	target, minLevel, fallback := r.target, r.level, r.fallback
+	r.mu.Unlock()
+
+	if target == nil {
+		if fallback == nil {
+			return len(p), nil
+		}
+		n, err := fallback.Write(p)
+		if err != nil {
+			return n, fmt.Errorf("write log fallback: %w", err)
+		}
+		return n, nil
+	}
+	if level != zerolog.NoLevel && level < minLevel {
+		return len(p), nil
+	}
+	return target.Write(p)
+}
+
+func (r *logRedirector) attach(target *logCapture, level zerolog.Level) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.target = target
+	r.level = level
+}
+
+func (r *logRedirector) detach() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.target = nil
+	r.level = zerolog.TraceLevel
+}
+
+// captureLogs routes global log output into a fresh buffer for the duration of
+// the test, filtered to level and above.
+//
+// Tests using it need not be sequential: other tests' goroutines keep logging
+// into the same buffer, which is why logCapture is synchronized and why
+// assertions here look for the lines they want rather than counting them.
+func captureLogs(t *testing.T, level zerolog.Level) *logCapture {
+	t.Helper()
+	buf := &logCapture{}
+	testLogRedirector.attach(buf, level)
+	t.Cleanup(testLogRedirector.detach)
+	return buf
 }
 
 func TestLogSafeResponse(t *testing.T) {
@@ -104,15 +178,10 @@ func TestLogSafeResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Capture log output
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			// Test the function
 			logSafeResponse(tt.result)
-
-			// Restore original logger
-			log.Logger = originalLogger
 
 			logOutput := buf.String()
 
@@ -171,10 +240,7 @@ func TestLogSafeResponse_BatchRedaction(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-			defer func() { log.Logger = originalLogger }()
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			logSafeResponse(tt.result)
 
@@ -196,10 +262,7 @@ func TestLogSafeResponse_DefaultOmitsBody(t *testing.T) {
 		Blob   string `json:"blob"`
 	}
 
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-	defer func() { log.Logger = originalLogger }()
+	buf := captureLogs(t, zerolog.DebugLevel)
 
 	logSafeResponse(secretShape{Marker: "should-not-appear", Blob: "AAAABASE64=="})
 
@@ -278,10 +341,7 @@ func TestHandleResponse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-			defer func() { log.Logger = originalLogger }()
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			require.NoError(t, handleResponse(tt.resp))
 
@@ -329,15 +389,10 @@ func TestLogSafeRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Capture log output
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			// Test the function
 			logSafeRequest(&tt.request)
-
-			// Restore original logger
-			log.Logger = originalLogger
 
 			logOutput := buf.String()
 
@@ -350,10 +405,7 @@ func TestLogSafeRequest(t *testing.T) {
 }
 
 func TestLogSafeRequest_AuthClaimParamsRedacted(t *testing.T) {
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-	defer func() { log.Logger = originalLogger }()
+	buf := captureLogs(t, zerolog.DebugLevel)
 
 	logSafeRequest(&models.RequestObject{
 		JSONRPC: "2.0",
@@ -370,10 +422,7 @@ func TestLogSafeRequest_AuthClaimParamsRedacted(t *testing.T) {
 }
 
 func TestLogSafeResponse_AuthLinkCodesRedacted(t *testing.T) {
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-	defer func() { log.Logger = originalLogger }()
+	buf := captureLogs(t, zerolog.DebugLevel)
 
 	logSafeResponse(models.AuthLinkStatusResponse{
 		Status:                  models.AuthLinkStatusPending,
@@ -419,13 +468,9 @@ func TestLogWSWriteError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf)
+			buf := captureLogs(t, zerolog.TraceLevel)
 
 			logWSWriteError(tt.err, "test message")
-
-			log.Logger = originalLogger
 
 			logOutput := buf.String()
 			assert.Contains(t, logOutput, tt.expectLevel)

--- a/pkg/api/server_logging_test.go
+++ b/pkg/api/server_logging_test.go
@@ -128,17 +128,27 @@ func (r *logRedirector) detach() {
 	r.level = zerolog.TraceLevel
 }
 
+// logCaptureLease serializes capture sessions. There is one global logger, so
+// two tests capturing at once would overwrite each other's target and the first
+// to finish would detach the second's buffer. Holding it for the test and
+// releasing in cleanup makes a concurrent caller wait its turn instead.
+var logCaptureLease syncutil.Mutex
+
 // captureLogs routes global log output into a fresh buffer for the duration of
 // the test, filtered to level and above.
 //
-// Tests using it need not be sequential: other tests' goroutines keep logging
-// into the same buffer, which is why logCapture is synchronized and why
-// assertions here look for the lines they want rather than counting them.
+// Other tests' goroutines keep logging into the same buffer while it is
+// attached, which is why logCapture is synchronized and why assertions here look
+// for the lines they want rather than counting them.
 func captureLogs(t *testing.T, level zerolog.Level) *logCapture {
 	t.Helper()
 	buf := &logCapture{}
+	logCaptureLease.Lock()
 	testLogRedirector.attach(buf, level)
-	t.Cleanup(testLogRedirector.detach)
+	t.Cleanup(func() {
+		testLogRedirector.detach()
+		logCaptureLease.Unlock()
+	})
 	return buf
 }
 

--- a/pkg/api/transport_timing_test.go
+++ b/pkg/api/transport_timing_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -70,10 +69,7 @@ func TestLogWebSocketTransportTimingFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-			defer func() { log.Logger = originalLogger }()
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			logWebSocketTransportTiming(
 				models.NewStringID("request-1"), tt.responseType, tt.encrypted, 321,
@@ -109,10 +105,7 @@ func TestHTTPResponseTransportTimingFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, _, _ := createTestPostHandler(t)
-			var buf logCapture
-			originalLogger := log.Logger
-			log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-			defer func() { log.Logger = originalLogger }()
+			buf := captureLogs(t, zerolog.DebugLevel)
 
 			body := `{"jsonrpc":"2.0","id":"transport-id","method":"` + tt.method + `"}`
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api", strings.NewReader(body))
@@ -171,10 +164,7 @@ func TestWebSocketDispatcherQueueMetadata(t *testing.T) {
 }
 
 func TestWebSocketDispatcherQueueTimingLogs(t *testing.T) {
-	var buf logCapture
-	originalLogger := log.Logger
-	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-	defer func() { log.Logger = originalLogger }()
+	buf := captureLogs(t, zerolog.DebugLevel)
 
 	var methodMap MethodMap
 	require.NoError(t, methodMap.AddMethod("test.queue", func(requests.RequestEnv) (any, error) {

--- a/pkg/database/corruption.go
+++ b/pkg/database/corruption.go
@@ -117,6 +117,26 @@ func NoteCorruption(dbPath string, err error, now time.Time) bool {
 	return true
 }
 
+// PreserveCorruptFile renames path aside to its CorruptBackupPath, so a file
+// about to be replaced or deleted survives as a forensic copy. A missing
+// source file is a silent no-op (nothing to preserve); any other stat or
+// rename failure is logged, not returned — recovery must proceed even when
+// the forensic copy could not be made. dbLabel names the database in the log
+// line (e.g. "media", "user").
+func PreserveCorruptFile(path, dbLabel string) {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return
+	} else if err != nil {
+		log.Warn().Err(err).Str("db", dbLabel).Str("path", path).Msg("failed to stat corrupt database file")
+		return
+	}
+	backup := CorruptBackupPath(path)
+	_ = os.Remove(backup)
+	if err := os.Rename(path, backup); err != nil {
+		log.Warn().Err(err).Str("db", dbLabel).Str("path", path).Msg("failed to preserve corrupt database file")
+	}
+}
+
 // RemoveSidecars deletes the -wal and -shm sidecar files for dbPath. A stale WAL
 // left next to a freshly restored or recreated database would re-corrupt it.
 func RemoveSidecars(dbPath string) {

--- a/pkg/database/mediadb/analyze_mask_test.go
+++ b/pkg/database/mediadb/analyze_mask_test.go
@@ -1,0 +1,85 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SQLite PRAGMA optimize mask bits, from the pragma documentation.
+const (
+	optimizeBitAnalyze      = 0x00002 // run ANALYZE on tables that might benefit
+	optimizeBitAnalysisCap  = 0x00010 // apply SQLITE_DEFAULT_OPTIMIZE_LIMIT as the analysis limit
+	optimizeBitUnqueriedTbl = 0x10000 // consider tables not queried on this connection
+)
+
+func parseAnalyzeMask(t *testing.T) int64 {
+	t.Helper()
+	raw := strings.TrimPrefix(analyzeApproximateMask, "0x")
+	mask, err := strconv.ParseInt(raw, 16, 64)
+	require.NoError(t, err, "analyzeApproximateMask must be parseable hex")
+	return mask
+}
+
+// TestAnalyzeApproximateMaskCapsAnalysisWork pins the three bits the mask must
+// carry. The mask used to be 0x10002, which omits 0x10; on the MiSTer test
+// device that produced silent stalls of up to 117 seconds on a single system,
+// with no log output at all.
+//
+// Do not read the name of this test as a guarantee. Bit 0x10 applies
+// SQLITE_DEFAULT_OPTIMIZE_LIMIT (2000) as the analysis limit, but the limit
+// does not stop a scan — sqlite3-binding.c statPush makes it seek past the
+// current distinct value of the index's leading column instead. On a
+// high-cardinality leading column that advances roughly one row per skip and
+// the scan walks the whole index anyway. Round 9 of #1279 measured a single
+// call at 54,442 ms with this mask in place. The bit is still worth setting;
+// it just is not a bound. See analyzeApproximateMask.
+func TestAnalyzeApproximateMaskCapsAnalysisWork(t *testing.T) {
+	t.Parallel()
+
+	mask := parseAnalyzeMask(t)
+
+	assert.NotZero(t, mask&optimizeBitAnalysisCap,
+		"mask %s must set 0x10 so SQLITE_DEFAULT_OPTIMIZE_LIMIT applies at all; without "+
+			"it nLimit is 0 and every qualifying ANALYZE is a plain full-index scan (see #1279)",
+		analyzeApproximateMask)
+	assert.NotZero(t, mask&optimizeBitAnalyze,
+		"mask %s must set 0x02 or PRAGMA optimize does nothing", analyzeApproximateMask)
+	assert.NotZero(t, mask&optimizeBitUnqueriedTbl,
+		"mask %s must set 0x10000 so tables that grew without being queried on "+
+			"this connection are still refreshed", analyzeApproximateMask)
+}
+
+// TestAnalyzeApproximateMaskValue pins the exact mask so a future edit has to
+// be deliberate rather than incidental.
+func TestAnalyzeApproximateMaskValue(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "0x10012", analyzeApproximateMask)
+
+	mask := parseAnalyzeMask(t)
+	want := int64(optimizeBitAnalyze | optimizeBitAnalysisCap | optimizeBitUnqueriedTbl)
+	assert.Equal(t, want, mask, "mask should be exactly analyze|cap|unqueried")
+}

--- a/pkg/database/mediadb/browse_cache_fk_regression_test.go
+++ b/pkg/database/mediadb/browse_cache_fk_regression_test.go
@@ -1,0 +1,138 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// Regression tests for the browse cache clear (#1279).
+//
+// The rebuild used to run two unqualified DELETEs with foreign key enforcement
+// on. BrowseDirs is the parent of three ON DELETE CASCADE foreign keys — a
+// self-reference plus two from BrowseDirCounts — so SQLite could not use its
+// truncate optimization: it deleted row by row, running child probes and the
+// recursive self-cascade through a statement journal. On the MiSTer test device
+// that measured 261.9s to clear ~21,500 rows, 13x the cost of the inserts that
+// replaced them.
+//
+// The fix pins a connection and disables foreign keys around the rebuild
+// transaction. That makes it critical to prove the pragma is genuinely restored
+// afterwards: a pooled connection leaking foreign_keys=OFF would silently
+// disable enforcement for unrelated queries for the rest of the process.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertForeignKeysEnforced proves enforcement is actually active, rather than
+// only that the pragma reads back as ON: it attempts a real violation and
+// requires SQLite to reject it.
+func assertForeignKeysEnforced(t *testing.T, ctx context.Context, mediaDB *MediaDB) { //nolint:revive // t before ctx is standard test helper convention
+	t.Helper()
+
+	_, err := mediaDB.sql.Load().ExecContext(ctx,
+		"INSERT INTO BrowseDirCounts (ParentDirDBID, ChildDirDBID, SystemDBID, FileCount) "+
+			"VALUES (?, ?, ?, ?)",
+		999999, 999999, 999999, 1)
+	require.Error(t, err,
+		"foreign key enforcement must be active after a browse cache rebuild; "+
+			"a connection leaked back into the pool with foreign_keys=OFF")
+	assert.Contains(t, err.Error(), "FOREIGN KEY",
+		"expected an FK constraint violation, got a different error")
+}
+
+// TestPopulateBrowseCache_RestoresForeignKeys_Integration is the guard that the
+// FK-disabling fix does not leak. It checks every connection the pool can hand
+// out, not just one, because only the pinned connection had the pragma changed.
+func TestPopulateBrowseCache_RestoresForeignKeys_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	insertSystemWithMedia(t, mediaDB, "SNES", "Super RPG",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "super-rpg.sfc")))
+
+	// Enforcement is on before the rebuild.
+	assertForeignKeysEnforced(t, ctx, mediaDB)
+
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+
+	// ...and still on after it, on any connection the pool returns.
+	for range 8 {
+		assertForeignKeysEnforced(t, ctx, mediaDB)
+	}
+
+	var fkEnabled int
+	require.NoError(t,
+		mediaDB.sql.Load().QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fkEnabled))
+	assert.Equal(t, 1, fkEnabled, "PRAGMA foreign_keys should read back as enabled")
+}
+
+// TestPopulateBrowseCache_RebuildDropsStaleRows_Integration checks the clear
+// still does its job with foreign keys off — rows for media that no longer
+// exists must not survive a rebuild.
+func TestPopulateBrowseCache_RebuildDropsStaleRows_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	snes := insertSystemWithMedia(t, mediaDB, "SNES", "Super RPG",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "super-rpg.sfc")))
+	insertSystemWithMedia(t, mediaDB, "NES", "Mario",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "nes", "mario.nes")))
+
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	before := countTableRows(t, mediaDB, "BrowseDirs", "1=1")
+	require.Positive(t, before, "first rebuild should populate dirs")
+	require.Positive(t, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"SystemDBID = ?", snes.DBID))
+
+	// Remove every SNES media row, then rebuild.
+	_, err := mediaDB.sql.Load().ExecContext(ctx, "DELETE FROM Media WHERE SystemDBID = ?", snes.DBID)
+	require.NoError(t, err)
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+
+	assert.Zero(t, countTableRows(t, mediaDB, "BrowseDirCounts", "SystemDBID = ?", snes.DBID),
+		"counts for a system with no media must not survive the rebuild")
+
+	// The clear runs with foreign keys off, so orphans would go unnoticed at
+	// write time. Verify the rebuilt tables are self-consistent anyway.
+	assert.Zero(t, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ParentDirDBID NOT IN (SELECT DBID FROM BrowseDirs)"),
+		"BrowseDirCounts.ParentDirDBID must reference a live BrowseDirs row")
+	assert.Zero(t, countTableRows(t, mediaDB, "BrowseDirCounts",
+		"ChildDirDBID NOT IN (SELECT DBID FROM BrowseDirs)"),
+		"BrowseDirCounts.ChildDirDBID must reference a live BrowseDirs row")
+	assert.Zero(t, countTableRows(t, mediaDB, "BrowseDirs",
+		"ParentDirDBID IS NOT NULL AND ParentDirDBID NOT IN (SELECT DBID FROM BrowseDirs)"),
+		"BrowseDirs.ParentDirDBID must reference a live BrowseDirs row")
+
+	assertForeignKeysEnforced(t, ctx, mediaDB)
+}

--- a/pkg/database/mediadb/browse_cache_refresh_cost_test.go
+++ b/pkg/database/mediadb/browse_cache_refresh_cost_test.go
@@ -1,0 +1,217 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// Diagnostic for #1279 open item B: the mid-scan browse cache refresh costs a
+// flat ~6 s per system on the MiSTer late in a reindex, regardless of whether
+// that system holds 7 files or 1,441, and 662,224 ms run-wide (12.7%).
+//
+// Three explanations have already been proposed and disproved: superlinear
+// system-count scaling, a regression in the foreign-key fix, and a full table
+// scan from ordering on the rowid (the query plan showed a covering index with
+// only a redundant sort). Rather than propose a fourth, this sweep holds the
+// refreshed system tiny and grows everything around it, then reports which
+// statement moves.
+//
+// Run with:
+//
+//	ZAPAROO_REFRESH_COST=1 go test -run TestBrowseCacheRefreshCostSweep -v ./pkg/database/mediadb/
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+// refreshCostBuffer collects zerolog JSON lines from the code under test.
+type refreshCostBuffer struct {
+	buf strings.Builder
+	mu  syncutil.Mutex
+}
+
+func (b *refreshCostBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("refresh cost buffer write: %w", err)
+	}
+	return n, nil
+}
+
+func (b *refreshCostBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// refreshTimingLine mirrors the fields on "browse cache refreshed for systems".
+type refreshTimingLine struct {
+	Message           string  `json:"message"`
+	Duration          float64 `json:"duration"`
+	VersionCheck      float64 `json:"versionCheck"`
+	ClearIncompatible float64 `json:"clearIncompatible"`
+	BeginTx           float64 `json:"beginTx"`
+	AttachLookup      float64 `json:"attachLookup"`
+	MediaScan         float64 `json:"mediaScan"`
+	DeleteCounts      float64 `json:"deleteCounts"`
+	Inserts           float64 `json:"inserts"`
+	Commit            float64 `json:"commit"`
+	Unattributed      float64 `json:"unattributed"`
+	NewDirs           int     `json:"newDirs"`
+	Counts            int     `json:"counts"`
+}
+
+func TestBrowseCacheRefreshCostSweep(t *testing.T) {
+	if os.Getenv("ZAPAROO_REFRESH_COST") == "" {
+		t.Skip("diagnostic sweep; set ZAPAROO_REFRESH_COST=1 to run")
+	}
+
+	// Each cell: how many systems are already indexed, and how much media they
+	// hold between them. The system being refreshed always holds tinySystemFiles
+	// files, so any growth in its refresh cost comes from the surroundings.
+	cells := []struct {
+		name          string
+		priorSystems  int
+		mediaPerPrior int
+	}{
+		{name: "10-systems-x-500", priorSystems: 10, mediaPerPrior: 500},
+		{name: "50-systems-x-500", priorSystems: 50, mediaPerPrior: 500},
+		{name: "100-systems-x-500", priorSystems: 100, mediaPerPrior: 500},
+		{name: "100-systems-x-2000", priorSystems: 100, mediaPerPrior: 2000},
+	}
+
+	t.Logf("%-20s %8s %9s | %7s %8s %9s %9s %9s %8s %8s %8s",
+		"cell", "media", "total", "verChk", "beginTx", "attachLk", "mediaScan", "delCounts",
+		"inserts", "commit", "unattr")
+
+	for _, cell := range cells {
+		t.Run(cell.name, func(t *testing.T) {
+			ctx := context.Background()
+			mediaDB, cleanup := setupBrowsePlanTestDB(t)
+			defer cleanup()
+
+			tinyID := seedRefreshCostDB(t, mediaDB, cell.priorSystems, cell.mediaPerPrior)
+			require.NoError(t, sqlAnalyze(ctx, mediaDB.sql.Load()))
+
+			// Refresh every prior system first, so BrowseDirs/BrowseDirCounts are
+			// populated exactly as they would be part-way through a real index.
+			for s := 1; s <= cell.priorSystems; s++ {
+				require.NoError(t, mediaDB.PopulateBrowseCacheForSystems(
+					ctx, []string{fmt.Sprintf("MiSTer:CostSys%03d", s)}))
+			}
+
+			buf := &refreshCostBuffer{}
+			prevLogger := log.Logger
+			prevLevel := zerolog.GlobalLevel()
+			zerolog.SetGlobalLevel(zerolog.InfoLevel)
+			log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+
+			err := mediaDB.PopulateBrowseCacheForSystems(ctx, []string{tinyID})
+
+			log.Logger = prevLogger
+			zerolog.SetGlobalLevel(prevLevel)
+			require.NoError(t, err)
+
+			var line refreshTimingLine
+			for _, l := range strings.Split(buf.String(), "\n") {
+				if !strings.Contains(l, `"browse cache refreshed for systems"`) {
+					continue
+				}
+				require.NoError(t, json.Unmarshal([]byte(l), &line), "line: %s", l)
+			}
+			require.NotEmpty(t, line.Message, "expected a refresh timing line")
+
+			totalMedia := cell.priorSystems*cell.mediaPerPrior + tinySystemFiles
+			t.Logf("%-20s %8d %8.1fms | %6.1f %7.1f %8.1f %8.1f %8.1f %7.1f %7.1f %7.1f",
+				cell.name, totalMedia, line.Duration,
+				line.VersionCheck, line.BeginTx, line.AttachLookup, line.MediaScan,
+				line.DeleteCounts, line.Inserts, line.Commit, line.Unattributed)
+		})
+	}
+}
+
+// tinySystemFiles matches the small systems that exposed the flat toll on the
+// device (UK101 held 7 files and still paid 6,115 ms).
+const tinySystemFiles = 7
+
+// seedRefreshCostDB creates priorSystems systems holding mediaPerPrior rows
+// each, plus one extra system holding only tinySystemFiles rows. Returns the
+// tiny system's SystemID.
+func seedRefreshCostDB(t *testing.T, mediaDB *MediaDB, priorSystems, mediaPerPrior int) string {
+	t.Helper()
+	ctx := context.Background()
+
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	sysStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO Systems (DBID, SystemID, Name) VALUES (?, ?, ?)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sysStmt.Close()) }()
+
+	titleStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, ?, ?, ?)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, titleStmt.Close()) }()
+
+	mediaStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing) "+
+			"VALUES (?, ?, ?, ?, ?, ?, 0)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, mediaStmt.Close()) }()
+
+	var dbid int64
+	seedSystem := func(s int, rows int) {
+		systemID := fmt.Sprintf("MiSTer:CostSys%03d", s)
+		_, err = sysStmt.ExecContext(ctx, int64(s), systemID, systemID)
+		require.NoError(t, err)
+		_, err = titleStmt.ExecContext(ctx, int64(s), int64(s),
+			fmt.Sprintf("cost-title-%03d", s), systemID)
+		require.NoError(t, err)
+
+		// 20 dirs per system under a shared ancestor, mirroring a real library.
+		for i := range rows {
+			dbid++
+			dir := fmt.Sprintf("/roms/shared/sys%03d/dir%02d/", s, i%20)
+			_, err = mediaStmt.ExecContext(ctx, dbid, int64(s), int64(s),
+				fmt.Sprintf("%sgame%06d.rom", dir, i), dir, fmt.Sprintf("game%06d", i))
+			require.NoError(t, err)
+		}
+	}
+
+	for s := 1; s <= priorSystems; s++ {
+		seedSystem(s, mediaPerPrior)
+	}
+	tinyIdx := priorSystems + 1
+	seedSystem(tinyIdx, tinySystemFiles)
+
+	require.NoError(t, tx.Commit())
+	return fmt.Sprintf("MiSTer:CostSys%03d", tinyIdx)
+}

--- a/pkg/database/mediadb/browse_cache_refresh_plan_test.go
+++ b/pkg/database/mediadb/browse_cache_refresh_plan_test.go
@@ -1,0 +1,201 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// The mid-scan browse cache refresh runs once per system during a full index.
+// Round 8 of #1279 measured it at 662,224 ms run-wide — 11.04 min, 12.7% of the
+// whole reindex, and 96% of that round's indexing regression.
+//
+// These tests do NOT explain that cost. They were written to test the theory
+// that the refresh query was reading the whole Media table once per system, and
+// they disproved it: the query already uses the covering partial index
+// Media(SystemDBID, Path) WHERE IsMissing = 0, and ordering on the rowid only
+// added a redundant sort over one system's rows — microseconds for the 7-file
+// systems that still paid ~6 s on the device.
+//
+// What survives is worth keeping on its own terms: the sort is pure waste, and
+// the covering index is easy to lose to an innocuous-looking ORDER BY. These
+// pin the plan. The real cause of the 12.7% is still open.
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// browseRefreshPlanSystems and browseRefreshPlanRowsPerSystem give the planner a
+// table where scanning is clearly worse than seeking: many systems, each holding
+// a small share of the rows, which is exactly the production shape (130 systems,
+// most of them tiny, sharing one 229k-row table).
+const (
+	browseRefreshPlanSystems       = 20
+	browseRefreshPlanRowsPerSystem = 500
+)
+
+// scanBrowseCacheMediaForSystemsQuery mirrors the statement built by
+// scanBrowseCacheMediaForSystems for the single-system case the mid-scan
+// refresh always uses. Kept in sync by TestBrowseCacheRefreshQuery_MatchesSource.
+const scanBrowseCacheMediaForSystemsQuery = "SELECT m.SystemDBID, m.Path FROM Media m " +
+	"WHERE m.IsMissing = 0 AND m.SystemDBID IN (?) " +
+	"ORDER BY m.SystemDBID, m.Path"
+
+// TestBrowseCacheRefreshQueryPlan_UsesCoveringIndex is the regression guard.
+//
+// Losing the covering index here is invisible in correctness terms and would
+// only show up as wall time on a device with a large library, so assert the
+// plan rather than trust it.
+func TestBrowseCacheRefreshQueryPlan_UsesCoveringIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	seedBrowseRefreshPlanDB(t, mediaDB, browseRefreshPlanSystems, browseRefreshPlanRowsPerSystem)
+	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql.Load()))
+
+	plan := browseRefreshQueryPlan(ctx, t, mediaDB, scanBrowseCacheMediaForSystemsQuery)
+	t.Logf("EXPLAIN QUERY PLAN:\n%s", plan)
+
+	assert.Contains(t, plan, "media_system_present_path_idx",
+		"the refresh must use the covering partial index Media(SystemDBID, Path) WHERE IsMissing = 0; "+
+			"without it every per-system refresh reads the entire Media table")
+
+	assert.NotContains(t, plan, "SCAN Media",
+		"the refresh must not scan Media — that would be a whole-table read once per system")
+
+	assert.NotContains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"the covering index already yields (SystemDBID, Path) order; a sort here means "+
+			"the ORDER BY no longer matches the index")
+}
+
+// TestBrowseCacheRefreshQueryPlan_OrderByRowidAddsSort records what the previous
+// ORDER BY actually cost, so the next reader does not have to re-derive it.
+//
+// ORDER BY m.DBID reads as a harmless stable ordering. It is not free: the
+// covering index carries (SystemDBID, Path) and does not yield rowid order, so
+// SQLite keeps the index and sorts the result into a temp B-tree. Small — this
+// is a per-system row set — but pure waste, since the caller only needs *a*
+// stable order and the index already provides one.
+func TestBrowseCacheRefreshQueryPlan_OrderByRowidAddsSort(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	seedBrowseRefreshPlanDB(t, mediaDB, browseRefreshPlanSystems, browseRefreshPlanRowsPerSystem)
+	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql.Load()))
+
+	rowidOrder := "SELECT m.SystemDBID, m.Path FROM Media m " +
+		"WHERE m.IsMissing = 0 AND m.SystemDBID IN (?) " +
+		"ORDER BY m.DBID"
+
+	plan := browseRefreshQueryPlan(ctx, t, mediaDB, rowidOrder)
+	t.Logf("ORDER BY m.DBID (the previous form) EXPLAIN QUERY PLAN:\n%s", plan)
+
+	assert.Contains(t, plan, "USE TEMP B-TREE FOR ORDER BY",
+		"ordering on the rowid should force a sort the covering index cannot serve; "+
+			"if this stops holding, the ORDER BY change is no longer buying anything "+
+			"and the comment on scanBrowseCacheMediaForSystems should be revisited")
+
+	assert.NotContains(t, plan, "SCAN Media",
+		"recording the disproved theory: ordering on the rowid does NOT make SQLite "+
+			"abandon the covering index for a full table scan")
+}
+
+// browseRefreshQueryPlan returns the joined EXPLAIN QUERY PLAN detail lines for
+// query, bound to a single system id the way the mid-scan refresh binds it.
+func browseRefreshQueryPlan(ctx context.Context, t *testing.T, mediaDB *MediaDB, query string) string {
+	t.Helper()
+
+	rows, err := mediaDB.sql.Load().QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, int64(1))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var planLines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		planLines = append(planLines, detail)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(planLines, "\n")
+}
+
+// seedBrowseRefreshPlanDB fills Media with rowsPerSystem rows for each of
+// systems systems, interleaved so that no system's rows are contiguous in rowid
+// order. Interleaving matters: it is what production looks like after repeated
+// partial reindexes, and it stops a rowid scan from accidentally looking cheap.
+func seedBrowseRefreshPlanDB(t *testing.T, mediaDB *MediaDB, systems, rowsPerSystem int) {
+	t.Helper()
+	ctx := context.Background()
+
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	systemStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO Systems (DBID, SystemID, Name) VALUES (?, ?, ?)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, systemStmt.Close()) }()
+
+	for s := 1; s <= systems; s++ {
+		_, err = systemStmt.ExecContext(ctx, int64(s),
+			fmt.Sprintf("MiSTer:PlanSystem%02d", s), fmt.Sprintf("Plan System %02d", s))
+		require.NoError(t, err)
+	}
+
+	titleStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, ?, ?, ?)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, titleStmt.Close()) }()
+
+	mediaStmt, err := tx.PrepareContext(ctx,
+		"INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, SortName) "+
+			"VALUES (?, ?, ?, ?, ?, ?)")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, mediaStmt.Close()) }()
+
+	var dbid int64
+	for i := 1; i <= rowsPerSystem; i++ {
+		for s := 1; s <= systems; s++ {
+			dbid++
+			parentDir := filepath.ToSlash(
+				filepath.Join(string(filepath.Separator), "roms", fmt.Sprintf("system%02d", s))) + "/"
+			name := fmt.Sprintf("Plan Game %02d-%05d", s, i)
+			path := filepath.ToSlash(filepath.Join(parentDir, fmt.Sprintf("plan-game-%02d-%05d.bin", s, i)))
+
+			_, err = titleStmt.ExecContext(ctx, dbid, int64(s),
+				fmt.Sprintf("plan-game-%02d-%05d", s, i), name)
+			require.NoError(t, err)
+			_, err = mediaStmt.ExecContext(ctx, dbid, dbid, int64(s), path, parentDir, name)
+			require.NoError(t, err)
+		}
+	}
+
+	require.NoError(t, tx.Commit())
+}

--- a/pkg/database/mediadb/browse_cache_refresh_plan_test.go
+++ b/pkg/database/mediadb/browse_cache_refresh_plan_test.go
@@ -54,12 +54,10 @@ const (
 	browseRefreshPlanRowsPerSystem = 500
 )
 
-// scanBrowseCacheMediaForSystemsQuery mirrors the statement built by
-// scanBrowseCacheMediaForSystems for the single-system case the mid-scan
-// refresh always uses. Kept in sync by TestBrowseCacheRefreshQuery_MatchesSource.
-const scanBrowseCacheMediaForSystemsQuery = "SELECT m.SystemDBID, m.Path FROM Media m " +
-	"WHERE m.IsMissing = 0 AND m.SystemDBID IN (?) " +
-	"ORDER BY m.SystemDBID, m.Path"
+// The single-system IN clause the mid-scan refresh always uses. The statement
+// itself comes from browseCacheMediaScanQuery, the same function production
+// calls, so there is no copy here that could drift from it.
+const browseRefreshPlanSingleSystemInClause = "?"
 
 // TestBrowseCacheRefreshQueryPlan_UsesCoveringIndex is the regression guard.
 //
@@ -76,7 +74,8 @@ func TestBrowseCacheRefreshQueryPlan_UsesCoveringIndex(t *testing.T) {
 	seedBrowseRefreshPlanDB(t, mediaDB, browseRefreshPlanSystems, browseRefreshPlanRowsPerSystem)
 	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql.Load()))
 
-	plan := browseRefreshQueryPlan(ctx, t, mediaDB, scanBrowseCacheMediaForSystemsQuery)
+	plan := browseRefreshQueryPlan(ctx, t, mediaDB,
+		browseCacheMediaScanQuery(browseRefreshPlanSingleSystemInClause))
 	t.Logf("EXPLAIN QUERY PLAN:\n%s", plan)
 
 	assert.Contains(t, plan, "media_system_present_path_idx",

--- a/pkg/database/mediadb/browse_overlay_plan_test.go
+++ b/pkg/database/mediadb/browse_overlay_plan_test.go
@@ -1,0 +1,142 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBrowseOverlayPlan_HigherPriorityCheckUsesParentDirRange is the regression
+// guard for the browse timeouts in #1279.
+//
+// overlayHigherPriorityDirectoryCondition runs as a correlated subquery once per
+// candidate row. Its ParentDir bounds are built by concatenation from the outer
+// row, so the planner cannot recognise them as a range when choosing an index.
+// Left to choose it took media_missing_idx, where IsMissing = 0 matches every
+// row, making each candidate scan the whole Media table. On the device database
+// that turned a 4-file directory into 64 ms and a 20,131-file directory into
+// more than ten minutes, which is why media.browse hit the API timeout.
+//
+// Asserting the plan rather than a duration: the cost only becomes visible at a
+// scale and on hardware a unit test cannot reproduce, but the wrong index shows
+// up in the plan immediately.
+func TestBrowseOverlayPlan_HigherPriorityCheckUsesParentDirRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 200)
+	seedAnalysisLimitedStats(ctx, t, mediaDB)
+
+	// Two routes, so the higher-priority condition is actually exercised: with
+	// a single route there is no higher priority to check against.
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: parentDir, IncludeDirs: true},
+		{PathPrefix: parentDir, IncludeDirs: true},
+	}}
+
+	plan := browseOverlayCountPlan(ctx, t, mediaDB, overlay)
+	t.Logf("EXPLAIN QUERY PLAN:\n%s", plan)
+
+	var descendant string
+	for line := range strings.Lines(plan) {
+		if strings.Contains(line, "descendant") {
+			descendant = strings.TrimSpace(line)
+		}
+	}
+	require.NotEmpty(t, descendant, "plan must reference the descendant scan; plan:\n%s", plan)
+
+	assert.Contains(t, descendant, "idx_media_browse_sort",
+		"the higher-priority check must resolve descendants through the ParentDir index; "+
+			"got %q", descendant)
+	assert.Contains(t, descendant, "ParentDir>",
+		"the check must run as a ParentDir range scan, not a filter over every row; got %q", descendant)
+	assert.NotContains(t, descendant, "media_missing_idx",
+		"media_missing_idx matches every present row, so using it here makes each candidate "+
+			"row scan the whole Media table (see #1279); got %q", descendant)
+}
+
+// browseOverlayCountPlan returns the joined EXPLAIN QUERY PLAN lines for the
+// overlay file-count statement, built exactly as production builds it.
+func browseOverlayCountPlan(
+	ctx context.Context, t *testing.T, mediaDB *MediaDB, overlay *database.BrowseOverlay,
+) string {
+	t.Helper()
+
+	query, args := browseOverlayFileCountQuery(database.BrowseFileCountOptions{Overlay: overlay})
+	rows, err := mediaDB.sql.Load().QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var lines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		lines = append(lines, detail)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(lines, "\n")
+}
+
+// seedAnalysisLimitedStats installs the sqlite_stat1 rows a real device carries,
+// copied from the #1279 test MiSTer.
+//
+// The shape that matters is media_missing_idx: "215287 2001" claims about 2,001
+// rows per IsMissing value when every one of the 215,287 rows shares the same
+// value. 2001 is SQLITE_DEFAULT_OPTIMIZE_LIMIT + 1 — PRAGMA optimize runs with
+// an analysis limit (analyzeApproximateMask sets bit 0x10), stops after 2,000
+// index entries and extrapolates, and for a single-valued index that estimate is
+// two orders of magnitude too selective. That wrong stat, not the data, is what
+// makes the planner choose media_missing_idx here.
+//
+// Analysing the fixture instead would produce honest stats for 200 rows, the
+// planner would pick correctly on its own, and this test would pass with or
+// without the fix.
+func seedAnalysisLimitedStats(ctx context.Context, t *testing.T, mediaDB *MediaDB) {
+	t.Helper()
+	sqlDB := mediaDB.sql.Load()
+	_, err := sqlDB.ExecContext(ctx, "ANALYZE")
+	require.NoError(t, err)
+	for _, row := range []struct{ idx, stat string }{
+		{"idx_media_browse_sort", "215287 14 14 2 1"},
+		{"idx_media_parentdir", "215287 14"},
+		{"idx_media_parentdir_system", "215287 14 10"},
+		{"media_missing_idx", "215287 2001"},
+		{"media_path_idx", "215287 2"},
+		{"media_system_present_path_idx", "215287 501 1"},
+		{"sqlite_autoindex_Media_1", "215287 501 1"},
+	} {
+		_, err = sqlDB.ExecContext(ctx,
+			"INSERT OR REPLACE INTO sqlite_stat1(tbl, idx, stat) VALUES ('Media', ?, ?)", row.idx, row.stat)
+		require.NoError(t, err, "seeding stat for %s", row.idx)
+	}
+	// The planner caches sqlite_stat1 per connection; force a reload.
+	_, err = sqlDB.ExecContext(ctx, "ANALYZE sqlite_master")
+	require.NoError(t, err)
+}

--- a/pkg/database/mediadb/browse_timing_log_test.go
+++ b/pkg/database/mediadb/browse_timing_log_test.go
@@ -112,11 +112,20 @@ func TestLogBrowseTiming_ReportsRealPoolContention(t *testing.T) {
 
 	// Contended: hold the only connection, start the browse, release after a
 	// known delay. The browse cannot begin work until the hold ends.
+	waitedBefore := sqlDB.Stats().WaitCount
 	hog, err := sqlDB.Conn(context.Background())
 	require.NoError(t, err)
 
 	done := make(chan map[string]any, 1)
 	go func() { done <- browse() }()
+
+	// Start the clock only once the browse is genuinely queued for the
+	// connection. Sleeping straight away instead assumed the goroutine reaches
+	// sqlDB.Conn within holdFor; on a loaded machine it need not, and the
+	// browse then never blocks and reports a connWait near zero.
+	require.Eventually(t, func() bool {
+		return sqlDB.Stats().WaitCount > waitedBefore
+	}, 10*time.Second, time.Millisecond, "browse never queued for the only connection")
 
 	time.Sleep(holdFor)
 	require.NoError(t, hog.Close())

--- a/pkg/database/mediadb/browse_timing_log_test.go
+++ b/pkg/database/mediadb/browse_timing_log_test.go
@@ -1,0 +1,115 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// browseTimingLine returns the single "browse call timing" record in captured
+// zerolog output, or reports that none was emitted.
+func browseTimingLine(t *testing.T, out string) (fields map[string]any, found bool) {
+	t.Helper()
+	for line := range strings.Lines(out) {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["message"] == "browse call timing" {
+			require.False(t, found, "expected at most one timing line, got more")
+			fields, found = rec, true
+		}
+	}
+	return fields, found
+}
+
+func captureBrowseTiming(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	prevLogger := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = prevLogger
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+	fn()
+	return buf.String()
+}
+
+// TestLogBrowseTiming_SplitsWaitFromWork is the guard for the attribution this
+// line exists to provide. A browse that is slow because it queued for a pooled
+// connection and one that is slow because its SQL is expensive look identical
+// in the logs otherwise, which is exactly the ambiguity that made a live
+// media.browse timeout un-diagnosable.
+func TestLogBrowseTiming_SplitsWaitFromWork(t *testing.T) {
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	t.Cleanup(cleanup)
+
+	out := captureBrowseTiming(t, func() {
+		// Backdate the start so the call is over the reporting threshold
+		// without the test having to sleep for it.
+		started := time.Now().Add(-2 * browseTimingLogThreshold)
+		mediaDB.logBrowseTiming("browse files", 21, started, samplePoolWait(mediaDB.sql.Load()))
+	})
+
+	fields, found := browseTimingLine(t, out)
+	require.True(t, found, "a call over the threshold must be reported; output:\n%s", out)
+
+	for _, key := range []string{"op", "elapsed", "poolConnWait", "poolConnWaitCount", "nonWait", "routes"} {
+		assert.Contains(t, fields, key, "timing line must carry %q", key)
+	}
+	assert.Equal(t, "browse files", fields["op"])
+	assert.InDelta(t, 21.0, fields["routes"], 0.001, "route count is the suspected cost multiplier")
+
+	numeric := func(key string) float64 {
+		v, ok := fields[key].(float64)
+		require.True(t, ok, "%q must be numeric, got %T", key, fields[key])
+		return v
+	}
+	assert.InDelta(t, numeric("elapsed"), numeric("nonWait")+numeric("poolConnWait"), 0.001,
+		"wait and work must account for the whole elapsed time, or the split means nothing")
+}
+
+// TestLogBrowseTiming_QuietBelowThreshold keeps the line off the hot path: a
+// browse served from cache runs many times per second and must not log.
+func TestLogBrowseTiming_QuietBelowThreshold(t *testing.T) {
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	t.Cleanup(cleanup)
+
+	out := captureBrowseTiming(t, func() {
+		mediaDB.logBrowseTiming("browse files", 2, time.Now(), samplePoolWait(mediaDB.sql.Load()))
+	})
+
+	_, found := browseTimingLine(t, out)
+	assert.False(t, found, "a fast browse must not log; output:\n%s", out)
+}

--- a/pkg/database/mediadb/browse_timing_log_test.go
+++ b/pkg/database/mediadb/browse_timing_log_test.go
@@ -20,11 +20,13 @@
 package mediadb
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -66,48 +68,129 @@ func captureBrowseTiming(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// TestLogBrowseTiming_SplitsWaitFromWork is the guard for the attribution this
-// line exists to provide. A browse that is slow because it queued for a pooled
-// connection and one that is slow because its SQL is expensive look identical
-// in the logs otherwise, which is exactly the ambiguity that made a live
-// media.browse timeout un-diagnosable.
-func TestLogBrowseTiming_SplitsWaitFromWork(t *testing.T) {
+// browseTimingNumeric reads a numeric field off a captured timing line.
+func browseTimingNumeric(t *testing.T, fields map[string]any, key string) float64 {
+	t.Helper()
+	v, ok := fields[key].(float64)
+	require.True(t, ok, "%q must be numeric, got %T", key, fields[key])
+	return v
+}
+
+// TestLogBrowseTiming_ReportsRealPoolContention drives a real BrowseFiles call
+// through the instrumented entry point with the pool deliberately saturated,
+// and asserts the reported wait actually reflects it.
+//
+// This is the assertion the line exists for. A browse blocked waiting for a
+// pooled connection and a browse executing expensive SQL are indistinguishable
+// in the logs without it, which is what made a live media.browse timeout
+// un-diagnosable. Asserting only that elapsed == nonWait + poolConnWait would
+// pass trivially when poolConnWait is zero, so the contended and uncontended
+// cases are compared against each other instead.
+func TestLogBrowseTiming_ReportsRealPoolContention(t *testing.T) {
 	mediaDB, cleanup := setupBrowsePlanTestDB(t)
 	t.Cleanup(cleanup)
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 50)
+
+	sqlDB := mediaDB.sql.Load()
+	// One connection, so a second caller must block until the first releases.
+	sqlDB.SetMaxOpenConns(1)
+
+	const holdFor = 400 * time.Millisecond
+	browse := func() map[string]any {
+		var fields map[string]any
+		out := captureBrowseTiming(t, func() {
+			_, err := mediaDB.BrowseFiles(context.Background(),
+				&database.BrowseFilesOptions{PathPrefix: parentDir, Limit: 10})
+			require.NoError(t, err)
+		})
+		f, found := browseTimingLine(t, out)
+		if found {
+			fields = f
+		}
+		return fields
+	}
+
+	// Contended: hold the only connection, start the browse, release after a
+	// known delay. The browse cannot begin work until the hold ends.
+	hog, err := sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+
+	done := make(chan map[string]any, 1)
+	go func() { done <- browse() }()
+
+	time.Sleep(holdFor)
+	require.NoError(t, hog.Close())
+
+	contended := <-done
+	require.NotNil(t, contended, "a browse blocked for %v must be over the reporting threshold", holdFor)
+
+	waitMS := browseTimingNumeric(t, contended, "connWait")
+	elapsedMS := browseTimingNumeric(t, contended, "elapsed")
+	workMS := browseTimingNumeric(t, contended, "work")
+
+	assert.Greater(t, waitMS, float64(holdFor.Milliseconds())*0.5,
+		"connWait must reflect the ~%v spent queued for the only connection; "+
+			"got %.1f ms, so the instrumentation is not measuring contention at all", holdFor, waitMS)
+	assert.Less(t, workMS, waitMS,
+		"a browse that spent most of its time queued must attribute more to wait than to work")
+	assert.InDelta(t, elapsedMS, workMS+waitMS, 1.0,
+		"wait and work must account for the whole elapsed time")
+
+	// Uncontended: the same query with the pool free must not report a
+	// comparable wait, or the field would be meaningless as a signal.
+	if uncontended := browse(); uncontended != nil {
+		assert.Less(t, browseTimingNumeric(t, uncontended, "connWait"), waitMS*0.5,
+			"an uncontended browse must not report a wait like the contended one")
+	}
+}
+
+// TestLogBrowseTiming_CarriesRouteCount pins the route count on the line. Route
+// count is the suspected cost multiplier for the overlay query, and having it
+// beside the wait is what allows the two to be compared without matching
+// timestamps across separate log entries.
+func TestLogBrowseTiming_CarriesRouteCount(t *testing.T) {
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	t.Cleanup(cleanup)
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 50)
+
+	// Two overlay sources, so the line must report routes=2.
+	overlay := &database.BrowseOverlay{Sources: []database.BrowseSource{
+		{PathPrefix: parentDir, IncludeDirs: true},
+		{PathPrefix: parentDir, IncludeDirs: false},
+	}}
+
+	// A 50-row browse finishes well under the production threshold on a
+	// desktop, so lower it rather than contriving a slow query.
+	origThreshold := browseTimingLogThreshold
+	browseTimingLogThreshold = 0
+	t.Cleanup(func() { browseTimingLogThreshold = origThreshold })
 
 	out := captureBrowseTiming(t, func() {
-		// Backdate the start so the call is over the reporting threshold
-		// without the test having to sleep for it.
-		started := time.Now().Add(-2 * browseTimingLogThreshold)
-		mediaDB.logBrowseTiming("browse files", 21, started, samplePoolWait(mediaDB.sql.Load()))
+		_, err := mediaDB.BrowseFiles(context.Background(),
+			&database.BrowseFilesOptions{PathPrefix: parentDir, Overlay: overlay, Limit: 50})
+		require.NoError(t, err)
 	})
-
 	fields, found := browseTimingLine(t, out)
-	require.True(t, found, "a call over the threshold must be reported; output:\n%s", out)
+	require.True(t, found, "with the threshold at zero every browse must log; output:\n%s", out)
 
-	for _, key := range []string{"op", "elapsed", "poolConnWait", "poolConnWaitCount", "nonWait", "routes"} {
+	for _, key := range []string{"op", "elapsed", "connWait", "work", "routes"} {
 		assert.Contains(t, fields, key, "timing line must carry %q", key)
 	}
 	assert.Equal(t, "browse files", fields["op"])
-	assert.InDelta(t, 21.0, fields["routes"], 0.001, "route count is the suspected cost multiplier")
-
-	numeric := func(key string) float64 {
-		v, ok := fields[key].(float64)
-		require.True(t, ok, "%q must be numeric, got %T", key, fields[key])
-		return v
-	}
-	assert.InDelta(t, numeric("elapsed"), numeric("nonWait")+numeric("poolConnWait"), 0.001,
-		"wait and work must account for the whole elapsed time, or the split means nothing")
+	assert.InDelta(t, 2.0, browseTimingNumeric(t, fields, "routes"), 0.001)
 }
 
 // TestLogBrowseTiming_QuietBelowThreshold keeps the line off the hot path: a
-// browse served from cache runs many times per second and must not log.
+// browse served quickly runs many times per second and must not log.
 func TestLogBrowseTiming_QuietBelowThreshold(t *testing.T) {
 	mediaDB, cleanup := setupBrowsePlanTestDB(t)
 	t.Cleanup(cleanup)
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 5)
 
 	out := captureBrowseTiming(t, func() {
-		mediaDB.logBrowseTiming("browse files", 2, time.Now(), samplePoolWait(mediaDB.sql.Load()))
+		_, err := mediaDB.BrowseFiles(context.Background(),
+			&database.BrowseFilesOptions{PathPrefix: parentDir, Limit: 5})
+		require.NoError(t, err)
 	})
 
 	_, found := browseTimingLine(t, out)

--- a/pkg/database/mediadb/cache_self_healing_test.go
+++ b/pkg/database/mediadb/cache_self_healing_test.go
@@ -497,3 +497,25 @@ func TestPopulateSystemTagsCacheForSystems_EmptyList(t *testing.T) {
 	err := mediaDB.PopulateSystemTagsCacheForSystems(ctx, []systemdefs.System{})
 	require.NoError(t, err, "should succeed as no-op for empty systems list")
 }
+
+// TestPopulateSystemTagsCache_FailsFastDuringActiveTransaction covers the
+// #1279 bug fix: this used to BeginTx unconditionally, and with the DSN's
+// _txlock=immediate that grabs SQLite's single WAL writer lock at BEGIN,
+// blocking for the full busy_timeout (and pinning a stale reader mark the
+// whole time) against an in-progress indexing transaction. It must now fail
+// immediately instead, matching applyMediaTagMutations's guard.
+func TestPopulateSystemTagsCache_FailsFastDuringActiveTransaction(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	defer func() { _ = mediaDB.RollbackTransaction() }()
+
+	err := mediaDB.PopulateSystemTagsCache(ctx)
+	require.ErrorIs(t, err, ErrTransactionActive)
+
+	err = mediaDB.PopulateSystemTagsCacheForSystems(ctx, []systemdefs.System{{ID: "NES"}})
+	require.ErrorIs(t, err, ErrTransactionActive)
+}

--- a/pkg/database/mediadb/commit_test.go
+++ b/pkg/database/mediadb/commit_test.go
@@ -20,42 +20,34 @@
 package mediadb
 
 import (
-	"database/sql"
-	"errors"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/stretchr/testify/assert"
 )
 
+// TestShouldCheckpointAfterCommit covers the three modes the function actually
+// branches on. Indexing status and its lookup error used to select the auto
+// behaviour; checkpointLargeWAL's size-driven checkpoint replaced that, so auto
+// no longer takes them and only Force asks for a checkpoint of its own.
 func TestShouldCheckpointAfterCommit(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		err    error
-		name   string
-		status string
-		mode   database.WALCheckpointMode
-		want   bool
+		name string
+		mode database.WALCheckpointMode
+		want bool
 	}{
-		{name: "auto running", mode: database.WALCheckpointAuto, status: IndexingStatusRunning, want: false},
-		{name: "auto pending", mode: database.WALCheckpointAuto, status: IndexingStatusPending, want: false},
-		{name: "auto completed", mode: database.WALCheckpointAuto, status: IndexingStatusCompleted, want: false},
-		{name: "auto failed", mode: database.WALCheckpointAuto, status: IndexingStatusFailed, want: false},
-		{
-			name: "auto status error", mode: database.WALCheckpointAuto,
-			status: "", err: errors.New("status failed"), want: false,
-		},
-		{name: "auto no rows", mode: database.WALCheckpointAuto, status: "", err: sql.ErrNoRows, want: false},
-		{name: "skip running", mode: database.WALCheckpointSkip, status: IndexingStatusRunning, want: false},
-		{name: "force completed", mode: database.WALCheckpointForce, status: IndexingStatusCompleted, want: true},
+		{name: "auto defers to checkpointLargeWAL", mode: database.WALCheckpointAuto, want: false},
+		{name: "skip never checkpoints", mode: database.WALCheckpointSkip, want: false},
+		{name: "force always checkpoints", mode: database.WALCheckpointForce, want: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.want, shouldCheckpointAfterCommit(tt.mode, tt.status, tt.err))
+			assert.Equal(t, tt.want, shouldCheckpointAfterCommit(tt.mode))
 		})
 	}
 }

--- a/pkg/database/mediadb/concurrent_operations_test.go
+++ b/pkg/database/mediadb/concurrent_operations_test.go
@@ -66,6 +66,12 @@ func TestConcurrentOptimizationPrevention(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	// sqlmock serves exactly one connection. Left unbounded, database/sql
+	// reacts to concurrent callers by trying to open a second one, which
+	// sqlmock refuses with "expected a connection to be available" — an
+	// intermittent failure that has nothing to do with what this test covers.
+	// Pinning the pool makes the callers queue on the one connection instead.
+	db.SetMaxOpenConns(1)
 
 	ctx := context.Background()
 	fakeClock := clockwork.NewRealClock()
@@ -210,6 +216,12 @@ func TestConcurrentStatusUpdates(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	// sqlmock serves exactly one connection. Left unbounded, database/sql
+	// reacts to concurrent callers by trying to open a second one, which
+	// sqlmock refuses with "expected a connection to be available" — an
+	// intermittent failure that has nothing to do with what this test covers.
+	// Pinning the pool makes the callers queue on the one connection instead.
+	db.SetMaxOpenConns(1)
 
 	ctx := context.Background()
 	mediaDB := &MediaDB{
@@ -287,6 +299,12 @@ func TestAtomicOptimizationFlag(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	// sqlmock serves exactly one connection. Left unbounded, database/sql
+	// reacts to concurrent callers by trying to open a second one, which
+	// sqlmock refuses with "expected a connection to be available" — an
+	// intermittent failure that has nothing to do with what this test covers.
+	// Pinning the pool makes the callers queue on the one connection instead.
+	db.SetMaxOpenConns(1)
 
 	ctx := context.Background()
 	mediaDB := &MediaDB{
@@ -398,6 +416,12 @@ func TestConcurrentIndexingAndOptimizationStatusChecks(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	// sqlmock serves exactly one connection. Left unbounded, database/sql
+	// reacts to concurrent callers by trying to open a second one, which
+	// sqlmock refuses with "expected a connection to be available" — an
+	// intermittent failure that has nothing to do with what this test covers.
+	// Pinning the pool makes the callers queue on the one connection instead.
+	db.SetMaxOpenConns(1)
 
 	ctx := context.Background()
 	mediaDB := &MediaDB{
@@ -448,6 +472,12 @@ func TestRaceConditionBetweenStatusAndOptimization(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
+	// sqlmock serves exactly one connection. Left unbounded, database/sql
+	// reacts to concurrent callers by trying to open a second one, which
+	// sqlmock refuses with "expected a connection to be available" — an
+	// intermittent failure that has nothing to do with what this test covers.
+	// Pinning the pool makes the callers queue on the one connection instead.
+	db.SetMaxOpenConns(1)
 
 	ctx := context.Background()
 	mediaDB := &MediaDB{

--- a/pkg/database/mediadb/corruption_recovery_test.go
+++ b/pkg/database/mediadb/corruption_recovery_test.go
@@ -171,13 +171,23 @@ func TestMediaDB_Recreate_KeepBackup(t *testing.T) {
 	mediaDB.MarkCorrupt("test")
 	path := mediaDB.GetDBPath()
 
+	// Write deterministic sidecars so the WAL/SHM preservation assertions below
+	// don't depend on incidental SQLite checkpoint timing at Close().
+	require.NoError(t, os.WriteFile(path+"-wal", []byte("wal contents"), 0o600))
+	require.NoError(t, os.WriteFile(path+"-shm", []byte("shm contents"), 0o600))
+
 	require.NoError(t, mediaDB.Recreate(true))
 
-	// Forensic backup kept, marker cleared. (The reopened WAL database creates fresh
-	// -wal/-shm sidecars; the point is the stale corrupt ones don't survive into it,
-	// which the empty+queryable check below confirms.)
+	// Forensic backup kept for the database and both sidecars, marker cleared.
+	// (The reopened WAL database creates fresh -wal/-shm sidecars; the point is
+	// the stale corrupt ones don't survive into it, which the empty+queryable
+	// check below confirms.)
 	_, backupErr := os.Stat(path + database.CorruptMarkerSuffix + ".bak")
-	require.NoError(t, backupErr, "backup copy should be kept when keepBackup=true")
+	require.NoError(t, backupErr, "database backup copy should be kept when keepBackup=true")
+	_, walBackupErr := os.Stat(path + "-wal" + database.CorruptMarkerSuffix + ".bak")
+	require.NoError(t, walBackupErr, "WAL backup copy should be kept when keepBackup=true")
+	_, shmBackupErr := os.Stat(path + "-shm" + database.CorruptMarkerSuffix + ".bak")
+	require.NoError(t, shmBackupErr, "SHM backup copy should be kept when keepBackup=true")
 	assert.False(t, mediaDB.IsMarkedCorrupt(), "marker should be cleared after recreate")
 
 	// Fresh schema: queryable and empty, with durable intent to rebuild it.

--- a/pkg/database/mediadb/indexing_cache_boost_test.go
+++ b/pkg/database/mediadb/indexing_cache_boost_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -198,6 +199,39 @@ func TestWALAutoCheckpointAppliesToPoolAndWriter(t *testing.T) {
 
 	mediaDB.SetWALAutoCheckpoint(defaultWALAutoCheckpoint)
 	assertPooledValues(defaultWALAutoCheckpoint)
+}
+
+// TestWALAutoCheckpointZeroDisablesRatherThanFallingBackToDefault covers the
+// bug fixed alongside #1279's indexing-checkpoint changes: pages=0 (disable
+// automatic checkpointing entirely, what indexing now requests) must persist
+// as 0, not be treated as "never configured" and silently fall back to
+// SQLite's default of 1000 — which is exactly what walAutoCheckpointPages did
+// before walAutoCheckpointSet was added, since it used pages<=0 to mean unset.
+func TestWALAutoCheckpointZeroDisablesRatherThanFallingBackToDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB := openIndexingCacheTestDB(ctx, t)
+	sqlDB := mediaDB.sql.Load()
+	sqlDB.SetMaxOpenConns(2)
+
+	// Before any explicit call, a fresh MediaDB reports SQLite's own default.
+	assert.Equal(t, defaultWALAutoCheckpoint, mediaDB.walAutoCheckpointPages())
+
+	mediaDB.SetWALAutoCheckpoint(0)
+	assert.Equal(t, 0, mediaDB.walAutoCheckpointPages(), "explicit 0 must not fall back to the default")
+
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	var pooledValue int
+	require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA wal_autocheckpoint").Scan(&pooledValue))
+	assert.Equal(t, 0, pooledValue)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	var writerValue int
+	require.NoError(t, mediaDB.tx.QueryRowContext(ctx, "PRAGMA wal_autocheckpoint").Scan(&writerValue))
+	assert.Equal(t, 0, writerValue, "a writer connection opened after disabling must also see 0, not the default")
+	require.NoError(t, mediaDB.RollbackTransaction())
 }
 
 func TestIndexingPragmaRestoreWithUnlimitedPool(t *testing.T) {
@@ -398,4 +432,169 @@ func TestCloseRollsBackAndReleasesWriterConnection(t *testing.T) {
 	assert.Nil(t, mediaDB.tx)
 	assert.Nil(t, mediaDB.txConn)
 	assert.False(t, mediaDB.inTransaction)
+}
+
+// TestOptimizationBoostAppliesWhileAnotherCallerHoldsAConnection reproduces the
+// round 8 failure of #1279.
+//
+// Post-index optimization begins seconds after indexing ends, while the app is
+// still polling. At baseMaxOpenConns (2) that leaves one free slot, and
+// drainPooledConns wants every slot, so the drain timed out and the entire
+// optimization ran at the 8MB default — visible only as dbCacheSize on the step
+// metrics long afterwards.
+//
+// ensureIndexingCacheBoostApplied is what makes this survivable: it reads the
+// pragma back through the pool — the same way the optimization steps get their
+// connection — and retries when the drain did not reach it.
+func TestOptimizationBoostAppliesWhileAnotherCallerHoldsAConnection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB := openIndexingCacheTestDB(ctx, t)
+	sqlDB := mediaDB.sql.Load()
+
+	// Stand in for the app's polling: hold a connection across the boost, then
+	// release it the way a short query would, so the retry has something to work
+	// with. Holding it forever would test a situation that does not occur.
+	held, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	releaseOnce := sync.OnceFunc(func() { _ = held.Close() })
+	defer releaseOnce()
+	go func() {
+		time.Sleep(connectionAcquireTimeout / 2)
+		releaseOnce()
+	}()
+
+	// The order RunBackgroundOptimizationWithLease uses: cap first, so the drain
+	// covers the slot the boost adds rather than leaving it to be opened later
+	// from the DSN at the default cache size.
+	mediaDB.SetIndexingConnBoost(true)
+	mediaDB.SetIndexingCacheSize(true)
+	mediaDB.ensureIndexingCacheBoostApplied()
+	t.Cleanup(func() {
+		mediaDB.SetIndexingConnBoost(false)
+		mediaDB.SetIndexingCacheSize(false)
+	})
+
+	// Read the pragma back the way the optimization steps do — through the pool,
+	// on whichever connection it hands out.
+	cacheSize, tempStore := readPragmas(ctx, t, sqlDB)
+	assert.Equal(t, -32768, cacheSize,
+		"optimization must run at the boosted cache size even when another caller "+
+			"held a pooled connection; round 8 silently ran the whole phase at -8192")
+	assert.Equal(t, tempStoreMemory, tempStore,
+		"temp_store must reach the pooled connection alongside cache_size")
+}
+
+// TestOptimizationBoostVerificationDetectsMissingPragma covers the check itself:
+// it must notice an unboosted pool rather than trusting that the drain worked.
+func TestOptimizationBoostVerificationDetectsMissingPragma(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB := openIndexingCacheTestDB(ctx, t)
+	sqlDB := mediaDB.sql.Load()
+
+	// Boost state is on, but no pragma has been pushed to any connection.
+	mediaDB.indexingCacheBoost.Store(true)
+	t.Cleanup(func() { mediaDB.SetIndexingCacheSize(false) })
+
+	wantCacheSize, _ := mediaDB.connPragmaValues()
+	require.Equal(t, "-32768", wantCacheSize)
+	assert.False(t, mediaDB.pooledCacheSizeMatches(sqlDB, wantCacheSize),
+		"verification must report a pool that never received the pragma; "+
+			"silently returning true here is what made the round 8 failure invisible")
+
+	// And the repair path must fix exactly that.
+	mediaDB.ensureIndexingCacheBoostApplied()
+	cacheSize, _ := readPragmas(ctx, t, sqlDB)
+	assert.Equal(t, -32768, cacheSize, "the retry must apply the pragma it found missing")
+}
+
+// TestConnectionOpenedAfterBoostCarriesBoostedPragmas covers the second, silent
+// half of the same bug: the pragmas reaching every connection that exists is not
+// enough if the boost then permits another one to be opened.
+//
+// Applying the cache size before raising the connection cap sized the drain
+// against the narrow cap, so the extra slot was later filled straight from the
+// DSN at -8192 with nothing left to configure it. That connection then served
+// optimization steps and their dbCacheSize metric, which is what the device logs
+// reported for three rounds while the drain itself had succeeded.
+func TestConnectionOpenedAfterBoostCarriesBoostedPragmas(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB := openIndexingCacheTestDB(ctx, t)
+	sqlDB := mediaDB.sql.Load()
+
+	// The order RunBackgroundOptimizationWithLease uses.
+	mediaDB.SetIndexingConnBoost(true)
+	mediaDB.SetIndexingCacheSize(true)
+	t.Cleanup(func() {
+		mediaDB.SetIndexingConnBoost(false)
+		mediaDB.SetIndexingCacheSize(false)
+	})
+
+	// Hold every slot at once so each one has to be a distinct physical
+	// connection, including any the boost newly permitted.
+	held := make([]*sql.Conn, 0, indexingMaxOpenConns)
+	for range indexingMaxOpenConns {
+		conn, err := sqlDB.Conn(ctx)
+		require.NoError(t, err)
+		held = append(held, conn)
+	}
+	t.Cleanup(func() {
+		for _, conn := range held {
+			_ = conn.Close()
+		}
+	})
+
+	for i, conn := range held {
+		var cacheSize int
+		require.NoError(t, conn.QueryRowContext(ctx, "PRAGMA cache_size").Scan(&cacheSize))
+		assert.Equal(t, -32768, cacheSize,
+			"pooled connection %d must carry the boosted cache size; a connection opened "+
+				"after the boost is born from the DSN at -8192 unless the cap was raised "+
+				"before the pragmas were applied (see #1279)", i)
+	}
+}
+
+// TestPooledCacheSizeMatchesRejectsPartiallyBoostedPool pins the verification
+// contract: a partially-boosted pool must not verify as applied.
+//
+// The previous implementation was a single pool query, which returns an
+// arbitrary connection. On the mixed pool below it answered correctly or
+// incorrectly depending on which connection the pool happened to hand out — a
+// coin flip, not a check. That nondeterminism is the bug: round 9 logged the
+// boost as applied and every optimization step then reported -8192. Draining
+// the pool makes the answer deterministic, which is what this pins.
+func TestPooledCacheSizeMatchesRejectsPartiallyBoostedPool(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mediaDB := openIndexingCacheTestDB(ctx, t)
+	sqlDB := mediaDB.sql.Load()
+
+	// Boost the flag but deliberately configure only ONE connection, leaving the
+	// rest of the pool at the DSN default.
+	mediaDB.indexingCacheBoost.Store(true)
+	t.Cleanup(func() { mediaDB.indexingCacheBoost.Store(false) })
+
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "PRAGMA cache_size = -32768")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	// Force a second physical connection to exist so the pool is genuinely mixed.
+	first, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	second, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	require.NoError(t, second.Close())
+
+	// Repeat: a single-sample check would only be caught on the runs where it
+	// happened to pick the unboosted connection.
+	for range 8 {
+		assert.False(t, mediaDB.pooledCacheSizeMatches(sqlDB, "-32768"),
+			"a pool where only some connections are boosted must NOT verify as applied; "+
+				"a check that answers by luck is worse than no check")
+	}
 }

--- a/pkg/database/mediadb/media_search.go
+++ b/pkg/database/mediadb/media_search.go
@@ -252,3 +252,60 @@ func (db *MediaDB) searchMediaTypeGroupsWithSQL(
 	}
 	return results, nil
 }
+
+// searchSplitAcrossCacheAndSQL answers a search that spans systems the slug
+// cache covers and systems currently being re-indexed.
+//
+// The cached side is re-entered through the normal search path with a narrowed
+// system list, so it takes the in-memory route it would have taken anyway. The
+// SQL side runs only for the in-flight systems, which is the difference between
+// a grouped LIKE across the whole library and one across a system or two.
+// Results are merged with the same ordering, dedup and limit the grouped SQL
+// path applies, so the caller cannot tell which rows came from where.
+func (db *MediaDB) searchSplitAcrossCacheAndSQL(
+	ctx context.Context,
+	cachedSystems, sqlSystems []string,
+	rawWords []string,
+	filters *database.SearchFilters,
+) ([]database.SearchResultWithCursor, error) {
+	cachedFilters := *filters
+	cachedFilters.Systems = systemsByIDs(cachedSystems)
+	results, err := db.SearchMediaWithFilters(ctx, &cachedFilters)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sqlSystems) > 0 {
+		sqlFilters := *filters
+		sqlFilters.Systems = systemsByIDs(sqlSystems)
+		groups := buildMediaSearchTypeGroups(sqlFilters.Systems, rawWords)
+		inFlight, sqlErr := db.searchMediaTypeGroupsWithSQL(ctx, groups, rawWords, &sqlFilters)
+		if sqlErr != nil {
+			return nil, sqlErr
+		}
+		results = append(results, inFlight...)
+	}
+
+	slices.SortFunc(results, func(a, b database.SearchResultWithCursor) int {
+		return compareSearchResults(&a, &b, filters.Sort)
+	})
+	results = slices.CompactFunc(results, func(a, b database.SearchResultWithCursor) bool {
+		return a.MediaID == b.MediaID
+	})
+	if len(results) > filters.Limit {
+		results = results[:filters.Limit]
+	}
+	return results, nil
+}
+
+// systemsByIDs resolves system IDs to definitions, dropping any the build does
+// not know about.
+func systemsByIDs(ids []string) []systemdefs.System {
+	out := make([]systemdefs.System, 0, len(ids))
+	for _, id := range ids {
+		if sys, err := systemdefs.GetSystem(id); err == nil {
+			out = append(out, *sys)
+		}
+	}
+	return out
+}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -126,7 +126,6 @@ const (
 	defaultConnTempStore     = "FILE"
 	defaultWALAutoCheckpoint = 1000
 	connectionAcquireTimeout = 5 * time.Second
-	mediaPageSize            = 4096 // SQLite's compiled-in default
 )
 
 // getSqliteConnParams constructs the SQLite connection string. MediaDB uses
@@ -514,7 +513,7 @@ func (db *MediaDB) Open() error {
 			log.Warn().Err(err).Msg("failed to enable media database cell size checks; continuing without")
 		}
 	}
-	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "media", database.SynchronousNormal, mediaPageSize)
+	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "media", database.SynchronousNormal, database.UnsetPageSize)
 
 	clearUtilityTagCache()
 	clearCoverAvailabilityCache()

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -97,11 +98,22 @@ const (
 // checkpoints (TRUNCATE) once the WAL has grown past this size, so a long
 // multi-system index cannot accumulate an unbounded WAL — and the page-cache /
 // shmem pressure that rides on it — before the post-index optimization checkpoint.
-// Kept modest so it fires well before the WAL can dominate RAM on a small-memory,
-// no-swap device, while staying large enough that the common run of tiny batches
-// never pays the SD/exFAT checkpoint cost. A var (not const) only so tests can
-// lower it; production never mutates it.
-var mediaWALCheckpointThreshold int64 = 96 * 1024 * 1024
+// With automatic checkpointing disabled during indexing (SetWALAutoCheckpoint(0),
+// see configureIndexingPragmas), this is now the only thing bounding WAL size, so
+// it must actually be reachable within a handful of systems rather than sit at a
+// size a real index rarely approaches.
+//
+// 8 MiB is measured, not provisional. On the #1279 MiSTer test device (229,553
+// media across 130 systems on SD) it fires on the larger systems and not on the
+// small ones, which is the intended shape: a system reaching ~10-13 MiB of WAL
+// pays a 3.2-14.1 s TRUNCATE, while the long tail of small systems never
+// reaches the threshold and pays nothing. Raising it would concentrate that
+// cost into rarer, longer stalls and hold more dirty WAL against page cache on
+// a 1 GB device; lowering it would make small-system commits start paying the
+// SD/exFAT checkpoint cost they currently avoid.
+//
+// A var (not const) only so tests can change it; production never mutates it.
+var mediaWALCheckpointThreshold int64 = 8 * 1024 * 1024
 
 // Connection pool sizing. Two connections (one writer, one reader) is the
 // steady-state balance for low-memory devices, but while indexing runs the
@@ -114,6 +126,7 @@ const (
 	defaultConnTempStore     = "FILE"
 	defaultWALAutoCheckpoint = 1000
 	connectionAcquireTimeout = 5 * time.Second
+	mediaPageSize            = 4096 // SQLite's compiled-in default
 )
 
 // getSqliteConnParams constructs the SQLite connection string. MediaDB uses
@@ -131,7 +144,7 @@ const (
 func getSqliteConnParams() string {
 	return "?_journal_mode=WAL&_synchronous=NORMAL&_busy_timeout=5000" +
 		"&_cache_size=" + defaultConnCacheSize + "&_temp_store=" + defaultConnTempStore + "&_mmap_size=0" +
-		"&_page_size=8192&_foreign_keys=ON&_txlock=immediate"
+		"&_foreign_keys=ON&_txlock=immediate"
 }
 
 type mediaDBIDBounds struct {
@@ -188,6 +201,8 @@ type MediaDB struct {
 	analyzeRetryDelay       time.Duration
 	mediaSearchBoundsGen    uint64
 	batchSize               int
+	walAutoCheckpoint       atomic.Int64
+	systemMediaCountsGen    atomic.Uint64
 	backgroundOpsMu         syncutil.RWMutex
 	mediaSearchBoundsMu     syncutil.RWMutex
 	sqlMu                   syncutil.RWMutex
@@ -197,8 +212,7 @@ type MediaDB struct {
 	needsIndexRebuild       atomic.Bool
 	isOptimizing            atomic.Bool
 	indexingCacheBoost      atomic.Bool
-	walAutoCheckpoint       atomic.Int64
-	systemMediaCountsGen    atomic.Uint64
+	walAutoCheckpointSet    atomic.Bool
 	inTransaction           bool
 	browseCacheDirty        bool
 	utilityTagCacheDirty    bool
@@ -233,7 +247,7 @@ type invalidationScope struct {
 	MediaRowsChanged        bool
 }
 
-// invalidateCaches handles all cache invalidation in one place
+// invalidateCaches handles all cache invalidation in one place.
 func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 	db.inMemoryTagCache.Store(nil)
 	db.systemMediaCountsCache.Store(nil)
@@ -283,7 +297,6 @@ func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 				systemsToInvalidate = append(systemsToInvalidate, *s)
 			}
 		}
-
 		if len(systemsToInvalidate) > 0 {
 			if err := db.InvalidateSystemTagsCache(db.ctx, systemsToInvalidate); err != nil {
 				log.Warn().Err(err).Msg("failed to invalidate system tags cache for specific systems")
@@ -381,15 +394,30 @@ func invalidationScopeForSystemIDs(systemIDs []string) invalidationScope {
 	return invalidationScope{SystemIDs: systemIDs}
 }
 
-func shouldCheckpointAfterCommit(mode database.WALCheckpointMode, _ string, _ error) bool {
-	switch mode {
-	case database.WALCheckpointSkip:
-		return false
-	case database.WALCheckpointForce:
-		return true
-	default:
-		return false
-	}
+// MidScanSystemTagsCacheSurvivesCommit reports whether populating SystemTagsCache
+// for one system partway through a run of systemCount systems is worth doing.
+//
+// It is not, once the run is large enough to invalidate all systems: an
+// all-systems scope drops the whole SystemTagsCache on every commit (see
+// invalidateCaches), so a population done just after one commit is deleted by
+// the next one. Repeating that per system spends a query and a transaction
+// commit each time for a cache that never holds more than the most recently
+// indexed system, and the end-of-run PopulateSystemTagsCache rebuilds it from
+// scratch regardless. Smaller runs keep a selective scope, so their populations
+// survive and stay worthwhile. Mirrors invalidationScopeForSystemIDs above;
+// keep the two in step.
+func MidScanSystemTagsCacheSurvivesCommit(systemCount int) bool {
+	return systemCount > 0 && systemCount <= maxSelectiveInvalidationSystems
+}
+
+// shouldCheckpointAfterCommit reports whether a commit must run an explicit
+// checkpoint of its own. Only WALCheckpointForce does. Callers that get false
+// still checkpoint via checkpointLargeWAL, which fires once the WAL passes
+// mediaWALCheckpointThreshold; that size-driven path replaced the older
+// indexing-status-driven force, so WALCheckpointAuto no longer needs the status
+// or its lookup error to decide.
+func shouldCheckpointAfterCommit(mode database.WALCheckpointMode) bool {
+	return mode == database.WALCheckpointForce
 }
 
 func (db *MediaDB) DropSlugSearchCacheForSystems(systemIDs []string) {
@@ -470,6 +498,10 @@ func (db *MediaDB) Open() error {
 		return fmt.Errorf("failed to open media database: %w", err)
 	}
 	sqlInstance.SetMaxOpenConns(baseMaxOpenConns)
+	// Set explicitly rather than relying on database/sql's default of 2 to
+	// happen to equal baseMaxOpenConns: an idle cap below the open cap lets the
+	// pool recycle connections and lose their pragmas. See SetIndexingConnBoost.
+	sqlInstance.SetMaxIdleConns(baseMaxOpenConns)
 	db.sql.Store(sqlInstance)
 	if _, err = sqlInstance.ExecContext(db.ctx, "PRAGMA cell_size_check=ON"); err != nil {
 		if database.IsCorruptionError(err) {
@@ -482,6 +514,8 @@ func (db *MediaDB) Open() error {
 			log.Warn().Err(err).Msg("failed to enable media database cell size checks; continuing without")
 		}
 	}
+	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "media", database.SynchronousNormal, mediaPageSize)
+
 	clearUtilityTagCache()
 	clearCoverAvailabilityCache()
 	clearImagePropertyTagCache()
@@ -508,12 +542,21 @@ func (db *MediaDB) GetDBPath() string {
 
 // SetIndexingCacheSize temporarily increases SQLite cache_size for bulk indexing.
 // Call with enable=true before indexing starts, and enable=false after it completes.
-// When enabled, sets 32MB cache (vs default 8MB) to reduce page eviction during
-// heavy insert workloads with non-sequential index keys.
+// When enabled, sets 32MB cache (vs default 8MB), intended to reduce page
+// eviction during heavy insert workloads with non-sequential index keys.
 //
 // Also switches temp_store to MEMORY for the duration: the GROUP BY temp B-trees
 // built by the post-indexing cache population are only a few MB, and the default
 // temp_store=FILE writes them to slow storage (SD card) on embedded devices.
+//
+// What this is actually worth has never been measured, and #1279 did not settle
+// it despite appearances. Round 11 was the first run where the boost reached
+// every pooled connection, and its optimization phase matched round 10's to
+// within 0.03% — but round 10 was not an unboosted control: two of its three
+// connections carried the boost and only the third came up at DSN defaults, so
+// the work may well have run boosted in both. Any future comparison has to turn
+// the boost off deliberately, and has to account for cache_size and temp_store
+// separately, since this one switch moves both.
 //
 // Both pragmas are per-connection, so every pooled connection is configured
 // when the indexing state changes. BeginTransaction also re-applies the current
@@ -533,13 +576,19 @@ func (db *MediaDB) SetIndexingCacheSize(enable bool) {
 }
 
 // SetWALAutoCheckpoint applies a per-connection SQLite WAL checkpoint trigger.
-// Resource-constrained indexing lowers it to cap automatic checkpoint bursts
-// inside tx.Commit, then restores SQLite's default after indexing.
+// Indexing disables it (pages=0) so SQLite never attempts an automatic
+// checkpoint inside tx.Commit, then restores SQLite's default after indexing;
+// checkpointLargeWAL drives checkpoints explicitly and deliberately instead.
+// pages=0 is a valid, distinct setting (disabled) from never having called
+// this at all, which is why walAutoCheckpointSet exists rather than treating
+// zero as "unset" — a MediaDB that never calls this keeps SQLite's compiled
+// default (walAutoCheckpointPages below), not zero.
 func (db *MediaDB) SetWALAutoCheckpoint(pages int) {
-	if pages <= 0 {
+	if pages < 0 {
 		return
 	}
 	db.walAutoCheckpoint.Store(int64(pages))
+	db.walAutoCheckpointSet.Store(true)
 	sqlDB := db.sql.Load()
 	if sqlDB == nil {
 		return
@@ -552,7 +601,7 @@ func (db *MediaDB) SetWALAutoCheckpoint(pages int) {
 		log.Warn().Err(acquireErr).Int("pages", pages).
 			Msg("failed to acquire pooled connections while setting WAL autocheckpoint")
 	}
-	//nolint:gosec // pages is a validated positive integer, not SQL input.
+	//nolint:gosec // pages is a validated non-negative integer, not SQL input.
 	query := "PRAGMA wal_autocheckpoint = " + strconv.Itoa(pages)
 	for _, conn := range conns {
 		if _, err := conn.ExecContext(db.ctx, query); err != nil {
@@ -565,39 +614,71 @@ func (db *MediaDB) SetWALAutoCheckpoint(pages int) {
 }
 
 func (db *MediaDB) walAutoCheckpointPages() int {
-	pages := db.walAutoCheckpoint.Load()
-	if pages <= 0 {
+	if !db.walAutoCheckpointSet.Load() {
 		return defaultWALAutoCheckpoint
 	}
-	return int(pages)
+	return int(db.walAutoCheckpoint.Load())
 }
 
 // drainPooledConns checks out every pool slot simultaneously. The caller must
 // hold sqlMu so a writer transaction cannot start while the pool is drained.
+//
+// The target is re-read on every iteration rather than sampled once. The cap is
+// not stable: SetIndexingConnBoost moves it between baseMaxOpenConns and
+// indexingMaxOpenConns from another goroutine, and a drain sized against the
+// wider value will block forever on a slot the pool can no longer create — with
+// every existing connection already held here, so nothing can be returned to
+// satisfy it either. That deadlock-against-self cost three device runs in
+// #1279; it resolved only when the acquire deadline fired, and the warning it
+// produced pointed at the post-failure cap rather than the one that was
+// targeted.
+//
+// Each acquisition also gets its own deadline. A single budget shared across
+// every slot means one slow acquisition silently spends the next one's time.
 func (db *MediaDB) drainPooledConns(sqlDB *sql.DB) ([]*sql.Conn, error) {
-	stats := sqlDB.Stats()
-	connCount := stats.MaxOpenConnections
-	if connCount <= 0 {
-		connCount = max(stats.OpenConnections, 1)
+	target := func() int {
+		stats := sqlDB.Stats()
+		count := stats.MaxOpenConnections
+		if count <= 0 {
+			count = max(stats.OpenConnections, 1)
+		}
+		if db.txConn != nil {
+			count--
+		}
+		return count
 	}
-	if db.txConn != nil {
-		connCount--
-	}
+
+	connCount := target()
 	if connCount <= 0 {
 		return nil, nil
 	}
-
-	acquireCtx, cancel := context.WithTimeout(db.ctx, connectionAcquireTimeout)
-	defer cancel()
 	conns := make([]*sql.Conn, 0, connCount)
-	for range connCount {
-		conn, err := sqlDB.Conn(acquireCtx)
+	for len(conns) < connCount {
+		// Re-read before each acquisition: a cap that shrank mid-drain means
+		// the connections already held are the whole pool and there is nothing
+		// left to wait for.
+		if current := target(); current < connCount {
+			connCount = current
+			continue
+		}
+		conn, err := db.acquirePooledConn(sqlDB)
 		if err != nil {
-			return conns, fmt.Errorf("failed to acquire pooled connection: %w", err)
+			return conns, err
 		}
 		conns = append(conns, conn)
 	}
 	return conns, nil
+}
+
+// acquirePooledConn checks out one connection under its own deadline.
+func (db *MediaDB) acquirePooledConn(sqlDB *sql.DB) (*sql.Conn, error) {
+	acquireCtx, cancel := context.WithTimeout(db.ctx, connectionAcquireTimeout)
+	defer cancel()
+	conn, err := sqlDB.Conn(acquireCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire pooled connection: %w", err)
+	}
+	return conn, nil
 }
 
 // applyPooledConnPragmas drains the pool so both indexing pragmas reach every
@@ -608,10 +689,27 @@ func (db *MediaDB) applyPooledConnPragmas(sqlDB *sql.DB) {
 
 	conns, acquireErr := db.drainPooledConns(sqlDB)
 	if acquireErr != nil {
+		// A partial drain leaves some connections on the old pragmas, and an
+		// empty one applies the boost nowhere at all. Round 8 of #1279 hit
+		// exactly that: the drain timed out, this returned quietly, and the
+		// whole post-index optimization ran at the 8MB default — visible only
+		// as dbCacheSize on the step metrics, hours later. Log what actually
+		// happened so the next run says so in the log itself. See #1279.
+		//
+		// maxOpenConns here is sampled AFTER the failure, so it can differ from
+		// the cap the drain sized itself against — three rounds of #1279 read
+		// "acquired 2 of a 2-connection pool, timed out" and looked like a
+		// contradiction for exactly that reason. connsInUse likewise counts the
+		// connections this drain is itself holding.
+		stats := sqlDB.Stats()
+		event := log.Warn().Err(acquireErr).
+			Int("connsAcquired", len(conns)).
+			Int("maxOpenConnsAfterFailure", stats.MaxOpenConnections).
+			Int("connsInUse", stats.InUse)
 		if errors.Is(acquireErr, context.DeadlineExceeded) {
-			log.Warn().Err(acquireErr).Msg("timed out acquiring pooled connections while enabling indexing pragmas")
+			event.Msg("timed out acquiring pooled connections while enabling indexing pragmas")
 		} else {
-			log.Warn().Err(acquireErr).Msg("failed to acquire pooled connection while enabling indexing pragmas")
+			event.Msg("failed to acquire pooled connection while enabling indexing pragmas")
 		}
 	}
 
@@ -649,6 +747,87 @@ func (db *MediaDB) restorePooledConnPragmas(sqlDB *sql.DB) {
 			log.Warn().Err(err).Msg("failed to restore pooled connection after indexing")
 		}
 	}
+}
+
+// ensureIndexingCacheBoostApplied checks that the cache_size pragma actually
+// reached every pooled connection, and retries once if it did not.
+//
+// applyPooledConnPragmas is best-effort by design: if it cannot check out every
+// pool slot it configures the ones it got and returns. That is the right
+// behaviour for indexing, which sets the boost while the pool is quiet, but
+// post-index optimization starts while the app is still polling, and round 8 of
+// #1279 spent its entire optimization phase at the 8MB default because of it.
+func (db *MediaDB) ensureIndexingCacheBoostApplied() {
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
+		return
+	}
+
+	wantCacheSize, _ := db.connPragmaValues()
+	if db.pooledCacheSizeMatches(sqlDB, wantCacheSize) {
+		return
+	}
+
+	log.Warn().
+		Str("want", wantCacheSize).
+		Msg("indexing cache boost did not reach the pool, retrying")
+	db.applyPooledConnPragmas(sqlDB)
+
+	if db.pooledCacheSizeMatches(sqlDB, wantCacheSize) {
+		log.Info().Str("cacheSize", wantCacheSize).Msg("indexing cache boost applied on retry")
+		return
+	}
+	// Not fatal — optimization is correct at any cache size, just slower. Logged
+	// loudly because the cost is large and otherwise invisible.
+	log.Warn().
+		Str("want", wantCacheSize).
+		Msg("indexing cache boost still not applied; optimization will run at the default cache size")
+}
+
+// pooledCacheSizeMatches reports whether EVERY pooled connection carries the
+// expected cache_size.
+//
+// This used to read the pragma back with a single pool query, which is not a
+// verification at all: the pool hands out an arbitrary connection, so the check
+// passed as soon as it happened to land on a boosted one while its siblings sat
+// at the default. That is precisely the state round 9 of #1279 was in when this
+// reported success and every optimization step then logged dbCacheSize -8192.
+// A check that cannot fail is worse than no check, so drain the pool and look
+// at all of them.
+func (db *MediaDB) pooledCacheSizeMatches(sqlDB *sql.DB, want string) bool {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
+	conns, acquireErr := db.drainPooledConns(sqlDB)
+	defer func() {
+		for _, conn := range conns {
+			if err := conn.Close(); err != nil {
+				log.Warn().Err(err).Msg("failed to release pooled connection after cache_size check")
+			}
+		}
+	}()
+	if acquireErr != nil {
+		// Could not see the whole pool, so cannot claim the whole pool matches.
+		log.Warn().Err(acquireErr).
+			Int("connsChecked", len(conns)).
+			Msg("could not drain pool to verify cache_size")
+		return false
+	}
+	if len(conns) == 0 {
+		return false
+	}
+
+	for _, conn := range conns {
+		var actual int
+		if err := conn.QueryRowContext(db.ctx, "PRAGMA cache_size").Scan(&actual); err != nil {
+			log.Warn().Err(err).Msg("failed to read back pooled cache_size")
+			return false
+		}
+		if strconv.Itoa(actual) != want {
+			return false
+		}
+	}
+	return true
 }
 
 // connPragmaValues returns the cache_size and temp_store settings matching the
@@ -723,18 +902,64 @@ func (db *MediaDB) releaseWriterConn() error {
 	return db.closeWriterConn(conn)
 }
 
+// analyzeApproximateMask is the PRAGMA optimize bitmask used for planner
+// statistics refreshes. Each bit matters:
+//
+//	0x00002  run ANALYZE on tables that might benefit (the actual work)
+//	0x00010  apply SQLITE_DEFAULT_OPTIMIZE_LIMIT (2000) as the analysis limit
+//	0x10000  consider tables that were not queried on this connection
+//
+// 0x10000 is off by default and is what lets a table qualify on size change
+// alone rather than on having been queried through this particular pooled
+// connection. That matters here because the pool hands out an arbitrary
+// connection per call.
+//
+// 0x10 is weaker than it looks, and this is worth stating plainly because an
+// earlier version of this comment claimed otherwise. It does not stop an
+// ANALYZE after 2000 rows: sqlite3-binding.c statPush makes the scan *seek
+// past the current distinct value of the index's leading column* once the
+// limit is hit. On a high-cardinality leading column each skip advances about
+// one row, so the scan degenerates into a full index walk. Media carries
+// media_path_idx(Path) and the UNIQUE(SystemDBID, Path) autoindex; MediaTitles
+// carries unique slug indexes. For those, 0x10 buys close to nothing.
+//
+// The consequence is measured, not theoretical: round 9 of #1279 saw this call
+// cost 2 ms at all but one system boundary and 54,442 ms at that one, on a
+// system holding 426 files, because PRAGMA optimize is database-wide and never
+// scoped to the system that just committed.
+//
+// If a spike like that needs attributing again, bit 0x01 turns PRAGMA optimize
+// into a reporting mode that returns one row per ANALYZE it would have run
+// without running any of them. Issue it by hand rather than on every call: it
+// costs an extra round-trip, and because the pool hands out an arbitrary
+// connection the reported plan may not describe the connection that did the
+// work.
+const analyzeApproximateMask = "0x10012"
+
 // AnalyzeApproximate refreshes query-planner statistics before synchronous
-// cache builds. PRAGMA optimize is intentionally used instead of raw ANALYZE:
-// on modern SQLite it bounds analysis work automatically and only refreshes
-// tables likely to benefit, which avoids multi-minute full-index scans on slow
-// MiSTer storage.
+// cache builds. PRAGMA optimize is used instead of a raw ANALYZE because it
+// only refreshes tables likely to benefit, but note the caveat on
+// analyzeApproximateMask: the 0x10 limit does not reliably bound the work.
 func (db *MediaDB) AnalyzeApproximate() error {
-	if db.sql.Load() == nil {
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
 		return ErrNullSQL
 	}
-	if _, err := db.sql.Load().ExecContext(db.ctx, "PRAGMA optimize=0x10002"); err != nil {
+	started := time.Now()
+	_, err := sqlDB.ExecContext(db.ctx, "PRAGMA optimize="+analyzeApproximateMask)
+	elapsed := time.Since(started)
+	if err != nil {
 		return fmt.Errorf("failed to run pragma optimize: %w", err)
 	}
+	// Warn rather than debug when it was not a no-op: the whole point of this
+	// telemetry is that a multi-second planner refresh is invisible otherwise.
+	logEvent := log.Debug()
+	if elapsed > time.Second {
+		logEvent = log.Warn()
+	}
+	logEvent.
+		Dur("elapsed", elapsed).
+		Msg("approximate ANALYZE completed")
 	return nil
 }
 
@@ -762,7 +987,11 @@ var secondaryIndexes = []secondaryIndex{
 	},
 	{name: "media_mediatitle_idx", ddl: "CREATE INDEX IF NOT EXISTS media_mediatitle_idx ON Media(MediaTitleDBID)"},
 	{name: "media_path_idx", ddl: "CREATE INDEX IF NOT EXISTS media_path_idx ON Media(Path)"},
-	{name: "media_system_path_idx", ddl: "CREATE INDEX IF NOT EXISTS media_system_path_idx ON Media(SystemDBID, Path)"},
+	// No entry for (SystemDBID, Path): Media declares UNIQUE(SystemDBID, Path),
+	// so SQLite already maintains sqlite_autoindex_Media_1 over exactly those
+	// columns in that order. A second identical index only doubled the b-tree
+	// maintenance on every Media write. Queries that need the access path pin it
+	// with INDEXED BY sqlite_autoindex_Media_1.
 	{name: "media_missing_idx", ddl: "CREATE INDEX IF NOT EXISTS media_missing_idx ON Media(IsMissing)"},
 	{
 		name: "media_system_present_path_idx",
@@ -1210,11 +1439,17 @@ func (db *MediaDB) IntegrityReport() []string {
 	return database.IntegrityReport(db.ctx, db.sql.Load(), database.DefaultIntegrityReportRows)
 }
 
-// Recreate discards the database file and reopens a fresh one. The connection is
-// closed; the main file is either preserved as a <db>.corrupt.bak forensic copy
-// (keepBackup — development builds only) or deleted; the -wal/-shm sidecars are
-// removed (a stale WAL would re-corrupt the new file); and Open() allocates a fresh
-// schema. Before any corrupt marker is cleared, the fresh database is marked pending
+// Recreate discards the database file and reopens a fresh one. The main file and
+// its -wal/-shm sidecars are either preserved together as <db>{,-wal,-shm}.corrupt.bak
+// forensic copies (keepBackup — development builds only) or deleted outright; the
+// connection is then closed; and Open() allocates a fresh schema. Preservation happens
+// before Close() deliberately: in WAL mode, SQLite's own close-time checkpoint deletes
+// the live -wal/-shm files outright (verified empirically — nothing survives a rename
+// attempted afterward), so capturing a consistent three-file forensic set from a single
+// point in time requires renaming them aside while the connection is still open. A
+// sidecar surviving on disk next to the freshly allocated database would re-corrupt it,
+// so every path still ends with RemoveSidecars regardless of whether keepBackup
+// succeeded. Before any corrupt marker is cleared, the fresh database is marked pending
 // for reindex and stale search caches are removed. This durable handoff lets startup
 // resume if the process exits before the caller starts indexing. Callers: corruption
 // recovery and the user-requested fresh-start rebuild (media.index with rebuild:true).
@@ -1225,6 +1460,12 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 		return errors.New("media database recreate already in progress")
 	}
 	defer db.recreating.Store(false)
+
+	if keepBackup {
+		database.PreserveCorruptFile(db.dbPath, "media")
+		database.PreserveCorruptFile(db.dbPath+"-wal", "media")
+		database.PreserveCorruptFile(db.dbPath+"-shm", "media")
+	}
 
 	if err := db.Close(); err != nil {
 		log.Warn().Err(err).Msg("error closing media database before recreate")
@@ -1241,16 +1482,11 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 	db.txConn = nil
 	db.inTransaction = false
 
-	if keepBackup {
-		backup := database.CorruptBackupPath(db.dbPath)
-		_ = os.Remove(backup)
-		if err := os.Rename(db.dbPath, backup); err != nil && !errors.Is(err, os.ErrNotExist) {
-			log.Warn().Err(err).Msg("failed to preserve corrupt media database backup; deleting instead")
-			if rmErr := os.Remove(db.dbPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
-				return fmt.Errorf("failed to remove corrupt media database: %w", rmErr)
-			}
-		}
-	} else if err := os.Remove(db.dbPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+	// PreserveCorruptFile above is best-effort: on a rename failure it logs and
+	// leaves the file in place. Whether or not keepBackup ran (or partially
+	// succeeded), db.dbPath must not still exist here — otherwise Open() below
+	// would reopen the corrupt database instead of allocating a fresh one.
+	if err := os.Remove(db.dbPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove corrupt media database: %w", err)
 	}
 
@@ -1506,7 +1742,11 @@ func (db *MediaDB) Allocate() error {
 	if db.sql.Load() == nil {
 		return ErrNullSQL
 	}
-	return sqlAllocate(db.sql.Load(), db.dbPath)
+	if err := sqlAllocate(db.sql.Load(), db.dbPath); err != nil {
+		return err
+	}
+	db.applySchemaReadyFixups()
+	return nil
 }
 
 func (db *MediaDB) MigrateUp() error {
@@ -1516,21 +1756,48 @@ func (db *MediaDB) MigrateUp() error {
 	if err := sqlMigrateUp(db.sql.Load(), db.dbPath); err != nil {
 		return err
 	}
-	// Best-effort: a database without real Media statistics gets the captured
-	// seed so mid-index queries have sane plans; the first system commit's
-	// approximate ANALYZE replaces it.
-	if err := sqlSeedPlannerStats(db.ctx, db.sql.Load()); err != nil {
-		log.Warn().Err(err).Msg("failed to seed planner statistics")
-	}
+	db.applySchemaReadyFixups()
 	// Best-effort: stamp the disambiguation version on a database with no
 	// titles before the first index writes any. The pending check performs the
 	// stamp as a side effect; without this, the check first runs during
 	// post-index optimization — after titles exist — and a fresh install pays
 	// a full backfill over values the index just computed.
+	//
+	// Only needed here. The other route to a fresh schema is Allocate, and both
+	// of its callers already cover this: Open's fresh-database branch is
+	// followed by MigrateUp at startup, and Recreate stamps the version itself
+	// straight after reopening.
 	if _, err := db.disambiguationBackfillPending(db.ctx); err != nil {
 		log.Warn().Err(err).Msg("failed to check disambiguation backfill state after migration")
 	}
 	return nil
+}
+
+// applySchemaReadyFixups runs the best-effort corrections a database needs once
+// its schema is current. Both are idempotent.
+//
+// Called from Allocate as well as MigrateUp because a brand-new database reaches
+// sqlMigrateUp through Allocate — Open takes that branch when the file does not
+// exist yet, and Recreate goes the same way. Recreate is the case that made this
+// matter: it reopens into a fresh database and starts a reindex immediately,
+// without a MigrateUp in between, so anything hooked only there was skipped for
+// every user-triggered rebuild.
+func (db *MediaDB) applySchemaReadyFixups() {
+	// A database without real Media statistics gets the captured seed so
+	// mid-index queries have sane plans; the first system commit's approximate
+	// ANALYZE replaces it. Without this a rebuild reindexes against an empty
+	// sqlite_stat1, which is the plan regression #1279 started from.
+	if err := sqlSeedPlannerStats(db.ctx, db.sql.Load()); err != nil {
+		log.Warn().Err(err).Msg("failed to seed planner statistics")
+	}
+	// The browse-cache migrations stamp OptimizationStatus=pending
+	// unconditionally so existing databases rebuild on upgrade, which also
+	// stamps a brand-new database that has nothing to rebuild. Drop it when
+	// there is no media, or the next start "resumes" an optimization over an
+	// empty database.
+	if err := db.clearOptimizationStampIfEmpty(db.ctx); err != nil {
+		log.Warn().Err(err).Msg("failed to clear optimization stamp on empty database")
+	}
 }
 
 func (db *MediaDB) Vacuum() error {
@@ -2244,6 +2511,12 @@ func (db *MediaDB) CommitTransaction() error {
 	return db.CommitTransactionWithOptions(database.TransactionOptions{WALCheckpoint: database.WALCheckpointAuto})
 }
 
+// slowCommitBreakdownThreshold matches the commitElapsed threshold the indexing
+// loop (mediascanner.go) already warns at, so the per-segment breakdown below
+// escalates to Warn on exactly the commits that already trip that alert —
+// making it actionable without cross-referencing the Debug-level breakdown.
+const slowCommitBreakdownThreshold = 5 * time.Second
+
 func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOptions) error {
 	db.sqlMu.Lock()
 	defer db.sqlMu.Unlock()
@@ -2252,6 +2525,7 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 		return nil // No active transaction
 	}
 
+	flushStart := time.Now()
 	// Flush all batch inserters before committing (if any were created).
 	if db.batchInsertSystem != nil {
 		if closeErr := db.closeAllBatchInserters(); closeErr != nil {
@@ -2261,10 +2535,19 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 	} else {
 		db.closeAllPreparedStatements()
 	}
+	flushElapsed := time.Since(flushStart)
+
+	// Measured immediately around tx.Commit() so a WAL-size drop with no
+	// explicit checkpoint logged afterward is direct evidence that SQLite's
+	// automatic checkpointing ran inside the commit itself.
+	walSizeBeforeCommit := db.mediaWALSizeForLog()
+	sqliteCommitStart := time.Now()
 	if err := db.tx.Commit(); err != nil {
 		cleanupErr := db.rollbackTransactionLocked()
 		return errors.Join(fmt.Errorf("failed to commit transaction: %w", err), cleanupErr)
 	}
+	sqliteCommitElapsed := time.Since(sqliteCommitStart)
+	walSizeAfterCommit := db.mediaWALSizeForLog()
 
 	// Release the pinned writer before post-commit pool queries and checkpoints.
 	// A cleanup failure does not turn an already-successful commit into an
@@ -2275,29 +2558,37 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 		log.Warn().Err(connErr).Msg("failed to reset writer connection after commit")
 	}
 
+	invalidateStart := time.Now()
 	// During indexing, keep last-good slug search coverage available for
 	// foreground launches/searches, but still invalidate durable/count caches so
 	// random queries never trust stale MediaCountCache ranges after a commit.
 	indexingStatus, statusErr := sqlGetIndexingStatus(db.ctx, db.sql.Load())
-	checkpointAfterCommit := shouldCheckpointAfterCommit(options.WALCheckpoint, indexingStatus, statusErr)
+	checkpointAfterCommit := shouldCheckpointAfterCommit(options.WALCheckpoint)
+
+	var scope invalidationScope
+	indexingBatchCommit := false
 	switch {
 	case statusErr != nil:
 		log.Warn().Err(statusErr).Msg("failed to determine indexing status for cache invalidation")
-		db.invalidateCaches(invalidationScope{
-			AllSystems: true, MediaRowsChanged: db.mediaSearchBoundsDirty,
-		})
+		scope = invalidationScope{AllSystems: true, MediaRowsChanged: db.mediaSearchBoundsDirty}
 	case indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending:
-		scope := db.cacheInvalidationScopeForCommittedTransaction()
+		scope = db.cacheInvalidationScopeForCommittedTransaction()
 		scope.PreserveSlugSearchCache = true
-		db.invalidateCaches(scope)
-		log.Debug().Str("status", indexingStatus).Msg("invalidated committed caches during indexing batch commit")
+		indexingBatchCommit = true
 	default:
-		db.invalidateCaches(db.cacheInvalidationScopeForCommittedTransaction())
+		scope = db.cacheInvalidationScopeForCommittedTransaction()
+	}
+
+	db.invalidateCaches(scope)
+	if indexingBatchCommit {
+		log.Debug().Str("status", indexingStatus).Msg("invalidated committed caches during indexing batch commit")
 	}
 	db.mediaSearchBoundsDirty = false
+
 	if err := db.flushBrowseCacheInvalidation(); err != nil {
 		return err
 	}
+	invalidateElapsed := time.Since(invalidateStart)
 
 	// Foreground metadata writes (favorite toggles) should not block on a full
 	// checkpoint. During indexing, batch commits can grow the WAL quickly, but
@@ -2305,6 +2596,7 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 	// unreliable SD/exFAT storage. So the common path only checkpoints once the WAL
 	// has grown past mediaWALCheckpointThreshold, bounding its size (and RAM
 	// pressure) without paying the checkpoint cost on every tiny batch.
+	checkpointStart := time.Now()
 	if checkpointAfterCommit {
 		beforeSize := db.mediaWALSizeForLog()
 		if chkErr := db.runWALCheckpointForLog("transaction_commit_forced", beforeSize); chkErr != nil {
@@ -2314,6 +2606,23 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 	} else {
 		db.checkpointLargeWAL()
 	}
+	checkpointElapsed := time.Since(checkpointStart)
+
+	totalElapsed := flushElapsed + sqliteCommitElapsed + invalidateElapsed + checkpointElapsed
+	breakdownEvent := log.Debug()
+	if totalElapsed > slowCommitBreakdownThreshold {
+		breakdownEvent = log.Warn()
+	}
+	breakdownEvent = logPoolStats(breakdownEvent, db.sql.Load())
+	breakdownEvent.
+		Dur("flush", flushElapsed).
+		Dur("sqliteCommit", sqliteCommitElapsed).
+		Dur("invalidate", invalidateElapsed).
+		Dur("checkpoint", checkpointElapsed).
+		Dur("total", totalElapsed).
+		Int64("walSizeBeforeCommit", walSizeBeforeCommit).
+		Int64("walSizeAfterCommit", walSizeAfterCommit).
+		Msg("media database commit breakdown")
 
 	return nil
 }
@@ -2380,6 +2689,22 @@ func (db *MediaDB) checkpointLargeWAL() {
 	}
 }
 
+// logPoolStats attaches the pool's current connection counts to event. A
+// checkpoint can only reclaim WAL frames up to the oldest connection still
+// holding an open read snapshot; if inUse is ever above 1 while indexing
+// holds the writer, that's direct evidence something else was checked out
+// at the same moment — see runWALCheckpointForLog.
+func logPoolStats(event *zerolog.Event, sqlDB *sql.DB) *zerolog.Event {
+	if sqlDB == nil {
+		return event
+	}
+	stats := sqlDB.Stats()
+	return event.
+		Int("poolOpen", stats.OpenConnections).
+		Int("poolInUse", stats.InUse).
+		Int("poolIdle", stats.Idle)
+}
+
 func (db *MediaDB) mediaWALSizeForLog() int64 {
 	if db.dbPath == "" {
 		return 0
@@ -2397,19 +2722,27 @@ func (db *MediaDB) mediaWALSizeForLog() int64 {
 }
 
 func (db *MediaDB) runWALCheckpointForLog(reason string, walSizeBefore int64) error {
+	checkpointStart := time.Now()
 	var busy, logFrames, checkpointedFrames int
 	if err := db.sql.Load().QueryRowContext(db.ctx, "PRAGMA wal_checkpoint(TRUNCATE);").
 		Scan(&busy, &logFrames, &checkpointedFrames); err != nil {
 		return fmt.Errorf("WAL checkpoint failed: %w", err)
 	}
+	elapsed := time.Since(checkpointStart)
 	walSizeAfter := db.mediaWALSizeForLog()
 	logEvent := log.Debug()
 	if busy > 0 || walSizeAfter >= mediaWALCheckpointThreshold {
 		logEvent = log.Warn()
 	}
+	// logFrames-checkpointedFrames is how many WAL frames a reader's open snapshot
+	// blocked reclaiming; the pool stats show whether a connection besides the
+	// writer was checked out at that moment — together they're the #1279
+	// stuck-checkpoint diagnosis this threshold being reachable now enables.
+	logEvent = logPoolStats(logEvent, db.sql.Load())
 	logEvent.
 		Str("reason", reason).
 		Str("path", db.dbPath+"-wal").
+		Dur("elapsed", elapsed).
 		Int64("walSizeBefore", walSizeBefore).
 		Int64("walSizeAfter", walSizeAfter).
 		Int64("threshold", mediaWALCheckpointThreshold).
@@ -2971,8 +3304,24 @@ func (db *MediaDB) GetAllUsedTags(ctx context.Context) ([]database.TagInfo, erro
 // PopulateSystemTagsCache rebuilds the cache table for fast tag lookups by system
 // This should be called after media indexing completes
 func (db *MediaDB) PopulateSystemTagsCache(ctx context.Context) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
 	if db.sql.Load() == nil {
 		return ErrNullSQL
+	}
+	// Unlike every other MediaDB write path, this used to BeginTx unconditionally
+	// against the pool. With _txlock=immediate in the DSN, that grabs SQLite's
+	// single WAL writer lock at BEGIN itself — while indexing holds it for a
+	// whole system's commit, a concurrent caller (this can self-heal from a
+	// plain read via GetSystemTagsCached) would block for the full busy_timeout
+	// pinning a reader mark at a stale WAL position the whole time. Fail fast
+	// instead, matching applyMediaTagMutations.
+	if db.inTransaction {
+		return ErrTransactionActive
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 	return sqlPopulateSystemTagsCache(ctx, db.sql.Load())
 }
@@ -2980,8 +3329,19 @@ func (db *MediaDB) PopulateSystemTagsCache(ctx context.Context) error {
 // PopulateSystemTagsCacheForSystems rebuilds cache for specific systems only
 // Used for incremental cache updates after individual system changes
 func (db *MediaDB) PopulateSystemTagsCacheForSystems(ctx context.Context, systems []systemdefs.System) error {
+	db.sqlMu.Lock()
+	defer db.sqlMu.Unlock()
+
 	if db.sql.Load() == nil {
 		return ErrNullSQL
+	}
+	// See PopulateSystemTagsCache above for why this guards against a
+	// concurrent indexing transaction rather than blocking on it.
+	if db.inTransaction {
+		return ErrTransactionActive
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
 	return sqlPopulateSystemTagsCacheForSystems(ctx, db.sql.Load(), systems)
 }
@@ -3860,6 +4220,60 @@ func (db *MediaDB) RunBackgroundOptimizationWithLease(
 
 	db.isOptimizing.Store(true)
 	db.backgroundOps.Add(1)
+
+	// Optimization is bulk work on an otherwise idle device, but it ran with the
+	// default 8MB cache, 2 connections and temp_store=FILE. The indexing boost is
+	// scoped to NewNamesIndex's stack frame (configureIndexingPragmas is installed
+	// there with defer), while post-index optimization is deliberately detached
+	// into its own goroutine that only starts after that function returns — so the
+	// boost was always already released by the time these steps ran. On the MiSTer
+	// test device that meant pragma_optimize read 359MB through an 8MB cache and
+	// the browse cache rebuild spilled its temp B-trees to the SD card. The
+	// startup-triggered optimization paths never had a boost at all.
+	//
+	// The media write lease makes optimization and indexing mutually exclusive, so
+	// these cannot interleave, but restore the previous state rather than assume.
+	//
+	// Registered before the recovery defer below so that, on a panic, the restore
+	// runs *after* the handler has written its status: restoring pragmas can
+	// discard a pooled connection, which the handler still needs.
+	// In round 8 of #1279 this boost silently did nothing. SetIndexingCacheSize
+	// drains every pooled connection to put the pragma on each one; another
+	// caller held one, the 5s drain timed out, and the whole optimization ran at
+	// the 8MB default regardless. Nothing said so — the only evidence was
+	// dbCacheSize on the step metrics, read hours after the fact.
+	//
+	// So the boost is verified rather than assumed, and retried once when it did
+	// not take. Contention here is transient (the app polls for a few
+	// milliseconds at a time), so a second attempt usually lands.
+	//
+	// Raise the connection cap BEFORE applying the pragmas. Doing it the other
+	// way round sizes the drain against the narrow cap, so the extra connection
+	// the next line permits is later opened straight from the DSN — at the 8MB
+	// default, with nothing left to configure it. Rounds 8, 9 and 10 of #1279
+	// all reported dbCacheSize -8192 for exactly that reason, even though the
+	// connections the drain did reach were configured correctly.
+	//
+	// An earlier attempt at this ordering was reverted because the drain timed
+	// out; that timeout was the caller-side race in startIndexing (the indexing
+	// pool boost was still pending, so the drain sized itself to a cap that was
+	// about to shrink underneath it) and is fixed at the source. drainPooledConns
+	// now also re-reads the target rather than sampling it once.
+	//
+	// Round 11 confirmed all six steps then run at -32768 with no drain timeout.
+	// It did not, however, show the boost is worth anything: see
+	// SetIndexingCacheSize for why round 10 is not a valid control to compare
+	// against. Treat the value of this boost as unmeasured.
+	if !db.indexingCacheBoost.Load() {
+		defer func() {
+			db.SetIndexingConnBoost(false)
+			db.SetIndexingCacheSize(false)
+		}()
+		db.SetIndexingConnBoost(true)
+		db.SetIndexingCacheSize(true)
+		db.ensureIndexingCacheBoostApplied()
+	}
+
 	defer func() {
 		// Recover from any panics to prevent crashing the entire service.
 		if r := recover(); r != nil {
@@ -4121,14 +4535,33 @@ func (db *MediaDB) WaitForBackgroundOperations() {
 // single connection for all foreground reads) and restores the steady-state
 // size afterwards. Safe to call around a Recreate: it always acts on the
 // currently-loaded pool.
+//
+// The idle cap is kept equal to the open cap on purpose, and this is a
+// correctness requirement rather than a pooling tweak: database/sql defaults
+// MaxIdleConns to 2, so a boosted pool of 3 would close its third connection
+// whenever it went idle and silently reopen a fresh one under load. Connection
+// pragmas do not survive that. SetWALAutoCheckpoint only reaches connections it
+// can drain when it is called, so a reopened connection comes back at SQLite's
+// compiled wal_autocheckpoint default instead of the 0 indexing requires, and a
+// write landing on it can trigger an automatic checkpoint outside
+// checkpointLargeWAL's explicit, measured path. Observed once on device during
+// #1279: a pooled connection reported SQLite's compiled default of 1000 pages
+// where indexing had set 0, with the pool size unchanged across the window, so
+// a reopened connection was the only explanation. Matching the caps keeps the
+// boosted connection alive for the whole run so its pragmas stay applied.
 func (db *MediaDB) SetIndexingConnBoost(active bool) {
 	sqlInstance := db.sql.Load()
 	if sqlInstance == nil {
 		return
 	}
+	// Order matters when shrinking: database/sql silently clamps MaxIdleConns
+	// down to MaxOpenConns, so lower the idle cap first to avoid leaving it
+	// above the new open cap.
 	if active {
 		sqlInstance.SetMaxOpenConns(indexingMaxOpenConns)
+		sqlInstance.SetMaxIdleConns(indexingMaxOpenConns)
 	} else {
+		sqlInstance.SetMaxIdleConns(baseMaxOpenConns)
 		sqlInstance.SetMaxOpenConns(baseMaxOpenConns)
 	}
 }

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -237,18 +237,53 @@ func (db *MediaDB) conn() sqlQueryable {
 	return db.sql.Load()
 }
 
+// readConn returns the pool handle for a read that must not wait on the writer.
+//
+// sqlMu exists to guard db.tx and the batch inserters — the fields conn() reads
+// — not the connection handle, which is an atomic pointer swapped without the
+// mutex by Recreate (see the Conn invariant in pkg/database/conn.go). A read
+// that goes straight to the pool therefore gains nothing from RLock, and pays
+// for it: CommitTransactionWithOptions holds sqlMu exclusively for the whole
+// commit, and Go's RWMutex is writer-preferring, so every such read queued
+// behind it for the commit's full duration.
+//
+// Measured on the #1279 device mid-index: a media.scrape.status call starting
+// at 13:25:44 took 25,030 ms, and the C64 batch commit that started at the same
+// second took 25,123 ms — the read was blocked for exactly the commit. With the
+// API timeout at 30 s that left no headroom. Browse already reads this way
+// (beginBrowse), so this only brings the metadata reads into line with it.
+//
+// Racing a Recreate is the documented behaviour of Conn: the reader sees either
+// the old handle, which fails cleanly with "database is closed", or the new one.
+func (db *MediaDB) readConn() (*sql.DB, error) {
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
+		return nil, ErrNullSQL
+	}
+	return sqlDB, nil
+}
+
 // invalidationScope describes what data was changed to determine cache invalidation scope
 type invalidationScope struct {
 	SystemIDs               []string
 	AllSystems              bool
 	PreserveSlugSearchCache bool
+	PreserveTagCache        bool
 	UtilityTagDBIDsChanged  bool
 	MediaRowsChanged        bool
 }
 
 // invalidateCaches handles all cache invalidation in one place.
 func (db *MediaDB) invalidateCaches(scope invalidationScope) {
-	db.inMemoryTagCache.Store(nil)
+	// Rebuilding the tag list aggregates every MediaTags and MediaTitleTags
+	// row (731,332 on the #1279 device) into ~25,000 tags. That is affordable
+	// once after a commit, but indexing commits per batch, so media.tags then
+	// pays it on every call and exceeded the 30s API timeout on device. During
+	// indexing the last-good list is served instead and the end-of-run rebuild
+	// republishes it — the same trade already made for the slug search cache.
+	if !scope.PreserveTagCache {
+		db.inMemoryTagCache.Store(nil)
+	}
 	db.systemMediaCountsCache.Store(nil)
 	db.systemMediaCountsGen.Add(1)
 	if scope.MediaRowsChanged {
@@ -262,10 +297,22 @@ func (db *MediaDB) invalidateCaches(scope invalidationScope) {
 		db.utilityTagCacheDirty = false
 	}
 	switch {
+	case scope.PreserveSlugSearchCache:
+		// An indexing run publishes each system's new entries as it commits
+		// (refreshMidScanCaches), so the commit itself must leave the cache
+		// alone — in both scopes. Removing the systems here instead makes a
+		// search that names them unservable from memory, and a library-wide
+		// search names every system, so the whole request drops onto the
+		// grouped SQL LIKE path for as long as the run lasts. Measured on the
+		// #1279 device mid-index: 242 ms for a query across 28 covered systems
+		// against 27,205 ms for the same query across all of them.
+		//
+		// Nothing is served wrongly in the meantime. The cache only nominates
+		// candidate title IDs and the rows come from a live query, so entries
+		// whose rows have gone return nothing; only files added since the last
+		// run are missing, and only until their system commits.
 	case scope.AllSystems:
-		if !scope.PreserveSlugSearchCache {
-			db.slugSearchCache.Store(nil)
-		}
+		db.slugSearchCache.Store(nil)
 	case len(scope.SystemIDs) > 0:
 		if cache := db.slugSearchCache.Load(); cache != nil {
 			db.slugSearchCache.Store(cache.withoutSystems(scope.SystemIDs))
@@ -1181,12 +1228,11 @@ func (db *MediaDB) UpdateLastGenerated() error {
 }
 
 func (db *MediaDB) GetLastGenerated() (time.Time, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return time.Time{}, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return time.Time{}, err
 	}
-	return sqlGetLastGenerated(db.ctx, db.sql.Load())
+	return sqlGetLastGenerated(db.ctx, sqlDB)
 }
 
 func (db *MediaDB) SetOptimizationStatus(status string) error {
@@ -1199,12 +1245,11 @@ func (db *MediaDB) SetOptimizationStatus(status string) error {
 }
 
 func (db *MediaDB) GetOptimizationStatus() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetOptimizationStatus(db.ctx, db.sql.Load())
+	return sqlGetOptimizationStatus(db.ctx, sqlDB)
 }
 
 // IsOptimizing reports whether the database is currently undergoing any
@@ -1267,24 +1312,22 @@ func (db *MediaDB) SetOptimizationStep(step string) error {
 }
 
 func (db *MediaDB) GetOptimizationStep() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetOptimizationStep(db.ctx, db.sql.Load())
+	return sqlGetOptimizationStep(db.ctx, sqlDB)
 }
 
 // GetIndexResumeAttempts returns the number of consecutive automatic resume
 // attempts that found no durable indexing progress since the previous resume.
 // It resets to zero once indexing reaches a clean state or the resume checkpoint moves.
 func (db *MediaDB) GetIndexResumeAttempts() (int, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return 0, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return 0, err
 	}
-	return sqlGetIndexResumeAttempts(db.ctx, db.sql.Load())
+	return sqlGetIndexResumeAttempts(db.ctx, sqlDB)
 }
 
 // IncrementIndexResumeAttempts bumps the no-progress resume-attempt counter and
@@ -1322,12 +1365,11 @@ func (db *MediaDB) ResetIndexResumeAttempts() error {
 // GetIndexResumeCheckpoint returns the durable indexing checkpoint observed at
 // the previous auto-resume. A changed checkpoint proves the index made progress.
 func (db *MediaDB) GetIndexResumeCheckpoint() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetIndexResumeCheckpoint(db.ctx, db.sql.Load())
+	return sqlGetIndexResumeCheckpoint(db.ctx, sqlDB)
 }
 
 // SetIndexResumeCheckpoint stores the durable indexing checkpoint observed at
@@ -1351,12 +1393,11 @@ func (db *MediaDB) SetIndexingStatus(status string) error {
 }
 
 func (db *MediaDB) GetIndexingStatus() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetIndexingStatus(db.ctx, db.sql.Load())
+	return sqlGetIndexingStatus(db.ctx, sqlDB)
 }
 
 // QuickCheck runs PRAGMA quick_check(1) and reports whether the database passes.
@@ -1365,13 +1406,12 @@ func (db *MediaDB) GetIndexingStatus() (string, error) {
 // is cheap enough to confirm suspected corruption before acting on it. Returns
 // ok=true only when SQLite reports the single sentinel row "ok".
 func (db *MediaDB) QuickCheck() (bool, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return false, ErrNullSQL
+	sqlDB, connErr := db.readConn()
+	if connErr != nil {
+		return false, connErr
 	}
 
-	rows, err := db.sql.Load().QueryContext(db.ctx, "PRAGMA quick_check(1)")
+	rows, err := sqlDB.QueryContext(db.ctx, "PRAGMA quick_check(1)")
 	if err != nil {
 		return false, fmt.Errorf("quick_check query failed: %w", err)
 	}
@@ -1430,12 +1470,11 @@ func (db *MediaDB) NoteCorruption(err error) bool {
 // corruption fingerprint in the logs — which are uploadable via the support bundle — when
 // the database file itself cannot be retrieved. A healthy database returns a single "ok" row.
 func (db *MediaDB) IntegrityReport() []string {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
+	sqlDB, err := db.readConn()
+	if err != nil {
 		return []string{"integrity check unavailable: database not connected"}
 	}
-	return database.IntegrityReport(db.ctx, db.sql.Load(), database.DefaultIntegrityReportRows)
+	return database.IntegrityReport(db.ctx, sqlDB, database.DefaultIntegrityReportRows)
 }
 
 // Recreate discards the database file and reopens a fresh one. The main file and
@@ -1550,12 +1589,11 @@ func (db *MediaDB) SetScrapingStatus(status string) error {
 }
 
 func (db *MediaDB) GetScrapingStatus() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetScrapingStatus(db.ctx, db.sql.Load())
+	return sqlGetScrapingStatus(db.ctx, sqlDB)
 }
 
 func (db *MediaDB) SetScrapingOperation(operation database.ScrapingOperation) error {
@@ -1568,12 +1606,11 @@ func (db *MediaDB) SetScrapingOperation(operation database.ScrapingOperation) er
 }
 
 func (db *MediaDB) GetScrapingOperation() (database.ScrapingOperation, bool, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return database.ScrapingOperation{}, false, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return database.ScrapingOperation{}, false, err
 	}
-	return sqlGetScrapingOperation(db.ctx, db.sql.Load())
+	return sqlGetScrapingOperation(db.ctx, sqlDB)
 }
 
 func (db *MediaDB) ClearScrapingOperation() error {
@@ -1595,12 +1632,11 @@ func (db *MediaDB) SetLastIndexedSystem(systemID string) error {
 }
 
 func (db *MediaDB) GetLastIndexedSystem() (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
-	return sqlGetLastIndexedSystem(db.ctx, db.sql.Load())
+	return sqlGetLastIndexedSystem(db.ctx, sqlDB)
 }
 
 // RecomputeTitleDisambiguation recomputes the stored disambiguating tag types
@@ -1631,12 +1667,11 @@ func (db *MediaDB) RecomputeSystemDisambiguation(ctx context.Context, systemDBID
 // IndexGeneration returns the monotonic counter that's bumped on every
 // successful indexing run. Returns 0 if no indexing has completed yet.
 func (db *MediaDB) IndexGeneration() (int64, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return 0, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return 0, err
 	}
-	return sqlGetIndexGeneration(db.ctx, db.sql.Load())
+	return sqlGetIndexGeneration(db.ctx, sqlDB)
 }
 
 // BumpIndexGeneration increments the index generation counter and returns
@@ -1664,12 +1699,11 @@ func (db *MediaDB) SetIndexingSystems(systemIDs []string) error {
 }
 
 func (db *MediaDB) GetIndexingSystems() ([]string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return nil, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return nil, err
 	}
-	return sqlGetIndexingSystems(db.ctx, db.sql.Load())
+	return sqlGetIndexingSystems(db.ctx, sqlDB)
 }
 
 func (db *MediaDB) SetIndexingPlanSystems(systemIDs []string) error {
@@ -1682,12 +1716,11 @@ func (db *MediaDB) SetIndexingPlanSystems(systemIDs []string) error {
 }
 
 func (db *MediaDB) GetIndexingPlanSystems() ([]string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-	if db.sql.Load() == nil {
-		return nil, ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return nil, err
 	}
-	return sqlGetIndexingPlanSystems(db.ctx, db.sql.Load())
+	return sqlGetIndexingPlanSystems(db.ctx, sqlDB)
 }
 
 func (db *MediaDB) UnsafeGetSQLDb() *sql.DB {
@@ -1799,6 +1832,9 @@ func (db *MediaDB) applySchemaReadyFixups() {
 	}
 }
 
+// Vacuum keeps sqlMu, unlike the metadata reads that moved to readConn: it
+// rewrites the whole database rather than reading it, and no client request
+// reaches it, so there is nothing to gain by letting it overlap a commit.
 func (db *MediaDB) Vacuum() error {
 	db.sqlMu.RLock()
 	defer db.sqlMu.RUnlock()
@@ -2573,6 +2609,7 @@ func (db *MediaDB) CommitTransactionWithOptions(options database.TransactionOpti
 	case indexingStatus == IndexingStatusRunning || indexingStatus == IndexingStatusPending:
 		scope = db.cacheInvalidationScopeForCommittedTransaction()
 		scope.PreserveSlugSearchCache = true
+		scope.PreserveTagCache = true
 		indexingBatchCommit = true
 	default:
 		scope = db.cacheInvalidationScopeForCommittedTransaction()
@@ -2655,6 +2692,8 @@ func (*MediaDB) CreateIndexes() error {
 	return nil
 }
 
+// Analyze keeps sqlMu for the same reason as Vacuum: it writes planner
+// statistics and sits off the client request path.
 func (db *MediaDB) Analyze() error {
 	db.sqlMu.RLock()
 	defer db.sqlMu.RUnlock()
@@ -2773,64 +2812,75 @@ func (db *MediaDB) WALCheckpoint() error {
 // BrowseDirectories returns distinct immediate subdirectory names under the given path prefix.
 // Browse call timing thresholds. Above the first a call is reported at info so
 // it survives the default log level; above the second it is a warn.
-const (
+// Vars, not consts, only so tests can lower them; production never mutates.
+var (
 	browseTimingLogThreshold  = 250 * time.Millisecond
 	browseTimingWarnThreshold = 5 * time.Second
 )
 
-// poolWaitSample captures database/sql's cumulative connection-wait counters.
+// browseCall pins one pooled connection for the duration of a browse request
+// and records how long it took to get one.
 //
-// These are POOL-WIDE totals, not per-caller: a delta across one browse call
-// includes time other goroutines spent blocked in the same window. That is
-// still the measurement needed here, because the open question is whether a
-// slow browse is executing SQL or queued behind the indexing writer for a
-// connection, and the logs cannot currently tell those apart. A near-zero
-// delta rules contention out; a large one says the pool was saturated, without
-// attributing the wait to this specific call.
-type poolWaitSample struct {
-	waitCount    int64
-	waitDuration time.Duration
+// Two reasons it acquires explicitly rather than handing sqlBrowse* the pool.
+// First attribution: a browse blocked waiting for a connection and one running
+// expensive SQL are indistinguishable in the logs otherwise, and pool-wide
+// wait counters cannot separate this caller's wait from any other goroutine's.
+// Second cost: a single browse request issues several statements, and against
+// the pool each one queues for a connection independently — a browse was
+// observed making dozens of acquisitions while the pool sat saturated. One
+// connection for the whole request replaces those with a single wait, and the
+// statements then see a consistent snapshot as a side benefit.
+type browseCall struct {
+	started time.Time
+	conn    *sql.Conn
+	op      string
+	wait    time.Duration
+	routes  int
 }
 
-func samplePoolWait(sqlDB *sql.DB) poolWaitSample {
+// beginBrowse acquires the request's connection. The caller must always call
+// finish, including on error, so the connection is released.
+func (db *MediaDB) beginBrowse(ctx context.Context, op string, routes int) (*browseCall, error) {
+	sqlDB := db.sql.Load()
 	if sqlDB == nil {
-		return poolWaitSample{}
+		return nil, ErrNullSQL
 	}
-	stats := sqlDB.Stats()
-	return poolWaitSample{waitCount: stats.WaitCount, waitDuration: stats.WaitDuration}
+	started := time.Now()
+	conn, err := sqlDB.Conn(ctx)
+	wait := time.Since(started)
+	if err != nil {
+		return nil, fmt.Errorf("browse %s: failed to acquire connection after %v: %w", op, wait, err)
+	}
+	return &browseCall{conn: conn, op: op, routes: routes, started: started, wait: wait}, nil
 }
 
-// logBrowseTiming splits a browse call's wall time into time the pool spent
-// handing out connections and time spent doing work. Browse is the one
-// foreground path that runs concurrently with indexing, so this is where the
-// distinction decides whether to fix the query or the concurrency.
-func (db *MediaDB) logBrowseTiming(op string, routes int, started time.Time, before poolWaitSample) {
-	elapsed := time.Since(started)
+func (c *browseCall) finish(db *MediaDB) {
+	if err := c.conn.Close(); err != nil {
+		log.Warn().Err(err).Str("op", c.op).Msg("failed to release browse connection")
+	}
+	elapsed := time.Since(c.started)
 	if elapsed < browseTimingLogThreshold {
 		return
 	}
 	sqlDB := db.sql.Load()
-	after := samplePoolWait(sqlDB)
-	connWait := after.waitDuration - before.waitDuration
-
 	event := log.Info()
 	if elapsed > browseTimingWarnThreshold {
 		event = log.Warn()
 	}
 	event = logPoolStats(event, sqlDB)
 	event = event.
-		Str("op", op).
+		Str("op", c.op).
 		Dur("elapsed", elapsed).
-		Dur("poolConnWait", connWait).
-		Int64("poolConnWaitCount", after.waitCount-before.waitCount).
-		Dur("nonWait", elapsed-connWait).
+		// connWait is this call's own queueing time, measured across its single
+		// acquisition, so work is always elapsed minus it and never negative.
+		Dur("connWait", c.wait).
+		Dur("work", elapsed-c.wait).
+		Bool("boosted", db.indexingCacheBoost.Load())
+	if c.routes > 0 {
 		// The overlay query joins Media once per source route and re-checks
 		// higher-priority routes per candidate row, so cost rises faster than
-		// route count. On the same line as the wait so the two are comparable
-		// without matching timestamps across log entries.
-		Bool("boosted", db.indexingCacheBoost.Load())
-	if routes > 0 {
-		event = event.Int("routes", routes)
+		// route count does. Reported here so the two are comparable on one line.
+		event = event.Int("routes", c.routes)
 	}
 	event.Msg("browse call timing")
 }
@@ -2841,11 +2891,12 @@ func (db *MediaDB) BrowseDirectories(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() {
-		db.logBrowseTiming("browse directories", len(browseOverlaySources(opts.Overlay)), started, wait)
-	}()
-	results, err := sqlBrowseDirectories(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse directories", len(browseOverlaySources(opts.Overlay)))
+	if err != nil {
+		return nil, err
+	}
+	defer call.finish(db)
+	results, err := sqlBrowseDirectories(ctx, call.conn, opts)
 	db.NoteCorruption(err)
 	return results, err
 }
@@ -2859,9 +2910,12 @@ func (db *MediaDB) BrowseFiles(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() { db.logBrowseTiming("browse files", len(browseOverlaySources(opts.Overlay)), started, wait) }()
-	results, err := sqlBrowseFiles(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse files", len(browseOverlaySources(opts.Overlay)))
+	if err != nil {
+		return nil, err
+	}
+	defer call.finish(db)
+	results, err := sqlBrowseFiles(ctx, call.conn, opts)
 	db.NoteCorruption(err)
 	return results, err
 }
@@ -2897,11 +2951,12 @@ func (db *MediaDB) BrowseFileCount(
 	if db.sql.Load() == nil {
 		return 0, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() {
-		db.logBrowseTiming("browse file count", len(browseOverlaySources(opts.Overlay)), started, wait)
-	}()
-	return sqlBrowseFileCount(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse file count", len(browseOverlaySources(opts.Overlay)))
+	if err != nil {
+		return 0, err
+	}
+	defer call.finish(db)
+	return sqlBrowseFileCount(ctx, call.conn, opts)
 }
 
 // BrowseDirCount returns the total number of immediate child directories under a path prefix.
@@ -2927,7 +2982,12 @@ func (db *MediaDB) BrowseIndex(
 	if db.sql.Load() == nil {
 		return database.BrowseIndexResult{}, ErrNullSQL
 	}
-	return sqlBrowseIndex(ctx, db.sql.Load(), &opts)
+	call, err := db.beginBrowse(ctx, "browse index", len(browseOverlaySources(opts.Overlay)))
+	if err != nil {
+		return database.BrowseIndexResult{}, err
+	}
+	defer call.finish(db)
+	return sqlBrowseIndex(ctx, call.conn, &opts)
 }
 
 // BrowseVirtualSchemes returns distinct URI schemes present in indexed media.
@@ -2949,9 +3009,12 @@ func (db *MediaDB) BrowseRootCounts(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() { db.logBrowseTiming("browse root counts", len(rootDirs), started, wait) }()
-	return sqlBrowseRootCounts(ctx, db.sql.Load(), rootDirs)
+	call, err := db.beginBrowse(ctx, "browse root counts", len(rootDirs))
+	if err != nil {
+		return nil, err
+	}
+	defer call.finish(db)
+	return sqlBrowseRootCounts(ctx, call.conn, rootDirs)
 }
 
 // BrowseRouteCounts returns populated route counts for system-scoped browse roots.
@@ -2961,9 +3024,12 @@ func (db *MediaDB) BrowseRouteCounts(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() { db.logBrowseTiming("browse route counts", 0, started, wait) }()
-	return sqlBrowseRouteCounts(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse route counts", 0)
+	if err != nil {
+		return nil, err
+	}
+	defer call.finish(db)
+	return sqlBrowseRouteCounts(ctx, call.conn, opts)
 }
 
 // BrowseSystemRootCandidates returns, in two batched queries, the immediate
@@ -2976,11 +3042,12 @@ func (db *MediaDB) BrowseSystemRootCandidates(
 	if db.sql.Load() == nil {
 		return database.BrowseSystemRootCandidates{}, false, ErrNullSQL
 	}
-	started, wait := time.Now(), samplePoolWait(db.sql.Load())
-	defer func() {
-		db.logBrowseTiming("browse system root candidates", len(opts.Roots), started, wait)
-	}()
-	return sqlBrowseSystemRootCandidates(ctx, db.sql.Load(), opts)
+	call, err := db.beginBrowse(ctx, "browse system root candidates", len(opts.Roots))
+	if err != nil {
+		return database.BrowseSystemRootCandidates{}, false, err
+	}
+	defer call.finish(db)
+	return sqlBrowseSystemRootCandidates(ctx, call.conn, opts)
 }
 
 // PopulateBrowseCache rebuilds the BrowseCache table from the current Media data.
@@ -3200,6 +3267,21 @@ func (db *MediaDB) SearchMediaWithFilters(
 			Int("maxQueryParams", sqliteMaxParams).
 			Str("sort", filters.Sort).
 			Msg("media search cache candidates exceed SQLite parameter budget")
+	}
+
+	// A cache that covered the whole library and is only missing the systems
+	// currently being re-indexed does not need a wholesale fallback: serve the
+	// covered systems from memory and scope the SQL to the few in flight. On
+	// the #1279 device the alternative was eight grouped LIKE queries across
+	// 293 systems for every search, every one of which hit the API timeout.
+	if cacheableGroups && !cacheReady {
+		if cached, viaSQL, ok := cache.PartitionServableSystems(systemIDs); ok && len(cached) > 0 {
+			log.Debug().
+				Int("cachedSystems", len(cached)).
+				Int("sqlSystems", len(viaSQL)).
+				Msg("media search splitting between cache and scoped SQL")
+			return db.searchSplitAcrossCacheAndSQL(ctx, cached, viaSQL, qWords, filters)
+		}
 	}
 
 	// Search each media type separately so one type's normalization does not
@@ -4684,24 +4766,20 @@ func (db *MediaDB) BackgroundOperationDone() {
 
 // GetLaunchCommandForMedia generates a title-based launch command for the given media.
 func (db *MediaDB) GetLaunchCommandForMedia(ctx context.Context, systemID, path string) (string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-
-	if db.sql.Load() == nil {
-		return "", ErrNullSQL
+	sqlDB, err := db.readConn()
+	if err != nil {
+		return "", err
 	}
 
-	return sqlGetLaunchCommandForMedia(ctx, db.sql.Load(), systemID, path)
+	return sqlGetLaunchCommandForMedia(ctx, sqlDB, systemID, path)
 }
 
 // CheckForDuplicateMediaTitles returns any MediaTitle records that have duplicate (SystemDBID, Slug) combinations.
 // Used in tests to validate data integrity after selective updates.
 func (db *MediaDB) CheckForDuplicateMediaTitles() ([]string, error) {
-	db.sqlMu.RLock()
-	defer db.sqlMu.RUnlock()
-
-	if db.sql.Load() == nil {
-		return nil, ErrNullSQL
+	sqlDB, connErr := db.readConn()
+	if connErr != nil {
+		return nil, connErr
 	}
 
 	query := `
@@ -4711,7 +4789,7 @@ func (db *MediaDB) CheckForDuplicateMediaTitles() ([]string, error) {
 		HAVING cnt > 1
 	`
 
-	rows, err := db.sql.Load().QueryContext(db.ctx, query)
+	rows, err := sqlDB.QueryContext(db.ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query duplicate media titles: %w", err)
 	}

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2771,12 +2771,80 @@ func (db *MediaDB) WALCheckpoint() error {
 }
 
 // BrowseDirectories returns distinct immediate subdirectory names under the given path prefix.
+// Browse call timing thresholds. Above the first a call is reported at info so
+// it survives the default log level; above the second it is a warn.
+const (
+	browseTimingLogThreshold  = 250 * time.Millisecond
+	browseTimingWarnThreshold = 5 * time.Second
+)
+
+// poolWaitSample captures database/sql's cumulative connection-wait counters.
+//
+// These are POOL-WIDE totals, not per-caller: a delta across one browse call
+// includes time other goroutines spent blocked in the same window. That is
+// still the measurement needed here, because the open question is whether a
+// slow browse is executing SQL or queued behind the indexing writer for a
+// connection, and the logs cannot currently tell those apart. A near-zero
+// delta rules contention out; a large one says the pool was saturated, without
+// attributing the wait to this specific call.
+type poolWaitSample struct {
+	waitCount    int64
+	waitDuration time.Duration
+}
+
+func samplePoolWait(sqlDB *sql.DB) poolWaitSample {
+	if sqlDB == nil {
+		return poolWaitSample{}
+	}
+	stats := sqlDB.Stats()
+	return poolWaitSample{waitCount: stats.WaitCount, waitDuration: stats.WaitDuration}
+}
+
+// logBrowseTiming splits a browse call's wall time into time the pool spent
+// handing out connections and time spent doing work. Browse is the one
+// foreground path that runs concurrently with indexing, so this is where the
+// distinction decides whether to fix the query or the concurrency.
+func (db *MediaDB) logBrowseTiming(op string, routes int, started time.Time, before poolWaitSample) {
+	elapsed := time.Since(started)
+	if elapsed < browseTimingLogThreshold {
+		return
+	}
+	sqlDB := db.sql.Load()
+	after := samplePoolWait(sqlDB)
+	connWait := after.waitDuration - before.waitDuration
+
+	event := log.Info()
+	if elapsed > browseTimingWarnThreshold {
+		event = log.Warn()
+	}
+	event = logPoolStats(event, sqlDB)
+	event = event.
+		Str("op", op).
+		Dur("elapsed", elapsed).
+		Dur("poolConnWait", connWait).
+		Int64("poolConnWaitCount", after.waitCount-before.waitCount).
+		Dur("nonWait", elapsed-connWait).
+		// The overlay query joins Media once per source route and re-checks
+		// higher-priority routes per candidate row, so cost rises faster than
+		// route count. On the same line as the wait so the two are comparable
+		// without matching timestamps across log entries.
+		Bool("boosted", db.indexingCacheBoost.Load())
+	if routes > 0 {
+		event = event.Int("routes", routes)
+	}
+	event.Msg("browse call timing")
+}
+
 func (db *MediaDB) BrowseDirectories(
 	ctx context.Context, opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() {
+		db.logBrowseTiming("browse directories", len(browseOverlaySources(opts.Overlay)), started, wait)
+	}()
 	results, err := sqlBrowseDirectories(ctx, db.sql.Load(), opts)
 	db.NoteCorruption(err)
 	return results, err
@@ -2791,6 +2859,8 @@ func (db *MediaDB) BrowseFiles(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() { db.logBrowseTiming("browse files", len(browseOverlaySources(opts.Overlay)), started, wait) }()
 	results, err := sqlBrowseFiles(ctx, db.sql.Load(), opts)
 	db.NoteCorruption(err)
 	return results, err
@@ -2827,6 +2897,10 @@ func (db *MediaDB) BrowseFileCount(
 	if db.sql.Load() == nil {
 		return 0, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() {
+		db.logBrowseTiming("browse file count", len(browseOverlaySources(opts.Overlay)), started, wait)
+	}()
 	return sqlBrowseFileCount(ctx, db.sql.Load(), opts)
 }
 
@@ -2875,6 +2949,8 @@ func (db *MediaDB) BrowseRootCounts(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() { db.logBrowseTiming("browse root counts", len(rootDirs), started, wait) }()
 	return sqlBrowseRootCounts(ctx, db.sql.Load(), rootDirs)
 }
 
@@ -2885,6 +2961,8 @@ func (db *MediaDB) BrowseRouteCounts(
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() { db.logBrowseTiming("browse route counts", 0, started, wait) }()
 	return sqlBrowseRouteCounts(ctx, db.sql.Load(), opts)
 }
 
@@ -2898,6 +2976,10 @@ func (db *MediaDB) BrowseSystemRootCandidates(
 	if db.sql.Load() == nil {
 		return database.BrowseSystemRootCandidates{}, false, ErrNullSQL
 	}
+	started, wait := time.Now(), samplePoolWait(db.sql.Load())
+	defer func() {
+		db.logBrowseTiming("browse system root candidates", len(opts.Roots), started, wait)
+	}()
 	return sqlBrowseSystemRootCandidates(ctx, db.sql.Load(), opts)
 }
 

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3029,10 +3029,18 @@ func TestMediaDB_CommitTransaction_IndexingPreservesLastGoodSlugCache_Integratio
 
 	insertGame(nesSystem, "Super Mario Bros Redux", filepath.Join("roms", "nes", "smb-redux.nes"))
 
+	// The commit leaves the cache alone, including for the system being
+	// indexed. Its entries are replaced when the scanner refreshes that system
+	// after the commit; removing them here would make any search naming it
+	// unservable from memory, and a library-wide search names every system.
+	// Serving them meanwhile is safe: the cache only nominates candidate title
+	// IDs and the rows come from a live query, so the newly inserted title is
+	// simply not offered yet.
 	cache = mediaDB.slugSearchCache.Load()
 	require.NotNil(t, cache)
-	assert.False(t, cache.complete)
-	assert.False(t, cache.CanServeSystems([]string{nesSystem.ID}))
+	assert.True(t, cache.complete)
+	assert.True(t, cache.CanServeSystems([]string{nesSystem.ID}),
+		"the system being indexed must stay servable from the cache")
 	assert.True(t, cache.CanServeSystems([]string{snesSystem.ID}))
 	_, found = mediaDB.GetCachedStats(context.Background(), statsQuery)
 	assert.False(t, found, "indexing commits should invalidate stale MediaCountCache while preserving slug cache")

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3370,6 +3370,108 @@ func TestPopulateBrowseCacheForSystems_IncrementalRefresh_Integration(t *testing
 	assert.Equal(t, 2, rootDirs[0].FileCount)
 }
 
+// browseCacheDirShape describes every cached dir by path rather than DBID, so
+// two caches built with different DBID assignments stay comparable.
+func browseCacheDirShape(t *testing.T, mediaDB *MediaDB) map[string]string {
+	t.Helper()
+
+	rows, err := mediaDB.sql.Load().QueryContext(context.Background(), `
+		SELECT d.Path, COALESCE(p.Path, ''), d.Name, d.IsVirtual
+		FROM BrowseDirs d
+		LEFT JOIN BrowseDirs p ON p.DBID = d.ParentDirDBID`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	shape := make(map[string]string)
+	for rows.Next() {
+		var dirPath, parentPath, name string
+		var isVirtual bool
+		require.NoError(t, rows.Scan(&dirPath, &parentPath, &name, &isVirtual))
+		shape[dirPath] = fmt.Sprintf("parent=%s name=%s virtual=%t", parentPath, name, isVirtual)
+	}
+	require.NoError(t, rows.Err())
+	return shape
+}
+
+// browseCacheCountShape keys counts by dir paths and SystemID for the same
+// reason as browseCacheDirShape.
+func browseCacheCountShape(t *testing.T, mediaDB *MediaDB) map[string]int {
+	t.Helper()
+
+	rows, err := mediaDB.sql.Load().QueryContext(context.Background(), `
+		SELECT p.Path, c.Path, s.SystemID, bc.FileCount
+		FROM BrowseDirCounts bc
+		JOIN BrowseDirs p ON p.DBID = bc.ParentDirDBID
+		JOIN BrowseDirs c ON c.DBID = bc.ChildDirDBID
+		JOIN Systems s ON s.DBID = bc.SystemDBID`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	shape := make(map[string]int)
+	for rows.Next() {
+		var parentPath, childPath, systemID string
+		var count int
+		require.NoError(t, rows.Scan(&parentPath, &childPath, &systemID, &count))
+		shape[parentPath+"|"+childPath+"|"+systemID] = count
+	}
+	require.NoError(t, rows.Err())
+	return shape
+}
+
+// TestPopulateBrowseCacheForSystems_MatchesFullRebuild_Integration pins the
+// per-system refresh against the full rebuild, which is the ground truth for
+// the cache's shape.
+//
+// The refresh resolves already-persisted dirs one path at a time instead of
+// loading BrowseDirs whole. A lookup that failed to find a shared dir would
+// mint a second DBID for it and split that dir's counts across two rows —
+// invisible to a DBID-keyed assertion, which is why both shapes are keyed by
+// path.
+func TestPopulateBrowseCacheForSystems_MatchesFullRebuild_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	// Shared ancestors, differing depths, one dir shared by two systems, and a
+	// virtual scheme — the shapes ensureDir resolves differently.
+	media := []struct {
+		systemID string
+		title    string
+		path     string
+	}{
+		{systemID: "SNES", title: "Super RPG", path: "/roms/snes/super-rpg.sfc"},
+		{systemID: "SNES", title: "Deep Quest", path: "/roms/snes/hacks/translated/deep-quest.sfc"},
+		{systemID: "NES", title: "Mario", path: "/roms/nes/mario.nes"},
+		{systemID: "NES", title: "Shared Cart", path: "/roms/multi/shared-cart.nes"},
+		{systemID: "Genesis", title: "Sonic", path: "/roms/multi/sonic.md"},
+		{systemID: "Genesis", title: "Streamed", path: "steam://run/12345"},
+	}
+	for _, m := range media {
+		sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: m.systemID, Name: m.systemID})
+		require.NoError(t, err)
+		insertSystemMedia(t, mediaDB, sys, m.title, m.path)
+	}
+
+	// One system at a time, exactly as a running index refreshes them.
+	for _, systemID := range []string{"SNES", "NES", "Genesis"} {
+		require.NoError(t, mediaDB.PopulateBrowseCacheForSystems(ctx, []string{systemID}))
+	}
+	incrementalDirs := browseCacheDirShape(t, mediaDB)
+	incrementalCounts := browseCacheCountShape(t, mediaDB)
+	require.NotEmpty(t, incrementalDirs)
+	require.NotEmpty(t, incrementalCounts)
+
+	require.NoError(t, mediaDB.PopulateBrowseCache(ctx))
+	assert.Equal(t, browseCacheDirShape(t, mediaDB), incrementalDirs,
+		"per-system refresh must build the same dirs as a full rebuild")
+	assert.Equal(t, browseCacheCountShape(t, mediaDB), incrementalCounts,
+		"per-system refresh must build the same counts as a full rebuild")
+}
+
 func TestBrowseFileCount_PartialCacheFallsBackForIncompleteCoverage_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/pkg/database/mediadb/migrations/20260825120000_drop_redundant_media_index.sql
+++ b/pkg/database/mediadb/migrations/20260825120000_drop_redundant_media_index.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- media_system_path_idx duplicated the index SQLite already maintains for
+-- Media's UNIQUE(SystemDBID, Path) constraint (sqlite_autoindex_Media_1): same
+-- columns, same order. Both were kept up to date on every Media insert and
+-- update, doubling b-tree maintenance on the indexing pipeline's hottest write
+-- path for no query benefit. Queries that need this access path now pin it with
+-- INDEXED BY sqlite_autoindex_Media_1, which produces an identical plan.
+-- Dropping it here so databases created before this migration also shed it;
+-- CreateSecondaryIndexes no longer recreates it after an index run.
+
+DROP INDEX IF EXISTS media_system_path_idx;
+
+-- +goose Down
+CREATE INDEX IF NOT EXISTS media_system_path_idx ON Media(SystemDBID, Path);

--- a/pkg/database/mediadb/optimization_stamp_test.go
+++ b/pkg/database/mediadb/optimization_stamp_test.go
@@ -1,0 +1,137 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// The browse-cache migrations stamp OptimizationStatus=pending unconditionally
+// so that existing databases rebuild their browse cache on upgrade. A brand-new
+// database runs the same chain, so it is born pending and the service then
+// "resumes" an optimization over zero media on first start.
+//
+// The stamp must stay for the upgrade path; these tests pin the narrow rule that
+// it is only cleared when there is provably nothing to optimize.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMigrateUp_ClearsOptimizationStampOnEmptyDB_Integration is the fix: a fresh
+// database must not come out of migration asking to be optimized.
+func TestMigrateUp_ClearsOptimizationStampOnEmptyDB_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	// setupTempMediaDB already migrated; a fresh DB has no media.
+	hasMedia, err := sqlMediaExists(context.Background(), mediaDB.sql.Load())
+	require.NoError(t, err)
+	require.False(t, hasMedia, "fixture should start with an empty database")
+
+	status, err := mediaDB.GetOptimizationStatus()
+	require.NoError(t, err)
+	assert.Empty(t, status,
+		"a fresh database must not be left with a pending optimization stamp; "+
+			"the service would resume a browse cache rebuild over zero media")
+
+	step, err := sqlGetOptimizationStep(context.Background(), mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Empty(t, step, "optimization step should be cleared alongside the status")
+}
+
+// TestClearOptimizationStampIfEmpty_KeepsStampWhenMediaExists_Integration is the
+// other half: the upgrade path depends on the stamp surviving on a populated
+// database, so the guard must not touch it there.
+func TestClearOptimizationStampIfEmpty_KeepsStampWhenMediaExists_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	insertSystemWithMedia(t, mediaDB, "SNES", "Super RPG",
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "snes", "super-rpg.sfc")))
+
+	require.NoError(t, mediaDB.SetOptimizationStatus(IndexingStatusPending))
+	require.NoError(t, sqlSetOptimizationStep(ctx, mediaDB.sql.Load(), "browse_cache"))
+
+	require.NoError(t, mediaDB.clearOptimizationStampIfEmpty(ctx))
+
+	status, err := mediaDB.GetOptimizationStatus()
+	require.NoError(t, err)
+	assert.Equal(t, IndexingStatusPending, status,
+		"a database with media must keep its pending stamp — this is the upgrade path")
+
+	step, err := sqlGetOptimizationStep(ctx, mediaDB.sql.Load())
+	require.NoError(t, err)
+	assert.Equal(t, "browse_cache", step, "the resume step must survive too")
+}
+
+// TestAllocate_SeedsPlannerStats_Integration covers the Allocate path getting
+// the planner stat seed.
+//
+// This is the path Recreate uses: it reopens into a fresh database and starts a
+// reindex immediately, with no MigrateUp in between. The seed used to be hooked
+// only on MigrateUp, so every user-triggered rebuild reindexed against an empty
+// sqlite_stat1 — the planner regression #1279 started from.
+func TestAllocate_SeedsPlannerStats_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	// setupTempMediaDB goes through OpenMediaDB, whose fresh-database branch
+	// calls Allocate — not MigrateUp.
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	var seeded int
+	require.NoError(t, mediaDB.sql.Load().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM sqlite_stat1 WHERE tbl = 'Media'").Scan(&seeded))
+	assert.Positive(t, seeded,
+		"a freshly allocated database must carry seeded planner statistics; "+
+			"without them a rebuild reindexes against an empty sqlite_stat1")
+}
+
+// TestClearOptimizationStampIfEmpty_NoStampIsNoop_Integration guards against the
+// guard itself writing to a database that had nothing stamped.
+func TestClearOptimizationStampIfEmpty_NoStampIsNoop_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	require.NoError(t, sqlClearOptimizationStamp(ctx, mediaDB.sql.Load()))
+	require.NoError(t, mediaDB.clearOptimizationStampIfEmpty(ctx))
+
+	status, err := mediaDB.GetOptimizationStatus()
+	require.NoError(t, err)
+	assert.Empty(t, status)
+}

--- a/pkg/database/mediadb/optimization_test.go
+++ b/pkg/database/mediadb/optimization_test.go
@@ -66,8 +66,12 @@ func expectBrowseCacheStep(mock sqlmock.Sqlmock) {
 	mock.ExpectExec("INSERT OR REPLACE INTO DBConfig").
 		WithArgs(DBConfigOptimizationStep, "browse_cache").
 		WillReturnResult(sqlmock.NewResult(1, 1))
-	// PopulateBrowseCache: BEGIN, SELECT (empty), DELETEs, root dir insert,
-	// count prepare, COMMIT.
+	// PopulateBrowseCache pins a connection and disables foreign keys before
+	// opening its transaction — the unqualified DELETE below cascades otherwise
+	// (see acquireBrowseCacheConn, #1279). Then: BEGIN, SELECT (empty), DELETEs,
+	// root dir insert, count prepare, COMMIT, and the pragma is restored.
+	mock.ExpectExec("PRAGMA foreign_keys = OFF").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT m.SystemDBID, m.Path").
 		WillReturnRows(sqlmock.NewRows([]string{"SystemDBID", "Path"}))
@@ -87,6 +91,8 @@ func expectBrowseCacheStep(mock sqlmock.Sqlmock) {
 		WithArgs(DBConfigBrowseIndexComplete, "1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
+	mock.ExpectExec("PRAGMA foreign_keys = ON").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 }
 
 // expectDisambiguationBackfillStepNoop mocks the disambiguation_backfill step

--- a/pkg/database/mediadb/reads_during_commit_test.go
+++ b/pkg/database/mediadb/reads_during_commit_test.go
@@ -1,0 +1,181 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// readsBlockedByWriterTimeout bounds how long a client read may wait on the
+// writer. It is generous on purpose: the point is to separate "does not wait on
+// the writer at all" from "waits for the whole commit", and an indexing commit
+// on the #1279 device reaches 25 s.
+const readsBlockedByWriterTimeout = 5 * time.Second
+
+// clientRead names a MediaDB read that a client request can reach while an
+// index is running.
+type clientRead struct {
+	run  func(*MediaDB) error
+	name string
+}
+
+func clientReadsReachableDuringIndexing() []clientRead {
+	return []clientRead{
+		{name: "GetIndexingStatus", run: func(db *MediaDB) error {
+			_, err := db.GetIndexingStatus()
+			return err
+		}},
+		{name: "GetOptimizationStatus", run: func(db *MediaDB) error {
+			_, err := db.GetOptimizationStatus()
+			return err
+		}},
+		{name: "GetOptimizationStep", run: func(db *MediaDB) error {
+			_, err := db.GetOptimizationStep()
+			return err
+		}},
+		{name: "GetScrapingStatus", run: func(db *MediaDB) error {
+			_, err := db.GetScrapingStatus()
+			return err
+		}},
+		{name: "GetScrapingOperation", run: func(db *MediaDB) error {
+			_, _, err := db.GetScrapingOperation()
+			return err
+		}},
+		{name: "GetLastGenerated", run: func(db *MediaDB) error {
+			_, err := db.GetLastGenerated()
+			return err
+		}},
+		{name: "GetLastIndexedSystem", run: func(db *MediaDB) error {
+			_, err := db.GetLastIndexedSystem()
+			return err
+		}},
+		{name: "GetIndexingSystems", run: func(db *MediaDB) error {
+			_, err := db.GetIndexingSystems()
+			return err
+		}},
+		{name: "GetIndexingPlanSystems", run: func(db *MediaDB) error {
+			_, err := db.GetIndexingPlanSystems()
+			return err
+		}},
+		{name: "GetIndexResumeAttempts", run: func(db *MediaDB) error {
+			_, err := db.GetIndexResumeAttempts()
+			return err
+		}},
+		{name: "GetIndexResumeCheckpoint", run: func(db *MediaDB) error {
+			_, err := db.GetIndexResumeCheckpoint()
+			return err
+		}},
+		{name: "IndexGeneration", run: func(db *MediaDB) error {
+			_, err := db.IndexGeneration()
+			return err
+		}},
+		{name: "GetLaunchCommandForMedia", run: func(db *MediaDB) error {
+			_, err := db.GetLaunchCommandForMedia(context.Background(), "NES", "/games/NES/x.nes")
+			return err
+		}},
+		{name: "QuickCheck", run: func(db *MediaDB) error {
+			_, err := db.QuickCheck()
+			return err
+		}},
+		{name: "CheckForDuplicateMediaTitles", run: func(db *MediaDB) error {
+			_, err := db.CheckForDuplicateMediaTitles()
+			return err
+		}},
+		{name: "IntegrityReport", run: func(db *MediaDB) error {
+			db.IntegrityReport()
+			return nil
+		}},
+	}
+}
+
+// TestMediaDB_ClientReadsDoNotWaitOnWriterLock pins that a client-reachable
+// read never queues behind the indexing writer.
+//
+// CommitTransactionWithOptions holds sqlMu exclusively for the entire commit,
+// and Go's RWMutex is writer-preferring, so any read taking RLock waits for the
+// whole thing. Measured on the #1279 device mid-index, a media.scrape.status
+// call starting at 13:25:44 took 25,030 ms while the C64 batch commit starting
+// the same second took 25,123 ms — with the API timeout at 30 s that left no
+// headroom.
+//
+// Holding sqlMu directly rather than driving a real commit is deliberate: it
+// reproduces the exact condition these reads must survive, without depending on
+// how long a commit happens to take on the machine running the test.
+func TestMediaDB_ClientReadsDoNotWaitOnWriterLock(t *testing.T) {
+	t.Parallel()
+
+	for _, read := range clientReadsReachableDuringIndexing() {
+		t.Run(read.name, func(t *testing.T) {
+			t.Parallel()
+
+			mediaDB, cleanup := setupTempMediaDB(t)
+			defer cleanup()
+
+			// Stand in for a commit in flight.
+			mediaDB.sqlMu.Lock()
+			defer mediaDB.sqlMu.Unlock()
+
+			done := make(chan error, 1)
+			go func() { done <- read.run(mediaDB) }()
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(readsBlockedByWriterTimeout):
+				t.Fatalf("%s blocked on the writer lock; a client read must not wait "+
+					"for an indexing commit, which reaches 25s on device", read.name)
+			}
+		})
+	}
+}
+
+// TestMediaDB_ClientReadsSucceedDuringOpenTransaction is the counterpart with a
+// real writer: a batch transaction is open and holds the single SQLite writer,
+// and the reads must still answer from the pool rather than joining it.
+func TestMediaDB_ClientReadsSucceedDuringOpenTransaction(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	require.NoError(t, mediaDB.SetIndexingStatus(IndexingStatusRunning))
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	t.Cleanup(func() {
+		if mediaDB.inTransaction {
+			_ = mediaDB.RollbackTransaction()
+		}
+	})
+
+	for _, read := range clientReadsReachableDuringIndexing() {
+		done := make(chan error, 1)
+		go func() { done <- read.run(mediaDB) }()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err, "%s failed while an indexing transaction was open", read.name)
+		case <-time.After(readsBlockedByWriterTimeout):
+			t.Fatalf("%s did not complete while an indexing transaction was open", read.name)
+		}
+	}
+}

--- a/pkg/database/mediadb/scan_reconcile_accounting_test.go
+++ b/pkg/database/mediadb/scan_reconcile_accounting_test.go
@@ -1,0 +1,178 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// The reconcile step-timings line is a measurement instrument, and an
+// instrument that quietly loses time is worse than none: round 9 of #1279 read
+// its numbers as a phase breakdown when they in fact covered only 78% of
+// reconcile wall time on aggregate, and as little as 55% on some systems. The
+// missing time was four untimed steps plus pacing folded into a step that
+// yields inside its own loop.
+//
+// These tests pin the two properties that make the line trustworthy: the
+// entries reconstruct wall time, and pacing is never billed as SQL work.
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseStepTimings turns the joined "name=ms name=ms" field back into a map.
+//
+// Step names contain spaces ("insert tag links"), so the separator between
+// entries and the separator within a name are the same character. Entries are
+// recovered by accumulating tokens until one carries the "=": that token ends
+// the entry, and everything before it is part of the name.
+func parseStepTimings(t *testing.T, steps string) map[string]int64 {
+	t.Helper()
+	out := map[string]int64{}
+	var nameParts []string
+	for _, token := range strings.Fields(steps) {
+		idx := strings.Index(token, "=")
+		if idx < 0 {
+			nameParts = append(nameParts, token)
+			continue
+		}
+		ms, err := strconv.ParseInt(token[idx+1:], 10, 64)
+		require.NoError(t, err, "step entry %q must carry an integer ms value", token)
+		name := strings.Join(append(nameParts, token[:idx]), " ")
+		out[name] = ms
+		nameParts = nil
+	}
+	require.Empty(t, nameParts, "trailing tokens with no value in %q", steps)
+	return out
+}
+
+// TestChunkedStepTiming_PacingIsNotBilledAsSQL is the core guarantee for the
+// two steps that yield inside their own loops. Both call the scanner's pauser
+// between chunks; on the MiSTer that pauser sleeps roughly as long as the work
+// it follows, so a step that counted it would report double its real cost and
+// the time would also be counted a second time in the scanner's throttle
+// total.
+func TestChunkedStepTiming_PacingIsNotBilledAsSQL(t *testing.T) {
+	t.Parallel()
+
+	const (
+		rows        = scanUpsertMediaBatchSize + 25 // forces a second chunk, so yield runs twice
+		pausePerRun = 40 * time.Millisecond         // the MiSTer ThrottleBackground work window
+	)
+
+	ctx := context.Background()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+	stageSyntheticMedia(t, sqlDB, 1, rows)
+
+	yields := 0
+	yield := func() error {
+		yields++
+		time.Sleep(pausePerRun)
+		return nil
+	}
+
+	started := time.Now()
+	affected, timing, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", 1, yield)
+	wall := time.Since(started)
+	require.NoError(t, err)
+	require.EqualValues(t, rows, affected)
+	require.GreaterOrEqual(t, yields, 2, "test needs at least two chunks to be meaningful")
+
+	assert.GreaterOrEqual(t, timing.pacing, time.Duration(yields)*pausePerRun,
+		"every yield must be captured in timing.pacing; otherwise the sleep is "+
+			"billed as SQL work and double-counted against the scanner's throttle total")
+
+	sqlTime := wall - timing.bounds - timing.pacing
+	assert.Less(t, sqlTime, wall-timing.pacing+time.Millisecond,
+		"reported SQL time must exclude pacing")
+	assert.Positive(t, timing.bounds,
+		"the per-chunk bounds lookup is a real statement and must be reported separately")
+}
+
+// TestChunkedStepTiming_PacingRecordedBeforeErrorReturn guards the error path.
+// A yield that fails still consumed wall time, and losing it would make the
+// failing system's numbers unreconstructable — exactly when they matter most.
+func TestChunkedStepTiming_PacingRecordedBeforeErrorReturn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+	stageSyntheticMedia(t, sqlDB, 1, 10)
+
+	sentinel := errors.New("pauser cancelled")
+	yield := func() error {
+		time.Sleep(20 * time.Millisecond)
+		return sentinel
+	}
+
+	_, timing, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", 1, yield)
+	require.ErrorIs(t, err, sentinel)
+	assert.GreaterOrEqual(t, timing.pacing, 20*time.Millisecond,
+		"pacing before a failed yield must still be reported")
+}
+
+// TestFlagMissingMediaTiming_ExcludesPacing covers the same contract for the
+// other chunked step. It has no bounds query — its loop is self-draining — so
+// only pacing applies.
+func TestFlagMissingMediaTiming_ExcludesPacing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+	stageSyntheticMedia(t, sqlDB, 1, 5)
+	_, _, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", 1, nil)
+	require.NoError(t, err)
+
+	// Empty ScanStage so every Media row now counts as missing.
+	_, err = sqlDB.ExecContext(ctx, "DELETE FROM ScanStage")
+	require.NoError(t, err)
+
+	yield := func() error {
+		time.Sleep(25 * time.Millisecond)
+		return nil
+	}
+	affected, timing, err := sqlFlagMissingMedia(ctx, sqlDB, "C64", 1, yield)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, affected)
+
+	assert.GreaterOrEqual(t, timing.pacing, 25*time.Millisecond,
+		"flag missing media yields between chunks and must report that time as pacing")
+	assert.Zero(t, timing.bounds,
+		"flag missing media has no bounds query; reporting one would invent a statement")
+}
+
+// TestParseStepTimings_HandlesMultiWordStepNames pins the parsing assumption
+// the reconstruction test relies on, since step names legitimately contain
+// spaces ("upsert media bounds").
+func TestParseStepTimings_HandlesMultiWordStepNames(t *testing.T) {
+	t.Parallel()
+
+	parsed := parseStepTimings(t, "upsert media=12 upsert media bounds=3 pacing=0 unattributed=-1")
+	assert.Equal(t, map[string]int64{
+		"upsert media":        12,
+		"upsert media bounds": 3,
+		"pacing":              0,
+		"unattributed":        -1,
+	}, parsed)
+}

--- a/pkg/database/mediadb/scan_reconcile_test.go
+++ b/pkg/database/mediadb/scan_reconcile_test.go
@@ -32,6 +32,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -142,6 +143,70 @@ func TestReconcileStagedSystem_FullScanInsertsTitlesMediaAndTags(t *testing.T) {
 	assert.False(t, byPath[gamePath].IsMissing)
 }
 
+// TestReconcileStagedSystem_FreshSystemMatchesFullPath is the correctness gate
+// for #1279's fresh-system fast path. Indexing an empty database skips the steps
+// that reconcile against pre-existing rows, on the argument that they are
+// provably no-ops there. This proves it by outcome: index a set of paths into a
+// fresh database, then index the identical set into a database that already
+// holds them (so every step runs), and require the resulting media, titles,
+// missing flags and tag links to be identical. A skip that was not actually a
+// no-op would show up as a difference here.
+func TestReconcileStagedSystem_FreshSystemMatchesFullPath(t *testing.T) {
+	t.Parallel()
+
+	paths := []string{
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Super Game (USA) (Rev 2).sfc")),
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Super Game (Japan).sfc")),
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Other Game (Europe) [!].sfc")),
+		filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Solo Title (World).sfc")),
+	}
+
+	// Keyed by path, not DBID: DBIDs legitimately differ between the two
+	// databases, the media and tags they describe must not.
+	snapshot := func(t *testing.T, db *mediadb.MediaDB) (map[string]bool, map[string][]string) {
+		t.Helper()
+		media := map[string]bool{}
+		tagsByPath := map[string][]string{}
+		for path, row := range mediaDBIDsBySystem(t, db, "SNES") {
+			media[path] = row.IsMissing
+			tagList, err := db.GetMediaTagsByMediaDBID(context.Background(), row.DBID)
+			require.NoError(t, err)
+			names := make([]string, 0, len(tagList))
+			for _, tag := range tagList {
+				names = append(names, tag.Type+":"+tag.Tag)
+			}
+			sort.Strings(names)
+			tagsByPath[path] = names
+		}
+		return media, tagsByPath
+	}
+
+	freshDB, freshCleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(freshCleanup)
+	freshStats := scantest.IndexMediaPaths(t, freshDB, "SNES", paths...)
+	freshMedia, freshTags := snapshot(t, freshDB)
+
+	fullDB, fullCleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(fullCleanup)
+	// Seed first so the second pass finds an existing Systems row and therefore
+	// runs every step, including the ones the fresh path skips.
+	scantest.IndexMediaPaths(t, fullDB, "SNES", paths...)
+	fullStats := scantest.IndexMediaPaths(t, fullDB, "SNES", paths...)
+	fullMedia, fullTags := snapshot(t, fullDB)
+
+	assert.Equal(t, freshMedia, fullMedia, "media rows and missing flags must match")
+	assert.Equal(t, freshTags, fullTags, "tag links must match")
+
+	// The skipped steps are exactly the ones that report pre-existing-state
+	// changes, so both runs must report none of them.
+	assert.Equal(t, int64(0), freshStats.MediaMissing)
+	assert.Equal(t, int64(0), freshStats.TitlesRenamed)
+	assert.Equal(t, int64(0), freshStats.TagLinksDeleted)
+	assert.Equal(t, int64(0), fullStats.MediaMissing)
+	assert.Equal(t, int64(0), fullStats.TitlesRenamed)
+	assert.Equal(t, int64(0), fullStats.TagLinksDeleted)
+}
+
 func TestReconcileStagedSystem_IdempotentRescanIsNoOp(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
@@ -157,21 +222,42 @@ func TestReconcileStagedSystem_IdempotentRescanIsNoOp(t *testing.T) {
 	assert.Equal(t, int64(0), stats.TouchedTitles)
 }
 
+// TestReconcileStagedSystem_YieldsBetweenSQLSteps checks reconcile paces between
+// its set-based SQL steps. It counts a fresh system and a re-index separately
+// because #1279 made a fresh system skip the steps that reconcile against
+// pre-existing rows, which necessarily removes their yields too. Fewer yields on
+// a fresh reconcile is the intended consequence, not a pacing regression: there
+// are fewer statements to pace between. The re-index count is the one that must
+// stay high, since that is the long path.
 func TestReconcileStagedSystem_YieldsBetweenSQLSteps(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
-	yields := 0
 	gamePath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Game.sfc"))
+
+	freshYields := 0
 	scantest.IndexMediaPathsWithOpts(t, mediaDB, "SNES", database.ScanReconcileOpts{
 		Yield: func() error {
-			yields++
+			freshYields++
 			return nil
 		},
 	}, gamePath)
 
-	assert.GreaterOrEqual(t, yields, 10, "reconcile should pace between set-based SQL steps")
+	rescanYields := 0
+	scantest.IndexMediaPathsWithOpts(t, mediaDB, "SNES", database.ScanReconcileOpts{
+		Yield: func() error {
+			rescanYields++
+			return nil
+		},
+	}, gamePath)
+
+	assert.GreaterOrEqual(t, freshYields, 5,
+		"a fresh reconcile should still pace between the steps it does run")
+	assert.GreaterOrEqual(t, rescanYields, 10,
+		"a re-index runs every step and should pace between them")
+	assert.Greater(t, rescanYields, freshYields,
+		"a fresh system skips pre-existing-state steps, so it should yield fewer times")
 }
 
 func TestReconcileStagedSystem_PropagatesYieldError(t *testing.T) {

--- a/pkg/database/mediadb/scan_reconcile_timings_log_test.go
+++ b/pkg/database/mediadb/scan_reconcile_timings_log_test.go
@@ -1,0 +1,144 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb_test
+
+// The end-to-end guard for the reconcile step-timings line: drive a real
+// reconcile, capture what it actually logged, and check the numbers add up.
+//
+// This lives in the external test package because it needs
+// helpers.NewInMemoryMediaDB, which imports mediadb.
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/scantest"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stepTimingsLine finds the single "scan reconcile step timings" record in
+// captured zerolog JSONL output and returns its elapsed and steps fields.
+func stepTimingsLine(t *testing.T, out string) (elapsedMS float64, steps string) {
+	t.Helper()
+	found := false
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" {
+			continue
+		}
+		var rec struct {
+			Message string  `json:"message"`
+			Steps   string  `json:"steps"`
+			Elapsed float64 `json:"elapsed"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec.Message != "scan reconcile step timings" {
+			continue
+		}
+		require.False(t, found, "expected exactly one step-timings line, got more")
+		found, elapsedMS, steps = true, rec.Elapsed, rec.Steps
+	}
+	require.True(t, found, "reconcile must emit a step-timings line; captured output:\n%s", out)
+	return elapsedMS, steps
+}
+
+// TestReconcileStepTimingsLine_AccountsForWallTime is the regression guard for
+// the gap that made round 9 of #1279 misread. Before pacing was split out and
+// the four untimed steps were named, the entries on this line covered as
+// little as 55% of reconcile wall time while reading like a complete
+// breakdown.
+//
+// The assertion is deliberately on the *unattributed* term rather than on any
+// individual step: it is the term that catches a step someone adds later and
+// forgets to record, which is exactly how the original gap appeared.
+func TestReconcileStepTimingsLine_AccountsForWallTime(t *testing.T) {
+	// Not parallel: swaps the global logger.
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	// TestMain disables logging for the whole binary; this test reads the log,
+	// so it re-enables it for its own duration and restores the suppression.
+	var buf bytes.Buffer
+	original := log.Logger
+	originalLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = original
+		zerolog.SetGlobalLevel(originalLevel)
+	})
+
+	paths := make([]string, 0, 40)
+	for i := range 40 {
+		paths = append(paths, filepath.ToSlash(filepath.Join(
+			string(filepath.Separator), "roms", "SNES",
+			"Game "+strconv.Itoa(i)+" (USA).sfc",
+		)))
+	}
+	stats := scantest.IndexMediaPaths(t, mediaDB, "SNES", paths...)
+	require.EqualValues(t, len(paths), stats.MediaUpserted)
+
+	elapsedMS, steps := stepTimingsLine(t, buf.String())
+	parsed := map[string]int64{}
+	var nameParts []string
+	for _, token := range strings.Fields(steps) {
+		idx := strings.Index(token, "=")
+		if idx < 0 {
+			nameParts = append(nameParts, token)
+			continue
+		}
+		ms, err := strconv.ParseInt(token[idx+1:], 10, 64)
+		require.NoError(t, err, "step entry %q must carry an integer ms value", token)
+		parsed[strings.Join(append(nameParts, token[:idx]), " ")] = ms
+		nameParts = nil
+	}
+
+	// The steps that must always be present, including the four that used to
+	// run untimed and the two accounting terms.
+	for _, want := range []string{
+		"resolve system", "insert titles", "upsert media",
+		"count touched titles", "clear scan stage", "pacing", "unattributed",
+	} {
+		assert.Contains(t, parsed, want,
+			"step-timings line must name %q; steps were: %s", want, steps)
+	}
+
+	var sum int64
+	for _, ms := range parsed {
+		sum += ms
+	}
+	// Millisecond truncation across ~15 entries is the only legitimate drift.
+	assert.InDelta(t, elapsedMS, float64(sum), float64(len(parsed)+2),
+		"entries must reconstruct elapsed (%.1f ms); got %d ms from: %s",
+		elapsedMS, sum, steps)
+
+	assert.LessOrEqual(t, parsed["unattributed"], int64(float64(elapsedMS)*0.25)+5,
+		"unattributed must stay a small share of reconcile; a large value means a "+
+			"step is running untimed, which is the #1279 gap reappearing. steps: %s", steps)
+}

--- a/pkg/database/mediadb/scan_staging_repair_test.go
+++ b/pkg/database/mediadb/scan_staging_repair_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func TestFlagMissingMedia_ChunksLargeMissingSet(t *testing.T) {
 	_, err = sqlDB.ExecContext(ctx, "INSERT INTO ScanStage (Path) VALUES (?)", keepPath)
 	require.NoError(t, err)
 
-	affected, err := sqlFlagMissingMedia(ctx, sqlDB, "C64", 1, nil)
+	affected, _, err := sqlFlagMissingMedia(ctx, sqlDB, "C64", 1, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, scanFlagMissingBatchSize+1, affected)
 
@@ -189,4 +190,230 @@ func TestClearScanStage_RecreatesMissingScratchTables(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, index, name)
 	}
+}
+
+// newUpsertStagedMediaTestDB builds a minimal schema covering only the
+// columns sqlUpsertStagedMedia touches, mirroring the pattern used by
+// TestFlagMissingMedia_ChunksLargeMissingSet above.
+func newUpsertStagedMediaTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	sqlDB, err := sql.Open(sqliteDriverName(), filepath.Join(t.TempDir(), "media.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+
+	_, err = sqlDB.ExecContext(context.Background(), `
+		CREATE TABLE MediaTitles (
+			DBID INTEGER PRIMARY KEY,
+			SystemDBID INTEGER NOT NULL,
+			Slug TEXT NOT NULL
+		);
+		CREATE TABLE Media (
+			DBID INTEGER PRIMARY KEY,
+			MediaTitleDBID INTEGER NOT NULL,
+			SystemDBID INTEGER NOT NULL,
+			Path TEXT NOT NULL,
+			ParentDir TEXT NOT NULL,
+			SortName TEXT NOT NULL,
+			IsMissing INTEGER NOT NULL DEFAULT 0,
+			UNIQUE (SystemDBID, Path)
+		);
+		CREATE TABLE ScanStage (
+			Path TEXT PRIMARY KEY,
+			ParentDir TEXT NOT NULL,
+			Slug TEXT NOT NULL,
+			SortName TEXT NOT NULL
+		) WITHOUT ROWID;
+	`)
+	require.NoError(t, err)
+	return sqlDB
+}
+
+// stageSyntheticMedia inserts n zero-padded-path titles/staged rows, one
+// title per row, so each row's identity in Media is unambiguous by Path.
+// Paths are zero-padded so BINARY ordering matches insertion order, which
+// the chunk-boundary tests below depend on.
+func stageSyntheticMedia(t *testing.T, sqlDB *sql.DB, systemDBID int64, n int) {
+	t.Helper()
+	ctx := context.Background()
+	for i := range n {
+		slug := fmt.Sprintf("game-%06d", i)
+		path := fmt.Sprintf("/roms/c64/%06d.d64", i)
+		_, err := sqlDB.ExecContext(ctx,
+			"INSERT INTO MediaTitles (SystemDBID, Slug) VALUES (?, ?)", systemDBID, slug)
+		require.NoError(t, err)
+		_, err = sqlDB.ExecContext(ctx,
+			"INSERT INTO ScanStage (Path, ParentDir, Slug, SortName) VALUES (?, ?, ?, ?)",
+			path, "/roms/c64", slug, slug)
+		require.NoError(t, err)
+	}
+}
+
+// readMediaRowsOrderedByPath reads every tracked Media column except DBID,
+// ordered by Path — DBID assignment order is not part of the chunking
+// contract (see sqlUpsertStagedMedia's doc comment).
+func readMediaRowsOrderedByPath(t *testing.T, sqlDB *sql.DB, systemDBID int64) []string {
+	t.Helper()
+	rows, err := sqlDB.QueryContext(context.Background(), `
+		SELECT Path || '|' || MediaTitleDBID || '|' || ParentDir || '|' || SortName || '|' || IsMissing
+		FROM Media WHERE SystemDBID = ? ORDER BY Path`, systemDBID)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	result := make([]string, 0)
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		result = append(result, line)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+// TestUpsertStagedMedia_ChunksAcrossBatchBoundary proves the cursor covers
+// the full staged key space across more than two chunk boundaries with no
+// gap and no double-visit.
+func TestUpsertStagedMedia_ChunksAcrossBatchBoundary(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+
+	const systemDBID = 1
+	const n = scanUpsertMediaBatchSize*2 + 1
+	stageSyntheticMedia(t, sqlDB, systemDBID, n)
+
+	affected, _, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", systemDBID, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, n, affected)
+
+	var count int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM Media WHERE SystemDBID = ?", systemDBID).Scan(&count))
+	require.Equal(t, n, count)
+
+	var mismatched int
+	require.NoError(t, sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM Media m
+		JOIN ScanStage s ON s.Path = m.Path
+		JOIN MediaTitles t ON t.DBID = m.MediaTitleDBID
+		WHERE m.SystemDBID = ?
+		  AND (t.Slug <> s.Slug OR m.ParentDir <> s.ParentDir OR m.SortName <> s.SortName OR m.IsMissing <> 0)`,
+		systemDBID).Scan(&mismatched))
+	require.Zero(t, mismatched)
+}
+
+// TestUpsertStagedMedia_NoOpChunkTerminates is the direct regression guard
+// for the "RowsAffected can't drive the loop" trap: ON CONFLICT ... WHERE
+// <changed> reports 0 for a rerun even though every chunk still has rows to
+// examine, so the cursor — not the affected count — must terminate the loop.
+// The timeout turns a cursor regression into a fast test failure instead of
+// a hung suite. This also doubles as an idempotency check.
+func TestUpsertStagedMedia_NoOpChunkTerminates(t *testing.T) {
+	t.Parallel()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+
+	const systemDBID = 1
+	const n = scanUpsertMediaBatchSize + 5
+	stageSyntheticMedia(t, sqlDB, systemDBID, n)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	first, _, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", systemDBID, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, n, first)
+
+	second, _, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", systemDBID, nil)
+	require.NoError(t, err)
+	require.Zero(t, second)
+}
+
+// TestUpsertStagedMedia_MatchesUnchunkedResult proves chunking doesn't change
+// the final result: the same staged set run through the chunked helper and
+// through the original single-statement SQL must produce identical Media
+// rows (DBID assignment order aside — see readMediaRowsOrderedByPath).
+func TestUpsertStagedMedia_MatchesUnchunkedResult(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const systemDBID = 1
+	const n = scanUpsertMediaBatchSize + 137 // spans a boundary, not a multiple of it
+
+	chunkedDB := newUpsertStagedMediaTestDB(t)
+	stageSyntheticMedia(t, chunkedDB, systemDBID, n)
+	_, _, err := sqlUpsertStagedMedia(ctx, chunkedDB, "C64", systemDBID, nil)
+	require.NoError(t, err)
+
+	unchunkedDB := newUpsertStagedMediaTestDB(t)
+	stageSyntheticMedia(t, unchunkedDB, systemDBID, n)
+	_, err = unchunkedDB.ExecContext(ctx, `
+		INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
+		SELECT t.DBID, ?, s.Path, s.ParentDir, s.SortName, 0
+		FROM ScanStage s
+		JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
+		WHERE true
+		ON CONFLICT (SystemDBID, Path) DO UPDATE SET
+			MediaTitleDBID = excluded.MediaTitleDBID,
+			ParentDir      = excluded.ParentDir,
+			SortName       = excluded.SortName,
+			IsMissing      = 0
+		WHERE MediaTitleDBID <> excluded.MediaTitleDBID
+		   OR ParentDir <> excluded.ParentDir
+		   OR SortName <> excluded.SortName
+		   OR IsMissing <> 0`, systemDBID, systemDBID)
+	require.NoError(t, err)
+
+	require.Equal(t,
+		readMediaRowsOrderedByPath(t, unchunkedDB, systemDBID),
+		readMediaRowsOrderedByPath(t, chunkedDB, systemDBID))
+}
+
+// TestUpsertStagedMedia_UpdatesChangedRowsAcrossChunks proves the
+// ON CONFLICT ... WHERE <changed> guard still discriminates per chunk:
+// only rows whose tracked columns actually differ are reported/corrected,
+// across a pre-populated set that straddles a chunk boundary.
+func TestUpsertStagedMedia_UpdatesChangedRowsAcrossChunks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sqlDB := newUpsertStagedMediaTestDB(t)
+
+	const systemDBID = 1
+	const n = scanUpsertMediaBatchSize + 50
+	stageSyntheticMedia(t, sqlDB, systemDBID, n)
+
+	// Rows [changedFrom, changedTo) straddle the chunk boundary at
+	// scanUpsertMediaBatchSize and get deliberately wrong values that must be
+	// corrected. Every other row is pre-populated already matching what the
+	// stage would produce, and must NOT be reported as changed.
+	const changedFrom = scanUpsertMediaBatchSize - 5
+	const changedTo = scanUpsertMediaBatchSize + 5
+	for i := range n {
+		slug := fmt.Sprintf("game-%06d", i)
+		path := fmt.Sprintf("/roms/c64/%06d.d64", i)
+		var titleDBID int64
+		require.NoError(t, sqlDB.QueryRowContext(ctx,
+			"SELECT DBID FROM MediaTitles WHERE SystemDBID = ? AND Slug = ?", systemDBID, slug).
+			Scan(&titleDBID))
+
+		if i >= changedFrom && i < changedTo {
+			_, err := sqlDB.ExecContext(ctx, `
+				INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
+				VALUES (?, ?, ?, 'wrong', 'wrong', 1)`, titleDBID, systemDBID, path)
+			require.NoError(t, err)
+		} else {
+			_, err := sqlDB.ExecContext(ctx, `
+				INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
+				VALUES (?, ?, ?, '/roms/c64', ?, 0)`, titleDBID, systemDBID, path, slug)
+			require.NoError(t, err)
+		}
+	}
+
+	affected, _, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", systemDBID, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, changedTo-changedFrom, affected)
+
+	var stillWrong int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM Media WHERE SystemDBID = ? "+
+			"AND (ParentDir = 'wrong' OR SortName = 'wrong' OR IsMissing <> 0)",
+		systemDBID).Scan(&stillWrong))
+	require.Zero(t, stillWrong)
 }

--- a/pkg/database/mediadb/slug_cache_coverage_test.go
+++ b/pkg/database/mediadb/slug_cache_coverage_test.go
@@ -1,0 +1,209 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cacheCoverageEntry keeps the buildTestCache literal readable.
+type cacheCoverageEntry = struct {
+	slug       string
+	secSlug    string
+	titleDBID  int64
+	systemDBID int64
+}
+
+// buildCoverageCache returns a complete cache holding entries for withData
+// systems, mirroring a finished index.
+func buildCoverageCache(withData int) *SlugSearchCache {
+	entries := make([]cacheCoverageEntry, 0, withData)
+	systems := make(map[int64]string, withData)
+	for i := 1; i <= withData; i++ {
+		id := fmt.Sprintf("System%03d", i)
+		systems[int64(i)] = id
+		entries = append(entries, cacheCoverageEntry{
+			slug:       fmt.Sprintf("game-%03d", i),
+			secSlug:    fmt.Sprintf("alt-%03d", i),
+			titleDBID:  int64(i),
+			systemDBID: int64(i),
+		})
+	}
+	cache := buildTestCache(entries, systems)
+	cache.complete = true
+	return cache
+}
+
+// requestedSystems mirrors a library-wide client search: every system Zaparoo
+// knows about, most of which hold no media on any given device.
+func requestedSystems(total int) []string {
+	ids := make([]string, 0, total)
+	for i := 1; i <= total; i++ {
+		ids = append(ids, fmt.Sprintf("System%03d", i))
+	}
+	return ids
+}
+
+// TestCanServeSystems_LibraryWideSearchDuringReindex reproduces the search
+// failure from #1279 at the shape the device actually has: a client asks for
+// 293 systems, the database holds rows for 106, and one of those is being
+// re-indexed.
+//
+// Before the fix every library-wide search fell through to the grouped SQL LIKE
+// path for the entire duration of an index — eight grouped queries per request,
+// the slowest single query 15.2 s on device, so every search hit the 30 s API
+// timeout. The systems vetoing the cache were overwhelmingly ones with no media
+// at all, which cannot affect a result either way.
+func TestCanServeSystems_LibraryWideSearchDuringReindex(t *testing.T) {
+	t.Parallel()
+
+	const (
+		systemsWithData = 106
+		systemsKnown    = 293
+	)
+	cache := buildCoverageCache(systemsWithData)
+	all := requestedSystems(systemsKnown)
+
+	require.True(t, cache.CanServeSystems(all),
+		"a complete cache must serve a library-wide search")
+
+	// Indexing removes the system it is about to rewrite.
+	midReindex := cache.withoutSystems([]string{"System007"})
+	require.False(t, midReindex.complete,
+		"dropping a system must clear complete so startup still rebuilds")
+
+	assert.True(t, midReindex.CanServeSystems([]string{"System004"}),
+		"an untouched system with data must still be servable")
+
+	// The system being re-indexed still has rows in SQL, so a search naming it
+	// must fall back rather than read this cache and report nothing.
+	assert.False(t, midReindex.CanServeSystems([]string{"System007"}),
+		"a dropped system must fall back to SQL; its rows still exist")
+	assert.False(t, midReindex.CanServeSystems(all),
+		"a library-wide search names the dropped system too, so it also falls back")
+
+	// The 187 systems with no media must no longer be what causes that: with
+	// the dropped system refreshed, the same library-wide search is servable.
+	refreshed := buildTestCache([]cacheCoverageEntry{
+		{slug: "game-007", titleDBID: 7, systemDBID: 7},
+	}, map[int64]string{7: "System007"})
+	refreshed.coveredSystems = map[string]struct{}{"System007": {}}
+	merged := mergeSlugSearchCaches(midReindex, refreshed)
+
+	assert.True(t, merged.CanServeSystems(all),
+		"once the in-flight system is folded back in, systems that simply have no media "+
+			"must not veto a library-wide search — that veto is what forced every search "+
+			"onto the grouped SQL LIKE path for a whole index")
+}
+
+// TestCanServeSystems_PartialCacheStaysStrict guards the other direction. A
+// cache built as a fragment — a fresh index that has only reached a few systems
+// — has no basis for assuming an unknown system is empty, so it must keep
+// refusing rather than silently answer from partial data.
+func TestCanServeSystems_PartialCacheStaysStrict(t *testing.T) {
+	t.Parallel()
+
+	fragment := buildTestCache([]cacheCoverageEntry{
+		{slug: "game-001", titleDBID: 1, systemDBID: 1},
+	}, map[int64]string{1: "System001"})
+	fragment.coveredSystems = map[string]struct{}{"System001": {}}
+
+	require.False(t, fragment.complete)
+	require.False(t, fragment.derivedFromComplete,
+		"a fragment never covered the library")
+
+	assert.True(t, fragment.CanServeSystems([]string{"System001"}))
+	assert.False(t, fragment.CanServeSystems([]string{"System001", "System002"}),
+		"a fragment cannot assume System002 is empty; it may simply not be built yet")
+}
+
+// TestCanServeSystems_DerivedFlagSurvivesRefresh checks the flag survives the
+// merge that folds a refreshed system back in, so coverage does not regress
+// after the first system of an index completes.
+func TestCanServeSystems_DerivedFlagSurvivesRefresh(t *testing.T) {
+	t.Parallel()
+
+	cache := buildCoverageCache(106)
+	midReindex := cache.withoutSystems([]string{"System007"})
+	require.True(t, midReindex.derivedFromComplete)
+
+	refreshed := buildTestCache([]cacheCoverageEntry{
+		{slug: "game-007", titleDBID: 7, systemDBID: 7},
+	}, map[int64]string{7: "System007"})
+	refreshed.coveredSystems = map[string]struct{}{"System007": {}}
+
+	merged := mergeSlugSearchCaches(midReindex, refreshed)
+	assert.True(t, merged.derivedFromComplete,
+		"folding a refreshed system back in must not lose the library-wide basis")
+	assert.True(t, merged.CanServeSystems(requestedSystems(293)))
+	assert.Contains(t, merged.coveredSystems, "System007",
+		"the refreshed system is covered again")
+}
+
+// TestPartitionServableSystems_SplitsCacheFromInFlight covers the split that
+// keeps a library-wide search off the grouped SQL LIKE path during an index.
+//
+// Without it, one system being re-indexed forced the whole search to SQL across
+// every system — the shape that timed out on the #1279 device. The split must
+// send only the in-flight system to SQL, keep the covered ones on the cache,
+// and drop systems that have no rows at all from both sides.
+func TestPartitionServableSystems_SplitsCacheFromInFlight(t *testing.T) {
+	t.Parallel()
+
+	cache := buildCoverageCache(106)
+	midReindex := cache.withoutSystems([]string{"System007"})
+
+	cached, viaSQL, ok := midReindex.PartitionServableSystems(requestedSystems(293))
+	require.True(t, ok, "a cache derived from a complete one must support the split")
+
+	assert.Equal(t, []string{"System007"}, viaSQL,
+		"only the system being re-indexed still needs SQL; its rows are mid-rewrite")
+	assert.Len(t, cached, 105,
+		"the other systems with data stay on the cache")
+	assert.NotContains(t, cached, "System007")
+	assert.NotContains(t, cached, "System200",
+		"a system with no rows belongs on neither side")
+}
+
+// TestPartitionServableSystems_DeclinesWhenNotApplicable keeps the split from
+// being used where its reasoning does not hold. A complete cache needs no
+// split, and a fragment cannot assume an unknown system is empty.
+func TestPartitionServableSystems_DeclinesWhenNotApplicable(t *testing.T) {
+	t.Parallel()
+
+	complete := buildCoverageCache(10)
+	_, _, ok := complete.PartitionServableSystems(requestedSystems(20))
+	assert.False(t, ok, "a complete cache serves everything; no split needed")
+
+	fragment := buildTestCache([]cacheCoverageEntry{
+		{slug: "game-001", titleDBID: 1, systemDBID: 1},
+	}, map[int64]string{1: "System001"})
+	fragment.coveredSystems = map[string]struct{}{"System001": {}}
+	_, _, ok = fragment.PartitionServableSystems([]string{"System001", "System002"})
+	assert.False(t, ok, "a fragment cannot assume System002 is empty")
+
+	var nilCache *SlugSearchCache
+	_, _, ok = nilCache.PartitionServableSystems([]string{"System001"})
+	assert.False(t, ok)
+}

--- a/pkg/database/mediadb/slug_cache_coverage_test.go
+++ b/pkg/database/mediadb/slug_cache_coverage_test.go
@@ -186,6 +186,40 @@ func TestPartitionServableSystems_SplitsCacheFromInFlight(t *testing.T) {
 		"a system with no rows belongs on neither side")
 }
 
+// TestWithoutSystems_IgnoresSystemsTheCacheNeverHeld pins that removing a
+// system the cache has no entries for does not disable it.
+//
+// InsertSystem outside a transaction invalidates with just the new system's ID,
+// and a system that has only just been inserted has no media yet — so it is
+// absent from the cache. Recording it as dropped made CanServeSystems refuse
+// every library-wide search, which is the grouped SQL LIKE path this cache
+// exists to avoid.
+func TestWithoutSystems_IgnoresSystemsTheCacheNeverHeld(t *testing.T) {
+	t.Parallel()
+
+	cache := buildCoverageCache(106)
+	all := requestedSystems(293)
+	require.True(t, cache.CanServeSystems(all))
+
+	afterInsert := cache.withoutSystems([]string{"BrandNewSystem"})
+
+	assert.True(t, afterInsert.CanServeSystems(all),
+		"inserting a system with no media must not push library-wide searches onto SQL")
+	assert.NotContains(t, afterInsert.droppedSystems, "BrandNewSystem",
+		"a system the cache never held has nothing stale to fall back for")
+
+	cached, viaSQL, ok := afterInsert.PartitionServableSystems(all)
+	require.True(t, ok)
+	assert.Empty(t, viaSQL, "no system needs SQL: none of them were being rewritten")
+	assert.Len(t, cached, 106)
+
+	// A system the cache does hold entries for must still be dropped, so its
+	// stale rows are not served while it is rewritten.
+	afterReindex := cache.withoutSystems([]string{"System007"})
+	assert.Contains(t, afterReindex.droppedSystems, "System007")
+	assert.False(t, afterReindex.CanServeSystems([]string{"System007"}))
+}
+
 // TestPartitionServableSystems_DeclinesWhenNotApplicable keeps the split from
 // being used where its reasoning does not hold. A complete cache needs no
 // split, and a fragment cannot assume an unknown system is empty.

--- a/pkg/database/mediadb/slug_search_cache.go
+++ b/pkg/database/mediadb/slug_search_cache.go
@@ -305,7 +305,7 @@ func buildSlugSearchCacheForSystems(ctx context.Context, db *sql.DB, systemIDs [
 	}
 
 	if len(coverage) == 0 {
-		finalizeCache(cache)
+		finalizeFragment(cache)
 		return cache, nil
 	}
 
@@ -398,6 +398,33 @@ func buildSlugSearchCacheForSystems(ctx context.Context, db *sql.DB, systemIDs [
 // finalizeCache sorts entries by system, builds system ranges, and builds the
 // trigram index. Called after raw data population by both production and test paths.
 func finalizeCache(cache *SlugSearchCache) {
+	finalizeCacheEntries(cache, true)
+}
+
+// finalizeFragment finalizes a selective refresh fragment without building its
+// trigram index.
+//
+// mergeSlugSearchCaches folds the fragment's trigrams into a new delta layer
+// derived from the merged cache's own slug data and the base's frequency cap; it
+// never reads the fragment's CSR arrays. Building them would allocate five
+// trigramCount-sized arrays (~850KB) and make three passes over the slug data on
+// every per-system refresh, all discarded. The one path that returns a fragment
+// directly — an empty base — builds the index there via ensureTrigramIndex.
+func finalizeFragment(cache *SlugSearchCache) {
+	finalizeCacheEntries(cache, false)
+}
+
+// ensureTrigramIndex builds the CSR index for a cache finalized without one.
+// Caches with no entries are left alone, matching finalizeCacheEntries, which
+// also skips the index for them.
+func ensureTrigramIndex(cache *SlugSearchCache) {
+	if cache.entryCount == 0 || cache.trigramOffsets != nil {
+		return
+	}
+	buildTrigramIndex(cache)
+}
+
+func finalizeCacheEntries(cache *SlugSearchCache, withTrigramIndex bool) {
 	if cache.coveredSystems == nil && !cache.complete {
 		cache.coveredSystems = make(map[string]struct{})
 	}
@@ -428,7 +455,9 @@ func finalizeCache(cache *SlugSearchCache) {
 
 	sortCacheBySystem(cache)
 	cache.systemRanges = buildSystemRanges(cache.systemDBIDs, cache.entryCount)
-	buildTrigramIndex(cache)
+	if withTrigramIndex {
+		buildTrigramIndex(cache)
+	}
 
 	cache.slugData = slices.Clip(cache.slugData)
 	cache.slugOffsets = slices.Clip(cache.slugOffsets)
@@ -562,6 +591,9 @@ func mergeSlugSearchCaches(base, replacement *SlugSearchCache) *SlugSearchCache 
 		return base
 	}
 	if replacement.complete || base == nil {
+		// The fragment becomes the published cache, so it needs its own CSR
+		// index; every other path folds it into a delta layer instead.
+		ensureTrigramIndex(replacement)
 		return replacement
 	}
 
@@ -665,6 +697,9 @@ func mergeSlugSearchCaches(base, replacement *SlugSearchCache) *SlugSearchCache 
 
 	merged.liveEntries = computeLiveEntries(merged.droppedRanges, merged.entryCount)
 	merged.trigramDeltas = appendTrigramDelta(base.trigramDeltas, merged, blockStart)
+	if len(merged.trigramDeltas) > maxTrigramDeltaLayers {
+		compactTrigramDeltas(merged)
+	}
 	return merged
 }
 
@@ -704,6 +739,42 @@ func appendTrigramDelta(existing []trigramDelta, merged *SlugSearchCache, blockS
 	layers = append(layers, existing...)
 	layers = append(layers, delta)
 	return layers
+}
+
+// maxTrigramDeltaLayers bounds how many delta layers a cache carries before the
+// CSR index is rebuilt to absorb them.
+//
+// Layers only exist mid-index: every per-system refresh appends one, and the
+// end-of-run full rebuild starts from none. Both postingListSize and
+// combinedPostingList walk every layer per trigram, so an unbounded count makes
+// search slower the longer an index runs — which works directly against the
+// reason progressive indexing keeps search available at all.
+//
+// The bound is a straight trade, measured at 130 systems / 208k entries.
+// Unbounded, the layers cost ~32us of fixed overhead per search (~75% of a
+// selective query's total time) and ~8MB of heap, because holding 688k postings
+// as 130 maps costs roughly 3x holding them as one array. One compaction is a
+// full CSR rebuild: ~37ms on x86, slower on MiSTer. 32 keeps both costs at about
+// a quarter of the unbounded worst case for ~4 rebuilds across a 131-system run.
+const maxTrigramDeltaLayers = 32
+
+// compactTrigramDeltas folds every delta layer back into a freshly built CSR
+// index, so subsequent lookups touch one array instead of walking N maps.
+//
+// Race-safe with already-published caches: buildTrigramIndex assigns new slices
+// rather than mutating in place, so a cache still held by a reader keeps the
+// arrays it was published with. Rebuilding also recomputes trigramCapped
+// against the current entry count, which delta layers cannot do — they inherit
+// whatever cap the CSR was built with.
+func compactTrigramDeltas(cache *SlugSearchCache) {
+	if cache.entryCount == 0 {
+		return
+	}
+	cache.trigramOffsets = nil
+	cache.trigramPostings = nil
+	cache.trigramCapped = nil
+	buildTrigramIndex(cache)
+	cache.trigramDeltas = nil
 }
 
 // sortCacheBySystem reorders all parallel arrays so entries are grouped by

--- a/pkg/database/mediadb/slug_search_cache.go
+++ b/pkg/database/mediadb/slug_search_cache.go
@@ -78,10 +78,14 @@ type trigramDelta map[uint32][]uint32
 // publishes a compact cache. All fields are immutable after publication via
 // the atomic pointer; writers build a new struct (sharing arrays) and swap.
 type SlugSearchCache struct {
-	systemDBIDToID  map[int64]string
-	systemIDToDBID  map[string]int64
-	systemRanges    map[int64][2]int
-	coveredSystems  map[string]struct{}
+	systemDBIDToID map[int64]string
+	systemIDToDBID map[string]int64
+	systemRanges   map[int64][2]int
+	coveredSystems map[string]struct{}
+	// droppedSystems are systems withoutSystems removed, as opposed to ones
+	// that never had rows. Their data still exists in SQL, so a search naming
+	// one must fall back rather than read this cache and report nothing.
+	droppedSystems  map[string]struct{}
 	secSlugOffsets  []uint32
 	slugOffsets     []uint32
 	secSlugData     []byte
@@ -96,6 +100,12 @@ type SlugSearchCache struct {
 	liveEntries     [][2]int
 	entryCount      int
 	complete        bool
+	// derivedFromComplete marks a cache that descends from one covering the
+	// whole library. It is the difference between "this system has no rows"
+	// and "this system has not been built yet", which coveredSystems alone
+	// cannot express — see CanServeSystems. Not persisted: a cache written to
+	// disk is either complete or rebuilt on load.
+	derivedFromComplete bool
 }
 
 // hasMidScanState reports whether the cache carries tombstones or trigram
@@ -492,6 +502,42 @@ func sortedCoveredSystems(covered map[string]struct{}) []string {
 	return ids
 }
 
+// PartitionServableSystems splits requested systems into those this cache can
+// answer and those a caller must still reach SQL for.
+//
+// Only meaningful on a cache that once covered the whole library: there an
+// unknown system genuinely has no rows, while a dropped one is mid-reindex and
+// its rows are still in SQL. A search spanning both can then serve the bulk
+// from memory and scope its SQL to the handful actually in flight, instead of
+// falling back wholesale — which on the #1279 device meant every library-wide
+// search ran eight grouped LIKE queries across 293 systems and timed out.
+//
+// Returns ok=false when the split does not apply and the caller should keep
+// its existing all-or-nothing behaviour.
+func (c *SlugSearchCache) PartitionServableSystems(systemIDs []string) (cached, viaSQL []string, ok bool) {
+	if c == nil || c.complete || !c.derivedFromComplete || len(systemIDs) == 0 {
+		return nil, nil, false
+	}
+	for _, systemID := range systemIDs {
+		if _, dropped := c.droppedSystems[systemID]; dropped {
+			viaSQL = append(viaSQL, systemID)
+			continue
+		}
+		if _, covered := c.coveredSystems[systemID]; covered {
+			cached = append(cached, systemID)
+			continue
+		}
+		if _, known := c.systemIDToDBID[systemID]; !known {
+			// No rows anywhere; contributes nothing to either side.
+			continue
+		}
+		// Known to the cache but neither covered nor dropped: unexpected, so
+		// fall back rather than guess.
+		return nil, nil, false
+	}
+	return cached, viaSQL, true
+}
+
 func (c *SlugSearchCache) CanServeSystems(systemIDs []string) bool {
 	if c == nil {
 		return false
@@ -503,9 +549,33 @@ func (c *SlugSearchCache) CanServeSystems(systemIDs []string) bool {
 		return false
 	}
 	for _, systemID := range systemIDs {
-		if _, ok := c.coveredSystems[systemID]; !ok {
+		if _, ok := c.coveredSystems[systemID]; ok {
+			continue
+		}
+		// A system the cache has never held entries for contributes no
+		// results, so it cannot make the answer wrong — but only once the
+		// cache is known to account for the whole library. Without this a
+		// library-wide search is unservable for the entire duration of an
+		// index: a client asks for every system Zaparoo knows about (293 on
+		// the #1279 device) while the database holds rows for far fewer (106),
+		// so the systems that simply have no media veto the cache and every
+		// search falls back to the grouped SQL LIKE path.
+		//
+		// The system currently being re-indexed is also absent here, and is
+		// likewise treated as contributing nothing until its refresh lands.
+		// Its rows are mid-rewrite, so a moment of no results for that one
+		// system is the intended degradation.
+		if _, dropped := c.droppedSystems[systemID]; dropped {
+			// Removed for re-indexing. Its rows are still in SQL, so the
+			// caller must fall back or it would silently report no results.
 			return false
 		}
+		if c.derivedFromComplete {
+			if _, known := c.systemIDToDBID[systemID]; !known {
+				continue
+			}
+		}
+		return false
 	}
 	return true
 }
@@ -542,6 +612,16 @@ func (c *SlugSearchCache) withoutSystems(systemIDs []string) *SlugSearchCache {
 		systemIDToDBID:  make(map[string]int64, len(c.systemIDToDBID)),
 		systemRanges:    make(map[int64][2]int, len(c.systemRanges)),
 		coveredSystems:  make(map[string]struct{}),
+		// Removing systems loses full coverage, but not the knowledge that
+		// every other system in the library is accounted for.
+		derivedFromComplete: c.complete || c.derivedFromComplete,
+		droppedSystems:      make(map[string]struct{}, len(c.droppedSystems)+len(remove)),
+	}
+	for systemID := range c.droppedSystems {
+		trimmed.droppedSystems[systemID] = struct{}{}
+	}
+	for systemID := range remove {
+		trimmed.droppedSystems[systemID] = struct{}{}
 	}
 
 	if c.complete {
@@ -609,22 +689,24 @@ func mergeSlugSearchCaches(base, replacement *SlugSearchCache) *SlugSearchCache 
 	}
 
 	merged := &SlugSearchCache{
-		slugData:        base.slugData,
-		slugOffsets:     base.slugOffsets,
-		secSlugData:     base.secSlugData,
-		secSlugOffsets:  base.secSlugOffsets,
-		titleDBIDs:      base.titleDBIDs,
-		systemDBIDs:     base.systemDBIDs,
-		trigramOffsets:  base.trigramOffsets,
-		trigramPostings: base.trigramPostings,
-		trigramCapped:   base.trigramCapped,
-		entryCount:      base.entryCount,
-		droppedRanges:   base.droppedRanges,
-		liveEntries:     nil, // recomputed below with the new entryCount
-		complete:        base.complete,
-		systemDBIDToID:  make(map[int64]string, len(base.systemDBIDToID)+len(replacement.systemDBIDToID)),
-		systemIDToDBID:  make(map[string]int64, len(base.systemIDToDBID)+len(replacement.systemIDToDBID)),
-		systemRanges:    make(map[int64][2]int, len(base.systemRanges)+len(replacement.systemRanges)),
+		slugData:            base.slugData,
+		slugOffsets:         base.slugOffsets,
+		secSlugData:         base.secSlugData,
+		secSlugOffsets:      base.secSlugOffsets,
+		titleDBIDs:          base.titleDBIDs,
+		systemDBIDs:         base.systemDBIDs,
+		trigramOffsets:      base.trigramOffsets,
+		trigramPostings:     base.trigramPostings,
+		trigramCapped:       base.trigramCapped,
+		entryCount:          base.entryCount,
+		droppedRanges:       base.droppedRanges,
+		liveEntries:         nil, // recomputed below with the new entryCount
+		complete:            base.complete,
+		derivedFromComplete: base.derivedFromComplete,
+		droppedSystems:      mergeDroppedSystems(base.droppedSystems, replacement.coveredSystems),
+		systemDBIDToID:      make(map[int64]string, len(base.systemDBIDToID)+len(replacement.systemDBIDToID)),
+		systemIDToDBID:      make(map[string]int64, len(base.systemIDToDBID)+len(replacement.systemIDToDBID)),
+		systemRanges:        make(map[int64][2]int, len(base.systemRanges)+len(replacement.systemRanges)),
 	}
 
 	if merged.complete {
@@ -1556,6 +1638,28 @@ func (db *MediaDB) RebuildSlugSearchCache() error {
 	return nil
 }
 
+// SlugSearchCacheCoverageForTesting reports whether an in-memory slug search
+// cache is currently loaded and, if so, how many systems it holds entries for
+// and whether it still accounts for the whole library. Tests outside this
+// package use it to assert the cache survives an indexing run; nothing in
+// production reads it.
+func (db *MediaDB) SlugSearchCacheCoverageForTesting() (loaded bool, systems int, libraryWide bool) {
+	cache := db.slugSearchCache.Load()
+	if cache == nil {
+		return false, 0, false
+	}
+	return true, len(cache.systemRanges), cache.complete || cache.derivedFromComplete
+}
+
+// CanServeSystemsFromSlugCacheForTesting reports whether a search naming the
+// given systems could be answered from the in-memory slug search cache. Tests
+// outside this package use it to assert coverage during an indexing run;
+// nothing in production reads it.
+func (db *MediaDB) CanServeSystemsFromSlugCacheForTesting(systemIDs []string) bool {
+	cache := db.slugSearchCache.Load()
+	return cache != nil && cache.CanServeSystems(systemIDs)
+}
+
 func (db *MediaDB) RefreshSlugSearchCacheForSystems(ctx context.Context, systemIDs []string) error {
 	fragment, err := buildSlugSearchCacheForSystems(ctx, db.sql.Load(), systemIDs)
 	if err != nil {
@@ -1572,4 +1676,23 @@ func (db *MediaDB) RefreshSlugSearchCacheForSystems(ctx context.Context, systemI
 		Bool("complete", refreshed.complete).
 		Msg("slug search cache refreshed for systems")
 	return nil
+}
+
+// mergeDroppedSystems clears systems from the dropped set as their refreshed
+// entries are folded back in.
+func mergeDroppedSystems(dropped, refreshed map[string]struct{}) map[string]struct{} {
+	if len(dropped) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(dropped))
+	for systemID := range dropped {
+		if _, back := refreshed[systemID]; back {
+			continue
+		}
+		out[systemID] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/pkg/database/mediadb/slug_search_cache.go
+++ b/pkg/database/mediadb/slug_search_cache.go
@@ -696,6 +696,19 @@ func mergeSlugSearchCaches(base, replacement *SlugSearchCache) *SlugSearchCache 
 	}
 
 	merged.liveEntries = computeLiveEntries(merged.droppedRanges, merged.entryCount)
+
+	if blockStart == 0 {
+		// The base contributed no entries, so it has no CSR index to preserve
+		// and there is nothing for a delta layer to sit on top of. Build the
+		// index outright: the unfiltered Search path keys off trigramPostings,
+		// so leaving this cache reachable only through a delta would put every
+		// query on linearSearch until enough refreshes accumulated to trigger
+		// compaction.
+		merged.trigramDeltas = nil
+		ensureTrigramIndex(merged)
+		return merged
+	}
+
 	merged.trigramDeltas = appendTrigramDelta(base.trigramDeltas, merged, blockStart)
 	if len(merged.trigramDeltas) > maxTrigramDeltaLayers {
 		compactTrigramDeltas(merged)

--- a/pkg/database/mediadb/slug_search_cache.go
+++ b/pkg/database/mediadb/slug_search_cache.go
@@ -621,6 +621,16 @@ func (c *SlugSearchCache) withoutSystems(systemIDs []string) *SlugSearchCache {
 		trimmed.droppedSystems[systemID] = struct{}{}
 	}
 	for systemID := range remove {
+		// Only systems the cache actually holds entries for become "dropped".
+		// A system it has never seen has nothing stale to fall back for, and
+		// marking it anyway is not harmless: droppedSystems makes
+		// CanServeSystems refuse, so one InsertSystem outside a transaction —
+		// which invalidates with the new system's ID, and a new system has no
+		// media yet — would put every library-wide search back on the grouped
+		// SQL LIKE path until the next full rebuild.
+		if _, known := c.systemIDToDBID[systemID]; !known {
+			continue
+		}
 		trimmed.droppedSystems[systemID] = struct{}{}
 	}
 

--- a/pkg/database/mediadb/slug_search_cache_bench_test.go
+++ b/pkg/database/mediadb/slug_search_cache_bench_test.go
@@ -116,3 +116,98 @@ func BenchmarkSlugSearchCache_MidScanChurn_FullSweep(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkSlugSearchCache_SearchWithDeltaLayers isolates what delta layers
+// cost a search. Every per-system refresh appends one layer, and both
+// postingListSize and combinedPostingList walk all layers per trigram —
+// postingListSize from inside a sort comparator — so a 131-system run ends with
+// ~130 of them.
+//
+// Both sub-benchmarks run against the SAME merged cache contents; only the
+// index representation differs. Comparing a 130-layer cache against a 0-layer
+// one would instead compare two different corpora, because each merge appends a
+// system's entries on top of tombstoning the old ones.
+func BenchmarkSlugSearchCache_SearchWithDeltaLayers(b *testing.B) {
+	const systems = 130
+	const titlesPerSystem = 800
+
+	build := func() *SlugSearchCache {
+		base, systemNames := buildBenchSweepCache(systems, titlesPerSystem)
+		cache := base
+		for s := 1; s <= systems; s++ {
+			cache = cache.withoutSystems([]string{systemNames[int64(s)]})
+			cache = mergeSlugSearchCaches(cache, buildBenchFragment(
+				int64(s), systemNames[int64(s)], titlesPerSystem))
+		}
+		return cache
+	}
+
+	// A broad query returns huge posting lists that dwarf the per-layer walk; a
+	// selective one is what a user actually types, and is where layer overhead
+	// is the largest share of the work.
+	queries := map[string][][][]byte{
+		"broad":     {{[]byte("game-title-number")}, {[]byte("alt-name")}},
+		"selective": {{[]byte("number-77-421")}},
+	}
+
+	// After 130 merges the layer count is whatever compaction left behind, which
+	// is at most maxTrigramDeltaLayers — not one layer per system. This measures
+	// the BOUNDED worst case that ships. The unbounded case (130 layers: 42.5us
+	// selective vs 10.8us compacted) was measured before compaction was wired in
+	// and is what justified the bound; it is no longer reachable here.
+	layered := build()
+	if got := len(layered.trigramDeltas); got == 0 || got > maxTrigramDeltaLayers {
+		b.Fatalf("expected 1..%d delta layers after compaction, got %d", maxTrigramDeltaLayers, got)
+	}
+	b.Logf("layered cache carries %d delta layers (cap %d)", len(layered.trigramDeltas), maxTrigramDeltaLayers)
+	compacted := build()
+	compactTrigramDeltas(compacted)
+	if len(compacted.trigramDeltas) != 0 {
+		b.Fatal("compaction must clear delta layers")
+	}
+
+	for _, shape := range []string{"broad", "selective"} {
+		query := queries[shape]
+		for _, variant := range []struct {
+			cache *SlugSearchCache
+			name  string
+		}{{name: "layered", cache: layered}, {name: "compacted", cache: compacted}} {
+			b.Run(shape+"/"+variant.name, func(b *testing.B) {
+				b.ReportAllocs()
+				b.ResetTimer()
+				for b.Loop() {
+					variant.cache.Search(nil, query)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkSlugSearchCache_CompactTrigramDeltas measures one compaction, which
+// is a full CSR rebuild over the whole corpus. This is the cost side of the
+// threshold choice: a lower layer cap buys search latency by paying this more
+// often during an index.
+func BenchmarkSlugSearchCache_CompactTrigramDeltas(b *testing.B) {
+	for _, tier := range []struct{ systems, titlesPerSystem int }{
+		{systems: 130, titlesPerSystem: 800},
+		{systems: 130, titlesPerSystem: 1600},
+	} {
+		b.Run(fmt.Sprintf("entries-%d", tier.systems*tier.titlesPerSystem*2), func(b *testing.B) {
+			base, systemNames := buildBenchSweepCache(tier.systems, tier.titlesPerSystem)
+			cache := base
+			for s := 1; s <= tier.systems; s++ {
+				cache = cache.withoutSystems([]string{systemNames[int64(s)]})
+				cache = mergeSlugSearchCaches(cache, buildBenchFragment(
+					int64(s), systemNames[int64(s)], tier.titlesPerSystem))
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				b.StopTimer()
+				clone := *cache
+				b.StartTimer()
+				compactTrigramDeltas(&clone)
+			}
+		})
+	}
+}

--- a/pkg/database/mediadb/slug_search_cache_persist_test.go
+++ b/pkg/database/mediadb/slug_search_cache_persist_test.go
@@ -290,7 +290,15 @@ func TestPersistedSlugSearchCacheMirrorsCacheStruct(t *testing.T) {
 
 	// Mid-scan state with no on-disk representation; each must exist on the
 	// struct so renames keep this list honest.
-	transientFields := []string{"trigramDeltas", "droppedRanges", "liveEntries"}
+	//
+	// derivedFromComplete and droppedSystems describe a cache partway through
+	// an index. PersistSlugSearchCache refuses such a cache (hasMidScanState),
+	// and a cache read back from disk is either complete or rebuilt, so both
+	// are correct at their zero value on load.
+	transientFields := []string{
+		"trigramDeltas", "droppedRanges", "liveEntries",
+		"derivedFromComplete", "droppedSystems",
+	}
 	for _, name := range transientFields {
 		_, ok := cacheT.FieldByName(name)
 		require.True(t, ok, "transient field %s missing from SlugSearchCache; update this list", name)

--- a/pkg/database/mediadb/slug_search_cache_test.go
+++ b/pkg/database/mediadb/slug_search_cache_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -830,4 +831,97 @@ func BenchmarkSlugSearchCacheBuild_FromDB(b *testing.B) {
 			cleanup()
 		})
 	}
+}
+
+// TestCompactTrigramDeltas_PreservesSearchResults is the correctness gate for
+// folding delta layers into the CSR index. Compaction rebuilds the trigram
+// index over a cache that also carries tombstoned entries from earlier
+// refreshes, and it recomputes the frequency cap against the current entry
+// count rather than the count the original CSR was built with — either could
+// silently change which entries a query returns.
+func TestCompactTrigramDeltas_PreservesSearchResults(t *testing.T) {
+	t.Parallel()
+
+	type entry = struct {
+		slug       string
+		secSlug    string
+		titleDBID  int64
+		systemDBID int64
+	}
+
+	systems := map[int64]string{1: "SNES", 2: "NES", 3: "Genesis"}
+	base := buildTestCache([]entry{
+		{slug: "super-mario-world", secSlug: "mario-world", titleDBID: 10, systemDBID: 1},
+		{slug: "super-metroid", titleDBID: 11, systemDBID: 1},
+		{slug: "super-mario-bros", secSlug: "mario-bros", titleDBID: 20, systemDBID: 2},
+		{slug: "the-legend-of-zelda", titleDBID: 21, systemDBID: 2},
+	}, systems)
+	base.complete = true
+
+	// Refresh two systems so the cache carries both tombstoned base entries and
+	// several delta layers, then a third that was never in the base.
+	cache := base
+	for _, refresh := range []struct {
+		systemID   string
+		entries    []entry
+		systemDBID int64
+	}{
+		{systemID: "SNES", systemDBID: 1, entries: []entry{
+			{slug: "super-mario-world", secSlug: "mario-world", titleDBID: 10, systemDBID: 1},
+			{slug: "super-mario-kart", titleDBID: 12, systemDBID: 1},
+		}},
+		{systemID: "NES", systemDBID: 2, entries: []entry{
+			{slug: "super-mario-bros", secSlug: "mario-bros", titleDBID: 20, systemDBID: 2},
+		}},
+		{systemID: "Genesis", systemDBID: 3, entries: []entry{
+			{slug: "sonic-the-hedgehog", titleDBID: 30, systemDBID: 3},
+			{slug: "super-hang-on", titleDBID: 31, systemDBID: 3},
+		}},
+	} {
+		fragment := buildTestCache(refresh.entries, map[int64]string{refresh.systemDBID: refresh.systemID})
+		fragment.coveredSystems = map[string]struct{}{refresh.systemID: {}}
+		cache = cache.withoutSystems([]string{refresh.systemID})
+		cache = mergeSlugSearchCaches(cache, fragment)
+	}
+	require.NotEmpty(t, cache.trigramDeltas, "setup must leave delta layers to compact")
+
+	queries := map[string][][][]byte{
+		"matches across systems": {{[]byte("super")}},
+		"matches one title":      {{[]byte("metroid")}},
+		"matches secondary slug": {{[]byte("mario-world")}},
+		"matches replaced entry": {{[]byte("mario-kart")}},
+		"matches nothing":        {{[]byte("castlevania")}},
+		"two required fragments": {{[]byte("super")}, {[]byte("mario")}},
+		"system never in base":   {{[]byte("hedgehog")}},
+	}
+	scopes := map[string][]int64{
+		"all systems": nil,
+		"SNES only":   {1},
+		"NES+Genesis": {2, 3},
+	}
+
+	before := make(map[string][]int64)
+	for queryName, query := range queries {
+		for scopeName, scope := range scopes {
+			got := cache.Search(scope, query)
+			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+			before[queryName+"/"+scopeName] = got
+		}
+	}
+
+	compactTrigramDeltas(cache)
+	require.Empty(t, cache.trigramDeltas, "compaction must clear delta layers")
+
+	for queryName, query := range queries {
+		for scopeName, scope := range scopes {
+			got := cache.Search(scope, query)
+			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+			assert.Equal(t, before[queryName+"/"+scopeName], got,
+				"compaction changed results for %s / %s", queryName, scopeName)
+		}
+	}
+
+	// Guard against the whole comparison passing vacuously on empty results.
+	assert.NotEmpty(t, cache.Search(nil, [][][]byte{{[]byte("super")}}),
+		"query fixture must actually match entries")
 }

--- a/pkg/database/mediadb/slug_search_cache_test.go
+++ b/pkg/database/mediadb/slug_search_cache_test.go
@@ -925,3 +925,47 @@ func TestCompactTrigramDeltas_PreservesSearchResults(t *testing.T) {
 	assert.NotEmpty(t, cache.Search(nil, [][][]byte{{[]byte("super")}}),
 		"query fixture must actually match entries")
 }
+
+// TestMergeIntoEmptyBaseBuildsTrigramIndex covers the case where a refresh
+// fragment is merged into a cache that exists but holds no entries — a cache
+// built before any system was indexed, or one whose entries have all been
+// tombstoned by withoutSystems.
+//
+// Search's unfiltered path keys off trigramPostings, so if the merge only
+// records a delta layer the whole cache stays on linearSearch until enough
+// further refreshes accumulate to trigger compaction. Assert the index exists,
+// not just that results are correct: results are correct either way, which is
+// exactly what makes the regression invisible without this.
+func TestMergeIntoEmptyBaseBuildsTrigramIndex(t *testing.T) {
+	t.Parallel()
+
+	type entry = struct {
+		slug       string
+		secSlug    string
+		titleDBID  int64
+		systemDBID int64
+	}
+
+	base := buildTestCache([]entry{}, map[int64]string{})
+	base.coveredSystems = map[string]struct{}{}
+	require.Zero(t, base.entryCount, "base must be a real but empty cache, not nil")
+
+	fragment := buildTestCache([]entry{
+		{slug: "super-mario-world", secSlug: "mario-world", titleDBID: 10, systemDBID: 1},
+		{slug: "super-metroid", titleDBID: 11, systemDBID: 1},
+	}, map[int64]string{1: "SNES"})
+	fragment.coveredSystems = map[string]struct{}{"SNES": {}}
+
+	merged := mergeSlugSearchCaches(base, fragment)
+
+	require.Equal(t, 2, merged.entryCount)
+	assert.NotEmpty(t, merged.trigramPostings,
+		"an empty base leaves nothing to layer a delta on, so the merge must build the CSR index; "+
+			"without it Search takes the linear path over every entry")
+	assert.Empty(t, merged.trigramDeltas,
+		"the index covers every entry, so there should be no delta layer left to compact")
+
+	assert.ElementsMatch(t, []int64{10, 11}, merged.Search(nil, [][][]byte{{[]byte("super")}}))
+	assert.ElementsMatch(t, []int64{10}, merged.Search(nil, [][][]byte{{[]byte("mario-world")}}))
+	assert.Empty(t, merged.Search(nil, [][][]byte{{[]byte("castlevania")}}))
+}

--- a/pkg/database/mediadb/spill_onset_sweep_test.go
+++ b/pkg/database/mediadb/spill_onset_sweep_test.go
@@ -1,0 +1,325 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+// Measures where SQLite's page cache starts spilling dirty pages to the WAL
+// during a long single-transaction media insert, as a function of cache_size and
+// row width.
+//
+// Round 7 of #1279 established the mechanism on the MiSTer: walBytes stays
+// pinned at the empty-WAL value, then walDelta and writeBytes jump together
+// while reads stay flat, and the per-chunk elapsed steps at exactly that point.
+// It also established that the onset is a stable per-system constant but NOT a
+// fixed row count:
+//
+//	C64        66,011 files   onset 16,000   (reproduced R6, R7)
+//	SNESMusic  31,232 files   onset 16,000   (R7)
+//	NES        17,123 files   onset 16,000   (R7)
+//	SNES       13,591 files   onset 10,000   (reproduced R5, R6, R7)
+//	ZXSpectrum 11,723 files   no spill through all 11,723 rows
+//
+// Two explanations were proposed and both were falsified by later data: "the
+// onset is exactly 16,000 rows" (SNES) and "residual staged rows drives it"
+// (SNESMusic, which has the smallest residual and an ordinary 16,000 onset).
+// The surviving hypothesis is that the cache fills by BYTES, so wider rows
+// cross the limit at fewer rows — SNES holds long scene-release ROM names while
+// SNESMusic holds short .spc names. This sweep tests it directly by asking
+// whether onset x bytes-per-row is roughly constant.
+//
+// Run:
+//
+//	go test ./pkg/database/mediadb/ -run TestSpillOnsetSweep -v -timeout 30m
+//
+// Skipped by default: it writes hundreds of MB and takes minutes.
+// A desktop's page cache and fast storage understate the device, so the value
+// here is the SHAPE and the ONSET LOCATION, never an absolute saving to quote
+// for MiSTer hardware.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	spillChunkRows = 2000    // matches the device's upsert chunk size
+	spillMaxRows   = 120_000 // enough headroom for a 64MB cache to spill
+)
+
+// spillResult is one (cacheSize, rowWidth) cell of the sweep.
+type spillResult struct {
+	cacheKiB     int
+	pathLen      int
+	onsetRows    int // 0 means no spill was observed
+	bytesPerRow  float64
+	totalWALSize int64
+}
+
+// spillWALSize returns the current size of the database's WAL file.
+func spillWALSize(t *testing.T, dbPath string) int64 {
+	t.Helper()
+	info, err := os.Stat(dbPath + "-wal")
+	if os.IsNotExist(err) {
+		return 0
+	}
+	require.NoError(t, err)
+	return info.Size()
+}
+
+// measureSpillOnset inserts rows into Media inside a single transaction, in
+// chunks, and returns the cumulative row count at which the WAL first grows.
+//
+// The WAL only grows mid-transaction when SQLite evicts dirty pages it can no
+// longer hold, so its first movement is a direct observation of the spill —
+// this is the same signal the device telemetry captured as walDelta.
+func measureSpillOnset(t *testing.T, cacheKiB, pathLen int) spillResult {
+	t.Helper()
+	ctx := context.Background()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	sqlDB := mediaDB.sql.Load()
+	dbPath := mediaDB.GetDBPath()
+
+	// Pin one connection: cache_size is per-connection, and the transaction
+	// below must run on the connection that received the pragma.
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("PRAGMA cache_size = -%d", cacheKiB))
+	require.NoError(t, err)
+	// Match indexing: no automatic checkpoint, so WAL growth is only ever the
+	// spill and never a checkpoint artefact.
+	_, err = conn.ExecContext(ctx, "PRAGMA wal_autocheckpoint = 0")
+	require.NoError(t, err)
+
+	// One system and one title to satisfy the foreign keys.
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'sweep', 'sweep')")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 1, 'sweep', 'Sweep')")
+	require.NoError(t, err)
+
+	// Pad the path to the requested width. Row width is the variable under test.
+	pad := strings.Repeat("x", maxInt(pathLen-64, 0))
+
+	tx, err := conn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing, SortName)
+		 VALUES (?, 1, 1, ?, ?, 0, ?)`)
+	require.NoError(t, err)
+	defer func() { _ = stmt.Close() }()
+
+	baseWAL := spillWALSize(t, dbPath)
+	res := spillResult{cacheKiB: cacheKiB, pathLen: pathLen}
+
+	for row := 1; row <= spillMaxRows; row++ {
+		dir := fmt.Sprintf("/media/fat/games/sweep/d%03d", row%256)
+		path := fmt.Sprintf("%s/%s_%08d.rom", dir, pad, row)
+		sortName := fmt.Sprintf("%s_%08d", pad, row)
+		if _, execErr := stmt.ExecContext(ctx, row, path, dir, sortName); execErr != nil {
+			t.Fatalf("insert row %d: %v", row, execErr)
+		}
+
+		if row%spillChunkRows != 0 {
+			continue
+		}
+		current := spillWALSize(t, dbPath)
+		if res.onsetRows == 0 && current > baseWAL {
+			res.onsetRows = row
+			res.bytesPerRow = float64(current-baseWAL) / float64(spillChunkRows)
+		}
+		res.totalWALSize = current
+		// Once the onset is found, a few more chunks confirm sustained growth
+		// rather than a one-off, then stop — the rest is just wall clock.
+		if res.onsetRows > 0 && row >= res.onsetRows+2*spillChunkRows {
+			break
+		}
+	}
+	return res
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// TestSpillOnsetSweep answers the open question from #1279 round 7: what sets
+// the spill onset? It sweeps cache_size against row width and prints the onset
+// for each combination.
+//
+// Reading the result:
+//   - onset roughly proportional to cache_size at fixed width -> the cache fills
+//     by bytes, and raising cache_size buys proportional headroom.
+//   - onset roughly inversely proportional to width at fixed cache -> row width
+//     explains why SNES (long ROM names) spills earlier than its file count
+//     suggests, which is the surviving hypothesis.
+//   - onset x bytes-per-row constant across the grid -> both hold, and the
+//     device onsets become predictable from row width alone.
+func TestSpillOnsetSweep(t *testing.T) {
+	if os.Getenv("ZAPAROO_SPILL_SWEEP") == "" {
+		t.Skip("set ZAPAROO_SPILL_SWEEP=1 to run the spill onset sweep (writes hundreds of MB)")
+	}
+
+	cacheSizes := []int{8192, 16384, 32768, 65536} // KiB: 8MB (default), 16, 32 (indexing), 64
+	pathLens := []int{64, 128, 256}                // short / medium / long scene-release style
+
+	var results []spillResult
+	for _, cacheKiB := range cacheSizes {
+		for _, pathLen := range pathLens {
+			name := fmt.Sprintf("cache%dMB_path%d", cacheKiB/1024, pathLen)
+			t.Run(name, func(t *testing.T) {
+				res := measureSpillOnset(t, cacheKiB, pathLen)
+				results = append(results, res)
+				if res.onsetRows == 0 {
+					t.Logf("cache=%dMB pathLen=%d: NO SPILL through %d rows",
+						cacheKiB/1024, pathLen, spillMaxRows)
+					return
+				}
+				t.Logf("cache=%dMB pathLen=%d: onset=%d rows, %.0f WAL bytes/row, onset*bytes=%.1f MB",
+					cacheKiB/1024, pathLen, res.onsetRows, res.bytesPerRow,
+					float64(res.onsetRows)*res.bytesPerRow/(1<<20))
+			})
+		}
+	}
+
+	t.Log("=== spill onset sweep ===")
+	t.Logf("%-10s %-9s %-12s %-14s", "cache", "pathLen", "onset(rows)", "WAL bytes/row")
+	for _, r := range results {
+		onset := "none"
+		if r.onsetRows > 0 {
+			onset = strconv.Itoa(r.onsetRows)
+		}
+		t.Logf("%-10s %-9d %-12s %-14.0f",
+			fmt.Sprintf("%dMB", r.cacheKiB/1024), r.pathLen, onset, r.bytesPerRow)
+	}
+}
+
+// measureSpillCost inserts a fixed number of rows in one transaction at a given
+// cache_size, then commits, and reports the wall time and the total WAL bytes
+// produced.
+//
+// This is the question the onset sweep cannot answer: whether spilling costs
+// anything. Dirty pages reach the WAL at commit regardless, so if a small cache
+// merely writes them earlier then eliminating the spill saves nothing. It is
+// only a real saving if a spilled page is re-dirtied and written again — which
+// random index insertion makes plausible but which has to be measured, not
+// assumed. Equal WAL totals mean redistribution; a larger total at a smaller
+// cache means genuine waste.
+func measureSpillCost(t *testing.T, cacheKiB, pathLen, rows int) (insert, commit time.Duration, walBytes int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	dbPath := mediaDB.GetDBPath()
+
+	conn, err := mediaDB.sql.Load().Conn(ctx)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("PRAGMA cache_size = -%d", cacheKiB))
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "PRAGMA wal_autocheckpoint = 0")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'sweep', 'sweep')")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx,
+		"INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 1, 'sweep', 'Sweep')")
+	require.NoError(t, err)
+	// Checkpoint the setup writes so the WAL measured below is only this workload.
+	_, err = conn.ExecContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+
+	pad := strings.Repeat("x", maxInt(pathLen-64, 0))
+	tx, err := conn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing, SortName)
+		 VALUES (?, 1, 1, ?, ?, 0, ?)`)
+	require.NoError(t, err)
+	defer func() { _ = stmt.Close() }()
+
+	insertStart := time.Now()
+	for row := 1; row <= rows; row++ {
+		dir := fmt.Sprintf("/media/fat/games/sweep/d%03d", row%256)
+		if _, execErr := stmt.ExecContext(ctx, row,
+			fmt.Sprintf("%s/%s_%08d.rom", dir, pad, row), dir,
+			fmt.Sprintf("%s_%08d", pad, row)); execErr != nil {
+			t.Fatalf("insert row %d: %v", row, execErr)
+		}
+	}
+	insert = time.Since(insertStart)
+
+	commitStart := time.Now()
+	require.NoError(t, tx.Commit())
+	commit = time.Since(commitStart)
+
+	return insert, commit, spillWALSize(t, dbPath)
+}
+
+// TestSpillCostByCacheSize measures what the spill actually costs, so a decision
+// about raising cache_size rests on a number rather than on the onset alone.
+func TestSpillCostByCacheSize(t *testing.T) {
+	if os.Getenv("ZAPAROO_SPILL_SWEEP") == "" {
+		t.Skip("set ZAPAROO_SPILL_SWEEP=1 to run the spill cost measurement")
+	}
+
+	const (
+		pathLen  = 128
+		attempts = 3
+	)
+	// 100k rows puts 32MB deep into the spilled regime (onset 34,000) while 64MB
+	// spills only late (onset 68,000) — the C64-shaped case where a bigger cache
+	// should pay off if it ever does. 40k is the control: 32MB barely spills there.
+	for _, rows := range []int{40_000, 100_000} {
+		t.Logf("=== %d rows, pathLen=%d, best of %d ===", rows, pathLen, attempts)
+		t.Logf("%-8s %-12s %-12s %-12s %-14s", "cache", "insert", "commit", "total", "WAL bytes")
+		for _, cacheKiB := range []int{8192, 32768, 65536} {
+			var bestTotal time.Duration
+			var bi, bc time.Duration
+			var bw int64
+			for attempt := range attempts {
+				ins, com, wal := measureSpillCost(t, cacheKiB, pathLen, rows)
+				if attempt == 0 || ins+com < bestTotal {
+					bestTotal, bi, bc, bw = ins+com, ins, com, wal
+				}
+			}
+			t.Logf("%-8s %-12s %-12s %-12s %-14d",
+				fmt.Sprintf("%dMB", cacheKiB/1024),
+				bi.Round(time.Millisecond), bc.Round(time.Millisecond),
+				bestTotal.Round(time.Millisecond), bw)
+		}
+	}
+}

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -1140,10 +1140,27 @@ func sqlBrowseFiles(
 	return sqlBrowseFilesFromMedia(ctx, db, opts)
 }
 
+// overlayHigherPriorityDirectoryCondition drops a directory that a
+// higher-priority route also provides, so an overlaid path shows one entry
+// rather than one per route.
+//
+// INDEXED BY idx_media_browse_sort is load-bearing, not a hint. This runs as a
+// correlated subquery once per candidate row, and its ParentDir bounds are
+// built by concatenation from the outer row, so the planner cannot see them as
+// a range at plan time. Left to choose, it picked media_missing_idx —
+// IsMissing = 0 matches every row in the table, so each candidate scanned the
+// whole of Media and only then filtered on ParentDir.
+//
+// Measured on the #1279 device database (229,553 rows): browsing a 4-file
+// directory took 64 ms, and a 20,131-file directory did not finish in ten
+// minutes. Against idx_media_browse_sort (ParentDir, IsMissing, ...) the same
+// two are 0.6 ms and 22 ms, because the bounds become a covering range scan.
+// The index is created by the base schema migration and recreated by
+// CreateSecondaryIndexes, so it is always present.
 const overlayHigherPriorityDirectoryCondition = `NOT EXISTS (
 	SELECT 1
 	FROM sources higher
-	INNER JOIN Media descendant ON descendant.IsMissing = 0
+	INNER JOIN Media descendant INDEXED BY idx_media_browse_sort ON descendant.IsMissing = 0
 	WHERE higher.priority < sources.priority
 		AND higher.include_dirs = 1
 		AND descendant.ParentDir >= higher.parent_dir || substr(m.Path, length(m.ParentDir) + 1) || '/'
@@ -1804,14 +1821,15 @@ func sqlBrowseFileCount(
 	return sqlBrowseFileCountFromMedia(ctx, db, opts)
 }
 
-func sqlBrowseOverlayFileCount(
-	ctx context.Context,
-	db sqlQueryable,
-	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
-) (int, error) {
+// browseOverlayFileCountQuery builds the overlay file-count statement and its
+// arguments. Separate from the exec so the query-plan regression test can
+// measure the statement production actually runs rather than a copy of it.
+func browseOverlayFileCountQuery(
+	opts database.BrowseFileCountOptions, //nolint:gocritic // mirrors the caller's value options
+) (query string, args []any) {
 	sources := browseOverlaySources(opts.Overlay)
 	values := make([]string, len(sources))
-	args := make([]any, 0, len(sources)+16)
+	args = make([]any, 0, len(sources)+16)
 	for i := range sources {
 		values[i] = "(?, ?, ?)"
 		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
@@ -1827,7 +1845,7 @@ func sqlBrowseOverlayFileCount(
 	}
 	where, filterArgs := browseFilesFilterCondition(filterOpts, false)
 	args = append(args, filterArgs...)
-	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+	return `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
 		ranked AS (
 			SELECT m.DBID,
 				ROW_NUMBER() OVER (
@@ -1842,7 +1860,15 @@ func sqlBrowseOverlayFileCount(
 		SELECT COUNT(*)
 		FROM ranked
 		INNER JOIN Media m ON m.DBID = ranked.DBID
-		WHERE ranked.source_rank = 1 AND ` + where
+		WHERE ranked.source_rank = 1 AND ` + where, args
+}
+
+func sqlBrowseOverlayFileCount(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseFileCountOptions, //nolint:gocritic // internal call mirrors MediaDBI value options
+) (int, error) {
+	query, args := browseOverlayFileCountQuery(opts)
 	var count int
 	if err := db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("browse overlay file count: %w", err)

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -236,3 +236,72 @@ func seedBenchBrowseDB(b *testing.B, mediaDB *MediaDB, rows int, withTags bool) 
 	require.NoError(b, tx.Commit())
 	return parentDir
 }
+
+// BenchmarkBrowseCacheRefresh_GrowingTable reproduces the mid-scan refresh
+// pattern of a long index: each system is refreshed once, in order, against a
+// BrowseDirs table that already holds every earlier system's dirs. The reported
+// time is the whole sweep, so a refresh whose cost tracks total table size shows
+// up as super-linear growth in systems rather than a constant per-system cost.
+func BenchmarkBrowseCacheRefresh_GrowingTable(b *testing.B) {
+	for _, systems := range []int{32, 128} {
+		b.Run(fmt.Sprintf("systems-%d", systems), func(b *testing.B) {
+			b.ReportAllocs()
+			ctx := context.Background()
+			for b.Loop() {
+				b.StopTimer()
+				mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+				systemIDs := seedBenchBrowseCacheSystems(b, mediaDB, systems)
+				b.StartTimer()
+
+				for _, systemID := range systemIDs {
+					if err := mediaDB.PopulateBrowseCacheForSystems(ctx, []string{systemID}); err != nil {
+						b.Fatal(err)
+					}
+				}
+
+				b.StopTimer()
+				cleanup()
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// seedBenchBrowseCacheSystems gives each system its own dir subtree under a
+// shared ancestor, so every refresh both reuses existing dirs and adds new ones.
+func seedBenchBrowseCacheSystems(b *testing.B, mediaDB *MediaDB, systems int) []string {
+	b.Helper()
+	ctx := context.Background()
+	const dirsPerSystem = 20
+	const filesPerDir = 5
+
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	systemIDs := make([]string, 0, systems)
+	for s := 1; s <= systems; s++ {
+		systemID := fmt.Sprintf("BenchSys%03d", s)
+		systemIDs = append(systemIDs, systemID)
+		_, err = tx.ExecContext(ctx,
+			"INSERT INTO Systems (DBID, SystemID, Name) VALUES (?, ?, ?)", s, systemID, systemID)
+		require.NoError(b, err)
+		_, err = tx.ExecContext(ctx,
+			"INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, ?, ?, ?)",
+			s, s, fmt.Sprintf("bench-title-%03d", s), systemID)
+		require.NoError(b, err)
+
+		for d := range dirsPerSystem {
+			dir := fmt.Sprintf("/roms/shared/sys%03d/dir%02d/", s, d)
+			for f := range filesPerDir {
+				_, err = tx.ExecContext(ctx, `
+					INSERT INTO Media (SystemDBID, MediaTitleDBID, Path, ParentDir, SortName, IsMissing)
+					VALUES (?, ?, ?, ?, ?, 0)`,
+					s, s, fmt.Sprintf("%sgame%02d.rom", dir, f), dir, fmt.Sprintf("game%02d", f))
+				require.NoError(b, err)
+			}
+		}
+	}
+	require.NoError(b, tx.Commit())
+	return systemIDs
+}

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -570,6 +570,15 @@ func attachBrowseCacheDirLookup(
 
 // scanBrowseCacheMediaForSystems feeds the target systems' non-missing media
 // rows into the builder.
+// browseCacheMediaScanQuery builds the media scan statement for the given IN
+// placeholder clause. Exists as its own function so the query-plan regression
+// test can measure the real statement rather than a copy of it that could drift.
+func browseCacheMediaScanQuery(inClause string) string {
+	return "SELECT m.SystemDBID, m.Path FROM Media m " +
+		"WHERE m.IsMissing = 0 AND m.SystemDBID IN (" + inClause + ") " +
+		"ORDER BY m.SystemDBID, m.Path"
+}
+
 func scanBrowseCacheMediaForSystems(
 	ctx context.Context, tx *sql.Tx, builder *browseCacheBuilder, inClause string, args []any,
 ) error {
@@ -581,9 +590,7 @@ func scanBrowseCacheMediaForSystems(
 	// Row order only decides which DBID a newly minted dir receives, so any stable
 	// order will do — and Path order is steadier than rowid order, which depends
 	// on insertion history. See browse_cache_refresh_plan_test.go.
-	rows, err := tx.QueryContext(ctx,
-		"SELECT m.SystemDBID, m.Path FROM Media m WHERE m.IsMissing = 0 AND m.SystemDBID IN ("+
-			inClause+") ORDER BY m.SystemDBID, m.Path", args...)
+	rows, err := tx.QueryContext(ctx, browseCacheMediaScanQuery(inClause), args...)
 	if err != nil {
 		return fmt.Errorf("browse cache: failed to query system media: %w", err)
 	}

--- a/pkg/database/mediadb/sql_browse_cache.go
+++ b/pkg/database/mediadb/sql_browse_cache.go
@@ -22,6 +22,8 @@ package mediadb
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"path"
 	"path/filepath"
@@ -29,8 +31,102 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+// browseCacheClearStatements empties the browse cache tables, children first.
+// Only safe to run with foreign key enforcement disabled — see
+// acquireBrowseCacheConn.
+//
+//goland:noinspection SqlWithoutWhere
+var browseCacheClearStatements = []string{
+	"DELETE FROM BrowseDirCounts",
+	"DELETE FROM BrowseDirs",
+}
+
+// sqlClearBrowseCacheTables empties both browse cache tables in a single
+// foreign-key-disabled transaction. Used when an on-disk cache from an older
+// schema has to be discarded before a refresh can reuse existing dir DBIDs.
+func sqlClearBrowseCacheTables(ctx context.Context, db *sql.DB) error {
+	conn, releaseConn, err := acquireBrowseCacheConn(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer releaseConn()
+
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("browse cache: failed to begin clear transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	started := time.Now()
+	for _, stmt := range browseCacheClearStatements {
+		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
+			return fmt.Errorf("browse cache: failed to clear incompatible cache: %w", execErr)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("browse cache: failed to commit clear: %w", err)
+	}
+	log.Debug().Dur("duration", time.Since(started)).Msg("browse cache cleared incompatible entries")
+	return nil
+}
+
+// acquireBrowseCacheConn pins a connection and disables foreign key enforcement
+// on it for the duration of a browse cache rebuild, returning the connection and
+// a release func that restores the pragma before the connection goes back to the
+// pool.
+//
+// BrowseDirs is the parent of three ON DELETE CASCADE foreign keys — a
+// self-reference plus two from BrowseDirCounts — and connections are opened
+// _foreign_keys=ON. With enforcement on, SQLite cannot apply its truncate
+// optimization to an unqualified DELETE: it removes rows one at a time, running
+// the child probes and the recursive self-cascade through a statement journal.
+// On the MiSTer test device that measured 261.9s to clear ~21,500 rows, 13x the
+// cost of the inserts that replaced them. Deleting children first with
+// enforcement off leaves no cascade work to do. See #1279, and sqlTruncate /
+// sqlTruncateSystems in sql_maintenance.go which solve the same problem.
+//
+// PRAGMA foreign_keys is session-local and is a no-op inside a transaction, so
+// the pragma has to be set on the same connection the transaction will use, and
+// before that transaction begins.
+func acquireBrowseCacheConn(ctx context.Context, db *sql.DB) (*sql.Conn, func(), error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("browse cache: failed to acquire connection: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("browse cache: failed to release connection")
+		}
+		return nil, nil, fmt.Errorf("browse cache: failed to disable foreign keys: %w", err)
+	}
+
+	release := func() {
+		// context.Background: the pragma must be restored even when ctx is already
+		// done, otherwise the connection returns to the pool with enforcement off
+		// and silently disables it for unrelated queries.
+		if _, resetErr := conn.ExecContext(context.Background(), "PRAGMA foreign_keys = ON"); resetErr != nil {
+			// Discard the physical connection rather than let it back into the
+			// pool with foreign keys disabled (same approach as closeWriterConn).
+			log.Warn().Err(resetErr).
+				Msg("browse cache: failed to restore foreign keys, discarding connection")
+			discardErr := conn.Raw(func(any) error { return driver.ErrBadConn })
+			if discardErr != nil &&
+				!errors.Is(discardErr, driver.ErrBadConn) &&
+				!errors.Is(discardErr, sql.ErrConnDone) {
+				log.Warn().Err(discardErr).Msg("browse cache: failed to discard connection")
+			}
+			return
+		}
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("browse cache: failed to release connection")
+		}
+	}
+	return conn, release, nil
+}
 
 const browseCacheSchemaVersion = "3"
 
@@ -60,8 +156,19 @@ type browseCacheCountKey struct {
 }
 
 type browseCacheBuilder struct {
-	dirs      map[string]*browseCacheDir
-	counts    map[browseCacheCountKey]int
+	dirs   map[string]*browseCacheDir
+	counts map[browseCacheCountKey]int
+	// lookupExisting resolves a dir path to its already-persisted row. It is nil
+	// for a full rebuild, which clears the table and owns every DBID itself.
+	// Incremental refreshes set it so a dir shared with an already-indexed system
+	// keeps its DBID, which that system's count rows reference.
+	lookupExisting func(path string) (*browseCacheDir, bool, error)
+	// lookupErr holds the first lookup failure. ensureDir cannot return an error
+	// without threading one through addMedia and countPairsForPath, so the caller
+	// must check this before persisting anything: after a failure the builder has
+	// minted a fresh DBID for a path that may already exist, and inserting that
+	// would violate the Path unique constraint or split a shared dir in two.
+	lookupErr error
 	nextDirID int64
 	mediaRows int
 }
@@ -83,7 +190,16 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 	builder := newBrowseCacheBuilder()
 	builder.ensureDir("/")
 
-	tx, err := db.BeginTx(ctx, nil)
+	// Pinned connection with foreign keys off: the clear below is an unqualified
+	// DELETE over a table with cascading children, which is pathologically slow
+	// with enforcement on. See acquireBrowseCacheConn.
+	conn, releaseConn, err := acquireBrowseCacheConn(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer releaseConn()
+
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("browse cache: failed to begin transaction: %w", err)
 	}
@@ -100,10 +216,7 @@ func sqlPopulateBrowseCache(ctx context.Context, db *sql.DB) error {
 		Msg("browse cache media scan complete")
 
 	deleteStarted := time.Now()
-	for _, stmt := range []string{
-		"DELETE FROM BrowseDirCounts",
-		"DELETE FROM BrowseDirs",
-	} {
+	for _, stmt := range browseCacheClearStatements {
 		if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
 			return fmt.Errorf("browse cache: failed to clear tables: %w", execErr)
 		}
@@ -224,6 +337,21 @@ func (b *browseCacheBuilder) addMedia(systemDBID int64, mediaPath string) {
 func (b *browseCacheBuilder) ensureDir(dirPath string) *browseCacheDir {
 	if dir, ok := b.dirs[dirPath]; ok {
 		return dir
+	}
+	// A miss is resolved against the table once and then cached in b.dirs either
+	// way, so each distinct path costs at most one probe per refresh. Ancestors
+	// are not walked here: countPairsForPath already calls ensureDir on every
+	// ancestor explicitly, and the recursion below exists only to fill parentID
+	// when minting a new dir.
+	if b.lookupExisting != nil && b.lookupErr == nil {
+		dir, found, err := b.lookupExisting(dirPath)
+		switch {
+		case err != nil:
+			b.lookupErr = err
+		case found:
+			b.dirs[dirPath] = dir
+			return dir
+		}
 	}
 	parentPath, name, isVirtual := browseCacheDirParentAndName(dirPath)
 	var parentID *int64
@@ -395,30 +523,49 @@ func insertBrowseCacheCounts(ctx context.Context, tx *sql.Tx, counts map[browseC
 	return nil
 }
 
-// loadBrowseCacheDirs seeds the builder with the existing BrowseDirs rows so
-// dirs shared across systems keep their DBIDs (other systems' count rows
-// reference them). Returns the first DBID available for newly created dirs.
-func loadBrowseCacheDirs(ctx context.Context, tx *sql.Tx, builder *browseCacheBuilder) (int64, error) {
-	rows, err := tx.QueryContext(ctx, "SELECT DBID, ParentDirDBID, Path, Name, IsVirtual FROM BrowseDirs")
-	if err != nil {
-		return 0, fmt.Errorf("browse cache: failed to load existing dirs: %w", err)
+// attachBrowseCacheDirLookup points the builder at the existing BrowseDirs rows
+// so dirs shared across systems keep their DBIDs (other systems' count rows
+// reference them). Returns the first DBID available for newly created dirs, and
+// a closer for the prepared statement.
+//
+// This resolves one path at a time instead of loading the whole table. The table
+// accumulates every dir from every system already indexed, while a refresh only
+// ever touches the ancestor closure of one system's media paths, so a full load
+// costs O(all dirs) per system and grew to 1.2s on the last system of a 131-
+// system run while inserting fewer rows than the first. Probing is O(dirs this
+// system touches) against the Path unique index, and each distinct path is
+// probed at most once because ensureDir caches hits and misses alike.
+func attachBrowseCacheDirLookup(
+	ctx context.Context, tx *sql.Tx, builder *browseCacheBuilder,
+) (firstNewID int64, closeFn func(), err error) {
+	// MAX over an INTEGER PRIMARY KEY is a single index seek, not a scan. Taken
+	// inside the refresh transaction, so the !compatible truncation above is
+	// already visible and restarts numbering at 1.
+	if scanErr := tx.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(DBID), 0) + 1 FROM BrowseDirs").Scan(&firstNewID); scanErr != nil {
+		return 0, nil, fmt.Errorf("browse cache: failed to read next dir id: %w", scanErr)
 	}
-	defer func() { _ = rows.Close() }()
+	builder.nextDirID = firstNewID
 
-	for rows.Next() {
+	stmt, err := tx.PrepareContext(ctx,
+		"SELECT DBID, ParentDirDBID, Path, Name, IsVirtual FROM BrowseDirs WHERE Path = ?")
+	if err != nil {
+		return 0, nil, fmt.Errorf("browse cache: failed to prepare dir lookup: %w", err)
+	}
+
+	builder.lookupExisting = func(path string) (*browseCacheDir, bool, error) {
 		var dir browseCacheDir
-		if scanErr := rows.Scan(&dir.id, &dir.parentID, &dir.path, &dir.name, &dir.isVirtual); scanErr != nil {
-			return 0, fmt.Errorf("browse cache: failed to scan existing dir: %w", scanErr)
+		scanErr := stmt.QueryRowContext(ctx, path).
+			Scan(&dir.id, &dir.parentID, &dir.path, &dir.name, &dir.isVirtual)
+		switch {
+		case errors.Is(scanErr, sql.ErrNoRows):
+			return nil, false, nil
+		case scanErr != nil:
+			return nil, false, fmt.Errorf("browse cache: failed to look up dir %s: %w", path, scanErr)
 		}
-		builder.dirs[dir.path] = &dir
-		if dir.id >= builder.nextDirID {
-			builder.nextDirID = dir.id + 1
-		}
+		return &dir, true, nil
 	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return 0, fmt.Errorf("browse cache: existing dirs iteration error: %w", rowsErr)
-	}
-	return builder.nextDirID, nil
+	return firstNewID, func() { _ = stmt.Close() }, nil
 }
 
 // scanBrowseCacheMediaForSystems feeds the target systems' non-missing media
@@ -427,9 +574,16 @@ func scanBrowseCacheMediaForSystems(
 	ctx context.Context, tx *sql.Tx, builder *browseCacheBuilder, inClause string, args []any,
 ) error {
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	// Ordered by (SystemDBID, Path), which is exactly what
+	// media_system_present_path_idx yields, so the covering index serves the scan
+	// and the ordering together. Ordering on m.DBID instead adds a temp B-tree
+	// sort: DBID is the rowid, and the index does not carry it in sorted order.
+	// Row order only decides which DBID a newly minted dir receives, so any stable
+	// order will do — and Path order is steadier than rowid order, which depends
+	// on insertion history. See browse_cache_refresh_plan_test.go.
 	rows, err := tx.QueryContext(ctx,
 		"SELECT m.SystemDBID, m.Path FROM Media m WHERE m.IsMissing = 0 AND m.SystemDBID IN ("+
-			inClause+") ORDER BY m.DBID", args...)
+			inClause+") ORDER BY m.SystemDBID, m.Path", args...)
 	if err != nil {
 		return fmt.Errorf("browse cache: failed to query system media: %w", err)
 	}
@@ -463,31 +617,52 @@ func sqlPopulateBrowseCacheForSystems(ctx context.Context, db *sql.DB, systemDBI
 	started := time.Now()
 	builder := newBrowseCacheBuilder()
 
+	// Per-statement timers. Round 8 of #1279 measured this function at 662,224 ms
+	// run-wide — 11.04 min, 12.7% of a full reindex — and could not say which
+	// statement spent it. The shape ruled out the obvious answers: the cost was
+	// flat at ~6 s whether a system held 7 files or 1,441, systems holding zero
+	// files paid nothing, and the inserts were 24-53 ms of an 8-19 s call. A flat
+	// per-call cost points at setup or teardown rather than at the work, so every
+	// step is timed separately and reported below.
+	var timing browseCacheRefreshTiming
+
+	// An on-disk cache from an older schema has to be cleared wholesale. That is
+	// the same cascading full-table delete as the full rebuild, so it runs in its
+	// own foreign-key-disabled transaction ahead of the refresh below. The common
+	// path — a compatible cache — keeps enforcement on: its delete is scoped to
+	// BrowseDirCounts, a child-only table where no cascade fires, and this
+	// function runs once per system on every index.
+	stepStart := time.Now()
+	compatible, err := sqlBrowseCacheVersionCompatible(ctx, db)
+	if err != nil {
+		return err
+	}
+	timing.versionCheck = time.Since(stepStart)
+	if !compatible {
+		stepStart = time.Now()
+		if clearErr := sqlClearBrowseCacheTables(ctx, db); clearErr != nil {
+			return clearErr
+		}
+		timing.clearIncompatible = time.Since(stepStart)
+	}
+
+	// Timed separately from the statements that follow: BeginTx can block waiting
+	// for a pooled connection, and connection wait is not query cost.
+	stepStart = time.Now()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("browse cache: failed to begin system refresh transaction: %w", err)
 	}
+	timing.beginTx = time.Since(stepStart)
 	defer func() { _ = tx.Rollback() }()
 
-	compatible, err := sqlBrowseCacheVersionCompatible(ctx, tx)
+	stepStart = time.Now()
+	firstNewID, closeLookup, err := attachBrowseCacheDirLookup(ctx, tx, builder)
 	if err != nil {
 		return err
 	}
-	if !compatible {
-		for _, stmt := range []string{
-			"DELETE FROM BrowseDirCounts",
-			"DELETE FROM BrowseDirs",
-		} {
-			if _, execErr := tx.ExecContext(ctx, stmt); execErr != nil {
-				return fmt.Errorf("browse cache: failed to clear incompatible cache: %w", execErr)
-			}
-		}
-	}
-
-	firstNewID, err := loadBrowseCacheDirs(ctx, tx, builder)
-	if err != nil {
-		return err
-	}
+	timing.attachLookup = time.Since(stepStart)
+	defer closeLookup()
 	builder.ensureDir("/")
 
 	args := make([]any, len(systemDBIDs))
@@ -496,15 +671,25 @@ func sqlPopulateBrowseCacheForSystems(ctx context.Context, db *sql.DB, systemDBI
 	}
 	inClause := prepareVariadic("?", ",", len(systemDBIDs))
 
+	stepStart = time.Now()
 	if err := scanBrowseCacheMediaForSystems(ctx, tx, builder, inClause, args); err != nil {
 		return err
 	}
+	timing.mediaScan = time.Since(stepStart)
+	// Must come before any write: ensureDir swallows lookup failures and mints a
+	// new DBID for the path it could not resolve, so persisting past one would
+	// duplicate a shared dir. The transaction rolls back untouched.
+	if builder.lookupErr != nil {
+		return builder.lookupErr
+	}
 
+	stepStart = time.Now()
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
 	if _, execErr := tx.ExecContext(ctx,
 		"DELETE FROM BrowseDirCounts WHERE SystemDBID IN ("+inClause+")", args...); execErr != nil {
 		return fmt.Errorf("browse cache: failed to clear system counts: %w", execErr)
 	}
+	timing.deleteCounts = time.Since(stepStart)
 
 	newDirs := make(map[string]*browseCacheDir)
 	for dirPath, dir := range builder.dirs {
@@ -512,12 +697,14 @@ func sqlPopulateBrowseCacheForSystems(ctx context.Context, db *sql.DB, systemDBI
 			newDirs[dirPath] = dir
 		}
 	}
+	stepStart = time.Now()
 	if err := insertBrowseCacheDirs(ctx, tx, newDirs); err != nil {
 		return err
 	}
 	if err := insertBrowseCacheCounts(ctx, tx, builder.counts); err != nil {
 		return err
 	}
+	timing.inserts = time.Since(stepStart)
 
 	// Mark the cache serveable but pending a full rebuild. Never downgrade
 	// visibility: the sentinel is only meaningful alongside present rows,
@@ -538,17 +725,57 @@ func sqlPopulateBrowseCacheForSystems(ctx context.Context, db *sql.DB, systemDBI
 		return fmt.Errorf("browse cache: failed to mark partial index coverage: %w", cfgErr)
 	}
 
+	stepStart = time.Now()
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("browse cache: failed to commit system refresh: %w", err)
 	}
+	timing.commit = time.Since(stepStart)
 
-	log.Info().
+	total := time.Since(started)
+	timing.unattributed = total - timing.sum()
+	timing.apply(log.Info().
 		Int("systems", len(systemDBIDs)).
 		Int("newDirs", len(newDirs)).
 		Int("counts", len(builder.counts)).
-		Dur("duration", time.Since(started)).
+		Dur("duration", total)).
 		Msg("browse cache refreshed for systems")
 	return nil
+}
+
+// browseCacheRefreshTiming breaks sqlPopulateBrowseCacheForSystems into its
+// individual statements so a slow refresh names the statement responsible.
+//
+// Every field is reported on every refresh, including the near-zero ones: the
+// point is to see which one is not near-zero, and a field omitted when small is
+// a field that cannot be ruled out later.
+type browseCacheRefreshTiming struct {
+	versionCheck      time.Duration
+	clearIncompatible time.Duration
+	beginTx           time.Duration
+	attachLookup      time.Duration
+	mediaScan         time.Duration
+	deleteCounts      time.Duration
+	inserts           time.Duration
+	commit            time.Duration
+	unattributed      time.Duration
+}
+
+func (t *browseCacheRefreshTiming) sum() time.Duration {
+	return t.versionCheck + t.clearIncompatible + t.beginTx + t.attachLookup +
+		t.mediaScan + t.deleteCounts + t.inserts + t.commit
+}
+
+func (t *browseCacheRefreshTiming) apply(e *zerolog.Event) *zerolog.Event {
+	return e.
+		Dur("versionCheck", t.versionCheck).
+		Dur("clearIncompatible", t.clearIncompatible).
+		Dur("beginTx", t.beginTx).
+		Dur("attachLookup", t.attachLookup).
+		Dur("mediaScan", t.mediaScan).
+		Dur("deleteCounts", t.deleteCounts).
+		Dur("inserts", t.inserts).
+		Dur("commit", t.commit).
+		Dur("unattributed", t.unattributed)
 }
 
 func sqlBrowseCacheVersionCompatible(ctx context.Context, db sqlQueryable) (bool, error) {

--- a/pkg/database/mediadb/sql_cache.go
+++ b/pkg/database/mediadb/sql_cache.go
@@ -52,7 +52,7 @@ func buildPopulateMediaTagsSQL(systemFilter string) string {
 				m.SystemDBID AS SystemDBID,
 				mt.TagDBID AS TagDBID,
 				COUNT(*) AS Cnt
-			FROM Media m INDEXED BY media_system_path_idx
+			FROM Media m INDEXED BY sqlite_autoindex_Media_1
 			CROSS JOIN MediaTags mt
 			%s
 			  AND mt.MediaDBID = m.DBID

--- a/pkg/database/mediadb/sql_media.go
+++ b/pkg/database/mediadb/sql_media.go
@@ -198,12 +198,12 @@ func sqlGetMissingMediaCount(ctx context.Context, db *sql.DB) (int, error) {
 // Single-table query on Media: this runs once per system over every media row,
 // and no caller reads TitleSlug, so the MediaTitles join would only add a
 // per-row B-tree probe. SystemID is filled from the argument. Ordering by Path
-// lets SQLite stream from media_system_path_idx instead of filtering by system
-// and then building a temp sort by DBID for large systems.
+// lets SQLite stream from the UNIQUE(SystemDBID, Path) index instead of
+// filtering by system and then building a temp sort by DBID for large systems.
 func sqlGetMediaBySystemID(ctx context.Context, db *sql.DB, systemID string) ([]database.MediaWithFullPath, error) {
 	query := `
 		SELECT m.DBID, m.Path, m.ParentDir, m.MediaTitleDBID, m.SortName, m.IsMissing
-		FROM Media m INDEXED BY media_system_path_idx
+		FROM Media m INDEXED BY sqlite_autoindex_Media_1
 		WHERE m.SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)
 		ORDER BY m.Path
 	`

--- a/pkg/database/mediadb/sql_optimization_stamp.go
+++ b/pkg/database/mediadb/sql_optimization_stamp.go
@@ -1,0 +1,95 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// sqlMediaExists reports whether the database holds any media rows at all.
+func sqlMediaExists(ctx context.Context, db sqlQueryable) (bool, error) {
+	var exists int
+	err := db.QueryRowContext(ctx, `SELECT 1 FROM Media LIMIT 1`).Scan(&exists)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to check for media rows: %w", err)
+	}
+	return true, nil
+}
+
+// sqlClearOptimizationStamp removes the pending optimization markers.
+func sqlClearOptimizationStamp(ctx context.Context, db sqlQueryable) error {
+	_, err := db.ExecContext(ctx,
+		"DELETE FROM DBConfig WHERE Name IN (?, ?)",
+		DBConfigOptimizationStatus,
+		DBConfigOptimizationStep,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to clear optimization stamp: %w", err)
+	}
+	return nil
+}
+
+// clearOptimizationStampIfEmpty drops a pending optimization stamp from a
+// database that has no media to optimize.
+//
+// Two migrations stamp OptimizationStatus=pending and OptimizationStep=browse_cache
+// unconditionally so that *existing* databases rebuild their browse cache on
+// upgrade (20260429142159_system_browse_cache.sql and 20260430054834_browse_v2.sql).
+// A brand-new database runs the same migration chain, so it is born pending too,
+// and checkAndResumeOptimization then "resumes" a browse cache rebuild over zero
+// media on first start.
+//
+// The stamp itself must stay — the upgrade path depends on it. This only clears
+// it where there is provably nothing to do. Mirrors disambiguationBackfillPending:
+// stamp-on-empty rather than skip-on-empty, so the state is corrected once at
+// migration time instead of being re-evaluated on every start.
+//
+// A rebuild via Recreate also lands here with an empty database, which is
+// correct: its legitimate pending stamp is written later, after indexing
+// finishes, so clearing here cannot race it.
+func (db *MediaDB) clearOptimizationStampIfEmpty(ctx context.Context) error {
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
+		return ErrNullSQL
+	}
+
+	status, err := sqlGetOptimizationStatus(ctx, sqlDB)
+	if err != nil {
+		return err
+	}
+	if status == "" {
+		return nil
+	}
+
+	hasMedia, err := sqlMediaExists(ctx, sqlDB)
+	if err != nil {
+		return err
+	}
+	if hasMedia {
+		return nil
+	}
+	return sqlClearOptimizationStamp(ctx, sqlDB)
+}

--- a/pkg/database/mediadb/sql_plan_test.go
+++ b/pkg/database/mediadb/sql_plan_test.go
@@ -41,7 +41,7 @@ func TestExplainHotScraperQueries(t *testing.T) {
 
 	explainQueryPlan(ctx, t, mediaDB.sql.Load(), `
 		SELECT m.DBID
-		FROM Media m INDEXED BY media_system_path_idx
+		FROM Media m INDEXED BY sqlite_autoindex_Media_1
 		CROSS JOIN MediaTags mt
 		WHERE m.SystemDBID = ?
 		  AND mt.MediaDBID = m.DBID

--- a/pkg/database/mediadb/sql_scan_reconcile.go
+++ b/pkg/database/mediadb/sql_scan_reconcile.go
@@ -76,12 +76,33 @@ type canonicalTagRow struct {
 // with sqlGetNonScannerTagDBIDs.
 const (
 	scanFlagMissingBatchSize = 5000
+	// A row here writes to roughly nine Media indexes (vs. scanFlagMissingBatchSize's
+	// single-column flip on rows an existing index already located), so a smaller
+	// chunk keeps a chunk under logScanReconcileStep's 5s warn threshold at the
+	// ~1.1-1.6ms/row rate seen at every observed system scale — see
+	// sqlUpsertStagedMedia and #1279.
+	scanUpsertMediaBatchSize = 2000
 	// Title-scoped disambiguation performs poorly on large media databases even
 	// for modest touched sets because SQLite repeatedly plans around a long ID
 	// scope. During scan reconcile, recomputing the current system in one pass is
 	// faster and still bounded; keep single-title updates scoped for tiny changes.
 	scanSystemDisambiguationThreshold = 1
-	scanStaleLinkFilter               = `
+	// #1279: on a 66k-file system this filter (used by "capture stale tag
+	// titles" and "delete stale tag links") and "capture tag additions" cost
+	// 205s combined finding zero rows. EXPLAIN QUERY PLAN at 50k synthetic
+	// scale (pkg/database/mediascanner/reconcile_query_plan_test.go,
+	// ZAPAROO_RECONCILE_EQP=1) shows both drive from Media filtered by an
+	// indexed SystemDBID search, not an unindexed full scan — so the cost is
+	// the query's shape, not a missing index: it must touch every existing
+	// (media, tag) pair for the system to prove none are stale, which is
+	// O(existing corpus) regardless of what changed. sqlite_stat1 is also
+	// stale for ScanStage/ScanStageTags mid-reconcile (they're cleared and
+	// repopulated every system, so ANALYZE never captures them), which likely
+	// affects join order elsewhere too — see the upsert media CROSS JOIN
+	// below for a case where that mattered. Candidate direction for a future
+	// round: start from ScanStageTags/ScanStage (bounded to what's staged)
+	// instead of Media, if the stale-detection semantics allow it.
+	scanStaleLinkFilter = `
 	FROM Media m
 	JOIN ScanStage s ON s.Path = m.Path
 	JOIN MediaTags mt ON mt.MediaDBID = m.DBID
@@ -210,6 +231,9 @@ func scanReconcileExec(ctx context.Context, db sqlQueryable, systemID, step, que
 	return affected, nil
 }
 
+// logScanReconcileStep is the single choke point every set-based reconcile step
+// logs through. A step slower than the threshold is warned rather than debugged
+// so it survives at the default log level.
 func logScanReconcileStep(systemID, step string, affected int64, elapsed time.Duration) {
 	logEvent := log.Debug()
 	if elapsed > 5*time.Second {
@@ -222,19 +246,37 @@ func logScanReconcileStep(systemID, step string, affected int64, elapsed time.Du
 		Msg("scan reconcile step completed")
 }
 
+// chunkedStepTiming carries the parts of a chunked step's wall time that must
+// not be reported as that step's SQL cost.
+//
+// pacing is time parked in the scanner's throttle between chunks. The scanner
+// already counts that in its own throttle total, so folding it into the step
+// would double-count it and make a step look expensive when it was only
+// waiting. bounds is the per-chunk cursor lookup — real SQL, but a different
+// statement from the step's main exec, and worth separating because it runs
+// once per chunk (33 times on a 66k-file system) and is invisible today.
+//
+// Both are subtracted from the step's reported figure and reported on their
+// own; see the step-timings line in sqlReconcileStagedSystem.
+type chunkedStepTiming struct {
+	bounds time.Duration
+	pacing time.Duration
+}
+
 func sqlFlagMissingMedia(
 	ctx context.Context,
 	db sqlQueryable,
 	systemID string,
 	systemDBID int64,
 	yield func() error,
-) (int64, error) {
+) (int64, chunkedStepTiming, error) {
 	const step = "flag missing media"
 	totalStart := time.Now()
 	totalAffected := int64(0)
+	var timing chunkedStepTiming
 	for {
 		if err := ctx.Err(); err != nil {
-			return totalAffected, fmt.Errorf("scan reconcile cancelled before %s: %w", step, err)
+			return totalAffected, timing, fmt.Errorf("scan reconcile cancelled before %s: %w", step, err)
 		}
 		chunkStart := time.Now()
 		res, err := db.ExecContext(ctx, `
@@ -254,11 +296,11 @@ func sqlFlagMissingMedia(
 				Str("step", step).
 				Dur("elapsed", chunkElapsed).
 				Msg("scan reconcile step failed")
-			return totalAffected, fmt.Errorf("scan reconcile %s failed: %w", step, err)
+			return totalAffected, timing, fmt.Errorf("scan reconcile %s failed: %w", step, err)
 		}
 		affected, err := res.RowsAffected()
 		if err != nil {
-			return totalAffected, fmt.Errorf("scan reconcile %s: failed to read affected rows: %w", step, err)
+			return totalAffected, timing, fmt.Errorf("scan reconcile %s: failed to read affected rows: %w", step, err)
 		}
 		totalAffected += affected
 		if affected > 0 {
@@ -274,46 +316,184 @@ func sqlFlagMissingMedia(
 				Msg("scan reconcile chunk completed")
 		}
 		if yield != nil {
-			if yieldErr := yield(); yieldErr != nil {
-				return totalAffected, fmt.Errorf("scan reconcile pacing after %s failed: %w", step, yieldErr)
+			pacingStart := time.Now()
+			yieldErr := yield()
+			timing.pacing += time.Since(pacingStart)
+			if yieldErr != nil {
+				return totalAffected, timing, fmt.Errorf("scan reconcile pacing after %s failed: %w", step, yieldErr)
 			}
 		}
 		if affected < scanFlagMissingBatchSize {
 			break
 		}
 	}
-	logScanReconcileStep(systemID, step, totalAffected, time.Since(totalStart))
-	return totalAffected, nil
+	logScanReconcileStep(systemID, step, totalAffected, time.Since(totalStart)-timing.pacing)
+	return totalAffected, timing, nil
+}
+
+// sqlUpsertStagedMedia folds ScanStage rows into Media in Path-ordered chunks
+// rather than one unchunked statement covering the whole system. On a system
+// large enough to matter this reconcile step showed super-linear cost as one
+// statement (see #1279): each chunked exec bounds Media's per-statement index
+// maintenance to scanUpsertMediaBatchSize rows.
+//
+// The chunk cursor is scanUpsertMediaBatchSize forward positions on
+// ScanStage.Path (that table's own WITHOUT ROWID primary key), found with a
+// cheap bounds query before each upsert exec. This can't reuse
+// sqlFlagMissingMedia's loop shape: that step is self-draining (each chunk's
+// UPDATE removes those rows from the next chunk's predicate), but staged rows
+// here still match the source query after being upserted, so a bare
+// LIMIT-only loop would reprocess the same rows forever. RowsAffected also
+// can't drive the loop — ON CONFLICT ... DO UPDATE ... WHERE <changed> reports
+// 0 for a chunk that changed nothing, even when more chunks remain — so the
+// cursor advances independently of it.
+func sqlUpsertStagedMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	systemID string,
+	systemDBID int64,
+	yield func() error,
+) (int64, chunkedStepTiming, error) {
+	const step = "upsert media"
+	totalStart := time.Now()
+	totalAffected := int64(0)
+	var timing chunkedStepTiming
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return totalAffected, timing, fmt.Errorf("scan reconcile cancelled before %s: %w", step, err)
+		}
+
+		var staged int64
+		var upperBound sql.NullString
+		boundsStart := time.Now()
+		boundsErr := db.QueryRowContext(ctx, `
+			SELECT COUNT(*), MAX(Path) FROM (
+				SELECT Path FROM ScanStage WHERE Path > ? ORDER BY Path LIMIT ?
+			)`, cursor, scanUpsertMediaBatchSize).Scan(&staged, &upperBound)
+		timing.bounds += time.Since(boundsStart)
+		if boundsErr != nil {
+			return totalAffected, timing,
+				fmt.Errorf("scan reconcile %s: failed to read chunk bounds: %w", step, boundsErr)
+		}
+		if staged == 0 || !upperBound.Valid {
+			break
+		}
+
+		chunkStart := time.Now()
+		// CROSS JOIN (not JOIN): SQLite's planner otherwise drives this from
+		// MediaTitles regardless of the Path range — verified by EXPLAIN QUERY
+		// PLAN at 50k scale (see reconcile_query_plan_test.go in mediascanner)
+		// even with a realistic ~2000-row chunk, which would have made every
+		// chunk rescan the whole system's titles instead of just its slice of
+		// ScanStage. CROSS JOIN is otherwise identical to JOIN in SQLite; it
+		// only disables join reordering, pinning ScanStage — already bounded
+		// to this chunk by the range predicate below — as the outer loop.
+		res, err := db.ExecContext(ctx, `
+			INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
+			SELECT t.DBID, ?, s.Path, s.ParentDir, s.SortName, 0
+			FROM ScanStage s
+			CROSS JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
+			WHERE s.Path > ? AND s.Path <= ?
+			ON CONFLICT (SystemDBID, Path) DO UPDATE SET
+				MediaTitleDBID = excluded.MediaTitleDBID,
+				ParentDir      = excluded.ParentDir,
+				SortName       = excluded.SortName,
+				IsMissing      = 0
+			WHERE MediaTitleDBID <> excluded.MediaTitleDBID
+			   OR ParentDir <> excluded.ParentDir
+			   OR SortName <> excluded.SortName
+			   OR IsMissing <> 0`, systemDBID, systemDBID, cursor, upperBound.String)
+		chunkElapsed := time.Since(chunkStart)
+		if err != nil {
+			log.Warn().
+				Str("system", systemID).
+				Str("step", step).
+				Dur("elapsed", chunkElapsed).
+				Msg("scan reconcile step failed")
+			return totalAffected, timing, fmt.Errorf("scan reconcile %s failed: %w", step, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return totalAffected, timing, fmt.Errorf("scan reconcile %s: failed to read affected rows: %w", step, err)
+		}
+		totalAffected += affected
+
+		// Unlike sqlFlagMissingMedia's chunk log, this one is NOT gated on
+		// affected > 0: a chunk that changes nothing and still costs seconds is
+		// exactly the pathology #1279 asks this telemetry to catch.
+		logEvent := log.Debug()
+		if chunkElapsed > 5*time.Second {
+			logEvent = log.Warn()
+		}
+		logEvent.Str("system", systemID).
+			Str("step", step).
+			Int64("batchStaged", staged).
+			Int64("batchRows", affected).
+			Int64("rowsAffected", totalAffected).
+			Dur("elapsed", chunkElapsed).
+			Msg("scan reconcile chunk completed")
+
+		if yield != nil {
+			pacingStart := time.Now()
+			yieldErr := yield()
+			timing.pacing += time.Since(pacingStart)
+			if yieldErr != nil {
+				return totalAffected, timing, fmt.Errorf("scan reconcile pacing after %s failed: %w", step, yieldErr)
+			}
+		}
+
+		cursor = upperBound.String
+	}
+	logScanReconcileStep(systemID, step, totalAffected, time.Since(totalStart)-timing.pacing)
+	return totalAffected, timing, nil
 }
 
 // sqlResolveScanSystem returns the DBID of the system row for systemID, creating
 // it when absent and anything is staged. found is false when the system has no
 // row and nothing is staged (nothing to reconcile).
-func sqlResolveScanSystem(ctx context.Context, db sqlQueryable, systemID string) (dbid int64, found bool, err error) {
-	err = db.QueryRowContext(ctx, "SELECT DBID FROM Systems WHERE SystemID = ?", systemID).Scan(&dbid)
+//
+// created reports that this call inserted the Systems row, i.e. the system had
+// no rows of its own anywhere in the database a moment ago. Media and
+// MediaTitles both declare FOREIGN KEY (SystemDBID) REFERENCES Systems(DBID)
+// and foreign keys are enforced on every connection, so no Systems row means no
+// Media, MediaTitles, MediaTags or MediaProperties for it either. Reconcile uses
+// that to skip the steps that exist purely to reconcile against pre-existing
+// rows — see freshSystem in sqlReconcileStagedSystem.
+type scanSystemRef struct {
+	dbid int64
+	// found is false when the system has no row and nothing is staged.
+	found bool
+	// created is true when this call inserted the row, i.e. the system is fresh.
+	created bool
+}
+
+func sqlResolveScanSystem(ctx context.Context, db sqlQueryable, systemID string) (scanSystemRef, error) {
+	var dbid int64
+	err := db.QueryRowContext(ctx, "SELECT DBID FROM Systems WHERE SystemID = ?", systemID).Scan(&dbid)
 	switch {
 	case err == nil:
-		return dbid, true, nil
+		return scanSystemRef{dbid: dbid, found: true}, nil
 	case errors.Is(err, sql.ErrNoRows):
 		staged, countErr := sqlScanStageCount(ctx, db)
 		if countErr != nil {
-			return 0, false, countErr
+			return scanSystemRef{}, countErr
 		}
 		if staged == 0 {
-			return 0, false, nil
+			return scanSystemRef{}, nil
 		}
 		res, insErr := db.ExecContext(ctx,
 			"INSERT INTO Systems (SystemID, Name) VALUES (?, ?)", systemID, systemID)
 		if insErr != nil {
-			return 0, false, fmt.Errorf("failed to insert system %s: %w", systemID, insErr)
+			return scanSystemRef{}, fmt.Errorf("failed to insert system %s: %w", systemID, insErr)
 		}
 		dbid, insErr = res.LastInsertId()
 		if insErr != nil {
-			return 0, false, fmt.Errorf("failed to read inserted system DBID for %s: %w", systemID, insErr)
+			return scanSystemRef{}, fmt.Errorf("failed to read inserted system DBID for %s: %w", systemID, insErr)
 		}
-		return dbid, true, nil
+		return scanSystemRef{dbid: dbid, found: true, created: true}, nil
 	default:
-		return 0, false, fmt.Errorf("failed to resolve system %s: %w", systemID, err)
+		return scanSystemRef{}, fmt.Errorf("failed to resolve system %s: %w", systemID, err)
 	}
 }
 
@@ -342,31 +522,100 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 ) (database.ScanReconcileStats, error) {
 	stats := database.ScanReconcileStats{}
 	started := time.Now()
+	// One line carrying every step's elapsed ms, emitted at info so it survives
+	// where the individual debug lines may not. Round 6 lost a whole system's
+	// profile to a log rotation and most per-chunk lines to truncated captures;
+	// a single summary line per system is recoverable where 34 chunk lines are
+	// not.
+	//
+	// Every step here excludes pacing: execStep records before it yields, and
+	// the two chunked steps that yield internally report their pacing
+	// separately (see chunkedStepTiming). Pacing is carried as its own entry so
+	// the entries still reconstruct wall time.
+	//
+	// The final entry is unattributed = wall time minus everything named. Round
+	// 9 measured the named steps missing 22.3% of reconcile in aggregate and up
+	// to 45% on individual systems, which is invisible without this term — the
+	// same blind spot the scanner's own gap timers closed one level up. Any
+	// step added below must go through recordStep or it reappears here.
+	stepTimings := make([]string, 0, 16)
+	var namedTotal, pacingTotal time.Duration
+	recordStep := func(step string, elapsed time.Duration) {
+		namedTotal += elapsed
+		stepTimings = append(stepTimings, step+"="+strconv.FormatInt(elapsed.Milliseconds(), 10))
+	}
+	// recordChunkedStep reports a step that yields inside its own loop: its SQL
+	// cost with bounds and pacing removed, plus the bounds lookups on their own.
+	// Pacing joins the run-wide total rather than becoming a per-step entry —
+	// one number per system is enough to check against the scanner's throttle.
+	recordChunkedStep := func(step string, elapsed time.Duration, timing chunkedStepTiming) {
+		recordStep(step, elapsed-timing.bounds-timing.pacing)
+		if timing.bounds > 0 {
+			recordStep(step+" bounds", timing.bounds)
+		}
+		pacingTotal += timing.pacing
+	}
 	defer func() {
-		log.Debug().Str("system", systemID).Dur("elapsed", time.Since(started)).Msg("scan reconcile completed")
+		elapsed := time.Since(started)
+		log.Debug().Str("system", systemID).Dur("elapsed", elapsed).Msg("scan reconcile completed")
+		if len(stepTimings) > 0 {
+			entries := make([]string, 0, len(stepTimings)+2)
+			entries = append(entries, stepTimings...)
+			entries = append(entries,
+				"pacing="+strconv.FormatInt(pacingTotal.Milliseconds(), 10),
+				"unattributed="+strconv.FormatInt((elapsed-namedTotal-pacingTotal).Milliseconds(), 10))
+			log.Info().
+				Str("system", systemID).
+				Dur("elapsed", elapsed).
+				Str("steps", strings.Join(entries, " ")).
+				Msg("scan reconcile step timings")
+		}
 	}()
 	log.Debug().Str("system", systemID).Bool("incompleteScan", opts.IncompleteScan).Msg("scan reconcile started")
 
 	execStep := func(step, query string, args ...any) (int64, error) {
+		stepStart := time.Now()
 		affected, execErr := scanReconcileExec(ctx, db, systemID, step, query, args...)
+		recordStep(step, time.Since(stepStart))
 		if execErr != nil || opts.Yield == nil {
 			return affected, execErr
 		}
-		if yieldErr := opts.Yield(); yieldErr != nil {
+		pacingStart := time.Now()
+		yieldErr := opts.Yield()
+		pacingTotal += time.Since(pacingStart)
+		if yieldErr != nil {
 			return affected, fmt.Errorf("scan reconcile pacing after %s failed: %w", step, yieldErr)
 		}
 		return affected, nil
 	}
 
-	systemDBID, found, err := sqlResolveScanSystem(ctx, db, systemID)
+	resolveStart := time.Now()
+	systemRef, err := sqlResolveScanSystem(ctx, db, systemID)
+	recordStep("resolve system", time.Since(resolveStart))
 	if err != nil {
 		return stats, err
 	}
-	if !found {
+	if !systemRef.found {
 		return stats, nil
 	}
+	systemDBID := systemRef.dbid
+	freshSystem := systemRef.created
 	stats.SystemKnown = true
 	stats.SystemDBID = systemDBID
+
+	// freshSystem means this reconcile created the system's Systems row, so it
+	// owned no Media, MediaTitles or MediaTags beforehand (see
+	// sqlResolveScanSystem). Every step below that exists to reconcile against
+	// pre-existing rows is then provably a no-op and is skipped. On a first index
+	// of a large system these were a third of its reconcile time while affecting
+	// zero rows (#1279). Three of them are no-ops for less obvious reasons than
+	// "their inputs are empty", so each carries its own justification at the skip
+	// site. Re-indexing an existing library never takes this path: the Systems row
+	// already exists, including for the system redone on crash-resume.
+	if freshSystem {
+		log.Debug().Str("system", systemID).
+			Msg("scan reconcile fresh system: skipping pre-existing-state steps")
+	}
 
 	// New titles: one row per staged slug not yet present for this system. The
 	// per-slug representative row is the lowest path, so multi-file titles pick
@@ -388,7 +637,15 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 	// on either column changing, since SearchMediaBySecondarySlug would
 	// otherwise keep matching against a stale secondary slug for rows that
 	// only get here via the Name branch.
-	stats.TitlesRenamed, err = execStep("rename titles", `
+	//
+	// Skipped on a fresh system, and note the reason is not "no rows to update":
+	// "insert titles" just created one row per staged slug. It is that those rows
+	// were written from the same min-ScanStage.Path expression this statement
+	// compares against, so both branches of the WHERE are false for every one of
+	// them. ScanStage.Path is the primary key, so the MIN subquery is
+	// single-valued and the two sides cannot disagree.
+	if !freshSystem {
+		stats.TitlesRenamed, err = execStep("rename titles", `
 		UPDATE MediaTitles SET
 			Name = (
 				SELECT s.TitleName FROM ScanStage s
@@ -414,8 +671,9 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 				  AND s.Path = (SELECT MIN(s2.Path) FROM ScanStage s2 WHERE s2.Slug = MediaTitles.Slug)
 			)
 		  )`, systemDBID)
-	if err != nil {
-		return stats, err
+		if err != nil {
+			return stats, err
+		}
 	}
 
 	// Touched-title captures against the pre-upsert state. Each feeds the
@@ -442,37 +700,47 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 				+ st.staged_count > 1`,
 			args: []any{systemDBID, systemDBID},
 		},
-		{
-			step: "capture reassigned titles",
-			query: `
-			INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
-			SELECT m.MediaTitleDBID FROM Media m
-			JOIN ScanStage s ON s.Path = m.Path
-			JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
-			WHERE m.SystemDBID = ? AND m.MediaTitleDBID <> t.DBID`,
-			args: []any{systemDBID, systemDBID},
-		},
-		{
-			step: "capture gaining titles",
-			query: `
-			INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
-			SELECT t.DBID FROM Media m
-			JOIN ScanStage s ON s.Path = m.Path
-			JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
-			WHERE m.SystemDBID = ? AND m.MediaTitleDBID <> t.DBID`,
-			args: []any{systemDBID, systemDBID},
-		},
-		{
-			step: "capture re-found titles",
-			query: `
-			INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
-			SELECT m.MediaTitleDBID FROM Media m
-			JOIN ScanStage s ON s.Path = m.Path
-			WHERE m.SystemDBID = ? AND m.IsMissing = 1`,
-			args: []any{systemDBID},
-		},
 	}
-	if !opts.IncompleteScan {
+	// The remaining captures all read FROM Media for this system, which is still
+	// empty at this point in a fresh reconcile (the upsert runs below), so they
+	// select nothing. "capture new media titles" above is deliberately NOT
+	// skipped: it is productive on a fresh system, and "capture tag additions"
+	// further down depends on it having populated ScanTouchedTitles — see the
+	// comment there before changing either.
+	if !freshSystem {
+		preUpsertCaptures = append(preUpsertCaptures,
+			scanReconcileStep{
+				step: "capture reassigned titles",
+				query: `
+				INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
+				SELECT m.MediaTitleDBID FROM Media m
+				JOIN ScanStage s ON s.Path = m.Path
+				JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
+				WHERE m.SystemDBID = ? AND m.MediaTitleDBID <> t.DBID`,
+				args: []any{systemDBID, systemDBID},
+			},
+			scanReconcileStep{
+				step: "capture gaining titles",
+				query: `
+				INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
+				SELECT t.DBID FROM Media m
+				JOIN ScanStage s ON s.Path = m.Path
+				JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
+				WHERE m.SystemDBID = ? AND m.MediaTitleDBID <> t.DBID`,
+				args: []any{systemDBID, systemDBID},
+			},
+			scanReconcileStep{
+				step: "capture re-found titles",
+				query: `
+				INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
+				SELECT m.MediaTitleDBID FROM Media m
+				JOIN ScanStage s ON s.Path = m.Path
+				WHERE m.SystemDBID = ? AND m.IsMissing = 1`,
+				args: []any{systemDBID},
+			},
+		)
+	}
+	if !opts.IncompleteScan && !freshSystem {
 		preUpsertCaptures = append(preUpsertCaptures, scanReconcileStep{
 			step: "capture newly missing titles",
 			query: `
@@ -491,22 +759,14 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 
 	// Media upsert: insert new rows, and update existing rows only when a
 	// tracked field actually differs (title reassignment, parent dir move,
-	// sort name change, or a missing row re-found on disk).
-	stats.MediaUpserted, err = execStep("upsert media", `
-		INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
-		SELECT t.DBID, ?, s.Path, s.ParentDir, s.SortName, 0
-		FROM ScanStage s
-		JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
-		WHERE true
-		ON CONFLICT (SystemDBID, Path) DO UPDATE SET
-			MediaTitleDBID = excluded.MediaTitleDBID,
-			ParentDir      = excluded.ParentDir,
-			SortName       = excluded.SortName,
-			IsMissing      = 0
-		WHERE MediaTitleDBID <> excluded.MediaTitleDBID
-		   OR ParentDir <> excluded.ParentDir
-		   OR SortName <> excluded.SortName
-		   OR IsMissing <> 0`, systemDBID, systemDBID)
+	// sort name change, or a missing row re-found on disk). Chunked by
+	// ScanStage.Path — see sqlUpsertStagedMedia for why.
+	upsertStart := time.Now()
+	var upsertTiming chunkedStepTiming
+	stats.MediaUpserted, upsertTiming, err = sqlUpsertStagedMedia(
+		ctx, db, systemID, systemDBID, opts.Yield,
+	)
+	recordChunkedStep("upsert media", time.Since(upsertStart), upsertTiming)
 	if err != nil {
 		return stats, err
 	}
@@ -530,8 +790,16 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 	// update so pathological path changes (hundreds of thousands of stale rows)
 	// report progress and honour cancellation between batches instead of spending
 	// minutes in one opaque SQLite statement.
-	if !opts.IncompleteScan {
-		stats.MediaMissing, err = sqlFlagMissingMedia(ctx, db, systemID, systemDBID, opts.Yield)
+	//
+	// Also skipped on a fresh system. Again the reason is not an empty table —
+	// the upsert has just filled Media — it is that every one of those rows was
+	// written from ScanStage moments ago with IsMissing = 0, so the
+	// "not present in ScanStage" predicate is false for all of them.
+	if !opts.IncompleteScan && !freshSystem {
+		flagMissingStart := time.Now()
+		var flagMissingTiming chunkedStepTiming
+		stats.MediaMissing, flagMissingTiming, err = sqlFlagMissingMedia(ctx, db, systemID, systemDBID, opts.Yield)
+		recordChunkedStep("flag missing media", time.Since(flagMissingStart), flagMissingTiming)
 		if err != nil {
 			return stats, err
 		}
@@ -560,23 +828,39 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 
 	// A tag added to an existing media changes its title's disambiguation.
 	// Runs after the media upsert so MediaTitleDBID reflects any reassignment.
-	if _, err = execStep("capture tag additions", `
-		WITH multi_titles AS (
-			SELECT MediaTitleDBID FROM Media
-			WHERE SystemDBID = ? AND IsMissing = 0
-			GROUP BY MediaTitleDBID HAVING COUNT(*) > 1
-		)
-		INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
-		SELECT m.MediaTitleDBID
-		FROM ScanStageTags st
-		JOIN Media m ON m.SystemDBID = ? AND m.Path = st.Path
-		JOIN multi_titles mtit ON mtit.MediaTitleDBID = m.MediaTitleDBID
-		JOIN TagTypes tt ON tt.Type = st.TagType
-		JOIN Tags t ON t.TypeDBID = tt.DBID AND t.Tag = st.Tag
-		WHERE NOT EXISTS (
-			SELECT 1 FROM MediaTags mt WHERE mt.MediaDBID = m.DBID AND mt.TagDBID = t.DBID
-		)`, systemDBID, systemDBID); err != nil {
-		return stats, err
+	//
+	// Skipped on a fresh system, and this one needs the most care of the set: its
+	// SELECT is NOT empty there. MediaTags is still empty at this point (the link
+	// insert is the next step), so the NOT EXISTS holds for every staged pair and
+	// the SELECT returns a row per tagged media in a multi-file title. It affects
+	// zero rows only because INSERT OR IGNORE finds every one of those TitleDBIDs
+	// already in ScanTouchedTitles, put there by "capture new media titles" above:
+	// on a fresh system that step captures exactly the titles with more than one
+	// staged file, and post-upsert the per-title media count equals the per-slug
+	// staged count, so multi_titles here is the same set.
+	//
+	// That makes the skip conditional on "capture new media titles" continuing to
+	// run and to capture that set. If either changes, this skip has to be
+	// re-derived — it is not safe by "the inputs are empty" reasoning.
+	if !freshSystem {
+		if _, err = execStep("capture tag additions", `
+			WITH multi_titles AS (
+				SELECT MediaTitleDBID FROM Media
+				WHERE SystemDBID = ? AND IsMissing = 0
+				GROUP BY MediaTitleDBID HAVING COUNT(*) > 1
+			)
+			INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
+			SELECT m.MediaTitleDBID
+			FROM ScanStageTags st
+			JOIN Media m ON m.SystemDBID = ? AND m.Path = st.Path
+			JOIN multi_titles mtit ON mtit.MediaTitleDBID = m.MediaTitleDBID
+			JOIN TagTypes tt ON tt.Type = st.TagType
+			JOIN Tags t ON t.TypeDBID = tt.DBID AND t.Tag = st.Tag
+			WHERE NOT EXISTS (
+				SELECT 1 FROM MediaTags mt WHERE mt.MediaDBID = m.DBID AND mt.TagDBID = t.DBID
+			)`, systemDBID, systemDBID); err != nil {
+			return stats, err
+		}
 	}
 
 	stats.TagLinksAdded, err = execStep("insert tag links", `
@@ -592,27 +876,38 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 
 	// Stale scanner-owned links on staged media: capture the owning titles,
 	// then delete the links.
-	staleTagTitleArgs := append([]any{systemDBID}, scanNonScannerTypeArgs(systemDBID)...)
-	if _, err = execStep("capture stale tag titles",
-		"WITH multi_titles AS ("+
-			"SELECT MediaTitleDBID FROM Media WHERE SystemDBID = ? AND IsMissing = 0 "+
-			"GROUP BY MediaTitleDBID HAVING COUNT(*) > 1) "+
-			"INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID) SELECT m.MediaTitleDBID"+scanStaleLinkFilter+
-			" AND EXISTS (SELECT 1 FROM multi_titles mtit WHERE mtit.MediaTitleDBID = m.MediaTitleDBID)",
-		staleTagTitleArgs...); err != nil {
-		return stats, err
-	}
-	stats.TagLinksDeleted, err = execStep("delete stale tag links",
-		"DELETE FROM MediaTags WHERE (MediaDBID, TagDBID) IN (SELECT mt.MediaDBID, mt.TagDBID"+
-			scanStaleLinkFilter+")",
-		scanNonScannerTypeArgs(systemDBID)...)
-	if err != nil {
-		return stats, err
+	//
+	// Both are skipped on a fresh system. MediaTags is not empty by now — the
+	// link insert above just filled it — but every row in it came from that
+	// statement, reading the same (path, tag type, tag) tuples that
+	// scanStaleLinkFilter's NOT EXISTS reconstructs, so no link can be stale.
+	// A fresh system has no other source of MediaTags rows: the scraper's
+	// writers cannot have touched media that did not exist, and reconcile holds
+	// the only write transaction.
+	if !freshSystem {
+		staleTagTitleArgs := append([]any{systemDBID}, scanNonScannerTypeArgs(systemDBID)...)
+		if _, err = execStep("capture stale tag titles",
+			"WITH multi_titles AS ("+
+				"SELECT MediaTitleDBID FROM Media WHERE SystemDBID = ? AND IsMissing = 0 "+
+				"GROUP BY MediaTitleDBID HAVING COUNT(*) > 1) "+
+				"INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID) SELECT m.MediaTitleDBID"+scanStaleLinkFilter+
+				" AND EXISTS (SELECT 1 FROM multi_titles mtit WHERE mtit.MediaTitleDBID = m.MediaTitleDBID)",
+			staleTagTitleArgs...); err != nil {
+			return stats, err
+		}
+		stats.TagLinksDeleted, err = execStep("delete stale tag links",
+			"DELETE FROM MediaTags WHERE (MediaDBID, TagDBID) IN (SELECT mt.MediaDBID, mt.TagDBID"+
+				scanStaleLinkFilter+")",
+			scanNonScannerTypeArgs(systemDBID)...)
+		if err != nil {
+			return stats, err
+		}
 	}
 
 	countTouchedStart := time.Now()
 	touchedCount, err := sqlCountScanTouchedTitles(ctx, db)
 	countTouchedElapsed := time.Since(countTouchedStart)
+	recordStep("count touched titles", countTouchedElapsed)
 	if err != nil {
 		return stats, err
 	}
@@ -623,7 +918,10 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 		Dur("elapsed", countTouchedElapsed).
 		Msg("scan reconcile touched titles counted")
 	if opts.Yield != nil {
-		if yieldErr := opts.Yield(); yieldErr != nil {
+		pacingStart := time.Now()
+		yieldErr := opts.Yield()
+		pacingTotal += time.Since(pacingStart)
+		if yieldErr != nil {
 			return stats, fmt.Errorf("scan reconcile pacing after touched-title count failed: %w", yieldErr)
 		}
 	}
@@ -653,6 +951,7 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 			return stats, fmt.Errorf("scan reconcile disambiguation recompute failed: %w", err)
 		}
 		disambiguationElapsed := time.Since(disambiguationStart)
+		recordStep("disambiguation", disambiguationElapsed)
 		logEvent := log.Debug()
 		if disambiguationElapsed > 5*time.Second {
 			logEvent = log.Warn()
@@ -663,13 +962,19 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 			Dur("elapsed", disambiguationElapsed).
 			Msg("scan reconcile disambiguation recompute completed")
 		if opts.Yield != nil {
-			if yieldErr := opts.Yield(); yieldErr != nil {
+			pacingStart := time.Now()
+			yieldErr := opts.Yield()
+			pacingTotal += time.Since(pacingStart)
+			if yieldErr != nil {
 				return stats, fmt.Errorf("scan reconcile pacing after disambiguation failed: %w", yieldErr)
 			}
 		}
 	}
 
-	if clearErr := sqlClearScanStage(ctx, db); clearErr != nil {
+	clearStart := time.Now()
+	clearErr := sqlClearScanStage(ctx, db)
+	recordStep("clear scan stage", time.Since(clearStart))
+	if clearErr != nil {
 		return stats, clearErr
 	}
 	return stats, nil

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -617,7 +617,7 @@ func getMediaIDsForTagDBIDs(
 	}
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
 	query := selectClause + `
-		FROM Media m INDEXED BY media_system_path_idx
+		FROM Media m INDEXED BY sqlite_autoindex_Media_1
 		CROSS JOIN MediaTags mt
 		WHERE m.SystemDBID = ?
 		  AND mt.MediaDBID = m.DBID

--- a/pkg/database/mediadb/sql_test.go
+++ b/pkg/database/mediadb/sql_test.go
@@ -38,7 +38,7 @@ import (
 
 const mediaBySystemIDQueryPattern = `SELECT m\.DBID, m\.Path, m\.ParentDir, m\.MediaTitleDBID, ` +
 	`m\.SortName, m\.IsMissing ` +
-	`FROM Media m INDEXED BY media_system_path_idx.*` +
+	`FROM Media m INDEXED BY sqlite_autoindex_Media_1.*` +
 	`WHERE m\.SystemDBID = \(SELECT DBID FROM Systems WHERE SystemID = \?\).*` +
 	`ORDER BY m\.Path`
 
@@ -921,7 +921,7 @@ func TestSqlPopulateSystemTagsCache_Success(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM SystemTagsCache").
 		WillReturnResult(sqlmock.NewResult(0, 5))
-	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY sqlite_autoindex_Media_1.*`).
 		WillReturnResult(sqlmock.NewResult(1, 6))
 	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
 		WillReturnResult(sqlmock.NewResult(1, 4))
@@ -958,7 +958,7 @@ func TestSqlPopulateSystemTagsCache_MediaInsertError(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM SystemTagsCache").
 		WillReturnResult(sqlmock.NewResult(0, 5))
-	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY sqlite_autoindex_Media_1.*`).
 		WillReturnError(sql.ErrConnDone)
 	mock.ExpectRollback()
 
@@ -977,7 +977,7 @@ func TestSqlPopulateSystemTagsCache_TitleInsertError(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM SystemTagsCache").
 		WillReturnResult(sqlmock.NewResult(0, 5))
-	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY sqlite_autoindex_Media_1.*`).
 		WillReturnResult(sqlmock.NewResult(1, 6))
 	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
 		WillReturnError(sql.ErrConnDone)
@@ -998,7 +998,7 @@ func TestSqlPopulateSystemTagsCache_CommitError(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE FROM SystemTagsCache").
 		WillReturnResult(sqlmock.NewResult(0, 5))
-	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY media_system_path_idx.*`).
+	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM Media m INDEXED BY sqlite_autoindex_Media_1.*`).
 		WillReturnResult(sqlmock.NewResult(1, 6))
 	mock.ExpectExec(`INSERT INTO SystemTagsCache.*FROM MediaTitleTags.*`).
 		WillReturnResult(sqlmock.NewResult(1, 4))

--- a/pkg/database/mediadb/stat1_seed_data.go
+++ b/pkg/database/mediadb/stat1_seed_data.go
@@ -26,14 +26,13 @@ package mediadb
 // library built through the production staging pipeline. See stat1_seed.go
 // for how and when they are applied.
 var stat1SeedRows = []struct{ tbl, idx, stat string }{
-	{tbl: "DBConfig", idx: "sqlite_autoindex_DBConfig_1", stat: "3 1"},
+	{tbl: "DBConfig", idx: "sqlite_autoindex_DBConfig_1", stat: "2 1"},
 	{tbl: "Media", idx: "idx_media_browse_sort", stat: "99000 3300 3300 1 1"},
 	{tbl: "Media", idx: "idx_media_parentdir", stat: "99000 3300"},
 	{tbl: "Media", idx: "idx_media_parentdir_system", stat: "99000 3300 3300"},
 	{tbl: "Media", idx: "media_mediatitle_idx", stat: "99000 1"},
 	{tbl: "Media", idx: "media_missing_idx", stat: "99000 99000"},
 	{tbl: "Media", idx: "media_path_idx", stat: "99000 1"},
-	{tbl: "Media", idx: "media_system_path_idx", stat: "99000 3300 1"},
 	{tbl: "Media", idx: "media_system_present_path_idx", stat: "99000 3300 1"},
 	{tbl: "Media", idx: "media_title_present_idx", stat: "99000 1 1"},
 	{tbl: "Media", idx: "sqlite_autoindex_Media_1", stat: "99000 3300 1"},
@@ -44,9 +43,9 @@ var stat1SeedRows = []struct{ tbl, idx, stat string }{
 	{tbl: "MediaTitles", idx: "mediatitles_slug_idx", stat: "99000 7"},
 	{tbl: "MediaTitles", idx: "mediatitles_system_slug_idx", stat: "99000 3300 1"},
 	{tbl: "Systems", idx: "sqlite_autoindex_Systems_1", stat: "30 1"},
-	{tbl: "TagTypes", idx: "sqlite_autoindex_TagTypes_1", stat: "49 1"},
-	{tbl: "Tags", idx: "tags_tag_idx", stat: "1219 1"},
-	{tbl: "Tags", idx: "tags_tagtype_idx", stat: "1219 31"},
-	{tbl: "Tags", idx: "tags_type_tag_idx", stat: "1219 31 1"},
-	{tbl: "goose_db_version", idx: "", stat: "14"},
+	{tbl: "TagTypes", idx: "sqlite_autoindex_TagTypes_1", stat: "50 1"},
+	{tbl: "Tags", idx: "tags_tag_idx", stat: "1220 1"},
+	{tbl: "Tags", idx: "tags_tagtype_idx", stat: "1220 31"},
+	{tbl: "Tags", idx: "tags_type_tag_idx", stat: "1220 31 1"},
+	{tbl: "goose_db_version", idx: "", stat: "15"},
 }

--- a/pkg/database/mediadb/wal_checkpoint_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_test.go
@@ -162,7 +162,6 @@ func TestConnectionParameters(t *testing.T) {
 	require.Contains(t, connParams, "_cache_size=-8192") // 8MB cache (safe on 256MB systems)
 	require.Contains(t, connParams, "_temp_store=FILE")  // temp tables on disk for safe VACUUM
 	require.Contains(t, connParams, "_mmap_size=0")      // disabled to avoid memory pressure
-	require.Contains(t, connParams, "_page_size=8192")
 	require.Contains(t, connParams, "_foreign_keys=ON")
 	require.Contains(t, connParams, "_busy_timeout=5000")
 

--- a/pkg/database/mediadb/wal_checkpoint_threshold_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_threshold_test.go
@@ -25,11 +25,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/jonboulle/clockwork"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -141,4 +144,111 @@ func TestCommitAboveThresholdTruncatesWAL(t *testing.T) {
 	require.NoError(t, h.db.sql.Load().QueryRowContext(
 		h.db.ctx, "SELECT COUNT(*) FROM Media").Scan(&count))
 	require.Equal(t, 4000, count)
+}
+
+// TestCheckpointLog_IncludesPoolStats asserts the checkpoint-completed log line
+// carries the connection pool's open/inUse/idle counts alongside the existing
+// busy/frame fields — added for #1279 to help tell whether a concurrent reader
+// (not just indexing's own writer) was checked out at the moment a checkpoint
+// couldn't fully reclaim the WAL. Cannot run in parallel: swaps zerolog.Logger.
+func TestCheckpointLog_IncludesPoolStats(t *testing.T) {
+	h := newWALTestDB(t)
+
+	orig := mediaWALCheckpointThreshold
+	mediaWALCheckpointThreshold = 32 * 1024
+	t.Cleanup(func() { mediaWALCheckpointThreshold = orig })
+
+	var buf strings.Builder
+	prevLogger := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = prevLogger
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+
+	require.NoError(t, h.db.BeginTransaction(false))
+	for i := range 4000 {
+		media := database.Media{
+			MediaTitleDBID: h.title.DBID,
+			SystemDBID:     h.system.DBID,
+			Path:           filepath.Join("test", "path", fmt.Sprintf("game%d.bin", i)),
+		}
+		_, err := h.db.InsertMedia(media)
+		require.NoError(t, err)
+	}
+	require.NoError(t, h.db.CommitTransaction())
+
+	output := buf.String()
+	require.Contains(t, output, "media database WAL checkpoint completed")
+	for _, field := range []string{`"poolOpen":`, `"poolInUse":`, `"poolIdle":`} {
+		require.Contains(t, output, field)
+	}
+}
+
+// TestCommitTransaction_LogsBreakdown asserts CommitTransactionWithOptions logs its
+// four-segment timing breakdown (flush/sqliteCommit/invalidate/checkpoint) plus the
+// WAL size immediately before and after tx.Commit() — the pair of numbers issue #1279
+// asks for to tell whether SQLite's automatic checkpointing ran inside the commit.
+// Cannot run in parallel with other tests: it swaps the shared zerolog.Logger/level.
+func TestCommitTransaction_LogsBreakdown(t *testing.T) {
+	h := newWALTestDB(t)
+
+	var buf strings.Builder
+	prevLogger := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		log.Logger = prevLogger
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+
+	require.NoError(t, h.db.BeginTransaction(false))
+	media := database.Media{
+		MediaTitleDBID: h.title.DBID,
+		SystemDBID:     h.system.DBID,
+		Path:           filepath.Join("test", "path", "game.bin"),
+	}
+	_, err := h.db.InsertMedia(media)
+	require.NoError(t, err)
+	require.NoError(t, h.db.CommitTransaction())
+
+	output := buf.String()
+	require.Contains(t, output, "media database commit breakdown")
+	for _, field := range []string{
+		`"flush":`, `"sqliteCommit":`, `"invalidate":`, `"checkpoint":`, `"total":`,
+		`"walSizeBeforeCommit":`, `"walSizeAfterCommit":`,
+		`"poolOpen":`, `"poolInUse":`, `"poolIdle":`,
+	} {
+		require.Contains(t, output, field)
+	}
+}
+
+// TestCommitTransaction_PreservesSlugCacheDuringIndexing asserts a batch commit
+// taken mid-indexing still takes the indexing branch of cache invalidation and
+// leaves the slug search cache intact, so foreground launches and searches keep
+// working off last-good coverage while an index is in progress.
+func TestCommitTransaction_PreservesSlugCacheDuringIndexing(t *testing.T) {
+	t.Parallel()
+
+	h := newWALTestDB(t)
+	require.NoError(t, h.db.SetIndexingStatus(IndexingStatusRunning))
+
+	sentinelCache := &SlugSearchCache{}
+	h.db.slugSearchCache.Store(sentinelCache)
+
+	require.NoError(t, h.db.BeginTransaction(false))
+	media := database.Media{
+		MediaTitleDBID: h.title.DBID,
+		SystemDBID:     h.system.DBID,
+		Path:           filepath.Join("test", "path", "game.bin"),
+	}
+	_, err := h.db.InsertMedia(media)
+	require.NoError(t, err)
+	require.NoError(t, h.db.CommitTransaction())
+
+	require.Same(t, sentinelCache, h.db.slugSearchCache.Load(),
+		"PreserveSlugSearchCache must still be honored during an indexing batch commit")
 }

--- a/pkg/database/mediascanner/gap_accounting_test.go
+++ b/pkg/database/mediascanner/gap_accounting_test.go
@@ -1,0 +1,226 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+// Guards the per-system time accounting on "completed system indexing".
+//
+// Round 7 of #1279 measured elapsed - (collect+insert+reconcile+commit) at
+// 11.87 min, 18.3% of a full reindex, with no log line accounting for any of
+// it — larger than disambiguation and roughly half of commit. Two systems in
+// that run spent over 98% of their wall time in that unmeasured window.
+//
+// The fix added setup/throttle/analyze/cacheRefresh timers plus an explicit
+// unattributed field. These tests pin the invariants that make those numbers
+// trustworthy.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// systemTiming mirrors the duration fields on "completed system indexing".
+// zerolog writes Dur() as float milliseconds by default.
+type systemTiming struct {
+	System       string  `json:"system"`
+	Message      string  `json:"message"`
+	Elapsed      float64 `json:"elapsed"`
+	Setup        float64 `json:"setup"`
+	Collect      float64 `json:"collect"`
+	Insert       float64 `json:"insert"`
+	Reconcile    float64 `json:"reconcile"`
+	Commit       float64 `json:"commit"`
+	Throttle     float64 `json:"throttle"`
+	Analyze      float64 `json:"analyze"`
+	CacheRefresh float64 `json:"cacheRefresh"`
+	Unattributed float64 `json:"unattributed"`
+}
+
+func (s *systemTiming) namedTotal() float64 {
+	return s.Setup + s.Collect + s.Insert + s.Reconcile +
+		s.Commit + s.Throttle + s.Analyze + s.CacheRefresh
+}
+
+// captureSystemTimings runs an index over the given systems and returns the
+// parsed "completed system indexing" lines.
+func captureSystemTimings(t *testing.T, systemFiles map[string][]string) []systemTiming {
+	t.Helper()
+
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	t.Cleanup(cleanup)
+
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+
+	buf := &syncLogBuffer{}
+	prevLogger := log.Logger
+	prevGlobal := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+	defer func() { log.Logger = prevLogger; zerolog.SetGlobalLevel(prevGlobal) }()
+
+	_, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	// Restore before reading so background optimization cannot race the read.
+	log.Logger = prevLogger
+	zerolog.SetGlobalLevel(prevGlobal)
+
+	var timings []systemTiming
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if !strings.Contains(line, `"completed system indexing"`) {
+			continue
+		}
+		var st systemTiming
+		require.NoError(t, json.Unmarshal([]byte(line), &st), "line: %s", line)
+		timings = append(timings, st)
+	}
+	return timings
+}
+
+// TestSystemTiming_PhasesAccountForElapsed is the core invariant: every field is
+// present, none is negative, and the named phases plus unattributed reconstruct
+// elapsed exactly.
+//
+// A negative unattributed is the failure that matters most — it means a phase is
+// being double-counted (for example throttle time also landing inside collect),
+// which would make every other figure on the line untrustworthy.
+func TestSystemTiming_PhasesAccountForElapsed(t *testing.T) {
+	// Cannot use t.Parallel(): mutates GlobalLauncherCache and log.Logger.
+	timings := captureSystemTimings(t, map[string][]string{
+		systemdefs.SystemNES:     {"a.bin", "b.bin", "c.bin"},
+		systemdefs.SystemSNES:    {"d.bin", "e.bin"},
+		systemdefs.SystemGenesis: {"f.bin"},
+	})
+	require.NotEmpty(t, timings, "expected completed system indexing lines")
+
+	for _, st := range timings {
+		t.Run(st.System, func(t *testing.T) {
+			t.Logf("elapsed=%.3fms setup=%.3f collect=%.3f insert=%.3f reconcile=%.3f "+
+				"commit=%.3f throttle=%.3f analyze=%.3f cacheRefresh=%.3f unattributed=%.3f (%.1f%%)",
+				st.Elapsed, st.Setup, st.Collect, st.Insert, st.Reconcile, st.Commit,
+				st.Throttle, st.Analyze, st.CacheRefresh, st.Unattributed,
+				st.Unattributed/st.Elapsed*100)
+
+			assert.GreaterOrEqual(t, st.Unattributed, 0.0,
+				"unattributed must never be negative — a negative value means a phase "+
+					"is counted twice, which invalidates the whole breakdown")
+
+			for name, v := range map[string]float64{
+				"setup": st.Setup, "collect": st.Collect, "insert": st.Insert,
+				"reconcile": st.Reconcile, "commit": st.Commit, "throttle": st.Throttle,
+				"analyze": st.Analyze, "cacheRefresh": st.CacheRefresh,
+			} {
+				assert.GreaterOrEqual(t, v, 0.0, "%s must not be negative", name)
+			}
+
+			// Reconstruct elapsed. Tolerance covers only float rounding in the
+			// log encoding, not slop in the accounting.
+			assert.InDelta(t, st.Elapsed, (&st).namedTotal()+st.Unattributed, 0.01,
+				"named phases plus unattributed must reconstruct elapsed")
+		})
+	}
+}
+
+// TestSystemTiming_SetupExcludesThrottleWait pins the boundary between setup and
+// throttle.
+//
+// The per-system loop waits on the pauser before doing anything else, and that
+// wait is counted in throttle. Measuring setup from the top of the loop instead
+// of from after that wait puts the same milliseconds in both fields — which
+// round 8 of #1279 shipped. Nothing catches it by inspection: elapsed is still
+// correct, and unattributed simply absorbs the error by shrinking, so the line
+// looks healthier the more wrong it is.
+//
+// A pauser with no baseline throttle makes the wait effectively free, so setup
+// here should reflect only the real setup work.
+func TestSystemTiming_SetupExcludesThrottleWait(t *testing.T) {
+	// Cannot use t.Parallel(): mutates GlobalLauncherCache and log.Logger.
+	timings := captureSystemTimings(t, map[string][]string{
+		systemdefs.SystemNES: {"a.bin", "b.bin"},
+	})
+	require.NotEmpty(t, timings, "expected completed system indexing lines")
+
+	for _, st := range timings {
+		t.Run(st.System, func(t *testing.T) {
+			// The decisive check: the named phases must not exceed elapsed. A
+			// double-count shows up here first, because the same wait is being
+			// billed to two fields that are both inside elapsed.
+			assert.LessOrEqual(t, (&st).namedTotal(), st.Elapsed+0.01,
+				"named phases must not exceed elapsed; overshoot means a window is "+
+					"counted twice (setup spanning the throttle wait is how this last happened)")
+
+			assert.GreaterOrEqual(t, st.Unattributed, 0.0,
+				"unattributed must stay non-negative")
+		})
+	}
+}
+
+// TestSystemTiming_FieldsPresent guards against a field being dropped from the
+// log line by a later edit. Round 7's analysis was only possible because the
+// per-system line carried everything; a silently missing field would put the
+// next investigation back to guessing.
+func TestSystemTiming_FieldsPresent(t *testing.T) {
+	// Cannot use t.Parallel(): mutates GlobalLauncherCache and log.Logger.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	platform, cfg, systems := setupCustomLauncherSystems(t, map[string][]string{
+		systemdefs.SystemNES: {"a.bin"},
+	})
+
+	buf := &syncLogBuffer{}
+	prevLogger := log.Logger
+	prevGlobal := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = zerolog.New(buf).Level(zerolog.InfoLevel)
+
+	_, err := NewNamesIndex(context.Background(), platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	log.Logger = prevLogger
+	zerolog.SetGlobalLevel(prevGlobal)
+	require.NoError(t, err)
+
+	var line string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, `"completed system indexing"`) {
+			line = l
+			break
+		}
+	}
+	require.NotEmpty(t, line, "expected a completed system indexing line")
+
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &fields))
+
+	for _, name := range []string{
+		"elapsed", "setup", "collect", "insert", "reconcile",
+		"commit", "throttle", "analyze", "cacheRefresh", "unattributed",
+	} {
+		assert.Contains(t, fields, name,
+			"completed system indexing must carry %q for per-system attribution", name)
+	}
+}

--- a/pkg/database/mediascanner/index_cache_survival_test.go
+++ b/pkg/database/mediascanner/index_cache_survival_test.go
@@ -1,0 +1,179 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// slugCacheProbe records the state of the in-memory slug search cache at a
+// chosen point of a run, sampled from the status callback.
+type slugCacheProbe struct {
+	systems int
+	loaded  bool
+	derived bool
+	ran     bool
+}
+
+// TestNewNamesIndex_SlugSearchCacheSurvivesRunStart pins the ordering between
+// the indexing status write and the first commit of a run.
+//
+// MediaDB chooses its cache invalidation scope per commit from the persisted
+// indexing status. A commit made while that status still reads "completed" is
+// treated as an ordinary write and drops the whole slug search cache, so
+// SeedCanonicalTags — which commits — has to run after the status says the run
+// has started, not before.
+//
+// With the two in the wrong order the cache is gone from the first commit of
+// every run onwards. On the #1279 device that put media.search on the grouped
+// SQL LIKE path for the whole index, and every request hit the 30s API timeout.
+func TestNewNamesIndex_SlugSearchCacheSurvivesRunStart(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	mediaDB, ok := db.MediaDB.(*mediadb.MediaDB)
+	require.True(t, ok, "test database must expose the concrete MediaDB")
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemGameboy: {"pocket_quest.bin"},
+		systemdefs.SystemSNES:    {"super_quest.bin"},
+	}
+	platform, cfg, _ := setupCustomLauncherSystems(t, systemFiles)
+	ctx := context.Background()
+
+	// Ask for every system, as a client-triggered re-index does. That is what
+	// makes the run's invalidation scope all-systems, the shape the device runs
+	// at; only the two with launchers hold any media.
+	systems := systemdefs.AllSystems()
+
+	// First run leaves a complete cache and a "completed" indexing status,
+	// which is the state a device is in when a user asks for a re-index.
+	_, err := NewNamesIndex(ctx, platform, cfg, systems, db, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	loaded, coveredSystems, derived := mediaDB.SlugSearchCacheCoverageForTesting()
+	require.True(t, loaded, "a finished run must leave a slug search cache")
+	require.True(t, derived, "a finished full run's cache covers the whole library")
+	require.Equal(t, 2, coveredSystems, "only systems holding media get cache entries")
+
+	// Second run: sample at the first system, which is after the canonical tag
+	// seeding commit and before any system has committed or refreshed.
+	probe := &slugCacheProbe{}
+	update := func(status IndexStatus) {
+		if status.SystemID == "" || probe.ran {
+			return
+		}
+		probe.ran = true
+		probe.loaded, probe.systems, probe.derived = mediaDB.SlugSearchCacheCoverageForTesting()
+	}
+
+	_, err = NewNamesIndex(ctx, platform, cfg, systems, db, update, nil)
+	require.NoError(t, err)
+	require.True(t, probe.ran, "status callback never observed the first system starting")
+
+	assert.True(t, probe.loaded,
+		"the slug search cache must survive the start of a run; dropping it here "+
+			"forces every search onto the SQL fallback until the run finishes")
+	assert.True(t, probe.derived,
+		"the surviving cache must still count as library-wide, so searches naming "+
+			"systems that hold no media can be served from it")
+	assert.Equal(t, 2, probe.systems,
+		"an all-systems run leaves the cache intact at the start; systems are dropped "+
+			"one at a time as the run reaches them")
+}
+
+// evictionRecordingMediaDB counts requests to evict systems from the slug
+// search cache. The eviction window sits entirely inside one system's
+// processing, between the status callback and that system's commit, so no
+// probe driven by the callback can observe it — counting the calls is what
+// makes the invariant testable.
+type evictionRecordingMediaDB struct {
+	database.MediaDBI
+	evicted atomic.Int64
+}
+
+func (m *evictionRecordingMediaDB) DropSlugSearchCacheForSystems(systemIDs []string) {
+	m.evicted.Add(1)
+	if dropper, ok := m.MediaDBI.(interface {
+		DropSlugSearchCacheForSystems(systemIDs []string)
+	}); ok {
+		dropper.DropSlugSearchCacheForSystems(systemIDs)
+	}
+}
+
+// TestNewNamesIndex_KeepsInFlightSystemInSlugCache pins that a run never
+// evicts the system it is about to rescan from the slug search cache.
+//
+// A client search with no system filter names every system Zaparoo knows
+// about, so an evicted system makes the whole request unservable from memory
+// and pushes it onto the grouped SQL LIKE path. Measured on the #1279 device
+// mid-index, the same query took 242 ms across 28 covered systems and
+// 27,205 ms across all of them.
+//
+// Keeping the entries is safe because the cache only nominates candidate title
+// IDs and the rows come from a live query: entries whose rows have gone return
+// nothing, and refreshMidScanCaches replaces the system's entries once it
+// commits.
+func TestNewNamesIndex_KeepsInFlightSystemInSlugCache(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	recorder := &evictionRecordingMediaDB{MediaDBI: db.MediaDB}
+	wrapped := &database.Database{MediaDB: recorder, UserDB: db.UserDB}
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemGameboy: {"pocket_quest.bin"},
+		systemdefs.SystemSNES:    {"super_quest.bin"},
+	}
+	platform, cfg, _ := setupCustomLauncherSystems(t, systemFiles)
+	ctx := context.Background()
+	systems := systemdefs.AllSystems()
+
+	_, err := NewNamesIndex(ctx, platform, cfg, systems, wrapped, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+	// Re-index: the run that has previous entries to lose.
+	_, err = NewNamesIndex(ctx, platform, cfg, systems, wrapped, func(IndexStatus) {}, nil)
+	require.NoError(t, err)
+
+	assert.Zero(t, recorder.evicted.Load(),
+		"indexing must not evict systems from the slug search cache; a search naming "+
+			"every system then falls back to the grouped SQL LIKE path for whichever "+
+			"are in flight")
+
+	mediaDB, ok := db.MediaDB.(*mediadb.MediaDB)
+	require.True(t, ok, "test database must expose the concrete MediaDB")
+	everySystemID := make([]string, len(systems))
+	for i := range systems {
+		everySystemID[i] = systems[i].ID
+	}
+	assert.True(t, mediaDB.CanServeSystemsFromSlugCacheForTesting(everySystemID),
+		"a finished run must leave a cache that can answer a library-wide search")
+}

--- a/pkg/database/mediascanner/journal_mode_guard_test.go
+++ b/pkg/database/mediascanner/journal_mode_guard_test.go
@@ -1,0 +1,104 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewNamesIndex_NonWALJournalModeFailsInsteadOfHanging exercises issue
+// #1279's deadlock characterisation directly: indexing batches one write
+// transaction per system while the next system's state load reads on a
+// separate pool connection. Under WAL that read sees the last committed
+// snapshot; under a rollback journal the writer's exclusive lock blocks it
+// until commit, which never arrives because that read is on the critical
+// path to reaching it. NewNamesIndex must reject a non-WAL database up front
+// with a clear error instead of hanging mid-index — this test fails the slow
+// way (timeout) if that guard regresses.
+func TestNewNamesIndex_NonWALJournalModeFailsInsteadOfHanging(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "media_rollback_journal.db")
+	sqlDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=DELETE&_foreign_keys=ON")
+	require.NoError(t, err)
+
+	// Launchers/RootDirs are deliberately left unstubbed: the WAL guard fires
+	// before NewNamesIndex ever reaches launcher discovery, so a call to
+	// either would itself indicate the guard regressed to running too late.
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
+
+	mediaDB := &mediadb.MediaDB{}
+	require.NoError(t, mediaDB.SetSQLForTesting(context.Background(), sqlDB, mockPlatform))
+	mediaDB.SetDBPathForTesting(dbPath)
+	defer func() { _ = mediaDB.Close() }()
+
+	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
+	defer userCleanup()
+
+	db := &database.Database{MediaDB: mediaDB, UserDB: userDB}
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		_, indexErr := NewNamesIndex(context.Background(), mockPlatform, cfg, nil, db, func(IndexStatus) {}, nil)
+		done <- indexErr
+	}()
+
+	select {
+	case indexErr := <-done:
+		require.Error(t, indexErr)
+		require.Contains(t, indexErr.Error(), "not in WAL journal mode")
+	case <-time.After(10 * time.Second):
+		t.Fatal("NewNamesIndex did not return promptly under a rollback journal; the WAL guard did not fire")
+	}
+}
+
+// TestCheckWALJournalMode_NilHandleIsNotFatal pins the guard's tolerance for a
+// MediaDBI with no open handle. Only a database that is definitely in the wrong
+// journal mode may fail indexing; an inability to determine the mode at all
+// must not, and must not panic either. This path used to be covered by a
+// recover() in the caller, which meant a nil dereference anywhere inside the
+// check would have been silently swallowed as the same "cannot verify" case.
+func TestCheckWALJournalMode_NilHandleIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	mockDB := testhelpers.NewMockMediaDBI()
+
+	var err error
+	require.NotPanics(t, func() {
+		err = checkWALJournalMode(context.Background(), mockDB)
+	})
+	require.NoError(t, err, "an unverifiable journal mode must let indexing proceed, not fail it")
+}

--- a/pkg/database/mediascanner/maintenance_failure_test.go
+++ b/pkg/database/mediascanner/maintenance_failure_test.go
@@ -183,6 +183,7 @@ func runMaintenanceFailureIndex(
 	}
 
 	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
 	platform.On("Launchers", mock.Anything).Return([]platforms.Launcher{})
 	platform.On("RootDirs", mock.Anything).Return([]string{})
 
@@ -236,6 +237,7 @@ func TestNewNamesIndex_EarlyAnalyzeCorruptionAbortsRun(t *testing.T) {
 	db.MediaDB = wrapped
 
 	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
 	platform.On("Launchers", mock.Anything).Return([]platforms.Launcher{{
 		ID:                 "nes-test",
 		SystemID:           "NES",
@@ -309,12 +311,63 @@ func TestRefreshMidScanCaches_PropagatesCorruptionFromEveryPhase(t *testing.T) {
 				}
 			}
 
-			err := refreshMidScanCaches(context.Background(), db, []string{"NES"})
+			// populateTagsCache=true so all three phases run; this test is about
+			// corruption propagation, not about when the tags phase is skipped.
+			err := refreshMidScanCaches(context.Background(), db, []string{"NES"}, true)
 			require.Error(t, err)
 			assert.True(t, database.IsCorruptionError(err))
 			db.AssertExpectations(t)
 		})
 	}
+}
+
+// TestRefreshMidScanCaches_SkipsTagsCacheWhenItWouldNotSurvive covers #1279: on a
+// run large enough that every commit invalidates all systems, SystemTagsCache is
+// dropped wholesale by the next commit, so populating it per system is wasted
+// work. The slug search and browse caches are scoped per system and survive, so
+// they must still run either way.
+func TestRefreshMidScanCaches_SkipsTagsCacheWhenItWouldNotSurvive(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name              string
+		populateTagsCache bool
+	}{
+		{name: "skips tags cache on all-systems runs", populateTagsCache: false},
+		{name: "populates tags cache on selective runs", populateTagsCache: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := &testhelpers.MockMediaDBI{}
+			db.On("RefreshSlugSearchCacheForSystems", mock.Anything, []string{"NES"}).Return(nil).Once()
+			db.On("PopulateBrowseCacheForSystems", mock.Anything, []string{"NES"}).Return(nil).Once()
+			if tc.populateTagsCache {
+				db.On("PopulateSystemTagsCacheForSystems", mock.Anything, mock.Anything).Return(nil).Once()
+			}
+
+			err := refreshMidScanCaches(context.Background(), db, []string{"NES"}, tc.populateTagsCache)
+			require.NoError(t, err)
+			if !tc.populateTagsCache {
+				db.AssertNotCalled(t, "PopulateSystemTagsCacheForSystems", mock.Anything, mock.Anything)
+			}
+			db.AssertExpectations(t)
+		})
+	}
+}
+
+// TestMidScanSystemTagsCacheSurvivesCommit_MatchesInvalidationScope guards the
+// pairing between the predicate and invalidationScopeForSystemIDs: if the
+// selective-invalidation threshold moves, the mid-scan skip must move with it or
+// it starts skipping populations that would in fact have survived.
+func TestMidScanSystemTagsCacheSurvivesCommit_MatchesInvalidationScope(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, mediadb.MidScanSystemTagsCacheSurvivesCommit(0), "no systems invalidates all")
+	assert.True(t, mediadb.MidScanSystemTagsCacheSurvivesCommit(1))
+	assert.True(t, mediadb.MidScanSystemTagsCacheSurvivesCommit(32), "at the threshold, still selective")
+	assert.False(t, mediadb.MidScanSystemTagsCacheSurvivesCommit(33), "past the threshold, all systems")
+	assert.False(t, mediadb.MidScanSystemTagsCacheSurvivesCommit(131), "a full MiSTer library")
 }
 
 func TestBestEffortMaintenanceError_PreservesWrappedCorruption(t *testing.T) {

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -58,7 +58,6 @@ const (
 	throttledMaxFilesPerTransaction = 500
 	disabledWALAutoCheckpoint       = 0
 	defaultWALAutoCheckpoint        = 1000
-	mediaIndexingPageSize           = 4096 // SQLite's compiled default; mirrors mediaPageSize in mediadb.go
 	mediaDatabaseCorruptMessage     = "media database is corrupt; manual repair or rebuild required; " +
 		"original database left untouched"
 	// walkEntryWaitInterval is how often (in scanned filesystem entries) the
@@ -108,7 +107,7 @@ func logIndexingEnvironment(db database.MediaDBI, platform platforms.Platform) {
 // physical connection. Best-effort, like logIndexingEnvironment above.
 func logEffectiveIndexingPragmas(ctx context.Context, db database.MediaDBI) {
 	database.LogEffectivePragmasForDB(
-		ctx, db.UnsafeGetSQLDb(), "media-indexing", database.SynchronousNormal, mediaIndexingPageSize,
+		ctx, db.UnsafeGetSQLDb(), "media-indexing", database.SynchronousNormal, database.UnsetPageSize,
 	)
 }
 

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -316,10 +316,6 @@ type PathResult struct {
 	System systemdefs.System
 }
 
-type slugSearchCacheDropper interface {
-	DropSlugSearchCacheForSystems(systemIDs []string)
-}
-
 type indexingPlanStore interface {
 	SetIndexingPlanSystems(systemIDs []string) error
 	GetIndexingPlanSystems() ([]string, error)
@@ -1288,6 +1284,35 @@ func NewNamesIndex(
 	}
 	log.Info().Msgf("starting indexing for requested systems: %v (runnable: %v)", requestedSystemIDs, currentSystemIDs)
 
+	// Clear the resume marker before the status says a run is under way, so a
+	// crash in between cannot make the next boot resume from the previous run's
+	// last system.
+	if !shouldResume {
+		if setErr := bestEffortMaintenanceError(
+			db.SetLastIndexedSystem(""), "failed to clear last indexed system",
+		); setErr != nil {
+			return 0, setErr
+		}
+	}
+
+	// Mark the run before it commits anything. MediaDB picks its cache
+	// invalidation scope on every commit by reading this status: a commit made
+	// while it still reads "completed" is an ordinary write, so it drops the
+	// whole in-memory slug search cache and the tag list, while a commit made
+	// during a run keeps both and lets the scanner invalidate per system as it
+	// goes.
+	//
+	// SeedCanonicalTags commits, so with the status written after it the first
+	// commit of every run threw both caches away. On the #1279 device that left
+	// media.search on the grouped SQL LIKE path and made media.tags re-aggregate
+	// 731,332 rows per call, and both hit the 30s API timeout.
+	if setErr := bestEffortMaintenanceError(
+		db.SetIndexingStatus(mediadb.IndexingStatusRunning),
+		"failed to set indexing status to running",
+	); setErr != nil {
+		return 0, setErr
+	}
+
 	// Ensure the canonical tag vocabulary exists before any system reconciles
 	// against it. Set-based: no existing rows are read into memory.
 	if err = SeedCanonicalTags(ctx, db); err != nil {
@@ -1301,20 +1326,6 @@ func NewNamesIndex(
 	}
 
 	logPhaseMetrics("seed_canonical_tags")
-
-	if setErr := bestEffortMaintenanceError(
-		db.SetIndexingStatus(mediadb.IndexingStatusRunning),
-		"failed to set indexing status to running",
-	); setErr != nil {
-		return 0, setErr
-	}
-	if !shouldResume {
-		if setErr := bestEffortMaintenanceError(
-			db.SetLastIndexedSystem(""), "failed to clear last indexed system",
-		); setErr != nil {
-			return 0, setErr
-		}
-	}
 
 	// Build sorted system list as the single loop driver. This covers all three
 	// previous sources: sysPathIDs (systems with paths), launcher-specific
@@ -1454,9 +1465,21 @@ func NewNamesIndex(
 			continue
 		}
 
-		if dropper, ok := db.(slugSearchCacheDropper); ok {
-			dropper.DropSlugSearchCacheForSystems([]string{systemID})
-		}
+		// The slug search cache deliberately keeps this system's previous
+		// entries while it is rescanned; refreshMidScanCaches replaces them
+		// once the system commits. Nothing is served wrongly in the meantime:
+		// the cache only nominates candidate title IDs, and the rows come from
+		// a live query, so entries whose rows have gone simply return nothing.
+		// Only files added since the last run are missing, and only until this
+		// system finishes.
+		//
+		// Evicting up front instead cost far more than it protected. A search
+		// naming an evicted system cannot be answered from memory, so a
+		// library-wide search — which names every system — fell back to the
+		// grouped SQL LIKE path for whichever systems were in flight. Measured
+		// on the #1279 device mid-index, the same query took 242 ms across 28
+		// covered systems and 27,205 ms across all of them; the difference was
+		// entirely the fallback for the four in flight.
 
 		// Drop any staged rows a crashed run left behind (a mid-system commit
 		// makes staged rows durable); this system re-stages from scratch.

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -56,8 +56,9 @@ const (
 	// throttledMaxFilesPerTransaction is used instead of maxFilesPerTransaction
 	// while background indexing is explicitly throttled or paused.
 	throttledMaxFilesPerTransaction = 500
-	constrainedWALAutoCheckpoint    = 128
+	disabledWALAutoCheckpoint       = 0
 	defaultWALAutoCheckpoint        = 1000
+	mediaIndexingPageSize           = 4096 // SQLite's compiled default; mirrors mediaPageSize in mediadb.go
 	mediaDatabaseCorruptMessage     = "media database is corrupt; manual repair or rebuild required; " +
 		"original database left untouched"
 	// walkEntryWaitInterval is how often (in scanned filesystem entries) the
@@ -70,6 +71,83 @@ const (
 	rootValidationConcurrency = 4
 	slowZIPListingThreshold   = 5 * time.Second
 )
+
+// logIndexingEnvironment records the storage and version context for an
+// indexing run once, up front: the effective pragmas (logged separately,
+// after configureIndexingPragmas applies them) tell us what SQLite is doing;
+// this tells us what it's doing it on. Best-effort — a lookup failure logs a
+// warning and indexing proceeds regardless.
+func logIndexingEnvironment(db database.MediaDBI, platform platforms.Platform) {
+	dbPath := db.GetDBPath()
+	event := log.Info().
+		Str("version", config.AppVersion).
+		Str("platform", platform.ID()).
+		Str("dbPath", dbPath)
+
+	if storage, ok := helpers.StorageInfoForPath(dbPath); ok {
+		event = event.
+			Str("fsType", storage.FSType).
+			Str("mountPoint", storage.Mountpoint).
+			Str("mountSource", storage.Source).
+			Str("mountOptions", storage.Options)
+	}
+
+	if freeBytes, freeErr := helpers.FreeDiskSpace(dbPath); freeErr != nil {
+		log.Warn().Err(freeErr).Msg("failed to determine free disk space before indexing")
+	} else {
+		event = event.Uint64("freeDiskBytes", freeBytes)
+	}
+
+	event.Msg("media indexing environment")
+}
+
+// logEffectiveIndexingPragmas reads back the pragmas actually applied to the
+// pool after configureIndexingPragmas ran, rather than trusting the request —
+// SetWALAutoCheckpoint (mediadb.go) skips a connection it cannot acquire
+// within its timeout, so a value set there can silently fail to reach every
+// physical connection. Best-effort, like logIndexingEnvironment above.
+func logEffectiveIndexingPragmas(ctx context.Context, db database.MediaDBI) {
+	database.LogEffectivePragmasForDB(
+		ctx, db.UnsafeGetSQLDb(), "media-indexing", database.SynchronousNormal, mediaIndexingPageSize,
+	)
+}
+
+// checkWALJournalMode reports a clear error when the media database is not in
+// WAL journal mode, instead of the silent mid-index hang a rollback journal
+// would otherwise cause (see the caller's comment for why). Verification
+// itself is best-effort: an inability to check — no open handle, connection
+// acquire failure, or pragma read failure — logs a warning and lets indexing
+// proceed, the same tolerance every other diagnostic in this file applies.
+// Only a definite non-WAL journal mode returns an error.
+func checkWALJournalMode(ctx context.Context, db database.MediaDBI) error {
+	sqlDB := db.UnsafeGetSQLDb()
+	if sqlDB == nil {
+		log.Warn().Msg("no database handle available to verify WAL journal mode before indexing; continuing")
+		return nil
+	}
+
+	journalConn, connErr := sqlDB.Conn(ctx)
+	if connErr != nil {
+		log.Warn().Err(connErr).Msg("failed to verify WAL journal mode before indexing; continuing")
+		return nil
+	}
+	pragmas, pragmaErr := database.ReadEffectivePragmas(ctx, journalConn)
+	if closeErr := journalConn.Close(); closeErr != nil {
+		log.Warn().Err(closeErr).Msg("failed to release WAL journal mode verification connection")
+	}
+	switch {
+	case pragmaErr != nil:
+		log.Warn().Err(pragmaErr).Msg("failed to verify WAL journal mode before indexing; continuing")
+		return nil
+	case pragmas.JournalMode != "wal":
+		return fmt.Errorf(
+			"media database is not in WAL journal mode (got %q); indexing requires WAL for its "+
+				"batched per-system transactions and would hang under a rollback journal instead of failing",
+			pragmas.JournalMode)
+	default:
+		return nil
+	}
+}
 
 // batchCommitLimit returns the file-count threshold for committing an
 // indexing batch. Explicitly throttled or paused work uses smaller commits so
@@ -87,15 +165,20 @@ type indexingPragmaDB interface {
 	SetWALAutoCheckpoint(pages int)
 }
 
-func configureIndexingPragmas(db indexingPragmaDB, baselinePaced bool) func() {
+// configureIndexingPragmas disables SQLite's automatic WAL checkpointing for the
+// duration of indexing, on every platform (not just resource-constrained ones):
+// device measurement on #1279 showed automatic checkpointing running inside
+// tx.Commit at the previous constrained 128-page threshold produced worse commit
+// stalls than the original report it was meant to fix (up to 29.5s, vs 16.6s
+// before), while checkpointLargeWAL's own explicit, logged checkpoint never once
+// fired because its threshold was unreachable. checkpointLargeWAL (now at a
+// reachable threshold — mediaWALCheckpointThreshold, mediadb.go) replaces it as
+// the sole, deliberate, measured checkpoint mechanism during indexing.
+func configureIndexingPragmas(db indexingPragmaDB) func() {
 	db.SetIndexingCacheSize(true)
-	if baselinePaced {
-		db.SetWALAutoCheckpoint(constrainedWALAutoCheckpoint)
-	}
+	db.SetWALAutoCheckpoint(disabledWALAutoCheckpoint)
 	return func() {
-		if baselinePaced {
-			db.SetWALAutoCheckpoint(defaultWALAutoCheckpoint)
-		}
+		db.SetWALAutoCheckpoint(defaultWALAutoCheckpoint)
 		db.SetIndexingCacheSize(false)
 	}
 }
@@ -853,7 +936,13 @@ func handleCancellation(ctx context.Context, db database.MediaDBI, message strin
 // system tags cache serves tag filters, and the browse cache serves directory
 // listings. Best-effort — a failure only means those systems stay on the SQL
 // fallback paths until the end-of-run rebuild.
-func refreshMidScanCaches(ctx context.Context, db database.MediaDBI, systemIDs []string) error {
+// populateTagsCache is false on runs big enough that every commit invalidates
+// all systems, which drops SystemTagsCache wholesale — see
+// mediadb.MidScanSystemTagsCacheSurvivesCommit. Populating it there is pure
+// cost: the rows are deleted by the next system's commit.
+func refreshMidScanCaches(
+	ctx context.Context, db database.MediaDBI, systemIDs []string, populateTagsCache bool,
+) error {
 	started := time.Now()
 	if err := bestEffortMaintenanceError(
 		db.RefreshSlugSearchCacheForSystems(ctx, systemIDs),
@@ -861,18 +950,20 @@ func refreshMidScanCaches(ctx context.Context, db database.MediaDBI, systemIDs [
 	); err != nil {
 		return err
 	}
-	sysDefs := make([]systemdefs.System, 0, len(systemIDs))
-	for _, id := range systemIDs {
-		if sys, err := systemdefs.GetSystem(id); err == nil && sys != nil {
-			sysDefs = append(sysDefs, *sys)
+	if populateTagsCache {
+		sysDefs := make([]systemdefs.System, 0, len(systemIDs))
+		for _, id := range systemIDs {
+			if sys, err := systemdefs.GetSystem(id); err == nil && sys != nil {
+				sysDefs = append(sysDefs, *sys)
+			}
 		}
-	}
-	if len(sysDefs) > 0 {
-		if err := bestEffortMaintenanceError(
-			db.PopulateSystemTagsCacheForSystems(ctx, sysDefs),
-			"mid-scan system tags cache refresh failed",
-		); err != nil {
-			return err
+		if len(sysDefs) > 0 {
+			if err := bestEffortMaintenanceError(
+				db.PopulateSystemTagsCacheForSystems(ctx, sysDefs),
+				"mid-scan system tags cache refresh failed",
+			); err != nil {
+				return err
+			}
 		}
 	}
 	if err := bestEffortMaintenanceError(
@@ -883,6 +974,7 @@ func refreshMidScanCaches(ctx context.Context, db database.MediaDBI, systemIDs [
 	}
 	log.Debug().
 		Strs("systems", systemIDs).
+		Bool("tagsCache", populateTagsCache).
 		Dur("elapsed", time.Since(started)).
 		Msg("mid-scan cache refresh complete")
 	return nil
@@ -949,6 +1041,7 @@ func NewNamesIndex(
 ) (indexedFiles int, err error) {
 	db := fdb.MediaDB
 	indexStartTime := time.Now()
+	logIndexingEnvironment(db, platform)
 	metrics := perfmetrics.NewRecorderForDB(db)
 	runMetricsStart := metrics.Capture(ctx, true)
 	phaseMetricsStart := runMetricsStart
@@ -970,11 +1063,11 @@ func NewNamesIndex(
 	tags.SetCompanyNameCache(make(map[string]tags.TagValue))
 	defer tags.SetCompanyNameCache(nil)
 
-	// Temporarily increase SQLite cache to 32MB for bulk indexing. Constrained
-	// indexing also bounds automatic checkpoints, with both settings restored on
-	// every return path.
-	cleanupPragmas := configureIndexingPragmas(db, pauser.HasBaselineThrottle())
+	// Temporarily increase SQLite cache to 32MB for bulk indexing and disable
+	// automatic WAL checkpointing, with both settings restored on every return path.
+	cleanupPragmas := configureIndexingPragmas(db)
 	defer cleanupPragmas()
+	logEffectiveIndexingPragmas(ctx, db)
 
 	log.Info().
 		Int("systemCount", len(systems)).
@@ -984,6 +1077,9 @@ func NewNamesIndex(
 	requestedSystemIDs := systemIDsFromDefs(systems)
 	allSystemIDs := systemIDsFromDefs(systemdefs.AllSystems())
 	fullRun := helpers.EqualStringSlices(requestedSystemIDs, allSystemIDs)
+	// Decided once: the invalidation scope depends on the run's system count,
+	// which does not change while the run is in flight.
+	midScanTagsCache := mediadb.MidScanSystemTagsCacheSurvivesCommit(len(requestedSystemIDs))
 
 	// Register terminal classification before readiness reads so corruption from
 	// either status query is persisted after transaction cleanup.
@@ -1002,6 +1098,19 @@ func NewNamesIndex(
 	_, checkErr := db.GetIndexingStatus()
 	if checkErr != nil {
 		return 0, fmt.Errorf("database not ready for indexing (possible lock or corruption): %w", checkErr)
+	}
+
+	// Indexing batches one write transaction per system while the next
+	// system's state load reads on a separate pool connection
+	// (PopulatePersistentScanStateForSystem). Under WAL that read sees the
+	// last committed snapshot while the writer transaction is still open;
+	// under a rollback journal the writer holds an exclusive lock for the
+	// whole transaction, so the separate-connection read blocks until
+	// commit — which never comes, because the read is on the critical path
+	// to reaching the next commit. Fail loudly here instead of hanging
+	// silently mid-index.
+	if walErr := checkWALJournalMode(ctx, db); walErr != nil {
+		return 0, walErr
 	}
 
 	// 2. Determine resume state
@@ -1250,10 +1359,6 @@ func NewNamesIndex(
 	rowsInBatch := int64(0)
 	batchStarted := false
 	pendingSystems := make([]string, 0)
-	// Set after the first system-boundary commit runs an approximate ANALYZE,
-	// so a fresh database gets planner statistics minutes into the scan
-	// instead of at the end.
-	earlyAnalyzeDone := false
 
 	// Sub-phase wall-time accumulators across the systems loop, logged once after
 	// it so the monolithic "systems" phase can be attributed to its parts:
@@ -1265,7 +1370,27 @@ func NewNamesIndex(
 		insertDur    time.Duration
 		reconcileDur time.Duration
 		commitDur    time.Duration
+		// Everything below was previously untimed. Round 7 measured
+		// elapsed - (collect+insert+reconcile+commit) at 11.87 min (18.3% of the
+		// run) with no log line accounting for any of it, so the largest single
+		// item in a reindex could not be worked on. See #1279.
+		//
+		// throttleDur is deliberately separate from the work phases: on a
+		// resource-constrained platform the scanner sleeps between work windows
+		// by design, and that time must never be mistaken for work being slow.
+		throttleDur     time.Duration
+		analyzeDur      time.Duration
+		cacheRefreshDur time.Duration
 	)
+
+	// timedWait accounts for time spent blocked in the pauser — throttle sleeps
+	// on constrained platforms, or an unbounded pause while a game is running.
+	timedWait := func(wait func() error) error {
+		start := time.Now()
+		err := wait()
+		throttleDur += time.Since(start)
+		return err
+	}
 
 	// TODO: skip unchanged systems via a per-system fingerprint — store
 	// hash(sorted walked paths) + parser version + media row count after each
@@ -1279,17 +1404,41 @@ func NewNamesIndex(
 	// are called for every system, fixing the stale-state gaps that existed in
 	// the previous loop 2 and loop 3.
 	for _, sys := range sortedSystems {
+		// Starts the iteration, not the collect phase: the pauser wait, status
+		// update, slug cache drop and scan-stage clear below all cost real time
+		// and used to fall outside the measured window entirely, so a system
+		// could report an elapsed far smaller than the wall time it consumed.
+		systemStartTime := time.Now()
+
 		// Check for cancellation or pause
 		select {
 		case <-ctx.Done():
 			return handleCancellationWithRollback(ctx, db, "Media indexing cancelled")
 		default:
 		}
-		if waitErr := pauser.Wait(ctx); waitErr != nil {
+		if waitErr := timedWait(func() error { return pauser.Wait(ctx) }); waitErr != nil {
 			return handleCancellationWithRollback(ctx, db, "Media indexing cancelled while paused")
 		}
+		// Setup is measured from after the wait above, not from systemStartTime:
+		// that wait is already counted in throttle, and measuring setup from the
+		// top of the loop would count it in both, inflating the named phases and
+		// shrinking unattributed by the same amount. elapsed still spans the whole
+		// iteration — throttle owns the wait, setup owns what follows it.
+		systemSetupStart := time.Now()
 
 		systemMetricsStart := metrics.Capture(ctx, false)
+		// Snapshot the run-level sub-phase accumulators so this system's own
+		// share can be reported when it finishes. Without per-system figures a
+		// system that runs long can only be attributed to "the systems phase";
+		// the whole-run breakdown logged after the loop cannot say whether the
+		// time went to walking, staging, reconciling or committing. See #1279.
+		systemCollectStart := collectDur
+		systemInsertStart := insertDur
+		systemReconcileStart := reconcileDur
+		systemCommitStart := commitDur
+		systemThrottleStart := throttleDur
+		systemAnalyzeStart := analyzeDur
+		systemCacheRefreshStart := cacheRefreshDur
 		systemID := sys.ID
 		status.SystemID = systemID
 		status.Step++
@@ -1321,8 +1470,10 @@ func NewNamesIndex(
 		}
 
 		files := make([]platforms.ScanResult, 0)
-		systemStartTime := time.Now()
 		collectStart := time.Now()
+		// Per-system setup: the pauser wait, status update, slug cache drop and
+		// scan-stage clear that ran before collection could start.
+		systemSetupDur := collectStart.Sub(systemSetupStart)
 		// Set when any file source for this system errors. The staged set is
 		// then a subset of the library, so the reconcile must not treat
 		// absence from it as evidence media is missing.
@@ -1481,7 +1632,7 @@ func NewNamesIndex(
 				return handleCancellationWithRollback(ctx, db, "Media indexing cancelled during file processing")
 			default:
 			}
-			if waitErr := pauser.Wait(ctx); waitErr != nil {
+			if waitErr := timedWait(func() error { return pauser.Wait(ctx) }); waitErr != nil {
 				return handleCancellationWithRollback(ctx, db,
 					"Media indexing cancelled while paused during file processing")
 			}
@@ -1583,7 +1734,7 @@ func NewNamesIndex(
 
 				// Give a throttled/paused foreground consumer a window right
 				// after the commit's fsync burst, before starting the next batch.
-				if waitErr := pauser.Wait(ctx); waitErr != nil {
+				if waitErr := timedWait(func() error { return pauser.Wait(ctx) }); waitErr != nil {
 					return handleCancellationWithRollback(ctx, db, "Media indexing cancelled after file-limit commit")
 				}
 			}
@@ -1655,7 +1806,7 @@ func NewNamesIndex(
 
 		// Apply only bounded pacing before commit. A full pause is honored
 		// immediately after commit so it cannot pin the writer transaction.
-		if waitErr := pauser.WaitForPacing(ctx); waitErr != nil {
+		if waitErr := timedWait(func() error { return pauser.WaitForPacing(ctx) }); waitErr != nil {
 			return handleCancellationWithRollback(ctx, db, "Media indexing cancelled after system reconcile")
 		}
 
@@ -1710,43 +1861,84 @@ func NewNamesIndex(
 
 			// Give a throttled/paused foreground consumer a window right
 			// after the commit's fsync burst, before analyze/cache refresh.
-			if waitErr := pauser.Wait(ctx); waitErr != nil {
+			if waitErr := timedWait(func() error { return pauser.Wait(ctx) }); waitErr != nil {
 				return handleCancellationWithRollback(ctx, db, "Media indexing cancelled after system boundary commit")
 			}
 
 			if len(justCommitted) > 0 {
-				// Give the query planner statistics as soon as the first system
-				// lands: a fresh database has an empty sqlite_stat1 until the
-				// end-of-run ANALYZE, and mid-scan fallback queries can pick
-				// catastrophic plans without it.
-				if !earlyAnalyzeDone {
-					if analyzeErr := bestEffortMaintenanceError(
-						db.AnalyzeApproximate(), "early approximate ANALYZE failed",
-					); analyzeErr != nil {
-						return 0, analyzeErr
-					}
-					earlyAnalyzeDone = true
+				// Refresh query planner statistics after every system boundary
+				// commit, not just the first: a fresh database has an empty
+				// sqlite_stat1 until the end-of-run ANALYZE, and stats captured
+				// once early (when Media holds only the first system's rows)
+				// stay frozen for the rest of a long run otherwise — the
+				// planner keeps believing a SystemDBID filter is unselective
+				// long after Media has grown far past that. PRAGMA optimize
+				// only re-analyzes a table whose size has changed >10x (or
+				// that lacks stats) since its last analysis, so this becomes
+				// a cheap no-op on most calls once table sizes stabilize
+				// relative to their last analysis. See #1279.
+				//
+				// Timed because it is not free when a table does qualify: this
+				// call sat in the untimed window and PRAGMA optimize used a mask
+				// that omitted SQLite's analysis limit, so a qualifying table got
+				// a full unbounded ANALYZE. The mask is fixed (see
+				// AnalyzeApproximate), and this timer is what proves it stays
+				// cheap on the device rather than assuming it.
+				analyzeStart := time.Now()
+				analyzeErr := bestEffortMaintenanceError(
+					db.AnalyzeApproximate(), "approximate ANALYZE after system commit failed",
+				)
+				analyzeDur += time.Since(analyzeStart)
+				if analyzeErr != nil {
+					return 0, analyzeErr
 				}
-				if cacheErr := refreshMidScanCaches(ctx, db, justCommitted); cacheErr != nil {
+				cacheRefreshStart := time.Now()
+				cacheErr := refreshMidScanCaches(ctx, db, justCommitted, midScanTagsCache)
+				cacheRefreshDur += time.Since(cacheRefreshStart)
+				if cacheErr != nil {
 					return 0, cacheErr
 				}
 
 				// Cache refresh (slug search, tags, browse) is read-heavy SQL
 				// work; give the foreground another window before the next
 				// system starts.
-				if waitErr := pauser.Wait(ctx); waitErr != nil {
+				if waitErr := timedWait(func() error { return pauser.Wait(ctx) }); waitErr != nil {
 					return handleCancellationWithRollback(ctx, db, "Media indexing cancelled after cache refresh")
 				}
 			}
 		}
 
 		systemElapsed := time.Since(systemStartTime)
+		systemCollect := collectDur - systemCollectStart
+		systemInsert := insertDur - systemInsertStart
+		systemReconcile := reconcileDur - systemReconcileStart
+		systemCommit := commitDur - systemCommitStart
+		systemThrottle := throttleDur - systemThrottleStart
+		systemAnalyze := analyzeDur - systemAnalyzeStart
+		systemCacheRefresh := cacheRefreshDur - systemCacheRefreshStart
+		// Whatever the named phases do not account for. Logged directly so the
+		// residue is visible without arithmetic across eight fields, and so a
+		// future regression in an untimed path shows up as a number rather than
+		// as a system that is mysteriously slow. Round 7 measured this at 18.3%
+		// of the run with nothing reporting it at all.
+		systemUnattributed := systemElapsed - systemSetupDur - systemCollect - systemInsert -
+			systemReconcile - systemCommit - systemThrottle - systemAnalyze - systemCacheRefresh
+
 		systemMetricsEnd := metrics.Capture(ctx, false)
 		perfmetrics.AddDelta(
 			log.Info().
 				Str("system", systemID).
 				Int("files", len(files)).
-				Dur("elapsed", systemElapsed),
+				Dur("elapsed", systemElapsed).
+				Dur("setup", systemSetupDur).
+				Dur("collect", systemCollect).
+				Dur("insert", systemInsert).
+				Dur("reconcile", systemReconcile).
+				Dur("commit", systemCommit).
+				Dur("throttle", systemThrottle).
+				Dur("analyze", systemAnalyze).
+				Dur("cacheRefresh", systemCacheRefresh).
+				Dur("unattributed", systemUnattributed),
 			&systemMetricsStart,
 			&systemMetricsEnd,
 		).Msg("completed system indexing")
@@ -1765,6 +1957,9 @@ func NewNamesIndex(
 		Dur("insert", insertDur).
 		Dur("reconcile", reconcileDur).
 		Dur("commit", commitDur).
+		Dur("throttle", throttleDur).
+		Dur("analyze", analyzeDur).
+		Dur("cacheRefresh", cacheRefreshDur).
 		Msg("media indexing systems sub-phase breakdown")
 	logPhaseMetrics("systems")
 

--- a/pkg/database/mediascanner/mediascanner_bench_test.go
+++ b/pkg/database/mediascanner/mediascanner_bench_test.go
@@ -23,12 +23,34 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 )
+
+// zaparooBenchLargeEnv gates reconcile benchmark cases large enough to blow
+// the 45-minute count=6 budget of task bench-baseline/bench-compare — neither
+// passes -short, so testing.Short() wouldn't gate these. Added for #1279 to
+// reproduce the scale (tens of thousands of files/tag links in one system)
+// where the reconcile pipeline showed super-linear cost on device:
+//
+//	ZAPAROO_BENCH_LARGE=1 go test -bench=Reconcile -benchtime=1x -count=1 ./pkg/database/mediascanner/
+const zaparooBenchLargeEnv = "ZAPAROO_BENCH_LARGE"
+
+// largeReconcileBenchSize is the size threshold above which a bench case
+// needs zaparooBenchLargeEnv set.
+const largeReconcileBenchSize = 50_000
+
+func skipUnlessLargeReconcileBench(b *testing.B) {
+	b.Helper()
+	if os.Getenv(zaparooBenchLargeEnv) != "1" {
+		b.Skipf("set %s=1 to run this large-scale reconcile benchmark", zaparooBenchLargeEnv)
+	}
+}
 
 func BenchmarkGetPathFragments(b *testing.B) {
 	cases := []struct {
@@ -135,10 +157,14 @@ func BenchmarkMediaScanner_StageAndReconcile_FreshDB(b *testing.B) {
 	}{
 		{name: "1k", n: 1_000},
 		{name: "10k", n: 10_000},
+		{name: "50k", n: largeReconcileBenchSize},
 	}
 
 	for _, sz := range sizes {
 		b.Run(sz.name, func(b *testing.B) {
+			if sz.n == largeReconcileBenchSize {
+				skipUnlessLargeReconcileBench(b)
+			}
 			b.ReportAllocs()
 			filenames := buildSyntheticFilenames(sz.n)
 			ctx := context.Background()
@@ -240,11 +266,15 @@ func BenchmarkMediaScanner_Reconcile_ExistingRows(b *testing.B) {
 		n    int
 	}{
 		{name: "10k", n: 10_000},
+		{name: "50k", n: largeReconcileBenchSize},
 		{name: "100k", n: 100_000},
 	}
 
 	for _, sz := range sizes {
 		b.Run(sz.name, func(b *testing.B) {
+			if sz.n == largeReconcileBenchSize {
+				skipUnlessLargeReconcileBench(b)
+			}
 			b.ReportAllocs()
 			filenames := buildSyntheticFilenames(sz.n)
 			ctx := context.Background()
@@ -275,6 +305,114 @@ func BenchmarkMediaScanner_Reconcile_ExistingRows(b *testing.B) {
 			b.ResetTimer()
 			for b.Loop() {
 				seedOnce()
+			}
+		})
+	}
+}
+
+// growingRunSystemCount, growingRunFilesPerSystem, and growingRunMegaFiles
+// shape BenchmarkMediaScanner_GrowingRun_AnalyzeCadence: a full library's
+// worth of distinct systems reconciled in sequence against one continuously
+// growing database, the shape a real device index run takes and none of the
+// other benchmarks in this file reproduce (they compare a fixed scan against
+// a small number of discrete existing-DB sizes, not a monotonic multi-system
+// growth curve). 120 systems of 500 files each, with every 20th system a
+// 20,000-file mega-system, approximates a real MiSTer library (#1279 round 3
+// device data: 131 systems, most under 1k files, a handful of mega-systems in
+// the tens of thousands) without the runtime of a full-scale run. The mega
+// systems specifically stress the risk this benchmark exists to check: a real
+// re-analysis (not a skipped no-op) firing against an already-large, still
+// growing Media table.
+const (
+	growingRunSystemCount    = 120
+	growingRunFilesPerSystem = 500
+	growingRunMegaEvery      = 20
+	growingRunMegaFiles      = 20_000
+)
+
+func growingRunFilesForSystem(sys int) int {
+	if sys%growingRunMegaEvery == 0 {
+		return growingRunMegaFiles
+	}
+	return growingRunFilesPerSystem
+}
+
+// BenchmarkMediaScanner_GrowingRun_AnalyzeCadence measures the aggregate cost
+// of calling AnalyzeApproximate (PRAGMA optimize) after every system-boundary
+// commit in a long run, instead of only once after the first system (#1279
+// round 4). PRAGMA optimize only re-analyzes a table whose size has changed
+// >10x (or that lacks stats) since its last analysis, so the expectation is
+// that most of these calls become cheap no-ops once table sizes stabilize
+// relative to their own last analysis — this benchmark measures whether that
+// expectation holds, rather than assuming it does.
+//
+//	ZAPAROO_BENCH_LARGE=1 go test -bench=GrowingRun -benchtime=1x -count=1 ./pkg/database/mediascanner/
+func BenchmarkMediaScanner_GrowingRun_AnalyzeCadence(b *testing.B) {
+	skipUnlessLargeReconcileBench(b)
+	ctx := context.Background()
+
+	cases := []struct {
+		name         string
+		analyzeEvery bool
+		analyzeOnce  bool
+	}{
+		{name: "PerSystem", analyzeEvery: true},
+		{name: "Once", analyzeOnce: true},
+		{name: "Never"},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+
+			for b.Loop() {
+				db, cleanup := helpers.NewInMemoryMediaDB(b)
+				if err := SeedCanonicalTags(ctx, db); err != nil {
+					b.Fatal(err)
+				}
+
+				var analyzeTotal time.Duration
+				analyzeCalls := 0
+				analyzed := false
+				for sys := range growingRunSystemCount {
+					systemID := fmt.Sprintf("synth%d", sys)
+					filenames := buildSyntheticFilenames(growingRunFilesForSystem(sys))
+					for i := range filenames {
+						filenames[i] = fmt.Sprintf("/roms/%s/f%d.rom", systemID, i)
+					}
+
+					if err := db.BeginTransaction(true); err != nil {
+						b.Fatal(err)
+					}
+					for _, fn := range filenames {
+						if err := StageMediaPath(&StageMediaPathParams{
+							DB: db, SystemID: systemID, Path: fn,
+						}); err != nil {
+							b.Fatal(err)
+						}
+					}
+					if _, err := db.ReconcileStagedSystem(ctx, systemID, database.ScanReconcileOpts{}); err != nil {
+						b.Fatal(err)
+					}
+					if err := db.CommitTransaction(); err != nil {
+						b.Fatal(err)
+					}
+
+					runAnalyze := tc.analyzeEvery || (tc.analyzeOnce && !analyzed)
+					if runAnalyze {
+						start := time.Now()
+						if err := db.AnalyzeApproximate(); err != nil {
+							b.Fatal(err)
+						}
+						analyzeTotal += time.Since(start)
+						analyzeCalls++
+						analyzed = true
+					}
+				}
+
+				b.ReportMetric(float64(analyzeTotal.Milliseconds()), "analyze-ms/op")
+				b.ReportMetric(float64(analyzeCalls), "analyze-calls/op")
+				cleanup()
 			}
 		})
 	}

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -2528,32 +2528,27 @@ func TestBatchCommitLimit_ShrinksWhenThrottledOrPaused(t *testing.T) {
 	assert.Equal(t, throttledMaxFilesPerTransaction, batchCommitLimit(paused), "paused pauser")
 }
 
-func TestConfigureIndexingPragmas_BaselinePacingRestoresOnReturn(t *testing.T) {
+// TestConfigureIndexingPragmas_DisablesWALAutoCheckpointAndRestoresOnReturn
+// covers both the disable and the restore-on-early-return, on every platform
+// (not just resource-constrained ones) — see configureIndexingPragmas's
+// comment for why this is now unconditional.
+func TestConfigureIndexingPragmas_DisablesWALAutoCheckpointAndRestoresOnReturn(t *testing.T) {
 	t.Parallel()
 
 	db := &recordingIndexingPragmaDB{}
 	earlyErr := errors.New("stop indexing early")
 	err := func() error {
-		cleanup := configureIndexingPragmas(db, true)
+		cleanup := configureIndexingPragmas(db)
 		defer cleanup()
 		return earlyErr
 	}()
 	require.ErrorIs(t, err, earlyErr)
 	assert.Equal(t, []string{
 		"cache:true",
-		fmt.Sprintf("wal:%d", constrainedWALAutoCheckpoint),
+		fmt.Sprintf("wal:%d", disabledWALAutoCheckpoint),
 		fmt.Sprintf("wal:%d", defaultWALAutoCheckpoint),
 		"cache:false",
 	}, db.calls)
-}
-
-func TestConfigureIndexingPragmas_UnpacedSkipsWAL(t *testing.T) {
-	t.Parallel()
-
-	db := &recordingIndexingPragmaDB{}
-	cleanup := configureIndexingPragmas(db, false)
-	cleanup()
-	assert.Equal(t, []string{"cache:true", "cache:false"}, db.calls)
 }
 
 func TestDirectoryWalkWorkers_ConstrainedOrRestricted(t *testing.T) {

--- a/pkg/database/mediascanner/mediascanner_test.go
+++ b/pkg/database/mediascanner/mediascanner_test.go
@@ -509,12 +509,17 @@ func TestNewNamesIndex_CorruptExistingTagsMarksDatabaseCorrupt(t *testing.T) {
 	mockMediaDB.On("GetIndexingStatus").Return("", nil).Twice()
 	mockMediaDB.On("GetAllSystems").Return([]database.System{}, nil).Once()
 	mockMediaDB.On("SetIndexingSystems", []string{"NES"}).Return(nil).Once()
+	// The run is marked before it seeds, so that seeding commit invalidates
+	// caches as an indexing commit rather than an ordinary write.
+	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusRunning).Return(nil).Once()
 	mockMediaDB.On("BeginTransaction", mock.AnythingOfType("bool")).Return(nil).Once()
 	mockMediaDB.On("SeedCanonicalTagDefinitions", mock.Anything).
 		Return(sqlite3.Error{Code: sqlite3.ErrCorrupt}).Once()
 	mockMediaDB.On("RollbackTransaction").Return(nil).Maybe()
 	mockMediaDB.On("SetIndexingStatus", mediadb.IndexingStatusCorrupt).Return(nil).Once()
-	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Once()
+	// Twice: a fresh run clears the resume marker before it marks itself
+	// running, and the corruption handler clears it again on the way out.
+	mockMediaDB.On("SetLastIndexedSystem", "").Return(nil).Twice()
 
 	_, err := NewNamesIndex(context.Background(), mockPlatform, cfg, []systemdefs.System{{ID: "NES"}},
 		&database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB}, func(IndexStatus) {}, nil)

--- a/pkg/database/mediascanner/reconcile_query_plan_test.go
+++ b/pkg/database/mediascanner/reconcile_query_plan_test.go
@@ -1,0 +1,247 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+// zaparooReconcileEQPEnv gates this investigation harness. It is not a
+// regression test: it exists to capture EXPLAIN QUERY PLAN, at a synthetic
+// scale close to the device system that surfaced the problem, for the three
+// reconcile steps #1279 found scaling with total corpus size instead of with
+// what actually changed (capture tag additions, capture stale tag titles,
+// delete stale tag links), plus the chunked upsert media statement added in
+// the same round (verifying its range predicate actually pins ScanStage as
+// the driving table is that fix's pre-ship gate).
+//
+//	ZAPAROO_RECONCILE_EQP=1 go test -run TestReconcileQueryPlansAtScale -v ./pkg/database/mediascanner/
+const zaparooReconcileEQPEnv = "ZAPAROO_RECONCILE_EQP"
+
+// explainQueryPlan and dumpSQLiteStats are duplicated (not imported) from
+// pkg/database/mediadb/sql_plan_test.go: they're unexported there, and this
+// harness lives in mediascanner specifically to reuse the synthetic-library
+// generator (buildSyntheticFilenames, StageMediaPath) without an import
+// cycle. Keep in sync if the originals change.
+func explainQueryPlan(ctx context.Context, t *testing.T, db *sql.DB, query string, args ...any) {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, rows.Close())
+	}()
+
+	t.Logf("EXPLAIN QUERY PLAN for:%s", query)
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		t.Logf("  id=%d parent=%d detail=%s", id, parent, detail)
+	}
+	require.NoError(t, rows.Err())
+}
+
+func dumpSQLiteStats(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	var statTableCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM sqlite_schema
+		WHERE type = 'table' AND name = 'sqlite_stat1'
+	`).Scan(&statTableCount))
+	if statTableCount == 0 {
+		t.Log("sqlite_stat1 not present; ANALYZE has not populated planner stats")
+		return
+	}
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT tbl, idx, stat
+		FROM sqlite_stat1
+		WHERE tbl IN ('ScanStage', 'ScanStageTags', 'Media', 'MediaTitles', 'MediaTags', 'Tags', 'TagTypes')
+		ORDER BY tbl, idx
+	`)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, rows.Close())
+	}()
+
+	for rows.Next() {
+		var tbl, stat string
+		var idx sql.NullString
+		require.NoError(t, rows.Scan(&tbl, &idx, &stat))
+		t.Logf("sqlite_stat1: tbl=%s idx=%s stat=%s", tbl, idx.String, stat)
+	}
+	require.NoError(t, rows.Err())
+}
+
+// TestReconcileQueryPlansAtScale is an investigation harness, not a
+// regression test — see zaparooReconcileEQPEnv.
+func TestReconcileQueryPlansAtScale(t *testing.T) {
+	if os.Getenv(zaparooReconcileEQPEnv) != "1" {
+		t.Skipf("set %s=1 to capture reconcile query plans at scale", zaparooReconcileEQPEnv)
+	}
+
+	const n = largeReconcileBenchSize
+	ctx := context.Background()
+	filenames := buildSyntheticFilenames(n)
+
+	db, cleanup := helpers.NewInMemoryMediaDB(t)
+	defer cleanup()
+	require.NoError(t, SeedCanonicalTags(ctx, db))
+
+	// MigrateUp (NewInMemoryMediaDB only calls the lower-level Allocate)
+	// seeds sqlite_stat1 the same way a fresh device install does — without
+	// it this harness would plan against empty statistics, which produces a
+	// different (likely better) plan than the device ever sees mid-index.
+	// On device, stats are seeded once at migrate time, refreshed once early
+	// via PRAGMA optimize, then not touched again until end-of-run — so
+	// during a mega-system's reconcile the planner is working from stats
+	// captured when the table was still small. See #1279 round 3 notes.
+	require.NoError(t, db.MigrateUp())
+
+	require.NoError(t, db.BeginTransaction(true))
+	for _, fn := range filenames {
+		require.NoError(t, StageMediaPath(&StageMediaPathParams{DB: db, SystemID: "nes", Path: fn}))
+	}
+	stats, err := db.ReconcileStagedSystem(ctx, "nes", database.ScanReconcileOpts{})
+	require.NoError(t, err)
+	require.NoError(t, db.CommitTransaction())
+	t.Logf("staged %d files -> %d titles, %d media, %d tag links",
+		n, stats.TitlesInserted, stats.MediaUpserted, stats.TagLinksAdded)
+
+	sqlDB := db.UnsafeGetSQLDb()
+	dumpSQLiteStats(ctx, t, sqlDB)
+
+	var cacheSize, pageCount int64
+	require.NoError(t, sqlDB.QueryRowContext(ctx, "PRAGMA cache_size").Scan(&cacheSize))
+	require.NoError(t, sqlDB.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount))
+	t.Logf("cache_size=%d page_count=%d", cacheSize, pageCount)
+
+	systemDBID := stats.SystemDBID
+
+	// sqlReconcileStagedSystem clears ScanStage at the end of every reconcile
+	// (sqlClearScanStage), so by this point it's empty — capturing EQP against
+	// an empty, statistics-less ScanStage would be unrepresentative of what
+	// the planner sees while the chunked upsert media statement actually
+	// runs. Re-stage the same files and commit (without reconciling this
+	// second batch) so ScanStage is populated the same way mid-reconcile,
+	// and visible to the pooled connection EXPLAIN QUERY PLAN below runs on
+	// (staging alone, via db.tx, wouldn't be — WAL readers on a different
+	// connection can't see an uncommitted transaction).
+	require.NoError(t, db.BeginTransaction(true))
+	for _, fn := range filenames {
+		require.NoError(t, StageMediaPath(&StageMediaPathParams{DB: db, SystemID: "nes", Path: fn}))
+	}
+	require.NoError(t, db.CommitTransaction())
+
+	// Query text below is duplicated from unexported statements/consts in
+	// pkg/database/mediadb/sql_scan_reconcile.go (scanStaleLinkFilter and the
+	// capture/delete steps built from it, plus the chunked upsert media
+	// statement) — kept in literal form here rather than exported, since
+	// this harness is an investigation tool, not a shipped dependency. Keep
+	// in sync with the source if those queries change shape.
+
+	explainQueryPlan(ctx, t, sqlDB, `
+		WITH multi_titles AS (
+			SELECT MediaTitleDBID FROM Media
+			WHERE SystemDBID = ? AND IsMissing = 0
+			GROUP BY MediaTitleDBID HAVING COUNT(*) > 1
+		)
+		INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID)
+		SELECT m.MediaTitleDBID
+		FROM ScanStageTags st
+		JOIN Media m ON m.SystemDBID = ? AND m.Path = st.Path
+		JOIN multi_titles mtit ON mtit.MediaTitleDBID = m.MediaTitleDBID
+		JOIN TagTypes tt ON tt.Type = st.TagType
+		JOIN Tags t ON t.TypeDBID = tt.DBID AND t.Tag = st.Tag
+		WHERE NOT EXISTS (
+			SELECT 1 FROM MediaTags mt WHERE mt.MediaDBID = m.DBID AND mt.TagDBID = t.DBID
+		)`, systemDBID, systemDBID)
+
+	const staleLinkFilter = `
+		FROM Media m
+		JOIN ScanStage s ON s.Path = m.Path
+		JOIN MediaTags mt ON mt.MediaDBID = m.DBID
+		JOIN Tags t ON t.DBID = mt.TagDBID
+		JOIN TagTypes tt ON tt.DBID = t.TypeDBID
+		WHERE m.SystemDBID = ?
+		  AND tt.Type NOT IN (?, ?, ?, ?, ?)
+		  AND tt.Type NOT LIKE ?
+		  AND tt.Type NOT LIKE ?
+		  AND NOT EXISTS (
+			SELECT 1 FROM ScanStageTags st
+			WHERE st.Path = m.Path AND st.TagType = tt.Type AND st.Tag = t.Tag
+		  )`
+	nonScannerTypeArgs := []any{
+		systemDBID,
+		string(tags.TagTypeUser),
+		string(tags.TagTypeProperty),
+		string(tags.TagTypeRating),
+		string(tags.TagTypeGenre),
+		string(tags.TagTypeGameFamily),
+		string(tags.ScraperType("")) + "%",
+		string(tags.ScraperRunType("")) + "%",
+	}
+
+	explainQueryPlan(ctx, t, sqlDB,
+		"WITH multi_titles AS ("+
+			"SELECT MediaTitleDBID FROM Media WHERE SystemDBID = ? AND IsMissing = 0 "+
+			"GROUP BY MediaTitleDBID HAVING COUNT(*) > 1) "+
+			"INSERT OR IGNORE INTO ScanTouchedTitles (TitleDBID) SELECT m.MediaTitleDBID"+staleLinkFilter+
+			" AND EXISTS (SELECT 1 FROM multi_titles mtit WHERE mtit.MediaTitleDBID = m.MediaTitleDBID)",
+		append([]any{systemDBID}, nonScannerTypeArgs...)...)
+
+	explainQueryPlan(ctx, t, sqlDB,
+		"DELETE FROM MediaTags WHERE (MediaDBID, TagDBID) IN (SELECT mt.MediaDBID, mt.TagDBID"+staleLinkFilter+")",
+		nonScannerTypeArgs...)
+
+	// The chunked upsert media statement from item 1, using an actual
+	// scanUpsertMediaBatchSize-wide slice of ScanStage.Path (not a wide-open
+	// sentinel range) — a real chunk's cardinality matters to the planner's
+	// cost estimate, so a near-unbounded range would not be representative.
+	var chunkLower, chunkUpper string
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT Path FROM ScanStage ORDER BY Path LIMIT 1 OFFSET ?", n/2).Scan(&chunkLower))
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT Path FROM ScanStage ORDER BY Path LIMIT 1 OFFSET ?", n/2+2000).Scan(&chunkUpper))
+	explainQueryPlan(ctx, t, sqlDB, `
+		INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName, IsMissing)
+		SELECT t.DBID, ?, s.Path, s.ParentDir, s.SortName, 0
+		FROM ScanStage s
+		CROSS JOIN MediaTitles t ON t.SystemDBID = ? AND t.Slug = s.Slug
+		WHERE s.Path > ? AND s.Path <= ?
+		ON CONFLICT (SystemDBID, Path) DO UPDATE SET
+			MediaTitleDBID = excluded.MediaTitleDBID,
+			ParentDir      = excluded.ParentDir,
+			SortName       = excluded.SortName,
+			IsMissing      = 0
+		WHERE MediaTitleDBID <> excluded.MediaTitleDBID
+		   OR ParentDir <> excluded.ParentDir
+		   OR SortName <> excluded.SortName
+		   OR IsMissing <> 0`, systemDBID, systemDBID, chunkLower, chunkUpper)
+}

--- a/pkg/database/mediascanner/resume_plan_test.go
+++ b/pkg/database/mediascanner/resume_plan_test.go
@@ -42,6 +42,7 @@ func TestNewNamesIndex_ResumeUsesPersistedPlanWhenCurrentRunnableSetShrinks(t *t
 	require.NoError(t, err)
 
 	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("ID").Return("test-platform")
 	mockPlatform.On("Launchers", cfg).Return([]platforms.Launcher{})
 	mockPlatform.On("RootDirs", cfg).Return([]string{})
 

--- a/pkg/database/mediascanner/virtual_launchables_test.go
+++ b/pkg/database/mediascanner/virtual_launchables_test.go
@@ -110,6 +110,7 @@ func TestNewNamesIndexIndexesVirtualMediaAndPreservesVirtualSystems(t *testing.T
 		MockPlatform: mocks.NewMockPlatform(),
 		defs:         []launchables.Launchable{item},
 	}
+	platform.On("ID").Return("test-platform")
 	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
 	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{})
 

--- a/pkg/database/pragmas.go
+++ b/pkg/database/pragmas.go
@@ -1,0 +1,140 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// SQLite's PRAGMA synchronous integer values, for comparing against
+// EffectivePragmas.Synchronous without a magic number at each call site.
+const (
+	SynchronousOff    = 0
+	SynchronousNormal = 1
+	SynchronousFull   = 2
+)
+
+// EffectivePragmas is what SQLite actually applied for a connection, read back
+// after open rather than trusted from the DSN. A DSN pragma can silently fail
+// to take (e.g. a filesystem that does not support WAL falls back to a
+// rollback journal), and nothing upstream of this reports that today.
+type EffectivePragmas struct {
+	JournalMode       string
+	Synchronous       int64
+	PageSize          int64
+	WALAutoCheckpoint int64
+	TempStore         int64
+	CacheSize         int64
+	BusyTimeout       int64
+	ForeignKeys       int64
+}
+
+// ReadEffectivePragmas queries the pragmas SQLite actually has set on conn.
+// Pragmas are per-connection state, so the caller must pass a connection
+// pinned via sqlDB.Conn (or the transaction's connection) rather than the
+// pool — querying through *sql.DB can silently land on a different physical
+// connection than the one being verified.
+func ReadEffectivePragmas(ctx context.Context, conn *sql.Conn) (EffectivePragmas, error) {
+	var p EffectivePragmas
+	if err := conn.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&p.JournalMode); err != nil {
+		return p, fmt.Errorf("failed to read journal_mode: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA synchronous").Scan(&p.Synchronous); err != nil {
+		return p, fmt.Errorf("failed to read synchronous: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA page_size").Scan(&p.PageSize); err != nil {
+		return p, fmt.Errorf("failed to read page_size: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA wal_autocheckpoint").Scan(&p.WALAutoCheckpoint); err != nil {
+		return p, fmt.Errorf("failed to read wal_autocheckpoint: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA temp_store").Scan(&p.TempStore); err != nil {
+		return p, fmt.Errorf("failed to read temp_store: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA cache_size").Scan(&p.CacheSize); err != nil {
+		return p, fmt.Errorf("failed to read cache_size: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&p.BusyTimeout); err != nil {
+		return p, fmt.Errorf("failed to read busy_timeout: %w", err)
+	}
+	if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&p.ForeignKeys); err != nil {
+		return p, fmt.Errorf("failed to read foreign_keys: %w", err)
+	}
+	return p, nil
+}
+
+// LogEffectivePragmas attaches p's fields to event for a single reportable
+// log line proving what SQLite actually applied, as opposed to what the DSN
+// asked for.
+func LogEffectivePragmas(event *zerolog.Event, p EffectivePragmas) *zerolog.Event {
+	return event.
+		Str("journalMode", p.JournalMode).
+		Int64("synchronous", p.Synchronous).
+		Int64("pageSize", p.PageSize).
+		Int64("walAutoCheckpoint", p.WALAutoCheckpoint).
+		Int64("tempStore", p.TempStore).
+		Int64("cacheSize", p.CacheSize).
+		Int64("busyTimeout", p.BusyTimeout).
+		Int64("foreignKeys", p.ForeignKeys)
+}
+
+// LogEffectivePragmasForDB pins a connection from sqlDB, reads back the
+// pragmas SQLite actually applied, and logs one line labelled dbLabel. It
+// warns instead of the usual info when journal_mode is not "wal" or the
+// effective synchronous/page_size do not match what the DSN asked for — a
+// DSN pragma can silently fail to take (e.g. a filesystem that falls back to
+// a rollback journal instead of WAL), and nothing upstream reported that
+// before this. Best-effort: a failure to acquire a connection or read the
+// pragmas back is logged and does not fail the open.
+func LogEffectivePragmasForDB(
+	ctx context.Context, sqlDB *sql.DB, dbLabel string, wantSynchronous, wantPageSize int64,
+) {
+	if sqlDB == nil {
+		log.Warn().Str("db", dbLabel).Msg("no database handle available to verify effective database pragmas")
+		return
+	}
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		log.Warn().Err(err).Str("db", dbLabel).Msg("failed to acquire connection to verify effective database pragmas")
+		return
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Str("db", dbLabel).Msg("failed to release pragma verification connection")
+		}
+	}()
+
+	pragmas, err := ReadEffectivePragmas(ctx, conn)
+	if err != nil {
+		log.Warn().Err(err).Str("db", dbLabel).Msg("failed to verify effective database pragmas")
+		return
+	}
+
+	event := log.Info()
+	if pragmas.JournalMode != "wal" || pragmas.Synchronous != wantSynchronous || pragmas.PageSize != wantPageSize {
+		event = log.Warn()
+	}
+	LogEffectivePragmas(event, pragmas).Str("db", dbLabel).Msg("effective database pragmas")
+}

--- a/pkg/database/pragmas.go
+++ b/pkg/database/pragmas.go
@@ -28,6 +28,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// UnsetPageSize is the wantPageSize value meaning "this database does not
+// configure page_size, so do not treat whatever it has as a mismatch".
+const UnsetPageSize int64 = 0
+
 // SQLite's PRAGMA synchronous integer values, for comparing against
 // EffectivePragmas.Synchronous without a magic number at each call site.
 const (
@@ -132,8 +136,15 @@ func LogEffectivePragmasForDB(
 		return
 	}
 
+	// wantPageSize == 0 means "not configured, so nothing to disagree with".
+	// page_size is fixed when a database file is created and none of the DSNs
+	// here set _page_size, so an existing database legitimately carries whatever
+	// it was created with; warning about that on every open would be noise
+	// against the mismatches that do matter.
+	pageSizeUnexpected := wantPageSize != 0 && pragmas.PageSize != wantPageSize
+
 	event := log.Info()
-	if pragmas.JournalMode != "wal" || pragmas.Synchronous != wantSynchronous || pragmas.PageSize != wantPageSize {
+	if pragmas.JournalMode != "wal" || pragmas.Synchronous != wantSynchronous || pageSizeUnexpected {
 		event = log.Warn()
 	}
 	LogEffectivePragmas(event, pragmas).Str("db", dbLabel).Msg("effective database pragmas")

--- a/pkg/database/pragmas_test.go
+++ b/pkg/database/pragmas_test.go
@@ -1,0 +1,172 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package database
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+// openTestSQLite opens a real (non-memory) SQLite file with the given DSN
+// query string appended. WAL mode has no effect against ":memory:" databases
+// — SQLite silently forces "memory" journal mode there instead — so the
+// pragma read-back tests need an actual file to be meaningful.
+func openTestSQLite(t *testing.T, dsnParams string) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "pragma_test.db")
+	db, err := sql.Open("sqlite3", dbPath+dsnParams)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, db.PingContext(context.Background()))
+	return db
+}
+
+func TestReadEffectivePragmas_WAL(t *testing.T) {
+	t.Parallel()
+	db := openTestSQLite(t, "?_journal_mode=WAL&_synchronous=NORMAL&_foreign_keys=ON")
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	pragmas, err := ReadEffectivePragmas(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, "wal", pragmas.JournalMode)
+	require.Equal(t, int64(SynchronousNormal), pragmas.Synchronous)
+	require.Equal(t, int64(4096), pragmas.PageSize, "SQLite's compiled default page size")
+	require.Equal(t, int64(1000), pragmas.WALAutoCheckpoint, "SQLite's default wal_autocheckpoint is 1000 pages")
+	require.Equal(t, int64(1), pragmas.ForeignKeys)
+}
+
+func TestReadEffectivePragmas_NonWALJournalMode(t *testing.T) {
+	t.Parallel()
+	db := openTestSQLite(t, "?_journal_mode=DELETE")
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	pragmas, err := ReadEffectivePragmas(context.Background(), conn)
+	require.NoError(t, err)
+	require.Equal(t, "delete", pragmas.JournalMode)
+}
+
+func TestReadEffectivePragmas_ErrorsOnClosedConnection(t *testing.T) {
+	t.Parallel()
+	db := openTestSQLite(t, "?_journal_mode=WAL")
+
+	conn, err := db.Conn(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	_, err = ReadEffectivePragmas(context.Background(), conn)
+	require.Error(t, err)
+}
+
+// The three tests below cannot run in parallel with each other or with any
+// other test that swaps log.Logger (matching the same constraint already
+// documented in mediascanner_test.go): log.Logger is a shared package
+// global, and t.Parallel() here raced two tests' loggers, at one point
+// leaving this test's capture buffer empty because a sibling test's deferred
+// restore fired mid-call.
+func TestLogEffectivePragmasForDB_MatchesExpectation_LogsInfo(t *testing.T) {
+	db := openTestSQLite(t, "?_journal_mode=WAL&_synchronous=NORMAL")
+
+	var buf strings.Builder
+	logger := zerolog.New(&buf)
+	prevLogger := log.Logger
+	log.Logger = logger
+	defer func() { log.Logger = prevLogger }()
+
+	LogEffectivePragmasForDB(context.Background(), db, "test-db", SynchronousNormal, 4096)
+
+	output := buf.String()
+	require.Contains(t, output, `"level":"info"`)
+	require.Contains(t, output, `"journalMode":"wal"`)
+	require.Contains(t, output, `"db":"test-db"`)
+}
+
+func TestLogEffectivePragmasForDB_UnexpectedSettings_LogsWarn(t *testing.T) {
+	db := openTestSQLite(t, "?_journal_mode=WAL&_synchronous=NORMAL")
+
+	var buf strings.Builder
+	logger := zerolog.New(&buf)
+	prevLogger := log.Logger
+	log.Logger = logger
+	defer func() { log.Logger = prevLogger }()
+
+	LogEffectivePragmasForDB(context.Background(), db, "test-db", SynchronousNormal, 8192)
+
+	output := buf.String()
+	require.Contains(t, output, `"level":"warn"`)
+}
+
+func TestLogEffectivePragmasForDB_AcquireFailure_LogsWarnWithoutPanic(t *testing.T) {
+	db := openTestSQLite(t, "?_journal_mode=WAL")
+	require.NoError(t, db.Close())
+
+	var buf strings.Builder
+	logger := zerolog.New(&buf)
+	prevLogger := log.Logger
+	log.Logger = logger
+	defer func() { log.Logger = prevLogger }()
+
+	require.NotPanics(t, func() {
+		LogEffectivePragmasForDB(context.Background(), db, "test-db", SynchronousNormal, 4096)
+	})
+	require.Contains(t, buf.String(), `"level":"warn"`)
+}
+
+// TestLogEffectivePragmasForDB_NilHandle_LogsWarnWithoutPanic covers the case
+// where the database was never opened, or was swapped out from under a caller.
+// A diagnostic that dereferences a nil handle would take down whatever it was
+// only trying to describe, and this used to be papered over by a recover() in
+// the indexing caller rather than handled here.
+func TestLogEffectivePragmasForDB_NilHandle_LogsWarnWithoutPanic(t *testing.T) {
+	var buf strings.Builder
+	logger := zerolog.New(&buf)
+	prevLogger := log.Logger
+	log.Logger = logger
+	defer func() { log.Logger = prevLogger }()
+
+	require.NotPanics(t, func() {
+		LogEffectivePragmasForDB(context.Background(), nil, "test-db", SynchronousNormal, 4096)
+	})
+	require.Contains(t, buf.String(), `"level":"warn"`)
+}
+
+// TestSynchronousConstantsMatchSQLite pins the PRAGMA synchronous integer
+// values these constants stand in for, so a future SQLite change (unlikely,
+// but these are otherwise unexplained magic numbers everywhere they're used)
+// is caught here rather than silently miscomparing.
+func TestSynchronousConstantsMatchSQLite(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 0, SynchronousOff)
+	require.Equal(t, 1, SynchronousNormal)
+	require.Equal(t, 2, SynchronousFull)
+}

--- a/pkg/database/pragmas_test.go
+++ b/pkg/database/pragmas_test.go
@@ -126,6 +126,35 @@ func TestLogEffectivePragmasForDB_UnexpectedSettings_LogsWarn(t *testing.T) {
 	require.Contains(t, output, `"level":"warn"`)
 }
 
+// TestLogEffectivePragmasForDB_UnsetPageSizeDoesNotWarn covers the callers'
+// actual configuration: none of them set _page_size, so an existing database
+// carries whatever page size it was created with. That is not a misconfiguration
+// and must not raise the line to warn, or the warnings that do matter — a WAL
+// fallback, a synchronous mismatch — get lost in noise on every open.
+func TestLogEffectivePragmasForDB_UnsetPageSizeDoesNotWarn(t *testing.T) {
+	db := openTestSQLite(t, "?_journal_mode=WAL&_synchronous=NORMAL")
+
+	logPragmas := func(wantPageSize int64) string {
+		var buf strings.Builder
+		prevLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = prevLogger }()
+		LogEffectivePragmasForDB(context.Background(), db, "test-db", SynchronousNormal, wantPageSize)
+		return buf.String()
+	}
+
+	// 8192 is deliberately not this database's page size, so a non-zero
+	// expectation must warn. Establishes that the comparison is live at all,
+	// which is what makes the UnsetPageSize case below meaningful rather than
+	// vacuously passing.
+	require.Contains(t, logPragmas(8192), `"level":"warn"`)
+
+	unset := logPragmas(UnsetPageSize)
+	require.Contains(t, unset, `"level":"info"`)
+	require.NotContains(t, unset, `"level":"warn"`)
+	require.Contains(t, unset, `"pageSize":`, "the value is still reported, just not judged")
+}
+
 func TestLogEffectivePragmasForDB_AcquireFailure_LogsWarnWithoutPanic(t *testing.T) {
 	db := openTestSQLite(t, "?_journal_mode=WAL")
 	require.NoError(t, db.Close())

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -30,6 +30,7 @@ import (
 	"html"
 	"math"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -1045,6 +1046,21 @@ func (g *GamelistXMLScraper) scrapeLoop(
 		totalProcessed += companion.Processed + processed
 		totalMatched += companion.Matched + matched
 		totalSkipped += companion.Skipped + skipped
+
+		// Hand this system's working set back to the OS before starting the
+		// next one. A system's peak is proportional to its size — C64 builds
+		// roughly 150 MB of indexes, parsed entries and parent metadata on top
+		// of a ~70 MB baseline — and Go does not return that on its own, so
+		// without this RSS ratchets from system to system.
+		//
+		// On the #1279 device (492 MB, no swap) that ratchet is what turns a
+		// large system into an outage: measured mid-scrape, concurrent API
+		// traffic took RSS from 222 MB to 325 MB, MemFree to 4 MB and page
+		// cache from 139 MB to 85 MB. With nothing left to evict the box
+		// thrashes on major faults — scrape throughput fell from ~250 children
+		// per 15s to 44 in 48s, and sshd could not complete a banner exchange.
+		// Releasing per system keeps the peak to one system rather than the run.
+		debug.FreeOSMemory()
 	}
 
 	ch <- scraper.ScrapeUpdate{
@@ -2067,6 +2083,13 @@ func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
 	sentinel := scraper.SentinelTagInfo("gamelist.xml")
 	stats := companionStats{WriteStats: scrapeWriteStats{UniqueTitleDBIDs: make(map[int64]struct{})}}
 	children = resolveCompanionSlugConflicts(system.ID, parents, children, &stats)
+
+	// Past this point only parentMeta and children are read, so drop the parsed
+	// parent entries rather than holding them for the whole loop — 17,418 of
+	// them on C64. resolveCompanionSlugConflicts keeps nothing that points at
+	// the slice: it copies the names it needs into a local map.
+	parentCount := len(parents)
+	parents = nil
 	lastProgress := time.Now().Add(-scrapeProgressInterval)
 	emitProgress := func(force bool) bool {
 		if ch == nil {
@@ -2095,7 +2118,7 @@ func (g *GamelistXMLScraper) processCompanionEntriesFromParsed(
 	defer func() {
 		log.Info().
 			Str("system", system.ID).
-			Int("parents", len(parents)).
+			Int("parents", parentCount).
 			Int("children", len(children)).
 			Int("processed", stats.Processed).
 			Int("matched", stats.Matched).

--- a/pkg/database/tags/filename_parser.go
+++ b/pkg/database/tags/filename_parser.go
@@ -916,6 +916,13 @@ func parseHTGDBPatchSuffix(filename string) ([]CanonicalTag, string, bool) {
 // version extraction. This keeps patch versions attached to their patch identity instead
 // of misclassifying the first bracketed version as the base ROM revision.
 func extractPatchBrackets(filename string) (patchTags []CanonicalTag, remaining string) {
+	// reSquareBracket cannot match without an opening bracket, and
+	// ReplaceAllStringFunc builds a fresh string even when nothing matches, so
+	// bracket-free names (the common case) would otherwise pay a regex run plus
+	// a string, slice and map allocation to get their own input back.
+	if strings.IndexByte(filename, '[') < 0 {
+		return nil, filename
+	}
 	patchTags = make([]CanonicalTag, 0)
 	seen := make(map[string]struct{})
 	remaining = reSquareBracket.ReplaceAllStringFunc(filename, func(group string) string {
@@ -2318,7 +2325,13 @@ func parseFilenameTitle(
 	// Step 2: Strip release group BEFORE separator normalization
 	// Release groups are typically "-GROUP" at the end, and the hyphen will be converted to a space
 	// So we need to remove it early before that conversion happens
-	title = reReleaseGroup.ReplaceAllString(title, "")
+	// reReleaseGroup is anchored at end-of-string and needs a '-', so a title
+	// with no hyphen at all cannot match. ReplaceAllString allocates a new
+	// string even on no match, and this runs twice per file, so skip the engine
+	// for the common hyphen-free case.
+	if strings.IndexByte(title, '-') >= 0 {
+		title = reReleaseGroup.ReplaceAllString(title, "")
+	}
 
 	// Step 3: Normalize filename separators (before scene artifact stripping)
 	// Heuristic: If filename has no spaces AND has 2+ separators (dots, underscores, or dashes),

--- a/pkg/database/userdb/backup.go
+++ b/pkg/database/userdb/backup.go
@@ -779,20 +779,6 @@ func (db *UserDB) restoreFailed(cause error) (database.RestoreInfo, error) {
 	return database.RestoreInfo{}, cause
 }
 
-func preserveCorruptFile(path string) {
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		return
-	} else if err != nil {
-		log.Warn().Err(err).Str("path", path).Msg("failed to stat corrupt user database file")
-		return
-	}
-	backup := database.CorruptBackupPath(path)
-	_ = os.Remove(backup)
-	if err := os.Rename(path, backup); err != nil {
-		log.Warn().Err(err).Str("path", path).Msg("failed to preserve corrupt user database file")
-	}
-}
-
 func (db *UserDB) RecoverFromCorruption() (database.RestoreInfo, error) {
 	// Recovery renames the database and its sidecars aside, so in-flight
 	// queries have to finish first. A drain failure is only logged: the
@@ -801,7 +787,7 @@ func (db *UserDB) RecoverFromCorruption() (database.RestoreInfo, error) {
 		log.Warn().Err(err).Msg("error closing corrupt user database before recovery")
 	}
 	for _, path := range []string{db.GetDBPath(), db.GetDBPath() + "-wal", db.GetDBPath() + "-shm"} {
-		preserveCorruptFile(path)
+		database.PreserveCorruptFile(path, "user")
 	}
 
 	backups, err := db.ListBackups()

--- a/pkg/database/userdb/userdb.go
+++ b/pkg/database/userdb/userdb.go
@@ -42,6 +42,8 @@ var ErrNullSQL = errors.New("UserDB is not connected")
 const sqliteConnParams = "?_journal_mode=WAL&_synchronous=FULL&_busy_timeout=5000" +
 	"&_cache_size=-512&_mmap_size=0"
 
+const userPageSize = 4096 // SQLite's compiled default; not set in sqliteConnParams
+
 const (
 	// connDrainTimeout bounds the wait for in-flight queries before an
 	// operation that replaces the database files gives up.
@@ -138,6 +140,7 @@ func (db *UserDB) openSQLConnection(dbPath string) (*sql.DB, error) {
 			log.Warn().Err(err).Msg("failed to enable user database cell size checks; continuing without")
 		}
 	}
+	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "user", database.SynchronousFull, userPageSize)
 	return sqlInstance, nil
 }
 

--- a/pkg/database/userdb/userdb.go
+++ b/pkg/database/userdb/userdb.go
@@ -42,8 +42,6 @@ var ErrNullSQL = errors.New("UserDB is not connected")
 const sqliteConnParams = "?_journal_mode=WAL&_synchronous=FULL&_busy_timeout=5000" +
 	"&_cache_size=-512&_mmap_size=0"
 
-const userPageSize = 4096 // SQLite's compiled default; not set in sqliteConnParams
-
 const (
 	// connDrainTimeout bounds the wait for in-flight queries before an
 	// operation that replaces the database files gives up.
@@ -140,7 +138,7 @@ func (db *UserDB) openSQLConnection(dbPath string) (*sql.DB, error) {
 			log.Warn().Err(err).Msg("failed to enable user database cell size checks; continuing without")
 		}
 	}
-	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "user", database.SynchronousFull, userPageSize)
+	database.LogEffectivePragmasForDB(db.ctx, sqlInstance, "user", database.SynchronousFull, database.UnsetPageSize)
 	return sqlInstance, nil
 }
 

--- a/pkg/helpers/mountinfo.go
+++ b/pkg/helpers/mountinfo.go
@@ -91,7 +91,9 @@ func unescapeMountField(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
-		if s[i] == '\\' && i+3 < len(s) {
+		// i+4 <= len(s) is the bound for the s[i+1:i+4] slice below: a backslash
+		// plus exactly three octal digits.
+		if s[i] == '\\' && i+4 <= len(s) {
 			if code, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
 				_ = b.WriteByte(byte(code))
 				i += 3

--- a/pkg/helpers/mountinfo.go
+++ b/pkg/helpers/mountinfo.go
@@ -1,0 +1,104 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Parsing /proc/self/mountinfo is deliberately in a portable file even though
+// the file only exists on Linux: it is pure string handling, so keeping it here
+// means the format tests run on every platform rather than only where the
+// procfs read is possible.
+
+// MountEntry is one line of /proc/self/mountinfo, reduced to the fields
+// callers need. Entries appear in mount order, so of two entries with the same
+// Mountpoint the later one shadows the earlier.
+type MountEntry struct {
+	Root       string // path inside the source filesystem, e.g. /zaparoo/profiles/x/saves
+	Mountpoint string // where it is mounted, e.g. /media/fat
+	FSType     string // e.g. exfat, vfat, cifs
+	Source     string // device or share, e.g. /dev/mmcblk0p1, //nas/share
+	Options    string // per-mount options, e.g. rw,noatime
+}
+
+// StorageInfo is the longest-matching mount for a path, for logging what
+// storage a file actually sits on.
+type StorageInfo struct {
+	FSType     string
+	Mountpoint string
+	Source     string
+	Options    string
+}
+
+// ParseMountInfo parses /proc/self/mountinfo content. Format per line:
+//
+//	36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw
+//	(1) (2) (3) (root) (mountpoint) (opts) (optional...) - (fstype) (source) (superopts)
+//
+// The number of optional fields between the options and the "-" separator
+// varies, which is why the separator is searched for rather than indexed.
+// Malformed lines are skipped.
+func ParseMountInfo(data string) []MountEntry {
+	var entries []MountEntry
+	for line := range strings.Lines(data) {
+		fields := strings.Fields(line)
+		sep := -1
+		for i, f := range fields {
+			if f == "-" && i >= 6 {
+				sep = i
+				break
+			}
+		}
+		if sep < 0 || sep+2 >= len(fields) || len(fields) < 5 {
+			continue
+		}
+		entries = append(entries, MountEntry{
+			Root:       unescapeMountField(fields[3]),
+			Mountpoint: unescapeMountField(fields[4]),
+			Options:    fields[5],
+			FSType:     fields[sep+1],
+			Source:     unescapeMountField(fields[sep+2]),
+		})
+	}
+	return entries
+}
+
+// unescapeMountField decodes the octal escapes the kernel uses for
+// whitespace in mountinfo fields (e.g. \040 for space).
+func unescapeMountField(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+3 < len(s) {
+			if code, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
+				_ = b.WriteByte(byte(code))
+				i += 3
+				continue
+			}
+		}
+		_ = b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/pkg/helpers/mountinfo_linux.go
+++ b/pkg/helpers/mountinfo_linux.go
@@ -47,9 +47,20 @@ func ReadMountInfo() ([]MountEntry, error) {
 	return ParseMountInfo(string(data)), nil
 }
 
-// StorageInfoForPath returns the mount entry that owns path: the entry whose
-// Mountpoint is the longest prefix of path's absolute form. Returns false if
-// mountinfo could not be read or nothing matches.
+// mountpointOwns reports whether absPath lies under mountpoint, comparing whole
+// path components. A plain prefix test would put /media/fatty under /media/fat
+// and pick the wrong storage for it. Separators are literal "/" because that is
+// what the kernel writes in mountinfo, regardless of host path conventions.
+func mountpointOwns(mountpoint, absPath string) bool {
+	if mountpoint == "/" {
+		return true
+	}
+	return absPath == mountpoint || strings.HasPrefix(absPath, mountpoint+"/")
+}
+
+// StorageInfoForPath returns the mount entry that owns path: the entry with the
+// longest mountpoint that contains it. Returns false if mountinfo could not be
+// read or nothing matches.
 func StorageInfoForPath(path string) (StorageInfo, bool) {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
@@ -63,7 +74,7 @@ func StorageInfoForPath(path string) (StorageInfo, bool) {
 	var best MountEntry
 	found := false
 	for _, e := range entries {
-		if e.Mountpoint != "/" && !strings.HasPrefix(absPath, e.Mountpoint) {
+		if !mountpointOwns(e.Mountpoint, absPath) {
 			continue
 		}
 		if !found || len(e.Mountpoint) >= len(best.Mountpoint) {

--- a/pkg/helpers/mountinfo_linux.go
+++ b/pkg/helpers/mountinfo_linux.go
@@ -1,0 +1,83 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// A var rather than a const so tests can point it at a fixture instead of
+// faking procfs.
+var mountInfoPath = filepath.Join(string(filepath.Separator), "proc", "self", "mountinfo")
+
+// MountInfoPath is the procfs mount table this package reads, for callers that
+// need to open or watch the file themselves rather than take a parsed snapshot.
+func MountInfoPath() string {
+	return mountInfoPath
+}
+
+// ReadMountInfo returns the current mount table.
+func ReadMountInfo() ([]MountEntry, error) {
+	data, err := os.ReadFile(mountInfoPath) //nolint:gosec // fixed procfs path assembled from constants
+	if err != nil {
+		return nil, fmt.Errorf("failed to read mountinfo: %w", err)
+	}
+	return ParseMountInfo(string(data)), nil
+}
+
+// StorageInfoForPath returns the mount entry that owns path: the entry whose
+// Mountpoint is the longest prefix of path's absolute form. Returns false if
+// mountinfo could not be read or nothing matches.
+func StorageInfoForPath(path string) (StorageInfo, bool) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return StorageInfo{}, false
+	}
+	entries, err := ReadMountInfo()
+	if err != nil {
+		return StorageInfo{}, false
+	}
+
+	var best MountEntry
+	found := false
+	for _, e := range entries {
+		if e.Mountpoint != "/" && !strings.HasPrefix(absPath, e.Mountpoint) {
+			continue
+		}
+		if !found || len(e.Mountpoint) >= len(best.Mountpoint) {
+			best = e
+			found = true
+		}
+	}
+	if !found {
+		return StorageInfo{}, false
+	}
+	return StorageInfo{
+		FSType:     best.FSType,
+		Mountpoint: best.Mountpoint,
+		Source:     best.Source,
+		Options:    best.Options,
+	}, true
+}

--- a/pkg/helpers/mountinfo_other.go
+++ b/pkg/helpers/mountinfo_other.go
@@ -1,0 +1,45 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package helpers
+
+import "errors"
+
+// errNoMountInfo is returned wherever the mount table is requested on a
+// platform that has no /proc/self/mountinfo to read it from.
+var errNoMountInfo = errors.New("mount table unavailable: no /proc/self/mountinfo on this platform")
+
+// MountInfoPath returns "" off Linux: there is no procfs mount table to open.
+func MountInfoPath() string {
+	return ""
+}
+
+// ReadMountInfo always fails off Linux. Callers treat an unreadable mount table
+// as "unknown storage" already, so this needs no separate handling from them.
+func ReadMountInfo() ([]MountEntry, error) {
+	return nil, errNoMountInfo
+}
+
+// StorageInfoForPath always returns false on non-Linux platforms: there is
+// no portable equivalent of /proc/self/mountinfo to read it from.
+func StorageInfoForPath(string) (StorageInfo, bool) {
+	return StorageInfo{}, false
+}

--- a/pkg/helpers/mountinfo_parse_test.go
+++ b/pkg/helpers/mountinfo_parse_test.go
@@ -1,0 +1,78 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Parsing is pure string handling, so these run on every platform even though
+// /proc/self/mountinfo only exists on Linux.
+
+func TestParseMountInfo(t *testing.T) {
+	t.Parallel()
+	data := `21 26 179:1 / /media/fat rw,noatime - exfat /dev/mmcblk0p1 rw,iocharset=utf8
+36 21 0:41 /saves /media/fat/saves rw,relatime shared:1 - cifs //10.0.0.3/MiSTer rw,username=x
+40 21 179:1 /System\040Volume\040Information /media/fat/svi rw - exfat /dev/mmcblk0p1 rw
+garbage line
+`
+	entries := ParseMountInfo(data)
+	require.Len(t, entries, 3)
+	assert.Equal(t, MountEntry{
+		Root: "/", Mountpoint: "/media/fat", Options: "rw,noatime", FSType: "exfat", Source: "/dev/mmcblk0p1",
+	}, entries[0])
+	assert.Equal(t, MountEntry{
+		Root: "/saves", Mountpoint: "/media/fat/saves", Options: "rw,relatime", FSType: "cifs",
+		Source: "//10.0.0.3/MiSTer",
+	}, entries[1])
+	assert.Equal(t, "/System Volume Information", entries[2].Root, "octal escapes decoded")
+}
+
+// The optional-field count between the options and the "-" separator varies
+// per line, which is why the parser searches for the separator rather than
+// indexing a fixed position. A line with several optional fields and one with
+// none must both parse to the same shape.
+func TestParseMountInfo_VariableOptionalFields(t *testing.T) {
+	t.Parallel()
+	data := "1 0 0:1 / /a rw shared:1 master:2 propagate_from:3 - ext4 /dev/root rw\n" +
+		"2 0 0:2 / /b rw - ext4 /dev/other rw\n"
+	entries := ParseMountInfo(data)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "ext4", entries[0].FSType)
+	assert.Equal(t, "/dev/root", entries[0].Source)
+	assert.Equal(t, "ext4", entries[1].FSType)
+	assert.Equal(t, "/dev/other", entries[1].Source)
+}
+
+func TestParseMountInfo_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, ParseMountInfo(""))
+	assert.Empty(t, ParseMountInfo("not a mountinfo line at all\n"))
+}
+
+func TestUnescapeMountField(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "plain", unescapeMountField("plain"))
+	assert.Equal(t, "System Volume Information", unescapeMountField(`System\040Volume\040Information`))
+	assert.Equal(t, `back\slash`, unescapeMountField(`back\slash`), "non-octal backslash sequence is left as-is")
+}

--- a/pkg/helpers/mountinfo_test.go
+++ b/pkg/helpers/mountinfo_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The three tests below cannot run in parallel with each other: the latter
+// two swap the package-level mountInfoPath var to point at a fake table,
+// which would race a concurrent StorageInfoForPath call in this first test
+// reading the real /proc/self/mountinfo path.
+func TestStorageInfoForPath(t *testing.T) {
+	// A real system's /proc/self/mountinfo always has at least a root entry,
+	// so any absolute path resolves to *some* mount — this exercises the
+	// longest-prefix-match logic against the live mount table without faking
+	// procfs, and cross-checks it against a stat-based sanity bound (the
+	// resolved mountpoint must actually be an ancestor directory of path).
+	dir := t.TempDir()
+	info, ok := StorageInfoForPath(dir)
+	require.True(t, ok, "expected some mount to own %s", dir)
+	assert.NotEmpty(t, info.FSType)
+
+	absDir, err := filepath.Abs(dir)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(absDir, info.Mountpoint),
+		"mountpoint %q should be a prefix of %q", info.Mountpoint, absDir)
+}
+
+func TestStorageInfoForPath_LongestMountWins(t *testing.T) {
+	orig := mountInfoPath
+	tmp := filepath.Join(t.TempDir(), "mountinfo")
+	data := "1 0 0:1 / / rw - ext4 /dev/root rw\n" +
+		"2 1 0:2 / /media rw - exfat /dev/sda1 rw\n" +
+		"3 2 0:3 / /media/fat rw - vfat /dev/sdb1 rw\n"
+	require.NoError(t, os.WriteFile(tmp, []byte(data), 0o600))
+	mountInfoPath = tmp
+	defer func() { mountInfoPath = orig }()
+
+	info, ok := StorageInfoForPath("/media/fat/zaparoo/media.db")
+	require.True(t, ok)
+	assert.Equal(t, "vfat", info.FSType)
+	assert.Equal(t, "/media/fat", info.Mountpoint)
+	assert.Equal(t, "/dev/sdb1", info.Source)
+
+	info, ok = StorageInfoForPath("/media/other")
+	require.True(t, ok)
+	assert.Equal(t, "exfat", info.FSType)
+	assert.Equal(t, "/media", info.Mountpoint)
+}
+
+func TestStorageInfoForPath_UnreadableMountInfo(t *testing.T) {
+	orig := mountInfoPath
+	mountInfoPath = filepath.Join(t.TempDir(), "does-not-exist")
+	defer func() { mountInfoPath = orig }()
+
+	_, ok := StorageInfoForPath("/anywhere")
+	assert.False(t, ok)
+}

--- a/pkg/helpers/mountinfo_test.go
+++ b/pkg/helpers/mountinfo_test.go
@@ -24,54 +24,84 @@ package helpers
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// The three tests below cannot run in parallel with each other: the latter
-// two swap the package-level mountInfoPath var to point at a fake table,
-// which would race a concurrent StorageInfoForPath call in this first test
-// reading the real /proc/self/mountinfo path.
-func TestStorageInfoForPath(t *testing.T) {
-	// A real system's /proc/self/mountinfo always has at least a root entry,
-	// so any absolute path resolves to *some* mount — this exercises the
-	// longest-prefix-match logic against the live mount table without faking
-	// procfs, and cross-checks it against a stat-based sanity bound (the
-	// resolved mountpoint must actually be an ancestor directory of path).
-	dir := t.TempDir()
-	info, ok := StorageInfoForPath(dir)
-	require.True(t, ok, "expected some mount to own %s", dir)
-	assert.NotEmpty(t, info.FSType)
+// These tests cannot run in parallel with each other: they swap the
+// package-level mountInfoPath var to point at a fixture.
 
-	absDir, err := filepath.Abs(dir)
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(absDir, info.Mountpoint),
-		"mountpoint %q should be a prefix of %q", info.Mountpoint, absDir)
+// useMountInfoFixture points mountInfoPath at a fake mount table for the
+// duration of the test. The real /proc/self/mountinfo is deliberately not read:
+// results would depend on how the host running the tests happens to be
+// partitioned, and procfs is a platform boundary.
+func useMountInfoFixture(t *testing.T, data string) {
+	t.Helper()
+	tmp := filepath.Join(t.TempDir(), "mountinfo")
+	require.NoError(t, os.WriteFile(tmp, []byte(data), 0o600))
+	orig := mountInfoPath
+	mountInfoPath = tmp
+	t.Cleanup(func() { mountInfoPath = orig })
 }
 
-func TestStorageInfoForPath_LongestMountWins(t *testing.T) {
-	orig := mountInfoPath
-	tmp := filepath.Join(t.TempDir(), "mountinfo")
-	data := "1 0 0:1 / / rw - ext4 /dev/root rw\n" +
-		"2 1 0:2 / /media rw - exfat /dev/sda1 rw\n" +
-		"3 2 0:3 / /media/fat rw - vfat /dev/sdb1 rw\n"
-	require.NoError(t, os.WriteFile(tmp, []byte(data), 0o600))
-	mountInfoPath = tmp
-	defer func() { mountInfoPath = orig }()
+const mountInfoFixture = "1 0 0:1 / / rw - ext4 /dev/root rw\n" +
+	"2 1 0:2 / /media rw - exfat /dev/sda1 rw\n" +
+	"3 2 0:3 / /media/fat rw - vfat /dev/sdb1 rw\n" +
+	"4 2 0:4 / /media/fatty rw - btrfs /dev/sdc1 rw\n"
+
+func TestStorageInfoForPath(t *testing.T) {
+	useMountInfoFixture(t, mountInfoFixture)
 
 	info, ok := StorageInfoForPath("/media/fat/zaparoo/media.db")
 	require.True(t, ok)
 	assert.Equal(t, "vfat", info.FSType)
 	assert.Equal(t, "/media/fat", info.Mountpoint)
 	assert.Equal(t, "/dev/sdb1", info.Source)
+	assert.Equal(t, "rw", info.Options)
+}
+
+func TestStorageInfoForPath_LongestMountWins(t *testing.T) {
+	useMountInfoFixture(t, mountInfoFixture)
+
+	info, ok := StorageInfoForPath("/media/fat/zaparoo/media.db")
+	require.True(t, ok)
+	assert.Equal(t, "/media/fat", info.Mountpoint)
 
 	info, ok = StorageInfoForPath("/media/other")
 	require.True(t, ok)
 	assert.Equal(t, "exfat", info.FSType)
 	assert.Equal(t, "/media", info.Mountpoint)
+
+	info, ok = StorageInfoForPath("/somewhere/else")
+	require.True(t, ok, "the root mount owns everything not under a longer one")
+	assert.Equal(t, "/", info.Mountpoint)
+}
+
+// TestStorageInfoForPath_MatchesWholePathComponents guards the case a plain
+// strings.HasPrefix gets wrong.
+//
+// The fixture here deliberately does NOT mount /media/fatty: with it mounted,
+// the longest-match tiebreak picks it anyway and a broken prefix test still
+// passes. The bug only shows when the similarly-named directory is not itself a
+// mountpoint, so /media/fatty/... must fall through to /media rather than being
+// captured by /media/fat.
+func TestStorageInfoForPath_MatchesWholePathComponents(t *testing.T) {
+	useMountInfoFixture(t, "1 0 0:1 / / rw - ext4 /dev/root rw\n"+
+		"2 1 0:2 / /media rw - exfat /dev/sda1 rw\n"+
+		"3 2 0:3 / /media/fat rw - vfat /dev/sdb1 rw\n")
+
+	info, ok := StorageInfoForPath("/media/fatty/zaparoo/media.db")
+	require.True(t, ok)
+	assert.Equal(t, "/media", info.Mountpoint, "/media/fatty must not be captured by the /media/fat mount")
+	assert.Equal(t, "exfat", info.FSType)
+
+	// The mountpoint itself, with no trailing component, still resolves to it.
+	info, ok = StorageInfoForPath("/media/fat")
+	require.True(t, ok)
+	assert.Equal(t, "vfat", info.FSType)
+	assert.Equal(t, "/media/fat", info.Mountpoint)
 }
 
 func TestStorageInfoForPath_UnreadableMountInfo(t *testing.T) {

--- a/pkg/platforms/mister/mounts.go
+++ b/pkg/platforms/mister/mounts.go
@@ -25,22 +25,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"golang.org/x/sys/unix"
 )
 
-var mountInfoPath = filepath.Join(string(filepath.Separator), "proc", "self", "mountinfo")
-
 // mountEntry is one line of /proc/self/mountinfo, reduced to the fields
 // mount ownership decisions need. Entries appear in mount order, so of two
 // entries with the same Mountpoint the later one shadows the earlier.
+//
+// Kept as a local type rather than using helpers.MountEntry directly because
+// it is the currency of the mounter interface below and of the ledger, and
+// none of that wants the per-mount options field.
 type mountEntry struct {
 	Root       string // path inside the source filesystem, e.g. /zaparoo/profiles/x/saves
 	Mountpoint string // where it is mounted, e.g. /media/fat/saves
@@ -61,11 +61,11 @@ type mounter interface {
 type sysMounter struct{}
 
 func (sysMounter) Mounts() ([]mountEntry, error) {
-	data, err := os.ReadFile(mountInfoPath) //nolint:gosec // fixed procfs path assembled from constants
+	entries, err := helpers.ReadMountInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read mountinfo: %w", err)
 	}
-	return parseMountInfo(string(data)), nil
+	return toMountEntries(entries), nil
 }
 
 func (m sysMounter) BindMount(source, target string) (mountEntry, error) {
@@ -116,55 +116,19 @@ func (sysMounter) Unmount(target string) error {
 	return nil
 }
 
-// parseMountInfo parses /proc/self/mountinfo content. Format per line:
-//
-//	36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw
-//	(1) (2) (3) (root) (mountpoint) (opts) (optional...) - (fstype) (source) (superopts)
-//
-// Malformed lines are skipped.
-func parseMountInfo(data string) []mountEntry {
-	var entries []mountEntry
-	for line := range strings.Lines(data) {
-		fields := strings.Fields(line)
-		sep := -1
-		for i, f := range fields {
-			if f == "-" && i >= 6 {
-				sep = i
-				break
-			}
-		}
-		if sep < 0 || sep+2 >= len(fields) || len(fields) < 5 {
-			continue
-		}
-		entries = append(entries, mountEntry{
-			Root:       unescapeMountField(fields[3]),
-			Mountpoint: unescapeMountField(fields[4]),
-			FSType:     fields[sep+1],
-			Source:     unescapeMountField(fields[sep+2]),
+// toMountEntries drops the per-mount options field helpers.ParseMountInfo
+// carries but the mount ownership logic here has no use for.
+func toMountEntries(entries []helpers.MountEntry) []mountEntry {
+	out := make([]mountEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, mountEntry{
+			Root:       e.Root,
+			Mountpoint: e.Mountpoint,
+			FSType:     e.FSType,
+			Source:     e.Source,
 		})
 	}
-	return entries
-}
-
-// unescapeMountField decodes the octal escapes the kernel uses for
-// whitespace in mountinfo fields (e.g. \040 for space).
-func unescapeMountField(s string) string {
-	if !strings.Contains(s, `\`) {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\\' && i+3 < len(s) {
-			if code, err := strconv.ParseUint(s[i+1:i+4], 8, 8); err == nil {
-				_ = b.WriteByte(byte(code))
-				i += 3
-				continue
-			}
-		}
-		_ = b.WriteByte(s[i])
-	}
-	return b.String()
+	return out
 }
 
 // mountsAt returns the mounts stacked on target in mount order: the last

--- a/pkg/platforms/mister/profiledata.go
+++ b/pkg/platforms/mister/profiledata.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
@@ -468,7 +469,7 @@ func (d *profileDataManager) writeNameFile(profileDir string, ref platforms.Prof
 // root drive appearing late, or a manual unmount.
 func (*Platform) WatchProfileData(ctx context.Context, onChange func()) {
 	go func() {
-		file, err := os.Open(mountInfoPath)
+		file, err := os.Open(helpers.MountInfoPath())
 		if err != nil {
 			log.Error().Err(err).Msg("profiles: mount watcher unavailable")
 			return
@@ -516,7 +517,7 @@ func (*Platform) WatchProfileData(ctx context.Context, onChange func()) {
 // mountInfoSum fingerprints the current mount table so poll wakeups that
 // end up changing nothing (mount + matching unmount) don't trigger work.
 func mountInfoSum() [32]byte {
-	data, err := os.ReadFile(mountInfoPath)
+	data, err := os.ReadFile(helpers.MountInfoPath())
 	if err != nil {
 		return [32]byte{}
 	}

--- a/pkg/platforms/mister/profiledata_test.go
+++ b/pkg/platforms/mister/profiledata_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/spf13/afero"
@@ -244,14 +245,17 @@ func TestApply_RejectsUnknownItem(t *testing.T) {
 	assert.Empty(t, d.ledger.entries)
 }
 
-func TestParseMountInfo(t *testing.T) {
+// TestToMountEntries pins the projection from the shared helpers parser onto
+// the local mountEntry type. The mountinfo format itself is covered in
+// pkg/helpers; what matters here is that the four fields mount ownership
+// decisions depend on survive the conversion intact.
+func TestToMountEntries(t *testing.T) {
 	t.Parallel()
 	data := `21 26 179:1 / /media/fat rw,noatime - exfat /dev/mmcblk0p1 rw,iocharset=utf8
 36 21 0:41 /saves /media/fat/saves rw,relatime shared:1 - cifs //10.0.0.3/MiSTer rw,username=x
 40 21 179:1 /System\040Volume\040Information /media/fat/svi rw - exfat /dev/mmcblk0p1 rw
-garbage line
 `
-	entries := parseMountInfo(data)
+	entries := toMountEntries(helpers.ParseMountInfo(data))
 	require.Len(t, entries, 3)
 	assert.Equal(t, mountEntry{
 		Root: "/", Mountpoint: "/media/fat", FSType: "exfat", Source: "/dev/mmcblk0p1",

--- a/pkg/service/daemon/daemon_test.go
+++ b/pkg/service/daemon/daemon_test.go
@@ -1234,13 +1234,48 @@ func TestWaitForServicePidFile_FailsWhenProcessExits(t *testing.T) {
 	assert.Contains(t, err.Error(), "exited before writing pidfile")
 }
 
-func TestStart_FailsWhenServiceWritesPidfileThenExits(t *testing.T) {
+// TestWaitForServicePidFile_FailsWhenProcessExitsAfterWritingPidfile covers the
+// branch where the pidfile holds the expected PID but that process is already
+// gone — a service that got far enough to announce itself and then died.
+//
+// It is driven at this level rather than through Start because Start races the
+// process's death: it polls, and a poll that lands while the doomed process is
+// still alive sees a live matching PID and reports the service ready. Reaping
+// the process first and writing the pidfile afterwards makes the state the
+// branch describes, without depending on scheduling.
+func TestWaitForServicePidFile_FailsWhenProcessExitsAfterWritingPidfile(t *testing.T) {
 	requireLinuxProc(t, "service PID identity checks")
 
 	svc := newTestService(t)
-	pidFile := filepath.Join(svc.pl.Settings().TempDir, config.PidFile)
-	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s' \"$$\" > %q\nexit 0\n", pidFile)
-	t.Setenv(config.AppEnv, writeFakeServiceScriptWithBody(t, script))
+	pidPath := filepath.Join(svc.pl.Settings().TempDir, config.PidFile)
+
+	process := exec.CommandContext(context.Background(), "sh", "-c", "exit 0")
+	require.NoError(t, process.Start())
+	pid := process.Process.Pid
+	// Reap so the PID is fully released; see the sibling test for why a zombie
+	// would still look alive.
+	require.NoError(t, process.Wait())
+
+	require.NoError(t, os.WriteFile(pidPath, []byte(strconv.Itoa(pid)), 0o600))
+
+	err := svc.waitForServicePidFile(pid, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exited after writing pidfile")
+}
+
+// TestStart_FailsWhenServiceExitsDuringStartup is the end-to-end counterpart:
+// a service process that dies during startup must surface as a Start error
+// rather than a successful launch.
+//
+// The fake service exits without writing a pidfile, which is the one startup
+// death Start can detect deterministically. Whether the poll observes the exit
+// immediately or the wait runs to its deadline, neither outcome is ready, so
+// there is no scheduling window in which this passes for the wrong reason.
+func TestStart_FailsWhenServiceExitsDuringStartup(t *testing.T) {
+	requireLinuxProc(t, "service PID identity checks")
+
+	svc := newTestService(t)
+	t.Setenv(config.AppEnv, writeFakeServiceScriptWithBody(t, "#!/bin/sh\nexit 0\n"))
 
 	err := svc.Start()
 	require.Error(t, err)

--- a/pkg/service/reader_manager_test.go
+++ b/pkg/service/reader_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -208,6 +209,43 @@ func (env *readerManagerEnv) expectNotification(t *testing.T, method string) {
 			t.Fatalf("timed out waiting for %s notification", method)
 		}
 	}
+}
+
+// waitForUI polls the UI service until its state matches, or fails with desc.
+//
+// expectNoToken is not a synchronisation point: it proves only that nothing was
+// launched within noTokenWait, not that the reader manager has staged the scan
+// and published its UI event. Reading env.ui.State() straight after it raced the
+// manager, and `go test -race ./pkg/...` caught it — the launch-guard tests
+// failed on an empty event list while passing on their own. Polling costs a
+// passing test nothing: it returns as soon as the state matches.
+func (env *readerManagerEnv) waitForUI(
+	t *testing.T,
+	desc string,
+	matches func(models.UIStateResponse) bool,
+) models.UIStateResponse {
+	t.Helper()
+	deadline := time.Now().Add(tokenTimeout)
+	var snapshot models.UIStateResponse
+	for {
+		snapshot = env.ui.State()
+		if matches(snapshot) {
+			return snapshot
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s; last UI state: %+v", desc, snapshot)
+			return snapshot
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// waitForUIEvents waits for the UI to be holding exactly want events.
+func (env *readerManagerEnv) waitForUIEvents(t *testing.T, want int) models.UIStateResponse {
+	t.Helper()
+	return env.waitForUI(t, fmt.Sprintf("%d UI event(s)", want), func(snapshot models.UIStateResponse) bool {
+		return len(snapshot.Events) == want
+	})
 }
 
 func (env *readerManagerEnv) expectUIState(
@@ -1215,8 +1253,7 @@ func TestReaderManager_LaunchGuard_OpensGlobalConfirmEvent(t *testing.T) {
 	})
 	env.expectNoToken(t)
 
-	uiState := env.ui.State()
-	require.Len(t, uiState.Events, 1)
+	uiState := env.waitForUIEvents(t, 1)
 	event := uiState.Events[0]
 	assert.Equal(t, models.UIEventKindConfirm, event.Kind)
 	assert.Equal(t, "Change game?", event.Title)
@@ -1236,8 +1273,7 @@ func TestReaderManager_LaunchGuard_UsesUIDWhenTokenTextIsEmpty(t *testing.T) {
 	})
 	env.expectNoToken(t)
 
-	uiState := env.ui.State()
-	require.Len(t, uiState.Events, 1)
+	uiState := env.waitForUIEvents(t, 1)
 	assert.Equal(t, "card-without-text", uiState.Events[0].Message)
 }
 
@@ -1258,7 +1294,7 @@ func TestReaderManager_LaunchGuard_DoesNotRenderConfirmOnHost(t *testing.T) {
 	})
 	env.expectNoToken(t)
 
-	require.Len(t, env.ui.State().Events, 1)
+	env.waitForUIEvents(t, 1)
 	assert.Equal(t, int32(0), renderer.presented.Load())
 }
 
@@ -1274,7 +1310,7 @@ func TestReaderManager_LaunchGuard_UIConfirmAndDismiss(t *testing.T) {
 		})
 		env.expectNoToken(t)
 
-		event := env.ui.State().Events[0]
+		event := env.waitForUIEvents(t, 1).Events[0]
 		require.NoError(t, env.ui.Respond(event.ID, models.UIResponseActionConfirm, ""))
 		assert.Equal(t, "card-a", env.expectToken(t).UID)
 	})
@@ -1288,7 +1324,7 @@ func TestReaderManager_LaunchGuard_UIConfirmAndDismiss(t *testing.T) {
 		})
 		env.expectNoToken(t)
 
-		event := env.ui.State().Events[0]
+		event := env.waitForUIEvents(t, 1).Events[0]
 		require.NoError(t, env.ui.Respond(event.ID, models.UIResponseActionDismiss, ""))
 		result := make(chan error, 1)
 		env.confirmQueue <- result
@@ -1306,7 +1342,7 @@ func TestReaderManager_LaunchGuard_MediaStopCancelsGlobalEvent(t *testing.T) {
 		Token:  &tokens.Token{UID: "card-a", Text: "**launch.system:snes", ScanTime: time.Now()},
 	})
 	env.expectNoToken(t)
-	require.Len(t, env.ui.State().Events, 1)
+	env.waitForUIEvents(t, 1)
 
 	env.st.SetActiveMedia(nil)
 	uiState := env.expectUIState(t, func(snapshot models.UIStateResponse) bool {
@@ -1330,16 +1366,15 @@ func TestReaderManager_LaunchGuard_DelayResetUpdatesSameEvent(t *testing.T) {
 
 	env.sendScan(readers.Scan{Source: "test-reader", Token: card})
 	env.sendScan(readers.Scan{Source: "test-reader", Token: nil})
-	original := env.ui.State()
-	require.Len(t, original.Events, 1)
+	original := env.waitForUIEvents(t, 1)
 
 	fakeClock.Advance(time.Second)
 	env.sendScan(readers.Scan{Source: "test-reader", Token: card})
 	env.expectNoToken(t)
-	updated := env.ui.State()
-	require.Len(t, updated.Events, 1)
+	updated := env.waitForUI(t, "the staged event to be revised", func(snapshot models.UIStateResponse) bool {
+		return len(snapshot.Events) == 1 && snapshot.Revision > original.Revision
+	})
 	assert.Equal(t, original.Events[0].ID, updated.Events[0].ID)
-	assert.Greater(t, updated.Revision, original.Revision)
 	require.NotNil(t, updated.Events[0].ExpiresAt)
 	assert.WithinDuration(
 		t, fakeClock.Now().Add(15*time.Second), *updated.Events[0].ExpiresAt, time.Microsecond,

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -1032,6 +1032,12 @@ func (m *MockMediaDBI) Open() error {
 }
 
 func (m *MockMediaDBI) UnsafeGetSQLDb() *sql.DB {
+	// Unstubbed returns nil rather than panicking: callers are diagnostics that
+	// already handle a database with no open handle, and a test that does not
+	// care about them should not have to stub this.
+	if !m.hasExpectation("UnsafeGetSQLDb") {
+		return nil
+	}
 	args := m.Called()
 	if db, ok := args.Get(0).(*sql.DB); ok {
 		return db
@@ -1095,6 +1101,11 @@ func (m *MockMediaDBI) GetMediaByText(query string) (database.Media, error) {
 }
 
 func (m *MockMediaDBI) GetDBPath() string {
+	// Unstubbed returns "" rather than panicking, for the same reason as
+	// UnsafeGetSQLDb above.
+	if !m.hasExpectation("GetDBPath") {
+		return ""
+	}
 	args := m.Called()
 	return args.String(0)
 }

--- a/pkg/testing/helpers/inmemory_db.go
+++ b/pkg/testing/helpers/inmemory_db.go
@@ -75,9 +75,15 @@ func NewInMemoryMediaDB(tb testing.TB) (db *mediadb.MediaDB, cleanup func()) {
 	tempDir := tb.TempDir()
 	dbPath := filepath.Join(tempDir, "mediadb_test.db")
 
-	// Open SQLite database using temp file with foreign keys enabled
-	// This matches the production database configuration and ensures CASCADE deletes work
-	sqlDB, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=ON")
+	// Open SQLite database using temp file with foreign keys enabled and WAL
+	// journal mode. WAL matches the production database configuration and
+	// ensures CASCADE deletes work; it is also load-bearing for indexing
+	// tests specifically — the batched-transaction architecture reads the
+	// next system's state on a separate pool connection while the previous
+	// system's writer transaction is still open, which only works under WAL
+	// (a rollback journal's exclusive lock would deadlock that read), and
+	// NewNamesIndex now verifies journal_mode is "wal" before indexing.
+	sqlDB, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=ON&_journal_mode=WAL")
 	if err != nil {
 		tb.Fatalf("Failed to open test database: %v", err)
 	}

--- a/pkg/testing/mocks/platform.go
+++ b/pkg/testing/mocks/platform.go
@@ -67,10 +67,17 @@ func (m *MockPlatform) SetPowerStatus(status power.Status) {
 	m.powerStatus = &status
 }
 
-// ID returns the unique ID of this platform
+// ID returns the unique ID of this platform. Unstubbed it returns "" rather
+// than panicking: it is read by diagnostics that run on paths a test may not be
+// exercising deliberately, and an incomplete mock should not fail those.
 func (m *MockPlatform) ID() string {
-	args := m.Called()
-	return args.String(0)
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "ID" {
+			args := m.Called()
+			return args.String(0)
+		}
+	}
+	return ""
 }
 
 // StartPre runs any necessary platform setup BEFORE the main service has started running

--- a/pkg/ui/tui/clients_test.go
+++ b/pkg/ui/tui/clients_test.go
@@ -61,7 +61,7 @@ func TestBuildClientsPage_FirstClientAdmin_Integration(t *testing.T) {
 		BuildClientsPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Clients", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Clients", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("no paired clients"))
 	assert.True(t, runner.ContainsText("Pair"))
 
@@ -69,9 +69,9 @@ func TestBuildClientsPage_FirstClientAdmin_Integration(t *testing.T) {
 	// administrator assignment.
 	runner.SimulateTab()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("first paired client", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("first paired client", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Pairing PIN: 123 456", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Pairing PIN: 123 456", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Role: Admin"))
 	assert.True(t, runner.ContainsText("Expires in:"))
 	require.True(t, runner.WaitForText("Expires in: 0:00", 3*time.Second))
@@ -101,9 +101,9 @@ func TestBuildClientsPage_RequireEncryptionConfirmation_Integration(t *testing.T
 		BuildClientsPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Require encryption", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Require encryption", uiSettleTimeout))
 	runner.SimulateArrowRight()
-	require.True(t, runner.WaitForText("Require encrypted remote", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Require encrypted remote", uiSettleTimeout))
 	runner.SimulateEnter()
 	mockSvc.AssertExpectations(t)
 }
@@ -130,7 +130,7 @@ func TestBuildClientsPage_DisableEncryptionImmediately_Integration(t *testing.T)
 		BuildClientsPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Require encryption", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Require encryption", uiSettleTimeout))
 	runner.SimulateArrowLeft()
 	mockSvc.AssertExpectations(t)
 }
@@ -153,10 +153,10 @@ func TestShowClientRolePicker_AdminWithoutProfilesStartsPairing_Integration(t *t
 		showClientRolePicker(mockSvc, pages, runner.App(), nil, func() {})
 	})
 
-	require.True(t, runner.WaitForText("Client Role", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Client Role", uiSettleTimeout))
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Pairing PIN: 654 321", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Pairing PIN: 654 321", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Profile PIN"))
 	runner.SimulateEnter()
 	mockSvc.AssertExpectations(t)
@@ -182,13 +182,13 @@ func TestShowClientRolePicker_AdminPromptsCredential_Integration(t *testing.T) {
 		showClientRolePicker(mockSvc, pages, runner.App(), profiles, func() {})
 	})
 
-	require.True(t, runner.WaitForText("Client Role", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Client Role", uiSettleTimeout))
 	runner.SimulateArrowDown() // Admin
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	runner.SimulateString("1234")
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Pairing PIN: 654 321", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Pairing PIN: 654 321", uiSettleTimeout))
 	runner.SimulateEnter()
 	mockSvc.AssertExpectations(t)
 }

--- a/pkg/ui/tui/dialog_test.go
+++ b/pkg/ui/tui/dialog_test.go
@@ -75,7 +75,7 @@ func TestDialog_SizesToContent(t *testing.T) {
 		pages.AddPage("dialog", dialog, true, true)
 		runner.App().SetFocus(dialog)
 	})
-	require.True(t, runner.WaitForText("Hi", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Hi", uiSettleTimeout))
 
 	bounds, ok := drawnBounds(runner)
 	require.True(t, ok, "dialog should be drawn")
@@ -118,7 +118,7 @@ func TestDialog_ClampedToParentWindow(t *testing.T) {
 		pages.AddPage("dialog", dialog, true, true)
 		runner.App().SetFocus(dialog)
 	})
-	require.True(t, runner.WaitForText("word-wrap", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("word-wrap", uiSettleTimeout))
 
 	bounds, ok := drawnBounds(runner)
 	require.True(t, ok, "dialog should be drawn")
@@ -155,7 +155,7 @@ func TestDialog_ButtonSelectionAndEscape(t *testing.T) {
 			pages.AddPage("dialog", dialog, true, true)
 			runner.App().SetFocus(dialog)
 		})
-		require.True(t, runner.WaitForText("Pick one", 500*time.Millisecond))
+		require.True(t, runner.WaitForText("Pick one", uiSettleTimeout))
 		return pressed
 	}
 
@@ -212,7 +212,7 @@ func TestDialog_LongTextWordWraps(t *testing.T) {
 		runner.App().SetFocus(dialog)
 	})
 
-	assert.True(t, runner.WaitForText("FINAL-MARKER", 500*time.Millisecond),
+	assert.True(t, runner.WaitForText("FINAL-MARKER", uiSettleTimeout),
 		"wrapped text should remain fully visible")
 }
 
@@ -236,12 +236,12 @@ func TestDialog_SetTextUpdatesContent(t *testing.T) {
 		pages.AddPage("dialog", dialog, true, true)
 		runner.App().SetFocus(dialog)
 	})
-	require.True(t, runner.WaitForText("Before", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Before", uiSettleTimeout))
 
 	runner.QueueUpdateDraw(func() {
 		dialog.SetText("After the update")
 	})
-	assert.True(t, runner.WaitForText("After the update", 500*time.Millisecond))
+	assert.True(t, runner.WaitForText("After the update", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Before"), "old text should be gone")
 }
 

--- a/pkg/ui/tui/encryption_prompt_test.go
+++ b/pkg/ui/tui/encryption_prompt_test.go
@@ -62,7 +62,7 @@ func TestShowEncryptionPrompt_Buttons_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Secure Zaparoo?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Secure Zaparoo?", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Secure Now"))
 	assert.True(t, runner.ContainsText("Not Now"))
 	assert.True(t, runner.ContainsText("Don't Ask Again"))
@@ -70,7 +70,7 @@ func TestShowEncryptionPrompt_Buttons_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(secureCalled, 100*time.Millisecond),
+	assert.True(t, runner.WaitForSignal(secureCalled, uiSettleTimeout),
 		"Secure Now callback should be called")
 	select {
 	case <-dontAskCalled:
@@ -124,7 +124,7 @@ func TestMaybeShowEncryptionPrompt_ShowsWithNoClients(t *testing.T) {
 		maybeShowEncryptionPrompt(svc, pages, runner.App(), nil)
 	})
 
-	assert.True(t, runner.WaitForText("Secure Zaparoo?", 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Secure Zaparoo?", uiSettleTimeout))
 	svc.AssertExpectations(t)
 }
 
@@ -156,7 +156,7 @@ func TestEncryptionPairingModal_SuccessKeepsEncryption(t *testing.T) {
 	})
 
 	require.True(t, runner.WaitForText("Zaparoo secured.", time.Second))
-	assert.True(t, runner.WaitForSignal(markPrompted, 100*time.Millisecond),
+	assert.True(t, runner.WaitForSignal(markPrompted, uiSettleTimeout),
 		"markPrompted should be called on success")
 	// Encryption must not be reverted on success.
 	assert.Equal(t, 0, svc.UpdateSettingsCallCount())

--- a/pkg/ui/tui/main_test.go
+++ b/pkg/ui/tui/main_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 	"unicode/utf8"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -54,7 +53,7 @@ func TestBuildMainPage_ShowsAppFooter(t *testing.T) {
 	const expectedFooterText = "Connect with the Zaparoo App (iOS/Android): https://zaparoo.app/"
 	require.True(t, runner.WaitForText(
 		expectedFooterText,
-		500*time.Millisecond,
+		uiSettleTimeout,
 	))
 
 	screenLines := strings.Split(runner.GetScreenText(), "\n")
@@ -389,14 +388,14 @@ func TestButtonGrid_HelpCallback_Integration(t *testing.T) {
 	// Should trigger help for first button on focus
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return containsHelpText("Help for button 1")
-	}, 100*time.Millisecond), "Should receive help for first button")
+	}, uiSettleTimeout), "Should receive help for first button")
 
 	// Navigate right
 	runner.SimulateArrowRight()
 
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return containsHelpText("Help for button 2")
-	}, 100*time.Millisecond), "Should receive help for second button")
+	}, uiSettleTimeout), "Should receive help for second button")
 }
 
 func TestButtonGrid_Navigation_Integration(t *testing.T) {
@@ -506,7 +505,7 @@ func TestButtonGrid_EscapeCallback_Integration(t *testing.T) {
 
 	runner.SimulateEscape()
 
-	assert.True(t, runner.WaitForSignal(escapeCalled, 100*time.Millisecond), "Escape callback should be called")
+	assert.True(t, runner.WaitForSignal(escapeCalled, uiSettleTimeout), "Escape callback should be called")
 }
 
 func TestButtonGrid_EnterActivatesButton_Integration(t *testing.T) {
@@ -535,7 +534,7 @@ func TestButtonGrid_EnterActivatesButton_Integration(t *testing.T) {
 
 	runner.SimulateEnter()
 
-	assert.True(t, runner.WaitForSignal(buttonPressed, 100*time.Millisecond), "Button should be activated on Enter")
+	assert.True(t, runner.WaitForSignal(buttonPressed, uiSettleTimeout), "Button should be activated on Enter")
 }
 
 func TestButtonGrid_DisabledButtonsSkipped_Integration(t *testing.T) {

--- a/pkg/ui/tui/online_test.go
+++ b/pkg/ui/tui/online_test.go
@@ -21,7 +21,6 @@ package tui
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -103,21 +102,21 @@ func TestBuildOnlineSettingsMenu_CustomEndpointsShowWarnings_Integration(t *test
 	})
 
 	require.True(t, runner.WaitForText(
-		"One or more Zaparoo Online endpoints are set to a custom server.", 100*time.Millisecond))
+		"One or more Zaparoo Online endpoints are set to a custom server.", uiSettleTimeout))
 
 	// Row descriptions only show in the help line for the currently
 	// selected row (dynamic help mode). Account, Warp, Unlink account,
 	// then Remote control.
-	require.True(t, runner.WaitForText("Remote control", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Remote control", uiSettleTimeout))
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
-	assert.True(t, runner.WaitForText("Custom server: custom-remote.example.com.", 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Custom server: custom-remote.example.com.", uiSettleTimeout))
 
 	// Two more down: past Remote control activity, to Play history sync.
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
-	assert.True(t, runner.WaitForText("Custom server: custom-playtime.example.com.", 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Custom server: custom-playtime.example.com.", uiSettleTimeout))
 }
 
 func TestBuildOnlineSettingsMenu_DefaultEndpointsShowNoWarning_Integration(t *testing.T) {
@@ -138,7 +137,7 @@ func TestBuildOnlineSettingsMenu_DefaultEndpointsShowNoWarning_Integration(t *te
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Remote control", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Remote control", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Custom server:"))
 }
 
@@ -157,7 +156,7 @@ func TestBuildOnlineSettingsMenu_NotLinkedShowsLinkAction_Integration(t *testing
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Link account", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Link account", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Not linked"), "link status shows on the menu line")
 	assert.True(t, runner.ContainsText("Play history sync"), "sync consent is configurable before linking")
 	assert.True(t, runner.ContainsText("Cloud backup"), "features are discoverable while unlinked")
@@ -181,7 +180,7 @@ func TestBuildOnlineSettingsMenu_LinkedShowsAccountControls_Integration(t *testi
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Account", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Account", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Linked"), "link status shows on the menu line")
 	assert.True(t, runner.ContainsText("Warp"), "Warp subscription status shows on the menu line")
 	assert.True(t, runner.ContainsText("Remote control"))
@@ -206,7 +205,7 @@ func TestBuildOnlineSettingsMenu_RemoteControlToggleUpdatesConsent_Integration(t
 	runner.QueueUpdateDraw(func() {
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Remote control", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Remote control", uiSettleTimeout))
 
 	// Account, Warp, Unlink account, then Remote control.
 	runner.SimulateArrowDown()
@@ -225,7 +224,7 @@ func TestBuildOnlineSettingsMenu_RemoteControlToggleUpdatesConsent_Integration(t
 			}
 		}
 		return false
-	}, 100*time.Millisecond), "toggle should disable remote control consent")
+	}, uiSettleTimeout), "toggle should disable remote control consent")
 }
 
 func TestBuildOnlineSettingsMenu_PlayHistoryToggleUpdatesConsent_Integration(t *testing.T) {
@@ -243,7 +242,7 @@ func TestBuildOnlineSettingsMenu_PlayHistoryToggleUpdatesConsent_Integration(t *
 	runner.QueueUpdateDraw(func() {
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Play history sync", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Play history sync", uiSettleTimeout))
 
 	// Account, Warp, Unlink account, Remote control, Remote control
 	// activity, then Play history sync.
@@ -265,7 +264,7 @@ func TestBuildOnlineSettingsMenu_PlayHistoryToggleUpdatesConsent_Integration(t *
 			}
 		}
 		return false
-	}, 100*time.Millisecond), "toggle should disable playtime sync consent")
+	}, uiSettleTimeout), "toggle should disable playtime sync consent")
 }
 
 func TestBuildOnlineSettingsMenu_LinkedShowsDeviceName_Integration(t *testing.T) {
@@ -286,7 +285,7 @@ func TestBuildOnlineSettingsMenu_LinkedShowsDeviceName_Integration(t *testing.T)
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Linked as Living Room MiSTer", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Linked as Living Room MiSTer", uiSettleTimeout))
 }
 
 func TestBuildOnlineSettingsMenu_CustomServerShownInStatus_Integration(t *testing.T) {
@@ -307,7 +306,7 @@ func TestBuildOnlineSettingsMenu_CustomServerShownInStatus_Integration(t *testin
 
 	// The custom server host shows in the help text of the selected
 	// Account row.
-	require.True(t, runner.WaitForText("This device is linked to backup.example.com", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("This device is linked to backup.example.com", uiSettleTimeout))
 }
 
 func TestBuildOnlineSettingsMenu_UnlinkConfirmFlow_Integration(t *testing.T) {
@@ -327,21 +326,21 @@ func TestBuildOnlineSettingsMenu_UnlinkConfirmFlow_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Unlink account", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Unlink account", uiSettleTimeout))
 
 	// Account section: Account row, Warp row, Unlink account.
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Unlink from Zaparoo Online?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Unlink from Zaparoo Online?", uiSettleTimeout))
 
 	// Confirm ("Yes" is focused first).
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("credentials were removed", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("credentials were removed", uiSettleTimeout))
 
 	// Dismiss the confirmation: the page rebuilds in the unlinked state.
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Link account", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Link account", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "Unlink", mock.Anything)
 }
 
@@ -360,7 +359,7 @@ func TestBuildOnlineSettingsMenu_CloudBackupNavigatesToBackupPage_Integration(t 
 	runner.QueueUpdateDraw(func() {
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Cloud backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Cloud backup", uiSettleTimeout))
 
 	// Account, Warp, Unlink account, Remote control, Remote control
 	// activity, Play history sync, then Cloud backup.
@@ -372,6 +371,6 @@ func TestBuildOnlineSettingsMenu_CloudBackupNavigatesToBackupPage_Integration(t 
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
 
-	require.True(t, runner.WaitForText("Automatic backup", 500*time.Millisecond),
+	require.True(t, runner.WaitForText("Automatic backup", uiSettleTimeout),
 		"selecting Cloud backup should open the backup settings page")
 }

--- a/pkg/ui/tui/profiles_test.go
+++ b/pkg/ui/tui/profiles_test.go
@@ -259,10 +259,10 @@ func TestBuildProfilesSettingsMenu_ToggleRequiresAdminPIN_Integration(t *testing
 		buildProfilesSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Require profile for launch", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Require profile for launch", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Block launches until a profile is active"))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	runner.SimulateString("1234")
 	runner.SimulateEnter()
 	select {
@@ -296,7 +296,7 @@ func TestBuildProfilesPage_Integration(t *testing.T) {
 		BuildProfilesPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Profiles", 100*time.Millisecond), "Profiles title should appear")
+	require.True(t, runner.WaitForText("Profiles", uiSettleTimeout), "Profiles title should appear")
 	assert.True(t, runner.ContainsText("Kid A"), "profile names should be listed")
 	assert.True(t, runner.ContainsText("Kid B"), "profile names should be listed")
 	assert.True(t, runner.ContainsText("active"), "active profile should be marked")
@@ -332,15 +332,15 @@ func TestBuildProfilesPage_SelectPromptsThenOpensEdit_Integration(t *testing.T) 
 		BuildProfilesPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Kid A", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Kid A", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("New"))
 	assert.True(t, runner.ContainsText("Switch"))
 	assert.True(t, runner.ContainsText("Back"))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	runner.SimulateString("1234")
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Edit", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Edit", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Write Card"))
 	assert.True(t, runner.ContainsText("Switch ID: ******"))
 	assert.False(t, runner.ContainsText("New ID"))
@@ -372,7 +372,7 @@ func TestProfileSwitchModal_Integration(t *testing.T) {
 			})
 	})
 
-	require.True(t, runner.WaitForText("Switch Profile", 100*time.Millisecond), "modal title should appear")
+	require.True(t, runner.WaitForText("Switch Profile", uiSettleTimeout), "modal title should appear")
 	assert.True(t, runner.ContainsText("Shared profile"), "shared profile entry should be listed")
 	assert.True(t, runner.ContainsText("Kid A (active)"), "active profile should be marked")
 	assert.True(t, runner.ContainsText("Kid B"), "profiles should be listed")
@@ -419,7 +419,7 @@ func TestProfileSwitchModal_ProtectedProfileRequiresPIN_Integration(t *testing.T
 	// prompt and does not send its bearer switch ID behind the user's back.
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	mockSvc.AssertNotCalled(t, "SwitchProfile", mock.Anything, mock.Anything)
 
 	// Non-digits are rejected by the field. A short PIN remains local and
@@ -427,7 +427,7 @@ func TestProfileSwitchModal_ProtectedProfileRequiresPIN_Integration(t *testing.T
 	runner.SimulateString("a123")
 	assert.False(t, runner.ContainsText("123"), "entered PIN must be masked")
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("PIN must be 4 to 8 digits", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("PIN must be 4 to 8 digits", uiSettleTimeout))
 	mockSvc.AssertNotCalled(t, "SwitchProfile", mock.Anything, mock.Anything)
 	runner.SimulateEnter() // dismiss validation error
 
@@ -474,7 +474,7 @@ func TestPromptProfileManagement_Integration(t *testing.T) {
 		}, nil)
 	})
 
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	runner.SimulateString("1234")
 	runner.SimulateEnter()
 	select {
@@ -503,7 +503,7 @@ func TestPromptProfileManagement_MultipleAdminsShowsChooser_Integration(t *testi
 		promptProfileManagement(mockSvc, pages, runner.App(), profiles, func() {}, nil)
 	})
 
-	require.True(t, runner.WaitForText("Administrator", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Administrator", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Kid A"))
 	assert.True(t, runner.ContainsText("Kid B"))
 }
@@ -522,7 +522,7 @@ func TestProfilePINEditModal_ShowsContextualClear_Integration(t *testing.T) {
 		showProfilePINEditModal(pages, runner.App(), true, func(string) {}, func() {}, nil)
 	})
 
-	require.True(t, runner.WaitForText("Profile PIN", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Profile PIN", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Set PIN"))
 	assert.True(t, runner.ContainsText("Clear PIN"))
 	assert.True(t, runner.ContainsText("Cancel"))
@@ -542,7 +542,7 @@ func TestProfileSwitchIDModal_RevealsOnlyOnSelection_Integration(t *testing.T) {
 		showProfileSwitchIDModal(pages, runner.App(), "corn-arm-truck", func() {}, nil)
 	})
 
-	require.True(t, runner.WaitForText("corn-arm-truck", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("corn-arm-truck", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Reset"))
 }
 
@@ -566,7 +566,7 @@ func TestBuildProfilesPage_EmptyState_Integration(t *testing.T) {
 		BuildProfilesPage(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("no profiles", 100*time.Millisecond),
+	require.True(t, runner.WaitForText("no profiles", uiSettleTimeout),
 		"empty state should explain profile setup")
 	assert.True(t, runner.ContainsText("New"), "stable New action should be visible")
 }
@@ -587,7 +587,7 @@ func TestBuildProfileEditPage_ProfileLookupFailureFailsClosed_Integration(t *tes
 		buildProfileEditPage(mockSvc, pages, runner.App(), nil)
 	})
 
-	require.True(t, runner.WaitForText("Failed to load profiles", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Failed to load profiles", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("initial administrator"))
 	mockSvc.AssertNotCalled(t, "NewProfile", mock.Anything, mock.Anything)
 }
@@ -611,7 +611,7 @@ func TestBuildProfileEditPage_New_Integration(t *testing.T) {
 		buildProfileEditPage(mockSvc, pages, runner.App(), nil)
 	})
 
-	require.True(t, runner.WaitForText("New", 100*time.Millisecond), "New title should appear")
+	require.True(t, runner.WaitForText("New", uiSettleTimeout), "New title should appear")
 	assert.True(t, runner.ContainsText("Name"), "Name field should be visible")
 	assert.True(t, runner.ContainsText("PIN"), "PIN field should be visible")
 	assert.True(t, runner.ContainsText("Limits"), "Limits toggle should be visible")
@@ -640,7 +640,7 @@ func TestBuildProfileEditPage_Edit_Integration(t *testing.T) {
 		buildProfileEditPage(mockSvc, pages, runner.App(), &profiles.Profiles[0])
 	})
 
-	require.True(t, runner.WaitForText("Edit", 100*time.Millisecond), "Edit title should appear")
+	require.True(t, runner.WaitForText("Edit", uiSettleTimeout), "Edit title should appear")
 	assert.True(t, runner.ContainsText("Kid A"), "existing name should be pre-filled")
 	assert.True(t, runner.ContainsText("PIN: ******"), "existing PIN should use a fixed mask")
 	assert.True(t, runner.ContainsText("Switch ID: ******"), "switch ID should be masked until selected")

--- a/pkg/ui/tui/remote_activity_test.go
+++ b/pkg/ui/tui/remote_activity_test.go
@@ -21,7 +21,6 @@ package tui
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -100,7 +99,7 @@ func TestBuildRemoteActivityPage_ShowsEntries_Integration(t *testing.T) {
 		buildRemoteActivityPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("launch", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("launch", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("20 Aug 12:00"))
 }
 
@@ -118,7 +117,7 @@ func TestBuildRemoteActivityPage_EmptyShowsPlaceholder_Integration(t *testing.T)
 		buildRemoteActivityPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("no remote activity yet", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("no remote activity yet", uiSettleTimeout))
 }
 
 func TestBuildOnlineSettingsMenu_RemoteControlActivityNavigatesToActivityPage_Integration(t *testing.T) {
@@ -136,7 +135,7 @@ func TestBuildOnlineSettingsMenu_RemoteControlActivityNavigatesToActivityPage_In
 	runner.QueueUpdateDraw(func() {
 		buildOnlineSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Remote control activity", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Remote control activity", uiSettleTimeout))
 
 	// Account, Warp, Unlink account, Remote control, then Remote control activity.
 	runner.SimulateArrowDown()
@@ -145,6 +144,6 @@ func TestBuildOnlineSettingsMenu_RemoteControlActivityNavigatesToActivityPage_In
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
 
-	require.True(t, runner.WaitForText("no remote activity yet", 500*time.Millisecond),
+	require.True(t, runner.WaitForText("no remote activity yet", uiSettleTimeout),
 		"selecting Remote control activity should open the activity page")
 }

--- a/pkg/ui/tui/searchmedia_test.go
+++ b/pkg/ui/tui/searchmedia_test.go
@@ -190,7 +190,7 @@ func TestBuildSearchMedia_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond), "Search Media title should appear")
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout), "Search Media title should appear")
 
 	// Verify UI elements are visible
 	assert.True(t, runner.ContainsText("Name"), "Name label should be visible")
@@ -243,7 +243,7 @@ func TestBuildSearchMedia_SearchWithResults_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	// Type in search
 	runner.SimulateString("mario")
@@ -256,7 +256,7 @@ func TestBuildSearchMedia_SearchWithResults_Integration(t *testing.T) {
 
 	// Wait for SearchMedia to be called using the mock's signal channel
 	called := mockSvc.SearchMediaCalled()
-	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond), "SearchMedia should be called")
+	assert.True(t, runner.WaitForSignal(called, uiSettleTimeout), "SearchMedia should be called")
 }
 
 func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
@@ -302,12 +302,12 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	runner.SimulateTab()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	require.True(t, runner.WaitForText("Loaded 2 results", uiSettleTimeout))
 	assert.Equal(t, 1, mockSvc.SearchMediaCallCount(), "initial selection should not immediately prefetch")
 
 	// Editing the input must not combine the previous page's cursor with a new query.
@@ -328,11 +328,11 @@ func TestBuildSearchMedia_AutoloadsMoreResults_Integration(t *testing.T) {
 		<-scrollDone
 		t.Fatal("scrolling blocked while the next page loaded")
 	}
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Loading more results", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	require.True(t, runner.WaitForText("Loading more results", uiSettleTimeout))
 	close(releaseNextPage)
 
-	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Game Three", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Game One"), "first page should remain visible")
 	assert.True(t, runner.ContainsText("game-two.chd"), "prefetch should preserve current selection")
 	assert.False(t, runner.ContainsText("Load more results"), "pagination should not add a list row")
@@ -383,21 +383,21 @@ func TestBuildSearchMedia_AutoloadErrorCanRetry_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		BuildSearchMedia(mockSvc, pages, runner.App(), NewSession())
 	})
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	runner.SimulateTab()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	require.True(t, runner.WaitForText("Loaded 2 results", uiSettleTimeout))
 	runner.SimulateArrowDown()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
 
-	assert.True(t, runner.WaitForText("Error loading more results", 100*time.Millisecond))
+	assert.True(t, runner.WaitForText("Error loading more results", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Load more results"), "failed load should not add a list row")
 
 	runner.SimulateArrowUp()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	assert.True(t, runner.WaitForText("Game Three", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	assert.True(t, runner.WaitForText("Game Three", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Game One"), "retry should preserve first page")
 	mockSvc.AssertExpectations(t)
 }
@@ -432,18 +432,18 @@ func TestBuildSearchMedia_FreshSearchErrorClearsPagination_Integration(t *testin
 	runner.QueueUpdateDraw(func() {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	runner.SimulateTab()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Loaded 2 results", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	require.True(t, runner.WaitForText("Loaded 2 results", uiSettleTimeout))
 
 	runner.SimulateArrowLeft()
 	session.SetSearchMediaName("new query")
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), 100*time.Millisecond))
-	require.True(t, runner.WaitForText("An error occurred during search", 100*time.Millisecond))
+	require.True(t, runner.WaitForSignal(mockSvc.SearchMediaCalled(), uiSettleTimeout))
+	require.True(t, runner.WaitForText("An error occurred during search", uiSettleTimeout))
 
 	runner.SimulateTab()
 	runner.SimulateArrowDown()
@@ -508,17 +508,17 @@ func TestBuildSearchMedia_DisambiguatingTags_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	// Trigger search
 	runner.SimulateTab()
 	runner.SimulateEnter()
 
 	called := mockSvc.SearchMediaCalled()
-	require.True(t, runner.WaitForSignal(called, 100*time.Millisecond), "SearchMedia should be called")
+	require.True(t, runner.WaitForSignal(called, uiSettleTimeout), "SearchMedia should be called")
 
 	// Results with disambiguating tags should show them in the row
-	assert.True(t, runner.WaitForText("region:eu", 100*time.Millisecond), "region:eu tag should appear in results")
+	assert.True(t, runner.WaitForText("region:eu", uiSettleTimeout), "region:eu tag should appear in results")
 	assert.True(t, runner.ContainsText("region:jp"), "region:jp tag should appear in results")
 
 	// Result without tags should still render cleanly (no spurious parens)
@@ -546,7 +546,7 @@ func TestBuildSearchMedia_EscapeGoesBack_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	// Helper to get front page
 	getFrontPage := func() string {
@@ -563,7 +563,7 @@ func TestBuildSearchMedia_EscapeGoesBack_Integration(t *testing.T) {
 	// Verify we went back
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return getFrontPage() == PageMain
-	}, 100*time.Millisecond), "Should navigate back to main page")
+	}, uiSettleTimeout), "Should navigate back to main page")
 }
 
 func TestBuildSearchMedia_ClearButton_Integration(t *testing.T) {
@@ -590,7 +590,7 @@ func TestBuildSearchMedia_ClearButton_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	// Navigate to Clear button (Tab then right)
 	runner.SimulateTab()
@@ -604,7 +604,7 @@ func TestBuildSearchMedia_ClearButton_Integration(t *testing.T) {
 		return session.GetSearchMediaName() == "" &&
 			session.GetSearchMediaSystem() == "" &&
 			session.GetSearchMediaSystemName() == "All"
-	}, 100*time.Millisecond), "Session state should be cleared")
+	}, uiSettleTimeout), "Session state should be cleared")
 }
 
 func TestBuildSearchMedia_SystemNavigation_Integration(t *testing.T) {
@@ -637,7 +637,7 @@ func TestBuildSearchMedia_SystemNavigation_Integration(t *testing.T) {
 		BuildSearchMedia(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Search Media", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Search Media", uiSettleTimeout))
 
 	// Navigate down to system button
 	runner.SimulateArrowDown()

--- a/pkg/ui/tui/settings_integration_test.go
+++ b/pkg/ui/tui/settings_integration_test.go
@@ -93,7 +93,7 @@ func TestSettingsList_ToggleActivation_Integration(t *testing.T) {
 	runner.SimulateEnter()
 
 	// Wait for the callback
-	assert.True(t, runner.WaitForSignal(toggleCalled, 100*time.Millisecond), "toggle callback should be called")
+	assert.True(t, runner.WaitForSignal(toggleCalled, uiSettleTimeout), "toggle callback should be called")
 	assert.True(t, toggleValue, "toggle value should be true after activation")
 }
 
@@ -121,7 +121,7 @@ func TestSettingsList_TextEditActivation_Integration(t *testing.T) {
 
 	assert.True(t, runner.ContainsText("Name: Not set"))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Edit Name", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Edit Name", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Enter the profile display name."))
 	runner.SimulateString("Kid A")
 	runner.SimulateEnter()
@@ -132,7 +132,7 @@ func TestSettingsList_TextEditActivation_Integration(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for text edit")
 	}
-	require.True(t, runner.WaitForText("Name: Kid A", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Name: Kid A", uiSettleTimeout))
 	assert.Equal(t, "Kid A", value)
 }
 
@@ -200,7 +200,7 @@ func TestSettingsList_EscapeGoesBack_Integration(t *testing.T) {
 	// Verify we switched to main page
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return getFrontPage() == "main"
-	}, 100*time.Millisecond), "Should switch to main page")
+	}, uiSettleTimeout), "Should switch to main page")
 }
 
 func TestButtonBar_Navigation_Integration(t *testing.T) {
@@ -234,7 +234,7 @@ func TestButtonBar_Navigation_Integration(t *testing.T) {
 	// Press Enter on first button
 	runner.SimulateEnter()
 
-	assert.True(t, runner.WaitForSignal(button1Pressed, 100*time.Millisecond), "first button should be pressed")
+	assert.True(t, runner.WaitForSignal(button1Pressed, uiSettleTimeout), "first button should be pressed")
 
 	// Navigate right to second button
 	runner.SimulateArrowRight()
@@ -242,7 +242,7 @@ func TestButtonBar_Navigation_Integration(t *testing.T) {
 	// Press Enter on second button
 	runner.SimulateEnter()
 
-	assert.True(t, runner.WaitForSignal(button2Pressed, 100*time.Millisecond), "second button should be pressed")
+	assert.True(t, runner.WaitForSignal(button2Pressed, uiSettleTimeout), "second button should be pressed")
 }
 
 func TestButtonBar_EscapeCallback_Integration(t *testing.T) {
@@ -268,7 +268,7 @@ func TestButtonBar_EscapeCallback_Integration(t *testing.T) {
 	// Press Escape
 	runner.SimulateEscape()
 
-	assert.True(t, runner.WaitForSignal(escapeCalled, 100*time.Millisecond), "escape callback should be called")
+	assert.True(t, runner.WaitForSignal(escapeCalled, uiSettleTimeout), "escape callback should be called")
 }
 
 func TestCheckList_Integration(t *testing.T) {
@@ -299,7 +299,7 @@ func TestCheckList_Integration(t *testing.T) {
 	// Toggle first item
 	runner.SimulateEnter()
 
-	assert.True(t, runner.WaitForSignal(selectionChanged, 100*time.Millisecond), "selection callback should be called")
+	assert.True(t, runner.WaitForSignal(selectionChanged, uiSettleTimeout), "selection callback should be called")
 
 	selMu.Lock()
 	require.Len(t, selections, 1)
@@ -310,7 +310,7 @@ func TestCheckList_Integration(t *testing.T) {
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
 
-	assert.True(t, runner.WaitForSignal(selectionChanged, 100*time.Millisecond), "selection callback should be called")
+	assert.True(t, runner.WaitForSignal(selectionChanged, uiSettleTimeout), "selection callback should be called")
 
 	selMu.Lock()
 	require.Len(t, selections, 2)
@@ -357,7 +357,7 @@ func TestCheckList_EscapeNavigation_Integration(t *testing.T) {
 	// Verify we went back to main
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return getFrontPage() == "main"
-	}, 100*time.Millisecond), "Should go back to main")
+	}, uiSettleTimeout), "Should go back to main")
 }
 
 func TestSettingsList_RefreshItems_Integration(t *testing.T) {

--- a/pkg/ui/tui/settings_test.go
+++ b/pkg/ui/tui/settings_test.go
@@ -92,7 +92,7 @@ func TestBuildSettingsMainMenu_Integration(t *testing.T) {
 	})
 
 	// Verify settings page is shown
-	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond), "Settings title should appear")
+	require.True(t, runner.WaitForText("Settings", uiSettleTimeout), "Settings title should appear")
 
 	// Verify menu items are visible
 	assert.True(t, runner.ContainsText("Readers"), "Readers menu item should be visible")
@@ -128,7 +128,7 @@ func TestBuildSettingsMainMenu_Navigation_Integration(t *testing.T) {
 		BuildSettingsMainMenuWithService(cfg, mockSvc, pages, runner.App(), nil, nil, "", "")
 	})
 
-	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Settings", uiSettleTimeout))
 
 	// Navigate down through menu items
 	runner.Screen().InjectArrowDown()
@@ -174,7 +174,7 @@ func TestBuildSettingsMainMenu_EscapeGoesBack_Integration(t *testing.T) {
 		BuildSettingsMainMenuWithService(cfg, mockSvc, pages, runner.App(), nil, rebuildMainPage, "", "")
 	})
 
-	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Settings", uiSettleTimeout))
 
 	rebuildDone := make(chan struct{}, 1)
 	go func() {
@@ -189,7 +189,7 @@ func TestBuildSettingsMainMenu_EscapeGoesBack_Integration(t *testing.T) {
 	runner.Draw()
 
 	// Should have called rebuild
-	assert.True(t, runner.WaitForSignal(rebuildDone, 100*time.Millisecond), "Should have called rebuildMainPage")
+	assert.True(t, runner.WaitForSignal(rebuildDone, uiSettleTimeout), "Should have called rebuildMainPage")
 }
 
 func TestBuildAudioSettingsMenu_Integration(t *testing.T) {
@@ -215,7 +215,7 @@ func TestBuildAudioSettingsMenu_Integration(t *testing.T) {
 	})
 
 	// Verify audio page is shown
-	require.True(t, runner.WaitForText("Audio", 100*time.Millisecond), "Audio title should appear")
+	require.True(t, runner.WaitForText("Audio", uiSettleTimeout), "Audio title should appear")
 
 	// Verify toggle is visible
 	assert.True(t, runner.ContainsText("Audio feedback"), "Audio feedback toggle should be visible")
@@ -242,7 +242,7 @@ func TestBuildAudioSettingsMenu_Toggle_Integration(t *testing.T) {
 		buildAudioSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Audio", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Audio", uiSettleTimeout))
 
 	// Toggle by pressing Enter
 	runner.Screen().InjectEnter()
@@ -250,7 +250,7 @@ func TestBuildAudioSettingsMenu_Toggle_Integration(t *testing.T) {
 
 	// Wait for UpdateSettings to be called using the mock's signal channel
 	called := mockSvc.UpdateSettingsCalled()
-	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond), "UpdateSettings should be called")
+	assert.True(t, runner.WaitForSignal(called, uiSettleTimeout), "UpdateSettings should be called")
 }
 
 func TestBuildAudioSettingsMenu_Error_Integration(t *testing.T) {
@@ -275,7 +275,7 @@ func TestBuildAudioSettingsMenu_Error_Integration(t *testing.T) {
 	})
 
 	// Should show error modal
-	require.True(t, runner.WaitForText("Failed", 100*time.Millisecond), "Error modal should appear")
+	require.True(t, runner.WaitForText("Failed", uiSettleTimeout), "Error modal should appear")
 }
 
 func TestBuildReadersSettingsMenu_Integration(t *testing.T) {
@@ -302,7 +302,7 @@ func TestBuildReadersSettingsMenu_Integration(t *testing.T) {
 		buildReadersSettingsMenu(cfg, mockSvc, pages, runner.App(), nil)
 	})
 
-	require.True(t, runner.WaitForText("Readers", 100*time.Millisecond), "Readers title should appear")
+	require.True(t, runner.WaitForText("Readers", uiSettleTimeout), "Readers title should appear")
 
 	// Verify menu items
 	assert.True(t, runner.ContainsText("Auto-detect"), "Auto-detect toggle should be visible")
@@ -333,7 +333,7 @@ func TestBuildReadersSettingsMenu_ScanModeOptions(t *testing.T) {
 		buildReadersSettingsMenu(cfg, mockSvc, pages, runner.App(), nil)
 	})
 
-	require.True(t, runner.WaitForText("Readers", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Readers", uiSettleTimeout))
 
 	// Verify scan mode displays Tap
 	assert.True(t, runner.ContainsText("Tap"), "Tap mode should be visible")
@@ -361,7 +361,7 @@ func TestBuildReaderEditPage_DownFromEnabledFocusesButtonBar(t *testing.T) {
 		buildReaderEditPage(cfg, mockSvc, pages, runner.App(), mockPlatform, &configuredReaders, 0)
 	})
 
-	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond), "Reader edit page should appear")
+	require.True(t, runner.WaitForText("Settings", uiSettleTimeout), "Reader edit page should appear")
 
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
@@ -399,7 +399,7 @@ func TestBuildAdvancedSettingsMenu_Integration(t *testing.T) {
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond), "Advanced title should appear")
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout), "Advanced title should appear")
 
 	// Verify menu items
 	assert.True(t, runner.ContainsText("Ignore systems"), "Ignore systems should be visible")
@@ -438,7 +438,7 @@ func TestBuildAdvancedSettingsMenu_ReloadCore_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
-	require.True(t, runner.WaitForText("Reload Core", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Reload Core", uiSettleTimeout))
 
 	runner.SimulateArrowDown()
 	enterDone := make(chan struct{})
@@ -469,7 +469,7 @@ func TestBuildAdvancedSettingsMenu_ReloadCore_Integration(t *testing.T) {
 		t.Fatal("reload action did not return")
 	}
 
-	require.True(t, runner.WaitForText("Core reloaded", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Core reloaded", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "ReloadCore", mock.Anything)
 }
 
@@ -488,12 +488,12 @@ func TestBuildAdvancedSettingsMenu_ReloadCoreError_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
-	require.True(t, runner.WaitForText("Reload Core", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Reload Core", uiSettleTimeout))
 
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
 
-	require.True(t, runner.WaitForText("Failed to reload Core", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Failed to reload Core", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "ReloadCore", mock.Anything)
 }
 
@@ -518,7 +518,7 @@ func TestBuildAdvancedSettingsMenu_ToggleDebugLogging_Integration(t *testing.T) 
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout))
 
 	// Navigate to debug logging (third item)
 	runner.Screen().InjectArrowDown()
@@ -531,7 +531,7 @@ func TestBuildAdvancedSettingsMenu_ToggleDebugLogging_Integration(t *testing.T) 
 
 	// Wait for UpdateSettings to be called using the mock's signal channel
 	called := mockSvc.UpdateSettingsCalled()
-	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond), "UpdateSettings should be called")
+	assert.True(t, runner.WaitForSignal(called, uiSettleTimeout), "UpdateSettings should be called")
 }
 
 func TestBuildAboutPage_Integration(t *testing.T) {
@@ -552,7 +552,7 @@ func TestBuildAboutPage_Integration(t *testing.T) {
 		buildAboutPage(pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("About", 100*time.Millisecond), "About title should appear")
+	require.True(t, runner.WaitForText("About", uiSettleTimeout), "About title should appear")
 
 	// Verify content
 	assert.True(t, runner.ContainsText("Zaparoo Core"), "Should show Zaparoo Core")
@@ -578,7 +578,7 @@ func TestBuildAboutPage_BackNavigation_Integration(t *testing.T) {
 		buildAboutPage(pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("About", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("About", uiSettleTimeout))
 
 	// Helper to check current page
 	getFrontPage := func() string {
@@ -595,7 +595,7 @@ func TestBuildAboutPage_BackNavigation_Integration(t *testing.T) {
 
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return getFrontPage() == PageSettingsMain
-	}, 100*time.Millisecond), "Should navigate back to settings main")
+	}, uiSettleTimeout), "Should navigate back to settings main")
 }
 
 func TestExitDelayLabels(t *testing.T) {
@@ -806,7 +806,7 @@ func TestBuildBackupSettingsMenu_FastFetchSkipsLoader_Integration(t *testing.T) 
 
 	// An instant fetch renders the page directly, well inside the grace
 	// period, so the loading frame never appears.
-	require.True(t, runner.WaitForText("Back up now", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Back up now", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Loading backup status..."))
 }
 
@@ -824,7 +824,7 @@ func TestBuildBackupSettingsMenu_UnlinkedShowsCloudLinkPointer_Integration(t *te
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Back up now", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Back up now", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Local"))
 	assert.True(t, runner.ContainsText("Cloud"))
 	assert.True(t, runner.ContainsText("View backups"))
@@ -849,7 +849,7 @@ func TestBuildBackupSettingsMenu_CloudControlsVisibleWhenLinked_Integration(t *t
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Automatic backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Automatic backup", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Local"))
 	assert.True(t, runner.ContainsText("Cloud"))
 	assert.True(t, runner.ContainsText("Schedule"))
@@ -872,7 +872,7 @@ func TestBuildBackupSettingsMenu_ToggleWritesBackupRemoteEnabled_Integration(t *
 	runner.QueueUpdateDraw(func() {
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Automatic backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Automatic backup", uiSettleTimeout))
 
 	// Navigate from local "Back up now" to the cloud toggle and flip it.
 	runner.SimulateArrowDown()
@@ -890,7 +890,7 @@ func TestBuildBackupSettingsMenu_ToggleWritesBackupRemoteEnabled_Integration(t *
 			}
 		}
 		return false
-	}, 100*time.Millisecond), "toggle should write BackupRemoteEnabled")
+	}, uiSettleTimeout), "toggle should write BackupRemoteEnabled")
 }
 
 func TestBuildBackupSettingsMenu_UnavailableWarpStillAttemptsUpload_Integration(t *testing.T) {
@@ -912,7 +912,7 @@ func TestBuildBackupSettingsMenu_UnavailableWarpStillAttemptsUpload_Integration(
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Automatic backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Automatic backup", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("View backups"), "restore must remain available")
 	// Local: Back up now, View backups; Cloud: Automatic backup, Schedule,
 	// Back up now. Four downs land on the cloud upload action.
@@ -920,12 +920,12 @@ func TestBuildBackupSettingsMenu_UnavailableWarpStillAttemptsUpload_Integration(
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
-	require.True(t, runner.WaitForText("Warp is required", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Warp is required", uiSettleTimeout))
 	// The cached "unavailable" value is only a hint: pressing the action
 	// must still attempt the upload, whose fresh server-side check is
 	// authoritative (a just-activated subscription works immediately).
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("requires an active Zaparoo Warp subscription", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("requires an active Zaparoo Warp subscription", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "RunRemoteBackup", mock.Anything)
 }
 
@@ -947,13 +947,13 @@ func TestBuildBackupSettingsMenu_BackupNowCallsService_Integration(t *testing.T)
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Back up now", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Back up now", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Creating backup", 500*time.Millisecond))
-	require.True(t, runner.WaitForText("Elapsed:", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Creating backup", uiSettleTimeout))
+	require.True(t, runner.WaitForText("Elapsed:", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Hide"), "progress modal must not offer a Hide button")
 	release <- time.Now()
-	require.True(t, runner.WaitForText("Backup created", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Backup created", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "CreateBackup", mock.Anything)
 }
 
@@ -973,9 +973,9 @@ func TestBuildBackupSettingsMenu_BackupErrorShowsSafeGuidance_Integration(t *tes
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Back up now", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Back up now", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Stop active media", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Stop active media", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("/private/path"))
 }
 
@@ -1000,7 +1000,7 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 		buildBackupSettingsMenu(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Automatic backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Automatic backup", uiSettleTimeout))
 	// Local: Back up now, View backups; Cloud: Automatic backup, Schedule,
 	// Back up now. Four downs land on the cloud upload action.
 	runner.SimulateArrowDown()
@@ -1008,7 +1008,7 @@ func TestBuildBackupSettingsMenu_RemoteBackupNowCallsService_Integration(t *test
 	runner.SimulateArrowDown()
 	runner.SimulateArrowDown()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("This device is already backed up.", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("This device is already backed up.", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Cloud backup"))
 	assert.False(t, runner.ContainsText("Cloud backup created"))
 	assert.True(t, runner.ContainsText("Snapshot: 2026-07-10 12:00:00 UTC"))
@@ -1041,7 +1041,7 @@ func TestWaitForCoreRestart_DownThenUp_Integration(t *testing.T) {
 			10*time.Millisecond, time.Minute, time.Minute, func() { close(done) })
 	})
 
-	require.True(t, runner.WaitForText("Core is restarting.", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Core is restarting.", uiSettleTimeout))
 	releaseFirstPoll <- struct{}{}
 	require.True(t, runner.WaitForText("Core restarted", time.Second))
 	assert.False(t, runner.ContainsText("Core is restarting."))
@@ -1099,7 +1099,7 @@ func TestBuildBackupListPage_DisplaysBackups_Integration(t *testing.T) {
 		buildBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", uiSettleTimeout))
 	pageName, primitive := pages.GetFrontPage()
 	require.Equal(t, PageSettingsBackupList, pageName)
 	frame, ok := primitive.(*PageFrame)
@@ -1143,14 +1143,14 @@ func TestBuildBackupListPage_SelectShowsDetailsModal_Integration(t *testing.T) {
 		buildBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Backup details", 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Size: 2 KB", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Backup details", uiSettleTimeout))
+	require.True(t, runner.WaitForText("Size: 2 KB", uiSettleTimeout))
 	assert.False(t, runner.ContainsText("Payload integrity"))
-	require.True(t, runner.WaitForText("Manifest:", 100*time.Millisecond))
-	require.True(t, runner.WaitForText("Zaparoo", 100*time.Millisecond), runner.GetScreenText())
-	require.True(t, runner.WaitForText("Settings", 100*time.Millisecond), runner.GetScreenText())
+	require.True(t, runner.WaitForText("Manifest:", uiSettleTimeout))
+	require.True(t, runner.WaitForText("Zaparoo", uiSettleTimeout), runner.GetScreenText())
+	require.True(t, runner.WaitForText("Settings", uiSettleTimeout), runner.GetScreenText())
 }
 
 func TestBuildBackupListPage_InspectFailureDisablesRestore_Integration(t *testing.T) {
@@ -1174,10 +1174,10 @@ func TestBuildBackupListPage_InspectFailureDisablesRestore_Integration(t *testin
 		buildBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Unable", 500*time.Millisecond), runner.GetScreenText())
-	require.True(t, runner.WaitForText("disabled", 100*time.Millisecond), runner.GetScreenText())
+	require.True(t, runner.WaitForText("Unable", uiSettleTimeout), runner.GetScreenText())
+	require.True(t, runner.WaitForText("disabled", uiSettleTimeout), runner.GetScreenText())
 	mockSvc.AssertNotCalled(t, "RestoreBackup", mock.Anything, backupName)
 }
 
@@ -1210,14 +1210,14 @@ func TestBackupDetailsModal_DeleteCallsService_Integration(t *testing.T) {
 		buildBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Local backup 2026-06-24 15:04:05 UTC", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Backup details", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Backup details", uiSettleTimeout))
 	runner.SimulateTab()
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Delete Local backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Delete Local backup", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Backup deleted", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Backup deleted", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "DeleteBackup", mock.Anything, backupName)
 }
 
@@ -1238,10 +1238,10 @@ func TestShowBackupRestoreConfirm_CallsService_Integration(t *testing.T) {
 		showBackupRestoreConfirm(mockSvc, pages, runner.App(), focus, backupName, nil)
 	})
 
-	require.True(t, runner.WaitForText("Restore Local backup", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Restore Local backup", uiSettleTimeout))
 	runner.Screen().InjectEnter()
 	runner.Draw()
-	require.True(t, runner.WaitForText("Backup restored", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Backup restored", uiSettleTimeout))
 	mockSvc.AssertCalled(t, "RestoreBackup", mock.Anything, backupName)
 }
 
@@ -1266,7 +1266,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingVisible_Integration(t *testing.
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond), "Advanced title should appear")
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout), "Advanced title should appear")
 
 	// Verify error reporting toggle is visible
 	assert.True(t, runner.ContainsText("Error reporting"), "Error reporting toggle should be visible")
@@ -1293,7 +1293,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingShowsConfirmModal_Integration(t
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout))
 
 	// Navigate to error reporting (fourth item)
 	runner.SimulateArrowDown() // to reload Core
@@ -1304,7 +1304,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingShowsConfirmModal_Integration(t
 	runner.SimulateEnter()
 
 	// Should show confirmation modal with Sentry mention
-	assert.True(t, runner.WaitForText("Sentry", 100*time.Millisecond),
+	assert.True(t, runner.WaitForText("Sentry", uiSettleTimeout),
 		"Confirmation modal should mention Sentry")
 }
 
@@ -1329,7 +1329,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingCancelDoesNotEnable_Integration
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout))
 
 	// Navigate to error reporting
 	runner.SimulateArrowDown() // to reload Core
@@ -1338,7 +1338,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingCancelDoesNotEnable_Integration
 
 	// Toggle error reporting - shows modal
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Sentry", 100*time.Millisecond), "Modal should appear")
+	require.True(t, runner.WaitForText("Sentry", uiSettleTimeout), "Modal should appear")
 
 	// Press Escape to cancel
 	runner.SimulateEscape()
@@ -1373,7 +1373,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingConfirmEnables_Integration(t *t
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout))
 
 	// Navigate to error reporting
 	runner.SimulateArrowDown() // to reload Core
@@ -1382,18 +1382,18 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingConfirmEnables_Integration(t *t
 
 	// Toggle error reporting - shows modal
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Sentry", 100*time.Millisecond), "Modal should appear")
+	require.True(t, runner.WaitForText("Sentry", uiSettleTimeout), "Modal should appear")
 
 	// Press Enter to confirm (Yes is the default focused button)
 	runner.SimulateEnter()
 
 	// Wait for UpdateSettings to be called
 	called := mockSvc.UpdateSettingsCalled()
-	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond),
+	assert.True(t, runner.WaitForSignal(called, uiSettleTimeout),
 		"UpdateSettings should be called when user confirms")
 
 	// Verify the toggle is now visually checked
-	assert.True(t, runner.WaitForText("[*]", 100*time.Millisecond),
+	assert.True(t, runner.WaitForText("[*]", uiSettleTimeout),
 		"Toggle should show as checked after confirming")
 }
 
@@ -1418,7 +1418,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingDisableNoConfirm_Integration(t 
 		buildAdvancedSettingsMenu(mockSvc, pages, runner.App())
 	})
 
-	require.True(t, runner.WaitForText("Advanced", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Advanced", uiSettleTimeout))
 
 	// Navigate to error reporting
 	runner.SimulateArrowDown() // to reload Core
@@ -1430,7 +1430,7 @@ func TestBuildAdvancedSettingsMenu_ErrorReportingDisableNoConfirm_Integration(t 
 
 	// UpdateSettings should be called immediately (no confirm modal for disable)
 	called := mockSvc.UpdateSettingsCalled()
-	assert.True(t, runner.WaitForSignal(called, 100*time.Millisecond),
+	assert.True(t, runner.WaitForSignal(called, uiSettleTimeout),
 		"UpdateSettings should be called immediately when disabling")
 
 	// Verify no modal appeared (no "Sentry" text visible)
@@ -1531,7 +1531,7 @@ func TestRemoteBackupListPage_GroupsSources_Integration(t *testing.T) {
 		buildRemoteBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("Living Room (this device)", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Living Room (this device)", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Old MiSTer (unlinked)"))
 	assert.True(t, runner.ContainsText("2 backups"), "current device merges the legacy snapshot")
 	assert.True(t, runner.ContainsText("1 backup"))
@@ -1539,7 +1539,7 @@ func TestRemoteBackupListPage_GroupsSources_Integration(t *testing.T) {
 
 	// Open the first of multiple groups to exercise its captured callback.
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 14:00:00 UTC", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 14:00:00 UTC", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Cloud backup 2026-07-10 13:00:00 UTC"))
 	assert.False(t, runner.ContainsText("Cloud backup 2026-07-10 12:00:00 UTC"))
 	assert.False(t, runner.ContainsText("Old MiSTer (unlinked)"))
@@ -1559,7 +1559,7 @@ func TestRemoteBackupListPage_Empty_Integration(t *testing.T) {
 		buildRemoteBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
 
-	require.True(t, runner.WaitForText("(no cloud backups found)", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("(no cloud backups found)", uiSettleTimeout))
 }
 
 func TestRemoteBackupSnapshotsPage_ShowsTypeAndSize_Integration(t *testing.T) {
@@ -1581,10 +1581,10 @@ func TestRemoteBackupSnapshotsPage_ShowsTypeAndSize_Integration(t *testing.T) {
 	runner.QueueUpdateDraw(func() {
 		buildRemoteBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("This device", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("This device", uiSettleTimeout))
 
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 13:00:00 UTC", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 13:00:00 UTC", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Cloud backup 2026-07-10 12:00:00 UTC"))
 	assert.True(t, runner.ContainsText("Manual"))
 	assert.True(t, runner.ContainsText("Scheduled"))
@@ -1619,12 +1619,12 @@ func TestRemoteBackupSnapshotsPage_IncompatibleCannotRestore_Integration(t *test
 	runner.QueueUpdateDraw(func() {
 		buildRemoteBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("This device", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("This device", uiSettleTimeout))
 
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("requires newer Core", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("requires newer Core", uiSettleTimeout))
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Incompatible backup", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Incompatible backup", uiSettleTimeout))
 	runner.SimulateEnter()
 	mockSvc.AssertNotCalled(t, "RestoreRemoteBackup", mock.Anything, mock.Anything)
 }
@@ -1646,13 +1646,13 @@ func TestRemoteBackupRestoreConfirm_WordingAndRestore_Integration(t *testing.T) 
 	runner.QueueUpdateDraw(func() {
 		buildRemoteBackupListPage(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("Old MiSTer (unlinked)", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Old MiSTer (unlinked)", uiSettleTimeout))
 
 	runner.SimulateEnter()
-	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 12:00:00 UTC", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Cloud backup 2026-07-10 12:00:00 UTC", uiSettleTimeout))
 	runner.SimulateEnter()
 
-	require.True(t, runner.WaitForText("Restore backup from Old MiSTer (unlinked)?", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("Restore backup from Old MiSTer (unlinked)?", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Snapshot: 2026-07-10 12:00:00 UTC"))
 	assert.True(t, runner.ContainsText("Overwrites: Zaparoo, Saves"))
 	assert.True(t, runner.ContainsText("The source backup is not changed."))
@@ -1716,7 +1716,7 @@ func TestStartAuthLinkFlow_SuccessMentionsCloudBackups_Integration(t *testing.T)
 	runner.QueueUpdateDraw(func() {
 		startAuthLinkFlow(mockSvc, pages, runner.App(), func() {})
 	})
-	require.True(t, runner.WaitForText("ABCD-1234", 500*time.Millisecond))
+	require.True(t, runner.WaitForText("ABCD-1234", uiSettleTimeout))
 
 	// The poll loop ticks every 2 seconds before observing approval.
 	require.True(t, runner.WaitForText("Device linked", 5*time.Second))

--- a/pkg/ui/tui/test_runner_test.go
+++ b/pkg/ui/tui/test_runner_test.go
@@ -198,6 +198,19 @@ func (r *TestAppRunner) RunError() error {
 }
 
 // WaitForCondition waits for a condition to be true, with a timeout.
+// uiSettleTimeout is how long the WaitFor* helpers keep polling before they give
+// up. It is only ever paid by a failing assertion: WaitForCondition polls every
+// 5ms and returns the moment the condition holds, so a generous value costs a
+// passing test nothing.
+//
+// The previous 100ms and 500ms deadlines were tight enough that a loaded machine
+// could miss a redraw that was on its way — `go test -race ./pkg/...` failed
+// TestShowBackupRestoreConfirm_CallsService_Integration and
+// TestBuildAdvancedSettingsMenu_ReloadCore_Integration this way, both passing on
+// their own. A deadline is not the right place to encode how quickly the UI
+// ought to react; assert on what the screen shows instead.
+const uiSettleTimeout = 5 * time.Second
+
 func (*TestAppRunner) WaitForCondition(condition func() bool, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/pkg/ui/tui/utils_test.go
+++ b/pkg/ui/tui/utils_test.go
@@ -606,7 +606,7 @@ func TestShowInfoModal_Integration(t *testing.T) {
 	})
 
 	// Verify modal is shown
-	require.True(t, runner.WaitForText("This is information", 500*time.Millisecond), "Modal message should appear")
+	require.True(t, runner.WaitForText("This is information", uiSettleTimeout), "Modal message should appear")
 	assert.True(t, runner.ContainsText("OK"), "OK button should be visible")
 }
 
@@ -633,14 +633,14 @@ func TestShowInfoModal_OnDismissCallback(t *testing.T) {
 	})
 
 	// Verify modal is shown
-	require.True(t, runner.WaitForText("Test message", 500*time.Millisecond), "Modal message should appear")
+	require.True(t, runner.WaitForText("Test message", uiSettleTimeout), "Modal message should appear")
 
 	// Press Enter to dismiss
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
 	// Verify callback was invoked
-	assert.True(t, runner.WaitForSignal(dismissCalled, 500*time.Millisecond), "onDismiss callback should be invoked")
+	assert.True(t, runner.WaitForSignal(dismissCalled, uiSettleTimeout), "onDismiss callback should be invoked")
 }
 
 func TestShowErrorModal_Integration(t *testing.T) {
@@ -666,14 +666,14 @@ func TestShowErrorModal_Integration(t *testing.T) {
 	})
 
 	// Verify modal is shown
-	require.True(t, runner.WaitForText("Something went wrong", 100*time.Millisecond), "Error message should appear")
+	require.True(t, runner.WaitForText("Something went wrong", uiSettleTimeout), "Error message should appear")
 	assert.True(t, runner.ContainsText("OK"), "OK button should be visible")
 
 	// Dismiss the modal
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(dismissCalled, 100*time.Millisecond), "Dismiss callback should be called")
+	assert.True(t, runner.WaitForSignal(dismissCalled, uiSettleTimeout), "Dismiss callback should be called")
 }
 
 func TestShowConfirmModal_Integration(t *testing.T) {
@@ -701,7 +701,7 @@ func TestShowConfirmModal_Integration(t *testing.T) {
 	})
 
 	// Verify modal is shown
-	require.True(t, runner.WaitForText("Are you sure?", 100*time.Millisecond), "Confirm message should appear")
+	require.True(t, runner.WaitForText("Are you sure?", uiSettleTimeout), "Confirm message should appear")
 	assert.True(t, runner.ContainsText("Yes"), "Yes button should be visible")
 	assert.True(t, runner.ContainsText("No"), "No button should be visible")
 
@@ -709,7 +709,7 @@ func TestShowConfirmModal_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(yesCalled, 100*time.Millisecond), "Yes callback should be called")
+	assert.True(t, runner.WaitForSignal(yesCalled, uiSettleTimeout), "Yes callback should be called")
 
 	// Check that No was not called (use very short timeout since we just want to verify it wasn't triggered)
 	select {
@@ -744,7 +744,7 @@ func TestShowConfirmModal_No_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Are you sure?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Are you sure?", uiSettleTimeout))
 
 	// Navigate to No button and click
 	runner.Screen().InjectTab()
@@ -752,7 +752,7 @@ func TestShowConfirmModal_No_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(noCalled, 100*time.Millisecond), "No callback should be called")
+	assert.True(t, runner.WaitForSignal(noCalled, uiSettleTimeout), "No callback should be called")
 
 	// Check that Yes was not called
 	select {
@@ -787,7 +787,7 @@ func TestShowWaitingModal_Integration(t *testing.T) {
 	})
 
 	// Verify modal is shown
-	require.True(t, runner.WaitForText("Please wait...", 100*time.Millisecond), "Waiting message should appear")
+	require.True(t, runner.WaitForText("Please wait...", uiSettleTimeout), "Waiting message should appear")
 	assert.True(t, runner.ContainsText("Cancel"), "Cancel button should be visible")
 	require.NotNil(t, cleanup)
 
@@ -840,7 +840,7 @@ func TestShowOSKModal_Integration(t *testing.T) {
 	runner.Screen().InjectEscape()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(cancelCalled, 100*time.Millisecond), "Cancel callback should be called")
+	assert.True(t, runner.WaitForSignal(cancelCalled, uiSettleTimeout), "Cancel callback should be called")
 }
 
 func TestShowErrorReportingPrompt_Enable_Integration(t *testing.T) {
@@ -868,7 +868,7 @@ func TestShowErrorReportingPrompt_Enable_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Help improve Zaparoo?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Help improve Zaparoo?", uiSettleTimeout))
 	assert.True(t, runner.ContainsText("Enable"))
 	assert.True(t, runner.ContainsText("Not Now"))
 
@@ -876,7 +876,7 @@ func TestShowErrorReportingPrompt_Enable_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(enableCalled, 100*time.Millisecond), "Enable callback should be called")
+	assert.True(t, runner.WaitForSignal(enableCalled, uiSettleTimeout), "Enable callback should be called")
 
 	select {
 	case <-notNowCalled:
@@ -910,7 +910,7 @@ func TestShowErrorReportingPrompt_NotNow_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Help improve Zaparoo?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Help improve Zaparoo?", uiSettleTimeout))
 
 	// Tab to "Not Now" and press Enter
 	runner.Screen().InjectTab()
@@ -918,7 +918,7 @@ func TestShowErrorReportingPrompt_NotNow_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(notNowCalled, 100*time.Millisecond), "Not Now callback should be called")
+	assert.True(t, runner.WaitForSignal(notNowCalled, uiSettleTimeout), "Not Now callback should be called")
 }
 
 func TestShowErrorReportingPrompt_DontAsk_Integration(t *testing.T) {
@@ -944,7 +944,7 @@ func TestShowErrorReportingPrompt_DontAsk_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Help improve Zaparoo?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Help improve Zaparoo?", uiSettleTimeout))
 
 	// Tab twice to "Don't Ask Again" and press Enter
 	runner.Screen().InjectTab()
@@ -954,7 +954,7 @@ func TestShowErrorReportingPrompt_DontAsk_Integration(t *testing.T) {
 	runner.Screen().InjectEnter()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(dontAskCalled, 100*time.Millisecond),
+	assert.True(t, runner.WaitForSignal(dontAskCalled, uiSettleTimeout),
 		"Don't Ask Again callback should be called")
 }
 
@@ -982,13 +982,13 @@ func TestShowErrorReportingPrompt_Escape_Integration(t *testing.T) {
 		)
 	})
 
-	require.True(t, runner.WaitForText("Help improve Zaparoo?", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Help improve Zaparoo?", uiSettleTimeout))
 
 	// Press Escape — should trigger Not Now, not Don't Ask Again
 	runner.Screen().InjectEscape()
 	runner.Draw()
 
-	assert.True(t, runner.WaitForSignal(notNowCalled, 100*time.Millisecond), "Escape should trigger Not Now callback")
+	assert.True(t, runner.WaitForSignal(notNowCalled, uiSettleTimeout), "Escape should trigger Not Now callback")
 
 	select {
 	case <-dontAskCalled:

--- a/pkg/ui/tui/writetag_test.go
+++ b/pkg/ui/tui/writetag_test.go
@@ -21,7 +21,6 @@ package tui
 
 import (
 	"testing"
-	"time"
 
 	"github.com/rivo/tview"
 	"github.com/stretchr/testify/assert"
@@ -115,7 +114,7 @@ func TestBuildTagsWriteMenu_Integration(t *testing.T) {
 		BuildTagsWriteMenu(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Write Token", 100*time.Millisecond), "Write Token title should appear")
+	require.True(t, runner.WaitForText("Write Token", uiSettleTimeout), "Write Token title should appear")
 
 	// Verify UI elements are visible
 	assert.True(t, runner.ContainsText("ZapScript"), "ZapScript label should be visible")
@@ -145,7 +144,7 @@ func TestBuildTagsWriteMenu_EscapeGoesBack_Integration(t *testing.T) {
 		BuildTagsWriteMenu(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Write Token", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Write Token", uiSettleTimeout))
 
 	// Helper to get current page
 	getFrontPage := func() string {
@@ -163,7 +162,7 @@ func TestBuildTagsWriteMenu_EscapeGoesBack_Integration(t *testing.T) {
 	// Verify we went back
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return getFrontPage() == PageMain
-	}, 100*time.Millisecond), "Should navigate back to main page")
+	}, uiSettleTimeout), "Should navigate back to main page")
 }
 
 func TestBuildTagsWriteMenu_ClearButton_Integration(t *testing.T) {
@@ -188,7 +187,7 @@ func TestBuildTagsWriteMenu_ClearButton_Integration(t *testing.T) {
 		BuildTagsWriteMenu(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Write Token", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Write Token", uiSettleTimeout))
 
 	// Navigate to Clear button (Tab then right)
 	runner.Screen().InjectTab()
@@ -203,7 +202,7 @@ func TestBuildTagsWriteMenu_ClearButton_Integration(t *testing.T) {
 	// Wait for session state to be cleared
 	assert.True(t, runner.WaitForCondition(func() bool {
 		return session.GetWriteTagZapScript() == ""
-	}, 100*time.Millisecond), "ZapScript should be cleared")
+	}, uiSettleTimeout), "ZapScript should be cleared")
 }
 
 func TestBuildTagsWriteMenu_Validation_Integration(t *testing.T) {
@@ -228,7 +227,7 @@ func TestBuildTagsWriteMenu_Validation_Integration(t *testing.T) {
 		BuildTagsWriteMenu(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Write Token", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Write Token", uiSettleTimeout))
 
 	// Verify page is showing and the ZapScript label is present
 	assert.True(t, runner.ContainsText("ZapScript"), "Should show ZapScript label")
@@ -256,7 +255,7 @@ func TestBuildTagsWriteMenu_InvalidScript_Integration(t *testing.T) {
 		BuildTagsWriteMenu(mockSvc, pages, runner.App(), session)
 	})
 
-	require.True(t, runner.WaitForText("Write Token", 100*time.Millisecond))
+	require.True(t, runner.WaitForText("Write Token", uiSettleTimeout))
 
 	// Verify page shows properly
 	assert.True(t, runner.ContainsText("ZapScript"), "Should show ZapScript label")


### PR DESCRIPTION
Indexing work from the #1279 investigation, measured on a MiSTer with 229,553 media across 130 systems on SD.

Six commits, each of which builds and passes its own package tests independently.

## What changed

**Reconcile** — the media upsert is chunked by `ScanStage.Path`; as one statement it showed super-linear cost, and chunking bounds Media's per-statement index maintenance. `CROSS JOIN` pins the join order, because the planner otherwise drove it from `MediaTitles` and rescanned the whole system's titles per chunk. Steps that reconcile against pre-existing state are skipped when reconcile created the system row; three of them are no-ops for reasons other than "their inputs are empty", so each skip carries its own justification at the site.

**Write path** — drops `media_system_path_idx`. It duplicated the index SQLite already maintains for `Media`'s `UNIQUE(SystemDBID, Path)` (same columns, same order), doubling b-tree maintenance on the hottest write path for no query benefit. The three queries that need that access path now pin `sqlite_autoindex_Media_1`, which produces an identical plan.

**WAL** — automatic checkpointing is now disabled during indexing on every platform, not just constrained ones: automatic checkpoints running inside `tx.Commit` at the previous constrained threshold produced worse stalls than the problem they were meant to fix (29.5 s vs 16.6 s), while the explicit checkpoint never fired because its threshold was unreachable. `mediaWALCheckpointThreshold` drops from 96 MiB to 8 MiB so it becomes the sole deliberate, logged checkpoint. On device it fires on larger systems and never on the long tail of small ones.

**Planner statistics** — refreshed at system boundaries rather than once per run, with the analysis-limit bit set on `PRAGMA optimize`. The previous mask omitted it, which produced silent multi-second stalls.

**Pool pragmas** — the indexing connection boost is released before optimization is handed off rather than on the way out of the goroutine. Optimization sizes its pool drain from `MaxOpenConns`, so a pending restore made it deadlock against its own held connections until the acquire deadline fired. The connection cap is now raised before pragmas are applied rather than after; the reverse order left the extra connection opened straight from the DSN with nothing to configure it, which is why three earlier runs reported the unboosted cache size. `MaxIdleConns` is kept equal to `MaxOpenConns` so a boosted connection is not closed and silently reopened at DSN defaults, and the boost is verified across every pooled connection instead of one arbitrary sample.

**Diagnostics** — effective pragmas are read back at open for both MediaDB and UserDB, since a DSN pragma can silently fail to take and nothing reported that before. Indexing now fails up front when the media database is not in WAL mode, instead of the mid-index hang a rollback journal causes. Corrupt-file preservation is shared between MediaDB and UserDB rather than duplicated.

**Unrelated cleanups that were in the same tree** — the `/proc/self/mountinfo` parser existed twice (mister's bind-mount ownership and indexing storage diagnostics), with `unescapeMountField` byte-identical between them; it is now one implementation in `pkg/helpers`, split so the format parsing is portable and only the procfs read is build-tagged. Two regexes in the filename parser now skip their pass when the input lacks the one byte the pattern cannot match without.

## Two things worth knowing before reviewing

**The cache-size boost's value is unmeasured.** Round 11 was the first run where it reached every pooled connection, and its optimization phase matched the previous run to within 0.03% — but that previous run was not an unboosted control (two of its three connections carried the boost; only the third came up at DSN defaults). So the comparison settles nothing. The race fix is justified independently — it removed a real ~5 s stall at the indexing/optimization handoff — but nothing here demonstrates the boost itself buys time. `SetIndexingCacheSize` says so in the code so it is not re-litigated from bad evidence. Getting a real answer needs a deliberate boost-off run, and it also has to separate `cache_size` from `temp_store`, since the one switch moves both.

**`stat1_seed_data.go` carries drift that is not from this change.** It is regenerated with its documented generator. Besides dropping the removed index and bumping the goose version, it picks up canonical tag seed changes that accumulated since it was last regenerated — `Tags` 1219 → 1220, `TagTypes` 49 → 50, and a `DBConfig` row count of 2 rather than 3. The file had simply gone stale; those values are what the generator produces against the current tree.

## Testing

`task lint`, `task cross-lint:all` (Windows and macOS) and `task test` (full suite, race detection) all clean.

Also fixes a pre-existing flaky test: five tests in `concurrent_operations_test.go` ran goroutines against a `sqlmock` that serves exactly one connection, with the pool left unbounded — so `database/sql` would try to open a second connection that sqlmock refuses. `TestRaceConditionBetweenStatusAndOptimization` failed roughly one run in five; the other four carried the same latent failure without having surfaced it.

The reconcile cost that remains is tracked in #1317, which now has the per-step measurements and a design proposal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved media indexing, database commits, browse-cache refreshes, and searches for large libraries.
  * Reduced delays when browsing or reading data during indexing and other database activity.

* **Reliability**
  * Improved recovery by preserving corrupted database files and related recovery data.
  * Strengthened handling of concurrent operations, transactions, and database checkpoints.

* **Diagnostics**
  * Added clearer timing and database health information to support troubleshooting.

* **Bug Fixes**
  * Fixed browse-cache consistency, stale references, foreign-key restoration, and searches during re-indexing.
  * Improved detection of incompatible database configurations and startup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->