### PR TITLE
fix(cli): remove unsupported config flag

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -56,7 +56,6 @@ type Flags struct {
 	Launch               *string
 	API                  *string
 	Version              *bool
-	Config               *bool
 	ShowLoader           *string
 	ShowPicker           *string
 	Reload               *bool
@@ -101,11 +100,6 @@ func SetupFlags() *Flags {
 			config.VersionFlagName,
 			false,
 			"print version and exit",
-		),
-		Config: flag.Bool(
-			"config",
-			false,
-			"start the text ui to handle Zaparoo config",
 		),
 		Reload: flag.Bool(
 			"reload",

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -23,7 +23,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"syscall"
 	"testing"
 
@@ -34,6 +36,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSetupFlags_DoesNotAdvertiseUnsupportedConfigFlag(t *testing.T) {
+	original := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet("test", flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	t.Cleanup(func() {
+		flag.CommandLine = original
+	})
+
+	SetupFlags()
+
+	assert.Nil(t, flag.Lookup("config"))
+}
 
 func TestReloadCore(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- remove unused `-config` flag from shared CLI help
- add regression coverage preventing unsupported flag from being advertised

Closes #1328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unsupported `-config` command-line option from the CLI.
  * Prevented the CLI from advertising an unavailable configuration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->