### PR TITLE
feat(updater): add update status and ways to trigger an update

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -349,6 +349,7 @@ Methods execute actions and return data from Core. See [API Methods](./methods) 
 | settings.auth.link              | Start online account link.                                                            | All clients |
 | settings.auth.link.status       | Return online account link flow status.                                               | Tiered |
 | settings.auth.link.cancel       | Cancel online account link flow.                                                      | Local/admin |
+| update.status                   | Report the last known update state without contacting the release server.             | Localhost or any paired client |
 | update.check                    | Check for newer Core version.                                                         | Localhost or any paired client |
 | update.apply                    | Apply latest update and restart gracefully.                                           | `update.apply` |
 

--- a/pkg/api/methods/update.go
+++ b/pkg/api/methods/update.go
@@ -193,6 +193,40 @@ func HandleUpdateCheck(
 		return nil, fmt.Errorf("update check failed: %w", err)
 	}
 
+	return updateResponse(result, autoInstall), nil
+}
+
+// HandleUpdateStatus reports what the device already knows about updates.
+//
+// It exists because a check is not free: it fetches and verifies signed
+// metadata and writes the outcome to the data directory, so anything that shows
+// update state whenever a screen is drawn would drive repeated flash writes and
+// outbound requests. Both a status line that refreshes on its own and a "check
+// now" button are wanted, and they are not the same request.
+//
+// The same authorization as a check. It reads no less about the device, and the
+// difference in cost is not a difference in who should see it.
+func HandleUpdateStatus(
+	env requests.RequestEnv, //nolint:gocritic // hugeParam
+	statusFn func(ctx context.Context, opts updater.Options) *updater.Result,
+) (any, error) {
+	if err := requireAuthenticated(&env); err != nil {
+		return nil, err
+	}
+
+	opts := updaterOptions(&env, updater.ModeManual)
+	opts.Gate = updateGateDeps(&env)
+	return updateResponse(statusFn(env.Context, opts), env.Config.UpdateInstall()), nil
+}
+
+func updateResponse(result *updater.Result, autoInstall bool) models.UpdateCheckResponse {
+	if result == nil {
+		return models.UpdateCheckResponse{
+			CurrentVersion: config.AppVersion,
+			AutoInstall:    autoInstall,
+		}
+	}
+
 	resp := models.UpdateCheckResponse{
 		CurrentVersion:  result.CurrentVersion,
 		LatestVersion:   result.LatestVersion,
@@ -228,7 +262,7 @@ func HandleUpdateCheck(
 			Detail:      result.LastResult.Detail,
 		}
 	}
-	return resp, nil
+	return resp
 }
 
 func HandleUpdateApply(

--- a/pkg/api/methods/update_test.go
+++ b/pkg/api/methods/update_test.go
@@ -1146,3 +1146,94 @@ func TestHandleUpdateApply_NoParamsIsNotForced(t *testing.T) {
 	assert.Nil(t, result)
 	assert.False(t, applied)
 }
+
+// Status reports what the last check concluded without contacting anything, so
+// a client can draw update state whenever a screen is painted.
+func TestHandleUpdateStatus_ReportsWhatTheLastCheckFound(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		IsLocal:  true,
+	}
+
+	checkedAt := time.Now().Add(-3 * time.Hour)
+	var gotMode updater.Mode
+	statusFn := func(_ context.Context, opts updater.Options) *updater.Result {
+		gotMode = opts.Mode
+		return &updater.Result{
+			CurrentVersion:  "2.9.0",
+			LatestVersion:   "2.10.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+			CheckedAt:       checkedAt,
+		}
+	}
+
+	result, err := HandleUpdateStatus(env, statusFn)
+	require.NoError(t, err)
+
+	resp, ok := result.(models.UpdateCheckResponse)
+	require.True(t, ok)
+	assert.Equal(t, "2.9.0", resp.CurrentVersion)
+	assert.Equal(t, "2.10.0", resp.LatestVersion)
+	assert.True(t, resp.UpdateAvailable)
+	assert.Equal(t, updater.ModeManual, gotMode)
+	require.NotNil(t, resp.CheckedAt)
+	assert.WithinDuration(t, checkedAt, *resp.CheckedAt, time.Second)
+}
+
+// A device that has never completed a check still has to answer, because the
+// screen asking is drawn before the first check runs.
+func TestHandleUpdateStatus_AnswersBeforeAnyCheckHasRun(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		IsLocal:  true,
+	}
+
+	result, err := HandleUpdateStatus(env, func(context.Context, updater.Options) *updater.Result {
+		return nil
+	})
+	require.NoError(t, err)
+
+	resp, ok := result.(models.UpdateCheckResponse)
+	require.True(t, ok)
+	assert.Equal(t, config.AppVersion, resp.CurrentVersion)
+	assert.False(t, resp.UpdateAvailable)
+	assert.Nil(t, resp.CheckedAt)
+}
+
+// Status reads device state, so it needs the same authorization a check does.
+func TestHandleUpdateStatus_RefusesAnUnauthenticatedClient(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.SetupBasicMock()
+
+	env := requests.RequestEnv{
+		Context:  t.Context(),
+		Platform: mockPlatform,
+		Config:   &config.Instance{},
+		IsLocal:  false,
+	}
+
+	called := false
+	_, err := HandleUpdateStatus(env, func(context.Context, updater.Options) *updater.Result {
+		called = true
+		return nil
+	})
+	require.Error(t, err)
+	assert.False(t, called, "an unauthorized request must not reach the updater")
+}

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -177,6 +177,7 @@ const (
 	MethodSettingsAuthLinkStatus      = "settings.auth.link.status"
 	MethodSettingsAuthLinkCancel      = "settings.auth.link.cancel"
 	MethodUpdateCheck                 = "update.check"
+	MethodUpdateStatus                = "update.status"
 	MethodUpdateApply                 = "update.apply"
 	MethodInputKeyboard               = "input.keyboard"
 	MethodInputGamepad                = "input.gamepad"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -456,6 +456,9 @@ func NewMethodMap() *MethodMap {
 		models.MethodUpdateCheck: func(env requests.RequestEnv) (any, error) {
 			return methods.HandleUpdateCheck(env, updater.Check)
 		},
+		models.MethodUpdateStatus: func(env requests.RequestEnv) (any, error) {
+			return methods.HandleUpdateStatus(env, updater.Status)
+		},
 		models.MethodUpdateApply: func(env requests.RequestEnv) (any, error) {
 			return methods.HandleUpdateApply(env, updater.Apply, env.State.RestartService)
 		},

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -60,6 +60,7 @@ type Flags struct {
 	ShowPicker           *string
 	Reload               *bool
 	Pair                 *bool
+	Update               *bool
 	Backup               *bool
 	Backups              *bool
 	Restore              *string
@@ -110,6 +111,11 @@ func SetupFlags() *Flags {
 			"pair",
 			false,
 			"start pairing flow and display PIN for client to enter",
+		),
+		Update: flag.Bool(
+			"update",
+			false,
+			"show update status, and install one if available",
 		),
 		Backup: flag.Bool(
 			"backup",
@@ -393,6 +399,8 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 			os.Exit(1)
 		}
 		os.Exit(0)
+	case *f.Update:
+		os.Exit(runUpdate(context.Background(), cfg, client.LocalClient))
 	case *f.Backup:
 		resp, err := client.LocalClient(context.Background(), cfg, models.MethodSettingsBackup, "")
 		if err != nil {

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -80,7 +80,7 @@ func runUpdateTo(
 		return 1
 	}
 
-	_, _ = fmt.Fprintf(stdout, "Installing %s. Core will restart when it finishes.\n", status.LatestVersion)
+	_, _ = fmt.Fprintln(stdout, describeInstallIntent(status))
 	applied, err := fetchUpdateApply(ctx, cfg, call)
 	if err != nil {
 		logClientCommandError(err, "error installing update")
@@ -121,6 +121,23 @@ func describeUpdateStatus(s *models.UpdateCheckResponse) string {
 		return describeAvailableUpdate(s)
 	}
 	return fmt.Sprintf("Running %s. %s", s.CurrentVersion, describeLastCheck(s.CheckedAt))
+}
+
+// describeInstallIntent says what is about to happen, and says it differently
+// when the release on offer is the one that already failed to start here.
+//
+// Only automatic installs decline that version; asking for it by hand is taken
+// as asking on purpose. But this flag is also how someone just looks at where
+// the device stands, so reinstalling the build that broke it should be stated
+// rather than done quietly under a line that reads like any other update.
+func describeInstallIntent(s *models.UpdateCheckResponse) string {
+	if s.LastResult != nil &&
+		s.LastResult.Outcome == updater.OutcomeRolledBack &&
+		s.LastResult.ToVersion == s.LatestVersion {
+		return fmt.Sprintf("Installing %s again, the version that already failed to start here. "+
+			"If it fails again, %s is restored as before.", s.LatestVersion, s.CurrentVersion)
+	}
+	return fmt.Sprintf("Installing %s. Core will restart when it finishes.", s.LatestVersion)
 }
 
 // describeLastUpdate reports an update that did not simply work. A success is

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -1,0 +1,194 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+)
+
+// runUpdate prints what the device knows about updates and installs one if
+// there is one to install, returning the process exit status.
+//
+// Status first, always. Someone running this wants to know where they stand
+// even when the answer is that nothing is available, and printing it costs a
+// local read. The install only follows when there is something to install, so
+// the command is safe to run out of curiosity.
+func runUpdate(ctx context.Context, cfg *config.Instance, call reloadAPICaller) int {
+	return runUpdateTo(ctx, os.Stdout, os.Stderr, cfg, call)
+}
+
+func runUpdateTo(
+	ctx context.Context, stdout, stderr io.Writer, cfg *config.Instance, call reloadAPICaller,
+) int {
+	status, err := fetchUpdateStatus(ctx, cfg, call, models.MethodUpdateStatus)
+	if err != nil {
+		logClientCommandError(err, "error reading update status")
+		_, _ = fmt.Fprintf(stderr, "Error reading update status: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(stdout, describeUpdateStatus(status))
+
+	if !status.UpdateAvailable {
+		return 0
+	}
+	if status.BlockedBy != nil && !status.BlockedBy.Forceable {
+		// Refusing here rather than letting the apply fail: the gate's message
+		// already says what to do, and a second copy of it as an error is worse
+		// than the first as an explanation.
+		return 1
+	}
+
+	_, _ = fmt.Fprintf(stdout, "Installing %s. Core will restart when it finishes.\n", status.LatestVersion)
+	applied, err := fetchUpdateApply(ctx, cfg, call)
+	if err != nil {
+		logClientCommandError(err, "error installing update")
+		_, _ = fmt.Fprintf(stderr, "Error installing update: %v\n", err)
+		return 1
+	}
+	_, _ = fmt.Fprintf(stdout, "Installed %s. It is confirmed once Core has run for a short while;\n"+
+		"if it fails to start, the previous version is restored automatically.\n", applied.NewVersion)
+	return 0
+}
+
+// describeUpdateStatus turns a status into the one line worth reading.
+//
+// Ordered by what a person needs to know first. An update that failed and was
+// undone outranks one that is waiting, which outranks one that is available,
+// because the earlier entries are the ones where something has already
+// happened to the device.
+func describeUpdateStatus(s *models.UpdateCheckResponse) string {
+	if s == nil {
+		return "Update status is unavailable."
+	}
+
+	switch s.Eligibility {
+	case updater.EligibilityDevelopment:
+		return fmt.Sprintf("Running %s, a development build. Updates do not apply to it.", s.CurrentVersion)
+	case updater.EligibilityManaged:
+		return fmt.Sprintf("Running %s. This install is managed by a package manager, "+
+			"which is where its updates come from.", s.CurrentVersion)
+	case updater.EligibilityUnsupported:
+		return fmt.Sprintf("Running %s. This install cannot update itself; "+
+			"use the installer it came from.", s.CurrentVersion)
+	}
+
+	if outcome := describeLastUpdate(s.LastResult); outcome != "" {
+		return outcome
+	}
+	if s.UpdateAvailable {
+		return describeAvailableUpdate(s)
+	}
+	return fmt.Sprintf("Running %s. %s", s.CurrentVersion, describeLastCheck(s.CheckedAt))
+}
+
+// describeLastUpdate reports an update that did not simply work. A success is
+// deliberately silent: the version on screen already says it happened, and a
+// device that is fine should not keep announcing it.
+func describeLastUpdate(last *models.UpdateLastResult) string {
+	if last == nil {
+		return ""
+	}
+	switch last.Outcome {
+	case updater.OutcomeRolledBack:
+		return fmt.Sprintf("Update to %s failed to start and was rolled back. "+
+			"Running %s again, and your data was restored with it.", last.ToVersion, last.FromVersion)
+	case updater.OutcomeRollbackBlocked:
+		return fmt.Sprintf("Update to %s failed and could not be undone. "+
+			"The device is still running it. See docs/ota-runbook.md.", last.ToVersion)
+	case updater.OutcomeRecoveryRequired:
+		return "An interrupted update could not be resolved automatically. " +
+			"Updates are paused until it is. See docs/ota-runbook.md."
+	default:
+		return ""
+	}
+}
+
+func describeAvailableUpdate(s *models.UpdateCheckResponse) string {
+	line := fmt.Sprintf("%s is available. Running %s.", s.LatestVersion, s.CurrentVersion)
+	switch {
+	case s.BlockedBy != nil:
+		return fmt.Sprintf("%s Cannot install right now: %s", line, s.BlockedBy.Message)
+	case s.RolloutHeld:
+		return line + " It is rolling out gradually and has not reached this device yet, " +
+			"so it will not install on its own. Asking for it by hand still works."
+	case s.DeferredReason != "":
+		return line + " Waiting for a quiet moment."
+	default:
+		return line
+	}
+}
+
+// describeLastCheck says how old the answer is. Status reads what the last
+// check found rather than looking again, so claiming to be up to date without
+// saying when that was established would be overstating it.
+func describeLastCheck(checkedAt *time.Time) string {
+	if checkedAt == nil || checkedAt.IsZero() {
+		return "No update check has completed yet."
+	}
+	age := time.Since(*checkedAt)
+	switch {
+	case age < 0:
+		return "Up to date."
+	case age < time.Hour:
+		return "Up to date, checked less than an hour ago."
+	case age < 48*time.Hour:
+		return fmt.Sprintf("Up to date, checked %d hours ago.", int(age.Hours()))
+	default:
+		return fmt.Sprintf("Up to date, last checked %d days ago.", int(age.Hours()/24))
+	}
+}
+
+func fetchUpdateStatus(
+	ctx context.Context, cfg *config.Instance, call reloadAPICaller, method string,
+) (*models.UpdateCheckResponse, error) {
+	raw, err := call(ctx, cfg, method, "")
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", method, err)
+	}
+	var resp models.UpdateCheckResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("reading the %s response: %w", method, err)
+	}
+	return &resp, nil
+}
+
+func fetchUpdateApply(
+	ctx context.Context, cfg *config.Instance, call reloadAPICaller,
+) (*models.UpdateApplyResponse, error) {
+	raw, err := call(ctx, cfg, models.MethodUpdateApply, "")
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", models.MethodUpdateApply, err)
+	}
+	var resp models.UpdateApplyResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("reading the %s response: %w", models.MethodUpdateApply, err)
+	}
+	return &resp, nil
+}

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -53,6 +53,21 @@ func runUpdateTo(
 		return 1
 	}
 
+	// Status answers from the last scheduled check, which runs every twelve
+	// hours. Someone typing this command is asking now, so look again rather
+	// than acting on an answer that old: it decides both whether anything is
+	// installed and which version this says it is installing. The stored answer
+	// is kept only where looking again could not change it.
+	if updater.EligibilityCanOfferUpdates(status.Eligibility) {
+		checked, checkErr := fetchUpdateStatus(ctx, cfg, call, models.MethodUpdateCheck)
+		if checkErr != nil {
+			logClientCommandError(checkErr, "error checking for updates")
+			_, _ = fmt.Fprintf(stderr, "Error checking for updates: %v\n", checkErr)
+			return 1
+		}
+		status = checked
+	}
+
 	_, _ = fmt.Fprintln(stdout, describeUpdateStatus(status))
 
 	if !status.UpdateAvailable {

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -36,8 +36,18 @@ import (
 
 // recordingCaller answers the update methods and remembers what was asked, so a
 // test can tell "showed the status" from "went ahead and installed".
+//
+// update.check answers the same as update.status unless a test overrides it,
+// which stands for a check that found nothing new.
 func recordingCaller(
 	t *testing.T, status *models.UpdateCheckResponse,
+) (call reloadAPICaller, called *[]string) {
+	t.Helper()
+	return recordingCallerWithCheck(t, status, status)
+}
+
+func recordingCallerWithCheck(
+	t *testing.T, status, checked *models.UpdateCheckResponse,
 ) (call reloadAPICaller, called *[]string) {
 	t.Helper()
 	called = &[]string{}
@@ -46,6 +56,10 @@ func recordingCaller(
 		switch method {
 		case models.MethodUpdateStatus:
 			body, err := json.Marshal(status)
+			require.NoError(t, err)
+			return string(body), nil
+		case models.MethodUpdateCheck:
+			body, err := json.Marshal(checked)
 			require.NoError(t, err)
 			return string(body), nil
 		case models.MethodUpdateApply:
@@ -74,7 +88,9 @@ func TestRunUpdate_ShowsStatusAndInstallsWhenOneIsAvailable(t *testing.T) {
 
 	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
 	assert.Equal(t, 0, code)
-	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateApply}, *called)
+	assert.Equal(t,
+		[]string{models.MethodUpdateStatus, models.MethodUpdateCheck, models.MethodUpdateApply},
+		*called)
 	assert.Contains(t, out.String(), "2.11.0 is available")
 	assert.Contains(t, out.String(), "Installed 2.11.0")
 	assert.Empty(t, errOut.String())
@@ -95,8 +111,65 @@ func TestRunUpdate_ReportsAndStopsWhenNothingIsAvailable(t *testing.T) {
 
 	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
 	assert.Equal(t, 0, code)
-	assert.Equal(t, []string{models.MethodUpdateStatus}, *called, "must not call apply")
+	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateCheck}, *called,
+		"must not call apply")
 	assert.Contains(t, out.String(), "Up to date")
+}
+
+// The stored status is whatever the last scheduled check found, and that runs
+// every twelve hours. Someone typing the command is asking now, so a release
+// published since then has to be found rather than reported as up to date.
+func TestRunUpdate_LooksAgainWhenTheStoredAnswerIsNothing(t *testing.T) {
+	t.Parallel()
+
+	checkedAt := time.Now().Add(-6 * time.Hour)
+	call, called := recordingCallerWithCheck(t,
+		&models.UpdateCheckResponse{
+			CurrentVersion: "2.10.0",
+			Eligibility:    updater.EligibilityEligible,
+			CheckedAt:      &checkedAt,
+		},
+		&models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+		})
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 0, code)
+	assert.Equal(t,
+		[]string{models.MethodUpdateStatus, models.MethodUpdateCheck, models.MethodUpdateApply},
+		*called)
+	assert.Contains(t, out.String(), "2.11.0 is available")
+	assert.NotContains(t, out.String(), "Up to date")
+}
+
+// Checking costs a network request and a write. The states whose answer comes
+// from what the install is, rather than from what has been released, cannot be
+// changed by looking, so they must not pay for it.
+func TestRunUpdate_DoesNotLookAgainWhenNoReleaseCouldApply(t *testing.T) {
+	t.Parallel()
+
+	for name, eligibility := range map[string]string{
+		"development build": updater.EligibilityDevelopment,
+		"managed install":   updater.EligibilityManaged,
+		"unsupported":       updater.EligibilityUnsupported,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			call, called := recordingCaller(t, &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    eligibility,
+			})
+			var out, errOut bytes.Buffer
+
+			code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+			assert.Equal(t, 0, code)
+			assert.Equal(t, []string{models.MethodUpdateStatus}, *called)
+		})
+	}
 }
 
 // The gate already explained itself. Trying anyway would only produce the same
@@ -119,7 +192,8 @@ func TestRunUpdate_DoesNotInstallThroughAGateThatCannotBeForced(t *testing.T) {
 
 	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
 	assert.Equal(t, 1, code)
-	assert.Equal(t, []string{models.MethodUpdateStatus}, *called, "must not call apply")
+	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateCheck}, *called,
+		"must not call apply")
 	assert.Contains(t, out.String(), "the media database is being indexed")
 }
 

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -283,3 +283,37 @@ func TestDescribeLastCheck_SaysHowOldTheAnswerIs(t *testing.T) {
 	stale := time.Now().Add(-6 * 24 * time.Hour)
 	assert.Contains(t, describeLastCheck(&stale), "6 days ago")
 }
+
+// Only automatic installs decline the version that already failed here, so
+// asking by hand still installs it. This flag is also how someone just looks at
+// where the device stands, so it has to say that is what it is doing.
+func TestDescribeInstallIntent_SaysWhenItIsRetryingTheVersionThatFailed(t *testing.T) {
+	t.Parallel()
+
+	retry := describeInstallIntent(&models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+		LastResult: &models.UpdateLastResult{
+			Outcome:     updater.OutcomeRolledBack,
+			FromVersion: "2.10.0",
+			ToVersion:   "2.11.0",
+		},
+	})
+	assert.Contains(t, retry, "already failed to start here")
+	assert.Contains(t, retry, "2.10.0 is restored")
+
+	// A newer release is a different release, and has not failed here.
+	ordinary := describeInstallIntent(&models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.12.0",
+		UpdateAvailable: true,
+		LastResult: &models.UpdateLastResult{
+			Outcome:     updater.OutcomeRolledBack,
+			FromVersion: "2.10.0",
+			ToVersion:   "2.11.0",
+		},
+	})
+	assert.Contains(t, ordinary, "Installing 2.12.0.")
+	assert.NotContains(t, ordinary, "already failed")
+}

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -1,0 +1,211 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCaller answers the update methods and remembers what was asked, so a
+// test can tell "showed the status" from "went ahead and installed".
+func recordingCaller(
+	t *testing.T, status *models.UpdateCheckResponse,
+) (call reloadAPICaller, called *[]string) {
+	t.Helper()
+	called = &[]string{}
+	return func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		*called = append(*called, method)
+		switch method {
+		case models.MethodUpdateStatus:
+			body, err := json.Marshal(status)
+			require.NoError(t, err)
+			return string(body), nil
+		case models.MethodUpdateApply:
+			body, err := json.Marshal(models.UpdateApplyResponse{
+				PreviousVersion: status.CurrentVersion,
+				NewVersion:      status.LatestVersion,
+			})
+			require.NoError(t, err)
+			return string(body), nil
+		default:
+			return "", errors.New("unexpected method " + method)
+		}
+	}, called
+}
+
+func TestRunUpdate_ShowsStatusAndInstallsWhenOneIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	call, called := recordingCaller(t, &models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+		Eligibility:     updater.EligibilityEligible,
+	})
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateApply}, *called)
+	assert.Contains(t, out.String(), "2.11.0 is available")
+	assert.Contains(t, out.String(), "Installed 2.11.0")
+	assert.Empty(t, errOut.String())
+}
+
+// Nothing to install must not turn into an install attempt, so the command is
+// safe to run just to see where the device stands.
+func TestRunUpdate_ReportsAndStopsWhenNothingIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	checkedAt := time.Now().Add(-2 * time.Hour)
+	call, called := recordingCaller(t, &models.UpdateCheckResponse{
+		CurrentVersion: "2.11.0",
+		Eligibility:    updater.EligibilityEligible,
+		CheckedAt:      &checkedAt,
+	})
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 0, code)
+	assert.Equal(t, []string{models.MethodUpdateStatus}, *called, "must not call apply")
+	assert.Contains(t, out.String(), "Up to date")
+}
+
+// The gate already explained itself. Trying anyway would only produce the same
+// sentence as an error.
+func TestRunUpdate_DoesNotInstallThroughAGateThatCannotBeForced(t *testing.T) {
+	t.Parallel()
+
+	call, called := recordingCaller(t, &models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+		Eligibility:     updater.EligibilityEligible,
+		BlockedBy: &models.UpdateBlockedBy{
+			Reason:    "indexing",
+			Message:   "the media database is being indexed",
+			Forceable: false,
+		},
+	})
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 1, code)
+	assert.Equal(t, []string{models.MethodUpdateStatus}, *called, "must not call apply")
+	assert.Contains(t, out.String(), "the media database is being indexed")
+}
+
+func TestDescribeUpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status *models.UpdateCheckResponse
+		want   string
+	}{
+		"nothing known": {status: nil, want: "unavailable"},
+		"development build": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "abc123-dev",
+				Eligibility:    updater.EligibilityDevelopment,
+			},
+			want: "development build",
+		},
+		"managed install": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    updater.EligibilityManaged,
+			},
+			want: "managed by a package manager",
+		},
+		// A rollback outranks an available update: something already happened to
+		// this device and the person needs to know before anything else.
+		"rollback outranks availability": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				Eligibility:     updater.EligibilityEligible,
+				LastResult: &models.UpdateLastResult{
+					Outcome:     updater.OutcomeRolledBack,
+					FromVersion: "2.10.0",
+					ToVersion:   "2.11.0",
+				},
+			},
+			want: "rolled back",
+		},
+		"a successful update is not worth announcing": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    updater.EligibilityEligible,
+				LastResult: &models.UpdateLastResult{
+					Outcome:     updater.OutcomeSucceeded,
+					FromVersion: "2.10.0",
+					ToVersion:   "2.11.0",
+				},
+			},
+			want: "Running 2.11.0",
+		},
+		"held by rollout": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				RolloutHeld:     true,
+				Eligibility:     updater.EligibilityEligible,
+			},
+			want: "has not reached this device yet",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Contains(t, describeUpdateStatus(tt.status), tt.want)
+		})
+	}
+}
+
+// Status reads what the last check found rather than looking again, so the line
+// has to admit how old that is instead of implying it just looked.
+func TestDescribeLastCheck_SaysHowOldTheAnswerIs(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, describeLastCheck(nil), "No update check has completed")
+
+	recent := time.Now().Add(-10 * time.Minute)
+	assert.Contains(t, describeLastCheck(&recent), "less than an hour ago")
+
+	hours := time.Now().Add(-5 * time.Hour)
+	assert.Contains(t, describeLastCheck(&hours), "5 hours ago")
+
+	stale := time.Now().Add(-6 * 24 * time.Hour)
+	assert.Contains(t, describeLastCheck(&stale), "6 days ago")
+}

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -63,9 +63,11 @@ func recordingCallerWithCheck(
 			require.NoError(t, err)
 			return string(body), nil
 		case models.MethodUpdateApply:
+			// The checked status is what apply installs, since the command acts
+			// on the check rather than on the stored answer.
 			body, err := json.Marshal(models.UpdateApplyResponse{
-				PreviousVersion: status.CurrentVersion,
-				NewVersion:      status.LatestVersion,
+				PreviousVersion: checked.CurrentVersion,
+				NewVersion:      checked.LatestVersion,
 			})
 			require.NoError(t, err)
 			return string(body), nil
@@ -143,6 +145,7 @@ func TestRunUpdate_LooksAgainWhenTheStoredAnswerIsNothing(t *testing.T) {
 		[]string{models.MethodUpdateStatus, models.MethodUpdateCheck, models.MethodUpdateApply},
 		*called)
 	assert.Contains(t, out.String(), "2.11.0 is available")
+	assert.Contains(t, out.String(), "Installed 2.11.0")
 	assert.NotContains(t, out.String(), "Up to date")
 }
 

--- a/pkg/cli/update_test.go
+++ b/pkg/cli/update_test.go
@@ -282,6 +282,13 @@ func TestDescribeLastCheck_SaysHowOldTheAnswerIs(t *testing.T) {
 
 	stale := time.Now().Add(-6 * 24 * time.Hour)
 	assert.Contains(t, describeLastCheck(&stale), "6 days ago")
+
+	// A device with no clock can produce a check stamped in the future. Saying
+	// it was checked "-3 hours ago" would read as a fault that is not there.
+	future := time.Now().Add(3 * time.Hour)
+	assert.Equal(t, "Up to date.", describeLastCheck(&future))
+
+	assert.Contains(t, describeLastCheck(&time.Time{}), "No update check has completed")
 }
 
 // Only automatic installs decline the version that already failed here, so
@@ -316,4 +323,125 @@ func TestDescribeInstallIntent_SaysWhenItIsRetryingTheVersionThatFailed(t *testi
 	})
 	assert.Contains(t, ordinary, "Installing 2.12.0.")
 	assert.NotContains(t, ordinary, "already failed")
+}
+
+// A status that cannot be read is a failure, not a device with no update: going
+// ahead on it would install against an unknown state.
+func TestRunUpdate_StopsWhenStatusCannotBeRead(t *testing.T) {
+	t.Parallel()
+
+	called := []string{}
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		called = append(called, method)
+		return "", errors.New("connection refused")
+	}
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 1, code)
+	assert.Equal(t, []string{models.MethodUpdateStatus}, called)
+	assert.Contains(t, errOut.String(), "Error reading update status")
+}
+
+// The check is what the command acts on, so failing it has to stop the run
+// rather than fall back to the stored answer it was meant to replace.
+func TestRunUpdate_StopsWhenTheCheckFails(t *testing.T) {
+	t.Parallel()
+
+	called := []string{}
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		called = append(called, method)
+		if method == models.MethodUpdateCheck {
+			return "", errors.New("no route to host")
+		}
+		body, err := json.Marshal(models.UpdateCheckResponse{
+			CurrentVersion: "2.10.0",
+			Eligibility:    updater.EligibilityEligible,
+		})
+		require.NoError(t, err)
+		return string(body), nil
+	}
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 1, code)
+	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateCheck}, called,
+		"must not call apply")
+	assert.Contains(t, errOut.String(), "Error checking for updates")
+}
+
+func TestRunUpdate_ReportsAFailedInstall(t *testing.T) {
+	t.Parallel()
+
+	available := models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+		Eligibility:     updater.EligibilityEligible,
+	}
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		if method == models.MethodUpdateApply {
+			return "", errors.New("install failed")
+		}
+		body, err := json.Marshal(available)
+		require.NoError(t, err)
+		return string(body), nil
+	}
+	var out, errOut bytes.Buffer
+
+	code := runUpdateTo(t.Context(), &out, &errOut, nil, call)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, errOut.String(), "Error installing update")
+}
+
+// A response that arrives but cannot be read must not be mistaken for an empty
+// one, which would read as a device with nothing to install.
+func TestFetchUpdate_RejectsAResponseItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	garbage := func(context.Context, *config.Instance, string, string) (string, error) {
+		return "not json", nil
+	}
+	_, err := fetchUpdateStatus(t.Context(), nil, garbage, models.MethodUpdateStatus)
+	require.Error(t, err)
+
+	_, err = fetchUpdateApply(t.Context(), nil, garbage)
+	require.Error(t, err)
+}
+
+// The states where an update did not simply work each need their own sentence;
+// a success deliberately produces none.
+func TestDescribeLastUpdate(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, describeLastUpdate(nil))
+	assert.Empty(t, describeLastUpdate(&models.UpdateLastResult{
+		Outcome: updater.OutcomeSucceeded, ToVersion: "2.11.0",
+	}))
+	assert.Contains(t, describeLastUpdate(&models.UpdateLastResult{
+		Outcome: updater.OutcomeRollbackBlocked, ToVersion: "2.11.0",
+	}), "could not be undone")
+	assert.Contains(t, describeLastUpdate(&models.UpdateLastResult{
+		Outcome: updater.OutcomeRecoveryRequired,
+	}), "interrupted update")
+}
+
+func TestDescribeAvailableUpdate_ExplainsWhyItIsWaiting(t *testing.T) {
+	t.Parallel()
+
+	base := models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+	}
+
+	blocked := base
+	blocked.BlockedBy = &models.UpdateBlockedBy{Message: "a token is being written"}
+	assert.Contains(t, describeAvailableUpdate(&blocked), "a token is being written")
+
+	deferred := base
+	deferred.DeferredReason = "media is running"
+	assert.Contains(t, describeAvailableUpdate(&deferred), "quiet moment")
+
+	assert.Equal(t, "2.11.0 is available. Running 2.10.0.", describeAvailableUpdate(&base))
 }

--- a/pkg/service/updater/marker.go
+++ b/pkg/service/updater/marker.go
@@ -77,15 +77,25 @@ const (
 // updateOutcome is written once an update reaches a terminal state.
 type updateOutcome string
 
+// The outcomes as they appear in API responses and on disk. Exported because
+// anything rendering an update's result has to match on them, and a client
+// spelling one out by hand compiles perfectly and then never matches.
 const (
-	outcomeSucceeded        updateOutcome = "succeeded"
-	outcomeRolledBack       updateOutcome = "rolledBack"
-	outcomeRecoveryRequired updateOutcome = "recoveryRequired"
-	// outcomeRollbackBlocked means the binary was rolled back but the user
+	OutcomeSucceeded        = "succeeded"
+	OutcomeRolledBack       = "rolledBack"
+	OutcomeRecoveryRequired = "recoveryRequired"
+	// OutcomeRollbackBlocked means the binary was rolled back but the user
 	// database snapshot could not be restored, or the rollback could not be
 	// completed at all, and the new binary was left installed instead. A device
 	// running a suspect version beats one that will not boot.
-	outcomeRollbackBlocked updateOutcome = "rollbackBlocked"
+	OutcomeRollbackBlocked = "rollbackBlocked"
+)
+
+const (
+	outcomeSucceeded        updateOutcome = OutcomeSucceeded
+	outcomeRolledBack       updateOutcome = OutcomeRolledBack
+	outcomeRecoveryRequired updateOutcome = OutcomeRecoveryRequired
+	outcomeRollbackBlocked  updateOutcome = OutcomeRollbackBlocked
 )
 
 var (

--- a/pkg/service/updater/state.go
+++ b/pkg/service/updater/state.go
@@ -55,17 +55,33 @@ var stateMu syncutil.Mutex
 //
 //nolint:govet // Field order keeps persisted state grouped by manifest, check, and outcome.
 type updaterState struct {
-	ManifestSeenAt       time.Time       `json:"manifestSeenAt"`
-	LastCheckAt          *time.Time      `json:"lastCheckAt,omitempty"`
-	LastResult           *updateResult   `json:"lastResult,omitempty"`
-	Deferral             *updateDeferral `json:"deferral,omitempty"`
-	ManifestETag         string          `json:"manifestETag"`
-	ManifestLastModified string          `json:"manifestLastModified"`
-	LastOfferedVersion   string          `json:"lastOfferedVersion,omitempty"`
-	ManifestGeneration   int64           `json:"manifestGeneration"`
-	CheckFailures        int             `json:"checkFailures,omitempty"`
-	StateVersion         int             `json:"stateVersion"`
-	LastCheckOK          *bool           `json:"lastCheckOK,omitempty"` //nolint:tagliatelle // Established initialism.
+	ManifestSeenAt       time.Time          `json:"manifestSeenAt"`
+	LastCheckAt          *time.Time         `json:"lastCheckAt,omitempty"`
+	LastResult           *updateResult      `json:"lastResult,omitempty"`
+	Deferral             *updateDeferral    `json:"deferral,omitempty"`
+	ManifestETag         string             `json:"manifestETag"`
+	ManifestLastModified string             `json:"manifestLastModified"`
+	LastOfferedVersion   string             `json:"lastOfferedVersion,omitempty"`
+	LastCheck            *lastCheckFindings `json:"lastCheck,omitempty"`
+	ManifestGeneration   int64              `json:"manifestGeneration"`
+	CheckFailures        int                `json:"checkFailures,omitempty"`
+	StateVersion         int                `json:"stateVersion"`
+	//nolint:tagliatelle // Established initialism.
+	LastCheckOK *bool `json:"lastCheckOK,omitempty"`
+}
+
+// lastCheckFindings is what the most recent completed check concluded, kept so
+// something can be said about updates without going to the network.
+//
+// It is not derived from the cached manifest. That copy is stored without its
+// signature — the signature is always fetched fresh, because the cache is a
+// bandwidth optimisation and never a trust boundary — so nothing offline can
+// verify it. These are the conclusions Core already drew from metadata it did
+// verify, which is a different and honest thing to report.
+type lastCheckFindings struct {
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable,omitempty"`
+	RolloutHeld     bool   `json:"rolloutHeld,omitempty"`
 }
 
 // updateDeferral records that an automatic install has been putting a version
@@ -273,6 +289,36 @@ func lastOfferedVersion(dir string) string {
 	stateMu.Lock()
 	defer stateMu.Unlock()
 	return loadState(dir).LastOfferedVersion
+}
+
+// stateSnapshot reads the whole of the persisted state at once, for a caller
+// that wants several fields and would otherwise take the lock once per field
+// and risk describing two different moments in one answer.
+func stateSnapshot(dir string) updaterState {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+	return loadState(dir)
+}
+
+// recordCheckFindings stores what a completed check concluded. A check that
+// could not reach the manifest records nothing, so the previous findings stay
+// as the last thing actually known rather than being replaced by silence.
+func recordCheckFindings(dir string, findings *lastCheckFindings) error {
+	if dir == "" || findings == nil {
+		return nil
+	}
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	st, err := loadStateWithError(dir)
+	if err != nil {
+		return fmt.Errorf("loading updater state before recording check findings: %w", err)
+	}
+	st.LastCheck = findings
+	if err := saveState(dir, &st); err != nil {
+		return fmt.Errorf("recording update check findings: %w", err)
+	}
+	return nil
 }
 
 func recordOfferedVersion(dir, version string) error {

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -96,6 +96,23 @@ const (
 	EligibilityUnsupported = "unsupported"
 )
 
+// EligibilityCanOfferUpdates reports whether looking for a release could change
+// what this device is told. It is false for the states whose answer is fixed by
+// what the install is rather than by what has been released, so a caller can
+// skip a request whose result it would have to discard.
+//
+// Shared because the answer decides whether a person's explicit "update now"
+// contacts the network, and two copies of that rule drifting apart would mean
+// one entry point silently reporting a stale answer.
+func EligibilityCanOfferUpdates(eligibility string) bool {
+	switch eligibility {
+	case EligibilityDevelopment, EligibilityManaged, EligibilityUnsupported:
+		return false
+	default:
+		return true
+	}
+}
+
 // Options describes the device an update is being resolved for.
 //
 //nolint:govet // Field order groups updater dependencies and device settings.

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -262,7 +262,67 @@ func Check(ctx context.Context, opts Options) (*Result, error) { //nolint:gocrit
 		}
 	}
 
+	if err := recordCheckFindings(stateDir, &lastCheckFindings{
+		LatestVersion:   result.LatestVersion,
+		UpdateAvailable: result.UpdateAvailable,
+		RolloutHeld:     result.RolloutHeld,
+	}); err != nil {
+		log.Warn().Err(err).Msg("could not record what this update check found")
+	}
+
 	return result, nil
+}
+
+// Status answers from what this device already knows, without contacting the
+// release server or writing anything.
+//
+// A check is expensive in a way that matters on the platforms Core runs on: it
+// fetches and verifies signed metadata and writes the result to the data
+// directory, which on MiSTer is a write onto exfat. That cost is why unpaired
+// clients are refused one. Anything that wants to show update state whenever a
+// screen is drawn has to be able to ask without paying it.
+//
+// The answer is as fresh as the last check, and CheckedAt says when that was,
+// so a caller can be honest about how old it is rather than implying it just
+// looked. Unlike a check, this reports normally on a development build instead
+// of refusing: saying which version is running and that updates do not apply to
+// it is exactly what someone looking at the screen wants to know.
+func Status(ctx context.Context, opts Options) *Result { //nolint:gocritic // hugeParam
+	stateDir := stateDirFor(opts.DataDir)
+	st := stateSnapshot(stateDir)
+
+	result := &Result{
+		CurrentVersion: config.AppVersion,
+		Channel:        opts.Channel,
+		Eligibility:    eligibilityFor(&opts),
+		LastResult:     lastOutcome(stateDir),
+	}
+	if st.LastCheckAt != nil {
+		result.CheckedAt = *st.LastCheckAt
+	}
+	if st.LastCheck == nil {
+		return result
+	}
+
+	result.LatestVersion = st.LastCheck.LatestVersion
+	result.RolloutHeld = st.LastCheck.RolloutHeld
+	// Recomputed rather than replayed. The recorded answer was true when the
+	// check ran, and the most likely reason it is not true now is that the
+	// update it describes has since been installed, so reporting it back would
+	// keep offering a version already running.
+	if upgrade, err := newerThanCurrent(result.LatestVersion); err == nil {
+		result.UpdateAvailable = upgrade
+	}
+	if !result.UpdateAvailable {
+		return result
+	}
+
+	readGate(ctx, &opts, result)
+	if deferral := peekDeferral(stateDir, result.LatestVersion); deferral != nil {
+		result.DeferredReason = deferral.Reason
+		result.DeferredSince = deferral.Since
+	}
+	return result
 }
 
 func clearDeferralForRelease(stateDir, version string) error {
@@ -281,25 +341,8 @@ func clearDeferralForRelease(stateDir, version string) error {
 // This only ever reports, so the gate is asked with nothing to acquire: a check
 // must not stop the user launching something while it answers.
 func noteGate(ctx context.Context, opts *Options, result *Result, stateDir, version string) {
-	if opts.Gate == nil {
-		return
-	}
-	reporting := *opts.Gate
-	reporting.AcquireRestore = nil
-	reporting.AcquireMediaGate = nil
-	decision, err := CanApplyUpdate(ctx, &reporting, ModeManual, false)
-	if err != nil {
-		log.Warn().Err(err).Msg("could not read what is in the way of an update")
-		return
-	}
-	decision.Release()
-	if decision.OK {
-		return
-	}
-	result.BlockedReason = decision.Reason
-	result.BlockedMessage = decision.Message
-	result.BlockedForceable = decision.Forceable
-	if !decision.Expires {
+	decision, reporting, ok := readGate(ctx, opts, result)
+	if !ok || !decision.Expires {
 		return
 	}
 	now := time.Now().UTC()
@@ -309,6 +352,36 @@ func noteGate(ctx context.Context, opts *Options, result *Result, stateDir, vers
 	if err := recordDeferralAt(stateDir, version, decision.Reason, now); err != nil {
 		log.Warn().Err(err).Msg("could not record why an update is waiting")
 	}
+}
+
+// readGate fills in what is currently in the way of installing, and reports
+// whether anything was. It writes nothing, so a caller that only wants to
+// describe the situation can use it on its own.
+//
+// The gate is asked with nothing to acquire: describing what is in the way must
+// not stop the user launching something while it answers.
+func readGate(
+	ctx context.Context, opts *Options, result *Result,
+) (decision GateDecision, reporting GateDeps, blocked bool) {
+	if opts.Gate == nil {
+		return GateDecision{}, GateDeps{}, false
+	}
+	reporting = *opts.Gate
+	reporting.AcquireRestore = nil
+	reporting.AcquireMediaGate = nil
+	decision, err := CanApplyUpdate(ctx, &reporting, ModeManual, false)
+	if err != nil {
+		log.Warn().Err(err).Msg("could not read what is in the way of an update")
+		return GateDecision{}, reporting, false
+	}
+	decision.Release()
+	if decision.OK {
+		return decision, reporting, false
+	}
+	result.BlockedReason = decision.Reason
+	result.BlockedMessage = decision.Message
+	result.BlockedForceable = decision.Forceable
+	return decision, reporting, true
 }
 
 // installAdvice says how this device gets a new release. A package manager

--- a/pkg/service/updater/updater.go
+++ b/pkg/service/updater/updater.go
@@ -182,6 +182,11 @@ type session struct {
 	close func()
 }
 
+// newSession builds the source an operation reads signed metadata from. It is a
+// variable so a test can supply one backed by a local server; nothing in the
+// product ever assigns to it.
+var newSession = makeUpdater
+
 func makeUpdater(opts Options) (*session, error) { //nolint:gocritic // hugeParam
 	// tlsroots hands back a transport this updater owns outright, so setting the
 	// header timeout here does not affect anything else in the process.
@@ -234,7 +239,7 @@ func Check(ctx context.Context, opts Options) (*Result, error) { //nolint:gocrit
 		return nil, ErrDevelopmentVersion
 	}
 
-	s, err := makeUpdater(opts)
+	s, err := newSession(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -254,31 +259,35 @@ func Check(ctx context.Context, opts Options) (*Result, error) { //nolint:gocrit
 		LastResult:     lastOutcome(stateDir),
 	}
 
-	if release == nil {
-		return result, nil
-	}
+	if release != nil {
+		version := otameta.VersionFromTag(release.TagName)
+		upgrade, err := newerThanCurrent(version)
+		if err != nil {
+			return nil, err
+		}
+		result.LatestVersion = version
+		if err := clearDeferralForRelease(stateDir, result.LatestVersion); err != nil {
+			log.Warn().Err(err).Msg("could not clear deferral for a superseded update")
+		}
+		result.UpdateAvailable = upgrade
+		result.ReleaseNotes = release.ReleaseNotes
 
-	version := otameta.VersionFromTag(release.TagName)
-	upgrade, err := newerThanCurrent(version)
-	if err != nil {
-		return nil, err
-	}
-	result.LatestVersion = version
-	if err := clearDeferralForRelease(stateDir, result.LatestVersion); err != nil {
-		log.Warn().Err(err).Msg("could not clear deferral for a superseded update")
-	}
-	result.UpdateAvailable = upgrade
-	result.ReleaseNotes = release.ReleaseNotes
-
-	if result.UpdateAvailable {
-		result.RolloutHeld = rolloutHeld(opts.DeviceID, release)
-		noteGate(ctx, &opts, result, stateDir, version)
-		if deferral := peekDeferral(stateDir, version); deferral != nil {
-			result.DeferredReason = deferral.Reason
-			result.DeferredSince = deferral.Since
+		if result.UpdateAvailable {
+			result.RolloutHeld = rolloutHeld(opts.DeviceID, release)
+			noteGate(ctx, &opts, result, stateDir, version)
+			if deferral := peekDeferral(stateDir, version); deferral != nil {
+				result.DeferredReason = deferral.Reason
+				result.DeferredSince = deferral.Since
+			}
 		}
 	}
 
+	// Recorded even when nothing applies, because "nothing applies" is a
+	// conclusion this check reached and not a check that failed. Returning
+	// before this would leave the previous findings standing, so a release that
+	// has since been withdrawn would keep being offered by Status for as long
+	// as no later check found a different one — which is exactly the situation
+	// withdrawing a release exists to end.
 	if err := recordCheckFindings(stateDir, &lastCheckFindings{
 		LatestVersion:   result.LatestVersion,
 		UpdateAvailable: result.UpdateAvailable,
@@ -526,7 +535,7 @@ func Apply(ctx context.Context, opts Options) (string, error) { //nolint:gocriti
 		return fail(err)
 	}
 
-	s, err := makeUpdater(opts)
+	s, err := newSession(opts)
 	if err != nil {
 		return fail(err)
 	}

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -562,3 +562,78 @@ func TestNoteGate_ReportsWithoutTakingAnyGate(t *testing.T) {
 	assert.False(t, restoreTaken)
 	assert.False(t, mediaTaken)
 }
+
+// Status answers from disk. The check that produced those findings is the only
+// thing that talks to the network, so nothing here may need it.
+func TestStatus_AnswersFromRecordedFindingsWithoutTheNetwork(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "2.10.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	dataDir := t.TempDir()
+	stateDir := stateDirFor(dataDir)
+	require.NoError(t, recordScheduledCheck(stateDir, true))
+	require.NoError(t, recordCheckFindings(stateDir, &lastCheckFindings{
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+	}))
+
+	// No manifest, no server, no baseURL: reaching for any of them would fail
+	// rather than quietly fall back.
+	result := Status(t.Context(), Options{DataDir: dataDir, Channel: "stable"})
+	require.NotNil(t, result)
+	assert.Equal(t, "2.10.0", result.CurrentVersion)
+	assert.Equal(t, "2.11.0", result.LatestVersion)
+	assert.True(t, result.UpdateAvailable)
+	assert.Equal(t, "stable", result.Channel)
+	assert.False(t, result.CheckedAt.IsZero(), "must say how old the answer is")
+}
+
+// The recorded findings describe the moment the check ran. Once the update has
+// been installed they would otherwise keep offering a version already running.
+func TestStatus_DoesNotOfferAVersionAlreadyInstalled(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "2.11.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	dataDir := t.TempDir()
+	require.NoError(t, recordCheckFindings(stateDirFor(dataDir), &lastCheckFindings{
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+	}))
+
+	result := Status(t.Context(), Options{DataDir: dataDir})
+	require.NotNil(t, result)
+	assert.False(t, result.UpdateAvailable, "recomputed against the running version")
+	assert.Equal(t, "2.11.0", result.LatestVersion)
+}
+
+// A check refuses outright on a development build. Status is what a screen
+// shows, and "this is a dev build so updates do not apply" is the useful answer.
+func TestStatus_ReportsADevelopmentBuildInsteadOfRefusing(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "abc1234-dev"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	_, checkErr := Check(t.Context(), Options{DataDir: t.TempDir()})
+	require.ErrorIs(t, checkErr, ErrDevelopmentVersion, "premise: a check refuses here")
+
+	result := Status(t.Context(), Options{DataDir: t.TempDir()})
+	require.NotNil(t, result)
+	assert.Equal(t, "abc1234-dev", result.CurrentVersion)
+	assert.Equal(t, EligibilityDevelopment, result.Eligibility)
+	assert.False(t, result.UpdateAvailable)
+}
+
+// Nothing has checked yet. Saying so is different from saying it is up to date.
+func TestStatus_SaysNothingIsKnownBeforeTheFirstCheck(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "2.10.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	result := Status(t.Context(), Options{DataDir: t.TempDir()})
+	require.NotNil(t, result)
+	assert.Empty(t, result.LatestVersion)
+	assert.False(t, result.UpdateAvailable)
+	assert.True(t, result.CheckedAt.IsZero(), "no check has happened, so there is no time to report")
+}

--- a/pkg/service/updater/updater_test.go
+++ b/pkg/service/updater/updater_test.go
@@ -22,6 +22,7 @@ package updater
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -636,4 +637,69 @@ func TestStatus_SaysNothingIsKnownBeforeTheFirstCheck(t *testing.T) {
 	assert.Empty(t, result.LatestVersion)
 	assert.False(t, result.UpdateAvailable)
 	assert.True(t, result.CheckedAt.IsZero(), "no check has happened, so there is no time to report")
+}
+
+// withdrawnManifest is a manifest whose only release cannot be installed here,
+// which is what a device sees once a release has been withdrawn.
+func withdrawnManifest(generation int64) string {
+	return fmt.Sprintf(`manifest_version: 1
+generation: %d
+issued_at: 2026-08-17T02:00:00Z
+key_id: test1
+last_release_id: 1
+last_asset_id: 10
+releases:
+  - id: 1
+    name: v2.16.1
+    tag_name: v2.16.1
+    channel: stable
+    published_at: 2026-08-10T00:00:00Z
+    assets:
+      - id: 10
+        name: zaparoo-zapos_arm64-2.16.1.tar.gz
+        size: 8123456
+        sha256: aaaa
+        url: https://github.com/ZaparooProject/zaparoo-core/releases/download/v2.16.1/zaparoo-zapos_arm64-2.16.1.tar.gz
+`, generation)
+}
+
+// Withdrawing a release is the emergency stop, so a check that finds nothing
+// left to install has to say so durably. Recording only when a release was
+// found would leave the previous offer standing, and Status would keep offering
+// a version that no longer exists until some later check happened to find a
+// different one.
+func TestCheck_ForgetsAnOfferOnceTheReleaseIsWithdrawn(t *testing.T) {
+	original := config.AppVersion
+	config.AppVersion = "2.10.0"
+	t.Cleanup(func() { config.AppVersion = original })
+
+	dataDir := t.TempDir()
+	stateDir := stateDirFor(dataDir)
+	require.NoError(t, recordCheckFindings(stateDir, &lastCheckFindings{
+		LatestVersion:   "2.16.1",
+		UpdateAvailable: true,
+	}))
+	require.True(t, Status(t.Context(), Options{DataDir: dataDir}).UpdateAvailable,
+		"the offer has to be there before the check that should clear it")
+
+	ms := newManifestServer(t, withdrawnManifest(9))
+	src := ms.source(stateDir, "linux", "amd64")
+	previous := newSession
+	newSession = func(Options) (*session, error) {
+		return &session{source: src, close: func() {}}, nil
+	}
+	t.Cleanup(func() { newSession = previous })
+
+	result, err := Check(t.Context(), Options{
+		DataDir: dataDir, Channel: "stable", PlatformID: "linux",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, result.LatestVersion)
+	assert.False(t, result.UpdateAvailable)
+
+	// The result alone is not the fix: what Status reports afterwards is.
+	status := Status(t.Context(), Options{DataDir: dataDir, Channel: "stable"})
+	require.NotNil(t, status)
+	assert.Empty(t, status.LatestVersion, "the withdrawn version must stop being offered")
+	assert.False(t, status.UpdateAvailable)
 }

--- a/pkg/ui/systray/systray.go
+++ b/pkg/ui/systray/systray.go
@@ -64,6 +64,15 @@ func systrayOnReady(
 		mReloadConfig := systray.AddMenuItem("Reload", "Reload Core settings and files")
 		mOpenLog := systray.AddMenuItem("View Log", "View Core log file")
 
+		systray.AddSeparator()
+		mPair := systray.AddMenuItem("Pair Device...", "Show a PIN to pair a phone or tablet")
+		// Titled from status rather than fixed, so the menu says whether there
+		// is anything to install before it is opened. Refreshed on a timer from
+		// update.status, which reads the last check off disk instead of asking
+		// the release server every time the menu is drawn.
+		mUpdate := systray.AddMenuItem(updateMenuTitle(nil), "")
+		go watchUpdateStatus(cfg, mUpdate)
+
 		if cfg.DebugLogging() {
 			systray.AddSeparator()
 		}
@@ -137,6 +146,10 @@ func systrayOnReady(
 						log.Error().Err(err).Msg("failed to open data dir")
 						notify("Error opening data directory.")
 					}
+				case <-mPair.ClickedCh:
+					go startPairing(cfg, notify)
+				case <-mUpdate.ClickedCh:
+					go applyUpdateFromMenu(cfg, mUpdate, notify)
 				case <-mAbout.ClickedCh:
 					msg := "Zaparoo Core\n" +
 						"Version v%s\n\n" +

--- a/pkg/ui/systray/systray_test.go
+++ b/pkg/ui/systray/systray_test.go
@@ -146,6 +146,11 @@ func TestUpdateMenuTitle(t *testing.T) {
 			want:      "Development build",
 			clickable: false,
 		},
+		"an install that cannot replace itself cannot act": {
+			status:    &models.UpdateCheckResponse{Eligibility: updater.EligibilityUnsupported},
+			want:      "Updates unavailable here",
+			clickable: false,
+		},
 		"a rollback is worth surfacing over anything else": {
 			status: &models.UpdateCheckResponse{
 				Eligibility:     updater.EligibilityEligible,

--- a/pkg/ui/systray/systray_test.go
+++ b/pkg/ui/systray/systray_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,6 +93,76 @@ func TestReloadCore(t *testing.T) {
 			} else {
 				require.EqualError(t, err, tt.expectedError)
 			}
+		})
+	}
+}
+
+// The tray entry has to answer "is there anything to do" from its own label,
+// because that is what someone opened the menu to find out.
+func TestUpdateMenuTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status    *models.UpdateCheckResponse
+		want      string
+		clickable bool
+	}{
+		"nothing read yet": {
+			status: nil, want: "Check for Updates", clickable: true,
+		},
+		"up to date": {
+			status:    &models.UpdateCheckResponse{Eligibility: updater.EligibilityEligible},
+			want:      "Up to date",
+			clickable: true,
+		},
+		"available": {
+			status: &models.UpdateCheckResponse{
+				Eligibility:     updater.EligibilityEligible,
+				UpdateAvailable: true,
+				LatestVersion:   "2.11.0",
+			},
+			want:      "Install 2.11.0",
+			clickable: true,
+		},
+		"available but not rolled out here": {
+			status: &models.UpdateCheckResponse{
+				Eligibility:     updater.EligibilityEligible,
+				UpdateAvailable: true,
+				RolloutHeld:     true,
+				LatestVersion:   "2.11.0",
+			},
+			want:      "not yet rolled out",
+			clickable: true,
+		},
+		// Says so rather than going quiet: an install entry that does nothing
+		// is more confusing than one that explains itself.
+		"managed install cannot act": {
+			status:    &models.UpdateCheckResponse{Eligibility: updater.EligibilityManaged},
+			want:      "Updates managed externally",
+			clickable: false,
+		},
+		"development build cannot act": {
+			status:    &models.UpdateCheckResponse{Eligibility: updater.EligibilityDevelopment},
+			want:      "Development build",
+			clickable: false,
+		},
+		"a rollback is worth surfacing over anything else": {
+			status: &models.UpdateCheckResponse{
+				Eligibility:     updater.EligibilityEligible,
+				UpdateAvailable: true,
+				LatestVersion:   "2.11.0",
+				LastResult:      &models.UpdateLastResult{Outcome: updater.OutcomeRolledBack},
+			},
+			want:      "rolled back",
+			clickable: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Contains(t, updateMenuTitle(tt.status), tt.want)
+			assert.Equal(t, tt.clickable, updateMenuClickable(tt.status))
 		})
 	}
 }

--- a/pkg/ui/systray/update.go
+++ b/pkg/ui/systray/update.go
@@ -73,12 +73,7 @@ func updateMenuClickable(status *models.UpdateCheckResponse) bool {
 	if status == nil {
 		return true
 	}
-	switch status.Eligibility {
-	case updater.EligibilityDevelopment, updater.EligibilityManaged, updater.EligibilityUnsupported:
-		return false
-	default:
-		return true
-	}
+	return updater.EligibilityCanOfferUpdates(status.Eligibility)
 }
 
 func watchUpdateStatus(cfg *config.Instance, item *systray.MenuItem) {

--- a/pkg/ui/systray/update.go
+++ b/pkg/ui/systray/update.go
@@ -1,0 +1,217 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package systray
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"fyne.io/systray"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/client"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/nixinwang/dialog"
+	"github.com/rs/zerolog/log"
+)
+
+// updateMenuRefresh is how often the menu entry re-reads the status.
+//
+// The read is local — update.status returns what the last check found without
+// contacting anything — so this paces a file read, not a network request. The
+// scheduled check behind it runs every twelve hours, so anything much tighter
+// would only redraw the same words.
+const updateMenuRefresh = 5 * time.Minute
+
+// updateMenuTitle is what the entry says before it is clicked. The menu is
+// where someone looks to find out whether there is anything to do, so it has to
+// answer that without being opened twice.
+func updateMenuTitle(status *models.UpdateCheckResponse) string {
+	switch {
+	case status == nil:
+		return "Check for Updates"
+	case status.Eligibility == updater.EligibilityDevelopment:
+		return "Development build"
+	case status.Eligibility == updater.EligibilityManaged:
+		return "Updates managed externally"
+	case status.Eligibility == updater.EligibilityUnsupported:
+		return "Updates unavailable here"
+	case status.LastResult != nil && status.LastResult.Outcome == updater.OutcomeRolledBack:
+		return "Last update was rolled back"
+	case status.UpdateAvailable && status.RolloutHeld:
+		return "Install " + status.LatestVersion + " (not yet rolled out)"
+	case status.UpdateAvailable:
+		return "Install " + status.LatestVersion
+	default:
+		return "Up to date"
+	}
+}
+
+// updateMenuClickable reports whether clicking the entry would do anything. An
+// entry that cannot act is disabled rather than hidden, because the words on it
+// are the answer someone opened the menu for.
+func updateMenuClickable(status *models.UpdateCheckResponse) bool {
+	if status == nil {
+		return true
+	}
+	switch status.Eligibility {
+	case updater.EligibilityDevelopment, updater.EligibilityManaged, updater.EligibilityUnsupported:
+		return false
+	default:
+		return true
+	}
+}
+
+func watchUpdateStatus(cfg *config.Instance, item *systray.MenuItem) {
+	for {
+		refreshUpdateMenu(cfg, item)
+		time.Sleep(updateMenuRefresh)
+	}
+}
+
+func refreshUpdateMenu(cfg *config.Instance, item *systray.MenuItem) {
+	status, err := readUpdateStatus(cfg)
+	if err != nil {
+		// Leave the entry as it was. Core may simply not be up yet, and
+		// replacing a true answer with an error is worse than a stale one.
+		log.Debug().Err(err).Msg("could not read update status for the tray menu")
+		return
+	}
+	item.SetTitle(updateMenuTitle(status))
+	if updateMenuClickable(status) {
+		item.Enable()
+	} else {
+		item.Disable()
+	}
+}
+
+// applyUpdateFromMenu installs an update if there is one, and otherwise checks
+// for one. Unlike the CLI this never blocks the caller: the menu has to stay
+// responsive, so the outcome arrives as a notification.
+func applyUpdateFromMenu(cfg *config.Instance, item *systray.MenuItem, notify func(string)) {
+	status, err := readUpdateStatus(cfg)
+	if err != nil {
+		log.Error().Err(err).Msg("could not read update status")
+		notify("Could not read update status.")
+		return
+	}
+
+	if !status.UpdateAvailable {
+		// Nothing known to install, so go and look. This is the one path that
+		// costs a network request, and it only happens because someone asked.
+		notify("Checking for updates...")
+		checked, checkErr := requestUpdateCheck(cfg)
+		if checkErr != nil {
+			log.Error().Err(checkErr).Msg("update check failed")
+			notify("Could not check for updates.")
+			return
+		}
+		refreshUpdateMenu(cfg, item)
+		if !checked.UpdateAvailable {
+			notify("Zaparoo Core is up to date.")
+			return
+		}
+		status = checked
+	}
+
+	if status.BlockedBy != nil && !status.BlockedBy.Forceable {
+		notify("Cannot update right now: " + status.BlockedBy.Message)
+		return
+	}
+
+	notify("Installing " + status.LatestVersion + "...")
+	applied, err := requestUpdateApply(cfg)
+	if err != nil {
+		log.Error().Err(err).Msg("update install failed")
+		notify("Update failed. The previous version is still installed.")
+		return
+	}
+	dialog.Message(
+		"Zaparoo Core %s is installed and will restart now.\n\n"+
+			"If it does not start correctly the previous version is restored automatically.",
+		applied.NewVersion,
+	).Title("Update Installed").Info()
+}
+
+// startPairing shows the PIN a client needs. The pairing flow already exists as
+// a CLI flag; on a desktop the tray is where someone will look for it, and
+// there is no terminal open to read a PIN out of.
+func startPairing(cfg *config.Instance, notify func(string)) {
+	ctx := context.Background()
+	raw, err := client.LocalClient(ctx, cfg, models.MethodClientsPairStart, "")
+	if err != nil {
+		log.Error().Err(err).Msg("could not start pairing")
+		notify("Could not start pairing.")
+		return
+	}
+	var resp models.ClientsPairStartResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		log.Error().Err(err).Msg("could not read the pairing response")
+		notify("Could not start pairing.")
+		return
+	}
+
+	dialog.Message(
+		"Enter this PIN in the Zaparoo app to pair it with this device:\n\n%s\n\n"+
+			"The PIN stops working once it is used or this dialog is closed.",
+		resp.PIN,
+	).Title("Pair a Device").Info()
+
+	// Closing the dialog is the person saying they are done, whether or not a
+	// client got there first. Leaving the PIN live afterwards would keep a
+	// credential valid that nobody is watching any more.
+	if _, err := client.LocalClient(ctx, cfg, models.MethodClientsPairCancel, ""); err != nil {
+		log.Debug().Err(err).Msg("could not cancel pairing after the dialog closed")
+	}
+}
+
+func readUpdateStatus(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
+	return updateCall(cfg, models.MethodUpdateStatus)
+}
+
+func requestUpdateCheck(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
+	return updateCall(cfg, models.MethodUpdateCheck)
+}
+
+func updateCall(cfg *config.Instance, method string) (*models.UpdateCheckResponse, error) {
+	raw, err := client.LocalClient(context.Background(), cfg, method, "")
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", method, err)
+	}
+	var resp models.UpdateCheckResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("reading the %s response: %w", method, err)
+	}
+	return &resp, nil
+}
+
+func requestUpdateApply(cfg *config.Instance) (*models.UpdateApplyResponse, error) {
+	raw, err := client.LocalClient(context.Background(), cfg, models.MethodUpdateApply, "")
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", models.MethodUpdateApply, err)
+	}
+	var resp models.UpdateApplyResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("reading the %s response: %w", models.MethodUpdateApply, err)
+	}
+	return &resp, nil
+}

--- a/pkg/ui/systray/update.go
+++ b/pkg/ui/systray/update.go
@@ -76,6 +76,26 @@ func updateMenuClickable(status *models.UpdateCheckResponse) bool {
 	return updater.EligibilityCanOfferUpdates(status.Eligibility)
 }
 
+// menuEntry is the part of a tray item this file drives. *systray.MenuItem
+// satisfies it, and a test can substitute something that records what was set.
+type menuEntry interface {
+	SetTitle(string)
+	Enable()
+	Disable()
+}
+
+// apiCaller is how these entries reach Core, and showDialog is how they get a
+// message in front of someone. Both are injected so the menu's decisions can be
+// tested without a running service or a native window.
+type (
+	apiCaller  func(ctx context.Context, cfg *config.Instance, method, params string) (string, error)
+	showDialog func(title, message string)
+)
+
+func nativeDialog(title, message string) {
+	dialog.Message("%s", message).Title(title).Info()
+}
+
 func watchUpdateStatus(cfg *config.Instance, item *systray.MenuItem) {
 	for {
 		refreshUpdateMenu(cfg, item)
@@ -83,8 +103,12 @@ func watchUpdateStatus(cfg *config.Instance, item *systray.MenuItem) {
 	}
 }
 
-func refreshUpdateMenu(cfg *config.Instance, item *systray.MenuItem) {
-	status, err := readUpdateStatus(cfg)
+func refreshUpdateMenu(cfg *config.Instance, item menuEntry) {
+	refreshUpdateMenuWith(cfg, item, client.LocalClient)
+}
+
+func refreshUpdateMenuWith(cfg *config.Instance, item menuEntry, call apiCaller) {
+	status, err := readUpdateStatus(cfg, call)
 	if err != nil {
 		// Leave the entry as it was. Core may simply not be up yet, and
 		// replacing a true answer with an error is worse than a stale one.
@@ -102,8 +126,14 @@ func refreshUpdateMenu(cfg *config.Instance, item *systray.MenuItem) {
 // applyUpdateFromMenu installs an update if there is one, and otherwise checks
 // for one. Unlike the CLI this never blocks the caller: the menu has to stay
 // responsive, so the outcome arrives as a notification.
-func applyUpdateFromMenu(cfg *config.Instance, item *systray.MenuItem, notify func(string)) {
-	status, err := readUpdateStatus(cfg)
+func applyUpdateFromMenu(cfg *config.Instance, item menuEntry, notify func(string)) {
+	applyUpdateFromMenuWith(cfg, item, notify, client.LocalClient, nativeDialog)
+}
+
+func applyUpdateFromMenuWith(
+	cfg *config.Instance, item menuEntry, notify func(string), call apiCaller, show showDialog,
+) {
+	status, err := readUpdateStatus(cfg, call)
 	if err != nil {
 		log.Error().Err(err).Msg("could not read update status")
 		notify("Could not read update status.")
@@ -114,13 +144,13 @@ func applyUpdateFromMenu(cfg *config.Instance, item *systray.MenuItem, notify fu
 		// Nothing known to install, so go and look. This is the one path that
 		// costs a network request, and it only happens because someone asked.
 		notify("Checking for updates...")
-		checked, checkErr := requestUpdateCheck(cfg)
+		checked, checkErr := requestUpdateCheck(cfg, call)
 		if checkErr != nil {
 			log.Error().Err(checkErr).Msg("update check failed")
 			notify("Could not check for updates.")
 			return
 		}
-		refreshUpdateMenu(cfg, item)
+		refreshUpdateMenuWith(cfg, item, call)
 		if !checked.UpdateAvailable {
 			notify("Zaparoo Core is up to date.")
 			return
@@ -134,25 +164,28 @@ func applyUpdateFromMenu(cfg *config.Instance, item *systray.MenuItem, notify fu
 	}
 
 	notify("Installing " + status.LatestVersion + "...")
-	applied, err := requestUpdateApply(cfg)
+	applied, err := requestUpdateApply(cfg, call)
 	if err != nil {
 		log.Error().Err(err).Msg("update install failed")
 		notify("Update failed. The previous version is still installed.")
 		return
 	}
-	dialog.Message(
+	show("Update Installed", fmt.Sprintf(
 		"Zaparoo Core %s is installed and will restart now.\n\n"+
 			"If it does not start correctly the previous version is restored automatically.",
-		applied.NewVersion,
-	).Title("Update Installed").Info()
+		applied.NewVersion))
 }
 
 // startPairing shows the PIN a client needs. The pairing flow already exists as
 // a CLI flag; on a desktop the tray is where someone will look for it, and
 // there is no terminal open to read a PIN out of.
 func startPairing(cfg *config.Instance, notify func(string)) {
+	startPairingWith(cfg, notify, client.LocalClient, nativeDialog)
+}
+
+func startPairingWith(cfg *config.Instance, notify func(string), call apiCaller, show showDialog) {
 	ctx := context.Background()
-	raw, err := client.LocalClient(ctx, cfg, models.MethodClientsPairStart, "")
+	raw, err := call(ctx, cfg, models.MethodClientsPairStart, "")
 	if err != nil {
 		log.Error().Err(err).Msg("could not start pairing")
 		notify("Could not start pairing.")
@@ -165,30 +198,28 @@ func startPairing(cfg *config.Instance, notify func(string)) {
 		return
 	}
 
-	dialog.Message(
+	show("Pair a Device", fmt.Sprintf(
 		"Enter this PIN in the Zaparoo app to pair it with this device:\n\n%s\n\n"+
-			"The PIN stops working once it is used or this dialog is closed.",
-		resp.PIN,
-	).Title("Pair a Device").Info()
+			"The PIN stops working once it is used or this dialog is closed.", resp.PIN))
 
 	// Closing the dialog is the person saying they are done, whether or not a
 	// client got there first. Leaving the PIN live afterwards would keep a
 	// credential valid that nobody is watching any more.
-	if _, err := client.LocalClient(ctx, cfg, models.MethodClientsPairCancel, ""); err != nil {
+	if _, err := call(ctx, cfg, models.MethodClientsPairCancel, ""); err != nil {
 		log.Debug().Err(err).Msg("could not cancel pairing after the dialog closed")
 	}
 }
 
-func readUpdateStatus(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
-	return updateCall(cfg, models.MethodUpdateStatus)
+func readUpdateStatus(cfg *config.Instance, call apiCaller) (*models.UpdateCheckResponse, error) {
+	return updateCall(cfg, models.MethodUpdateStatus, call)
 }
 
-func requestUpdateCheck(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
-	return updateCall(cfg, models.MethodUpdateCheck)
+func requestUpdateCheck(cfg *config.Instance, call apiCaller) (*models.UpdateCheckResponse, error) {
+	return updateCall(cfg, models.MethodUpdateCheck, call)
 }
 
-func updateCall(cfg *config.Instance, method string) (*models.UpdateCheckResponse, error) {
-	raw, err := client.LocalClient(context.Background(), cfg, method, "")
+func updateCall(cfg *config.Instance, method string, call apiCaller) (*models.UpdateCheckResponse, error) {
+	raw, err := call(context.Background(), cfg, method, "")
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", method, err)
 	}
@@ -199,8 +230,8 @@ func updateCall(cfg *config.Instance, method string) (*models.UpdateCheckRespons
 	return &resp, nil
 }
 
-func requestUpdateApply(cfg *config.Instance) (*models.UpdateApplyResponse, error) {
-	raw, err := client.LocalClient(context.Background(), cfg, models.MethodUpdateApply, "")
+func requestUpdateApply(cfg *config.Instance, call apiCaller) (*models.UpdateApplyResponse, error) {
+	raw, err := call(context.Background(), cfg, models.MethodUpdateApply, "")
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", models.MethodUpdateApply, err)
 	}

--- a/pkg/ui/systray/update_test.go
+++ b/pkg/ui/systray/update_test.go
@@ -1,0 +1,411 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package systray
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeEntry records what the menu was told to do.
+type fakeEntry struct {
+	title    string
+	enabled  bool
+	disabled bool
+}
+
+func (f *fakeEntry) SetTitle(title string) { f.title = title }
+func (f *fakeEntry) Enable()               { f.enabled = true }
+func (f *fakeEntry) Disable()              { f.disabled = true }
+
+// callerFor answers each method from a table and records the order asked.
+func callerFor(t *testing.T, answers map[string]any) (call apiCaller, asked *[]string) {
+	t.Helper()
+	asked = &[]string{}
+	return func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		*asked = append(*asked, method)
+		answer, ok := answers[method]
+		if !ok {
+			return "", errors.New("unexpected method " + method)
+		}
+		if err, isErr := answer.(error); isErr {
+			return "", err
+		}
+		body, err := json.Marshal(answer)
+		require.NoError(t, err)
+		return string(body), nil
+	}, asked
+}
+
+func TestRefreshUpdateMenu_TitlesTheEntryFromStatus(t *testing.T) {
+	t.Parallel()
+
+	call, asked := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+		},
+	})
+	item := &fakeEntry{}
+
+	refreshUpdateMenuWith(nil, item, call)
+	assert.Equal(t, "Install 2.11.0", item.title)
+	assert.True(t, item.enabled)
+	assert.Equal(t, []string{models.MethodUpdateStatus}, *asked,
+		"drawing the menu must not cost a check")
+}
+
+// Where updates do not apply the entry stays visible but dead, because the
+// words on it are the answer someone opened the menu for.
+func TestRefreshUpdateMenu_DisablesTheEntryWhereUpdatesDoNotApply(t *testing.T) {
+	t.Parallel()
+
+	call, _ := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion: "abc123-dev",
+			Eligibility:    updater.EligibilityDevelopment,
+		},
+	})
+	item := &fakeEntry{}
+
+	refreshUpdateMenuWith(nil, item, call)
+	assert.Equal(t, "Development build", item.title)
+	assert.True(t, item.disabled)
+	assert.False(t, item.enabled)
+}
+
+// Core may simply not be up yet. Replacing a true answer with an error would be
+// worse than leaving a stale one.
+func TestRefreshUpdateMenu_LeavesTheEntryAloneWhenCoreCannotBeReached(t *testing.T) {
+	t.Parallel()
+
+	call, _ := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: errors.New("connection refused"),
+	})
+	item := &fakeEntry{title: "Up to date"}
+
+	refreshUpdateMenuWith(nil, item, call)
+	assert.Equal(t, "Up to date", item.title)
+	assert.False(t, item.enabled)
+	assert.False(t, item.disabled)
+}
+
+func TestApplyUpdateFromMenu_InstallsAndReportsThroughTheDialog(t *testing.T) {
+	t.Parallel()
+
+	call, asked := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+		},
+		models.MethodUpdateApply: models.UpdateApplyResponse{
+			PreviousVersion: "2.10.0",
+			NewVersion:      "2.11.0",
+		},
+	})
+
+	var notes []string
+	var shownTitle, shownBody string
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(title, message string) { shownTitle, shownBody = title, message })
+
+	assert.Equal(t, []string{models.MethodUpdateStatus, models.MethodUpdateApply}, *asked)
+	assert.Contains(t, notes, "Installing 2.11.0...")
+	assert.Equal(t, "Update Installed", shownTitle)
+	assert.Contains(t, shownBody, "2.11.0")
+}
+
+// With nothing known to install, clicking goes and looks. That is the one path
+// that costs a network request, and it only happens because someone asked.
+func TestApplyUpdateFromMenu_ChecksWhenNothingIsKnownAndStopsWhenStillNothing(t *testing.T) {
+	t.Parallel()
+
+	upToDate := models.UpdateCheckResponse{
+		CurrentVersion: "2.11.0",
+		Eligibility:    updater.EligibilityEligible,
+	}
+	call, asked := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: upToDate,
+		models.MethodUpdateCheck:  upToDate,
+	})
+
+	var notes []string
+	shown := false
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) { shown = true })
+
+	assert.Equal(t, []string{
+		models.MethodUpdateStatus, models.MethodUpdateCheck, models.MethodUpdateStatus,
+	}, *asked, "must not call apply")
+	assert.Contains(t, notes, "Zaparoo Core is up to date.")
+	assert.False(t, shown)
+}
+
+// A gate that cannot be forced has already explained itself, so the menu repeats
+// its reason instead of attempting an install that would fail.
+func TestApplyUpdateFromMenu_DoesNotInstallThroughAGateThatCannotBeForced(t *testing.T) {
+	t.Parallel()
+
+	call, asked := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+			BlockedBy: &models.UpdateBlockedBy{
+				Reason:    "indexing",
+				Message:   "the media database is being indexed",
+				Forceable: false,
+			},
+		},
+	})
+
+	var notes []string
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) {})
+
+	assert.Equal(t, []string{models.MethodUpdateStatus}, *asked, "must not call apply")
+	assert.Contains(t, notes, "Cannot update right now: the media database is being indexed")
+}
+
+// An install that fails leaves the previous version running, and saying so is
+// the difference between a scare and an explanation.
+func TestApplyUpdateFromMenu_SaysThePreviousVersionSurvivedAFailedInstall(t *testing.T) {
+	t.Parallel()
+
+	call, _ := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+		},
+		models.MethodUpdateApply: errors.New("install failed"),
+	})
+
+	var notes []string
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) {})
+
+	assert.Contains(t, notes, "Update failed. The previous version is still installed.")
+}
+
+// Closing the dialog is the person saying they are done. Leaving the PIN live
+// would keep a credential valid that nobody is watching.
+func TestStartPairing_ShowsThePINAndCancelsWhenTheDialogCloses(t *testing.T) {
+	t.Parallel()
+
+	call, asked := callerFor(t, map[string]any{
+		models.MethodClientsPairStart:  models.ClientsPairStartResponse{PIN: "482913"},
+		models.MethodClientsPairCancel: struct{}{},
+	})
+
+	var shownBody string
+	order := []string{}
+	startPairingWith(nil, func(string) {}, call, func(_, message string) {
+		shownBody = message
+		order = append(order, "dialog")
+	})
+
+	assert.Contains(t, shownBody, "482913")
+	assert.Equal(t,
+		[]string{models.MethodClientsPairStart, models.MethodClientsPairCancel}, *asked)
+	assert.Equal(t, []string{"dialog"}, order, "the PIN is cancelled after the dialog closes")
+}
+
+func TestStartPairing_ReportsAFailureToStart(t *testing.T) {
+	t.Parallel()
+
+	call, _ := callerFor(t, map[string]any{
+		models.MethodClientsPairStart: errors.New("refused"),
+	})
+
+	var notes []string
+	shown := false
+	startPairingWith(nil, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) { shown = true })
+
+	assert.Equal(t, []string{"Could not start pairing."}, notes)
+	assert.False(t, shown, "there is no PIN to show")
+}
+
+func TestApplyUpdateFromMenu_ReportsWhenStatusCannotBeRead(t *testing.T) {
+	t.Parallel()
+
+	call, asked := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: errors.New("connection refused"),
+	})
+
+	var notes []string
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) {})
+
+	assert.Equal(t, []string{models.MethodUpdateStatus}, *asked)
+	assert.Equal(t, []string{"Could not read update status."}, notes)
+}
+
+// A check that turns one up carries straight on into the install, and refreshes
+// the entry so the menu behind the notification is no longer stale.
+func TestApplyUpdateFromMenu_InstallsWhatTheCheckTurnedUp(t *testing.T) {
+	t.Parallel()
+
+	available := models.UpdateCheckResponse{
+		CurrentVersion:  "2.10.0",
+		LatestVersion:   "2.11.0",
+		UpdateAvailable: true,
+		Eligibility:     updater.EligibilityEligible,
+	}
+	answers := map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion: "2.10.0",
+			Eligibility:    updater.EligibilityEligible,
+		},
+		models.MethodUpdateCheck: available,
+		models.MethodUpdateApply: models.UpdateApplyResponse{
+			PreviousVersion: "2.10.0", NewVersion: "2.11.0",
+		},
+	}
+	call, asked := callerFor(t, answers)
+
+	var notes []string
+	shown := false
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) { shown = true })
+
+	assert.Equal(t, []string{
+		models.MethodUpdateStatus, models.MethodUpdateCheck,
+		models.MethodUpdateStatus, models.MethodUpdateApply,
+	}, *asked)
+	assert.Contains(t, notes, "Installing 2.11.0...")
+	assert.True(t, shown)
+}
+
+func TestApplyUpdateFromMenu_ReportsAFailedCheck(t *testing.T) {
+	t.Parallel()
+
+	call, _ := callerFor(t, map[string]any{
+		models.MethodUpdateStatus: models.UpdateCheckResponse{
+			CurrentVersion: "2.10.0",
+			Eligibility:    updater.EligibilityEligible,
+		},
+		models.MethodUpdateCheck: errors.New("no route to host"),
+	})
+
+	var notes []string
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) {})
+
+	assert.Contains(t, notes, "Could not check for updates.")
+}
+
+// A response that arrives but cannot be read is a failure, not an empty answer:
+// treating it as "nothing available" would quietly show the wrong thing.
+func TestUpdateCall_RejectsAResponseItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	call := func(context.Context, *config.Instance, string, string) (string, error) {
+		return "not json", nil
+	}
+	_, err := updateCall(nil, models.MethodUpdateStatus, call)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), models.MethodUpdateStatus)
+}
+
+func TestStartPairing_ReportsAPairingResponseItCannotRead(t *testing.T) {
+	t.Parallel()
+
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		if method == models.MethodClientsPairStart {
+			return "not json", nil
+		}
+		return "{}", nil
+	}
+
+	var notes []string
+	shown := false
+	startPairingWith(nil, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) { shown = true })
+
+	assert.Equal(t, []string{"Could not start pairing."}, notes)
+	assert.False(t, shown)
+}
+
+// An apply response that cannot be read is a failed install as far as the menu
+// is concerned, because it has no version to report and no proof it worked.
+func TestApplyUpdateFromMenu_TreatsAnUnreadableApplyResponseAsAFailure(t *testing.T) {
+	t.Parallel()
+
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		if method == models.MethodUpdateApply {
+			return "not json", nil
+		}
+		body, err := json.Marshal(models.UpdateCheckResponse{
+			CurrentVersion:  "2.10.0",
+			LatestVersion:   "2.11.0",
+			UpdateAvailable: true,
+			Eligibility:     updater.EligibilityEligible,
+		})
+		require.NoError(t, err)
+		return string(body), nil
+	}
+
+	var notes []string
+	shown := false
+	applyUpdateFromMenuWith(nil, &fakeEntry{}, func(m string) { notes = append(notes, m) }, call,
+		func(string, string) { shown = true })
+
+	assert.Contains(t, notes, "Update failed. The previous version is still installed.")
+	assert.False(t, shown)
+}
+
+// The PIN was already shown, so a cancel that fails is logged and nothing else:
+// there is no second thing to tell the person to do about it.
+func TestStartPairing_SurvivesACancelThatFails(t *testing.T) {
+	t.Parallel()
+
+	call := func(_ context.Context, _ *config.Instance, method, _ string) (string, error) {
+		if method == models.MethodClientsPairCancel {
+			return "", errors.New("connection closed")
+		}
+		body, err := json.Marshal(models.ClientsPairStartResponse{PIN: "482913"})
+		require.NoError(t, err)
+		return string(body), nil
+	}
+
+	var notes []string
+	var shownBody string
+	startPairingWith(nil, func(m string) { notes = append(notes, m) }, call,
+		func(_, message string) { shownBody = message })
+
+	assert.Contains(t, shownBody, "482913")
+	assert.Empty(t, notes, "the PIN was shown; a failed cancel is not the person's problem")
+}

--- a/pkg/ui/tui/main.go
+++ b/pkg/ui/tui/main.go
@@ -547,9 +547,10 @@ func BuildMainPage(
 	webUI := fmt.Sprintf("http://%s:%d/app/", ip, cfg.APIPort())
 
 	statusText.SetText(fmt.Sprintf(
-		"%s %s\n%s %s\n%s\n[:::%s]%s[:::-]",
+		"%s %s\n%s %s\n%s %s\n%s\n[:::%s]%s[:::-]",
 		FormatLabel("Service"), svcStatus,
 		FormatLabel("Address"), ipDisplay,
+		FormatLabel("Version"), updateStatusLine(cfg),
 		FormatLabel("Web UI"),
 		webUI, webUI,
 	))

--- a/pkg/ui/tui/update.go
+++ b/pkg/ui/tui/update.go
@@ -38,7 +38,11 @@ import (
 // rather than a request and a flash write. A check still happens on its own
 // every twelve hours behind it.
 func updateStatusLine(cfg *config.Instance) string {
-	status, err := readUpdateStatus(cfg)
+	return updateStatusLineWith(cfg, client.LocalClient)
+}
+
+func updateStatusLineWith(cfg *config.Instance, call apiCaller) string {
+	status, err := readUpdateStatus(cfg, call)
 	if err != nil {
 		// The daemon may not be up yet, which is normal while the TUI is
 		// starting. The running version is still worth showing on its own.
@@ -83,8 +87,12 @@ func formatUpdateStatus(status *models.UpdateCheckResponse) string {
 	}
 }
 
-func readUpdateStatus(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
-	raw, err := client.LocalClient(context.Background(), cfg, models.MethodUpdateStatus, "")
+// apiCaller is how the line reaches Core, injected so the fallback behaviour
+// can be tested without a running service.
+type apiCaller func(ctx context.Context, cfg *config.Instance, method, params string) (string, error)
+
+func readUpdateStatus(cfg *config.Instance, call apiCaller) (*models.UpdateCheckResponse, error) {
+	raw, err := call(context.Background(), cfg, models.MethodUpdateStatus, "")
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", models.MethodUpdateStatus, err)
 	}

--- a/pkg/ui/tui/update.go
+++ b/pkg/ui/tui/update.go
@@ -1,0 +1,96 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/client"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/rs/zerolog/log"
+)
+
+// updateStatusLine is the version line on the main screen.
+//
+// It calls update.status, which reports what the last check found without
+// contacting the release server, so drawing the screen costs a local read
+// rather than a request and a flash write. A check still happens on its own
+// every twelve hours behind it.
+func updateStatusLine(cfg *config.Instance) string {
+	status, err := readUpdateStatus(cfg)
+	if err != nil {
+		// The daemon may not be up yet, which is normal while the TUI is
+		// starting. The running version is still worth showing on its own.
+		log.Debug().Err(err).Msg("could not read update status for the TUI")
+		return config.AppVersion
+	}
+	return formatUpdateStatus(status)
+}
+
+// formatUpdateStatus keeps the running version first and appends only what adds
+// something: a line that says the version and then nothing else is the normal,
+// uninteresting case and should look like it.
+func formatUpdateStatus(status *models.UpdateCheckResponse) string {
+	if status == nil {
+		return config.AppVersion
+	}
+	current := status.CurrentVersion
+	if current == "" {
+		current = config.AppVersion
+	}
+
+	if status.LastResult != nil {
+		switch status.LastResult.Outcome {
+		case updater.OutcomeRolledBack:
+			return fmt.Sprintf("%s (update to %s was rolled back)", current, status.LastResult.ToVersion)
+		case updater.OutcomeRollbackBlocked:
+			return current + " (update failed and could not be undone)"
+		case updater.OutcomeRecoveryRequired:
+			return current + " (an interrupted update needs attention)"
+		}
+	}
+
+	switch {
+	case status.UpdateAvailable && status.RolloutHeld:
+		return fmt.Sprintf("%s (%s available, rolling out gradually)", current, status.LatestVersion)
+	case status.UpdateAvailable:
+		return fmt.Sprintf("%s (%s available)", current, status.LatestVersion)
+	case status.Eligibility == updater.EligibilityManaged:
+		return current + " (managed externally)"
+	default:
+		return current
+	}
+}
+
+func readUpdateStatus(cfg *config.Instance) (*models.UpdateCheckResponse, error) {
+	raw, err := client.LocalClient(context.Background(), cfg, models.MethodUpdateStatus, "")
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", models.MethodUpdateStatus, err)
+	}
+	var resp models.UpdateCheckResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return nil, fmt.Errorf("reading the %s response: %w", models.MethodUpdateStatus, err)
+	}
+	return &resp, nil
+}

--- a/pkg/ui/tui/update_test.go
+++ b/pkg/ui/tui/update_test.go
@@ -1,0 +1,93 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package tui
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatUpdateStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		status *models.UpdateCheckResponse
+		want   string
+	}{
+		// The ordinary case should read as just a version. Anything appended
+		// implies something needs doing.
+		"up to date says only the version": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    updater.EligibilityEligible,
+			},
+			want: "2.11.0",
+		},
+		"available": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				Eligibility:     updater.EligibilityEligible,
+			},
+			want: "2.10.0 (2.11.0 available)",
+		},
+		"held by rollout explains why it is not installing": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				RolloutHeld:     true,
+				Eligibility:     updater.EligibilityEligible,
+			},
+			want: "2.10.0 (2.11.0 available, rolling out gradually)",
+		},
+		"a rollback outranks an available update": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				Eligibility:     updater.EligibilityEligible,
+				LastResult: &models.UpdateLastResult{
+					Outcome:   updater.OutcomeRolledBack,
+					ToVersion: "2.11.0",
+				},
+			},
+			want: "2.10.0 (update to 2.11.0 was rolled back)",
+		},
+		"managed installs say where updates come from": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    updater.EligibilityManaged,
+			},
+			want: "2.11.0 (managed externally)",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatUpdateStatus(tt.status))
+		})
+	}
+}

--- a/pkg/ui/tui/update_test.go
+++ b/pkg/ui/tui/update_test.go
@@ -20,11 +20,16 @@
 package tui
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/updater"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatUpdateStatus(t *testing.T) {
@@ -82,6 +87,38 @@ func TestFormatUpdateStatus(t *testing.T) {
 			},
 			want: "2.11.0 (managed externally)",
 		},
+		// Nothing read yet still has to draw, because the line exists before
+		// the first check completes.
+		"nothing known falls back to the running version": {
+			status: nil,
+			want:   config.AppVersion,
+		},
+		"a status with no version of its own uses the running one": {
+			status: &models.UpdateCheckResponse{Eligibility: updater.EligibilityEligible},
+			want:   config.AppVersion,
+		},
+		// An update that failed and could not be undone is the one state where
+		// the device is running something nobody chose.
+		"a rollback that could not be completed": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.11.0",
+				Eligibility:    updater.EligibilityEligible,
+				LastResult: &models.UpdateLastResult{
+					Outcome: updater.OutcomeRollbackBlocked, ToVersion: "2.11.0",
+				},
+			},
+			want: "2.11.0 (update failed and could not be undone)",
+		},
+		"an interrupted update still needs attention": {
+			status: &models.UpdateCheckResponse{
+				CurrentVersion: "2.10.0",
+				Eligibility:    updater.EligibilityEligible,
+				LastResult: &models.UpdateLastResult{
+					Outcome: updater.OutcomeRecoveryRequired,
+				},
+			},
+			want: "2.10.0 (an interrupted update needs attention)",
+		},
 	}
 
 	for name, tt := range tests {
@@ -90,4 +127,40 @@ func TestFormatUpdateStatus(t *testing.T) {
 			assert.Equal(t, tt.want, formatUpdateStatus(tt.status))
 		})
 	}
+}
+
+// The daemon may not be up yet while the TUI is starting. The running version
+// is still worth showing on its own, so a failed read must not blank the line.
+func TestUpdateStatusLine_FallsBackToTheRunningVersion(t *testing.T) {
+	t.Parallel()
+
+	line := updateStatusLineWith(nil,
+		func(context.Context, *config.Instance, string, string) (string, error) {
+			return "", errors.New("connection refused")
+		})
+	assert.Equal(t, config.AppVersion, line)
+
+	// A response that arrives but cannot be read is the same situation.
+	line = updateStatusLineWith(nil,
+		func(context.Context, *config.Instance, string, string) (string, error) {
+			return "not json", nil
+		})
+	assert.Equal(t, config.AppVersion, line)
+}
+
+func TestUpdateStatusLine_ShowsWhatStatusReported(t *testing.T) {
+	t.Parallel()
+
+	line := updateStatusLineWith(nil,
+		func(context.Context, *config.Instance, string, string) (string, error) {
+			body, err := json.Marshal(models.UpdateCheckResponse{
+				CurrentVersion:  "2.10.0",
+				LatestVersion:   "2.11.0",
+				UpdateAvailable: true,
+				Eligibility:     updater.EligibilityEligible,
+			})
+			require.NoError(t, err)
+			return string(body), nil
+		})
+	assert.Equal(t, "2.10.0 (2.11.0 available)", line)
 }


### PR DESCRIPTION
`update.apply` was reachable only over the API. Nothing in the CLI could start one, and no interface showed whether an update existed, so the only sign was an inbox message — which keeps one row per category and updates it in place, so it is a current-state view rather than a history.

**A status display cannot be built on `update.check`.** A check fetches and verifies signed metadata and writes the outcome to the data directory, which on MiSTer is a write onto exfat. That cost is exactly why `HandleUpdateCheck` refuses unpaired clients. Anything that draws update state whenever a screen is painted has to be able to ask without paying it.

- **`update.status`** answers from what the last check found, contacting nothing and writing nothing. It deliberately does *not* re-derive this from the cached manifest: that copy is stored without its signature, because the signature is fetched fresh every time so the cache stays a bandwidth optimisation and never a trust boundary. Instead the check records its own conclusions, which were drawn from metadata it did verify. `checkedAt` says how old they are, and availability is recomputed against the running version so an update since installed stops being offered. Unlike a check it reports normally on a development build instead of refusing, because "this is a dev build, updates do not apply" is the useful answer on a screen.
- **`-update`** prints status, checks for a release, and installs only when there is something to install, so it is safe to run out of curiosity. It blocks until the restart, because someone at a terminal wants the outcome, and refuses rather than attempting an install the gate has already said no to.
- **Tray entry** titles itself from status, so the menu answers before it is opened, disables itself where updates do not apply, and reports through notifications rather than blocking.
- **TUI** gains the version line, which says only the version when there is nothing else to say — anything appended implies something needs doing.
- **Tray pairing dialog**, since a desktop has no terminal open to read a PIN out of. It cancels pairing when the dialog closes rather than leaving a live credential nobody is watching.
- **Outcome strings are exported.** Rendering an update's result means matching on them, and a client spelling one out by hand compiles and then silently never matches.

The status line orders by what happened to the device: a rollback outranks a waiting update, which outranks an available one. A successful update is deliberately silent — the version on screen already says it happened.

Two later commits fix defects found running this on a Windows device:

- `-update` acted on the stored status directly, and that comes from a check which runs every twelve hours. A release published since then was reported as "up to date" and never installed; a stale "available" named the wrong version, so it announced one version and installed whichever apply resolved as newest. It now checks whenever looking could change the answer, and keeps the stored answer only for the eligibility states whose answer comes from what the install is. That rule is shared with the tray menu so the two cannot drift.
- `-update` reinstalled the release that had just been rolled back without mentioning it. Declining stays reserved for automatic installs, since a person asking again is asking on purpose, but this flag is also how someone looks at where the device stands, so it now says that is what it is doing.

Full suite, deadlock, lint and Windows cross-lint pass. The flag, the status method and the tray were exercised on a Windows 11 device against a local signed manifest, through install, rollback and automatic install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added update status reporting without requiring a network check.
  - Added a CLI option to view update status and install available updates.
  - Added system tray update notifications, update installation, and device pairing access.
  - Added version and update details to the terminal interface.
  - Added the `update.status` API method for local and paired clients.

- **Bug Fixes**
  - Improved handling of rollout holds, blocked updates, retries, rollbacks, and recovery states.
  - Preserved the most recent update-check information for more accurate status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->