### PR TITLE
fix(updater): recover interrupted rollbacks, cover install boundaries

### DIFF
--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -73,8 +73,10 @@ promote now verifies the live signature and advances from its generation;
 Do not use it unless the signed live metadata is genuinely unavailable and the
 recovery generation is known to exceed every generation devices may have seen.
 
-Start a significant release at a partial `rollout` — 5, then 25, then 100 over a
-few days — and widen it with **OTA rollout**. Bucketing is salted per release,
+Start a significant release at a partial `rollout` — 5, then 25, then 100 — and
+widen it with **OTA rollout**. Hold each rung long enough to see failures that
+only a real fleet produces: at least 24 hours at 5, 72 hours at 25, and 7 days
+at 100 before the release counts as fully out. Bucketing is salted per release,
 so widening keeps the devices already on it and a different release picks a
 fresh, uncorrelated cohort. No device is permanently a guinea pig.
 
@@ -278,11 +280,15 @@ Contain it with all of these controls:
 
 1. Put controlled devices on a unique precursor version higher than every
    public release.
-2. Set bad release `min_upgrade_from` to that precursor so ordinary beta devices
+2. Give the bad release a version higher than that precursor. `min_upgrade_from`
+   only tests the running version against the floor; a release is separately
+   refused unless it is newer than the version already running, so a bad build
+   at or below the precursor is never installed and the drill proves nothing.
+3. Set bad release `min_upgrade_from` to that precursor so ordinary beta devices
    cannot qualify.
-3. Check release-tag bucketing offline and select intended controlled devices
+4. Check release-tag bucketing offline and select intended controlled devices
    inside a 5% rollout without publishing raw DeviceIDs.
-4. Inspect a promote dry-run before publishing. Never use stable and never widen
+5. Inspect a promote dry-run before publishing. Never use stable and never widen
    the deliberately bad release above 5%.
 
 Require automatic selection/install, failed confirmation, complete binary,

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -266,9 +266,18 @@ UserDB. A managed installation must remain payload-ineligible and untouched.
 ### Cross-platform confirmation cycle
 
 Observe one complete signed check → automatic install → restart → confirmation
-on MiSTer, SteamOS, writable Windows, unmanaged Batocera and one musl platform.
-Verify generation/asset selection, gates, restarted version, update result,
-marker/sidecar cleanup and retained UserDB data on each.
+on MiSTer, SteamOS, writable Windows, unmanaged Batocera, and one install that
+is not package-manager managed. Verify generation/asset selection, gates,
+restarted version, update result, marker/sidecar cleanup and retained UserDB
+data on each.
+
+Pick that set for the differences that actually reach the updater: a target
+filesystem where `chmod` is a no-op and directory fsync is unsupported
+(MiSTer's exfat), a battery-backed device (Steam Deck), the rename-aside
+replacement backend (Windows), platform-owned payload extras (Batocera), and an
+install `ManagedByPackageManager` reports false for, since that is the only
+shape where automatic installation is permitted at all. Every release is built
+against glibc, so libc variance is not one of the axes.
 
 ## Controlled beta rollback and withdrawal drill
 

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -67,14 +67,11 @@ Promote downloads every archive to the runner and hashes it there. GitHub's
 reported digests are cross-checked against those hashes in both directions, but
 what gets signed is always the bytes on disk.
 
-The first promote is different. The manifest currently live predates signing, so
-there is no `manifest.yaml.sig` to verify and no `generation` to advance from.
-Publishing on top of an unsigned manifest is refused by default — a stripped
-signature would otherwise rewind the counter and stall updates for every device
-holding a watermark. To bootstrap, dispatch that one promote with
-`generation_floor` set above any generation already published (0 has never been
-published, so any positive value works). Every promote after it verifies a
-signature and needs no floor.
+The signed manifest was bootstrapped at generation 1 on 2026-08-17. Every
+promote now verifies the live signature and advances from its generation;
+`generation_floor` is disaster-recovery input, not part of a normal promote.
+Do not use it unless the signed live metadata is genuinely unavailable and the
+recovery generation is known to exceed every generation devices may have seen.
 
 Start a significant release at a partial `rollout` — 5, then 25, then 100 over a
 few days — and widen it with **OTA rollout**. Bucketing is salted per release,
@@ -149,6 +146,169 @@ or copy the backup there, then start the service. That restores the version the
 device was already running; the pending update is unwound on the next start.
 Never put the `-new` file in place by hand: the durable marker still records an
 interrupted install, so recovery must restore the known-good outgoing binary.
+
+## Automatic installation controls
+
+Automatic installation has two independent controls. Neither one changes the
+other:
+
+- `[updates] install = true` is an explicit per-device opt-in. Its default is
+  `false` and remains off when update checking is disabled.
+- `rollout` is a signed field on one release. It limits which opted-in devices
+  may install that release automatically. It never enables installation.
+
+| Device `install` | Release `rollout` | Result |
+|---|---:|---|
+| `false` | 0–100 | Check/notification only; no automatic install |
+| `true` | 0 | Automatic install held for every device |
+| `true` | 5 | Deterministically selected 5% of opted-in devices may install |
+| `true` | 100 | Every opted-in eligible device may install |
+
+The bucket is stable for one device and release, widens monotonically for that
+release, and is re-salted by a different release tag. Manual `update.apply`
+ignores rollout; authorization, platform, power, storage and activity gates
+still apply.
+
+### Platform support
+
+Raw-binary automatic installation is intended for non-package-managed Windows,
+Linux, SteamOS, Bazzite, ChimeraOS, ReplayOS, RetroPie, Recalbox, ZapOS, MiSTeX,
+LibreELEC, MiSTer and Batocera installs that pass platform preflight.
+
+- Windows must be able to create/remove an install-directory probe and open the
+  target for rename. Protected installer-owned locations remain on the Windows
+  installer path; Core reports `eligibility: unsupported` and never elevates.
+- Managed MiSTer/Batocera installations remain on their package-manager path.
+  Batocera payload files are installed only for unmanaged archive installs.
+- macOS is excluded. Its supported update path must operate on a signed app
+  bundle or App Store installation, not replace one raw executable.
+
+### Readiness checklist
+
+Before changing a device or publishing test metadata:
+
+1. Confirm OTA validate passed and inspect an OTA promote dry-run artifact.
+2. Record tag, channel, rollout, `min_upgrade_from`, manifest generation and
+   asset digest/size.
+3. Confirm device version, platform/architecture, channel, managed status,
+   `updates.check`, `updates.install`, install target and preflight eligibility.
+4. Confirm free space and power state. Automatic installs require charging,
+   external power, or at least 40% battery where battery status is available.
+5. Read current update result and ensure no unresolved pending or quarantined
+   marker exists.
+6. Take a recoverable UserDB backup and confirm local console, SSH, removable
+   media or installer recovery access before any destructive test.
+7. Test one device at a time. Device changes and workflow dispatches require
+   explicit approval.
+
+### Observation and evidence
+
+Use `update.check` to record selected version, eligibility, `autoInstall`,
+`rolloutHeld`, deferral reason/time and previous update outcome. Device
+`updater/state.json` also carries `lastCheckAt`, `lastCheckOK`, `checkFailures`
+and `lastOfferedVersion`; these are diagnostics, not permission to install.
+Collect updater logs and relevant Sentry/support reports. Sentry reporting is
+opt-in and support reports are incomplete, so absence of either is not proof of
+fleet health.
+
+For every validation record:
+
+```text
+operator/date:
+release tag/channel/generation/rollout/floor:
+device label/platform/arch/from/to:
+DeviceID bucket result (never publish raw DeviceID):
+power/free-space/managed status:
+check, install, restart and confirmation timestamps:
+outcome and deferral details:
+binary/payload/database/marker/sidecar checks:
+logs, screenshots or downloaded evidence:
+go/no-go decision:
+```
+
+Stop immediately on `rollbackBlocked`, `recoveryRequired`, an empty Windows
+boot target, unrecovered database, payload mismatch, signature/generation
+inconsistency, or repeated unexplained check/install failure. Set rollout to 0
+while investigating. Withdraw when release safety or metadata integrity is in
+doubt. Do not widen based only on elapsed time.
+
+## Final validation matrix
+
+Run this only after updater code, transaction-boundary tests, documentation and
+post-merge CI are complete.
+
+### Windows
+
+On a writable portable or per-user install, cover apply/confirm, forced startup
+rollback, failed incoming rename with successful undo, sharing/scanner
+violations, repeated swaps, sidecar cleanup and a read-only outgoing executable.
+Exercise the double-failure/manual-recovery path only with local recovery access.
+On an installer-owned protected location, verify unsupported eligibility and
+installer guidance with no elevation or mutation. On battery-equipped hardware,
+include the 20% manual and 40% automatic thresholds.
+
+### Steam Deck / SteamOS
+
+Verify checking while charging/discharging, automatic rejection at 39%,
+acceptance at 40%, charger removal after staging but before the immediate
+pre-install check, normal confirmation, and failed-start rollback without a
+supervisor restart loop.
+
+### Batocera
+
+For an unmanaged archive install, verify all seven payload destinations and
+modes, backup of existing files, original-absence handling for new files,
+confirmation cleanup and failed-start restoration of binary, payload and
+UserDB. A managed installation must remain payload-ineligible and untouched.
+
+### Cross-platform confirmation cycle
+
+Observe one complete signed check → automatic install → restart → confirmation
+on MiSTer, SteamOS, writable Windows, unmanaged Batocera and one musl platform.
+Verify generation/asset selection, gates, restarted version, update result,
+marker/sidecar cleanup and retained UserDB data on each.
+
+## Controlled beta rollback and withdrawal drill
+
+Run a deliberately bad build only on beta after the normal hardware matrix
+passes. Build it so `-version` succeeds but normal service startup fails; this
+exercises watchdog rollback rather than archive/probe rejection.
+
+Contain it with all of these controls:
+
+1. Put controlled devices on a unique precursor version higher than every
+   public release.
+2. Set bad release `min_upgrade_from` to that precursor so ordinary beta devices
+   cannot qualify.
+3. Check release-tag bucketing offline and select intended controlled devices
+   inside a 5% rollout without publishing raw DeviceIDs.
+4. Inspect a promote dry-run before publishing. Never use stable and never widen
+   the deliberately bad release above 5%.
+
+Require automatic selection/install, failed confirmation, complete binary,
+payload and UserDB rollback, durable `rolledBack` result and return to the
+precursor. Then dispatch OTA withdraw and verify signed public metadata advances
+and no longer offers the release. Record decision-to-verification time against
+the under-five-minute target. Confirm a non-qualifying beta device never
+installs it.
+
+## Opt-in beta rollout evidence gates
+
+After withdrawing the bad build, use a good beta release to exercise 5% → 25%
+→ 100% rollout among devices whose owners explicitly enabled
+`[updates] install = true`. Dry-run and review each metadata change first.
+
+- Dwell at least 24 hours at 5%, 72 hours at 25%, and 7 days at 100%.
+- Require explained outcomes from controlled matrix devices at each rung.
+- Require zero unexplained `rollbackBlocked`/`recoveryRequired` outcomes,
+  Windows empty-target incidents, updater-related Sentry regressions or
+  corroborated support failures.
+- Confirm expected deferrals/backoff recover without intervention.
+- Record explicit go/no-go before widening.
+
+At any blocker, set rollout to 0, preserve evidence and withdraw if safety is in
+doubt. This validates opt-in operation only; automatic installation remains off
+by default.
 
 ## Setup
 

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -149,6 +149,48 @@ device was already running; the pending update is unwound on the next start.
 Never put the `-new` file in place by hand: the durable marker still records an
 interrupted install, so recovery must restore the known-good outgoing binary.
 
+### A device will not start after going back to an older version
+
+Core refuses to start when the user database has been migrated by a newer build
+than the one now installed:
+
+```text
+database schema is newer than this binary supports: database is at version
+20260828000000 but this binary only supports up to 20260818120000, update to a
+newer version or reinstall the previous version
+```
+
+This is deliberate. The media database is rebuilt in the same situation because
+a reindex reconstructs it, but the user database holds history, mappings,
+profiles and favourites that nothing can reconstruct, so starting by discarding
+them would be worse than not starting.
+
+Rolling back through Core never causes this: the update snapshot restores the
+database alongside the binary, so the schema goes back with it. What causes it
+is replacing the binary some other way — reinstalling an older release by hand,
+or a package manager moving the install backwards.
+
+On a platform with a service supervisor this presents as a service that keeps
+restarting rather than an error, because each attempt fails the same way. On
+MiSTer there is no journal at all. Either way the explanation is in
+`core.log`, and it names both versions.
+
+Recover in this order:
+
+1. **Reinstall the newer version.** Always works and loses nothing, and is the
+   right answer whenever going back was not deliberate.
+2. **Restore a user database backup taken before the newer build ran**, from
+   `backups/` in the data directory, then start the older version. Check the
+   backup predates the upgrade — restoring one taken *after* it puts the same
+   schema back and fails identically.
+3. If neither is possible, the database has to be moved aside and recreated
+   empty, which loses that data. Keep the file: a later build that understands
+   the schema can still open it.
+
+Automatic backups are pruned to the most recent three, so a device that ran the
+newer build for several boots may no longer hold a backup old enough for step 2.
+Take one before deliberately moving a device back.
+
 ## Automatic installation controls
 
 Automatic installation has two independent controls. Neither one changes the

--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -281,12 +281,22 @@ doubt. Do not widen based only on elapsed time.
 Run this only after updater code, transaction-boundary tests, documentation and
 post-merge CI are complete.
 
+Stopping Core within the confirmation window counts as a failed start and rolls
+the update back. That is correct — a process killed partway through is
+indistinguishable from one that crashed — but it means a device stopped by hand
+between the restart and the confirmation will report a rollback that nothing
+was actually wrong with. Let an install confirm before stopping it, and read any
+rollback that follows a manual stop as an artifact of the stop.
+
 ### Windows
 
 On a writable portable or per-user install, cover apply/confirm, forced startup
 rollback, failed incoming rename with successful undo, sharing/scanner
 violations, repeated swaps, sidecar cleanup and a read-only outgoing executable.
 Exercise the double-failure/manual-recovery path only with local recovery access.
+Confirm the restart actually happens: a Windows install replaces the binary and
+stops the service well before anything re-execs, so an update that installs and
+never comes back looks from the outside like one that simply took a while.
 On an installer-owned protected location, verify unsupported eligibility and
 installer guidance with no elevation or mutation. On battery-equipped hardware,
 include the 20% manual and 40% automatic thresholds.

--- a/pkg/service/updater/install.go
+++ b/pkg/service/updater/install.go
@@ -254,7 +254,7 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 		removeInstallArtifacts(ctx, m, candidatePath, opts.binary, payloadOps)
 		return fmt.Errorf("preserving the current binary: %w", err)
 	}
-	if err := saveMarker(dir, m); err != nil {
+	if err := payloadOps.saveMarker(dir, m); err != nil {
 		removeInstallArtifacts(ctx, m, candidatePath, opts.binary, payloadOps)
 		return fmt.Errorf("recording the start of the update install: %w", err)
 	}
@@ -283,13 +283,13 @@ func installStaged(ctx context.Context, opts *installOptions) (retErr error) {
 	// to do. Before it, a failed swap left the old one exactly where it was and
 	// the unwind has to leave it alone.
 	m.BinaryReplaced = true
-	if err := syncDir(filepath.Dir(opts.TargetPath)); err != nil {
+	if err := payloadOps.syncDirectory(filepath.Dir(opts.TargetPath)); err != nil {
 		return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
 			fmt.Errorf("flushing the installed binary: %w", err))
 	}
 
 	m.State = markerInstalled
-	if err := saveMarker(dir, m); err != nil {
+	if err := payloadOps.saveMarker(dir, m); err != nil {
 		return abortInstallAfterErrorWithOps(ctx, opts.DataDir, m, candidatePath, opts.binary, payloadOps,
 			fmt.Errorf("recording the completed update install: %w", err))
 	}

--- a/pkg/service/updater/install_test.go
+++ b/pkg/service/updater/install_test.go
@@ -20,6 +20,7 @@
 package updater
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -200,6 +201,175 @@ func TestInstallStaged_RestoresPayloadWhenIncomingVersionNeverRan(t *testing.T) 
 	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
 	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
 	assert.NoFileExists(t, f.snapshotPath, "abort discards the unused snapshot instead of restoring it")
+}
+
+type installPayloadPaths struct {
+	existingStaged string
+	newStaged      string
+	existingTarget string
+	newTarget      string
+}
+
+func addInstallPayloads(t *testing.T, f *installStagedFixture, opts *installOptions) installPayloadPaths {
+	t.Helper()
+
+	installRoot := filepath.Dir(f.targetPath)
+	paths := installPayloadPaths{
+		existingStaged: filepath.Join(f.stagingDir, "scripts", "services", "zaparoo_service"),
+		newStaged:      filepath.Join(f.stagingDir, "scripts", "new-helper.sh"),
+		existingTarget: filepath.Join(installRoot, "services", "zaparoo_service"),
+		newTarget:      filepath.Join(installRoot, "new-helper.sh"),
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.existingStaged), 0o750))
+	//nolint:gosec // Executable payload fixtures.
+	require.NoError(t, os.WriteFile(paths.existingStaged, []byte("new service"), 0o755))
+	//nolint:gosec // Executable payload fixtures.
+	require.NoError(t, os.WriteFile(paths.newStaged, []byte("new helper"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(paths.existingTarget), 0o750))
+	//nolint:gosec // Executable payload fixture.
+	require.NoError(t, os.WriteFile(paths.existingTarget, []byte("old service"), 0o700))
+	opts.Staged.payloadFiles = []stagedPayloadFile{
+		{Path: paths.existingStaged, RelativePath: "services/zaparoo_service", Mode: 0o755},
+		{Path: paths.newStaged, RelativePath: "new-helper.sh", Mode: 0o755},
+	}
+	return paths
+}
+
+func assertFailedPayloadInstallUndone(
+	t *testing.T, f *installStagedFixture, paths installPayloadPaths,
+) {
+	t.Helper()
+
+	f.assertInstallUndone(t)
+	assert.Equal(t, "old service", readFileString(t, paths.existingTarget))
+	assert.NoFileExists(t, paths.newTarget)
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+	assert.True(t, f.backupper.resumed)
+}
+
+func TestInstallStaged_PreQuiesceRefusalLeavesLiveFilesUntouched(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	opts := f.options()
+	paths := addInstallPayloads(t, f, opts)
+	gateErr := errors.New("power changed")
+	opts.PreQuiesce = func(context.Context) error { return gateErr }
+
+	err := installStaged(t.Context(), opts)
+	require.ErrorIs(t, err, gateErr)
+	assert.False(t, f.backupper.called)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "old service", readFileString(t, paths.existingTarget))
+	assert.NoFileExists(t, paths.newTarget)
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installCandidateSuffix))
+	assert.NoFileExists(t, installSidecarPath(paths.existingTarget, installCandidateSuffix))
+	assert.NoFileExists(t, installSidecarPath(paths.existingTarget, installBackupSuffix))
+	assert.NoDirExists(t, f.stagingDir)
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+}
+
+func TestInstallStaged_PartialPayloadPreparationFailureCleansCandidates(t *testing.T) {
+	f := newInstallStagedFixture(t)
+	opts := f.options()
+	paths := addInstallPayloads(t, f, opts)
+	require.NoError(t, os.Mkdir(paths.newTarget, 0o750))
+
+	err := installStaged(t.Context(), opts)
+	require.ErrorContains(t, err, "not a regular file")
+	assert.False(t, f.backupper.called)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "old service", readFileString(t, paths.existingTarget))
+	assert.NoFileExists(t, installSidecarPath(f.targetPath, installCandidateSuffix))
+	assert.NoFileExists(t, installSidecarPath(paths.existingTarget, installCandidateSuffix))
+	assert.NoFileExists(t, installSidecarPath(paths.existingTarget, installBackupSuffix))
+	assert.NoDirExists(t, f.stagingDir)
+	assert.NoFileExists(t, markerPath(stateDirFor(f.dataDir)))
+}
+
+func TestInstallStaged_PostMarkerFailuresRestoreEverything(t *testing.T) {
+	tests := map[string]struct {
+		configure func(*testing.T, *installStagedFixture, *installOptions, installPayloadPaths)
+		want      string
+	}{
+		"payload replacement": {
+			want: "installing payload file",
+			configure: func(_ *testing.T, _ *installStagedFixture, opts *installOptions, paths installPayloadPaths) {
+				failed := false
+				opts.payload.replace = func(source, target string) error {
+					if !failed && target == paths.newTarget {
+						failed = true
+						return errors.New("payload rename failed")
+					}
+					return os.Rename(source, target)
+				}
+			},
+		},
+		"payload directory sync": {
+			want: "flushing installed payload file",
+			configure: func(_ *testing.T, _ *installStagedFixture, opts *installOptions, paths installPayloadPaths) {
+				failed := false
+				opts.payload.syncDirectory = func(dir string) error {
+					if !failed && dir == filepath.Dir(paths.existingTarget) {
+						content, readErr := os.ReadFile(paths.existingTarget) //nolint:gosec // test-owned path
+						if readErr == nil && string(content) == "new service" {
+							failed = true
+							return errors.New("payload directory sync failed")
+						}
+					}
+					return syncDir(dir)
+				}
+			},
+		},
+		"binary replacement": {
+			want: "installing the staged binary",
+			configure: func(_ *testing.T, _ *installStagedFixture, opts *installOptions, _ installPayloadPaths) {
+				opts.binary.replaceRunning = func(string, string) error {
+					return errors.New("binary rename failed")
+				}
+			},
+		},
+		"binary directory sync": {
+			want: "flushing the installed binary",
+			configure: func(_ *testing.T, f *installStagedFixture, opts *installOptions, _ installPayloadPaths) {
+				failed := false
+				opts.payload.syncDirectory = func(dir string) error {
+					if !failed && dir == filepath.Dir(f.targetPath) {
+						content, readErr := os.ReadFile(f.targetPath) //nolint:gosec // test-owned path
+						if readErr == nil && string(content) != "old binary" {
+							failed = true
+							return errors.New("binary directory sync failed")
+						}
+					}
+					return syncDir(dir)
+				}
+			},
+		},
+		"final marker": {
+			want: "recording the completed update install",
+			configure: func(_ *testing.T, _ *installStagedFixture, opts *installOptions, _ installPayloadPaths) {
+				failed := false
+				opts.payload.saveMarker = func(dir string, marker *pendingMarker) error {
+					if !failed && marker.State == markerInstalled {
+						failed = true
+						return errors.New("final marker sync failed")
+					}
+					return saveMarker(dir, marker)
+				}
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newInstallStagedFixture(t)
+			opts := f.options()
+			paths := addInstallPayloads(t, f, opts)
+			tt.configure(t, f, opts, paths)
+
+			err := installStaged(t.Context(), opts)
+			require.ErrorContains(t, err, tt.want)
+			assertFailedPayloadInstallUndone(t, f, paths)
+		})
+	}
 }
 
 func TestPreparePayloadCandidates_UsesInjectedFilesystem(t *testing.T) {

--- a/pkg/service/updater/watchdog.go
+++ b/pkg/service/updater/watchdog.go
@@ -407,7 +407,7 @@ func confirmWithOps(
 	defer markerMu.Unlock()
 
 	dir := stateDirFor(dataDir)
-	m, err := loadMarker(dir)
+	m, err := fileOps.load(dir)
 	if err != nil || m == nil {
 		return "", nil //nolint:nilerr // a marker this build cannot read is not ours to commit
 	}
@@ -417,7 +417,7 @@ func confirmWithOps(
 
 	m.Outcome = outcomeSucceeded
 	m.OutcomeAt = time.Now().UTC()
-	if err := saveMarker(dir, m); err != nil {
+	if err := fileOps.save(dir, m); err != nil {
 		return "", fmt.Errorf("recording the confirmed update: %w", err)
 	}
 	if err := finalizeTerminalUpdate(ctx, dataDir, m, fileOps); err != nil {
@@ -550,6 +550,10 @@ func rollBack(
 		return handleRollbackFailure(dir, m, fileOps, err)
 	}
 
+	// The on-disk marker still names the binary restore until this save makes
+	// the terminal outcome durable. If the save fails after the backup rename,
+	// that path proves the missing backup was consumed by this exact restore.
+	m.RestoringPath = ""
 	m.Outcome = outcomeRolledBack
 	m.OutcomeAt = time.Now().UTC()
 	if err := fileOps.save(dir, m); err != nil {
@@ -697,7 +701,7 @@ func restorePayloadFile(
 		return nil
 	}
 
-	return restoreReplacedFileState(dir, m, payload.BackupPath, payload.TargetPath, fileOps, false)
+	return restoreReplacedFileState(dir, m, payload.BackupPath, payload.TargetPath, fileOps)
 }
 
 // restoreReplacedFiles renames what the install displaced back over what it
@@ -712,25 +716,18 @@ func restoreReplacedFiles(dir string, m *pendingMarker, fileOps watchdogFileOps)
 	// replacement the payload extras use.
 	binaryOps := fileOps
 	binaryOps.replace = fileOps.binary.replace
-	return restoreReplacedFile(dir, m, m.BackupPath, m.TargetPath, binaryOps)
+	return restoreReplacedFileState(dir, m, m.BackupPath, m.TargetPath, binaryOps)
 }
 
-// restoreReplacedFile records the path about to move before renaming it. If a
-// power cut lands after the rename but before the marker can advance, a missing
-// backup is then proof that this exact move completed, not a guess based on the
-// rollback's coarse state.
-func restoreReplacedFile(
-	dir string, m *pendingMarker, backupPath, targetPath string, fileOps watchdogFileOps,
-) error {
-	return restoreReplacedFileState(dir, m, backupPath, targetPath, fileOps, true)
-}
-
+// restoreReplacedFileState records the path about to move before renaming it.
+// If a power cut lands after the rename but before the marker can advance, a
+// missing backup is then proof that this exact move completed, not a guess based
+// on the rollback's coarse state.
 func restoreReplacedFileState(
 	dir string,
 	m *pendingMarker,
 	backupPath, targetPath string,
 	fileOps watchdogFileOps,
-	clearRestoringPath bool,
 ) error {
 	if backupPath == "" || targetPath == "" {
 		return fmt.Errorf("%w: the update recorded no backup for a file it replaced", errRollbackPrerequisite)
@@ -741,12 +738,6 @@ func restoreReplacedFileState(
 		if errors.Is(statErr, os.ErrNotExist) && m.RestoringPath == targetPath {
 			if _, targetErr := fileOps.fs.Stat(targetPath); targetErr != nil {
 				return fmt.Errorf("restored backup and target are both unavailable for %q: %w", targetPath, targetErr)
-			}
-			if clearRestoringPath {
-				m.RestoringPath = ""
-				if saveErr := fileOps.save(dir, m); saveErr != nil {
-					return fmt.Errorf("recording the completed file restore: %w", saveErr)
-				}
 			}
 			return nil
 		}
@@ -768,12 +759,6 @@ func restoreReplacedFileState(
 	}
 	if err := fileOps.syncDirectory(filepath.Dir(targetPath)); err != nil {
 		return fmt.Errorf("flushing restored file %q: %w", targetPath, err)
-	}
-	if clearRestoringPath {
-		m.RestoringPath = ""
-		if err := fileOps.save(dir, m); err != nil {
-			return fmt.Errorf("recording the completed file restore: %w", err)
-		}
 	}
 	return nil
 }

--- a/pkg/service/updater/watchdog_test.go
+++ b/pkg/service/updater/watchdog_test.go
@@ -559,6 +559,81 @@ func TestConfirm_RetriesFailedBinaryBackupCleanup(t *testing.T) {
 	assert.NoFileExists(t, f.snapshotPath)
 }
 
+func TestConfirm_FailedOutcomeSaveKeepsRecoveryFiles(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	saveErr := errors.New("marker storage unavailable")
+	ops := defaultWatchdogFileOps()
+	ops.marker.save = func(string, *pendingMarker) error { return saveErr }
+	version, err := confirmWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
+	require.ErrorIs(t, err, saveErr)
+	assert.Empty(t, version)
+	assert.FileExists(t, f.backupPath)
+	assert.FileExists(t, f.snapshotPath)
+
+	onDisk, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, onDisk)
+	assert.Empty(t, onDisk.Outcome)
+
+	version, err = Confirm(t.Context(), f.dataDir, testTargetVersion)
+	require.NoError(t, err)
+	assert.Equal(t, testTargetVersion, version)
+	assert.NoFileExists(t, markerPath(dir))
+}
+
+func TestConfirm_FailedResultWriteRetainsTerminalMarker(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	recordErr := errors.New("result storage unavailable")
+	ops := defaultWatchdogFileOps()
+	ops.marker.record = func(string, *pendingMarker) error { return recordErr }
+	version, err := confirmWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
+	require.ErrorIs(t, err, recordErr)
+	assert.Equal(t, testTargetVersion, version)
+	assert.FileExists(t, f.backupPath)
+	assert.FileExists(t, f.snapshotPath)
+
+	onDisk, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, onDisk)
+	assert.Equal(t, outcomeSucceeded, onDisk.Outcome)
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	assert.NoFileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.backupPath)
+	assert.NoFileExists(t, f.snapshotPath)
+}
+
+func TestConfirm_FailedMarkerClearRetriesTerminalCleanup(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	clearErr := errors.New("marker removal unavailable")
+	ops := defaultWatchdogFileOps()
+	ops.marker.clear = func(string) error { return clearErr }
+	version, err := confirmWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
+	require.ErrorIs(t, err, clearErr)
+	assert.Equal(t, testTargetVersion, version)
+	assert.FileExists(t, markerPath(dir))
+	assert.NoFileExists(t, f.backupPath)
+	assert.NoFileExists(t, f.snapshotPath)
+
+	require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion))
+	assert.NoFileExists(t, markerPath(dir))
+}
+
 func TestConfirm_IgnoresAMarkerItDoesNotOwn(t *testing.T) {
 	t.Parallel()
 
@@ -734,6 +809,72 @@ func TestRunStartupWatchdog_AbortsInterruptedInstallWithoutRestoringDB(t *testin
 	assert.True(t, cleared)
 	assert.NoFileExists(t, f.snapshotPath)
 	assert.NoDirExists(t, f.stagingDir)
+}
+
+func TestRunStartupWatchdog_AbortsInterruptedPayloadInstallShapes(t *testing.T) {
+	for _, allPayloadsInstalled := range []bool{false, true} {
+		name := "subset installed"
+		if allPayloadsInstalled {
+			name = "all installed before binary"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newInstallFixture(t)
+			dir := stateDirFor(f.dataDir)
+			// The outgoing binary still owns the target name, so this is an abort,
+			// not a rollback of a version that opened the database.
+			//nolint:gosec // executable stand-in owned by this test
+			require.NoError(t, os.WriteFile(f.targetPath, []byte("old binary"), 0o755))
+
+			payloadDir := filepath.Join(filepath.Dir(f.targetPath), "services")
+			require.NoError(t, os.MkdirAll(payloadDir, 0o750))
+			existingTarget := filepath.Join(payloadDir, "service")
+			existingBackup := installSidecarPath(existingTarget, installBackupSuffix)
+			newTarget := filepath.Join(payloadDir, "new-helper")
+			newCandidate := installSidecarPath(newTarget, installCandidateSuffix)
+			require.NoError(t, os.WriteFile(existingTarget, []byte("new service"), 0o600))
+			require.NoError(t, os.WriteFile(existingBackup, []byte("old service"), 0o600))
+			if allPayloadsInstalled {
+				require.NoError(t, os.WriteFile(newTarget, []byte("new helper"), 0o600))
+			} else {
+				require.NoError(t, os.WriteFile(newCandidate, []byte("new helper"), 0o600))
+			}
+
+			m := f.marker(markerInstalling)
+			m.BinaryReplaced = false
+			m.PayloadBackups = []payloadBackup{
+				{TargetPath: existingTarget, BackupPath: existingBackup},
+				{TargetPath: newTarget, CandidatePath: newCandidate, OriginalMissing: true},
+			}
+			require.NoError(t, saveMarker(dir, m))
+
+			require.NoError(t, RunStartupWatchdog(t.Context(), f.dataDir, testPrevVersion))
+			assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+			assert.Equal(t, "old service", readFileString(t, existingTarget))
+			assert.NoFileExists(t, newTarget)
+			assert.NoFileExists(t, newCandidate)
+			assert.Equal(t, "after the update", readTestDBNote(t, f.dbPath),
+				"an incoming version that never ran must not restore UserDB")
+			assert.NoFileExists(t, markerPath(dir))
+		})
+	}
+}
+
+func TestRunStartupWatchdog_RollsBackBinaryLeftInstalling(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerInstalling)))
+
+	err := RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+	assert.NoFileExists(t, markerPath(dir))
+
+	res := peekUpdateResult(dir)
+	require.NotNil(t, res)
+	assert.Equal(t, outcomeRolledBack, res.Outcome)
 }
 
 func TestRestoreUserDB_UsesSuppliedFilesystem(t *testing.T) {
@@ -1222,6 +1363,45 @@ func TestRunStartupWatchdog_StopsStartupWhenRestoredDatabaseCannotBeRecorded(t *
 	require.NotNil(t, onDisk)
 	assert.False(t, onDisk.UserDBRestored)
 	assert.Equal(t, markerRollingBack, onDisk.State)
+}
+
+func TestRunStartupWatchdog_RetriesWhenRollbackOutcomeCannotBeSaved(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	dir := stateDirFor(f.dataDir)
+	require.NoError(t, saveMarker(dir, f.marker(markerConfirming)))
+
+	saveErr := errors.New("terminal marker storage unavailable")
+	ops := defaultWatchdogFileOps()
+	realSave := ops.marker.save
+	saveCalls := 0
+	ops.marker.save = func(gotDir string, marker *pendingMarker) error {
+		saveCalls++
+		if saveCalls == 4 {
+			return saveErr
+		}
+		return realSave(gotDir, marker)
+	}
+
+	err := runStartupWatchdogWithOps(t.Context(), f.dataDir, testTargetVersion, ops)
+	require.ErrorIs(t, err, ErrRolledBack)
+	require.ErrorIs(t, err, saveErr)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.NoFileExists(t, f.backupPath)
+
+	onDisk, loadErr := loadMarker(dir)
+	require.NoError(t, loadErr)
+	require.NotNil(t, onDisk)
+	assert.Equal(t, markerRollingBack, onDisk.State)
+	assert.Equal(t, f.targetPath, onDisk.RestoringPath)
+	assert.Empty(t, onDisk.Outcome)
+
+	err = RunStartupWatchdog(t.Context(), f.dataDir, testTargetVersion)
+	require.ErrorIs(t, err, ErrRolledBack)
+	assert.Equal(t, "old binary", readFileString(t, f.targetPath))
+	assert.Equal(t, "before the update", readTestDBNote(t, f.dbPath))
+	assert.NoFileExists(t, markerPath(dir))
 }
 
 // The failed-start hook runs after the startup watchdog in the same Start call.


### PR DESCRIPTION
- A rollback cleared and persisted the marker's `restoringPath` immediately after renaming the binary back, so a crash before the terminal outcome save left a consumed backup with nothing on disk explaining it. The next boot read that as a permanently missing prerequisite and abandoned the rollback, leaving the version that failed to start installed; the field now stays set until the terminal outcome save makes the whole rollback durable in one write.
- `restoreReplacedFile` and `restoreReplacedFileState` collapse into one function now that the binary and payload restores no longer differ, and `confirmWithOps` loads and saves through the injected marker operations rather than calling the package functions directly.
- `installStaged` takes its two marker saves and the directory sync after the binary swap from `payloadOps`, matching the payload loop that already did. Production behaviour is unchanged; the calls go through the same seam the rest of the install uses.
- New install tests cover the transaction boundaries that had none: a pre-quiesce refusal leaving every live file, sidecar and marker untouched, a payload preparation failure part way through removing the candidates it had already made, and the five post-marker failures (payload replace, payload directory sync, binary replace, binary directory sync, final marker save) each restoring the binary, the payloads and the user database.
- New watchdog tests cover a failed outcome save, result write and marker clear each keeping what the next boot needs, an interrupted payload install aborting correctly whether some or all payloads were in place, and a binary left in the installing state rolling back.
- `docs/ota-runbook.md` documents the device side of automatic installation: `[updates] install` and `rollout` as independent controls with a truth table, platform support, a readiness checklist, an evidence record template, the Windows/Steam Deck/Batocera validation matrix and cross-platform confirmation cycle, the deliberate bad-build rollback and withdrawal drill, and the opt-in rollout evidence gates.
- The runbook's `generation_floor` guidance described bootstrapping onto an unsigned manifest, which stopped being true once signing was bootstrapped at generation 1. It now describes the floor as disaster-recovery input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the OTA runbook with signed-manifest promotion guidance.
  - Added required rollout holds at 5%, 25%, and 100%.
  - Clarified cross-platform validation criteria, upgrade compatibility, and beta rollback procedures.

- **Bug Fixes**
  - Improved installation reliability by consistently restoring payloads, binaries, markers, and snapshots after failures.
  - Strengthened recovery for interrupted installations and failed rollbacks.
  - Ensured incomplete cleanup is retried safely during the next startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->