### PR TITLE
fix(api): trust the device's own .local origins

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1815,6 +1815,31 @@ func StartWithReady(
 		}
 	}
 
+	log.Info().Str("listen", listenAddr).Msg("starting HTTP server")
+	log.Debug().Msg("HTTP server attempting to bind")
+
+	// Bind before reporting startup success so callers can fail fast when the
+	// configured API port is already in use, and before the origin lists are
+	// built so a port-zero bind resolves to the port they advertise.
+	lc := &net.ListenConfig{}
+	listener, err := lc.Listen(st.GetContext(), "tcp", listenAddr)
+	if err != nil {
+		bindErr := fmt.Errorf("failed to bind API listener: %w", err)
+		log.Error().Err(bindErr).Msg("failed to bind to port")
+		notifyReady(bindErr)
+		st.StopService()
+		return bindErr
+	}
+
+	// If port 0 was requested, adopt the port actually bound so callers can
+	// discover it and every allowed origin carries the real port.
+	if port == 0 {
+		if addr, ok := listener.Addr().(*net.TCPAddr); ok {
+			port = addr.Port
+			_ = cfg.SetAPIPort(port)
+		}
+	}
+
 	baseOrigins := make([]string, 0, len(allowedOrigins)+4)
 	baseOrigins = append(baseOrigins, allowedOrigins...)
 	baseOrigins = append(baseOrigins,
@@ -2143,29 +2168,6 @@ func StartWithReady(
 	}
 
 	serverDone := make(chan error, 1)
-
-	log.Info().Str("listen", cfg.APIListen()).Msg("starting HTTP server")
-	log.Debug().Msg("HTTP server attempting to bind")
-
-	// Create the listener before reporting startup success so callers can fail
-	// fast when the configured API port is already in use.
-	lc := &net.ListenConfig{}
-	listener, err := lc.Listen(st.GetContext(), "tcp", server.Addr)
-	if err != nil {
-		bindErr := fmt.Errorf("failed to bind API listener: %w", err)
-		log.Error().Err(bindErr).Msg("failed to bind to port")
-		notifyReady(bindErr)
-		st.StopService()
-		return bindErr
-	}
-
-	// If port 0 was requested, update config with the actual bound port
-	// so callers can discover which port the server is listening on.
-	if port == 0 {
-		if addr, ok := listener.Addr().(*net.TCPAddr); ok {
-			_ = cfg.SetAPIPort(addr.Port)
-		}
-	}
 
 	log.Debug().Msg("HTTP server bound to port, ready to accept connections")
 	notifyReady(nil)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -888,6 +888,58 @@ func expandCustomOrigins(customOrigins []string, port int) []string {
 	return result
 }
 
+// localHostNames returns the names a browser on the LAN can reach this device
+// by. That is the OS hostname plus the ".local" forms an mDNS responder
+// publishes for it: responders derive the host record from the OS hostname, so
+// a device called "mister" answers to "mister.local" regardless of what
+// instance name Core advertises over DNS-SD. Hostnames that are already fully
+// qualified contribute their short label too, because avahi publishes the short
+// name under ".local" while the bundled responder appends the suffix to the
+// whole name. Results are deduplicated case-insensitively.
+func localHostNames(hostname string) []string {
+	hostname = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(hostname), "."))
+	if hostname == "" {
+		return nil
+	}
+
+	candidates := []string{hostname}
+	if !strings.HasSuffix(strings.ToLower(hostname), ".local") {
+		candidates = append(candidates, hostname+".local")
+	}
+	if label, _, found := strings.Cut(hostname, "."); found && label != "" {
+		candidates = append(candidates, label+".local")
+	}
+
+	seen := make(map[string]struct{}, len(candidates))
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		key := strings.ToLower(candidate)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, candidate)
+	}
+
+	return result
+}
+
+// expandHostNameOrigins allows each host name over HTTP and HTTPS, with and
+// without the API port. The port-less forms cover reverse proxies serving Core
+// on a default port.
+func expandHostNameOrigins(names []string, port int) []string {
+	result := make([]string, 0, len(names)*4)
+	for _, name := range names {
+		result = append(result,
+			"http://"+name,
+			"https://"+name,
+			fmt.Sprintf("http://%s:%d", name, port),
+			fmt.Sprintf("https://%s:%d", name, port),
+		)
+	}
+	return result
+}
+
 // expandLocalIPOrigins creates allowed origins for current local interface IPs.
 func expandLocalIPOrigins(localIPs []string, port int) []string {
 	result := make([]string, 0, len(localIPs)*2)
@@ -1712,7 +1764,6 @@ func Start(
 	limitsManager *playtime.LimitsManager,
 	profilesSvc *profiles.Service,
 	notifBroker *broker.Broker,
-	mdnsHostname string,
 	player audio.Player,
 	playbackManager audio.PlaybackManager,
 	indexPauser *syncutil.Pauser,
@@ -1722,7 +1773,7 @@ func Start(
 ) error {
 	return StartWithReady(
 		platform, cfg, st, inTokenQueue, confirmQueue, db, limitsManager, profilesSvc,
-		notifBroker, mdnsHostname, player, playbackManager, indexPauser, scrapePauser, backupPauser, tracker, nil,
+		notifBroker, player, playbackManager, indexPauser, scrapePauser, backupPauser, tracker, nil,
 	)
 }
 
@@ -1739,7 +1790,6 @@ func StartWithReady(
 	limitsManager *playtime.LimitsManager,
 	profilesSvc *profiles.Service,
 	notifBroker *broker.Broker,
-	mdnsHostname string,
 	player audio.Player,
 	playbackManager audio.PlaybackManager,
 	indexPauser *syncutil.Pauser,
@@ -1780,29 +1830,18 @@ func StartWithReady(
 		log.Debug().Msgf("adding local IP to allowed origins: %s", localIP)
 	}
 
-	// Build static origins (base + mDNS + OS hostname). Local IP origins are
+	// Build static origins (base + host names). Local IP origins are
 	// checked dynamically because network interfaces may appear after startup.
 	staticOrigins := buildStaticAllowedOrigins(baseOrigins, nil, port)
 
-	if mdnsHostname != "" {
-		mdnsLocal := mdnsHostname + ".local"
-		staticOrigins = append(staticOrigins,
-			"http://"+mdnsLocal,
-			"https://"+mdnsLocal,
-			fmt.Sprintf("http://%s:%d", mdnsLocal, port),
-			fmt.Sprintf("https://%s:%d", mdnsLocal, port),
-		)
-		log.Debug().Str("hostname", mdnsLocal).Msg("added mDNS hostname to allowed origins")
+	hostname, hostErr := os.Hostname()
+	if hostErr != nil {
+		log.Warn().Err(hostErr).Msg("could not read OS hostname for allowed origins")
 	}
-
-	if hostname, err := os.Hostname(); err == nil && hostname != "" {
-		staticOrigins = append(staticOrigins,
-			"http://"+hostname,
-			"https://"+hostname,
-			fmt.Sprintf("http://%s:%d", hostname, port),
-			fmt.Sprintf("https://%s:%d", hostname, port),
-		)
-		log.Debug().Str("hostname", hostname).Msg("added OS hostname to allowed origins")
+	hostNames := localHostNames(hostname)
+	if len(hostNames) > 0 {
+		staticOrigins = append(staticOrigins, expandHostNameOrigins(hostNames, port)...)
+		log.Debug().Strs("hostnames", hostNames).Msg("added host names to allowed origins")
 	}
 
 	log.Debug().Msgf("staticOrigins: %v", staticOrigins)

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -819,8 +819,8 @@ func TestServerTrustsOwnHostnameOrigins(t *testing.T) {
 		require.NoError(t, <-serverErr)
 	}()
 
-	// The listener takes an OS-assigned port, so this checks the port-less
-	// origin forms. Port-bearing forms are covered by TestOriginPolicy_MDNSHostname.
+	// The listener takes an OS-assigned port, so this also covers the
+	// port-bearing origin forms carrying the port actually bound.
 	port := waitForServerReady(t, cfg)
 
 	client := &http.Client{Timeout: time.Second}
@@ -839,9 +839,18 @@ func TestServerTrustsOwnHostnameOrigins(t *testing.T) {
 	}
 
 	for _, name := range hostNames {
-		for _, origin := range []string{"http://" + name, "https://" + name} {
+		origins := []string{
+			"http://" + name,
+			"https://" + name,
+			fmt.Sprintf("http://%s:%d", name, port),
+			fmt.Sprintf("https://%s:%d", name, port),
+		}
+		for _, origin := range origins {
 			assert.Equal(t, origin, checkOrigin(origin), "origin %s should be allowed", origin)
 		}
+		// Port 0 is what was configured; it must never be advertised.
+		assert.Empty(t, checkOrigin(fmt.Sprintf("http://%s:0", name)),
+			"the unresolved port must not be trusted")
 	}
 
 	assert.Empty(t, checkOrigin("http://not-this-device.invalid"), "unrelated origins must stay rejected")

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -26,11 +26,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/broker"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
@@ -45,6 +48,35 @@ func newTestBroker(ctx context.Context, source <-chan models.Notification) *brok
 	b := broker.NewBroker(ctx, source)
 	b.Start()
 	return b
+}
+
+// waitForServerReady blocks until the API server has bound its listener and
+// written the resolved port back to the config, then returns that port.
+func waitForServerReady(t *testing.T, cfg *config.Instance) int {
+	t.Helper()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	for range 100 {
+		port := cfg.APIPort()
+		if port == 0 {
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		healthURL := fmt.Sprintf("http://localhost:%d/health", port)
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, healthURL, http.NoBody)
+		if reqErr != nil {
+			continue
+		}
+		resp, connErr := client.Do(req) //nolint:gosec // test hitting local test server
+		if connErr == nil {
+			_ = resp.Body.Close()
+			return port
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Fatal("API server did not become ready")
+	return 0
 }
 
 func TestStartWithReadyReportsBindFailure(t *testing.T) {
@@ -78,7 +110,7 @@ func TestStartWithReadyReportsBindFailure(t *testing.T) {
 	go func() {
 		serverErr <- StartWithReady(
 			platform, cfg, st, tokenQueue, nil, db,
-			nil, nil, notifBroker, "", nil, nil, nil, nil, nil, nil, ready,
+			nil, nil, notifBroker, nil, nil, nil, nil, nil, nil, ready,
 		)
 	}()
 
@@ -143,7 +175,7 @@ func TestServerStartupConcurrency(t *testing.T) {
 				defer close(serverDone)
 				serverErr <- StartWithReady(
 					platform, cfg, st, tokenQueue, nil, db,
-					nil, nil, notifBroker, "", nil, nil, nil, nil, nil, nil, ready,
+					nil, nil, notifBroker, nil, nil, nil, nil, nil, nil, ready,
 				)
 			}()
 			// Cleanup: stop service first, then wait for server goroutine to fully exit
@@ -226,7 +258,7 @@ func TestServerStartupImmediateConnection(t *testing.T) {
 	go func() {
 		defer close(serverDone)
 		serverErr <- Start(
-			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, "", nil, nil, nil, nil, nil, nil,
+			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, nil, nil, nil, nil, nil, nil,
 		)
 	}()
 	// Cleanup: stop service first, then wait for server goroutine to fully exit
@@ -313,7 +345,7 @@ func TestServerListenContextCancellation(t *testing.T) {
 	go func() {
 		defer close(done)
 		serverErr <- Start(
-			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, "", nil, nil, nil, nil, nil, nil,
+			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, nil, nil, nil, nil, nil, nil,
 		)
 	}()
 
@@ -649,6 +681,172 @@ func TestOriginPolicy_DelayedLocalIPAvailability(t *testing.T) {
 	))
 }
 
+func TestLocalHostNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		hostname string
+		expected []string
+	}{
+		{
+			name:     "short hostname gains its mDNS name",
+			hostname: "MiSTer",
+			expected: []string{"MiSTer", "MiSTer.local"},
+		},
+		{
+			name:     "hostname already under .local is not doubled up",
+			hostname: "macbook.local",
+			expected: []string{"macbook.local"},
+		},
+		{
+			name:     "fully qualified hostname also covers its short label",
+			hostname: "mister.lan",
+			expected: []string{"mister.lan", "mister.lan.local", "mister.local"},
+		},
+		{
+			name:     "trailing dot is trimmed",
+			hostname: "mister.",
+			expected: []string{"mister", "mister.local"},
+		},
+		{
+			name:     "empty hostname contributes nothing",
+			hostname: "",
+			expected: nil,
+		},
+		{
+			name:     "whitespace hostname contributes nothing",
+			hostname: "   ",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, localHostNames(tt.hostname))
+		})
+	}
+}
+
+func TestExpandHostNameOrigins(t *testing.T) {
+	t.Parallel()
+
+	result := expandHostNameOrigins([]string{"mister.local"}, 7497)
+
+	assert.Equal(t, []string{
+		"http://mister.local",
+		"https://mister.local",
+		"http://mister.local:7497",
+		"https://mister.local:7497",
+	}, result)
+}
+
+func TestOriginPolicy_MDNSHostname(t *testing.T) {
+	t.Parallel()
+
+	port := 7497
+	staticOrigins := buildStaticAllowedOrigins(allowedOrigins, nil, port)
+	staticOrigins = append(staticOrigins, expandHostNameOrigins(localHostNames("mister"), port)...)
+	localIPsProvider := func() []string { return nil }
+	customOriginsProvider := func() []string { return nil }
+
+	// Browsing the web UI at the device's mDNS name is the common case: the
+	// page connects back over a WebSocket carrying that origin.
+	assert.True(t, isAllowedOrigin(
+		"http://mister.local:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, true, "websocket",
+	))
+	assert.True(t, isAllowedOrigin(
+		"http://mister.local:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+	// A reverse proxy in front of Core serves the name on a default port.
+	assert.True(t, isAllowedOrigin(
+		"https://mister.local", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+	// Another device on the same network is still not trusted.
+	assert.False(t, isAllowedOrigin(
+		"http://batocera.local:7497", staticOrigins, localIPsProvider, customOriginsProvider, port, false, "cors",
+	))
+}
+
+// TestServerTrustsOwnHostnameOrigins is a regression test for the mDNS hostname
+// origins never reaching the allowlist: they were built from the discovery
+// service's instance name, which only resolves once discovery starts, and
+// discovery starts after the API server has already built its static origins.
+// Browsing the web UI at http://<hostname>.local:<port> then failed to connect.
+func TestServerTrustsOwnHostnameOrigins(t *testing.T) {
+	t.Parallel()
+
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+	hostNames := localHostNames(hostname)
+	require.NotEmpty(t, hostNames, "test host must have a usable hostname")
+	require.True(t, slices.ContainsFunc(hostNames, func(name string) bool {
+		return strings.HasSuffix(strings.ToLower(name), ".local")
+	}), "host names must include an mDNS name")
+
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+
+	fs := helpers.NewMemoryFS()
+	configDir := t.TempDir()
+	cfg, err := helpers.NewTestConfigWithPort(fs, configDir, 0)
+	require.NoError(t, err)
+
+	st, notifCh := state.NewState(platform, "test-boot-uuid")
+	notifBroker := newTestBroker(st.GetContext(), notifCh)
+
+	db := &database.Database{
+		UserDB:  helpers.NewMockUserDBI(),
+		MediaDB: helpers.NewMockMediaDBI(),
+	}
+
+	tokenQueue := make(chan tokens.Token, 1)
+
+	serverDone := make(chan struct{})
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverDone)
+		serverErr <- Start(
+			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, nil, nil, nil, nil, nil, nil,
+		)
+	}()
+	defer func() {
+		st.StopService()
+		close(tokenQueue)
+		<-serverDone
+		require.NoError(t, <-serverErr)
+	}()
+
+	// The listener takes an OS-assigned port, so this checks the port-less
+	// origin forms. Port-bearing forms are covered by TestOriginPolicy_MDNSHostname.
+	port := waitForServerReady(t, cfg)
+
+	client := &http.Client{Timeout: time.Second}
+	healthURL := fmt.Sprintf("http://localhost:%d/health", port)
+
+	checkOrigin := func(origin string) string {
+		req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, healthURL, http.NoBody)
+		require.NoError(t, reqErr)
+		req.Header.Set("Origin", origin)
+
+		resp, doErr := client.Do(req) //nolint:gosec // test hitting local test server
+		require.NoError(t, doErr)
+		defer func() { _ = resp.Body.Close() }()
+
+		return resp.Header.Get("Access-Control-Allow-Origin")
+	}
+
+	for _, name := range hostNames {
+		for _, origin := range []string{"http://" + name, "https://" + name} {
+			assert.Equal(t, origin, checkOrigin(origin), "origin %s should be allowed", origin)
+		}
+	}
+
+	assert.Empty(t, checkOrigin("http://not-this-device.invalid"), "unrelated origins must stay rejected")
+}
+
 // TestServerBindFailureStopsService verifies that when the API server fails to bind
 // to its port (e.g., port already in use), it calls StopService() to trigger a
 // graceful shutdown of the entire service. This is a regression test for issue #448.
@@ -679,7 +877,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	go func() {
 		defer close(server1Done)
 		server1Err <- Start(
-			platform1, cfg1, st1, tokenQueue1, nil, db1, nil, nil, notifBroker1, "", nil, nil, nil, nil, nil, nil,
+			platform1, cfg1, st1, tokenQueue1, nil, db1, nil, nil, notifBroker1, nil, nil, nil, nil, nil, nil,
 		)
 	}()
 
@@ -725,7 +923,7 @@ func TestServerBindFailureStopsService(t *testing.T) {
 	go func() {
 		defer close(server2Done)
 		server2Err <- Start(
-			platform2, cfg2, st2, tokenQueue2, nil, db2, nil, nil, notifBroker2, "", nil, nil, nil, nil, nil, nil,
+			platform2, cfg2, st2, tokenQueue2, nil, db2, nil, nil, notifBroker2, nil, nil, nil, nil, nil, nil,
 		)
 	}()
 
@@ -1000,7 +1198,7 @@ func TestSSE_ReceivesNotifications(t *testing.T) {
 	go func() {
 		defer close(serverDone)
 		serverErr <- Start(
-			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, "", nil, nil, nil, nil, nil, nil,
+			platform, cfg, st, tokenQueue, nil, db, nil, nil, notifBroker, nil, nil, nil, nil, nil, nil,
 		)
 	}()
 	defer func() {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -566,7 +566,7 @@ func startService(
 	go func() {
 		apiDone <- api.StartWithReady(
 			pl, cfg, st, itq, cfq, db, limitsManager, profilesSvc,
-			notifBroker, discoveryService.InstanceName(), player, playbackManager, indexPauser, scrapePauser,
+			notifBroker, player, playbackManager, indexPauser, scrapePauser,
 			backupPauser, idleSched, apiReady,
 		)
 	}()


### PR DESCRIPTION
Browsing the Web UI at `http://<hostname>.local:7497` loads the page and then sits there without connecting. The files are static assets any browser can fetch, but the WebSocket back to Core carries the page's origin, and that origin was never on the allowlist.

`server.go` builds `.local` origins from `mdnsHostname`, which `service.go` fills with `discoveryService.InstanceName()`. That name is only resolved inside `discovery.Start()`, which runs after the API server has built its static origins and reported ready, so the value was always `""` and the block never executed. The existing tests cover the origin expansion helpers, not the wiring, so nothing caught it.

The instance name was also the wrong input. A DNS-SD instance name is a service label, not a host name: `zeroconf.Register` takes the A record from `os.Hostname()`, as avahi does, so a device called `mister` answers to `mister.local` regardless of what instance name Core advertises. Setting `instance_name` never changed the name a browser resolves.

## Changes

- Host names now come from the OS hostname, which the server already read for the port-less forms. `mdnsHostname` is removed from `Start` and `StartWithReady`.
- A fully qualified hostname also contributes its short label, since avahi publishes the short name under `.local` while zeroconf appends the suffix to the whole name. A hostname already ending in `.local`, which is what macOS reports, is left alone.
- `TestOriginPolicy_MDNSHostname` covers the name expansion, and `TestServerTrustsOwnHostnameOrigins` starts a server and checks the CORS response for the host's real names, so the wiring is covered too.

Origins reached by any other name still need an `allowed_origins` entry. Core will not trust a name only because it resolves to the device, since that is what DNS rebinding relies on.

`discovery.InstanceName()` keeps its tests but no longer has a production caller.

Found while writing the DNS origin documentation asked for in #1283.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local access now recognizes the device hostname, `.local` address, and short hostname across HTTP/HTTPS and port/no-port formats.
  - Server requests from the device’s own hostname are trusted automatically.
  - Dynamically assigned ports are correctly included in allowed local origins.

- **Bug Fixes**
  - Improved local server access when hostname-based addresses are used.
  - Hostname lookup failures are now logged during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->