### PR TITLE
perf(mediadb): skip unchanged reconciles and finish the #1279 hardening

### DIFF
--- a/pkg/database/corruption.go
+++ b/pkg/database/corruption.go
@@ -124,7 +124,8 @@ func NoteCorruption(dbPath string, err error, now time.Time) bool {
 // the forensic copy could not be made. dbLabel names the database in the log
 // line (e.g. "media", "user").
 func PreserveCorruptFile(path, dbLabel string) {
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
 		return
 	} else if err != nil {
 		log.Warn().Err(err).Str("db", dbLabel).Str("path", path).Msg("failed to stat corrupt database file")
@@ -134,7 +135,15 @@ func PreserveCorruptFile(path, dbLabel string) {
 	_ = os.Remove(backup)
 	if err := os.Rename(path, backup); err != nil {
 		log.Warn().Err(err).Str("db", dbLabel).Str("path", path).Msg("failed to preserve corrupt database file")
+		return
 	}
+	// Logged at warn with the rest of the recovery trail: this is the file a
+	// corruption report needs, and the line is how its author finds it.
+	log.Warn().
+		Str("db", dbLabel).
+		Str("path", backup).
+		Int64("bytes", info.Size()).
+		Msg("preserved corrupt database file for post-mortem")
 }
 
 // RemoveSidecars deletes the -wal and -shm sidecar files for dbPath. A stale WAL

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -834,6 +834,11 @@ type ScanReconcileStats struct {
 	// SystemKnown is false when the system has no DB row and nothing was staged,
 	// meaning the reconcile was a no-op and no Systems row was created.
 	SystemKnown bool
+	// Unchanged is true when the staged set matched the fingerprint stored by
+	// the previous successful reconcile and its durable-state guards held, so
+	// every reconcile statement was skipped as provably a no-op. The staging
+	// tables are still cleared and the counts above are all zero.
+	Unchanged bool
 }
 
 // JournalMode represents SQLite journal mode

--- a/pkg/database/mediadb/crash_consistency_test.go
+++ b/pkg/database/mediadb/crash_consistency_test.go
@@ -1,0 +1,465 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests reproduce, deterministically and without hardware, the failure
+// boundaries the MiSTer corruption reports (#1279) cluster around: power loss
+// after a commit but before its checkpoint, mid-transaction with dirty pages
+// already spilled to the WAL, a torn write at the WAL tail, and a checkpoint
+// interrupted part-way through copying frames into the main file. Each one
+// drives the production indexing write path — staging, the tag-link reconcile,
+// commit — against a real file-backed database, then copies the on-disk files
+// to a fresh directory to stand in for what storage would have preserved, and
+// damages the copy where the failure would have. Reopening the copy is the
+// recovery SQLite performs at the next boot; what these pin down is that the
+// data it recovers is exactly the committed set and the file passes an
+// integrity check. The one storage failure they cannot model is a drive that
+// acknowledges an fsync it did not perform, which is the case the corruption
+// marker and rebuild exist for (see TestMediaDB_ZeroedPages_DetectedAndRecovered).
+
+const crashTestFilesPerSystem = 150
+
+// stageSystemFiles indexes n synthetic files for systemID through the
+// production staging path — staging rows with canonical and dynamic tags, the
+// set-based reconcile, and the batch commit — and returns the reconcile stats.
+func stageSystemFiles(t *testing.T, h *walTestDB, systemID, prefix string, n int) database.ScanReconcileStats {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, h.db.BeginTransaction(true))
+	require.NoError(t, h.db.ClearScanStage())
+	for i := range n {
+		path := fmt.Sprintf("/roms/%s/%s %03d (USA).bin", systemID, prefix, i)
+		require.NoError(t, h.db.StageScannedMedia(&database.ScanStagedMedia{
+			Path:          path,
+			ParentDir:     ParentDirForMediaPath(path),
+			Slug:          fmt.Sprintf("%s%03d", strings.ToLower(prefix), i),
+			TitleName:     fmt.Sprintf("%s %03d", prefix, i),
+			SortName:      fmt.Sprintf("%s %03d", prefix, i),
+			SlugLength:    len(prefix) + 3,
+			SlugWordCount: 2,
+			Tags: []database.ScanStagedTag{
+				{Type: string(tags.TagTypeRegion), Value: "us"},
+				{Type: string(tags.TagTypeExtension), Value: "bin"},
+			},
+		}))
+	}
+	stats, err := h.db.ReconcileStagedSystem(ctx, systemID, database.ScanReconcileOpts{})
+	require.NoError(t, err)
+	require.NoError(t, h.db.CommitTransaction())
+	return stats
+}
+
+// newCrashTestDB is a file-backed MediaDB with the canonical tag vocabulary
+// seeded and the WAL truncated to empty, so the frames a test then writes are
+// the only ones in it and can be attributed to individual commits by offset.
+func newCrashTestDB(t *testing.T) *walTestDB {
+	t.Helper()
+	h := newWALTestDB(t)
+	h.db.batchSize = 5000 // production default; newWALTestDB only exercises the prepared-statement path
+	ctx := context.Background()
+	require.NoError(t, h.db.BeginTransaction(false))
+	require.NoError(t, h.db.SeedCanonicalTagDefinitions(ctx))
+	require.NoError(t, h.db.CommitTransaction())
+	require.NoError(t, h.db.WALCheckpoint())
+	require.Zero(t, walSize(t, h.dbPath), "the WAL must start empty so every frame is attributable")
+	return &h
+}
+
+func copyFileIfExists(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src) //nolint:gosec // test-controlled temp paths
+	if os.IsNotExist(err) {
+		return
+	}
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(dst, data, 0o600)) //nolint:gosec // test-controlled temp path
+}
+
+// snapshotDatabase copies the database and whichever sidecars exist to a fresh
+// directory: the on-disk state a power loss at that instant would have left
+// for the next boot to recover from.
+func snapshotDatabase(t *testing.T, dbPath string) string {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), "crash.db")
+	copyFileIfExists(t, dbPath, target)
+	copyFileIfExists(t, dbPath+"-wal", target+"-wal")
+	copyFileIfExists(t, dbPath+"-shm", target+"-shm")
+	return target
+}
+
+// openSnapshot reopens a snapshot exactly as production would, with the same
+// connection parameters, which is when SQLite runs WAL recovery.
+func openSnapshot(t *testing.T, dbPath string) *sql.DB {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+	return sqlDB
+}
+
+func countRowsWhere(t *testing.T, sqlDB *sql.DB, table, where string, args ...any) int {
+	t.Helper()
+	query := "SELECT COUNT(*) FROM " + table
+	if where != "" {
+		query += " WHERE " + where
+	}
+	var n int
+	require.NoError(t, sqlDB.QueryRowContext(context.Background(), query, args...).Scan(&n))
+	return n
+}
+
+func countSystemMedia(t *testing.T, sqlDB *sql.DB, systemID string) int {
+	t.Helper()
+	return countRowsWhere(t, sqlDB, "Media",
+		"SystemDBID = (SELECT DBID FROM Systems WHERE SystemID = ?)", systemID)
+}
+
+func requireIntegrityOK(t *testing.T, sqlDB *sql.DB) {
+	t.Helper()
+	require.Equal(t, []string{"ok"},
+		database.IntegrityReport(context.Background(), sqlDB, database.DefaultIntegrityReportRows))
+}
+
+// walFrame is one frame of the WAL file format: a 24-byte header (page number,
+// then the database size in pages for a commit frame and zero otherwise) and
+// one page of content.
+type walFrame struct {
+	offset     int
+	pageNo     uint32
+	commitSize uint32
+}
+
+const walHeaderSize = 32
+
+func parseWAL(t *testing.T, wal []byte) (pageSize int, frames []walFrame) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(wal), walHeaderSize, "WAL has no header")
+	magic := binary.BigEndian.Uint32(wal[0:4])
+	require.Contains(t, []uint32{0x377f0682, 0x377f0683}, magic, "not a WAL file")
+	pageSize = int(binary.BigEndian.Uint32(wal[8:12]))
+	frameSize := 24 + pageSize
+	for off := walHeaderSize; off+frameSize <= len(wal); off += frameSize {
+		frames = append(frames, walFrame{
+			offset:     off,
+			pageNo:     binary.BigEndian.Uint32(wal[off : off+4]),
+			commitSize: binary.BigEndian.Uint32(wal[off+4 : off+8]),
+		})
+	}
+	return pageSize, frames
+}
+
+// framesFrom returns the frames written at or after walOffset — the ones a
+// commit that began when the WAL was walOffset bytes long produced.
+func framesFrom(frames []walFrame, walOffset int64) []walFrame {
+	for i, frame := range frames {
+		if int64(frame.offset) >= walOffset {
+			return frames[i:]
+		}
+	}
+	return nil
+}
+
+func firstCommitFrame(t *testing.T, frames []walFrame) walFrame {
+	t.Helper()
+	for _, frame := range frames {
+		if frame.commitSize != 0 {
+			return frame
+		}
+	}
+	require.FailNow(t, "no commit frame found")
+	return walFrame{}
+}
+
+func truncateFile(t *testing.T, path string, size int64) {
+	t.Helper()
+	require.NoError(t, os.Truncate(path, size))
+}
+
+func flipByte(t *testing.T, path string, offset int64) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+	b := make([]byte, 1)
+	_, err = f.ReadAt(b, offset)
+	require.NoError(t, err)
+	b[0] ^= 0xff
+	_, err = f.WriteAt(b, offset)
+	require.NoError(t, err)
+}
+
+// applyWALFrames copies the content of frames into the main database file at
+// their page positions, which is what a checkpoint does frame by frame; a
+// checkpoint interrupted after n frames has done exactly this for the first n.
+func applyWALFrames(t *testing.T, dbPath string, wal []byte, pageSize int, frames []walFrame) {
+	t.Helper()
+	f, err := os.OpenFile(dbPath, os.O_RDWR, 0o600) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+	for _, frame := range frames {
+		page := wal[frame.offset+24 : frame.offset+24+pageSize]
+		_, err = f.WriteAt(page, int64(frame.pageNo-1)*int64(pageSize))
+		require.NoError(t, err)
+	}
+}
+
+// A commit is durable in the WAL alone. Power loss after the commit but before
+// any checkpoint — the normal state between indexing batches now that
+// automatic checkpointing is off during a run — must recover every committed
+// row, including the tag links and the fingerprint written in the same
+// transaction.
+func TestCrashConsistency_CommittedTransactionSurvivesWithoutCheckpoint(t *testing.T) {
+	h := newCrashTestDB(t)
+	stats := stageSystemFiles(t, h, "SNES", "Alpha", crashTestFilesPerSystem)
+	require.Equal(t, int64(crashTestFilesPerSystem), stats.MediaUpserted)
+	require.Equal(t, int64(2*crashTestFilesPerSystem), stats.TagLinksAdded)
+	require.Positive(t, walSize(t, h.dbPath), "the commit must still be in the WAL, not checkpointed")
+
+	snapshot := openSnapshot(t, snapshotDatabase(t, h.dbPath))
+	requireIntegrityOK(t, snapshot)
+	assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, snapshot, "SNES"))
+	assert.Equal(t, 2*crashTestFilesPerSystem, countRowsWhere(t, snapshot, "MediaTags", ""))
+	assert.Equal(t, 1, countRowsWhere(t, snapshot, "ScanSystemFingerprints", ""),
+		"the fingerprint commits with the reconcile it describes")
+}
+
+// A large transaction spills dirty pages into the WAL before it commits. Those
+// frames carry no commit marker, so a crash mid-transaction — or the rollback
+// the scanner performs on cancellation — must leave none of them visible, and
+// the database must be usable for the next transaction.
+func TestCrashConsistency_SpilledUncommittedFramesAreInvisible(t *testing.T) {
+	h := newCrashTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, h.db.BeginTransaction(false))
+	// Shrink the writer's page cache so the inserts below spill to the WAL
+	// long before commit, as a system-sized batch does at the default size.
+	_, err := h.db.tx.ExecContext(ctx, "PRAGMA cache_size = 2")
+	require.NoError(t, err)
+	_, err = h.db.tx.ExecContext(ctx, "PRAGMA cache_spill = 2")
+	require.NoError(t, err)
+	for i := range 2000 {
+		_, err = h.db.InsertMedia(database.Media{
+			MediaTitleDBID: h.title.DBID,
+			SystemDBID:     h.system.DBID,
+			Path:           fmt.Sprintf("/roms/test/spill %04d.bin", i),
+		})
+		require.NoError(t, err)
+	}
+	require.Positive(t, walSize(t, h.dbPath), "dirty pages must have spilled into the WAL before commit")
+
+	midTransaction := snapshotDatabase(t, h.dbPath)
+	require.NoError(t, h.db.RollbackTransaction())
+
+	snapshot := openSnapshot(t, midTransaction)
+	requireIntegrityOK(t, snapshot)
+	assert.Zero(t, countRowsWhere(t, snapshot, "Media", ""), "spilled frames without a commit must not be recovered")
+
+	// The original, after its rollback, is equally clean and still writable.
+	requireIntegrityOK(t, h.db.sql.Load())
+	assert.Zero(t, countRowsWhere(t, h.db.sql.Load(), "Media", ""))
+	stats := stageSystemFiles(t, h, "SNES", "Alpha", 10)
+	assert.Equal(t, int64(10), stats.MediaUpserted)
+	assert.Equal(t, 10, countSystemMedia(t, h.db.sql.Load(), "SNES"))
+}
+
+// A torn write at the WAL tail — the last frames of the newest commit missing
+// or damaged — must drop that whole commit and nothing before it. This is the
+// power-loss case synchronous=NORMAL accepts (the WAL is not fsynced per
+// commit): the previous batch survives intact and the interrupted one is
+// redone on resume, never half-applied.
+func TestCrashConsistency_TornWALTailDropsOnlyTheLastCommit(t *testing.T) {
+	h := newCrashTestDB(t)
+	stageSystemFiles(t, h, "SNES", "Alpha", crashTestFilesPerSystem)
+	walAfterFirst := walSize(t, h.dbPath)
+	stageSystemFiles(t, h, "NES", "Beta", crashTestFilesPerSystem)
+
+	wal, err := os.ReadFile(h.dbPath + "-wal") //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	pageSize, frames := parseWAL(t, wal)
+	second := framesFrom(frames, walAfterFirst)
+	require.NotEmpty(t, second, "the second commit must have written frames")
+	secondCommit := firstCommitFrame(t, second)
+	frameSize := int64(24 + pageSize)
+
+	tests := []struct {
+		damage func(t *testing.T, walPath string)
+		name   string
+	}{
+		{
+			name: "commit frame torn mid-page",
+			damage: func(t *testing.T, walPath string) {
+				truncateFile(t, walPath, int64(secondCommit.offset)+frameSize-10)
+			},
+		},
+		{
+			name: "commit frame never written",
+			damage: func(t *testing.T, walPath string) {
+				truncateFile(t, walPath, int64(secondCommit.offset))
+			},
+		},
+		{
+			name: "first frame of the commit corrupted",
+			damage: func(t *testing.T, walPath string) {
+				flipByte(t, walPath, int64(second[0].offset)+24+int64(pageSize)/2)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := snapshotDatabase(t, h.dbPath)
+			tt.damage(t, path+"-wal")
+
+			snapshot := openSnapshot(t, path)
+			requireIntegrityOK(t, snapshot)
+			assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, snapshot, "SNES"),
+				"the earlier commit is intact")
+			assert.Zero(t, countSystemMedia(t, snapshot, "NES"), "the torn commit is dropped whole")
+			assert.Zero(t, countRowsWhere(t, snapshot, "Systems", "SystemID = ?", "NES"),
+				"nothing of the torn transaction is applied, not even its first statements")
+			assert.Equal(t, 2*crashTestFilesPerSystem, countRowsWhere(t, snapshot, "MediaTags", ""),
+				"tag links of the intact commit are all present and none of the torn one's")
+		})
+	}
+}
+
+// A checkpoint copies WAL frames into the main file one page at a time and
+// only resets the WAL once every frame is durable there. Power loss part-way
+// through leaves the main file with some pages new and some old, and the WAL
+// still complete — the next open must replay the WAL over the partial copy and
+// reach the fully committed state, whether the interrupted checkpoint had
+// applied one frame or all of them.
+func TestCrashConsistency_InterruptedCheckpointReplaysWAL(t *testing.T) {
+	h := newCrashTestDB(t)
+	stageSystemFiles(t, h, "SNES", "Alpha", crashTestFilesPerSystem)
+	stageSystemFiles(t, h, "NES", "Beta", crashTestFilesPerSystem)
+
+	wal, err := os.ReadFile(h.dbPath + "-wal") //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	pageSize, frames := parseWAL(t, wal)
+	require.Greater(t, len(frames), 2)
+
+	tests := []struct {
+		applied func() []walFrame
+		name    string
+	}{
+		{name: "one frame applied", applied: func() []walFrame { return frames[:1] }},
+		{name: "half the frames applied", applied: func() []walFrame { return frames[:len(frames)/2] }},
+		{name: "every frame applied but the WAL not reset", applied: func() []walFrame { return frames }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := snapshotDatabase(t, h.dbPath)
+			applyWALFrames(t, path, wal, pageSize, tt.applied())
+
+			snapshot := openSnapshot(t, path)
+			requireIntegrityOK(t, snapshot)
+			assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, snapshot, "SNES"))
+			assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, snapshot, "NES"))
+			assert.Equal(t, 4*crashTestFilesPerSystem, countRowsWhere(t, snapshot, "MediaTags", ""))
+			assert.Equal(t, 2, countRowsWhere(t, snapshot, "ScanSystemFingerprints", ""))
+		})
+	}
+}
+
+// After a completed TRUNCATE checkpoint the main file is self-contained: a
+// crash that loses the (empty) WAL and the SHM afterwards loses nothing.
+func TestCrashConsistency_CheckpointedDatabaseStandsAlone(t *testing.T) {
+	h := newCrashTestDB(t)
+	stageSystemFiles(t, h, "SNES", "Alpha", crashTestFilesPerSystem)
+	require.NoError(t, h.db.WALCheckpoint())
+	require.Zero(t, walSize(t, h.dbPath), "TRUNCATE checkpoint must empty the WAL")
+
+	target := filepath.Join(t.TempDir(), "alone.db")
+	copyFileIfExists(t, h.dbPath, target)
+	require.NoFileExists(t, target+"-wal")
+	require.NoFileExists(t, target+"-shm")
+
+	snapshot := openSnapshot(t, target)
+	requireIntegrityOK(t, snapshot)
+	assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, snapshot, "SNES"))
+	assert.Equal(t, 2*crashTestFilesPerSystem, countRowsWhere(t, snapshot, "MediaTags", ""))
+}
+
+// Cancelling indexing mid-reconcile takes the scanner's rollback path. The
+// reconcile must stop at its next step, the rollback must leave the previous
+// commit's rows and fingerprint exactly as they were, and the same system must
+// then reconcile cleanly from scratch.
+func TestCrashConsistency_CancelledReconcileRollsBackCleanly(t *testing.T) {
+	h := newCrashTestDB(t)
+	stageSystemFiles(t, h, "SNES", "Alpha", crashTestFilesPerSystem)
+	fingerprintBefore := countRowsWhere(t, h.db.sql.Load(), "ScanSystemFingerprints", "")
+	require.Equal(t, 1, fingerprintBefore)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, h.db.BeginTransaction(true))
+	require.NoError(t, h.db.ClearScanStage())
+	for i := range 2 * crashTestFilesPerSystem {
+		path := fmt.Sprintf("/roms/SNES/Alpha %03d (USA).bin", i)
+		require.NoError(t, h.db.StageScannedMedia(&database.ScanStagedMedia{
+			Path: path, ParentDir: ParentDirForMediaPath(path),
+			Slug: fmt.Sprintf("alpha%03d", i), TitleName: fmt.Sprintf("Alpha %03d", i),
+			SortName: fmt.Sprintf("Alpha %03d", i), SlugLength: 8, SlugWordCount: 2,
+			Tags: []database.ScanStagedTag{{Type: string(tags.TagTypeRegion), Value: "us"}},
+		}))
+	}
+	yields := 0
+	_, err := h.db.ReconcileStagedSystem(ctx, "SNES", database.ScanReconcileOpts{
+		Yield: func() error {
+			yields++
+			if yields == 3 {
+				cancel()
+			}
+			return nil
+		},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.NoError(t, h.db.RollbackTransaction())
+
+	live := h.db.sql.Load()
+	requireIntegrityOK(t, live)
+	assert.Equal(t, crashTestFilesPerSystem, countSystemMedia(t, live, "SNES"),
+		"the cancelled reconcile's rows are rolled back")
+	assert.Equal(t, fingerprintBefore, countRowsWhere(t, live, "ScanSystemFingerprints", ""))
+	assert.Zero(t, countRowsWhere(t, live, "ScanStage", ""), "staged rows roll back with the transaction")
+
+	stats := stageSystemFiles(t, h, "SNES", "Alpha", 2*crashTestFilesPerSystem)
+	assert.False(t, stats.Unchanged, "a changed set after a cancelled run must reconcile")
+	assert.Equal(t, int64(crashTestFilesPerSystem), stats.MediaUpserted, "only the new half is inserted")
+	assert.Equal(t, 2*crashTestFilesPerSystem, countSystemMedia(t, live, "SNES"))
+	requireIntegrityOK(t, live)
+}

--- a/pkg/database/mediadb/forensic_set_test.go
+++ b/pkg/database/mediadb/forensic_set_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -36,13 +35,6 @@ import (
 // SHM kept together, untouched, and reassemblable into a database that opens
 // with every committed row — including rows that only ever reached the WAL.
 func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		// The scenario needs a second connection open across Recreate, and
-		// Windows will not let PreserveCorruptFile rename a database file
-		// while any handle on it is still open.
-		t.Skip("open SQLite handles block renaming the database on Windows")
-	}
-
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/pkg/database/mediadb/forensic_set_test.go
+++ b/pkg/database/mediadb/forensic_set_test.go
@@ -1,0 +1,98 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet pins what a
+// corruption post-mortem needs from Recreate: the database, its WAL and its
+// SHM kept together, untouched, and reassemblable into a database that opens
+// with every committed row — including rows that only ever reached the WAL.
+func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	insertSystemWithMedia(t, mediaDB, "NES", "Some Game", filepath.Join("roms", "nes", "game.nes"))
+	path := mediaDB.GetDBPath()
+	require.FileExists(t, path+"-wal", "the row must still be in the WAL for the set to matter")
+
+	// A second, read-only connection keeps the WAL and SHM on disk through
+	// Close(): SQLite checkpoints and deletes them only when the last
+	// connection leaves, and a read-only connection can do neither. That is
+	// the on-disk state a crashed or corrupt process leaves behind, which is
+	// what the forensic set exists to capture.
+	holder, err := sql.Open("sqlite3", "file:"+path+"?mode=ro")
+	require.NoError(t, err)
+	holderConn, err := holder.Conn(ctx)
+	require.NoError(t, err)
+	var seen int
+	require.NoError(t, holderConn.QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&seen))
+	require.Equal(t, 1, seen)
+	holderReleased := false
+	releaseHolder := func() {
+		if holderReleased {
+			return
+		}
+		holderReleased = true
+		require.NoError(t, holderConn.Close())
+		require.NoError(t, holder.Close())
+	}
+	t.Cleanup(releaseHolder)
+
+	mediaDB.MarkCorrupt("test")
+	require.NoError(t, mediaDB.Recreate(true))
+
+	preserved := make(map[string]string, 3)
+	for _, file := range []string{path, path + "-wal", path + "-shm"} {
+		backup := database.CorruptBackupPath(file)
+		require.FileExists(t, backup, "forensic set must include %s", filepath.Base(file))
+		preserved[file] = backup
+	}
+	// The renamed files are no longer in use by anything: release the holder
+	// before reading them back so the check below sees closed, quiescent files.
+	releaseHolder()
+
+	// One consistent set: put back under a single name it opens cleanly and
+	// holds the committed row, which was only ever in the WAL.
+	target := filepath.Join(t.TempDir(), "forensic.db")
+	copyFileIfExists(t, preserved[path], target)
+	copyFileIfExists(t, preserved[path+"-wal"], target+"-wal")
+	copyFileIfExists(t, preserved[path+"-shm"], target+"-shm")
+	forensic := openSnapshot(t, target)
+	requireIntegrityOK(t, forensic)
+	assert.Equal(t, 1, countRowsWhere(t, forensic, "Media", ""))
+
+	// The rebuilt database is fresh, and the marker is cleared.
+	assert.False(t, mediaDB.IsMarkedCorrupt())
+	assert.Zero(t, countRowsWhere(t, mediaDB.sql.Load(), "Media", ""))
+	ok, err := mediaDB.QuickCheck()
+	require.NoError(t, err)
+	assert.True(t, ok)
+}

--- a/pkg/database/mediadb/forensic_set_test.go
+++ b/pkg/database/mediadb/forensic_set_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -35,6 +36,13 @@ import (
 // SHM kept together, untouched, and reassemblable into a database that opens
 // with every committed row — including rows that only ever reached the WAL.
 func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The scenario needs a second connection open across Recreate, and
+		// Windows will not let PreserveCorruptFile rename a database file
+		// while any handle on it is still open.
+		t.Skip("open SQLite handles block renaming the database on Windows")
+	}
+
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -42,6 +50,22 @@ func TestMediaDB_Recreate_KeepBackup_PreservesConsistentForensicSet(t *testing.T
 	insertSystemWithMedia(t, mediaDB, "NES", "Some Game", filepath.Join("roms", "nes", "game.nes"))
 	path := mediaDB.GetDBPath()
 	require.FileExists(t, path+"-wal", "the row must still be in the WAL for the set to matter")
+
+	// The set only matters if the row is genuinely WAL-only, so prove the main
+	// database alone cannot answer for it. This has to happen before Recreate:
+	// Recreate closes the database first, and that close can checkpoint the row
+	// into the main file.
+	mainOnly := filepath.Join(t.TempDir(), "main-only.db")
+	copyFileIfExists(t, path, mainOnly)
+	var mainOnlyMedia int
+	mainOnlyErr := openSnapshot(t, mainOnly).
+		QueryRowContext(ctx, "SELECT COUNT(*) FROM Media").Scan(&mainOnlyMedia)
+	if mainOnlyErr == nil {
+		assert.Zero(t, mainOnlyMedia, "the row must not have been checkpointed into the main database")
+	} else {
+		// Nothing has been checkpointed at all, so even the schema is missing.
+		require.ErrorContains(t, mainOnlyErr, "no such table")
+	}
 
 	// A second, read-only connection keeps the WAL and SHM on disk through
 	// Close(): SQLite checkpoints and deletes them only when the last

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1477,20 +1477,19 @@ func (db *MediaDB) IntegrityReport() []string {
 	return database.IntegrityReport(db.ctx, sqlDB, database.DefaultIntegrityReportRows)
 }
 
-// Recreate discards the database file and reopens a fresh one. The main file and
-// its -wal/-shm sidecars are either preserved together as <db>{,-wal,-shm}.corrupt.bak
-// forensic copies (keepBackup — development builds only) or deleted outright; the
-// connection is then closed; and Open() allocates a fresh schema. Preservation happens
-// before Close() deliberately: in WAL mode, SQLite's own close-time checkpoint deletes
-// the live -wal/-shm files outright (verified empirically — nothing survives a rename
-// attempted afterward), so capturing a consistent three-file forensic set from a single
-// point in time requires renaming them aside while the connection is still open. A
-// sidecar surviving on disk next to the freshly allocated database would re-corrupt it,
-// so every path still ends with RemoveSidecars regardless of whether keepBackup
-// succeeded. Before any corrupt marker is cleared, the fresh database is marked pending
-// for reindex and stale search caches are removed. This durable handoff lets startup
-// resume if the process exits before the caller starts indexing. Callers: corruption
-// recovery and the user-requested fresh-start rebuild (media.index with rebuild:true).
+// Recreate discards the database file and reopens a fresh one. The connection is
+// closed first; then the main file and its -wal/-shm sidecars are either preserved
+// together as <db>{,-wal,-shm}.corrupt.bak forensic copies (keepBackup — development
+// builds only) or deleted outright; and Open() allocates a fresh schema. Preservation
+// happens after Close() so the three files are a stopped, consistent set: nothing is
+// writing to any of them when they are renamed, and renaming a file SQLite still has
+// open fails on Windows (see the comment at the call site). A sidecar surviving on disk
+// next to the freshly allocated database would re-corrupt it, so every path still ends
+// with RemoveSidecars regardless of whether keepBackup succeeded. Before any corrupt
+// marker is cleared, the fresh database is marked pending for reindex and stale search
+// caches are removed. This durable handoff lets startup resume if the process exits
+// before the caller starts indexing. Callers: corruption recovery and the
+// user-requested fresh-start rebuild (media.index with rebuild:true).
 func (db *MediaDB) Recreate(keepBackup bool) error {
 	// Serialize recreates: a user-triggered rebuild must never interleave its
 	// close/delete/reopen with corruption recovery's (or another rebuild's).
@@ -1517,12 +1516,15 @@ func (db *MediaDB) Recreate(keepBackup bool) error {
 	// into the main database, which is the file being preserved, or it could
 	// not, and the WAL is still on disk to be preserved with it.
 	//
-	// The -shm is deliberately not preserved. It is a shared-memory index
-	// rebuilt from the WAL on demand, holds nothing durable, and is the one
-	// file whose mapping Windows would refuse to rename anyway.
+	// All three files are kept as one set. The -shm holds nothing durable (it
+	// is the WAL index, rebuilt from the WAL on demand), but a post-mortem of a
+	// torn write wants the files exactly as the process last saw them, and once
+	// the connection is closed its mapping is released so the rename succeeds
+	// everywhere. The user database's recovery preserves the same three.
 	if keepBackup {
-		database.PreserveCorruptFile(db.dbPath, "media")
-		database.PreserveCorruptFile(db.dbPath+"-wal", "media")
+		for _, path := range []string{db.dbPath, db.dbPath + "-wal", db.dbPath + "-shm"} {
+			database.PreserveCorruptFile(path, "media")
+		}
 	}
 
 	// Clear any transaction state so db.conn() can't hand out a stale closed tx after

--- a/pkg/database/mediadb/migrations/20260829120000_scan_system_fingerprints.sql
+++ b/pkg/database/mediadb/migrations/20260829120000_scan_system_fingerprints.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Per-system record of the last successful scan reconcile: a digest of the
+-- staged set it consumed and a digest of the stored rows it left behind. When
+-- the next scan stages a byte-identical set against unchanged stored rows,
+-- reconcile is provably a no-op and is skipped (see sqlReconcileStagedSystem).
+-- Rows are written inside the reconcile's own transaction so a rollback
+-- discards them together with the work they describe.
+CREATE TABLE IF NOT EXISTS ScanSystemFingerprints (
+    SystemDBID  INTEGER PRIMARY KEY,
+    Fingerprint TEXT    NOT NULL,
+    StateDigest TEXT    NOT NULL,
+    MediaCount  INTEGER NOT NULL,
+    TitleCount  INTEGER NOT NULL,
+    ReconcileMs INTEGER NOT NULL,
+    FOREIGN KEY (SystemDBID) REFERENCES Systems(DBID) ON DELETE CASCADE
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS ScanSystemFingerprints;

--- a/pkg/database/mediadb/scan_reconcile_test.go
+++ b/pkg/database/mediadb/scan_reconcile_test.go
@@ -228,13 +228,17 @@ func TestReconcileStagedSystem_IdempotentRescanIsNoOp(t *testing.T) {
 // pre-existing rows, which necessarily removes their yields too. Fewer yields on
 // a fresh reconcile is the intended consequence, not a pacing regression: there
 // are fewer statements to pace between. The re-index count is the one that must
-// stay high, since that is the long path.
+// stay high, since that is the long path — so the re-index stages a changed set;
+// an identical one would be skipped outright (#1317) and pace only its
+// fingerprint read, which TestReconcileStagedSystem_UnchangedRescanYieldsOnce
+// covers.
 func TestReconcileStagedSystem_YieldsBetweenSQLSteps(t *testing.T) {
 	t.Parallel()
 	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
 	t.Cleanup(cleanup)
 
 	gamePath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Game.sfc"))
+	addedPath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Other Game.sfc"))
 
 	freshYields := 0
 	scantest.IndexMediaPathsWithOpts(t, mediaDB, "SNES", database.ScanReconcileOpts{
@@ -250,14 +254,37 @@ func TestReconcileStagedSystem_YieldsBetweenSQLSteps(t *testing.T) {
 			rescanYields++
 			return nil
 		},
-	}, gamePath)
+	}, gamePath, addedPath)
 
 	assert.GreaterOrEqual(t, freshYields, 5,
 		"a fresh reconcile should still pace between the steps it does run")
 	assert.GreaterOrEqual(t, rescanYields, 10,
-		"a re-index runs every step and should pace between them")
+		"a changed re-index runs every step and should pace between them")
 	assert.Greater(t, rescanYields, freshYields,
 		"a fresh system skips pre-existing-state steps, so it should yield fewer times")
+}
+
+// TestReconcileStagedSystem_UnchangedRescanYieldsOnce pins the pacing shape of
+// a skipped reconcile: the staged-set digest is a real read of the staging
+// tables, so it yields once after it, and nothing else runs.
+func TestReconcileStagedSystem_UnchangedRescanYieldsOnce(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := helpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	gamePath := filepath.ToSlash(filepath.Join(string(filepath.Separator), "roms", "SNES", "Game.sfc"))
+	scantest.IndexMediaPaths(t, mediaDB, "SNES", gamePath)
+
+	rescanYields := 0
+	stats := scantest.IndexMediaPathsWithOpts(t, mediaDB, "SNES", database.ScanReconcileOpts{
+		Yield: func() error {
+			rescanYields++
+			return nil
+		},
+	}, gamePath)
+
+	assert.True(t, stats.Unchanged, "an identical re-index must be skipped")
+	assert.Equal(t, 1, rescanYields, "a skipped reconcile paces only after its fingerprint read")
 }
 
 func TestReconcileStagedSystem_PropagatesYieldError(t *testing.T) {
@@ -282,7 +309,8 @@ func TestReconcileStagedSystem_PropagatesYieldError(t *testing.T) {
 		Yield: func() error { return yieldErr },
 	})
 	require.ErrorIs(t, err, yieldErr)
-	assert.Contains(t, err.Error(), "scan reconcile pacing after insert titles failed")
+	// The staged-set fingerprint is the first paced step of a full scan.
+	assert.Contains(t, err.Error(), "scan reconcile pacing after fingerprint failed")
 }
 
 // TestReconcileStagedSystem_IncompleteScanPreservesMissingState pins

--- a/pkg/database/mediadb/sql_maintenance.go
+++ b/pkg/database/mediadb/sql_maintenance.go
@@ -49,6 +49,10 @@ func sqlTruncate(ctx context.Context, db *sql.DB) error {
 
 	// Delete in reverse dependency order (children first, parents last)
 	// to avoid any cascading overhead and minimize index updates
+	//
+	// The canonical tag vocabulary stamp goes with Tags and TagTypes: it records
+	// that the vocabulary rows exist, and leaving it behind would make the next
+	// index run skip seeding them into the now-empty tables.
 	sqlStmt := `
 	delete from MediaProperties;
 	delete from MediaTitleProperties;
@@ -59,10 +63,12 @@ func sqlTruncate(ctx context.Context, db *sql.DB) error {
 	delete from MediaTitles;
 	delete from Tags;
 	delete from TagTypes;
+	delete from ScanSystemFingerprints;
 	delete from Systems;
 	delete from SlugResolutionCache;
 	delete from BrowseDirCounts;
 	delete from BrowseDirs;
+	delete from DBConfig where Name = '` + DBConfigCanonicalTagVocabHash + `';
 	`
 	_, err = db.ExecContext(ctx, sqlStmt)
 	if err != nil {
@@ -203,6 +209,17 @@ func sqlTruncateSystems(ctx context.Context, db *sql.DB, systemIDs []string) err
 	if _, err = conn.ExecContext(ctx,
 		fmt.Sprintf("DELETE FROM MediaTitles WHERE SystemDBID IN (%s)", dbidPlaceholders), systemDBIDs...); err != nil {
 		return fmt.Errorf("failed to delete MediaTitles: %w", err)
+	}
+	// Explicit because foreign keys are off here, so the ON DELETE CASCADE on
+	// the fingerprint row would not fire. A stale row must not survive: the
+	// next scan of this system creates a fresh Systems row whose DBID can be
+	// reused, and a matching fingerprint would then describe rows that no
+	// longer exist.
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
+	if _, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"DELETE FROM ScanSystemFingerprints WHERE SystemDBID IN (%s)", dbidPlaceholders,
+	), systemDBIDs...); err != nil {
+		return fmt.Errorf("failed to delete scan fingerprints: %w", err)
 	}
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders
 	if _, err = conn.ExecContext(ctx,

--- a/pkg/database/mediadb/sql_scan_fingerprint.go
+++ b/pkg/database/mediadb/sql_scan_fingerprint.go
@@ -1,0 +1,286 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"strconv"
+
+	"github.com/rs/zerolog/log"
+)
+
+// scanReconcileVersion identifies what sqlReconcileStagedSystem derives from a
+// staged set and writes to the media tables. It is folded into every stored
+// fingerprint, so bumping it invalidates all of them and the next index run
+// reconciles every system once more. Bump it whenever a reconcile statement
+// changes what it writes for the same staged input — a fingerprint match is
+// only proof of "nothing to do" while the reconcile that produced the stored
+// state is the one that would run now.
+const scanReconcileVersion = "1"
+
+// scanStagedSet is the staged input for one system as seen by reconcile: the
+// digest of every ScanStage and ScanStageTags row it will consume, plus the
+// row counts behind it. Properties are counted rather than hashed because the
+// scanner only stages a property that is absent from the database
+// (stagedPropertiesFromPath), so any staged property is new work by
+// construction and the count alone decides whether reconcile can be skipped.
+type scanStagedSet struct {
+	fingerprint string
+	files       int64
+	tagRows     int64
+	properties  int64
+}
+
+// scanStoredState digests the rows reconcile owns for one system — the ones
+// its statements would read and compare against the staged set. Reconcile is
+// only provably a no-op when both its inputs are unchanged: the staged set
+// (scanStagedSet) and the stored state it would reconcile that set against.
+// Hashing the stored state, rather than trusting that only reconcile writes
+// it, is what lets an edit made by anything else — a scraper or API write of a
+// scanner-owned tag, an orphan cleanup, a manual repair — fail open into a
+// full reconcile instead of being silently preserved.
+type scanStoredState struct {
+	digest string
+	titles int64
+	media  int64
+}
+
+// scanFingerprintRow is the durable record of the last successful reconcile
+// for one system: the staged set it consumed and the stored state it left
+// behind. Counts are carried for the skip log line.
+type scanFingerprintRow struct {
+	fingerprint string
+	stateDigest string
+	mediaCount  int64
+	titleCount  int64
+	reconcileMs int64
+}
+
+// scanFingerprintGeneration returns the generation prefix folded into every
+// staged-set digest: the reconcile behaviour version, the applied schema
+// version, the compiled-in canonical tag vocabulary and the disambiguation
+// algorithm version. A change to any of them moves every fingerprint, so a
+// release that alters what reconcile would produce for the same files never
+// matches a fingerprint written by the previous release.
+func scanFingerprintGeneration(ctx context.Context, db sqlQueryable) (string, error) {
+	var schemaVersion int64
+	err := db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version WHERE is_applied = 1",
+	).Scan(&schemaVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to read schema version for scan fingerprint: %w", err)
+	}
+	typeRows, tagRows := canonicalTagVocabRows()
+	return "reconcile\x00" + scanReconcileVersion +
+		"\nschema\x00" + strconv.FormatInt(schemaVersion, 10) +
+		"\nvocab\x00" + canonicalTagVocabHash(typeRows, tagRows) +
+		"\ndisambiguation\x00" + disambiguationAlgoVersion + "\n", nil
+}
+
+// sqlScanStagedFingerprint digests the staged set for the current system. Rows
+// are read in primary-key order from both WITHOUT ROWID tables, so the digest
+// is independent of the order files were staged in, and every column reconcile
+// consumes is included — a parser change that alters a slug, sort name or tag
+// without touching the path moves the digest.
+//
+// The row scans deliberately run without the caller's cancellation: with a
+// cancellable context the SQLite driver interrupts each rows.Next() through a
+// goroutine, which on a 30k-row staged set costs more than the scan itself.
+// Cancellation is checked between the scans instead.
+func sqlScanStagedFingerprint(ctx context.Context, db sqlQueryable) (scanStagedSet, error) {
+	var set scanStagedSet
+	generation, err := scanFingerprintGeneration(ctx, db)
+	if err != nil {
+		return set, err
+	}
+	h := sha256.New()
+	_, _ = h.Write([]byte("zaparoo-scan-fingerprint\n"))
+	_, _ = h.Write([]byte(generation))
+
+	readCtx := context.WithoutCancel(ctx)
+	if err = ctx.Err(); err != nil {
+		return set, fmt.Errorf("scan fingerprint cancelled: %w", err)
+	}
+	// One row and one column per staged file, with its tags folded in by SQL,
+	// rather than a second scan of ScanStageTags: every row and every column
+	// crossing the driver costs an allocation, and a system's tag rows
+	// outnumber its files several times over. The tag list is ordered inside
+	// the aggregate so the row is deterministic. Fields are joined with unit
+	// and record separators, which no filename or tag value contains.
+	set.files, err = hashRows(readCtx, db, h, "files", "staged files", `
+		SELECT s.Path || char(31) || s.ParentDir || char(31) || s.Slug || char(31) || s.TitleName || char(31)
+			|| s.SortName || char(31) || s.SlugLength || char(31) || s.SlugWordCount || char(31)
+			|| COALESCE(s.SecondarySlug, '') || char(31)
+			|| COALESCE((
+				SELECT group_concat(st.TagType || char(31) || st.Tag, char(30) ORDER BY st.TagType, st.Tag)
+				FROM ScanStageTags st WHERE st.Path = s.Path
+			), '')
+		FROM ScanStage s ORDER BY s.Path`)
+	if err != nil {
+		return set, err
+	}
+	if err = db.QueryRowContext(readCtx, "SELECT COUNT(*) FROM ScanStageTags").Scan(&set.tagRows); err != nil {
+		return set, fmt.Errorf("failed to count staged tags for scan fingerprint: %w", err)
+	}
+	if err = db.QueryRowContext(readCtx, "SELECT COUNT(*) FROM ScanStageProperties").Scan(&set.properties); err != nil {
+		return set, fmt.Errorf("failed to count staged properties for scan fingerprint: %w", err)
+	}
+	set.fingerprint = hex.EncodeToString(h.Sum(nil))
+	return set, nil
+}
+
+// sqlScanStoredStateDigest digests the rows reconcile would compare the staged
+// set against, for one system: one row per media, in path order (which the
+// (SystemDBID, Path) index provides without a sort), carrying the columns
+// reconcile reads or rewrites for existing rows. Those are the media row's
+// parent directory, sort name and missing flag (the upsert and missing-flag
+// steps), its title's slug, name and secondary slug (title reassignment and
+// the rename step) and its tag links (the link insert and stale-link delete),
+// folded into the row as an ordered list of tag DBIDs. A title is hashed
+// through its media rather than on its own because reconcile only ever reaches
+// a title through a staged file. Links are hashed for every tag type, not just
+// the scanner-owned ones — that costs one reconcile of a system after it is
+// scraped, and avoids joining Tags and TagTypes to filter by type.
+//
+// Runs without cancellation for the same reason as sqlScanStagedFingerprint.
+func sqlScanStoredStateDigest(ctx context.Context, db sqlQueryable, systemDBID int64) (scanStoredState, error) {
+	var state scanStoredState
+	h := sha256.New()
+	_, _ = h.Write([]byte("zaparoo-scan-stored-state\n"))
+
+	var err error
+	if err = ctx.Err(); err != nil {
+		return state, fmt.Errorf("scan stored state digest cancelled: %w", err)
+	}
+	// One column per row for the same reason as the staged-set query. Every
+	// text operand is COALESCEd: a NULL anywhere would null the whole row and
+	// hash as empty, silently hiding that row's other fields.
+	state.media, err = hashRows(context.WithoutCancel(ctx), db, h, "media", "system media", `
+		SELECT m.Path || char(31) || COALESCE(m.ParentDir, '') || char(31) || COALESCE(m.SortName, '') || char(31)
+			|| m.IsMissing || char(31) || t.Slug || char(31) || COALESCE(t.Name, '') || char(31)
+			|| COALESCE(t.SecondarySlug, '') || char(31)
+			|| COALESCE((
+				SELECT group_concat(mt.TagDBID, ',' ORDER BY mt.TagDBID)
+				FROM MediaTags mt WHERE mt.MediaDBID = m.DBID
+			), '')
+		FROM Media m
+		JOIN MediaTitles t ON t.DBID = m.MediaTitleDBID
+		WHERE m.SystemDBID = ? ORDER BY m.Path`, systemDBID)
+	if err != nil {
+		return state, err
+	}
+	if err = db.QueryRowContext(context.WithoutCancel(ctx),
+		"SELECT COUNT(*) FROM MediaTitles WHERE SystemDBID = ?", systemDBID,
+	).Scan(&state.titles); err != nil {
+		return state, fmt.Errorf("failed to count system titles for scan fingerprint: %w", err)
+	}
+	state.digest = hex.EncodeToString(h.Sum(nil))
+	return state, nil
+}
+
+// hashRows runs query and folds every row into h as one NUL-separated,
+// newline-terminated record after a section header, returning the row count.
+// Values are read as their textual form (integers print in decimal), which is
+// stable across driver versions. NUL cannot appear in a SQLite TEXT value read
+// through the driver, so the framing is unambiguous and adjacent rows cannot
+// alias each other.
+func hashRows(
+	ctx context.Context, db sqlQueryable, h hash.Hash, section, what, query string, args ...any,
+) (int64, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s for scan fingerprint: %w", what, err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Str("rows", what).Msg("failed to close scan fingerprint rows")
+		}
+	}()
+	columns, err := rows.Columns()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s columns for scan fingerprint: %w", what, err)
+	}
+	values := make([]sql.RawBytes, len(columns))
+	scanArgs := make([]any, len(columns))
+	for i := range values {
+		scanArgs[i] = &values[i]
+	}
+	_, _ = h.Write([]byte(section + "\n"))
+	var count int64
+	for rows.Next() {
+		if err = rows.Scan(scanArgs...); err != nil {
+			return 0, fmt.Errorf("failed to scan %s for scan fingerprint: %w", what, err)
+		}
+		count++
+		for i, value := range values {
+			if i > 0 {
+				_, _ = h.Write([]byte{0})
+			}
+			_, _ = h.Write(value)
+		}
+		_, _ = h.Write([]byte{'\n'})
+	}
+	if err = rows.Err(); err != nil {
+		return 0, fmt.Errorf("failed reading %s for scan fingerprint: %w", what, err)
+	}
+	return count, nil
+}
+
+func sqlLoadScanFingerprint(ctx context.Context, db sqlQueryable, systemDBID int64) (scanFingerprintRow, bool, error) {
+	var row scanFingerprintRow
+	err := db.QueryRowContext(ctx, `
+		SELECT Fingerprint, StateDigest, MediaCount, TitleCount, ReconcileMs
+		FROM ScanSystemFingerprints WHERE SystemDBID = ?`, systemDBID,
+	).Scan(&row.fingerprint, &row.stateDigest, &row.mediaCount, &row.titleCount, &row.reconcileMs)
+	if errors.Is(err, sql.ErrNoRows) {
+		return row, false, nil
+	}
+	if err != nil {
+		return row, false, fmt.Errorf("failed to load scan fingerprint: %w", err)
+	}
+	return row, true, nil
+}
+
+func sqlStoreScanFingerprint(ctx context.Context, db sqlQueryable, systemDBID int64, row scanFingerprintRow) error {
+	if _, err := db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO ScanSystemFingerprints
+			(SystemDBID, Fingerprint, StateDigest, MediaCount, TitleCount, ReconcileMs)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		systemDBID, row.fingerprint, row.stateDigest, row.mediaCount, row.titleCount, row.reconcileMs,
+	); err != nil {
+		return fmt.Errorf("failed to store scan fingerprint: %w", err)
+	}
+	return nil
+}
+
+func sqlDeleteScanFingerprint(ctx context.Context, db sqlQueryable, systemDBID int64) error {
+	if _, err := db.ExecContext(ctx,
+		"DELETE FROM ScanSystemFingerprints WHERE SystemDBID = ?", systemDBID,
+	); err != nil {
+		return fmt.Errorf("failed to clear scan fingerprint: %w", err)
+	}
+	return nil
+}

--- a/pkg/database/mediadb/sql_scan_reconcile.go
+++ b/pkg/database/mediadb/sql_scan_reconcile.go
@@ -617,6 +617,93 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 			Msg("scan reconcile fresh system: skipping pre-existing-state steps")
 	}
 
+	// Digest the staged set before any statement consumes it. Reconcile is a
+	// pure function of (ScanStage, ScanStageTags, stored state), and the stored
+	// state is by definition what the previous reconcile produced from its own
+	// staged set — so a byte-identical staged set against unchanged stored rows
+	// provably has nothing to do, and every step below is skipped. On the #1279
+	// device that was 45% of indexing wall time spent proving zero rows
+	// changed (#1317). The digest is computed on every reconcile, not just the
+	// ones that may skip, because it is what gets stored for the next run.
+	//
+	// An incomplete scan never fingerprints: its staged set is a subset of the
+	// library, so neither comparing against it nor remembering it is sound,
+	// and the stored row is cleared at the end so the next full scan
+	// reconciles. A digest failure is treated the same way — fail open.
+	var staged scanStagedSet
+	fingerprinted := false
+	if !opts.IncompleteScan {
+		fingerprintStart := time.Now()
+		staged, err = sqlScanStagedFingerprint(ctx, db)
+		recordStep("fingerprint", time.Since(fingerprintStart))
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return stats, err
+			}
+			log.Warn().Err(err).Str("system", systemID).
+				Msg("scan fingerprint unavailable; reconciling without it")
+		} else {
+			fingerprinted = true
+		}
+		if opts.Yield != nil {
+			pacingStart := time.Now()
+			if yieldErr := opts.Yield(); yieldErr != nil {
+				return stats, fmt.Errorf("scan reconcile pacing after fingerprint failed: %w", yieldErr)
+			}
+			pacingTotal += time.Since(pacingStart)
+		}
+	}
+	// A fresh system has no previous reconcile to compare against; its row is
+	// written below so the next scan can skip. The stored-state digest is only
+	// computed once the cheaper staged-set comparison has already matched.
+	if fingerprinted && !freshSystem {
+		decideStart := time.Now()
+		stored, found, loadErr := sqlLoadScanFingerprint(ctx, db, systemDBID)
+		if loadErr != nil {
+			return stats, loadErr
+		}
+		reason := ""
+		switch {
+		case !found:
+			reason = "no fingerprint from a previous reconcile"
+		case staged.properties > 0:
+			reason = "staged properties present"
+		case stored.fingerprint != staged.fingerprint:
+			reason = "staged set changed"
+		default:
+			state, stateErr := sqlScanStoredStateDigest(ctx, db, systemDBID)
+			if stateErr != nil {
+				return stats, stateErr
+			}
+			if stored.stateDigest != state.digest {
+				reason = "stored media state changed"
+			}
+		}
+		recordStep("fingerprint decision", time.Since(decideStart))
+		if reason == "" {
+			stats.Unchanged = true
+			log.Info().
+				Str("system", systemID).
+				Int64("stagedFiles", staged.files).
+				Int64("stagedTags", staged.tagRows).
+				Int64("media", stored.mediaCount).
+				Int64("titles", stored.titleCount).
+				Int64("lastReconcileMs", stored.reconcileMs).
+				Msg("scan reconcile skipped: staged set and stored state unchanged since last reconcile")
+			clearStart := time.Now()
+			clearErr := sqlClearScanStage(ctx, db)
+			recordStep("clear scan stage", time.Since(clearStart))
+			return stats, clearErr
+		}
+		log.Debug().
+			Str("system", systemID).
+			Str("reason", reason).
+			Int64("stagedFiles", staged.files).
+			Int64("stagedTags", staged.tagRows).
+			Int64("stagedProperties", staged.properties).
+			Msg("scan reconcile running: staged set not skippable")
+	}
+
 	// New titles: one row per staged slug not yet present for this system. The
 	// per-slug representative row is the lowest path, so multi-file titles pick
 	// their metadata deterministically.
@@ -977,6 +1064,33 @@ func sqlReconcileStagedSystem( //nolint:gocognit,funlen // linear statement sequ
 	if clearErr != nil {
 		return stats, clearErr
 	}
+
+	// Remember this reconcile's input and the state it left behind, inside the
+	// same transaction, so a rollback or crash before commit discards the
+	// fingerprint together with the work it describes. Without a usable
+	// fingerprint (incomplete scan, digest failure) any stale row is removed
+	// instead, so the next full scan cannot match against state this reconcile
+	// may have changed.
+	storeStart := time.Now()
+	if fingerprinted {
+		state, stateErr := sqlScanStoredStateDigest(ctx, db, systemDBID)
+		if stateErr != nil {
+			return stats, stateErr
+		}
+		err = sqlStoreScanFingerprint(ctx, db, systemDBID, scanFingerprintRow{
+			fingerprint: staged.fingerprint,
+			stateDigest: state.digest,
+			mediaCount:  state.media,
+			titleCount:  state.titles,
+			reconcileMs: time.Since(started).Milliseconds(),
+		})
+	} else {
+		err = sqlDeleteScanFingerprint(ctx, db, systemDBID)
+	}
+	recordStep("store fingerprint", time.Since(storeStart))
+	if err != nil {
+		return stats, err
+	}
 	return stats, nil
 }
 
@@ -1066,40 +1180,7 @@ func invalidateCanonicalTagVocabStampIfDeleted(ctx context.Context, db sqlQuerya
 // of the vocabulary hash short-circuits the whole pass when a previous run
 // already seeded this exact vocabulary.
 func sqlSeedCanonicalTags(ctx context.Context, db sqlQueryable) error {
-	// Dedupe within the statement: the NOT EXISTS anti-join only sees rows
-	// already in the table, not other rows of the same INSERT ... SELECT.
-	seenTypes := map[string]struct{}{}
-	typeRows := make([]canonicalTypeRow, 0, len(tags.CanonicalTagDefinitions)+2)
-	addType := func(tagType tags.TagType) {
-		name := string(tagType)
-		if _, ok := seenTypes[name]; ok {
-			return
-		}
-		seenTypes[name] = struct{}{}
-		typeRows = append(typeRows, canonicalTypeRow{name, tags.IsExclusiveType(tagType)})
-	}
-	addType(tags.TagTypeUnknown)
-	addType(tags.TagTypeExtension)
-	for tagType := range tags.CanonicalTagDefinitions {
-		addType(tagType)
-	}
-
-	seenTags := map[string]struct{}{}
-	tagRows := make([]canonicalTagRow, 0, 1400)
-	addTag := func(typeName, value string) {
-		key := typeName + "\x00" + value
-		if _, ok := seenTags[key]; ok {
-			return
-		}
-		seenTags[key] = struct{}{}
-		tagRows = append(tagRows, canonicalTagRow{typeName: typeName, value: value})
-	}
-	addTag(string(tags.TagTypeUnknown), "unknown")
-	for tagType, values := range tags.CanonicalTagDefinitions {
-		for _, value := range values {
-			addTag(string(tagType), tags.PadTagValue(strings.ToLower(string(value))))
-		}
-	}
+	typeRows, tagRows := canonicalTagVocabRows()
 
 	// The vocabulary is compiled into the binary, so once a run has seeded it
 	// the anti-joined inserts are guaranteed no-ops until a release changes the
@@ -1170,4 +1251,47 @@ func sqlSeedCanonicalTags(ctx context.Context, db sqlQueryable) error {
 		log.Warn().Err(err).Msg("failed to write canonical tag vocabulary stamp")
 	}
 	return nil
+}
+
+// canonicalTagVocabRows builds the compiled-in canonical tag vocabulary as the
+// type and value rows sqlSeedCanonicalTags inserts. Shared with the scan
+// fingerprint, which folds the vocabulary's digest into every stored
+// fingerprint so a release that adds a canonical tag reconciles every system
+// once instead of silently never linking the new tag.
+func canonicalTagVocabRows() ([]canonicalTypeRow, []canonicalTagRow) {
+	// Dedupe within the statement: the NOT EXISTS anti-join only sees rows
+	// already in the table, not other rows of the same INSERT ... SELECT.
+	seenTypes := map[string]struct{}{}
+	typeRows := make([]canonicalTypeRow, 0, len(tags.CanonicalTagDefinitions)+2)
+	addType := func(tagType tags.TagType) {
+		name := string(tagType)
+		if _, ok := seenTypes[name]; ok {
+			return
+		}
+		seenTypes[name] = struct{}{}
+		typeRows = append(typeRows, canonicalTypeRow{name, tags.IsExclusiveType(tagType)})
+	}
+	addType(tags.TagTypeUnknown)
+	addType(tags.TagTypeExtension)
+	for tagType := range tags.CanonicalTagDefinitions {
+		addType(tagType)
+	}
+
+	seenTags := map[string]struct{}{}
+	tagRows := make([]canonicalTagRow, 0, 1400)
+	addTag := func(typeName, value string) {
+		key := typeName + "\x00" + value
+		if _, ok := seenTags[key]; ok {
+			return
+		}
+		seenTags[key] = struct{}{}
+		tagRows = append(tagRows, canonicalTagRow{typeName: typeName, value: value})
+	}
+	addTag(string(tags.TagTypeUnknown), "unknown")
+	for tagType, values := range tags.CanonicalTagDefinitions {
+		for _, value := range values {
+			addTag(string(tagType), tags.PadTagValue(strings.ToLower(string(value))))
+		}
+	}
+	return typeRows, tagRows
 }

--- a/pkg/database/mediadb/stat1_seed_data.go
+++ b/pkg/database/mediadb/stat1_seed_data.go
@@ -42,10 +42,11 @@ var stat1SeedRows = []struct{ tbl, idx, stat string }{
 	{tbl: "MediaTitles", idx: "mediatitles_secondary_slug_idx", stat: "99000 99000"},
 	{tbl: "MediaTitles", idx: "mediatitles_slug_idx", stat: "99000 7"},
 	{tbl: "MediaTitles", idx: "mediatitles_system_slug_idx", stat: "99000 3300 1"},
+	{tbl: "ScanSystemFingerprints", idx: "", stat: "30"},
 	{tbl: "Systems", idx: "sqlite_autoindex_Systems_1", stat: "30 1"},
 	{tbl: "TagTypes", idx: "sqlite_autoindex_TagTypes_1", stat: "50 1"},
 	{tbl: "Tags", idx: "tags_tag_idx", stat: "1220 1"},
 	{tbl: "Tags", idx: "tags_tagtype_idx", stat: "1220 31"},
 	{tbl: "Tags", idx: "tags_type_tag_idx", stat: "1220 31 1"},
-	{tbl: "goose_db_version", idx: "", stat: "15"},
+	{tbl: "goose_db_version", idx: "", stat: "16"},
 }

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -1402,12 +1402,6 @@ func NewNamesIndex(
 		return err
 	}
 
-	// TODO: skip unchanged systems via a per-system fingerprint — store
-	// hash(sorted walked paths) + parser version + media row count after each
-	// system completes; on match at the next run, skip the state load, parse,
-	// and reconcile phases entirely. Needs its own design pass for
-	// invalidation rules (parser/config changes) and a forced-reindex path.
-	//
 	// Unified loop: each system is processed exactly once regardless of source.
 	// Filesystem scan, per-system launcher scanners, and any-scanners are all
 	// collected before the AddMediaPath phase. Populate* and FlushScanStateMaps
@@ -1806,6 +1800,7 @@ func NewNamesIndex(
 		if reconcileStats.SystemKnown {
 			log.Debug().
 				Str("system", systemID).
+				Bool("unchanged", reconcileStats.Unchanged).
 				Int64("titlesInserted", reconcileStats.TitlesInserted).
 				Int64("titlesRenamed", reconcileStats.TitlesRenamed).
 				Int64("mediaUpserted", reconcileStats.MediaUpserted).

--- a/pkg/database/mediascanner/mediascanner_bench_test.go
+++ b/pkg/database/mediascanner/mediascanner_bench_test.go
@@ -199,11 +199,18 @@ func BenchmarkMediaScanner_StageAndReconcile_FreshDB(b *testing.B) {
 
 // BenchmarkMediaScanner_Reconcile_FixedScanGrowingDB re-indexes the same 1k
 // files against databases of growing size. This is the memory-scaling
-// regression guard for the staging rearchitecture: allocations must stay flat
-// as the existing row count grows (the old pipeline preloaded every existing
-// row into Go maps, so its footprint scaled with the database instead of the
-// scan). The n-1k rows outside the scan flip to missing on the first
+// regression guard for the staging rearchitecture: retained memory must stay
+// flat as the existing row count grows (the old pipeline preloaded every
+// existing row into Go maps, so its footprint scaled with the database instead
+// of the scan). The n-1k rows outside the scan flip to missing on the first
 // reconcile, before the timer starts; timed iterations are steady-state.
+//
+// Since #1317 the steady-state iterations are skipped reconciles, and the
+// skip's stored-state digest streams one row per media of the system through
+// the driver (sqlScanStoredStateDigest). B/op and allocs/op therefore grow
+// with the system's row count here — that is transient per-row garbage from
+// the driver, not retained state, and it is why the digest is a single
+// one-column query rather than a scan per table.
 func BenchmarkMediaScanner_Reconcile_FixedScanGrowingDB(b *testing.B) {
 	const scanSize = 1_000
 	sizes := []struct {
@@ -259,7 +266,10 @@ func BenchmarkMediaScanner_Reconcile_FixedScanGrowingDB(b *testing.B) {
 // BenchmarkMediaScanner_Reconcile_ExistingRows measures an unchanged full
 // re-index against a database that already holds the same rows. Cost is
 // expected to scale linearly with scan size (per-file parse + staging), never
-// super-linearly with the database.
+// super-linearly with the database. Since #1317 the reconcile itself is
+// skipped here: the staged-set fingerprint matches the stored one, so the
+// timed work is staging plus the two digests (staged set, stored state) that
+// prove the skip is safe.
 func BenchmarkMediaScanner_Reconcile_ExistingRows(b *testing.B) {
 	sizes := []struct {
 		name string

--- a/pkg/database/mediascanner/scan_fingerprint_test.go
+++ b/pkg/database/mediascanner/scan_fingerprint_test.go
@@ -1,0 +1,524 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the staged-set fingerprint that lets reconcile skip a system
+// whose staged input and stored state are unchanged since its last reconcile
+// (#1317). A false skip hides real media changes and a user would only see
+// missing media, so most of the cases here are the ways the skip must NOT
+// happen.
+
+func snesPath(name string) string {
+	return filepath.Join(string(filepath.Separator), "roms", "SNES", name)
+}
+
+// stagedSNESMedia builds a staged row by hand so a test can vary the fields
+// reconcile consumes — tags, properties, slug — while keeping the path fixed,
+// which StageMediaPath (deriving everything from the filename) cannot do.
+func stagedSNESMedia(path string, stagedTags ...database.ScanStagedTag) database.ScanStagedMedia {
+	return database.ScanStagedMedia{
+		Path:          path,
+		ParentDir:     mediadb.ParentDirForMediaPath(filepath.ToSlash(path)),
+		Slug:          "somegame",
+		TitleName:     "Some Game",
+		SortName:      "Some Game",
+		SlugLength:    8,
+		SlugWordCount: 2,
+		Tags:          stagedTags,
+	}
+}
+
+// stageAndReconcile runs pre-built staged rows through seeding, staging,
+// reconcile and commit, rolling back on a reconcile error so the caller can
+// assert on the state a failed run leaves behind.
+func stageAndReconcile(
+	t *testing.T, db *mediadb.MediaDB, systemID string, opts database.ScanReconcileOpts,
+	media ...database.ScanStagedMedia,
+) (*database.ScanReconcileStats, error) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, SeedCanonicalTags(ctx, db))
+	require.NoError(t, db.BeginTransaction(true))
+	require.NoError(t, db.ClearScanStage())
+	for i := range media {
+		require.NoError(t, db.StageScannedMedia(&media[i]))
+	}
+	stats, err := db.ReconcileStagedSystem(ctx, systemID, opts)
+	if err != nil {
+		require.NoError(t, db.RollbackTransaction())
+		return &stats, fmt.Errorf("reconcile staged system: %w", err)
+	}
+	require.NoError(t, db.CommitTransaction())
+	return &stats, nil
+}
+
+func fingerprintRowCount(t *testing.T, db database.MediaDBI) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.UnsafeGetSQLDb().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM ScanSystemFingerprints").Scan(&n))
+	return n
+}
+
+// reindex is indexMediaPaths returning its stats by pointer, so the assertion
+// helpers below can take them without copying the struct per call.
+func reindex(t *testing.T, db database.MediaDBI, systemID string, paths ...string) *database.ScanReconcileStats {
+	t.Helper()
+	stats := indexMediaPaths(t, db, systemID, paths...)
+	return &stats
+}
+
+func assertReconcileRan(t *testing.T, stats *database.ScanReconcileStats) {
+	t.Helper()
+	assert.False(t, stats.Unchanged, "reconcile must not be skipped")
+}
+
+func assertReconcileSkipped(t *testing.T, stats *database.ScanReconcileStats) {
+	t.Helper()
+	assert.True(t, stats.Unchanged, "an unchanged system must be skipped")
+	assert.Zero(t, stats.TitlesInserted+stats.TitlesRenamed+stats.MediaUpserted+stats.MediaMissing+
+		stats.TagsInserted+stats.TagLinksAdded+stats.TagLinksDeleted+stats.TouchedTitles,
+		"a skipped reconcile reports no work")
+}
+
+func TestScanFingerprint_UnchangedReindexIsSkipped(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	paths := []string{snesPath("Alpha (USA).sfc"), snesPath("Beta (Europe) (Rev 2).sfc")}
+	first := reindex(t, mediaDB, "SNES", paths...)
+	assertReconcileRan(t, first)
+	assert.Equal(t, 1, fingerprintRowCount(t, mediaDB), "a successful reconcile stores its fingerprint")
+	before := mediaBySystem(t, mediaDB, "SNES")
+
+	second := reindex(t, mediaDB, "SNES", paths...)
+	assertReconcileSkipped(t, second)
+	assert.Equal(t, before, mediaBySystem(t, mediaDB, "SNES"), "a skipped reconcile leaves the rows as they were")
+	assert.Subset(t, mediaTagStrings(t, mediaDB, before[paths[0]].DBID), []string{"region:us", "extension:sfc"})
+
+	// Skipping is stable: nothing about a skipped run changes the next decision.
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", paths...))
+}
+
+func TestScanFingerprint_SkipClearsStagingTables(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Alpha (USA).sfc")
+	reindex(t, mediaDB, "SNES", path)
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", path))
+
+	for _, table := range []string{"ScanStage", "ScanStageTags", "ScanStageProperties"} {
+		var n int
+		require.NoError(t, mediaDB.UnsafeGetSQLDb().QueryRowContext(context.Background(),
+			"SELECT COUNT(*) FROM "+table).Scan(&n))
+		assert.Zero(t, n, "%s must be cleared by a skipped reconcile", table)
+	}
+}
+
+// The digest is over rows in primary-key order, not staging order, so the
+// order the filesystem walk happens to yield files in cannot defeat it.
+func TestScanFingerprint_StagingOrderDoesNotMatter(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	a, b, c := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc"), snesPath("Gamma (Japan).sfc")
+	reindex(t, mediaDB, "SNES", a, b, c)
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", c, a, b))
+}
+
+func TestScanFingerprint_AddedFileReconciles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	a, b := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc")
+	reindex(t, mediaDB, "SNES", a)
+
+	stats := reindex(t, mediaDB, "SNES", a, b)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.MediaUpserted)
+	require.Len(t, mediaBySystem(t, mediaDB, "SNES"), 2)
+
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", a, b))
+}
+
+func TestScanFingerprint_RemovedFileReconciles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	a, b := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc")
+	reindex(t, mediaDB, "SNES", a, b)
+
+	stats := reindex(t, mediaDB, "SNES", a)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.MediaMissing)
+	assert.True(t, mediaBySystem(t, mediaDB, "SNES")[b].IsMissing)
+
+	// The reduced set is the new steady state and skips like any other.
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", a))
+
+	// The file coming back is a staged-set change again.
+	stats = reindex(t, mediaDB, "SNES", a, b)
+	assertReconcileRan(t, stats)
+	assert.False(t, mediaBySystem(t, mediaDB, "SNES")[b].IsMissing)
+}
+
+// A parser or configuration change that alters what is derived from an
+// unchanged filename must move the fingerprint: the tags are part of the
+// staged set, not just the paths.
+func TestScanFingerprint_StagedTagChangeReconciles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Some Game.sfc")
+	usa := database.ScanStagedTag{Type: string(tags.TagTypeRegion), Value: "us"}
+	europe := database.ScanStagedTag{Type: string(tags.TagTypeRegion), Value: "eu"}
+
+	_, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, stagedSNESMedia(path, usa))
+	require.NoError(t, err)
+	stats, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, stagedSNESMedia(path, usa))
+	require.NoError(t, err)
+	assertReconcileSkipped(t, stats)
+
+	stats, err = stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, stagedSNESMedia(path, europe))
+	require.NoError(t, err)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.TagLinksAdded)
+	assert.Equal(t, int64(1), stats.TagLinksDeleted)
+	row := mediaBySystem(t, mediaDB, "SNES")[path]
+	assert.ElementsMatch(t, []string{"region:eu"}, mediaTagStrings(t, mediaDB, row.DBID))
+}
+
+// The same path staged with a different title derivation (slug, name, sort
+// name) is a changed set even though no file was added or removed.
+func TestScanFingerprint_StagedTitleChangeReconciles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Some Game.sfc")
+	original := stagedSNESMedia(path)
+	_, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, original)
+	require.NoError(t, err)
+
+	renamed := original
+	renamed.TitleName = "Some Game Deluxe"
+	renamed.SortName = "Some Game Deluxe"
+	stats, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, renamed)
+	require.NoError(t, err)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.TitlesRenamed)
+	assert.Equal(t, "Some Game Deluxe", mediaBySystem(t, mediaDB, "SNES")[path].SortName)
+}
+
+// The scanner only stages a property it could not find in the database, so a
+// staged property is new work by construction and can never be skipped over.
+func TestScanFingerprint_StagedPropertyForcesReconcile(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Some Game.sfc")
+	plain := stagedSNESMedia(path)
+	_, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, plain)
+	require.NoError(t, err)
+
+	withProperty := plain
+	withProperty.Properties = []database.ScanStagedProperty{{
+		Type: string(tags.TagTypeProperty),
+		Name: string(tags.TagPropertyGameID),
+		Text: "SNS-XX-USA",
+	}}
+	for range 2 {
+		stats, runErr := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, withProperty)
+		require.NoError(t, runErr)
+		assertReconcileRan(t, stats)
+	}
+
+	stats, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{}, plain)
+	require.NoError(t, err)
+	assertReconcileSkipped(t, stats)
+}
+
+// Anything that edits the rows reconcile owns behind its back — here a
+// scanner-owned tag written through the same API the scraper and tag editing
+// use, and a media row deleted outright — must fail open into a reconcile
+// even though the staged set is identical. This is the stored-state half of
+// the fingerprint; the media-count guard alone would miss the first case.
+func TestScanFingerprint_OutOfBandStateChangeReconciles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("scanner-owned tag link added", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+		t.Cleanup(cleanup)
+
+		path := snesPath("Alpha (USA).sfc")
+		reindex(t, mediaDB, "SNES", path)
+		row := mediaBySystem(t, mediaDB, "SNES")[path]
+		require.NoError(t, mediaDB.UpsertMediaTags(context.Background(), row.DBID, []database.TagInfo{
+			{Type: string(tags.TagTypeRegion), Tag: "eu"},
+		}))
+
+		stats := reindex(t, mediaDB, "SNES", path)
+		assertReconcileRan(t, stats)
+		assert.Equal(t, int64(1), stats.TagLinksDeleted, "the stale link is removed by the reconcile that ran")
+		assert.NotContains(t, mediaTagStrings(t, mediaDB, row.DBID), "region:eu")
+
+		assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", path))
+	})
+
+	t.Run("media row deleted", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+		t.Cleanup(cleanup)
+
+		a, b := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc")
+		reindex(t, mediaDB, "SNES", a, b)
+		_, err := mediaDB.UnsafeGetSQLDb().ExecContext(context.Background(),
+			"DELETE FROM Media WHERE DBID = ?", mediaBySystem(t, mediaDB, "SNES")[b].DBID)
+		require.NoError(t, err)
+
+		stats := reindex(t, mediaDB, "SNES", a, b)
+		assertReconcileRan(t, stats)
+		assert.Equal(t, int64(1), stats.MediaUpserted, "the deleted row is re-inserted")
+		require.Len(t, mediaBySystem(t, mediaDB, "SNES"), 2)
+	})
+
+	t.Run("media flagged missing", func(t *testing.T) {
+		t.Parallel()
+		mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+		t.Cleanup(cleanup)
+
+		path := snesPath("Alpha (USA).sfc")
+		reindex(t, mediaDB, "SNES", path)
+		_, err := mediaDB.UnsafeGetSQLDb().ExecContext(context.Background(),
+			"UPDATE Media SET IsMissing = 1 WHERE DBID = ?", mediaBySystem(t, mediaDB, "SNES")[path].DBID)
+		require.NoError(t, err)
+
+		stats := reindex(t, mediaDB, "SNES", path)
+		assertReconcileRan(t, stats)
+		assert.False(t, mediaBySystem(t, mediaDB, "SNES")[path].IsMissing, "the file is on disk, so it is re-found")
+	})
+}
+
+// A stored fingerprint from a different generation — a release whose
+// reconcile, schema, tag vocabulary or disambiguation version differs — never
+// matches. Modelled by rewriting the stored digest, which is what any of those
+// changes does to the comparison.
+func TestScanFingerprint_GenerationMismatchReconciles(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Alpha (USA).sfc")
+	reindex(t, mediaDB, "SNES", path)
+	_, err := mediaDB.UnsafeGetSQLDb().ExecContext(context.Background(),
+		"UPDATE ScanSystemFingerprints SET Fingerprint = 'written-by-another-generation'")
+	require.NoError(t, err)
+
+	assertReconcileRan(t, reindex(t, mediaDB, "SNES", path))
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", path))
+}
+
+// An incomplete scan stages a subset of the library, so it must neither be
+// compared against a full scan's fingerprint nor leave one behind: the first
+// full scan after it reconciles, and only then does skipping resume.
+func TestScanFingerprint_IncompleteScanNeverSkipsAndForgetsFingerprint(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	a, b := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc")
+	reindex(t, mediaDB, "SNES", a, b)
+	require.Equal(t, 1, fingerprintRowCount(t, mediaDB))
+
+	incomplete := database.ScanReconcileOpts{IncompleteScan: true}
+	ctx := context.Background()
+	require.NoError(t, mediaDB.BeginTransaction(true))
+	require.NoError(t, mediaDB.ClearScanStage())
+	require.NoError(t, StageMediaPath(&StageMediaPathParams{DB: mediaDB, SystemID: "SNES", Path: a}))
+	require.NoError(t, StageMediaPath(&StageMediaPathParams{DB: mediaDB, SystemID: "SNES", Path: b}))
+	stats, err := mediaDB.ReconcileStagedSystem(ctx, "SNES", incomplete)
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+	assertReconcileRan(t, &stats)
+	assert.Zero(t, fingerprintRowCount(t, mediaDB), "an incomplete scan clears the stored fingerprint")
+
+	assertReconcileRan(t, reindex(t, mediaDB, "SNES", a, b))
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", a, b))
+}
+
+// The fingerprint is written inside the reconcile's transaction, so a run that
+// is rolled back — here cancelled through the pacing hook, the path the
+// scanner's own cancellation takes — leaves the previous fingerprint in place
+// and the rows it describes untouched. If the aborted run's fingerprint leaked,
+// the next scan of the same set would be skipped with the new file missing.
+func TestScanFingerprint_RolledBackReconcileLeavesNoFingerprint(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	a, b := snesPath("Alpha (USA).sfc"), snesPath("Beta (USA).sfc")
+	reindex(t, mediaDB, "SNES", a)
+
+	cancelled := errors.New("indexing cancelled")
+	yields := 0
+	_, err := stageAndReconcile(t, mediaDB, "SNES", database.ScanReconcileOpts{
+		Yield: func() error {
+			yields++
+			if yields > 3 {
+				return cancelled
+			}
+			return nil
+		},
+	}, stagedSNESMedia(a), stagedSNESMedia(b))
+	require.ErrorIs(t, err, cancelled)
+	require.Len(t, mediaBySystem(t, mediaDB, "SNES"), 1, "the rolled-back reconcile wrote nothing")
+
+	stats := reindex(t, mediaDB, "SNES", a, b)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.MediaUpserted)
+	require.Len(t, mediaBySystem(t, mediaDB, "SNES"), 2)
+}
+
+func TestScanFingerprint_TruncatedSystemReconcilesFresh(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Alpha (USA).sfc")
+	reindex(t, mediaDB, "SNES", path)
+	require.NoError(t, mediaDB.TruncateSystems([]string{"SNES"}))
+	assert.Zero(t, fingerprintRowCount(t, mediaDB), "truncating a system drops its fingerprint")
+
+	stats := reindex(t, mediaDB, "SNES", path)
+	assertReconcileRan(t, stats)
+	assert.Equal(t, int64(1), stats.MediaUpserted)
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", path))
+}
+
+// A forced rebuild recreates the database from scratch; nothing survives to
+// be matched against.
+func TestScanFingerprint_RecreatedDatabaseReconcilesFresh(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	path := snesPath("Alpha (USA).sfc")
+	reindex(t, mediaDB, "SNES", path)
+	require.NoError(t, mediaDB.Recreate(false))
+	assert.Zero(t, fingerprintRowCount(t, mediaDB))
+
+	stats := reindex(t, mediaDB, "SNES", path)
+	assertReconcileRan(t, stats)
+	require.Len(t, mediaBySystem(t, mediaDB, "SNES"), 1)
+}
+
+// Fingerprints are per system: a change in one must not disturb another's
+// skip, and each system's row is keyed to its own Systems row.
+func TestScanFingerprint_SystemsAreIndependent(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := testhelpers.NewInMemoryMediaDB(t)
+	t.Cleanup(cleanup)
+
+	snes := snesPath("Alpha (USA).sfc")
+	nes := filepath.Join(string(filepath.Separator), "roms", "NES", "Beta (USA).nes")
+	nes2 := filepath.Join(string(filepath.Separator), "roms", "NES", "Gamma (USA).nes")
+	reindex(t, mediaDB, "SNES", snes)
+	reindex(t, mediaDB, "NES", nes)
+	require.Equal(t, 2, fingerprintRowCount(t, mediaDB))
+
+	assertReconcileRan(t, reindex(t, mediaDB, "NES", nes, nes2))
+	assertReconcileSkipped(t, reindex(t, mediaDB, "SNES", snes))
+	assertReconcileSkipped(t, reindex(t, mediaDB, "NES", nes, nes2))
+}
+
+// TestNewNamesIndex_SecondRunSkipsUnchangedSystems drives the whole scanner
+// twice over the same files and checks that every system is skipped on the
+// second run, that the media are still all there, and that the skip is
+// reported where an operator would look for it.
+func TestNewNamesIndex_SecondRunSkipsUnchangedSystems(t *testing.T) {
+	// Cannot use t.Parallel() - modifies shared GlobalLauncherCache and log.Logger.
+	db, cleanup := testhelpers.NewTestDatabase(t)
+	defer cleanup()
+
+	systemFiles := map[string][]string{
+		systemdefs.SystemGameboy: {"pocket_quest.bin", "pocket_quest_2.bin"},
+		systemdefs.SystemSNES:    {"super_quest.bin"},
+	}
+	platform, cfg, systems := setupCustomLauncherSystems(t, systemFiles)
+	ctx := context.Background()
+
+	var buf strings.Builder
+	prevLogger := log.Logger
+	prevLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.InfoLevel)
+	t.Cleanup(func() {
+		log.Logger = prevLogger
+		zerolog.SetGlobalLevel(prevLevel)
+	})
+	const skipped = "scan reconcile skipped"
+
+	first, err := NewNamesIndex(ctx, platform, cfg, systems, db, func(_ IndexStatus) {}, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, first)
+	assert.Zero(t, strings.Count(buf.String(), skipped), "a fresh index reconciles every system")
+	assert.Equal(t, 2, fingerprintRowCount(t, db.MediaDB))
+
+	buf.Reset()
+	second, err := NewNamesIndex(ctx, platform, cfg, systems, db, func(_ IndexStatus) {}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, first, second, "a skipped system still counts its files")
+	assert.Equal(t, 2, strings.Count(buf.String(), skipped), "every unchanged system is skipped")
+
+	total, err := db.MediaDB.GetTotalMediaCount()
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	status, err := db.MediaDB.GetIndexingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, mediadb.IndexingStatusCompleted, status)
+}


### PR DESCRIPTION
- Reconcile now stores a per-system fingerprint after each successful run, in the same transaction: a digest of the staged set (ScanStage rows with their tags, prefixed with the reconcile version, schema version, canonical tag vocabulary hash and disambiguation version) and a digest of the stored rows reconcile owns (media path/parent dir/sort name/missing flag, title slug/name/secondary slug, tag-link DBIDs). When both match on the next scan, every reconcile statement is skipped. On the #1279 device reconcile was 45% of indexing wall time, almost all of it on systems where every step affected zero rows (#1317).
- The stored-state digest goes beyond the media-count guard #1317 proposed: four existing reconcile tests showed that guard missing out-of-band edits with unchanged counts (a scanner-owned tag written through `UpsertMediaTags`, a raw repair), so those now fail open into a full reconcile. Incomplete scans and digest errors reconcile and delete the stored row; fresh systems reconcile and store; any staged property forces a reconcile; `TruncateSystems`/`Truncate` delete the rows explicitly since foreign keys are off there.
- Both digests read one row per file or media with tags folded in by an ordered `group_concat` and all fields concatenated into one column. Measured against a `git archive` export of `origin/main` (count=6, benchstat; the committed baseline has no `MediaScanner_*` entries): `Reconcile_ExistingRows` −15%/−17% sec/op at 10k/100k with +7% allocs; `Reconcile_FixedScanGrowingDB/100k` +60% sec/op and 387k vs 84k allocs/op, because its steady state is now a skip that digests a 100k-row system for a 1k-file scan (per-table scans were 3.3M allocs). The benchmark comment explains the new shape. Device cost is not measured yet.
- `Truncate` deleted `Tags`/`TagTypes` but left the canonical vocabulary stamp, so the next run would have skipped seeding into empty tables; it now clears the stamp.
- `Recreate(keepBackup)` preserves the database, WAL and SHM together after `Close()` (it dropped the SHM and its doc comment still described rename-before-close), logs each preserved file's path and size, and a test reassembles the three files and checks the WAL-only row survives. The dev-builds-only policy for keeping the copy is unchanged.
- New crash-consistency tests drive the staging/tag-link/commit path on a file database, snapshot the files, damage the copy and reopen: commit without checkpoint, spilled uncommitted frames, torn WAL tail (three variants), checkpoint interrupted after one/half/all frames, checkpointed database without sidecars, and cancellation mid-reconcile. Every case checks `integrity_check` on the recovered file.
- `stat1_seed_data.go` is regenerated with its generator for the new table and migration version; that is the only change in it.

Refs #1279, #1317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unchanged media scans are now detected and skipped, reducing redundant reconciliation work.
  - Reconcile results indicate when no changes were required.
  - Recovery logs record preserved database backup paths and file sizes.

- **Bug Fixes**
  - Database recovery preserves the complete backup set, including WAL and shared-memory files.
  - Maintenance operations now clear scan fingerprint data correctly.

- **Tests**
  - Added coverage for crash recovery, forensic backups, scan skipping, and reconciliation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->