### PR TITLE
chore(mister): point the root require at the tagged module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ZaparooProject/go-gameid v0.2.0
 	github.com/ZaparooProject/go-pn532 v0.23.0
 	github.com/ZaparooProject/go-zapscript v0.18.0
-	github.com/ZaparooProject/zaparoo-core/mister v0.0.0
+	github.com/ZaparooProject/zaparoo-core/mister v0.1.0
 	github.com/adrg/xdg v0.5.3
 	github.com/andygrunwald/vdf v1.1.0
 	github.com/bendahl/uinput v1.7.0
@@ -150,8 +150,7 @@ require (
 // would let Core compile an older catalog than the one checked out beside it,
 // with both test suites still passing, so build it from the tree instead.
 //
-// The require above is a placeholder: the replace means it is never fetched,
-// and it exists only so the module is named. Point it at a real mister/vX.Y.Z
-// once one is tagged, for the benefit of anyone importing Core as a library
-// who also compiles pkg/platforms/mister.
+// The require above is not fetched here either, because of the replace; it is
+// what anyone importing Core as a library resolves if they also compile
+// pkg/platforms/mister. Move it whenever a new mister/vX.Y.Z is tagged.
 replace github.com/ZaparooProject/zaparoo-core/mister => ./mister

--- a/mister/README.md
+++ b/mister/README.md
@@ -15,10 +15,10 @@ Core builds this module straight from the working tree. The root `go.mod`
 carries a `replace` pointing at `./mister`, so a change here takes effect in
 Core on the same commit and there is no pin to bump.
 
-The `require` line in the root `go.mod` is a placeholder. The `replace` means it
-is never fetched during a Core build; it exists so the module is named. Point it
-at a real `mister/vX.Y.Z` once one is tagged, for anyone who imports Core as a
-library and also compiles `pkg/platforms/mister`.
+The `require` line in the root `go.mod` names the last tagged version. The
+`replace` means it is never fetched during a Core build; it is what anyone
+importing Core as a library resolves if they also compile
+`pkg/platforms/mister`. Move it whenever a new tag is cut.
 
 Without the `replace` this drifts silently: Core would compile whatever version
 the proxy last served while `task test` runs this module's own tests against the


### PR DESCRIPTION
`mister/v0.1.0` is published, so the `v0.0.0` placeholder in the root `go.mod` can name a real version.

The `replace` directive still builds Core from `./mister`, so nothing changes for this repo. The `require` line is what anyone importing Core as a library resolves if they also compile `pkg/platforms/mister`.

`mister/README.md` no longer describes the line as a placeholder, and says to move it whenever a new tag is cut.