### PR TITLE
fix(desktop): restart into an installed update instead of stalling

### DIFF
--- a/cmd/mac/main.go
+++ b/cmd/mac/main.go
@@ -128,17 +128,32 @@ func run() error {
 	}
 
 	sigs := make(chan os.Signal, 1)
-	defer close(sigs)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	exit := make(chan bool, 1)
-	defer close(exit)
+
+	var (
+		svcDone          <-chan struct{}
+		restartRequested func() bool
+	)
+	if svcResult != nil {
+		svcDone = svcResult.Done
+		restartRequested = svcResult.RestartRequested
+	}
+
+	// The tray and the TUI each own the main thread until the user closes them,
+	// so the service is watched alongside whichever one is running rather than
+	// after it. Each mode passes the call that ends its own loop.
+	var restarting <-chan bool
 
 	// Handle application modes
 	switch {
 	case *daemonMode:
 		log.Info().Msg("started in daemon mode")
+		// Nothing to end here, so this blocks below on its own.
+		restarting = restart.WaitForShutdown(sigs, exit, svcDone, restartRequested, nil)
 	case *guiMode:
+		restarting = restart.WaitForShutdown(sigs, exit, svcDone, restartRequested, systray.Quit)
 		systray.Run(cfg, pl, systrayIcon, func(string) {}, func() {
 			exit <- true
 		})
@@ -155,6 +170,7 @@ func run() error {
 			return fmt.Errorf("error building UI: %w", err)
 		}
 
+		restarting = restart.WaitForShutdown(sigs, exit, svcDone, restartRequested, app.Stop)
 		err = app.Run()
 		if err != nil {
 			log.Error().Err(err).Msg("error running UI")
@@ -164,30 +180,16 @@ func run() error {
 		exit <- true
 	}
 
-	var svcDone <-chan struct{}
-	if svcResult != nil {
-		svcDone = svcResult.Done
-	}
-
-	stopSvc := func() {
-		if svcResult != nil {
-			if err := svcResult.Stop(); err != nil {
-				log.Error().Msgf("error stopping service: %s", err)
-			}
+	if <-restarting {
+		// The service already stopped itself on the way to being replaced.
+		if err := restart.Exec(); err != nil {
+			return fmt.Errorf("failed to re-exec for restart: %w", err)
 		}
+		return nil
 	}
-
-	select {
-	case <-sigs:
-		stopSvc()
-	case <-exit:
-		stopSvc()
-	case <-svcDone:
-		log.Info().Msg("service shut down internally")
-		if svcResult != nil {
-			if err := restart.ExecIfRequested(svcResult.RestartRequested); err != nil {
-				return fmt.Errorf("failed to re-exec for restart: %w", err)
-			}
+	if svcResult != nil {
+		if err := svcResult.Stop(); err != nil {
+			log.Error().Msgf("error stopping service: %s", err)
 		}
 	}
 

--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -143,6 +143,41 @@ func restartAfterReleasing(instance *singleInstance, restartFn func() error) err
 	return restartFn()
 }
 
+// watchForShutdown waits for whatever ends this run and calls quit so the tray's
+// event loop lets go of the main thread. The returned channel yields whether the
+// process should re-exec into the binary that replaced it.
+//
+// The watching has to happen here rather than after the tray, because the tray's
+// loop blocks until it quits and an update stops the service from underneath it.
+// Waiting afterwards meant an installed update never restarted: the service shut
+// down, the tray stayed up in front of nothing, and the new binary only ran if
+// someone quit or rebooted.
+func watchForShutdown(
+	sigs <-chan os.Signal,
+	exit <-chan bool,
+	done <-chan struct{},
+	restartRequested func() bool,
+	quit func(),
+) <-chan bool {
+	restarting := make(chan bool, 1)
+	go func() {
+		reExec := false
+		select {
+		case <-sigs:
+		case <-exit:
+		case <-done:
+			log.Info().Msg("service shut down internally")
+			reExec = restartRequested != nil && restartRequested()
+		}
+		restarting <- reExec
+		// Always quit the tray, including when the tray is what ended the run:
+		// calling it a second time is a no-op and skipping it would leave the
+		// loop running when the service is the thing that stopped.
+		quit()
+	}()
+	return restarting
+}
+
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
@@ -226,11 +261,11 @@ func run() error {
 	}
 
 	sigs := make(chan os.Signal, 1)
-	defer close(sigs)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	exit := make(chan bool, 1)
-	defer close(exit)
+
+	restarting := watchForShutdown(sigs, exit, svcResult.Done, svcResult.RestartRequested, systray.Quit)
 
 	systray.Run(cfg, pl, icon,
 		func(msg string) {
@@ -241,24 +276,16 @@ func run() error {
 		},
 	)
 
-	select {
-	case <-sigs:
-		err = svcResult.Stop()
-		if err != nil {
-			log.Error().Msgf("error stopping service: %s", err)
+	if <-restarting {
+		// The service stopped itself on the way to being replaced. Stopping it
+		// again would only delay the binary that replaced it.
+		if err := restartAfterReleasing(instance, restart.Exec); err != nil {
+			return fmt.Errorf("failed to re-exec for restart: %w", err)
 		}
-	case <-exit:
-		err = svcResult.Stop()
-		if err != nil {
-			log.Error().Msgf("error stopping service: %s", err)
-		}
-	case <-svcResult.Done:
-		log.Info().Msg("service shut down internally")
-		if svcResult.RestartRequested != nil && svcResult.RestartRequested() {
-			if err := restartAfterReleasing(instance, restart.Exec); err != nil {
-				return fmt.Errorf("failed to re-exec for restart: %w", err)
-			}
-		}
+		return nil
+	}
+	if err := svcResult.Stop(); err != nil {
+		log.Error().Msgf("error stopping service: %s", err)
 	}
 
 	return nil

--- a/cmd/windows/main.go
+++ b/cmd/windows/main.go
@@ -143,41 +143,6 @@ func restartAfterReleasing(instance *singleInstance, restartFn func() error) err
 	return restartFn()
 }
 
-// watchForShutdown waits for whatever ends this run and calls quit so the tray's
-// event loop lets go of the main thread. The returned channel yields whether the
-// process should re-exec into the binary that replaced it.
-//
-// The watching has to happen here rather than after the tray, because the tray's
-// loop blocks until it quits and an update stops the service from underneath it.
-// Waiting afterwards meant an installed update never restarted: the service shut
-// down, the tray stayed up in front of nothing, and the new binary only ran if
-// someone quit or rebooted.
-func watchForShutdown(
-	sigs <-chan os.Signal,
-	exit <-chan bool,
-	done <-chan struct{},
-	restartRequested func() bool,
-	quit func(),
-) <-chan bool {
-	restarting := make(chan bool, 1)
-	go func() {
-		reExec := false
-		select {
-		case <-sigs:
-		case <-exit:
-		case <-done:
-			log.Info().Msg("service shut down internally")
-			reExec = restartRequested != nil && restartRequested()
-		}
-		restarting <- reExec
-		// Always quit the tray, including when the tray is what ended the run:
-		// calling it a second time is a no-op and skipping it would leave the
-		// loop running when the service is the thing that stopped.
-		quit()
-	}()
-	return restarting
-}
-
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
@@ -265,7 +230,10 @@ func run() error {
 
 	exit := make(chan bool, 1)
 
-	restarting := watchForShutdown(sigs, exit, svcResult.Done, svcResult.RestartRequested, systray.Quit)
+	// The tray owns the main thread until it quits, so the service has to be
+	// watched alongside it rather than after it.
+	restarting := restart.WaitForShutdown(
+		sigs, exit, svcResult.Done, svcResult.RestartRequested, systray.Quit)
 
 	systray.Run(cfg, pl, icon,
 		func(msg string) {

--- a/cmd/windows/main_test.go
+++ b/cmd/windows/main_test.go
@@ -8,7 +8,10 @@ package main
 
 import (
 	"errors"
+	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -134,4 +137,80 @@ func TestRestartAfterReleasing_DoesNotRestartWhenReleaseFails(t *testing.T) {
 	require.ErrorIs(t, err, releaseErr)
 	assert.False(t, restarted)
 	assert.NotZero(t, instance.handle)
+}
+
+// An installed update stops the service from underneath the tray's event loop.
+// The loop owns the main thread until it quits, so unless something notices the
+// service ending and quits the tray, the process keeps a tray icon in front of a
+// stopped service and never re-execs into the binary that replaced it.
+func TestWatchForShutdown_QuitsTheTrayAndRestartsWhenTheServiceStopsItself(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	quit := make(chan struct{})
+
+	restarting := watchForShutdown(
+		nil, nil, done,
+		func() bool { return true },
+		func() { close(quit) },
+	)
+
+	close(done)
+	assert.True(t, <-restarting, "an internal shutdown that wants a restart must ask for one")
+	select {
+	case <-quit:
+	case <-time.After(time.Second):
+		t.Fatal("the tray was never told to quit, so its loop would hold the process open")
+	}
+}
+
+// A service that stopped on its own without asking to be restarted is an
+// ordinary shutdown, and re-execing would resurrect a service the user stopped.
+func TestWatchForShutdown_DoesNotRestartWhenNoneWasRequested(t *testing.T) {
+	t.Parallel()
+
+	for name, restartRequested := range map[string]func() bool{
+		"nothing asked": func() bool { return false },
+		"no reporter":   nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			done := make(chan struct{})
+			close(done)
+
+			restarting := watchForShutdown(nil, nil, done, restartRequested, func() {})
+			assert.False(t, <-restarting)
+		})
+	}
+}
+
+// Quitting from the tray, or a signal, ends the run without a restart. The tray
+// is quit again in the first case, which is a no-op, because skipping it would
+// mean the service-stopped case left the loop running.
+func TestWatchForShutdown_EndsWithoutRestartingOnSignalAndOnTrayExit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signal", func(t *testing.T) {
+		t.Parallel()
+		sigs := make(chan os.Signal, 1)
+		quit := make(chan struct{})
+
+		restarting := watchForShutdown(sigs, nil, nil, func() bool { return true }, func() { close(quit) })
+		sigs <- syscall.SIGTERM
+
+		assert.False(t, <-restarting, "a signal is not an update")
+		<-quit
+	})
+
+	t.Run("tray exit", func(t *testing.T) {
+		t.Parallel()
+		exit := make(chan bool, 1)
+		quit := make(chan struct{})
+
+		restarting := watchForShutdown(nil, exit, nil, func() bool { return true }, func() { close(quit) })
+		exit <- true
+
+		assert.False(t, <-restarting)
+		<-quit
+	})
 }

--- a/cmd/windows/main_test.go
+++ b/cmd/windows/main_test.go
@@ -8,10 +8,7 @@ package main
 
 import (
 	"errors"
-	"os"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,80 +134,4 @@ func TestRestartAfterReleasing_DoesNotRestartWhenReleaseFails(t *testing.T) {
 	require.ErrorIs(t, err, releaseErr)
 	assert.False(t, restarted)
 	assert.NotZero(t, instance.handle)
-}
-
-// An installed update stops the service from underneath the tray's event loop.
-// The loop owns the main thread until it quits, so unless something notices the
-// service ending and quits the tray, the process keeps a tray icon in front of a
-// stopped service and never re-execs into the binary that replaced it.
-func TestWatchForShutdown_QuitsTheTrayAndRestartsWhenTheServiceStopsItself(t *testing.T) {
-	t.Parallel()
-
-	done := make(chan struct{})
-	quit := make(chan struct{})
-
-	restarting := watchForShutdown(
-		nil, nil, done,
-		func() bool { return true },
-		func() { close(quit) },
-	)
-
-	close(done)
-	assert.True(t, <-restarting, "an internal shutdown that wants a restart must ask for one")
-	select {
-	case <-quit:
-	case <-time.After(time.Second):
-		t.Fatal("the tray was never told to quit, so its loop would hold the process open")
-	}
-}
-
-// A service that stopped on its own without asking to be restarted is an
-// ordinary shutdown, and re-execing would resurrect a service the user stopped.
-func TestWatchForShutdown_DoesNotRestartWhenNoneWasRequested(t *testing.T) {
-	t.Parallel()
-
-	for name, restartRequested := range map[string]func() bool{
-		"nothing asked": func() bool { return false },
-		"no reporter":   nil,
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			done := make(chan struct{})
-			close(done)
-
-			restarting := watchForShutdown(nil, nil, done, restartRequested, func() {})
-			assert.False(t, <-restarting)
-		})
-	}
-}
-
-// Quitting from the tray, or a signal, ends the run without a restart. The tray
-// is quit again in the first case, which is a no-op, because skipping it would
-// mean the service-stopped case left the loop running.
-func TestWatchForShutdown_EndsWithoutRestartingOnSignalAndOnTrayExit(t *testing.T) {
-	t.Parallel()
-
-	t.Run("signal", func(t *testing.T) {
-		t.Parallel()
-		sigs := make(chan os.Signal, 1)
-		quit := make(chan struct{})
-
-		restarting := watchForShutdown(sigs, nil, nil, func() bool { return true }, func() { close(quit) })
-		sigs <- syscall.SIGTERM
-
-		assert.False(t, <-restarting, "a signal is not an update")
-		<-quit
-	})
-
-	t.Run("tray exit", func(t *testing.T) {
-		t.Parallel()
-		exit := make(chan bool, 1)
-		quit := make(chan struct{})
-
-		restarting := watchForShutdown(nil, exit, nil, func() bool { return true }, func() { close(quit) })
-		exit <- true
-
-		assert.False(t, <-restarting)
-		<-quit
-	})
 }

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -172,7 +171,7 @@ func (f *Flags) Pre(pl platforms.Platform) {
 // situation already surfaced on stderr — so it logs at Warn to stay out of
 // Sentry; any other failure logs at Error.
 func logClientCommandError(err error, msg string) {
-	if errors.Is(err, syscall.ECONNREFUSED) {
+	if isConnectionRefused(err) {
 		log.Warn().Err(err).Msg(msg)
 		return
 	}

--- a/pkg/cli/connrefused.go
+++ b/pkg/cli/connrefused.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+	"syscall"
+)
+
+// isConnectionRefused reports whether a dial failed because nothing was
+// listening, which is what a CLI command sees when Core is not running.
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED)
+}

--- a/pkg/cli/connrefused_test.go
+++ b/pkg/cli/connrefused_test.go
@@ -1,0 +1,57 @@
+//go:build !windows
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A refused connection means Core is not running, which is expected and gets
+// logged at Warn to stay out of Sentry. The check runs against a real refused
+// dial rather than a hand-built error, because what a dial actually returns is
+// the thing that has to match.
+func TestIsConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	listener, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	var dialer net.Dialer
+	_, dialErr := dialer.DialContext(t.Context(), "tcp", addr)
+	require.Error(t, dialErr, "nothing should be listening on a closed port")
+	assert.True(t, isConnectionRefused(dialErr), "a real refused dial must be recognised")
+
+	// Wrapped the way the callers wrap it, since that is how it arrives.
+	assert.True(t, isConnectionRefused(fmt.Errorf("calling update.status: %w", dialErr)))
+
+	assert.False(t, isConnectionRefused(errors.New("something else")))
+	assert.False(t, isConnectionRefused(nil))
+}

--- a/pkg/cli/connrefused_windows.go
+++ b/pkg/cli/connrefused_windows.go
@@ -1,0 +1,41 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// isConnectionRefused reports whether a dial failed because nothing was
+// listening, which is what a CLI command sees when Core is not running.
+//
+// A refused connect on Windows comes back as the Winsock error, not the POSIX
+// one: syscall.ECONNREFUSED exists here but is a placeholder in the synthetic
+// APPLICATION_ERROR range that no socket call ever returns, and Errno.Is has no
+// mapping between the two. Comparing against only the POSIX name therefore
+// never matches, which logged "Core is not running" at Error and reported an
+// expected situation to Sentry every time a CLI command ran with the service
+// stopped. Both names are checked so neither platform relies on the other's.
+func isConnectionRefused(err error) bool {
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, windows.WSAECONNREFUSED)
+}

--- a/pkg/cli/connrefused_windows_test.go
+++ b/pkg/cli/connrefused_windows_test.go
@@ -1,0 +1,61 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This is the platform the check was wrong on. A refused connect here returns
+// the Winsock error, while syscall.ECONNREFUSED is a placeholder in the
+// synthetic APPLICATION_ERROR range that no socket call produces, and Errno.Is
+// maps nothing between them. Comparing against only the POSIX name therefore
+// never matched, so "Core is not running" logged at Error and was reported.
+//
+// The test dials for real rather than building the error by hand, because the
+// error a dial actually returns is the thing that has to match.
+func TestIsConnectionRefused_MatchesTheWinsockError(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	listener, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	var dialer net.Dialer
+	_, dialErr := dialer.DialContext(t.Context(), "tcp", addr)
+	require.Error(t, dialErr, "nothing should be listening on a closed port")
+
+	require.NotErrorIs(t, dialErr, syscall.ECONNREFUSED,
+		"the POSIX name alone is what used to be compared, and it does not match here")
+	assert.True(t, isConnectionRefused(dialErr))
+	assert.True(t, isConnectionRefused(fmt.Errorf("calling update.status: %w", dialErr)))
+
+	assert.False(t, isConnectionRefused(errors.New("something else")))
+	assert.False(t, isConnectionRefused(nil))
+}

--- a/pkg/service/restart/restart.go
+++ b/pkg/service/restart/restart.go
@@ -40,6 +40,46 @@ func ExecIfRequested(restartRequested func() bool) error {
 	return Exec()
 }
 
+// WaitForShutdown waits for whatever ends a run and calls quit, so a UI that
+// owns the main thread lets go of it. The returned channel yields whether the
+// process should re-exec into the binary that replaced it.
+//
+// This has to run alongside the UI rather than after it. A tray or a terminal UI
+// blocks its caller until the user closes it, and an update stops the service
+// from underneath that loop. Waiting for the service afterwards means an
+// installed update never restarts: the service shuts down, the UI stays up in
+// front of nothing, and the new binary only runs if someone quits or reboots.
+//
+// A nil done or sigs channel simply never fires, which is what a mode with no
+// service of its own wants.
+func WaitForShutdown(
+	sigs <-chan os.Signal,
+	exit <-chan bool,
+	done <-chan struct{},
+	restartRequested func() bool,
+	quit func(),
+) <-chan bool {
+	restarting := make(chan bool, 1)
+	go func() {
+		reExec := false
+		select {
+		case <-sigs:
+		case <-exit:
+		case <-done:
+			log.Info().Msg("service shut down internally")
+			reExec = restartRequested != nil && restartRequested()
+		}
+		restarting <- reExec
+		// Always quit, including when the UI is what ended the run: quitting an
+		// already-stopped UI does nothing, while skipping it would leave the
+		// loop running whenever the service is the thing that stopped.
+		if quit != nil {
+			quit()
+		}
+	}()
+	return restarting
+}
+
 // ExecAfterRollback re-execs the restored binary. A successful Exec never
 // returns, so every return preserves the rollback error for diagnosis.
 func ExecAfterRollback(rollbackErr error) error {

--- a/pkg/service/restart/restart_test.go
+++ b/pkg/service/restart/restart_test.go
@@ -22,7 +22,9 @@ package restart
 import (
 	"errors"
 	"os"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
@@ -81,4 +83,80 @@ func TestBinaryPath_AppEnvTakesPrecedence(t *testing.T) {
 	exe, err := os.Executable()
 	require.NoError(t, err)
 	assert.NotEqual(t, exe, path)
+}
+
+// An installed update stops the service from underneath the UI event loop.
+// The loop owns the main thread until it quits, so unless something notices the
+// service ending and quits the UI, the process keeps a UI in front of a
+// stopped service and never re-execs into the binary that replaced it.
+func TestWaitForShutdown_QuitsTheUIAndRestartsWhenTheServiceStopsItself(t *testing.T) {
+	t.Parallel()
+
+	done := make(chan struct{})
+	quit := make(chan struct{})
+
+	restarting := WaitForShutdown(
+		nil, nil, done,
+		func() bool { return true },
+		func() { close(quit) },
+	)
+
+	close(done)
+	assert.True(t, <-restarting, "an internal shutdown that wants a restart must ask for one")
+	select {
+	case <-quit:
+	case <-time.After(time.Second):
+		t.Fatal("the UI was never told to quit, so its loop would hold the process open")
+	}
+}
+
+// A service that stopped on its own without asking to be restarted is an
+// ordinary shutdown, and re-execing would resurrect a service the user stopped.
+func TestWaitForShutdown_DoesNotRestartWhenNoneWasRequested(t *testing.T) {
+	t.Parallel()
+
+	for name, restartRequested := range map[string]func() bool{
+		"nothing asked": func() bool { return false },
+		"no reporter":   nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			done := make(chan struct{})
+			close(done)
+
+			restarting := WaitForShutdown(nil, nil, done, restartRequested, func() {})
+			assert.False(t, <-restarting)
+		})
+	}
+}
+
+// Quitting from the UI, or a signal, ends the run without a restart. The tray
+// is quit again in the first case, which is a no-op, because skipping it would
+// mean the service-stopped case left the loop running.
+func TestWaitForShutdown_EndsWithoutRestartingOnSignalAndOnUIExit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signal", func(t *testing.T) {
+		t.Parallel()
+		sigs := make(chan os.Signal, 1)
+		quit := make(chan struct{})
+
+		restarting := WaitForShutdown(sigs, nil, nil, func() bool { return true }, func() { close(quit) })
+		sigs <- syscall.SIGTERM
+
+		assert.False(t, <-restarting, "a signal is not an update")
+		<-quit
+	})
+
+	t.Run("ui exit", func(t *testing.T) {
+		t.Parallel()
+		exit := make(chan bool, 1)
+		quit := make(chan struct{})
+
+		restarting := WaitForShutdown(nil, exit, nil, func() bool { return true }, func() { close(quit) })
+		exit <- true
+
+		assert.False(t, <-restarting)
+		<-quit
+	})
 }

--- a/pkg/ui/systray/systray.go
+++ b/pkg/ui/systray/systray.go
@@ -170,6 +170,10 @@ func reloadCore(
 	return nil
 }
 
+// Run shows the tray icon and does not return until the tray quits, because the
+// native event loop it starts owns the calling thread. Anything that has to
+// react to the service ending has to watch for it on another goroutine and call
+// Quit.
 func Run(
 	cfg *config.Instance,
 	pl platforms.Platform,
@@ -178,4 +182,10 @@ func Run(
 	exit func(),
 ) {
 	systray.Run(systrayOnReady(cfg, pl, icon, notify), exit)
+}
+
+// Quit ends the tray's event loop, which lets Run return. It is safe to call
+// from another goroutine and does nothing if the tray has already quit.
+func Quit() {
+	systray.Quit()
 }


### PR DESCRIPTION
An OTA install on Windows and macOS stopped the service and never restarted. The tray and the TUI each block the main thread until the user closes them, and both entrypoints waited for the service to end *after* that call, so the branch that re-execs was unreachable. The service shut down, the UI stayed up in front of nothing, the API stopped answering, and the new binary only ran if someone quit or rebooted.

- `WaitForShutdown` moves into `pkg/service/restart`, watching signals, the UI's own exit and the service's `Done` on its own goroutine, and quitting the UI so the loop releases the main thread. It returns whether the process should re-exec. Both entrypoints use it, and its tests now run on every platform instead of only Windows.
- `cmd/windows/main.go` passes `systray.Quit`.
- `cmd/mac/main.go` passes the call that ends whichever mode is running: `systray.Quit` for the tray, `app.Stop` for the TUI, and nothing for daemon mode, which has no loop to end. Automatic installation is not a goal for macOS in v1, but manual apply reaches the same path.
- `systray.Quit` added so a caller can end the tray's event loop from another goroutine.
- `logClientCommandError` logs a refused connection at Warn because it means Core is not running, which is expected and already shown on stderr. The comparison used only `syscall.ECONNREFUSED`, which on Windows is a placeholder in the synthetic `APPLICATION_ERROR` range that no socket call returns, and `Errno.Is` has no mapping to the Winsock error a refused dial produces. Every CLI command run with the service stopped logged at Error instead, and error-level logs are sent to Sentry.

Both defects are present on `main`; the restart stall dates from the original self-update work. Found while running the OTA validation matrix on a Windows 11 device, where an applied update left `pending.json` at `state: installed`, the log ending at `service cleanup completed`, and the process alive with a dead API two minutes later. After the fix that same install logs `service shut down internally` and `spawning new process for update restart`, comes back on a new PID, and confirms 30s later.

The macOS half is unverified on hardware — it is the same defect and the same fix, reasoned from the identical code shape.