### PR TITLE
fix(mister): skip Arcade Organizer output written into _Arcade

### DIFF
--- a/pkg/database/mediascanner/arcade_organizer_test.go
+++ b/pkg/database/mediascanner/arcade_organizer_test.go
@@ -1,0 +1,206 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldSkipSymlinkAlias_Skip(t *testing.T) {
+	t.Parallel()
+
+	skip, err := shouldSkipSymlinkAlias(context.Background(), func() (bool, error) { return true, nil })
+	require.NoError(t, err)
+	assert.True(t, skip)
+}
+
+func TestShouldSkipSymlinkAlias_FsTimeout(t *testing.T) {
+	t.Parallel()
+
+	skip, err := shouldSkipSymlinkAlias(context.Background(), func() (bool, error) {
+		return false, fmt.Errorf("stale mount: %w", ErrFsTimeout)
+	})
+	require.NoError(t, err)
+	assert.True(t, skip, "a timed-out readlink must not hand the link back to fastwalk's untimed stat")
+}
+
+func TestShouldSkipSymlinkAlias_OtherError(t *testing.T) {
+	t.Parallel()
+
+	skip, err := shouldSkipSymlinkAlias(context.Background(), func() (bool, error) {
+		return false, os.ErrNotExist
+	})
+	require.NoError(t, err)
+	assert.False(t, skip, "an unreadable link keeps its ordinary handling")
+}
+
+func TestShouldSkipSymlinkAlias_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	skip, err := shouldSkipSymlinkAlias(ctx, func() (bool, error) {
+		return false, fmt.Errorf("stale mount: %w", ErrFsTimeout)
+	})
+	assert.False(t, skip)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// installArcadeOrganizerLauncher swaps in a launcher cache holding a MiSTer
+// style Arcade launcher rooted at rootDir and returns the matching platform.
+// The caller must not run in parallel: the global launcher cache is shared.
+func installArcadeOrganizerLauncher(t *testing.T, cfg *config.Instance, rootDir string) *mocks.MockPlatform {
+	t.Helper()
+
+	launcher := platforms.Launcher{
+		ID:                       "arcade-launcher",
+		SystemID:                 systemdefs.SystemArcade,
+		Folders:                  []string{"_Arcade"},
+		Extensions:               []string{".mra"},
+		ScanDirectoryExcludes:    []string{"_Organized", "_1 A-E", "_3 Collections"},
+		ScanSkipInternalSymlinks: true,
+	}
+
+	platform := mocks.NewMockPlatform()
+	platform.On("ID").Return("test-platform")
+	platform.On("Settings").Return(platforms.Settings{})
+	platform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir})
+	platform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{launcher})
+
+	testLauncherCacheMutex.Lock()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.Initialize(platform, cfg)
+	helpers.GlobalLauncherCache = testCache
+	t.Cleanup(func() {
+		helpers.GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	})
+	return platform
+}
+
+func TestGetFiles_SkipsArcadeOrganizerInPlace(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	arcadeDir := filepath.Join(rootDir, "_Arcade")
+	externalDir := filepath.Join(rootDir, "external")
+	require.NoError(t, os.MkdirAll(filepath.Join(arcadeDir, "_alternatives"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(arcadeDir, "_Arcade Offset"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(arcadeDir, "_favorites"), 0o750))
+	require.NoError(t, os.MkdirAll(externalDir, 0o750))
+
+	canonicalPath := filepath.Join(arcadeDir, "Pooyan.mra")
+	alternativePath := filepath.Join(arcadeDir, "_alternatives", "Pooyan (alt).mra")
+	offsetPath := filepath.Join(arcadeDir, "_Arcade Offset", "Pooyan (fix).mra")
+	externalTarget := filepath.Join(externalDir, "External.mra")
+	for _, path := range []string{canonicalPath, alternativePath, offsetPath, externalTarget} {
+		require.NoError(t, os.WriteFile(path, []byte("<misterromdescription/>"), 0o600))
+	}
+
+	// Organizer category folders written straight into _Arcade (ORGDIR=_Arcade).
+	platformDir := filepath.Join(arcadeDir, "_3 Collections", "_1 By Platform", "_Konami")
+	require.NoError(t, os.MkdirAll(filepath.Join(arcadeDir, "_1 A-E"), 0o750))
+	require.NoError(t, os.MkdirAll(platformDir, 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(arcadeDir, "_Organized", "_1 A-E"), 0o750))
+	categoryAlias := filepath.Join(arcadeDir, "_1 A-E", "Pooyan.mra")
+	platformAlias := filepath.Join(platformDir, "Pooyan.mra")
+	organizedAlias := filepath.Join(arcadeDir, "_Organized", "_1 A-E", "Pooyan.mra")
+	for _, alias := range []string{categoryAlias, platformAlias, organizedAlias} {
+		require.NoError(t, os.Symlink(canonicalPath, alias))
+	}
+	// TOPDIR adds directory symlinks at the Organizer root; PREPEND_YEAR adds a
+	// second file symlink per game.
+	topdirLink := filepath.Join(arcadeDir, "_Konami")
+	require.NoError(t, os.Symlink(platformDir, topdirLink))
+	yearAlias := filepath.Join(arcadeDir, "}82 Pooyan.mra")
+	require.NoError(t, os.Symlink(canonicalPath, yearAlias))
+	// Hand-made aliases with relative and dangling internal targets.
+	relativeAlias := filepath.Join(arcadeDir, "_favorites", "Pooyan.mra")
+	require.NoError(t, os.Symlink(filepath.Join("..", "Pooyan.mra"), relativeAlias))
+	brokenAlias := filepath.Join(arcadeDir, "Missing.mra")
+	require.NoError(t, os.Symlink(filepath.Join(arcadeDir, "missing.mra"), brokenAlias))
+	// A loop back to the parent and a link to media outside the scan root.
+	require.NoError(t, os.Symlink("..", filepath.Join(arcadeDir, "_loop")))
+	externalAlias := filepath.Join(arcadeDir, "External.mra")
+	require.NoError(t, os.Symlink(externalTarget, externalAlias))
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+	platform := installArcadeOrganizerLauncher(t, cfg, rootDir)
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemArcade, arcadeDir, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{canonicalPath, alternativePath, offsetPath, externalAlias}, files)
+
+	matcher := helpers.NewLauncherMatcher(cfg, platform)
+	for _, alias := range []string{
+		categoryAlias, platformAlias, organizedAlias, yearAlias, relativeAlias,
+		filepath.Join(topdirLink, "Pooyan.mra"),
+	} {
+		assert.True(t, matcher.MatchSystemFile(systemdefs.SystemArcade, alias),
+			"organizer alias %s must remain directly launchable", alias)
+	}
+}
+
+func TestGetFiles_IgnoresArcadeOrganizerSibling(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	arcadeDir := filepath.Join(rootDir, "_Arcade")
+	coresDir := filepath.Join(arcadeDir, "cores")
+	require.NoError(t, os.MkdirAll(coresDir, 0o750))
+	canonicalPath := filepath.Join(arcadeDir, "Pooyan.mra")
+	require.NoError(t, os.WriteFile(canonicalPath, []byte("<misterromdescription/>"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(coresDir, "Pooyan_20240101.rbf"), []byte("rbf"), 0o600))
+
+	// ORGDIR=/media/fat/_Arcade Organized: a sibling tree plus a cores symlink.
+	siblingDir := filepath.Join(rootDir, "_Arcade Organized")
+	require.NoError(t, os.MkdirAll(filepath.Join(siblingDir, "_1 A-E"), 0o750))
+	siblingAlias := filepath.Join(siblingDir, "_1 A-E", "Pooyan.mra")
+	require.NoError(t, os.Symlink(canonicalPath, siblingAlias))
+	require.NoError(t, os.Symlink(coresDir, filepath.Join(siblingDir, "cores")))
+
+	fs := testhelpers.NewMemoryFS()
+	cfg, err := testhelpers.NewTestConfig(fs, t.TempDir())
+	require.NoError(t, err)
+	platform := installArcadeOrganizerLauncher(t, cfg, rootDir)
+
+	matcher := helpers.NewLauncherMatcher(cfg, platform)
+	assert.False(t, matcher.MatchSystemFileForScan(systemdefs.SystemArcade, siblingAlias),
+		"a folder whose name merely starts with _Arcade is not part of the Arcade scan root")
+
+	files, err := GetFiles(context.Background(), cfg, platform, systemdefs.SystemArcade, arcadeDir, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{canonicalPath}, files)
+}

--- a/pkg/database/mediascanner/arcade_organizer_test.go
+++ b/pkg/database/mediascanner/arcade_organizer_test.go
@@ -77,6 +77,21 @@ func TestShouldSkipSymlinkAlias_ContextCancellation(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+// A link read that lands after cancellation still answers. Returning that
+// answer let the walk carry on as though nothing had been interrupted, and a
+// cancellation during the final entry then reported a partial scan as complete.
+func TestShouldSkipSymlinkAlias_CancelledDuringSuccessfulCheck(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	skip, err := shouldSkipSymlinkAlias(ctx, func() (bool, error) {
+		cancel()
+		return true, nil
+	})
+	assert.False(t, skip)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 // installArcadeOrganizerLauncher swaps in a launcher cache holding a MiSTer
 // style Arcade launcher rooted at rootDir and returns the matching platform.
 // The caller must not run in parallel: the global launcher cache is shared.

--- a/pkg/database/mediascanner/fsutil.go
+++ b/pkg/database/mediascanner/fsutil.go
@@ -113,6 +113,14 @@ func lstatWithContext(ctx context.Context, path string) (os.FileInfo, error) {
 	}, "lstat", path)
 }
 
+// readlinkWithContext runs os.Readlink with a timeout. Same timeout and
+// cancellation semantics as statWithContext.
+func readlinkWithContext(ctx context.Context, path string) (string, error) {
+	return doWithTimeout(ctx, func() (string, error) {
+		return os.Readlink(path)
+	}, "readlink", path)
+}
+
 // evalSymlinksWithContext runs filepath.EvalSymlinks with a timeout. Same
 // timeout and cancellation semantics as statWithContext.
 func evalSymlinksWithContext(ctx context.Context, path string) (string, error) {

--- a/pkg/database/mediascanner/fsutil_readlink_test.go
+++ b/pkg/database/mediascanner/fsutil_readlink_test.go
@@ -1,0 +1,56 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadlinkWithContext_Success(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o600))
+	link := filepath.Join(dir, "link")
+	require.NoError(t, os.Symlink(target, link))
+
+	resolved, err := readlinkWithContext(context.Background(), link)
+	require.NoError(t, err)
+	assert.Equal(t, target, resolved)
+}
+
+func TestReadlinkWithContext_NotSymlink(t *testing.T) {
+	_, err := readlinkWithContext(context.Background(), t.TempDir())
+	require.Error(t, err)
+}
+
+func TestReadlinkWithContext_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := readlinkWithContext(ctx, t.TempDir())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -708,6 +708,26 @@ func shouldSkipExcludedSymlink(
 	return false, nil
 }
 
+// shouldSkipSymlinkAlias reports whether a symlink must be kept out of the
+// walk because it aliases media already scanned under its target path. A
+// timeout while reading the link leaves its target unknown, but letting
+// fastwalk continue would immediately repeat the blocking call without a
+// timeout, so the link is skipped. Any other read error keeps the link in the
+// walk so ordinary handling applies. Context cancellation takes precedence.
+func shouldSkipSymlinkAlias(ctx context.Context, check func() (bool, error)) (bool, error) {
+	skip, err := check()
+	if err == nil {
+		return skip, nil
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return false, ctxErr
+	}
+	if errors.Is(err, ErrFsTimeout) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // GetFiles searches for all valid games in a given path and returns a list of
 // files. Uses fastwalk for parallel directory traversal with built-in symlink
 // cycle detection. Deep searches .zip files when ZipsAsDirs is enabled.
@@ -727,6 +747,7 @@ func GetFiles(
 	var entriesScanned atomic.Int64
 	var symlinksEncountered atomic.Int64
 	var directoriesExcluded atomic.Int64
+	var symlinkAliasesSkipped atomic.Int64
 	walkStartTime := time.Now()
 
 	var mu syncutil.Mutex
@@ -782,6 +803,25 @@ func GetFiles(
 					Str("system", systemID).
 					Str("path", p).
 					Msg("skipping launcher-excluded scan directory")
+				return filepath.SkipDir
+			}
+		}
+
+		if isSymlink {
+			skip, skipErr := shouldSkipSymlinkAlias(ctx, func() (bool, error) {
+				return matcher.ShouldSkipScanSymlink(system.ID, p, func() (string, error) {
+					return readlinkWithContext(ctx, p)
+				})
+			})
+			if skipErr != nil {
+				return skipErr
+			}
+			if skip {
+				symlinkAliasesSkipped.Add(1)
+				log.Debug().
+					Str("system", systemID).
+					Str("path", p).
+					Msg("skipping symlink alias of scanned media")
 				return filepath.SkipDir
 			}
 		}
@@ -879,6 +919,7 @@ func GetFiles(
 		Int64("entriesScanned", scanned).
 		Int64("symlinksEncountered", symlinksEncountered.Load()).
 		Int64("directoriesExcluded", directoriesExcluded.Load()).
+		Int64("symlinkAliasesSkipped", symlinkAliasesSkipped.Load()).
 		Int("filesFound", len(results)).
 		Dur("elapsed", walkElapsed).
 		Msg("completed directory walk")

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -716,11 +716,14 @@ func shouldSkipExcludedSymlink(
 // walk so ordinary handling applies. Context cancellation takes precedence.
 func shouldSkipSymlinkAlias(ctx context.Context, check func() (bool, error)) (bool, error) {
 	skip, err := check()
-	if err == nil {
-		return skip, nil
-	}
+	// Checked before the success return too: a link read that lands after
+	// cancellation still answers, and returning it would let the walk carry on
+	// as though nothing had been interrupted.
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return false, ctxErr
+	}
+	if err == nil {
+		return skip, nil
 	}
 	if errors.Is(err, ErrFsTimeout) {
 		return true, nil
@@ -908,6 +911,12 @@ func GetFiles(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to walk directory %s: %w", path, err)
+	}
+	// The callback checks the context per entry, so cancellation during the
+	// last one leaves the walk finishing normally. Reporting a partial file
+	// list as a complete scan is worse than losing a cancelled run's work.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("directory walk cancelled: %w", ctxErr)
 	}
 
 	scanned := entriesScanned.Load()

--- a/pkg/helpers/paths.go
+++ b/pkg/helpers/paths.go
@@ -238,6 +238,7 @@ type launcherPrecomp struct {
 	extensions            []string // pre-lowercased extensions
 	scanExcludes          []string // pre-normalized scan-only file exclude patterns
 	scanDirectoryExcludes []string // pre-normalized scan-only directory exclude patterns
+	skipInternalSymlinks  bool     // skip symlinks whose target is inside this launcher's roots
 }
 
 // LauncherMatcher provides optimized path matching with pre-normalized paths.
@@ -333,6 +334,7 @@ func NewLauncherMatcher(cfg *config.Instance, pl platforms.Platform) *LauncherMa
 				NormalizePathForComparison(exclude),
 			)
 		}
+		lp.skipInternalSymlinks = l.ScanSkipInternalSymlinks
 
 		precomp[l.ID] = lp
 	}
@@ -444,6 +446,80 @@ func (m *LauncherMatcher) ShouldSkipScanDirectory(systemID, path string) bool {
 	}
 
 	return matched
+}
+
+// ShouldSkipScanSymlink reports whether a symlink found under a launcher scan
+// root should be skipped because its target resolves inside that launcher's
+// folders. Such an alias only duplicates media indexed under the target's own
+// path. Every filesystem-scanning launcher whose root contains the link must
+// opt in through ScanSkipInternalSymlinks, so a launcher sharing the root
+// keeps the aliases it needs. readTarget is only called once that agreement
+// holds, so systems without the flag pay no filesystem cost.
+func (m *LauncherMatcher) ShouldSkipScanSymlink(
+	systemID, linkPath string,
+	readTarget func() (string, error),
+) (bool, error) {
+	normLink := NormalizePathForComparison(linkPath)
+	launchers := GlobalLauncherCache.GetLaunchersBySystem(systemID)
+	var candidateRoots []string
+
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SkipFilesystemScan {
+			continue
+		}
+		lc := m.precomp[launcher.ID]
+		if lc == nil {
+			continue
+		}
+
+		contains := false
+		for _, roots := range [][]string{lc.rootPairs, lc.absFolders} {
+			for _, root := range roots {
+				if !pathHasPrefixNormalized(normLink, root) {
+					continue
+				}
+				if normLink == root {
+					return false, nil
+				}
+				contains = true
+			}
+		}
+		if !contains {
+			continue
+		}
+		if !lc.skipInternalSymlinks {
+			return false, nil
+		}
+		candidateRoots = append(candidateRoots, lc.rootPairs...)
+		candidateRoots = append(candidateRoots, lc.absFolders...)
+	}
+	if len(candidateRoots) == 0 {
+		return false, nil
+	}
+
+	target, err := readTarget()
+	if err != nil {
+		return false, err
+	}
+	normTarget := NormalizePathForComparison(resolveSymlinkTargetLexically(linkPath, target))
+	for _, root := range candidateRoots {
+		if pathHasPrefixNormalized(normTarget, root) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// resolveSymlinkTargetLexically turns a raw symlink target into an absolute
+// path without touching the filesystem: relative targets are joined to the
+// link's directory. The result is only compared against scan roots, so
+// symlinked ancestors in the path do not need resolving.
+func resolveSymlinkTargetLexically(linkPath, target string) string {
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+	return filepath.Join(filepath.Dir(linkPath), target)
 }
 
 func scanDirectoryExcludeMatches(relPath string, patterns []string) bool {

--- a/pkg/helpers/paths_matcher_symlink_test.go
+++ b/pkg/helpers/paths_matcher_symlink_test.go
@@ -1,0 +1,179 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLauncherMatcher_ShouldSkipScanSymlink(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache
+	rootDir := t.TempDir()
+	otherRoot := t.TempDir()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{})
+	mockPlatform.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{rootDir, otherRoot})
+	mockPlatform.On("Launchers", mock.AnythingOfType("*config.Instance")).Return([]platforms.Launcher{
+		{
+			ID:                       "Arcade",
+			SystemID:                 "Arcade",
+			Folders:                  []string{"_Arcade"},
+			Extensions:               []string{".mra"},
+			ScanSkipInternalSymlinks: true,
+		},
+		{
+			ID:         "Plain",
+			SystemID:   "Plain",
+			Folders:    []string{"plain"},
+			Extensions: []string{".bin"},
+		},
+		{
+			ID:                       "SharedOptIn",
+			SystemID:                 "Shared",
+			Folders:                  []string{"shared"},
+			ScanSkipInternalSymlinks: true,
+		},
+		{
+			ID:       "SharedPlain",
+			SystemID: "Shared",
+			Folders:  []string{"shared"},
+		},
+		{
+			ID:                       "SharedSkippedOptIn",
+			SystemID:                 "SharedSkipped",
+			Folders:                  []string{"shared-skipped"},
+			ScanSkipInternalSymlinks: true,
+		},
+		{
+			ID:                 "SharedSkippedNonFilesystem",
+			SystemID:           "SharedSkipped",
+			Folders:            []string{"shared-skipped"},
+			SkipFilesystemScan: true,
+		},
+	})
+
+	cfg := &config.Instance{}
+	testLauncherCacheMutex.Lock()
+	originalCache := GlobalLauncherCache
+	testCache := &LauncherCache{}
+	testCache.Initialize(mockPlatform, cfg)
+	GlobalLauncherCache = testCache
+	defer func() {
+		GlobalLauncherCache = originalCache
+		testLauncherCacheMutex.Unlock()
+	}()
+
+	matcher := NewLauncherMatcher(cfg, mockPlatform)
+	arcadeDir := filepath.Join(rootDir, "_Arcade")
+	canonical := filepath.Join(arcadeDir, "Pooyan.mra")
+	targetOf := func(target string) func() (string, error) {
+		return func() (string, error) { return target, nil }
+	}
+	mustNotRead := func() (string, error) {
+		t.Helper()
+		t.Fatal("readTarget must not be called when no launcher opts in")
+		return "", nil
+	}
+
+	skip, err := matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "_1 A-E", "Pooyan.mra"), targetOf(canonical),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "absolute target inside the scan root is an alias")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "_1 A-E", "Pooyan.mra"), targetOf(filepath.Join("..", "Pooyan.mra")),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "relative target resolved against the link directory")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "_Konami"),
+		targetOf(filepath.Join(arcadeDir, "_3 Collections", "_1 By Platform", "_Konami")),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "directory symlinks inside the scan root are aliases too")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "alias.mra"), targetOf(filepath.Join(otherRoot, "_Arcade", "Pooyan.mra")),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "target under another root of the same launcher is still indexed there")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(rootDir, "_ARCADE", "alias.mra"),
+		targetOf(filepath.Join(rootDir, "_arcade", "Pooyan.mra")),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "matching is case-insensitive")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "External.mra"),
+		targetOf(filepath.Join(rootDir, "elsewhere", "External.mra")),
+	)
+	require.NoError(t, err)
+	assert.False(t, skip, "target outside every scan root is real media reachable only through the link")
+
+	skip, err = matcher.ShouldSkipScanSymlink("Arcade", filepath.Join(arcadeDir, "_loop"), targetOf(".."))
+	require.NoError(t, err)
+	assert.False(t, skip, "a link to the parent of the scan root is left to the walker's cycle guard")
+
+	skip, err = matcher.ShouldSkipScanSymlink("Arcade", arcadeDir, mustNotRead)
+	require.NoError(t, err)
+	assert.False(t, skip, "the scan root itself is never skipped")
+
+	skip, err = matcher.ShouldSkipScanSymlink("Arcade", filepath.Join(rootDir, "other", "alias.mra"), mustNotRead)
+	require.NoError(t, err)
+	assert.False(t, skip, "links outside every scan root are not the matcher's concern")
+
+	skip, err = matcher.ShouldSkipScanSymlink("Plain", filepath.Join(rootDir, "plain", "alias.bin"), mustNotRead)
+	require.NoError(t, err)
+	assert.False(t, skip, "launchers without the flag keep their aliases")
+
+	skip, err = matcher.ShouldSkipScanSymlink("Shared", filepath.Join(rootDir, "shared", "alias"), mustNotRead)
+	require.NoError(t, err)
+	assert.False(t, skip, "one launcher must not drop an alias needed by another launcher on the same root")
+
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"SharedSkipped", filepath.Join(rootDir, "shared-skipped", "alias"),
+		targetOf(filepath.Join(rootDir, "shared-skipped", "real")),
+	)
+	require.NoError(t, err)
+	assert.True(t, skip, "a non-filesystem launcher must not block the opt-in")
+
+	readErr := errors.New("stale mount")
+	skip, err = matcher.ShouldSkipScanSymlink(
+		"Arcade", filepath.Join(arcadeDir, "alias.mra"), func() (string, error) { return "", readErr },
+	)
+	require.ErrorIs(t, err, readErr, "read errors are the caller's to interpret")
+	assert.False(t, skip)
+
+	assert.True(t, matcher.MatchSystemFile("Arcade", filepath.Join(arcadeDir, "_1 A-E", "Pooyan.mra")),
+		"alias skipping must not affect direct launches")
+}

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -267,6 +267,12 @@ func (c *arcadeSystemCache) scanFiles(
 ) ([]platforms.ScanResult, error) {
 	var results []platforms.ScanResult
 	matcher := helpers.NewLauncherMatcher(cfg, c.platform)
+	// afero.Walk reports symlinks without following them, so an Organizer
+	// alias arrives here as a file entry and must be filtered by its target.
+	var readLink func(string) (string, error)
+	if linkReader, ok := c.platform.filesystem().(afero.LinkReader); ok {
+		readLink = linkReader.ReadlinkIfPossible
+	}
 	for _, root := range c.platform.RootDirs(cfg) {
 		select {
 		case <-ctx.Done():
@@ -297,6 +303,16 @@ func (c *arcadeSystemCache) scanFiles(
 						return filepath.SkipDir
 					}
 					return nil
+				}
+				if info.Mode()&os.ModeSymlink != 0 && readLink != nil {
+					skip, skipErr := matcher.ShouldSkipScanSymlink(
+						systemdefs.SystemArcade, path, func() (string, error) { return readLink(path) },
+					)
+					if skipErr != nil {
+						log.Debug().Err(skipErr).Str("path", path).Msg("unable to read MiSTer arcade symlink")
+					} else if skip {
+						return nil
+					}
 				}
 				ext := filepath.Ext(path)
 				if strings.EqualFold(ext, ".mra") || strings.EqualFold(ext, ".mgl") {

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -321,10 +321,12 @@ func (c *arcadeSystemCache) scanFiles(
 				return nil
 			},
 		)
+		// Walk can finish without observing cancellation when the last entry
+		// is already in flight, so partial results must not look complete.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if walkErr != nil {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
 			log.Warn().Err(walkErr).Str("path", arcadePath).Msg("unable to scan MiSTer arcade files for classification")
 		}
 	}

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/arcadedb"
+	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/mgls"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -349,6 +351,69 @@ func TestArcadeSystemCacheScanFilesFiltersSupportedExtensions(t *testing.T) {
 		{Path: canonicalPath},
 		{Path: externalAlias},
 	}, results)
+}
+
+// cancellingLinkFs cancels the scan while a symlink target is being read, so
+// the walk finishes without any later entry observing the cancellation.
+type cancellingLinkFs struct {
+	afero.Fs
+	cancel context.CancelFunc
+}
+
+func (f *cancellingLinkFs) LstatIfPossible(name string) (info os.FileInfo, lstated bool, err error) {
+	lstater, ok := f.Fs.(afero.Lstater)
+	if !ok {
+		info, err = f.Stat(name)
+		return info, false, err //nolint:wrapcheck // Test filesystem passthrough.
+	}
+	return lstater.LstatIfPossible(name) //nolint:wrapcheck // Test filesystem passthrough.
+}
+
+func (f *cancellingLinkFs) ReadlinkIfPossible(name string) (string, error) {
+	f.cancel()
+	linkReader, ok := f.Fs.(afero.LinkReader)
+	if !ok {
+		return "", afero.ErrNoReadlink
+	}
+	return linkReader.ReadlinkIfPossible(name) //nolint:wrapcheck // Test filesystem passthrough.
+}
+
+func TestArcadeSystemCacheScanFilesFailsOnCancelDuringFinalEntry(t *testing.T) {
+	root := t.TempDir()
+	arcadeRoot := filepath.Join(root, "_Arcade")
+	require.NoError(t, os.MkdirAll(arcadeRoot, 0o750))
+	externalDir := filepath.Join(root, "external")
+	require.NoError(t, os.MkdirAll(externalDir, 0o750))
+	externalTarget := filepath.Join(externalDir, "External.mra")
+	require.NoError(t, os.WriteFile(externalTarget, []byte("test"), 0o600))
+	// The only entry under _Arcade, so nothing is walked after its target read.
+	require.NoError(t, os.Symlink(externalTarget, filepath.Join(arcadeRoot, "External.mra")))
+
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[launchers]\nindex_root = [%q]\n", root)))
+	platform := NewPlatform()
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.InitializeFromSlice(platform.Launchers(cfg))
+	helpers.GlobalLauncherCache = testCache
+	t.Cleanup(func() { helpers.GlobalLauncherCache = originalCache })
+
+	// Leave index_root as the only root so the walk below is the last one,
+	// matching /media/fat on a device.
+	originalCustom, originalGames := misterconfig.CustomFolders, misterconfig.GamesFolders
+	misterconfig.CustomFolders, misterconfig.GamesFolders = nil, nil
+	t.Cleanup(func() {
+		misterconfig.CustomFolders, misterconfig.GamesFolders = originalCustom, originalGames
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	platform.fs = &cancellingLinkFs{Fs: afero.NewOsFs(), cancel: cancel}
+	cache := newArcadeSystemCache(platform)
+
+	results, err := cache.scanFiles(ctx, cfg)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, results)
 }
 
 func TestAddNeoGeoMVSLauncherSharesScannerCache(t *testing.T) {

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -318,6 +318,18 @@ func TestArcadeSystemCacheScanFilesFiltersSupportedExtensions(t *testing.T) {
 	}
 	aliasPath := filepath.Join(organizedDir, "Pooyan.mra")
 	require.NoError(t, os.Symlink(canonicalPath, aliasPath))
+	// Organizer output written straight into _Arcade, plus a PREPEND_YEAR
+	// alias at the Organizer root and a link to media outside _Arcade.
+	inPlaceDir := filepath.Join(arcadeRoot, "_1 A-E")
+	require.NoError(t, os.MkdirAll(inPlaceDir, 0o750))
+	require.NoError(t, os.Symlink(canonicalPath, filepath.Join(inPlaceDir, "Pooyan.mra")))
+	require.NoError(t, os.Symlink(canonicalPath, filepath.Join(arcadeRoot, "}82 Pooyan.mra")))
+	externalDir := filepath.Join(root, "external")
+	require.NoError(t, os.MkdirAll(externalDir, 0o750))
+	externalTarget := filepath.Join(externalDir, "External.mra")
+	require.NoError(t, os.WriteFile(externalTarget, []byte("test"), 0o600))
+	externalAlias := filepath.Join(arcadeRoot, "External.mra")
+	require.NoError(t, os.Symlink(externalTarget, externalAlias))
 
 	cfg := &config.Instance{}
 	require.NoError(t, cfg.LoadTOML(fmt.Sprintf("[launchers]\nindex_root = [%q]\n", root)))
@@ -335,6 +347,7 @@ func TestArcadeSystemCacheScanFilesFiltersSupportedExtensions(t *testing.T) {
 		{Path: mraPath},
 		{Path: mglPath},
 		{Path: canonicalPath},
+		{Path: externalAlias},
 	}, results)
 }
 

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -55,6 +55,26 @@ var misterDefaultScanExcludes = []string{
 	"empty_hdd.zip/boot.vhd",
 }
 
+// arcadeOrganizerScanDirectoryExcludes are the directories the MiSTer Arcade
+// Organizer script generates: its ORGDIR_DIRECTORIES category folders plus the
+// default _Organized container. They hold symlinks (or copies, with
+// NO_SYMLINKS) of MRAs that are already indexed under _Arcade. The script can
+// write the category folders straight into _Arcade instead of under
+// _Organized, so the container name alone is not enough.
+var arcadeOrganizerScanDirectoryExcludes = []string{
+	"_Organized",
+	"_1 0-9",
+	"_1 A-E",
+	"_1 F-K",
+	"_1 L-Q",
+	"_1 R-T",
+	"_1 U-Z",
+	"_2 Region",
+	"_3 Collections",
+	"_4 Video & Inputs",
+	"_5 Extra Software",
+}
+
 func checkInZip(path string) string {
 	if !strings.HasSuffix(strings.ToLower(path), ".zip") {
 		return path
@@ -2285,12 +2305,13 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		},
 		// Other
 		{
-			ID:                    systemdefs.SystemArcade,
-			SystemID:              systemdefs.SystemArcade,
-			Folders:               []string{"_Arcade"},
-			Extensions:            []string{".mra", ".mgl"},
-			ScanDirectoryExcludes: []string{"_Organized"},
-			Launch:                launchArcade(pl, systemdefs.SystemArcade),
+			ID:                       systemdefs.SystemArcade,
+			SystemID:                 systemdefs.SystemArcade,
+			Folders:                  []string{"_Arcade"},
+			Extensions:               []string{".mra", ".mgl"},
+			ScanDirectoryExcludes:    arcadeOrganizerScanDirectoryExcludes,
+			ScanSkipInternalSymlinks: true,
+			Launch:                   launchArcade(pl, systemdefs.SystemArcade),
 		},
 		{
 			ID:         systemdefs.SystemArduboy,

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -580,7 +580,12 @@ func TestArcadeLauncherExtensions(t *testing.T) {
 
 	require.NotNil(t, arcadeLauncher, "Arcade launcher should exist")
 	assert.Equal(t, []string{"_Arcade"}, arcadeLauncher.Folders)
-	assert.Equal(t, []string{"_Organized"}, arcadeLauncher.ScanDirectoryExcludes)
+	assert.Equal(t, arcadeOrganizerScanDirectoryExcludes, arcadeLauncher.ScanDirectoryExcludes)
+	assert.Contains(t, arcadeLauncher.ScanDirectoryExcludes, "_Organized")
+	assert.Contains(t, arcadeLauncher.ScanDirectoryExcludes, "_1 A-E")
+	assert.Contains(t, arcadeLauncher.ScanDirectoryExcludes, "_4 Video & Inputs")
+	assert.True(t, arcadeLauncher.ScanSkipInternalSymlinks,
+		"Arcade Organizer aliases resolve inside _Arcade and must not be indexed twice")
 	assert.Contains(t, arcadeLauncher.Extensions, ".mra")
 	assert.Contains(t, arcadeLauncher.Extensions, ".mgl")
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -355,6 +355,11 @@ type Launcher struct {
 	// Use for launchers that rely entirely on custom scanners (e.g., Batocera
 	// gamelist.xml, Kodi API queries) and don't need filesystem scanning.
 	SkipFilesystemScan bool
+	// ScanSkipInternalSymlinks skips symlinks whose target resolves inside this
+	// launcher's Folders during media scanning. The target is indexed under its
+	// own path, so the alias would only duplicate it. Applies to symlinked files
+	// and directories. Direct path launches remain unaffected.
+	ScanSkipInternalSymlinks bool
 	// Available is populated by LauncherCache.
 	Available bool
 }


### PR DESCRIPTION
- The Arcade Organizer can write its ten category folders straight into `_Arcade` (`ORGDIR=/media/fat/_Arcade`), so excluding `_Organized` alone still indexed every game once per category. Those folder names are now excluded for the Arcade launcher as well, which also covers the `NO_SYMLINKS` copy mode.
- Adds `Launcher.ScanSkipInternalSymlinks` and `LauncherMatcher.ShouldSkipScanSymlink`: a symlink whose target resolves inside the launcher's own scan folders is skipped during scanning, because the target is indexed under its own path. This covers `TOPDIR` directory symlinks, `PREPEND_YEAR` links and custom `ORGDIR` locations under `_Arcade`. Only the Arcade launcher opts in, every launcher sharing a root must agree, and direct launches of alias paths are unchanged.
- The MiSTer arcade classifier's fallback walk applies the same rule, and the directory walk log now reports `symlinkAliasesSkipped`.
- The sibling layout (`/media/fat/_Arcade Organized`) was already outside every scan root; a test now pins that.
- Tests cover the in-place layout, directory and relative aliases, dangling links, a parent loop, and links to media outside `_Arcade` that must stay indexed.

Closes #1290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved arcade media scanning for symlinked files.
  * Prevented duplicate indexing of symlink aliases for already-scanned media.
  * Added support for excluding Arcade Organizer-generated directories.
  * Preserved direct launching while allowing internal symlink aliases to be skipped.
* **Bug Fixes**
  * Improved handling of dangling, external, and inaccessible symlinks.
  * Added safer behavior for scan timeouts and cancelled operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->