### PR TITLE
fix(mediadb): back up a corrupt database where Windows allows it

### DIFF
--- a/pkg/database/corruption_test.go
+++ b/pkg/database/corruption_test.go
@@ -212,3 +212,52 @@ func TestConnLoadStore(t *testing.T) {
 	c.Store(nil)
 	assert.Nil(t, c.Load())
 }
+
+// A corrupt database is renamed aside so it survives the rebuild that replaces
+// it. That copy is the only evidence of what went wrong, and the caller removes
+// the original immediately afterwards, so a preserve that quietly does nothing
+// destroys the thing it exists to keep.
+func TestPreserveCorruptFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renames the file aside", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "media.db")
+		require.NoError(t, os.WriteFile(path, []byte("corrupt pages"), 0o600))
+
+		PreserveCorruptFile(path, "media")
+
+		assert.NoFileExists(t, path, "the original is renamed, not copied")
+		kept, err := os.ReadFile(CorruptBackupPath(path))
+		require.NoError(t, err)
+		assert.Equal(t, "corrupt pages", string(kept))
+	})
+
+	t.Run("keeps the newest of repeated failures", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "media.db")
+		require.NoError(t, os.WriteFile(CorruptBackupPath(path), []byte("older"), 0o600))
+		require.NoError(t, os.WriteFile(path, []byte("newer"), 0o600))
+
+		PreserveCorruptFile(path, "media")
+
+		kept, err := os.ReadFile(CorruptBackupPath(path))
+		require.NoError(t, err)
+		assert.Equal(t, "newer", string(kept),
+			"a second corruption must not be dropped in favour of the first")
+	})
+
+	// Sidecars come and go depending on what the close managed to checkpoint, so
+	// being asked to preserve one that is not there is ordinary.
+	t.Run("does nothing for a file that is not there", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "media.db-wal")
+
+		PreserveCorruptFile(path, "media")
+
+		assert.NoFileExists(t, CorruptBackupPath(path))
+	})
+}

--- a/pkg/database/mediadb/corruption_recovery_test.go
+++ b/pkg/database/mediadb/corruption_recovery_test.go
@@ -171,23 +171,18 @@ func TestMediaDB_Recreate_KeepBackup(t *testing.T) {
 	mediaDB.MarkCorrupt("test")
 	path := mediaDB.GetDBPath()
 
-	// Write deterministic sidecars so the WAL/SHM preservation assertions below
-	// don't depend on incidental SQLite checkpoint timing at Close().
-	require.NoError(t, os.WriteFile(path+"-wal", []byte("wal contents"), 0o600))
-	require.NoError(t, os.WriteFile(path+"-shm", []byte("shm contents"), 0o600))
-
 	require.NoError(t, mediaDB.Recreate(true))
 
-	// Forensic backup kept for the database and both sidecars, marker cleared.
-	// (The reopened WAL database creates fresh -wal/-shm sidecars; the point is
-	// the stale corrupt ones don't survive into it, which the empty+queryable
-	// check below confirms.)
+	// The corrupt database is kept for a post-mortem, and the marker is cleared.
+	//
+	// Only the database file is asserted on. The sidecars are preserved after
+	// the close, by which point either SQLite checkpointed the WAL into this
+	// file or it did not, so whether a -wal backup exists depends on what the
+	// close managed — a real condition, not something a test should pin. What
+	// PreserveCorruptFile does with a sidecar that is there is covered by its
+	// own tests, against plain files and no live database.
 	_, backupErr := os.Stat(path + database.CorruptMarkerSuffix + ".bak")
 	require.NoError(t, backupErr, "database backup copy should be kept when keepBackup=true")
-	_, walBackupErr := os.Stat(path + "-wal" + database.CorruptMarkerSuffix + ".bak")
-	require.NoError(t, walBackupErr, "WAL backup copy should be kept when keepBackup=true")
-	_, shmBackupErr := os.Stat(path + "-shm" + database.CorruptMarkerSuffix + ".bak")
-	require.NoError(t, shmBackupErr, "SHM backup copy should be kept when keepBackup=true")
 	assert.False(t, mediaDB.IsMarkedCorrupt(), "marker should be cleared after recreate")
 
 	// Fresh schema: queryable and empty, with durable intent to rebuild it.

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1499,12 +1499,6 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 	}
 	defer db.recreating.Store(false)
 
-	if keepBackup {
-		database.PreserveCorruptFile(db.dbPath, "media")
-		database.PreserveCorruptFile(db.dbPath+"-wal", "media")
-		database.PreserveCorruptFile(db.dbPath+"-shm", "media")
-	}
-
 	if err := db.Close(); err != nil {
 		log.Warn().Err(err).Msg("error closing media database before recreate")
 	}
@@ -1514,16 +1508,33 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 	// dereference. A guard check (Load() == nil) followed by a second Load() for the
 	// query would otherwise race the swap-to-nil and panic.
 
+	// Preserved after the close, not before it, because renaming a file SQLite
+	// still has open fails on Windows: the main database and WAL are opened
+	// without FILE_SHARE_DELETE and the -shm is memory-mapped, so every rename
+	// here returned a sharing violation and the forensic copy was silently
+	// skipped — then the corrupt database was removed below with no backup at
+	// all. Nothing is lost by waiting: either the close checkpointed the WAL
+	// into the main database, which is the file being preserved, or it could
+	// not, and the WAL is still on disk to be preserved with it.
+	//
+	// The -shm is deliberately not preserved. It is a shared-memory index
+	// rebuilt from the WAL on demand, holds nothing durable, and is the one
+	// file whose mapping Windows would refuse to rename anyway.
+	if keepBackup {
+		database.PreserveCorruptFile(db.dbPath, "media")
+		database.PreserveCorruptFile(db.dbPath+"-wal", "media")
+	}
+
 	// Clear any transaction state so db.conn() can't hand out a stale closed tx after
 	// the reopen below. Close has already rolled back and released any writer connection.
 	db.tx = nil
 	db.txConn = nil
 	db.inTransaction = false
 
-	// PreserveCorruptFile above is best-effort: on a rename failure it logs and
-	// leaves the file in place. Whether or not keepBackup ran (or partially
-	// succeeded), db.dbPath must not still exist here — otherwise Open() below
-	// would reopen the corrupt database instead of allocating a fresh one.
+	// PreserveCorruptFile is best-effort: on a rename failure it logs and leaves
+	// the file in place. Whether or not keepBackup ran (or partially succeeded),
+	// db.dbPath must not still exist here — otherwise Open() below would reopen
+	// the corrupt database instead of allocating a fresh one.
 	if err := os.Remove(db.dbPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to remove corrupt media database: %w", err)
 	}


### PR DESCRIPTION
`Recreate` renamed the media database and its sidecars aside *before* closing them. SQLite opens the database and WAL without `FILE_SHARE_DELETE` and keeps the `-shm` memory-mapped, so on Windows every one of those renames returned a sharing violation. `PreserveCorruptFile` is best-effort and only logs, so the failure was silent — and `Recreate` then removed the database, leaving no forensic copy of the corruption it had just been asked to keep.

- **Preserve after the close.** Nothing is lost by waiting: either the close checkpointed the WAL into the database being preserved, or it could not and the WAL is still on disk to preserve alongside it. `UserDB.RecoverFromCorruption` already recovers in this order — MediaDB was the outlier.
- **Stop preserving `-shm`.** It is a shared-memory index rebuilt from the WAL on demand, holds nothing durable, and is the one file whose mapping Windows would refuse to rename anyway.
- **`TestMediaDB_Recreate_KeepBackup` no longer writes sidecars into a live database.** Doing that to make its assertions deterministic is what surfaced this: the write to the mapped `-shm` fails outright on Windows. It now asserts what the operation actually guarantees, and `PreserveCorruptFile` is covered directly, against plain files with no live database.

This is why the Windows suite has been red on `main` since #1322 — the last green main run was `bd813ea8`, and the failure predates the OTA PRs merged today.

Verified on a Windows 11 device rather than inferred, with the test binary cross-compiled and run there:

- unmodified `main`: fails on the `-shm` write with `The requested operation cannot be performed on a file with a user-mapped section open`
- old ordering with the new test: fails `database backup copy should be kept when keepBackup=true`, confirming no backup was produced at all
- this branch: passes

Full suite, deadlock, lint and both cross-lints pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database recovery to reliably preserve corrupt database files before recreation.
  * Reduced the risk of losing forensic backups on Windows.
  * Preserves the database and WAL backup files while avoiding unreliable shared-memory sidecar preservation.

* **Tests**
  * Added coverage for backup creation, retaining the newest backup, and handling missing files.
  * Updated recovery tests to reflect reliable backup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->