### PR TITLE
fix(mister): map .neo filenames through Neo Geo romsets

### DIFF
--- a/pkg/database/mediascanner/indexing_pipeline_test.go
+++ b/pkg/database/mediascanner/indexing_pipeline_test.go
@@ -506,6 +506,18 @@ func TestGetPathFragments_ProvidedName(t *testing.T) {
 	})
 	assert.Equal(t, "mslug", withoutName.Title, "filename-derived title without ProvidedName")
 
+	// A standalone .neo romset takes the romsets.xml title but keeps its
+	// extension, which is where the extension tag comes from.
+	neoPath := string(filepath.Separator) + filepath.Join("media", "fat", "games", "NEOGEO", "mslug.neo")
+	neoWithName := GetPathFragments(&PathFragmentParams{
+		Path:         neoPath,
+		SystemID:     "NeoGeo",
+		ProvidedName: "Metal Slug",
+	})
+	assert.Equal(t, "Metal Slug", neoWithName.Title, "ProvidedName must be used as .neo title")
+	assert.Equal(t, "metalslug", neoWithName.Slug, ".neo slug must derive from provided name")
+	assert.Equal(t, ".neo", neoWithName.Ext, ".neo extension must be kept for the extension tag")
+
 	// ProvidedName overrides title even when the filename has tag-like
 	// content; tags themselves are still extracted from the filename.
 	tagged := GetPathFragments(&PathFragmentParams{

--- a/pkg/platforms/mister/cores/cores_test.go
+++ b/pkg/platforms/mister/cores/cores_test.go
@@ -253,6 +253,24 @@ func TestPathToMGLDef(t *testing.T) {
 			wantMgl:  Systems["MegaVGMDrive"].Slots[0].Mgl,
 		},
 		{
+			name:     "NeoGeo .neo ROM set",
+			systemID: "NeoGeo",
+			path:     "mslug.neo",
+			wantMgl:  Systems["NeoGeo"].Slots[0].Mgl,
+		},
+		{
+			name:     "NeoGeo uppercase .NEO ROM set",
+			systemID: "NeoGeo",
+			path:     "MSLUG.NEO",
+			wantMgl:  Systems["NeoGeo"].Slots[0].Mgl,
+		},
+		{
+			name:     "NeoGeo .zip has no slot (system hook supplies the file tag)",
+			systemID: "NeoGeo",
+			path:     "mslug.zip",
+			wantErr:  true,
+		},
+		{
 			name:     "No matching extension returns error",
 			systemID: "NES",
 			path:     "unknown.zip",
@@ -478,6 +496,56 @@ func TestLookupCore(t *testing.T) {
 					t.Fatalf("expected a system core, got %+v", got)
 				}
 			}
+		})
+	}
+}
+
+func TestHookNeoGeo(t *testing.T) {
+	t.Parallel()
+
+	fileTag := func(path string) string {
+		return "\t<file delay=\"1\" type=\"f\" index=\"1\" path=\"../../../../.." + path + "\"/>\n"
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "zip romset gets file tag",
+			path: "/media/fat/games/NEOGEO/mslug.zip",
+			want: fileTag("/media/fat/games/NEOGEO/mslug.zip"),
+		},
+		{
+			name: "uppercase zip romset gets file tag",
+			path: "/media/fat/games/NEOGEO/MSLUG.ZIP",
+			want: fileTag("/media/fat/games/NEOGEO/MSLUG.ZIP"),
+		},
+		{
+			name: "extracted romset folder gets file tag",
+			path: "/media/fat/games/NEOGEO/mslug",
+			want: fileTag("/media/fat/games/NEOGEO/mslug"),
+		},
+		{
+			name: "neo file falls through to the core slot",
+			path: "/media/fat/games/NEOGEO/mslug.neo",
+			want: "",
+		},
+		{
+			name: "uppercase neo file falls through to the core slot",
+			path: "/media/fat/games/NEOGEO/MSLUG.NEO",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := hookNeoGeo(nil, nil, tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/platforms/mister/custom_scanners_test.go
+++ b/pkg/platforms/mister/custom_scanners_test.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -455,13 +456,27 @@ func findAmigaLauncher(t *testing.T, launchers []platforms.Launcher) *platforms.
 func findNeoGeoLauncher(t *testing.T, launchers []platforms.Launcher) *platforms.Launcher {
 	t.Helper()
 
+	return findLauncherByID(t, launchers, systemdefs.SystemNeoGeo)
+}
+
+func findLauncherByID(t *testing.T, launchers []platforms.Launcher, id string) *platforms.Launcher {
+	t.Helper()
+
 	for i := range launchers {
-		if launchers[i].ID == "NeoGeo" {
+		if launchers[i].ID == id {
 			return &launchers[i]
 		}
 	}
-	require.FailNow(t, "NeoGeo launcher should exist")
+	require.FailNow(t, "launcher should exist", "id: %s", id)
 	return nil
+}
+
+func scanResultPaths(results []platforms.ScanResult) []string {
+	paths := make([]string, 0, len(results))
+	for _, r := range results {
+		paths = append(paths, r.Path)
+	}
+	return paths
 }
 
 func writeAmigaVisionInstall(t *testing.T, path, game string) {
@@ -626,6 +641,312 @@ func TestNeoGeoScanner_HandlesMalformedRomsets(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []platforms.ScanResult{{Path: contentPath}}, results)
+}
+
+func TestApplyNeoGeoRomsetNames(t *testing.T) {
+	t.Parallel()
+
+	neoGeoPath := filepath.Join(string(filepath.Separator), "media", "fat", "games", "NEOGEO")
+	names := map[string]string{
+		"mslug":      "Metal Slug",
+		"mslugalias": "Metal Slug",
+		"kof98":      "King of Fighters '98",
+	}
+	rootNeo := filepath.Join(neoGeoPath, "mslug.neo")
+
+	tests := []struct {
+		romsets   map[string]string
+		name      string
+		input     []platforms.ScanResult
+		want      []platforms.ScanResult
+		wantNamed int
+	}{
+		{
+			name:      "root neo file",
+			romsets:   names,
+			input:     []platforms.ScanResult{{Path: rootNeo}},
+			want:      []platforms.ScanResult{{Path: rootNeo, Name: "Metal Slug"}},
+			wantNamed: 1,
+		},
+		{
+			name:    "nested neo file",
+			romsets: names,
+			input: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "Favorites", "collection", "kof98.neo")},
+			},
+			want: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "Favorites", "collection", "kof98.neo"), Name: "King of Fighters '98"},
+			},
+			wantNamed: 1,
+		},
+		{
+			name:    "neo file inside collection zip",
+			romsets: names,
+			input:   []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "collection.zip", "mslug.neo")}},
+			want: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "collection.zip", "mslug.neo"), Name: "Metal Slug"},
+			},
+			wantNamed: 1,
+		},
+		{
+			name:    "mixed case extension and romset id",
+			romsets: names,
+			input: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "MSLUG.NEO")},
+				{Path: filepath.Join(neoGeoPath, "Kof98.Neo")},
+			},
+			want: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "MSLUG.NEO"), Name: "Metal Slug"},
+				{Path: filepath.Join(neoGeoPath, "Kof98.Neo"), Name: "King of Fighters '98"},
+			},
+			wantNamed: 2,
+		},
+		{
+			name:      "alias romset id",
+			romsets:   names,
+			input:     []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "mslugalias.neo")}},
+			want:      []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "mslugalias.neo"), Name: "Metal Slug"}},
+			wantNamed: 1,
+		},
+		{
+			name:    "unknown romset id is left alone",
+			romsets: names,
+			input:   []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "homebrew.neo")}},
+			want:    []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "homebrew.neo")}},
+		},
+		{
+			name:    "multi-dot stem is not a romset id",
+			romsets: names,
+			input:   []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "mslug.v2.neo")}},
+			want:    []platforms.ScanResult{{Path: filepath.Join(neoGeoPath, "mslug.v2.neo")}},
+		},
+		{
+			name:    "existing name is kept",
+			romsets: names,
+			input:   []platforms.ScanResult{{Path: rootNeo, Name: "Custom"}},
+			want:    []platforms.ScanResult{{Path: rootNeo, Name: "Custom"}},
+		},
+		{
+			name:    "non-neo entries are untouched",
+			romsets: names,
+			input: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "mslug.zip")},
+				{Path: filepath.Join(neoGeoPath, "mslug")},
+				{Path: filepath.Join(neoGeoPath, "mslug.zip", "crom0")},
+			},
+			want: []platforms.ScanResult{
+				{Path: filepath.Join(neoGeoPath, "mslug.zip")},
+				{Path: filepath.Join(neoGeoPath, "mslug")},
+				{Path: filepath.Join(neoGeoPath, "mslug.zip", "crom0")},
+			},
+		},
+		{
+			name:    "duplicate paths are both named",
+			romsets: names,
+			input:   []platforms.ScanResult{{Path: rootNeo}, {Path: rootNeo}},
+			want: []platforms.ScanResult{
+				{Path: rootNeo, Name: "Metal Slug"},
+				{Path: rootNeo, Name: "Metal Slug"},
+			},
+			wantNamed: 2,
+		},
+		{
+			name:    "empty romsets",
+			romsets: map[string]string{},
+			input:   []platforms.ScanResult{{Path: rootNeo}},
+			want:    []platforms.ScanResult{{Path: rootNeo}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			results := append([]platforms.ScanResult(nil), tt.input...)
+			named := applyNeoGeoRomsetNames(results, tt.romsets)
+			assert.Equal(t, tt.wantNamed, named)
+			assert.Equal(t, tt.want, results)
+		})
+	}
+}
+
+func TestNeoGeoScanner_MapsNeoFilesThroughRomsets(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	favoritesPath := filepath.Join(neoGeoPath, "Favorites")
+	collectionPath := filepath.Join(favoritesPath, "collection")
+	rootNeoPath := filepath.Join(neoGeoPath, "mslug.neo")
+	nestedNeoPath := filepath.Join(favoritesPath, "KOF98.NEO")
+	unknownNeoPath := filepath.Join(collectionPath, "homebrew.neo")
+	zipNeoPath := filepath.Join(neoGeoPath, "collection.zip", "samshoalias.neo")
+	zipPath := filepath.Join(neoGeoPath, "mslug.zip")
+	folderPath := filepath.Join(neoGeoPath, "kof98")
+
+	require.NoError(t, os.MkdirAll(collectionPath, 0o700))
+	require.NoError(t, os.MkdirAll(folderPath, 0o700))
+	require.NoError(t, os.WriteFile(rootNeoPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(nestedNeoPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(unknownNeoPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(folderPath, "crom0"), []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(`<?xml version="1.0"?>
+<romsets>
+  <romset name="mslug" altname="Metal Slug"/>
+  <romset name="kof98" altname="King of Fighters '98"/>
+  <romset name="samsho,samshoalias" altname="Samurai Shodown"/>
+</romsets>
+`), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	p := NewPlatform()
+	neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+	// Mirrors what the filesystem walk hands the scanner: .neo files at any
+	// depth (including inside a collection zip), romset contents, and the
+	// same path twice from overlapping roots.
+	initial := []platforms.ScanResult{
+		{Path: rootNeoPath},
+		{Path: nestedNeoPath},
+		{Path: unknownNeoPath},
+		{Path: zipNeoPath},
+		{Path: filepath.Join(folderPath, "kof98.neo")},
+		{Path: filepath.Join(zipPath, "crom0")},
+		{Path: filepath.Join(folderPath, "crom0")},
+		{Path: rootNeoPath},
+	}
+
+	results, err := neoGeoLauncher.Scanner(context.Background(), cfg, systemdefs.SystemNeoGeo, initial)
+	require.NoError(t, err)
+
+	assert.Contains(t, results, platforms.ScanResult{Path: rootNeoPath, Name: "Metal Slug"})
+	assert.Contains(t, results, platforms.ScanResult{Path: nestedNeoPath, Name: "King of Fighters '98"})
+	assert.Contains(t, results, platforms.ScanResult{Path: zipNeoPath, Name: "Samurai Shodown"})
+	assert.Contains(t, results, platforms.ScanResult{Path: unknownNeoPath})
+	assert.Contains(t, results, platforms.ScanResult{Path: zipPath, Name: "Metal Slug", NoExt: true})
+	assert.Contains(t, results, platforms.ScanResult{Path: folderPath, Name: "King of Fighters '98", NoExt: true})
+
+	paths := scanResultPaths(results)
+	assert.NotContains(t, paths, filepath.Join(folderPath, "kof98.neo"))
+	assert.NotContains(t, paths, filepath.Join(zipPath, "crom0"))
+	assert.NotContains(t, paths, filepath.Join(folderPath, "crom0"))
+
+	rootNeoEntries := 0
+	for _, r := range results {
+		if r.Path != rootNeoPath {
+			continue
+		}
+		rootNeoEntries++
+		assert.Equal(t, "Metal Slug", r.Name)
+		assert.False(t, r.NoExt, ".neo entries keep their extension")
+	}
+	assert.Equal(t, 2, rootNeoEntries, "duplicate .neo paths are both named; the indexer coalesces them")
+}
+
+func TestNeoGeoScanner_LeavesNeoFilesUnmappedWithoutRomsets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		romsets string
+	}{
+		{name: "missing romsets.xml"},
+		{name: "invalid romsets.xml", romsets: "<romsets>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			neoGeoPath := filepath.Join(root, "NEOGEO")
+			neoPath := filepath.Join(neoGeoPath, "mslug.neo")
+			zipNeoPath := filepath.Join(neoGeoPath, "collection.zip", "mslug.neo")
+			require.NoError(t, os.MkdirAll(neoGeoPath, 0o700))
+			require.NoError(t, os.WriteFile(neoPath, []byte("test"), 0o600))
+			if tt.romsets != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(tt.romsets), 0o600))
+			}
+
+			cfg, err := config.NewConfig(t.TempDir(), config.Values{
+				Launchers: config.Launchers{
+					IndexRoot: []string{root},
+				},
+			})
+			require.NoError(t, err)
+
+			p := NewPlatform()
+			neoGeoLauncher := findNeoGeoLauncher(t, p.Launchers(cfg))
+			initial := []platforms.ScanResult{{Path: neoPath}, {Path: zipNeoPath}}
+
+			results, err := neoGeoLauncher.Scanner(context.Background(), cfg, systemdefs.SystemNeoGeo, initial)
+			require.NoError(t, err)
+
+			assert.Equal(t, initial, results)
+		})
+	}
+}
+
+func TestNeoGeoScanner_SharesMappedNeoWithMVS(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	neoPath := filepath.Join(neoGeoPath, "mslug.neo")
+	require.NoError(t, os.MkdirAll(neoGeoPath, 0o700))
+	require.NoError(t, os.WriteFile(neoPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "romsets.xml"), []byte(`<?xml version="1.0"?>
+<romsets>
+  <romset name="mslug" altname="Metal Slug"/>
+</romsets>
+`), 0o600))
+
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Launchers: config.Launchers{
+			IndexRoot: []string{root},
+		},
+	})
+	require.NoError(t, err)
+
+	// Both launchers must come from the same Launchers call to share a cache.
+	launchers := NewPlatform().Launchers(cfg)
+	neoGeoLauncher := findNeoGeoLauncher(t, launchers)
+	mvsLauncher := findLauncherByID(t, launchers, systemdefs.SystemNeoGeoMVS)
+
+	results, err := neoGeoLauncher.Scanner(
+		context.Background(), cfg, systemdefs.SystemNeoGeo, []platforms.ScanResult{{Path: neoPath}},
+	)
+	require.NoError(t, err)
+	assert.Contains(t, results, platforms.ScanResult{Path: neoPath, Name: "Metal Slug"})
+
+	mvsResults, err := mvsLauncher.Scanner(context.Background(), cfg, systemdefs.SystemNeoGeoMVS, nil)
+	require.NoError(t, err)
+	assert.Equal(t, results, mvsResults)
+}
+
+func TestCollectNeoGeoRomsetEntries_IgnoresNeoFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	neoGeoPath := filepath.Join(root, "NEOGEO")
+	zipPath := filepath.Join(neoGeoPath, "mslug.zip")
+	require.NoError(t, os.MkdirAll(neoGeoPath, 0o700))
+	require.NoError(t, os.WriteFile(zipPath, []byte("test"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(neoGeoPath, "mslug.neo"), []byte("test"), 0o600))
+
+	romsets := map[string]string{"mslug": "Metal Slug"}
+	entries, err := collectNeoGeoRomsetEntries(
+		context.Background(), afero.NewOsFs(), neoGeoPath, romsets, make(map[string]struct{}),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []platforms.ScanResult{{Path: zipPath, Name: "Metal Slug", NoExt: true}}, entries)
 }
 
 func TestCollectNeoGeoRomsetEntries_DeduplicatesOverlappingRoots(t *testing.T) {

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -49,6 +49,7 @@ func TestCheckInZip_NonZipPath(t *testing.T) {
 		"/path/to/game.rom",
 		"/path/to/game.bin",
 		"/path/to/game.ZIP.backup",
+		"/media/fat/games/NEOGEO/mslug.neo",
 		"",
 	}
 

--- a/pkg/platforms/mister/mgls/mgls_test.go
+++ b/pkg/platforms/mister/mgls/mgls_test.go
@@ -666,3 +666,30 @@ func TestGenerateMgl_NoMatchingSlot(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no matching mgl args")
 }
+
+// A romset-mapped .neo file is launched by its unchanged path, so it must
+// produce the same MGL file tag as the equivalent .zip romset: .neo via the
+// core's ROM set slot, .zip via the NeoGeo system hook.
+func TestGenerateMgl_NeoGeoNeoMatchesZip(t *testing.T) {
+	t.Parallel()
+
+	core := cores.Systems["NeoGeo"]
+	paths := []string{
+		"/media/fat/games/NEOGEO/mslug.neo",
+		"/media/fat/games/NEOGEO/MSLUG.NEO",
+		"/media/fat/games/NEOGEO/mslug.zip",
+	}
+
+	for _, path := range paths {
+		override, err := cores.RunSystemHook(nil, &core, path)
+		require.NoError(t, err, path)
+
+		mgl, err := GenerateMgl(&core, core.RBF, path, override)
+		require.NoError(t, err, path)
+
+		want := "<mistergamedescription>\n\t<rbf>_Console/NeoGeo</rbf>\n" +
+			"\t<file delay=\"1\" type=\"f\" index=\"1\" path=\"../../../../.." + path + "\"/>\n" +
+			"</mistergamedescription>"
+		assert.Equal(t, want, mgl, path)
+	}
+}

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1109,6 +1109,8 @@ func collectNeoGeoRomsetEntries(
 		if isZip {
 			candidateID = strings.TrimSuffix(lowerBase, filepath.Ext(lowerBase))
 		} else if !isDirectory {
+			// Plain files such as .neo are already in the walked results;
+			// applyNeoGeoRomsetNames names those in place.
 			return nil
 		}
 
@@ -1191,6 +1193,33 @@ func filterNeoGeoGameContents(
 		filtered = append(filtered, r)
 	}
 	return filtered
+}
+
+// applyNeoGeoRomsetNames sets Name on .neo results whose filename stem
+// matches a romsets.xml entry, so a standalone mslug.neo gets the same
+// title as mslug.zip. It must run after filterNeoGeoGameContents so .neo
+// files inside romset zips and folders are already gone. NoExt is left
+// false so the extension tag is kept, and Path is never changed. Results
+// are updated in place; the return value is the number of entries named.
+func applyNeoGeoRomsetNames(results []platforms.ScanResult, romsetNames map[string]string) int {
+	named := 0
+	for i := range results {
+		if results[i].Name != "" {
+			continue
+		}
+		base := filepath.Base(results[i].Path)
+		ext := filepath.Ext(base)
+		if !strings.EqualFold(ext, ".neo") {
+			continue
+		}
+		altName, ok := romsetNames[strings.ToLower(strings.TrimSuffix(base, ext))]
+		if !ok {
+			continue
+		}
+		results[i].Name = altName
+		named++
+	}
+	return named
 }
 
 // filterNeoGeoZipToNeoOnly filters results when no romsets.xml is available.
@@ -1578,6 +1607,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 			log.Info().Msg("starting neogeo scan")
 			inputResultCount := len(results)
 			filteredResultCount := 0
+			namedResultCount := 0
 			addedResultCount := 0
 			romsetDefinitionCount := 0
 			romsetsFilename := "romsets.xml"
@@ -1636,6 +1666,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 				results = filterNeoGeoZipToNeoOnly(results)
 			} else {
 				results = filterNeoGeoGameContents(results, names, neogeoPaths)
+				namedResultCount = applyNeoGeoRomsetNames(results, names)
 			}
 			if removed := resultsBeforeFilter - len(results); removed > 0 {
 				filteredResultCount = removed
@@ -1671,7 +1702,7 @@ func (p *Platform) Launchers(cfg *config.Instance) []platforms.Launcher {
 
 			log.Debug().Int("roots", len(sfs)).Int("romsets", romsetDefinitionCount).
 				Int("aliases", len(names)).Int("input", inputResultCount).Int("filtered", filteredResultCount).
-				Int("added", addedResultCount).Int("results", len(results)).
+				Int("named", namedResultCount).Int("added", addedResultCount).Int("results", len(results)).
 				Msg("neogeo scan completed")
 
 			return results, nil


### PR DESCRIPTION
- The Neo Geo scanner now names standalone `.neo` scan results from `romsets.xml`, so `mslug.neo` gets the same title as `mslug.zip`. Naming runs after the romset content filter and only sets `Name`; `Path` and `NoExt` are unchanged, so the file launches as before and keeps its extension tag.
- Applies to `.neo` files at the NEOGEO root, in nested folders, and inside collection zips. The extension and romset ID match case-insensitively, including comma-separated aliases.
- Zip and extracted-folder handling, the missing or invalid `romsets.xml` fallback, the Neo Geo MVS shared scanner cache, and the launch path are unchanged.
- Adds scanner, system hook, and MGL tests covering the mapping, the fallback, MVS sharing, and `.neo`/`.zip` launch parity.

Closes #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - NeoGeo `.neo` files are now recognized and labeled using matching alternate names from the ROM database.
  - Named NeoGeo games appear consistently across NeoGeo and MVS libraries, including nested and mixed-case paths.
  - Standalone `.neo` files retain their correct file extension and launch behavior.
  - NeoGeo `.neo` and `.zip` formats now generate equivalent launch metadata for consistent gameplay.

- **Bug Fixes**
  - Unmapped or malformed ROM database entries no longer produce incorrect game names.
  - Duplicate and embedded ROM entries are filtered from collected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->