### PR TITLE
fix(test): stop wall-clock and mock races failing CI on macOS and Windows

### DIFF
--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -770,6 +770,12 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			mockUserDB := &helpers.MockUserDBI{}
 			mockMediaDB := helpers.NewMockMediaDBI()
 
+			// Indexing re-applies the UserDB projection near the end of a run. It
+			// normally loses the race with the cancellation below, but when it
+			// wins, an unexpected call panics the whole test binary rather than
+			// failing this test (#1379).
+			mockUserDB.On("ListMediaUserData").Return([]database.MediaUserData{}, nil).Maybe()
+
 			// Persisted optimization state is restart intent, not process ownership.
 			mockMediaDB.On("GetOptimizationStatus").Return(tt.optimizationStatus, nil)
 			mockMediaDB.On("SetOptimizationStatus", mock.Anything).Return(nil).Maybe()
@@ -812,6 +818,8 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			mockMediaDB.On("PopulateSystemTagsCacheForSystems", mock.Anything, mock.Anything).Return(nil).Maybe()
 			mockMediaDB.On("RefreshSlugSearchCacheForSystems", mock.Anything, mock.Anything).Return(nil).Maybe()
 			mockMediaDB.On("RunBackgroundOptimization", mock.Anything, mock.Anything).Return().Maybe()
+			mockMediaDB.On("RunBackgroundOptimizationWithLease",
+				mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 			mockMediaDB.On("TrackBackgroundOperation").Return().Maybe()
 			mockMediaDB.On("BackgroundOperationDone").Return().Maybe()
 

--- a/pkg/audio/playback.go
+++ b/pkg/audio/playback.go
@@ -51,6 +51,9 @@ const (
 	ringBufferFrames = 4 * targetSampleRate
 	// decodeChunkFrames is the number of frames decoded per prefetch iteration (100 ms).
 	decodeChunkFrames = 100 * targetSampleRate / 1000
+	// defaultPrefetchTick is how often the prefetch goroutine wakes to look for
+	// ring space when nothing else has woken it.
+	defaultPrefetchTick = 100 * time.Millisecond
 )
 
 // PlaybackOptions configures a long-form Play call.
@@ -286,18 +289,22 @@ func (*LongformPlaybackManager) slotKey(slot string) (string, error) {
 // background goroutine. This bounds memory use to ringBufferFrames regardless of
 // file length and keeps decoding off the malgo audio thread.
 type streamingSource struct {
-	streamer       beep.Streamer
-	decoder        beep.StreamSeekCloser
-	onDrain        func(natural bool)
-	file           *os.File
-	wakeCh         chan struct{}
-	doneCh         chan struct{}
-	cancelFn       context.CancelFunc
-	path           string
-	ring           [][2]float64
-	chunk          [][2]float64
-	volume         float64
-	totalFrames    int64
+	streamer    beep.Streamer
+	decoder     beep.StreamSeekCloser
+	onDrain     func(natural bool)
+	file        *os.File
+	wakeCh      chan struct{}
+	doneCh      chan struct{}
+	cancelFn    context.CancelFunc
+	path        string
+	ring        [][2]float64
+	chunk       [][2]float64
+	volume      float64
+	totalFrames int64
+	// tickInterval is how often the prefetch goroutine wakes on its own; zero
+	// means defaultPrefetchTick. Tests lengthen it so that a full ring can only
+	// be the result of a burst fill, never of one chunk per wake-up.
+	tickInterval   time.Duration
 	sourceRate     int
 	quality        int
 	mu             syncutil.Mutex
@@ -362,17 +369,18 @@ func newStreamingSource(path string, volume float64, quality int) (*streamingSou
 	streamer := streamerAtTargetSampleRate(decoder, format.SampleRate, quality)
 
 	return &streamingSource{
-		ring:        make([][2]float64, ringBufferFrames),
-		path:        path,
-		volume:      volume,
-		totalFrames: totalFrames,
-		sourceRate:  int(format.SampleRate),
-		quality:     quality,
-		wakeCh:      make(chan struct{}, 1),
-		decoder:     decoder,
-		file:        f,
-		streamer:    streamer,
-		chunk:       make([][2]float64, decodeChunkFrames),
+		ring:         make([][2]float64, ringBufferFrames),
+		path:         path,
+		volume:       volume,
+		totalFrames:  totalFrames,
+		tickInterval: defaultPrefetchTick,
+		sourceRate:   int(format.SampleRate),
+		quality:      quality,
+		wakeCh:       make(chan struct{}, 1),
+		decoder:      decoder,
+		file:         f,
+		streamer:     streamer,
+		chunk:        make([][2]float64, decodeChunkFrames),
 	}, nil
 }
 
@@ -401,7 +409,11 @@ func (s *streamingSource) prefetch(ctx context.Context, done chan struct{}) {
 		}
 	}()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
+	interval := s.tickInterval
+	if interval <= 0 {
+		interval = defaultPrefetchTick
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	var reportedUnderruns uint64
 

--- a/pkg/audio/playback_test.go
+++ b/pkg/audio/playback_test.go
@@ -423,11 +423,17 @@ func TestStreamingSource_SeekAfterEOFRefillsRing(t *testing.T) {
 }
 
 // TestStreamingSource_PrefetchFillsRingWithoutTickerPacing verifies the prefetch
-// goroutine fills the entire ring in a burst rather than one chunk per 100 ms
-// tick. Per-tick pacing capped decode at 1x realtime, so the ring never built a
+// goroutine fills the entire ring in a burst rather than one chunk per tick.
+// Per-tick pacing capped decode at 1x realtime, so the ring never built a
 // cushion and CPU contention produced period-sized dropouts (crackle) on slow
-// ARM devices. Filling the 4 s ring takes 40 chunks: burst-filling completes in
-// well under 2 s, while per-tick pacing needs at least 4 s.
+// ARM devices.
+//
+// The tick is stretched to an hour so the assertion is structural rather than
+// timed: filling the 4 s ring takes 40 chunks, and only a goroutine that keeps
+// decoding until the ring is full can get there before the first wake-up. A
+// return to one chunk per tick fails here however fast the machine is, and the
+// deadline below is only a hang guard — measuring the fill instead made this
+// test a race against real decode work on a loaded CI runner (#1379).
 func TestStreamingSource_PrefetchFillsRingWithoutTickerPacing(t *testing.T) {
 	t.Parallel()
 
@@ -437,12 +443,13 @@ func TestStreamingSource_PrefetchFillsRingWithoutTickerPacing(t *testing.T) {
 
 	s, err := newStreamingSource(path, 1.0, resampleQuality)
 	require.NoError(t, err)
+	s.tickInterval = time.Hour
 	s.startPrefetch()
 	t.Cleanup(s.stopAndDeregister)
 
 	require.Eventually(t, func() bool {
 		return s.bufferedFrames() == len(s.ring)
-	}, 2*time.Second, 5*time.Millisecond, "prefetch should burst-fill the full ring")
+	}, 30*time.Second, 5*time.Millisecond, "prefetch should burst-fill the full ring")
 }
 
 func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
@@ -455,9 +462,12 @@ func TestStreamingSource_ConcurrentPrefetchAndMix(t *testing.T) {
 	require.NoError(t, err)
 	s.startPrefetch()
 	t.Cleanup(s.stopAndDeregister)
+	// A full ring is this test's starting position, not its subject, so the
+	// deadline is a hang guard: real decode and resample work on a shared CI
+	// runner is not something to race (#1379).
 	require.Eventually(t, func() bool {
 		return s.bufferedFrames() == len(s.ring)
-	}, 2*time.Second, 5*time.Millisecond)
+	}, 30*time.Second, 5*time.Millisecond)
 
 	buf := make([][2]float64, 2048)
 	deadline := time.Now().Add(5 * time.Second)

--- a/pkg/database/mediadb/scan_reconcile_accounting_test.go
+++ b/pkg/database/mediadb/scan_reconcile_accounting_test.go
@@ -31,6 +31,7 @@ package mediadb
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strconv"
 	"strings"
@@ -67,6 +68,23 @@ func parseStepTimings(t *testing.T, steps string) map[string]int64 {
 	return out
 }
 
+// slowBoundsDB delays the per-chunk bounds lookup, the one QueryRowContext
+// sqlUpsertStagedMedia issues, so that its cost is far larger than any
+// platform's clock granularity. Windows' timer ticks at ~15.6 ms and a bounds
+// query against a warm SQLite file finishes well inside one tick, which read
+// back as exactly 0 and failed a bare positivity assertion there (#1379).
+type slowBoundsDB struct {
+	sqlQueryable
+	delay time.Duration
+	calls int
+}
+
+func (db *slowBoundsDB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
+	db.calls++
+	time.Sleep(db.delay)
+	return db.sqlQueryable.QueryRowContext(ctx, query, args...)
+}
+
 // TestChunkedStepTiming_PacingIsNotBilledAsSQL is the core guarantee for the
 // two steps that yield inside their own loops. Both call the scanner's pauser
 // between chunks; on the MiSTer that pauser sleeps roughly as long as the work
@@ -79,11 +97,13 @@ func TestChunkedStepTiming_PacingIsNotBilledAsSQL(t *testing.T) {
 	const (
 		rows        = scanUpsertMediaBatchSize + 25 // forces a second chunk, so yield runs twice
 		pausePerRun = 40 * time.Millisecond         // the MiSTer ThrottleBackground work window
+		boundsDelay = 40 * time.Millisecond
 	)
 
 	ctx := context.Background()
 	sqlDB := newUpsertStagedMediaTestDB(t)
 	stageSyntheticMedia(t, sqlDB, 1, rows)
+	boundsDB := &slowBoundsDB{sqlQueryable: sqlDB, delay: boundsDelay}
 
 	yields := 0
 	yield := func() error {
@@ -92,9 +112,7 @@ func TestChunkedStepTiming_PacingIsNotBilledAsSQL(t *testing.T) {
 		return nil
 	}
 
-	started := time.Now()
-	affected, timing, err := sqlUpsertStagedMedia(ctx, sqlDB, "C64", 1, yield)
-	wall := time.Since(started)
+	affected, timing, err := sqlUpsertStagedMedia(ctx, boundsDB, "C64", 1, yield)
 	require.NoError(t, err)
 	require.EqualValues(t, rows, affected)
 	require.GreaterOrEqual(t, yields, 2, "test needs at least two chunks to be meaningful")
@@ -103,10 +121,14 @@ func TestChunkedStepTiming_PacingIsNotBilledAsSQL(t *testing.T) {
 		"every yield must be captured in timing.pacing; otherwise the sleep is "+
 			"billed as SQL work and double-counted against the scanner's throttle total")
 
-	sqlTime := wall - timing.bounds - timing.pacing
-	assert.Less(t, sqlTime, wall-timing.pacing+time.Millisecond,
-		"reported SQL time must exclude pacing")
-	assert.Positive(t, timing.bounds,
+	// Two claims, neither of them a race against the clock: the lookup runs once
+	// per chunk (counted, not timed), and the delay injected into it lands in
+	// timing.bounds, so the timer really does wrap the bounds statement. The
+	// requirement stays at one delay rather than one per call because a coarse
+	// clock can read each measured interval up to a tick short, and scaling it by
+	// the call count would put the granularity back in.
+	require.GreaterOrEqual(t, boundsDB.calls, 2, "each chunk must run its own bounds lookup")
+	assert.GreaterOrEqual(t, timing.bounds, boundsDelay,
 		"the per-chunk bounds lookup is a real statement and must be reported separately")
 }
 


### PR DESCRIPTION
Closes #1379.

Three tests fail on CI for reasons unrelated to the product, and between them they make main's status close to meaningless: of the last 25 `Lint and Test` runs on main, one succeeded. Because the macOS and Windows jobs only run on pushes to main, none of this is visible on a pull request.

**macOS, `TestStreamingSource_PrefetchFillsRingWithoutTickerPacing`.** The test proved prefetch burst-fills its ring by giving it 2 s, since per-tick pacing would need 4 s. That 2 s was also the budget for decoding and resampling 6 s of 44.1 kHz audio in a parallel test on a shared runner, so a loaded macOS job failed it with prefetch behaving correctly — that is how `4023de5b` went red. `streamingSource` now carries the prefetch wake-up interval as a field and the test stretches it to an hour, so a full ring can only be the result of a burst fill and runner speed cannot decide the outcome. `ConcurrentPrefetchAndMix` waits for the same fill on the same 2 s deadline as a precondition; it gets a deadline it cannot lose.

**Windows, `TestChunkedStepTiming_PacingIsNotBilledAsSQL`.** `assert.Positive(t, timing.bounds)` asks whether a small SQLite query took a measurable amount of time. Windows' timer ticks at ~15.6 ms and the query finishes inside one tick, so it read back as exactly `0s`. The test now wraps the DB so the bounds lookup sleeps 40 ms, and asserts the two things actually claimed: the lookup runs once per chunk (counted, not timed) and the injected delay lands in `timing.bounds`.

**macOS, `TestHandleGenerateMedia_SystemFiltering`.** Separate flake found while confirming the other two. The test runs real indexing against a mocked MediaDB and cancels it; when the goroutine outruns cancellation it calls `ListMediaUserData` on a mock with no expectations, and testify's panic takes down the whole `pkg/api/methods` binary. Letting the goroutine run to completion showed `RunBackgroundOptimizationWithLease` is unmocked too, so covering only the first call would have moved the panic rather than removed it.

Both wall-clock fixes were checked against injected regressions rather than trusted: reinstating per-tick pacing fails the audio test, and dropping `timing.bounds += time.Since(...)` fails the bounds test. The mock panic reproduces exactly as it did on CI when the expectation is removed and cancellation delayed.

macOS and Windows are not reachable locally and a pull request will not run them either, so the injected-regression checks stand in for that; the real verdict lands on the post-merge run on main.

The `concurrency` block noted at the bottom of #1379 is deliberately not touched here — cancelling superseded runs is intended behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved streaming audio prefetch behavior with configurable timing, helping playback adapt more reliably across different conditions.
  - Strengthened media processing reliability during indexing and cancellation scenarios.
- **Bug Fixes**
  - Improved timing accuracy for media database operations, providing more consistent processing behavior.
- **Tests**
  - Expanded coverage for audio prefetching, media processing, and database timing to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->