### PR TITLE
fix(build): follow the steamos docs to their new path

### DIFF
--- a/scripts/tasks/utils/makezip/main.go
+++ b/scripts/tasks/utils/makezip/main.go
@@ -50,7 +50,7 @@ var platformDocs = map[string]string{
 	"mistex":    "mistex.md",
 	"recalbox":  "recalbox.mdx",
 	"replayos":  "replayos.md",
-	"steamos":   "steamos.md",
+	"steamos":   "steamos/index.md",
 	"windows":   "windows/index.md",
 	// Interim packaging fallback until dedicated ZapOS docs are published.
 	"zapos": "linux/index.md",


### PR DESCRIPTION
`build (steamos, amd64)` was the only target still failing after #1344:

```
Error downloading documentation: downloading steamos docs:
all 5 attempts failed, last error: attempt 5: HTTP 404: Not Found
```

The archive tool fetches each platform's page from the website repository to use as the archive README. The SteamOS page moved from `steamos.md` into a `steamos/` directory, so the fetch 404s and fails the target after its retries.

I checked all twelve mapped paths, not just the failing one — every other still resolves, so this is the only move. The sibling map of public URLs in the same file already used `steamos/`, which is also the shape the other moved pages take.

Verified by running the real `steamos:build-amd64` locally end to end: the archive builds and its README is the 220-line SteamOS page rather than a fallback.

Worth noting the shape of this: the release build fetches from another repository at build time, so a page moving there breaks releases here. #1345 now runs this same path weekly, so the next one surfaces in a build check rather than when someone cuts a tag.