### PR TITLE
fix(media): align browse container resolution with media.meta and bound its batch

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -109,6 +109,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gomod-
 
+      # Only the module cache is persisted, so every Windows run compiled the
+      # module from scratch: cgo plus a -race test binary per package, at
+      # GOMAXPROCS 2. That put the first test result seven minutes in and left
+      # the job still linking when the timeout killed it. This cache is keyed by
+      # commit and restored by prefix, so a run starts from the nearest previous
+      # build rather than from nothing.
+      - name: Cache Go build cache (Windows)
+        if: matrix.os == 'windows'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: D:\go-cache
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('go.mod', 'go.sum') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gobuild-${{ hashFiles('go.mod', 'go.sum') }}-
+            ${{ runner.os }}-gobuild-
+
       - name: Download Go modules (Windows)
         if: matrix.os == 'windows'
         shell: msys2 {0}

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -764,6 +764,8 @@ Set `rootView` to `contents` with exactly one system to replace its filesystem r
 
 A directory whose direct contents collapse to a single logical launch target is returned with that target's `mediaId`, display name, `zapScript`, `tags`, and `hasCover`, so a per-game disc folder appears as one launchable game. A directory qualifies when it holds one media file, one `.m3u` plus its discs, or one `.cue` plus its companion tracks, and holds no media in subdirectories. Its `type` stays `directory` and it keeps its own `path` and `fileCount`, so clients can still navigate into it. Directories that hold nested media or an ambiguous file set stay plain directories.
 
+A directory holding media for more than one system also stays plain, because its `fileCount` is the sum across those systems and the rule is applied one system at a time. A page spanning several systems is resolved per system when `systems` names them; without a `systems` filter such a page is left unresolved, since browsing a media root lists one directory per installed system and resolving all of them is disproportionate to that page's cost.
+
 Tags filter direct media files in the current path. Directories remain visible for navigation with unfiltered `fileCount` values, while `totalFiles`, file pagination, and cursors reflect only matching files. Tagged directory entries remain plain directories rather than being promoted to logical single-game aliases.
 
 #### Parameters

--- a/docs/media-titles.md
+++ b/docs/media-titles.md
@@ -28,7 +28,8 @@ When launching by title (e.g. `launch.title` with arg `NES/Super Mario Bros`):
 3. Slugifies the game name using the same normalization as indexing
 4. Tries matching strategies in order until finding a result (see [Matching strategies](#matching-strategies))
 5. Scores and filters results to pick the best match
-6. Caches the resolution for future queries
+6. Promotes the match to its directory's container launch target, if it has one (see [Container promotion](#container-promotion))
+7. Caches the resolution for future queries
 
 ---
 
@@ -265,3 +266,21 @@ When multiple results match, they get filtered and scored:
 5. Preferred languages from user config
 6. File type priority based on launcher extension order
 7. Quality tie-breaking: numeric suffix penalty, path depth, character density, filename length
+
+### Container promotion
+
+Every file in a disc folder shares one title: `Game.cue` and its `Game (Track 01).bin`
+tracks all slugify to the same thing, and `(Track 01)` produces no tag to tell them
+apart. Selection alone therefore cannot reliably return the cue sheet, and the slug
+search is capped at 50 rows, so in a large folder the cue may not be a candidate at all.
+
+After a match is selected, Zaparoo asks the database what the match's *directory*
+collapses to, using the same rule browse, `media.meta` and the scrapers use: a lone
+file, one `.m3u` plus its discs, or one `.cue` plus its companion tracks. When that
+names a different file, it becomes the launch target and the cached resolution.
+
+Two things bound it. Only a path whose extension could accompany a cue or an m3u is
+checked, so an ordinary `.nes` or `.sfc` costs no extra query. And a tag the query
+asked for that the selection carried is never given up — a playlist holds no `disc`
+tag, so `PSX/Game (Disc 2)` keeps the disc it named, while a region both files carry
+promotes normally.

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -1322,9 +1322,11 @@ func buildBrowseResponse(
 }
 
 // resolveDirSingletonAliases batch-resolves singleton container aliases for the
-// page's candidate directories when browsing a single system. Only small dirs
-// (recursive FileCount <= maxSingletonAliasCandidateFiles) are considered, so
-// large trees like MiSTer's _Arcade/_alternatives are never scanned.
+// page's candidate directories when browsing a single system. Every directory
+// holding media for that system is offered to the resolver, which reads only
+// each candidate's direct rows, so the container rule alone decides what
+// collapses and browse agrees with media.meta and the scrapers on a disc folder
+// of any size.
 func resolveDirSingletonAliases(
 	env *requests.RequestEnv,
 	path string,
@@ -1359,7 +1361,9 @@ func resolveDirSingletonAliases(
 
 	var candidates []database.SingletonAliasCandidate
 	for _, dir := range dirs {
-		if !isSingletonDirectoryAliasCandidate(dir.FileCount) {
+		// A directory with no media for this system has nothing to collapse to,
+		// and the resolver keys its nested-media test on a non-zero count.
+		if dir.FileCount <= 0 {
 			continue
 		}
 		if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
@@ -1446,14 +1450,6 @@ func buildMediaEntry(
 	entry.RelPath = mediaResponseRelativePath(env, result.SystemID, result.Path)
 
 	return entry
-}
-
-// isSingletonDirectoryAliasCandidate bounds the dirs considered for singleton
-// alias resolution: real disc-folder containers hold a handful of files, and
-// the cap keeps the batch query from fetching rows for large directory trees.
-func isSingletonDirectoryAliasCandidate(fileCount int) bool {
-	const maxSingletonAliasCandidateFiles = 64
-	return fileCount > 0 && fileCount <= maxSingletonAliasCandidateFiles
 }
 
 // isPathUnderRoots checks if the given path is at or under one of the allowed root directories.

--- a/pkg/api/methods/media_browse.go
+++ b/pkg/api/methods/media_browse.go
@@ -1321,12 +1321,94 @@ func buildBrowseResponse(
 	}, nil
 }
 
+// groupSingletonAliasCandidates buckets a page's directories by the system each
+// one belongs to.
+//
+// A directory holding media for more than one system is left out, and cannot
+// currently be anything else. BrowseDirectoryResult.FileCount is the sum across
+// systems, while the resolver counts direct rows one system at a time, so the
+// nested-media test it keys on compares a per-system count against a total and
+// never balances. Offering the directory anyway would cost a scan to reach the
+// same answer. Resolving one properly means carrying per-system counts out of
+// the browse query — BrowseDirCounts already stores them per system and the
+// query sums them — which is more than the case is worth while a systems filter
+// is the normal way to browse: with one, the query narrows SystemIDs to that
+// system and the same directory resolves like any other.
+func groupSingletonAliasCandidates(
+	path string,
+	dirs []database.BrowseDirectoryResult,
+	systems []systemdefs.System,
+) (order []string, bySystem map[string][]database.SingletonAliasCandidate) {
+	requested := make(map[string]struct{}, len(systems))
+	for _, system := range systems {
+		requested[system.ID] = struct{}{}
+	}
+
+	bySystem = make(map[string][]database.SingletonAliasCandidate, len(systems))
+	for _, dir := range dirs {
+		// A directory with no media has nothing to collapse to, and the
+		// resolver keys its nested-media test on a non-zero count.
+		if dir.FileCount <= 0 {
+			continue
+		}
+
+		var systemID string
+		switch {
+		case len(dir.SystemIDs) == 1:
+			systemID = dir.SystemIDs[0]
+		case len(dir.SystemIDs) == 0 && len(systems) == 1:
+			// The media fallback query reports no systems at all, so a
+			// single-system request is the only thing that can attribute it.
+			systemID = systems[0].ID
+		default:
+			// Media for several systems, or none that a single-system request
+			// could attribute. Neither can be counted per system here.
+			continue
+		}
+		if len(requested) > 0 {
+			if _, ok := requested[systemID]; !ok {
+				continue
+			}
+		}
+
+		childDir := dir.Path
+		if childDir == "" {
+			childDir = filepath.ToSlash(filepath.Join(path, dir.Name))
+		}
+		if _, seen := bySystem[systemID]; !seen {
+			order = append(order, systemID)
+		}
+		bySystem[systemID] = append(bySystem[systemID], database.SingletonAliasCandidate{
+			ChildDir:  strings.TrimSuffix(filepath.ToSlash(childDir), "/") + "/",
+			FileCount: dir.FileCount,
+		})
+	}
+	return order, bySystem
+}
+
 // resolveDirSingletonAliases batch-resolves singleton container aliases for the
-// page's candidate directories when browsing a single system. Every directory
-// holding media for that system is offered to the resolver, which reads only
-// each candidate's direct rows, so the container rule alone decides what
-// collapses and browse agrees with media.meta and the scrapers on a disc folder
-// of any size.
+// page's candidate directories. Every directory holding media for exactly one
+// system is offered to that system's resolver, which reads only each
+// candidate's direct rows, so the container rule alone decides what collapses
+// and browse agrees with media.meta and the scrapers on a disc folder of any
+// size.
+//
+// An unfiltered page spanning several systems resolves nothing, which is the
+// behaviour it has always had rather than a new restriction: the system this
+// used to elect for the whole page was abandoned as soon as a second one
+// appeared. What changed is that a directory which cannot be attributed no
+// longer decides the page, only itself.
+//
+// The bound stays because of one page. Browsing a media root lists a directory
+// per installed system, each with a recursive file count in the hundreds, and
+// nothing in BrowseDirectoryResult tells that page apart from a genuine mixed
+// page of two disc folders — so grouping it freely would turn the cheapest page
+// in the API into a resolver batch per installed system. A client that wants
+// aliases across systems names the systems, which bounds the work to what it
+// asked for. Lifting the restriction means recognising a system's own launcher
+// root, which env.LauncherCache and Platform.RootDirs can both answer; with
+// those excluded the media-root page has no candidates and a mixed page becomes
+// safe to resolve per system.
 func resolveDirSingletonAliases(
 	env *requests.RequestEnv,
 	path string,
@@ -1337,74 +1419,51 @@ func resolveDirSingletonAliases(
 		return nil
 	}
 
-	// Determine which system to resolve against. Use the explicit filter if
-	// exactly one system was requested; otherwise infer from the directory
-	// entries (all dirs with media must belong to the same single system).
-	var systemID string
-	if len(systems) == 1 {
-		systemID = systems[0].ID
-	} else if len(systems) == 0 {
-		for _, dir := range dirs {
-			if len(dir.SystemIDs) == 0 {
-				continue
-			}
-			if len(dir.SystemIDs) > 1 || (systemID != "" && systemID != dir.SystemIDs[0]) {
-				systemID = ""
-				break
-			}
-			systemID = dir.SystemIDs[0]
-		}
-	}
-	if systemID == "" {
+	order, bySystem := groupSingletonAliasCandidates(path, dirs, systems)
+	if len(order) == 0 {
 		return nil
 	}
-
-	var candidates []database.SingletonAliasCandidate
-	for _, dir := range dirs {
-		// A directory with no media for this system has nothing to collapse to,
-		// and the resolver keys its nested-media test on a non-zero count.
-		if dir.FileCount <= 0 {
-			continue
-		}
-		if len(dir.SystemIDs) > 0 && (len(dir.SystemIDs) != 1 || dir.SystemIDs[0] != systemID) {
-			continue
-		}
-		childDir := dir.Path
-		if childDir == "" {
-			childDir = filepath.ToSlash(filepath.Join(path, dir.Name))
-		}
-		candidates = append(candidates, database.SingletonAliasCandidate{
-			ChildDir:  strings.TrimSuffix(filepath.ToSlash(childDir), "/") + "/",
-			FileCount: dir.FileCount,
-		})
-	}
-	if len(candidates) == 0 {
+	if len(systems) == 0 && len(order) > 1 {
+		log.Debug().Str("path", path).Int("systems", len(order)).
+			Msg("browse singleton alias resolution skipped for unfiltered multi-system page")
 		return nil
 	}
 
 	started := time.Now()
-	system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
-	if sysErr != nil {
-		log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
-		return nil
-	}
-	aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
-		env.Context, system.DBID, candidates,
-	)
-	if aliasErr != nil {
-		log.Debug().Err(aliasErr).Str("path", path).Msg("browse singleton alias batch resolution failed")
-		return nil
-	}
 	var singletonAliases map[string]database.SingletonContainerAlias
-	if len(aliases) > 0 {
-		singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
+	candidateCount := 0
+	for _, systemID := range order {
+		candidates := bySystem[systemID]
+		candidateCount += len(candidates)
+
+		system, sysErr := env.Database.MediaDB.FindSystemBySystemID(systemID)
+		if sysErr != nil {
+			log.Debug().Err(sysErr).Str("system", systemID).Msg("browse singleton alias system lookup failed")
+			continue
+		}
+		aliases, aliasErr := env.Database.MediaDB.ResolveSingletonContainerAliases(
+			env.Context, system.DBID, candidates,
+		)
+		if aliasErr != nil {
+			// One system failing leaves the rest of the page resolvable.
+			log.Debug().Err(aliasErr).Str("path", path).Str("system", systemID).
+				Msg("browse singleton alias batch resolution failed")
+			continue
+		}
+		if len(aliases) == 0 {
+			continue
+		}
+		if singletonAliases == nil {
+			singletonAliases = make(map[string]database.SingletonContainerAlias, len(aliases))
+		}
 		for i := range aliases {
 			singletonAliases[aliases[i].ChildDir] = aliases[i]
 		}
 	}
 	log.Debug().
 		Str("path", path).
-		Int("candidates", len(candidates)).
+		Int("systems", len(order)).
+		Int("candidates", candidateCount).
 		Int("aliases", len(singletonAliases)).
 		Dur("duration", time.Since(started)).
 		Msg("browse singleton alias resolution timing")

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -142,6 +142,17 @@ func mockSystemRootCandidatesNotReady(mockMediaDB *helpers.MockMediaDBI) {
 		Return(database.BrowseSystemRootCandidates{}, false, nil)
 }
 
+// stubNoSingletonAliases lets a browse test whose fixture holds directories with
+// media reach the alias resolver without asserting anything about it. Every
+// directory carrying media for the system in scope is a candidate, so a test
+// about pagination or overlays still walks this path.
+func stubNoSingletonAliases(mockMediaDB *helpers.MockMediaDBI, systemID string) {
+	mockMediaDB.On("FindSystemBySystemID", systemID).
+		Return(database.System{DBID: 1, SystemID: systemID}, nil).Maybe()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, mock.Anything, mock.Anything).
+		Return([]database.SingletonContainerAlias(nil), nil).Maybe()
+}
+
 func browseTestAbsPath(parts ...string) string {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -300,6 +311,7 @@ func TestHandleMediaBrowse_RootContentsUsesOrderedPhysicalSources(t *testing.T) 
 	})).Return([]database.SearchResultWithCursor{{
 		MediaID: 7, SystemID: "SNES", Name: "Game", Path: route2 + "/Game.sfc",
 	}}, nil)
+	stubNoSingletonAliases(mockMediaDB, "SNES")
 
 	systems := []string{"SNES"}
 	env := newBrowseEnv(t, mockMediaDB, mockPlatform, models.BrowseParams{
@@ -351,6 +363,7 @@ func TestHandleMediaBrowse_RootContentsPaginatesDirectories(t *testing.T) {
 	}, nil)
 	mockMediaDB.On("BrowseDirCount", mock.Anything, mock.Anything).Return(2, nil)
 	mockMediaDB.On("BrowseFileCount", mock.Anything, mock.Anything).Return(1, nil)
+	stubNoSingletonAliases(mockMediaDB, "SNES")
 
 	systems := []string{"SNES"}
 	maxResults := 1
@@ -412,6 +425,7 @@ func TestHandleMediaBrowse_RootContentsTransitionsFromDirectoriesToFiles(t *test
 	})).Return([]database.SearchResultWithCursor{
 		{MediaID: 9, SystemID: "SNES", Name: "Game", Path: route + "/Game.sfc"},
 	}, nil).Once()
+	stubNoSingletonAliases(mockMediaDB, "SNES")
 
 	systems := []string{"SNES"}
 	maxResults := 1
@@ -1235,12 +1249,13 @@ func TestBuildBrowseResponse_NestedOnlyDirectoryRemainsPlain(t *testing.T) {
 	mockPlatform.AssertExpectations(t)
 }
 
-func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirSkipsLookup(t *testing.T) {
+func TestBuildBrowseResponse_SingletonAnnotation_MultiSystemDirSkipsLookup(t *testing.T) {
 	t.Parallel()
 
-	// A directory above the candidate file cap (e.g. MiSTer's
-	// _Arcade/_alternatives tree) must not trigger any alias resolution —
-	// no Settings, system lookup, or resolver calls at all.
+	// MiSTer's _Arcade/_alternatives tree holds media for a dozen systems at
+	// once, which is what keeps it out of alias resolution — no Settings,
+	// system lookup, or resolver calls at all. Its size has nothing to do with
+	// it: a directory of any size collapses or not by the container rule alone.
 	systems := []systemdefs.System{{ID: "Arcade"}}
 	path := filepath.ToSlash(filepath.Join("media", "fat", "_Arcade"))
 
@@ -1253,7 +1268,11 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirSkipsLookup(t *test
 		Platform: mockPlatform,
 	}
 	result, err := buildBrowseResponse(env, path,
-		[]database.BrowseDirectoryResult{{Name: "_alternatives", FileCount: 5000, SystemIDs: []string{"Arcade"}}},
+		[]database.BrowseDirectoryResult{{
+			Name:      "_alternatives",
+			FileCount: 5000,
+			SystemIDs: []string{"Arcade", "CPS1", "CPS2", "IremM72", "SegaSystem16"},
+		}},
 		nil, defaultMaxResults, 0, 0, nil, false, systems)
 	require.NoError(t, err)
 	browseResults, ok := result.(models.BrowseResults)
@@ -1267,11 +1286,13 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirSkipsLookup(t *test
 	mockPlatform.AssertNotCalled(t, "Settings")
 }
 
-func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirExcludedFromCandidates(t *testing.T) {
+func TestBuildBrowseResponse_SingletonAnnotation_LargeDirIsOfferedToResolver(t *testing.T) {
 	t.Parallel()
 
-	// When the page mixes small candidate dirs with an oversized one, only
-	// the small dirs are passed to the resolver.
+	// A large directory is a candidate like any other. It stays a plain
+	// directory because the resolver returns no alias for it, not because
+	// browse refused to ask — that refusal is what made browse disagree with
+	// media.meta and the scrapers about the same folder.
 	nesSystem := database.System{DBID: 1, SystemID: "NES"}
 	systems := []systemdefs.System{{ID: "NES"}}
 	path := filepath.ToSlash(filepath.Join("roms", "NES"))
@@ -1296,8 +1317,12 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirExcludedFromCandida
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("Settings").Return(platforms.Settings{ZipsAsDirs: true}).Maybe()
 	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	collectionPath := filepath.ToSlash(filepath.Join(path, "Collection"))
 	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
-		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+		[]database.SingletonAliasCandidate{
+			{ChildDir: dirPath + "/", FileCount: 1},
+			{ChildDir: collectionPath + "/", FileCount: 500},
+		}).
 		Return(alias, nil).Once()
 
 	env := &requests.RequestEnv{
@@ -1319,6 +1344,71 @@ func TestBuildBrowseResponse_SingletonAnnotation_OversizedDirExcludedFromCandida
 	assert.Zero(t, browseResults.Entries[1].MediaID)
 	mockMediaDB.AssertExpectations(t)
 	mockPlatform.AssertExpectations(t)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_ManyTrackDiscFolderPromoted is
+// the case from #1378: a PSX folder holding one cue sheet and 70 bin tracks.
+// media.meta resolved it to the cue and the scrapers wrote folder-named artwork
+// to that row, while browse returned it as a plain directory because a file
+// count above 64 kept it away from the resolver.
+func TestBuildBrowseResponse_SingletonAnnotation_ManyTrackDiscFolderPromoted(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 2, SystemID: "PSX"}
+	systems := []systemdefs.System{{ID: "PSX"}}
+	path := filepath.ToSlash(filepath.Join("media", "fat", "games", "ZapDisc"))
+	dirPath := filepath.ToSlash(filepath.Join(path, "Y_ManyBins"))
+	cuePath := filepath.ToSlash(filepath.Join(dirPath, "Yankee.cue"))
+	row := database.MediaFullRow{
+		Media: database.Media{
+			DBID:      20,
+			Path:      cuePath,
+			ParentDir: dirPath + "/",
+		},
+		Title:  database.MediaTitle{DBID: 30, Name: "Yankee"},
+		System: psxSystem,
+	}
+	alias := []database.SingletonContainerAlias{{
+		ChildDir:      dirPath + "/",
+		Row:           row,
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+		HasCover:      true,
+	}}
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 71}}).
+		Return(alias, nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "Y_ManyBins", FileCount: 71, SystemIDs: []string{"PSX"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false, systems)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+
+	entry := browseResults.Entries[0]
+	assert.Equal(t, "directory", entry.Type)
+	assert.Equal(t, dirPath, entry.Path)
+	assert.Equal(t, row.DBID, entry.MediaID)
+	assert.Equal(t, "Yankee", entry.Name)
+	require.NotNil(t, entry.ZapScript)
+	assert.True(t, entry.HasCover)
+	require.NotNil(t, entry.FileCount)
+	assert.Equal(t, 71, *entry.FileCount)
+	mockMediaDB.AssertExpectations(t)
 }
 
 func TestBuildBrowseResponse_SingletonAnnotation_HasCoverPropagated(t *testing.T) {
@@ -1698,10 +1788,7 @@ func TestHandleMediaBrowse_FilesystemFiltersBySystem(t *testing.T) {
 		}, nil)
 	mockMediaDB.On("BrowseFileCount", mock.Anything, browseFileCountSystemOpts(sharedPrefix, "SNES")).
 		Return(1, nil)
-	mockMediaDB.On("FindSystemBySystemID", "SNES").
-		Return(database.System{DBID: 1, SystemID: "SNES"}, nil).Maybe()
-	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, mock.Anything, mock.Anything).
-		Return([]database.SingletonContainerAlias(nil), nil).Maybe()
+	stubNoSingletonAliases(mockMediaDB, "SNES")
 
 	path := filepath.ToSlash(sharedPath)
 	systems := []string{"SNES"}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -2954,3 +2954,123 @@ func TestBuildBrowseResponse_SingletonAnnotation_UnattributedDirsUseRequestedSys
 	assert.Equal(t, int64(22), browseResults.Entries[0].MediaID)
 	mockMediaDB.AssertExpectations(t)
 }
+
+// TestBuildBrowseResponse_SingletonAnnotation_SystemLookupErrorKeepsOthers
+// covers the other per-system failure: the system row itself cannot be read.
+// It must cost that system's directories only, not the page.
+func TestBuildBrowseResponse_SingletonAnnotation_SystemLookupErrorKeepsOthers(t *testing.T) {
+	t.Parallel()
+
+	genesisSystem := database.System{DBID: 3, SystemID: "Genesis"}
+	path := filepath.ToSlash(filepath.Join("games", "shared"))
+	genesisPath := filepath.ToSlash(filepath.Join(path, "GenGame"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").
+		Return(database.System{}, errors.New("system row unreadable")).Once()
+	mockMediaDB.On("FindSystemBySystemID", "Genesis").Return(genesisSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, genesisSystem.DBID, mock.Anything).
+		Return(aliasFor(genesisPath, genesisSystem, 21, "GenGame"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "PsxGame", FileCount: 4, SystemIDs: []string{"PSX"}},
+			{Name: "GenGame", FileCount: 1, SystemIDs: []string{"Genesis"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false,
+		[]systemdefs.System{{ID: "PSX"}, {ID: "Genesis"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	byName := map[string]models.BrowseEntry{}
+	for _, entry := range browseResults.Entries {
+		byName[entry.Name] = entry
+	}
+	assert.Zero(t, byName["PsxGame"].MediaID)
+	assert.NotZero(t, byName["GenGame"].MediaID)
+	mockMediaDB.AssertExpectations(t)
+	// The system that failed lookup must never reach the resolver.
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases",
+		mock.Anything, int64(0), mock.Anything)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_EmptyDirsAreNotCandidates: a
+// directory with no media has nothing to collapse to, and the resolver keys its
+// nested-media test on a non-zero count.
+func TestBuildBrowseResponse_SingletonAnnotation_EmptyDirsAreNotCandidates(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.ToSlash(filepath.Join("games", "ZapDisc"))
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: "Empty", FileCount: 0, SystemIDs: []string{"PSX"}}},
+		nil, defaultMaxResults, 0, 0, nil, false, []systemdefs.System{{ID: "PSX"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Zero(t, browseResults.Entries[0].MediaID)
+	mockMediaDB.AssertNotCalled(t, "FindSystemBySystemID", mock.Anything)
+	mockMediaDB.AssertNotCalled(t, "ResolveSingletonContainerAliases",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_UnrequestedSystemIsSkipped: a
+// filtered browse must never resolve a system the client did not ask for. The
+// directory queries already narrow SystemIDs, so this guards the grouping
+// itself rather than the query.
+func TestBuildBrowseResponse_SingletonAnnotation_UnrequestedSystemIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 2, SystemID: "PSX"}
+	path := filepath.ToSlash(filepath.Join("games", "shared"))
+	psxPath := filepath.ToSlash(filepath.Join(path, "PsxGame"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: psxPath + "/", FileCount: 4}}).
+		Return(aliasFor(psxPath, psxSystem, 20, "PsxGame"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "PsxGame", FileCount: 4, SystemIDs: []string{"PSX"}},
+			{Name: "SnesGame", FileCount: 1, SystemIDs: []string{"SNES"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false, []systemdefs.System{{ID: "PSX"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	byName := map[string]models.BrowseEntry{}
+	for _, entry := range browseResults.Entries {
+		byName[entry.Name] = entry
+	}
+	assert.NotZero(t, byName["PsxGame"].MediaID)
+	assert.Zero(t, byName["SnesGame"].MediaID)
+	mockMediaDB.AssertExpectations(t)
+	mockMediaDB.AssertNotCalled(t, "FindSystemBySystemID", "SNES")
+}

--- a/pkg/api/methods/media_browse_test.go
+++ b/pkg/api/methods/media_browse_test.go
@@ -1062,7 +1062,11 @@ func TestBuildBrowseResponse_SingletonAnnotation_InferredFromDirSystemIDs(t *tes
 	mockPlatform.AssertExpectations(t)
 }
 
-func TestBuildBrowseResponse_SingletonAnnotation_SkipsLookupForMixedDirSystems(t *testing.T) {
+// An unfiltered page spanning several systems resolves nothing, on purpose.
+// Browsing a media root lists one directory per installed system, each with a
+// recursive file count in the hundreds, and that page is indistinguishable here
+// from this one. A client wanting aliases across systems names the systems.
+func TestBuildBrowseResponse_SingletonAnnotation_SkipsUnfilteredMultiSystemPage(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.ToSlash(filepath.Join("roms", "shared"))
@@ -2752,4 +2756,201 @@ func TestHandleMediaBrowseCancelledIsQuiet(t *testing.T) {
 	var quietErr *models.QuietClientError
 	require.ErrorAs(t, err, &quietErr)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// aliasFor builds a resolved alias for a directory holding one media file.
+func aliasFor(dirPath string, system database.System, mediaDBID int64, name string,
+) []database.SingletonContainerAlias {
+	return []database.SingletonContainerAlias{{
+		ChildDir: dirPath + "/",
+		Row: database.MediaFullRow{
+			Media: database.Media{
+				DBID:      mediaDBID,
+				Path:      filepath.ToSlash(filepath.Join(dirPath, name+".cue")),
+				ParentDir: dirPath + "/",
+			},
+			Title:  database.MediaTitle{DBID: mediaDBID + 100, Name: name},
+			System: system,
+		},
+		Tags:          []database.TagInfo{},
+		ZapScriptTags: []database.TagInfo{},
+	}}
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_MixedDirDoesNotBlockSiblings is
+// the bug measured on the test device: a page of 14 PSX disc folders promoted
+// nothing because one folder also held a Genesis file. A directory that cannot
+// be resolved must be skipped on its own, not decide the page.
+func TestBuildBrowseResponse_SingletonAnnotation_MixedDirDoesNotBlockSiblings(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 2, SystemID: "PSX"}
+	path := filepath.ToSlash(filepath.Join("games", "ZapDisc"))
+	discPath := filepath.ToSlash(filepath.Join(path, "B_004"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: discPath + "/", FileCount: 4}}).
+		Return(aliasFor(discPath, psxSystem, 20, "B_004"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "B_004", FileCount: 4, SystemIDs: []string{"PSX"}},
+			{Name: "B_MULTI", FileCount: 5, SystemIDs: []string{"Genesis", "PSX"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false, nil)
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+
+	byName := map[string]models.BrowseEntry{}
+	for _, entry := range browseResults.Entries {
+		byName[entry.Name] = entry
+	}
+	promoted, ok := byName["B_004"]
+	require.True(t, ok)
+	assert.Equal(t, int64(20), promoted.MediaID)
+	require.NotNil(t, promoted.ZapScript)
+
+	mixed, ok := byName["B_MULTI"]
+	require.True(t, ok)
+	assert.Zero(t, mixed.MediaID)
+	assert.Nil(t, mixed.ZapScript)
+	mockMediaDB.AssertExpectations(t)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_ResolvesEachRequestedSystem pins
+// behaviour nothing covered before: a filter naming two systems resolved
+// nothing at all, because the page elected a single system or gave up.
+func TestBuildBrowseResponse_SingletonAnnotation_ResolvesEachRequestedSystem(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 2, SystemID: "PSX"}
+	genesisSystem := database.System{DBID: 3, SystemID: "Genesis"}
+	path := filepath.ToSlash(filepath.Join("games", "shared"))
+	psxPath := filepath.ToSlash(filepath.Join(path, "PsxGame"))
+	genesisPath := filepath.ToSlash(filepath.Join(path, "GenGame"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("FindSystemBySystemID", "Genesis").Return(genesisSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: psxPath + "/", FileCount: 4}}).
+		Return(aliasFor(psxPath, psxSystem, 20, "PsxGame"), nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, genesisSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: genesisPath + "/", FileCount: 1}}).
+		Return(aliasFor(genesisPath, genesisSystem, 21, "GenGame"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "PsxGame", FileCount: 4, SystemIDs: []string{"PSX"}},
+			{Name: "GenGame", FileCount: 1, SystemIDs: []string{"Genesis"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false,
+		[]systemdefs.System{{ID: "PSX"}, {ID: "Genesis"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 2)
+	for _, entry := range browseResults.Entries {
+		assert.NotZero(t, entry.MediaID, entry.Name)
+		require.NotNil(t, entry.ZapScript, entry.Name)
+	}
+	mockMediaDB.AssertExpectations(t)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_OneSystemErrorKeepsOthers: a
+// resolver failure used to blank the whole page. It now costs only its own
+// system's directories.
+func TestBuildBrowseResponse_SingletonAnnotation_OneSystemErrorKeepsOthers(t *testing.T) {
+	t.Parallel()
+
+	psxSystem := database.System{DBID: 2, SystemID: "PSX"}
+	genesisSystem := database.System{DBID: 3, SystemID: "Genesis"}
+	path := filepath.ToSlash(filepath.Join("games", "shared"))
+	genesisPath := filepath.ToSlash(filepath.Join(path, "GenGame"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "PSX").Return(psxSystem, nil).Once()
+	mockMediaDB.On("FindSystemBySystemID", "Genesis").Return(genesisSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, psxSystem.DBID, mock.Anything).
+		Return([]database.SingletonContainerAlias(nil), errors.New("database is busy")).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, genesisSystem.DBID, mock.Anything).
+		Return(aliasFor(genesisPath, genesisSystem, 21, "GenGame"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{
+			{Name: "PsxGame", FileCount: 4, SystemIDs: []string{"PSX"}},
+			{Name: "GenGame", FileCount: 1, SystemIDs: []string{"Genesis"}},
+		},
+		nil, defaultMaxResults, 0, 0, nil, false,
+		[]systemdefs.System{{ID: "PSX"}, {ID: "Genesis"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+
+	byName := map[string]models.BrowseEntry{}
+	for _, entry := range browseResults.Entries {
+		byName[entry.Name] = entry
+	}
+	assert.Zero(t, byName["PsxGame"].MediaID)
+	assert.NotZero(t, byName["GenGame"].MediaID)
+	mockMediaDB.AssertExpectations(t)
+}
+
+// TestBuildBrowseResponse_SingletonAnnotation_UnattributedDirsUseRequestedSystem
+// covers the media fallback query, which reports no systems per directory at
+// all. A single-system request is the only thing that can attribute those.
+func TestBuildBrowseResponse_SingletonAnnotation_UnattributedDirsUseRequestedSystem(t *testing.T) {
+	t.Parallel()
+
+	nesSystem := database.System{DBID: 1, SystemID: "NES"}
+	path := filepath.ToSlash(filepath.Join("roms", "NES"))
+	dirPath := filepath.ToSlash(filepath.Join(path, "Game"))
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Settings").Return(platforms.Settings{}).Maybe()
+	mockMediaDB.On("FindSystemBySystemID", "NES").Return(nesSystem, nil).Once()
+	mockMediaDB.On("ResolveSingletonContainerAliases", mock.Anything, nesSystem.DBID,
+		[]database.SingletonAliasCandidate{{ChildDir: dirPath + "/", FileCount: 1}}).
+		Return(aliasFor(dirPath, nesSystem, 22, "Game"), nil).Once()
+
+	env := &requests.RequestEnv{
+		Context:  context.Background(),
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Platform: mockPlatform,
+	}
+	result, err := buildBrowseResponse(env, path,
+		[]database.BrowseDirectoryResult{{Name: "Game", FileCount: 1}},
+		nil, defaultMaxResults, 0, 0, nil, false, []systemdefs.System{{ID: "NES"}})
+	require.NoError(t, err)
+	browseResults, ok := result.(models.BrowseResults)
+	require.True(t, ok)
+	require.Len(t, browseResults.Entries, 1)
+	assert.Equal(t, int64(22), browseResults.Entries[0].MediaID)
+	mockMediaDB.AssertExpectations(t)
 }

--- a/pkg/database/container/container.go
+++ b/pkg/database/container/container.go
@@ -94,6 +94,17 @@ func MediaExt(mediaPath string) string {
 	return ""
 }
 
+// MayHaveContainerTarget reports whether a media path could sit in a directory
+// whose launch target is a different file. Only the extensions that can
+// accompany a cue sheet or an m3u playlist qualify, so a caller holding an
+// ordinary rom can skip a container lookup entirely. The m3u companion set
+// contains the cue set, so one test covers both kinds: a .bin may be standing
+// in for a cue, and a .cue or .chd for an m3u. An .m3u itself is excluded
+// because promoting one could only return itself.
+func MayHaveContainerTarget(mediaPath string) bool {
+	return isM3UCompanionExt(MediaExt(mediaPath))
+}
+
 func isCueCompanionExt(ext string) bool {
 	switch ext {
 	case ".bin", ".wav", ".mp3", ".ogg", ".flac", ".ape":

--- a/pkg/database/container/container_test.go
+++ b/pkg/database/container/container_test.go
@@ -220,3 +220,34 @@ func TestMediaExt(t *testing.T) {
 	assert.Empty(t, container.MediaExt("/roms/PSX/Game"))
 	assert.Empty(t, container.MediaExt("/roms/my.dir/Game"))
 }
+
+func TestMayHaveContainerTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/roms/PSX/Game/Game (Track 01).bin",
+		"/roms/PSX/Game/Game (Track 01).WAV",
+		"/roms/PSX/Game/Game.mp3",
+		"/roms/PSX/Game/Game.ogg",
+		"/roms/PSX/Game/Game.flac",
+		"/roms/PSX/Game/Game.ape",
+		"/roms/PSX/Game/Game.cue",
+		"/roms/PSX/Game/Game (Disc 1).chd",
+		"/roms/PSX/Game/Game.iso",
+	} {
+		assert.True(t, container.MayHaveContainerTarget(path), path)
+	}
+
+	for _, path := range []string{
+		"/roms/NES/Mario.nes",
+		"/roms/SNES/Mario.sfc",
+		"/roms/Genesis/Sonic.md",
+		"/roms/Arcade/game.zip",
+		"/roms/PSX/Game",
+		// A playlist is already a launch target, so promoting one could only
+		// ever return itself.
+		"/roms/PSX/Game/Game.m3u",
+	} {
+		assert.False(t, container.MayHaveContainerTarget(path), path)
+	}
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1206,6 +1206,10 @@ type MediaDBI interface {
 	// direct contents of containerPath for systemDBID, or nil, nil when the
 	// container is empty, nested-only, or ambiguous.
 	FindSingleContainerLaunchMedia(ctx context.Context, systemDBID int64, containerPath string) (*Media, error)
+	// FindSingleContainerLaunchMediaBySystemID is FindSingleContainerLaunchMedia
+	// keyed by system ID, for callers that address a system by name rather than
+	// by row.
+	FindSingleContainerLaunchMediaBySystemID(ctx context.Context, systemID, containerPath string) (*Media, error)
 	// ResolveSingletonContainerAliases resolves the given candidate child
 	// directories for systemDBID in a single batch query, returning one
 	// SingletonContainerAlias per candidate that collapses to a single launch

--- a/pkg/database/mediadb/mediadb_integration_test.go
+++ b/pkg/database/mediadb/mediadb_integration_test.go
@@ -4776,3 +4776,45 @@ func TestMediaDB_BrowseFiles_UsesRankPrefixSortForNumberedCollections(t *testing
 	require.Len(t, nextPage, 1)
 	assert.Equal(t, "Contra", nextPage[0].Name)
 }
+
+// slugResolutionPurgeVersion is 20260902160000_purge_stale_slug_resolutions,
+// which retires cache entries written before title resolution learned to
+// promote a match to its container's launch target.
+const slugResolutionPurgeVersion = 20260902160000
+
+// TestMigrations_PurgesSlugResolutionsCachedBeforeContainerPromotion covers the
+// upgrade path a reindex would otherwise be needed for: a cache entry naming a
+// disc folder's companion file keeps launching that file, because a cache hit
+// returns without consulting the container rule.
+func TestMigrations_PurgesSlugResolutionsCachedBeforeContainerPromotion(t *testing.T) {
+	mediaDB, cleanup := setupTempMediaDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	require.NoError(t, mediaDB.MigrateUp())
+	sqlDB := mediaDB.UnsafeGetSQLDb()
+	goose.SetBaseFS(migrationFiles)
+	require.NoError(t, goose.SetDialect("sqlite"))
+	// Roll back to just before the purge so it can be observed running.
+	require.NoError(t, goose.DownTo(sqlDB, "migrations", slugResolutionPurgeVersion-1))
+
+	// The cache row keys a real media row, so seed the companion file a
+	// pre-promotion resolution would have landed on.
+	_, err := sqlDB.ExecContext(ctx, `
+		INSERT INTO Systems (DBID, SystemID, Name) VALUES (900, 'PSX', 'PSX');
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (900, 900, 'b064', 'B_064');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir)
+		VALUES (900, 900, 900, '/roms/PSX/B_064/B_064 (Track 001).bin', '/roms/PSX/B_064/');
+		INSERT INTO SlugResolutionCache
+			(CacheKey, SystemID, Slug, TagFilters, MediaDBID, Strategy, LastUpdated)
+		VALUES ('PSX:b064:', 'PSX', 'b064', '[]', 900, 'strategy_exact_match', 0);
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, goose.Up(sqlDB, "migrations"))
+
+	var remaining int
+	require.NoError(t, sqlDB.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM SlugResolutionCache").Scan(&remaining))
+	assert.Zero(t, remaining, "entries cached before container promotion must not survive the upgrade")
+}

--- a/pkg/database/mediadb/migrations/20260902160000_purge_stale_slug_resolutions.sql
+++ b/pkg/database/mediadb/migrations/20260902160000_purge_stale_slug_resolutions.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Title resolution now promotes a match to its directory's container launch
+-- target, so a disc folder resolves to its cue sheet or playlist rather than to
+-- whichever companion file the slug search happened to pick. Entries cached
+-- before that change still name the companion, and a cache hit returns without
+-- consulting the container rule -- deliberately, because that lookup would
+-- otherwise run on every launch of a disc image forever.
+--
+-- Clearing the cache once retires those entries without taxing the hot path.
+-- Nothing is lost: the table only memoises resolutions the pipeline can redo,
+-- and the next launch of each title repopulates it with a promoted ID.
+
+DELETE FROM SlugResolutionCache;
+
+-- +goose Down
+-- The cache rebuilds itself on use, so there is nothing to restore.
+SELECT 1;

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -191,6 +191,25 @@ func findMediaIDsByPathBatch(ctx context.Context, db sqlQueryable, paths []strin
 	return results, rows.Err()
 }
 
+// FindSingleContainerLaunchMediaBySystemID implements MediaDBI. Title
+// resolution holds a system ID rather than a system row, so it cannot call
+// FindSingleContainerLaunchMedia directly. Doing the lookup here keeps that
+// caller free of system rows entirely.
+func (db *MediaDB) FindSingleContainerLaunchMediaBySystemID(
+	ctx context.Context, systemID, containerPath string,
+) (*database.Media, error) {
+	if db.sql.Load() == nil {
+		return nil, ErrNullSQL
+	}
+
+	system, err := db.FindSystemBySystemID(systemID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to look up system %q: %w", systemID, err)
+	}
+
+	return db.FindSingleContainerLaunchMedia(ctx, system.DBID, containerPath)
+}
+
 func (db *MediaDB) FindSingleContainerLaunchMedia(
 	ctx context.Context, systemDBID int64, containerPath string,
 ) (*database.Media, error) {

--- a/pkg/database/mediadb/sql_scraper.go
+++ b/pkg/database/mediadb/sql_scraper.go
@@ -24,6 +24,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -759,6 +761,13 @@ const (
 	bulkTagInsertRowsPerStmt   = 400
 	bulkPropUpsertRowsPerStmt  = 200
 	bulkDeleteEntityIDsPerStmt = sqliteMaxParams - 1
+	// batchLookupIDsPerQuery bounds the IDs in one IN list for the shared
+	// by-ID lookups, and aliasCandidatesPerQuery the candidate directories in
+	// one ParentDir scan. A browse page size is client-supplied, so without
+	// these a page of a thousand container directories builds a single query
+	// that outlives the request budget.
+	batchLookupIDsPerQuery  = 200
+	aliasCandidatesPerQuery = 200
 )
 
 type scrapeBatchSQLStats struct {
@@ -2824,6 +2833,10 @@ func (db *MediaDB) GetMediaWithTitleAndSystem(ctx context.Context, mediaDBID int
 	return &row, nil
 }
 
+// GetMediaWithTitleAndSystemByIDs implements MediaDBI. The lookup runs in
+// batchLookupIDsPerQuery-sized chunks: one IN list holding every requested ID,
+// joined against MediaTitles and Systems, is what exceeded the browse request
+// budget on a page of a thousand container directories.
 func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 	ctx context.Context, mediaDBIDs []int64,
 ) (map[int64]database.MediaFullRow, error) {
@@ -2835,6 +2848,20 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 		return nil, ErrNullSQL
 	}
 
+	for chunk := range slices.Chunk(dedupeInt64s(mediaDBIDs), batchLookupIDsPerQuery) {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("GetMediaWithTitleAndSystemByIDs interrupted: %w", err)
+		}
+		if err := db.appendMediaFullRowsByIDs(ctx, chunk, results); err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}
+
+func (db *MediaDB) appendMediaFullRowsByIDs(
+	ctx context.Context, mediaDBIDs []int64, results map[int64]database.MediaFullRow,
+) error {
 	args := int64Args(mediaDBIDs)
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
 	rows, err := db.sql.Load().QueryContext(ctx, `
@@ -2849,7 +2876,7 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 		WHERE m.DBID IN (`+prepareVariadic("?", ",", len(mediaDBIDs))+`)
 	`, args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query GetMediaWithTitleAndSystemByIDs: %w", err)
+		return fmt.Errorf("failed to query GetMediaWithTitleAndSystemByIDs: %w", err)
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
@@ -2867,11 +2894,14 @@ func (db *MediaDB) GetMediaWithTitleAndSystemByIDs(
 			&row.Title.DisambiguationTypes,
 			&row.System.DBID, &row.System.SystemID, &row.System.Name,
 		); err != nil {
-			return nil, fmt.Errorf("failed to scan GetMediaWithTitleAndSystemByIDs: %w", err)
+			return fmt.Errorf("failed to scan GetMediaWithTitleAndSystemByIDs: %w", err)
 		}
 		results[row.DBID] = row
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to iterate GetMediaWithTitleAndSystemByIDs: %w", err)
+	}
+	return nil
 }
 
 // GetMediaTagsByMediaDBID returns the file-level tags (MediaTags) for a single
@@ -2911,6 +2941,9 @@ func (db *MediaDB) GetMediaTagsByMediaDBID(ctx context.Context, mediaDBID int64)
 	return scanTagInfos(rows)
 }
 
+// GetMediaTagsByMediaDBIDs implements MediaDBI. Like the full-row lookup it
+// queries in batchLookupIDsPerQuery-sized chunks, so a caller-sized ID list
+// cannot build one oversized IN list.
 func (db *MediaDB) GetMediaTagsByMediaDBIDs(
 	ctx context.Context, mediaDBIDs []int64,
 ) (map[int64][]database.TagInfo, error) {
@@ -2922,6 +2955,24 @@ func (db *MediaDB) GetMediaTagsByMediaDBIDs(
 		return nil, ErrNullSQL
 	}
 
+	// Chunks are disjoint because the IDs are deduplicated first, so each media
+	// row's tags are grouped by exactly one chunk and copying cannot double them.
+	for chunk := range slices.Chunk(dedupeInt64s(mediaDBIDs), batchLookupIDsPerQuery) {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("GetMediaTagsByMediaDBIDs interrupted: %w", err)
+		}
+		chunkTags, err := db.mediaTagsForIDs(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		maps.Copy(results, chunkTags)
+	}
+	return results, nil
+}
+
+func (db *MediaDB) mediaTagsForIDs(
+	ctx context.Context, mediaDBIDs []int64,
+) (map[int64][]database.TagInfo, error) {
 	args := int64Args(mediaDBIDs)
 	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders like "?, ?, ?".
 	rows, err := db.sql.Load().QueryContext(ctx, `
@@ -3280,14 +3331,76 @@ func int64Args(values []int64) []any {
 	return args
 }
 
+// dedupeInt64s drops repeated IDs, keeping first-seen order. A chunked IN query
+// needs this: one IN list returns a row once however many times its ID appears,
+// but the same ID landing in two chunks would return its rows twice.
+func dedupeInt64s(values []int64) []int64 {
+	seen := make(map[int64]struct{}, len(values))
+	out := make([]int64, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+// scanContainerDirRows appends the direct media rows of childDirs into
+// childDirRows and reports how many it read.
+func (db *MediaDB) scanContainerDirRows(
+	ctx context.Context,
+	systemDBID int64,
+	childDirs []string,
+	childDirRows map[string][]database.Media,
+) (int, error) {
+	args := make([]any, 0, 1+len(childDirs))
+	args = append(args, systemDBID)
+	for _, childDir := range childDirs {
+		args = append(args, childDir)
+	}
+
+	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
+	rows, err := db.sql.Load().QueryContext(ctx, `
+		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
+		FROM Media
+		WHERE SystemDBID = ? AND IsMissing = 0 AND ParentDir IN (`+
+		prepareVariadic("?", ",", len(childDirs))+`)`, args...)
+	if err != nil {
+		return 0, fmt.Errorf("resolve singleton aliases query: %w", err)
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			log.Warn().Err(closeErr).Msg("failed to close rows")
+		}
+	}()
+
+	scanned := 0
+	for rows.Next() {
+		var m database.Media
+		if scanErr := rows.Scan(
+			&m.DBID, &m.MediaTitleDBID, &m.SystemDBID, &m.Path, &m.ParentDir, &m.IsMissing,
+		); scanErr != nil {
+			return scanned, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
+		}
+		childDirRows[m.ParentDir] = append(childDirRows[m.ParentDir], m)
+		scanned++
+	}
+	if rowsErr := rows.Err(); rowsErr != nil {
+		return scanned, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
+	}
+	return scanned, nil
+}
+
 // ResolveSingletonContainerAliases implements MediaDBI.
-// It fetches the direct media rows of every candidate child directory in a
-// single ParentDir IN query and returns one SingletonContainerAlias per
-// candidate that collapses to a single logical launch target. Candidates whose
-// recursive FileCount exceeds their direct row count contain nested
-// subdirectories and are omitted, as are ambiguous file sets. Tags and
-// ZapScriptTags are populated via two batch queries plus in-memory
-// disambiguation — the same approach used by the search path.
+// It fetches the direct media rows of the candidate child directories in
+// aliasCandidatesPerQuery-sized ParentDir IN queries and returns one
+// SingletonContainerAlias per candidate that collapses to a single logical
+// launch target. Candidates whose recursive FileCount exceeds their direct row
+// count contain nested subdirectories and are omitted, as are ambiguous file
+// sets. Tags and ZapScriptTags are populated via two batch queries plus
+// in-memory disambiguation — the same approach used by the search path.
 func (db *MediaDB) ResolveSingletonContainerAliases(
 	ctx context.Context,
 	systemDBID int64,
@@ -3303,10 +3416,11 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 	// Per-step timing, emitted once at debug level so the on-device breakdown of
 	// a slow resolution is visible without changing behaviour.
 	var inScanDur, fullRowsDur, tagsDur, zapDur, coverDur time.Duration
-	var inScanRows int
+	var inScanRows, inScanChunks int
 	defer func() {
 		log.Debug().
 			Int("candidates", len(dirCandidates)).
+			Int("inScanChunks", inScanChunks).
 			Int("inScanRows", inScanRows).
 			Dur("inScanDuration", inScanDur).
 			Dur("fullRowsDuration", fullRowsDur).
@@ -3316,49 +3430,37 @@ func (db *MediaDB) ResolveSingletonContainerAliases(
 			Msg("resolve singleton aliases step timing")
 	}()
 
+	// Repeated candidates collapse to one entry so a directory's rows are never
+	// scanned by two chunks and appended twice.
 	expectedCounts := make(map[string]int, len(dirCandidates))
-	args := make([]any, 0, 1+len(dirCandidates))
-	args = append(args, systemDBID)
+	childDirs := make([]string, 0, len(dirCandidates))
 	for _, c := range dirCandidates {
 		childDir := c.ChildDir
 		if !strings.HasSuffix(childDir, "/") {
 			childDir += "/"
 		}
+		if _, seen := expectedCounts[childDir]; !seen {
+			childDirs = append(childDirs, childDir)
+		}
 		expectedCounts[childDir] = c.FileCount
-		args = append(args, childDir)
 	}
 
-	// One query for the direct media rows of all candidate dirs, served by
-	// idx_media_parentdir_system.
+	// The direct media rows of the candidate dirs, served by
+	// idx_media_parentdir_system. The scan is chunked because a browse page size
+	// is client-supplied: one IN list per page put a thousand seeks in a single
+	// query and left no budget for the lookups that follow it.
+	childDirRows := make(map[string][]database.Media, len(childDirs))
 	inScanStart := time.Now()
-	//nolint:gosec // Safe: prepareVariadic only generates SQL placeholders.
-	rows, err := db.sql.Load().QueryContext(ctx, `
-		SELECT DBID, MediaTitleDBID, SystemDBID, Path, ParentDir, IsMissing
-		FROM Media
-		WHERE SystemDBID = ? AND IsMissing = 0 AND ParentDir IN (`+
-		prepareVariadic("?", ",", len(dirCandidates))+`)`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("resolve singleton aliases query: %w", err)
-	}
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil {
-			log.Warn().Err(closeErr).Msg("failed to close rows")
+	for chunk := range slices.Chunk(childDirs, aliasCandidatesPerQuery) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("resolve singleton aliases interrupted: %w", ctxErr)
 		}
-	}()
-
-	childDirRows := make(map[string][]database.Media, len(dirCandidates))
-	for rows.Next() {
-		var m database.Media
-		if scanErr := rows.Scan(
-			&m.DBID, &m.MediaTitleDBID, &m.SystemDBID, &m.Path, &m.ParentDir, &m.IsMissing,
-		); scanErr != nil {
-			return nil, fmt.Errorf("resolve singleton aliases scan: %w", scanErr)
+		chunkRows, scanErr := db.scanContainerDirRows(ctx, systemDBID, chunk, childDirRows)
+		if scanErr != nil {
+			return nil, scanErr
 		}
-		childDirRows[m.ParentDir] = append(childDirRows[m.ParentDir], m)
-		inScanRows++
-	}
-	if rowsErr := rows.Err(); rowsErr != nil {
-		return nil, fmt.Errorf("resolve singleton aliases rows: %w", rowsErr)
+		inScanRows += chunkRows
+		inScanChunks++
 	}
 	inScanDur = time.Since(inScanStart)
 

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -2970,3 +2970,103 @@ func TestManyTrackDiscFolderResolvesTheSameBothWays(t *testing.T) {
 	assert.Equal(t, cuePath, launch.Path, "browse and media.meta must name the same launch media")
 	assert.Equal(t, aliases[0].Row.DBID, launch.DBID)
 }
+
+// TestFindSingleContainerLaunchMediaBySystemID covers the lookup title
+// resolution uses. It holds a system ID rather than a system row, and going
+// through the database is what lets it see a container's launch target even
+// when the slug search that produced the match never returned it.
+func TestFindSingleContainerLaunchMediaBySystemID(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := aliasTestDir(parent, "B_064")
+	cuePath := filepath.ToSlash(filepath.Join(parent, "B_064", "B_064.cue"))
+	trackPath := filepath.ToSlash(filepath.Join(parent, "B_064", "B_064 (Track 001).bin"))
+
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'b064', 'B_064');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 1, 2, ?, ?);
+	`, cuePath, gameDir, trackPath, gameDir)
+	require.NoError(t, err)
+
+	launch, err := mediaDB.FindSingleContainerLaunchMediaBySystemID(ctx, "PSX", gameDir)
+	require.NoError(t, err)
+	require.NotNil(t, launch)
+	assert.Equal(t, cuePath, launch.Path, "the cue sheet stands in for its tracks")
+
+	// The same directory under another system holds none of those rows.
+	other, err := mediaDB.FindSingleContainerLaunchMediaBySystemID(ctx, "NES", gameDir)
+	require.NoError(t, err)
+	assert.Nil(t, other)
+}
+
+// TestFindSingleContainerLaunchMediaBySystemID_UnknownSystemErrors keeps an
+// unresolvable system a reported error rather than a silent "no container",
+// which the caller would treat as "nothing to promote".
+func TestFindSingleContainerLaunchMediaBySystemID_UnknownSystemErrors(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+
+	launch, err := mediaDB.FindSingleContainerLaunchMediaBySystemID(
+		context.Background(), "NotASystem", "roms/NotASystem/Game/")
+	require.Error(t, err)
+	assert.Nil(t, launch)
+}
+
+// TestResolveSingletonContainerAliases_AmbiguousDirIsNotAliased covers the
+// resolver's other exclusion. A count match only proves the directory has no
+// nested media; two cue sheets are still two games and must stay browseable.
+func TestResolveSingletonContainerAliases_AmbiguousDirIsNotAliased(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := aliasTestDir(parent, "TwoGames")
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'one', 'One');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES
+			(1, 1, 2, ?, ?),
+			(2, 1, 2, ?, ?);
+	`,
+		filepath.ToSlash(filepath.Join(parent, "TwoGames", "One.cue")), gameDir,
+		filepath.ToSlash(filepath.Join(parent, "TwoGames", "Two.cue")), gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2,
+		[]database.SingletonAliasCandidate{{ChildDir: gameDir, FileCount: 2}})
+	require.NoError(t, err)
+	assert.Empty(t, aliases, "two cue sheets do not collapse to one launch target")
+}
+
+// TestResolveSingletonContainerAliases_CandidateWithoutTrailingSlash checks the
+// normalisation the ChildDir contract relies on: ParentDir is stored with a
+// trailing slash, so a candidate lacking one must still match its rows.
+func TestResolveSingletonContainerAliases_CandidateWithoutTrailingSlash(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := aliasTestDir(parent, "Solo")
+	mediaPath := filepath.ToSlash(filepath.Join(parent, "Solo", "Solo.chd"))
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'solo', 'Solo');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+	`, mediaPath, gameDir)
+	require.NoError(t, err)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2,
+		[]database.SingletonAliasCandidate{{ChildDir: strings.TrimSuffix(gameDir, "/"), FileCount: 1}})
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, mediaPath, aliases[0].Row.Path)
+}

--- a/pkg/database/mediadb/sql_scraper_test.go
+++ b/pkg/database/mediadb/sql_scraper_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
@@ -2751,4 +2752,221 @@ func TestGetMediaTagsByMediaRefs_ChunksBeyondSQLiteParamLimit(t *testing.T) {
 		{Tag: "alpha", Type: "scraper.test", Label: "Alpha"},
 	}, got[3])
 	assert.Len(t, got, 2)
+}
+
+// seedSingleFileContainerDirs inserts count directories under parent, each
+// holding one media file, and returns their candidate list in insertion order.
+func seedSingleFileContainerDirs(
+	t *testing.T, mediaDB *MediaDB, parent string, count int,
+) []database.SingletonAliasCandidate {
+	t.Helper()
+	ctx := context.Background()
+	candidates := make([]database.SingletonAliasCandidate, 0, count)
+	tx, err := mediaDB.sql.Load().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	for i := range count {
+		id := int64(i + 1)
+		name := fmt.Sprintf("Game%04d", i)
+		dir := aliasTestDir(parent, name)
+		path := filepath.ToSlash(filepath.Join(parent, name, name+".chd"))
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 2, ?, ?);
+		`, id, fmt.Sprintf("game%04d", i), name)
+		require.NoError(t, err)
+		_, err = tx.ExecContext(ctx, `
+			INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (?, ?, 2, ?, ?);
+		`, id, id, path, dir)
+		require.NoError(t, err)
+		candidates = append(candidates, database.SingletonAliasCandidate{ChildDir: dir, FileCount: 1})
+	}
+	require.NoError(t, tx.Commit())
+	return candidates
+}
+
+// TestResolveSingletonContainerAliases_ChunkBoundaries walks the candidate count
+// across the chunk size so an off-by-one in the chunk loop cannot pass: a
+// browse page size is client-supplied and routinely lands either side of it.
+func TestResolveSingletonContainerAliases_ChunkBoundaries(t *testing.T) {
+	t.Parallel()
+
+	for _, count := range []int{
+		aliasCandidatesPerQuery - 1,
+		aliasCandidatesPerQuery,
+		aliasCandidatesPerQuery + 1,
+		aliasCandidatesPerQuery*2 + 1,
+	} {
+		t.Run(fmt.Sprintf("%d candidates", count), func(t *testing.T) {
+			t.Parallel()
+			mediaDB, cleanup := setupAliasTestDB(t)
+			defer cleanup()
+
+			parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+			candidates := seedSingleFileContainerDirs(t, mediaDB, parent, count)
+
+			aliases, err := mediaDB.ResolveSingletonContainerAliases(context.Background(), 2, candidates)
+			require.NoError(t, err)
+			require.Len(t, aliases, count)
+
+			byDir := make(map[string]database.SingletonContainerAlias, count)
+			for _, a := range aliases {
+				byDir[a.ChildDir] = a
+			}
+			for _, c := range candidates {
+				alias, ok := byDir[c.ChildDir]
+				require.True(t, ok, "missing alias for %s", c.ChildDir)
+				assert.Equal(t, c.ChildDir, alias.Row.ParentDir)
+			}
+		})
+	}
+}
+
+// TestResolveSingletonContainerAliases_DuplicateCandidatesResolveOnce guards the
+// chunked scan. The repeat is placed far enough down the list to land in a
+// later chunk than the original: within one chunk the IN list returns the rows
+// once regardless, but two chunks would each read them and append, making a
+// one-file container look like a two-file one and stop it collapsing.
+func TestResolveSingletonContainerAliases_DuplicateCandidatesResolveOnce(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	candidates := seedSingleFileContainerDirs(t, mediaDB, parent, aliasCandidatesPerQuery+1)
+	first := candidates[0]
+	candidates = append(candidates, first)
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(context.Background(), 2, candidates)
+	require.NoError(t, err)
+	require.Len(t, aliases, aliasCandidatesPerQuery+1)
+
+	byDir := make(map[string]database.SingletonContainerAlias, len(aliases))
+	for _, a := range aliases {
+		byDir[a.ChildDir] = a
+	}
+	alias, ok := byDir[first.ChildDir]
+	require.True(t, ok, "the repeated dir must still resolve")
+	assert.Equal(t, first.ChildDir, alias.Row.ParentDir)
+}
+
+func TestResolveSingletonContainerAliases_CancelledContextFails(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	candidates := seedSingleFileContainerDirs(t, mediaDB, parent, aliasCandidatesPerQuery+1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, candidates)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, aliases)
+}
+
+// TestGetMediaWithTitleAndSystemByIDs_ChunksLargeIDLists covers the query that
+// exceeded the browse request budget on a page of container directories: every
+// requested ID must come back however many chunks it takes.
+func TestGetMediaWithTitleAndSystemByIDs_ChunksLargeIDLists(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	count := batchLookupIDsPerQuery*2 + 1
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	seedSingleFileContainerDirs(t, mediaDB, parent, count)
+
+	ids := make([]int64, 0, count)
+	for i := range count {
+		ids = append(ids, int64(i+1))
+	}
+
+	rows, err := mediaDB.GetMediaWithTitleAndSystemByIDs(ctx, ids)
+	require.NoError(t, err)
+	require.Len(t, rows, count)
+	for _, id := range ids {
+		row, ok := rows[id]
+		require.True(t, ok, "missing row for media %d", id)
+		assert.Equal(t, "PSX", row.System.SystemID)
+	}
+}
+
+// TestGetMediaTagsByMediaDBIDs_ChunksAndDeduplicates proves the chunked lookup
+// returns every media's tags exactly once, including when the caller repeats an
+// ID in a later chunk. The media.meta callers build their ID lists from request
+// input, so a repeat is reachable from the wire.
+func TestGetMediaTagsByMediaDBIDs_ChunksAndDeduplicates(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	count := batchLookupIDsPerQuery*2 + 1
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	seedSingleFileContainerDirs(t, mediaDB, parent, count)
+
+	ids := make([]int64, 0, count+1)
+	for i := range count {
+		id := int64(i + 1)
+		ids = append(ids, id)
+		_, err := mediaDB.sql.Load().ExecContext(ctx,
+			`INSERT INTO MediaTags (MediaDBID, TagDBID) VALUES (?, 10)`, id)
+		require.NoError(t, err)
+	}
+	// The first ID again, landing in a different chunk from its own.
+	ids = append(ids, 1)
+
+	tagsByID, err := mediaDB.GetMediaTagsByMediaDBIDs(ctx, ids)
+	require.NoError(t, err)
+	require.Len(t, tagsByID, count)
+	assert.Len(t, tagsByID[1], 1, "a repeated ID must not double its tags")
+	assert.Len(t, tagsByID[int64(count)], 1)
+}
+
+// TestManyTrackDiscFolderResolvesTheSameBothWays is #1378: a disc folder of one
+// cue sheet and 70 bin tracks. media.meta resolved it through
+// FindSingleContainerLaunchMedia and the scrapers through container.Index, while
+// browse's batch resolver was never asked because of a file-count cap. Both
+// paths must now name the same launch media.
+func TestManyTrackDiscFolderResolvesTheSameBothWays(t *testing.T) {
+	t.Parallel()
+	mediaDB, cleanup := setupAliasTestDB(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const trackCount = 70
+	parent := filepath.ToSlash(filepath.Join("roms", "PSX"))
+	gameDir := aliasTestDir(parent, "Y_ManyBins")
+	cuePath := filepath.ToSlash(filepath.Join(parent, "Y_ManyBins", "Yankee.cue"))
+
+	_, err := mediaDB.sql.Load().ExecContext(ctx, `
+		INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (1, 2, 'yankee', 'Yankee');
+		INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (1, 1, 2, ?, ?);
+	`, cuePath, gameDir)
+	require.NoError(t, err)
+
+	for i := range trackCount {
+		id := int64(i + 2)
+		name := fmt.Sprintf("Yankee (Track %02d).bin", i+1)
+		_, err = mediaDB.sql.Load().ExecContext(ctx, `
+			INSERT INTO MediaTitles (DBID, SystemDBID, Slug, Name) VALUES (?, 2, ?, ?);
+			INSERT INTO Media (DBID, MediaTitleDBID, SystemDBID, Path, ParentDir) VALUES (?, ?, 2, ?, ?);
+		`, id, fmt.Sprintf("yankee-track-%02d", i+1), name,
+			id, id, filepath.ToSlash(filepath.Join(parent, "Y_ManyBins", name)), gameDir)
+		require.NoError(t, err)
+	}
+
+	aliases, err := mediaDB.ResolveSingletonContainerAliases(ctx, 2, []database.SingletonAliasCandidate{
+		{ChildDir: gameDir, FileCount: trackCount + 1},
+	})
+	require.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, cuePath, aliases[0].Row.Path)
+
+	launch, err := mediaDB.FindSingleContainerLaunchMedia(ctx, 2, strings.TrimSuffix(gameDir, "/"))
+	require.NoError(t, err)
+	require.NotNil(t, launch)
+	assert.Equal(t, cuePath, launch.Path, "browse and media.meta must name the same launch media")
+	assert.Equal(t, aliases[0].Row.DBID, launch.DBID)
 }

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -3292,6 +3292,22 @@ func TestProcessCompanionEntries_ThrottlesBatchProgress(t *testing.T) {
 	})
 }
 
+const (
+	// companionPauseObservationWindow is how long the worker is watched for
+	// while paused. It only has to be long enough for the goroutine to reach
+	// Pauser.Wait, and a slow machine makes the assertion safer rather than
+	// flakier, because the thing being proven is that nothing happens.
+	companionPauseObservationWindow = 150 * time.Millisecond
+	// companionResumeBudget bounds the wait for the worker to finish once it is
+	// resumed. It is deliberately far larger than the work needs: the property
+	// under test is that Resume unblocks the loop at all, and a budget tight
+	// enough to also measure how fast two children are written turns scheduling
+	// latency into a test failure. At 2s this failed on a loaded machine with
+	// the pauser behaving correctly. The bound exists only so a worker that
+	// never resumes fails instead of hanging the suite.
+	companionResumeBudget = 60 * time.Second
+)
+
 func TestProcessCompanionEntries_HonorsPauseBetweenChildren(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -3322,7 +3338,7 @@ func TestProcessCompanionEntries_HonorsPauseBetweenChildren(t *testing.T) {
 	select {
 	case <-done:
 		require.FailNow(t, "processCompanionEntries did not block on a paused pauser before processing children")
-	case <-time.After(150 * time.Millisecond):
+	case <-time.After(companionPauseObservationWindow):
 	}
 	require.Empty(t, mockDB.batches, "companion writes must not run while indexing is paused")
 
@@ -3331,7 +3347,7 @@ func TestProcessCompanionEntries_HonorsPauseBetweenChildren(t *testing.T) {
 	select {
 	case stats := <-done:
 		assertCompanionCounts(t, &stats, 2, 2, 0)
-	case <-time.After(2 * time.Second):
+	case <-time.After(companionResumeBudget):
 		require.FailNow(t, "processCompanionEntries did not resume after pauser.Resume()")
 	}
 	require.Len(t, mockDB.batches, 1)

--- a/pkg/testing/helpers/db_mocks.go
+++ b/pkg/testing/helpers/db_mocks.go
@@ -3045,6 +3045,19 @@ func (m *MockMediaDBI) FindMediaIDsByPaths(
 	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
 }
 
+func (m *MockMediaDBI) FindSingleContainerLaunchMediaBySystemID(
+	ctx context.Context, systemID, containerPath string,
+) (*database.Media, error) {
+	if !m.hasExpectedCall("FindSingleContainerLaunchMediaBySystemID") {
+		return nil, nil //nolint:nilnil // default mock behavior for tests that do not exercise aliasing
+	}
+	args := m.Called(ctx, systemID, containerPath)
+	if result, ok := args.Get(0).(*database.Media); ok {
+		return result, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+	}
+	return nil, args.Error(1) //nolint:wrapcheck // mock passes testify errors through unwrapped by design
+}
+
 func (m *MockMediaDBI) FindSingleContainerLaunchMedia(
 	ctx context.Context, systemDBID int64, containerPath string,
 ) (*database.Media, error) {

--- a/pkg/zapscript/launch_title_test.go
+++ b/pkg/zapscript/launch_title_test.go
@@ -1968,3 +1968,51 @@ func TestCmdTitlePerformance(t *testing.T) {
 		mockPlatform.AssertExpectations(t)
 	})
 }
+
+// TestCmdTitleLaunchesContainerCueForTruncatedDiscFolder is the reported symptom
+// end to end. Every file in a disc folder shares one MediaTitle and the slug
+// search is capped, so the only candidate here is a bin track — exactly what the
+// device returned when @PSX/B_064 booted "B_064 (Track 001).bin". The launcher
+// must still be handed the cue sheet.
+func TestCmdTitleLaunchesContainerCueForTruncatedDiscFolder(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	mockPlatform := newMockPlatformWithLaunchers()
+
+	discDir := "/games/PSX/B_064/"
+	trackPath := discDir + "B_064 (Track 001).bin"
+	cuePath := discDir + "B_064.cue"
+
+	mockMediaDB.On("GetCachedSlugResolution", mock.Anything, "PSX", mock.Anything, []zapscript.TagFilter(nil)).
+		Return(int64(0), "", false)
+	mockMediaDB.On("SearchMediaBySlug", mock.Anything, "PSX", mock.Anything, []zapscript.TagFilter(nil)).
+		Return([]database.SearchResultWithCursor{{
+			SystemID: "PSX", Name: "B_064", Path: trackPath, MediaID: 7,
+		}}, nil)
+	mockMediaDB.On("FindSingleContainerLaunchMediaBySystemID", mock.Anything, "PSX", discDir).
+		Return(&database.Media{DBID: 99, Path: cuePath}, nil)
+	mockMediaDB.On("GetMediaByDBID", mock.Anything, int64(99)).
+		Return(database.SearchResultWithCursor{
+			SystemID: "PSX", Name: "B_064", Path: cuePath, MediaID: 99,
+		}, nil)
+	mockMediaDB.On("SetCachedSlugResolution", mock.Anything, "PSX", mock.Anything, []zapscript.TagFilter(nil),
+		mock.AnythingOfType("int64"), mock.AnythingOfType("string")).Return(nil).Maybe()
+	mockMediaDB.On("GetMediaPropertyMetadata", mock.Anything, mock.AnythingOfType("int64")).
+		Return([]database.MediaProperty{}, nil).Maybe()
+	mockPlatform.On("LaunchMedia", mock.Anything, cuePath, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil)
+
+	result, err := cmdTitle(mockPlatform, platforms.CmdEnv{
+		Playlist: playlists.PlaylistController{},
+		Cfg:      &config.Instance{},
+		Database: &database.Database{MediaDB: mockMediaDB},
+		Cmd:      zapscript.Command{Name: "launch.title", Args: []string{"PSX/B_064"}},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, result.MediaChanged)
+	mockPlatform.AssertExpectations(t)
+	mockPlatform.AssertNotCalled(t, "LaunchMedia",
+		mock.Anything, trackPath, mock.Anything, mock.Anything, mock.Anything)
+}

--- a/pkg/zapscript/titles/container_promotion_test.go
+++ b/pkg/zapscript/titles/container_promotion_test.go
@@ -527,6 +527,11 @@ func TestResolveTitle_PromotedRowUnreadableKeepsSelection(t *testing.T) {
 	require.NotNil(t, result)
 	assert.Equal(t, discTrackPath, result.Result.Path)
 	assert.Equal(t, int64(7), result.Result.MediaID)
+	// Keeping the selection is also what happens when promotion never runs, so
+	// pin that it did run and failed at the re-read.
+	mockMediaDB.AssertCalled(t, "FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, "PSX", discDir)
+	mockMediaDB.AssertCalled(t, "GetMediaByDBID", mock.Anything, int64(99))
 }
 
 // TestResolveTitle_KeepsSelectionWhenDirectoryIsNotAContainer is the ordinary
@@ -564,6 +569,10 @@ func TestResolveTitle_KeepsSelectionWhenDirectoryIsNotAContainer(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, flatPath, result.Result.Path)
+	// The point of the case is that a .chd passes the gate and the lookup finds
+	// no container, not that the gate skipped it.
+	mockMediaDB.AssertCalled(t, "FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, "PSX", "/roms/PSX/")
 	mockMediaDB.AssertNotCalled(t, "GetMediaByDBID", mock.Anything, mock.Anything)
 }
 
@@ -600,5 +609,9 @@ func TestResolveTitle_KeepsSelectionWhenAlreadyTheContainerTarget(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, discCuePath, result.Result.Path)
+	// The lookup must run and name the row already selected; skipping it
+	// entirely would look identical from the result alone.
+	mockMediaDB.AssertCalled(t, "FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, "PSX", discDir)
 	mockMediaDB.AssertNotCalled(t, "GetMediaByDBID", mock.Anything, mock.Anything)
 }

--- a/pkg/zapscript/titles/container_promotion_test.go
+++ b/pkg/zapscript/titles/container_promotion_test.go
@@ -1,0 +1,397 @@
+// Zaparoo Core
+// Copyright (c) 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Zaparoo Core.
+//
+// Zaparoo Core is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Zaparoo Core is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Zaparoo Core.  If not, see <http://www.gnu.org/licenses/>.
+
+package titles
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/go-zapscript"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	discDir       = "/roms/PSX/B_064/"
+	discTrackPath = "/roms/PSX/B_064/B_064 (Track 001).bin"
+	discCuePath   = "/roms/PSX/B_064/B_064.cue"
+)
+
+// setupContainerPromotion points the container lookup for discDir at a launch
+// target and lets GetMediaByDBID return that target's row.
+func setupContainerPromotion(
+	m *helpers.MockMediaDBI, launchMediaID int64, launchPath string, launchTags []database.TagInfo,
+) {
+	m.On("FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, mock.Anything, discDir,
+	).Return(&database.Media{DBID: launchMediaID, Path: launchPath}, nil)
+	m.On("GetMediaByDBID", mock.Anything, launchMediaID).
+		Return(database.SearchResultWithCursor{
+			SystemID: "PSX",
+			Name:     "B_064",
+			Path:     launchPath,
+			MediaID:  launchMediaID,
+			Tags:     launchTags,
+		}, nil)
+}
+
+func newPromotionTestConfig(t *testing.T) *config.Instance {
+	t.Helper()
+	cfg, err := helpers.NewTestConfig(nil, t.TempDir())
+	require.NoError(t, err)
+	return cfg
+}
+
+// TestResolveTitle_PromotesTrackToContainerCue is the shape from the device:
+// the slug search is capped at 50 rows and every file in a disc folder shares
+// one title, so the cue sheet is not among the candidates at all. Selection can
+// only return a track; the container lookup is what reaches the cue.
+func TestResolveTitle_PromotesTrackToContainerCue(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discTrackPath,
+		MediaID:  7,
+	}}, nil)
+	setupContainerPromotion(mockMediaDB, 99, discCuePath, nil)
+	cacheWritten := setupCacheWriteSync(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discCuePath, result.Result.Path)
+	assert.Equal(t, int64(99), result.Result.MediaID)
+
+	select {
+	case <-cacheWritten:
+	case <-time.After(time.Second):
+		t.Fatal("cache write goroutine did not complete in time")
+	}
+	// The promoted ID must be what gets cached, or the next launch of this
+	// title replays the wrong pick straight out of the cache.
+	mockMediaDB.AssertCalled(t, "SetCachedSlugResolution",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything, int64(99), mock.Anything)
+}
+
+// TestResolveTitle_PromotesDiscToPlaylist covers the multi-disc layout that ES-DE
+// platforms index with stock launchers: a .chd is a companion of an .m3u, so a
+// disc image must still reach the playlist that stands for the whole set.
+func TestResolveTitle_PromotesDiscToPlaylist(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discDir + "B_064 (Disc 001).chd",
+		MediaID:  7,
+	}}, nil)
+	setupContainerPromotion(mockMediaDB, 42, discDir+"B_064.m3u", nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discDir+"B_064.m3u", result.Result.Path)
+}
+
+// TestResolveTitle_PromotesCueToPlaylist proves a .cue is inside the gate: it is
+// a container target for its own tracks but a companion of an enclosing .m3u.
+func TestResolveTitle_PromotesCueToPlaylist(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discCuePath,
+		MediaID:  7,
+	}}, nil)
+	setupContainerPromotion(mockMediaDB, 42, discDir+"B_064.m3u", nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discDir+"B_064.m3u", result.Result.Path)
+}
+
+// TestResolveTitle_SkipsContainerLookupForPlainRom pins the cost gate: an
+// ordinary rom can never be standing in for a container, so launching one must
+// not add a database round trip.
+func TestResolveTitle_SkipsContainerLookupForPlainRom(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	romPath := "/roms/NES/Mario/Mario.nes"
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "NES",
+		Name:     "Mario",
+		Path:     romPath,
+		MediaID:  3,
+	}}, nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "NES",
+		GameName:  "Mario",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, romPath, result.Result.Path)
+	mockMediaDB.AssertNotCalled(t, "FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestResolveTitle_KeepsRequestedDiscOverPlaylist guards the one case where
+// promotion is wrong: a query naming a disc must get that disc, not the playlist
+// that stands for every disc.
+func TestResolveTitle_KeepsRequestedDiscOverPlaylist(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	discPath := discDir + "B_064 (Disc 2).chd"
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discPath,
+		MediaID:  7,
+		Tags:     []database.TagInfo{{Type: "disc", Tag: "2"}},
+	}}, nil)
+	// The playlist carries no disc tag, which is exactly what makes it the
+	// wrong answer to a query that named one.
+	setupContainerPromotion(mockMediaDB, 42, discDir+"B_064.m3u", nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:       "PSX",
+		GameName:       "B_064",
+		AdditionalTags: []zapscript.TagFilter{{Type: "disc", Value: "2", Operator: zapscript.TagOperatorAND}},
+		MediaDB:        mockMediaDB,
+		Cfg:            cfg,
+		MediaType:      slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discPath, result.Result.Path)
+}
+
+// TestResolveTitle_PromotesWhenBothRowsCarryRequestedTag is the other half of
+// the guard: a tag both rows share was never what distinguished them, so it must
+// not block promotion.
+func TestResolveTitle_PromotesWhenBothRowsCarryRequestedTag(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	usa := []database.TagInfo{{Type: "region", Tag: "us"}}
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discTrackPath,
+		MediaID:  7,
+		Tags:     usa,
+	}}, nil)
+	setupContainerPromotion(mockMediaDB, 99, discCuePath, usa)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:       "PSX",
+		GameName:       "B_064",
+		AdditionalTags: []zapscript.TagFilter{{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND}},
+		MediaDB:        mockMediaDB,
+		Cfg:            cfg,
+		MediaType:      slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discCuePath, result.Result.Path)
+}
+
+// TestResolveTitle_ContainerLookupErrorKeepsSelection: a container lookup exists
+// to launch the better file, never to fail a launch that would otherwise work.
+func TestResolveTitle_ContainerLookupErrorKeepsSelection(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discTrackPath,
+		MediaID:  7,
+	}}, nil)
+	mockMediaDB.On("FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, mock.Anything, discDir,
+	).Return((*database.Media)(nil), errors.New("database is busy"))
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discTrackPath, result.Result.Path)
+}
+
+// TestResolveTitle_PromotesAtLowerConfidenceExit pins the second call site.
+// A row with no tags scores 0.65 against a tag filter, below the early-return
+// threshold, so this resolution leaves through the final block instead.
+func TestResolveTitle_PromotesAtLowerConfidenceExit(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discTrackPath,
+		MediaID:  7,
+	}}, nil)
+	setupContainerPromotion(mockMediaDB, 99, discCuePath, nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:       "PSX",
+		GameName:       "B_064",
+		AdditionalTags: []zapscript.TagFilter{{Type: "region", Value: "us", Operator: zapscript.TagOperatorAND}},
+		MediaDB:        mockMediaDB,
+		Cfg:            cfg,
+		MediaType:      slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Less(t, result.Confidence, ConfidenceHigh)
+	assert.Equal(t, discCuePath, result.Result.Path)
+}
+
+// TestResolveTitle_CacheHitSkipsContainerLookup: the cached ID was already
+// promoted when it was written, so the cache path must not pay for it again.
+func TestResolveTitle_CacheHitSkipsContainerLookup(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	mockMediaDB.On("GetCachedSlugResolution",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return(int64(99), StrategyExactMatch, true)
+	mockMediaDB.On("GetMediaByDBID", mock.Anything, int64(99)).
+		Return(database.SearchResultWithCursor{
+			SystemID: "PSX",
+			Name:     "B_064",
+			Path:     discCuePath,
+			MediaID:  99,
+		}, nil)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discCuePath, result.Result.Path)
+	mockMediaDB.AssertNotCalled(t, "FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, mock.Anything, mock.Anything)
+}

--- a/pkg/zapscript/titles/container_promotion_test.go
+++ b/pkg/zapscript/titles/container_promotion_test.go
@@ -395,3 +395,210 @@ func TestResolveTitle_CacheHitSkipsContainerLookup(t *testing.T) {
 	mockMediaDB.AssertNotCalled(t, "FindSingleContainerLaunchMediaBySystemID",
 		mock.Anything, mock.Anything, mock.Anything)
 }
+
+// TestPromotionLosesRequestedTag covers the guard that decides when a container
+// promotion would throw away something the query asked for. Each operator has
+// its own notion of "satisfied", and getting any of them wrong either launches
+// the wrong file or refuses a promotion that was correct.
+func TestPromotionLosesRequestedTag(t *testing.T) {
+	t.Parallel()
+
+	tag := func(typ, value string) database.TagInfo {
+		return database.TagInfo{Type: typ, Tag: value}
+	}
+	filter := func(typ, value string, op zapscript.TagOperator) zapscript.TagFilter {
+		return zapscript.TagFilter{Type: typ, Value: value, Operator: op}
+	}
+
+	tests := []struct {
+		name     string
+		selected []database.TagInfo
+		promoted []database.TagInfo
+		filters  []zapscript.TagFilter
+		want     bool
+	}{
+		{
+			name: "no filters never blocks promotion",
+			want: false,
+		},
+		{
+			name:     "AND: playlist lacks the disc the query named",
+			selected: []database.TagInfo{tag("disc", "2")},
+			filters:  []zapscript.TagFilter{filter("disc", "2", zapscript.TagOperatorAND)},
+			want:     true,
+		},
+		{
+			name:     "AND: a tag both rows carry was never the distinction",
+			selected: []database.TagInfo{tag("region", "us")},
+			promoted: []database.TagInfo{tag("region", "us")},
+			filters:  []zapscript.TagFilter{filter("region", "us", zapscript.TagOperatorAND)},
+			want:     false,
+		},
+		{
+			name:    "AND: a tag neither row carries is not lost by promoting",
+			filters: []zapscript.TagFilter{filter("region", "us", zapscript.TagOperatorAND)},
+			want:    false,
+		},
+		{
+			name:     "NOT: promotion carries the tag the query excluded",
+			promoted: []database.TagInfo{tag("unfinished", "beta")},
+			filters:  []zapscript.TagFilter{filter("unfinished", "beta", zapscript.TagOperatorNOT)},
+			want:     true,
+		},
+		{
+			name:    "NOT: neither row carries the excluded tag",
+			filters: []zapscript.TagFilter{filter("unfinished", "beta", zapscript.TagOperatorNOT)},
+			want:    false,
+		},
+		{
+			name:     "OR: promotion satisfies none of the group",
+			selected: []database.TagInfo{tag("region", "us")},
+			filters: []zapscript.TagFilter{
+				filter("region", "us", zapscript.TagOperatorOR),
+				filter("region", "eu", zapscript.TagOperatorOR),
+			},
+			want: true,
+		},
+		{
+			// Comparing an OR group filter by filter would wrongly block this.
+			name:     "OR: promotion satisfies the group a different way",
+			selected: []database.TagInfo{tag("region", "us")},
+			promoted: []database.TagInfo{tag("region", "eu")},
+			filters: []zapscript.TagFilter{
+				filter("region", "us", zapscript.TagOperatorOR),
+				filter("region", "eu", zapscript.TagOperatorOR),
+			},
+			want: false,
+		},
+		{
+			name: "OR: the selection satisfied nothing in the group either",
+			filters: []zapscript.TagFilter{
+				filter("region", "us", zapscript.TagOperatorOR),
+				filter("region", "eu", zapscript.TagOperatorOR),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			selected := database.SearchResultWithCursor{MediaID: 1, Tags: tt.selected}
+			promoted := database.SearchResultWithCursor{MediaID: 2, Tags: tt.promoted}
+			assert.Equal(t, tt.want, promotionLosesRequestedTag(&selected, &promoted, tt.filters))
+		})
+	}
+}
+
+// TestResolveTitle_PromotedRowUnreadableKeepsSelection: the container named a
+// different launch target but its row could not be read. A launch that would
+// otherwise work must not fail because of that.
+func TestResolveTitle_PromotedRowUnreadableKeepsSelection(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discTrackPath,
+		MediaID:  7,
+	}}, nil)
+	mockMediaDB.On("FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, mock.Anything, discDir,
+	).Return(&database.Media{DBID: 99, Path: discCuePath}, nil)
+	mockMediaDB.On("GetMediaByDBID", mock.Anything, int64(99)).
+		Return(database.SearchResultWithCursor{}, errors.New("row is gone"))
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discTrackPath, result.Result.Path)
+	assert.Equal(t, int64(7), result.Result.MediaID)
+}
+
+// TestResolveTitle_KeepsSelectionWhenDirectoryIsNotAContainer is the ordinary
+// case for a disc image: the extension passes the gate, so the lookup runs, but
+// a flat library folder holds many games and collapses to nothing.
+func TestResolveTitle_KeepsSelectionWhenDirectoryIsNotAContainer(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	flatPath := "/roms/PSX/B_064.chd"
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     flatPath,
+		MediaID:  7,
+	}}, nil)
+	mockMediaDB.On("FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, "PSX", "/roms/PSX/",
+	).Return((*database.Media)(nil), nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, flatPath, result.Result.Path)
+	mockMediaDB.AssertNotCalled(t, "GetMediaByDBID", mock.Anything, mock.Anything)
+}
+
+// TestResolveTitle_KeepsSelectionWhenAlreadyTheContainerTarget: selection landed
+// on the cue sheet itself, so there is nothing to swap and no row to re-read.
+func TestResolveTitle_KeepsSelectionWhenAlreadyTheContainerTarget(t *testing.T) {
+	t.Parallel()
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	cfg := newPromotionTestConfig(t)
+
+	setupCacheMiss(mockMediaDB)
+	mockMediaDB.On("SearchMediaBySlug",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+	).Return([]database.SearchResultWithCursor{{
+		SystemID: "PSX",
+		Name:     "B_064",
+		Path:     discCuePath,
+		MediaID:  99,
+	}}, nil)
+	mockMediaDB.On("FindSingleContainerLaunchMediaBySystemID",
+		mock.Anything, "PSX", discDir,
+	).Return(&database.Media{DBID: 99, Path: discCuePath}, nil)
+	setupCacheWrite(mockMediaDB)
+
+	result, err := ResolveTitle(context.Background(), &ResolveParams{
+		SystemID:  "PSX",
+		GameName:  "B_064",
+		MediaDB:   mockMediaDB,
+		Cfg:       cfg,
+		MediaType: slugs.MediaTypeGame,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, discCuePath, result.Result.Path)
+	mockMediaDB.AssertNotCalled(t, "GetMediaByDBID", mock.Anything, mock.Anything)
+}

--- a/pkg/zapscript/titles/resolve.go
+++ b/pkg/zapscript/titles/resolve.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/container"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
@@ -82,6 +83,118 @@ func cacheSlugResolution(
 			log.Warn().Err(cacheErr).Msg("failed to cache slug resolution")
 		}
 	}()
+}
+
+// promotionLosesRequestedTag reports whether swapping selected for promoted
+// would give up a tag the query asked for and the selection actually carried.
+// A playlist holds no disc tag, so "Game (Disc 2)" keeps the disc it named,
+// while a region both rows carry promotes normally and a tag neither row
+// carries was never a distinction between them. HasAllTags cannot answer this:
+// it treats an absent tag type as unevaluable rather than as a mismatch, so a
+// playlist passes every filter its own tracks were selected by.
+func promotionLosesRequestedTag(
+	selected, promoted *database.SearchResultWithCursor,
+	tagFilters []zapscript.TagFilter,
+) bool {
+	if len(tagFilters) == 0 {
+		return false
+	}
+
+	selectedTags := tagValueSets(selected)
+	promotedTags := tagValueSets(promoted)
+	carries := func(sets map[string]map[string]struct{}, filter zapscript.TagFilter) bool {
+		values, ok := sets[filter.Type]
+		if !ok {
+			return false
+		}
+		_, ok = values[filter.Value]
+		return ok
+	}
+
+	andFilters, notFilters, orFilters := database.GroupTagFiltersByOperator(tagFilters)
+	for _, filter := range andFilters {
+		if carries(selectedTags, filter) && !carries(promotedTags, filter) {
+			return true
+		}
+	}
+	for _, filter := range notFilters {
+		if !carries(selectedTags, filter) && carries(promotedTags, filter) {
+			return true
+		}
+	}
+
+	// An OR group is satisfied by any one of its filters, so it is only lost
+	// when the selection matched something in the group and the promotion
+	// matches nothing in it. Comparing filter by filter would refuse a
+	// promotion that simply satisfies the group a different way.
+	if len(orFilters) > 0 {
+		selectedMatches, promotedMatches := false, false
+		for _, filter := range orFilters {
+			if carries(selectedTags, filter) {
+				selectedMatches = true
+			}
+			if carries(promotedTags, filter) {
+				promotedMatches = true
+			}
+		}
+		if selectedMatches && !promotedMatches {
+			return true
+		}
+	}
+	return false
+}
+
+// promoteToContainerLaunchMedia swaps a resolved media for the launch target of
+// the directory holding it, so a title that matched one of a disc folder's
+// tracks launches the cue sheet or playlist that browse, media.meta and the
+// scrapers all name for that folder.
+//
+// The question goes to the database rather than to the candidates in hand:
+// every file in such a folder shares one title, the slug search is capped, and
+// the container's own launch target is routinely outside that cap. Selecting
+// among the rows already fetched cannot reach it.
+//
+// Anything unexpected keeps the original selection. A container lookup exists
+// to launch the better file, never to fail a launch that would otherwise work.
+func promoteToContainerLaunchMedia(
+	ctx context.Context,
+	mediadb database.MediaDBI,
+	systemID string,
+	selected *database.SearchResultWithCursor,
+	tagFilters []zapscript.TagFilter,
+) database.SearchResultWithCursor {
+	if !container.MayHaveContainerTarget(selected.Path) {
+		return *selected
+	}
+	containerPath := container.ParentDir(selected.Path)
+	if containerPath == "" {
+		return *selected
+	}
+
+	launch, err := mediadb.FindSingleContainerLaunchMediaBySystemID(ctx, systemID, containerPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", selected.Path).
+			Msg("container launch lookup failed, keeping resolved media")
+		return *selected
+	}
+	if launch == nil || launch.DBID == selected.MediaID {
+		return *selected
+	}
+
+	promoted, err := mediadb.GetMediaByDBID(ctx, launch.DBID)
+	if err != nil {
+		log.Debug().Err(err).Int64("mediaID", launch.DBID).
+			Msg("failed to read container launch media, keeping resolved media")
+		return *selected
+	}
+
+	if promotionLosesRequestedTag(selected, &promoted, tagFilters) {
+		return *selected
+	}
+
+	log.Info().Str("from", selected.Path).Str("to", promoted.Path).
+		Msg("promoted resolved title to its container launch media")
+	return promoted
 }
 
 // ResolveTitle runs the full title resolution pipeline against the media database.
@@ -155,6 +268,8 @@ func ResolveTitle(ctx context.Context, params *ResolveParams) (*ResolveResult, e
 			results, tagFilters, params.Cfg, MatchQualityExact, params.Launchers)
 
 		if confidence >= ConfidenceHigh {
+			selectedResult = promoteToContainerLaunchMedia(
+				ctx, mediadb, systemID, &selectedResult, tagFilters)
 			cacheSlugResolution(ctx, mediadb, systemID, slug, tagFilters, selectedResult.MediaID, StrategyExactMatch)
 			return &ResolveResult{
 				Result:     selectedResult,
@@ -315,8 +430,12 @@ func ResolveTitle(ctx context.Context, params *ResolveParams) (*ResolveResult, e
 		return nil, ErrLowConfidence
 	}
 
+	bestCandidate.result = promoteToContainerLaunchMedia(
+		ctx, mediadb, systemID, &bestCandidate.result, tagFilters)
+
 	// Cache the successful resolution without letting cache bookkeeping block
-	// launch-critical title resolution.
+	// launch-critical title resolution. Promotion runs first so the cached ID is
+	// the container's launch target, not the sibling the search happened to pick.
 	cacheSlugResolution(ctx, mediadb, systemID, slug, tagFilters, bestCandidate.result.MediaID, bestCandidate.strategy)
 
 	return &ResolveResult{


### PR DESCRIPTION
## Summary

`pkg/database/container` exists so one rule decides when a directory of indexed media collapses to a single launch target. Browse did not use that rule as written: `isSingletonDirectoryAliasCandidate` dropped any directory whose recursive `FileCount` exceeded 64 before the resolver was asked. `FindSingleContainerLaunchMedia`, behind `media.meta` and `media.image`, and `container.Index`, behind the scrapers, apply no size limit, so the three disagreed about the same folder. `docs/api/methods.md` and `docs/scraper.md` already described the rule without a limit, so the code was the outlier and neither needed an edit.

Removing the cap makes every directory on a page a candidate, which is the input that blows up #1377, so the batch is bounded first.

- `ResolveSingletonContainerAliases` runs its `ParentDir IN` scan in `aliasCandidatesPerQuery`-sized chunks. `GetMediaWithTitleAndSystemByIDs` and `GetMediaTagsByMediaDBIDs` chunk at source rather than at the call site: the first is also reached from the `media.meta` batch path, the second from four more callers, all with caller-sized ID lists. Each loop checks the context between chunks so a cancelled request stops instead of running the rest.
- Candidates and IDs are deduplicated before chunking. One `IN` list returns a row once however many times its key appears, but a key landing in two chunks reads its rows twice, and the alias scan appends per `ParentDir` — a repeated directory would look like it held twice the files and stop collapsing.
- `isSingletonDirectoryAliasCandidate` is gone. A directory qualifies on `FileCount > 0`, and the container rule alone decides what collapses.
- The step-timing debug line gains `inScanChunks`.

The cap's own comment called it a batch-size guard. Its stated fear was misplaced twice over: the batch query reads only `ParentDir = <dir>/` rows, so a tree of subdirectories returns nothing and costs one index seek, and the example it named — MiSTer's `_Arcade/_alternatives` — holds media for a dozen systems and is already excluded by the single-system check above it. The two tests that encoded the cap are retargeted rather than deleted: one now asserts the multi-system guard that genuinely protects that directory, the other that a large directory is offered to the resolver and stays plain because no alias comes back. Three unrelated browse tests held fixtures that now reach the resolver and gained alias stubs.

Closes #1377
Closes #1378

## Verified

`task test`, `task lint`, `task cross-lint:all`.

Both fixes were reproduced and confirmed on the MiSTer test device, A/B against `origin/main` with the same corpus under both binaries.

`media.browse` of the parent against `media.meta` on the folder path:

| folder | files | main browse | branch browse | media.meta |
|---|---|---|---|---|
| 1 `.cue` + 3 `.bin` | 4 | promoted | promoted | resolves |
| 1 `.cue` + 63 `.bin` | 64 | promoted | promoted | resolves |
| 1 `.cue` + 64 `.bin` | 65 | plain dir | promoted | resolves |
| 1 `.cue` + 70 `.bin` | 71 | plain dir | promoted | resolves |
| 1 `.m3u` + 100 `.chd` | 101 | plain dir | promoted | resolves |
| 2 `.cue` + 68 `.bin` | 70 | plain dir | plain dir | no resolve |
| media in a subdirectory | 2 | plain dir | plain dir | no resolve |

64 promoting and 65 not is the cap exactly. The `media-folder` scraper attached `media/boxart/Y_ManyBins.png` to the 71-file folder's cue, and the promoted browse entry reports `hasCover` for it — only that folder.

`media.browse` of 1000 one-cue directories:

| maxResults | main | branch |
|---|---|---|
| 100 | 0.83s, 100 promoted | 0.80s, 100 |
| 500 | 1.36s, 500 promoted | 1.62s, 500 |
| 999 | 30.1s, 0 promoted | 2.61s, 999 |
| 1000 | 30.1s, 0 promoted | 2.44s, 1000 |

## Cost

Larger directories are now candidates, at roughly 0.2ms per direct row, spent proving directories are not containers. On the device's stock library:

| page | main | branch | rows scanned |
|---|---|---|---|
| `/media/fat/games/MegaDrive` | 82ms | 225ms | 745 |
| `/media/fat/games/NES` | 179ms | 316ms | 584 |

This is the price of one shared definition. A guard would buy back a tenth of a second on pages of large flat ROM folders and reintroduce the disagreement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Matched disc tracks and other container media can now launch through the appropriate cue sheet or playlist.
  * Browse results resolve singleton directory aliases independently for each explicitly selected system.
  * Large media directories are now considered for alias resolution.

* **Bug Fixes**
  * Multi-system directories remain unresolved when browsing without a system filter.
  * Empty directories continue to be excluded from alias resolution.
  * Tag-specific selections and successful results are preserved when container lookups fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->