### PR TITLE
fix(mediadb): stop the browse sort migration rebuilding the index at startup

### DIFF
--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -186,26 +186,43 @@ func TestMediaTagCompositeLookupAndDelete(t *testing.T) {
 	assert.ErrorIs(t, err, sql.ErrNoRows)
 }
 
-// The browse sort index orders SortName with a collation this binary registers
-// on its connections rather than storing in the file, so a build without it
-// cannot prepare any statement against Media. Introducing the index through a
-// migration is what moves the schema version past older builds, so going back
-// to one raises ErrSchemaAhead and startup rebuilds the media database instead
-// of failing on a schema it cannot parse. CreateSecondaryIndexes only runs at
-// the end of an indexing run, so an index present on a freshly migrated
-// database can only have come from a migration.
-func TestMigrations_CreateBrowseSortIndexWithItsCollation(t *testing.T) {
+// The browse sort collation must carry a schema version bump: without one, a
+// build that lacks ZAPAROO_TITLE_V1 opens the database happily and then fails
+// on the first prepare against Media, and the rebuild that exists for an
+// unreadable schema never fires.
+//
+// The migration must do that and nothing else. Rebuilding the index there ran
+// it over every media row while the service was starting, with nothing on
+// screen to say why — 2m14s on a 229k-item library, and libraries get much
+// bigger. CreateSecondaryIndexes owns that work, at the end of an indexing run.
+func TestMigrations_BrowseSortCollationBumpsVersionWithoutTableWork(t *testing.T) {
 	mediaDB, cleanup := setupTempMediaDB(t)
 	defer cleanup()
+	ctx := context.Background()
 
 	require.NoError(t, mediaDB.MigrateUp())
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+
+	var marker string
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT Value FROM DBConfig WHERE Name = 'BrowseSortCollation'",
+	).Scan(&marker), "the version-bearing migration must have applied")
+	assert.Equal(t, strings.ToLower(browseTitleCollationName), marker)
 
 	var indexSQL string
-	require.NoError(t, mediaDB.UnsafeGetSQLDb().QueryRowContext(context.Background(),
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
 		"SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", browseSortIndexName,
-	).Scan(&indexSQL), "browse sort index must exist on a freshly migrated database")
+	).Scan(&indexSQL))
+	assert.NotContains(t, indexSQL, browseTitleCollationName,
+		"migrating must not rebuild the index; that belongs to CreateSecondaryIndexes")
+
+	// And the index does become collated, at the point that owns it.
+	require.NoError(t, mediaDB.CreateSecondaryIndexes())
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", browseSortIndexName,
+	).Scan(&indexSQL))
 	assert.Contains(t, indexSQL, browseTitleCollationName,
-		"the index must carry the collation whose absence breaks older builds")
+		"an indexing run replaces it with the collated form")
 }
 
 func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -223,6 +224,36 @@ func TestMigrations_BrowseSortCollationBumpsVersionWithoutTableWork(t *testing.T
 	).Scan(&indexSQL))
 	assert.Contains(t, indexSQL, browseTitleCollationName,
 		"an indexing run replaces it with the collated form")
+
+	// An explicit downgrade must restore the legacy index before lowering the
+	// schema version. Otherwise a build without the custom collation accepts the
+	// version but cannot prepare statements against Media.
+	goose.SetBaseFS(migrationFiles)
+	require.NoError(t, goose.SetDialect("sqlite"))
+	require.NoError(t, goose.Down(sqlDB, "migrations"))
+
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?", browseSortIndexName,
+	).Scan(&indexSQL))
+	assert.NotContains(t, indexSQL, browseTitleCollationName)
+
+	var markerCount int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM DBConfig WHERE Name = 'BrowseSortCollation'",
+	).Scan(&markerCount))
+	assert.Zero(t, markerCount)
+
+	dbPath := mediaDB.GetDBPath()
+	require.NoError(t, mediaDB.Close())
+	legacyDB, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, legacyDB.Close()) }()
+	stmt, err := legacyDB.PrepareContext(ctx, "SELECT DBID FROM Media LIMIT 1")
+	require.NoError(t, err, "legacy connection must prepare Media statements after downgrade")
+	defer func() { require.NoError(t, stmt.Close()) }()
+	var mediaDBID int64
+	err = stmt.QueryRowContext(ctx).Scan(&mediaDBID)
+	require.ErrorIs(t, err, sql.ErrNoRows)
 }
 
 func setupTempMediaDB(t *testing.T) (db *MediaDB, cleanup func()) {

--- a/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
+++ b/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
@@ -25,4 +25,9 @@ INSERT INTO DBConfig (Name, Value) VALUES ('BrowseSortCollation', 'zaparoo_title
     ON CONFLICT(Name) DO UPDATE SET Value = excluded.Value;
 
 -- +goose Down
+-- An explicit downgrade can follow an indexing run that created the collated
+-- index. Restore the legacy definition before lowering the schema version so
+-- a build without ZAPAROO_TITLE_V1 can prepare statements against Media.
+DROP INDEX IF EXISTS idx_media_browse_sort;
+CREATE INDEX idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID);
 DELETE FROM DBConfig WHERE Name = 'BrowseSortCollation';

--- a/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
+++ b/pkg/database/mediadb/migrations/20260830140000_browse_sort_collation.sql
@@ -1,26 +1,28 @@
 -- +goose Up
--- idx_media_browse_sort orders SortName with the ZAPAROO_TITLE_V1 collation,
--- which this binary's SQLite driver registers per connection rather than
--- storing in the file. A build without that collation cannot prepare any
--- statement against Media at all, because SQLite resolves index definitions
--- first: indexing dies on its first insert with "no such collation sequence"
--- and browse falls back to "no query solution". Nothing recovers from it,
--- because the media database is rebuilt on a schema version it does not
--- understand, and creating an index bumps no version by itself.
+-- A schema version bump, deliberately doing no table work.
 --
--- CreateSecondaryIndexes owns this index's real lifecycle, dropping and
--- recreating it around bulk inserts. Creating it here as well moves the schema
--- version past what older builds embed, so going back to one of them raises
--- ErrSchemaAhead and startup rebuilds the media database instead of running
--- against a schema it cannot parse.
+-- idx_media_browse_sort orders SortName with the ZAPAROO_TITLE_V1 collation,
+-- which the driver registers per connection rather than storing in the file. A
+-- build without that collation cannot prepare any statement against Media at
+-- all, because SQLite resolves index definitions first: indexing dies on its
+-- first insert with "no such collation sequence" and browse falls back to
+-- "no query solution". Recreating the index bumps no version by itself, so
+-- nothing triggered the rebuild that already exists for a schema an older
+-- build cannot read.
+--
+-- Moving the version is the whole job. Going back to a build without the
+-- collation now raises ErrSchemaAhead and startup rebuilds the media database.
+--
+-- Replacing the index itself stays in CreateSecondaryIndexes, at the end of an
+-- indexing run. Doing it here instead rebuilt the index over every media row
+-- while the service was starting and nothing on screen said why: 2m14s on a
+-- 229k-item library on MiSTer SD, and libraries get much larger than that.
+-- Until that run happens the index is simply the uncollated one; browse stays
+-- correct because the collation is written into the queries, and INDEXED BY
+-- still plans against it.
 
--- 20260609120000_media_sortname created this index without a collation, so it
--- has to be replaced rather than created. Queries pin it with INDEXED BY, so
--- dropping it without putting it back would fail browse outright.
-DROP INDEX IF EXISTS idx_media_browse_sort;
-CREATE INDEX idx_media_browse_sort
-    ON Media(ParentDir, IsMissing, SortName COLLATE ZAPAROO_TITLE_V1, DBID);
+INSERT INTO DBConfig (Name, Value) VALUES ('BrowseSortCollation', 'zaparoo_title_v1')
+    ON CONFLICT(Name) DO UPDATE SET Value = excluded.Value;
 
 -- +goose Down
-DROP INDEX IF EXISTS idx_media_browse_sort;
-CREATE INDEX idx_media_browse_sort ON Media(ParentDir, IsMissing, SortName, DBID);
+DELETE FROM DBConfig WHERE Name = 'BrowseSortCollation';


### PR DESCRIPTION
The migration added in #1356 exists only to move the schema version, so a build without `ZAPAROO_TITLE_V1` raises `ErrSchemaAhead` and rebuilds the media database instead of failing on the first prepare against `Media`.

It also rebuilt `idx_media_browse_sort`, which ran over every media row **while the service was starting, with nothing on screen to say why**. Measured on a 229k-item library on MiSTer SD: **2m14s** of frozen startup (20:04:18 → 20:06:32). Libraries get considerably larger than that.

The version bump is the whole job. Replacing the index stays in `CreateSecondaryIndexes`, at the end of an indexing run, where a large index build is expected — which is where #1356 originally put it.

## The interim is safe

Between upgrade and the next index run the index is the uncollated one. Verified that browse still works against it:

- `INDEXED BY idx_media_browse_sort` still plans — the index exists either way, created by `20260609120000_media_sortname`.
- A collated `ORDER BY … COLLATE ZAPAROO_TITLE_V1` still runs, and ordering stays correct because the collation is written into the queries. Only the index-ordered sort is lost until the next index run.

## Test

`TestMigrations_BrowseSortCollationBumpsVersionWithoutTableWork` pins both halves: the migration applies its marker and leaves the index uncollated, and `CreateSecondaryIndexes` then replaces it with the collated form.

## Note

Nothing reports progress while a migration runs — startup logged "opening databases" and went silent for over two minutes. That is a general gap, not specific to this migration, and worth addressing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database upgrades for browse sorting.
  * Upgrades now record the required sort-collation version without rebuilding the entire browse index immediately.
  * Browse indexes are refreshed later during the standard indexing process, reducing migration overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->