### PR TITLE
ci: build every release target weekly without publishing

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,39 @@
+name: Build check
+
+# Builds every release target and throws the results away.
+#
+# The release build is otherwise only exercised by cutting a tag, so a change
+# that breaks it goes unnoticed until someone tries to release. That is how the
+# archive tool's platform-package import survived: pull request CI never runs
+# the release path, and developer machines have the libraries it needs.
+#
+# This publishes nothing. test_build skips creating the release, uploading
+# assets and signing, so there are no tags and no notifications — it speaks up
+# only when a target stops building.
+
+on:
+  schedule:
+    # Weekly. The release build changes rarely, and what matters is that a break
+    # survives days rather than reaching a release.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+# Declared once for the whole workflow: a job-level block would replace this
+# rather than add to it. Enough to build and reach the zigcc image, and nothing
+# that could publish.
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-check
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      # Names the archives this build discards. No release is created and
+      # nothing looks this up, so it is not a real tag.
+      tag: v0.0.0-buildcheck
+      test_build: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
         type: string
         default: ""
       test_build:
-        description: "Test build only (no release created, uses test-signing)"
+        description: "Test build only: build every target, publish and sign nothing"
         required: false
         type: boolean
         default: false
@@ -27,7 +27,7 @@ on:
         type: boolean
         default: false
       test_build:
-        description: "Test build only (no release created)"
+        description: "Test build only: build every target, publish and sign nothing"
         required: false
         type: boolean
         default: false
@@ -185,26 +185,26 @@ jobs:
           GOFLAGS: "-buildvcs=false"
         run: APP_VERSION=${VERSION} task ${{matrix.platform}}:build-${{matrix.arch}}
       - name: Upload unsigned Windows exe
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && !inputs.test_build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows-exe-${{matrix.arch}}
           path: _build/windows_${{matrix.arch}}/Zaparoo.exe
           retention-days: 30
       - name: Copy installer to consistent name
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && !inputs.test_build
         run: |
           cp "_build/windows_${{matrix.arch}}/Output/zaparoo-${{matrix.arch}}-${VERSION}-setup.exe" \
              "_build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe"
       - name: Upload unsigned Windows installer
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && !inputs.test_build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unsigned-windows-installer-${{matrix.arch}}
           path: _build/windows_${{matrix.arch}}/Output/zaparoo-setup.exe
           retention-days: 30
       - name: Upload Windows distribution files
-        if: matrix.platform == 'windows'
+        if: matrix.platform == 'windows' && !inputs.test_build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-dist-${{matrix.arch}}
@@ -259,7 +259,10 @@ jobs:
     timeout-minutes: 30
     name: Sign all Windows binaries
     needs: build
-    if: ${{ !cancelled() && needs.build.result == 'success' }}
+    # Skipped for a test build: signing needs the release policy and its
+    # credentials, and a build that publishes nothing has no artifact worth
+    # spending a signature on.
+    if: ${{ !cancelled() && needs.build.result == 'success' && !inputs.test_build }}
     permissions:
       contents: write
       actions: read


### PR DESCRIPTION
The release build is only otherwise exercised by cutting a tag, so a change that breaks it goes unnoticed until someone tries to release. Pull request CI never runs that path, and developer machines have the libraries it needs — which is how the import that broke all 22 targets in #1344 survived from one release to the next.

- **`build-check.yml`** runs the same matrix weekly and throws the result away. Weekly rather than daily because the release build changes rarely, and what matters is that a break survives days rather than reaching a release. Also dispatchable by hand, which is worth doing before cutting a tag.
- **`test_build` now means what its name says.** It already skipped creating the release and uploading assets, but `sign-windows` was not gated on it, so a test build would still submit to SignPath under the `release-signing` policy and leave unsigned Windows artifacts behind. A build that publishes nothing has no artifact worth spending a signature on. Signing and those four uploads are now skipped with it.

The release path is unchanged: `test_build` is false there, and every gated step is packaging or upload, never a compile.

Nothing is published, so there are no tags and no notifications — it speaks up only when a target stops building, which is the thing that was missing.

Two notes:

- Merge #1344 first, or the first run goes red for the reason that motivated this.
- `workflow_dispatch` only appears once the workflow is on the default branch, so this cannot be trial-run until it merges.

`actionlint` clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Added scheduled and manually triggered release-build checks.
  * Test builds now build all supported targets without publishing, uploading, or signing artifacts.
  * Windows packaging and signing are skipped during test builds to keep validation safe and non-releasable.
  * Updated build instructions to clarify test-build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->