### PR TITLE
feat(steamos): add portable backup support

### DIFF
--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -366,8 +366,11 @@ type BackupPattern struct {
 }
 
 type BackupDefinition struct {
-	SourceRoot         string
-	RestoreRoot        string
+	SourceRoot  string
+	RestoreRoot string
+	// RestoreTargetRoot optionally maps RestoreRoot to a platform-discovered
+	// physical category root. It must never be derived from backup contents.
+	RestoreTargetRoot  string
 	Category           string
 	Include            []BackupPattern
 	Exclude            []BackupPattern

--- a/pkg/platforms/shared/linuxemu/emudeck.go
+++ b/pkg/platforms/shared/linuxemu/emudeck.go
@@ -191,7 +191,7 @@ func emuDeckWrapperPath(paths *EmuDeckPaths, emulator emulatorConfig) string {
 	if emulator.wrapper == "" {
 		return ""
 	}
-	return filepath.Join(filepath.Dir(paths.RomsPath), "tools", "launchers", emulator.wrapper)
+	return filepath.Join(paths.ToolsPath, "launchers", emulator.wrapper)
 }
 
 func validEmuDeckWrapper(path string) bool {

--- a/pkg/platforms/shared/linuxemu/emudeck.go
+++ b/pkg/platforms/shared/linuxemu/emudeck.go
@@ -116,14 +116,14 @@ func emuDeckLaunchers(_ *config.Instance, options *Options) []platforms.Launcher
 		mappedFolder := emuDeckSystemFolder(folder)
 		emulator, mapped := emulatorMapping[mappedFolder]
 		if !mapped || (emulator.typeName == emulatorRetroArch && !retroArchAvailable(options)) ||
-			(emulator.typeName == emulatorStandalone && !emuDeckEmulatorAvailable(options, paths, emulator)) {
+			(emulator.typeName == emulatorStandalone && !emuDeckEmulatorAvailable(options, &paths, emulator)) {
 			continue
 		}
 		info, ok := esde.LookupByFolderName(mappedFolder)
 		if !ok {
 			continue
 		}
-		launcher, ok := createEmuDeckLauncher(options, folder, mappedFolder, info, paths, emulator)
+		launcher, ok := createEmuDeckLauncher(options, folder, mappedFolder, info, &paths, emulator)
 		if ok {
 			result = append(result, launcher)
 		}
@@ -135,7 +135,7 @@ func createEmuDeckLauncher(
 	options *Options,
 	folder, mappedFolder string,
 	info esde.SystemInfo,
-	paths EmuDeckPaths,
+	paths *EmuDeckPaths,
 	emulator emulatorConfig,
 ) (platforms.Launcher, bool) {
 	var launcher platforms.Launcher
@@ -187,7 +187,7 @@ func emuDeckSystemFolder(folder string) string {
 	}
 }
 
-func emuDeckWrapperPath(paths EmuDeckPaths, emulator emulatorConfig) string {
+func emuDeckWrapperPath(paths *EmuDeckPaths, emulator emulatorConfig) string {
 	if emulator.wrapper == "" {
 		return ""
 	}
@@ -202,14 +202,14 @@ func validEmuDeckWrapper(path string) bool {
 	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
 }
 
-func emuDeckEmulatorAvailable(options *Options, paths EmuDeckPaths, emulator emulatorConfig) bool {
+func emuDeckEmulatorAvailable(options *Options, paths *EmuDeckPaths, emulator emulatorConfig) bool {
 	return validEmuDeckWrapper(emuDeckWrapperPath(paths, emulator)) ||
 		(emulator.flatpakID != "" && options.IsFlatpakInstalled(emulator.flatpakID))
 }
 
 func standaloneEmuDeckLauncher(
 	options *Options,
-	paths EmuDeckPaths,
+	paths *EmuDeckPaths,
 	emulator emulatorConfig,
 ) platforms.Launcher {
 	buildCommand := func(path string) (*platforms.LaunchCommand, error) {
@@ -250,7 +250,7 @@ func standaloneEmuDeckLauncher(
 
 func emuDeckStandaloneCommand(
 	options *Options,
-	paths EmuDeckPaths,
+	paths *EmuDeckPaths,
 	emulator emulatorConfig,
 	path string,
 ) (*platforms.LaunchCommand, error) {

--- a/pkg/platforms/shared/linuxemu/integration_test.go
+++ b/pkg/platforms/shared/linuxemu/integration_test.go
@@ -40,11 +40,21 @@ func TestDefaultEmuDeckPathsReadsSettings(t *testing.T) {
 	settingsDir := filepath.Join(home, filepath.FromSlash(emuDeckSettingsDir))
 	require.NoError(t, os.MkdirAll(settingsDir, 0o750))
 	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.sh"), []byte(
-		"romsPath=\"$HOME/Games/Emulation/roms\"\nmalicious=$(touch /tmp/nope)\n",
+		"emulationPath=\"$HOME/Games/Emulation\"\n"+
+			"romsPath=\"$HOME/Libraries/roms\"\n"+
+			"biosPath=\"$HOME/Firmware\"\n"+
+			"savesPath=\"$HOME/Save Data\"\n"+
+			"storagePath=\"$HOME/Emulator Storage\"\n"+
+			"malicious=$(touch /tmp/nope)\n",
 	), 0o600))
 
 	paths := DefaultEmuDeckPaths(home)
-	assert.Equal(t, filepath.Join(home, "Games", "Emulation", "roms"), paths.RomsPath)
+	assert.Equal(t, filepath.Join(home, "Games", "Emulation"), paths.EmulationPath)
+	assert.Equal(t, filepath.Join(home, "Libraries", "roms"), paths.RomsPath)
+	assert.Equal(t, filepath.Join(home, "Games", "Emulation", "tools"), paths.ToolsPath)
+	assert.Equal(t, filepath.Join(home, "Firmware"), paths.BiosPath)
+	assert.Equal(t, filepath.Join(home, "Save Data"), paths.SavesPath)
+	assert.Equal(t, filepath.Join(home, "Emulator Storage"), paths.StoragePath)
 	assert.Equal(t, filepath.Join(home, "ES-DE", "gamelists"), paths.GamelistPath)
 }
 
@@ -62,6 +72,51 @@ func TestDefaultEmuDeckPathsRejectsShellExpansion(t *testing.T) {
 	assert.Equal(t, filepath.Join(home, "Emulation", "roms"), paths.RomsPath)
 }
 
+func TestDefaultEmuDeckPathsRejectsDangerousSymlinkRoot(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	settingsDir := filepath.Join(home, filepath.FromSlash(emuDeckSettingsDir))
+	require.NoError(t, os.MkdirAll(settingsDir, 0o750))
+	link := filepath.Join(home, "unsafe-saves")
+	require.NoError(t, os.Symlink(home, link))
+	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.sh"), []byte(
+		"savesPath=\""+link+"\"\n",
+	), 0o600))
+
+	paths := DefaultEmuDeckPaths(home)
+	assert.Equal(t, filepath.Join(home, "Emulation", "saves"), paths.SavesPath)
+}
+
+func TestDefaultEmuDeckPathsRejectsRootSymlinkAncestor(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	settingsDir := filepath.Join(home, filepath.FromSlash(emuDeckSettingsDir))
+	require.NoError(t, os.MkdirAll(settingsDir, 0o750))
+	link := filepath.Join(home, "root-link")
+	require.NoError(t, os.Symlink(string(filepath.Separator), link))
+	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.sh"), []byte(
+		"savesPath=\""+filepath.Join(link, "not-created-by-zaparoo")+"\"\n",
+	), 0o600))
+
+	paths := DefaultEmuDeckPaths(home)
+	assert.Equal(t, filepath.Join(home, "Emulation", "saves"), paths.SavesPath)
+}
+
+func TestDefaultEmuDeckPathsRejectsExistingPathThroughRootSymlink(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	settingsDir := filepath.Join(home, filepath.FromSlash(emuDeckSettingsDir))
+	require.NoError(t, os.MkdirAll(settingsDir, 0o750))
+	link := filepath.Join(home, "root-link")
+	require.NoError(t, os.Symlink(string(filepath.Separator), link))
+	require.NoError(t, os.WriteFile(filepath.Join(settingsDir, "settings.sh"), []byte(
+		"savesPath=\""+filepath.Join(link, "tmp")+"\"\n",
+	), 0o600))
+
+	paths := DefaultEmuDeckPaths(home)
+	assert.Equal(t, filepath.Join(home, "Emulation", "saves"), paths.SavesPath)
+}
+
 func TestDefaultRetroDECKPathsReadsJSON(t *testing.T) {
 	t.Parallel()
 
@@ -70,11 +125,26 @@ func TestDefaultRetroDECKPathsReadsJSON(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0o750))
 	customHome := filepath.Join(home, "Games", "RetroDECK")
 	customRoms := filepath.Join(home, "External", "roms")
-	content := `{"version":"1","paths":{"rd_home_path":"` + customHome + `","roms_path":"` + customRoms + `"}}`
+	customSaves := filepath.Join(home, "Persistent", "saves")
+	customStates := filepath.Join(home, "Persistent", "states")
+	customBios := filepath.Join(home, "Persistent", "bios")
+	customStorage := filepath.Join(home, "Persistent", "storage")
+	content := `{"version":"1","paths":{` +
+		`"rd_home_path":"` + customHome + `",` +
+		`"roms_path":"` + customRoms + `",` +
+		`"saves_path":"` + customSaves + `",` +
+		`"states_path":"` + customStates + `",` +
+		`"bios_path":"` + customBios + `",` +
+		`"storage_path":"` + customStorage + `"}}`
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "retrodeck.json"), []byte(content), 0o600))
 
 	paths := DefaultRetroDECKPaths(home)
+	assert.Equal(t, customHome, paths.HomePath)
 	assert.Equal(t, customRoms, paths.RomsPath)
+	assert.Equal(t, customSaves, paths.SavesPath)
+	assert.Equal(t, customStates, paths.StatesPath)
+	assert.Equal(t, customBios, paths.BiosPath)
+	assert.Equal(t, customStorage, paths.StoragePath)
 	assert.Equal(t, filepath.Join(customHome, "ES-DE", "gamelists"), paths.GamelistPath)
 }
 

--- a/pkg/platforms/shared/linuxemu/integration_test.go
+++ b/pkg/platforms/shared/linuxemu/integration_test.go
@@ -719,3 +719,23 @@ func TestLaunchersRegistersNothingWithoutDependencies(t *testing.T) {
 
 	assert.Empty(t, Launchers(nil, options, nil))
 }
+
+func TestEmuDeckWrapperPathUsesToolsPath(t *testing.T) {
+	t.Parallel()
+
+	// EmuDeck lets romsPath and toolsPath point at different roots; the
+	// launcher wrappers only ever live under toolsPath.
+	paths := EmuDeckPaths{
+		RomsPath:  filepath.Join(string(filepath.Separator), "mnt", "sdcard", "roms"),
+		ToolsPath: filepath.Join(string(filepath.Separator), "home", "deck", "Emulation", "tools"),
+	}
+	got := emuDeckWrapperPath(&paths, emulatorConfig{wrapper: "DuckStation.sh"})
+	want := filepath.Join(paths.ToolsPath, "launchers", "DuckStation.sh")
+	if got != want {
+		t.Fatalf("wrapper path: got %s, want %s", got, want)
+	}
+
+	if emuDeckWrapperPath(&paths, emulatorConfig{}) != "" {
+		t.Fatal("expected empty path for an emulator with no wrapper")
+	}
+}

--- a/pkg/platforms/shared/linuxemu/paths.go
+++ b/pkg/platforms/shared/linuxemu/paths.go
@@ -181,6 +181,7 @@ func parseShellPathAssignment(contents, key, homeDir string) string {
 			continue
 		}
 		value = strings.TrimSpace(value)
+		literal := false
 		if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
 			unquoted, err := strconv.Unquote(value)
 			if err != nil {
@@ -188,12 +189,17 @@ func parseShellPathAssignment(contents, key, homeDir string) string {
 			}
 			value = unquoted
 		} else if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
-			value = value[1 : len(value)-1]
+			// POSIX single quoting escapes an apostrophe as '\'' and leaves
+			// everything else, including $HOME and ~, literal.
+			value = strings.ReplaceAll(value[1:len(value)-1], `'\''`, "'")
+			literal = true
 		}
-		value = strings.ReplaceAll(value, "${HOME}", homeDir)
-		value = strings.ReplaceAll(value, "$HOME", homeDir)
-		if strings.HasPrefix(value, "~/") {
-			value = filepath.Join(homeDir, value[2:])
+		if !literal {
+			value = strings.ReplaceAll(value, "${HOME}", homeDir)
+			value = strings.ReplaceAll(value, "$HOME", homeDir)
+			if strings.HasPrefix(value, "~/") {
+				value = filepath.Join(homeDir, value[2:])
+			}
 		}
 		if strings.ContainsAny(value, "$`\n\r") || !validConfiguredPath(value, homeDir) {
 			return ""

--- a/pkg/platforms/shared/linuxemu/paths.go
+++ b/pkg/platforms/shared/linuxemu/paths.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -26,13 +27,23 @@ const (
 
 // EmuDeckPaths holds discovered EmuDeck library paths.
 type EmuDeckPaths struct {
-	RomsPath     string
-	GamelistPath string
+	EmulationPath string
+	RomsPath      string
+	ToolsPath     string
+	BiosPath      string
+	SavesPath     string
+	StoragePath   string
+	GamelistPath  string
 }
 
 // RetroDECKPaths holds discovered RetroDECK library paths.
 type RetroDECKPaths struct {
+	HomePath     string
 	RomsPath     string
+	SavesPath    string
+	StatesPath   string
+	BiosPath     string
+	StoragePath  string
 	GamelistPath string
 }
 
@@ -40,52 +51,70 @@ type retroDECKConfig struct {
 	Paths map[string]string `json:"paths"`
 }
 
-// DefaultEmuDeckPaths discovers EmuDeck's configured ROM root and standard
-// ES-DE gamelist directory without executing its shell settings file.
+// DefaultEmuDeckPaths discovers EmuDeck's independently configurable data
+// roots without executing its shell settings file.
 func DefaultEmuDeckPaths(homeDir string) EmuDeckPaths {
 	if homeDir == "" {
 		return EmuDeckPaths{}
 	}
-	romsPath := filepath.Join(homeDir, "Emulation", "roms")
+	paths := EmuDeckPaths{EmulationPath: filepath.Join(homeDir, "Emulation")}
 	settingsPath := filepath.Join(homeDir, filepath.FromSlash(emuDeckSettingsDir), "settings.sh")
+	contents := ""
 	if data, err := readLimitedFile(settingsPath); err == nil {
-		if configured := parseShellPathAssignment(string(data), "romsPath", homeDir); configured != "" {
-			romsPath = configured
+		contents = string(data)
+		if configured := parseShellPathAssignment(contents, "emulationPath", homeDir); configured != "" {
+			paths.EmulationPath = configured
 		}
 	}
-	return EmuDeckPaths{
-		RomsPath:     romsPath,
-		GamelistPath: filepath.Join(homeDir, "ES-DE", "gamelists"),
-	}
+	paths.RomsPath = configuredShellPath(contents, "romsPath", homeDir, filepath.Join(paths.EmulationPath, "roms"))
+	paths.ToolsPath = configuredShellPath(contents, "toolsPath", homeDir, filepath.Join(paths.EmulationPath, "tools"))
+	paths.BiosPath = configuredShellPath(contents, "biosPath", homeDir, filepath.Join(paths.EmulationPath, "bios"))
+	paths.SavesPath = configuredShellPath(contents, "savesPath", homeDir, filepath.Join(paths.EmulationPath, "saves"))
+	paths.StoragePath = configuredShellPath(
+		contents, "storagePath", homeDir, filepath.Join(paths.EmulationPath, "storage"),
+	)
+	paths.GamelistPath = filepath.Join(homeDir, "ES-DE", "gamelists")
+	return paths
 }
 
-// DefaultRetroDECKPaths discovers RetroDECK's configurable userdata paths from
-// its Flatpak JSON config, falling back to documented defaults.
+func configuredShellPath(contents, key, homeDir, fallback string) string {
+	if configured := parseShellPathAssignment(contents, key, homeDir); configured != "" {
+		return configured
+	}
+	return fallback
+}
+
+// DefaultRetroDECKPaths discovers RetroDECK's independently configurable
+// userdata paths from its Flatpak JSON config, falling back to documented defaults.
 func DefaultRetroDECKPaths(homeDir string) RetroDECKPaths {
 	if homeDir == "" {
 		return RetroDECKPaths{}
 	}
-	homePath := filepath.Join(homeDir, "retrodeck")
-	romsPath := filepath.Join(homePath, "roms")
+	configured := make(map[string]string)
 	configPath := filepath.Join(homeDir, filepath.FromSlash(retroDECKConfigDir), "retrodeck.json")
 	if data, err := readLimitedFile(configPath); err == nil {
 		var parsed retroDECKConfig
 		if json.Unmarshal(data, &parsed) == nil {
-			paths := parsed.Paths
-			if validConfiguredPath(paths["rd_home_path"], homeDir) {
-				homePath = filepath.Clean(paths["rd_home_path"])
-			}
-			if validConfiguredPath(paths["roms_path"], homeDir) {
-				romsPath = filepath.Clean(paths["roms_path"])
-			} else {
-				romsPath = filepath.Join(homePath, "roms")
-			}
+			configured = parsed.Paths
 		}
 	}
+	homePath := configuredJSONPath(configured, "rd_home_path", homeDir, filepath.Join(homeDir, "retrodeck"))
 	return RetroDECKPaths{
-		RomsPath:     romsPath,
+		HomePath:     homePath,
+		RomsPath:     configuredJSONPath(configured, "roms_path", homeDir, filepath.Join(homePath, "roms")),
+		SavesPath:    configuredJSONPath(configured, "saves_path", homeDir, filepath.Join(homePath, "saves")),
+		StatesPath:   configuredJSONPath(configured, "states_path", homeDir, filepath.Join(homePath, "states")),
+		BiosPath:     configuredJSONPath(configured, "bios_path", homeDir, filepath.Join(homePath, "bios")),
+		StoragePath:  configuredJSONPath(configured, "storage_path", homeDir, filepath.Join(homePath, "storage")),
 		GamelistPath: filepath.Join(homePath, "ES-DE", "gamelists"),
 	}
+}
+
+func configuredJSONPath(paths map[string]string, key, homeDir, fallback string) string {
+	if validConfiguredPath(paths[key], homeDir) {
+		return filepath.Clean(paths[key])
+	}
+	return fallback
 }
 
 func readProviderSystemFolders(path string) ([]string, error) {
@@ -152,8 +181,13 @@ func parseShellPathAssignment(contents, key, homeDir string) string {
 			continue
 		}
 		value = strings.TrimSpace(value)
-		if len(value) >= 2 && ((value[0] == '"' && value[len(value)-1] == '"') ||
-			(value[0] == '\'' && value[len(value)-1] == '\'')) {
+		if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+			unquoted, err := strconv.Unquote(value)
+			if err != nil {
+				return ""
+			}
+			value = unquoted
+		} else if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
 			value = value[1 : len(value)-1]
 		}
 		value = strings.ReplaceAll(value, "${HOME}", homeDir)
@@ -177,5 +211,76 @@ func validConfiguredPath(path, homeDir string) bool {
 		return false
 	}
 	clean := filepath.Clean(path)
-	return clean != string(filepath.Separator) && clean != filepath.Clean(homeDir)
+	if clean == string(filepath.Separator) || clean == filepath.Clean(homeDir) {
+		return false
+	}
+	resolved, existingRoot, ok := resolvedPathFromExistingAncestor(clean)
+	if !ok || existingRoot == string(filepath.Separator) {
+		return false
+	}
+	return resolved != string(filepath.Separator) && resolved != filepath.Clean(homeDir)
+}
+
+func hasAncestorResolvingSymlink(candidate string) bool {
+	absolute, err := filepath.Abs(candidate)
+	if err != nil {
+		return true
+	}
+	volume := filepath.VolumeName(absolute)
+	current := volume + string(filepath.Separator)
+	parts := strings.Split(strings.TrimPrefix(absolute, current), string(filepath.Separator))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return false
+		}
+		if statErr != nil {
+			return true
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		resolved, resolveErr := filepath.EvalSymlinks(current)
+		if resolveErr != nil {
+			return true
+		}
+		rel, relErr := filepath.Rel(filepath.Clean(resolved), current)
+		if relErr != nil || rel == "." || rel == ".." ||
+			(!filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvedPathFromExistingAncestor(candidate string) (resolved, existingRoot string, ok bool) {
+	if hasAncestorResolvingSymlink(candidate) {
+		return "", "", false
+	}
+	current := filepath.Clean(candidate)
+	var suffix []string
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			root, resolveErr := filepath.EvalSymlinks(current)
+			if resolveErr != nil {
+				return "", "", false
+			}
+			root = filepath.Clean(root)
+			return filepath.Clean(filepath.Join(append([]string{root}, suffix...)...)), root, true
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", "", false
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", "", false
+		}
+		suffix = append([]string{filepath.Base(current)}, suffix...)
+		current = parent
+	}
 }

--- a/pkg/platforms/shared/linuxemu/retrodeck.go
+++ b/pkg/platforms/shared/linuxemu/retrodeck.go
@@ -42,7 +42,7 @@ func retroDECKLaunchers(_ *config.Instance, options *Options) []platforms.Launch
 		if !ok {
 			continue
 		}
-		result = append(result, createRetroDECKLauncher(options, folder, info, paths))
+		result = append(result, createRetroDECKLauncher(options, folder, info, &paths))
 	}
 	return result
 }
@@ -51,7 +51,7 @@ func createRetroDECKLauncher(
 	options *Options,
 	folder string,
 	info esde.SystemInfo,
-	paths RetroDECKPaths,
+	paths *RetroDECKPaths,
 ) platforms.Launcher {
 	launcher := platforms.Launcher{
 		ID: "RetroDECK" + info.GetLauncherID(), SystemID: info.SystemID,

--- a/pkg/platforms/steamos/backup.go
+++ b/pkg/platforms/steamos/backup.go
@@ -192,10 +192,28 @@ func (p *Platform) BackupDefinitions() []platforms.BackupDefinition {
 // compatibility definitions are restore-only and never traversed for backup.
 func (p *Platform) BackupPlan() platforms.BackupPlan {
 	home := steamOSHomeDir()
+	if !validBackupHome(home) {
+		return platforms.BackupPlan{Warnings: []platforms.BackupWarning{unresolvedHomeWarning()}}
+	}
 	definitions := durableDefinitions(home)
 	prefixDefinitions, warnings := discoverNonSteamDefinitionsAt(home, p.configuredSteamBackupRoot())
 	definitions = append(definitions, prefixDefinitions...)
 	return platforms.BackupPlan{Definitions: definitions, Warnings: warnings}
+}
+
+// validBackupHome rejects an unresolved home directory. Definitions built from
+// an empty home are relative, and the collector would walk the working
+// directory as a trusted source root.
+func validBackupHome(home string) bool {
+	return home != "" && filepath.IsAbs(home)
+}
+
+func unresolvedHomeWarning() platforms.BackupWarning {
+	return platforms.BackupWarning{
+		Category: backupCategorySettings,
+		Path:     "",
+		Reason:   "home directory could not be resolved; nothing was collected",
+	}
 }
 
 func (p *Platform) configuredSteamBackupRoot() string {
@@ -223,6 +241,9 @@ func BackupDefinitions(home string) []platforms.BackupDefinition {
 }
 
 func steamOSBackupDefinitions(home, configuredSteamRoot string) []platforms.BackupDefinition {
+	if !validBackupHome(home) {
+		return nil
+	}
 	definitions := durableDefinitions(home)
 	discovered, _ := discoverNonSteamDefinitionsAt(home, configuredSteamRoot)
 	definitions = append(definitions, discovered...)
@@ -231,6 +252,9 @@ func steamOSBackupDefinitions(home, configuredSteamRoot string) []platforms.Back
 }
 
 func durableDefinitions(home string) []platforms.BackupDefinition {
+	if !validBackupHome(home) {
+		return nil
+	}
 	definitions := make([]platforms.BackupDefinition, 0, 96)
 	definitions = append(definitions,
 		definition(
@@ -247,7 +271,20 @@ func durableDefinitions(home string) []platforms.BackupDefinition {
 	definitions = append(definitions, emulatorDefinitions(home)...)
 	definitions = append(definitions, launcherDefinitions(home)...)
 	definitions = append(definitions, faugusMetadataDefinitions(home)...)
-	return definitions
+	return absoluteDefinitions(definitions)
+}
+
+// absoluteDefinitions drops any definition whose source root is relative. A
+// provider path that failed discovery would otherwise resolve against the
+// working directory.
+func absoluteDefinitions(definitions []platforms.BackupDefinition) []platforms.BackupDefinition {
+	filtered := definitions[:0]
+	for i := range definitions {
+		if filepath.IsAbs(definitions[i].SourceRoot) {
+			filtered = append(filtered, definitions[i])
+		}
+	}
+	return filtered
 }
 
 func definition(

--- a/pkg/platforms/steamos/backup.go
+++ b/pkg/platforms/steamos/backup.go
@@ -1,0 +1,512 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/linuxemu"
+)
+
+const (
+	backupCategorySettings   = "settings"
+	backupCategorySaves      = "saves"
+	backupCategorySavestates = "savestates"
+)
+
+var (
+	savestatePatterns = []platforms.BackupPattern{
+		{Contains: "states/"},
+		{Contains: "statesaves/"},
+		{Contains: "savestates/"},
+	}
+	windowsUserSavePatterns = []platforms.BackupPattern{
+		{Glob: "*/Documents/**"},
+		{Glob: "*/Saved Games/**"},
+		{Glob: "*/AppData/Roaming/**"},
+		{Glob: "*/AppData/LocalLow/**"},
+		{Glob: "*/AppData/Local/**"},
+	}
+	windowsSaveExclusions = []platforms.BackupPattern{
+		{Glob: "*/Application Data/**"},
+		{Glob: "*/Cookies/**"},
+		{Glob: "*/Local Settings/**"},
+		{Glob: "*/My Documents/**"},
+		{Glob: "*/NetHood/**"},
+		{Glob: "*/PrintHood/**"},
+		{Glob: "*/Recent/**"},
+		{Glob: "*/SendTo/**"},
+		{Glob: "*/Start Menu/**"},
+		{Glob: "*/Templates/**"},
+		{Glob: "*/AppData/Local/Battle.net/**"},
+		{Glob: "*/AppData/Local/Temp/**"},
+		{Glob: "*/AppData/Local/D3DSCache/**"},
+		{Glob: "*/AppData/Local/NVIDIA/**"},
+		{Glob: "*/AppData/Local/AMD/**"},
+		{Glob: "*.dxvk.bin"},
+		{Glob: "*.dxvk.lut"},
+		{Glob: "CachedData.db"},
+		{Contains: "internet cache/"},
+		{Contains: "cache/"},
+		{Contains: "caches/"},
+		{Contains: "crashdumps/"},
+		{Contains: "crashes/"},
+		{Contains: "logs/"},
+		{Contains: "telemetry/"},
+	}
+	emuDeckConfigIncludes = []platforms.BackupPattern{
+		{Glob: "settings.*"},
+		{Glob: ".RPCS3MigrationCompleted"},
+		{Glob: ".cloned"},
+		{Glob: ".dolphinlegacysymlinks"},
+		{Glob: ".dolphinsymlinks"},
+		{Glob: ".finished"},
+		{Glob: ".rat"},
+		{Glob: ".rau"},
+		{Glob: ".ui-finished"},
+		{Glob: ".updaterId"},
+		{Glob: "android/**"},
+		{Glob: "custom_scripts/**"},
+		{Glob: "feeds/**"},
+		{Glob: "store/**"},
+	}
+	emuDeckConfigExclusions = []platforms.BackupPattern{
+		{Glob: "backend/**"},
+		{Glob: "blob_storage/**"},
+		{Glob: "Cache/**"},
+		{Glob: "Code Cache/**"},
+		{Glob: "Crashpad/**"},
+		{Glob: "databases/**"},
+		{Glob: "DawnCache/**"},
+		{Glob: "Dictionaries/**"},
+		{Glob: "GPUCache/**"},
+		{Glob: "IndexedDB/**"},
+		{Glob: "Local Storage/**"},
+		{Glob: "logs/**"},
+		{Glob: "python_virtual_env/**"},
+		{Glob: "Service Worker/**"},
+		{Glob: "Session Storage/**"},
+		{Glob: "shared_proto_db/**"},
+		{Glob: "VideoDecodeStats/**"},
+		{Glob: "WebStorage/**"},
+	}
+	providerBIOSExclusions = []platforms.BackupPattern{
+		{Glob: "RetroArch_v*.zip"},
+		{Glob: "RetroArch_v*/**"},
+		{Glob: "HdPacks/**"},
+		{Glob: "Mupen64plus/cache/**"},
+		{Glob: "Mupen64plus/hires_texture/**"},
+		{Glob: "PPSSPP/**"},
+		{Glob: "Vita3K/ux0/user/**"},
+		{Glob: "azahar/keys/**"},
+		{Glob: "cemu/usr/save/**"},
+		{Glob: "dolphin-emu/Sys/**"},
+		{Glob: "fbneo/patched/**"},
+		{Glob: "pico-8/carts/**"},
+		{Glob: "pico-8/cdata/**"},
+		{Glob: "rpcs3/dev_hdd0/home/**"},
+		{Glob: "ryujinx/keys/**"},
+		{Glob: "scummvm/extra/**"},
+		{Glob: "shadps4/sys_modules/**"},
+		{Glob: "ume/**"},
+		{Contains: "themes/"},
+	}
+	emuDeckManagedSaveExclusions = []platforms.BackupPattern{
+		{Glob: "Cemu/saves/**"},
+		{Glob: "Vita3K/saves/**"},
+		{Glob: "azahar/saves/**"},
+		{Glob: "azahar/states/**"},
+		{Glob: "dolphin/GC/**"},
+		{Glob: "dolphin/StateSaves/**"},
+		{Glob: "dolphin/Wii/**"},
+		{Glob: "es-de/gamelists/**"},
+		{Glob: "ppsspp/saves/**"},
+		{Glob: "ppsspp/states/**"},
+		{Glob: "primehack/GC/**"},
+		{Glob: "primehack/StateSaves/**"},
+		{Glob: "primehack/Wii/**"},
+		{Glob: "retroarch/saves/**"},
+		{Glob: "retroarch/states/**"},
+		{Glob: "rpcs3/saves/**"},
+		{Glob: "rpcs3/trophy/**"},
+		{Glob: "ryujinx/saveMeta/**"},
+		{Glob: "ryujinx/saves/**"},
+		{Glob: "ryujinx/system/**"},
+		{Glob: "ryujinx/system_saves/**"},
+		{Glob: "shadps4/saves/**"},
+		{Glob: "xenia/saves/**"},
+	}
+	emulatorConfigExclusions = []platforms.BackupPattern{
+		{Contains: "cache/"},
+		{Contains: "caches/"},
+		{Contains: "logs/"},
+		{Contains: "cores/"},
+		{Contains: "downloads/"},
+		{Contains: "downloaded_media/"},
+		{Contains: "covers/"},
+		{Contains: "screenshots/"},
+		{Contains: "shaders/"},
+		{Contains: "textures/"},
+		{Contains: "texture_packs/"},
+		{Contains: "themes/"},
+		{Contains: "artwork/"},
+		{Contains: "thumbnails/"},
+		{Contains: "media/"},
+		{Contains: "saves/"},
+		{Contains: "states/"},
+		{Contains: "statesaves/"},
+		{Contains: "savestates/"},
+		{Contains: "savedata/"},
+		{Contains: "memcards/"},
+		{Contains: "memorycards/"},
+		{Contains: "sstates/"},
+		{Contains: "sharedobjects/"},
+		{Contains: "ppsspp_state/"},
+	}
+)
+
+// BackupRestoreRoot is the fallback for legacy definitions. SteamOS definitions
+// use explicit restore targets so custom provider roots and category symlinks
+// restore to the destination installation's active paths.
+func (*Platform) BackupRestoreRoot() string {
+	return steamOSHomeDir()
+}
+
+// BackupDefinitions returns the restore allow-list. Dynamic provider mappings
+// are listed before narrow compatibility fallbacks so configured external roots
+// win when they are available on the destination.
+func (p *Platform) BackupDefinitions() []platforms.BackupDefinition {
+	home := steamOSHomeDir()
+	return steamOSBackupDefinitions(home, p.configuredSteamBackupRoot())
+}
+
+// BackupPlan walks only durable roots and discovered non-Steam prefixes. Broad
+// compatibility definitions are restore-only and never traversed for backup.
+func (p *Platform) BackupPlan() platforms.BackupPlan {
+	home := steamOSHomeDir()
+	definitions := durableDefinitions(home)
+	prefixDefinitions, warnings := discoverNonSteamDefinitionsAt(home, p.configuredSteamBackupRoot())
+	definitions = append(definitions, prefixDefinitions...)
+	return platforms.BackupPlan{Definitions: definitions, Warnings: warnings}
+}
+
+func (p *Platform) configuredSteamBackupRoot() string {
+	if p == nil {
+		return ""
+	}
+	root := p.backupSteamRoot.Load()
+	if root == nil {
+		return ""
+	}
+	return *root
+}
+
+func steamOSHomeDir() string {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
+// BackupDefinitions returns SteamOS restore policy rooted at home.
+func BackupDefinitions(home string) []platforms.BackupDefinition {
+	return steamOSBackupDefinitions(home, "")
+}
+
+func steamOSBackupDefinitions(home, configuredSteamRoot string) []platforms.BackupDefinition {
+	definitions := durableDefinitions(home)
+	discovered, _ := discoverNonSteamDefinitionsAt(home, configuredSteamRoot)
+	definitions = append(definitions, discovered...)
+	definitions = append(definitions, broadNonSteamPoliciesAt(home, configuredSteamRoot)...)
+	return definitions
+}
+
+func durableDefinitions(home string) []platforms.BackupDefinition {
+	definitions := make([]platforms.BackupDefinition, 0, 96)
+	definitions = append(definitions,
+		definition(
+			filepath.Join(home, ".config", "EmuDeck"), filepath.Join(".config", "EmuDeck"),
+			backupCategorySettings, emuDeckConfigIncludes, emuDeckConfigExclusions,
+		),
+		esdeDefinition(home),
+		steamROMManagerDefinition(home),
+	)
+	emuDeckPaths := linuxemu.DefaultEmuDeckPaths(home)
+	retroDECKPaths := linuxemu.DefaultRetroDECKPaths(home)
+	definitions = append(definitions, emuDeckDefinitions(&emuDeckPaths)...)
+	definitions = append(definitions, retroDECKDefinitions(home, &retroDECKPaths)...)
+	definitions = append(definitions, emulatorDefinitions(home)...)
+	definitions = append(definitions, launcherDefinitions(home)...)
+	definitions = append(definitions, faugusMetadataDefinitions(home)...)
+	return definitions
+}
+
+func definition(
+	sourceRoot, restoreRoot, category string,
+	include, exclude []platforms.BackupPattern,
+) platforms.BackupDefinition {
+	targetRoot := sourceRoot
+	trustedRoot := sourceRoot
+	if !safeDefinitionRoot(sourceRoot) {
+		targetRoot = filepath.Join(sourceRoot, ".zaparoo-rejected-root")
+		trustedRoot = targetRoot
+	}
+	return platforms.BackupDefinition{
+		SourceRoot: sourceRoot, RestoreRoot: restoreRoot, RestoreTargetRoot: targetRoot,
+		Category: category, Include: include, Exclude: exclude,
+		SourceTrustedRoots: []string{trustedRoot},
+	}
+}
+
+func safeDefinitionRoot(candidate string) bool {
+	absolute, err := filepath.Abs(candidate)
+	if err != nil {
+		return false
+	}
+	absolute = filepath.Clean(absolute)
+	resolved, existingRoot, ok := resolvedBackupPathFromExistingAncestor(absolute)
+	if !ok || existingRoot == string(filepath.Separator) || resolved == string(filepath.Separator) {
+		return false
+	}
+	rel, err := filepath.Rel(resolved, absolute)
+	return err != nil || rel == "." || rel == ".." || filepath.IsAbs(rel) ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func resolvedBackupPathFromExistingAncestor(candidate string) (resolved, existingRoot string, ok bool) {
+	if hasAncestorResolvingSymlink(candidate) {
+		return "", "", false
+	}
+	current := filepath.Clean(candidate)
+	var suffix []string
+	for {
+		_, err := os.Lstat(current)
+		if err == nil {
+			root, resolveErr := filepath.EvalSymlinks(current)
+			if resolveErr != nil {
+				return "", "", false
+			}
+			root = filepath.Clean(root)
+			return filepath.Clean(filepath.Join(append([]string{root}, suffix...)...)), root, true
+		}
+		if !os.IsNotExist(err) {
+			return "", "", false
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", "", false
+		}
+		suffix = append([]string{filepath.Base(current)}, suffix...)
+		current = parent
+	}
+}
+
+func appendBackupPatterns(
+	base []platforms.BackupPattern, extra ...platforms.BackupPattern,
+) []platforms.BackupPattern {
+	result := make([]platforms.BackupPattern, 0, len(base)+len(extra))
+	result = append(result, base...)
+	return append(result, extra...)
+}
+
+func hasAncestorResolvingSymlink(candidate string) bool {
+	absolute, err := filepath.Abs(candidate)
+	if err != nil {
+		return true
+	}
+	volume := filepath.VolumeName(absolute)
+	current := volume + string(filepath.Separator)
+	parts := strings.Split(strings.TrimPrefix(absolute, current), string(filepath.Separator))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, statErr := os.Lstat(current)
+		if errors.Is(statErr, os.ErrNotExist) {
+			return false
+		}
+		if statErr != nil {
+			return true
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		resolved, resolveErr := filepath.EvalSymlinks(current)
+		if resolveErr != nil {
+			return true
+		}
+		rel, relErr := filepath.Rel(filepath.Clean(resolved), current)
+		if relErr != nil || rel == "." || rel == ".." ||
+			(!filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator))) {
+			return true
+		}
+	}
+	return false
+}
+
+func nonRecursiveDefinition(
+	sourceRoot, restoreRoot, category string,
+	include []platforms.BackupPattern,
+) platforms.BackupDefinition {
+	result := definition(sourceRoot, restoreRoot, category, include, nil)
+	result.NonRecursive = true
+	return result
+}
+
+func esdeDefinition(home string) platforms.BackupDefinition {
+	return definition(
+		filepath.Join(home, "ES-DE"), "ES-DE", backupCategorySettings,
+		[]platforms.BackupPattern{
+			{Glob: "es_settings.xml"},
+			{Contains: "collections/"},
+			{Contains: "custom_systems/"},
+			{Contains: "gamelists/"},
+			{Contains: "scripts/"},
+		},
+		[]platforms.BackupPattern{
+			{Glob: "es_log.txt"},
+			{Contains: "downloaded_media/"},
+			{Contains: "themes/"},
+		},
+	)
+}
+
+func steamROMManagerDefinition(home string) platforms.BackupDefinition {
+	rel := filepath.Join(".config", "steam-rom-manager", "userData")
+	return definition(
+		filepath.Join(home, rel), rel, backupCategorySettings,
+		[]platforms.BackupPattern{{All: true}},
+		[]platforms.BackupPattern{
+			{Glob: "*cache.json"},
+			{Contains: "cache/"},
+			{Contains: "logs/"},
+			{Contains: "downloaded_media/"},
+		},
+	)
+}
+
+func emuDeckDefinitions(paths *linuxemu.EmuDeckPaths) []platforms.BackupDefinition {
+	xemuDefinition := nonRecursiveDefinition(
+		filepath.Join(paths.StoragePath, "xemu"), filepath.Join("Emulation", "storage", "xemu"),
+		backupCategorySaves,
+		[]platforms.BackupPattern{{Glob: "xbox_hdd.qcow2"}, {Glob: "eeprom.bin"}},
+	)
+	return []platforms.BackupDefinition{
+		definition(paths.SavesPath, filepath.Join("Emulation", "saves"), backupCategorySaves,
+			[]platforms.BackupPattern{{All: true}},
+			appendBackupPatterns(savestatePatterns, emuDeckManagedSaveExclusions...)),
+		definition(paths.SavesPath, filepath.Join("Emulation", "saves"), backupCategorySavestates,
+			savestatePatterns, emuDeckManagedSaveExclusions),
+		definition(paths.BiosPath, filepath.Join("Emulation", "bios"), backupCategorySettings,
+			[]platforms.BackupPattern{{All: true}}, providerBIOSExclusions),
+		definition(
+			filepath.Join(paths.StoragePath, "rpcs3", "dev_hdd0", "home"),
+			filepath.Join("Emulation", "storage", "rpcs3", "dev_hdd0", "home"),
+			backupCategorySaves, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "rpcs3", "dev_flash"),
+			filepath.Join("Emulation", "storage", "rpcs3", "dev_flash"),
+			backupCategorySettings, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "Vita3K", "ux0", "user"),
+			filepath.Join("Emulation", "storage", "Vita3K", "ux0", "user"),
+			backupCategorySaves, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "Vita3K", "vs0"),
+			filepath.Join("Emulation", "storage", "Vita3K", "vs0"),
+			backupCategorySettings, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "yuzu", "nand", "user", "save"),
+			filepath.Join("Emulation", "storage", "yuzu", "nand", "user", "save"),
+			backupCategorySaves, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "ryujinx", "games"),
+			filepath.Join("Emulation", "storage", "ryujinx", "games"),
+			backupCategorySettings, []platforms.BackupPattern{{All: true}}, emulatorConfigExclusions,
+		),
+		xemuDefinition,
+		definition(
+			filepath.Join(paths.StoragePath, "citra", "sdmc"),
+			filepath.Join("Emulation", "storage", "citra", "sdmc"),
+			backupCategorySaves,
+			[]platforms.BackupPattern{{Contains: "data/"}, {Contains: "extdata/"}}, nil,
+		),
+		definition(
+			filepath.Join(paths.StoragePath, "azahar", "sdmc"),
+			filepath.Join("Emulation", "storage", "azahar", "sdmc"),
+			backupCategorySaves,
+			[]platforms.BackupPattern{{Contains: "data/"}, {Contains: "extdata/"}}, nil,
+		),
+		definition(
+			filepath.Join(paths.RomsPath, "wiiu", "mlc01", "usr", "save"),
+			filepath.Join("Emulation", "roms", "wiiu", "mlc01", "usr", "save"),
+			backupCategorySaves, []platforms.BackupPattern{{All: true}}, nil,
+		),
+		definition(
+			filepath.Join(paths.RomsPath, "xbox360", "content"),
+			filepath.Join("Emulation", "roms", "xbox360", "content"),
+			backupCategorySaves,
+			[]platforms.BackupPattern{{Contains: "00000001/"}, {Contains: "fffe07d1/"}}, nil,
+		),
+	}
+}
+
+func retroDECKDefinitions(home string, paths *linuxemu.RetroDECKPaths) []platforms.BackupDefinition {
+	esdeRoot := filepath.Dir(paths.GamelistPath)
+	return []platforms.BackupDefinition{
+		definition(paths.SavesPath, filepath.Join("retrodeck", "saves"), backupCategorySaves,
+			[]platforms.BackupPattern{{All: true}}, nil),
+		definition(paths.StatesPath, filepath.Join("retrodeck", "states"), backupCategorySavestates,
+			[]platforms.BackupPattern{{All: true}}, nil),
+		definition(paths.BiosPath, filepath.Join("retrodeck", "bios"), backupCategorySettings,
+			[]platforms.BackupPattern{{All: true}}, providerBIOSExclusions),
+		definition(esdeRoot, filepath.Join("retrodeck", "ES-DE"), backupCategorySettings,
+			[]platforms.BackupPattern{
+				{Glob: "es_settings.xml"},
+				{Contains: "collections/"},
+				{Contains: "custom_systems/"},
+				{Contains: "gamelists/"},
+				{Contains: "scripts/"},
+			},
+			[]platforms.BackupPattern{{Contains: "downloaded_media/"}, {Contains: "themes/"}},
+		),
+		definition(
+			filepath.Join(home, ".var", "app", "net.retrodeck.retrodeck", "config"),
+			filepath.Join(".var", "app", "net.retrodeck.retrodeck", "config"),
+			backupCategorySettings, []platforms.BackupPattern{{All: true}},
+			appendBackupPatterns(emulatorConfigExclusions,
+				platforms.BackupPattern{Glob: "*cache.json"},
+				platforms.BackupPattern{Glob: "Cemu/cemu/**"},
+				platforms.BackupPattern{Glob: "ES-DE/collections/**"},
+				platforms.BackupPattern{Glob: "ES-DE/custom_systems/**"},
+				platforms.BackupPattern{Glob: "ES-DE/gamelists/**"},
+				platforms.BackupPattern{Glob: "mame/hiscore/**"},
+				platforms.BackupPattern{Glob: "melonDS/bios/**"},
+				platforms.BackupPattern{Glob: "ppsspp/PSP/Cheats/**"},
+				platforms.BackupPattern{Glob: "retroarch/system/**"},
+				platforms.BackupPattern{Glob: "Ryujinx/games/**"},
+				platforms.BackupPattern{Contains: "resources/"},
+				platforms.BackupPattern{Contains: "retroarch/assets/"},
+				platforms.BackupPattern{Contains: "retroarch/database/"},
+				platforms.BackupPattern{Contains: "retroarch/filters/"},
+				platforms.BackupPattern{Contains: "retroarch/info/"},
+				platforms.BackupPattern{Contains: "retroarch/overlays/"},
+			),
+		),
+	}
+}

--- a/pkg/platforms/steamos/backup_emulators.go
+++ b/pkg/platforms/steamos/backup_emulators.go
@@ -1,0 +1,453 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+)
+
+type emulatorPathDefinition struct {
+	rel      string
+	category string
+	include  []platforms.BackupPattern
+	exclude  []platforms.BackupPattern
+	nonRecur bool
+}
+
+func emulatorDefinitions(home string) []platforms.BackupDefinition {
+	paths := []emulatorPathDefinition{
+		// RetroArch.
+		retroArchSettings(filepath.Join(".var", "app", "org.libretro.RetroArch", "config", "retroarch")),
+		savePath(filepath.Join(".var", "app", "org.libretro.RetroArch", "config", "retroarch", "saves")),
+		statePath(filepath.Join(".var", "app", "org.libretro.RetroArch", "config", "retroarch", "states")),
+
+		// Dolphin and PrimeHack split profiles/configuration into XDG config and console data into XDG data.
+		settingsPath(filepath.Join(".config", "dolphin-emu")),
+		settingsPath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "config", "dolphin-emu")),
+		settingsPath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Config")),
+		settingsPath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "GameSettings")),
+		savePath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "GC")),
+		dolphinWiiSaves(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Wii")),
+		savePath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "GBA", "Saves")),
+		statePath(filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "StateSaves")),
+		settingsPath(filepath.Join(".local", "share", "dolphin-emu", "Config")),
+		settingsPath(filepath.Join(".local", "share", "dolphin-emu", "GameSettings")),
+		savePath(filepath.Join(".local", "share", "dolphin-emu", "GC")),
+		dolphinWiiSaves(filepath.Join(".local", "share", "dolphin-emu", "Wii")),
+		savePath(filepath.Join(".local", "share", "dolphin-emu", "GBA", "Saves")),
+		statePath(filepath.Join(".local", "share", "dolphin-emu", "StateSaves")),
+		settingsPath(filepath.Join(".var", "app", "io.github.shiiion.primehack", "config", "dolphin-emu")),
+		settingsPath(filepath.Join(".var", "app", "io.github.shiiion.primehack", "data", "dolphin-emu", "Config")),
+		settingsPath(filepath.Join(
+			".var", "app", "io.github.shiiion.primehack", "data", "dolphin-emu", "GameSettings",
+		)),
+		savePath(filepath.Join(".var", "app", "io.github.shiiion.primehack", "data", "dolphin-emu", "GC")),
+		dolphinWiiSaves(filepath.Join(".var", "app", "io.github.shiiion.primehack", "data", "dolphin-emu", "Wii")),
+		statePath(filepath.Join(".var", "app", "io.github.shiiion.primehack", "data", "dolphin-emu", "StateSaves")),
+
+		// PPSSPP.
+		ppssppSettings(filepath.Join(".var", "app", "org.ppsspp.PPSSPP", "config", "ppsspp")),
+		savePath(filepath.Join(".var", "app", "org.ppsspp.PPSSPP", "config", "ppsspp", "PSP", "SAVEDATA")),
+		statePath(filepath.Join(".var", "app", "org.ppsspp.PPSSPP", "config", "ppsspp", "PSP", "PPSSPP_STATE")),
+
+		// PCSX2 native/AppImage and Flatpak.
+		settingsPath(filepath.Join(".config", "PCSX2")),
+		savePath(filepath.Join(".config", "PCSX2", "memcards")),
+		statePath(filepath.Join(".config", "PCSX2", "sstates")),
+		settingsPath(filepath.Join(".var", "app", "net.pcsx2.PCSX2", "config", "PCSX2")),
+		savePath(filepath.Join(".var", "app", "net.pcsx2.PCSX2", "config", "PCSX2", "memcards")),
+		statePath(filepath.Join(".var", "app", "net.pcsx2.PCSX2", "config", "PCSX2", "sstates")),
+
+		// Cemu configuration and user-supplied console material. Installed titles under mlc01 are excluded.
+		cemuSettings(filepath.Join(".config", "Cemu")),
+		nonRecursiveSettings(filepath.Join(".local", "share", "Cemu"), "keys.txt", "otp.bin", "seeprom.bin"),
+		cemuSettings(filepath.Join(".var", "app", "info.cemu.Cemu", "config", "Cemu")),
+		nonRecursiveSettings(
+			filepath.Join(".var", "app", "info.cemu.Cemu", "data", "Cemu"),
+			"keys.txt", "otp.bin", "seeprom.bin",
+		),
+
+		// xemu stores configuration and mutable EEPROM data under XDG data.
+		nonRecursiveSettings(filepath.Join(".local", "share", "xemu"), "xemu.toml", "xemu.toml.bak"),
+		nonRecursiveSave(filepath.Join(".local", "share", "xemu"), "eeprom.bin"),
+		nonRecursiveSettings(
+			filepath.Join(".var", "app", "app.xemu.xemu", "data", "xemu", "xemu"),
+			"xemu.toml", "xemu.toml.bak",
+		),
+		nonRecursiveSave(
+			filepath.Join(".var", "app", "app.xemu.xemu", "data", "xemu", "xemu"), "eeprom.bin",
+		),
+
+		// Citra and Azahar. CIA title content is excluded; title data/extdata and states are preserved separately.
+		citraSettings(filepath.Join(".local", "share", "citra-emu")),
+		citraSaves(filepath.Join(".local", "share", "citra-emu", "sdmc")),
+		citraNANDSaves(filepath.Join(".local", "share", "citra-emu", "nand")),
+		statePath(filepath.Join(".local", "share", "citra-emu", "states")),
+		citraSettings(filepath.Join(".var", "app", "org.citra_emu.citra", "data", "citra-emu")),
+		citraSaves(filepath.Join(".var", "app", "org.citra_emu.citra", "data", "citra-emu", "sdmc")),
+		citraNANDSaves(filepath.Join(".var", "app", "org.citra_emu.citra", "data", "citra-emu", "nand")),
+		statePath(filepath.Join(".var", "app", "org.citra_emu.citra", "data", "citra-emu", "states")),
+		citraSettings(filepath.Join(".local", "share", "azahar-emu")),
+		citraSaves(filepath.Join(".local", "share", "azahar-emu", "sdmc")),
+		citraNANDSaves(filepath.Join(".local", "share", "azahar-emu", "nand")),
+		statePath(filepath.Join(".local", "share", "azahar-emu", "states")),
+		citraSettings(filepath.Join(".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu")),
+		citraSaves(filepath.Join(".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "sdmc")),
+		citraNANDSaves(filepath.Join(".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "nand")),
+		statePath(filepath.Join(".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "states")),
+
+		// Ryujinx and Ryubing configuration, firmware/keys, profiles, and user/system saves.
+		ryujinxSettings(filepath.Join(".config", "Ryujinx")),
+		savePath(filepath.Join(".config", "Ryujinx", "bis", "user", "save")),
+		savePath(filepath.Join(".config", "Ryujinx", "bis", "user", "saveMeta")),
+		savePath(filepath.Join(".config", "Ryujinx", "bis", "user", "savemeta")),
+		savePath(filepath.Join(".config", "Ryujinx", "bis", "system", "save")),
+		ryujinxSettings(filepath.Join(".config", "Ryubing")),
+		savePath(filepath.Join(".config", "Ryubing", "bis", "user", "save")),
+		savePath(filepath.Join(".config", "Ryubing", "bis", "user", "saveMeta")),
+		savePath(filepath.Join(".config", "Ryubing", "bis", "user", "savemeta")),
+		savePath(filepath.Join(".config", "Ryubing", "bis", "system", "save")),
+		ryujinxSettings(filepath.Join(".var", "app", "org.ryujinx.Ryujinx", "config", "Ryujinx")),
+		savePath(filepath.Join(".var", "app", "org.ryujinx.Ryujinx", "config", "Ryujinx", "bis", "user", "save")),
+		savePath(filepath.Join(".var", "app", "org.ryujinx.Ryujinx", "config", "Ryujinx", "bis", "user", "saveMeta")),
+		savePath(filepath.Join(".var", "app", "org.ryujinx.Ryujinx", "config", "Ryujinx", "bis", "user", "savemeta")),
+		savePath(filepath.Join(".var", "app", "org.ryujinx.Ryujinx", "config", "Ryujinx", "bis", "system", "save")),
+		ryujinxSettings(filepath.Join(".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx")),
+		savePath(filepath.Join(".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx", "bis", "user", "save")),
+		savePath(filepath.Join(
+			".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx", "bis", "user", "saveMeta",
+		)),
+		savePath(filepath.Join(
+			".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx", "bis", "user", "savemeta",
+		)),
+		savePath(filepath.Join(
+			".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx", "bis", "system", "save",
+		)),
+
+		// RPCS3: keep configuration, firmware, user homes, virtual memory cards, and states without installed games.
+		rpcs3Settings(filepath.Join(".config", "rpcs3")),
+		settingsPath(filepath.Join(".config", "rpcs3", "dev_flash")),
+		savePath(filepath.Join(".config", "rpcs3", "dev_hdd0", "home")),
+		savePath(filepath.Join(".config", "rpcs3", "dev_hdd0", "savedata")),
+		savePath(filepath.Join(".config", "rpcs3", "dev_usb000", "PS3", "SAVEDATA")),
+		statePath(filepath.Join(".config", "rpcs3", "savestates")),
+		rpcs3Settings(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3")),
+		settingsPath(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_flash")),
+		savePath(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_hdd0", "home")),
+		savePath(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_hdd0", "savedata")),
+		savePath(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_usb000", "PS3", "SAVEDATA")),
+		statePath(filepath.Join(".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "savestates")),
+
+		// Vita3K: keep configuration, firmware partitions, and per-user data without apps/patches.
+		settingsPath(filepath.Join(".config", "Vita3K")),
+		settingsPath(filepath.Join(".local", "share", "Vita3K", "vs0")),
+		savePath(filepath.Join(".local", "share", "Vita3K", "ux0", "user")),
+		settingsPath(filepath.Join(".var", "app", "org.vita3k.Vita3K", "config", "Vita3K")),
+		settingsPath(filepath.Join(".var", "app", "org.vita3k.Vita3K", "data", "Vita3K", "vs0")),
+		savePath(filepath.Join(".var", "app", "org.vita3k.Vita3K", "data", "Vita3K", "ux0", "user")),
+
+		// DuckStation and melonDS.
+		settingsPath(filepath.Join(".local", "share", "duckstation")),
+		savePath(filepath.Join(".local", "share", "duckstation", "memcards")),
+		statePath(filepath.Join(".local", "share", "duckstation", "savestates")),
+		settingsPath(filepath.Join(".var", "app", "org.duckstation.DuckStation", "config", "duckstation")),
+		savePath(filepath.Join(".var", "app", "org.duckstation.DuckStation", "config", "duckstation", "memcards")),
+		statePath(filepath.Join(".var", "app", "org.duckstation.DuckStation", "config", "duckstation", "savestates")),
+		settingsPath(filepath.Join(".config", "melonDS")),
+		settingsPath(filepath.Join(".var", "app", "net.kuribo64.melonDS", "config", "melonDS")),
+
+		// RMG and mGBA.
+		settingsPath(filepath.Join(".config", "RMG")),
+		savePath(filepath.Join(".local", "share", "RMG", "Save")),
+		settingsPath(filepath.Join(".var", "app", "com.github.Rosalie241.RMG", "config", "RMG")),
+		savePath(filepath.Join(".var", "app", "com.github.Rosalie241.RMG", "data", "RMG", "Save")),
+		settingsPath(filepath.Join(".config", "mgba")),
+		settingsPath(filepath.Join(".var", "app", "io.mgba.mGBA", "config", "mgba")),
+
+		// MAME and Supermodel persisted user trees.
+		mameSettings(".mame"),
+		savePath(filepath.Join(".mame", "nvram")),
+		savePath(filepath.Join(".mame", "memcard")),
+		savePath(filepath.Join(".mame", "diff")),
+		statePath(filepath.Join(".mame", "sta")),
+		mameSettings(filepath.Join(".var", "app", "org.mamedev.MAME", ".mame")),
+		savePath(filepath.Join(".var", "app", "org.mamedev.MAME", ".mame", "nvram")),
+		savePath(filepath.Join(".var", "app", "org.mamedev.MAME", ".mame", "memcard")),
+		savePath(filepath.Join(".var", "app", "org.mamedev.MAME", ".mame", "diff")),
+		statePath(filepath.Join(".var", "app", "org.mamedev.MAME", ".mame", "sta")),
+		settingsPath(filepath.Join(".supermodel", "Config")),
+		savePath(filepath.Join(".supermodel", "NVRAM")),
+		settingsPath(filepath.Join(".var", "app", "com.supermodel3.Supermodel", ".supermodel", "Config")),
+		savePath(filepath.Join(".var", "app", "com.supermodel3.Supermodel", ".supermodel", "NVRAM")),
+
+		// Flycast VMUs/NVRAM and configuration.
+		settingsPath(filepath.Join(".config", "flycast")),
+		flycastSaves(filepath.Join(".local", "share", "flycast")),
+		settingsPath(filepath.Join(".var", "app", "org.flycast.Flycast", "config", "flycast")),
+		flycastSaves(filepath.Join(".var", "app", "org.flycast.Flycast", "data", "flycast")),
+
+		// ScummVM saves and configuration.
+		settingsPath(filepath.Join(".config", "scummvm")),
+		savePath(filepath.Join(".local", "share", "scummvm", "saves")),
+		settingsPath(filepath.Join(".var", "app", "org.scummvm.ScummVM", "config", "scummvm")),
+		savePath(filepath.Join(".var", "app", "org.scummvm.ScummVM", "data", "scummvm", "saves")),
+
+		// Ruffle SharedObjects are game progress, not cache.
+		settingsPath(filepath.Join(".config", "ruffle")),
+		savePath(filepath.Join(".local", "share", "ruffle", "SharedObjects")),
+		settingsPath(filepath.Join(".var", "app", "rs.ruffle.Ruffle", "config", "ruffle")),
+		savePath(filepath.Join(".var", "app", "rs.ruffle.Ruffle", "data", "ruffle", "SharedObjects")),
+
+		// shadPS4 configuration, firmware modules, input profiles, saves, and trophies.
+		settingsPath(filepath.Join(".config", "shadps4")),
+		settingsPath(filepath.Join(".config", "shadPS4")),
+		shadPS4Settings(filepath.Join(".local", "share", "shadps4")),
+		shadPS4Saves(filepath.Join(".local", "share", "shadps4")),
+		shadPS4Settings(filepath.Join(".local", "share", "shadPS4")),
+		shadPS4Saves(filepath.Join(".local", "share", "shadPS4")),
+		settingsPath(filepath.Join(".var", "app", "net.shadps4.shadPS4", "config", "shadps4")),
+		settingsPath(filepath.Join(".var", "app", "net.shadps4.shadPS4", "config", "shadPS4")),
+		shadPS4Settings(filepath.Join(".var", "app", "net.shadps4.shadPS4", "data", "shadps4")),
+		shadPS4Saves(filepath.Join(".var", "app", "net.shadps4.shadPS4", "data", "shadps4")),
+		shadPS4Settings(filepath.Join(".var", "app", "net.shadps4.shadPS4", "data", "shadPS4")),
+		shadPS4Saves(filepath.Join(".var", "app", "net.shadps4.shadPS4", "data", "shadPS4")),
+	}
+
+	definitions := make([]platforms.BackupDefinition, 0, len(paths))
+	seen := make(map[string]struct{}, len(paths))
+	for _, item := range paths {
+		key := item.category + "\x00" + item.rel
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		def := definition(
+			filepath.Join(home, item.rel), item.rel, item.category, item.include, item.exclude,
+		)
+		def.NonRecursive = item.nonRecur
+		definitions = append(definitions, def)
+	}
+	return definitions
+}
+
+func retroArchSettings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}},
+		exclude: appendBackupPatterns(emulatorConfigExclusions,
+			platforms.BackupPattern{Contains: "assets/"},
+			platforms.BackupPattern{Contains: "database/"},
+			platforms.BackupPattern{Contains: "filters/"},
+			platforms.BackupPattern{Contains: "info/"},
+			platforms.BackupPattern{Contains: "overlays/"},
+		),
+	}
+}
+
+func settingsPath(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}}, exclude: emulatorConfigExclusions,
+	}
+}
+
+func savePath(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves, include: []platforms.BackupPattern{{All: true}},
+	}
+}
+
+func statePath(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySavestates, include: []platforms.BackupPattern{{All: true}},
+	}
+}
+
+func nonRecursiveSettings(rel string, names ...string) emulatorPathDefinition {
+	include := make([]platforms.BackupPattern, 0, len(names))
+	for _, name := range names {
+		include = append(include, platforms.BackupPattern{Glob: name})
+	}
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings, include: include, nonRecur: true,
+	}
+}
+
+func nonRecursiveSave(rel string, names ...string) emulatorPathDefinition {
+	include := make([]platforms.BackupPattern, 0, len(names))
+	for _, name := range names {
+		include = append(include, platforms.BackupPattern{Glob: name})
+	}
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves, include: include, nonRecur: true,
+	}
+}
+
+func ppssppSettings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}},
+		exclude: appendBackupPatterns(emulatorConfigExclusions,
+			platforms.BackupPattern{Glob: "PSP/SYSTEM/DUMP/**"},
+		),
+	}
+}
+
+func cemuSettings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}},
+		exclude: appendBackupPatterns(emulatorConfigExclusions,
+			platforms.BackupPattern{Glob: "cemu/**"},
+		),
+	}
+}
+
+func citraSettings(rel string) emulatorPathDefinition {
+	exclude := append([]platforms.BackupPattern{}, emulatorConfigExclusions...)
+	exclude = append(exclude,
+		platforms.BackupPattern{Glob: "log/**"},
+		platforms.BackupPattern{Contains: "sdmc/"},
+		platforms.BackupPattern{Contains: "nand/data/"},
+		platforms.BackupPattern{Contains: "nand/title/"},
+	)
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}}, exclude: exclude,
+	}
+}
+
+func citraSaves(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves,
+		include: []platforms.BackupPattern{{Contains: "data/"}, {Contains: "extdata/"}},
+	}
+}
+
+func citraNANDSaves(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves,
+		include: []platforms.BackupPattern{{Contains: "data/"}, {Contains: "extdata/"}},
+	}
+}
+
+func ryujinxSettings(rel string) emulatorPathDefinition {
+	exclude := appendBackupPatterns(emulatorConfigExclusions,
+		platforms.BackupPattern{Contains: "bis/user/save/"},
+		platforms.BackupPattern{Contains: "bis/user/savemeta/"},
+		platforms.BackupPattern{Contains: "bis/system/save/"},
+		platforms.BackupPattern{Contains: "bis/user/contents/"},
+		platforms.BackupPattern{Contains: "games/"},
+	)
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{{All: true}}, exclude: exclude,
+	}
+}
+
+func rpcs3Settings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{
+			{Glob: "*.yml"},
+			{Glob: "*.yaml"},
+			{Glob: "*.dat"},
+			{Glob: "*.ini"},
+			{Contains: "config/"},
+			{Contains: "guiconfigs/"},
+			{Contains: "input_configs/"},
+			{Contains: "patches/"},
+		},
+		exclude: appendBackupPatterns(emulatorConfigExclusions,
+			platforms.BackupPattern{Contains: "dev_bdvd/"},
+			platforms.BackupPattern{Contains: "dev_hdd0/game/"},
+			platforms.BackupPattern{Contains: "dev_hdd0/savedata/"},
+			platforms.BackupPattern{Contains: "dev_hdd1/"},
+			platforms.BackupPattern{Contains: "dev_usb000/"},
+		),
+	}
+}
+
+func mameSettings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{
+			{Glob: "*.ini"}, {Contains: "cfg/"}, {Contains: "ctrlr/"}, {Contains: "ini/"},
+		},
+		exclude: emulatorConfigExclusions,
+	}
+}
+
+func dolphinWiiSaves(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves,
+		include: []platforms.BackupPattern{
+			{Glob: "shared2/sys/**"},
+			{Glob: "shared2/wc24/**"},
+			{Glob: "shared2/menu/FaceLib/**"},
+			{Glob: "sys/**"},
+			{Glob: "title/*/*/data/**"},
+		},
+	}
+}
+
+func shadPS4Settings(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySettings,
+		include: []platforms.BackupPattern{
+			{Glob: "*.ini"},
+			{Glob: "*.json"},
+			{Glob: "*.toml"},
+			{Glob: "*.xml"},
+			{Glob: "*.yaml"},
+			{Glob: "*.yml"},
+			{Contains: "cheats/"},
+			{Contains: "custom_configs/"},
+			{Contains: "inputs/"},
+			{Contains: "patches/"},
+			{Contains: "sys_modules/"},
+		},
+		exclude: appendBackupPatterns(emulatorConfigExclusions,
+			platforms.BackupPattern{Contains: "captures/"},
+			platforms.BackupPattern{Contains: "download/"},
+			platforms.BackupPattern{Contains: "fonts/"},
+			platforms.BackupPattern{Contains: "game_data/"},
+			platforms.BackupPattern{Contains: "savedata/"},
+			platforms.BackupPattern{Contains: "shader/"},
+			platforms.BackupPattern{Contains: "temp/"},
+			platforms.BackupPattern{Contains: "trophy/"},
+		),
+	}
+}
+
+func shadPS4Saves(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves,
+		include: []platforms.BackupPattern{
+			{Glob: "savedata/**"},
+			{Glob: "trophy/**"},
+			{Glob: "custom_trophy/**"},
+			{Glob: "home/*/savedata/**"},
+			{Glob: "home/*/trophy/**"},
+		},
+	}
+}
+
+func flycastSaves(rel string) emulatorPathDefinition {
+	return emulatorPathDefinition{
+		rel: rel, category: backupCategorySaves,
+		include: []platforms.BackupPattern{
+			{Glob: "*.bin"},
+			{Glob: "*.vmu"},
+			{Glob: "*.nvm"},
+			{Glob: "*.flash"},
+			{Contains: "vmu"},
+		},
+	}
+}

--- a/pkg/platforms/steamos/backup_emulators.go
+++ b/pkg/platforms/steamos/backup_emulators.go
@@ -447,7 +447,7 @@ func flycastSaves(rel string) emulatorPathDefinition {
 			{Glob: "*.vmu"},
 			{Glob: "*.nvm"},
 			{Glob: "*.flash"},
-			{Contains: "vmu"},
+			{Contains: "vmu/"},
 		},
 	}
 }

--- a/pkg/platforms/steamos/backup_launchers.go
+++ b/pkg/platforms/steamos/backup_launchers.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"path/filepath"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+)
+
+func launcherDefinitions(home string) []platforms.BackupDefinition {
+	definitions := make([]platforms.BackupDefinition, 0, 10)
+	for _, rel := range []string{
+		filepath.Join(".kodi", "userdata"),
+		filepath.Join(".var", "app", "tv.kodi.Kodi", "data", "userdata"),
+		filepath.Join(".var", "app", "tv.kodi.Kodi", "data", "kodi", "userdata"),
+		filepath.Join(".var", "app", "tv.kodi.Kodi", ".kodi", "userdata"),
+	} {
+		definitions = append(definitions, definition(
+			filepath.Join(home, rel), rel, backupCategorySettings,
+			[]platforms.BackupPattern{{All: true}},
+			[]platforms.BackupPattern{
+				{Contains: "thumbnails/"},
+				{Glob: filepath.Join("Database", "Textures*.db")},
+				{Contains: "cache/"},
+				{Contains: "temp/"},
+				{Contains: "logs/"},
+				{Contains: "themes/"},
+			},
+		))
+	}
+	for _, rel := range []string{
+		filepath.Join(".config", "Moonlight Game Streaming Project"),
+		filepath.Join(
+			".var", "app", "com.moonlight_stream.Moonlight", "config",
+			"Moonlight Game Streaming Project",
+		),
+	} {
+		definitions = append(definitions, nonRecursiveDefinition(
+			filepath.Join(home, rel), rel, backupCategorySettings,
+			[]platforms.BackupPattern{{Glob: "Moonlight.conf"}},
+		))
+	}
+	for _, rel := range []string{
+		filepath.Join(".config", "bottles"),
+		filepath.Join(".var", "app", "com.usebottles.bottles", "config", "bottles"),
+	} {
+		definitions = append(definitions, definition(
+			filepath.Join(home, rel), rel, backupCategorySettings,
+			[]platforms.BackupPattern{{All: true}},
+			[]platforms.BackupPattern{{Contains: "cache/"}, {Contains: "logs/"}, {Contains: "downloads/"}},
+		))
+	}
+	return definitions
+}
+
+func faugusMetadataDefinitions(home string) []platforms.BackupDefinition {
+	paths := []string{
+		filepath.Join(".config", "faugus-launcher"),
+		filepath.Join(".local", "share", "faugus-launcher"),
+		filepath.Join(".var", "app", "io.github.Faugus.faugus-launcher", "config", "faugus-launcher"),
+		filepath.Join(".var", "app", "io.github.Faugus.faugus-launcher", "data", "faugus-launcher"),
+	}
+	definitions := make([]platforms.BackupDefinition, 0, len(paths))
+	for _, rel := range paths {
+		definitions = append(definitions, definition(
+			filepath.Join(home, rel), rel, backupCategorySettings,
+			[]platforms.BackupPattern{{All: true}},
+			[]platforms.BackupPattern{
+				{Contains: "cache/"},
+				{Contains: "logs/"},
+				{Contains: "downloads/"},
+				{Contains: "screenshots/"},
+			},
+		))
+	}
+	return definitions
+}

--- a/pkg/platforms/steamos/backup_prefixes.go
+++ b/pkg/platforms/steamos/backup_prefixes.go
@@ -1,0 +1,572 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/internal/vdfbinary"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	sharedsteam "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/steam"
+	"github.com/andygrunwald/vdf"
+)
+
+const (
+	steamShortcutsMaxSize = int64(16 << 20)
+	steamLibraryMaxSize   = int64(4 << 20)
+	faugusLibraryMaxSize  = int64(16 << 20)
+)
+
+type steamLibrary struct {
+	id        string
+	steamApps string
+}
+
+type faugusBackupGame struct {
+	GameID string `json:"gameid"`
+	Prefix string `json:"prefix"`
+}
+
+func broadNonSteamPoliciesAt(home, configuredSteamRoot string) []platforms.BackupDefinition {
+	steamRoot := selectedSteamInstallRoot(home, configuredSteamRoot)
+	steamAppsRoot := sharedsteam.FindSteamAppsDir(steamRoot)
+	userdataRoot := filepath.Join(steamRoot, "userdata")
+	compatdataRoot := filepath.Join(steamAppsRoot, "compatdata")
+	definitions := make([]platforms.BackupDefinition, 0, 9)
+	definitions = append(definitions,
+		definition(
+			userdataRoot, filepath.Join("Steam", "userdata"), backupCategorySettings,
+			[]platforms.BackupPattern{{Glob: filepath.Join("*", "config", "shortcuts.vdf")}}, nil,
+		),
+		definition(
+			compatdataRoot, filepath.Join("Steam", "nonsteam"), backupCategorySettings,
+			[]platforms.BackupPattern{{Glob: filepath.Join("[234]?????????", "pfx", "*.reg")}}, nil,
+		),
+		definition(
+			compatdataRoot, filepath.Join("Steam", "nonsteam"), backupCategorySaves,
+			steamPrefixSavePatterns(), steamPrefixSaveExclusions(),
+		),
+	)
+
+	for _, root := range bottleRoots(home) {
+		definitions = append(definitions, broadBottlePolicies(root)...)
+	}
+	fallbackBottleRoot := preferredBottleRoot(home)
+	fallbackBottleRoot.restore = filepath.Join("Bottles", "custom")
+	definitions = append(definitions, broadBottlePolicies(fallbackBottleRoot)...)
+	definitions = append(definitions,
+		definition(
+			filepath.Join(home, "Faugus"), "Faugus", backupCategorySettings,
+			[]platforms.BackupPattern{
+				{Glob: filepath.Join("*", "*.reg")},
+				{Glob: filepath.Join("*", "pfx", "*.reg")},
+			}, nil,
+		),
+		definition(
+			filepath.Join(home, "Faugus"), "Faugus", backupCategorySaves,
+			append(
+				prefixWindowsPatterns(filepath.Join("*", "drive_c", "users"), windowsUserSavePatterns),
+				prefixWindowsPatterns(filepath.Join("*", "pfx", "drive_c", "users"), windowsUserSavePatterns)...,
+			),
+			append(
+				prefixWindowsPatterns(filepath.Join("*", "drive_c", "users"), windowsSaveExclusions),
+				prefixWindowsPatterns(filepath.Join("*", "pfx", "drive_c", "users"), windowsSaveExclusions)...,
+			),
+		),
+	)
+	return definitions
+}
+
+func discoverNonSteamDefinitions(home string) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	return discoverNonSteamDefinitionsAt(home, "")
+}
+
+func discoverNonSteamDefinitionsAt(
+	home, configuredSteamRoot string,
+) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	definitions, warnings := discoverSteamShortcutDefinitionsAt(home, configuredSteamRoot)
+	bottles, bottleWarnings := discoverBottlesDefinitions(home)
+	definitions = append(definitions, bottles...)
+	warnings = append(warnings, bottleWarnings...)
+	faugus, faugusWarnings := discoverFaugusDefinitions(home)
+	definitions = append(definitions, faugus...)
+	warnings = append(warnings, faugusWarnings...)
+	return definitions, warnings
+}
+
+func discoverSteamShortcutDefinitions(home string) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	return discoverSteamShortcutDefinitionsAt(home, "")
+}
+
+func discoverSteamShortcutDefinitionsAt(
+	home, configuredSteamRoot string,
+) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	steamRoot := selectedSteamInstallRoot(home, configuredSteamRoot)
+	userdataRoot := filepath.Join(steamRoot, "userdata")
+	entries, err := os.ReadDir(userdataRoot)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, []platforms.BackupWarning{{
+			Category: backupCategorySettings,
+			Path:     filepath.ToSlash(filepath.Join("Steam", "userdata")),
+			Reason:   "Steam shortcuts are unreadable",
+		}}
+	}
+
+	definitions := make([]platforms.BackupDefinition, 0)
+	warnings := make([]platforms.BackupWarning, 0)
+	appIDs := make(map[uint32]struct{})
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, parseErr := strconv.ParseUint(entry.Name(), 10, 64); parseErr != nil {
+			continue
+		}
+		configRoot := filepath.Join(userdataRoot, entry.Name(), "config")
+		shortcutsPath := filepath.Join(configRoot, "shortcuts.vdf")
+		info, statErr := os.Stat(shortcutsPath)
+		if errors.Is(statErr, os.ErrNotExist) {
+			continue
+		}
+		logicalRoot := filepath.Join("Steam", "userdata", entry.Name(), "config")
+		if statErr != nil || !info.Mode().IsRegular() {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySettings,
+				Path:     filepath.ToSlash(filepath.Join(logicalRoot, "shortcuts.vdf")),
+				Reason:   "Steam shortcuts are unreadable",
+			})
+			continue
+		}
+		definitions = append(definitions, nonRecursiveDefinition(
+			configRoot, logicalRoot, backupCategorySettings,
+			[]platforms.BackupPattern{{Glob: "shortcuts.vdf"}},
+		))
+
+		shortcuts, readErr := readSteamShortcuts(shortcutsPath)
+		if readErr != nil {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySettings,
+				Path:     filepath.ToSlash(filepath.Join(logicalRoot, "shortcuts.vdf")),
+				Reason:   "Steam shortcuts could not be parsed; raw metadata was preserved",
+			})
+			continue
+		}
+		for _, shortcut := range shortcuts {
+			appIDs[shortcut.AppID] = struct{}{}
+		}
+	}
+
+	libraries, libraryWarnings := discoverSteamLibraries(steamRoot)
+	warnings = append(warnings, libraryWarnings...)
+	compatdataIDs, compatdataWarnings := discoverNonSteamCompatdataIDs(libraries)
+	warnings = append(warnings, compatdataWarnings...)
+	for appID := range compatdataIDs {
+		appIDs[appID] = struct{}{}
+	}
+	for appID := range appIDs {
+		id := strconv.FormatUint(uint64(appID), 10)
+		for _, library := range libraries {
+			prefixSource := filepath.Join(library.steamApps, "compatdata", id, "pfx")
+			usersPath := filepath.Join(prefixSource, "drive_c", "users")
+			if info, statErr := os.Stat(usersPath); statErr != nil || !info.IsDir() {
+				continue
+			}
+			logicalRoot := filepath.Join("Steam", "nonsteam", id, "pfx")
+			definitions = append(definitions, windowsPrefixDefinitions(prefixSource, logicalRoot)...)
+			break
+		}
+	}
+	return definitions, warnings
+}
+
+func discoverNonSteamCompatdataIDs(
+	libraries []steamLibrary,
+) (map[uint32]struct{}, []platforms.BackupWarning) {
+	result := make(map[uint32]struct{})
+	warnings := make([]platforms.BackupWarning, 0)
+	for _, library := range libraries {
+		compatdataRoot := filepath.Join(library.steamApps, "compatdata")
+		entries, err := os.ReadDir(compatdataRoot)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySaves,
+				Path:     filepath.ToSlash(filepath.Join("Steam", "nonsteam")),
+				Reason:   "Steam compatibility data is unreadable",
+			})
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			id, parseErr := strconv.ParseUint(entry.Name(), 10, 32)
+			if parseErr == nil && id >= 1<<31 {
+				result[uint32(id)] = struct{}{}
+			}
+		}
+	}
+	return result, warnings
+}
+
+func selectedSteamInstallRoot(home, configured string) string {
+	if safeExternalRoot(configured, home) {
+		if info, err := os.Stat(configured); err == nil && info.IsDir() {
+			return filepath.Clean(configured)
+		}
+	}
+	return steamInstallRoot(home)
+}
+
+func steamInstallRoot(home string) string {
+	candidates := []string{
+		filepath.Join(home, ".local", "share", "Steam"),
+		filepath.Join(home, ".steam", "steam"),
+		filepath.Join(home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
+		filepath.Join(home, ".var", "app", "com.valvesoftware.Steam", ".steam", "steam"),
+		filepath.Join(home, "snap", "steam", "common", ".local", "share", "Steam"),
+		filepath.Join(home, "snap", "steam", "common", ".steam", "steam"),
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+	}
+	return candidates[0]
+}
+
+func discoverSteamLibraries(steamRoot string) ([]steamLibrary, []platforms.BackupWarning) {
+	mainSteamApps := sharedsteam.FindSteamAppsDir(steamRoot)
+	libraries := []steamLibrary{{id: "0", steamApps: mainSteamApps}}
+	path := filepath.Join(mainSteamApps, "libraryfolders.vdf")
+	data, err := readLimitedBackupFile(path, steamLibraryMaxSize)
+	if errors.Is(err, os.ErrNotExist) {
+		return libraries, nil
+	}
+	if err != nil {
+		return libraries, []platforms.BackupWarning{{
+			Category: backupCategorySettings,
+			Path:     filepath.ToSlash(filepath.Join("Steam", "libraryfolders.vdf")),
+			Reason:   "Steam library configuration is unreadable",
+		}}
+	}
+	parsed, err := vdf.NewParser(bytes.NewReader(data)).Parse()
+	if err != nil {
+		return libraries, []platforms.BackupWarning{{
+			Category: backupCategorySettings,
+			Path:     filepath.ToSlash(filepath.Join("Steam", "libraryfolders.vdf")),
+			Reason:   "Steam library configuration could not be parsed",
+		}}
+	}
+	folders, ok := parsed["libraryfolders"].(map[string]any)
+	if !ok {
+		return libraries, nil
+	}
+	for id, raw := range folders {
+		folder, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		libraryPath, ok := folder["path"].(string)
+		if !ok || !safeExternalRoot(libraryPath, steamRoot) {
+			continue
+		}
+		libraries = append(libraries, steamLibrary{
+			id: id, steamApps: filepath.Join(filepath.Clean(libraryPath), "steamapps"),
+		})
+	}
+	sort.Slice(libraries[1:], func(i, j int) bool {
+		return libraries[i+1].id < libraries[j+1].id
+	})
+	return libraries, nil
+}
+
+func readSteamShortcuts(path string) ([]vdfbinary.Shortcut, error) {
+	data, err := readLimitedBackupFile(path, steamShortcutsMaxSize)
+	if err != nil {
+		return nil, fmt.Errorf("read Steam shortcuts: %w", err)
+	}
+	shortcuts, err := vdfbinary.ParseShortcuts(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("parse Steam shortcuts: %w", err)
+	}
+	return shortcuts, nil
+}
+
+func windowsPrefixDefinitions(sourceRoot, restoreRoot string) []platforms.BackupDefinition {
+	usersSource := filepath.Join(sourceRoot, "drive_c", "users")
+	usersRestore := filepath.Join(restoreRoot, "drive_c", "users")
+	return []platforms.BackupDefinition{
+		nonRecursiveDefinition(
+			sourceRoot, restoreRoot, backupCategorySettings,
+			[]platforms.BackupPattern{{Glob: "*.reg"}},
+		),
+		definition(
+			usersSource, usersRestore, backupCategorySaves,
+			windowsUserSavePatterns, windowsSaveExclusions,
+		),
+	}
+}
+
+type bottleRoot struct {
+	source  string
+	restore string
+}
+
+func broadBottlePolicies(root bottleRoot) []platforms.BackupDefinition {
+	return []platforms.BackupDefinition{
+		definition(
+			root.source, root.restore, backupCategorySettings,
+			[]platforms.BackupPattern{
+				{Glob: filepath.Join("*", "bottle.yml")},
+				{Glob: filepath.Join("*", "*.reg")},
+			}, nil,
+		),
+		definition(
+			root.source, root.restore, backupCategorySaves,
+			prefixWindowsPatterns(filepath.Join("*", "drive_c", "users"), windowsUserSavePatterns),
+			prefixWindowsPatterns(filepath.Join("*", "drive_c", "users"), windowsSaveExclusions),
+		),
+	}
+}
+
+func preferredBottleRoot(home string) bottleRoot {
+	known := bottleRoots(home)
+	for _, root := range known {
+		if info, err := os.Stat(root.source); err == nil && info.IsDir() {
+			return root
+		}
+	}
+	return known[0]
+}
+
+func bottleRoots(home string) []bottleRoot {
+	roots := []bottleRoot{
+		{
+			source:  filepath.Join(home, ".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles"),
+			restore: filepath.Join(".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles"),
+		},
+		{
+			source:  filepath.Join(home, ".local", "share", "bottles", "bottles"),
+			restore: filepath.Join(".local", "share", "bottles", "bottles"),
+		},
+	}
+	if configured := strings.TrimSpace(os.Getenv("BOTTLES_PATH")); safeExternalRoot(configured, home) {
+		if filepath.Base(configured) != "bottles" {
+			configured = filepath.Join(configured, "bottles")
+		}
+		roots = append([]bottleRoot{{source: configured, restore: filepath.Join("Bottles", "custom")}}, roots...)
+	}
+	return roots
+}
+
+func discoverBottlesDefinitions(home string) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	definitions := make([]platforms.BackupDefinition, 0)
+	warnings := make([]platforms.BackupWarning, 0)
+	for _, root := range bottleRoots(home) {
+		entries, err := os.ReadDir(root.source)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySettings,
+				Path:     filepath.ToSlash(root.restore), Reason: "Bottles data is unreadable",
+			})
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || !safePortableSegment(entry.Name()) {
+				continue
+			}
+			source := filepath.Join(root.source, entry.Name())
+			restore := filepath.Join(root.restore, entry.Name())
+			settings := nonRecursiveDefinition(
+				source, restore, backupCategorySettings,
+				[]platforms.BackupPattern{{Glob: "bottle.yml"}, {Glob: "*.reg"}},
+			)
+			definitions = append(definitions, settings)
+			users := filepath.Join(source, "drive_c", "users")
+			if info, statErr := os.Stat(users); statErr == nil && info.IsDir() {
+				definitions = append(definitions, definition(
+					users, filepath.Join(restore, "drive_c", "users"), backupCategorySaves,
+					windowsUserSavePatterns, windowsSaveExclusions,
+				))
+			}
+		}
+	}
+	return definitions, warnings
+}
+
+func discoverFaugusDefinitions(home string) ([]platforms.BackupDefinition, []platforms.BackupWarning) {
+	prefixes := make(map[string]string)
+	warnings := make([]platforms.BackupWarning, 0)
+	for _, rel := range []string{
+		filepath.Join(".local", "share", "faugus-launcher", "games.json"),
+		filepath.Join(".var", "app", "io.github.Faugus.faugus-launcher", "data", "faugus-launcher", "games.json"),
+	} {
+		path := filepath.Join(home, rel)
+		data, err := readLimitedBackupFile(path, faugusLibraryMaxSize)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySettings,
+				Path:     filepath.ToSlash(rel), Reason: "Faugus game metadata is unreadable",
+			})
+			continue
+		}
+		var games []faugusBackupGame
+		if err = json.Unmarshal(data, &games); err != nil {
+			warnings = append(warnings, platforms.BackupWarning{
+				Category: backupCategorySettings,
+				Path:     filepath.ToSlash(rel), Reason: "Faugus game metadata could not be parsed",
+			})
+			continue
+		}
+		for _, game := range games {
+			prefix := normalizeWinePrefix(game.Prefix)
+			if !safePortableSegment(game.GameID) || !safeExternalRoot(prefix, home) {
+				continue
+			}
+			prefixes[game.GameID] = prefix
+		}
+	}
+
+	root := filepath.Join(home, "Faugus")
+	entries, err := os.ReadDir(root)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || !safePortableSegment(entry.Name()) {
+				continue
+			}
+			if _, exists := prefixes[entry.Name()]; exists {
+				continue
+			}
+			prefix := normalizeWinePrefix(filepath.Join(root, entry.Name()))
+			if prefix != "" {
+				prefixes[entry.Name()] = prefix
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		warnings = append(warnings, platforms.BackupWarning{
+			Category: backupCategorySaves, Path: "Faugus", Reason: "Faugus prefixes are unreadable",
+		})
+	}
+
+	ids := make([]string, 0, len(prefixes))
+	for id := range prefixes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	definitions := make([]platforms.BackupDefinition, 0, len(ids)*2)
+	for _, id := range ids {
+		definitions = append(definitions, windowsPrefixDefinitions(
+			prefixes[id], filepath.Join("Faugus", id, "pfx"),
+		)...)
+	}
+	return definitions, warnings
+}
+
+func normalizeWinePrefix(candidate string) string {
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || !filepath.IsAbs(candidate) {
+		return ""
+	}
+	candidate = filepath.Clean(candidate)
+	for _, root := range []string{candidate, filepath.Join(candidate, "pfx")} {
+		if info, err := os.Stat(filepath.Join(root, "drive_c", "users")); err == nil && info.IsDir() {
+			return root
+		}
+	}
+	return ""
+}
+
+func steamPrefixSavePatterns() []platforms.BackupPattern {
+	return prefixWindowsPatterns(
+		filepath.Join("[234]?????????", "pfx", "drive_c", "users"), windowsUserSavePatterns,
+	)
+}
+
+func steamPrefixSaveExclusions() []platforms.BackupPattern {
+	return prefixWindowsPatterns(
+		filepath.Join("[234]?????????", "pfx", "drive_c", "users"), windowsSaveExclusions,
+	)
+}
+
+func prefixWindowsPatterns(prefix string, patterns []platforms.BackupPattern) []platforms.BackupPattern {
+	result := make([]platforms.BackupPattern, 0, len(patterns))
+	for _, pattern := range patterns {
+		if pattern.Glob != "" {
+			if !strings.ContainsAny(pattern.Glob, `/\\`) {
+				result = append(result, pattern)
+				continue
+			}
+			result = append(result, platforms.BackupPattern{
+				Glob: filepath.Join(prefix, pattern.Glob),
+			})
+			continue
+		}
+		result = append(result, pattern)
+	}
+	return result
+}
+
+func readLimitedBackupFile(path string, limit int64) ([]byte, error) {
+	file, err := os.Open(path) //nolint:gosec // Fixed per-user integration metadata path.
+	if err != nil {
+		return nil, fmt.Errorf("open backup metadata: %w", err)
+	}
+	defer file.Close() //nolint:errcheck // Read-only file.
+	data, err := io.ReadAll(io.LimitReader(file, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("read backup metadata: %w", err)
+	}
+	if int64(len(data)) > limit {
+		return nil, errors.New("backup metadata exceeds size limit")
+	}
+	return data, nil
+}
+
+func safeExternalRoot(candidate, forbiddenRoot string) bool {
+	if candidate == "" || !filepath.IsAbs(candidate) || strings.ContainsAny(candidate, "\x00\n\r") {
+		return false
+	}
+	clean := filepath.Clean(candidate)
+	if clean == string(filepath.Separator) || clean == filepath.Clean(forbiddenRoot) {
+		return false
+	}
+	resolved, existingRoot, ok := resolvedBackupPathFromExistingAncestor(clean)
+	if !ok || existingRoot == string(filepath.Separator) || resolved == string(filepath.Separator) {
+		return false
+	}
+	forbiddenResolved, _, forbiddenOK := resolvedBackupPathFromExistingAncestor(forbiddenRoot)
+	if !forbiddenOK {
+		forbiddenResolved = filepath.Clean(forbiddenRoot)
+	}
+	return resolved != filepath.Clean(forbiddenResolved)
+}
+
+func safePortableSegment(value string) bool {
+	return value != "" && value != "." && value != ".." && filepath.Base(value) == value &&
+		!strings.ContainsAny(value, "/\\\x00\n\r")
+}

--- a/pkg/platforms/steamos/backup_restore_paths.go
+++ b/pkg/platforms/steamos/backup_restore_paths.go
@@ -1,0 +1,218 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/linuxemu"
+)
+
+// PrepareBackupRestore preserves destination storage mappings while restoring
+// provider settings. Data follows the destination's active roots rather than
+// stale absolute paths captured on another device.
+func (*Platform) PrepareBackupRestore() (func(bool) error, error) {
+	home := steamOSHomeDir()
+	emuDeckPaths := linuxemu.DefaultEmuDeckPaths(home)
+	retroPaths := destinationRetroDECKPaths(home)
+	return func(success bool) error {
+		if !success {
+			return nil
+		}
+		return errors.Join(
+			rewriteEmuDeckPaths(home, &emuDeckPaths),
+			rewriteRetroDECKPaths(home, retroPaths),
+		)
+	}, nil
+}
+
+func rewriteEmuDeckPaths(home string, paths *linuxemu.EmuDeckPaths) error {
+	path := filepath.Join(home, ".config", "EmuDeck", "settings.sh")
+	assignments := map[string]string{
+		"emulationPath": paths.EmulationPath,
+		"romsPath":      paths.RomsPath,
+		"toolsPath":     paths.ToolsPath,
+		"biosPath":      paths.BiosPath,
+		"savesPath":     paths.SavesPath,
+		"storagePath":   paths.StoragePath,
+		"ESDEscrapData": filepath.Join(paths.ToolsPath, "downloaded_media"),
+	}
+	data, mode, err := readRestoreConfig(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading restored EmuDeck paths: %w", err)
+	}
+	lines := strings.Split(string(data), "\n")
+	seen := make(map[string]struct{}, len(assignments))
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "export "))
+		key, _, found := strings.Cut(trimmed, "=")
+		if !found {
+			continue
+		}
+		value, ok := assignments[strings.TrimSpace(key)]
+		if !ok {
+			continue
+		}
+		prefix := ""
+		if strings.HasPrefix(strings.TrimSpace(line), "export ") {
+			prefix = "export "
+		}
+		key = strings.TrimSpace(key)
+		lines[i] = prefix + key + "=" + strconv.Quote(value)
+		seen[key] = struct{}{}
+	}
+	missing := make([]string, 0, len(assignments))
+	for key := range assignments {
+		if _, ok := seen[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+	for _, key := range missing {
+		lines = append(lines, key+"="+strconv.Quote(assignments[key]))
+	}
+	return writeRestoreConfig(path, []byte(strings.Join(lines, "\n")), mode)
+}
+
+func destinationRetroDECKPaths(home string) map[string]string {
+	paths := linuxemu.DefaultRetroDECKPaths(home)
+	esdeRoot := filepath.Dir(paths.GamelistPath)
+	result := map[string]string{
+		"rd_home_path":          paths.HomePath,
+		"roms_path":             paths.RomsPath,
+		"saves_path":            paths.SavesPath,
+		"states_path":           paths.StatesPath,
+		"bios_path":             paths.BiosPath,
+		"storage_path":          paths.StoragePath,
+		"shaders_path":          filepath.Join(paths.HomePath, "shaders"),
+		"backups_path":          filepath.Join(paths.HomePath, "backups"),
+		"downloaded_media_path": filepath.Join(esdeRoot, "downloaded_media"),
+		"themes_path":           filepath.Join(esdeRoot, "themes"),
+		"logs_path":             filepath.Join(paths.HomePath, "logs"),
+		"screenshots_path":      filepath.Join(paths.HomePath, "screenshots"),
+		"mods_path":             filepath.Join(paths.HomePath, "mods"),
+		"texture_packs_path":    filepath.Join(paths.HomePath, "texture_packs"),
+		"borders_path":          filepath.Join(paths.HomePath, "borders"),
+		"cheats_path":           filepath.Join(paths.HomePath, "cheats"),
+		"portmaster_path":       filepath.Join(paths.HomePath, "PortMaster"),
+		"videos_path":           filepath.Join(paths.HomePath, "videos"),
+	}
+	configPath := filepath.Join(
+		home, ".var", "app", "net.retrodeck.retrodeck", "config", "retrodeck", "retrodeck.json",
+	)
+	data, _, err := readRestoreConfig(configPath)
+	if err != nil {
+		return result
+	}
+	var parsed struct {
+		Paths map[string]string `json:"paths"`
+	}
+	if json.Unmarshal(data, &parsed) != nil {
+		return result
+	}
+	for key, value := range parsed.Paths {
+		if safeExternalRoot(value, home) {
+			result[key] = filepath.Clean(value)
+		}
+	}
+	return result
+}
+
+func rewriteRetroDECKPaths(home string, destinationPaths map[string]string) error {
+	path := filepath.Join(
+		home, ".var", "app", "net.retrodeck.retrodeck", "config", "retrodeck", "retrodeck.json",
+	)
+	data, mode, err := readRestoreConfig(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading restored RetroDECK paths: %w", err)
+	}
+	var parsed map[string]any
+	if err = json.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("parsing restored RetroDECK paths: %w", err)
+	}
+	rawPaths, ok := parsed["paths"].(map[string]any)
+	if !ok {
+		return errors.New("restored RetroDECK configuration has no paths object")
+	}
+	for key, value := range destinationPaths {
+		if _, exists := rawPaths[key]; exists {
+			rawPaths[key] = value
+		}
+	}
+	updated, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding restored RetroDECK paths: %w", err)
+	}
+	updated = append(updated, '\n')
+	return writeRestoreConfig(path, updated, mode)
+}
+
+func readRestoreConfig(path string) (data []byte, mode os.FileMode, err error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("checking provider configuration: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, 0, errors.New("provider configuration is not a regular file")
+	}
+	data, err = readLimitedBackupFile(path, 1<<20)
+	return data, info.Mode().Perm(), err
+}
+
+func writeRestoreConfig(path string, data []byte, mode os.FileMode) (err error) {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".zaparoo-provider-paths-*")
+	if err != nil {
+		return fmt.Errorf("creating provider path temporary file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			err = errors.Join(err, removeErr)
+		}
+	}()
+	if err = tmp.Chmod(mode); err == nil {
+		_, err = tmp.Write(data)
+	}
+	if err == nil {
+		err = tmp.Sync()
+	}
+	if closeErr := tmp.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("writing provider path temporary file: %w", err)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replacing restored provider paths: %w", err)
+	}
+	dirHandle, err := os.Open(dir) // #nosec G304 -- path is fixed provider configuration parent.
+	if err != nil {
+		return fmt.Errorf("opening provider path directory: %w", err)
+	}
+	if syncErr := dirHandle.Sync(); syncErr != nil {
+		_ = dirHandle.Close()
+		return fmt.Errorf("syncing provider path directory: %w", syncErr)
+	}
+	if err = dirHandle.Close(); err != nil {
+		return fmt.Errorf("closing provider path directory: %w", err)
+	}
+	return nil
+}

--- a/pkg/platforms/steamos/backup_restore_paths.go
+++ b/pkg/platforms/steamos/backup_restore_paths.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/linuxemu"
@@ -24,6 +23,9 @@ import (
 // stale absolute paths captured on another device.
 func (*Platform) PrepareBackupRestore() (func(bool) error, error) {
 	home := steamOSHomeDir()
+	if !validBackupHome(home) {
+		return nil, errors.New("home directory could not be resolved for restore")
+	}
 	emuDeckPaths := linuxemu.DefaultEmuDeckPaths(home)
 	retroPaths := destinationRetroDECKPaths(home)
 	return func(success bool) error {
@@ -35,6 +37,12 @@ func (*Platform) PrepareBackupRestore() (func(bool) error, error) {
 			rewriteRetroDECKPaths(home, retroPaths),
 		)
 	}, nil
+}
+
+// shellQuote wraps a value in POSIX single quotes so a sourced settings.sh
+// stores the path verbatim. Double quotes would leave $, ` and \ active.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 func rewriteEmuDeckPaths(home string, paths *linuxemu.EmuDeckPaths) error {
@@ -72,7 +80,7 @@ func rewriteEmuDeckPaths(home string, paths *linuxemu.EmuDeckPaths) error {
 			prefix = "export "
 		}
 		key = strings.TrimSpace(key)
-		lines[i] = prefix + key + "=" + strconv.Quote(value)
+		lines[i] = prefix + key + "=" + shellQuote(value)
 		seen[key] = struct{}{}
 	}
 	missing := make([]string, 0, len(assignments))
@@ -83,7 +91,7 @@ func rewriteEmuDeckPaths(home string, paths *linuxemu.EmuDeckPaths) error {
 	}
 	sort.Strings(missing)
 	for _, key := range missing {
-		lines = append(lines, key+"="+strconv.Quote(assignments[key]))
+		lines = append(lines, key+"="+shellQuote(assignments[key]))
 	}
 	return writeRestoreConfig(path, []byte(strings.Join(lines, "\n")), mode)
 }

--- a/pkg/platforms/steamos/backup_test.go
+++ b/pkg/platforms/steamos/backup_test.go
@@ -1,0 +1,419 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package steamos
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/linuxemu"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/fixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackupDefinitionsCoverDurableDataWithoutBroadGameRoots(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	definitions := BackupDefinitions(home)
+
+	assertDefinition := func(sourceRoot, restoreRoot, category string) platforms.BackupDefinition {
+		t.Helper()
+		for _, definition := range definitions {
+			if definition.SourceRoot == sourceRoot && definition.RestoreRoot == restoreRoot &&
+				definition.Category == category {
+				return definition
+			}
+		}
+		t.Fatalf("missing definition: %s -> %s (%s)", sourceRoot, restoreRoot, category)
+		return platforms.BackupDefinition{}
+	}
+
+	assertDefinition(
+		filepath.Join(home, "Emulation", "saves"), filepath.Join("Emulation", "saves"), backupCategorySaves,
+	)
+	assertDefinition(
+		filepath.Join(home, "Emulation", "saves"), filepath.Join("Emulation", "saves"),
+		backupCategorySavestates,
+	)
+	assertDefinition(
+		filepath.Join(home, "Emulation", "bios"), filepath.Join("Emulation", "bios"), backupCategorySettings,
+	)
+	assertDefinition(
+		filepath.Join(home, "retrodeck", "saves"), filepath.Join("retrodeck", "saves"), backupCategorySaves,
+	)
+	assertDefinition(
+		filepath.Join(home, "ES-DE"), "ES-DE", backupCategorySettings,
+	)
+	assertDefinition(
+		filepath.Join(home, ".config", "EmuDeck"), filepath.Join(".config", "EmuDeck"),
+		backupCategorySettings,
+	)
+	for _, expected := range []struct {
+		rel      string
+		category string
+	}{
+		{filepath.Join(".config", "steam-rom-manager", "userData"), backupCategorySettings},
+		{filepath.Join(".var", "app", "app.xemu.xemu", "data", "xemu", "xemu"), backupCategorySettings},
+		{
+			filepath.Join(".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Config"),
+			backupCategorySettings,
+		},
+		{filepath.Join(".var", "app", "com.github.Rosalie241.RMG", "data", "RMG", "Save"), backupCategorySaves},
+		{filepath.Join(".var", "app", "rs.ruffle.Ruffle", "data", "ruffle", "SharedObjects"), backupCategorySaves},
+		{filepath.Join(".var", "app", "org.mamedev.MAME", ".mame", "nvram"), backupCategorySaves},
+		{filepath.Join(".var", "app", "com.supermodel3.Supermodel", ".supermodel", "NVRAM"), backupCategorySaves},
+		{filepath.Join(".kodi", "userdata"), backupCategorySettings},
+		{filepath.Join(".config", "Moonlight Game Streaming Project"), backupCategorySettings},
+	} {
+		assertDefinition(filepath.Join(home, expected.rel), expected.rel, expected.category)
+	}
+
+	assertDefinition(
+		filepath.Join(home, "Emulation", "roms", "wiiu", "mlc01", "usr", "save"),
+		filepath.Join("Emulation", "roms", "wiiu", "mlc01", "usr", "save"),
+		backupCategorySaves,
+	)
+	assertDefinition(
+		filepath.Join(home, "Emulation", "roms", "xbox360", "content"),
+		filepath.Join("Emulation", "roms", "xbox360", "content"),
+		backupCategorySaves,
+	)
+
+	for _, definition := range definitions {
+		assert.NotEqual(t, filepath.Join(home, ".local", "share", "Steam", "steamapps", "common"),
+			definition.SourceRoot)
+		assert.NotEqual(t, filepath.Join(home, ".local", "share", "Steam", "steamapps", "shadercache"),
+			definition.SourceRoot)
+		assert.NotEqual(t, filepath.Join(home, "Emulation", "roms"), definition.SourceRoot)
+		assert.NotEqual(t, filepath.Join(home, "Emulation", "storage"), definition.SourceRoot)
+		assert.NotEqual(t, filepath.Join(home, "retrodeck", "roms"), definition.SourceRoot)
+		assert.NotEqual(t, filepath.Join(home, ".local", "share", "flatpak"), definition.SourceRoot)
+	}
+}
+
+func TestBackupPlanSelectsOnlyNonSteamCompatdata(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	steamRoot := filepath.Join(home, ".local", "share", "Steam")
+	userConfig := filepath.Join(steamRoot, "userdata", "123", "config")
+	require.NoError(t, os.MkdirAll(userConfig, 0o750))
+	const shortcutAppID = uint32(4_000_000_001)
+	shortcuts := fixtures.BuildShortcutsVDF([]fixtures.TestShortcut{{
+		AppID: shortcutAppID, AppName: "Non-Steam Game", Exe: "game.exe", StartDir: ".", Optional: true,
+	}})
+	require.NoError(t, os.WriteFile(filepath.Join(userConfig, "shortcuts.vdf"), shortcuts, 0o600))
+
+	nonSteamPrefix := filepath.Join(
+		steamRoot, "steamapps", "compatdata", strconv.FormatUint(uint64(shortcutAppID), 10), "pfx",
+	)
+	steamGamePrefix := filepath.Join(steamRoot, "steamapps", "compatdata", "123456", "pfx")
+	require.NoError(t, os.MkdirAll(filepath.Join(nonSteamPrefix, "drive_c", "users"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(steamGamePrefix, "drive_c", "users"), 0o750))
+
+	definitions, warnings := discoverNonSteamDefinitions(home)
+	require.Empty(t, warnings)
+
+	sources := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		sources = append(sources, definition.SourceRoot)
+	}
+	assert.Contains(t, sources, userConfig)
+	assert.Contains(t, sources, nonSteamPrefix)
+	assert.Contains(t, sources, filepath.Join(nonSteamPrefix, "drive_c", "users"))
+	assert.NotContains(t, sources, steamGamePrefix)
+	assert.NotContains(t, sources, filepath.Join(steamGamePrefix, "drive_c", "users"))
+	assert.NotContains(t, sources, filepath.Join(steamRoot, "steamapps", "compatdata"),
+		"collection plan must never walk every Steam prefix")
+}
+
+func TestBackupPlanDiscoversFlatpakSteamAndExternalLibraryPrefix(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	steamRoot := filepath.Join(
+		home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam",
+	)
+	userConfig := filepath.Join(steamRoot, "userdata", "123", "config")
+	require.NoError(t, os.MkdirAll(userConfig, 0o750))
+	const shortcutAppID = uint32(4_000_000_001)
+	shortcuts := fixtures.BuildShortcutsVDF([]fixtures.TestShortcut{{
+		AppID: shortcutAppID, AppName: "External Game", Exe: "game.exe", StartDir: ".", Optional: true,
+	}})
+	require.NoError(t, os.WriteFile(filepath.Join(userConfig, "shortcuts.vdf"), shortcuts, 0o600))
+
+	externalLibrary := filepath.Join(home, "external-library")
+	steamApps := filepath.Join(steamRoot, "steamapps")
+	require.NoError(t, os.MkdirAll(steamApps, 0o750))
+	libraryVDF := `"libraryfolders" { "1" { "path" "` + externalLibrary + `" } }`
+	require.NoError(t, os.WriteFile(filepath.Join(steamApps, "libraryfolders.vdf"), []byte(libraryVDF), 0o600))
+	externalPrefix := filepath.Join(
+		externalLibrary, "steamapps", "compatdata", strconv.FormatUint(uint64(shortcutAppID), 10), "pfx",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Join(externalPrefix, "drive_c", "users"), 0o750))
+
+	definitions, warnings := discoverSteamShortcutDefinitions(home)
+	require.Empty(t, warnings)
+	sources := make([]string, 0, len(definitions))
+	for _, def := range definitions {
+		sources = append(sources, def.SourceRoot)
+	}
+	assert.Contains(t, sources, userConfig)
+	assert.Contains(t, sources, externalPrefix)
+	assert.Contains(t, sources, filepath.Join(externalPrefix, "drive_c", "users"))
+}
+
+func TestBackupUsesConfiguredSteamRoot(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	configuredRoot := filepath.Join(home, "custom-steam")
+	configRoot := filepath.Join(configuredRoot, "userdata", "123", "config")
+	require.NoError(t, os.MkdirAll(configRoot, 0o750))
+	shortcuts := fixtures.BuildShortcutsVDF([]fixtures.TestShortcut{{
+		AppID: 4_000_000_001, AppName: "Configured Game", Exe: "game.exe", StartDir: ".", Optional: true,
+	}})
+	require.NoError(t, os.WriteFile(filepath.Join(configRoot, "shortcuts.vdf"), shortcuts, 0o600))
+
+	definitions, warnings := discoverSteamShortcutDefinitionsAt(home, configuredRoot)
+	require.Empty(t, warnings)
+	require.NotEmpty(t, definitions)
+	assert.Equal(t, configRoot, definitions[0].SourceRoot)
+	assert.Equal(t, configuredRoot, selectedSteamInstallRoot(home, configuredRoot))
+}
+
+func TestSteamInstallRootSupportsSnap(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	snapRoot := filepath.Join(home, "snap", "steam", "common", ".steam", "steam")
+	require.NoError(t, os.MkdirAll(snapRoot, 0o750))
+	assert.Equal(t, snapRoot, steamInstallRoot(home))
+}
+
+func TestBackupPlanReportsMalformedSteamShortcuts(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	configRoot := filepath.Join(home, ".local", "share", "Steam", "userdata", "123", "config")
+	require.NoError(t, os.MkdirAll(configRoot, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(configRoot, "shortcuts.vdf"), []byte("invalid"), 0o600))
+	highBitPrefix := filepath.Join(
+		home, ".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Join(highBitPrefix, "drive_c", "users"), 0o750))
+
+	definitions, warnings := discoverSteamShortcutDefinitions(home)
+
+	require.Len(t, definitions, 3)
+	sources := make([]string, 0, len(definitions))
+	for _, def := range definitions {
+		sources = append(sources, def.SourceRoot)
+	}
+	assert.Contains(t, sources, configRoot)
+	assert.Contains(t, sources, highBitPrefix)
+	assert.Contains(t, sources, filepath.Join(highBitPrefix, "drive_c", "users"))
+	require.Len(t, warnings, 1)
+	assert.Equal(t, backupCategorySettings, warnings[0].Category)
+	assert.Equal(t, "Steam shortcuts could not be parsed; raw metadata was preserved", warnings[0].Reason)
+}
+
+func TestBackupDefinitionsRejectDangerousCategorySymlink(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	emulation := filepath.Join(home, "Emulation")
+	require.NoError(t, os.MkdirAll(emulation, 0o750))
+	saves := filepath.Join(emulation, "saves")
+	require.NoError(t, os.Symlink(home, saves))
+
+	definitions := BackupDefinitions(home)
+	for _, def := range definitions {
+		if def.RestoreRoot != filepath.Join("Emulation", "saves") || def.Category != backupCategorySaves {
+			continue
+		}
+		assert.NotEqual(t, saves, def.RestoreTargetRoot)
+		assert.Contains(t, def.RestoreTargetRoot, ".zaparoo-rejected-root")
+		return
+	}
+	t.Fatal("missing EmuDeck saves definition")
+}
+
+func TestSafeDefinitionRootRejectsExistingPathThroughRootSymlink(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	rootLink := filepath.Join(home, "root-link")
+	require.NoError(t, os.Symlink(string(filepath.Separator), rootLink))
+
+	assert.False(t, safeDefinitionRoot(filepath.Join(rootLink, "tmp")))
+}
+
+func TestSafeDefinitionRootAllowsExternalCategorySymlink(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	target := t.TempDir()
+	link := filepath.Join(home, "external-saves")
+	require.NoError(t, os.Symlink(target, link))
+
+	assert.True(t, safeDefinitionRoot(link))
+}
+
+func TestBackupDefinitionsUseIndependentProviderTargets(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	emuSettings := filepath.Join(home, ".config", "EmuDeck")
+	require.NoError(t, os.MkdirAll(emuSettings, 0o750))
+	emuSaves := filepath.Join(home, "custom", "emu-saves")
+	emuBios := filepath.Join(home, "custom", "emu-bios")
+	emuStorage := filepath.Join(home, "custom", "emu-storage")
+	emuRoms := filepath.Join(home, "custom", "emu-roms")
+	require.NoError(t, os.WriteFile(filepath.Join(emuSettings, "settings.sh"), []byte(
+		"romsPath=\""+emuRoms+"\"\n"+
+			"savesPath=\""+emuSaves+"\"\n"+
+			"biosPath=\""+emuBios+"\"\n"+
+			"storagePath=\""+emuStorage+"\"\n",
+	), 0o600))
+
+	retroConfig := filepath.Join(home, ".var", "app", "net.retrodeck.retrodeck", "config", "retrodeck")
+	require.NoError(t, os.MkdirAll(retroConfig, 0o750))
+	retroSaves := filepath.Join(home, "custom", "retro-saves")
+	retroStates := filepath.Join(home, "custom", "retro-states")
+	retroBios := filepath.Join(home, "custom", "retro-bios")
+	content, err := json.Marshal(map[string]any{"paths": map[string]string{
+		"saves_path": retroSaves, "states_path": retroStates, "bios_path": retroBios,
+	}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(retroConfig, "retrodeck.json"), content, 0o600))
+
+	definitions := BackupDefinitions(home)
+	assertTarget := func(restoreRoot, category, target string) {
+		t.Helper()
+		for _, def := range definitions {
+			if def.RestoreRoot == restoreRoot && def.Category == category && def.RestoreTargetRoot == target {
+				return
+			}
+		}
+		t.Fatalf("missing target %s -> %s (%s)", restoreRoot, target, category)
+	}
+	assertTarget(filepath.Join("Emulation", "saves"), backupCategorySaves, emuSaves)
+	assertTarget(filepath.Join("Emulation", "bios"), backupCategorySettings, emuBios)
+	assertTarget(filepath.Join("retrodeck", "saves"), backupCategorySaves, retroSaves)
+	assertTarget(filepath.Join("retrodeck", "states"), backupCategorySavestates, retroStates)
+	assertTarget(filepath.Join("retrodeck", "bios"), backupCategorySettings, retroBios)
+}
+
+func TestPrepareBackupRestorePreservesDestinationProviderPaths(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	emuSettings := filepath.Join(home, ".config", "EmuDeck", "settings.sh")
+	destinationEmulation := filepath.Join(home, "destination", "Emulation")
+	writeBackupTestFile(t, emuSettings,
+		"emulationPath=\""+destinationEmulation+"\"\n"+
+			"romsPath=\""+filepath.Join(destinationEmulation, "roms")+"\"\n"+
+			"savesPath=\""+filepath.Join(destinationEmulation, "saves")+"\"\n"+
+			"biosPath=\""+filepath.Join(destinationEmulation, "bios")+"\"\n"+
+			"storagePath=\""+filepath.Join(destinationEmulation, "storage")+"\"\n")
+
+	retroConfig := filepath.Join(
+		home, ".var", "app", "net.retrodeck.retrodeck", "config", "retrodeck", "retrodeck.json",
+	)
+	destinationRetro := filepath.Join(home, "destination", "retrodeck")
+	writeBackupTestFile(t, retroConfig, `{"paths":{"rd_home_path":"`+destinationRetro+`",`+
+		`"roms_path":"`+filepath.Join(destinationRetro, "roms")+`",`+
+		`"saves_path":"`+filepath.Join(destinationRetro, "saves")+`",`+
+		`"states_path":"`+filepath.Join(destinationRetro, "states")+`",`+
+		`"bios_path":"`+filepath.Join(destinationRetro, "bios")+`",`+
+		`"storage_path":"`+filepath.Join(destinationRetro, "storage")+`"}}`)
+
+	destinationEmuDeckPaths := linuxemu.DefaultEmuDeckPaths(home)
+	destinationRetroPaths := destinationRetroDECKPaths(home)
+	writeBackupTestFile(t, emuSettings, "emulationPath=\"/old/Emulation\"\nromsPath=\"/old/roms\"\n")
+	writeBackupTestFile(t, retroConfig, `{"paths":{"rd_home_path":"/old/retrodeck",`+
+		`"roms_path":"/old/roms","saves_path":"/old/saves","states_path":"/old/states",`+
+		`"bios_path":"/old/bios","storage_path":"/old/storage"}}`)
+	require.NoError(t, rewriteEmuDeckPaths(home, &destinationEmuDeckPaths))
+	require.NoError(t, rewriteRetroDECKPaths(home, destinationRetroPaths))
+
+	emuPaths := linuxemu.DefaultEmuDeckPaths(home)
+	assert.Equal(t, destinationEmulation, emuPaths.EmulationPath)
+	assert.Equal(t, filepath.Join(destinationEmulation, "roms"), emuPaths.RomsPath)
+	assert.Equal(t, filepath.Join(destinationEmulation, "saves"), emuPaths.SavesPath)
+	assert.Equal(t, filepath.Join(destinationEmulation, "bios"), emuPaths.BiosPath)
+	assert.Equal(t, filepath.Join(destinationEmulation, "storage"), emuPaths.StoragePath)
+	retroPaths := linuxemu.DefaultRetroDECKPaths(home)
+	assert.Equal(t, destinationRetro, retroPaths.HomePath)
+	assert.Equal(t, filepath.Join(destinationRetro, "roms"), retroPaths.RomsPath)
+	assert.Equal(t, filepath.Join(destinationRetro, "saves"), retroPaths.SavesPath)
+	assert.Equal(t, filepath.Join(destinationRetro, "states"), retroPaths.StatesPath)
+	assert.Equal(t, filepath.Join(destinationRetro, "bios"), retroPaths.BiosPath)
+	assert.Equal(t, filepath.Join(destinationRetro, "storage"), retroPaths.StoragePath)
+}
+
+func writeBackupTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+}
+
+func TestDiscoverFaugusCustomPrefix(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	customPrefix := filepath.Join(home, "custom-prefix")
+	require.NoError(t, os.MkdirAll(filepath.Join(customPrefix, "drive_c", "users"), 0o750))
+	libraryPath := filepath.Join(home, ".local", "share", "faugus-launcher", "games.json")
+	writeBackupTestFile(t, libraryPath, `[{"gameid":"game-1","prefix":"`+customPrefix+`"}]`)
+
+	definitions, warnings := discoverFaugusDefinitions(home)
+	require.Empty(t, warnings)
+	sources := make([]string, 0, len(definitions))
+	for _, def := range definitions {
+		sources = append(sources, def.SourceRoot)
+	}
+	assert.Contains(t, sources, customPrefix)
+	assert.Contains(t, sources, filepath.Join(customPrefix, "drive_c", "users"))
+}
+
+func TestDiscoverBottlesReportsUnreadableRoot(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	root := filepath.Join(home, ".local", "share", "bottles", "bottles")
+	writeBackupTestFile(t, root, "not a directory")
+
+	definitions, warnings := discoverBottlesDefinitions(home)
+	assert.Empty(t, definitions)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "Bottles data is unreadable", warnings[0].Reason)
+}
+
+func TestDiscoverBottlesAndFaugusDefinitionsAvoidInstalledGames(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	bottleRoot := filepath.Join(
+		home, ".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "My Bottle",
+	)
+	faugusRoot := filepath.Join(home, "Faugus", "My Game", "pfx")
+	for _, root := range []string{bottleRoot, faugusRoot} {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "drive_c", "users", "steamuser", "Documents"), 0o750))
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "drive_c", "Program Files", "Game"), 0o750))
+	}
+
+	bottles, bottleWarnings := discoverBottlesDefinitions(home)
+	faugus, faugusWarnings := discoverFaugusDefinitions(home)
+	require.Empty(t, bottleWarnings)
+	require.Empty(t, faugusWarnings)
+	definitions := bottles
+	definitions = append(definitions, faugus...)
+	sources := make([]string, 0, len(definitions))
+	for _, definition := range definitions {
+		sources = append(sources, definition.SourceRoot)
+	}
+
+	assert.Contains(t, sources, filepath.Join(bottleRoot, "drive_c", "users"))
+	assert.Contains(t, sources, filepath.Join(faugusRoot, "drive_c", "users"))
+	for _, source := range sources {
+		assert.NotContains(t, source, filepath.Join("drive_c", "Program Files"))
+	}
+}

--- a/pkg/platforms/steamos/backup_test.go
+++ b/pkg/platforms/steamos/backup_test.go
@@ -9,6 +9,7 @@ package steamos
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -350,6 +351,83 @@ func TestPrepareBackupRestorePreservesDestinationProviderPaths(t *testing.T) {
 	assert.Equal(t, filepath.Join(destinationRetro, "states"), retroPaths.StatesPath)
 	assert.Equal(t, filepath.Join(destinationRetro, "bios"), retroPaths.BiosPath)
 	assert.Equal(t, filepath.Join(destinationRetro, "storage"), retroPaths.StoragePath)
+}
+
+func TestRewriteEmuDeckPathsQuotesShellMetacharacters(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	emuSettings := filepath.Join(home, ".config", "EmuDeck", "settings.sh")
+	// $ stays active inside a double-quoted shell assignment, and an
+	// apostrophe has to survive the single quoting we now emit.
+	emulation := filepath.Join(home, "Bob's $HOME Emulation")
+	require.NoError(t, os.MkdirAll(emulation, 0o750))
+	writeBackupTestFile(t, emuSettings, "emulationPath=\"/old/Emulation\"\n")
+
+	paths := linuxemu.EmuDeckPaths{
+		EmulationPath: emulation,
+		RomsPath:      filepath.Join(emulation, "roms"),
+		ToolsPath:     filepath.Join(emulation, "tools"),
+		BiosPath:      filepath.Join(emulation, "bios"),
+		SavesPath:     filepath.Join(emulation, "saves"),
+		StoragePath:   filepath.Join(emulation, "storage"),
+	}
+	require.NoError(t, rewriteEmuDeckPaths(home, &paths))
+
+	assert.Equal(t, emulation, sourceEmuDeckSetting(t, emuSettings))
+}
+
+func TestRewriteEmuDeckPathsRoundTripsApostrophes(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+	emuSettings := filepath.Join(home, ".config", "EmuDeck", "settings.sh")
+	emulation := filepath.Join(home, "Bob's Emulation")
+	require.NoError(t, os.MkdirAll(emulation, 0o750))
+	writeBackupTestFile(t, emuSettings, "emulationPath=\"/old/Emulation\"\n")
+
+	paths := linuxemu.EmuDeckPaths{EmulationPath: emulation}
+	require.NoError(t, rewriteEmuDeckPaths(home, &paths))
+
+	assert.Equal(t, emulation, sourceEmuDeckSetting(t, emuSettings))
+	assert.Equal(t, emulation, linuxemu.DefaultEmuDeckPaths(home).EmulationPath)
+}
+
+// sourceEmuDeckSetting reads emulationPath back the way EmuDeck does, by
+// sourcing settings.sh in a POSIX shell.
+func sourceEmuDeckSetting(t *testing.T, settingsPath string) string {
+	t.Helper()
+	//nolint:gosec // Fixed script; the settings path is a test-owned temporary file.
+	sourced, err := exec.CommandContext(
+		t.Context(), "sh", "-c",
+		". \"$1\" >/dev/null 2>&1; printf %s \"$emulationPath\"", "sh", settingsPath,
+	).Output()
+	require.NoError(t, err)
+	return string(sourced)
+}
+
+func TestBackupDefinitionsFailClosedWithoutHome(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, BackupDefinitions(""))
+	assert.Empty(t, BackupDefinitions("relative/home"))
+	assert.Empty(t, durableDefinitions(""))
+}
+
+func TestDurableDefinitionsHaveAbsoluteSourceRoots(t *testing.T) {
+	t.Parallel()
+	definitions := durableDefinitions(t.TempDir())
+	require.NotEmpty(t, definitions)
+	for _, definition := range definitions {
+		assert.True(t, filepath.IsAbs(definition.SourceRoot),
+			"relative source root: %s", definition.SourceRoot)
+	}
+}
+
+func TestFlycastSavesDoNotMatchArbitraryVMUNames(t *testing.T) {
+	t.Parallel()
+	saves := flycastSaves("flycast")
+	for _, pattern := range saves.include {
+		assert.NotEqual(t, "vmu", pattern.Contains,
+			"bare vmu substring collects unrelated files")
+	}
 }
 
 func writeBackupTestFile(t *testing.T, path, contents string) {

--- a/pkg/platforms/steamos/emudeck.go
+++ b/pkg/platforms/steamos/emudeck.go
@@ -135,7 +135,7 @@ func launchStandaloneEmulator(
 func createEmuDeckLauncher(
 	systemFolder string,
 	systemInfo esde.SystemInfo,
-	paths EmuDeckPaths,
+	paths *EmuDeckPaths,
 	retroArchOpts *sharedretroarch.Options,
 ) platforms.Launcher {
 	emulator := emulatorMapping[systemFolder]
@@ -242,7 +242,7 @@ func buildEmuDeckLaunchers(
 		if !ok {
 			continue
 		}
-		result = append(result, createEmuDeckLauncher(systemFolder, systemInfo, paths, retroArchOpts))
+		result = append(result, createEmuDeckLauncher(systemFolder, systemInfo, &paths, retroArchOpts))
 	}
 	log.Info().Int("count", len(result)).Msg("EmuDeck launchers registered")
 	return result

--- a/pkg/platforms/steamos/launchers_test.go
+++ b/pkg/platforms/steamos/launchers_test.go
@@ -148,7 +148,7 @@ func TestCreateEmuDeckLauncherTest(t *testing.T) {
 	options.CoresDir = coresDir
 	options.AppendConfigPath = appendConfigPath
 	options.LaunchEnv = func() []string { return []string{"STEAMOS_SESSION=1"} }
-	launcher := createEmuDeckLauncher("nes", systemInfo, paths, options)
+	launcher := createEmuDeckLauncher("nes", systemInfo, &paths, options)
 	assert.Contains(t, launcher.Groups, platformshared.LauncherGroupEmuDeck)
 
 	mediaPath := filepath.Join(paths.RomsPath, "nes", "super_mario.nes")
@@ -233,7 +233,7 @@ func TestCreateRetroDECKLauncherTest(t *testing.T) {
 		SystemID: "snes",
 	}
 
-	launcher := createRetroDECKLauncher("snes", systemInfo, paths)
+	launcher := createRetroDECKLauncher("snes", systemInfo, &paths)
 	assert.Contains(t, launcher.Groups, platformshared.LauncherGroupRetroDECK)
 	mediaPath := filepath.Join(paths.RomsPath, "snes", "chrono_trigger.sfc")
 	command, err := launcher.BuildLaunchCommand(nil, mediaPath, nil)
@@ -307,7 +307,7 @@ func TestEmuDeckLauncherID(t *testing.T) {
 		SystemID: "nes",
 	}
 
-	launcher := createEmuDeckLauncher("nes", systemInfo, paths, testEmuDeckRetroArchOptions())
+	launcher := createEmuDeckLauncher("nes", systemInfo, &paths, testEmuDeckRetroArchOptions())
 
 	assert.Equal(t, "nes", launcher.SystemID)
 	assert.Contains(t, launcher.ID, "EmuDeck")
@@ -326,7 +326,7 @@ func TestRetroDECKLauncherID(t *testing.T) {
 		SystemID: "snes",
 	}
 
-	launcher := createRetroDECKLauncher("snes", systemInfo, paths)
+	launcher := createRetroDECKLauncher("snes", systemInfo, &paths)
 
 	assert.Equal(t, "snes", launcher.SystemID)
 	assert.Contains(t, launcher.ID, "RetroDECK")
@@ -346,7 +346,7 @@ func TestEmuDeckRetroArchLauncherHasControls(t *testing.T) {
 		SystemID: "nes",
 	}
 
-	launcher := createEmuDeckLauncher("nes", systemInfo, paths, testEmuDeckRetroArchOptions())
+	launcher := createEmuDeckLauncher("nes", systemInfo, &paths, testEmuDeckRetroArchOptions())
 
 	expectedControls := []string{
 		platforms.ControlSaveState,
@@ -382,7 +382,7 @@ func TestEmuDeckStandaloneLauncherHasNoControls(t *testing.T) {
 		SystemID: "psx",
 	}
 
-	launcher := createEmuDeckLauncher("psx", systemInfo, paths, testEmuDeckRetroArchOptions())
+	launcher := createEmuDeckLauncher("psx", systemInfo, &paths, testEmuDeckRetroArchOptions())
 	mediaPath := filepath.Join(paths.RomsPath, "psx", "game.chd")
 	command, err := launcher.BuildLaunchCommand(nil, mediaPath, nil)
 	require.NoError(t, err)

--- a/pkg/platforms/steamos/platform.go
+++ b/pkg/platforms/steamos/platform.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
@@ -72,6 +73,7 @@ type Platform struct {
 	steamRuntime              runtimeBroker
 	setActiveMedia            func(*models.ActiveMedia)
 	emulationOptionsOverride  *linuxemu.Options
+	backupSteamRoot           atomic.Pointer[string]
 	retroArchAppendConfigPath string
 }
 
@@ -191,6 +193,7 @@ func (p *Platform) StartPost(
 	// Resolve Steam root once so tracker uses the same configured installation
 	// as the Steam launcher.
 	steamRoot := steam.NewClient(steam.DefaultSteamOSOptions()).FindSteamDir(cfg)
+	p.backupSteamRoot.Store(&steamRoot)
 
 	// Create shared process scanner for both Steam and emulator tracking
 	p.procScanner = procscanner.New()

--- a/pkg/platforms/steamos/retrodeck.go
+++ b/pkg/platforms/steamos/retrodeck.go
@@ -111,7 +111,9 @@ func LaunchViaRetroDECK(ctx context.Context, romPath string) (*os.Process, error
 }
 
 // createRetroDECKLauncher creates a launcher for a specific RetroDECK system.
-func createRetroDECKLauncher(systemFolder string, systemInfo esde.SystemInfo, paths RetroDECKPaths) platforms.Launcher {
+func createRetroDECKLauncher(
+	systemFolder string, systemInfo esde.SystemInfo, paths *RetroDECKPaths,
+) platforms.Launcher {
 	launcher := platforms.Launcher{
 		ID:                 "RetroDECK" + systemInfo.GetLauncherID(),
 		SystemID:           systemInfo.SystemID,
@@ -221,7 +223,7 @@ func GetRetroDECKLaunchers(_ *config.Instance) []platforms.Launcher {
 			Str("launcherID", systemInfo.GetLauncherID()).
 			Msg("registering RetroDECK launcher")
 
-		launcher := createRetroDECKLauncher(systemFolder, systemInfo, paths)
+		launcher := createRetroDECKLauncher(systemFolder, systemInfo, &paths)
 		result = append(result, launcher)
 	}
 

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -843,12 +843,30 @@ func backupPatternsMatch(rel string, patterns []platforms.BackupPattern) bool {
 		if !strings.Contains(glob, "/") {
 			target = path.Base(lowerRel)
 		}
-		matched, err := path.Match(glob, target)
-		if err == nil && matched {
+		if matchBackupGlob(glob, target) {
 			return true
 		}
 	}
 	return false
+}
+
+func matchBackupGlob(glob, target string) bool {
+	if prefixGlob, found := strings.CutSuffix(glob, "/**"); found {
+		for i := strings.IndexByte(target, '/'); i >= 0; {
+			matched, err := path.Match(prefixGlob, target[:i])
+			if err == nil && matched {
+				return true
+			}
+			next := strings.IndexByte(target[i+1:], '/')
+			if next < 0 {
+				break
+			}
+			i += next + 1
+		}
+		return false
+	}
+	matched, err := path.Match(glob, target)
+	return err == nil && matched
 }
 
 func (m *Manager) resolveBackupPath(name string) (string, error) {

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -880,6 +880,15 @@ func TestZaparooRestorePolicyMirrorsCollector(t *testing.T) {
 	assert.False(t, allowed("auth.toml"))
 }
 
+func TestBackupPatternsRecursiveGlobIsRootAnchored(t *testing.T) {
+	t.Parallel()
+	patterns := []platforms.BackupPattern{{Glob: "*/Documents/**"}}
+	assert.True(t, backupPatternsMatch(filepath.Join("steamuser", "Documents", "Game", "save.dat"), patterns))
+	assert.True(t, backupPatternsMatch(filepath.Join("STEAMUSER", "DOCUMENTS", "save.dat"), patterns))
+	assert.False(t, backupPatternsMatch(filepath.Join("steamuser", "Other", "Documents", "save.dat"), patterns))
+	assert.False(t, backupPatternsMatch(filepath.Join("Documents", "save.dat"), patterns))
+}
+
 func TestManagerCreateInspectRestoreNestedConfigFiles(t *testing.T) {
 	t.Parallel()
 	env := newBackupTestEnv(t, platformids.Mister)

--- a/pkg/service/backup/collector.go
+++ b/pkg/service/backup/collector.go
@@ -157,10 +157,16 @@ func (m *Manager) definitionTrustedRoots(def *platforms.BackupDefinition) []stri
 	if len(def.SourceTrustedRoots) > 0 {
 		return canonicalCategoryRoots(def.SourceTrustedRoots, "")
 	}
+	if def.RestoreTargetRoot != "" {
+		return canonicalCategoryRoots([]string{def.SourceRoot}, "")
+	}
 	return definitionCategoryRoots(def, m.pl.RootDirs(m.cfg))
 }
 
 func definitionCategoryRoots(def *platforms.BackupDefinition, platformRoots []string) []string {
+	if def.RestoreTargetRoot != "" {
+		return canonicalCategoryRoots([]string{def.RestoreTargetRoot}, "")
+	}
 	storageRoots := make([]string, 0, len(platformRoots)+1)
 	if primary, ok := definitionStorageRoot(def); ok {
 		storageRoots = append(storageRoots, primary)
@@ -199,7 +205,7 @@ func canonicalCategoryRoots(storageRoots []string, categoryRoot string) []string
 	canonical := make([]string, 0, len(storageRoots))
 	for _, storageRoot := range storageRoots {
 		resolved, ok := canonicalPathFromExistingAncestor(storageRoot)
-		if !ok {
+		if !ok || filepath.Clean(resolved) == string(filepath.Separator) {
 			continue
 		}
 		root := filepath.Clean(filepath.Join(resolved, categoryRoot))
@@ -283,6 +289,9 @@ func (c *sourceCollector) walk(
 	}
 	if len(filepath.ToSlash(logicalRel)) > maxArchivePathLen {
 		c.warn(spec.definition.Category, "<path-too-long>", "source path exceeds portable limit")
+		return
+	}
+	if logicalRel != "" && backupPatternsMatch(filepath.ToSlash(logicalRel)+"/", spec.definition.Exclude) {
 		return
 	}
 	info, err := os.Lstat(physicalPath)

--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -996,7 +996,7 @@ func (m *Manager) restoreTargetPolicy(file *FileRef) (restorePolicy, error) {
 		}
 		policy := restorePolicy{
 			logical: filepath.Join(root, filepath.FromSlash(file.RestorePath)),
-			roots:   buildRestoreRootPolicies([]string{root}),
+			roots:   buildRestoreRootPolicies([]string{root}, false),
 		}
 		if len(policy.roots) == 0 {
 			return restorePolicy{}, fmt.Errorf("zaparoo restore root is unavailable: %s", root)
@@ -1013,12 +1013,22 @@ func (m *Manager) restoreTargetPolicy(file *FileRef) (restorePolicy, error) {
 		if def.Category != file.Category || !allowedRestorePath(file, []platforms.BackupDefinition{*def}) {
 			continue
 		}
+		logical := filepath.Join(
+			m.platformRestoreRoot(helpers.DataDir(m.pl)), filepath.FromSlash(file.RestorePath),
+		)
+		if def.RestoreTargetRoot != "" {
+			rel := file.RestorePath
+			if restoreRoot := filepath.ToSlash(def.RestoreRoot); restoreRoot != "" {
+				rel = strings.TrimPrefix(file.RestorePath, restoreRoot+"/")
+			}
+			logical = filepath.Join(def.RestoreTargetRoot, filepath.FromSlash(rel))
+		}
 		policy := restorePolicy{
 			definition: def,
-			logical: filepath.Join(
-				m.platformRestoreRoot(helpers.DataDir(m.pl)), filepath.FromSlash(file.RestorePath),
+			logical:    logical,
+			roots: buildRestoreRootPolicies(
+				m.definitionRestoreRootCandidates(def), def.RestoreTargetRoot != "",
 			),
-			roots: buildRestoreRootPolicies(m.definitionRestoreRootCandidates(def)),
 		}
 		if len(policy.roots) == 0 {
 			return restorePolicy{}, fmt.Errorf("restore roots are unavailable for %s", file.RestorePath)
@@ -1041,11 +1051,11 @@ func (m *Manager) isSensitiveRestoreTarget(target string) bool {
 	return false
 }
 
-func buildRestoreRootPolicies(candidates []string) []restoreRootPolicy {
+func buildRestoreRootPolicies(candidates []string, allowCategorySymlink bool) []restoreRootPolicy {
 	seen := make(map[string]struct{}, len(candidates))
 	var policies []restoreRootPolicy
 	for _, candidate := range candidates {
-		for _, policy := range restoreRootPolicyChain(candidate) {
+		for _, policy := range restoreRootPolicyChain(candidate, allowCategorySymlink) {
 			key := policy.root + "\x00" + policy.prefix
 			if _, ok := seen[key]; ok {
 				continue
@@ -1065,7 +1075,7 @@ func buildRestoreRootPolicies(candidates []string) []restoreRootPolicy {
 	return policies
 }
 
-func restoreRootPolicyChain(candidate string) []restoreRootPolicy {
+func restoreRootPolicyChain(candidate string, allowCategorySymlink bool) []restoreRootPolicy {
 	candidate, err := filepath.Abs(candidate)
 	if err != nil {
 		return nil
@@ -1079,9 +1089,9 @@ func restoreRootPolicyChain(candidate string) []restoreRootPolicy {
 		if statErr == nil {
 			resolved := current
 			if info.Mode()&os.ModeSymlink != 0 {
-				if categoryRoot {
-					// The category target must match another independently approved
-					// policy; resolving it here would make any target trusted.
+				if categoryRoot && !allowCategorySymlink {
+					// Implicit category targets must match another independently approved
+					// policy. Explicit platform restore targets may resolve their root.
 					statErr = os.ErrInvalid
 				} else {
 					resolved, statErr = filepath.EvalSymlinks(current)

--- a/pkg/service/backup/steamos_integration_test.go
+++ b/pkg/service/backup/steamos_integration_test.go
@@ -1,0 +1,418 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package backup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	platformids "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/steamos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSteamOSRestorePolicyAcceptsNarrowDynamicPrefixPlan(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.SteamOS)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	basePlatform.definitions = steamos.BackupDefinitions(env.RootDir)
+	env.Manager.pl = backupRestoreRootPlatform{
+		restoreRoot:    env.RootDir,
+		backupPlatform: basePlatform,
+	}
+
+	platformFiles := []FileRef{
+		{Category: CategorySettings, RestorePath: filepath.ToSlash(filepath.Join(
+			".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "Arcade",
+			"bottle.yml",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "Arcade",
+			"drive_c", "users", "steamuser", "Documents", "Game", "save.dat",
+		))},
+		{Category: CategorySettings, RestorePath: filepath.ToSlash(filepath.Join(
+			"Bottles", "custom", "Arcade", "bottle.yml",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			"Bottles", "custom", "Arcade", "drive_c", "users", "steamuser", "Saved Games",
+			"Game", "save.dat",
+		))},
+		{Category: CategorySettings, RestorePath: filepath.ToSlash(filepath.Join(
+			"Faugus", "Game", "pfx", "user.reg",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			"Steam", "nonsteam", "4000000001", "pfx", "drive_c", "users", "steamuser",
+			"AppData", "LocalLow", "Studio", "Game", "save.dat",
+		))},
+	}
+	files := make([]FileRef, 0, 1+len(platformFiles))
+	files = append(files, FileRef{
+		Category: CategoryZaparoo, RestorePath: "user.db", ArchivePath: zaparooArchive("user.db"),
+	})
+	for _, file := range platformFiles {
+		file.ArchivePath = platformArchive(file.RestorePath)
+		files = append(files, file)
+	}
+
+	err := env.Manager.validateManifestPolicy(&Manifest{Platform: platformids.SteamOS, Files: files})
+	require.NoError(t, err)
+}
+
+func TestSteamOSRestorePolicyRejectsBroadPrefixPaths(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.SteamOS)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	basePlatform.definitions = steamos.BackupDefinitions(env.RootDir)
+	env.Manager.pl = backupRestoreRootPlatform{
+		restoreRoot: env.RootDir, backupPlatform: basePlatform,
+	}
+
+	invalid := []FileRef{
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "123456", "pfx", "drive_c",
+			"users", "steamuser", "Documents", "save.dat",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			"Steam", "nonsteam", "123456", "pfx", "drive_c", "users", "steamuser",
+			"Documents", "save.dat",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			"Steam", "nonsteam", "4000000001", "pfx", "drive_c", "users", "steamuser", "Other",
+			"Documents", "save.dat",
+		))},
+		{Category: CategorySettings, RestorePath: filepath.ToSlash(filepath.Join(
+			"Steam", "nonsteam", "4000000001", "pfx", "tracked_files",
+		))},
+		{Category: CategorySaves, RestorePath: filepath.ToSlash(filepath.Join(
+			".var", "app", "com.usebottles.bottles", "data", "bottles", "bottles", "Arcade",
+			"drive_c", "users", "steamuser", "Other", "Documents", "save.dat",
+		))},
+	}
+	for _, file := range invalid {
+		file.ArchivePath = platformArchive(file.RestorePath)
+		manifest := Manifest{Platform: platformids.SteamOS, Files: []FileRef{
+			{Category: CategoryZaparoo, RestorePath: "user.db", ArchivePath: zaparooArchive("user.db")},
+			file,
+		}}
+		err := env.Manager.validateManifestPolicy(&manifest)
+		require.ErrorContains(t, err, "not collected", file.RestorePath)
+	}
+}
+
+func TestSteamOSBackupRestoresCustomEmuDeckTarget(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.SteamOS)
+	customRoot := t.TempDir()
+	customSaves := filepath.Join(customRoot, "saves")
+	settingsPath := filepath.Join(env.RootDir, ".config", "EmuDeck", "settings.sh")
+	writeTestFile(t, settingsPath, "savesPath=\""+customSaves+"\"\n")
+	savePath := filepath.Join(customSaves, "retroarch", "game.srm")
+	writeTestFile(t, savePath, "original\n")
+
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	basePlatform.definitions = steamos.BackupDefinitions(env.RootDir)
+	env.Manager.pl = backupRestoreRootPlatform{
+		restoreRoot: env.RootDir, backupPlatform: basePlatform,
+	}
+
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	staged := stageTestZip(t, info.Path)
+	assert.Contains(t, restorePaths(staged.Manifest.Files), filepath.ToSlash(filepath.Join(
+		"Emulation", "saves", "retroarch", "game.srm",
+	)))
+	writeTestFile(t, savePath, "changed\n")
+	_, err = env.Manager.Restore(context.Background(), info.Name)
+	require.NoError(t, err)
+	data, err := os.ReadFile(savePath) // #nosec G304 -- test-owned temp path.
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(data))
+	_, err = os.Stat(filepath.Join(env.RootDir, "Emulation", "saves", "retroarch", "game.srm"))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestSteamOSBackupRestoresThroughExplicitCategorySymlink(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.SteamOS)
+	target := t.TempDir()
+	link := filepath.Join(env.RootDir, "Emulation", "saves")
+	require.NoError(t, os.MkdirAll(filepath.Dir(link), 0o750))
+	require.NoError(t, os.Symlink(target, link))
+	savePath := filepath.Join(target, "game.srm")
+	writeTestFile(t, savePath, "original\n")
+
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	basePlatform.definitions = steamos.BackupDefinitions(env.RootDir)
+	env.Manager.pl = backupRestoreRootPlatform{
+		restoreRoot: env.RootDir, backupPlatform: basePlatform,
+	}
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	writeTestFile(t, savePath, "changed\n")
+	_, err = env.Manager.Restore(context.Background(), info.Name)
+	require.NoError(t, err)
+	data, err := os.ReadFile(savePath) // #nosec G304 -- test-owned temp path.
+	require.NoError(t, err)
+	assert.Equal(t, "original\n", string(data))
+}
+
+func restorePaths(files []FileRef) map[string]struct{} {
+	result := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		result[file.RestorePath] = struct{}{}
+	}
+	return result
+}
+
+func TestSteamOSBackupRestoresDurableDataAndExcludesReplaceableContent(t *testing.T) {
+	t.Parallel()
+	env := newBackupTestEnv(t, platformids.SteamOS)
+	basePlatform, ok := env.Manager.pl.(backupPlatform)
+	require.True(t, ok)
+	basePlatform.definitions = steamos.BackupDefinitions(env.RootDir)
+	env.Manager.pl = backupRestoreRootPlatform{
+		restoreRoot:    env.RootDir,
+		backupPlatform: basePlatform,
+	}
+
+	durable := map[string]string{
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "saves", "game.srm",
+		): "emulator-save\n",
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "states", "game.state",
+		): "emulator-state\n",
+		filepath.Join("Emulation", "bios", "scph5501.bin"):                 "user-bios\n",
+		filepath.Join("ES-DE", "collections", "custom.cfg"):                "custom-collection\n",
+		filepath.Join(".config", "EmuDeck", "settings.sh"):                 "savesPath=\"/tmp/saves\"\n",
+		filepath.Join(".config", "EmuDeck", "custom_scripts", "custom.sh"): "custom-script\n",
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "retroarch.cfg",
+		): "input-config\n",
+		filepath.Join(
+			".var", "app", "app.xemu.xemu", "data", "xemu", "xemu", "xemu.toml",
+		): "xemu-config\n",
+		filepath.Join(
+			".var", "app", "app.xemu.xemu", "data", "xemu", "xemu", "eeprom.bin",
+		): "xemu-eeprom\n",
+		filepath.Join(
+			".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Config", "Dolphin.ini",
+		): "dolphin-config\n",
+		filepath.Join(
+			".var", "app", "org.DolphinEmu.dolphin-emu", "config", "dolphin-emu", "Profiles",
+			"GCPad", "custom.ini",
+		): "dolphin-profile\n",
+		filepath.Join(
+			".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Wii", "title",
+			"00010000", "52534d45", "data", "save.dat",
+		): "dolphin-wii-save\n",
+		filepath.Join(
+			".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "GBA", "Saves",
+			"game.sav",
+		): "dolphin-gba-save\n",
+		filepath.Join(
+			".var", "app", "rs.ruffle.Ruffle", "data", "ruffle", "SharedObjects", "game.sol",
+		): "ruffle-save\n",
+		filepath.Join(
+			".var", "app", "org.mamedev.MAME", ".mame", "nvram", "game", "nvram",
+		): "mame-nvram\n",
+		filepath.Join(".kodi", "userdata", "Database", "MyVideos131.db"): "kodi-library\n",
+		filepath.Join(
+			".config", "Moonlight Game Streaming Project", "Moonlight.conf",
+		): "moonlight-identity\n",
+		filepath.Join(
+			".config", "steam-rom-manager", "userData", "userConfigurations.json",
+		): "custom-parser\n",
+		filepath.Join(
+			".var", "app", "org.citra_emu.citra", "data", "citra-emu", "sdmc", "Nintendo 3DS",
+			"id0", "title", "00040000", "00112233", "data", "00000001.sav",
+		): "citra-save\n",
+		filepath.Join(
+			".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "nand", "data", "id0",
+			"extdata", "00048000", "F000000B", "gamecoin.dat",
+		): "azahar-system-save\n",
+		filepath.Join(
+			".config", "Ryujinx", "bis", "user", "save", "0000000000000001", "save.dat",
+		): "ryujinx-save\n",
+		filepath.Join(
+			".config", "Ryujinx", "bis", "user", "saveMeta", "0000000000000001", "meta.dat",
+		): "ryujinx-save-meta\n",
+		filepath.Join(
+			".var", "app", "io.github.ryubing.Ryujinx", "config", "Ryujinx", "bis", "system", "save",
+			"8000000000000010", "save.dat",
+		): "ryujinx-system-save\n",
+		filepath.Join(".config", "Ryujinx", "system", "prod.keys"): "switch-keys\n",
+		filepath.Join(
+			".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "savestates", "game.SAVESTAT",
+		): "rpcs3-state\n",
+		filepath.Join(
+			".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_hdd0", "savedata", "vmc",
+			"card.VM2",
+		): "rpcs3-memory-card\n",
+		filepath.Join(
+			".var", "app", "net.shadps4.shadPS4", "data", "shadPS4", "home", "1000", "savedata",
+			"CUSA00001", "save.dat",
+		): "shadps4-save\n",
+		filepath.Join(
+			".var", "app", "net.shadps4.shadPS4", "data", "shadPS4", "home", "1000", "inputs",
+			"controller.json",
+		): "shadps4-input\n",
+		filepath.Join(
+			".local", "share", "Steam", "userdata", "123", "config", "shortcuts.vdf",
+		): "shortcuts\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx", "drive_c",
+			"users", "steamuser", "Documents", "NonSteamGame", "save.dat",
+		): "non-steam-save\n",
+		filepath.Join("retrodeck", "saves", "nes", "game.srm"): "retrodeck-save\n",
+	}
+	excluded := map[string]string{
+		filepath.Join("Emulation", "roms", "nes", "game.nes"):                                 "rom\n",
+		filepath.Join("Emulation", "bios", "RetroArch_v1.10.1.zip"):                           "runtime-archive\n",
+		filepath.Join("Emulation", "bios", "RetroArch_v1.10.1", "retroarch"):                  "runtime\n",
+		filepath.Join("Emulation", "bios", "ume", "hash", "software.xml"):                     "runtime-metadata\n",
+		filepath.Join("Emulation", "bios", "PPSSPP", "themes", "default.ini"):                 "runtime-theme\n",
+		filepath.Join("Emulation", "bios", "dolphin-emu", "Sys", "codehandler.bin"):           "runtime-system-data\n",
+		filepath.Join("Emulation", "saves", "retroarch", "saves", "alias.srm"):                "managed-alias\n",
+		filepath.Join(".config", "EmuDeck", "backend", ".git", "objects", "pack", "pack.bin"): "repo\n",
+		filepath.Join(".config", "EmuDeck", "python_virtual_env", "lib", "site.py"):           "venv\n",
+		filepath.Join(
+			"Emulation", "tools", "downloaded_media", "cover.png",
+		): "scraped-media\n",
+		filepath.Join("retrodeck", "roms", "nes", "game.nes"): "retrodeck-rom\n",
+		filepath.Join("retrodeck", "logs", "retrodeck.log"):   "log\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "common", "Game", "game.exe",
+		): "steam-game\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "shadercache", "123", "cache.bin",
+		): "shader-cache\n",
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "cache", "index.bin",
+		): "cache\n",
+		filepath.Join(
+			".var", "app", "org.ppsspp.PPSSPP", "config", "ppsspp", "PSP", "SYSTEM", "DUMP", "log.txt",
+		): "emulator-log\n",
+		filepath.Join(
+			".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "log", "azahar_log.txt",
+		): "emulator-log\n",
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "assets", "menu.png",
+		): "runtime-asset\n",
+		filepath.Join(
+			".var", "app", "org.libretro.RetroArch", "config", "retroarch", "overlays", "border.png",
+		): "border\n",
+		filepath.Join(".kodi", "userdata", "Thumbnails", "a", "cover.jpg"): "kodi-thumbnail\n",
+		filepath.Join(".kodi", "userdata", "Database", "Textures13.db"):    "kodi-texture-cache\n",
+		filepath.Join(
+			".var", "app", "org.citra_emu.citra", "data", "citra-emu", "sdmc", "Nintendo 3DS",
+			"id0", "title", "00040000", "00112233", "content", "game.app",
+		): "installed-cia\n",
+		filepath.Join(
+			".config", "Ryujinx", "bis", "user", "Contents", "registered", "installed.nca",
+		): "installed-switch-content\n",
+		filepath.Join(
+			".var", "app", "org.DolphinEmu.dolphin-emu", "data", "dolphin-emu", "Wii", "title",
+			"00010000", "52534d45", "content", "game.app",
+		): "installed-wii-content\n",
+		filepath.Join(
+			".var", "app", "net.rpcs3.RPCS3", "config", "rpcs3", "dev_hdd0", "game", "TEST12345",
+			"payload.dat",
+		): "installed-ps3-content\n",
+		filepath.Join(
+			".var", "app", "net.shadps4.shadPS4", "data", "shadPS4", "game_data", "CUSA00001",
+			"game.bin",
+		): "installed-ps4-content\n",
+		filepath.Join(
+			".var", "app", "net.retrodeck.retrodeck", "config", "ES-DE", "resources", "splash.svg",
+		): "frontend-runtime-resource\n",
+		filepath.Join(
+			".var", "app", "net.retrodeck.retrodeck", "config", "steam-rom-manager", "userData",
+			"artworkCache.json",
+		): "artwork-cache\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx", "drive_c",
+			"users", "steamuser", "AppData", "Local", "Game", "Cache", "blob.bin",
+		): "windows-cache\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx", "drive_c",
+			"users", "steamuser", "AppData", "Local", "Battle.net", "CachedData.db",
+		): "launcher-cache\n",
+		filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx", "drive_c",
+			"users", "steamuser", "AppData", "Local", "dxvk", "pipeline.dxvk.bin",
+		): "shader-cache\n",
+		filepath.Join(".config", "PCSX2", "themes", "custom", "theme.json"): "theme\n",
+	}
+	for path, contents := range durable {
+		writeTestFile(t, filepath.Join(env.RootDir, path), contents)
+	}
+	for path, contents := range excluded {
+		writeTestFile(t, filepath.Join(env.RootDir, path), contents)
+	}
+
+	info, err := env.Manager.Create(context.Background())
+	require.NoError(t, err)
+	staged := stageTestZip(t, info.Path)
+	byRestorePath := make(map[string]FileRef, len(staged.Manifest.Files))
+	for _, file := range staged.Manifest.Files {
+		byRestorePath[file.RestorePath] = file
+	}
+	for path := range durable {
+		restorePath := path
+		switch path {
+		case filepath.Join(".local", "share", "Steam", "userdata", "123", "config", "shortcuts.vdf"):
+			restorePath = filepath.Join("Steam", "userdata", "123", "config", "shortcuts.vdf")
+		case filepath.Join(
+			".local", "share", "Steam", "steamapps", "compatdata", "4000000001", "pfx", "drive_c",
+			"users", "steamuser", "Documents", "NonSteamGame", "save.dat",
+		):
+			restorePath = filepath.Join(
+				"Steam", "nonsteam", "4000000001", "pfx", "drive_c", "users", "steamuser",
+				"Documents", "NonSteamGame", "save.dat",
+			)
+		}
+		assert.Contains(t, byRestorePath, filepath.ToSlash(restorePath))
+	}
+	for path := range excluded {
+		assert.NotContains(t, byRestorePath, filepath.ToSlash(path))
+	}
+	assert.Equal(t, CategorySaves, byRestorePath[filepath.ToSlash(filepath.Join(
+		".var", "app", "app.xemu.xemu", "data", "xemu", "xemu", "eeprom.bin",
+	))].Category)
+	assert.Equal(t, CategorySaves, byRestorePath[filepath.ToSlash(filepath.Join(
+		".var", "app", "org.azahar_emu.Azahar", "data", "azahar-emu", "nand", "data", "id0",
+		"extdata", "00048000", "F000000B", "gamecoin.dat",
+	))].Category)
+
+	for path := range durable {
+		writeTestFile(t, filepath.Join(env.RootDir, path), "changed\n")
+	}
+	for path := range excluded {
+		writeTestFile(t, filepath.Join(env.RootDir, path), "changed-but-excluded\n")
+	}
+
+	_, err = env.Manager.Restore(context.Background(), info.Name)
+	require.NoError(t, err)
+	for path, expected := range durable {
+		data, readErr := os.ReadFile(filepath.Join(env.RootDir, path)) // #nosec G304 -- test-owned temp path.
+		require.NoError(t, readErr)
+		assert.Equal(t, expected, string(data), path)
+	}
+	for path := range excluded {
+		data, readErr := os.ReadFile(filepath.Join(env.RootDir, path)) // #nosec G304 -- test-owned temp path.
+		require.NoError(t, readErr)
+		assert.Equal(t, "changed-but-excluded\n", string(data), path)
+	}
+}


### PR DESCRIPTION
## Summary

- add portable SteamOS backup coverage for EmuDeck, RetroDECK, emulator saves and firmware, frontends, launchers, and non-Steam prefixes
- preserve destination-specific provider mappings while enforcing path-anchored collection and restore policies
- harden custom-root and symlink handling against broad filesystem traversal and exclude replaceable games, ROMs, runtimes, media, and caches
- add comprehensive backup, restore, discovery, compatibility, and regression coverage

## Validation

- `task test`
- `task lint`
- deployed to a real Steam Deck and audited all 6,018 entries in a successful 1.3 GB backup
- verified every archive hash, 40 durable-data checks, 28 exclusion rules, isolated cross-root restore, UserDB integrity, and fail-closed root-symlink behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SteamOS backup support for emulator data, settings, saves, savestates, non-Steam games, Bottles, Faugus Launcher, Kodi, and Moonlight.
  * Backup and restore paths now adapt to destination-specific EmuDeck and RetroDECK locations.
  * Added discovery of independently configured library, storage, BIOS, saves, and state paths.

* **Bug Fixes**
  * Improved symlink and unsafe-path protection during backup and restore.
  * Recursive backup patterns now match nested paths correctly.
  * Expanded configuration parsing and fallback handling for EmuDeck and RetroDECK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->