### PR TITLE
fix(launchers): make launcher IDs case-insensitive

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -59,7 +59,7 @@ This would return a response like:
   "jsonrpc": "2.0",
   "id": "550e8400-e29b-41d4-a716-446655440000",
   "result": {
-    "version": "0.7.0",
+    "version": "2.16.1",
     "platform": "linux"
   }
 }
@@ -257,7 +257,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods execute actions and return data from Core. This catalog documents **88 non-deprecated registered methods**. See [API Methods](./methods) for request and response contracts, complete access details, and examples. **Local/admin** means localhost or authenticated admin, including paired and valid static API-key admins; **Tiered** means fields or availability vary by client and are detailed in method reference.
+Methods execute actions and return data from Core. This catalog documents **87 non-deprecated registered methods**. See [API Methods](./methods) for request and response contracts, complete access details, and examples. **Local/admin** means localhost or authenticated admin, including paired and valid static API-key admins; **Tiered** means fields or availability vary by client and are detailed in method reference.
 
 | ID                              | Description                                                                           | Access |
 | :------------------------------ | :------------------------------------------------------------------------------------ | :----- |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -52,7 +52,7 @@ curl -X POST http://10.0.0.123:7497/api/v0.1 \
   }'
 ```
 
-This would return a response like:
+For release 2.16.1, this would return a response like:
 
 ```json
 {
@@ -64,6 +64,8 @@ This would return a response like:
   }
 }
 ```
+
+The reported version is build-dependent. Core returns `config.AppVersion`, populated from `APP_VERSION` during release builds.
 
 Unlike WebSocket connections, HTTP requests are stateless and do not support notifications. Each request requires a complete JSON-RPC 2.0 payload and will receive a single response.
 
@@ -257,7 +259,7 @@ Requests from the local device are allowed without restriction. Remote requests 
 
 ## Methods
 
-Methods execute actions and return data from Core. This catalog documents **87 non-deprecated registered methods**. See [API Methods](./methods) for request and response contracts, complete access details, and examples. **Local/admin** means localhost or authenticated admin, including paired and valid static API-key admins; **Tiered** means fields or availability vary by client and are detailed in method reference.
+Methods execute actions and return data from Core. See [API Methods](./methods) for request and response contracts, complete access details, and examples. **Local/admin** means localhost or authenticated admin, including paired and valid static API-key admins; **Tiered** means fields or availability vary by client and are detailed in method reference.
 
 | ID                              | Description                                                                           | Access |
 | :------------------------------ | :------------------------------------------------------------------------------------ | :----- |

--- a/pkg/config/configcustomlaunchers_test.go
+++ b/pkg/config/configcustomlaunchers_test.go
@@ -239,13 +239,13 @@ execute = "echo test"
 	assert.Equal(t, "WorkingLauncher", entries[0].ID)
 }
 
-func TestLoadCustomLaunchers_InlineEntryWinsDuplicateID(t *testing.T) {
+func TestLoadCustomLaunchers_InlineEntryWinsCaseInsensitiveDuplicateID(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	launchersDir := filepath.Join("data", "launchers")
 	require.NoError(t, fs.MkdirAll(launchersDir, 0o750))
 	require.NoError(t, afero.WriteFile(fs, filepath.Join(launchersDir, "duplicate.toml"), []byte(`
 [[launchers.custom]]
-id = "InlineLauncher"
+id = "inlinelauncher"
 execute = "echo external"
 `), 0o600))
 

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -83,7 +83,7 @@ func (lc *LauncherCache) Initialize(pl platforms.Platform, cfg *config.Instance,
 
 func launcherInSlice(launchers []platforms.Launcher, id string) bool {
 	for i := range launchers {
-		if launchers[i].ID == id {
+		if strings.EqualFold(launchers[i].ID, id) {
 			return true
 		}
 	}
@@ -165,18 +165,29 @@ func (lc *LauncherCache) setLaunchableSystems(systems []launchables.VirtualSyste
 	lc.launchableSystems = append([]launchables.VirtualSystem(nil), systems...)
 }
 
-// GetLauncherByID finds a launcher by its unique ID.
-// Returns nil if no launcher with the given ID is found.
+// GetLauncherByID finds a launcher by its case-insensitive unique ID.
+// Returns nil if no launcher is found or IDs differing only by case make the lookup ambiguous.
 func (lc *LauncherCache) GetLauncherByID(id string) *platforms.Launcher {
 	lc.mu.RLock()
 	defer lc.mu.RUnlock()
 
+	var match *platforms.Launcher
 	for i := range lc.allLaunchers {
-		if lc.allLaunchers[i].ID == id {
-			return &lc.allLaunchers[i]
+		candidate := &lc.allLaunchers[i]
+		if !strings.EqualFold(candidate.ID, id) {
+			continue
 		}
+		if match != nil {
+			if candidate.ID != match.ID {
+				log.Error().Str("launcherID", id).Str("firstID", match.ID).Str("conflictingID", candidate.ID).
+					Msg("ambiguous case-insensitive launcher ID")
+				return nil
+			}
+			continue
+		}
+		match = candidate
 	}
-	return nil
+	return match
 }
 
 // Refresh rebuilds the cache with updated launcher data.

--- a/pkg/helpers/launcher_cache_test.go
+++ b/pkg/helpers/launcher_cache_test.go
@@ -93,6 +93,33 @@ func TestGetLauncherByID_Found(t *testing.T) {
 	assert.Equal(t, "SNES", launcher.SystemID)
 }
 
+func TestGetLauncherByID_CaseInsensitivePreservesID(t *testing.T) {
+	t.Parallel()
+
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "Native-Audio", SystemID: "Audio"},
+	})
+
+	launcher := cache.GetLauncherByID("native-audio")
+	require.NotNil(t, launcher)
+	assert.Equal(t, "Native-Audio", launcher.ID)
+	assert.Equal(t, "Audio", launcher.SystemID)
+}
+
+func TestGetLauncherByID_CaseFoldCollisionIsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "Steam", SystemID: "PC"},
+		{ID: "steam", SystemID: "PC"},
+	})
+
+	assert.Nil(t, cache.GetLauncherByID("Steam"))
+	assert.Nil(t, cache.GetLauncherByID("STEAM"))
+}
+
 func TestGetLauncherByID_NotFound(t *testing.T) {
 	t.Parallel()
 
@@ -276,7 +303,7 @@ func TestInitialize_DeduplicatesExtraLaunchers(t *testing.T) {
 	})
 
 	extra := platforms.Launcher{ID: "extra-launcher", SystemID: "SNES"}
-	duplicate := platforms.Launcher{ID: "platform-launcher", SystemID: "NES"} // same ID as platform launcher
+	duplicate := platforms.Launcher{ID: "PLATFORM-LAUNCHER", SystemID: "NES"} // same ID with different casing
 
 	cache := &LauncherCache{}
 	cache.Initialize(mp, nil, extra, duplicate)

--- a/pkg/platforms/shared/linuxemu/integration.go
+++ b/pkg/platforms/shared/linuxemu/integration.go
@@ -101,17 +101,16 @@ func newFlatpakChecker() func(string) bool {
 func Launchers(cfg *config.Instance, options Options, existing []platforms.Launcher) []platforms.Launcher {
 	options.normalize()
 	result := make([]platforms.Launcher, 0, 64)
-	seen := make(map[string]struct{}, len(existing)+64)
+	seenIDs := make([]string, len(existing), len(existing)+64)
 	for i := range existing {
-		seen[strings.ToLower(existing[i].ID)] = struct{}{}
+		seenIDs[i] = existing[i].ID
 	}
 	appendUnique := func(items ...platforms.Launcher) {
 		for i := range items {
-			canonicalID := strings.ToLower(items[i].ID)
-			if _, duplicate := seen[canonicalID]; duplicate {
+			if launcherIDInSlice(seenIDs, items[i].ID) {
 				continue
 			}
-			seen[canonicalID] = struct{}{}
+			seenIDs = append(seenIDs, items[i].ID)
 			result = append(result, items[i])
 		}
 	}
@@ -128,6 +127,15 @@ func Launchers(cfg *config.Instance, options Options, existing []platforms.Launc
 	}
 	configurePlainESDEScanners(cfg, &options, result)
 	return result
+}
+
+func launcherIDInSlice(ids []string, id string) bool {
+	for i := range ids {
+		if strings.EqualFold(ids[i], id) {
+			return true
+		}
+	}
+	return false
 }
 
 func wrapGameMode(options *Options, launcher *platforms.Launcher) {

--- a/pkg/platforms/shared/linuxemu/integration.go
+++ b/pkg/platforms/shared/linuxemu/integration.go
@@ -103,14 +103,15 @@ func Launchers(cfg *config.Instance, options Options, existing []platforms.Launc
 	result := make([]platforms.Launcher, 0, 64)
 	seen := make(map[string]struct{}, len(existing)+64)
 	for i := range existing {
-		seen[existing[i].ID] = struct{}{}
+		seen[strings.ToLower(existing[i].ID)] = struct{}{}
 	}
 	appendUnique := func(items ...platforms.Launcher) {
 		for i := range items {
-			if _, duplicate := seen[items[i].ID]; duplicate {
+			canonicalID := strings.ToLower(items[i].ID)
+			if _, duplicate := seen[canonicalID]; duplicate {
 				continue
 			}
-			seen[items[i].ID] = struct{}{}
+			seen[canonicalID] = struct{}{}
 			result = append(result, items[i])
 		}
 	}

--- a/pkg/platforms/shared/linuxemu/integration_test.go
+++ b/pkg/platforms/shared/linuxemu/integration_test.go
@@ -143,6 +143,24 @@ func TestStandaloneDiscoversNativeBeforeFlatpak(t *testing.T) {
 	t.Fatal("native ScummVM launcher not discovered")
 }
 
+func TestLaunchersSuppressesCaseInsensitiveExistingID(t *testing.T) {
+	t.Parallel()
+
+	options := NewOptions(t.TempDir(), sharedretroarch.Options{})
+	options.IncludeRetroArch = false
+	options.IncludeProviderDecks = false
+	options.LookPath = func(name string) (string, error) {
+		if name == "pcsx2-qt" {
+			return filepath.Join(string(filepath.Separator), "usr", "bin", "pcsx2-qt"), nil
+		}
+		return "", errors.New("missing")
+	}
+	options.IsFlatpakInstalled = func(string) bool { return false }
+
+	launchers := Launchers(nil, options, []platforms.Launcher{{ID: "pcsx2"}})
+	assert.NotContains(t, launcherIDs(launchers), "PCSX2")
+}
+
 func TestStandaloneDiscoversEmuDeckAppImage(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/shared/linuxemu/integration_test.go
+++ b/pkg/platforms/shared/linuxemu/integration_test.go
@@ -150,15 +150,21 @@ func TestLaunchersSuppressesCaseInsensitiveExistingID(t *testing.T) {
 	options.IncludeRetroArch = false
 	options.IncludeProviderDecks = false
 	options.LookPath = func(name string) (string, error) {
-		if name == "pcsx2-qt" {
-			return filepath.Join(string(filepath.Separator), "usr", "bin", "pcsx2-qt"), nil
+		if name == "scummvm" {
+			return filepath.Join(string(filepath.Separator), "usr", "bin", "scummvm"), nil
 		}
 		return "", errors.New("missing")
 	}
 	options.IsFlatpakInstalled = func(string) bool { return false }
 
-	launchers := Launchers(nil, options, []platforms.Launcher{{ID: "pcsx2"}})
-	assert.NotContains(t, launcherIDs(launchers), "PCSX2")
+	launchers := Launchers(nil, options, []platforms.Launcher{{ID: "scummvmstandalone"}})
+	assert.NotContains(t, launcherIDs(launchers), "ScummVMStandalone")
+}
+
+func TestLauncherIDInSliceUsesEqualFold(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, launcherIDInSlice([]string{"Σ"}, "ς"))
 }
 
 func TestStandaloneDiscoversEmuDeckAppImage(t *testing.T) {

--- a/pkg/zapscript/launch.go
+++ b/pkg/zapscript/launch.go
@@ -742,16 +742,38 @@ func searchMediaBySystemTier(
 }
 
 func findLauncher(pl platforms.Platform, cfg *platforms.CmdEnv, launcherID string) *platforms.Launcher {
+	return findLauncherIn(pl.Launchers(cfg.Cfg), helpers.GlobalLauncherCache, launcherID)
+}
+
+func findLauncherIn(
+	launchers []platforms.Launcher,
+	cache *helpers.LauncherCache,
+	launcherID string,
+) *platforms.Launcher {
 	if launcherID == "" {
 		return nil
 	}
-	launchers := pl.Launchers(cfg.Cfg)
+
+	var match *platforms.Launcher
 	for i := range launchers {
-		if strings.EqualFold(launchers[i].ID, launcherID) {
-			return &launchers[i]
+		candidate := &launchers[i]
+		if !strings.EqualFold(candidate.ID, launcherID) {
+			continue
 		}
+		if match != nil {
+			if candidate.ID != match.ID {
+				log.Error().Str("launcherID", launcherID).Str("firstID", match.ID).
+					Str("conflictingID", candidate.ID).Msg("ambiguous case-insensitive launcher ID")
+				return nil
+			}
+			continue
+		}
+		match = candidate
 	}
-	return helpers.GlobalLauncherCache.GetLauncherByID(launcherID)
+	if match != nil {
+		return match
+	}
+	return cache.GetLauncherByID(launcherID)
 }
 
 type launchTarget struct {

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -57,6 +57,58 @@ func launchTestAbsPath(parts ...string) string {
 	return filepath.Join(append([]string{root}, parts...)...)
 }
 
+func TestFindLauncherIn_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	cache := &pathhelpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "Cache-Only", SystemID: "Audio"},
+	})
+	platformLaunchers := []platforms.Launcher{
+		{ID: "Platform-Launcher", SystemID: "PC"},
+	}
+
+	tests := []struct {
+		name      string
+		launcher  string
+		wantID    string
+		launchers []platforms.Launcher
+	}{
+		{
+			name:      "platform launcher",
+			launchers: platformLaunchers,
+			launcher:  "PLATFORM-LAUNCHER",
+			wantID:    "Platform-Launcher",
+		},
+		{
+			name:     "cache-only launcher",
+			launcher: "CACHE-ONLY",
+			wantID:   "Cache-Only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			launcher := findLauncherIn(tt.launchers, cache, tt.launcher)
+			require.NotNil(t, launcher)
+			assert.Equal(t, tt.wantID, launcher.ID)
+		})
+	}
+}
+
+func TestFindLauncherIn_CaseFoldCollisionIsAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	cache := &pathhelpers.LauncherCache{}
+	launchers := []platforms.Launcher{
+		{ID: "Steam", SystemID: "PC"},
+		{ID: "steam", SystemID: "PC"},
+	}
+
+	assert.Nil(t, findLauncherIn(launchers, cache, "STEAM"))
+}
+
 func TestMediaIDForHistoryEntry_ResolvesMedia(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- make launcher cache lookup and extra-launcher deduplication case-insensitive while preserving original ID casing
- fail closed on case-fold collisions and apply matching behavior to ZapScript launcher resolution
- prevent Linux emulator integrations from colliding with case-differing custom launchers
- cover cache-only lookup, custom precedence, ambiguity handling, and case-insensitive custom validation
- refresh API documentation version and method count

Closes #1319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launcher IDs are now matched case-insensitively across discovery, lookup, caching, and launching.
  - Duplicate launchers with IDs differing only by capitalization are suppressed.

- **Bug Fixes**
  - Ambiguous case-only duplicate IDs are safely rejected instead of selecting unpredictably.
  - Inline launcher configurations take precedence over matching file-based entries regardless of capitalization.

- **Documentation**
  - Updated the API example version to 2.16.1.
  - Corrected the documented registered method count to 87.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->