### PR TITLE
fix(zapscript): resolve **control launchers through the launcher cache

### DIFF
--- a/pkg/api/methods/media_control.go
+++ b/pkg/api/methods/media_control.go
@@ -92,17 +92,12 @@ func HandleMediaControl(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	if err != nil {
 		return nil, fmt.Errorf("control action %q failed: %w", params.Action, err)
 	}
-	if params.Action == platforms.ControlStop {
-		switch {
-		case slot == mediaslot.Background:
-			env.State.SetBackgroundMedia(nil)
-			env.State.SetBackgroundPlaylist(nil)
-		case media.LauncherID == platforms.NativeAudioLauncherID:
-			// Native audio has no OS process, so no platform tracker clears the
-			// primary media on an explicit stop, and the drain callback ignores
-			// non-natural drains.
-			env.State.SetActiveMedia(nil)
-		}
+	// Primary-slot media state is cleared by the launcher's own stop control, so
+	// the ZapScript control command gets the same behaviour. Background state is
+	// handled here because it also has to clear the background playlist.
+	if params.Action == platforms.ControlStop && slot == mediaslot.Background {
+		env.State.SetBackgroundMedia(nil)
+		env.State.SetBackgroundPlaylist(nil)
 	}
 
 	return NoContent{}, nil

--- a/pkg/api/methods/media_control.go
+++ b/pkg/api/methods/media_control.go
@@ -92,9 +92,9 @@ func HandleMediaControl(env requests.RequestEnv) (any, error) { //nolint:gocriti
 	if err != nil {
 		return nil, fmt.Errorf("control action %q failed: %w", params.Action, err)
 	}
-	// Primary-slot media state is cleared by the launcher's own stop control, so
-	// the ZapScript control command gets the same behaviour. Background state is
-	// handled here because it also has to clear the background playlist.
+	// Media state is cleared by the launcher's own stop control, so the ZapScript
+	// control command gets the same behaviour. The background playlist is service
+	// state the launcher cannot reach, so a background stop clears it here.
 	if params.Action == platforms.ControlStop && slot == mediaslot.Background {
 		env.State.SetBackgroundMedia(nil)
 		env.State.SetBackgroundPlaylist(nil)

--- a/pkg/api/methods/media_control_test.go
+++ b/pkg/api/methods/media_control_test.go
@@ -422,7 +422,11 @@ func TestHandleMediaControl_StopBackgroundClearsMedia(t *testing.T) {
 	assert.Nil(t, st.BackgroundMedia(), "stop on background slot must clear background media")
 }
 
-func TestHandleMediaControl_StopPrimaryNativeAudioClearsMedia(t *testing.T) {
+// TestHandleMediaControl_StopPrimaryDelegatesMediaClear checks the handler no longer
+// clears primary media itself. Native audio clears it from inside its own stop control
+// so the ZapScript control command gets the same behaviour; see
+// TestNativeAudioLauncher_StopControlClearsPrimaryMedia.
+func TestHandleMediaControl_StopPrimaryDelegatesMediaClear(t *testing.T) {
 	t.Parallel()
 
 	pl := mocks.NewMockPlatform()
@@ -434,10 +438,54 @@ func TestHandleMediaControl_StopPrimaryNativeAudioClearsMedia(t *testing.T) {
 	st.SetActiveMedia(models.NewActiveMedia("Audio", "Audio", "song.mp3", "Song", platforms.NativeAudioLauncherID))
 	require.NotNil(t, st.ActiveMedia())
 
+	cleared := false
 	cache := &helpers.LauncherCache{}
 	cache.InitializeFromSlice([]platforms.Launcher{
 		{
 			ID: platforms.NativeAudioLauncherID,
+			Controls: map[string]platforms.Control{
+				platforms.ControlStop: {
+					Func: func(_ context.Context, _ *config.Instance, _ platforms.ControlParams) error {
+						cleared = true
+						st.SetActiveMedia(nil)
+						return nil
+					},
+				},
+			},
+		},
+	})
+
+	env := requests.RequestEnv{
+		Context:       context.Background(),
+		State:         st,
+		LauncherCache: cache,
+		Params:        json.RawMessage(`{"action":"stop"}`),
+	}
+
+	_, err := HandleMediaControl(env)
+	require.NoError(t, err)
+	assert.True(t, cleared, "the launcher control must be the one clearing active media")
+	assert.Nil(t, st.ActiveMedia())
+}
+
+// TestHandleMediaControl_StopPrimaryNonAudioKeepsMedia pins that the handler does not
+// clear primary media for launchers whose stop control does not, such as an emulator
+// whose process exit is what ends the session.
+func TestHandleMediaControl_StopPrimaryNonAudioKeepsMedia(t *testing.T) {
+	t.Parallel()
+
+	pl := mocks.NewMockPlatform()
+	pl.SetupBasicMock()
+	st, ns := state.NewState(pl, "test")
+	defer st.StopService()
+	drainNotifications(t, ns)
+
+	st.SetActiveMedia(models.NewActiveMedia("SNES", "SNES", "game.sfc", "Game", "emulator"))
+
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice([]platforms.Launcher{
+		{
+			ID: "emulator",
 			Controls: map[string]platforms.Control{
 				platforms.ControlStop: {
 					Func: func(_ context.Context, _ *config.Instance, _ platforms.ControlParams) error {
@@ -457,7 +505,7 @@ func TestHandleMediaControl_StopPrimaryNativeAudioClearsMedia(t *testing.T) {
 
 	_, err := HandleMediaControl(env)
 	require.NoError(t, err)
-	assert.Nil(t, st.ActiveMedia(), "stop on primary native audio must clear active media")
+	assert.NotNil(t, st.ActiveMedia())
 }
 
 func TestHandleMediaControl_BackgroundSlotNoMedia(t *testing.T) {

--- a/pkg/helpers/launcher_cache.go
+++ b/pkg/helpers/launcher_cache.go
@@ -37,6 +37,7 @@ type LauncherCache struct {
 	availableBySystemID map[string][]platforms.Launcher
 	allLaunchers        []platforms.Launcher
 	launchableSystems   []launchables.VirtualSystem
+	extraLaunchers      []platforms.Launcher
 	mu                  syncutil.RWMutex
 }
 
@@ -46,7 +47,13 @@ var GlobalLauncherCache = &LauncherCache{}
 // Initialize builds the launcher cache from platform launchers.
 // Optional extra launchers (e.g. the native-audio launcher) are appended after
 // deduplication. This should be called once at startup after custom launchers are loaded.
+// The extras are retained so Refresh can reapply them.
 func (lc *LauncherCache) Initialize(pl platforms.Platform, cfg *config.Instance, extra ...platforms.Launcher) {
+	lc.setExtraLaunchers(extra)
+	lc.rebuild(pl, cfg, extra)
+}
+
+func (lc *LauncherCache) rebuild(pl platforms.Platform, cfg *config.Instance, extra []platforms.Launcher) {
 	launchableSystems, launchableMedia := launchables.Available(cfg, pl)
 	all := pl.Launchers(cfg)
 	all = append(all, launchables.LaunchersFor(launchableSystems, launchableMedia)...)
@@ -165,6 +172,18 @@ func (lc *LauncherCache) setLaunchableSystems(systems []launchables.VirtualSyste
 	lc.launchableSystems = append([]launchables.VirtualSystem(nil), systems...)
 }
 
+func (lc *LauncherCache) setExtraLaunchers(extra []platforms.Launcher) {
+	lc.mu.Lock()
+	defer lc.mu.Unlock()
+	lc.extraLaunchers = append([]platforms.Launcher(nil), extra...)
+}
+
+func (lc *LauncherCache) getExtraLaunchers() []platforms.Launcher {
+	lc.mu.RLock()
+	defer lc.mu.RUnlock()
+	return append([]platforms.Launcher(nil), lc.extraLaunchers...)
+}
+
 // GetLauncherByID finds a launcher by its case-insensitive unique ID.
 // Returns nil if no launcher is found or IDs differing only by case make the lookup ambiguous.
 func (lc *LauncherCache) GetLauncherByID(id string) *platforms.Launcher {
@@ -190,12 +209,14 @@ func (lc *LauncherCache) GetLauncherByID(id string) *platforms.Launcher {
 	return match
 }
 
-// Refresh rebuilds the cache with updated launcher data.
+// Refresh rebuilds the cache with updated launcher data, reapplying the extra
+// launchers registered by Initialize. Without that, a refresh would drop every
+// launcher the platform cannot build itself and break control actions for it.
 // This can be called via API to refresh the cache without restarting.
 // During refresh, concurrent GetLaunchableSystems calls may briefly see no
 // virtual systems while the cache is rebuilt; they reappear after initialization.
 func (lc *LauncherCache) Refresh(pl platforms.Platform, cfg *config.Instance) {
-	lc.Initialize(pl, cfg)
+	lc.rebuild(pl, cfg, lc.getExtraLaunchers())
 }
 
 // ToRelativePath converts an absolute media path to a relative path with the

--- a/pkg/helpers/launcher_cache_test.go
+++ b/pkg/helpers/launcher_cache_test.go
@@ -336,3 +336,43 @@ func TestInitialize_ExtraLauncherIsRetrievable(t *testing.T) {
 	require.NotNil(t, found)
 	assert.Equal(t, "Audio", found.SystemID)
 }
+
+// TestRefresh_PreservesExtraLaunchers covers the launchers a platform cannot build
+// itself. A refresh that dropped them would silently break every control action for
+// native audio until the service restarted.
+func TestRefresh_PreservesExtraLaunchers(t *testing.T) {
+	t.Parallel()
+
+	mp := mocks.NewMockPlatform()
+	mp.On("Launchers", mock.Anything).Return([]platforms.Launcher{
+		{ID: "platform-launcher", SystemID: "NES"},
+	})
+
+	extra := platforms.Launcher{ID: "native-audio", SystemID: "Audio"}
+
+	cache := &LauncherCache{}
+	cache.Initialize(mp, nil, extra)
+	require.NotNil(t, cache.GetLauncherByID("native-audio"))
+
+	cache.Refresh(mp, nil)
+
+	found := cache.GetLauncherByID("native-audio")
+	require.NotNil(t, found, "refresh must reapply extra launchers")
+	assert.Equal(t, "Audio", found.SystemID)
+	assert.NotNil(t, cache.GetLauncherByID("platform-launcher"))
+}
+
+func TestInitialize_WithoutExtrasClearsPreviousExtras(t *testing.T) {
+	t.Parallel()
+
+	mp := mocks.NewMockPlatform()
+	mp.On("Launchers", mock.Anything).Return([]platforms.Launcher{})
+
+	cache := &LauncherCache{}
+	cache.Initialize(mp, nil, platforms.Launcher{ID: "native-audio", SystemID: "Audio"})
+	require.NotNil(t, cache.GetLauncherByID("native-audio"))
+
+	// Initialize states the full set of extras; a later call with none replaces them.
+	cache.Initialize(mp, nil)
+	assert.Nil(t, cache.GetLauncherByID("native-audio"))
+}

--- a/pkg/platforms/native_audio.go
+++ b/pkg/platforms/native_audio.go
@@ -64,12 +64,12 @@ func NativeAudioLauncher(
 			return launchNativeAudio(playback, setBackgroundMedia, cfg, path, opts)
 		},
 		Controls: map[string]Control{
-			ControlTogglePause: {Func: nativeAudioControl(playback, nil, ControlTogglePause)},
-			ControlPause:       {Func: nativeAudioControl(playback, nil, ControlPause)},
-			ControlResume:      {Func: nativeAudioControl(playback, nil, ControlResume)},
-			ControlStop:        {Func: nativeAudioControl(playback, stopPrimaryMedia, ControlStop)},
-			ControlFastForward: {Func: nativeAudioControl(playback, nil, ControlFastForward)},
-			ControlRewind:      {Func: nativeAudioControl(playback, nil, ControlRewind)},
+			ControlTogglePause: {Func: nativeAudioControl(playback, nil, nil, ControlTogglePause)},
+			ControlPause:       {Func: nativeAudioControl(playback, nil, nil, ControlPause)},
+			ControlResume:      {Func: nativeAudioControl(playback, nil, nil, ControlResume)},
+			ControlStop:        {Func: nativeAudioControl(playback, setBackgroundMedia, stopPrimaryMedia, ControlStop)},
+			ControlFastForward: {Func: nativeAudioControl(playback, nil, nil, ControlFastForward)},
+			ControlRewind:      {Func: nativeAudioControl(playback, nil, nil, ControlRewind)},
 		},
 	}
 }
@@ -116,6 +116,7 @@ func launchNativeAudio(
 
 func nativeAudioControl(
 	playback audio.PlaybackManager,
+	setBackgroundMedia func(*models.ActiveMedia),
 	stopPrimaryMedia func(ctx context.Context, stop func() error) error,
 	action string,
 ) ControlFunc {
@@ -146,9 +147,18 @@ func nativeAudioControl(
 				}
 				return nil
 			}
-			// The background slot is left to the caller: clearing it also has to
-			// clear the background playlist, which is service state.
-			if slot != mediaslot.Primary || stopPrimaryMedia == nil {
+			if slot == mediaslot.Background {
+				if err := stop(); err != nil {
+					return err
+				}
+				// Launching set the background media, so stopping clears it. The
+				// background playlist is service state and stays with the caller.
+				if setBackgroundMedia != nil {
+					setBackgroundMedia(nil)
+				}
+				return nil
+			}
+			if stopPrimaryMedia == nil {
 				return stop()
 			}
 			return stopPrimaryMedia(ctx, stop)

--- a/pkg/platforms/native_audio.go
+++ b/pkg/platforms/native_audio.go
@@ -40,11 +40,14 @@ import (
 const NativeAudioLauncherID = "native-audio"
 
 // NativeAudioLauncher returns the launcher that plays audio files in-process via the
-// shared malgo output device. Both playback and the background-media state setter are
-// injected so the launcher carries no package-level globals.
+// shared malgo output device. Playback and the media state hooks are injected so the
+// launcher carries no package-level globals. clearPrimaryMedia runs after an explicit
+// stop of the primary slot; native audio has no OS process, so no platform tracker
+// notices the stop and the drain callback only fires for tracks that end on their own.
 func NativeAudioLauncher(
 	playback audio.PlaybackManager,
 	setBackgroundMedia func(*models.ActiveMedia),
+	clearPrimaryMedia func(),
 ) Launcher {
 	return Launcher{
 		ID:       NativeAudioLauncherID,
@@ -60,12 +63,12 @@ func NativeAudioLauncher(
 			return launchNativeAudio(playback, setBackgroundMedia, cfg, path, opts)
 		},
 		Controls: map[string]Control{
-			ControlTogglePause: {Func: nativeAudioControl(playback, ControlTogglePause)},
-			ControlPause:       {Func: nativeAudioControl(playback, ControlPause)},
-			ControlResume:      {Func: nativeAudioControl(playback, ControlResume)},
-			ControlStop:        {Func: nativeAudioControl(playback, ControlStop)},
-			ControlFastForward: {Func: nativeAudioControl(playback, ControlFastForward)},
-			ControlRewind:      {Func: nativeAudioControl(playback, ControlRewind)},
+			ControlTogglePause: {Func: nativeAudioControl(playback, nil, ControlTogglePause)},
+			ControlPause:       {Func: nativeAudioControl(playback, nil, ControlPause)},
+			ControlResume:      {Func: nativeAudioControl(playback, nil, ControlResume)},
+			ControlStop:        {Func: nativeAudioControl(playback, clearPrimaryMedia, ControlStop)},
+			ControlFastForward: {Func: nativeAudioControl(playback, nil, ControlFastForward)},
+			ControlRewind:      {Func: nativeAudioControl(playback, nil, ControlRewind)},
 		},
 	}
 }
@@ -110,7 +113,11 @@ func launchNativeAudio(
 	return nil, nil //nolint:nilnil // native audio has no OS process to return
 }
 
-func nativeAudioControl(playback audio.PlaybackManager, action string) ControlFunc {
+func nativeAudioControl(
+	playback audio.PlaybackManager,
+	clearPrimaryMedia func(),
+	action string,
+) ControlFunc {
 	return func(_ context.Context, _ *config.Instance, params ControlParams) error {
 		if playback == nil {
 			return errors.New("native audio playback is not initialized")
@@ -132,7 +139,15 @@ func nativeAudioControl(playback audio.PlaybackManager, action string) ControlFu
 		case ControlResume:
 			return playback.Resume(slot)
 		case ControlStop:
-			return playback.Stop(slot)
+			if stopErr := playback.Stop(slot); stopErr != nil {
+				return fmt.Errorf("stop native audio: %w", stopErr)
+			}
+			// The background slot is left to the caller: clearing it also has to
+			// clear the background playlist, which is service state.
+			if slot == mediaslot.Primary && clearPrimaryMedia != nil {
+				clearPrimaryMedia()
+			}
+			return nil
 		case ControlFastForward:
 			return playback.Seek(slot, controlSeekDuration(params.Args, 10*time.Second))
 		case ControlRewind:

--- a/pkg/platforms/native_audio.go
+++ b/pkg/platforms/native_audio.go
@@ -41,13 +41,14 @@ const NativeAudioLauncherID = "native-audio"
 
 // NativeAudioLauncher returns the launcher that plays audio files in-process via the
 // shared malgo output device. Playback and the media state hooks are injected so the
-// launcher carries no package-level globals. clearPrimaryMedia runs after an explicit
-// stop of the primary slot; native audio has no OS process, so no platform tracker
-// notices the stop and the drain callback only fires for tracks that end on their own.
+// launcher carries no package-level globals. stopPrimaryMedia wraps an explicit stop
+// of the primary slot: native audio has no OS process, so no platform tracker notices
+// the stop and the drain callback only fires for tracks that end on their own, which
+// leaves the service to run the stop it is handed and clear the active media around it.
 func NativeAudioLauncher(
 	playback audio.PlaybackManager,
 	setBackgroundMedia func(*models.ActiveMedia),
-	clearPrimaryMedia func(),
+	stopPrimaryMedia func(ctx context.Context, stop func() error) error,
 ) Launcher {
 	return Launcher{
 		ID:       NativeAudioLauncherID,
@@ -66,7 +67,7 @@ func NativeAudioLauncher(
 			ControlTogglePause: {Func: nativeAudioControl(playback, nil, ControlTogglePause)},
 			ControlPause:       {Func: nativeAudioControl(playback, nil, ControlPause)},
 			ControlResume:      {Func: nativeAudioControl(playback, nil, ControlResume)},
-			ControlStop:        {Func: nativeAudioControl(playback, clearPrimaryMedia, ControlStop)},
+			ControlStop:        {Func: nativeAudioControl(playback, stopPrimaryMedia, ControlStop)},
 			ControlFastForward: {Func: nativeAudioControl(playback, nil, ControlFastForward)},
 			ControlRewind:      {Func: nativeAudioControl(playback, nil, ControlRewind)},
 		},
@@ -115,10 +116,10 @@ func launchNativeAudio(
 
 func nativeAudioControl(
 	playback audio.PlaybackManager,
-	clearPrimaryMedia func(),
+	stopPrimaryMedia func(ctx context.Context, stop func() error) error,
 	action string,
 ) ControlFunc {
-	return func(_ context.Context, _ *config.Instance, params ControlParams) error {
+	return func(ctx context.Context, _ *config.Instance, params ControlParams) error {
 		if playback == nil {
 			return errors.New("native audio playback is not initialized")
 		}
@@ -139,15 +140,18 @@ func nativeAudioControl(
 		case ControlResume:
 			return playback.Resume(slot)
 		case ControlStop:
-			if stopErr := playback.Stop(slot); stopErr != nil {
-				return fmt.Errorf("stop native audio: %w", stopErr)
+			stop := func() error {
+				if stopErr := playback.Stop(slot); stopErr != nil {
+					return fmt.Errorf("stop native audio: %w", stopErr)
+				}
+				return nil
 			}
 			// The background slot is left to the caller: clearing it also has to
 			// clear the background playlist, which is service state.
-			if slot == mediaslot.Primary && clearPrimaryMedia != nil {
-				clearPrimaryMedia()
+			if slot != mediaslot.Primary || stopPrimaryMedia == nil {
+				return stop()
 			}
-			return nil
+			return stopPrimaryMedia(ctx, stop)
 		case ControlFastForward:
 			return playback.Seek(slot, controlSeekDuration(params.Args, 10*time.Second))
 		case ControlRewind:

--- a/pkg/platforms/native_audio_test.go
+++ b/pkg/platforms/native_audio_test.go
@@ -207,7 +207,7 @@ func TestLaunchNativeAudio_ReturnsNilProcess(t *testing.T) {
 
 func TestNativeAudioControl_NilPlayback(t *testing.T) {
 	t.Parallel()
-	fn := nativeAudioControl(nil, nil, ControlTogglePause)
+	fn := nativeAudioControl(nil, nil, nil, ControlTogglePause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not initialized")
@@ -216,7 +216,7 @@ func TestNativeAudioControl_NilPlayback(t *testing.T) {
 func TestNativeAudioControl_BadSlot(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlPause)
+	fn := nativeAudioControl(fp, nil, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{string(gozapscript.KeySlot): "badslot"},
 	})
@@ -227,7 +227,7 @@ func TestNativeAudioControl_BadSlot(t *testing.T) {
 func TestNativeAudioControl_EmptySlotDefaultsPrimary(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlPause)
+	fn := nativeAudioControl(fp, nil, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, mediaslot.Primary, fp.lastSlot)
@@ -236,7 +236,7 @@ func TestNativeAudioControl_EmptySlotDefaultsPrimary(t *testing.T) {
 func TestNativeAudioControl_TogglePause(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{toggleErr: errors.New("toggle err")}
-	fn := nativeAudioControl(fp, nil, ControlTogglePause)
+	fn := nativeAudioControl(fp, nil, nil, ControlTogglePause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "toggle", fp.lastCall)
@@ -246,7 +246,7 @@ func TestNativeAudioControl_TogglePause(t *testing.T) {
 func TestNativeAudioControl_Pause(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{pauseErr: errors.New("pause err")}
-	fn := nativeAudioControl(fp, nil, ControlPause)
+	fn := nativeAudioControl(fp, nil, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "pause", fp.lastCall)
@@ -255,7 +255,7 @@ func TestNativeAudioControl_Pause(t *testing.T) {
 func TestNativeAudioControl_Resume(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{resumeErr: errors.New("resume err")}
-	fn := nativeAudioControl(fp, nil, ControlResume)
+	fn := nativeAudioControl(fp, nil, nil, ControlResume)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "resume", fp.lastCall)
@@ -264,7 +264,7 @@ func TestNativeAudioControl_Resume(t *testing.T) {
 func TestNativeAudioControl_Stop(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{stopErr: errors.New("stop err")}
-	fn := nativeAudioControl(fp, nil, ControlStop)
+	fn := nativeAudioControl(fp, nil, nil, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "stop", fp.lastCall)
@@ -275,7 +275,7 @@ func TestNativeAudioControl_StopPrimaryRunsThroughHook(t *testing.T) {
 	fp := &fakePlayback{}
 	hookCalls := 0
 	stoppedInsideHook := false
-	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+	fn := nativeAudioControl(fp, nil, func(_ context.Context, stop func() error) error {
 		hookCalls++
 		assert.Empty(t, fp.lastCall, "playback must not be stopped before the hook runs")
 		err := stop()
@@ -295,7 +295,7 @@ func TestNativeAudioControl_StopHookReceivesControlContext(t *testing.T) {
 	type ctxKey struct{}
 	ctx := context.WithValue(context.Background(), ctxKey{}, "control")
 	var seen context.Context
-	fn := nativeAudioControl(fp, func(ctx context.Context, stop func() error) error {
+	fn := nativeAudioControl(fp, nil, func(ctx context.Context, stop func() error) error {
 		seen = ctx
 		return stop()
 	}, ControlStop)
@@ -304,14 +304,17 @@ func TestNativeAudioControl_StopHookReceivesControlContext(t *testing.T) {
 	assert.Equal(t, "control", seen.Value(ctxKey{}))
 }
 
-func TestNativeAudioControl_StopBackgroundSkipsPrimaryHook(t *testing.T) {
+func TestNativeAudioControl_StopBackgroundClearsBackgroundMedia(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
 	hookCalls := 0
-	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
-		hookCalls++
-		return stop()
-	}, ControlStop)
+	var published []*models.ActiveMedia
+	fn := nativeAudioControl(fp,
+		func(m *models.ActiveMedia) { published = append(published, m) },
+		func(_ context.Context, stop func() error) error {
+			hookCalls++
+			return stop()
+		}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{string(gozapscript.KeySlot): mediaslot.Background},
 	})
@@ -319,6 +322,20 @@ func TestNativeAudioControl_StopBackgroundSkipsPrimaryHook(t *testing.T) {
 	assert.Equal(t, "stop", fp.lastCall)
 	assert.Equal(t, mediaslot.Background, fp.lastSlot)
 	assert.Equal(t, 0, hookCalls, "a background stop must not touch primary media")
+	require.Len(t, published, 1, "a background stop clears the background media set on launch")
+	assert.Nil(t, published[0])
+}
+
+func TestNativeAudioControl_StopBackgroundErrorKeepsBackgroundMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{stopErr: errors.New("stop err")}
+	published := 0
+	fn := nativeAudioControl(fp, func(*models.ActiveMedia) { published++ }, nil, ControlStop)
+	err := fn(context.Background(), nil, ControlParams{
+		Args: map[string]string{string(gozapscript.KeySlot): mediaslot.Background},
+	})
+	require.Error(t, err)
+	assert.Equal(t, 0, published, "a failed background stop must not clear background media")
 }
 
 func TestNativeAudioControl_StopErrorReachesHook(t *testing.T) {
@@ -326,7 +343,7 @@ func TestNativeAudioControl_StopErrorReachesHook(t *testing.T) {
 	stopErr := errors.New("stop err")
 	fp := &fakePlayback{stopErr: stopErr}
 	var hookErr error
-	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+	fn := nativeAudioControl(fp, nil, func(_ context.Context, stop func() error) error {
 		hookErr = stop()
 		return hookErr
 	}, ControlStop)
@@ -339,7 +356,7 @@ func TestNativeAudioControl_StopHookErrorSkipsStop(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
 	gateErr := errors.New("gate err")
-	fn := nativeAudioControl(fp, func(context.Context, func() error) error {
+	fn := nativeAudioControl(fp, nil, func(context.Context, func() error) error {
 		return gateErr
 	}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
@@ -351,7 +368,7 @@ func TestNativeAudioControl_PauseSkipsStopHook(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
 	hookCalls := 0
-	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+	fn := nativeAudioControl(fp, nil, func(_ context.Context, stop func() error) error {
 		hookCalls++
 		return stop()
 	}, ControlPause)
@@ -364,7 +381,7 @@ func TestNativeAudioControl_PauseSkipsStopHook(t *testing.T) {
 func TestNativeAudioControl_StopNilHooksAreSafe(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlStop)
+	fn := nativeAudioControl(fp, nil, nil, ControlStop)
 	for _, slot := range []string{mediaslot.Primary, mediaslot.Background} {
 		err := fn(context.Background(), nil, ControlParams{
 			Args: map[string]string{string(gozapscript.KeySlot): slot},
@@ -378,7 +395,7 @@ func TestNativeAudioControl_StopNilHooksAreSafe(t *testing.T) {
 func TestNativeAudioControl_FastForward_Default(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlFastForward)
+	fn := nativeAudioControl(fp, nil, nil, ControlFastForward)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, "seek", fp.lastCall)
@@ -388,7 +405,7 @@ func TestNativeAudioControl_FastForward_Default(t *testing.T) {
 func TestNativeAudioControl_Rewind_Default(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlRewind)
+	fn := nativeAudioControl(fp, nil, nil, ControlRewind)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, "seek", fp.lastCall)
@@ -398,7 +415,7 @@ func TestNativeAudioControl_Rewind_Default(t *testing.T) {
 func TestNativeAudioControl_FastForward_Custom(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlFastForward)
+	fn := nativeAudioControl(fp, nil, nil, ControlFastForward)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{"seconds": "5"},
 	})
@@ -409,7 +426,7 @@ func TestNativeAudioControl_FastForward_Custom(t *testing.T) {
 func TestNativeAudioControl_Rewind_Custom(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, ControlRewind)
+	fn := nativeAudioControl(fp, nil, nil, ControlRewind)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{"seconds": "5"},
 	})
@@ -420,7 +437,7 @@ func TestNativeAudioControl_Rewind_Custom(t *testing.T) {
 func TestNativeAudioControl_Unsupported(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, nil, "fly")
+	fn := nativeAudioControl(fp, nil, nil, "fly")
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported native audio control")
@@ -549,4 +566,24 @@ func TestNativeAudioLauncher_StopControlRunsThroughHook(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, hookCalls)
 	assert.Equal(t, "stop", fp.lastCall)
+}
+
+// TestNativeAudioLauncher_BackgroundStopClearsBackgroundMedia pins the state the
+// launcher owns: it publishes background media on launch, so its stop control is
+// what clears it, for the API and the ZapScript control paths alike.
+func TestNativeAudioLauncher_BackgroundStopClearsBackgroundMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	var current *models.ActiveMedia
+	l := NativeAudioLauncher(fp, func(m *models.ActiveMedia) { current = m }, nil)
+
+	_, err := l.Launch(nil, "/music/track.mp3", &LaunchOptions{Slot: mediaslot.Background})
+	require.NoError(t, err)
+	require.NotNil(t, current)
+
+	err = l.Controls[ControlStop].Func(context.Background(), nil, ControlParams{
+		Args: map[string]string{string(gozapscript.KeySlot): mediaslot.Background},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, current)
 }

--- a/pkg/platforms/native_audio_test.go
+++ b/pkg/platforms/native_audio_test.go
@@ -207,7 +207,7 @@ func TestLaunchNativeAudio_ReturnsNilProcess(t *testing.T) {
 
 func TestNativeAudioControl_NilPlayback(t *testing.T) {
 	t.Parallel()
-	fn := nativeAudioControl(nil, ControlTogglePause)
+	fn := nativeAudioControl(nil, nil, ControlTogglePause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not initialized")
@@ -216,7 +216,7 @@ func TestNativeAudioControl_NilPlayback(t *testing.T) {
 func TestNativeAudioControl_BadSlot(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlPause)
+	fn := nativeAudioControl(fp, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{string(gozapscript.KeySlot): "badslot"},
 	})
@@ -227,7 +227,7 @@ func TestNativeAudioControl_BadSlot(t *testing.T) {
 func TestNativeAudioControl_EmptySlotDefaultsPrimary(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlPause)
+	fn := nativeAudioControl(fp, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, mediaslot.Primary, fp.lastSlot)
@@ -236,7 +236,7 @@ func TestNativeAudioControl_EmptySlotDefaultsPrimary(t *testing.T) {
 func TestNativeAudioControl_TogglePause(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{toggleErr: errors.New("toggle err")}
-	fn := nativeAudioControl(fp, ControlTogglePause)
+	fn := nativeAudioControl(fp, nil, ControlTogglePause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "toggle", fp.lastCall)
@@ -246,7 +246,7 @@ func TestNativeAudioControl_TogglePause(t *testing.T) {
 func TestNativeAudioControl_Pause(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{pauseErr: errors.New("pause err")}
-	fn := nativeAudioControl(fp, ControlPause)
+	fn := nativeAudioControl(fp, nil, ControlPause)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "pause", fp.lastCall)
@@ -255,7 +255,7 @@ func TestNativeAudioControl_Pause(t *testing.T) {
 func TestNativeAudioControl_Resume(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{resumeErr: errors.New("resume err")}
-	fn := nativeAudioControl(fp, ControlResume)
+	fn := nativeAudioControl(fp, nil, ControlResume)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Equal(t, "resume", fp.lastCall)
@@ -264,16 +264,69 @@ func TestNativeAudioControl_Resume(t *testing.T) {
 func TestNativeAudioControl_Stop(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{stopErr: errors.New("stop err")}
-	fn := nativeAudioControl(fp, ControlStop)
+	fn := nativeAudioControl(fp, nil, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
+	assert.Equal(t, "stop", fp.lastCall)
+}
+
+func TestNativeAudioControl_StopPrimaryClearsMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	cleared := false
+	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
+	require.NoError(t, err)
+	assert.Equal(t, "stop", fp.lastCall)
+	assert.True(t, cleared, "stop on the primary slot must clear active media")
+}
+
+func TestNativeAudioControl_StopBackgroundLeavesPrimaryMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	cleared := false
+	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	err := fn(context.Background(), nil, ControlParams{
+		Args: map[string]string{string(gozapscript.KeySlot): mediaslot.Background},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, mediaslot.Background, fp.lastSlot)
+	assert.False(t, cleared, "background stop must not touch primary media")
+}
+
+func TestNativeAudioControl_StopErrorLeavesMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{stopErr: errors.New("stop err")}
+	cleared := false
+	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
+	require.Error(t, err)
+	assert.False(t, cleared, "a failed stop must not clear active media")
+}
+
+func TestNativeAudioControl_PauseDoesNotClearMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	cleared := false
+	fn := nativeAudioControl(fp, func() { cleared = true }, ControlPause)
+	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
+	require.NoError(t, err)
+	assert.False(t, cleared)
+}
+
+func TestNativeAudioControl_StopNilClearIsSafe(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	fn := nativeAudioControl(fp, nil, ControlStop)
+	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
+	require.NoError(t, err)
 	assert.Equal(t, "stop", fp.lastCall)
 }
 
 func TestNativeAudioControl_FastForward_Default(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlFastForward)
+	fn := nativeAudioControl(fp, nil, ControlFastForward)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, "seek", fp.lastCall)
@@ -283,7 +336,7 @@ func TestNativeAudioControl_FastForward_Default(t *testing.T) {
 func TestNativeAudioControl_Rewind_Default(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlRewind)
+	fn := nativeAudioControl(fp, nil, ControlRewind)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
 	assert.Equal(t, "seek", fp.lastCall)
@@ -293,7 +346,7 @@ func TestNativeAudioControl_Rewind_Default(t *testing.T) {
 func TestNativeAudioControl_FastForward_Custom(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlFastForward)
+	fn := nativeAudioControl(fp, nil, ControlFastForward)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{"seconds": "5"},
 	})
@@ -304,7 +357,7 @@ func TestNativeAudioControl_FastForward_Custom(t *testing.T) {
 func TestNativeAudioControl_Rewind_Custom(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, ControlRewind)
+	fn := nativeAudioControl(fp, nil, ControlRewind)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{"seconds": "5"},
 	})
@@ -315,7 +368,7 @@ func TestNativeAudioControl_Rewind_Custom(t *testing.T) {
 func TestNativeAudioControl_Unsupported(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	fn := nativeAudioControl(fp, "fly")
+	fn := nativeAudioControl(fp, nil, "fly")
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported native audio control")
@@ -401,7 +454,7 @@ func TestAudioDisplayName(t *testing.T) {
 func TestNativeAudioLauncher_Fields(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	l := NativeAudioLauncher(fp, nil)
+	l := NativeAudioLauncher(fp, nil, nil)
 
 	assert.Equal(t, NativeAudioLauncherID, l.ID)
 	assert.Equal(t, "Audio", l.SystemID)
@@ -422,4 +475,22 @@ func TestNativeAudioLauncher_Fields(t *testing.T) {
 		assert.True(t, ok, "missing control: %s", key)
 		assert.NotNil(t, ctrl.Func, "nil Func for control: %s", key)
 	}
+}
+
+// TestNativeAudioLauncher_StopControlClearsPrimaryMedia checks the factory wires the
+// clear hook to stop and nothing else. Native audio has no OS process, so without it
+// an explicit stop leaves the daemon reporting the track as still playing.
+func TestNativeAudioLauncher_StopControlClearsPrimaryMedia(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	cleared := 0
+	l := NativeAudioLauncher(fp, nil, func() { cleared++ })
+
+	err := l.Controls[ControlPause].Func(context.Background(), nil, ControlParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, cleared)
+
+	err = l.Controls[ControlStop].Func(context.Background(), nil, ControlParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, cleared)
 }

--- a/pkg/platforms/native_audio_test.go
+++ b/pkg/platforms/native_audio_test.go
@@ -270,57 +270,109 @@ func TestNativeAudioControl_Stop(t *testing.T) {
 	assert.Equal(t, "stop", fp.lastCall)
 }
 
-func TestNativeAudioControl_StopPrimaryClearsMedia(t *testing.T) {
+func TestNativeAudioControl_StopPrimaryRunsThroughHook(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	cleared := false
-	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	hookCalls := 0
+	stoppedInsideHook := false
+	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+		hookCalls++
+		assert.Empty(t, fp.lastCall, "playback must not be stopped before the hook runs")
+		err := stop()
+		stoppedInsideHook = fp.lastCall == "stop"
+		return err
+	}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
 	require.NoError(t, err)
-	assert.Equal(t, "stop", fp.lastCall)
-	assert.True(t, cleared, "stop on the primary slot must clear active media")
+	assert.Equal(t, 1, hookCalls, "a primary stop must run through the hook")
+	assert.True(t, stoppedInsideHook, "the hook owns the stop so it can gate it")
+	assert.Equal(t, mediaslot.Primary, fp.lastSlot)
 }
 
-func TestNativeAudioControl_StopBackgroundLeavesPrimaryMedia(t *testing.T) {
+func TestNativeAudioControl_StopHookReceivesControlContext(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	cleared := false
-	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "control")
+	var seen context.Context
+	fn := nativeAudioControl(fp, func(ctx context.Context, stop func() error) error {
+		seen = ctx
+		return stop()
+	}, ControlStop)
+	require.NoError(t, fn(ctx, nil, ControlParams{Args: map[string]string{}}))
+	require.NotNil(t, seen)
+	assert.Equal(t, "control", seen.Value(ctxKey{}))
+}
+
+func TestNativeAudioControl_StopBackgroundSkipsPrimaryHook(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	hookCalls := 0
+	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+		hookCalls++
+		return stop()
+	}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{
 		Args: map[string]string{string(gozapscript.KeySlot): mediaslot.Background},
 	})
 	require.NoError(t, err)
+	assert.Equal(t, "stop", fp.lastCall)
 	assert.Equal(t, mediaslot.Background, fp.lastSlot)
-	assert.False(t, cleared, "background stop must not touch primary media")
+	assert.Equal(t, 0, hookCalls, "a background stop must not touch primary media")
 }
 
-func TestNativeAudioControl_StopErrorLeavesMedia(t *testing.T) {
+func TestNativeAudioControl_StopErrorReachesHook(t *testing.T) {
 	t.Parallel()
-	fp := &fakePlayback{stopErr: errors.New("stop err")}
-	cleared := false
-	fn := nativeAudioControl(fp, func() { cleared = true }, ControlStop)
+	stopErr := errors.New("stop err")
+	fp := &fakePlayback{stopErr: stopErr}
+	var hookErr error
+	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+		hookErr = stop()
+		return hookErr
+	}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
-	require.Error(t, err)
-	assert.False(t, cleared, "a failed stop must not clear active media")
+	require.ErrorIs(t, err, stopErr)
+	require.ErrorIs(t, hookErr, stopErr, "the hook must see the failure so it can leave media alone")
 }
 
-func TestNativeAudioControl_PauseDoesNotClearMedia(t *testing.T) {
+func TestNativeAudioControl_StopHookErrorSkipsStop(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	cleared := false
-	fn := nativeAudioControl(fp, func() { cleared = true }, ControlPause)
+	gateErr := errors.New("gate err")
+	fn := nativeAudioControl(fp, func(context.Context, func() error) error {
+		return gateErr
+	}, ControlStop)
 	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
-	require.NoError(t, err)
-	assert.False(t, cleared)
+	require.ErrorIs(t, err, gateErr)
+	assert.Empty(t, fp.lastCall, "a hook that never runs the stop must leave playback alone")
 }
 
-func TestNativeAudioControl_StopNilClearIsSafe(t *testing.T) {
+func TestNativeAudioControl_PauseSkipsStopHook(t *testing.T) {
+	t.Parallel()
+	fp := &fakePlayback{}
+	hookCalls := 0
+	fn := nativeAudioControl(fp, func(_ context.Context, stop func() error) error {
+		hookCalls++
+		return stop()
+	}, ControlPause)
+	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
+	require.NoError(t, err)
+	assert.Equal(t, 0, hookCalls)
+	assert.Equal(t, "pause", fp.lastCall)
+}
+
+func TestNativeAudioControl_StopNilHooksAreSafe(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
 	fn := nativeAudioControl(fp, nil, ControlStop)
-	err := fn(context.Background(), nil, ControlParams{Args: map[string]string{}})
-	require.NoError(t, err)
-	assert.Equal(t, "stop", fp.lastCall)
+	for _, slot := range []string{mediaslot.Primary, mediaslot.Background} {
+		err := fn(context.Background(), nil, ControlParams{
+			Args: map[string]string{string(gozapscript.KeySlot): slot},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "stop", fp.lastCall)
+		assert.Equal(t, slot, fp.lastSlot)
+	}
 }
 
 func TestNativeAudioControl_FastForward_Default(t *testing.T) {
@@ -477,20 +529,24 @@ func TestNativeAudioLauncher_Fields(t *testing.T) {
 	}
 }
 
-// TestNativeAudioLauncher_StopControlClearsPrimaryMedia checks the factory wires the
-// clear hook to stop and nothing else. Native audio has no OS process, so without it
+// TestNativeAudioLauncher_StopControlRunsThroughHook checks the factory wires the
+// stop hook to stop and nothing else. Native audio has no OS process, so without it
 // an explicit stop leaves the daemon reporting the track as still playing.
-func TestNativeAudioLauncher_StopControlClearsPrimaryMedia(t *testing.T) {
+func TestNativeAudioLauncher_StopControlRunsThroughHook(t *testing.T) {
 	t.Parallel()
 	fp := &fakePlayback{}
-	cleared := 0
-	l := NativeAudioLauncher(fp, nil, func() { cleared++ })
+	hookCalls := 0
+	l := NativeAudioLauncher(fp, nil, func(_ context.Context, stop func() error) error {
+		hookCalls++
+		return stop()
+	})
 
 	err := l.Controls[ControlPause].Func(context.Background(), nil, ControlParams{})
 	require.NoError(t, err)
-	assert.Equal(t, 0, cleared)
+	assert.Equal(t, 0, hookCalls)
 
 	err = l.Controls[ControlStop].Func(context.Background(), nil, ControlParams{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, cleared)
+	assert.Equal(t, 1, hookCalls)
+	assert.Equal(t, "stop", fp.lastCall)
 }

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -185,12 +185,16 @@ type CmdEnv struct {
 	// run, such as inside a hook script.
 	BeforeExit      func()
 	PlaybackManager audio.PlaybackManager
-	UI              *uievents.Service
-	Playlist        playlists.PlaylistController
-	Cfg             *config.Instance
-	Database        *database.Database
-	ExprEnv         *zapscript.ArgExprEnv
-	Source          string
+	// LauncherCache resolves the launcher behind the active media. It holds
+	// launchers the platform cannot build itself, so it is the only complete
+	// source; never resolve a launcher ID from Platform.Launchers alone.
+	LauncherCache LauncherResolver
+	UI            *uievents.Service
+	Playlist      playlists.PlaylistController
+	Cfg           *config.Instance
+	Database      *database.Database
+	ExprEnv       *zapscript.ArgExprEnv
+	Source        string
 	// PathRoot is an optional per-token root for resolving relative filesystem paths.
 	PathRoot      string
 	Cmd           zapscript.Command
@@ -500,6 +504,13 @@ type Scraper struct {
 	ID                 string
 	Name               string
 	SupportedSystemIDs []string
+}
+
+// LauncherResolver looks up a launcher by its unique ID. Implementations cover
+// launchers a platform cannot construct on its own, such as native audio, which
+// needs the playback manager injected at service startup.
+type LauncherResolver interface {
+	GetLauncherByID(id string) *Launcher
 }
 
 // LauncherRefreshProvider is optionally implemented by platforms that cache

--- a/pkg/service/queues_beforeexit_test.go
+++ b/pkg/service/queues_beforeexit_test.go
@@ -20,6 +20,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,8 +28,11 @@ import (
 	"time"
 
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/api/models"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database/systemdefs"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/syncutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -381,4 +385,99 @@ func TestRunTokenZapScript_StopStillHappensWithHarmlessHook(t *testing.T) {
 
 	assert.Equal(t, []string{"before_exit", "stop"}, env.rec.snapshot(),
 		"a hook that launches nothing must not suppress the stop")
+}
+
+// stubPlayback is the PlaybackManager the native-audio launcher needs for the
+// control tests below: it records calls and never fails.
+type stubPlayback struct {
+	calls []string
+	mu    syncutil.Mutex
+}
+
+func (p *stubPlayback) record(call string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, call)
+}
+
+func (p *stubPlayback) snapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.calls...)
+}
+
+func (p *stubPlayback) Play(string, string, audio.PlaybackOptions) error {
+	p.record("play")
+	return nil
+}
+
+func (p *stubPlayback) Stop(string) error {
+	p.record("stop")
+	return nil
+}
+
+func (p *stubPlayback) Pause(string) error {
+	p.record("pause")
+	return nil
+}
+
+func (p *stubPlayback) Resume(string) error {
+	p.record("resume")
+	return nil
+}
+
+func (p *stubPlayback) TogglePause(string) error {
+	p.record("toggle_pause")
+	return nil
+}
+
+func (p *stubPlayback) Seek(string, time.Duration) error {
+	p.record("seek")
+	return nil
+}
+
+func (*stubPlayback) State(string) audio.PlaybackState {
+	return audio.PlaybackState{}
+}
+
+// TestRunTokenZapScript_BeforeExitControlStopOnNativeAudio drives **control:stop
+// from a before_exit script while native audio is the outgoing media. The stop
+// control takes the media stop gate exclusively; before_exit runs with no gate
+// held, so the token must complete and leave nothing playing.
+func TestRunTokenZapScript_BeforeExitControlStopOnNativeAudio(t *testing.T) {
+	// Not parallel: cmdControl resolves launchers through the global launcher
+	// cache, which this test replaces for its duration.
+	env := setupExitTestEnv(t, keypressHook)
+	env.svc.Config.SetSystemDefaults([]config.SystemsDefault{
+		{System: systemdefs.SystemAudio, BeforeExit: "**control:stop"},
+	})
+	pm := &stubPlayback{}
+	env.svc.PlaybackManager = pm
+	previous := helpers.GlobalLauncherCache.GetAllLaunchers()
+	helpers.GlobalLauncherCache.InitializeFromSlice([]platforms.Launcher{
+		platforms.NativeAudioLauncher(pm, env.svc.State.SetBackgroundMedia,
+			func(ctx context.Context, stop func() error) error {
+				return stopNativeAudioPrimaryMedia(ctx, env.svc, stop)
+			}),
+	})
+	t.Cleanup(func() { helpers.GlobalLauncherCache.InitializeFromSlice(previous) })
+
+	env.svc.State.SetActiveMedia(models.NewActiveMedia(
+		systemdefs.SystemAudio, "Audio", "track.mp3", "Track", platforms.NativeAudioLauncherID))
+	gen, active := env.svc.State.ActiveMediaReadyGeneration()
+	require.True(t, active)
+	env.svc.State.MarkActiveMediaReady(gen)
+
+	done := make(chan error, 1)
+	go func() { done <- env.run(t, "**stop") }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("gated **control:stop from before_exit hung the stop")
+	}
+
+	assert.Equal(t, []string{"stop"}, pm.snapshot(), "before_exit must stop native audio exactly once")
+	assert.Nil(t, env.svc.State.ActiveMedia(), "the stop control clears the media it stopped")
+	assert.Zero(t, env.rec.count("stop"), "nothing is left for the outer stop to exit")
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -208,19 +208,24 @@ type drainCallbackRegistrar interface {
 	SetDrainCallback(slot string, fn func(natural bool))
 }
 
+// clearNativeAudioPrimaryMedia clears active media once native audio has stopped
+// on the primary slot. Another launcher may have taken over active media while the
+// track was still playing (e.g. a game started outside Zaparoo); only clear it if
+// native audio still owns it.
+func clearNativeAudioPrimaryMedia(svc *ServiceContext) {
+	media := svc.State.ActiveMedia()
+	if media == nil || media.LauncherID != platforms.NativeAudioLauncherID {
+		return
+	}
+	svc.State.SetActiveMedia(nil)
+}
+
 func wireNativeAudioDrainCallbacks(pm drainCallbackRegistrar, svc *ServiceContext) {
 	pm.SetDrainCallback(mediaslot.Primary, func(natural bool) {
 		if !natural {
 			return
 		}
-		// Another launcher may have taken over active media while the track was
-		// still playing (e.g. a game started outside Zaparoo); only clear it if
-		// native audio still owns it.
-		media := svc.State.ActiveMedia()
-		if media == nil || media.LauncherID != platforms.NativeAudioLauncherID {
-			return
-		}
-		svc.State.SetActiveMedia(nil)
+		clearNativeAudioPrimaryMedia(svc)
 	})
 	pm.SetDrainCallback(mediaslot.Background, func(natural bool) {
 		if !natural {
@@ -548,7 +553,11 @@ func startService(
 	launcherCacheStarted := time.Now()
 	helpers.GlobalLauncherCache.Initialize(
 		pl, cfg,
-		platforms.NativeAudioLauncher(playbackManager, st.SetBackgroundMedia),
+		platforms.NativeAudioLauncher(
+			playbackManager,
+			st.SetBackgroundMedia,
+			func() { clearNativeAudioPrimaryMedia(svc) },
+		),
 	)
 	log.Debug().Dur("duration", time.Since(launcherCacheStarted)).Msg("launcher cache initialized")
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -211,13 +211,37 @@ type drainCallbackRegistrar interface {
 // clearNativeAudioPrimaryMedia clears active media once native audio has stopped
 // on the primary slot. Another launcher may have taken over active media while the
 // track was still playing (e.g. a game started outside Zaparoo); only clear it if
-// native audio still owns it.
+// native audio still owns it. The ownership check and the clear are one atomic
+// step, so a lifecycle tracker publishing another launcher's media in between
+// is left alone.
 func clearNativeAudioPrimaryMedia(svc *ServiceContext) {
-	media := svc.State.ActiveMedia()
-	if media == nil || media.LauncherID != platforms.NativeAudioLauncherID {
-		return
+	svc.State.ClearActiveMediaIf(func(media *models.ActiveMedia) bool {
+		return media != nil && media.LauncherID == platforms.NativeAudioLauncherID
+	})
+}
+
+// stopNativeAudioPrimaryMedia runs an explicit stop of native audio on the
+// primary slot and clears the active media it owned. Native audio has no OS
+// process, so no platform tracker notices the stop, and the drain callback only
+// fires for tracks that end on their own. The media stop gate is held across
+// both steps: launches publish active media under the read side of that gate,
+// so a track launched while this runs cannot have its state wiped by a stop
+// that was meant for its predecessor.
+func stopNativeAudioPrimaryMedia(ctx context.Context, svc *ServiceContext, stop func() error) error {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	svc.State.SetActiveMedia(nil)
+	release, err := svc.State.AcquireMediaStop(ctx)
+	if err != nil {
+		return fmt.Errorf("wait for in-flight media launch: %w", err)
+	}
+	defer release()
+
+	if err := stop(); err != nil {
+		return err
+	}
+	clearNativeAudioPrimaryMedia(svc)
+	return nil
 }
 
 func wireNativeAudioDrainCallbacks(pm drainCallbackRegistrar, svc *ServiceContext) {
@@ -556,7 +580,9 @@ func startService(
 		platforms.NativeAudioLauncher(
 			playbackManager,
 			st.SetBackgroundMedia,
-			func() { clearNativeAudioPrimaryMedia(svc) },
+			func(ctx context.Context, stop func() error) error {
+				return stopNativeAudioPrimaryMedia(ctx, svc, stop)
+			},
 		),
 	)
 	log.Debug().Dur("duration", time.Since(launcherCacheStarted)).Msg("launcher cache initialized")

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -447,6 +447,55 @@ func TestWireNativeAudioDrainCallbacks_PrimaryDrainKeepsOtherLaunchersMedia(t *t
 	assert.NotNil(t, st.ActiveMedia(), "natural audio drain must not clear another launcher's media")
 }
 
+// TestClearNativeAudioPrimaryMedia covers the helper shared by the drain callback and
+// the native-audio stop control, which is what makes an explicit **control:stop clear
+// playing state the same way media.control does.
+func TestClearNativeAudioPrimaryMedia(t *testing.T) {
+	t.Parallel()
+
+	newSvc := func(t *testing.T, media *models.ActiveMedia) *ServiceContext {
+		t.Helper()
+		st, ns := state.NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+		t.Cleanup(func() {
+			st.StopService()
+			for {
+				select {
+				case <-ns:
+				default:
+					return
+				}
+			}
+		})
+		if media != nil {
+			st.SetActiveMedia(media)
+		}
+		return &ServiceContext{State: st, PlaylistQueue: make(chan *playlists.Playlist, 1)}
+	}
+
+	t.Run("clears native audio media", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, models.NewActiveMedia(
+			"Audio", "Audio", "track.mp3", "Track", platforms.NativeAudioLauncherID,
+		))
+		clearNativeAudioPrimaryMedia(svc)
+		assert.Nil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("keeps another launcher's media", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, models.NewActiveMedia("SNES", "SNES", "game.sfc", "Game", "mister-launcher"))
+		clearNativeAudioPrimaryMedia(svc)
+		assert.NotNil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("no active media is a no-op", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nil)
+		clearNativeAudioPrimaryMedia(svc)
+		assert.Nil(t, svc.State.ActiveMedia())
+	})
+}
+
 func TestWireNativeAudioDrainCallbacks_NonNaturalBackgroundNoOp(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -2003,3 +2003,194 @@ func TestConfirmPendingUpdate_ShutdownAbandonsTheWait(t *testing.T) {
 		t.Fatal("confirmPendingUpdate kept waiting after the service shut down")
 	}
 }
+
+// TestWireNativeAudioDrainCallbacks_NonNaturalPrimaryNoOp pins the split of
+// responsibilities behind an explicit stop. The drain fires with natural=false
+// for a stop or a replacement; the stop control clears the state itself and a
+// replacement's launch publishes the new track, so the callback must leave
+// active media alone.
+func TestWireNativeAudioDrainCallbacks_NonNaturalPrimaryNoOp(t *testing.T) {
+	t.Parallel()
+
+	st, ns := state.NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+	t.Cleanup(func() {
+		st.StopService()
+		for {
+			select {
+			case <-ns:
+			default:
+				return
+			}
+		}
+	})
+	st.SetActiveMedia(models.NewActiveMedia(
+		"Audio", "Audio", "track.mp3", "Track", platforms.NativeAudioLauncherID,
+	))
+	require.NotNil(t, st.ActiveMedia())
+
+	svc := &ServiceContext{State: st, PlaylistQueue: make(chan *playlists.Playlist, 1)}
+	registrar := &testDrainCallbackRegistrar{}
+	wireNativeAudioDrainCallbacks(registrar, svc)
+
+	registrar.callbacks[mediaslot.Primary](false)
+	assert.NotNil(t, st.ActiveMedia(), "an explicit stop or replacement drain must not clear primary media")
+}
+
+// TestStopNativeAudioPrimaryMedia covers the hook behind the native-audio stop
+// control: the stop runs under the media stop gate and the active media it owned
+// is cleared once it succeeds.
+func TestStopNativeAudioPrimaryMedia(t *testing.T) {
+	t.Parallel()
+
+	nativeTrack := func(name string) *models.ActiveMedia {
+		return models.NewActiveMedia("Audio", "Audio", name+".mp3", name, platforms.NativeAudioLauncherID)
+	}
+	newSvc := func(t *testing.T, media *models.ActiveMedia) *ServiceContext {
+		t.Helper()
+		st, ns := state.NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+		t.Cleanup(func() {
+			st.StopService()
+			for {
+				select {
+				case <-ns:
+				default:
+					return
+				}
+			}
+		})
+		if media != nil {
+			st.SetActiveMedia(media)
+		}
+		return &ServiceContext{State: st, PlaylistQueue: make(chan *playlists.Playlist, 1)}
+	}
+
+	t.Run("stops then clears native audio media", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		stopped := false
+		err := stopNativeAudioPrimaryMedia(context.Background(), svc, func() error {
+			stopped = true
+			assert.NotNil(t, svc.State.ActiveMedia(), "media is cleared after the stop, not before")
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, stopped)
+		assert.Nil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("failed stop keeps media and returns the error", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		stopErr := errors.New("device busy")
+		err := stopNativeAudioPrimaryMedia(context.Background(), svc, func() error { return stopErr })
+		require.ErrorIs(t, err, stopErr)
+		assert.NotNil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("keeps another launcher's media", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, models.NewActiveMedia("SNES", "SNES", "game.sfc", "Game", "mister-launcher"))
+		stopped := false
+		err := stopNativeAudioPrimaryMedia(context.Background(), svc, func() error {
+			stopped = true
+			return nil
+		})
+		require.NoError(t, err)
+		assert.True(t, stopped, "the slot is still silenced even when a game owns the media")
+		assert.NotNil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("nil context is tolerated", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		//nolint:staticcheck // the nil context is the case under test
+		err := stopNativeAudioPrimaryMedia(nil, svc, func() error { return nil })
+		require.NoError(t, err)
+		assert.Nil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("cancelled context skips the stop", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		stopped := false
+		err := stopNativeAudioPrimaryMedia(ctx, svc, func() error {
+			stopped = true
+			return nil
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		assert.False(t, stopped, "a stop that cannot take the gate must not run half way")
+		assert.NotNil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("waits for an in-flight launch", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		access, err := svc.State.AcquireMediaLaunch()
+		require.NoError(t, err)
+
+		stopped := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			done <- stopNativeAudioPrimaryMedia(context.Background(), svc, func() error {
+				close(stopped)
+				return nil
+			})
+		}()
+		select {
+		case <-stopped:
+			t.Fatal("the stop ran while a launch held the media gate")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		// The launch publishes its track and releases the gate; the stop then
+		// lands on that track, so its state is what gets cleared.
+		access.SetActiveMedia(nativeTrack("replacement"))
+		access.Release()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("the stop never acquired the media gate")
+		}
+		<-stopped
+		assert.Nil(t, svc.State.ActiveMedia())
+	})
+
+	t.Run("launch queued behind the stop keeps its media", func(t *testing.T) {
+		t.Parallel()
+		svc := newSvc(t, nativeTrack("track"))
+		inStop := make(chan struct{})
+		launched := make(chan struct{})
+		go func() {
+			defer close(launched)
+			<-inStop
+			access, err := svc.State.AcquireMediaLaunch()
+			if err != nil {
+				return
+			}
+			access.SetActiveMedia(nativeTrack("next"))
+			access.Release()
+		}()
+
+		err := stopNativeAudioPrimaryMedia(context.Background(), svc, func() error {
+			close(inStop)
+			select {
+			case <-launched:
+				t.Error("a launch published while the stop held the media gate")
+			case <-time.After(100 * time.Millisecond):
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		select {
+		case <-launched:
+		case <-time.After(5 * time.Second):
+			t.Fatal("the launch never acquired the media gate after the stop released it")
+		}
+		media := svc.State.ActiveMedia()
+		require.NotNil(t, media, "the track launched after the stop must keep its state")
+		assert.Equal(t, "next", media.Name)
+	})
+}

--- a/pkg/service/state/state.go
+++ b/pkg/service/state/state.go
@@ -894,6 +894,14 @@ func (s *State) SetActiveMedia(media *models.ActiveMedia) {
 	s.publishActiveMedia(media, false)
 }
 
+// ClearActiveMediaIf clears the active media when cond holds for its current
+// value, and reports whether it did. The check and the clear happen under one
+// lock, so a publication that lands between them cannot be wiped by a stop
+// that was meant for the media it replaced.
+func (s *State) ClearActiveMediaIf(cond func(*models.ActiveMedia) bool) bool {
+	return s.updateActiveMediaState(nil, cond)
+}
+
 func (s *State) publishActiveMedia(media *models.ActiveMedia, restoreAccessHeld bool) {
 	if media != nil {
 		if err := s.ctx.Err(); err != nil {
@@ -929,19 +937,27 @@ func (s *State) publishActiveMedia(media *models.ActiveMedia, restoreAccessHeld 
 		}
 	}
 
-	s.updateActiveMediaState(media)
+	s.updateActiveMediaState(media, nil)
 }
 
-func (s *State) updateActiveMediaState(media *models.ActiveMedia) {
+// updateActiveMediaState applies media as the new active media and reports
+// whether the state changed. A non-nil cond is evaluated against the current
+// media under the lock and vetoes the update when it returns false.
+func (s *State) updateActiveMediaState(media *models.ActiveMedia, cond func(*models.ActiveMedia) bool) bool {
 	s.mu.Lock()
 
 	// Read oldMedia inside lock to prevent race condition where another
 	// goroutine modifies activeMedia between our read and lock acquisition
 	oldMedia := s.activeMedia
 
+	if cond != nil && !cond(oldMedia) {
+		s.mu.Unlock()
+		return false
+	}
+
 	if oldMedia == nil && media == nil {
 		s.mu.Unlock()
-		return
+		return false
 	}
 
 	// Capture hook references inside lock
@@ -972,7 +988,7 @@ func (s *State) updateActiveMediaState(media *models.ActiveMedia) {
 		if stopHook != nil {
 			stopHook()
 		}
-		return
+		return true
 	}
 
 	media.Slot = mediaslot.Primary
@@ -999,7 +1015,7 @@ func (s *State) updateActiveMediaState(media *models.ActiveMedia) {
 		if hook != nil {
 			go hook(media, gen)
 		}
-		return
+		return true
 	}
 
 	if !oldMedia.Equal(media) {
@@ -1032,11 +1048,12 @@ func (s *State) updateActiveMediaState(media *models.ActiveMedia) {
 		if hook != nil {
 			go hook(media, gen)
 		}
-		return
+		return true
 	}
 
 	// No changes
 	s.mu.Unlock()
+	return false
 }
 
 func (s *State) SetBackgroundMedia(media *models.ActiveMedia) {

--- a/pkg/service/state/state_test.go
+++ b/pkg/service/state/state_test.go
@@ -475,3 +475,98 @@ func TestLockOrder_RestoreThenLaunchThenPublish(t *testing.T) {
 	releaseGate()
 	releaseRestore()
 }
+
+func TestClearActiveMediaIf_ClearsWhenConditionHolds(t *testing.T) {
+	t.Parallel()
+	st, notifications := NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+	defer st.StopService()
+
+	st.SetActiveMedia(models.NewActiveMedia("Audio", "Audio", "track.mp3", "Track", "native-audio"))
+	<-notifications // started
+
+	var seen *models.ActiveMedia
+	cleared := st.ClearActiveMediaIf(func(media *models.ActiveMedia) bool {
+		seen = media
+		return media != nil && media.LauncherID == "native-audio"
+	})
+
+	assert.True(t, cleared)
+	assert.Nil(t, st.ActiveMedia())
+	require.NotNil(t, seen, "the condition must see the media it is deciding about")
+	assert.Equal(t, "Track", seen.Name)
+	select {
+	case n := <-notifications:
+		assert.Equal(t, models.NotificationStopped, n.Method)
+	default:
+		t.Fatal("clearing active media must announce the stop")
+	}
+}
+
+func TestClearActiveMediaIf_KeepsMediaWhenConditionFails(t *testing.T) {
+	t.Parallel()
+	st, notifications := NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+	defer st.StopService()
+
+	st.SetActiveMedia(models.NewActiveMedia("SNES", "SNES", "game.sfc", "Game", "emulator"))
+	<-notifications // started
+	gen, _ := st.ActiveMediaReadyGeneration()
+
+	cleared := st.ClearActiveMediaIf(func(media *models.ActiveMedia) bool {
+		return media != nil && media.LauncherID == "native-audio"
+	})
+
+	assert.False(t, cleared)
+	require.NotNil(t, st.ActiveMedia())
+	assert.Equal(t, "Game", st.ActiveMedia().Name)
+	current, _ := st.ActiveMediaReadyGeneration()
+	assert.Equal(t, gen, current, "a vetoed clear must not move the media generation")
+	select {
+	case n := <-notifications:
+		t.Fatalf("a vetoed clear must not notify, got %s", n.Method)
+	default:
+	}
+}
+
+func TestClearActiveMediaIf_NoMediaIsNoOp(t *testing.T) {
+	t.Parallel()
+	st, notifications := NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+	defer st.StopService()
+
+	calls := 0
+	cleared := st.ClearActiveMediaIf(func(media *models.ActiveMedia) bool {
+		calls++
+		assert.Nil(t, media)
+		return true
+	})
+
+	assert.False(t, cleared)
+	assert.Equal(t, 1, calls)
+	select {
+	case n := <-notifications:
+		t.Fatalf("nothing to clear must not notify, got %s", n.Method)
+	default:
+	}
+}
+
+// TestClearActiveMediaIf_ConditionSeesConcurrentPublication is the race the
+// conditional clear exists for: a publication that lands after a caller decided
+// to clear must be judged on its own, not wiped by a decision about its
+// predecessor.
+func TestClearActiveMediaIf_ConditionSeesConcurrentPublication(t *testing.T) {
+	t.Parallel()
+	st, _ := NewState(mocks.NewMockPlatform(), "test-boot-uuid")
+	defer st.StopService()
+
+	st.SetActiveMedia(models.NewActiveMedia("Audio", "Audio", "track.mp3", "Track", "native-audio"))
+	// Simulate the stale read-then-clear: the decision was made against the
+	// audio track, then a game took over before the clear ran.
+	st.SetActiveMedia(models.NewActiveMedia("SNES", "SNES", "game.sfc", "Game", "emulator"))
+
+	cleared := st.ClearActiveMediaIf(func(media *models.ActiveMedia) bool {
+		return media != nil && media.LauncherID == "native-audio"
+	})
+
+	assert.False(t, cleared)
+	require.NotNil(t, st.ActiveMedia())
+	assert.Equal(t, "Game", st.ActiveMedia().Name)
+}

--- a/pkg/zapscript/commands.go
+++ b/pkg/zapscript/commands.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/audio"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/database"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers/boolutil"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/service/playlists"
@@ -549,6 +550,7 @@ func RunCommand(
 		AcquireMediaLaunch: opts.AcquireMediaLaunch,
 		BeforeExit:         opts.BeforeExit,
 		PlaybackManager:    opts.PlaybackManager,
+		LauncherCache:      helpers.GlobalLauncherCache,
 		UI:                 opts.UI,
 		Playlist:           plsc,
 		Source:             token.Source,

--- a/pkg/zapscript/control_cmd.go
+++ b/pkg/zapscript/control_cmd.go
@@ -33,6 +33,7 @@ var (
 	ErrNoActiveMedia         = errors.New("no active media")
 	ErrNoLauncher            = errors.New("no launcher associated with active media")
 	ErrNoControlCapabilities = errors.New("no control capabilities")
+	ErrNoLauncherCache       = errors.New("launcher cache not available")
 )
 
 //nolint:gocritic // single-use parameter in command handler
@@ -55,13 +56,13 @@ func cmdControl(pl platforms.Platform, env platforms.CmdEnv) (platforms.CmdResul
 		return platforms.CmdResult{}, ErrNoLauncher
 	}
 
-	var launcher *platforms.Launcher
-	for _, l := range pl.Launchers(env.Cfg) {
-		if l.ID == launcherID {
-			launcher = &l
-			break
-		}
+	// Resolve through the launcher cache, not pl.Launchers: launchers built at
+	// service startup rather than by the platform, such as native audio, only
+	// exist in the cache. The API control path resolves the same way.
+	if env.LauncherCache == nil {
+		return platforms.CmdResult{}, ErrNoLauncherCache
 	}
+	launcher := env.LauncherCache.GetLauncherByID(launcherID)
 	if launcher == nil {
 		return platforms.CmdResult{}, fmt.Errorf("launcher not found: %s", launcherID)
 	}

--- a/pkg/zapscript/control_cmd_test.go
+++ b/pkg/zapscript/control_cmd_test.go
@@ -26,11 +26,21 @@ import (
 
 	"github.com/ZaparooProject/go-zapscript"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/config"
+	"github.com/ZaparooProject/zaparoo-core/v2/pkg/helpers"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/platforms"
 	"github.com/ZaparooProject/zaparoo-core/v2/pkg/testing/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// newControlLauncherCache seeds a launcher cache the way the service does at
+// startup. cmdControl resolves through the cache rather than the platform's own
+// launcher list, so tests must not rely on Platform.Launchers.
+func newControlLauncherCache(launchers []platforms.Launcher) *helpers.LauncherCache {
+	cache := &helpers.LauncherCache{}
+	cache.InitializeFromSlice(launchers)
+	return cache
+}
 
 func newControlExprEnv(launcherID string) *zapscript.ArgExprEnv {
 	return &zapscript.ArgExprEnv{
@@ -51,7 +61,7 @@ func TestCmdControl_Success(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -65,7 +75,8 @@ func TestCmdControl_Success(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	result, err := cmdControl(mockPlatform, env)
@@ -80,7 +91,7 @@ func TestCmdControl_SuccessWithScript(t *testing.T) {
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
 	mockPlatform.On("KeyboardPress", "{f2}").Return(nil)
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -94,7 +105,8 @@ func TestCmdControl_SuccessWithScript(t *testing.T) {
 			Name: "control",
 			Args: []string{"save_state"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	result, err := cmdControl(mockPlatform, env)
@@ -112,7 +124,7 @@ func TestCmdControl_ScriptUsesServiceContext(t *testing.T) {
 
 	mockPlatform := mocks.NewMockPlatform()
 	mockPlatform.On("ID").Return("test")
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -126,9 +138,10 @@ func TestCmdControl_ScriptUsesServiceContext(t *testing.T) {
 			Name: "control",
 			Args: []string{"save_state"},
 		},
-		ExprEnv:     newControlExprEnv("test-launcher"),
-		ServiceCtx:  serviceCtx,
-		LauncherCtx: launcherCtx,
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
+		ServiceCtx:    serviceCtx,
+		LauncherCtx:   launcherCtx,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -221,7 +234,7 @@ func TestCmdControl_LauncherNotFound(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{ID: "other-launcher"},
 	})
 
@@ -230,7 +243,8 @@ func TestCmdControl_LauncherNotFound(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("missing-launcher"),
+		ExprEnv:       newControlExprEnv("missing-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -242,7 +256,7 @@ func TestCmdControl_NoControls(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{ID: "test-launcher"},
 	})
 
@@ -251,7 +265,8 @@ func TestCmdControl_NoControls(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -264,7 +279,7 @@ func TestCmdControl_UnknownAction(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -280,7 +295,8 @@ func TestCmdControl_UnknownAction(t *testing.T) {
 			Name: "control",
 			Args: []string{"nonexistent_action"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -292,7 +308,7 @@ func TestCmdControl_NoImplementation(t *testing.T) {
 	t.Parallel()
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -306,7 +322,8 @@ func TestCmdControl_NoImplementation(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -324,7 +341,7 @@ func TestCmdControl_AdvArgsPassThrough(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -342,7 +359,8 @@ func TestCmdControl_AdvArgsPassThrough(t *testing.T) {
 				"name": "quicksave",
 			}),
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -360,7 +378,7 @@ func TestCmdControl_WhenKeyStripped(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -378,7 +396,8 @@ func TestCmdControl_WhenKeyStripped(t *testing.T) {
 				"slot": "1",
 			}),
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -397,7 +416,7 @@ func TestCmdControl_WhenOnlyAdvArg(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -414,7 +433,8 @@ func TestCmdControl_WhenOnlyAdvArg(t *testing.T) {
 				"when": "true",
 			}),
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
@@ -432,7 +452,7 @@ func TestCmdControl_WaitsForMediaReadyBeforeControl(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -446,8 +466,9 @@ func TestCmdControl_WaitsForMediaReadyBeforeControl(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv:     newControlExprEnv("test-launcher"),
-		LauncherCtx: context.Background(),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
+		LauncherCtx:   context.Background(),
 		WaitForMediaReady: func(ctx context.Context) error {
 			require.NotNil(t, ctx)
 			waited = true
@@ -470,7 +491,7 @@ func TestCmdControl_WaitForMediaReadyErrorSkipsControl(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -484,7 +505,8 @@ func TestCmdControl_WaitForMediaReadyErrorSkipsControl(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 		WaitForMediaReady: func(context.Context) error {
 			return errors.New("not ready")
 		},
@@ -504,7 +526,7 @@ func TestCmdControl_FuncError(t *testing.T) {
 	}
 
 	mockPlatform := mocks.NewMockPlatform()
-	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
 		{
 			ID: "test-launcher",
 			Controls: map[string]platforms.Control{
@@ -518,11 +540,104 @@ func TestCmdControl_FuncError(t *testing.T) {
 			Name: "control",
 			Args: []string{"toggle_pause"},
 		},
-		ExprEnv: newControlExprEnv("test-launcher"),
+		ExprEnv:       newControlExprEnv("test-launcher"),
+		LauncherCache: launcherCache,
 	}
 
 	_, err := cmdControl(mockPlatform, env)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "kodi connection refused")
 	assert.Contains(t, err.Error(), "control action")
+}
+
+// TestCmdControl_LauncherOnlyInCache pins issue #1386: the native-audio launcher is
+// built at service startup and only ever lives in the launcher cache, never in
+// Platform.Launchers. Resolving from the platform list fails every control action
+// for it with "launcher not found".
+func TestCmdControl_LauncherOnlyInCache(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	mockPlatform := mocks.NewMockPlatform()
+	mockPlatform.On("Launchers", (*config.Instance)(nil)).Return([]platforms.Launcher{
+		{ID: "some-platform-launcher"},
+	})
+
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
+		{ID: "some-platform-launcher"},
+		{
+			ID: platforms.NativeAudioLauncherID,
+			Controls: map[string]platforms.Control{
+				platforms.ControlPause: {
+					Func: func(context.Context, *config.Instance, platforms.ControlParams) error {
+						called = true
+						return nil
+					},
+				},
+			},
+		},
+	})
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "control",
+			Args: []string{platforms.ControlPause},
+		},
+		ExprEnv:       newControlExprEnv(platforms.NativeAudioLauncherID),
+		LauncherCache: launcherCache,
+	}
+
+	_, err := cmdControl(mockPlatform, env)
+	require.NoError(t, err)
+	assert.True(t, called, "control must run for a launcher only present in the cache")
+}
+
+// TestCmdControl_LauncherIDCaseInsensitive matches the cache's own lookup rules and
+// the API control path, which both compare launcher IDs case-insensitively.
+func TestCmdControl_LauncherIDCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	mockPlatform := mocks.NewMockPlatform()
+	launcherCache := newControlLauncherCache([]platforms.Launcher{
+		{
+			ID: "Generic",
+			Controls: map[string]platforms.Control{
+				platforms.ControlPause: {
+					Func: func(context.Context, *config.Instance, platforms.ControlParams) error {
+						called = true
+						return nil
+					},
+				},
+			},
+		},
+	})
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "control",
+			Args: []string{platforms.ControlPause},
+		},
+		ExprEnv:       newControlExprEnv("generic"),
+		LauncherCache: launcherCache,
+	}
+
+	_, err := cmdControl(mockPlatform, env)
+	require.NoError(t, err)
+	assert.True(t, called)
+}
+
+func TestCmdControl_NilLauncherCache(t *testing.T) {
+	t.Parallel()
+
+	env := platforms.CmdEnv{
+		Cmd: zapscript.Command{
+			Name: "control",
+			Args: []string{"toggle_pause"},
+		},
+		ExprEnv: newControlExprEnv("test-launcher"),
+	}
+
+	_, err := cmdControl(mocks.NewMockPlatform(), env)
+	require.ErrorIs(t, err, ErrNoLauncherCache)
 }


### PR DESCRIPTION
- `cmdControl` resolved the active media's launcher by scanning `Platform.Launchers`, which never contains the native-audio launcher: it is built at service startup so the playback manager can be injected, and reaches the launcher cache as an extra. Every `**control` action against native audio failed with `launcher not found: native-audio` while `media.control`, which resolves through the cache, worked.
- Adds a `LauncherResolver` interface in `pkg/platforms` and a `LauncherCache` field on `CmdEnv`, populated from `helpers.GlobalLauncherCache` at the single construction site. `pkg/platforms` cannot import `pkg/helpers` because helpers already imports platforms, hence the interface rather than the concrete type.
- Launcher IDs are now matched case-insensitively in `**control`, as the cache and the API control path already do, and the `launchables` virtual launchers resolve too, reporting `no control capabilities` instead of `launcher not found`.
- `**control:stop` stopped native audio without clearing active media, so the daemon kept reporting the track as playing. The clear moves into the native-audio stop control, guarded the same way the drain callback is, so both `**control` and `media.control` get it; the API handler keeps the background-slot branch because that also clears the background playlist.
- `LauncherCache.Refresh` called `Initialize` with no extras, dropping every launcher the platform cannot build itself. After a `launchers.refresh` or a MiSTer RBF rescan, native audio was absent from the cache and even `media.control` failed, leaving a playing track with no way to pause or stop it through the API. Reproduced on 2.17.0. Refresh now reapplies the extras registered by `Initialize`.

Closes #1386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping primary native audio now reliably clears active media.
  * Background media remains unaffected when stopping primary audio.
  * Media state is preserved when a launcher does not handle its own cleanup.
  * Stop actions now complete reliably during media transitions and shutdown hooks.

* **Improvements**
  * Launcher controls remain available after launcher data refreshes.
  * Controls can resolve runtime-provided launchers.
  * Launcher lookup is case-insensitive for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->