### PR TITLE
feat(readers): add the zapdisplay display accessory driver

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,4 +69,4 @@ Device profiles are named buckets of preferences and limits, with no passwords o
 
 ## Reader Auto-Detection
 
-11 reader types: acr122pcsc, externaldrive, file, libnfc, mqtt, operator (MiSTer only), opticaldrive, pn532, rs232barcode, simpleserial, tty2oled
+12 reader types: acr122pcsc, externaldrive, file, libnfc, mqtt, operator (MiSTer only), opticaldrive, pn532, rs232barcode, simpleserial, tty2oled, zapdisplay

--- a/pkg/api/methods/media_image.go
+++ b/pkg/api/methods/media_image.go
@@ -60,8 +60,12 @@ const (
 	misterMediaImageMaxBytes  = int64(2 * 1024 * 1024)
 	defaultMediaImageMaxBytes = int64(8 * 1024 * 1024)
 	mediaImageNoImageMax      = 4096
-	mediaImageDeliveryInline  = "inline"
-	mediaImageDeliveryPath    = "localPath"
+	// MediaImageDeliveryInline and MediaImageDeliveryLocalPath are the two
+	// values media.image accepts for its delivery param, matching the oneof
+	// constraint on models.MediaImageParams. Exported so in-process callers
+	// build requests from the same constants the handler validates against.
+	MediaImageDeliveryInline    = "inline"
+	MediaImageDeliveryLocalPath = "localPath"
 	// mediaThumbCacheDirName is the sub-directory under the core cache dir where
 	// resized thumbnail files are persisted across restarts.
 	mediaThumbCacheDirName = "thumbs"
@@ -839,7 +843,7 @@ func inlineMediaImageResponse(data []byte, contentType, sourcePath, typeTag stri
 		Extension:   mediaContentExtension(contentType, sourcePath),
 		ContentType: contentType,
 		Data:        base64.StdEncoding.EncodeToString(data),
-		Delivery:    mediaImageDeliveryInline,
+		Delivery:    MediaImageDeliveryInline,
 		TypeTag:     typeTag,
 	}
 }
@@ -853,7 +857,7 @@ func localMediaImageResponse(
 	return models.MediaImageResponse{
 		Extension:   mediaContentExtension(contentType, ""),
 		ContentType: contentType,
-		Delivery:    mediaImageDeliveryPath,
+		Delivery:    MediaImageDeliveryLocalPath,
 		LocalPath:   path,
 		TypeTag:     typeTag,
 	}, true
@@ -886,9 +890,9 @@ func cachedMediaImageResponse(
 
 func validateMediaImageDelivery(delivery string, ref mediaRefParam) error {
 	switch delivery {
-	case "", mediaImageDeliveryInline:
+	case "", MediaImageDeliveryInline:
 		return nil
-	case mediaImageDeliveryPath:
+	case MediaImageDeliveryLocalPath:
 		if ref.MaxSize == nil || *ref.MaxSize <= 0 {
 			return models.ClientErrf("media.image: localPath delivery requires a positive maxSize")
 		}
@@ -926,7 +930,7 @@ func HandleMediaImage(env requests.RequestEnv) (result any, resultErr error) {
 	if deliveryErr := validateMediaImageDelivery(delivery, ref); deliveryErr != nil {
 		return nil, deliveryErr
 	}
-	localPath := delivery == mediaImageDeliveryPath
+	localPath := delivery == MediaImageDeliveryLocalPath
 
 	// Snap the requested size onto a standard tier so every view shares one
 	// cached image per cover and the resize dimension is bounded. All downstream

--- a/pkg/api/methods/media_image_test.go
+++ b/pkg/api/methods/media_image_test.go
@@ -702,7 +702,7 @@ func TestHandleMediaImage_TimingLog(t *testing.T) {
 		})
 
 		assert.Equal(t, true, event["ok"])
-		assert.Equal(t, mediaImageDeliveryInline, event["delivery"])
+		assert.Equal(t, MediaImageDeliveryInline, event["delivery"])
 		assert.Equal(t, true, event["mediaId"])
 		assert.Equal(t, json.Number("512"), event["maxSize"])
 		assert.Contains(t, event, "duration")
@@ -718,7 +718,7 @@ func TestHandleMediaImage_TimingLog(t *testing.T) {
 		})
 
 		assert.Equal(t, false, event["ok"])
-		assert.Equal(t, mediaImageDeliveryPath, event["delivery"])
+		assert.Equal(t, MediaImageDeliveryLocalPath, event["delivery"])
 		assert.Equal(t, true, event["mediaId"])
 		assert.Contains(t, event, "duration")
 	})
@@ -823,7 +823,7 @@ func TestHandleMediaImage_LocalPathColdAndWarm(t *testing.T) {
 	require.NoError(t, err)
 	resp, ok := result.(models.MediaImageResponse)
 	require.True(t, ok)
-	assert.Equal(t, mediaImageDeliveryPath, resp.Delivery)
+	assert.Equal(t, MediaImageDeliveryLocalPath, resp.Delivery)
 	assert.Empty(t, resp.Data)
 	assert.True(t, filepath.IsAbs(resp.LocalPath))
 	assert.True(t, cache.isSafeLocalPath(resp.LocalPath))
@@ -840,7 +840,7 @@ func TestHandleMediaImage_LocalPathColdAndWarm(t *testing.T) {
 	warmResp, ok := warmResult.(models.MediaImageResponse)
 	require.True(t, ok)
 	assert.Equal(t, resp.LocalPath, warmResp.LocalPath)
-	assert.Equal(t, mediaImageDeliveryPath, warmResp.Delivery)
+	assert.Equal(t, MediaImageDeliveryLocalPath, warmResp.Delivery)
 	strictDB.AssertExpectations(t)
 }
 
@@ -865,7 +865,7 @@ func TestHandleMediaImage_LocalPathCacheWriteFailureFallsBackInline(t *testing.T
 	require.NoError(t, err)
 	resp, ok := result.(models.MediaImageResponse)
 	require.True(t, ok)
-	assert.Equal(t, mediaImageDeliveryInline, resp.Delivery)
+	assert.Equal(t, MediaImageDeliveryInline, resp.Delivery)
 	assert.Empty(t, resp.LocalPath)
 	decoded, err := base64.StdEncoding.DecodeString(resp.Data)
 	require.NoError(t, err)

--- a/pkg/config/configreaders.go
+++ b/pkg/config/configreaders.go
@@ -38,6 +38,32 @@ type DriverConfig struct {
 	Enabled    *bool  `toml:"enabled,omitempty"`
 	AutoDetect *bool  `toml:"auto_detect,omitempty"`
 	ScanMode   string `toml:"scan_mode,omitempty"`
+	// Rotation turns a display accessory's output, in degrees clockwise, for a
+	// panel mounted the other way up. Degrees rather than a flip flag so
+	// quarter turns do not need a new field later. A driver whose hardware
+	// cannot do the requested angle reports that rather than guessing.
+	Rotation int `toml:"rotation,omitempty"`
+}
+
+// Display rotations a driver may be asked for. Only 0 and 180 work on current
+// hardware: a quarter turn needs a layout built for the other aspect, not a
+// transform, so it is accepted here and refused by the driver until some
+// display can honour it.
+const (
+	RotationNone     = 0
+	RotationQuarter  = 90
+	RotationHalf     = 180
+	RotationThreeQtr = 270
+)
+
+// IsValidRotation reports whether degrees is a rotation the config accepts.
+func IsValidRotation(degrees int) bool {
+	switch degrees {
+	case RotationNone, RotationQuarter, RotationHalf, RotationThreeQtr:
+		return true
+	default:
+		return false
+	}
 }
 
 type ReadersScan struct {
@@ -373,6 +399,26 @@ func (c *Instance) isDriverAutoDetectEnabledLocked(driverID string, defaultAutoD
 	}
 
 	return c.vals.Readers.AutoDetect && defaultAutoDetect
+}
+
+// DriverRotation returns the display rotation configured for a driver, in
+// degrees clockwise, or 0 when none is set.
+//
+// The value is returned as written rather than validated here. Which angles are
+// possible is a property of the panel, not of the config, so the driver is the
+// only place that can tell a typo from an angle its hardware cannot manage -
+// and it reports both the same way.
+func (c *Instance) DriverRotation(driverID string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	normalizedID := normalizeDriverID(driverID)
+	for key, cfg := range c.vals.Readers.Drivers {
+		if normalizeDriverID(key) == normalizedID {
+			return cfg.Rotation
+		}
+	}
+	return RotationNone
 }
 
 // IsReaderEnabled centralizes reader enablement rules across platform lists,

--- a/pkg/config/configreaders_test.go
+++ b/pkg/config/configreaders_test.go
@@ -872,3 +872,42 @@ func TestConnectionStringFoldsCase(t *testing.T) {
 	assert.Equal(t, "simpleserial:/dev/ttyACM0",
 		ReadersConnect{Driver: "Simple_Serial", Path: "/dev/ttyACM0"}.ConnectionString())
 }
+
+func TestDriverRotation(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Instance{
+		vals: Values{
+			Readers: Readers{
+				Drivers: map[string]DriverConfig{
+					"zapdisplay":    {Rotation: RotationHalf},
+					"tty2oled":      {Enabled: boolPtr(true)},
+					"Simple_Serial": {Rotation: RotationQuarter},
+					"nonsense":      {Rotation: 45},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, RotationHalf, cfg.DriverRotation("zapdisplay"))
+	assert.Equal(t, RotationNone, cfg.DriverRotation("tty2oled"), "a driver section with no rotation means none")
+	assert.Equal(t, RotationNone, cfg.DriverRotation("absent"), "an unconfigured driver means none")
+
+	// Driver IDs are matched the same way the enable rules match them.
+	assert.Equal(t, RotationQuarter, cfg.DriverRotation("simpleserial"))
+
+	// Returned as written: only the driver knows which angles its panel can do,
+	// so it reports a typo and an impossible angle the same way.
+	assert.Equal(t, 45, cfg.DriverRotation("nonsense"))
+}
+
+func TestIsValidRotation(t *testing.T) {
+	t.Parallel()
+
+	for _, degrees := range []int{RotationNone, RotationQuarter, RotationHalf, RotationThreeQtr} {
+		assert.True(t, IsValidRotation(degrees))
+	}
+	for _, degrees := range []int{-90, 45, 1, 360} {
+		assert.False(t, IsValidRotation(degrees))
+	}
+}

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -133,17 +133,104 @@ func (lc *LauncherCache) InitializeFromSlice(launchers []platforms.Launcher) {
 	lc.rebuildFromSlice(launchers)
 }
 
+// applySystemIDFolders lets a folder named after the system ID be scanned even
+// when no launcher declares it.
+//
+// System IDs are the names Zaparoo already uses in its API, in the scraper's
+// custom gamelist bundles and in published metadata packs, so a library
+// organised that way is indexed without the user writing per-launcher folder
+// lists. MiSTer's launchers hand-list these names already; doing it here gives
+// every platform and every launcher set the same behaviour.
+//
+// This belongs on the launcher rather than in path discovery because the folder
+// has to be equally visible to LauncherMatcher, which decides which launcher
+// owns a scanned file. A path discovered but owned by nobody indexes nothing.
+//
+// A folder another system already scans by name stays with that system. Only
+// MSX1 and MSX2 hit that today: folders named msx1 and msx2 are declared by MSX.
+func applySystemIDFolders(launchers []platforms.Launcher) {
+	declared := make(map[string]map[string]struct{})
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SkipFilesystemScan {
+			continue
+		}
+		for _, folder := range launcher.Folders {
+			if folder == "" || filepath.IsAbs(folder) {
+				continue
+			}
+			key := strings.ToLower(folder)
+			if declared[key] == nil {
+				declared[key] = make(map[string]struct{})
+			}
+			declared[key][launcher.SystemID] = struct{}{}
+		}
+	}
+
+	for i := range launchers {
+		launcher := &launchers[i]
+		if launcher.SystemID == "" || launcher.SkipFilesystemScan {
+			continue
+		}
+		// Only extend launchers that already scan a root-relative folder.
+		// A launcher with no folders matches by other means, such as a Test
+		// function or an absolute path, and giving it one would widen what it
+		// claims rather than just renaming where it looks.
+		if !hasRelativeFolder(launcher.Folders) {
+			continue
+		}
+		if !wantsSystemIDFolder(launcher.SystemID, launcher.Folders, declared) {
+			continue
+		}
+		// Folders can share a backing array with the caller's slice, so grow a
+		// copy rather than appending in place.
+		folders := make([]string, 0, len(launcher.Folders)+1)
+		folders = append(folders, launcher.Folders...)
+		folders = append(folders, launcher.SystemID)
+		launcher.Folders = folders
+	}
+}
+
+// hasRelativeFolder reports whether any folder is resolved against the index
+// roots, as opposed to being an absolute path.
+func hasRelativeFolder(folders []string) bool {
+	for _, folder := range folders {
+		if folder != "" && !filepath.IsAbs(folder) {
+			return true
+		}
+	}
+	return false
+}
+
+// wantsSystemIDFolder reports whether systemID should be added to folders.
+func wantsSystemIDFolder(
+	systemID string, folders []string, declared map[string]map[string]struct{},
+) bool {
+	for _, folder := range folders {
+		if strings.EqualFold(folder, systemID) {
+			return false
+		}
+	}
+	for owner := range declared[strings.ToLower(systemID)] {
+		if !strings.EqualFold(owner, systemID) {
+			return false
+		}
+	}
+	return true
+}
+
 func (lc *LauncherCache) rebuildFromSlice(launchers []platforms.Launcher) {
 	lc.mu.Lock()
 	defer lc.mu.Unlock()
 	lc.allLaunchers = make([]platforms.Launcher, len(launchers))
 	copy(lc.allLaunchers, launchers)
+	applySystemIDFolders(lc.allLaunchers)
 	lc.launchableSystems = nil
 
 	lc.bySystemID = make(map[string][]platforms.Launcher)
 	lc.availableBySystemID = make(map[string][]platforms.Launcher)
-	for i := range launchers {
-		launcher := launchers[i]
+	for i := range lc.allLaunchers {
+		launcher := lc.allLaunchers[i]
 		if launcher.Availability == nil {
 			launcher.Available = true
 			launcher.AvailabilityReason = ""

--- a/pkg/helpers/launcher_system_id_folder_test.go
+++ b/pkg/helpers/launcher_system_id_folder_test.go
@@ -1,0 +1,179 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func foldersFor(t *testing.T, cache *LauncherCache, systemID string) []string {
+	t.Helper()
+	all := cache.GetAllLaunchers()
+	for i := range all {
+		if all[i].SystemID == systemID {
+			return all[i].Folders
+		}
+	}
+	t.Fatalf("no launcher for system %q", systemID)
+	return nil
+}
+
+func TestSystemIDFolderAddedWhenUndeclared(t *testing.T) {
+	t.Parallel()
+
+	// RetroArch launchers declare only the EmulationStation folder, so a
+	// library organised by Zaparoo system ID would otherwise never be scanned.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "ra-genesis", SystemID: "Genesis", Folders: []string{"megadrive"}},
+	})
+
+	assert.Equal(t, []string{"megadrive", "Genesis"}, foldersFor(t, cache, "Genesis"))
+}
+
+func TestSystemIDFolderVisibleToBothLookups(t *testing.T) {
+	t.Parallel()
+
+	// The folder has to reach GetLaunchersBySystem too: path discovery uses
+	// that, while LauncherMatcher uses GetAllLaunchers. If they disagree a
+	// path is discovered but no launcher claims the files in it.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "ra-genesis", SystemID: "Genesis", Folders: []string{"megadrive"}},
+	})
+
+	bySystem := cache.GetLaunchersBySystem("Genesis")
+	require.Len(t, bySystem, 1)
+	assert.Contains(t, bySystem[0].Folders, "Genesis")
+	assert.Contains(t, foldersFor(t, cache, "Genesis"), "Genesis")
+}
+
+func TestSystemIDFolderNotDuplicatedWhenDeclared(t *testing.T) {
+	t.Parallel()
+
+	// MiSTer's launchers already hand-list the system ID.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "mister-genesis", SystemID: "Genesis", Folders: []string{"MegaDrive", "Genesis"}},
+	})
+	assert.Equal(t, []string{"MegaDrive", "Genesis"}, foldersFor(t, cache, "Genesis"))
+
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "lower", SystemID: "Genesis", Folders: []string{"genesis"}},
+	})
+	assert.Equal(t, []string{"genesis"}, foldersFor(t, cache, "Genesis"), "match is case-insensitive")
+}
+
+func TestSystemIDFolderYieldsToAnotherSystem(t *testing.T) {
+	t.Parallel()
+
+	// Folders named msx1 and msx2 are declared by system MSX, so systems MSX1
+	// and MSX2 must not claim them. This is the only real collision today.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "msx", SystemID: "MSX", Folders: []string{"msx1", "msx2"}},
+		{ID: "msx1", SystemID: "MSX1", Folders: []string{"msx1alt"}},
+		{ID: "msx2", SystemID: "MSX2", Folders: []string{"msx2alt"}},
+		{ID: "gen", SystemID: "Genesis", Folders: []string{"megadrive"}},
+	})
+
+	assert.Equal(t, []string{"msx1alt"}, foldersFor(t, cache, "MSX1"), "MSX owns the msx1 folder")
+	assert.Equal(t, []string{"msx2alt"}, foldersFor(t, cache, "MSX2"), "MSX owns the msx2 folder")
+	assert.Contains(t, foldersFor(t, cache, "Genesis"), "Genesis", "unrelated systems are unaffected")
+}
+
+func TestSystemIDFolderSkippedForNonScanningLaunchers(t *testing.T) {
+	t.Parallel()
+
+	// A launcher that never reads the filesystem gains nothing from a folder,
+	// and must not reserve that name against another system.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "kodi", SystemID: "MSX", Folders: []string{"msx1"}, SkipFilesystemScan: true},
+		{ID: "msx1", SystemID: "MSX1", Folders: []string{"msx1alt"}},
+	})
+
+	// Its own declared folder is left alone, but it gains no system-ID folder.
+	assert.Equal(t, []string{"msx1"}, foldersFor(t, cache, "MSX"))
+	// And it reserved nothing, so MSX1 is free to use its own ID.
+	assert.Equal(t, []string{"msx1alt", "MSX1"}, foldersFor(t, cache, "MSX1"))
+}
+
+func TestSystemIDFolderSkippedForLaunchersWithoutRelativeFolders(t *testing.T) {
+	t.Parallel()
+
+	// A launcher with no root-relative folder matches by other means, such as
+	// a Test function or an absolute path. Handing it a folder would widen
+	// what it claims rather than just renaming where it looks.
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "byTest", SystemID: "PS2"},
+		{ID: "absOnly", SystemID: "PS3", Folders: []string{"/opt/roms/ps3"}},
+	})
+
+	assert.Empty(t, foldersFor(t, cache, "PS2"))
+	assert.Equal(t, []string{"/opt/roms/ps3"}, foldersFor(t, cache, "PS3"))
+}
+
+func TestSystemIDFolderDoesNotMutateCallerSlice(t *testing.T) {
+	t.Parallel()
+
+	// Callers reuse launcher definitions across cache rebuilds; appending in
+	// place would grow their Folders slice on every refresh.
+	input := []platforms.Launcher{
+		{ID: "ra-genesis", SystemID: "Genesis", Folders: []string{"megadrive"}},
+	}
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice(input)
+	cache.InitializeFromSlice(input)
+
+	assert.Equal(t, []string{"megadrive"}, input[0].Folders, "caller's slice is untouched")
+	assert.Equal(t, []string{"megadrive", "Genesis"}, foldersFor(t, cache, "Genesis"))
+}
+
+func TestSystemIDFolderIgnoresAbsoluteAndEmptyFolders(t *testing.T) {
+	t.Parallel()
+
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "abs", SystemID: "Other", Folders: []string{"/opt/roms/Genesis", ""}},
+		{ID: "gen", SystemID: "Genesis", Folders: []string{"megadrive"}},
+	})
+
+	// An absolute path does not reserve the bare name for another system.
+	assert.Contains(t, foldersFor(t, cache, "Genesis"), "Genesis")
+}
+
+func TestSystemIDFolderSkippedWithoutSystemID(t *testing.T) {
+	t.Parallel()
+
+	cache := &LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{ID: "generic", Folders: []string{"media"}},
+	})
+
+	launchers := cache.GetAllLaunchers()
+	require.Len(t, launchers, 1)
+	assert.Equal(t, []string{"media"}, launchers[0].Folders)
+}

--- a/pkg/helpers/serial.go
+++ b/pkg/helpers/serial.go
@@ -69,15 +69,36 @@ func ignoreSerialDevice(path string) bool {
 		return true
 	}
 
-	if _, err := os.Stat("/usr/bin/udevadm"); err != nil {
-		log.Debug().Msgf("udevadm not found, skipping ignore list check")
+	vid, pid, ok := SerialDeviceVIDPID(path)
+	if !ok {
 		return false
+	}
+
+	for _, v := range ignoreDevices {
+		if vid == v.Vid && pid == v.Pid {
+			return true
+		}
+	}
+	return false
+}
+
+// SerialDeviceVIDPID returns the USB vendor and product IDs for a serial
+// device, lowercased.
+//
+// The third return is false when the IDs cannot be determined: a non-USB
+// device, or a platform without udevadm. A caller deciding whether to probe a
+// port should treat unknown as "cannot rule out" rather than as a match, so a
+// device stays reachable where this cannot answer.
+func SerialDeviceVIDPID(path string) (vid, pid string, ok bool) {
+	if _, err := os.Stat("/usr/bin/udevadm"); err != nil {
+		log.Debug().Msg("udevadm not found, cannot read USB IDs")
+		return "", "", false
 	}
 
 	// Validate device path to prevent command injection
 	if !strings.HasPrefix(path, "/dev/") {
 		log.Error().Str("path", path).Msg("invalid device path")
-		return false
+		return "", "", false
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -86,78 +107,68 @@ func ignoreSerialDevice(path string) bool {
 	cmd := exec.CommandContext(ctx, "/usr/bin/udevadm", "info", "--name="+path)
 	out, err := cmd.Output()
 	if err != nil {
-		log.Error().Err(err).Msg("udevadm failed")
-		return false
+		// Debug rather than error: this is now called speculatively across
+		// every candidate port, where a node with no udev record is an
+		// ordinary answer rather than a fault worth reporting.
+		log.Debug().Err(err).Str("path", path).Msg("udevadm failed")
+		return "", "", false
 	}
 
-	vid := ""
-	pid := ""
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.HasPrefix(line, "E: ID_VENDOR_ID=") {
-			vid = strings.TrimPrefix(line, "E: ID_VENDOR_ID=")
-		} else if strings.HasPrefix(line, "E: ID_MODEL_ID=") {
-			pid = strings.TrimPrefix(line, "E: ID_MODEL_ID=")
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if rest, found := strings.CutPrefix(line, "E: ID_VENDOR_ID="); found {
+			vid = rest
+		} else if rest, found := strings.CutPrefix(line, "E: ID_MODEL_ID="); found {
+			pid = rest
 		}
 	}
-
 	if vid == "" || pid == "" {
-		return false
+		return "", "", false
+	}
+	return strings.ToLower(vid), strings.ToLower(pid), true
+}
+
+// listLinuxSerialDevices returns /dev nodes whose name starts with one of the
+// given prefixes, minus anything on the shared ignore list.
+//
+// The prefix set is the caller's because a driver for a native-USB device wants
+// only CDC-ACM nodes, while the general reader listing also wants USB-to-UART
+// bridges.
+func listLinuxSerialDevices(prefixes ...string) ([]string, error) {
+	const dir = "/dev"
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []string{}, nil
+		}
+		return nil, fmt.Errorf("failed to read /dev directory: %w", err)
 	}
 
-	vid = strings.ToLower(vid)
-	pid = strings.ToLower(pid)
+	devices := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !hasAnyPrefix(entry.Name(), prefixes) {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if ignoreSerialDevice(path) {
+			continue
+		}
+		devices = append(devices, path)
+	}
+	return devices, nil
+}
 
-	for _, v := range ignoreDevices {
-		if vid == v.Vid && pid == v.Pid {
+func hasAnyPrefix(name string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(name, prefix) {
 			return true
 		}
 	}
-
 	return false
 }
 
 func getLinuxList() ([]string, error) {
-	path := "/dev"
-
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return []string{}, nil
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open /dev directory: %w", err)
-	}
-	defer func(f *os.File) {
-		closeErr := f.Close()
-		if closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close serial device folder")
-		}
-	}(f)
-
-	files, err := f.Readdir(0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read /dev directory: %w", err)
-	}
-
-	devices := make([]string, 0, len(files))
-
-	for _, v := range files {
-		if v.IsDir() {
-			continue
-		}
-
-		if !strings.HasPrefix(v.Name(), "ttyUSB") && !strings.HasPrefix(v.Name(), "ttyACM") {
-			continue
-		}
-
-		if ignoreSerialDevice(filepath.Join(path, v.Name())) {
-			continue
-		}
-
-		devices = append(devices, filepath.Join(path, v.Name()))
-	}
-
-	return devices, nil
+	return listLinuxSerialDevices("ttyUSB", "ttyACM")
 }
 
 func GetSerialDeviceList() ([]string, error) {
@@ -207,4 +218,57 @@ func GetSerialDeviceList() ([]string, error) {
 		}
 		return ports, nil
 	}
+}
+
+// IsUSBCDCDeviceName reports whether a serial device path looks like a USB
+// CDC-ACM node for the current platform.
+//
+// Split out from the listing functions so the naming rules can be tested
+// without the host actually having such a device attached.
+func IsUSBCDCDeviceName(goos, path string) bool {
+	name := filepath.Base(path)
+	switch goos {
+	case "linux":
+		return strings.HasPrefix(name, "ttyACM")
+	case "darwin":
+		// Native-USB devices appear as tty.usbmodem; tty.usbserial is a
+		// USB-to-UART bridge and never a CDC-ACM device.
+		return strings.HasPrefix(name, "tty.usbmodem")
+	case "windows":
+		// Windows exposes every serial port as COMn with no way to tell a
+		// CDC-ACM device from a bridge, so the caller's handshake has to.
+		return strings.HasPrefix(name, "COM")
+	default:
+		return true
+	}
+}
+
+// GetUSBCDCDeviceList returns serial device nodes that are USB CDC-ACM
+// interfaces.
+//
+// Microcontrollers with a native USB peripheral, such as the ESP32-S3,
+// enumerate as CDC-ACM rather than through a USB-to-UART bridge, so on macOS
+// they appear as tty.usbmodem and are missed entirely by GetSerialDeviceList.
+// Using the narrower list also keeps a driver's probes away from bridge-attached
+// hardware it could never be.
+//
+// On Linux the shared ignore list is applied as well, so known non-reader
+// devices such as light guns are never opened.
+func GetUSBCDCDeviceList() ([]string, error) {
+	if runtime.GOOS == "linux" {
+		return listLinuxSerialDevices("ttyACM")
+	}
+
+	ports, err := serial.GetPortsList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get serial ports list: %w", err)
+	}
+
+	devices := make([]string, 0, len(ports))
+	for _, path := range ports {
+		if IsUSBCDCDeviceName(runtime.GOOS, path) {
+			devices = append(devices, path)
+		}
+	}
+	return devices, nil
 }

--- a/pkg/helpers/serial_cdc_test.go
+++ b/pkg/helpers/serial_cdc_test.go
@@ -1,0 +1,53 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUSBCDCDeviceName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{name: "linux CDC ACM node", goos: "linux", path: "/dev/ttyACM0", want: true},
+		{name: "linux USB-UART bridge", goos: "linux", path: "/dev/ttyUSB0", want: false},
+		{name: "linux unrelated tty", goos: "linux", path: "/dev/ttyS0", want: false},
+		// The ESP32-S3 has a native USB peripheral, so macOS names it
+		// tty.usbmodem. Matching only tty.usbserial would never find it.
+		{name: "darwin native USB device", goos: "darwin", path: "/dev/tty.usbmodem14201", want: true},
+		{name: "darwin USB-UART bridge", goos: "darwin", path: "/dev/tty.usbserial-1420", want: false},
+		{name: "windows COM port", goos: "windows", path: "COM3", want: true},
+		{name: "windows non-COM", goos: "windows", path: "LPT1", want: false},
+		{name: "unknown platform accepts anything", goos: "plan9", path: "/dev/eia0", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsUSBCDCDeviceName(tc.goos, tc.path))
+		})
+	}
+}

--- a/pkg/platforms/batocera/platform.go
+++ b/pkg/platforms/batocera/platform.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/jonboulle/clockwork"
@@ -86,6 +87,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
 		tty2oled.NewReader(cfg, p),
+		zapdisplay.NewReaderWithDefaults(cfg, true),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/libreelec/platform.go
+++ b/pkg/platforms/libreelec/platform.go
@@ -50,6 +50,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/adrg/xdg"
@@ -81,6 +82,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
 		tty2oled.NewReader(cfg, p),
+		zapdisplay.NewReader(cfg),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/mac/platform.go
+++ b/pkg/platforms/mac/platform.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/adrg/xdg"
@@ -81,6 +82,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		tty2oled.NewReader(cfg, p),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
+		zapdisplay.NewReader(cfg),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	widgetmodels "github.com/ZaparooProject/zaparoo-core/v2/pkg/ui/widgets/models"
@@ -195,6 +196,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		opticaldrive.NewReader(cfg),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
+		zapdisplay.NewReaderWithDefaults(cfg, true),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/mistex/platform.go
+++ b/pkg/platforms/mistex/platform.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/rs/zerolog/log"
@@ -75,6 +76,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		tty2oled.NewReader(cfg, p),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
+		zapdisplay.NewReaderWithDefaults(cfg, true),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/recalbox/platform.go
+++ b/pkg/platforms/recalbox/platform.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/adrg/xdg"
@@ -79,6 +80,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
 		tty2oled.NewReader(cfg, p),
+		zapdisplay.NewReader(cfg),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/retropie/platform.go
+++ b/pkg/platforms/retropie/platform.go
@@ -49,6 +49,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/adrg/xdg"
@@ -79,6 +80,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
 		tty2oled.NewReader(cfg, p),
+		zapdisplay.NewReader(cfg),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/shared/linuxbase/readers.go
+++ b/pkg/platforms/shared/linuxbase/readers.go
@@ -25,6 +25,7 @@ package linuxbase
 import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/externaldrive"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/file"
@@ -35,7 +36,18 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 )
+
+// zapdisplayDefaultEnabled reports whether the display accessory should be
+// detected without the user opting in.
+//
+// It is on where the display is a first-party accessory for that device, and
+// off elsewhere: detection has to open a serial port and write to it, which is
+// only a reasonable default when the hardware is expected.
+func zapdisplayDefaultEnabled(p platforms.Platform) bool {
+	return p != nil && p.ID() == ids.ReplayOS
+}
 
 // SupportedReaders returns the list of enabled readers for Linux platforms.
 // The platform parameter is needed for tty2oled reader initialization.
@@ -52,6 +64,7 @@ func SupportedReaders(cfg *config.Instance, p platforms.Platform) []readers.Read
 		opticaldrive.NewReaderWithDefaults(cfg, false, false),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
+		zapdisplay.NewReaderWithDefaults(cfg, zapdisplayDefaultEnabled(p)),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/platforms/shared/linuxbase/zapdisplay_default_test.go
+++ b/pkg/platforms/shared/linuxbase/zapdisplay_default_test.go
@@ -1,0 +1,59 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package linuxbase
+
+import (
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/ids"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZapdisplayDefaultEnabledPerPlatform(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		platform string
+		want     bool
+	}{
+		// ReplayOS ships the display as a first-party accessory.
+		{platform: ids.ReplayOS, want: true},
+		// Everything else sharing the Linux reader set stays opt-in, because
+		// detection opens a serial port and writes to it.
+		{platform: ids.Linux, want: false},
+		{platform: ids.SteamOS, want: false},
+		{platform: ids.Bazzite, want: false},
+	} {
+		t.Run(tc.platform, func(t *testing.T) {
+			t.Parallel()
+			pl := mocks.NewMockPlatform()
+			pl.On("ID").Return(tc.platform)
+			assert.Equal(t, tc.want, zapdisplayDefaultEnabled(pl))
+		})
+	}
+}
+
+func TestZapdisplayDefaultEnabledHandlesNilPlatform(t *testing.T) {
+	t.Parallel()
+	assert.False(t, zapdisplayDefaultEnabled(nil))
+}

--- a/pkg/platforms/windows/platform.go
+++ b/pkg/platforms/windows/platform.go
@@ -60,6 +60,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/rs232barcode"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/simpleserial"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/tty2oled"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/zapdisplay"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/idle"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
 	"github.com/adrg/xdg"
@@ -106,6 +107,7 @@ func (p *Platform) SupportedReaders(cfg *config.Instance) []readers.Reader {
 		tty2oled.NewReader(cfg, p),
 		mqtt.NewReader(cfg),
 		externaldrive.NewReader(cfg),
+		zapdisplay.NewReader(cfg),
 	}
 
 	var enabled []readers.Reader

--- a/pkg/readers/readers.go
+++ b/pkg/readers/readers.go
@@ -88,6 +88,44 @@ type OpenOpts struct {
 	Probing bool
 }
 
+// ErrNoArtwork is returned by an ArtworkSource when a media item has no usable
+// artwork. Display drivers treat it as an ordinary outcome and render without a
+// cover rather than failing the whole update.
+var ErrNoArtwork = errors.New("no artwork available")
+
+// MediaArtwork is cover art for a media item, resolved from Core's own stored
+// metadata rather than from a driver-specific asset pack.
+type MediaArtwork struct {
+	// ContentType names the encoding of Data: whatever Core's artwork
+	// pipeline produced, which is PNG, JPEG or WebP.
+	ContentType string
+	// TypeTag records the property the image came from, for example
+	// "property:image-boxart".
+	TypeTag string
+	Data    []byte
+}
+
+// ArtworkSource resolves cover art for a media item. Display drivers that
+// render Core's stored artwork are handed one when they are registered, so they
+// do not need a database handle of their own.
+//
+// Media is addressed by system ID and path because ActiveMedia carries no media
+// ID in-process; only API handlers populate that field.
+//
+// maxSize is a hint for the longest edge in pixels. Core snaps it onto a
+// standard thumbnail tier, so the image may come back larger than requested and
+// callers should scale to their own dimensions.
+type ArtworkSource interface {
+	Artwork(ctx context.Context, systemID, path string, maxSize int) (*MediaArtwork, error)
+}
+
+// ArtworkConsumer is implemented by display drivers that render Core's stored
+// artwork. Core calls SetArtworkSource once, when the reader is registered, and
+// a driver must cope with never being called at all.
+type ArtworkConsumer interface {
+	SetArtworkSource(ArtworkSource)
+}
+
 type Reader interface {
 	// Metadata returns static configuration for this driver.
 	Metadata() DriverMetadata

--- a/pkg/readers/testutils/mock_serial.go
+++ b/pkg/readers/testutils/mock_serial.go
@@ -32,11 +32,14 @@ type MockSerialPort struct {
 	ReadError  error
 	CloseError error
 	TimeoutErr error
+	WriteError error
 	ReadFunc   func(p []byte) (n int, err error)
+	WriteFunc  func(p []byte) (n int, err error)
 	ReadData   []byte
+	writes     [][]byte
 	ReadIndex  int
 	Closed     bool
-	mu         syncutil.RWMutex // protects Closed, CloseError
+	mu         syncutil.RWMutex // protects Closed, CloseError, writes
 }
 
 // NewMockSerialPort creates a new mock serial port for testing.
@@ -76,6 +79,41 @@ func (m *MockSerialPort) Read(p []byte) (n int, err error) {
 	n = copy(p, m.ReadData[m.ReadIndex:])
 	m.ReadIndex += n
 	return n, nil
+}
+
+// Write implements the Write method for serial ports. Written buffers are
+// recorded so tests can assert on the exact bytes a reader sent.
+func (m *MockSerialPort) Write(p []byte) (n int, err error) {
+	m.mu.RLock()
+	closed := m.Closed
+	m.mu.RUnlock()
+
+	if closed {
+		return 0, errors.New("port closed")
+	}
+
+	if m.WriteFunc != nil {
+		return m.WriteFunc(p)
+	}
+	if m.WriteError != nil {
+		return 0, m.WriteError
+	}
+
+	recorded := make([]byte, len(p))
+	copy(recorded, p)
+	m.mu.Lock()
+	m.writes = append(m.writes, recorded)
+	m.mu.Unlock()
+	return len(p), nil
+}
+
+// Writes returns a copy of every buffer passed to Write (thread-safe).
+func (m *MockSerialPort) Writes() [][]byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([][]byte, len(m.writes))
+	copy(out, m.writes)
+	return out
 }
 
 // Close implements the Close method for serial ports.

--- a/pkg/readers/testutils/serialport.go
+++ b/pkg/readers/testutils/serialport.go
@@ -30,6 +30,7 @@ import (
 // This interface is used by serial-based readers for dependency injection and testing.
 type SerialPort interface {
 	Read(p []byte) (n int, err error)
+	Write(p []byte) (n int, err error)
 	Close() error
 	SetReadTimeout(t time.Duration) error
 }

--- a/pkg/readers/tty2oled/protocol.go
+++ b/pkg/readers/tty2oled/protocol.go
@@ -75,9 +75,6 @@ const (
 
 // Configuration constants from MiSTer shell script
 const (
-	// Rotation settings
-	DefaultRotation = false // false = normal, true = 180° flipped
-
 	// Enhanced transitions
 	DefaultTransition = TransitionAuto
 

--- a/pkg/readers/tty2oled/tty2oled.go
+++ b/pkg/readers/tty2oled/tty2oled.go
@@ -94,9 +94,13 @@ func NewReader(cfg *config.Instance, pl platforms.Platform) *Reader {
 	return r
 }
 
+// driverID is this driver's identifier, used for its metadata and to look up
+// its section in the reader config.
+const driverID = "tty2oled"
+
 func (*Reader) Metadata() readers.DriverMetadata {
 	return readers.DriverMetadata{
-		ID:                "tty2oled",
+		ID:                driverID,
 		DefaultEnabled:    false,
 		DefaultAutoDetect: true,
 		Description:       "TTY2OLED serial display device",
@@ -104,7 +108,7 @@ func (*Reader) Metadata() readers.DriverMetadata {
 }
 
 func (*Reader) IDs() []string {
-	return []string{"tty2oled"}
+	return []string{driverID}
 }
 
 // getState returns the current connection state
@@ -568,6 +572,28 @@ func (r *Reader) handshakeWithContextOnPort(_ context.Context, port serial.Port)
 	return nil
 }
 
+// rotationEnabled reports whether the panel should be driven upside down.
+//
+// The SSD1322 has a hardware 180 degree flip and nothing else, so a quarter
+// turn is reported and ignored rather than approximated: a display the wrong
+// way up still works, and refusing to connect would be a worse answer to a
+// config mistake. The device keeps no settings of its own, so this is re-sent
+// on every connect.
+func (r *Reader) rotationEnabled() bool {
+	degrees := r.cfg.DriverRotation(driverID)
+	switch degrees {
+	case config.RotationNone:
+		return false
+	case config.RotationHalf:
+		return true
+	default:
+		log.Warn().
+			Int("rotation", degrees).
+			Msg("tty2oled: display supports 0 and 180 only, leaving it unrotated")
+		return false
+	}
+}
+
 // initializeDeviceOnPort sends the initialization commands on a specific port
 func (r *Reader) initializeDeviceOnPort(port serial.Port) error {
 	// Bash script sequence after QWERTZ: sendcontrast, sendrotation, sendtime, sendscreensaver
@@ -586,7 +612,7 @@ func (r *Reader) initializeDeviceOnPort(port serial.Port) error {
 	}
 
 	// sendrotation: if rotation is enabled, send CMDROT,1 then CMDSORG
-	if DefaultRotation {
+	if r.rotationEnabled() {
 		if err := r.sendCommandOnPort(port, CmdRotate+",1"); err != nil {
 			return fmt.Errorf("failed to send rotation command: %w", err)
 		}

--- a/pkg/readers/tty2oled/tty2oled_test.go
+++ b/pkg/readers/tty2oled/tty2oled_test.go
@@ -1003,3 +1003,34 @@ func TestNewReader_DoesNotLeakGoroutine(t *testing.T) {
 	// Discard without closing — any goroutine started here would be a leak.
 	_ = NewReader(cfg, mockPlatform)
 }
+
+func rotationConfig(t *testing.T, degrees int) *config.Instance {
+	t.Helper()
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Readers: config.Readers{
+			Drivers: map[string]config.DriverConfig{
+				driverID: {Rotation: degrees},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestRotationFollowsDriverConfig(t *testing.T) {
+	t.Parallel()
+
+	// The panel keeps no settings of its own, so Core decides on every connect.
+	assert.True(t, (&Reader{cfg: rotationConfig(t, config.RotationHalf)}).rotationEnabled())
+	assert.False(t, (&Reader{cfg: rotationConfig(t, config.RotationNone)}).rotationEnabled())
+}
+
+func TestRotationIgnoresAnglesThePanelCannotDo(t *testing.T) {
+	t.Parallel()
+
+	// The SSD1322 has a hardware 180 degree flip and nothing else, so a quarter
+	// turn is reported and ignored rather than approximated.
+	assert.False(t, (&Reader{cfg: rotationConfig(t, config.RotationQuarter)}).rotationEnabled())
+	assert.False(t, (&Reader{cfg: rotationConfig(t, config.RotationThreeQtr)}).rotationEnabled())
+	assert.False(t, (&Reader{cfg: rotationConfig(t, 45)}).rotationEnabled())
+}

--- a/pkg/readers/zapdisplay/cover.go
+++ b/pkg/readers/zapdisplay/cover.go
@@ -1,0 +1,170 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+	"image"
+	"image/jpeg"
+	"image/png"
+	"strings"
+
+	"golang.org/x/image/draw"
+	"golang.org/x/image/webp"
+)
+
+// coverAssetID derives a stable, device-legal identifier for a cover.
+//
+// The checksum is part of the ID so that re-scraped artwork for the same media
+// produces a different ID and is uploaded rather than silently re-selected.
+func coverAssetID(systemID, path string, pixels []byte) string {
+	digest := sha256.Sum256([]byte(systemID + "\x00" + path))
+	id := fmt.Sprintf("c%s-%08x", hex.EncodeToString(digest[:6]), crc32.ChecksumIEEE(pixels))
+	if len(id) > 47 {
+		id = id[:47]
+	}
+	return id
+}
+
+// fitCover scales a source image's dimensions into the display's artwork box.
+//
+// Height is filled first, because the panel is short and wide and vertical
+// space is what artwork is starved of. Anything that would then be too wide for
+// the device's detail column is scaled down rather than cropped: the aspect the
+// artwork was drawn at is the thing worth preserving, and the device lays out
+// around whatever it is sent.
+func fitCover(width, height int) (fittedWidth, fittedHeight int) {
+	if width <= 0 || height <= 0 {
+		return 0, 0
+	}
+	scaledW := (coverMaxHeight*width + height/2) / height
+	if scaledW < 1 {
+		scaledW = 1
+	}
+	if scaledW <= coverMaxWidth {
+		return scaledW, coverMaxHeight
+	}
+	scaledH := (coverMaxWidth*height + width/2) / width
+	if scaledH < 1 {
+		scaledH = 1
+	}
+	return coverMaxWidth, scaledH
+}
+
+// encodedCover is artwork ready for the device: packed pixels plus the size
+// they were packed at. The size travels with the pixels because artwork is not
+// a fixed slot, so ASSET_USE has to restate it.
+type encodedCover struct {
+	pixels []byte
+	width  int
+	height int
+}
+
+// encodeCover converts artwork into the little-endian RGB565 buffer the device
+// renders, along with the dimensions it was encoded at.
+//
+// The device is told the size rather than assuming one, so box art keeps its
+// own aspect: portrait for most console art, landscape for the roughly 4:3
+// covers several systems use, and wider still for a marquee or a screenshot.
+func encodeCover(data []byte, contentType string) (encodedCover, error) {
+	src, err := decodeImage(data, contentType)
+	if err != nil {
+		return encodedCover{}, err
+	}
+
+	width, height := fitCover(src.Bounds().Dx(), src.Bounds().Dy())
+	if width == 0 || height == 0 {
+		return encodedCover{}, fmt.Errorf("cover has no pixels: %dx%d", src.Bounds().Dx(), src.Bounds().Dy())
+	}
+
+	dst := image.NewRGBA(image.Rect(0, 0, width, height))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), src, src.Bounds(), draw.Src, nil)
+
+	out := make([]byte, 0, width*height*2)
+	for y := range height {
+		for x := range width {
+			// RGBA() returns 16-bit premultiplied channels; the high byte is
+			// the 8-bit value RGB565 is packed from. Masking to a byte before
+			// each conversion keeps every step provably in range.
+			r, g, b, _ := dst.At(x, y).RGBA()
+			r8 := uint16((r >> 8) & 0xFF)
+			g8 := uint16((g >> 8) & 0xFF)
+			b8 := uint16((b >> 8) & 0xFF)
+			pixel := (r8&0xF8)<<8 | (g8&0xFC)<<3 | b8>>3
+			out = append(out, byte(pixel&0xFF), byte((pixel>>8)&0xFF))
+		}
+	}
+	if len(out) != width*height*2 {
+		return encodedCover{}, fmt.Errorf("encoded cover is %d bytes, expected %d", len(out), width*height*2)
+	}
+	return encodedCover{pixels: out, width: width, height: height}, nil
+}
+
+// decodeImage decodes the formats Core's artwork pipeline can produce. It
+// dispatches on content type first and falls back to magic bytes, because a
+// scraped file's recorded type is not always right.
+func decodeImage(data []byte, contentType string) (image.Image, error) {
+	switch {
+	case strings.Contains(contentType, "png"):
+		return decodePNG(data)
+	case strings.Contains(contentType, "jpeg"), strings.Contains(contentType, "jpg"):
+		return decodeJPEG(data)
+	case strings.Contains(contentType, "webp"):
+		return decodeWebP(data)
+	}
+
+	switch {
+	case bytes.HasPrefix(data, []byte("\x89PNG\r\n\x1a\n")):
+		return decodePNG(data)
+	case len(data) >= 2 && data[0] == 0xff && data[1] == 0xd8:
+		return decodeJPEG(data)
+	case len(data) >= 12 && bytes.HasPrefix(data, []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WEBP")):
+		return decodeWebP(data)
+	}
+	return nil, fmt.Errorf("unsupported cover image type %q", contentType)
+}
+
+func decodePNG(data []byte) (image.Image, error) {
+	img, err := png.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode PNG cover: %w", err)
+	}
+	return img, nil
+}
+
+func decodeJPEG(data []byte) (image.Image, error) {
+	img, err := jpeg.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode JPEG cover: %w", err)
+	}
+	return img, nil
+}
+
+func decodeWebP(data []byte) (image.Image, error) {
+	img, err := webp.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("decode WebP cover: %w", err)
+	}
+	return img, nil
+}

--- a/pkg/readers/zapdisplay/cover_test.go
+++ b/pkg/readers/zapdisplay/cover_test.go
@@ -1,0 +1,190 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func solidPNG(t *testing.T, w, h int, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+func solidJPEG(t *testing.T, w, h int, c color.Color) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			img.Set(x, y, c)
+		}
+	}
+	var buf bytes.Buffer
+	require.NoError(t, jpeg.Encode(&buf, img, nil))
+	return buf.Bytes()
+}
+
+func TestEncodeCoverPreservesSourceAspect(t *testing.T) {
+	t.Parallel()
+
+	// Artwork is not a fixed slot. The source aspect is what the device lays
+	// out around, so it must survive encoding rather than being cropped to a
+	// shape the panel does not actually require.
+	for _, tc := range []struct {
+		name         string
+		w, h         int
+		wantW, wantH int
+	}{
+		{"portrait box art", 400, 600, 192, coverMaxHeight},
+		{"japanese n64 box art", 234, 320, 211, coverMaxHeight},
+		{"us n64 box art", 320, 234, 394, coverMaxHeight},
+		{"square", 512, 512, coverMaxHeight, coverMaxHeight},
+		{"4:3 screenshot", 640, 480, 384, coverMaxHeight},
+		// Too wide to fill the height without overrunning the width cap, so it
+		// is scaled down and letterboxed instead of losing its sides.
+		{"3d box render", 300, 162, coverMaxWidth, 276},
+		{"marquee", 1600, 400, coverMaxWidth, 128},
+		{"tiny", 8, 12, 192, coverMaxHeight},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := encodeCover(solidPNG(t, tc.w, tc.h, color.RGBA{R: 10, G: 20, B: 30, A: 255}), "image/png")
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantW, out.width)
+			assert.Equal(t, tc.wantH, out.height)
+			assert.Len(t, out.pixels, out.width*out.height*2)
+			assert.LessOrEqual(t, len(out.pixels), coverMaxBytes)
+		})
+	}
+}
+
+func TestEncodeCoverPacksLittleEndianRGB565(t *testing.T) {
+	t.Parallel()
+
+	// Pure red is 0xF800 in RGB565, so every pixel must be 0x00 then 0xF8.
+	out, err := encodeCover(solidPNG(t, 60, 90, color.RGBA{R: 255, A: 255}), "image/png")
+	require.NoError(t, err)
+	require.Len(t, out.pixels, out.width*out.height*2)
+
+	for i := 0; i < len(out.pixels); i += 2 {
+		require.Equalf(t, byte(0x00), out.pixels[i], "low byte at %d", i)
+		require.Equalf(t, byte(0xF8), out.pixels[i+1], "high byte at %d", i)
+	}
+}
+
+func TestEncodeCoverDetectsFormatFromMagicBytes(t *testing.T) {
+	t.Parallel()
+
+	// A wrong or missing content type must not stop a decodable image.
+	out, err := encodeCover(solidPNG(t, 120, 180, color.RGBA{B: 255, A: 255}), "application/octet-stream")
+	require.NoError(t, err)
+	assert.Len(t, out.pixels, out.width*out.height*2)
+
+	out, err = encodeCover(solidJPEG(t, 120, 180, color.RGBA{G: 255, A: 255}), "")
+	require.NoError(t, err)
+	assert.Len(t, out.pixels, out.width*out.height*2)
+}
+
+func TestEncodeCoverRejectsUndecodableInput(t *testing.T) {
+	t.Parallel()
+
+	_, err := encodeCover([]byte("not an image at all"), "image/png")
+	require.Error(t, err)
+
+	// Truncated PNG: the header matches but the body does not decode.
+	full := solidPNG(t, 40, 40, color.White)
+	_, err = encodeCover(full[:20], "image/png")
+	require.Error(t, err)
+}
+
+func TestFitCoverStaysInsideTheDeviceBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ w, h int }{
+		{1, 1},
+		{4000, 3000},
+		{3000, 4000},
+		{10000, 1},
+		{1, 10000},
+		{coverMaxWidth, coverMaxHeight},
+	} {
+		w, h := fitCover(tc.w, tc.h)
+		assert.LessOrEqual(t, w, coverMaxWidth)
+		assert.LessOrEqual(t, h, coverMaxHeight)
+		assert.Positive(t, w)
+		assert.Positive(t, h)
+		assert.LessOrEqual(t, w*h*2, coverMaxBytes)
+	}
+}
+
+func TestFitCoverRejectsEmptySources(t *testing.T) {
+	t.Parallel()
+
+	w, h := fitCover(0, 100)
+	assert.Zero(t, w)
+	assert.Zero(t, h)
+}
+
+// assetIDPattern is the identifier charset and length the firmware accepts.
+// coverAssetID is built to satisfy it; this is the assertion that it does.
+var assetIDPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,47}$`)
+
+func TestCoverAssetIDIsDeviceLegalAndStable(t *testing.T) {
+	t.Parallel()
+
+	pixels := make([]byte, 1024)
+	first := coverAssetID("snes", "/games/SNES/Super Metroid.sfc", pixels)
+	second := coverAssetID("snes", "/games/SNES/Super Metroid.sfc", pixels)
+
+	assert.Equal(t, first, second, "same media and artwork must reuse the same asset ID")
+	assert.Regexp(t, assetIDPattern, first)
+
+	// Different artwork for the same media must not reuse the ID, or the
+	// device would keep showing the stale cover it already holds.
+	changed := make([]byte, 1024)
+	changed[0] = 0xFF
+	assert.NotEqual(t, first, coverAssetID("snes", "/games/SNES/Super Metroid.sfc", changed))
+
+	// Long paths must still produce a legal ID.
+	long := coverAssetID("snes", "/"+string(make([]byte, 500)), pixels)
+	assert.Regexp(t, assetIDPattern, long)
+}
+
+// colorRed is the fixture colour for cover tests.
+func colorRed() color.Color {
+	return color.RGBA{R: 255, A: 255}
+}

--- a/pkg/readers/zapdisplay/fakedevice_test.go
+++ b/pkg/readers/zapdisplay/fakedevice_test.go
@@ -1,0 +1,497 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+)
+
+// fakeScene is the state the device would have rendered on a SHOW.
+type fakeScene struct {
+	scene   string
+	title   string
+	system  string
+	status  string
+	message string
+	accent  string
+	coverID string
+}
+
+// fakeDevice simulates the zapdisplay firmware over an in-memory serial port.
+//
+// It implements the same command set, asset state machine and CRC checks as the
+// real device, so the driver can be exercised end to end without hardware. It
+// also reproduces the two transport quirks that matter: responses terminated
+// with CRLF, and reads that return (0, nil) when there is nothing to deliver.
+type fakeDevice struct {
+	// writeErr and failNextAssetUse inject faults: a dead link and a device
+	// that has forgotten the asset it was asked to show.
+	writeErr error
+	// gate, when non-nil, blocks every Write until it is closed. Tests use it
+	// to prove the driver does no serial I/O on the media notify path.
+	gate chan struct{}
+	// pending is the scene being assembled; it is committed on SHOW.
+	pending          fakeScene
+	committedID      string
+	failNextAssetUse string
+	stagingID        string
+	stagingMime      string
+	chunkBuf         []byte
+	stagingData      []byte
+	partial          []byte
+	// commands records every complete command line received, in order.
+	commands []string
+	scenes   []fakeScene
+	out      []byte
+	// unsolicited is emitted before the next response, standing in for the
+	// ESP-IDF log output that shares the serial stream.
+	unsolicited    []string
+	committedBytes int
+	// awaitingBytes is non-zero while the device is mid-chunk, mirroring the
+	// firmware's blocking read after OK ASSET_CHUNK_DATA.
+	awaitingBytes int
+	awaitingIndex int
+	stagingBytes  int
+	nextChunk     int
+	committedW    int
+	committedH    int
+	gateMu        syncutil.RWMutex
+	mu            syncutil.Mutex
+	stagingCRC    uint32
+	stagingDone   bool
+	closed        bool
+	// awaitingRaw distinguishes a binary chunk from a base64 one; the raw path
+	// exists because the firmware's console passes bytes through unmodified.
+	awaitingRaw bool
+}
+
+func newFakeDevice() *fakeDevice {
+	return &fakeDevice{}
+}
+
+func (f *fakeDevice) Read(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return 0, errors.New("port closed")
+	}
+	if len(f.out) == 0 {
+		// Read timeout: the real driver library reports this as (0, nil).
+		return 0, nil
+	}
+	n := copy(p, f.out)
+	f.out = f.out[n:]
+	return n, nil
+}
+
+func (f *fakeDevice) Write(p []byte) (int, error) {
+	f.gateMu.RLock()
+	gate := f.gate
+	f.gateMu.RUnlock()
+	if gate != nil {
+		<-gate
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return 0, errors.New("port closed")
+	}
+	if f.writeErr != nil {
+		return 0, f.writeErr
+	}
+
+	for _, b := range p {
+		if f.awaitingBytes > 0 {
+			f.chunkBuf = append(f.chunkBuf, b)
+			f.awaitingBytes--
+			if f.awaitingBytes == 0 {
+				f.finishChunkLocked()
+			}
+			continue
+		}
+		if b == '\n' {
+			line := strings.TrimRight(string(f.partial), "\r")
+			f.partial = f.partial[:0]
+			f.handleLineLocked(line)
+			continue
+		}
+		f.partial = append(f.partial, b)
+	}
+	return len(p), nil
+}
+
+func (*fakeDevice) SetReadTimeout(time.Duration) error { return nil }
+
+func (f *fakeDevice) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+
+// reply queues a response the way the device emits it: LF written by the
+// firmware, converted to CRLF by the USB Serial/JTAG console.
+func (f *fakeDevice) replyLocked(format string, args ...any) {
+	for _, line := range f.unsolicited {
+		f.out = append(f.out, []byte(line+"\r\n")...)
+	}
+	f.unsolicited = nil
+	f.out = append(f.out, []byte(fmt.Sprintf(format, args...)+"\r\n")...)
+}
+
+func (f *fakeDevice) finishChunkLocked() {
+	raw := f.awaitingRaw
+	f.awaitingRaw = false
+
+	decoded := f.chunkBuf
+	if !raw {
+		var err error
+		decoded, err = base64.StdEncoding.DecodeString(string(f.chunkBuf))
+		if err != nil {
+			f.chunkBuf = nil
+			f.replyLocked("ERR bad-base64")
+			return
+		}
+	}
+	f.chunkBuf = nil
+	if len(f.stagingData)+len(decoded) > f.stagingBytes {
+		f.replyLocked("ERR overflow")
+		return
+	}
+	f.stagingData = append(f.stagingData, decoded...)
+	f.nextChunk++
+	f.replyLocked("OK ASSET_CHUNK %d", f.awaitingIndex)
+}
+
+//nolint:gocritic // a command dispatch table would be less readable than this chain
+func (f *fakeDevice) handleLineLocked(line string) {
+	if line == "" {
+		return
+	}
+	f.commands = append(f.commands, line)
+
+	switch {
+	case line == "HELLO "+protocolVersion:
+		f.replyLocked("OK " + protocolVersion)
+	case line == "INFO":
+		f.replyLocked("INFO %s fw=0.1.0 display=hd458002c40 visible=320x960 transport=cdc "+
+			"features=scenes,assets-b64,quiet", protocolVersion)
+	case line == "PING":
+		f.replyLocked("PONG")
+	case line == "QUIET", line == "VERBOSE":
+		f.replyLocked("OK")
+	case line == "CLEAR":
+		f.pending = fakeScene{}
+		f.replyLocked("OK")
+	case line == "SHOW":
+		f.scenes = append(f.scenes, f.pending)
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "SCENE "):
+		f.handleSceneLocked(strings.TrimPrefix(line, "SCENE "))
+	case strings.HasPrefix(line, "TITLE "):
+		f.pending.title = truncate(strings.TrimPrefix(line, "TITLE "), maxTitleLen)
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "SYSTEM "):
+		f.pending.system = truncate(strings.TrimPrefix(line, "SYSTEM "), maxSystemLen)
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "STATUS "):
+		f.pending.status = truncate(strings.TrimPrefix(line, "STATUS "), maxStatusLen)
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "MESSAGE "):
+		f.pending.message = truncate(strings.TrimPrefix(line, "MESSAGE "), maxMessageLen)
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "ACCENT "):
+		f.handleAccentLocked(strings.TrimPrefix(line, "ACCENT "))
+	case strings.HasPrefix(line, "ELAPSED"), strings.HasPrefix(line, "TIME "):
+		f.replyLocked("OK")
+	case strings.HasPrefix(line, "ASSET_CHUNK_RAW "):
+		f.handleRawChunkHeaderLocked(strings.TrimPrefix(line, "ASSET_CHUNK_RAW "))
+	case strings.HasPrefix(line, "ASSET_BEGIN "):
+		f.handleAssetBeginLocked(strings.TrimPrefix(line, "ASSET_BEGIN "))
+	case strings.HasPrefix(line, "ASSET_CHUNK_DATA "):
+		f.handleChunkHeaderLocked(strings.TrimPrefix(line, "ASSET_CHUNK_DATA "))
+	case strings.HasPrefix(line, "ASSET_END "):
+		f.handleAssetEndLocked(strings.TrimPrefix(line, "ASSET_END "))
+	case strings.HasPrefix(line, "ASSET_USE "):
+		f.handleAssetUseLocked(strings.TrimPrefix(line, "ASSET_USE "))
+	default:
+		f.replyLocked("ERR unknown-command")
+	}
+}
+
+func (f *fakeDevice) handleSceneLocked(name string) {
+	switch name {
+	case "idle", "launching", "playing", "error":
+		f.pending.scene = name
+		f.replyLocked("OK")
+	default:
+		f.replyLocked("ERR bad-scene")
+	}
+}
+
+func (f *fakeDevice) handleAccentLocked(value string) {
+	trimmed := strings.TrimPrefix(value, "#")
+	if len(trimmed) != 6 {
+		f.replyLocked("ERR bad-color")
+		return
+	}
+	for _, c := range trimmed {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", c) {
+			f.replyLocked("ERR bad-color")
+			return
+		}
+	}
+	f.pending.accent = value
+	f.replyLocked("OK")
+}
+
+func (f *fakeDevice) handleAssetBeginLocked(args string) {
+	parts := strings.Fields(args)
+	if len(parts) != 4 {
+		f.replyLocked("ERR bad-asset-begin")
+		return
+	}
+	size, err := strconv.Atoi(parts[2])
+	if err != nil || size <= 0 {
+		f.replyLocked("ERR bad-asset-begin")
+		return
+	}
+	crc, err := strconv.ParseUint(parts[3], 16, 32)
+	if err != nil {
+		f.replyLocked("ERR bad-asset-begin")
+		return
+	}
+	f.stagingID = parts[0]
+	f.stagingMime = parts[1]
+	f.stagingBytes = size
+	f.stagingCRC = uint32(crc)
+	f.stagingData = nil
+	f.stagingDone = false
+	f.nextChunk = 0
+	f.replyLocked("OK ASSET_BEGIN")
+}
+
+func (f *fakeDevice) handleChunkHeaderLocked(args string) {
+	parts := strings.Fields(args)
+	if len(parts) != 2 {
+		f.replyLocked("ERR bad-asset-chunk")
+		return
+	}
+	index, err1 := strconv.Atoi(parts[0])
+	length, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil || length <= 0 || length%4 != 0 {
+		f.replyLocked("ERR bad-asset-chunk")
+		return
+	}
+	if index != f.nextChunk {
+		f.replyLocked("ERR bad-chunk-index")
+		return
+	}
+	f.awaitingIndex = index
+	f.awaitingBytes = length
+	f.chunkBuf = nil
+	f.replyLocked("OK ASSET_CHUNK_DATA")
+}
+
+// handleRawChunkHeaderLocked mirrors the firmware's binary-clean path: the
+// length is arbitrary and the bytes go straight into the asset buffer.
+func (f *fakeDevice) handleRawChunkHeaderLocked(args string) {
+	parts := strings.Fields(args)
+	if len(parts) != 2 {
+		f.replyLocked("ERR bad-asset-chunk")
+		return
+	}
+	index, err1 := strconv.Atoi(parts[0])
+	length, err2 := strconv.Atoi(parts[1])
+	if err1 != nil || err2 != nil || length <= 0 {
+		f.replyLocked("ERR bad-asset-chunk")
+		return
+	}
+	if index != f.nextChunk {
+		f.replyLocked("ERR bad-chunk-index")
+		return
+	}
+	f.awaitingIndex = index
+	f.awaitingBytes = length
+	f.awaitingRaw = true
+	f.chunkBuf = nil
+	f.replyLocked("OK ASSET_CHUNK_RAW")
+}
+
+func (f *fakeDevice) handleAssetEndLocked(id string) {
+	switch {
+	case f.stagingID == "" || id != f.stagingID:
+		f.replyLocked("ERR bad-asset-id")
+	case len(f.stagingData) != f.stagingBytes:
+		f.replyLocked("ERR bad-asset-size")
+	case crc32.ChecksumIEEE(f.stagingData) != f.stagingCRC:
+		f.replyLocked("ERR crc")
+	default:
+		f.stagingDone = true
+		f.replyLocked("OK ASSET %s bytes=%d crc=%08x", id, len(f.stagingData), f.stagingCRC)
+	}
+}
+
+func (f *fakeDevice) handleAssetUseLocked(args string) {
+	parts := strings.Fields(args)
+	if len(parts) != 5 || parts[0] != "cover" || parts[4] != "rgb565" {
+		f.replyLocked("ERR bad-asset-use")
+		return
+	}
+	id := parts[1]
+	width, errW := strconv.Atoi(parts[2])
+	height, errH := strconv.Atoi(parts[3])
+	if errW != nil || errH != nil || width <= 0 || height <= 0 ||
+		width > coverMaxWidth || height > coverMaxHeight {
+		f.replyLocked("ERR bad-asset-size")
+		return
+	}
+	f.committedW = width
+	f.committedH = height
+
+	if f.failNextAssetUse != "" {
+		reason := f.failNextAssetUse
+		f.failNextAssetUse = ""
+		f.replyLocked("ERR %s", reason)
+		return
+	}
+
+	// Already committed: re-selectable without another upload.
+	if f.committedID != "" && f.committedID == id {
+		f.pending.coverID = id
+		f.replyLocked("OK")
+		return
+	}
+	if !f.stagingDone || f.stagingID != id {
+		f.replyLocked("ERR asset-missing")
+		return
+	}
+	if f.stagingMime != "image/rgb565" {
+		f.replyLocked("ERR bad-asset-mime")
+		return
+	}
+	// The device accepts any aspect within its bounds, so the declared size is
+	// what the payload has to match, not a fixed slot.
+	if len(f.stagingData) != width*height*2 {
+		f.replyLocked("ERR bad-asset-size")
+		return
+	}
+	f.committedID = id
+	f.committedBytes = len(f.stagingData)
+	f.stagingDone = false
+	f.pending.coverID = id
+	f.replyLocked("OK")
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
+// --- test helpers ---
+
+func (f *fakeDevice) commandLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.commands))
+	copy(out, f.commands)
+	return out
+}
+
+func (f *fakeDevice) renderedScenes() []fakeScene {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeScene, len(f.scenes))
+	copy(out, f.scenes)
+	return out
+}
+
+func (f *fakeDevice) lastScene() (fakeScene, bool) {
+	scenes := f.renderedScenes()
+	if len(scenes) == 0 {
+		return fakeScene{}, false
+	}
+	return scenes[len(scenes)-1], true
+}
+
+func (f *fakeDevice) countCommands(prefix string) int {
+	count := 0
+	for _, cmd := range f.commandLog() {
+		if strings.HasPrefix(cmd, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+// forgetAssets simulates the device rebooting: it keeps the link but loses
+// every uploaded asset, which is the real cause of ERR asset-missing.
+func (f *fakeDevice) forgetAssets() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.committedID = ""
+	f.stagingDone = false
+	f.stagingID = ""
+}
+
+func (f *fakeDevice) queueLogLine(line string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unsolicited = append(f.unsolicited, line)
+}
+
+// gateWrites blocks all writes until the returned function is called.
+func (f *fakeDevice) gateWrites() func() {
+	gate := make(chan struct{})
+	f.gateMu.Lock()
+	f.gate = gate
+	f.gateMu.Unlock()
+
+	return func() {
+		f.gateMu.Lock()
+		f.gate = nil
+		f.gateMu.Unlock()
+		close(gate)
+	}
+}
+
+func (f *fakeDevice) setWriteError(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writeErr = err
+}
+
+// committedSize returns the byte length of the cover the device is holding.
+func (f *fakeDevice) committedSize() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.committedBytes
+}

--- a/pkg/readers/zapdisplay/fakedevice_test.go
+++ b/pkg/readers/zapdisplay/fakedevice_test.go
@@ -59,11 +59,13 @@ type fakeDevice struct {
 	pending          fakeScene
 	committedID      string
 	failNextAssetUse string
-	stagingID        string
-	stagingMime      string
-	chunkBuf         []byte
-	stagingData      []byte
-	partial          []byte
+	// rotation is the device-owned setting, which the firmware keeps in NVS.
+	rotation    string
+	stagingID   string
+	stagingMime string
+	chunkBuf    []byte
+	stagingData []byte
+	partial     []byte
 	// commands records every complete command line received, in order.
 	commands []string
 	scenes   []fakeScene
@@ -201,7 +203,7 @@ func (f *fakeDevice) handleLineLocked(line string) {
 		f.replyLocked("OK " + protocolVersion)
 	case line == "INFO":
 		f.replyLocked("INFO %s fw=0.1.0 display=hd458002c40 visible=320x960 transport=cdc "+
-			"features=scenes,assets-b64,quiet", protocolVersion)
+			"features=scenes,assets-b64,quiet,settings", protocolVersion)
 	case line == "PING":
 		f.replyLocked("PONG")
 	case line == "QUIET", line == "VERBOSE":
@@ -228,6 +230,8 @@ func (f *fakeDevice) handleLineLocked(line string) {
 		f.replyLocked("OK")
 	case strings.HasPrefix(line, "ACCENT "):
 		f.handleAccentLocked(strings.TrimPrefix(line, "ACCENT "))
+	case strings.HasPrefix(line, "SET "):
+		f.handleSetLocked(strings.TrimPrefix(line, "SET "))
 	case strings.HasPrefix(line, "ELAPSED"), strings.HasPrefix(line, "TIME "):
 		f.replyLocked("OK")
 	case strings.HasPrefix(line, "ASSET_CHUNK_RAW "):
@@ -243,6 +247,26 @@ func (f *fakeDevice) handleLineLocked(line string) {
 	default:
 		f.replyLocked("ERR unknown-command")
 	}
+}
+
+// handleSetLocked mirrors the firmware's settings store, which owns its values
+// and answers ERR bad-value for an angle the panel has no layout for.
+func (f *fakeDevice) handleSetLocked(args string) {
+	key, value, ok := strings.Cut(args, " ")
+	if !ok {
+		f.replyLocked("ERR bad-value")
+		return
+	}
+	if key != "rotation" {
+		f.replyLocked("ERR bad-setting")
+		return
+	}
+	if value != "0" && value != "180" {
+		f.replyLocked("ERR bad-value")
+		return
+	}
+	f.rotation = value
+	f.replyLocked("OK")
 }
 
 func (f *fakeDevice) handleSceneLocked(name string) {
@@ -494,4 +518,12 @@ func (f *fakeDevice) committedSize() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.committedBytes
+}
+
+// settingRotation returns the rotation the device is holding, as the firmware
+// would keep it in NVS.
+func (f *fakeDevice) settingRotation() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.rotation
 }

--- a/pkg/readers/zapdisplay/main_test.go
+++ b/pkg/readers/zapdisplay/main_test.go
@@ -1,0 +1,30 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/readers/zapdisplay/probecache.go
+++ b/pkg/readers/zapdisplay/probecache.go
@@ -1,0 +1,101 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"os"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+)
+
+// probeRetryInterval is how long a failed port is left alone before it is
+// tried again.
+//
+// A retry is needed because the display itself can fail a probe: the ESP32-S3
+// enumerates from its ROM bootloader, so the device node exists before the
+// firmware's protocol loop is answering. A probe that lands in that window
+// times out, and with no retry the display would stay undetectable until it
+// was physically replugged. Only ports that passed the vendor filter ever get
+// here, so this is mostly re-asking the display rather than other hardware.
+const probeRetryInterval = time.Minute
+
+// Ports that answered something other than the zapdisplay handshake.
+//
+// Auto-detect runs once a second. Without this a port that is not a display
+// would be opened and written to on every tick for as long as it stays plugged
+// in, which for a 3D printer or a microcontroller is both pointless and rude.
+//
+// An entry is keyed by the device file's modification time, so unplugging and
+// replugging - which recreates the node - clears it and the port is probed
+// again. That mirrors how the PN532 driver tracks its own failed probes.
+type failedProbeEntry struct {
+	deviceModTime time.Time
+	failedAt      time.Time
+}
+
+var (
+	probeStateMu     syncutil.RWMutex
+	failedProbePaths = make(map[string]failedProbeEntry)
+)
+
+// refreshFailedProbes drops entries whose device file has changed or gone away,
+// so a replug or a different device at the same path is probed afresh.
+func refreshFailedProbes() {
+	probeStateMu.Lock()
+	defer probeStateMu.Unlock()
+	for path, entry := range failedProbePaths {
+		info, err := os.Stat(path)
+		if err != nil || !info.ModTime().Equal(entry.deviceModTime) {
+			delete(failedProbePaths, path)
+		}
+	}
+}
+
+// probeFailedRecently reports whether a port failed a probe recently enough to
+// skip. An older failure is retried, and recordFailedProbe re-arms the window
+// if it fails again, so a port that is simply not a display is still only
+// opened once a minute.
+func probeFailedRecently(path string, now time.Time) bool {
+	probeStateMu.RLock()
+	defer probeStateMu.RUnlock()
+	entry, failed := failedProbePaths[path]
+	return failed && now.Sub(entry.failedAt) < probeRetryInterval
+}
+
+func recordFailedProbe(path string, now time.Time) {
+	info, err := os.Stat(path)
+	if err != nil {
+		// The device vanished mid-probe. Nothing to remember it by, and it will
+		// be reported fresh if it comes back.
+		return
+	}
+	probeStateMu.Lock()
+	defer probeStateMu.Unlock()
+	failedProbePaths[path] = failedProbeEntry{deviceModTime: info.ModTime(), failedAt: now}
+}
+
+// clearFailedProbe forgets one path, so a port that has just been claimed is
+// probed normally if the reader later disconnects.
+func clearFailedProbe(path string) {
+	probeStateMu.Lock()
+	defer probeStateMu.Unlock()
+	delete(failedProbePaths, path)
+}

--- a/pkg/readers/zapdisplay/probecache_test.go
+++ b/pkg/readers/zapdisplay/probecache_test.go
@@ -1,0 +1,188 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetProbeState clears the package-level cache so tests do not leak into
+// each other. These cannot run in parallel for the same reason.
+func resetProbeState(t *testing.T) {
+	t.Helper()
+	probeStateMu.Lock()
+	failedProbePaths = make(map[string]failedProbeEntry)
+	probeStateMu.Unlock()
+	t.Cleanup(func() {
+		probeStateMu.Lock()
+		failedProbePaths = make(map[string]failedProbeEntry)
+		probeStateMu.Unlock()
+	})
+}
+
+func fakeDevNode(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ttyACM0")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	return path
+}
+
+func TestFailedProbeIsRememberedSoPortsAreNotHammered(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	path := fakeDevNode(t)
+
+	assert.False(t, probeFailedRecently(path, now), "nothing known about a fresh port")
+	recordFailedProbe(path, now)
+
+	// Auto-detect runs once a second; a port that answered wrongly must not be
+	// reopened and written to on every tick.
+	assert.True(t, probeFailedRecently(path, now))
+	refreshFailedProbes()
+	assert.True(t, probeFailedRecently(path, now), "an unchanged device stays remembered")
+}
+
+func TestFailedProbeClearedWhenDeviceReplugged(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	path := fakeDevNode(t)
+	recordFailedProbe(path, now)
+	require.True(t, probeFailedRecently(path, now))
+
+	// Replugging recreates the device node, which changes its mtime. The port
+	// may now be a different device entirely, so it has to be probed again.
+	future := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(path, future, future))
+	refreshFailedProbes()
+
+	assert.False(t, probeFailedRecently(path, now))
+}
+
+func TestFailedProbeClearedWhenDeviceDisappears(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	path := fakeDevNode(t)
+	recordFailedProbe(path, now)
+	require.NoError(t, os.Remove(path))
+
+	refreshFailedProbes()
+	assert.False(t, probeFailedRecently(path, now), "an unplugged device leaves no entry behind")
+}
+
+func TestClearFailedProbeForgetsOnePath(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	a, b := fakeDevNode(t), fakeDevNode(t)
+	recordFailedProbe(a, now)
+	recordFailedProbe(b, now)
+
+	clearFailedProbe(a)
+	assert.False(t, probeFailedRecently(a, now))
+	assert.True(t, probeFailedRecently(b, now), "clearing one path leaves the others alone")
+}
+
+func TestRecordFailedProbeIgnoresMissingDevice(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	missing := filepath.Join(t.TempDir(), "gone")
+
+	// The device vanished mid-probe: there is nothing to key an entry on, and
+	// it should be treated as unknown rather than remembered as failed.
+	recordFailedProbe(missing, now)
+	assert.False(t, probeFailedRecently(missing, now))
+}
+
+func TestFailedProbeRetriedAfterTheRetryInterval(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	path := fakeDevNode(t)
+
+	recordFailedProbe(path, now)
+	require.True(t, probeFailedRecently(path, now.Add(probeRetryInterval-time.Second)))
+
+	// The display itself can fail a probe: its USB peripheral enumerates from
+	// the ROM bootloader, so the node exists before the firmware answers. A
+	// failure that is never retried would leave it undetectable until replug.
+	assert.False(t, probeFailedRecently(path, now.Add(probeRetryInterval)))
+}
+
+func TestFailedProbeRearmsAfterEachRetry(t *testing.T) {
+	resetProbeState(t)
+	now := time.Now()
+	path := fakeDevNode(t)
+
+	recordFailedProbe(path, now)
+	retryAt := now.Add(probeRetryInterval)
+	require.False(t, probeFailedRecently(path, retryAt))
+
+	// A port that is simply not a display must go back to being skipped, so
+	// retrying costs one open a minute rather than one a second.
+	recordFailedProbe(path, retryAt)
+	assert.True(t, probeFailedRecently(path, retryAt.Add(time.Second)))
+}
+
+func TestCouldBeDisplayAllowsUnknownVendor(t *testing.T) {
+	t.Parallel()
+
+	// Where the vendor cannot be read - no udevadm, or a non-USB node - the
+	// port must still be probed, or the display would be undetectable there.
+	r := NewReader(&config.Instance{})
+	r.vendorIDs = func(string) (string, string, bool) { return "", "", false }
+	assert.True(t, r.couldBeDisplay("/dev/ttyACM0"))
+}
+
+func TestCouldBeDisplayAcceptsTheDisplayVendor(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(&config.Instance{})
+	r.vendorIDs = func(string) (string, string, bool) { return espressifVID, "1001", true }
+	assert.True(t, r.couldBeDisplay("/dev/ttyACM0"))
+}
+
+func TestCouldBeDisplayRejectsOtherVendors(t *testing.T) {
+	t.Parallel()
+
+	// Probing writes to whatever is on the other end, and /dev/ttyACM* is also
+	// where 3D printers and Arduino-class boards appear. A known other vendor
+	// must never be opened.
+	r := NewReader(&config.Instance{})
+	r.vendorIDs = func(string) (string, string, bool) { return "2341", "0043", true }
+	assert.False(t, r.couldBeDisplay("/dev/ttyACM0"))
+}
+
+func TestDefaultEnabledIsPerPlatform(t *testing.T) {
+	t.Parallel()
+
+	// Detection writes to a serial port, so it is only on by default where the
+	// display is an expected accessory.
+	assert.False(t, NewReader(&config.Instance{}).Metadata().DefaultEnabled)
+	assert.False(t, NewReaderWithDefaults(&config.Instance{}, false).Metadata().DefaultEnabled)
+	assert.True(t, NewReaderWithDefaults(&config.Instance{}, true).Metadata().DefaultEnabled)
+
+	// Auto-detect stays on regardless: it only runs once the driver is enabled.
+	assert.True(t, NewReader(&config.Instance{}).Metadata().DefaultAutoDetect)
+}

--- a/pkg/readers/zapdisplay/protocol.go
+++ b/pkg/readers/zapdisplay/protocol.go
@@ -1,0 +1,421 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
+)
+
+const (
+	// protocolVersion is the wire contract this driver speaks. The device
+	// echoes it back during the handshake and it is the only reliable way to
+	// identify the accessory: it enumerates with Espressif's stock USB ID and
+	// no product string.
+	protocolVersion = "zapdisplay/1"
+
+	baudRate    = 115200
+	readTimeout = 250 * time.Millisecond
+
+	// handshakeTimeout bounds the whole claim sequence during detection. Auto
+	// detect probes once a second, so a wedged port must not hold it up.
+	handshakeTimeout = 2 * time.Second
+	// commandTimeout covers an ordinary command. SHOW is the slow one: the
+	// device answers only after it has drawn a full 400x960 frame.
+	commandTimeout = 5 * time.Second
+	// uploadTimeout covers a single asset chunk exchange.
+	uploadTimeout = 8 * time.Second
+
+	// Artwork bounds, mirroring the firmware's main/ui/state.h. Artwork is not
+	// a fixed slot: box art is portrait on some systems and landscape on
+	// others, so the device is sent whatever aspect the source has and lays out
+	// its detail column around it.
+	coverMaxWidth  = 512
+	coverMaxHeight = 288
+	coverMaxBytes  = coverMaxWidth * coverMaxHeight * 2
+
+	// chunkDecodedBytes is the payload per base64 asset chunk. The device
+	// decodes into a 768 byte buffer and requires the base64 length to be a
+	// multiple of 4, so 768 decoded bytes (1024 encoded) fills it exactly.
+	chunkDecodedBytes = 768
+
+	// chunkRawBytes is the payload per raw chunk on firmware that advertises
+	// "assets-raw". Raw bytes go straight into the asset buffer, so the device
+	// imposes no size limit and this is chosen purely to amortise the per-chunk
+	// round trip: throughput flattens around here, and raw transfer is roughly
+	// two and a half times faster than base64 end to end.
+	chunkRawBytes = 32768
+
+	// Field lengths the device silently truncates at, minus the terminator.
+	maxTitleLen   = 63
+	maxSystemLen  = 47
+	maxStatusLen  = 47
+	maxMessageLen = 95
+)
+
+// errNotZapDisplay reports that a port answered, but not as a display.
+var errNotZapDisplay = errors.New("not a zapdisplay device")
+
+// protocolError is an ERR response from the device. The reason is matched
+// against known values, so callers can react to a missing asset without
+// string-matching the whole message themselves.
+type protocolError struct {
+	command string
+	reason  string
+}
+
+func (e *protocolError) Error() string {
+	return fmt.Sprintf("zapdisplay %q failed: %s", e.command, e.reason)
+}
+
+// isAssetMissing reports whether err is the device saying it does not hold the
+// asset the host asked it to display, which happens after it reboots.
+func isAssetMissing(err error) bool {
+	var protoErr *protocolError
+	return errors.As(err, &protoErr) && protoErr.reason == "asset-missing"
+}
+
+// logLinePattern matches ESP-IDF log output, which shares the serial stream
+// with protocol responses. Lines like "I (1234) display: Render scene: idle"
+// are skipped wherever a response is expected.
+var logLinePattern = regexp.MustCompile(`^[VDIWE] \(\d+\)`)
+
+// ansiPattern strips terminal colour codes, which ESP-IDF adds to log lines
+// when colour output is enabled in the firmware build.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func isProtocolNoise(line string) bool {
+	if line == "" {
+		return true
+	}
+	// An unsolicited READY beacon arrives every five seconds until QUIET is
+	// accepted, and can land in the middle of any exchange.
+	return logLinePattern.MatchString(line) || strings.HasPrefix(line, "READY "+protocolVersion)
+}
+
+// lineReader turns a serial port into newline-delimited lines.
+//
+// It cannot use bufio: go.bug.st/serial signals a read timeout by returning
+// (0, nil), which bufio treats as lack of progress and turns into
+// io.ErrNoProgress after a hundred such reads. Here a timed-out read is simply
+// a retry until the caller's deadline passes.
+type lineReader struct {
+	port testutils.SerialPort
+	buf  []byte
+	tmp  [512]byte
+}
+
+func newLineReader(port testutils.SerialPort) *lineReader {
+	return &lineReader{port: port}
+}
+
+// readLine returns the next complete line, without its terminator. The device
+// writes "\n" but the USB Serial/JTAG console converts that to "\r\n", so the
+// carriage return is stripped here.
+func (l *lineReader) readLine(ctx context.Context, deadline time.Time) (string, error) {
+	for {
+		if idx := indexNewline(l.buf); idx >= 0 {
+			line := string(l.buf[:idx])
+			l.buf = l.buf[idx+1:]
+			return strings.TrimRight(line, "\r"), nil
+		}
+
+		if err := ctx.Err(); err != nil {
+			return "", fmt.Errorf("read line: %w", err)
+		}
+		if !time.Now().Before(deadline) {
+			return "", context.DeadlineExceeded
+		}
+
+		n, err := l.port.Read(l.tmp[:])
+		if err != nil {
+			return "", fmt.Errorf("read from display: %w", err)
+		}
+		if n == 0 {
+			// Read timeout. Nothing to do but try again until the deadline.
+			continue
+		}
+		l.buf = append(l.buf, l.tmp[:n]...)
+	}
+}
+
+// drain consumes and discards whatever is already buffered, giving boot logs a
+// moment to finish before the handshake starts.
+func (l *lineReader) drain(ctx context.Context, d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) && ctx.Err() == nil {
+		if _, err := l.readLine(ctx, deadline); err != nil {
+			return
+		}
+	}
+}
+
+func indexNewline(b []byte) int {
+	for i, c := range b {
+		if c == '\n' {
+			return i
+		}
+	}
+	return -1
+}
+
+// session is a claimed connection to a display.
+type session struct {
+	port     testutils.SerialPort
+	lines    *lineReader
+	info     string
+	features map[string]bool
+	buf      []byte
+}
+
+func newSession(port testutils.SerialPort) *session {
+	return &session{port: port, lines: newLineReader(port)}
+}
+
+// writeLine sends one command. The device matches commands on an exact prefix
+// plus a single space, so the caller is responsible for well-formed text.
+func (s *session) writeLine(text string) error {
+	if strings.ContainsAny(text, "\r\n") {
+		return fmt.Errorf("command %q contains a line break", text)
+	}
+	s.buf = append(s.buf[:0], text...)
+	s.buf = append(s.buf, '\n')
+	if _, err := s.port.Write(s.buf); err != nil {
+		return fmt.Errorf("write command %q: %w", text, err)
+	}
+	return nil
+}
+
+// writeRaw sends payload bytes that are not a command, used for the framed
+// portion of an asset chunk.
+func (s *session) writeRaw(payload []byte) error {
+	if _, err := s.port.Write(payload); err != nil {
+		return fmt.Errorf("write payload: %w", err)
+	}
+	return nil
+}
+
+// expect reads until a line matches one of the wanted prefixes, skipping log
+// output and stray beacons. An ERR line ends the wait with a protocolError.
+func (s *session) expect(ctx context.Context, command string, timeout time.Duration, wanted ...string) (string, error) {
+	deadline := time.Now().Add(timeout)
+	seen := make([]string, 0, 4)
+
+	for {
+		line, err := s.lines.readLine(ctx, deadline)
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				return "", fmt.Errorf("timed out waiting for %v after %q (saw %v)", wanted, command, seen)
+			}
+			return "", err
+		}
+		line = ansiPattern.ReplaceAllString(line, "")
+		if isProtocolNoise(line) {
+			continue
+		}
+		if len(seen) < cap(seen) {
+			seen = append(seen, line)
+		}
+		if reason, ok := strings.CutPrefix(line, "ERR "); ok {
+			return "", &protocolError{command: command, reason: reason}
+		}
+		for _, want := range wanted {
+			if strings.HasPrefix(line, want) {
+				return line, nil
+			}
+		}
+	}
+}
+
+// command sends a line and waits for the matching response.
+func (s *session) command(ctx context.Context, text string, timeout time.Duration, wanted ...string) (string, error) {
+	if err := s.writeLine(text); err != nil {
+		return "", err
+	}
+	return s.expect(ctx, text, timeout, wanted...)
+}
+
+// claim performs the handshake that identifies a display and takes ownership of
+// the stream. QUIET stops the five-second READY beacon so later exchanges are
+// not interleaved with it.
+func (s *session) claim(ctx context.Context) error {
+	s.lines.drain(ctx, 200*time.Millisecond)
+
+	if _, err := s.command(ctx, "HELLO "+protocolVersion, handshakeTimeout, "OK "+protocolVersion); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timed out") {
+			return errNotZapDisplay
+		}
+		return err
+	}
+
+	info, err := s.command(ctx, "INFO", handshakeTimeout, "INFO "+protocolVersion)
+	if err != nil {
+		return err
+	}
+	s.info = info
+	s.features = parseFeatures(info)
+
+	if _, err := s.command(ctx, "QUIET", handshakeTimeout, "OK"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseFeatures pulls the capability tokens out of an INFO line.
+//
+// Parsed rather than substring-matched: features= is one field among several,
+// and a display name or firmware version containing a capability token would
+// otherwise claim a capability the device does not have.
+func parseFeatures(info string) map[string]bool {
+	features := map[string]bool{}
+	for _, field := range strings.Fields(info) {
+		rest, ok := strings.CutPrefix(field, "features=")
+		if !ok {
+			continue
+		}
+		for _, token := range strings.Split(rest, ",") {
+			if token != "" {
+				features[token] = true
+			}
+		}
+	}
+	return features
+}
+
+// uploadCover sends a cover image and selects it for the playing scene.
+//
+// The ordering matters. The device holds the committed cover separately from
+// the upload buffer, so ASSET_USE is what makes a freshly uploaded image
+// visible, and re-sending ASSET_USE alone re-selects an image it already has.
+func (s *session) uploadCover(ctx context.Context, assetID string, pixels []byte) error {
+	if len(pixels) == 0 || len(pixels) > coverMaxBytes {
+		return fmt.Errorf("cover must be 1..%d bytes, got %d", coverMaxBytes, len(pixels))
+	}
+
+	sum := crc32.ChecksumIEEE(pixels)
+	begin := fmt.Sprintf("ASSET_BEGIN %s image/rgb565 %d %08x", assetID, len(pixels), sum)
+	if _, err := s.command(ctx, begin, uploadTimeout, "OK ASSET_BEGIN"); err != nil {
+		return err
+	}
+
+	var err error
+	if s.features["assets-raw"] {
+		err = s.uploadRawChunks(ctx, pixels)
+	} else {
+		err = s.uploadBase64Chunks(ctx, pixels)
+	}
+	if err != nil {
+		return err
+	}
+
+	end := "ASSET_END " + assetID
+	want := fmt.Sprintf("OK ASSET %s bytes=%d crc=%08x", assetID, len(pixels), sum)
+	if _, err := s.command(ctx, end, uploadTimeout, want); err != nil {
+		return err
+	}
+	return nil
+}
+
+// uploadRawChunks sends payload bytes with no encoding. The firmware sets its
+// console to pass received bytes through unmodified, which is what makes this
+// safe; older firmware translated CR and silently corrupted binary payloads,
+// which is why base64 remains the fallback.
+func (s *session) uploadRawChunks(ctx context.Context, pixels []byte) error {
+	for index, offset := 0, 0; offset < len(pixels); index, offset = index+1, offset+chunkRawBytes {
+		end := min(offset+chunkRawBytes, len(pixels))
+		chunk := pixels[offset:end]
+
+		header := fmt.Sprintf("ASSET_CHUNK_RAW %d %d", index, len(chunk))
+		if _, err := s.command(ctx, header, uploadTimeout, "OK ASSET_CHUNK_RAW"); err != nil {
+			return err
+		}
+		// The device is now blocking on exactly this many bytes, so the chunk
+		// has to be treated as atomic: abandoning it here would wedge the
+		// firmware until its read deadline expires.
+		if err := s.writeRaw(chunk); err != nil {
+			return err
+		}
+		want := fmt.Sprintf("OK ASSET_CHUNK %d", index)
+		if _, err := s.expect(ctx, header, uploadTimeout, want); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *session) uploadBase64Chunks(ctx context.Context, pixels []byte) error {
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(chunkDecodedBytes))
+	for index, offset := 0, 0; offset < len(pixels); index, offset = index+1, offset+chunkDecodedBytes {
+		end := min(offset+chunkDecodedBytes, len(pixels))
+		chunk := encoded[:base64.StdEncoding.EncodedLen(end-offset)]
+		base64.StdEncoding.Encode(chunk, pixels[offset:end])
+
+		header := fmt.Sprintf("ASSET_CHUNK_DATA %d %d", index, len(chunk))
+		if _, err := s.command(ctx, header, uploadTimeout, "OK ASSET_CHUNK_DATA"); err != nil {
+			return err
+		}
+		if err := s.writeRaw(chunk); err != nil {
+			return err
+		}
+		want := fmt.Sprintf("OK ASSET_CHUNK %d", index)
+		if _, err := s.expect(ctx, header, uploadTimeout, want); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// useCover selects an already-uploaded cover for the playing scene. The size is
+// part of the command because the device stores whatever aspect it was sent.
+func (s *session) useCover(ctx context.Context, assetID string, width, height int) error {
+	text := fmt.Sprintf("ASSET_USE cover %s %d %d rgb565", assetID, width, height)
+	_, err := s.command(ctx, text, commandTimeout, "OK")
+	return err
+}
+
+// pushClock gives the device a wall clock for its idle screens. Failure is not
+// worth propagating: the device simply skips the clock screen when it has never
+// been told the time.
+func (s *session) pushClock(ctx context.Context) {
+	if !s.features["clock"] {
+		return
+	}
+	now := time.Now()
+	_, offset := now.Zone()
+	text := fmt.Sprintf("TIME %d %d", now.Unix(), offset)
+	// A device that will not take the clock simply never shows a clock screen,
+	// which is the same as never having been told.
+	_, _ = s.command(ctx, text, commandTimeout, "OK")
+}
+
+func (s *session) close() error {
+	if err := s.port.Close(); err != nil {
+		return fmt.Errorf("close display port: %w", err)
+	}
+	return nil
+}

--- a/pkg/readers/zapdisplay/protocol.go
+++ b/pkg/readers/zapdisplay/protocol.go
@@ -398,6 +398,24 @@ func (s *session) useCover(ctx context.Context, assetID string, width, height in
 	return err
 }
 
+// setRotation turns the panel for a display mounted the other way up.
+//
+// The device owns this setting and keeps it in NVS, so it also comes up the
+// right way round with no host attached. Core sends it anyway on every connect,
+// because Core is where the user configured it and the device's copy is only a
+// cache.
+//
+// The firmware takes 0 and 180 and answers ERR bad-value for anything else: the
+// panel has one landscape layout, so a quarter turn would need a UI it does not
+// have rather than a transform.
+func (s *session) setRotation(ctx context.Context, degrees int) error {
+	if !s.features["settings"] {
+		return fmt.Errorf("display firmware has no settings support, cannot rotate to %d", degrees)
+	}
+	_, err := s.command(ctx, fmt.Sprintf("SET rotation %d", degrees), commandTimeout, "OK")
+	return err
+}
+
 // pushClock gives the device a wall clock for its idle screens. Failure is not
 // worth propagating: the device simply skips the clock screen when it has never
 // been told the time.

--- a/pkg/readers/zapdisplay/protocol_test.go
+++ b/pkg/readers/zapdisplay/protocol_test.go
@@ -1,0 +1,226 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stallingPort returns (0, nil) a fixed number of times before delivering data,
+// reproducing how go.bug.st/serial reports a read timeout.
+type stallingPort struct {
+	data   []byte
+	mu     syncutil.Mutex
+	stalls int
+	reads  int
+}
+
+func (p *stallingPort) Read(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.reads++
+	if p.stalls > 0 {
+		p.stalls--
+		return 0, nil
+	}
+	if len(p.data) == 0 {
+		return 0, nil
+	}
+	n := copy(b, p.data)
+	p.data = p.data[n:]
+	return n, nil
+}
+
+func (*stallingPort) Write(b []byte) (int, error)        { return len(b), nil }
+func (*stallingPort) Close() error                       { return nil }
+func (*stallingPort) SetReadTimeout(time.Duration) error { return nil }
+
+func TestLineReaderTreatsEmptyReadsAsTimeoutNotFailure(t *testing.T) {
+	t.Parallel()
+
+	// More than bufio's 100-empty-read limit, which is why this driver cannot
+	// use bufio.Reader on a serial port.
+	port := &stallingPort{stalls: 250, data: []byte("OK zapdisplay/1\r\n")}
+	reader := newLineReader(port)
+
+	line, err := reader.readLine(context.Background(), time.Now().Add(2*time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, "OK zapdisplay/1", line, "carriage return must be stripped")
+	assert.Greater(t, port.reads, 250)
+}
+
+func TestLineReaderTimesOutWithoutData(t *testing.T) {
+	t.Parallel()
+
+	reader := newLineReader(&stallingPort{stalls: 1 << 30})
+	_, err := reader.readLine(context.Background(), time.Now().Add(20*time.Millisecond))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestLineReaderSplitsMultipleLinesFromOneRead(t *testing.T) {
+	t.Parallel()
+
+	reader := newLineReader(&stallingPort{data: []byte("OK\r\nPONG\r\n")})
+	deadline := time.Now().Add(time.Second)
+
+	first, err := reader.readLine(context.Background(), deadline)
+	require.NoError(t, err)
+	second, err := reader.readLine(context.Background(), deadline)
+	require.NoError(t, err)
+
+	assert.Equal(t, "OK", first)
+	assert.Equal(t, "PONG", second)
+}
+
+func TestExpectSkipsLogLinesAndBeacons(t *testing.T) {
+	t.Parallel()
+
+	noise := strings.Join([]string{
+		"I (1234) display: Render scene: playing",
+		"READY zapdisplay/1 fw=0.1.0 display=hd458002c40_320x960",
+		"W (1240) zapdisplay.protocol: something",
+		"OK",
+	}, "\r\n") + "\r\n"
+
+	sess := newSession(&stallingPort{data: []byte(noise)})
+	line, err := sess.expect(context.Background(), "SHOW", time.Second, "OK")
+	require.NoError(t, err)
+	assert.Equal(t, "OK", line)
+}
+
+func TestExpectSkipsColouredLogLines(t *testing.T) {
+	t.Parallel()
+
+	noise := "\x1b[0;32mI (99) display: hello\x1b[0m\r\nOK\r\n"
+	sess := newSession(&stallingPort{data: []byte(noise)})
+
+	line, err := sess.expect(context.Background(), "SHOW", time.Second, "OK")
+	require.NoError(t, err)
+	assert.Equal(t, "OK", line)
+}
+
+func TestExpectSurfacesDeviceErrors(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession(&stallingPort{data: []byte("ERR asset-missing\r\n")})
+	_, err := sess.expect(context.Background(), "ASSET_USE cover x 192 288 rgb565", time.Second, "OK")
+
+	require.Error(t, err)
+	var protoErr *protocolError
+	require.ErrorAs(t, err, &protoErr)
+	assert.Equal(t, "asset-missing", protoErr.reason)
+	assert.True(t, isAssetMissing(err))
+}
+
+func TestIsAssetMissingIgnoresOtherFailures(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, isAssetMissing(errors.New("boom")))
+	assert.False(t, isAssetMissing(&protocolError{command: "SHOW", reason: "render-failed"}))
+}
+
+func TestExpectTimeoutReportsWhatItSaw(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession(&stallingPort{data: []byte("SOMETHING ELSE\r\n")})
+	_, err := sess.expect(context.Background(), "SHOW", 50*time.Millisecond, "OK")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SHOW")
+	assert.Contains(t, err.Error(), "SOMETHING ELSE")
+}
+
+func TestWriteLineRejectsEmbeddedNewlines(t *testing.T) {
+	t.Parallel()
+
+	sess := newSession(&stallingPort{})
+	require.Error(t, sess.writeLine("TITLE bad\ninjected"))
+	require.Error(t, sess.writeLine("TITLE bad\rinjected"))
+}
+
+func TestUploadCoverRejectsSizesTheDeviceCannotHold(t *testing.T) {
+	t.Parallel()
+
+	// Any aspect within the device's bounds is legal now, so only an empty
+	// buffer or one that overruns the asset limit is rejected up front.
+	sess := newSession(&stallingPort{})
+	err := sess.uploadCover(context.Background(), "abc", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bytes")
+
+	err = sess.uploadCover(context.Background(), "abc", make([]byte, coverMaxBytes+2))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bytes")
+}
+
+func TestDisplayFieldFoldsAccentsAndDropsUnrenderable(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"accents folded to ascii", "Pokémon Rouge", "Pokemon Rouge"},
+		{"plain ascii untouched", "Super Metroid", "Super Metroid"},
+		{"unrenderable dropped", "Ys Ⅰ ドラゴン", "Ys"},
+		{"control characters removed", "Bad\x07Title", "BadTitle"},
+		{"whitespace collapsed", "  Sonic   the   Hedgehog  ", "Sonic the Hedgehog"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, displayField(tc.input, maxTitleLen, "UNKNOWN"))
+		})
+	}
+}
+
+func TestDisplayFieldFallsBackWhenNothingRenderable(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "UNKNOWN", displayField("", maxTitleLen, "UNKNOWN"))
+	assert.Equal(t, "UNKNOWN", displayField("ドラゴン", maxTitleLen, "UNKNOWN"))
+}
+
+func TestDisplayFieldTruncatesToDeviceBuffer(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 200)
+	assert.Len(t, displayField(long, maxTitleLen, "UNKNOWN"), maxTitleLen)
+	assert.Len(t, displayField(long, maxSystemLen, "UNKNOWN"), maxSystemLen)
+}
+
+func TestMediaKeyDistinguishesIdleFromMedia(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, mediaKey(nil))
+	assert.NotEmpty(t, mediaKey(testMedia("snes", "Super Metroid")))
+	assert.NotEqual(t,
+		mediaKey(testMedia("snes", "Super Metroid")),
+		mediaKey(testMedia("snes", "Chrono Trigger")),
+	)
+}

--- a/pkg/readers/zapdisplay/zapdisplay.go
+++ b/pkg/readers/zapdisplay/zapdisplay.go
@@ -355,6 +355,10 @@ func (r *Reader) Open(device config.ReadersConnect, _ chan<- readers.Scan, opts 
 
 	r.connected.Store(true)
 
+	// Before the first frame, so a rotated panel never shows one upside down
+	// and then flips.
+	r.applyRotation(r.workerCtx, sess)
+
 	if err := r.renderIdle(r.workerCtx, sess); err != nil {
 		log.Warn().Err(err).Msg("zapdisplay: failed to render idle scene")
 	}
@@ -364,6 +368,28 @@ func (r *Reader) Open(device config.ReadersConnect, _ chan<- readers.Scan, opts 
 
 	log.Info().Str("port", device.Path).Str("info", sess.info).Msg("zapdisplay display connected")
 	return nil
+}
+
+// applyRotation turns the panel to match the configured rotation.
+//
+// A rotation this panel cannot do is reported and ignored rather than failing
+// the connect: a display that is the wrong way up is still a working display,
+// and refusing to come up at all would be a worse answer to a config typo.
+func (r *Reader) applyRotation(ctx context.Context, sess *session) {
+	degrees := r.cfg.DriverRotation(driverID)
+	if degrees != config.RotationNone && degrees != config.RotationHalf {
+		log.Warn().
+			Int("rotation", degrees).
+			Msg("zapdisplay: display supports 0 and 180 only, leaving it unrotated")
+		degrees = config.RotationNone
+	}
+
+	// Zero is sent rather than skipped: the device keeps its rotation across
+	// power cycles, so a panel may still be holding one the user has since
+	// turned off.
+	if err := sess.setRotation(ctx, degrees); err != nil {
+		log.Warn().Err(err).Int("rotation", degrees).Msg("zapdisplay: could not set display rotation")
+	}
 }
 
 // Close stops the worker and releases the port. It is safe to call on a reader

--- a/pkg/readers/zapdisplay/zapdisplay.go
+++ b/pkg/readers/zapdisplay/zapdisplay.go
@@ -1,0 +1,780 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package zapdisplay drives a Zaparoo display accessory over USB serial.
+//
+// The accessory is display-only: it never produces scans. On every media change
+// it is sent the title, system name and cover art that Core already holds, so
+// unlike a picture-pack display it works for any scraped media without shipping
+// per-system artwork of its own.
+package zapdisplay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unicode"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/tokens"
+	"github.com/jonboulle/clockwork"
+	"github.com/rs/zerolog/log"
+	"go.bug.st/serial"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	driverID = "zapdisplay"
+
+	// artworkMaxSize is the longest edge asked of Core's artwork pipeline. It is
+	// the tier above the cover slot's 180px, so the image never needs upscaling
+	// and the decode stays cheap on constrained devices.
+	artworkMaxSize = 256
+
+	// launchingDelay is how long a media change may run before the display puts
+	// up a launching frame. Below this the work finishes fast enough that the
+	// extra frame reads as a flash rather than as feedback.
+	launchingDelay = 200 * time.Millisecond
+
+	// espressifVID is the USB vendor ID the display enumerates under. The
+	// firmware uses the ESP32-S3's native USB peripheral, which reports
+	// Espressif's stock ID and no product string, so this is the only thing
+	// that can be checked before opening a port.
+	//
+	// Probing writes a line to whatever is on the other end, and /dev/ttyACM*
+	// is also where 3D printers, Arduino-class boards and CNC controllers
+	// appear. Narrowing to this vendor keeps the handshake away from them.
+	espressifVID = "303a"
+
+	// refreshInterval re-sends the current scene so the firmware's uptime-based
+	// anti-retention offset advances during a long session. It never re-uploads
+	// the cover.
+	refreshInterval = 2 * time.Minute
+)
+
+var (
+	_ readers.Reader          = (*Reader)(nil)
+	_ readers.ArtworkConsumer = (*Reader)(nil)
+)
+
+// vendorLookup reports the USB vendor and product IDs behind a serial device,
+// or ok=false when they cannot be determined. It is a field on the reader, like
+// the port factory and the clock, so a test can exercise the vendor filter
+// without a real device attached.
+type vendorLookup func(path string) (vid, pid string, ok bool)
+
+// Reader is a Zaparoo display accessory.
+type Reader struct {
+	cfg          *config.Instance
+	portFactory  testutils.SerialPortFactory
+	clock        clockwork.Clock
+	vendorIDs    vendorLookup
+	artwork      readers.ArtworkSource
+	session      *session
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
+	// desired is what the display should be showing; nil means idle. wake
+	// carries a single coalescing signal, so any burst of media changes
+	// collapses into one render of the newest state.
+	desired    *models.ActiveMedia
+	wake       chan struct{}
+	appliedKey string
+	cachedKey  string
+	cachedID   string
+	path       string
+	info       string
+	cachedPix  []byte
+	// Dimensions the cached cover was encoded at. Artwork is not a fixed slot,
+	// so re-selecting a cover the device already holds has to restate its size.
+	cachedW        int
+	cachedH        int
+	mu             syncutil.RWMutex
+	wg             sync.WaitGroup
+	connected      atomic.Bool
+	defaultEnabled bool
+}
+
+// NewReader allocates a driver instance. It performs no I/O and starts no
+// goroutines: auto-detection builds the full reader list every second and
+// discards the instances it does not use.
+func NewReader(cfg *config.Instance) *Reader {
+	return NewReaderWithDefaults(cfg, false)
+}
+
+// NewReaderWithDefaults allocates a driver instance whose enabled-by-default
+// state is chosen by the platform. Platforms that ship the display as a
+// first-party accessory enable it so it is plug and play; elsewhere it stays
+// opt-in, because detection has to write to a serial port to identify it.
+func NewReaderWithDefaults(cfg *config.Instance, defaultEnabled bool) *Reader {
+	return &Reader{
+		cfg:            cfg,
+		portFactory:    testutils.DefaultSerialPortFactory,
+		clock:          clockwork.NewRealClock(),
+		vendorIDs:      helpers.SerialDeviceVIDPID,
+		wake:           make(chan struct{}, 1),
+		defaultEnabled: defaultEnabled,
+	}
+}
+
+func (r *Reader) Metadata() readers.DriverMetadata {
+	return readers.DriverMetadata{
+		ID:                driverID,
+		DefaultEnabled:    r.defaultEnabled,
+		DefaultAutoDetect: true,
+		Description:       "Zaparoo display accessory",
+	}
+}
+
+func (*Reader) IDs() []string {
+	return []string{driverID}
+}
+
+func (*Reader) Capabilities() []readers.Capability {
+	return []readers.Capability{readers.CapabilityDisplay}
+}
+
+// SetArtworkSource implements readers.ArtworkConsumer. Core calls it when the
+// reader is registered; the driver renders title and system only until then.
+func (r *Reader) SetArtworkSource(source readers.ArtworkSource) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.artwork = source
+}
+
+func (r *Reader) Path() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.path
+}
+
+func (r *Reader) Connected() bool {
+	return r.connected.Load()
+}
+
+func (r *Reader) Info() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if !r.connected.Load() {
+		return driverID + " (disconnected)"
+	}
+	if r.info != "" {
+		return r.info
+	}
+	return driverID + " (" + r.path + ")"
+}
+
+func (r *Reader) ReaderID() string {
+	path := r.Path()
+	stablePath := helpers.GetUSBTopologyPath(path)
+	if stablePath == "" {
+		stablePath = path
+	}
+	return readers.GenerateReaderID(driverID, stablePath)
+}
+
+func (*Reader) Write(string) (*tokens.Token, error) {
+	return nil, errors.New("writing not supported on display-only reader")
+}
+
+func (*Reader) CancelWrite() {
+	// No-op: this reader cannot write tokens.
+}
+
+// Detect looks for a display on a serial port no other driver has claimed.
+func (r *Reader) Detect(connected []string) string {
+	ports, err := helpers.GetUSBCDCDeviceList()
+	if err != nil {
+		log.Warn().Err(err).Msg("zapdisplay: failed to list serial ports")
+		return ""
+	}
+
+	refreshFailedProbes()
+	now := r.clock.Now()
+
+	for _, path := range ports {
+		if pathClaimed(connected, path) {
+			continue
+		}
+		if probeFailedRecently(path, now) {
+			continue
+		}
+		if !r.couldBeDisplay(path) {
+			continue
+		}
+		if r.probe(path) {
+			clearFailedProbe(path)
+			return driverID + ":" + path
+		}
+		recordFailedProbe(path, now)
+	}
+	return ""
+}
+
+// couldBeDisplay reports whether a port is worth opening at all.
+//
+// Auto-detect runs every second, so without this the driver would write its
+// handshake to every unrelated serial device on the machine, repeatedly. When
+// the vendor cannot be determined the port is still probed: that is the case on
+// platforms without udevadm, where refusing would make the display
+// undetectable.
+func (r *Reader) couldBeDisplay(path string) bool {
+	vid, _, ok := r.vendorIDs(path)
+	if !ok {
+		return true
+	}
+	return vid == espressifVID
+}
+
+// pathClaimed reports whether any connected reader already owns this port.
+// Connection strings are "driver:path", so the driver prefix is dropped first.
+func pathClaimed(connected []string, path string) bool {
+	for _, entry := range connected {
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) == 2 && parts[1] == path {
+			return true
+		}
+	}
+	return false
+}
+
+// probe opens a port and runs the handshake, then closes it again. Open
+// re-opens the winner, matching how auto-detection drives every other driver.
+func (r *Reader) probe(path string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), handshakeTimeout)
+	defer cancel()
+
+	sess, err := r.dial(path)
+	if err != nil {
+		log.Trace().Err(err).Str("port", path).Msg("zapdisplay: port not usable")
+		return false
+	}
+	defer func() {
+		if closeErr := sess.close(); closeErr != nil {
+			log.Trace().Err(closeErr).Str("port", path).Msg("zapdisplay: error closing probe port")
+		}
+	}()
+
+	if err := sess.claim(ctx); err != nil {
+		log.Trace().Err(err).Str("port", path).Msg("zapdisplay: handshake failed")
+		return false
+	}
+	return true
+}
+
+func (r *Reader) dial(path string) (*session, error) {
+	port, err := r.portFactory(path, &serial.Mode{
+		BaudRate: baudRate,
+		DataBits: 8,
+		Parity:   serial.NoParity,
+		StopBits: serial.OneStopBit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open serial port %s: %w", path, err)
+	}
+	if err := port.SetReadTimeout(readTimeout); err != nil {
+		if closeErr := port.Close(); closeErr != nil {
+			log.Trace().Err(closeErr).Msg("zapdisplay: error closing port after timeout failure")
+		}
+		return nil, fmt.Errorf("set read timeout on %s: %w", path, err)
+	}
+	return newSession(port), nil
+}
+
+// Open claims a display and starts the render worker.
+func (r *Reader) Open(device config.ReadersConnect, _ chan<- readers.Scan, opts readers.OpenOpts) error {
+	if !readers.MatchesDriverID(r.IDs(), device.Driver) {
+		return fmt.Errorf("wrong driver for zapdisplay reader: %s", device.Driver)
+	}
+
+	logFailure := func(err error, msg string) {
+		if opts.Probing {
+			log.Trace().Err(err).Str("port", device.Path).Msg(msg)
+			return
+		}
+		log.Error().Err(err).Str("port", device.Path).Msg(msg)
+	}
+
+	sess, err := r.dial(device.Path)
+	if err != nil {
+		logFailure(err, "zapdisplay: failed to open display")
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), handshakeTimeout*3)
+	claimErr := sess.claim(ctx)
+	cancel()
+	if claimErr != nil {
+		if closeErr := sess.close(); closeErr != nil {
+			log.Trace().Err(closeErr).Msg("zapdisplay: error closing port after failed handshake")
+		}
+		logFailure(claimErr, "zapdisplay: handshake failed")
+		return claimErr
+	}
+
+	r.mu.Lock()
+	r.path = device.Path
+	r.session = sess
+	r.info = sess.info
+	// A reconnect must not inherit the previous device's cover state: the new
+	// device holds nothing.
+	r.appliedKey = ""
+	r.cachedKey = ""
+	r.cachedID = ""
+	r.cachedPix = nil
+	// Always a fresh context so re-opening after Close works.
+	r.workerCtx, r.workerCancel = context.WithCancel(context.Background())
+	r.mu.Unlock()
+
+	r.connected.Store(true)
+
+	if err := r.renderIdle(r.workerCtx, sess); err != nil {
+		log.Warn().Err(err).Msg("zapdisplay: failed to render idle scene")
+	}
+
+	r.wg.Add(1)
+	go r.worker()
+
+	log.Info().Str("port", device.Path).Str("info", sess.info).Msg("zapdisplay display connected")
+	return nil
+}
+
+// Close stops the worker and releases the port. It is safe to call on a reader
+// that was never opened, and safe to call twice.
+func (r *Reader) Close() error {
+	r.connected.Store(false)
+
+	r.mu.Lock()
+	cancel := r.workerCancel
+	r.workerCancel = nil
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	// Wait outside the lock: the worker takes it while rendering.
+	r.wg.Wait()
+
+	r.mu.Lock()
+	sess := r.session
+	r.session = nil
+	path := r.path
+	r.mu.Unlock()
+
+	if sess != nil {
+		if err := sess.close(); err != nil {
+			log.Debug().Err(err).Str("port", path).Msg("zapdisplay: error closing port")
+		}
+		log.Info().Str("port", path).Msg("zapdisplay display disconnected")
+	}
+	return nil
+}
+
+// OnMediaChange records the new state and wakes the worker.
+//
+// This runs on the media publish path while state locks are held, so it must
+// not touch the serial port: a full cover upload takes on the order of a
+// second and would stall every other media consumer.
+func (r *Reader) OnMediaChange(media *models.ActiveMedia) error {
+	if !r.connected.Load() {
+		return errors.New("display is not connected")
+	}
+
+	r.mu.Lock()
+	r.desired = media
+	r.mu.Unlock()
+
+	select {
+	case r.wake <- struct{}{}:
+	default:
+		// A wake is already pending and the worker re-reads desired, so the
+		// newest state is what gets rendered either way.
+	}
+	return nil
+}
+
+func (r *Reader) worker() {
+	defer r.wg.Done()
+
+	r.mu.RLock()
+	ctx := r.workerCtx
+	r.mu.RUnlock()
+
+	ticker := r.clock.NewTicker(refreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.wake:
+			r.guard("apply", func() { r.applyDesired(ctx) })
+		case <-ticker.Chan():
+			r.guard("refresh", func() { r.refreshScene(ctx) })
+		}
+	}
+}
+
+// guard runs one render step with panic recovery.
+//
+// The render path decodes PNG, JPEG and WebP from files Core scraped, which is
+// the one input here that a malformed file could crash. Without this a bad
+// cover would take the whole daemon down rather than one display.
+//
+// The link is dropped rather than retried: a panic part way through a scene
+// leaves the device stream desynced, with a command possibly written and its
+// response never read. The service prunes a disconnected reader and reconnects,
+// which resynchronises through a fresh handshake.
+func (r *Reader) guard(step string, run func()) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			return
+		}
+		log.Error().
+			Str("step", step).
+			Str("port", r.Path()).
+			Interface("panic", recovered).
+			Bytes("stack", debug.Stack()).
+			Msg("zapdisplay: render panicked, dropping the link")
+		r.connected.Store(false)
+	}()
+	run()
+}
+
+// applyDesired renders whatever media is currently wanted.
+func (r *Reader) applyDesired(ctx context.Context) {
+	r.mu.RLock()
+	media := r.desired
+	sess := r.session
+	applied := r.appliedKey
+	r.mu.RUnlock()
+
+	if sess == nil {
+		return
+	}
+
+	key := mediaKey(media)
+	if key == applied {
+		return
+	}
+
+	var err error
+	switch media {
+	case nil:
+		err = r.renderIdle(ctx, sess)
+	default:
+		// The launching frame is decided during the render, once enough time
+		// has actually passed to be worth acknowledging, rather than guessed
+		// at up front.
+		err = r.renderPlaying(ctx, sess, media, r.clock.Now())
+	}
+	if err != nil {
+		r.handleRenderError(err)
+		return
+	}
+
+	r.mu.Lock()
+	r.appliedKey = key
+	r.mu.Unlock()
+}
+
+// refreshScene re-sends the current scene without re-uploading artwork, so the
+// firmware's image-retention offset advances during long sessions.
+func (r *Reader) refreshScene(ctx context.Context) {
+	r.mu.RLock()
+	sess := r.session
+	applied := r.appliedKey
+	r.mu.RUnlock()
+
+	if sess == nil || applied == "" {
+		return
+	}
+	if _, err := sess.command(ctx, "SHOW", commandTimeout, "OK"); err != nil {
+		r.handleRenderError(err)
+	}
+}
+
+// handleRenderError decides whether a failure means the device has gone away.
+// A protocol-level ERR is the device answering, so the link is fine; anything
+// else is treated as a disconnect and lets the service prune the reader.
+func (r *Reader) handleRenderError(err error) {
+	var protoErr *protocolError
+	if errors.As(err, &protoErr) {
+		log.Warn().Err(err).Msg("zapdisplay: device rejected a command")
+		return
+	}
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	log.Warn().Err(err).Msg("zapdisplay: display link failed, marking disconnected")
+	r.connected.Store(false)
+}
+
+func (*Reader) renderIdle(ctx context.Context, sess *session) error {
+	if _, err := sess.command(ctx, "CLEAR", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "SCENE idle", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "STATUS Ready", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	// The device knows nothing about the time of day, so give it one. It has no
+	// RTC and forgets this on reset, which is why it is re-sent whenever the
+	// scene is rebuilt rather than only at connect.
+	sess.pushClock(ctx)
+	_, err := sess.command(ctx, "SHOW", commandTimeout, "OK")
+	return err
+}
+
+// renderLaunching puts something on screen while the cover is still being
+// fetched, scaled and pushed. That takes seconds on a fresh title, and a panel
+// that sits on the previous game for the whole of it looks broken.
+func (*Reader) renderLaunching(ctx context.Context, sess *session, media *models.ActiveMedia) error {
+	if _, err := sess.command(ctx, "CLEAR", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "SCENE launching", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	title := displayField(media.Name, maxTitleLen, "Untitled")
+	if _, err := sess.command(ctx, "TITLE "+title, commandTimeout, "OK"); err != nil {
+		return err
+	}
+	system := displayField(systemLabel(media), maxSystemLen, "Unknown system")
+	if _, err := sess.command(ctx, "SYSTEM "+system, commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "STATUS Starting", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	_, err := sess.command(ctx, "SHOW", commandTimeout, "OK")
+	return err
+}
+
+// playingStatus reports what the launcher is actually doing. A display
+// insisting "Playing" over a paused game is simply wrong, and it is the kind of
+// wrong a glanceable panel gets blamed for.
+func playingStatus(media *models.ActiveMedia, hasCover bool) string {
+	switch media.PlaybackState {
+	case models.MediaPlaybackStatePaused:
+		return "Paused"
+	case models.MediaPlaybackStateStopped:
+		return "Stopped"
+	case models.MediaPlaybackStatePlaying:
+	}
+	if !hasCover {
+		return "Playing - no cover"
+	}
+	return "Playing"
+}
+
+func (r *Reader) renderPlaying(
+	ctx context.Context, sess *session, media *models.ActiveMedia, started time.Time,
+) error {
+	if _, err := sess.command(ctx, "CLEAR", commandTimeout, "OK"); err != nil {
+		return err
+	}
+
+	hasCover := r.applyCover(ctx, sess, media, started)
+
+	title := displayField(media.Name, maxTitleLen, "Untitled")
+	system := displayField(systemLabel(media), maxSystemLen, "Unknown system")
+	status := playingStatus(media, hasCover)
+
+	if _, err := sess.command(ctx, "SCENE playing", commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "TITLE "+title, commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "SYSTEM "+system, commandTimeout, "OK"); err != nil {
+		return err
+	}
+	if _, err := sess.command(ctx, "STATUS "+status, commandTimeout, "OK"); err != nil {
+		return err
+	}
+	// Core knows when the session began, so the device is told once and counts
+	// on from there. Sending a duration every minute would be the only reason
+	// left to talk to it during a long session.
+	if sess.features["clock"] && !media.Started.IsZero() {
+		elapsed := int(time.Since(media.Started).Seconds())
+		if elapsed >= 0 {
+			text := fmt.Sprintf("ELAPSED %d", elapsed)
+			if _, err := sess.command(ctx, text, commandTimeout, "OK"); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := sess.command(ctx, "SHOW", commandTimeout, "OK")
+	return err
+}
+
+// applyCover gets the cover onto the device and selects it, reporting whether
+// the playing scene will have artwork. A missing or unreadable cover is an
+// ordinary outcome: the scene still renders, just without one.
+func (r *Reader) applyCover(
+	ctx context.Context, sess *session, media *models.ActiveMedia, started time.Time,
+) bool {
+	key := mediaKey(media)
+
+	r.mu.RLock()
+	source := r.artwork
+	cachedKey := r.cachedKey
+	assetID := r.cachedID
+	pixels := r.cachedPix
+	width := r.cachedW
+	height := r.cachedH
+	r.mu.RUnlock()
+
+	if cachedKey != key || assetID == "" {
+		if source == nil {
+			return false
+		}
+		art, err := source.Artwork(ctx, media.SystemID, media.Path, artworkMaxSize)
+		if err != nil {
+			if !errors.Is(err, readers.ErrNoArtwork) {
+				log.Debug().Err(err).Str("media", media.Name).Msg("zapdisplay: could not resolve cover")
+			}
+			return false
+		}
+		encoded, err := encodeCover(art.Data, art.ContentType)
+		if err != nil {
+			log.Debug().Err(err).Str("media", media.Name).Msg("zapdisplay: could not encode cover")
+			return false
+		}
+		pixels = encoded.pixels
+		width = encoded.width
+		height = encoded.height
+		assetID = coverAssetID(media.SystemID, media.Path, pixels)
+
+		// Resolving artwork is the variable part of a media change: a database
+		// miss or a large image decode is what makes one slow. Once that has
+		// already cost more than launchingDelay, put a frame up before the
+		// upload so the display is not left on the previous game.
+		if r.clock.Since(started) >= launchingDelay {
+			if launchErr := r.renderLaunching(ctx, sess, media); launchErr != nil {
+				// Not fatal: the playing frame below is the one that matters.
+				log.Debug().Err(launchErr).Msg("zapdisplay: could not show launching frame")
+			}
+		}
+
+		if err := sess.uploadCover(ctx, assetID, pixels); err != nil {
+			log.Debug().Err(err).Msg("zapdisplay: cover upload failed")
+			return false
+		}
+		r.mu.Lock()
+		r.cachedKey = key
+		r.cachedID = assetID
+		r.cachedPix = pixels
+		r.cachedW = width
+		r.cachedH = height
+		r.mu.Unlock()
+	}
+
+	err := sess.useCover(ctx, assetID, width, height)
+	if err == nil {
+		return true
+	}
+	if !isAssetMissing(err) {
+		log.Debug().Err(err).Msg("zapdisplay: could not select cover")
+		return false
+	}
+
+	// The device lost the asset, which normally means it rebooted. Send it once
+	// more before giving up on artwork for this scene.
+	if err := sess.uploadCover(ctx, assetID, pixels); err != nil {
+		log.Debug().Err(err).Msg("zapdisplay: cover re-upload failed")
+		return false
+	}
+	if err := sess.useCover(ctx, assetID, width, height); err != nil {
+		log.Debug().Err(err).Msg("zapdisplay: could not select cover after re-upload")
+		return false
+	}
+	return true
+}
+
+// mediaKey identifies what the display is showing. Empty means idle.
+func mediaKey(media *models.ActiveMedia) string {
+	if media == nil {
+		return ""
+	}
+	return media.SystemID + "\x00" + media.Path
+}
+
+func systemLabel(media *models.ActiveMedia) string {
+	if media.SystemName != "" {
+		return media.SystemName
+	}
+	return media.SystemID
+}
+
+// newASCIIFolder folds accents down to their base letters so titles such as
+// "Pokémon" render as "Pokemon" rather than losing characters: the device's
+// bundled font only covers printable ASCII.
+//
+// A fresh chain per call is deliberate. transform.Chain carries internal
+// buffers and is not safe to share, and this runs a handful of times per media
+// change.
+func newASCIIFolder() transform.Transformer {
+	return transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+}
+
+// displayField prepares text for a protocol field: folded to ASCII, stripped of
+// anything the device cannot render, and truncated to the device's buffer.
+func displayField(value string, maxLen int, fallback string) string {
+	folded, _, err := transform.String(newASCIIFolder(), value)
+	if err != nil {
+		folded = value
+	}
+
+	var b strings.Builder
+	for _, r := range folded {
+		switch {
+		case r >= ' ' && r <= '~':
+			_, _ = b.WriteRune(r)
+		case unicode.IsSpace(r):
+			_ = b.WriteByte(' ')
+		default:
+			// Unrenderable. Dropping is better than a run of '?' glyphs.
+		}
+	}
+
+	out := strings.Join(strings.Fields(b.String()), " ")
+	if out == "" {
+		return fallback
+	}
+	if len(out) > maxLen {
+		out = strings.TrimSpace(out[:maxLen])
+	}
+	return out
+}

--- a/pkg/readers/zapdisplay/zapdisplay_test.go
+++ b/pkg/readers/zapdisplay/zapdisplay_test.go
@@ -1,0 +1,653 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package zapdisplay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers/testutils"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.bug.st/serial"
+)
+
+const testPort = "/dev/ttyACM-test"
+
+func testMedia(systemID, name string) *models.ActiveMedia {
+	return &models.ActiveMedia{
+		SystemID:   systemID,
+		SystemName: strings.ToUpper(systemID),
+		Name:       name,
+		Path:       "/games/" + systemID + "/" + name + ".rom",
+	}
+}
+
+// stubArtwork stands in for Core's media image pipeline.
+type stubArtwork struct {
+	err         error
+	clock       *clockwork.FakeClock
+	contentType string
+	data        []byte
+	// resolveFor advances the fake clock, standing in for a slow lookup.
+	resolveFor time.Duration
+	calls      atomic.Int32
+}
+
+func (s *stubArtwork) Artwork(_ context.Context, _, _ string, _ int) (*readers.MediaArtwork, error) {
+	s.calls.Add(1)
+	if s.clock != nil && s.resolveFor > 0 {
+		s.clock.Advance(s.resolveFor)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &readers.MediaArtwork{ContentType: s.contentType, Data: s.data, TypeTag: "property:image-boxart"}, nil
+}
+
+// newTestReader builds a reader wired to dev and a fake clock, and guarantees
+// it is closed so goleak can verify no goroutine survives the test.
+func newTestReader(t *testing.T, dev *fakeDevice) (*Reader, *clockwork.FakeClock) {
+	t.Helper()
+
+	clock := clockwork.NewFakeClock()
+	r := NewReader(&config.Instance{})
+	r.clock = clock
+	r.portFactory = func(_ string, _ *serial.Mode) (testutils.SerialPort, error) {
+		return dev, nil
+	}
+	t.Cleanup(func() {
+		require.NoError(t, r.Close())
+	})
+	return r, clock
+}
+
+func openTestReader(t *testing.T, r *Reader) {
+	t.Helper()
+	err := r.Open(config.ReadersConnect{Driver: driverID, Path: testPort}, nil, readers.OpenOpts{})
+	require.NoError(t, err)
+	require.True(t, r.Connected())
+}
+
+// waitForSettledScene blocks until the most recently rendered scene satisfies
+// want, and returns it.
+//
+// The driver renders a launching frame before the playing one whenever artwork
+// still has to be fetched, so a test that waits on a scene count can observe
+// the intermediate frame. Waiting for the state under test instead keeps these
+// assertions independent of how many frames it takes to get there.
+func waitForSettledScene(t *testing.T, dev *fakeDevice, want func(fakeScene) bool) fakeScene {
+	t.Helper()
+	var last fakeScene
+	require.Eventually(t, func() bool {
+		scene, ok := dev.lastScene()
+		if !ok {
+			return false
+		}
+		last = scene
+		return want(scene)
+	}, 5*time.Second, time.Millisecond, "display never settled on the expected scene")
+	return last
+}
+
+// waitForScenes blocks until the device has rendered at least n scenes.
+func waitForScenes(t *testing.T, dev *fakeDevice, n int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(dev.renderedScenes()) >= n
+	}, 5*time.Second, time.Millisecond, "expected at least %d rendered scenes", n)
+}
+
+func sceneIs(name string) func(fakeScene) bool {
+	return func(s fakeScene) bool { return s.scene == name }
+}
+
+// countScenes returns how many rendered scenes have the given name.
+func countScenes(dev *fakeDevice, name string) int {
+	n := 0
+	for _, s := range dev.renderedScenes() {
+		if s.scene == name {
+			n++
+		}
+	}
+	return n
+}
+
+func TestMetadataAndCapabilities(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(&config.Instance{})
+	meta := r.Metadata()
+
+	assert.Equal(t, driverID, meta.ID)
+	assert.False(t, meta.DefaultEnabled, "probing writes to serial ports, so stay opt-in")
+	assert.True(t, meta.DefaultAutoDetect)
+	assert.Equal(t, []string{driverID}, r.IDs())
+	assert.Equal(t, []readers.Capability{readers.CapabilityDisplay}, r.Capabilities())
+}
+
+func TestWriteIsRejected(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(&config.Instance{})
+	token, err := r.Write("**launch.random:snes")
+	require.Error(t, err)
+	assert.Nil(t, token)
+	r.CancelWrite()
+}
+
+func TestNewReaderDoesNotStartGoroutines(t *testing.T) {
+	t.Parallel()
+
+	// Auto-detect builds every driver once a second and discards the ones it
+	// does not use, so construction must be allocation-only. goleak in
+	// TestMain is what actually enforces this.
+	for range 50 {
+		r := NewReader(&config.Instance{})
+		require.NoError(t, r.Close())
+	}
+}
+
+func TestOpenPerformsHandshakeAndRendersIdle(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	commands := dev.commandLog()
+	require.GreaterOrEqual(t, len(commands), 3)
+	assert.Equal(t, "HELLO "+protocolVersion, commands[0])
+	assert.Equal(t, "INFO", commands[1])
+	assert.Equal(t, "QUIET", commands[2], "the READY beacon must be silenced before rendering")
+
+	scene, ok := dev.lastScene()
+	require.True(t, ok, "opening should render an idle scene")
+	assert.Equal(t, "idle", scene.scene)
+	assert.Contains(t, r.Info(), "fw=")
+}
+
+func TestOpenRejectsWrongDriver(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+
+	err := r.Open(config.ReadersConnect{Driver: "pn532", Path: testPort}, nil, readers.OpenOpts{})
+	require.Error(t, err)
+	assert.False(t, r.Connected())
+	assert.Empty(t, dev.commandLog(), "a mismatched driver must not touch the port")
+}
+
+func TestOpenFailsCleanlyOnUnresponsivePort(t *testing.T) {
+	t.Parallel()
+
+	// A port that answers nothing: another device, or nothing at all.
+	silent := &stallingPort{stalls: 1 << 30}
+	r := NewReader(&config.Instance{})
+	r.clock = clockwork.NewFakeClock()
+	r.portFactory = func(_ string, _ *serial.Mode) (testutils.SerialPort, error) {
+		return silent, nil
+	}
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+	err := r.Open(config.ReadersConnect{Driver: driverID, Path: testPort}, nil, readers.OpenOpts{})
+	require.Error(t, err)
+	assert.False(t, r.Connected())
+}
+
+func TestOnMediaChangeDoesNoSerialIO(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	// With writes gated, any serial I/O on this path would block forever.
+	release := dev.gateWrites()
+	defer release()
+
+	done := make(chan error, 1)
+	go func() { done <- r.OnMediaChange(testMedia("snes", "Super Metroid")) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnMediaChange blocked on the serial port; it runs on the media publish path")
+	}
+}
+
+func TestOnMediaChangeCoalescesBursts(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	baseline := countScenes(dev, "playing")
+	release := dev.gateWrites()
+
+	for i := range 50 {
+		require.NoError(t, r.OnMediaChange(testMedia("snes", fmt.Sprintf("Game %02d", i))))
+	}
+	release()
+
+	waitForSettledScene(t, dev, func(s fakeScene) bool {
+		return s.scene == "playing" && s.title == "Game 49"
+	})
+
+	rendered := countScenes(dev, "playing") - baseline
+	assert.LessOrEqual(t, rendered, 2,
+		"50 changes should collapse into at most one in-flight and one pending render")
+}
+
+func TestOnMediaChangeNilRendersIdle(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+
+	// Stopping media must clear the display rather than leaving the last game
+	// on screen forever.
+	require.NoError(t, r.OnMediaChange(nil))
+	waitForSettledScene(t, dev, sceneIs("idle"))
+
+	assert.Contains(t, dev.commandLog(), "SCENE idle")
+}
+
+func TestOnMediaChangeRendersTitleAndSystem(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	// idle at open, then launching while the cover is fetched, then playing.
+	scene := waitForSettledScene(t, dev, sceneIs("playing"))
+
+	assert.Equal(t, "Super Metroid", scene.title)
+	assert.Equal(t, "SNES", scene.system)
+	assert.Empty(t, scene.coverID, "no artwork source means no cover")
+	assert.Contains(t, scene.status, "no cover")
+}
+
+func TestRenderToleratesInterleavedDeviceLogs(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	// QUIET does not silence every firmware log line, so protocol responses
+	// arrive interleaved with ESP-IDF output and must still be matched.
+	dev.queueLogLine("I (12345) display: Render scene: playing")
+	dev.queueLogLine("\x1b[0;33mW (12346) zapdisplay.protocol: noisy\x1b[0m")
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	// idle at open, then launching while the cover is fetched, then playing.
+	scene := waitForSettledScene(t, dev, sceneIs("playing"))
+
+	assert.Equal(t, "Super Metroid", scene.title)
+}
+
+func TestOnMediaChangeRejectedWhenDisconnected(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(&config.Instance{})
+	require.Error(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+}
+
+func TestCoverUploadFramingMatchesDevice(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{
+		contentType: "image/png",
+		data:        solidPNG(t, 200, 300, colorRed()),
+	})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	// idle at open, then launching while the cover is fetched, then playing.
+	scene := waitForSettledScene(t, dev, sceneIs("playing"))
+
+	assert.NotEmpty(t, scene.coverID, "cover should have been selected")
+	assert.Equal(t, "Playing", scene.status)
+
+	// A 200x300 source fills the height and keeps its aspect: 192x288, which is
+	// 110592 bytes. At 768 decoded bytes per chunk that is 144 whole chunks
+	// with nothing left over.
+	assert.Equal(t, 144, dev.countCommands("ASSET_CHUNK_DATA "))
+	assert.Equal(t, 1, dev.countCommands("ASSET_BEGIN "))
+	assert.Equal(t, 1, dev.countCommands("ASSET_END "))
+
+	commands := dev.commandLog()
+	assert.Contains(t, commands, "ASSET_CHUNK_DATA 143 1024", "final chunk is full")
+	assert.Equal(t, 192*288*2, dev.committedSize())
+	assert.Contains(t, commands, "ASSET_USE cover "+scene.coverID+" 192 288 rgb565")
+
+	// CLEAR resets pending state, so it has to come before the fields.
+	assert.Less(t, indexOf(commands, "CLEAR"), indexOf(commands, "SCENE playing"))
+}
+
+func TestCoverIsNotReuploadedForRepeatMedia(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{contentType: "image/png", data: solidPNG(t, 200, 300, colorRed())})
+	openTestReader(t, r)
+
+	media := testMedia("snes", "Super Metroid")
+	require.NoError(t, r.OnMediaChange(media))
+	waitForScenes(t, dev, 2)
+
+	require.NoError(t, r.OnMediaChange(nil))
+	waitForScenes(t, dev, 3)
+
+	// Returning to media the device already holds skips the launching frame:
+	// re-selecting a committed cover is instant, so a "starting" scene would
+	// only flash.
+	require.NoError(t, r.OnMediaChange(media))
+	waitForScenes(t, dev, 4)
+
+	assert.Equal(t, 1, dev.countCommands("ASSET_BEGIN "), "the device still holds the cover; re-select it")
+	assert.Equal(t, 2, dev.countCommands("ASSET_USE "))
+}
+
+func TestCoverReuploadedAfterDeviceForgetsIt(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{contentType: "image/png", data: solidPNG(t, 200, 300, colorRed())})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+
+	// The device rebooted: it kept the link but lost every asset.
+	dev.forgetAssets()
+	require.NoError(t, r.OnMediaChange(nil))
+	waitForSettledScene(t, dev, sceneIs("idle"))
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	scene := waitForSettledScene(t, dev, func(s fakeScene) bool {
+		return s.scene == "playing" && s.coverID != ""
+	})
+
+	assert.NotEmpty(t, scene.coverID, "driver should recover by uploading the cover again")
+	assert.Equal(t, 2, dev.countCommands("ASSET_BEGIN "))
+}
+
+func TestArtworkFailureStillRendersScene(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		source *stubArtwork
+		name   string
+	}{
+		{name: "no artwork stored", source: &stubArtwork{err: readers.ErrNoArtwork}},
+		{name: "lookup failed", source: &stubArtwork{err: errors.New("database is busy")}},
+		{name: "undecodable image", source: &stubArtwork{contentType: "image/png", data: []byte("junk")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dev := newFakeDevice()
+			r, _ := newTestReader(t, dev)
+			r.SetArtworkSource(tc.source)
+			openTestReader(t, r)
+
+			require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+			scene := waitForSettledScene(t, dev, sceneIs("playing"))
+
+			assert.Equal(t, "Super Metroid", scene.title)
+			assert.Empty(t, scene.coverID)
+			assert.Zero(t, dev.countCommands("ASSET_BEGIN "))
+		})
+	}
+}
+
+func TestRefreshResendsSceneWithoutReuploadingCover(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, clock := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{contentType: "image/png", data: solidPNG(t, 200, 300, colorRed())})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+
+	uploadsBefore := dev.countCommands("ASSET_BEGIN ")
+	scenesBefore := len(dev.renderedScenes())
+
+	// The firmware's anti-retention offset only advances when the host
+	// re-sends SHOW, so a long session needs a periodic nudge.
+	require.NoError(t, clock.BlockUntilContext(t.Context(), 1))
+	clock.Advance(refreshInterval)
+	require.Eventually(t, func() bool {
+		return len(dev.renderedScenes()) > scenesBefore
+	}, 5*time.Second, time.Millisecond, "the refresh should re-send the scene")
+
+	assert.Equal(t, uploadsBefore, dev.countCommands("ASSET_BEGIN "), "a refresh must not re-upload artwork")
+}
+
+// panicArtwork stands in for anything in the render path that can panic. In
+// production that is the PNG, JPEG and WebP decoders running on scraped files.
+type panicArtwork struct{}
+
+func (panicArtwork) Artwork(_ context.Context, _, _ string, _ int) (*readers.MediaArtwork, error) {
+	panic("malformed cover")
+}
+
+func TestRenderPanicDoesNotKillTheProcess(t *testing.T) {
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.SetArtworkSource(panicArtwork{})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+
+	// A panic part way through a scene leaves the device stream desynced, so
+	// the link is dropped and the service reconnects through a fresh
+	// handshake. Reaching this assertion at all is the point: an unrecovered
+	// panic on the worker goroutine would take the whole daemon down.
+	require.Eventually(t, func() bool {
+		return !r.Connected()
+	}, 5*time.Second, time.Millisecond, "a panicking render should drop the link")
+}
+
+func TestLinkFailureMarksReaderDisconnected(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	dev.setWriteError(errors.New("input/output error"))
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+
+	// readerManager prunes readers that report themselves disconnected.
+	require.Eventually(t, func() bool {
+		return !r.Connected()
+	}, 5*time.Second, time.Millisecond, "a dead link should mark the reader disconnected")
+}
+
+func TestCloseIsIdempotentAndReopenable(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	require.NoError(t, r.Close())
+	require.NoError(t, r.Close(), "closing twice must be safe")
+	assert.False(t, r.Connected())
+
+	// readerManager reconnects a pruned reader on its next tick.
+	reopened := newFakeDevice()
+	r.portFactory = func(_ string, _ *serial.Mode) (testutils.SerialPort, error) {
+		return reopened, nil
+	}
+	openTestReader(t, r)
+	assert.True(t, r.Connected())
+}
+
+func TestCloseWithoutOpenIsSafe(t *testing.T) {
+	t.Parallel()
+
+	r := NewReader(&config.Instance{})
+	require.NoError(t, r.Close())
+}
+
+func TestReaderIDIsStableForAPath(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	first := r.ReaderID()
+	assert.Equal(t, first, r.ReaderID())
+	assert.Contains(t, first, driverID)
+}
+
+func TestPathClaimedIgnoresOtherDriversPorts(t *testing.T) {
+	t.Parallel()
+
+	connected := []string{"pn532:/dev/ttyACM0", "zapdisplay:/dev/ttyACM1"}
+
+	assert.True(t, pathClaimed(connected, "/dev/ttyACM0"), "another driver already owns this port")
+	assert.True(t, pathClaimed(connected, "/dev/ttyACM1"))
+	assert.False(t, pathClaimed(connected, "/dev/ttyACM2"))
+}
+
+func indexOf(values []string, want string) int {
+	for i, v := range values {
+		if v == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestFastLoadSkipsLaunchingFrame(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	// The fake clock never advances during the resolve, so this is the fastest
+	// possible load.
+	r.SetArtworkSource(&stubArtwork{contentType: "image/png", data: solidPNG(t, 200, 300, colorRed())})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+
+	// A raw-chunk upload finishes quickly enough that a launching frame would
+	// read as a flash rather than as feedback.
+	assert.Zero(t, countScenes(dev, "launching"), "a fast load should go straight to playing")
+	assert.NotContains(t, dev.commandLog(), "SCENE launching")
+}
+
+func TestSlowLoadShowsLaunchingFrame(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, clock := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{
+		contentType: "image/png",
+		data:        solidPNG(t, 200, 300, colorRed()),
+		clock:       clock,
+		resolveFor:  launchingDelay + 50*time.Millisecond,
+	})
+	openTestReader(t, r)
+
+	require.NoError(t, r.OnMediaChange(testMedia("snes", "Super Metroid")))
+	scene := waitForSettledScene(t, dev, sceneIs("playing"))
+
+	// Once the work has genuinely taken a while, the display should not sit on
+	// the previous game while the cover uploads.
+	assert.Equal(t, 1, countScenes(dev, "launching"), "a slow resolve should be acknowledged")
+	assert.Equal(t, "Super Metroid", scene.title)
+
+	commands := dev.commandLog()
+	launching := indexOf(commands, "SCENE launching")
+	upload := indexOfPrefix(commands, "ASSET_BEGIN ")
+	require.NotEqual(t, -1, launching)
+	require.NotEqual(t, -1, upload)
+	assert.Less(t, launching, upload,
+		"the launching frame must land before the upload it is covering for")
+}
+
+func TestLaunchingFrameSkippedForCachedCover(t *testing.T) {
+	t.Parallel()
+
+	dev := newFakeDevice()
+	r, clock := newTestReader(t, dev)
+	r.SetArtworkSource(&stubArtwork{
+		contentType: "image/png",
+		data:        solidPNG(t, 200, 300, colorRed()),
+		clock:       clock,
+		resolveFor:  launchingDelay + 50*time.Millisecond,
+	})
+	openTestReader(t, r)
+
+	media := testMedia("snes", "Super Metroid")
+	require.NoError(t, r.OnMediaChange(media))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+	require.NoError(t, r.OnMediaChange(nil))
+	waitForSettledScene(t, dev, sceneIs("idle"))
+
+	before := countScenes(dev, "launching")
+	require.NoError(t, r.OnMediaChange(media))
+	waitForSettledScene(t, dev, sceneIs("playing"))
+
+	// Re-selecting a cover the device already holds does no resolve and no
+	// upload, so there is nothing to acknowledge however slow the source is.
+	assert.Equal(t, before, countScenes(dev, "launching"))
+}
+
+// indexOfPrefix returns the position of the first command starting with want.
+func indexOfPrefix(values []string, want string) int {
+	for i, v := range values {
+		if strings.HasPrefix(v, want) {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/readers/zapdisplay/zapdisplay_test.go
+++ b/pkg/readers/zapdisplay/zapdisplay_test.go
@@ -491,6 +491,68 @@ func TestRenderPanicDoesNotKillTheProcess(t *testing.T) {
 	}, 5*time.Second, time.Millisecond, "a panicking render should drop the link")
 }
 
+// configWithRotation builds a reader config carrying a display rotation. It
+// round-trips through TOML, so it also proves the field is persisted.
+func configWithRotation(t *testing.T, degrees int) *config.Instance {
+	t.Helper()
+	cfg, err := config.NewConfig(t.TempDir(), config.Values{
+		Readers: config.Readers{
+			Drivers: map[string]config.DriverConfig{
+				driverID: {Rotation: degrees},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return cfg
+}
+
+func TestRotationIsSentBeforeTheFirstFrame(t *testing.T) {
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.cfg = configWithRotation(t, config.RotationHalf)
+	openTestReader(t, r)
+
+	cmds := dev.commandLog()
+	rotateAt, showAt := -1, -1
+	for i, cmd := range cmds {
+		if cmd == "SET rotation 180" && rotateAt < 0 {
+			rotateAt = i
+		}
+		if cmd == "SHOW" && showAt < 0 {
+			showAt = i
+		}
+	}
+
+	require.GreaterOrEqual(t, rotateAt, 0, "rotation should be sent on connect")
+	require.GreaterOrEqual(t, showAt, 0, "the idle scene should be rendered")
+	assert.Less(t, rotateAt, showAt, "a rotated panel must not show a frame the wrong way up first")
+	assert.Equal(t, "180", dev.settingRotation())
+}
+
+func TestRotationIsClearedWhenNotConfigured(t *testing.T) {
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	openTestReader(t, r)
+
+	// Sent rather than skipped: the device keeps its rotation across power
+	// cycles, so it may still be holding one the user has since turned off.
+	assert.Contains(t, dev.commandLog(), "SET rotation 0")
+	assert.Equal(t, "0", dev.settingRotation())
+}
+
+func TestUnsupportedRotationLeavesThePanelUnrotated(t *testing.T) {
+	dev := newFakeDevice()
+	r, _ := newTestReader(t, dev)
+	r.cfg = configWithRotation(t, config.RotationQuarter)
+	openTestReader(t, r)
+
+	// The panel has one landscape layout, so a quarter turn would need a UI it
+	// does not have. Connecting anyway beats refusing over a config mistake.
+	assert.NotContains(t, dev.commandLog(), "SET rotation 90")
+	assert.Equal(t, "0", dev.settingRotation())
+	assert.True(t, r.Connected())
+}
+
 func TestLinkFailureMarksReaderDisconnected(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/artwork/artwork.go
+++ b/pkg/service/artwork/artwork.go
@@ -1,0 +1,184 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package artwork resolves cover art for display readers through the same
+// pipeline that serves the media.image API method, so a connected display gets
+// the artwork Core already scraped, resized and cached for its other clients.
+package artwork
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/rs/zerolog/log"
+)
+
+// imageTypes is the preference order a display asks for. Box art first because
+// a display is showing one small portrait image and boxes suit that shape
+// better than a screenshot does.
+var imageTypes = []string{"boxart", "thumbnail", "image", "titleshot", "screenshot"}
+
+// maxRequestedSize caps the longest edge a caller can ask for. It matches the
+// top of Core's thumbnail tier ladder, above which the pipeline would only be
+// upscaling, and keeps the int32 conversion below provably in range.
+const maxRequestedSize = 768
+
+// Source resolves artwork by delegating to the media.image handler. It holds
+// only what that handler reads, and deliberately not the service context, so
+// pkg/service can depend on this package without a cycle.
+type Source struct {
+	platform platforms.Platform
+	cfg      *config.Instance
+	db       *database.Database
+}
+
+// New returns a Source. It is safe to call before any media exists; artwork is
+// resolved per request.
+func New(pl platforms.Platform, cfg *config.Instance, db *database.Database) *Source {
+	return &Source{platform: pl, cfg: cfg, db: db}
+}
+
+// Artwork implements readers.ArtworkSource.
+//
+// It returns readers.ErrNoArtwork when the media is unknown or simply has no
+// image, which is an ordinary outcome rather than a failure: plenty of media is
+// never scraped.
+func (s *Source) Artwork(
+	ctx context.Context, systemID, path string, maxSize int,
+) (*readers.MediaArtwork, error) {
+	if s.db == nil {
+		return nil, readers.ErrNoArtwork
+	}
+	// Guard here rather than letting the handler reject it, so a caller bug
+	// cannot be mistaken for media that simply has no artwork.
+	if systemID == "" || path == "" {
+		return nil, fmt.Errorf("artwork lookup needs a system and a path, got %q and %q", systemID, path)
+	}
+
+	if maxSize <= 0 || maxSize > maxRequestedSize {
+		maxSize = maxRequestedSize
+	}
+	requested := int32(maxSize)
+
+	params := models.MediaImageParams{
+		System:     systemID,
+		Path:       path,
+		MaxSize:    &requested,
+		ImageTypes: imageTypes,
+		// A local path avoids base64-encoding the image only to decode it
+		// again in this process. The handler falls back to inline delivery
+		// when the thumbnail cache is unavailable, so both are handled below.
+		Delivery: methods.MediaImageDeliveryLocalPath,
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal media image params: %w", err)
+	}
+
+	// The image handler shares a single-slot semaphore with API traffic, so
+	// bound the wait the same way an API request would be bounded.
+	ctx, cancel := context.WithTimeout(ctx, config.APIRequestTimeout)
+	defer cancel()
+
+	result, err := methods.HandleMediaImage(requests.RequestEnv{
+		Context:       ctx,
+		Platform:      s.platform,
+		Config:        s.cfg,
+		Database:      s.db,
+		LauncherCache: helpers.GlobalLauncherCache,
+		Params:        raw,
+	})
+	if err != nil {
+		return nil, s.classify(systemID, path, err)
+	}
+
+	response, ok := result.(models.MediaImageResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected media image result type %T", result)
+	}
+	return decode(&response)
+}
+
+// classify turns a media.image failure into the error a display driver should
+// see.
+//
+// The handler reports "this media has no image" as a quiet client error, which
+// is the ordinary case for unscraped media and stays silent. Everything the
+// handler classifies as a plain client error is also treated as no artwork -
+// unknown media and an oversized image both land there, and neither is worth
+// failing a scene over - but it is logged, so a malformed request from this
+// package shows up instead of silently rendering every title coverless.
+func (*Source) classify(systemID, path string, err error) error {
+	var quietErr *models.QuietClientError
+	if errors.As(err, &quietErr) {
+		return readers.ErrNoArtwork
+	}
+
+	var clientErr *models.ClientError
+	if errors.As(err, &clientErr) {
+		log.Debug().Err(err).
+			Str("system", systemID).
+			Str("path", path).
+			Msg("artwork: media image request rejected, rendering without a cover")
+		return readers.ErrNoArtwork
+	}
+
+	return fmt.Errorf("resolve media image: %w", err)
+}
+
+func decode(response *models.MediaImageResponse) (*readers.MediaArtwork, error) {
+	var data []byte
+	switch {
+	case response.LocalPath != "":
+		read, err := os.ReadFile(response.LocalPath)
+		if err != nil {
+			return nil, fmt.Errorf("read cached artwork: %w", err)
+		}
+		data = read
+	case response.Data != "":
+		decoded, err := base64.StdEncoding.DecodeString(response.Data)
+		if err != nil {
+			return nil, fmt.Errorf("decode artwork payload: %w", err)
+		}
+		data = decoded
+	default:
+		return nil, readers.ErrNoArtwork
+	}
+
+	if len(data) == 0 {
+		return nil, readers.ErrNoArtwork
+	}
+	return &readers.MediaArtwork{
+		ContentType: response.ContentType,
+		TypeTag:     response.TypeTag,
+		Data:        data,
+	}, nil
+}

--- a/pkg/service/artwork/artwork_test.go
+++ b/pkg/service/artwork/artwork_test.go
@@ -1,0 +1,161 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package artwork_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"image"
+	"image/png"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/artwork"
+	testhelpers "github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func pngBytes(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 4, 4))))
+	return buf.Bytes()
+}
+
+// testRow builds a fixture unique to the calling test. The media.image handler
+// keeps a process-wide negative cache keyed by system and path, so tests that
+// shared a fixture would leak "no image" results into each other.
+func testRow(t *testing.T) *database.MediaFullRow {
+	t.Helper()
+	unique := strings.NewReplacer("/", "-", " ", "-").Replace(t.Name())
+	return &database.MediaFullRow{
+		Media:  database.Media{DBID: 4242, Path: filepath.Join("games", unique+".rom")},
+		Title:  database.MediaTitle{DBID: 4243, Slug: "artwork-fixture", Name: "Artwork Fixture"},
+		System: database.System{DBID: 424, SystemID: "zd-" + unique, Name: "Test System"},
+	}
+}
+
+func newSource(t *testing.T, titleProps []database.MediaProperty) (*artwork.Source, *database.MediaFullRow) {
+	t.Helper()
+
+	row := testRow(t)
+	mockDB := testhelpers.NewMockMediaDBI()
+	mockDB.On("FindSystemBySystemID", row.System.SystemID).Return(row.System, nil)
+	mockDB.On("FindMediaBySystemAndPath", mock.Anything, row.System.DBID, row.Path).Return(&row.Media, nil)
+	mockDB.On("GetMediaWithTitleAndSystem", mock.Anything, row.DBID).Return(row, nil)
+	mockDB.On("GetMediaProperties", mock.Anything, row.DBID).Return([]database.MediaProperty{}, nil)
+	mockDB.On("GetMediaTitleProperties", mock.Anything, row.Title.DBID).Return(titleProps, nil)
+	// Any other system is simply unknown to this database.
+	mockDB.On("FindSystemBySystemID", mock.Anything).Return(database.System{}, sql.ErrNoRows).Maybe()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	cfg, err := testhelpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+
+	return artwork.New(pl, cfg, &database.Database{MediaDB: mockDB}), row
+}
+
+func TestArtworkReturnsStoredCover(t *testing.T) {
+	t.Parallel()
+
+	source, row := newSource(t, []database.MediaProperty{
+		{TypeTag: "property:image-boxart", ContentType: "image/png", Binary: pngBytes(t)},
+	})
+
+	art, err := source.Artwork(context.Background(), row.System.SystemID, row.Path, 256)
+	require.NoError(t, err)
+	require.NotNil(t, art)
+	assert.NotEmpty(t, art.Data)
+	assert.Contains(t, art.TypeTag, "boxart")
+	assert.NotEmpty(t, art.ContentType)
+}
+
+func TestArtworkReportsNoArtworkWhenMediaHasNone(t *testing.T) {
+	t.Parallel()
+
+	source, row := newSource(t, []database.MediaProperty{})
+
+	// Plenty of media is never scraped. That is an ordinary outcome, and the
+	// driver renders a coverless scene rather than treating it as a failure.
+	_, err := source.Artwork(context.Background(), row.System.SystemID, row.Path, 256)
+	require.Error(t, err)
+	require.ErrorIs(t, err, readers.ErrNoArtwork)
+}
+
+func TestArtworkReportsNoArtworkForUnknownSystem(t *testing.T) {
+	t.Parallel()
+
+	source, _ := newSource(t, []database.MediaProperty{})
+
+	_, err := source.Artwork(context.Background(), "system-that-does-not-exist", "whatever.rom", 256)
+	require.Error(t, err)
+	require.ErrorIs(t, err, readers.ErrNoArtwork)
+}
+
+func TestArtworkWithoutDatabaseReportsNoArtwork(t *testing.T) {
+	t.Parallel()
+
+	source := artwork.New(nil, nil, nil)
+	_, err := source.Artwork(context.Background(), "any-system", "any/path.rom", 256)
+	require.ErrorIs(t, err, readers.ErrNoArtwork)
+}
+
+func TestArtworkClampsOutOfRangeMaxSize(t *testing.T) {
+	t.Parallel()
+
+	// An out-of-range hint must not be rejected by the image handler's own
+	// parameter validation; it is clamped to the top thumbnail tier instead.
+	for _, maxSize := range []int{0, -1, 1 << 20} {
+		t.Run(fmt.Sprintf("maxSize %d", maxSize), func(t *testing.T) {
+			t.Parallel()
+			source, row := newSource(t, []database.MediaProperty{
+				{TypeTag: "property:image-boxart", ContentType: "image/png", Binary: pngBytes(t)},
+			})
+			art, err := source.Artwork(context.Background(), row.System.SystemID, row.Path, maxSize)
+			require.NoError(t, err)
+			assert.NotEmpty(t, art.Data)
+		})
+	}
+}
+
+func TestArtworkRejectsIncompleteRequests(t *testing.T) {
+	t.Parallel()
+
+	source, row := newSource(t, []database.MediaProperty{})
+
+	// A caller that forgot to fill in the media is a bug here, not media that
+	// happens to have no artwork, so it must not be reported as ErrNoArtwork.
+	_, err := source.Artwork(context.Background(), "", row.Path, 256)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, readers.ErrNoArtwork)
+
+	_, err = source.Artwork(context.Background(), row.System.SystemID, "", 256)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, readers.ErrNoArtwork)
+}

--- a/pkg/service/readers.go
+++ b/pkg/service/readers.go
@@ -547,12 +547,16 @@ func readerManager(
 						log.Info().Msgf("reader count changed: %d connected", len(rs))
 					}
 					lastReaderCount = len(rs)
-				} else if readerConnectAttempts%120 == 1 && len(rs) == 0 {
-					// Only log if no readers for 2 minutes
+				} else if readerConnectAttempts%120 == 1 && countScanCapableReaders(rs) == 0 {
+					// Only log if no readers for 2 minutes. Counted by what can
+					// produce a scan, not by list length: a display-only reader
+					// is connected hardware but leaves the user with no way to
+					// scan a token, which is what this is here to point at.
 					log.Debug().
 						Int("attempts", readerConnectAttempts).
+						Int("connected", len(rs)).
 						Bool("autoDetect", svc.Config.AutoDetect()).
-						Msg("no readers connected")
+						Msg("no scan-capable readers connected")
 				}
 
 				for _, r := range rs {
@@ -1046,4 +1050,20 @@ preprocessing:
 			}
 		}
 	}
+}
+
+// countScanCapableReaders counts readers that can actually produce a scan.
+//
+// Display accessories are readers in every structural sense but never emit a
+// token, so counting them would silence the "nothing to scan with" diagnostic
+// for a user who has a panel connected and no reader.
+func countScanCapableReaders(rs []readers.Reader) int {
+	n := 0
+	for _, r := range rs {
+		if r == nil || readers.HasCapability(r, readers.CapabilityDisplay) {
+			continue
+		}
+		n++
+	}
+	return n
 }

--- a/pkg/service/readers_test.go
+++ b/pkg/service/readers_test.go
@@ -1267,3 +1267,19 @@ on_scan = "**echo:on_scan ran"`))
 	tok := env.expectToken(t)
 	assert.Equal(t, "token-a", tok.UID, "scan must still reach the token queue when ZapScript is disabled")
 }
+
+func TestCountScanCapableReadersIgnoresDisplays(t *testing.T) {
+	t.Parallel()
+
+	scanner := mocks.NewMockReader()
+	scanner.On("Capabilities").Return([]readers.Capability{readers.CapabilityWrite})
+
+	display := mocks.NewMockReader()
+	display.On("Capabilities").Return([]readers.Capability{readers.CapabilityDisplay})
+
+	// A display accessory is connected hardware but cannot scan a token, so it
+	// must not silence the "nothing to scan with" diagnostic.
+	assert.Equal(t, 0, countScanCapableReaders([]readers.Reader{display}))
+	assert.Equal(t, 0, countScanCapableReaders([]readers.Reader{nil}))
+	assert.Equal(t, 1, countScanCapableReaders([]readers.Reader{display, scanner}))
+}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/mediaslot"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/artwork"
 	backupsvc "github.com/ZaparooProject/zaparoo-core/v2/pkg/service/backup"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/broker"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/discovery"
@@ -440,6 +441,10 @@ func startService(
 	// Initialize inbox service for system notifications
 	log.Info().Msg("initializing inbox service")
 	st.SetInbox(inbox.NewService(db.UserDB, st.Notifications))
+
+	// Display readers render cover art from Core's own media metadata, so give
+	// them a way to reach it now the database is open.
+	st.SetArtworkSource(artwork.New(pl, cfg, db))
 
 	if mediaDBReset != nil {
 		notifyMediaDBSchemaReset(st, mediaDBReset.userDataLost, mediaDBReset.corrupt)

--- a/pkg/service/state/artwork_source_test.go
+++ b/pkg/service/state/artwork_source_test.go
@@ -1,0 +1,136 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package state_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/readers"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/state"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSource struct{}
+
+func (*stubSource) Artwork(context.Context, string, string, int) (*readers.MediaArtwork, error) {
+	return nil, readers.ErrNoArtwork
+}
+
+// displayReader is a mock reader that also accepts an artwork source, standing
+// in for a real display driver.
+type displayReader struct {
+	*mocks.MockReader
+	source readers.ArtworkSource
+}
+
+func (d *displayReader) SetArtworkSource(source readers.ArtworkSource) {
+	d.source = source
+}
+
+func newDisplayReader(readerID string) *displayReader {
+	m := mocks.NewMockReader()
+	m.SetupBasicMock()
+	m.ExpectedCalls = nil
+	m.On("Close").Return(nil).Maybe()
+	m.On("Metadata").Return(readers.DriverMetadata{ID: "zapdisplay"})
+	m.On("Path").Return("/dev/ttyACM0")
+	m.On("Connected").Return(true)
+	m.On("ReaderID").Return(readerID)
+	m.On("Capabilities").Return([]readers.Capability{readers.CapabilityDisplay})
+	m.On("OnMediaChange", mock.Anything).Return(nil).Maybe()
+	return &displayReader{MockReader: m}
+}
+
+func TestSetReaderInjectsArtworkSource(t *testing.T) {
+	t.Parallel()
+
+	st, _ := state.NewState(nil, "boot")
+	source := &stubSource{}
+	st.SetArtworkSource(source)
+
+	reader := newDisplayReader("zapdisplay-abc")
+	st.SetReader(reader)
+
+	assert.Same(t, source, reader.source, "a display reader should be handed the artwork source on registration")
+	assert.Same(t, source, st.ArtworkSource())
+}
+
+func TestSetReaderWithoutArtworkSourceIsSafe(t *testing.T) {
+	t.Parallel()
+
+	// Readers can connect before the database is open, so no source is set yet.
+	st, _ := state.NewState(nil, "boot")
+	reader := newDisplayReader("zapdisplay-abc")
+	st.SetReader(reader)
+
+	assert.Nil(t, reader.source)
+	assert.Nil(t, st.ArtworkSource())
+}
+
+func TestSetReaderLeavesNonConsumersAlone(t *testing.T) {
+	t.Parallel()
+
+	st, _ := state.NewState(nil, "boot")
+	st.SetArtworkSource(&stubSource{})
+
+	// A plain reader does not implement ArtworkConsumer; registering it must
+	// not panic or otherwise misbehave.
+	m := mocks.NewMockReader()
+	m.SetupBasicMock()
+	st.SetReader(m)
+
+	require.Len(t, st.ListReaders(), 1)
+}
+
+func TestSetReaderPushesCurrentMediaToNewDisplay(t *testing.T) {
+	t.Parallel()
+
+	st, ns := state.NewState(nil, "boot")
+	// Drain notifications so the channel never fills during the test.
+	go func() {
+		for range ns { //nolint:revive // draining is the point
+		}
+	}()
+
+	media := models.NewActiveMedia("snes", "Super Nintendo", "/games/sm.sfc", "Super Metroid", "retroarch")
+	st.SetActiveMedia(media)
+
+	reader := newDisplayReader("zapdisplay-abc")
+	st.SetReader(reader)
+
+	// Plugging a display in mid-game produces no media change, so registration
+	// has to hand it the current state or it would sit on an idle screen.
+	reader.AssertCalled(t, "OnMediaChange", media)
+}
+
+func TestSetReaderDoesNotPushWhenNothingIsPlaying(t *testing.T) {
+	t.Parallel()
+
+	st, _ := state.NewState(nil, "boot")
+	reader := newDisplayReader("zapdisplay-abc")
+	st.SetReader(reader)
+
+	reader.AssertNotCalled(t, "OnMediaChange", mock.Anything)
+}

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -87,6 +87,7 @@ type State struct {
 	beforeExitHook        func()
 	pendingLaunchOverride *PendingLaunchOverride
 	pendingWrite          *PendingWrite
+	artworkSource         readers.ArtworkSource
 	backupCoordinator     *backupcoordinator.Coordinator
 	launcherManager       *LauncherManager
 	uiEvents              *uievents.Service
@@ -396,11 +397,41 @@ func (s *State) SetReader(reader readers.Reader) {
 		Driver:    reader.Metadata().ID,
 		Path:      reader.Path(),
 	}
+	artworkSource := s.artworkSource
+	currentMedia := s.activeMedia
 
 	s.mu.Unlock()
 
+	// Everything below calls into the reader or the notification channel, so
+	// it must stay outside the lock.
+	if consumer, ok := reader.(readers.ArtworkConsumer); ok && artworkSource != nil {
+		consumer.SetArtworkSource(artworkSource)
+	}
+
 	// Send notification outside lock to prevent deadlock
 	notifications.ReadersAdded(s.Notifications, payload)
+
+	// A display connected part way through a session has no media change to
+	// react to, so hand it the current state instead of leaving it on an idle
+	// screen while a game is running.
+	if currentMedia != nil {
+		s.safeNotifyReader(reader, currentMedia)
+	}
+}
+
+// SetArtworkSource sets the source display readers use to resolve cover art.
+// Called during service startup once the database is ready.
+func (s *State) SetArtworkSource(source readers.ArtworkSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.artworkSource = source
+}
+
+// ArtworkSource returns the cover art source, or nil if one was never set.
+func (s *State) ArtworkSource() readers.ArtworkSource {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.artworkSource
 }
 
 // RemoveReader removes a reader by its ReaderID and closes it.


### PR DESCRIPTION
Adds a reader driver for the Zaparoo display accessory: a USB-connected
320x960 panel that shows the title, system and cover art of whatever is
playing.

Unlike tty2oled, which renders system logos from downloaded picture packs,
this sources everything from Core's own stored metadata through the existing
`media.image` pipeline, so it works for any scraped media without shipping
per-system artwork.

## Artwork for display readers

Display drivers get no database handle, so there was no way for one to reach
artwork Core already scrapes, resizes and caches.

`readers.ArtworkSource` is implemented by a new `pkg/service/artwork` package
on top of the `media.image` handler, and handed to a driver through the
optional `readers.ArtworkConsumer` interface. `Reader` itself is unchanged:
adding a method there would touch all eleven drivers plus the mock, and
`ArtworkConsumer` follows the pattern already used for late injection.

Injection happens in `State.SetReader`, the single choke point both the
configured and auto-detected connect paths funnel through. `SetReader` also
pushes the currently playing media to a display that connects part way
through a session, which otherwise sat on an idle screen while a game ran.

Media is addressed by system ID and path because `ActiveMedia` carries no
media ID in process.

## The driver

Display only: `CapabilityDisplay`, never produces a scan, rejects writes.

`OnMediaChange` records the newest state and wakes a worker rather than
touching the port. It runs on the media publish path while state locks are
held, and a cover upload takes on the order of a second.

Renders are guarded by panic recovery. The path decodes PNG, JPEG and WebP
from scraped files, and a malformed one would otherwise take the daemon down
rather than one display. A panic drops the link so the service reconnects
through a fresh handshake, rather than carrying on against a stream that may
have a command written and its response unread.

## Detection

The board uses the ESP32-S3 native USB peripheral, so it enumerates with
Espressif's stock vendor ID and no product string. The handshake is the only
positive identification, but the vendor ID rules out the 3D printers and
Arduino-class boards that also appear on `/dev/ttyACM*`, before anything is
opened. A port whose vendor cannot be read is still probed, or the display
would be undetectable where udevadm is absent.

Ports that answer wrongly are remembered for a minute, keyed by the device
node's mtime so a replug clears the entry. The retry window matters because
the display can fail its own probe: its USB peripheral enumerates from the
ROM bootloader, so the node exists before the firmware is answering.

`helpers.GetSerialDeviceList` matches only `tty.usbserial` on macOS, which is
a USB-to-UART bridge and never this board, so native-USB devices get their
own listing. `SerialDeviceVIDPID` is factored out of `ignoreSerialDevice`,
and the two `/dev` walks fold into one prefix-driven lister.

## Defaults

Enabled by default on MiSTer, MiSTeX, Batocera and ReplayOS, where the panel
is a first-party accessory. Opt-in everywhere else, since detection has to
open a serial port and write to it.

This is a behaviour change for existing users on those four platforms: the
driver goes from dormant to probing Espressif serial devices. It is bounded
by the vendor filter and the per-plug probe cache.

## Display rotation

Both drivers could already rotate and neither had a way in. tty2oled's
sequence sat behind `DefaultRotation`, a compile-time `false` const, so no
user could reach it; the zapdisplay firmware has `SET rotation` that the
driver never sent.

```toml
[readers.drivers.zapdisplay]
rotation = 180
```

Degrees rather than a flip flag, so quarter turns do not need a new field
later. Each driver reads it at connect and applies it in its own init
sequence — tty2oled where `CMDSORG` and its settle belong, zapdisplay before
the first frame so a rotated panel never shows one the wrong way up and then
flips.

Core is the authority and the device stores a copy. tty2oled keeps no
settings and has to be told on every connect; zapdisplay persists in NVS so
it comes up right with no host attached. Zero is sent rather than skipped, so
a panel is not left holding a rotation the user has since turned off.

Which angles are possible is a property of the panel, so config accepts 0,
90, 180 and 270 and the driver refuses what it cannot do. Neither current
display manages a quarter turn — both have one landscape layout, and turning
one needs a UI built for the other aspect rather than a transform. An
impossible angle is logged and the panel left unrotated, so a config mistake
does not stop a display connecting.

Config only, no settings API surface.

## System ID folders

Unrelated to the display, and separable if you would rather it landed on its
own.

A library organised as one folder per Zaparoo system ID indexed almost
nothing unless a launcher happened to declare that exact folder name. On a
test share, 43 of 154 system folders were scannable; Genesis and Gameboy
indexed zero media despite holding tens of thousands of files. After the
change the same share went from 199,884 to 256,379 indexed media, with
Genesis at 25,407 and Gameboy at 13,492.

System IDs are already the names used in the API, in the scraper's custom
gamelist bundles and in published metadata packs. This treats a folder named
after one as scannable, in the launcher cache so it is equally visible to
`LauncherMatcher` — a path discovered but owned by no launcher indexes
nothing.

Only launchers that already scan a root-relative folder are extended, and a
folder another system already scans by name stays with that system.

## Notes for review

- `pkg/readers/testutils.SerialPort` gains `Write`, and `MockSerialPort`
  records what was written so driver tests can assert on exact bytes.
- The "no readers connected" diagnostic now counts scan-capable readers, so
  a display does not silence it for a user who has no way to scan a token.
- `ignoreSerialDevice` logs a udevadm failure at debug rather than error. It
  is now called speculatively across every candidate port, where a node with
  no udev record is an ordinary answer.
- `MediaImageDeliveryInline` and `MediaImageDeliveryLocalPath` are exported
  so an in-process caller builds requests from the same constants the
  handler validates against. Wire values unchanged.
- No config schema change. The existing driver-enable machinery covers both
  `[readers.drivers.zapdisplay]` and a pinned `[[readers.connect]]` entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ZapDisplay accessories across supported platforms.
  * Displays can show media titles, systems, playback states, and cover artwork.
  * Added cover-art retrieval from stored media and improved display reconnect behavior.
  * Added configurable display rotation, including support for TTY2OLED and ZapDisplay.
  * Added cross-platform USB CDC serial-device detection.
  * Launcher scanning now automatically recognizes system-specific folders when appropriate.

* **Bug Fixes**
  * Improved handling of unavailable serial-device metadata and failed detection attempts.
  * Reader diagnostics now distinguish display-only devices from scan-capable readers.

* **Documentation**
  * Updated the supported reader list to include ZapDisplay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
