### PR TITLE
fix(mediadb): naturally sort browse titles

### DIFF
--- a/pkg/api/methods/media_browse_index.go
+++ b/pkg/api/methods/media_browse_index.go
@@ -39,26 +39,18 @@ import (
 //
 // Phase 1 (current): buckets are derived from the first character of
 // Media.SortName via the shared bucketer (BrowseNameFirstChar /
-// browseBucketKeyExpr), giving Latin/numeric buckets A-Z, 0-9, #. SortName has
-// no phonetic normalization, so CJK titles all land in '#' — identical to how
-// media.browse already orders them, so no regression. The response reports
-// scheme "latin".
+// browseBucketKeyExpr), giving Latin/numeric buckets A-Z, 0-9, #. Browse uses a
+// case-insensitive, punctuation-aware natural collation that keeps those buckets
+// contiguous. SortName has no phonetic normalization, so CJK titles all land in
+// '#'. The response reports scheme "latin".
 //
-// Phase 2 (later, Core-side, no client change): populate a normalized,
-// case-folded sort key at index time and bucket/sort on it instead of SortName.
-// This is the same change for two problems:
-//   - Latin: SortName is BINARY-collated, so lowercase-initial titles sort after
-//     'Z' and would strand under the wrong bucket. A case-folded key fixes the
-//     ordering wrinkle.
-//   - CJK: bucket by pinyin initial (Chinese), kana row (Japanese), or hangul
-//     initial (Korean). Korean is computable from the codepoint; Chinese needs a
-//     Han->pinyin table; Japanese needs reading (yomi) data and is the hardest.
-// The vehicle is a *stored* column populated in Go at index time (a generated
-// column cannot run the phonetic transforms), indexed like SortName. Swapping it
-// in touches only the one shared bucketer; the facet, the letter filter, and the
-// seek cursor follow automatically. No data backfill — it fills on the next
-// manual reindex; pre-reindex rows fall back to SortName bucketing. The response
-// then reports scheme "pinyin"/"kana"/"hangul"/"mixed".
+// Phase 2 (later, Core-side, no client change): populate a phonetic sort key at
+// index time and bucket by pinyin initial (Chinese), kana row (Japanese), or
+// hangul initial (Korean). Korean is computable from the codepoint; Chinese needs
+// a Han->pinyin table; Japanese needs reading (yomi) data and is the hardest.
+// The vehicle is a stored column populated in Go at index time. Swapping it in
+// touches only the shared bucketer; facet, letter filter, and seek cursor follow.
+// Response then reports scheme "pinyin"/"kana"/"hangul"/"mixed".
 //
 // Forward-compatibility is already baked in so Phase 2 needs no client change:
 // scheme and key are opaque, label is separate from key, and jumping is done via

--- a/pkg/database/mediadb/concurrent_read_during_tx_test.go
+++ b/pkg/database/mediadb/concurrent_read_during_tx_test.go
@@ -46,7 +46,7 @@ func TestFindSystemBySystemID_ConcurrentDuringIndexingTransaction(t *testing.T) 
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 
-	sqlDB, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sqlDB.Close())

--- a/pkg/database/mediadb/frontend_prereq_plan_test.go
+++ b/pkg/database/mediadb/frontend_prereq_plan_test.go
@@ -109,7 +109,7 @@ func TestFrontendPrerequisiteQueryPlansUseExistingIndexes(t *testing.T) {
 			SELECT m.DBID
 			FROM Media m
 			WHERE `+whereClause+`
-			ORDER BY m.SortName ASC, m.DBID ASC
+			ORDER BY m.SortName COLLATE ZAPAROO_TITLE_V1 ASC, m.DBID ASC
 			LIMIT ?`, args...)
 		assertRandomPlanContains(t, plan, "mediatags_tag_media_idx")
 		assertRandomPlanContains(t, plan, "mediatitletags_tag_idx")

--- a/pkg/database/mediadb/mediadb.go
+++ b/pkg/database/mediadb/mediadb.go
@@ -1009,9 +1009,12 @@ func (db *MediaDB) AnalyzeApproximate() error {
 	return nil
 }
 
+const browseSortIndexName = "idx_media_browse_sort"
+
 type secondaryIndex struct {
-	name string
-	ddl  string
+	name               string
+	ddl                string
+	replaceWhenEnsured bool
 }
 
 // secondaryIndexes lists all secondary indexes that can be dropped before bulk
@@ -1096,8 +1099,10 @@ var secondaryIndexes = []secondaryIndex{
 		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_parentdir_system ON Media(ParentDir, SystemDBID)",
 	},
 	{
-		name: "idx_media_browse_sort",
-		ddl:  "CREATE INDEX IF NOT EXISTS idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID)",
+		name: browseSortIndexName,
+		ddl: "CREATE INDEX IF NOT EXISTS " + browseSortIndexName +
+			" ON Media(ParentDir, IsMissing, SortName COLLATE " + browseTitleCollationName + ", DBID)",
+		replaceWhenEnsured: true,
 	},
 }
 
@@ -1135,18 +1140,68 @@ func (db *MediaDB) secondaryIndexExists(indexName string) (bool, error) {
 	return true, nil
 }
 
+func (db *MediaDB) secondaryIndexCurrent(idx secondaryIndex) (bool, error) {
+	exists, err := db.secondaryIndexExists(idx.name)
+	if err != nil || !exists {
+		return exists, err
+	}
+	if idx.name != browseSortIndexName {
+		return true, nil
+	}
+
+	rows, err := db.conn().QueryContext(db.ctx,
+		"SELECT name, coll FROM pragma_index_xinfo(?) WHERE key = 1", idx.name)
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect index %s: %w", idx.name, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var column, collation sql.NullString
+		if scanErr := rows.Scan(&column, &collation); scanErr != nil {
+			return false, fmt.Errorf("failed to scan index %s columns: %w", idx.name, scanErr)
+		}
+		if column.String == "SortName" {
+			return strings.EqualFold(collation.String, browseTitleCollationName), nil
+		}
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return false, fmt.Errorf("failed to read index %s columns: %w", idx.name, rowsErr)
+	}
+	return false, nil
+}
+
 func (db *MediaDB) missingSecondaryIndexes() ([]secondaryIndex, error) {
 	missing := make([]secondaryIndex, 0)
 	for _, idx := range secondaryIndexes {
-		exists, err := db.secondaryIndexExists(idx.name)
+		current, err := db.secondaryIndexCurrent(idx)
 		if err != nil {
 			return nil, err
 		}
-		if !exists {
+		if !current {
 			missing = append(missing, idx)
 		}
 	}
 	return missing, nil
+}
+
+func (db *MediaDB) replaceSecondaryIndex(idx secondaryIndex) error {
+	tx, err := db.sql.Load().BeginTx(db.ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin replacement of index %s: %w", idx.name, err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err = tx.ExecContext(db.ctx, "DROP INDEX IF EXISTS "+idx.name); err != nil {
+		return fmt.Errorf("failed to drop old index %s: %w", idx.name, err)
+	}
+	if _, err = tx.ExecContext(db.ctx, idx.ddl); err != nil {
+		return fmt.Errorf("failed to create replacement index %s: %w", idx.name, err)
+	}
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit replacement index %s: %w", idx.name, err)
+	}
+	return nil
 }
 
 // CreateSecondaryIndexes recreates dropped secondary indexes after bulk inserts
@@ -1176,7 +1231,12 @@ func (db *MediaDB) CreateSecondaryIndexes() error {
 
 	for _, idx := range indexesToEnsure {
 		started := time.Now()
-		_, err := db.sql.Load().ExecContext(db.ctx, idx.ddl)
+		var err error
+		if idx.replaceWhenEnsured {
+			err = db.replaceSecondaryIndex(idx)
+		} else {
+			_, err = db.sql.Load().ExecContext(db.ctx, idx.ddl)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to create index %s: %w", idx.name, err)
 		}

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -3943,16 +3943,46 @@ func TestMediaDB_CreateSecondaryIndexes_RecreatesMissingIndexes_Integration(t *t
 		_, err := mediaDB.UnsafeGetSQLDb().ExecContext(ctx, "DROP INDEX IF EXISTS "+indexName)
 		require.NoError(t, err)
 	}
+	replaceBrowseSortIndexWithBinary(t, mediaDB)
+	current, err := mediaDB.secondaryIndexCurrent(browseSortIndexForTest(t))
+	require.NoError(t, err)
+	require.False(t, current, "fixture should carry the legacy binary browse index")
 
 	mediaDB.needsIndexRebuild.Store(false)
 
-	err := mediaDB.CreateSecondaryIndexes()
+	err = mediaDB.CreateSecondaryIndexes()
 	require.NoError(t, err)
 	assert.False(t, mediaDB.needsIndexRebuild.Load())
 
 	for _, indexName := range []string{"media_path_idx", "idx_media_parentdir"} {
 		assertIndexExists(t, mediaDB, indexName)
 	}
+	current, err = mediaDB.secondaryIndexCurrent(browseSortIndexForTest(t))
+	require.NoError(t, err)
+	assert.True(t, current, "legacy browse index should be replaced with natural collation")
+}
+
+func TestMediaDB_ReplaceSecondaryIndexFailureKeepsOldIndex_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	t.Parallel()
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	replaceBrowseSortIndexWithBinary(t, mediaDB)
+	bad := secondaryIndex{
+		name:               browseSortIndexName,
+		ddl:                "CREATE INDEX idx_media_browse_sort ON Media(NoSuchColumn)",
+		replaceWhenEnsured: true,
+	}
+	err := mediaDB.replaceSecondaryIndex(bad)
+	require.Error(t, err)
+
+	assertIndexExists(t, mediaDB, browseSortIndexName)
+	current, err := mediaDB.secondaryIndexCurrent(browseSortIndexForTest(t))
+	require.NoError(t, err)
+	assert.False(t, current, "failed atomic replacement should roll back to the legacy index")
 }
 
 func TestMediaDB_RebuildTagCache_SelectiveIndexingWarmsTouchedAndUntouchedSystems_Integration(t *testing.T) {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -186,6 +186,28 @@ func TestMediaTagCompositeLookupAndDelete(t *testing.T) {
 	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
+// The browse sort index orders SortName with a collation this binary registers
+// on its connections rather than storing in the file, so a build without it
+// cannot prepare any statement against Media. Introducing the index through a
+// migration is what moves the schema version past older builds, so going back
+// to one raises ErrSchemaAhead and startup rebuilds the media database instead
+// of failing on a schema it cannot parse. CreateSecondaryIndexes only runs at
+// the end of an indexing run, so an index present on a freshly migrated
+// database can only have come from a migration.
+func TestMigrations_CreateBrowseSortIndexWithItsCollation(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+
+	require.NoError(t, mediaDB.MigrateUp())
+
+	var indexSQL string
+	require.NoError(t, mediaDB.UnsafeGetSQLDb().QueryRowContext(context.Background(),
+		"SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", browseSortIndexName,
+	).Scan(&indexSQL), "browse sort index must exist on a freshly migrated database")
+	assert.Contains(t, indexSQL, browseTitleCollationName,
+		"the index must carry the collation whose absence breaks older builds")
+}
+
 func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {
 	// Create temp directory that the mock platform will use
 	tempDir, err := os.MkdirTemp("", "zaparoo-test-mediadb-*")

--- a/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
+++ b/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- idx_media_browse_sort orders SortName with the ZAPAROO_TITLE_V1 collation,
+-- which this binary's SQLite driver registers per connection rather than
+-- storing in the file. A build without that collation cannot prepare any
+-- statement against Media at all, because SQLite resolves index definitions
+-- first: indexing dies on its first insert with "no such collation sequence"
+-- and browse falls back to "no query solution". Nothing recovers from it,
+-- because the media database is rebuilt on a schema version it does not
+-- understand, and creating an index bumps no version by itself.
+--
+-- CreateSecondaryIndexes owns this index's real lifecycle, dropping and
+-- recreating it around bulk inserts. Creating it here as well moves the schema
+-- version past what older builds embed, so going back to one of them raises
+-- ErrSchemaAhead and startup rebuilds the media database instead of running
+-- against a schema it cannot parse.
+
+-- 20260609120000_media_sortname created this index without a collation, so it
+-- has to be replaced rather than created. Queries pin it with INDEXED BY, so
+-- dropping it without putting it back would fail browse outright.
+DROP INDEX IF EXISTS idx_media_browse_sort;
+CREATE INDEX idx_media_browse_sort
+    ON Media(ParentDir, IsMissing, SortName COLLATE ZAPAROO_TITLE_V1, DBID);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_media_browse_sort;
+CREATE INDEX idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID);

--- a/pkg/database/mediadb/sql_browse.go
+++ b/pkg/database/mediadb/sql_browse.go
@@ -816,10 +816,10 @@ func runBrowseOverlayDirectories(
 	opts database.BrowseDirectoriesOptions,
 ) ([]database.BrowseDirectoryResult, error) {
 	if opts.AfterName != "" {
-		query += ` AND name > ?`
+		query += ` AND ` + browseNaturalSortExpr("name") + ` > ?`
 		args = append(args, opts.AfterName)
 	}
-	query += ` ORDER BY name ASC`
+	query += ` ORDER BY ` + browseNaturalSortExpr("name") + ` ASC`
 	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
 		query += limitClause
 		args = append(args, limitArgs...)
@@ -907,10 +907,10 @@ func sqlBrowseDirectoriesFromCache(
 		args = append(args, systemArgs...)
 	}
 	if opts.AfterName != "" {
-		query += ` AND d.Name > ?`
+		query += ` AND ` + browseNaturalSortExpr("d.Name") + ` > ?`
 		args = append(args, opts.AfterName)
 	}
-	query += ` GROUP BY d.DBID, d.Name ORDER BY d.Name ASC`
+	query += ` GROUP BY d.DBID, d.Name ORDER BY ` + browseNaturalSortExpr("d.Name") + ` ASC`
 	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
 		query += limitClause
 		args = append(args, limitArgs...)
@@ -955,10 +955,10 @@ func sqlBrowseDirectoriesFromCacheForSingleSystem(
 			AND d.IsVirtual = 0
 			AND s.SystemID = ?`
 	if opts.AfterName != "" {
-		query += ` AND d.Name > ?`
+		query += ` AND ` + browseNaturalSortExpr("d.Name") + ` > ?`
 		args = append(args, opts.AfterName)
 	}
-	query += ` ORDER BY d.Name ASC`
+	query += ` ORDER BY ` + browseNaturalSortExpr("d.Name") + ` ASC`
 	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
 		query += limitClause
 		args = append(args, limitArgs...)
@@ -1003,10 +1003,10 @@ func sqlBrowseDirectoriesFromMedia(
 		 WHERE instr(Rest, '/') > 0
 		 GROUP BY Name`
 	if opts.AfterName != "" {
-		query += ` HAVING Name > ?`
+		query += ` HAVING ` + browseNaturalSortExpr("Name") + ` > ?`
 		args = append(args, opts.AfterName)
 	}
-	query += ` ORDER BY Name ASC`
+	query += ` ORDER BY ` + browseNaturalSortExpr("Name") + ` ASC`
 	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
 		query += limitClause
 		args = append(args, limitArgs...)
@@ -1055,10 +1055,10 @@ func sqlBrowseDirectoriesForSystemsFromMedia(
 		 WHERE instr(Rest, '/') > 0
 		 GROUP BY Name`
 	if opts.AfterName != "" {
-		query += ` HAVING Name > ?`
+		query += ` HAVING ` + browseNaturalSortExpr("Name") + ` > ?`
 		args = append(args, opts.AfterName)
 	}
-	query += ` ORDER BY Name ASC`
+	query += ` ORDER BY ` + browseNaturalSortExpr("Name") + ` ASC`
 	if limitClause, limitArgs := browseDirLimitClause(opts.Limit); limitClause != "" {
 		query += limitClause
 		args = append(args, limitArgs...)
@@ -1128,6 +1128,14 @@ func browseFilenameExpr() string {
 	return `substr(m.Path, length(m.ParentDir) + 1)`
 }
 
+func browseNaturalSortExpr(expr string) string {
+	return expr + " COLLATE " + browseDirectoryCollationName
+}
+
+func browseTitleSortExpr() string {
+	return "m.SortName COLLATE " + browseTitleCollationName
+}
+
 func browseRankPrefixSortExpr() string {
 	filename := browseFilenameExpr()
 	return `CASE WHEN substr(` + filename + `, 1, 1) BETWEEN '0' AND '9' ` +
@@ -1144,7 +1152,7 @@ func browseSortExpr(sortOrder string) string {
 	case browseSortDatePrefixAsc, browseSortDatePrefixDesc:
 		return browseFilenameExpr()
 	default:
-		return "m.SortName"
+		return browseTitleSortExpr()
 	}
 }
 
@@ -1365,7 +1373,7 @@ func sqlBrowseOverlayFilesFromMedia(
 	where, filterArgs := browseFilesFilterCondition(&filterOpts, false)
 	args = append(args, filterArgs...)
 	sortMode := opts.Sort
-	sortExpr := "m.SortName"
+	sortExpr := browseTitleSortExpr()
 	if opts.Sort == "filename-asc" || opts.Sort == "filename-desc" {
 		sortExpr = browseFilenameExpr()
 	}
@@ -2272,7 +2280,7 @@ func sqlBrowseIndex(
 		Tags:       opts.Tags,
 	}
 	sortMode := resolveBrowseSortMode(ctx, db, filesOpts)
-	if browseSortExpr(sortMode) != "m.SortName" {
+	if browseSortExpr(sortMode) != browseTitleSortExpr() {
 		total, err := sqlBrowseFileCount(ctx, db, database.BrowseFileCountOptions{
 			PathPrefix: opts.PathPrefix,
 			Systems:    opts.Systems,
@@ -2298,10 +2306,10 @@ func sqlBrowseIndex(
 	}
 	bucketExpr := browseBucketKeyExpr("m.SortName")
 	// The window orders by the browse sort expression, which idx_media_browse_sort
-	// already provides (ParentDir, IsMissing equality then SortName, DBID), so the
-	// window needs no sort; only the GROUP BY (folded bucket, not index order) uses
-	// a transient btree. rn gives each row's position so MIN(rn) per bucket finds
-	// the bucket's first row, joined back for its keyset.
+	// already provides (ParentDir, IsMissing equality then naturally collated
+	// SortName, DBID), so the window needs no sort; only the GROUP BY (folded
+	// bucket, not index order) uses a transient btree. rn gives each row's
+	// position so MIN(rn) per bucket finds the first row, joined back for its keyset.
 	desc := sortMode == "name-desc"
 
 	query := `WITH ordered AS (
@@ -2417,7 +2425,8 @@ func sqlBrowseOverlayIndex(
 			SELECT ` + bucketExpr + ` AS bucket,
 				m.SortName AS sortValue,
 				m.DBID AS dbid,
-				ROW_NUMBER() OVER (ORDER BY m.SortName ` + direction + `, m.DBID ` + direction + `) AS rn
+				ROW_NUMBER() OVER (ORDER BY ` + browseTitleSortExpr() + ` ` + direction +
+		`, m.DBID ` + direction + `) AS rn
 			FROM ranked
 			INNER JOIN Media m ON m.DBID = ranked.DBID
 			WHERE ranked.source_rank = 1 AND ` + where + `

--- a/pkg/database/mediadb/sql_browse_bench_test.go
+++ b/pkg/database/mediadb/sql_browse_bench_test.go
@@ -34,6 +34,80 @@ import (
 
 const browseBenchRows = 1000
 
+func BenchmarkBrowseSortIndexCreate_239k(b *testing.B) {
+	const rows = 239_000
+
+	for _, tc := range []struct {
+		name string
+		ddl  string
+	}{
+		{
+			name: "binary",
+			ddl:  "CREATE INDEX idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID)",
+		},
+		{
+			name: "natural",
+			ddl: "CREATE INDEX idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName COLLATE " +
+				browseTitleCollationName + ", DBID)",
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			mediaDB, cleanup := setupBrowseBenchMediaDB(b)
+			defer cleanup()
+			require.NoError(b, dropBrowseSortIndex(mediaDB))
+			seedBrowseSortIndexBenchmark(b, mediaDB, rows)
+			b.ReportMetric(rows, "rows")
+			b.ResetTimer()
+
+			for b.Loop() {
+				b.StopTimer()
+				require.NoError(b, dropBrowseSortIndex(mediaDB))
+				b.StartTimer()
+				_, err := mediaDB.sql.Load().ExecContext(context.Background(), tc.ddl)
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+func dropBrowseSortIndex(mediaDB *MediaDB) error {
+	_, err := mediaDB.sql.Load().ExecContext(context.Background(), "DROP INDEX IF EXISTS idx_media_browse_sort")
+	if err != nil {
+		return fmt.Errorf("drop browse sort benchmark index: %w", err)
+	}
+	return nil
+}
+
+func seedBrowseSortIndexBenchmark(b *testing.B, mediaDB *MediaDB, rows int) {
+	b.Helper()
+	ctx := context.Background()
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(b, err)
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (1, 'Bench', 'Bench');
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 1, 'bench', 'Bench');
+	`)
+	require.NoError(b, err)
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO Media (MediaTitleDBID, SystemDBID, Path, ParentDir, SortName)
+		VALUES (1, 1, ?, ?, ?)
+	`)
+	require.NoError(b, err)
+	defer func() { require.NoError(b, stmt.Close()) }()
+
+	for i := range rows {
+		shuffled := (i * 104729) % rows
+		parentDir := fmt.Sprintf("/roms/system-%03d/", i%96)
+		name := fmt.Sprintf("Game: Variant %d! Disc %d", shuffled, i%12)
+		path := fmt.Sprintf("%sgame-%06d.rom", parentDir, i)
+		_, err = stmt.ExecContext(ctx, path, parentDir, name)
+		require.NoError(b, err)
+	}
+	require.NoError(b, tx.Commit())
+}
+
 func BenchmarkBrowseFiles_TagAttach_100(b *testing.B) {
 	benchBrowseFilesTagAttach(b, "no-tags", false)
 	benchBrowseFilesTagAttach(b, "with-tags", true)
@@ -155,6 +229,9 @@ func setupBrowseBenchMediaDB(b *testing.B) (mediaDB *MediaDB, cleanup func()) {
 
 	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
 	require.NoError(b, err)
+	// Browse benchmarks model a database after media update has run the
+	// secondary-index creation phase.
+	require.NoError(b, mediaDB.CreateSecondaryIndexes())
 	cleanup = func() {
 		if mediaDB != nil {
 			_ = mediaDB.Close()

--- a/pkg/database/mediadb/sql_browse_plan_test.go
+++ b/pkg/database/mediadb/sql_browse_plan_test.go
@@ -52,11 +52,12 @@ func TestBrowseFilesQueryPlan_NameSortHasNoFilesort(t *testing.T) {
 	parentDir := seedBrowsePlanTestDB(t, mediaDB, arcadeScaleRows)
 	require.NoError(t, sqlAnalyze(ctx, mediaDB.sql.Load()))
 
-	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+	query := `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+			m.SortName COLLATE ZAPAROO_TITLE_V1 AS SortValue
 		FROM Media m
 		INNER JOIN Systems s ON m.SystemDBID = s.DBID
 		WHERE m.ParentDir = ? AND m.IsMissing = 0
-		ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`
+		ORDER BY m.SortName COLLATE ZAPAROO_TITLE_V1 ASC, m.DBID ASC LIMIT ?`
 
 	rows, err := mediaDB.sql.Load().QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, parentDir, 301)
 	require.NoError(t, err)
@@ -116,24 +117,26 @@ func TestExplainBrowseFilesQuery(t *testing.T) {
 		{
 			name: "name-sort first-page (no cursor)",
 			// Filter ParentDir + IsMissing via idx_media_browse_sort, sort by
-			// m.SortName — no filesort, no MediaTitles join.
-			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+			// naturally collated SortName — no filesort, no MediaTitles join.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+					m.SortName COLLATE ZAPAROO_TITLE_V1 AS SortValue
 				FROM Media m
 				INNER JOIN Systems s ON m.SystemDBID = s.DBID
 				WHERE m.ParentDir = ? AND m.IsMissing = 0
-				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+				ORDER BY m.SortName COLLATE ZAPAROO_TITLE_V1 ASC, m.DBID ASC LIMIT ?`,
 			args: []any{parentDir, 301},
 		},
 		{
 			name: "name-sort non-first-page (with cursor)",
-			// Keyset cursor on (m.SortName, m.DBID) — same table as the filter,
-			// so the index can serve the seek directly.
-			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+			// Keyset cursor on naturally collated (m.SortName, m.DBID) — same
+			// table as the filter, so the index can serve the seek directly.
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+					m.SortName COLLATE ZAPAROO_TITLE_V1 AS SortValue
 				FROM Media m
 				INNER JOIN Systems s ON m.SystemDBID = s.DBID
 				WHERE m.ParentDir = ? AND m.IsMissing = 0
-				  AND (m.SortName, m.DBID) > (?, ?)
-				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+				  AND (m.SortName COLLATE ZAPAROO_TITLE_V1, m.DBID) > (?, ?)
+				ORDER BY m.SortName COLLATE ZAPAROO_TITLE_V1 ASC, m.DBID ASC LIMIT ?`,
 			args: []any{parentDir, midName, midID, 301},
 		},
 		{
@@ -150,12 +153,13 @@ func TestExplainBrowseFilesQuery(t *testing.T) {
 			name: "name-sort with letter filter",
 			// Letter filter now uses m.SortName — stays on the same table, no
 			// separate MediaTitles lookup.
-			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID, m.SortName AS SortValue
+			query: `SELECT s.SystemID, m.SortName, m.Path, m.DBID, m.MediaTitleDBID,
+					m.SortName COLLATE ZAPAROO_TITLE_V1 AS SortValue
 				FROM Media m
 				INNER JOIN Systems s ON m.SystemDBID = s.DBID
 				WHERE m.ParentDir = ? AND m.IsMissing = 0
 				  AND UPPER(SUBSTR(m.SortName, 1, 1)) = ?
-				ORDER BY m.SortName ASC, m.DBID ASC LIMIT ?`,
+				ORDER BY m.SortName COLLATE ZAPAROO_TITLE_V1 ASC, m.DBID ASC LIMIT ?`,
 			// "B" matches "Browse Game ..." — all rows pass.
 			args: []any{parentDir, "B", 301},
 		},
@@ -201,6 +205,9 @@ func setupBrowsePlanTestDB(t *testing.T) (mediaDB *MediaDB, cleanup func()) {
 
 	mediaDB, err = OpenMediaDB(context.Background(), mockPlatform)
 	require.NoError(t, err)
+	// Query-plan fixtures model a database after media update has run the
+	// secondary-index creation phase.
+	require.NoError(t, mediaDB.CreateSecondaryIndexes())
 	cleanup = func() {
 		if mediaDB != nil {
 			_ = mediaDB.Close()

--- a/pkg/database/mediadb/sql_trace_bench_test.go
+++ b/pkg/database/mediadb/sql_trace_bench_test.go
@@ -81,6 +81,9 @@ func setupTraceBenchMediaDB(b *testing.B, rows int, collector *sqlTraceCollector
 	registerTraceBenchDriverOnce.Do(func() {
 		sql.Register(sqliteTraceBenchDriver, &sqlite3.SQLiteDriver{
 			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				if err := registerMediaSQLiteCollations(conn); err != nil {
+					return err
+				}
 				return conn.SetTrace(&sqlite3.TraceConfig{
 					Callback:  collector.callback,
 					EventMask: sqlite3.TraceStmt | sqlite3.TraceProfile,

--- a/pkg/database/mediadb/sql_trace_runtime.go
+++ b/pkg/database/mediadb/sql_trace_runtime.go
@@ -61,6 +61,9 @@ var runtimeSQLTrace = newRuntimeSQLTraceCollector()
 func init() {
 	sql.Register(sqliteTraceRuntimeDriver, &sqlite3.SQLiteDriver{
 		ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+			if err := registerMediaSQLiteCollations(conn); err != nil {
+				return err
+			}
 			if !config.IsDevelopmentVersion() {
 				return nil
 			}
@@ -77,7 +80,7 @@ func sqliteDriverName() string {
 	if config.IsDevelopmentVersion() {
 		return sqliteTraceRuntimeDriver
 	}
-	return "sqlite3"
+	return sqliteMediaDriver
 }
 
 func newRuntimeSQLTraceCollector() *runtimeSQLTraceCollector {

--- a/pkg/database/mediadb/sqlite_driver.go
+++ b/pkg/database/mediadb/sqlite_driver.go
@@ -17,12 +17,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !sqlite_trace && !trace
-
 package mediadb
 
-func sqliteDriverName() string {
-	return sqliteMediaDriver
+import (
+	"database/sql"
+	"fmt"
+
+	sqlite3 "github.com/mattn/go-sqlite3"
+)
+
+const sqliteMediaDriver = "sqlite3_zaparoo_media"
+
+func init() {
+	sql.Register(sqliteMediaDriver, &sqlite3.SQLiteDriver{
+		ConnectHook: registerMediaSQLiteCollations,
+	})
 }
 
-func logSQLTraceSummary() {}
+func registerMediaSQLiteCollations(conn *sqlite3.SQLiteConn) error {
+	if err := conn.RegisterCollation(browseTitleCollationName, compareBrowseTitles); err != nil {
+		return fmt.Errorf("register media title collation: %w", err)
+	}
+	if err := conn.RegisterCollation(browseDirectoryCollationName, compareBrowseDirectoryNames); err != nil {
+		return fmt.Errorf("register media directory collation: %w", err)
+	}
+	return nil
+}

--- a/pkg/database/mediadb/title_sort.go
+++ b/pkg/database/mediadb/title_sort.go
@@ -1,0 +1,219 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"cmp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Version collation names when comparison semantics change. SQLite persists
+// collation order in indexes, so a new version must rebuild the browse index.
+const (
+	browseTitleCollationName     = "ZAPAROO_TITLE_V1"
+	browseDirectoryCollationName = "ZAPAROO_DIRECTORY_V1"
+)
+
+type browseTitleTokenKind uint8
+
+type browseTitleToken struct {
+	value string
+	next  int
+	kind  browseTitleTokenKind
+}
+
+const (
+	browseTitleTokenNumber browseTitleTokenKind = iota
+	browseTitleTokenText
+)
+
+// compareBrowseTitles defines title order for media browsing. Punctuation is
+// treated as a separator, digit runs compare numerically, and text compares
+// case-insensitively. The raw title is the final tiebreaker, making the
+// collation total and deterministic even when normalized forms match.
+func compareBrowseTitles(left, right string) int {
+	if left == right {
+		return 0
+	}
+
+	// Keep first-character buckets contiguous so media.browse.index offsets and
+	// seek cursors describe the exact media.browse order.
+	if order := cmp.Compare(browseTitleBucketRank(left), browseTitleBucketRank(right)); order != 0 {
+		return order
+	}
+
+	var leftAt, rightAt int
+	for {
+		leftToken, leftOK := nextBrowseTitleToken(left, leftAt)
+		rightToken, rightOK := nextBrowseTitleToken(right, rightAt)
+		switch {
+		case !leftOK && !rightOK:
+			return strings.Compare(left, right)
+		case !leftOK:
+			return -1
+		case !rightOK:
+			return 1
+		}
+
+		if leftToken.kind != rightToken.kind {
+			return cmp.Compare(leftToken.kind, rightToken.kind)
+		}
+
+		var order int
+		if leftToken.kind == browseTitleTokenNumber {
+			order = compareBrowseTitleNumbers(leftToken.value, rightToken.value)
+		} else {
+			order = compareBrowseTitleText(leftToken.value, rightToken.value)
+		}
+		if order != 0 {
+			return order
+		}
+		leftAt = leftToken.next
+		rightAt = rightToken.next
+	}
+}
+
+// browseTitleBucketRank mirrors browseBucketKeyExpr's ASCII buckets and their
+// browse order: symbols, numbers, then A-Z. Non-ASCII initials stay in '#'.
+func browseTitleBucketRank(title string) int {
+	if title == "" {
+		return 0
+	}
+	first := title[0]
+	if first >= '0' && first <= '9' {
+		return 1
+	}
+	if first >= 'a' && first <= 'z' {
+		first -= 'a' - 'A'
+	}
+	if first >= 'A' && first <= 'Z' {
+		return int(first-'A') + 2
+	}
+	return 0
+}
+
+func nextBrowseTitleToken(title string, at int) (browseTitleToken, bool) {
+	for at < len(title) {
+		r, size := utf8.DecodeRuneInString(title[at:])
+		switch {
+		case r >= '0' && r <= '9':
+			start := at
+			at += size
+			for at < len(title) && title[at] >= '0' && title[at] <= '9' {
+				at++
+			}
+			return browseTitleToken{value: title[start:at], next: at, kind: browseTitleTokenNumber}, true
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			start := at
+			at += size
+			for at < len(title) {
+				r, size = utf8.DecodeRuneInString(title[at:])
+				if (r >= '0' && r <= '9') || (!unicode.IsLetter(r) && !unicode.IsNumber(r)) {
+					break
+				}
+				at += size
+			}
+			return browseTitleToken{value: title[start:at], next: at, kind: browseTitleTokenText}, true
+		default:
+			at += size
+		}
+	}
+	return browseTitleToken{}, false
+}
+
+func compareBrowseDirectoryNames(left, right string) int {
+	leftTitle := stripBrowseDirectoryMetadata(left)
+	rightTitle := stripBrowseDirectoryMetadata(right)
+	if order := compareBrowseTitles(leftTitle, rightTitle); order != 0 {
+		return order
+	}
+	return strings.Compare(left, right)
+}
+
+func stripBrowseDirectoryMetadata(name string) string {
+	var stripped strings.Builder
+	stripped.Grow(len(name))
+	for at := 0; at < len(name); {
+		r, size := utf8.DecodeRuneInString(name[at:])
+		closer, metadata := browseMetadataCloser(r)
+		if !metadata {
+			_, _ = stripped.WriteString(name[at : at+size])
+			at += size
+			continue
+		}
+		at += size
+		for at < len(name) {
+			r, size = utf8.DecodeRuneInString(name[at:])
+			at += size
+			if r == closer {
+				break
+			}
+		}
+	}
+	return stripped.String()
+}
+
+func browseMetadataCloser(opener rune) (rune, bool) {
+	switch opener {
+	case '(':
+		return ')', true
+	case '[':
+		return ']', true
+	case '{':
+		return '}', true
+	case '<':
+		return '>', true
+	default:
+		return 0, false
+	}
+}
+
+func compareBrowseTitleNumbers(left, right string) int {
+	leftSignificant := strings.TrimLeft(left, "0")
+	if leftSignificant == "" {
+		leftSignificant = "0"
+	}
+	rightSignificant := strings.TrimLeft(right, "0")
+	if rightSignificant == "" {
+		rightSignificant = "0"
+	}
+	if order := cmp.Compare(len(leftSignificant), len(rightSignificant)); order != 0 {
+		return order
+	}
+	if order := strings.Compare(leftSignificant, rightSignificant); order != 0 {
+		return order
+	}
+	return cmp.Compare(len(left), len(right))
+}
+
+func compareBrowseTitleText(left, right string) int {
+	for left != "" && right != "" {
+		leftRune, leftSize := utf8.DecodeRuneInString(left)
+		rightRune, rightSize := utf8.DecodeRuneInString(right)
+		if order := cmp.Compare(unicode.ToLower(leftRune), unicode.ToLower(rightRune)); order != 0 {
+			return order
+		}
+		left = left[leftSize:]
+		right = right[rightSize:]
+	}
+	return cmp.Compare(len(left), len(right))
+}

--- a/pkg/database/mediadb/title_sort_test.go
+++ b/pkg/database/mediadb/title_sort_test.go
@@ -1,0 +1,311 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type browseTitleFixture struct {
+	title    string
+	filename string
+}
+
+var pandemoniumBrowseFixtures = []browseTitleFixture{
+	{title: "Pandemonium 10", filename: "m-ten.nes"},
+	{title: "pandemonium 2", filename: "a-two.nes"},
+	{title: "Pandemonium: Bonus", filename: "c-bonus.nes"},
+	{title: "Pandemonium?", filename: "y-question.nes"},
+	{title: "Pandemonium!", filename: "z-original.nes"},
+	{title: "Pandemonium 02", filename: "b-zero-two.nes"},
+}
+
+func browseSortIndexForTest(t testing.TB) secondaryIndex {
+	t.Helper()
+	for _, idx := range secondaryIndexes {
+		if idx.name == browseSortIndexName {
+			return idx
+		}
+	}
+	t.Fatalf("secondary index %s not found", browseSortIndexName)
+	return secondaryIndex{}
+}
+
+func replaceBrowseSortIndexWithBinary(t testing.TB, mediaDB *MediaDB) {
+	t.Helper()
+	_, err := mediaDB.sql.Load().ExecContext(context.Background(),
+		"DROP INDEX IF EXISTS "+browseSortIndexName)
+	require.NoError(t, err)
+	_, err = mediaDB.sql.Load().ExecContext(context.Background(),
+		"CREATE INDEX "+browseSortIndexName+" ON Media(ParentDir, IsMissing, SortName, DBID)")
+	require.NoError(t, err)
+}
+
+func TestCompareBrowseTitles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		left  string
+		right string
+	}{
+		{name: "punctuated original before sequel", left: "Pandemonium!", right: "Pandemonium 2"},
+		{name: "numeric suffix", left: "Pandemonium 2", right: "Pandemonium 10"},
+		{name: "leading numeric title", left: "2 Fast", right: "10 Fast"},
+		{name: "case insensitive primary order", left: "alpha 2", right: "Alpha 10"},
+		{name: "fewer leading zeroes first", left: "Game 2", right: "Game 02"},
+		{name: "numbered sequel before subtitle", left: "Game 2", right: "Game: Bonus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Negative(t, compareBrowseTitles(tt.left, tt.right))
+			assert.Positive(t, compareBrowseTitles(tt.right, tt.left))
+		})
+	}
+
+	assert.Zero(t, compareBrowseTitles("Pandemonium!", "Pandemonium!"))
+	assert.Negative(t, compareBrowseTitles("Alpha", "alpha"),
+		"raw title must provide a stable tiebreaker after case folding")
+	assert.Negative(t,
+		compareBrowseDirectoryNames("Pandemonium! (USA) (Rev 1)", "Pandemonium 2 (USA)"),
+		"directory metadata must not outrank the punctuated base title")
+}
+
+func TestBrowseFiles_NaturalTitleOrderAndKeysetPagination(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	parentDir := browseTestDir("roms", "psx")
+
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "PSX", Name: "PSX"})
+	require.NoError(t, err)
+	for _, fixture := range pandemoniumBrowseFixtures {
+		insertSystemMedia(t, mediaDB, system, fixture.title, parentDir+fixture.filename)
+	}
+
+	want := []string{
+		"Pandemonium!",
+		"Pandemonium?",
+		"pandemonium 2",
+		"Pandemonium 02",
+		"Pandemonium 10",
+		"Pandemonium: Bonus",
+	}
+
+	var (
+		got    []string
+		cursor *database.BrowseCursor
+	)
+	for {
+		page, browseErr := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+			PathPrefix: parentDir,
+			Cursor:     cursor,
+			Limit:      2,
+		})
+		require.NoError(t, browseErr)
+		if len(page) == 0 {
+			break
+		}
+		for i := range page {
+			got = append(got, page[i].Name)
+		}
+		last := page[len(page)-1]
+		assert.Equal(t, last.Name, last.SortValue, "cursor keeps raw title compatibility")
+		cursor = &database.BrowseCursor{
+			SortValue: last.SortValue,
+			SortMode:  last.SortMode,
+			LastID:    last.MediaID,
+		}
+	}
+	assert.Equal(t, want, got)
+
+	desc, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: parentDir,
+		Sort:       "name-desc",
+		Limit:      len(want),
+	})
+	require.NoError(t, err)
+	descNames := make([]string, len(desc))
+	for i := range desc {
+		descNames[i] = desc[i].Name
+	}
+	assert.Equal(t, []string{
+		"Pandemonium: Bonus",
+		"Pandemonium 10",
+		"Pandemonium 02",
+		"pandemonium 2",
+		"Pandemonium?",
+		"Pandemonium!",
+	}, descNames)
+
+	byFilename, err := mediaDB.BrowseFiles(ctx, &database.BrowseFilesOptions{
+		PathPrefix: parentDir,
+		Sort:       "filename-asc",
+		Limit:      len(want),
+	})
+	require.NoError(t, err)
+	filenameNames := make([]string, len(byFilename))
+	for i := range byFilename {
+		filenameNames[i] = byFilename[i].Name
+	}
+	assert.Equal(t, []string{
+		"pandemonium 2",
+		"Pandemonium 02",
+		"Pandemonium: Bonus",
+		"Pandemonium 10",
+		"Pandemonium?",
+		"Pandemonium!",
+	}, filenameNames, "explicit filename ordering must not use title collation")
+}
+
+func TestBrowseFiles_NaturalOrderWithLegacyBinaryIndex(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	parentDir := browseTestDir("roms", "psx")
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "PSX", Name: "PSX"})
+	require.NoError(t, err)
+	insertSystemMedia(t, mediaDB, system, "Pandemonium 2", parentDir+"sequel.nes")
+	insertSystemMedia(t, mediaDB, system, "Pandemonium!", parentDir+"original.nes")
+	replaceBrowseSortIndexWithBinary(t, mediaDB)
+
+	files, err := mediaDB.BrowseFiles(context.Background(), &database.BrowseFilesOptions{
+		PathPrefix: parentDir,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+	assert.Equal(t, []string{"Pandemonium!", "Pandemonium 2"}, []string{files[0].Name, files[1].Name},
+		"natural SQL collation must stay correct while background optimization retains the legacy index")
+}
+
+func TestBrowseDirectories_NaturalOrderAndKeysetPagination(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+	parentDir := browseTestDir("roms", "psx")
+	system, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "PSX", Name: "PSX"})
+	require.NoError(t, err)
+	for _, name := range []string{
+		"Pandemonium 10 (USA)",
+		"Pandemonium 2 (USA)",
+		"Pandemonium! (USA) (Rev 1)",
+	} {
+		insertSystemMedia(t, mediaDB, system, name,
+			parentDir+name+"/"+name+".chd")
+	}
+	require.NoError(t, mediaDB.PopulateBrowseCache(ctx))
+
+	systems := []systemdefs.System{{ID: "PSX"}}
+	first, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		PathPrefix: parentDir,
+		Systems:    systems,
+		Limit:      1,
+	})
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "Pandemonium! (USA) (Rev 1)", first[0].Name)
+
+	remaining, err := mediaDB.BrowseDirectories(ctx, database.BrowseDirectoriesOptions{
+		PathPrefix: parentDir,
+		AfterName:  first[0].Name,
+		Systems:    systems,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, remaining, 2)
+	assert.Equal(t, []string{"Pandemonium 2 (USA)", "Pandemonium 10 (USA)"},
+		[]string{remaining[0].Name, remaining[1].Name})
+
+	fallback, err := sqlBrowseDirectoriesForSystemsFromMedia(ctx, mediaDB.sql.Load(),
+		database.BrowseDirectoriesOptions{PathPrefix: parentDir, Systems: systems})
+	require.NoError(t, err)
+	require.Len(t, fallback, 3)
+	assert.Equal(t, []string{
+		"Pandemonium! (USA) (Rev 1)",
+		"Pandemonium 2 (USA)",
+		"Pandemonium 10 (USA)",
+	}, []string{fallback[0].Name, fallback[1].Name, fallback[2].Name})
+}
+
+func TestBrowseIndex_CaseInsensitiveNaturalOrderStaysContiguous(t *testing.T) {
+	t.Parallel()
+
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	seedBrowseIndexMedia(t, mediaDB, "NES", []string{"Zulu", "bravo", "alpha 2", "Alpha"})
+
+	files, err := mediaDB.BrowseFiles(context.Background(), &database.BrowseFilesOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "name-asc",
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	names := make([]string, len(files))
+	for i := range files {
+		names[i] = files[i].Name
+	}
+	assert.Equal(t, []string{"Alpha", "alpha 2", "bravo", "Zulu"}, names)
+
+	index, err := mediaDB.BrowseIndex(context.Background(), database.BrowseIndexOptions{
+		PathPrefix: browseIndexTestDir,
+		Sort:       "name-asc",
+	})
+	require.NoError(t, err)
+	require.Len(t, index.Buckets, 3)
+	assert.Equal(t, []string{"A", "B", "Z"}, []string{
+		index.Buckets[0].Key,
+		index.Buckets[1].Key,
+		index.Buckets[2].Key,
+	})
+	assert.Equal(t, []int{2, 1, 1}, []int{
+		index.Buckets[0].Count,
+		index.Buckets[1].Count,
+		index.Buckets[2].Count,
+	})
+	assert.Equal(t, []int{0, 2, 3}, []int{
+		index.Buckets[0].Offset,
+		index.Buckets[1].Offset,
+		index.Buckets[2].Offset,
+	})
+	for _, bucket := range index.Buckets {
+		assert.Equal(t, bucket.Key, firstBrowsedBucketForCursor(t, mediaDB, bucket, index.SortMode))
+	}
+}
+
+func TestBrowseTitleCollationLeavesSearchOrderingSeparate(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Media.DBID", searchSortExpr(""))
+	assert.Equal(t, "MediaTitles.Name COLLATE NOCASE", searchSortExpr("name-asc"))
+}

--- a/pkg/database/mediadb/wal_checkpoint_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_test.go
@@ -42,7 +42,7 @@ func TestWALCheckpointing(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := tempDir + "/test.db"
 
-	sqlDB, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -181,7 +181,7 @@ func TestTransactionPerformanceWithWAL(t *testing.T) {
 	ctx := context.Background()
 
 	// Create in-memory database with the same connection parameters as production
-	sqlDB, err := sql.Open("sqlite3", ":memory:"+getSqliteConnParams())
+	sqlDB, err := sql.Open(sqliteDriverName(), ":memory:"+getSqliteConnParams())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sqlDB.Close())
@@ -260,7 +260,7 @@ func TestWALSizeManagement(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := tempDir + "/test.db"
 
-	sqlDB, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, sqlDB.Close())

--- a/pkg/database/mediadb/wal_checkpoint_threshold_test.go
+++ b/pkg/database/mediadb/wal_checkpoint_threshold_test.go
@@ -51,7 +51,7 @@ func newWALTestDB(t *testing.T) walTestDB {
 	tempDir := t.TempDir()
 	dbPath := filepath.Join(tempDir, "test.db")
 
-	sqlDB, err := sql.Open("sqlite3", dbPath+getSqliteConnParams())
+	sqlDB, err := sql.Open(sqliteDriverName(), dbPath+getSqliteConnParams())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, sqlDB.Close())

--- a/pkg/database/mediascanner/journal_mode_guard_test.go
+++ b/pkg/database/mediascanner/journal_mode_guard_test.go
@@ -21,16 +21,14 @@ package mediascanner
 
 import (
 	"context"
-	"database/sql"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,20 +44,25 @@ import (
 func TestNewNamesIndex_NonWALJournalModeFailsInsteadOfHanging(t *testing.T) {
 	t.Parallel()
 
-	dbPath := filepath.Join(t.TempDir(), "media_rollback_journal.db")
-	sqlDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=DELETE&_foreign_keys=ON")
-	require.NoError(t, err)
-
 	// Launchers/RootDirs are deliberately left unstubbed: the WAL guard fires
 	// before NewNamesIndex ever reaches launcher discovery, so a call to
 	// either would itself indicate the guard regressed to running too late.
+	tempDir := t.TempDir()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test-platform")
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
 
-	mediaDB := &mediadb.MediaDB{}
-	require.NoError(t, mediaDB.SetSQLForTesting(context.Background(), sqlDB, mockPlatform))
-	mediaDB.SetDBPathForTesting(dbPath)
+	mediaDB, err := mediadb.OpenMediaDB(context.Background(), mockPlatform)
+	require.NoError(t, err)
 	defer func() { _ = mediaDB.Close() }()
+	// Keep one pooled connection so the production DSN cannot open another and
+	// restore WAL after this test deliberately switches the database to DELETE.
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+	sqlDB.SetMaxOpenConns(1)
+	var journalMode string
+	require.NoError(t, sqlDB.QueryRowContext(context.Background(),
+		"PRAGMA journal_mode=DELETE").Scan(&journalMode))
+	require.Equal(t, "delete", journalMode)
 
 	userDB, userCleanup := testhelpers.NewInMemoryUserDB(t)
 	defer userCleanup()

--- a/pkg/testing/helpers/inmemory_db.go
+++ b/pkg/testing/helpers/inmemory_db.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/userdb"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -71,35 +72,18 @@ func NewInMemoryUserDB(t *testing.T) (db *userdb.UserDB, cleanup func()) {
 func NewInMemoryMediaDB(tb testing.TB) (db *mediadb.MediaDB, cleanup func()) {
 	tb.Helper()
 
-	// Create temporary directory for test database
+	// Use the production MediaDB opener so tests get the same SQLite connection
+	// hooks, WAL settings, pool behavior, and migrations as runtime databases.
 	tempDir := tb.TempDir()
-	dbPath := filepath.Join(tempDir, "mediadb_test.db")
-
-	// Open SQLite database using temp file with foreign keys enabled and WAL
-	// journal mode. WAL matches the production database configuration and
-	// ensures CASCADE deletes work; it is also load-bearing for indexing
-	// tests specifically — the batched-transaction architecture reads the
-	// next system's state on a separate pool connection while the previous
-	// system's writer transaction is still open, which only works under WAL
-	// (a rollback journal's exclusive lock would deadlock that read), and
-	// NewNamesIndex now verifies journal_mode is "wal" before indexing.
-	sqlDB, err := sql.Open("sqlite3", dbPath+"?_foreign_keys=ON&_journal_mode=WAL")
-	if err != nil {
-		tb.Fatalf("Failed to open test database: %v", err)
-	}
-
-	db = &mediadb.MediaDB{}
-	ctx := context.Background()
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test-platform")
-	err = db.SetSQLForTesting(ctx, sqlDB, mockPlatform)
+	mockPlatform.On("Settings").Return(platforms.Settings{DataDir: tempDir})
+
+	var err error
+	db, err = mediadb.OpenMediaDB(context.Background(), mockPlatform)
 	if err != nil {
-		if closeErr := sqlDB.Close(); closeErr != nil {
-			tb.Errorf("Failed to close SQL database after setup error: %v", closeErr)
-		}
 		tb.Fatalf("Failed to set up MediaDB for testing: %v", err)
 	}
-	db.SetDBPathForTesting(dbPath)
 
 	cleanup = func() {
 		if err := db.Close(); err != nil {


### PR DESCRIPTION
## Summary
- add versioned SQLite collations for case-insensitive, punctuation-aware natural browse ordering
- preserve bucket boundaries, keyset pagination, filename sorting, and search relevance
- replace legacy browse index through normal media database update path
- cover title and directory ordering with regression, query-plan, and benchmark tests

Validated with full race tests, lint, and live MiSTer browse/index verification.

## Schema version and rollback

`idx_media_browse_sort` orders `SortName` with `ZAPAROO_TITLE_V1`, which the driver registers per connection rather than storing in the file. Replacing the index at index time left no trace in the schema version, so a build without the collation opened and migrated the database happily and then failed on the first prepare against `Media` — SQLite resolves index definitions before it can prepare anything.

Reproduced on a MiSTer, running a build without the collation against a database this branch had indexed:

```
error generating media db
  failed to seed canonical tags: failed to prepare insert media statement:
  no such collation sequence: ZAPAROO_TITLE_V1
```

Browse fails the same way, with `no query solution`, because queries pin the index with `INDEXED BY`. Nothing recovered from it: the media database is only rebuilt for a schema version it does not understand, and replacing an index bumps no version by itself.

The index is now replaced by a migration. Going back to a build without the collation raises `ErrSchemaAhead`, and startup rebuilds the media database as it already does for any newer schema. The `Down` restores the uncollated form created by `20260609120000_media_sortname`.

`TestMigrations_CreateBrowseSortIndexWithItsCollation` pins this: `CreateSecondaryIndexes` only runs at the end of an indexing run, so an index present on a freshly migrated database can only have come from a migration.

User data was never at risk — the update backup covers UserDB, and MediaDB is rebuildable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added natural, case-insensitive title sorting for media browsing.
  - Numeric portions of titles now sort in intuitive numerical order.
  - Directory names are sorted consistently while ignoring common bracketed metadata.

- **Bug Fixes**
  - Improved browse pagination, cursor navigation, alphabetical filtering, and search ordering.
  - Updated existing browse indexes automatically to use the latest sorting behavior.
  - Ensured sorting remains consistent across cached, indexed, and media-backed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
