### PR TITLE
fix: arcade play tracking, companion artwork matching and plaintext notification leak

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1077,6 +1077,9 @@ func broadcastToSessions(session *melody.Melody, plaintext []byte) {
 // On any send-side encryption failure (counter exhaustion, AEAD setup
 // error, write failure) the session is closed: a desynced session
 // cannot recover and keeping it open hides the bug from the client.
+//
+// A session whose transport mode is not settled yet never reaches here: the
+// caller queues for it instead, so the notification survives the wait.
 func writeNotificationFrame(
 	writeFn func([]byte) error,
 	cs *apimiddleware.ClientSession,
@@ -1097,6 +1100,14 @@ func writeNotificationFrame(
 
 func writeNotificationToSession(s *melody.Session, plaintext []byte) {
 	cs := getClientSession(s)
+	if cs == nil && getWebSocketAuthState(s) == webSocketAuthUnsettled {
+		// Transport mode still unknown: hold the notification rather than
+		// guess. It is flushed or discarded once the client's first frame
+		// arrives, or flushed when the settle grace expires.
+		if queue := getNotificationQueue(s); queue != nil && queue.enqueue(plaintext) {
+			return
+		}
+	}
 	if err := writeNotificationFrame(s.Write, cs, getWebSocketAuthState(s), plaintext); err != nil {
 		logWSWriteError(err, "broadcasting notification")
 		closeMelodySession(s)
@@ -1491,7 +1502,7 @@ func decryptIncomingFrame(
 			return nil, nil, false
 		}
 		setClientSession(session, newSession)
-		setWebSocketAuthState(session, webSocketAuthEncrypted)
+		settleWebSocketTransport(session, webSocketAuthEncrypted, false)
 		return pt, newSession, true
 	}
 
@@ -1507,8 +1518,8 @@ func decryptIncomingFrame(
 		return nil, nil, false
 	}
 	// The client spoke plaintext, so the transport mode is now settled and
-	// notifications can be written to this session in the clear.
-	setWebSocketAuthState(session, webSocketAuthPlaintext)
+	// anything queued while it was unknown can be released in the clear.
+	settleWebSocketTransport(session, webSocketAuthPlaintext, false)
 	return msg, nil, true
 }
 
@@ -1983,9 +1994,11 @@ func StartWithReady(
 	// run the normal session close path.
 	session.HandleConnect(func(s *melody.Session) {
 		startWebSocketAuthDeadline(s, webSocketAuthenticationTimeout)
+		startWebSocketSettleGrace(s, webSocketSettleGrace)
 	})
 	session.HandleDisconnect(func(s *melody.Session) {
 		stopWebSocketAuthDeadline(s)
+		stopWebSocketSettleGrace(s)
 		closeWSDispatcher(s)
 	})
 	session.HandleError(func(s *melody.Session, herr error) {
@@ -2058,13 +2071,16 @@ func StartWithReady(
 		// encryption setting of false means encryption is optional, not absent,
 		// so a paired client can still negotiate an encrypted session. Starting
 		// as plaintext would let notifications broadcast in that window go out
-		// in the clear to a client that has already switched to encrypted.
+		// in the clear to a client that has already switched to encrypted, so
+		// they are queued instead until the first frame settles the mode or
+		// the settle grace runs out.
 		authState := webSocketAuthUnsettled
 		if cfg.EncryptionEnabled() && !apimiddleware.IsLoopbackAddr(r.RemoteAddr) {
 			authState = webSocketAuthPending
 		}
 		err := session.HandleRequestWithKeys(w, r, map[string]any{
-			melodySessionAuthStateKey: authState,
+			melodySessionAuthStateKey:  authState,
+			melodySessionNotifQueueKey: &wsNotificationQueue{},
 		})
 		if err != nil {
 			log.Warn().Err(err).Str("version", version).Msg("websocket upgrade failed")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1107,6 +1107,10 @@ func writeNotificationToSession(s *melody.Session, plaintext []byte) {
 		if queue := getNotificationQueue(s); queue != nil && queue.enqueue(plaintext) {
 			return
 		}
+		// The queue refused it, so the session settled between the read above
+		// and the enqueue. Re-read the encryption session or an upgrade that
+		// landed in that window would be written with a stale nil and dropped.
+		cs = getClientSession(s)
 	}
 	if err := writeNotificationFrame(s.Write, cs, getWebSocketAuthState(s), plaintext); err != nil {
 		logWSWriteError(err, "broadcasting notification")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1506,6 +1506,9 @@ func decryptIncomingFrame(
 		closeMelodySession(session)
 		return nil, nil, false
 	}
+	// The client spoke plaintext, so the transport mode is now settled and
+	// notifications can be written to this session in the clear.
+	setWebSocketAuthState(session, webSocketAuthPlaintext)
 	return msg, nil, true
 }
 
@@ -2051,7 +2054,12 @@ func StartWithReady(
 				return
 			}
 		}
-		authState := webSocketAuthPlaintext
+		// The transport mode is not known until the client's first frame: an
+		// encryption setting of false means encryption is optional, not absent,
+		// so a paired client can still negotiate an encrypted session. Starting
+		// as plaintext would let notifications broadcast in that window go out
+		// in the clear to a client that has already switched to encrypted.
+		authState := webSocketAuthUnsettled
 		if cfg.EncryptionEnabled() && !apimiddleware.IsLoopbackAddr(r.RemoteAddr) {
 			authState = webSocketAuthPending
 		}

--- a/pkg/api/server_encryption.go
+++ b/pkg/api/server_encryption.go
@@ -40,6 +40,12 @@ const (
 type webSocketAuthState string
 
 const (
+	// webSocketAuthUnsettled is the initial state when encryption is optional:
+	// the client may still negotiate an encrypted session on its first frame,
+	// so the transport mode is not known yet. Unlike webSocketAuthPending it
+	// does not arm the authentication deadline, because staying quiet is
+	// legitimate for a client that is never required to authenticate.
+	webSocketAuthUnsettled webSocketAuthState = "unsettled"
 	webSocketAuthPending   webSocketAuthState = "pending"
 	webSocketAuthPlaintext webSocketAuthState = "plaintext"
 	webSocketAuthEncrypted webSocketAuthState = "encrypted"

--- a/pkg/api/server_encryption.go
+++ b/pkg/api/server_encryption.go
@@ -26,6 +26,7 @@ import (
 
 	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/olahol/melody"
 	"github.com/rs/zerolog/log"
 )
@@ -35,6 +36,24 @@ const (
 	melodySessionEncryptionKey   = "encryption_session"
 	melodySessionAuthStateKey    = "authentication_state"
 	melodySessionAuthDeadlineKey = "authentication_deadline"
+	melodySessionNotifQueueKey   = "notification_queue"
+	melodySessionSettleTimerKey  = "settle_timer"
+)
+
+const (
+	// webSocketSettleGrace bounds how long an optional-encryption session's
+	// transport mode may stay unknown. A client that negotiates encryption
+	// sends its first frame straight after the upgrade, so this only has to
+	// cover a round trip. A client that never speaks is a notification
+	// listener (the CLI's -read and -pair waits, the TUI's listeners) and is
+	// settled as plaintext when the grace expires, because starving it of
+	// notifications forever is worse than the leak this window closes.
+	webSocketSettleGrace = 2 * time.Second
+	// webSocketPendingNotifLimit caps what one unsettled session may hold, so
+	// a burst during the grace window cannot grow without bound. Overflow
+	// drops the newest notification, matching the broker's own best-effort
+	// delivery.
+	webSocketPendingNotifLimit = 64
 )
 
 type webSocketAuthState string
@@ -44,7 +63,9 @@ const (
 	// the client may still negotiate an encrypted session on its first frame,
 	// so the transport mode is not known yet. Unlike webSocketAuthPending it
 	// does not arm the authentication deadline, because staying quiet is
-	// legitimate for a client that is never required to authenticate.
+	// legitimate for a client that is never required to authenticate; the
+	// state instead resolves to plaintext after webSocketSettleGrace.
+	// Notifications broadcast while unsettled are queued, not written.
 	webSocketAuthUnsettled webSocketAuthState = "unsettled"
 	webSocketAuthPending   webSocketAuthState = "pending"
 	webSocketAuthPlaintext webSocketAuthState = "plaintext"
@@ -80,6 +101,116 @@ func startWebSocketAuthDeadline(session *melody.Session, timeout time.Duration) 
 		}
 	})
 	session.Set(melodySessionAuthDeadlineKey, timer)
+}
+
+// wsNotificationQueue holds notifications broadcast to a session whose
+// transport mode is not settled yet. Writing them in the clear would desync a
+// client that has already committed to an encrypted session, and dropping them
+// would starve a listener that never sends a frame, so they are held until the
+// mode is known and then either flushed in order or discarded.
+//
+// The flush happens under the lock so a broadcast arriving mid-flush cannot
+// overtake the notifications it was queued behind.
+type wsNotificationQueue struct {
+	pending [][]byte
+	mu      syncutil.Mutex
+	settled bool
+}
+
+// enqueue holds a notification while the transport mode is unknown. It reports
+// false once the mode is settled, which is the caller's signal to write
+// normally.
+func (q *wsNotificationQueue) enqueue(plaintext []byte) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.settled {
+		return false
+	}
+	if len(q.pending) >= webSocketPendingNotifLimit {
+		log.Warn().Msg("ws: dropping notification, unsettled session queue is full")
+		return true
+	}
+	q.pending = append(q.pending, append([]byte(nil), plaintext...))
+	return true
+}
+
+func getNotificationQueue(session *melody.Session) *wsNotificationQueue {
+	value, ok := session.Get(melodySessionNotifQueueKey)
+	if !ok {
+		return nil
+	}
+	queue, ok := value.(*wsNotificationQueue)
+	if !ok {
+		return nil
+	}
+	return queue
+}
+
+// settleWebSocketTransport records the session's transport mode and releases
+// the notifications queued while it was unknown: flushed in order for a
+// plaintext session, discarded for one that turned out to be encrypted.
+//
+// The whole transition happens under the queue's lock so the settle grace
+// expiring cannot race an encrypted first frame into publishing the queue in
+// the clear, and so a broadcast arriving mid-flush cannot overtake the
+// notifications it was queued behind. onlyIfUnsettled is how the grace timer
+// stands down when the client has spoken in the meantime.
+func settleWebSocketTransport(session *melody.Session, state webSocketAuthState, onlyIfUnsettled bool) {
+	queue := getNotificationQueue(session)
+	if queue == nil {
+		if onlyIfUnsettled && getWebSocketAuthState(session) != webSocketAuthUnsettled {
+			return
+		}
+		setWebSocketAuthState(session, state)
+		stopWebSocketSettleGrace(session)
+		return
+	}
+
+	queue.mu.Lock()
+	defer queue.mu.Unlock()
+	if onlyIfUnsettled && queue.settled {
+		return
+	}
+	pending := queue.pending
+	queue.pending = nil
+	queue.settled = true
+	setWebSocketAuthState(session, state)
+	stopWebSocketSettleGrace(session)
+	if state != webSocketAuthPlaintext {
+		return
+	}
+	for _, plaintext := range pending {
+		if err := session.Write(plaintext); err != nil {
+			logWSWriteError(err, "flushing queued notifications")
+			return
+		}
+	}
+}
+
+// startWebSocketSettleGrace settles a silent session as plaintext once the
+// grace expires, so a client that only ever listens still gets notifications.
+func startWebSocketSettleGrace(session *melody.Session, grace time.Duration) {
+	if getWebSocketAuthState(session) != webSocketAuthUnsettled {
+		return
+	}
+	timer := time.AfterFunc(grace, func() {
+		if getWebSocketAuthState(session) != webSocketAuthUnsettled {
+			return
+		}
+		log.Debug().Msg("ws: no client frame within settle grace, treating session as plaintext")
+		settleWebSocketTransport(session, webSocketAuthPlaintext, true)
+	})
+	session.Set(melodySessionSettleTimerKey, timer)
+}
+
+func stopWebSocketSettleGrace(session *melody.Session) {
+	value, ok := session.Get(melodySessionSettleTimerKey)
+	if !ok {
+		return
+	}
+	if timer, ok := value.(*time.Timer); ok {
+		timer.Stop()
+	}
 }
 
 func stopWebSocketAuthDeadline(session *melody.Session) {

--- a/pkg/api/server_encryption.go
+++ b/pkg/api/server_encryption.go
@@ -44,11 +44,21 @@ const (
 	// webSocketSettleGrace bounds how long an optional-encryption session's
 	// transport mode may stay unknown. A client that negotiates encryption
 	// sends its first frame straight after the upgrade, so this only has to
-	// cover a round trip. A client that never speaks is a notification
-	// listener (the CLI's -read and -pair waits, the TUI's listeners) and is
-	// settled as plaintext when the grace expires, because starving it of
-	// notifications forever is worse than the leak this window closes.
-	webSocketSettleGrace = 2 * time.Second
+	// cover building that frame and one round trip. A client that never
+	// speaks is a notification listener (the CLI's -read and -pair waits, the
+	// TUI's listeners) and is settled as plaintext when the grace expires,
+	// because starving it of notifications forever is worse than the window
+	// this leaves open.
+	//
+	// Nothing distinguishes the two at the upgrade, so the value is a
+	// trade-off in both directions: longer leaves more room for a slow
+	// encrypted client, shorter delivers a listener's first notifications
+	// sooner. Queueing removes the cost of waiting — a listener loses nothing,
+	// it only waits — so the ceiling is what the shortest listener tolerates.
+	// The TUI's generate-database screen reconnects every 2s
+	// (mediaManagePollInterval), so the grace has to clear its whole budget
+	// with room to spare or that screen never sees an update.
+	webSocketSettleGrace = 750 * time.Millisecond
 	// webSocketPendingNotifLimit caps what one unsettled session may hold, so
 	// a burst during the grace window cannot grow without bound. Overflow
 	// drops the newest notification, matching the broker's own best-effort

--- a/pkg/api/server_encryption_test.go
+++ b/pkg/api/server_encryption_test.go
@@ -24,12 +24,17 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/crypto"
 	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/olahol/melody"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -300,4 +305,124 @@ func TestWriteNotificationFrame_UnsettledSessionIsNotWrittenPlaintext(t *testing
 			}
 		})
 	}
+}
+
+// A notification broadcast before the client's first frame must survive until
+// the transport mode is known, then be delivered in the order it was queued.
+func TestWSNotificationQueue_FlushesInOrderOnPlaintext(t *testing.T) {
+	t.Parallel()
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
+		session = s
+		close(ready)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+	<-ready
+
+	writeNotificationToSession(session, []byte(`{"n":1}`))
+	writeNotificationToSession(session, []byte(`{"n":2}`))
+
+	settleWebSocketTransport(session, webSocketAuthPlaintext, false)
+	writeNotificationToSession(session, []byte(`{"n":3}`))
+
+	got := make([]string, 0, 3)
+	for range 3 {
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+		_, msg, readErr := conn.ReadMessage()
+		require.NoError(t, readErr)
+		got = append(got, string(msg))
+	}
+	assert.Equal(t, []string{`{"n":1}`, `{"n":2}`, `{"n":3}`}, got,
+		"queued notifications must be delivered before the ones that follow the settle")
+}
+
+// The point of queueing: a client that turns out to have negotiated encryption
+// must never see the plaintext that was broadcast while its mode was unknown.
+func TestWSNotificationQueue_DiscardsOnEncrypted(t *testing.T) {
+	t.Parallel()
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
+		session = s
+		close(ready)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+	<-ready
+
+	writeNotificationToSession(session, []byte(`{"secret":true}`))
+	settleWebSocketTransport(session, webSocketAuthEncrypted, false)
+	// A later broadcast has no encryption session attached in this harness, so
+	// writeNotificationFrame drops it too: nothing may reach the wire.
+	writeNotificationToSession(session, []byte(`{"secret":false}`))
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
+	_, _, err = conn.ReadMessage()
+	require.Error(t, err, "plaintext queued before an encrypted upgrade must be discarded")
+}
+
+// The grace timer stands down once the client has spoken, so an encrypted
+// session cannot be flipped back to plaintext by a late firing.
+func TestSettleWebSocketTransport_GraceDoesNotOverrideEncrypted(t *testing.T) {
+	t.Parallel()
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
+		session = s
+		close(ready)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+	<-ready
+
+	settleWebSocketTransport(session, webSocketAuthEncrypted, false)
+	settleWebSocketTransport(session, webSocketAuthPlaintext, true)
+	assert.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session))
 }

--- a/pkg/api/server_encryption_test.go
+++ b/pkg/api/server_encryption_test.go
@@ -34,6 +34,7 @@ import (
 	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/helpers"
+	"github.com/gorilla/websocket"
 	"github.com/olahol/melody"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,11 +126,38 @@ type testEncryptionPeerSecrets struct {
 	aad      []byte
 }
 
+// testEncryptionSourceIP is the client address the test frames are built for.
+// EstablishSession binds a session to it, so callers driving the frame through
+// the server have to present the same one.
+const testEncryptionSourceIP = "192.168.1.50"
+
+// testEncryptionFirstFrame carries everything needed to drive a real encrypted
+// first frame through the server: the gateway that will accept it, the frame
+// itself, and the client-side cipher state for reading what comes back.
+type testEncryptionFirstFrame struct {
+	gateway *apimiddleware.EncryptionGateway
+	secrets *testEncryptionPeerSecrets
+	frame   apimiddleware.EncryptedFirstFrame
+}
+
 // establishTestEncryptionSession constructs a real *apimiddleware.ClientSession
 // the same way the production server does: pair a fake client, build a valid
 // encrypted first frame, and run it through EncryptionGateway.EstablishSession.
 // Returns the resulting session and the matching client-side cipher state.
 func establishTestEncryptionSession(t *testing.T) (*apimiddleware.ClientSession, *testEncryptionPeerSecrets) {
+	t.Helper()
+
+	first := newTestEncryptionFirstFrame(t)
+	cs, _, err := first.gateway.EstablishSession(first.frame, testEncryptionSourceIP)
+	require.NoError(t, err)
+	require.NotNil(t, cs)
+	return cs, first.secrets
+}
+
+// newTestEncryptionFirstFrame pairs a fake client and builds the encrypted
+// first frame it would send, without establishing the session, so a test can
+// hand the frame to the code under test instead of the gateway.
+func newTestEncryptionFirstFrame(t *testing.T) *testEncryptionFirstFrame {
 	t.Helper()
 
 	pairingKey := make([]byte, crypto.PairingKeySize)
@@ -165,20 +193,19 @@ func establishTestEncryptionSession(t *testing.T) (*apimiddleware.ClientSession,
 	ct, err := crypto.Encrypt(clientC2S, keys.C2SNonce, 0, plaintextReq, aad)
 	require.NoError(t, err)
 
-	first := apimiddleware.EncryptedFirstFrame{
-		Version:     apimiddleware.EncryptionProtoVersion,
-		Ciphertext:  base64.StdEncoding.EncodeToString(ct),
-		AuthToken:   c.AuthToken,
-		SessionSalt: base64.StdEncoding.EncodeToString(salt),
-	}
-	cs, _, err := mgr.EstablishSession(first, "192.168.1.50")
-	require.NoError(t, err)
-	require.NotNil(t, cs)
-
-	return cs, &testEncryptionPeerSecrets{
-		s2cGCM:   clientS2C,
-		s2cNonce: keys.S2CNonce,
-		aad:      aad,
+	return &testEncryptionFirstFrame{
+		gateway: mgr,
+		frame: apimiddleware.EncryptedFirstFrame{
+			Version:     apimiddleware.EncryptionProtoVersion,
+			Ciphertext:  base64.StdEncoding.EncodeToString(ct),
+			AuthToken:   c.AuthToken,
+			SessionSalt: base64.StdEncoding.EncodeToString(salt),
+		},
+		secrets: &testEncryptionPeerSecrets{
+			s2cGCM:   clientS2C,
+			s2cNonce: keys.S2CNonce,
+			aad:      aad,
+		},
 	}
 }
 
@@ -384,6 +411,11 @@ func TestWSNotificationQueue_DiscardsOnEncrypted(t *testing.T) {
 
 	writeNotificationToSession(session, []byte(`{"secret":true}`))
 	settleWebSocketTransport(session, webSocketAuthEncrypted, false)
+
+	queue := getNotificationQueue(session)
+	require.NotNil(t, queue)
+	assert.Empty(t, queue.pending, "settling as encrypted must drop what was held, not keep it for a later flush")
+
 	// A later broadcast has no encryption session attached in this harness, so
 	// writeNotificationFrame drops it too: nothing may reach the wire.
 	writeNotificationToSession(session, []byte(`{"secret":false}`))
@@ -494,4 +526,207 @@ func TestSettleWebSocketTransport_LateEncryptedUpgradeEndsPlaintext(t *testing.T
 	)
 	require.NoError(t, err)
 	assert.Equal(t, afterUpgrade, decrypted)
+}
+
+// newQueuedTestSession dials a melody session set up the way the WebSocket
+// upgrade sets one up for optional encryption: transport mode unknown, with a
+// queue attached. Returns the server-side session and the client connection.
+func newQueuedTestSession(t *testing.T) (*melody.Session, *websocket.Conn) {
+	t.Helper()
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
+		session = s
+		close(ready)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { _ = m.Close() })
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	t.Cleanup(func() { _ = conn.Close() })
+	<-ready
+	return session, conn
+}
+
+// The queue holds notifications for a session whose mode is unknown, so it has
+// to bound what one session can hold and it has to own its copy: the caller's
+// buffer is not guaranteed to survive until the flush.
+func TestWSNotificationQueue_EnqueueBounds(t *testing.T) {
+	t.Parallel()
+
+	q := &wsNotificationQueue{}
+
+	first := []byte(`{"n":0}`)
+	require.True(t, q.enqueue(first))
+	first[3] = 'X'
+	assert.Equal(t, `{"n":0}`, string(q.pending[0]),
+		"the queue must copy, so a caller reusing its buffer cannot rewrite a held notification")
+
+	for range webSocketPendingNotifLimit {
+		require.True(t, q.enqueue([]byte(`{"n":1}`)))
+	}
+	assert.Len(t, q.pending, webSocketPendingNotifLimit,
+		"a burst during the grace must not grow the queue without bound")
+
+	q.settled = true
+	assert.False(t, q.enqueue([]byte(`{"n":2}`)),
+		"once the mode is settled the caller writes directly instead of queueing")
+	assert.Len(t, q.pending, webSocketPendingNotifLimit, "a refused enqueue must not store anything")
+}
+
+// A session that disconnects while notifications are held cannot be written
+// to. The flush has to give up on the first failure rather than work through
+// the rest of the queue against a dead connection.
+func TestSettleWebSocketTransport_FlushStopsOnWriteError(t *testing.T) {
+	t.Parallel()
+
+	session, _ := newQueuedTestSession(t)
+	writeNotificationToSession(session, []byte(`{"n":1}`))
+	writeNotificationToSession(session, []byte(`{"n":2}`))
+
+	require.NoError(t, session.Close())
+	require.Eventually(t, session.IsClosed, time.Second, 5*time.Millisecond)
+
+	settleWebSocketTransport(session, webSocketAuthPlaintext, false)
+
+	queue := getNotificationQueue(session)
+	require.NotNil(t, queue)
+	assert.True(t, queue.settled, "the mode is settled even when the flush cannot be delivered")
+	assert.Empty(t, queue.pending, "a failed flush must not leave the queue holding notifications")
+}
+
+// The settle grace exists for sessions whose mode is merely unknown. A session
+// that is required to authenticate is pending, not unsettled, and must never
+// be handed a timer that would settle it as plaintext without a client frame.
+func TestStartWebSocketSettleGrace_OnlyArmsForUnsettled(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		state    webSocketAuthState
+		name     string
+		wantArms bool
+	}{
+		{name: "unsettled arms", state: webSocketAuthUnsettled, wantArms: true},
+		{name: "required encryption does not arm", state: webSocketAuthPending},
+		{name: "already plaintext does not arm", state: webSocketAuthPlaintext},
+		{name: "already encrypted does not arm", state: webSocketAuthEncrypted},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			session, _ := newQueuedTestSession(t)
+			session.Set(melodySessionAuthStateKey, tt.state)
+			startWebSocketSettleGrace(session, time.Hour)
+
+			_, armed := session.Get(melodySessionSettleTimerKey)
+			assert.Equal(t, tt.wantArms, armed)
+			if armed {
+				stopWebSocketSettleGrace(session)
+			}
+		})
+	}
+}
+
+// Not every melody session carries a queue: only the ones the upgrade handler
+// builds do. Settling must still record the mode for the others rather than
+// silently doing nothing, and the grace timer must still stand down once the
+// client has spoken.
+func TestSettleWebSocketTransport_WithoutQueue(t *testing.T) {
+	t.Parallel()
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		session = s
+		close(ready)
+	})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+	<-ready
+
+	require.Nil(t, getNotificationQueue(session))
+
+	settleWebSocketTransport(session, webSocketAuthEncrypted, false)
+	require.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session))
+
+	settleWebSocketTransport(session, webSocketAuthPlaintext, true)
+	assert.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session),
+		"a late grace must not downgrade a session that already spoke")
+}
+
+// The reported bug, driven through the production entry point: a paired client
+// negotiates encryption on its first frame even though the server only treats
+// encryption as optional. Anything broadcast before that frame arrived is
+// queued, and establishing the session has to discard it rather than let it
+// reach a client that has already committed to encrypted mode.
+func TestDecryptIncomingFrame_EncryptedFirstFrameDiscardsQueuedPlaintext(t *testing.T) {
+	t.Parallel()
+
+	first := newTestEncryptionFirstFrame(t)
+	session, conn := newQueuedTestSession(t)
+
+	queued := []byte(`{"jsonrpc":"2.0","method":"tokens.added"}`)
+	writeNotificationToSession(session, queued)
+
+	//nolint:gosec // G117 false positive: the auth token is a test fixture, not a credential
+	body, err := json.Marshal(first.frame)
+	require.NoError(t, err)
+	pt, cs, ok := decryptIncomingFrame(
+		session, body, first.gateway, false, false, testEncryptionSourceIP,
+	)
+	require.True(t, ok, "an encrypted first frame is accepted when encryption is optional")
+	require.NotNil(t, cs)
+	assert.JSONEq(t, `{"jsonrpc":"2.0","method":"version","id":1}`, string(pt))
+	assert.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session))
+
+	// Assert on the queue rather than only on the wire: with the client
+	// session attached, later notifications are encrypted whether or not the
+	// queue was emptied, so a queue still holding plaintext would go unnoticed
+	// until something settled it and flushed it in the clear.
+	queue := getNotificationQueue(session)
+	require.NotNil(t, queue)
+	assert.True(t, queue.settled, "establishing encryption settles the transport mode")
+	assert.Empty(t, queue.pending, "queued plaintext must be discarded by the upgrade, not left to flush later")
+
+	after := []byte(`{"jsonrpc":"2.0","method":"tokens.removed"}`)
+	writeNotificationToSession(session, after)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.NotEqual(t, queued, msg, "plaintext queued before the upgrade must be discarded, not flushed")
+
+	var frame apimiddleware.EncryptedFrame
+	require.NoError(t, json.Unmarshal(msg, &frame))
+	ct, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+	require.NoError(t, err)
+	decrypted, err := crypto.Decrypt(
+		first.secrets.s2cGCM, first.secrets.s2cNonce, 0, ct, first.secrets.aad,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, after, decrypted, "the first frame on the wire is the one sent after the upgrade")
 }

--- a/pkg/api/server_encryption_test.go
+++ b/pkg/api/server_encryption_test.go
@@ -264,3 +264,40 @@ func TestUnsupportedEncryptionVersionResponse_WireShape(t *testing.T) {
 	assert.InDelta(t, float64(1), supported[0], 0,
 		"only protocol version 1 is currently supported")
 }
+
+// A client connecting while encryption is optional has not yet revealed
+// whether it will negotiate an encrypted session, because that happens on its
+// first frame. Notifications broadcast in that window must not be written in
+// the clear: the client may already have committed to encrypted mode, and a
+// plaintext frame arriving afterwards desyncs it.
+func TestWriteNotificationFrame_UnsettledSessionIsNotWrittenPlaintext(t *testing.T) {
+	t.Parallel()
+
+	plaintext := []byte(`{"jsonrpc":"2.0","method":"media.scrape.update"}`)
+	tests := []struct {
+		name      string
+		authState webSocketAuthState
+		wantWrite bool
+	}{
+		{name: "unsettled suppresses", authState: webSocketAuthUnsettled, wantWrite: false},
+		{name: "pending suppresses", authState: webSocketAuthPending, wantWrite: false},
+		{name: "settled plaintext writes", authState: webSocketAuthPlaintext, wantWrite: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []byte
+			require.NoError(t, writeNotificationFrame(func(data []byte) error {
+				got = append([]byte(nil), data...)
+				return nil
+			}, nil, tt.authState, plaintext))
+
+			if tt.wantWrite {
+				assert.Equal(t, plaintext, got)
+			} else {
+				assert.Nil(t, got, "notification must not reach a session of unknown transport mode")
+			}
+		})
+	}
+}

--- a/pkg/api/server_encryption_test.go
+++ b/pkg/api/server_encryption_test.go
@@ -426,3 +426,72 @@ func TestSettleWebSocketTransport_GraceDoesNotOverrideEncrypted(t *testing.T) {
 	settleWebSocketTransport(session, webSocketAuthPlaintext, true)
 	assert.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session))
 }
+
+// The settle grace resolves a silent session as plaintext, so a client whose
+// encrypted first frame arrives after it expires does see the queue flushed in
+// the clear. That window is the accepted trade-off, but it has to stay a
+// window: once the late frame establishes encryption, everything after it is
+// encrypted, so the exposure cannot continue for the life of the session.
+func TestSettleWebSocketTransport_LateEncryptedUpgradeEndsPlaintext(t *testing.T) {
+	t.Parallel()
+
+	cs, clientSecrets := establishTestEncryptionSession(t)
+
+	m := newWebSocketSession()
+	var session *melody.Session
+	ready := make(chan struct{})
+	m.HandleConnect(func(s *melody.Session) {
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
+		session = s
+		close(ready)
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+	<-ready
+
+	// Broadcast while the client is still silent, then let the grace expire.
+	beforeUpgrade := []byte(`{"jsonrpc":"2.0","method":"tokens.added"}`)
+	writeNotificationToSession(session, beforeUpgrade)
+	settleWebSocketTransport(session, webSocketAuthPlaintext, true)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+	require.Equal(t, beforeUpgrade, msg,
+		"the grace settles a silent session as plaintext; this is the accepted window")
+
+	// The delayed encrypted first frame finally arrives.
+	setClientSession(session, cs)
+	settleWebSocketTransport(session, webSocketAuthEncrypted, false)
+	assert.Equal(t, webSocketAuthEncrypted, getWebSocketAuthState(session))
+
+	afterUpgrade := []byte(`{"jsonrpc":"2.0","method":"tokens.removed"}`)
+	writeNotificationToSession(session, afterUpgrade)
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err = conn.ReadMessage()
+	require.NoError(t, err)
+	require.NotEqual(t, afterUpgrade, msg, "nothing may go out in the clear after the upgrade")
+
+	var frame apimiddleware.EncryptedFrame
+	require.NoError(t, json.Unmarshal(msg, &frame))
+	ct, err := base64.StdEncoding.DecodeString(frame.Ciphertext)
+	require.NoError(t, err)
+	decrypted, err := crypto.Decrypt(
+		clientSecrets.s2cGCM, clientSecrets.s2cNonce, 0, ct, clientSecrets.aad,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, afterUpgrade, decrypted)
+}

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1341,16 +1342,33 @@ func TestWebSocketSilentListenerReceivesNotifications(t *testing.T) {
 	// Broadcast repeatedly: the first notifications land while the session is
 	// still unsettled and have to survive the wait, and the later ones cover
 	// the settled steady state.
+	//
+	// The broadcaster is joined rather than only signalled. Parking it in
+	// time.Sleep left it running after the test returned, and whether goleak
+	// saw it came down to which woke first: it passed on Linux and failed on
+	// Windows, where the coarser timer lost that race.
 	stop := make(chan struct{})
-	defer close(stop)
+	var broadcasting sync.WaitGroup
+	broadcasting.Add(1)
+	defer func() {
+		close(stop)
+		broadcasting.Wait()
+	}()
 	go func() {
+		defer broadcasting.Done()
 		payload, _ := json.Marshal(map[string]string{"uid": "silent-listener"})
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-stop:
 				return
-			case st.Notifications <- models.Notification{Method: "tokens.added", Params: payload}:
-				time.Sleep(200 * time.Millisecond)
+			case <-ticker.C:
+				select {
+				case st.Notifications <- models.Notification{Method: "tokens.added", Params: payload}:
+				case <-stop:
+					return
+				}
 			}
 		}
 	}()

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -1304,6 +1304,10 @@ func TestSSE_ReceivesNotifications(t *testing.T) {
 // waits and both TUI listeners are built on it. Holding such a session at
 // "transport mode unknown" forever would starve it, so the settle grace has to
 // release it as plaintext.
+//
+// The deadline is the shortest budget any of those listeners gives a
+// connection: the TUI's generate-database screen reconnects every 2s, so a
+// settle grace that does not clear 2s leaves that screen showing nothing.
 func TestWebSocketSilentListenerReceivesNotifications(t *testing.T) {
 	t.Parallel()
 
@@ -1351,7 +1355,7 @@ func TestWebSocketSilentListenerReceivesNotifications(t *testing.T) {
 		}
 	}()
 
-	require.NoError(t, conn.SetReadDeadline(time.Now().Add(10*time.Second)))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
 	_, msg, err := conn.ReadMessage()
 	require.NoError(t, err, "a listener that never sends a frame must still get notifications")
 

--- a/pkg/api/server_startup_test.go
+++ b/pkg/api/server_startup_test.go
@@ -1298,3 +1298,64 @@ func TestSSE_ReceivesNotifications(t *testing.T) {
 	assert.Equal(t, "2.0", obj.JSONRPC)
 	assert.Equal(t, "tokens.staged", obj.Method)
 }
+
+// A notification listener connects and never sends a frame: that is exactly
+// what pkg/api/client's WaitNotification does, and the CLI's -read and -pair
+// waits and both TUI listeners are built on it. Holding such a session at
+// "transport mode unknown" forever would starve it, so the settle grace has to
+// release it as plaintext.
+func TestWebSocketSilentListenerReceivesNotifications(t *testing.T) {
+	t.Parallel()
+
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+	cfg, err := helpers.NewTestConfigWithPort(helpers.NewMemoryFS(), t.TempDir(), 0)
+	require.NoError(t, err)
+
+	st, notifCh := state.NewState(platform, "test-boot-uuid")
+	notifBroker := newTestBroker(st.GetContext(), notifCh)
+	db := &database.Database{UserDB: helpers.NewMockUserDBI(), MediaDB: helpers.NewMockMediaDBI()}
+	tokenQueue := make(chan tokens.Token, 1)
+	ready := make(chan error, 1)
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- StartWithReady(
+			platform, cfg, st, tokenQueue, nil, db,
+			nil, nil, notifBroker, nil, nil, nil, nil, nil, nil, ready,
+		)
+	}()
+	defer func() {
+		st.StopService()
+		<-serverErr
+	}()
+	require.NoError(t, <-ready)
+	port := waitForServerReady(t, cfg)
+
+	conn := dialWS(t, fmt.Sprintf("ws://127.0.0.1:%d/api/v0", port))
+	defer func() { _ = conn.Close() }()
+
+	// Broadcast repeatedly: the first notifications land while the session is
+	// still unsettled and have to survive the wait, and the later ones cover
+	// the settled steady state.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		payload, _ := json.Marshal(map[string]string{"uid": "silent-listener"})
+		for {
+			select {
+			case <-stop:
+				return
+			case st.Notifications <- models.Notification{Method: "tokens.added", Params: payload}:
+				time.Sleep(200 * time.Millisecond)
+			}
+		}
+	}()
+
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(10*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err, "a listener that never sends a frame must still get notifications")
+
+	var obj models.NotificationObject
+	require.NoError(t, json.Unmarshal(msg, &obj))
+	assert.Equal(t, "tokens.added", obj.Method)
+}

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -335,3 +335,51 @@ func TestWSRejectsOverLimitRequests(t *testing.T) {
 		assert.Contains(t, strings.ToLower(err.Error()), "message too big")
 	}
 }
+
+// A plaintext first frame settles the session's transport mode, which is what
+// re-enables notification delivery. Until that frame arrives the mode is
+// unknown, because a paired client may negotiate encryption instead even when
+// the server only treats encryption as optional.
+func TestDecryptIncomingFrame_PlaintextFrameSettlesAuthState(t *testing.T) {
+	t.Parallel()
+
+	before := make(chan webSocketAuthState, 1)
+	after := make(chan webSocketAuthState, 1)
+
+	m := newWebSocketSession()
+	m.HandleConnect(func(s *melody.Session) {
+		// Mirror the real upgrade handler for the optional-encryption case.
+		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+	})
+	m.HandleMessage(func(s *melody.Session, msg []byte) {
+		before <- getWebSocketAuthState(s)
+		_, _, ok := decryptIncomingFrame(s, msg, nil, false, true, "127.0.0.1")
+		require.True(t, ok)
+		after <- getWebSocketAuthState(s)
+		_ = s.Write([]byte("ack"))
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	defer func() { _ = m.Close() }()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(
+		websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":"1","method":"version"}`),
+	))
+	_, _, err = conn.ReadMessage()
+	require.NoError(t, err)
+
+	assert.Equal(t, webSocketAuthUnsettled, <-before,
+		"transport mode is unknown until the client's first frame")
+	assert.Equal(t, webSocketAuthPlaintext, <-after,
+		"a plaintext first frame settles the session as plaintext")
+}

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -345,16 +345,21 @@ func TestDecryptIncomingFrame_PlaintextFrameSettlesAuthState(t *testing.T) {
 
 	before := make(chan webSocketAuthState, 1)
 	after := make(chan webSocketAuthState, 1)
+	accepted := make(chan bool, 1)
 
 	m := newWebSocketSession()
 	m.HandleConnect(func(s *melody.Session) {
 		// Mirror the real upgrade handler for the optional-encryption case.
 		s.Set(melodySessionAuthStateKey, webSocketAuthUnsettled)
+		s.Set(melodySessionNotifQueueKey, &wsNotificationQueue{})
 	})
+	// This runs on melody's readPump goroutine, so it reports back rather than
+	// asserting: a failed require here would stop that goroutine before "ack"
+	// is written and leave the test blocked on ReadMessage instead of failing.
 	m.HandleMessage(func(s *melody.Session, msg []byte) {
 		before <- getWebSocketAuthState(s)
 		_, _, ok := decryptIncomingFrame(s, msg, nil, false, true, "127.0.0.1")
-		require.True(t, ok)
+		accepted <- ok
 		after <- getWebSocketAuthState(s)
 		_ = s.Write([]byte("ack"))
 	})
@@ -375,9 +380,11 @@ func TestDecryptIncomingFrame_PlaintextFrameSettlesAuthState(t *testing.T) {
 	require.NoError(t, conn.WriteMessage(
 		websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":"1","method":"version"}`),
 	))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	_, _, err = conn.ReadMessage()
 	require.NoError(t, err)
 
+	require.True(t, <-accepted, "a plaintext frame is accepted when encryption is optional")
 	assert.Equal(t, webSocketAuthUnsettled, <-before,
 		"transport mode is unknown until the client's first frame")
 	assert.Equal(t, webSocketAuthPlaintext, <-after,

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -254,12 +254,14 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 	case *f.Read:
 		enableRun := client.DisableZapScript(cfg)
 
-		// cleanup after ctrl-c
+		// cleanup after ctrl-c. The channel is never closed: stopping the
+		// delivery is enough, and closing it from here would wake the handler
+		// goroutine into closing it a second time, panicking the process on
+		// every successful read.
 		sigs := make(chan os.Signal, 1)
 		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 		go func() {
 			<-sigs
-			close(sigs)
 			enableRun()
 			os.Exit(0)
 		}()
@@ -271,12 +273,12 @@ func (f *Flags) Post(cfg *config.Instance, _ platforms.Platform) {
 		if err != nil {
 			logClientCommandError(err, "error waiting for notification")
 			_, _ = fmt.Fprintf(os.Stderr, "Error waiting for notification: %v\n", err)
-			close(sigs)
+			signal.Stop(sigs)
 			enableRun()
 			os.Exit(1)
 		}
 
-		close(sigs)
+		signal.Stop(sigs)
 		enableRun()
 		_, _ = fmt.Println(resp)
 		os.Exit(0)

--- a/pkg/database/scraper/gamelistxml/scraper.go
+++ b/pkg/database/scraper/gamelistxml/scraper.go
@@ -1977,18 +1977,38 @@ func companionSlugMediaType(systemID string) slugs.MediaType {
 
 func isASCIIDigit(b byte) bool { return b >= '0' && b <= '9' }
 
+// stripASCIIDigits removes every ASCII digit from a slug.
+func stripASCIIDigits(slug string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return -1
+		}
+		return r
+	}, slug)
+}
+
 // companionParentNameScore rates how consistent a parent's display name is with a child
 // slug stem. A ZaparooCompanion gamelist can erroneously list one slug under multiple
 // parents (e.g. "phantasystar4" under both "Phantasy Star 4" and "Phantasy Star 3"); the
-// score picks the parent whose name actually matches the slug. 2 = exact slug match, 1 =
-// one slug extends the other at a non-digit boundary (a subtitle or hack suffix), 0 = no
-// relation. The non-digit boundary stops "phantasystar1" from matching "phantasystar12".
+// score picks the parent whose name actually matches the slug. 3 = exact slug match, 2 =
+// the parent slug is the child slug with a series number added, 1 = one slug extends the
+// other at a non-digit boundary (a subtitle or hack suffix), 0 = no relation. The
+// non-digit boundary stops "phantasystar1" from matching "phantasystar12".
+//
+// Tier 2 exists because a ROM filename often omits the series number the canonical name
+// carries: "Crash Bandicoot - Warped" (the US title) against parent "Crash Bandicoot 3 -
+// Warped". Without it the true parent scores 0 while unrelated parent "Crash Bandicoot"
+// scores 1 on the prefix rule and wins outright. Digits are only stripped from the parent
+// side, never the child, because a number the child carries and the parent lacks means
+// they are different entries in a series ("crashbandicoot2" is not "Crash Bandicoot").
 func companionParentNameScore(mediaType slugs.MediaType, childSlug, parentName string) int {
 	parentSlug := slugs.Slugify(mediaType, parentName)
 	switch {
 	case parentSlug == "" || childSlug == "":
 		return 0
 	case parentSlug == childSlug:
+		return 3
+	case stripASCIIDigits(parentSlug) == childSlug:
 		return 2
 	case strings.HasPrefix(parentSlug, childSlug) && !isASCIIDigit(parentSlug[len(childSlug)]):
 		return 1
@@ -2005,8 +2025,8 @@ func companionParentNameScore(mediaType slugs.MediaType, childSlug, parentName s
 // child for that slug is dropped rather than risk writing the wrong parent's metadata onto a
 // title. Children matched by real path/filename, slugs claimed by a single parent, and
 // ties between exactly-named parents are left untouched (the latter preserves the prior
-// first-wins behavior, since equally-named parents carry equivalent metadata). Ties among
-// prefix-only matches are dropped, because differently-named parents do not share metadata.
+// first-wins behavior, since equally-named parents carry equivalent metadata). Ties below
+// an exact match are dropped, because differently-named parents do not share metadata.
 func resolveCompanionSlugConflicts(
 	systemID string,
 	parents []companionParent,
@@ -2064,13 +2084,14 @@ func resolveCompanionSlugConflicts(
 		switch {
 		case winnerCount == 1:
 			conflicts[stem] = resolution{winner: winner}
-		case bestScore == 1:
-			// Tie among prefix-only matches: the parents are differently named (e.g.
-			// "Mega" vs "Megaman X" both weakly matching "megaman"), so their metadata is
+		case bestScore < 3:
+			// Tie below an exact name match: the parents are differently named (e.g.
+			// "Mega" vs "Megaman X" both weakly matching "megaman", or "Final Fantasy 4"
+			// vs "Final Fantasy 6" both reducing to "finalfantasy"), so their metadata is
 			// not equivalent. Drop rather than risk writing the wrong parent's metadata.
 			conflicts[stem] = resolution{drop: true}
 		}
-		// winnerCount > 1 && bestScore == 2: tie among exact-name matches; leave unmanaged
+		// winnerCount > 1 && bestScore == 3: tie among exact-name matches; leave unmanaged
 		// (equally-named parents carry equivalent metadata, preserving first-wins behavior).
 	}
 	if len(conflicts) == 0 {

--- a/pkg/database/scraper/gamelistxml/scraper_test.go
+++ b/pkg/database/scraper/gamelistxml/scraper_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/container"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/scraper"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/slugs"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/tags"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms/shared/esapi"
@@ -2906,6 +2907,77 @@ func TestResolveCompanionSlugConflicts(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, nonSlug, "non-slug child untouched")
+}
+
+// A ZaparooCompanion PSX gamelist lists "crashbandicootwarped.slug" under both
+// "Crash Bandicoot" (19282) and the correct "Crash Bandicoot 3 - Warped" (19262),
+// because the US title omits the series number. The wrong parent used to win on a
+// prefix match while the correct one scored 0, so Crash 3 inherited Crash 1's box
+// art and description.
+func TestResolveCompanionSlugConflicts_SeriesNumberOmittedFromChild(t *testing.T) {
+	t.Parallel()
+	parents := []companionParent{
+		{GameID: "19282", Game: esapi.Game{Name: "Crash Bandicoot"}},
+		{GameID: "19262", Game: esapi.Game{Name: "Crash Bandicoot 3 - Warped"}},
+		{GameID: "19270", Game: esapi.Game{Name: "Crash Bandicoot 2 - Cortex Strikes Back"}},
+	}
+	child := func(stem, parent string) companionChild {
+		return companionChild{ResolvedPath: filepath.Join(t.TempDir(), stem+".slug"), ParentGameID: parent}
+	}
+	children := []companionChild{
+		child("crashbandicootwarped", "19282"),
+		child("crashbandicootwarped", "19262"),
+		// The same gamelist also lists "crashbandicoot2.slug" under both 19282 and
+		// 19270; that one already resolved correctly on a prefix match and must stay
+		// correct.
+		child("crashbandicoot2", "19282"),
+		child("crashbandicoot2", "19270"),
+	}
+
+	var stats companionStats
+	got := resolveCompanionSlugConflicts("PSX", parents, children, &stats)
+
+	parentFor := func(stem string) []string {
+		var ids []string
+		for _, c := range got {
+			if s, ok := companionSlugStem(c.ResolvedPath); ok && s == stem {
+				ids = append(ids, c.ParentGameID)
+			}
+		}
+		return ids
+	}
+	assert.Equal(t, []string{"19262"}, parentFor("crashbandicootwarped"),
+		"parent carrying the series number wins over an unrelated prefix match")
+	assert.Equal(t, []string{"19270"}, parentFor("crashbandicoot2"),
+		"a number the child carries must not be stripped away to match a shorter parent")
+}
+
+func TestCompanionParentNameScore(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		childSlug  string
+		parentName string
+		want       int
+	}{
+		{"exact match", "crashbandicoot", "Crash Bandicoot", 3},
+		{"parent adds series number", "crashbandicootwarped", "Crash Bandicoot 3 - Warped", 2},
+		{"parent adds subtitle", "crashbandicoot2", "Crash Bandicoot 2 - Cortex Strikes Back", 1},
+		{"child adds subtitle", "megamanx", "Megaman", 1},
+		{"child adds series number", "crashbandicoot2", "Crash Bandicoot", 0},
+		{"unrelated", "crashbandicootwarped", "Some Unrelated Game", 0},
+		{"empty child", "", "Crash Bandicoot", 0},
+		{"empty parent", "crashbandicoot", "", 0},
+		// Digits are never stripped from the child, so distinct series entries stay
+		// distinct rather than both collapsing onto a numberless parent.
+		{"different series entries", "finalfantasy4", "Final Fantasy 6", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := companionParentNameScore(slugs.MediaTypeGame, tc.childSlug, tc.parentName)
+			assert.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func TestProcessCompanionEntries_RewritesAlreadyScraped(t *testing.T) {

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -69,6 +69,7 @@ type Tracker struct {
 	db               *database.Database
 	arcadeResolved   map[string]arcadeResolution
 	setActiveGame    func(string) error
+	coreNameFile     string
 	selection        selectionFiles
 	ActiveSystemName string
 	ActiveSystem     string
@@ -171,8 +172,18 @@ func NewTracker(
 		setActiveMedia:   setActiveMedia,
 		readActiveGame:   activegame.GetActiveGame,
 		setActiveGame:    activegame.SetActiveGame,
+		coreNameFile:     misterconfig.CoreNameFile,
 		selection:        misterSelectionFiles(),
 	}, nil
+}
+
+// coreNamePath is the CORENAME file this tracker reads. Tests override it;
+// zero-value trackers fall back to MiSTer's real path.
+func (tr *Tracker) coreNamePath() string {
+	if tr.coreNameFile != "" {
+		return tr.coreNameFile
+	}
+	return misterconfig.CoreNameFile
 }
 
 func (tr *Tracker) activeGame() (string, error) {
@@ -291,7 +302,7 @@ func (tr *Tracker) LoadCore() {
 	tr.mu.Lock()
 	defer tr.mu.Unlock()
 
-	data, err := os.ReadFile(misterconfig.CoreNameFile)
+	data, err := os.ReadFile(tr.coreNamePath())
 	if err != nil {
 		// CORENAME is absent until MiSTer launches a core (e.g. right after boot).
 		// That's expected; other read errors (permissions, I/O) stay at Error.
@@ -304,6 +315,15 @@ func (tr *Tracker) LoadCore() {
 	}
 
 	coreName := strings.TrimSpace(string(data))
+
+	// MiSTer truncates CORENAME before rewriting it, so inotify delivers a write
+	// event while the file is still empty. An empty read is never a real core
+	// change: acting on it retires the active media milliseconds before the new
+	// core name arrives, splitting one play session in two.
+	if coreName == "" {
+		log.Debug().Msg("core name file is empty, ignoring transient write")
+		return
+	}
 
 	if coreName == misterconfig.MenuCore {
 		err := tr.setActiveGamePath("")
@@ -352,10 +372,14 @@ func (tr *Tracker) LoadCore() {
 			tr.ActiveGamePath = "" // no way to find mra path from CORENAME
 		}
 
-		// Check if this arcade game was recently launched via card scan
-		// If so, suppress duplicate notification
+		// Check if this arcade game was recently launched via card scan. Consume
+		// the cache entry either way, but only suppress the notification while
+		// that launch's media is still published. If the media has already been
+		// retired there is nothing left to duplicate, and this is the only
+		// chance to restore it.
 		if arcadePl, ok := tr.pl.(platformWithArcadeCache); ok {
-			if arcadePl.CheckAndClearArcadeCardLaunch(result.CoreName) {
+			cardLaunch := arcadePl.CheckAndClearArcadeCardLaunch(result.CoreName)
+			if cardLaunch && tr.arcadeMediaPublished(activeGamePath) {
 				log.Debug().
 					Str("setname", result.CoreName).
 					Msg("skipping duplicate arcade notification (launched via card)")
@@ -366,11 +390,8 @@ func (tr *Tracker) LoadCore() {
 		// Don't overwrite a more authoritative observation of the same game:
 		// a Zaparoo launch or a resolved FILESELECT event may already have
 		// published this canonical .mra path before CORENAME caught up.
-		if mraPath != "" {
-			if active := tr.activeMedia(); active != nil &&
-				active.SystemID == ArcadeSystem && active.Path == mraPath {
-				return
-			}
+		if tr.arcadeMediaPublished(activeGamePath) {
+			return
 		}
 
 		tr.setActiveMedia(models.NewActiveMedia(
@@ -467,6 +488,16 @@ func (tr *Tracker) ClearActiveGame() error {
 	err := tr.setActiveGamePath("")
 	tr.stopGame()
 	return err
+}
+
+// arcadeMediaPublished reports whether the active media already covers this
+// arcade launch, so a redundant publish can be skipped safely.
+func (tr *Tracker) arcadeMediaPublished(path string) bool {
+	if path == "" {
+		return false
+	}
+	active := tr.activeMedia()
+	return active != nil && active.SystemID == ArcadeSystem && active.Path == path
 }
 
 func (tr *Tracker) stopGame() {

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -1018,6 +1018,43 @@ func dispatchTrackerFileLoad(settled <-chan time.Time, load func()) {
 	}()
 }
 
+// trackerFileLoad picks the load function for a watched tracker file, and
+// reports whether its write has to settle before the file is read.
+//
+// Settling matters for every file that is rewritten by truncating first: the
+// inotify event arrives while the file is still empty, and an empty read is
+// not a real state change. ACTIVEGAME is written that way by SetActiveGame
+// itself, and reading the truncated value retires the media the launch just
+// published, splitting one play session into a zero-second entry and the
+// tracker's later restore of it. CORENAME needs no delay because LoadCore
+// filters the empty read itself.
+func (tr *Tracker) trackerFileLoad(name string) (load func(), settle bool) {
+	switch {
+	case name == misterconfig.CoreNameFile:
+		return tr.LoadCore, false
+	case name == misterconfig.ActiveGameFile:
+		return tr.loadGame, true
+	case name == misterconfig.FileSelectFile:
+		// MakeFile truncates before writing the new status. Wait for
+		// FILESELECT, FULLPATH, and CURRENTPATH to settle as one event.
+		return tr.loadFileSelection, true
+	case trackerRecentFileChanged(name):
+		// MiSTer truncates and rewrites binary recent files. Let the write
+		// settle before reading the first complete record.
+		return func() {
+			recentErr := tr.loadRecent(name)
+			if recentErr != nil {
+				if errors.Is(recentErr, os.ErrNotExist) {
+					log.Debug().Err(recentErr).Msg("recent file was replaced before it could be read")
+				} else {
+					log.Error().Msgf("error loading recent file: %s", recentErr)
+				}
+			}
+		}, true
+	}
+	return nil, false
+}
+
 // StartFileWatch Start thread for monitoring changes to all files relating to core/game launches.
 func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 	log.Info().Msg("starting file watcher")
@@ -1038,31 +1075,14 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 				if !trackerFileChanged(event.Op) {
 					continue
 				}
+				load, settle := tr.trackerFileLoad(event.Name)
 				switch {
-				case event.Name == misterconfig.CoreNameFile:
-					tr.LoadCore()
-				case event.Name == misterconfig.ActiveGameFile:
-					tr.loadGame()
-				case event.Name == misterconfig.FileSelectFile:
-					// MakeFile truncates before writing the new status. Wait for
-					// FILESELECT, FULLPATH, and CURRENTPATH to settle as one event
-					// without blocking delivery of later watcher events.
-					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), tr.loadFileSelection)
-				case trackerRecentFileChanged(event.Name):
-					// MiSTer truncates and rewrites binary recent files. Let the
-					// write settle before reading the first complete record without
-					// blocking delivery of later watcher events.
-					filename := event.Name
-					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), func() {
-						recentErr := tr.loadRecent(filename)
-						if recentErr != nil {
-							if errors.Is(recentErr, os.ErrNotExist) {
-								log.Debug().Err(recentErr).Msg("recent file was replaced before it could be read")
-							} else {
-								log.Error().Msgf("error loading recent file: %s", recentErr)
-							}
-						}
-					})
+				case load == nil:
+					continue
+				case settle:
+					dispatchTrackerFileLoad(time.After(trackerFileSettleDelay), load)
+				default:
+					load()
 				}
 			case watchErr, ok := <-watcher.Errors:
 				if !ok {

--- a/pkg/platforms/mister/tracker/tracker.go
+++ b/pkg/platforms/mister/tracker/tracker.go
@@ -1030,7 +1030,7 @@ func dispatchTrackerFileLoad(settled <-chan time.Time, load func()) {
 // filters the empty read itself.
 func (tr *Tracker) trackerFileLoad(name string) (load func(), settle bool) {
 	switch {
-	case name == misterconfig.CoreNameFile:
+	case name == tr.coreNamePath():
 		return tr.LoadCore, false
 	case name == misterconfig.ActiveGameFile:
 		return tr.loadGame, true
@@ -1093,19 +1093,20 @@ func StartFileWatch(tr *Tracker) (*fsnotify.Watcher, error) {
 		}
 	}()
 
-	if _, statErr := os.Stat(misterconfig.CoreNameFile); os.IsNotExist(statErr) {
+	coreNameFile := tr.coreNamePath()
+	if _, statErr := os.Stat(coreNameFile); os.IsNotExist(statErr) {
 		//nolint:gosec // MiSTer system file, needs to be readable by other apps
-		writeErr := os.WriteFile(misterconfig.CoreNameFile, []byte(""), 0o644)
+		writeErr := os.WriteFile(coreNameFile, []byte(""), 0o644)
 		if writeErr != nil {
 			return nil, fmt.Errorf("failed to write core name file: %w", writeErr)
 		}
-		log.Info().Msgf("created core name file: %s", misterconfig.CoreNameFile)
+		log.Info().Msgf("created core name file: %s", coreNameFile)
 	}
 
-	log.Debug().Msgf("adding watcher for core name file: %s", misterconfig.CoreNameFile)
-	err = watcher.Add(misterconfig.CoreNameFile)
+	log.Debug().Msgf("adding watcher for core name file: %s", coreNameFile)
+	err = watcher.Add(coreNameFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to watch core name file (%s): %w", misterconfig.CoreNameFile, err)
+		return nil, fmt.Errorf("failed to watch core name file (%s): %w", coreNameFile, err)
 	}
 
 	if _, statErr := os.Stat(misterconfig.CoreConfigFolder); os.IsNotExist(statErr) {

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -818,3 +818,104 @@ func TestLoadFileSelection(t *testing.T) {
 		assert.Equal(t, gamePath, seen)
 	})
 }
+
+// arcadeCachePlatform implements the optional platformWithArcadeCache interface
+// so LoadCore's card-launch suppression can be exercised.
+type arcadeCachePlatform struct {
+	*mocks.MockPlatform
+	setname string
+}
+
+func (p *arcadeCachePlatform) CheckAndClearArcadeCardLaunch(setname string) bool {
+	if p.setname != "" && p.setname == setname {
+		p.setname = ""
+		return true
+	}
+	return false
+}
+
+// MiSTer truncates CORENAME before rewriting it, so inotify delivers a write
+// event while the file is still empty. Acting on that empty read retired the
+// active media a moment before the real core name arrived.
+func TestLoadCoreIgnoresEmptyCoreNameFile(t *testing.T) {
+	t.Parallel()
+
+	coreFile := filepath.Join(t.TempDir(), "CORENAME")
+	require.NoError(t, os.WriteFile(coreFile, []byte("  \n"), 0o600))
+
+	published := models.NewActiveMedia(ArcadeSystem, ArcadeSystem, "esprade.mra", "ESP Ra.De.", "Arcade")
+	tr := &Tracker{
+		coreNameFile:   coreFile,
+		ActiveCore:     misterconfig.MenuCore,
+		activeMedia:    func() *models.ActiveMedia { return published },
+		setActiveMedia: func(media *models.ActiveMedia) { published = media },
+		setActiveGame: func(string) error {
+			t.Error("empty CORENAME must not touch the active game file")
+			return nil
+		},
+	}
+
+	tr.LoadCore()
+
+	assert.NotNil(t, published, "empty CORENAME must not retire active media")
+	assert.Equal(t, misterconfig.MenuCore, tr.ActiveCore, "empty read must not become the active core")
+}
+
+// The card-launch cache suppresses the duplicate notification that follows a
+// Zaparoo-initiated arcade launch. Once the media has been retired there is
+// nothing left to duplicate, so CORENAME is the only chance to restore it.
+func TestLoadCoreArcadeCardLaunchSuppression(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		existing    *models.ActiveMedia
+		name        string
+		wantPublish bool
+	}{
+		{
+			name:        "restores media retired before the core name arrived",
+			existing:    nil,
+			wantPublish: true,
+		},
+		{
+			name: "still suppresses the duplicate while media is live",
+			existing: models.NewActiveMedia(
+				ArcadeSystem, ArcadeSystem, "esprade", "ESP Ra.De.", "Arcade",
+			),
+			wantPublish: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			coreFile := filepath.Join(t.TempDir(), "CORENAME")
+			require.NoError(t, os.WriteFile(coreFile, []byte("esprade"), 0o600))
+
+			published := tt.existing
+			var publishCalled bool
+			tr := &Tracker{
+				pl:           &arcadeCachePlatform{MockPlatform: mocks.NewMockPlatform(), setname: "esprade"},
+				coreNameFile: coreFile,
+				NameMap: []NameMapping{
+					{CoreName: "esprade", System: ArcadeSystem, ArcadeName: "ESP Ra.De."},
+				},
+				activeMedia: func() *models.ActiveMedia { return published },
+				setActiveMedia: func(media *models.ActiveMedia) {
+					publishCalled = true
+					published = media
+				},
+				setActiveGame: func(string) error { return nil },
+			}
+
+			tr.LoadCore()
+
+			assert.Equal(t, tt.wantPublish, publishCalled)
+			if tt.wantPublish {
+				require.NotNil(t, published)
+				assert.Equal(t, ArcadeSystem, published.SystemID)
+				assert.Equal(t, "ESP Ra.De.", published.Name)
+			}
+		})
+	}
+}

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -930,6 +930,7 @@ func TestTrackerFileLoadSettles(t *testing.T) {
 	tr := &Tracker{}
 
 	tests := []struct {
+		tracker    *Tracker
 		name       string
 		file       string
 		wantLoad   bool
@@ -944,13 +945,30 @@ func TestTrackerFileLoadSettles(t *testing.T) {
 			wantSettle: true,
 		},
 		{name: "core name is read immediately", file: misterconfig.CoreNameFile, wantLoad: true, wantSettle: false},
+		{
+			name:       "core name override is routed, not the real path",
+			tracker:    &Tracker{coreNameFile: "/tmp/zaparoo-test-corename"},
+			file:       "/tmp/zaparoo-test-corename",
+			wantLoad:   true,
+			wantSettle: false,
+		},
+		{
+			name:     "an overridden tracker ignores the real core name file",
+			tracker:  &Tracker{coreNameFile: "/tmp/zaparoo-test-corename"},
+			file:     misterconfig.CoreNameFile,
+			wantLoad: false,
+		},
 		{name: "unknown file has no loader", file: "/tmp/not-a-tracker-file", wantLoad: false, wantSettle: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			load, settle := tr.trackerFileLoad(tt.file)
+			target := tr
+			if tt.tracker != nil {
+				target = tt.tracker
+			}
+			load, settle := target.trackerFileLoad(tt.file)
 			assert.Equal(t, tt.wantLoad, load != nil)
 			assert.Equal(t, tt.wantSettle, settle)
 		})

--- a/pkg/platforms/mister/tracker/tracker_test.go
+++ b/pkg/platforms/mister/tracker/tracker_test.go
@@ -919,3 +919,40 @@ func TestLoadCoreArcadeCardLaunchSuppression(t *testing.T) {
 		})
 	}
 }
+
+// Every tracker file that is rewritten by truncating first has to settle
+// before it is read, or the handler acts on the empty intermediate state.
+// ACTIVEGAME is the one that bites: SetActiveGame truncates it, and reading
+// that empty value retires the media the launch just published.
+func TestTrackerFileLoadSettles(t *testing.T) {
+	t.Parallel()
+
+	tr := &Tracker{}
+
+	tests := []struct {
+		name       string
+		file       string
+		wantLoad   bool
+		wantSettle bool
+	}{
+		{name: "active game settles", file: misterconfig.ActiveGameFile, wantLoad: true, wantSettle: true},
+		{name: "file select settles", file: misterconfig.FileSelectFile, wantLoad: true, wantSettle: true},
+		{
+			name:       "recent file settles",
+			file:       filepath.Join(misterconfig.CoreConfigFolder, "GBC_recent_0.cfg"),
+			wantLoad:   true,
+			wantSettle: true,
+		},
+		{name: "core name is read immediately", file: misterconfig.CoreNameFile, wantLoad: true, wantSettle: false},
+		{name: "unknown file has no loader", file: "/tmp/not-a-tracker-file", wantLoad: false, wantSettle: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			load, settle := tr.trackerFileLoad(tt.file)
+			assert.Equal(t, tt.wantLoad, load != nil)
+			assert.Equal(t, tt.wantSettle, settle)
+		})
+	}
+}


### PR DESCRIPTION
Three unrelated bugs found while investigating a report that arcade games on MiSTer register as closing immediately, and that some PlayStation games share box art.

## Arcade play tracking dies on launch

MiSTer truncates `/tmp/CORENAME` before rewriting it, so inotify delivers a write event while the file is still empty. `LoadCore` treated that empty read as a real core change and retired the active media milliseconds before the new core name arrived. On the test device 8 of 19 `core changed` events had an empty `new_core`.

Every platform hit this, but only arcade stayed dead. Once the real core name arrived, the card-launch dedupe at `tracker.go:355` returned early without republishing, because it assumed the launch's media was still live. Non-arcade cores fell through to `loadGameLocked` and recovered, which is why only arcade was reported.

`LoadCore` now ignores an empty read, and the dedupe suppresses only while media for that launch is still published. The CORENAME path moves onto `Tracker` so `LoadCore` is testable without touching the real `/tmp/CORENAME`, following the existing `selection` and `setActiveGame` injection points.

Introduced by #1364, which added the `coreMatchesSystem` gate and the `stopGame` fallback. `mistex` shares this tracker.

## Companion artwork lands on the wrong game

A ZaparooCompanion gamelist lists loose aliases under each parent, so one slug is often claimed by several. PSX lists `crashbandicootwarped.slug` under both `Crash Bandicoot` (19282) and the correct `Crash Bandicoot 3 - Warped` (19262), because the US title omits the 3.

`companionParentNameScore` gave the wrong parent 1 on the prefix rule while the correct one scored 0, so it won outright as the unique best. Crash 3 inherited Crash 1's box art, description and release year.

Adds a tier between exact and prefix: the parent slug equals the child slug with digit runs inserted. Digits are stripped from the parent side only, because a number the child carries and the parent lacks means they are different entries in a series — that is what keeps `crashbandicoot2.slug` resolving to Crash 2 rather than Crash 1, which it does today via a prefix match. Ties now drop below an exact match, so two parents reducing to the same digit-stripped slug are not guessed between.

The bundle's alias under 19282 is also wrong at the source, and 19282 likewise claims `crashbandicoottrilogy`, `crashbandicoot123` and `crashbandicootcollection123`. That is worth fixing in whatever generates the entries, but the resolver exists to tolerate noisy aliases and users already have the file on disk.

Note this only affects future scrapes; existing rows need a forced re-scrape.

## Plaintext notifications leak to sessions that upgrade

An encryption setting of `false` means encryption is optional, not absent, so a paired client can still negotiate an encrypted session on its first frame. The WebSocket upgrade decided the session's transport mode from that setting alone and started it as plaintext, but the mode is not known until the client's first frame arrives.

Notifications broadcast in that window went out in the clear to a client that had already committed to encrypted mode, desyncing it. It only surfaced while notifications were actively firing: every `media.scrape.status` poll during a scrape failed, since each poll is a fresh connection and progress notifications broadcast continuously.

Sessions now start unsettled and settle to plaintext on a plaintext first frame. Required encryption still starts pending so the authentication deadline arms; unsettled does not arm it, because staying quiet is legitimate for a client that is never required to authenticate. `writeNotificationFrame` needed no change — it already drops anything that is not settled plaintext.

One behaviour change beyond the bug: a notification broadcast before a client's first frame is now dropped for that client rather than sent in the clear. Required-encryption mode already behaved this way, so any client that works there already sends a frame first, but a listener that connects and stays silent would miss notifications until it speaks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket notification delivery during optional encryption negotiation.
  * Improved companion game matching when series numbers are omitted.
  * Improved MiSTer core tracking by handling transient reads, settling file updates, and preventing duplicate arcade notifications.
  * Improved CLI signal handling to prevent duplicate shutdown processing.

* **Tests**
  * Added coverage for WebSocket notifications, companion matching, MiSTer tracking, and arcade notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->