### PR TITLE
feat(mister): add CAVE 68000 arcade system

### DIFF
--- a/pkg/assets/systems/Cave68000.json
+++ b/pkg/assets/systems/Cave68000.json
@@ -1,0 +1,7 @@
+{
+  "id": "Cave68000",
+  "name": "CAVE 68000",
+  "category": "Arcade",
+  "releaseDate": "1994-01-01",
+  "manufacturer": "CAVE"
+}

--- a/pkg/database/systemdefs/systemdefs.go
+++ b/pkg/database/systemdefs/systemdefs.go
@@ -309,6 +309,7 @@ const (
 	SystemAtomiswave          = "Atomiswave"
 	SystemArduboy             = "Arduboy"
 	SystemChip8               = "Chip8"
+	SystemCave68000           = "Cave68000"
 	SystemCPS1                = "CPS1"
 	SystemCPS2                = "CPS2"
 	SystemCPS3                = "CPS3"
@@ -1579,6 +1580,11 @@ var Systems = map[string]System{
 	SystemJ2ME: {
 		ID:    SystemJ2ME,
 		Slugs: []string{"javame", "javamobile", "mobilephone"},
+	},
+	SystemCave68000: {
+		ID:        SystemCave68000,
+		Slugs:     []string{"cave", "cave68k"},
+		Fallbacks: []string{SystemArcade},
 	},
 	SystemCPS1: {
 		ID:        SystemCPS1,

--- a/pkg/platforms/mister/arcade_systems.go
+++ b/pkg/platforms/mister/arcade_systems.go
@@ -27,6 +27,7 @@ type arcadeSystemSpec struct {
 }
 
 var misterArcadeSystemSpecs = []arcadeSystemSpec{
+	{systemID: systemdefs.SystemCave68000, platforms: []string{"CAVE 68000"}},
 	{systemID: systemdefs.SystemCPS1, platforms: []string{"Capcom CPS-1", "Capcom CPS-1.5"}},
 	{systemID: systemdefs.SystemCPS2, platforms: []string{"Capcom CPS-2"}},
 	{systemID: systemdefs.SystemCPS3, platforms: []string{"Capcom CPS-3"}},

--- a/pkg/platforms/mister/arcade_systems_test.go
+++ b/pkg/platforms/mister/arcade_systems_test.go
@@ -25,6 +25,12 @@ func TestArcadeSetSystemsMapsCuratedPlatforms(t *testing.T) {
 	t.Parallel()
 
 	setSystems := arcadeSetSystems([]arcadedb.ArcadeDbEntry{
+		{Setname: "donpachi", Platform: "CAVE 68000"},
+		{Setname: "DDONPACH", Platform: "CAVE 68000"},
+		{Setname: "donpachihk", Platform: "CAVE 68000"},
+		{Setname: "esprade_fp", Platform: "CAVE 68000"},
+		{Setname: "mazinger", Platform: "CAVE 68000"},
+		{Setname: "uopoko", Platform: "CAVE 68000"},
 		{Setname: "CPS1GAME", Platform: "Capcom CPS-1"},
 		{Setname: "cps15game", Platform: "Capcom CPS-1.5"},
 		{Setname: "cps2game", Platform: "Capcom CPS-2"},
@@ -41,6 +47,12 @@ func TestArcadeSetSystemsMapsCuratedPlatforms(t *testing.T) {
 		{Setname: "unknown", Platform: "Unique hardware"},
 	})
 
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["donpachi"])
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["ddonpach"])
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["donpachihk"])
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["esprade_fp"])
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["mazinger"])
+	assert.Equal(t, systemdefs.SystemCave68000, setSystems["uopoko"])
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps1game"])
 	assert.Equal(t, systemdefs.SystemCPS1, setSystems["cps15game"])
 	assert.Equal(t, systemdefs.SystemCPS2, setSystems["cps2game"])
@@ -164,6 +176,130 @@ func TestArcadeSystemCacheClassifiesProvidedMRAFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, classifiedPath, results[0].Path)
 	assert.Equal(t, 2, mraReads, "second demand serves from memory")
+}
+
+// TestArcadeSystemCacheClassifiesCave68000MRAFiles covers the CAVE 68000
+// system through the shared classification pass: representative sets, an
+// alternate region set, a Free Play variant, an uppercase MRA setname, sets
+// from another board, and sets missing from the arcade DB.
+func TestArcadeSystemCacheClassifiesCave68000MRAFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeMRA := func(name, setName string) string {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(fmt.Sprintf(
+			"<misterromdescription><setname>%s</setname></misterromdescription>", setName,
+		)), 0o600))
+		return path
+	}
+	donpachiPath := writeMRA("DonPachi.mra", "donpachi")
+	ddonpachPath := writeMRA("DoDonPachi.mra", "DDONPACH")
+	donpachihkPath := writeMRA("DonPachi (HK).mra", "donpachihk")
+	espradeFPPath := writeMRA("ESP RaDe (Free Play).mra", "esprade_fp")
+	cps1Path := writeMRA("1941.mra", "1941")
+	unknownPath := writeMRA("Homebrew.mra", "notinarcadedb")
+
+	cache := newTestArcadeSystemCache(t)
+	cache.readArcadeDB = func(platforms.Platform) ([]arcadedb.ArcadeDbEntry, error) {
+		return []arcadedb.ArcadeDbEntry{
+			{Setname: "donpachi", Platform: "CAVE 68000"},
+			// Repeated setname: a duplicated arcade DB row must not classify
+			// the same MRA twice.
+			{Setname: "donpachi", Platform: "CAVE 68000"},
+			{Setname: "ddonpach", Platform: "CAVE 68000"},
+			{Setname: "donpachihk", Platform: "CAVE 68000"},
+			{Setname: "esprade_fp", Platform: "CAVE 68000"},
+			{Setname: "1941", Platform: "Capcom CPS-1"},
+			{Setname: "twincobr", Platform: "Toaplan 1"},
+		}, nil
+	}
+
+	input := []platforms.ScanResult{
+		{Path: donpachiPath},
+		{Path: ddonpachPath},
+		{Path: donpachihkPath},
+		{Path: espradeFPPath},
+		{Path: cps1Path},
+		{Path: unknownPath},
+	}
+	inputBefore := append([]platforms.ScanResult(nil), input...)
+
+	// The ordinary Arcade system still receives every MRA: a granular system
+	// is an additional filtered view, not a replacement.
+	arcadeResults, err := cache.captureScanner(
+		context.Background(), &config.Instance{}, systemdefs.SystemArcade, input,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, inputBefore, arcadeResults)
+
+	caveResults, err := cache.scanner(systemdefs.SystemCave68000)(
+		context.Background(), &config.Instance{}, systemdefs.SystemCave68000, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []platforms.ScanResult{
+		{Path: donpachiPath}, {Path: ddonpachPath}, {Path: donpachihkPath}, {Path: espradeFPPath},
+	}, caveResults, "each CAVE 68000 set is classified exactly once, in capture order")
+
+	// A set from another board must not land in CAVE 68000, and a CAVE set
+	// must not leak into another granular system.
+	cps1Results, err := cache.scanner(systemdefs.SystemCPS1)(
+		context.Background(), &config.Instance{}, systemdefs.SystemCPS1, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []platforms.ScanResult{{Path: cps1Path}}, cps1Results)
+}
+
+// TestArcadeSystemCacheReusesPersistedCaveClassification proves CAVE 68000
+// rides on the existing persisted classification cache instead of re-reading
+// unchanged MRA files on every index.
+func TestArcadeSystemCacheReusesPersistedCaveClassification(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	guwangePath := filepath.Join(dir, "Guwange.mra")
+	require.NoError(t, os.WriteFile(guwangePath, []byte(
+		"<misterromdescription><setname>guwange</setname></misterromdescription>",
+	), 0o600))
+	uopokoPath := filepath.Join(dir, "Puzzle Uo Poko.mra")
+	require.NoError(t, os.WriteFile(uopokoPath, []byte(
+		"<misterromdescription><setname>uopoko</setname></misterromdescription>",
+	), 0o600))
+	persistPath := filepath.Join(t.TempDir(), arcadeClassCacheFileName)
+	input := []platforms.ScanResult{{Path: guwangePath}, {Path: uopokoPath}}
+
+	classify := func(mraReads *int) []platforms.ScanResult {
+		cache := newArcadeSystemCache(NewPlatform())
+		cache.persistPath = persistPath
+		cache.readArcadeDB = func(platforms.Platform) ([]arcadedb.ArcadeDbEntry, error) {
+			return []arcadedb.ArcadeDbEntry{
+				{Setname: "guwange", Platform: "CAVE 68000"},
+				{Setname: "uopoko", Platform: "CAVE 68000"},
+			}, nil
+		}
+		baseReadMRA := cache.readMRA
+		cache.readMRA = func(path string) (mgls.MRA, error) {
+			*mraReads++
+			return baseReadMRA(path)
+		}
+		_, err := cache.captureScanner(context.Background(), &config.Instance{}, systemdefs.SystemArcade, input)
+		require.NoError(t, err)
+		results, err := cache.scanner(systemdefs.SystemCave68000)(
+			context.Background(), &config.Instance{}, systemdefs.SystemCave68000, nil,
+		)
+		require.NoError(t, err)
+		return results
+	}
+
+	coldReads := 0
+	cold := classify(&coldReads)
+	assert.Equal(t, input, cold)
+	assert.Equal(t, 2, coldReads, "cold cache parses every CAVE MRA")
+
+	warmReads := 0
+	warm := classify(&warmReads)
+	assert.Equal(t, cold, warm)
+	assert.Zero(t, warmReads, "unchanged CAVE MRAs are served from the persisted cache")
 }
 
 func TestArcadeSystemCachePersistedCacheSkipsUnchangedMRAReads(t *testing.T) {


### PR DESCRIPTION
- Add the `Cave68000` system definition with `cave`/`cave68k` slugs and an `Arcade` fallback, plus its `pkg/assets/systems/Cave68000.json` metadata (name "CAVE 68000", category Arcade, 1994, CAVE).
- Map the exact ArcadeDB platform value `CAVE 68000` to the new system in `misterArcadeSystemSpecs`, which registers the MiSTer launcher and the setname lookup from the same table. The bundled ArcadeDB has 24 sets with that value.
- Titles remain in the ordinary Arcade system: the Arcade launcher is still a pipeline scanner returning its input unchanged, and the granular launcher reuses the captured file list and the persisted classification cache, so no extra scanning or MRA parsing happens.
- Cover the new system in tests: representative and alternate sets, uppercase MRA setnames, a duplicated ArcadeDB row, sets from other boards, sets missing from the database, Arcade coexistence, and persisted-cache reuse across cache instances.

Closes #1269