### PR TITLE
fix(api): serialize NoContent as null

### DIFF
--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -2466,7 +2466,7 @@ An object:
 
 #### Result
 
-Returns an empty object `{}` on success.
+Returns `null` on success.
 
 #### Example
 
@@ -2489,7 +2489,7 @@ Returns an empty object `{}` on success.
 {
   "jsonrpc": "2.0",
   "id": "c3d4e5f6-7a5d-11ef-9c7b-020304050607",
-  "result": {}
+  "result": null
 }
 ```
 
@@ -3353,7 +3353,7 @@ Delete a local backup ZIP.
 
 #### Result
 
-Returns an empty object `{}` on success.
+Returns `null` on success.
 
 #### Example
 
@@ -3370,7 +3370,7 @@ Returns an empty object `{}` on success.
 {
   "jsonrpc": "2.0",
   "id": "backup-delete-1",
-  "result": {}
+  "result": null
 }
 ```
 
@@ -4039,7 +4039,7 @@ Delete a profile. Local UIs may gate this action with `profiles.verify`. The fin
 
 #### Result
 
-Null.
+Returns `null` on success.
 
 ### profiles.active
 
@@ -4195,7 +4195,7 @@ An object:
 
 #### Result
 
-Returns an empty object `{}` on success.
+Returns `null` on success.
 
 #### Example
 
@@ -4223,7 +4223,7 @@ Returns an empty object `{}` on success.
 {
   "jsonrpc": "2.0",
   "id": "562c0b60-7ae8-11ef-87d7-020304050607",
-  "result": {}
+  "result": null
 }
 ```
 
@@ -4987,7 +4987,7 @@ Revoke a paired client. Existing encrypted sessions remain active until they dis
 
 #### Result
 
-Returns an empty object `{}` on success.
+Returns `null` on success.
 
 #### Example
 
@@ -5004,7 +5004,7 @@ Returns an empty object `{}` on success.
 {
   "jsonrpc": "2.0",
   "id": "clients-delete-1",
-  "result": {}
+  "result": null
 }
 ```
 
@@ -5065,7 +5065,7 @@ None.
 
 #### Result
 
-Returns an empty object `{}` on success.
+Returns `null` on success.
 
 #### Example
 
@@ -5081,7 +5081,7 @@ Returns an empty object `{}` on success.
 {
   "jsonrpc": "2.0",
   "id": "clients-pair-cancel-1",
-  "result": {}
+  "result": null
 }
 ```
 

--- a/pkg/api/methods/media.go
+++ b/pkg/api/methods/media.go
@@ -955,8 +955,11 @@ func HandleGenerateMedia(env requests.RequestEnv) (any, error) {
 		env.Database,
 		env.IndexPauser,
 	)
+	if err != nil {
+		return nil, err
+	}
 
-	return nil, err
+	return NoContent{}, nil
 }
 
 func searchResultSystem(

--- a/pkg/api/methods/media_cancel_test.go
+++ b/pkg/api/methods/media_cancel_test.go
@@ -359,7 +359,7 @@ func TestMediaIndexingCancellation_Integration(t *testing.T) {
 	// Start media generation
 	result, err := HandleGenerateMedia(generateEnv)
 	require.NoError(t, err)
-	assert.Nil(t, result) // HandleGenerateMedia returns nil on success
+	assert.Equal(t, NoContent{}, result) // HandleGenerateMedia reports void success
 
 	// Poll to see if we can catch the process running
 	timeout := time.After(1 * time.Second)

--- a/pkg/api/methods/media_rebuild_test.go
+++ b/pkg/api/methods/media_rebuild_test.go
@@ -110,6 +110,24 @@ func TestHandleGenerateMedia_RejectsRebuildWithSystemsFilter(t *testing.T) {
 	assert.False(t, IsIndexing(), "a rejected request must not claim the indexing slot")
 }
 
+func TestHandleGenerateMedia_GenerationFailureReturnsNoResult(t *testing.T) {
+	// Not parallel: shares the global statusInstance.
+	ClearIndexingStatus()
+	// Occupy the indexing slot so starting generation fails after every
+	// param check has passed.
+	SetIndexingForTest()
+	t.Cleanup(ClearIndexingStatus)
+
+	mockMediaDB := helpers.NewMockMediaDBI()
+	env := newRebuildTestEnv(t, mockMediaDB, "")
+
+	result, err := HandleGenerateMedia(env)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "indexing already in progress")
+	assert.Nil(t, result, "a failed request must carry only the error, never a void success")
+	mockMediaDB.AssertNotCalled(t, "Recreate", mock.Anything)
+}
+
 func TestHandleGenerateMedia_RebuildRecreatesDatabaseBeforeIndexing(t *testing.T) {
 	// Not parallel: shares the global statusInstance.
 	ClearIndexingStatus()

--- a/pkg/api/methods/media_scrape.go
+++ b/pkg/api/methods/media_scrape.go
@@ -648,7 +648,7 @@ func startMediaScrapeWithRunID(env *requests.RequestEnv, params models.MediaScra
 		log.Info().Str("scraper", scraperID).Str("status", finalStatus).Msg("scraper run complete")
 	}()
 
-	return nil, nil //nolint:nilnil // API handler returns nil result and nil error for async start
+	return NoContent{}, nil
 }
 
 // checkpointScrapingWAL flushes the WAL after a scraper run. It returns true when the

--- a/pkg/api/methods/media_scrape_test.go
+++ b/pkg/api/methods/media_scrape_test.go
@@ -247,7 +247,7 @@ func TestHandleMediaScrape_HappyPath(t *testing.T) {
 
 	result, err := HandleMediaScrape(env)
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, NoContent{}, result)
 
 	// Collect notifications: expect at minimum the initial "scraping:true" and
 	// the terminal "done:true" notifications.
@@ -444,7 +444,7 @@ func TestHandleMediaScrape_WipesThumbCacheOnCompletion(t *testing.T) {
 
 			result, err := HandleMediaScrape(env)
 			require.NoError(t, err)
-			assert.Nil(t, result)
+			assert.Equal(t, NoContent{}, result)
 
 			var gotDone bool
 			timeout := time.After(2 * time.Second)
@@ -554,7 +554,7 @@ func TestHandleMediaScrape_ResumesStalePauseForBackgroundMedia(t *testing.T) {
 
 	result, err := HandleMediaScrape(env)
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, NoContent{}, result)
 	assert.False(t, scraperSawPaused)
 	assert.False(t, pauser.IsPaused())
 
@@ -627,7 +627,7 @@ func TestHandleMediaScrape_FatalUpdateDoesNotSynthesizeDone(t *testing.T) {
 
 	result, err := HandleMediaScrape(env)
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, NoContent{}, result)
 
 	require.Eventually(t, func() bool {
 		return !IsScrapingRunning()
@@ -1217,7 +1217,7 @@ func TestHandleMediaScrape_CachesProgressScrapedCountAndRefreshesDone(t *testing
 
 	result, err := HandleMediaScrape(env)
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, NoContent{}, result)
 
 	var progressCounts []int
 	var doneCount int
@@ -1388,7 +1388,7 @@ func TestHandleMediaScrape_EmitsProgressUpdates(t *testing.T) {
 
 	result, err := HandleMediaScrape(env)
 	require.NoError(t, err)
-	assert.Nil(t, result)
+	assert.Equal(t, NoContent{}, result)
 
 	var gotDone bool
 	var maxProcessed int

--- a/pkg/api/methods/methods_test.go
+++ b/pkg/api/methods/methods_test.go
@@ -864,7 +864,7 @@ func TestHandleGenerateMedia_SystemFiltering(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Nil(t, result)
+			assert.Equal(t, NoContent{}, result)
 
 			// Cancel the background indexing goroutine and wait for it
 			// to finish so it doesn't leak into the next subtest.

--- a/pkg/api/methods/run.go
+++ b/pkg/api/methods/run.go
@@ -50,7 +50,18 @@ import (
 // ErrNotAllowed is returned when a run request is not allowed.
 var ErrNotAllowed = errors.New("not allowed")
 
+// NoContent is the success value for methods that return nothing. It marshals
+// as JSON null so a void method's response carries "result": null, which is
+// what the API docs publish and what these methods sent before this sentinel
+// replaced a bare nil result.
 type NoContent struct{}
+
+// MarshalJSON must keep a value receiver: handlers return NoContent{} as an
+// any, and encoding/json only finds a pointer-receiver marshaller on an
+// addressable value.
+func (NoContent) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
+}
 
 // runParamsForLog returns a copy of run params with any bearer credential in
 // the ZapScript removed, so a profile card run through the API cannot leave

--- a/pkg/api/methods/run_test.go
+++ b/pkg/api/methods/run_test.go
@@ -21,6 +21,7 @@ package methods
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -231,4 +232,44 @@ func TestHandleStopWithoutActiveMedia(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, NoContent{}, value)
 	mockPlatform.AssertExpectations(t)
+}
+
+// TestNoContentMarshalsAsNull pins the wire shape of a void method's result.
+// docs/api/methods.md publishes "result": null for every method that returns
+// nothing, and JSON-RPC 2.0 §5 requires the key to be present on success.
+func TestNoContentMarshalsAsNull(t *testing.T) {
+	t.Parallel()
+
+	direct, err := json.Marshal(NoContent{})
+	require.NoError(t, err)
+	assert.JSONEq(t, "null", string(direct))
+
+	// Handlers return NoContent{} as an any, and encoding/json only finds a
+	// pointer-receiver marshaller on an addressable value. This is the case
+	// the value receiver exists for.
+	boxed, err := json.Marshal(any(NoContent{}))
+	require.NoError(t, err)
+	assert.JSONEq(t, "null", string(boxed))
+}
+
+// TestNoContentResponseObjectCarriesNullResult covers the full response shape.
+// All three send paths (plaintext WebSocket, encrypted WebSocket, HTTP POST)
+// marshal this same struct, so pinning it here covers each of them.
+func TestNoContentResponseObjectCarriesNullResult(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(models.ResponseObject{
+		JSONRPC: "2.0",
+		ID:      models.NewStringID("no-content-1"),
+		Result:  NoContent{},
+	})
+	require.NoError(t, err)
+
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &fields))
+
+	result, ok := fields["result"]
+	require.True(t, ok, "result must be present on success, not omitted")
+	assert.JSONEq(t, "null", string(result))
+	assert.NotContains(t, fields, "error")
 }

--- a/pkg/api/models/models.go
+++ b/pkg/api/models/models.go
@@ -251,6 +251,10 @@ type ErrorObject struct {
 	Code    int    `json:"code"`
 }
 
+// ResponseObject carries a method's successful result. Result has no
+// omitempty because JSON-RPC 2.0 §5 requires the key on success, so a method
+// with nothing to return sends "result": null. Void handlers express that with
+// methods.NoContent, which marshals itself as null.
 type ResponseObject struct {
 	Result  any          `json:"result"`
 	Error   *ErrorObject `json:"error,omitempty"`

--- a/pkg/api/server_post_test.go
+++ b/pkg/api/server_post_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
@@ -255,6 +256,40 @@ func TestHandlePostRequest_ValidRequest(t *testing.T) {
 	assert.Equal(t, int64(1), tracker.started.Load(), "RequestStarted should fire once")
 	assert.Equal(t, tracker.started.Load(), tracker.ended.Load(),
 		"RequestStarted and RequestEnded must balance")
+}
+
+// TestHandlePostRequest_NoContentResultIsNull pins the wire shape of a void
+// method over HTTP POST: "result" present and null, per docs/api/methods.md
+// and JSON-RPC 2.0 §5.
+func TestHandlePostRequest_NoContentResultIsNull(t *testing.T) {
+	t.Parallel()
+
+	handler, methodMap, _ := createTestPostHandler(t)
+
+	err := methodMap.AddMethod("test.nocontent", func(_ requests.RequestEnv) (any, error) {
+		return methods.NoContent{}, nil
+	}, true)
+	require.NoError(t, err)
+
+	reqBody := `{"jsonrpc":"2.0","id":"` + uuid.New().String() + `","method":"test.nocontent"}`
+	//nolint:noctx // test helper, no context needed
+	req := httptest.NewRequest(http.MethodPost, "/api", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Decode into raw messages: a decoded ResponseObject cannot tell a null
+	// result apart from a missing result key, and the key must be present.
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &fields))
+
+	result, ok := fields["result"]
+	require.True(t, ok, "void method must send a result key, not omit it")
+	assert.JSONEq(t, "null", string(result))
+	assert.NotContains(t, fields, "error")
 }
 
 func TestHandlePostRequest_RejectsUnpairedRemoteOnUnknownPlatform(t *testing.T) {

--- a/pkg/api/server_ws_e2e_test.go
+++ b/pkg/api/server_ws_e2e_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/methods"
 	apimiddleware "github.com/ZaparooProject/zaparoo-core/v2/pkg/api/middleware"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models/requests"
@@ -181,6 +182,64 @@ func TestWSInjectsPlaybackManager(t *testing.T) {
 	var resp models.ResponseObject
 	require.NoError(t, json.Unmarshal(msg, &resp))
 	assert.Nil(t, resp.Error)
+}
+
+// TestWSNoContentResultIsNull pins the wire shape of a void method over the
+// plaintext WebSocket path. The encrypted path is not tested separately:
+// sendWSEncryptedResponse builds the identical models.ResponseObject and only
+// then encrypts it, so TestNoContentResponseObjectCarriesNullResult in
+// pkg/api/methods covers it by construction.
+func TestWSNoContentResultIsNull(t *testing.T) {
+	t.Parallel()
+
+	methodMap := NewMethodMap()
+	err := methodMap.AddMethod("test.nocontent", func(_ requests.RequestEnv) (any, error) {
+		return methods.NoContent{}, nil
+	})
+	require.NoError(t, err)
+
+	platform := mocks.NewMockPlatform()
+	platform.SetupBasicMock()
+	cfg, err := helpers.NewTestConfigWithPort(helpers.NewMemoryFS(), t.TempDir(), 0)
+	require.NoError(t, err)
+	st, _ := state.NewState(platform, "test-boot-uuid")
+	t.Cleanup(st.StopService)
+	db := &database.Database{UserDB: helpers.NewMockUserDBI(), MediaDB: helpers.NewMockMediaDBI()}
+	m := newWebSocketSession()
+	m.HandleMessage(handleWSMessage(
+		methodMap, platform, cfg, st, make(chan tokens.Token, 1), make(chan chan error, 1), db,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+	))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api", func(w http.ResponseWriter, r *http.Request) {
+		_ = m.HandleRequest(w, r)
+	})
+	srv := httptest.NewServer(mux)
+	defer func() {
+		_ = m.Close()
+		srv.Close()
+	}()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	conn := dialWS(t, "ws://"+u.Host+"/api")
+	defer func() { _ = conn.Close() }()
+
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage,
+		[]byte(`{"jsonrpc":"2.0","method":"test.nocontent","id":1}`)))
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(2*time.Second)))
+	_, msg, err := conn.ReadMessage()
+	require.NoError(t, err)
+
+	// Decode into raw messages: a decoded ResponseObject cannot tell a null
+	// result apart from a missing result key, and the key must be present.
+	var fields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(msg, &fields))
+
+	result, ok := fields["result"]
+	require.True(t, ok, "void method must send a result key, not omit it")
+	assert.JSONEq(t, "null", string(result))
+	assert.NotContains(t, fields, "error")
 }
 
 // TestWSEncryption_RemotePlaintextRejectedWhenEnabled pins:

--- a/pkg/testing/mocks/api_client.go
+++ b/pkg/testing/mocks/api_client.go
@@ -67,7 +67,7 @@ func (m *MockAPIClient) SetupSettingsError(err error) {
 
 // SetupUpdateSettingsSuccess configures the mock to accept settings updates.
 func (m *MockAPIClient) SetupUpdateSettingsSuccess() {
-	m.On("Call", mock.Anything, models.MethodSettingsUpdate, mock.Anything).Return("{}", nil)
+	m.On("Call", mock.Anything, models.MethodSettingsUpdate, mock.Anything).Return("null", nil)
 }
 
 // SetupUpdateSettingsError configures the mock to return an error on update.
@@ -117,7 +117,7 @@ func (m *MockAPIClient) SetupReadersError(err error) {
 
 // SetupWriteTagSuccess configures the mock to accept write tag operations.
 func (m *MockAPIClient) SetupWriteTagSuccess() {
-	m.On("Call", mock.Anything, models.MethodReadersWrite, mock.Anything).Return("{}", nil)
+	m.On("Call", mock.Anything, models.MethodReadersWrite, mock.Anything).Return("null", nil)
 }
 
 // SetupWriteTagError configures the mock to return an error for write tag.
@@ -127,7 +127,7 @@ func (m *MockAPIClient) SetupWriteTagError(err error) {
 
 // SetupCancelWriteTagSuccess configures the mock to accept cancel write operations.
 func (m *MockAPIClient) SetupCancelWriteTagSuccess() {
-	m.On("Call", mock.Anything, models.MethodReadersWriteCancel, "").Return("{}", nil)
+	m.On("Call", mock.Anything, models.MethodReadersWriteCancel, "").Return("null", nil)
 }
 
 // SetupCancelWriteTagError configures the mock to return an error for cancel write.


### PR DESCRIPTION
- Give `NoContent` a `MarshalJSON` returning `null`, so the 24 void JSON-RPC methods send `"result": null` instead of `"result": {}`. The receiver must stay a value receiver: handlers return `NoContent{}` as an `any`, and `encoding/json` only finds a pointer-receiver marshaller on an addressable value.
- All three send paths marshal the same `models.ResponseObject`, so one marshaller covers plaintext WebSocket, encrypted WebSocket and HTTP POST. No server change needed.
- Switch `media.generate` and `media.scrape` to return `NoContent{}` instead of a literal nil, so void success has one representation and a `nilnil` suppression goes away. Neither changes on the wire — both already sent `null`.
- Correct the five `docs/api/methods.md` entries that described `{}` (`media.control`, `settings.backup.delete`, `mappings.new`, `clients.delete`, `clients.pair.cancel`) and normalise `profiles.delete`'s phrasing. `git blame` puts those five after the regression landed, so they documented the drift rather than the contract. The other 19 entries already said `null`.
- Document on `ResponseObject` why `Result` has no `omitempty`: JSON-RPC 2.0 §5 requires the key on success, so a void method sends `null` rather than omitting it.
- Zaparoo Online is unaffected. `stop` is the only void method in the remote allowlist and it routes through `encodeEmptyResult`, which hard-codes an empty object regardless of what the method returned.
- `zaparoo -api <void-method>` now prints `null` instead of `{}`.

BREAKING CHANGE: 24 void methods change their wire result from `{}` to `null`. For 19 of them this brings the code in line with what the docs have always published, and `null` is what they sent before v2.10.0. The five methods listed above are the only ones whose documented contract changes. No first-party client is affected — the app resolves the result verbatim and ignores it for void methods, and the Rust and Go clients discard it.

Closes #1369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Void JSON-RPC operations now consistently return `"result": null` on success instead of an empty object or missing result.
  - Updated media generation and scraping responses to use the standard empty-result format.
  - Affected operations include media control, profile and client deletion, settings backup deletion, mapping creation, and pairing cancellation.

- **Documentation**
  - Updated API method descriptions and response examples to document `null` success results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->