### PR TITLE
docs(ota): correct what a SteamOS rollback looks like

### DIFF
--- a/docs/ota-runbook.md
+++ b/docs/ota-runbook.md
@@ -303,10 +303,20 @@ include the 20% manual and 40% automatic thresholds.
 
 ### Steam Deck / SteamOS
 
-Verify checking while charging/discharging, automatic rejection at 39%,
-acceptance at 40%, charger removal after staging but before the immediate
-pre-install check, normal confirmation, and failed-start rollback without a
-supervisor restart loop.
+Verify checking while charging/discharging, automatic rejection below the
+automatic floor, acceptance above it, charger removal after staging but before
+the immediate pre-install check, normal confirmation, and failed-start rollback.
+
+A refused automatic install is silent. Nothing is logged and no marker is
+written, so a device that is simply not installing looks the same as one that
+never checked. Read `update.status`: an update it reports as available on a
+device with `install = true` that stays on its old version is being held by a
+gate, and the battery is the usual reason.
+
+The rollback happens in the same boot, before the process exits, so the user
+unit's `Restart=on-failure` is never triggered and `NRestarts` stays at zero.
+Do not wait for the supervisor to restart the bad build or for a second boot to
+roll it back — neither happens, and watching for them reads as a hang.
 
 ### Batocera
 


### PR DESCRIPTION
Two things the Steam Deck run showed the runbook has wrong, both of which would make an operator misread a working device.

- **The rollback is same-boot.** The matrix said to verify a failed start rolls back "without a supervisor restart loop", which implies watching systemd restart the bad build and counting boots. It never gets that far: the rollback runs inside the process before it exits, so the user unit's `Restart=on-failure` is never triggered and `NRestarts` stays at `0`. Someone waiting for a second boot would read a correct rollback as a hang.
- **A refused automatic install is silent.** `runInstall` returns on `!decision.OK` without logging, so a device held back by the battery gate looks exactly like one that never checked. The section now says to read `update.status` instead.

Observed on the device: `the updated version failed to start, rolling back` → `update rolled back` → re-exec, all within the same second, ending healthy on the previous version with `NRestarts: 0` and `outcome: rolledBack`. Separately, an available update with `install = true` at 34–38% battery sat unin­stalled for the full 900s install window and produced no log line.

Documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Steam Deck and SteamOS validation guidance to use the general automatic-install battery threshold.
  * Clarified that refused automatic installations are silent and leave no log entry or marker.
  * Added guidance for checking update status when installation is held.
  * Documented same-boot rollback behavior and clarified that a supervisor restart or second boot is not expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->