### PR TITLE
fix(mister): ignore a file selection re-notified after a core exits

### DIFF
--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -627,6 +627,32 @@ func readFileSelectionFrom(statusFile, fullPathFile, currentPathFile string) (fi
 	return sel, nil
 }
 
+// selectionStaleWindow bounds how far apart MiSTer's FILESELECT status and the
+// CURRENTPATH it describes may be written and still belong to the same
+// selection. Both MiSTer and writeCurrentPathTo write the trio back to back,
+// so a real selection lands well inside this.
+const selectionStaleWindow = 2 * time.Second
+
+// selectionIsStale reports whether FILESELECT was written meaningfully later
+// than the path it claims to describe.
+//
+// MiSTer never clears FILESELECT after a launch and rewrites it again when a
+// core exits, leaving the status at "selected" while FULLPATH and CURRENTPATH
+// still name the game that just ended. Without this the exit re-notification
+// reads as a fresh launch and resurrects the game that was just closed, which
+// then accrues playtime forever because no further core change is coming.
+func selectionIsStale(statusFile, currentPathFile string, window time.Duration) (bool, error) {
+	statusInfo, err := os.Stat(statusFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat file selection status: %w", err)
+	}
+	pathInfo, err := os.Stat(currentPathFile)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat selected current path: %w", err)
+	}
+	return statusInfo.ModTime().Sub(pathInfo.ModTime()) > window, nil
+}
+
 // stripExt mirrors the extension stripping MiSTer's get_display_name
 // (file_io.cpp) applies to CURRENTPATH for .mra/.mgl/.rbf files and cores
 // with a single declared extension.
@@ -789,6 +815,21 @@ func (tr *Tracker) loadFileSelection() {
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to read MiSTer file selection")
 		return
+	}
+
+	if sel.Status == "selected" {
+		// Fail open: an unreadable timestamp must not drop a real launch.
+		stale, staleErr := selectionIsStale(
+			misterconfig.FileSelectFile, misterconfig.CurrentPathFile, selectionStaleWindow,
+		)
+		switch {
+		case staleErr != nil:
+			log.Warn().Err(staleErr).Msg("failed to age MiSTer file selection, treating it as current")
+		case stale:
+			log.Debug().Str("path", sel.FullPath).
+				Msg("ignoring MiSTer file selection re-notified after its paths were written")
+			return
+		}
 	}
 
 	storageSelection, _ := os.ReadFile(filepath.Join(misterconfig.CoreConfigFolder, "device.bin"))

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -808,32 +808,54 @@ func hasSystemLauncher(launchers []platforms.Launcher) bool {
 // loadFileSelection reads a settled native MiSTer file-selection event and,
 // if it resolves to a trackable game, records it the same way a Zaparoo
 // launch does.
-func (tr *Tracker) loadFileSelection() {
-	sel, err := readFileSelectionFrom(
-		misterconfig.FileSelectFile, misterconfig.FullPathFile, misterconfig.CurrentPathFile,
-	)
+// selectionFiles names the MiSTer file-selector trio plus the storage
+// selection, so the resolution below can be driven from a temp directory.
+type selectionFiles struct {
+	status      string
+	fullPath    string
+	currentPath string
+	deviceBin   string
+}
+
+func misterSelectionFiles() selectionFiles {
+	return selectionFiles{
+		status:      misterconfig.FileSelectFile,
+		fullPath:    misterconfig.FullPathFile,
+		currentPath: misterconfig.CurrentPathFile,
+		deviceBin:   filepath.Join(misterconfig.CoreConfigFolder, "device.bin"),
+	}
+}
+
+// resolveSelectedLaunchPath reads the settled selection and reports the path
+// MiSTer launched, or ok=false when there is nothing to act on: an unreadable
+// trio, a selection that cannot be resolved confidently, or a status
+// re-notified long after the paths it describes.
+func resolveSelectedLaunchPath(files selectionFiles, window time.Duration) (string, bool) {
+	sel, err := readFileSelectionFrom(files.status, files.fullPath, files.currentPath)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to read MiSTer file selection")
-		return
+		return "", false
 	}
 
 	if sel.Status == "selected" {
 		// Fail open: an unreadable timestamp must not drop a real launch.
-		stale, staleErr := selectionIsStale(
-			misterconfig.FileSelectFile, misterconfig.CurrentPathFile, selectionStaleWindow,
-		)
+		stale, staleErr := selectionIsStale(files.status, files.currentPath, window)
 		switch {
 		case staleErr != nil:
 			log.Warn().Err(staleErr).Msg("failed to age MiSTer file selection, treating it as current")
 		case stale:
 			log.Debug().Str("path", sel.FullPath).
 				Msg("ignoring MiSTer file selection re-notified after its paths were written")
-			return
+			return "", false
 		}
 	}
 
-	storageSelection, _ := os.ReadFile(filepath.Join(misterconfig.CoreConfigFolder, "device.bin"))
-	path, ok := composeSelectedPath(sel, storageSelection, os.Stat, os.ReadDir)
+	storageSelection, _ := os.ReadFile(files.deviceBin) // #nosec G304 -- fixed MiSTer config path
+	return composeSelectedPath(sel, storageSelection, os.Stat, os.ReadDir)
+}
+
+func (tr *Tracker) loadFileSelection() {
+	path, ok := resolveSelectedLaunchPath(misterSelectionFiles(), selectionStaleWindow)
 	if !ok {
 		return
 	}
@@ -848,7 +870,7 @@ func (tr *Tracker) loadFileSelection() {
 	}
 
 	log.Info().Str("path", path).Msg("manual MiSTer file launch detected")
-	if err = activegame.SetActiveGame(path); err != nil {
+	if err := activegame.SetActiveGame(path); err != nil {
 		log.Error().Err(err).Str("path", path).Msg("failed to set selected active game")
 	}
 }

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -67,6 +67,8 @@ type Tracker struct {
 	activeMedia      func() *models.ActiveMedia
 	db               *database.Database
 	arcadeResolved   map[string]arcadeResolution
+	setActiveGame    func(string) error
+	selection        selectionFiles
 	ActiveSystemName string
 	ActiveSystem     string
 	ActiveGameID     string
@@ -144,6 +146,8 @@ func NewTracker(
 		NameMap:          nameMap,
 		activeMedia:      activeMedia,
 		setActiveMedia:   setActiveMedia,
+		setActiveGame:    activegame.SetActiveGame,
+		selection:        misterSelectionFiles(),
 	}, nil
 }
 
@@ -805,9 +809,6 @@ func hasSystemLauncher(launchers []platforms.Launcher) bool {
 	return false
 }
 
-// loadFileSelection reads a settled native MiSTer file-selection event and,
-// if it resolves to a trackable game, records it the same way a Zaparoo
-// launch does.
 // selectionFiles names the MiSTer file-selector trio plus the storage
 // selection, so the resolution below can be driven from a temp directory.
 type selectionFiles struct {
@@ -854,8 +855,11 @@ func resolveSelectedLaunchPath(files selectionFiles, window time.Duration) (stri
 	return composeSelectedPath(sel, storageSelection, os.Stat, os.ReadDir)
 }
 
+// loadFileSelection resolves the tracker's file-selector trio and records the
+// result as the active game. Both the trio and the recorder come from the
+// tracker so a test can drive the whole decision from a temp directory.
 func (tr *Tracker) loadFileSelection() {
-	path, ok := resolveSelectedLaunchPath(misterSelectionFiles(), selectionStaleWindow)
+	path, ok := resolveSelectedLaunchPath(tr.selection, selectionStaleWindow)
 	if !ok {
 		return
 	}
@@ -870,7 +874,7 @@ func (tr *Tracker) loadFileSelection() {
 	}
 
 	log.Info().Str("path", path).Msg("manual MiSTer file launch detected")
-	if err := activegame.SetActiveGame(path); err != nil {
+	if err := tr.setActiveGame(path); err != nil {
 		log.Error().Err(err).Str("path", path).Msg("failed to set selected active game")
 	}
 }

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -143,6 +143,66 @@ func TestResolveStorageRelativePath(t *testing.T) {
 // ended. That re-notification must not read as a new launch: it resurrected
 // the closed game, which then accrued playtime forever because no further core
 // change was coming.
+// resolveSelectedLaunchPath is where the staleness rule actually runs, so the
+// regression is pinned here rather than only on the predicate: without the
+// gate, exiting a core republished the game that had just closed.
+func TestResolveSelectedLaunchPath(t *testing.T) {
+	t.Parallel()
+
+	build := func(t *testing.T, gameName string, statusAge, pathAge time.Duration) (selectionFiles, string) {
+		t.Helper()
+		dir := t.TempDir()
+		gamesDir := filepath.Join(dir, "games")
+		require.NoError(t, os.MkdirAll(gamesDir, 0o750))
+		gamePath := filepath.Join(gamesDir, gameName)
+		require.NoError(t, os.WriteFile(gamePath, []byte("rom"), 0o600))
+
+		files := selectionFiles{
+			status:      filepath.Join(dir, "FILESELECT"),
+			fullPath:    filepath.Join(dir, "FULLPATH"),
+			currentPath: filepath.Join(dir, "CURRENTPATH"),
+			deviceBin:   filepath.Join(dir, "device.bin"),
+		}
+		require.NoError(t, os.WriteFile(files.status, []byte("selected"), 0o600))
+		require.NoError(t, os.WriteFile(files.fullPath, []byte(gamePath), 0o600))
+		require.NoError(t, os.WriteFile(files.currentPath, []byte(gameName), 0o600))
+
+		now := time.Now()
+		require.NoError(t, os.Chtimes(files.status, now.Add(-statusAge), now.Add(-statusAge)))
+		for _, f := range []string{files.fullPath, files.currentPath} {
+			require.NoError(t, os.Chtimes(f, now.Add(-pathAge), now.Add(-pathAge)))
+		}
+		return files, gamePath
+	}
+
+	t.Run("a settled selection resolves", func(t *testing.T) {
+		t.Parallel()
+		files, gamePath := build(t, "Blockade.mra", 10*time.Second, 10*time.Second)
+		path, ok := resolveSelectedLaunchPath(files, selectionStaleWindow)
+		require.True(t, ok, "a selection written with its paths is a real launch")
+		assert.Equal(t, gamePath, path)
+	})
+
+	t.Run("a status re-notified after a core exit is ignored", func(t *testing.T) {
+		t.Parallel()
+		// MiSTer rewrites FILESELECT on exit and leaves it at "selected", while
+		// FULLPATH and CURRENTPATH still name the game that just ended.
+		files, _ := build(t, "Blockade.mra", 0, 31*time.Second)
+		_, ok := resolveSelectedLaunchPath(files, selectionStaleWindow)
+		assert.False(t, ok, "the exit re-notification must not read as a launch")
+	})
+
+	t.Run("an unreadable timestamp fails open", func(t *testing.T) {
+		t.Parallel()
+		files, gamePath := build(t, "Blockade.mra", 0, 31*time.Second)
+		require.NoError(t, os.Remove(files.currentPath))
+		require.NoError(t, os.WriteFile(files.currentPath, []byte("Blockade.mra"), 0o600))
+		path, ok := resolveSelectedLaunchPath(files, time.Hour)
+		require.True(t, ok, "a window that cannot be exceeded still resolves")
+		assert.Equal(t, gamePath, path)
+	})
+}
+
 func TestSelectionIsStale(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -138,6 +138,60 @@ func TestResolveStorageRelativePath(t *testing.T) {
 	)
 }
 
+// MiSTer leaves FILESELECT at "selected" after a launch and rewrites it when
+// the core exits, while FULLPATH and CURRENTPATH still name the game that just
+// ended. That re-notification must not read as a new launch: it resurrected
+// the closed game, which then accrued playtime forever because no further core
+// change was coming.
+func TestSelectionIsStale(t *testing.T) {
+	t.Parallel()
+
+	write := func(t *testing.T, statusAge, pathAge time.Duration) (string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		statusFile := filepath.Join(dir, "FILESELECT")
+		currentPathFile := filepath.Join(dir, "CURRENTPATH")
+		require.NoError(t, os.WriteFile(statusFile, []byte("selected"), 0o600))
+		require.NoError(t, os.WriteFile(currentPathFile, []byte("Blockade.mra"), 0o600))
+		now := time.Now()
+		require.NoError(t, os.Chtimes(statusFile, now.Add(-statusAge), now.Add(-statusAge)))
+		require.NoError(t, os.Chtimes(currentPathFile, now.Add(-pathAge), now.Add(-pathAge)))
+		return statusFile, currentPathFile
+	}
+
+	t.Run("written together is current", func(t *testing.T) {
+		t.Parallel()
+		statusFile, currentPathFile := write(t, 10*time.Second, 10*time.Second)
+		stale, err := selectionIsStale(statusFile, currentPathFile, selectionStaleWindow)
+		require.NoError(t, err)
+		assert.False(t, stale)
+	})
+
+	t.Run("status re-notified long after its paths is stale", func(t *testing.T) {
+		t.Parallel()
+		// The real capture: paths at 13:39:56, status rewritten at 13:40:27.
+		statusFile, currentPathFile := write(t, 0, 31*time.Second)
+		stale, err := selectionIsStale(statusFile, currentPathFile, selectionStaleWindow)
+		require.NoError(t, err)
+		assert.True(t, stale)
+	})
+
+	t.Run("paths newer than status is not stale", func(t *testing.T) {
+		t.Parallel()
+		statusFile, currentPathFile := write(t, 31*time.Second, 0)
+		stale, err := selectionIsStale(statusFile, currentPathFile, selectionStaleWindow)
+		require.NoError(t, err)
+		assert.False(t, stale)
+	})
+
+	t.Run("missing file reports an error so the caller can fail open", func(t *testing.T) {
+		t.Parallel()
+		statusFile, _ := write(t, 0, 0)
+		_, err := selectionIsStale(statusFile, filepath.Join(t.TempDir(), "absent"), selectionStaleWindow)
+		require.Error(t, err)
+	})
+}
+
 func TestReadFileSelectionFrom(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -4,15 +4,20 @@ package tracker
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	misterconfig "github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mister/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -192,14 +197,22 @@ func TestResolveSelectedLaunchPath(t *testing.T) {
 		assert.False(t, ok, "the exit re-notification must not read as a launch")
 	})
 
-	t.Run("an unreadable timestamp fails open", func(t *testing.T) {
+	t.Run("a window that cannot be exceeded still resolves", func(t *testing.T) {
 		t.Parallel()
 		files, gamePath := build(t, "Blockade.mra", 0, 31*time.Second)
 		require.NoError(t, os.Remove(files.currentPath))
 		require.NoError(t, os.WriteFile(files.currentPath, []byte("Blockade.mra"), 0o600))
 		path, ok := resolveSelectedLaunchPath(files, time.Hour)
-		require.True(t, ok, "a window that cannot be exceeded still resolves")
+		require.True(t, ok, "the gate only drops a status older than the window")
 		assert.Equal(t, gamePath, path)
+	})
+
+	t.Run("an unreadable trio is ignored", func(t *testing.T) {
+		t.Parallel()
+		files, _ := build(t, "Blockade.mra", 10*time.Second, 10*time.Second)
+		require.NoError(t, os.Remove(files.fullPath))
+		_, ok := resolveSelectedLaunchPath(files, selectionStaleWindow)
+		assert.False(t, ok, "a half-written trio must not read as a launch")
 	})
 }
 
@@ -246,9 +259,11 @@ func TestSelectionIsStale(t *testing.T) {
 
 	t.Run("missing file reports an error so the caller can fail open", func(t *testing.T) {
 		t.Parallel()
-		statusFile, _ := write(t, 0, 0)
+		statusFile, currentPathFile := write(t, 0, 0)
 		_, err := selectionIsStale(statusFile, filepath.Join(t.TempDir(), "absent"), selectionStaleWindow)
-		require.Error(t, err)
+		require.Error(t, err, "an unreadable current path must be reported, not treated as current")
+		_, err = selectionIsStale(filepath.Join(t.TempDir(), "absent"), currentPathFile, selectionStaleWindow)
+		require.Error(t, err, "an unreadable status must be reported, not treated as current")
 	})
 }
 
@@ -608,4 +623,140 @@ func TestMediaLookupContextUsesServiceContext(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("MediaDB lookup context should follow service context")
 	}
+}
+
+func TestMisterSelectionFiles(t *testing.T) {
+	t.Parallel()
+
+	files := misterSelectionFiles()
+	assert.Equal(t, misterconfig.FileSelectFile, files.status)
+	assert.Equal(t, misterconfig.FullPathFile, files.fullPath)
+	assert.Equal(t, misterconfig.CurrentPathFile, files.currentPath)
+	assert.Equal(t, filepath.Join(misterconfig.CoreConfigFolder, "device.bin"), files.deviceBin)
+}
+
+// buildSelection writes MiSTer's file-selector trio into a temp directory and
+// ages the status file relative to the paths it describes, which is what tells
+// a real launch apart from the status MiSTer rewrites when a core exits.
+func buildSelection(
+	t *testing.T, gameName string, statusAge, pathAge time.Duration,
+) (files selectionFiles, gamePath string) {
+	t.Helper()
+	dir := t.TempDir()
+	gamesDir := filepath.Join(dir, "games")
+	require.NoError(t, os.MkdirAll(gamesDir, 0o750))
+	gamePath = filepath.Join(gamesDir, gameName)
+	require.NoError(t, os.WriteFile(gamePath, []byte("rom"), 0o600))
+
+	files = selectionFiles{
+		status:      filepath.Join(dir, "FILESELECT"),
+		fullPath:    filepath.Join(dir, "FULLPATH"),
+		currentPath: filepath.Join(dir, "CURRENTPATH"),
+		deviceBin:   filepath.Join(dir, "device.bin"),
+	}
+	require.NoError(t, os.WriteFile(files.status, []byte("selected"), 0o600))
+	require.NoError(t, os.WriteFile(files.fullPath, []byte(gamePath), 0o600))
+	require.NoError(t, os.WriteFile(files.currentPath, []byte(gameName), 0o600))
+
+	now := time.Now()
+	require.NoError(t, os.Chtimes(files.status, now.Add(-statusAge), now.Add(-statusAge)))
+	for _, f := range []string{files.fullPath, files.currentPath} {
+		require.NoError(t, os.Chtimes(f, now.Add(-pathAge), now.Add(-pathAge)))
+	}
+	return files, gamePath
+}
+
+// TestLoadFileSelection drives the whole selection path, not just the
+// staleness predicate: the exit re-notification only causes harm because
+// loadFileSelection went on to publish an active game from it.
+func TestLoadFileSelection(t *testing.T) {
+	// Cannot use t.Parallel() - swaps the shared GlobalLauncherCache.
+
+	pl := mocks.NewMockPlatform()
+	pl.On("Settings").Return(platforms.Settings{})
+	pl.On("RootDirs", mock.AnythingOfType("*config.Instance")).Return([]string{})
+
+	originalCache := helpers.GlobalLauncherCache
+	testCache := &helpers.LauncherCache{}
+	testCache.InitializeFromSlice([]platforms.Launcher{{
+		ID:         "NES",
+		SystemID:   "NES",
+		Extensions: []string{".nes"},
+	}})
+	helpers.GlobalLauncherCache = testCache
+	t.Cleanup(func() { helpers.GlobalLauncherCache = originalCache })
+
+	newTracker := func(files selectionFiles, record func(string) error) *Tracker {
+		return &Tracker{
+			pl:            pl,
+			cfg:           &config.Instance{},
+			selection:     files,
+			setActiveGame: record,
+		}
+	}
+
+	t.Run("a settled selection is recorded", func(t *testing.T) {
+		files, gamePath := buildSelection(t, "Zelda.nes", 10*time.Second, 10*time.Second)
+		var recorded []string
+		tr := newTracker(files, func(path string) error {
+			recorded = append(recorded, path)
+			return nil
+		})
+
+		tr.loadFileSelection()
+
+		assert.Equal(t, []string{gamePath}, recorded)
+	})
+
+	t.Run("a status re-notified after a core exit records nothing", func(t *testing.T) {
+		files, _ := buildSelection(t, "Zelda.nes", 0, 31*time.Second)
+		var recorded []string
+		tr := newTracker(files, func(path string) error {
+			recorded = append(recorded, path)
+			return nil
+		})
+
+		tr.loadFileSelection()
+
+		assert.Empty(t, recorded, "the exit re-notification must not resurrect the closed game")
+	})
+
+	t.Run("a system or menu file records nothing", func(t *testing.T) {
+		files, _ := buildSelection(t, "Menu.rbf", 10*time.Second, 10*time.Second)
+		var recorded []string
+		tr := newTracker(files, func(path string) error {
+			recorded = append(recorded, path)
+			return nil
+		})
+
+		tr.loadFileSelection()
+
+		assert.Empty(t, recorded)
+	})
+
+	t.Run("a path no launcher claims records nothing", func(t *testing.T) {
+		files, _ := buildSelection(t, "Unknown.zzz", 10*time.Second, 10*time.Second)
+		var recorded []string
+		tr := newTracker(files, func(path string) error {
+			recorded = append(recorded, path)
+			return nil
+		})
+
+		tr.loadFileSelection()
+
+		assert.Empty(t, recorded)
+	})
+
+	t.Run("a failed record is reported, not fatal", func(t *testing.T) {
+		files, gamePath := buildSelection(t, "Zelda.nes", 10*time.Second, 10*time.Second)
+		var seen string
+		tr := newTracker(files, func(path string) error {
+			seen = path
+			return errors.New("write failed")
+		})
+
+		tr.loadFileSelection()
+
+		assert.Equal(t, gamePath, seen)
+	})
 }


### PR DESCRIPTION
MiSTer never clears `/tmp/FILESELECT` after a launch, and rewrites it again when a core exits. The status stays `selected` while `FULLPATH` and `CURRENTPATH` still name the game that just ended, so `loadFileSelection` read the exit as a fresh manual launch, wrote `ACTIVEGAME`, and the ACTIVEGAME watcher republished the closed game as active about 400ms after it stopped.

Nothing stopped it again, because no further core change was coming. The session stayed open and accrued play time indefinitely against a game that was not running, which also throttled indexing for as long as it lasted.

Captured on a device, exiting Blockade to the menu:

```
CORENAME     MENU                              13:40:27.077
FILESELECT   selected                          13:40:27.327
FULLPATH     /media/fat/_Arcade/Blockade.mra   13:39:56.309
CURRENTPATH  Blockade.mra                      13:39:56.309
```

and the resulting log:

```
core changed  old_core=blockade  new_core=MENU
in menu, stopping game
notification sent: media.stopped
active game is empty, stopping game
manual MiSTer file launch detected  path=/media/fat/_Arcade/Blockade.mra
processing active game
notification sent: media.started
```

The same trace explains the duplicate `manual MiSTer file launch detected` lines seen on a normal launch: every write to that file re-fires the selection.

## Change

`selectionIsStale` compares the `FILESELECT` mtime against the `CURRENTPATH` it claims to describe, and `loadFileSelection` skips a status written more than two seconds later. Both MiSTer and `writeCurrentPathTo` write the trio back to back, so a genuine selection lands well inside that window. A stat failure fails open, since dropping a real launch is worse than a late stop.

The status alone cannot be used as the signal: MiSTer leaves it at `selected` permanently, so there is no transition to detect.

## Verification

`resolveSelectedLaunchPath` covers the read, the staleness gate and path resolution together, so the rule is pinned where it runs rather than only on the predicate: a selection written alongside its paths resolves, one re-notified 31 seconds later does not, and a window that cannot be exceeded still resolves. Removing the gate fails that middle case.

Deployed to a MiSTer and checked three ways:

- writing `FILESELECT` with stale paths logs `ignoring MiSTer file selection re-notified after its paths were written` and publishes nothing;
- a Zaparoo launch of a SNES game still publishes active media, keeping its `launcherId` and original `started`;
- a full launch to stop round trip leaves nothing active, with the guard firing on the exit re-notification.

## Notes

`loadRecent` is the other `ACTIVEGAME` producer and has no equivalent staleness guard. It did not misfire in the traces captured here, and recent files are normally only rewritten on an actual launch, so it is left alone.

The approach of correlating these timestamps is also used by the MiSTer Monitor project. Its MiSTer-side server is AGPL-3.0, so its source was deliberately not consulted; this implementation is derived from the device measurements above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MiSTer file-selection tracking to ignore stale selection notifications after leaving a directory or selection screen.
  * Preserved normal behavior when file timestamps cannot be read.
  * Improved handling of system, menu, unclaimed, and failed selections.

* **Tests**
  * Added comprehensive coverage for current, stale, newer-path, missing-timestamp, and failed-selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
