### PR TITLE
feat(mister): group alt cores and add unstable nightly launchers

### DIFF
--- a/pkg/platforms/mister/cores/rbf_cache.go
+++ b/pkg/platforms/mister/cores/rbf_cache.go
@@ -573,6 +573,36 @@ func (c *RBFCache) ResolveLauncher(cfg *config.Instance, launcherID, systemID st
 	return c.GetBySystemID(systemID)
 }
 
+// ResolveLauncherStrict reports the RBF a launcher would use, without
+// ResolveLauncher's fall back to the system's stock core. A launcher that
+// registered its own alt core paths resolves to one of those or to nothing:
+// "would silently run the stock core instead" is not the same as installed,
+// and callers deciding whether a launcher is usable must not conflate them.
+// cfg may be nil, which skips the load_path check.
+func (c *RBFCache) ResolveLauncherStrict(cfg *config.Instance, launcherID, systemID string) (RBFInfo, bool) {
+	key := launcherID
+	if key == "" {
+		key = systemID
+	}
+
+	if cfg != nil {
+		if lp := cfg.LookupLauncherDefaults(key, nil).LoadPath; lp != "" {
+			return c.GetByMglPath(lp)
+		}
+	}
+
+	if launcherID != "" {
+		if rbfInfo, ok := c.GetByLauncherID(launcherID); ok {
+			return rbfInfo, true
+		}
+		if len(c.AltCorePaths(launcherID)) > 0 {
+			return RBFInfo{}, false
+		}
+	}
+
+	return c.GetBySystemID(systemID)
+}
+
 func (c *RBFCache) relatedCandidates(rbfPath string) []string {
 	canonicalDir, shortName := splitRBFPath(rbfPath)
 	if shortName == "" {

--- a/pkg/platforms/mister/cores/rbf_cache_test.go
+++ b/pkg/platforms/mister/cores/rbf_cache_test.go
@@ -438,6 +438,57 @@ func TestRBFCache_Resolve_RetroAchievementsAltCore(t *testing.T) {
 	assert.Equal(t, "_RA_Cores/Cores/NES", got.MglName)
 }
 
+func TestResolveLauncherStrict_MissingAltCoreDoesNotFallBack(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/SNES_20240101.rbf", ShortName: "SNES", MglName: "_Console/SNES"},
+	})
+	cache.RegisterAltCore("LLAPISNES", "_LLAPI/SNES_LLAPI")
+
+	// ResolveLauncher reports what a launch would actually load, which is the
+	// stock core. Strict resolution must not, or every uninstalled alt core
+	// family looks installed.
+	got, ok := cache.ResolveLauncher(nil, "LLAPISNES", "SNES")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/SNES", got.MglName)
+
+	_, ok = cache.ResolveLauncherStrict(nil, "LLAPISNES", "SNES")
+	assert.False(t, ok)
+}
+
+func TestResolveLauncherStrict_InstalledAltCoreResolves(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/SNES_20240101.rbf", ShortName: "SNES", MglName: "_Console/SNES"},
+		{
+			Path:      "/media/fat/_LLAPI/SNES_LLAPI_20240101.rbf",
+			ShortName: "SNES_LLAPI", MglName: "_LLAPI/SNES_LLAPI",
+		},
+	})
+	cache.RegisterAltCore("LLAPISNES", "_LLAPI/SNES_LLAPI")
+
+	got, ok := cache.ResolveLauncherStrict(nil, "LLAPISNES", "SNES")
+	require.True(t, ok)
+	assert.Equal(t, "_LLAPI/SNES_LLAPI", got.MglName)
+}
+
+func TestResolveLauncherStrict_StockLauncherStillResolves(t *testing.T) {
+	t.Parallel()
+
+	cache := &RBFCache{}
+	cache.BuildFromRBFs([]RBFInfo{
+		{Path: "/media/fat/_Console/SNES_20240101.rbf", ShortName: "SNES", MglName: "_Console/SNES"},
+	})
+
+	got, ok := cache.ResolveLauncherStrict(nil, "SNES", "SNES")
+	require.True(t, ok)
+	assert.Equal(t, "_Console/SNES", got.MglName)
+}
+
 func TestRBFCache_Resolve_AltCoreFallsBackToSystemID(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/launchers.go
+++ b/pkg/platforms/mister/launchers.go
@@ -464,11 +464,121 @@ func retroAchievementsSetName(launcherID string) (string, bool) {
 	}
 }
 
-func applyRetroAchievementsLauncherGroup(launchers []platforms.Launcher) []platforms.Launcher {
-	for i := range launchers {
-		if _, ok := retroAchievementsSetName(launchers[i].ID); ok {
-			launchers[i].Groups = append(launchers[i].Groups, shared.LauncherGroupRetroAchievements)
+// altCorePath is a registered alt core RBF path split for classification.
+// lowerName is precomputed because most rules need a case-insensitive check
+// and CreateLaunchers reruns on every Launchers call.
+type altCorePath struct {
+	dir       string
+	lowerName string
+}
+
+func newAltCorePath(rbfPath string) altCorePath {
+	dir, shortName := splitAltCorePath(rbfPath)
+	return altCorePath{dir: dir, lowerName: strings.ToLower(shortName)}
+}
+
+// altCoreGroupRule classifies a launcher by the RBF paths it registers with the
+// global cache. Paths are ground truth: the launcher ID is not, because IDs
+// like DB9DualRAMPSX and PWM2XPSX belong to more than one family and no prefix
+// rule can express that.
+type altCoreGroupRule struct {
+	match func(p altCorePath) bool
+	group string
+}
+
+// altCoreGroupRules is ordered. Primary families (the distribution a core came
+// from) come first so Groups[0] identifies the family; secondary attributes
+// like dual-SDRAM follow. Callers such as the browse scheme map read Groups[0].
+var altCoreGroupRules = []altCoreGroupRule{
+	{
+		group: shared.LauncherGroupRetroAchievements,
+		match: func(p altCorePath) bool { return dirWithin(p.dir, "_RA_Cores/Cores") },
+	},
+	{
+		group: shared.LauncherGroupLLAPI,
+		match: func(p altCorePath) bool { return dirWithin(p.dir, "_LLAPI") },
+	},
+	{
+		group: shared.LauncherGroupSinden,
+		match: func(p altCorePath) bool {
+			return dirWithin(p.dir, "Light Gun") || dirWithin(p.dir, "_Sinden")
+		},
+	},
+	{
+		// The PWM database sorts overclocked builds into a _Turbo subfolder.
+		group: shared.LauncherGroupPWM,
+		match: func(p altCorePath) bool { return dirWithin(p.dir, "_ConsolePWM") },
+	},
+	{
+		group: shared.LauncherGroupUnstable,
+		match: func(p altCorePath) bool { return strings.Contains(p.lowerName, "_unstable_") },
+	},
+	{
+		group: shared.LauncherGroupDB9,
+		match: func(p altCorePath) bool { return strings.HasSuffix(p.lowerName, "_db9") },
+	},
+	{
+		group: shared.LauncherGroupDualRAM,
+		match: func(p altCorePath) bool {
+			return dirWithin(p.dir, "_Console (Dual SDRAM)") ||
+				strings.Contains(p.lowerName, "_dualsdram")
+		},
+	},
+}
+
+func splitAltCorePath(rbfPath string) (dir, shortName string) {
+	if idx := strings.LastIndex(rbfPath, "/"); idx >= 0 {
+		return rbfPath[:idx], rbfPath[idx+1:]
+	}
+	return "", rbfPath
+}
+
+// dirWithin reports whether dir is want or a folder inside it.
+func dirWithin(dir, want string) bool {
+	if strings.EqualFold(dir, want) {
+		return true
+	}
+	return len(dir) > len(want) && strings.EqualFold(dir[:len(want)+1], want+"/")
+}
+
+// altCoreGroups returns the config groups a launcher belongs to, derived from
+// every RBF path it registered. A launcher with no registered paths is a stock
+// core launcher and gets no group.
+func altCoreGroups(launcherID string, scratch []altCorePath) ([]string, []altCorePath) {
+	rbfPaths := cores.GlobalRBFCache.AltCorePaths(launcherID)
+	if len(rbfPaths) == 0 {
+		return nil, scratch
+	}
+
+	paths := scratch[:0]
+	for _, rbfPath := range rbfPaths {
+		paths = append(paths, newAltCorePath(rbfPath))
+	}
+
+	var groups []string
+	for _, rule := range altCoreGroupRules {
+		for _, path := range paths {
+			if rule.match(path) {
+				groups = append(groups, rule.group)
+				break
+			}
 		}
+	}
+	return groups, paths
+}
+
+// applyAltCoreLauncherGroups tags every alt core launcher with the groups its
+// registered RBF paths imply. Must run after the launcher slice is built, since
+// the launch constructors are what register those paths.
+func applyAltCoreLauncherGroups(launchers []platforms.Launcher) []platforms.Launcher {
+	var scratch []altCorePath
+	for i := range launchers {
+		var groups []string
+		groups, scratch = altCoreGroups(launchers[i].ID, scratch)
+		if len(groups) == 0 {
+			continue
+		}
+		launchers[i].Groups = append(launchers[i].Groups, groups...)
 	}
 	return launchers
 }
@@ -2366,5 +2476,10 @@ func CreateLaunchers(pl platforms.Platform) []platforms.Launcher {
 		},
 	}
 
-	return applyDefaultScanExcludes(enableMGLIndexing(applyRetroAchievementsLauncherGroup(launchers)))
+	unstable := createUnstableLaunchers()
+	all := make([]platforms.Launcher, 0, len(launchers)+len(unstable))
+	all = append(all, launchers...)
+	all = append(all, unstable...)
+
+	return applyDefaultScanExcludes(enableMGLIndexing(applyAltCoreLauncherGroups(all)))
 }

--- a/pkg/platforms/mister/launchers_test.go
+++ b/pkg/platforms/mister/launchers_test.go
@@ -1084,6 +1084,106 @@ func TestRetroAchievementsLaunchersExist(t *testing.T) {
 	}
 }
 
+// TestAltCoreLauncherGroups pins every alt core family to its config group.
+// The counts are exact: a new alt core launcher that the path classifier does
+// not recognise fails here rather than silently missing from preference.
+func TestAltCoreLauncherGroups(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	counts := map[string]int{}
+	for i := range launchers {
+		for _, group := range launchers[i].Groups {
+			counts[group]++
+		}
+	}
+
+	cases := []struct {
+		group string
+		want  int
+	}{
+		{platformshared.LauncherGroupRetroAchievements, 21},
+		{platformshared.LauncherGroupDB9, 32},
+		{platformshared.LauncherGroupLLAPI, 18},
+		{platformshared.LauncherGroupSinden, 7},
+		{platformshared.LauncherGroupPWM, 5},
+		{platformshared.LauncherGroupDualRAM, 7},
+		{platformshared.LauncherGroupUnstable, 45},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, counts[tc.group], "launcher count for group %s", tc.group)
+	}
+
+	members := []struct {
+		id    string
+		group string
+	}{
+		{"LLAPISNES", platformshared.LauncherGroupLLAPI},
+		{"LLAPI80MHzNintendo64", platformshared.LauncherGroupLLAPI},
+		{"DB9MegaDrive", platformshared.LauncherGroupDB9},
+		{"DB9GBAAccuracy", platformshared.LauncherGroupDB9},
+		{"SindenNES", platformshared.LauncherGroupSinden},
+		{"PWMPSX", platformshared.LauncherGroupPWM},
+		{"PWM2XPSX", platformshared.LauncherGroupPWM},
+		{"DualRAMJaguar", platformshared.LauncherGroupDualRAM},
+		{"RASNES", platformshared.LauncherGroupRetroAchievements},
+	}
+	for _, tc := range members {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			found := findLauncher(launchers, tc.id)
+			require.NotNil(t, found, "%s launcher should exist", tc.id)
+			assert.Contains(t, found.Groups, tc.group)
+		})
+	}
+}
+
+// TestDB9DualRAMLaunchersAreInBothGroups covers the reason classification reads
+// registered RBF paths instead of ID prefixes: these cores are a DB9 fork build
+// *and* a dual-SDRAM build, and no prefix rule can say both.
+func TestDB9DualRAMLaunchersAreInBothGroups(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	for _, id := range []string{"DB9DualRAMPSX", "DB9DualRAMSaturn"} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			found := findLauncher(launchers, id)
+			require.NotNil(t, found)
+			assert.Equal(t,
+				[]string{platformshared.LauncherGroupDB9, platformshared.LauncherGroupDualRAM},
+				found.Groups,
+				"the family group must come first so Groups[0] identifies the distribution",
+			)
+		})
+	}
+}
+
+// TestStockLaunchersHaveNoGroup keeps the stock cores out of every group, so a
+// preference entry naming a family never resolves to the default core.
+func TestStockLaunchersHaveNoGroup(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	for _, id := range []string{"SNES", "NES", "PSX", "Saturn", "Genesis", "2XPSX", "80MHzNintendo64"} {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+
+			found := findLauncher(launchers, id)
+			require.NotNil(t, found, "%s launcher should exist", id)
+			assert.Empty(t, found.Groups)
+		})
+	}
+}
+
 func TestRetroAchievementsAtari2600LauncherMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -1466,7 +1466,12 @@ func setCoreAvailability(launchers []platforms.Launcher) {
 			if systems, _ := cores.GlobalRBFCache.Count(); systems == 0 {
 				return nil
 			}
-			if _, ok := cores.GlobalRBFCache.ResolveLauncher(cfg, launcherID, systemID); ok {
+			// Strict: an alt core launcher whose own RBF is missing falls
+			// back to the stock core at launch time, but reporting that as
+			// available makes every uninstalled family (LLAPI, DB9, ...) look
+			// installed and lets an ordered launchers.preference match a group
+			// the device does not have.
+			if _, ok := cores.GlobalRBFCache.ResolveLauncherStrict(cfg, launcherID, systemID); ok {
 				return nil
 			}
 			return fmt.Errorf("core not installed: %s", misterExpectedCorePath(launcherID, systemID))

--- a/pkg/platforms/mister/platform_test.go
+++ b/pkg/platforms/mister/platform_test.go
@@ -544,6 +544,49 @@ func TestSetCoreAvailability_MissingCoreIsUnavailableWithReason(t *testing.T) {
 	assert.Contains(t, err.Error(), "_Console/SNES")
 }
 
+// TestSetCoreAvailability_MissingAltCoreIsUnavailable covers the rule that
+// makes an ordered launchers.preference work: a launcher for a core family the
+// device does not have must report unavailable, even though launching it would
+// silently fall back to the system's stock core.
+func TestSetCoreAvailability_MissingAltCoreIsUnavailable(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path: "/media/fat/_Console/SNES_20260311.rbf", Filename: "SNES_20260311.rbf",
+			ShortName: "SNES", MglName: "_Console/SNES",
+		},
+	})
+	cores.GlobalRBFCache.RegisterAltCore("LLAPISNES", "_LLAPI/SNES_LLAPI")
+
+	launchers := []platforms.Launcher{{ID: "LLAPISNES", SystemID: "SNES"}}
+	setCoreAvailability(launchers)
+	require.NotNil(t, launchers[0].Availability)
+
+	err := launchers[0].Availability(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "_LLAPI/SNES_LLAPI")
+}
+
+// TestSetCoreAvailability_InstalledAltCoreIsAvailable is the other half: once
+// the family's core is on the card the launcher reports available.
+func TestSetCoreAvailability_InstalledAltCoreIsAvailable(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path: "/media/fat/_Console/SNES_20260311.rbf", Filename: "SNES_20260311.rbf",
+			ShortName: "SNES", MglName: "_Console/SNES",
+		},
+		{
+			Path: "/media/fat/_LLAPI/SNES_LLAPI_20260311.rbf", Filename: "SNES_LLAPI_20260311.rbf",
+			ShortName: "SNES_LLAPI", MglName: "_LLAPI/SNES_LLAPI",
+		},
+	})
+	cores.GlobalRBFCache.RegisterAltCore("LLAPISNES", "_LLAPI/SNES_LLAPI")
+
+	launchers := []platforms.Launcher{{ID: "LLAPISNES", SystemID: "SNES"}}
+	setCoreAvailability(launchers)
+	require.NotNil(t, launchers[0].Availability)
+	assert.NoError(t, launchers[0].Availability(nil))
+}
+
 func TestSetCoreAvailability_NonCoreLauncherLeftAlone(t *testing.T) {
 	withRBFCache(t, nil)
 

--- a/pkg/platforms/mister/unstable.go
+++ b/pkg/platforms/mister/unstable.go
@@ -1,0 +1,152 @@
+//go:build linux
+
+package mister
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+)
+
+// unstableCorePattern is the RBF name pattern the unstable nightlies use:
+// <Core>_unstable_<8-digit date>_<hash>.rbf. It is registered without a
+// directory so a nightly resolves wherever it was installed — the
+// unstable_nightlies_folder database puts them in _Unstable, but the scripts
+// people use to fetch individual cores do not always agree. Glob resolution
+// picks the newest match, so a folder holding several dated builds of one core
+// launches the latest.
+func unstableCorePattern(rbfName string) string {
+	return rbfName + "_unstable_<date>_<hash>"
+}
+
+// unstableNightlyCore is one core published by the unstable nightlies database
+// (MiSTer-unstable-nightlies/Unstable_Folder_MiSTer).
+type unstableNightlyCore struct {
+	// systemID pins the launcher to a single system. Empty means the entry
+	// expands to one launcher per system whose stock core is rbfNames[0], so a
+	// nightly that serves several systems — the NES core also runs FDS — can be
+	// preferred for all of them.
+	systemID string
+	// idSuffix overrides the launcher ID suffix, which defaults to the system
+	// ID. Needed where one system has more than one nightly.
+	idSuffix string
+	// rbfNames are the core's RBF base names in resolution order. A second name
+	// is a legacy name the same core used to ship under.
+	rbfNames []string
+}
+
+// unstableNightlyCores lists the cores published by the unstable nightlies
+// database. Arcade cores (Galaga, Galaxian, QBert, SEGASYS1, SpaceInvaders,
+// Tecmo) are omitted because arcade media launches through an MRA that names
+// its own RBF, as are the menu core and the MiSTer main binary. Cores with no
+// Zaparoo system (AtariST, PC88, ST-V) are omitted too.
+var unstableNightlyCores = []unstableNightlyCore{
+	{rbfNames: []string{"3DO"}},
+	{rbfNames: []string{"AcornAtom"}},
+	{rbfNames: []string{"AcornElectron"}},
+	{rbfNames: []string{"AliceMC10"}},
+	{rbfNames: []string{"Amstrad"}},
+	{rbfNames: []string{"Apple-II"}},
+	{rbfNames: []string{"Atari7800"}},
+	{rbfNames: []string{"AtariLynx"}},
+	{rbfNames: []string{"C64"}},
+	{rbfNames: []string{"CDi"}},
+	{rbfNames: []string{"Chip8"}},
+	{rbfNames: []string{"ColecoVision"}},
+	{rbfNames: []string{"GBA"}},
+	{rbfNames: []string{"Gameboy"}},
+	{rbfNames: []string{"MSX"}},
+	{rbfNames: []string{"MacPlus"}},
+	{rbfNames: []string{"MegaCD"}},
+	// The Genesis system's stock core is MegaDrive; Genesis is the name the
+	// same core shipped under before it was renamed.
+	{rbfNames: []string{"MegaDrive", "Genesis"}},
+	// The Minimig nightly also backs the Amiga system, but MiSTer's Amiga
+	// launcher is bespoke — it resolves AmigaVision listing files and virtual
+	// MGL paths — so a generic alt core would launch that media wrong. Only
+	// AmigaCD32, which uses the plain launch path, gets a nightly.
+	{
+		systemID: systemdefs.SystemAmigaCD32,
+		rbfNames: []string{"Minimig"},
+	},
+	{rbfNames: []string{"NES"}},
+	{rbfNames: []string{"NeoGeo"}},
+	{rbfNames: []string{"PSX"}},
+	{rbfNames: []string{"S32X"}},
+	{rbfNames: []string{"SMS"}},
+	{rbfNames: []string{"SNES"}},
+	{rbfNames: []string{"Saturn"}},
+	{rbfNames: []string{"TatungEinstein"}},
+	{rbfNames: []string{"Ti994a"}},
+	{rbfNames: []string{"TurboGrafx16"}},
+	{rbfNames: []string{"X68000"}},
+	{rbfNames: []string{"ZX-Spectrum"}},
+	{rbfNames: []string{"ZXNext"}},
+	{rbfNames: []string{"ao486"}},
+	// Dual-SDRAM nightly, matching the DualRAMSaturn stable alt core.
+	{
+		systemID: systemdefs.SystemSaturn,
+		idSuffix: "DualRAMSaturn",
+		rbfNames: []string{"Saturn_DualSDRAM"},
+	},
+}
+
+// systemsByStockCore indexes every system by its stock core's RBF name,
+// lowercased. Built once: cores.Systems is a static table, and CreateLaunchers
+// runs on every Launchers call.
+var systemsByStockCore = sync.OnceValue(func() map[string][]string {
+	index := make(map[string][]string, len(cores.Systems))
+	for systemID, core := range cores.Systems {
+		if core.RBF == "" {
+			continue
+		}
+		_, shortName := splitAltCorePath(core.RBF)
+		key := strings.ToLower(shortName)
+		index[key] = append(index[key], systemID)
+	}
+	for key := range index {
+		sort.Strings(index[key])
+	}
+	return index
+})
+
+// createUnstableLaunchers builds an Unstable* launcher per nightly core and
+// system. They carry no folders or extensions: like the other alt core
+// families they only ever launch media the system's stock launcher already
+// indexed, reached through launchers.preference or an explicit launcher arg.
+func createUnstableLaunchers() []platforms.Launcher {
+	launchers := make([]platforms.Launcher, 0, len(unstableNightlyCores))
+
+	for _, entry := range unstableNightlyCores {
+		patterns := make([]string, 0, len(entry.rbfNames))
+		for _, rbfName := range entry.rbfNames {
+			patterns = append(patterns, unstableCorePattern(rbfName))
+		}
+
+		systemIDs := []string{entry.systemID}
+		if entry.systemID == "" {
+			systemIDs = systemsByStockCore()[strings.ToLower(entry.rbfNames[0])]
+		}
+
+		for _, systemID := range systemIDs {
+			suffix := entry.idSuffix
+			if suffix == "" {
+				suffix = systemID
+			}
+			launcherID := "Unstable" + suffix
+			launchers = append(launchers, platforms.Launcher{
+				ID:       launcherID,
+				SystemID: systemID,
+				Launch: launchAltCoreCandidates(
+					launcherID, systemID, patterns[0], patterns[1:]...,
+				),
+			})
+		}
+	}
+
+	return launchers
+}

--- a/pkg/platforms/mister/unstable_test.go
+++ b/pkg/platforms/mister/unstable_test.go
@@ -1,0 +1,242 @@
+//go:build linux
+
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mister
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/cores"
+	platformshared "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findLauncher(launchers []platforms.Launcher, id string) *platforms.Launcher {
+	for i := range launchers {
+		if launchers[i].ID == id {
+			return &launchers[i]
+		}
+	}
+	return nil
+}
+
+func TestUnstableLaunchersExist(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	cases := []struct {
+		id       string
+		systemID string
+	}{
+		{"UnstableSNES", "SNES"},
+		{"UnstableNES", "NES"},
+		// The NES nightly also runs FDS, so FDS gets its own launcher.
+		{"UnstableFDS", "FDS"},
+		{"UnstablePSX", "PSX"},
+		{"UnstableSaturn", "Saturn"},
+		{"UnstableDualRAMSaturn", "Saturn"},
+		{"UnstableGenesis", "Genesis"},
+		{"UnstableGBA", "GBA"},
+		{"UnstableGameboy", "Gameboy"},
+		{"UnstableGameboyColor", "GameboyColor"},
+		{"UnstableMegaCD", "MegaCD"},
+		{"UnstableNeoGeo", "NeoGeo"},
+		{"UnstableAmigaCD32", "AmigaCD32"},
+		{"UnstableZXSpectrum", "ZXSpectrum"},
+		{"Unstableao486", "ao486"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.id, func(t *testing.T) {
+			t.Parallel()
+
+			found := findLauncher(launchers, tc.id)
+			require.NotNil(t, found, "%s launcher should exist", tc.id)
+			assert.Equal(t, tc.systemID, found.SystemID,
+				"%s must inherit slots from %s", tc.id, tc.systemID)
+			assert.Contains(t, found.Groups, platformshared.LauncherGroupUnstable)
+		})
+	}
+}
+
+// TestUnstableLaunchersSkipArcadeAndNonSystemCores guards the curation in
+// unstableNightlyCores: arcade nightlies launch through MRAs that name their
+// own RBF, and cores without a Zaparoo system have nothing to attach to.
+func TestUnstableLaunchersSkipArcadeAndNonSystemCores(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	for _, id := range []string{
+		"UnstableArcade", "UnstableArcadeGalaga", "UnstableArcadeTecmo",
+		"UnstableAtariST", "UnstablePC88", "UnstableSTV", "UnstableMenu",
+	} {
+		assert.Nil(t, findLauncher(launchers, id), "%s should not exist", id)
+	}
+
+	// The Minimig nightly serves Amiga too, but the Amiga launcher resolves
+	// AmigaVision listing files and virtual MGL paths that a generic alt core
+	// launcher would mishandle.
+	assert.Nil(t, findLauncher(launchers, "UnstableAmiga"),
+		"Amiga must keep its bespoke launcher")
+}
+
+func TestUnstableLauncherRegistersDatedPattern(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	CreateLaunchers(pl)
+
+	assert.Equal(t,
+		[]string{"SNES_unstable_<date>_<hash>"},
+		cores.GlobalRBFCache.AltCorePaths("UnstableSNES"),
+	)
+	assert.Equal(t,
+		[]string{"Saturn_DualSDRAM_unstable_<date>_<hash>"},
+		cores.GlobalRBFCache.AltCorePaths("UnstableDualRAMSaturn"),
+	)
+	// The Genesis system's stock core is MegaDrive; Genesis is the legacy name
+	// the same core shipped under, kept as a fallback candidate.
+	assert.Equal(t,
+		[]string{"MegaDrive_unstable_<date>_<hash>", "Genesis_unstable_<date>_<hash>"},
+		cores.GlobalRBFCache.AltCorePaths("UnstableGenesis"),
+	)
+}
+
+func TestUnstableDualRAMSaturnIsInBothGroups(t *testing.T) {
+	t.Parallel()
+
+	pl := NewPlatform()
+	launchers := CreateLaunchers(pl)
+
+	found := findLauncher(launchers, "UnstableDualRAMSaturn")
+	require.NotNil(t, found)
+	assert.Equal(t,
+		[]string{platformshared.LauncherGroupUnstable, platformshared.LauncherGroupDualRAM},
+		found.Groups,
+		"the family group must come first so Groups[0] identifies the distribution",
+	)
+}
+
+func TestUnstableLauncherResolvesNightlyRBF(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path:      "/media/fat/_Console/SNES_20260311.rbf",
+			Filename:  "SNES_20260311.rbf",
+			ShortName: "SNES",
+			MglName:   "_Console/SNES",
+		},
+		{
+			Path:      "/media/fat/_Unstable/SNES_unstable_20260824_1919a7.rbf",
+			Filename:  "SNES_unstable_20260824_1919a7.rbf",
+			ShortName: "SNES_unstable_20260824_1919a7",
+			MglName:   "_Unstable/SNES_unstable_20260824_1919a7",
+		},
+	})
+
+	pl := NewPlatform()
+	CreateLaunchers(pl)
+
+	info, ok := cores.GlobalRBFCache.ResolveLauncherStrict(nil, "UnstableSNES", "SNES")
+	require.True(t, ok)
+	assert.Equal(t, "_Unstable/SNES_unstable_20260824_1919a7", info.MglName)
+}
+
+func TestUnstableLauncherPrefersNewestNightly(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path:      "/media/fat/_Unstable/SNES_unstable_20260101_aaaaaa.rbf",
+			Filename:  "SNES_unstable_20260101_aaaaaa.rbf",
+			ShortName: "SNES_unstable_20260101_aaaaaa",
+			MglName:   "_Unstable/SNES_unstable_20260101_aaaaaa",
+		},
+		{
+			Path:      "/media/fat/_Unstable/SNES_unstable_20260824_1919a7.rbf",
+			Filename:  "SNES_unstable_20260824_1919a7.rbf",
+			ShortName: "SNES_unstable_20260824_1919a7",
+			MglName:   "_Unstable/SNES_unstable_20260824_1919a7",
+		},
+	})
+
+	pl := NewPlatform()
+	CreateLaunchers(pl)
+
+	info, ok := cores.GlobalRBFCache.ResolveLauncherStrict(nil, "UnstableSNES", "SNES")
+	require.True(t, ok)
+	assert.Equal(t, "_Unstable/SNES_unstable_20260824_1919a7", info.MglName)
+}
+
+// TestUnstableSaturnIgnoresDualSDRAMNightly covers the token matcher's
+// part-count rule: the plain Saturn nightly must not resolve to the dual-SDRAM
+// build, which needs two SDRAM boards to run at all.
+func TestUnstableSaturnIgnoresDualSDRAMNightly(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path:      "/media/fat/_Console/Saturn_20260311.rbf",
+			Filename:  "Saturn_20260311.rbf",
+			ShortName: "Saturn",
+			MglName:   "_Console/Saturn",
+		},
+		{
+			Path:      "/media/fat/_Unstable/Saturn_DualSDRAM_unstable_20260817_13ea1a.rbf",
+			Filename:  "Saturn_DualSDRAM_unstable_20260817_13ea1a.rbf",
+			ShortName: "Saturn_DualSDRAM_unstable_20260817_13ea1a",
+			MglName:   "_Unstable/Saturn_DualSDRAM_unstable_20260817_13ea1a",
+		},
+	})
+
+	pl := NewPlatform()
+	CreateLaunchers(pl)
+
+	_, ok := cores.GlobalRBFCache.ResolveLauncherStrict(nil, "UnstableSaturn", "Saturn")
+	assert.False(t, ok, "plain Saturn nightly must not match the dual-SDRAM build")
+
+	info, ok := cores.GlobalRBFCache.ResolveLauncherStrict(nil, "UnstableDualRAMSaturn", "Saturn")
+	require.True(t, ok)
+	assert.Equal(t, "_Unstable/Saturn_DualSDRAM_unstable_20260817_13ea1a", info.MglName)
+}
+
+func TestUnstableLauncherUnavailableWithoutNightly(t *testing.T) {
+	withRBFCache(t, []cores.RBFInfo{
+		{
+			Path:      "/media/fat/_Console/SNES_20260311.rbf",
+			Filename:  "SNES_20260311.rbf",
+			ShortName: "SNES",
+			MglName:   "_Console/SNES",
+		},
+	})
+
+	pl := NewPlatform()
+	CreateLaunchers(pl)
+
+	launchers := []platforms.Launcher{{ID: "UnstableSNES", SystemID: "SNES"}}
+	setCoreAvailability(launchers)
+	require.NotNil(t, launchers[0].Availability)
+
+	err := launchers[0].Availability(nil)
+	require.Error(t, err, "an uninstalled nightly must not report available")
+	assert.Contains(t, err.Error(), "SNES_unstable_<date>_<hash>")
+}

--- a/pkg/platforms/shared/launchers.go
+++ b/pkg/platforms/shared/launchers.go
@@ -41,3 +41,15 @@ const (
 	LauncherGroupKodiTV            = "KodiTV"
 	LauncherGroupKodiMusic         = "KodiMusic"
 )
+
+// MiSTer alt-core launcher groups. Each name matches a family of cores
+// published by a distinct MiSTer downloader database, so a user can prefer a
+// whole family at once with a single [launchers] preference entry.
+const (
+	LauncherGroupDB9      = "DB9"
+	LauncherGroupLLAPI    = "LLAPI"
+	LauncherGroupDualRAM  = "DualRAM"
+	LauncherGroupSinden   = "Sinden"
+	LauncherGroupPWM      = "PWM"
+	LauncherGroupUnstable = "Unstable"
+)

--- a/pkg/zapscript/launch_test.go
+++ b/pkg/zapscript/launch_test.go
@@ -672,6 +672,37 @@ preference = ["Native", "RetroDECK"]
 	mockPlatform.AssertExpectations(t)
 }
 
+// TestApplySystemDefaultLauncher_SkipsUninstalledMisterCoreFamily is the
+// MiSTer shape of an ordered preference: the device has LLAPI cores but no
+// unstable nightlies, so the first entry must fall through instead of matching
+// a family that is not installed.
+func TestApplySystemDefaultLauncher_SkipsUninstalledMisterCoreFamily(t *testing.T) {
+	t.Parallel()
+
+	mockPlatform := mocks.NewMockPlatform()
+	cfg := &config.Instance{}
+	require.NoError(t, cfg.LoadTOML(`
+[launchers]
+preference = ["Unstable", "LLAPI"]
+`))
+	launchers := []platforms.Launcher{
+		{
+			ID: "UnstableSNES", SystemID: "SNES",
+			Groups:       []string{platformshared.LauncherGroupUnstable},
+			Availability: func(*config.Instance) error { return errors.New("core not installed") },
+		},
+		{ID: "LLAPISNES", SystemID: "SNES", Groups: []string{platformshared.LauncherGroupLLAPI}},
+		{ID: "SNES", SystemID: "SNES"},
+	}
+	mockPlatform.On("Launchers", cfg).Once().Return(launchers)
+	env := platforms.CmdEnv{Cfg: cfg, Cmd: zapscript.Command{AdvArgs: zapscript.NewAdvArgs(nil)}}
+
+	launcherID := applySystemDefaultLauncher(mockPlatform, &env, "SNES")
+
+	assert.Equal(t, "LLAPISNES", launcherID)
+	mockPlatform.AssertExpectations(t)
+}
+
 func TestApplySystemDefaultLauncher_SystemDefaultBeatsGlobalPreference(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Add `DB9`, `LLAPI`, `DualRAM`, `Sinden`, `PWM` and `Unstable` launcher groups, so `[launchers] preference` can prefer a whole core family the way it already could for `RetroAchievements`.
- Classify alt core launchers by the RBF paths they register with the global cache rather than by ID prefix. `DB9DualRAMPSX`, `DB9DualRAMSaturn` and `UnstableDualRAMSaturn` each belong to two families, which no prefix rule can express, and new alt cores now classify themselves.
- Add `Unstable*` launchers for the cores published by the `unstable_nightlies_folder` database. The RBF cache already parsed `<Core>_unstable_<date>_<hash>`, but only as a fallback for a missing stock core, so a nightly could never be preferred over one. Arcade nightlies are excluded because arcade media launches through an MRA that names its own RBF, as are cores with no Zaparoo system and Amiga, whose launcher resolves AmigaVision listing files a generic alt core would mishandle.
- Fix alt core availability. It used `ResolveLauncher`, which falls back to the system's stock core, so `LLAPISNES` reported available on a device with no `_LLAPI` folder and silently launched the stock core. An ordered preference therefore always matched its first entry. `RBFCache.ResolveLauncherStrict` omits that fallback and now backs the availability check; `LauncherRuntime` still uses the fallback path, since it reports what a launch would really load.

Refs #1298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for MiSTer unstable nightly core launchers, including automatic selection of the newest installed build.
  - Added launcher groups for DB9, LLAPI, DualRAM, Sinden, PWM, Unstable, and existing alt-core families.
  - Improved grouping for overlapping core families, such as DB9 and DualRAM.

- **Bug Fixes**
  - Uninstalled alternate cores are no longer reported as available through stock-core fallback.
  - Launcher preferences now skip unavailable core families and continue to the next suitable option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->