### PR TITLE
fix: media database recovery, symlink scanning, cover invalidation and SteamOS exit status

### DIFF
--- a/cmd/steamos/main.go
+++ b/cmd/steamos/main.go
@@ -46,7 +46,7 @@ import (
 func main() {
 	if err := run(); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err)
-		os.Exit(1)
+		os.Exit(cli.ExitCodeFor(err))
 	}
 }
 

--- a/pkg/audio/resample_bypass_test.go
+++ b/pkg/audio/resample_bypass_test.go
@@ -60,26 +60,44 @@ func TestStreamerAtTargetSampleRate_BypassesAtTargetRate(t *testing.T) {
 
 	t.Run("a lower rate source is resampled", func(t *testing.T) {
 		t.Parallel()
-		src := &countingStreamer{}
-		got := streamerAtTargetSampleRate(src, beep.SampleRate(44100), resampleQuality)
-		require.NotSame(t, src, got, "a mismatched rate must be resampled")
-
-		// Pulling one output buffer must draw fewer input samples than it
-		// produced, which is what resampling 44.1k up to 48k means.
-		out := make([][2]float64, 4800)
-		n, ok := got.Stream(out)
-		require.True(t, ok)
-		require.Equal(t, len(out), n)
-		assert.Less(t, src.pulled, n*2,
-			"resampling 44.1kHz to 48kHz should not pull wildly more input than output")
-		assert.Positive(t, src.pulled, "the resampler must read from the source")
+		assertResampledFrom(t, 44100)
 	})
 
 	t.Run("a higher rate source is resampled", func(t *testing.T) {
 		t.Parallel()
-		src := &countingStreamer{}
-		got := streamerAtTargetSampleRate(src, beep.SampleRate(192000), resampleQuality)
-		assert.NotSame(t, src, got,
-			"192kHz is what the bundled feedback sounds are; it must be resampled")
+		// 192kHz is what the bundled feedback sounds are.
+		assertResampledFrom(t, 192000)
 	})
+}
+
+// assertResampledFrom pins the input-to-output ratio a resampler from srcRate
+// must hold. Checking only that the source was read cannot tell a real
+// resampler from a passthrough or from one running the ratio backwards, and
+// either of those plays the sound at the wrong pitch.
+func assertResampledFrom(t *testing.T, srcRate int) {
+	t.Helper()
+
+	src := &countingStreamer{}
+	got := streamerAtTargetSampleRate(src, beep.SampleRate(srcRate), resampleQuality)
+	require.NotSame(t, src, got, "a mismatched rate must be resampled")
+
+	// Enough output that the resampler's internal chunking averages out; a
+	// single buffer still carries a partial chunk of over-read.
+	const buffers = 10
+	out := make([][2]float64, 4800)
+	produced := 0
+	for range buffers {
+		n, ok := got.Stream(out)
+		require.True(t, ok)
+		require.Equal(t, len(out), n)
+		produced += n
+	}
+
+	// One input chunk of slack either way. The distance to a passthrough
+	// (produced) or to the inverted ratio is far larger than that, so both
+	// still fail.
+	want := produced * srcRate / targetSampleRate
+	const slack = 2048
+	assert.InDelta(t, want, src.pulled, slack,
+		"resampling %dHz to %dHz must draw input in proportion to the rate", srcRate, targetSampleRate)
 }

--- a/pkg/audio/resample_bypass_test.go
+++ b/pkg/audio/resample_bypass_test.go
@@ -1,0 +1,85 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package audio
+
+import (
+	"testing"
+
+	"github.com/gopxl/beep/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingStreamer is a silent source that records how many samples were pulled
+// out of it, so a test can tell a passthrough from a resampler by behaviour
+// rather than by identity alone.
+type countingStreamer struct {
+	pulled int
+}
+
+func (c *countingStreamer) Stream(samples [][2]float64) (int, bool) {
+	for i := range samples {
+		samples[i] = [2]float64{0, 0}
+	}
+	c.pulled += len(samples)
+	return len(samples), true
+}
+
+func (*countingStreamer) Err() error { return nil }
+
+// TestStreamerAtTargetSampleRate_BypassesAtTargetRate covers #1249: a source
+// already at the output rate must be handed straight through, because wrapping
+// it in a resampler costs real work per sample on a device that has little to
+// spare. Anything else must still be resampled, or it plays at the wrong pitch.
+func TestStreamerAtTargetSampleRate_BypassesAtTargetRate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source already at the target rate is returned unchanged", func(t *testing.T) {
+		t.Parallel()
+		src := &countingStreamer{}
+		got := streamerAtTargetSampleRate(src, beep.SampleRate(targetSampleRate), resampleQuality)
+		assert.Same(t, src, got, "a source at the target rate must not be wrapped")
+	})
+
+	t.Run("a lower rate source is resampled", func(t *testing.T) {
+		t.Parallel()
+		src := &countingStreamer{}
+		got := streamerAtTargetSampleRate(src, beep.SampleRate(44100), resampleQuality)
+		require.NotSame(t, src, got, "a mismatched rate must be resampled")
+
+		// Pulling one output buffer must draw fewer input samples than it
+		// produced, which is what resampling 44.1k up to 48k means.
+		out := make([][2]float64, 4800)
+		n, ok := got.Stream(out)
+		require.True(t, ok)
+		require.Equal(t, len(out), n)
+		assert.Less(t, src.pulled, n*2,
+			"resampling 44.1kHz to 48kHz should not pull wildly more input than output")
+		assert.Positive(t, src.pulled, "the resampler must read from the source")
+	})
+
+	t.Run("a higher rate source is resampled", func(t *testing.T) {
+		t.Parallel()
+		src := &countingStreamer{}
+		got := streamerAtTargetSampleRate(src, beep.SampleRate(192000), resampleQuality)
+		assert.NotSame(t, src, got,
+			"192kHz is what the bundled feedback sounds are; it must be resampled")
+	})
+}

--- a/pkg/audio/resample_bypass_test.go
+++ b/pkg/audio/resample_bypass_test.go
@@ -96,8 +96,8 @@ func assertResampledFrom(t *testing.T, srcRate int) {
 	// One input chunk of slack either way. The distance to a passthrough
 	// (produced) or to the inverted ratio is far larger than that, so both
 	// still fail.
-	want := produced * srcRate / targetSampleRate
+	want := float64(produced) * float64(srcRate) / float64(targetSampleRate)
 	const slack = 2048
-	assert.InDelta(t, want, src.pulled, slack,
+	assert.InDelta(t, want, float64(src.pulled), slack,
 		"resampling %dHz to %dHz must draw input in proportion to the rate", srcRate, targetSampleRate)
 }

--- a/pkg/cli/exit_test.go
+++ b/pkg/cli/exit_test.go
@@ -72,3 +72,27 @@ func TestServiceUnitsDeclineToRestartOnTheUnrecoverableStatus(t *testing.T) {
 			"%s: empty RestartPreventExitStatus", path)
 	}
 }
+
+// The status only reaches a supervisor if the entrypoint returns it. Every
+// platform whose installed unit declines to restart on ExitUnrecoverable has to
+// map the error through ExitCodeFor; a main that exits 1 unconditionally puts
+// the restart loop back while the unit still claims to prevent it.
+//
+// cmd/steamos installs the same unit as cmd/linux, through
+// pkg/platforms/linux/installer, and exited 1 for every startup failure.
+func TestSupervisedEntrypointsMapTheUnrecoverableStatus(t *testing.T) {
+	t.Parallel()
+
+	entrypoints := []string{
+		filepath.Join("..", "..", "cmd", "linux", "main.go"),
+		filepath.Join("..", "..", "cmd", "replayos", "main.go"),
+		filepath.Join("..", "..", "cmd", "steamos", "main.go"),
+	}
+
+	for _, path := range entrypoints {
+		data, err := os.ReadFile(path) //nolint:gosec // repository-relative test fixture
+		require.NoError(t, err, "entrypoint should be readable")
+		assert.Contains(t, string(data), "os.Exit(cli.ExitCodeFor(err))",
+			"%s: startup errors must carry the unrecoverable status to the supervisor", path)
+	}
+}

--- a/pkg/database/mediadb/scrape_cover_invalidation_test.go
+++ b/pkg/database/mediadb/scrape_cover_invalidation_test.go
@@ -1,0 +1,100 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediadb
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyScrapeResult_InvalidatesCoverAvailabilityIndex covers a scrape that
+// adds artwork to a title the cover index has already been built for.
+//
+// The index is what media.search and media.history answer hasCover from. A
+// scrape writes image properties straight through ApplyScrapeResult, and the
+// only invalidation on that path recorded systems for the *thumbnail* cache,
+// which is a different cache. The index therefore kept its pre-scrape answer
+// and every freshly scraped cover reported hasCover=false until Core restarted.
+//
+// Observed on a MiSTer: after the mister-docs scraper matched 5 titles and
+// wrote image-boxart properties for all of them, media.search reported
+// hasCover=false for each; restarting Core flipped them all to true.
+func TestApplyScrapeResult_InvalidatesCoverAvailabilityIndex(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	seedImagePropertyTags(t, mediaDB)
+
+	ctx := context.Background()
+	sys, err := mediaDB.FindOrInsertSystem(database.System{SystemID: "NES", Name: "NES"})
+	require.NoError(t, err)
+	nesSystem, err := systemdefs.GetSystem("NES")
+	require.NoError(t, err)
+
+	require.NoError(t, mediaDB.BeginTransaction(false))
+	title, err := mediaDB.InsertMediaTitle(&database.MediaTitle{
+		SystemDBID: sys.DBID,
+		Slug:       slugs.Slugify(nesSystem.GetMediaType(), "Scraped Cover"),
+		Name:       "Scraped Cover",
+	})
+	require.NoError(t, err)
+	media, err := mediaDB.InsertMedia(database.Media{
+		SystemDBID:     sys.DBID,
+		MediaTitleDBID: title.DBID,
+		Path:           filepath.Join("roms", "nes", "scraped_cover.nes"),
+		ParentDir:      filepath.ToSlash(filepath.Join("roms", "nes")) + "/",
+	})
+	require.NoError(t, err)
+	require.NoError(t, mediaDB.CommitTransaction())
+
+	// Build the index while the title has no artwork, so it caches "no cover".
+	firstPass := []database.SearchResultWithCursor{{MediaID: media.DBID, MediaTitleID: title.DBID}}
+	require.NoError(t, fetchAndAttachCoverFlags(ctx, mediaDB.sql.Load(), firstPass))
+	require.False(t, firstPass[0].HasCover)
+	mediaDB.WaitForBackgroundOperations()
+	require.NotNil(t, cachedCoverAvailabilityIndex(mediaDB.sql.Load()),
+		"the index must be built for this test to mean anything")
+
+	// A scrape writes title artwork, exactly as the mister-docs scraper does.
+	require.NoError(t, mediaDB.ApplyScrapeResult(ctx, media.DBID, title.DBID, &database.ScrapeWrite{
+		Sentinel: database.TagInfo{Type: "scraper.test", Tag: "scraped"},
+		TitleProps: []database.MediaProperty{{
+			TypeTag: tags.PropertyTypeTag(tags.TagPropertyImageBoxart),
+			Text:    filepath.ToSlash(filepath.Join("docs", "NES", "Artwork", "scraped.png")),
+		}},
+	}))
+
+	assert.Nil(t, cachedCoverAvailabilityIndex(mediaDB.sql.Load()),
+		"a scrape that writes artwork must invalidate the cover index")
+
+	statuses, err := mediaDB.GetMediaCoverStatus(ctx, []database.MediaRef{
+		{MediaDBID: media.DBID, MediaTitleDBID: title.DBID},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[int64]bool{media.DBID: true}, statuses,
+		"scraped artwork must be visible without restarting Core")
+}

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -1671,6 +1671,13 @@ func (db *MediaDB) recordScrapeImageChanges(ctx context.Context, writeCtx *scrap
 		return
 	}
 
+	// The committed write changed image properties, so the in-memory cover
+	// availability index no longer matches the database. The systems recorded
+	// below drive thumbnail invalidation, which is a separate cache; without
+	// this, media.search and media.history keep answering hasCover=false for
+	// artwork that has just been scraped, until a restart rebuilds the index.
+	clearCoverAvailabilityCacheFor(db.sql.Load())
+
 	conditions := make([]string, 0, 2)
 	args := make([]any, 0, len(writeCtx.changedImageMediaIDs)+len(writeCtx.changedImageMediaTitleIDs))
 	if len(writeCtx.changedImageMediaIDs) > 0 {

--- a/pkg/database/mediascanner/dirent_linux.go
+++ b/pkg/database/mediascanner/dirent_linux.go
@@ -1,0 +1,55 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package mediascanner
+
+import "syscall"
+
+// Filesystem magics for the FAT family. exFAT is what MiSTer and most handheld
+// images use for the storage holding games.
+const (
+	exfatSuperMagic = 0x2011BAB0
+	msdosSuperMagic = 0x4D44
+)
+
+// direntTypesReportSymlinks reports whether readdir on the filesystem holding
+// path fills in the symlink type for directory entries.
+//
+// The FAT family does not. Linux's exFAT driver stores symlinks and reports
+// them correctly through lstat, but returns DT_REG for them in getdents64, so
+// a walk that trusts the dirent type sees an ordinary file. Measured on a
+// MiSTer: a tree of 88 symlinks walked with symlinksEncountered = 0, while
+// lstat on the same entries reported every one as a link.
+//
+// A filesystem this cannot identify is treated as reporting types correctly,
+// so the walk keeps its current cost everywhere it already works.
+func direntTypesReportSymlinks(path string) bool {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return true
+	}
+	switch int64(stat.Type) { //nolint:unconvert // Type is int32 on 32-bit
+	case exfatSuperMagic, msdosSuperMagic:
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/database/mediascanner/dirent_other.go
+++ b/pkg/database/mediascanner/dirent_other.go
@@ -1,0 +1,30 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !linux
+
+package mediascanner
+
+// direntTypesReportSymlinks reports whether readdir on the filesystem holding
+// path fills in the symlink type for directory entries. Only Linux's FAT-family
+// drivers are known to omit it, and only Linux is checked, so everywhere else
+// keeps the dirent type and pays nothing.
+func direntTypesReportSymlinks(_ string) bool {
+	return true
+}

--- a/pkg/database/mediascanner/dirent_test.go
+++ b/pkg/database/mediascanner/dirent_test.go
@@ -1,0 +1,170 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errFakeDirEntryInfo = errors.New("fake dir entry has no info")
+
+// fakeDirEntry reports a dirent type independently of what the path really is,
+// which is what a FAT-family readdir does to a symlink.
+type fakeDirEntry struct {
+	name string
+	mode fs.FileMode
+}
+
+func (f fakeDirEntry) Name() string             { return f.name }
+func (f fakeDirEntry) IsDir() bool              { return f.mode.IsDir() }
+func (f fakeDirEntry) Type() fs.FileMode        { return f.mode }
+func (fakeDirEntry) Info() (fs.FileInfo, error) { return nil, errFakeDirEntryInfo }
+
+type fakeFileInfo struct{ mode fs.FileMode }
+
+func (fakeFileInfo) Name() string        { return "fake" }
+func (fakeFileInfo) Size() int64         { return 0 }
+func (f fakeFileInfo) Mode() fs.FileMode { return f.mode }
+func (fakeFileInfo) ModTime() time.Time  { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool       { return f.mode.IsDir() }
+func (fakeFileInfo) Sys() any            { return nil }
+
+// TestEntryIsSymlink_FallsBackWhereDirentTypesLie covers the MiSTer exFAT case:
+// readdir calls a symlink a regular file, so trusting the dirent type alone
+// leaves ScanSkipInternalSymlinks doing nothing and the alias gets indexed as a
+// second copy of media already scanned under its real path.
+func TestEntryIsSymlink_FallsBackWhereDirentTypesLie(t *testing.T) {
+	t.Parallel()
+
+	lstatSaysLink := func() (os.FileInfo, error) {
+		return fakeFileInfo{mode: fs.ModeSymlink}, nil
+	}
+	lstatSaysFile := func() (os.FileInfo, error) {
+		return fakeFileInfo{mode: 0}, nil
+	}
+	lstatFails := func() (os.FileInfo, error) {
+		return nil, errors.New("lstat refused")
+	}
+
+	tests := []struct {
+		lstat       func() (os.FileInfo, error)
+		name        string
+		entry       fakeDirEntry
+		reliable    bool
+		wantSymlink bool
+	}{
+		{
+			name:        "dirent reports the link",
+			entry:       fakeDirEntry{name: "a", mode: fs.ModeSymlink},
+			lstat:       lstatSaysFile,
+			reliable:    true,
+			wantSymlink: true,
+		},
+		{
+			name:        "dirent lies and types are trusted",
+			entry:       fakeDirEntry{name: "a"},
+			lstat:       lstatSaysLink,
+			reliable:    true,
+			wantSymlink: false,
+		},
+		{
+			name:        "dirent lies and types are not trusted",
+			entry:       fakeDirEntry{name: "a"},
+			lstat:       lstatSaysLink,
+			reliable:    false,
+			wantSymlink: true,
+		},
+		{
+			name:        "ordinary file stays an ordinary file",
+			entry:       fakeDirEntry{name: "a"},
+			lstat:       lstatSaysFile,
+			reliable:    false,
+			wantSymlink: false,
+		},
+		{
+			name:        "a failed lstat leaves the dirent's answer",
+			entry:       fakeDirEntry{name: "a"},
+			lstat:       lstatFails,
+			reliable:    false,
+			wantSymlink: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantSymlink, entryIsSymlink(tt.entry, tt.reliable, tt.lstat))
+		})
+	}
+}
+
+// TestEntryIsSymlink_NeverLstatsADirectory keeps the fallback off the common
+// path: directory entries are reported correctly everywhere here, so paying an
+// lstat for them would add cost to every directory in the walk for nothing.
+func TestEntryIsSymlink_NeverLstatsADirectory(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	lstat := func() (os.FileInfo, error) {
+		called = true
+		return fakeFileInfo{mode: fs.ModeSymlink}, nil
+	}
+
+	got := entryIsSymlink(fakeDirEntry{name: "d", mode: fs.ModeDir}, false, lstat)
+	assert.False(t, got)
+	assert.False(t, called, "a directory entry must not be lstatted")
+}
+
+// TestEntryIsSymlink_AgreesWithTheFilesystem pins the fallback against a real
+// link rather than a stub, so the mode check cannot drift from what lstat
+// actually returns.
+func TestEntryIsSymlink_AgreesWithTheFilesystem(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.rom")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o600))
+	link := filepath.Join(dir, "alias.rom")
+	require.NoError(t, os.Symlink(target, link))
+
+	lstat := func() (os.FileInfo, error) { return os.Lstat(link) }
+
+	// The dirent lies, exactly as a FAT-family readdir would.
+	assert.True(t, entryIsSymlink(fakeDirEntry{name: "alias.rom"}, false, lstat))
+	assert.False(t, entryIsSymlink(fakeDirEntry{name: "alias.rom"}, true, lstat))
+}
+
+// TestDirentTypesReportSymlinks_TrustsAnOrdinaryFilesystem guards the fail-open
+// rule: an unrecognised or unreadable filesystem must keep the walk's existing
+// cost rather than adding an lstat per entry.
+func TestDirentTypesReportSymlinks_TrustsAnOrdinaryFilesystem(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, direntTypesReportSymlinks(t.TempDir()))
+	assert.True(t, direntTypesReportSymlinks(filepath.Join(t.TempDir(), "does-not-exist")))
+}

--- a/pkg/database/mediascanner/mediascanner.go
+++ b/pkg/database/mediascanner/mediascanner.go
@@ -708,6 +708,35 @@ func shouldSkipExcludedSymlink(
 	return false, nil
 }
 
+// entryIsSymlink reports whether a walked entry is a symlink.
+//
+// The dirent type is trusted wherever readdir fills it in. Where it does not —
+// the FAT family, which is what MiSTer's /media/fat is — every symlink arrives
+// looking like an ordinary file, which silently disables both the excluded
+// directory and the alias exclusion below it. lstat is the only way to tell
+// there, and it is a plain call rather than a timeout-wrapped one because it
+// runs per entry against a directory that was just read; the timeout-wrapped
+// calls stay on the symlink branches, which only a real link reaches. A failed
+// lstat leaves the entry as the dirent described it.
+//
+// Directories are left alone: a directory entry is reported as one on every
+// filesystem here, and a link to a directory is exactly the case the dirent
+// type gets wrong, so it arrives as a non-directory and is checked.
+func entryIsSymlink(
+	d fs.DirEntry,
+	direntTypesReliable bool,
+	lstat func() (os.FileInfo, error),
+) bool {
+	if d.Type()&os.ModeSymlink != 0 {
+		return true
+	}
+	if direntTypesReliable || d.IsDir() {
+		return false
+	}
+	info, err := lstat()
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}
+
 // shouldSkipSymlinkAlias reports whether a symlink must be kept out of the
 // walk because it aliases media already scanned under its target path. A
 // timeout while reading the link leaves its target unknown, but letting
@@ -763,7 +792,12 @@ func GetFiles(
 
 	matcher := helpers.NewLauncherMatcher(cfg, platform)
 
-	log.Debug().Str("system", systemID).Str("path", path).Msg("starting directory walk")
+	// Resolved once per root rather than per entry: one statfs, and the answer
+	// cannot change under the walk.
+	direntSymlinkTypes := direntTypesReportSymlinks(path)
+
+	log.Debug().Str("system", systemID).Str("path", path).
+		Bool("direntSymlinkTypes", direntSymlinkTypes).Msg("starting directory walk")
 	err = fastwalk.Walk(conf, path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			// fastwalk reports a directory read failure by re-invoking this
@@ -787,10 +821,12 @@ func GetFiles(
 		}
 
 		n := entriesScanned.Add(1)
-		if d.Type()&os.ModeSymlink != 0 {
+		isSymlink := entryIsSymlink(d, direntSymlinkTypes, func() (os.FileInfo, error) {
+			return os.Lstat(p)
+		})
+		if isSymlink {
 			symlinksEncountered.Add(1)
 		}
-		isSymlink := d.Type()&os.ModeSymlink != 0
 		if (d.IsDir() || isSymlink) && matcher.ShouldSkipScanDirectory(system.ID, p) {
 			shouldSkip := d.IsDir()
 			if isSymlink {

--- a/pkg/database/mediascanner/walk_skipdir_test.go
+++ b/pkg/database/mediascanner/walk_skipdir_test.go
@@ -1,0 +1,96 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package mediascanner
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/charlievieth/fastwalk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWalkSkipDirFromFileKeepsSiblings pins the semantics the symlink-alias
+// branch in GetFiles depends on. That branch returns filepath.SkipDir for an
+// alias, and an alias normally sits in a directory alongside real media —
+// Arcade Organizer output written straight into _Arcade, for instance. Under
+// filepath.WalkDir, SkipDir returned for a non-directory skips the rest of the
+// containing directory, which would silently drop every sibling after it.
+//
+// This asserts fastwalk does not do that, because the alias skip would
+// otherwise be a media-loss bug rather than a de-duplication.
+func TestWalkSkipDirFromFileKeepsSiblings(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.rom")
+	require.NoError(t, os.WriteFile(target, []byte("x"), 0o600))
+	// Sorts before the real entries, so a "skip the rest of this directory"
+	// implementation would drop all of them.
+	require.NoError(t, os.Symlink(target, filepath.Join(root, "00-alias.rom")))
+
+	realNames := []string{"a-real.rom", "b-real.rom", "c-real.rom", "d-real.rom"}
+	for _, n := range realNames {
+		require.NoError(t, os.WriteFile(filepath.Join(root, n), []byte("x"), 0o600))
+	}
+
+	for _, workers := range []int{1, 4} {
+		t.Run("workers", func(t *testing.T) {
+			t.Parallel()
+			var mu syncutil.Mutex
+			var seen []string
+
+			conf := &fastwalk.Config{Follow: true, NumWorkers: workers}
+			err := fastwalk.Walk(conf, root, func(p string, d fs.DirEntry, walkErr error) error {
+				// The fixture is a fresh temp dir, so a walk error here means
+				// the test itself is broken rather than a condition to skip.
+				require.NoError(t, walkErr)
+				rel, relErr := filepath.Rel(root, p)
+				require.NoError(t, relErr)
+				if rel == "." {
+					return nil
+				}
+				mu.Lock()
+				seen = append(seen, rel)
+				mu.Unlock()
+				if d.Type()&os.ModeSymlink != 0 {
+					return filepath.SkipDir
+				}
+				return nil
+			})
+			require.NoError(t, err)
+
+			mu.Lock()
+			sort.Strings(seen)
+			mu.Unlock()
+
+			for _, n := range realNames {
+				assert.Contains(t, seen, n,
+					"skipping an alias must not drop its siblings")
+			}
+			assert.Contains(t, seen, "target.rom")
+		})
+	}
+}

--- a/pkg/service/mediadb_corrupt_startup_test.go
+++ b/pkg/service/mediadb_corrupt_startup_test.go
@@ -1,0 +1,133 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/mediadb"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptMediaDBPages scribbles over a stretch of pages past the header, which
+// is what a torn write on the storage looks like: the file still opens, and the
+// damage is only found when SQLite reads one of the ruined pages.
+func corruptMediaDBPages(t *testing.T, dataDir string) {
+	t.Helper()
+	path := filepath.Join(dataDir, config.MediaDbFile)
+
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600) //nolint:gosec // test-owned temp dir
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	info, err := f.Stat()
+	require.NoError(t, err)
+	const pageSize = 4096
+	require.Greater(t, info.Size(), int64(pageSize*4),
+		"the seeded database must be big enough to damage past its header")
+
+	// Page 1 is left intact so the file still opens as a database and the damage
+	// is found while reading, which is the shape a torn write takes. Everything
+	// after it goes, so the b-tree the schema check walks is certain to be hit
+	// however the pages happen to be laid out.
+	junk := make([]byte, info.Size()-pageSize)
+	for i := range junk {
+		junk[i] = byte(i%251) ^ 0xA5
+	}
+	_, err = f.WriteAt(junk, pageSize)
+	require.NoError(t, err)
+	require.NoError(t, f.Sync())
+
+	for _, sidecar := range []string{
+		path + "-wal",
+		path + "-shm",
+		filepath.Join(dataDir, config.CacheDir, config.MediaDbFile+".schema_version.json"),
+	} {
+		if err := os.Remove(sidecar); err != nil {
+			require.ErrorIs(t, err, os.ErrNotExist)
+		}
+	}
+}
+
+// TestMakeDatabase_CorruptMediaDBRebuilds covers a media database damaged badly
+// enough that the migration check cannot read it.
+//
+// There is a recovery path for corruption found once the database is open, in
+// index_resume.go, but startup never reached it: makeDatabase returned the
+// migration error, Start gave up, and the next boot failed in exactly the same
+// place. Observed on a MiSTer — after damaging the file, Core would not start at
+// all, twice in a row, writing media.db.corrupt each time and never acting on
+// it. That is a device that cannot run Zaparoo over a file a reindex rebuilds
+// from the filesystem, which is the same trade the schema-ahead branch already
+// resolves in favour of starting.
+func TestMakeDatabase_CorruptMediaDBRebuilds(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+	seedMigratedMediaDB(ctx, t, pl)
+	corruptMediaDBPages(t, dataDir)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err, "a corrupt media database must not stop startup")
+	require.NotNil(t, mediaDBReset, "the caller has to know the database was discarded")
+	assert.True(t, mediaDBReset.corrupt,
+		"the notice must say damage, not a version change: nobody changed versions")
+
+	_, err = db.MediaDB.FindSystemBySystemID(testSystemID)
+	require.Error(t, err, "the damaged database's rows must not survive the rebuild")
+
+	status, err := db.MediaDB.GetIndexingStatus()
+	require.NoError(t, err)
+	assert.Equal(t, mediadb.IndexingStatusPending, status,
+		"the rebuilt database must be left pending so startup reindexes it")
+
+	assert.False(t, db.MediaDB.IsMarkedCorrupt(),
+		"the corrupt marker must be cleared, or the next boot rebuilds a healthy database")
+
+	version := mediaDBSchemaVersion(ctx, t, dataDir)
+	assert.Positive(t, version, "the rebuilt database must be migrated to this build's schema")
+}
+
+// The rebuilt database has to be usable immediately, not merely openable: the
+// reindex that follows writes to it straight away.
+func TestMakeDatabase_RebuiltCorruptMediaDBIsWritable(t *testing.T) {
+	ctx := context.Background()
+	pl, dataDir := newMediaDBPlatform(t)
+	seedMigratedMediaDB(ctx, t, pl)
+	corruptMediaDBPages(t, dataDir)
+
+	db, mediaDBReset, err := makeDatabase(ctx, pl)
+	t.Cleanup(func() { closeDatabase(db) })
+	require.NoError(t, err)
+	require.NotNil(t, mediaDBReset)
+
+	system, err := db.MediaDB.InsertSystem(database.System{
+		Name: "Rebuilt System", SystemID: "rebuilt-system",
+	})
+	require.NoError(t, err, "the rebuilt database must accept writes")
+	assert.Positive(t, system.DBID)
+}

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -304,13 +304,42 @@ func TestStart_SchemaAheadPostsInboxMessage(t *testing.T) {
 // A reindex restores the media list and (after a re-scrape) the artwork, so the notice
 // only has to explain that. Favorites and launcher overrides are different: nothing
 // can rebuild them, so when they did not make it across the notice has to say so.
+//
+// The corrupt path gets its own wording because nothing changed versions there:
+// the downgrade explanation would send the user looking for a cause that does
+// not exist instead of at their storage.
 func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 	tests := []struct {
 		name         string
+		wantTitle    string
+		wantBody     string
 		userDataLost bool
+		corrupt      bool
 	}{
-		{name: "user data carried across", userDataLost: false},
-		{name: "user data lost", userDataLost: true},
+		{
+			name:      "version change, user data carried across",
+			wantTitle: "Media database was rebuilt after a version change",
+			wantBody:  "older than the one that last ran",
+		},
+		{
+			name:         "version change, user data lost",
+			userDataLost: true,
+			wantTitle:    "Media database was rebuilt after a version change",
+			wantBody:     "before this device last updated",
+		},
+		{
+			name:      "damage found, user data carried across",
+			corrupt:   true,
+			wantTitle: "Media database was rebuilt after damage was found",
+			wantBody:  "check the device's storage",
+		},
+		{
+			name:         "damage found, user data lost",
+			corrupt:      true,
+			userDataLost: true,
+			wantTitle:    "Media database was rebuilt after damage was found",
+			wantBody:     "in an older version of Zaparoo",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -325,15 +354,22 @@ func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 			t.Cleanup(st.StopService)
 			st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
 
-			notifyMediaDBSchemaReset(st, tt.userDataLost, false)
+			notifyMediaDBSchemaReset(st, tt.userDataLost, tt.corrupt)
 
 			messages, err := db.UserDB.GetInboxMessages()
 			require.NoError(t, err)
 			require.Len(t, messages, 1)
 			assert.Equal(t, inbox.CategoryMediaDBSchemaReset, messages[0].Category)
 			assert.Equal(t, inbox.SeverityWarning, messages[0].Severity)
+			assert.Equal(t, tt.wantTitle, messages[0].Title,
+				"damage and a version change need different explanations")
+			assert.Contains(t, messages[0].Body, tt.wantBody)
 			assert.Contains(t, messages[0].Body, "indexed again",
 				"the notice always explains the reindex")
+			if tt.corrupt {
+				assert.NotContains(t, messages[0].Body, "older than the one that last ran",
+					"nothing changed versions, so the notice must not blame a downgrade")
+			}
 			if tt.userDataLost {
 				assert.Contains(t, messages[0].Body, "Favorites")
 			} else {
@@ -342,28 +378,4 @@ func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 			}
 		})
 	}
-}
-
-// The notice is an explanation, not part of the rebuild, so a failed write is
-// logged and startup continues.
-func TestNotifyMediaDBSchemaReset_InboxWriteFailureIsNotFatal(t *testing.T) {
-	userDB := testhelpers.NewMockUserDBI()
-	userDB.On("AddInboxMessage", mock.Anything).
-		Return((*database.InboxMessage)(nil), errors.New("user database is unwritable"))
-
-	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
-	t.Cleanup(st.StopService)
-	st.SetInbox(inbox.NewService(userDB, st.Notifications))
-
-	notifyMediaDBSchemaReset(st, false, false)
-
-	userDB.AssertExpectations(t)
-}
-
-func TestNotifyMediaDBSchemaReset_WithoutInboxIsNoOp(_ *testing.T) {
-	// Must not panic before the inbox service exists, or with no state at all.
-	notifyMediaDBSchemaReset(nil, false, false)
-	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
-	defer st.StopService()
-	notifyMediaDBSchemaReset(st, true, false)
 }

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -338,7 +338,7 @@ func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 			corrupt:      true,
 			userDataLost: true,
 			wantTitle:    "Media database was rebuilt after damage was found",
-			wantBody:     "in an older version of Zaparoo",
+			wantBody:     "before the database was rebuilt",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/service/mediadb_schema_reset_test.go
+++ b/pkg/service/mediadb_schema_reset_test.go
@@ -325,7 +325,7 @@ func TestNotifyMediaDBSchemaReset_PostsInboxMessage(t *testing.T) {
 			t.Cleanup(st.StopService)
 			st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
 
-			notifyMediaDBSchemaReset(st, tt.userDataLost)
+			notifyMediaDBSchemaReset(st, tt.userDataLost, false)
 
 			messages, err := db.UserDB.GetInboxMessages()
 			require.NoError(t, err)
@@ -355,15 +355,15 @@ func TestNotifyMediaDBSchemaReset_InboxWriteFailureIsNotFatal(t *testing.T) {
 	t.Cleanup(st.StopService)
 	st.SetInbox(inbox.NewService(userDB, st.Notifications))
 
-	notifyMediaDBSchemaReset(st, false)
+	notifyMediaDBSchemaReset(st, false, false)
 
 	userDB.AssertExpectations(t)
 }
 
 func TestNotifyMediaDBSchemaReset_WithoutInboxIsNoOp(_ *testing.T) {
 	// Must not panic before the inbox service exists, or with no state at all.
-	notifyMediaDBSchemaReset(nil, false)
+	notifyMediaDBSchemaReset(nil, false, false)
 	st, _ := state.NewState(testmocks.NewMockPlatform(), "test-boot-uuid")
 	defer st.StopService()
-	notifyMediaDBSchemaReset(st, true)
+	notifyMediaDBSchemaReset(st, true, false)
 }

--- a/pkg/service/remote/manager_test.go
+++ b/pkg/service/remote/manager_test.go
@@ -427,16 +427,25 @@ func TestStartRunLoopDispatchesOperationThenStopsOnCancel(t *testing.T) {
 		Return(true, nil).Once()
 	userDB.On("StoreRemoteCommandResult", "cmd_run", "executing", "succeeded", mock.Anything, "").
 		Return(true, nil).Once()
-	userDB.On("MarkRemoteCommandResultReported", "cmd_run").Return(nil).Once()
+	// The loop marks the result reported only after the POST returns, so the
+	// test has to wait for that call rather than for the server hit: cancelling
+	// in between kills the in-flight POST and the mark never happens.
+	reported := make(chan struct{})
+	userDB.On("MarkRemoteCommandResultReported", "cmd_run").
+		Run(func(_ mock.Arguments) { close(reported) }).
+		Return(nil).Once()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 	Start(ctx, &Deps{Platform: platform, Config: cfg, DB: &database.Database{UserDB: userDB}}, &wg)
 
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&resultCalls) == 1
-	}, 2*time.Second, 10*time.Millisecond, "operation result was never reported")
-	assert.Equal(t, int32(1), acceptedCalls)
+	select {
+	case <-reported:
+	case <-time.After(2 * time.Second):
+		t.Fatal("operation result was never reported")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&resultCalls))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&acceptedCalls))
 
 	cancel()
 	done := make(chan struct{})

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -442,7 +442,7 @@ func startService(
 	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
 
 	if mediaDBReset != nil {
-		notifyMediaDBSchemaReset(st, mediaDBReset.userDataLost)
+		notifyMediaDBSchemaReset(st, mediaDBReset.userDataLost, mediaDBReset.corrupt)
 	}
 
 	// Initialize profiles and restore the persisted active profile before

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -46,14 +46,19 @@ const zapLinkHostExpiration = 30 * 24 * time.Hour
 
 const userDBBackupMaxAge = 24 * time.Hour
 
-// mediaDBSchemaReset reports that the media database was discarded because its
-// schema was newer than this build supports.
+// mediaDBSchemaReset reports that the media database was discarded, either
+// because its schema was newer than this build supports or because the file was
+// corrupt.
 type mediaDBSchemaReset struct {
 	// userDataLost is set when favorites or launcher overrides that existed only in
 	// the discarded database could not be read out of it, or could not all be written
 	// to the user database. No reindex can rebuild them and nothing else holds a copy,
 	// so the user is told rather than left to notice on their own.
 	userDataLost bool
+	// corrupt distinguishes a malformed file from a downgrade. The rebuild is the
+	// same; what the user is told is not, and "you went back a version" is actively
+	// misleading when nobody changed versions.
+	corrupt bool
 }
 
 func setupEnvironment(pl platforms.Platform) error {
@@ -125,6 +130,9 @@ func makeDatabase(
 	log.Debug().Msg("running media database migrations")
 	var reset *mediaDBSchemaReset
 	err = mediaDB.MigrateUp()
+	// Asked once, before the switch: NoteCorruption writes the marker as a side
+	// effect, so it must not be re-evaluated per branch.
+	mediaCorrupt := err != nil && (mediaDB.NoteCorruption(err) || mediaDB.IsMarkedCorrupt())
 	switch {
 	case errors.Is(err, database.ErrSchemaAhead):
 		// A newer build migrated this file and the device has since gone back to
@@ -157,6 +165,39 @@ func makeDatabase(
 		}
 		if resetErr := resetMediaDBForNewerSchema(mediaDB); resetErr != nil {
 			return db, nil, fmt.Errorf("rebuilding media database with a newer schema: %w", resetErr)
+		}
+	case mediaCorrupt:
+		// The file is malformed. There is a recovery path for corruption found
+		// once the database is open (index_resume.go), but corruption bad enough
+		// to fail the migration check never reaches it: startup returns here, and
+		// the next boot fails in exactly the same place. That leaves a device that
+		// cannot start Core at all over a file a reindex reproduces from the
+		// filesystem, which is the outcome the schema-ahead branch above exists to
+		// avoid. Rebuild for the same reason.
+		//
+		// Only genuine SQLite corruption takes this branch. NoteCorruption is what
+		// decides that, so a transient open failure still ends startup rather than
+		// discarding a database that was fine.
+		log.Warn().Err(err).Msg("media database is corrupt, rebuilding it")
+		reset = &mediaDBSchemaReset{corrupt: true}
+		// Best-effort: the rescue reads from the corrupt file, so it may well fail.
+		// A partial read is still worth having, and failure is reported rather than
+		// assumed harmless.
+		rescued, rescueErr := rescueMediaUserData(ctx, mediaDB)
+		switch {
+		case rescueErr != nil:
+			log.Error().Err(rescueErr).
+				Msg("could not read media user data out of the corrupt media database")
+			reset.userDataLost = true
+		case len(rescued) > 0:
+			if importErr := backfillMediaUserData(ctx, db, rescued); importErr != nil {
+				log.Error().Err(importErr).
+					Msg("could not import media user data rescued from the corrupt media database")
+				reset.userDataLost = true
+			}
+		}
+		if resetErr := resetMediaDBForCorruption(mediaDB); resetErr != nil {
+			return db, nil, fmt.Errorf("rebuilding corrupt media database: %w", resetErr)
 		}
 	case err != nil:
 		return db, nil, fmt.Errorf("error migrating mediadb: %w", err)
@@ -216,10 +257,32 @@ func resetMediaDBForNewerSchema(mediaDB *mediadb.MediaDB) error {
 	return nil
 }
 
+// resetMediaDBForCorruption replaces a malformed media database with an empty
+// one at this build's schema, left marked pending so the startup resume check
+// reindexes it. Recreate clears the corrupt marker as part of the handoff, so
+// the next boot does not treat the fresh file as the corrupt one.
+//
+// A forensic copy is kept where the build allows it: unlike a downgrade, the
+// cause here is not known, and the file is the only evidence of what went wrong.
+func resetMediaDBForCorruption(mediaDB *mediadb.MediaDB) error {
+	log.Warn().Strs("integrity", mediaDB.IntegrityReport()).
+		Msg("media database integrity report before rebuild")
+	if err := mediaDB.Recreate(config.IsDevelopmentVersion()); err != nil {
+		return fmt.Errorf("recreating corrupt media database: %w", err)
+	}
+	// As in resetMediaDBForNewerSchema: Recreate's reopen allocates the schema,
+	// but seeding planner statistics for the reindex about to start only happens
+	// through MigrateUp.
+	if err := mediaDB.MigrateUp(); err != nil {
+		return fmt.Errorf("migrating rebuilt media database: %w", err)
+	}
+	return nil
+}
+
 // notifyMediaDBSchemaReset tells the user why their media is being indexed
 // again. makeDatabase discards the database before the inbox service exists, so
 // the message is posted from Start once it does.
-func notifyMediaDBSchemaReset(st *state.State, userDataLost bool) {
+func notifyMediaDBSchemaReset(st *state.State, userDataLost, corrupt bool) {
 	if st == nil {
 		return
 	}
@@ -228,18 +291,34 @@ func notifyMediaDBSchemaReset(st *state.State, userDataLost bool) {
 		log.Warn().Msg("inbox unavailable, cannot report media database rebuild")
 		return
 	}
+	title := "Media database was rebuilt after a version change"
 	body := "This version of Zaparoo is older than the one that last ran and could not read " +
 		"the media database it left behind. The database has been rebuilt and your media is being " +
 		"indexed again. Re-scrape your library to restore box art and metadata."
+	if corrupt {
+		// Nobody changed versions here, so the downgrade wording would send the
+		// user looking for a cause that does not exist. Corruption is a storage
+		// fault, and the SD card is the thing worth their attention.
+		title = "Media database was rebuilt after damage was found"
+		body = "Zaparoo found damage in its media database and could not read it. The database " +
+			"has been rebuilt and your media is being indexed again. Re-scrape your library to " +
+			"restore box art and metadata. If this keeps happening, check the device's storage."
+	}
 	if userDataLost {
 		// The rescue is the only thing that could have saved these, and it did not.
 		// A reindex will not bring them back, so say so plainly.
 		// A failed read cannot tell an empty database from one full of favorites, so
 		// this hedges rather than telling someone who had none that they lost some.
-		body += " Favorites and launcher overrides set before this device last updated may " +
+		// "before this device last updated" is only true of a downgrade; on the
+		// corruption path nothing updated, so say when they were set instead.
+		when := "before this device last updated"
+		if corrupt {
+			when = "in an older version of Zaparoo"
+		}
+		body += " Favorites and launcher overrides set " + when + " may " +
 			"not have been carried across, and may need to be set again."
 	}
-	if err := inboxSvc.Add("Media database was rebuilt after a version change",
+	if err := inboxSvc.Add(title,
 		inbox.WithBody(body),
 		inbox.WithSeverity(inbox.SeverityWarning),
 		inbox.WithCategory(inbox.CategoryMediaDBSchemaReset),

--- a/pkg/service/startup.go
+++ b/pkg/service/startup.go
@@ -313,7 +313,7 @@ func notifyMediaDBSchemaReset(st *state.State, userDataLost, corrupt bool) {
 		// corruption path nothing updated, so say when they were set instead.
 		when := "before this device last updated"
 		if corrupt {
-			when = "in an older version of Zaparoo"
+			when = "before the database was rebuilt"
 		}
 		body += " Favorites and launcher overrides set " + when + " may " +
 			"not have been carried across, and may need to be set again."


### PR DESCRIPTION
Four defects found while testing the `v2.16.1..main` range on a MiSTer, plus one
test gap. Each fix has a regression test that fails without it.

## A corrupt media database stopped the device booting Core

Corruption found once the media database is open routes into the recovery in
`index_resume.go`, which recreates the file and reindexes. Corruption bad enough
to fail the migration check never reached it: `makeDatabase` returned the error,
`Start` gave up, and the next boot failed in exactly the same place.

On the device Core refused to start twice in a row, writing `media.db.corrupt`
each time and never acting on it:

```
error migrating mediadb: failed to run media database migrations:
checking database schema version: database disk image is malformed
```

That is a device that cannot run Zaparoo at all, over a file a reindex rebuilds
from the filesystem — the same trade the schema-ahead branch directly above
already resolves in favour of starting, and its comment says so.

Only genuine SQLite corruption takes the branch; `NoteCorruption` decides, and it
is asked once before the switch because it writes the marker as a side effect. A
transient open failure still ends startup rather than discarding a database that
was fine. A downgrade and a damaged file both end in a rebuild, but "this version
is older than the one that last ran" is misleading when nobody changed versions,
so the corruption notice names the damage and points at the storage instead.

## `ScanSkipInternalSymlinks` did nothing on MiSTer

The walk decided symlink-ness from the readdir dirent type alone. Linux's exFAT
driver returns `DT_REG` for symlinks while reporting them correctly through
`lstat`, so on MiSTer — whose `/media/fat` is exFAT — neither the excluded
directory skip (#1294) nor the alias skip (#1351) could ever run.

Measured before the change: a walk over a tree of 88 symlinks reported
`symlinksEncountered 0`, and a single link aliasing an already-indexed ROM took
Genesis from 708 to 709 media, indexing the alias as a second copy of the same
file.

Filesystems are asked once per scan root rather than per entry, and only the FAT
family answers no, so every filesystem that already reports the type keeps the
walk exactly as it was. Where the answer is no, a non-directory entry costs one
plain `lstat` — not the timeout-wrapped kind, which stays on the symlink branches
that only a real link reaches. Directories are never `lstat`ed.

`walk_skipdir_test.go` pins the assumption the alias branch rests on: it returns
`filepath.SkipDir` for a file, and under `filepath.WalkDir` that would drop every
remaining entry in the containing directory, taking real media sitting beside
organizer output with it. fastwalk does not behave that way, and now a test says
so.

## Scraped artwork reported no cover until a restart

`media.search` and `media.history` answer `hasCover` from an in-memory cover
availability index. A scrape writes image properties through `ApplyScrapeResult`,
whose post-commit hook recorded the affected systems for thumbnail invalidation —
a different cache. Nothing dropped the cover index, so it kept answering from the
state it was built in.

Observed on the device: the mister-docs scraper matched 5 titles and wrote
`image-boxart` properties for all of them, `media.search` reported
`hasCover false` for every one, and restarting Core flipped them all to true with
nothing else changing.

The clear goes in `recordScrapeImageChanges`, which already returns early when a
write touched no image properties and already runs after the commit on both
`ApplyScrapeResult` and `ApplyScrapeResults`, so an ordinary metadata-only scrape
pays nothing.

## SteamOS never returned the unrecoverable exit status

#1335 gave startup failures a person has to resolve their own exit status and
taught the service units to decline restarting on it. `cmd/linux` and
`cmd/replayos` map the error through `cli.ExitCodeFor`; `cmd/steamos` still
exited 1 for everything, while installing the same unit — through
`pkg/platforms/linux/installer` — that carries `RestartPreventExitStatus=78`.

A schema-ahead user database on a Steam Deck therefore still got the restart loop
the change was written to stop. The panic handler keeps exiting 1 deliberately.

One test already ties the sentinel to the status and another ties the status to
the unit files; nothing checked that the entrypoints installing those units
return it. The new test closes that, and fails on the old `cmd/steamos`.

## Test gap: the 48 kHz resampler bypass

#1249 added `streamerAtTargetSampleRate` so a source already at the output rate
is handed straight through instead of being wrapped in a resampler. Nothing
referenced it from a test, so neither branch was exercised: a regression that
always resampled would cost work per sample on the devices with the least to
spare, and one that never resampled would play every other rate at the wrong
pitch. Both fail silently. 192 kHz is covered because that is the rate of the
bundled feedback sounds, which is the path a stock install runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrupted media databases can now be rebuilt automatically during startup, with recovery notifications and best-effort preservation of media data.
  - Newly scraped artwork is reflected immediately in cover availability results without requiring a restart.
  - Media scanning now detects symlink aliases more reliably on Linux filesystems, preventing missed files and directories.
  - Startup failures now report the appropriate recovery status to the supervising system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->