### PR TITLE
fix(updater): stop reinstalling a release that already rolled back

### DIFF
--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -371,7 +371,49 @@ func autoInstallReleaseAllowed(opts *Options, release *otameta.Release) error {
 	if rolloutHeld(opts.DeviceID, release) {
 		return fmt.Errorf("%w: release is not rolled out to this device", errAutoInstallIneligible)
 	}
+	if version := releaseVersion(release); rolledBackHere(opts.DataDir, version) {
+		return fmt.Errorf("%w: %s already failed to start on this device",
+			errAutoInstallIneligible, version)
+	}
 	return nil
+}
+
+func releaseVersion(release *otameta.Release) string {
+	if release == nil {
+		return ""
+	}
+	return otameta.VersionFromTag(release.TagName)
+}
+
+// rolledBackHere reports whether this exact version was already installed here
+// and had to be rolled back.
+//
+// Nothing else declines it. Without this an automatic install repeats the whole
+// download, snapshot, swap and restore on every check for as long as the bad
+// release stays published, which on a device whose owner is not watching is a
+// loop nobody sees: the inbox keeps one row per category, so the tenth failure
+// looks exactly like the first.
+//
+// Only automatic installs are declined. A person asking for it again is asking
+// on purpose, and a later version is a different release that has not failed.
+func rolledBackHere(dataDir, version string) bool {
+	if dataDir == "" || version == "" {
+		return false
+	}
+	last := lastOutcome(stateDirFor(dataDir))
+	if last == nil {
+		return false
+	}
+	return last.Outcome == string(outcomeRolledBack) && last.ToVersion == version
+}
+
+// PreviouslyRolledBack reports the same refusal as the one Apply enforces, from
+// a check result a caller already has. Apply is the authority; this lets a
+// scheduler skip the work instead of arranging an install that will be refused.
+func PreviouslyRolledBack(result *Result) bool {
+	return result != nil && result.LastResult != nil &&
+		result.LastResult.Outcome == string(outcomeRolledBack) &&
+		result.LastResult.ToVersion == result.LatestVersion
 }
 
 func rolloutHeld(deviceID string, release *otameta.Release) bool {

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
@@ -354,6 +355,77 @@ func TestAutoInstallReleaseAllowed(t *testing.T) {
 		autoInstallReleaseAllowed(&Options{Mode: ModeAuto, DeviceID: "device-1"}, held),
 		errAutoInstallIneligible)
 	assert.NoError(t, autoInstallReleaseAllowed(&Options{Mode: ModeAuto}, full))
+}
+
+// A release that already failed to start here must not be installed again on
+// its own. Nothing else declines it, so without this the device repeats the
+// download, snapshot, swap and restore every time it checks.
+func TestAutoInstallReleaseAllowed_RefusesAVersionThisDeviceRolledBack(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	require.NoError(t, recordUpdateResult(stateDirFor(dataDir), &updateResult{
+		At:          time.Date(2026, 8, 28, 9, 21, 0, 0, time.UTC),
+		Outcome:     outcomeRolledBack,
+		FromVersion: "2.90.1",
+		ToVersion:   "2.90.2",
+	}))
+	bad := &otameta.Release{TagName: "v2.90.2", Rollout: 100}
+
+	require.ErrorIs(t,
+		autoInstallReleaseAllowed(&Options{Mode: ModeAuto, DataDir: dataDir}, bad),
+		errAutoInstallIneligible,
+		"the automatic path must not retry a version that failed here")
+
+	// A person asking for it again is asking on purpose.
+	assert.NoError(t,
+		autoInstallReleaseAllowed(&Options{Mode: ModeManual, DataDir: dataDir}, bad),
+		"a manual apply must still be able to retry it")
+
+	// A later release has not failed here, so it is offered normally.
+	assert.NoError(t, autoInstallReleaseAllowed(
+		&Options{Mode: ModeAuto, DataDir: dataDir},
+		&otameta.Release{TagName: "v2.90.3", Rollout: 100},
+	), "a newer version is a different release")
+}
+
+func TestRolledBackHere(t *testing.T) {
+	t.Parallel()
+
+	dataDir := t.TempDir()
+	assert.False(t, rolledBackHere(dataDir, "2.90.2"), "no recorded result yet")
+	assert.False(t, rolledBackHere("", "2.90.2"))
+
+	require.NoError(t, recordUpdateResult(stateDirFor(dataDir), &updateResult{
+		Outcome:     outcomeSucceeded,
+		FromVersion: "2.90.0",
+		ToVersion:   "2.90.1",
+	}))
+	assert.False(t, rolledBackHere(dataDir, "2.90.1"), "a version that installed cleanly is not blocked")
+
+	require.NoError(t, recordUpdateResult(stateDirFor(dataDir), &updateResult{
+		Outcome:     outcomeRolledBack,
+		FromVersion: "2.90.1",
+		ToVersion:   "2.90.2",
+	}))
+	assert.True(t, rolledBackHere(dataDir, "2.90.2"))
+	assert.False(t, rolledBackHere(dataDir, "2.90.3"), "only the version that failed is blocked")
+	assert.False(t, rolledBackHere(dataDir, ""))
+}
+
+func TestPreviouslyRolledBack(t *testing.T) {
+	t.Parallel()
+
+	rolledBack := &OutcomeReport{Outcome: string(outcomeRolledBack), ToVersion: "2.90.2"}
+	assert.True(t, PreviouslyRolledBack(&Result{LatestVersion: "2.90.2", LastResult: rolledBack}))
+	assert.False(t, PreviouslyRolledBack(&Result{LatestVersion: "2.90.3", LastResult: rolledBack}),
+		"a newer offer is not the release that failed")
+	assert.False(t, PreviouslyRolledBack(&Result{
+		LatestVersion: "2.90.2",
+		LastResult:    &OutcomeReport{Outcome: string(outcomeSucceeded), ToVersion: "2.90.2"},
+	}))
+	assert.False(t, PreviouslyRolledBack(&Result{LatestVersion: "2.90.2"}))
+	assert.False(t, PreviouslyRolledBack(nil))
 }
 
 func TestApply_UpdateInProgress(t *testing.T) {

--- a/pkg/service/updater_scheduler.go
+++ b/pkg/service/updater_scheduler.go
@@ -235,6 +235,16 @@ func (s *updaterScheduler) tryInstall(ctx context.Context) {
 	result := s.pending.Load()
 	if s.cfg == nil || !s.cfg.UpdateCheck() || !s.cfg.UpdateInstall() ||
 		s.installScheduled.Load() || !s.installDue(s.clock.Now()) || !autoInstallable(result) {
+		// Every other reason here is visible elsewhere: the settings are the
+		// operator's own, and the rest are reported by update.check. A version
+		// held back because it already failed on this device is not, and an
+		// update that stops arriving with no explanation is the hardest kind to
+		// diagnose from a log.
+		if updater.PreviouslyRolledBack(result) {
+			log.Info().
+				Str("version", result.LatestVersion).
+				Msg("not installing a version that already failed to start here; apply it manually to retry")
+		}
 		return
 	}
 

--- a/pkg/service/updater_scheduler.go
+++ b/pkg/service/updater_scheduler.go
@@ -227,7 +227,8 @@ func (s *updaterScheduler) tryCheck(ctx context.Context) {
 
 func autoInstallable(result *updater.Result) bool {
 	return result != nil && result.UpdateAvailable && !result.RolloutHeld &&
-		result.Eligibility == updater.EligibilityEligible
+		result.Eligibility == updater.EligibilityEligible &&
+		!updater.PreviouslyRolledBack(result)
 }
 
 func (s *updaterScheduler) tryInstall(ctx context.Context) {

--- a/pkg/service/updater_scheduler_test.go
+++ b/pkg/service/updater_scheduler_test.go
@@ -305,4 +305,15 @@ func TestAutoInstallable(t *testing.T) {
 	copyResult.UpdateAvailable = false
 	assert.False(t, autoInstallable(&copyResult))
 	assert.False(t, autoInstallable(nil))
+
+	// A release this device already rolled back is not scheduled again. Apply
+	// refuses it anyway; skipping here avoids arranging work that cannot run.
+	copyResult = *eligible
+	copyResult.LatestVersion = "2.90.2"
+	copyResult.LastResult = &updater.OutcomeReport{Outcome: "rolledBack", ToVersion: "2.90.2"}
+	assert.False(t, autoInstallable(&copyResult))
+
+	// The version after it has not failed here.
+	copyResult.LatestVersion = "2.90.3"
+	assert.True(t, autoInstallable(&copyResult))
 }


### PR DESCRIPTION
Stacked on #1330. Found by hardware testing on RePlayOS, which is the only device here that is not package-manager managed and so the only one where automatic installation runs at all.

- A device with `[updates] install = true` reinstalls a release that failed to start, indefinitely. Nothing in the decision path consults how the last update ended: `lastResult` is persisted and read only to populate the check response, `autoInstallable` tests availability, rollout and eligibility, and `autoInstallReleaseAllowed` tests mode, managed status and rollout. None of them notice that this exact version rolled back an hour ago.
- Each pass downloads the archive, snapshots the user database, swaps the binary, fails, and restores everything, repeating on every check and immediately on every restart until the release is withdrawn or its rollout set to zero. Observed on hardware: three installs and two rollbacks before withdrawal stopped it. On MiSTer that is a write cycle onto exfat each time.
- It is invisible from the device. `Inbox` has a unique index on `(Category, ProfileID)` and updates in place, so the tenth failure looks exactly like the first, and the point of enabling automatic installation is that nobody is watching.
- `Apply` now refuses, in `ModeAuto` only, a version this device already rolled back, and the scheduler skips arranging an install that would be refused. Manual `update.apply` is unaffected: a person asking again is asking on purpose. A later version is a different release and is offered normally, so a fix promoted above the bad build still lands without intervention.
- The new refusal logs its reason. Every other early return in `tryInstall` is visible elsewhere — the settings belong to the operator and the rest are reported by `update.check` — but an update that silently stops arriving is the hardest kind to diagnose.

Verified on the device that produced the loop: offered the same bad release it declined with `installs` and `rollbacks` unchanged and the reason logged, then a manual `update.apply` installed it, failed and rolled back as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Automatic updates no longer repeatedly install a release that previously failed to start and was rolled back on the device.
  - Newer releases remain eligible for automatic installation.
  - Skipped releases are clearly logged with instructions to retry installation manually.
- **Reliability**
  - Improved detection of previously rolled-back release versions to prevent repeated update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->