### PR TITLE
fix(build): keep the signing checkout in step with the archive tool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,9 +269,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Every repository package makezip imports has to be listed here, or
+          # the repackage step below cannot build it. TestSigningCheckoutCovers
+          # Imports keeps this in step with what the tool actually imports.
           sparse-checkout: |
             scripts/
-            pkg/platforms/batocera/payload.go
+            pkg/platforms/batocera/payload/
             pkg/platforms/updatepayload/
             go.mod
             go.sum

--- a/scripts/tasks/utils/makezip/imports_test.go
+++ b/scripts/tasks/utils/makezip/imports_test.go
@@ -23,10 +23,15 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 )
+
+// modulePrefix is this module's import path, so a repository package can be
+// told from a third-party one.
+const modulePrefix = "github.com/ZaparooProject/zaparoo-core/v2/"
 
 // allowedPlatformImports are the platform packages this tool may import: both
 // hold data and nothing else.
@@ -69,6 +74,53 @@ func TestNoPlatformPackageImports(t *testing.T) {
 			t.Errorf("%s imports %s: a platform package compiles the readers stack, "+
 				"which needs libnfc headers the archive machine does not have. "+
 				"Move whatever is needed into a package that holds only data.", name, path)
+		}
+	}
+}
+
+// The signing job checks out only the paths it lists, so a repository package
+// this tool imports has to appear there or the release repackage step cannot
+// build it. That break lands after Windows binaries have already been signed,
+// which is the most expensive place in the pipeline to discover it.
+func TestSigningCheckoutCoversImports(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := os.ReadFile(filepath.Join("..", "..", "..", "..",
+		".github", "workflows", "build.yml"))
+	if err != nil {
+		t.Fatalf("reading the release workflow: %v", err)
+	}
+	checkout := string(workflow)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading this package's directory: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, name, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			t.Fatalf("parsing %s: %v", name, parseErr)
+		}
+		for _, spec := range file.Imports {
+			path, unquoteErr := strconv.Unquote(spec.Path.Value)
+			if unquoteErr != nil {
+				t.Fatalf("reading an import path in %s: %v", name, unquoteErr)
+			}
+			dir, ok := strings.CutPrefix(path, modulePrefix)
+			if !ok {
+				continue
+			}
+			if !strings.Contains(checkout, dir+"/") {
+				t.Errorf("%s imports %s but the signing job's sparse-checkout does not "+
+					"include %s/: the repackage step would fail to build this tool, after "+
+					"the Windows binaries have been signed.", name, path, dir)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The `sign-windows` job uses a sparse checkout that lists exactly the paths `makezip` needs. #1344 moved the Batocera payload data into its own package, and that list still named the old file, so the repackage step could not build the tool:

```
no required module provides package
github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/batocera/payload
```

My regression, from #1344. The import guard I added there only checked one half of the relationship — which packages the tool may import — and not whether the release pipeline actually checks them out.

- The sparse-checkout entry becomes `pkg/platforms/batocera/payload/`.
- `TestSigningCheckoutCoversImports` compares the tool's repository imports against that list, so they cannot drift again. Verified by restoring the old entry and watching it fail with the missing path named.

Worth saying where this lands in the pipeline: all 22 targets built and SignPath had already signed the Windows binaries before this step ran. A missing checkout path is about the most expensive way to fail a release, so it is worth a test rather than a fix alone.

The `digest-mismatch: error` lines elsewhere in that job's log are an echoed input default of `download-artifact`, not failures.

Full suite, lint, actionlint clean.