### PR TITLE
perf(mediadb): serve merged browse root directories from the browse cache

### DIFF
--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -519,6 +519,14 @@ func browseSystemRootContents(
 	}
 	sources, virtualEntries := systemRootContentsSources(env, rootEntries)
 	overlay := &database.BrowseOverlay{Sources: sources}
+	// The merged root is the launcher's first screen for every system, but it was
+	// the only browse path emitting no per-query timing, so a slow one showed up
+	// only as an anonymous mediadb "browse call timing" line. Report the first
+	// route as the path: the rest are on the same line via routes.
+	overlayPath := ""
+	if len(sources) > 0 {
+		overlayPath = sources[0].PathPrefix
+	}
 	if cursor != nil {
 		virtualEntries = nil
 	}
@@ -537,20 +545,24 @@ func browseSystemRootContents(
 		if cursor != nil {
 			afterName = cursor.DirName
 		}
+		started := time.Now()
 		dirs, dirsErr := env.Database.MediaDB.BrowseDirectories(env.Context, database.BrowseDirectoriesOptions{
 			Overlay:   overlay,
 			AfterName: afterName,
 			Systems:   systems,
 			Limit:     maxResults + 1,
 		})
+		logBrowseTiming("root_contents_directories", overlayPath, started, len(dirs))
 		if dirsErr != nil {
 			return nil, fmt.Errorf("error browsing system root contents directories: %w", dirsErr)
 		}
 		if cursor == nil {
+			started = time.Now()
 			totalDirs, err = env.Database.MediaDB.BrowseDirCount(env.Context, database.BrowseDirCountOptions{
 				Overlay: overlay,
 				Systems: systems,
 			})
+			logBrowseTiming("root_contents_dir_count", overlayPath, started, totalDirs)
 			if err != nil {
 				return nil, fmt.Errorf("error counting system root contents directories: %w", err)
 			}
@@ -588,6 +600,7 @@ func browseSystemRootContents(
 				env, dirs, nil, virtualEntries, maxResults, totalFiles, totalDirs, next, hasNext, systems, tags,
 			)
 		}
+		started = time.Now()
 		files, filesErr := env.Database.MediaDB.BrowseFiles(env.Context, &database.BrowseFilesOptions{
 			Overlay: overlay,
 			Limit:   remaining + 1,
@@ -595,6 +608,7 @@ func browseSystemRootContents(
 			Systems: systems,
 			Tags:    tags,
 		})
+		logBrowseTiming("root_contents_files", overlayPath, started, len(files))
 		if filesErr != nil {
 			return nil, fmt.Errorf("error browsing system root contents files: %w", filesErr)
 		}
@@ -613,6 +627,7 @@ func browseSystemRootContents(
 	if cursor != nil && cursor.Phase == browsePhaseFiles && cursor.LastID == 0 {
 		fileCursor = nil
 	}
+	filesStarted := time.Now()
 	files, filesErr := env.Database.MediaDB.BrowseFiles(env.Context, &database.BrowseFilesOptions{
 		Overlay: overlay,
 		Cursor:  fileCursor,
@@ -622,6 +637,7 @@ func browseSystemRootContents(
 		Systems: systems,
 		Tags:    tags,
 	})
+	logBrowseTiming("root_contents_files", overlayPath, filesStarted, len(files))
 	if filesErr != nil {
 		return nil, fmt.Errorf("error browsing system root contents files: %w", filesErr)
 	}
@@ -649,12 +665,18 @@ func browseRootContentsFileCount(
 	systems []systemdefs.System,
 	tags []zapscript.TagFilter,
 ) (int, error) {
+	started := time.Now()
 	count, err := env.Database.MediaDB.BrowseFileCount(env.Context, database.BrowseFileCountOptions{
 		Overlay: &database.BrowseOverlay{Sources: sources},
 		Letter:  letter,
 		Systems: systems,
 		Tags:    tags,
 	})
+	prefix := ""
+	if len(sources) > 0 {
+		prefix = sources[0].PathPrefix
+	}
+	logBrowseTiming("root_contents_file_count", prefix, started, count)
 	if err != nil {
 		return 0, fmt.Errorf("error counting system root contents files: %w", err)
 	}

--- a/pkg/database/mediadb/browse_overlay_plan_test.go
+++ b/pkg/database/mediadb/browse_overlay_plan_test.go
@@ -21,6 +21,7 @@ package mediadb
 
 import (
 	"context"
+	"path"
 	"strings"
 	"testing"
 
@@ -139,4 +140,80 @@ func seedAnalysisLimitedStats(ctx context.Context, t *testing.T, mediaDB *MediaD
 	// The planner caches sqlite_stat1 per connection; force a reload.
 	_, err = sqlDB.ExecContext(ctx, "ANALYZE sqlite_master")
 	require.NoError(t, err)
+}
+
+// TestBrowseOverlayDirectoriesPlan_UsesCacheIndexes pins the plan of the
+// cache-backed merged directory listing.
+//
+// The cost this change removes is a Media prefix range scan per route
+// (m.Path >= parent_dir ...), which reads every row beneath the route. The
+// replacement must reach BrowseDirCounts by ParentDirDBID and touch Media only
+// for the direct-file shadow check, which is a ParentDir equality lookup.
+// Asserting the plan rather than a duration: at fixture scale either shape
+// finishes instantly, but the wrong one shows up in the plan immediately.
+func TestBrowseOverlayDirectoriesPlan_UsesCacheIndexes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mediaDB, cleanup := setupBrowsePlanTestDB(t)
+	defer cleanup()
+
+	parentDir := seedBrowsePlanTestDB(t, mediaDB, 200)
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	seedAnalysisLimitedStats(ctx, t, mediaDB)
+
+	root := path.Dir(strings.TrimSuffix(parentDir, "/")) + "/"
+	sources := []database.BrowseSource{
+		{PathPrefix: root, IncludeDirs: true},
+		{PathPrefix: parentDir, IncludeDirs: true},
+	}
+	opts := database.BrowseDirectoriesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+	}
+	parentIDs, usable, err := browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, nil)
+	require.NoError(t, err)
+	require.True(t, usable, "the fixture must leave the cache serving this listing")
+
+	mediaQuery, mediaArgs := browseOverlayDirectoriesMediaQuery(opts)
+	mediaPlan := browseQueryPlan(ctx, t, mediaDB, mediaQuery, mediaArgs)
+	t.Logf("fallback EXPLAIN QUERY PLAN:\n%s", mediaPlan)
+	// Pinning the fallback's shape first is what gives the assertion below its
+	// meaning: "Path>" is the range scan over every row beneath a route, and
+	// asserting its absence only says something because it is present here.
+	require.Contains(t, mediaPlan, "Path>",
+		"the fallback is expected to range-scan Media by path; plan:\n%s", mediaPlan)
+
+	query, args := browseOverlayDirectoriesCacheQuery(opts, sources, parentIDs)
+	plan := browseQueryPlan(ctx, t, mediaDB, query, args)
+	t.Logf("cache EXPLAIN QUERY PLAN:\n%s", plan)
+
+	assert.Contains(t, plan, "BrowseDirCounts",
+		"the candidate directories must come from the browse cache; plan:\n%s", plan)
+	assert.NotContains(t, plan, "Path>",
+		"a Path range scan means the listing is still reading every media row "+
+			"beneath each route, which is the cost this path exists to avoid; plan:\n%s", plan)
+	assert.Contains(t, plan, "ParentDir=?",
+		"Media may still be read for the direct-file shadow check, but only as an "+
+			"equality lookup on ParentDir; plan:\n%s", plan)
+}
+
+// browseQueryPlan returns the joined EXPLAIN QUERY PLAN lines for a statement.
+func browseQueryPlan(
+	ctx context.Context, t *testing.T, mediaDB *MediaDB, query string, args []any,
+) string {
+	t.Helper()
+
+	rows, err := mediaDB.sql.Load().QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var lines []string
+	for rows.Next() {
+		var id, parent, notUsed int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+		lines = append(lines, detail)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(lines, "\n")
 }

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -588,21 +588,192 @@ func sqlBrowseDirectories(
 	return sqlBrowseDirectoriesFromMediaFallback(ctx, db, opts)
 }
 
+// browseOverlayDirectFilesCTE names the files sitting directly in each route, so
+// a directory can be dropped when a higher-priority route already provides that
+// name as a file. Shared by both overlay directory statements; the caller
+// appends the system filter's args when systemClause is non-empty.
+func browseOverlayDirectFilesCTE(systemClause string) string {
+	query := `direct_files AS (
+			SELECT sources.priority,
+				substr(m.Path, length(m.ParentDir) + 1) AS name
+			FROM sources
+			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
+			INNER JOIN Systems s ON m.SystemDBID = s.DBID
+			WHERE m.IsMissing = 0`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+	}
+	return query + `
+		)`
+}
+
+// browseOverlayDirectoryTail collapses the candidate directories to one entry
+// per name, letting the highest-priority route win, and drops any shadowed by a
+// higher-priority route's direct file. Identical for both statements: only the
+// directory_candidates CTE above it differs between them.
+const browseOverlayDirectoryTail = `ranked AS (
+			SELECT directory_candidates.*,
+				ROW_NUMBER() OVER (PARTITION BY name ORDER BY priority ASC) AS source_rank
+			FROM directory_candidates
+			WHERE NOT EXISTS (
+				SELECT 1 FROM direct_files
+				WHERE direct_files.priority < directory_candidates.priority
+					AND direct_files.name = directory_candidates.name
+			)
+		)
+		SELECT name, file_count, system_ids, parent_dir || name
+		FROM ranked
+		WHERE source_rank = 1`
+
+// sqlBrowseOverlayDirectories lists the merged immediate subdirectories of an
+// overlay's routes, preferring the browse cache and falling back to Media.
+//
+// The overlay branch used to go straight to Media while every other browse entry
+// point routed through the cache. Recomputing a route's child directories means
+// scanning every media row beneath it: on the #1279 device database that is
+// 66,011 rows for C64, and BrowseDirCount runs the same statement a second time
+// per page just to take len(dirs). BrowseDirCounts already holds those names and
+// counts, built from the same IsMissing = 0 rows, so the two agree by
+// construction.
 func sqlBrowseOverlayDirectories(
 	ctx context.Context,
 	db sqlQueryable,
 	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
 	sources := browseOverlaySources(opts.Overlay)
+	parentIDs, usable, err := browseOverlayCacheParents(ctx, db, sources, opts.Systems)
+	if err != nil {
+		return nil, err
+	}
+	if usable {
+		return sqlBrowseOverlayDirectoriesFromCache(ctx, db, opts, sources, parentIDs)
+	}
+	return sqlBrowseOverlayDirectoriesFromMedia(ctx, db, opts)
+}
+
+// browseOverlayCacheParents resolves each directory-contributing route to its
+// BrowseDirs row and reports whether the cache can answer the listing.
+//
+// A route missing from BrowseDirs does not mean "this route has no
+// subdirectories" — it means the cache has never seen that path, and serving
+// from it would silently drop directories Media still holds. Any such route
+// sends the whole statement to the fallback, matching how
+// sqlBrowseDirectories treats a parent it cannot find.
+func browseOverlayCacheParents(
+	ctx context.Context,
+	db sqlQueryable,
+	sources []database.BrowseSource,
+	systems []systemdefs.System,
+) (parentIDs []int64, usable bool, err error) {
+	ready, err := sqlBrowseCacheReady(ctx, db)
+	if err != nil || !ready {
+		return nil, false, err
+	}
+	covered, err := sqlBrowseCacheCoversSystems(ctx, db, systems)
+	if err != nil || !covered {
+		return nil, false, err
+	}
+
+	parentIDs = make([]int64, len(sources))
+	for i := range sources {
+		if !sources[i].IncludeDirs {
+			continue
+		}
+		id, ok, dirErr := sqlBrowseDirID(ctx, db, browseRouteCacheKey(sources[i].PathPrefix))
+		if dirErr != nil {
+			return nil, false, dirErr
+		}
+		if !ok {
+			return nil, false, nil
+		}
+		parentIDs[i] = id
+	}
+	return parentIDs, true, nil
+}
+
+func sqlBrowseOverlayDirectoriesFromCache(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+	sources []database.BrowseSource,
+	parentIDs []int64,
+) ([]database.BrowseDirectoryResult, error) {
+	query, args := browseOverlayDirectoriesCacheQuery(opts, sources, parentIDs)
+	return runBrowseOverlayDirectories(ctx, db, query, args, opts)
+}
+
+// browseOverlayDirectoriesCacheQuery builds the cache-backed statement and its
+// arguments. Separate from the exec so the query-plan regression test measures
+// the statement production actually runs rather than a copy of it, matching
+// browseOverlayFileCountQuery.
+func browseOverlayDirectoriesCacheQuery(
+	opts database.BrowseDirectoriesOptions,
+	sources []database.BrowseSource,
+	parentIDs []int64,
+) (query string, args []any) {
 	values := make([]string, len(sources))
-	args := make([]any, 0, len(sources)+16)
+	args = make([]any, 0, len(sources)*4+16)
+	for i := range sources {
+		values[i] = "(?, ?, ?, ?)"
+		args = append(args, sources[i].PathPrefix, parentIDs[i], i, sources[i].IncludeDirs)
+	}
+
+	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
+	query = `WITH sources(parent_dir, parent_id, priority, include_dirs) AS (VALUES ` +
+		strings.Join(values, ",") + `),
+		directory_candidates AS (
+			SELECT sources.parent_dir,
+				sources.priority,
+				child.Name AS name,
+				SUM(counts.FileCount) AS file_count,
+				GROUP_CONCAT(DISTINCT s.SystemID) AS system_ids
+			FROM sources
+			INNER JOIN BrowseDirCounts counts
+				ON counts.ParentDirDBID = sources.parent_id
+				-- v3 self rows are the parent's own direct-file count, not a child.
+				AND counts.ChildDirDBID != counts.ParentDirDBID
+			INNER JOIN BrowseDirs child ON child.DBID = counts.ChildDirDBID
+			INNER JOIN Systems s ON s.DBID = counts.SystemDBID
+			WHERE sources.include_dirs = 1 AND child.IsVirtual = 0`
+	if systemClause != "" {
+		query += ` AND ` + systemClause
+		args = append(args, systemArgs...)
+	}
+	query += `
+			GROUP BY sources.parent_dir, sources.priority, child.DBID, child.Name
+		), ` + browseOverlayDirectFilesCTE(systemClause)
+	if systemClause != "" {
+		args = append(args, systemArgs...)
+	}
+	return query + `, ` + browseOverlayDirectoryTail, args
+}
+
+func sqlBrowseOverlayDirectoriesFromMedia(
+	ctx context.Context,
+	db sqlQueryable,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
+	query, args := browseOverlayDirectoriesMediaQuery(opts)
+	return runBrowseOverlayDirectories(ctx, db, query, args, opts)
+}
+
+// browseOverlayDirectoriesMediaQuery builds the fallback statement, which
+// derives the child directories by scanning every media row beneath each route.
+// Factored out alongside browseOverlayDirectoriesCacheQuery so the plan test can
+// compare the two shapes.
+func browseOverlayDirectoriesMediaQuery(
+	opts database.BrowseDirectoriesOptions,
+) (query string, args []any) {
+	sources := browseOverlaySources(opts.Overlay)
+	values := make([]string, len(sources))
+	args = make([]any, 0, len(sources)*3+16)
 	for i := range sources {
 		values[i] = "(?, ?, ?)"
 		args = append(args, sources[i].PathPrefix, i, sources[i].IncludeDirs)
 	}
 
 	systemClause, systemArgs := browseSystemFilterClause("s.SystemID", opts.Systems)
-	query := `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
+	query = `WITH sources(parent_dir, priority, include_dirs) AS (VALUES ` + strings.Join(values, ",") + `),
 		matched_dirs AS (
 			SELECT sources.parent_dir,
 				sources.priority,
@@ -628,31 +799,22 @@ func sqlBrowseOverlayDirectories(
 			FROM matched_dirs
 			WHERE instr(rest, '/') > 0
 			GROUP BY parent_dir, priority, name
-		), direct_files AS (
-			SELECT sources.priority,
-				substr(m.Path, length(m.ParentDir) + 1) AS name
-			FROM sources
-			INNER JOIN Media m ON m.ParentDir = sources.parent_dir
-			INNER JOIN Systems s ON m.SystemDBID = s.DBID
-			WHERE m.IsMissing = 0`
+		), ` + browseOverlayDirectFilesCTE(systemClause)
 	if systemClause != "" {
-		query += ` AND ` + systemClause
 		args = append(args, systemArgs...)
 	}
-	query += `
-		), ranked AS (
-			SELECT directory_candidates.*,
-				ROW_NUMBER() OVER (PARTITION BY name ORDER BY priority ASC) AS source_rank
-			FROM directory_candidates
-			WHERE NOT EXISTS (
-				SELECT 1 FROM direct_files
-				WHERE direct_files.priority < directory_candidates.priority
-					AND direct_files.name = directory_candidates.name
-			)
-		)
-		SELECT name, file_count, system_ids, parent_dir || name
-		FROM ranked
-		WHERE source_rank = 1`
+	return query + `, ` + browseOverlayDirectoryTail, args
+}
+
+// runBrowseOverlayDirectories appends the paging clauses both overlay directory
+// statements end with and reads the rows.
+func runBrowseOverlayDirectories(
+	ctx context.Context,
+	db sqlQueryable,
+	query string,
+	args []any,
+	opts database.BrowseDirectoriesOptions,
+) ([]database.BrowseDirectoryResult, error) {
 	if opts.AfterName != "" {
 		query += ` AND name > ?`
 		args = append(args, opts.AfterName)

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -1619,3 +1619,297 @@ func TestBrowseOverlayFiles_FirstRootWinsByFilesystemName(t *testing.T) {
 		index.Buckets[0].Key, index.Buckets[1].Key, index.Buckets[2].Key,
 	})
 }
+
+// overlayDirsFixture seeds two overlapping routes plus a third that must
+// contribute no directories, and returns the sources in priority order.
+//
+// The shapes it covers are the ones the merged root view actually produces:
+// the same directory name under two routes (the higher-priority route wins),
+// a directory shadowed by a higher-priority route's file of the same name,
+// a directory only the lower-priority route has, and an IncludeDirs: false
+// route (an ancestor already represented by a more specific route).
+func overlayDirsFixture(t *testing.T, mediaDB *MediaDB) []database.BrowseSource {
+	t.Helper()
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	high := browseTestDir("overlay", "high")
+	low := browseTestDir("overlay", "low")
+	noDirs := browseTestDir("overlay", "nodirs")
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	insert := func(name, mediaPath string) {
+		t.Helper()
+		title, titleErr := mediaDB.InsertMediaTitle(&database.MediaTitle{
+			SystemDBID: system.DBID,
+			Slug:       slugs.Slugify(nesSystem.GetMediaType(), name+mediaPath),
+			Name:       name,
+		})
+		require.NoError(t, titleErr)
+		_, mediaErr := mediaDB.InsertMedia(database.Media{
+			SystemDBID:     system.DBID,
+			MediaTitleDBID: title.DBID,
+			Path:           mediaPath,
+			ParentDir:      filepath.ToSlash(filepath.Dir(mediaPath)) + "/",
+			SortName:       name,
+		})
+		require.NoError(t, mediaErr)
+	}
+	// Shared name: both routes have a "Both" directory, high priority wins.
+	insert("High Both", high+"Both/One.nes")
+	insert("High Both Two", high+"Both/Two.nes")
+	insert("Low Both", low+"Both/Three.nes")
+	// Shadowed: high has a file named "Shadow", low has a directory.
+	insert("Shadow File", high+"Shadow")
+	insert("Shadowed Media", low+"Shadow/Inside.nes")
+	// Only in the lower-priority route.
+	insert("Only Low", low+"OnlyLow/Inside.nes")
+	// The IncludeDirs: false route's subdirectory must never be listed.
+	insert("Excluded", noDirs+"Excluded/Inside.nes")
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	return []database.BrowseSource{
+		{PathPrefix: high, IncludeDirs: true},
+		{PathPrefix: low, IncludeDirs: true},
+		{PathPrefix: noDirs, IncludeDirs: false},
+	}
+}
+
+func nesSystemForTest(t *testing.T) []systemdefs.System {
+	t.Helper()
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+	return []systemdefs.System{*nesSystem}
+}
+
+// TestBrowseOverlayDirectories_CacheMatchesMedia is the assertion the cache
+// routing exists for: the browse cache and the Media scan must return the same
+// merged directory listing, or the merged root view changes depending on
+// whether an index has finished.
+//
+// Recomputing this from Media means scanning every row beneath every route —
+// 66,011 rows for C64 on the #1279 device database, twice per page because
+// BrowseDirCount reruns the same statement. BrowseDirCounts already holds the
+// same names and counts, built from the same IsMissing = 0 rows.
+func TestBrowseOverlayDirectories_CacheMatchesMedia(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sources := overlayDirsFixture(t, mediaDB)
+	systems := nesSystemForTest(t)
+	opts := database.BrowseDirectoriesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: systems,
+	}
+
+	_, usable, err := browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, systems)
+	require.NoError(t, err)
+	require.False(t, usable, "with no cache built the listing must come from media")
+
+	fromMedia, err := mediaDB.BrowseDirectories(ctx, opts)
+	require.NoError(t, err)
+	mediaDirCount, err := mediaDB.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+		Overlay: opts.Overlay,
+		Systems: systems,
+	})
+	require.NoError(t, err)
+
+	// The expected shape, pinned so a change in either path is visible rather
+	// than the two silently agreeing on something wrong.
+	require.Len(t, fromMedia, 2)
+	assert.Equal(t, []string{"Both", "OnlyLow"}, []string{fromMedia[0].Name, fromMedia[1].Name})
+	assert.Equal(t, 2, fromMedia[0].FileCount, "the higher-priority route's Both wins with its own count")
+	assert.Equal(t, browseTestPath("overlay", "high")+"/Both", fromMedia[0].Path)
+	assert.Equal(t, browseTestPath("overlay", "low")+"/OnlyLow", fromMedia[1].Path)
+	assert.Equal(t, 2, mediaDirCount)
+
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+
+	_, usable, err = browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, systems)
+	require.NoError(t, err)
+	require.True(t, usable, "a full rebuild must make the cache serve the listing")
+
+	fromCache, err := mediaDB.BrowseDirectories(ctx, opts)
+	require.NoError(t, err)
+	assert.Equal(t, fromMedia, fromCache)
+
+	cacheDirCount, err := mediaDB.BrowseDirCount(ctx, database.BrowseDirCountOptions{
+		Overlay: opts.Overlay,
+		Systems: systems,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, mediaDirCount, cacheDirCount)
+}
+
+// TestBrowseOverlayDirectories_CachePagesLikeMedia covers AfterName and Limit,
+// which page the merged root's directory phase.
+func TestBrowseOverlayDirectories_CachePagesLikeMedia(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sources := overlayDirsFixture(t, mediaDB)
+	systems := nesSystemForTest(t)
+	overlay := &database.BrowseOverlay{Sources: sources}
+
+	pages := func() [][]database.BrowseDirectoryResult {
+		t.Helper()
+		first, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			Overlay: overlay,
+			Systems: systems,
+			Limit:   1,
+		})
+		require.NoError(t, err)
+		require.Len(t, first, 1)
+		second, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			Overlay:   overlay,
+			Systems:   systems,
+			AfterName: first[0].Name,
+			Limit:     1,
+		})
+		require.NoError(t, err)
+		return [][]database.BrowseDirectoryResult{first, second}
+	}
+
+	fromMedia := pages()
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+	assert.Equal(t, fromMedia, pages())
+	assert.Equal(t, "Both", fromMedia[0][0].Name)
+	assert.Equal(t, "OnlyLow", fromMedia[1][0].Name)
+}
+
+// TestBrowseOverlayDirectories_FallsBackWhenCacheCannotAnswer pins the three
+// ways the cache is declined. Each must land on the media scan and return the
+// full listing: serving a partial answer would drop directories that exist.
+func TestBrowseOverlayDirectories_FallsBackWhenCacheCannotAnswer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("route missing from the cache", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := setupTempMediaDB(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		sources := overlayDirsFixture(t, mediaDB)
+		systems := nesSystemForTest(t)
+		require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+
+		// A route absent from BrowseDirs is not a route without subdirectories:
+		// the cache has never seen it, so answering from the cache would hide
+		// the directories media still holds.
+		_, err := mediaDB.sql.Load().ExecContext(ctx,
+			"DELETE FROM BrowseDirs WHERE Path = ?", sources[1].PathPrefix)
+		require.NoError(t, err)
+
+		_, usable, err := browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, systems)
+		require.NoError(t, err)
+		assert.False(t, usable, "a route the cache never saw must send the listing to media")
+
+		dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			Overlay: &database.BrowseOverlay{Sources: sources},
+			Systems: systems,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Both", "OnlyLow"}, []string{dirs[0].Name, dirs[1].Name})
+	})
+
+	t.Run("cache does not cover the system", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := setupTempMediaDB(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		sources := overlayDirsFixture(t, mediaDB)
+		systems := nesSystemForTest(t)
+
+		// A per-system refresh for a different system leaves the cache present
+		// but marked incomplete, which is the mid-index state.
+		other, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "SNES", Name: "SNES"})
+		require.NoError(t, err)
+		require.NoError(t, sqlPopulateBrowseCacheForSystems(ctx, mediaDB.sql.Load(), []int64{other.DBID}))
+
+		_, usable, err := browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, systems)
+		require.NoError(t, err)
+		assert.False(t, usable, "an incomplete cache without this system's rows must not answer")
+
+		dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			Overlay: &database.BrowseOverlay{Sources: sources},
+			Systems: systems,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Both", "OnlyLow"}, []string{dirs[0].Name, dirs[1].Name})
+	})
+
+	t.Run("cache invalidated", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := setupTempMediaDB(t)
+		defer cleanup()
+
+		ctx := context.Background()
+		sources := overlayDirsFixture(t, mediaDB)
+		systems := nesSystemForTest(t)
+		require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+		_, err := mediaDB.sql.Load().ExecContext(ctx,
+			"INSERT OR REPLACE INTO DBConfig (Name, Value) VALUES (?, ?)",
+			DBConfigBrowseIndexVersion, "not-a-known-version")
+		require.NoError(t, err)
+
+		_, usable, err := browseOverlayCacheParents(ctx, mediaDB.sql.Load(), sources, systems)
+		require.NoError(t, err)
+		assert.False(t, usable, "an unrecognised cache version must not be served")
+
+		dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+			Overlay: &database.BrowseOverlay{Sources: sources},
+			Systems: systems,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Both", "OnlyLow"}, []string{dirs[0].Name, dirs[1].Name})
+	})
+}
+
+// TestBrowseOverlayDirectories_ReadsFromTheCache is what makes the equivalence
+// tests above mean something. They compare two paths that agree by design, so
+// they would pass just as well if the cache were never consulted.
+//
+// Here the cached count is changed to a value the media table cannot produce.
+// If the listing still reports it, the statement read BrowseDirCounts; if it
+// reports the media count, the routing has regressed to the prefix scan this
+// change exists to avoid.
+func TestBrowseOverlayDirectories_ReadsFromTheCache(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sources := overlayDirsFixture(t, mediaDB)
+	systems := nesSystemForTest(t)
+	require.NoError(t, sqlPopulateBrowseCache(ctx, mediaDB.sql.Load()))
+
+	const sentinelCount = 4242
+	res, err := mediaDB.sql.Load().ExecContext(ctx, `
+		UPDATE BrowseDirCounts
+		SET FileCount = ?
+		WHERE ChildDirDBID = (SELECT DBID FROM BrowseDirs WHERE Path = ?)
+			AND ParentDirDBID != ChildDirDBID`,
+		sentinelCount, sources[0].PathPrefix+"Both/")
+	require.NoError(t, err)
+	updated, err := res.RowsAffected()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), updated, "the fixture must produce exactly one cached count for Both")
+
+	dirs, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		Overlay: &database.BrowseOverlay{Sources: sources},
+		Systems: systems,
+	})
+	require.NoError(t, err)
+	require.Len(t, dirs, 2)
+	assert.Equal(t, "Both", dirs[0].Name)
+	assert.Equal(t, sentinelCount, dirs[0].FileCount,
+		"the merged root directory listing must come from BrowseDirCounts, not a Media prefix scan")
+}


### PR DESCRIPTION
`media.browse` with `rootView: "contents"` merges a system's launcher routes into one listing. The on-device launcher opens every system through it (`merged_root_view` on both `media.browse` and `media.browse.index`), so it is the first screen after picking a system.

The overlay branch of `sqlBrowseDirectories` was the only browse path that never consulted the browse cache. It is checked before the cache lookup, so the listing derived every child directory name and recursive file count by range-scanning `Media` under each route — 66,011 rows for C64 on the #1279 device database. `BrowseDirCount` reruns the same statement unlimited per page just to take `len(dirs)`, so the scan happens twice on a first page.

`BrowseDirCounts` already holds those names and counts, and is built from the same `IsMissing = 0` rows, so the two agree by construction.

## Changes

- `sqlBrowseOverlayDirectories` resolves each directory-contributing route to its `BrowseDirs` row and joins `BrowseDirCounts` by `ParentDirDBID`. The route priority dedupe, the higher-priority direct-file shadow check, `AfterName` and `Limit` are unchanged and shared verbatim between both statements.
- Falls back to the Media scan when the cache is absent or on an unrecognised version, when it does not cover the requested systems, or when any route is missing from `BrowseDirs`. A route the cache has never seen is not a route without subdirectories, so answering from the cache would hide directories Media still holds.
- `browseSystemRootContents` was the only browse path with no `logBrowseTiming` calls, so a slow merged root surfaced only as an anonymous mediadb `browse call timing` line with no path. Adds `root_contents_directories`, `root_contents_dir_count`, `root_contents_file_count` and `root_contents_files`.

## Measured

Against a copy of the device database (229,553 media), running the production statement builders over all 105 systems with their real route sets. Identical results for every system.

| | media scan | browse cache |
|---|---|---|
| all 105 systems | 755 ms | 33 ms |
| C64 | 216 ms | 0.43 ms |
| SNESMusic | 100 ms | 0.41 ms |
| NES | 57 ms | 0.41 ms |
| SNES | 51 ms | 0.39 ms |

Desktop, warm page cache. The MiSTer reads this from SD.

The overlay *file* queries join on `m.ParentDir = sources.parent_dir`, so they only touch each route's direct children — 10 ms against 3.2 ms for the plain equivalent across all 105 systems. Left alone.

## Tests

- Equivalence between the cache and Media statements, including the shared-name, shadowed-directory and `IncludeDirs: false` cases, plus `AfterName`/`Limit` paging.
- The three fallback cases: route missing from `BrowseDirs`, cache not covering the system after a per-system refresh, and an unrecognised cache version.
- `TestBrowseOverlayDirectories_ReadsFromTheCache` changes a cached count to a value the media table cannot produce, so the equivalence tests above cannot pass vacuously if the routing regresses.
- `TestBrowseOverlayDirectoriesPlan_UsesCacheIndexes` pins the fallback's `Path>` range scan first, then asserts the cache statement has none and reaches `BrowseDirCounts`.

## Not done

On-device before/after on the test MiSTer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved merged directory browsing by using cached directory data when available, reducing unnecessary media scans.
  * Automatically falls back to the existing search path when cached data is unavailable or outdated.

* **Monitoring**
  * Added detailed timing and result-count information for directory and file browsing queries.

* **Reliability**
  * Added coverage for paging, cache fallback scenarios, and consistency between cached and non-cached directory listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->