### PR TITLE
feat(media): include tags in media.history entries

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -1530,6 +1530,7 @@ Optionally, an object:
 | startedAt  | string | Yes      | Timestamp when media started in RFC3339 format.        |
 | endedAt    | string | No       | Timestamp when media stopped in RFC3339 format. Omitted if media is still active. |
 | playTime   | number | Yes      | Duration of the play session in seconds.               |
+| tags       | [TagInfo](#taginfo-object)[] | No | Tags for the resolved media, merged from file-level and title-level tags exactly as `media.search` returns them. An empty array means the media is indexed but has no tags. Omitted when `mediaId` is omitted or when media database enrichment fails or times out. |
 
 #### Example
 
@@ -1566,7 +1567,11 @@ Optionally, an object:
         "launcherId": "SNES",
         "startedAt": "2025-01-22T14:30:00Z",
         "endedAt": "2025-01-22T15:15:30Z",
-        "playTime": 2730
+        "playTime": 2730,
+        "tags": [
+          { "tag": "favorite", "type": "collection" },
+          { "tag": "platformer", "type": "genre" }
+        ]
       }
     ],
     "pagination": {
@@ -1613,6 +1618,7 @@ Optionally, an object:
 | totalPlayTime | number | Yes      | Total play time across all sessions in seconds.        |
 | sessionCount  | number | Yes      | Number of play sessions.                               |
 | lastPlayedAt  | string | Yes      | Timestamp of the most recent session in RFC3339 format. |
+| tags          | [TagInfo](#taginfo-object)[] | No | Tags for the resolved media, merged from file-level and title-level tags exactly as `media.search` returns them. An empty array means the media is indexed but has no tags. Omitted when `mediaId` is omitted or when media database enrichment fails or times out. |
 
 #### Example
 
@@ -1647,7 +1653,11 @@ Optionally, an object:
         "relativePath": "snes/Super Mario World (USA).sfc",
         "totalPlayTime": 7200,
         "sessionCount": 12,
-        "lastPlayedAt": "2026-02-14T20:30:00Z"
+        "lastPlayedAt": "2026-02-14T20:30:00Z",
+        "tags": [
+          { "tag": "favorite", "type": "collection" },
+          { "tag": "platformer", "type": "genre" }
+        ]
       }
     ]
   }

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -1106,9 +1106,9 @@ func HandleMediaSearch(env requests.RequestEnv) (any, error) { //nolint:gocritic
 	// valid image request merely because optional enrichment timed out.
 	coverStatusesKnown := false
 	if len(searchResults) > 0 {
-		coverRefs := make([]database.MediaCoverRef, len(searchResults))
+		coverRefs := make([]database.MediaRef, len(searchResults))
 		for i := range searchResults {
-			coverRefs[i] = database.MediaCoverRef{
+			coverRefs[i] = database.MediaRef{
 				MediaDBID:      searchResults[i].MediaID,
 				MediaTitleDBID: searchResults[i].MediaTitleID,
 			}

--- a/pkg/api/methods/media_history.go
+++ b/pkg/api/methods/media_history.go
@@ -109,6 +109,8 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	// Unknown must remain true in the response so clients do not suppress a
 	// valid image request merely because optional enrichment timed out.
 	coverStatusesKnown := false
+	var tagsByID map[int64][]database.TagInfo
+	tagsKnown := false
 	enrichCtx, cancelEnrichment := optionalDBEnrichmentContext(env.Context)
 	defer cancelEnrichment()
 
@@ -116,30 +118,12 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	if enrichErr != nil {
 		log.Debug().Err(enrichErr).Msg("could not enrich media history from media database")
 	} else {
-		resolvedMediaIDs := make(map[mediaPathRef]int64, len(mediaRows))
-		coverRefs := make([]database.MediaCoverRef, 0, len(mediaRows))
-		seenIDs := make(map[int64]struct{}, len(mediaRows))
-		for _, ref := range mediaRefs {
-			row := mediaRows[ref]
-			if row.DBID <= 0 {
-				continue
-			}
-			resolvedMediaIDs[ref] = row.DBID
-			if _, ok := seenIDs[row.DBID]; ok {
-				continue
-			}
-			seenIDs[row.DBID] = struct{}{}
-			coverRefs = append(coverRefs, database.MediaCoverRef{
-				MediaDBID:      row.DBID,
-				MediaTitleDBID: row.MediaTitleDBID,
-			})
-		}
-
-		mediaIDs = resolvedMediaIDs
-		if len(coverRefs) == 0 {
+		var resolvedRefs []database.MediaRef
+		mediaIDs, resolvedRefs = resolvedMediaRefs(mediaRefs, mediaRows)
+		if len(resolvedRefs) == 0 {
 			coverStatusesKnown = true
 		} else {
-			resolvedCoverStatuses, coverErr := env.Database.MediaDB.GetMediaCoverStatus(enrichCtx, coverRefs)
+			resolvedCoverStatuses, coverErr := env.Database.MediaDB.GetMediaCoverStatus(enrichCtx, resolvedRefs)
 			if coverErr != nil {
 				log.Debug().Err(coverErr).Msg("could not enrich media history cover status")
 			} else {
@@ -147,6 +131,7 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 				coverStatusesKnown = true
 			}
 		}
+		tagsByID, tagsKnown = mediaTagsByRefs(enrichCtx, env.Database.MediaDB, resolvedRefs)
 	}
 	enrichElapsed := time.Since(enrichStarted)
 
@@ -180,11 +165,13 @@ func HandleMediaHistory(env requests.RequestEnv) (any, error) { //nolint:gocriti
 			StartedAt:  startedAt,
 			EndedAt:    endedAt,
 			PlayTime:   entry.PlayTime,
+			Tags:       mediaEntryTags(tagsKnown, mediaID, tagsByID),
 		})
 	}
 
 	log.Debug().
 		Int("entries", len(responseEntries)).
+		Int("taggedMedia", len(tagsByID)).
 		Bool("distinctMedia", distinctMedia).
 		Dur("queryDuration", queryElapsed).
 		Dur("enrichDuration", enrichElapsed).

--- a/pkg/api/methods/media_history_latest_test.go
+++ b/pkg/api/methods/media_history_latest_test.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -133,5 +134,39 @@ func TestHandleMediaHistoryLatest_DatabaseError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "error getting latest media history")
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryLatest_ResponseHasNoTagsAndNoMediaDBCalls(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockUserDB.On("GetLatestMediaHistory").Return(database.MediaHistoryEntry{
+		DBID:       12,
+		SystemID:   "SNES",
+		SystemName: "Super Nintendo Entertainment System",
+		MediaName:  "Super Mario World",
+		MediaPath:  filepath.ToSlash(filepath.Join("roms", "snes", "smw.sfc")),
+		LauncherID: "SNES",
+		StartTime:  time.Unix(1_770_000_000, 0).UTC(),
+	}, true, nil)
+
+	result, err := HandleMediaHistoryLatest(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	var decoded struct {
+		Entry map[string]any `json:"entry"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.NotNil(t, decoded.Entry)
+	assert.NotContains(t, decoded.Entry, "tags")
+	assert.NotContains(t, decoded.Entry, "mediaId")
+	assert.Empty(t, mockMediaDB.Calls, "media.history.latest must not touch the media database")
 	mockUserDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_history_test.go
+++ b/pkg/api/methods/media_history_test.go
@@ -173,7 +173,7 @@ func TestHandleMediaHistory_IncludesCoverStatus(t *testing.T) {
 			{SystemID: "NES", Path: coveredPath, DBID: 20, MediaTitleDBID: 200},
 			{SystemID: "NES", Path: uncoveredPath, DBID: 10, MediaTitleDBID: 100},
 		}, nil)
-	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaCoverRef{
+	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaRef{
 		{MediaDBID: 20, MediaTitleDBID: 200},
 		{MediaDBID: 10, MediaTitleDBID: 100},
 	}).Return(map[int64]bool{20: true, 10: false}, nil)
@@ -202,36 +202,65 @@ func TestHandleMediaHistory_EnrichmentFailuresAreNonFatal(t *testing.T) {
 		DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "History", StartTime: time.Now(),
 	}
 
+	assertEnrichmentDeadline := func(t *testing.T, args mock.Arguments) {
+		t.Helper()
+		ctx, ok := args.Get(0).(context.Context)
+		require.True(t, ok)
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok, "optional enrichment must have a deadline")
+		assert.WithinDuration(t, time.Now().Add(optionalDBEnrichmentTimeout), deadline, time.Second)
+	}
+	resolvedRef := []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}
+
 	tests := []struct {
 		setup           func(*testing.T, *helpers.MockMediaDBI)
 		name            string
+		expectedTags    []database.TagInfo
 		expectedMediaID int64
+		expectTagLookup bool
 	}{
 		{
 			name: "media identity lookup",
 			setup: func(_ *testing.T, mockMediaDB *helpers.MockMediaDBI) {
 				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
 					Return(nil, errors.New("identity lookup failed"))
+				mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
+					Return(map[int64][]database.TagInfo{}, nil).Maybe()
 			},
 		},
 		{
 			name:            "cover lookup",
 			expectedMediaID: 42,
+			expectedTags:    []database.TagInfo{},
+			expectTagLookup: true,
 			setup: func(t *testing.T, mockMediaDB *helpers.MockMediaDBI) {
 				t.Helper()
 				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
 					Return([]database.MediaPathID{{
 						SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420,
 					}}, nil)
-				mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaCoverRef{{
-					MediaDBID: 42, MediaTitleDBID: 420,
-				}}).Run(func(args mock.Arguments) {
-					ctx, ok := args.Get(0).(context.Context)
-					require.True(t, ok)
-					deadline, ok := ctx.Deadline()
-					require.True(t, ok, "optional enrichment must have a deadline")
-					assert.WithinDuration(t, time.Now().Add(optionalDBEnrichmentTimeout), deadline, time.Second)
-				}).Return(nil, errors.New("cover lookup failed"))
+				mockMediaDB.On("GetMediaCoverStatus", mock.Anything, resolvedRef).
+					Run(func(args mock.Arguments) { assertEnrichmentDeadline(t, args) }).
+					Return(nil, errors.New("cover lookup failed"))
+				mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, resolvedRef).
+					Return(map[int64][]database.TagInfo{}, nil).Once()
+			},
+		},
+		{
+			name:            "tag lookup",
+			expectedMediaID: 42,
+			expectTagLookup: true,
+			setup: func(t *testing.T, mockMediaDB *helpers.MockMediaDBI) {
+				t.Helper()
+				mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+					Return([]database.MediaPathID{{
+						SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420,
+					}}, nil)
+				mockMediaDB.On("GetMediaCoverStatus", mock.Anything, resolvedRef).
+					Return(map[int64]bool{42: true}, nil)
+				mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, resolvedRef).
+					Run(func(args mock.Arguments) { assertEnrichmentDeadline(t, args) }).
+					Return(nil, errors.New("tag lookup failed")).Once()
 			},
 		},
 	}
@@ -256,6 +285,10 @@ func TestHandleMediaHistory_EnrichmentFailuresAreNonFatal(t *testing.T) {
 			require.Len(t, response.Entries, 1)
 			assert.Equal(t, tt.expectedMediaID, response.Entries[0].MediaID)
 			assert.True(t, response.Entries[0].HasCover)
+			assert.Equal(t, tt.expectedTags, response.Entries[0].Tags)
+			if !tt.expectTagLookup {
+				mockMediaDB.AssertNotCalled(t, "GetMediaTagsByMediaRefs", mock.Anything, mock.Anything)
+			}
 			mockUserDB.AssertExpectations(t)
 			mockMediaDB.AssertExpectations(t)
 		})
@@ -582,4 +615,262 @@ func TestHandleMediaHistory_InvalidParams(t *testing.T) {
 
 	_, err := HandleMediaHistory(env)
 	require.Error(t, err)
+}
+
+// marshalledHistoryEntries round-trips a handler result through JSON so tests
+// can assert on key presence rather than Go zero values.
+func marshalledHistoryEntries(t *testing.T, result any) []map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	var decoded struct {
+		Entries []map[string]any `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	return decoded.Entries
+}
+
+func TestHandleMediaHistory_IncludesTags(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	taggedPath := filepath.Join(string(filepath.Separator), "games", "tagged.nes")
+	untaggedPath := filepath.Join(string(filepath.Separator), "games", "untagged.nes")
+	taggedTags := []database.TagInfo{
+		{Tag: "favorite", Type: "collection", Label: "Favorite"},
+		{Tag: "1990", Type: "year"},
+	}
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 2, SystemID: "NES", MediaPath: taggedPath, MediaName: "Tagged", StartTime: now},
+			{DBID: 1, SystemID: "NES", MediaPath: untaggedPath, MediaName: "Untagged", StartTime: now},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{taggedPath, untaggedPath}).
+		Return([]database.MediaPathID{
+			{SystemID: "NES", Path: taggedPath, DBID: 20, MediaTitleDBID: 200},
+			{SystemID: "NES", Path: untaggedPath, DBID: 10, MediaTitleDBID: 100},
+		}, nil)
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{
+		{MediaDBID: 20, MediaTitleDBID: 200},
+		{MediaDBID: 10, MediaTitleDBID: 100},
+	}).Return(map[int64][]database.TagInfo{20: taggedTags}, nil).Once()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Params:   json.RawMessage(`{}`),
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 2)
+	assert.Equal(t, taggedTags, response.Entries[0].Tags)
+	assert.Equal(t, []database.TagInfo{}, response.Entries[1].Tags)
+
+	entries := marshalledHistoryEntries(t, result)
+	require.Len(t, entries, 2)
+	assert.Len(t, entries[0]["tags"], 2)
+	assert.Equal(t, []any{}, entries[1]["tags"], "indexed media without tags must serialise as an empty array")
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_UnresolvedMediaOmitsTags(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	resolvedPath := filepath.Join(string(filepath.Separator), "games", "resolved.nes")
+	missingPath := filepath.Join(string(filepath.Separator), "games", "missing.nes")
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 2, SystemID: "NES", MediaPath: resolvedPath, MediaName: "Resolved", StartTime: now},
+			{DBID: 1, SystemID: "NES", MediaPath: missingPath, MediaName: "Missing", StartTime: now},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{resolvedPath, missingPath}).
+		Return([]database.MediaPathID{
+			{SystemID: "NES", Path: resolvedPath, DBID: 20, MediaTitleDBID: 200},
+		}, nil)
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{
+		{MediaDBID: 20, MediaTitleDBID: 200},
+	}).Return(map[int64][]database.TagInfo{}, nil).Once()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 2)
+	assert.Equal(t, []database.TagInfo{}, response.Entries[0].Tags)
+	assert.Nil(t, response.Entries[1].Tags)
+
+	entries := marshalledHistoryEntries(t, result)
+	require.Len(t, entries, 2)
+	assert.Contains(t, entries[0], "tags")
+	assert.NotContains(t, entries[1], "tags", "unresolved history rows must omit tags")
+	assert.NotContains(t, entries[1], "mediaId")
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_NoResolvedMediaSkipsTagLookup(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "missing.nes")
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "Missing", StartTime: time.Now()},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{}, nil)
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{}, nil).Maybe()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 1)
+	assert.Nil(t, response.Entries[0].Tags)
+	mockMediaDB.AssertNotCalled(t, "GetMediaTagsByMediaRefs", mock.Anything, mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "GetMediaCoverStatus", mock.Anything, mock.Anything)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_CoverFailureDoesNotAffectTags(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "history.nes")
+	tags := []database.TagInfo{{Tag: "favorite", Type: "collection"}}
+	refs := []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "History", StartTime: time.Now()},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
+	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, refs).
+		Return(nil, errors.New("cover lookup failed"))
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, refs).
+		Return(map[int64][]database.TagInfo{42: tags}, nil).Once()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 1)
+	assert.Equal(t, int64(42), response.Entries[0].MediaID)
+	assert.True(t, response.Entries[0].HasCover)
+	assert.Equal(t, tags, response.Entries[0].Tags)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_RepeatedMediaRowsShareOneRef(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "repeat.nes")
+	tags := []database.TagInfo{{Tag: "favorite", Type: "collection"}}
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), 26).
+		Return([]database.MediaHistoryEntry{
+			{DBID: 3, SystemID: "NES", MediaPath: mediaPath, MediaName: "Repeat", StartTime: now},
+			{DBID: 2, SystemID: "NES", MediaPath: mediaPath, MediaName: "Repeat", StartTime: now.Add(-time.Hour)},
+			{DBID: 1, SystemID: "NES", MediaPath: mediaPath, MediaName: "Repeat", StartTime: now.Add(-2 * time.Hour)},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "NES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil).
+		Once()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}).
+		Return(map[int64][]database.TagInfo{42: tags}, nil).Once()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Params:   json.RawMessage(`{"distinctMedia": false}`),
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, 3)
+	for i := range response.Entries {
+		assert.Equal(t, int64(42), response.Entries[i].MediaID)
+		assert.Equal(t, tags, response.Entries[i].Tags)
+	}
+	mockMediaDB.AssertNumberOfCalls(t, "FindMediaIDsByPaths", 1)
+	mockMediaDB.AssertNumberOfCalls(t, "GetMediaTagsByMediaRefs", 1)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistory_FullPageUsesSingleTagBatch(t *testing.T) {
+	t.Parallel()
+
+	const pageSize = 100
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	entries := make([]database.MediaHistoryEntry, 0, pageSize)
+	rows := make([]database.MediaPathID, 0, pageSize)
+	tagsByID := make(map[int64][]database.TagInfo, pageSize)
+	for i := range pageSize {
+		mediaPath := filepath.Join(string(filepath.Separator), "games", fmt.Sprintf("game-%03d.nes", i))
+		mediaID := int64(1000 + i)
+		entries = append(entries, database.MediaHistoryEntry{
+			DBID: int64(pageSize - i), SystemID: "NES", MediaPath: mediaPath, MediaName: "Game", StartTime: now,
+		})
+		rows = append(rows, database.MediaPathID{
+			SystemID: "NES", Path: mediaPath, DBID: mediaID, MediaTitleDBID: mediaID * 10,
+		})
+		if i%2 == 0 {
+			tagsByID[mediaID] = []database.TagInfo{{Tag: fmt.Sprintf("tag-%d", i), Type: "test"}}
+		}
+	}
+	mockUserDB.On("GetMediaHistory", []string(nil), int64(0), pageSize+1).Return(entries, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, mock.MatchedBy(func(paths []string) bool {
+		return len(paths) == pageSize
+	})).Return(rows, nil).Once()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.MatchedBy(func(refs []database.MediaRef) bool {
+		return len(refs) == pageSize
+	})).Return(tagsByID, nil).Once()
+
+	result, err := HandleMediaHistory(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Params:   json.RawMessage(`{"limit": 100}`),
+	})
+	require.NoError(t, err)
+	response, ok := result.(models.MediaHistoryResponse)
+	require.True(t, ok)
+	require.Len(t, response.Entries, pageSize)
+	for i := range response.Entries {
+		mediaID := int64(1000 + i)
+		assert.Equal(t, mediaID, response.Entries[i].MediaID)
+		if i%2 == 0 {
+			assert.Equal(t, tagsByID[mediaID], response.Entries[i].Tags)
+		} else {
+			assert.Equal(t, []database.TagInfo{}, response.Entries[i].Tags)
+		}
+	}
+	mockMediaDB.AssertNumberOfCalls(t, "FindMediaIDsByPaths", 1)
+	mockMediaDB.AssertNumberOfCalls(t, "GetMediaTagsByMediaRefs", 1)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_history_top.go
+++ b/pkg/api/methods/media_history_top.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/validation"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/rs/zerolog/log"
 )
 
@@ -82,7 +83,20 @@ func HandleMediaHistoryTop(env requests.RequestEnv) (any, error) {
 			Path:     entries[i].MediaPath,
 		})
 	}
-	mediaIDs := mediaResponseMediaIDs(&env, mediaRefs)
+	mediaIDs := make(map[mediaPathRef]int64)
+	var tagsByID map[int64][]database.TagInfo
+	tagsKnown := false
+	enrichCtx, cancelEnrichment := optionalDBEnrichmentContext(env.Context)
+	defer cancelEnrichment()
+
+	mediaRows, enrichErr := resolveMediaPathIDs(enrichCtx, env.Database.MediaDB, mediaRefs)
+	if enrichErr != nil {
+		log.Debug().Err(enrichErr).Msg("could not enrich media history top from media database")
+	} else {
+		var resolvedRefs []database.MediaRef
+		mediaIDs, resolvedRefs = resolvedMediaRefs(mediaRefs, mediaRows)
+		tagsByID, tagsKnown = mediaTagsByRefs(enrichCtx, env.Database.MediaDB, resolvedRefs)
+	}
 
 	responseEntries := make([]models.MediaHistoryTopEntry, 0, len(entries))
 	for i := range entries {
@@ -98,6 +112,7 @@ func HandleMediaHistoryTop(env requests.RequestEnv) (any, error) {
 			LastPlayedAt:  entry.LastPlayedAt.Format(time.RFC3339),
 			TotalPlayTime: entry.TotalPlayTime,
 			SessionCount:  entry.SessionCount,
+			Tags:          mediaEntryTags(tagsKnown, mediaIDs[ref], tagsByID),
 		})
 	}
 

--- a/pkg/api/methods/media_history_top_test.go
+++ b/pkg/api/methods/media_history_top_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -107,7 +108,7 @@ func TestHandleMediaHistoryTop_WithMediaIDAndRelativePath(t *testing.T) {
 		},
 	}, nil)
 	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
-		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42}}, nil)
+		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
 
 	env := requests.RequestEnv{
 		Context:       context.Background(),
@@ -126,6 +127,7 @@ func TestHandleMediaHistoryTop_WithMediaIDAndRelativePath(t *testing.T) {
 	assert.Equal(t, int64(42), resp.Entries[0].MediaID)
 	require.NotNil(t, resp.Entries[0].RelPath)
 	assert.Equal(t, relPath, *resp.Entries[0].RelPath)
+	assert.Equal(t, []database.TagInfo{}, resp.Entries[0].Tags)
 
 	mockUserDB.AssertExpectations(t)
 	mockMediaDB.AssertExpectations(t)
@@ -452,4 +454,187 @@ func TestHandleMediaHistoryTop_DatabaseError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error getting media history top")
 
 	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryTop_IncludesTags(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	taggedPath := filepath.Join(string(filepath.Separator), "games", "tagged.sfc")
+	untaggedPath := filepath.Join(string(filepath.Separator), "games", "untagged.sfc")
+	missingPath := filepath.Join(string(filepath.Separator), "games", "missing.sfc")
+	tags := []database.TagInfo{{Tag: "favorite", Type: "collection", Label: "Favorite"}}
+	mockUserDB.On("GetMediaHistoryTop", []string(nil), (*time.Time)(nil), 25).
+		Return([]database.MediaHistoryTopEntry{
+			{
+				SystemID: "SNES", MediaName: "Tagged", MediaPath: taggedPath,
+				TotalPlayTime: 300, SessionCount: 3, LastPlayedAt: now,
+			},
+			{
+				SystemID: "SNES", MediaName: "Untagged", MediaPath: untaggedPath,
+				TotalPlayTime: 200, SessionCount: 2, LastPlayedAt: now,
+			},
+			{
+				SystemID: "SNES", MediaName: "Missing", MediaPath: missingPath,
+				TotalPlayTime: 100, SessionCount: 1, LastPlayedAt: now,
+			},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{taggedPath, untaggedPath, missingPath}).
+		Return([]database.MediaPathID{
+			{SystemID: "SNES", Path: taggedPath, DBID: 42, MediaTitleDBID: 420},
+			{SystemID: "SNES", Path: untaggedPath, DBID: 43, MediaTitleDBID: 430},
+		}, nil).Once()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{
+		{MediaDBID: 42, MediaTitleDBID: 420},
+		{MediaDBID: 43, MediaTitleDBID: 430},
+	}).Return(map[int64][]database.TagInfo{42: tags}, nil).Once()
+
+	result, err := HandleMediaHistoryTop(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	resp, ok := result.(models.MediaHistoryTopResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, 3)
+	assert.Equal(t, int64(42), resp.Entries[0].MediaID)
+	assert.Equal(t, tags, resp.Entries[0].Tags)
+	assert.Equal(t, int64(43), resp.Entries[1].MediaID)
+	assert.Equal(t, []database.TagInfo{}, resp.Entries[1].Tags)
+	assert.Zero(t, resp.Entries[2].MediaID)
+	assert.Nil(t, resp.Entries[2].Tags)
+
+	raw, err := json.Marshal(result)
+	require.NoError(t, err)
+	var decoded struct {
+		Entries []map[string]any `json:"entries"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Len(t, decoded.Entries, 3)
+	assert.Len(t, decoded.Entries[0]["tags"], 1)
+	assert.Equal(t, []any{}, decoded.Entries[1]["tags"])
+	assert.NotContains(t, decoded.Entries[2], "tags")
+	mockMediaDB.AssertNumberOfCalls(t, "FindMediaIDsByPaths", 1)
+	mockMediaDB.AssertNumberOfCalls(t, "GetMediaTagsByMediaRefs", 1)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryTop_TagLookupFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "top.sfc")
+	mockUserDB.On("GetMediaHistoryTop", []string(nil), (*time.Time)(nil), 25).
+		Return([]database.MediaHistoryTopEntry{
+			{
+				SystemID: "SNES", MediaName: "Top", MediaPath: mediaPath,
+				TotalPlayTime: 300, SessionCount: 3, LastPlayedAt: time.Now(),
+			},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return([]database.MediaPathID{{SystemID: "SNES", Path: mediaPath, DBID: 42, MediaTitleDBID: 420}}, nil)
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, []database.MediaRef{{MediaDBID: 42, MediaTitleDBID: 420}}).
+		Run(func(args mock.Arguments) {
+			ctx, ok := args.Get(0).(context.Context)
+			require.True(t, ok)
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok, "optional enrichment must have a deadline")
+			assert.WithinDuration(t, time.Now().Add(optionalDBEnrichmentTimeout), deadline, time.Second)
+		}).
+		Return(nil, errors.New("tag lookup failed")).Once()
+
+	result, err := HandleMediaHistoryTop(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	resp, ok := result.(models.MediaHistoryTopResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, 1)
+	assert.Equal(t, int64(42), resp.Entries[0].MediaID)
+	assert.Nil(t, resp.Entries[0].Tags)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryTop_IdentityLookupFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mediaPath := filepath.Join(string(filepath.Separator), "games", "top.sfc")
+	mockUserDB.On("GetMediaHistoryTop", []string(nil), (*time.Time)(nil), 25).
+		Return([]database.MediaHistoryTopEntry{
+			{
+				SystemID: "SNES", MediaName: "Top", MediaPath: mediaPath,
+				TotalPlayTime: 300, SessionCount: 3, LastPlayedAt: time.Now(),
+			},
+		}, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, []string{mediaPath}).
+		Return(nil, errors.New("identity lookup failed"))
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{}, nil).Maybe()
+
+	result, err := HandleMediaHistoryTop(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+	})
+	require.NoError(t, err)
+	resp, ok := result.(models.MediaHistoryTopResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, 1)
+	assert.Zero(t, resp.Entries[0].MediaID)
+	assert.Nil(t, resp.Entries[0].Tags)
+	mockMediaDB.AssertNotCalled(t, "GetMediaTagsByMediaRefs", mock.Anything, mock.Anything)
+	mockUserDB.AssertExpectations(t)
+}
+
+func TestHandleMediaHistoryTop_FullPageUsesSingleTagBatch(t *testing.T) {
+	t.Parallel()
+
+	const pageSize = 100
+	mockUserDB := helpers.NewMockUserDBI()
+	mockMediaDB := helpers.NewMockMediaDBI()
+	now := time.Now()
+	entries := make([]database.MediaHistoryTopEntry, 0, pageSize)
+	rows := make([]database.MediaPathID, 0, pageSize)
+	for i := range pageSize {
+		mediaPath := filepath.Join(string(filepath.Separator), "games", fmt.Sprintf("game-%03d.sfc", i))
+		entries = append(entries, database.MediaHistoryTopEntry{
+			SystemID: "SNES", MediaName: fmt.Sprintf("Game %d", i), MediaPath: mediaPath,
+			TotalPlayTime: pageSize - i, SessionCount: 1, LastPlayedAt: now,
+		})
+		rows = append(rows, database.MediaPathID{
+			SystemID: "SNES", Path: mediaPath, DBID: int64(1000 + i), MediaTitleDBID: int64(10000 + i),
+		})
+	}
+	mockUserDB.On("GetMediaHistoryTop", []string(nil), (*time.Time)(nil), pageSize).Return(entries, nil)
+	mockMediaDB.On("FindMediaIDsByPaths", mock.Anything, mock.MatchedBy(func(paths []string) bool {
+		return len(paths) == pageSize
+	})).Return(rows, nil).Once()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.MatchedBy(func(refs []database.MediaRef) bool {
+		return len(refs) == pageSize
+	})).Return(map[int64][]database.TagInfo{}, nil).Once()
+
+	result, err := HandleMediaHistoryTop(requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{UserDB: mockUserDB, MediaDB: mockMediaDB},
+		Params:   json.RawMessage(`{"limit": 100}`),
+	})
+	require.NoError(t, err)
+	resp, ok := result.(models.MediaHistoryTopResponse)
+	require.True(t, ok)
+	require.Len(t, resp.Entries, pageSize)
+	for i := range resp.Entries {
+		assert.Equal(t, int64(1000+i), resp.Entries[i].MediaID)
+		assert.Equal(t, []database.TagInfo{}, resp.Entries[i].Tags)
+	}
+	mockMediaDB.AssertNumberOfCalls(t, "FindMediaIDsByPaths", 1)
+	mockMediaDB.AssertNumberOfCalls(t, "GetMediaTagsByMediaRefs", 1)
+	mockUserDB.AssertExpectations(t)
+	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/api/methods/media_response_helpers.go
+++ b/pkg/api/methods/media_response_helpers.go
@@ -196,3 +196,66 @@ func mediaIDsByPath(ctx context.Context, db database.MediaDBI, refs []mediaPathR
 	}
 	return mediaIDs
 }
+
+// resolvedMediaRefs flattens resolved rows into media IDs keyed by path ref
+// and a MediaRef list deduplicated by media DBID in entry order, ready for
+// batch cover-status and tag lookups.
+func resolvedMediaRefs(
+	order []mediaPathRef, rows map[mediaPathRef]database.MediaPathID,
+) (map[mediaPathRef]int64, []database.MediaRef) {
+	mediaIDs := make(map[mediaPathRef]int64, len(rows))
+	refs := make([]database.MediaRef, 0, len(rows))
+	seen := make(map[int64]struct{}, len(rows))
+	for _, ref := range order {
+		row := rows[ref]
+		if row.DBID <= 0 {
+			continue
+		}
+		mediaIDs[ref] = row.DBID
+		if _, ok := seen[row.DBID]; ok {
+			continue
+		}
+		seen[row.DBID] = struct{}{}
+		refs = append(refs, database.MediaRef{
+			MediaDBID:      row.DBID,
+			MediaTitleDBID: row.MediaTitleDBID,
+		})
+	}
+	return mediaIDs, refs
+}
+
+// mediaTagsByRefs batch-loads tags for resolved media rows. The bool reports
+// whether tags are known: false means the lookup failed, so callers must omit
+// tags rather than report the media as untagged.
+func mediaTagsByRefs(
+	ctx context.Context, db database.MediaDBI, refs []database.MediaRef,
+) (map[int64][]database.TagInfo, bool) {
+	if db == nil || len(refs) == 0 {
+		return map[int64][]database.TagInfo{}, true
+	}
+	started := time.Now()
+	tags, err := db.GetMediaTagsByMediaRefs(ctx, refs)
+	if err != nil {
+		log.Debug().Err(err).Msg("could not resolve media tags by ref")
+		return nil, false
+	}
+	log.Debug().
+		Int("refs", len(refs)).
+		Int("tagged", len(tags)).
+		Dur("duration", time.Since(started)).
+		Msg("media tag enrichment timing")
+	return tags, true
+}
+
+// mediaEntryTags returns the tags for one response entry: nil (omitted from
+// JSON) when the media is unresolved or tags are unknown, and an empty slice
+// when the media is indexed but untagged.
+func mediaEntryTags(known bool, mediaID int64, tags map[int64][]database.TagInfo) []database.TagInfo {
+	if !known || mediaID <= 0 {
+		return nil
+	}
+	if entryTags := tags[mediaID]; entryTags != nil {
+		return entryTags
+	}
+	return []database.TagInfo{}
+}

--- a/pkg/api/methods/media_response_helpers_test.go
+++ b/pkg/api/methods/media_response_helpers_test.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -245,4 +246,103 @@ func TestMediaIDsByPath_IgnoresRowsForUnrequestedSystems(t *testing.T) {
 		{SystemID: "NES", Path: path}: 10,
 	}, ids)
 	mockDB.AssertExpectations(t)
+}
+
+func TestResolvedMediaRefs_DedupesByMediaIDInEntryOrder(t *testing.T) {
+	t.Parallel()
+
+	first := mediaPathRef{SystemID: "NES", Path: filepath.Join("games", "a.nes")}
+	second := mediaPathRef{SystemID: "NES", Path: filepath.Join("games", "b.nes")}
+	missing := mediaPathRef{SystemID: "NES", Path: filepath.Join("games", "missing.nes")}
+	rows := map[mediaPathRef]database.MediaPathID{
+		first:  {SystemID: "NES", Path: first.Path, DBID: 7, MediaTitleDBID: 70},
+		second: {SystemID: "NES", Path: second.Path, DBID: 5, MediaTitleDBID: 50},
+	}
+
+	mediaIDs, refs := resolvedMediaRefs([]mediaPathRef{first, second, first, missing}, rows)
+
+	assert.Equal(t, map[mediaPathRef]int64{first: 7, second: 5}, mediaIDs)
+	assert.Equal(t, []database.MediaRef{
+		{MediaDBID: 7, MediaTitleDBID: 70},
+		{MediaDBID: 5, MediaTitleDBID: 50},
+	}, refs)
+}
+
+func TestMediaTagsByRefs_EmptyRefsSkipsLookup(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, mock.Anything).
+		Return(map[int64][]database.TagInfo{}, nil).Maybe()
+
+	tags, known := mediaTagsByRefs(context.Background(), mockMediaDB, nil)
+
+	assert.True(t, known)
+	assert.Equal(t, map[int64][]database.TagInfo{}, tags)
+	mockMediaDB.AssertNotCalled(t, "GetMediaTagsByMediaRefs", mock.Anything, mock.Anything)
+}
+
+func TestMediaTagsByRefs_NilDatabaseIsKnownEmpty(t *testing.T) {
+	t.Parallel()
+
+	tags, known := mediaTagsByRefs(context.Background(), nil, []database.MediaRef{{MediaDBID: 1, MediaTitleDBID: 10}})
+
+	assert.True(t, known)
+	assert.Equal(t, map[int64][]database.TagInfo{}, tags)
+}
+
+func TestMediaTagsByRefs_ErrorReturnsUnknown(t *testing.T) {
+	t.Parallel()
+
+	refs := []database.MediaRef{{MediaDBID: 1, MediaTitleDBID: 10}}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, refs).
+		Return(nil, errors.New("tag lookup failed")).Once()
+
+	tags, known := mediaTagsByRefs(context.Background(), mockMediaDB, refs)
+
+	assert.False(t, known)
+	assert.Nil(t, tags)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestMediaTagsByRefs_ReturnsLookupResult(t *testing.T) {
+	t.Parallel()
+
+	refs := []database.MediaRef{{MediaDBID: 1, MediaTitleDBID: 10}}
+	expected := map[int64][]database.TagInfo{1: {{Tag: "favorite", Type: "collection"}}}
+	mockMediaDB := testhelpers.NewMockMediaDBI()
+	mockMediaDB.On("GetMediaTagsByMediaRefs", mock.Anything, refs).Return(expected, nil).Once()
+
+	tags, known := mediaTagsByRefs(context.Background(), mockMediaDB, refs)
+
+	assert.True(t, known)
+	assert.Equal(t, expected, tags)
+	mockMediaDB.AssertExpectations(t)
+}
+
+func TestMediaEntryTags_TriState(t *testing.T) {
+	t.Parallel()
+
+	tagged := []database.TagInfo{{Tag: "favorite", Type: "collection"}}
+	tags := map[int64][]database.TagInfo{1: tagged, 3: nil}
+	tests := []struct {
+		name     string
+		expected []database.TagInfo
+		mediaID  int64
+		known    bool
+	}{
+		{name: "unknown tags omit", known: false, mediaID: 1, expected: nil},
+		{name: "unresolved media omits", known: true, mediaID: 0, expected: nil},
+		{name: "tagged media returns tags", known: true, mediaID: 1, expected: tagged},
+		{name: "untagged media returns empty array", known: true, mediaID: 2, expected: []database.TagInfo{}},
+		{name: "nil map entry returns empty array", known: true, mediaID: 3, expected: []database.TagInfo{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, mediaEntryTags(tt.known, tt.mediaID, tags))
+		})
+	}
 }

--- a/pkg/api/methods/media_search_test.go
+++ b/pkg/api/methods/media_search_test.go
@@ -273,7 +273,7 @@ func TestHandleMediaSearch_IncludesCoverStatus(t *testing.T) {
 				MediaID: 2, MediaTitleID: 22,
 			},
 		}, nil)
-	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaCoverRef{
+	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaRef{
 		{MediaDBID: 1, MediaTitleDBID: 11},
 		{MediaDBID: 2, MediaTitleDBID: 22},
 	}).Return(map[int64]bool{1: true, 2: false}, nil)
@@ -306,7 +306,7 @@ func TestHandleMediaSearch_CoverFailureIsNonFatal(t *testing.T) {
 			SystemID: "NES", Name: "Game", Path: filepath.Join("games", "game.nes"),
 			MediaID: 1, MediaTitleID: 11,
 		}}, nil)
-	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaCoverRef{{
+	mockMediaDB.On("GetMediaCoverStatus", mock.Anything, []database.MediaRef{{
 		MediaDBID: 1, MediaTitleDBID: 11,
 	}}).Run(func(args mock.Arguments) {
 		ctx, ok := args.Get(0).(context.Context)

--- a/pkg/api/models/responses.go
+++ b/pkg/api/models/responses.go
@@ -291,9 +291,14 @@ type MediaHistoryResponseEntry struct {
 	MediaPath  string  `json:"mediaPath"`
 	LauncherID string  `json:"launcherId"`
 	StartedAt  string  `json:"startedAt"`
-	PlayTime   int     `json:"playTime"`
-	MediaID    int64   `json:"mediaId,omitempty"`
-	HasCover   bool    `json:"hasCover"`
+	// Tags is nil when the media is unresolved or tag enrichment failed
+	// (key omitted) and an empty slice when the media is indexed but
+	// untagged (serialised as []). omitzero keeps that distinction;
+	// omitempty would drop the empty array.
+	Tags     []database.TagInfo `json:"tags,omitzero"`
+	PlayTime int                `json:"playTime"`
+	MediaID  int64              `json:"mediaId,omitempty"`
+	HasCover bool               `json:"hasCover"`
 }
 
 type MediaHistoryResponse struct {
@@ -315,15 +320,18 @@ type MediaHistoryLatestResponse struct {
 }
 
 type MediaHistoryTopEntry struct {
-	RelPath       *string `json:"relativePath,omitempty"`
-	SystemID      string  `json:"systemId"`
-	SystemName    string  `json:"systemName"`
-	MediaName     string  `json:"mediaName"`
-	MediaPath     string  `json:"mediaPath"`
-	LastPlayedAt  string  `json:"lastPlayedAt"`
-	TotalPlayTime int     `json:"totalPlayTime"`
-	SessionCount  int     `json:"sessionCount"`
-	MediaID       int64   `json:"mediaId,omitempty"`
+	RelPath      *string `json:"relativePath,omitempty"`
+	SystemID     string  `json:"systemId"`
+	SystemName   string  `json:"systemName"`
+	MediaName    string  `json:"mediaName"`
+	MediaPath    string  `json:"mediaPath"`
+	LastPlayedAt string  `json:"lastPlayedAt"`
+	// Tags follows the same nil-omitted / empty-array rule as
+	// MediaHistoryResponseEntry.Tags.
+	Tags          []database.TagInfo `json:"tags,omitzero"`
+	TotalPlayTime int                `json:"totalPlayTime"`
+	SessionCount  int                `json:"sessionCount"`
+	MediaID       int64              `json:"mediaId,omitempty"`
 }
 
 type MediaHistoryTopResponse struct {

--- a/pkg/api/models/responses_test.go
+++ b/pkg/api/models/responses_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -396,5 +397,66 @@ func TestClientsPairedNotification_JSONShape(t *testing.T) {
 		_, present := got[k]
 		assert.False(t, present,
 			"clients.paired notification must never include %q", k)
+	}
+}
+
+func marshalledTagsField(t *testing.T, value any) (any, bool) {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	require.NoError(t, err)
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(raw, &fields))
+	tags, present := fields["tags"]
+	return tags, present
+}
+
+func TestMediaHistoryEntries_TagsJSONTriState(t *testing.T) {
+	t.Parallel()
+
+	populated := []database.TagInfo{{Tag: "favorite", Type: "collection", Label: "Favorite"}}
+	tests := []struct {
+		value       any
+		name        string
+		wantPresent bool
+		wantLen     int
+	}{
+		{name: "history nil tags omitted", value: MediaHistoryResponseEntry{}},
+		{
+			name:        "history empty tags serialised as empty array",
+			value:       MediaHistoryResponseEntry{Tags: []database.TagInfo{}},
+			wantPresent: true,
+		},
+		{
+			name:        "history populated tags",
+			value:       MediaHistoryResponseEntry{Tags: populated},
+			wantPresent: true,
+			wantLen:     1,
+		},
+		{name: "top nil tags omitted", value: MediaHistoryTopEntry{}},
+		{
+			name:        "top empty tags serialised as empty array",
+			value:       MediaHistoryTopEntry{Tags: []database.TagInfo{}},
+			wantPresent: true,
+		},
+		{
+			name:        "top populated tags",
+			value:       MediaHistoryTopEntry{Tags: populated},
+			wantPresent: true,
+			wantLen:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tags, present := marshalledTagsField(t, tt.value)
+			require.Equal(t, tt.wantPresent, present)
+			if !tt.wantPresent {
+				return
+			}
+			list, ok := tags.([]any)
+			require.True(t, ok, "tags must serialise as a JSON array, got %T", tags)
+			assert.Len(t, list, tt.wantLen)
+		})
 	}
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -249,8 +249,9 @@ type MediaPathID struct {
 	MediaTitleDBID int64
 }
 
-// MediaCoverRef identifies media and title rows for a cover-status lookup.
-type MediaCoverRef struct {
+// MediaRef identifies a Media row and its MediaTitle row for batch lookups
+// such as cover status and tags.
+type MediaRef struct {
 	MediaDBID      int64
 	MediaTitleDBID int64
 }
@@ -1109,7 +1110,7 @@ type MediaDBI interface {
 	BrowseFiles(ctx context.Context, opts *BrowseFilesOptions) ([]SearchResultWithCursor, error)
 	// GetMediaCoverStatus returns statuses keyed by MediaDBID. True means a media-
 	// or title-level image exists; absent keys mean no cover.
-	GetMediaCoverStatus(ctx context.Context, refs []MediaCoverRef) (map[int64]bool, error)
+	GetMediaCoverStatus(ctx context.Context, refs []MediaRef) (map[int64]bool, error)
 	BrowseFileCount(ctx context.Context, opts BrowseFileCountOptions) (int, error)
 	BrowseIndex(ctx context.Context, opts BrowseIndexOptions) (BrowseIndexResult, error)
 	BrowseVirtualSchemes(ctx context.Context, opts BrowseVirtualSchemesOptions) ([]BrowseVirtualScheme, error)
@@ -1329,6 +1330,15 @@ type MediaDBI interface {
 	// (MediaTitleTags) for a single MediaTitle row.
 	GetMediaTitleTagsByMediaTitleDBID(ctx context.Context, mediaTitleDBID int64) ([]TagInfo, error)
 	GetMediaTitleTagsByMediaTitleDBIDs(ctx context.Context, mediaTitleDBIDs []int64) (map[int64][]TagInfo, error)
+
+	// GetMediaTagsByMediaRefs returns the merged file-level (MediaTags) and
+	// title-level (MediaTitleTags) tags for each referenced media row, keyed
+	// by MediaDBID. This is the same tag view media.search attaches to
+	// results, unlike GetMediaTagsByMediaDBIDs which is file-level only.
+	// Tags are deduplicated by (type, tag) and sorted by type then tag.
+	// Untagged media have no map entry. Refs with MediaDBID <= 0 are ignored.
+	// The lookup is batched internally under the SQLite parameter limit.
+	GetMediaTagsByMediaRefs(ctx context.Context, refs []MediaRef) (map[int64][]TagInfo, error)
 
 	// UpsertMediaBlob inserts a blob into MediaBlobs when no row with the same
 	// SHA-256 hash of framed content type and bytes already exists, then returns its DBID.

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -2933,7 +2933,7 @@ func (db *MediaDB) BrowseFiles(
 
 // GetMediaCoverStatus reports image-property availability at media or title scope.
 func (db *MediaDB) GetMediaCoverStatus(
-	ctx context.Context, refs []database.MediaCoverRef,
+	ctx context.Context, refs []database.MediaRef,
 ) (map[int64]bool, error) {
 	if db.sql.Load() == nil {
 		return nil, ErrNullSQL

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -1793,7 +1793,7 @@ func queryImagePropertyEntityIDChunk(
 }
 
 func fetchCoverStatuses(
-	ctx context.Context, db sqlQueryable, refs []database.MediaCoverRef,
+	ctx context.Context, db sqlQueryable, refs []database.MediaRef,
 ) (map[int64]bool, error) {
 	statuses := make(map[int64]bool, len(refs))
 	results := make([]database.SearchResultWithCursor, 0, len(refs))

--- a/pkg/database/mediadb/sql_browse_test.go
+++ b/pkg/database/mediadb/sql_browse_test.go
@@ -1195,7 +1195,7 @@ func TestFetchAndAttachCoverFlags_Integration_MediaLevelProperty(t *testing.T) {
 	assert.True(t, results[0].HasCover, "media with image property should have HasCover=true")
 	assert.False(t, results[1].HasCover, "media without image property should have HasCover=false")
 
-	statuses, err := mediaDB.GetMediaCoverStatus(ctx, []database.MediaCoverRef{
+	statuses, err := mediaDB.GetMediaCoverStatus(ctx, []database.MediaRef{
 		{MediaDBID: mediaA.DBID, MediaTitleDBID: titleA.DBID},
 		{MediaDBID: mediaB.DBID, MediaTitleDBID: titleB.DBID},
 		{MediaDBID: mediaA.DBID, MediaTitleDBID: titleA.DBID},
@@ -1253,7 +1253,7 @@ func TestCoverAvailabilityIndex_AsyncBuildAndInvalidation(t *testing.T) {
 	assert.True(t, index.hasTitle(title.DBID))
 	assert.False(t, index.hasMedia(media.DBID))
 
-	statuses, err := mediaDB.GetMediaCoverStatus(ctx, []database.MediaCoverRef{
+	statuses, err := mediaDB.GetMediaCoverStatus(ctx, []database.MediaRef{
 		{MediaDBID: media.DBID, MediaTitleDBID: title.DBID},
 		{MediaDBID: media.DBID + 1, MediaTitleDBID: title.DBID + 1},
 	})

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -3087,6 +3087,24 @@ func (db *MediaDB) GetMediaTitleTagsByMediaTitleDBIDs(
 	return scanGroupedTagInfos(rows)
 }
 
+// GetMediaTagsByMediaRefs returns the merged file-level and title-level tags
+// for each referenced media row, keyed by MediaDBID, matching the tag view
+// media.search attaches to results.
+func (db *MediaDB) GetMediaTagsByMediaRefs(
+	ctx context.Context, refs []database.MediaRef,
+) (map[int64][]database.TagInfo, error) {
+	if len(refs) == 0 {
+		return map[int64][]database.TagInfo{}, nil
+	}
+	sqlDB := db.sql.Load()
+	if sqlDB == nil {
+		return nil, ErrNullSQL
+	}
+	merged, err := fetchTagsByRefs(ctx, sqlDB, refs)
+	db.NoteCorruption(err)
+	return merged, err
+}
+
 type propertyGroupMode int
 
 const (

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2653,3 +2653,102 @@ func TestResolveSingletonContainerAliases_HasCoverSetFromTitleProperty(t *testin
 	assert.True(t, byDir[coverDir].HasCover, "aliased dir with title-scope image property should have HasCover=true")
 	assert.False(t, byDir[noCoverDir].HasCover, "aliased dir without image property should have HasCover=false")
 }
+
+// seedMediaRefTagFixture adds Media 2 (Title 2, untagged) and Media 3 (Title
+// 1, no file tags) beside the seeded Media 1, then tags Media 1 at file level
+// and Title 1 at title level so file/title merging and fan-out are observable.
+func seedMediaRefTagFixture(t *testing.T, mediaDB *MediaDB) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (2, 1, 'zelda', 'Zelda');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (2, 2, 1, ?);
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path) VALUES (3, 1, 1, ?);
+	`, filepath.ToSlash(filepath.Join("roms", "zelda.nes")), filepath.ToSlash(filepath.Join("roms", "mario-alt.nes")))
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.UpsertMediaTags(ctx, 1, []database.TagInfo{
+		{Type: "developer", Tag: "nintendo", Label: "Nintendo"},
+		{Type: "scraper.test", Tag: "alpha", Label: "Alpha"},
+	}))
+	require.NoError(t, mediaDB.UpsertMediaTitleTags(ctx, 1, []database.TagInfo{
+		{Type: "scraper.test", Tag: "alpha", Label: "Alpha"},
+	}))
+}
+
+func TestGetMediaTagsByMediaRefs_MergesFileAndTitleTags(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	seedMediaRefTagFixture(t, mediaDB)
+
+	got, err := mediaDB.GetMediaTagsByMediaRefs(context.Background(), []database.MediaRef{
+		{MediaDBID: 1, MediaTitleDBID: 1},
+		{MediaDBID: 2, MediaTitleDBID: 2},
+		{MediaDBID: 3, MediaTitleDBID: 1},
+		{MediaDBID: 999, MediaTitleDBID: 999},
+		{},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "nintendo", Type: "developer", Label: "Nintendo"},
+		{Tag: "alpha", Type: "scraper.test", Label: "Alpha"},
+	}, got[1], "file and title tags merge, duplicates collapse, sorted by type then tag")
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "alpha", Type: "scraper.test", Label: "Alpha"},
+	}, got[3], "title tags fan out to sibling media without its file tags")
+	assert.NotContains(t, got, int64(2), "untagged media has no entry")
+	assert.NotContains(t, got, int64(999))
+	assert.NotContains(t, got, int64(0))
+	assert.Len(t, got, 2)
+}
+
+func TestGetMediaTagsByMediaRefs_EmptyRefsReturnEmptyMap(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+
+	got, err := mediaDB.GetMediaTagsByMediaRefs(context.Background(), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+
+	got, err = mediaDB.GetMediaTagsByMediaRefs(context.Background(), []database.MediaRef{{}, {MediaDBID: -1}})
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+func TestGetMediaTagsByMediaRefs_ChunksBeyondSQLiteParamLimit(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupScraperTestDB(t)
+	defer cleanup()
+	seedMediaRefTagFixture(t, mediaDB)
+
+	// Well over the 999-parameter limit once media and title IDs are both
+	// bound. Filler refs use nonexistent media and title IDs so they cannot
+	// pick up tags; the real rows sit at both ends so fan-out has to work
+	// across chunks, and Media 1 repeats to prove deduplication.
+	const fillerCount = 1200
+	refs := make([]database.MediaRef, 0, fillerCount+3)
+	refs = append(refs, database.MediaRef{MediaDBID: 1, MediaTitleDBID: 1})
+	for i := range fillerCount {
+		refs = append(refs, database.MediaRef{MediaDBID: int64(10_000 + i), MediaTitleDBID: int64(20_000 + i)})
+	}
+	refs = append(refs,
+		database.MediaRef{MediaDBID: 1, MediaTitleDBID: 1},
+		database.MediaRef{MediaDBID: 3, MediaTitleDBID: 1},
+	)
+
+	got, err := mediaDB.GetMediaTagsByMediaRefs(context.Background(), refs)
+	require.NoError(t, err)
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "nintendo", Type: "developer", Label: "Nintendo"},
+		{Tag: "alpha", Type: "scraper.test", Label: "Alpha"},
+	}, got[1])
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "alpha", Type: "scraper.test", Label: "Alpha"},
+	}, got[3])
+	assert.Len(t, got, 2)
+}

--- a/pkg/database/mediadb/sql_search.go
+++ b/pkg/database/mediadb/sql_search.go
@@ -42,6 +42,9 @@ const (
 	largeCandidateScanFloor = 10_000
 	maxScopedStreamSystems  = 4
 	tagPreflightMaxResults  = 25
+	// tagRefsPerQuery bounds one tag batch so its media and title ID lists
+	// together stay under the SQLite parameter limit.
+	tagRefsPerQuery = sqliteMaxParams / 2
 )
 
 var errSearchCandidateSetTooSparse = errors.New("large media search candidate set is too sparse to stream")
@@ -184,6 +187,37 @@ func fetchAndAttachTagsByResultIDs(
 		}
 	}
 
+	tagQueryStarted := time.Now()
+	fetched, err := fetchTagsBySourceIDs(ctx, db, tagIDs)
+	if err != nil {
+		return err
+	}
+
+	finishAttachTags(results, fetched.tagsMap)
+	attachZapScriptTagsFromFetchedTags(results, fetched.mediaTagKeys)
+	log.Debug().
+		Int("rows", len(results)).
+		Int("tagPairs", len(fetched.tagsMap)).
+		Dur("preflightDuration", preflightDuration).
+		Dur("tagQueryDuration", time.Since(tagQueryStarted)).
+		Dur("duration", time.Since(unionStarted)).
+		Msg("fetch and attach tags by result IDs timing")
+	logFetchAndAttachTagsTiming(results, len(fetched.tagsMap), unionStarted)
+	return nil
+}
+
+// sourceTags is the result of one tag batch: tagsMap holds the merged
+// file-level and title-level tags per media DBID (unsorted, deduplicated by
+// type and tag), and mediaTagKeys records which of those pairs came from the
+// file-level MediaTags table.
+type sourceTags struct {
+	tagsMap      map[int64][]database.TagInfo
+	mediaTagKeys map[int64]map[tagKey]struct{}
+}
+
+// fetchTagsBySourceIDs runs the media-ID plus title-ID tag query for one
+// batch and fans title-level tags out to every media row sharing the title.
+func fetchTagsBySourceIDs(ctx context.Context, db sqlQueryable, tagIDs resultTagIDs) (sourceTags, error) {
 	mediaPlaceholders := prepareVariadic("?", ",", len(tagIDs.mediaIDs))
 	titlePlaceholders := prepareVariadic("?", ",", len(tagIDs.titleIDs))
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?"
@@ -220,10 +254,9 @@ func fetchAndAttachTagsByResultIDs(
 		tagsArgs = append(tagsArgs, id)
 	}
 
-	tagQueryStarted := time.Now()
 	tagsStmt, err := db.PrepareContext(ctx, tagsQuery)
 	if err != nil {
-		return fmt.Errorf("failed to prepare tags query: %w", err)
+		return sourceTags{}, fmt.Errorf("failed to prepare tags query: %w", err)
 	}
 	defer func() {
 		if closeErr := tagsStmt.Close(); closeErr != nil {
@@ -233,7 +266,7 @@ func fetchAndAttachTagsByResultIDs(
 
 	tagsRows, err := tagsStmt.QueryContext(ctx, tagsArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to execute tags query: %w", err)
+		return sourceTags{}, fmt.Errorf("failed to execute tags query: %w", err)
 	}
 	defer func() {
 		if closeErr := tagsRows.Close(); closeErr != nil {
@@ -241,51 +274,116 @@ func fetchAndAttachTagsByResultIDs(
 		}
 	}()
 
-	tagsMap := make(map[int64][]database.TagInfo)
+	fetched := sourceTags{
+		tagsMap:      make(map[int64][]database.TagInfo),
+		mediaTagKeys: make(map[int64]map[tagKey]struct{}),
+	}
 	seen := make(map[int64]map[tagKey]int)
-	mediaTagKeys := make(map[int64]map[tagKey]struct{})
 	for tagsRows.Next() {
 		tagRow, scanErr := scanSourceTagRow(tagsRows)
 		if scanErr != nil {
-			return fmt.Errorf("failed to scan tags result: %w", scanErr)
+			return sourceTags{}, fmt.Errorf("failed to scan tags result: %w", scanErr)
 		}
 
 		mediaIDsForTag := []int64{tagRow.sourceID}
 		if tagRow.sourceKind == 1 {
 			mediaIDsForTag = tagIDs.titleToMediaIDs[tagRow.sourceID]
 		} else {
-			keys := mediaTagKeys[tagRow.sourceID]
+			keys := fetched.mediaTagKeys[tagRow.sourceID]
 			if keys == nil {
 				keys = make(map[tagKey]struct{})
-				mediaTagKeys[tagRow.sourceID] = keys
+				fetched.mediaTagKeys[tagRow.sourceID] = keys
 			}
 			keys[tagKey{typ: tagRow.tagType, tag: dbtags.UnpadTagValue(tagRow.tag)}] = struct{}{}
 		}
 		for _, mediaID := range mediaIDsForTag {
-			appendTagInfo(tagsMap, seen, mediaID, tagRow.tag, tagRow.tagType, tagRow.label)
+			appendTagInfo(fetched.tagsMap, seen, mediaID, tagRow.tag, tagRow.tagType, tagRow.label)
 		}
 	}
 	if err = tagsRows.Err(); err != nil {
-		return fmt.Errorf("tags rows iteration error: %w", err)
+		return sourceTags{}, fmt.Errorf("tags rows iteration error: %w", err)
+	}
+	return fetched, nil
+}
+
+// fetchTagsByRefs returns the merged file-level and title-level tags for each
+// referenced media row, keyed by MediaDBID, through the same query path search
+// results use. Refs are deduplicated by MediaDBID and queried in chunks that
+// stay under the SQLite parameter limit. Untagged media have no map entry.
+func fetchTagsByRefs(
+	ctx context.Context, db sqlQueryable, refs []database.MediaRef,
+) (map[int64][]database.TagInfo, error) {
+	unique := make([]database.MediaRef, 0, len(refs))
+	seen := make(map[int64]struct{}, len(refs))
+	for _, ref := range refs {
+		if ref.MediaDBID <= 0 {
+			continue
+		}
+		if _, dup := seen[ref.MediaDBID]; dup {
+			continue
+		}
+		seen[ref.MediaDBID] = struct{}{}
+		unique = append(unique, ref)
 	}
 
-	finishAttachTags(results, tagsMap)
-	attachZapScriptTagsFromFetchedTags(results, mediaTagKeys)
-	log.Debug().
-		Int("rows", len(results)).
-		Int("tagPairs", len(tagsMap)).
-		Dur("preflightDuration", preflightDuration).
-		Dur("tagQueryDuration", time.Since(tagQueryStarted)).
-		Dur("duration", time.Since(unionStarted)).
-		Msg("fetch and attach tags by result IDs timing")
-	logFetchAndAttachTagsTiming(results, len(tagsMap), unionStarted)
-	return nil
+	tagsMap := make(map[int64][]database.TagInfo, len(unique))
+	if len(unique) == 0 {
+		return tagsMap, nil
+	}
+	if len(unique) <= tagPreflightMaxResults {
+		tagIDs := collectRefTagIDs(unique)
+		hasTags, err := resultIDsHaveTags(ctx, db, tagIDs.mediaIDs, tagIDs.titleIDs)
+		if err != nil {
+			return nil, err
+		}
+		if !hasTags {
+			return tagsMap, nil
+		}
+	}
+
+	for start := 0; start < len(unique); start += tagRefsPerQuery {
+		chunk := unique[start:min(start+tagRefsPerQuery, len(unique))]
+		fetched, err := fetchTagsBySourceIDs(ctx, db, collectRefTagIDs(chunk))
+		if err != nil {
+			return nil, err
+		}
+		// Each media DBID lives in exactly one chunk, so assignment is a merge.
+		for mediaID, tags := range fetched.tagsMap {
+			sortTagInfos(tags)
+			tagsMap[mediaID] = tags
+		}
+	}
+	return tagsMap, nil
 }
 
 type resultTagIDs struct {
 	titleToMediaIDs map[int64][]int64
 	mediaIDs        []int64
 	titleIDs        []int64
+}
+
+// collectRefTagIDs builds the source ID sets for a batch of media refs that
+// are already unique by MediaDBID. Title IDs are deduplicated and refs
+// without a title only contribute their media ID.
+func collectRefTagIDs(refs []database.MediaRef) resultTagIDs {
+	tagIDs := resultTagIDs{
+		mediaIDs:        make([]int64, 0, len(refs)),
+		titleToMediaIDs: make(map[int64][]int64, len(refs)),
+		titleIDs:        make([]int64, 0, len(refs)),
+	}
+	for _, ref := range refs {
+		tagIDs.mediaIDs = append(tagIDs.mediaIDs, ref.MediaDBID)
+		if ref.MediaTitleDBID <= 0 {
+			continue
+		}
+		if _, ok := tagIDs.titleToMediaIDs[ref.MediaTitleDBID]; !ok {
+			tagIDs.titleIDs = append(tagIDs.titleIDs, ref.MediaTitleDBID)
+		}
+		tagIDs.titleToMediaIDs[ref.MediaTitleDBID] = append(
+			tagIDs.titleToMediaIDs[ref.MediaTitleDBID], ref.MediaDBID,
+		)
+	}
+	return tagIDs
 }
 
 func collectResultTagIDs(results []database.SearchResultWithCursor) resultTagIDs {
@@ -428,15 +526,20 @@ func appendTagInfo(
 	tagsMap[mediaID] = append(tagsMap[mediaID], tagInfo)
 }
 
+// sortTagInfos orders tags by type then tag, the order every tag list in an
+// API response uses.
+func sortTagInfos(tags []database.TagInfo) {
+	sort.Slice(tags, func(i, j int) bool {
+		if tags[i].Type != tags[j].Type {
+			return tags[i].Type < tags[j].Type
+		}
+		return tags[i].Tag < tags[j].Tag
+	})
+}
+
 func finishAttachTags(results []database.SearchResultWithCursor, tagsMap map[int64][]database.TagInfo) {
 	for mediaID := range tagsMap {
-		tags := tagsMap[mediaID]
-		sort.Slice(tags, func(i, j int) bool {
-			if tags[i].Type != tags[j].Type {
-				return tags[i].Type < tags[j].Type
-			}
-			return tags[i].Tag < tags[j].Tag
-		})
+		sortTagInfos(tagsMap[mediaID])
 	}
 
 	for i := range results {

--- a/pkg/database/mediadb/sql_search_test.go
+++ b/pkg/database/mediadb/sql_search_test.go
@@ -1049,3 +1049,89 @@ func TestSQLSelectRandomGameWithStats_SparseUsesUniformOrdinal(t *testing.T) {
 // disambiguation_test.go (RecomputeSystemDisambiguation + attachZapScriptTags),
 // since the logic now lives in stored per-title types rather than in-memory
 // page grouping.
+
+func TestFetchTagsByRefs_OneQueryPerChunk(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Two full chunks and no preflight (well above tagPreflightMaxResults).
+	refs := make([]database.MediaRef, 0, 2*tagRefsPerQuery)
+	for i := range 2 * tagRefsPerQuery {
+		refs = append(refs, database.MediaRef{MediaDBID: int64(i + 1), MediaTitleDBID: int64(5000 + i)})
+	}
+	tagColumns := []string{"SourceKind", "SourceDBID", "Tag", "Type", "DisplayName"}
+	mock.ExpectPrepare(`SELECT.*SourceKind.*SourceDBID.*FROM MediaTags.*FROM MediaTitleTags`).
+		ExpectQuery().
+		WillReturnRows(sqlmock.NewRows(tagColumns).AddRow(0, int64(1), "Rev A", "rev", "Revision A"))
+	mock.ExpectPrepare(`SELECT.*SourceKind.*SourceDBID.*FROM MediaTags.*FROM MediaTitleTags`).
+		ExpectQuery().
+		WillReturnRows(sqlmock.NewRows(tagColumns).AddRow(1, int64(5000+tagRefsPerQuery), "1990", "year", "1990"))
+
+	tags, err := fetchTagsByRefs(context.Background(), db, refs)
+	require.NoError(t, err)
+
+	assert.Equal(t, []database.TagInfo{{Tag: "Rev A", Type: "rev", Label: "Revision A"}}, tags[1])
+	assert.Equal(t, []database.TagInfo{{Tag: "1990", Type: "year", Label: "1990"}}, tags[int64(tagRefsPerQuery+1)])
+	assert.Len(t, tags, 2)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchTagsByRefs_PreflightSkipsFullQuery(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT EXISTS.*MediaTags.*MediaTitleTags`).
+		WithArgs(int64(1), int64(2), int64(3), int64(10), int64(30)).
+		WillReturnRows(sqlmock.NewRows([]string{"hasTags"}).AddRow(false))
+
+	tags, err := fetchTagsByRefs(context.Background(), db, []database.MediaRef{
+		{MediaDBID: 1, MediaTitleDBID: 10},
+		{MediaDBID: 2, MediaTitleDBID: 10},
+		{MediaDBID: 3, MediaTitleDBID: 30},
+	})
+	require.NoError(t, err)
+
+	assert.NotNil(t, tags)
+	assert.Empty(t, tags)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFetchTagsByRefs_DedupesRefsBeforeQuery(t *testing.T) {
+	t.Parallel()
+	db, mock, err := testsqlmock.NewSQLMock()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery(`SELECT EXISTS.*MediaTags.*MediaTitleTags`).
+		WithArgs(int64(1), int64(2), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"hasTags"}).AddRow(true))
+	mock.ExpectPrepare(`SELECT.*SourceKind.*SourceDBID.*FROM MediaTags.*FROM MediaTitleTags`).
+		ExpectQuery().
+		WithArgs(int64(1), int64(2), int64(10)).
+		WillReturnRows(sqlmock.NewRows([]string{"SourceKind", "SourceDBID", "Tag", "Type", "DisplayName"}).
+			AddRow(0, int64(1), "Rev A", "rev", "Revision A").
+			AddRow(1, int64(10), "Action", "genre", "Action").
+			AddRow(1, int64(10), "Rev A", "rev", ""))
+
+	tags, err := fetchTagsByRefs(context.Background(), db, []database.MediaRef{
+		{MediaDBID: 1, MediaTitleDBID: 10},
+		{MediaDBID: 1, MediaTitleDBID: 10},
+		{MediaDBID: 2, MediaTitleDBID: 10},
+		{MediaDBID: 0, MediaTitleDBID: 10},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "Action", Type: "genre", Label: "Action"},
+		{Tag: "Rev A", Type: "rev", Label: "Revision A"},
+	}, tags[1], "file and title copies of the same tag collapse, keeping the label")
+	assert.Equal(t, []database.TagInfo{
+		{Tag: "Action", Type: "genre", Label: "Action"},
+		{Tag: "Rev A", Type: "rev"},
+	}, tags[2])
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -2866,7 +2866,7 @@ func (m *MockMediaDBI) BrowseFiles(
 }
 
 func (m *MockMediaDBI) GetMediaCoverStatus(
-	ctx context.Context, refs []database.MediaCoverRef,
+	ctx context.Context, refs []database.MediaRef,
 ) (map[int64]bool, error) {
 	if !m.hasExpectedCall("GetMediaCoverStatus") {
 		return map[int64]bool{}, nil
@@ -3426,6 +3426,19 @@ func (m *MockMediaDBI) GetMediaTitleTagsByMediaTitleDBIDs(
 	ctx context.Context, mediaTitleDBIDs []int64,
 ) (map[int64][]database.TagInfo, error) {
 	args := m.Called(ctx, mediaTitleDBIDs)
+	if result, ok := args.Get(0).(map[int64][]database.TagInfo); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
+func (m *MockMediaDBI) GetMediaTagsByMediaRefs(
+	ctx context.Context, refs []database.MediaRef,
+) (map[int64][]database.TagInfo, error) {
+	if !m.hasExpectedCall("GetMediaTagsByMediaRefs") {
+		return map[int64][]database.TagInfo{}, nil
+	}
+	args := m.Called(ctx, refs)
 	if result, ok := args.Get(0).(map[int64][]database.TagInfo); ok {
 		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 	}


### PR DESCRIPTION
- Add a `tags` field (`TagInfo[]`) to `media.history` and `media.history.top` entries so clients can read favourite state without a `media.meta` call per row. Tags are loaded in one batched MediaDB call per request under the existing 500ms enrichment budget, and enrichment failures still return the UserDB history as before.
- The field is omitted when a history row cannot be resolved in MediaDB or the tag lookup fails, and is an empty array when the media is indexed but has no tags. The field uses `omitzero` so the empty array survives serialisation.
- Add `MediaDBI.GetMediaTagsByMediaRefs`, which returns the same merged file-level and title-level tag view that `media.search` attaches to results. The search tag query is extracted into a shared `fetchTagsBySourceIDs` so both paths run identical SQL; refs are deduplicated and chunked under the SQLite parameter limit.
- Rename `MediaCoverRef` to `MediaRef` so the cover-status and tag lookups share one ref type, and switch `media.history.top` to the same path resolution `media.history` uses so title IDs are available.
- `media.history.latest` is unchanged. API docs updated for both entry objects.
- Tests cover tagged and untagged media, unresolved rows, identity/cover/tag lookup failures independently, repeated media rows, full 100-entry pages with a single batch call, JSON omission versus empty array, the unchanged latest endpoint, and the new MediaDB method against a real database including chunking past the parameter limit.

Closes #1323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional tags to media history and top-history API responses.
  * Tags combine file-level and title-level metadata, with duplicates removed and results consistently ordered.
  * Untagged indexed media now returns an empty tag list, while unavailable metadata remains omitted.
* **Bug Fixes**
  * Improved resilience when media or tag lookups fail; history responses continue loading without tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->