### PR TITLE
fix(service): stop restarting when the schema is ahead of the binary

### DIFF
--- a/cmd/linux/main.go
+++ b/cmd/linux/main.go
@@ -41,7 +41,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		os.Exit(cli.ExitCodeFor(err))
 	}
 }
 

--- a/cmd/replayos/conf/zaparoo.service
+++ b/cmd/replayos/conf/zaparoo.service
@@ -11,6 +11,11 @@ WorkingDirectory=/media/sd/zaparoo
 ExecStart=/media/sd/zaparoo/zaparoo -daemon
 Restart=on-failure
 RestartSec=5s
+# Core exits 78 when starting again cannot help, currently a user database
+# written by a newer build than the one installed. Retrying that every five
+# seconds buries the explanation under copies of itself; failing here leaves it
+# readable in systemctl status. See docs/ota-runbook.md.
+RestartPreventExitStatus=78
 
 # Logging
 StandardOutput=journal

--- a/cmd/replayos/main.go
+++ b/cmd/replayos/main.go
@@ -61,7 +61,7 @@ const serviceFilePath = "/etc/systemd/system/zaparoo.service"
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		os.Exit(cli.ExitCodeFor(err))
 	}
 }
 

--- a/pkg/cli/exit.go
+++ b/pkg/cli/exit.go
@@ -1,0 +1,58 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+)
+
+// ExitUnrecoverable is the exit status for a startup failure that starting
+// again cannot fix.
+//
+// The service units set RestartPreventExitStatus to it. Without that, a
+// supervisor retries every few seconds forever: each attempt reopens the
+// databases, fails in the same place, and writes the same error, so the one
+// line explaining the problem is buried under repetitions of itself and the
+// device looks like it is doing something about it. Stopping at a failed unit
+// with the reason still visible is the more useful answer.
+//
+// 78 is EX_CONFIG from sysexits.h, which is close enough to what this is: the
+// state on disk is not something this build can work with.
+const ExitUnrecoverable = 78
+
+// ExitCodeFor maps a startup error to the process exit status to leave behind.
+//
+// Only conditions a person has to resolve qualify. Anything transient — a
+// missing network, a busy file, a database that can be recovered — stays 1 so
+// the supervisor keeps trying, because those do come good on their own.
+func ExitCodeFor(err error) int {
+	if err == nil {
+		return 0
+	}
+	// A schema written by a newer build. Core refuses to start rather than
+	// discard user data it cannot reconstruct, and no number of restarts
+	// changes what is in the file; recovery is in docs/ota-runbook.md.
+	if errors.Is(err, database.ErrSchemaAhead) {
+		return ExitUnrecoverable
+	}
+	return 1
+}

--- a/pkg/cli/exit_test.go
+++ b/pkg/cli/exit_test.go
@@ -1,0 +1,74 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExitCodeFor(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, ExitCodeFor(nil))
+	assert.Equal(t, 1, ExitCodeFor(errors.New("something broke")))
+
+	// The error reaches main through service.Start and makeDatabase, each of
+	// which wraps it, so the status has to survive the whole chain rather than
+	// only matching the bare sentinel.
+	wrapped := fmt.Errorf("error starting service: %w",
+		fmt.Errorf("error migrating userdb: %w",
+			fmt.Errorf("%w: database is at version 20260828000000 but this binary "+
+				"only supports up to 20260818120000", database.ErrSchemaAhead)))
+	assert.Equal(t, ExitUnrecoverable, ExitCodeFor(wrapped))
+	assert.Equal(t, ExitUnrecoverable, ExitCodeFor(database.ErrSchemaAhead))
+}
+
+// The exit status is only useful if the units decline to restart on it, and
+// nothing else connects the two: a change to one and not the other reinstates
+// the restart loop silently.
+func TestServiceUnitsDeclineToRestartOnTheUnrecoverableStatus(t *testing.T) {
+	t.Parallel()
+
+	units := []string{
+		filepath.Join("..", "..", "cmd", "replayos", "conf", "zaparoo.service"),
+		filepath.Join("..", "platforms", "linux", "installer", "conf", "zaparoo.service"),
+	}
+	want := fmt.Sprintf("RestartPreventExitStatus=%d", ExitUnrecoverable)
+
+	for _, path := range units {
+		data, err := os.ReadFile(path) //nolint:gosec // repository-relative test fixture
+		require.NoError(t, err, "unit file should be readable")
+		unit := string(data)
+		require.Contains(t, unit, "Restart=on-failure",
+			"%s: this test only matters while the unit restarts on failure", path)
+		assert.Contains(t, unit, want,
+			"%s: must not restart on the unrecoverable exit status", path)
+		assert.NotContains(t, unit, "RestartPreventExitStatus=\n",
+			"%s: empty RestartPreventExitStatus", path)
+	}
+}

--- a/pkg/platforms/linux/installer/conf/zaparoo.service
+++ b/pkg/platforms/linux/installer/conf/zaparoo.service
@@ -8,6 +8,11 @@ Type=simple
 ExecStart={{.ExecPath}} -daemon
 Restart=on-failure
 RestartSec=5s
+# Core exits 78 when starting again cannot help, currently a user database
+# written by a newer build than the one installed. Retrying that every five
+# seconds buries the explanation under copies of itself; failing here leaves it
+# readable in systemctl status. See docs/ota-runbook.md.
+RestartPreventExitStatus=78
 TimeoutStopSec=15s
 KillMode=control-group
 


### PR DESCRIPTION
Found while restoring a test device by hand. Independent of #1330 and #1334, so it can merge in any order.

- Core refuses to start when the user database was migrated by a newer build than the one installed. That refusal is correct and stays: the media database is rebuilt in the same situation because a reindex reconstructs it, while the user database holds history, mappings and profiles that nothing can.
- The problem is what follows. The process exits 1, the supervisor retries every five seconds, and each attempt reopens the databases, fails identically and logs the same line. Observed on ReplayOS: twenty-one restarts in about two minutes, with the one useful message buried under copies of itself while the device appears to be recovering.
- Startup failures a person has to resolve now exit 78 (`EX_CONFIG`), and both service units set `RestartPreventExitStatus=78`, so the unit stops in a failed state with the reason readable from `systemctl status`. Transient failures — no network, a busy file, a recoverable database — still exit 1 and are still retried, because those do come good on their own.
- The exit status and the unit files only work as a pair and nothing else ties them together, so a test reads both units and fails if either stops declining the status, or declines an empty one.

Reachable without OTA: manually reinstalling an older release, or a package manager moving an install backwards, both produce it. Rolling back through Core does not, because the update snapshot restores the database alongside the binary. Operator recovery is documented in the runbook entry on #1330.

`systemd-analyze verify` accepts both units.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Startup failures now return meaningful exit statuses instead of always returning status 1.
  * Incompatible user databases are identified with a dedicated status code.
  * The service no longer repeatedly restarts when an incompatible database is detected, keeping the diagnostic message visible in service status.

* **Tests**
  * Added coverage for exit-status handling and service restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->